### PR TITLE
fix(apply-patch): keep binary previews byte-safe

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed `apply_patch` binary-file previews so delete and move operations render a concise marker instead of decoded byte garbage, with move-only patches preserving the original bytes.
+
 ### Removed
 
 ## [2026.8.5-2] - 2026-08-05

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/apply.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/apply.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import { mkdir, rename, rm, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { withFileMutationQueue } from "../../../tools/file-mutation-queue.ts";
 import { ApplyPatchError } from "./errors.ts";
@@ -73,6 +73,18 @@ async function writeFileAtomic(
 	}
 }
 
+async function writeBinaryFileAtomic(absPath: string, content: Uint8Array): Promise<void> {
+	const tempPath = `${absPath}.tmp.${process.pid}.${Math.random().toString(16).slice(2)}`;
+	await writeFile(tempPath, content);
+	try {
+		await rename(tempPath, absPath);
+	} catch (error) {
+		if (!hasErrorCode(error, "EEXIST")) throw error;
+		await unlink(absPath);
+		await rename(tempPath, absPath);
+	}
+}
+
 export async function __testWriteFileAtomic(
 	absPath: string,
 	content: string,
@@ -103,29 +115,60 @@ async function applySingleHunk(
 		}
 
 		if (hunk.type === "delete") {
-			const oldContent = await readFile(absolutePath, "utf-8");
+			const source = await readPatchFileSnapshot(absolutePath);
 			const preview = buildPatchPreviewFile({
 				hunk,
-				source: { exists: true, content: oldContent },
+				source,
 				newContent: "",
 			});
 			await rm(absolutePath);
 			return { summary: `delete: ${hunk.filePath}`, appliedFile: hunk.filePath, fuzz: 0, preview };
 		}
 
-		const currentContent = await readFile(absolutePath, "utf-8");
-		const chunkResult =
-			hunk.chunks.length === 0
-				? { content: currentContent, fuzz: 0 }
-				: replaceChunks(currentContent, hunk.filePath, hunk.chunks);
-
-		if (hunk.movePath) {
-			const absoluteMovePath = resolvePatchPath(cwd, hunk.movePath);
-			const moveDestination =
-				absoluteMovePath === absolutePath ? undefined : await readPatchFileSnapshot(absoluteMovePath);
+		const source = await readPatchFileSnapshot(absolutePath);
+		if (!source.exists) {
+			const error = new Error(`ENOENT: no such file or directory, open '${absolutePath}'`) as NodeJS.ErrnoException;
+			error.code = "ENOENT";
+			throw error;
+		}
+		const absoluteMovePath = hunk.movePath ? resolvePatchPath(cwd, hunk.movePath) : undefined;
+		const moveDestination =
+			absoluteMovePath && absoluteMovePath !== absolutePath
+				? await readPatchFileSnapshot(absoluteMovePath)
+				: undefined;
+		if (source.binary) {
+			if (hunk.chunks.length > 0) {
+				throw new Error(`apply_patch cannot apply text hunks to binary file: ${hunk.filePath}`);
+			}
+			if (!hunk.movePath || !absoluteMovePath || !source.bytes) {
+				throw new Error(`apply_patch cannot update binary file without a move destination: ${hunk.filePath}`);
+			}
 			const preview = buildPatchPreviewFile({
 				hunk,
-				source: { exists: true, content: currentContent },
+				source,
+				newContent: "",
+				...(moveDestination ? { moveDestination } : {}),
+			});
+			await mkdir(path.dirname(absoluteMovePath), { recursive: true });
+			await writeBinaryFileAtomic(absoluteMovePath, source.bytes);
+			if (absoluteMovePath !== absolutePath) await rm(absolutePath);
+			return {
+				summary: `move: ${hunk.filePath} -> ${hunk.movePath}`,
+				appliedFile: hunk.movePath,
+				fuzz: 0,
+				preview,
+			};
+		}
+
+		const chunkResult =
+			hunk.chunks.length === 0
+				? { content: source.content, fuzz: 0 }
+				: replaceChunks(source.content, hunk.filePath, hunk.chunks);
+
+		if (hunk.movePath && absoluteMovePath) {
+			const preview = buildPatchPreviewFile({
+				hunk,
+				source,
 				newContent: chunkResult.content,
 				...(moveDestination ? { moveDestination } : {}),
 			});
@@ -142,7 +185,7 @@ async function applySingleHunk(
 
 		const preview = buildPatchPreviewFile({
 			hunk,
-			source: { exists: true, content: currentContent },
+			source,
 			newContent: chunkResult.content,
 		});
 		await writeFileAtomic(absolutePath, chunkResult.content);

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/changes.md
@@ -1,5 +1,35 @@
 # changes
 
+## Binary-safe patch previews (2026-08-05)
+
+### What changed
+
+- `preview.ts`: reads source and move-destination snapshots as bytes, classifies NUL-containing or invalid-UTF-8 files
+  as binary before constructing any line or unified diff, and carries that typed marker through pending and completed
+  previews.
+- `apply.ts`: deletion and update/move results reuse the same byte-aware snapshot. Move-only binary patches preserve
+  the original bytes atomically, while text hunks against binary sources fail instead of decoding and rewriting them.
+- `preview-format.ts` / `types.ts`: binary files render as a concise `(binary)` summary with no diff, patch payload, or
+  synthetic line counts.
+
+### Why
+
+Deleting an accidental PNG with `apply_patch` decoded the image as UTF-8, built a normal line diff containing `�PNG`,
+NUL/control bytes, `IHDR`, and `IDAT`, then rendered that payload inside the live TUI card. Character/line truncation
+bounded the size but did not make binary content safe.
+
+### Why this belongs in the extension
+
+The builtin owns the source snapshot, preview metadata, persisted result details, and custom renderer. Fixing the
+shared differential renderer would only hide one consumer while leaving poisoned binary diffs in session and
+app-server result data.
+
+### Expected upstream conflict zones
+
+- LOW: `preview.ts` snapshot decoding and binary preview construction.
+- LOW: `apply.ts` delete-source snapshot reuse.
+- LOW: `preview-format.ts` per-file summary formatting and `types.ts` preview metadata.
+
 ## Codemode lazy activation (2026-08-04)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/preview-format.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/preview-format.ts
@@ -68,6 +68,10 @@ function formatLineCountSummary(added: number, removed: number): string {
 	return `(+${added} -${removed})`;
 }
 
+function formatPatchFileSummary(file: ApplyPatchPreviewFile): string {
+	return file.binary ? "(binary)" : formatLineCountSummary(file.added, file.removed);
+}
+
 function countLines(text: string): number {
 	if (text.length === 0) return 0;
 	let lines = 1;
@@ -127,7 +131,7 @@ export function formatPatchPreview(
 		const file = preview.files[0];
 		if (file) {
 			lines.push(
-				`• ${formatPatchOperation(file.operation)} ${formatPatchFilePath(file, cwd)} ${formatLineCountSummary(file.added, file.removed)}`,
+				`• ${formatPatchOperation(file.operation)} ${formatPatchFilePath(file, cwd)} ${formatPatchFileSummary(file)}`,
 			);
 			if (expanded && file.diff)
 				lines.push(
@@ -142,7 +146,7 @@ export function formatPatchPreview(
 	const noun = preview.files.length === 1 ? "file" : "files";
 	lines.push(`• Edited ${preview.files.length} ${noun} ${formatLineCountSummary(preview.added, preview.removed)}`);
 	for (const file of preview.files) {
-		lines.push(`  └ ${formatPatchFilePath(file, cwd)} ${formatLineCountSummary(file.added, file.removed)}`);
+		lines.push(`  └ ${formatPatchFilePath(file, cwd)} ${formatPatchFileSummary(file)}`);
 		if (expanded && file.diff)
 			lines.push(
 				...truncatePreview(file.diff)
@@ -205,10 +209,10 @@ export function renderPatchPreview(
 	if (expanded) {
 		try {
 			const renderFile = (file: ApplyPatchPreviewFile, headerPrefix: string): string => {
-				const header = `• ${formatPatchOperation(file.operation)} ${formatPatchFilePath(file, cwd)} ${formatLineCountSummary(file.added, file.removed)}`;
+				const header = `• ${formatPatchOperation(file.operation)} ${formatPatchFilePath(file, cwd)} ${formatPatchFileSummary(file)}`;
 				if (!file.diff) {
 					return headerPrefix.length > 0
-						? `${headerPrefix}${formatPatchFilePath(file, cwd)} ${formatLineCountSummary(file.added, file.removed)}`
+						? `${headerPrefix}${formatPatchFilePath(file, cwd)} ${formatPatchFileSummary(file)}`
 						: header;
 				}
 
@@ -217,7 +221,7 @@ export function renderPatchPreview(
 					theme,
 				});
 				if (headerPrefix.length > 0) {
-					const nestedHeader = `${headerPrefix}${formatPatchFilePath(file, cwd)} ${formatLineCountSummary(file.added, file.removed)}`;
+					const nestedHeader = `${headerPrefix}${formatPatchFilePath(file, cwd)} ${formatPatchFileSummary(file)}`;
 					return `${nestedHeader}\n${renderedDiff
 						.split("\n")
 						.map((line) => `    ${line}`)

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/preview.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/preview.ts
@@ -16,11 +16,22 @@ import { resolvePatchPath } from "./workspace.ts";
 export type PatchFileSnapshot = {
 	readonly exists: boolean;
 	readonly content: string;
+	readonly binary?: true;
+	readonly bytes?: Uint8Array;
 };
 
 export async function readPatchFileSnapshot(absolutePath: string): Promise<PatchFileSnapshot> {
 	try {
-		return { exists: true, content: await readFile(absolutePath, "utf-8") };
+		const bytes = await readFile(absolutePath);
+		if (bytes.includes(0)) return { exists: true, content: "", binary: true, bytes };
+		try {
+			return {
+				exists: true,
+				content: new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+			};
+		} catch {
+			return { exists: true, content: "", binary: true, bytes };
+		}
 	} catch (error) {
 		if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
 			return { exists: false, content: "" };
@@ -57,6 +68,17 @@ export function buildPatchPreviewFile(input: {
 	readonly moveDestination?: PatchFileSnapshot;
 }): ApplyPatchPreviewFile {
 	const { hunk, source, newContent, moveDestination } = input;
+	if (source.binary || moveDestination?.binary) {
+		return {
+			filePath: hunk.filePath,
+			...(hunk.type === "update" && hunk.movePath ? { movePath: hunk.movePath } : {}),
+			operation: hunk.type === "add" && source.exists ? "update" : hunk.type,
+			binary: true,
+			diff: "",
+			added: 0,
+			removed: 0,
+		};
+	}
 	switch (hunk.type) {
 		case "add": {
 			const operation = source.exists ? "update" : "add";
@@ -102,24 +124,34 @@ async function createPatchPreviewFile(cwd: string, hunk: ParsedPatch): Promise<A
 			return buildPatchPreviewFile({ hunk, source, newContent: hunk.content });
 		}
 		case "delete": {
-			const oldContent = await readFile(absolutePath, "utf-8");
+			const source = await readPatchFileSnapshot(absolutePath);
 			return buildPatchPreviewFile({
 				hunk,
-				source: { exists: true, content: oldContent },
+				source,
 				newContent: "",
 			});
 		}
 		case "update": {
-			const oldContent = await readFile(absolutePath, "utf-8");
-			const newContent =
-				hunk.chunks.length === 0 ? oldContent : replaceChunks(oldContent, hunk.filePath, hunk.chunks).content;
+			const source = await readPatchFileSnapshot(absolutePath);
 			const moveDestination =
 				hunk.movePath && hunk.movePath !== hunk.filePath
 					? await readPatchFileSnapshot(resolvePatchPath(cwd, hunk.movePath))
 					: undefined;
+			if (source.binary || moveDestination?.binary) {
+				return buildPatchPreviewFile({
+					hunk,
+					source,
+					newContent: "",
+					...(moveDestination ? { moveDestination } : {}),
+				});
+			}
+			const newContent =
+				hunk.chunks.length === 0
+					? source.content
+					: replaceChunks(source.content, hunk.filePath, hunk.chunks).content;
 			return buildPatchPreviewFile({
 				hunk,
-				source: { exists: true, content: oldContent },
+				source,
 				newContent,
 				...(moveDestination ? { moveDestination } : {}),
 			});
@@ -132,7 +164,9 @@ async function createPatchPreviewFile(cwd: string, hunk: ParsedPatch): Promise<A
 }
 
 function hasPreviewChange(file: ApplyPatchPreviewFile): boolean {
-	return file.operation !== "update" || file.movePath !== undefined || file.diff.trim().length > 0;
+	return (
+		file.binary === true || file.operation !== "update" || file.movePath !== undefined || file.diff.trim().length > 0
+	);
 }
 
 export async function createPatchPreview(cwd: string, hunks: ParsedPatch[]): Promise<ApplyPatchPreview> {

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/types.ts
@@ -38,6 +38,7 @@ export type ApplyPatchPreviewFile = {
 	filePath: string;
 	movePath?: string;
 	operation: ApplyPatchOperation;
+	binary?: true;
 	diff: string;
 	patch?: string;
 	added: number;

--- a/packages/coding-agent/test/suite/gpt-apply-patch-rich-render.test.ts
+++ b/packages/coding-agent/test/suite/gpt-apply-patch-rich-render.test.ts
@@ -124,6 +124,178 @@ describe("gpt apply_patch rich TUI rendering", () => {
 		expect(rendered).toContain("+1 after");
 	});
 
+	it("renders binary deletions without raw byte previews", async () => {
+		initTheme("dark");
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const targetPath = path.join(harness.tempDir, "--full-page");
+		await writeFile(
+			targetPath,
+			Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0x80, 0x41]),
+		);
+		const args = {
+			input: `*** Begin Patch
+*** Delete File: --full-page
+*** End Patch`,
+		};
+		const tool = createApplyPatchTool();
+		let pendingRendered = "";
+
+		const result = await tool.execute(
+			"call-binary-delete",
+			args,
+			undefined,
+			(update) => {
+				const component = tool.renderResult?.(
+					update,
+					{ expanded: true, isPartial: true },
+					theme,
+					createRenderContext(harness.tempDir, args, {
+						executionStarted: true,
+						argsComplete: true,
+						isPartial: true,
+					}),
+				);
+				pendingRendered = stripAnsi(component?.render(120).join("\n") ?? "");
+			},
+			{ cwd: harness.tempDir } as Parameters<ApplyPatchTool["execute"]>[4],
+		);
+		const component = tool.renderResult?.(
+			result,
+			{ expanded: true, isPartial: false },
+			theme,
+			createRenderContext(harness.tempDir, args, { executionStarted: true, argsComplete: true, isPartial: false }),
+		);
+		const completedRendered = stripAnsi(component?.render(120).join("\n") ?? "");
+
+		await expect(readFile(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(result.details?.preview?.files[0]).toMatchObject({
+			filePath: "--full-page",
+			operation: "delete",
+			binary: true,
+			diff: "",
+			added: 0,
+			removed: 0,
+		});
+		for (const rendered of [pendingRendered, completedRendered]) {
+			expect(rendered).toContain("--full-page (binary)");
+			expect(rendered).not.toContain("PNG");
+			expect(rendered).not.toContain("\uFFFD");
+			expect(rendered).not.toMatch(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/u);
+		}
+	});
+
+	it("moves binary files without decoding bytes into previews", async () => {
+		initTheme("dark");
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sourcePath = path.join(harness.tempDir, "source.png");
+		const destinationPath = path.join(harness.tempDir, "moved.png");
+		const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0x80, 0x41]);
+		await writeFile(sourcePath, binary);
+		const args = {
+			input: `*** Begin Patch
+*** Update File: source.png
+*** Move to: moved.png
+*** End Patch`,
+		};
+		const tool = createApplyPatchTool();
+		let pendingPreview: unknown;
+		let pendingRendered = "";
+
+		const result = await tool.execute(
+			"call-binary-move",
+			args,
+			undefined,
+			(update) => {
+				pendingPreview = update.details?.preview?.files[0];
+				const component = tool.renderResult?.(
+					update,
+					{ expanded: true, isPartial: true },
+					theme,
+					createRenderContext(harness.tempDir, args, {
+						executionStarted: true,
+						argsComplete: true,
+						isPartial: true,
+					}),
+				);
+				pendingRendered = stripAnsi(component?.render(120).join("\n") ?? "");
+			},
+			{ cwd: harness.tempDir } as Parameters<ApplyPatchTool["execute"]>[4],
+		);
+		const component = tool.renderResult?.(
+			result,
+			{ expanded: true, isPartial: false },
+			theme,
+			createRenderContext(harness.tempDir, args, { executionStarted: true, argsComplete: true, isPartial: false }),
+		);
+		const completedRendered = stripAnsi(component?.render(120).join("\n") ?? "");
+
+		await expect(readFile(sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await readFile(destinationPath)).toEqual(binary);
+		expect(pendingPreview).toMatchObject({
+			filePath: "source.png",
+			movePath: "moved.png",
+			operation: "update",
+			binary: true,
+			diff: "",
+			added: 0,
+			removed: 0,
+		});
+		expect(pendingPreview).not.toHaveProperty("patch");
+		expect(result.details?.preview?.files[0]).toMatchObject({
+			filePath: "source.png",
+			movePath: "moved.png",
+			operation: "update",
+			binary: true,
+			diff: "",
+			added: 0,
+			removed: 0,
+		});
+		expect(result.details?.preview?.files[0]).not.toHaveProperty("patch");
+		for (const rendered of [pendingRendered, completedRendered]) {
+			expect(rendered).toContain("source.png");
+			expect(rendered).toContain("moved.png");
+			expect(rendered).toContain("(binary)");
+			expect(rendered).not.toContain("PNG");
+			expect(rendered).not.toContain("\uFFFD");
+		}
+	});
+
+	it("rejects text hunks against binary files without mutating bytes", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const sourcePath = path.join(harness.tempDir, "source.png");
+		const destinationPath = path.join(harness.tempDir, "moved.png");
+		const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff, 0x80, 0x41]);
+		await writeFile(sourcePath, binary);
+		const tool = createApplyPatchTool();
+
+		const result = await tool.execute(
+			"call-binary-text-hunk",
+			{
+				input: `*** Begin Patch
+*** Update File: source.png
+*** Move to: moved.png
+@@
+-old
++new
+*** End Patch`,
+			},
+			undefined,
+			undefined,
+			{ cwd: harness.tempDir } as Parameters<ApplyPatchTool["execute"]>[4],
+		);
+
+		expect(await readFile(sourcePath)).toEqual(binary);
+		await expect(readFile(destinationPath)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(result.details?.result?.failures).toHaveLength(1);
+		expect(result.details?.result?.failures[0]?.message).toContain(
+			"apply_patch cannot apply text hunks to binary file: source.png",
+		);
+		expect(result.details?.result?.appliedFiles).toEqual([]);
+	});
+
 	it("keeps the changed hunk visible when the applied diff is large", async () => {
 		initTheme("dark");
 		const harness = await createHarness();


### PR DESCRIPTION
## Summary

- classify patched files as binary before UTF-8 decoding or diff construction
- omit binary diff/patch payloads and render a concise `(binary)` marker
- preserve exact bytes for move-only binary patches and reject text hunks before mutation
- retain existing ENOENT, text diff, persisted-result, and app-server behavior

## Root cause

`apply_patch` read every source file with UTF-8 encoding before building its pending and completed previews. Deleting or moving an accidental PNG therefore converted invalid bytes to U+FFFD and rendered `�PNG`, control data, `IHDR`, and `IDAT` inside the live TUI card.

## Verification

- RED deletion regression reproduced decoded PNG bytes in preview metadata
- GREEN deletion regression: 1/1
- RED move regression reproduced exact-byte corruption
- GREEN move regression: 1/1
- mutation proof: pending preview payload retention and binary text-hunk acceptance each fail the new assertions
- final apply_patch domain: 10 files, 73 tests passed
- rebased verification: 5 files, 32 tests passed
- `npm run check`: passed after rebase
- standard isolated CLI smoke: 8/8 passed

## Real-surface QA

- native PTY delete scenario: exact binary marker, no PNG/control leakage, CLI exit 0
- native PTY move scenario: exact destination bytes preserved, binary marker rendered, CLI exit 0
- both raw streams replayed through xterm at 140x40
- Chrome screenshots confirm intact success panel, composer, footer, colors, wrapping, and glyph widths
- ports, fake servers, PTY sessions, Chrome, tmux, and temporary sandboxes cleaned

Evidence is stored locally under:

`local-ignore/qa-evidence/20260805-apply-patch-binary-preview/`

Key artifacts:

- `tui.png`
- `tui-move.png`
- `driver-result.json`
- `driver-result-move.json`
- `mutation-red-coverage.txt`
- `coverage-green.txt`
- `final-validation.txt`
- `cleanup-receipt.txt`

## Independent review

- visual integrity: `UNCONDITIONAL APPROVAL`
- final functional criteria: `UNCONDITIONAL APPROVAL`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `apply_patch` previews binary‑safe by reading file snapshots as bytes, detecting binaries before decoding, and showing a simple “(binary)” marker instead of diffs. Move‑only binary updates now preserve exact bytes with atomic writes.

- **Bug Fixes**
  - Read snapshots as bytes; classify NUL/invalid‑UTF‑8 files as binary and skip diff/patch payloads.
  - Preserve bytes on binary moves with atomic writes; reuse the same snapshot for delete/update/move.
  - Reject text hunks on binary files with a clear error; do not mutate source bytes; still include the file in the preview.
  - Preview formatting renders “(binary)” for affected files in both pending and completed views.

- **Docs**
  - Updated `CHANGELOG.md` and `changes.md` to record the binary preview fix.

<sup>Written for commit efeaca70f2302bbdaca4331e70bd9afb50d566d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

