### PR TITLE
feat(coding-agent): render shared rule activations

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,13 @@
 # Builtin extensions changes
 
+## rule-activation: shared project-rules and TTSR notices (2026-08-04)
+
+- Added `rule-activation/` as a presentation-only builtin module with a typed discriminated activation contract, defensive persisted-data parser, custom-entry append/registration helpers, and a compact/expandable Box/Text renderer.
+- Project-rules and TTSR both register the same renderer so either extension still works when loaded alone. Project-rules records successful dynamic tool-path matches; TTSR records committed remediation while preserving its separate persistence entry and hidden model nudge.
+- Why shared code is required: the two engines retain incompatible discovery, matching, deduplication, and remediation semantics, but the TUI needs one stable durable-entry contract instead of engine-specific raw transcript text.
+- Coverage: `test/rules-before-agent-start.test.ts`, `test/ttsr/extension-wiring.test.ts`, and `test/suite/rule-activation-renderer.test.ts`.
+- Expected merge conflict zones: the new `rule-activation/` directory and the small registration/append seams in `rules/index.ts` and `ttsr/index.ts`. Do not fold engine policy into the shared module during conflict resolution.
+
 ## service-tier: enable fast mode for Codex API extension providers (2026-08-03)
 
 - `/fast` now checks the model's `openai-codex-responses` API capability instead

