### PR TITLE
fix(coding-agent): keep default fallback chains when users configure their own

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -726,8 +726,11 @@ export class AgentSession {
 			this.settingsManager.getRawFallbackChains(),
 			this._modelRegistry,
 		);
+		// `source` names the scope that supplied the chains so a single log line
+		// points at the file to open; "default" means no scope configured any.
+		const fallbackChainsSource = this.settingsManager.getFallbackChainsScope() ?? "default";
 		for (const warning of this._fallbackValidationWarnings) {
-			fallbackLogger.warn("validation_warning", { warning });
+			fallbackLogger.warn("validation_warning", { warning, source: fallbackChainsSource });
 		}
 		this._selectorCooldowns = new SelectorCooldowns(config.fallbackNow ?? (() => Date.now()));
 		this._fallbackNow = config.fallbackNow ?? (() => Date.now());

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -12,6 +12,11 @@
   at least one entry", because an empty array is now the documented opt-out.
 - The malformed-map warning names the offending value
   (`"...but got null."` / `"...but got an array."`) instead of being anonymous.
+- `SettingsManager.getFallbackChainsScope()` reports which scope supplied
+  `retry.fallbackChains` (project wins, since it replaces the map wholesale), and
+  every `validation_warning` log record now carries that scope as `source`, so a
+  single log line names the file to open. `source` is `"default"` when no scope
+  configured chains and the resolved map is the shipped defaults.
 
 ### Why
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,43 @@
 # changes
 
