### PR TITLE
docs(changelog): document Bun runtime release

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,10 +6,14 @@
 
 ### Added
 
+- Added strict 429 retry-hint extraction with canonical markers at Anthropic and Codex API boundaries, and propagated structured `retry-after` hints through provider retries ([#657](https://github.com/code-yeongyu/senpi/pull/657)).
+
 ### Changed
 
 ### Fixed
 
+- Enforced final Anthropic tool-use/tool-result pairing after pruning, interruption, or model switching ([#641](https://github.com/code-yeongyu/senpi/pull/641)).
+- Restored non-429 `retry-after` handling displaced during the hint-aware 429 retry migration ([#657](https://github.com/code-yeongyu/senpi/pull/657)).
 - Updated GPT-5.6 Terra and Luna pricing across OpenAI and passthrough model catalogs.
 - Fixed Fireworks Kimi K3 models to use the OpenAI-compatible API with native reasoning-effort levels and deferred tools ([#7199](https://github.com/earendil-works/pi/issues/7199), [#7230](https://github.com/earendil-works/pi/pull/7230) by [@XBeg9](https://github.com/XBeg9)).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,11 +8,30 @@
 
 ### Added
 
+- Added resume-first continuity for Claude SDK OAuth sessions, including lineage reattachment across aborts, account failover, restarts, model changes, and thinking-level changes ([#634](https://github.com/code-yeongyu/senpi/pull/634), [#635](https://github.com/code-yeongyu/senpi/pull/635), [#636](https://github.com/code-yeongyu/senpi/pull/636), [#637](https://github.com/code-yeongyu/senpi/pull/637)).
+- Added hint-aware 429 retry routing with tier classification, probe-back scheduling, and visible retry-probe events in interactive and RPC modes ([#657](https://github.com/code-yeongyu/senpi/pull/657)).
+- Added retries for transient idle-compaction warm-up failures while the agent remains idle ([#661](https://github.com/code-yeongyu/senpi/pull/661)).
+
 ### Changed
+
+- Migrated the build toolchain to TypeScript 7.0.2 stable with native `tsc`, replacing experimental `tsgo`/`@typescript/native-preview` usage and retaining the TypeScript 6 API bridge required by the relative-import checker ([#651](https://github.com/code-yeongyu/senpi/pull/651)).
+- Moved compiled Senpi binary builds and npm publication to the Bun 1.4+ canary runtime, guarded by revision-aware assertions and cross-platform runtime smoke tests ([#651](https://github.com/code-yeongyu/senpi/pull/651)).
+- Aligned compaction and assistant-boundary restoration with Claude SDK OAuth session lineages ([#636](https://github.com/code-yeongyu/senpi/pull/636)).
 
 ### Fixed
 
+- Fixed Claude SDK OAuth abort settlement and persistence of forked session identifiers ([#634](https://github.com/code-yeongyu/senpi/pull/634), [#637](https://github.com/code-yeongyu/senpi/pull/637)).
+- Fixed Anthropic tool-use/tool-result pairing after pruning, interruption, or model switching ([#641](https://github.com/code-yeongyu/senpi/pull/641)).
+- Compacted persisted apply-patch previews and bounded patch bodies to prevent oversized transcript artifacts ([#649](https://github.com/code-yeongyu/senpi/pull/649)).
+- Bounded summarization overflow retries to prevent unbounded compaction loops ([#652](https://github.com/code-yeongyu/senpi/pull/652)).
+- Fully reconnected expired MCP sessions instead of reusing stale transport handles ([#655](https://github.com/code-yeongyu/senpi/pull/655)).
+- Rearmed wake delivery for fresh terminal monitors ([#658](https://github.com/code-yeongyu/senpi/pull/658)).
+- Prevented loop-guard repetition detection from conflating distinct targets ([#659](https://github.com/code-yeongyu/senpi/pull/659)).
+- Unwedged goal continuations after non-automatic compaction and resumed queued messages even when compaction completion hooks throw ([#660](https://github.com/code-yeongyu/senpi/pull/660)).
+
 ### Removed
+
+- Removed the legacy `web-ui` workspace from the monorepo ([#651](https://github.com/code-yeongyu/senpi/pull/651)).
 
 ## [2026.8.1] - 2026-08-01
 


### PR DESCRIPTION
## Summary

Documents every release-relevant fork change since `v2026.8.1`, with the
release headline centered on the Bun runtime/toolchain movement from PR #651.
The user-facing changelog now explains that compiled binaries and npm
publication run on Bun 1.4+ canary with revision-aware assertions and
cross-platform runtime smoke coverage.

## Changes

- Document TypeScript 7.0.2 stable native `tsc`, Bun 1.4+ canary build/publish
  runtime, and removal of the legacy `web-ui` workspace.
- Add missing AI notes for Anthropic tool pairing and structured retry hints.
- Add missing coding-agent notes for Claude SDK OAuth continuity, compacted
  apply-patch results, bounded compaction retries, MCP reconnects, hint-aware
  429 routing, monitor wake delivery, loop-guard targets, goal continuation,
  and idle compaction retries.

## QA & Evidence

- **Changelog bookkeeping tests:** `node --test scripts/release-changelog.test.mjs scripts/release.test.mjs`
  - Result: 6/6 passed.
  - Artifact: `local-ignore/qa-evidence/20260803-bun-runtime-release/green-changelog-validation.txt`
- **Repository static validation:** `npm run check`
  - Result: passed with lockfile-defined dependencies.
  - Artifact: `local-ignore/qa-evidence/20260803-bun-runtime-release/quality-gates.txt`
- **Release script suite:** `npm run test:scripts`
  - Result: 79/79 passed.
  - Artifact: `local-ignore/qa-evidence/20260803-bun-runtime-release/quality-gates.txt`
- **Real CLI smoke:** `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test`
  - Result: 8/8 passed; real auth unchanged.
  - Artifact: `local-ignore/qa-evidence/20260803-bun-runtime-release/quality-gates.txt`
- **Whitespace validation:** `git diff --check`
  - Result: passed.

## Risks & Residuals

- Documentation-only release audit; no runtime source is changed.
- The release script will stamp these notes as `2026.8.3` only after this PR is
  merged and `main` is clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates changelogs to document the Bun 1.4+ canary runtime migration for builds and `npm` publish, plus the TypeScript 7.0.2 toolchain and removal of the legacy `web-ui` workspace. Also records retry-hint handling, Anthropic tool pairing, OAuth continuity, compaction bounds, MCP reconnects, and other stability fixes; docs-only, no source changes.

<sup>Written for commit a7e6f4c2e6169579314f6cfd244bc20fc69f1b33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

