### PR TITLE
docs(changelog): audit v2026.8.5 release notes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,9 +10,19 @@
 
 ### Fixed
 
-- Kept tool parameter schemas rooted in an object type. A root `anyOf`/`oneOf`/`allOf` previously had its `type` hoisted into the branches and deleted, so OpenAI-compatible gateways rejected the request with `tools.function.parameters.type is required and must be "object"`, and the Moonshot root-union merge dropped the root's own properties entirely ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
-- Sent the real parameters of root-union tool schemas to Anthropic. `convertTools` read top-level `properties` only, so plugin and MCP tools defined as a root union reached the model with no parameters at all ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
-- Stopped retrying provider request-shape rejections. Gateways wrap these deterministic failures in 5xx envelopes, so they were classified transient and the identical invalid payload was replayed on the same model before fallback inherited it ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+- Fixed OpenAI-compatible Chat Completions tool schemas whose object-shaped root used `anyOf`, `oneOf`, or `allOf`:
+  root object typing is no longer hoisted away, and object-shaped root `anyOf`/`oneOf` schemas now retain root
+  properties and required names while merging branch properties. The same object-root normalization is used for
+  Moonshot, while scalar and mixed root unions are left unchanged rather than being mislabeled as objects
+  ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+- Fixed Anthropic tool conversion advertising object-shaped root `anyOf`/`oneOf` schemas as parameterless tools.
+  The adapter now resolves those schemas into top-level properties and required names before constructing
+  `input_schema`, while leaving ordinary object schemas unchanged
+  ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+- Stopped same-model retries for recognized malformed `tools.`/`functions.` schema errors, including
+  gateway-wrapped 5xx responses and `invalid tool schema` messages. These matches are classified non-retryable before
+  generic server-error rules; unrelated transient 5xx failures remain retryable
+  ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
 
 ### Removed
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -4,32 +4,30 @@
 
 ### What changed and why
 
-- `utils/tool-schema-compat.ts` no longer hoists a ROOT schema's `type` into its combiner
-  branches. A tool's root `parameters` must stay an object schema: OpenAI-compatible gateways
-  reject a typeless root with `tools.function.parameters.type is required and must be "object"`,
-  which is exactly how an Apitopia/Kimi turn died on 2026-08-04. `normalizeNode` now takes an
-  `isRoot` flag so branch-level hoisting (still correct below the root) is unchanged, and
-  `ensureRootObjectSchema` guarantees the emitted root is always `{"type":"object", ...}`.
-- `mergeRootObjectUnion` now merges the root's OWN `properties`/`required` with the branches'
-  instead of replacing them. It previously returned `{"properties":{},"type":"object"}` for a root
-  union that declared its properties at the root — silently sending a tool with zero parameters.
-  Untyped constraint-only branches (`{ required: [...] }` over root properties) are accepted, and
-  `required` keeps root entries plus only the names every branch shares.
-- Both flavors share one root guarantee: `normalizeToolParametersForMoonshot` is now the OpenAI
-  normalization plus annotation stripping, rather than a second, divergent root-merge path.
-- `api/anthropic-messages.ts` resolves a tool's root parameters through the shared
-  `resolveRootObjectSchema` before building `input_schema`. `convertTools` reads top-level
-  `properties`/`required` only, so a tool whose parameters are a root union arrived as
-  `{"properties":{},"required":[]}` — Claude was told the tool takes no arguments. senpi's own
-  `monitorSchema` was flattened in July to dodge this, but plugin and MCP tools ship root unions
-  and cannot be flattened by us, so the conversion itself has to handle them.
-- `utils/retry.ts` classifies provider request-shape rejections as NON-retryable, and
-  `NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN` is renamed `NON_RETRYABLE_PROVIDER_ERROR_PATTERN`
-  because it no longer covers only limits. Gateways wrap these deterministic rejections in 5xx
-  envelopes (`500 server_error: Invalid request: tools.function.parameters...`), so matching on
-  status text alone classified a permanent failure as transient: the identical payload was replayed
-  on the identical model until the turn died. The patterns are anchored on the
-  `tools.`/`functions.` request path so unrelated prose mentioning tools stays retryable.
+- `utils/tool-schema-compat.ts` no longer hoists a ROOT schema's `type` into its combiner branches.
+  OpenAI-compatible gateways reject a covered object-shaped root when normalization removes its required
+  `type: "object"`, which is exactly how an Apitopia/Kimi turn died on 2026-08-04. `normalizeNode` now takes an
+  `isRoot` flag so branch-level hoisting (still correct below the root) is unchanged. Plain and object-shaped roots
+  receive or retain object typing, while scalar and mixed root unions remain unchanged instead of being mislabeled.
+  Root `allOf` is protected from root type hoisting but is not flattened into a synthetic object.
+- `mergeRootObjectUnion` merges object-shaped root `anyOf`/`oneOf` schemas without replacing the root's own
+  `properties`/`required`. It previously returned `{"properties":{},"type":"object"}` for a root union that declared
+  its properties at the root — silently sending a tool with zero parameters. Untyped constraint-only branches
+  (`{ required: [...] }` over root properties) are accepted, and `required` keeps root entries plus only the names
+  every branch shares.
+- `normalizeToolParametersForMoonshot` now reuses the same object-root normalization before annotation stripping,
+  rather than maintaining a second, divergent root-merge path.
+- `api/anthropic-messages.ts` resolves object-shaped root `anyOf`/`oneOf` parameters through the shared
+  `resolveRootObjectSchema` before building `input_schema`. `convertTools` reads top-level `properties`/`required`
+  only, so covered root unions previously arrived as `{"properties":{},"required":[]}`. The conversion now merges
+  their properties and required names while leaving ordinary object schemas unchanged; non-object unions and root
+  `allOf` remain outside this resolver's flattening boundary.
+- `utils/retry.ts` classifies five recognized malformed tool/function schema message forms as NON-retryable, and
+  `NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN` is renamed `NON_RETRYABLE_PROVIDER_ERROR_PATTERN` because it no
+  longer covers only limits. Gateways can wrap these deterministic rejections in retryable-looking 5xx envelopes,
+  so generic status matching replayed an equivalent invalid request on the same model. Four matchers target
+  `tools.`/`functions.` request paths; `invalid tool schema` is intentionally broader. Eligible configured
+  fallbacks rebuild their own provider-specific request rather than inheriting guaranteed identical bytes.
 
 ### Why this cannot be expressed externally
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,10 +12,26 @@
 
 ### Fixed
 