+## Default fallback chains survive user chain configuration (2026-08-04)
+
+### What changed
+
+- `retry-fallback/settings.ts` now layers user `retry.fallbackChains` over
+  `DEFAULT_FALLBACK_CHAINS` per key instead of replacing the whole map. A user
+  key of the same name still replaces that default outright (never a union), and
+  an explicit empty array removes a default the user does not want.
+- `retry-fallback/validate.ts` no longer warns that an empty chain "must contain
+  at least one entry", because an empty array is now the documented opt-out.
+- The malformed-map warning names the offending value
+  (`"...but got null."` / `"...but got an array."`) instead of being anonymous.
+
+### Why
+
+- Configuring an unrelated model silently deleted every shipped default chain.
+  A user who added only `apitopia/kimi-k3-*` chains lost the default
+  `anthropic/claude-fable-5` chain without any warning.
+- That loss then propagated into policy: with no chain for the active model,
+  `hasConfiguredChain()` returned false, the 2026-08-03 server-fallback policy
+  correctly disabled `abortServerSideFallback`, and Anthropic's server-side
+  substitution replaced the user's intended client fallback. The policy behaved
+  as designed; its input was wrong.
+- The anonymous "must be a plain object" warning fired repeatedly in real logs
+  with no way to identify which value produced it.
+
+### Why this cannot be expressed externally
+
+- Defaults-vs-user resolution happens inside settings resolution, before any
+  extension observes a session. An extension can add chains through
+  `setFallbackChain`, but cannot restore a default the resolver already dropped.
+
+### Expected merge conflict zones
+
+- LOW: `retry-fallback/settings.ts` `resolveFallbackChains()`.
+- LOW: `retry-fallback/validate.ts` empty-entry branch and the malformed-map string.
+- LOW: fallback settings/validate test expectations.
+
 ## Durable compaction telemetry correlation (2026-08-03)
 
 ### What changed

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -51,13 +51,28 @@ function isStringArray(value: unknown): value is string[] {
 	return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
+/**
+ * User chains layer over the shipped defaults per key instead of replacing the
+ * whole map. Configuring an unrelated model must not silently delete a default
+ * chain: that left the defaulted model with no client chain at all, which in
+ * turn disabled the server-fallback abort and handed model choice back to the
+ * provider. A same-named key still replaces that default outright (never a
+ * union), and an explicit empty array removes a default the user does not want.
+ *
+ * Cross-scope replacement (global vs project) stays wholesale and is handled by
+ * `deepMergeSettings`; this only resolves defaults against the merged result.
+ */
 function resolveFallbackChains(value: unknown): FallbackChains {
 	if (value === undefined) return cloneDefaultFallbackChains();
 	if (!isPlainObject(value)) return cloneDefaultFallbackChains();
 
-	const chains: Record<string, readonly string[]> = {};
+	const chains: Record<string, readonly string[]> = cloneDefaultFallbackChains();
 	for (const [key, entries] of Object.entries(value)) {
 		if (!isStringArray(entries)) return cloneDefaultFallbackChains();
+		if (entries.length === 0) {
+			delete chains[key];
+			continue;
+		}
 		chains[key] = [...entries];
 	}
 	return chains;

--- a/packages/coding-agent/src/core/retry-fallback/validate.ts
+++ b/packages/coding-agent/src/core/retry-fallback/validate.ts
@@ -33,10 +33,21 @@ function validateThinkingLevel(
 	}
 }
 
+/**
+ * Names the offending value so a single log line identifies the producer. The
+ * bare form of this warning fired repeatedly in the wild with no way to tell
+ * which settings value caused it.
+ */
+function describeValue(value: unknown): string {
+	if (value === null) return "null";
+	if (Array.isArray(value)) return "an array";
+	return `a ${typeof value}`;
+}
+
 /** Returns configuration warnings without changing malformed fallback-chain settings. */
 export function validateFallbackChains(chains: unknown, registry: FallbackModelRegistry): string[] {
 	if (chains === undefined) return [];
-	if (!isPlainObject(chains)) return ["Fallback chains must be a plain object."];
+	if (!isPlainObject(chains)) return [`Fallback chains must be a plain object, but got ${describeValue(chains)}.`];
 
 	const warnings: string[] = [];
 	const models = registry.getAll();
@@ -62,8 +73,9 @@ export function validateFallbackChains(chains: unknown, registry: FallbackModelR
 			warnings.push(`Fallback chain "${key}" entries must be an array of strings.`);
 			continue;
 		}
+		// An empty array is the documented opt-out that removes a shipped default
+		// chain, so it is a valid instruction rather than a malformed entry.
 		if (entries.length === 0) {
-			warnings.push(`Fallback chain "${key}" must contain at least one entry.`);
 			continue;
 		}
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1010,6 +1010,18 @@ export class SettingsManager {
 		return this.settings.retry?.fallbackChains;
 	}
 
+	/**
+	 * Which scope supplied `retry.fallbackChains`, so a validation warning can name
+	 * the file to open. Project scope wins because it replaces the global chain map
+	 * wholesale. Returns undefined when no scope configured chains and the resolved
+	 * map is therefore the shipped defaults.
+	 */
+	getFallbackChainsScope(): SettingsScope | undefined {
+		if (this.projectSettings.retry?.fallbackChains !== undefined) return "project";
+		if (this.globalSettings.retry?.fallbackChains !== undefined) return "global";
+		return undefined;
+	}
+
 	getRetryFallbackSettings(): ResolvedRetryFallbackSettings {
 		return resolveRetryFallbackSettings(this.settings.retry);
 	}

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -100,6 +100,33 @@ describe("SettingsManager retry fallback settings", () => {
 		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).toEqual(defaultChains);
 	});
 
+	it("reports which settings scope supplied the fallback chains", () => {
+		const { agentDir, projectDir } = createPaths();
+		// Nothing configured: the resolved chains are the shipped defaults, not a file.
+		expect(SettingsManager.create(projectDir, agentDir).getFallbackChainsScope()).toBeUndefined();
+
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ retry: { fallbackChains: { "anthropic/claude-fable-5": ["ccapi/kimi-k3:max"] } } }),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getFallbackChainsScope()).toBe("global");
+
+		writeFileSync(
+			join(projectDir, CONFIG_DIR_NAME, "settings.json"),
+			JSON.stringify({ retry: { fallbackChains: { "anthropic/project": ["ccapi/project"] } } }),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getFallbackChainsScope()).toBe("project");
+	});
+
+	it("names a malformed chain map's offending type so one log line identifies it", () => {
+		const { agentDir, projectDir } = createPaths();
+		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ retry: { fallbackChains: null } }));
+		const manager = SettingsManager.create(projectDir, agentDir);
+		expect(manager.getFallbackChainsScope()).toBe("global");
+		// Malformed input still degrades to the shipped defaults rather than to nothing.
+		expect(manager.getRetryFallbackSettings().chains).toEqual(defaultChains);
+	});
+
 	it("keeps default chains for models the user did not configure", () => {
 		const { agentDir, projectDir } = createPaths();
 		writeFileSync(

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -93,9 +93,51 @@ describe("SettingsManager retry fallback settings", () => {
 		await reloaded.flush();
 		expect(existsSync(join(projectDir, CONFIG_DIR_NAME, "settings.json"))).toBe(false);
 
+		// Removing the user's override restores the shipped default for that key
+		// rather than leaving the model with no chain at all.
 		reloaded.removeFallbackChain("anthropic/claude-fable-5");
 		await reloaded.flush();
-		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).toEqual({});
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).toEqual(defaultChains);
+	});
+
+	it("keeps default chains for models the user did not configure", () => {
+		const { agentDir, projectDir } = createPaths();
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				retry: {
+					fallbackChains: {
+						"apitopia/kimi-k3-unlocked": ["apitopia/kimi-k3-ultrafast-unlocked:max"],
+					},
+				},
+			}),
+		);
+
+		const chains = SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains;
+
+		expect(chains["apitopia/kimi-k3-unlocked"]).toEqual(["apitopia/kimi-k3-ultrafast-unlocked:max"]);
+		expect(chains["anthropic/claude-fable-5"]).toEqual(defaultChains["anthropic/claude-fable-5"]);
+	});
+
+	it("lets a user chain replace a default outright and an empty array delete it", () => {
+		const { agentDir, projectDir } = createPaths();
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({
+				retry: { fallbackChains: { "anthropic/claude-fable-5": ["ccapi/kimi-k3:max"] } },
+			}),
+		);
+		expect(
+			SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains["anthropic/claude-fable-5"],
+		).toEqual(["ccapi/kimi-k3:max"]);
+
+		writeFileSync(
+			join(agentDir, "settings.json"),
+			JSON.stringify({ retry: { fallbackChains: { "anthropic/claude-fable-5": [] } } }),
+		);
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).not.toHaveProperty(
+			"anthropic/claude-fable-5",
+		);
 	});
 
 	it("uses project retry settings over global settings, replacing chains wholesale", () => {
@@ -116,11 +158,13 @@ describe("SettingsManager retry fallback settings", () => {
 			JSON.stringify({ retry: { fallbackChains: { "anthropic/project": ["ccapi/project"] } } }),
 		);
 
-		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
-			modelFallback: false,
-			chains: { "anthropic/project": ["ccapi/project"] },
-			revertPolicy: "never",
-		});
+		const resolved = SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings();
+		expect(resolved.modelFallback).toBe(false);
+		expect(resolved.revertPolicy).toBe("never");
+		// Project scope replaces the global scope's chain map wholesale: the global
+		// "anthropic/primary" entry must not survive into the project-scoped result.
+		expect(resolved.chains["anthropic/project"]).toEqual(["ccapi/project"]);
+		expect(resolved.chains).not.toHaveProperty("anthropic/primary");
 		expect(readFileSync(join(projectSettingsDir, "settings.json"), "utf-8")).toContain("anthropic/project");
 	});
 

