### PR TITLE
fix(agent-session): unwedge goal continuations stalled by non-auto compaction

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2961,8 +2961,21 @@ export class AgentSession {
 					this.agent.steer(appMessage);
 				}
 			} else if (options?.triggerTurn) {
-				await this._enforceCompactionBeforeProvider(this._findLastAssistantMessage(), false, "pre_prompt");
-				await this._enforceFinalProviderAdmission([appMessage]);
+				try {
+					await this._enforceCompactionBeforeProvider(this._findLastAssistantMessage(), false, "pre_prompt");
+					await this._enforceFinalProviderAdmission([appMessage]);
+				} catch (error) {
+					// Mirror sendUserMessage's retention contract: an admission
+					// rejection must retain the message for later delivery instead
+					// of silently dropping it (the fire-and-forget extension action
+					// swallows this rejection).
+					if (options.deliverAs === "followUp") {
+						this.agent.followUp(appMessage);
+					} else {
+						this.agent.steer(appMessage);
+					}
+					throw error;
+				}
 				await this._promptAgent(appMessage);
 			} else {
 				this.agent.state.messages.push(appMessage);
@@ -3695,6 +3708,7 @@ export class AgentSession {
 			}
 			this._releasePendingCompactionAdmission(admission, outcome);
 			if (disconnected && !this.isCompacting) this._reconnectToAgent();
+			if (outcome === "completed") this._resumeQueuedMessagesAfterCompaction();
 		}
 	}
 
@@ -3729,6 +3743,7 @@ export class AgentSession {
 			if (!execution.accepted) {
 				return { applied: false, reason: "rejected" };
 			}
+			this._resumeQueuedMessagesAfterCompaction();
 			return { applied: true, reason: "ok" };
 		} catch (error) {
 			if (!compactionExecutionOwnsTerminalTransition(error)) {
@@ -4585,6 +4600,19 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Mirror _runAutoCompaction's post-success recovery for non-auto compaction
+	 * owners (manual, extension action, extension apply): a custom triggerTurn
+	 * message sent while the compaction was running is parked in the agent-level
+	 * queues without starting a turn, so a settled compaction must deliver it or
+	 * hidden continuations (e.g. goal) wedge until manual user input.
+	 */
+	private _resumeQueuedMessagesAfterCompaction(): void {
+		if (this.pendingMessageCount > 0 || this.agent.hasQueuedMessages()) {
+			this._scheduleContinuationAfterCurrentEvent();
+		}
+	}
+
 	private _scheduleContinuationAfterCurrentEvent(
 		options: AgentContinuationOptions = {},
 		retryContinuation = false,
@@ -5071,6 +5099,7 @@ export class AgentSession {
 							}
 							this._releasePendingCompactionAdmission(admission, outcome);
 							if (disconnected && !this.isCompacting) this._reconnectToAgent();
+							if (outcome === "completed") this._resumeQueuedMessagesAfterCompaction();
 						}
 					})();
 				},

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5152,6 +5152,7 @@ export class AgentSession {
 					const controller = admission.controller;
 					void (async () => {
 						let outcome: "completed" | "failed" | "aborted" = "failed";
+						let compactionCompleted = false;
 						let disconnected = false;
 
 						try {
@@ -5168,6 +5169,7 @@ export class AgentSession {
 							});
 							if (execution.accepted) {
 								outcome = "completed";
+								compactionCompleted = true;
 								options?.onComplete?.(execution.result);
 							} else {
 								outcome = "failed";
@@ -5199,7 +5201,9 @@ export class AgentSession {
 							}
 							this._releasePendingCompactionAdmission(admission, outcome);
 							if (disconnected && !this.isCompacting) this._reconnectToAgent();
-							if (outcome === "completed") this._resumeQueuedMessagesAfterCompaction();
+							// A throwing onComplete consumer overwrites outcome in the catch
+							// block, so recovery keys off whether compaction itself succeeded.
+							if (compactionCompleted) this._resumeQueuedMessagesAfterCompaction();
 						}
 					})();
 				},

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,42 @@
 # changes
 
