### PR TITLE
feat(coding-agent): proportion test discipline to change seams, drop prose-pinning tests

### DIFF
--- a/packages/coding-agent/src/core/dynamic-prompt/changes.md
+++ b/packages/coding-agent/src/core/dynamic-prompt/changes.md
@@ -1,5 +1,24 @@
 # changes.md — dynamic-prompt
 
+## Test-discipline rules: prose-pinning prohibition + behavior wording (2026-08-03)
+
+### What changed
+
+- `verification.ts`: `prompt-behavior-coverage` rewritten as a prohibition — never pin prose, prompt wording, or doc text with a test; test only machine-consumed values (parsed fields, sentinel tokens, shipped-copy equality); a pure-prose change ships with no new test. `mock-contract-integrity` directive now says "behavior being asserted" instead of "contract being asserted" (id and concern unchanged; ids are not rendered into prompts).
+- Prose-pinning assertions removed from the prompt test suites in the same increment; remaining prompt coverage asserts parsed rule data and machine-consumed sentinels only.
+
+### Why
+
+A full session-corpus investigation (2026-08-03) found the old wording normalized prompt-text contract tests across every model: 113 sessions used contract-test vocabulary, and docs-only changes grew prose-pinning tests (e.g. `check-mcp-docs.test.mjs`). The rule now forbids the pattern at the source instead of merely preferring behavior assertions, and the word "contract" stops seeding contract-test naming.
+
+### Why extension system couldn't handle this
+
+The Test Discipline section is core prompt assembly (`buildTestDisciplineSection()`), single-sourced into every preset and the fallback prompt; no extension hook rewrites it.
+
+### Expected merge conflict zones
+
+- `verification.ts` rule directives. Resolution: keep the prohibition/behavior wording; re-apply upstream rule additions on top.
+
 ## CLI system-prompt overrides reapplied in `_rebuildSystemPrompt()` (2026-07-18)
 
 ### What changed

--- a/packages/coding-agent/src/core/dynamic-prompt/verification.ts
+++ b/packages/coding-agent/src/core/dynamic-prompt/verification.ts
@@ -32,13 +32,13 @@ export const TEST_DISCIPLINE_RULES = [
 		id: "mock-contract-integrity",
 		concern: "mock-contracts",
 		directive:
-			"Mocks must preserve the contract being asserted; do not isolate so heavily that the integration under test cannot fail.",
+			"Mocks must preserve the behavior being asserted; do not isolate so heavily that the integration under test cannot fail.",
 	},
 	{
 		id: "prompt-behavior-coverage",
 		concern: "prompt-tests",
 		directive:
-			"Prompt tests must assert behavior, decisions, structure, or parsed rule data rather than merely pinning an exact prompt sentence.",
+			"Never pin prose, prompt wording, or doc text with a test; test only machine-consumed values (parsed fields, sentinel tokens, shipped-copy equality). A pure-prose change ships with no new test.",
 	},
 	{
 		id: "single-pass-runner",

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,25 @@
 # prompt-preset Extension Changes
 
+## Kimi K3 + GPT-5.6: test-proportionality rules (2026-08-03)
+
+### What changed
+
+- `kimi-k3.ts`: the Verification section opens with a terminal condition — one successful verification command ends the check; one focused test per behavior change at the touched seam; prose, docs, and visual-only changes take review + real-surface QA instead of tests.
+- `gpt-5.6.ts`: `TEST_FIRST` scoped — the failing test is written at the seam the change touches; prose, doc, and visual-only changes take review plus real-surface QA, not tests. Header comment updated: the deleted blanket "default to not adding tests" rule returns as a scoped seam rule inside test-first.
+- Prose-pinning assertions stripped from `test/suite/prompt-presets-*.test.ts` and other prompt test files; what remains asserts machine-consumed behavior (preset resolution, model matching, rule ids/concerns, tool-name sentinels).
+
+### Why
+
+The 2026-08-03 session-corpus investigation showed K3 writing more test files than any other model (636 writes) and GPT-5.6's preset having deleted its upstream scope rule. kimi.md prescribes terminal conditions over prohibitions; claude-opus-5.md warns explicit verification instructions compound into over-verification. The prose-pinning test removals follow the repo's own convention (`prompt-behavior-coverage`: parsed rule data, never pinned sentences).
+
+### Why extension system couldn't handle this
+
+Presets are core-owned prompt builders; the proportionality rule belongs in the prompt text itself.
+
+### Expected merge conflict zones
+
+- `kimi-k3.ts` Verification section, `gpt-5.6.ts` `TEST_FIRST` constant. Resolution: keep the scoping sentences.
+
 ## DeepSeek V4 presets: flash, flash-0731, pro (2026-07-31)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-5.6.ts
@@ -36,8 +36,10 @@
 // its point of use, replacing the weaker text it supersedes rather than being
 // appended as a trailer: the old "independent calls run in the same message" /
 // "each shell command is its own bash call" pair, the mid-paragraph todo
-// mechanics, and the "default to not adding tests" rule (deleted - it directly
-// contradicts test-first). The GPT-5.6 guide's Programmatic-Tool-Calling
+// mechanics, and the "default to not adding tests" rule (re-scoped into
+// test-first itself: tests at the touched seam, prose and visual work via
+// real-surface QA - the blanket version contradicted test-first, the scoped
+// version bounds it). The GPT-5.6 guide's Programmatic-Tool-Calling
 // section drives the shape: a bounded routing contract naming the stage,
 // eligible surface, output, and what stays direct beats generic "use PTC
 // efficiently" wording, which does not route.
@@ -96,7 +98,7 @@ const TODO_GRANULARITY =
 	"Split the work to the finest actionable grain - one item per edit plus the check that proves it - and drive every transition the moment it happens: start it, complete it, append newly discovered steps, drop abandoned ones, never batch the updates.";
 
 const TEST_FIRST =
-	"Work test-first on behavior changes: write the failing test, watch it fail for the right reason, then make the smallest change that turns it green. Skip that only for formatting, comments, renames, or dependency bumps, and never write a test that cannot fail for the regression it names.";
+	"Work test-first on behavior changes: write the one failing test at the seam the change touches, watch it fail for the right reason, then make the smallest change that turns it green. Prose, doc, and visual-only changes take review plus real-surface QA, not tests. Skip test-first also for formatting, comments, renames, or dependency bumps, and never write a test that cannot fail for the regression it names.";
 
 const ATOMIC_COMMITS =
 	"When commits are authorized, commit atomically per verified increment, in the repository's existing message convention, each commit green on its own - never one omnibus commit at the end.";

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
@@ -36,6 +36,13 @@
 // clarifying question instead of an invented assumption. The Style section's
 // permission-begging ban carves that question out so the two rules cannot
 // collide.
+//
+// 2026-08-03: the Verification section opens with a test-proportionality
+// terminal condition (one focused test at the touched seam; prose, docs, and
+// visual-only work take review + real-surface QA instead of tests). The
+// session corpus showed K3 writing more test files than any other model, and
+// the K2-line guidance prescribes terminal conditions over prohibitions, so
+// the rule names when checking stops instead of forbidding tests.
 
 import type { DynamicPromptCoreContext } from "../../../dynamic-prompt/build.ts";
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
@@ -88,7 +95,7 @@ Tier the scope, never the rigor.
 - V2 — single-domain behavioral edits: diagnostics on changed files in parallel, related tests, one execution of the affected runnable entry point when one exists.
 - V3 — multi-file or cross-cutting work: diagnostics on every changed file, related tests, build, manual exercise of user-visible behavior through its real surface.
 
-"Should pass" is not verification - run the validator before reporting anything clean. Fix only issues your changes caused; note pre-existing failures separately.
+One successful verification command ends the check - stop unless it fails. Write one focused test per behavior change, at the seam the change touches; prose, docs, and visual-only changes take review plus real-surface QA instead of tests. "Should pass" is not verification - run the validator before reporting anything clean. Fix only issues your changes caused; note pre-existing failures separately.
 
 ${buildTestDisciplineSection()}
 

--- a/packages/coding-agent/test/compaction/checkpoint-directive-characterization.test.ts
+++ b/packages/coding-agent/test/compaction/checkpoint-directive-characterization.test.ts
@@ -138,6 +138,5 @@ describe("checkpoint directive relocation: 60s system-prompt window -> one-shot 
 
 		expect(result?.systemPrompt).toBeUndefined();
 		expect(String(result?.message?.content)).toContain(RESTORATION_DIRECTIVE);
-		expect(String(result?.message?.content)).toContain("Restore checkpointed session configuration:");
 	});
 });

