### PR TITLE
fix(goal): shorten user-grace auto-resume countdown to 10s

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -46,7 +46,7 @@ hidden continuation can be queued at a time. The stall notice is goal-wide: from
 3rd consecutive toolless continuation turn it prefixes the prompt with `<goal_stall_check>`
 and switches between monitor-flavored bullets while monitors are active and generic
 recovery bullets otherwise. Accepted direct input disarms a pending continuation,
-and a clean accepted user turn arms a visible 60-second grace countdown before the Goal
+and a clean accepted user turn arms a visible 10-second grace countdown before the Goal
 resumes; mechanically blocked Goals are reactivated on accepted input, including admitted
 steering. A `length` stop gets exactly one minimal truncation recovery before the goal
 blocks on repetition, terminal provider errors block the goal only when `AgentEndEvent.willRetry`

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -8,7 +8,7 @@ export const GOAL_CONTINUATION_CAP = 8;
 export const GOAL_STALL_TOOLLESS_THRESHOLD = 3;
 export const GOAL_REPETITION_HASH_STREAK = 3;
 export const GOAL_LENGTH_RECOVERY_LIMIT = 1;
-export const GOAL_USER_GRACE_DELAY_MS = 60_000;
+export const GOAL_USER_GRACE_DELAY_MS = 10_000;
 
 export type GoalContinuationPath = "immediate" | "monitorDelayed" | "userGrace" | "sessionStart";
 

--- a/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
@@ -182,6 +182,6 @@ describe("goal continuation verdict", () => {
 		expect(GOAL_STALL_TOOLLESS_THRESHOLD).toBe(3);
 		expect(GOAL_REPETITION_HASH_STREAK).toBe(3);
 		expect(GOAL_LENGTH_RECOVERY_LIMIT).toBe(1);
-		expect(GOAL_USER_GRACE_DELAY_MS).toBe(60_000);
+		expect(GOAL_USER_GRACE_DELAY_MS).toBe(10_000);
 	});
 });

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -459,7 +459,7 @@ describe("goal continuation while a monitor is active", () => {
 
 		const countdownStarted = waitForGoalStatus(
 			status,
-			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 1m") === true,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 10s") === true,
 		);
 		await runUserInitiatedTurn(handlers, ctx);
 		await countdownStarted;
@@ -467,7 +467,7 @@ describe("goal continuation while a monitor is active", () => {
 
 		const countdownAdvanced = waitForGoalStatus(
 			status,
-			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 30s") === true,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 5s") === true,
 		);
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS / 2);
 		await countdownAdvanced;
@@ -499,7 +499,7 @@ describe("goal continuation while a monitor is active", () => {
 
 		const countdownStarted = waitForGoalStatus(
 			status,
-			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 1m") === true,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal resumes in 10s") === true,
 		);
 		await runUserInitiatedTurn(handlers, ctx);
 		await countdownStarted;


### PR DESCRIPTION
## Summary

Shorten the goal user-grace auto-resume countdown from 60s to 10s. After a clean accepted user turn, the TUI now renders `goal resumes in 10s` (ticking down from 10) instead of `goal resumes in 1m` (from 60).

## Why

The 60-second grace window was too long for interactive workflows — the goal sat idle for a full minute before auto-resuming. 10s keeps the grace behavior (a real user prompt still cancels the countdown) while resuming the goal promptly.

## Changes

- `continuation.ts`: `GOAL_USER_GRACE_DELAY_MS` `60_000` → `10_000`
- `goal/AGENTS.md`: behavioral doc updated (60-second → 10-second)
- `goal-continuation-verdict.test.ts`: constant assertion `60_000` → `10_000`
- `goal-monitor-continuation.test.ts`: countdown-label expectations updated (`1m` → `10s`, `30s` → `5s`)

## Verification

- Affected goal test suite: 5 files, 96 tests — GREEN
- `npm run check` — exit 0 (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, tsc, browser-smoke)
- QA evidence: `local-ignore/qa-evidence/20260803-goal-grace-10s/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortened the goal user-grace auto-resume countdown from 60s to 10s to reduce idle time after a clean accepted user turn. The TUI now shows “goal resumes in 10s,” and `GOAL_USER_GRACE_DELAY_MS`, docs, and tests were updated to match.

<sup>Written for commit 340a3f9c76bc5a6d06c269813acd253c6b7310eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

