### PR TITLE
fix(ai): keep root object type on OpenAI-completions tool parameters

### DIFF
--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1590,7 +1590,7 @@ function convertTools(
 			function: {
 				name: tool.name,
 				description: tool.description,
-				parameters: normalizedParameters as FunctionParameters,
+				parameters: ensureRootObjectType(normalizedParameters) as FunctionParameters,
 				// Only include strict if provider supports it. Some reject unknown fields.
 				...(compat.supportsStrictMode !== false && { strict: strict ?? false }),
 			},
@@ -1615,10 +1615,30 @@ function normalizeRequestToolSchemas(
 					: normalizeToolParametersForOpenAICompat(tool.function.parameters);
 			return {
 				...tool,
-				function: { ...tool.function, parameters },
+				function: { ...tool.function, parameters: ensureRootObjectType(parameters) },
 			};
 		}),
 	};
+}
+
+/**
+ * OpenAI Chat Completions requires every function's `parameters` to be a JSON
+ * Schema object rooted at `type: "object"`. Combiner normalization may move the
+ * root `type` into `anyOf` / `oneOf` / `allOf` branches (a shape some
+ * OpenAI-compatible gateways require), so restore the root marker at the wire
+ * boundary for every tool. `$ref`-rooted schemas are left untouched.
+ */
+function ensureRootObjectType(parameters: unknown): Record<string, unknown> {
+	if (parameters === null || typeof parameters !== "object" || Array.isArray(parameters)) {
+		return parameters as Record<string, unknown>;
+	}
+
+	const record = parameters as Record<string, unknown>;
+	if (record.type !== undefined || "$ref" in record) {
+		return record;
+	}
+
+	return { ...record, type: "object" };
 }
 
 function parseChunkUsage(

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,31 @@
 # AI Source Changes
 
+## 2026-08-04 - Preserve root object type in OpenAI-completions tool parameters
+
+### What changed and why
+
+- `api/openai-completions.ts` guarantees every function tool's `parameters`
+  root declares `type: "object"` at the wire boundary (`ensureRootObjectType`),
+  applied in both `convertTools` and `normalizeRequestToolSchemas`.
+- OpenAI-compatible gateways backed by Gemini-style validation (for example
+  OpenCode Go / Zen proxying to Console) reject function schemas whose root
+  `type` was dropped by combiner normalization (`anyOf` / `oneOf` / `allOf`),
+  returning `Invalid schema for function ...: schema must be a JSON Schema of
+  'type: "object"', got 'type: null'`. The normalizer intentionally moves the
+  root `type` into combiner branches for Moonshot-flavored backends, so the
+  root marker is restored at the API boundary instead of changing the
+  normalizer's provider-specific behavior.
+- `test/openai-completions-tool-schema-compat.test.ts` pins the wire shape for
+  both the initial conversion and the post-`onPayload` re-normalization paths
+  using a scan-style `oneOf` schema.
+
+### Expected merge conflict zones
+
+- LOW: `api/openai-completions.ts` around `convertTools` /
+  `normalizeRequestToolSchemas`.
+- LOW: `test/openai-completions-tool-schema-compat.test.ts` if upstream adds
+  parallel wire-shape tests.
+
 ## 2026-08-03 - Hint-aware 429 retry-after propagation
 
 ### What changed and why

--- a/packages/ai/test/openai-completions-tool-schema-compat.test.ts
+++ b/packages/ai/test/openai-completions-tool-schema-compat.test.ts
@@ -1,6 +1,7 @@
 import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { stream as streamOpenAICompletions } from "../src/api/openai-completions.ts";
 import type { Context, Model } from "../src/types.ts";
@@ -266,5 +267,159 @@ describe("tool-schema-compat", () => {
 				await once(server, "close");
 			}
 		});
