### PR TITLE
test(mcp): barrier cache assertions on exact refreshed tool names

### DIFF
--- a/packages/coding-agent/test/mcp/catalog-cache.test.ts
+++ b/packages/coding-agent/test/mcp/catalog-cache.test.ts
@@ -65,7 +65,7 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 		await awaitMcpToolRegistration("fx");
-		await awaitCacheTools(root, 2);
+		await awaitCacheTools(root, ["tool_1", "tool_2"]);
 
 		expect(dedupedRegisteredTools(pi)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 		expect(await readCounter(counterFile)).toBe(1);
@@ -82,7 +82,7 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 		await awaitMcpToolRegistration("fx");
-		await awaitCacheTools(root, 1);
+		await awaitCacheTools(root, ["tool_1"]);
 
 		expect(dedupedRegisteredTools(pi)).toEqual(["mcp_fx_tool_1"]);
 		const cache = await readCache(root);
@@ -98,7 +98,7 @@ describe("MCP disk metadata cache", () => {
 
 		await attach(root, pi);
 		await awaitMcpToolRegistration("fx");
-		await awaitCacheTools(root, 1);
+		await awaitCacheTools(root, ["tool_1"]);
 
 		expect(dedupedRegisteredTools(pi)).toEqual(["mcp_fx_tool_1"]);
 		expect(withoutMcpUtilityTools(pi.registeredTools)).not.toContain("mcp_fx_fake_999");
@@ -120,6 +120,7 @@ describe("MCP disk metadata cache", () => {
 		await attach(root, pi);
 
 		await waitForCondition(() => withoutMcpUtilityTools(pi.activeTools).includes("mcp_fx_tool_2"), 10_000);
+		await awaitCacheTools(root, ["tool_1", "tool_2"]);
 		expect(await readCounter(counterFile)).toBe(1);
 		expect(withoutMcpUtilityTools(pi.activeTools)).toEqual(["mcp_fx_tool_1", "mcp_fx_tool_2"]);
 		expect(withoutMcpUtilityTools(pi.activeTools)).not.toContain("mcp_fx_stale_cached");
@@ -143,13 +144,7 @@ describe("MCP disk metadata cache", () => {
 			]);
 			// Both attaches are race-bounded; the cache refresh completes in the
 			// background continuation, so await the torn-write window closing.
-			await waitForCondition(async () => {
-				try {
-					return (await readCache(root)).servers.fx.tools.length === 3;
-				} catch {
-					return false;
-				}
-			}, 10_000);
+			await awaitCacheTools(root, ["tool_1", "tool_2", "tool_3"]);
 			const cache = await readCache(root);
 			expect(cache.servers.fx.tools.map((tool) => tool.name)).toEqual(["tool_1", "tool_2", "tool_3"]);
 		} finally {
@@ -184,11 +179,15 @@ function dedupedRegisteredTools(pi: ReturnType<typeof capturingPi>): string[] {
 }
 
 /** The raced background continuation writes the disk cache after the in-memory
- * catalog is set; await the file landing before asserting its contents. */
-async function awaitCacheTools(root: TestRoot, count: number): Promise<void> {
+ * catalog is set; await the file landing before asserting its contents. Match
+ * the exact refreshed tool names, never a count: a stale entry can coincide
+ * with the fresh catalog's size (a poisoned 1-tool cache vs a fresh 1-tool
+ * catalog), so a count-only barrier can pass on pre-refresh data. */
+async function awaitCacheTools(root: TestRoot, expectedNames: string[]): Promise<void> {
 	await waitForCondition(async () => {
 		try {
-			return (await readCache(root)).servers.fx.tools.length === count;
+			const names = (await readCache(root)).servers.fx.tools.map((tool) => tool.name);
+			return names.length === expectedNames.length && names.every((name, index) => name === expectedNames[index]);
 		} catch {
 			return false;
 		}


### PR DESCRIPTION
## Summary

`test/mcp/catalog-cache.test.ts` flaked on CI (`Test (coding-agent 2/3)` shard) with two signatures:
- run 30881909344: `invalidates config-hash mismatches…` read `configHash` `"poisoned"` instead of the fresh hash
- earlier main run: `refreshes eager servers…` read `['stale_cached']` instead of `['tool_1','tool_2']`

**Root cause (proven by mutation, not inference):** the suite barriered cache-refresh assertions on tool **counts** and **in-memory** registration state. In `startup-race.ts` the in-memory `entry.cachedCatalog` is set before `writeMcpCachedServer` completes, and `writeMcpCachedServer` re-reads + atomic-writes the file across several awaits — so in-memory barriers pass while the refreshed disk cache is still in flight. Worse, a poisoned/stale cache whose tool **count** coincides with the fresh catalog (1 vs 1) passes a count-only barrier on pre-refresh data. On CI's two-worker forks pool the stale read intermittently loses the race; locally the write usually wins (6/6), which is why it never reproduced on dev machines.

Production code is correct (the write lands; atomic rename prevents torn JSON) — this is a test-barrier fix only.

## Fix

`awaitCacheTools(root, expectedNames)` now polls the cache file until the tool names equal the **exact refreshed set** — a count can coincide with stale content, the names cannot. Applied at every call site (ttl/corrupt/hash/concurrent), and the eager test gains an explicit cache-content barrier after its in-memory `activeTools` barrier.

## Evidence

- **RED (mutation proof):** +300ms delay injected before `atomicWriteJson` (never committed): old barriers fail 2/6 reproducing **both CI signatures exactly** (same assertions, same lines).
- **GREEN:** fixed barriers pass 6/6 under the **same** mutation; mutation reverted; 6/6 plain and `CI=1`.
- **Determinism:** 100 consecutive `CI=1 npx vitest --run test/mcp/catalog-cache.test.ts` runs — 100/100 pass.
- **Static:** `npm run check` clean. Diff is test-only (+12/−13).
- Full receipts: `local-ignore/qa-evidence/20260804-catalog-cache-flaky-barriers/`.

## Note on an unrelated pre-existing drift

`npm run check` runs `biome check --write`, which self-heals formatting. `main` currently carries a format deviation in `test/suite/retry-fallback-chains.test.ts` (landed by PR #686's `1f0e0784c`); CI never flags it because the same `--write` runs there. This PR deliberately does **not** include that unrelated reformat — flagged here for a separate micro-PR if wanted.

## Test plan

- [x] Mutation RED→GREEN (deterministic reproduction of both CI flake signatures)
- [x] 100x CI-faithful stress (forks pool, 2 workers)
- [x] Full `test/mcp` scope green
- [x] `npm run check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky `MCP disk metadata cache` tests by waiting for exact tool names in the on-disk cache instead of tool counts. This removes the in-memory vs. disk write race that caused intermittent stale reads on CI.

- **Bug Fixes**
  - Updated `awaitCacheTools(root, expectedNames)` to poll until cache file tool names match exactly.
  - Replaced count-based barriers at all call sites and added a cache-content barrier to the eager load test.
  - Eliminates CI flakes where tests read a `"poisoned"` `configHash` or `['stale_cached']` tools.

<sup>Written for commit 501182f2d736caba2a7c6891c717766c7a75176a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

