### PR TITLE
ci(changelog): gate PRs on CHANGELOG [Unreleased] entries

### DIFF
--- a/.github/workflows/changelog-gate.yml
+++ b/.github/workflows/changelog-gate.yml
@@ -1,0 +1,43 @@
+name: Changelog gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changelog-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # User-facing PRs must ship a CHANGELOG [Unreleased] entry (or carry the
+  # `no-changelog` label) so release archaeology stops catching missed entries.
+  changelog-gate:
+    name: Changelog gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '24'
+
+      - name: Check PR changelog
+        run: node scripts/check-pr-changelog.mjs --base ${{ github.event.pull_request.base.sha }} --labels "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Changelog gate"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -47,6 +48,36 @@ jobs:
         run: |
           {
             echo "## Static checks"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # User-facing PRs must ship a CHANGELOG [Unreleased] entry (or carry the
+  # `no-changelog` label) so release archaeology stops catching missed entries.
+  changelog-gate:
+    name: Changelog gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '24'
+
+      - name: Check PR changelog
+        run: node scripts/check-pr-changelog.mjs --base ${{ github.event.pull_request.base.sha }} --labels "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Changelog gate"
             echo "- Status: ${{ job.status }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -48,36 +47,6 @@ jobs:
         run: |
           {
             echo "## Static checks"
-            echo "- Status: ${{ job.status }}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  # User-facing PRs must ship a CHANGELOG [Unreleased] entry (or carry the
-  # `no-changelog` label) so release archaeology stops catching missed entries.
-  changelog-gate:
-    name: Changelog gate
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: '24'
-
-      - name: Check PR changelog
-        run: node scripts/check-pr-changelog.mjs --base ${{ github.event.pull_request.base.sha }} --labels "${{ join(github.event.pull_request.labels.*.name, ',') }}"
-
-      - name: Workflow summary
-        if: always()
-        shell: bash
-        run: |
-          {
-            echo "## Changelog gate"
             echo "- Status: ${{ job.status }}"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/scripts/check-pr-changelog.mjs
+++ b/scripts/check-pr-changelog.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+// Release-managed packages (see .github/agent/commands/cl.md). Runtime source
+// changes under these trees must ship a CHANGELOG.md [Unreleased] entry in the
+// same PR, unless the PR carries the `no-changelog` label.
+const RELEASE_MANAGED_PACKAGES = ["ai", "agent", "coding-agent", "tui", "pty", "senpi-codemode"];
+const RUNTIME_SOURCE_PATTERN = new RegExp(`^packages/(?:${RELEASE_MANAGED_PACKAGES.join("|")})/src/`);
+const CRATES_SOURCE_PATTERN = /^crates\/senpi-pty\//;
+const CHANGELOG_PATTERN = /(^|\/)CHANGELOG\.md$/i;
+const NO_CHANGELOG_LABEL = "no-changelog";
+
+// Generated model catalogs are excluded from changelog audits per cl.md unless
+// accompanied by an intentional product-facing change.
+const GENERATED_CATALOG_FILES = new Set([
+	"packages/ai/src/models.generated.ts",
+	"packages/ai/src/image-models.generated.ts",
+]);
+
+function isTestFile(path) {
+	return /(^|\/)(__tests__|tests?)\//.test(path) || /\.(test|spec)(-d)?\.[cm]?[jt]sx?$/.test(path);
+}
+
+function isDocsFile(path) {
+	return /\.(md|mdx)$/i.test(path);
+}
+
+export function isRuntimeSourceChange(path) {
+	if (GENERATED_CATALOG_FILES.has(path)) {
+		return false;
+	}
+	if (isTestFile(path) || isDocsFile(path)) {
+		return false;
+	}
+	return RUNTIME_SOURCE_PATTERN.test(path) || CRATES_SOURCE_PATTERN.test(path);
+}
+
+export function isChangelogChange(path) {
+	return CHANGELOG_PATTERN.test(path);
+}
+
+export function checkPrChangelog({ changedFiles, labels }) {
+	const normalizedLabels = labels.map((label) => label.trim()).filter(Boolean);
+	const hasNoChangelogLabel = normalizedLabels.includes(NO_CHANGELOG_LABEL);
+	const changelogFiles = changedFiles.filter(isChangelogChange);
+	const runtimeFiles = changedFiles.filter(isRuntimeSourceChange);
+
+	let pass;
+	let reason;
+	if (runtimeFiles.length === 0) {
+		pass = true;
+		reason = "no runtime source changes detected";
+	} else if (changelogFiles.length > 0) {
+		pass = true;
+		reason = `changelog entry updated (${changelogFiles.join(", ")})`;
+	} else if (hasNoChangelogLabel) {
+		pass = true;
+		reason = `'${NO_CHANGELOG_LABEL}' label present`;
+	} else {
+		pass = false;
+		reason = "runtime source changed without a CHANGELOG.md entry";
+	}
+
+	return { pass, reason, runtimeFiles, changelogFiles, hasNoChangelogLabel };
+}
+
+function parseArgs(argv) {
+	const args = { labels: [] };
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === "--base") {
+			args.base = argv[index + 1];
+			index += 1;
+		} else if (arg === "--labels") {
+			args.labels = (argv[index + 1] ?? "")
+				.split(",")
+				.map((label) => label.trim())
+				.filter(Boolean);
+			index += 1;
+		} else {
+			throw new Error(`unknown argument: ${arg}`);
+		}
+	}
+	if (!args.base) {
+		throw new Error("missing required --base <sha> argument");
+	}
+	return args;
+}
+
+function listChangedFiles(base) {
+	const result = spawnSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+		encoding: "utf8",
+	});
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.status !== 0) {
+		throw new Error(`git diff --name-only ${base}...HEAD failed:\n${result.stderr.trim()}`);
+	}
+	return result.stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+}
+
+export function main(argv) {
+	let args;
+	try {
+		args = parseArgs(argv);
+	} catch (error) {
+		console.error(`changelog-gate: ERROR - ${error.message}`);
+		console.error("usage: node scripts/check-pr-changelog.mjs --base <sha> [--labels a,b,c]");
+		return 1;
+	}
+
+	let changedFiles;
+	try {
+		changedFiles = listChangedFiles(args.base);
+	} catch (error) {
+		console.error(`changelog-gate: ERROR - ${error.message}`);
+		return 1;
+	}
+
+	const result = checkPrChangelog({ changedFiles, labels: args.labels });
+	const verdict = result.pass ? "PASS" : "FAIL";
+	console.log(`changelog-gate: ${verdict} - ${result.reason}`);
+	if (!result.pass) {
+		for (const file of result.runtimeFiles) {
+			console.log(`  runtime change: ${file}`);
+		}
+		console.log(
+			"Add an entry under ## [Unreleased] in the affected package CHANGELOG.md, " +
+				`or apply the '${NO_CHANGELOG_LABEL}' label if this change is not user-facing.`,
+		);
+	}
+	return result.pass ? 0 : 1;
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+	process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/check-pr-changelog.test.mjs
+++ b/scripts/check-pr-changelog.test.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { checkPrChangelog } from "./check-pr-changelog.mjs";
+
+describe("check-pr-changelog gate", () => {
+	it("fails when runtime package source changes without a changelog entry", () => {
+		// Given
+		const changedFiles = ["packages/ai/src/index.ts"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, false);
+		assert.deepEqual(result.runtimeFiles, ["packages/ai/src/index.ts"]);
+	});
+
+	it("passes when runtime source changes include a CHANGELOG.md edit", () => {
+		// Given
+		const changedFiles = ["packages/tui/src/components/app.ts", "packages/tui/CHANGELOG.md"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, true);
+	});
+
+	it("passes when runtime source changes carry the no-changelog label", () => {
+		// Given
+		const changedFiles = ["packages/agent/src/run.ts"];
+		const labels = ["bug", "no-changelog"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels });
+
+		// Then
+		assert.equal(result.pass, true);
+	});
+
+	it("passes when only test files change", () => {
+		// Given
+		const changedFiles = [
+			"packages/coding-agent/src/cli.test.ts",
+			"packages/ai/src/__tests__/models.test.ts",
+		];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, true);
+	});
+
+	it("passes when only docs change", () => {
+		// Given
+		const changedFiles = ["packages/ai/README.md", "docs/guide.md", "packages/tui/src/notes.md"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, true);
+	});
+
+	it("passes when only workflows change", () => {
+		// Given
+		const changedFiles = [".github/workflows/ci.yml"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, true);
+	});
+
+	it("fails when runtime source and tests change together without a changelog entry", () => {
+		// Given
+		const changedFiles = ["packages/pty/src/index.ts", "packages/pty/src/index.test.ts"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, false);
+		assert.deepEqual(result.runtimeFiles, ["packages/pty/src/index.ts"]);
+	});
+
+	it("fails when crates/senpi-pty changes without a changelog entry", () => {
+		// Given
+		const changedFiles = ["crates/senpi-pty/src/lib.rs"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, false);
+		assert.deepEqual(result.runtimeFiles, ["crates/senpi-pty/src/lib.rs"]);
+	});
+
+	it("passes when only scripts and examples change", () => {
+		// Given
+		const changedFiles = ["scripts/local-release.mjs", "packages/senpi-codemode/examples/demo.ts"];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, true);
+	});
+
+	it("passes when only generated model catalogs change (cl.md audit skip rule)", () => {
+		// Given
+		const changedFiles = [
+			"packages/ai/src/models.generated.ts",
+			"packages/ai/src/image-models.generated.ts",
+		];
+
+		// When
+		const result = checkPrChangelog({ changedFiles, labels: [] });
+
+		// Then
+		assert.equal(result.pass, true);
+	});
+});


