### PR TITLE
fix(apply-patch): compact persisted result previews

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -2,19 +2,22 @@
 
 ### What changed
 
-- Completed `apply_patch` results retain the bounded visible diff and unified patch while replacing nested applied-operation previews with lightweight metadata.
+- Completed `apply_patch` previews retain the TUI's bounded diff and retain a complete unified patch only when it is at most 16 KiB per file; larger patch bodies are omitted rather than persisted or emitted as malformed truncated diffs.
+- Nested applied-operation previews are rebuilt as lightweight metadata without full diff or patch bodies, including the fail-fast `ApplyPatchError` recovery result.
+- App-server file-change projection keeps its complete unified-diff contract for retained patches within the 16 KiB budget; oversized patches do not produce a file-change diff from persisted result details.
 
 ### Why
 
-- Full file diffs were persisted twice in tool-result details, causing session files and resident memory to grow unnecessarily.
+- Full old/new file contents in unified patches dominated completed tool-result details after diff compaction, so large add, delete, and update operations still scaled with source size in session files and resident memory.
+- App-server projection and session persistence consume the same completed result object with no extension-scoped post-projection persistence seam. A fixed budget is therefore required to bound retention without storing a second live-only copy; omitting oversized patches avoids sending invalid partial unified diffs.
 
 ### Why this cannot be expressed externally
 
-- The duplicate payload is constructed inside the builtin `apply_patch` tool before session persistence.
+- The payload and its source-backed unified patches are constructed inside the builtin `apply_patch` tool before app-server projection and session persistence.
 
 ### Expected merge conflict zones
 
-- LOW: `core/extensions/builtin/gpt-apply-patch/tool.ts`.
+- LOW: `core/extensions/builtin/gpt-apply-patch/apply.ts` and `tool.ts` completed-result construction.
 
 ## Backfill: injected app-server turns (2026-08-01)
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,21 @@
+## Compact completed apply_patch result details (2026-08-02)
+
+### What changed
+
+- Completed `apply_patch` results retain the bounded visible diff and unified patch while replacing nested applied-operation previews with lightweight metadata.
+
+### Why
+
+- Full file diffs were persisted twice in tool-result details, causing session files and resident memory to grow unnecessarily.
+
+### Why this cannot be expressed externally
+
+- The duplicate payload is constructed inside the builtin `apply_patch` tool before session persistence.
+
+### Expected merge conflict zones
+
+- LOW: `core/extensions/builtin/gpt-apply-patch/tool.ts`.
+
 ## Backfill: injected app-server turns (2026-08-01)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/apply.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/apply.ts
@@ -44,6 +44,19 @@ function extractErrorCode(error: unknown): string | undefined {
 	return undefined;
 }
 
+export function compactApplyPatchResult(result: ApplyPatchResult): ApplyPatchResult {
+	return {
+		...result,
+		details: {
+			...result.details,
+			appliedOperations: result.details.appliedOperations.map(({ operationIndex, preview }) => {
+				const { diff: _diff, patch: _patch, ...metadata } = preview;
+				return { operationIndex, preview: { ...metadata, diff: "" } };
+			}),
+		},
+	};
+}
+
 async function writeFileAtomic(
 	absPath: string,
 	content: string,
@@ -224,7 +237,7 @@ export async function applyPatch(cwd: string, patchText: string): Promise<string
 				recoveryInstructions: createRecoveryInstructions({ appliedFiles, failures }),
 				details: { fuzz: 0, appliedOperations },
 			};
-			throw new ApplyPatchError(message, result);
+			throw new ApplyPatchError(message, compactApplyPatchResult(result));
 		}
 	}
 

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
@@ -4,21 +4,22 @@
 
 ### What changed
 
