### PR TITLE
fix(tui): show server fallback abort once

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Fixed
 
+- Fixed client-policy server fallback aborts rendering both a refusal-shaped assistant `Error:` row and the dedicated
+  fallback notice box. Diagnosed aborts now leave the notice box as the single visible explanation while preserving
+  the original message diagnostics and incremental render-cache updates
+  ([#724](https://github.com/code-yeongyu/senpi/pull/724)).
+
 ### Removed
 
 ## [2026.8.5-2] - 2026-08-05

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,35 @@
 # changes
 
+## Server fallback abort uses one TUI notice (2026-08-05)
+
+### What changed
+
+- `components/assistant-render-descriptors.ts` now owns assistant transcript descriptor construction and no longer
+  emits the provider's refusal-shaped `Error:` row when the message carries the `server_fallback_aborted` diagnostic.
+  The dedicated interactive warning widget remains the single visible explanation and still reports the server
+  transition plus configured-chain behavior.
+- `components/assistant-message.ts` delegates descriptor construction to that focused module, keeping both renderer
+  files below the repository's 250 pure-LOC ceiling.
+- Assistant render signatures now include diagnostics, so a diagnostic added to the active message removes any stale
+  error descriptor during incremental rendering.
+- `../../../test/assistant-message-incremental-render.test.ts` covers both initial diagnosed rendering and same-message
+  diagnostic updates.
+
+### Why
+
+- The provider error and the dedicated fallback widget described the same client-policy abort back to back, making one
+  fallback transition look like two separate failures.
+
+### Why extension system couldn't handle this
+
+- Assistant stop-reason descriptors and their incremental render cache are private built-in TUI behavior. An extension
+  cannot suppress one diagnostic-specific error row while preserving the session message and dedicated warning event.
+
+### Expected merge conflict zones
+
+- LOW: `components/assistant-message.ts` descriptor integration and `components/assistant-render-descriptors.ts`
+  error-tail construction.
+
 ## Fallback transitions render as shared notice boxes (2026-08-04)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-message.ts
@@ -1,9 +1,8 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { type Component, Container, Markdown, type MarkdownTheme, Spacer, Text } from "@earendil-works/pi-tui";
 import type { MarkdownTransformer } from "../../../core/extensions/types.ts";
-import { formatDuration } from "../../../utils/duration.ts";
-import { formatProviderNativeBody, formatProviderNativeSummary } from "../../provider-native-rendering.ts";
 import { getMarkdownTheme, theme } from "../theme/theme.ts";
+import { type AssistantRenderDescriptor, createAssistantRenderDescriptors } from "./assistant-render-descriptors.ts";
 import { createMarkdownTransform } from "./markdown-transform.ts";
 import { createBoundedRenderSignature } from "./render-signature.ts";
 
@@ -11,30 +10,8 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
-type MarkdownDescriptorKind = "text-md" | "thinking-md";
-type TextDescriptorKind = "thinking-label" | "provider-native-summary" | "provider-native-body" | "error-text";
-type RenderDescriptorKind = "spacer" | MarkdownDescriptorKind | TextDescriptorKind;
-type RenderDescriptor = { readonly kind: RenderDescriptorKind; readonly text: string };
-
-const SPACER_DESCRIPTOR = { kind: "spacer", text: "" } as const satisfies RenderDescriptor;
-
 function assertNever(value: never): never {
 	throw new TypeError(`Unexpected assistant render variant: ${String(value)}`);
-}
-
-function isVisibleContent(content: AssistantMessage["content"][number], providerNativeVisible: boolean): boolean {
-	switch (content.type) {
-		case "text":
-			return Boolean(content.text.trim());
-		case "thinking":
-			return Boolean(content.thinking.trim());
-		case "providerNative":
-			return providerNativeVisible;
-		case "toolCall":
-			return false;
-		default:
-			return assertNever(content);
-	}
 }
 
 export class AssistantMessageComponent extends Container {
@@ -47,7 +24,7 @@ export class AssistantMessageComponent extends Container {
 	private markdownTransformers: readonly MarkdownTransformer[];
 	private lastMessage?: AssistantMessage;
 	private lastMessageSignature?: string;
-	private renderDescriptors: readonly RenderDescriptor[] = [];
+	private renderDescriptors: readonly AssistantRenderDescriptor[] = [];
 	private hasToolCalls = false;
 	private expanded = false;
 	private isStreaming = false;
@@ -137,122 +114,16 @@ export class AssistantMessageComponent extends Container {
 		this.renderCache = undefined;
 		if (streamingChanged) this.renderDescriptors = [];
 		this.hasToolCalls = message.content.some((content) => content.type === "toolCall");
-		const descriptors = this.createRenderDescriptors(message);
+		const descriptors = createAssistantRenderDescriptors(message, {
+			expanded: this.expanded,
+			hiddenThinkingLabel: this.hiddenThinkingLabel,
+			hideThinkingBlock: this.hideThinkingBlock,
+			hasToolCalls: this.hasToolCalls,
+		});
 		this.reconcileRenderDescriptors(descriptors);
 	}
 
-	private createRenderDescriptors(message: AssistantMessage): readonly RenderDescriptor[] {
-		const descriptors: RenderDescriptor[] = [];
-		if (message.content.some((content) => isVisibleContent(content, true))) descriptors.push(SPACER_DESCRIPTOR);
-		for (let i = 0; i < message.content.length; i++) {
-			const content = message.content[i];
-			switch (content.type) {
-				case "text": {
-					const text = content.text.trim();
-					if (text) descriptors.push({ kind: "text-md", text });
-					break;
-				}
-				case "thinking": {
-					const thinkingBlocks: string[] = [];
-					let hasTiming = false;
-					let isDone = true;
-					let minStart = Number.POSITIVE_INFINITY;
-					let maxEnd = Number.NEGATIVE_INFINITY;
-					for (; i < message.content.length; i++) {
-						const thinkingContent = message.content[i];
-						if (thinkingContent.type !== "thinking") break;
-						const startedAt = thinkingContent.startedAt;
-						if (startedAt !== undefined) {
-							hasTiming = true;
-							minStart = Math.min(minStart, startedAt);
-							const endedAt = thinkingContent.endedAt;
-							if (endedAt === undefined) {
-								isDone = false;
-							} else {
-								maxEnd = Math.max(maxEnd, endedAt);
-							}
-						}
-						const thinking = thinkingContent.thinking.trim();
-						if (thinking) thinkingBlocks.push(thinking);
-					}
-					i--;
-					if (thinkingBlocks.length === 0) break;
-					if (!hasTiming) {
-						const text = this.hideThinkingBlock
-							? theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel))
-							: thinkingBlocks.join("\n\n");
-						descriptors.push({ kind: this.hideThinkingBlock ? "thinking-label" : "thinking-md", text });
-					} else {
-						const label = isDone
-							? theme.italic(
-									theme.fg("thinkingText", `Thought: ${formatDuration(Math.max(0, maxEnd - minStart))}`),
-								)
-							: theme.italic(theme.fg("thinkingText", this.hiddenThinkingLabel));
-						if (this.hideThinkingBlock) {
-							descriptors.push({ kind: "thinking-label", text: label });
-						} else {
-							descriptors.push(
-								{ kind: "thinking-label", text: label },
-								{ kind: "thinking-md", text: thinkingBlocks.join("\n\n") },
-							);
-						}
-					}
-					if (message.content.slice(i + 1).some((following) => isVisibleContent(following, false)))
-						descriptors.push(SPACER_DESCRIPTOR);
-					break;
-				}
-				case "providerNative":
-					descriptors.push(
-						{
-							kind: "provider-native-summary",
-							text: theme.fg("muted", formatProviderNativeSummary(message, content, this.expanded)),
-						},
-						{
-							kind: "provider-native-body",
-							text: theme.fg("dim", formatProviderNativeBody(content, this.expanded)),
-						},
-					);
-					if (message.content.slice(i + 1).some((following) => isVisibleContent(following, true)))
-						descriptors.push(SPACER_DESCRIPTOR);
-					break;
-				case "toolCall":
-					break;
-				default:
-					assertNever(content);
-			}
-		}
-		const addError = (text: string): void => {
-			descriptors.push(SPACER_DESCRIPTOR, { kind: "error-text", text: theme.fg("error", text) });
-		};
-		switch (message.stopReason) {
-			case "length":
-				addError(
-					"Error: Model stopped because it reached the maximum output token limit. The response may be incomplete.",
-				);
-				break;
-			case "aborted": {
-				if (this.hasToolCalls) break;
-				const abortMessage =
-					message.errorMessage && message.errorMessage !== "Request was aborted"
-						? message.errorMessage
-						: "Operation aborted";
-				addError(abortMessage);
-				break;
-			}
-			case "error":
-				if (!this.hasToolCalls) addError(`Error: ${message.errorMessage || "Unknown error"}`);
-				break;
-			case "pending":
-			case "stop":
-			case "toolUse":
-				break;
-			default:
-				assertNever(message.stopReason);
-		}
-		return descriptors;
-	}
-
-	private reconcileRenderDescriptors(descriptors: readonly RenderDescriptor[]): void {
+	private reconcileRenderDescriptors(descriptors: readonly AssistantRenderDescriptor[]): void {
 		let divergentIndex = 0;
 		const sharedLength = Math.min(this.renderDescriptors.length, descriptors.length);
 		while (divergentIndex < sharedLength) {
@@ -273,7 +144,7 @@ export class AssistantMessageComponent extends Container {
 		this.renderDescriptors = descriptors;
 	}
 
-	private createRenderChild(descriptor: RenderDescriptor): Component {
+	private createRenderChild(descriptor: AssistantRenderDescriptor): Component {
 		switch (descriptor.kind) {
 			case "spacer":
 				return new Spacer(1);
@@ -312,7 +183,7 @@ export class AssistantMessageComponent extends Container {
 			content: message.content,
 			hiddenThinkingLabel: this.hiddenThinkingLabel,
 			hideThinkingBlock: this.hideThinkingBlock,
-			errorMessage: message.errorMessage,
+			errorState: [message.diagnostics, message.errorMessage],
 			stopReason: message.stopReason,
 		});
 	}

--- a/packages/coding-agent/src/modes/interactive/components/assistant-render-descriptors.ts
+++ b/packages/coding-agent/src/modes/interactive/components/assistant-render-descriptors.ts
@@ -1,0 +1,157 @@
+import { type AssistantMessage, SERVER_FALLBACK_ABORTED_DIAGNOSTIC } from "@earendil-works/pi-ai";
+import { formatDuration } from "../../../utils/duration.ts";
+import { formatProviderNativeBody, formatProviderNativeSummary } from "../../provider-native-rendering.ts";
+import { theme } from "../theme/theme.ts";
+
+type MarkdownDescriptorKind = "text-md" | "thinking-md";
+type TextDescriptorKind = "thinking-label" | "provider-native-summary" | "provider-native-body" | "error-text";
+type AssistantRenderDescriptorKind = "spacer" | MarkdownDescriptorKind | TextDescriptorKind;
+
+export type AssistantRenderDescriptor = {
+	readonly kind: AssistantRenderDescriptorKind;
+	readonly text: string;
+};
+
+type AssistantRenderDescriptorOptions = {
+	readonly expanded: boolean;
+	readonly hiddenThinkingLabel: string;
+	readonly hideThinkingBlock: boolean;
+	readonly hasToolCalls: boolean;
+};
+
+const SPACER_DESCRIPTOR = { kind: "spacer", text: "" } as const satisfies AssistantRenderDescriptor;
+
+function assertNever(value: never): never {
+	throw new TypeError(`Unexpected assistant render variant: ${String(value)}`);
+}
+
+function isVisibleContent(content: AssistantMessage["content"][number], providerNativeVisible: boolean): boolean {
+	switch (content.type) {
+		case "text":
+			return Boolean(content.text.trim());
+		case "thinking":
+			return Boolean(content.thinking.trim());
+		case "providerNative":
+			return providerNativeVisible;
+		case "toolCall":
+			return false;
+		default:
+			return assertNever(content);
+	}
+}
+
+export function createAssistantRenderDescriptors(
+	message: AssistantMessage,
+	options: AssistantRenderDescriptorOptions,
+): readonly AssistantRenderDescriptor[] {
+	const descriptors: AssistantRenderDescriptor[] = [];
+	if (message.content.some((content) => isVisibleContent(content, true))) descriptors.push(SPACER_DESCRIPTOR);
+	for (let i = 0; i < message.content.length; i++) {
+		const content = message.content[i];
+		switch (content.type) {
+			case "text": {
+				const text = content.text.trim();
+				if (text) descriptors.push({ kind: "text-md", text });
+				break;
+			}
+			case "thinking": {
+				const thinkingBlocks: string[] = [];
+				let hasTiming = false;
+				let isDone = true;
+				let minStart = Number.POSITIVE_INFINITY;
+				let maxEnd = Number.NEGATIVE_INFINITY;
+				for (; i < message.content.length; i++) {
+					const thinkingContent = message.content[i];
+					if (thinkingContent.type !== "thinking") break;
+					const startedAt = thinkingContent.startedAt;
+					if (startedAt !== undefined) {
+						hasTiming = true;
+						minStart = Math.min(minStart, startedAt);
+						const endedAt = thinkingContent.endedAt;
+						if (endedAt === undefined) {
+							isDone = false;
+						} else {
+							maxEnd = Math.max(maxEnd, endedAt);
+						}
+					}
+					const thinking = thinkingContent.thinking.trim();
+					if (thinking) thinkingBlocks.push(thinking);
+				}
+				i--;
+				if (thinkingBlocks.length === 0) break;
+				if (!hasTiming) {
+					const text = options.hideThinkingBlock
+						? theme.italic(theme.fg("thinkingText", options.hiddenThinkingLabel))
+						: thinkingBlocks.join("\n\n");
+					descriptors.push({ kind: options.hideThinkingBlock ? "thinking-label" : "thinking-md", text });
+				} else {
+					const label = isDone
+						? theme.italic(theme.fg("thinkingText", `Thought: ${formatDuration(Math.max(0, maxEnd - minStart))}`))
+						: theme.italic(theme.fg("thinkingText", options.hiddenThinkingLabel));
+					if (options.hideThinkingBlock) {
+						descriptors.push({ kind: "thinking-label", text: label });
+					} else {
+						descriptors.push(
+							{ kind: "thinking-label", text: label },
+							{ kind: "thinking-md", text: thinkingBlocks.join("\n\n") },
+						);
+					}
+				}
+				if (message.content.slice(i + 1).some((following) => isVisibleContent(following, false)))
+					descriptors.push(SPACER_DESCRIPTOR);
+				break;
+			}
+			case "providerNative":
+				descriptors.push(
+					{
+						kind: "provider-native-summary",
+						text: theme.fg("muted", formatProviderNativeSummary(message, content, options.expanded)),
+					},
+					{
+						kind: "provider-native-body",
+						text: theme.fg("dim", formatProviderNativeBody(content, options.expanded)),
+					},
+				);
+				if (message.content.slice(i + 1).some((following) => isVisibleContent(following, true)))
+					descriptors.push(SPACER_DESCRIPTOR);
+				break;
+			case "toolCall":
+				break;
+			default:
+				assertNever(content);
+		}
+	}
+	const addError = (text: string): void => {
+		descriptors.push(SPACER_DESCRIPTOR, { kind: "error-text", text: theme.fg("error", text) });
+	};
+	switch (message.stopReason) {
+		case "length":
+			addError(
+				"Error: Model stopped because it reached the maximum output token limit. The response may be incomplete.",
+			);
+			break;
+		case "aborted": {
+			if (options.hasToolCalls) break;
+			const abortMessage =
+				message.errorMessage && message.errorMessage !== "Request was aborted"
+					? message.errorMessage
+					: "Operation aborted";
+			addError(abortMessage);
+			break;
+		}
+		case "error":
+			if (
+				!options.hasToolCalls &&
+				!message.diagnostics?.some((entry) => entry.type === SERVER_FALLBACK_ABORTED_DIAGNOSTIC)
+			)
+				addError(`Error: ${message.errorMessage || "Unknown error"}`);
+			break;
+		case "pending":
+		case "stop":
+		case "toolUse":
+			break;
+		default:
+			assertNever(message.stopReason);
+	}
+	return descriptors;
+}

--- a/packages/coding-agent/test/assistant-message-incremental-render.test.ts
+++ b/packages/coding-agent/test/assistant-message-incremental-render.test.ts
@@ -20,7 +20,7 @@ type RenderParityCase = {
 
 function createAssistantMessage(
 	content: AssistantMessage["content"],
-	overrides: Partial<Pick<AssistantMessage, "errorMessage" | "stopReason">> = {},
+	overrides: Partial<Pick<AssistantMessage, "diagnostics" | "errorMessage" | "stopReason">> = {},
 ): AssistantMessage {
 	return {
 		role: "assistant",
@@ -37,6 +37,7 @@ function createAssistantMessage(
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		stopReason: overrides.stopReason ?? "stop",
+		diagnostics: overrides.diagnostics,
 		errorMessage: overrides.errorMessage,
 		timestamp: 0,
 	};
@@ -227,5 +228,37 @@ describe("AssistantMessageComponent incremental rendering", () => {
 		expect(getRequiredChild(component, 1)).toBe(initialPrefix);
 		expect(getRequiredChild(component, 2)).not.toBe(initialTail);
 		expect(getContentChildren(component).length).toBeGreaterThan(initialLength);
+	});
+
+	test("#given a diagnosed server fallback abort #when rendered #then leaves the notice to the fallback widget", () => {
+		const component = createComponent(
+			createAssistantMessage([], {
+				stopReason: "error",
+				errorMessage: "Server-side fallback (claude-fable-5 -> claude-opus-5) aborted by client policy",
+				diagnostics: [
+					{
+						type: "server_fallback_aborted",
+						timestamp: 0,
+						details: { from: "claude-fable-5", to: "claude-opus-5" },
+					},
+				],
+			}),
+		);
+
+		expect(component.render(100).join("\n")).not.toContain("Error: Server-side fallback");
+	});
+
+	test("#given diagnostics added to the active message #when rerendered #then removes the stale fallback error", () => {
+		const message = createAssistantMessage([], {
+			stopReason: "error",
+			errorMessage: "Server-side fallback (claude-fable-5 -> claude-opus-5) aborted by client policy",
+		});
+		const component = createComponent(message);
+		expect(component.render(100).join("\n")).toContain("Error: Server-side fallback");
+
+		message.diagnostics = [{ type: "server_fallback_aborted", timestamp: 0 }];
+		component.updateContent(message);
+
+		expect(component.render(100).join("\n")).not.toContain("Error: Server-side fallback");
 	});
 });


### PR DESCRIPTION
## Summary

Server-side fallback aborts were rendered twice in the interactive TUI: once as the provider's refusal-shaped assistant `Error:` row and again as the dedicated fallback notice box. This PR keeps the notice box as the single user-facing explanation while preserving the original assistant message and diagnostics for retry/session logic.

## Changes

- Suppress the assistant error-tail descriptor only when the message carries the `server_fallback_aborted` diagnostic.
- Include diagnostics in the assistant render signature so a diagnostic added to the active message removes a stale error row immediately.
- Extract assistant render-descriptor construction into a focused module, bringing the touched renderer below the repository's 250 pure-LOC ceiling without changing its other text, thinking, provider-native, or stop-reason behavior.
- Add deterministic coverage for both initial diagnosed rendering and same-message diagnostic updates.
- Record the fork-visible TUI behavior and merge-conflict zones.

## QA & Evidence

- **Focused fallback and assistant rendering tests**
  - Command: `npm --prefix packages/coding-agent test -- assistant-message.test.ts assistant-message-incremental-render.test.ts assistant-message-render-signature.test.ts interactive-mode-fallback.test.ts`
  - Observed: 4 files passed, 48 tests passed after rebasing onto current `origin/main`.
  - Artifact: `local-ignore/qa-evidence/20260805-widget-only-server-fallback/verification-summary.md`
  - Why sufficient: covers the removed duplicate row, live diagnostic cache invalidation, retained widget event, and unchanged descriptor behavior.

- **Coding-agent package suite**
  - Command: `npm --prefix packages/coding-agent test`
  - Observed: exit code 0.
  - Artifact: `local-ignore/qa-evidence/20260805-widget-only-server-fallback/verification-summary.md`
  - Why sufficient: exercises the broader CLI/session/TUI package around the renderer change.

- **Static validation**
  - Command: `npm run check`
  - Observed: Biome, pinned-dependency, import, shrinkwrap, install-lock, TypeScript, and browser-smoke checks passed after rebase.
  - Artifact: `local-ignore/qa-evidence/20260805-widget-only-server-fallback/verification-summary.md`
  - Why sufficient: proves formatting, type contracts, workspace metadata, and browser-safe imports remain valid.

- **Production build**
  - Command: `npm run build`
  - Observed: all workspace build phases passed after rebase.
  - Artifact: `local-ignore/qa-evidence/20260805-widget-only-server-fallback/verification-summary.md`
  - Why sufficient: proves the extracted module ships through the real package build graph.

- **Exact renderer QA**
  - Driver: `local-ignore/qa-evidence/20260805-widget-only-server-fallback/renderer-qa.mjs`
  - Observed: assistant lines were empty; the real notice box rendered `Server fallback aborted · claude-fable-5 → claude-opus-5` and `Retrying on your configured fallback chain.`
  - Artifact: `local-ignore/qa-evidence/20260805-widget-only-server-fallback/renderer-result.txt`
  - Why sufficient: directly observes the requested widget-only output from built TUI components.

- **Real TUI smoke**
  - Command: `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence widget-only-server-fallback-tui-final`
  - Observed: 5/5 passed; boot, render, composer input, teardown, and real-auth integrity all succeeded.
  - Artifact: `local-ignore/qa-evidence/20260805-widget-only-server-fallback-tui-final/`
  - Why sufficient: proves the source-built interactive CLI still works through a real terminal surface.

## Risks & Residuals

- Diagnostic suppression is intentionally narrow: ordinary provider errors still render their existing `Error:` row.
- Session/provider message data is unchanged; only the interactive descriptor layer suppresses the duplicate visual.
- `assistant-message-incremental-render.test.ts` is at 239 pure LOC, inside the 250-line limit but in the warning band; future additions should split fallback-specific cases into their own test module.

## Related Issues

- User-reported duplicate server fallback notice in the interactive TUI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate “server fallback aborted” messages in the interactive TUI by showing only the notice box and suppressing the extra assistant Error row. Preserves message/diagnostics, clears stale errors live when diagnostics are added, and documents the fix in the change logs.

- **Bug Fixes**
  - Suppress assistant error tail when `server_fallback_aborted` is present.
  - Update render signature to include diagnostics so adding one clears a stale error row immediately.
  - No change to text/thinking/provider-native or other stop-reason behavior.

- **Refactors**
  - Extract assistant render-descriptor construction to `assistant-render-descriptors.ts`; `assistant-message.ts` now delegates.
  - Add targeted tests for initial diagnosed rendering and same-message diagnostic updates.

<sup>Written for commit d2e9078ddf823e81841c0af06249c2405fa2c011. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