--- a/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
@@ -48,7 +48,9 @@ describe("model fallback host wiring", () => {
 
 		expect(harness.settingsManager.getRawFallbackChains()).toBeUndefined();
 		await getFallbackCommand(harness).handler(`${primary} ${fallback}`, context);
-		expect(harness.settingsManager.getRetryFallbackSettings().chains).toEqual({ [primary]: [fallback] });
+		// The quick-set chain is what must reach the engine; shipped defaults for
+		// other models stay resolved alongside it.
+		expect(harness.settingsManager.getRetryFallbackSettings().chains[primary]).toEqual([fallback]);
 
 		harness.setResponses([
 			fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" }),

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -8,6 +8,7 @@ import {
 	parseFallbackSelector,
 	resolveChainKey,
 } from "../../src/core/retry-fallback/chains.ts";
+import { DEFAULT_FALLBACK_CHAINS, resolveRetryFallbackSettings } from "../../src/core/retry-fallback/settings.ts";
 
 const models = [
 	getModel("openai", "gpt-5.4"),
@@ -114,5 +115,33 @@ describe("fallback chain selectors", () => {
 		expect(candidatesAfter(entries, "openai/gpt-5.4:high")).toEqual([]);
 		expect(candidatesAfter(entries, "anthropic/claude-sonnet-4-5:high")).toEqual(entries.slice(1));
 		expect(candidatesAfter(entries, "unknown/model")).toEqual(entries);
+	});
+});
+
+describe("resolveRetryFallbackSettings chain defaults", () => {
+	const fableKey = "anthropic/claude-fable-5";
+
+	it("keeps a shipped default chain when the user configures an unrelated model", () => {
+		const resolved = resolveRetryFallbackSettings({
+			fallbackChains: { "apitopia/kimi-k3-unlocked": ["apitopia/kimi-k3-ultrafast-unlocked:max"] },
+		});
+
+		expect(resolved.chains["apitopia/kimi-k3-unlocked"]).toEqual(["apitopia/kimi-k3-ultrafast-unlocked:max"]);
+		expect(resolved.chains[fableKey]).toEqual(DEFAULT_FALLBACK_CHAINS[fableKey]);
+		expect(DEFAULT_FALLBACK_CHAINS[fableKey]).toHaveLength(3);
+	});
+
+	it("replaces a colliding default outright and removes one set to an empty array", () => {
+		expect(resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: ["ccapi/kimi-k3:max"] } }).chains[fableKey]).toEqual(
+			["ccapi/kimi-k3:max"],
+		);
+
+		expect(resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: [] } }).chains).not.toHaveProperty(fableKey);
+	});
+
+	it("falls back to the shipped defaults for a malformed chain map", () => {
+		expect(resolveRetryFallbackSettings({ fallbackChains: undefined }).chains[fableKey]).toEqual(
+			DEFAULT_FALLBACK_CHAINS[fableKey],
+		);
 	});
 });

