### PR TITLE
fix(coding-agent): hide Bun console diagnostics in TUI

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## Bun console diagnostics stay behind the interactive terminal guard (2026-08-03)
+
+### What changed
+
+- While the TUI owns the terminal, the interactive stderr guard now routes `console.info`, `console.warn`, and
+  `console.error` through its hidden, redacted debug-log sink and restores the exact console methods whenever the
+  terminal is released.
+- Coverage models Bun's native console behavior, which bypasses a replaced `process.stderr.write`, and pins
+  terminal silence, debug-log redaction, and restoration.
+
+### Why
+
+- omo-senpi emits ulw-loop and start-work diagnostics through `console.*`. Node routes those calls through the
+  patched stderr writer, but Bun writes them through its native console implementation, so the diagnostics could
+  corrupt the interactive footer even though direct `process.stderr.write` coverage was green.
+
+### Why this cannot be expressed externally
+
+- Extensions cannot protect the host TUI from runtime-specific console output before it reaches the terminal.
+  The host must own console interception for exactly the interval in which it owns the terminal.
+
+### Expected merge conflict zones
+
+- LOW: `interactive-stderr-guard.ts` and its focused regression test.
+
 ## Backfill: exit alias and footer provider priority (2026-08-01)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-stderr-guard.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-stderr-guard.ts
@@ -1,8 +1,22 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { format } from "node:util";
 import { getDebugLogPath } from "../../config.ts";
 import { restoreStderr, takeOverStderr } from "../../core/output-guard.ts";
 import { redactSensitiveOutput } from "../../core/sensitive-output.ts";