### PR DESCRIPTION
## Problem

The v2026.8.4 cycle shipped 13 PRs. **#682 and #687 landed with no changelog entry** — discovered only by manual commit-by-commit archaeology during the release changelog audit, which is exactly the expensive, error-prone work a merge-time gate eliminates.

## Change

- **`scripts/check-pr-changelog.mjs`** — pure, unit-testable `checkPrChangelog({ changedFiles, labels })` plus a CLI (`--base <sha>` diffs `base...HEAD`, `--labels a,b,c`, verdict line, exit 0/1). Runtime source under the six release-managed packages (`packages/{ai,agent,coding-agent,tui,pty,senpi-codemode}/src/**`) or `crates/senpi-pty/**` **fails** without a `CHANGELOG.md` edit in the same PR, unless the PR carries the `no-changelog` label. Test-only, docs-only, examples, workflow/CI, and scripts-only changes are exempt, as are the generated model catalogs `cl.md` already excludes.
- **`scripts/check-pr-changelog.test.mjs`** — 10 node:test cases in the repo's existing Given/When/Then style, covering all eight mandated scenarios plus the scripts/examples and generated-catalog exemptions.
- **`.github/workflows/changelog-gate.yml`** — a dedicated workflow on `pull_request` with `types: [opened, synchronize, reopened, labeled, unlabeled]`, so applying or removing `no-changelog` re-evaluates the gate immediately.