-- `tool.ts`: completed previews persist `truncatePreview()` output while preserving each top-level unified `patch`.
-- Nested `result.details.appliedOperations` entries retain only operation indexes, paths, move destinations, operation types, and line counts.
-- Regression coverage verifies bounded visible diffs, preserved unified patches, and metadata-only nested operations.
+- `tool.ts`: completed previews persist `truncatePreview()` output and retain a complete unified `patch` only when it is at most 16 KiB per file; oversized patches are omitted instead of retaining source-sized bodies or producing malformed truncations.
+- `apply.ts`: pure result compaction uses destructuring omission so nested applied operations keep indexes and preview metadata, including future optional fields, while dropping full patch bodies and emptying diffs. The fail-fast `ApplyPatchError` path uses the same compaction.
+- Regression coverage uses a 3,000-line fixture to cap serialized completed details below 12,000 bytes, while existing app-server projection tests pin complete diffs for patches within budget.
 
 ### Why
 
-- Completed results retained full operation diffs in both the visible preview and nested result details, duplicating large payloads in append-only sessions.
+- After visible-diff and nested-operation compaction, `preview.files[].patch` still contained both old and new file contents and accounted for effectively all retained bytes on large updates, additions, and deletions.
+- App-server projection runs from the same result object later copied into the persisted tool-result message. There is no builtin-extension seam after projection but before persistence, so a documented fixed budget is the smallest safe retention boundary; omission is preferable to an invalid partial unified diff.
 
 ### Why extension system couldn't handle this
 
-- The redundant payload is assembled by the builtin tool before the session manager persists the tool result.
+- The source-backed patch payload is assembled by the builtin tool before both app-server projection and session persistence.
 
 ### Expected merge conflict zones
 
-- LOW: `tool.ts` completed-result construction.
+- LOW: `apply.ts` result compaction and `tool.ts` completed-preview construction.
 
 ## Failed apply_patch outcomes are explicit errors (2026-07-31)
 

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
@@ -5,8 +5,9 @@
 ### What changed
 
 - `tool.ts`: completed previews persist `truncatePreview()` output and retain a complete unified `patch` only when it is at most 16 KiB per file; oversized patches are omitted instead of retaining source-sized bodies or producing malformed truncations.
+- `index.ts`: the public barrel exports `APPLY_PATCH_RESULT_PATCH_MAX_BYTES` alongside the tool factory and preview limits so retention-contract tests share the production budget.
 - `apply.ts`: pure result compaction uses destructuring omission so nested applied operations keep indexes and preview metadata, including future optional fields, while dropping full patch bodies and emptying diffs. The fail-fast `ApplyPatchError` path uses the same compaction.
-- Regression coverage uses a 3,000-line fixture to cap serialized completed details below 12,000 bytes, while existing app-server projection tests pin complete diffs for patches within budget.
+- Regression coverage uses a 3,000-line fixture to cap serialized completed details below half the per-file patch budget. App-server projection tests pin complete diffs within budget and an empty projection when a patch exceeds it.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## Compact completed result retention (2026-08-02)
+
+### What changed
+
+- `tool.ts`: completed previews persist `truncatePreview()` output while preserving each top-level unified `patch`.
+- Nested `result.details.appliedOperations` entries retain only operation indexes, paths, move destinations, operation types, and line counts.
+- Regression coverage verifies bounded visible diffs, preserved unified patches, and metadata-only nested operations.
+
+### Why
+
+- Completed results retained full operation diffs in both the visible preview and nested result details, duplicating large payloads in append-only sessions.
+
+### Why extension system couldn't handle this
+
+- The redundant payload is assembled by the builtin tool before the session manager persists the tool result.
+
+### Expected merge conflict zones
+
+- LOW: `tool.ts` completed-result construction.
+
 ## Failed apply_patch outcomes are explicit errors (2026-07-31)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/index.ts
