### PR TITLE
ci(release): delegate npm publish to the publish-npm identity

### DIFF
--- a/.github/agent/skills/release-publish/SKILL.md
+++ b/.github/agent/skills/release-publish/SKILL.md
@@ -32,35 +32,26 @@ Run `scripts/release.mjs` from a clean `main` checkout.
 - [ ] Use a clean dedicated clone if the main checkout has foreign state.
 - [ ] Never clean, stash, or otherwise disturb other people's work.
 - [ ] Use the protected-main path when needed; `UPSTREAM_AUTOMATION_TOKEN` exists for authenticated protected-main pushes.
-- [ ] Known broken today: the tag pipeline's `publish-npm` job fails its OIDC publish with npm PUT 404 (observed on v2026.7.28-2 AND v2026.7.28-3, 2026-07-28): the job carries `environment: npm-publish`, whose OIDC subject does not match the npm trusted-publisher registration. Until the registration accepts the environment subject (or the environment is removed from the job), publish through `gh workflow run publish-npm.yml -f version=<v> -f publish-only=true` — the proven-working route used for v2026.7.28, -2, and -3.
+- [ ] npm publish is delegated: the tag pipeline's `publish-npm` job no longer publishes — it dispatches `publish-npm.yml` in publish-only mode (the proven route from the v2026.7.28-x and v2026.8.4 recoveries) and gates the public GitHub Release on that run's success. npm's trusted publisher matches the `publish-npm.yml` workflow identity only; never reintroduce a direct publish or an `environment:` on the publish path (the environment subject is what npm rejects).
 - [ ] Do not rerun `scripts/release.mjs` after the tag has been pushed.
 - [ ] If checks fail before the tag push, fix first, then re-release from the beginning.
 - [ ] Treat `E404` noise for `@code-yeongyu/senpi-orchestrator` as non-fatal.
 - [ ] Use `node scripts/release-notes.mjs` / the cl.md audit before publishing notes.
 - [ ] Keep release notes product-facing only.
 
-## Approval checkpoint
-
-This is the step past sessions risked forgetting.
+## Publish watch
 
 After tag push, watch the `build-binaries` workflow run (find the run id via `gh run list --workflow=build-binaries.yml --branch main --limit 1 --json databaseId -q '.[0].databaseId'`).
 
-After `stage-github-release`, check `publish-npm` for a pending `npm-publish` Environment deployment and approve it. Discover what is pending first, then approve:
+The `publish-npm` job dispatches `publish-npm.yml` in publish-only mode, prints the dispatched run URL, waits up to 60 minutes, and fails if the publish run fails. There is no environment approval gate on the publish path — the old `npm-publish` environment subject is exactly what npm's trusted-publisher registration rejects.
 
-```bash
-# List pending deployments for the run (shows environment name + id)
-gh api repos/code-yeongyu/senpi/actions/runs/<run_id>/pending_deployments
-# Approve the npm-publish deployment
-gh api repos/code-yeongyu/senpi/actions/runs/<run_id>/pending_deployments -X POST -F environment_ids[]=<id> -F comment="release approval"
-```
-
-Never consider the release done before `publish-npm` and `publish-github-release` complete and the GitHub Release is non-draft.
+Never consider the release done before `publish-npm` and `publish-github-release` complete and the GitHub Release is non-draft. If the publish job fails, recover with `gh workflow run publish-npm.yml -f version=<v> -f publish-only=true`, never by rerunning `release.mjs`.
 
 ## Gate disambiguation
 
 These are separate controls and must not be conflated:
 
-- GitHub Environment approval: the `npm-publish` pending deployment gate.
+- GitHub Environment approval: removed from the publish path (the `npm-publish` environment subject is what npm rejects); the unused environment may remain in repo settings harmlessly.
 - npm OIDC trusted publishing: the npm-side trusted publishing path used by the job.
 - npm lifecycle-script review: the `npm approve-scripts --allow-scripts-pending` trust review, which is not publish approval.
 - Protected-main authorization: the authenticated push path for protected `main`, which is distinct from publish approval.
@@ -68,7 +59,7 @@ These are separate controls and must not be conflated:
 ## Hazards and hard rules
 
 - Protected-main push failures are expected if the token path is wrong; use `UPSTREAM_AUTOMATION_TOKEN` for the authenticated release push path.
-- The tag pipeline's environment-gated `publish-npm` job currently 404s on OIDC (see Pre-flight checklist); `.github/workflows/publish-npm.yml` publish-only is the working publish route until the npm trusted-publisher registration accepts the `npm-publish` environment subject. Re-check after any npm-side config change.
+- The tag pipeline publishes only through the dispatched `publish-npm.yml` identity (see Pre-flight checklist). If npm-side config changes, re-verify with a `dry_run` dispatch before the next release.
 - Never rerun `scripts/release.mjs` after the tag is pushed. If publishing fails, recover from the existing tag workflow.
 - If a check or test fails before the tag push, stop and fix the issue, then re-release. Do not try to salvage a bad release by continuing past the failure.
 - `E404` noise for `@code-yeongyu/senpi-orchestrator` is not a release failure.

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -14,6 +14,11 @@ on:
         description: 'Source ref to build/publish (defaults to tag; use only for release recovery)'
         required: false
         type: string
