### PR TITLE
fix(apply-patch): enable codemode lazy activation

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## Codemode lazy activation (2026-08-04)
+
+### What changed
+
+- `extension.ts`: tracks the current apply-patch wire mode and registers an extension-owned lazy activator. When codemode requests the already-registered `apply_patch` tool through `executeTool(..., { activateInactiveTool: true })`, the activator adds it to the live tool set only for eligible GPT/OpenAI wire modes.
+- `types.ts`: the narrow apply-patch extension API accepts the runtime's lazy-activator registration hook while remaining usable by isolated extension stubs that do not provide it.
+
+### Why
+
+The apply-patch extension deliberately preserves an active tool set that contains neither `edit` nor `write`, so `apply_patch` can remain registered but inactive. Codemode exposes registered extension tool schemas and asks the owning extension to authorize lazy activation, but apply-patch did not register that authorization. Eval calls therefore failed with `Tool apply_patch is registered but inactive` even on eligible GPT/OpenAI models.
+
+### Why this belongs in the extension
+
+Inactive-tool eligibility is intentionally owned by the registering extension. A core fallback that activates every registered tool would bypass permission, tombstone, model-gating, and user-selection policies. The apply-patch extension can safely decide eligibility from its current wire mode without changing generic tool-registry behavior.
+
+### Expected upstream conflict zones
+
+- `extension.ts`: apply-patch model/session toolset synchronization, local state shape, and event registration order.
+- `types.ts`: the narrowed `ApplyPatchExtensionAPI` surface.
+
 ## Compact completed result retention (2026-08-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/extension.ts
