### PR TITLE
fix(mcp): fully reconnect expired sessions

### DIFF
--- a/.omo/plans/mcp-session-expiry-full-reconnect.md
+++ b/.omo/plans/mcp-session-expiry-full-reconnect.md
@@ -1,0 +1,212 @@
+# MCP Session Expiry Full Reconnect
+
+## Goal
+
+Make MCP tool calls recover automatically when a server reports session expiry
+and the renewed session requires the same catalog/list handshake performed by
+`/mcp reconnect`. The retry must reuse the existing service-aware reconnect
+path, remain bounded to one retry, preserve actionable failure behavior, and
+ship with deterministic RED-to-GREEN evidence plus real-source CLI QA.
+
+## Recovered Failure
+
+- Senpi session: `019fc0e8-634f-7745-aecc-068d31cc8e5d`
+- Exact result:
+  `SessionExpiredError: MCP server aside_browser session expired; reinitialize retry also expired; run /mcp reconnect aside_browser`
+- Re-running `tool_search` only reactivated the same tool and repeated the
+  failure.
+- Local versions at reproduction:
+  - Senpi/source: `2026.8.1`
+  - Aside CLI: `1.26.709.1533`
+- The timestamped local MCP backup configured `aside_browser` as
+  `/Users/yeongyu/.local/bin/aside mcp` with search exposure.
+
+## Root Cause
+
+`withMcpSessionExpiryRetry()` calls bare `ServerConnection.renew()`. That renews
+the transport, but it does not reset reconnect state or run the service callback
+that:
+
+1. refreshes auth;
+2. invalidates `cacheRefreshedAfterConnect`;
+3. renews the transport;
+4. recollects tools/resources/prompts/instructions;
+5. rewrites the catalog cache;
+6. restores resource subscriptions.
+
+The explicit `/mcp reconnect` command already uses `reconnectMcpNow()`, which
+performs that full sequence. `tool_search` only changes the active tool set and
+cannot repair connection state.
+
+## Decision
+
+In `health.ts`, replace the session-expiry retry's direct
+`connection.renew()` with `reconnectMcpNow(connection)`.
+
+This is the smallest correct change because:
+
+- it reuses the exact proven manual reconnect implementation;
+- it adds no new state, tool, command, or policy;
+- connections without configured reconnect state retain the existing fallback
+  because `reconnectMcpNow()` delegates to `connection.renew()`;
+- the retry remains bounded: a second session-expiry error still marks the
+  connection suspended and returns actionable guidance.
+
+## Tier and Delegation
+
+Tier: **HEAVY** because MCP session-handling/reconnect semantics change.
+
+Completed independent read-only lanes:
+
+- `mcp-reconnect-audit` traced thin renew versus service-aware reconnect.
+- `mcp-expiry-repro` identified deterministic fixtures and QA seams.
+
+The lead owns implementation, RED/GREEN ordering, QA, delivery, merge, and
+cleanup because those steps share one mutable worktree and one evidence ledger.
+
+## Implementation Waves
+
+### Setup
+
+1. Create branch/worktree `fix/mcp-session-expiry-full-reconnect`.
+2. Commit this plan and open a draft PR.
+3. Register the binding goal.
+
+### RED
+
+1. Add fixture flag `--expire-first-tool-call`.
+2. Add fixture flag `--require-list-before-tool-call`.
+3. Track whether `tools/list` ran for each HTTP fixture session.
+4. Add `test/mcp/session-expiry-full-reconnect.test.ts` with:
+   - catalog-handshake recovery;
+   - permanent-expiry bounded failure;
+   - ordinary one-shot expiry recovery.
+5. Run each test selector against unchanged production code and capture RED.
+
+### GREEN
+
+1. Import `reconnectMcpNow` in `health.ts`.
+2. Use it for `withMcpSessionExpiryRetry()` recovery.
+3. Add the fork change entry to `mcp/changes.md`.
+4. Re-run each selector and capture GREEN.
+
+### Verification
+
+1. Run LSP diagnostics on changed TypeScript files.
+2. Run:
+   `npx vitest run test/mcp/diagnose.test.ts test/mcp/reconnect.test.ts test/mcp/ping-on-call.test.ts test/mcp/session-expiry-full-reconnect.test.ts`
+3. Run root `npm run check`.
+4. Run a temporary isolated real-source CLI driver with:
+   - localhost fake model;
+   - HTTP MCP fixture using both new flags;
+   - one scripted `mcp_fx_tool_1` call;
+   - assertion that the recovered tool result reaches the next model request.
+5. Run standard Senpi QA:
+   `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-mcp-tool mcp_fx_tool_1 --tool-args '{"value":"ok"}' --evidence mcp-session-expiry-full-reconnect`
+6. Record teardown for every process, port, and sandbox.
+
+### Delivery
+
+1. Self-review the diff and evidence.
+2. Commit the verified runtime/test/ledger increment.
+3. Push and mark the PR ready.
+4. Drive checks to green.
+5. Merge with a merge commit.
+6. Remove and prune the worktree.
+
+## Success Criteria
+
+### Criterion 1: catalog-handshake recovery
+
+Command:
+
+```bash
+cd packages/coding-agent
+npx vitest run test/mcp/session-expiry-full-reconnect.test.ts \
+  -t "refreshes the catalog before retrying an expired tool call"
+```
+
+Fixture:
+`--tools 1 --expire-first-tool-call --require-list-before-tool-call`
+
+PASS:
+
+- result is `fixture tool_1 value=after-expiry mode=alpha`;
+- state is `connected`;
+- generation increments once;
+- reconnect counter is `1`.
+
+RED before production change:
+
+- thin renew skips `tools/list`;
+- retry expires;
+- state becomes `suspended`;
+- manual reconnect guidance is returned.
+
+### Criterion 2: permanent-expiry bounded failure
+
+Command:
+
+```bash
+cd packages/coding-agent
+npx vitest run test/mcp/session-expiry-full-reconnect.test.ts \
+  -t "suspends after one full reconnect when the renewed session also expires"
+```
+
+Fixture: `--tools 1 --always-expire-tool-calls`
+
+PASS:
+
+- call rejects with `/mcp reconnect fx` guidance;
+- state is `suspended`;
+- reconnect counter is exactly `1`;
+- no third attempt occurs.
+
+RED before production change:
+
+- reconnect counter is `0`, proving only thin renewal ran.
+
+### Criterion 3: ordinary expiry remains green
+
+Command:
+
+```bash
+cd packages/coding-agent
+npx vitest run test/mcp/session-expiry-full-reconnect.test.ts \
+  -t "keeps ordinary one-shot session expiry recovery green"
+```
+
+Fixture: `--tools 1 --expire-first-tool-call`
+
+PASS:
+
+- result is `fixture tool_1 value=ordinary mode=alpha`;
+- state is `connected`;
+- reconnect counter is `1`.
+
+RED before production change:
+
+- result may succeed, but reconnect counter remains `0`.
+
+### Real-source CLI proof
+
+Command:
+
+```bash
+node local-ignore/qa-evidence/20260803-mcp-session-expiry-full-reconnect/full-reconnect-cli.mjs
+```
+
+PASS:
+
+- exit `0`;
+- verdict JSON contains `"pass": true`;
+- next fake-model request contains the recovered fixture result;
+- final output contains `MCP-SESSION-RECOVERY-PASS`;
+- cleanup receipt confirms no fixture/model/CLI processes or temp sandbox
+  remain.
+
+## Stop Condition
+
+Stop immediately when GitHub reports the PR as `MERGED`, the task worktree is
+removed, all three criteria and both real CLI QA surfaces pass with captured
+evidence and cleanup receipts, and the registered goal is completed.

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,34 @@
 # mcp Extension Changes
 
