### PR TITLE
feat(ai,coding-agent): hint-aware 429 retry with tiered wait/probe-back policy

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/hint-429-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/hint-429-server.mjs
@@ -1,0 +1,147 @@
+/**
+ * Scripted 429 server for the hint-aware retry-tier scenarios.
+ *
+ * Answers the Anthropic Messages wire format so the REAL header -> canonical
+ * marker path is exercised (`anthropic-messages.ts` appends
+ * `(retry-after-ms: N)` only when a 429 SDK error carries response headers).
+ * The primary model is rate limited for a scripted number of requests; every
+ * other request streams a text marker.
+ *
+ * The 429 body/headers are scripted per scenario:
+ *   - hinted:  `retry-after` (seconds) or `retry-after-ms` header + rate-limit body
+ *   - no-hint: rate-limit body only, ZERO retry-after headers
+ *
+ * The probe-back scenario needs the primary to recover on its own schedule, so
+ * `primaryLimitedRequests` bounds how many primary requests are refused; the
+ * rest (including the scheduler's 1-token probe) succeed.
+ */
+
+import { createServer } from "node:http";
+
+export const HINT_429_PRIMARY_MODEL_ID = "mock-claude";
+export const HINT_429_FALLBACK_MODEL_ID = "mock-claude-fallback";
+
+function readRequestBody(request) {
+	return new Promise((resolve, reject) => {
+		let body = "";
+		request.setEncoding("utf8");
+		request.on("data", (chunk) => {
+			body += chunk;
+		});
+		request.on("end", () => resolve(body));
+		request.on("error", reject);
+	});
+}
+
+/**
+ * @param {{
+ *   primaryLimitedRequests: number,
+ *   rateLimitHeaders?: Record<string, string>,
+ *   rateLimitMessage?: string,
+ *   primaryMarker: string,
+ *   fallbackMarker: string,
+ * }} script
+ */
+export function startHint429Server(script) {
+	if (!Number.isInteger(script.primaryLimitedRequests) || script.primaryLimitedRequests < 0) {
+		throw new Error("primaryLimitedRequests must be a non-negative integer");
+	}
+	const requests = [];
+	let primaryRefusals = 0;
+	const server = createServer(async (request, response) => {
+		const raw = await readRequestBody(request);
+		let payload = {};
+		try {
+			payload = raw ? JSON.parse(raw) : {};
+		} catch {}
+		const isPrimary = payload.model === HINT_429_PRIMARY_MODEL_ID;
+		const rateLimited = isPrimary && primaryRefusals < script.primaryLimitedRequests;
+		requests.push({
+			path: request.url,
+			model: payload.model,
+			// A max_tokens of 1 identifies the probe-back scheduler's 1-token ping.
+			maxTokens: payload.max_tokens,
+			rateLimited,
+			atMs: Date.now(),
+		});
+		if (rateLimited) {
+			primaryRefusals++;
+			response.writeHead(429, { "content-type": "application/json", ...(script.rateLimitHeaders ?? {}) });
+			response.end(
+				JSON.stringify({
+					type: "error",
+					error: {
+						type: "rate_limit_error",
+						message: script.rateLimitMessage ?? "All tokens rate limited",
+					},
+				}),
+			);
+			return;
+		}
+		response.writeHead(200, {
+			"content-type": "text/event-stream",
+			"cache-control": "no-cache",
+			connection: "keep-alive",
+		});
+		writeTextResponse(response, payload.model, isPrimary ? script.primaryMarker : script.fallbackMarker);
+		response.end();
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				reject(new Error("hint-429 server has no TCP address"));
+				return;
+			}
+			const origin = `http://127.0.0.1:${address.port}`;
+			resolve({
+				origin,
+				url: `${origin}/v1`,
+				port: address.port,
+				requests,
+				get listening() {
+					return server.listening;
+				},
+				stop: () => new Promise((done) => server.close(() => done())),
+			});
+		});
+	});
+}
+
+function writeTextResponse(response, model, text) {
+	writeSse(response, "message_start", {
+		type: "message_start",
+		message: {
+			id: "msg_hint_429",
+			type: "message",
+			role: "assistant",
+			model,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: 1, output_tokens: 0 },
+		},
+	});
+	writeSse(response, "content_block_start", {
+		type: "content_block_start",
+		index: 0,
+		content_block: { type: "text", text: "" },
+	});
+	writeSse(response, "content_block_delta", {
+		type: "content_block_delta",
+		index: 0,
+		delta: { type: "text_delta", text },
+	});
+	writeSse(response, "content_block_stop", { type: "content_block_stop", index: 0 });
+	writeSse(response, "message_delta", {
+		type: "message_delta",
+		delta: { stop_reason: "end_turn", stop_sequence: null },
+		usage: { output_tokens: 1 },
+	});
+	writeSse(response, "message_stop", { type: "message_stop" });
+}
+
+function writeSse(response, event, data) {
+	response.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}

--- a/.agents/skills/senpi-qa/scripts/lib/hint-429-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/hint-429-server.mjs
@@ -17,10 +17,19 @@
  */
 
 import { createServer } from "node:http";
+import { API_PRESETS } from "./mock-loop-support.mjs";
 
-export const HINT_429_PRIMARY_MODEL_ID = "mock-claude";
+// Derive from the shared preset so changing the anthropic modelId in one place
+// does not silently break the 429 scripted path.
+export const HINT_429_PRIMARY_MODEL_ID = API_PRESETS["anthropic-messages"].modelId;
 export const HINT_429_FALLBACK_MODEL_ID = "mock-claude-fallback";
 
