### PR TITLE
fix(ai): keep tool schemas rooted in an object and stop retrying request-shape rejections

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Kept tool parameter schemas rooted in an object type. A root `anyOf`/`oneOf`/`allOf` previously had its `type` hoisted into the branches and deleted, so OpenAI-compatible gateways rejected the request with `tools.function.parameters.type is required and must be "object"`, and the Moonshot root-union merge dropped the root's own properties entirely ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+- Stopped retrying provider request-shape rejections. Gateways wrap these deterministic failures in 5xx envelopes, so they were classified transient and the identical invalid payload was replayed on the same model before fallback inherited it ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+
 ### Removed
 
 ## [2026.8.3] - 2026-08-03

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Kept tool parameter schemas rooted in an object type. A root `anyOf`/`oneOf`/`allOf` previously had its `type` hoisted into the branches and deleted, so OpenAI-compatible gateways rejected the request with `tools.function.parameters.type is required and must be "object"`, and the Moonshot root-union merge dropped the root's own properties entirely ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+- Sent the real parameters of root-union tool schemas to Anthropic. `convertTools` read top-level `properties` only, so plugin and MCP tools defined as a root union reached the model with no parameters at all ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
 - Stopped retrying provider request-shape rejections. Gateways wrap these deterministic failures in 5xx envelopes, so they were classified transient and the identical invalid payload was replayed on the same model before fallback inherited it ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
 
 ### Removed

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -49,6 +49,7 @@ import {
 } from "../utils/server-fallback-receipt.ts";
 import { normalizeToolCallId } from "../utils/tool-call-id.ts";
 import { isForcedToolChoiceUnsupportedError, omitToolChoiceParam } from "../utils/tool-choice-fallback.ts";
+import { resolveRootObjectSchema } from "../utils/tool-schema-compat.ts";
 import { demotedToolCallText, demotedToolResultText } from "../utils/unavailable-tool-text.ts";
 import { sanitizeAnthropicToolPairs } from "./anthropic-tool-pairs.ts";
 import { resolveCloudflareBaseUrl } from "./cloudflare.ts";
