### PR TITLE
test(coding-agent): deflake Anthropic session tests

### DIFF
--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -1,4 +1,5 @@
-import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createAuthenticatedModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { waitForSignalBeforeCompletion } from "./promise-test-utils.ts";
 /**
  * Tests for AgentSession concurrent prompt guard.
  */
@@ -106,7 +107,7 @@ describe("AgentSession concurrent prompt guard", () => {
 
 	async function createSession() {
 		const model = getModel("anthropic", "claude-sonnet-4-5")!;
-		let abortSignal: AbortSignal | undefined;
+		const streamStarted = Promise.withResolvers<void>();
 
 		// Use a stream function that responds to abort
 		const agent = new Agent({
@@ -117,18 +118,15 @@ describe("AgentSession concurrent prompt guard", () => {
 				tools: [],
 			},
 			streamFn: (_model, _context, options) => {
-				abortSignal = options?.signal;
+				streamStarted.resolve();
 				const stream = new MockAssistantStream();
 				queueMicrotask(() => {
 					stream.push({ type: "start", partial: createAssistantMessage("") });
-					const checkAbort = () => {
-						if (abortSignal?.aborted) {
-							stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") });
-						} else {
-							setTimeout(checkAbort, 5);
-						}
-					};
-					checkAbort();
+					const signal = options?.signal;
+					const abort = () =>
+						stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") });
+					if (signal?.aborted) abort();
+					else signal?.addEventListener("abort", abort, { once: true });
 				});
 				return stream;
 			},
@@ -137,30 +135,28 @@ describe("AgentSession concurrent prompt guard", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		// Set a runtime API key so validation passes
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
+		const modelRuntime = getModelRuntime(modelRegistry);
 
 		session = new AgentSession({
 			agent,
 			sessionManager,
 			settingsManager,
 			cwd: tempDir,
-			modelRuntime: getModelRuntime(modelRegistry),
+			modelRuntime,
 			resourceLoader: createTestResourceLoader(),
 		});
 
-		return session;
+		return { modelRuntime, streamStarted: streamStarted.promise };
 	}
 
 	it("should throw when prompt() called while streaming", async () => {
-		await createSession();
+		const { modelRuntime, streamStarted } = await createSession();
+		expect(modelRuntime.hasConfiguredAuth("anthropic")).toBe(true);
 
 		// Start first prompt (don't await, it will block until abort)
 		const firstPrompt = session.prompt("First message");
-
-		// Wait a tick for isStreaming to be set
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await waitForSignalBeforeCompletion(firstPrompt, streamStarted, "provider stream start");
 
 		// Verify we're streaming
 		expect(session.isStreaming).toBe(true);
@@ -176,11 +172,11 @@ describe("AgentSession concurrent prompt guard", () => {
 	});
 
 	it("should allow steer() while streaming", async () => {
-		await createSession();
+		const { streamStarted } = await createSession();
 
 		// Start first prompt
 		const firstPrompt = session.prompt("First message");
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await waitForSignalBeforeCompletion(firstPrompt, streamStarted, "provider stream start");
 
 		// steer should work while streaming
 		expect(() => session.steer("Steering message")).not.toThrow();
@@ -192,11 +188,11 @@ describe("AgentSession concurrent prompt guard", () => {
 	});
 
 	it("should allow followUp() while streaming", async () => {
-		await createSession();
+		const { streamStarted } = await createSession();
 
 		// Start first prompt
 		const firstPrompt = session.prompt("First message");
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await waitForSignalBeforeCompletion(firstPrompt, streamStarted, "provider stream start");
 
 		// followUp should work while streaming
 		expect(() => session.followUp("Follow-up message")).not.toThrow();
@@ -209,7 +205,9 @@ describe("AgentSession concurrent prompt guard", () => {
 
 	it("should queue extension-origin steering messages while streaming", async () => {
 		const model = getModel("anthropic", "claude-sonnet-4-5")!;
-		let abortSignal: AbortSignal | undefined;
+		const steerText = "Steer from extension";
+		const streamStarted = Promise.withResolvers<void>();
+		const steerQueued = Promise.withResolvers<void>();
 		let sawSteeringMessage = false;
 		let lastInputSource: string | undefined;
 		const queueEvents: Array<{ steering: readonly string[]; followUp: readonly string[] }> = [];
@@ -222,7 +220,7 @@ describe("AgentSession concurrent prompt guard", () => {
 				tools: [],
 			},
 			streamFn: (_model, context, options) => {
-				abortSignal = options?.signal;
+				streamStarted.resolve();
 				const stream = new MockAssistantStream();
 				queueMicrotask(() => {
 					const userTexts = context.messages
@@ -238,7 +236,7 @@ describe("AgentSession concurrent prompt guard", () => {
 								.join("\n");
 						});
 
-					if (userTexts.includes("Steer from extension")) {
+					if (userTexts.includes(steerText)) {
 						sawSteeringMessage = true;
 						stream.push({ type: "start", partial: createAssistantMessage("") });
 						stream.push({ type: "done", reason: "stop", message: createAssistantMessage("Steered") });
@@ -246,14 +244,11 @@ describe("AgentSession concurrent prompt guard", () => {
 					}
 
 					stream.push({ type: "start", partial: createAssistantMessage("") });
-					const checkAbort = () => {
-						if (abortSignal?.aborted) {
-							stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") });
-						} else {
-							setTimeout(checkAbort, 5);
-						}
-					};
-					checkAbort();
+					const signal = options?.signal;
+					const abort = () =>
+						stream.push({ type: "error", reason: "aborted", error: createAssistantMessage("Aborted") });
+					if (signal?.aborted) abort();
+					else signal?.addEventListener("abort", abort, { once: true });
 				});
 				return stream;
 			},
@@ -262,8 +257,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 
 		const extensionsResult = await createTestExtensionsResult([
 			(pi) => {
@@ -287,11 +281,12 @@ describe("AgentSession concurrent prompt guard", () => {
 		session.subscribe((event) => {
 			if (event.type === "queue_update") {
 				queueEvents.push({ steering: event.steering, followUp: event.followUp });
+				if (event.steering.includes(steerText)) steerQueued.resolve();
 			}
 		});
 
 		const firstPrompt = session.prompt("First message");
-		await new Promise((resolve) => setTimeout(resolve, 10));
+		await waitForSignalBeforeCompletion(firstPrompt, streamStarted.promise, "provider stream start");
 		expect(session.isStreaming).toBe(true);
 
 		const pi = (
@@ -303,13 +298,14 @@ describe("AgentSession concurrent prompt guard", () => {
 		).testExtensionApi;
 		expect(pi).toBeDefined();
 
-		pi!.sendUserMessage("Steer from extension", { deliverAs: "steer" });
-		await new Promise((resolve) => setTimeout(resolve, 25));
+		pi!.sendUserMessage(steerText, { deliverAs: "steer" });
+		await steerQueued.promise;
+		await session.waitForSettledSessionWork();
 
 		expect(session.pendingMessageCount).toBe(1);
-		expect(session.getSteeringMessages()).toContain("Steer from extension");
+		expect(session.getSteeringMessages()).toContain(steerText);
 		expect(lastInputSource).toBe("extension");
-		expect(queueEvents.some((event) => event.steering.includes("Steer from extension"))).toBe(true);
+		expect(queueEvents.some((event) => event.steering.includes(steerText))).toBe(true);
 
 		await session.abort();
 		await firstPrompt.catch(() => {});
@@ -341,8 +337,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 
 		session = new AgentSession({
 			agent,
@@ -447,8 +442,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 
 		session = new AgentSession({
 			agent,
@@ -574,8 +568,7 @@ describe("AgentSession concurrent prompt guard", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 
 		session = new AgentSession({
 			agent,
@@ -587,12 +580,15 @@ describe("AgentSession concurrent prompt guard", () => {
 			baseToolsOverride: { dummy: tool },
 		});
 
+		const assistantMessageEndStarted = Promise.withResolvers<void>();
+		const releaseAssistantMessageEnd = Promise.withResolvers<void>();
 		const testRunner: TestExtensionRunner = {
 			hasHandlers: () => false,
 			emit: async () => {},
 			emitMessageEnd: async (event) => {
 				if (event.type === "message_end" && event.message?.role === "assistant") {
-					await new Promise((resolve) => setTimeout(resolve, 40));
+					assistantMessageEndStarted.resolve();
+					await releaseAssistantMessageEnd.promise;
 				}
 				return undefined;
 			},
@@ -602,9 +598,11 @@ describe("AgentSession concurrent prompt guard", () => {
 		};
 		installTestExtensionRunner(session, testRunner);
 
-		await session.prompt("hi");
+		const prompt = session.prompt("hi");
+		await waitForSignalBeforeCompletion(prompt, assistantMessageEndStarted.promise, "assistant message_end handler");
+		releaseAssistantMessageEnd.resolve();
+		await prompt;
 		await session.agent.waitForIdle();
-		await new Promise((resolve) => setTimeout(resolve, 100));
 
 		const messageEntries = sessionManager.getEntries().filter((entry) => entry.type === "message");
 		expect(messageEntries.map((entry) => entry.message.role)).toEqual([

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -9,7 +9,7 @@ import { AgentSession } from "../src/core/agent-session.ts";
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
-import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createAuthenticatedModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 import { createTestResourceLoader } from "./utilities.ts";
 
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -106,8 +106,7 @@ describe("AgentSession retry", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1 } });
 
 		session = new AgentSession({
@@ -208,8 +207,7 @@ describe("AgentSession retry", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } });
 		session = new AgentSession({
 			agent,
@@ -293,8 +291,7 @@ describe("AgentSession retry", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } });
 
 		session = new AgentSession({

--- a/packages/coding-agent/test/fixtures/rpc-classic-harness.ts
+++ b/packages/coding-agent/test/fixtures/rpc-classic-harness.ts
@@ -31,7 +31,7 @@ import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.t
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 import { SettingsManager } from "../../src/core/settings-manager.ts";
-import { createModelRegistry, getModelRuntime } from "../model-runtime-test-utils.ts";
+import { createAuthenticatedModelRegistry, createModelRegistry, getModelRuntime } from "../model-runtime-test-utils.ts";
 import { createTestResourceLoader } from "../utilities.ts";
 
 /** Captured wire state shared between the mocked modules and the test. */
@@ -120,10 +120,9 @@ async function createAgentSession(
 
 	const sessionManager = SessionManager.inMemory();
 	const settingsManager = SettingsManager.create(tempDir, tempDir);
-	const modelRegistry = await createModelRegistry(authStorage, tempDir);
-	if (withAuth) {
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
-	}
+	const modelRegistry = withAuth
+		? await createAuthenticatedModelRegistry(authStorage, tempDir)
+		: await createModelRegistry(authStorage, tempDir);
 
 	const session = new AgentSession({
 		agent,

--- a/packages/coding-agent/test/high-reasoning-warning-event.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-event.test.ts
@@ -9,7 +9,7 @@ import { AgentSession, type AgentSessionEvent } from "../src/core/agent-session.
 import { AuthStorage } from "../src/core/auth-storage.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
-import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createAuthenticatedModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 import { createTestResourceLoader } from "./utilities.ts";
 
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -99,8 +99,7 @@ describe("AgentSession high_reasoning_warning event", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 
 		session = new AgentSession({
 			agent,

--- a/packages/coding-agent/test/high-reasoning-warning-rpc.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-rpc.test.ts
@@ -10,7 +10,7 @@ import { AuthStorage } from "../src/core/auth-storage.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
 import { createRpcEventOutputBuffer } from "../src/modes/rpc/event-output-buffer.ts";
-import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createAuthenticatedModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 import { createTestResourceLoader } from "./utilities.ts";
 
 class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
@@ -96,8 +96,7 @@ describe("RPC publish of high_reasoning_warning", () => {
 		const sessionManager = SessionManager.inMemory();
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-		const modelRegistry = await createModelRegistry(authStorage, tempDir);
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
 
 		session = new AgentSession({
 			agent,

--- a/packages/coding-agent/test/model-runtime-test-utils.ts
+++ b/packages/coding-agent/test/model-runtime-test-utils.ts
@@ -14,6 +14,14 @@ export async function createModelRegistry(credentials: CredentialStore, modelsPa
 	return wrap(await ModelRuntime.create({ credentials, modelsPath, allowModelNetwork: false }));
 }
 
+export async function createAuthenticatedModelRegistry(
+	credentials: CredentialStore,
+	modelsPath?: string,
+): Promise<ModelRegistry> {
+	await credentials.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+	return createModelRegistry(credentials, modelsPath);
+}
+
 export async function createInMemoryModelRegistry(credentials: CredentialStore): Promise<ModelRegistry> {
 	return wrap(await ModelRuntime.create({ credentials, modelsPath: null, allowModelNetwork: false }));
 }

--- a/packages/coding-agent/test/promise-test-utils.test.ts
+++ b/packages/coding-agent/test/promise-test-utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { waitForSignalBeforeCompletion } from "./promise-test-utils.ts";
+
+describe("waitForSignalBeforeCompletion", () => {
+	it("returns when the signal arrives first", async () => {
+		const operation = Promise.withResolvers<void>();
+		const signal = Promise.withResolvers<void>();
+		const waiting = waitForSignalBeforeCompletion(operation.promise, signal.promise, "stream start");
+
+		signal.resolve();
+
+		await expect(waiting).resolves.toBeUndefined();
+		operation.reject(new Error("handled after signal"));
+	});
+
+	it("rethrows an operation rejection that arrives first", async () => {
+		const operation = Promise.withResolvers<void>();
+		const signal = Promise.withResolvers<void>();
+		const waiting = waitForSignalBeforeCompletion(operation.promise, signal.promise, "stream start");
+		const error = new Error("auth failed");
+
+		operation.reject(error);
+
+		await expect(waiting).rejects.toBe(error);
+	});
+
+	it("rejects when the operation completes before the signal", async () => {
+		const operation = Promise.withResolvers<void>();
+		const signal = Promise.withResolvers<void>();
+		const waiting = waitForSignalBeforeCompletion(operation.promise, signal.promise, "stream start");
+
+		operation.resolve();
+
+		await expect(waiting).rejects.toThrow("Operation completed before stream start");
+	});
+});

--- a/packages/coding-agent/test/promise-test-utils.ts
+++ b/packages/coding-agent/test/promise-test-utils.ts
@@ -1,0 +1,16 @@
+export async function waitForSignalBeforeCompletion(
+	operation: Promise<unknown>,
+	signal: Promise<void>,
+	description: string,
+): Promise<void> {
+	const operationOutcome = operation.then(
+		() => ({ status: "completed" }) as const,
+		(error: unknown) => ({ status: "rejected", error }) as const,
+	);
+	const outcome = await Promise.race([signal.then(() => ({ status: "signaled" }) as const), operationOutcome]);
+
+	if (outcome.status === "rejected") throw outcome.error;
+	if (outcome.status === "completed") {
+		throw new Error(`Operation completed before ${description}`);
+	}
+}

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -16,7 +16,7 @@ import { AuthStorage } from "../src/core/auth-storage.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
 import { runRpcMode } from "../src/modes/rpc/rpc-mode.ts";
-import { createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
+import { createAuthenticatedModelRegistry, createModelRegistry, getModelRuntime } from "./model-runtime-test-utils.ts";
 import { createTestResourceLoader } from "./utilities.ts";
 
 const rpcIo = vi.hoisted(() => ({
@@ -129,10 +129,9 @@ async function createRuntimeHost(options: { withAuth: boolean; responseDelayMs: 
 	const sessionManager = SessionManager.inMemory();
 	const settingsManager = SettingsManager.create(tempDir, tempDir);
 	const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
-	const modelRegistry = await createModelRegistry(authStorage, tempDir);
-	if (options.withAuth) {
-		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
-	}
+	const modelRegistry = options.withAuth
+		? await createAuthenticatedModelRegistry(authStorage, tempDir)
+		: await createModelRegistry(authStorage, tempDir);
 
 	const session = new AgentSession({
 		agent,

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -730,7 +730,7 @@ describe("ToolExecutionComponent parity", () => {
 			);
 
 			const collapsed = stripAnsi(component.render(120).join("\n"));
-			expect(collapsed).toContain(scenario.compact);
+			expect(collapsed.replace(/\s+/g, " ")).toContain(scenario.compact);
 			expect(collapsed).not.toContain(scenario.hidden);
 			if (scenario.absent) {
 				expect(collapsed).not.toContain(scenario.absent);


### PR DESCRIPTION
## Summary

- seed Anthropic test credentials before `ModelRuntime.create()` so session fixtures start with a correct configured-auth snapshot
- replace fixed sleeps and abort polling in concurrent session tests with exact promise, queue, and abort signals
- preserve missing-auth RPC branches while centralizing authenticated registry setup
- make the compact outside-`AGENTS.md` read assertion stable when long worktree paths wrap at 120 columns

## Root cause

`agent-session-concurrent.test.ts` created `ModelRuntime` before writing its
Anthropic test key. The runtime snapshot therefore reported
`hasConfiguredAuth("anthropic") === false`, even though the later live
`checkAuth()` fallback could read the key.

Under full-suite load, the test's fixed 10 ms wait expired before that fallback
completed. The `isStreaming` assertion failed, teardown removed `auth.json`,
and the still-pending prompt rejected as an unhandled
`No API key found for anthropic`.

The regression now asserts the configured-auth snapshot directly, so it cannot
pass through the live fallback. A mutation that restores the old ordering fails
that exact assertion.

## Verification

- canonical full-suite RED captured with the exact unhandled Anthropic error
- identical targeted regression:
  - RED: 1 failed at `hasConfiguredAuth("anthropic")`
  - GREEN: 1 passed
- mutation proof:
  - reversed helper ordering: RED
  - restored credential-first ordering: GREEN
- affected suite after final main sync: 8 files, all passing
- `npm run check`: passed
- `npm run build`: passed
- complete coding-agent suite after final main sync:
  - 809 files passed, 4 skipped
  - 6,724 tests passed, 35 skipped
  - zero failures or unhandled errors
- Senpi QA common self-check: 9/9 passed
- real source CLI Anthropic mock-loop:
  - `POST /v1/messages`
  - prompt: `reply AUTH-FLAKE-QA`
  - stdout: `SENPI-QA-MOCK: reply AUTH-FLAKE-QA`
  - real auth hash unchanged
  - no task-owned process, port, or sandbox remained

## Review

Five independent review-work lanes completed:

- goal/constraint verification: PASS
- code quality and deterministic async testing: PASS
- security/auth semantics: PASS
- hands-on QA: PASS
- repository context/history: PASS after fast-forwarding current `main`

This is test-only. Production auth/session behavior is unchanged, and no fork
`changes.md` entry is required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes Anthropic session tests by seeding credentials before runtime init and switching to event-driven waits. Improves determinism in concurrent and RPC tests; no production changes.

- **Bug Fixes**
  - Seed test credentials before `ModelRuntime.create()` via `createAuthenticatedModelRegistry()`, ensuring `hasConfiguredAuth("anthropic")` is true and snapshots are stable.
  - Replace fixed sleeps and abort polling with `waitForSignalBeforeCompletion` and abort event listeners; added `promise-test-utils` with unit tests.
  - Preserve missing-auth RPC branches while centralizing authenticated registry setup in fixtures.
  - Stabilize compact outside-`AGENTS.md` read assertion by normalizing whitespace in the `ToolExecutionComponent` test.

<sup>Written for commit b1b3cc11a62e687e9a910d230b829ca2f5d54176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