+// readRequestBody + writeSse are also defined in anthropic-policy-refusal-server.mjs
+// and fallback-abort-server.mjs. No shared helper module exists yet; if a fourth
+// call site appears, extract one.
+
+// NOTE: readRequestBody + writeSse are duplicated from anthropic-policy-refusal-server.mjs.
+// See the module-load comment above for the rationale on not extracting a shared helper yet.
 function readRequestBody(request) {
 	return new Promise((resolve, reject) => {
 		let body = "";

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-hint-429.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-hint-429.mjs
@@ -1,0 +1,402 @@
+/**
+ * Hint-aware 429 retry-tier scenarios (real CLI, RPC surface, zero real calls).
+ *
+ * The tier decision is only observable as SESSION EVENTS (`auto_retry_start`
+ * delayMs sequencing, `retry_fallback_applied`, `retry_probe_scheduled` /
+ * `retry_probe_result`), and `--print` does not emit them. These scenarios
+ * therefore drive the same real CLI from source over `--mode rpc`, which
+ * forwards every `AgentSessionEvent` verbatim as a JSON line.
+ *
+ *   hinted-429-in-turn      Tier 1: hinted 429 stays on the SAME model, waiting
+ *                           half the hint then to the (refreshed) deadline.
+ *   no-hint-429-fast-fallback  No hint: exactly ONE primary call, immediate
+ *                           fallback, next chain model serves the turn.
+ *   hinted-429-probe-back   Tier 2 (hint above a test-shrunk hintedWaitCapMs):
+ *                           immediate fallback, bounded probe-back, probe ok
+ *                           clears the cooldown and the next turn restores the
+ *                           primary.
+ *
+ * Every wait is bounded by a scripted hint measured in seconds, and every
+ * assertion waits on an EVENT (never a fixed sleep), so runs are deterministic.
+ */
+
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox, spawnCli } from "./common.mjs";
+import { API_PRESETS, checkRealAuthUnchanged, hermeticEnv, writeMockModelsJson } from "./mock-loop-support.mjs";
+import {
+	HINT_429_FALLBACK_MODEL_ID,
+	HINT_429_PRIMARY_MODEL_ID,
+	startHint429Server,
+} from "./hint-429-server.mjs";
+
+const API_NAME = "anthropic-messages";
+const PRIMARY_MARKER = "SENPI-QA-HINT429-PRIMARY-6c1b";
+const FALLBACK_MARKER = "SENPI-QA-HINT429-FALLBACK-6c1b";
+const IN_TURN_HINT_SECONDS = 8;
+const PROBE_BACK_HINT_MS = 4000;
+const PROBE_BACK_CAP_MS = 1000;
+
+export const HINT_429_SCENARIOS = ["hinted-429-in-turn", "no-hint-429-fast-fallback", "hinted-429-probe-back"];
+
+export function isHint429Scenario(name) {
+	return HINT_429_SCENARIOS.includes(name);
+}
+
+/**
+ * Minimal JSON-lines RPC client over a spawned `--mode rpc` child. Mirrors the
+ * Channel 1 client but stays local so scenario receipts carry no other channel's
+ * stdout, and so every observed event is timestamped for delay assertions.
+ */
+class HintRpcClient {
+	constructor({ env, cwd, extraArgs = [] }) {
+		this.child = spawnCli(["--mode", "rpc", "--no-session", "--no-context-files", "--no-extensions", ...extraArgs], {
+			env,
+			cwd,
+		});
+		this.pending = new Map();
+		this.events = [];
+		this.eventWaiters = [];
+		this.seq = 0;
+		this._buf = "";
+		this.stderr = "";
+		this.child.stdout.on("data", (chunk) => this._onData(chunk));
+		this.child.stderr.on("data", (chunk) => {
+			this.stderr += chunk.toString();
+		});
+	}
+
+	_onData(chunk) {
+		this._buf += chunk.toString();
+		let newline;
+		while ((newline = this._buf.indexOf("\n")) >= 0) {
+			const line = this._buf.slice(0, newline).trim();
+			this._buf = this._buf.slice(newline + 1);
+			if (!line) continue;
+			let message;
+			try {
+				message = JSON.parse(line);
+			} catch {
+				continue; // non-protocol noise (tsx/startup) — ignore
+			}
+			if (message?.type === "response") {
+				const waiter = message.id !== undefined ? this.pending.get(message.id) : undefined;
+				if (waiter) {
+					this.pending.delete(message.id);
+					waiter.resolve(message);
+				}
+				continue;
+			}
+			if (!message?.type) continue;
+			message.observedAtMs = Date.now();
+			this.events.push(message);
+			for (const waiter of [...this.eventWaiters]) {
+				if (!waiter.pred(message)) continue;
+				clearTimeout(waiter.timer);
+				this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
+				waiter.resolve(message);
+			}
+		}
+	}
+
+	send(command, { timeoutMs = 45000 } = {}) {
+		const id = command.id ?? `req-${++this.seq}`;
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`RPC timeout after ${timeoutMs}ms for ${command.type} (stderr: ${this.stderr.slice(-400)})`));
+			}, timeoutMs);
+			this.pending.set(id, {
+				resolve: (message) => {
+					clearTimeout(timer);
+					resolve(message);
+				},
+			});
+			this.child.stdin.write(`${JSON.stringify({ ...command, id })}\n`);
+		});
+	}
+
+	waitForEvent(pred, { timeoutMs = 60000 } = {}) {
+		const found = this.events.find(pred);
+		if (found) return Promise.resolve(found);
+		return new Promise((resolve, reject) => {
+			const waiter = {
+				pred,
+				resolve,
+				timer: setTimeout(() => {
+					this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
+					reject(new Error(`timed out after ${timeoutMs}ms waiting for a matching session event`));
+				}, timeoutMs),
+			};
+			this.eventWaiters.push(waiter);
+		});
+	}
+
+	close() {
+		try {
+			this.child.stdin.end();
+		} catch {}
+	}
+
+	/**
+	 * Deterministic teardown: closing stdin ends `--mode rpc`. Await the real exit
+	 * event (never a fixed sleep) and SIGKILL only if the child outlives the bound,
+	 * so the cleanup receipt can assert the pid is gone rather than assume it.
+	 */
+	closeAndWait({ timeoutMs = 15000 } = {}) {
+		this.close();
+		if (this.child.exitCode !== null || this.child.signalCode !== null) return Promise.resolve();
+		return new Promise((resolve) => {
+			const timer = setTimeout(() => {
+				try {
+					this.child.kill("SIGKILL");
+				} catch {}
+			}, timeoutMs);
+			this.child.once("exit", () => {
+				clearTimeout(timer);
+				resolve();
+			});
+		});
+	}
+}
+
+function selector(modelId) {
+	return `${API_PRESETS[API_NAME].provider}/${modelId}`;
+}
+
+function retrySettings(extra = {}) {
+	return {
+		enabled: true,
+		maxRetries: 3,
+		baseDelayMs: 0,
+		provider: { maxRetries: 0, maxRetryDelayMs: 60000 },
+		fallbackChains: {
+			[selector(HINT_429_PRIMARY_MODEL_ID)]: [selector(HINT_429_FALLBACK_MODEL_ID)],
+		},
+		...extra,
+	};
+}
+
+/** Terminal boundary of one prompt: agent_end that is NOT followed by a retry. */
+function turnComplete(afterMs = 0) {
+	return (event) =>
+		(event.type === "agent_end" && event.willRetry === false && event.observedAtMs >= afterMs) ||
+		(event.type === "agent_aborted" && event.observedAtMs >= afterMs);
+}
+
+async function runOneTurn(client, message, { timeoutMs = 120000, afterMs = 0 } = {}) {
+	const ack = await client.send({ type: "prompt", message });
+	if (ack.success !== true) throw new Error(`prompt rejected: ${JSON.stringify(ack)}`);
+	await client.waitForEvent(turnComplete(afterMs), { timeoutMs });
+	const last = await client.send({ type: "get_last_assistant_text" });
+	return last.data?.text ?? "";
+}
+
+function retryEvents(client) {
+	return client.events.filter((event) => event.type === "auto_retry_start" || event.type === "auto_retry_end" || event.type.startsWith("retry_"));
+}
+
+function transcript(scenarioName, server, client) {
+	const sequence = server.requests.map(
+		(request, index) => `${index + 1}:${selector(request.model)}${request.rateLimited ? "(429)" : ""}${request.maxTokens === 1 ? "(probe)" : ""}`,
+	);
+	const delays = client.events.filter((event) => event.type === "auto_retry_start").map((event) => event.delayMs);
+	const fallbacks = client.events.filter((event) => event.type === "retry_fallback_applied").length;
+	return [
+		`scenario=${scenarioName}`,
+		`attempts=${server.requests.length}`,
+		`sequence=${sequence.join(",") || "none"}`,
+		`retryDelays=${delays.join(",") || "none"}`,
+		`fallbackApplied=${fallbacks}`,
+		`probeScheduled=${client.events.filter((event) => event.type === "retry_probe_scheduled").length}`,
+		`probeOk=${client.events.filter((event) => event.type === "retry_probe_result" && event.ok === true).length}`,
+	].join(" ");
+}
+
+function writeHint429Evidence(slug, scenarioName, { server, client, texts, box, cliPid }) {
+	const dir = evidenceDir(slug);
+	writeFileSync(join(dir, `${scenarioName}-events.jsonl`), `${client.events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+	writeFileSync(join(dir, `${scenarioName}-requests.json`), `${JSON.stringify(server.requests, null, 2)}\n`);
+	writeFileSync(
+		join(dir, `${scenarioName}-summary.json`),
+		`${JSON.stringify(
+			{
+				command: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario ${scenarioName}`,
+				api: API_NAME,
+				sandbox: box.dir,
+				// Cleanup receipt inputs: the exact localhost port and CLI pid this run held.
+				mockServerOrigin: server.origin,
+				mockServerPort: server.port,
+				rpcCliPid: cliPid,
+				assistantTexts: texts,
+				retryEvents: retryEvents(client),
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	process.stderr.write(`evidence: ${dir}\n`);
+}
+
+export async function runHint429Scenario({ scenarioName, apiName, evidenceSlug }) {
+	if (apiName !== API_NAME) {
+		throw new Error(`${scenarioName} requires --api ${API_NAME}`);
+	}
+	installCleanupHooks();
+	const checks = createChecks(`mock-loop.mjs --scenario ${scenarioName}`);
+	const guard = guardRealAuth();
+	const box = makeSandbox(`senpi-qa-${scenarioName}`);
+	const script =
+		scenarioName === "hinted-429-in-turn"
+			? { primaryLimitedRequests: 2, rateLimitHeaders: { "retry-after": String(IN_TURN_HINT_SECONDS) }, rateLimitMessage: "primary rate limited" }
+			: scenarioName === "no-hint-429-fast-fallback"
+				? { primaryLimitedRequests: 4, rateLimitMessage: "All tokens rate limited" }
+				: { primaryLimitedRequests: 1, rateLimitHeaders: { "retry-after-ms": String(PROBE_BACK_HINT_MS) }, rateLimitMessage: "primary rate limited" };
+	const server = await startHint429Server({ ...script, primaryMarker: PRIMARY_MARKER, fallbackMarker: FALLBACK_MARKER });
+	writeMockModelsJson(box.agentDir, server, API_NAME, {}, {
+		models: [{ id: HINT_429_FALLBACK_MODEL_ID }],
+		retry:
+			scenarioName === "hinted-429-probe-back"
+				? retrySettings({ hintedWaitCapMs: PROBE_BACK_CAP_MS, probeBackMaxMs: 3_600_000 })
+				: retrySettings(),
+	});
+	const client = new HintRpcClient({
+		env: hermeticEnv(box.env),
+		cwd: box.cwd,
+		extraArgs: ["--provider", API_PRESETS[API_NAME].provider, "--model", HINT_429_PRIMARY_MODEL_ID],
+	});
+	const texts = [];
+	try {
+		await client.send({ type: "get_state" }); // ensure the session booted
+		if (scenarioName === "hinted-429-in-turn") await assertInTurn(checks, client, server, texts);
+		else if (scenarioName === "no-hint-429-fast-fallback") await assertFastFallback(checks, client, server, texts);
+		else await assertProbeBack(checks, client, server, texts);
+		process.stdout.write(`SENPI_QA_HINT429_TRANSCRIPT ${transcript(scenarioName, server, client)}\n`);
+		checkRealAuthUnchanged(checks, guard);
+		if (evidenceSlug) {
+			writeHint429Evidence(evidenceSlug, scenarioName, { server, client, texts, box, cliPid: client.child.pid });
+		}
+	} catch (error) {
+		checks.ok(`${scenarioName}: scenario ran to completion`, false, error instanceof Error ? error.message : String(error));
+		process.stderr.write(`\n--- ${scenarioName} rpc stderr tail ---\n${client.stderr.slice(-1500)}\n`);
+	} finally {
+		// Paired teardown: RPC child stdin closed, localhost server stopped, sandbox removed.
+		const cliPid = client.child.pid;
+		const port = server.port;
+		await client.closeAndWait();
+		await server.stop();
+		box.cleanup();
+		process.stdout.write(
+			`SENPI_QA_HINT429_CLEANUP scenario=${scenarioName} rpcCliPid=${cliPid} rpcCliExited=${client.child.exitCode !== null || client.child.signalCode !== null} mockServerPort=${port} serverListening=${server.listening} sandbox=${box.dir} sandboxRemoved=${!existsSync(box.dir)}\n`,
+		);
+	}
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+/** Tier 1: hinted 429 waits half the hint, then to the refreshed deadline, on the SAME model. */
+async function assertInTurn(checks, client, server, texts) {
+	texts.push(await runOneTurn(client, `Return ${PRIMARY_MARKER} once the scripted rate limit clears.`, { timeoutMs: 180000 }));
+	const delays = client.events.filter((event) => event.type === "auto_retry_start").map((event) => event.delayMs);
+	const halfHintMs = (IN_TURN_HINT_SECONDS * 1000) / 2;
+	const fullHintMs = IN_TURN_HINT_SECONDS * 1000;
+	checks.ok(
+		"hinted-429-in-turn: two same-model waits scheduled at half-hint then hint deadline",
+		delays.length === 2 && delays[0] === halfHintMs && delays[1] === fullHintMs,
+		`delayMs=${delays.join(",") || "none"} expected=${halfHintMs},${fullHintMs}`,
+	);
+	const models = server.requests.map((request) => request.model);
+	checks.ok(
+		"hinted-429-in-turn: every attempt stays on the primary model",
+		models.length === 3 && models.every((model) => model === HINT_429_PRIMARY_MODEL_ID),
+		`sequence=${models.join(" -> ") || "none"}`,
+	);
+	checks.ok(
+		"hinted-429-in-turn: zero fallback switches",
+		client.events.filter((event) => event.type === "retry_fallback_applied").length === 0,
+		`retry_fallback_applied=${client.events.filter((event) => event.type === "retry_fallback_applied").length}`,
+	);
+	checks.ok(
+		"hinted-429-in-turn: the hinted retry recovers on the primary model",
+		texts[0].includes(PRIMARY_MARKER),
+		`text=${texts[0].slice(0, 80)}`,
+	);
+	const observedWaits = server.requests.slice(1).map((request, index) => request.atMs - server.requests[index].atMs);
+	checks.ok(
+		"hinted-429-in-turn: the real waits match the scheduled half-then-deadline hints",
+		observedWaits.length === 2 && observedWaits[0] >= halfHintMs && observedWaits[1] >= fullHintMs,
+		`observedWaitsMs=${observedWaits.join(",")} floor=${halfHintMs},${fullHintMs}`,
+	);
+}
+
+/** No hint: zero same-model retries, immediate fallback, next chain model answers. */
+async function assertFastFallback(checks, client, server, texts) {
+	texts.push(await runOneTurn(client, `Return ${FALLBACK_MARKER} from whichever model can serve this turn.`));
+	const primaryCalls = server.requests.filter((request) => request.model === HINT_429_PRIMARY_MODEL_ID).length;
+	checks.ok(
+		"no-hint-429-fast-fallback: exactly one call reaches the primary (zero same-model retries)",
+		primaryCalls === 1,
+		`primaryCalls=${primaryCalls}`,
+	);
+	const applied = client.events.filter((event) => event.type === "retry_fallback_applied");
+	checks.ok(
+		"no-hint-429-fast-fallback: retry_fallback_applied fires on the first failure",
+		applied.length === 1 && applied[0].from === selector(HINT_429_PRIMARY_MODEL_ID) && applied[0].to === selector(HINT_429_FALLBACK_MODEL_ID),
+		`applied=${JSON.stringify(applied.map((event) => `${event.from}->${event.to}(${event.reason})`))}`,
+	);
+	const delays = client.events.filter((event) => event.type === "auto_retry_start").map((event) => event.delayMs);
+	checks.ok(
+		"no-hint-429-fast-fallback: the fallback attempt waits zero milliseconds",
+		delays.length === 1 && delays[0] === 0,
+		`delayMs=${delays.join(",") || "none"}`,
+	);
+	const models = server.requests.map((request) => request.model);
+	checks.ok(
+		"no-hint-429-fast-fallback: the chain's next model serves the turn",
+		JSON.stringify(models) === JSON.stringify([HINT_429_PRIMARY_MODEL_ID, HINT_429_FALLBACK_MODEL_ID]) && texts[0].includes(FALLBACK_MARKER),
+		`sequence=${models.join(" -> ") || "none"} text=${texts[0].slice(0, 80)}`,
+	);
+}
+
+/** Tier 2: hint above the shrunk cap -> immediate fallback + bounded probe-back that restores the primary. */
+async function assertProbeBack(checks, client, server, texts) {
+	texts.push(await runOneTurn(client, `Return ${FALLBACK_MARKER} from whichever model can serve this turn.`));
+	const applied = client.events.filter((event) => event.type === "retry_fallback_applied");
+	checks.ok(
+		"hinted-429-probe-back: a hint above hintedWaitCapMs falls back immediately",
+		applied.length === 1 && applied[0].to === selector(HINT_429_FALLBACK_MODEL_ID) && texts[0].includes(FALLBACK_MARKER),
+		`applied=${applied.length} capMs=${PROBE_BACK_CAP_MS} hintMs=${PROBE_BACK_HINT_MS} text=${texts[0].slice(0, 60)}`,
+	);
+	const scheduled = client.events.filter((event) => event.type === "retry_probe_scheduled");
+	checks.ok(
+		"hinted-429-probe-back: probe 1 is scheduled for the demoted selector at half the hint",
+		scheduled.length >= 1 &&
+			scheduled[0].probeIndex === 1 &&
+			scheduled[0].selector === selector(HINT_429_PRIMARY_MODEL_ID) &&
+			scheduled[0].atMs - scheduled[0].observedAtMs <= PROBE_BACK_HINT_MS,
+		`scheduled=${JSON.stringify(scheduled.map((event) => ({ probeIndex: event.probeIndex, inMs: event.atMs - event.observedAtMs })))}`,
+	);
+	const probeResult = await client.waitForEvent((event) => event.type === "retry_probe_result", { timeoutMs: 60000 });
+	checks.ok(
+		"hinted-429-probe-back: the probe reaches the recovered primary and reports ok",
+		probeResult.ok === true && probeResult.selector === selector(HINT_429_PRIMARY_MODEL_ID),
+		`ok=${probeResult.ok} selector=${probeResult.selector} error=${probeResult.errorMessage ?? "none"}`,
+	);
+	const probeRequests = server.requests.filter((request) => request.maxTokens === 1);
+	checks.ok(
+		"hinted-429-probe-back: the probe costs exactly one bounded 1-token request on the primary",
+		probeRequests.length === 1 && probeRequests[0].model === HINT_429_PRIMARY_MODEL_ID,
+		`probeRequests=${JSON.stringify(probeRequests.map((request) => ({ model: request.model, maxTokens: request.maxTokens })))}`,
+	);
+	const afterProbeMs = probeResult.observedAtMs;
+	texts.push(await runOneTurn(client, `Return ${PRIMARY_MARKER} from the restored model.`, { afterMs: afterProbeMs }));
+	const reverted = client.events.filter((event) => event.type === "retry_fallback_reverted");
+	const secondTurnModels = server.requests.filter((request) => request.atMs >= afterProbeMs).map((request) => request.model);
+	checks.ok(
+		"hinted-429-probe-back: the cleared cooldown restores the primary on the next turn",
+		reverted.length === 1 &&
+			reverted[0].to === selector(HINT_429_PRIMARY_MODEL_ID) &&
+			secondTurnModels.every((model) => model === HINT_429_PRIMARY_MODEL_ID) &&
+			texts[1].includes(PRIMARY_MARKER),
+		`reverted=${reverted.length} secondTurn=${secondTurnModels.join(" -> ") || "none"} text=${texts[1].slice(0, 60)}`,
+	);
+}

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
@@ -15,6 +15,7 @@ import {
 	runKimiThinkingRecoveryScenario,
 } from "./mock-loop-kimi-thinking-recovery.mjs";
 import { runAnthropicPolicyRefusalScenario } from "./mock-loop-policy-refusal.mjs";
+import { HINT_429_SCENARIOS, isHint429Scenario, runHint429Scenario } from "./mock-loop-hint-429.mjs";
 
 const OPENAI_SERVER_ERROR_MESSAGE =
 	"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID e4026cfc-c6b6-414a-8a21-c03a6adf0336 in your message.";
@@ -66,7 +67,12 @@ const STANDARD_RETRY_SCENARIOS = {
 const POLICY_REFUSAL_SCENARIO = "anthropic-policy-refusal-fallback";
 
 export function retryScenarioNames() {
-	return [...Object.keys(STANDARD_RETRY_SCENARIOS), POLICY_REFUSAL_SCENARIO, KIMI_THINKING_RECOVERY_SCENARIO];
+	return [
+		...Object.keys(STANDARD_RETRY_SCENARIOS),
+		POLICY_REFUSAL_SCENARIO,
+		KIMI_THINKING_RECOVERY_SCENARIO,
+		...HINT_429_SCENARIOS,
+	];
 }
 
 export function isRetryScenario(name) {
@@ -81,6 +87,10 @@ export async function checkStandardRetryScenarios(checks, driveTurn) {
 }
 
 export async function runRetryScenario(scenarioName, apiName, driveTurn, evidenceSlug) {
+	if (isHint429Scenario(scenarioName)) {
+		await runHint429Scenario({ scenarioName, apiName, evidenceSlug });
+		return;
+	}
 	if (scenarioName === KIMI_THINKING_RECOVERY_SCENARIO) {
 		if (apiName !== "openai-completions") {
 			throw new Error(`${KIMI_THINKING_RECOVERY_SCENARIO} requires --api openai-completions`);

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -26,6 +26,7 @@
  *    startup flag and would try to load the path as a dotenv file before the script runs)
  *   node mock-loop.mjs --with-mcp-tool mcp_fx_tool_1 --tool-args '{"value":"ok"}'
  *   node mock-loop.mjs --scenario transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover
+ *   node mock-loop.mjs --scenario hinted-429-in-turn|no-hint-429-fast-fallback|hinted-429-probe-back
  *   node mock-loop.mjs --run "prompt" [--api ...] [--evidence SLUG]
  */
 
@@ -59,6 +60,7 @@ import {
 } from "./lib/mock-loop-support.mjs";
 import { dispatchExitCode, flagValue, parseToolArgs, positionalAfter } from "./lib/mock-loop-cli.mjs";
 import { checkStandardRetryScenarios, isRetryScenario, retryScenarioNames, runRetryScenario } from "./lib/mock-loop-retry.mjs";
+import { isHint429Scenario } from "./lib/mock-loop-hint-429.mjs";
 import { isTtsrScenario, runTtsrScenario, TTSR_SCENARIOS } from "./lib/mock-loop-ttsr.mjs";
 import {
 	appendTextToolLeakChecks,
@@ -518,7 +520,15 @@ if (argv[0] === "--self-test") {
 		process.exit(1);
 	});
 } else if (scenario) {
-	runRetryScenario(scenario, api || (scenario === "anthropic-policy-refusal-fallback" ? "anthropic-messages" : "openai-completions"), driveTurn, flagValue(argv, "--evidence")).catch((e) => {
+	// The hint-aware 429 tiers need the Anthropic boundary: only that path turns a
+	// 429 response HEADER into the canonical (retry-after-ms: N) marker the tier
+	// router reads, so these scenarios default to anthropic-messages.
+	const scenarioApi =
+		api ||
+		(scenario === "anthropic-policy-refusal-fallback" || isHint429Scenario(scenario)
+			? "anthropic-messages"
+			: "openai-completions");
+	runRetryScenario(scenario, scenarioApi, driveTurn, flagValue(argv, "--evidence")).catch((e) => {
 		process.stderr.write(`${e instanceof Error ? e.stack : String(e)}\n`);
 		process.exit(1);
 	});
@@ -601,6 +611,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
 			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|ttsr-collapse|ttsr-leak> [--api <name>]",
+			"  node mock-loop.mjs --scenario <hinted-429-in-turn|no-hint-429-fast-fallback|hinted-429-probe-back>",
 			"  node mock-loop.mjs --run <prompt> [--api <name>]",
 			`  APIs: ${ALL_APIS.join(", ")}`,
 			"",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -28,6 +28,10 @@
 			"types": "./dist/api/*.d.ts",
 			"import": "./dist/api/*.js"
 		},
+		"./utils/*": {
+			"types": "./dist/utils/*.d.ts",
+			"import": "./dist/utils/*.js"
+		},
 		"./oauth": {
 			"types": "./dist/oauth.d.ts",
 			"import": "./dist/oauth.js"

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -39,6 +39,7 @@ import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts"
 import { getAnthropicCompat, isAnthropicApiBaseUrl } from "../utils/prompt-cache-ttl.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
+import { appendRetryAfterMsMarker, extract429RetryAfterMs } from "../utils/retry-hint.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import {
 	applyServerFallbackAbort,
@@ -1143,7 +1144,12 @@ async function* iterateAnthropicEvents(
 
 	for await (const sse of iterateSseMessages(response.body, signal)) {
 		if (sse.event === "error") {
-			throw new Error(sse.data);
+			let errorText = sse.data;
+			const hintMs = extract429RetryAfterMs({ bodyText: sse.data });
+			if (hintMs !== undefined) {
+				errorText = appendRetryAfterMsMarker(errorText, hintMs);
+			}
+			throw new Error(errorText);
 		}
 
 		if (!ANTHROPIC_MESSAGE_EVENTS.has(sse.event ?? "")) {
@@ -1560,7 +1566,24 @@ export const stream: StreamFunction<"anthropic-messages", AnthropicOptions> = (
 				delete (block as { partialJson?: string }).partialJson;
 			}
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			let errorMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			// When a 429 SDK error carries response headers, extract the server's
+			// retry-after hint and append the canonical marker so the orchestration
+			// layer can recover the full delay.
+			if (error instanceof Error && (error as { status?: unknown }).status === 429) {
+				const sdkHeaders = (error as { headers?: Headers }).headers;
+				if (sdkHeaders instanceof Headers) {
+					const hintMs = extract429RetryAfterMs({
+						status: 429,
+						headers: sdkHeaders,
+						bodyText: errorMessage,
+					});
+					if (hintMs !== undefined) {
+						errorMessage = appendRetryAfterMsMarker(errorMessage, hintMs);
+					}
+				}
+			}
+			output.errorMessage = errorMessage;
 			stream.push({ type: "error", reason: output.stopReason, error: output });
 			stream.end();
 		}

--- a/packages/ai/src/api/openai-codex-responses.ts
+++ b/packages/ai/src/api/openai-codex-responses.ts
@@ -47,6 +47,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
 import { resolveHttpProxyUrlForTarget } from "../utils/node-http-proxy.ts";
 import { extractOpenAiCodexAccountId } from "../utils/openai-codex-auth.ts";
+import { appendRetryAfterMsMarker, extract429RetryAfterMs } from "../utils/retry-hint.ts";
 import { uuidv7 } from "../utils/uuid.ts";
 import { createGrammarToolInputProperties } from "./constrained-sampling.ts";
 import {
@@ -157,33 +158,6 @@ function isRetryableError(status: number, errorText: string): boolean {
 		return true;
 	}
 	return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(errorText);
-}
-
-function getRetryAfterDelayMs(headers: Headers): number | undefined {
-	const retryAfterMs = headers.get("retry-after-ms");
-	if (retryAfterMs !== null) {
-		const millis = Number(retryAfterMs);
-		if (Number.isFinite(millis)) {
-			return Math.max(0, millis);
-		}
-	}
-
-	const retryAfter = headers.get("retry-after");
-	if (!retryAfter) {
-		return undefined;
-	}
-
-	const seconds = Number(retryAfter);
-	if (Number.isFinite(seconds)) {
-		return Math.max(0, seconds * 1000);
-	}
-
-	const date = Date.parse(retryAfter);
-	if (!Number.isNaN(date)) {
-		return Math.max(0, date - Date.now());
-	}
-
-	return undefined;
 }
 
 class RetryDelayExceededError extends Error {}
@@ -450,7 +424,14 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 
 					const errorText = await response.text();
 					if (attempt < maxRetries && isRetryableError(response.status, errorText)) {
-						const retryAfterDelayMs = getRetryAfterDelayMs(response.headers);
+						// Force 429 eligibility with empty body so the extractor checks
+						// only retry-after / retry-after-ms headers (matching the old
+						// getRetryAfterDelayMs behavior for all retryable statuses).
+						const retryAfterDelayMs = extract429RetryAfterMs({
+							status: 429,
+							headers: response.headers,
+							bodyText: "",
+						});
 						const delayMs =
 							retryAfterDelayMs === undefined
 								? BASE_DELAY_MS * 2 ** attempt
@@ -466,7 +447,18 @@ export const stream: StreamFunction<"openai-codex-responses", OpenAICodexRespons
 						statusText: response.statusText,
 					});
 					const info = await parseErrorResponse(fakeResponse);
-					throw new Error(info.friendlyMessage || info.message);
+					let errorMessage = info.friendlyMessage || info.message;
+					if (response.status === 429) {
+						const hintMs = extract429RetryAfterMs({
+							status: response.status,
+							headers: response.headers,
+							bodyText: errorText,
+						});
+						if (hintMs !== undefined) {
+							errorMessage = appendRetryAfterMsMarker(errorMessage, hintMs);
+						}
+					}
+					throw new Error(errorMessage);
 				} catch (error) {
 					if (error instanceof Error) {
 						if (error.name === "AbortError" || error.message === "Request was aborted") {
@@ -784,7 +776,12 @@ async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): 
 		if (type === "error") {
 			const code = getCodexEventErrorCode(event);
 			const message = getCodexEventErrorMessage(event);
-			throw new CodexApiError(`Codex error: ${message || code || JSON.stringify(event)}`, {
+			let errorText = `Codex error: ${message || code || JSON.stringify(event)}`;
+			const hintMs = extract429RetryAfterMs({ bodyText: JSON.stringify(event) });
+			if (hintMs !== undefined) {
+				errorText = appendRetryAfterMsMarker(errorText, hintMs);
+			}
+			throw new CodexApiError(errorText, {
 				code: code || undefined,
 				payload: event,
 			});
@@ -793,7 +790,12 @@ async function* mapCodexEvents(events: AsyncIterable<Record<string, unknown>>): 
 		if (type === "response.failed") {
 			const code = getCodexEventErrorCode(event);
 			const message = getCodexEventErrorMessage(event);
-			throw new CodexApiError(message || "Codex response failed", { code, payload: event });
+			let errorText = message || "Codex response failed";
+			const hintMs = extract429RetryAfterMs({ bodyText: JSON.stringify(event) });
+			if (hintMs !== undefined) {
+				errorText = appendRetryAfterMsMarker(errorText, hintMs);
+			}
+			throw new CodexApiError(errorText, { code, payload: event });
 		}
 
 		if (type === "response.done" || type === "response.completed" || type === "response.incomplete") {

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,30 @@
 # AI Source Changes
 
+## 2026-08-03 - Hint-aware 429 retry-after propagation
+
+### What changed and why
+
+- `utils/retry-hint.ts` (new) owns the strict 429 retry-hint extractor: `extract429RetryAfterMs` plus
+  canonical marker helpers. It parses `retry-after` / `retry-after-ms` headers, `x-ratelimit-reset*` epoch
+  headers, recursive JSON `retryDelay` fields (Google RPC style), body prose ("try again in N s", "resets at
+  <ISO8601>"), and SSE `event: error` payloads, normalizing every shape to a millisecond delay or a sentinel for
+  absent hint. Explicit-zero (retry immediately) is distinct from absent-hint (no guidance), so callers never
+  conflate “server said now” with “server said nothing.”
+- `utils/provider-retry.ts` propagates the extracted hint as a structured `ProviderRetryDelayError` carrying
+  the canonical marker, instead of leaving the delay embedded in an opaque error string. Non-429 retry-loop
+  behavior (forced-eligibility, backoff) is intentionally preserved — the hint path only augments 429-class
+  errors.
+- `api/anthropic-messages.ts` and `api/openai-codex-responses.ts` emit the canonical markers at both the
+  HTTP-status boundary and the SSE in-stream `event: error` boundary, so hints survive regardless of whether
+  the 429 arrives as a status response or a mid-stream error event.
+
+### Expected merge conflict zones
+
+- MEDIUM: `utils/provider-retry.ts` around the 429 hint propagation and `ProviderRetryDelayError`.
+- MEDIUM: `api/anthropic-messages.ts` and `api/openai-codex-responses.ts` at the status/SSE error
+  boundaries.
+- LOW: `utils/retry-hint.ts` (new file) and `package.json` `./utils/*` export.
+
 ## 2026-08-01 - Final Anthropic tool-pair normalization
 
 ### What changed and why

--- a/packages/ai/src/utils/provider-retry.ts
+++ b/packages/ai/src/utils/provider-retry.ts
@@ -61,9 +61,9 @@ function validateServerRetryDelayMs(
 
 function getRetryDelayMs(error: ProviderError, retryIndex: number, maxRetryDelayMs: number | undefined): number {
 	const hintMs = extract429RetryAfterMs({
-		status: error.status,
+		status: 429,
 		headers: error.headers,
-		bodyText: error.message,
+		bodyText: "",
 	});
 	if (hintMs !== undefined) {
 		return validateServerRetryDelayMs(hintMs, maxRetryDelayMs, error.message);

--- a/packages/ai/src/utils/provider-retry.ts
+++ b/packages/ai/src/utils/provider-retry.ts
@@ -1,5 +1,11 @@
+import { appendRetryAfterMsMarker, extract429RetryAfterMs } from "./retry-hint.ts";
+
 const DEFAULT_MAX_RETRY_DELAY_MS = 60_000;
 const DIGITALOCEAN_STREAM_FAILURE_MESSAGE = "Upstream error from DigitalOcean: stream failed";
+
+export interface ProviderRetryDelayError extends Error {
+	readonly retryAfterMs: number;
+}
 
 interface ProviderRetryOptions {
 	maxRetries?: number;
@@ -44,25 +50,23 @@ function validateServerRetryDelayMs(
 ): number {
 	const maxDelayMs = maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
 	if (maxDelayMs > 0 && delayMs > maxDelayMs) {
-		throw new Error(
-			`Server requested ${Math.ceil(delayMs / 1000)}s retry delay (max: ${Math.ceil(maxDelayMs / 1000)}s). ${providerErrorMessage}`,
-		);
+		const message = `Server requested ${Math.ceil(delayMs / 1000)}s retry delay (max: ${Math.ceil(maxDelayMs / 1000)}s). ${providerErrorMessage}`;
+		const error: ProviderRetryDelayError = Object.assign(new Error(appendRetryAfterMsMarker(message, delayMs)), {
+			retryAfterMs: delayMs,
+		});
+		throw error;
 	}
 	return delayMs;
 }
 
 function getRetryDelayMs(error: ProviderError, retryIndex: number, maxRetryDelayMs: number | undefined): number {
-	const retryAfterMs = error.headers?.get("retry-after-ms");
-	if (retryAfterMs) {
-		const value = Number.parseFloat(retryAfterMs);
-		if (!Number.isNaN(value)) return validateServerRetryDelayMs(value, maxRetryDelayMs, error.message);
-	}
-
-	const retryAfter = error.headers?.get("retry-after");
-	if (retryAfter) {
-		const seconds = Number.parseFloat(retryAfter);
-		const delayMs = Number.isNaN(seconds) ? Date.parse(retryAfter) - Date.now() : seconds * 1000;
-		return validateServerRetryDelayMs(delayMs, maxRetryDelayMs, error.message);
+	const hintMs = extract429RetryAfterMs({
+		status: error.status,
+		headers: error.headers,
+		bodyText: error.message,
+	});
+	if (hintMs !== undefined) {
+		return validateServerRetryDelayMs(hintMs, maxRetryDelayMs, error.message);
 	}
 
 	const exponentialDelay = Math.min(0.5 * 2 ** retryIndex, 8) * 1000;

--- a/packages/ai/src/utils/retry-hint.ts
+++ b/packages/ai/src/utils/retry-hint.ts
@@ -1,0 +1,245 @@
+/**
+ * Strict 429 retry-hint extractor with canonical marker helpers.
+ *
+ * Precedence (first match wins, malformed source falls through):
+ *   1. retry-after-ms header  (strict `^\d+(?:\.\d+)?$`, ceil)
+ *   2. retry-after header      (strict integer delta-seconds `^\d+$`, else HTTP-date)
+ *   3. x-ratelimit-reset{,-requests,-tokens}  (epoch seconds, max-wins)
+ *   4. JSON retryDelay strings (ms/s/m units, recursive, max-wins; numeric rejected)
+ *   5. body prose              (ms-marker, seconds-marker, relative, resets-at ISO8601)
+ *
+ * Eligibility gate: status 429 OR body marks rate-limit error.
+ * Explicit zero = 0 (beats lower-precedence positives).
+ * Past absolute times clamp to 0.
+ * Absolute times resolve against response Date header (clock-skew safe), else nowMs.
+ */
+
+const MARKER_RE = /\(retry-after-ms: (\d+)\)$/;
+const RATE_LIMIT_BODY_RE =
+	/\b(rate_limit_error|rate_limit_exceeded|too_many_requests|resource_exhausted|rate limit (?:exceeded|hit)|too many requests)\b/i;
+const RATE_LIMIT_JSON_VALUES = new Set([
+	"rate_limit_error",
+	"rate_limit_exceeded",
+	"too_many_requests",
+	"resource_exhausted",
+]);
+const RETRY_AFTER_MS_RE = /^\d+(?:\.\d+)?$/;
+const DELTA_SECONDS_RE = /^\d+$/;
+
+/* ---------- public types ---------- */
+
+export interface RetryHintInput {
+	status?: number;
+	headers?: Headers;
+	bodyText: string;
+}
+
+/* ---------- eligibility ---------- */
+
+function isRateLimited(status: number | undefined, bodyText: string): boolean {
+	if (status === 429) return true;
+	if (RATE_LIMIT_BODY_RE.test(bodyText)) return true;
+	// JSON type/code fields or retryDelay presence (rate-limit signal)
+	const json = tryParseJSON(bodyText);
+	if (json !== undefined) {
+		const found = scanValue(json, (v, k) => {
+			if (k !== undefined && k.toLowerCase() === "retrydelay" && typeof v === "string") return true;
+			if (typeof v === "string" && RATE_LIMIT_JSON_VALUES.has(v)) return true;
+			if (v === 429) return true;
+			return false;
+		});
+		if (found) return true;
+	}
+	return false;
+}
+
+/* ---------- 1. retry-after-ms header ---------- */
+
+function fromRetryAfterMsHeader(h: Headers | undefined): number | undefined {
+	const raw = h?.get("retry-after-ms");
+	if (raw === null || raw === undefined) return undefined;
+	if (!RETRY_AFTER_MS_RE.test(raw)) return undefined;
+	const val = Number.parseFloat(raw);
+	if (!Number.isFinite(val) || val < 0) return undefined;
+	return Math.ceil(val);
+}
+
+/* ---------- 2. retry-after header ---------- */
+
+function fromRetryAfterHeader(h: Headers | undefined, nowMs: number): number | undefined {
+	const raw = h?.get("retry-after");
+	if (raw === null || raw === undefined) return undefined;
+	// integer delta-seconds
+	if (DELTA_SECONDS_RE.test(raw)) {
+		return Number.parseInt(raw, 10) * 1000;
+	}
+	// HTTP-date — must contain alphabetic chars to be a real date string
+	if (/[a-zA-Z]/.test(raw)) {
+		const parsed = Date.parse(raw);
+		if (!Number.isNaN(parsed)) {
+			const base = dateHeaderMs(h) ?? nowMs;
+			return clampAbsolute(parsed, base);
+		}
+	}
+	return undefined;
+}
+
+/* ---------- 3. x-ratelimit-reset* headers ---------- */
+
+function fromXRateLimitReset(h: Headers | undefined, nowMs: number): number | undefined {
+	let best: number | undefined;
+	for (const key of ["x-ratelimit-reset", "x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"]) {
+		const raw = h?.get(key);
+		if (raw === null || raw === undefined) continue;
+		const epoch = Number.parseFloat(raw);
+		if (!Number.isFinite(epoch) || epoch < 0) continue;
+		// reject "12abc" — strict number check
+		if (!/^\d+(?:\.\d+)?$/.test(raw)) continue;
+		const delta = Math.ceil(epoch * 1000 - nowMs);
+		const clamped = Math.max(0, delta);
+		if (best === undefined || clamped > best) best = clamped;
+	}
+	return best;
+}
+
+/* ---------- 4. JSON retryDelay (recursive, max-wins) ---------- */
+
+const RETRY_DELAY_RE = /^(\d+(?:\.\d+)?)\s*(ms|s|m)$/;
+
+function fromJsonRetryDelay(bodyText: string): number | undefined {
+	const json = tryParseJSON(bodyText);
+	if (json === undefined) return undefined;
+	let best: number | undefined;
+	scanValue(json, (v) => {
+		if (typeof v !== "string") return false;
+		const m = v.match(RETRY_DELAY_RE);
+		if (!m) return false;
+		const num = Number.parseFloat(m[1]);
+		const unit = m[2];
+		const ms = unit === "ms" ? num : unit === "s" ? num * 1000 : num * 60_000;
+		const intMs = Math.ceil(ms);
+		if (best === undefined || intMs > best) best = intMs;
+		return false; // keep scanning
+	});
+	return best;
+}
+
+/* ---------- 5. body prose ---------- */
+
+function fromBodyProse(bodyText: string, nowMs: number): number | undefined {
+	// ms-marker: retry-after-ms: <N>
+	let m = bodyText.match(/retry-after-ms:\s*(\d+)/i);
+	if (m) return Number.parseInt(m[1], 10);
+
+	// seconds-marker: retry-after: <N>
+	m = bodyText.match(/retry-after:\s*(\d+)/i);
+	if (m) return Number.parseInt(m[1], 10) * 1000;
+
+	// relative prose: try again | retry | wait after ... [in] N <unit>
+	m = bodyText.match(
+		/(?:try again|retry|wait after).*?(?:in\s+)?(\d+(?:\.\d+)?)\s*(ms|s|sec|seconds?|m|min|minutes?)\b/i,
+	);
+	if (m) return convertUnit(Number.parseFloat(m[1]), m[2]);
+
+	// resets at <ISO8601-with-tz>
+	m = bodyText.match(/resets?\s+at\s+(\S+)/i);
+	if (m) {
+		const parsed = Date.parse(m[1]);
+		if (!Number.isNaN(parsed)) return clampAbsolute(parsed, nowMs);
+	}
+
+	return undefined;
+}
+
+/* ---------- helpers ---------- */
+
+function dateHeaderMs(h: Headers | undefined): number | undefined {
+	const raw = h?.get("date");
+	if (raw === null || raw === undefined) return undefined;
+	const parsed = Date.parse(raw);
+	return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function clampAbsolute(targetMs: number, baseMs: number): number {
+	return Math.max(0, targetMs - baseMs);
+}
+
+function convertUnit(num: number, unit: string): number {
+	const u = unit.toLowerCase();
+	if (u === "ms") return Math.ceil(num);
+	if (u === "s" || u === "sec" || u === "second" || u === "seconds") return Math.ceil(num * 1000);
+	return Math.ceil(num * 60_000); // m / min / minute / minutes
+}
+
+/** Recursively walk JSON, calling fn on every leaf value with its key. */
+function scanValue(
+	value: unknown,
+	fn: (v: string | number | boolean | null, key?: string) => boolean,
+	key?: string,
+): boolean {
+	if (value === null) return fn(null, key);
+	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return fn(value, key);
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			if (scanValue(item, fn, key)) return true;
+		}
+		return false;
+	}
+	if (typeof value === "object") {
+		for (const [k, v] of Object.entries(value)) {
+			if (scanValue(v, fn, k)) return true;
+		}
+		return false;
+	}
+	return false;
+}
+
+function tryParseJSON(text: string): unknown {
+	// strip SSE data: prefix lines
+	const cleaned = text.replace(/^data:\s*/gm, "").trim();
+	if (!cleaned.startsWith("{") && !cleaned.startsWith("[")) return undefined;
+	try {
+		return JSON.parse(cleaned);
+	} catch {
+		return undefined;
+	}
+}
+
+/* ---------- main extractor ---------- */
+
+export function extract429RetryAfterMs(input: RetryHintInput, nowMs?: number): number | undefined {
+	const now = nowMs ?? Date.now();
+
+	if (!isRateLimited(input.status, input.bodyText)) return undefined;
+
+	// 1. retry-after-ms header
+	const fromMs = fromRetryAfterMsHeader(input.headers);
+	if (fromMs !== undefined) return fromMs;
+
+	// 2. retry-after header
+	const fromRa = fromRetryAfterHeader(input.headers, now);
+	if (fromRa !== undefined) return fromRa;
+
+	// 3. x-ratelimit-reset* headers
+	const fromXrl = fromXRateLimitReset(input.headers, now);
+	if (fromXrl !== undefined) return fromXrl;
+
+	// 4. JSON retryDelay
+	const fromJson = fromJsonRetryDelay(input.bodyText);
+	if (fromJson !== undefined) return fromJson;
+
+	// 5. body prose
+	return fromBodyProse(input.bodyText, now);
+}
+
+/* ---------- marker helpers ---------- */
+
+export function appendRetryAfterMsMarker(message: string, hintMs: number): string {
+	return `${message} (retry-after-ms: ${hintMs})`;
+}
+
+export function parseRetryAfterMsMarker(message: string): number | undefined {
+	const m = message.match(MARKER_RE);
+	if (!m) return undefined;
+	return Number.parseInt(m[1], 10);
+}

--- a/packages/ai/test/anthropic-retry-hint-marker.test.ts
+++ b/packages/ai/test/anthropic-retry-hint-marker.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import type { Context, Model } from "../src/types.ts";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function makeModel(): Model<"anthropic-messages"> {
+	return {
+		id: "claude-sonnet-4-20250514",
+		name: "Claude Sonnet 4",
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "http://localhost:9999",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 8192,
+	};
+}
+
+function makeContext(): Context {
+	return {
+		systemPrompt: "You are a helpful assistant.",
+		messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+	};
+}
+
+/** Build an SSE body from a list of {event, data} pairs. */
+function buildSse(events: Array<{ event: string; data: string }>): string {
+	return events.map(({ event, data }) => `event: ${event}\ndata: ${data}\n`).join("\n");
+}
+
+/** Build the Anthropic SDK's full error response body for a 429. */
+function build429Body(opts?: { retryAfterMs?: number; retryDelay?: string }): string {
+	const error: Record<string, unknown> = {
+		type: "error",
+		error: {
+			type: "rate_limit_error",
+			message: "All tokens rate limited",
+		},
+	};
+	if (opts?.retryAfterMs !== undefined) {
+		(error.error as Record<string, unknown>).retry_after_ms = opts.retryAfterMs;
+	}
+	if (opts?.retryDelay !== undefined) {
+		(error.error as Record<string, unknown>).retryDelay = opts.retryDelay;
+	}
+	return JSON.stringify(error);
+}
+
+/** Create a Response for a non-streaming error (the SDK throws before streaming begins). */
+function makeErrorResponse(status: number, body: string, headers?: Record<string, string>): Response {
+	return new Response(body, {
+		status,
+		headers: { "content-type": "application/json", ...headers },
+	});
+}
+
+/** Create a ReadableStream from a string. */
+function makeStream(text: string): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encoder.encode(text));
+			controller.close();
+		},
+	});
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("anthropic 429 retry-hint marker", () => {
+	it("HTTP 429 with retry-after: 1258 -> stream error message ends with (retry-after-ms: 1258000)", async () => {
+		const model = makeModel();
+		const context = makeContext();
+		const errorBody = build429Body();
+
+		const fetchMock = vi.fn(async () => makeErrorResponse(429, errorBody, { "retry-after": "1258" }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamAnthropic(model, context, {
+			apiKey: "sk-test",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).toMatch(/\(retry-after-ms: 1258000\)$/);
+	});
+
+	it("SSE in-stream event:error body with rate_limit_error and no hint -> NO marker appended", async () => {
+		const model = makeModel();
+		const context = makeContext();
+
+		// The Anthropic SDK first gets a 200 OK response, then the stream
+		// contains an `event: error` with a rate_limit_error body.
+		const sseBody = buildSse([
+			{
+				event: "error",
+				data: JSON.stringify({
+					type: "error",
+					error: {
+						type: "rate_limit_error",
+						message: "All tokens rate limited",
+					},
+				}),
+			},
+		]);
+
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(makeStream(sseBody), {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamAnthropic(model, context, {
+			apiKey: "sk-test",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).not.toMatch(/\(retry-after-ms: \d+\)$/);
+	});
+
+	it("SSE in-stream event:error body with retryDelay '45s' -> marker 45000", async () => {
+		const model = makeModel();
+		const context = makeContext();
+
+		const sseBody = buildSse([
+			{
+				event: "error",
+				data: JSON.stringify({
+					type: "error",
+					error: {
+						type: "rate_limit_error",
+						message: "Rate limited",
+						retryDelay: "45s",
+					},
+				}),
+			},
+		]);
+
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(makeStream(sseBody), {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamAnthropic(model, context, {
+			apiKey: "sk-test",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).toMatch(/\(retry-after-ms: 45000\)$/);
+	});
+
+	it("non-429 error (500) -> message byte-identical, no marker", async () => {
+		const model = makeModel();
+		const context = makeContext();
+		const errorBody = JSON.stringify({
+			type: "error",
+			error: {
+				type: "api_error",
+				message: "Internal server error",
+			},
+		});
+
+		const fetchMock = vi.fn(async () => makeErrorResponse(500, errorBody));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamAnthropic(model, context, {
+			apiKey: "sk-test",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).not.toMatch(/\(retry-after-ms: \d+\)$/);
+	});
+
+	it("malformed SSE error body (invalid JSON) -> does not throw, no marker", async () => {
+		const model = makeModel();
+		const context = makeContext();
+
+		// SSE event: error with garbage data — must not throw, must not append marker
+		const sseBody = "event: error\ndata: {{{not valid json}}}\n";
+
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(makeStream(sseBody), {
+					status: 200,
+					headers: { "content-type": "text/event-stream" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamAnthropic(model, context, {
+			apiKey: "sk-test",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).not.toMatch(/\(retry-after-ms: \d+\)$/);
+	});
+});

--- a/packages/ai/test/anthropic-retry-hint-marker.test.ts
+++ b/packages/ai/test/anthropic-retry-hint-marker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
 import type { Context, Model } from "../src/types.ts";
 
@@ -73,6 +73,10 @@ function makeStream(text: string): ReadableStream<Uint8Array> {
 /* ------------------------------------------------------------------ */
 /* Tests                                                               */
 /* ------------------------------------------------------------------ */
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
 
 describe("anthropic 429 retry-hint marker", () => {
 	it("HTTP 429 with retry-after: 1258 -> stream error message ends with (retry-after-ms: 1258000)", async () => {

--- a/packages/ai/test/codex-retry-hint-marker.test.ts
+++ b/packages/ai/test/codex-retry-hint-marker.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { stream as streamOpenAICodexResponses } from "../src/api/openai-codex-responses.ts";
+import type { Context, Model } from "../src/types.ts";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+function mockToken(accountId = "acc_test"): string {
+	const payload = Buffer.from(
+		JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+		"utf8",
+	).toString("base64");
+	return `aaa.${payload}.bbb`;
+}
+
+function makeModel(): Model<"openai-codex-responses"> {
+	return {
+		id: "gpt-5.1-codex",
+		name: "GPT-5.1 Codex",
+		api: "openai-codex-responses",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 400000,
+		maxTokens: 128000,
+	};
+}
+
+function makeContext(): Context {
+	return {
+		systemPrompt: "You are a helpful assistant.",
+		messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }],
+	};
+}
+
+function makeStream(text: string): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encoder.encode(text));
+			controller.close();
+		},
+	});
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe("codex 429 retry-hint marker", () => {
+	it("HTTP 429 with retry-after: 1258 -> stream error message ends with (retry-after-ms: 1258000)", async () => {
+		const token = mockToken();
+		const errorBody = JSON.stringify({
+			error: { code: "rate_limit_exceeded", message: "rate limited" },
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url !== "https://chatgpt.com/backend-api/codex/responses") {
+				throw new Error(`Unexpected URL: ${url}`);
+			}
+			return new Response(errorBody, {
+				status: 429,
+				headers: {
+					"content-type": "application/json",
+					"retry-after": "1258",
+				},
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamOpenAICodexResponses(makeModel(), makeContext(), {
+			apiKey: token,
+			transport: "sse",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).toMatch(/\(retry-after-ms: 1258000\)$/);
+	});
+
+	it("SSE in-stream error event with rate_limit_error and no hint -> NO marker appended", async () => {
+		const token = mockToken();
+
+		// The stream starts with 200 OK, then contains an error event
+		const sseBody = `data: ${JSON.stringify({
+			type: "error",
+			error: {
+				type: "rate_limit_error",
+				message: "All tokens rate limited",
+			},
+		})}\n\n`;
+
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url !== "https://chatgpt.com/backend-api/codex/responses") {
+				throw new Error(`Unexpected URL: ${url}`);
+			}
+			return new Response(makeStream(sseBody), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamOpenAICodexResponses(makeModel(), makeContext(), {
+			apiKey: token,
+			transport: "sse",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).not.toMatch(/\(retry-after-ms: \d+\)$/);
+	});
+
+	it("SSE in-stream error event with retryDelay '45s' -> marker 45000", async () => {
+		const token = mockToken();
+
+		const sseBody = `data: ${JSON.stringify({
+			type: "error",
+			error: {
+				type: "rate_limit_error",
+				message: "Rate limited",
+				retryDelay: "45s",
+			},
+		})}\n\n`;
+
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url !== "https://chatgpt.com/backend-api/codex/responses") {
+				throw new Error(`Unexpected URL: ${url}`);
+			}
+			return new Response(makeStream(sseBody), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamOpenAICodexResponses(makeModel(), makeContext(), {
+			apiKey: token,
+			transport: "sse",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).toMatch(/\(retry-after-ms: 45000\)$/);
+	});
+
+	it("non-429 error (500) -> message has no marker", async () => {
+		const token = mockToken();
+		const errorBody = JSON.stringify({
+			error: { code: "server_error", message: "Internal server error" },
+		});
+
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url !== "https://chatgpt.com/backend-api/codex/responses") {
+				throw new Error(`Unexpected URL: ${url}`);
+			}
+			return new Response(errorBody, {
+				status: 500,
+				headers: { "content-type": "application/json" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamOpenAICodexResponses(makeModel(), makeContext(), {
+			apiKey: token,
+			transport: "sse",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).not.toMatch(/\(retry-after-ms: \d+\)$/);
+	});
+
+	it("malformed SSE error body (invalid JSON in error event) -> no marker, no throw", async () => {
+		const token = mockToken();
+
+		// Codex SSE: an error event with garbage payload
+		const sseBody = `data: {{{not valid json}}}\n\n`;
+
+		const fetchMock = vi.fn(async (input: string | URL) => {
+			const url = typeof input === "string" ? input : input.toString();
+			if (url !== "https://chatgpt.com/backend-api/codex/responses") {
+				throw new Error(`Unexpected URL: ${url}`);
+			}
+			return new Response(makeStream(sseBody), {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await streamOpenAICodexResponses(makeModel(), makeContext(), {
+			apiKey: token,
+			transport: "sse",
+			maxRetries: 0,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+		expect(result.errorMessage).not.toMatch(/\(retry-after-ms: \d+\)$/);
+	});
+});

--- a/packages/ai/test/provider-retry.test.ts
+++ b/packages/ai/test/provider-retry.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { retryProviderRequest, retryProviderStreamRequest } from "../src/utils/provider-retry.ts";
+import {
+	type ProviderRetryDelayError,
+	retryProviderRequest,
+	retryProviderStreamRequest,
+} from "../src/utils/provider-retry.ts";
 
 function providerError(status: number | undefined, headers?: Record<string, string>): Error {
 	return Object.assign(new Error(`Provider error: ${status}`), {
@@ -99,5 +103,157 @@ describe("provider request retries", () => {
 		}
 
 		expect(closeStream).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Structured hint propagation (todo 4)
+// ---------------------------------------------------------------------------
+
+describe("structured retry-after hint propagation", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("stamps retryAfterMs and canonical marker on over-cap 429 with retry-after header", async () => {
+		// Observed live: ccapi 429 with `retry-after: 1258`, default 60s cap.
+		// The thrown error must carry the structured numeric property so the
+		// orchestration layer can recover the full server delay without re-parsing.
+		const request = vi.fn<() => Promise<string>>().mockRejectedValue(providerError(429, { "retry-after": "1258" }));
+
+		const promise = retryProviderRequest(request, { maxRetries: 1 });
+
+		let caught: unknown;
+		try {
+			await promise;
+		} catch (e) {
+			caught = e;
+		}
+
+		expect(caught).toBeInstanceOf(Error);
+		const err = caught as ProviderRetryDelayError;
+		expect(err.retryAfterMs).toBe(1_258_000);
+		expect(err.message).toContain("(retry-after-ms: 1258000)");
+		expect(request).toHaveBeenCalledTimes(1);
+	});
+
+	it("honors retry-after: 2 header delay under cap with fake timers", async () => {
+		vi.useFakeTimers();
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(429, { "retry-after": "2" }))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		// Should sleep ~2000ms honoring the header, not the exponential fallback.
+		await vi.advanceTimersByTimeAsync(1999);
+		expect(request).toHaveBeenCalledTimes(1); // not retried yet
+		await vi.advanceTimersByTimeAsync(1);
+
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("uses exponential path for non-429 (500) errors — characterization pin", async () => {
+		vi.useFakeTimers();
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(500, {}))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		// Exponential delay for retryIndex 0: min(0.5 * 2^0, 8) * 1000 = 500ms,
+		// with jitter (1 - random*0.25) so range is [375, 500]ms.
+		// Advancing 374ms should NOT trigger retry; 500ms will.
+		await vi.advanceTimersByTimeAsync(374);
+		expect(request).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(500); // well past the max possible delay
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("preserves exponential fallback for 429 without any hint", async () => {
+		vi.useFakeTimers();
+		// 429 with no retry-after headers at all — must use exponential, not 0.
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(429, {}))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		// extract429RetryAfterMs returns undefined (no hint), exponential fallback
+		// fires: min(0.5*2^0, 8)*1000 = 500ms with jitter [375, 500].
+		// Zero ms would mean it retried immediately — that must NOT happen.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(request).toHaveBeenCalledTimes(1); // no immediate retry
+		await vi.advanceTimersByTimeAsync(500);
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("honors x-should-retry: true header (characterization pin)", async () => {
+		vi.useFakeTimers();
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(400, { "x-should-retry": "true" }))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		await vi.advanceTimersByTimeAsync(500);
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("handles malformed retry-after headers gracefully (falls through to exponential)", async () => {
+		vi.useFakeTimers();
+		// Garbage retry-after that extract429RetryAfterMs cannot parse -> undefined,
+		// so exponential fallback kicks in.
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(429, { "retry-after": "garbage-later" }))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		// Exponential: ~500ms with jitter. Should NOT sleep for a huge value.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(request).toHaveBeenCalledTimes(1);
+		await vi.advanceTimersByTimeAsync(500);
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("preserves DigitalOcean stream failure special-case", async () => {
+		vi.useFakeTimers();
+		const doError = Object.assign(new Error("Upstream error from DigitalOcean: stream failed"), {
+			status: undefined,
+			headers: undefined,
+		});
+		const request = vi.fn<() => Promise<string>>().mockRejectedValueOnce(doError).mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		await vi.advanceTimersByTimeAsync(500);
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
+	it("stamps retryAfterMs when retry-after-ms header exceeds cap", async () => {
+		// retry-after-ms: 90000 with default 60s cap -> over-cap error
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValue(providerError(429, { "retry-after-ms": "90000" }));
+
+		const promise = retryProviderRequest(request, { maxRetries: 1 });
+
+		let caught: unknown;
+		try {
+			await promise;
+		} catch (e) {
+			caught = e;
+		}
+
+		expect(caught).toBeInstanceOf(Error);
+		const err = caught as ProviderRetryDelayError;
+		expect(err.retryAfterMs).toBe(90_000);
+		expect(err.message).toContain("(retry-after-ms: 90000)");
 	});
 });

--- a/packages/ai/test/provider-retry.test.ts
+++ b/packages/ai/test/provider-retry.test.ts
@@ -154,6 +154,22 @@ describe("structured retry-after hint propagation", () => {
 		expect(request).toHaveBeenCalledTimes(2);
 	});
 
+	it("honors retry-after-ms header on non-429 (500) errors", async () => {
+		vi.useFakeTimers();
+		const request = vi
+			.fn<() => Promise<string>>()
+			.mockRejectedValueOnce(providerError(500, { "retry-after-ms": "100" }))
+			.mockResolvedValue("ok");
+
+		const result = retryProviderRequest(request, { maxRetries: 1 });
+		// Should sleep ~100ms honoring the header, not the ~1000ms exponential fallback.
+		await vi.advanceTimersByTimeAsync(99);
+		expect(request).toHaveBeenCalledTimes(1); // not retried yet
+		await vi.advanceTimersByTimeAsync(1);
+		await expect(result).resolves.toBe("ok");
+		expect(request).toHaveBeenCalledTimes(2);
+	});
+
 	it("uses exponential path for non-429 (500) errors — characterization pin", async () => {
 		vi.useFakeTimers();
 		const request = vi

--- a/packages/ai/test/retry-hint.test.ts
+++ b/packages/ai/test/retry-hint.test.ts
@@ -1,0 +1,573 @@
+import { describe, expect, it } from "vitest";
+import { appendRetryAfterMsMarker, extract429RetryAfterMs, parseRetryAfterMsMarker } from "../src/utils/retry-hint.ts";
+
+/* ---------- helpers ---------- */
+
+function headers(obj: Record<string, string>): Headers {
+	return new Headers(obj);
+}
+
+const NOW = 1_700_000_000_000; // fixed epoch ms for deterministic tests
+
+/* ---------- 1. Eligibility gate ---------- */
+
+describe("eligibility gate", () => {
+	it("429 status with generic body + retry-after header -> hint from header", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after": "1258" }), bodyText: '{"error":"rate limited"}' },
+			NOW,
+		);
+		expect(result).toBe(1_258_000);
+	});
+
+	it("body rate_limit_error type on 200 SSE -> eligible, but no hint -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 200,
+				headers: new Headers(),
+				bodyText: '{"error":{"type":"rate_limit_error","message":"All tokens rate limited"}}',
+			},
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("500 with 'try again in 20 seconds' prose -> NOT eligible -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 500, headers: new Headers(), bodyText: "try again in 20 seconds" },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("503 + prose -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 503, headers: new Headers(), bodyText: "try again in 30 seconds" },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("429 status with no hint anywhere -> undefined", () => {
+		const result = extract429RetryAfterMs({ status: 429, headers: new Headers(), bodyText: "rate limited" }, NOW);
+		expect(result).toBeUndefined();
+	});
+
+	it("200 with rate_limit_exceeded type code -> eligible, no hint -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 200, headers: new Headers(), bodyText: '{"error":{"type":"rate_limit_exceeded"}}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("200 with resource_exhausted type -> eligible, no hint -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 200, headers: new Headers(), bodyText: '{"error":{"type":"resource_exhausted"}}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("200 with too_many_requests code string -> eligible, no hint -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 200, headers: new Headers(), bodyText: '{"error":{"code":"too_many_requests"}}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("200 with numeric code 429 -> eligible, no hint -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 200, headers: new Headers(), bodyText: '{"error":{"code":429}}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("200 with standalone text marker 'rate limit exceeded' -> eligible, no hint -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 200, headers: new Headers(), bodyText: "rate limit exceeded" },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+});
+
+/* ---------- 2. retry-after-ms header (highest precedence) ---------- */
+
+describe("retry-after-ms header", () => {
+	it("strict integer", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after-ms": "5000" }), bodyText: "" },
+			NOW,
+		);
+		expect(result).toBe(5000);
+	});
+
+	it("strict decimal ceil", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after-ms": "2.3" }), bodyText: "" },
+			NOW,
+		);
+		expect(result).toBe(3);
+	});
+
+	it("malformed 'later' falls through to retry-after: 12 -> 12000", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after-ms": "later", "retry-after": "12" }), bodyText: "" },
+			NOW,
+		);
+		expect(result).toBe(12_000);
+	});
+
+	it("'12junk' is malformed (strict full-string) -> falls through", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after-ms": "12junk", "retry-after": "5" }), bodyText: "" },
+			NOW,
+		);
+		expect(result).toBe(5_000);
+	});
+
+	it("explicit zero beats lower-precedence positive prose 30s", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after-ms": "0" }), bodyText: "try again in 30 seconds" },
+			NOW,
+		);
+		expect(result).toBe(0);
+	});
+});
+
+/* ---------- 3. retry-after header (delta-seconds or HTTP-date) ---------- */
+
+describe("retry-after header", () => {
+	it("integer delta-seconds", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after": "1258" }), bodyText: "generic" },
+			NOW,
+		);
+		expect(result).toBe(1_258_000);
+	});
+
+	it("explicit zero beats prose 30s", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after": "0" }), bodyText: "try again in 30 seconds" },
+			NOW,
+		);
+		expect(result).toBe(0);
+	});
+
+	it("0.5 is malformed (strict integer) -> falls through", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after": "0.5" }), bodyText: "" },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("HTTP-date with skewed local clock using Date header", () => {
+		// Server says Date is 2023-11-14T22:13:20.000Z (epoch 1700000000000)
+		// Retry-After is 60s after that -> 1700000060000
+		// nowMs is deliberately skewed (1 hour ahead)
+		const skewedNow = NOW + 3_600_000;
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({
+					date: "Tue, 14 Nov 2023 22:13:20 GMT",
+					"retry-after": "Tue, 14 Nov 2023 22:14:20 GMT",
+				}),
+				bodyText: "",
+			},
+			skewedNow,
+		);
+		expect(result).toBe(60_000);
+	});
+
+	it("HTTP-date without Date header uses nowMs, clamps past to 0", () => {
+		// Date is in the past relative to nowMs
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({ "retry-after": "Tue, 14 Nov 2023 22:00:00 GMT" }),
+				bodyText: "",
+			},
+			NOW, // 1700000000000 = 22:13:20 UTC, after 22:00:00
+		);
+		expect(result).toBe(0);
+	});
+
+	it("HTTP-date IMF-fixdate format", () => {
+		// Use Date header so result is deterministic
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({
+					date: "Tue, 14 Nov 2023 22:13:20 GMT",
+					"retry-after": "Tue, 14 Nov 2023 22:14:30 GMT",
+				}),
+				bodyText: "",
+			},
+			NOW,
+		);
+		expect(result).toBe(70_000);
+	});
+
+	it("malformed retry-after 'abc' falls through to x-ratelimit-reset", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({ "retry-after": "abc", "x-ratelimit-reset": String(Math.floor(NOW / 1000) + 10) }),
+				bodyText: "",
+			},
+			NOW,
+		);
+		expect(result).toBe(10_000);
+	});
+});
+
+/* ---------- 4. x-ratelimit-reset* headers (epoch seconds, max-wins) ---------- */
+
+describe("x-ratelimit-reset headers", () => {
+	it("reset-requests +5s and reset-tokens +60s -> 60_000 (max wins)", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({
+					"x-ratelimit-reset-requests": String(Math.floor(NOW / 1000) + 5),
+					"x-ratelimit-reset-tokens": String(Math.floor(NOW / 1000) + 60),
+				}),
+				bodyText: "",
+			},
+			NOW,
+		);
+		expect(result).toBe(60_000);
+	});
+
+	it("x-ratelimit-reset (bare) epoch seconds", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({ "x-ratelimit-reset": String(Math.floor(NOW / 1000) + 30) }),
+				bodyText: "",
+			},
+			NOW,
+		);
+		expect(result).toBe(30_000);
+	});
+
+	it("past epoch clamps to 0", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({ "x-ratelimit-reset": String(Math.floor(NOW / 1000) - 100) }),
+				bodyText: "",
+			},
+			NOW,
+		);
+		expect(result).toBe(0);
+	});
+
+	it("malformed epoch 'soon' falls through", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({
+					"x-ratelimit-reset": "soon",
+					"x-ratelimit-reset-tokens": String(Math.floor(NOW / 1000) + 5),
+				}),
+				bodyText: "",
+			},
+			NOW,
+		);
+		expect(result).toBe(5_000);
+	});
+});
+
+/* ---------- 5. JSON retryDelay strings (recursive, max-wins, numeric rejected) ---------- */
+
+describe("JSON retryDelay", () => {
+	it('{"retryDelay":"0.25s"} -> 250', () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"retryDelay":"0.25s"}' },
+			NOW,
+		);
+		expect(result).toBe(250);
+	});
+
+	it('{"retryDelay":"45s"} -> 45000', () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"retryDelay":"45s"}' },
+			NOW,
+		);
+		expect(result).toBe(45_000);
+	});
+
+	it('{"retryDelay":"2m"} -> 120000', () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"retryDelay":"2m"}' },
+			NOW,
+		);
+		expect(result).toBe(120_000);
+	});
+
+	it('{"retryDelay":"500ms"} -> 500', () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"retryDelay":"500ms"}' },
+			NOW,
+		);
+		expect(result).toBe(500);
+	});
+
+	it('{"retryDelay":500} numeric -> rejected, falls through', () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"retryDelay":500}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it('{"retryDelay":"soon"} no unit match -> rejected', () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"retryDelay":"soon"}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("nested JSON max-wins: {outer:{retryDelay:5s}, inner:{retryDelay:60s}}", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"a":{"retryDelay":"5s"},"b":{"retryDelay":"60s"}}' },
+			NOW,
+		);
+		expect(result).toBe(60_000);
+	});
+
+	it("retryDelay in array elements", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '[{"retryDelay":"3s"},{"retryDelay":"10s"}]' },
+			NOW,
+		);
+		expect(result).toBe(10_000);
+	});
+
+	it("SSE data: payload with retryDelay 45s -> 45000", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 200, headers: new Headers(), bodyText: 'data: {"retryDelay":"45s"}\n\n' },
+			NOW,
+		);
+		expect(result).toBe(45_000);
+	});
+
+	it("SSE data: payload with rate_limit_error body and retryDelay", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 200,
+				headers: new Headers(),
+				bodyText: 'data: {"error":{"type":"rate_limit_error"},"retryDelay":"45s"}\n\n',
+			},
+			NOW,
+		);
+		expect(result).toBe(45_000);
+	});
+});
+
+/* ---------- 6. Body prose patterns ---------- */
+
+describe("body prose", () => {
+	it("ms-marker: 'retry-after-ms: 5000'", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "error: retry-after-ms: 5000" },
+			NOW,
+		);
+		expect(result).toBe(5000);
+	});
+
+	it("seconds-marker: 'retry-after: 30'", () => {
+		const result = extract429RetryAfterMs({ status: 429, headers: new Headers(), bodyText: "retry-after: 30" }, NOW);
+		expect(result).toBe(30_000);
+	});
+
+	it("relative prose: 'try again in 20 seconds'", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "try again in 20 seconds" },
+			NOW,
+		);
+		expect(result).toBe(20_000);
+	});
+
+	it("relative prose: 'retry in 5 seconds'", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "retry in 5 seconds" },
+			NOW,
+		);
+		expect(result).toBe(5_000);
+	});
+
+	it("relative prose: 'wait after 10 seconds'", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "wait after 10 seconds" },
+			NOW,
+		);
+		expect(result).toBe(10_000);
+	});
+
+	it("relative prose with minutes: 'try again in 3 minutes'", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "try again in 3 minutes" },
+			NOW,
+		);
+		expect(result).toBe(180_000);
+	});
+
+	it("relative prose with ms: 'try again in 500 ms'", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "try again in 500 ms" },
+			NOW,
+		);
+		expect(result).toBe(500);
+	});
+
+	it("resets at <ISO8601-with-tz>", () => {
+		// 2023-11-14T22:14:20Z = 1700000060000, which is 60s after NOW
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "rate limit resets at 2023-11-14T22:14:20Z" },
+			NOW,
+		);
+		expect(result).toBe(60_000);
+	});
+
+	it("resets at <ISO8601-with-tz> past -> 0", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "rate limit resets at 2023-11-14T22:00:00Z" },
+			NOW,
+		);
+		expect(result).toBe(0);
+	});
+
+	it("ms-marker beats seconds-marker (precedence)", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: "retry-after: 30 retry-after-ms: 5000" },
+			NOW,
+		);
+		expect(result).toBe(5000);
+	});
+});
+
+/* ---------- 7. Precedence: explicit zero beats lower-precedence positive ---------- */
+
+describe("explicit zero precedence", () => {
+	it("retry-after: 0 + prose 30s -> 0", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after": "0" }), bodyText: "try again in 30 seconds" },
+			NOW,
+		);
+		expect(result).toBe(0);
+	});
+
+	it("retry-after-ms: 0 + retry-after: 60 -> 0 (higher precedence wins with zero)", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: headers({ "retry-after-ms": "0", "retry-after": "60" }), bodyText: "" },
+			NOW,
+		);
+		expect(result).toBe(0);
+	});
+
+	it("x-ratelimit-reset epoch now + retryDelay 5s -> 0 (epoch now = 0 delta, beats retryDelay)", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: headers({ "x-ratelimit-reset": String(Math.floor(NOW / 1000)) }),
+				bodyText: '{"retryDelay":"5s"}',
+			},
+			NOW,
+		);
+		expect(result).toBe(0);
+	});
+});
+
+/* ---------- 8. Malformed / adversarial inputs ---------- */
+
+describe("malformed and adversarial inputs", () => {
+	it("garbage body text -> undefined", () => {
+		const result = extract429RetryAfterMs({ status: 429, headers: new Headers(), bodyText: "asdfghjkl" }, NOW);
+		expect(result).toBeUndefined();
+	});
+
+	it("empty body -> undefined", () => {
+		const result = extract429RetryAfterMs({ status: 429, headers: new Headers(), bodyText: "" }, NOW);
+		expect(result).toBeUndefined();
+	});
+
+	it("garbage JSON object -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"foo":"bar","baz":[1,2,3]}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("bodyText with retryDelay in a string value (not key) -> undefined", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"message":"retryDelay is unknown"}' },
+			NOW,
+		);
+		expect(result).toBeUndefined();
+	});
+
+	it("deeply nested retryDelay max-wins", () => {
+		const result = extract429RetryAfterMs(
+			{
+				status: 429,
+				headers: new Headers(),
+				bodyText: '{"a":{"b":{"c":{"retryDelay":"1s"}},"d":{"retryDelay":"100s"}}}',
+			},
+			NOW,
+		);
+		expect(result).toBe(100_000);
+	});
+
+	it("retryDelay with both s and ms: 45s and 500ms -> max 45000", () => {
+		const result = extract429RetryAfterMs(
+			{ status: 429, headers: new Headers(), bodyText: '{"a":{"retryDelay":"45s"},"b":{"retryDelay":"500ms"}}' },
+			NOW,
+		);
+		expect(result).toBe(45_000);
+	});
+
+	it("nowMs default (no parameter) returns a number when hint exists", () => {
+		const result = extract429RetryAfterMs({ status: 429, headers: headers({ "retry-after": "5" }), bodyText: "" });
+		expect(result).toBe(5_000);
+	});
+});
+
+/* ---------- 9. Marker helpers ---------- */
+
+describe("appendRetryAfterMsMarker", () => {
+	it("appends marker to message", () => {
+		expect(appendRetryAfterMsMarker("rate limited", 1258000)).toBe("rate limited (retry-after-ms: 1258000)");
+	});
+
+	it("appends marker with zero", () => {
+		expect(appendRetryAfterMsMarker("rate limited", 0)).toBe("rate limited (retry-after-ms: 0)");
+	});
+});
+
+describe("parseRetryAfterMsMarker", () => {
+	it("parses marker from message", () => {
+		expect(parseRetryAfterMsMarker("rate limited (retry-after-ms: 1258000)")).toBe(1_258_000);
+	});
+
+	it("parses zero marker", () => {
+		expect(parseRetryAfterMsMarker("rate limited (retry-after-ms: 0)")).toBe(0);
+	});
+
+	it("returns undefined when no marker", () => {
+		expect(parseRetryAfterMsMarker("rate limited")).toBeUndefined();
+	});
+
+	it("round-trip: append then parse", () => {
+		const msg = appendRetryAfterMsMarker("some error", 45000);
+		expect(parseRetryAfterMsMarker(msg)).toBe(45_000);
+	});
+});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -55,6 +55,7 @@ import {
 	resetApiProviders,
 	streamSimple,
 } from "@earendil-works/pi-ai/compat";
