### PR TITLE
fix(coding-agent): bound provider timeout retry continuation

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/rpc-qa-client.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/rpc-qa-client.mjs
@@ -1,0 +1,103 @@
+import { spawnCli } from "./common.mjs";
+
+export class RpcQaClient {
+	constructor({ env, cwd, extraArgs }) {
+		this.child = spawnCli(["--mode", "rpc", "--no-session", "--no-context-files", ...extraArgs], { env, cwd });
+		this.pending = new Map();
+		this.events = [];
+		this.eventWaiters = [];
+		this.stderr = "";
+		this.buffer = "";
+		this.sequence = 0;
+		this.child.stdout.on("data", (chunk) => this.onData(chunk));
+		this.child.stderr.on("data", (chunk) => {
+			this.stderr += chunk.toString();
+		});
+	}
+
+	onData(chunk) {
+		this.buffer += chunk.toString();
+		let newline = this.buffer.indexOf("\n");
+		while (newline >= 0) {
+			const line = this.buffer.slice(0, newline).trim();
+			this.buffer = this.buffer.slice(newline + 1);
+			if (line) this.onLine(line);
+			newline = this.buffer.indexOf("\n");
+		}
+	}
+
+	onLine(line) {
+		let message;
+		try {
+			message = JSON.parse(line);
+		} catch {
+			this.stderr += `[ignored non-protocol stdout] ${line.slice(0, 200)}\n`;
+			return;
+		}
+		if (message.type === "response") {
+			const waiter = this.pending.get(message.id);
+			if (!waiter) return;
+			clearTimeout(waiter.timer);
+			this.pending.delete(message.id);
+			waiter.resolve(message);
+			return;
+		}
+		if (!message.type) return;
+		this.events.push(message);
+		const eventIndex = this.events.length - 1;
+		for (const waiter of [...this.eventWaiters]) {
+			if (eventIndex < waiter.afterIndex || !waiter.predicate(message)) continue;
+			clearTimeout(waiter.timer);
+			this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
+			waiter.resolve(message);
+		}
+	}
+
+	send(command, timeoutMs = 15_000) {
+		const id = `qa-${++this.sequence}`;
+		return new Promise((resolveResponse, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`RPC response timeout for ${command.type}: ${this.stderr.slice(-400)}`));
+			}, timeoutMs);
+			this.pending.set(id, { resolve: resolveResponse, timer });
+			this.child.stdin.write(`${JSON.stringify({ ...command, id })}\n`);
+		});
+	}
+
+	waitForEvent(predicate, afterIndex, timeoutMs = 15_000) {
+		const found = this.events.slice(afterIndex).find(predicate);
+		if (found) return Promise.resolve(found);
+		return new Promise((resolveEvent, reject) => {
+			const waiter = {
+				afterIndex,
+				predicate,
+				resolve: resolveEvent,
+				timer: setTimeout(() => {
+					this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
+					reject(new Error(`RPC event timeout: ${this.stderr.slice(-400)}`));
+				}, timeoutMs),
+			};
+			this.eventWaiters.push(waiter);
+		});
+	}
+
+	close() {
+		this.child.stdin.end();
+	}
+
+	kill() {
+		this.child.kill("SIGKILL");
+	}
+
+	waitForExit(timeoutMs = 5_000) {
+		if (this.child.exitCode !== null) return Promise.resolve(this.child.exitCode);
+		return new Promise((resolveExit, reject) => {
+			const timer = setTimeout(() => reject(new Error("RPC process did not exit after stdin closed")), timeoutMs);
+			this.child.once("close", (code) => {
+				clearTimeout(timer);
+				resolveExit(code);
+			});
+		});
+	}
+}

