### PR TITLE
fix: remove fatal per-turn compaction cap

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -374,7 +374,7 @@ function describeCompactionRejection(cause: CompactionRejectionCause): string {
 		case "circuit-breaker":
 			return "Compaction rejected: the compaction circuit breaker is open after repeated failures. Wait for the cooldown and retry.";
 		case "per-turn-cap":
-			return "Compaction rejected: per-turn compaction cap reached for this turn.";
+			return "Compaction rejected: absolute compaction cap reached for this session.";
 		case "stale-revision":
 			return "Compaction rejected: the session changed while the summary was being prepared. Retry compaction against the latest context.";
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -476,11 +476,11 @@ export default function compactionExtension(
 			return { cancel: true, reason: SDK_NATIVE_LANE_REJECTION_REASON };
 		}
 		if (cap.shouldRejectByCap(state, { reason: event.reason }).cancel) {
-			getLogger(ctx).debug("skip_cap", { reason: event.reason, count: state.acceptedThisTurn });
+			getLogger(ctx).debug("skip_cap", { reason: event.reason, count: state.acceptedAbsolute });
 			return {
 				cancel: true,
 				rejectionCause: "per-turn-cap",
-				reason: "per-turn compaction cap reached for this turn",
+				reason: "absolute compaction cap reached",
 			};
 		}
 		const now = Date.now();

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/per-turn-cap.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/per-turn-cap.ts
@@ -1,7 +1,6 @@
 import type { CompactionReason } from "../../types.ts";
 import type { CompactionExtensionState } from "./state.ts";
 
-export const softCap = 3;
 export const hardCap = 10;
 
 export interface ShouldRejectByCapOptions {
@@ -24,27 +23,13 @@ export function incrementIneffective(state: CompactionExtensionState): Compactio
 	};
 }
 
-export function isOverSoftCap(state: CompactionExtensionState): boolean {
-	return state.acceptedThisTurn + (state.ineffectiveAttemptsThisTurn ?? 0) >= softCap;
-}
-
 export function isOverHardCap(state: CompactionExtensionState): boolean {
 	return state.acceptedAbsolute >= hardCap;
 }
 
 export function shouldRejectByCap(
 	state: CompactionExtensionState,
-	opts?: ShouldRejectByCapOptions,
+	_opts?: ShouldRejectByCapOptions,
 ): { cancel: boolean } {
-	if (isOverHardCap(state)) {
-		return { cancel: true };
-	}
-	const bypass = opts?.manual === true || opts?.reason === "manual" || opts?.reason === "extension";
-	if (bypass) {
-		return { cancel: false };
-	}
-	if (isOverSoftCap(state)) {
-		return { cancel: true };
-	}
-	return { cancel: false };
+	return { cancel: isOverHardCap(state) };
 }

