### PR TITLE
fix(coding-agent): suppress distinct loop-guard targets

### DIFF
--- a/.agents/skills/senpi-qa/scripts/loop-guard-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/loop-guard-qa.mjs
@@ -32,6 +32,23 @@ function rawBody(request) {
 	return request.raw ?? JSON.stringify(request.body ?? {});
 }
 
+function hasReminder(request, headline) {
+	const messages = request.body?.messages;
+	if (!Array.isArray(messages)) return false;
+	return messages.some(
+		(message) =>
+			message.role === "user" &&
+			Array.isArray(message.content) &&
+			message.content.some(
+				(part) =>
+					part?.type === "text" &&
+					typeof part.text === "string" &&
+					part.text.startsWith("<system-reminder>") &&
+					(headline === undefined || part.text.includes(headline)),
+			),
+	);
+}
+
 async function drive({ turns, extraArgs = [] }) {
 	const preset = API_PRESETS[API];
 	const box = makeSandbox("loop-guard-qa");
@@ -54,8 +71,7 @@ async function drive({ turns, extraArgs = [] }) {
 
 async function expectReminder(checks, { name, turns, headline, minRequests, extraArgs }) {
 	const { box, server, result } = await drive({ turns, extraArgs });
-	const bodies = server.requests.map(rawBody);
-	const hitIndex = bodies.findIndex((body, index) => index >= 1 && body.includes(headline));
+	const hitIndex = server.requests.findIndex((request, index) => index >= 1 && hasReminder(request, headline));
 	const pass = result.code === 0 && server.requests.length >= minRequests && hitIndex >= 1;
 	checks.ok(
 		`${name}: reminder steered into a later provider request`,
@@ -129,6 +145,46 @@ async function selfTest() {
 		extraArgs: ["--approve"],
 		turns: cycleTurns,
 	});
+
+	{
+		const loopGuardDir = join(
+			process.cwd(),
+			"packages/coding-agent/src/core/extensions/builtin/loop-guard",
+		);
+		const turns = ["detectors.ts", "notice.ts", "policy.ts", "similarity.ts", "tracker.ts"].map((fileName) => ({
+			toolCalls: [{ name: "read", args: { path: join(loopGuardDir, fileName) } }],
+		}));
+		turns.push({ text: "done" });
+		const { box, server, result } = await drive({ extraArgs: ["--approve"], turns });
+		const leaked = server.requests.some((request) => hasReminder(request));
+		checks.ok(
+			"distinct read targets: productive fan-out fires no reminder",
+			result.code === 0 && !leaked,
+			`code=${result.code} requests=${server.requests.length} leaked=${leaked}`,
+		);
+		if (evidenceSlug !== undefined) {
+			const dir = evidenceDir(evidenceSlug);
+			writeFileSync(
+				join(dir, "distinct-read-targets.json"),
+				JSON.stringify(
+					{
+						requestCount: server.requests.length,
+						exitCode: result.code,
+						leaked,
+						requestBodies: server.requests.map((request, index) => ({
+							index,
+							url: request.url,
+							raw: rawBody(request),
+						})),
+					},
+					null,
+					2,
+				),
+			);
+		}
+		await server.stop();
+		box.cleanup();
+	}
 
 	{
 		const { box, server, result } = await drive({

--- a/.agents/skills/senpi-qa/scripts/loop-guard-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/loop-guard-qa.mjs
@@ -157,10 +157,11 @@ async function selfTest() {
 		turns.push({ text: "done" });
 		const { box, server, result } = await drive({ extraArgs: ["--approve"], turns });
 		const leaked = server.requests.some((request) => hasReminder(request));
+		const complete = server.requests.length >= turns.length;
 		checks.ok(
 			"distinct read targets: productive fan-out fires no reminder",
-			result.code === 0 && !leaked,
-			`code=${result.code} requests=${server.requests.length} leaked=${leaked}`,
+			result.code === 0 && complete && !leaked,
+			`code=${result.code} requests=${server.requests.length} complete=${complete} leaked=${leaked}`,
 		);
 		if (evidenceSlug !== undefined) {
 			const dir = evidenceDir(evidenceSlug);
@@ -170,6 +171,7 @@ async function selfTest() {
 					{
 						requestCount: server.requests.length,
 						exitCode: result.code,
+						complete,
 						leaked,
 						requestBodies: server.requests.map((request, index) => ({
 							index,

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/changes.md
@@ -1,5 +1,32 @@
 # loop-guard changes
 
+## loop-guard: suppress distinct-target similarity false positives (2026-08-03)
+
+- `similar` detection now recognizes stable target fields for `read`,
+  `bash_output`, `task_output`, `task_update`, `task_send`, and
+  `lsp_diagnostics`. When every call in the trailing same-tool run exposes a
+  target and all targets are distinct, the run is productive fan-out and the
+  similar warning stays silent. Missing or malformed target data falls through
+  to the existing bigram-Dice detector.
+- Same-target behavior is unchanged: pagination of one `read.path`, polling one
+  task or terminal session, byte-identical calls, and repeating cycles continue
+  to warn at the existing thresholds.
+- Why: a scan of local senpi sessions found the false positives concentrated in
+  the `similar` detector, especially long-common-prefix paths and IDs. The
+  `identical` and `cycle` detectors were precise, so broad threshold tuning would
+  weaken useful protections instead of fixing target identity.
+- This cannot be implemented as a separate public extension: the builtin owns
+  the private tracker/detector state and steers its reminder during
+  `tool_execution_start`; another extension cannot override that policy or
+  retract an already-steered custom message.
+- Tests: distinct-target RED→GREEN coverage moved into the focused
+  `loop-guard-similar-detector.test.ts` suite to keep test modules below the
+  250-pure-LOC ceiling. Extension wiring coverage proves distinct reads produce
+  no message while existing same-target, identical, and cycle cases stay green.
+- Expected merge conflict zones: LOW in `detectors.ts` (one target-identity
+  predicate in the similar detector); LOW in the loop-guard test suites; NONE in
+  public extension APIs, tracker signatures, policy thresholds, or renderer.
+
 ## loop-guard: tool-call loop detection with steered reminders (2026-07-31)
 
 - New builtin extension `loop-guard` that observes the pure tool-call stream

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/detectors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/detectors.ts
@@ -10,6 +10,15 @@ import {
 import { meanAdjacentSimilarity } from "./similarity.ts";
 import type { ToolCallRecord } from "./tracker.ts";
 
+const TARGET_FIELDS = new Map<string, readonly string[]>([
+	["read", ["path"]],
+	["bash_output", ["bash_id"]],
+	["task_output", ["task_id", "name"]],
+	["task_update", ["task_id"]],
+	["task_send", ["to"]],
+	["lsp_diagnostics", ["filePath"]],
+]);
+
 export type LoopGuardDetection =
 	| { readonly kind: "identical"; readonly toolName: string; readonly count: number; readonly fingerprint: string }
 	| {
@@ -28,6 +37,33 @@ export type LoopGuardDetection =
 	  };
 
 export type LoopGuardKind = LoopGuardDetection["kind"];
+
+function targetIdentity(record: ToolCallRecord): string | undefined {
+	const fields = TARGET_FIELDS.get(record.toolName);
+	if (fields === undefined) return undefined;
+	let args: unknown;
+	try {
+		args = JSON.parse(record.argsJson);
+	} catch {
+		return undefined;
+	}
+	if (typeof args !== "object" || args === null || Array.isArray(args)) return undefined;
+	for (const field of fields) {
+		const value: unknown = Reflect.get(args, field);
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
+}
+
+function hasAllDistinctTargets(records: readonly ToolCallRecord[]): boolean {
+	const identities: string[] = [];
+	for (const record of records) {
+		const identity = targetIdentity(record);
+		if (identity === undefined) return false;
+		identities.push(identity);
+	}
+	return new Set(identities).size === identities.length;
+}
 
 export function detectIdenticalRun(records: readonly ToolCallRecord[]): LoopGuardDetection | undefined {
 	const last = records[records.length - 1];
@@ -50,8 +86,10 @@ export function detectSimilarRun(records: readonly ToolCallRecord[]): LoopGuardD
 		run++;
 	}
 	if (run < SIMILAR_RUN_THRESHOLD) return undefined;
-	const argStrings = records.slice(records.length - run).map((record) => record.argsJson);
+	const runRecords = records.slice(records.length - run);
+	const argStrings = runRecords.map((record) => record.argsJson);
 	if (new Set(argStrings).size === 1) return undefined;
+	if (hasAllDistinctTargets(runRecords)) return undefined;
 	const similarity = meanAdjacentSimilarity(argStrings);
 	if (similarity < SIMILARITY_THRESHOLD) return undefined;
 	return { kind: "similar", toolName: last.toolName, count: run, similarity, fingerprint: last.toolName };

--- a/packages/coding-agent/test/suite/loop-guard-detectors.test.ts
+++ b/packages/coding-agent/test/suite/loop-guard-detectors.test.ts
@@ -3,15 +3,10 @@ import {
 	detectCycle,
 	detectIdenticalRun,
 	detectLoop,
-	detectSimilarRun,
 	NoticeGate,
 } from "../../src/core/extensions/builtin/loop-guard/detectors.ts";
 import { buildLoopGuardReminder } from "../../src/core/extensions/builtin/loop-guard/notice.ts";
-import {
-	IDENTICAL_RUN_THRESHOLD,
-	SIMILAR_RUN_THRESHOLD,
-	SIMILARITY_THRESHOLD,
-} from "../../src/core/extensions/builtin/loop-guard/policy.ts";
+import { IDENTICAL_RUN_THRESHOLD, SIMILARITY_THRESHOLD } from "../../src/core/extensions/builtin/loop-guard/policy.ts";
 import {
 	bigramCounts,
 	diceSimilarity,
@@ -91,42 +86,6 @@ describe("detectIdenticalRun", () => {
 			["read", { path: "a.ts", limit: 50 }],
 		);
 		expect(detectIdenticalRun(records)?.count).toBe(3);
-	});
-});
-
-describe("detectSimilarRun", () => {
-	it("returns undefined for productive runs with distinct args", () => {
-		const records = recs(
-			["bash", { command: "vitest run test/a.test.ts" }],
-			["bash", { command: "git status --short" }],
-			["bash", { command: "npm run check" }],
-			["bash", { command: "rg -n 'loopGuard' packages" }],
-			["bash", { command: "node scripts/build.mjs --watch" }],
-		);
-		expect(detectSimilarRun(records)).toBeUndefined();
-	});
-
-	it("returns undefined while the run is all-identical (identical detector owns it)", () => {
-		const records = recs(
-			...Array.from({ length: SIMILAR_RUN_THRESHOLD }, () => ["read", { path: "a.ts" }] as [string, unknown]),
-		);
-		expect(detectSimilarRun(records)).toBeUndefined();
-	});
-
-	it("fires for near-identical pagination runs at the threshold", () => {
-		const records = recs(
-			["read", { path: "src/app.ts", offset: 1, limit: 200 }],
-			["read", { path: "src/app.ts", offset: 201, limit: 200 }],
-			["read", { path: "src/app.ts", offset: 401, limit: 200 }],
-			["read", { path: "src/app.ts", offset: 601, limit: 200 }],
-			["read", { path: "src/app.ts", offset: 801, limit: 200 }],
-		);
-		const detection = detectSimilarRun(records);
-		expect(detection?.kind).toBe("similar");
-		expect(detection?.count).toBe(SIMILAR_RUN_THRESHOLD);
-		if (detection?.kind === "similar") {
-			expect(detection.similarity).toBeGreaterThanOrEqual(SIMILARITY_THRESHOLD);
-		}
 	});
 });
 

--- a/packages/coding-agent/test/suite/loop-guard-extension.test.ts
+++ b/packages/coding-agent/test/suite/loop-guard-extension.test.ts
@@ -105,6 +105,16 @@ describe("loop-guard extension", () => {
 		expect(harness.sent[0]?.message.content).not.toContain("LOOP GUARD - IDENTICAL TOOL CALLS");
 	});
 
+	it("stays silent for near-identical reads targeting distinct paths", () => {
+		const harness = createLoopGuardHarness();
+		const basePath =
+			"/Users/yeongyu/local-workspaces/senpi/packages/coding-agent/src/core/extensions/builtin/loop-guard";
+		for (const fileName of ["detectors.ts", "notice.ts", "policy.ts", "similarity.ts", "tracker.ts"]) {
+			toolStart(harness.fire, "read", { path: `${basePath}/${fileName}` });
+		}
+		expect(harness.sent).toHaveLength(0);
+	});
+
 	it("uses the distinct cycle prompt for repeating rotations", () => {
 		const harness = createLoopGuardHarness();
 		for (let i = 0; i < 3; i++) {

--- a/packages/coding-agent/test/suite/loop-guard-similar-detector.test.ts
+++ b/packages/coding-agent/test/suite/loop-guard-similar-detector.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { detectSimilarRun } from "../../src/core/extensions/builtin/loop-guard/detectors.ts";
+import { SIMILAR_RUN_THRESHOLD, SIMILARITY_THRESHOLD } from "../../src/core/extensions/builtin/loop-guard/policy.ts";
+import type { ToolCallRecord } from "../../src/core/extensions/builtin/loop-guard/tracker.ts";
+import { canonicalizeArgs } from "../../src/core/extensions/builtin/loop-guard/tracker.ts";
+
+function rec(toolName: string, args: unknown): ToolCallRecord {
+	const argsJson = canonicalizeArgs(args);
+	return { toolName, argsJson, signature: `${toolName}\u0000${argsJson}` };
+}
+
+function recs(...calls: Array<[string, unknown]>): ToolCallRecord[] {
+	return calls.map(([name, args]) => rec(name, args));
+}
+
+describe("detectSimilarRun", () => {
+	it("returns undefined for productive runs with distinct args", () => {
+		const records = recs(
+			["bash", { command: "vitest run test/a.test.ts" }],
+			["bash", { command: "git status --short" }],
+			["bash", { command: "npm run check" }],
+			["bash", { command: "rg -n 'loopGuard' packages" }],
+			["bash", { command: "node scripts/build.mjs --watch" }],
+		);
+		expect(detectSimilarRun(records)).toBeUndefined();
+	});
+
+	it("returns undefined for distinct read targets with long common path prefixes", () => {
+		const basePath =
+			"/Users/yeongyu/local-workspaces/senpi/packages/coding-agent/src/core/extensions/builtin/loop-guard";
+		const records = recs(
+			["read", { path: `${basePath}/detectors.ts` }],
+			["read", { path: `${basePath}/notice.ts` }],
+			["read", { path: `${basePath}/policy.ts` }],
+			["read", { path: `${basePath}/similarity.ts` }],
+			["read", { path: `${basePath}/tracker.ts` }],
+		);
+		expect(detectSimilarRun(records)).toBeUndefined();
+	});
+
+	it("returns undefined while the run is all-identical (identical detector owns it)", () => {
+		const records = recs(
+			...Array.from({ length: SIMILAR_RUN_THRESHOLD }, () => ["read", { path: "a.ts" }] as [string, unknown]),
+		);
+		expect(detectSimilarRun(records)).toBeUndefined();
+	});
+
+	it("fires for near-identical pagination runs at the threshold", () => {
+		const records = recs(
+			["read", { path: "src/app.ts", offset: 1, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 201, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 401, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 601, limit: 200 }],
+			["read", { path: "src/app.ts", offset: 801, limit: 200 }],
+		);
+		const detection = detectSimilarRun(records);
+		expect(detection?.kind).toBe("similar");
+		expect(detection?.count).toBe(SIMILAR_RUN_THRESHOLD);
+		if (detection?.kind === "similar") {
+			expect(detection.similarity).toBeGreaterThanOrEqual(SIMILARITY_THRESHOLD);
+		}
+	});
+
+	it("returns undefined for polling distinct task targets", () => {
+		const records = recs(
+			["task_output", { task_id: "st_019fc57c", mode: "status" }],
+			["task_output", { task_id: "st_019fc57d", mode: "status" }],
+			["task_output", { task_id: "st_019fc57e", mode: "status" }],
+			["task_output", { task_id: "st_019fc57f", mode: "status" }],
+			["task_output", { task_id: "st_019fc580", mode: "status" }],
+		);
+		expect(detectSimilarRun(records)).toBeUndefined();
+	});
+
+	it.each([
+		{
+			toolName: "bash_output",
+			targets: ["bash_17a", "bash_17b", "bash_17c", "bash_17d", "bash_17e"],
+			args: (target: string) => ({ bash_id: target, filter: "", view: "log" }),
+		},
+		{
+			toolName: "lsp_diagnostics",
+			targets: ["detectors.ts", "notice.ts", "policy.ts", "similarity.ts", "tracker.ts"],
+			args: (target: string) => ({
+				filePath: `/Users/yeongyu/local-workspaces/senpi/packages/coding-agent/src/core/extensions/builtin/loop-guard/${target}`,
+				severity: "all",
+			}),
+		},
+		{
+			toolName: "task_update",
+			targets: ["task_17a", "task_17b", "task_17c", "task_17d", "task_17e"],
+			args: (target: string) => ({
+				team_run_id: "team_123",
+				task_id: target,
+				status: "in_progress",
+				owner: "lead",
+			}),
+		},
+		{
+			toolName: "task_send",
+			targets: ["st_019fc57a", "st_019fc57b", "st_019fc57c", "st_019fc57d", "st_019fc57e"],
+			args: (target: string) => ({
+				to: target,
+				message: "return status",
+				team_run_id: "",
+				summary: "",
+				all_scope: false,
+			}),
+		},
+	])("returns undefined for distinct $toolName targets", ({ toolName, targets, args }) => {
+		expect(detectSimilarRun(targets.map((target) => rec(toolName, args(target))))).toBeUndefined();
+	});
+
+	it("fires for repeated polling of the same task target", () => {
+		const records = recs(
+			["task_output", { task_id: "st_019fc57d", mode: "tail", tail_lines: 20 }],
+			["task_output", { task_id: "st_019fc57d", mode: "tail", tail_lines: 40 }],
+			["task_output", { task_id: "st_019fc57d", mode: "tail", tail_lines: 60 }],
+			["task_output", { task_id: "st_019fc57d", mode: "tail", tail_lines: 80 }],
+			["task_output", { task_id: "st_019fc57d", mode: "tail", tail_lines: 100 }],
+		);
+		const detection = detectSimilarRun(records);
+		expect(detection?.kind).toBe("similar");
+		expect(detection?.count).toBe(SIMILAR_RUN_THRESHOLD);
+	});
+});


### PR DESCRIPTION
## Summary

- suppress `similar` loop-guard warnings only when every call in a same-tool
  run exposes a known target and all targets are distinct
- cover distinct read paths, task ids, terminal ids, diagnostic files, team
  task updates, and task-send recipients
- preserve same-target pagination/polling plus all existing identical and cycle
  behavior
- add a permanent real-CLI QA scenario and structure reminder detection so
  source text inside tool results cannot impersonate a steered reminder

## Evidence

### RED → GREEN

- RED: distinct long-common-prefix read paths returned a `similar` detection
- RED: the extension steered one warning for the productive read sequence
- RED matrix: read, task_output, bash_output, lsp_diagnostics, task_update,
  and task_send distinct-target cases all failed before the fix
- GREEN: focused loop-guard suites — 3 files, 39 tests

### Corpus replay

- 1,464 local senpi session files / 357 persisted notices / 0 parse errors
- new conservative rule suppresses 26 unambiguous distinct-target similar
  warnings
- preserves all 101 identical and 166 cycle notices, plus same-target polling
- broader rules were rejected because they would silence observed multi-task
  polling rotations and repeated-file investigations

### Validation

- `npm run build`
- `npm run check` — 2,686 files checked, no fixes
- `cd packages/coding-agent && npm test`
- `node .agents/skills/senpi-qa/scripts/loop-guard-qa.mjs --self-test --evidence loop-guard-fp`
  — 6/6 pass, including real source-CLI distinct-read silence
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence loop-guard-fp-mock-loop`
- `git diff --check`

LSP diagnostics were attempted for every changed TypeScript file, but this
harness rejects dedicated-worktree paths outside its request cwd. The
repository's root `tsc --noEmit` in `npm run check` passed as the authoritative
fallback.

## Delivery

- merge with a merge commit; do not squash or rebase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses false positive "similar" loop-guard warnings by recognizing distinct targets across same-tool runs, so productive fan-out doesn’t trigger reminders. Keeps identical, cycle, and same-target pagination/polling warnings unchanged.

- **Bug Fixes**
  - Treats distinct targets as productive for `read.path`, `bash_output.bash_id`, `task_output.task_id|name`, `task_update.task_id`, `task_send.to`, and `lsp_diagnostics.filePath`.
  - Falls back to existing bigram-Dice similarity when target data is missing or malformed.
  - Hardens tests and CLI QA: focused suites plus a real scenario now verify no reminder for distinct read fan-out, require all scripted provider turns to complete, and preserve existing warnings.

<sup>Written for commit 4c1d443a625d9f59cab859f4f3536bb141bbc343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

