### PR TITLE
fix(goal): prompt to resume blocked goals on restart

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -54,6 +54,18 @@ is false, and resumed sessions with 8+ trailing historical continuation entries 
 session-start auto-resume. `tokenBudget` remains inert compatibility metadata only; this
 policy is budget-free by design.
 
+## RESTART RESUME PROMPT
+
+On `session_start` with reason `resume`, an idle TUI session with no pending
+messages prompts before doing anything else when the stored goal is stopped but
+unfinished — `paused` or `blocked`. `isResumeOfStoppedGoal` (lifecycle-helpers.ts)
+owns that admission and `maybePromptResumeStoppedGoal` (index.ts) renders it;
+the title names the actual status (`Resume blocked goal?`). Accepting flips the
+goal to `active` as a `"user"` mutation and queues a continuation; declining
+leaves the status untouched. `active` and `complete` goals never prompt. This
+mirrors codex `maybe_prompt_resume_paused_goal_after_resume`, minus its
+`UsageLimited` arm, which senpi has no counterpart for.
+
 ## PERSISTENCE
 
 `store.ts` writes `GoalFile{version:1, goal}` to

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,45 @@
 # goal Extension Changes
 
+## Restart resume prompt covers every stopped-but-unfinished goal (2026-08-04)
+
+### What changed
+
+- `lifecycle-helpers.ts` renames `isResumeOfPausedGoal` to `isResumeOfStoppedGoal`
+  and admits the whole stopped-but-unfinished set (`paused` and `blocked`) instead
+  of `paused` alone. The idle / has-UI / no-pending-messages guards and the
+  `"resume"` session-start reason are unchanged.
+- `index.ts` renames `maybePromptResumePausedGoal` to
+  `maybePromptResumeStoppedGoal`, renames the `LEAVE_GOAL_PAUSED_CHOICE` constant
+  to `LEAVE_GOAL_STOPPED_CHOICE` (`"Leave stopped"`), and interpolates the goal's
+  real status into the prompt title (`Resume blocked goal?` / `Resume paused
+  goal?`) so the dialog names the state the user is actually resuming from.
+- Accepting the prompt is unchanged: the goal flips to `active` via a `"user"`
+  mutation, accounting restarts, the footer refreshes, and a continuation is
+  queued through the same admission path.
+
+### Why
+
+- Ports the upstream codex rule in
+  `codex-rs/tui/src/app/thread_goal_actions.rs`
+  (`maybe_prompt_resume_paused_goal_after_resume`), which prompts on resume for
+  `Paused | Blocked | UsageLimited` — every status that stopped the goal without
+  finishing it. senpi previously ported only the `paused` arm.
+- A `blocked` goal was unrecoverable on restart: no prompt fired, and the
+  session-start auto-continuation denied it with `not-eligible` because the
+  status is not `active`. The goal stayed blocked with no user-visible
+  affordance, even though `blocked` is reached by ordinary events — a user
+  interrupt, a terminal provider error, or a tripped continuation guard.
+- senpi stays budget-free, so codex's `UsageLimited` arm has no counterpart and
+  no budget status is introduced. The senpi stopped set is exactly
+  `paused | blocked`; `complete` and `active` are untouched.
+
+### Expected merge conflict zones on the next sync
+
+- LOW in `lifecycle-helpers.ts` around the renamed predicate and its status set;
+  standalone `pi-goal` has no restart resume prompt.
+- LOW in `index.ts` around the `session_start` handler's resume-prompt call and
+  the choice constants.
+
 ## Legacy `pi-goal` state is imported once at session start (2026-07-31)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -8,7 +8,7 @@ import { GOAL_CONTINUATION_CAP } from "./continuation.ts";
 import { GoalDirectInputLifecycle } from "./direct-input-lifecycle.ts";
 import { GoalElapsedTicker } from "./elapsed-ticker.ts";
 import { formatGoalForTool, goalStatusLabel } from "./format.ts";