@@ -61,10 +61,14 @@ function hasApplyPatchFailures(details: unknown): boolean {
 function syncToolset(
 	pi: ApplyPatchExtensionAPI,
 	model: Model<string> | undefined,
-	state: ApplyPatchToolsetState & { activeVariant?: ApplyPatchToolVariant },
+	state: ApplyPatchToolsetState & {
+		activeVariant?: ApplyPatchToolVariant;
+		wireMode: ApplyPatchWireMode;
+	},
 	variants: Readonly<Record<ApplyPatchToolVariant, ReturnType<typeof createApplyPatchTool>>>,
 ): void {
 	const mode = getApplyPatchWireMode(model);
+	state.wireMode = mode;
 	const currentToolNames = pi.getActiveTools();
 	if (mode !== "none") {
 		if (state.activeVariant !== mode) {
@@ -87,14 +91,31 @@ function syncToolset(
 	pi.setActiveTools([...new Set(restored)]);
 }
 
+function registerApplyPatchLazyActivator(
+	pi: ApplyPatchExtensionAPI,
+	state: { readonly wireMode: ApplyPatchWireMode },
+): void {
+	pi.registerLazyToolActivator?.((toolName) => {
+		if (toolName !== APPLY_PATCH_NAME || state.wireMode === "none") return false;
+		const activeToolNames = pi.getActiveTools();
+		if (activeToolNames.includes(APPLY_PATCH_NAME)) return false;
+		pi.setActiveTools([...activeToolNames, APPLY_PATCH_NAME]);
+		return true;
+	});
+}
+
 export function registerApplyPatchExtension(pi: ApplyPatchExtensionAPI): void {
-	const state: ApplyPatchToolsetState & { activeVariant?: ApplyPatchToolVariant } = { removedEditToolNames: [] };
+	const state: ApplyPatchToolsetState & {
+		activeVariant?: ApplyPatchToolVariant;
+		wireMode: ApplyPatchWireMode;
+	} = { removedEditToolNames: [], wireMode: "none" };
 	const variants = {
 		freeform: createApplyPatchTool("freeform"),
 		json: createApplyPatchTool("json"),
 	} as const;
 	state.activeVariant = "freeform";
 	pi.registerTool(variants.freeform);
+	registerApplyPatchLazyActivator(pi, state);
 	pi.on("tool_result", async (event) => {
 		if (event.toolName !== APPLY_PATCH_NAME || event.isError || !hasApplyPatchFailures(event.details)) {
 			return undefined;

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/types.ts
@@ -140,4 +140,5 @@ export type ApplyPatchToolDefinition = ToolDefinition<
 
 export type ApplyPatchExtensionAPI = Pick<ExtensionAPI, "on" | "getActiveTools" | "getAllTools" | "setActiveTools"> & {
 	registerTool: (tool: ApplyPatchToolDefinition) => void;
+	registerLazyToolActivator?: ExtensionAPI["registerLazyToolActivator"];
 };

--- a/packages/senpi-codemode/test/eval-extension-tools.test.ts
+++ b/packages/senpi-codemode/test/eval-extension-tools.test.ts
@@ -1,0 +1,117 @@
+import type { AgentToolResult, ToolDefinition } from "@code-yeongyu/senpi";
+import { describe, expect, it } from "vitest";
+import registerApplyPatchExtension from "../../coding-agent/src/core/extensions/builtin/gpt-apply-patch/extension.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+type ExtensionHandler = (event: unknown, context: unknown) => unknown;
+type LazyToolActivator = (toolName: string) => boolean;
+
+const PATCH_SENTINEL = "extension apply_patch reached";
+
+function createApplyPatchEvalHarness(model: { readonly api: string; readonly id: string }) {
+	const handlers = new Map<string, ExtensionHandler>();
+	const registeredTools = new Map<string, ToolDefinition>();
+	let activeToolNames: string[] = [];
+	let lazyToolActivator: LazyToolActivator | undefined;
+
+	registerApplyPatchExtension({
+		registerTool(tool: ToolDefinition) {
+			registeredTools.set(tool.name, tool);
+		},
+		registerLazyToolActivator(activate: LazyToolActivator) {
+			lazyToolActivator = activate;
+		},
+		getActiveTools: () => [...activeToolNames],
+		getAllTools: () => [...registeredTools.values()],
+		setActiveTools(toolNames: string[]) {
+			activeToolNames = [...toolNames];
+		},
+		on(event: string, handler: ExtensionHandler) {
+			handlers.set(event, handler);
+		},
+	} as never);
+
+	const selectModel = async () => {
+		const handler = handlers.get("model_select");
+		if (!handler) throw new Error("apply_patch extension did not register model_select");
+		await handler({ model }, { model });
+	};
+	const executeTool = async (toolName: string): Promise<AgentToolResult<unknown>> => {
+		if (!registeredTools.has(toolName)) throw new Error(`Unknown tool ${toolName}`);
+		if (!activeToolNames.includes(toolName) && lazyToolActivator?.(toolName) !== true) {
+			throw new Error(`Tool ${toolName} is registered but inactive. Active tools: ${activeToolNames.join(", ")}`);
+		}
+		return { content: [{ type: "text", text: PATCH_SENTINEL }], details: {} };
+	};
+
+	return { executeTool, selectModel };
+}
+
+async function invokeApplyPatchThroughEval(
+	harness: ReturnType<typeof createApplyPatchEvalHarness>,
+	cellId: string,
+): Promise<FakeKernel> {
+	await harness.selectModel();
+	const kernel = new FakeKernel([
+		{
+			type: "tool-call",
+			callId: `${cellId}-call`,
+			toolName: "apply_patch",
+			args: { input: "*** Begin Patch\n*** End Patch" },
+		},
+		result(cellId, "done"),
+	]);
+	const tool = createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager: new FakeManager([["js", kernel]]),
+		cellTimeoutSeconds: 30,
+		executeTool: harness.executeTool,
+	});
+	await tool.execute(
+		cellId,
+		{
+			language: "js",
+			code: "await tool.apply_patch({input: patch})",
+			summary: "Invoke the extension-provided apply_patch tool through eval",
+		},
+		undefined,
+		undefined,
+		fakeExtensionContext(),
+	);
+	return kernel;
+}
+
+describe("eval extension tools", () => {
+	it("calls an eligible inactive apply_patch extension tool through eval", async () => {
+		const harness = createApplyPatchEvalHarness({
+			api: "openai-responses",
+			id: "gpt-5.6-sol",
+		});
+		const kernel = await invokeApplyPatchThroughEval(harness, "extension-cell");
+
+		expect(kernel.replies).toContainEqual({
+			type: "tool-reply",
+			callId: "extension-cell-call",
+			ok: true,
+			value: { text: PATCH_SENTINEL },
+		});
+	});
+
+	it("keeps apply_patch inactive for an ineligible model", async () => {
+		const harness = createApplyPatchEvalHarness({
+			api: "anthropic-messages",
+			id: "claude-fable-5",
+		});
+		const kernel = await invokeApplyPatchThroughEval(harness, "ineligible-cell");
+
+		expect(kernel.replies).toContainEqual({
+			type: "tool-reply",
+			callId: "ineligible-cell-call",
+			ok: false,
+			error: {
+				message: "Tool apply_patch is registered but inactive. Active tools: ",
+			},
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- let the built-in `apply_patch` extension authorize codemode's existing lazy-activation path on eligible GPT/OpenAI wire modes
- preserve explicit inactive-tool rejection for ineligible models and all other registered tools
- add focused eval-bridge regression coverage and record the fork-specific merge surface

## Root cause

`apply_patch` is always registered, but the extension intentionally preserves an
active tool set that contains neither `edit` nor `write`. Senpi-codemode exposes
registered schemas and invokes `executeTool(..., { activateInactiveTool: true })`,
but inactive eligibility belongs to the registering extension. MCP registered a
lazy activator; apply-patch did not, so eligible eval calls failed with:

`Tool apply_patch is registered but inactive`

The fix stays in the apply-patch extension rather than adding an unsafe core
fallback that could activate permission-denied, tombstoned, model-gated, or
user-hidden tools.

## Verification

- RED captured before production edits: eligible apply-patch eval call returned the exact inactive-tool error
- focused GREEN: `eval-extension-tools.test.ts` — 2/2 passed
- adjacent regressions: 6 files, 72/72 passed
- changed-file TypeScript LSP diagnostics: 0
- real built CLI: eval called both a sandbox extension tool and inactive `apply_patch`; sentinel returned and target file changed
- Senpi QA: mock-loop 4/4 and CLI smoke 8/8
- `npm run build`: passed
- `npm run check`: passed
- `npm test`: passed across all workspaces
- `git diff --check`: passed

Local evidence was captured under:
`local-ignore/qa-evidence/20260804-codemode-extension-tools/`

## Risk

Lazy activation promotes `apply_patch` into the live active set for the
remainder of an eligible session. This matches the existing MCP lazy-activation
contract. Ineligible model/API modes continue to reject the call.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable lazy activation of `apply_patch` for codemode on eligible GPT/OpenAI wire modes to stop “registered but inactive” errors. Ineligible models still reject the tool.

- **Bug Fixes**
  - Tracks wire mode and registers a lazy activator to add `apply_patch` only when eligible.
  - Adds `registerLazyToolActivator` to `ApplyPatchExtensionAPI` for safe, extension-owned activation.
  - Adds eval tests covering eligible activation and ineligible rejection.

<sup>Written for commit 87d7ff45b4adacba210ab9af42cb4a96150252e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

