### PR TITLE
feat(ttsr): interrupt cross-turn repetition loops

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-ttsr.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-ttsr.mjs
@@ -5,7 +5,7 @@ import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks } from ".
 const CTRL_SEP = ["<", "|", "sep", "|", ">"].join("");
 const BANG_RUN_300 = /!{300}/;
 
-export const TTSR_SCENARIOS = ["ttsr-collapse", "ttsr-leak"];
+export const TTSR_SCENARIOS = ["ttsr-collapse", "ttsr-leak", "ttsr-repetitive-turns"];
 
 export function isTtsrScenario(name) {
 	return TTSR_SCENARIOS.includes(name);
@@ -22,11 +22,59 @@ function writeTtsrEvidence(slug, scenarioName, result, server) {
 	process.stderr.write(`evidence: ${dir}\n`);
 }
 
+const REPEATED_STATUS_TURNS = [
+	"I read this as continue supervising the portable matrix; it has started cleanly with 1 check green and 8 still pending.",
+	"I read this as continue supervising the portable matrix; it has started cleanly with 2 checks green and 7 jobs pending.",
+	"I read this as continue supervising the portable matrix; it has started cleanly with 3 checks green and 6 gates pending.",
+];
+
+async function runRepetitiveTurnsScenario({ apiName, driveTurn, evidenceSlug, checks, guard, finalMarker, scenarioName }) {
+	const { box, server, result } = await driveTurn({
+		apiName,
+		turns: [
+			{ text: REPEATED_STATUS_TURNS[0] },
+			{ text: REPEATED_STATUS_TURNS[1] },
+			{ text: REPEATED_STATUS_TURNS[2] },
+			{ text: finalMarker },
+		],
+		prompt: `Report status repeatedly and finish with ${finalMarker}.`,
+		extraArgs: ["--approve"],
+		followUpPrompts: ["continue", "continue"],
+		timeoutMs: 180000,
+	});
+
+	try {
+		const output = `${result.stdout}\n${result.stderr}`;
+		const allBodies = JSON.stringify(server.requests.map((r) => r.body ?? r.raw ?? ""));
+		checks.ok(`${scenarioName}: CLI exits zero`, result.code === 0 && !result.timedOut, `code=${result.code}`);
+		checks.ok(
+			`${scenarioName}: cross-turn repetition triggered an extra bounded turn`,
+			server.requests.length > 2,
+			`requests=${server.requests.length}`,
+		);
+		checks.ok(
+			`${scenarioName}: repetitive-turns system-interrupt injected into a later request`,
+			allBodies.includes("repetitive-turns"),
+			`interruptPresent=${allBodies.includes("repetitive-turns")}`,
+		);
+		checks.ok(`${scenarioName}: recovery answer returned`, output.includes(finalMarker), `marker=${finalMarker}`);
+		guard.assertUnchanged();
+		if (evidenceSlug) writeTtsrEvidence(evidenceSlug, scenarioName, result, server);
+	} finally {
+		await server.stop();
+		box.cleanup();
+	}
+	process.exit(checks.finish() ? 0 : 1);
+}
+
 export async function runTtsrScenario({ scenarioName, apiName, driveTurn, evidenceSlug }) {
 	installCleanupHooks();
 	const checks = createChecks(`mock-loop.mjs --scenario ${scenarioName} --api ${apiName}`);
 	const guard = guardRealAuth();
 	const finalMarker = `SENPI-QA-${scenarioName.toUpperCase().replace(/-/g, "_")}-FINAL`;
+	if (scenarioName === "ttsr-repetitive-turns") {
+		return runRepetitiveTurnsScenario({ apiName, driveTurn, evidenceSlug, checks, guard, finalMarker, scenarioName });
+	}
 	const collapse = scenarioName === "ttsr-collapse";
 	const firstTurn = collapse
 		? { reasoning: `analyzing the problem ${"!".repeat(600)}`, chunks: 40 }

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -120,6 +120,7 @@ async function driveTurn({
 	modelOverrides,
 	mockModels,
 	retry,
+	followUpPrompts = [],
 }) {
 	const p = API_PRESETS[apiName];
 	const box = makeSandbox(`mock-loop-${apiName}`);
@@ -140,6 +141,22 @@ async function driveTurn({
 		prompt,
 	];
 	const result = await runCli(args, { env: hermeticEnv(box.env), cwd: box.cwd, timeoutMs });
+	if (followUpPrompts.length > 0) {
+		let combined = result;
+		for (const followUp of followUpPrompts) {
+			const followArgs = args.slice(0, -1);
+			followArgs.splice(followArgs.length - 1, 0, "--continue");
+			followArgs.push(followUp);
+			const next = await runCli(followArgs, { env: hermeticEnv(box.env), cwd: box.cwd, timeoutMs });
+			combined = {
+				code: next.code,
+				stdout: `${combined.stdout}\n${next.stdout}`,
+				stderr: `${combined.stderr}\n${next.stderr}`,
+				timedOut: combined.timedOut || next.timedOut,
+			};
+		}
+		return { box, server, result: combined, preset: p, prepared };
+	}
 	return { box, server, result, preset: p, prepared };
 }
 
@@ -610,7 +627,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
-			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|ttsr-collapse|ttsr-leak> [--api <name>]",
+			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|ttsr-collapse|ttsr-leak|ttsr-repetitive-turns> [--api <name>]",
 			"  node mock-loop.mjs --scenario <hinted-429-in-turn|no-hint-429-fast-fallback|hinted-429-probe-back>",
 			"  node mock-loop.mjs --run <prompt> [--api <name>]",
 			`  APIs: ${ALL_APIS.join(", ")}`,

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/changes.md
@@ -1,5 +1,35 @@
 # TTSR Fork Tracker
 
+## 2026-08-04 - Cross-turn repetitive-turns detection
+
+### What changed and why
+
+- TTSR gained a third builtin detection lane, `repetitive-turns`, that watches assistant output ACROSS turns instead of within a single generation. The existing collapse and control-token-leak detectors only see one streamed message, so a model that emits a fresh but near-identical status message every turn (an "I read this as continue waiting; N green, M remain" supervision loop) never trips them and can burn an unbounded number of turns making no progress.
+- Detection is generic, not phrase-specific: each completed assistant text is normalized (lowercased, digit runs and hex-like ids folded to `#`, whitespace collapsed) and compared to the previous turn with word-trigram Jaccard similarity. Three consecutive turns at or above 0.55 similarity trip the lane, so numeric-only deltas between otherwise identical templates still match while genuinely progressing work does not.
+- Remediation reuses the shipped rule-nudge path: the next near-duplicate generation is aborted mid-stream via `ctx.abort()`, the injection is recorded through `recordInjection` (so both the `ttsr-injection` entry and the shared rule-activation record are emitted), and a `<system-interrupt rule="repetitive-turns">` nudge tells the model to stop restating status and take a different concrete action or declare what it is blocked on.
+- The lane latches after firing and only re-arms once a sufficiently dissimilar turn resets the streak, so a single loop yields exactly one interruption rather than one per repeated turn.
+- `--ttsr-rules-disabled=repetitive-turns` disables the lane end to end, matching the existing builtin-disable contract.
+
+### Why an extension-local change is required
+
+- Cross-turn state cannot live in `StreamWatcher`, which is reset at every `turn_start` by design; the detector is therefore held by the extension across turns and fed from `message_end`, using only the public `pi.*` surface. No `packages/ai`, `packages/agent`, or `agent-session.ts` change is involved.
+
+### Session-resume rehydration
+
+- Cross-turn state is rebuilt at init from persisted history (`ctx.sessionManager.getEntries()`, last 8 assistant texts) because each `--print` / `--continue` invocation is a fresh process. Without this, any resumed session — the long-running supervision sessions this lane targets — had no cross-turn protection at all; real-CLI QA caught it while the unit suite was green.
+
+### Coverage
+
+- `test/ttsr/repetitive-turns.test.ts` pins normalization, trigram similarity, the streak threshold, the minimum-length floor, and latch/reset behavior.
+- `test/suite/ttsr-extension.test.ts` proves through the faux provider that a near-duplicate streak aborts and injects exactly one `repetitive-turns` nudge with a persisted injection entry, that an unrelated repeated template also trips (genericity), that genuinely progressing turns are untouched, and that the disable flag silences the lane.
+
+- Real-CLI QA ships as `senpi-qa` mock-loop scenario `ttsr-repetitive-turns` (chained `--continue` runs against the local fake model server), alongside the existing `ttsr-collapse` and `ttsr-leak` scenarios.
+
+### Expected merge conflict zones
+
+- LOW: additive detector module and prompt constant.
+- MEDIUM: `index.ts` `message_update` / `message_end` handlers now carry the cross-turn arm/record steps alongside the existing collapse, leak, and manager-rule branches.
+
 ## 2026-08-04 - Shared visible activation records
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/detectors/repetitive-turns.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/detectors/repetitive-turns.ts
@@ -1,0 +1,108 @@
+import type { DetectorMatch } from "../types.ts";
+
+export const REPETITIVE_TURNS_RULE_NAME = "repetitive-turns";
+
+export const REPETITIVE_TURNS_SIMILARITY_THRESHOLD = 0.55;
+export const REPETITIVE_TURNS_STREAK_LENGTH = 3;
+export const REPETITIVE_TURNS_MIN_NORMALIZED_CHARS = 40;
+export const REPETITIVE_TURNS_HISTORY_CAPACITY = 6;
+
+const WORD_PATTERN = /[\p{L}\p{N}#]+/gu;
+const DIGIT_RUN_PATTERN = /\d[\d.,:/-]*/g;
+const HEX_LIKE_PATTERN = /\b[0-9a-f]{7,}\b/gi;
+const SAMPLE_LENGTH = 80;
+
+export function normalizeTurnText(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(HEX_LIKE_PATTERN, "#")
+		.replace(DIGIT_RUN_PATTERN, "#")
+		.split(/\s+/)
+		.filter((token) => token.length > 0)
+		.join(" ")
+		.trim();
+}
+
+function wordTrigrams(normalized: string): Set<string> {
+	const words = normalized.match(WORD_PATTERN) ?? [];
+	const grams = new Set<string>();
+	for (let i = 0; i + 3 <= words.length; i++) {
+		grams.add(`${words[i]} ${words[i + 1]} ${words[i + 2]}`);
+	}
+	return grams;
+}
+
+export function trigramJaccard(a: string, b: string): number {
+	const gramsA = wordTrigrams(a);
+	const gramsB = wordTrigrams(b);
+	if (gramsA.size === 0 || gramsB.size === 0) return 0;
+	let intersection = 0;
+	for (const gram of gramsA) {
+		if (gramsB.has(gram)) intersection += 1;
+	}
+	return intersection / (gramsA.size + gramsB.size - intersection);
+}
+
+export function isNearDuplicateOfPreviousTurn(normalizedCandidate: string, normalizedPrevious: string): boolean {
+	return trigramJaccard(normalizedCandidate, normalizedPrevious) >= REPETITIVE_TURNS_SIMILARITY_THRESHOLD;
+}
+
+interface TurnEntry {
+	readonly normalized: string;
+	readonly grams: Set<string>;
+}
+
+export interface RepetitiveTurnsState {
+	readonly history: TurnEntry[];
+	streak: number;
+	latched: boolean;
+}
+
+export function createRepetitiveTurnsState(): RepetitiveTurnsState {
+	return { history: [], streak: 0, latched: false };
+}
+
+function jaccardSets(a: Set<string>, b: Set<string>): number {
+	if (a.size === 0 || b.size === 0) return 0;
+	let intersection = 0;
+	for (const gram of a) {
+		if (b.has(gram)) intersection += 1;
+	}
+	return intersection / (a.size + b.size - intersection);
+}
+
+export function recordTurnText(state: RepetitiveTurnsState, text: string): DetectorMatch | null {
+	const normalized = normalizeTurnText(text);
+	if (normalized.length < REPETITIVE_TURNS_MIN_NORMALIZED_CHARS) {
+		return null;
+	}
+	const grams = wordTrigrams(normalized);
+	const previous = state.history[state.history.length - 1];
+	const similarity = previous === undefined ? 0 : jaccardSets(grams, previous.grams);
+	state.history.push({ normalized, grams });
+	if (state.history.length > REPETITIVE_TURNS_HISTORY_CAPACITY) {
+		state.history.shift();
+	}
+	if (similarity >= REPETITIVE_TURNS_SIMILARITY_THRESHOLD) {
+		state.streak += 1;
+	} else {
+		state.streak = 0;
+		if (state.latched) state.latched = false;
+	}
+	if (state.latched || state.streak < REPETITIVE_TURNS_STREAK_LENGTH - 1) {
+		return null;
+	}
+	state.latched = true;
+	return {
+		rule: REPETITIVE_TURNS_RULE_NAME,
+		reason: `assistant repeated a near-identical message across ${state.streak + 1} consecutive turns (jaccard ${similarity.toFixed(2)})`,
+		anomalyStartOffset: 0,
+		garbageStartOffset: 0,
+		detail: {
+			mechanism: "cross-turn",
+			streak: state.streak + 1,
+			similarity: Number(similarity.toFixed(3)),
+			sample: normalized.slice(0, SAMPLE_LENGTH),
+		},
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/index.ts
@@ -5,17 +5,14 @@ import { appendRuleActivation, registerRuleActivationRenderer } from "../rule-ac
 import { BUILTIN_TTSR_RULES } from "./builtin-rules.ts";
 import { registerTtsrCommands, type TtsrPublicState } from "./commands.ts";
 import { claimAbort, createGenerationState, markUserCancelled } from "./coordinator.ts";
+import { REPETITIVE_TURNS_RULE_NAME } from "./detectors/repetitive-turns.ts";
 import { discoverTtsrRulesSync } from "./discovery.ts";
 import { TtsrManager } from "./manager.ts";
-import { COLLAPSE_RULE_CONTENT } from "./prompts.ts";
-import {
-	buildErrorShellReplacement,
-	buildNudgeMessage,
-	buildTruncateReplacement,
-	type TruncatableAssistantMessage,
-	type TtsrNudgeMessage,
-} from "./remediation.ts";
+import { REPETITIVE_TURNS_RULE_CONTENT } from "./prompts.ts";
+import { buildNudgeMessage, type TtsrNudgeMessage } from "./remediation.ts";
+import { collectAssistantText, RepetitiveTurnsLane, readPersistedAssistantTexts } from "./repetitive-turns-lane.ts";
 import { compileRuleCondition } from "./rule-condition.ts";
+import { buildStreamRemediation } from "./stream-remediation.ts";
 import {
 	DEFAULT_TTSR_SETTINGS,
 	type DetectionResolution,
@@ -74,6 +71,7 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 	let pendingRuleNudge: PendingRuleNudge | null = null;
 	let pendingNudge: TtsrNudgeMessage | null = null;
 	let disabled = false;
+	const repetitiveTurns = new RepetitiveTurnsLane();
 
 	function cancelRemediation(): void {
 		if (pendingRemediation !== null || pendingNudge !== null || pendingRuleNudge !== null) {
@@ -81,6 +79,7 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 			pendingRemediation = null;
 			pendingRuleNudge = null;
 			pendingNudge = null;
+			repetitiveTurns.disarm();
 		}
 	}
 
@@ -112,6 +111,7 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 		if (manager !== null) return;
 		disabled = pi.getFlag("ttsr-disabled") === true;
 		const disabledRules = parseDisabledRules(pi.getFlag("ttsr-rules-disabled"));
+		repetitiveTurns.configure(new Set(disabledRules));
 		const settings = { ...DEFAULT_TTSR_SETTINGS, enabled: !disabled, disabledRules };
 		manager = new TtsrManager(settings, (pattern) => compileRuleCondition(pattern).regex);
 		const injectedNames = ctx.sessionManager
@@ -132,6 +132,7 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 			manager.addRule(rule);
 		}
 		watcher = new StreamWatcher(manager, disabledRules);
+		repetitiveTurns.restoreFromHistory(readPersistedAssistantTexts(ctx));
 		if (ctx.mode === "tui") {
 			try {
 				ctx.ui.onTerminalInput((data) => {
@@ -171,6 +172,7 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 		genState = createGenerationState();
 		pendingRemediation = null;
 		pendingRuleNudge = null;
+		repetitiveTurns.resetTurn();
 		watcher?.reset();
 	});
 
@@ -192,6 +194,17 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 			ctx.abort();
 			return;
 		}
+		if (source === "text") {
+			const canArm = pendingRuleNudge === null && !genState.abortClaimed;
+			if (repetitiveTurns.observeTextDelta(deltaEvent.delta, canArm) && !genState.abortClaimed) {
+				genState.abortClaimed = true;
+				genState.abortOwner = "collapse-repetition";
+				genState.selfAbortAt = Date.now();
+				notify(ctx, REPETITIVE_TURNS_RULE_NAME);
+				ctx.abort();
+				return;
+			}
+		}
 		const interrupting = outcome.ruleMatches.filter((rule) => rule.interruptMode === "always");
 		const rule = interrupting[0];
 		if (rule !== undefined && pendingRuleNudge === null && !genState.abortClaimed) {
@@ -207,6 +220,14 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 	pi.on("message_end", (event) => {
 		if (genState.userCancelled) return undefined;
 		if (event.message.role !== "assistant") return undefined;
+		const turnText = collectAssistantText(event.message);
+		if (repetitiveTurns.armed) {
+			repetitiveTurns.commitArmedTurn(turnText);
+			manager?.markInjectedByNames([REPETITIVE_TURNS_RULE_NAME]);
+			recordInjection(REPETITIVE_TURNS_RULE_NAME, [REPETITIVE_TURNS_RULE_NAME], "nudge");
+			pendingNudge = buildNudgeMessage(REPETITIVE_TURNS_RULE_NAME, REPETITIVE_TURNS_RULE_CONTENT);
+			return undefined;
+		}
 		if (pendingRuleNudge !== null) {
 			const pending = pendingRuleNudge;
 			pendingRuleNudge = null;
@@ -215,29 +236,28 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 			pendingNudge = buildNudgeMessage(pending.rule.name, pending.rule.content);
 			return undefined;
 		}
-		if (pendingRemediation === null) return undefined;
-		const pending = pendingRemediation;
-		pendingRemediation = null;
-		try {
-			if (pending.resolution.remediation.corruptionScope === "generation") {
-				recordInjection(pending.resolution.owner, pending.resolution.observedRules, "provider-error");
-				return { message: { ...event.message, ...buildErrorShellReplacement() } };
+		if (pendingRemediation !== null) {
+			if (turnText !== null) repetitiveTurns.recordCompletedTurn(turnText);
+			const pending = pendingRemediation;
+			pendingRemediation = null;
+			try {
+				const outcome = buildStreamRemediation(pending, event.message);
+				recordInjection(outcome.owner, outcome.observedRules, outcome.retryMode);
+				if (outcome.nudge !== null) {
+					pendingNudge = outcome.nudge;
+				}
+				const merged = { ...event.message, ...outcome.replacement };
+				return { message: merged as unknown as typeof event.message };
+			} catch (error) {
+				pi.appendEntry("ttsr-remediation-error", {
+					message: error instanceof Error ? error.message : String(error),
+					at: Date.now(),
+				});
+				return undefined;
 			}
-			const replaced = buildTruncateReplacement(
-				event.message as unknown as TruncatableAssistantMessage,
-				pending.resolution.match.garbageStartOffset,
-				pending.streamKind,
-			);
-			recordInjection(pending.resolution.owner, pending.resolution.observedRules, "nudge");
-			pendingNudge = buildNudgeMessage(pending.resolution.owner, COLLAPSE_RULE_CONTENT);
-			return { message: replaced as unknown as typeof event.message };
-		} catch (error) {
-			pi.appendEntry("ttsr-remediation-error", {
-				message: error instanceof Error ? error.message : String(error),
-				at: Date.now(),
-			});
-			return undefined;
 		}
+		if (turnText !== null) repetitiveTurns.recordCompletedTurn(turnText);
+		return undefined;
 	});
 
 	pi.on("agent_settled", () => {

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/prompts.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/prompts.ts
@@ -21,3 +21,9 @@ export const LEAK_ERROR_MESSAGE = "Degeneration guard: control-token leakage; tr
 
 export const COLLAPSE_RULE_NAME = "collapse-repetition";
 export const CONTROL_LEAK_RULE_NAME = "control-token-leak";
+
+export const REPETITIVE_TURNS_RULE_CONTENT = [
+	"Your recent replies repeated the same near-identical status message across consecutive turns — a cross-turn repetition loop.",
+	"Stop restating the situation. Do not emit another progress recap.",
+	"Take a different concrete action now: use a tool, inspect new state, change the approach, or — if the task is actually blocked — say exactly what you are waiting for and stop.",
+].join("\n");

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/repetitive-turns-lane.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/repetitive-turns-lane.ts
@@ -1,0 +1,116 @@
+import {
+	createRepetitiveTurnsState,
+	isNearDuplicateOfPreviousTurn,
+	normalizeTurnText,
+	REPETITIVE_TURNS_MIN_NORMALIZED_CHARS,
+	REPETITIVE_TURNS_RULE_NAME,
+	type RepetitiveTurnsState,
+	recordTurnText,
+} from "./detectors/repetitive-turns.ts";
+
+export function collectAssistantText(message: { readonly content: unknown }): string | null {
+	if (!Array.isArray(message.content)) return null;
+	let combined = "";
+	for (const block of message.content) {
+		if (typeof block !== "object" || block === null) continue;
+		if (!("type" in block) || block.type !== "text") continue;
+		const value: unknown = Reflect.get(block, "text");
+		if (typeof value === "string") combined += value;
+	}
+	return combined.length > 0 ? combined : null;
+}
+
+const RESTORED_TURN_LIMIT = 8;
+
+interface SessionEntrySource {
+	readonly sessionManager: { getEntries(): readonly unknown[] };
+}
+
+export function readPersistedAssistantTexts(ctx: SessionEntrySource): string[] {
+	const texts: string[] = [];
+	for (const entry of ctx.sessionManager.getEntries()) {
+		if (typeof entry !== "object" || entry === null) continue;
+		if (!("type" in entry) || entry.type !== "message") continue;
+		const message: unknown = Reflect.get(entry, "message");
+		if (typeof message !== "object" || message === null) continue;
+		if (Reflect.get(message, "role") !== "assistant") continue;
+		const text = collectAssistantText({ content: Reflect.get(message, "content") });
+		if (text !== null) texts.push(text);
+	}
+	return texts.slice(-RESTORED_TURN_LIMIT);
+}
+
+export class RepetitiveTurnsLane {
+	#state: RepetitiveTurnsState = createRepetitiveTurnsState();
+	#armed = false;
+	#recovering = false;
+	#currentTurnText = "";
+	#lastCompletedTurnText: string | null = null;
+	#enabled = true;
+
+	configure(disabledRules: ReadonlySet<string>): void {
+		this.#enabled = !disabledRules.has(REPETITIVE_TURNS_RULE_NAME);
+	}
+
+	resetSession(): void {
+		this.#state = createRepetitiveTurnsState();
+		this.#armed = false;
+		this.#recovering = false;
+		this.#currentTurnText = "";
+		this.#lastCompletedTurnText = null;
+	}
+
+	restoreFromHistory(assistantTexts: readonly string[]): void {
+		for (const text of assistantTexts) {
+			this.recordCompletedTurn(text);
+		}
+		this.#armed = false;
+	}
+
+	resetTurn(): void {
+		this.#armed = false;
+		this.#currentTurnText = "";
+	}
+
+	disarm(): void {
+		this.#armed = false;
+	}
+
+	get armed(): boolean {
+		return this.#armed;
+	}
+
+	observeTextDelta(delta: string, canArm: boolean): boolean {
+		if (this.#enabled && !this.#armed && !this.#recovering && canArm && this.#lastCompletedTurnText !== null) {
+			const candidate = normalizeTurnText(this.#currentTurnText + delta);
+			if (
+				candidate.length >= REPETITIVE_TURNS_MIN_NORMALIZED_CHARS &&
+				isNearDuplicateOfPreviousTurn(candidate, this.#lastCompletedTurnText)
+			) {
+				this.#armed = true;
+			}
+		}
+		this.#currentTurnText += delta;
+		return this.#armed;
+	}
+
+	commitArmedTurn(turnText: string | null): void {
+		this.#armed = false;
+		this.#recovering = true;
+		if (turnText !== null) {
+			this.#lastCompletedTurnText = normalizeTurnText(turnText);
+		}
+	}
+
+	recordCompletedTurn(turnText: string): void {
+		const normalized = normalizeTurnText(turnText);
+		this.#lastCompletedTurnText = normalized;
+		if (!this.#enabled) return;
+		const match = recordTurnText(this.#state, turnText);
+		if (match === null) {
+			if (this.#recovering) this.#recovering = false;
+			return;
+		}
+		this.#armed = true;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/stream-remediation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/stream-remediation.ts
@@ -1,0 +1,47 @@
+import { COLLAPSE_RULE_CONTENT } from "./prompts.ts";
+import {
+	buildErrorShellReplacement,
+	buildNudgeMessage,
+	buildTruncateReplacement,
+	type ErrorShellReplacement,
+	type TruncatableAssistantMessage,
+	type TtsrNudgeMessage,
+} from "./remediation.ts";
+import type { DetectionResolution } from "./types.ts";
+
+export interface StreamRemediationInput {
+	readonly resolution: DetectionResolution;
+	readonly streamKind: "text" | "thinking";
+}
+
+export interface StreamRemediationOutcome {
+	readonly replacement: ErrorShellReplacement | TruncatableAssistantMessage;
+	readonly nudge: TtsrNudgeMessage | null;
+	readonly owner: string;
+	readonly observedRules: readonly string[];
+	readonly retryMode: "nudge" | "provider-error";
+}
+
+export function buildStreamRemediation(pending: StreamRemediationInput, message: unknown): StreamRemediationOutcome {
+	if (pending.resolution.remediation.corruptionScope === "generation") {
+		return {
+			replacement: buildErrorShellReplacement(),
+			nudge: null,
+			owner: pending.resolution.owner,
+			observedRules: pending.resolution.observedRules,
+			retryMode: "provider-error",
+		};
+	}
+	const replaced = buildTruncateReplacement(
+		message as TruncatableAssistantMessage,
+		pending.resolution.match.garbageStartOffset,
+		pending.streamKind,
+	);
+	return {
+		replacement: replaced,
+		nudge: buildNudgeMessage(pending.resolution.owner, COLLAPSE_RULE_CONTENT),
+		owner: pending.resolution.owner,
+		observedRules: pending.resolution.observedRules,
+		retryMode: "nudge",
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/types.ts
@@ -46,7 +46,7 @@ export interface DetectorContext {
 }
 
 export interface DetectorMatch {
-	readonly rule: "collapse-repetition" | "control-token-leak";
+	readonly rule: "collapse-repetition" | "control-token-leak" | "repetitive-turns";
 	readonly reason: string;
 	readonly anomalyStartOffset: number;
 	readonly garbageStartOffset: number;

--- a/packages/coding-agent/test/suite/ttsr-extension.test.ts
+++ b/packages/coding-agent/test/suite/ttsr-extension.test.ts
@@ -287,3 +287,113 @@ describe("message_end fail-closed ordering", () => {
 		expect(harness.faux.getCallLog().length).toBe(2);
 	});
 });
+
+describe("repetitive turns remediation", () => {
+	let harness: Harness;
+
+	afterEach(() => {
+		harness.cleanup();
+	});
+
+	const STATUS_TURNS = [
+		"I read this as continue supervising the portable matrix; it has started cleanly with 1 check green and 8 still pending.",
+		"I read this as continue supervising the portable matrix; it has started cleanly with 2 checks green and 7 jobs pending.",
+		"I read this as continue supervising the portable matrix; it has started cleanly with 3 checks green and 6 gates pending.",
+		"I read this as continue supervising the portable matrix; it has started cleanly with 4 checks green and 5 builds pending.",
+	];
+
+	it("interrupts a cross-turn near-duplicate streak and injects a corrective nudge", async () => {
+		harness = await createHarness({ extensionFactories: [ttsrExtension], persistSession: true });
+		harness.setResponses([
+			fauxAssistantMessage([fauxText(STATUS_TURNS[0])]),
+			fauxAssistantMessage([fauxText(STATUS_TURNS[1])]),
+			fauxAssistantMessage([fauxText(STATUS_TURNS[2])]),
+			fauxAssistantMessage([fauxText(STATUS_TURNS[3])]),
+			fauxAssistantMessage([fauxText("breaking the loop: taking a concrete action now")]),
+		]);
+
+		await harness.session.prompt("watch the gates");
+		await harness.session.prompt("continue");
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.getCallLog()).toHaveLength(5);
+		const nudges = ttsrNudges(harness);
+		expect(nudges.length).toBeGreaterThanOrEqual(1);
+		for (const nudge of nudges) {
+			expect(nudge).toContain('<system-interrupt reason="rule_violation" rule="repetitive-turns">');
+			expect(nudge).toMatch(/stop|break|concrete action|do not restate/i);
+		}
+		expect(getMessageText(harness.session.messages.at(-1))).toContain("breaking the loop");
+
+		const entries = readSessionEntries(harness);
+		const injectionEntries = entries.filter((e) => e.type === "custom" && e.customType === "ttsr-injection");
+		expect(injectionEntries.length).toBe(nudges.length);
+	});
+
+	it("detects repetition generically, not a baked-in phrase", async () => {
+		harness = await createHarness({ extensionFactories: [ttsrExtension], persistSession: true });
+		harness.setResponses([
+			fauxAssistantMessage([
+				fauxText("Still working on the frobnicate step. Pass 1 of 9 is done, queue drained here."),
+			]),
+			fauxAssistantMessage([
+				fauxText("Still working on the frobnicate step. Pass 2 of 9 is done, queue drained again."),
+			]),
+			fauxAssistantMessage([
+				fauxText("Still working on the frobnicate step. Pass 3 of 9 is done, queue drained fully."),
+			]),
+			fauxAssistantMessage([fauxText("frobnicate finished; moving to the deploy checklist")]),
+		]);
+
+		await harness.session.prompt("frob the widget");
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.getCallLog()).toHaveLength(3);
+		const nudges = ttsrNudges(harness);
+		expect(nudges.length).toBeGreaterThanOrEqual(1);
+		expect(nudges[0]).toContain('rule="repetitive-turns"');
+	});
+
+	it("leaves genuinely progressing turns alone", async () => {
+		harness = await createHarness({ extensionFactories: [ttsrExtension], persistSession: true });
+		harness.setResponses([
+			fauxAssistantMessage([fauxText(STATUS_TURNS[0])]),
+			fauxAssistantMessage([
+				fauxText(
+					"The two reds are again Linux jobs while Windows and macOS remain active; switching to a run-level watcher.",
+				),
+			]),
+			fauxAssistantMessage([
+				fauxText(
+					"Windows now passes the integration binary; the store tests hardcode a shell path, so I am gating the live cases.",
+				),
+			]),
+			fauxAssistantMessage([fauxText("All checks green; merging the pull request and removing the worktree.")]),
+		]);
+
+		await harness.session.prompt("watch the gates");
+		await harness.session.prompt("continue");
+		await harness.session.prompt("continue");
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.getCallLog()).toHaveLength(4);
+		expect(ttsrNudges(harness)).toEqual([]);
+	});
+
+	it("honors ttsr-rules-disabled for the repetitive-turns lane", async () => {
+		harness = await createHarness({
+			extensionFactories: [ttsrExtension],
+			extensionFlagValues: new Map([["ttsr-rules-disabled", "repetitive-turns"]]),
+			persistSession: true,
+		});
+		harness.setResponses(STATUS_TURNS.map((text) => fauxAssistantMessage([fauxText(text)])));
+
+		await harness.session.prompt("watch the gates");
+		await harness.session.prompt("continue");
+		await harness.session.prompt("continue");
+		await harness.session.prompt("continue");
+
+		expect(harness.faux.getCallLog()).toHaveLength(4);
+		expect(ttsrNudges(harness)).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/ttsr/repetitive-turns.test.ts
+++ b/packages/coding-agent/test/ttsr/repetitive-turns.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	createRepetitiveTurnsState,
+	normalizeTurnText,
+	REPETITIVE_TURNS_RULE_NAME,
+	recordTurnText,
+	trigramJaccard,
+} from "../../src/core/extensions/builtin/ttsr/detectors/repetitive-turns.ts";
+
+const SESSION_STATUS_VARIANTS = [
+	"I read this as continue supervising the portable-PTY matrix; it has started cleanly with 1 check green and 8 pending.",
+	"I read this as continue supervising the portable-PTY matrix; it has started cleanly with 2 checks green and 7 pending.",
+	"I read this as continue supervising the portable-PTY matrix; it has started cleanly with 3 checks green and 6 pending.",
+	"I read this as continue supervising the portable-PTY matrix; it has started cleanly with 4 checks green and 5 pending.",
+];
+
+describe("normalizeTurnText", () => {
+	it("lowercases and folds digits, timestamps, and hex-like ids", () => {
+		expect(normalizeTurnText("3 checks Green, 6 remain at 06:08:27")).toBe("# checks green, # remain at #");
+		expect(normalizeTurnText("run 30882887316 on head 9a201e8 done")).toBe("run # on head # done");
+	});
+
+	it("collapses whitespace runs", () => {
+		expect(normalizeTurnText("a   b\tc\nd")).toBe("a b c d");
+	});
+});
+
+describe("trigramJaccard", () => {
+	it("is 1 for identical normalized texts and 0 for disjoint ones", () => {
+		const a = normalizeTurnText(SESSION_STATUS_VARIANTS[0]);
+		expect(trigramJaccard(a, a)).toBe(1);
+		expect(trigramJaccard("alpha beta gamma delta epsilon", "one two three four five")).toBe(0);
+	});
+
+	it("matches near-duplicates that are not identical after normalization", () => {
+		const a = normalizeTurnText("Still working on the frobnicate step. Pass 1 of 9 is done, queue drained here.");
+		const b = normalizeTurnText("Still working on the frobnicate step. Pass 2 of 9 is done, queue drained again.");
+		expect(a).not.toBe(b);
+		expect(trigramJaccard(a, b)).toBeGreaterThanOrEqual(0.55);
+	});
+
+	it("scores the session-019fca2b status variants as highly similar", () => {
+		const normalized = SESSION_STATUS_VARIANTS.map(normalizeTurnText);
+		for (let i = 1; i < normalized.length; i++) {
+			expect(trigramJaccard(normalized[i - 1], normalized[i])).toBeGreaterThanOrEqual(0.55);
+		}
+	});
+
+	it("scores genuinely different updates as dissimilar", () => {
+		const a = normalizeTurnText(SESSION_STATUS_VARIANTS[0]);
+		const b = normalizeTurnText(
+			"The run completed by hitting the Windows job timeout at the limit; both Windows jobs were cancelled, not assertion-failed.",
+		);
+		expect(trigramJaccard(a, b)).toBeLessThan(0.35);
+	});
+});
+
+describe("repetitive-turns detector", () => {
+	it("does not fire on the first two similar turns, then fires on the third consecutive near-duplicate", () => {
+		const state = createRepetitiveTurnsState();
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[0])).toBeNull();
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[1])).toBeNull();
+		const match = recordTurnText(state, SESSION_STATUS_VARIANTS[2]);
+		expect(match).not.toBeNull();
+		expect(match?.rule).toBe(REPETITIVE_TURNS_RULE_NAME);
+		expect(match?.detail.mechanism).toBe("cross-turn");
+	});
+
+	it("stays silent for genuinely changing updates", () => {
+		const state = createRepetitiveTurnsState();
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[0])).toBeNull();
+		expect(
+			recordTurnText(
+				state,
+				"The two reds are again Linux jobs while Windows and macOS x64 remain active. I am switching to a run-level watcher for the current head.",
+			),
+		).toBeNull();
+		expect(
+			recordTurnText(
+				state,
+				"Windows now passes the PTY integration binary; the next store tests hardcode a shell path. I am gating only the live lifecycle cases.",
+			),
+		).toBeNull();
+		expect(
+			recordTurnText(state, "All checks are green; merging the pull request and cleaning up the worktree now."),
+		).toBeNull();
+	});
+
+	it("ignores texts below the minimum length floor even when identical", () => {
+		const state = createRepetitiveTurnsState();
+		expect(recordTurnText(state, "ok")).toBeNull();
+		expect(recordTurnText(state, "ok")).toBeNull();
+		expect(recordTurnText(state, "ok")).toBeNull();
+	});
+
+	it("suppresses refiring while latched and resets on a dissimilar turn", () => {
+		const state = createRepetitiveTurnsState();
+		recordTurnText(state, SESSION_STATUS_VARIANTS[0]);
+		recordTurnText(state, SESSION_STATUS_VARIANTS[1]);
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[2])).not.toBeNull();
+		// given the detector just fired, a fourth similar turn stays latched
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[3])).toBeNull();
+		// when a dissimilar turn arrives, the streak resets and unlatches
+		expect(
+			recordTurnText(
+				state,
+				"The Windows timeout occurs inside the integration binary: only the two pure buffer tests finish; every live lifecycle test stalls.",
+			),
+		).toBeNull();
+		expect(state.latched).toBe(false);
+		expect(state.streak).toBe(0);
+	});
+
+	it("does not let an old dissimilar turn break a current streak (window is consecutive)", () => {
+		const state = createRepetitiveTurnsState();
+		recordTurnText(
+			state,
+			"Completely unrelated planning note about refactoring the parser into smaller units with tests.",
+		);
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[0])).toBeNull();
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[1])).toBeNull();
+		expect(recordTurnText(state, SESSION_STATUS_VARIANTS[2])).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Problem

TTSR's existing lanes (`collapse-repetition`, `control-token-leak`) only inspect a **single streamed generation**. A model that emits a *fresh but near-identical* message every turn never trips them.

Observed in session `019fca2b-02e0-7337-b655-58e66c1cbe41`: ~50 minutes of turns like

```
05:29:38  I read this as continue supervising the portable-PTY matrix; ... one check green and eight pending.
05:30:37  I read this as keep the current Bunshin matrix under observation; two checks are green, seven remain ...
05:31:08  I read this as continue waiting on the active Bunshin gates; three checks are green, six remain ...
06:09:12  I read this as continue waiting on the active Bunshin gates; three checks are green, six remain ...
```

Every message is individually well-formed, so nothing interrupted it. Only the numbers moved.

## What this adds

A third builtin lane, **`repetitive-turns`**, that detects the loop *across* turns and reuses the shipped abort → nudge → retry path.

- **Generic, not phrase-specific.** Text is normalized (lowercased, digit runs and hex-like ids folded to `#`, whitespace collapsed) and compared to the previous turn with **word-trigram Jaccard** similarity. Three consecutive turns at or above `0.55` trip the lane, so numeric-only deltas match while genuinely progressing work does not. No literal string like `"I read this as"` appears anywhere in the detector.
- **Interrupts and injects.** The next near-duplicate generation is aborted mid-stream, the injection is recorded through the existing `recordInjection` (so both the `ttsr-injection` entry and the shared rule-activation record fire), and a `<system-interrupt rule="repetitive-turns">` nudge tells the model to stop restating status and take a different concrete action — or state plainly what it is blocked on.
- **Latches.** One interruption per streak; re-arms only after a dissimilar turn. A loop that *resumes* is re-interrupted.
- **Disableable.** `--ttsr-rules-disabled=repetitive-turns` silences it end to end.

## The bug manual QA caught

The first real-CLI QA run **failed** where the unit suite was green: each `--print` / `--continue` invocation is a **fresh process**, so the in-memory cross-turn state started empty every run and never armed. Resumed sessions — precisely the long-running supervision sessions this lane targets — had **zero** protection.

Fixed by rehydrating the lane at init from persisted history (`ctx.sessionManager.getEntries()`, last 8 assistant texts). The faux harness keeps one process alive across prompts, which is exactly why it could not see this.

## Evidence

**Static** — `npm run check`: exit 0 (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, `tsc --noEmit`, browser smoke). `tsc` caught two real type errors during development (the `DetectorMatch.rule` union, the readonly `ErrorShellReplacement`); both fixed, not suppressed.

**Tests** — `test/ttsr/` + `test/suite/ttsr-extension.test.ts` + `test/suite/loop-guard-detectors.test.ts`: **18 files / 326 tests passing**, nothing skipped.

**Mutation proof (not tautological coverage)** — forcing the similarity threshold `0.55 → 0.999` fails **5** tests, including both suite scenarios; reverting restores green. An earlier version of these tests passed *inertly* because the fixtures normalized to byte-identical strings and the arm used exact equality — caught and fixed by routing the arm through the same Jaccard threshold and using fixtures that genuinely differ after normalization.

**Real CLI (`senpi-qa` mock loop, zero tokens)** — new scenario `--scenario ttsr-repetitive-turns`, **4/4 PASS**: real CLI from source, isolated sandbox, `PI_OFFLINE`, real `auth.json` sha256 asserted unchanged; three chained `--continue` runs against a local fake model server scripted with near-duplicate turns. Asserts exit 0, an extra bounded turn, `repetitive-turns` present in a later request body, and the recovery marker returned.

Regression: `ttsr-collapse` **4/4**, `ttsr-leak` **4/4** — existing lanes unaffected.

Evidence saved under `local-ignore/qa-evidence/20260804-ttsr-repetitive-turns/` (gitignored).

## Notes for the reviewer

- `index.ts` was 230 pure LOC before this change; the lane pushed it to 329. Per the repo's file-size rule the touched units were extracted rather than carried: `repetitive-turns-lane.ts` (all cross-turn state and decisions) and `stream-remediation.ts` (the collapse/leak replacement construction previously inlined in `message_end`). `index.ts` is back to 250.
- No changes to `packages/ai`, `packages/agent`, or `agent-session.ts` — the lane rides the public extension API only. Cross-turn state cannot live in `StreamWatcher`, which resets every `turn_start` by design.
- `ttsr/changes.md` updated in the same increment, including expected merge-conflict zones.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new TTSR lane, `repetitive-turns`, that detects and interrupts cross-turn repetition loops, then injects a corrective nudge. Also restores cross-turn state on resumed CLI runs so the guard works across `--continue`.

- **New Features**
  - Generic cross-turn detector: normalize text (lowercase, fold digits/hex to `#`), compare with word-trigram Jaccard; three consecutive turns at ≥0.55 arms the lane.
  - Aborts the next near-duplicate mid-stream and records an injection with `<system-interrupt rule="repetitive-turns">` asking for a different concrete action.
  - Latches once per streak; re-arms after a dissimilar turn. Disable with `--ttsr-rules-disabled=repetitive-turns`.

- **Bug Fixes**
  - Cross-turn state now rehydrates at init from session history (`ctx.sessionManager.getEntries()`, last 8 assistant texts), fixing loss of state across fresh `--print` / `--continue` processes that left resumed sessions unprotected.

<sup>Written for commit a379a973e4cac838811ad2aa0b37bcfc93dfdb38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