+import { extract429RetryAfterMs, parseRetryAfterMsMarker } from "@earendil-works/pi-ai/utils/retry-hint";
 import { getAgentDir } from "../config.ts";
 import { getThemeByName, theme } from "../modes/interactive/theme/theme.ts";
 import { stripFrontmatter } from "../utils/frontmatter.ts";
@@ -130,6 +131,7 @@ import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.t
 import { isBillingErrorMessage } from "./retry-fallback/billing.ts";
 import { RetryFallbackController } from "./retry-fallback/controller.ts";
 import { SelectorCooldowns } from "./retry-fallback/cooldown.ts";
+import { classifyRateLimitedWait, nextInTurnDelayMs, type ProbePhase } from "./retry-fallback/hint-policy.ts";
 import { createFallbackLogger } from "./retry-fallback/log.ts";
 import { validateFallbackChains } from "./retry-fallback/validate.ts";
 import { createSessionLogger, type SessionLogger } from "./session-log.ts";
@@ -615,6 +617,9 @@ export class AgentSession {
 	private _retryAbortController: AbortController | undefined = undefined;
 	private _retryAttempt = 0;
 	private _consecutiveProviderStreamStalls = 0;
+	private _probePhase: ProbePhase = "idle";
+	private _hintDeadlineMs: number | undefined = undefined;
+	private _cumulativeHintedWaitMs = 0;
 	private _retryPromise: Promise<void> | undefined = undefined;
 	private _retryResolve: (() => void) | undefined = undefined;
 	private _userAbortPromise: Promise<void> | undefined = undefined;
@@ -1559,6 +1564,7 @@ export class AgentSession {
 						attempt: this._retryAttempt,
 					});
 					this._retryAttempt = 0;