+- Brought GitHub binary installs up to parity with npm for paused terminal monitors: after the wake budget suppresses
+  noisy line updates, the same monitor's terminal completion, timeout, or kill summary now clears the notifier pause
+  and prior rate limit, resets the monitor-only wake streak, and wakes the session automatically without
+  `monitor({ action: "rearm" })` or another wake-budget charge. Intermediate events remain suppressed until rearm,
+  and the pause notice now makes that distinction explicit ([#717](https://github.com/code-yeongyu/senpi/pull/717)).
 - Fixed provider transport-timeout retries remaining indefinitely Working when both
   ordinary stream guards were disabled; retry continuations now abort only their
   captured Agent run at the configured retry cap, settle the session, and leave
   later prompts/takeovers untouched ([#719](https://github.com/code-yeongyu/senpi/pull/719)).
+- Fixed OpenAI-compatible tool calls failing when an object-shaped root combiner lost its required
+  `type: "object"`, and fixed Moonshot normalization dropping root-declared properties while merging
+  object-shaped root `anyOf`/`oneOf` schemas. Scalar and mixed root unions remain unchanged instead of being
+  mislabeled as objects ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+- Fixed Anthropic receiving object-shaped root `anyOf`/`oneOf` tools with an empty parameter map. Senpi now merges
+  their properties and computes top-level required names before constructing Anthropic `input_schema`, while
+  preserving ordinary object schemas ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
+- Stopped retrying recognized malformed tool/function schema errors on the same model when gateways wrap them in
+  retryable-looking 5xx responses. With auto-retry enabled and a configured candidate, eligible error-only turns
+  switch immediately to that fallback; without a candidate they settle after the first call, while generic
+  transient server errors remain retryable ([#718](https://github.com/code-yeongyu/senpi/pull/718)).
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Prepare accurate public release notes for `v2026.8.5`, covering every merged runtime change after
`v2026.8.4-2`.

The audit found two release-note defects:

- PR #717 merged after the `v2026.8.4-2` tag, but its changelog commit remained inside that already-released
  section. This adds an explicit GitHub-binary catch-up note to the current cycle without rewriting immutable
  release history.
- PR #718 documented three AI fixes only in the source-package changelog, while GitHub release notes are generated
  exclusively from `packages/coding-agent/CHANGELOG.md`. Its original wording also overstated the implementation
  boundaries.

PR #719's existing coding-agent entry is accurate and remains unchanged.

## Changes

- Add an ultradetailed PR #717 `Unreleased / Fixed` entry describing:
  - automatic summary wake after monitor pause;
  - continued intermediate-line suppression;
  - prior rate-limit and wake-streak reset;
  - no additional wake-budget charge;
  - the clarified rearm notice.
- Replace PR #718's AI bullets with boundary-accurate descriptions of:
  - object-shaped root schema handling;
  - Anthropic root `anyOf`/`oneOf` parameter merging;
  - the recognized non-retryable malformed-schema messages.
- Duplicate all three PR #718 user-facing fixes into the coding-agent release-note source.
- Correct the matching overclaims in `packages/ai/src/changes.md`.
- Leave released changelog sections byte-identical.

## Release audit

Expected public `v2026.8.5` note coverage:

- PR #717: one coding-agent entry
- PR #718: three coding-agent entries and three AI source-package entries
- PR #719: one unchanged coding-agent entry

No additional package changelog targets or external-contributor attribution are required.

## Validation

- `git diff --check`
- `node scripts/check-pr-changelog.mjs --base origin/main --labels ""`
- Simulated `scripts/release-notes.mjs extract` for `2026.8.5`
- Extracted public-note counts:
  - `#717`: 1
  - `#718`: 3
  - `#719`: 1
- Released sections in `packages/ai/CHANGELOG.md` and
  `packages/coding-agent/CHANGELOG.md` are byte-identical to `origin/main`.

## Publication safety follow-up

The release operator will freeze main after final release preparation because the delegated npm publish workflow
currently checks out default main instead of pinning the release tag. This PR does not expand into that workflow
hardening; source identity will be verified operationally before completing the release.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audits and fixes the v2026.8.5 changelog so GitHub release notes match all runtime changes since `v2026.8.4-2`, without altering previously released sections.

- **Bug Fixes**
  - Add a coding-agent catch-up entry for #717 (auto-wake after paused monitor completion; no extra wake charge; reset and notice clarified).
  - Rewrite #718 notes with accurate scope in `packages/ai`; mirror the three user-facing fixes in `packages/coding-agent/CHANGELOG.md` (object-root combiner handling, Anthropic root-union parameters, and non-retryable malformed schema errors).
  - Keep #719 unchanged; prior release sections remain byte-identical.

<sup>Written for commit 62ab8cdf3a41cc82b0c1050a38b42f9ce35c285b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

