### PR TITLE
fix(release): pin stable Bun binary compiler

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -41,10 +41,12 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: canary
+          # Cross-compilation downloads target executables matching the running Bun
+          # release. Canary can advance before those target artifacts are published.
+          bun-version: '1.3.14'
 
-      - name: Assert bun canary channel
-        run: bash scripts/assert-bun-canary.sh
+      - name: Report Bun compiler version
+        run: bun --version
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Pinned compiled binary release builds to Bun 1.3.14 instead of the moving canary, keeping all six cross-compilation target executables downloadable during release recovery.
+
 ### Removed
 
 ## [2026.8.3-3] - 2026-08-03

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Pinned compiled binary release builds to Bun 1.3.14 instead of the moving canary, keeping all six cross-compilation target executables downloadable during release recovery.
+- Pinned compiled binary release builds to Bun 1.3.14 instead of the moving canary, keeping all six cross-compilation target executables downloadable during release recovery ([#674](https://github.com/code-yeongyu/senpi/pull/674)).
 
 ### Removed
 

--- a/scripts/build-binaries-workflow.test.mjs
+++ b/scripts/build-binaries-workflow.test.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const workflow = readFileSync(new URL("../.github/workflows/build-binaries.yml", import.meta.url), "utf8");
+
+describe("binary release workflow", () => {
+	it("pins a stable Bun release with downloadable cross-compile executables", () => {
+		assert.match(workflow, /bun-version:\s*['"]1\.3\.14['"]/);
+		assert.doesNotMatch(workflow, /bun-version:\s*canary/);
+		assert.doesNotMatch(workflow, /assert-bun-canary\.sh/);
+	});
+
+	it("keeps recovery source refs separate from the published release tag", () => {
+		assert.match(workflow, /RELEASE_TAG:\s*\$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}/);
+		assert.match(
+			workflow,
+			/SOURCE_REF:\s*\$\{\{ github\.event\.inputs\.source_ref \|\| github\.event\.inputs\.tag \|\| github\.ref_name \}\}/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- pin compiled binary releases to Bun 1.3.14 instead of the moving canary channel
- add a workflow contract test covering the pinned compiler and release-recovery `source_ref`
- document the Bun binary release reliability fix in the coding-agent changelog

## Why

The `v2026.8.3-3` tag-triggered binary workflow installed Bun canary 1.4.0 before matching cross-compile target executables were downloadable. `bun build --compile --target=bun-darwin-arm64` therefore failed with:

```text
Target platform 'bun-darwin-aarch64-v1.4.0' is not available for download.
```

The npm packages are already published successfully. After this PR merges, the existing workflow recovery input can build the unchanged `v2026.8.3-3` tag from corrected `main` without moving the tag or republishing npm.

## Validation

- RED: `node --test scripts/build-binaries-workflow.test.mjs` failed against `bun-version: canary`
- GREEN: `node --test scripts/build-binaries-workflow.test.mjs` — 2/2
- `npm run test:scripts` — 86/86
- `npm run check` — exit 0
- `actionlint .github/workflows/build-binaries.yml` — exit 0
- `git diff --check` — clean
- real cross-compile: Bun 1.3.14 downloaded and compiled `bun-linux-x64-v1.3.14`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the binary release workflow to `bun` 1.3.14 instead of canary. This fixes failed cross-compiles, allows recovery builds of `v2026.8.3-3` without retagging or republishing, and adds a workflow contract test with a changelog update.

<sup>Written for commit 0685b45be9abbfac5e20bbf55e45228bf4e39121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

