### PR TITLE
fix(coding-agent): dedupe dynamic rules in live context

### DIFF
--- a/.omo/plans/dynamic-rule-context-dedup.md
+++ b/.omo/plans/dynamic-rule-context-dedup.md
@@ -1,0 +1,54 @@
+# Dynamic Rule Context Deduplication
+
+## Goal
+
+Inject each unchanged dynamic project rule at most once while it remains in the
+live agent context. An accepted compaction clears that knowledge boundary so the
+rule can be injected again. A changed rule body must also inject again before
+compaction.
+
+## Root Cause
+
+The rules builtin stores dynamic deduplication as a map keyed by target path.
+Reading a second file that matches the same rule creates a new target key, so
+the unchanged rule is appended to the second tool result and a second
+`Project rules` activation notice is recorded.
+
+## Design
+
+1. Replace target-scoped dynamic dedup state with a session-wide set keyed by
+   canonical rule path plus content hash.
+2. Remove the target-path parameter from the private cache, engine, and
+   extension call sites.
+3. Keep the existing accepted `session_compact` reset unchanged.
+4. Keep content hashes in the dedup key so live rule edits are not hidden.
+5. Record the Senpi-specific vendored adaptation and re-vendor conflict zones.
+
+## Test-First Sequence
+
+1. Add a focused regression test outside the near-limit legacy rules test file.
+2. Capture RED: two distinct matching targets append the same rule twice.
+3. Characterize rejected compaction, accepted compaction, and changed-content
+   behavior.
+4. Apply the smallest cache and private API change.
+5. Capture GREEN for all focused scenarios.
+
+## Verification
+
+- Focused Vitest regression file.
+- LSP diagnostics for every changed TypeScript file.
+- Pure LOC measurement and TypeScript architecture self-review.
+- Root `npm run check`, relevant tests, and root build.
+- Real source-built Senpi CLI with an isolated fake model server:
+  - two matching files produce one unchanged-rule injection and one activation;
+  - changing the rule produces one updated injection.
+- Production extension-runner driver:
+  - rejected compaction keeps suppression;
+  - accepted compaction restores injection.
+- Cleanup receipt proves no QA server, port, sandbox, or worktree remains.
+
+## Delivery
+
+Ship through `fix/dynamic-rule-context-dedup` into `main` with a reviewer-readable
+PR, green CI, Cubic approval or an explicit quota-exhausted skip, merge commit,
+and task-worktree removal.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed dynamic project rules being re-injected for every distinct matching tool target: unchanged rule content now stays deduplicated while it remains in the live agent context, then becomes eligible again after accepted compaction or a rule-content change ([#712](https://github.com/code-yeongyu/senpi/pull/712)).
 - Fixed MCP prompt slash commands going missing after startup-raced server connections: the MCP service now emits a catalog-registration signal after publishing each snapshot, and prompt command registration waits for the server's prompt metadata instead of inferring readiness from tool registration ([#706](https://github.com/code-yeongyu/senpi/pull/706)).
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/rules/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/changes.md
@@ -2,6 +2,24 @@
 
 Vendored from [`code-yeongyu/pi-rules`](https://github.com/code-yeongyu/pi-rules) (see `external-versions.json`).
 
+## 2026-08-04 - Live-context dedup for dynamic rules
+
+### What changed and why
+
+- Dynamic rule matching and target fingerprints remain per tool target, but delivery dedup now uses one `live-context` scope for the active extension session.
+- Reading a second target that matches an unchanged rule therefore does not append the same instruction body or another `Project rules` activation while that body remains in model context.
+- Rejected compaction keeps the dedup state warm. Accepted compaction still calls `engine.resetSession(...)`, so a later matching tool result restores the rule after context loss.
+- The existing rule-content hash remains part of the engine's dedup key, so editing a rule makes the updated body eligible for immediate re-injection without waiting for compaction.
+
+### Why this cannot be supplied by another extension
+
+- Dynamic injection filtering and `markDynamicInjected(...)` calls happen inside this builtin's private `tool_result` handler. A second extension cannot remove an already-appended instruction block or activation entry without duplicating and replacing the rules engine.
+
+### Coverage and expected conflict zones
+
+- Coverage: `test/rules-dynamic-cross-target-dedup.test.ts` verifies distinct-target suppression, rejected/accepted compaction boundaries, activation counts, and changed-content re-injection.
+- Expected conflicts: `index.ts` around the dynamic `tool_result` filter and mark loop. Preserve the shared `DYNAMIC_CONTEXT_SCOPE` argument while keeping `fingerprintDynamicTargets(...)` target-specific.
+
 ## 2026-08-04 - Shared activation notices for dynamic rules
 
 ### What changed and why
@@ -33,4 +51,4 @@ Vendored from [`code-yeongyu/pi-rules`](https://github.com/code-yeongyu/pi-rules
 
 ## Conflict zones
 
-Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the parameter-property patches after re-running the transform, then re-check `npm run check`. The same applies to the environment resolver (`config.ts`, `index.ts`, `rules/types.ts`), the complete-result budget plus `<project_rules>` envelope (`rules/constants.ts`, `rules/formatter.ts`), and the static-selection filter in `index.ts`. Dropping the resolver makes the documented `PI_RULES_*` values inert; dropping complete-result budgeting makes Senpi's wrapper exceed the configured limit; dropping the envelope or static-selection adaptation silently removes project rules on the `claude-agent-sdk` lane or subsequent prompts. Re-run `test/rules-env-config.test.ts`, `test/rules-before-agent-start.test.ts`, and `test/claude-agent-sdk-project-instructions.test.ts` after every re-vendor.
+Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the parameter-property patches after re-running the transform, then re-check `npm run check`. The same applies to the environment resolver (`config.ts`, `index.ts`, `rules/types.ts`), the complete-result budget plus `<project_rules>` envelope (`rules/constants.ts`, `rules/formatter.ts`), the static-selection filter, and the dynamic `DYNAMIC_CONTEXT_SCOPE` in `index.ts`. Dropping the resolver makes the documented `PI_RULES_*` values inert; dropping complete-result budgeting makes Senpi's wrapper exceed the configured limit; dropping the envelope or static-selection adaptation silently removes project rules on the `claude-agent-sdk` lane or subsequent prompts; dropping the live-context scope reintroduces repeated dynamic instructions for each distinct matching target. Re-run `test/rules-env-config.test.ts`, `test/rules-before-agent-start.test.ts`, `test/rules-dynamic-cross-target-dedup.test.ts`, and `test/claude-agent-sdk-project-instructions.test.ts` after every re-vendor.

--- a/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/index.ts
@@ -15,6 +15,7 @@ import type { PiRulesConfig } from "./rules/types.ts";
 type PiRulesMode = PiRulesConfig["mode"];
 
 const MODE_VALUES = new Set<string>(["static", "dynamic", "both", "off"]);
+const DYNAMIC_CONTEXT_SCOPE = "live-context";
 
 export default function piRulesExtension(pi: ExtensionAPI): void {
 	pi.registerFlag("pi-rules-disabled", {
@@ -134,7 +135,7 @@ export default function piRulesExtension(pi: ExtensionAPI): void {
 		);
 		engine.commitDynamicTargetFingerprints(fingerprints);
 		const rules = loaded.rules.filter(
-			(rule) => !engine.isStaticInjected(rule) && !engine.isDynamicInjected(firstTargetPath, rule),
+			(rule) => !engine.isStaticInjected(rule) && !engine.isDynamicInjected(DYNAMIC_CONTEXT_SCOPE, rule),
 		);
 		if (rules.length === 0) {
 			return undefined;
@@ -144,7 +145,7 @@ export default function piRulesExtension(pi: ExtensionAPI): void {
 		const targetPath = displayPath(ctx.cwd, firstPendingTarget);
 		const block = engine.formatDynamic(rules, targetPath);
 		for (const rule of rules) {
-			engine.markDynamicInjected(firstTargetPath, rule);
+			engine.markDynamicInjected(DYNAMIC_CONTEXT_SCOPE, rule);
 		}
 		appendRuleActivation(pi, {
 			kind: "project-rules",

--- a/packages/coding-agent/test/rules-dynamic-cross-target-dedup.test.ts
+++ b/packages/coding-agent/test/rules-dynamic-cross-target-dedup.test.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
+import { createEventBus } from "../src/core/event-bus.ts";
+import piRulesExtension from "../src/core/extensions/builtin/rules/index.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../src/core/extensions/loader.ts";
+import { ExtensionRunner } from "../src/core/extensions/runner.ts";
+import type { ExtensionActions, ExtensionContextActions, SessionCompactEvent } from "../src/core/extensions/types.ts";
+import type { ModelRegistry } from "../src/core/model-registry.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
+import { createModelRegistry } from "./model-runtime-test-utils.ts";
+
+const RULE_PATH = ".omo/rules/shared.md";
+
+interface AppendedEntry {
+	readonly customType: string;
+	readonly data: unknown;
+}
+
+describe("rules dynamic cross-target dedup", () => {
+	let projectDir: string;
+	let rulePath: string;
+	let ruleToken: string;
+	let firstTarget: string;
+	let secondTarget: string;
+	let appendedEntries: AppendedEntry[];
+	let sessionManager: SessionManager;
+	let modelRegistry: ModelRegistry;
+
+	const actions: ExtensionActions = {
+		registerLazyToolActivator: () => {},
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: (customType, data) => appendedEntries.push({ customType, data }),
+		setSessionName: () => {},
+		getSessionName: () => undefined,
+		setLabel: () => {},
+		executeTool: async <TDetails = unknown>() => ({ content: [], details: undefined as TDetails }),
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+		refreshTools: () => {},
+		registerRemovedToolHint: () => {},
+		getCommands: () => [],
+		setModel: async () => false,
+		getThinkingLevel: () => "off",
+		setThinkingLevel: () => {},
+		setSessionModel: async () => false,
+		setSessionThinkingLevel: () => {},
+		setSessionFastMode: () => {},
+	};
+
+	const contextActions: ExtensionContextActions = {
+		getModel: () => undefined,
+		getServiceTier: () => undefined,
+		getScopedModels: () => [],
+		isIdle: () => true,
+		isProjectTrusted: () => true,
+		getSignal: () => undefined,
+		abort: () => {},
+		hasPendingMessages: () => false,
+		isCompacting: () => false,
+		shutdown: () => {},
+		getContextUsage: () => undefined,
+		compact: () => {},
+		getMessageRevision: () => 0,
+		applyCompaction: async () => ({ applied: false, reason: "rejected" }),
+		getCompactionSettings: () => DEFAULT_COMPACTION_SETTINGS,
+		getLookAtSettings: () => ({ enabled: true, models: undefined }),
+		getImageSettings: () => ({ autoResize: true, blockImages: false }),
+		sessionSettings: createInMemoryExtensionSessionSettings(),
+		getSystemPrompt: () => "",
+		getLoadedHookSources: () => ({
+			agentDir: projectDir,
+			cwd: projectDir,
+			globalHookSourcePaths: [],
+			globalHooksPath: join(projectDir, "hooks.json"),
+			preSessionHookSourcePaths: [],
+			projectHookSourcePaths: [],
+			projectHooksPath: join(projectDir, ".senpi", "hooks.json"),
+			runtimeHookSourcePaths: [],
+		}),
+	};
+
+	const createRunner = async (): Promise<ExtensionRunner> => {
+		const runtime = createExtensionRuntime();
+		const extension = await loadExtensionFromFactory(
+			piRulesExtension,
+			projectDir,
+			createEventBus(),
+			runtime,
+			"<builtin:rules>",
+		);
+		const runner = new ExtensionRunner([extension], runtime, projectDir, sessionManager, modelRegistry);
+		runner.bindCore(actions, contextActions);
+		return runner;
+	};
+
+	const readResult = (runner: ExtensionRunner, path: string) =>
+		runner.emitToolResult({
+			type: "tool_result",
+			toolName: "read",
+			toolCallId: `call-${randomUUID()}`,
+			input: { path },
+			content: [{ type: "text", text: "<file contents>" }],
+			details: undefined,
+			isError: false,
+		});
+
+	const textOf = (content: ReadonlyArray<{ type: string }> | undefined): string =>
+		(content ?? [])
+			.filter((item): item is { type: "text"; text: string } => item.type === "text")
+			.map((item) => item.text)
+			.join("\n");
+
+	const activationCount = (): number =>
+		appendedEntries.filter((entry) => {
+			if (entry.customType !== "rule-activation" || typeof entry.data !== "object" || entry.data === null) {
+				return false;
+			}
+			const rules = Reflect.get(entry.data, "rules");
+			return Array.isArray(rules) && rules.includes(RULE_PATH);
+		}).length;
+
+	beforeEach(async () => {
+		projectDir = realpathSync.native(mkdtempSync(join(tmpdir(), "rules-dynamic-dedup-")));
+		mkdirSync(join(projectDir, ".git"), { recursive: true });
+		mkdirSync(join(projectDir, ".omo", "rules"), { recursive: true });
+		ruleToken = `DYNAMIC-RULE-${randomUUID()}`;
+		rulePath = join(projectDir, RULE_PATH);
+		writeFileSync(rulePath, ruleContents(ruleToken), "utf-8");
+		firstTarget = join(projectDir, "fig-001.ts");
+		secondTarget = join(projectDir, "fig-002.ts");
+		writeFileSync(firstTarget, "export const first = true;\n", "utf-8");
+		writeFileSync(secondTarget, "export const second = true;\n", "utf-8");
+		appendedEntries = [];
+		sessionManager = SessionManager.inMemory();
+		modelRegistry = await createModelRegistry(AuthStorage.create(join(projectDir, "auth.json")));
+	});
+
+	afterEach(() => rmSync(projectDir, { recursive: true, force: true }));
+
+	it("injects one unchanged rule across two distinct matching targets", async () => {
+		const runner = await createRunner();
+
+		expect(textOf((await readResult(runner, firstTarget))?.content)).toContain(ruleToken);
+		expect(textOf((await readResult(runner, secondTarget))?.content)).not.toContain(ruleToken);
+		expect(activationCount()).toBe(1);
+	});
+
+	it("keeps suppression after rejected compaction and resets it after accepted compaction", async () => {
+		const runner = await createRunner();
+
+		expect(textOf((await readResult(runner, firstTarget))?.content)).toContain(ruleToken);
+		await runner.emit({
+			type: "session_compact",
+			reason: "manual",
+			requestId: "rejected-compaction",
+			accepted: false,
+			rejectionCause: "cancelled-by-extension",
+			fromExtension: false,
+			willRetry: false,
+		} satisfies SessionCompactEvent);
+		expect(textOf((await readResult(runner, secondTarget))?.content)).not.toContain(ruleToken);
+		expect(activationCount()).toBe(1);
+
+		await runner.emit({
+			type: "session_compact",
+			reason: "manual",
+			requestId: "accepted-compaction",
+			accepted: true,
+			fromExtension: false,
+			willRetry: false,
+			compactionEntry: {
+				type: "compaction",
+				id: "compaction-entry",
+				parentId: null,
+				timestamp: new Date(0).toISOString(),
+				summary: "compacted",
+				firstKeptEntryId: "kept-entry",
+				tokensBefore: 100,
+			},
+		} satisfies SessionCompactEvent);
+		expect(textOf((await readResult(runner, secondTarget))?.content)).toContain(ruleToken);
+		expect(activationCount()).toBe(2);
+	});
+
+	it("re-injects when rule content changes before compaction", async () => {
+		const runner = await createRunner();
+		expect(textOf((await readResult(runner, firstTarget))?.content)).toContain(ruleToken);
+
+		const updatedToken = `UPDATED-RULE-${randomUUID()}`;
+		writeFileSync(rulePath, ruleContents(updatedToken), "utf-8");
+		const future = new Date(Date.now() + 10_000);
+		utimesSync(rulePath, future, future);
+
+		const updatedResult = textOf((await readResult(runner, secondTarget))?.content);
+		expect(updatedResult).toContain(updatedToken);
+		expect(updatedResult).not.toContain(ruleToken);
+		expect(activationCount()).toBe(2);
+	});
+});
+
+function ruleContents(token: string): string {
+	return `---\nglobs: "**/*.ts"\n---\n\n# Shared rule\n\n${token}\n`;
+}


### PR DESCRIPTION
## Summary

Fix repeated dynamic project-rule injection across different tool targets.
Unchanged rule content is now deduplicated for the live extension context while
accepted compaction and live rule edits remain explicit re-injection boundaries.

## Changes

- Use one `live-context` dedup scope in the rules extension's dynamic
  `tool_result` path.
- Keep matching and target fingerprints target-specific.
- Keep accepted `session_compact` reset and content-hash invalidation unchanged.
- Add focused coverage for distinct targets, rejected/accepted compaction,
  activation counts, and changed rule content.
- Record the Senpi-specific vendored adaptation and re-vendor conflict zone.

## QA & Evidence

- RED: the distinct-target regression failed because `fig-002.ts` received the
  same rule canary already injected for `fig-001.ts`.
- GREEN: `test/rules-dynamic-cross-target-dedup.test.ts` — 3/3 passed.
- Related rules suite — 4 files, 18/18 passed.
- `npm run check` — passed, including `tsc --noEmit`.
- `npm run build` — passed across the full workspace.
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test` — 43/43
  passed.
- Real source-built CLI:
  - unchanged rule injections across two targets: `1`
  - matching project-rule activations: `1`
  - updated rule injections after content change: `1`
  - old token present in updated block: `false`
- Compaction module surface:
  - rejected compaction re-injected: `false`
  - accepted compaction re-injected: `true`
- Cleanup receipt: fake servers stopped, ports closed, sandboxes removed, and
  real auth unchanged.

## Risks & Residuals

- Dynamic rule matching remains target-specific; only delivery deduplication
  uses a shared live-context scope.
- Accepted compaction continues to clear rule-memory state.
- `lsp_diagnostics` could not target the sibling worktree because the harness
  fixes LSP requests to the original cwd; focused Vitest compilation plus
  `npm run check`/`tsc --noEmit` passed instead.

## Plan

`.omo/plans/dynamic-rule-context-dedup.md`