--- a/packages/coding-agent/test/compaction/prompt-sections.test.ts
+++ b/packages/coding-agent/test/compaction/prompt-sections.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildPrompt,
-	MERGED_COMPACTION_PROMPT_BRANCH,
-	MERGED_COMPACTION_PROMPT_SYSTEM,
 	MERGED_COMPACTION_PROMPT_USER,
 	resolvePromptFamily,
 } from "../../src/core/extensions/builtin/compaction/prompts.ts";
@@ -11,101 +9,13 @@ import {
 // Per-section presence
 // ============================================================================
 
-describe("DEFAULT variant — per-section landmarks", () => {
-	it("contains the system directive header", () => {
-		expect(MERGED_COMPACTION_PROMPT_SYSTEM).toContain("[SYSTEM DIRECTIVE: OH-MY-OPENCODE - COMPACTION CONTEXT]");
-	});
-
-	it("contains section 1: User Requests", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("## 1. User Requests (Verbatim)");
-	});
-
-	it("contains section 2: Final Goal", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("## 2. Final Goal");
-	});
-
-	it("contains section 3: Constraints & Preferences", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("## 3. Constraints & Preferences (Verbatim Only)");
-	});
-
-	it("contains section 4: Work Completed", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("## 4. Work Completed");
-	});
-
-	it("contains section 5: Active Working Context", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("## 5. Active Working Context");
-	});
-
-	it("contains section 6: Remaining Tasks", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("## 6. Remaining Tasks");
-	});
-
-	it("contains section 7: Exact Next Steps", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("## 7. Exact Next Steps");
-	});
-
-	it("contains the 'Quote constraints verbatim' instruction", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("Quote constraints verbatim");
-	});
-
-	it("contains the 'Do NOT invent' instruction", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("Do NOT invent");
-	});
-});
-
 // ============================================================================
 // Cardinal rules R1-R4 (4 tests, one each)
 // ============================================================================
 
-describe("SYSTEM block — cardinal rules", () => {
-	it("R1: quotes user requests and constraints verbatim", () => {
-		expect(MERGED_COMPACTION_PROMPT_SYSTEM).toContain(
-			"R1. Quote user requests and constraints VERBATIM. Do not paraphrase.",
-		);
-	});
-
-	it('R2: writes "None." for empty sections, never deletes a section', () => {
-		expect(MERGED_COMPACTION_PROMPT_SYSTEM).toContain(
-			'R2. If a section has no content, write "None." Never delete a section.',
-		);
-	});
-
-	it("R3: treats previous summary fields as immutable", () => {
-		expect(MERGED_COMPACTION_PROMPT_SYSTEM).toContain(
-			"R3. Where a previous summary is supplied, treat its User Requests, Final Goal, and Constraints fields as IMMUTABLE. Append, never rewrite, those three sections.",
-		);
-	});
-
-	it("R4: preserves every session_id, file path, and identifier byte-for-byte", () => {
-		expect(MERGED_COMPACTION_PROMPT_SYSTEM).toContain(
-			"R4. Preserve every session_id, file path, and identifier byte-for-byte.",
-		);
-	});
-});
-
 // ============================================================================
 // Canonical order (1 test)
 // ============================================================================
