### PR TITLE
fix(coding-agent): list PI_RULES settings in --help

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - The ambient Claude auth availability probe now passes `windowsHide: true` when spawning `claude auth status`, so the background check no longer opens a console window on Windows ([#870](https://github.com/code-yeongyu/senpi/issues/870)).
+- `senpi --help` now lists the `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` environment settings that the built-in rules extension reads, so the two environment-only character limits are discoverable from the CLI ([#678](https://github.com/code-yeongyu/senpi/issues/678)).
 
 ### New Features
 

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -434,6 +434,9 @@ ${chalk.bold("Environment Variables:")}
   ${ENV_SESSION_DIR.padEnd(32)} - Session storage directory (overridden by --session-dir)
   PI_PACKAGE_DIR                   - Override package directory (for Nix/Guix store paths)
   PI_OFFLINE                       - Disable startup network operations when set to 1/true/yes
+  PI_RULES_DISABLED                - Disable built-in rules when set to 1/true/yes/on
+  PI_RULES_MAX_RULE_CHARS          - Per-rule formatted payload character cap (default: 12000)
+  PI_RULES_MAX_RESULT_CHARS        - Complete static/dynamic block character cap (default: 40000)
   PI_TELEMETRY                     - Override install telemetry when set to 1/true/yes or 0/false/no
   PI_SHARE_VIEWER_URL              - Base URL for /share command (default: https://pi.dev/session/)
 

--- a/packages/coding-agent/src/cli/changes.md
+++ b/packages/coding-agent/src/cli/changes.md
@@ -17,6 +17,29 @@
 - LOW: `args.ts` environment-variable help rows.
 
 
+||||||| parent of 30188918f (fix(coding-agent): list PI_RULES settings in help)
+
+## PI_RULES environment settings in top-level help (2026-08-03)
+
+### What changed
+
+- `args.ts`: the Environment Variables section now lists `PI_RULES_DISABLED`,
+  `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` with their accepted values and defaults.
+
+### Why
+
+- The settings added in #670 were documented in the README but omitted from `senpi --help`, leaving the two
+  environment-only character limits undiscoverable from the CLI.
+
+### Why extension system couldn't handle this
+
+- The static Environment Variables section belongs to `printHelp()` and extensions can register flags, not help
+  entries for environment settings.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `args.ts` Environment Variables rows.
+
 ## `senpi --list-tips` prints the tip catalog as JSON (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/678-pi-rules-help-env.test.ts
+++ b/packages/coding-agent/test/suite/regressions/678-pi-rules-help-env.test.ts
@@ -1,0 +1,20 @@
+import { expect, test, vi } from "vitest";
+import { printHelp } from "../../../src/cli/args.ts";
+
+test("lists the public PI_RULES environment settings in top-level help", () => {
+	// Given: the top-level help output is captured without loading extension flags.
+	const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+	try {
+		// When: the CLI renders its built-in help surface.
+		printHelp(undefined, false);
+		const output = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
+
+		// Then: every public rules setting is discoverable by name.
+		expect(output).toContain("PI_RULES_DISABLED");
+		expect(output).toContain("PI_RULES_MAX_RULE_CHARS");
+		expect(output).toContain("PI_RULES_MAX_RESULT_CHARS");
+	} finally {
+		logSpy.mockRestore();
+	}
+});


### PR DESCRIPTION
## Summary

- list `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` in the top-level Environment Variables help
- keep accepted values and defaults aligned with the runtime and README added in #670
- add an issue-numbered help regression and the required fork `changes.md` record

Closes #678

## Root cause

`printHelp()` maintains its Environment Variables section independently. PR #670 added the runtime settings and README rows, but did not update that static help surface. The two character limits have no equivalent CLI flags, so they were otherwise undiscoverable from `senpi --help`.

## RED -> GREEN

- `npx vitest --run test/suite/regressions/678-pi-rules-help-env.test.ts`
  - RED: 1 failed because `PI_RULES_DISABLED` was absent from top-level help
  - GREEN: 1 passed after adding the three rows
- adjacent help coverage: 3 files, 82 tests passed

## Verification

- `npm run check`
- `npm run build`
- no-excuse TypeScript audit: no violations in the two changed TS files
- repository QA self-check: 9/9 passed
- CLI smoke self-test: 8/8 passed
- hands-on review QA: 20/20 scenarios passed, including `--help`, `-h`, duplicate detection, exact defaults, and invalid environment values
- five-lane review plus runtime audit: all passed at `30188918f96d033def3eaaf48af4273512a60c42`

Built/source CLI observation:

```text
PI_RULES_DISABLED                - Disable built-in rules when set to 1/true/yes/on
PI_RULES_MAX_RULE_CHARS          - Per-rule formatted payload character cap (default: 12000)
PI_RULES_MAX_RESULT_CHARS        - Complete static/dynamic block character cap (default: 40000)
```

Both normal and `-ne` help invocations exited 0 with empty stderr.

The full coding-agent suite reached 6745 passing tests with one unrelated timing-sensitive issue #5303 assertion failing under full-suite load; that test file passed 2/2 immediately in isolation. No production behavior in that path is changed here.

## Scope

- README is unchanged because #670 already documents the correct contract.
- `CHANGELOG.md` is intentionally unchanged per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PI rules environment settings to `senpi --help` so users can discover and configure rule limits. Previously absent; now `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` are listed with accepted values and defaults.

- Adds help rows in `args.ts`, aligned with runtime and README; the two character limits remain env-only (no CLI flags).
- Adds a regression test that asserts the three settings appear in top-level help.
- Updates `CHANGELOG.md` to record the help change.
- No runtime behavior change.

<sup>Written for commit 01bd793e84a7e3eb84dc46ff7cfbca57a544c50d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