+      dry_run:
+        description: 'Build and validate only: skip the GitHub Release upload and the npm publish dispatch'
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -112,6 +117,7 @@ jobs:
   stage-github-release:
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ inputs.dry_run != true }}
     permissions:
       actions: read
       contents: write
@@ -195,54 +201,63 @@ jobs:
             exit 1
           fi
 
+  # npm trusted publishing is bound to the publish-npm.yml workflow identity
+  # (workflow_ref), so this workflow must never publish directly. Dispatch
+  # publish-npm.yml in publish-only mode — the same mechanism used for manual
+  # release recovery — and gate the public GitHub Release on its result.
   publish-npm:
     runs-on: ubuntu-latest
     needs: stage-github-release
-    environment: npm-publish
+    if: ${{ inputs.dry_run != true }}
     permissions:
-      contents: read
-      id-token: write
+      actions: write
     env:
+      GH_REPO: ${{ github.repository }}
       RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
-      SOURCE_REF: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref_name }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          ref: ${{ env.SOURCE_REF }}
-          persist-credentials: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-          cache: npm
-
-      - name: Install system dependencies
+      - name: Dispatch publish-npm.yml
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev fd-find ripgrep
-          sudo ln -s "$(which fdfind)" /usr/local/bin/fd
+          set -euo pipefail
 
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
+          VERSION="${RELEASE_TAG#v}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          # One minute of lookback absorbs runner/GitHub clock skew when the
+          # await step matches the dispatched run by creation time.
+          echo "not_before=$(date -u -d '1 minute ago' +%Y-%m-%dT%H:%M:%SZ)" >> "${GITHUB_OUTPUT}"
+          gh workflow run publish-npm.yml -f version="${VERSION}" -f publish-only=true
 
-      # Build only — the tagged commit already passed the required "Check and test"
-      # status gate on main (full `npm run check` + `npm test`). Re-running the whole
-      # workspace test suite here is redundant and, on this contended publish runner,
-      # its subprocess-heavy suites (app-server/daemon, MCP, PTY) leak handles and hang
-      # the job. Build produces the dist artifacts `scripts/publish.mjs` bundles.
-      - name: Build
-        run: npm run build
-
-      - name: Upgrade npm for trusted publishing
+      - name: Await publish-npm.yml completion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOT_BEFORE: ${{ steps.dispatch.outputs.not_before }}
         run: |
-          npm install -g npm@11.16.0 --ignore-scripts
-          npm --version
+          set -euo pipefail
 