@@ -23,7 +23,7 @@ export {
 export { seekSequence } from "./seek-sequence.ts";
 export { StreamingPatchParser } from "./streaming-parser.ts";
 export { extractPatchedPaths, normalizePatchText, stripHeredoc } from "./text.ts";
-export { createApplyPatchTool } from "./tool.ts";
+export { APPLY_PATCH_RESULT_PATCH_MAX_BYTES, createApplyPatchTool } from "./tool.ts";
 export type {
 	ApplyPatchExtensionAPI,
 	ApplyPatchFailure,

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
@@ -1,7 +1,7 @@
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import type { AgentToolResult, ToolRenderContext } from "../../types.ts";
 import { defineTool } from "../../types.ts";
-import { applyPatchDetailed, buildPartialFailureText } from "./apply.ts";
+import { applyPatchDetailed, buildPartialFailureText, compactApplyPatchResult } from "./apply.ts";
 import {
 	APPLY_PATCH_FREEFORM_DESCRIPTION,
 	APPLY_PATCH_JSON_DESCRIPTION,
@@ -23,13 +23,27 @@ import type {
 	FreeformToolFormat,
 } from "./types.ts";
 
+export const APPLY_PATCH_RESULT_PATCH_MAX_BYTES = 16 * 1024;
+
+function retainedPatch(patch: string | undefined): string | undefined {
+	if (patch === undefined || Buffer.byteLength(patch, "utf8") > APPLY_PATCH_RESULT_PATCH_MAX_BYTES) {
+		return undefined;
+	}
+	return patch;
+}
+
 function appliedPreview(result: ApplyPatchResult): ApplyPatchPreview | undefined {
 	const files = [...result.details.appliedOperations]
 		.sort((left, right) => left.operationIndex - right.operationIndex)
-		.map((operation) => ({
-			...operation.preview,
-			diff: truncatePreview(operation.preview.diff),
-		}));
+		.map((operation) => {
+			const { diff, patch, ...metadata } = operation.preview;
+			const boundedPatch = retainedPatch(patch);
+			return {
+				...metadata,
+				diff: truncatePreview(diff),
+				...(boundedPatch === undefined ? {} : { patch: boundedPatch }),
+			};
+		});
 	if (files.length === 0) return undefined;
 	return {
 		files,
@@ -103,20 +117,6 @@ function renderFailureBox(
 	return component;
 }
 
-function compactAppliedOperations(result: ApplyPatchResult): void {
-	result.details.appliedOperations = result.details.appliedOperations.map(({ operationIndex, preview }) => ({
-		operationIndex,
-		preview: {
-			filePath: preview.filePath,
-			...(preview.movePath === undefined ? {} : { movePath: preview.movePath }),
-			operation: preview.operation,
-			diff: "",
-			added: preview.added,
-			removed: preview.removed,
-		},
-	}));
-}
-
 export function createApplyPatchTool(variant: "freeform" | "json" = "freeform"): ApplyPatchToolDefinition {
 	const tool = defineTool<typeof APPLY_PATCH_PARAMS, ApplyPatchToolDetails | undefined, ApplyPatchRenderState>({
 		name: "apply_patch",
@@ -153,16 +153,18 @@ export function createApplyPatchTool(variant: "freeform" | "json" = "freeform"):
 				onUpdate?.({ content: [{ type: "text", text: progressUpdate.text }], details: progressUpdate.details });
 			});
 			const resultPreview = appliedPreview(result);
-			compactAppliedOperations(result);
+			const persistedResult = compactApplyPatchResult(result);
 			if (result.failures.length > 0) {
 				return {
 					content: [{ type: "text", text: buildPartialFailureText(result) }],
-					details: resultPreview ? { preview: resultPreview, result } : { result },
+					details: resultPreview
+						? { preview: resultPreview, result: persistedResult }
+						: { result: persistedResult },
 				};
 			}
 			return {
 				content: [{ type: "text", text: result.summaries.join("\n") }],
-				details: resultPreview ? { preview: resultPreview, result } : { result },
+				details: resultPreview ? { preview: resultPreview, result: persistedResult } : { result: persistedResult },
 			};
 		},
 		renderCall(args, theme, context: ToolRenderContext<ApplyPatchRenderState, { input: string }>) {

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/tool.ts
@@ -11,7 +11,7 @@ import {
 import { normalizeApplyPatchArguments } from "./params.ts";
 import { parsePatch } from "./parser.ts";
 import { createPendingPatchUpdate } from "./preview.ts";
-import { getApplyPatchRenderState, renderPatchPreview } from "./preview-format.ts";
+import { getApplyPatchRenderState, renderPatchPreview, truncatePreview } from "./preview-format.ts";
 import { renderStreamingPatchCall } from "./streaming-render.ts";
 import type {
 	ApplyPatchPreview,
@@ -26,7 +26,10 @@ import type {
 function appliedPreview(result: ApplyPatchResult): ApplyPatchPreview | undefined {
 	const files = [...result.details.appliedOperations]
 		.sort((left, right) => left.operationIndex - right.operationIndex)
-		.map((operation) => operation.preview);
+		.map((operation) => ({
+			...operation.preview,
+			diff: truncatePreview(operation.preview.diff),
+		}));
 	if (files.length === 0) return undefined;
 	return {
 		files,
@@ -100,6 +103,20 @@ function renderFailureBox(
 	return component;
 }
 
+function compactAppliedOperations(result: ApplyPatchResult): void {
+	result.details.appliedOperations = result.details.appliedOperations.map(({ operationIndex, preview }) => ({
+		operationIndex,
+		preview: {
+			filePath: preview.filePath,
+			...(preview.movePath === undefined ? {} : { movePath: preview.movePath }),
+			operation: preview.operation,
+			diff: "",
+			added: preview.added,
+			removed: preview.removed,
+		},
+	}));
+}
+
 export function createApplyPatchTool(variant: "freeform" | "json" = "freeform"): ApplyPatchToolDefinition {
 	const tool = defineTool<typeof APPLY_PATCH_PARAMS, ApplyPatchToolDetails | undefined, ApplyPatchRenderState>({
 		name: "apply_patch",
@@ -136,6 +153,7 @@ export function createApplyPatchTool(variant: "freeform" | "json" = "freeform"):
 				onUpdate?.({ content: [{ type: "text", text: progressUpdate.text }], details: progressUpdate.details });
 			});
 			const resultPreview = appliedPreview(result);
+			compactAppliedOperations(result);
 			if (result.failures.length > 0) {
 				return {
 					content: [{ type: "text", text: buildPartialFailureText(result) }],

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,17 @@
 # Core Extensions Changes
 
+## 2026-08-02 - Completed apply_patch details avoid duplicate full diffs
+
+### What changed and why
+
+- The builtin `apply_patch` tool stores the same bounded diff used by the TUI in its top-level preview.
+- Nested applied-operation previews retain paths, operation types, line counts, and operation indexes but no longer duplicate full diffs.
+- Unified patches remain available for app-server file-change projection.
+
+### Expected merge conflict zones
+
+- LOW: `builtin/gpt-apply-patch/tool.ts` completed-result construction.
+
 ## 2026-08-01 - Anthropic pair guards share the provider-final sanitizer
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,16 +1,17 @@
 # Core Extensions Changes
 
-## 2026-08-02 - Completed apply_patch details avoid duplicate full diffs
+## 2026-08-02 - Completed apply_patch details have fixed retention bounds
 
 ### What changed and why
 
-- The builtin `apply_patch` tool stores the same bounded diff used by the TUI in its top-level preview.
-- Nested applied-operation previews retain paths, operation types, line counts, and operation indexes but no longer duplicate full diffs.
-- Unified patches remain available for app-server file-change projection.
+- The builtin `apply_patch` tool stores the same bounded diff used by the TUI in its top-level preview and retains complete unified patches only up to 16 KiB per file.
+- Oversized unified patches are omitted rather than persisting old/new file bodies or exposing malformed truncated diffs; app-server file-change projection remains complete for patches within budget.
+- Nested applied-operation previews and fail-fast error recovery results retain paths, move destinations, operation types, line counts, operation indexes, fuzz, and failure/recovery metadata without full patch bodies.
+- Projection and persistence receive the same completed result object, with no extension-owned post-projection persistence hook, so the explicit byte budget is the narrowest boundary that also removes source-size scaling.
 
 ### Expected merge conflict zones
 
-- LOW: `builtin/gpt-apply-patch/tool.ts` completed-result construction.
+- LOW: `builtin/gpt-apply-patch/apply.ts` and `tool.ts` result construction.
 
 ## 2026-08-01 - Anthropic pair guards share the provider-final sanitizer
 

--- a/packages/coding-agent/test/suite/app-server-task24-file-change-results.test.ts
+++ b/packages/coding-agent/test/suite/app-server-task24-file-change-results.test.ts
@@ -5,7 +5,10 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { parsePatch } from "diff";
 import { afterEach, describe, expect, it } from "vitest";
-import { createApplyPatchTool } from "../../src/core/extensions/builtin/gpt-apply-patch/tool.ts";
+import {
+	APPLY_PATCH_RESULT_PATCH_MAX_BYTES,
+	createApplyPatchTool,
+} from "../../src/core/extensions/builtin/gpt-apply-patch/index.ts";
 import { createEditTool } from "../../src/core/tools/edit.ts";
 import { createWriteTool } from "../../src/core/tools/write.ts";
 import { fileChangeProjection } from "../../src/modes/app-server/threads/projection-file-changes.ts";
@@ -123,6 +126,34 @@ describe("app-server task 24 real file-change result contracts", () => {
 			{ oldFileName: "one.txt", newFileName: "one.txt" },
 			{ oldFileName: "two.txt", newFileName: "two.txt" },
 		]);
+	});
+
+	it("omits oversized apply_patch diffs from app-server projection", async () => {
+		// Given: a real add patch whose unified diff exceeds the per-file retention budget.
+		const harness = await createApplyPatchHarness();
+		const addedLines = Array.from(
+			{ length: 300 },
+			(_, index) => `line ${index + 1} with padding that makes the retained unified patch exceed its byte budget`,
+		);
+		const input = `*** Begin Patch
+*** Add File: oversized.txt
+${addedLines.map((line) => `+${line}`).join("\n")}
+*** End Patch`;
+		expect(Buffer.byteLength(input, "utf8")).toBeGreaterThan(APPLY_PATCH_RESULT_PATCH_MAX_BYTES);
+
+		// When: the patch executes and its exact result is projected.
+		const result = await executeApplyPatch(harness, input);
+		const projection = fileChangeProjection({
+			id: "apply-call",
+			name: "apply_patch",
+			args: { input },
+			status: "completed",
+			result,
+		});
+
+		// Then: the oversized patch is omitted whole instead of emitting a malformed or truncated diff.
+		expect(projection.item).toMatchObject({ changes: [] });
+		expect(projection.diff).toBe("");
 	});
 
 	it("keeps only successful unified patches from a partial apply_patch result", async () => {

--- a/packages/coding-agent/test/suite/gpt-apply-patch-backport.test.ts
+++ b/packages/coding-agent/test/suite/gpt-apply-patch-backport.test.ts
@@ -57,8 +57,9 @@ describe("gpt-apply-patch backported behavior", () => {
 		harnesses.push(harness);
 		await writeFile(path.join(harness.tempDir, "ok.txt"), "before\n", "utf-8");
 
-		await expect(
-			applyPatch(
+		let caught: unknown;
+		try {
+			await applyPatch(
 				harness.tempDir,
 				`*** Begin Patch
 *** Update File: ok.txt
@@ -70,8 +71,25 @@ describe("gpt-apply-patch backported behavior", () => {
 -x
 +y
 *** End Patch`,
-			),
-		).rejects.toBeInstanceOf(ApplyPatchError);
+			);
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ApplyPatchError);
+		if (!(caught instanceof ApplyPatchError)) throw new Error("Expected ApplyPatchError");
+		expect(caught.result.details.appliedOperations).toEqual([
+			{
+				operationIndex: 0,
+				preview: {
+					filePath: "ok.txt",
+					operation: "update",
+					diff: "",
+					added: 1,
+					removed: 1,
+				},
+			},
+		]);
 	});
 
 	it("tracks fuzz tiers in detailed result", async () => {

--- a/packages/coding-agent/test/suite/regressions/648-apply-patch-result-retention.test.ts
+++ b/packages/coding-agent/test/suite/regressions/648-apply-patch-result-retention.test.ts
@@ -19,7 +19,10 @@ describe("apply_patch result retention", () => {
 		const tempDir = await mkdtemp(path.join(tmpdir(), "senpi-apply-patch-retention-"));
 		tempDirs.push(tempDir);
 		const targetPath = path.join(tempDir, "sample.txt");
-		const before = Array.from({ length: 24 }, (_, index) => `line ${index + 1} before`);
+		const before = Array.from(
+			{ length: 3000 },
+			(_, index) => `line ${index + 1} before with padding that makes unbounded retained patches observable`,
+		);
 		const after = before.map((line) => line.replace("before", "after"));
 		await writeFile(targetPath, `${before.join("\n")}\n`, "utf-8");
 
@@ -48,10 +51,9 @@ ${after.map((line) => `+${line}`).join("\n")}
 		expect(visibleFile.diff.length).toBeLessThanOrEqual(PATCH_PREVIEW_MAX_CHARS);
 		expect(visibleFile.diff).toContain("line 1 before");
 		expect(visibleFile.diff).toContain("…");
-		expect(visibleFile.patch).toContain("--- sample.txt");
-		expect(visibleFile.patch).toContain("+++ sample.txt");
-		expect(visibleFile.patch).toContain("-line 24 before");
-		expect(visibleFile.patch).toContain("+line 24 after");
+		const persistedBytes = Buffer.byteLength(JSON.stringify(result.details), "utf8");
+		expect(persistedBytes).toBeLessThan(12_000);
+		expect(visibleFile).not.toHaveProperty("patch");
 
 		expect(patchResult.details.appliedOperations).toEqual([
 			{
@@ -60,8 +62,8 @@ ${after.map((line) => `+${line}`).join("\n")}
 					filePath: "sample.txt",
 					operation: "update",
 					diff: "",
-					added: 24,
-					removed: 24,
+					added: 3000,
+					removed: 3000,
 				},
 			},
 		]);

--- a/packages/coding-agent/test/suite/regressions/648-apply-patch-result-retention.test.ts
+++ b/packages/coding-agent/test/suite/regressions/648-apply-patch-result-retention.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createApplyPatchTool,
+	PATCH_PREVIEW_MAX_CHARS,
+	PATCH_PREVIEW_MAX_LINES,
+} from "../../../src/core/extensions/builtin/gpt-apply-patch/index.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map((tempDir) => rm(tempDir, { recursive: true, force: true })));
+});
+
+describe("apply_patch result retention", () => {
+	it("persists a bounded visible preview and metadata-only applied operations", async () => {
+		const tempDir = await mkdtemp(path.join(tmpdir(), "senpi-apply-patch-retention-"));
+		tempDirs.push(tempDir);
+		const targetPath = path.join(tempDir, "sample.txt");
+		const before = Array.from({ length: 24 }, (_, index) => `line ${index + 1} before`);
+		const after = before.map((line) => line.replace("before", "after"));
+		await writeFile(targetPath, `${before.join("\n")}\n`, "utf-8");
+
+		const patch = `*** Begin Patch
+*** Update File: sample.txt
+@@
+${before.map((line) => `-${line}`).join("\n")}
+${after.map((line) => `+${line}`).join("\n")}
+*** End Patch`;
+		const tool = createApplyPatchTool();
+		const result = await tool.execute("call-retention", { input: patch }, undefined, undefined, {
+			cwd: tempDir,
+		} as Parameters<typeof tool.execute>[4]);
+
+		expect(await readFile(targetPath, "utf-8")).toBe(`${after.join("\n")}\n`);
+		const preview = result.details?.preview;
+		const patchResult = result.details?.result;
+		expect(preview).toBeDefined();
+		expect(patchResult).toBeDefined();
+		if (!preview || !patchResult) throw new Error("apply_patch result details were missing");
+
+		const visibleFile = preview.files[0];
+		expect(visibleFile).toBeDefined();
+		if (!visibleFile) throw new Error("apply_patch visible preview was missing");
+		expect(visibleFile.diff.split("\n").length).toBeLessThanOrEqual(PATCH_PREVIEW_MAX_LINES);
+		expect(visibleFile.diff.length).toBeLessThanOrEqual(PATCH_PREVIEW_MAX_CHARS);
+		expect(visibleFile.diff).toContain("line 1 before");
+		expect(visibleFile.diff).toContain("…");
+		expect(visibleFile.patch).toContain("--- sample.txt");
+		expect(visibleFile.patch).toContain("+++ sample.txt");
+		expect(visibleFile.patch).toContain("-line 24 before");
+		expect(visibleFile.patch).toContain("+line 24 after");
+
+		expect(patchResult.details.appliedOperations).toEqual([
+			{
+				operationIndex: 0,
+				preview: {
+					filePath: "sample.txt",
+					operation: "update",
+					diff: "",
+					added: 24,
+					removed: 24,
+				},
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/648-apply-patch-result-retention.test.ts
+++ b/packages/coding-agent/test/suite/regressions/648-apply-patch-result-retention.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	APPLY_PATCH_RESULT_PATCH_MAX_BYTES,
 	createApplyPatchTool,
 	PATCH_PREVIEW_MAX_CHARS,
 	PATCH_PREVIEW_MAX_LINES,
@@ -52,7 +53,7 @@ ${after.map((line) => `+${line}`).join("\n")}
 		expect(visibleFile.diff).toContain("line 1 before");
 		expect(visibleFile.diff).toContain("…");
 		const persistedBytes = Buffer.byteLength(JSON.stringify(result.details), "utf8");
-		expect(persistedBytes).toBeLessThan(12_000);
+		expect(persistedBytes).toBeLessThan(APPLY_PATCH_RESULT_PATCH_MAX_BYTES / 2);
 		expect(visibleFile).not.toHaveProperty("patch");
 
 		expect(patchResult.details.appliedOperations).toEqual([


### PR DESCRIPTION
## Summary

- cap retained top-level unified patches at 16 KiB per file; oversized patches are omitted whole rather than truncated, avoiding malformed unified diffs
- keep TUI-visible diffs bounded and replace nested applied-operation previews with metadata after constructing the final preview
- add regression coverage for bounded persisted details and the app-server's empty file-change projection for oversized patches

Fixes #648

## Verification

Current head `0f43a753e`:

- `npm --prefix packages/coding-agent test -- test/suite/gpt-apply-patch test/suite/regressions/648-apply-patch-result-retention.test.ts` — 8 files / 61 tests passed
- `npm --prefix packages/coding-agent test -- test/suite/app-server-task24-apply-patch-identity.test.ts test/suite/app-server-task24-file-change-results.test.ts test/suite/app-server-task24-diff.test.ts test/suite/app-server-task24-review-regressions.test.ts` — 4 files / 15 tests passed
- mutation proof: the new oversized-projection test failed when the 16 KiB retention guard was disabled, then passed after restoring it

Earlier verification recorded for commit `3ee70786a` and not re-run on the current head:

- `npm run check` — passed
- `npm run build` — passed
- Senpi QA sandbox self-check — 9/9 passed
- Senpi CLI smoke — 8/8 passed
- deterministic mock-loop QA — 43/43 passed
- five-lane pre-PR review (constraints, quality, security, hands-on QA, upstream context) — passed

## Compatibility

Complete `preview.files[].patch` unified diffs are retained only when each file's patch is at most 16 KiB. Oversized patches are omitted rather than truncated, so app-server file-change projection emits no change and no diff for those files; IDE/app-server clients therefore show no file-change diff for oversized patches. The filesystem mutation still completes, and within-budget patches remain projected as complete unified diffs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compact `apply_patch` result previews to remove duplicate full diffs and cap retained patch bodies to 16 KiB per file. Keeps bounded visible diffs, preserves unified patches only within budget, and stores metadata-only for nested operations to reduce session size.

- **Bug Fixes**
  - Persist TUI-bounded diffs in the preview via `truncatePreview()`.
  - Retain `preview.files[].patch` only if ≤16 KiB; omit oversized patches to avoid malformed truncations (app-server projection stays complete within budget).
  - Persist compacted results for both success and `ApplyPatchError` paths: nested `result.details.appliedOperations` drop patch bodies and clear diffs, keeping metadata (paths, operation type, counts, indexes).
  - Add regression test covering bounded diffs, 16 KiB patch retention, and metadata-only nesting.

<sup>Written for commit 1711ce35251ae2ec4122eaa9db3d91950211d5f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