+## Resume queued messages after non-auto compaction; retain admission-rejected custom messages (2026-08-03)
+
+### What changed
+
+- `agent-session.ts` gained `_resumeQueuedMessagesAfterCompaction()`, mirroring
+  `_runAutoCompaction`'s accepted-path recovery, and calls it on the success
+  paths of `applyCompaction()`, the extension `compact` context action, and
+  manual `compact()`.
+- `sendCustomMessage()`'s non-streaming `triggerTurn` path now retains the
+  message in the matching agent-level queue (`followUp`/`steer`) before
+  rethrowing when provider admission (`_enforceCompactionBeforeProvider` /
+  `_enforceFinalProviderAdmission`) rejects, mirroring `sendUserMessage`'s
+  documented retention contract.
+
+### Why
+
+- A custom `triggerTurn` message sent while a non-auto compaction owned the
+  session (extension feedback stage via `beginCompaction`, extension `compact`
+  action, manual `/compact`) was parked in the agent-level queues without a
+  turn and nothing resumed it afterwards; an admission rejection dropped the
+  message entirely because the fire-and-forget extension `sendMessage` action
+  swallows the rejection. Hidden goal continuations were the primary victim:
+  their single-flight latch clears only on `agent_start`, so the goal silently
+  idled at "Pursuing goal (...)" until manual user input.
+
+### Why this cannot be expressed externally
+
+- Both fixes depend on internal compaction lifecycle ownership, agent-level
+  queue state, and the private continuation scheduler; no extension hook can
+  observe or reschedule them.
+
+### Expected merge conflict zones
+
+- MEDIUM: `agent-session.ts` around `compact()` / `applyCompaction()` / the
+  extension `compact` action finally blocks, `sendCustomMessage()`'s
+  triggerTurn branch, and `_scheduleContinuationAfterCurrentEvent()`.
+
 ## Backfill: eval bridge deadlock prevention (2026-08-01)
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/goal-continuation-compaction-stall.test.ts
+++ b/packages/coding-agent/test/suite/regressions/goal-continuation-compaction-stall.test.ts
@@ -1,0 +1,266 @@
+import { type AssistantMessage, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareCompaction } from "../../../src/core/compaction/index.ts";
+import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
+import type { CustomMessage } from "../../../src/core/messages.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * Regression: a hidden goal continuation (any custom triggerTurn message) that
+ * is queued while a non-auto compaction owns the session must be resumed once
+ * that compaction settles, and an admission-rejected custom message must be
+ * retained instead of dropped. Without this, the goal extension's single-flight
+ * latch stays armed forever and the session silently idles at
+ * "Pursuing goal (…)" until manual user input.
+ */
+
+function createUsage(totalTokens: number) {
+	return {
+		input: totalTokens,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function wedgedContinuationMessage(): CustomMessage {
+	return {
+		role: "custom",
+		customType: "goal-continuation",
+		content: [{ type: "text", text: "Continue working toward the goal." }],
+		display: false,
+		timestamp: Date.now(),
+	};
+}
+
+function seedConversation(harness: Harness): void {
+	const now = Date.now();
+	const model = harness.getModel();
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "earlier prompt" }],
+		timestamp: now - 3000,
+	});
+	harness.sessionManager.appendMessage({
+		...fauxAssistantMessage("earlier response", { timestamp: now - 2000 }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: createUsage(9_500),
+	});
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "previous prompt" }],
+		timestamp: now - 1000,
+	});
+	harness.sessionManager.appendMessage({
+		...fauxAssistantMessage("previous response", { timestamp: now - 500 }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: createUsage(9_500),
+	});
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+}
+
+describe("goal continuation compaction stall regression", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("resumes a custom triggerTurn message queued during extension feedback compaction", async () => {
+		let ctxRef: ExtensionContext | undefined;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async (_event, ctx) => {
+						ctxRef = ctx;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		seedConversation(harness);
+		if (!ctxRef) throw new Error("extension context was not captured");
+
+		const preparation = prepareCompaction(
+			harness.sessionManager.getBranch(),
+			harness.settingsManager.getCompactionSettings(),
+			false,
+		);
+		if (!preparation) throw new Error("expected a compaction preparation");
+
+		// Mirror applyBlockingCompaction: feedback stage opens the compaction
+		// lifecycle for the whole (long) summarization window.
+		const signal = ctxRef.beginCompaction?.({ reason: "extension" });
+		expect(signal).toBeDefined();
+
+		harness.setResponses([fauxAssistantMessage("continuation turn ran")]);
+		await harness.session.sendCustomMessage(
+			{
+				customType: "goal-continuation",
+				content: "Continue working toward the goal.",
+				display: false,
+			},
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
+		// Queued without a turn while the compaction lifecycle is running.
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+		expect(harness.faux.state.callCount).toBe(0);
+
+		const applied = await harness.session.applyCompaction(
+			{
+				summary: "warm summary",
+				firstKeptEntryId: preparation.firstKeptEntryId,
+				tokensBefore: preparation.tokensBefore,
+				details: {},
+			},
+			{ reason: "extension" },
+		);
+		expect(applied.applied).toBe(true);
+		ctxRef.endCompaction?.({ reason: "extension", signal });
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+	});
+
+	it("resumes agent-level queued messages after a manual compaction", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "manual summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		seedConversation(harness);
+
+		harness.setResponses([fauxAssistantMessage("continuation turn ran")]);
+		harness.session.agent.followUp(wedgedContinuationMessage());
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+
+		await harness.session.compact();
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+	});
+
+	it("resumes agent-level queued messages after the extension compact action", async () => {
+		let ctxRef: ExtensionContext | undefined;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async (_event, ctx) => {
+						ctxRef = ctx;
+					});
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "extension summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		seedConversation(harness);
+		if (!ctxRef) throw new Error("extension context was not captured");
+
+		harness.setResponses([fauxAssistantMessage("continuation turn ran")]);
+		harness.session.agent.followUp(wedgedContinuationMessage());
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+
+		const completed = createDeferred();
+		ctxRef.compact({ onComplete: () => completed.resolve() });
+		await completed.promise;
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+	});
+
+	it("retains a custom triggerTurn message when required compaction is rejected", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async () => ({
+						cancel: true,
+						rejectionCause: "cancelled-by-extension",
+						reason: "forced rejection",
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const now = Date.now();
+		const model = harness.getModel();
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "previous prompt" }],
+			timestamp: now - 1000,
+		});
+		const overflowAssistant: AssistantMessage = {
+			...fauxAssistantMessage("", {
+				stopReason: "error",
+				errorMessage: "context_length_exceeded",
+				timestamp: now - 500,
+			}),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(100),
+		};
+		harness.sessionManager.appendMessage(overflowAssistant);
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		harness.setResponses([fauxAssistantMessage("must not reach provider")]);
+
+		await expect(
+			harness.session.sendCustomMessage(
+				{ customType: "goal-continuation", content: "Continue working toward the goal.", display: false },
+				{ triggerTurn: true, deliverAs: "followUp" },
+			),
+		).rejects.toThrow("Context remains above the compaction threshold because compaction did not complete");
+
+		expect(harness.faux.state.callCount).toBe(0);
+		// The rejected message must be retained for later delivery, mirroring
+		// sendUserMessage's retention contract, instead of silently dropped.
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/goal-continuation-compaction-stall.test.ts
+++ b/packages/coding-agent/test/suite/regressions/goal-continuation-compaction-stall.test.ts
@@ -213,6 +213,50 @@ describe("goal continuation compaction stall regression", () => {
 		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
 	});
 