+
+const consoleLevels = ["error", "info", "warn"] as const;
+
+type ConsoleLevel = (typeof consoleLevels)[number];
+type ConsoleMethod = (...data: unknown[]) => void;
+
+interface InteractiveConsoleState {
+	readonly error: ConsoleMethod;
+	readonly info: ConsoleMethod;
+	readonly warn: ConsoleMethod;
+}
+
+let interactiveConsoleState: InteractiveConsoleState | undefined;
 
 function appendHiddenInteractiveStderr(text: string): void {
 	if (text.length === 0) {
@@ -17,10 +31,47 @@ function appendHiddenInteractiveStderr(text: string): void {
 	fs.chmodSync(debugLogPath, 0o600);
 }
 
+function replaceConsoleMethod(level: ConsoleLevel, method: ConsoleMethod): void {
+	Object.defineProperty(console, level, {
+		configurable: true,
+		value: method,
+		writable: true,
+	});
+}
+
+function takeOverInteractiveConsole(): void {
+	if (interactiveConsoleState) {
+		return;
+	}
+	interactiveConsoleState = {
+		error: console.error,
+		info: console.info,
+		warn: console.warn,
+	};
+	const writeHiddenConsoleDiagnostic = (...data: unknown[]) => {
+		process.stderr.write(`${format(...data)}\n`);
+	};
+	for (const level of consoleLevels) {
+		replaceConsoleMethod(level, writeHiddenConsoleDiagnostic);
+	}
+}
+
+function restoreInteractiveConsole(): void {
+	if (!interactiveConsoleState) {
+		return;
+	}
+	for (const level of consoleLevels) {
+		replaceConsoleMethod(level, interactiveConsoleState[level]);
+	}
+	interactiveConsoleState = undefined;
+}
+
 export function takeOverInteractiveStderr(): void {
 	takeOverStderr(appendHiddenInteractiveStderr, redactSensitiveOutput);
+	takeOverInteractiveConsole();
 }
 
 export function restoreInteractiveStderr(): void {
+	restoreInteractiveConsole();
 	restoreStderr();
 }

--- a/packages/coding-agent/test/interactive-stderr-guard.test.ts
+++ b/packages/coding-agent/test/interactive-stderr-guard.test.ts
@@ -11,9 +11,18 @@ import {
 
 const originalStderrWrite = process.stderr.write;
 const originalAgentDir = process.env[ENV_AGENT_DIR];
+const consoleLevels = ["error", "info", "warn"] as const;
+const originalConsoleMethods = {
+	error: console.error,
+	info: console.info,
+	warn: console.warn,
+};
 const githubFineGrainedPat = "github_pat_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
 const tempDirs: string[] = [];
+
+type ConsoleLevel = keyof typeof originalConsoleMethods;
+type ConsoleMethod = (...data: unknown[]) => void;
 
 function replaceStderrWrite(write: typeof process.stderr.write): void {
 	Object.defineProperty(process.stderr, "write", {
@@ -39,10 +48,21 @@ function createCapturingStderrWrite(capture: (text: string) => void): typeof pro
 	}) satisfies typeof process.stderr.write;
 }
 
+function replaceConsoleMethod(level: ConsoleLevel, method: ConsoleMethod): void {
+	Object.defineProperty(console, level, {
+		configurable: true,
+		value: method,
+		writable: true,
+	});
+}
+
 afterEach(() => {
 	restoreInteractiveStderr();
 	restoreStderr();
 	replaceStderrWrite(originalStderrWrite);
+	for (const level of consoleLevels) {
+		replaceConsoleMethod(level, originalConsoleMethods[level]);
+	}
 	if (originalAgentDir === undefined) {
 		delete process.env[ENV_AGENT_DIR];
 	} else {
@@ -145,5 +165,35 @@ describe("interactive stderr guard", () => {
 		expect(log).not.toContain("stderr-secret");
 		expect(log).not.toContain(githubFineGrainedPat);
 		expect((statSync(debugLogPath).mode & 0o777).toString(8)).toBe("600");
+	});
+
+	it("hides Bun-style console diagnostics while the TUI owns the terminal and restores them afterwards", () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "pi-hidden-console-"));
+		tempDirs.push(agentDir);
+		process.env[ENV_AGENT_DIR] = agentDir;
+		let terminalText = "";
+		const bunConsoleWrite = (...data: unknown[]) => {
+			terminalText += `${data.map(String).join(" ")}\n`;
+		};
+		for (const level of consoleLevels) {
+			replaceConsoleMethod(level, bunConsoleWrite);
+		}
+
+		takeOverInteractiveStderr();
+		console.info("omo-senpi start-work-continuation skipped SECRET_TOKEN=console-secret");
+		console.warn("omo-senpi ulw-loop status ignored", { reason: "non-zero-exit" });
+		console.error("omo-senpi component registration failed");
+
+		expect(terminalText).toBe("");
+		restoreInteractiveStderr();
+		console.info("visible after restore");
+		expect(terminalText).toBe("visible after restore\n");
+
+		const log = readFileSync(getDebugLogPath(), "utf8");
+		expect(log).toContain("start-work-continuation skipped");
+		expect(log).toContain("ulw-loop status ignored");
+		expect(log).toContain("component registration failed");
+		expect(log).toContain("SECRET_TOKEN=[REDACTED]");
+		expect(log).not.toContain("console-secret");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes Bun-specific TUI corruption from extension diagnostics emitted through `console.info`, `console.warn`, and `console.error`.

Bun's native console bypasses a replaced `process.stderr.write`, so the interactive stderr guard added in #105 did not see omo-senpi's ulw-loop and start-work diagnostics. The interactive guard now takes over those console methods while the TUI owns the terminal, formats them through the existing hidden/redacted stderr sink, and restores the exact methods whenever the terminal is released.

Closes #675.
Closes #676.

## RED -> GREEN

- **Actual runtime RED:** the same probe under Node captured the marker in the hidden sink, while Bun emitted it on real stderr with an empty hidden sink.
- **Focused RED:** `npm test -- test/interactive-stderr-guard.test.ts`
  - 1 new test failed, 4 existing tests passed.
  - Failure showed all three concrete omo diagnostics in the terminal sink.
- **Focused GREEN:** the same command passed **5/5** after the fix.
- **Actual Bun GREEN:** the patched Bun probe emitted no diagnostic text to stdout/stderr, captured all markers in the debug log, redacted the QA secret, restored the original console methods, and removed its sandbox.

## Manual QA

- Chromium/xterm.js true-color TUI capture using the real source CLI under Bun and an isolated QA extension:
  - TUI rendered and accepted `SENPIQATYPED1234`.
  - `omo-senpi start-work-continuation skipped`, `omo-senpi ulw-loop status ignored`, and `omo-senpi component registration failed` were absent from the terminal capture.
  - All three were present in the isolated debug log with the QA secret redacted.
  - Screenshot manually inspected; footer remained intact.
  - Width check: 120/120 columns, no overflow, no border misalignment.
  - Browser closed, PTY process gone, sandbox removed, real auth unchanged.
- Canonical Senpi TUI smoke:
  - `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence 20260803-bun-console-stderr-guard`
  - **5/5 passed**, including teardown and real-auth integrity.

## Validation

- LSP diagnostics clean on both changed TypeScript files.
- `npm run check` passed twice after the final source and changes-record state.
- `git diff --check` clean.
- Pure LOC: guard 67; focused test 175.

## Evidence

Local reviewer receipts are stored under:

`local-ignore/qa-evidence/20260803-bun-console-stderr-guard/`

They include RED/GREEN outputs, the actual Bun probe, xterm screenshot/text/metadata, redacted debug log, width report, canonical TUI smoke, cleanup receipts, root check, and self-review.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Bun console diagnostics from corrupting the TUI by intercepting `console.info`, `console.warn`, and `console.error` during interactive mode. Messages are routed to the hidden redacted debug log, and the original console methods are restored when the terminal is released. Fixes #675 and #676.

- **Bug Fixes**
  - Extended the interactive stderr guard to take over `console.*` while the TUI owns the terminal and send output to the hidden, redacted sink; restores methods on release.
  - Added a focused test that simulates Bun’s native console, ensuring no terminal leakage, correct redaction, and 0600 permissions on the debug log.

<sup>Written for commit 37dba4980eb3bff2698f93fc6802137ae1d89e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