--- a/packages/coding-agent/src/core/extensions/builtin/rule-activation/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rule-activation/index.ts
@@ -1,0 +1,18 @@
+import type { ExtensionAPI } from "../../types.ts";
+import { renderRuleActivationEntry } from "./renderer.ts";
+import { RULE_ACTIVATION_ENTRY_TYPE, type RuleActivationDetails } from "./types.ts";
+
+export {
+	type ProjectRulesActivationDetails,
+	RULE_ACTIVATION_ENTRY_TYPE,
+	type RuleActivationDetails,
+	type TtsrActivationDetails,
+} from "./types.ts";
+
+export function registerRuleActivationRenderer(pi: ExtensionAPI): void {
+	pi.registerEntryRenderer(RULE_ACTIVATION_ENTRY_TYPE, renderRuleActivationEntry);
+}
+
+export function appendRuleActivation(pi: ExtensionAPI, details: RuleActivationDetails): void {
+	pi.appendEntry(RULE_ACTIVATION_ENTRY_TYPE, details);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rule-activation/renderer.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rule-activation/renderer.ts
@@ -1,0 +1,49 @@
+import { Box, Text } from "@earendil-works/pi-tui";
+import type { EntryRenderer } from "../../types.ts";
+import { parseRuleActivationDetails, type RuleActivationDetails } from "./types.ts";
+
+const BOLD = "\u001b[1m";
+const BOLD_OFF = "\u001b[22m";
+
+export const renderRuleActivationEntry: EntryRenderer<unknown> = (entry, options, theme) => {
+	const details = parseRuleActivationDetails(entry.data);
+	if (details === undefined) return undefined;
+	const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+	box.addChild(new Text(theme.fg("accent", `${BOLD}${titleLine(details)}${BOLD_OFF}`), 0, 0));
+	box.addChild(new Text(theme.fg("dim", summaryLine(details)), 0, 0));
+	if (options.expanded) {
+		box.addChild(new Text(theme.fg("dim", detailLine(details)), 0, 0));
+	}
+	return box;
+};
+
+function titleLine(details: RuleActivationDetails): string {
+	switch (details.kind) {
+		case "project-rules":
+			return `● Project rules · ${details.targetPath}`;
+		case "ttsr":
+			return `⚠ Stream rule · ${details.owner}`;
+	}
+}
+
+function summaryLine(details: RuleActivationDetails): string {
+	switch (details.kind) {
+		case "project-rules": {
+			const noun = details.rules.length === 1 ? "instruction" : "instructions";
+			return `${details.rules.length} ${noun} matched and injected for this tool result.`;
+		}
+		case "ttsr":
+			return details.remediation === "nudge"
+				? "Output interrupted; a corrective nudge was queued."
+				: "Corrupted generation discarded; bounded provider retry started.";
+	}
+}
+
+function detailLine(details: RuleActivationDetails): string {
+	switch (details.kind) {
+		case "project-rules":
+			return details.rules.map((rule) => `rule ${rule}`).join("\n");
+		case "ttsr":
+			return `remediation ${details.remediation} · observed ${details.rules.join(", ")}`;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rule-activation/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rule-activation/types.ts
@@ -1,0 +1,66 @@
+export const RULE_ACTIVATION_ENTRY_TYPE = "rule-activation";
+
+export interface ProjectRulesActivationDetails {
+	readonly kind: "project-rules";
+	readonly targetPath: string;
+	readonly rules: readonly string[];
+}
+
+export interface TtsrActivationDetails {
+	readonly kind: "ttsr";
+	readonly owner: string;
+	readonly rules: readonly string[];
+	readonly remediation: "nudge" | "provider-error";
+}
+
+export type RuleActivationDetails = ProjectRulesActivationDetails | TtsrActivationDetails;
+
+export function parseRuleActivationDetails(value: unknown): RuleActivationDetails | undefined {
+	if (!isObject(value)) return undefined;
+	const kind = Reflect.get(value, "kind");
+	switch (kind) {
+		case "project-rules":
+			return parseProjectRulesActivation(value);
+		case "ttsr":
+			return parseTtsrActivation(value);
+		default:
+			return undefined;
+	}
+}
+
+function parseProjectRulesActivation(value: object): ProjectRulesActivationDetails | undefined {
+	const targetPath = Reflect.get(value, "targetPath");
+	const rules = stringList(Reflect.get(value, "rules"));
+	if (typeof targetPath !== "string" || targetPath.length === 0 || rules === undefined) return undefined;
+	return { kind: "project-rules", targetPath, rules };
+}
+
+function parseTtsrActivation(value: object): TtsrActivationDetails | undefined {
+	const owner = Reflect.get(value, "owner");
+	const rules = stringList(Reflect.get(value, "rules"));
+	const remediation = Reflect.get(value, "remediation");
+	if (
+		typeof owner !== "string" ||
+		owner.length === 0 ||
+		rules === undefined ||
+		(remediation !== "nudge" && remediation !== "provider-error")
+	) {
+		return undefined;
+	}
+	return { kind: "ttsr", owner, rules, remediation };
+}
+
+function stringList(value: unknown): readonly string[] | undefined {
+	if (
+		!Array.isArray(value) ||
+		value.length === 0 ||
+		!value.every((entry) => typeof entry === "string" && entry.length > 0)
+	) {
+		return undefined;
+	}
+	return value;
+}
+
+function isObject(value: unknown): value is object {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/rules/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/changes.md
@@ -2,6 +2,23 @@
 
 Vendored from [`code-yeongyu/pi-rules`](https://github.com/code-yeongyu/pi-rules) (see `external-versions.json`).
 
+## 2026-08-04 - Shared activation notices for dynamic rules
+
+### What changed and why
+
+- The vendored extension now registers Senpi's shared `rule-activation` entry renderer and appends a typed, display-only activation entry after a newly matched dynamic rule block is added to a tool result.
+- The notice records the tool target and matched rule paths so the TUI can show a compact summary and expandable details instead of presenting the injected instruction block as undifferentiated tool output.
+- Static `before_agent_start` delivery, dynamic fingerprint deduplication, and the exact model-facing instruction block are unchanged.
+
+### Why this cannot stay upstream-only
+
+- Upstream pi-rules owns matching and prompt delivery but does not own Senpi's custom-entry renderer registry or shared TTSR presentation layer. The adapter therefore belongs at the Senpi builtin boundary.
+
+### Coverage and expected conflict zones
+
+- Coverage: `test/rules-before-agent-start.test.ts` verifies unchanged dynamic model delivery plus the typed activation entry; `test/suite/rule-activation-renderer.test.ts` verifies standalone renderer registration and malformed persisted-data handling.
+- Expected conflicts: `index.ts` around renderer registration and the dynamic `tool_result` return path. Preserve the shared activation append after `markDynamicInjected(...)` and before returning augmented tool content.
+
 ## Senpi adaptations vs upstream
 
 - Imports rewritten by `scripts/vendor-transform.mjs`: `@mariozechner/pi-tui` -> `@earendil-works/pi-tui`; `@mariozechner/pi-coding-agent` symbols -> `../../types.ts` (and `Theme` -> `modes/interactive/theme/theme.ts`); relative `.js` import suffixes -> `.ts`.

--- a/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
@@ -3,6 +3,7 @@ import { isAbsolute, relative } from "node:path";
 
 import type { ExtensionAPI } from "../../types.ts";
 
+import { appendRuleActivation, registerRuleActivationRenderer } from "../rule-activation/index.ts";
 import { registerSlashCommands } from "./commands.ts";
 import { configFromEnvironment } from "./config.ts";
 import { createEngine } from "./rules/engine.ts";
@@ -41,6 +42,7 @@ export default function piRulesExtension(pi: ExtensionAPI): void {
 		extractToolPaths,
 	});
 	registerSlashCommands(pi, engine);
+	registerRuleActivationRenderer(pi);
 
 	function syncConfigFromFlags(): void {
 		const disabled = pi.getFlag("pi-rules-disabled");
@@ -139,10 +141,16 @@ export default function piRulesExtension(pi: ExtensionAPI): void {
 		}
 
 		const firstPendingTarget = pendingFingerprints[0]?.targetPath ?? firstTargetPath;
-		const block = engine.formatDynamic(rules, displayPath(ctx.cwd, firstPendingTarget));
+		const targetPath = displayPath(ctx.cwd, firstPendingTarget);
+		const block = engine.formatDynamic(rules, targetPath);
 		for (const rule of rules) {
 			engine.markDynamicInjected(firstTargetPath, rule);
 		}
+		appendRuleActivation(pi, {
+			kind: "project-rules",
+			targetPath,
+			rules: rules.map((rule) => rule.relativePath),
+		});
 
 		return { content: [...event.content, { type: "text", text: block }] };
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/changes.md
@@ -1,5 +1,23 @@
 # TTSR Fork Tracker
 
+## 2026-08-04 - Shared visible activation records
+
+### What changed and why
+
+- TTSR now registers Senpi's shared `rule-activation` entry renderer and appends a typed visible activation record whenever remediation is committed.
+- The new record reports the detector owner, observed rule ids, and whether the remediation used a hidden nudge or bounded provider-error retry.
+- The existing `ttsr-injection` persistence entry, hidden corrective `custom_message`, abort/truncation flow, provider retry, repeat gating, and session restoration are unchanged.
+
+### Why an extension-local change is required
+
+- TTSR remains the sole owner of the point where a detection becomes committed remediation. A generic TUI layer cannot infer that state safely from stream deltas or from the hidden nudge without coupling itself to the coordinator.
+- The shared module owns only typed presentation; TTSR still owns detection, interruption, transcript mutation, and retry policy.
+
+### Coverage and expected conflict zones
+
+- Coverage: `test/ttsr/extension-wiring.test.ts` verifies both remediation modes retain their existing records/messages and add the typed activation entry; `test/suite/rule-activation-renderer.test.ts` verifies standalone renderer registration and expanded TTSR details.
+- Expected conflicts: `index.ts` around extension registration and `recordInjection(...)`. Preserve both the original persistence append and the additional shared activation append.
+
 ## 2026-07-31 - Interrupt fabricated unavailable-tool calls
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/index.ts
@@ -1,6 +1,7 @@
 import { getKeybindings } from "@earendil-works/pi-tui";
 
 import type { ExtensionAPI, ExtensionContext, MessageUpdateEvent } from "../../types.ts";
+import { appendRuleActivation, registerRuleActivationRenderer } from "../rule-activation/index.ts";
 import { BUILTIN_TTSR_RULES } from "./builtin-rules.ts";
 import { registerTtsrCommands, type TtsrPublicState } from "./commands.ts";
 import { claimAbort, createGenerationState, markUserCancelled } from "./coordinator.ts";
@@ -53,6 +54,7 @@ function parseDisabledRules(raw: boolean | string | undefined): string[] {
 }
 
 export default function ttsrExtension(pi: ExtensionAPI): void {
+	registerRuleActivationRenderer(pi);
 	pi.registerFlag("ttsr-disabled", {
 		type: "boolean",
 		default: false,
@@ -82,12 +84,18 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 		}
 	}
 
-	function recordInjection(owner: string, observed: readonly string[], retryMode: string): void {
+	function recordInjection(owner: string, observed: readonly string[], retryMode: "nudge" | "provider-error"): void {
 		pi.appendEntry(TTSR_INJECTION_CUSTOM_TYPE, {
 			rules: observed,
 			owner,
 			remediation: retryMode,
 			at: Date.now(),
+		});
+		appendRuleActivation(pi, {
+			kind: "ttsr",
+			owner,
+			rules: observed,
+			remediation: retryMode,
 		});
 	}
 

--- a/packages/coding-agent/test/rules-before-agent-start.test.ts
+++ b/packages/coding-agent/test/rules-before-agent-start.test.ts
@@ -27,12 +27,21 @@ import { createModelRegistry } from "./model-runtime-test-utils.ts";
 
 const BASE_SYSTEM_PROMPT = "BASE SYSTEM PROMPT (rebuilt by the host on every user prompt)";
 const STATIC_BLOCK_HEADING = "## Project Instructions";
+const RULE_ACTIVATION_ENTRY_TYPE = "rule-activation";
+
+interface AppendedEntry {
+	readonly customType: string;
+	readonly data: unknown;
+}
 
 describe("rules builtin - before_agent_start delivery", () => {
 	let projectDir: string;
 	let canaryRulePath: string;
 	let canaryRuleContents: string;
 	let canaryToken: string;
+	let dynamicRuleToken: string;
+	let targetPath: string;
+	let appendedEntries: AppendedEntry[];
 	let sessionManager: SessionManager;
 	let modelRegistry: ModelRegistry;
 
@@ -40,7 +49,9 @@ describe("rules builtin - before_agent_start delivery", () => {
 		registerLazyToolActivator: () => {},
 		sendMessage: () => {},
 		sendUserMessage: () => {},
-		appendEntry: () => {},
+		appendEntry: (customType, data) => {
+			appendedEntries.push({ customType, data });
+		},
 		setSessionName: () => {},
 		getSessionName: () => undefined,
 		setLabel: () => {},
@@ -123,7 +134,17 @@ describe("rules builtin - before_agent_start delivery", () => {
 		canaryRuleContents = `---\nalwaysApply: true\n---\n\n# Canary rule\n\n${canaryToken}\n`;
 		canaryRulePath = join(projectDir, ".omo", "rules", "canary.md");
 		writeFileSync(canaryRulePath, canaryRuleContents, "utf-8");
+		dynamicRuleToken = `RULES-DYNAMIC-CANARY-${randomUUID()}`;
+		writeFileSync(
+			join(projectDir, ".omo", "rules", "typescript.md"),
+			`---\nglobs: src/**/*.ts\n---\n\n# TypeScript rule\n\n${dynamicRuleToken}\n`,
+			"utf-8",
+		);
+		targetPath = join(projectDir, "src", "lib", "proxy", "strategy.ts");
+		mkdirSync(join(projectDir, "src", "lib", "proxy"), { recursive: true });
+		writeFileSync(targetPath, "export const strategy = true;\n", "utf-8");
 
+		appendedEntries = [];
 		sessionManager = SessionManager.inMemory();
 		modelRegistry = await createModelRegistry(AuthStorage.create(join(projectDir, "auth.json")));
 	});
@@ -211,5 +232,40 @@ describe("rules builtin - before_agent_start delivery", () => {
 			result?.systemPrompt ?? "",
 			"a rule already present as a native context file must not be injected again",
 		).not.toContain(canaryToken);
+	});
+
+	it("#given a path-scoped rule #when a matching read tool result arrives #then the model block and display-only activation entry are both emitted", async () => {
+		const runner = await createRunner();
+		const prompt = await runner.emitBeforeAgentStart(
+			"Read the target TypeScript file",
+			undefined,
+			BASE_SYSTEM_PROMPT,
+			{
+				cwd: projectDir,
+			},
+		);
+		expect(prompt?.systemPrompt ?? "").not.toContain(dynamicRuleToken);
+
+		const toolResult = await runner.emitToolResult({
+			type: "tool_result",
+			toolName: "read",
+			toolCallId: "call-read-strategy",
+			input: { path: "src/lib/proxy/strategy.ts" },
+			content: [{ type: "text", text: "export const strategy = true;" }],
+			details: undefined,
+			isError: false,
+		});
+
+		expect(textOf(toolResult?.content)).toContain(dynamicRuleToken);
+		expect(appendedEntries).toContainEqual(
+			expect.objectContaining({
+				customType: RULE_ACTIVATION_ENTRY_TYPE,
+				data: expect.objectContaining({
+					kind: "project-rules",
+					targetPath: "src/lib/proxy/strategy.ts",
+					rules: expect.arrayContaining([".omo/rules/typescript.md"]),
+				}),
+			}),
+		);
 	});
 });

--- a/packages/coding-agent/test/suite/rule-activation-renderer.test.ts
+++ b/packages/coding-agent/test/suite/rule-activation-renderer.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { createEventBus } from "../../src/core/event-bus.ts";
+import piRulesExtension from "../../src/core/extensions/builtin/rules/index.ts";
+import ttsrExtension from "../../src/core/extensions/builtin/ttsr/index.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
+import type { EntryRenderer, ExtensionFactory } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+
+const RULE_ACTIVATION_ENTRY_TYPE = "rule-activation";
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+async function rendererFrom(factory: ExtensionFactory): Promise<EntryRenderer | undefined> {
+	const extension = await loadExtensionFromFactory(
+		factory,
+		process.cwd(),
+		createEventBus(),
+		createExtensionRuntime(),
+		"<test:rule-activation>",
+	);
+	return extension.entryRenderers?.get(RULE_ACTIVATION_ENTRY_TYPE);
+}
+
+function renderedText(
+	renderer: EntryRenderer,
+	data: unknown,
+	expanded: boolean,
+	width = 100,
+): { readonly text: string; readonly lines: readonly string[] } {
+	const component = renderer(
+		{
+			type: "custom",
+			id: "activation-entry",
+			parentId: null,
+			timestamp: "2026-08-04T00:00:00.000Z",
+			customType: RULE_ACTIVATION_ENTRY_TYPE,
+			data,
+		},
+		{ expanded },
+		theme,
+	);
+	const lines = component?.render(width) ?? [];
+	return { text: lines.join("\n").replace(ANSI_PATTERN, ""), lines };
+}
+
+describe("shared rule activation renderer", () => {
+	it("#given project-rules loads alone #when its activation entry renders #then the notice is compact and expands matched rule paths", async () => {
+		initTheme("dark");
+		const renderer = await rendererFrom(piRulesExtension);
+		expect(renderer).toBeTypeOf("function");
+		if (renderer === undefined) return;
+		const data = {
+			kind: "project-rules",
+			targetPath: "src/lib/proxy/strategy.ts",
+			rules: [".omo/rules/typescript.md"],
+		};
+
+		const collapsed = renderedText(renderer, data, false);
+		const expanded = renderedText(renderer, data, true);
+
+		expect(collapsed.text).toContain("Project rules · src/lib/proxy/strategy.ts");
+		expect(collapsed.text).not.toContain(".omo/rules/typescript.md");
+		expect(expanded.text).toContain(".omo/rules/typescript.md");
+	});
+
+	it("#given TTSR loads alone #when its activation entry renders #then remediation and observed rules are visible", async () => {
+		initTheme("dark");
+		const renderer = await rendererFrom(ttsrExtension);
+		expect(renderer).toBeTypeOf("function");
+		if (renderer === undefined) return;
+
+		const rendered = renderedText(
+			renderer,
+			{
+				kind: "ttsr",
+				owner: "collapse-repetition",
+				rules: ["collapse-repetition"],
+				remediation: "nudge",
+			},
+			true,
+		);
+
+		expect(rendered.text).toContain("Stream rule · collapse-repetition");
+		expect(rendered.text).toContain("nudge");
+		expect(rendered.text).toContain("collapse-repetition");
+	});
+
+	it("#given malformed persisted data #when the shared renderer runs #then it returns no component", async () => {
+		initTheme("dark");
+		const renderer = await rendererFrom(piRulesExtension);
+		expect(renderer).toBeTypeOf("function");
+		if (renderer === undefined) return;
+
+		const component = renderer(
+			{
+				type: "custom",
+				id: "malformed-activation",
+				parentId: null,
+				timestamp: "2026-08-04T00:00:00.000Z",
+				customType: RULE_ACTIVATION_ENTRY_TYPE,
+				data: { kind: "project-rules", targetPath: 42, rules: [] },
+			},
+			{ expanded: false },
+			theme,
+		);
+
+		expect(component).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/suite/ttsr-activation-assertions.ts
+++ b/packages/coding-agent/test/suite/ttsr-activation-assertions.ts
@@ -1,0 +1,26 @@
+import { expect } from "vitest";
+
+interface PersistedEntry {
+	readonly type?: string;
+	readonly customType?: string;
+	readonly data?: unknown;
+}
+
+interface ExpectedActivation {
+	readonly owner: string;
+	readonly rules: readonly string[];
+	readonly remediation: "nudge" | "provider-error";
+}
+
+export function expectTtsrActivation(entries: readonly PersistedEntry[], expected: ExpectedActivation): void {
+	expect(entries).toContainEqual(
+		expect.objectContaining({
+			type: "custom",
+			customType: "rule-activation",
+			data: {
+				kind: "ttsr",
+				...expected,
+			},
+		}),
+	);
+}

--- a/packages/coding-agent/test/suite/ttsr-extension.test.ts
+++ b/packages/coding-agent/test/suite/ttsr-extension.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import ttsrExtension from "../../src/core/extensions/builtin/ttsr/index.ts";
 import { LEAK_ERROR_MESSAGE } from "../../src/core/extensions/builtin/ttsr/prompts.ts";
 import { createHarness, getMessageText, type Harness } from "./harness.ts";
+import { expectTtsrActivation } from "./ttsr-activation-assertions.ts";
 
 const FABRICATED_TOOL_CALL_RULE_NAME = "fabricated-unavailable-tool-call";
 
@@ -148,7 +149,12 @@ describe("collapse remediation persistence", () => {
 		const lines = readSessionLines(harness);
 		const entries = readSessionEntries(harness);
 		expect(lines.length).toBe(entries.length);
-		expect(lines.length).toBe(6);
+		expect(lines.length).toBe(7);
+		expectTtsrActivation(entries, {
+			owner: "collapse-repetition",
+			rules: ["collapse-repetition"],
+			remediation: "nudge",
+		});
 
 		const assistantEntries = entries.filter((e) => e.type === "message" && e.message?.role === "assistant");
 		expect(assistantEntries.length).toBe(2);
@@ -205,7 +211,12 @@ describe("leakage remediation retry", () => {
 
 		const lines = readSessionLines(harness);
 		const entries = readSessionEntries(harness);
-		expect(lines.length).toBe(5);
+		expect(lines.length).toBe(6);
+		expectTtsrActivation(entries, {
+			owner: "control-token-leak",
+			rules: ["control-token-leak"],
+			remediation: "provider-error",
+		});
 
 		const assistantEntries = entries.filter((e) => e.type === "message" && e.message?.role === "assistant");
 		expect(assistantEntries.length).toBe(2);

--- a/packages/coding-agent/test/ttsr/extension-wiring.test.ts
+++ b/packages/coding-agent/test/ttsr/extension-wiring.test.ts
@@ -7,6 +7,8 @@ import { LEAK_ERROR_MESSAGE } from "../../src/core/extensions/builtin/ttsr/promp
 import { TTSR_INJECTION_CUSTOM_TYPE } from "../../src/core/extensions/builtin/ttsr/types.ts";
 import { createHarness, getMessageText, type Harness } from "../suite/harness.ts";
 
+const RULE_ACTIVATION_ENTRY_TYPE = "rule-activation";
+
 interface PersistedMessage {
 	role?: string;
 	stopReason?: string;
@@ -19,6 +21,7 @@ interface PersistedEntry {
 	type?: string;
 	customType?: string;
 	message?: PersistedMessage;
+	data?: unknown;
 }
 
 function ctrlToken(name: string): string {
@@ -76,6 +79,18 @@ describe("ttsr extension wiring", () => {
 		const nudges = entries.filter((e) => e.type === "custom_message" && e.customType === TTSR_INJECTION_CUSTOM_TYPE);
 		expect(nudges.length).toBeGreaterThan(0);
 
+		const activations = entries.filter((e) => e.type === "custom" && e.customType === RULE_ACTIVATION_ENTRY_TYPE);
+		expect(activations).toContainEqual(
+			expect.objectContaining({
+				data: {
+					kind: "ttsr",
+					owner: "collapse-repetition",
+					rules: ["collapse-repetition"],
+					remediation: "nudge",
+				},
+			}),
+		);
+
 		expect(harness.faux.getCallLog().length).toBe(2);
 		const finalText = assistantEntries.map((e) => getMessageText(e.message)).join("\n");
 		expect(finalText).toContain("recovered answer");
@@ -99,6 +114,18 @@ describe("ttsr extension wiring", () => {
 
 		const injections = entries.filter((e) => e.type === "custom" && e.customType === TTSR_INJECTION_CUSTOM_TYPE);
 		expect(injections.length).toBeGreaterThan(0);
+
+		const activations = entries.filter((e) => e.type === "custom" && e.customType === RULE_ACTIVATION_ENTRY_TYPE);
+		expect(activations).toContainEqual(
+			expect.objectContaining({
+				data: {
+					kind: "ttsr",
+					owner: "control-token-leak",
+					rules: ["control-token-leak"],
+					remediation: "provider-error",
+				},
+			}),
+		);
 
 		expect(harness.faux.getCallLog().length).toBe(2);
 		const finalText = assistantEntries.map((e) => getMessageText(e.message)).join("\n");


### PR DESCRIPTION
## Summary

- add a shared typed `rule-activation` custom-entry contract and compact/expanded TUI renderer
- show project-rules dynamic matches as a dedicated activation card while preserving the existing tool-result instruction block
- show committed TTSR remediation through the same notice family while preserving abort, truncation, persistence, hidden nudge, and retry behavior
- record the fork-specific integration and conflict zones in the applicable `changes.md` files

## Design

The two engines remain independent:

- project-rules still owns discovery, path matching, fingerprints, and prompt/tool-result injection
- TTSR still owns stream detection, abort coordination, transcript repair, repeat gating, and bounded retries
- the new shared module owns only typed display data, defensive persisted-data parsing, and TUI presentation

Both extensions register the same entry renderer so standalone extension loading continues to work.

## Test plan

- `npx vitest run packages/coding-agent/test/suite/loop-guard-extension.test.ts packages/coding-agent/test/rules-before-agent-start.test.ts packages/coding-agent/test/ttsr/extension-wiring.test.ts packages/coding-agent/test/suite/rule-activation-renderer.test.ts`
  - 4 files, 19 tests passed after rebasing onto the latest `origin/main`
- `npm run check`
- `npm run build`
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --evidence rule-activation-regression`
  - 43/43 passed, localhost-only fake provider, real auth unchanged
- `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence rule-activation-tui-smoke`
  - 5/5 passed, including teardown and auth-integrity checks

## Real TUI QA

The source CLI was driven through a real PTY rendered by xterm.js in Chrome at 120x34:

- compact card: target path visible, rule detail withheld
- expanded card via `Ctrl+O`: `.omo/rules/typescript.md` visible
- model-facing `Additional project instructions matched...` content remained in the expanded read tool output
- automated terminal check: max width 120/120, zero overflow, aligned borders
- two independent visual reviewers returned unconditional PASS for hierarchy, loop-guard consistency, true-color boundaries, terminal width, glyph width, and CJK/ZWJ wrapping

Evidence is retained locally under:

`local-ignore/qa-evidence/20260804-rule-activation/`

## Risk

Low and localized. The shared layer does not control rule matching or remediation policy. The expected upstream conflict zones are the small registration/append seams in `rules/index.ts` and `ttsr/index.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared `rule-activation` entry and TUI renderer so both `rules` and `ttsr` show unified activation cards in the transcript. Matching and remediation policy remain unchanged; this only adds typed display data.

- **New Features**
  - New `rule-activation/` module with a discriminated type, defensive parser, and compact/expanded Box/Text renderer.
  - `rules`: after a dynamic match, appends an entry with `targetPath` and matched rule paths; registers the renderer.
  - `ttsr`: when remediation is committed, appends an entry with `owner`, observed `rules`, and `remediation` (`nudge` or `provider-error`); registers the renderer.
  - Compact view shows target path or owner; expanded view shows rule paths or remediation details. Malformed persisted data is ignored.

<sup>Written for commit b150296a76cf51056f5c706361955550289a03bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

