### PR TITLE
docs(changelog): audit unreleased changes for v2026.8.4

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,11 +8,21 @@
 
 ### Added
 
+- Added one shared transcript notice system for rule-driven behavior: loop-guard, TTSR, goal continuation, and fallback handling now emit structured activation records and render them through the same notice kit, keeping transcript appearance, metadata, and activation history consistent instead of maintaining four divergent UI paths ([#689](https://github.com/code-yeongyu/senpi/pull/689), [#692](https://github.com/code-yeongyu/senpi/pull/692)).
+- Added cross-turn repetition protection to TTSR: the agent now compares bounded normalized content across consecutive turns, detects repeated response cycles that span turn boundaries, records the triggering pattern, and interrupts the loop before another duplicate turn can continue; deterministic unit coverage and a real mock-loop QA scenario pin the behavior ([#694](https://github.com/code-yeongyu/senpi/pull/694)).
+
 ### Changed
+
+- Shortened the goal continuation grace countdown after an accepted user turn from 60 seconds to 10 seconds, preserving the user's opportunity to cancel automatic continuation while avoiding a full minute of idle time before a goal resumes ([#682](https://github.com/code-yeongyu/senpi/pull/682)).
 
 ### Fixed
 
 - Pinned compiled binary release builds to Bun 1.3.14 instead of the moving canary, keeping all six cross-compilation target executables downloadable during release recovery ([#674](https://github.com/code-yeongyu/senpi/pull/674)).
+- Hid extension and runtime diagnostics emitted through Bun's native `console.info`, `console.warn`, and `console.error` while the interactive TUI owns the terminal, routing them through the existing hidden/redacted stderr sink and restoring the exact original console methods when terminal ownership ends so internal warnings no longer corrupt the transcript ([#677](https://github.com/code-yeongyu/senpi/pull/677)).
+- Recovered required compactions instead of leaving the session in a retry loop or stalled state: failed required compactions can now re-enter recovery, an accepted recovery supersedes the earlier admission error, deterministic fallback sizing is bounded, and stale terminal events remain associated with the superseded attempt rather than poisoning the active recovery ([#684](https://github.com/code-yeongyu/senpi/pull/684)).
+- Suppressed the stream error previously surfaced when a user cancels an in-progress compaction with Escape, treating the abort as an intentional terminal outcome while preserving cleanup and subsequent session usability ([#685](https://github.com/code-yeongyu/senpi/pull/685)).
+- Preserved built-in default fallback chains when users add their own configured chains instead of replacing the defaults wholesale, and identified the exact settings scope responsible when a fallback-chain warning is rendered so project, user, and runtime configuration conflicts can be diagnosed directly ([#686](https://github.com/code-yeongyu/senpi/pull/686)).
+- Restored blocked-goal continuation across interruption boundaries: sessions now prompt to resume goals that were already blocked when the process restarts, and a goal blocked by a provider error resumes on the next accepted user message instead of remaining permanently stuck ([#687](https://github.com/code-yeongyu/senpi/pull/687), [#688](https://github.com/code-yeongyu/senpi/pull/688)).
 
 ### Removed
 

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Breaking Changes
 
+- Replaced the eval tool's optional presentation `title` with a required user-language `summary`: every eval call must now describe the cell's purpose in the user's language, callers using `title` must migrate to `summary`, and the generated tool schema, prompt contract, README examples, bridge fixtures, and test corpus all enforce the new argument ([#695](https://github.com/code-yeongyu/senpi/pull/695)).
+
 ### Added
+
+- Rendered each eval summary inside its transcript cell frame and used the same summary to label detached cells and their completion notices, so concurrent or long-running JavaScript and Python work remains identifiable after detachment and when results arrive asynchronously ([#695](https://github.com/code-yeongyu/senpi/pull/695)).
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- audit all 47 commits and 127 changed files since `v2026.8.3-3`
- add ultra-detailed user-facing release notes for coding-agent PRs #674, #677, #682, #684, #685, #686, #687, #688, #689, #692, and #694
- document the breaking eval `summary` contract and transcript/detached-cell rendering from #695 in the senpi-codemode changelog
- classify merge wrappers, test-only #693, QA companions, change-ledger updates, CI-only maintenance, and release scaffolding without duplicate bullets

## Audit evidence

- RED before edits: 13 merged PRs in range, but only 11 explicitly represented; #682 and #687 were missing
- GREEN after edits: all 47 commits classified, all required PR/package mappings represented, released sections untouched
- complete local evidence:
  - `local-ignore/qa-evidence/20260804-release/pre-edit-changelog-red.md`
  - `local-ignore/qa-evidence/20260804-release/commit-diff-matrix.md`
  - `local-ignore/qa-evidence/20260804-release/post-edit-changelog-green.md`

The evidence directory is intentionally gitignored and remains local.

## Verification

- `npm --prefix packages/coding-agent test -- test/changelog.test.ts` — 2 tests passed
- `git diff --check` — passed
- all six release-managed changelogs contain exactly one `[Unreleased]` section
- only `packages/coding-agent/CHANGELOG.md` and `packages/senpi-codemode/CHANGELOG.md` changed
- `package-lock.json` unchanged

## Release intent

After this PR is merged and `main` is clean/CI-green, the repository release guide will be followed with `scripts/release.mjs` for `v2026.8.4`. The tag-triggered workflow uses GitHub Actions OIDC through the `npm-publish` environment; no local npm token is required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audited and finalized the v2026.8.4 unreleased changelogs. Updated `packages/coding-agent` with clear notes on the new transcript notice system, repetition protection, shorter continuation grace, and recovery/console/fallback fixes; and documented a breaking eval API change and summary rendering in `packages/senpi-codemode`.

- **Migration**
  - Replace eval arg `title` with required `summary` (user-language string).
  - Update callers/tests that referenced `title`; `summary` appears in transcript, detached cells, and completion notices.

<sup>Written for commit 087ac3304beaee93238df723208cccb4b4c8396f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