-import { isResumeOfPausedGoal, queueGoalContinuation } from "./lifecycle-helpers.ts";
+import { isResumeOfStoppedGoal, queueGoalContinuation } from "./lifecycle-helpers.ts";
 import { MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
 import { migrateLegacyGoalFile } from "./persistence.ts";
 import { accountGoalUsage, readGoal, updateGoal } from "./store.ts";
@@ -21,7 +21,7 @@ import { updateGoalUi } from "./ui.ts";
 import { GOAL_WAIT_STATUS_KEY, GoalWaitTicker } from "./wait-ticker.ts";
 
 const RESUME_GOAL_CHOICE = "Resume goal";
-const LEAVE_GOAL_PAUSED_CHOICE = "Leave paused";
+const LEAVE_GOAL_STOPPED_CHOICE = "Leave stopped";
 const STALE_EXTENSION_CONTEXT_ERROR_PREFIX = "This extension ctx is stale after session replacement or reload.";
 
 type AgentGoalAccounting = {
@@ -109,7 +109,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			clearAgentGoalAccounting();
 		}
 		refreshGoalUi(ctx, goal);
-		if (await maybePromptResumePausedGoal(pi, ctx, event.reason, goal)) {
+		if (await maybePromptResumeStoppedGoal(pi, ctx, event.reason, goal)) {
 			return;
 		}
 		// A config reload must not auto-start an agent that was stopped. Only a fresh
@@ -241,19 +241,19 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		monitorContinuation.dispose();
 	});
 