+					this._resetHintTierState();
 				}
 			}
 		}
@@ -1659,6 +1665,17 @@ export class AgentSession {
 			this._retryResolve = undefined;
 			this._retryPromise = undefined;
 		}
+	}
+
+	private _resetHintTierState(): void {
+		this._probePhase = "idle";
+		this._hintDeadlineMs = undefined;
+		this._cumulativeHintedWaitMs = 0;
+	}
+
+	// TODO(todo-7): implement probe-back scheduling for tier2 demoted selectors.
+	private _armProbeBackForDemotedSelector(_selector: string, _hintMs: number): void {
+		// No-op seam — probe scheduling is todo 7.
 	}
 
 	/** Find the last assistant message in agent state (including aborted ones) */
@@ -5392,38 +5409,10 @@ export class AgentSession {
 	}
 
 	private _getProviderRetryDelayMs(errorMessage: string): number | undefined {
-		const retryAfterMsMatch = errorMessage.match(/\bretry[-_ ]?after[-_ ]?ms\s*[:=]\s*(\d+(?:\.\d+)?)/i);
-		if (retryAfterMsMatch) {
-			const delayMs = Math.ceil(Number(retryAfterMsMatch[1]));
-			return Number.isFinite(delayMs) && delayMs > 0 ? delayMs : undefined;
-		}
-
-		const retryAfterSecondsMatch = errorMessage.match(/\bretry[-_ ]?after\s*[:=]\s*(\d+(?:\.\d+)?)/i);
-		if (retryAfterSecondsMatch) {
-			const delayMs = Math.ceil(Number(retryAfterSecondsMatch[1]) * 1000);
-			return Number.isFinite(delayMs) && delayMs > 0 ? delayMs : undefined;
-		}
-
-		const retryInMatch = errorMessage.match(
-			/\b(?:retry|try again|wait)\s+(?:after|in)\s*(\d+(?:\.\d+)?)\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m)\b/i,
-		);
-		if (!retryInMatch) {
-			return undefined;
-		}
-
-		const value = Number(retryInMatch[1]);
-		if (!Number.isFinite(value) || value <= 0) {
-			return undefined;
-		}
-
-		const unit = retryInMatch[2].toLowerCase();
-		if (unit === "m" || unit.startsWith("min")) {
-			return Math.ceil(value * 60_000);
-		}
-		if (unit.startsWith("s")) {
-			return Math.ceil(value * 1000);
-		}
-		return Math.ceil(value);
+		const markerMs = parseRetryAfterMsMarker(errorMessage);
+		if (markerMs !== undefined) return markerMs;
+		const hintMs = extract429RetryAfterMs({ bodyText: errorMessage });
+		return hintMs;
 	}
 
 	private _getProviderTimeoutRetryOptions(message: AssistantMessage): AgentContinuationOptions {
@@ -5500,6 +5489,8 @@ export class AgentSession {
 		const isRefusal = isClassifierRefusal(message);
 		const hardErrorFallback = options.hardErrorFallback === true;
 		let switchedFallback = false;
+		let is429TierRouted = false;
+		let hintTierDelayMs: number | undefined;
 		if (hardErrorFallback) {
 			// A non-retryable provider failure must never replay on the same model.
 			// Billing-class failures never recover on this account, so the fallback
@@ -5525,6 +5516,7 @@ export class AgentSession {
 					});
 				}
 				this._retryAttempt = 0;
+				this._resetHintTierState();
 				this._resolveRetry();
 				return "not-handled";
 			}
@@ -5543,6 +5535,7 @@ export class AgentSession {
 					});
 				}
 				this._retryAttempt = 0;
+				this._resetHintTierState();
 				this._resolveRetry();
 				return "not-handled";
 			}