@@ -2330,7 +2331,12 @@ function convertTools(
 
 	return tools.map((tool, index) => {
 		const strict = resolveJsonSchemaStrictSampling(tool, supportsStrictTools);
-		const schema = tool.parameters as { properties?: unknown; required?: string[] };
+		// A root union carries no top-level properties, so reading them directly
+		// would advertise the tool to the model as taking no arguments at all.
+		const schema = resolveRootObjectSchema(tool.parameters as Record<string, unknown>) as {
+			properties?: unknown;
+			required?: string[];
+		};
 		const legacyInputSchema = {
 			type: "object" as const,
 			properties: schema.properties ?? {},

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -17,6 +17,12 @@
   `required` keeps root entries plus only the names every branch shares.
 - Both flavors share one root guarantee: `normalizeToolParametersForMoonshot` is now the OpenAI
   normalization plus annotation stripping, rather than a second, divergent root-merge path.
+- `api/anthropic-messages.ts` resolves a tool's root parameters through the shared
+  `resolveRootObjectSchema` before building `input_schema`. `convertTools` reads top-level
+  `properties`/`required` only, so a tool whose parameters are a root union arrived as
+  `{"properties":{},"required":[]}` — Claude was told the tool takes no arguments. senpi's own
+  `monitorSchema` was flattened in July to dodge this, but plugin and MCP tools ship root unions
+  and cannot be flattened by us, so the conversion itself has to handle them.
 - `utils/retry.ts` classifies provider request-shape rejections as NON-retryable, and
   `NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN` is renamed `NON_RETRYABLE_PROVIDER_ERROR_PATTERN`
   because it no longer covers only limits. Gateways wrap these deterministic rejections in 5xx

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,43 @@
 # AI Source Changes
 
+## 2026-08-05 - Root-object tool schemas and request-shape error classification
+
+### What changed and why
+
+- `utils/tool-schema-compat.ts` no longer hoists a ROOT schema's `type` into its combiner
+  branches. A tool's root `parameters` must stay an object schema: OpenAI-compatible gateways
+  reject a typeless root with `tools.function.parameters.type is required and must be "object"`,
+  which is exactly how an Apitopia/Kimi turn died on 2026-08-04. `normalizeNode` now takes an
+  `isRoot` flag so branch-level hoisting (still correct below the root) is unchanged, and
+  `ensureRootObjectSchema` guarantees the emitted root is always `{"type":"object", ...}`.
+- `mergeRootObjectUnion` now merges the root's OWN `properties`/`required` with the branches'
+  instead of replacing them. It previously returned `{"properties":{},"type":"object"}` for a root
+  union that declared its properties at the root — silently sending a tool with zero parameters.
+  Untyped constraint-only branches (`{ required: [...] }` over root properties) are accepted, and
+  `required` keeps root entries plus only the names every branch shares.
+- Both flavors share one root guarantee: `normalizeToolParametersForMoonshot` is now the OpenAI
+  normalization plus annotation stripping, rather than a second, divergent root-merge path.
+- `utils/retry.ts` classifies provider request-shape rejections as NON-retryable, and
+  `NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN` is renamed `NON_RETRYABLE_PROVIDER_ERROR_PATTERN`
+  because it no longer covers only limits. Gateways wrap these deterministic rejections in 5xx
+  envelopes (`500 server_error: Invalid request: tools.function.parameters...`), so matching on
+  status text alone classified a permanent failure as transient: the identical payload was replayed
+  on the identical model until the turn died. The patterns are anchored on the
+  `tools.`/`functions.` request path so unrelated prose mentioning tools stays retryable.
+
+### Why this cannot be expressed externally
+
+- Wire-payload schema normalization runs inside the provider adapter, after extension payload
+  hooks, so no extension can repair the emitted tool schema. Retry classification is consumed by
+  the agent session's hard-error routing, which lives below any extension seam.
+
+### Expected merge conflict zones
+
+- MEDIUM: `utils/tool-schema-compat.ts` around root handling and `mergeRootObjectUnion`.
+- MEDIUM: `utils/retry.ts` in the non-retryable pattern list and its renamed constant.
+- LOW: `test/openai-completions-tool-schema-compat.test.ts`, `test/retry.test.ts`.
+
+
 ## 2026-08-03 - Hint-aware 429 retry-after propagation
 
 ### What changed and why

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -4,7 +4,7 @@ function buildProviderErrorPattern(patterns: readonly string[]): RegExp {
 	return new RegExp(patterns.join("|"), "i");
 }
 
-const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
+const NON_RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
 	// OpenCode Go/free-tier limits returned as 429 JSON error types by OpenCode's
 	// Zen API. These are subscription/account limits, not transient throttles.
 	"GoUsageLimitError",
@@ -28,6 +28,20 @@ const NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN = buildProviderErrorPattern([
 	// spend limit, so same-model retries can never recover it.
 	"credits_required",
 	"credits are required",
+
+	// Request-shape rejections: the provider refused the payload we built, not the
+	// work it describes. Gateways wrap these in whatever status they like — the
+	// observed Apitopia/Kimi case arrives as `500 server_error: Invalid request:
+	// tools.function.parameters.type is required and must be "object"` — so the
+	// status text alone would classify a permanent failure as transient. The same
+	// bytes are rejected on every attempt and on every fallback model, so retrying
+	// can only burn the turn. Anchored on the `tools[...]`/`functions[...]` request
+	// path so unrelated prose mentioning tools stays retryable.
+	"invalid request: tools\\.",
+	"invalid request: functions\\.",
+	"tools\\.[^ ]*function\\.parameters",
+	"tools\\.\\d+\\.function\\.parameters",
+	"invalid tool schema",
 ]);
 
 const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
@@ -285,6 +299,6 @@ export function isProviderTimeoutError(message: AssistantMessage): boolean {
  */
 export function isRetryableErrorMessage(errorMessage: string): boolean {
 	if (!errorMessage) return false;
-	if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(errorMessage)) return false;
+	if (NON_RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage)) return false;
 	return RETRYABLE_PROVIDER_ERROR_PATTERN.test(errorMessage);
 }

--- a/packages/ai/src/utils/tool-schema-compat.ts
+++ b/packages/ai/src/utils/tool-schema-compat.ts
@@ -90,19 +90,34 @@ function collapseConstUnion(node: Record<string, unknown>): void {
 	node.enum = values;
 }
 
+/**
+ * Collapse a root-level object union into one object schema.
+ *
+ * A tool's root parameters schema must be a plain `{"type":"object"}` schema:
+ * OpenAI-compatible gateways reject a root that only carries `anyOf`/`oneOf`
+ * with `tools.function.parameters.type is required and must be "object"`. The
+ * merge is intentionally lossy in the direction of permissiveness — branch
+ * exclusivity becomes advisory — but it must never lose a declared parameter,
+ * so the root's own `properties` and `required` are merged with the branches'
+ * rather than replaced by them.
+ */
 function mergeRootObjectUnion(schema: Record<string, unknown>): Record<string, unknown> | undefined {
 	const branches = Array.isArray(schema.anyOf) ? schema.anyOf : Array.isArray(schema.oneOf) ? schema.oneOf : undefined;
 	if (branches === undefined || branches.length === 0) return undefined;
+	if (schema.properties !== undefined && !isJsonObject(schema.properties)) return undefined;
+	if (schema.required !== undefined && !Array.isArray(schema.required)) return undefined;
 
 	const objectBranches: Record<string, unknown>[] = [];
 	for (const branch of branches) {
-		if (!isJsonObject(branch) || branch.type !== "object") return undefined;
+		// An untyped branch is a constraint-only variant (e.g. `{ required: [...] }`)
+		// over the root's own properties, so it merges like an object branch.
+		if (!isJsonObject(branch) || (branch.type !== "object" && branch.type !== undefined)) return undefined;
 		if (branch.properties !== undefined && !isJsonObject(branch.properties)) return undefined;
 		if (branch.required !== undefined && !Array.isArray(branch.required)) return undefined;
 		objectBranches.push(branch);
 	}
 
-	const properties: Record<string, unknown> = {};
+	const properties: Record<string, unknown> = isJsonObject(schema.properties) ? { ...schema.properties } : {};
 	for (const branch of objectBranches) {
 		if (!isJsonObject(branch.properties)) continue;
 		for (const [name, propertySchema] of Object.entries(branch.properties)) {
@@ -114,29 +129,36 @@ function mergeRootObjectUnion(schema: Record<string, unknown>): Record<string, u
 		}
 	}
 
-	const firstRequired = objectBranches[0]?.required;
-	let commonRequired = Array.isArray(firstRequired)
-		? firstRequired.filter((name): name is string => typeof name === "string")
+	// Only names required by EVERY branch stay required; a name required by one
+	// branch alone would reject payloads the union accepts. Root-level `required`
+	// applies to all branches, so it is unioned back in.
+	const rootRequired = Array.isArray(schema.required)
+		? schema.required.filter((name): name is string => typeof name === "string")
 		: [];
-	for (const branch of objectBranches.slice(1)) {
-		const branchRequired = new Set(
-			Array.isArray(branch.required)
-				? branch.required.filter((name): name is string => typeof name === "string")
-				: [],
-		);
-		commonRequired = commonRequired.filter((name) => branchRequired.has(name));
-	}
+	const branchRequiredSets = objectBranches.map(
+		(branch) =>
+			new Set(
+				Array.isArray(branch.required)
+					? branch.required.filter((name): name is string => typeof name === "string")
+					: [],
+			),
+	);
+	const firstBranchRequired = branchRequiredSets[0];
+	const commonBranchRequired = firstBranchRequired
+		? [...firstBranchRequired].filter((name) => branchRequiredSets.every((names) => names.has(name)))
+		: [];
+	const required = [...new Set([...rootRequired, ...commonBranchRequired])];
 
 	const { anyOf: _anyOf, oneOf: _oneOf, ...rest } = schema;
 	return {
 		...rest,
 		type: "object",
 		properties,
-		...(commonRequired.length > 0 ? { required: commonRequired } : {}),
+		...(required.length > 0 ? { required } : {}),
 	};
 }
 
-function normalizeNode(node: unknown): unknown {
+function normalizeNode(node: unknown, isRoot = false): unknown {
 	if (Array.isArray(node)) {
 		return node.map((child) => normalizeNode(child));
 	}
@@ -146,7 +168,9 @@ function normalizeNode(node: unknown): unknown {
 	}
 
 	const hasCombiner = COMBINER_KEYS.some((key) => Array.isArray(node[key]));
-	if (hasCombiner) {
+	// The root of a tool's parameters must keep `type: "object"`; hoisting it into
+	// the branches leaves a typeless root that gateways reject outright.
+	if (hasCombiner && !isRoot) {
 		moveTypeIntoCombinerBranches(node);
 	}
 
@@ -183,7 +207,20 @@ function normalizeNode(node: unknown): unknown {
  * for OpenAI-compatible Chat Completions backends.
  */
 export function normalizeToolParametersForOpenAICompat(schema: Record<string, unknown>): Record<string, unknown> {
-	return normalizeNode(structuredClone(schema)) as Record<string, unknown>;
+	const normalized = normalizeNode(structuredClone(schema), true) as Record<string, unknown>;
+	return ensureRootObjectSchema(normalized);
+}
+
+/**
+ * Guarantee the wire shape every OpenAI-compatible backend requires for tool
+ * parameters: a root object schema. A root union is merged into one object
+ * schema; a root that merely lost its `type` gets it restored.
+ */
+function ensureRootObjectSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	const merged = mergeRootObjectUnion(schema);
+	if (merged) return merged;
+	if (schema.type === undefined) return { ...schema, type: "object" };
+	return schema;
 }
 
 /**
@@ -191,8 +228,7 @@ export function normalizeToolParametersForOpenAICompat(schema: Record<string, un
  * normalization, drop non-structural annotation keywords that Moonshot rejects.
  */
 export function normalizeToolParametersForMoonshot(schema: Record<string, unknown>): Record<string, unknown> {
-	const normalized = normalizeToolParametersForOpenAICompat(schema);
-	return stripMoonshotAnnotations(mergeRootObjectUnion(normalized) ?? normalized);
+	return stripMoonshotAnnotations(normalizeToolParametersForOpenAICompat(schema));
 }
 
 function stripMoonshotAnnotations(node: unknown): Record<string, unknown> {

--- a/packages/ai/src/utils/tool-schema-compat.ts
+++ b/packages/ai/src/utils/tool-schema-compat.ts
@@ -213,14 +213,21 @@ export function normalizeToolParametersForOpenAICompat(schema: Record<string, un
 
 /**
  * Guarantee the wire shape every OpenAI-compatible backend requires for tool
- * parameters: a root object schema. A root union is merged into one object
- * schema; a root that merely lost its `type` gets it restored.
+ * parameters: a root object schema. A root union of object shapes is merged into
+ * one object schema; a root that merely lost its `type` gets it restored.
+ *
+ * A root whose branches are not object shapes is left alone: forcing
+ * `type: "object"` onto a scalar union would assert something the schema
+ * contradicts, which is worse than the missing keyword. Tool parameters are
+ * objects in practice, so this only guards against corrupting an exotic schema.
  */
 function ensureRootObjectSchema(schema: Record<string, unknown>): Record<string, unknown> {
 	const merged = mergeRootObjectUnion(schema);
 	if (merged) return merged;
-	if (schema.type === undefined) return { ...schema, type: "object" };
-	return schema;
+	if (schema.type !== undefined) return schema;
+	const hasCombiner = COMBINER_KEYS.some((key) => Array.isArray(schema[key]));
+	if (hasCombiner) return schema;
+	return { ...schema, type: "object" };
 }
 
 /**

--- a/packages/ai/src/utils/tool-schema-compat.ts
+++ b/packages/ai/src/utils/tool-schema-compat.ts
@@ -238,6 +238,17 @@ export function normalizeToolParametersForMoonshot(schema: Record<string, unknow
 	return stripMoonshotAnnotations(normalizeToolParametersForOpenAICompat(schema));
 }
 
+/**
+ * Resolve a tool's root parameters into a single object schema, without the
+ * OpenAI-specific rewrites. Wire formats that read a tool's parameters from
+ * top-level `properties`/`required` need this: a root union carries neither, so
+ * they would otherwise describe the tool to the model as taking no arguments.
+ * Schemas that are already plain objects are returned untouched.
+ */
+export function resolveRootObjectSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	return mergeRootObjectUnion(structuredClone(schema)) ?? schema;
+}
+
 function stripMoonshotAnnotations(node: unknown): Record<string, unknown> {
 	if (Array.isArray(node)) {
 		return node.map((child) => stripMoonshotAnnotations(child)) as unknown as Record<string, unknown>;

--- a/packages/ai/test/anthropic-root-union-tool-schema.test.ts
+++ b/packages/ai/test/anthropic-root-union-tool-schema.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getModel } from "../src/compat.ts";
+import { streamAnthropic } from "../src/providers/anthropic.ts";
+import type { Context, Model } from "../src/types.ts";
+
+interface AnthropicToolPayload {
+	tools?: Array<{ name: string; input_schema: { properties?: Record<string, unknown>; required?: string[] } }>;
+}
+
+interface AnthropicMockState {
+	createParams: AnthropicToolPayload | undefined;
+}
+
+const mockState = vi.hoisted<AnthropicMockState>(() => ({ createParams: undefined }));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	function createSseResponse(): Response {
+		const body = [
+			`event: message_start\ndata: ${JSON.stringify({
+				type: "message_start",
+				message: { id: "msg_test", usage: { input_tokens: 10, output_tokens: 0 } },
+			})}\n`,
+			`event: message_delta\ndata: ${JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 5 },
+			})}\n`,
+			`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n`,
+		].join("\n");
+
+		return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+	}
+
+	class FakeAnthropic {
+		messages = {
+			create: (params: AnthropicToolPayload) => {
+				mockState.createParams = params;
+				return { asResponse: async () => createSseResponse() };
+			},
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+// Plugin and MCP tools ship root unions routinely and senpi cannot flatten a
+// schema it does not own. The Anthropic conversion reads top-level properties
+// only, so these arrived as {"properties":{},"required":[]}: a parameterless tool.
+const rootUnionContext: Context = {
+	messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	tools: [
+		{
+			name: "monitor",
+			description: "Subscribe to a command's output",
+			parameters: {
+				anyOf: [
+					{
+						type: "object",
+						properties: { command: { type: "string" }, description: { type: "string" } },
+						required: ["command", "description"],
+					},
+					{
+						type: "object",
+						properties: { bash_id: { type: "string" } },
+						required: ["bash_id"],
+					},
+				],
+			},
+		},
+	],
+};
+
+async function capturePayload(model: Model<"anthropic-messages">, context: Context): Promise<AnthropicToolPayload> {
+	await streamAnthropic({ ...model, baseUrl: "http://127.0.0.1:9" }, context, { apiKey: "fake-key" }).result();
+	if (!mockState.createParams) throw new Error("Expected payload to be captured");
+	return mockState.createParams;
+}
+
+describe("Anthropic root-union tool schemas", () => {
+	beforeEach(() => {
+		mockState.createParams = undefined;
+	});
+
+	it("sends the union's parameters instead of an empty schema", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-fable-5"), rootUnionContext);
+
+		const schema = payload.tools?.[0]?.input_schema;
+		expect(Object.keys(schema?.properties ?? {}).sort()).toEqual(["bash_id", "command", "description"]);
+	});
+
+	it("requires only what every branch of the union requires", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-fable-5"), rootUnionContext);
+
+		// `command` is required by one branch only, so forcing it globally would
+		// reject calls the union accepts.
+		expect(payload.tools?.[0]?.input_schema.required).toEqual([]);
+	});
+
+	it("leaves an ordinary object schema untouched", async () => {
+		const payload = await capturePayload(getModel("anthropic", "claude-fable-5"), {
+			messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+			tools: [
+				{
+					name: "get_weather",
+					description: "Get the weather",
+					parameters: {
+						type: "object",
+						properties: { city: { type: "string" } },
+						required: ["city"],
+					},
+				},
+			],
+		});
+
+		expect(payload.tools?.[0]?.input_schema.properties).toEqual({ city: { type: "string" } });
+		expect(payload.tools?.[0]?.input_schema.required).toEqual(["city"]);
+	});
+});

--- a/packages/ai/test/openai-completions-tool-schema-compat.test.ts
+++ b/packages/ai/test/openai-completions-tool-schema-compat.test.ts
@@ -38,7 +38,11 @@ describe("tool-schema-compat", () => {
 			});
 		});
 
-		it("moves a parent type into untyped combiner branches", () => {
+		it("merges a root object union instead of hoisting the root type into branches", () => {
+			// A root union used to be rewritten to a branches-only schema with no root
+			// `type`, which OpenAI-compatible gateways reject outright. The root of a
+			// tool's parameters must stay an object schema, so the branches are merged
+			// into it instead.
 			const schema = {
 				type: "object",
 				anyOf: [{ properties: { a: { type: "string" } } }, { properties: { b: { type: "number" } } }],
@@ -47,10 +51,34 @@ describe("tool-schema-compat", () => {
 			const normalized = normalizeToolParametersForOpenAICompat(schema);
 
 			expect(normalized).toEqual({
-				anyOf: [
-					{ type: "object", properties: { a: { type: "string" } } },
-					{ type: "object", properties: { b: { type: "number" } } },
-				],
+				type: "object",
+				properties: { a: { type: "string" }, b: { type: "number" } },
+			});
+		});
+
+		it("still moves a parent type into untyped combiner branches below the root", () => {
+			const schema = {
+				type: "object",
+				properties: {
+					variant: {
+						type: "object",
+						anyOf: [{ properties: { a: { type: "string" } } }, { properties: { b: { type: "number" } } }],
+					},
+				},
+			};
+
+			const normalized = normalizeToolParametersForOpenAICompat(schema);
+
+			expect(normalized).toEqual({
+				type: "object",
+				properties: {
+					variant: {
+						anyOf: [
+							{ type: "object", properties: { a: { type: "string" } } },
+							{ type: "object", properties: { b: { type: "number" } } },
+						],
+					},
+				},
 			});
 		});
 
@@ -261,6 +289,177 @@ describe("tool-schema-compat", () => {
 						},
 					},
 				]);
+			} finally {
+				server.close();
+				await once(server, "close");
+			}
+		});
+	});
+	describe("root combiner schemas (regression: gateway rejects missing root type)", () => {
+		// Apitopia -> Kimi replied `500 server_error: Invalid request:
+		// tools.function.parameters.type is required and must be "object"` because
+		// the root `type: "object"` was deleted whenever the root carried a combiner.
+		// A tool's root parameters schema must always stay a valid object schema.
+		const monitorShape = {
+			type: "object",
+			properties: {
+				action: { type: "string" },
+				command: { type: "string" },
+				bash_id: { type: "string" },
+			},
+			anyOf: [{ required: ["command"] }, { required: ["bash_id"] }],
+		};
+
+		it("keeps the root type on an OpenAI-compatible root combiner schema", () => {
+			const normalized = normalizeToolParametersForOpenAICompat(structuredClone(monitorShape));
+
+			expect(normalized.type).toBe("object");
+		});
+
+		it("keeps the root type on a Moonshot-flavored root combiner schema", () => {
+			const normalized = normalizeToolParametersForMoonshot(structuredClone(monitorShape));
+
+			expect(normalized.type).toBe("object");
+		});
+
+		it("preserves root-level properties when merging a root object union", () => {
+			const normalized = normalizeToolParametersForMoonshot(structuredClone(monitorShape));
+
+			expect(Object.keys(normalized.properties as Record<string, unknown>).sort()).toEqual([
+				"action",
+				"bash_id",
+				"command",
+			]);
+		});
+
+		it("keeps root-level required entries that every branch shares", () => {
+			const schema = {
+				type: "object",
+				required: ["to"],
+				properties: {
+					to: { type: "string" },
+					message: { type: "string" },
+					payload: { type: "object" },
+				},
+				oneOf: [{ required: ["message"] }, { required: ["payload"] }],
+			};
+
+			const normalized = normalizeToolParametersForMoonshot(structuredClone(schema));
+
+			expect(normalized.type).toBe("object");
+			expect(normalized.required).toEqual(["to"]);
+			expect(Object.keys(normalized.properties as Record<string, unknown>).sort()).toEqual([
+				"message",
+				"payload",
+				"to",
+			]);
+		});
+
+		it("merges branch properties into the root object union without dropping root properties", () => {
+			const schema = {
+				type: "object",
+				properties: { app: { type: "string" } },
+				anyOf: [
+					{
+						type: "object",
+						required: ["app", "element_index"],
+						properties: { element_index: { type: "integer" } },
+					},
+					{ type: "object", required: ["app", "x"], properties: { x: { type: "number" } } },
+				],
+			};
+
+			const normalized = normalizeToolParametersForMoonshot(structuredClone(schema));
+
+			expect(normalized.type).toBe("object");
+			expect(Object.keys(normalized.properties as Record<string, unknown>).sort()).toEqual([
+				"app",
+				"element_index",
+				"x",
+			]);
+			expect(normalized.required).toEqual(["app"]);
+		});
+	});
+	describe("wire payload (real request builder)", () => {
+		it("never sends a tool whose root parameters lack type object", async () => {
+			const requestBodies: Array<Record<string, unknown>> = [];
+			const server = http.createServer(async (req, res) => {
+				let body = "";
+				for await (const chunk of req) body += chunk.toString();
+				requestBodies.push(JSON.parse(body) as Record<string, unknown>);
+				res.writeHead(200, { "content-type": "text/event-stream" });
+				res.write(
+					`data: ${JSON.stringify({
+						id: "chatcmpl-root",
+						object: "chat.completion.chunk",
+						created: 0,
+						model: "kimi-test",
+						choices: [{ index: 0, delta: { content: "ok" }, finish_reason: null }],
+					})}\n\n`,
+				);
+				res.write(
+					`data: ${JSON.stringify({
+						id: "chatcmpl-root",
+						object: "chat.completion.chunk",
+						created: 0,
+						model: "kimi-test",
+						choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+					})}\n\n`,
+				);
+				res.write("data: [DONE]\n\n");
+				res.end();
+			});
+			server.listen(0, "127.0.0.1");
+			await once(server, "listening");
+
+			try {
+				const { port } = server.address() as AddressInfo;
+				const model: Model<"openai-completions"> = {
+					id: "kimi-test",
+					name: "Kimi Test",
+					api: "openai-completions",
+					provider: "moonshotai",
+					baseUrl: `http://127.0.0.1:${port}`,
+					reasoning: false,
+					input: ["text"],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 128000,
+					maxTokens: 4096,
+				};
+				const context: Context = {
+					messages: [{ role: "user", content: "hello", timestamp: 1 }],
+					tools: [
+						{
+							name: "monitor",
+							description: "Subscribe to a command's output",
+							parameters: {
+								type: "object",
+								properties: {
+									action: { type: "string" },
+									command: { type: "string" },
+									bash_id: { type: "string" },
+								},
+								anyOf: [{ required: ["command"] }, { required: ["bash_id"] }],
+							},
+						},
+					],
+				};
+
+				const result = await streamOpenAICompletions(model, context, { apiKey: "test-key" }).result();
+
+				expect(result.stopReason).toBe("stop");
+				const tools = requestBodies[0]?.tools as Array<{
+					function: { parameters: Record<string, unknown> };
+				}>;
+				expect(tools).toHaveLength(1);
+				for (const tool of tools) {
+					expect(tool.function.parameters.type).toBe("object");
+					expect(Object.keys(tool.function.parameters.properties as Record<string, unknown>).sort()).toEqual([
+						"action",
+						"bash_id",
+						"command",
+					]);
+				}
 			} finally {
 				server.close();
 				await once(server, "close");

--- a/packages/ai/test/openai-completions-tool-schema-compat.test.ts
+++ b/packages/ai/test/openai-completions-tool-schema-compat.test.ts
@@ -355,6 +355,36 @@ describe("tool-schema-compat", () => {
 			]);
 		});
 
+		it("does not claim object type for a root union of non-object branches", () => {
+			// Forcing `type: "object"` here would contradict every branch. The root
+			// object guarantee only applies to schemas that really are objects.
+			const schema = { anyOf: [{ type: "string" }, { type: "number" }] };
+
+			const normalized = normalizeToolParametersForOpenAICompat(structuredClone(schema));
+
+			expect(normalized.type).toBeUndefined();
+			expect(normalized.anyOf).toEqual([{ type: "string" }, { type: "number" }]);
+		});
+
+		it("does not merge a root union whose branches are not all object shapes", () => {
+			const schema = {
+				type: "object",
+				properties: { a: { type: "string" } },
+				anyOf: [{ type: "object", properties: { x: { type: "string" } } }, { type: "string" }],
+			};
+
+			const normalized = normalizeToolParametersForMoonshot(structuredClone(schema));
+
+			expect(normalized.type).toBe("object");
+			expect(normalized.properties).toEqual({ a: { type: "string" } });
+		});
+
+		it("adds the object type back to a rootless-type schema with no combiner", () => {
+			const normalized = normalizeToolParametersForOpenAICompat({ properties: { a: { type: "string" } } });
+
+			expect(normalized.type).toBe("object");
+		});
+
 		it("merges branch properties into the root object union without dropping root properties", () => {
 			const schema = {
 				type: "object",

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -26,6 +26,10 @@ const anthropicOrphanServerToolMessage =
 	'400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1: `web_search` tool use with id `srvtoolu_01Gchdhqw1UaCNUuVq2LhMH9` was found without a corresponding `web_search_tool_result` block"},"request_id":"req_011CdQL9JsEk5NWJxWQX4NiG"}';
 const anthropicInvalidMaxTokensMessage =
 	'400 {"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: must be greater than or equal to 1"}}';
+const apitopiaToolSchemaRejectionMessage =
+	'500 data: {"error":{"message":"500 server_error: Invalid request: tools.function.parameters.type is required and must be \\"object\\"","type":"server_error","code":500,"status":500,"statusCode":500,"isRetryable":true}}\n\ndata:[DONE]\n\n';
+const moonshotToolSchemaRejectionMessage =
+	"500 server_error: Invalid request: tools.0.function.parameters: invalid tool schema";
 
 describe("provider retry classification", () => {
 	it("matches explicit provider retry guidance", () => {
@@ -234,6 +238,39 @@ describe("provider retry classification", () => {
 				fauxAssistantMessage("", { stopReason: "error", errorMessage: anthropicInvalidMaxTokensMessage }),
 			),
 		).toBe(false);
+	});
+
+	it("keeps gateway-wrapped tool-schema rejections non-retryable", () => {
+		// Apitopia wraps Kimi's deterministic request-shape rejection in a 500
+		// server_error envelope. The status text says transient, the semantics say
+		// permanent: the identical payload is rejected on every attempt and on every
+		// fallback model, so retrying only burns the turn (observed 2026-08-04).
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: apitopiaToolSchemaRejectionMessage }),
+			),
+		).toBe(false);
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: moonshotToolSchemaRejectionMessage }),
+			),
+		).toBe(false);
+	});
+
+	it("keeps genuine transient server errors retryable alongside schema rejections", () => {
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: openAIServerErrorMessage }),
+			),
+		).toBe(true);
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "500 server_error: internal error, please retry",
+				}),
+			),
+		).toBe(true);
 	});
 
 	it("keeps provider limit errors non-retryable", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -6,6 +6,8 @@ import { createHarness, type Harness } from "./harness.ts";
 const primary = "faux/faux-1";
 const fallback = "faux/faux-2";
 const insufficientQuota = "billing error: insufficient_quota";
+const toolSchemaRejection =
+	'500 server_error: Invalid request: tools.function.parameters.type is required and must be "object"';
 
 type RetryFallbackInternals = {
 	_retryFallback?: { deps?: { cooldowns?: SelectorCooldowns } };
@@ -87,6 +89,52 @@ describe("retry fallback hard errors", () => {
 		expect(harness.faux.state.callCount).toBe(1);
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+	});
+
+	it("does not replay a gateway-wrapped tool-schema rejection on the same model", async () => {
+		// Apitopia wrapped Kimi's deterministic request-shape rejection in a 500
+		// server_error envelope, so it read as transient and every retry resent the
+		// identical invalid payload to the identical model until the turn died
+		// (observed 2026-08-04). The payload is what is wrong, so replaying it can
+		// never succeed.
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: toolSchemaRejection })]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+		expect(harness.session.state.messages.at(-1)).toMatchObject({ errorMessage: toolSchemaRejection });
+	});
+
+	it("switches models immediately on a tool-schema rejection instead of retrying in place", async () => {
+		// With a chain configured the rejection must take the hard-error path: one
+		// call on the failing model, an immediate switch, and no same-model retry
+		// backoff in between. The observed session instead reported
+		// "Retrying (2/3)" against the model that had already rejected the payload.
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 3, baseDelayMs: 60_000, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: toolSchemaRejection }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(
+			harness.events
+				.filter((event) => event.type === "retry_fallback_applied")
+				.map((event) => (event.type === "retry_fallback_applied" ? event.reason : "")),
+		).toEqual(["hard-error"]);
 	});
 
 	it("does not treat context overflow as a hard-error fallback", async () => {


### PR DESCRIPTION
## Problem

A turn died with a provider error that no retry and no fallback could rescue:

```
500 server_error: Invalid request: tools.function.parameters.type is required and must be "object"
```

Session forensics (`~/.senpi/agent/sessions/.../2026-08-04T22-33-45-197Z_*.jsonl`) show every
attempt staying on the same model, then `Fallback chain exhausted`. A later report shows the
other half of the same failure: fallback DID switch models, landed on a model that hit the
identical error, and then reported `Retrying (2/3)` against a payload that could never be accepted.

There are two independent defects behind that, and both are fixed here.

### 1. We were building an invalid tool schema

`normalizeToolParametersForOpenAICompat` hoisted a schema's `type` into its combiner branches and
deleted the parent. That is correct below the root, but a tool's ROOT `parameters` must stay an
object schema. A tool whose parameters are a root union (`type: "object"` + `anyOf`) therefore went
to the wire with **no root `type`** — byte-for-byte the error above.

The Moonshot path then made it worse. `mergeRootObjectUnion` merged only the BRANCH properties and
dropped the root's own, so a root union declaring its properties at the root normalized to:

```json
{"properties": {}, "type": "object"}
```

A tool advertised to the model with **zero parameters**, silently.

### 2. A permanent failure was classified as transient

The gateway wraps this deterministic rejection in a 5xx envelope, so `isRetryableErrorMessage`
matched `500` / `server_error` and called it transient. The identical payload was then replayed on
the identical model until the budget was spent — and the fallback that followed inherited the same
doomed bytes.

### 3. The same root-union schemas reached Anthropic with no parameters at all

`convertTools` in `anthropic-messages.ts` builds `input_schema` from top-level
`properties`/`required` only. A tool whose parameters are a root union carries neither, so it
arrived as:

```json
{"type": "object", "properties": {}, "required": []}
```

Claude was told the tool takes no arguments. senpi's own `monitorSchema` was flattened in July to
dodge exactly this (`packages/coding-agent/.../terminal/changes.md`, 2026-07-27), but plugin and
MCP tools ship root unions and we cannot flatten a schema we do not own — so the conversion itself
has to resolve them. It now shares the root-object resolution with the OpenAI-compatible path.

This matters for the reported failure specifically: `anthropic/claude-opus-5` is the model that
fell back to Kimi, so the fallback target was silently degraded by the same root defect.

## Fix

- Normalization tracks the root: types are hoisted only below it, and the emitted root is always a
  valid `{"type": "object", ...}` schema.
- A root object union merges into ONE object schema that keeps the root's own `properties` and
  `required` alongside the branches'. `required` keeps root entries plus only names every branch
  shares, so the merged schema never rejects a payload the union accepts.
- Both flavors share that one root guarantee instead of Moonshot carrying a divergent root-merge, and
  the Anthropic conversion reuses the same root resolution so no provider silently drops parameters.
- Request-shape rejections are classified non-retryable, anchored on the `tools.` / `functions.`
  request path so unrelated prose stays retryable. They now take the hard-error path, which
  switches models immediately rather than burning same-model retries.

## Evidence

Every criterion went RED before the fix and GREEN after; the two tests written after their fix were
mutation-proved by reverting the classifier.

| Proof | Before | After |
|---|---|---|
| Root type preserved (compat + moonshot) | `type` key absent | `type === "object"` |
| Root properties preserved | `{"properties":{}}` | all 3 properties intact |
| Real request builder wire payload | typeless root | `"type": "object"` + full properties |
| Classifier on the exact session error | `true` (retryable) | `false` |
| Agent turn on a schema rejection | 2 calls, same model | 1 call, then immediate switch |
| Root-union tool sent to Anthropic | `{"properties":{},"required":[]}` | all 3 properties, correct `required` |

Mutation proof for the agent-level tests: reverting the classifier returns `callCount 2` and the
run takes 30s because it hits the real backoff — the wasted wait this removes.

- `packages/ai`: **1778 passed**, 0 failed.
- retry-fallback suite (7 files): **51 passed**.
- `npm run check`: clean.
- Wire-payload artifacts: `local-ignore/qa-evidence/20260805-tool-schema-root-type/`.

## Notes

- The reported `Cannot find module .../pi-ai/dist/api/anthropic-messages.js` was investigated and is
  **not** a source defect: that path no longer exists, and the live install (2026.8.4-2) ships both
  `anthropic-messages.js` and its `.lazy.js`. Left unchanged rather than inventing a fix.
- One existing test asserted the old branches-only root shape. It pinned the defect, so it now
  asserts the merged root object, and a sibling test keeps below-root hoisting covered.