+	it("resumes queued messages when the compact action onComplete callback throws", async () => {
+		let ctxRef: ExtensionContext | undefined;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 0 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_start", async (_event, ctx) => {
+						ctxRef = ctx;
+					});
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "extension summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		seedConversation(harness);
+		if (!ctxRef) throw new Error("extension context was not captured");
+
+		harness.setResponses([fauxAssistantMessage("continuation turn ran")]);
+		harness.session.agent.followUp(wedgedContinuationMessage());
+		expect(harness.session.agent.hasQueuedMessages()).toBe(true);
+
+		const completed = createDeferred();
+		ctxRef.compact({
+			onComplete: () => {
+				completed.resolve();
+				throw new Error("onComplete consumer failed");
+			},
+		});
+		await completed.promise;
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.session.agent.hasQueuedMessages()).toBe(false);
+	});
+
 	it("retains a custom triggerTurn message when required compaction is rejected", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1", contextWindow: 10_000, maxTokens: 1_000 }],


### PR DESCRIPTION
## Problem

A session with an active goal can silently stall at `Pursuing goal (…)` — no continuation turn ever starts — until the user manually types a message. Observed in a real session (senpi 2026.8.1): goal idle for tens of minutes, and the wake-up user message immediately ran "Compacting context...".

## Root cause

Two defects in the goal-continuation / compaction interplay:

1. **Non-auto compaction never resumes queued agent-level messages.**
   `sendCustomMessage()` parks a custom `triggerTurn` message into the agent-level `followUp`/`steer` queues without starting a turn while a compaction admission/lifecycle is active (`agent-session.ts` triggerTurn queue branch). `_runAutoCompaction` resumes those queues after success, but the non-auto completion paths never did:
   - `applyCompaction()` (used by the extension blocking/speculative flow — the long `beginCompaction` feedback window is exactly where `agent_end` goal continuations land),
   - the extension `compact` context action,
   - manual `compact()`.

   The goal extension's hidden continuation is the primary victim: its single-flight `continuationPending` latch clears only on `agent_start`, so a swallowed continuation permanently denies every later continuation (silent `single-flight` deny) — the session idles forever while the goal stays "active".

2. **Admission rejection drops custom messages.**
   When required pre-prompt compaction cannot complete, `sendCustomMessage()`'s triggerTurn path threw `RequiredCompactionError` **after** dropping the message (the fire-and-forget extension `sendMessage` action swallows the rejection). `sendUserMessage` documents and implements queue retention for the same failure; custom messages got no retention — same latch wedge.

## Fix

- New `_resumeQueuedMessagesAfterCompaction()` mirroring `_runAutoCompaction`'s accepted-path recovery, invoked on the success paths of `applyCompaction()`, the extension `compact` action, and manual `compact()`.
- `sendCustomMessage()` triggerTurn now retains the message in the matching agent-level queue before rethrowing on admission rejection (parity with `sendUserMessage`'s retention contract).

No goal-extension change needed: once the queued continuation starts a turn, `agent_start` clears the latch.

## Tests (failing-first)

`packages/coding-agent/test/suite/regressions/goal-continuation-compaction-stall.test.ts` — all four captured RED before the fix, GREEN after:

- resumes a custom triggerTurn message queued during extension feedback compaction (incident path: `beginCompaction` → queue → `applyCompaction`)
- resumes agent-level queued messages after a manual compaction
- resumes agent-level queued messages after the extension compact action
- retains a custom triggerTurn message when required compaction is rejected

RED: T1–T3 failed with `expected +0 to be 1` (queued message never resumed), T4 with `expected false to be true` (message dropped).

## Verification

- New regression file: 4/4 green.
- Blast radius: 59 test files / 544 tests across goal + compaction + session scopes green.
- Root `npm run check` green.
- senpi-qa evidence (common self-check, mock-loop, RPC, CLI smoke) under `local-ignore/qa-evidence/20260803-goal-compaction-stall/`.
- `src/core/changes.md` entry added in the same increment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stall where sessions with an active goal could get stuck at “Pursuing goal (…)”. Queued goal continuations now resume after non-auto compaction, and are retained on admission rejection so the next turn can start.

- Bug Fixes
  - Added `_resumeQueuedMessagesAfterCompaction()` and call it after successful non-auto compaction (`applyCompaction()`, extension `compact`, manual `compact()`), so queued `followUp`/`steer` messages trigger a turn — even if the extension `compact` `onComplete` callback throws.
  - Updated `sendCustomMessage()` `triggerTurn` to retain the message in the agent queue on admission rejection (parity with `sendUserMessage`); regression tests now cover resume paths (incl. thrown `onComplete`) and retention.

<sup>Written for commit 5a3f3d754d1af0403da8209896c7c5757f58c8ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

