### PR TITLE
fix(coding-agent): follow server fallback without client chain

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -693,7 +693,6 @@ export class AgentSession {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
 		this.settingsManager = config.settingsManager;
-		this.agent.abortServerSideFallback = this.settingsManager.getAbortServerSideFallback();
 		const noModelFallback =
 			config.resourceLoader.getExtensions().runtime.flagValues.get("no-model-fallback") === true ||
 			process.env.SENPI_NO_FALLBACK === "1";
@@ -1178,6 +1177,8 @@ export class AgentSession {
 	private async _promptAgent(messages: AgentMessage | AgentMessage[]): Promise<void> {
 		this._isAgentRunActive = true;
 		this._requiredCompactionAdmissionError = undefined;
+		this.agent.abortServerSideFallback =
+			this.settingsManager.getAbortServerSideFallback() && this._retryFallback.hasConfiguredChain();
 		try {
 			await this.agent.prompt(messages);
 			// AgentSession's subscriber intentionally queues event work instead of
@@ -3401,6 +3402,8 @@ export class AgentSession {
 		}
 		const thinkingLevel = this._getThinkingLevelForModelSwitch(opts.ephemeralThinkingLevel);
 		this.agent.state.model = model;
+		this.agent.abortServerSideFallback =
+			this.settingsManager.getAbortServerSideFallback() && this._retryFallback.hasConfiguredChain();
 		if (opts.appendSessionEntry) {
 			this.sessionManager.appendModelChange(
 				model.provider,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,39 @@
 # changes
 
+## Prefer configured client fallback chains over server substitutions (2026-08-03)
+
+### What changed
+
+- `agent-session.ts` now enables Anthropic's server-fallback abort only when the
+  current model has a configured client fallback chain.
+- The policy refreshes before each prompt and after every active-model switch,
+  so `/fallback` edits, manual model changes, retry fallbacks, and primary
+  restoration cannot carry stale precedence into the next provider request.
+- An explicit `retry.abortServerSideFallback: false` still opts out even when a
+  client chain exists.
+
+### Why
+
+- The previous session bootstrap enabled the abort unconditionally by default.
+  When Anthropic substituted `claude-opus-4-8` for `claude-opus-5` and no client
+  chain existed, Senpi discarded the valid substitute response and surfaced an
+  error plus a warning telling the user to configure `/fallback`.
+- Server fallback should be the default recovery when the user has not selected
+  a client policy; an explicit client chain should remain authoritative when it
+  exists.
+
+### Why this cannot be expressed externally
+
+- The decision must be forwarded in request-local provider options before the
+  Anthropic stream parses a fallback receipt. Extensions can configure chains
+  and observe events, but cannot change the agent loop's provider option after
+  model selection and before each internal retry continuation.
+
+### Expected merge conflict zones
+
+- LOW: `agent-session.ts` around `_promptAgent()` and `_switchActiveModel()`.
+- LOW: server-fallback option/routing tests.
+
 ## Resume queued messages after non-auto compaction; retain admission-rejected custom messages (2026-08-03)
 
 ### What changed

--- a/packages/coding-agent/test/suite/server-fallback-abort-option.test.ts
+++ b/packages/coding-agent/test/suite/server-fallback-abort-option.test.ts
@@ -21,18 +21,52 @@ describe("abortServerSideFallback reaches the provider options", () => {
 		while (harnesses.length > 0) harnesses.pop()?.cleanup();
 	});
 
-	it("forwards the default (enabled) to the stream function", async () => {
-		const harness = await createHarness({});
+	it("enables the abort when the current model has a configured chain", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { fallbackChains: { "faux/faux-1": ["faux/faux-2"] } } },
+		});
 		harnesses.push(harness);
 		const captured = await captureStreamOptions(harness);
 		expect(captured).toHaveLength(1);
 		expect(captured[0]?.abortServerSideFallback).toBe(true);
 	});
 
-	it("forwards an explicit opt-out", async () => {
-		const harness = await createHarness({ settings: { retry: { abortServerSideFallback: false } } });
+	it("follows the server fallback when the current model has no configured chain", async () => {
+		const harness = await createHarness({ settings: { retry: { fallbackChains: {} } } });
 		harnesses.push(harness);
 		const captured = await captureStreamOptions(harness);
+		expect(captured[0]?.abortServerSideFallback).toBe(false);
+	});
+
+	it("forwards an explicit opt-out", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					abortServerSideFallback: false,
+					fallbackChains: { "faux/faux-1": ["faux/faux-2"] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		const captured = await captureStreamOptions(harness);
+		expect(captured[0]?.abortServerSideFallback).toBe(false);
+	});
+
+	it("refreshes the policy after a model switch", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { fallbackChains: { "faux/faux-1": ["faux/faux-2"] } } },
+		});
+		harnesses.push(harness);
+		const fallbackModel = harness.getModel("faux-2");
+		expect(fallbackModel).toBeDefined();
+		if (!fallbackModel) return;
+
+		await harness.session.setModel(fallbackModel);
+		const captured = await captureStreamOptions(harness);
+
 		expect(captured[0]?.abortServerSideFallback).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/suite/server-fallback-abort.test.ts
+++ b/packages/coding-agent/test/suite/server-fallback-abort.test.ts
@@ -5,7 +5,7 @@ import {
 	SERVER_FALLBACK_ABORTED_DIAGNOSTIC,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import { createHarness, type Harness } from "./harness.ts";
+import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
 
 const primary = "faux/faux-1";
 const fallback = "faux/faux-2";
@@ -71,21 +71,28 @@ describe("server-side fallback abort routing", () => {
 		).toEqual([]);
 	});
 
-	it("reports that no chain is configured so the UI can point at /fallback", async () => {
-		const harness = await createHarness({ settings: { retry: { enabled: true, baseDelayMs: 1 } } });
+	it("keeps the server-selected response when no client chain is configured", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: {} } },
+		});
 		harnesses.push(harness);
-		harness.setResponses([abortedByServerFallback("claude-opus-5", "claude-opus-4-6")]);
+		const inner = harness.session.agent.streamFunction;
+		harness.session.agent.streamFunction = (model, context, options) => {
+			harness.setResponses([
+				options?.abortServerSideFallback === true
+					? abortedByServerFallback("claude-opus-5", "claude-opus-4-8")
+					: fauxAssistantMessage("server fallback answer"),
+			]);
+			return inner(model, context, options);
+		};
 
 		await harness.session.prompt("audit this");
 
-		expect(harness.eventsOfType("server_fallback_aborted")).toMatchObject([
-			{ from: "claude-opus-5", to: "claude-opus-4-6", chainConfigured: false },
-		]);
-		// A refusal with no chain settles without exhaustion, so the abort event is
-		// the only signal the UI gets for the missing-chain case.
+		expect(harness.eventsOfType("server_fallback_aborted")).toEqual([]);
 		expect(harness.eventsOfType("retry_fallback_exhausted")).toEqual([]);
 		expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
 		expect(harness.faux.state.callCount).toBe(1);
+		expect(getAssistantTexts(harness)).toContain("server fallback answer");
 	});
 
 	it("keeps the abort diagnostics on the persisted turn", async () => {


### PR DESCRIPTION
## Summary

- follow Anthropic's server-selected fallback when the current model has no configured client fallback chain
- keep an explicit `/fallback` chain authoritative by aborting the server substitution and retrying on the configured model
- refresh the request policy before every prompt and after model switches so session-local chain edits and retry transitions cannot use stale precedence
- preserve `retry.abortServerSideFallback: false` as an explicit opt-out

## Why

Senpi previously enabled `abortServerSideFallback` unconditionally by default. When Anthropic substituted a valid model and the user had no client chain for the requested model, Senpi discarded that response and emitted:

```text
Server-side fallback (...) aborted by client policy
Server fallback ... aborted; no chain configured (set one with /fallback)
```

The provider layer already honors a substitution unless the request option is strictly `true`; this PR makes the coding-agent set that option from the current model's actual client-chain state.

## Verification

### RED -> GREEN

```text
npm --prefix packages/coding-agent test -- \
  test/suite/server-fallback-abort-option.test.ts \
  test/suite/server-fallback-abort.test.ts
```

- RED: 3 expected failures — no-chain and post-model-switch options were `true`, and the no-chain turn emitted `server_fallback_aborted`
- GREEN: focused fallback set plus the double-Escape exhaustion regression passed, 10/10 tests

### Provider regression

```text
npm --prefix packages/ai test -- test/anthropic-server-fallback-abort.test.ts
```

- 8/8 tests passed, covering the existing Anthropic receipt and option behavior

### Static validation

```text
npm run check
```

- passed Biome, dependency/import/lock checks, TypeScript, and browser smoke

### Real CLI QA

- No configured chain, real source TUI: one `claude-opus-5` request; provider-native fallback receipt and `Server fallback accepted` rendered; no client-policy/no-chain warning
- Configured chain, real source `--print`: request sequence `claude-opus-5 -> claude-opus-4-8`; final output `Configured client fallback accepted`
- Both hermetic local servers and all PTY/sandbox resources were removed

Local sanitized evidence:

```text
local-ignore/qa-evidence/20260803-server-fallback-policy/no-chain/
local-ignore/qa-evidence/20260803-server-fallback-policy/configured-chain/
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follow provider-selected model fallbacks when no client fallback chain exists, and only abort server substitutions when a `/fallback` chain is configured. The abort policy now refreshes per prompt and on model switches; explicit `retry.abortServerSideFallback: false` is still honored.

- **Bug Fixes**
  - Accept server fallbacks by default when no client chain is set.
  - Abort and retry on the configured chain when `/fallback` exists.
  - Refresh the abort policy before each prompt and after model switches to prevent stale settings.

<sup>Written for commit 911ca0c06519478818b72b7526fae7e4cc9310e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