### Why a dedicated workflow instead of a job in `ci.yml`

The gate needs `labeled`/`unlabeled` events. Adding those types to `ci.yml`'s shared `pull_request` trigger would re-run the **entire** CI suite — check, build, and all sharded test jobs — on every label change. Isolating the gate keeps `ci.yml`'s trigger untouched and makes label events cost one checkout plus one Node script.

## Evidence

- **RED** (tests written first, script absent): `ERR_MODULE_NOT_FOUND` → tests 1, pass 0, fail 1.
- **GREEN**: `node --test scripts/check-pr-changelog.test.mjs` → tests 10, pass 10, fail 0.
- CLI exercised against real git history: PASS path exits 0 with `changelog-gate: PASS - no runtime source changes detected`; a bogus base exits 1 with a clean error.
- `actionlint .github/workflows/changelog-gate.yml .github/workflows/ci.yml` → exit 0, zero findings.
- **Self-hosting**: this PR touches only `scripts/**` and `.github/workflows/**`, so the gate runs on itself and must report PASS.

## Follow-up (not in this PR)

The gate is advisory until it is added to branch protection as a required status check — a repo-settings change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI gate that requires a `[Unreleased]` `CHANGELOG.md` entry when runtime code changes, enforced by a dedicated workflow. This prevents missed changelog entries without rerunning full CI on label changes.

- **New Features**
  - Adds `scripts/check-pr-changelog.mjs` with a CLI to fail PRs that change runtime code under `packages/{ai,agent,coding-agent,tui,pty,senpi-codemode}/src/**` or `crates/senpi-pty/**` unless a `CHANGELOG.md` is edited; `no-changelog` label bypasses.
  - Adds tests in `scripts/check-pr-changelog.test.mjs` for core scenarios.
  - Introduces `changelog-gate` workflow reacting to `opened`, `synchronize`, `reopened`, `labeled`, `unlabeled`.
  - Exempts tests, docs, examples, workflows/CI, scripts, and generated model catalogs.

- **Migration**
  - Mark “Changelog gate” as a required status check in branch protection to enforce.

<sup>Written for commit 08244245dd806c050a8ef2cc8579015446a670a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