+## Session-expiry retry uses the full service reconnect (2026-08-03)
+
+### What changed
+- `health.ts` now routes a session-expired tool call through
+  `reconnectMcpNow()` before retrying, instead of renewing only the transport.
+- The retry therefore reuses the same service callback as
+  `/mcp reconnect <server>`: reset reconnect state, refresh auth, invalidate
+  catalog readiness, renew the transport, recollect the catalog, update cache
+  metadata, and restore resource subscriptions.
+- The retry remains bounded to one attempt. A renewed session that also
+  expires is still marked suspended with the existing actionable reconnect
+  guidance.
+
+### Why
+- Some MCP servers require a fresh catalog/list handshake after a new transport
+  session is initialized. Thin `connection.renew()` skipped that handshake, so
+  the retry immediately expired again and left the server suspended even
+  though the explicit `/mcp reconnect` path could recover it.
+
+### Why extension system couldn't handle this alone
+- The recovery must invoke the process-owned MCP service's private reconnect
+  callback, which owns auth refresh, catalog cache state, and subscriptions.
+  An external extension can call the exposed tool but cannot replace the
+  builtin's guarded tool-call retry boundary.
+
+### Expected merge conflict zones
+- LOW: `health.ts` session-expiry retry branch.
+- LOW: HTTP MCP fixture options and session-expiry regression tests.
+
 ## Classic reload preserves unchanged MCP servers (2026-07-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/health.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/health.ts