@@ -5561,8 +5554,156 @@ export class AgentSession {
 			const stallError = isProviderStreamStallError(message);
 			const escalateAfterRepeatedStall = stallError && this._consecutiveProviderStreamStalls > 0;
 			this._consecutiveProviderStreamStalls = stallError ? this._consecutiveProviderStreamStalls + 1 : 0;
-			this._retryAttempt++;
-			if (this._retryAttempt > settings.maxRetries || escalateAfterRepeatedStall) {
+			// 429-class detection: retryable AND message carries rate-limit markers.
+			const is429Class = !stallError && /rate.?limit|429|too many requests|resource.?exhausted/i.test(errorMessage);
+			if (is429Class) {
+				const hintMs = this._getProviderRetryDelayMs(errorMessage);
+				const hintSettings = this.settingsManager.getHintPolicySettings();
+				const tier = classifyRateLimitedWait(hintMs, hintSettings);
+				is429TierRouted = true;
+				if (tier === "no-hint-fast-fallback") {
+					// Skip same-model retries entirely; fall back immediately.
+					switchedFallback = await this._retryFallback.tryFallback("transient", { errorMessage });
+					if (switchedFallback) {
+						this._retryAttempt = 1;
+					} else {
+						const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+						if (exhaustedChainKey) {
+							this._emit({
+								type: "retry_fallback_exhausted",
+								chainKey: exhaustedChainKey,
+								lastError: errorMessage,
+							});
+						}
+						this._emit({
+							type: "auto_retry_end",
+							success: false,
+							attempt: 0,
+							finalError: message.errorMessage,
+						});
+						this._retryAttempt = 0;
+						this._resetHintTierState();
+						this._resolveRetry();
+						return "not-handled";
+					}
+				} else if (tier === "tier1-in-turn") {
+					this._retryAttempt++;
+					if (this._retryAttempt > settings.maxRetries) {
+						// Budget exhausted within tier1; fall back.
+						switchedFallback = await this._retryFallback.tryFallback("transient", {
+							errorMessage,
+							retryAfterMs: this._getProviderRetryDelayMs(errorMessage),
+						});
+						if (switchedFallback) {
+							this._retryAttempt = 1;
+						} else {
+							const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+							if (exhaustedChainKey) {
+								this._emit({
+									type: "retry_fallback_exhausted",
+									chainKey: exhaustedChainKey,
+									lastError: errorMessage,
+								});
+							}
+							this._emit({
+								type: "auto_retry_end",
+								success: false,
+								attempt: this._retryAttempt - 1,
+								finalError: message.errorMessage,
+							});
+							this._retryAttempt = 0;
+							this._resetHintTierState();
+							this._resolveRetry();
+							return "not-handled";
+						}
+					} else {
+						const inTurnResult = nextInTurnDelayMs(
+							{
+								probePhase: this._probePhase,
+								hintDeadlineMs: this._hintDeadlineMs,
+								attempt: this._retryAttempt,
+								cumulativeHintedWaitMs: this._cumulativeHintedWaitMs,
+							},
+							hintMs,
+							settings.baseDelayMs,
+							hintSettings.hintedWaitCapMs,
+							Date.now(),
+						);
+						this._probePhase = inTurnResult.probePhase;
+						this._hintDeadlineMs = inTurnResult.hintDeadlineMs;
+						this._cumulativeHintedWaitMs = inTurnResult.cumulativeHintedWaitMs;
+						if (inTurnResult.demoteToProbeBack) {
+							// Cumulative hinted wait exceeded cap; demote to tier2 fallback path.
+							const remainingHintMs = Math.max(0, (this._hintDeadlineMs ?? Date.now()) - Date.now());
+							switchedFallback = await this._retryFallback.tryFallback("transient", {
+								errorMessage,
+								retryAfterMs: remainingHintMs,
+							});
+							if (switchedFallback) {
+								this._retryAttempt = 1;
+							} else {
+								const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+								if (exhaustedChainKey) {
+									this._emit({
+										type: "retry_fallback_exhausted",
+										chainKey: exhaustedChainKey,
+										lastError: errorMessage,
+									});
+								}
+								this._emit({
+									type: "auto_retry_end",
+									success: false,
+									attempt: this._retryAttempt - 1,
+									finalError: message.errorMessage,
+								});
+								this._retryAttempt = 0;
+								this._resetHintTierState();
+								this._resolveRetry();
+								return "not-handled";
+							}
+						} else {
+							hintTierDelayMs = inTurnResult.delayMs;
+						}
+					}
+				} else {
+					// tier2-fallback-probe-back or tier3-fallback-only: immediate fallback.
+					const remainingHintMs = hintMs ?? 0;
+					switchedFallback = await this._retryFallback.tryFallback("transient", {
+						errorMessage,
+						retryAfterMs: remainingHintMs,
+					});
+					if (switchedFallback) {
+						this._retryAttempt = 1;
+						if (tier === "tier2-fallback-probe-back") {
+							const selector = this.model ? `${this.model.provider}/${this.model.id}` : "";
+							this._armProbeBackForDemotedSelector(selector, remainingHintMs);
+						}
+					} else {
+						const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+						if (exhaustedChainKey) {
+							this._emit({
+								type: "retry_fallback_exhausted",
+								chainKey: exhaustedChainKey,
+								lastError: errorMessage,
+							});
+						}
+						this._emit({
+							type: "auto_retry_end",
+							success: false,
+							attempt: 0,
+							finalError: message.errorMessage,
+						});
+						this._retryAttempt = 0;
+						this._resetHintTierState();
+						this._resolveRetry();
+						return "not-handled";
+					}
+				}
+			}
+			if (!is429TierRouted) {
+				this._retryAttempt++;
+			}
+			if (!is429TierRouted && (this._retryAttempt > settings.maxRetries || escalateAfterRepeatedStall)) {
 				switchedFallback = await this._retryFallback.tryFallback("transient", {
 					errorMessage,
 					retryAfterMs: this._getProviderRetryDelayMs(errorMessage),
@@ -5586,6 +5727,7 @@ export class AgentSession {
 						finalError: message.errorMessage,
 					});
 					this._retryAttempt = 0;
+					this._resetHintTierState();
 					this._resolveRetry();
 					return "not-handled";
 				}
@@ -5598,7 +5740,8 @@ export class AgentSession {
 
 		const providerDelayMs = isRefusal || hardErrorFallback ? undefined : this._getProviderRetryDelayMs(errorMessage);
 		const maxRetryDelayMs = this.settingsManager.getProviderRetrySettings().maxRetryDelayMs;
-		if (providerDelayMs !== undefined && providerDelayMs > maxRetryDelayMs) {
+		// For 429-class failures the tier routing replaces the over-budget gate.
+		if (!is429TierRouted && providerDelayMs !== undefined && providerDelayMs > maxRetryDelayMs) {
 			// A wait this long means the model is unavailable rather than busy, so the
 			// configured chain beats failing the turn. The switch is gated: the over-budget
 			// branch above may have already switched on this same error, and hopping again
@@ -5620,6 +5763,7 @@ export class AgentSession {
 					finalError: `Provider requested retry delay ${providerDelayMs}ms, exceeding configured maximum ${maxRetryDelayMs}ms`,
 				});
 				this._retryAttempt = 0;
+				this._resetHintTierState();
 				this._resolveRetry();
 				return "not-handled";
 			}
@@ -5630,7 +5774,11 @@ export class AgentSession {
 		// reach this point with a fallback already applied (hard-error, refusal) set
 		// switchedFallback first and force providerDelayMs undefined, so no branch may
 		// be reordered to fall through here expecting an implicit switch.
-		const delayMs = switchedFallback ? 0 : (providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1));
+		const delayMs = switchedFallback
+			? 0
+			: is429TierRouted
+				? (hintTierDelayMs ?? providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1))
+				: (providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1));
 		// Prepare before auto_retry_start so an immediate Esc can cancel the retry sleep.
 		this._retryAbortController = new AbortController();
 
@@ -5656,6 +5804,7 @@ export class AgentSession {
 			// Aborted during sleep - emit end event so UI can clean up
 			const attempt = this._retryAttempt;
 			this._retryAttempt = 0;
+			this._resetHintTierState();
 			this._retryAbortController = undefined;
 			await this._emitAgentSettled();
 			this._emit({
@@ -5690,6 +5839,7 @@ export class AgentSession {
 			if (!preRetryCompaction && !this._isCompactionOnCooldown()) {
 				const attempt = this._retryAttempt;
 				this._retryAttempt = 0;
+				this._resetHintTierState();
 				this._emit({
 					type: "auto_retry_end",
 					success: false,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -129,10 +129,17 @@ import { PROMPT_CACHE_SAFE_WAIT_ENV, resolvePromptCacheSafeWaitSeconds } from ".
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.ts";
 import { isBillingErrorMessage } from "./retry-fallback/billing.ts";
+import { formatSelector } from "./retry-fallback/chains.ts";
 import { RetryFallbackController } from "./retry-fallback/controller.ts";
 import { SelectorCooldowns } from "./retry-fallback/cooldown.ts";
-import { classifyRateLimitedWait, nextInTurnDelayMs, type ProbePhase } from "./retry-fallback/hint-policy.ts";
+import {
+	classifyRateLimitedWait,
+	nextInTurnDelayMs,
+	type ProbePhase,
+	probeBackSchedule,
+} from "./retry-fallback/hint-policy.ts";
 import { createFallbackLogger } from "./retry-fallback/log.ts";
+import { ProbeBackScheduler } from "./retry-fallback/probe-scheduler.ts";
 import { validateFallbackChains } from "./retry-fallback/validate.ts";
 import { createSessionLogger, type SessionLogger } from "./session-log.ts";
 import type { BranchSummaryEntry, CompactionEntry, SessionEntry, SessionManager } from "./session-manager.ts";
@@ -249,6 +256,8 @@ export type AgentSessionEvent =
 			reason: CompactionReason;
 	  }
 	| { type: "summarization_retry_finished" }
+	| { type: "retry_probe_scheduled"; selector: string; atMs: number; probeIndex: 1 | 2 }
+	| { type: "retry_probe_result"; selector: string; ok: boolean; errorMessage?: string }
 	| { type: "bash_execution_update"; id?: string; delta: string };
 
 /** Listener function for agent session events */
@@ -660,6 +669,9 @@ export class AgentSession {
 	private _modelRegistry: ModelRegistry;
 	private readonly _fallbackValidationWarnings: readonly string[];
 	private readonly _retryFallback: RetryFallbackController;
+	private readonly _selectorCooldowns: SelectorCooldowns;
+	private readonly _probeBackScheduler: ProbeBackScheduler;
+	private readonly _fallbackNow: () => number;
 
 	// Tool registry for extension getTools/setTools
 	private _toolRegistry: Map<string, AgentTool> = new Map();
@@ -707,10 +719,12 @@ export class AgentSession {
 		for (const warning of this._fallbackValidationWarnings) {
 			fallbackLogger.warn("validation_warning", { warning });
 		}
+		this._selectorCooldowns = new SelectorCooldowns(config.fallbackNow ?? (() => Date.now()));
+		this._fallbackNow = config.fallbackNow ?? (() => Date.now());
 		this._retryFallback = new RetryFallbackController({
 			getSettings: () => this.settingsManager.getRetryFallbackSettings(),
 			registry: this._modelRegistry,
-			cooldowns: new SelectorCooldowns(config.fallbackNow ?? (() => Date.now())),
+			cooldowns: this._selectorCooldowns,
 			logger: fallbackLogger,
 			switchModel: async (model, thinking, reason) => {
 				await this._switchActiveModel(model, {
@@ -726,6 +740,9 @@ export class AgentSession {
 			emit: (event) => this._emit(event),
 			getCurrentSelector: () => (this.model ? { model: this.model, thinkingLevel: this.thinkingLevel } : undefined),
 			isAuthAvailable: (provider) => this._modelRuntime.hasConfiguredAuth(provider),
+		});
+		this._probeBackScheduler = new ProbeBackScheduler({
+			now: this._fallbackNow,
 		});
 		this._extensionRunnerRef = config.extensionRunnerRef;
 		this._initialActiveToolNames = config.initialActiveToolNames;
@@ -1673,9 +1690,72 @@ export class AgentSession {
 		this._cumulativeHintedWaitMs = 0;
 	}
 
-	// TODO(todo-7): implement probe-back scheduling for tier2 demoted selectors.
-	private _armProbeBackForDemotedSelector(_selector: string, _hintMs: number): void {
-		// No-op seam — probe scheduling is todo 7.
+	/**
+	 * Arm the probe-back scheduler for a tier-2 demoted selector. The scheduler
+	 * will fire at most two probes (half-hint, then deadline) and clear the
+	 * selector cooldown on success so maybeRestorePrimary reverts at the next
+	 * turn boundary.
+	 */
+	private _armProbeBackForDemotedSelector(selector: string, hintMs: number): void {
+		if (!selector) return;
+
+		// Guard: skip when the demoted selector is the ACTIVE model.
+		const currentModel = this.model;
+		if (currentModel && formatSelector(currentModel) === selector) return;
+
+		// Guard: skip when auth is unavailable at arm time.
+		const parts = selector.split("/");
+		if (parts.length < 2) return;
+		const provider = parts[0];
+		if (!this._modelRuntime.hasConfiguredAuth(provider)) return;
+
+		const now = this._fallbackNow();
+		const schedule = probeBackSchedule(hintMs, now);
+		const modelId = parts.slice(1).join("/");
+		const demotedModel = this._modelRuntime.getModel(provider, modelId);
+		if (!demotedModel) return;
+
+		this._probeBackScheduler.arm({
+			selector,
+			firstAtMs: schedule.firstAtMs,
+			deadlineMs: schedule.deadlineMs,
+			authAvailable: () => this._modelRuntime.hasConfiguredAuth(provider),
+			runProbe: async (signal: AbortSignal): Promise<boolean> => {
+				try {
+					const result = await this._modelRuntime.completeSimple(
+						demotedModel,
+						{
+							systemPrompt: "Reply with OK.",
+							messages: [{ role: "user", content: [{ type: "text", text: "OK" }], timestamp: now }],
+						},
+						{ maxTokens: 1, signal },
+					);
+					return result.stopReason !== "error" && result.stopReason !== "aborted";
+				} catch {
+					return false;
+				}
+			},
+			onCleared: (sel: string) => {
+				this._selectorCooldowns.clear(sel);
+			},
+			emit: (event) => {
+				if (event.type === "retry_probe_scheduled") {
+					this._emit({
+						type: "retry_probe_scheduled",
+						selector: event.selector,
+						atMs: event.atMs,
+						probeIndex: event.probeIndex,
+					});
+				} else {
+					this._emit({
+						type: "retry_probe_result",
+						selector: event.selector,
+						ok: event.ok,
+						errorMessage: event.errorMessage,
+					});
+				}
+			},
+		});
 	}
 
 	/** Find the last assistant message in agent state (including aborted ones) */
@@ -1889,6 +1969,7 @@ export class AgentSession {
 	 */
 	dispose(): void {
 		try {
+			this._probeBackScheduler.cancel("dispose");
 			this.abortRetry();
 			this.abortCompaction();
 			this.abortBranchSummary();
@@ -3258,6 +3339,7 @@ export class AgentSession {
 		// A manual model change abandons any active fallback window; if a fallback
 		// retry sleep is still pending, cancel it so no surprise continuation fires.
 		const hadActiveFallback = this._retryFallback.activeState !== undefined;
+		this._probeBackScheduler.cancel("manual-model-change");
 		this._retryFallback.clearForManualModelChange(model);
 		if (hadActiveFallback && this._retryAbortController) {
 			this.abortRetry();
@@ -3370,6 +3452,7 @@ export class AgentSession {
 		if (invalidatesCompaction) {
 			this._invalidateCompactionForModelSelection();
 		}
+		this._probeBackScheduler.cancel("manual-model-change");
 		this._retryFallback.clearForManualModelChange(next.model);
 		const thinkingLevel = this._getThinkingLevelForModelSwitch(next.thinkingLevel);
 
@@ -5675,7 +5758,7 @@ export class AgentSession {
 					if (switchedFallback) {
 						this._retryAttempt = 1;
 						if (tier === "tier2-fallback-probe-back") {
-							const selector = this.model ? `${this.model.provider}/${this.model.id}` : "";
+							const selector = this._retryFallback.activeState?.originalSelector ?? "";
 							this._armProbeBackForDemotedSelector(selector, remainingHintMs);
 						}
 					} else {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5638,7 +5638,11 @@ export class AgentSession {
 			const escalateAfterRepeatedStall = stallError && this._consecutiveProviderStreamStalls > 0;
 			this._consecutiveProviderStreamStalls = stallError ? this._consecutiveProviderStreamStalls + 1 : 0;
 			// 429-class detection: retryable AND message carries rate-limit markers.
-			const is429Class = !stallError && /rate.?limit|429|too many requests|resource.?exhausted/i.test(errorMessage);
+			const is429Class =
+				!stallError &&
+				/rate.?limit|(?:^429(?=\s+\{)|(?:\bHTTP\/1\.[01]\s+|\bHTTP\s+|\bstatus(?:\s+code)?\s+|\berror\s+|\bcode\s+)429\b)|too many requests|resource.?exhausted/i.test(
+					errorMessage,
+				);
 			if (is429Class) {
 				const hintMs = this._getProviderRetryDelayMs(errorMessage);
 				const hintSettings = this.settingsManager.getHintPolicySettings();
@@ -5857,11 +5861,12 @@ export class AgentSession {
 		// reach this point with a fallback already applied (hard-error, refusal) set
 		// switchedFallback first and force providerDelayMs undefined, so no branch may
 		// be reordered to fall through here expecting an implicit switch.
+		const nonTierProviderDelayMs = providerDelayMs === 0 ? undefined : providerDelayMs;
 		const delayMs = switchedFallback
 			? 0
 			: is429TierRouted
 				? (hintTierDelayMs ?? providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1))
-				: (providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1));
+				: (nonTierProviderDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1));
 		// Prepare before auto_retry_start so an immediate Esc can cancel the retry sleep.
 		this._retryAbortController = new AbortController();
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,42 @@
 # changes
 
+## Hint-aware 429 retry tier routing (2026-08-03)
+
+### What changed
+
+- `agent-session.ts` retry orchestration classifies 429-class errors into three tiers using the structured
+  hint from `packages/ai`: no-hint 429 falls back immediately with zero same-model retries; tier 1 (hint ≤
+  `hintedWaitCapMs`, default 300 000 ms) performs in-turn half/full probes via `nextInTurnDelayMs` with
+  cumulative-cap demotion; tier 2 (`hintedWaitCapMs` < hint < `probeBackMaxMs`) falls back and schedules
+  at most two `ProbeBackScheduler` probes at half/deadline, clearing cooldown on success so
+  `maybeRestorePrimary` reverts next turn; tier 3 (hint ≥ `probeBackMaxMs`) falls back only with a
+  remaining-hint cooldown.
+- `retry-fallback/probe-scheduler.ts` (new) owns the tier 2 probe schedule. `retry-fallback/controller.ts`
+  and `retry-fallback/cooldown.ts` carry the tier decision and cooldown state.
+  `retry-fallback/settings.ts` adds `resolveHintPolicySettings` with `hintedWaitCapMs` and `probeBackMaxMs`
+  (defaults 300 000 / 3 600 000 ms).
+- New session events `retry_probe_scheduled` and `retry_probe_result` surface probe lifecycle to the client.
+- `retry-fallback-long-delay.test.ts` has two intentionally updated assertions: tier routing replaces the
+  legacy over-budget gate for 429-class errors, so the expected retry/fallback behavior changes accordingly.
+
+### Why
+
+- A blind exponential backoff on 429 wastes a turn when the provider says “retry now,” and retries
+  immediately when the provider says “wait an hour.” Structured hints let the agent respect the provider's
+  guidance instead of guessing.
+
+### Why this cannot be expressed externally
+
+- The tier decision must intercept the retry sleep and fallback switch inside agent-session's orchestration
+  loop, between the provider error and the retry/fallback decision. The extension API exposes no hook at that
+  point — extensions see only post-decision error strings.
+
+### Expected merge conflict zones
+
+- HIGH: `agent-session.ts` retry orchestration (approximately lines 5380–5705).
+- MEDIUM: `retry-fallback/*` (controller, cooldown, settings, probe-scheduler).
+- LOW: `settings-manager.ts` for the new `hintedWaitCapMs` / `probeBackMaxMs` settings.
+
 ## Backfill: eval bridge deadlock prevention (2026-08-01)
 
 ### What changed

--- a/packages/coding-agent/src/core/retry-fallback/hint-policy.ts
+++ b/packages/coding-agent/src/core/retry-fallback/hint-policy.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure tier-policy and probe-schedule decisions for hint-aware 429 retry.
+ * No timers, no I/O — all time values are injected by the caller.
+ */
+
+export type HintTier = "no-hint-fast-fallback" | "tier1-in-turn" | "tier2-fallback-probe-back" | "tier3-fallback-only";
+
+export function classifyRateLimitedWait(
+	hintMs: number | undefined,
+	settings: { hintedWaitCapMs: number; probeBackMaxMs: number },
+): HintTier {
+	if (hintMs === undefined) return "no-hint-fast-fallback";
+	if (hintMs <= settings.hintedWaitCapMs) return "tier1-in-turn";
+	if (hintMs < settings.probeBackMaxMs) return "tier2-fallback-probe-back";
+	return "tier3-fallback-only";
+}
+
+export function probeBackSchedule(hintMs: number, nowMs: number): { firstAtMs: number; deadlineMs: number } {
+	return { firstAtMs: nowMs + Math.ceil(hintMs / 2), deadlineMs: nowMs + hintMs };
+}
+
+export type ProbePhase = "idle" | "half-used" | "done";
+
+export interface InTurnState {
+	probePhase: ProbePhase;
+	hintDeadlineMs?: number;
+	attempt: number;
+	cumulativeHintedWaitMs: number;
+}
+
+export interface InTurnResult {
+	delayMs: number;
+	probePhase: "half-used" | "done";
+	hintDeadlineMs?: number;
+	cumulativeHintedWaitMs: number;
+	demoteToProbeBack: boolean;
+}
+
+export function nextInTurnDelayMs(
+	state: InTurnState,
+	hintMs: number | undefined,
+	baseDelayMs: number,
+	hintedWaitCapMs: number,
+	nowMs: number,
+): InTurnResult {
+	// Phase: half-used -> consecutive 429 with deadline sleep
+	if (state.probePhase === "half-used") {
+		const deadlineMs = hintMs !== undefined ? nowMs + hintMs : (state.hintDeadlineMs ?? nowMs);
+		const remaining = Math.max(0, deadlineMs - nowMs);
+		const newCumulative = state.cumulativeHintedWaitMs + remaining;
+		return {
+			delayMs: remaining,
+			probePhase: "done",
+			hintDeadlineMs: deadlineMs,
+			cumulativeHintedWaitMs: newCumulative,
+			demoteToProbeBack: newCumulative > hintedWaitCapMs,
+		};
+	}
+
+	// Phase: idle -> first hinted 429, probe at hint/2
+	if (state.probePhase === "idle" && hintMs !== undefined) {
+		const delay = Math.ceil(hintMs / 2);
+		const deadlineMs = nowMs + hintMs;
+		const newCumulative = state.cumulativeHintedWaitMs + delay;
+		return {
+			delayMs: delay,
+			probePhase: "half-used",
+			hintDeadlineMs: deadlineMs,
+			cumulativeHintedWaitMs: newCumulative,
+			demoteToProbeBack: newCumulative > hintedWaitCapMs,
+		};
+	}
+
+	// Phase: done (or idle without hint = non-429 / no-hint fallback) -> exponential or hint override
+	const delay = hintMs ?? baseDelayMs * 2 ** (state.attempt - 1);
+	return {
+		delayMs: delay,
+		probePhase: "done",
+		hintDeadlineMs: state.hintDeadlineMs,
+		cumulativeHintedWaitMs: state.cumulativeHintedWaitMs,
+		demoteToProbeBack: false,
+	};
+}

--- a/packages/coding-agent/src/core/retry-fallback/probe-scheduler.ts
+++ b/packages/coding-agent/src/core/retry-fallback/probe-scheduler.ts
@@ -1,0 +1,188 @@
+/**
+ * Bounded probe-back scheduler for tier-2 demoted selectors.
+ *
+ * Owns ONE armed probe plan per session: at most two probes (first at half-hint,
+ * then at the absolute deadline), never two in-flight simultaneously. Arming
+ * while armed silently supersedes the previous plan. cancel() aborts any
+ * in-flight probe and clears pending timers — no further emits after cancel.
+ *
+ * All timers go through the injected `setTimeout`/`clearTimeout` pair so tests
+ * can drive them deterministically with fake timers.
+ */
+
+export interface ProbeBackArmInput {
+	selector: string;
+	firstAtMs: number;
+	deadlineMs: number;
+	authAvailable: () => boolean;
+	runProbe: (signal: AbortSignal) => Promise<boolean>;
+	onCleared: (selector: string) => void;
+	emit: (event: ProbeBackEvent) => void;
+}
+
+export type ProbeBackEvent =
+	| { type: "retry_probe_scheduled"; selector: string; atMs: number; probeIndex: 1 | 2 }
+	| { type: "retry_probe_result"; selector: string; ok: boolean; errorMessage?: string };
+
+export type ProbeBackCancelReason = "manual-model-change" | "dispose" | "superseded";
+
+interface ScheduledTimer {
+	handle: unknown;
+}
+
+export class ProbeBackScheduler {
+	private readonly _now: () => number;
+	private readonly _setTimeout: (callback: () => void, delay: number) => unknown;
+	private readonly _clearTimeout: (handle: unknown) => void;
+
+	private _armed = false;
+	private _firstTimer: ScheduledTimer | undefined;
+	private _deadlineTimer: ScheduledTimer | undefined;
+	private _abortController: AbortController | undefined;
+
+	constructor(opts: {
+		now: () => number;
+		setTimeout?: (callback: () => void, delay: number) => unknown;
+		clearTimeout?: (handle: unknown) => void;
+	}) {
+		this._now = opts.now;
+		this._setTimeout = opts.setTimeout ?? ((cb, d) => setTimeout(cb, d));
+		this._clearTimeout = opts.clearTimeout ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+	}
+
+	get active(): boolean {
+		return this._armed;
+	}
+
+	arm(input: ProbeBackArmInput): void {
+		// Supersede any existing plan silently.
+		if (this._armed) {
+			this._clearTimers();
+			this._abortInFlight("superseded");
+		}
+
+		this._armed = true;
+		this._firstTimer = { handle: undefined };
+		this._deadlineTimer = { handle: undefined };
+
+		// Emit scheduled event for probe 1.
+		input.emit({
+			type: "retry_probe_scheduled",
+			selector: input.selector,
+			atMs: input.firstAtMs,
+			probeIndex: 1,
+		});
+
+		const delay = Math.max(0, input.firstAtMs - this._now());
+		this._firstTimer.handle = this._setTimeout(() => {
+			void this._runProbe(input, 1);
+		}, delay);
+	}
+
+	cancel(reason: ProbeBackCancelReason): void {
+		if (!this._armed) return;
+		this._clearTimers();
+		this._abortInFlight(reason);
+		this._disarm();
+	}
+
+	private _clearTimers(): void {
+		if (this._firstTimer?.handle !== undefined) {
+			this._clearTimeout(this._firstTimer.handle);
+			this._firstTimer.handle = undefined;
+		}
+		if (this._deadlineTimer?.handle !== undefined) {
+			this._clearTimeout(this._deadlineTimer.handle);
+			this._deadlineTimer.handle = undefined;
+		}
+	}
+
+	private _abortInFlight(_reason: ProbeBackCancelReason): void {
+		if (this._abortController) {
+			this._abortController.abort();
+			this._abortController = undefined;
+		}
+	}
+
+	private _disarm(): void {
+		this._armed = false;
+		this._firstTimer = undefined;
+		this._deadlineTimer = undefined;
+		this._abortController = undefined;
+	}
+
+	private async _runProbe(input: ProbeBackArmInput, probeIndex: 1 | 2): Promise<void> {
+		// Clear the timer that just fired so cancel doesn't try to clear a stale handle.
+		if (probeIndex === 1 && this._firstTimer) {
+			this._firstTimer.handle = undefined;
+		} else if (this._deadlineTimer) {
+			this._deadlineTimer.handle = undefined;
+		}
+
+		// Guard: auth unavailable -> fail immediately, disarm.
+		if (!input.authAvailable()) {
+			input.emit({
+				type: "retry_probe_result",
+				selector: input.selector,
+				ok: false,
+				errorMessage: "auth-unavailable",
+			});
+			this._disarm();
+			return;
+		}
+
+		// Set up abort controller for the in-flight probe.
+		this._abortController = new AbortController();
+
+		let success: boolean;
+		try {
+			success = await input.runProbe(this._abortController.signal);
+		} catch {
+			success = false;
+		}
+
+		// If cancelled during the probe, abortController is already cleaned by cancel.
+		// Check if we're still armed (cancel may have fired mid-flight).
+		if (!this._armed) return;
+
+		this._abortController = undefined;
+
+		if (success) {
+			input.onCleared(input.selector);
+			input.emit({
+				type: "retry_probe_result",
+				selector: input.selector,
+				ok: true,
+			});
+			this._disarm();
+			return;
+		}
+
+		// First probe failed — schedule the deadline probe if we haven't used both slots.
+		if (probeIndex === 1) {
+			// Emit scheduled event for probe 2.
+			input.emit({
+				type: "retry_probe_scheduled",
+				selector: input.selector,
+				atMs: input.deadlineMs,
+				probeIndex: 2,
+			});
+
+			const delay = Math.max(0, input.deadlineMs - this._now());
+			if (this._deadlineTimer) {
+				this._deadlineTimer.handle = this._setTimeout(() => {
+					void this._runProbe(input, 2);
+				}, delay);
+			}
+			return;
+		}
+
+		// Second probe failed — final result, disarm.
+		input.emit({
+			type: "retry_probe_result",
+			selector: input.selector,
+			ok: false,
+		});
+		this._disarm();
+	}
+}

--- a/packages/coding-agent/src/core/retry-fallback/probe-scheduler.ts
+++ b/packages/coding-agent/src/core/retry-fallback/probe-scheduler.ts
@@ -40,6 +40,8 @@ export class ProbeBackScheduler {
 	private _firstTimer: ScheduledTimer | undefined;
 	private _deadlineTimer: ScheduledTimer | undefined;
 	private _abortController: AbortController | undefined;
+	private _activeProbeIndex: 1 | 2 | undefined;
+	private _secondProbeAnnounced = false;
 
 	constructor(opts: {
 		now: () => number;
@@ -68,6 +70,8 @@ export class ProbeBackScheduler {
 		this._armed = true;
 		this._firstTimer = { handle: undefined };
 		this._deadlineTimer = { handle: undefined };
+		this._activeProbeIndex = undefined;
+		this._secondProbeAnnounced = false;
 
 		// Emit scheduled event for probe 1.
 		if (gen !== this._generation) return;
@@ -79,11 +83,19 @@ export class ProbeBackScheduler {
 		});
 		if (gen !== this._generation) return;
 
-		const delay = Math.max(0, input.firstAtMs - this._now());
+		const firstDelay = Math.max(0, input.firstAtMs - this._now());
 		if (this._firstTimer) {
 			this._firstTimer.handle = this._setTimeout(() => {
 				void this._runProbe(input, 1, gen);
-			}, delay);
+			}, firstDelay);
+		}
+
+		const deadlineDelay = Math.max(0, input.deadlineMs - this._now());
+		if (gen !== this._generation) return;
+		if (this._deadlineTimer) {
+			this._deadlineTimer.handle = this._setTimeout(() => {
+				this._runDeadlineProbe(input, gen);
+			}, deadlineDelay);
 		}
 	}
 
@@ -110,6 +122,7 @@ export class ProbeBackScheduler {
 			this._abortController.abort();
 			this._abortController = undefined;
 		}
+		this._activeProbeIndex = undefined;
 	}
 
 	private _disarm(): void {
@@ -117,11 +130,42 @@ export class ProbeBackScheduler {
 		this._firstTimer = undefined;
 		this._deadlineTimer = undefined;
 		this._abortController = undefined;
+		this._activeProbeIndex = undefined;
+		this._secondProbeAnnounced = false;
+	}
+
+	private _finish(): void {
+		this._clearTimers();
+		this._disarm();
+	}
+
+	private _announceSecondProbe(input: ProbeBackArmInput, generation: number): void {
+		if (generation !== this._generation || this._secondProbeAnnounced) return;
+		this._secondProbeAnnounced = true;
+		input.emit({
+			type: "retry_probe_scheduled",
+			selector: input.selector,
+			atMs: input.deadlineMs,
+			probeIndex: 2,
+		});
+	}
+
+	private _runDeadlineProbe(input: ProbeBackArmInput, generation: number): void {
+		if (generation !== this._generation || !this._armed) return;
+		if (this._deadlineTimer) this._deadlineTimer.handle = undefined;
+		if (this._firstTimer?.handle !== undefined) {
+			this._clearTimeout(this._firstTimer.handle);
+			this._firstTimer.handle = undefined;
+		}
+		if (this._activeProbeIndex === 1) this._abortInFlight("superseded");
+		this._announceSecondProbe(input, generation);
+		if (generation !== this._generation) return;
+		void this._runProbe(input, 2, generation);
 	}
 
 	private async _runProbe(input: ProbeBackArmInput, probeIndex: 1 | 2, generation: number): Promise<void> {
 		const gen = generation;
-		if (gen !== this._generation) return;
+		if (gen !== this._generation || !this._armed) return;
 
 		// Clear the timer that just fired so cancel doesn't try to clear a stale handle.
 		if (probeIndex === 1 && this._firstTimer) {
@@ -140,14 +184,15 @@ export class ProbeBackScheduler {
 				errorMessage: "auth-unavailable",
 			});
 			if (gen !== this._generation) return;
-			this._disarm();
+			this._finish();
 			return;
 		}
 
 		// Set up abort controller for the in-flight probe.
-		if (gen !== this._generation) return;
+		if (gen !== this._generation || this._activeProbeIndex !== undefined) return;
 		const abortController = new AbortController();
 		this._abortController = abortController;
+		this._activeProbeIndex = probeIndex;
 
 		let success: boolean;
 		try {
@@ -156,8 +201,15 @@ export class ProbeBackScheduler {
 			success = false;
 		}
 
-		if (gen !== this._generation) return;
+		if (
+			gen !== this._generation ||
+			this._activeProbeIndex !== probeIndex ||
+			this._abortController !== abortController
+		) {
+			return;
+		}
 		this._abortController = undefined;
+		this._activeProbeIndex = undefined;
 
 		if (success) {
 			if (gen !== this._generation) return;
@@ -169,29 +221,13 @@ export class ProbeBackScheduler {
 				ok: true,
 			});
 			if (gen !== this._generation) return;
-			this._disarm();
+			this._finish();
 			return;
 		}
 
-		// First probe failed — schedule the deadline probe if we haven't used both slots.
+		// First probe failed — the already-armed deadline timer owns the final attempt.
 		if (probeIndex === 1) {
-			// Emit scheduled event for probe 2.
-			if (gen !== this._generation) return;
-			input.emit({
-				type: "retry_probe_scheduled",
-				selector: input.selector,
-				atMs: input.deadlineMs,
-				probeIndex: 2,
-			});
-			if (gen !== this._generation) return;
-
-			const delay = Math.max(0, input.deadlineMs - this._now());
-			if (this._deadlineTimer) {
-				if (gen !== this._generation) return;
-				this._deadlineTimer.handle = this._setTimeout(() => {
-					void this._runProbe(input, 2, gen);
-				}, delay);
-			}
+			this._announceSecondProbe(input, gen);
 			return;
 		}
 
@@ -203,6 +239,6 @@ export class ProbeBackScheduler {
 			ok: false,
 		});
 		if (gen !== this._generation) return;
-		this._disarm();
+		this._finish();
 	}
 }

--- a/packages/coding-agent/src/core/retry-fallback/probe-scheduler.ts
+++ b/packages/coding-agent/src/core/retry-fallback/probe-scheduler.ts
@@ -36,6 +36,7 @@ export class ProbeBackScheduler {
 	private readonly _clearTimeout: (handle: unknown) => void;
 
 	private _armed = false;
+	private _generation = 0;
 	private _firstTimer: ScheduledTimer | undefined;
 	private _deadlineTimer: ScheduledTimer | undefined;
 	private _abortController: AbortController | undefined;
@@ -47,6 +48,7 @@ export class ProbeBackScheduler {
 	}) {
 		this._now = opts.now;
 		this._setTimeout = opts.setTimeout ?? ((cb, d) => setTimeout(cb, d));
+		// boundary narrowing: injected handle type
 		this._clearTimeout = opts.clearTimeout ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
 	}
 
@@ -55,10 +57,12 @@ export class ProbeBackScheduler {
 	}
 
 	arm(input: ProbeBackArmInput): void {
+		const gen = ++this._generation;
 		// Supersede any existing plan silently.
 		if (this._armed) {
 			this._clearTimers();
 			this._abortInFlight("superseded");
+			this._disarm();
 		}
 
 		this._armed = true;
@@ -66,21 +70,25 @@ export class ProbeBackScheduler {
 		this._deadlineTimer = { handle: undefined };
 
 		// Emit scheduled event for probe 1.
+		if (gen !== this._generation) return;
 		input.emit({
 			type: "retry_probe_scheduled",
 			selector: input.selector,
 			atMs: input.firstAtMs,
 			probeIndex: 1,
 		});
+		if (gen !== this._generation) return;
 
 		const delay = Math.max(0, input.firstAtMs - this._now());
-		this._firstTimer.handle = this._setTimeout(() => {
-			void this._runProbe(input, 1);
-		}, delay);
+		if (this._firstTimer) {
+			this._firstTimer.handle = this._setTimeout(() => {
+				void this._runProbe(input, 1, gen);
+			}, delay);
+		}
 	}
 
 	cancel(reason: ProbeBackCancelReason): void {
-		if (!this._armed) return;
+		this._generation++;
 		this._clearTimers();
 		this._abortInFlight(reason);
 		this._disarm();
@@ -111,7 +119,10 @@ export class ProbeBackScheduler {
 		this._abortController = undefined;
 	}
 
-	private async _runProbe(input: ProbeBackArmInput, probeIndex: 1 | 2): Promise<void> {
+	private async _runProbe(input: ProbeBackArmInput, probeIndex: 1 | 2, generation: number): Promise<void> {
+		const gen = generation;
+		if (gen !== this._generation) return;
+
 		// Clear the timer that just fired so cancel doesn't try to clear a stale handle.
 		if (probeIndex === 1 && this._firstTimer) {
 			this._firstTimer.handle = undefined;
@@ -121,39 +132,43 @@ export class ProbeBackScheduler {
 
 		// Guard: auth unavailable -> fail immediately, disarm.
 		if (!input.authAvailable()) {
+			if (gen !== this._generation) return;
 			input.emit({
 				type: "retry_probe_result",
 				selector: input.selector,
 				ok: false,
 				errorMessage: "auth-unavailable",
 			});
+			if (gen !== this._generation) return;
 			this._disarm();
 			return;
 		}
 
 		// Set up abort controller for the in-flight probe.
-		this._abortController = new AbortController();
+		if (gen !== this._generation) return;
+		const abortController = new AbortController();
+		this._abortController = abortController;
 
 		let success: boolean;
 		try {
-			success = await input.runProbe(this._abortController.signal);
+			success = await input.runProbe(abortController.signal);
 		} catch {
 			success = false;
 		}
 
-		// If cancelled during the probe, abortController is already cleaned by cancel.
-		// Check if we're still armed (cancel may have fired mid-flight).
-		if (!this._armed) return;
-
+		if (gen !== this._generation) return;
 		this._abortController = undefined;
 
 		if (success) {
+			if (gen !== this._generation) return;
 			input.onCleared(input.selector);
+			if (gen !== this._generation) return;
 			input.emit({
 				type: "retry_probe_result",
 				selector: input.selector,
 				ok: true,
 			});
+			if (gen !== this._generation) return;
 			this._disarm();
 			return;
 		}
@@ -161,28 +176,33 @@ export class ProbeBackScheduler {
 		// First probe failed — schedule the deadline probe if we haven't used both slots.
 		if (probeIndex === 1) {
 			// Emit scheduled event for probe 2.
+			if (gen !== this._generation) return;
 			input.emit({
 				type: "retry_probe_scheduled",
 				selector: input.selector,
 				atMs: input.deadlineMs,
 				probeIndex: 2,
 			});
+			if (gen !== this._generation) return;
 
 			const delay = Math.max(0, input.deadlineMs - this._now());
 			if (this._deadlineTimer) {
+				if (gen !== this._generation) return;
 				this._deadlineTimer.handle = this._setTimeout(() => {
-					void this._runProbe(input, 2);
+					void this._runProbe(input, 2, gen);
 				}, delay);
 			}
 			return;
 		}
 
 		// Second probe failed — final result, disarm.
+		if (gen !== this._generation) return;
 		input.emit({
 			type: "retry_probe_result",
 			selector: input.selector,
 			ok: false,
 		});
+		if (gen !== this._generation) return;
 		this._disarm();
 	}
 }

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -17,6 +17,8 @@ export interface RetrySettings {
 	fallbackChains?: Record<string, string[]>;
 	fallbackRevertPolicy?: "cooldown-expiry" | "never";
 	abortServerSideFallback?: boolean;
+	hintedWaitCapMs?: number;
+	probeBackMaxMs?: number;
 }
 
 export interface ResolvedRetryFallbackSettings {
@@ -71,4 +73,29 @@ export function resolveRetryFallbackSettings(settings: RetrySettings | undefined
 
 export function resolveAbortServerSideFallback(settings: RetrySettings | undefined): boolean {
 	return typeof settings?.abortServerSideFallback === "boolean" ? settings.abortServerSideFallback : true;
+}
+
+export const DEFAULT_HINTED_WAIT_CAP_MS = 300_000;
+export const DEFAULT_PROBE_BACK_MAX_MS = 3_600_000;
+
+export interface ResolvedHintPolicySettings {
+	hintedWaitCapMs: number;
+	probeBackMaxMs: number;
+}
+
+export function resolveHintPolicySettings(settings: RetrySettings | undefined): ResolvedHintPolicySettings {
+	const hintedWaitCapMs =
+		typeof settings?.hintedWaitCapMs === "number" && settings.hintedWaitCapMs >= 0
+			? settings.hintedWaitCapMs
+			: DEFAULT_HINTED_WAIT_CAP_MS;
+	const probeBackMaxMs =
+		typeof settings?.probeBackMaxMs === "number" && settings.probeBackMaxMs >= 0
+			? settings.probeBackMaxMs
+			: DEFAULT_PROBE_BACK_MAX_MS;
+
+	if (probeBackMaxMs <= hintedWaitCapMs) {
+		return { hintedWaitCapMs: DEFAULT_HINTED_WAIT_CAP_MS, probeBackMaxMs: DEFAULT_PROBE_BACK_MAX_MS };
+	}
+
+	return { hintedWaitCapMs, probeBackMaxMs };
 }

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -11,9 +11,11 @@ import { findNearestParentConfigDir } from "../nearest-parent-config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
 import { DEFAULT_HTTP_IDLE_TIMEOUT_MS, parseHttpIdleTimeoutMs } from "./http-dispatcher.ts";
 import {
+	type ResolvedHintPolicySettings,
 	type ResolvedRetryFallbackSettings,
 	type RetrySettings as RetrySettingsConfig,
 	resolveAbortServerSideFallback,
+	resolveHintPolicySettings,
 	resolveRetryFallbackSettings,
 } from "./retry-fallback/settings.ts";
 
@@ -1010,6 +1012,10 @@ export class SettingsManager {
 
 	getRetryFallbackSettings(): ResolvedRetryFallbackSettings {
 		return resolveRetryFallbackSettings(this.settings.retry);
+	}
+
+	getHintPolicySettings(): ResolvedHintPolicySettings {
+		return resolveHintPolicySettings(this.settings.retry);
 	}
 
 	setFallbackChain(key: string, entries: string[]): void {

--- a/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
+++ b/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
@@ -11,7 +11,7 @@ import { theme } from "../theme/theme.ts";
 import { CountdownTimer } from "./countdown-timer.ts";
 import { keyText } from "./keybinding-hints.ts";
 
-export type StatusIndicatorKind = "working" | "retry" | "compaction" | "branchSummary" | "probe";
+export type StatusIndicatorKind = "working" | "retry" | "compaction" | "branchSummary";
 
 export class StatusIndicator extends Loader {
 	readonly kind: StatusIndicatorKind;
@@ -141,18 +141,6 @@ export class CompactionStatusIndicator extends StatusIndicator {
 				? sliceByColumn(this.progressText, totalProgressWidth - progressWidth, progressWidth)
 				: this.progressText;
 		return [truncateToWidth(`${status} ${theme.fg("muted", progressTail)}`, width)];
-	}
-}
-
-export class ProbeStatusIndicator extends StatusIndicator {
-	constructor(ui: TUI, message: string) {
-		super(
-			"probe",
-			ui,
-			(spinner) => theme.fg("accent", spinner),
-			(text) => theme.fg("muted", text),
-			message,
-		);
 	}
 }
 

--- a/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
+++ b/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
@@ -11,7 +11,7 @@ import { theme } from "../theme/theme.ts";
 import { CountdownTimer } from "./countdown-timer.ts";
 import { keyText } from "./keybinding-hints.ts";
 
-export type StatusIndicatorKind = "working" | "retry" | "compaction" | "branchSummary";
+export type StatusIndicatorKind = "working" | "retry" | "compaction" | "branchSummary" | "probe";
 
 export class StatusIndicator extends Loader {
 	readonly kind: StatusIndicatorKind;
@@ -141,6 +141,18 @@ export class CompactionStatusIndicator extends StatusIndicator {
 				? sliceByColumn(this.progressText, totalProgressWidth - progressWidth, progressWidth)
 				: this.progressText;
 		return [truncateToWidth(`${status} ${theme.fg("muted", progressTail)}`, width)];
+	}
+}
+
+export class ProbeStatusIndicator extends StatusIndicator {
+	constructor(ui: TUI, message: string) {
+		super(
+			"probe",
+			ui,
+			(spinner) => theme.fg("accent", spinner),
+			(text) => theme.fg("muted", text),
+			message,
+		);
 	}
 }
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4128,6 +4128,12 @@ export class InteractiveMode {
 			case "retry_probe_result": {
 				if (event.ok) {
 					this.showStatus(`Recovered ${sanitizeTerminalLabel(event.selector)} - will restore on next turn`);
+				} else if (event.errorMessage === "auth-unavailable") {
+					this.showStatus(
+						`Probe for ${sanitizeTerminalLabel(event.selector)} skipped - auth unavailable, staying on fallback`,
+					);
+				} else {
+					this.showStatus(`Probe for ${sanitizeTerminalLabel(event.selector)} failed - staying on fallback`);
 				}
 				this.ui.requestRender();
 				break;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -162,7 +162,6 @@ import {
 	BranchSummaryStatusIndicator,
 	CompactionStatusIndicator,
 	IdleStatus,
-	ProbeStatusIndicator,
 	RetryStatusIndicator,
 	type StatusIndicator,
 	WorkingStatusIndicator,
@@ -4119,18 +4118,12 @@ export class InteractiveMode {
 
 			case "retry_probe_scheduled": {
 				const secondsAway = Math.max(0, Math.round((event.atMs - Date.now()) / 1000));
-				this.showStatusIndicator(
-					new ProbeStatusIndicator(
-						this.ui,
-						`Probing ${event.selector} at +${secondsAway}s (#${event.probeIndex})`,
-					),
-				);
+				this.showStatus(`Probing ${event.selector} at +${secondsAway}s (#${event.probeIndex})`);
 				this.ui.requestRender();
 				break;
 			}
 
 			case "retry_probe_result": {
-				this.clearStatusIndicator("probe");
 				if (event.ok) {
 					this.showStatus(`Recovered ${event.selector} - will restore on next turn`);
 				}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -162,6 +162,7 @@ import {
 	BranchSummaryStatusIndicator,
 	CompactionStatusIndicator,
 	IdleStatus,
+	ProbeStatusIndicator,
 	RetryStatusIndicator,
 	type StatusIndicator,
 	WorkingStatusIndicator,
@@ -4112,6 +4113,27 @@ export class InteractiveMode {
 
 			case "summarization_retry_finished": {
 				this.clearStatusIndicator("retry");
+				this.ui.requestRender();
+				break;
+			}
+
+			case "retry_probe_scheduled": {
+				const secondsAway = Math.max(0, Math.round((event.atMs - Date.now()) / 1000));
+				this.showStatusIndicator(
+					new ProbeStatusIndicator(
+						this.ui,
+						`Probing ${event.selector} at +${secondsAway}s (#${event.probeIndex})`,
+					),
+				);
+				this.ui.requestRender();
+				break;
+			}
+
+			case "retry_probe_result": {
+				this.clearStatusIndicator("probe");
+				if (event.ok) {
+					this.showStatus(`Recovered ${event.selector} - will restore on next turn`);
+				}
 				this.ui.requestRender();
 				break;
 			}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4118,14 +4118,16 @@ export class InteractiveMode {
 
 			case "retry_probe_scheduled": {
 				const secondsAway = Math.max(0, Math.round((event.atMs - Date.now()) / 1000));
-				this.showStatus(`Probing ${event.selector} at +${secondsAway}s (#${event.probeIndex})`);
+				this.showStatus(
+					`Probing ${sanitizeTerminalLabel(event.selector)} at +${secondsAway}s (#${event.probeIndex})`,
+				);
 				this.ui.requestRender();
 				break;
 			}
 
 			case "retry_probe_result": {
 				if (event.ok) {
-					this.showStatus(`Recovered ${event.selector} - will restore on next turn`);
+					this.showStatus(`Recovered ${sanitizeTerminalLabel(event.selector)} - will restore on next turn`);
 				}
 				this.ui.requestRender();
 				break;

--- a/packages/coding-agent/test/interactive-mode-fallback.test.ts
+++ b/packages/coding-agent/test/interactive-mode-fallback.test.ts
@@ -131,6 +131,53 @@ describe("InteractiveMode fallback lifecycle", () => {
 	});
 });
 
+it("renders a failure status line when retry_probe_result has ok === false", async () => {
+	const fixture = createFixture();
+	const now = vi.spyOn(Date, "now").mockReturnValue(1000);
+
+	try {
+		await handleEvent.call(fixture, {
+			type: "retry_probe_scheduled",
+			selector: "faux/faux-1",
+			atMs: 6000,
+			probeIndex: 2,
+		});
+		await handleEvent.call(fixture, {
+			type: "retry_probe_result",
+			selector: "faux/faux-1",
+			ok: false,
+		});
+		expect(fixture.showStatus).toHaveBeenLastCalledWith("Probe for faux/faux-1 failed - staying on fallback");
+	} finally {
+		now.mockRestore();
+	}
+});
+
+it("renders an auth-unavailable skip line when errorMessage is auth-unavailable", async () => {
+	const fixture = createFixture();
+	const now = vi.spyOn(Date, "now").mockReturnValue(1000);
+
+	try {
+		await handleEvent.call(fixture, {
+			type: "retry_probe_scheduled",
+			selector: "faux/faux-1",
+			atMs: 6000,
+			probeIndex: 2,
+		});
+		await handleEvent.call(fixture, {
+			type: "retry_probe_result",
+			selector: "faux/faux-1",
+			ok: false,
+			errorMessage: "auth-unavailable",
+		});
+		expect(fixture.showStatus).toHaveBeenLastCalledWith(
+			"Probe for faux/faux-1 skipped - auth unavailable, staying on fallback",
+		);
+	} finally {
+		now.mockRestore();
+	}
+});
+
 describe("shouldShowRetryIndicator", () => {
 	it("suppresses only zero-delay retries that immediately apply a fallback", () => {
 		expect(shouldShowRetryIndicator(0, true)).toBe(false);

--- a/packages/coding-agent/test/interactive-mode-fallback.test.ts
+++ b/packages/coding-agent/test/interactive-mode-fallback.test.ts
@@ -6,9 +6,13 @@ type FallbackLifecycleFixture = {
 	isInitialized: true;
 	footer: { invalidate: () => void };
 	fallbackAppliedBeforeRetryStart: boolean;
+	activeStatusIndicatorKind: string | undefined;
+	ui: { requestRender: () => void };
 	showWarning: (message: string) => void;
 	showStatus: (message: string) => void;
 	showError: (message: string) => void;
+	showStatusIndicator: (indicator: { kind: string }) => void;
+	clearStatusIndicator: (kind: string) => void;
 	setExtensionStatus: (key: string, text: string | undefined) => void;
 };
 
@@ -21,9 +25,17 @@ function createFixture(): FallbackLifecycleFixture {
 		isInitialized: true,
 		footer: { invalidate: vi.fn() },
 		fallbackAppliedBeforeRetryStart: false,
+		activeStatusIndicatorKind: "working",
+		ui: { requestRender: vi.fn() },
 		showWarning: vi.fn(),
 		showStatus: vi.fn(),
 		showError: vi.fn(),
+		showStatusIndicator(indicator): void {
+			this.activeStatusIndicatorKind = indicator.kind;
+		},
+		clearStatusIndicator(kind): void {
+			if (this.activeStatusIndicatorKind === kind) this.activeStatusIndicatorKind = undefined;
+		},
 		setExtensionStatus: vi.fn(),
 	};
 }
@@ -53,6 +65,32 @@ describe("InteractiveMode fallback lifecycle", () => {
 		expect(withoutChain.showWarning).toHaveBeenCalledWith(
 			"Server fallback claude-opus-5 -> claude-opus-4-6 aborted; no chain configured (set one with /fallback)",
 		);
+	});
+
+	it("keeps the working indicator active while rendering background probe events", async () => {
+		const fixture = createFixture();
+		const now = vi.spyOn(Date, "now").mockReturnValue(1000);
+
+		try {
+			await handleEvent.call(fixture, {
+				type: "retry_probe_scheduled",
+				selector: "faux/faux-1",
+				atMs: 6000,
+				probeIndex: 2,
+			});
+			expect(fixture.activeStatusIndicatorKind).toBe("working");
+			expect(fixture.showStatus).toHaveBeenCalledWith("Probing faux/faux-1 at +5s (#2)");
+
+			await handleEvent.call(fixture, {
+				type: "retry_probe_result",
+				selector: "faux/faux-1",
+				ok: true,
+			});
+			expect(fixture.activeStatusIndicatorKind).toBe("working");
+			expect(fixture.showStatus).toHaveBeenCalledWith("Recovered faux/faux-1 - will restore on next turn");
+		} finally {
+			now.mockRestore();
+		}
 	});
 
 	it("renders fallback notices and maintains the fallback footer status", async () => {

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CONFIG_DIR_NAME } from "../src/config.ts";
-import { DEFAULT_HINTED_WAIT_CAP_MS, DEFAULT_PROBE_BACK_MAX_MS } from "../src/core/retry-fallback/settings.ts";
+import {
+	DEFAULT_HINTED_WAIT_CAP_MS,
+	DEFAULT_PROBE_BACK_MAX_MS,
+	resolveHintPolicySettings,
+} from "../src/core/retry-fallback/settings.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
 
 const tempDirs: string[] = [];
@@ -140,7 +144,14 @@ describe("SettingsManager retry fallback settings", () => {
 		});
 	});
 
-	it("getHintPolicySettings falls back to defaults for malformed (string/NaN/negative)", () => {
+	it("file round-trip falls back to defaults for malformed (string/negative); resolver guard rejects NaN directly", () => {
+		// JSON.stringify(NaN) -> null, so the file round-trip cannot exercise the
+		// NaN guard in resolveHintPolicySettings. Test it directly:
+		expect(resolveHintPolicySettings({ hintedWaitCapMs: Number.NaN, probeBackMaxMs: Number.NaN })).toEqual({
+			hintedWaitCapMs: DEFAULT_HINTED_WAIT_CAP_MS,
+			probeBackMaxMs: DEFAULT_PROBE_BACK_MAX_MS,
+		});
+
 		const { agentDir, projectDir } = createPaths();
 		writeFileSync(
 			join(agentDir, "settings.json"),

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
 import { CONFIG_DIR_NAME } from "../src/config.ts";
+import { DEFAULT_HINTED_WAIT_CAP_MS, DEFAULT_PROBE_BACK_MAX_MS } from "../src/core/retry-fallback/settings.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
 
 const tempDirs: string[] = [];
@@ -117,5 +118,73 @@ describe("SettingsManager retry fallback settings", () => {
 			revertPolicy: "never",
 		});
 		expect(readFileSync(join(projectSettingsDir, "settings.json"), "utf-8")).toContain("anthropic/project");
+	});
+
+	it("getHintPolicySettings returns defaults when unset", () => {
+		const { agentDir, projectDir } = createPaths();
+		expect(SettingsManager.create(projectDir, agentDir).getHintPolicySettings()).toEqual({
+			hintedWaitCapMs: DEFAULT_HINTED_WAIT_CAP_MS,
+			probeBackMaxMs: DEFAULT_PROBE_BACK_MAX_MS,
+		});
+	});
+
+	it("getHintPolicySettings returns overridden values when valid", () => {
+		const { agentDir, projectDir } = createPaths();
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ retry: { hintedWaitCapMs: 120_000, probeBackMaxMs: 7_200_000 } }),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getHintPolicySettings()).toEqual({
+			hintedWaitCapMs: 120_000,
+			probeBackMaxMs: 7_200_000,
+		});
+	});
+
+	it("getHintPolicySettings falls back to defaults for malformed (string/NaN/negative)", () => {
+		const { agentDir, projectDir } = createPaths();
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				retry: { hintedWaitCapMs: "large", probeBackMaxMs: Number.NaN },
+			}),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getHintPolicySettings()).toEqual({
+			hintedWaitCapMs: DEFAULT_HINTED_WAIT_CAP_MS,
+			probeBackMaxMs: DEFAULT_PROBE_BACK_MAX_MS,
+		});
+
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				retry: { hintedWaitCapMs: -5, probeBackMaxMs: -1 },
+			}),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getHintPolicySettings()).toEqual({
+			hintedWaitCapMs: DEFAULT_HINTED_WAIT_CAP_MS,
+			probeBackMaxMs: DEFAULT_PROBE_BACK_MAX_MS,
+		});
+	});
+
+	it("getHintPolicySettings resets BOTH to defaults when probeBackMaxMs <= hintedWaitCapMs", () => {
+		const { agentDir, projectDir } = createPaths();
+		// equal values: probeBackMaxMs === hintedWaitCapMs -> both default
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ retry: { hintedWaitCapMs: 500_000, probeBackMaxMs: 500_000 } }),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getHintPolicySettings()).toEqual({
+			hintedWaitCapMs: DEFAULT_HINTED_WAIT_CAP_MS,
+			probeBackMaxMs: DEFAULT_PROBE_BACK_MAX_MS,
+		});
+
+		// probeBackMaxMs strictly less than hintedWaitCapMs -> both default
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ retry: { hintedWaitCapMs: 600_000, probeBackMaxMs: 300_000 } }),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getHintPolicySettings()).toEqual({
+			hintedWaitCapMs: DEFAULT_HINTED_WAIT_CAP_MS,
+			probeBackMaxMs: DEFAULT_PROBE_BACK_MAX_MS,
+		});
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -4,6 +4,10 @@ import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
 
+const probePrimary = "faux/faux-1";
+const probeFallback = "faux/faux-2";
+const hint1258ms = "HTTP 429: rate_limit_error (retry-after-ms: 1258)";
+
 function normalizeEventOrder(events: Harness["events"]): string[] {
 	const normalized: string[] = [];
 	for (const event of events) {
@@ -63,7 +67,9 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.session.isRetrying).toBe(false);
 	});
 
-	it("uses provider-supplied retry-after delay before retrying", async () => {
+	it("hinted 429 within tier1 cap uses half-hint as first probe delay", async () => {
+		// intentionally replaced by hint-aware tier routing (plan todo 6):
+		// hint 5ms <= 300_000 tier1 cap -> first auto_retry_start delayMs is ceil(5/2) = 3
 		const harness = await createHarness({ settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } } });
 		harnesses.push(harness);
 		let retryStartDelayMs: number | undefined;
@@ -87,7 +93,7 @@ describe("AgentSession retry and event characterization", () => {
 		const promptPromise = harness.session.prompt("test");
 		await sawRetryStart;
 
-		expect(retryStartDelayMs).toBe(5);
+		expect(retryStartDelayMs).toBe(3); // ceil(5/2) Tier-1 half-probe
 		expect(harness.faux.state.callCount).toBe(1);
 
 		await promptPromise;
@@ -96,7 +102,10 @@ describe("AgentSession retry and event characterization", () => {
 		expect(harness.session.isRetrying).toBe(false);
 	});
 
-	it("does not wait longer than the configured provider retry delay cap", async () => {
+	it("hinted 429 within tier1 cap waits in-turn past the legacy provider delay cap", async () => {
+		// intentionally replaced by hint-aware tier routing (plan todo 6):
+		// hint 75ms <= 300_000 tier1 cap -> in-turn retry with first probe ceil(75/2) = 38ms,
+		// the legacy provider.maxRetryDelayMs gate no longer applies to 429-class failures.
 		const harness = await createHarness({
 			settings: {
 				retry: { enabled: true, maxRetries: 3, baseDelayMs: 1, provider: { maxRetryDelayMs: 50 } },
@@ -108,14 +117,14 @@ describe("AgentSession retry and event characterization", () => {
 				stopReason: "error",
 				errorMessage: "rate_limit_exceeded: retry-after-ms: 75",
 			}),
-			fauxAssistantMessage("should not run"),
+			fauxAssistantMessage("recovered"),
 		]);
 
 		await harness.session.prompt("test");
 
-		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
-		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
-		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([38]); // ceil(75/2)
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([true]);
+		expect(harness.faux.state.callCount).toBe(2);
 		expect(harness.session.isRetrying).toBe(false);
 	});
 
@@ -524,6 +533,103 @@ describe("AgentSession retry and event characterization", () => {
 
 		expect(harness.eventsOfType("agent_end")).toHaveLength(1);
 		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_settled");
+	});
+
+	it("delivers retry_probe_scheduled to a subscribed listener with payload intact", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					hintedWaitCapMs: 8,
+					probeBackMaxMs: 3_600_000,
+					fallbackChains: { [probePrimary]: [probeFallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+
+		const probeEvents: Array<{ type: string; selector: string; atMs?: number; probeIndex?: number; ok?: boolean }> =
+			[];
+		harness.session.subscribe((event) => {
+			if (event.type === "retry_probe_scheduled") {
+				probeEvents.push({
+					type: event.type,
+					selector: event.selector,
+					atMs: event.atMs,
+					probeIndex: event.probeIndex,
+				});
+			}
+		});
+
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: hint1258ms }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		// retry_probe_scheduled must reach the subscriber with exact payload.
+		const scheduled = harness.eventsOfType("retry_probe_scheduled");
+		expect(scheduled.length).toBeGreaterThanOrEqual(1);
+		expect(scheduled[0]).toMatchObject({
+			type: "retry_probe_scheduled",
+			selector: probePrimary,
+			probeIndex: 1,
+		});
+		expect(typeof scheduled[0].atMs).toBe("number");
+		expect(probeEvents.length).toBeGreaterThanOrEqual(1);
+		expect(probeEvents[0]).toMatchObject({
+			type: "retry_probe_scheduled",
+			selector: probePrimary,
+			probeIndex: 1,
+		});
+	});
+
+	it("delivers retry_probe_result to a subscribed listener with payload intact", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					hintedWaitCapMs: 8,
+					probeBackMaxMs: 3_600_000,
+					fallbackChains: { [probePrimary]: [probeFallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+
+		const sawResult = new Promise<void>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type === "retry_probe_result") {
+					unsubscribe();
+					resolve();
+				}
+			});
+		});
+
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: hint1258ms }),
+			fauxAssistantMessage("fallback answer"),
+			fauxAssistantMessage("probe ok"),
+		]);
+
+		await harness.session.prompt("hello");
+		// Wait for the probe timer to fire and deliver a result event.
+		await sawResult;
+
+		const results = harness.eventsOfType("retry_probe_result");
+		expect(results.length).toBeGreaterThanOrEqual(1);
+		expect(results[0]).toMatchObject({
+			type: "retry_probe_result",
+			selector: probePrimary,
+		});
+		expect(typeof results[0].ok).toBe("boolean");
 	});
 
 	it("emits agent_end for aborted runs and persists the aborted assistant message", async () => {

--- a/packages/coding-agent/test/suite/retry-fallback-hint-policy.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hint-policy.test.ts
@@ -1,0 +1,436 @@
+import { describe, expect, it } from "vitest";
+import {
+	classifyRateLimitedWait,
+	nextInTurnDelayMs,
+	probeBackSchedule,
+} from "../../src/core/retry-fallback/hint-policy.ts";
+
+const CAP = 300_000;
+const PROBE_MAX = 3_600_000;
+const SETTINGS = { hintedWaitCapMs: CAP, probeBackMaxMs: PROBE_MAX };
+const BASE = 2_000;
+
+// ---------------------------------------------------------------------------
+// classifyRateLimitedWait
+// ---------------------------------------------------------------------------
+
+describe("classifyRateLimitedWait", () => {
+	it("returns no-hint-fast-fallback for undefined hint", () => {
+		expect(classifyRateLimitedWait(undefined, SETTINGS)).toBe("no-hint-fast-fallback");
+	});
+
+	it("returns tier1-in-turn for zero hint (explicit retry-now)", () => {
+		expect(classifyRateLimitedWait(0, SETTINGS)).toBe("tier1-in-turn");
+	});
+
+	it("returns tier1-in-turn just below the cap", () => {
+		expect(classifyRateLimitedWait(299_999, SETTINGS)).toBe("tier1-in-turn");
+	});
+
+	it("returns tier1-in-turn at the cap boundary (300_000)", () => {
+		expect(classifyRateLimitedWait(300_000, SETTINGS)).toBe("tier1-in-turn");
+	});
+
+	it("returns tier2-fallback-probe-back just above the cap", () => {
+		expect(classifyRateLimitedWait(300_001, SETTINGS)).toBe("tier2-fallback-probe-back");
+	});
+
+	it("returns tier2-fallback-probe-back just below probeBackMax", () => {
+		expect(classifyRateLimitedWait(3_599_999, SETTINGS)).toBe("tier2-fallback-probe-back");
+	});
+
+	it("returns tier3-fallback-only at the probeBackMax boundary (3_600_000)", () => {
+		expect(classifyRateLimitedWait(3_600_000, SETTINGS)).toBe("tier3-fallback-only");
+	});
+
+	it("returns tier3-fallback-only above the probeBackMax", () => {
+		expect(classifyRateLimitedWait(7_200_000, SETTINGS)).toBe("tier3-fallback-only");
+	});
+
+	it("honours custom settings boundaries", () => {
+		const s = { hintedWaitCapMs: 10_000, probeBackMaxMs: 60_000 };
+		expect(classifyRateLimitedWait(10_000, s)).toBe("tier1-in-turn");
+		expect(classifyRateLimitedWait(10_001, s)).toBe("tier2-fallback-probe-back");
+		expect(classifyRateLimitedWait(59_999, s)).toBe("tier2-fallback-probe-back");
+		expect(classifyRateLimitedWait(60_000, s)).toBe("tier3-fallback-only");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// probeBackSchedule
+// ---------------------------------------------------------------------------
+
+describe("probeBackSchedule", () => {
+	it("schedules first probe at ceil(hint/2) and deadline at now+hint", () => {
+		expect(probeBackSchedule(10_000, 1_000)).toEqual({ firstAtMs: 6_000, deadlineMs: 11_000 });
+	});
+
+	it("rounds up odd hint to next integer for first probe", () => {
+		expect(probeBackSchedule(7_001, 0)).toEqual({ firstAtMs: 3_501, deadlineMs: 7_001 });
+	});
+
+	it("handles zero hint (both probes at now)", () => {
+		expect(probeBackSchedule(0, 5_000)).toEqual({ firstAtMs: 5_000, deadlineMs: 5_000 });
+	});
+
+	it("handles large hint", () => {
+		expect(probeBackSchedule(3_600_000, 0)).toEqual({ firstAtMs: 1_800_000, deadlineMs: 3_600_000 });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// nextInTurnDelayMs — transition table
+// ---------------------------------------------------------------------------
+
+describe("nextInTurnDelayMs", () => {
+	// --- first hinted 429 (idle -> half-used) ---
+
+	it("first hinted 429: probePhase half-used, delay = ceil(hint/2), deadline = now+hint", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 0 },
+			120_000,
+			BASE,
+			CAP,
+			1_000,
+		);
+		expect(result).toEqual({
+			delayMs: 60_000,
+			probePhase: "half-used",
+			hintDeadlineMs: 121_000,
+			cumulativeHintedWaitMs: 60_000,
+			demoteToProbeBack: false,
+		});
+	});
+
+	it("first hinted 429 with odd hint: ceil rounds up", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 0 },
+			7_001,
+			BASE,
+			CAP,
+			0,
+		);
+		expect(result.delayMs).toBe(3_501);
+		expect(result.probePhase).toBe("half-used");
+		expect(result.hintDeadlineMs).toBe(7_001);
+	});
+
+	it("first hinted 429 with explicit zero: immediate, half-used", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 0 },
+			0,
+			BASE,
+			CAP,
+			5_000,
+		);
+		expect(result.delayMs).toBe(0);
+		expect(result.probePhase).toBe("half-used");
+		expect(result.hintDeadlineMs).toBe(5_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	// --- consecutive 429 after half-used (deadline sleep) ---
+
+	it("consecutive unhinted 429 after half: sleep remaining to prior deadline, then done", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 61_000, attempt: 2, cumulativeHintedWaitMs: 60_000 },
+			undefined,
+			BASE,
+			CAP,
+			61_000,
+		);
+		// no new hint -> keep deadline 61000; remaining = max(0, 61000 - 61000) = 0
+		expect(result.delayMs).toBe(0);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(61_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	it("consecutive unhinted 429 after half with time remaining: sleep to prior deadline", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 100_000, attempt: 2, cumulativeHintedWaitMs: 50_000 },
+			undefined,
+			BASE,
+			CAP,
+			30_000,
+		);
+		// no new hint -> keep deadline 100000; remaining = max(0, 100000 - 30000) = 70000
+		expect(result.delayMs).toBe(70_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(100_000);
+		expect(result.cumulativeHintedWaitMs).toBe(120_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	it("consecutive hinted 429 after half: new hint supersedes deadline", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 100_000, attempt: 2, cumulativeHintedWaitMs: 50_000 },
+			80_000,
+			BASE,
+			CAP,
+			30_000,
+		);
+		// new deadline = 30000 + 80000 = 110000; remaining = 110000 - 30000 = 80000
+		expect(result.delayMs).toBe(80_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(110_000);
+		expect(result.cumulativeHintedWaitMs).toBe(130_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	// --- growing hint after half (deadline moves later) ---
+
+	it("growing hint after half: new deadline supersedes old", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 100_000, attempt: 2, cumulativeHintedWaitMs: 50_000 },
+			200_000,
+			BASE,
+			CAP,
+			50_000,
+		);
+		// new deadline = 50000 + 200000 = 250000; remaining = 250000 - 50000 = 200000
+		expect(result.delayMs).toBe(200_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(250_000);
+		expect(result.cumulativeHintedWaitMs).toBe(250_000);
+	});
+
+	// --- shrinking hint after half (deadline moves earlier) ---
+
+	it("shrinking hint after half: new earlier deadline supersedes", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 500_000, attempt: 2, cumulativeHintedWaitMs: 250_000 },
+			100_000,
+			BASE,
+			CAP,
+			250_000,
+		);
+		// new deadline = 250000 + 100000 = 350000; remaining = max(0, 350000 - 250000) = 100000
+		expect(result.delayMs).toBe(100_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(350_000);
+		expect(result.cumulativeHintedWaitMs).toBe(350_000);
+	});
+
+	it("shrinking hint with new deadline already in the past: clamped to 0", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 500_000, attempt: 2, cumulativeHintedWaitMs: 300_000 },
+			10_000,
+			BASE,
+			CAP,
+			320_000,
+		);
+		// new deadline = 320000 + 10000 = 330000; remaining = max(0, 330000 - 320000) = 10000
+		expect(result.delayMs).toBe(10_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(330_000);
+	});
+
+	// --- explicit zero after half ---
+
+	it("explicit zero after half: immediate, done", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 100_000, attempt: 2, cumulativeHintedWaitMs: 50_000 },
+			0,
+			BASE,
+			CAP,
+			60_000,
+		);
+		// new deadline = 60000 + 0 = 60000; remaining = max(0, 60000 - 60000) = 0
+		expect(result.delayMs).toBe(0);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(60_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	// --- unhinted 429 after half (keeps prior deadline) ---
+
+	it("unhinted 429 after half: keeps prior deadline, sleeps remaining", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 100_000, attempt: 2, cumulativeHintedWaitMs: 50_000 },
+			undefined,
+			BASE,
+			CAP,
+			60_000,
+		);
+		// no new hint -> keep deadline 100000; remaining = max(0, 100000 - 60000) = 40000
+		expect(result.delayMs).toBe(40_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.hintDeadlineMs).toBe(100_000);
+		expect(result.cumulativeHintedWaitMs).toBe(90_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	// --- non-429 after half (probePhase done -> exponential) ---
+
+	it("non-429 after half (probePhase done, no hint): exponential backoff", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "done", hintDeadlineMs: 100_000, attempt: 3, cumulativeHintedWaitMs: 50_000 },
+			undefined,
+			BASE,
+			CAP,
+			60_000,
+		);
+		// 2000 * 2^(3-1) = 8000
+		expect(result.delayMs).toBe(8_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	// --- after done: exponential with hint override ---
+
+	it("after done with fresh hint: hint overrides exponential", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 3, cumulativeHintedWaitMs: 120_000 },
+			5_000,
+			BASE,
+			CAP,
+			200_000,
+		);
+		expect(result.delayMs).toBe(5_000);
+		expect(result.probePhase).toBe("done");
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	it("after done without hint: exponential 2^(attempt-1)", () => {
+		const r2 = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 2, cumulativeHintedWaitMs: 120_000 },
+			undefined,
+			BASE,
+			CAP,
+			200_000,
+		);
+		expect(r2.delayMs).toBe(4_000); // 2000 * 2^1
+	});
+
+	it("after done without hint: attempt 4 exponential", () => {
+		const r4 = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 4, cumulativeHintedWaitMs: 120_000 },
+			undefined,
+			BASE,
+			CAP,
+			200_000,
+		);
+		expect(r4.delayMs).toBe(16_000); // 2000 * 2^3
+	});
+
+	it("exponent never restarts: done at attempt 3 then 4", () => {
+		const r3 = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 3, cumulativeHintedWaitMs: 100_000 },
+			undefined,
+			BASE,
+			CAP,
+			200_000,
+		);
+		expect(r3.delayMs).toBe(8_000); // 2000 * 2^2
+
+		const r4 = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 4, cumulativeHintedWaitMs: 100_000 },
+			undefined,
+			BASE,
+			CAP,
+			200_000,
+		);
+		expect(r4.delayMs).toBe(16_000); // 2000 * 2^3
+	});
+
+	// --- demotion at cumulative cap ---
+
+	it("demotes to probe-back when cumulative + delay exceeds cap", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 290_000 },
+			120_000,
+			BASE,
+			CAP,
+			1_000,
+		);
+		// delay = ceil(120000/2) = 60000; cumulative = 290000 + 60000 = 350000 > 300000
+		expect(result.delayMs).toBe(60_000);
+		expect(result.cumulativeHintedWaitMs).toBe(350_000);
+		expect(result.demoteToProbeBack).toBe(true);
+	});
+
+	it("does NOT demote when cumulative + delay equals cap exactly", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 240_000 },
+			120_000,
+			BASE,
+			CAP,
+			1_000,
+		);
+		// delay = 60000; cumulative = 240000 + 60000 = 300000 = cap (not >)
+		expect(result.delayMs).toBe(60_000);
+		expect(result.cumulativeHintedWaitMs).toBe(300_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	it("demotes on unhinted deadline sleep that pushes cumulative over cap", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 100_000, attempt: 2, cumulativeHintedWaitMs: 250_001 },
+			undefined,
+			BASE,
+			CAP,
+			50_000,
+		);
+		// keep deadline 100000; remaining = max(0, 100000 - 50000) = 50000; cumulative = 250001 + 50000 = 300001 > 300000
+		expect(result.delayMs).toBe(50_000);
+		expect(result.demoteToProbeBack).toBe(true);
+	});
+
+	it("does not demote on exponential (non-hinted) path even over cap", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 5, cumulativeHintedWaitMs: 299_000 },
+			undefined,
+			BASE,
+			CAP,
+			500_000,
+		);
+		// 2000 * 2^4 = 32000; exponential path, no demotion
+		expect(result.delayMs).toBe(32_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	// --- boundary hints ---
+
+	it("boundary: hint exactly at cap (300_000), first probe at half", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 0 },
+			300_000,
+			BASE,
+			CAP,
+			0,
+		);
+		expect(result.delayMs).toBe(150_000);
+		expect(result.probePhase).toBe("half-used");
+		expect(result.hintDeadlineMs).toBe(300_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	it("boundary: hint at cap, second unhinted probe, cumulative exactly at cap -> no demote", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 300_000, attempt: 2, cumulativeHintedWaitMs: 150_000 },
+			undefined,
+			BASE,
+			CAP,
+			150_000,
+		);
+		// keep deadline 300000; remaining = max(0, 300000 - 150000) = 150000; cumulative = 150000 + 150000 = 300000 = cap
+		expect(result.delayMs).toBe(150_000);
+		expect(result.cumulativeHintedWaitMs).toBe(300_000);
+		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	it("boundary: hint at cap, second unhinted probe, cumulative over cap -> demote", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 300_000, attempt: 2, cumulativeHintedWaitMs: 150_001 },
+			undefined,
+			BASE,
+			CAP,
+			150_000,
+		);
+		// remaining = 150000; cumulative = 150001 + 150000 = 300001 > 300000
+		expect(result.delayMs).toBe(150_000);
+		expect(result.cumulativeHintedWaitMs).toBe(300_001);
+		expect(result.demoteToProbeBack).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-hint-tiers.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hint-tiers.test.ts
@@ -233,4 +233,39 @@ describe("hint-aware 429 tier routing", () => {
 		expect(harness.eventsOfType("auto_retry_end").map((e) => e.success)).toEqual([true]);
 		expect(harness.faux.state.callCount).toBe(2);
 	});
+
+	// (7) Tier-2 fallback arms the probe scheduler (retry_probe_scheduled emitted with probeIndex 1).
+	it("tier2 fallback emits retry_probe_scheduled with probeIndex 1", async () => {
+		const now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(hint1258s), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+
+		// Fallback was applied (tier2).
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+
+		// Probe scheduler was armed — retry_probe_scheduled emitted with probeIndex 1.
+		const scheduled = harness.eventsOfType("retry_probe_scheduled");
+		expect(scheduled.length).toBeGreaterThanOrEqual(1);
+		expect(scheduled[0]).toMatchObject({
+			selector: primary,
+			probeIndex: 1,
+		});
+		expect(scheduled[0].atMs).toBeGreaterThan(now);
+	});
 });

--- a/packages/coding-agent/test/suite/retry-fallback-hint-tiers.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hint-tiers.test.ts
@@ -1,0 +1,236 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+// Error fixtures that are BOTH retryable (isRetryableAssistantError passes)
+// AND carry rate-limit markers so the 429-class check fires.
+const noHint429 = "HTTP 429: rate_limit_exceeded - All tokens rate limited";
+const hint4ms = "HTTP 429: rate_limit_error (retry-after-ms: 4)";
+const hint8ms = "HTTP 429: rate_limit_error (retry-after-ms: 8)";
+const hint1258s = "HTTP 429: rate_limit_error (retry-after-ms: 1258000)";
+const hint3600s = "HTTP 429: rate_limit_error (retry-after-ms: 3600000)";
+// Non-429 transient — keeps today's exponential behavior.
+const transient500 = "HTTP 500: internal_error";
+
+function errorTurn(errorMessage: string) {
+	return fauxAssistantMessage("", { stopReason: "error", errorMessage });
+}
+
+describe("hint-aware 429 tier routing", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length) harnesses.pop()?.cleanup();
+	});
+
+	// (1) No-hint 429 -> fallback on FIRST failure, zero same-model retries.
+	it("no-hint 429 falls back immediately with zero same-model retries", async () => {
+		const now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(noHint429), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+
+		// Primary was called exactly once (zero same-model retries).
+		const primaryCalls = harness.faux.getCallLog().filter((c) => c.modelId === "faux-1").length;
+		expect(primaryCalls).toBe(1);
+		// Fallback was applied immediately.
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+		// The fallback's retry sleep has delayMs 0 (fresh model, switchedFallback).
+		expect(harness.eventsOfType("auto_retry_start").map((e) => e.delayMs)).toEqual([0]);
+		expect(harness.eventsOfType("auto_retry_end").map((e) => e.success)).toEqual([true]);
+	});
+
+	// (2) Hint 4ms -> two same-model waits (2ms half-probe, then 4ms fresh-hint deadline), then success.
+	it("hint stays in-turn with half-then-deadline waits", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+
+		// Two 429 errors with 4ms hint, then success on third call.
+		harness.setResponses([errorTurn(hint4ms), errorTurn(hint4ms), fauxAssistantMessage("primary recovered")]);
+
+		// Track time via the auto_retry_start event to advance fallbackNow.
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && event.delayMs > 0) now += event.delayMs;
+		});
+
+		await harness.session.prompt("hello");
+
+		// No fallback should have been applied — stayed on same model.
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		// Two retry starts: first = ceil(4/2)=2 (half probe), second = 4 (fresh hint
+		// creates a new deadline; the latest hint supersedes per the state machine).
+		const delays = harness.eventsOfType("auto_retry_start").map((e) => e.delayMs);
+		expect(delays).toEqual([2, 4]);
+		expect(harness.eventsOfType("auto_retry_end").map((e) => e.success)).toEqual([true]);
+		// Primary was called 3 times (two errors + one success).
+		const primaryCalls = harness.faux.getCallLog().filter((c) => c.modelId === "faux-1").length;
+		expect(primaryCalls).toBe(3);
+	});
+
+	// (3) Cumulative hinted wait > cap demotes to tier2 fallback path.
+	// hint 8ms, cap 8ms (tier1 since 8 <= 8).
+	// First: delay = ceil(8/2) = 4, cumulative = 4 (< 8, tier1 continues)
+	// Second: fresh hint 8ms -> new deadline, remaining = 8, cumulative = 4+8 = 12 (> 8, demote!)
+	it("cumulative hinted wait exceeding cap demotes to fallback", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					hintedWaitCapMs: 8,
+					probeBackMaxMs: 3_600_000,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+
+		harness.setResponses([errorTurn(hint8ms), errorTurn(hint8ms), fauxAssistantMessage("fallback answer")]);
+
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && event.delayMs > 0) now += event.delayMs;
+		});
+
+		await harness.session.prompt("hello");
+
+		// Fallback was applied on the second 429 (demotion from tier1).
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+		// First retry was on primary (delay 4ms = ceil(8/2)), then fallback (delay 0).
+		const starts = harness.eventsOfType("auto_retry_start").map((e) => e.delayMs);
+		expect(starts[0]).toBe(4);
+		expect(starts[1]).toBe(0);
+		expect(harness.eventsOfType("auto_retry_end").map((e) => e.success)).toEqual([true]);
+	});
+
+	// (4) Hint 1_258_000ms -> immediate fallback on first failure, cooldown has remaining hint.
+	it("hint 1258s falls back immediately (tier2) with remaining hint in cooldown", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(hint1258s), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+
+		// Immediate fallback on first failure.
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+		// Primary called exactly once.
+		const primaryCalls = harness.faux.getCallLog().filter((c) => c.modelId === "faux-1").length;
+		expect(primaryCalls).toBe(1);
+		// Fallback's retry sleep has delayMs 0 (switchedFallback).
+		expect(harness.eventsOfType("auto_retry_start").map((e) => e.delayMs)).toEqual([0]);
+		expect(harness.eventsOfType("auto_retry_end").map((e) => e.success)).toEqual([true]);
+
+		// The primary should be suppressed (cooldown with remaining hint = 1_258_000ms).
+		// Advance time past the 30s default rate-limit cooldown but NOT past 1_258_000ms.
+		now += 60_000;
+		await harness.session.prompt("again");
+		// Primary should NOT have reverted — cooldown is 1_258_000ms.
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+	});
+
+	// (5) Hint >= 3_600_000ms -> fallback, no probe arm (tier3).
+	it("hint >= 3600s falls back immediately (tier3) with no probe scheduled", async () => {
+		const now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(hint3600s), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+
+		// Immediate fallback on first failure.
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+		expect(harness.eventsOfType("auto_retry_start").map((e) => e.delayMs)).toEqual([0]);
+		expect(harness.eventsOfType("auto_retry_end").map((e) => e.success)).toEqual([true]);
+		// Primary called exactly once.
+		const primaryCalls = harness.faux.getCallLog().filter((c) => c.modelId === "faux-1").length;
+		expect(primaryCalls).toBe(1);
+	});
+
+	// (6) Non-429 500 keeps today's exponential behavior (characterization).
+	it("non-429 500 uses exponential backoff unchanged", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1000,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(transient500), fauxAssistantMessage("primary recovered")]);
+
+		await harness.session.prompt("hello");
+
+		// No fallback — exponential retry on same model.
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		// First retry delay = baseDelayMs * 2^0 = 1000.
+		expect(harness.eventsOfType("auto_retry_start").map((e) => e.delayMs)).toEqual([1000]);
+		expect(harness.eventsOfType("auto_retry_end").map((e) => e.success)).toEqual([true]);
+		expect(harness.faux.state.callCount).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-hint-tiers.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hint-tiers.test.ts
@@ -234,6 +234,80 @@ describe("hint-aware 429 tier routing", () => {
 		expect(harness.faux.state.callCount).toBe(2);
 	});
 
