### PR TITLE
fix(coding-agent): suppress aborted compaction stream errors

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,35 @@
 # Builtin compaction extension changes
 
+## Treat caller-aborted summary stream failures as cancellation (2026-08-03)
+
+### What changed
+
+- `runExtensionCompaction()` now converts a summary-generation rejection to the existing
+  `undefined` cancellation result when its caller signal has been aborted.
+- Non-abort stream and provider failures are still rethrown unchanged.
+- A focused regression test reproduces the late stream-result rejection seen after ESC and
+  separately proves an ordinary stream failure remains visible.
+
+### Why
+
+- The compaction watchdog can stop waiting as soon as ESC aborts the caller signal, while the
+  provider stream's final result rejects a moment later with
+  `Assistant message stream consumption was cancelled`.
+- That late rejection escaped the documented `runExtensionCompaction()` cancellation contract,
+  causing the builtin extension runner to print an error and stack trace after the normal
+  `Auto-compaction cancelled` notice.
+
+### Why an extension could not do this
+
+- This is the builtin compaction extension's own summary-stream consumption boundary. No external
+  extension hook can intercept the private stream result before `runExtensionCompaction()` returns
+  to the extension runner.
+
+### Expected merge-conflict zones
+
+- `speculative.ts` around `runExtensionCompaction()` and its call to `generateSummaryMessage()`.
+- Compaction stream cancellation tests under `test/compaction/`.
+
 ## Idle warm-up retries transient failures while the session stays idle (2026-08-03)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -461,19 +461,25 @@ export async function runExtensionCompaction(
 
 	while (true) {
 		if (signal?.aborted) return undefined;
-		const response = await generateSummaryMessage({
-			context,
-			messages,
-			onProgress,
-			prompt,
-			signal,
-			snapshot,
-			auth: {
-				apiKey: auth.apiKey,
-				headers: auth.headers,
-				extraBody: auth.extraBody,
-			},
-		});
+		let response: Message | undefined;
+		try {
+			response = await generateSummaryMessage({
+				context,
+				messages,
+				onProgress,
+				prompt,
+				signal,
+				snapshot,
+				auth: {
+					apiKey: auth.apiKey,
+					headers: auth.headers,
+					extraBody: auth.extraBody,
+				},
+			});
+		} catch (error) {
+			if (signal?.aborted) return undefined;
+			throw error;
+		}
 		if (!response) return undefined;
 
 		if (isAssistantMessage(response) && isContextOverflow(response, snapshot.contextWindow)) {

--- a/packages/coding-agent/test/compaction/speculative-abort-cancellation.test.ts
+++ b/packages/coding-agent/test/compaction/speculative-abort-cancellation.test.ts
@@ -1,0 +1,131 @@
+import {
+	createAssistantMessageEventStream,
+	type FauxModelDefinition,
+	fauxAssistantMessage,
+	registerFauxProvider,
+} from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import {
+	createSpeculativeCompactionSnapshot,
+	runExtensionCompaction,
+	type SpeculativeCompactionContext,
+} from "../../src/core/extensions/builtin/compaction/speculative.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+const registrations: Array<{ unregister: () => void }> = [];
+
+type Registration = ReturnType<typeof registerFauxProvider>;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+function createContext(registration: Registration): SpeculativeCompactionContext {
+	const model = registration.getModel();
+	const authStorage = AuthStorage.inMemory();
+	authStorage.setRuntimeApiKey(model.provider, "faux-key");
+	const modelRegistry = ModelRegistry.inMemory(authStorage);
+	modelRegistry.registerProvider(model.provider, {
+		baseUrl: model.baseUrl,
+		apiKey: "faux-key",
+		api: registration.api,
+		models: registration.models.map((registeredModel) => ({
+			id: registeredModel.id,
+			name: registeredModel.name,
+			api: registeredModel.api,
+			reasoning: registeredModel.reasoning,
+			input: registeredModel.input,
+			cost: registeredModel.cost,
+			contextWindow: registeredModel.contextWindow,
+			maxTokens: registeredModel.maxTokens,
+			baseUrl: registeredModel.baseUrl,
+		})),
+	});
+	const sessionManager = SessionManager.inMemory();
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "first user ".repeat(12_000) }],
+		timestamp: Date.now() - 3_000,
+	});
+	sessionManager.appendMessage({
+		...fauxAssistantMessage("first assistant ".repeat(12_000), { timestamp: Date.now() - 2_000 }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 50_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 50_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	});
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "second user ".repeat(12_000) }],
+		timestamp: Date.now() - 1_000,
+	});
+
+	return {
+		model,
+		modelRegistry,
+		sessionManager,
+		getContextUsage: () => ({ tokens: 50_000, contextWindow: model.contextWindow, percent: 25 }),
+		getMessageRevision: () => 1,
+		applyCompaction: async () => ({ applied: true, reason: "ok" }),
+	};
+}
+
+function createPendingSummary() {
+	const model: FauxModelDefinition = {
+		id: "faux-compaction-abort",
+		reasoning: false,
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	};
+	const registration = registerFauxProvider({ models: [model] });
+	registrations.push(registration);
+	const context = createContext(registration);
+	const snapshot = createSpeculativeCompactionSnapshot(context, { generation: 1 });
+	if (!snapshot) throw new Error("expected a compaction snapshot");
+
+	const stream = createAssistantMessageEventStream();
+	const started = Promise.withResolvers<void>();
+	vi.spyOn(context.modelRegistry!.modelRuntime, "stream").mockImplementation(() => {
+		started.resolve();
+		return stream;
+	});
+
+	return { context, snapshot, started: started.promise, stream };
+}
+
+describe("speculative compaction stream cancellation", () => {
+	it("treats a late stream rejection after caller abort as cancellation", async () => {
+		const { context, snapshot, started, stream } = createPendingSummary();
+		const controller = new AbortController();
+
+		const result = runExtensionCompaction(context, snapshot, controller.signal);
+		await started;
+		controller.abort();
+		stream.fail(new Error("Assistant message stream consumption was cancelled"));
+
+		await expect(result).resolves.toBeUndefined();
+	});
+
+	it("still surfaces a stream rejection when the caller did not abort", async () => {
+		const { context, snapshot, started, stream } = createPendingSummary();
+		const failure = new Error("provider stream failed");
+
+		const result = runExtensionCompaction(context, snapshot);
+		await started;
+		stream.fail(failure);
+
+		await expect(result).rejects.toBe(failure);
+	});
+});


