### PR TITLE
fix(mcp): strip null-valued schema types

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fixed MCP prompt slash commands going missing after startup-raced server connections: the MCP service now emits a catalog-registration signal after publishing each snapshot, and prompt command registration waits for the server's prompt metadata instead of inferring readiness from tool registration ([#706](https://github.com/code-yeongyu/senpi/pull/706)).
+- Fixed HTTP 400 failures from MCP servers that emit invalid JSON-null `type` keywords by stripping only those malformed values at the shared MCP schema-conversion boundary while preserving valid JSON Schema null types ([#713](https://github.com/code-yeongyu/senpi/pull/713)).
 
 ### Removed
 

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,31 @@
 # mcp Extension Changes
 
+## Strip invalid null-valued MCP schema types (2026-08-04)
+
+### What changed
+- `expose/schema-compat.ts` now omits JSON-null `type` keywords while
+  recursively resolving MCP tool input schemas into TypeBox definitions.
+- Valid JSON Schema null types remain unchanged, including `type: "null"` and
+  union arrays such as `type: ["string", "null"]`.
+- `test/mcp/schema-compat.test.ts` covers root, nested property, and combiner
+  branch null values plus both valid null-type forms.
+
+### Why
+- Some MCP servers emit `type: null`. JSON Schema permits the string `"null"`
+  but not the JSON null value; strict OpenAI-compatible providers reject the
+  malformed tool definition with HTTP 400 before the model can answer.
+- Sanitizing at MCP conversion protects every provider adapter that receives
+  the registered tool, rather than patching one provider-specific wire path.
+
+### Why extension system couldn't handle this alone
+- The MCP builtin owns conversion from external `tools/list` schemas to the
+  registered `ToolDefinition`. Other extensions cannot rewrite that private
+  schema conversion before the tool enters the shared provider pipeline.
+
+### Expected merge conflict zones
+- LOW: `expose/schema-compat.ts` recursive `$ref` copy loop.
+- LOW: `test/mcp/schema-compat.test.ts` schema-conversion cases.
+
 ## Session-expiry retry uses the full service reconnect (2026-08-03)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/expose/schema-compat.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/expose/schema-compat.ts
@@ -152,6 +152,7 @@ function resolveRefs(value: unknown, root: unknown, seenRefs: Set<string>, warni
 
 	const result: Record<string, unknown> = {};
 	for (const [key, child] of Object.entries(value)) {
+		if (key === "type" && child === null) continue;
 		result[key] = resolveRefs(child, root, seenRefs, warnings);
 	}
 	return result;

--- a/packages/coding-agent/test/mcp/schema-compat.test.ts
+++ b/packages/coding-agent/test/mcp/schema-compat.test.ts
@@ -27,6 +27,32 @@ describe("mcp schema compatibility", () => {
 		expect(Object.getOwnPropertyDescriptor(result.schema, "additionalProperties")).toBeUndefined();
 	});
 
+	it("strips null-valued type keywords recursively", () => {
+		const result = convertJsonSchemaToTypeBox({
+			type: null,
+			properties: {
+				pattern: { type: null, description: "ast-grep pattern" },
+				jsonNull: { type: "null" },
+				maybeText: { type: ["string", "null"] },
+				choice: {
+					anyOf: [{ type: null, const: "all" }, { type: "string" }],
+				},
+			},
+		});
+
+		expect(result.warnings).toEqual([]);
+		expect(JSON.parse(JSON.stringify(result.schema))).toEqual({
+			properties: {
+				pattern: { description: "ast-grep pattern" },
+				jsonNull: { type: "null" },
+				maybeText: { type: ["string", "null"] },
+				choice: {
+					anyOf: [{ const: "all" }, { type: "string" }],
+				},
+			},
+		});
+	});
+
 	it("falls back to a permissive object and warning for unresolvable refs", () => {
 		const result = convertJsonSchemaToTypeBox({
 			type: "object",


### PR DESCRIPTION
## Summary

Some MCP servers emit invalid JSON Schema entries with `type: null`. Senpi
previously copied those entries into TypeBox tool definitions unchanged, so
strict OpenAI-compatible providers rejected the request with HTTP 400 before
the model could answer.

This PR strips only JSON-null `type` values at the first Senpi-owned MCP schema
conversion boundary. Valid JSON Schema null declarations (`type: "null"` and
`type: ["string", "null"]`) remain unchanged, and every provider adapter now
receives the sanitized MCP tool definition.

## Changes

- Omit null-valued `type` keys during recursive MCP schema conversion.
- Add regression coverage for root, nested property, and combiner-branch null
  types while pinning both valid null-type forms.
- Record the fork-specific MCP compatibility behavior and merge-conflict zones.

## QA & Evidence

- **Failing-first unit proof**
  - Command: `npm exec vitest -- --run packages/coding-agent/test/mcp/schema-compat.test.ts -t "strips null-valued type keywords recursively"`
  - Before: failed because `type: null` remained at the root, nested property,
    and `anyOf` branch.
  - After: passed.
- **Real source CLI + MCP + provider boundary**
  - A local MCP stdio server advertised the malformed schema and a local
    OpenAI-compatible endpoint rejected any outbound `"type":null`.
  - Before: one request, one HTTP 400, null type observed, no final answer.
  - After: two requests, zero rejections, zero null types, MCP result fed into
    turn 2, final marker returned, real auth unchanged.
  - Local sanitized evidence:
    `local-ignore/qa-evidence/20260804-mcp-null-schema/`.
- **Standard real CLI MCP regression**
  - Command: `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-mcp-tool mcp_fx_tool_1 --tool-args '{"value":"ok"}' --evidence mcp-null-schema-regression`
  - Result: exit 0; two model turns; fixture executed and fed back; final marker
    present; real auth unchanged.
- **Automated validation**
  - `npm exec vitest -- --run packages/coding-agent/test/mcp/schema-compat.test.ts packages/coding-agent/test/mcp/register-call.test.ts` — 16/16 passed.
  - `npm run check` — passed.
  - `npm run build` — passed across all workspaces.
  - Biome changed-file check and `git diff --check` — clean.

## Cleanup

- RED/GREEN fake-provider ports closed.
- MCP fixture processes stopped.
- QA sandboxes removed.
- Temporary QA driver and debug journal removed.

## Risks & Residuals

- The sanitizer intentionally handles only the invalid JSON null value. It does
  not alter valid `"null"` type semantics or other schema keywords.
- No provider-specific code changed; the fix is centralized at the MCP
  registration boundary.

## Report

- Discord context: https://discord.com/channels/1452487457085063218/1490539106797621259/1534198581974663234

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip invalid `type: null` from MCP tool input schemas during conversion to TypeBox so strict OpenAI‑compatible providers stop rejecting requests. Valid null types (`"null"` and `["string","null"]`) are kept.

- **Bug Fixes**
  - Recursively omit JSON-null `type` keys during MCP schema conversion.
  - Preserve valid null-type declarations unchanged.
  - Add tests for root, nested property, and `anyOf` branch cases.
  - Record the fix in `packages/coding-agent/CHANGELOG.md` and `mcp/changes.md`.

<sup>Written for commit 32dd7763e59bb2c7afe0674fd8011cd62d22017a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

