### PR TITLE
fix(tui): survive dead terminal during shutdown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- Fixed interactive shutdown crashing with `setRawMode failed with errno: 5` when an SSH or PTY peer disappears before
+  terminal raw-mode restoration. Senpi now completes the requested exit for dead terminals without hiding unexpected
+  restoration failures ([#726](https://github.com/code-yeongyu/senpi/pull/726)).
 - Fixed `apply_patch` binary-file previews so delete and move operations render a concise marker instead of decoded byte garbage, with move-only patches preserving the original bytes.
 - Fixed client-policy server fallback aborts rendering both a refusal-shaped assistant `Error:` row and the dedicated
   fallback notice box. Diagnosed aborts now leave the notice box as the single visible explanation while preserving

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Fixed terminal shutdown crashing with `setRawMode failed with errno: 5` when an SSH or PTY peer disappears before
+  raw-mode restoration. Dead-terminal restoration errors are now best-effort while unexpected errors remain visible
+  ([#726](https://github.com/code-yeongyu/senpi/pull/726)).
+
 ### Removed
 
 ## [2026.8.5-2] - 2026-08-05

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,32 @@
 # TUI delta rendering fork changes
 
+## 2026-08-05: dead-terminal raw-mode restoration is best-effort during shutdown
+
+### What changed
+
+- `ProcessTerminal.stop()` still restores the raw-mode state captured by `start()`, but now treats `EIO`, `EPIPE`,
+  and `ENOTCONN` from the teardown-time `setRawMode()` call as a dead terminal instead of crashing the exiting CLI.
+- Unexpected raw-mode restoration errors still propagate so shutdown does not hide unrelated defects.
+- `test/terminal.test.ts` covers successful restoration, the dead-terminal `EIO` regression, and unexpected-error
+  propagation.
+
+### Why
+
+- An SSH or PTY peer can disappear after input draining but before raw-mode restoration. Node/Bun then throws a
+  synchronous stdin ioctl error, which bypasses the coding-agent's stdout/stderr error handlers and replaces the
+  requested exit with an uncaught `setRawMode failed with errno: 5` stack.
+
+### Why this cannot be expressed externally
+
+- Raw-mode ownership and restoration are private `ProcessTerminal` lifecycle responsibilities. Extensions receive
+  neither the saved raw-mode state nor a teardown hook around the stdin ioctl.
+
+### Expected merge conflict zones
+
+- LOW: `packages/tui/src/terminal.ts` around the terminal error classifier and `ProcessTerminal.stop()` raw-mode
+  restoration.
+- LOW: `packages/tui/test/terminal.test.ts` around lifecycle coverage.
+
 ## 2026-07-31: atomic visible-cursor frames for IME and animations
 
 ### What changed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -13,6 +13,7 @@ const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
 const APPLE_TERMINAL_SHIFT_ENTER_SEQUENCE = "\x1b[13;2u";
 const DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS = 7;
+const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 const KEYBOARD_PROTOCOL_RESPONSE_FRAGMENT_TIMEOUT_MS = 150;
 const KITTY_KEYBOARD_PROTOCOL_QUERY = `\x1b[>${DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS}u\x1b[?u\x1b[c`;
 
@@ -50,6 +51,15 @@ export function keyboardEnhancementEnabled(): boolean {
 	const value = process.env.PI_TUI_KEYBOARD_PROTOCOL;
 	if (value === undefined) return true;
 	return !["0", "false", "no", "off"].includes(value.toLowerCase());
+}
+
+function isDeadTerminalError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		"code" in error &&
+		typeof error.code === "string" &&
+		DEAD_TERMINAL_ERROR_CODES.has(error.code)
+	);
 }
 
 /**
@@ -529,7 +539,11 @@ export class ProcessTerminal implements Terminal {
 
 		// Restore raw mode state
 		if (process.stdin.setRawMode) {
-			process.stdin.setRawMode(this.wasRaw);
+			try {
+				process.stdin.setRawMode(this.wasRaw);
+			} catch (error) {
+				if (!isDeadTerminalError(error)) throw error;
+			}
 		}
 
 		this.removeExternalStdoutGuard();

--- a/packages/tui/test/terminal.test.ts
+++ b/packages/tui/test/terminal.test.ts
@@ -47,6 +47,33 @@ function resetFakeTimers(): void {
 	mock.timers.reset();
 }
 
+type TerminalStopHarness = {
+	terminal: ProcessTerminal;
+	cleanup(): void;
+};
+
+function setupTerminalStopHarness(wasRaw: boolean, restoreRawMode: (mode: boolean) => void): TerminalStopHarness {
+	const terminal = new ProcessTerminal();
+	const previousPause = process.stdin.pause;
+	const previousSetRawMode = process.stdin.setRawMode;
+
+	Reflect.set(terminal, "wasRaw", wasRaw);
+	Reflect.set(terminal, "rawStdoutWrite", (_data: string) => {});
+	Reflect.set(process.stdin, "pause", () => process.stdin);
+	Reflect.set(process.stdin, "setRawMode", (mode: boolean) => {
+		restoreRawMode(mode);
+		return process.stdin;
+	});
+
+	return {
+		terminal,
+		cleanup(): void {
+			Reflect.set(process.stdin, "pause", previousPause);
+			Reflect.set(process.stdin, "setRawMode", previousSetRawMode);
+		},
+	};
+}
+
 describe("normalizeAppleTerminalInput", () => {
 	it("rewrites Apple Terminal Return to CSI-u Shift+Enter when Shift is pressed", () => {
 		assert.equal(normalizeAppleTerminalInput("\r", true, true), "\x1b[13;2u");
@@ -289,6 +316,59 @@ describe("ProcessTerminal Kitty keyboard protocol negotiation", () => {
 			harness.cleanup();
 			assert.equal(harness.writes.includes("\x1b[<u"), false);
 			assert.equal(harness.writes.includes("\x1b[>4;0m"), false);
+		} finally {
+			harness.cleanup();
+		}
+	});
+});
+
+describe("ProcessTerminal stop", () => {
+	it("restores the previous raw mode during stop", () => {
+		// Given
+		const restoredModes: boolean[] = [];
+		const harness = setupTerminalStopHarness(true, (mode) => {
+			restoredModes.push(mode);
+		});
+
+		try {
+			// When
+			harness.terminal.stop();
+
+			// Then
+			assert.deepEqual(restoredModes, [true]);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not throw when raw-mode restoration fails during stop", () => {
+		// Given
+		const eio = Object.assign(new Error("setRawMode failed"), { code: "EIO" });
+		const harness = setupTerminalStopHarness(false, () => {
+			throw eio;
+		});
+
+		try {
+			// When / Then
+			assert.doesNotThrow(() => harness.terminal.stop());
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("rethrows unexpected raw-mode restoration failures", () => {
+		// Given
+		const invalidArgument = Object.assign(new Error("unexpected setRawMode failure"), { code: "EINVAL" });
+		const harness = setupTerminalStopHarness(false, () => {
+			throw invalidArgument;
+		});
+
+		try {
+			// When / Then
+			assert.throws(
+				() => harness.terminal.stop(),
+				(error: unknown) => error === invalidArgument,
+			);
 		} finally {
 			harness.cleanup();
 		}


### PR DESCRIPTION
## Summary

Senpi could crash while exiting if an SSH or PTY peer disappeared between input draining and raw-mode restoration. The synchronous `stdin.setRawMode()` error bypassed the existing stdout/stderr dead-terminal handlers and replaced the requested exit with an uncaught `setRawMode failed with errno: 5` stack.

This PR makes raw-mode restoration best-effort only for established dead-terminal codes (`EIO`, `EPIPE`, `ENOTCONN`). Successful restoration remains unchanged, and unexpected errors still propagate.

## Changes

- Contain dead-terminal failures around teardown-time raw-mode restoration in `ProcessTerminal.stop()`.
- Add deterministic coverage for successful restoration, the reported `EIO` regression, and unexpected-error propagation.
- Record the fork-specific lifecycle behavior and upstream conflict zones in the TUI changes ledger.

## QA & Evidence

- **Failing-first regression:** scoped test exited 1 before the implementation because the synthetic `EIO` escaped `ProcessTerminal.stop()`.
- **Mutation proof:** temporarily removing the restoration call made the normal-path assertion fail with `actual: []`, `expected: [true]`; the mutation was immediately reverted.
- **Scoped GREEN:** 3/3 stop-path tests passed.
- **TUI package suite:** 527 passed, 0 failed.
- **TUI build:** `tsc -p tsconfig.build.json` passed.
- **Repository validation:** `npm run check` passed, including Biome, pinned dependency/import/lock checks, workspace TypeScript, and browser smoke.
- **Real TUI surface:** `node .agents/skills/senpi-qa/scripts/tui-smoke.mjs --self-test --driver tmux --evidence setrawmode-shutdown` passed 5/5; the transcript contained no raw-mode EIO or uncaught stack and the harness reported no leaked session/process.
- **xterm.js visual smoke:** real source TUI rendered at 120x34, accepted input, had no overflow or border misalignment, and the PTY/sandbox were cleaned up.

Sanitized local receipts are under `local-ignore/qa-evidence/20260805-setrawmode-shutdown/` in the task worktree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent shutdown crashes when the terminal disappears by making raw-mode restoration best-effort. CLIs using `tui` no longer throw `setRawMode` errors on exit for dead SSH/PTY peers; unexpected errors still surface.

- **Bug Fixes**
  - Treat `EIO`, `EPIPE`, and `ENOTCONN` from `process.stdin.setRawMode` as dead terminal in `ProcessTerminal.stop()` and continue shutdown.
  - Keep normal restoration unchanged and rethrow unexpected errors.
  - Add tests for success, dead-terminal handling, and unexpected-error propagation.

<sup>Written for commit 172ed557ae7dce406110a9ab729cd904444a984e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

