### PR TITLE
fix(terminal): rearm wake delivery for fresh monitors

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,31 @@
 # terminal builtin extension — fork surface
 
+## Fresh monitors reset a spent wake budget (2026-08-03)
+
+### What changed
+
+- Creating a monitor now resets the session-global monitor notification pause before
+  the new runtime can emit output or its completion summary.
+- A regression drives a real monitor after a prior watch exhausts the wake budget and
+  proves the fresh monitor's completion still triggers a model-visible wake.
+
+### Why
+
+- The wake budget intentionally pauses noisy watches, but that pause previously leaked
+  into later monitors. A newly requested watch could run and disappear from the TUI
+  without delivering its completion, leaving deferred goal work looking stopped.
+
+### Why this cannot be expressed externally
+
+- The fix depends on the built-in monitor tool's ordering relative to the
+  session-scoped notifier and monitor registry.
+
+### Expected merge conflict zones
+
+- `tools/monitor.ts` around monitor creation and `tools/context.ts` around notifier
+  callbacks.
+- `test/suite/terminal-monitor-notify.test.ts` around wake-budget coverage.
+
 ## Backfill: Anthropic availability monitoring (2026-08-01)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
@@ -26,7 +26,7 @@ export interface TerminalToolContext {
 	readonly monitorRegistry?: MonitorRegistry;
 	/** Receives filtered monitor line and terminal-summary events. */
 	readonly onMonitorEvent?: (event: MonitorEvent) => void;
-	/** Resets session-global wake-budget delivery after a monitor was explicitly rearmed. */
+	/** Resets session-global wake-budget delivery for a fresh or explicitly rearmed monitor. */
 	readonly onMonitorRearmed?: (id: string) => void;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -94,6 +94,7 @@ async function createMonitor(
 		cwd: execCtx?.cwd,
 		...(input.persistent ? {} : { timeoutMs: resolveTimeoutMs(input.timeout_ms) }),
 	});
+	ctx.onMonitorRearmed?.(id);
 	registry.register({ id, description: input.description, runtime, filter });
 	return textResult(`Monitor started with ID: ${id}`, { details: { bash_id: id, monitor: true } });
 }

--- a/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import { MonitorRegistry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
 import { TERMINAL_PROMPT_SECTION } from "../../src/core/extensions/builtin/terminal/prompt.ts";
 import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createMonitorTool } from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
@@ -86,6 +88,52 @@ describe("terminal monitor event delivery", () => {
 		scheduler.advanceBy(2000);
 		expect(sent).toHaveLength(6);
 		expect(sent[5]?.message.content).toContain("resumed");
+	});
+
+	it("delivers completion from a new monitor after the prior wake budget paused", async () => {
+		const { notifier, scheduler, sent } = createNotifier({ settings: { wakeBudget: 1 } });
+		notifier.notifyEvent(line("bash_prior", "prior", "budget exhausted"));
+		scheduler.advanceBy(2000);
+		expect(sent).toHaveLength(1);
+
+		const manager = new TerminalManager();
+		const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		try {
+			let resolveSummary: (() => void) | undefined;
+			const summary = new Promise<void>((resolve) => {
+				resolveSummary = resolve;
+			});
+			const registry = new MonitorRegistry((event) => {
+				notifier.notifyEvent(event);
+				if (event.type === "summary") resolveSummary?.();
+			});
+			const ctx = {
+				manager,
+				monitorRegistry: registry,
+				onMonitorRearmed: (id: string) => notifier.rearm(id),
+				cwd: process.cwd(),
+				defaultCols: 120,
+				defaultRows: 40,
+				getEnv: () => ({ ...process.env }),
+			} satisfies TerminalToolContext;
+
+			await createMonitorTool(ctx).execute("fresh-monitor", {
+				description: "fresh completion",
+				command: "printf 'done\\n'",
+			});
+			await summary;
+			scheduler.advanceBy(2000);
+
+			expect(sent).toHaveLength(2);
+			expect(sent[1]?.message.content).toContain("Monitor event(fresh completion): done");
+			expect(sent[1]?.message.content).toContain("watcher completed (exit code 0)");
+			expect(sent[1]?.options).toMatchObject({ triggerTurn: true });
+		} finally {
+			await manager.teardown();
+			if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+			else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+		}
 	});
 
 	it("never injects monitor events in off, print, or json modes", () => {


### PR DESCRIPTION
## Summary

- reset monitor notification delivery when a brand-new monitor is created
- keep the reset before registry registration so fast output/completion cannot race ahead
- add a deterministic integration regression for a fresh monitor after the previous wake budget paused
- document the fork-specific behavior in the terminal changes ledger

## Root cause

The monitor notifier's session-global wake pause survived into later monitor
subscriptions. A new monitor could run and settle normally, but all of its line
and completion events were dropped, so deferred goal work did not wake and the
TUI eventually had no active monitor left to display.

## RED -> GREEN

- RED: `terminal monitor event delivery > delivers completion from a new monitor after the prior wake budget paused`
  - expected two model-visible notifications, received one
- GREEN: the same test passes and observes the fresh monitor's output,
  `watcher completed (exit code 0)`, and `triggerTurn: true`

## Verification

- `npm run build`
- `npm run check`
- focused monitor tests: 20/20 characterization, 9/9 regression
- coding-agent package suite: 798 files passed, 4 skipped; 6655 tests passed, 35 skipped
- `cli-smoke.mjs --self-test`: 8/8
- `rpc-drive.mjs --self-test`: 4/4
- `mock-loop.mjs --with-tool --api openai-responses`: 4/4
- browser/xterm real TUI:
  - active capture visibly shows `◉ watching fresh monitor wake proof (0s)`
  - cleared capture visibly removes the monitor row
  - both PTY processes were killed and QA sandboxes removed

Local sanitized receipts:
`local-ignore/qa-evidence/20260803-monitor-tui/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rearms wake delivery for fresh terminal monitors so their output and completion events are delivered even after a previous watch exhausted the wake budget. Fixes dropped notifications so the TUI and deferred work stay in sync.

- **Bug Fixes**
  - Call `onMonitorRearmed` during monitor creation (before registry registration) to reset the session-global pause.
  - Clarified `TerminalToolContext` doc to include fresh-monitor rearm.
  - Added a regression test to ensure a new monitor delivers completion and triggers a turn post-pause.
  - Documented the behavior in the terminal changes ledger.

<sup>Written for commit a4a0dfaedf49ba9234dfdd33e884f24c70a0a5c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