-	async function maybePromptResumePausedGoal(
+	async function maybePromptResumeStoppedGoal(
 		pi: ExtensionAPI,
 		ctx: ExtensionContext,
 		sessionStartReason: string,
 		goal: Goal | null,
 	): Promise<boolean> {
-		if (!isResumeOfPausedGoal(ctx, sessionStartReason, goal)) {
+		if (!isResumeOfStoppedGoal(ctx, sessionStartReason, goal)) {
 			return false;
 		}
 
-		const choice = await ctx.ui.select(`Resume paused goal?\nGoal: ${goal.objective}`, [
+		const choice = await ctx.ui.select(`Resume ${goal.status} goal?\nGoal: ${goal.objective}`, [
 			RESUME_GOAL_CHOICE,
-			LEAVE_GOAL_PAUSED_CHOICE,
+			LEAVE_GOAL_STOPPED_CHOICE,
 		]);
 		if (choice !== RESUME_GOAL_CHOICE) return true;
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -35,14 +35,27 @@ export type SessionStartContinuationOptions = {
 	readonly markContinuationPending: () => void;
 };
 
-export function isResumeOfPausedGoal(
+/**
+ * Statuses that leave a goal stopped without finishing it. A restart is the only
+ * moment the user can act on them, so both earn the resume prompt.
+ */
+const STOPPED_UNFINISHED_GOAL_STATUSES: readonly Goal["status"][] = ["paused", "blocked"];
+
+/**
+ * Mirrors codex `maybe_prompt_resume_paused_goal_after_resume`
+ * (codex-rs/tui/src/app/thread_goal_actions.rs), which prompts on resume for every
+ * stopped-but-unfinished status. senpi is budget-free, so codex's `UsageLimited`
+ * has no counterpart here and the stopped set is `paused | blocked`.
+ */
+export function isResumeOfStoppedGoal(
 	ctx: ExtensionContext,
 	sessionStartReason: string,
 	goal: Goal | null,
 ): goal is Goal {
 	return (
 		sessionStartReason === "resume" &&
-		goal?.status === "paused" &&
+		goal !== null &&
+		STOPPED_UNFINISHED_GOAL_STATUSES.includes(goal.status) &&
 		ctx.hasUI &&
 		ctx.isIdle() &&
 		!ctx.hasPendingMessages()

--- a/packages/coding-agent/test/manual-qa/goal-blocked-resume-restart.test.ts
+++ b/packages/coding-agent/test/manual-qa/goal-blocked-resume-restart.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Real-surface QA driver (manual-qa; not part of the default suite).
+ *
+ * Drives the REAL builtin goal extension across a simulated process restart to
+ * prove that a `blocked` goal produces the restart resume prompt, that accepting
+ * reactivates it and queues a continuation, and that declining leaves it blocked.
+ *
+ * Run: npx vitest run test/manual-qa/goal-blocked-resume-restart.test.ts
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
+import { readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
+
+type AnyTool = ToolDefinition<any, any, any>;
+type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+const THREAD = "qa-thread-blocked";
+const transcript: string[] = [];
+const say = (line: string): void => {
+	transcript.push(line);
+	console.log(line);
+};
+
+function makeSession(dir: string, onSelect: (options: string[]) => string | undefined) {
+	const tools = new Map<string, AnyTool>();
+	const handlers = new Map<string, Handler[]>();
+	const sent: Array<{ customType: string }> = [];
+	const prompts: Array<{ prompt: string; options: string[] }> = [];
+	const pi = {
+		registerTool: (tool: AnyTool) => tools.set(tool.name, tool),
+		registerCommand: () => {},
+		on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
+		sendMessage: (message: { customType: string }) => sent.push(message),
+		registerEntryRenderer: () => {},
+		appendEntry: () => {},
+	} as unknown as ExtensionAPI;
+	goalExtension(pi);
+	const ctx = {
+		hasUI: true,
+		cwd: dir,
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		ui: {
+			notify: () => {},
+			setStatus: () => {},
+			select: async (prompt: string, options: string[]) => {
+				prompts.push({ prompt, options });
+				return onSelect(options);
+			},
+		},
+		sessionManager: {
+			getSessionFile: () => join(dir, "session.jsonl"),
+			getSessionDir: () => dir,
+			getSessionId: () => THREAD,
+			getBranch: () => [],
+		},
+	} as unknown as ExtensionContext;
+	const fire = async (event: string, payload: unknown): Promise<void> => {
+		for (const handler of handlers.get(event) ?? []) await handler(payload, ctx);
+	};
+	return { tools, ctx, sent, prompts, fire };
+}
+
+it("prompts to resume a blocked goal after a process restart", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "senpi-qa-goal-resume-"));
+	const storeRef = { baseDir: join(dir, "extensions", "goal"), threadId: THREAD };
+
+	// Session A: the goal gets blocked, then the process goes away.
+	const a = makeSession(dir, () => undefined);
+	await a.tools
+		.get("create_goal")
+		?.execute("c1", { objective: "Finish the release checklist" }, undefined, undefined, a.ctx);
+	await a.tools
+		.get("update_goal")
+		?.execute("u1", { status: "blocked", reason: "user interrupted the turn" }, undefined, undefined, a.ctx);
+	await a.fire("session_shutdown", { type: "session_shutdown" });
+	const afterA = await readGoal(storeRef);
+	say(`[session A] persisted status after shutdown: ${afterA?.status} (reason: ${afterA?.blockedReason})`);
+	expect(afterA?.status).toBe("blocked");
+
+	// Session B: fresh process over the same store, resumed -> must prompt.
+	const b = makeSession(dir, (options) => options[0]);
+	await b.fire("session_start", { type: "session_start", reason: "resume" });
+	say(`[session B] resume prompts shown: ${b.prompts.length}`);
+	for (const entry of b.prompts) {
+		say(`[session B] prompt body:    ${JSON.stringify(entry.prompt)}`);
+		say(`[session B] prompt options: ${JSON.stringify(entry.options)}`);
+	}
+	const afterB = await readGoal(storeRef);
+	say(`[session B] status after accepting "Resume goal": ${afterB?.status}`);
+	say(`[session B] continuation queued: ${JSON.stringify(b.sent.map((message) => message.customType))}`);
+
+	expect(b.prompts).toHaveLength(1);
+	expect(b.prompts[0]?.prompt).toContain("Resume blocked goal?");
+	expect(b.prompts[0]?.prompt).toContain("Finish the release checklist");
+	expect(b.prompts[0]?.options).toEqual(["Resume goal", "Leave stopped"]);
+	expect(afterB?.status).toBe("active");
+	expect(b.sent.map((message) => message.customType)).toEqual(["goal-continuation"]);
+
+	// Session C: blocked again, resumed, declined -> stays blocked.
+	await b.tools
+		.get("update_goal")
+		?.execute("u2", { status: "blocked", reason: "user interrupted the turn" }, undefined, undefined, b.ctx);
+	const c = makeSession(dir, (options) => options[1]);
+	await c.fire("session_start", { type: "session_start", reason: "resume" });
+	const afterC = await readGoal(storeRef);
+	say(`[session C] declined -> status stays: ${afterC?.status}; continuations queued: ${c.sent.length}`);
+	expect(afterC?.status).toBe("blocked");
+	expect(c.sent).toHaveLength(0);
+
+	await rm(dir, { recursive: true, force: true });
+	say(`cleanup: rm -rf ${dir}`);
+});

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -546,6 +546,74 @@ describe("goal extension reload does not auto-start a stopped agent", () => {
 	});
 });
 
+describe("goal extension resume-on-restart prompt (codex parity)", () => {
+	async function makeSelectingCtx(
+		prompts: string[],
+		choice: (options: string[]) => string | undefined,
+		threadId: string,
+	): Promise<ExtensionContext> {
+		const base = await makeCtx(threadId);
+		return {
+			...base,
+			hasUI: true,
+			ui: {
+				notify: () => {},
+				select: async (prompt: string, options: string[]) => {
+					prompts.push(prompt);
+					return choice(options);
+				},
+				setStatus: () => {},
+			},
+		} as unknown as ExtensionContext;
+	}
+
+	it("prompts to resume a blocked goal on session_start reason 'resume'", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const prompts: string[] = [];
+		const ctx = await makeSelectingCtx(prompts, (options) => options[0], "thread-blocked-resume");
+		await tools.get("create_goal")?.execute("c1", { objective: "Finish the migration" }, undefined, undefined, ctx);
+		await tools
+			.get("update_goal")
+			?.execute("u1", { status: "blocked", reason: "provider error" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "resume" }, ctx);
+
+		expect(prompts).toHaveLength(1);
+		expect(prompts[0]).toContain("Finish the migration");
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
+		expect(sent.map((entry) => entry.message.customType)).toEqual(["goal-continuation"]);
+	});
+
+	it("leaves a blocked goal stopped when the user declines the resume prompt", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const prompts: string[] = [];
+		const ctx = await makeSelectingCtx(prompts, (options) => options[1], "thread-blocked-declined");
+		await tools.get("create_goal")?.execute("c1", { objective: "Finish the migration" }, undefined, undefined, ctx);
+		await tools
+			.get("update_goal")
+			?.execute("u1", { status: "blocked", reason: "provider error" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "resume" }, ctx);
+
+		expect(prompts).toHaveLength(1);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("blocked");
+		expect(sent).toHaveLength(0);
+	});
+
+	it("never prompts for a completed goal on resume", async () => {
+		const { tools, handlers } = createGoalHarness();
+		const prompts: string[] = [];
+		const ctx = await makeSelectingCtx(prompts, (options) => options[0], "thread-complete-resume");
+		await tools.get("create_goal")?.execute("c1", { objective: "Finish the migration" }, undefined, undefined, ctx);
+		await tools.get("update_goal")?.execute("u1", { status: "complete" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "resume" }, ctx);
+
+		expect(prompts).toHaveLength(0);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("complete");
+	});
+});
+
 describe("goal extension session_start migration-lite admission", () => {
 	it("suppresses auto-continuation and notifies when a resumed session ends in a continuation flood", async () => {
 		const { tools, handlers, sent } = createGoalHarness();

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -13,6 +13,7 @@ import {
 	formatTokensCompact,
 	goalToolResponse,
 } from "../../src/core/extensions/builtin/goal/format.ts";
+import { isResumeOfStoppedGoal } from "../../src/core/extensions/builtin/goal/lifecycle-helpers.ts";
 import {
 	buildContinuationPrompt,
 	buildGoalStallNotice,
@@ -40,6 +41,48 @@ function makeGoal(overrides: Partial<Goal> = {}): Goal {
 		...overrides,
 	};
 }
+
+function resumeCtx(overrides: { hasUI?: boolean; isIdle?: boolean; hasPendingMessages?: boolean } = {}) {
+	return {
+		hasUI: overrides.hasUI ?? true,
+		isIdle: () => overrides.isIdle ?? true,
+		hasPendingMessages: () => overrides.hasPendingMessages ?? false,
+	} as unknown as Parameters<typeof isResumeOfStoppedGoal>[0];
+}
+
+/**
+ * Mirrors codex `maybe_prompt_resume_paused_goal_after_resume`
+ * (codex-rs/tui/src/app/thread_goal_actions.rs), which prompts on resume for every
+ * stopped-but-unfinished status. senpi is budget-free, so its stopped set is
+ * `paused | blocked` — codex's `UsageLimited` has no senpi counterpart.
+ */
+describe("goal resume-on-restart admission (codex parity)", () => {
+	it("prompts on resume for every stopped-but-unfinished status", () => {
+		for (const status of ["paused", "blocked"] as const) {
+			expect(isResumeOfStoppedGoal(resumeCtx(), "resume", makeGoal({ status }))).toBe(true);
+		}
+	});
+
+	it("never prompts for goals that are not stopped-but-unfinished", () => {
+		for (const status of ["active", "complete"] as const) {
+			expect(isResumeOfStoppedGoal(resumeCtx(), "resume", makeGoal({ status }))).toBe(false);
+		}
+		expect(isResumeOfStoppedGoal(resumeCtx(), "resume", null)).toBe(false);
+	});
+
+	it("only prompts on the resume session-start reason", () => {
+		for (const reason of ["startup", "reload"]) {
+			expect(isResumeOfStoppedGoal(resumeCtx(), reason, makeGoal({ status: "blocked" }))).toBe(false);
+		}
+	});
+
+	it("requires an idle UI session with no pending messages", () => {
+		const blocked = makeGoal({ status: "blocked" });
+		expect(isResumeOfStoppedGoal(resumeCtx({ hasUI: false }), "resume", blocked)).toBe(false);
+		expect(isResumeOfStoppedGoal(resumeCtx({ isIdle: false }), "resume", blocked)).toBe(false);
+		expect(isResumeOfStoppedGoal(resumeCtx({ hasPendingMessages: true }), "resume", blocked)).toBe(false);
+	});
+});
 
 function assistantMessageWithStopReason(stopReason: "aborted" | "error" | "stop" | "toolUse"): AgentMessage {
 	return {


### PR DESCRIPTION
## What

Ports the upstream codex **goal resume-on-restart** rule so senpi applies the same rule.

Upstream: `codex-rs/tui/src/app/thread_goal_actions.rs` :: `maybe_prompt_resume_paused_goal_after_resume` prompts on session resume for **every status that stopped the goal without finishing it** — `Paused | Blocked | UsageLimited`.

senpi had ported only the `paused` arm. `isResumeOfPausedGoal` gated on `goal?.status === "paused"`, so a **`blocked`** goal on restart got:

1. no resume prompt (predicate returns `false`), and
2. no continuation either — the session-start auto-queue reaches `evaluateGoalContinuation`, which denies with `not-eligible` because the status is not `active`.

The goal was silently stuck with zero user-visible affordance. `blocked` is not an exotic state: a user interrupt, a terminal provider error (`willRetry === false`), or a tripped continuation guard all land there.

## Change

- `isResumeOfPausedGoal` → `isResumeOfStoppedGoal`, admitting the stopped-but-unfinished set `paused | blocked`. The `"resume"` reason and the idle / has-UI / no-pending-messages guards are unchanged.
- `maybePromptResumePausedGoal` → `maybePromptResumeStoppedGoal`; the prompt title interpolates the real status (`Resume blocked goal?` / `Resume paused goal?`) and the decline choice reads `Leave stopped` instead of `Leave paused`.
- Accepting is unchanged: `active` via a `"user"` mutation, accounting restarts, footer refreshes, continuation queued through the same admission path.

senpi stays **budget-free** — codex's `UsageLimited` arm has no counterpart and no budget status is introduced. `active` and `complete` still never prompt.

## Evidence

**RED captured before the production change:**

- `goal-modules.test.ts` — 4 failing (predicate matrix, symbol absent).
- `goal-extension.test.ts` "codex parity" — 2 failing for the right reason: a blocked goal on resume produced **0 prompts** (`expected [] to have a length of 1`). The completed-goal case passed unchanged.

**GREEN after:**

```
goal-modules.test.ts + goal-extension.test.ts   59 passed (59)
full goal surface (8 files)                    139 passed (139)
npm run check                                   exit 0
```

**Real-surface QA** — `test/manual-qa/goal-blocked-resume-restart.test.ts` drives the real extension across a simulated process restart (session A blocks + shuts down; session B is a fresh extension instance over the same on-disk store):

```
[session A] persisted status after shutdown: blocked (reason: user interrupted the turn)
[session B] resume prompts shown: 1
[session B] prompt body:    "Resume blocked goal?\nGoal: Finish the release checklist"
[session B] prompt options: ["Resume goal","Leave stopped"]
[session B] status after accepting "Resume goal": active
[session B] continuation queued: ["goal-continuation"]
[session C] declined -> status stays: blocked; continuations queued: 0
cleanup: rm -rf /var/folders/.../senpi-qa-goal-resume-viMx91
```

## Docs

`goal/changes.md` gets the fork entry with expected merge-conflict zones; `goal/AGENTS.md` gains a `RESTART RESUME PROMPT` section.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prompts users to resume blocked or paused goals when a session resumes, so goals don’t get stuck after a restart and behavior matches upstream.

- **Bug Fixes**
  - Resume prompt now shows on restart for goals with status `blocked` or `paused`. Accepting sets the goal to `active` and queues a continuation.
  - Renamed `isResumeOfPausedGoal` to `isResumeOfStoppedGoal`. Prompt title names the real status, and decline reads “Leave stopped”.
  - No budget status is introduced; upstream `UsageLimited` is not included. Tests and docs updated.

<sup>Written for commit 5d86a7f65e13389c5077918b20c9f6d4a9169687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

