### PR TITLE
fix(tui): preserve Herdr scrollback on expansion

### DIFF
--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,31 @@
 # TUI delta rendering fork changes
 
+## 2026-08-04: preserve scrollback inside Herdr panes
+
+### What changed
+
+- Multiplexer detection now recognizes Herdr when both `HERDR_ENV=1` and
+  `HERDR_PANE_ID` are present.
+- Herdr panes therefore use the bounded mux viewport repaint path instead of
+  clearing and replaying scrollback when completed tool results expand.
+
+### Why
+
+Herdr is a terminal multiplexer but does not expose the tmux, screen, or Zellij
+markers used by the existing detector. Expanding several completed tool results
+could consequently replay offscreen transcript content with terminal sequences
+that left stale or mismatched rows in cmux+Herdr panes.
+
+### Why this cannot be an extension
+
+Multiplexer detection selects the core TUI repaint strategy before extensions
+can participate in rendering.
+
+### Expected merge-conflict zones
+
+- `src/mux.ts`
+- `test/mux-scrollback.test.ts`
+
 ## 2026-07-31: atomic visible-cursor frames for IME and animations
 
 ### What changed

--- a/packages/tui/src/mux.ts
+++ b/packages/tui/src/mux.ts
@@ -1,5 +1,11 @@
 export function isMultiplexerSession(): boolean {
-	return Boolean(process.env.TMUX || process.env.TMUX_PANE || process.env.STY || process.env.ZELLIJ);
+	return Boolean(
+		process.env.TMUX ||
+			process.env.TMUX_PANE ||
+			process.env.STY ||
+			process.env.ZELLIJ ||
+			(process.env.HERDR_ENV === "1" && process.env.HERDR_PANE_ID),
+	);
 }
 
 export function useLegacyMuxRender(): boolean {

--- a/packages/tui/test/mux-scrollback.test.ts
+++ b/packages/tui/test/mux-scrollback.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
+import { isMultiplexerSession } from "../src/mux.ts";
 import { TUI } from "../src/tui.ts";
 import {
 	assertFrameBalanced,
@@ -20,6 +21,26 @@ import {
 } from "./mux-scrollback-harness.ts";
 
 describe("TUI multiplexer scrollback preservation", () => {
+	it("uses mux-safe viewport repaint for tool expansion inside Herdr", async () => {
+		await withEnv({ HERDR_ENV: "1", HERDR_PANE_ID: "w13:p4" }, async () => {
+			assert.strictEqual(isMultiplexerSession(), true, "Herdr panes must preserve multiplexer scrollback");
+			const { terminal, tui, writes } = await renderReplayTrigger(undefined);
+
+			assert.strictEqual(countOccurrences(writes, SCROLLBACK_CLEAR), 0);
+			assert.strictEqual(countOccurrences(writes, ROW_CLEAR), terminal.rows);
+			assert.strictEqual(tui.muxViewportRepaints, 1);
+			assert.deepStrictEqual(terminal.getViewport(), [
+				"tail row 0",
+				"tail row 1",
+				"tail row 2",
+				"tail row 3",
+				"tail row 4",
+				"tail row 5",
+			]);
+			tui.stop();
+		});
+	});
+
 	it("emits a screen clear without clearing scrollback when width changes inside a multiplexer", async () => {
 		const terminal = new LoggingVirtualTerminal(40, 6);
 		const tui = new TUI(terminal, muxOptions());

--- a/packages/tui/test/mux.test.ts
+++ b/packages/tui/test/mux.test.ts
@@ -2,7 +2,16 @@ import assert from "node:assert";
 import { afterEach, describe, it } from "node:test";
 import { isMultiplexerSession, useLegacyMuxRender, viewportRenderEnabled } from "../src/mux.ts";
 
-const ENV_KEYS = ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "PI_TUI_LEGACY_MUX_RENDER", "PI_TUI_VIEWPORT_RENDER"] as const;
+const ENV_KEYS = [
+	"TMUX",
+	"TMUX_PANE",
+	"STY",
+	"ZELLIJ",
+	"HERDR_ENV",
+	"HERDR_PANE_ID",
+	"PI_TUI_LEGACY_MUX_RENDER",
+	"PI_TUI_VIEWPORT_RENDER",
+] as const;
 
 type EnvKey = (typeof ENV_KEYS)[number];
 
@@ -42,6 +51,24 @@ describe("isMultiplexerSession", () => {
 
 			assert.equal(isMultiplexerSession(), true, key);
 		}
+	});
+
+	it("returns true for a Herdr pane", () => {
+		clearEnv();
+		process.env.HERDR_ENV = "1";
+		process.env.HERDR_PANE_ID = "w13:p4";
+
+		assert.equal(isMultiplexerSession(), true);
+	});
+
+	it("requires both Herdr markers", () => {
+		clearEnv();
+		process.env.HERDR_ENV = "1";
+		assert.equal(isMultiplexerSession(), false);
+
+		delete process.env.HERDR_ENV;
+		process.env.HERDR_PANE_ID = "w13:p4";
+		assert.equal(isMultiplexerSession(), false);
 	});
 
 	it("returns false when multiplexer environment variables are unset", () => {

--- a/packages/tui/test/setup-multiplexer-env.mjs
+++ b/packages/tui/test/setup-multiplexer-env.mjs
@@ -2,10 +2,10 @@
 // before any TUI test runs.
 //
 // TUI multiplexer detection (`isMultiplexerSession` in `src/mux.ts`) reads
-// TMUX/TMUX_PANE/STY/ZELLIJ from `process.env` to decide whether to preserve
+// TMUX/TMUX_PANE/STY/ZELLIJ/HERDR_ENV/HERDR_PANE_ID from `process.env` to decide whether to preserve
 // pane scrollback, which suppresses the `ESC[3J` scrollback reset on the
 // default render path. Tests that assert that default, non-multiplexer path
-// would otherwise fail when the suite is run inside tmux/screen/zellij — even
+// would otherwise fail when the suite is run inside tmux/screen/zellij/Herdr — even
 // though CI (which has no multiplexer) passes — because they inherit the
 // ambient markers.
 //
@@ -20,6 +20,6 @@
 // baseline. Kept as plain `.mjs` so it loads without the tsx transform and is
 // not subject to the src-only build type-check.
 
-for (const key of ["TMUX", "TMUX_PANE", "STY", "ZELLIJ"]) {
+for (const key of ["TMUX", "TMUX_PANE", "STY", "ZELLIJ", "HERDR_ENV", "HERDR_PANE_ID"]) {
 	delete process.env[key];
 }


### PR DESCRIPTION
## Summary
- recognize confirmed Herdr panes as multiplexer sessions
- route Ctrl+O expansion through the bounded viewport repaint instead of full scrollback replay
- cover Herdr marker detection and repaint behavior with focused regressions

## Verification
- `npm --prefix packages/tui test`
- `npm run check`
- real source Senpi in Herdr with three completed bash tools; Ctrl+O showed the current viewport without stale/mismatched rows
- TUI smoke evidence: `local-ignore/qa-evidence/20260804-issue-701-herdr-expansion/tui-smoke-tmux.txt`

Fixes #701

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves scrollback when expanding tool output (Ctrl+O) inside Herdr panes by detecting Herdr as a multiplexer and using the viewport repaint path. Fixes #701.

- **Bug Fixes**
  - Detects Herdr panes when HERDR_ENV=1 and HERDR_PANE_ID are set, treating them as multiplexer sessions.
  - Routes Ctrl+O expansion through bounded viewport repaint instead of replaying scrollback, preventing stale/mismatched rows.
  - Adds tests for Herdr detection and repaint behavior; clears Herdr vars in test env setup.
  - Requires both markers to avoid changing behavior in non-Herdr terminals.

<sup>Written for commit 9edb38f00e2777d1f49233e712c3626cf9277862. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