-
-describe("DEFAULT variant — canonical section order", () => {
-	it("has sections 1-7 in strict sequential order", () => {
-		const s1 = MERGED_COMPACTION_PROMPT_USER.indexOf("## 1. User Requests (Verbatim)");
-		const s2 = MERGED_COMPACTION_PROMPT_USER.indexOf("## 2. Final Goal");
-		const s3 = MERGED_COMPACTION_PROMPT_USER.indexOf("## 3. Constraints & Preferences (Verbatim Only)");
-		const s4 = MERGED_COMPACTION_PROMPT_USER.indexOf("## 4. Work Completed");
-		const s5 = MERGED_COMPACTION_PROMPT_USER.indexOf("## 5. Active Working Context");
-		const s6 = MERGED_COMPACTION_PROMPT_USER.indexOf("## 6. Remaining Tasks");
-		const s7 = MERGED_COMPACTION_PROMPT_USER.indexOf("## 7. Exact Next Steps");
-
-		expect(s1).toBeGreaterThanOrEqual(0);
-		expect(s2).toBeGreaterThan(s1);
-		expect(s3).toBeGreaterThan(s2);
-		expect(s4).toBeGreaterThan(s3);
-		expect(s5).toBeGreaterThan(s4);
-		expect(s6).toBeGreaterThan(s5);
-		expect(s7).toBeGreaterThan(s6);
-	});
-});
 
 // ============================================================================
 // Two-pass (2 tests)
@@ -114,30 +24,16 @@ describe("DEFAULT variant — canonical section order", () => {
 describe("DEFAULT variant — task-intent acquisition", () => {
 	it("instructs emission of the task-intent block before summary", () => {
 		expect(MERGED_COMPACTION_PROMPT_USER).toContain("<task-intent>");
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("Write one <task-intent>");
 		expect(MERGED_COMPACTION_PROMPT_USER).not.toContain("Emit <task-intent>");
 		expect(MERGED_COMPACTION_PROMPT_USER.indexOf("<task-intent>")).toBeLessThan(
 			MERGED_COMPACTION_PROMPT_USER.indexOf("<summary>"),
-		);
-	});
-
-	it("lists both task-intent and summary blocks in the final IMPORTANT line", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain(
-			"IMPORTANT: Respond with ONLY the <task-intent>...</task-intent> and <summary>...</summary> blocks as your text output.",
 		);
 	});
 });
 
 describe("DEFAULT variant — family landmarks", () => {
 	it("contains the claude baseline acquisition wording", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).toContain("structured handoff summary");
 		expect(MERGED_COMPACTION_PROMPT_USER).toContain("<task-intent>");
-	});
-
-	it("contains the gpt terse acquisition wording", () => {
-		const prompt = buildPrompt({ variant: "default", promptFamily: "gpt" });
-		expect(prompt.user).toContain("Write one <task-intent>");
-		expect(prompt.user).not.toContain("Emit <task-intent>");
 	});
 });
 
@@ -166,14 +62,10 @@ describe("TURN_PREFIX variant", () => {
 	it("does not acquire task-intent when one is already present", () => {
 		const prompt = buildPrompt({ variant: "turn_prefix", taskIntent: "anchored" });
 		expect(prompt.user).not.toContain("ORIGINAL_REQUEST:");
-		expect(prompt.user).toContain("## 1. User Requests (Verbatim)");
 	});
 
 	it("acquires task-intent only when absent", () => {
 		const prompt = buildPrompt({ variant: "turn_prefix" });
-		expect(prompt.user).toContain(
-			"Silently determine the current task intent and the minimum context needed for the next turn.",
-		);
 		expect(prompt.user).toContain("<summary>");
 	});
 });
