### PR TITLE
test(ai): use current Copilot overflow model

### DIFF
--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -132,9 +132,9 @@ describe("Context overflow error handling", () => {
 	describe("GitHub Copilot (OAuth)", () => {
 		// Google model via Copilot
 		it.skipIf(!githubCopilotToken)(
-			"gemini-2.5-pro - should detect overflow via isContextOverflow",
+			"gemini-3.5-flash - should detect overflow via isContextOverflow",
 			async () => {
-				const model = getModel("github-copilot", "gemini-2.5-pro");
+				const model = getModel("github-copilot", "gemini-3.5-flash");
 				const result = await testContextOverflow(model, githubCopilotToken!);
 				logResult(result);
 


### PR DESCRIPTION
## Summary

- replace the removed GitHub Copilot `gemini-2.5-pro` live overflow-test fixture with `gemini-3.5-flash`
- use a model ID present in both the checked-in catalog and the freshly regenerated catalog
- unblock `scripts/local-release.mjs` and the live release script after model regeneration

## RED

The guide-mandated local release smoke ran model generation and then failed root type-checking:

```text
packages/ai/test/context-overflow.test.ts:137:46 - error TS2345:
Argument of type '"gemini-2.5-pro"' is not assignable ...
```

The refreshed Copilot catalog contains `gemini-3.1-pro-preview`, `gemini-3.5-flash`, and `gemini-3.6-flash`; `gemini-2.5-pro` has been removed.

## GREEN

- root `npm run check` passes against the checked-in catalog with no formatter changes
- `npm --prefix packages/ai run generate-models` completes with 1,172 tool-capable models
- root `npm run check` passes again against the regenerated catalog
- `packages/ai/test/context-overflow.test.ts` imports/type-checks successfully; all 35 credential-gated live cases remain skipped without real credentials
- `git diff --check` passes

## Scope

One test fixture changes; no provider runtime behavior or generated catalog is committed by this PR. The release script remains responsible for committing the freshly generated catalog as part of the versioned release artifacts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the GitHub Copilot overflow test to use `gemini-3.5-flash` instead of the removed `gemini-2.5-pro`. This fixes the type error after model catalog regeneration and unblocks the release scripts.

- **Bug Fixes**
  - Use a model ID present in both the checked-in and regenerated catalogs.
  - Root checks pass before and after catalog generation; live overflow tests remain skipped without credentials.

<sup>Written for commit 5b8c182bda6425abc512d22206691ea09f471a17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