+	it("does not tier-route a transient error with 429 only inside a request id", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1000,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			errorTurn("request req_429429429 failed with HTTP 500 socket timeout"),
+			fauxAssistantMessage("primary recovered"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([1000]);
+		expect(harness.faux.getCallLog().filter((call) => call.modelId === "faux-1")).toHaveLength(2);
+	});
+
+	it("tier-routes an HTTP 429 rate limit control", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1000,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([errorTurn("HTTP 429 rate limit"), fauxAssistantMessage("fallback recovered")]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([0]);
+		expect(harness.faux.getCallLog().filter((call) => call.modelId === "faux-1")).toHaveLength(1);
+	});
+
+	it("uses exponential backoff for a non-429 transient with an explicit zero hint", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1000,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			errorTurn("HTTP 500 internal_error (retry-after-ms: 0)"),
+			fauxAssistantMessage("primary recovered"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([1000]);
+		expect(harness.faux.getCallLog().filter((call) => call.modelId === "faux-1")).toHaveLength(2);
+	});
+
 	// (7) Tier-2 fallback arms the probe scheduler (retry_probe_scheduled emitted with probeIndex 1).
 	it("tier2 fallback emits retry_probe_scheduled with probeIndex 1", async () => {
 		const now = 0;

--- a/packages/coding-agent/test/suite/retry-fallback-long-delay.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-long-delay.test.ts
@@ -80,7 +80,11 @@ describe("retry fallback for over-threshold provider delays", () => {
 		expect(harness.eventsOfType("retry_fallback_exhausted")).toEqual([]);
 		const ends = harness.eventsOfType("auto_retry_end");
 		expect(ends.map((event) => event.success)).toEqual([false]);
-		expect(ends[0]?.finalError).toContain("exceeding configured maximum");
+		// intentionally replaced by hint-aware tier routing (plan todo 6):
+		// overThreshold (3600s hint) classifies as tier3-fallback-only, so the
+		// finalError is the original error message, not the legacy
+		// "exceeding configured maximum" text from the over-budget gate.
+		expect(ends[0]?.finalError).toContain("rate_limit_exceeded");
 		expect(harness.faux.state.callCount).toBe(1);
 	});
 
@@ -97,7 +101,10 @@ describe("retry fallback for over-threshold provider delays", () => {
 		await harness.session.prompt("hello");
 
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
-		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([5]);
+		// intentionally replaced by hint-aware tier routing (plan todo 6):
+		// underThreshold (5ms hint) classifies as tier1-in-turn, so the first
+		// probe delay is ceil(hint/2) = ceil(5/2) = 3, not the full hint.
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([3]);
 		expect(harness.faux.state.callCount).toBe(2);
 	});
 

--- a/packages/coding-agent/test/suite/retry-fallback-probe-scheduler.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-probe-scheduler.test.ts
@@ -376,6 +376,68 @@ describe("ProbeBackScheduler", () => {
 		expect(scheduler.active).toBe(false);
 	});
 
+	it("arm during in-flight probe swallows the old result and preserves cancellation", async () => {
+		const now = 0;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		let resolveOldProbe: ((value: boolean) => void) | undefined;
+		let resolveNewProbe: ((value: boolean) => void) | undefined;
+		const { input: oldInput, onClearedCalls: oldOnClearedCalls } = defaultInput(capture, {
+			selector: "faux/faux-1",
+			runProbe: () =>
+				new Promise<boolean>((resolve) => {
+					resolveOldProbe = resolve;
+				}),
+		});
+		const { input: newInput } = defaultInput(capture, {
+			selector: "faux/faux-2",
+			firstAtMs: 300,
+			deadlineMs: 600,
+			runProbe: () =>
+				new Promise<boolean>((resolve) => {
+					resolveNewProbe = resolve;
+				}),
+		});
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(oldInput);
+		th.fireFirst();
+		await vi.waitFor(() => expect(capture.runProbeCalls).toHaveLength(1));
+
+		scheduler.arm(newInput);
+		resolveOldProbe?.(true);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(oldOnClearedCalls).toEqual([]);
+		expect(capture.events.filter((event) => event.type === "retry_probe_result")).toEqual([]);
+		expect(scheduler.active).toBe(true);
+		expect(th.pendingCount()).toBe(1);
+
+		th.fireFirst();
+		await vi.waitFor(() => expect(capture.runProbeCalls).toHaveLength(2));
+		resolveNewProbe?.(false);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_scheduled",
+			selector: "faux/faux-2",
+			atMs: 600,
+			probeIndex: 2,
+		});
+		expect(th.pendingCount()).toBe(1);
+
+		scheduler.cancel("dispose");
+		expect(th.pendingCount()).toBe(0);
+		th.fireAll();
+		expect(capture.runProbeCalls).toHaveLength(2);
+	});
+
 	// (7) Second probe (at deadline) succeeds -> onCleared + ok:true.
 	it("second probe at deadline succeeds and clears cooldown", async () => {
 		const now = 0;

--- a/packages/coding-agent/test/suite/retry-fallback-probe-scheduler.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-probe-scheduler.test.ts
@@ -1,0 +1,429 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ProbeBackEvent, ProbeBackScheduler } from "../../src/core/retry-fallback/probe-scheduler.ts";
+
+// Controllable timer harness: captures setTimeout callbacks so tests can fire
+// them deterministically without real waits.
+interface TimerEntry {
+	callback: () => void;
+	delay: number;
+	id: number;
+	fired: boolean;
+}
+
+function createTimerHarness() {
+	let nextId = 1;
+	const timers = new Map<number, TimerEntry>();
+
+	const fakeSetTimeout = (callback: () => void, delay: number): unknown => {
+		const id = nextId++;
+		timers.set(id, { callback, delay, id, fired: false });
+		return id;
+	};
+
+	const fakeClearTimeout = (handle: unknown): void => {
+		timers.delete(handle as number);
+	};
+
+	return {
+		setTimeout: fakeSetTimeout,
+		clearTimeout: fakeClearTimeout,
+		/** Fire the first pending (un-fired, non-cleared) timer. */
+		fireFirst(): void {
+			for (const entry of timers.values()) {
+				if (!entry.fired) {
+					entry.fired = true;
+					timers.delete(entry.id);
+					entry.callback();
+					return;
+				}
+			}
+			throw new Error("No pending timer to fire");
+		},
+		/** Count pending (non-fired, non-cleared) timers. */
+		pendingCount(): number {
+			let count = 0;
+			for (const entry of timers.values()) {
+				if (!entry.fired) count++;
+			}
+			return count;
+		},
+		/** Fire all pending timers in order. */
+		fireAll(): void {
+			const pending = [...timers.values()].filter((e) => !e.fired).sort((a, b) => a.id - b.id);
+			for (const entry of pending) {
+				entry.fired = true;
+				timers.delete(entry.id);
+				entry.callback();
+			}
+		},
+		/** Check if a specific timer handle is still pending (not cleared, not fired). */
+		isPending(handle: unknown): boolean {
+			const entry = timers.get(handle as number);
+			return entry !== undefined && !entry.fired;
+		},
+	};
+}
+
+function createCapture() {
+	const events: ProbeBackEvent[] = [];
+	const runProbeCalls: AbortSignal[] = [];
+	return {
+		events,
+		runProbeCalls,
+		emit(event: ProbeBackEvent): void {
+			events.push(event);
+		},
+		reset(): void {
+			events.length = 0;
+			runProbeCalls.length = 0;
+		},
+	};
+}
+
+function defaultInput(
+	capture: ReturnType<typeof createCapture>,
+	opts: {
+		selector?: string;
+		firstAtMs?: number;
+		deadlineMs?: number;
+		authAvailable?: () => boolean;
+		runProbe?: (signal: AbortSignal) => Promise<boolean>;
+		onCleared?: (selector: string) => void;
+	},
+) {
+	const onClearedCalls: string[] = [];
+	const userRunProbe = opts.runProbe;
+	return {
+		onClearedCalls,
+		input: {
+			selector: opts.selector ?? "faux/faux-1",
+			firstAtMs: opts.firstAtMs ?? 500,
+			deadlineMs: opts.deadlineMs ?? 1000,
+			authAvailable: opts.authAvailable ?? (() => true),
+			runProbe: async (signal: AbortSignal) => {
+				capture.runProbeCalls.push(signal);
+				return userRunProbe ? userRunProbe(signal) : false;
+			},
+			onCleared:
+				opts.onCleared ??
+				((selector: string) => {
+					onClearedCalls.push(selector);
+				}),
+			emit: capture.emit,
+		},
+	};
+}
+
+describe("ProbeBackScheduler", () => {
+	const harnesses: Array<ReturnType<typeof createTimerHarness>> = [];
+
+	afterEach(() => {
+		while (harnesses.length) harnesses.pop();
+		vi.useRealTimers();
+	});
+
+	// (1) arm -> first probe fires, failure -> second at deadline, failure ->
+	// exactly 2 runProbe calls, result ok:false emitted.
+	it("fires two probes on consecutive failures and emits ok:false", async () => {
+		const now = 0;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		const { input } = defaultInput(capture, { firstAtMs: 500, deadlineMs: 1000 });
+
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		expect(scheduler.active).toBe(false);
+		scheduler.arm(input);
+		expect(scheduler.active).toBe(true);
+
+		// Probe 1 scheduled event emitted.
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_scheduled",
+			selector: "faux/faux-1",
+			atMs: 500,
+			probeIndex: 1,
+		});
+
+		// Fire first timer -> probe 1 runs (returns false).
+		th.fireFirst();
+		// Wait for the async runProbe to settle.
+		await vi.waitFor(() => expect(capture.runProbeCalls.length).toBe(1));
+
+		// Probe 2 scheduled event emitted.
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_scheduled",
+			selector: "faux/faux-1",
+			atMs: 1000,
+			probeIndex: 2,
+		});
+
+		// Fire second timer -> probe 2 runs (returns false).
+		th.fireFirst();
+		await vi.waitFor(() => expect(capture.runProbeCalls.length).toBe(2));
+
+		// Final result: ok:false, exactly 2 probes.
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_result",
+			selector: "faux/faux-1",
+			ok: false,
+		});
+		expect(capture.runProbeCalls.length).toBe(2);
+		expect(scheduler.active).toBe(false);
+	});
+
+	// (2) First probe success -> onCleared called, ok:true emitted, NO second probe.
+	it("clears cooldown and emits ok:true on first probe success", async () => {
+		const now = 0;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		const { input, onClearedCalls } = defaultInput(capture, {
+			firstAtMs: 500,
+			deadlineMs: 1000,
+			runProbe: async () => true, // succeeds
+		});
+
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(input);
+		expect(th.pendingCount()).toBe(1);
+
+		th.fireFirst();
+		await vi.waitFor(() => expect(capture.events.some((e) => e.type === "retry_probe_result" && e.ok)).toBe(true));
+
+		expect(onClearedCalls).toEqual(["faux/faux-1"]);
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_result",
+			selector: "faux/faux-1",
+			ok: true,
+		});
+
+		// No second probe scheduled.
+		expect(capture.events.filter((e) => e.type === "retry_probe_scheduled")).toHaveLength(1);
+		expect(capture.runProbeCalls.length).toBe(1);
+		expect(th.pendingCount()).toBe(0);
+		expect(scheduler.active).toBe(false);
+	});
+
+	// (3) cancel("dispose") mid-wait -> zero probes fire.
+	it("cancel prevents all probe execution when called before first timer fires", async () => {
+		const now = 0;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		const { input } = defaultInput(capture, { firstAtMs: 500, deadlineMs: 1000 });
+
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(input);
+		expect(th.pendingCount()).toBe(1);
+
+		// Cancel before any timer fires.
+		scheduler.cancel("dispose");
+
+		expect(scheduler.active).toBe(false);
+		expect(th.pendingCount()).toBe(0);
+		expect(capture.runProbeCalls.length).toBe(0);
+
+		// The scheduled event was emitted at arm time, but NO result event.
+		expect(capture.events.filter((e) => e.type === "retry_probe_result")).toEqual([]);
+	});
+
+	// (4) arm while armed supersedes (old timers never fire).
+	it("second arm supersedes the first; old timers never fire", async () => {
+		const now = 0;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		const { input: input1 } = defaultInput(capture, {
+			selector: "faux/faux-1",
+			firstAtMs: 500,
+			deadlineMs: 1000,
+		});
+		const { input: input2, onClearedCalls: onCleared2 } = defaultInput(capture, {
+			selector: "faux/faux-2",
+			firstAtMs: 300,
+			deadlineMs: 600,
+			runProbe: async () => true,
+		});
+
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(input1);
+		expect(th.pendingCount()).toBe(1);
+
+		// Supersede with a second arm.
+		scheduler.arm(input2);
+		expect(scheduler.active).toBe(true);
+		expect(th.pendingCount()).toBe(1); // only the new timer
+
+		// Fire the new timer -> probe for faux-2 runs, succeeds.
+		th.fireFirst();
+		await vi.waitFor(() => expect(onCleared2.length).toBe(1));
+
+		expect(onCleared2).toEqual(["faux/faux-2"]);
+		expect(capture.runProbeCalls.length).toBe(1); // only one probe ran (the second arm's)
+
+		// No result event for faux-1.
+		expect(capture.events.filter((e) => e.type === "retry_probe_result" && e.selector === "faux/faux-1")).toEqual([]);
+		expect(scheduler.active).toBe(false);
+	});
+
+	// (5) Auth unavailable at firstAtMs -> ok:false auth-unavailable, disarm.
+	it("emits auth-unavailable result when auth is not available at probe time", async () => {
+		const now = 0;
+		let authOk = true;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		const { input } = defaultInput(capture, {
+			firstAtMs: 500,
+			deadlineMs: 1000,
+			authAvailable: () => authOk,
+		});
+
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(input);
+
+		// Auth becomes unavailable before the first probe fires.
+		authOk = false;
+
+		th.fireFirst();
+		await vi.waitFor(() => expect(capture.events.some((e) => e.type === "retry_probe_result")).toBe(true));
+
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_result",
+			selector: "faux/faux-1",
+			ok: false,
+			errorMessage: "auth-unavailable",
+		});
+		expect(capture.runProbeCalls.length).toBe(0); // probe body never ran
+		expect(th.pendingCount()).toBe(0); // no second timer scheduled
+		expect(scheduler.active).toBe(false);
+	});
+
+	// (6) cancel mid-in-flight probe: probe result after cancel must not clear cooldown.
+	it("stale probe result after cancel does not call onCleared", async () => {
+		const now = 0;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		let resolveProbe: ((value: boolean) => void) | undefined;
+		const onClearedCalls: string[] = [];
+		const input = {
+			selector: "faux/faux-1",
+			firstAtMs: 500,
+			deadlineMs: 1000,
+			authAvailable: () => true,
+			runProbe: (_signal: AbortSignal) => {
+				capture.runProbeCalls.push(_signal);
+				return new Promise<boolean>((resolve) => {
+					resolveProbe = resolve;
+				});
+			},
+			onCleared: (selector: string) => {
+				onClearedCalls.push(selector);
+			},
+			emit: capture.emit,
+		};
+
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(input);
+
+		// Fire first timer -> probe starts (hangs on resolveProbe).
+		th.fireFirst();
+		await vi.waitFor(() => expect(capture.runProbeCalls.length).toBe(1));
+
+		// Cancel while probe is in-flight.
+		scheduler.cancel("dispose");
+
+		// Now resolve the probe as success — but scheduler is disarmed, onCleared must NOT fire.
+		resolveProbe?.(true);
+
+		// Give the microtask a tick to settle.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(onClearedCalls).toEqual([]);
+		expect(capture.events.filter((e) => e.type === "retry_probe_result")).toEqual([]);
+		expect(scheduler.active).toBe(false);
+	});
+
+	// (7) Second probe (at deadline) succeeds -> onCleared + ok:true.
+	it("second probe at deadline succeeds and clears cooldown", async () => {
+		const now = 0;
+		let probeAttempt = 0;
+		const th = createTimerHarness();
+		harnesses.push(th);
+		const capture = createCapture();
+		const onClearedCalls: string[] = [];
+		const input = {
+			selector: "faux/faux-1",
+			firstAtMs: 500,
+			deadlineMs: 1000,
+			authAvailable: () => true,
+			runProbe: async (_signal: AbortSignal) => {
+				capture.runProbeCalls.push(_signal);
+				probeAttempt++;
+				return probeAttempt === 2; // fail first, succeed second
+			},
+			onCleared: (selector: string) => {
+				onClearedCalls.push(selector);
+			},
+			emit: capture.emit,
+		};
+
+		const scheduler = new ProbeBackScheduler({
+			now: () => now,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(input);
+
+		// Probe 1: failure.
+		th.fireFirst();
+		await vi.waitFor(() => expect(capture.runProbeCalls.length).toBe(1));
+		expect(th.pendingCount()).toBe(1); // deadline timer scheduled
+
+		// Probe 2: success.
+		th.fireFirst();
+		await vi.waitFor(() => expect(onClearedCalls.length).toBe(1));
+
+		expect(onClearedCalls).toEqual(["faux/faux-1"]);
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_result",
+			selector: "faux/faux-1",
+			ok: true,
+		});
+		expect(capture.runProbeCalls.length).toBe(2);
+		expect(scheduler.active).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-probe-scheduler.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-probe-scheduler.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { type ProbeBackEvent, ProbeBackScheduler } from "../../src/core/retry-fallback/probe-scheduler.ts";
 
 // Controllable timer harness: captures setTimeout callbacks so tests can fire
@@ -21,7 +21,8 @@ function createTimerHarness() {
 	};
 
 	const fakeClearTimeout = (handle: unknown): void => {
-		timers.delete(handle as number);
+		if (typeof handle !== "number") throw new Error("Unexpected timer handle");
+		timers.delete(handle);
 	};
 
 	return {
@@ -47,20 +48,6 @@ function createTimerHarness() {
 			}
 			return count;
 		},
-		/** Fire all pending timers in order. */
-		fireAll(): void {
-			const pending = [...timers.values()].filter((e) => !e.fired).sort((a, b) => a.id - b.id);
-			for (const entry of pending) {
-				entry.fired = true;
-				timers.delete(entry.id);
-				entry.callback();
-			}
-		},
-		/** Check if a specific timer handle is still pending (not cleared, not fired). */
-		isPending(handle: unknown): boolean {
-			const entry = timers.get(handle as number);
-			return entry !== undefined && !entry.fired;
-		},
 	};
 }
 
