### PR TITLE
fix(coding-agent): avoid recursive render-signature array hashing

### DIFF
--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,25 +1,5 @@
 # changes
 
-## Large array render signatures avoid recursive tail slicing (2026-08-04)
-
-### What changed
-
-- Render-signature hashing now processes omitted array items iteratively instead of recursively slicing another
-  tail array for every 40 items.
-- Coverage reproduces large-array hashing under a constrained JavaScript stack and verifies that changing an
-  omitted item still changes the signature.
-
-### Why
-
-- Tool results can contain large numeric arrays, including `Buffer.toJSON().data` from screenshot capture code.
-  Recursive tail hashing copied progressively smaller arrays and reset traversal state on every chunk, which could
-  overflow the JavaScript call stack while the TUI rendered the result.
-
-### Expected merge conflict zones
-
-- `components/render-signature.ts` if render-cache signature hashing changes.
-- `../../../test/render-signature.test.ts` if render-signature regression coverage changes.
-
 ## Bun console diagnostics stay behind the interactive terminal guard (2026-08-03)
 
 ### What changed
@@ -1637,3 +1617,23 @@ The tip line was teaching a small slice of the product while most of the surface
 - Changed `src/modes/interactive/interactive-mode.ts` and `compaction-queue-transfer.ts` so every terminal `compaction_end` flushes the TUI compaction queue: accepted compactions keep prompt-admission delivery, while failed/rejected/aborted ones route queued input through the native steer/followUp queues (`deferAdmission`) with a visible held-count status and a `compaction_queue_deferred` session-log event. Previously the queue was flushed only on success, so messages typed during a failing compaction were silently parked forever and lost on session switch (field report 2026-07-30).
 - This was changed in core UI because the compaction queue and `compaction_end` handling are internal `InteractiveMode` state; extensions cannot observe or drain that queue.
 - Expected merge-conflict zone on upstream sync: the `compaction_end` handler and `flushCompactionQueue()` in `src/modes/interactive/interactive-mode.ts`, plus `compaction-queue-transfer.ts` transfer options.
+
+## Large array render signatures avoid recursive tail slicing (2026-08-04)
+
+### What changed
+
+- Render-signature hashing now processes omitted array items iteratively instead of recursively slicing another
+  tail array for every 40 items.
+- Coverage reproduces large-array hashing under a constrained JavaScript stack and verifies that changing an
+  omitted item still changes the signature.
+
+### Why
+
+- Tool results can contain large numeric arrays, including `Buffer.toJSON().data` from screenshot capture code.
+  Recursive tail hashing copied progressively smaller arrays and reset traversal state on every chunk, which could
+  overflow the JavaScript call stack while the TUI rendered the result.
+
+### Expected merge conflict zones
+
+- `components/render-signature.ts` if render-cache signature hashing changes.
+- `../../../test/render-signature.test.ts` if render-signature regression coverage changes.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## Large array render signatures avoid recursive tail slicing (2026-08-04)
+
+### What changed
+
+- Render-signature hashing now processes omitted array items iteratively instead of recursively slicing another
+  tail array for every 40 items.
+- Coverage reproduces large-array hashing under a constrained JavaScript stack and verifies that changing an
+  omitted item still changes the signature.
+
+### Why
+
+- Tool results can contain large numeric arrays, including `Buffer.toJSON().data` from screenshot capture code.
+  Recursive tail hashing copied progressively smaller arrays and reset traversal state on every chunk, which could
+  overflow the JavaScript call stack while the TUI rendered the result.
+
+### Expected merge conflict zones
+
+- `components/render-signature.ts` if render-cache signature hashing changes.
+- `../../../test/render-signature.test.ts` if render-signature regression coverage changes.
+
 ## Bun console diagnostics stay behind the interactive terminal guard (2026-08-03)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/render-signature.ts