--- a/.agents/skills/senpi-qa/scripts/mock-loop-transport-timeout-recovery.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop-transport-timeout-recovery.mjs
@@ -1,0 +1,222 @@
+import { createServer } from "node:http";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { createConnection } from "node:net";
+import { isAbsolute, join, resolve } from "node:path";
+import {
+	createChecks,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+} from "./lib/common.mjs";
+import { API_PRESETS, hermeticEnv, writeMockModelsJson } from "./lib/mock-loop-support.mjs";
+import { RpcQaClient } from "./lib/rpc-qa-client.mjs";
+
+const FINAL_MARKER = "SENPI_TIMEOUT_RECOVERED";
+const RETRY_TIMEOUT_MS = 1_000;
+
+function startServer() {
+	const requests = [];
+	const hungResponses = new Set();
+	const server = createServer((request, response) => {
+		const chunks = [];
+		request.on("data", (chunk) => chunks.push(chunk));
+		request.on("end", () => {
+			const body = Buffer.concat(chunks).toString("utf8");
+			let model = "unknown";
+			try {
+				model = JSON.parse(body).model ?? "unknown";
+			} catch {
+				model = "malformed-json";
+			}
+			requests.push({ attempt: requests.length + 1, url: request.url, model });
+			if (requests.length === 1) {
+				response.writeHead(200, {
+					"content-type": "text/event-stream",
+					"cache-control": "no-cache",
+					connection: "keep-alive",
+				});
+				response.end(
+					`event: error\ndata: ${JSON.stringify({ error: { message: "Request timed out.", type: "timeout_error" } })}\n\n`,
+				);
+				return;
+			}
+			response.writeHead(200, {
+				"content-type": "text/event-stream",
+				"cache-control": "no-cache",
+				connection: "keep-alive",
+			});
+			if (requests.length === 2) {
+				hungResponses.add(response);
+				response.once("close", () => hungResponses.delete(response));
+				return;
+			}
+			const base = {
+				id: "chatcmpl-timeout-recovery",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: API_PRESETS["openai-completions"].modelId,
+			};
+			const send = (delta, finishReason = null) => {
+				response.write(
+					`data: ${JSON.stringify({ ...base, choices: [{ index: 0, delta, finish_reason: finishReason }] })}\n\n`,
+				);
+			};
+			send({ role: "assistant", content: "" });
+			send({ content: FINAL_MARKER });
+			send({}, "stop");
+			response.end("data: [DONE]\n\n");
+		});
+	});
+	return new Promise((resolveServer, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				reject(new Error("Failed to resolve fake server port"));
+				return;
+			}
+			resolveServer({
+				url: `http://127.0.0.1:${address.port}/v1`,
+				port: address.port,
+				requests,
+				stop: () =>
+					new Promise((done) => {
+						for (const response of hungResponses) response.destroy();
+						hungResponses.clear();
+						server.close(done);
+					}),
+			});
+		});
+	});
+}
+
+function portIsClosed(port) {
+	return new Promise((resolveClosed) => {
+		const socket = createConnection({ host: "127.0.0.1", port });
+		const timer = setTimeout(() => {
+			socket.destroy();
+			resolveClosed(false);
+		}, 500);
+		socket.once("connect", () => {
+			clearTimeout(timer);
+			socket.destroy();
+			resolveClosed(false);
+		});
+		socket.once("error", () => {
+			clearTimeout(timer);
+			resolveClosed(true);
+		});
+	});
+}
+
+async function main() {
+	installCleanupHooks();
+	const checks = createChecks("mock-loop-transport-timeout-recovery.mjs");
+	const guard = guardRealAuth();
+	const box = makeSandbox("mock-loop-transport-timeout-recovery");
+	const server = await startServer();
+	const evidenceFlag = process.argv[process.argv.indexOf("--evidence-dir") + 1];
+	const evidencePath = evidenceFlag
+		? isAbsolute(evidenceFlag)
+			? evidenceFlag
+			: resolve(repoRoot(), evidenceFlag)
+		: join(repoRoot(), "local-ignore", "qa-evidence", "20260804-provider-timeout-retry-liveness");
+	mkdirSync(evidencePath, { recursive: true });
+	let client;
+	let summary = { pass: false };
+	try {
+		const preset = API_PRESETS["openai-completions"];
+		writeMockModelsJson(box.agentDir, server, "openai-completions");
+		writeFileSync(
+			join(box.agentDir, "settings.json"),
+			JSON.stringify({
+				httpIdleTimeoutMs: 0,
+				retry: {
+					enabled: true,
+					maxRetries: 1,
+					baseDelayMs: 1,
+					provider: {
+						maxRetries: 0,
+						maxRetryDelayMs: 60_000,
+						streamRetryTimeoutMs: RETRY_TIMEOUT_MS,
+						streamStartTimeoutMs: 0,
+					},
+				},
+			}),
+		);
+		client = new RpcQaClient({
+			env: hermeticEnv(box.env),
+			cwd: box.cwd,
+			extraArgs: ["--provider", preset.provider, "--model", preset.modelId, "--no-extensions"],
+		});
+		await client.send({ type: "get_state" });
+		const firstEventIndex = client.events.length;
+		const firstAck = await client.send({ type: "prompt", message: "trigger timeout recovery" });
+		const firstSettled = await client.waitForEvent((event) => event.type === "agent_settled", firstEventIndex);
+		const idleState = await client.send({ type: "get_state" });
+		const secondEventIndex = client.events.length;
+		const secondAck = await client.send({ type: "prompt", message: `return ${FINAL_MARKER}` });
+		await client.waitForEvent((event) => event.type === "agent_settled", secondEventIndex);
+		const last = await client.send({ type: "get_last_assistant_text" });
+		const markerCount = (last.data?.text ?? "").split(FINAL_MARKER).length - 1;
+		const timeoutSeen = client.events.some(
+			(event) => event.type === "message_end" && event.message?.errorMessage === "Request timed out.",
+		);
+		const pass =
+			firstAck.success === true &&
+			secondAck.success === true &&
+			firstSettled.type === "agent_settled" &&
+			idleState.data?.isStreaming === false &&
+			server.requests.length === 3 &&
+			markerCount === 1 &&
+			timeoutSeen;
+		checks.ok(
+			"same RPC process settles a hung timeout retry and accepts the next prompt",
+			pass,
+			`requests=${server.requests.length} marker=${markerCount} streaming=${idleState.data?.isStreaming}`,
+		);
+		summary = { pass, markerCount, timeoutSeen, requests: server.requests, events: client.events };
+	} catch (error) {
+		summary = {
+			...summary,
+			error: error instanceof Error ? error.message : String(error),
+			requests: server.requests,
+			events: client?.events ?? [],
+		};
+		throw error;
+	} finally {
+		client?.close();
+		let exitCode = null;
+		if (client) {
+			try {
+				exitCode = await client.waitForExit();
+			} catch {
+				client.kill();
+				exitCode = await client.waitForExit();
+			}
+		}
+		await server.stop();
+		const closed = await portIsClosed(server.port);
+		box.cleanup();
+		const sandboxRemoved = !existsSync(box.dir);
+		const authUnchanged = guard.assertUnchanged();
+		summary = { ...summary, cleanup: { exitCode, portClosed: closed, sandboxRemoved, authUnchanged } };
+		const { events = [], ...summaryWithoutEvents } = summary;
+		writeFileSync(join(evidencePath, "rpc-events.jsonl"), events.map((event) => JSON.stringify(event)).join("\n"));
+		writeFileSync(join(evidencePath, "request-ledger.json"), `${JSON.stringify(summary.requests ?? [], null, 2)}\n`);
+		writeFileSync(join(evidencePath, "rpc-stderr.txt"), client?.stderr ?? "");
+		writeFileSync(join(evidencePath, "rpc-summary.json"), `${JSON.stringify(summaryWithoutEvents, null, 2)}\n`);
+		checks.ok(
+			"RPC process, fake server port, sandbox, and auth state are clean",
+			exitCode === 0 && closed && sandboxRemoved && authUnchanged,
+			`exit=${exitCode} portClosed=${closed} sandboxRemoved=${sandboxRemoved}`,
+		);
+	}
+	process.exitCode = checks.finish() ? 0 : 1;
+}
+
+main().catch((error) => {
+	process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+	process.exit(1);
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Fixed
 
+- Fixed provider transport-timeout retries remaining indefinitely Working when both
+  ordinary stream guards were disabled; retry continuations now abort only their
+  captured Agent run at the configured retry cap, settle the session, and leave
+  later prompts/takeovers untouched ([#719](https://github.com/code-yeongyu/senpi/pull/719)).
+
 ### Removed
 
 ## [2026.8.4-2] - 2026-08-04

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -127,6 +127,7 @@ import { type AvailableModelsSource, getModelNarrowingPatterns, resolveModelScop
 import type { ModelRuntime } from "./model-runtime.ts";
 import { PROMPT_CACHE_SAFE_WAIT_ENV, resolvePromptCacheSafeWaitSeconds } from "./prompt-cache-budget.ts";
 import { expandPromptTemplate, type PromptTemplate } from "./prompt-templates.ts";
+import { createProviderTimeoutRetryPlan, runBoundedRetryContinuation } from "./provider-timeout-retry.ts";
 import type { ResourceExtensionPaths, ResourceLoader } from "./resource-loader.ts";
 import { isBillingErrorMessage } from "./retry-fallback/billing.ts";
 import { formatSelector } from "./retry-fallback/chains.ts";
@@ -4812,6 +4813,7 @@ export class AgentSession {
 
 	private async _continueAgentAfterCurrentRun(
 		options: AgentContinuationOptions = {},
+		retryTimeoutMs?: number,
 	): Promise<"continued" | "taken-over"> {
 		await this.agent.waitForIdle();
 		try {
@@ -4820,19 +4822,26 @@ export class AgentSession {
 			await this._revalidateScheduledContinuationAdmission();
 			if (this.agent.state.isStreaming) return "taken-over";
 
-			if (this._scheduledContinuationRecompacted) {
-				const tail = this.agent.state.messages.at(-1);
-				if (tail?.role === "assistant" && (tail.stopReason === "error" || tail.stopReason === "aborted")) {
-					this._retireFailedRetryAssistant(tail);
-					if (this.agent.state.messages.at(-1) === tail) {
-						this.agent.state.messages = this.agent.state.messages.slice(0, -1);
-						this._incrementMessageRevision();
+			await runBoundedRetryContinuation({
+				continueRun: async () => {
+					if (this._scheduledContinuationRecompacted) {
+						const tail = this.agent.state.messages.at(-1);
+						if (tail?.role === "assistant" && (tail.stopReason === "error" || tail.stopReason === "aborted")) {
+							this._retireFailedRetryAssistant(tail);
+							if (this.agent.state.messages.at(-1) === tail) {
+								this.agent.state.messages = this.agent.state.messages.slice(0, -1);
+								this._incrementMessageRevision();
+							}
+						}
+						await this.agent.continueWithQueuedMessages(options);
+					} else {
+						await this.agent.continue(options);
 					}
-				}
-				await this.agent.continueWithQueuedMessages(options);
-			} else {
-				await this.agent.continue(options);
-			}
+				},
+				getActiveSignal: () => this.agent.signal,
+				abortActive: () => this.agent.abort(),
+				timeoutMs: retryTimeoutMs,
+			});
 			return "continued";
 		} catch (error) {
 			if (
@@ -4864,13 +4873,14 @@ export class AgentSession {
 	private _scheduleContinuationAfterCurrentEvent(
 		options: AgentContinuationOptions = {},
 		retryContinuation = false,
+		retryTimeoutMs?: number,
 	): void {
 		// Tool hooks wait for queued message persistence, so continue() cannot run inside this event promise.
 		const currentEventQueue = this._agentEventQueue;
 		const finishContinuationWork = this._sessionWorkBarrier.begin();
 		const continueAfterEvent = async (): Promise<void> => {
 			try {
-				await this._continueAgentAfterCurrentRun(options);
+				await this._continueAgentAfterCurrentRun(options, retryTimeoutMs);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
 				this._emit({
@@ -5687,23 +5697,6 @@ export class AgentSession {
 		return hintMs;
 	}
 
-	private _getProviderTimeoutRetryOptions(message: AssistantMessage): AgentContinuationOptions {
-		if (!isProviderTimeoutError(message)) return {};
-
-		const capMs = this.settingsManager.getProviderStreamRetryTimeoutMs();
-		const capEnabledBound = (configuredMs: number | undefined): number | undefined => {
-			if (capMs === undefined || configuredMs === undefined) return undefined;
-			return Math.min(configuredMs, capMs);
-		};
-		const timeoutMs = capEnabledBound(this.agent.timeoutMs);
-		const streamStartTimeoutMs = capEnabledBound(this.agent.streamStartTimeoutMs);
-		return {
-			deferQueuedMessages: true,
-			...(timeoutMs === undefined ? {} : { timeoutMs }),
-			...(streamStartTimeoutMs === undefined ? {} : { streamStartTimeoutMs }),
-		};
-	}
-
 	/**
 	 * Retry policy + callbacks shared by compaction and branch-summary summarization calls.
 	 * Uses the same `settings.retry` budget/backoff as agent-turn retries so a single transient
@@ -6135,9 +6128,14 @@ export class AgentSession {
 		// the first queue poll so user input stays deferred until that request proves
 		// responsive. A concurrent low-level Agent prompt is a benign takeover, not
 		// a terminal continuation failure.
-		const continuationOptions = this._getProviderTimeoutRetryOptions(message);
+		const continuation = createProviderTimeoutRetryPlan({
+			message,
+			streamRetryTimeoutMs: this.settingsManager.getProviderStreamRetryTimeoutMs(),
+			timeoutMs: this.agent.timeoutMs,
+			streamStartTimeoutMs: this.agent.streamStartTimeoutMs,
+		});
 		this.agent.suppressQueuedMessageDrain();
-		this._scheduleContinuationAfterCurrentEvent(continuationOptions, true);
+		this._scheduleContinuationAfterCurrentEvent(continuation.options, true, continuation.watchdogTimeoutMs);
 
 		return "continued";
 	}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,43 @@
 # changes
 
+## Bound provider-timeout retry continuations (2026-08-05)
+
+### What changed
+
+- Provider stream/transport timeout retries keep the existing first-request
+  option cap, including the rule that disabled ordinary stream guards stay
+  disabled.
+- A separate retry-continuation watchdog now uses the same positive
+  `retry.provider.streamRetryTimeoutMs` budget to abort only the Agent run whose
+  signal it captured. A later prompt or low-level takeover cannot be cancelled
+  by the stale timer.
+- Timeout option planning and watchdog ownership live in
+  `provider-timeout-retry.ts`; the oversized `AgentSession` delegates instead of
+  absorbing another retry responsibility.
+
+### Why
+
+- A transport error such as `Request timed out.` could start a retry while both
+  ordinary stream guards were disabled. If that retry emitted no provider
+  events, its detached continuation held the session work barrier and retry
+  promise forever, leaving the interactive session visibly Working until the
+  process restarted.
+- Re-enabling user-disabled stream guards would mask the wedge by changing an
+  intentional policy. The retry-owned watchdog supplies liveness without
+  changing provider call options.
+
+### Why this cannot be expressed externally
+
+- Only `AgentSession` owns the retry promise, scheduled-continuation barrier,
+  active Agent signal, and settled lifecycle. An extension cannot prove that a
+  timer still owns the same retry run before aborting it.
+
+### Expected merge conflict zones
+
+- MEDIUM: `agent-session.ts` scheduled continuation and retry admission wiring.
+- LOW: `provider-timeout-retry.ts` timeout option planning and owned-run abort.
+- LOW: provider timeout recovery regression file organization.
+
 ## Default fallback chains survive user chain configuration (2026-08-04)
 
 ### What changed

--- a/packages/coding-agent/src/core/provider-timeout-retry.ts
+++ b/packages/coding-agent/src/core/provider-timeout-retry.ts
@@ -1,0 +1,74 @@
+import type { AgentContinuationOptions } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage } from "@earendil-works/pi-ai/compat";
+import { isProviderTimeoutError } from "@earendil-works/pi-ai/compat";
+
+export interface ProviderTimeoutRetryPlan {
+	options: AgentContinuationOptions;
+	watchdogTimeoutMs: number | undefined;
+}
+
+export interface ProviderTimeoutRetryPlanInput {
+	message: AssistantMessage;
+	streamRetryTimeoutMs: number | undefined;
+	timeoutMs: number | undefined;
+	streamStartTimeoutMs: number | undefined;
+}
+
+export interface BoundedRetryContinuation {
+	continueRun(): Promise<void>;
+	getActiveSignal(): AbortSignal | undefined;
+	abortActive(): void;
+	timeoutMs: number | undefined;
+}
+
+export function createProviderTimeoutRetryPlan({
+	message,
+	streamRetryTimeoutMs,
+	timeoutMs,
+	streamStartTimeoutMs,
+}: ProviderTimeoutRetryPlanInput): ProviderTimeoutRetryPlan {
+	if (!isProviderTimeoutError(message)) {
+		return { options: {}, watchdogTimeoutMs: undefined };
+	}
+
+	const capEnabledBound = (configuredMs: number | undefined): number | undefined => {
+		if (streamRetryTimeoutMs === undefined || configuredMs === undefined) return undefined;
+		return Math.min(configuredMs, streamRetryTimeoutMs);
+	};
+	const boundedTimeoutMs = capEnabledBound(timeoutMs);
+	const boundedStreamStartTimeoutMs = capEnabledBound(streamStartTimeoutMs);
+	return {
+		options: {
+			deferQueuedMessages: true,
+			...(boundedTimeoutMs === undefined ? {} : { timeoutMs: boundedTimeoutMs }),
+			...(boundedStreamStartTimeoutMs === undefined ? {} : { streamStartTimeoutMs: boundedStreamStartTimeoutMs }),
+		},
+		watchdogTimeoutMs:
+			boundedTimeoutMs === undefined && boundedStreamStartTimeoutMs === undefined ? streamRetryTimeoutMs : undefined,
+	};
+}
+
+export async function runBoundedRetryContinuation({
+	continueRun,
+	getActiveSignal,
+	abortActive,
+	timeoutMs,
+}: BoundedRetryContinuation): Promise<void> {
+	const continuation = continueRun();
+	const ownedSignal = getActiveSignal();
+	if (timeoutMs === undefined || ownedSignal === undefined) {
+		await continuation;
+		return;
+	}
+
+	const timer = setTimeout(() => {
+		if (getActiveSignal() === ownedSignal) {
+			abortActive();
+		}
+	}, timeoutMs);
+	try {
+		await continuation;
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -5,28 +5,11 @@ import {
 	fauxAssistantMessage,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.ts";
+import { createHarness, type Harness } from "../harness.ts";
 
 const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
 const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
 const RETRY_PROVIDER_TIMEOUT_MS = 30_000;
-
-type ContinuationInternals = {
-	_scheduledContinuationRecompacted: boolean;
-	_revalidateScheduledContinuationAdmission(): Promise<void>;
-};
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	const timeout = new Promise<never>((_resolve, reject) => {
-		timer = setTimeout(() => reject(new Error(message)), timeoutMs);
-	});
-	try {
-		return await Promise.race([promise, timeout]);
-	} finally {
-		if (timer !== undefined) clearTimeout(timer);
-	}
-}
 
 function createAssistantStream(): EventStream<AssistantMessageEvent, AssistantMessage> {
 	return new EventStream<AssistantMessageEvent, AssistantMessage>(
@@ -61,14 +44,6 @@ function genericTimeoutError() {
 	});
 }
 
-function getRequestUserTexts(harness: Harness): string[][] {
-	return harness.faux
-		.getCallLog()
-		.map((call) =>
-			call.context.messages.filter((message) => message.role === "user").map((message) => getMessageText(message)),
-		);
-}
-
 function getStreamStartTimeoutMs(options: unknown): number | undefined {
 	if (!options || typeof options !== "object" || !("streamStartTimeoutMs" in options)) return undefined;
 	const value = (options as { streamStartTimeoutMs?: unknown }).streamStartTimeoutMs;
@@ -84,71 +59,6 @@ describe("provider idle recovery", () => {
 		while (harnesses.length > 0) {
 			harnesses.pop()?.cleanup();
 		}
-	});
-
-	it("preserves steering until the timed-out retry recovers under configured timeouts", async () => {
-		const harness = await createHarness({
-			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 0 } },
-		});
-		harnesses.push(harness);
-		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
-		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
-		harness.setResponses([
-			idleTimeoutError(),
-			genericTimeoutError(),
-			fauxAssistantMessage("original request recovered"),
-			fauxAssistantMessage("steering request recovered"),
-		]);
-
-		let queuedSteering: Promise<void> | undefined;
-		let resolveSteeringResponse: (() => void) | undefined;
-		const steeringResponse = new Promise<void>((resolve) => {
-			resolveSteeringResponse = resolve;
-		});
-		const unsubscribe = harness.session.subscribe((event) => {
-			if (event.type === "auto_retry_start" && queuedSteering === undefined) {
-				queuedSteering = harness.session.steer("continue");
-			}
-			if (
-				event.type === "message_end" &&
-				event.message.role === "assistant" &&
-				getMessageText(event.message) === "steering request recovered"
-			) {
-				resolveSteeringResponse?.();
-			}
-		});
-
-		try {
-			await harness.session.prompt("original request");
-			await queuedSteering;
-			await withTimeout(
-				steeringResponse,
-				1_000,
-				`queued steering response was not produced: ${JSON.stringify(getRequestUserTexts(harness))}`,
-			);
-		} finally {
-			unsubscribe();
-		}
-
-		expect(getRequestUserTexts(harness)).toEqual([
-			["original request"],
-			["original request"],
-			["original request"],
-			["original request", "continue"],
-		]);
-		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
-			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
-			RETRY_PROVIDER_TIMEOUT_MS,
-			RETRY_PROVIDER_TIMEOUT_MS,
-			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
-		]);
-		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
-			DEFAULT_STREAM_START_TIMEOUT_MS,
-			RETRY_PROVIDER_TIMEOUT_MS,
-			RETRY_PROVIDER_TIMEOUT_MS,
-			DEFAULT_STREAM_START_TIMEOUT_MS,
-		]);
-		expect(getUserTexts(harness)).toEqual(["original request", "continue"]);
 	});
 
 	it("uses the configured provider stream retry cap", async () => {
@@ -242,124 +152,6 @@ describe("provider idle recovery", () => {
 
 		expect(harness.faux.state.callCount).toBe(1);
 		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
-	});
-
-	it.each([
-		["assistant", "queued"],
-		["assistant", "empty"],
-		["non-assistant", "queued"],
-		["non-assistant", "empty"],
-	] as const)(
-		"keeps timeout retries queue-first after recompaction with a %s tail and %s queue",
-		async (tail, queueState) => {
-			const harness = await createHarness({
-				settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
-			});
-			harnesses.push(harness);
-			harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
-			harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
-			const internals = harness.session as unknown as ContinuationInternals;
-			vi.spyOn(internals, "_revalidateScheduledContinuationAdmission").mockImplementation(async () => {
-				internals._scheduledContinuationRecompacted = true;
-				if (tail === "assistant") {
-					harness.agent.state.messages = [
-						...harness.agent.state.messages,
-						fauxAssistantMessage("", { stopReason: "error", errorMessage: "Request timed out." }),
-					];
-					return;
-				}
-				harness.agent.state.messages = [
-					...harness.agent.state.messages,
-					{
-						role: "custom",
-						customType: "compactionSummary",
-						content: "accepted retry compaction summary",
-						display: false,
-						timestamp: Date.now(),
-					},
-				];
-			});
-			const queueAwareContinue = vi.spyOn(harness.agent, "continueWithQueuedMessages");
-			let queuedInput: Promise<void> | undefined;
-			harness.session.subscribe((event) => {
-				if (queueState === "queued" && event.type === "auto_retry_start" && queuedInput === undefined) {
-					queuedInput = harness.session.steer("queued after timeout");
-				}
-			});
-			harness.setResponses([
-				genericTimeoutError(),
-				fauxAssistantMessage("recovered after recompaction"),
-				fauxAssistantMessage("must not run"),
-			]);
-
-			await harness.session.prompt("original request");
-			await queuedInput;
-
-			expect(queueAwareContinue).toHaveBeenCalledTimes(1);
-			expect(harness.eventsOfType("continuation_error")).toEqual([]);
-			const retryUserTexts = [
-				"original request",
-				...(tail === "non-assistant" ? ["accepted retry compaction summary"] : []),
-				...(queueState === "queued" ? ["queued after timeout"] : []),
-			];
-			expect(getRequestUserTexts(harness)).toEqual([["original request"], retryUserTexts]);
-			expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
-				DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
-				RETRY_PROVIDER_TIMEOUT_MS,
-			]);
-			expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
-				DEFAULT_STREAM_START_TIMEOUT_MS,
-				RETRY_PROVIDER_TIMEOUT_MS,
-			]);
-		},
-	);
-
-	it("retains queued input when a capped retry is aborted in flight", async () => {
-		const harness = await createHarness({
-			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
-		});
-		harnesses.push(harness);
-		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
-		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
-		const retryRequestStarted = createDeferred();
-		let queuedInput: Promise<void> | undefined;
-		harness.session.subscribe((event) => {
-			if (event.type === "auto_retry_start" && queuedInput === undefined) {
-				queuedInput = harness.session.steer("retain through retry abort");
-			}
-		});
-		harness.setResponses([
-			genericTimeoutError(),
-			async (_context, options) => {
-				retryRequestStarted.resolve();
-				await new Promise<void>((resolve) => {
-					const signal = options?.signal;
-					if (signal?.aborted) {
-						resolve();
-						return;
-					}
-					signal?.addEventListener("abort", () => resolve(), { once: true });
-				});
-				return fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request was aborted" });
-			},
-			fauxAssistantMessage("must not run"),
-		]);
-
-		const prompt = harness.session.prompt("original request");
-		await retryRequestStarted.promise;
-		await queuedInput;
-		await harness.session.abort();
-		await prompt;
-		await harness.session.waitForSettledSessionWork();
-
-		expect(harness.faux.state.callCount).toBe(2);
-		expect(harness.faux.getCallLog()[1]?.options?.timeoutMs).toBe(RETRY_PROVIDER_TIMEOUT_MS);
-		expect(harness.session.getSteeringMessages()).toEqual(["retain through retry abort"]);
-		expect(harness.agent.hasQueuedMessages()).toBe(true);
-		expect(harness.eventsOfType("continuation_error")).toEqual([]);
-		expect(harness.session.isRetrying).toBe(false);
-		expect(harness.session.isStreaming).toBe(false);
-		expect(harness.agent.state.isStreaming).toBe(false);
 	});
 
 	it("expires a no-first-event retry at the retry cap instead of the configured start timeout", async () => {

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -114,44 +114,57 @@ describe("provider idle recovery", () => {
 		]);
 	});
 
-	it("does not apply provider timeout policy to incidental extension timeout text", async () => {
+	it("bounds a hung retry continuation after a provider transport timeout", async () => {
+		vi.useFakeTimers();
+		const retryTimeoutMs = 1_000;
 		const harness = await createHarness({
-			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 1,
+					baseDelayMs: 0,
+					provider: { streamRetryTimeoutMs: retryTimeoutMs },
+				},
+			},
 		});
 		harnesses.push(harness);
-		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
-		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
-		harness.setResponses([
-			fauxAssistantMessage("", { stopReason: "error", errorMessage: "extension timed out" }),
-			fauxAssistantMessage("generic retry recovered"),
-		]);
+		harness.agent.timeoutMs = undefined;
+		harness.agent.streamStartTimeoutMs = undefined;
+		const retryRequestStarted = createDeferred();
+		let providerCalls = 0;
+		harness.agent.streamFunction = () => {
+			providerCalls++;
+			const stream = createAssistantStream();
+			if (providerCalls === 1) {
+				queueMicrotask(() => stream.push({ type: "error", reason: "error", error: genericTimeoutError() }));
+			} else {
+				retryRequestStarted.resolve();
+			}
+			return stream;
+		};
 
-		await harness.session.prompt("first request");
+		const prompt = harness.session.prompt("first request");
+		let settled = false;
+		let settledWork: Promise<void> | undefined;
+		try {
+			await vi.runOnlyPendingTimersAsync();
+			await retryRequestStarted.promise;
+			settledWork = harness.session.waitForSettledSessionWork().then(() => {
+				settled = true;
+			});
+			await vi.advanceTimersByTimeAsync(retryTimeoutMs);
+			await vi.advanceTimersByTimeAsync(0);
 
-		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
-			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
-			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
-		]);
-		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
-			DEFAULT_STREAM_START_TIMEOUT_MS,
-			DEFAULT_STREAM_START_TIMEOUT_MS,
-		]);
-	});
-
-	it("does not retry unrelated aborted timeout text", async () => {
-		const harness = await createHarness({
-			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
-		});
-		harnesses.push(harness);
-		harness.setResponses([
-			fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Command timed out after 30000ms" }),
-			fauxAssistantMessage("must not run"),
-		]);
-
-		await harness.session.prompt("first request");
-
-		expect(harness.faux.state.callCount).toBe(1);
-		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+			expect(settled).toBe(true);
+			expect(harness.session.isRetrying).toBe(false);
+			expect(harness.session.isStreaming).toBe(false);
+			expect(harness.eventsOfType("agent_settled")).toHaveLength(1);
+			expect(providerCalls).toBe(2);
+		} finally {
+			if (harness.session.isStreaming) await harness.session.abort();
+			await prompt;
+			await settledWork;
+		}
 	});
 
 	it("expires a no-first-event retry at the retry cap instead of the configured start timeout", async () => {

--- a/packages/coding-agent/test/suite/regressions/provider-idle-steering.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-steering.test.ts
@@ -1,0 +1,178 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getMessageText, getUserTexts, type Harness } from "../harness.ts";
+
+const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
+const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
+const RETRY_PROVIDER_TIMEOUT_MS = 30_000;
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+	});
+	try {
+		return await Promise.race([promise, timeout]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = () => {};
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	return { promise, resolve };
+}
+
+function idleTimeoutError() {
+	return fauxAssistantMessage("", {
+		stopReason: "error",
+		errorMessage: `Idle timeout waiting for provider stream after ${DEFAULT_PROVIDER_IDLE_TIMEOUT_MS}ms`,
+	});
+}
+
+function genericTimeoutError() {
+	return fauxAssistantMessage("", {
+		stopReason: "error",
+		errorMessage: "Request timed out.",
+	});
+}
+
+function getRequestUserTexts(harness: Harness): string[][] {
+	return harness.faux
+		.getCallLog()
+		.map((call) =>
+			call.context.messages.filter((message) => message.role === "user").map((message) => getMessageText(message)),
+		);
+}
+
+function getStreamStartTimeoutMs(options: unknown): number | undefined {
+	if (!options || typeof options !== "object" || !("streamStartTimeoutMs" in options)) return undefined;
+	const value = (options as { streamStartTimeoutMs?: unknown }).streamStartTimeoutMs;
+	return typeof value === "number" ? value : undefined;
+}
+
+describe("provider idle steering", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("preserves steering until the timed-out retry recovers under configured timeouts", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 2, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+		harness.setResponses([
+			idleTimeoutError(),
+			genericTimeoutError(),
+			fauxAssistantMessage("original request recovered"),
+			fauxAssistantMessage("steering request recovered"),
+		]);
+
+		let queuedSteering: Promise<void> | undefined;
+		let resolveSteeringResponse: (() => void) | undefined;
+		const steeringResponse = new Promise<void>((resolve) => {
+			resolveSteeringResponse = resolve;
+		});
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && queuedSteering === undefined) {
+				queuedSteering = harness.session.steer("continue");
+			}
+			if (
+				event.type === "message_end" &&
+				event.message.role === "assistant" &&
+				getMessageText(event.message) === "steering request recovered"
+			) {
+				resolveSteeringResponse?.();
+			}
+		});
+
+		try {
+			await harness.session.prompt("original request");
+			await queuedSteering;
+			await withTimeout(
+				steeringResponse,
+				1_000,
+				`queued steering response was not produced: ${JSON.stringify(getRequestUserTexts(harness))}`,
+			);
+		} finally {
+			unsubscribe();
+		}
+
+		expect(getRequestUserTexts(harness)).toEqual([
+			["original request"],
+			["original request"],
+			["original request"],
+			["original request", "continue"],
+		]);
+		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+		]);
+		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			RETRY_PROVIDER_TIMEOUT_MS,
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+		]);
+		expect(getUserTexts(harness)).toEqual(["original request", "continue"]);
+	});
+
+	it("retains queued input when a capped retry is aborted in flight", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+		const retryRequestStarted = createDeferred();
+		let queuedInput: Promise<void> | undefined;
+		harness.session.subscribe((event) => {
+			if (event.type === "auto_retry_start" && queuedInput === undefined) {
+				queuedInput = harness.session.steer("retain through retry abort");
+			}
+		});
+		harness.setResponses([
+			genericTimeoutError(),
+			async (_context, options) => {
+				retryRequestStarted.resolve();
+				await new Promise<void>((resolve) => {
+					const signal = options?.signal;
+					if (signal?.aborted) {
+						resolve();
+						return;
+					}
+					signal?.addEventListener("abort", () => resolve(), { once: true });
+				});
+				return fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request was aborted" });
+			},
+			fauxAssistantMessage("must not run"),
+		]);
+
+		const prompt = harness.session.prompt("original request");
+		await retryRequestStarted.promise;
+		await queuedInput;
+		await harness.session.abort();
+		await prompt;
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.state.callCount).toBe(2);
+		expect(harness.faux.getCallLog()[1]?.options?.timeoutMs).toBe(RETRY_PROVIDER_TIMEOUT_MS);
+		expect(harness.session.getSteeringMessages()).toEqual(["retain through retry abort"]);
+		expect(harness.agent.hasQueuedMessages()).toBe(true);
+		expect(harness.eventsOfType("continuation_error")).toEqual([]);
+		expect(harness.session.isRetrying).toBe(false);
+		expect(harness.session.isStreaming).toBe(false);
+		expect(harness.agent.state.isStreaming).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/provider-retry-recompaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-retry-recompaction.test.ts
@@ -1,0 +1,114 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHarness, getMessageText, type Harness } from "../harness.ts";
+
+const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
+const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
+const RETRY_PROVIDER_TIMEOUT_MS = 30_000;
+
+type ContinuationInternals = {
+	_scheduledContinuationRecompacted: boolean;
+	_revalidateScheduledContinuationAdmission(): Promise<void>;
+};
+
+function genericTimeoutError() {
+	return fauxAssistantMessage("", {
+		stopReason: "error",
+		errorMessage: "Request timed out.",
+	});
+}
+
+function getRequestUserTexts(harness: Harness): string[][] {
+	return harness.faux
+		.getCallLog()
+		.map((call) =>
+			call.context.messages.filter((message) => message.role === "user").map((message) => getMessageText(message)),
+		);
+}
+
+function getStreamStartTimeoutMs(options: unknown): number | undefined {
+	if (!options || typeof options !== "object" || !("streamStartTimeoutMs" in options)) return undefined;
+	const value = (options as { streamStartTimeoutMs?: unknown }).streamStartTimeoutMs;
+	return typeof value === "number" ? value : undefined;
+}
+
+describe("provider retry recompaction", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it.each([
+		["assistant", "queued"],
+		["assistant", "empty"],
+		["non-assistant", "queued"],
+		["non-assistant", "empty"],
+	] as const)(
+		"keeps timeout retries queue-first after recompaction with a %s tail and %s queue",
+		async (tail, queueState) => {
+			const harness = await createHarness({
+				settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+			});
+			harnesses.push(harness);
+			harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+			harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+			const internals = harness.session as unknown as ContinuationInternals;
+			vi.spyOn(internals, "_revalidateScheduledContinuationAdmission").mockImplementation(async () => {
+				internals._scheduledContinuationRecompacted = true;
+				if (tail === "assistant") {
+					harness.agent.state.messages = [
+						...harness.agent.state.messages,
+						fauxAssistantMessage("", { stopReason: "error", errorMessage: "Request timed out." }),
+					];
+					return;
+				}
+				harness.agent.state.messages = [
+					...harness.agent.state.messages,
+					{
+						role: "custom",
+						customType: "compactionSummary",
+						content: "accepted retry compaction summary",
+						display: false,
+						timestamp: Date.now(),
+					},
+				];
+			});
+			const queueAwareContinue = vi.spyOn(harness.agent, "continueWithQueuedMessages");
+			let queuedInput: Promise<void> | undefined;
+			harness.session.subscribe((event) => {
+				if (queueState === "queued" && event.type === "auto_retry_start" && queuedInput === undefined) {
+					queuedInput = harness.session.steer("queued after timeout");
+				}
+			});
+			harness.setResponses([
+				genericTimeoutError(),
+				fauxAssistantMessage("recovered after recompaction"),
+				fauxAssistantMessage("must not run"),
+			]);
+
+			await harness.session.prompt("original request");
+			await queuedInput;
+
+			expect(queueAwareContinue).toHaveBeenCalledTimes(1);
+			expect(harness.eventsOfType("continuation_error")).toEqual([]);
+			const retryUserTexts = [
+				"original request",
+				...(tail === "non-assistant" ? ["accepted retry compaction summary"] : []),
+				...(queueState === "queued" ? ["queued after timeout"] : []),
+			];
+			expect(getRequestUserTexts(harness)).toEqual([["original request"], retryUserTexts]);
+			expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+				DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+				RETRY_PROVIDER_TIMEOUT_MS,
+			]);
+			expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
+				DEFAULT_STREAM_START_TIMEOUT_MS,
+				RETRY_PROVIDER_TIMEOUT_MS,
+			]);
+		},
+	);
+});

--- a/packages/coding-agent/test/suite/regressions/provider-timeout-classification.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-timeout-classification.test.ts
@@ -1,0 +1,62 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
+const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
+
+function getStreamStartTimeoutMs(options: unknown): number | undefined {
+	if (!options || typeof options !== "object" || !("streamStartTimeoutMs" in options)) return undefined;
+	const value = (options as { streamStartTimeoutMs?: unknown }).streamStartTimeoutMs;
+	return typeof value === "number" ? value : undefined;
+}
+
+describe("provider timeout classification", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("does not apply provider timeout policy to incidental extension timeout text", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = DEFAULT_PROVIDER_IDLE_TIMEOUT_MS;
+		harness.agent.streamStartTimeoutMs = DEFAULT_STREAM_START_TIMEOUT_MS;
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "extension timed out" }),
+			fauxAssistantMessage("generic retry recovered"),
+		]);
+
+		await harness.session.prompt("first request");
+
+		expect(harness.faux.getCallLog().map((call) => call.options?.timeoutMs)).toEqual([
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+			DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,
+		]);
+		expect(harness.faux.getCallLog().map((call) => getStreamStartTimeoutMs(call.options))).toEqual([
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+			DEFAULT_STREAM_START_TIMEOUT_MS,
+		]);
+	});
+
+	it("does not retry unrelated aborted timeout text", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Command timed out after 30000ms" }),
+			fauxAssistantMessage("must not run"),
+		]);
+
+		await harness.session.prompt("first request");
+
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.eventsOfType("auto_retry_start")).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- bound provider transport/stream timeout retry continuations when both ordinary stream guards are disabled
- abort only the retry-owned Agent run by comparing the captured active signal, so a later takeover cannot be cancelled
- preserve the existing retry option policy: enabled guards are still capped and disabled guards stay absent
- split oversized provider recovery tests by behavior and add deterministic real-RPC regression evidence

## Root cause

Session `019fcd1d-84cf-7ff3-977b-bc21b62e3162` recorded:

1. native monitor `bash_183`
2. native background build `bash_184`
3. an empty assistant message with `stopReason: "error"` and `errorMessage: "Request timed out."`
4. a retry continuation whose second provider stream emitted no events

`AgentSession` scheduled that retry behind its session work barrier. Because both normal stream guards were disabled, the retry had no liveness bound; the barrier, retry promise, and user-visible Working state remained active until process restart.

OMO was audited separately and did not trigger or prolong this state.

## Fix

- `provider-timeout-retry.ts` now owns:
  - provider-timeout retry option planning
  - the retry-only watchdog decision
  - active-run signal ownership and abort
- the outer watchdog is armed only when both ordinary retry guards are absent
- configured ordinary guards keep the previous terminal event/error behavior
- explicit `streamRetryTimeoutMs: 0` still disables the cap

## RED -> GREEN

Focused regression:

```text
provider idle recovery > bounds a hung retry continuation after a provider transport timeout
```

RED failed because `settled` remained `false` after the configured retry deadline.

GREEN proves:

- session work barrier settles
- `session.isRetrying === false`
- `session.isStreaming === false`
- one `agent_settled` event
- exactly two provider attempts

Evidence:

- `local-ignore/qa-evidence/20260804-provider-timeout-retry-liveness/red-focused-test.txt`
- `local-ignore/qa-evidence/20260804-provider-timeout-retry-liveness/green-focused-test.txt`

The package test script already supplies `vitest --run`, so the executable scoped command is:

```bash
npm test -- test/suite/regressions/provider-idle-recovery.test.ts
```

## Real surface QA

```bash
node .agents/skills/senpi-qa/scripts/mock-loop-transport-timeout-recovery.mjs \
  --evidence-dir local-ignore/qa-evidence/20260804-provider-timeout-retry-liveness
```

The real source RPC CLI:

1. receives literal SSE error `Request timed out.`
2. starts a retry whose stream emits no events
3. returns to idle through the retry watchdog
4. accepts a second prompt in the same process
5. returns exactly one `SENPI_TIMEOUT_RECOVERED`

Final result: `2/2 passed`.

Mutation proof disables the owned-run abort and makes the same scenario fail with `RPC event timeout`.

Cleanup receipt proves RPC exit `0`, port closed, sandbox removed, real auth unchanged, and no residual process.

## Validation

- provider timeout regression files: 4 files, 12 tests passed
- adjacent terminal monitor regressions from PR #717: 2 files, 16 tests passed
- `npm run check`: passed, no formatter fixes on final run
- workspace build: passed
- full `npm test`: passed across all workspaces
- final real RPC QA: 2/2 passed
- `git diff --check`: clean
- all new code files remain below 250 pure LOC

## Commits

- `9e0ef9848 test(coding-agent): split provider timeout recovery coverage`
- `90f91e20d fix(coding-agent): bound provider timeout retry continuation`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stuck "Working" state after provider transport timeouts by bounding retry continuations with a run-owned watchdog. Sessions now settle and accept the next prompt without changing the existing retry cap policy.

- **Bug Fixes**
  - Introduced `packages/coding-agent/src/core/provider-timeout-retry.ts` to plan provider-timeout options and run a retry-only watchdog that aborts only the same active run.
  - Updated `AgentSession` to use the bounded continuation; the outer watchdog arms only when both ordinary stream guards are disabled. `retry.provider.streamRetryTimeoutMs: 0` still disables caps.
  - Split regressions into focused suites (`provider-idle-steering`, `provider-retry-recompaction`, `provider-timeout-classification`), added real RPC QA scripts (`.agents/skills/senpi-qa/scripts/lib/rpc-qa-client.mjs`, `.../mock-loop-transport-timeout-recovery.mjs`), and updated `CHANGELOG.md` and `changes.md`.

<sup>Written for commit dfc1c8884252f0e6971b8811d2362c37f5f7b5ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

