### PR TITLE
docs(changelog): record MCP prompt registration race fix

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed MCP prompt slash commands going missing after startup-raced server connections: the MCP service now emits a catalog-registration signal after publishing each snapshot, and prompt command registration waits for the server's prompt metadata instead of inferring readiness from tool registration ([#706](https://github.com/code-yeongyu/senpi/pull/706)).
+
 ### Removed
 
 ## [2026.8.4] - 2026-08-04


### PR DESCRIPTION
Adds the `[Unreleased]` changelog entry for #706 (MCP prompt registration race fix).

The new Changelog gate correctly flagged #706 for touching runtime source without an entry; auto-merge proceeded because the gate is not yet a required check. This PR pays the debt the gate named — and the gate itself should report PASS here (changelog-only change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `[Unreleased]` changelog entry in `coding-agent` to document the MCP prompt registration race fix. It notes that prompt slash commands could disappear after startup-raced connections and that the fix adds a catalog-registration signal and waits for prompt metadata before registering commands.

<sup>Written for commit 3ca1ffc4b4af92598dfed749b9c8a1c690404fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