+++ b/packages/coding-agent/src/modes/interactive/components/render-signature.ts
@@ -41,16 +41,42 @@ function sampleSignatureString(text: string): string {
 }
 
 function hashSignatureString(source: string): string {
-	let hash = 0x811c9dc5;
+	return formatSignatureHash(updateSignatureHash(0x811c9dc5, source));
+}
+
+function updateSignatureHash(hash: number, source: string): number {
 	for (let index = 0; index < source.length; index++) {
 		hash ^= source.charCodeAt(index);
 		hash = Math.imul(hash, 0x01000193);
 	}
+	return hash;
+}
+
+function formatSignatureHash(hash: number): string {
 	return (hash >>> 0).toString(36);
 }
 
 function hashSignatureValue(value: unknown): string {
 	return hashSignatureString(JSON.stringify(summarizeSignatureValue(value)));
+}
+
+function hashSignatureArrayTail(
+	value: readonly unknown[],
+	start: number,
+	depth: number,
+	seen: WeakSet<object>,
+): string {
+	let hash = 0x811c9dc5;
+	for (let index = start; index < value.length; index++) {
+		hash = updateSignatureHash(hash, String(index));
+		hash = updateSignatureHash(hash, "\u0000");
+		hash = updateSignatureHash(
+			hash,
+			JSON.stringify(summarizeSignatureValue(value[index], String(index), depth + 1, seen)),
+		);
+		hash = updateSignatureHash(hash, "\u0000");
+	}
+	return formatSignatureHash(hash);
 }
 
 function summarizeSignatureValue(
@@ -97,7 +123,7 @@ function summarizeSignatureValue(
 			.slice(0, SIGNATURE_ARRAY_ITEM_LIMIT)
 			.map((item, index) => summarizeSignatureValue(item, String(index), depth + 1, seen));
 		if (value.length > SIGNATURE_ARRAY_ITEM_LIMIT) {
-			const tailHash = hashSignatureValue(value.slice(SIGNATURE_ARRAY_ITEM_LIMIT));
+			const tailHash = hashSignatureArrayTail(value, SIGNATURE_ARRAY_ITEM_LIMIT, depth, seen);
 			seen.delete(value);
 			return [...summarized, `[+${value.length - SIGNATURE_ARRAY_ITEM_LIMIT} items hash=${tailHash}]`];
 		}

--- a/packages/coding-agent/test/render-signature.test.ts
+++ b/packages/coding-agent/test/render-signature.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { describe, expect, test, vi } from "vitest";
 import { createBoundedRenderSignature } from "../src/modes/interactive/components/render-signature.ts";
 
@@ -17,5 +18,41 @@ describe("createBoundedRenderSignature", () => {
 		} finally {
 			charCodeSpy.mockRestore();
 		}
+	});
+
+	test("#given a large array #when creating a render signature #then omitted item changes remain observable", () => {
+		const values = Array.from({ length: 400 }, (_, index) => index);
+		const signature = createBoundedRenderSignature(values);
+
+		expect(signature).toContain("[+360 items hash=");
+
+		values[200] = -1;
+		expect(createBoundedRenderSignature(values)).not.toBe(signature);
+	});
+
+	test("#given a large array #when hashing under a constrained stack #then signature creation completes", () => {
+		const moduleUrl = new URL("../src/modes/interactive/components/render-signature.ts", import.meta.url).href;
+		const script = `
+			import { createBoundedRenderSignature } from ${JSON.stringify(moduleUrl)};
+			const signature = createBoundedRenderSignature(Array.from({ length: 50_000 }, (_, index) => index & 255));
+			if (!signature.includes("[+49960 items hash=")) process.exit(2);
+		`;
+		const result = spawnSync(
+			process.execPath,
+			["--stack_size=256", "--import", "tsx", "--input-type=module", "--eval", script],
+			{
+				encoding: "utf8",
+			},
+		);
+
+		expect({
+			signal: result.signal,
+			status: result.status,
+			stderr: result.stderr,
+		}).toEqual({
+			signal: null,
+			status: 0,
+			stderr: "",
+		});
 	});
 });


### PR DESCRIPTION
## Summary

- hash omitted array items iteratively instead of recursively slicing each 40-item tail
- preserve render-signature changes when an omitted array item changes
- add focused regression coverage and the required interactive change record

## Why

PR #88 introduced bounded render signatures to reduce resume and render work for large session payloads. Its array
tail path calls `hashSignatureValue(value.slice(40))`, so a large numeric array creates another progressively
smaller array and recursive call for every 40 items.

Tool results can contain those arrays through normal JavaScript serialization, including
`Buffer.toJSON().data`. A sufficiently large payload can therefore fail while the TUI computes its render cache
signature:

```text
RangeError: Maximum call stack size exceeded
    at summarizeSignatureValue
    at hashSignatureValue
```

This change keeps nesting recursion governed by the existing depth limit while processing sibling tail items in
one iterative pass.

Related implementation history: #88. GitHub search found no matching issue or existing fix PR for this array-tail
failure.

## Validation

- `npm run test --workspace @code-yeongyu/senpi -- test/render-signature.test.ts test/tool-execution-render-signature.test.ts test/assistant-message-render-signature.test.ts`
- `npm run check`
- `npm run build`
- `npm test`
- constrained-stack component QA: 50,000-byte `Buffer.toJSON().data` reached
  `ToolExecutionComponent.render()` and rendered 7 lines
- constrained-stack direct QA: 500,000 numeric items produced a bounded signature in 63 ms
- isolated source TUI PTY smoke: boot, render, composer input, and clean exit; real auth hash unchanged

## Expected merge conflict zones

- `packages/coding-agent/src/modes/interactive/components/render-signature.ts`
- `packages/coding-agent/test/render-signature.test.ts`
- `packages/coding-agent/src/modes/interactive/changes.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid stack overflows and preserve render cache correctness by hashing large array tails iteratively in the render signature. Large session payloads now render reliably.

- **Bug Fixes**
  - Replaced recursive array-tail slicing with a single iterative hash pass, keeping recursion depth bounded and ensuring changes in omitted items still affect the signature.
  - Added regression tests (including a constrained-stack run) and relocated the change note in `changes.md`.

<sup>Written for commit 5fadce30d6c098a9f5db4b9f2004bb61b8844cef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