+	});
+});
+
+async function captureChatCompletionsBodies(): Promise<{
+	bodies: Array<Record<string, unknown>>;
+	port: number;
+	close: () => Promise<void>;
+}> {
+	const bodies: Array<Record<string, unknown>> = [];
+	const server = http.createServer(async (req, res) => {
+		let body = "";
+		for await (const chunk of req) {
+			body += chunk.toString();
+		}
+		bodies.push(JSON.parse(body) as Record<string, unknown>);
+
+		res.writeHead(200, { "content-type": "text/event-stream" });
+		res.write(
+			`data: ${JSON.stringify({
+				id: "chatcmpl-schema",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "schema-test",
+				choices: [{ index: 0, delta: { content: "ok" }, finish_reason: null }],
+			})}\n\n`,
+		);
+		res.write(
+			`data: ${JSON.stringify({
+				id: "chatcmpl-schema",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: "schema-test",
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			})}\n\n`,
+		);
+		res.write("data: [DONE]\n\n");
+		res.end();
+	});
+	server.listen(0, "127.0.0.1");
+	await once(server, "listening");
+	const { port } = server.address() as AddressInfo;
+	return {
+		bodies,
+		port,
+		close: async () => {
+			server.close();
+			await once(server, "close");
+		},
+	};
+}
+
+function openAICompatModel(baseUrl: string): Model<"openai-completions"> {
+	return {
+		id: "schema-test",
+		name: "Schema Test",
+		api: "openai-completions",
+		provider: "openai",
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128000,
+		maxTokens: 4096,
+	};
+}
+
+const scanLikeParameters = {
+	type: "object",
+	properties: {
+		ruleFile: { type: "string" },
+		inlineRules: { type: "string" },
+		paths: { type: "array", items: { type: "string" } },
+	},
+	required: ["paths"],
+	oneOf: [
+		{ required: ["ruleFile"], not: { required: ["inlineRules"] } },
+		{ required: ["inlineRules"], not: { required: ["ruleFile"] } },
+	],
+	additionalProperties: false,
+} as const;
+
+describe("OpenAI-completions wire boundary", () => {
+	it("keeps a root object type on combiner tool schemas", async () => {
+		const { bodies, port, close } = await captureChatCompletionsBodies();
+		try {
+			const model = openAICompatModel(`http://127.0.0.1:${port}`);
+			const context: Context = {
+				messages: [{ role: "user", content: "hello", timestamp: 1 }],
+				tools: [
+					{
+						name: "mcp__ast_grep_scan",
+						description: "Scan files with YAML rules.",
+						parameters: Type.Unsafe(scanLikeParameters),
+					},
+				],
+			};
+
+			const result = await streamOpenAICompletions(model, context, { apiKey: "test-key" }).result();
+
+			expect(result.stopReason).toBe("stop");
+			const tools = bodies[0]?.tools as Array<{
+				type: string;
+				function: { parameters: Record<string, unknown> };
+			}>;
+			const parameters = tools[0]?.function.parameters;
+			expect(parameters?.type).toBe("object");
+			expect(parameters?.oneOf).toHaveLength(2);
+			expect(parameters?.properties).toHaveProperty("paths");
+		} finally {
+			await close();
+		}
+	});
+
+	it("keeps a root object type on tools injected after the initial conversion", async () => {
+		const { bodies, port, close } = await captureChatCompletionsBodies();
+		try {
+			const model = openAICompatModel(`http://127.0.0.1:${port}`);
+			const context: Context = {
+				messages: [{ role: "user", content: "hello", timestamp: 1 }],
+			};
+
+			const result = await streamOpenAICompletions(model, context, {
+				apiKey: "test-key",
+				onPayload: (payload) => {
+					if (typeof payload !== "object" || payload === null) {
+						throw new Error("Expected an object payload");
+					}
+					return {
+						...payload,
+						tools: [
+							{
+								type: "function",
+								function: {
+									name: "mcp__ast_grep_scan",
+									description: "Scan files with YAML rules.",
+									parameters: scanLikeParameters,
+								},
+							},
+						],
+					};
+				},
+			}).result();
+
+			expect(result.stopReason).toBe("stop");
+			const tools = bodies[0]?.tools as Array<{
+				type: string;
+				function: { parameters: Record<string, unknown> };
+			}>;
+			const parameters = tools[0]?.function.parameters;
+			expect(parameters?.type).toBe("object");
+			expect(parameters?.oneOf).toHaveLength(2);
+		} finally {
+			await close();
+		}
 	});
 });


### PR DESCRIPTION
Closes #710

## Summary

Function tools whose parameters schema uses a combiner (`anyOf` / `oneOf` / `allOf`) are sent to OpenAI-compatible backends without the root `type: "object"` marker, because `normalizeToolParametersForOpenAICompat` moves the root `type` into combiner branches and deletes it. Gemini-backed gateways (OpenCode Go / Zen proxying to Console) then reject the request with `Invalid schema for function 'mcp__ast_grep_scan': schema must be a JSON Schema of 'type: "object"', got 'type: null'`.

This change restores the root `type: "object"` marker at the OpenAI-completions wire boundary:

- `convertTools` (initial tool conversion)
- `normalizeRequestToolSchemas` (re-normalization after `onPayload` / injected tools)

The Moonshot-flavored normalizer behavior (`toolSchemaFlavor: "moonshot-mfjs"`) is left untouched.

## Test plan

- `packages/ai/test/openai-completions-tool-schema-compat.test.ts`: new wire-boundary tests cover both conversion paths with a scan-style `type: "object"` + `oneOf` schema, asserting the root `type` and `oneOf` survive to the actual HTTP request body.
- `npx vitest run` in `packages/ai`: 9/9 in the compat file, 1773 passed overall (1 unrelated pre-existing import failure in `packages/coding-agent/src/core/tools/diff-render.ts`).
- Repo pre-commit gate (`npm run check`) passed: Biome, pinned deps, ts-imports, shrinkwrap, install lock, full `tsc --noEmit`, browser smoke.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the root `type: "object"` on function tool parameters sent to OpenAI Chat Completions, so schemas with `anyOf`/`oneOf`/`allOf` are accepted by Gemini-backed OpenAI-compatible gateways.

- **Bug Fixes**
  - Added `ensureRootObjectType` and applied it in `convertTools` and `normalizeRequestToolSchemas`.
  - Leaves `$ref`-rooted schemas and Moonshot-flavored normalization unchanged.
  - Added wire-boundary tests to confirm the root `type` and combiners persist for both initial tools and `onPayload`-injected tools.

<sup>Written for commit b6a1ace4bb47ff64b982f21392686fedb11f5913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