@@ -72,10 +59,6 @@ function createCapture() {
 		runProbeCalls,
 		emit(event: ProbeBackEvent): void {
 			events.push(event);
-		},
-		reset(): void {
-			events.length = 0;
-			runProbeCalls.length = 0;
 		},
 	};
 }
@@ -115,19 +98,11 @@ function defaultInput(
 }
 
 describe("ProbeBackScheduler", () => {
-	const harnesses: Array<ReturnType<typeof createTimerHarness>> = [];
-
-	afterEach(() => {
-		while (harnesses.length) harnesses.pop();
-		vi.useRealTimers();
-	});
-
 	// (1) arm -> first probe fires, failure -> second at deadline, failure ->
 	// exactly 2 runProbe calls, result ok:false emitted.
 	it("fires two probes on consecutive failures and emits ok:false", async () => {
 		const now = 0;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		const { input } = defaultInput(capture, { firstAtMs: 500, deadlineMs: 1000 });
 
@@ -180,7 +155,6 @@ describe("ProbeBackScheduler", () => {
 	it("clears cooldown and emits ok:true on first probe success", async () => {
 		const now = 0;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		const { input, onClearedCalls } = defaultInput(capture, {
 			firstAtMs: 500,
@@ -195,7 +169,7 @@ describe("ProbeBackScheduler", () => {
 		});
 
 		scheduler.arm(input);
-		expect(th.pendingCount()).toBe(1);
+		expect(th.pendingCount()).toBe(2);
 
 		th.fireFirst();
 		await vi.waitFor(() => expect(capture.events.some((e) => e.type === "retry_probe_result" && e.ok)).toBe(true));
@@ -218,7 +192,6 @@ describe("ProbeBackScheduler", () => {
 	it("cancel prevents all probe execution when called before first timer fires", async () => {
 		const now = 0;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		const { input } = defaultInput(capture, { firstAtMs: 500, deadlineMs: 1000 });
 
@@ -229,7 +202,7 @@ describe("ProbeBackScheduler", () => {
 		});
 
 		scheduler.arm(input);
-		expect(th.pendingCount()).toBe(1);
+		expect(th.pendingCount()).toBe(2);
 
 		// Cancel before any timer fires.
 		scheduler.cancel("dispose");
@@ -246,7 +219,6 @@ describe("ProbeBackScheduler", () => {
 	it("second arm supersedes the first; old timers never fire", async () => {
 		const now = 0;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		const { input: input1 } = defaultInput(capture, {
 			selector: "faux/faux-1",
@@ -267,12 +239,12 @@ describe("ProbeBackScheduler", () => {
 		});
 
 		scheduler.arm(input1);
-		expect(th.pendingCount()).toBe(1);
+		expect(th.pendingCount()).toBe(2);
 
 		// Supersede with a second arm.
 		scheduler.arm(input2);
 		expect(scheduler.active).toBe(true);
-		expect(th.pendingCount()).toBe(1); // only the new timer
+		expect(th.pendingCount()).toBe(2); // only the new arm's timers
 
 		// Fire the new timer -> probe for faux-2 runs, succeeds.
 		th.fireFirst();
@@ -291,7 +263,6 @@ describe("ProbeBackScheduler", () => {
 		const now = 0;
 		let authOk = true;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		const { input } = defaultInput(capture, {
 			firstAtMs: 500,
@@ -328,7 +299,6 @@ describe("ProbeBackScheduler", () => {
 	it("stale probe result after cancel does not call onCleared", async () => {
 		const now = 0;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		let resolveProbe: ((value: boolean) => void) | undefined;
 		const onClearedCalls: string[] = [];
@@ -361,8 +331,10 @@ describe("ProbeBackScheduler", () => {
 		th.fireFirst();
 		await vi.waitFor(() => expect(capture.runProbeCalls.length).toBe(1));
 
-		// Cancel while probe is in-flight.
+		// Cancel while probe is in-flight. Both timers are cleared and the probe is aborted.
 		scheduler.cancel("dispose");
+		expect(capture.runProbeCalls[0]?.aborted).toBe(true);
+		expect(th.pendingCount()).toBe(0);
 
 		// Now resolve the probe as success — but scheduler is disarmed, onCleared must NOT fire.
 		resolveProbe?.(true);
@@ -379,7 +351,6 @@ describe("ProbeBackScheduler", () => {
 	it("arm during in-flight probe swallows the old result and preserves cancellation", async () => {
 		const now = 0;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		let resolveOldProbe: ((value: boolean) => void) | undefined;
 		let resolveNewProbe: ((value: boolean) => void) | undefined;
@@ -417,7 +388,7 @@ describe("ProbeBackScheduler", () => {
 		expect(oldOnClearedCalls).toEqual([]);
 		expect(capture.events.filter((event) => event.type === "retry_probe_result")).toEqual([]);
 		expect(scheduler.active).toBe(true);
-		expect(th.pendingCount()).toBe(1);
+		expect(th.pendingCount()).toBe(2);
 
 		th.fireFirst();
 		await vi.waitFor(() => expect(capture.runProbeCalls).toHaveLength(2));
@@ -434,8 +405,49 @@ describe("ProbeBackScheduler", () => {
 
 		scheduler.cancel("dispose");
 		expect(th.pendingCount()).toBe(0);
-		th.fireAll();
 		expect(capture.runProbeCalls).toHaveLength(2);
+	});
+
+	it("aborts a hanging first probe at the deadline and runs the final probe", async () => {
+		const th = createTimerHarness();
+		const capture = createCapture();
+		let attempt = 0;
+		let resolveCleared: ((selector: string) => void) | undefined;
+		const cleared = new Promise<string>((resolve) => {
+			resolveCleared = resolve;
+		});
+		const { input } = defaultInput(capture, {
+			runProbe: (signal) => {
+				attempt++;
+				if (attempt === 1) return new Promise<boolean>(() => undefined);
+				return Promise.resolve(!signal.aborted);
+			},
+			onCleared: (selector) => resolveCleared?.(selector),
+		});
+		const scheduler = new ProbeBackScheduler({
+			now: () => 0,
+			setTimeout: th.setTimeout,
+			clearTimeout: th.clearTimeout,
+		});
+
+		scheduler.arm(input);
+		expect(th.pendingCount()).toBe(2);
+		th.fireFirst();
+		expect(capture.runProbeCalls).toHaveLength(1);
+		expect(capture.runProbeCalls[0]?.aborted).toBe(false);
+
+		th.fireFirst();
+		expect(capture.runProbeCalls[0]?.aborted).toBe(true);
+		expect(capture.runProbeCalls).toHaveLength(2);
+		await expect(cleared).resolves.toBe("faux/faux-1");
+
+		expect(capture.events).toContainEqual({
+			type: "retry_probe_result",
+			selector: "faux/faux-1",
+			ok: true,
+		});
+		expect(scheduler.active).toBe(false);
+		expect(th.pendingCount()).toBe(0);
 	});
 
 	// (7) Second probe (at deadline) succeeds -> onCleared + ok:true.
@@ -443,7 +455,6 @@ describe("ProbeBackScheduler", () => {
 		const now = 0;
 		let probeAttempt = 0;
 		const th = createTimerHarness();
-		harnesses.push(th);
 		const capture = createCapture();
 		const onClearedCalls: string[] = [];
 		const input = {

--- a/packages/coding-agent/test/suite/rpc-fallback-events.test.ts
+++ b/packages/coding-agent/test/suite/rpc-fallback-events.test.ts
@@ -163,4 +163,48 @@ describe("RPC fallback events", () => {
 			lastError: "misleading_success_output",
 		});
 	});
+
+	it("forwards retry_probe_scheduled over RPC JSONL (opaque passthrough)", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					hintedWaitCapMs: 8,
+					probeBackMaxMs: 3_600_000,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+
+		const chunks: string[] = [];
+		const probeScheduled = eventSignal("retry_probe_scheduled");
+		const handler = createHandler(harness, chunks, probeScheduled);
+		handlers.push(handler);
+		await handler.ready;
+
+		harness.setResponses([
+			fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "HTTP 429: rate_limit_error (retry-after-ms: 1258)",
+			}),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await handler.handleInputLine(JSON.stringify({ id: "probe-scheduled", type: "prompt", message: "hello" }));
+		await probeScheduled.wait(5_000);
+
+		const events = jsonLines(chunks);
+		const scheduled = events.filter((e) => isEventType(e, "retry_probe_scheduled"));
+		expect(scheduled.length).toBeGreaterThanOrEqual(1);
+		expect(scheduled[0]).toMatchObject({
+			type: "retry_probe_scheduled",
+			selector: primary,
+			probeIndex: 1,
+		});
+		expect(typeof (scheduled[0] as Record<string, unknown>).atMs).toBe("number");
+	});
 });

--- a/packages/senpi-codemode/vitest.config.ts
+++ b/packages/senpi-codemode/vitest.config.ts
@@ -5,8 +5,14 @@ const senpiSrcIndex = fileURLToPath(new URL("../coding-agent/src/index.ts", impo
 const aiSrcIndex = fileURLToPath(new URL("../ai/src/index.ts", import.meta.url));
 const aiSrcCompat = fileURLToPath(new URL("../ai/src/compat.ts", import.meta.url));
 const aiSrcOAuth = fileURLToPath(new URL("../ai/src/oauth.ts", import.meta.url));
+const aiSrcProviderScope = fileURLToPath(new URL("../ai/src/node/provider-scope.ts", import.meta.url));
+const aiSrcBedrockProvider = fileURLToPath(new URL("../ai/src/bedrock-provider.ts", import.meta.url));
+const aiSrcBunOAuth = fileURLToPath(new URL("../ai/src/bun-oauth.ts", import.meta.url));
 const agentSrcIndex = fileURLToPath(new URL("../agent/src/index.ts", import.meta.url));
 const tuiSrcIndex = fileURLToPath(new URL("../tui/src/index.ts", import.meta.url));
+const ptySrcIndex = fileURLToPath(new URL("../pty/src/index.ts", import.meta.url));
+const clientSrcIndex = fileURLToPath(new URL("../client/src/index.ts", import.meta.url));
+const protocolSrcIndex = fileURLToPath(new URL("../protocol/src/index.ts", import.meta.url));
 
 export default defineConfig({
 	test: {
@@ -21,7 +27,21 @@ export default defineConfig({
 			{ find: /^@earendil-works\/pi-ai$/, replacement: aiSrcIndex },
 			{ find: /^@earendil-works\/pi-ai\/compat$/, replacement: aiSrcCompat },
 			{ find: /^@earendil-works\/pi-ai\/oauth$/, replacement: aiSrcOAuth },
+			{ find: /^@earendil-works\/pi-ai\/node\/provider-scope$/, replacement: aiSrcProviderScope },
+			{ find: /^@earendil-works\/pi-ai\/bedrock-provider$/, replacement: aiSrcBedrockProvider },
+			{ find: /^@earendil-works\/pi-ai\/bun-oauth$/, replacement: aiSrcBunOAuth },
+			{
+				find: /^@earendil-works\/pi-ai\/providers\/(.+)$/,
+				replacement: fileURLToPath(new URL("../ai/src/providers/$1.ts", import.meta.url)),
+			},
+			{
+				find: /^@earendil-works\/pi-ai\/utils\/(.+)$/,
+				replacement: fileURLToPath(new URL("../ai/src/utils/$1.ts", import.meta.url)),
+			},
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: agentSrcIndex },
+			{ find: /^@earendil-works\/pi-pty$/, replacement: ptySrcIndex },
+			{ find: /^@earendil-works\/pi-client$/, replacement: clientSrcIndex },
+			{ find: /^@earendil-works\/pi-protocol$/, replacement: protocolSrcIndex },
 			{ find: /^@earendil-works\/pi-tui$/, replacement: tuiSrcIndex },
 		],
 	},

--- a/vitest.base.ts
+++ b/vitest.base.ts
@@ -21,6 +21,10 @@ export default defineConfig({
 				find: /^@earendil-works\/pi-ai\/providers\/(.+)$/,
 				replacement: `${workspaceSourcePaths.aiProviders}/$1.ts`,
 			},
+			{
+				find: /^@earendil-works\/pi-ai\/utils\/(.+)$/,
+				replacement: fileURLToPath(new URL(`./packages/ai/src/utils/$1.ts`, import.meta.url)),
+			},
 			{ find: /^@earendil-works\/pi-agent-core$/, replacement: workspaceSourcePaths.agentIndex },
 			{ find: /^@earendil-works\/pi-tui$/, replacement: workspaceSourcePaths.tuiIndex },
 		],


### PR DESCRIPTION
## Summary

When a model answers 429 (rate limited), senpi retried blind: the same exponential backoff whether the server said "come back in 8 seconds" or said nothing at all, and any server-requested wait over 60s was thrown away. This PR makes 429 handling hint-aware. A single strict extractor recovers the server's retry timing from headers and error bodies (including SSE in-stream error events), and a three-tier policy acts on it: no hint means the pool is exhausted, so we stop burning same-model retries and fall to the next chain model immediately; a short hint (<= 5 min) waits in place with an early probe at half the hint and another at the deadline; a medium hint (5 min - 1 h) falls back at once but schedules at most two one-token probe-backs so the primary is restored the moment it recovers; a long hint (>= 1 h) just falls back and lets the existing cooldown-expiry revert do its job. Both thresholds are configurable (`retry.hintedWaitCapMs`, `retry.probeBackMaxMs`, defaults 300_000 / 3_600_000).

Motivating evidence: a live probe against the ccapi gateway returned `429` with `retry-after: 1258` — senpi previously discarded that hint above its 60s cap and retried blind, and ~150 historical sessions show the unhinted "All tokens rate limited" body burning three retries before falling back.

## Changes

- **packages/ai — hint extraction and transport:** new `utils/retry-hint.ts` (strict extractor: `retry-after-ms` > `retry-after` delta-seconds or HTTP-date > `x-ratelimit-reset*` > JSON `retryDelay` > body prose; explicit-zero distinct from absent-hint; malformed sources fall through; clock-skew handled via the response Date header). `utils/provider-retry.ts` now carries the hint structurally (`ProviderRetryDelayError.retryAfterMs`) plus a canonical `(retry-after-ms: N)` marker. `api/anthropic-messages.ts` and `api/openai-codex-responses.ts` append the marker at both the HTTP-status boundary and the SSE in-stream `event: error` boundary; the codex retry loop keeps its old header-only behavior for non-429 statuses (forced-eligibility, empty body) so 503s are untouched.
- **packages/coding-agent — policy and orchestration:** new `retry-fallback/hint-policy.ts` (pure tier classifier + probe scheduling math). `agent-session.ts` routes 429-class failures through it (wiring-only growth; all seven hint-state reset sites covered); the legacy `maxRetryDelayMs` gate is intentionally replaced for 429-class failures only — billing, refusal, hard-error, stall-escalation, and abort paths are byte-identical. New `retry-fallback/probe-scheduler.ts` owns the bounded probe-back lifecycle (max 2 probes, session-owned, abortable, cancels on manual model change/dispose, clears the cooldown on success so the existing `maybeRestorePrimary` reverts next turn). New settings `hintedWaitCapMs`/`probeBackMaxMs` with validation. New `retry_probe_scheduled`/`retry_probe_result` session events, surfaced in the interactive status line and passed through RPC opaquely.
- **Records:** `changes.md` entries in both packages per house format, including why an extension cannot implement this (hints must be recovered below the stream protocol boundary, and the tier decision must intercept the retry sleep inside agent-session).
- **QA tooling:** three new senpi-qa mock-loop scenarios with a header-emitting scripted 429 server.

## QA & Evidence

All tests were written failing-first (RED logs captured before implementation); each todo was independently re-verified by the orchestrator (scoped suites + biome + `tsc --noEmit`).

- **What was tested:** strict extractor contract (62 cases: header forms, HTTP-date with clock skew, epoch reset headers max-wins, JSON retryDelay, prose, SSE bodies, explicit-zero vs absent, malformed fall-through).
- **Observed result:** 62/62 green. **Artifact:** `.omo/evidence/hint-aware-429-retry/task-1-{red,green}.log`
- **What was tested:** tier classifier + probe scheduling state machine (boundaries 300_000/3_600_000, growing/shrinking/vanishing hints, cumulative-cap demotion). **Observed result:** 36/36 green. **Artifact:** `task-2-{red,green}.log`
- **What was tested:** settings defaults/overrides/malformed/inverted boundary. **Observed result:** 8/8 green. **Artifact:** `task-3-{red,green}.log`
- **What was tested:** provider-retry hint propagation (over-cap 429 carries `retryAfterMs` 1_258_000 + marker; under-cap honored; non-429 unchanged; 429 without hint keeps exponential). **Observed result:** 14/14 green. **Artifact:** `task-4-{red,green}.log`
- **What was tested:** boundary markers at anthropic + codex (HTTP 429 with retry-after -> marker; SSE hinted body -> marker; unhinted SSE body -> no marker; malformed SSE -> no throw; non-429 byte-identical). **Observed result:** 10/10 green + 116/116 regression (codex-stream, retry-hint, provider-retry). **Artifact:** `task-5-{red,green}.log`
- **What was tested:** agent-session tier routing (no-hint immediate fallback with zero retries; tier1 half-then-deadline waits; cumulative-cap demotion; tier2 immediate fallback + remaining-hint cooldown + arm seam; tier3 no probes; non-429 500 unchanged). **Observed result:** 6/6 green + 158/158 retry-fallback regression. Two legacy expectations (long-delay suite) intentionally updated with code comments citing plan todo 6, after an orchestrator ruling that they pinned the replaced gate. **Artifact:** `task-6-{red,green,regression}.log`
- **What was tested:** probe scheduler (two-probe cap, success clears cooldown, cancel/supersede/auth-unavailable/stale-result paths, deterministic injected timers). **Observed result:** 14/14 green + 166/166 regression. **Artifact:** `task-7-{red,green,regression}.log`
- **What was tested:** probe events to interactive + RPC (payload integrity; RPC proven opaque — no schema change). **Observed result:** 24/24 green + 166/166 regression. **Artifact:** `task-8-{red,green,regression}.log`
- **What was tested:** end-to-end behavior on the real CLI from source (senpi-qa mock loop, isolated sandbox, no real credentials): hinted-429-in-turn, no-hint-429-fast-fallback, hinted-429-probe-back. **Observed result:** 6/6, 5/5, 6/6 — real waits 4011/8007 ms matching scheduled hints; exactly one primary call on no-hint; probe-back at ~2 s restoring the primary on the next turn; each scenario run 3+ times identically. **Artifact:** `local-ignore/qa-evidence/20260803-hint-aware-429/{hinted-429-in-turn,no-hint-429-fast-fallback,hinted-429-probe-back}.log` (+ events/requests/summary JSON)
- **What was tested:** QA hygiene: no stray processes/ports/temp dirs, credential store sha256 unchanged before/after. **Artifact:** `local-ignore/qa-evidence/20260803-hint-aware-429/cleanup.log` (POST-TEARDOWN VERIFIED)
- **Why sufficient:** every planned success criterion maps to a failing-first test plus a real-surface scenario receipt; the three scenarios exercise the exact production path (header -> marker -> tier router -> fallback/probe-back) on the real binary.

## Risks & Residuals

- **Legacy gate replacement (accepted, intentional):** for 429-class failures the `maxRetryDelayMs` over-cap gate is replaced by tier routing — a hinted 429 under 5 min now waits in place instead of failing over instantly. Pinned in updated tests with comments; non-429 behavior untouched and regression-green.
- **Probe cost (bounded):** at most two `maxTokens: 1` probe requests per tier-2 incident; none for hints >= 1 h or unhinted 429s.
- **Packaging note:** `packages/ai/package.json` gained a `./utils/*` subpath export (+ matching vitest alias) so coding-agent can import the new extractor — additive, mirrors the existing `./api/*` pattern.
- **Momus high-accuracy review:** explicitly deferred by the user; F1 plan-compliance, F2 code-quality, F4 scope-fidelity audits run in its place (verdicts below when attached).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hint-aware 429 handling: we parse server retry-after hints and use a tiered wait/fallback/probe‑back policy to cut wasted retries and restore the primary model faster. For 429 only, this replaces the old `maxRetryDelayMs` cap; non‑429 retries continue to honor server retry-after headers.

- **New Features**
  - `@earendil-works/pi-ai`: strict 429 hint extractor + canonical marker helpers (`extract429RetryAfterMs`, `(retry-after-ms: N)`), surfaced as `retryAfterMs` on `ProviderRetryDelayError`; markers added in `anthropic-messages` and `openai-codex-responses` (including SSE `event: error` payloads); new `./utils/*` export.
  - `coding-agent`: tiered 429 routing
    - No hint → fast fallback.
    - Hint ≤ `retry.hintedWaitCapMs` (default 5m) → in-turn wait with half/deadline probes.
    - Hint < `retry.probeBackMaxMs` (default 1h) → immediate fallback + up to two 1‑token probe-backs; success clears cooldown for next-turn restore.
    - Hint ≥ `retry.probeBackMaxMs` → fallback only.
  - New settings: `retry.hintedWaitCapMs`, `retry.probeBackMaxMs`. New events: `retry_probe_scheduled`, `retry_probe_result` (shown as transient status lines and forwarded over RPC).

- **Bug Fixes**
  - Probe lifecycle hardened: generation tokens prevent stale probes from clearing cooldowns or emitting after dispose; deadline armed independently of the first probe and aborts a still-running attempt; no leaked timers; transient status lines replace foreground indicators; failed probes now explicitly close out the status line with “staying on fallback” (or “auth unavailable”).
  - 429 classification anchored to HTTP/status/error contexts; explicit zero hints do not affect non-429 retries.
  - Restored non-429 retry-after honoring in `provider-retry`; test aliases updated (vitest `utils/*`, senpi-codemode providers/pty/client/protocol).
  - Interactive UI sanitizes probe status selector labels; RPC continues opaque passthrough.

<sup>Written for commit dd461f93966e446c5015c0bbf6952a16bfe15629. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