--- a/packages/coding-agent/test/suite/retry-fallback-validate.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-validate.test.ts
@@ -39,21 +39,19 @@ describe("validateFallbackChains", () => {
 		{
 			name: "non-object values",
 			chains: null,
-			warnings: ["Fallback chains must be a plain object."],
+			warnings: ["Fallback chains must be a plain object, but got null."],
 		},
 		{
 			name: "arrays and nested garbage",
 			chains: ["openai/gpt-5.4"],
-			warnings: ["Fallback chains must be a plain object."],
+			warnings: ["Fallback chains must be a plain object, but got an array."],
 		},
 		{
 			name: "role and wildcard keys",
 			chains: { default: [], "openai/*": [] },
 			warnings: [
 				'Fallback chain key "default" must use a provider/model selector; roles are unsupported.',
-				'Fallback chain "default" must contain at least one entry.',
 				'Fallback chain key "openai/*" cannot contain wildcards.',
-				'Fallback chain "openai/*" must contain at least one entry.',
 			],
 		},
 		{
@@ -68,7 +66,7 @@ describe("validateFallbackChains", () => {
 			],
 		},
 		{
-			name: "non-string and empty entry lists",
+			name: "non-string entry lists, with an empty list accepted as a default opt-out",
 			chains: {
 				"openai/gpt-5.4": ["anthropic/claude-sonnet-4-5", 42],
 				"anthropic/claude-sonnet-4-5": [],
@@ -76,7 +74,6 @@ describe("validateFallbackChains", () => {
 			},
 			warnings: [
 				'Fallback chain "openai/gpt-5.4" entries must be an array of strings.',
-				'Fallback chain "anthropic/claude-sonnet-4-5" must contain at least one entry.',
 				'Fallback chain "test/no-reasoning" entries must be an array of strings.',
 			],
 		},


### PR DESCRIPTION
## Problem

`resolveFallbackChains()` returned **only** the user's keys whenever
`retry.fallbackChains` was set, discarding every entry in
`DEFAULT_FALLBACK_CHAINS`.

A user who configured two unrelated chains:

```json
"fallbackChains": {
  "apitopia/kimi-k3-ultrafast-unlocked": ["apitopia/kimi-k3-unlocked:max"],
  "apitopia/kimi-k3-unlocked": ["apitopia/kimi-k3-ultrafast-unlocked:max"]
}
```

silently lost the shipped `anthropic/claude-fable-5` chain.

That loss then propagated into policy. With no chain for the active model,
`hasConfiguredChain()` returned `false`, so the server-fallback policy from
#671 correctly disabled `abortServerSideFallback`, and Anthropic's
server-side substitution to `claude-opus-5` replaced the intended client
fallback to `apitopia/kimi-k3-unlocked`.

**The #671 policy is not changed by this PR and is not at fault** — it
behaved exactly as designed on an input that had been silently corrupted
upstream of it.

Observed in the wild (`~/.senpi/agent/logs/fallback.log`):

```
{"event":"no_chain","selector":"anthropic/claude-fable-5"}   2026-08-04T00:27:42.343Z
```

versus the same selector working before the override:

```
{"event":"fallback_applied","from":"anthropic/claude-fable-5","to":"apitopia/kimi-k3-unlocked"}
```

## Change

User chains layer over defaults **per key**:

| Case | Result |
|---|---|
| user key absent from defaults | user key added |
| default key the user did not configure | default survives |
| user key collides with a default | user array replaces it (no union) |
| user key maps to `[]` | that default is removed (explicit opt-out) |
| malformed map or entry | defaults, with a warning |

Cross-scope (global vs project) replacement stays wholesale — that is
separate, documented, and untouched.

Secondary: the malformed-map warning now names the offending value
(`...but got null.` / `...but got an array.`). The anonymous version fired
133 times in real logs with no way to identify the producer. Empty chains no
longer warn, since an empty array is now a meaningful instruction.

## Verification

RED captured before each production change, GREEN after.

- **RED (criterion 1)**: `expected undefined to deeply equal [...]` — the
  fable-5 default was gone under the user's unrelated kimi keys.
- **GREEN**: `test/settings-manager-retry-fallback.test.ts` 10/10.
- **Regression**: 61/61 across 8 fallback suites, none skipped —
  `server-fallback-abort`, `server-fallback-abort-option`,
  `retry-fallback-chains`, `retry-fallback-validate`,
  `settings-manager-retry-fallback`, `model-fallback-command`,
  `retry-fallback-engine`, `retry-fallback-refusal`.
- **Real surface**: resolved a real-world settings file through
  `SettingsManager` and confirmed all three chains resolve, with
  `anthropic/claude-fable-5` restored:

```
anthropic/claude-fable-5 => ["apitopia/kimi-k3-unlocked:max","anthropic/claude-opus-5:xhigh","anthropic/claude-opus-4-8:xhigh"]
VERDICT: PASS - default chain survives user config
```

- `npm run check`: pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep default fallback chains even when users add their own by merging per key instead of replacing the whole map. This prevents losing defaults like `anthropic/claude-fable-5` and restores the intended client-side fallback behavior.

- **Bug Fixes**
  - Layer user `retry.fallbackChains` over shipped defaults per key; same-named keys replace the default, and an empty array removes a default. Malformed maps fall back to defaults with a warning.
  - Validation now names the offending value (e.g., “null”, “an array”) and accepts empty lists as an explicit opt-out.
  - `validation_warning` logs now include a `source` field (`project`, `global`, or `default`) so you know which settings file to check.
  - Updated the host-wiring test to assert the quick-set chain for the target key instead of the entire map, since defaults persist alongside it.
  - Added resolver-level tests for `resolveRetryFallbackSettings()` to cover the three outcomes: unrelated keys keep defaults, collisions replace, and empty arrays remove defaults.

<sup>Written for commit 1f0e0784ce1a7aa05968bdb0e1c6498576edadd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

