### PR TITLE
fix(mcp): await prompt catalog registration

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -72,6 +72,7 @@ export class McpService {
 	readonly #pendingAuth = new Map<string, import("./auth/oauth-provider.ts").McpOAuthProvider>();
 	readonly #interactiveAuthServers = new Set<string>();
 	readonly #promptCommandNames = new Set<string>();
+	readonly #registrationListeners = new Set<() => void>();
 	#refreshActiveSetWhenNoTools = false;
 	#tierBRegistration: McpSessionRegistration | undefined;
 	#historyScanned = false;
@@ -181,6 +182,14 @@ export class McpService {
 		return this.#tierBRegistration?.resourceServers ?? [];
 	}
 
+	/** Subscribe to completed catalog registrations. Consumers must inspect the
+	 * resulting snapshot because tool, resource, and prompt catalogs can become
+	 * available in different startup-race generations. */
+	onMcpRegistrationChanged(listener: () => void): () => void {
+		this.#registrationListeners.add(listener);
+		return () => this.#registrationListeners.delete(listener);
+	}
+
 	/** Reveal skill-owned tools (todo 37): activation is effective the next
 	 * turn, exactly like an tool_search promotion. Unknown names are ignored. */
 	activateSkillMcpTools(names: readonly string[]): void {
@@ -209,6 +218,7 @@ export class McpService {
 		this.#pendingAuth.clear();
 		this.#interactiveAuthServers.clear();
 		this.#promptCommandNames.clear();
+		this.#registrationListeners.clear();
 		this.#wireStatusBySession.clear();
 		this.#latestWireStatus = { servers: [] };
 		const entries = [...this.#connections.values()];
@@ -449,6 +459,7 @@ export class McpService {
 		this.#tierBRegistration = await registerMcpServiceDirectTools(pi, config, this.#connections.values(), {
 			refreshActiveSetWhenEmpty: this.#refreshActiveSetWhenNoTools,
 		});
+		for (const listener of this.#registrationListeners) listener();
 		// A (re-)registration recomputes the active set from config alone, so any
 		// promotions recorded in history are worth replaying on the next scan.
 		this.#historyScanned = false;

--- a/packages/coding-agent/test/mcp/fixtures/register-call.ts
+++ b/packages/coding-agent/test/mcp/fixtures/register-call.ts
@@ -59,6 +59,33 @@ export async function awaitMcpToolRegistration(
 	);
 }
 
+/** Subscribe before attach and await the exact prompt catalog registration.
+ * Tool registration is not a sufficient barrier: during a startup-raced cold
+ * connect, listTools can finish before the cache refresh has listed prompts. */
+export function awaitMcpPromptRegistration(serverName: string, promptName: string, timeoutMs = 10_000): Promise<void> {
+	const service = getMcpService();
+	return new Promise((resolve, reject) => {
+		let unsubscribe = (): void => {};
+		const timeout = setTimeout(() => {
+			unsubscribe();
+			reject(new Error(`MCP prompt registration timed out: ${serverName}/${promptName}`));
+		}, timeoutMs);
+		const check = (): void => {
+			const registered = service
+				.getMcpPromptServers()
+				.some(
+					(server) => server.server === serverName && server.prompts.some((prompt) => prompt.name === promptName),
+				);
+			if (!registered) return;
+			clearTimeout(timeout);
+			unsubscribe();
+			resolve();
+		};
+		unsubscribe = service.onMcpRegistrationChanged(check);
+		check();
+	});
+}
+
 /** Await registration of one specific tool on a capturing pi (use for proxy
  * gateways / zero-searchable-tool servers where getTierBSearchable stays empty). */
 export async function awaitMcpTool(pi: CapturingPi, toolName: string, timeoutMs = 10_000): Promise<void> {

--- a/packages/coding-agent/test/mcp/prompts-commands.test.ts
+++ b/packages/coding-agent/test/mcp/prompts-commands.test.ts
@@ -9,7 +9,7 @@ import {
 	resetMcpPromptCommandsForTests,
 } from "../../src/core/extensions/builtin/mcp/prompts.ts";
 import { getMcpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
-import { attach, awaitMcpToolRegistration, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
+import { attach, awaitMcpPromptRegistration, capturingPi, mcpRoot as makeMcpRoot } from "./fixtures/register-call.ts";
 import { cleanupRoots, setConfig, stdioServer, type TestRoot } from "./fixtures/service-lifecycle.ts";
 
 const cleanupTasks: Array<() => Promise<void>> = [];
@@ -67,8 +67,9 @@ describe("mcp prompts as slash commands", () => {
 		const root = mcpRoot("prompts-live");
 		setConfig(root, { fx: stdioServer(["--tools", "1"]) });
 		const pi = capturingPi();
+		const promptRegistration = awaitMcpPromptRegistration("fx", "fixture_prompt");
 		await attach(root, pi);
-		await awaitMcpToolRegistration("fx");
+		await promptRegistration;
 
 		const recorder = commandRecorder();
 		const added = registerMcpPromptCommands(recorder as never, getMcpService().getMcpPromptServers());


### PR DESCRIPTION
## Problem

`test/mcp/prompts-commands.test.ts` flaked in CI on PR #696 (run 30891507925, attempt 1): `expected [] to deeply equal [ 'mcp:fx:fixture_prompt' ]` — green on rerun. Classic nondeterminism.

## Root cause

The test treated **searchable tool registration as proof that prompt metadata had also registered**. `awaitMcpToolRegistration("fx")` only observes `getTierBSearchable()`. During a startup-raced cold connection, a registration generation can publish `listTools` results while the full cache refresh is still collecting resources and prompts — so searchable tools are non-empty while `getMcpPromptServers()` is still empty. Tool-only and full-catalog states become visible in separate generations, and the test asserted on the wrong barrier.

Investigated and rejected: fixture server not connected (the failure occurs *after* tool registration, so startup had advanced past connection), and shared-singleton leakage from another test (the exact failure reproduces in an isolated single-file process).

## Fix

- `mcp/service.ts`: the service now emits a registration-completed signal after publishing each catalog snapshot (`onMcpRegistrationChanged(listener)` → unsubscribe; listeners cleared on reset). The doc comment names the race: tool, resource, and prompt catalogs can become available in different startup-race generations.
- `test/mcp/fixtures/register-call.ts`: new `awaitMcpPromptRegistration(server, prompt)` — subscribes **before** attach, checks the exact prompt in `getMcpPromptServers()`, resolves on the exact state transition, and re-checks current state immediately after subscribing to close the subscribe/check boundary. No sleeps, no polling; only a bounded failure timeout.
- `test/mcp/prompts-commands.test.ts`: creates the registration promise **before** `attach(...)`, then awaits it — replacing the insufficient tool-registration barrier.

## Evidence

- **RED**: the normal file passed 30/30 locally, so the race boundary was swept directly: at `SENPI_MCP_STARTUP_TIMEOUT_MS=100` the exact CI failure reproduces — `AssertionError: expected [] to deeply equal [ 'mcp:fx:fixture_prompt' ]` (log: captured in run notes).
- **GREEN**: 25/25 consecutive passes at the same 100 ms window that produced RED. Independent lead re-run: 5/5 at the same window.
- Broader MCP suite (worker run): 47 files / 307 tests green. `tsc --noEmit` clean, biome clean, `git diff --check` clean.

## Pre-existing failure observed during review (not touched, not caused by this diff)

`test/mcp/oauth-race.test.ts` ("cross-process refresh race") failed 2 tests on the lead's machine during review — **identically with the base files from origin/main checked out**, i.e. pre-existing and environment-sensitive, unrelated to this change. Surfacing per no-suppress discipline; it is a separate deflake candidate of the same class.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes the MCP prompts test by waiting for prompt catalog registration instead of tool-only registration. Adds a registration change signal in `McpService` and a test helper that subscribes before `attach`.

- **Bug Fixes**
  - `McpService`: adds `onMcpRegistrationChanged` and emits after each catalog snapshot; clears listeners on reset.
  - Tests: adds `awaitMcpPromptRegistration(server, prompt)` to await exact prompt visibility without polling.
  - Updates `prompts-commands.test.ts` to subscribe pre-attach and await prompt registration, replacing the tool-registration barrier.

<sup>Written for commit b2023b3fb2166150317976a0e71406fd6283dd28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

