### PR TITLE
chore(format): apply biome formatting before release

### DIFF
--- a/packages/coding-agent/test/suite/codemode-bridge.test.ts
+++ b/packages/coding-agent/test/suite/codemode-bridge.test.ts
@@ -110,7 +110,9 @@ async function createCodemodeHarness(options: {
 
 async function runEvalTurn(harness: Harness, code: string): Promise<string> {
 	harness.setResponses([
-		fauxAssistantMessage(fauxToolCall("eval", { language: "js", code, summary: "run eval through bridge hooks" }), { stopReason: "toolUse" }),
+		fauxAssistantMessage(fauxToolCall("eval", { language: "js", code, summary: "run eval through bridge hooks" }), {
+			stopReason: "toolUse",
+		}),
 		(context: FauxContext) => fauxAssistantMessage(extractToolResultText(context)),
 	]);
 

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -132,9 +132,9 @@ describe("resolveRetryFallbackSettings chain defaults", () => {
 	});
 
 	it("replaces a colliding default outright and removes one set to an empty array", () => {
-		expect(resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: ["ccapi/kimi-k3:max"] } }).chains[fableKey]).toEqual(
-			["ccapi/kimi-k3:max"],
-		);
+		expect(
+			resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: ["ccapi/kimi-k3:max"] } }).chains[fableKey],
+		).toEqual(["ccapi/kimi-k3:max"]);
 
 		expect(resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: [] } }).chains).not.toHaveProperty(fableKey);
 	});

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -783,9 +783,7 @@ export function renderEvalCall(
 		const timeout = args.timeout === undefined ? "" : ` timeout ${args.timeout}s`;
 		component.setBlocks([
 			{ kind: "text", text: style(theme, "toolTitle", `eval ${args.language}${reset}${timeout}`) },
-			...(args.summary === undefined
-				? []
-				: [{ kind: "text" as const, text: style(theme, "muted", args.summary) }]),
+			...(args.summary === undefined ? [] : [{ kind: "text" as const, text: style(theme, "muted", args.summary) }]),
 			{
 				kind: "text",
 				text: style(theme, "mdCodeBlock", args.code.trim().length > 0 ? args.code : "..."),

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -141,7 +141,13 @@ describe("eval detached cells", () => {
 			),
 		).rejects.toThrow(/busy running detached cell busy-js[\s\S]*still computing/u);
 		await expect(
-			tool.execute("py-cell", { language: "py", code: "answer = 42", summary: "compute answer in python" }, undefined, undefined, interactiveContext()),
+			tool.execute(
+				"py-cell",
+				{ language: "py", code: "answer = 42", summary: "compute answer in python" },
+				undefined,
+				undefined,
+				interactiveContext(),
+			),
 		).resolves.toSatisfy((value: AgentToolResult<unknown>) => textOf(value).includes("py-ok"));
 
 		await manager.stop("busy-js");
@@ -390,7 +396,13 @@ describe("eval detached cell status emissions", () => {
 		const kernel = new FakeKernel([result("plain-cell", "1")]);
 		const tool = createTool(manager, [["js", kernel]]);
 
-		await tool.execute("plain-cell", { language: "js", code: "1", summary: "plain no detach" }, undefined, undefined, interactiveContext());
+		await tool.execute(
+			"plain-cell",
+			{ language: "js", code: "1", summary: "plain no detach" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
 
 		expect(status.emissions).toEqual([]);
 

--- a/packages/senpi-codemode/test/eval-render-theme.test.ts
+++ b/packages/senpi-codemode/test/eval-render-theme.test.ts
@@ -157,7 +157,9 @@ describe("eval renderer theme hierarchy", () => {
 
 		// When
 		const lines = [
-			...renderEvalCall({ language: "js", code, summary: "collapse previews" }, TEST_THEME, callContext()).render(80),
+			...renderEvalCall({ language: "js", code, summary: "collapse previews" }, TEST_THEME, callContext()).render(
+				80,
+			),
 			...renderEvalResult(result, { expanded: false, isPartial: false }, TEST_THEME, resultContext()).render(80),
 		];
 

--- a/packages/senpi-codemode/test/eval-render.test.ts
+++ b/packages/senpi-codemode/test/eval-render.test.ts
@@ -309,7 +309,11 @@ describe("eval renderer", () => {
 
 	it("Given a result exists when the compact call lane renders then it also yields an empty component", () => {
 		// Given the compact call preview (no theme, no spinner) and the same lane once a result exists
-		const compact = renderEvalCall({ language: "js", code: "1 + 1", summary: "quick math" }, undefined, callContext());
+		const compact = renderEvalCall(
+			{ language: "js", code: "1 + 1", summary: "quick math" },
+			undefined,
+			callContext(),
+		);
 		const yielded = renderEvalCall(
 			{ language: "js", code: "1 + 1", summary: "quick math" },
 			undefined,

--- a/packages/senpi-codemode/test/eval-status.test.ts
+++ b/packages/senpi-codemode/test/eval-status.test.ts
@@ -4,15 +4,8 @@ import type { EvalDetachedCellStatusEntry } from "../src/tool/detached-cell-mana
 
 const T0 = 1_000_000;
 
-function entry(
-	cellId: string,
-	language: "js" | "py",
-	summary?: string,
-	startedAtMs = T0,
-): EvalDetachedCellStatusEntry {
-	return summary === undefined
-		? { cellId, language, startedAtMs }
-		: { cellId, language, summary, startedAtMs };
+function entry(cellId: string, language: "js" | "py", summary?: string, startedAtMs = T0): EvalDetachedCellStatusEntry {
+	return summary === undefined ? { cellId, language, startedAtMs } : { cellId, language, summary, startedAtMs };
 }
 
 describe("formatEvalCellStatus", () => {


### PR DESCRIPTION
## Summary

- apply the seven formatting rewrites produced by the repository's own `npm run check`
- make the release preflight idempotent so `scripts/release.mjs` does not discover unrelated dirty source/test files after running its mandatory check
- preserve runtime and test behavior; this is a Biome-only formatting increment

## Why this blocks the release

On clean merged `main`, the release preflight command:

```sh
npm run check
```

reported `Fixed 7 files` and left the release checkout dirty. The live release script runs the same command before creating its release commits. Landing the formatter output first prevents the release from accidentally carrying unrelated formatter drift or aborting with leftover changes.

## Verification

- first `npm run check`: passed and reported `Fixed 7 files`
- second `npm run check`: passed and reported `No fixes applied`
- coding-agent focused tests: 2 files passed, 15 tests passed
- senpi-codemode focused tests: 72 files passed, 1 skipped; 508 tests passed, 6 skipped
- `git diff --check`: passed
- only the seven formatter-produced files changed

## Test-first note

This is a formatting-only increment with no behavior delta, so it is exempt from a failing-first production test. The idempotence proof is the relevant release gate: unchanged main rewrites seven files, while this branch's second check rewrites none.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies Biome formatting to seven files and makes the release preflight idempotent so `scripts/release.mjs` doesn’t detect unrelated dirty files after `npm run check`. Format-only change; runtime and tests are unchanged.

<sup>Written for commit 2842f1136939ccbd743a2b95692c18eedfa7e781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