@@ -8,6 +8,7 @@ import {
 	isRetriableMcpError,
 	SessionExpiredError,
 } from "./errors.ts";
+import { reconnectMcpNow } from "./reconnect.ts";
 
 export const MCP_PING_STALE_MS = 30_000;
 export const MCP_PING_TIMEOUT_MS = 2_000;
@@ -66,7 +67,7 @@ export async function withMcpSessionExpiryRetry<T>(
 	} catch (error) {
 		if (!isMcpSessionExpiredError(error)) throw error;
 		connection.markDegraded(sessionExpiredError(connection, error, true));
-		await connection.renew();
+		await reconnectMcpNow(connection);
 		try {
 			return await operation();
 		} catch (retryError) {

--- a/packages/coding-agent/test/mcp/fixtures/http-server.ts
+++ b/packages/coding-agent/test/mcp/fixtures/http-server.ts
@@ -10,6 +10,7 @@ interface SessionEntry {
 	transport: StreamableHTTPServerTransport;
 	expired: boolean;
 	handledRequests: number;
+	listedTools: boolean;
 }
 
 async function main(): Promise<void> {
@@ -18,6 +19,7 @@ async function main(): Promise<void> {
 	await delaySlowStart(options);
 
 	const sessions = new Map<string, SessionEntry>();
+	let toolCallCount = 0;
 	const httpServer = createServer(async (req, res) => {
 		try {
 			if (options.bearerToken && req.headers.authorization !== `Bearer ${options.bearerToken}`) {
@@ -38,11 +40,19 @@ async function main(): Promise<void> {
 				writeJson(res, 404, { error: "fixture session expired" });
 				return;
 			}
-			if (options.alwaysExpireToolCalls && isToolCallRequest(body)) {
-				writeJson(res, 404, { error: "fixture tool call session expired" });
-				return;
+			if (isToolCallRequest(body)) {
+				toolCallCount += 1;
+				if (
+					options.alwaysExpireToolCalls ||
+					(options.expireFirstToolCall && toolCallCount === 1) ||
+					(options.requireListBeforeToolCall && !entry.listedTools)
+				) {
+					writeJson(res, 404, { error: "fixture tool call session expired" });
+					return;
+				}
 			}
 			await entry.transport.handleRequest(req, res, body);
+			if (isToolListRequest(body)) entry.listedTools = true;
 			const id = entry.transport.sessionId;
 			if (id && !entry.expired) sessions.set(id, entry);
 			if (isCountedSessionRequest(body)) entry.handledRequests++;
@@ -90,7 +100,7 @@ function createOrFindSession(
 	const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => `fx-${randomUUID()}` });
 	const server = createFixtureServer(parseFixtureOptions(process.argv.slice(2)));
 	void server.connect(transport);
-	const entry: SessionEntry = { server, transport, expired: false, handledRequests: 0 };
+	const entry: SessionEntry = { server, transport, expired: false, handledRequests: 0, listedTools: false };
 	const id = transport.sessionId;
 	if (id) sessions.set(id, entry);
 	return entry;
@@ -98,6 +108,10 @@ function createOrFindSession(
 
 function isToolCallRequest(body: unknown): boolean {
 	return typeof body === "object" && body !== null && "method" in body && body.method === "tools/call";
+}
+
+function isToolListRequest(body: unknown): boolean {
+	return typeof body === "object" && body !== null && "method" in body && body.method === "tools/list";
 }
 
 function isCountedSessionRequest(body: unknown): boolean {

--- a/packages/coding-agent/test/mcp/fixtures/http-server.ts
+++ b/packages/coding-agent/test/mcp/fixtures/http-server.ts
@@ -19,7 +19,7 @@ async function main(): Promise<void> {
 	await delaySlowStart(options);
 
 	const sessions = new Map<string, SessionEntry>();
-	let toolCallCount = 0;
+	let firstToolCallExpired = false;
 	const httpServer = createServer(async (req, res) => {
 		try {
 			if (options.bearerToken && req.headers.authorization !== `Bearer ${options.bearerToken}`) {
@@ -41,10 +41,11 @@ async function main(): Promise<void> {
 				return;
 			}
 			if (isToolCallRequest(body)) {
-				toolCallCount += 1;
+				const expiresFirstCall = options.expireFirstToolCall && !firstToolCallExpired;
+				if (expiresFirstCall) firstToolCallExpired = true;
 				if (
 					options.alwaysExpireToolCalls ||
-					(options.expireFirstToolCall && toolCallCount === 1) ||
+					expiresFirstCall ||
 					(options.requireListBeforeToolCall && !entry.listedTools)
 				) {
 					writeJson(res, 404, { error: "fixture tool call session expired" });

--- a/packages/coding-agent/test/mcp/fixtures/options.ts
+++ b/packages/coding-agent/test/mcp/fixtures/options.ts
@@ -20,6 +20,8 @@ export interface FixtureOptions {
 	instructions: string | undefined;
 	port: number;
 	expireSession: boolean;
+	expireFirstToolCall: boolean;
+	requireListBeforeToolCall: boolean;
 	alwaysExpireToolCalls: boolean;
 	bearerToken: string | undefined;
 	spawnGrandchild: boolean;
@@ -48,6 +50,8 @@ export function parseFixtureOptions(argv: readonly string[]): FixtureOptions {
 		instructions: readStringFlag(argv, "--instructions"),
 		port: readIntegerFlag(argv, "--port", 0),
 		expireSession: argv.includes("--expire-session"),
+		expireFirstToolCall: argv.includes("--expire-first-tool-call"),
+		requireListBeforeToolCall: argv.includes("--require-list-before-tool-call"),
 		alwaysExpireToolCalls: argv.includes("--always-expire-tool-calls"),
 		bearerToken: readStringFlag(argv, "--bearer"),
 		spawnGrandchild: argv.includes("--spawn-grandchild"),
@@ -133,6 +137,8 @@ function validateArgs(argv: readonly string[], options: FixtureOptions): void {
 		"--binary-output-tool",
 		"--emit-list-changed",
 		"--expire-session",
+		"--expire-first-tool-call",
+		"--require-list-before-tool-call",
 		"--always-expire-tool-calls",
 		"--spawn-grandchild",
 	]);

--- a/packages/coding-agent/test/mcp/session-expiry-full-reconnect.test.ts
+++ b/packages/coding-agent/test/mcp/session-expiry-full-reconnect.test.ts
@@ -1,0 +1,116 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ServerConnection } from "../../src/core/extensions/builtin/mcp/connection.ts";
+import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import {
+	attach,
+	awaitMcpToolRegistration,
+	capturingPi,
+	mcpRoot,
+	type RegisteredMcpTool,
+	registeredTool,
+	testContext,
+	textContent,
+} from "./fixtures/register-call.ts";
+import { cleanupRoots, setConfig } from "./fixtures/service-lifecycle.ts";
+import { type HttpFixture, spawnHttpFixture } from "./fixtures/spawn-fixture.ts";
+
+const cleanupTasks: Array<() => Promise<void>> = [];
+const httpFixtures: HttpFixture[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await getMcpService().dispose("quit");
+	resetMcpServiceForTests();
+	for (const fixture of httpFixtures.splice(0)) await fixture.cleanup();
+	await cleanupRoots(cleanupTasks);
+});
+
+describe("MCP session expiry full reconnect", () => {
+	it("refreshes the catalog before retrying an expired tool call", async () => {
+		const { connection, tool } = await setupFixture(
+			["--tools", "1", "--expire-first-tool-call", "--require-list-before-tool-call"],
+			"catalog-refresh",
+		);
+		const initialGeneration = connection.generation;
+
+		const result = await tool.execute(
+			"tc-catalog-refresh",
+			{ value: "after-expiry" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+
+		expect(textContent(result)).toBe("fixture tool_1 value=after-expiry mode=alpha");
+		expect(connection.state).toBe("connected");
+		expect(connection.generation).toBe(initialGeneration + 1);
+		expect(reconnectCount("fx")).toBe(1);
+	});
+
+	it("suspends after one full reconnect when the renewed session also expires", async () => {
+		const { connection, tool } = await setupFixture(
+			["--tools", "1", "--always-expire-tool-calls"],
+			"persistent-expiry",
+		);
+		const callTool = vi.spyOn(Client.prototype, "callTool");
+
+		await expect(
+			tool.execute("tc-persistent-expiry", { value: "still-expired" }, undefined, undefined, testContext()),
+		).rejects.toThrow(/run \/mcp reconnect fx/);
+
+		expect(connection.state).toBe("suspended");
+		expect(reconnectCount("fx")).toBe(1);
+		expect(callTool).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps ordinary one-shot session expiry recovery green", async () => {
+		const { connection, tool } = await setupFixture(["--tools", "1", "--expire-first-tool-call"], "ordinary-expiry");
+
+		const result = await tool.execute(
+			"tc-ordinary-expiry",
+			{ value: "ordinary" },
+			undefined,
+			undefined,
+			testContext(),
+		);
+
+		expect(textContent(result)).toBe("fixture tool_1 value=ordinary mode=alpha");
+		expect(connection.state).toBe("connected");
+		expect(reconnectCount("fx")).toBe(1);
+	});
+});
+
+async function setupFixture(
+	args: string[],
+	slug: string,
+): Promise<{ connection: ServerConnection; tool: RegisteredMcpTool }> {
+	const fixture = await spawnHttpFixture(args);
+	httpFixtures.push(fixture);
+	const root = mcpRoot(slug, cleanupTasks);
+	setConfig(root, { fx: httpServer(fixture.url) });
+	const pi = capturingPi();
+	await attach(root, pi);
+	await awaitMcpToolRegistration("fx");
+	const connection = getMcpService().getConnection("fx");
+	if (connection === undefined) throw new Error("missing fx connection");
+	return { connection, tool: registeredTool(pi, "mcp_fx_tool_1") };
+}
+
+function httpServer(url: string): Record<string, unknown> {
+	return {
+		type: "http",
+		url,
+		connectTimeoutMs: 2_000,
+		requestTimeoutMs: 5_000,
+		startupTimeoutMs: 2_000,
+	};
+}
+
+function reconnectCount(name: string): number {
+	const snapshot = getMcpService()
+		.getServerSnapshots()
+		.find((candidate) => candidate.name === name);
+	if (snapshot === undefined) throw new Error(`missing ${name} snapshot`);
+	return snapshot.counters.reconnectCount;
+}


### PR DESCRIPTION
## Summary

- make automatic MCP session-expiry recovery use the same service-aware reconnect path as `/mcp reconnect`
- add deterministic HTTP fixture coverage for renewed sessions that require a fresh `tools/list` handshake
- prove bounded failure when the renewed session also expires
- capture real-source CLI QA and standard Senpi MCP mock-loop evidence before merge

## Recovered failure

Session `019fc0e8-634f-7745-aecc-068d31cc8e5d` recorded:

```text
SessionExpiredError: MCP server aside_browser session expired; reinitialize retry also expired; run /mcp reconnect aside_browser
```

`tool_search` only reactivated the same tool and repeated the failure.

## Root cause

The automatic session-expiry retry uses thin `connection.renew()`. The explicit
reconnect command uses `reconnectMcpNow()`, whose service callback also refreshes
auth, invalidates catalog readiness, recollects the MCP catalog, updates cache
metadata, and restores subscriptions.

## Plan

See `.omo/plans/mcp-session-expiry-full-reconnect.md`.

## Evidence

Evidence directory:
`local-ignore/qa-evidence/20260803-mcp-session-expiry-full-reconnect/`

RED:

- catalog-handshake case failed with the recovered manual reconnect error
- permanent-expiry case recorded `reconnectCount=0`
- ordinary expiry returned the result but recorded `reconnectCount=0`
- real source CLI sent the manual reconnect error to the second model request

GREEN:

- all three selectors pass through `reconnectMcpNow()`
- scoped MCP tests: 4 files, 19 tests passed
- root `npm run check`: exit 0
- real source CLI:
  - recovered tool result reached the second model request
  - final marker returned
  - fixture/model ports closed
  - fixture PID stopped
  - sandbox removed
  - real auth unchanged
- standard Senpi MCP mock loop: 5/5 passed

## Validation

```text
Test Files 4 passed (4)
Tests 19 passed (19)
npm run check: PASS
Biome changed files: PASS
TypeScript noEmit: PASS
git diff --check: PASS
```
