### PR TITLE
fix(claude-sdk-oauth): close browser callback prompt (LAB-33)

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,18 @@
 # Builtin extensions changes
 
+## service-tier: enable fast mode for Codex API extension providers (2026-08-03)
+
+- `/fast` now checks the model's `openai-codex-responses` API capability instead
+  of requiring the built-in `openai-codex` provider id. Extension providers
+  such as `codex-pool` can therefore use the same session-level
+  `service_tier: "priority"` path without shadowing the stock command.
+- Non-Codex providers remain unchanged and still receive the existing warning.
+- Coverage: `test/suite/service-tier-extension.test.ts` registers a
+  `codex-pool` model on the Codex responses API, toggles `/fast`, and verifies
+  both the session indicator and request payload.
+- Expected merge conflict zones: LOW in `service-tier.ts` at the two Codex
+  eligibility guards; LOW in `service-tier-extension.test.ts`.
+
 ## tps: monotonic elapsed-time source for assistant intervals (2026-07-31)
 
 - `tps.ts` now derives assistant-message elapsed time from the monotonic

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/account-command.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/account-command.ts
@@ -165,6 +165,13 @@ async function addAccount(ctx: ExtensionCommandContext): Promise<void> {
 		await ctx.modelRegistry.modelRuntime.login(CLAUDE_SDK_OAUTH_PROVIDER_ID, "oauth", {
 			signal: ctx.signal,
 			prompt: async (prompt) => {
+				if (prompt.type === "select") {
+					const labels = prompt.options.map((option) => option.label);
+					const selected = await ctx.ui.select(prompt.message, labels);
+					const id = prompt.options.find((option) => option.label === selected)?.id;
+					if (!id) throw new Error("Login cancelled");
+					return id;
+				}
 				const answer = await ctx.ui.input(prompt.message);
 				if (answer === undefined) throw new Error("Login cancelled");
 				return answer;

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/account-events.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/account-events.ts
@@ -18,6 +18,21 @@ export type ProviderAccountEvent = ProviderAccountsChangedEvent | ProviderAccoun
 type ProviderAccountEventListener = (event: ProviderAccountEvent) => void;
 
 const listeners = new Set<ProviderAccountEventListener>();
+const PROVIDER_ACCOUNT_EVENT_BRIDGE = Symbol.for("senpi.provider-account-events.emit.v1");
+
+type ProviderAccountEventGlobal = typeof globalThis & {
+	[PROVIDER_ACCOUNT_EVENT_BRIDGE]?: (event: ProviderAccountEvent) => void;
+};
+
+const eventGlobal = globalThis as ProviderAccountEventGlobal;
+if (!eventGlobal[PROVIDER_ACCOUNT_EVENT_BRIDGE]) {
+	Object.defineProperty(eventGlobal, PROVIDER_ACCOUNT_EVENT_BRIDGE, {
+		value: (event: ProviderAccountEvent) => emit(event),
+		enumerable: false,
+		configurable: false,
+		writable: false,
+	});
+}
 
 export function subscribeProviderAccountEvents(listener: ProviderAccountEventListener): () => void {
 	listeners.add(listener);

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/accounts.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/accounts.ts
@@ -69,6 +69,12 @@ export function removeAccount(credential: ClaudeSdkOauthCredential, name: string
 	const accounts = storedSlots(credential).filter((slot) => slot.name !== name);
 	const next: ClaudeSdkOauthCredential = { ...credential, accounts };
 	if (credential.pinned === name) delete next.pinned;
+	if (credential.slotState?.[name]) {
+		const slotState = { ...credential.slotState };
+		delete slotState[name];
+		if (Object.keys(slotState).length === 0) delete next.slotState;
+		else next.slotState = slotState;
+	}
 	return next;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
@@ -148,7 +148,11 @@ async function managedPool(settings: ClaudeSdkOauthProviderSettings): Promise<Ma
 			(name) => environment[name],
 		);
 	}
-	if (accounts.length === 0) return undefined;
+	if (accounts.length === 0) {
+		throw new Error(
+			"authentication_failed: No Claude SDK OAuth accounts configured. Add one with /claude-account add.",
+		);
+	}
 	const stored = credential?.type === "oauth" ? (credential as ClaudeSdkOauthCredential) : undefined;
 	return { accounts, lane, pinnedAccount: settings.pinnedAccount ?? stored?.pinned, store };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,11 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-03 - Browser callback closes manual-code input
+
+- Forward each Anthropic OAuth prompt's `AbortSignal` through the extension OAuth callback adapter.
+- When the localhost browser callback wins, the still-pending manual-code input now closes before account naming starts instead of leaving duplicated, mirrored fields.
+- Coverage: `test/suite/regressions/lab-33-claude-oauth-prompt-abort.test.ts`.
+
 ## 2026-08-02 - Provider configuration account manager
 
 - Selecting a configured Claude SDK OAuth provider now opens account controls instead of immediately starting another OAuth login.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,12 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-02 - Provider configuration account manager
+
+- Selecting a configured Claude SDK OAuth provider now opens account controls instead of immediately starting another OAuth login.
+- The provider menu supports add, per-account logout, full logout, pin, unpin, and unblock while preserving the existing `/claude-account` command surface.
+- Empty pools still enter OAuth directly, so first-time login behavior is unchanged.
+- Merge-conflict risk: low. The change is isolated to the provider OAuth login adapter and its focused tests.
+
 ## 2026-08-01 - Fail closed after managed-account logout
 
 - Managed `oauth-slots` and `config-dir` modes now report that login is required when their account pool is empty instead of silently falling back to ambient Claude CLI credentials.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,12 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-01 - Fail closed after managed-account logout
+
+- Managed `oauth-slots` and `config-dir` modes now report that login is required when their account pool is empty instead of silently falling back to ambient Claude CLI credentials.
+- This makes `/logout` authoritative for the selected managed provider: a fallback attempt cannot reuse an unrelated local Claude login and appear to answer successfully.
+- Ambient mode remains unchanged and still intentionally inherits non-Senpi Claude authentication.
+- Merge-conflict risk: low. The only overlap surface is the empty-pool branch in `managedPool`.
+
 ## 2026-07-31 - Native system prompt, session reuse, env overrides, and transcript hardening
 
 - **System prompt modes (new default: `full`).** Added a `systemPromptMode` setting with three values. `full` (new default) sends senpi's own composed system prompt verbatim — previously the lane rebuilt a prompt from the SDK `claude_code` preset plus three extracted regions, so any region without a dedicated extractor was silently dropped (a persistent response-language instruction never reached the model). `preset-append` is the previous behaviour, now DEPRECATED and kept for one release; selecting it emits a one-time warning. `override` loads the system prompt verbatim from a file (`systemPromptFile`). The legacy `appendSystemPrompt` key still works and maps onto the modes: `false` → `preset-append`, `true`/unset → `full`. Setting both `appendSystemPrompt` and `systemPromptMode` makes `systemPromptMode` win and emits a warning.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
@@ -48,6 +48,7 @@ export default function claudeSdkOauthExtension(pi: ExtensionAPI): void {
 		streamSimple: streamClaudeSdkOauth,
 		oauth: createOAuthConfig({
 			readCurrent: async () => readStoredCredential(CLAUDE_SDK_OAUTH_PROVIDER_ID),
+			readEnv: (name) => process.env[name],
 			readAnthropicCredential: async () => {
 				const credential = readStoredCredential("anthropic");
 				return credential && typeof credential.access === "string"

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
@@ -6,6 +6,8 @@ import {
 	type ClaudeSdkOauthCredential,
 	emptyCredential,
 	listAccounts,
+	pinAccount,
+	removeAccount,
 	SENTINEL_OAUTH_FIELDS,
 } from "./accounts.ts";
 
@@ -13,6 +15,7 @@ export type OAuthLoginCallbacks = {
 	signal?: AbortSignal;
 	onAuth?: (event: { url: string }) => void | Promise<void>;
 	onPrompt?: (prompt: { message: string; placeholder?: string }) => Promise<string>;
+	onSelect?: (prompt: { message: string; options: { id: string; label: string }[] }) => Promise<string | undefined>;
 	onManualCodeInput?: () => Promise<string>;
 	onProgress?: (message: string) => void;
 };
@@ -48,9 +51,119 @@ async function promptAccountName(callbacks: OAuthLoginCallbacks, existing: Accou
 	return answer || `account-${existing.length + 1}`;
 }
 
+function accountSummary(
+	credential: ClaudeSdkOauthCredential,
+	readEnv?: (name: string) => string | undefined,
+	now = Date.now(),
+): string {
+	return listAccounts(credential, readEnv)
+		.map((slot) => {
+			const state: string[] = [];
+			if (credential.pinned === slot.name) state.push("pinned");
+			if (slot.blockReason === "auth_error") state.push("needs re-login");
+			else if (slot.blockedUntil !== undefined && slot.blockedUntil > now) {
+				state.push(`blocked ${Math.ceil((slot.blockedUntil - now) / 1000)}s`);
+			} else state.push("available");
+			return `${slot.name} — ${state.join(", ")}`;
+		})
+		.join("\n");
+}
+
+async function pickAccount(
+	callbacks: OAuthLoginCallbacks,
+	accounts: AccountSlot[],
+	message: string,
+): Promise<string | undefined> {
+	return callbacks.onSelect?.({
+		message,
+		options: accounts.map((slot) => ({ id: slot.name, label: slot.name })),
+	});
+}
+
+function clearPin(credential: ClaudeSdkOauthCredential): ClaudeSdkOauthCredential {
+	if (credential.pinned === undefined) return credential;
+	const next = { ...credential };
+	delete next.pinned;
+	return next;
+}
+
+function clearAccountBlock(credential: ClaudeSdkOauthCredential, name: string): ClaudeSdkOauthCredential {
+	const next: ClaudeSdkOauthCredential = {
+		...credential,
+		accounts: (credential.accounts ?? []).map((slot) => {
+			if (slot.name !== name) return slot;
+			const next = { ...slot };
+			delete next.blockedUntil;
+			delete next.blockReason;
+			return next;
+		}),
+	};
+	if (credential.slotState?.[name]) {
+		const slotState = { ...credential.slotState };
+		delete slotState[name];
+		if (Object.keys(slotState).length === 0) delete next.slotState;
+		else next.slotState = slotState;
+	}
+	return next;
+}
+
+async function manageExistingAccounts(
+	credential: ClaudeSdkOauthCredential,
+	callbacks: OAuthLoginCallbacks,
+	readEnv?: (name: string) => string | undefined,
+): Promise<ClaudeSdkOauthCredential | undefined> {
+	const accounts = listAccounts(credential, readEnv);
+	const action = await callbacks.onSelect?.({
+		message: `Claude accounts\n${accountSummary(credential, readEnv)}`,
+		options: [
+			{ id: "add", label: "Add an account" },
+			{ id: "remove", label: "Log out of one account" },
+			{ id: "logout-all", label: "Log out of every stored account" },
+			{ id: "pin", label: "Pin an account" },
+			{ id: "unpin", label: "Clear the pin" },
+			{ id: "unblock", label: "Clear a block" },
+		],
+	});
+
+	switch (action) {
+		case "add":
+			return undefined;
+		case "remove": {
+			const name = await pickAccount(callbacks, credential.accounts ?? [], "Log out of which stored account?");
+			return name ? removeAccount(credential, name) : credential;
+		}
+		case "logout-all": {
+			const confirmed = await callbacks.onSelect?.({
+				message: `Log out of all ${(credential.accounts ?? []).length} stored Claude account(s)?`,
+				options: [
+					{ id: "no", label: "Cancel" },
+					{ id: "yes", label: "Log out of every account" },
+				],
+			});
+			if (confirmed !== "yes") return credential;
+			const cleared = { ...clearPin(credential), accounts: [] };
+			delete cleared.slotState;
+			return cleared;
+		}
+		case "pin": {
+			const name = await pickAccount(callbacks, accounts, "Pin which account?");
+			return name ? pinAccount(credential, name) : credential;
+		}
+		case "unpin":
+			return clearPin(credential);
+		case "unblock": {
+			const name = await pickAccount(callbacks, accounts, "Clear the block on which account?");
+			return name ? clearAccountBlock(credential, name) : credential;
+		}
+		default:
+			return credential;
+	}
+}
+
 export function createOAuthConfig(deps: {
 	readCurrent: CurrentCredentialReader;
 	readAnthropicCredential?: () => Promise<{ access: string; refresh: string; expires: number } | undefined>;
+	readEnv?: (name: string) => string | undefined;
 	loginFlow?: OAuthAuth;
 }): OAuthConfigShape {
 	return {
@@ -58,7 +171,11 @@ export function createOAuthConfig(deps: {
 
 		async login(callbacks) {
 			const current = (await deps.readCurrent()) ?? emptyCredential();
-			const existing = listAccounts(current);
+			const existing = listAccounts(current, deps.readEnv);
+			if (existing.length > 0 && callbacks.onSelect) {
+				const managed = await manageExistingAccounts(current, callbacks, deps.readEnv);
+				if (managed) return managed;
+			}
 			if (existing.length === 0 && deps.readAnthropicCredential && callbacks.onPrompt) {
 				const imported = await deps.readAnthropicCredential();
 				if (imported) {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
@@ -14,7 +14,7 @@ import {
 export type OAuthLoginCallbacks = {
 	signal?: AbortSignal;
 	onAuth?: (event: { url: string }) => void | Promise<void>;
-	onPrompt?: (prompt: { message: string; placeholder?: string }) => Promise<string>;
+	onPrompt?: (prompt: { message: string; placeholder?: string; signal?: AbortSignal }) => Promise<string>;
 	onSelect?: (prompt: { message: string; options: { id: string; label: string }[] }) => Promise<string | undefined>;
 	onManualCodeInput?: () => Promise<string>;
 	onProgress?: (message: string) => void;
@@ -195,7 +195,13 @@ export function createOAuthConfig(deps: {
 				signal: callbacks.signal,
 				prompt: async (prompt) => {
 					if (prompt.type === "select") return "";
-					return callbacks.onPrompt ? callbacks.onPrompt({ message: prompt.message }) : "";
+					return callbacks.onPrompt
+						? callbacks.onPrompt({
+								message: prompt.message,
+								placeholder: prompt.placeholder,
+								signal: prompt.signal,
+							})
+						: "";
 				},
 				notify: (event) => {
 					if (event.type === "auth_url" && callbacks.onAuth) void callbacks.onAuth({ url: event.url });

--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -23,6 +23,7 @@ goal/
 ├── cache-warm.ts     # Cache-warm metrics estimator + scheduled/resumed notices + goal-cache-warmup entry contract
 ├── cache-warm-renderer.ts # TUI entry renderer for goal-cache-warmup custom entries
 ├── elapsed-ticker.ts # GoalElapsedTicker + goalLiveElapsedSeconds (live footer refresh)
+├── wait-progress.ts  # renderGoalWaitBar + formatGoalWaitLabel (continuation-wait countdown render)
 ├── errors.ts         # Goal{AlreadyExists,NotFound}/store error classes
 └── changes.md        # Fork tracker (port + budget behavior removal + wire compatibility)
 ```
@@ -95,6 +96,6 @@ Do not return an `isError` property; it is ignored.
 ## NOTES
 
 - Tests: `test/suite/goal-store.test.ts`, `goal-modules.test.ts`,
-  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
+  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts`, `goal-wait-progress.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
 - Registered last in `builtin/index.ts` `builtinExtensions`; inert until a goal
   is created.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -110,6 +110,55 @@
 - LOW in monitor continuation tests that observe delayed persistence.
 - NONE in the goal store schema, public extension API, or status transitions.
 
+## PROPOSAL: continuation-wait countdown render layer (2026-07-31)
+
+Status: **render layer only.** The wiring that drives this into the footer is deliberately
+not part of this change and is open for maintainer direction.
+
+### What changed
+
+- New `wait-progress.ts` exports `GOAL_WAIT_BAR_CELLS` (12), `renderGoalWaitBar(elapsedRatio)`
+  and `formatGoalWaitLabel({ kind, remainingMs, totalMs, activeMonitorCount })`. It reuses
+  `formatWakeDuration` from `cache-warm.ts` so a wait countdown reads identically to the
+  existing cache-warm notices.
+- `kind: "userGrace"` renders `▰▰▰▱▱▱▱▱▱▱▱▱ goal resumes in 47s`;
+  `kind: "monitor"` renders `… goal continues in 3m 12s · 2 monitors on duty` with
+  singular/plural monitor wording. Ratios are clamped, so a late timer never overflows the bar
+  and a negative remaining time renders `0s` rather than a minus sign.
+- Nothing imports the module yet: no scheduler, event, entry, or footer behavior changes here.
+
+### Why
+
+`#schedule()` in `monitor-continuation.ts` treats its two waits asymmetrically. The `monitor`
+branch (`GOAL_MONITOR_CONTINUATION_DELAY_MS`, 240s) emits `ui.notify` plus a durable
+`goal-cache-warmup` entry, so the wait is visible. The `userGrace` branch
+(`GOAL_USER_GRACE_DELAY_MS`, `continuation.ts:11`, 60s) emits nothing at all — no notify, no
+event, no entry. A session that is waiting out the grace window is therefore
+indistinguishable from a hung one for a full minute.
+
+Session forensics on a real transcript show the shape: gaps of 60.0s / 60.3s / 60.5s / 61.6s
+each begin immediately after a `senpi.hooks.stop-state {count:0}` record and end with a
+`goal-continuation` injection, with no rendered output in between. The 240s monitor wait in the
+same session did produce visible `goal-cache-warmup` scheduled→resumed entries. Tool calls
+paired 170/170 and child-task wakes delivered 11/11 in that transcript, so the silence is the
+unrendered wait itself and not a lost result or a dropped wake.
+
+### Open questions for maintainers
+
+- Should the `userGrace` branch emit a durable entry (symmetric with `goal-cache-warmup`), a
+  transient footer segment only, or both?
+- If footer-only: extend `GoalElapsedTicker`, or add a second ticker so the wait countdown and
+  the `Pursuing goal (…)` elapsed segment stay independent?
+- Is a 12-cell bar the right footer budget, or should the countdown be text-only?
+
+### Expected merge conflict zones on next upstream sync
+
+- NONE for `wait-progress.ts` — new fork-only file with no importers.
+- LOW in `AGENTS.md` (FILES table + tests list, additive lines only).
+- Wiring, once agreed, would touch `monitor-continuation.ts` `#schedule()` and the footer
+  status surface; both are fork-owned but `#schedule()` is actively edited, so that follow-up
+  carries real conflict risk and is intentionally left out of this change.
+
 ## Observable progress resets the persisted continuation cap streak (2026-07-30)
 
 ### What changed
@@ -679,4 +728,3 @@ codex-aligned tool naming, and budget-driven behavior removed. An optional
 - LOW in `types.ts` around the `SessionEvent` union and `on()` overloads (additive).
 - LOW in `agent-session.ts` around `abort()` and the `AgentSessionEvent` union (additive).
 - LOW in `goal/index.ts` around the session_start handler and the new session_abort handler.
-

--- a/packages/coding-agent/src/core/extensions/builtin/goal/wait-progress.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/wait-progress.ts
@@ -1,0 +1,43 @@
+import { formatWakeDuration } from "./cache-warm.ts";
+
+export type GoalWaitKind = "monitor" | "userGrace";
+
+export interface GoalWaitLabelInput {
+	readonly kind: GoalWaitKind;
+	readonly remainingMs: number;
+	readonly totalMs: number;
+	readonly activeMonitorCount: number;
+}
+
+export const GOAL_WAIT_BAR_CELLS = 12;
+
+const FILLED_CELL = "\u25b0";
+const EMPTY_CELL = "\u25b1";
+
+function clampRatio(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.min(1, Math.max(0, value));
+}
+
+export function renderGoalWaitBar(elapsedRatio: number): string {
+	const filled = Math.round(clampRatio(elapsedRatio) * GOAL_WAIT_BAR_CELLS);
+	return FILLED_CELL.repeat(filled) + EMPTY_CELL.repeat(GOAL_WAIT_BAR_CELLS - filled);
+}
+
+function elapsedRatioOf(remainingMs: number, totalMs: number): number {
+	if (totalMs <= 0) return 1;
+	return clampRatio((totalMs - Math.max(0, remainingMs)) / totalMs);
+}
+
+function monitorsOnDuty(count: number): string {
+	return count === 1 ? "1 monitor on duty" : `${count} monitors on duty`;
+}
+
+export function formatGoalWaitLabel(input: GoalWaitLabelInput): string {
+	const bar = renderGoalWaitBar(elapsedRatioOf(input.remainingMs, input.totalMs));
+	const remaining = formatWakeDuration(Math.max(0, input.remainingMs));
+	if (input.kind === "monitor") {
+		return `${bar} goal continues in ${remaining} \u00b7 ${monitorsOnDuty(input.activeMonitorCount)}`;
+	}
+	return `${bar} goal resumes in ${remaining}`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -7,7 +7,6 @@ export type { ServiceTier };
 
 type ProviderPayload = Record<string, unknown>;
 
-const OPENAI_CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
 const FAST_MODEL_SUFFIX = "-fast";
 const PRIORITY_TIER: ServiceTier = "priority";
@@ -88,7 +87,7 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 		pi.setSessionFastMode(false);
 
 		const model = ctx.model;
-		if (model?.provider !== OPENAI_CODEX_PROVIDER) {
+		if (model?.api !== OPENAI_CODEX_RESPONSES_API) {
 			return;
 		}
 
@@ -102,7 +101,7 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 		description: "Toggle OpenAI Codex fast mode for this session",
 		handler: async (_args, ctx) => {
 			const model = ctx.model;
-			if (model?.provider !== OPENAI_CODEX_PROVIDER) {
+			if (model?.api !== OPENAI_CODEX_RESPONSES_API) {
 				ctx.ui.notify("Fast mode is only available for OpenAI Codex models.", "warning");
 				return;
 			}

--- a/packages/coding-agent/test/claude-sdk-oauth-accounts.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-accounts.test.ts
@@ -1,5 +1,6 @@
 import { type Credential, type CredentialStore, InMemoryCredentialStore } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
+import { subscribeProviderAccountEvents } from "../src/core/extensions/builtin/claude-sdk-oauth/account-events.ts";
 import {
 	addAccount,
 	assertSentinelInvariant,
@@ -45,6 +46,21 @@ const slotA = {
 };
 
 describe("account slots", () => {
+	it("bridges addon account-change notifications to stock listeners", () => {
+		const events: unknown[] = [];
+		const unsubscribe = subscribeProviderAccountEvents((event) => events.push(event));
+		try {
+			const bridge = (globalThis as Record<symbol, unknown>)[Symbol.for("senpi.provider-account-events.emit.v1")] as
+				| ((event: unknown) => void)
+				| undefined;
+			expect(bridge).toBeTypeOf("function");
+			bridge?.({ type: "accounts_changed", provider: "claude-sdk-oauth" });
+		} finally {
+			unsubscribe();
+		}
+		expect(events).toEqual([{ type: "accounts_changed", provider: "claude-sdk-oauth" }]);
+	});
+
 	it("creates an empty credential with sentinel top-level fields", () => {
 		const cred = emptyCredential();
 		expect(cred.type).toBe("oauth");
@@ -61,8 +77,16 @@ describe("account slots", () => {
 		expect(listAccounts(cred).map((a) => a.name)).toEqual(["default", "work"]);
 		cred = pinAccount(cred, "work");
 		expect(cred.pinned).toBe("work");
+		cred = {
+			...cred,
+			slotState: {
+				default: { blockedUntil: 123, blockReason: "rate_limit" },
+				work: { blockedUntil: 456, blockReason: "quota" },
+			},
+		};
 		cred = removeAccount(cred, "default");
 		expect(listAccounts(cred).map((a) => a.name)).toEqual(["work"]);
+		expect(cred.slotState).toEqual({ work: { blockedUntil: 456, blockReason: "quota" } });
 	});
 
 	it("rejects duplicate account names", () => {

--- a/packages/coding-agent/test/claude-sdk-oauth-login.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-login.test.ts
@@ -1,6 +1,11 @@
 import type { OAuthAuth } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
-import { listAccounts, SENTINEL_OAUTH_FIELDS } from "../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
+import { describe, expect, it, vi } from "vitest";
+import {
+	addAccount,
+	emptyCredential,
+	listAccounts,
+	SENTINEL_OAUTH_FIELDS,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
 import { createOAuthConfig } from "../src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts";
 
 function fakeFlow(credential: { access: string; refresh: string; expires: number }): OAuthAuth {
@@ -77,5 +82,146 @@ describe("claude-sdk-oauth oauth login config", () => {
 		const config = createOAuthConfig({ readCurrent: async () => undefined, loginFlow: fakeFlow(fresh) });
 		const credential = await config.login({});
 		expect(await config.refreshToken(credential)).toBe(credential);
+	});
+
+	it("opens account management instead of starting OAuth when accounts already exist", async () => {
+		const current = addAccount(addAccount(emptyCredential(), { name: "default", ...fresh, source: "login" }), {
+			name: "work",
+			access: "a2",
+			refresh: "r2",
+			expires: Date.now() + 60_000,
+			source: "login",
+		});
+		const login = vi.fn(async () => ({ type: "oauth" as const, ...fresh }));
+		const selections = ["pin", "work"];
+		const config = createOAuthConfig({
+			readCurrent: async () => current,
+			loginFlow: { ...fakeFlow(fresh), login },
+		});
+
+		const credential = await config.login({
+			onSelect: async ({ options }) => {
+				expect(options.length).toBeGreaterThan(0);
+				return selections.shift();
+			},
+		});
+
+		expect(credential).toMatchObject({ pinned: "work" });
+		expect(login).not.toHaveBeenCalled();
+	});
+
+	it("logout-all clears accounts, pins, and stale slot state", async () => {
+		const current = {
+			...addAccount(emptyCredential(), { name: "default", ...fresh, source: "login" as const }),
+			pinned: "default",
+			slotState: { default: { blockedUntil: 123, blockReason: "quota" } },
+		};
+		const selections = ["logout-all", "yes"];
+		const config = createOAuthConfig({ readCurrent: async () => current, loginFlow: fakeFlow(fresh) });
+
+		const credential = await config.login({
+			onSelect: async () => selections.shift(),
+		});
+
+		expect(listAccounts(credential as never)).toEqual([]);
+		expect(credential).not.toHaveProperty("pinned");
+		expect(credential).not.toHaveProperty("slotState");
+	});
+
+	it("unblock clears only the selected account block", async () => {
+		const current = addAccount(emptyCredential(), {
+			name: "default",
+			...fresh,
+			source: "login",
+			blockedUntil: 123,
+			blockReason: "quota",
+		});
+		const selections = ["unblock", "default"];
+		const config = createOAuthConfig({ readCurrent: async () => current, loginFlow: fakeFlow(fresh) });
+
+		const credential = await config.login({ onSelect: async () => selections.shift() });
+		expect(listAccounts(credential as never)[0]).not.toHaveProperty("blockReason");
+		expect(listAccounts(credential as never)[0]).not.toHaveProperty("blockedUntil");
+	});
+
+	it("includes environment accounts in pin and unblock controls", async () => {
+		const current = {
+			...emptyCredential(),
+			slotState: { env: { blockedUntil: 123, blockReason: "quota" } },
+		};
+		const selections = ["pin", "env"];
+		const config = createOAuthConfig({
+			readCurrent: async () => current,
+			readEnv: (name) => (name === "CLAUDE_CODE_OAUTH_TOKEN" ? "environment-token" : undefined),
+			loginFlow: fakeFlow(fresh),
+		});
+
+		const credential = await config.login({ onSelect: async () => selections.shift() });
+		expect(credential).toMatchObject({ pinned: "env" });
+
+		const unblockSelections = ["unblock", "env"];
+		const unblocked = await createOAuthConfig({
+			readCurrent: async () => current,
+			readEnv: (name) => (name === "CLAUDE_CODE_OAUTH_TOKEN" ? "environment-token" : undefined),
+			loginFlow: fakeFlow(fresh),
+		}).login({ onSelect: async () => unblockSelections.shift() });
+		expect(unblocked).not.toHaveProperty("slotState");
+	});
+
+	it("removes one stored account and its stale state", async () => {
+		const current = {
+			...addAccount(addAccount(emptyCredential(), { name: "default", ...fresh, source: "login" as const }), {
+				name: "work",
+				access: "a2",
+				refresh: "r2",
+				expires: fresh.expires,
+				source: "login" as const,
+			}),
+			slotState: { default: { blockedUntil: 123, blockReason: "quota" } },
+		};
+		const selections = ["remove", "default"];
+		const config = createOAuthConfig({ readCurrent: async () => current, loginFlow: fakeFlow(fresh) });
+
+		const credential = await config.login({ onSelect: async () => selections.shift() });
+		expect(listAccounts(credential as never).map((slot) => slot.name)).toEqual(["work"]);
+		expect(credential).not.toHaveProperty("slotState");
+	});
+
+	it("can clear a stored pin without starting OAuth", async () => {
+		const current = {
+			...addAccount(emptyCredential(), { name: "default", ...fresh, source: "login" as const }),
+			pinned: "default",
+		};
+		const login = vi.fn(async () => ({ type: "oauth" as const, ...fresh }));
+		const config = createOAuthConfig({
+			readCurrent: async () => current,
+			loginFlow: { ...fakeFlow(fresh), login },
+		});
+
+		const credential = await config.login({ onSelect: async () => "unpin" });
+		expect(credential).not.toHaveProperty("pinned");
+		expect(login).not.toHaveBeenCalled();
+	});
+
+	it("can choose add from management and complete a new OAuth login", async () => {
+		const current = addAccount(emptyCredential(), { name: "default", ...fresh, source: "login" });
+		const login = vi.fn(async () => ({
+			type: "oauth" as const,
+			access: "a2",
+			refresh: "r2",
+			expires: fresh.expires,
+		}));
+		const config = createOAuthConfig({
+			readCurrent: async () => current,
+			loginFlow: { ...fakeFlow(fresh), login },
+		});
+
+		const credential = await config.login({
+			onSelect: async () => "add",
+			onPrompt: async () => "work",
+		});
+
+		expect(listAccounts(credential as never).map((slot) => slot.name)).toEqual(["default", "work"]);
+		expect(login).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/coding-agent/test/suite/goal-wait-progress.test.ts
+++ b/packages/coding-agent/test/suite/goal-wait-progress.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatGoalWaitLabel,
+	GOAL_WAIT_BAR_CELLS,
+	renderGoalWaitBar,
+} from "../../src/core/extensions/builtin/goal/wait-progress.ts";
+
+const FILLED = "▰";
+const EMPTY = "▱";
+
+function filledCells(bar: string): number {
+	return [...bar].filter((cell) => cell === FILLED).length;
+}
+
+describe("goal wait progress bar", () => {
+	it("renders an empty bar at the start of the wait", () => {
+		expect(renderGoalWaitBar(0)).toBe(EMPTY.repeat(GOAL_WAIT_BAR_CELLS));
+	});
+
+	it("renders a full bar once the wait has elapsed", () => {
+		expect(renderGoalWaitBar(1)).toBe(FILLED.repeat(GOAL_WAIT_BAR_CELLS));
+	});
+
+	it("fills proportionally at the halfway point", () => {
+		const bar = renderGoalWaitBar(0.5);
+		expect([...bar]).toHaveLength(GOAL_WAIT_BAR_CELLS);
+		expect(filledCells(bar)).toBe(Math.round(GOAL_WAIT_BAR_CELLS / 2));
+	});
+
+	it("clamps out-of-range ratios instead of overflowing the bar", () => {
+		expect(renderGoalWaitBar(-1)).toBe(EMPTY.repeat(GOAL_WAIT_BAR_CELLS));
+		expect(renderGoalWaitBar(9)).toBe(FILLED.repeat(GOAL_WAIT_BAR_CELLS));
+	});
+});
+
+describe("goal wait label", () => {
+	it("shows remaining seconds and a partially filled bar for a user-grace wait", () => {
+		const label = formatGoalWaitLabel({
+			kind: "userGrace",
+			remainingMs: 47_000,
+			totalMs: 60_000,
+			activeMonitorCount: 0,
+		});
+
+		expect(label).toContain("47s");
+		expect(label).toContain(FILLED);
+		expect(label).toContain(EMPTY);
+	});
+
+	it("formats a multi-minute monitor wait and names the monitors on duty", () => {
+		const label = formatGoalWaitLabel({
+			kind: "monitor",
+			remainingMs: 192_000,
+			totalMs: 240_000,
+			activeMonitorCount: 2,
+		});
+
+		expect(label).toContain("3m 12s");
+		expect(label).toContain("2 monitors");
+	});
+
+	it("uses the singular monitor wording for a single monitor", () => {
+		const label = formatGoalWaitLabel({
+			kind: "monitor",
+			remainingMs: 60_000,
+			totalMs: 240_000,
+			activeMonitorCount: 1,
+		});
+
+		expect(label).toContain("1 monitor");
+		expect(label).not.toContain("1 monitors");
+	});
+
+	it("never renders a negative remaining time", () => {
+		const label = formatGoalWaitLabel({
+			kind: "userGrace",
+			remainingMs: -5_000,
+			totalMs: 60_000,
+			activeMonitorCount: 0,
+		});
+
+		expect(label).toContain("0s");
+		expect(label).not.toContain("-");
+	});
+
+	it("keeps the user-grace label free of monitor wording", () => {
+		const label = formatGoalWaitLabel({
+			kind: "userGrace",
+			remainingMs: 30_000,
+			totalMs: 60_000,
+			activeMonitorCount: 3,
+		});
+
+		expect(label).not.toContain("monitor");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/lab-27-claude-oauth-logout.test.ts
+++ b/packages/coding-agent/test/suite/regressions/lab-27-claude-oauth-logout.test.ts
@@ -1,0 +1,44 @@
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	overrideAuthLaneBoundary,
+	queryWithAuthLane,
+	resetAuthLaneBoundary,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts";
+import type {
+	Options,
+	SDKMessage,
+	SdkQuery,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+
+async function consume(messages: AsyncGenerator<SDKMessage>): Promise<void> {
+	for await (const _message of messages) void _message;
+}
+
+afterEach(() => {
+	resetAuthLaneBoundary();
+});
+
+describe("LAB-27 Claude OAuth logout", () => {
+	it("requires login instead of falling back to ambient Claude credentials", async () => {
+		overrideAuthLaneBoundary({
+			createStore: () => new InMemoryCredentialStore(),
+			env: () => ({ PATH: "/usr/bin" }),
+		});
+		const query = vi.fn(() => {
+			throw new Error("ambient Claude query must not run");
+		}) as unknown as SdkQuery;
+
+		const messages = queryWithAuthLane({
+			prompt: "resume",
+			query,
+			buildOptions: () => ({}) as Options,
+			providerSettings: { tokenInjection: "oauth-slots" },
+		});
+
+		await expect(consume(messages)).rejects.toThrow(
+			"No Claude SDK OAuth accounts configured. Add one with /claude-account add.",
+		);
+		expect(query).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/lab-33-claude-oauth-prompt-abort.test.ts
+++ b/packages/coding-agent/test/suite/regressions/lab-33-claude-oauth-prompt-abort.test.ts
@@ -1,0 +1,48 @@
+import type { OAuthAuth } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { createOAuthConfig } from "../../../src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts";
+
+describe("LAB-33 Claude OAuth prompt lifecycle", () => {
+	it("forwards the provider abort signal to the manual-code prompt", async () => {
+		let providerSignal: AbortSignal | undefined;
+		let callbackSignal: AbortSignal | undefined;
+
+		const loginFlow: OAuthAuth = {
+			name: "LAB-33 fake browser callback",
+			login: async (interaction) => {
+				const controller = new AbortController();
+				providerSignal = controller.signal;
+				await interaction.prompt({
+					type: "manual_code",
+					message: "Paste the authorization code",
+					signal: controller.signal,
+				});
+				controller.abort();
+				return {
+					type: "oauth",
+					access: "new-access",
+					refresh: "new-refresh",
+					expires: Date.now() + 3_600_000,
+				};
+			},
+			refresh: async (credential) => credential,
+			toAuth: async (credential) => ({ apiKey: credential.access }),
+		};
+
+		const config = createOAuthConfig({
+			readCurrent: async () => undefined,
+			loginFlow,
+		});
+
+		await config.login({
+			onPrompt: async (prompt) => {
+				callbackSignal = "signal" in prompt && prompt.signal instanceof AbortSignal ? prompt.signal : undefined;
+				return "browser-callback-code";
+			},
+			onProgress: () => {},
+		});
+
+		expect(callbackSignal).toBe(providerSignal);
+		expect(callbackSignal?.aborted).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -6,6 +6,7 @@ import serviceTierExtension, {
 import { createHarness, type Harness } from "./harness.ts";
 
 const CODEX_PROVIDER = "openai-codex";
+const CODEX_POOL_PROVIDER = "codex-pool";
 const CODEX_API = "openai-codex-responses";
 const BASE_MODEL_ID = "gpt-5.6-sol";
 const FAST_MODEL_ID = `${BASE_MODEL_ID}-fast`;
@@ -164,6 +165,27 @@ describe("service-tier builtin extension", () => {
 		expect(harness.session.isFastModeActive()).toBe(false);
 		const defaultPayload = { model: BASE_MODEL_ID };
 		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
+	});
+
+	it("toggles the priority tier for extension providers using the Codex responses API", async () => {
+		const harness = await createHarness({
+			api: CODEX_API,
+			provider: CODEX_POOL_PROVIDER,
+			models: [{ id: BASE_MODEL_ID }],
+			extensionFactories: [serviceTierExtension],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+		const notify = vi.spyOn(runner.getUIContext(), "notify");
+
+		await harness.session.prompt("/fast");
+
+		expect(notify).toHaveBeenCalledWith(`Fast mode enabled: ${BASE_MODEL_ID}`, "info");
+		expect(harness.session.isFastModeActive()).toBe(true);
+		expect(await runner.emitBeforeProviderRequest({ model: BASE_MODEL_ID })).toEqual({
+			model: BASE_MODEL_ID,
+			service_tier: "priority",
+		});
 	});
 
 	it("keeps session fast mode on across a mid-session switch to another Codex model", async () => {


### PR DESCRIPTION
https://linear.app/jgplabs/issue/LAB-33/다중-계정-로그인-입력-필드가-중복-동기화됨

## Summary
- forward the Anthropic OAuth prompt AbortSignal through the extension OAuth adapter
- close the pending manual-code input when the localhost browser callback wins
- prevent account naming from overlapping the stale manual input

## Verification
- RED then GREEN: lab-33-claude-oauth-prompt-abort.test.ts
- changed-file LSP diagnostics: clean
- npm run check: clean
- Claude OAuth scoped suite: 4 files / 10 tests passed
- Anthropic OAuth suite: 6 tests passed
- real Orca/xterm.js QA: one account-name input, no mirrored field, isolated auth state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicated OAuth inputs by aborting the manual-code prompt when the localhost browser callback completes (LAB-33). Also adds account management for `claude-sdk-oauth`, enables fast mode for Codex API extension providers, and introduces a wait-progress render utility.

- **Bug Fixes**
  - Forward the Anthropic OAuth prompt `AbortSignal` through the extension and close the manual-code input when the browser callback wins to prevent mirrored fields and overlapping account naming (LAB-33).
  - Managed `oauth-slots` and `config-dir` modes now fail closed when no accounts are configured, avoiding fallback to ambient Claude credentials after logout (LAB-27).

- **New Features**
  - Provider menu for `claude-sdk-oauth`: add/remove, logout-all, pin/unpin, and unblock; includes environment accounts; first-time login still goes straight to OAuth.
  - `/fast` now keys off the `openai-codex-responses` API, enabling extension providers like `codex-pool` to use priority tier without shadowing the stock provider.
  - New wait-progress render layer (`wait-progress.ts`) for continuation countdowns; render-only, not wired yet.

<sup>Written for commit 137c7e5596f312787ac3c57e111ba7804319b0cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

