### PR TITLE
fix(claude-sdk-oauth): close browser callback prompt (LAB-33)

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,11 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-03 - Browser callback closes manual-code input
+
+- Forward each Anthropic OAuth prompt's `AbortSignal` through the extension OAuth callback adapter.
+- When the localhost browser callback wins, the still-pending manual-code input now closes before account naming starts instead of leaving duplicated, mirrored fields.
+- Coverage: `test/suite/regressions/lab-33-claude-oauth-prompt-abort.test.ts`.
+
 ## 2026-08-01 - Resume-first session continuity (SDK ledger is authoritative)
 
 - **One SDK session lineage per senpi conversation.** A new `query()` is no longer a new session: every query replacement re-attaches with `resume: <sdkSessionId>`, so normal turns, model switches, thinking-level switches, ESC aborts, idle expiry, and shared-root account failover all continue the same lineage. Flattening the transcript into a `<conversation_history>` envelope is demoted to a last resort, reachable only when the SDK transcript is genuinely unusable.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
@@ -12,7 +12,7 @@ import {
 export type OAuthLoginCallbacks = {
 	signal?: AbortSignal;
 	onAuth?: (event: { url: string }) => void | Promise<void>;
-	onPrompt?: (prompt: { message: string; placeholder?: string }) => Promise<string>;
+	onPrompt?: (prompt: { message: string; placeholder?: string; signal?: AbortSignal }) => Promise<string>;
 	onManualCodeInput?: () => Promise<string>;
 	onProgress?: (message: string) => void;
 };
@@ -78,7 +78,13 @@ export function createOAuthConfig(deps: {
 				signal: callbacks.signal,
 				prompt: async (prompt) => {
 					if (prompt.type === "select") return "";
-					return callbacks.onPrompt ? callbacks.onPrompt({ message: prompt.message }) : "";
+					return callbacks.onPrompt
+						? callbacks.onPrompt({
+								message: prompt.message,
+								placeholder: prompt.placeholder,
+								signal: prompt.signal,
+							})
+						: "";
 				},
 				notify: (event) => {
 					if (event.type === "auth_url" && callbacks.onAuth) void callbacks.onAuth({ url: event.url });

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
@@ -78,13 +78,7 @@ export function createOAuthConfig(deps: {
 				signal: callbacks.signal,
 				prompt: async (prompt) => {
 					if (prompt.type === "select") return "";
-					return callbacks.onPrompt
-						? callbacks.onPrompt({
-								message: prompt.message,
-								placeholder: prompt.placeholder,
-								signal: prompt.signal,
-							})
-						: "";
+					return callbacks.onPrompt ? callbacks.onPrompt(prompt) : "";
 				},
 				notify: (event) => {
 					if (event.type === "auth_url" && callbacks.onAuth) void callbacks.onAuth({ url: event.url });

--- a/packages/coding-agent/test/suite/regressions/lab-33-claude-oauth-prompt-abort.test.ts
+++ b/packages/coding-agent/test/suite/regressions/lab-33-claude-oauth-prompt-abort.test.ts
@@ -1,0 +1,48 @@
+import type { OAuthAuth } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { createOAuthConfig } from "../../../src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts";
+
+describe("LAB-33 Claude OAuth prompt lifecycle", () => {
+	it("forwards the provider abort signal to the manual-code prompt", async () => {
+		let providerSignal: AbortSignal | undefined;
+		let callbackSignal: AbortSignal | undefined;
+
+		const loginFlow: OAuthAuth = {
+			name: "LAB-33 fake browser callback",
+			login: async (interaction) => {
+				const controller = new AbortController();
+				providerSignal = controller.signal;
+				await interaction.prompt({
+					type: "manual_code",
+					message: "Paste the authorization code",
+					signal: controller.signal,
+				});
+				controller.abort();
+				return {
+					type: "oauth",
+					access: "new-access",
+					refresh: "new-refresh",
+					expires: Date.now() + 3_600_000,
+				};
+			},
+			refresh: async (credential) => credential,
+			toAuth: async (credential) => ({ apiKey: credential.access }),
+		};
+
+		const config = createOAuthConfig({
+			readCurrent: async () => undefined,
+			loginFlow,
+		});
+
+		await config.login({
+			onPrompt: async (prompt) => {
+				callbackSignal = "signal" in prompt && prompt.signal instanceof AbortSignal ? prompt.signal : undefined;
+				return "browser-callback-code";
+			},
+			onProgress: () => {},
+		});
+
+		expect(callbackSignal).toBe(providerSignal);
+		expect(callbackSignal?.aborted).toBe(true);
+	});
+});


### PR DESCRIPTION
https://linear.app/jgplabs/issue/LAB-33/multi-account-login-input-fields-duplicated-and-synced

## Summary
- forward the Anthropic OAuth prompt AbortSignal through the extension OAuth adapter
- close the pending manual-code input when the localhost browser callback wins
- prevent account naming from overlapping the stale manual input

## Verification
- RED then GREEN: lab-33-claude-oauth-prompt-abort.test.ts
- changed production-file LSP diagnostics: clean
- npm run check: clean
- Claude OAuth scoped suite: 4 files / 10 tests passed
- real Orca/xterm.js QA: one account-name input, no mirrored field, isolated auth state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the stale manual-code prompt when the browser callback completes in the `claude-sdk-oauth` extension. Prevents duplicated inputs and mirrored account naming in multi-account login (LAB-33).

- **Bug Fixes**
  - Pass the full provider prompt to `onPrompt` (message, placeholder, signal) via the OAuth adapter.
  - Abort and close the manual-code input when the localhost browser callback wins.
  - Add regression test `lab-33-claude-oauth-prompt-abort.test.ts` to verify signal forwarding and prompt abort.

<sup>Written for commit d6ab6cd0c444b72596d9131bf86de4956e8a6002. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

