### PR TITLE
fix(release): publish client protocol aliases

### DIFF
--- a/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
@@ -186,8 +186,8 @@ describe("prepareSenpiBundledWorkspaces", () => {
 			"@code-yeongyu/senpi-codemode": "^2026.7.22",
 			"@earendil-works/pi-agent-core": "npm:@code-yeongyu/senpi-agent-core@^2026.7.22",
 			"@earendil-works/pi-ai": "npm:@code-yeongyu/senpi-ai@^2026.7.22",
-			"@earendil-works/pi-client": "^2026.7.22",
-			"@earendil-works/pi-protocol": "^2026.7.22",
+			"@earendil-works/pi-client": "npm:@code-yeongyu/senpi-client@^2026.7.22",
+			"@earendil-works/pi-protocol": "npm:@code-yeongyu/senpi-protocol@^2026.7.22",
 			"@earendil-works/pi-pty": "npm:@code-yeongyu/senpi-pty@^2026.7.22",
 			"@earendil-works/pi-tui": "npm:@code-yeongyu/senpi-tui@^2026.7.22",
 		});

--- a/scripts/prepare-senpi-publish-manifest.mjs
+++ b/scripts/prepare-senpi-publish-manifest.mjs
@@ -4,6 +4,8 @@ import { join } from "node:path";
 export const ownedRegistryAliases = new Map([
 	["@earendil-works/pi-ai", "@code-yeongyu/senpi-ai"],
 	["@earendil-works/pi-agent-core", "@code-yeongyu/senpi-agent-core"],
+	["@earendil-works/pi-client", "@code-yeongyu/senpi-client"],
+	["@earendil-works/pi-protocol", "@code-yeongyu/senpi-protocol"],
 	["@earendil-works/pi-tui", "@code-yeongyu/senpi-tui"],
 	["@earendil-works/pi-pty", "@code-yeongyu/senpi-pty"],
 ]);

--- a/scripts/publish-registry-dependencies.test.mjs
+++ b/scripts/publish-registry-dependencies.test.mjs
@@ -15,6 +15,8 @@ const PRIVATE_UPSTREAM_WORKSPACES = [
 const OWNED_REGISTRY_ALIASES = [
 	"@code-yeongyu/senpi-ai",
 	"@code-yeongyu/senpi-agent-core",
+	"@code-yeongyu/senpi-client",
+	"@code-yeongyu/senpi-protocol",
 	"@code-yeongyu/senpi-tui",
 	"@code-yeongyu/senpi-pty",
 	"@code-yeongyu/senpi-codemode",

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -21,6 +21,8 @@ import { rewritePublishManifest } from "./publish-manifest.mjs";
 const packages = [
 	{ directory: "packages/ai", name: "@code-yeongyu/senpi-ai", rewriteManifest: true },
 	{ directory: "packages/agent", name: "@code-yeongyu/senpi-agent-core", rewriteManifest: true },
+	{ directory: "packages/client", name: "@code-yeongyu/senpi-client", rewriteManifest: true },
+	{ directory: "packages/protocol", name: "@code-yeongyu/senpi-protocol", rewriteManifest: true },
 	{ directory: "packages/tui", name: "@code-yeongyu/senpi-tui", rewriteManifest: true },
 	{ directory: "packages/pty", name: "@code-yeongyu/senpi-pty", rewriteManifest: true },
 	{ directory: "packages/senpi-codemode", name: "@code-yeongyu/senpi-codemode", rewriteManifest: true },


### PR DESCRIPTION
## Summary

Publishes fork-owned client and protocol aliases and rewrites the Senpi publish
manifest to use them.

## Root cause

`@code-yeongyu/senpi@2026.8.3` bundled client and protocol successfully, but
Bun still resolves declared dependencies through the registry. The manifest
kept `@earendil-works/pi-client` and `pi-protocol`, which do not exist in npm,
so `bun add -g` failed with 404s.

## Fix

- Publish `@code-yeongyu/senpi-client`.
- Publish `@code-yeongyu/senpi-protocol`.
- Rewrite the original import-path dependency keys through npm aliases.

## Verification

- RED: real `bun add -g @code-yeongyu/senpi@2026.8.3` failed on both upstream names.
- GREEN: focused alias and publish-manifest tests pass.
- GREEN: `npm run test:scripts` passes 81/81.
- GREEN: `npm run check` and `git diff --check` pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global install failures by publishing fork-owned client/protocol packages and aliasing upstream names in the publish manifest so Bun resolves valid registry deps.

- **Bug Fixes**
  - Publish `@code-yeongyu/senpi-client` and `@code-yeongyu/senpi-protocol`.
  - Alias `@earendil-works/pi-client` -> `npm:@code-yeongyu/senpi-client` and `@earendil-works/pi-protocol` -> `npm:@code-yeongyu/senpi-protocol`.
  - Update publish scripts and tests to include the new packages and aliases.

<sup>Written for commit 9dc91e919f9520894feec63783bc6bb5cef4ec1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

