### PR TITLE
fix(release): align local smoke package set

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 
+- Aligned the isolated local-release smoke package set with the actual Senpi release boundary: it no longer builds or packs the independently versioned SQLite storage workspace or the private server workspace, preventing unrelated upstream API drift in those packages from blocking validation of the eight packages that the local Senpi artifact actually installs.
 - Pinned compiled binary release builds to Bun 1.3.14 instead of the moving canary, keeping all six cross-compilation target executables downloadable during release recovery ([#674](https://github.com/code-yeongyu/senpi/pull/674)).
 - Hid extension and runtime diagnostics emitted through Bun's native `console.info`, `console.warn`, and `console.error` while the interactive TUI owns the terminal, routing them through the existing hidden/redacted stderr sink and restoring the exact original console methods when terminal ownership ends so internal warnings no longer corrupt the transcript ([#677](https://github.com/code-yeongyu/senpi/pull/677)).
 - Recovered required compactions instead of leaving the session in a retry loop or stalled state: failed required compactions can now re-enter recovery, an accepted recovery supersedes the earlier admission error, deterministic fallback sizing is bounded, and stale terminal events remain associated with the superseded attempt rather than poisoning the active recovery ([#684](https://github.com/code-yeongyu/senpi/pull/684)).

--- a/scripts/local-release.mjs
+++ b/scripts/local-release.mjs
@@ -16,10 +16,8 @@ const packages = [
 	{ directory: "packages/agent", name: "@earendil-works/pi-agent-core" },
 	{ directory: "packages/protocol", name: "@earendil-works/pi-protocol" },
 	{ directory: "packages/client", name: "@earendil-works/pi-client" },
-	{ directory: "packages/storage/sqlite-node", name: "@earendil-works/pi-storage-sqlite-node" },
 	{ directory: "packages/senpi-codemode", name: "@code-yeongyu/senpi-codemode" },
 	{ directory: "packages/coding-agent", name: "@code-yeongyu/senpi" },
-	{ directory: "packages/server", name: "@code-yeongyu/senpi-server" },
 ];
 const packageCliCommand = "senpi";
 function printUsage() {

--- a/scripts/local-release.test.mjs
+++ b/scripts/local-release.test.mjs
@@ -89,8 +89,21 @@ describe("local release package list", () => {
 			.map((line) => JSON.parse(line));
 		const testIndex = npmCalls.findIndex((call) => call.args.join(" ") === "test");
 		const lastBuildIndex = npmCalls.findLastIndex((call) => call.args.join(" ") === "run build");
+		const excludedPackageSuffixes = [
+			`${sep}packages${sep}storage${sep}sqlite-node`,
+			`${sep}packages${sep}server`,
+		];
 		assert.ok(testIndex > lastBuildIndex, "expected local-release to build every package before running tests");
 		assert.equal(npmCalls[testIndex]?.ci, "1", "expected local-release tests to use deterministic CI concurrency");
+		assert.equal(
+			npmCalls.some(
+				(call) =>
+					excludedPackageSuffixes.some((suffix) => call.cwd.endsWith(suffix)) &&
+					(call.args.join(" ") === "run build" || call.args[0] === "pack"),
+			),
+			false,
+			"expected local-release to exclude independently versioned storage and private server packages",
+		);
 		assert.ok(
 			npmCalls.some((call) => call.cwd.endsWith(ptyDirectorySuffix) && call.args.join(" ") === "run build"),
 			"expected local-release to build packages/pty",


### PR DESCRIPTION
## Summary

- align the isolated local-release smoke package list with the actual Senpi artifact boundary
- stop building and packing `packages/storage/sqlite-node`, which follows an independent upstream semver/API line
- stop building and packing the private `packages/server` workspace
- retain the eight packages required by the isolated npm/Bun installs, including bundled-only client/protocol and source-only codemode

## RED

After the model catalog was regenerated successfully, the guide-mandated local release smoke failed while building an unrelated workspace:

```text
packages/storage/sqlite-node/src/sqlite/storage/index.ts:1:42
Module '"@earendil-works/pi-agent-core"' has no exported member 'SessionReader'.
```

The package is explicitly excluded from the lockstep/publish release set and retains independent version `0.83.0`, so its upstream API drift must not block Senpi's isolated release artifact.

## GREEN

- new failing-first test proves storage/server build or pack calls are forbidden
- script suite: 86 tests passed
- root `npm run check`: passed with no formatter changes
- changelog test: 2 tests passed
- full corrected `npm run release:local -- --force`: exit 0
- full workspace suite inside the smoke: 817 test files passed, 6,807 tests passed, expected skips only
- generated eight intended tarballs
- generated local Bun binary, isolated npm install, and isolated Bun install
- manual artifact QA:
  - isolated npm CLI `--version`: `2026.8.3-3`
  - local Bun binary `--version`: `2026.8.3-3`
  - isolated Bun package CLI `--version`: `2026.8.3-3`
  - npm and Bun `--help`: exit 0 with expected usage
  - `senpi update nonsense --no-approve`: exits nonzero with `No matching package found for nonsense`

## Changelog

Adds an `[Unreleased]` maintainer-facing fix documenting that local release validation now covers the eight packages installed by the local Senpi artifact rather than unrelated independent/private workspaces.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the local release smoke test and packaging with the actual Senpi artifact boundary. Prevents unrelated workspace changes from blocking validation by excluding the independently versioned SQLite storage and the private server packages.

- **Bug Fixes**
  - Excludes `packages/storage/sqlite-node` (`@earendil-works/pi-storage-sqlite-node`) and `packages/server` (`@code-yeongyu/senpi-server`) from build/pack in `scripts/local-release.mjs`.
  - Adds a test that forbids build/pack calls for those workspaces and ensures remaining packages build before tests.
  - Keeps the eight shipped packages, including bundled-only client/protocol and source-only codemode, in the smoke set.

<sup>Written for commit 8ffc1d34c4952ab346dc7dd2a0da4bcc7d1a2998. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