-      - name: Publish npm packages
-        run: node scripts/publish.mjs
+          # The dispatched run can take a few seconds to appear in the API.
+          run_id=""
+          for _ in $(seq 1 12); do
+            run_id="$(gh run list --workflow publish-npm.yml --event workflow_dispatch --limit 20 \
+              --json databaseId,createdAt \
+              --jq "[.[] | select(.createdAt >= \"${NOT_BEFORE}\")] | .[0].databaseId // empty")"
+            if [[ -n "${run_id}" ]]; then
+              break
+            fi
+            sleep 5
+          done
+
+          if [[ -z "${run_id}" ]]; then
+            echo "::error::Could not find the dispatched publish-npm.yml run."
+            exit 1
+          fi
+
+          echo "Watching publish-npm.yml run ${run_id}: https://github.com/${GH_REPO}/actions/runs/${run_id}"
+          if ! timeout 3600 gh run watch "${run_id}" --exit-status --interval 20; then
+            echo "::error::publish-npm.yml run ${run_id} failed or exceeded the 60 minute wait budget."
+            exit 1
+          fi
 
   publish-github-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,7 +8,7 @@ name: Release
         required: false
         type: string
         default: ''
-      dry-run:
+      dry_run:
         description: 'Dry-run preview only (no publish or push)'
         required: false
         type: boolean
@@ -82,7 +82,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             ARGS+=(--version "${{ inputs.version }}")
           fi
-          if [ "${{ inputs.dry-run }}" = "true" ]; then
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
             ARGS+=(--dry-run)
           fi
           npm run release -- "${ARGS[@]}"
@@ -91,6 +91,7 @@ jobs:
         if: inputs.publish-only == true
         env:
           EXPECTED_VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           test -n "$EXPECTED_VERSION" || {
             echo "publish-only requires an explicit version" >&2
@@ -101,7 +102,11 @@ jobs:
             echo "expected $EXPECTED_VERSION, found $ACTUAL_VERSION" >&2
             exit 1
           }
-          node scripts/publish.mjs
+          PUBLISH_ARGS=()
+          if [ "$DRY_RUN" = "true" ]; then
+            PUBLISH_ARGS+=(--dry-run)
+          fi
+          node scripts/publish.mjs "${PUBLISH_ARGS[@]}"
 
       - name: Workflow summary
         if: always()
@@ -114,6 +119,7 @@ jobs:
             echo "| --- | --- |"
             echo "| Job status | ${{ job.status }} |"
             echo "| Mode | ${{ inputs.publish-only && 'publish-only' || 'release' }} |"
+            echo "| Dry run | ${{ inputs.dry_run }} |"
             echo "| Version | ${{ inputs.version || 'auto' }} |"
             echo "| Commit | ${{ github.sha }} |"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

The tag pipeline's npm publish has failed on **three consecutive releases** — v2026.7.28-2, v2026.7.28-3, and v2026.8.4 — each time with `npm error code E404` / `404 Not Found - PUT` while publishing packages that already exist.

Root cause: npm's trusted-publisher registration matches the **caller** workflow identity (`workflow_ref`). `build-binaries.yml` published directly, so its OIDC token carried `build-binaries.yml` (plus the `npm-publish` environment subject) — neither of which npm trusts. Every recovery so far used the same manual workaround: `gh workflow run publish-npm.yml -f version=<v> -f publish-only=true` (v2026.8.4 recovery: run 30897391411, success).

`.github/agent/skills/release-publish/SKILL.md` has carried this as "Known broken today" since 2026-07-28. This PR codifies the proven workaround into the pipeline.

## Change

- `build-binaries.yml`'s `publish-npm` job no longer checks out, builds, or publishes. With `permissions: actions: write` it dispatches `publish-npm.yml -f version=<tag minus v> -f publish-only=true`, so the OIDC token always carries the `publish-npm.yml` identity npm trusts.
- The job then locates the dispatched run (creation-time filter with a 1-minute clock-skew margin) and gates on `gh run watch --exit-status` with a 60-minute budget — a failed publish fails `build-binaries` **before** the GitHub Release goes public.
- New `dry_run` input on both workflows: on `build-binaries` it skips the release upload and the dispatch; on `publish-npm.yml` it routes to `scripts/publish.mjs --dry-run`, which pack-validates all six packages and exits before any real publish.
- `publish-npm.yml`'s input `dry-run` renamed to `dry_run`. The hyphenated form was unusable in GitHub expressions (`inputs.dry-run` parses as subtraction), so the dry-run path was latently broken; no caller referenced the old name.
- SKILL.md updated: the "Known broken today" entry, the approval checkpoint, gate disambiguation, and the hazards entry now describe the delegated path.

## Reviewer note — the environment approval gate is gone, deliberately

The old `publish-npm` job carried `environment: npm-publish`. That environment's OIDC subject is **precisely what npm rejects**, and `publish-npm.yml` — the path that actually works — has never had an environment. Keeping the gate would mean keeping the broken path; adding it to `publish-npm.yml` would break the working one. Publishing remains gated by repo write access (tag push via `release.mjs`, or maintainer dispatch). The now-unused `npm-publish` environment can be deleted in repo settings as a follow-up.

## Evidence

- **RED**: run 30896845086 → `npm error code E404`, `404 Not Found - PUT` in the `publish-npm` job.
- **GREEN**: `actionlint .github/workflows/build-binaries.yml .github/workflows/publish-npm.yml` → exit 0, zero findings.
- Workflow contract tests: `scripts/build-binaries-workflow.test.mjs`, `scripts/publish-workflow.test.mjs` → 4/4 pass, unmodified.
- OIDC behavior confirmed by research: npm matches `workflow_ref` (caller), not `job_workflow_ref` — so a `workflow_call`/reusable-workflow design would still have been rejected. `workflow_dispatch` is a documented exception to the "GITHUB_TOKEN events do not trigger workflows" rule, which is why the dispatch route works.
- Post-merge QA: `gh workflow run build-binaries.yml -f tag=v2026.8.4 -f source_ref=v2026.8.4 -f dry_run=true` exercises the chain with no publish and no release mutation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delegate npm publish to the trusted `publish-npm.yml` identity to fix npm trusted-publisher E404s and gate the GitHub Release on its success. Adds dry-run support and removes the broken environment gate from the publish path.

- **Bug Fixes**
  - `build-binaries.yml` stops publishing and dispatches `publish-npm.yml` with `publish-only=true` so the OIDC token matches the trusted workflow.
  - Watches the dispatched run (60‑minute budget) and fails the pipeline if it fails, before the release goes public.
  - Removes the `npm-publish` environment gate from the publish path to avoid the rejected OIDC subject.

- **New Features**
  - Adds `dry_run` input to both workflows; build path skips release upload and dispatch, publish path routes to `scripts/publish.mjs --dry-run`.
  - Renames `dry-run` to `dry_run` in `publish-npm.yml` for expression compatibility; updates SKILL docs to reflect the delegated publish flow.

<sup>Written for commit f095db910b1806e196b5fe5357f8a770d200960d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