@@ -181,9 +73,6 @@ describe("TURN_PREFIX variant", () => {
 describe("UPDATE variant", () => {
 	it("injects the task-intent block before previous summary when present", () => {
 		const prompt = buildPrompt({ variant: "update", previousSummary: "prev", taskIntent: "intent bytes" });
-		expect(prompt.user).toContain(
-			"Immutable provenance of the original task. Do not rewrite it. Newer explicit user steering overrides it.",
-		);
 		expect(prompt.user).toContain("<task-intent>");
 		expect(prompt.user).toContain("intent bytes");
 		expect(prompt.user.indexOf("<previous-summary>")).toBeLessThan(prompt.user.indexOf("<task-intent>"));
@@ -191,15 +80,7 @@ describe("UPDATE variant", () => {
 
 	it("requests task-intent acquisition when absent", () => {
 		const prompt = buildPrompt({ variant: "update", previousSummary: "prev" });
-		expect(prompt.user).toContain("Write one <task-intent>");
 		expect(prompt.user).toContain("<previous-summary>");
-	});
-});
-
-describe("BRANCH variant", () => {
-	it("is unchanged", () => {
-		expect(MERGED_COMPACTION_PROMPT_BRANCH).toContain("PASS 1 — Internal task-intent extraction");
-		expect(MERGED_COMPACTION_PROMPT_BRANCH).toContain("PASS 2 — Emit summary biased toward Pass 1");
 	});
 });
 
@@ -221,12 +102,6 @@ describe("PROMPT FAMILY classifier", () => {
 // ============================================================================
 // Negative (1 test)
 // ============================================================================
-
-describe("DEFAULT variant — negative assertions", () => {
-	it("does NOT contain '## Critical Context'", () => {
-		expect(MERGED_COMPACTION_PROMPT_USER).not.toContain("## Critical Context");
-	});
-});
 
 // ============================================================================
 // buildPrompt smoke test

--- a/packages/coding-agent/test/dynamic-prompt/workstation.test.ts
+++ b/packages/coding-agent/test/dynamic-prompt/workstation.test.ts
@@ -55,14 +55,12 @@ describe("buildWorkstationSection", () => {
 
 		expect(section).toContain("<execution_context>");
 		expect(section).toContain("</execution_context>");
-		expect(section).toContain("Code you write may target any machine; code you run always runs here.");
 	});
 
 	test("codex dialect is terse without tags or shouting", () => {
 		const section = buildWorkstationSection({ selectedTools: ["bash", "eval"], dialect: "codex", facts: FACTS });
 		const instruction = section.slice(section.indexOf("</workstation>"));
 
-		expect(instruction).toContain("executed code runs here");
 		expect(instruction).not.toContain("<execution_context>");
 		expect(instruction).not.toContain("MUST");
 		expect(instruction).not.toContain("EXECUTION HAPPENS HERE");

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -247,25 +247,6 @@ describe("skills", () => {
 			expect(result).toContain("<location>/path/to/skill/SKILL.md</location>");
 		});
 
-		it("should include intro text before XML", () => {
-			const skills: Skill[] = [
-				createTestSkill({
-					name: "test-skill",
-					description: "A test skill.",
-					filePath: "/path/to/skill/SKILL.md",
-					baseDir: "/path/to/skill",
-				}),
-			];
-
-			const result = formatSkillsForPrompt(skills);
-			const xmlStart = result.indexOf("<available_skills>");
-			const introText = result.substring(0, xmlStart);
-
-			expect(introText).toContain("The following skills provide specialized instructions");
-			expect(introText).toContain("Use the read tool to load a skill's file");
-			expect(introText).toContain("even loosely matches");
-		});
-
 		it("should escape XML special characters", () => {
 			const skills: Skill[] = [
 				createTestSkill({

--- a/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
+++ b/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
@@ -126,13 +126,6 @@ describe("buildBashTimeoutPrompt", () => {
 		expect(prompt).toContain("Recommended maximum timeout: 90s (90s)");
 	});
 
-	it("instructs the model to set timeout explicitly for long-running commands", () => {
-		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
-
-		expect(prompt).toMatch(/long-running commands/i);
-		expect(prompt).toMatch(/explicit `timeout`/i);
-	});
-
 	it("routes beyond-max workloads to background sessions and monitor, not tmux", () => {
 		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
 

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -138,27 +138,11 @@ describe("goal extension contract (budget-free)", () => {
 		const serialized = JSON.stringify(update).toLowerCase();
 		expect(create?.description).toMatch(/4,000.*file/i);
 		expect(JSON.stringify(create?.parameters)).toMatch(/4,000.*file/i);
-		expect(create?.description).toMatch(/complete.*archive.*unfinished/i);
 		expect(serialized).toContain("complete");
 		expect(serialized).toContain("blocked");
 		expect(serialized).toContain("reason");
-		expect(update?.description).toMatch(/3 consecutive goal turns/i);
-		expect(update?.description).toMatch(/no live resumption channel|no live monitor/i);
-		expect(update?.description).toMatch(/wait.*not an impasse/i);
-		expect(update?.description).toMatch(/fresh blocked audit after resume/i);
-		expect(update?.description).toMatch(/hard, slow, or uncertain/i);
 		expect(serialized).not.toContain("budget");
 		expect(JSON.stringify(tools.get("get_goal")).toLowerCase()).not.toContain("budget");
-	});
-
-	it("documents the todo gate and decisive completion in the update_goal description", () => {
-		const { tools } = createGoalHarness();
-		const description = tools.get("update_goal")?.description ?? "";
-		expect(description).toMatch(/completion audit/i);
-		expect(description).toMatch(/todo/i);
-		expect(description).toMatch(/rejected while/i);
-		expect(description).toMatch(/same turn/i);
-		expect(description).toMatch(/unmistakably clear/i);
 	});
 
 	it("creates, reads, and completes a goal through the tools and file store", async () => {

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -206,61 +206,14 @@ describe("goal continuation prompt (budget-free)", () => {
 		expect(prompt.toLowerCase()).not.toContain("tokens remaining");
 		expect(prompt.toLowerCase()).not.toContain("budget_limited");
 	});
-
-	it("carries a decisive completion audit that must flip to update_goal complete", () => {
-		const prompt = buildContinuationPrompt(makeGoal());
-		expect(prompt).toMatch(/completion audit/i);
-		expect(prompt).toMatch(/call update_goal with status "complete" in this same turn/i);
-		expect(prompt).toMatch(/leaving the goal active/i);
-		expect(prompt).toMatch(/todo task/i);
-		expect(prompt).toMatch(/completed or dropped/i);
-	});
-
-	it("carries a conservative blocked audit gated on a recurring, unmistakable impasse", () => {
-		const prompt = buildContinuationPrompt(makeGoal());
-		expect(prompt).toMatch(/blocked audit/i);
-		expect(prompt).toMatch(/unmistakably clear/i);
-		expect(prompt).toMatch(/three consecutive goal turns/i);
-		expect(prompt).toMatch(/hard, slow, uncertain/i);
-		expect(prompt).toMatch(/user input or an external-state change/i);
-	});
-
-	it("treats waiting on a live resumption channel as a legal turn ending, never as blocked", () => {
-		const prompt = buildContinuationPrompt(makeGoal());
-		expect(prompt).toMatch(/live resumption channel/i);
-		expect(prompt).toMatch(/wait.*not an impasse|never grounds a blocked/i);
-	});
-
-	it("gates the blocked audit on having no live resumption channel", () => {
-		const prompt = buildContinuationPrompt(makeGoal());
-		expect(prompt).toMatch(/no active monitor/i);
-		expect(prompt).toMatch(/end the turn and let it wake/i);
-	});
-
-	it("forbids ending a goal turn with narration instead of action or an update_goal call", () => {
-		const prompt = buildContinuationPrompt(makeGoal());
-		expect(prompt).toMatch(/exactly one/i);
-		expect(prompt).toMatch(/status report|done-claim/i);
-		expect(prompt).not.toMatch(/wait_for/);
-		expect(prompt).not.toMatch(/tmux/i);
-	});
 });
 
 describe("goal truncation recovery prompt", () => {
 	it("stays short and re-injects no objective text or audit blocks", () => {
 		const prompt = buildTruncationRecoveryPrompt();
-		expect(prompt.split(/\s+/).filter(Boolean).length).toBeLessThanOrEqual(120);
 		expect(prompt).not.toContain("<untrusted_objective>");
 		expect(prompt.toLowerCase()).not.toContain("objective");
 		expect(prompt.toLowerCase()).not.toContain("audit");
-	});
-
-	it("tells the model to continue from the cut point without restarting or restating", () => {
-		const prompt = buildTruncationRecoveryPrompt();
-		expect(prompt).toMatch(/output[- ]token limit|token limit/i);
-		expect(prompt).toMatch(/continue/i);
-		expect(prompt).toMatch(/do not restart|not restart|without restarting/i);
-		expect(prompt).toMatch(/restate/i);
 	});
 });
 
@@ -272,10 +225,6 @@ describe("goal stall notice", () => {
 		expect(notice).toContain("3");
 		expect(notice).not.toContain("bash_output");
 		expect(notice).not.toContain("kill_bash");
-		expect(notice).toMatch(/todo list/i);
-		expect(notice).toMatch(/concrete action/i);
-		expect(notice).toMatch(/blocked audit/i);
-		expect(notice).toMatch(/do not end/i);
 	});
 
 	it("keeps the monitor-investigation bullets while monitors are active", () => {

--- a/packages/coding-agent/test/suite/gpt-apply-patch-extension.test.ts
+++ b/packages/coding-agent/test/suite/gpt-apply-patch-extension.test.ts
@@ -203,7 +203,6 @@ describe("gpt-apply-patch builtin extension", () => {
 		// Codex GPT-5.2 guard: ban inline python/heredoc-driven file mutation through bash.
 		expect(joined.toLowerCase()).toMatch(/python/);
 		// Codex GPT-5.2 guard: do not waste tokens re-reading after a successful patch.
-		expect(joined.toLowerCase()).toMatch(/re-?read|do not.*read/);
 	});
 
 	it("applies Codex-format patches from JSON input to files", async () => {

--- a/packages/coding-agent/test/suite/look-at-prompts.test.ts
+++ b/packages/coding-agent/test/suite/look-at-prompts.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { buildLookAtUserMessage, LOOK_AT_SYSTEM_PROMPT } from "../../src/core/extensions/builtin/look-at/prompts.ts";
+import { buildLookAtUserMessage } from "../../src/core/extensions/builtin/look-at/prompts.ts";
 
 describe("look_at prompts", () => {
-	it("requires evidence-based OCR and a body-only response", () => {
-		expect(LOOK_AT_SYSTEM_PROMPT).toMatch(/transcribe.*visible.*text.*verbatim/is);
-		expect(LOOK_AT_SYSTEM_PROMPT).toMatch(/never fabricate.*occluded.*blurry/is);
-		expect(LOOK_AT_SYSTEM_PROMPT).toMatch(/only.*response body.*no.*preamble.*postscript/is);
-	});
-
 	it("puts the requested goal and every attached source label in the user message", () => {
 		const message = buildLookAtUserMessage("Compare the warning states", ["before.png", "after.png"]);
 

--- a/packages/coding-agent/test/suite/prompt-presets-claude-fable-5.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-claude-fable-5.test.ts
@@ -51,11 +51,6 @@ describe("Claude Fable 5 prompt preset", () => {
 		// then
 		expect(preset?.name).toBe("claude-fable-5");
 		expect(preset?.prompt).toContain("You are senpi");
-		expect(preset?.prompt).toContain("## Intent Gate");
-		expect(preset?.prompt).toContain("a recommendation, not a survey");
-		expect(preset?.prompt).toContain("audit each claim against a tool result");
-		expect(preset?.prompt).toContain("on account of context limits");
-		expect(preset?.prompt.length).toBeGreaterThan(2_000);
 	});
 
 	it.each(["claude-opus-4-8", "~anthropic/claude-fable-latest", "some-fable-compatible-router"])(
@@ -83,7 +78,6 @@ describe("Claude Fable 5 prompt preset", () => {
 
 		// then
 		expect(preset?.name).toBe("claude-fable-5");
-		expect(preset?.prompt).toContain("audit each claim against a tool result");
 	});
 
 	it("keeps every shared test-discipline rule after the dieted core rewrite", () => {
@@ -98,19 +92,6 @@ describe("Claude Fable 5 prompt preset", () => {
 		for (const rule of TEST_DISCIPLINE_RULES) {
 			expect(preset?.prompt).toContain(rule.directive);
 		}
-	});
-
-	it("declares the binding stop condition in the routing line", () => {
-		// given
-		const settings: PromptPresetSettings = { promptPreset: "auto" };
-		const model = createModel("claude-fable-5", "anthropic");
-
-		// when
-		const preset = resolvePreset(model, settings);
-
-		// then
-		expect(preset?.prompt).toContain("I'll stop when [the exact, observable condition that ends this turn].");
-		expect(preset?.prompt).toContain("defect, not diligence");
 	});
 
 	it("does not include GPT or Kimi tuning in the claude-fable-5 preset", () => {

--- a/packages/coding-agent/test/suite/prompt-presets-claude-opus-5.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-claude-opus-5.test.ts
@@ -50,12 +50,6 @@ describe("Claude Opus 5 prompt preset", () => {
 		// then
 		expect(preset?.name).toBe("claude-opus-5");
 		expect(preset?.prompt).toContain("You are senpi");
-		expect(preset?.prompt).toContain("## Intent Gate");
-		expect(preset?.prompt).toContain("I'll stop when [the exact, observable condition that ends this turn]");
-		expect(preset?.prompt).toContain("a defect, not diligence");
-		expect(preset?.prompt).toContain("narrowing, widening, or transforming");
-		expect(preset?.prompt).toContain("auto-compacts context");
-		expect(preset?.prompt.length).toBeGreaterThan(2_000);
 	});
 
 	it.each(["claude-opus-4-5", "claude-opus-4.5", "claude-opus-4-8", "claude-fable-5", "some-opus-compatible-router"])(
@@ -110,7 +104,6 @@ describe("Claude Opus 5 prompt preset", () => {
 
 		// then
 		expect(preset?.name).toBe("claude-opus-5");
-		expect(preset?.prompt).toContain("a defect, not diligence");
 	});
 
 	it("does not include GPT or Kimi tuning in the claude-opus-5 preset", () => {
@@ -124,20 +117,6 @@ describe("Claude Opus 5 prompt preset", () => {
 		// then
 		expect(preset?.name).toBe("claude-opus-5");
 		expect(preset?.prompt).not.toContain("apply_patch");
-		expect(preset?.prompt).not.toContain("filler verification language");
-	});
-
-	it("does not carry the 4.7/4.8 scope-literalism or house-style tuning", () => {
-		// given
-		const settings: PromptPresetSettings = { promptPreset: "auto" };
-		const model = createModel("claude-opus-5", "anthropic");
-
-		// when
-		const preset = resolvePreset(model, settings);
-
-		// then
-		expect(preset?.prompt).not.toContain('"every", "all", and "each" mean the full set');
-		expect(preset?.prompt).not.toContain("cream/serif/terracotta");
 	});
 
 	it("returns claude-opus-5 preset for every Claude Opus 5 built-in catalog model", () => {

--- a/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-extension.test.ts
@@ -177,20 +177,6 @@ describe("prompt preset resolver", () => {
 		for (const rule of GPT56_EXECUTION_RULES) {
 			expect(preset?.prompt).toContain(rule.directive);
 		}
-		// Hephaestus parity: autonomous deep-worker contracts.
-		expect(preset?.prompt).toContain("Implement, don't propose");
-		expect(preset?.prompt).toContain("## Manual QA Gate");
-		expect(preset?.prompt).toContain("## Failure Recovery");
-		expect(preset?.prompt).toContain("## Pragmatism & Scope");
-		expect(preset?.prompt).toContain("## Stop Goal");
-		// Binding stop contract: declared per-turn stop condition + mandatory immediate stop.
-		expect(preset?.prompt).toContain("I'll stop right away when");
-		expect(preset?.prompt).toContain("BINDING");
-		expect(preset?.prompt).toContain("STOPPING IS MANDATORY AND IMMEDIATE");
-		expect(preset?.prompt).not.toContain("## Stop Rules");
-		expect(preset?.prompt).toContain("Never revert or modify changes you did not make");
-		// Verification binds to validators senpi can actually run; no phantom diagnostics tool.
-		expect(preset?.prompt).toContain("type check");
 		expect(preset?.prompt).not.toContain("lsp_diagnostics");
 		// omo-only tool contracts must NOT leak into senpi's tool surface.
 		expect(preset?.prompt).not.toContain("librarian");
@@ -657,7 +643,6 @@ describe("prompt preset resolver", () => {
 		// Negative guard: no inline python through bash for file mutation/inspection.
 		expect(prompt.toLowerCase()).toMatch(/python/);
 		// Negative guard: codex's "do not waste tokens re-reading after apply_patch".
-		expect(prompt.toLowerCase()).toMatch(/re-?read|do not.*read/);
 		// Positive routing: prefer the senpi `grep` tool over invoking grep/rg through bash.
 		expect(prompt.toLowerCase()).toMatch(/\brg\b|ripgrep/);
 	});

--- a/packages/coding-agent/test/suite/prompt-presets-gpt-5-6.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-gpt-5-6.test.ts
@@ -134,7 +134,6 @@ describe("GPT-5.6 execution discipline", () => {
 		const prompt = buildPrompt("gpt-5.6", "gpt-5.6-luna");
 
 		// then
-		expect(prompt).not.toContain("Default to not adding tests");
 		expect(prompt).toContain("apply_patch");
 	});
 

--- a/packages/coding-agent/test/suite/prompt-presets-gpt-eval-routing.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-gpt-eval-routing.test.ts
@@ -49,31 +49,6 @@ describe("GPT eval tool routing", () => {
 		if (!preset) {
 			throw new Error(`expected ${presetName} preset to resolve`);
 		}
-		expect(preset.prompt).toContain("When `exec` and `wait` are available");
-		expect(preset.prompt).toContain("when `eval` is available, follow its Tool Guidelines");
 		expect(preset.prompt).toContain(evalGuideline);
-	});
-
-	it("keeps GPT-specific eval routing out of Grok", () => {
-		// Given: the non-GPT Grok preset with eval registered.
-		const settings: PromptPresetSettings = { promptPreset: "grok-4.5" };
-		const model = createModel("grok-4.5");
-
-		// When: its system prompt is composed.
-		const preset = resolvePreset(model, settings, {
-			selectedTools: ["eval"],
-			toolSnippets: { eval: "Run one persistent code cell." },
-			promptGuidelines: [],
-			contextFiles: [],
-			skills: [],
-		});
-
-		// Then: it does not inherit either the former or current GPT-only routing rule.
-		if (!preset) {
-			throw new Error("expected grok-4.5 preset to resolve");
-		}
-		expect(preset.prompt).not.toContain("When `eval` is available, use it as the default coordinator");
-		expect(preset.prompt).not.toContain("When `eval` is available, follow its Tool Guidelines for multi-call work.");
-		expect(preset.prompt).not.toContain("When `exec` and `wait` are available");
 	});
 });

--- a/packages/coding-agent/test/suite/prompt-presets-grok-4-5.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-grok-4-5.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from "node:fs";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getModels, getProviders } from "@earendil-works/pi-ai/compat";
 import { describe, expect, it } from "vitest";
@@ -58,29 +57,14 @@ describe("Grok 4.5 prompt preset", () => {
 		// then
 		expect(preset?.name).toBe("grok-4.5");
 		// CEO / orchestrator role signals (full corePrompt rewrite, like gpt-5.6).
-		expect(preset?.prompt).toMatch(/acting as CEO and orchestrator/i);
-		expect(preset?.prompt).toMatch(/single human-facing surface/i);
-		expect(preset?.prompt).toMatch(/delegate implementation via `bash`/i);
-		expect(preset?.prompt).toMatch(/senpi --print/i);
 		// CEO passes the gpt-5.6 prompting guide to workers by spawning them
 		// with --model gpt-5.6*, not by restating the doctrine in the CEO
 		// prompt itself.
-		expect(preset?.prompt).toMatch(/--model gpt-5\.6/i);
-		expect(preset?.prompt).toMatch(/gpt-5\.6 prompting guide/i);
-		expect(preset?.prompt).toMatch(/consult oracle before deploying non-trivial work/i);
-		expect(preset?.prompt).toMatch(/review invocation/i);
-		expect(preset?.prompt).toMatch(/you are the human surface/i);
-		expect(preset?.prompt).toMatch(/stop goal/i);
-		expect(preset?.prompt).toMatch(/stopping is mandatory and immediate/i);
 		// Shared sections are reused, not duplicated.
 		expect(preset?.prompt).toContain("apply_patch");
-		expect(preset?.prompt).toContain("### Test Discipline");
 		// Routing-line discipline preserved.
-		expect(preset?.prompt).toMatch(/i read this as \[intent\] - \[plan\]/i);
 		// The full corePrompt is substantially larger than the old tuningSection.
-		expect(preset?.prompt.length).toBeGreaterThan(3000);
 		// Must NOT name a nonexistent task/subagent tool (senpi has no such tool).
-		expect(preset?.prompt).not.toMatch(/`task` child|category: "deep"|category: "ultrabrain"|run_in_background/i);
 	});
 
 	it.each(["grok-4.3", "grok-4.20-0309-reasoning", "grok-3", "grok-code-fast-1", "some-grok-compatible-router"])(
@@ -108,8 +92,6 @@ describe("Grok 4.5 prompt preset", () => {
 
 		// then
 		expect(preset?.name).toBe("grok-4.5");
-		expect(preset?.prompt).toMatch(/acting as CEO and orchestrator/i);
-		expect(preset?.prompt).toMatch(/delegate implementation via `bash`/i);
 	});
 
 	it("returns grok-4.5 preset for every Grok 4.5 built-in catalog model", () => {
@@ -133,15 +115,5 @@ describe("Grok 4.5 prompt preset", () => {
 			]),
 		);
 		expect(misses).toEqual([]);
-	});
-
-	it("does not invent Grok preset edition numbers while unreleased", () => {
-		// given — Grok 4.5 has never been formally merged; fake v1/v2/… theater is noise
-		const changesPath = new URL("../../src/core/extensions/builtin/prompt-preset/changes.md", import.meta.url);
-		const changes = readFileSync(changesPath, "utf8");
-
-		// then
-		expect(changes).toMatch(/Grok 4\.5 preset \(unreleased/);
-		expect(changes).not.toMatch(/Grok 4\.5 preset v\d+/);
 	});
 });

--- a/packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-kimi-k3.test.ts
@@ -31,11 +31,6 @@ function getKimiK3CatalogModels(): Model<Api>[] {
 	return getProviders().flatMap((provider) => (getModels(provider) as Model<Api>[]).filter(hasKimiK3CatalogSignal));
 }
 
-function extractSection(prompt: string, heading: string): string {
-	const match = prompt.match(new RegExp(`## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`));
-	return match?.[1] ?? "";
-}
-
 describe("Kimi K3 prompt preset", () => {
 	it.each([
 		{ id: "k3", provider: "kimi-coding", api: "anthropic-messages" as const },
@@ -55,13 +50,7 @@ describe("Kimi K3 prompt preset", () => {
 		// then
 		expect(preset?.name).toBe("kimi-k3");
 		expect(preset?.prompt).toContain("You are senpi");
-		expect(preset?.prompt).toContain("## Intent Gate");
 		expect(preset?.prompt).toContain("running on Kimi K3");
-		expect(preset?.prompt).toContain("I'll stop when [the exact, observable condition that ends this turn]");
-		expect(preset?.prompt).toContain("evidence-first");
-		expect(preset?.prompt).toContain("skip filler verification language");
-		expect(preset?.prompt).toContain("a recommendation, not a survey");
-		expect(preset?.prompt.length).toBeGreaterThan(2_000);
 	});
 
 	it.each(["kimi-k2.6-0528", "kimi-k2.7-code", "kimi-for-coding", "kimi-latest", "grok-3", "deepseek-r1-k3b"])(
@@ -90,8 +79,6 @@ describe("Kimi K3 prompt preset", () => {
 
 		// then
 		expect(k3?.name).toBe("kimi-k3");
-		expect(k3?.prompt).not.toContain("running on Kimi K2.7");
-		expect(k3?.prompt).not.toContain("Avoid restating the user's request");
 		expect(k26?.name).toBe("kimi-k2-6");
 		expect(k26?.prompt).not.toContain("running on Kimi K3");
 		expect(k27?.name).toBe("kimi-k2-7");
@@ -137,33 +124,6 @@ describe("Kimi K3 prompt preset", () => {
 		// then
 		expect(preset?.name).toBe("kimi-k3");
 		expect(preset?.prompt).not.toContain("apply_patch");
-	});
-
-	it("routes surviving ambiguity to a clarifying question instead of an assumption", () => {
-		// given
-		const settings: PromptPresetSettings = { promptPreset: "auto" };
-		const model = createModel("kimi-k3", "moonshotai", "anthropic-messages");
-
-		// when
-		const preset = resolvePreset(model, settings);
-		const prompt = preset?.prompt ?? "";
-		const intentGate = extractSection(prompt, "Intent Gate");
-		const style = extractSection(prompt, "Style");
-
-		// then: the reflect-then-ask rule renders inside the Intent Gate, not elsewhere
-		expect(intentGate).toMatch(/reread the request once for ambiguity/i);
-		// resolution order: context first, trivial gaps filled silently
-		expect(intentGate).toMatch(/code, files, and conversation/i);
-		expect(intentGate).toMatch(/silently fill trivial gaps/i);
-		// terminal condition: surviving material ambiguity -> one specific question, end the turn
-		expect(intentGate).toMatch(/material ambiguity survives[\s\S]*?one specific question[\s\S]*?end the turn/i);
-		// acting on a fabricated assumption is classified as a defect
-		expect(intentGate).toMatch(/invented assumption[\s\S]*?defect/i);
-		// the ask rule is stated exactly once across the whole prompt
-		expect(prompt.match(/one specific question/g)).toHaveLength(1);
-		expect(prompt.match(/reread the request once for ambiguity/gi)).toHaveLength(1);
-		// the style permission-begging ban carves out the clarifying question
-		expect(style).toMatch(/clarifying question[\s\S]*?not permission-begging/i);
 	});
 
 	it("returns kimi-k3 preset for every Kimi K3 built-in catalog model", () => {

--- a/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
 import { MonitorRegistry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
-import { TERMINAL_PROMPT_SECTION } from "../../src/core/extensions/builtin/terminal/prompt.ts";
 import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createMonitorTool } from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
 import { createNotifier, line } from "./terminal-monitor-notify-harness.ts";
@@ -148,23 +147,5 @@ describe("terminal monitor event delivery", () => {
 			scheduler.advanceBy(10_000);
 			expect(sent).toHaveLength(0);
 		}
-	});
-
-	it("teaches watcher discipline at the owning terminal surfaces", () => {
-		expect(TERMINAL_PROMPT_SECTION).toContain("monitor");
-		// Discipline is the routing rule (waits are monitors, not poll loops) plus noise control,
-		// not any particular wording — assert each rule at the surface that owns it, never a
-		// pinned sentence: the routing rule ships as the monitor tool's guideline, the noise
-		// rule stays in the terminal section.
-		const stubCtx = {
-			manager: { get: () => undefined },
-			cwd: process.cwd(),
-			defaultCols: 120,
-			defaultRows: 40,
-			getEnv: () => process.env,
-		} as unknown as TerminalToolContext;
-		const guidelines = (createMonitorTool(stubCtx).promptGuidelines ?? []).join("\n");
-		expect(guidelines).toMatch(/never a foreground\s+sleep\/poll loop/);
-		expect(TERMINAL_PROMPT_SECTION).toMatch(/Filter\s+noise at the command source/);
 	});
 });

--- a/packages/coding-agent/test/system-prompt.test.ts
+++ b/packages/coding-agent/test/system-prompt.test.ts
@@ -45,19 +45,6 @@ describe("buildSystemPrompt", () => {
 			expect(prompt).toContain("- edit:");
 			expect(prompt).toContain("- write:");
 		});
-
-		test("instructs models to resolve pi docs and examples under absolute base paths", () => {
-			const prompt = buildSystemPrompt({
-				contextFiles: [],
-				skills: [],
-				cwd: process.cwd(),
-			});
-
-			expect(prompt).toContain(
-				"- When reading pi docs or examples, resolve docs/... under Additional docs and examples/... under Examples, not the current working directory",
-			);
-			expect(prompt).toContain("environment variables (docs/environment-variables.md)");
-		});
 	});
 
 	describe("custom tool snippets", () => {


### PR DESCRIPTION
## Why

The 2026-08-03 full session-corpus investigation (1,260 senpi transcripts) found the prompt stack itself pushing every model into test ceremony: 113 sessions used contract-test vocabulary, docs-only edits grew prose contract tests (e.g. `check-mcp-docs.test.mjs`), a one-line config change got 6 test files, and Kimi K3 wrote 636 test files — the `Tests are the FLOOR` / contract framing was the driver.

## What changes

- **`verification.ts`** — `prompt-behavior-coverage` is now a **prohibition**: never pin prose, prompt wording, or doc text with a test; test only machine-consumed values (parsed fields, sentinel tokens, shipped-copy equality); a pure-prose change ships with no new test. `mock-contract-integrity` now says *behavior* being asserted (ids/concerns unchanged) so the word "contract" stops seeding contract-test naming.
- **`kimi-k3.ts`** — Verification opens with a terminal condition: one successful verification command ends the check; one focused test per behavior change at the touched seam; prose/docs/visual-only work takes review + real-surface QA instead of tests (per kimi.md guidance).
- **`gpt-5.6.ts`** — `TEST_FIRST` scoped to the seam the change touches; prose/doc/visual changes take QA, not tests. The deleted blanket no-tests default returns as a scoped seam rule.
- **Test suites** — prose-pinning assertions stripped across 18 prompt test files (wording, headings, char counts, phrase absence, changes.md content pins). Kept: parsed rule data, preset/model mapping, data round-trips, value rendering, tool-name sentinels, XML sentinel ordering, shipped-copy equality.
- changes.md entries for both areas in the same increment.

## Evidence

- Touched suites: 315 + 95 + 29 vitest tests green (incl. gpt-apply-patch after real install)
- `npm run check` clean (zero errors/warnings on touched files)
- senpi-qa `cli-smoke.mjs --self-test`: 8/8 PASS, real auth untouched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened test discipline to forbid prose-pinning and scope tests to the seam of the change across `packages/coding-agent`. Kimi K3 and GPT-5.6 presets now use proportional verification; prompt tests drop brittle wording checks and keep machine-consumed behavior.

- **Refactors**
  - `verification.ts`: “prompt-behavior-coverage” is now a prohibition; test only machine-consumed values (parsed fields, sentinels, shipped-copy equality). Pure-prose changes add no tests. “mock-contract-integrity” now says “behavior being asserted.”
  - Presets: `kimi-k3.ts` adds a terminal condition (one focused test at the touched seam; prose/docs/visual use review + real-surface QA). `gpt-5.6.ts` scopes `TEST_FIRST` to the touched seam and routes prose/doc/visual changes to QA.
  - Tests: removed prose-pinning assertions across prompt suites; kept parsed rule data, preset/model mapping, round-trips, value rendering, tool-name/XML sentinels, and shipped-copy equality.
  - Docs: updated `src/core/dynamic-prompt/changes.md` and `src/core/extensions/builtin/prompt-preset/changes.md`.

<sup>Written for commit 46daa6d97d88368ef295e5cad207502226b935ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

