### PR TITLE
feat(senpi-codemode): replace eval title with required user-language summary

### DIFF
--- a/packages/coding-agent/test/suite/codemode-bridge.test.ts
+++ b/packages/coding-agent/test/suite/codemode-bridge.test.ts
@@ -110,7 +110,7 @@ async function createCodemodeHarness(options: {
 
 async function runEvalTurn(harness: Harness, code: string): Promise<string> {
 	harness.setResponses([
-		fauxAssistantMessage(fauxToolCall("eval", { language: "js", code }), { stopReason: "toolUse" }),
+		fauxAssistantMessage(fauxToolCall("eval", { language: "js", code, summary: "run eval through bridge hooks" }), { stopReason: "toolUse" }),
 		(context: FauxContext) => fauxAssistantMessage(extractToolResultText(context)),
 	]);
 

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -14,7 +14,7 @@ task-tool names are known.
 	handle and continue in their existing kernel. Completion is injected with the
 	final value/error and buffered output; use `eval({ action: "peek"|"stop",
 	cell_id })` to inspect or terminate a detached cell. A running peek preserves
-	the original code and title together with current output, phase, status
+	the original code and summary together with current output, phase, status
 	events, tool-call summaries, elapsed duration, and structured display state;
 	a terminal peek preserves the exact final result.
 - Loopback, bearer-authenticated kernel bridge with bounded JSONL frames.
@@ -127,6 +127,16 @@ updates, and transcripts remain owned by that engine.
 `isolated`, `apply`, and `merge` are accepted for compatibility but emit a
 warning because this task-engine integration has no isolation model.
 
+## Required summary
+
+Every `eval` run call MUST include a `summary` — one line in the user's
+conversational language stating what the cell does and for what purpose (e.g.
+a Korean conversation produces a Korean summary such as "src 전체에서
+legacyClient 사용처 집계"). The summary is shown in the TUI while the cell
+runs and in the finished result, so you can always tell what is running and
+why. Values longer than 80 characters are force-truncated. A run request
+without a `summary` fails with a teaching error.
+
 ## Detached cells
 
 `eval` accepts `on_timeout: "detach"|"error"`. The default is `"detach"` in
@@ -137,8 +147,8 @@ a busy error with its cell id and output tail; calls in other languages continue
 normally. Do not re-run the cell.
 
 While any cell is detached, the interactive footer shows a highlighted
-`↗ <language> · <title>` status on the extension status line (the cell id when
-the call had no title), clearing as soon as the last detached cell settles.
+`↗ <language> · <summary>` status on the extension status line (the cell id
+when the call had no summary), clearing as soon as the last detached cell settles.
 
 Use `eval({ action: "peek", cell_id })` for its state and buffered output, or
 `eval({ action: "stop", cell_id })` to cancel it. Python stop interrupts the

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,29 @@
 # senpi-codemode fork changes
 
+## Eval `summary` replaces `title` (2026-08-04)
+
+### What changed
+
+- `title` removed from the eval input surface entirely (schema, `EvalToolInput`, `EvalCellResult`, `EvalToolDetails`, renderers, detached surfaces, prompt, README, tests, QA scripts). Phase/status-event `title` is a different concept and is untouched.
+- `summary` is now REQUIRED for run requests: schema property stays optional because the flat schema object is shared with the peek/stop actions, so required-ness is enforced in `parseEvalRequest` exactly like `language`/`code`, with the teaching error: `eval run requires summary — one line in the user's language: what this cell does and for what purpose`.
+- The 80-char clamp runs in the `ToolDefinition`'s `prepareArguments` hook, which executes BEFORE schema validation, so an over-long summary can never become a validation error.
+- The schema description carries the user-language WHAT+WHY writing guide the model reads at call time.
+- Rendering: title-less header, muted summary line beneath it in transcript frames and live-update text; detached footer label is `summary ?? cellId`.
+- Back-compat: callers still sending `title` keep validating (value ignored); legacy stored results (title-only details) re-render without a label and without crashing.
+
+### Why
+
+- `title` was decorative metadata the model rarely populated meaningfully; `summary` forces a one-line, user-language description of intent at every run, improving transcript readability and downstream debugging.
+- Enforcing required-ness in the parser (not the schema) keeps the shared flat schema valid for peek/stop while still rejecting run requests that omit `summary`.
+
+### Why this cannot be expressed externally
+
+- The change spans the tool schema, request parser, type definitions, renderers, detached-cell manager, status events, prompt instructions, README, and all QA scripts — a single coordinated fork commit.
+
+### Expected merge conflict zones
+
+- `src/tool/types.ts`, `src/tool/eval-request.ts`, `src/tool/eval-tool.ts`, `src/tool/cell-runtime.ts`, `src/tool/render.ts`, `src/tool/detached-cell-manager.ts`, `src/tool/detached-cell-snapshot.ts`, `src/extension/eval-status.ts`, `src/prompt/eval-prompt.ts`, `README.md`, `test/`, `scripts/`.
+
 ## Backfill: persistent eval lifecycle and tool surface (2026-08-01)
 
 ### What changed

--- a/packages/senpi-codemode/scripts/qa-detached-peek.ts
+++ b/packages/senpi-codemode/scripts/qa-detached-peek.ts
@@ -137,7 +137,7 @@ async function main(): Promise<void> {
 			{
 				language: "py",
 				code,
-				title: "real detached peek",
+				summary: "real detached peek",
 				on_timeout: "detach",
 			},
 			undefined,

--- a/packages/senpi-codemode/scripts/qa-e2e-eval.ts
+++ b/packages/senpi-codemode/scripts/qa-e2e-eval.ts
@@ -90,6 +90,7 @@ async function runDefaultScenario(
 	const result = await session.executeTool<EvalToolDetails>("eval", {
 		language: "js",
 		code: "for(let i=0;i<3000;i++)console.log('L'+i)",
+		summary: "Print 3000 lines to verify output truncation and spill artifact",
 	});
 	const artifactPath = result.details.meta?.artifactId;
 	const spillExists = artifactPath !== undefined && existsSync(artifactPath);
@@ -97,7 +98,7 @@ async function runDefaultScenario(
 	console.log(`SPILL_EXISTS: ${spillExists}`);
 	let rubyRejected = false;
 	try {
-		await session.executeTool("eval", { language: "rb", code: "puts 1" });
+		await session.executeTool("eval", { language: "rb", code: "puts 1", summary: "Run Ruby to confirm disabled languages are rejected" });
 	} catch (error) {
 		if (error instanceof Error) rubyRejected = true;
 		else throw error;
@@ -112,14 +113,14 @@ async function runDefaultScenario(
 async function runAbortScenario(
 	session: Awaited<ReturnType<typeof createAgentSession>>["session"],
 ): Promise<void> {
-	await session.executeTool<EvalToolDetails>("eval", { language: "py", code: "x=42" });
+	await session.executeTool<EvalToolDetails>("eval", { language: "py", code: "x=42", summary: "Set Python variable x=42 before abort test" });
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(new DOMException("QA abort", "AbortError")), 500);
 	let interrupted: AgentToolResult<EvalToolDetails>;
 	try {
 		interrupted = await session.executeTool<EvalToolDetails>(
 			"eval",
-			{ language: "py", code: "while True: pass" },
+			{ language: "py", code: "while True: pass", summary: "Run infinite loop to test cooperative abort and state preservation" },
 			{ signal: controller.signal },
 		);
 	} finally {
@@ -130,7 +131,7 @@ async function runAbortScenario(
 		interrupted.details.isError === true ||
 		interruptedText.includes("QA abort") ||
 		interruptedText.toLowerCase().includes("interrupt");
-	const resumed = await session.executeTool<EvalToolDetails>("eval", { language: "py", code: "print(x)" });
+	const resumed = await session.executeTool<EvalToolDetails>("eval", { language: "py", code: "print(x)", summary: "Print x after abort to verify Python state survived" });
 	const resumedText = textOf(resumed);
 	console.log(`CANCELLED: ${cancelled}`);
 	console.log(`STATE: ${resumedText.trim()}`);

--- a/packages/senpi-codemode/scripts/qa-js-cell.ts
+++ b/packages/senpi-codemode/scripts/qa-js-cell.ts
@@ -216,7 +216,7 @@ async function runQa(options: QaOptions): Promise<void> {
 			try {
 				const result = await tool.execute(
 					`qa-cell-${index + 1}`,
-					{ language: "js", code, timeout: options.timeoutSeconds },
+					{ language: "js", code, timeout: options.timeoutSeconds, summary: `Execute JS cell #${index + 1} from QA --code args` },
 					undefined,
 					undefined,
 					qaContext,

--- a/packages/senpi-codemode/scripts/qa-render-dump.ts
+++ b/packages/senpi-codemode/scripts/qa-render-dump.ts
@@ -89,7 +89,7 @@ if (fixture === undefined) throw new TypeError("--fixture is required");
 const input: EvalToolInput = {
 	language: "py",
 	code: fixture === "success" ? "config = read('/tmp/config.json')" : "print('korean-output-test')",
-	title: fixture === "success" ? "load config" : "failed cell",
+	summary: fixture === "success" ? "load config" : "failed cell",
 };
 const statusEvents =
 	fixture === "success"
@@ -105,7 +105,7 @@ const statusEvents =
 			];
 const details: EvalToolDetails = {
 	language: "py",
-	...(fixture === "success" ? { title: "load config" } : {}),
+	...(fixture === "success" ? { summary: "load config" } : {}),
 	durationMs: fixture === "success" ? 1_250 : 900,
 	toolCalls:
 		fixture === "success"
@@ -134,7 +134,7 @@ const details: EvalToolDetails = {
 	cells: [
 		{
 			index: 0,
-			title: fixture === "success" ? "load config" : "failed cell",
+			summary: fixture === "success" ? "load config" : "failed cell",
 			code: input.code,
 			language: "py",
 			output:

--- a/packages/senpi-codemode/scripts/qa-timeout-state.ts
+++ b/packages/senpi-codemode/scripts/qa-timeout-state.ts
@@ -40,7 +40,7 @@ try {
 		// Cooperative interrupt: the runner answers SIGINT, so state must survive and
 		// the timeout message must say the kernel remains running.
 		const cooperative = await tool
-			.execute("qa-coop", { language: "py", code: "x=42\nimport time\ntime.sleep(30)", on_timeout: "error", timeout: 1 }, undefined, undefined, ctx)
+			.execute("qa-coop", { language: "py", code: "x=42\nimport time\ntime.sleep(30)", on_timeout: "error", timeout: 1, summary: "Sleep 30s with 1s timeout to test cooperative interrupt and state preservation" }, undefined, undefined, ctx)
 			.then(() => "UNEXPECTED-SUCCESS", (error: Error) => `${error.name}: ${error.message}`);
 		console.log(`COOPERATIVE_TIMEOUT: ${cooperative}`);
 

--- a/packages/senpi-codemode/src/extension/eval-status.ts
+++ b/packages/senpi-codemode/src/extension/eval-status.ts
@@ -28,7 +28,7 @@ function packLabels(labels: readonly string[], budget: number): string {
 }
 
 function labelOf(entry: EvalDetachedCellStatusEntry): string {
-	return entry.title === undefined || entry.title.length === 0 ? entry.cellId : entry.title;
+	return entry.summary === undefined || entry.summary.length === 0 ? entry.cellId : entry.summary;
 }
 
 /**

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -59,7 +59,7 @@ type Context = Readonly<Record<string, ContextValue>>;
 type EvalPromptExample = {
 	readonly caption: string;
 	readonly language: keyof EnabledLanguages;
-	readonly title: string;
+	readonly summary: string;
 	readonly code: string;
 };
 
@@ -71,19 +71,19 @@ const REUSE_CHAIN_EXAMPLES = [
 	{
 		caption: "First call — set up once",
 		language: "py",
-		title: "collect targets",
+		summary: "Count all TypeScript source files under src/ excluding tests",
 		code: "from pathlib import Path\nfrom collections import Counter\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\nprint(len(files))",
 	},
 	{
 		caption: "Second call — reuse `files`, batch-read in one cell",
 		language: "py",
-		title: "scan usages",
+		summary: "Find which files reference legacyClient so we know what to migrate",
 		code: "hits = Counter()\nfor p in files:\n    hits[p.name] = read(p).count('legacyClient')\ndisplay({k: v for k, v in hits.items() if v})",
 	},
 	{
 		caption: "Third call — reuse results, fan out session tools in parallel",
 		language: "py",
-		title: "confirm callsites",
+		summary: "Confirm exact callsite lines in each directory to plan the refactor",
 		code: "dirs = ['src/core', 'src/tools']\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))",
 	},
 ] as const satisfies readonly EvalPromptExample[];
@@ -122,7 +122,7 @@ Fields:
 
 - \`language\` — {{#if py}}\`"py"\` IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}\`"js"\` persistent JavaScript VM{{/if}}{{#if rb}}{{#ifAny py js}}, {{/ifAny}}\`"rb"\` persistent Ruby kernel{{/if}}{{#if jl}}{{#ifAny py js rb}}, {{/ifAny}}\`"jl"\` persistent Julia kernel{{/if}}.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
+- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long{{#if spawns}} non-agent{{/if}} tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
@@ -214,7 +214,7 @@ export function buildEvalPrompt(
 	};
 	const examples = REUSE_CHAIN_EXAMPLES.filter((example) => enabled[example.language])
 		.map((example) => {
-			const call = { language: example.language, title: example.title, code: example.code };
+			const call = { language: example.language, summary: example.summary, code: example.code };
 			return `### ${example.caption}\n\`\`\`json\n${JSON.stringify(call, null, 2)}\n\`\`\``;
 		})
 		.join("\n\n");

--- a/packages/senpi-codemode/src/tool/cell-runtime.ts
+++ b/packages/senpi-codemode/src/tool/cell-runtime.ts
@@ -119,7 +119,7 @@ export class CellResultBuilder {
 		return {
 			language: this.#state.input.language,
 			languages: [this.#state.input.language],
-			...(this.#state.input.title === undefined ? {} : { title: this.#state.input.title }),
+			...(this.#state.input.summary === undefined ? {} : { summary: this.#state.input.summary }),
 			durationMs: this.#state.durationMs,
 			toolCalls: [...this.#state.toolCalls],
 			truncated: output?.truncated ?? false,
@@ -128,7 +128,7 @@ export class CellResultBuilder {
 			cells: [
 				{
 					index: 0,
-					...(this.#state.input.title === undefined ? {} : { title: this.#state.input.title }),
+					...(this.#state.input.summary === undefined ? {} : { summary: this.#state.input.summary }),
 					code: this.#state.input.code,
 					language: this.#state.input.language,
 					output: this.#state.output,
@@ -146,12 +146,12 @@ export class CellResultBuilder {
 	}
 
 	#liveUpdateText(): string {
-		const title = this.#state.input.title === undefined ? "" : ` ${this.#state.input.title}`;
+		const summary = this.#state.input.summary === undefined ? "" : ` ${this.#state.input.summary}`;
 		const aggregateOutput = this.#output.aggregateText();
 		const outputLines = aggregateOutput.split("\n");
 		const hasTrailingNewline = aggregateOutput.endsWith("\n");
 		if (hasTrailingNewline) outputLines.pop();
 		const output = `${outputLines.slice(-8).join("\n")}${hasTrailingNewline ? "\n" : ""}`;
-		return `1/1 cells ${this.#state.status}\n[1] ${this.#state.input.language}${title} ${this.#state.status}${output.length === 0 ? "" : `\n${output}`}`;
+		return `1/1 cells ${this.#state.status}\n[1] ${this.#state.input.language}${summary} ${this.#state.status}${output.length === 0 ? "" : `\n${output}`}`;
 	}
 }

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -50,7 +50,7 @@ export interface EvalDetachedCellNotifier {
 export interface EvalDetachedCellStatusEntry {
 	readonly cellId: string;
 	readonly language: EvalLanguage;
-	readonly title?: string;
+	readonly summary?: string;
 	readonly startedAtMs: number;
 }
 
@@ -193,7 +193,7 @@ export class EvalDetachedCellManager {
 				cellId: cell.cellId,
 				language: cell.input.language,
 				startedAtMs: cell.startedAtMs,
-				...(cell.input.title === undefined ? {} : { title: cell.input.title }),
+				...(cell.input.summary === undefined ? {} : { summary: cell.input.summary }),
 			})),
 		);
 	}

--- a/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
@@ -52,14 +52,14 @@ function fallbackResult(input: EvalToolInput): AgentToolResult<EvalToolDetails> 
 		details: {
 			language: input.language,
 			languages: [input.language],
-			...(input.title === undefined ? {} : { title: input.title }),
+			...(input.summary === undefined ? {} : { summary: input.summary }),
 			durationMs: 0,
 			toolCalls: [],
 			truncated: false,
 			cells: [
 				{
 					index: 0,
-					...(input.title === undefined ? {} : { title: input.title }),
+					...(input.summary === undefined ? {} : { summary: input.summary }),
 					code: input.code,
 					language: input.language,
 					output: "",

--- a/packages/senpi-codemode/src/tool/eval-request.ts
+++ b/packages/senpi-codemode/src/tool/eval-request.ts
@@ -1,7 +1,20 @@
 import type { ExtensionContext } from "@code-yeongyu/senpi";
-import type { EvalControlInput, EvalToolInput, EvalToolRequest } from "./types.ts";
+import { EVAL_SUMMARY_MAX_LENGTH, type EvalControlInput, type EvalToolInput, type EvalToolRequest } from "./types.ts";
 
 const NON_INTERACTIVE_MODES = new Set(["print", "json"]);
+
+const ELLIPSIS = "...";
+
+// Harness-side enforcement of the schema maxLength: the tool advertises the limit, but an
+// over-limit value is force-truncated here (prepareArguments runs before schema validation)
+// instead of failing the call.
+export function clampEvalSummary(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().replace(/\s+/gu, " ");
+	if (normalized.length === 0) return undefined;
+	if (normalized.length <= EVAL_SUMMARY_MAX_LENGTH) return normalized;
+	return `${normalized.slice(0, EVAL_SUMMARY_MAX_LENGTH - ELLIPSIS.length)}${ELLIPSIS}`;
+}
 
 export function parseEvalRequest(params: unknown): EvalToolRequest {
 	if (!isRecord(params)) throw new TypeError("eval parameters must be an object");
@@ -14,13 +27,18 @@ export function parseEvalRequest(params: unknown): EvalToolRequest {
 		throw new TypeError(`Unknown eval action "${String(params.action)}"`);
 	if (!isEvalLanguage(params.language)) throw new TypeError("eval run requires language");
 	if (typeof params.code !== "string") throw new TypeError("eval run requires code");
+	const summary = clampEvalSummary(params.summary);
+	if (summary === undefined)
+		throw new TypeError(
+			"eval run requires summary — one line in the user's language: what this cell does and for what purpose",
+		);
 	if (params.on_timeout !== undefined && params.on_timeout !== "detach" && params.on_timeout !== "error")
 		throw new TypeError(`Unknown eval on_timeout value "${String(params.on_timeout)}"`);
 	return {
 		language: params.language,
 		code: params.code,
+		summary,
 		...(params.action === "run" ? { action: "run" as const } : {}),
-		...(typeof params.title === "string" ? { title: params.title } : {}),
 		...(typeof params.timeout === "number" ? { timeout: params.timeout } : {}),
 		...(params.on_timeout === "detach" || params.on_timeout === "error" ? { on_timeout: params.on_timeout } : {}),
 		...(typeof params.reset === "boolean" ? { reset: params.reset } : {}),

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -8,10 +8,16 @@ import { abortError, CellExecution, defaultTimeoutFactory } from "./cell-executi
 import { CellHandler, type CellState } from "./cell-handler.ts";
 import { EvalDetachedCellManager } from "./detached-cell-manager.ts";
 import { detachedKernelBusyError, executeEvalControl, resultAfterDetach } from "./detached-eval-result.ts";
-import { evalTimeoutBehavior, isEvalControlRequest, parseEvalRequest } from "./eval-request.ts";
+import { clampEvalSummary, evalTimeoutBehavior, isEvalControlRequest, parseEvalRequest } from "./eval-request.ts";
 import type { CreateEvalToolOptions, EvalCellInvocation } from "./eval-tool-options.ts";
 import { describeTimeoutState } from "./interrupt-note.ts";
-import { createEvalInputSchema, type EvalInputSchema, type EvalToolDetails, enabledLanguageList } from "./types.ts";
+import {
+	createEvalInputSchema,
+	type EvalInputSchema,
+	type EvalToolDetails,
+	type EvalToolRequest,
+	enabledLanguageList,
+} from "./types.ts";
 
 export type { EvalTimeoutFactory } from "./cell-execution.ts";
 export type { CreateEvalToolOptions } from "./eval-tool-options.ts";
@@ -35,6 +41,15 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 		promptGuidelines: [...prompt.promptGuidelines],
 		parameters,
 		executionMode: "sequential",
+		prepareArguments: (args) => {
+			if (typeof args !== "object" || args === null) return args as EvalToolRequest;
+			const record = args as Record<string, unknown>;
+			if (record.action === "peek" || record.action === "stop") return args as EvalToolRequest;
+			const summary = clampEvalSummary(record.summary);
+			if (summary === undefined) delete record.summary;
+			else record.summary = summary;
+			return args as EvalToolRequest;
+		},
 		...(options.renderers?.renderCall === undefined ? {} : { renderCall: options.renderers.renderCall }),
 		...(options.renderers?.renderResult === undefined ? {} : { renderResult: options.renderers.renderResult }),
 		async execute(toolCallId, params, signal, onUpdate, ctx) {

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -255,8 +255,7 @@ function renderPrefixed(text: string, environment: RenderEnvironment, prefixStyl
 
 function cellHeader(cell: EvalCellResult, environment: RenderEnvironment, badges: CellBadges): string {
 	const presentation = cellPresentation(cell.status, environment.spinnerFrame);
-	const title = cell.title === undefined ? "" : ` ${cell.title}`;
-	let header = `eval ${cell.language}${title} ${presentation.label} ${presentation.icon}`;
+	let header = `eval ${cell.language} ${presentation.label} ${presentation.icon}`;
 	if (cell.durationMs !== undefined) header += ` · ${formatDuration(cell.durationMs)}`;
 	if (badges.reset) header += " · reset";
 	if (badges.timeout !== undefined) header += ` · timeout ${badges.timeout}s`;
@@ -511,6 +510,16 @@ function renderCell(cell: EvalCellResult, environment: RenderEnvironment, badges
 		continuation: "│  ",
 		color: "borderAccent",
 	});
+	if (cell.summary !== undefined) {
+		appendLines(
+			lines,
+			renderPrefixed(style(environment.theme, "muted", cell.summary), environment, {
+				prefix: "│ ",
+				continuation: "│ ",
+				color: "muted",
+			}),
+		);
+	}
 	const innerWidth = Math.max(1, environment.width - 2);
 	const codePreview = previewText(
 		highlightedCode(cell.code, cell.language, environment.theme),
@@ -726,7 +735,6 @@ function resultHeader(
 	status: "running" | "done" | "error",
 	theme: Theme | undefined,
 ): string {
-	const title = details?.title === undefined ? "" : ` ${details.title}`;
 	let color: ThemeColor;
 	switch (status) {
 		case "running":
@@ -739,7 +747,7 @@ function resultHeader(
 			color = "error";
 			break;
 	}
-	return style(theme, color, `eval ${details?.language ?? "?"}${title} ${status}`);
+	return style(theme, color, `eval ${details?.language ?? "?"} ${status}`);
 }
 
 function resultMetadata(
@@ -771,11 +779,13 @@ export function renderEvalCall(
 		return component;
 	}
 	if (theme === undefined && context.spinnerFrame === undefined) {
-		const title = args.title === undefined ? "" : ` ${args.title}`;
 		const reset = args.reset === true ? " reset" : "";
 		const timeout = args.timeout === undefined ? "" : ` timeout ${args.timeout}s`;
 		component.setBlocks([
-			{ kind: "text", text: style(theme, "toolTitle", `eval ${args.language}${title}${reset}${timeout}`) },
+			{ kind: "text", text: style(theme, "toolTitle", `eval ${args.language}${reset}${timeout}`) },
+			...(args.summary === undefined
+				? []
+				: [{ kind: "text" as const, text: style(theme, "muted", args.summary) }]),
 			{
 				kind: "text",
 				text: style(theme, "mdCodeBlock", args.code.trim().length > 0 ? args.code : "..."),
@@ -799,7 +809,7 @@ export function renderEvalCall(
 				};
 				const cell: EvalCellResult = {
 					index: 0,
-					...(args.title === undefined ? {} : { title: args.title }),
+					...(args.summary === undefined ? {} : { summary: args.summary }),
 					code: args.code,
 					language: args.language,
 					output: "",
@@ -850,6 +860,9 @@ export function renderEvalResult(
 	const status = resultStatus(details, options, context.isError);
 	const blocks: RenderBlock[] = [
 		{ kind: "text", text: resultHeader(details, status, theme) },
+		...(details?.summary === undefined
+			? []
+			: [{ kind: "text" as const, text: style(theme, "muted", details.summary) }]),
 		...resultMetadata(details, options, theme),
 		{ kind: "blank" },
 	];

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -11,11 +11,13 @@ export function enabledLanguageList(enabled: EnabledEvalLanguages): EvalLanguage
 	return evalLanguageOrder.filter((language) => enabled[language]);
 }
 
+export const EVAL_SUMMARY_MAX_LENGTH = 80;
+
 export interface EvalToolInput {
 	readonly language: EvalLanguage;
 	readonly code: string;
 	readonly action?: "run";
-	readonly title?: string;
+	readonly summary: string;
 	readonly timeout?: number;
 	readonly on_timeout?: "detach" | "error";
 	readonly reset?: boolean;
@@ -38,7 +40,13 @@ const fullEvalInputSchema = Type.Object({
 		Type.Union([Type.Literal("py"), Type.Literal("js"), Type.Literal("rb"), Type.Literal("jl")]),
 	),
 	code: Type.Optional(Type.String({ description: "Cell body, verbatim." })),
-	title: Type.Optional(Type.String({ description: "Short transcript label." })),
+	summary: Type.Optional(
+		Type.String({
+			maxLength: EVAL_SUMMARY_MAX_LENGTH,
+			description:
+				"REQUIRED for run. ONE line in the USER'S conversational language (Korean conversation -> Korean summary) stating WHAT this cell does and FOR WHAT PURPOSE; shown in the TUI while the cell runs. Longer values are force-truncated to 80 chars.",
+		}),
+	),
 	timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
 	on_timeout: Type.Optional(
 		Type.Union([Type.Literal("detach"), Type.Literal("error")], {
@@ -68,7 +76,13 @@ export function createEvalInputSchema(enabled: EnabledEvalLanguages): EvalInputS
 			),
 			language: Type.Optional(languageSchema),
 			code: Type.Optional(Type.String({ description: "Cell body, verbatim." })),
-			title: Type.Optional(Type.String({ description: "Short transcript label." })),
+			summary: Type.Optional(
+				Type.String({
+					maxLength: EVAL_SUMMARY_MAX_LENGTH,
+					description:
+						"REQUIRED for run. ONE line in the USER'S conversational language (Korean conversation -> Korean summary) stating WHAT this cell does and FOR WHAT PURPOSE; shown in the TUI while the cell runs. Longer values are force-truncated to 80 chars.",
+				}),
+			),
 			timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
 			on_timeout: Type.Optional(
 				Type.Union([Type.Literal("detach"), Type.Literal("error")], {
@@ -134,7 +148,7 @@ export type EvalDisplayOutput =
 
 export type EvalCellResult = {
 	readonly index: number;
-	readonly title?: string;
+	readonly summary?: string;
 	readonly code: string;
 	readonly language: EvalLanguage;
 	readonly output: string;
@@ -148,7 +162,7 @@ export type EvalCellResult = {
 export interface EvalToolDetails {
 	readonly language: EvalLanguage;
 	readonly languages?: readonly EvalLanguage[];
-	readonly title?: string;
+	readonly summary?: string;
 	readonly durationMs: number;
 	readonly toolCalls: readonly EvalToolCallSummary[];
 	readonly truncated: boolean;

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -18,7 +18,7 @@ Fields:
 
 - \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM, \`"rb"\` persistent Ruby kernel, \`"jl"\` persistent Julia kernel.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
+- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long non-agent tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
@@ -89,7 +89,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "collect targets",
+  "summary": "Count all TypeScript source files under src/ excluding tests",
   "code": "from pathlib import Path\\nfrom collections import Counter\\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\\nprint(len(files))"
 }
 \`\`\`
@@ -98,7 +98,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "scan usages",
+  "summary": "Find which files reference legacyClient so we know what to migrate",
   "code": "hits = Counter()\\nfor p in files:\\n    hits[p.name] = read(p).count('legacyClient')\\ndisplay({k: v for k, v in hits.items() if v})"
 }
 \`\`\`
@@ -107,7 +107,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "confirm callsites",
+  "summary": "Confirm exact callsite lines in each directory to plan the refactor",
   "code": "dirs = ['src/core', 'src/tools']\\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))"
 }
 \`\`\`
@@ -138,7 +138,7 @@ Fields:
 
 - \`language\` — \`"js"\` persistent JavaScript VM.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
+- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first.
@@ -213,7 +213,7 @@ Fields:
 
 - \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`title\` (optional) — short transcript label (e.g. \`"imports"\`).
+- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
@@ -269,7 +269,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "collect targets",
+  "summary": "Count all TypeScript source files under src/ excluding tests",
   "code": "from pathlib import Path\\nfrom collections import Counter\\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\\nprint(len(files))"
 }
 \`\`\`
@@ -278,7 +278,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "scan usages",
+  "summary": "Find which files reference legacyClient so we know what to migrate",
   "code": "hits = Counter()\\nfor p in files:\\n    hits[p.name] = read(p).count('legacyClient')\\ndisplay({k: v for k, v in hits.items() if v})"
 }
 \`\`\`
@@ -287,7 +287,7 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 \`\`\`json
 {
   "language": "py",
-  "title": "confirm callsites",
+  "summary": "Confirm exact callsite lines in each directory to plan the refactor",
   "code": "dirs = ['src/core', 'src/tools']\\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))"
 }
 \`\`\`

--- a/packages/senpi-codemode/test/agent-bridge.test.ts
+++ b/packages/senpi-codemode/test/agent-bridge.test.ts
@@ -63,7 +63,7 @@ describe("agent bridge", () => {
 		// When
 		const evalResult = await tool.execute(
 			"cell-1",
-			{ language: "js", code: "await agent('summarize x')" },
+			{ language: "js", code: "await agent('summarize x')", summary: "spawn summarizer" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -117,7 +117,7 @@ describe("agent bridge", () => {
 		// When
 		await tool.execute(
 			"cell-invalid",
-			{ language: "js", code: "agent('')" },
+			{ language: "js", code: "agent('')", summary: "invalid agent call" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),

--- a/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
+++ b/packages/senpi-codemode/test/eval-bridge-finalization.test.ts
@@ -88,7 +88,7 @@ describe("eval bridge finalization", () => {
 		});
 		const execution = createTool(kernel, executeTool).execute(
 			"bridge-timeout",
-			{ language: "js", code: "await tool.demo({})" },
+			{ language: "js", code: "await tool.demo({})", summary: "bridge timeout" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -111,7 +111,7 @@ describe("eval bridge finalization", () => {
 				vi.fn(async () => ({ content: [], details: {} })),
 			).execute(
 				"bridge-rejection",
-				{ language: "js", code: "await tool.demo({})" },
+				{ language: "js", code: "await tool.demo({})", summary: "bridge rejection" },
 				undefined,
 				undefined,
 				fakeExtensionContext(),
@@ -142,7 +142,7 @@ describe("eval bridge finalization", () => {
 		});
 		const execution = createTool(kernel, executeTool).execute(
 			"bridge-success-timeout",
-			{ language: "js", code: "await tool.demo({})", timeout: 1 },
+			{ language: "js", code: "await tool.demo({})", timeout: 1, summary: "bridge success timeout" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),

--- a/packages/senpi-codemode/test/eval-cell-id-reuse.test.ts
+++ b/packages/senpi-codemode/test/eval-cell-id-reuse.test.ts
@@ -38,7 +38,13 @@ async function run(
 	language: "js" | "py",
 	code: string,
 ): Promise<AgentToolResult<unknown>> {
-	return await tool.execute(cellId, { language, code }, undefined, undefined, interactiveContext());
+	return await tool.execute(
+		cellId,
+		{ language, code, summary: "reuse probe" },
+		undefined,
+		undefined,
+		interactiveContext(),
+	);
 }
 
 async function detach(
@@ -50,7 +56,7 @@ async function detach(
 	const started = kernel.deferNextRun();
 	const execution = tool.execute(
 		cellId,
-		{ language, code: "await forever", on_timeout: "detach" },
+		{ language, code: "await forever", on_timeout: "detach", summary: "detach probe" },
 		undefined,
 		undefined,
 		interactiveContext(),

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -64,7 +64,7 @@ async function detach(
 	const started = kernel.deferNextRun();
 	const execution = tool.execute(
 		cellId,
-		{ language, code: "await forever", on_timeout: "detach" },
+		{ language, code: "await forever", summary: "detach long-running cell", on_timeout: "detach" },
 		undefined,
 		undefined,
 		interactiveContext(),
@@ -134,14 +134,14 @@ describe("eval detached cells", () => {
 		await expect(
 			tool.execute(
 				"blocked-js",
-				{ language: "js", code: "sideEffect()" },
+				{ language: "js", code: "sideEffect()", summary: "blocked js side effect" },
 				undefined,
 				undefined,
 				interactiveContext(),
 			),
 		).rejects.toThrow(/busy running detached cell busy-js[\s\S]*still computing/u);
 		await expect(
-			tool.execute("py-cell", { language: "py", code: "answer = 42" }, undefined, undefined, interactiveContext()),
+			tool.execute("py-cell", { language: "py", code: "answer = 42", summary: "compute answer in python" }, undefined, undefined, interactiveContext()),
 		).resolves.toSatisfy((value: AgentToolResult<unknown>) => textOf(value).includes("py-ok"));
 
 		await manager.stop("busy-js");
@@ -201,7 +201,7 @@ describe("eval detached cells", () => {
 		const tool = createTool(new EvalDetachedCellManager(), [["js", kernel]]);
 		const execution = tool.execute(
 			"print-timeout",
-			{ language: "js", code: "await forever" },
+			{ language: "js", code: "await forever", summary: "print mode timeout" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -226,7 +226,7 @@ describe("eval detached cells", () => {
 		const completionStarted = completionKernel.deferNextRun();
 		const completion = completionTool.execute(
 			"completion-wins",
-			{ language: "js", code: "return 1", on_timeout: "detach" },
+			{ language: "js", code: "return 1", summary: "completion race", on_timeout: "detach" },
 			undefined,
 			undefined,
 			interactiveContext(),
@@ -306,17 +306,17 @@ describe("eval detached cell status emissions", () => {
 		return { emissions, onStatusChange: (entries) => emissions.push([...entries]) };
 	}
 
-	async function detachTitled(
+	async function detachSummarized(
 		tool: ReturnType<typeof createTool>,
 		kernel: FakeKernel,
 		cellId: string,
-		title: string,
+		summary: string,
 		language: "js" | "py" = "js",
 	): Promise<void> {
 		const started = kernel.deferNextRun();
 		const execution = tool.execute(
 			cellId,
-			{ language, code: "await forever", title, on_timeout: "detach" },
+			{ language, code: "await forever", summary, on_timeout: "detach" },
 			undefined,
 			undefined,
 			interactiveContext(),
@@ -336,10 +336,10 @@ describe("eval detached cell status emissions", () => {
 		const kernel = new FakeKernel([]);
 		const tool = createTool(manager, [["js", kernel]]);
 
-		await detachTitled(tool, kernel, "status-cell", "numpy feather rerun");
+		await detachSummarized(tool, kernel, "status-cell", "numpy feather rerun");
 
 		expect(status.emissions).toEqual([
-			[{ cellId: "status-cell", language: "js", title: "numpy feather rerun", startedAtMs: expect.any(Number) }],
+			[{ cellId: "status-cell", language: "js", summary: "numpy feather rerun", startedAtMs: expect.any(Number) }],
 		]);
 
 		kernel.completeDeferredRun(result("status-cell", "42"));
@@ -363,24 +363,24 @@ describe("eval detached cell status emissions", () => {
 			["py", py],
 		]);
 
-		await detachTitled(tool, js, "js-cell", "bundle build", "js");
-		await detachTitled(tool, py, "py-cell", "strip repairs", "py");
+		await detachSummarized(tool, js, "js-cell", "bundle build", "js");
+		await detachSummarized(tool, py, "py-cell", "strip repairs", "py");
 
 		expect(status.emissions.at(-1)).toEqual([
-			{ cellId: "js-cell", language: "js", title: "bundle build", startedAtMs: expect.any(Number) },
-			{ cellId: "py-cell", language: "py", title: "strip repairs", startedAtMs: expect.any(Number) },
+			{ cellId: "js-cell", language: "js", summary: "bundle build", startedAtMs: expect.any(Number) },
+			{ cellId: "py-cell", language: "py", summary: "strip repairs", startedAtMs: expect.any(Number) },
 		]);
 
 		await manager.stop("js-cell");
 
 		expect(status.emissions.at(-1)).toEqual([
-			{ cellId: "py-cell", language: "py", title: "strip repairs", startedAtMs: expect.any(Number) },
+			{ cellId: "py-cell", language: "py", summary: "strip repairs", startedAtMs: expect.any(Number) },
 		]);
 		await manager.stop("py-cell");
 		await manager.flushNotifications();
 	});
 
-	it("omits the title when the cell had none and stays silent for cells that never detach", async () => {
+	it("omits the summary when the cell had none and stays silent for cells that never detach", async () => {
 		vi.useFakeTimers();
 		const status = statusRecorder();
 		const manager = new EvalDetachedCellManager({
@@ -390,7 +390,7 @@ describe("eval detached cell status emissions", () => {
 		const kernel = new FakeKernel([result("plain-cell", "1")]);
 		const tool = createTool(manager, [["js", kernel]]);
 
-		await tool.execute("plain-cell", { language: "js", code: "1" }, undefined, undefined, interactiveContext());
+		await tool.execute("plain-cell", { language: "js", code: "1", summary: "plain no detach" }, undefined, undefined, interactiveContext());
 
 		expect(status.emissions).toEqual([]);
 
@@ -399,7 +399,7 @@ describe("eval detached cell status emissions", () => {
 		const started = detachedKernel.deferNextRun();
 		const execution = detachedTool.execute(
 			"untitled-cell",
-			{ language: "js", code: "await forever", on_timeout: "detach" },
+			{ language: "js", code: "await forever", summary: "untitled detached", on_timeout: "detach" },
 			undefined,
 			undefined,
 			interactiveContext(),
@@ -409,7 +409,7 @@ describe("eval detached cell status emissions", () => {
 		await execution;
 
 		expect(status.emissions).toEqual([
-			[{ cellId: "untitled-cell", language: "js", startedAtMs: expect.any(Number) }],
+			[{ cellId: "untitled-cell", language: "js", summary: "untitled detached", startedAtMs: expect.any(Number) }],
 		]);
 		await manager.stop("untitled-cell");
 		await manager.flushNotifications();

--- a/packages/senpi-codemode/test/eval-detached-peek.test.ts
+++ b/packages/senpi-codemode/test/eval-detached-peek.test.ts
@@ -53,7 +53,7 @@ async function startRichDetachedCell() {
 		{
 			language: "js",
 			code: source,
-			title: "collect progress",
+			summary: "collect progress",
 			on_timeout: "detach",
 		},
 		undefined,
@@ -97,7 +97,7 @@ describe("detached eval peek", () => {
 			code: source,
 			language: "js",
 			status: "detached",
-			title: "collect progress",
+			summary: "collect progress",
 		});
 		expect(cell.output).toContain("before detach");
 		expect(cell.durationMs).toBeGreaterThanOrEqual(1_000);
@@ -156,7 +156,7 @@ describe("detached eval peek", () => {
 			{
 				language: "js",
 				code: "display({ answer: 42 })",
-				title: "terminal result",
+				summary: "terminal result",
 				on_timeout: "detach",
 			},
 			undefined,
@@ -188,7 +188,7 @@ describe("detached eval peek", () => {
 			code: "display({ answer: 42 })",
 			durationMs: 75,
 			status: "complete",
-			title: "terminal result",
+			summary: "terminal result",
 		});
 		expect(peek.details.phase).toBe("finalizing");
 		expect(peek.details.jsonOutputs).toEqual([{ answer: 42 }]);

--- a/packages/senpi-codemode/test/eval-detached-settlement.test.ts
+++ b/packages/senpi-codemode/test/eval-detached-settlement.test.ts
@@ -36,7 +36,7 @@ function requireCell(resultValue: AgentToolResult<EvalToolDetails>) {
 describe("detached eval settlement", () => {
 	it("stops reading the live provider after terminal settlement", () => {
 		const manager = new EvalDetachedCellManager();
-		const input = { language: "js" as const, code: "42", title: "provider" };
+		const input = { language: "js" as const, code: "42", summary: "provider" };
 		const cell = manager.create("provider-cell", input);
 		const provider = vi.fn(
 			(): AgentToolResult<EvalToolDetails> => ({
@@ -44,7 +44,7 @@ describe("detached eval settlement", () => {
 				details: {
 					language: "js",
 					languages: ["js"],
-					title: "provider",
+					summary: "provider",
 					durationMs: 0,
 					toolCalls: [],
 					truncated: false,
@@ -80,7 +80,7 @@ describe("detached eval settlement", () => {
 		const lateCompletion = new Deferred<void>();
 		const execution = tool.execute(
 			"cancelled-cell",
-			{ language: "js", code: "await forever", on_timeout: "detach" },
+			{ language: "js", code: "await forever", summary: "detach then settle", on_timeout: "detach" },
 			undefined,
 			(update) => {
 				if (update.details.cells?.[0]?.status === "complete") lateCompletion.resolve(undefined);

--- a/packages/senpi-codemode/test/eval-display-parity.test.ts
+++ b/packages/senpi-codemode/test/eval-display-parity.test.ts
@@ -39,7 +39,7 @@ describe("eval display text parity", () => {
 		// When
 		const toolResult = await createTool(kernel).execute(
 			"display-order",
-			{ language: "js", code: "print('before'); display({answer: 42}); print('after')" },
+			{ language: "js", code: "print('before'); display({answer: 42}); print('after')", summary: "display order" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -58,7 +58,7 @@ describe("eval display text parity", () => {
 		// When
 		const toolResult = await createTool(kernel).execute(
 			"empty",
-			{ language: "js", code: "undefined" },
+			{ language: "js", code: "undefined", summary: "empty cell" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -82,7 +82,7 @@ describe("eval display text parity", () => {
 		// When
 		const toolResult = await createTool(kernel).execute(
 			"large-display",
-			{ language: "js", code: "display(value)" },
+			{ language: "js", code: "display(value)", summary: "large display" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),

--- a/packages/senpi-codemode/test/eval-render-fixtures.ts
+++ b/packages/senpi-codemode/test/eval-render-fixtures.ts
@@ -36,7 +36,7 @@ export function callContext(options?: RenderContextOptions): CallContext;
 export function callContext(input?: EvalComponent | RenderContextOptions): CallContext {
 	const options = resolveContextOptions(input, false);
 	return {
-		args: options.args ?? { language: "js", code: "" },
+		args: options.args ?? { language: "js", code: "", summary: "render fixture" },
 		toolCallId: "eval-render-call",
 		invalidate: () => {},
 		lastComponent: options.lastComponent,
@@ -59,7 +59,7 @@ export function resultContext(options?: RenderContextOptions): ResultContext;
 export function resultContext(input?: EvalComponent | RenderContextOptions, showImages = false): ResultContext {
 	const options = resolveContextOptions(input, showImages);
 	return {
-		args: options.args ?? { language: "js", code: "" },
+		args: options.args ?? { language: "js", code: "", summary: "render fixture" },
 		toolCallId: "eval-render-result",
 		invalidate: () => {},
 		lastComponent: options.lastComponent,

--- a/packages/senpi-codemode/test/eval-render-preview.test.ts
+++ b/packages/senpi-codemode/test/eval-render-preview.test.ts
@@ -9,6 +9,7 @@ describe("eval renderer preview", () => {
 		const givenArgs = {
 			language: "js",
 			code: codeLines.join("\n"),
+			summary: "six line preview",
 		} satisfies Parameters<typeof renderEvalCall>[0];
 
 		// When
@@ -143,6 +144,7 @@ describe("eval renderer preview", () => {
 		const givenArgs = {
 			language: "js",
 			code: codeLines.join("\n"),
+			summary: "show everything",
 		} satisfies Parameters<typeof renderEvalCall>[0];
 		const givenResult = evalResult(
 			{ language: "js", durationMs: 1, toolCalls, truncated: false },
@@ -187,14 +189,16 @@ describe("eval renderer preview", () => {
 		const givenArgs = {
 			language: "js",
 			code: codeLines.join("\n"),
+			summary: "large listing",
 		} satisfies Parameters<typeof renderEvalCall>[0];
 
 		// When
 		const lines = renderEvalCall(givenArgs, undefined, callContext({ expanded: true })).render(80);
 
 		// Then
-		expect.soft(lines).toHaveLength(codeLines.length + 1);
-		expect.soft(lines[1]).toBe(codeLines[0]);
+		expect.soft(lines).toHaveLength(codeLines.length + 2);
+		expect.soft(lines[1]).toBe("large listing");
+		expect.soft(lines[2]).toBe(codeLines[0]);
 		expect.soft(lines.at(-1)).toBe(codeLines.at(-1));
 	});
 

--- a/packages/senpi-codemode/test/eval-render-state.test.ts
+++ b/packages/senpi-codemode/test/eval-render-state.test.ts
@@ -19,7 +19,7 @@ describe("eval renderer state", () => {
 		const givenResult = evalResult(
 			{
 				language: "js",
-				title: "analysis",
+				summary: "analysis",
 				phase: "summarizing",
 				durationMs: 11,
 				toolCalls: [],
@@ -42,8 +42,8 @@ describe("eval renderer state", () => {
 		const metadataText = lines.join("\n");
 		expect.soft(statusLine).toContain("eval");
 		expect.soft(statusLine).toContain("js");
-		expect.soft(statusLine).toContain("analysis");
 		expect.soft(statusLine).toContain("done");
+		expect.soft(metadataText).toContain("analysis");
 		expect.soft(metadataText).toContain("phase");
 		expect.soft(metadataText).toContain("summarizing");
 		expect.soft(metadataText).toContain("took 11ms");
@@ -262,7 +262,7 @@ describe("eval renderer state", () => {
 	it("Given call badges and cells in every lifecycle state when rendered then headers expose icons and formatted durations", () => {
 		// Given
 		const call = renderEvalCall(
-			{ language: "py", code: "work()", title: "resettable", reset: true, timeout: 3 },
+			{ language: "py", code: "work()", summary: "resettable", reset: true, timeout: 3 },
 			undefined,
 			callContext({ spinnerFrame: 0 }),
 		);
@@ -273,10 +273,10 @@ describe("eval renderer state", () => {
 				toolCalls: [],
 				truncated: false,
 				cells: [
-					{ index: 0, title: "queued", code: "queued()", language: "py", output: "", status: "pending" },
+					{ index: 0, summary: "queued", code: "queued()", language: "py", output: "", status: "pending" },
 					{
 						index: 1,
-						title: "active",
+						summary: "active",
 						code: "active()",
 						language: "py",
 						output: "",
@@ -285,7 +285,7 @@ describe("eval renderer state", () => {
 					},
 					{
 						index: 2,
-						title: "finished",
+						summary: "finished",
 						code: "finished()",
 						language: "py",
 						output: "ok",
@@ -294,7 +294,7 @@ describe("eval renderer state", () => {
 					},
 					{
 						index: 3,
-						title: "broken",
+						summary: "broken",
 						code: "broken()",
 						language: "py",
 						output: "boom",
@@ -318,12 +318,13 @@ describe("eval renderer state", () => {
 			.join("\n");
 
 		// Then
-		expect.soft(callText).toContain("eval py resettable running");
+		expect.soft(callText).toContain("eval py running");
+		expect.soft(callText).toContain("resettable");
 		expect.soft(callText).toContain("reset");
 		expect.soft(callText).toContain("timeout 3s");
-		expect.soft(resultText).toContain("eval py queued pending ○");
-		expect.soft(resultText).toMatch(/eval py active running [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/u);
-		expect.soft(resultText).toContain("eval py finished done ✓ · 1m 1s");
-		expect.soft(resultText).toContain("eval py broken error ✗ · 1h 2m");
+		expect.soft(resultText).toContain("eval py pending ○");
+		expect.soft(resultText).toMatch(/eval py running [⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/u);
+		expect.soft(resultText).toContain("eval py done ✓ · 1m 1s");
+		expect.soft(resultText).toContain("eval py error ✗ · 1h 2m");
 	});
 });

--- a/packages/senpi-codemode/test/eval-render-streaming.test.ts
+++ b/packages/senpi-codemode/test/eval-render-streaming.test.ts
@@ -8,7 +8,7 @@ describe("eval renderer streaming reuse", () => {
 		const givenResult = evalResult(
 			{
 				language: "py",
-				title: "stream",
+				summary: "stream",
 				phase: "setup",
 				durationMs: 0,
 				toolCalls: [],
@@ -26,7 +26,13 @@ describe("eval renderer streaming reuse", () => {
 		);
 
 		// Then
-		expect(renderLines(component).slice(0, 4)).toEqual(["eval py stream running", "phase setup", "", "partial-one"]);
+		expect(renderLines(component).slice(0, 5)).toEqual([
+			"eval py running",
+			"stream",
+			"phase setup",
+			"",
+			"partial-one",
+		]);
 	});
 
 	it("Given second partial result when reused then stale output is replaced and nested tool rows render", () => {
@@ -35,7 +41,7 @@ describe("eval renderer streaming reuse", () => {
 			evalResult(
 				{
 					language: "py",
-					title: "stream",
+					summary: "stream",
 					phase: "setup",
 					durationMs: 0,
 					toolCalls: [],
@@ -53,7 +59,7 @@ describe("eval renderer streaming reuse", () => {
 			evalResult(
 				{
 					language: "py",
-					title: "stream",
+					summary: "stream",
 					phase: "calling tools",
 					durationMs: 0,
 					toolCalls: [
@@ -73,7 +79,7 @@ describe("eval renderer streaming reuse", () => {
 		const lines = renderLines(secondPartial);
 		const visibleText = lines.join("\n");
 		expect.soft(secondPartial).toBe(firstPartial);
-		expect.soft(lines.slice(0, 2)).toEqual(["eval py stream running", "phase calling tools"]);
+		expect.soft(lines.slice(0, 3)).toEqual(["eval py running", "stream", "phase calling tools"]);
 		expect.soft(lines).toContain("partial-two");
 		expect.soft(lines).toContain("- tool.search: ok");
 		expect.soft(lines).toContain("- tool.write: error (denied)");
@@ -87,7 +93,7 @@ describe("eval renderer streaming reuse", () => {
 			evalResult(
 				{
 					language: "py",
-					title: "stream",
+					summary: "stream",
 					phase: "calling tools",
 					durationMs: 0,
 					toolCalls: [{ name: "search", ok: true }],
@@ -105,7 +111,7 @@ describe("eval renderer streaming reuse", () => {
 			evalResult(
 				{
 					language: "py",
-					title: "stream",
+					summary: "stream",
 					phase: "complete",
 					durationMs: 9,
 					toolCalls: [],
@@ -122,7 +128,7 @@ describe("eval renderer streaming reuse", () => {
 		const lines = renderLines(final);
 		const visibleText = lines.join("\n");
 		expect.soft(final).toBe(partial);
-		expect.soft(lines.slice(0, 4)).toEqual(["eval py stream done", "phase complete | took 9ms", "", "final-only"]);
+		expect.soft(lines.slice(0, 5)).toEqual(["eval py done", "stream", "phase complete | took 9ms", "", "final-only"]);
 		expect.soft(visibleText).not.toContain("partial-two");
 		expect.soft(visibleText).not.toContain("running");
 		expect.soft(visibleText).not.toContain("tool.search");
@@ -200,7 +206,11 @@ describe("eval renderer streaming reuse", () => {
 
 	it("Given separate call component when result streams then call preview remains distinct and unchanged", () => {
 		// Given
-		const call = renderEvalCall({ language: "js", code: "const value = 1" }, undefined, callContext());
+		const call = renderEvalCall(
+			{ language: "js", code: "const value = 1", summary: "assign constant" },
+			undefined,
+			callContext(),
+		);
 		const callPreview = renderLines(call);
 		const partial = renderEvalResult(
 			evalResult(
@@ -239,7 +249,7 @@ describe("eval renderer streaming reuse", () => {
 		expect.soft(final).toBe(partial);
 		expect.soft(final).not.toBe(call);
 		expect.soft(renderLines(call)).toEqual(callPreview);
-		expect.soft(renderLines(call)).toEqual(["eval js", "const value = 1"]);
+		expect.soft(renderLines(call)).toEqual(["eval js", "assign constant", "const value = 1"]);
 		expect.soft(renderLines(final).slice(0, 4)).toEqual(["eval js done", "phase complete | took 3ms", "", "final"]);
 	});
 

--- a/packages/senpi-codemode/test/eval-render-theme.test.ts
+++ b/packages/senpi-codemode/test/eval-render-theme.test.ts
@@ -157,7 +157,7 @@ describe("eval renderer theme hierarchy", () => {
 
 		// When
 		const lines = [
-			...renderEvalCall({ language: "js", code }, TEST_THEME, callContext()).render(80),
+			...renderEvalCall({ language: "js", code, summary: "collapse previews" }, TEST_THEME, callContext()).render(80),
 			...renderEvalResult(result, { expanded: false, isPartial: false }, TEST_THEME, resultContext()).render(80),
 		];
 
@@ -191,7 +191,7 @@ describe("eval renderer theme hierarchy", () => {
 	it("Given a themed JavaScript call when rendered then the framed code uses syntax highlighting", () => {
 		// Given
 		const component = renderEvalCall(
-			{ language: "js", code: "const answer = 42;", title: "compute" },
+			{ language: "js", code: "const answer = 42;", summary: "compute" },
 			TEST_THEME,
 			callContext(),
 		);
@@ -201,7 +201,8 @@ describe("eval renderer theme hierarchy", () => {
 		const codeLine = requiredLine(lines, "answer");
 
 		// Then
-		expect.soft(stripAnsi(lines[0] ?? "")).toContain("eval js compute pending");
+		expect.soft(stripAnsi(lines[0] ?? "")).toContain("eval js pending");
+		expect.soft(stripAnsi(lines.join("\n"))).toContain("compute");
 		expect.soft(stripAnsi(codeLine)).toContain("const answer = 42;");
 		expect.soft(codeLine.startsWith(TEST_THEME.getFgAnsi("mdCodeBlock"))).toBe(false);
 	});

--- a/packages/senpi-codemode/test/eval-render-width.test.ts
+++ b/packages/senpi-codemode/test/eval-render-width.test.ts
@@ -18,12 +18,12 @@ function longWord(label: string): string {
 }
 
 describe.each(WIDTHS)("eval renderer width %i", (width) => {
-	it("Given wide output title emoji ANSI and long words when rendered then every line fits", () => {
+	it("Given wide output summary emoji ANSI and long words when rendered then every line fits", () => {
 		// Given
 		const givenCall = renderEvalCall(
 			{
 				language: "py",
-				title: "analysis🙂",
+				summary: "analysis🙂",
 				code: [
 					"print('hello🙂')",
 					longWord("call"),
@@ -38,7 +38,7 @@ describe.each(WIDTHS)("eval renderer width %i", (width) => {
 		const givenResult = evalResult(
 			{
 				language: "py",
-				title: "analysis🙂",
+				summary: "analysis🙂",
 				durationMs: 12,
 				toolCalls: [{ name: "searchTool", ok: true }],
 				truncated: false,
@@ -156,7 +156,7 @@ describe("eval renderer rerender width behavior", () => {
 		// Given
 		const component = renderEvalResult(
 			evalResult(
-				{ language: "rb", title: "resize🙂", durationMs: 4, toolCalls: [], truncated: false },
+				{ language: "rb", summary: "resize🙂", durationMs: 4, toolCalls: [], truncated: false },
 				[longWord("wide"), "second line", "third line🙂"].join("\n"),
 			),
 			{ expanded: false, isPartial: false },
@@ -176,7 +176,9 @@ describe("eval renderer rerender width behavior", () => {
 	it("Given collapsed component when rerendered expanded then hidden preview content returns and fits", () => {
 		// Given
 		const codeLines = Array.from({ length: 7 }, (_, index) => `code-${index + 1}-${longWord("cell")}`);
-		const args = { language: "js", code: codeLines.join("\n") } satisfies Parameters<typeof renderEvalCall>[0];
+		const args = { language: "js", code: codeLines.join("\n"), summary: "wide preview" } satisfies Parameters<
+			typeof renderEvalCall
+		>[0];
 		const collapsed = renderEvalCall(args, undefined, callContext());
 
 		// When
@@ -207,7 +209,7 @@ describe("eval renderer cell detail width", () => {
 				cells: [
 					{
 						index: 0,
-						title: "failed cell",
+						summary: "failed cell",
 						code: "print('korean-output-test')",
 						language: "py",
 						output: "korean-output-test and this very long error description must wrap to fit the width",
@@ -246,7 +248,8 @@ describe("eval renderer cell detail width", () => {
 
 		// Then
 		expectLinesWithinWidth(lines, width, "narrow detail render");
-		expect.soft(text).toContain("eval py failed cell error");
+		expect.soft(text).toContain("eval py error");
+		expect.soft(text).toContain("failed cell");
 		expect.soft(text).toContain("read 12 chars");
 		expect.soft(text).toContain("worker-cell done");
 		expect.soft(text).toContain("display[1]");

--- a/packages/senpi-codemode/test/eval-render.test.ts
+++ b/packages/senpi-codemode/test/eval-render.test.ts
@@ -10,7 +10,7 @@ describe("eval renderer", () => {
 		const givenArgs = {
 			language: "py",
 			code: "  print('hello')\nprint('later')",
-			title: "setup",
+			summary: "setup",
 			reset: true,
 			timeout: 3,
 		} satisfies Parameters<typeof renderEvalCall>[0];
@@ -19,7 +19,12 @@ describe("eval renderer", () => {
 		const component = renderEvalCall(givenArgs, undefined, callContext());
 
 		// Then
-		expect(renderLines(component)).toEqual(["eval py setup reset timeout 3s", "  print('hello')", "print('later')"]);
+		expect(renderLines(component)).toEqual([
+			"eval py reset timeout 3s",
+			"setup",
+			"  print('hello')",
+			"print('later')",
+		]);
 	});
 
 	it("renders an ellipsis for empty call code", () => {
@@ -27,13 +32,14 @@ describe("eval renderer", () => {
 		const givenArgs = {
 			language: "jl",
 			code: "   ",
+			summary: "blank cell",
 		} satisfies Parameters<typeof renderEvalCall>[0];
 
 		// When
 		const component = renderEvalCall(givenArgs, undefined, callContext());
 
 		// Then
-		expect(renderLines(component)).toEqual(["eval jl", "..."]);
+		expect(renderLines(component)).toEqual(["eval jl", "blank cell", "..."]);
 	});
 
 	it("renders completed result text while hiding image placeholders when images are disabled", () => {
@@ -45,7 +51,7 @@ describe("eval renderer", () => {
 			],
 			details: {
 				language: "js",
-				title: "chart",
+				summary: "chart",
 				durationMs: 11,
 				toolCalls: [
 					{ name: "search", ok: true },
@@ -65,7 +71,8 @@ describe("eval renderer", () => {
 
 		// Then
 		expect(renderLines(component)).toEqual([
-			"eval js chart done",
+			"eval js done",
+			"chart",
 			"took 11ms",
 			"",
 			"stdout",
@@ -87,7 +94,7 @@ describe("eval renderer", () => {
 			],
 			details: {
 				language: "js",
-				title: "chart",
+				summary: "chart",
 				durationMs: 11,
 				toolCalls: [
 					{ name: "search", ok: true },
@@ -139,7 +146,7 @@ describe("eval renderer", () => {
 		const givenResult = evalResult(
 			{
 				language: "py",
-				title: "stream",
+				summary: "stream",
 				durationMs: 0,
 				toolCalls: [],
 				truncated: false,
@@ -156,19 +163,88 @@ describe("eval renderer", () => {
 		);
 
 		// Then
-		expect(renderLines(component)[0]).toBe("eval py stream running");
+		expect(renderLines(component)[0]).toBe("eval py running");
+		expect(renderLines(component)[1]).toBe("stream");
+	});
+
+	it("Given legacy stored details carrying title and no summary when rendered then no label line and no crash", () => {
+		// Given a pre-summary stored payload: title survived in old sessions, summary never existed.
+		// The cast simulates legacy data rehydrated into the current details shape.
+		const legacyCellDetails = {
+			language: "py",
+			title: "legacy label",
+			durationMs: 3,
+			toolCalls: [],
+			truncated: false,
+			cells: [
+				{
+					index: 0,
+					title: "legacy label",
+					code: "print('old')",
+					language: "py",
+					output: "old",
+					status: "complete",
+					durationMs: 3,
+				},
+			],
+		} as unknown as EvalToolDetails;
+		const legacyFallbackDetails = {
+			language: "py",
+			title: "legacy label",
+			durationMs: 3,
+			toolCalls: [],
+			truncated: false,
+		} as unknown as EvalToolDetails;
+
+		// When the cell frame and the fallback frame (no cells) render collapsed and expanded
+		const renders = [
+			...renderLines(
+				renderEvalResult(
+					evalResult(legacyCellDetails, "old"),
+					{ expanded: false, isPartial: false },
+					undefined,
+					resultContext(),
+				),
+			),
+			...renderEvalResult(
+				evalResult(legacyCellDetails, "old"),
+				{ expanded: true, isPartial: false },
+				undefined,
+				resultContext({ expanded: true }),
+			).render(80),
+			...renderLines(
+				renderEvalResult(
+					evalResult(legacyFallbackDetails, "old"),
+					{ expanded: false, isPartial: false },
+					undefined,
+					resultContext(),
+				),
+			),
+		];
+
+		// Then every frame renders without crashing and none emits a standalone label line
+		expect(renders.length).toBeGreaterThan(0);
+		expect(renders.some((line) => line.trim() === "legacy label")).toBe(false);
 	});
 
 	it("reuses the call component when a later call render receives it as lastComponent", () => {
 		// Given
-		const first = renderEvalCall({ language: "js", code: "first()" }, undefined, callContext());
+		const first = renderEvalCall(
+			{ language: "js", code: "first()", summary: "first pass" },
+			undefined,
+			callContext(),
+		);
 
 		// When
-		const second = renderEvalCall({ language: "js", code: "second()" }, undefined, callContext(first));
+		const second = renderEvalCall(
+			{ language: "js", code: "second()", summary: "second pass" },
+			undefined,
+			callContext(first),
+		);
 
 		// Then
 		expect(second).toBe(first);
-		expect(renderLines(second)).toEqual(["eval js", "second()"]);
+		expect(renderLines(second)).toEqual(["eval js", "second pass", "second()"]);
 	});
 
 	it("reuses the result component from partial to final result when it is passed as lastComponent", () => {
@@ -195,7 +271,7 @@ describe("eval renderer", () => {
 
 	it("keeps call and result lanes distinct when the result lane starts without lastComponent", () => {
 		// Given
-		const call = renderEvalCall({ language: "js", code: "1 + 1" }, undefined, callContext());
+		const call = renderEvalCall({ language: "js", code: "1 + 1", summary: "quick math" }, undefined, callContext());
 
 		// When
 		const result = renderEvalResult(
@@ -207,21 +283,21 @@ describe("eval renderer", () => {
 
 		// Then
 		expect(result).not.toBe(call);
-		expect(renderLines(call)).toEqual(["eval js", "1 + 1"]);
+		expect(renderLines(call)).toEqual(["eval js", "quick math", "1 + 1"]);
 		expect(renderLines(result)).toEqual(["eval js done", "took 1ms", "", "2"]);
 	});
 
 	it("Given a streaming result exists when the framed call lane renders then it yields an empty component", () => {
 		// Given a framed call render (spinnerFrame set) that would otherwise draw its own pending/running box
 		const withoutResult = renderEvalCall(
-			{ language: "py", code: "print('x')" },
+			{ language: "py", code: "print('x')", summary: "print probe" },
 			undefined,
 			callContext({ spinnerFrame: 0 }),
 		);
 
 		// When the same call lane renders after a result has arrived
 		const withResult = renderEvalCall(
-			{ language: "py", code: "print('x')" },
+			{ language: "py", code: "print('x')", summary: "print probe" },
 			undefined,
 			callContext({ spinnerFrame: 0, hasResult: true }),
 		);
@@ -233,11 +309,15 @@ describe("eval renderer", () => {
 
 	it("Given a result exists when the compact call lane renders then it also yields an empty component", () => {
 		// Given the compact call preview (no theme, no spinner) and the same lane once a result exists
-		const compact = renderEvalCall({ language: "js", code: "1 + 1" }, undefined, callContext());
-		const yielded = renderEvalCall({ language: "js", code: "1 + 1" }, undefined, callContext({ hasResult: true }));
+		const compact = renderEvalCall({ language: "js", code: "1 + 1", summary: "quick math" }, undefined, callContext());
+		const yielded = renderEvalCall(
+			{ language: "js", code: "1 + 1", summary: "quick math" },
+			undefined,
+			callContext({ hasResult: true }),
+		);
 
 		// Then the pre-result preview renders code while the post-result lane is empty
-		expect.soft(renderLines(compact)).toEqual(["eval js", "1 + 1"]);
+		expect.soft(renderLines(compact)).toEqual(["eval js", "quick math", "1 + 1"]);
 		expect.soft(renderLines(yielded)).toEqual([]);
 	});
 
@@ -246,14 +326,14 @@ describe("eval renderer", () => {
 		const givenResult = evalResult(
 			{
 				language: "py",
-				title: "load config",
+				summary: "load config",
 				durationMs: 1_250,
 				toolCalls: [],
 				truncated: false,
 				cells: [
 					{
 						index: 0,
-						title: "load config",
+						summary: "load config",
 						code: "config = {'a': 1}",
 						language: "py",
 						output: "loaded",
@@ -278,7 +358,8 @@ describe("eval renderer", () => {
 
 		// Then
 		expect.soft(lines[0]).toContain("╭─");
-		expect.soft(text).toContain("eval py load config done");
+		expect.soft(text).toContain("eval py done");
+		expect.soft(text).toContain("load config");
 		expect.soft(text).toContain("✓");
 		expect.soft(text).toContain("1s");
 		expect.soft(text).toContain("read 42 chars · from /tmp/config.json");

--- a/packages/senpi-codemode/test/eval-request-summary.test.ts
+++ b/packages/senpi-codemode/test/eval-request-summary.test.ts
@@ -130,7 +130,10 @@ describe("parseEvalRequest summary enforcement", () => {
 describe("eval tool schema", () => {
 	it("describes summary with the verbatim required-for-run guide", () => {
 		const tool = buildTool();
-		const summary = tool.parameters.properties.summary;
+		const summary = tool.parameters.properties.summary as unknown as {
+			readonly description?: string;
+			readonly maxLength?: number;
+		};
 		expect(summary.description).toContain(SUMMARY_SCHEMA_DESCRIPTION);
 		expect(summary.maxLength).toBe(EVAL_SUMMARY_MAX_LENGTH);
 	});

--- a/packages/senpi-codemode/test/eval-request-summary.test.ts
+++ b/packages/senpi-codemode/test/eval-request-summary.test.ts
@@ -1,0 +1,204 @@
+import { type ToolCall, validateToolArguments } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { clampEvalSummary, isEvalControlRequest, parseEvalRequest } from "../src/tool/eval-request.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { EVAL_SUMMARY_MAX_LENGTH, type EvalToolInput, type EvalToolRequest } from "../src/tool/types.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+const TEACHING_ERROR =
+	"eval run requires summary — one line in the user's language: what this cell does and for what purpose";
+const SUMMARY_SCHEMA_DESCRIPTION =
+	"REQUIRED for run. ONE line in the USER'S conversational language (Korean conversation -> Korean summary) stating WHAT this cell does and FOR WHAT PURPOSE; shown in the TUI while the cell runs. Longer values are force-truncated to 80 chars.";
+
+type EvalTool = ReturnType<typeof createEvalTool>;
+
+function buildTool(): EvalTool {
+	const kernel = new FakeKernel([result("cell-1", "1", 1)]);
+	return createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager: new FakeManager([["js", kernel]]),
+		cellTimeoutSeconds: 30,
+		executeTool: vi.fn(),
+	});
+}
+
+function parseRun(params: unknown): EvalToolInput {
+	const parsed = parseEvalRequest(params);
+	if (isEvalControlRequest(parsed)) throw new Error("expected a run request");
+	return parsed;
+}
+
+function parseError(params: unknown): TypeError {
+	try {
+		parseEvalRequest(params);
+	} catch (error) {
+		expect(error).toBeInstanceOf(TypeError);
+		return error as TypeError;
+	}
+	throw new Error("expected parseEvalRequest to throw");
+}
+
+function prepareEvalArguments(tool: EvalTool, args: unknown): Record<string, unknown> {
+	const prepare = tool.prepareArguments;
+	if (prepare === undefined) throw new Error("eval tool must define prepareArguments");
+	return { ...prepare(args) };
+}
+
+function validatePrepared(tool: EvalTool, prepared: Record<string, unknown>): Record<string, unknown> {
+	const toolCall: ToolCall = { type: "toolCall", id: "call-1", name: "eval", arguments: prepared };
+	return validateToolArguments(tool, toolCall) as Record<string, unknown>;
+}
+
+describe("clampEvalSummary", () => {
+	it("returns undefined for non-string values", () => {
+		expect(clampEvalSummary(undefined)).toBeUndefined();
+		expect(clampEvalSummary(null)).toBeUndefined();
+		expect(clampEvalSummary(42)).toBeUndefined();
+		expect(clampEvalSummary(true)).toBeUndefined();
+		expect(clampEvalSummary({})).toBeUndefined();
+	});
+
+	it("trims and collapses internal whitespace", () => {
+		expect(clampEvalSummary("  a   b  ")).toBe("a b");
+		expect(clampEvalSummary("a\n\tb   c")).toBe("a b c");
+	});
+
+	it("returns undefined for empty or whitespace-only values", () => {
+		expect(clampEvalSummary("")).toBeUndefined();
+		expect(clampEvalSummary("   ")).toBeUndefined();
+	});
+
+	it("passes through values within the limit unchanged", () => {
+		const exact = "x".repeat(EVAL_SUMMARY_MAX_LENGTH);
+		expect(clampEvalSummary(exact)).toBe(exact);
+		expect(clampEvalSummary("check legacyClient usage")).toBe("check legacyClient usage");
+	});
+
+	it("force-truncates over-limit values to 80 chars ending in ellipsis", () => {
+		const clamped = clampEvalSummary("y".repeat(81));
+		expect(clamped).toBe(`${"y".repeat(77)}...`);
+		expect(clamped).toHaveLength(EVAL_SUMMARY_MAX_LENGTH);
+	});
+});
+
+describe("parseEvalRequest summary enforcement", () => {
+	it("throws the teaching error when a run omits summary", () => {
+		expect(parseError({ language: "py", code: "print(1)" }).message).toBe(TEACHING_ERROR);
+	});
+
+	it("throws the teaching error when a run summary is empty, blank, or non-string", () => {
+		expect(parseError({ language: "py", code: "print(1)", summary: "" }).message).toBe(TEACHING_ERROR);
+		expect(parseError({ language: "py", code: "print(1)", summary: "   " }).message).toBe(TEACHING_ERROR);
+		expect(parseError({ language: "py", code: "print(1)", summary: 42 }).message).toBe(TEACHING_ERROR);
+	});
+
+	it("throws the teaching error for an explicit run action without summary", () => {
+		expect(parseError({ action: "run", language: "py", code: "print(1)" }).message).toBe(TEACHING_ERROR);
+	});
+
+	it("passes through summaries within the limit", () => {
+		const parsed = parseRun({ language: "py", code: "print(1)", summary: "집계 셀 실행" });
+		expect(parsed.summary).toBe("집계 셀 실행");
+	});
+
+	it("collapses whitespace in summaries", () => {
+		expect(parseRun({ language: "py", code: "print(1)", summary: "  a   b  " }).summary).toBe("a b");
+	});
+
+	it("clamps over-limit summaries to 80 chars ending in ellipsis", () => {
+		const parsed = parseRun({ language: "py", code: "print(1)", summary: "s".repeat(120) });
+		expect(parsed.summary).toHaveLength(EVAL_SUMMARY_MAX_LENGTH);
+		expect(parsed.summary.endsWith("...")).toBe(true);
+	});
+
+	it("accepts peek and stop without a summary and ignores a provided one", () => {
+		expect(parseEvalRequest({ action: "peek", cell_id: "cell-1" })).toEqual({ action: "peek", cell_id: "cell-1" });
+		expect(parseEvalRequest({ action: "stop", cell_id: "cell-1" })).toEqual({ action: "stop", cell_id: "cell-1" });
+		expect(parseEvalRequest({ action: "peek", cell_id: "cell-1", summary: "ignored" })).toEqual({
+			action: "peek",
+			cell_id: "cell-1",
+		});
+	});
+
+	it("parses legacy title-bearing runs with title absent from the result", () => {
+		const parsed = parseRun({ title: "legacy label", summary: "kept summary", language: "py", code: "print(1)" });
+		expect(parsed).toEqual({ language: "py", code: "print(1)", summary: "kept summary" });
+		expect("title" in parsed).toBe(false);
+	});
+});
+
+describe("eval tool schema", () => {
+	it("describes summary with the verbatim required-for-run guide", () => {
+		const tool = buildTool();
+		const summary = tool.parameters.properties.summary;
+		expect(summary.description).toContain(SUMMARY_SCHEMA_DESCRIPTION);
+		expect(summary.maxLength).toBe(EVAL_SUMMARY_MAX_LENGTH);
+	});
+
+	it("removes title from the input schema", () => {
+		const tool = buildTool();
+		expect("title" in tool.parameters.properties).toBe(false);
+	});
+});
+
+describe("eval tool prepareArguments", () => {
+	it("clamps a 500-char summary before schema validation", () => {
+		const tool = buildTool();
+		const prepared = prepareEvalArguments(tool, {
+			language: "js",
+			code: "return 1",
+			summary: "s".repeat(500),
+		});
+		expect(prepared.summary).toBe(`${"s".repeat(77)}...`);
+		const validated = validatePrepared(tool, prepared);
+		expect(validated.summary).toBe(prepared.summary);
+	});
+
+	it("schema validation alone rejects the over-limit summary the clamp prevents", () => {
+		const tool = buildTool();
+		expect(() => validatePrepared(tool, { language: "js", code: "return 1", summary: "s".repeat(500) })).toThrow(
+			/summary/,
+		);
+	});
+
+	it("drops an empty summary instead of failing validation", () => {
+		const tool = buildTool();
+		const prepared = prepareEvalArguments(tool, { language: "js", code: "return 1", summary: "   " });
+		expect("summary" in prepared).toBe(false);
+	});
+
+	it("passes peek and stop arguments through untouched", () => {
+		const tool = buildTool();
+		const prepared = prepareEvalArguments(tool, { action: "peek", cell_id: "cell-9", summary: "  padded  " });
+		expect(prepared).toEqual({ action: "peek", cell_id: "cell-9", summary: "  padded  " });
+	});
+
+	it("keeps legacy title props and still validates", () => {
+		const tool = buildTool();
+		const prepared = prepareEvalArguments(tool, {
+			language: "js",
+			code: "return 1",
+			summary: "legacy caller",
+			title: "old label",
+		});
+		expect(prepared.title).toBe("old label");
+		const validated = validatePrepared(tool, prepared);
+		expect(validated.title).toBe("old label");
+		expect(validated.summary).toBe("legacy caller");
+	});
+});
+
+describe("eval tool execute error path", () => {
+	it("surfaces the teaching error as a tool error when summary is missing", async () => {
+		const tool = buildTool();
+		const call = tool.execute(
+			"cell-1",
+			{ language: "js", code: "return 42" } as unknown as EvalToolRequest,
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+		await expect(call).rejects.toThrowError(TypeError);
+		await expect(call).rejects.toThrow(TEACHING_ERROR);
+	});
+});

--- a/packages/senpi-codemode/test/eval-status-ticker.test.ts
+++ b/packages/senpi-codemode/test/eval-status-ticker.test.ts
@@ -3,10 +3,10 @@ import { EVAL_STATUS_TICK_INTERVAL_MS, EvalStatusTicker } from "../src/extension
 import type { EvalDetachedCellStatusEntry } from "../src/tool/detached-cell-manager.ts";
 
 const T0 = 1_000_000;
-const entry = (cellId: string, title: string, startedAtMs = T0): EvalDetachedCellStatusEntry => ({
+const entry = (cellId: string, summary: string, startedAtMs = T0): EvalDetachedCellStatusEntry => ({
 	cellId,
 	language: "py",
-	title,
+	summary,
 	startedAtMs,
 });
 

--- a/packages/senpi-codemode/test/eval-status-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-status-wiring.test.ts
@@ -111,14 +111,14 @@ async function detachOne(
 	kernel: FakeKernel,
 	ctx: ExtensionContext,
 	cellId: string,
-	title: string,
+	summary: string,
 ): Promise<void> {
 	const tool = pi.registeredTool;
 	if (!tool) throw new Error("eval tool was not registered");
 	const started = kernel.deferNextRun();
 	const execution = tool.execute(
 		cellId,
-		{ language: "js", code: "await forever", title, on_timeout: "detach" },
+		{ language: "js", code: "await forever", summary, on_timeout: "detach" },
 		undefined,
 		undefined,
 		ctx,

--- a/packages/senpi-codemode/test/eval-status.test.ts
+++ b/packages/senpi-codemode/test/eval-status.test.ts
@@ -4,8 +4,15 @@ import type { EvalDetachedCellStatusEntry } from "../src/tool/detached-cell-mana
 
 const T0 = 1_000_000;
 
-function entry(cellId: string, language: "js" | "py", title?: string, startedAtMs = T0): EvalDetachedCellStatusEntry {
-	return title === undefined ? { cellId, language, startedAtMs } : { cellId, language, title, startedAtMs };
+function entry(
+	cellId: string,
+	language: "js" | "py",
+	summary?: string,
+	startedAtMs = T0,
+): EvalDetachedCellStatusEntry {
+	return summary === undefined
+		? { cellId, language, startedAtMs }
+		: { cellId, language, summary, startedAtMs };
 }
 
 describe("formatEvalCellStatus", () => {
@@ -17,30 +24,42 @@ describe("formatEvalCellStatus", () => {
 		expect(formatEvalCellStatus([], T0)).toBeUndefined();
 	});
 
-	it("shows glyph, language, and title for a single detached cell", () => {
+	it("shows glyph, language, and summary for a single detached cell", () => {
 		expect(formatEvalCellStatus([entry("cell-1", "py", "numpy feather rerun")], T0 + 5_000)).toBe(
 			"↗ py · numpy feather rerun (5s)",
 		);
 	});
 
-	it("falls back to the cell id when the cell has no title", () => {
+	it("falls back to the cell id when the cell has no summary", () => {
 		expect(formatEvalCellStatus([entry("cell-123", "js")], T0 + 180_000)).toBe("↗ js · cell-123 (3m)");
 	});
 
-	it("truncates an overlong single title to the shared 48-char budget with an ellipsis", () => {
-		const longTitle = "x".repeat(80);
-		const status = formatEvalCellStatus([entry("cell-1", "py", longTitle)], T0);
+	it("falls back to the cell id when the summary is empty", () => {
+		expect(formatEvalCellStatus([entry("cell-123", "js", "")], T0)).toBe("↗ js · cell-123 (0s)");
+	});
+
+	it("truncates an overlong single summary to the shared 48-char budget with an ellipsis", () => {
+		const longSummary = "x".repeat(80);
+		const status = formatEvalCellStatus([entry("cell-1", "py", longSummary)], T0);
 		expect(status).toBe(`↗ py · ${"x".repeat(48 - "↗ py · ".length - " (0s)".length - 1)}… (0s)`);
 		expect(status?.length).toBe(48);
 	});
 
-	it("lists every title when multiple detached cells fit the budget", () => {
+	it("truncates a Korean summary to the length budget by code units", () => {
+		const koreanSummary = "src 전체에서 legacyClient 사용처 집계".repeat(3);
+		const status = formatEvalCellStatus([entry("cell-ko", "py", koreanSummary)], T0);
+		expect(status?.length).toBeLessThanOrEqual(48);
+		expect(status).toContain("src 전체에서");
+		expect(status).toMatch(/… \(0s\)$/u);
+	});
+
+	it("lists every summary when multiple detached cells fit the budget", () => {
 		expect(formatEvalCellStatus([entry("a", "js", "alpha"), entry("b", "py", "beta")], T0 + 60_000)).toBe(
 			"↗ eval 2: alpha, beta (1m)",
 		);
 	});
 
-	it("keeps only whole titles and folds the rest into a +N more tail", () => {
+	it("keeps only whole summaries and folds the rest into a +N more tail", () => {
 		const entries = [
 			entry("a", "js", "first-cell-title"),
 			entry("b", "py", "second-cell-title"),
@@ -51,7 +70,7 @@ describe("formatEvalCellStatus", () => {
 		expect(status?.length).toBeLessThanOrEqual(48);
 	});
 
-	it("keeps the +N more counter when not even one whole title fits", () => {
+	it("keeps the +N more counter when not even one whole summary fits", () => {
 		const entries = [
 			entry("a", "js", "a-very-long-cell-title-that-cannot-fit"),
 			entry("b", "py", "another-long-cell-title-that-cannot-fit"),

--- a/packages/senpi-codemode/test/eval-stop-state-note.test.ts
+++ b/packages/senpi-codemode/test/eval-stop-state-note.test.ts
@@ -36,7 +36,7 @@ async function detachPyCell(
 	const started = kernel.deferNextRun();
 	const execution = tool.execute(
 		cellId,
-		{ language: "py", code: "await forever", on_timeout: "detach" },
+		{ language: "py", code: "await forever", on_timeout: "detach", summary: "stop note probe" },
 		undefined,
 		undefined,
 		{ ...fakeExtensionContext(), mode: "tui" as const },
@@ -96,7 +96,7 @@ describe("eval stop reports true kernel state", () => {
 		const started = kernel.deferNextRun();
 		const execution = tool.execute(
 			"stop-js-cell",
-			{ language: "js", code: "await forever", on_timeout: "detach" },
+			{ language: "js", code: "await forever", on_timeout: "detach", summary: "stop note probe" },
 			undefined,
 			undefined,
 			{ ...fakeExtensionContext(), mode: "tui" as const },

--- a/packages/senpi-codemode/test/eval-tool-call-capture.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-call-capture.test.ts
@@ -30,7 +30,7 @@ describe("eval tool-call capture", () => {
 
 		const toolResult = await createTool(kernel, executeTool).execute(
 			"capture-success",
-			{ language: "js", code: "await tool.read({ path: '/tmp/x' })" },
+			{ language: "js", code: "await tool.read({ path: '/tmp/x' })", summary: "capture success" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -57,7 +57,7 @@ describe("eval tool-call capture", () => {
 
 		const toolResult = await createTool(kernel, executeTool).execute(
 			"capture-error-bit",
-			{ language: "js", code: "await tool.bash({ command: 'exit 1' })" },
+			{ language: "js", code: "await tool.bash({ command: 'exit 1' })", summary: "capture error bit" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -85,7 +85,7 @@ describe("eval tool-call capture", () => {
 
 		const toolResult = await createTool(kernel, executeTool).execute(
 			"capture-rejection",
-			{ language: "js", code: "await tool.blocked({ path: '/tmp/blocked' })" },
+			{ language: "js", code: "await tool.blocked({ path: '/tmp/blocked' })", summary: "capture rejection" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -110,7 +110,7 @@ describe("eval tool-call capture", () => {
 
 		const toolResult = await createTool(kernel, executeTool, () => []).execute(
 			"capture-reserved",
-			{ language: "js", code: "await tool.__schema__({})" },
+			{ language: "js", code: "await tool.__schema__({})", summary: "capture reserved" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -130,7 +130,7 @@ describe("eval tool-call capture", () => {
 
 		const toolResult = await createTool(kernel, executeTool).execute(
 			"capture-cap",
-			{ language: "js", code: "many calls" },
+			{ language: "js", code: "many calls", summary: "capture cap" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -164,7 +164,7 @@ describe("eval tool-call capture", () => {
 
 		await createTool(kernel, executeTool).execute(
 			"capture-stream",
-			{ language: "js", code: "await tool.read({ path: '/tmp/live' })" },
+			{ language: "js", code: "await tool.read({ path: '/tmp/live' })", summary: "capture stream" },
 			undefined,
 			onUpdate,
 			fakeExtensionContext(),

--- a/packages/senpi-codemode/test/eval-tool-execution-render.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-execution-render.test.ts
@@ -1,9 +1,12 @@
 import type { AgentToolResult } from "@code-yeongyu/senpi";
 import { initTheme, ToolExecutionComponent } from "@code-yeongyu/senpi";
 import type { TUI } from "@earendil-works/pi-tui";
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
 import { renderEvalCall, renderEvalResult } from "../src/tool/render.ts";
 import type { EvalToolDetails } from "../src/tool/types.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
 
 // This test drives the REAL interactive ToolExecutionComponent — the exact component the TUI mux
 // renders — through the pending -> running -> done lifecycle of an `eval` tool call. It is the
@@ -37,15 +40,17 @@ function evalToolDef(): ToolDefParam {
 	} as unknown as ToolDefParam;
 }
 
-function cellResult(status: "running" | "complete", output: string, durationMs: number): ExecResult {
+function cellResult(status: "running" | "complete", output: string, durationMs: number, summary?: string): ExecResult {
+	const label = summary === undefined ? {} : { summary };
 	const details: EvalToolDetails = {
 		language: "py",
 		languages: ["py"],
+		...label,
 		durationMs,
 		toolCalls: [],
 		truncated: false,
 		phase: status === "complete" ? "complete" : "running",
-		cells: [{ index: 0, code: CODE, language: "py", output, status, durationMs }],
+		cells: [{ index: 0, ...label, code: CODE, language: "py", output, status, durationMs }],
 	};
 	const agentResult: AgentToolResult<EvalToolDetails> = { content: [{ type: "text", text: output }], details };
 	return { ...agentResult, isError: false };
@@ -149,5 +154,195 @@ describe("nested tool-call widgets in ToolExecutionComponent", () => {
 		expect(output).toContain("config.json");
 
 		component.stopAnimation();
+	});
+});
+
+describe("eval summary in transcript frames", () => {
+	beforeAll(() => {
+		initTheme();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	function summaryComponent(): ToolExecutionComponent {
+		const ui = { requestRender: () => {} } as unknown as TUI;
+		const component = new ToolExecutionComponent(
+			"eval",
+			"eval-summary",
+			{ language: "py", code: CODE, summary: "collect progress" },
+			{},
+			evalToolDef(),
+			ui,
+			"/tmp",
+		);
+		component.setArgsComplete();
+		return component;
+	}
+
+	function expectSummaryUnderHeader(lines: readonly string[], status: string): void {
+		const plain = lines.map(stripAnsi);
+		const headerIndex = plain.findIndex((line) => line.includes("eval py"));
+		expect(headerIndex).toBeGreaterThanOrEqual(0);
+		expect.soft(plain[headerIndex]).toContain(`eval py ${status}`);
+		expect.soft(plain[headerIndex]).not.toContain("collect progress");
+		expect.soft(plain[headerIndex + 1]?.replace("│", "").trim()).toBe("collect progress");
+	}
+
+	it("Given a running eval with a summary when the frame renders then the header drops the label segment and the summary sits under it", () => {
+		// Given the real interactive component streaming a running result whose cell carries a summary
+		const component = summaryComponent();
+		component.markExecutionStarted();
+		component.updateResult(cellResult("running", "", 0, "collect progress"), true);
+
+		// When the running frame renders
+		const lines = component.render(80);
+
+		// Then the header has no label segment and the muted summary line sits directly under it
+		expectSummaryUnderHeader(lines, "running");
+		component.stopAnimation();
+	});
+
+	it("Given a completed eval with a summary when the result frame renders then it carries the summary", () => {
+		// Given the real interactive component receiving its final result
+		const component = summaryComponent();
+		component.markExecutionStarted();
+		component.updateResult(cellResult("complete", OUTPUT, 12, "collect progress"), false);
+
+		// When the done frame renders
+		const lines = component.render(80);
+
+		// Then the result frame carries the summary under the title-less header
+		expectSummaryUnderHeader(lines, "done");
+		component.stopAnimation();
+	});
+
+	it("Given a six-line cell with a summary when collapsed then the summary line and a four-line code preview render", () => {
+		// Given a finished cell whose code overflows the collapsed preview budget
+		const codeLines = ["a = 1", "b = 2", "c = 3", "d = 4", "e = 5", "f = 6"];
+		const details: EvalToolDetails = {
+			language: "py",
+			languages: ["py"],
+			summary: "tally rows",
+			durationMs: 7,
+			toolCalls: [],
+			truncated: false,
+			cells: [
+				{
+					index: 0,
+					summary: "tally rows",
+					code: codeLines.join("\n"),
+					language: "py",
+					output: "done",
+					status: "complete",
+					durationMs: 7,
+				},
+			],
+		};
+		const givenResult: AgentToolResult<EvalToolDetails> = {
+			content: [{ type: "text", text: "done" }],
+			details,
+		};
+
+		// When the result renders collapsed and expanded
+		const collapsed = renderEvalResult(givenResult, { expanded: false, isPartial: false }, undefined, {
+			args: { language: "py", code: codeLines.join("\n"), summary: "tally rows" },
+			toolCallId: "eval-summary-collapsed",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: {},
+			cwd: "/tmp",
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: false,
+			showImages: false,
+			imageProtocol: null,
+			isError: false,
+		}).render(80);
+		const expanded = renderEvalResult(givenResult, { expanded: true, isPartial: false }, undefined, {
+			args: { language: "py", code: codeLines.join("\n"), summary: "tally rows" },
+			toolCallId: "eval-summary-expanded",
+			invalidate: () => {},
+			lastComponent: undefined,
+			state: {},
+			cwd: "/tmp",
+			executionStarted: true,
+			argsComplete: true,
+			isPartial: false,
+			expanded: true,
+			showImages: false,
+			imageProtocol: null,
+			isError: false,
+		}).render(80);
+
+		// Then collapsed shows the summary plus exactly the last four code lines; expanded keeps the summary too
+		const collapsedText = collapsed.join("\n");
+		const expandedText = expanded.join("\n");
+		expect.soft(collapsedText).toContain("tally rows");
+		expect.soft(collapsedText).toContain("2 earlier code lines");
+		for (const visibleLine of codeLines.slice(-4)) expect.soft(collapsedText).toContain(visibleLine);
+		for (const hiddenLine of codeLines.slice(0, 2)) expect.soft(collapsedText).not.toContain(hiddenLine);
+		expect.soft(expandedText).toContain("tally rows");
+		for (const codeLine of codeLines) expect.soft(expandedText).toContain(codeLine);
+	});
+
+	it("Given a detached cell with a summary when peeked live and terminal then both results carry the summary", async () => {
+		// Given a js cell that detaches on timeout (style of eval-detached-peek's rich-cell flow)
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		const tool = createEvalTool({
+			enabledLanguages: { js: true, py: false, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", kernel]]),
+			cellTimeoutSeconds: 1,
+			executeTool: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+			cellManager: manager,
+		});
+		const interactive = { ...fakeExtensionContext(), mode: "tui" as const };
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"summary-cell",
+			{ language: "js", code: "await new Promise(() => {})", summary: "collect progress", on_timeout: "detach" },
+			undefined,
+			undefined,
+			interactive,
+		);
+		await started;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+
+		// When the still-running detached cell is peeked
+		const live = await tool.execute(
+			"peek-live",
+			{ action: "peek", cell_id: "summary-cell" },
+			undefined,
+			undefined,
+			interactive,
+		);
+
+		// Then the live peek result carries the summary on the details and the cell
+		expect.soft(live.details.summary).toBe("collect progress");
+		expect.soft(live.details.cells?.[0]?.status).toBe("detached");
+		expect.soft(live.details.cells?.[0]?.summary).toBe("collect progress");
+
+		// When the kernel run completes and the terminal snapshot is peeked
+		kernel.completeDeferredRun(result("summary-cell", "done", 5));
+		await manager.waitForTerminal("summary-cell");
+		const terminal = await tool.execute(
+			"peek-terminal",
+			{ action: "peek", cell_id: "summary-cell" },
+			undefined,
+			undefined,
+			interactive,
+		);
+
+		// Then the terminal peek result still carries the summary
+		expect.soft(terminal.details.summary).toBe("collect progress");
+		expect.soft(terminal.details.cells?.[0]?.status).toBe("complete");
+		expect.soft(terminal.details.cells?.[0]?.summary).toBe("collect progress");
+
+		await manager.flushNotifications();
 	});
 });

--- a/packages/senpi-codemode/test/eval-tool-interrupt.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-interrupt.test.ts
@@ -51,7 +51,7 @@ describe("createEvalTool interrupt handling", () => {
 		const tool = createTool(manager);
 		const execution = tool.execute(
 			"cell-acquire-abort",
-			{ language: "js", code: "1" },
+			{ language: "js", code: "1", summary: "acquire abort" },
 			controller.signal,
 			undefined,
 			fakeExtensionContext(),
@@ -71,7 +71,7 @@ describe("createEvalTool interrupt handling", () => {
 		const tool = createTool(new FakeManager([["js", kernel]]));
 		const execution = tool.execute(
 			"cell-reset-timeout",
-			{ language: "js", code: "1", reset: true, timeout: 1 },
+			{ language: "js", code: "1", reset: true, timeout: 1, summary: "reset timeout" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -111,7 +111,7 @@ describe("createEvalTool interrupt handling", () => {
 		const tool = createTool(new FakeManager([["js", kernel]]), 30, executeTool);
 		const execution = tool.execute(
 			"cell-active-abort",
-			{ language: "js", code: "await tool.slow({})" },
+			{ language: "js", code: "await tool.slow({})", summary: "active abort" },
 			controller.signal,
 			undefined,
 			fakeExtensionContext(),
@@ -136,7 +136,7 @@ describe("createEvalTool interrupt handling", () => {
 		const outcome = tool
 			.execute(
 				"cell-pending-interrupt",
-				{ language: "js", code: "await pending" },
+				{ language: "js", code: "await pending", summary: "pending interrupt" },
 				controller.signal,
 				undefined,
 				fakeExtensionContext(),
@@ -179,7 +179,7 @@ describe("createEvalTool interrupt handling", () => {
 		const execution = tool
 			.execute(
 				"cell-interrupt-rejection",
-				{ language: "js", code: "await pending" },
+				{ language: "js", code: "await pending", summary: "interrupt rejection" },
 				controller.signal,
 				undefined,
 				fakeExtensionContext(),
@@ -207,7 +207,7 @@ describe("createEvalTool interrupt handling", () => {
 		const tool = createTool(new FakeManager([["js", kernel]]));
 		const toolResult = await tool.execute(
 			"cell-late-abort",
-			{ language: "js", code: "1" },
+			{ language: "js", code: "1", summary: "late abort" },
 			controller.signal,
 			undefined,
 			fakeExtensionContext(),
@@ -230,7 +230,7 @@ describe("createEvalTool interrupt handling", () => {
 		await expect(
 			tool.execute(
 				"cell-pre-abort",
-				{ language: "js", code: "return 42" },
+				{ language: "js", code: "return 42", summary: "pre abort" },
 				controller.signal,
 				undefined,
 				fakeExtensionContext(),
@@ -257,7 +257,7 @@ describe("createEvalTool interrupt handling", () => {
 
 		const toolResult = await tool.execute(
 			"cell-timeout-status",
-			{ language: "js", code: "await tool.slow({})" },
+			{ language: "js", code: "await tool.slow({})", summary: "timeout status" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),

--- a/packages/senpi-codemode/test/eval-tool-output.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-output.test.ts
@@ -72,7 +72,7 @@ describe("eval tool output pipeline", () => {
 		// When
 		const toolResult = await tool.execute(
 			"sink-cell",
-			{ language: "js", code: "display({answer: 42})", title: "sink" },
+			{ language: "js", code: "display({answer: 42})", summary: "sink" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -82,7 +82,7 @@ describe("eval tool output pipeline", () => {
 		expect(toolResult.details).toMatchObject({
 			language: "js",
 			languages: ["js"],
-			title: "sink",
+			summary: "sink",
 			durationMs: 17,
 			truncated: true,
 			jsonOutputs: [jsonValue],
@@ -90,7 +90,7 @@ describe("eval tool output pipeline", () => {
 			cells: [
 				{
 					index: 0,
-					title: "sink",
+					summary: "sink",
 					code: "display({answer: 42})",
 					language: "js",
 					status: "complete",
@@ -130,7 +130,7 @@ describe("eval tool output pipeline", () => {
 		// When
 		const toolResult = await tool.execute(
 			"live-cell",
-			{ language: "js", code: "print('first'); print('second')" },
+			{ language: "js", code: "print('first'); print('second')", summary: "stream live tail" },
 			undefined,
 			onUpdate,
 			fakeExtensionContext(),
@@ -149,11 +149,11 @@ describe("eval tool output pipeline", () => {
 		const firstLiveUpdate = updates.find((update) => update.details.cells?.[0]?.output === "first\n");
 		const secondLiveUpdate = updates.find((update) => update.details.cells?.[0]?.output === "first\nsecond\n");
 		expect(firstLiveUpdate).toMatchObject({
-			content: [{ type: "text", text: "1/1 cells running\n[1] js running\nfirst\n" }],
+			content: [{ type: "text", text: "1/1 cells running\n[1] js stream live tail running\nfirst\n" }],
 			details: { cells: [{ output: "first\n", status: "running" }] },
 		});
 		expect(secondLiveUpdate).toMatchObject({
-			content: [{ type: "text", text: "1/1 cells running\n[1] js running\nfirst\nsecond\n" }],
+			content: [{ type: "text", text: "1/1 cells running\n[1] js stream live tail running\nfirst\nsecond\n" }],
 			details: { cells: [{ output: "first\nsecond\n", status: "running" }] },
 		});
 		expect(updates.at(-1)?.details.cells?.[0]?.status).toBe("complete");
@@ -178,7 +178,7 @@ describe("eval tool output pipeline", () => {
 		// When
 		await tool.execute(
 			"bounded-live-cell",
-			{ language: "js", code: "for (let i = 1; i <= 10; i++) print(i)" },
+			{ language: "js", code: "for (let i = 1; i <= 10; i++) print(i)", summary: "bounded live tail" },
 			undefined,
 			(update) => updates.push(update),
 			fakeExtensionContext(),
@@ -187,7 +187,9 @@ describe("eval tool output pipeline", () => {
 		// Then
 		const completeLiveUpdate = updates.find((update) => update.details.cells?.[0]?.output === lines.join(""));
 		expect(completeLiveUpdate).toMatchObject({
-			content: [{ type: "text", text: `1/1 cells running\n[1] js running\n${lines.slice(-8).join("")}` }],
+			content: [
+				{ type: "text", text: `1/1 cells running\n[1] js bounded live tail running\n${lines.slice(-8).join("")}` },
+			],
 			details: { cells: [{ output: lines.join(""), status: "running" }] },
 		});
 	});
@@ -213,7 +215,7 @@ describe("eval tool output pipeline", () => {
 		// When
 		const toolResult = await tool.execute(
 			"image-cell",
-			{ language: "js", code: "display(image)" },
+			{ language: "js", code: "display(image)", summary: "resize display" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -246,7 +248,7 @@ describe("eval tool output pipeline", () => {
 		// When
 		const toolResult = await tool.execute(
 			"error-cell",
-			{ language: "js", code: "throw new Error('boom')" },
+			{ language: "js", code: "throw new Error('boom')", summary: "error path" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -290,7 +292,7 @@ describe("eval tool output pipeline", () => {
 		// When
 		const toolResult = await tool.execute(
 			"status-history",
-			{ language: "js", code: "for (const path of paths) read(path)" },
+			{ language: "js", code: "for (const path of paths) read(path)", summary: "status history" },
 			undefined,
 			onUpdate,
 			fakeExtensionContext(),

--- a/packages/senpi-codemode/test/eval-tool-timeout-state.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-timeout-state.test.ts
@@ -28,7 +28,7 @@ async function runTimedOutCell(
 	const outcome = tool
 		.execute(
 			"timeout-cell",
-			{ language, code: "await forever", on_timeout: "error", timeout: 1 },
+			{ language, code: "await forever", on_timeout: "error", timeout: 1, summary: "timeout state" },
 			undefined,
 			undefined,
 			interactiveContext(),

--- a/packages/senpi-codemode/test/eval-tool.test.ts
+++ b/packages/senpi-codemode/test/eval-tool.test.ts
@@ -64,7 +64,7 @@ describe("createEvalTool", () => {
 		expect(tool.executionMode).toBe("sequential");
 		const toolResult = await tool.execute(
 			"cell-1",
-			{ language: "js", code: "return 42", title: "math" },
+			{ language: "js", code: "return 42", summary: "math" },
 			undefined,
 			onUpdate,
 			fakeExtensionContext(),
@@ -73,7 +73,7 @@ describe("createEvalTool", () => {
 		expect(tool.parameters.properties.language.anyOf).toEqual([{ const: "js", type: "string" }]);
 		expect(textOf(toolResult)).toContain("hello");
 		expect(textOf(toolResult)).toContain("42");
-		expect(toolResult.details).toMatchObject({ language: "js", title: "math", durationMs: 7, truncated: false });
+		expect(toolResult.details).toMatchObject({ language: "js", summary: "math", durationMs: 7, truncated: false });
 		expect(updates).toContainEqual(expect.objectContaining({ phase: "setup" }));
 	});
 
@@ -96,7 +96,7 @@ describe("createEvalTool", () => {
 
 		const toolResult = await tool.execute(
 			"cell-2",
-			{ language: "js", code: "await tool.demo({x:1})" },
+			{ language: "js", code: "await tool.demo({x:1})", summary: "demo tool call" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -129,7 +129,7 @@ describe("createEvalTool", () => {
 
 		const toolResult = await tool.execute(
 			"cell-3",
-			{ language: "js", code: "await tool.eval({})" },
+			{ language: "js", code: "await tool.eval({})", summary: "recursive eval" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -154,7 +154,13 @@ describe("createEvalTool", () => {
 		});
 
 		await expect(
-			tool.execute("cell-4", { language: "js", code: "1" }, undefined, undefined, fakeExtensionContext()),
+			tool.execute(
+				"cell-4",
+				{ language: "js", code: "1", summary: "unsupported language probe" },
+				undefined,
+				undefined,
+				fakeExtensionContext(),
+			),
 		).rejects.toThrow('Unsupported eval language "js". Enabled languages: py');
 	});
 
@@ -174,7 +180,7 @@ describe("createEvalTool", () => {
 
 		const toolResult = await tool.execute(
 			"cell-5",
-			{ language: "js", code: "heavy()", timeout: 2, reset: true },
+			{ language: "js", code: "heavy()", timeout: 2, reset: true, summary: "heavy run" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -204,7 +210,7 @@ describe("createEvalTool", () => {
 
 		const first = await tool.execute(
 			"cell-6",
-			{ language: "js", code: "await tool.blocked({})" },
+			{ language: "js", code: "await tool.blocked({})", summary: "blocked tool" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -213,7 +219,7 @@ describe("createEvalTool", () => {
 		kernel.replaceMessages([result("cell-7", "next-ok")]);
 		const second = await tool.execute(
 			"cell-7",
-			{ language: "js", code: "1 + 1" },
+			{ language: "js", code: "1 + 1", summary: "next cell" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -256,14 +262,17 @@ describe("createEvalTool", () => {
 		// When
 		const toolResult = await tool.execute(
 			"proxy-cell",
-			{ language: "js", code: "return 42" },
+			{ language: "js", code: "return 42", summary: "proxied run" },
 			controller.signal,
 			undefined,
 			fakeExtensionContext(),
 		);
 
 		// Then
-		expect(proxyExecutor).toHaveBeenCalledWith({ language: "js", code: "return 42" }, controller.signal);
+		expect(proxyExecutor).toHaveBeenCalledWith(
+			{ language: "js", code: "return 42", summary: "proxied run" },
+			controller.signal,
+		);
 		expect(getKernel).not.toHaveBeenCalled();
 		expect(textOf(toolResult)).toBe("proxied");
 	});

--- a/packages/senpi-codemode/test/extension.test.ts
+++ b/packages/senpi-codemode/test/extension.test.ts
@@ -215,7 +215,13 @@ describe("senpi-codemode extension factory", () => {
 			expect(tool.description).not.toContain('`"rb"`');
 			expect(tool.description).not.toContain('`"jl"`');
 			await expect(
-				tool.execute("disabled-ruby", { language: "rb", code: "1" }, undefined, undefined, ctx),
+				tool.execute(
+					"disabled-ruby",
+					{ language: "rb", code: "1", summary: "disabled probe" },
+					undefined,
+					undefined,
+					ctx,
+				),
 			).rejects.toThrow('Unsupported eval language "rb". Enabled languages: js');
 		} finally {
 			await emit(pi, "session_shutdown", {}, ctx);
@@ -412,7 +418,13 @@ describe("senpi-codemode extension factory", () => {
 		const tool = pi.registeredTool;
 		if (!tool) throw new Error("eval tool was not registered");
 		await expect(
-			tool.execute("after-shutdown", { language: "js", code: "1" }, undefined, undefined, ctx),
+			tool.execute(
+				"after-shutdown",
+				{ language: "js", code: "1", summary: "post shutdown" },
+				undefined,
+				undefined,
+				ctx,
+			),
 		).rejects.toThrow("session has not started");
 		expect(manager.getKernelCount).toBe(0);
 	});
@@ -429,13 +441,25 @@ describe("senpi-codemode extension lifecycle", () => {
 		await emit(pi, "session_start", { reason: "startup" }, ctx);
 		const tool = pi.registeredTool;
 		expect(tool).toBeDefined();
-		const run = tool?.execute("cell-running", { language: "js", code: "await pending()" }, undefined, undefined, ctx);
+		const run = tool?.execute(
+			"cell-running",
+			{ language: "js", code: "await pending()", summary: "mid run cell" },
+			undefined,
+			undefined,
+			ctx,
+		);
 		await manager.runStarted.promise;
 		await emit(pi, "session_shutdown", {}, ctx);
 
 		await expect(run).resolves.toMatchObject({ details: expect.objectContaining({ isError: true }) });
 		await expect(
-			tool?.execute("after-shutdown", { language: "js", code: "1" }, undefined, undefined, ctx),
+			tool?.execute(
+				"after-shutdown",
+				{ language: "js", code: "1", summary: "post shutdown" },
+				undefined,
+				undefined,
+				ctx,
+			),
 		).rejects.toMatchObject({ name: "CodemodeSessionDisposedError" });
 		expect([manager.disposeCount, manager.getKernelCount]).toEqual([1, 1]);
 		expect(manager.runControllers[0]?.signal.aborted).toBe(true);
@@ -453,7 +477,7 @@ describe("senpi-codemode extension lifecycle", () => {
 		const notification = pi.nextMessage();
 		const run = tool.execute(
 			"notified-detached",
-			{ language: "js", code: "await pending()", timeout: 1, on_timeout: "detach" },
+			{ language: "js", code: "await pending()", timeout: 1, on_timeout: "detach", summary: "notified detached" },
 			undefined,
 			undefined,
 			ctx,
@@ -481,7 +505,13 @@ describe("senpi-codemode extension lifecycle", () => {
 		await emit(pi, "session_start", { reason: "startup" }, ctx);
 		const tool = pi.registeredTool;
 		if (!tool) throw new Error("eval tool was not registered");
-		const run = tool.execute("tracked-cell", { language: "js", code: "await pending()" }, undefined, undefined, ctx);
+		const run = tool.execute(
+			"tracked-cell",
+			{ language: "js", code: "await pending()", summary: "tracked cell" },
+			undefined,
+			undefined,
+			ctx,
+		);
 		await manager.runStarted.promise;
 
 		// When
@@ -497,7 +527,13 @@ describe("senpi-codemode extension lifecycle", () => {
 		expect(settled.details).toMatchObject({ isError: true, cells: [{ status: "error" }] });
 		expect(manager.events).toEqual(["interrupt", "dispose"]);
 		await expect(
-			tool.execute("after-shutdown", { language: "js", code: "1" }, undefined, undefined, ctx),
+			tool.execute(
+				"after-shutdown",
+				{ language: "js", code: "1", summary: "post shutdown" },
+				undefined,
+				undefined,
+				ctx,
+			),
 		).rejects.toMatchObject({ name: "CodemodeSessionDisposedError" });
 	});
 });

--- a/packages/senpi-codemode/test/output-bridge.test.ts
+++ b/packages/senpi-codemode/test/output-bridge.test.ts
@@ -222,7 +222,7 @@ describe("output bridge", () => {
 		// When
 		await tool.execute(
 			"cell-1",
-			{ language: "js", code: 'await output("st_123")' },
+			{ language: "js", code: 'await output("st_123")', summary: "output read" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -262,7 +262,11 @@ describe("output bridge", () => {
 			// When
 			const evalResult = await tool.execute(
 				"real-output-cell",
-				{ language: "js", code: 'const transcript = await output("st_123"); return transcript;' },
+				{
+					language: "js",
+					code: 'const transcript = await output("st_123"); return transcript;',
+					summary: "output echo",
+				},
 				undefined,
 				undefined,
 				fakeExtensionContext(),

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -90,7 +90,7 @@ describe("buildEvalPrompt", () => {
 
 		// When: their embedded reuse-chain examples are rendered.
 		// Then: only Python kernels carry examples, and those teach batch + tool bridging.
-		expect(python).toContain("collect targets");
+		expect(python).toContain("Count all TypeScript source files under src/ excluding tests");
 		expect(python).toContain("tool.grep");
 		expect(python).toContain("parallel([");
 		expect(ruby).not.toContain("<examples>");

--- a/packages/senpi-codemode/test/schema-bridge.test.ts
+++ b/packages/senpi-codemode/test/schema-bridge.test.ts
@@ -78,7 +78,7 @@ describe("cell-handler dispatch for the reserved schema tool", () => {
 
 		await tool.execute(
 			"cell-1",
-			{ language: "js", code: 'await tool_schema("mcp_computer_use_batch")' },
+			{ language: "js", code: 'await tool_schema("mcp_computer_use_batch")', summary: "schema probe" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),

--- a/packages/senpi-codemode/test/tool-schema-hint.test.ts
+++ b/packages/senpi-codemode/test/tool-schema-hint.test.ts
@@ -63,7 +63,7 @@ describe("kernel tool-call argument failures", () => {
 
 		await tool.execute(
 			"cell-1",
-			{ language: "js", code: 'await tool.mcp_computer_use_batch({app: "Safari"})' },
+			{ language: "js", code: 'await tool.mcp_computer_use_batch({app: "Safari"})', summary: "hint catalog" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),
@@ -82,7 +82,7 @@ describe("kernel tool-call argument failures", () => {
 
 		await tool.execute(
 			"cell-1",
-			{ language: "js", code: "await tool.unlisted_tool({})" },
+			{ language: "js", code: "await tool.unlisted_tool({})", summary: "hint passthrough" },
 			undefined,
 			undefined,
 			fakeExtensionContext(),


### PR DESCRIPTION
## Summary

The eval tool's short `title` label is removed entirely and replaced by a **required** one-line `summary` that the model must write **in the user's own conversational language**, stating what the cell does and for what purpose. The terminal shows that line under the (now title-less) eval header while the cell runs and in the finished result, and background/detached cells use it as their footer label — so it is always visible what a running cell is doing and why.

The writing guide lives inside the tool schema itself, so every model sees it at call time. A run without a summary fails with an instructive, self-correcting error; an over-long summary is trimmed to 80 characters in `prepareArguments` (before schema validation) so it can never turn into a validation failure. Callers that still send the removed `title` keep working — the value is simply ignored.

## Changes

**Schema, parse, and clamp** (`src/tool/types.ts`, `src/tool/eval-request.ts`, `src/tool/eval-tool.ts`)
- `title` removed from `EvalToolInput`, both schema objects, `EvalCellResult`, and `EvalToolDetails`.
- `summary` added: required on `EvalToolInput`, optional on the two result types (legacy stored results predate it). The schema property stays optional because the flat schema object is shared with the `peek`/`stop` actions; required-ness is enforced in `parseEvalRequest` exactly like `language`/`code`.
- `clampEvalSummary` mirrors the proven `clampTaskSummary` behavior (trim, collapse whitespace, force-truncate to 80 with `...`), wired as `prepareArguments` so it runs before schema validation.

**Prompt and docs** (`src/prompt/eval-prompt.ts`, `README.md`)
- Fields section documents `summary` as required with the user-language what+why guide; all three examples carry real summaries; snapshot regenerated. README field docs and the detached-footer doc updated.

**Rendering** (`src/tool/cell-runtime.ts`, `src/tool/render.ts`)
- Header drops the title segment; a muted summary line renders directly beneath it in collapsed and expanded views, in the live/running frame and the result frame. Legacy title-only stored results render without a label and without crashing.

**Detached surfaces** (`src/tool/detached-cell-manager.ts`, `src/tool/detached-cell-snapshot.ts`, `src/extension/eval-status.ts`)
- Status entries carry `summary`; the footer label becomes `summary ?? cellId` within the existing 48-character budget.

**Fork record** (`changes.md`) documents the breaking change and its merge-conflict zones.

## QA & Evidence

- **Schema + parse + clamp (criteria 1, 5, 6):** `npx tsx ../../node_modules/vitest/dist/cli.js --run test/eval-request-summary.test.ts` → 21/21 passed. Covers: run without summary throws the exact teaching error through the real `tool.execute` path; over-limit values clamped to 80 chars in `prepareArguments` before validation; the built schema's summary description carries the verbatim REQUIRED/user-language/WHAT-WHY guide. Artifacts: `.omo/evidence/task-1-codemode-eval-summary-red.txt` / `-green.txt`.
- **Rendering + live text (criterion 2):** render/state/streaming/theme/width/preview + tool-execution suites → 11 files / 106 tests passed. `scripts/qa-render-dump.ts --fixture success|error` frames show a title-less header (`eval py done ✓ · 1s`) with the summary line beneath. Artifacts: `.omo/evidence/task-3-codemode-eval-summary-red.txt` / `-green.txt` / `-legacy.txt`; `local-ignore/qa-evidence/20260804-eval-summary/qa-render-dump-*.txt`. Korean/CJK-width capture: `local-ignore/qa-evidence/20260804-eval-summary-f3/scenario2-render-dump-korean.txt`.
- **Detached footer label (criterion 3):** `eval-status`/`eval-detach`/`eval-detached-peek`/`eval-detached-settlement` suites pass; `labelOf` is `summary ?? cellId`; Korean 48-char-budget case at `test/eval-status.test.ts:49`. Artifact: `.omo/evidence/task-4-orchestrator-verify.txt`.
- **Title fully removed (criterion 4):** `rg -n '\btitle\b' packages/senpi-codemode/src --type ts` hits only phase/status-event seams (http-server, protocol, cell-handler, cell-runtime setPhase, render eventString, kernel preludes). Artifact: `.omo/evidence/task-5-codemode-eval-summary-check.txt`.
- **Legacy tolerance (criterion 7):** title-only stored details re-render without crash and without a label (characterization test in `test/eval-render.test.ts`). Artifact: `.omo/evidence/task-3-codemode-eval-summary-legacy.txt`.
- **Full gates:** package suite 72 files / 508 tests passed (exit 0, single run); `npm run check` exit 0 (biome + pinned-deps + ts-imports + shrinkwrap + install-lock + tsc --noEmit + browser-smoke). Artifact: `.omo/evidence/task-5-codemode-eval-summary-vitest.txt`.


## Risks & Residuals

- **Breaking change for callers:** any client sending `title` loses that label (ignored, not rejected) and any client omitting `summary` now gets an instructive error instead of a silent run. Mitigated by parse-level teaching error + unknown-prop tolerance, both integration-tested.
- **Legacy sessions:** previously stored eval results carry `title` and no `summary`; they re-render without a label and without crashing (characterization test).
- **Phase/status-event `title`** is a different concept and is deliberately untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the eval cell `title` with a required one-line `summary` in the user's language. The summary shows under the header while running and in results, labels detached cells, and is auto-clamped to 80 chars.

- **New Features**
  - `summary` required for `eval run`; `title` is removed and ignored if sent.
  - Summary writing guide lives in the tool schema; README and prompt updated with examples.
  - Clamp to 80 chars in `prepareArguments` (before schema validation).
  - TUI: header drops title; a muted summary line renders beneath it for calls and results.
  - Detached cells use `summary ?? cellId` as the status footer label.
  - Legacy tolerance: stored results with only `title` render without a label and do not crash.
  - `coding-agent` codemode bridge test updated to include a required `summary`.

- **Migration**
  - Update all `eval` calls to include `summary` (one line, user’s conversational language: what the cell does and why).
  - Remove any use of `title` in requests and UIs; it is now ignored.
  - Keep summaries ≤80 chars to avoid truncation.

<sup>Written for commit df738c26625315ecc811c41004cc0fd5783155e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

