### PR TITLE
docs(changelog): audit v2026.8.4-2 release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,16 +8,32 @@
 
 ### Added
 
-- Flatten and bootstrap continuity notices now report the re-sent payload size and how many duplicate ultrawork directive blocks were collapsed, so Claude SDK OAuth token cost is visible at the moment it is paid ([#705](https://github.com/code-yeongyu/senpi/pull/705))
+- Added Claude SDK OAuth full-prompt payload telemetry: flatten and bootstrap continuity diagnostics now carry
+  the UTF-8 byte size of serialized text blocks and the number of duplicate `<ultrawork-mode>` directives removed,
+  while interactive flatten notices render the transmitted size in B, KB, or MB and include the collapsed count
+  when it is non-zero ([#705](https://github.com/code-yeongyu/senpi/pull/705)).
 
 ### Changed
 
 ### Fixed
 
-- Collapsed repeated `<ultrawork-mode>` directive blocks to the single most recent copy when the Claude SDK OAuth lane flattens a conversation, cutting the re-sent prompt on a representative transcript from 85,890 to 18,094 bytes ([#705](https://github.com/code-yeongyu/senpi/pull/705))
-- Fixed dynamic project rules being re-injected for every distinct matching tool target: unchanged rule content now stays deduplicated while it remains in the live agent context, then becomes eligible again after accepted compaction or a rule-content change ([#712](https://github.com/code-yeongyu/senpi/pull/712)).
-- Fixed MCP prompt slash commands going missing after startup-raced server connections: the MCP service now emits a catalog-registration signal after publishing each snapshot, and prompt command registration waits for the server's prompt metadata instead of inferring readiness from tool registration ([#706](https://github.com/code-yeongyu/senpi/pull/706)).
-- Fixed HTTP 400 failures from MCP servers that emit invalid JSON-null `type` keywords by stripping only those malformed values at the shared MCP schema-conversion boundary while preserving valid JSON Schema null types ([#713](https://github.com/code-yeongyu/senpi/pull/713)).
+- Fixed Claude SDK OAuth full-history re-sends repeatedly billing accumulated `<ultrawork-mode>` directives by
+  post-processing both resident flatten/bootstrap prompts and the non-resident full-prompt path: every earlier
+  complete directive becomes a one-line superseded marker while the most recent copy, surrounding text, non-text
+  blocks, unmatched tags, source messages, and continuity hashes remain intact. Nested directives, including
+  nesting split across serialized text blocks, fail closed unchanged instead of producing a corrupted prompt. In
+  the ten-turn fixture with five 17,000-character directive bodies, serialization fell from 85,890 bytes and five
+  directive blocks to 18,094 bytes and one block ([#705](https://github.com/code-yeongyu/senpi/pull/705)).
+- Fixed unchanged dynamic project rules being appended again whenever a different tool target matched the same rule:
+  matching and target fingerprints remain target-specific, but delivered rule bodies now share one live-context
+  deduplication scope, preventing duplicate instructions and `Project rules` activation notices until an accepted
+  compaction clears the context boundary or a changed rule-content hash makes the updated body eligible for immediate
+  re-injection ([#712](https://github.com/code-yeongyu/senpi/pull/712)).
+- Fixed strict OpenAI-compatible providers rejecting MCP tool definitions with HTTP 400 when a server emits the
+  invalid JSON Schema form `type: null`: MCP schema conversion now recursively omits only JSON-null `type` keys at
+  the root, in nested properties, and inside combiner branches before registering the shared tool definition, while
+  preserving surrounding schema fields and valid null declarations such as `type: "null"` and
+  `type: ["string", "null"]` ([#713](https://github.com/code-yeongyu/senpi/pull/713)).
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Audit the complete 34-commit / 9-PR delta after `v2026.8.4` and prepare accurate, reviewer-readable release notes for the next CalVer release.

The detailed notes cover the shipped Claude SDK OAuth directive-deduplication and payload telemetry, dynamic-rule live-context deduplication, and recursive MCP null-schema compatibility fix. The prior PR #706 entry is removed because the merged registration signal is consumed only by the test helper; production MCP prompt command registration does not subscribe to it.

## Changes

- Expand the Claude SDK OAuth telemetry note with the exact UTF-8 byte/count diagnostics and the interactive flatten-notice boundary.
- Expand the Claude SDK OAuth fix with resident and non-resident serialization paths, preserved message/hash behavior, fail-closed nested-tag handling, and the measured 85,890-to-18,094-byte fixture reduction.
- Expand dynamic-rule deduplication with the target-specific matching versus shared live-context delivery boundary, activation-notice suppression, accepted-compaction reset, and content-hash invalidation.
- Expand MCP schema compatibility with recursive root/property/combiner handling and preservation of valid JSON Schema null forms.
- Remove the unsupported product claim for PR #706 instead of publishing behavior that the production runtime does not implement.
- Leave every released changelog section immutable and retain internal-contributor attribution format.

## QA & Evidence

- **What was tested:** `git diff --check`
  - **Observed result:** passed with no whitespace errors.
  - **Why sufficient:** validates the only changed Markdown file at the patch boundary.
- **What was tested:** `node scripts/check-pr-changelog.mjs --base "$(git merge-base HEAD origin/main)" --labels ""`
  - **Observed result:** `changelog-gate: PASS - no runtime source changes detected`.
  - **Why sufficient:** exercises the repository's required changelog gate against this exact branch.
- **What was tested:** `node --test scripts/check-pr-changelog.test.mjs`
  - **Observed result:** 10 tests passed, 0 failed.
  - **Why sufficient:** confirms the gate's runtime, documentation, test, workflow, Rust PTY, and generated-catalog classifications remain healthy.
- **Manual QA:** not applicable; this PR changes release prose only and does not alter machine-consumed values or runtime behavior.

## Risks & Residuals

- The release notes intentionally omit PRs #702-#704 because they are release/CI housekeeping under `.github/agent/commands/cl.md`.
- PR #706 remains an internal test synchronization seam, not a claimed product fix. A future production wiring change should add its own changelog entry.
- No released section, package manifest, source file, generated artifact, dependency, or lockfile changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audited and updated the v2026.8.4-2 release notes in `packages/coding-agent/CHANGELOG.md` to accurately reflect shipped behavior and remove an unsupported claim.
Expanded notes cover OAuth payload telemetry and directive dedup, dynamic-rule live-context dedup and re-injection boundaries, and recursive MCP JSON Schema null-type compatibility, while removing the MCP prompt registration claim from #706.

<sup>Written for commit 1a9b55551821e7d677198df2dbe43f6e62ea92a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