--- a/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
@@ -2,7 +2,7 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FAILURE_TRIP_THRESHOLD } from "../../src/core/extensions/builtin/compaction/circuit-breaker.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
-import { softCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
+import { hardCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
 import type { ExtensionHandler } from "../../src/core/extensions/index.ts";
 import {
 	connectionErrorResponse,
@@ -64,7 +64,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 		expect(harness.registration.state.callCount).toBe(FAILURE_TRIP_THRESHOLD);
 	});
 
-	it("bounds successful hard-limit blocking compactions by the soft cap", async () => {
+	it("bounds successful hard-limit blocking compactions by the absolute cap", async () => {
 		const handlers = captureHandlers();
 		const beforeAgentStart = handlers.get("before_agent_start");
 		const sessionCompact = handlers.get("session_compact");
@@ -72,7 +72,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 		expect(sessionCompact).toBeDefined();
 		const harness = createBlockingContext({ usageTokens: 9_950 });
 		registrations.push(harness.registration);
-		const attempts = softCap * 4;
+		const attempts = hardCap + 2;
 		harness.registration.setResponses(
 			Array.from({ length: attempts }, () => fauxAssistantMessage("## Goal\ncompact summary")),
 		);
@@ -86,10 +86,10 @@ describe("blocking compaction route guards (issue #527)", () => {
 			}
 		}
 
-		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(softCap);
+		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(hardCap);
 	});
 
-	it("admits compaction again after the provider turn ends", async () => {
+	it("admits compaction across a provider turn boundary until the absolute cap", async () => {
 		const handlers = captureHandlers();
 		const beforeAgentStart = handlers.get("before_agent_start");
 		const sessionCompact = handlers.get("session_compact");
@@ -100,20 +100,24 @@ describe("blocking compaction route guards (issue #527)", () => {
 		const harness = createBlockingContext({ usageTokens: 9_950 });
 		registrations.push(harness.registration);
 		harness.registration.setResponses(
-			Array.from({ length: softCap + 1 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
+			Array.from({ length: hardCap + 1 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
 		);
 
-		for (let round = 0; round < softCap; round++) {
+		for (let round = 0; round < hardCap - 1; round++) {
+			const appliedBefore = (harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length;
 			await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
-			await sessionCompact?.(acceptedCompactionEvent(round, 8_000) as never, harness.ctx);
+			const appliedAfter = (harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length;
+			if (appliedAfter > appliedBefore) {
+				await sessionCompact?.(acceptedCompactionEvent(round, 8_000) as never, harness.ctx);
+			}
 		}
 		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
 		await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
 
-		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(softCap + 1);
+		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(hardCap);
 	});
 
-	it("resets the soft cap on turn_end even after degradation recovery fires", async () => {
+	it("keeps admitting compactions after degradation recovery until the absolute cap", async () => {
 		const handlers = captureHandlers();
 		const beforeAgentStart = handlers.get("before_agent_start");
 		const sessionCompact = handlers.get("session_compact");
@@ -126,19 +130,18 @@ describe("blocking compaction route guards (issue #527)", () => {
 		const harness = createBlockingContext({ usageTokens: 9_950 });
 		registrations.push(harness.registration);
 		harness.registration.setResponses(
-			Array.from({ length: softCap + 2 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
+			Array.from({ length: hardCap + 1 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
 		);
 
-		// Fill the soft cap with accepted compactions this provider turn.
-		for (let round = 0; round < softCap; round++) {
+		for (let round = 0; round < hardCap - 1; round++) {
+			const appliedBefore = (harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length;
 			await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
-			await sessionCompact?.(acceptedCompactionEvent(round, 8_000) as never, harness.ctx);
+			const appliedAfter = (harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length;
+			if (appliedAfter > appliedBefore) {
+				await sessionCompact?.(acceptedCompactionEvent(round, 8_000) as never, harness.ctx);
+			}
 		}
-		const appliedAtCap = (harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length;
 
-		// Trigger post-compaction degradation recovery: three no-text assistant
-		// turns set recoveryTriggeredThisCycle, which used to skip the turn_end
-		// counter reset when the reset was not in `finally`.
 		for (let turn = 0; turn < 3; turn++) {
 			await messageEnd?.(
 				{
@@ -150,12 +153,13 @@ describe("blocking compaction route guards (issue #527)", () => {
 		}
 		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
 
-		// The next provider turn must open at a fresh soft counter and admit.
 		await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
-		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(appliedAtCap);
+		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(
+			hardCap,
+		);
 	});
 
-	it("counts zero-yield attempts before admitting turn-end recovery", async () => {
+	it("admits turn-end recovery after zero-yield attempts", async () => {
 		const handlers = captureHandlers();
 		const turnEnd = handlers.get("turn_end");
 		const sessionCompact = handlers.get("session_compact");
@@ -172,6 +176,6 @@ describe("blocking compaction route guards (issue #527)", () => {
 		await sessionCompact?.(acceptedCompactionEvent(1, 0) as never, harness.ctx);
 		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
 
-		expect(beginCompaction).not.toHaveBeenCalled();
+		expect(beginCompaction).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/compaction/ineffective-cap.test.ts
+++ b/packages/coding-agent/test/compaction/ineffective-cap.test.ts
@@ -1,6 +1,6 @@
 import { registerFauxProvider } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import { incrementAccepted, isOverSoftCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
+import { incrementAccepted, shouldRejectByCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
 import { createInitialState, resetTurnCounter } from "../../src/core/extensions/builtin/compaction/state.ts";
 import { computeStructuralYield, isIneffectiveCompaction } from "../../src/core/extensions/builtin/compaction/yield.ts";
 
@@ -79,14 +79,14 @@ describe("compaction ineffective cap", () => {
 	});
 
 	describe("Given a turn with two accepted compactions and one ineffective attempt", () => {
-		it("Then the 4th auto compaction is rejected by the cap", () => {
+		it("Then the next auto compaction remains admitted below the absolute cap", () => {
 			registerFauxProvider();
 			let state = createInitialState();
 			state = acceptN(state, 2);
 			state = { ...state, ineffectiveAttemptsThisTurn: 1 };
-			expect(isOverSoftCap(state)).toBe(true);
+			expect(shouldRejectByCap(state)).toEqual({ cancel: false });
 			state = incrementAccepted(state);
-			expect(isOverSoftCap(state)).toBe(true);
+			expect(shouldRejectByCap(state)).toEqual({ cancel: false });
 			state = resetTurnCounter(state, "turn-1");
 			expect(state.acceptedThisTurn).toBe(0);
 			expect(state.ineffectiveAttemptsThisTurn).toBe(0);

--- a/packages/coding-agent/test/compaction/per-turn-cap.test.ts
+++ b/packages/coding-agent/test/compaction/per-turn-cap.test.ts
@@ -6,13 +6,13 @@ import {
 	hardCap,
 	incrementAccepted,
 	shouldRejectByCap,
-	softCap,
 } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
 import { resetTurnCounter } from "../../src/core/extensions/builtin/compaction/state.ts";
 import { migrateSessionEntries, parseSessionEntries, type SessionEntry } from "../../src/core/session-manager.ts";
 
 interface FutureCapState {
 	acceptedThisTurn: number;
+	ineffectiveAttemptsThisTurn?: number;
 	acceptedAbsolute: number;
 }
 
@@ -27,7 +27,7 @@ const incrementAcceptedFuture = incrementAccepted as unknown as IncrementAccepte
 const shouldRejectByCapFuture = shouldRejectByCap as unknown as ShouldRejectByCapFn;
 const resetTurnCounterFuture = resetTurnCounter as unknown as ResetTurnCounterFn;
 
-const EXPECTED_SOFT_CAP = 3;
+const REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION = 3;
 const EXPECTED_HARD_CAP = 10;
 
 function createInitialCapState(): FutureCapState {
@@ -67,34 +67,48 @@ beforeAll(() => {
 	perTurnFixtureEntries = entries.filter((entry): entry is SessionEntry => entry.type !== "session");
 });
 
-describe("compaction per-turn cap", () => {
-	describe("Given a fresh turn with the soft cap of 3 accepted compactions", () => {
-		describe("When 3 compactions are accepted and a 4th is checked", () => {
-			it("Then the 4th compaction is rejected with { cancel: true }", () => {
+describe("compaction admission cap", () => {
+	describe("Given three accepted compactions below the absolute hard cap", () => {
+		describe("When a fourth required compaction is checked", () => {
+			it("Then it is accepted instead of terminating the turn", () => {
 				const registration = registerFauxProvider();
 				registrations.push(registration);
 
-				expect(softCap).toBe(EXPECTED_SOFT_CAP);
 				const compactionEntries = perTurnFixtureEntries.filter((entry) => entry.type === "compaction");
-				expect(compactionEntries.length).toBeGreaterThanOrEqual(EXPECTED_SOFT_CAP + 1);
+				expect(compactionEntries.length).toBeGreaterThanOrEqual(REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION + 1);
 
-				const stateAfterThree = acceptN(createInitialCapState(), EXPECTED_SOFT_CAP);
+				const stateAfterThree = acceptN(createInitialCapState(), REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION);
 				const decision = shouldRejectByCapFuture(stateAfterThree);
 
-				expect(stateAfterThree.acceptedThisTurn).toBe(EXPECTED_SOFT_CAP);
-				expect(decision).toEqual({ cancel: true });
+				expect(stateAfterThree.acceptedThisTurn).toBe(REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION);
+				expect(stateAfterThree.acceptedAbsolute).toBe(REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION);
+				expect(decision).toEqual({ cancel: false });
 			});
 		});
 	});
 
-	describe("Given the soft cap has been reached this turn", () => {
+	describe("Given three ineffective compaction attempts below the absolute hard cap", () => {
+		describe("When the next required compaction is checked", () => {
+			it("Then it is accepted instead of terminating the turn", () => {
+				const stateAfterIneffectiveAttempts: FutureCapState = {
+					acceptedThisTurn: 0,
+					ineffectiveAttemptsThisTurn: REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION,
+					acceptedAbsolute: 0,
+				};
+
+				expect(shouldRejectByCapFuture(stateAfterIneffectiveAttempts)).toEqual({ cancel: false });
+			});
+		});
+	});
+
+	describe("Given accepted compactions were recorded this turn", () => {
 		describe("When the turn ends and resetTurnCounter is applied", () => {
 			it("Then the per-turn counter resets to 0 and the next compaction is accepted", () => {
 				const registration = registerFauxProvider();
 				registrations.push(registration);
 
-				const stateAtCap = acceptN(createInitialCapState(), EXPECTED_SOFT_CAP);
-				expect(shouldRejectByCapFuture(stateAtCap)).toEqual({ cancel: true });
+				const stateAtCap = acceptN(createInitialCapState(), REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION);
+				expect(shouldRejectByCapFuture(stateAtCap)).toEqual({ cancel: false });
 
 				const stateAfterTurnEnd = resetTurnCounterFuture(stateAtCap);
 
@@ -104,24 +118,24 @@ describe("compaction per-turn cap", () => {
 		});
 	});
 
-	describe("Given the soft cap has been reached and the absolute hard cap is 10", () => {
+	describe("Given accepted compactions are below the absolute hard cap", () => {
 		describe("When a manual /compact is checked with manual: true", () => {
-			it("Then the cap is bypassed and the manual compaction is accepted", () => {
+			it("Then the manual compaction is accepted", () => {
 				const registration = registerFauxProvider();
 				registrations.push(registration);
 
 				expect(hardCap).toBe(EXPECTED_HARD_CAP);
 
-				const stateAtSoftCap: FutureCapState = {
-					acceptedThisTurn: EXPECTED_SOFT_CAP,
-					acceptedAbsolute: EXPECTED_SOFT_CAP,
+				const stateBelowHardCap: FutureCapState = {
+					acceptedThisTurn: REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION,
+					acceptedAbsolute: REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION,
 				};
-				expect(shouldRejectByCapFuture(stateAtSoftCap)).toEqual({ cancel: true });
+				expect(shouldRejectByCapFuture(stateBelowHardCap)).toEqual({ cancel: false });
 
-				const manualDecision = shouldRejectByCapFuture(stateAtSoftCap, { manual: true });
+				const manualDecision = shouldRejectByCapFuture(stateBelowHardCap, { manual: true });
 
 				expect(manualDecision).toEqual({ cancel: false });
-				expect(stateAtSoftCap.acceptedAbsolute).toBeLessThan(EXPECTED_HARD_CAP);
+				expect(stateBelowHardCap.acceptedAbsolute).toBeLessThan(EXPECTED_HARD_CAP);
 			});
 		});
 	});
@@ -143,14 +157,14 @@ describe("compaction per-turn cap", () => {
 		});
 	});
 
-	describe("Given the soft cap was reached and the session is reloaded with fresh in-memory state", () => {
+	describe("Given compactions were recorded and the session is reloaded with fresh in-memory state", () => {
 		describe("When the per-turn counter is read on the reloaded state", () => {
 			it("Then the counter is 0 and the next compaction is accepted", () => {
 				const registration = registerFauxProvider();
 				registrations.push(registration);
 
-				const preReloadState = acceptN(createInitialCapState(), EXPECTED_SOFT_CAP);
-				expect(preReloadState.acceptedThisTurn).toBe(EXPECTED_SOFT_CAP);
+				const preReloadState = acceptN(createInitialCapState(), REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION);
+				expect(preReloadState.acceptedThisTurn).toBe(REQUIRED_COMPACTIONS_BEFORE_NEXT_ADMISSION);
 
 				const reloadedState = createInitialCapState();
 


### PR DESCRIPTION
## Summary
- Allow required compaction beyond the former per-turn soft cap.
- Retain the absolute hard cap of 10 and report it accurately.
- Cover accepted, ineffective, route-guard, and degradation-recovery paths.

## Validation
- `npm --prefix packages/coding-agent test -- test/compaction` (52 files, 392 tests)
- `npm run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the per-turn compaction cap so required compactions can continue within a turn. Compaction now only stops at the absolute session cap (10), preventing premature turn termination.

- **Bug Fixes**
  - Enforce only the absolute cap of 10 via `shouldRejectByCap`; removed soft-cap checks.
  - Updated logs and rejection text to “absolute compaction cap” and count `acceptedAbsolute`.
  - Fixed route guards to admit compaction across turn boundaries and after degradation recovery until the hard cap.
  - Updated tests for absolute-cap behavior (accepted, ineffective, route-guard, and recovery paths).

<sup>Written for commit bb08d0e950d06cbbf2ae0418eb9367f54312b739. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

