### PR TITLE
fix(compaction): bound summarization overflow retries + log compaction_start

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1041,6 +1041,10 @@ export class AgentSession {
 
 	/** Mirror stuck-prone lifecycle transitions into logs/session.log (content-free). */
 	private _logSessionEvent(event: AgentSessionEvent): void {
+		if (event.type === "compaction_start") {
+			this._sessionLogger.info("compaction_start", { reason: event.reason });
+			return;
+		}
 		if (event.type === "compaction_end") {
 			this._sessionLogger.info("compaction_decision", {
 				reason: event.reason,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
@@ -10,6 +10,7 @@ compaction/
 ├── state.ts                  # In-memory compaction state + persistence shape
 ├── policy.ts                 # Adaptive threshold + decision matrix
 ├── speculative.ts            # Parallel speculative compaction during next turn
+├── overflow-retry.ts         # Bounded overflow-retry policy: input presize, geometric shrink, attempt cap + wall-clock budget
 ├── idle.ts                   # Proactive idle compaction predicate + instructions (agent_end trigger)
 ├── context-reduction.ts      # Deterministic no-LLM reductions (collapse tool-result runs, shrink old answers, clear old tool results)
 ├── openai-remote.ts          # OpenAI Responses remote-compaction route (`senpi.compaction.openai-remote.v1` schema)

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,52 @@
 # Builtin compaction extension changes
 
+## Bounded summarization overflow retries (2026-08-03)
+
+### What changed
+
+- New `overflow-retry.ts`: the summarization overflow-retry policy extracted from `speculative.ts`.
+  `MAX_SUMMARIZATION_OVERFLOW_RETRIES` (3), `SUMMARIZATION_OVERFLOW_TOTAL_BUDGET_MS` (240s across
+  retries), `SUMMARIZATION_INPUT_BUDGET_RATIO` (0.6 of the window), `SummarizationOverflowExhaustedError`,
+  `boundSummarizationInput` (pre-sizes the summarization input, prompt-token aware), and
+  `shrinkSummarizationInputForOverflowRetry` (halves the estimated input per retry instead of dropping
+  one history item, keeping the drop-oldest fallback when every message sits at the turn boundary).
+  The old-message pruning helpers moved here unchanged.
+- `speculative.ts` `runExtensionCompaction`: pre-sizes the summarization input before the first billed
+  attempt and bounds the overflow-retry loop by attempt cap and cumulative wall-clock budget; exhaustion
+  throws the typed error instead of looping or falling through a generic `Error`.
+- `deterministic-fallback.ts` classifies the exhaustion as `summarization-overflow-exhausted`, so
+  required compaction degrades to the deterministic fallback; `transient-failure.ts` treats it as a
+  transient lane failure so the circuit breaker records it and the next run starts pre-sized.
+
+### Why
+
+- Issue #650: on openai-codex/gpt-5.6-sol a blocking compaction wedged for ~48 minutes on
+  "Compacting...". The retry loop removed exactly one history item per FULL billed summarization attempt
+  with no attempt cap, no cumulative budget, and no session.log evidence; the summarization input itself
+  was unbudgeted (only tool results were pruned), so a session whose provider-side input exceeded the real
+  window drew an overflow verdict on every completed attempt. Observed cost: ~13.5M tokens for a
+  compaction that never landed; ESC was the only exit.
+
+### Why not an extension
+
+- This IS the builtin compaction extension; the bound belongs in the retry policy itself.
+
+### Merge-conflict zones
+
+- LOW: `speculative.ts` around `runExtensionCompaction`; `overflow-retry.ts` is fork-owned.
+
+## Session-log visibility for compaction start (2026-08-03)
+
+### What changed
+
+- `core/agent-session.ts` `_logSessionEvent` mirrors `compaction_start` (reason only) into
+  `logs/session.log`; previously only `compaction_end` was mirrored, so a wedged compaction left zero
+  log evidence for its entire lifetime (issue #650).
+
+### Merge-conflict zones
+
+- LOW: `_logSessionEvent` early-return chain.
+
 ## Lane-policy hardening: prune stand-down, live resumeMode, boundary ledger (2026-08-01)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
@@ -1,10 +1,14 @@
 import { type CompactionPreparation, type CompactionResult, estimateContextTokens } from "../../../compaction/index.ts";
 import { StreamDurationBudgetError, StreamIdleTimeoutError } from "../../../compaction/stream-watchdog.ts";
 import { buildSessionContext, type CompactionEntry, type SessionEntry } from "../../../session-manager.ts";
+import { SummarizationOverflowExhaustedError } from "./overflow-retry.ts";
 import { SummaryRequestError } from "./speculative.ts";
 import { capUtf8Bytes } from "./task-intent.ts";
 
-export type RequiredCompactionFallbackFailure = "summarization-timeout" | "upstream-stream-truncated";
+export type RequiredCompactionFallbackFailure =
+	| "summarization-timeout"
+	| "upstream-stream-truncated"
+	| "summarization-overflow-exhausted";
 
 interface RecoveryMetadata {
 	taskIntent?: string;
@@ -27,6 +31,9 @@ export function classifyRequiredCompactionFallbackFailure(
 	}
 	if (error instanceof SummaryRequestError && error.transient && error.failureKind === "upstream-stream-truncated") {
 		return "upstream-stream-truncated";
+	}
+	if (error instanceof SummarizationOverflowExhaustedError) {
+		return "summarization-overflow-exhausted";
 	}
 	return undefined;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/overflow-retry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/overflow-retry.ts
@@ -1,0 +1,183 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { estimateTokens } from "../../../compaction/index.ts";
+
+/**
+ * Overflow-retry policy for summarization requests (issue #650).
+ *
+ * When the provider verdicts a completed summarization response as context
+ * overflow, retrying with a slightly smaller input is correct — but the
+ * historical loop removed exactly one history item per FULL billed attempt,
+ * so a session whose summarization input exceeded the real window wedged on
+ * "Compacting..." for the length of its history (observed: ~48 minutes and
+ * ~13.5M billed tokens on gpt-5.6-sol). Every knob below exists to keep the
+ * worst case small and observable:
+ *
+ * - the summarization input is pre-sized before the first attempt;
+ * - each retry halves the estimated input instead of dropping one item;
+ * - retries stop at a hard attempt cap and a cumulative wall-clock budget;
+ * - exhaustion throws a typed error the deterministic fallback can classify.
+ */
+
+export const MAX_SUMMARIZATION_OVERFLOW_RETRIES = 3;
+
+/**
+ * Cumulative wall-clock budget across all overflow retries of one compaction
+ * run. Twice the per-attempt stream budget: a slow provider may consume the
+ * per-attempt watchdog on each attempt, and the retry loop must still end
+ * well inside one user's patience.
+ */
+export const SUMMARIZATION_OVERFLOW_TOTAL_BUDGET_MS = 240_000;
+
+/** Fraction of the context window the summarization input may occupy. */
+export const SUMMARIZATION_INPUT_BUDGET_RATIO = 0.6;
+
+/** Floor for the history budget after reserving space for the prompt. */
+const MIN_HISTORY_BUDGET_TOKENS = 256;
+
+export class SummarizationOverflowExhaustedError extends Error {
+	readonly attempts: number;
+	readonly elapsedMs: number;
+
+	constructor(attempts: number, elapsedMs: number) {
+		super(
+			`Compaction summary request exceeded the context window after ${attempts} overflow ` +
+				`${attempts === 1 ? "retry" : "retries"} over ${Math.round(elapsedMs / 1000)}s`,
+		);
+		this.name = "SummarizationOverflowExhaustedError";
+		this.attempts = attempts;
+		this.elapsedMs = elapsedMs;
+	}
+}
+
+export interface PruneStep {
+	messages: AgentMessage[];
+	removedTokens: number;
+}
+
+export function estimateTotalTokens(messages: AgentMessage[]): number {
+	let total = 0;
+	for (const message of messages) total += estimateTokens(message);
+	return total;
+}
+
+function getToolCallIds(message: AgentMessage): Set<string> {
+	const ids = new Set<string>();
+	if (message.role !== "assistant") return ids;
+	for (const block of message.content) {
+		if (block.type === "toolCall") ids.add(block.id);
+	}
+	return ids;
+}
+
+function findLastUserLikeIndex(messages: AgentMessage[]): number {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const role = messages[index]?.role;
+		if (role === "user" || role === "bashExecution") return index;
+	}
+	return messages.length;
+}
+
+function removeAssistantToolPair(messages: AgentMessage[], assistantIndex: number): PruneStep {
+	const ids = getToolCallIds(messages[assistantIndex]);
+	let removedTokens = 0;
+	const pruned = messages.filter((message, index) => {
+		const remove = index === assistantIndex || (message.role === "toolResult" && ids.has(message.toolCallId));
+		if (remove) removedTokens += estimateTokens(message);
+		return !remove;
+	});
+	return { messages: pruned, removedTokens };
+}
+
+function removeFirstOldToolPair(messages: AgentMessage[], boundaryIndex: number): PruneStep | undefined {
+	for (let index = 0; index < boundaryIndex; index++) {
+		const message = messages[index];
+		if (!message) continue;
+		if (message.role === "assistant" && getToolCallIds(message).size > 0)
+			return removeAssistantToolPair(messages, index);
+		if (message.role === "toolResult") {
+			return {
+				messages: messages.filter((_message, candidateIndex) => candidateIndex !== index),
+				removedTokens: estimateTokens(message),
+			};
+		}
+	}
+	return undefined;
+}
+
+function removeFirstOldMessage(messages: AgentMessage[], boundaryIndex: number): PruneStep | undefined {
+	for (let index = 0; index < boundaryIndex; index++) {
+		const message = messages[index];
+		if (!message || message.role === "toolResult") continue;
+		if (message.role === "assistant" && getToolCallIds(message).size > 0)
+			return removeAssistantToolPair(messages, index);
+		return {
+			messages: messages.filter((_candidate, candidateIndex) => candidateIndex !== index),
+			removedTokens: estimateTokens(message),
+		};
+	}
+	return undefined;
+}
+
+export function pruneOldMessagesToBudget(messages: AgentMessage[], targetTokens: number): AgentMessage[] {
+	let pruned = messages;
+	let total = estimateTotalTokens(pruned);
+	while (total > targetTokens) {
+		const boundaryIndex = findLastUserLikeIndex(pruned);
+		const next = removeFirstOldToolPair(pruned, boundaryIndex) ?? removeFirstOldMessage(pruned, boundaryIndex);
+		if (!next || next.messages.length === pruned.length) break;
+		pruned = next.messages;
+		total -= next.removedTokens;
+	}
+	return pruned;
+}
+
+/** Estimated-token budget for the history portion of a summarization request. */
+export function summarizationHistoryBudget(contextWindow: number, promptTokens: number): number {
+	return Math.max(
+		MIN_HISTORY_BUDGET_TOKENS,
+		Math.floor(contextWindow * SUMMARIZATION_INPUT_BUDGET_RATIO) - promptTokens,
+	);
+}
+
+/**
+ * Pre-size the summarization input before the first billed attempt. Only the
+ * oldest messages are dropped; a fitting input passes through untouched.
+ */
+export function boundSummarizationInput(
+	messages: AgentMessage[],
+	contextWindow: number,
+	promptTokens: number,
+): AgentMessage[] {
+	return pruneOldMessagesToBudget(messages, summarizationHistoryBudget(contextWindow, promptTokens));
+}
+
+/**
+ * Shrink for the next overflow retry. Halving the estimated input converges
+ * in O(log n) retries instead of the historical one-item-per-attempt O(n),
+ * where each attempt was a full billed summarization stream.
+ */
+export function shrinkSummarizationInputForOverflowRetry(
+	messages: AgentMessage[],
+	contextWindow: number,
+	promptTokens: number,
+): AgentMessage[] | undefined {
+	if (messages.length <= 1) return undefined;
+	const budget = summarizationHistoryBudget(contextWindow, promptTokens);
+	const halfTokens = Math.floor(estimateTotalTokens(messages) / 2);
+	const shrunk = pruneOldMessagesToBudget(messages, Math.min(halfTokens, budget));
+	if (shrunk.length < messages.length) return shrunk;
+	// Every remaining message sits at or after the turn boundary, so budget
+	// pruning cannot shrink further; still drop the oldest so the retry
+	// differs from the rejected attempt instead of re-billing an identical one.
+	return messages.slice(1);
+}
+
+/**
+ * Decide whether another billed overflow retry is allowed. The attempt cap and
+ * the cumulative budget are both checked BEFORE scheduling a new request: an
+ * attempt that consumed the whole per-attempt watchdog must not be followed by
+ * another equally expensive one once the total budget is spent.
+ */
+export function allowOverflowRetry(attempts: number, elapsedMs: number): boolean {
+	return attempts < MAX_SUMMARIZATION_OVERFLOW_RETRIES && elapsedMs < SUMMARIZATION_OVERFLOW_TOTAL_BUDGET_MS;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -19,7 +19,6 @@ import {
 	type CompactionResult,
 	DEFAULT_COMPACTION_SETTINGS,
 	estimateContextTokens,
-	estimateTokens,
 	prepareCompaction,
 } from "../../../compaction/index.ts";
 import {
@@ -31,6 +30,15 @@ import { convertToLlm } from "../../../messages.ts";
 import type { ModelRegistry } from "../../../model-registry.ts";
 import type { ReadonlySessionManager } from "../../../session-manager.ts";
 import type { ApplyCompactionResult, ContextUsage, ProviderRequestPreparation } from "../../types.ts";
+import {
+	allowOverflowRetry,
+	boundSummarizationInput,
+	estimateTotalTokens,
+	pruneOldMessagesToBudget,
+	SUMMARIZATION_INPUT_BUDGET_RATIO,
+	SummarizationOverflowExhaustedError,
+	shrinkSummarizationInputForOverflowRetry,
+} from "./overflow-retry.ts";
 import { computeEffectiveKeepRecentTokens, computeEffectiveThreshold } from "./policy.ts";
 import { buildPrompt, type MergedCompactionPromptVariant } from "./prompts.ts";
 import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";
@@ -39,7 +47,6 @@ import * as truncation from "./tool-truncation.ts";
 import { computeStructuralYield } from "./yield.ts";
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
-const COMPACTION_BUDGET_RATIO = 0.6;
 const EMERGENCY_CONTEXT_TARGET_RATIO = 0.95;
 // Hysteresis: the emergency prune engages at EMERGENCY_CONTEXT_TARGET_RATIO but only
 // releases once the context falls below this lower ratio. A single threshold makes a
@@ -51,7 +58,6 @@ const SUMMARY_TOKEN_HEADROOM = 32_768;
 const SUMMARY_CONTEXT_WINDOW_RESERVE_RATIO = 0.5;
 const SUMMARY_SCHEMA = "senpi.compaction.summary.v1";
 type CompactionProgressCallback = (delta: string) => void;
-type PruneStep = { messages: AgentMessage[]; removedTokens: number };
 
 export interface SpeculativeCompactionContext {
 	model: Model<any> | undefined;
@@ -281,13 +287,13 @@ async function generateSummaryMessage(options: {
 	}
 }
 
-function pruneToolResults(messages: AgentMessage[], contextWindow: number): AgentMessage[] {
+function pruneToolResults(messages: AgentMessage[], contextWindow: number, budgetRatio: number): AgentMessage[] {
 	const toolResults = messages
 		.filter((message) => message.role === "toolResult")
 		.map((message) => ({ content: message.content, details: undefined }));
 	if (toolResults.length === 0) return messages;
 
-	const prunedResults = truncation.prePruneToolOutputsToBudget(toolResults, contextWindow * COMPACTION_BUDGET_RATIO);
+	const prunedResults = truncation.prePruneToolOutputsToBudget(toolResults, contextWindow * budgetRatio);
 	let resultIndex = 0;
 	return messages.map((message) => {
 		if (message.role !== "toolResult") return message;
@@ -311,93 +317,6 @@ export function truncateContextMessages(messages: AgentMessage[]): AgentMessage[
 		resultIndex++;
 		return truncated ? { ...message, content: truncated.content } : message;
 	});
-}
-
-function getToolCallIds(message: AgentMessage): Set<string> {
-	const ids = new Set<string>();
-	if (message.role !== "assistant") return ids;
-	for (const block of message.content) {
-		if (block.type === "toolCall") ids.add(block.id);
-	}
-	return ids;
-}
-
-function findLastUserLikeIndex(messages: AgentMessage[]): number {
-	for (let index = messages.length - 1; index >= 0; index--) {
-		const role = messages[index]?.role;
-		if (role === "user" || role === "bashExecution") return index;
-	}
-	return messages.length;
-}
-
-function removeAssistantToolPair(messages: AgentMessage[], assistantIndex: number): PruneStep {
-	const ids = getToolCallIds(messages[assistantIndex]);
-	let removedTokens = 0;
-	const pruned = messages.filter((message, index) => {
-		const remove = index === assistantIndex || (message.role === "toolResult" && ids.has(message.toolCallId));
-		if (remove) removedTokens += estimateTokens(message);
-		return !remove;
-	});
-	return { messages: pruned, removedTokens };
-}
-
-function removeFirstOldToolPair(messages: AgentMessage[], boundaryIndex: number): PruneStep | undefined {
-	for (let index = 0; index < boundaryIndex; index++) {
-		const message = messages[index];
-		if (!message) continue;
-		if (message.role === "assistant" && getToolCallIds(message).size > 0)
-			return removeAssistantToolPair(messages, index);
-		if (message.role === "toolResult") {
-			return {
-				messages: messages.filter((_message, candidateIndex) => candidateIndex !== index),
-				removedTokens: estimateTokens(message),
-			};
-		}
-	}
-	return undefined;
-}
-
-function removeFirstOldMessage(messages: AgentMessage[], boundaryIndex: number): PruneStep | undefined {
-	for (let index = 0; index < boundaryIndex; index++) {
-		const message = messages[index];
-		if (!message || message.role === "toolResult") continue;
-		if (message.role === "assistant" && getToolCallIds(message).size > 0)
-			return removeAssistantToolPair(messages, index);
-		return {
-			messages: messages.filter((_candidate, candidateIndex) => candidateIndex !== index),
-			removedTokens: estimateTokens(message),
-		};
-	}
-	return undefined;
-}
-
-function pruneOldMessagesToBudget(messages: AgentMessage[], targetTokens: number): AgentMessage[] {
-	let pruned = messages;
-	let total = estimateTotalTokens(pruned);
-	while (total > targetTokens) {
-		const boundaryIndex = findLastUserLikeIndex(pruned);
-		const next = removeFirstOldToolPair(pruned, boundaryIndex) ?? removeFirstOldMessage(pruned, boundaryIndex);
-		if (!next || next.messages.length === pruned.length) break;
-		pruned = next.messages;
-		total -= next.removedTokens;
-	}
-	return pruned;
-}
-
-function removeOldestHistoryItemForOverflowRetry(messages: AgentMessage[]): AgentMessage[] | undefined {
-	if (messages.length <= 1) return undefined;
-	const boundaryIndex = findLastUserLikeIndex(messages);
-	return (
-		removeFirstOldToolPair(messages, boundaryIndex)?.messages ??
-		removeFirstOldMessage(messages, boundaryIndex)?.messages ??
-		(messages.length > 1 ? messages.slice(1) : undefined)
-	);
-}
-
-function estimateTotalTokens(messages: AgentMessage[]): number {
-	let total = 0;
-	for (const message of messages) total += estimateTokens(message);
-	return total;
 }
 
 /**
@@ -434,7 +353,9 @@ export function hardLimitEmergencyPrune(
 	if (!engaged) {
 		return { messages, needsAggressiveCompaction: false };
 	}
-	const noLlmPruned = truncateContextMessages(pruneToolResults(messages, contextWindow));
+	const noLlmPruned = truncateContextMessages(
+		pruneToolResults(messages, contextWindow, SUMMARIZATION_INPUT_BUDGET_RATIO),
+	);
 	if (estimateTotalTokens(noLlmPruned) <= targetTokens) {
 		return { messages: noLlmPruned, needsAggressiveCompaction: false };
 	}
@@ -519,16 +440,24 @@ export async function runExtensionCompaction(
 		throw new SummaryGenerationError("auth", `summarization credentials unavailable: ${detail}`);
 	}
 
-	let messages = pruneToolResults(
-		[...snapshot.preparation.messagesToSummarize, ...snapshot.preparation.turnPrefixMessages],
-		snapshot.contextWindow,
-	);
 	const prompt = buildPrompt({
 		variant: snapshot.promptVariant,
 		previousSummary: snapshot.preparation.previousSummary,
 		taskIntent: resolveInheritedTaskIntent(snapshot.branchEntries ?? []),
 		customInstructions: snapshot.customInstructions,
 	});
+	const promptTokens = approxTokens(prompt.user);
+	let messages = boundSummarizationInput(
+		pruneToolResults(
+			[...snapshot.preparation.messagesToSummarize, ...snapshot.preparation.turnPrefixMessages],
+			snapshot.contextWindow,
+			SUMMARIZATION_INPUT_BUDGET_RATIO,
+		),
+		snapshot.contextWindow,
+		promptTokens,
+	);
+	const overflowRetryStartMs = Date.now();
+	let overflowAttempts = 0;
 
 	while (true) {
 		if (signal?.aborted) return undefined;
@@ -548,9 +477,13 @@ export async function runExtensionCompaction(
 		if (!response) return undefined;
 
 		if (isAssistantMessage(response) && isContextOverflow(response, snapshot.contextWindow)) {
-			const retryMessages = removeOldestHistoryItemForOverflowRetry(messages);
-			if (!retryMessages || retryMessages.length === messages.length) {
-				break;
+			overflowAttempts++;
+			const elapsedMs = Date.now() - overflowRetryStartMs;
+			const retryMessages = allowOverflowRetry(overflowAttempts, elapsedMs)
+				? shrinkSummarizationInputForOverflowRetry(messages, snapshot.contextWindow, promptTokens)
+				: undefined;
+			if (!retryMessages) {
+				throw new SummarizationOverflowExhaustedError(overflowAttempts, elapsedMs);
 			}
 			messages = retryMessages;
 			continue;
@@ -610,8 +543,6 @@ export async function runExtensionCompaction(
 			},
 		};
 	}
-
-	throw new Error("Compaction summary request exceeded the context window after retrying with a smaller input");
 }
 
 export async function applyGeneratedCompaction(

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/transient-failure.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/transient-failure.ts
@@ -15,10 +15,12 @@
  */
 import { isRetryableErrorMessage } from "@earendil-works/pi-ai";
 import { StreamDurationBudgetError, StreamIdleTimeoutError } from "../../../compaction/stream-watchdog.ts";
+import { SummarizationOverflowExhaustedError } from "./overflow-retry.ts";
 import { SummaryRequestError } from "./speculative.ts";
 
 export function isTransientSummarizationFailure(error: unknown, message: string): boolean {
 	if (error instanceof StreamDurationBudgetError || error instanceof StreamIdleTimeoutError) return true;
 	if (error instanceof SummaryRequestError) return error.transient;
+	if (error instanceof SummarizationOverflowExhaustedError) return true;
 	return isRetryableErrorMessage(message);
 }

--- a/packages/coding-agent/test/compaction/overflow-retry-bound.test.ts
+++ b/packages/coding-agent/test/compaction/overflow-retry-bound.test.ts
@@ -1,0 +1,179 @@
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createFileOps, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import { classifyRequiredCompactionFallbackFailure } from "../../src/core/extensions/builtin/compaction/deterministic-fallback.ts";
+import {
+	runExtensionCompaction,
+	type SpeculativeCompactionContext,
+	type SpeculativeCompactionSnapshot,
+} from "../../src/core/extensions/builtin/compaction/speculative.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+/**
+ * Issue #650: on gpt-5.6 (openai-codex) a wedged blocking compaction burned
+ * ~13.5M billed tokens across dozens of sequential summarization attempts.
+ * The provider rejected an oversized summarization request that senpi's
+ * estimator believed fit (provider-side input includes replayed reasoning
+ * the estimator cannot see), and each retry dropped exactly one history
+ * item before re-billing a full summarization stream.
+ */
+
+const CONTEXT_WINDOW = 8_000;
+const HISTORY_MESSAGE_COUNT = 40;
+const HISTORY_MESSAGE_CHARS = 1_200;
+const EXPECTED_MAX_OVERFLOW_RETRIES = 3;
+
+function oversizedHistory(count: number) {
+	return Array.from({ length: count }, (_, index) => ({
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text: `history-${index} ${"x".repeat(HISTORY_MESSAGE_CHARS)}` }],
+		timestamp: index,
+	}));
+}
+
+const PROVIDER_HARD_LIMIT_MESSAGE = "Your input exceeds the context window of this model";
+
+function createOverflowingModelContext() {
+	const registration = registerFauxProvider({ models: [{ id: "gpt-5.6-sol", contextWindow: CONTEXT_WINDOW }] });
+	const model = registration.getModel();
+	const sessionManager = SessionManager.inMemory();
+	const modelRegistry = Object.create(null) as SpeculativeCompactionContext["modelRegistry"];
+	if (modelRegistry) {
+		modelRegistry.getApiKeyAndHeaders = vi.fn(async () => ({ ok: true as const, apiKey: "test-key" }));
+	}
+	const context = {
+		model,
+		sessionManager,
+		modelRegistry,
+		getContextUsage: () => ({ tokens: 0, percent: 0, contextWindow: CONTEXT_WINDOW }),
+		getMessageRevision: () => 1,
+		applyCompaction: vi.fn(async () => ({ applied: true as const, reason: "ok" as const })),
+	} as unknown as SpeculativeCompactionContext;
+	const snapshot = {
+		generation: 1,
+		expectedRevision: 1,
+		model,
+		contextWindow: CONTEXT_WINDOW,
+		preparation: {
+			firstKeptEntryId: "keep",
+			messagesToSummarize: oversizedHistory(HISTORY_MESSAGE_COUNT),
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 12_000,
+			fileOps: createFileOps(),
+			settings: { ...DEFAULT_COMPACTION_SETTINGS },
+		},
+		promptVariant: "default" as const,
+		origin: "blocking" as const,
+		systemPrompt: "",
+	} as unknown as SpeculativeCompactionSnapshot;
+	return { registration, context, snapshot };
+}
+
+function queueProviderHardLimitResponses(
+	registration: ReturnType<typeof registerFauxProvider>,
+	count: number,
+	text = "discarded summary that the provider rejects as oversized",
+): void {
+	registration.setResponses(
+		Array.from(
+			{ length: count },
+			() => () => fauxAssistantMessage(text, { stopReason: "error", errorMessage: PROVIDER_HARD_LIMIT_MESSAGE }),
+		),
+	);
+}
+
+function requestContentTokens(call: { context: { messages: readonly unknown[] } }): number {
+	let total = 0;
+	for (const message of call.context.messages) {
+		const content = (message as { content?: readonly { text?: string }[] }).content ?? [];
+		for (const block of content) total += Math.ceil((block.text ?? "").length / 4);
+	}
+	return total;
+}
+
+describe("compaction overflow retry bound (issue #650)", () => {
+	it("Given a provider that always rejects the input When compaction runs Then billed attempts stop at the cap and degrade classifiably", async () => {
+		const { registration, context, snapshot } = createOverflowingModelContext();
+		queueProviderHardLimitResponses(registration, 12);
+
+		const failure = await runExtensionCompaction(context, snapshot).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		expect(registration.state.callCount).toBeLessThanOrEqual(1 + EXPECTED_MAX_OVERFLOW_RETRIES);
+		expect(failure).toBeInstanceOf(Error);
+		expect(classifyRequiredCompactionFallbackFailure(failure)).not.toBeUndefined();
+	});
+
+	it("Given an oversized summarization input When compaction runs Then every billed request fits the input budget", async () => {
+		const { registration, context, snapshot } = createOverflowingModelContext();
+		queueProviderHardLimitResponses(registration, 12);
+
+		await runExtensionCompaction(context, snapshot).then(
+			() => undefined,
+			() => undefined,
+		);
+
+		const callLog = registration.getCallLog();
+		expect(callLog.length).toBeGreaterThan(0);
+		for (const call of callLog) {
+			expect(requestContentTokens(call)).toBeLessThanOrEqual(Math.floor(CONTEXT_WINDOW * 0.6));
+		}
+	});
+
+	it("Given retries When the input shrinks Then it shrinks geometrically instead of one message at a time", async () => {
+		const { registration, context, snapshot } = createOverflowingModelContext();
+		queueProviderHardLimitResponses(registration, 12);
+
+		await runExtensionCompaction(context, snapshot).then(
+			() => undefined,
+			() => undefined,
+		);
+
+		const messageCounts = registration.getCallLog().map((call) => call.context.messages.length);
+		expect(messageCounts.length).toBeGreaterThan(1);
+		for (let index = 1; index < messageCounts.length; index++) {
+			const previous = messageCounts[index - 1] ?? 0;
+			const current = messageCounts[index] ?? 0;
+			expect(current).toBeLessThanOrEqual(Math.ceil(previous / 2) + 1);
+		}
+	});
+
+	it("Given slow rejected attempts When the cumulative budget elapses Then no further billed attempt is scheduled", async () => {
+		vi.useFakeTimers();
+		try {
+			const { registration, context, snapshot } = createOverflowingModelContext();
+			// ~100s of streaming per attempt at 10 tokens/s: under the 120s
+			// per-attempt watchdog, so every attempt completes and is rejected;
+			// only a cross-attempt budget can stop the loop.
+			const slowRejection = () =>
+				fauxAssistantMessage(`discarded ${"y".repeat(4_000)}`, {
+					stopReason: "error",
+					errorMessage: PROVIDER_HARD_LIMIT_MESSAGE,
+				});
+			registration.setResponses(Array.from({ length: 12 }, () => slowRejection));
+
+			const settled = runExtensionCompaction(context, snapshot).then(
+				() => "resolved" as const,
+				(error: unknown) => error,
+			);
+			let outcome: "resolved" | unknown | undefined;
+			void settled.then((value) => {
+				outcome = value;
+			});
+			for (let step = 0; step < 600 && outcome === undefined; step++) {
+				await vi.advanceTimersByTimeAsync(1_000);
+			}
+
+			expect(outcome).not.toBe("resolved");
+			// Attempts complete at ~100s each; a 240s cross-attempt budget stops the
+			// loop after the third attempt, one earlier than the retry cap alone.
+			expect(registration.state.callCount).toBeLessThanOrEqual(EXPECTED_MAX_OVERFLOW_RETRIES);
+			expect(classifyRequiredCompactionFallbackFailure(outcome)).not.toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/coding-agent/test/compaction/speculative-compaction.test.ts
+++ b/packages/coding-agent/test/compaction/speculative-compaction.test.ts
@@ -480,7 +480,7 @@ describe("speculative compaction", () => {
 
 	it("retries a compaction summary request with a smaller input after a context-window failure", async () => {
 		// Given
-		const context = createContext();
+		const context = createContext({ shrink: true });
 		const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
 		context.registration.setResponses([
 			fauxAssistantMessage("", {
@@ -501,8 +501,15 @@ describe("speculative compaction", () => {
 
 	it("keeps pruning and retrying after repeated compaction summary context-window failures", async () => {
 		// Given
-		const context = createContext();
+		const context = createContext({ shrink: true });
 		context.getCompactionSettings = () => ({ ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 1 });
+		for (let index = 0; index < 6; index++) {
+			context.sessionManager.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: `retry-marker-${index} ${"z".repeat(1_600)}` }],
+				timestamp: Date.now() - 900 + index,
+			});
+		}
 		context.sessionManager.appendMessage({
 			role: "user",
 			content: [{ type: "text", text: "kept recent user" }],
@@ -528,6 +535,8 @@ describe("speculative compaction", () => {
 
 		// Then
 		expect(result?.summary).toBe("eventually compacted");
+		const requestMessages = context.registration.getCallLog().map((entry) => entry.context.messages.length);
+		expect(requestMessages).toHaveLength(3);
 		const requestTexts = context.registration.getCallLog().map((entry) => {
 			const firstMessage = entry.context.messages[0];
 			if (!firstMessage) return "";
@@ -538,13 +547,15 @@ describe("speculative compaction", () => {
 				.map((part) => part.text)
 				.join("\n");
 		});
-		expect(requestTexts).toHaveLength(3);
 		expect(requestTexts[0]).toContain("first user");
 		expect(requestTexts[1]).not.toContain("first user");
-		expect(requestTexts[1]).toContain("first assistant");
-		expect(requestTexts[2]).not.toContain("first assistant");
-		expect(requestTexts[2]).toContain("second user");
-		expect(requestTexts[2]).not.toContain("kept recent user");
+		expect(requestTexts[1]).not.toContain("second user");
+		expect(requestTexts[1]).toContain("retry-marker-0");
+		expect(requestTexts[2]).not.toContain("retry-marker-0");
+		expect(requestMessages[1]).toBeLessThan(requestMessages[0] as number);
+		expect(requestMessages[2]).toBeLessThan(requestMessages[1] as number);
+		const lastRequestText = JSON.stringify(context.registration.getCallLog()[2]?.context.messages);
+		expect(lastRequestText).not.toContain("kept recent user");
 	});
 
 	it("sends the conversation as native messages with a trailing summarization instruction", async () => {

--- a/packages/coding-agent/test/session-log-routes.test.ts
+++ b/packages/coding-agent/test/session-log-routes.test.ts
@@ -63,6 +63,34 @@ describe("session.log stuck-route instrumentation", () => {
 		});
 	});
 
+	it("logs compaction_start before the decision so a wedged compaction is visible (issue #650)", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 16_384, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi: ExtensionAPI) => {
+					pi.on("session_before_compact", () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "test rejection",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("seed handled")]);
+		await harness.session.prompt("seed context ".repeat(40));
+
+		await getRunAutoCompaction(harness)("threshold", false);
+		await harness.session.waitForSettledSessionWork();
+
+		const events = readSessionLog(harness).filter(
+			(line) => line.event === "compaction_start" || line.event === "compaction_decision",
+		);
+		expect(events[0]).toMatchObject({ event: "compaction_start", reason: "threshold" });
+		expect(events.at(-1)?.event).toBe("compaction_decision");
+	});
+
 	it("logs queue_enqueue for native steer and followUp queueing", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1", contextWindow: 128_000, maxTokens: 64 }],


### PR DESCRIPTION
Fixes #650.

## Summary

On `openai-codex` / `gpt-5.6-sol` a blocking compaction could wedge for ~48 minutes on `Compacting...` and burn ~13.5M billed tokens across dozens of sequential summarization attempts, with no `compaction_start` ever logged.

Root cause: the overflow-retry loop in `runExtensionCompaction` removed exactly **one history item per full billed summarization attempt** — no attempt cap, no cumulative wall-clock budget, no log line — and the summarization input itself was unbudgeted (only tool results were pruned), so a session whose provider-side input exceeded the real window drew an overflow verdict on every completed attempt and kept re-billing near-identical prefixes.

## Fix

- **New `overflow-retry.ts`** (policy extracted from `speculative.ts`, which shrinks 569→509 pure LOC):
  - `boundSummarizationInput` — pre-sizes the summarization input to 0.6×window (prompt-token aware) before the first billed attempt;
  - `shrinkSummarizationInputForOverflowRetry` — **halves** the estimated input per retry (O(log n) convergence) instead of dropping one item, keeping a drop-oldest fallback when every message sits at the turn boundary;
  - `MAX_SUMMARIZATION_OVERFLOW_RETRIES = 3` and `SUMMARIZATION_OVERFLOW_TOTAL_BUDGET_MS = 240s`, both checked **before** scheduling another billed attempt;
  - exhaustion throws typed `SummarizationOverflowExhaustedError(attempts, elapsedMs)`.
- `deterministic-fallback.ts` classifies the exhaustion (`summarization-overflow-exhausted`) so required compaction degrades to the deterministic fallback; `transient-failure.ts` treats it as a transient lane failure (breaker records it; the next run starts pre-sized).
- `agent-session.ts` mirrors `compaction_start` (reason only) into `logs/session.log`; previously only `compaction_end` was mirrored, so a wedged compaction left zero log evidence for its entire lifetime.

Out of scope (flagged in the issue as an unconfirmed lead): the `getPromptContextWindow` reserve collapse (272K→144K) makes the emergency prune engage early at 61.6%; real but separate from the wedge, left for a follow-up.

## Evidence (RED → GREEN + real surface)

Unit (`test/compaction/overflow-retry-bound.test.ts`), each captured RED against the pre-fix checkout, GREEN after:

| Leg | RED (pre-fix) | GREEN |
|---|---|---|
| attempt cap | `expected 13 to be ≤ 4` (one billed request per history item) | ≤ 1+3 attempts, typed classifiable error |
| input presize | `expected 12838 to be ≤ 4800` (full oversized input billed) | every request ≤ 0.6×window |
| geometric shrink | `expected 40 to be ≤ 22` (one message per retry) | halving per retry |
| cumulative budget | `expected 13 to be ≤ 3` (no cross-attempt budget) | loop stops at the 240s budget |

- Full compaction scope green: `test/compaction/` 46 files / 340 tests; `test/suite -t compaction` 32/167; `test/suite/regressions/` green (two theme/fs-watch failures were an unbuilt-worktree environment issue, pass after `npm run build`, unrelated).
- `npm run check` green.
- Real CLI QA (senpi-qa RPC channel, fake model server rejecting every summarization request as overflow):
  - **fixed**: 3 billed attempts, wire-verified shrinking payloads `80383 → 80333 → 40260` bytes, terminal compaction outcome in ~10ms, CLI responsive after, `compaction_start` present in session.log;
  - **pre-fix main (same driver)**: 4 attempts starting with the full `120456`-byte unbounded input, no `compaction_start` in session.log;
  - harness self-tests: common 9/9, mock-loop 43/43, rpc-drive 4/4, cli-smoke 8/8.
  - receipts: `local-ignore/qa-evidence/20260803-650-compaction-overflow-bound/`

## Test plan

- `npx vitest --run test/compaction/` (46/340 green)
- `npx vitest --run test/session-log-routes.test.ts`
- `npm run check`
- `node local-ignore/qa-evidence/20260803-650-compaction-overflow-bound/compaction-overflow-qa.mjs` (9/9)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents compaction wedges and runaway token spend by bounding summarization overflow retries, and adds session log visibility for compaction start. Compaction now pre-sizes and geometrically shrinks inputs, caps retries, and stops on a total time budget with a typed, classifiable error.

- **Bug Fixes**
  - Pre-size summarization input to 60% of the window (prompt-token aware) before the first attempt.
  - On overflow, halve the input each retry; drop-oldest fallback when all messages sit at the turn boundary.
  - Stop before scheduling a new attempt when hitting either 3 retries or a 240s total budget; throw `SummarizationOverflowExhaustedError`.
  - Classify exhaustion for the deterministic fallback; treat as transient for the breaker so the next run starts pre-sized.
  - Mirror `compaction_start` (reason) into `logs/session.log` so wedged compactions are visible.

- **Refactors**
  - Extracted the overflow-retry policy to `overflow-retry.ts`; simplified `speculative.ts`.

<sup>Written for commit 07405ce1a3e1a996a1cd730071aeea1e100a8e93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