### PR DESCRIPTION
## Summary

- Treat a summary stream rejection as expected cancellation when the compaction caller signal is already aborted.
- Preserve ordinary provider and stream errors unchanged.
- Add focused coverage for the late stream-result rejection reported after pressing ESC.
- Document the fork behavior and merge-conflict surface.

## Root cause

The compaction watchdog can stop consuming as soon as ESC aborts the caller signal, while the provider stream's final
result rejects a moment later with `Assistant message stream consumption was cancelled`. That late rejection escaped
`runExtensionCompaction()` and was reported by the builtin extension runner after the normal cancellation notice.

## Verification

- RED: focused cancellation case rejected with the exact reported error while the ordinary-error case passed.
- GREEN: `test/compaction/speculative-abort-cancellation.test.ts` — 2/2 passed.
- Compaction suite: 47 files, 327 tests passed.
- `npm run check`: passed.
- Latest `origin/main` merged; post-merge focused tests, compaction suite, and `npm run check` passed.

## Manual QA

Source Senpi TUI in a persistent PTY:

1. Seeded a clean exact session with two large turns.
2. Forced pre-prompt compaction with isolated 16K model metadata.
3. Held an OpenAI-compatible SSE summary stream after its first delta.
4. Injected ESC only after the server confirmed stream consumption.

Observed:

- `Context overflow detected, compacting... (esc to cancel)`
- `Compacting... (esc to cancel) partial held summary`
- `Auto-compaction cancelled`
- No `Extension "<builtin:compaction>" error`
- No `Assistant message stream consumption was cancelled` stack
- Editor accepted `SESSION-USABLE-AFTER-CANCEL`

Evidence is stored locally under `local-ignore/qa-evidence/20260803-compaction-esc/`, including an xterm.js-rendered PNG.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress spurious compaction errors after ESC by treating late summary stream rejections as normal cancellation when the caller `AbortSignal` is aborted. Real provider/stream errors still bubble up; adds a focused regression test.

- **Bug Fixes**
  - In `runExtensionCompaction()`, return `undefined` if `generateSummaryMessage` rejects and the caller signal is already aborted; otherwise rethrow.
  - Stops the late "Assistant message stream consumption was cancelled" error from surfacing after "Auto-compaction cancelled".
  - Adds `speculative-abort-cancellation.test.ts` to verify both the aborted and ordinary failure paths.

<sup>Written for commit 1116bd8ebadffa20dfeb0d777f4911aabab54610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

