### PR TITLE
feat(tui): add atomic tool output mode

### DIFF
--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,44 @@
 # changes
 
+## Bundled extension tools retain built-in provenance (2026-08-05)
+
+### What changed
+
+- `resource-loader.ts` marks bundled built-in extension entry paths as `source: "builtin"` when applying extension,
+  command, and tool source information.
+
+### Why
+
+- Bundled codemode is loaded from its package path, but its Eval tool still needs the same trusted provenance as
+  factory-backed built-ins. Treating it as a user-local extension disabled trusted atomic metadata at runtime.
+
+### Why this cannot be expressed externally
+
+- Source provenance is assigned while the core resource loader constructs the authoritative extension registry.
+
+### Expected merge conflict zones
+
+- LOW: `resource-loader.ts` extension source-info assignment.
+
+## Tool output keybinding describes the three-state cycle (2026-08-05)
+
+### What changed
+
+- The `app.tools.expand` action description now names collapsed, expanded, and atomic output instead of describing a
+  boolean expansion toggle.
+
+### Why
+
+- Ctrl+O now cycles three output modes, so help and keybinding discovery must describe the action users actually get.
+
+### Why this cannot be expressed externally
+
+- The action description is owned by the core keybinding registry consumed by built-in help surfaces.
+
+### Expected merge conflict zones
+
+- LOW: `keybindings.ts` `app.tools.expand` description.
+
 ## Bound provider-timeout retry continuations (2026-08-05)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,23 @@
 # Core Extensions Changes
 
+## 2026-08-05 - Tool renderers can release suspended state
+
+### What changed and why
+
+- `ToolDefinition` gains an optional `disposeRenderState(state)` lifecycle hook.
+- The interactive tool shell calls the hook when a renderer is suspended or disposed, so extensions can release
+  renderer-owned timers and resources instead of leaving invisible work active in atomic mode.
+
+### Why this cannot be expressed externally
+
+- Renderer state is created and retained by the built-in interactive shell; only the shared tool-definition contract
+  can provide a lifecycle boundary for every extension renderer.
+
+### Expected merge conflict zones
+
+- LOW: `types.ts` `ToolDefinition` renderer members.
+- LOW: interactive `tool-execution-renderer.ts` suspension and disposal.
+
 ## 2026-08-03 - ExtensionContext exposes the resolved agent dir
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -632,6 +632,9 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 		theme: Theme,
 		context: ToolRenderContext<TState, Static<TParams>>,
 	) => Component;
+
+	/** Release renderer-owned resources when the tool view is suspended or disposed. */
+	disposeRenderState?: (state: TState) => void;
 }
 
 type AnyToolDefinition = ToolDefinition<any, any, any>;

--- a/packages/coding-agent/src/core/keybindings.ts
+++ b/packages/coding-agent/src/core/keybindings.ts
@@ -86,7 +86,10 @@ export const KEYBINDINGS = {
 	},
 	"app.model.select": { defaultKeys: "ctrl+l", description: "Open model selector" },
 	"app.history.search": { defaultKeys: "ctrl+r", description: "Search prompt history across sessions" },
-	"app.tools.expand": { defaultKeys: "ctrl+o", description: "Toggle tool output" },
+	"app.tools.expand": {
+		defaultKeys: "ctrl+o",
+		description: "Cycle collapsed, expanded, and atomic tool output",
+	},
 	"app.thinking.toggle": {
 		defaultKeys: "ctrl+t",
 		description: "Toggle thinking blocks",

--- a/packages/coding-agent/src/core/resource-loader.ts
+++ b/packages/coding-agent/src/core/resource-loader.ts
@@ -39,7 +39,7 @@ import { loadPromptTemplates } from "./prompt-templates.ts";
 import { SettingsManager } from "./settings-manager.ts";
 import type { Skill } from "./skills.ts";
 import { loadSkills } from "./skills.ts";
-import { createSourceInfo, type SourceInfo } from "./source-info.ts";
+import { createSourceInfo, createSyntheticSourceInfo, type SourceInfo } from "./source-info.ts";
 import { resetTimings, time } from "./timings.ts";
 
 export interface ResourceExtensionPaths {
@@ -997,10 +997,15 @@ export class DefaultResourceLoader implements ResourceLoader {
 	}
 
 	private applyExtensionSourceInfo(extensions: Extension[], metadataByPath: Map<string, PathMetadata>): void {
+		const bundledExtensionPaths = this.getBundledExtensionEntryPaths();
 		for (const extension of extensions) {
-			extension.sourceInfo =
-				this.findSourceInfoForPath(extension.path, undefined, metadataByPath) ??
-				this.getDefaultSourceInfoForPath(extension.path);
+			extension.sourceInfo = bundledExtensionPaths.has(extension.resolvedPath)
+				? createSyntheticSourceInfo(extension.path, {
+						source: "builtin",
+						baseDir: dirname(extension.resolvedPath),
+					})
+				: (this.findSourceInfoForPath(extension.path, undefined, metadataByPath) ??
+					this.getDefaultSourceInfoForPath(extension.path));
 			for (const command of extension.commands.values()) {
 				command.sourceInfo = extension.sourceInfo;
 			}

--- a/packages/coding-agent/src/core/tools/bash.ts
+++ b/packages/coding-agent/src/core/tools/bash.ts
@@ -533,6 +533,10 @@ export function createBashToolDefinition(
 			component.invalidate();
 			return component;
 		},
+		disposeRenderState(state) {
+			if (state.interval) clearInterval(state.interval);
+			state.interval = undefined;
+		},
 	};
 }
 

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -1,5 +1,25 @@
 # core/tools changes
 
+## bash renderer cleanup on suspension (2026-08-05)
+
+### What changed
+
+- `bash.ts` implements the renderer-state disposal hook and clears its elapsed-time interval when the interactive
+  shell suspends or disposes the renderer.
+
+### Why
+
+- Atomic mode replaces the classic Bash view. Its hidden elapsed timer must not continue requesting renders while the
+  atomic row is active.
+
+### Why extension system couldn't handle this
+
+- The interval belongs to the built-in Bash renderer state and must be released by that definition's lifecycle hook.
+
+### Expected merge conflict zones
+
+- LOW: `bash.ts` renderer members in `createBashToolDefinition()`.
+
 ## source-backed write result patches (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,38 @@
 # changes
 
+## Atomic one-line tool output mode (2026-08-05)
+
+### What changed
+
+- `app.tools.expand` now cycles collapsed, expanded, and atomic tool output.
+- Atomic mode renders ordinary tools as adjacent full-width one-line rows with zero horizontal container padding or hard-coded leading spaces, exact bold tool names, shallow known-tool metadata, and original spinner placement.
+- Bash places its active spinner immediately after the tool name; Eval follows its native reading order: `eval`, target, active spinner, then call count.
+- Ctrl+O reaches direct, nested, and still-pending tool components while preserving top-level expansion ownership for non-tool components.
+- Monitor, Todo, and Goal tools retain their dedicated renderers, and classic, Grok, and extension self-renderers restore when leaving atomic mode.
+- Metadata observation is bounded, strips terminal and bidirectional control characters, accepts only safe-integer
+  counts, and separates Eval targets from trusted facts with the reserved delimiter.
+- Built-in metadata and passthrough behavior require registered built-in provenance, so same-name extension overrides remain untrusted.
+- Live tool trust is captured by session and tool-call ID; transcript rebuilds reuse captured execution-time provenance,
+  while historical calls without it default to untrusted.
+- Entering atomic mode suspends hidden renderers and releases renderer-owned resources through an explicit lifecycle hook.
+- `components/tool-execution-controller.ts` owns mode selection, atomic eligibility, render caching, suspension/resume,
+  and spinner policy so the high-frequency component remains below the repository size ceiling.
+
+### Why
+
+- Dense tool activity needs a compact scan mode without losing the command target, progress, or useful result counts.
+
+### Why this cannot be expressed externally
+
+- Atomic spacing, renderer restoration, and mode propagation depend on the built-in tool component tree and global interactive keybinding state.
+
+### Integration boundary
+
+- This change does not alter TUI scrollback replay.
+- Expected merge conflict zones for future upstream ports are `interactive-mode.ts`, `components/tool-execution.ts`,
+  `components/tool-execution-controller.ts`, `components/tool-execution-renderer.ts`, `tool-call-provenance.ts`,
+  keybinding/help copy, and this record.
+
 ## Server fallback abort uses one TUI notice (2026-08-05)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/atomic-tool-metadata.ts
+++ b/packages/coding-agent/src/modes/interactive/components/atomic-tool-metadata.ts
@@ -1,0 +1,153 @@
+import { atomicTarget, bashFailureStatus, observedBashLines, sanitizeAtomicLabel } from "./atomic-tool-observation.ts";
+import type { ToolExecutionIdentity, ToolExecutionRenderState } from "./tool-execution-types.ts";
+
+const PASSTHROUGH_TOOLS = new Set(["monitor", "todo", "create_goal", "get_goal", "update_goal"]);
+const STATUS_TOOLS = new Set([
+	"task",
+	"task_create",
+	"task_get",
+	"task_list",
+	"task_update",
+	"team_create",
+	"team_delete",
+]);
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function count(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function plural(value: number, noun: string): string {
+	return `${value} ${noun}${value === 1 ? "" : "s"}`;
+}
+
+function knownCount(toolName: string, args: unknown, details: unknown): string | undefined {
+	const detailFields = record(details);
+	const argFields = record(args);
+	switch (toolName) {
+		case "read": {
+			const totalLines = count(record(detailFields?.truncation)?.totalLines);
+			return totalLines === undefined ? undefined : plural(totalLines, "line");
+		}
+		case "lsp_diagnostics": {
+			const diagnostics = count(detailFields?.totalDiagnostics);
+			return diagnostics === undefined ? undefined : plural(diagnostics, "diagnostic");
+		}
+		case "lsp_find_references": {
+			const references =
+				count(detailFields?.totalReferences) ??
+				(Array.isArray(detailFields?.references) ? detailFields.references.length : undefined);
+			return references === undefined ? undefined : plural(references, "reference");
+		}
+		case "lsp_symbols": {
+			const symbols =
+				count(detailFields?.totalSymbols) ??
+				(Array.isArray(detailFields?.symbols) ? detailFields.symbols.length : undefined);
+			return symbols === undefined ? undefined : plural(symbols, "symbol");
+		}
+		case "web_search": {
+			const results =
+				count(detailFields?.totalResults) ??
+				(Array.isArray(detailFields?.results) ? detailFields.results.length : undefined);
+			return results === undefined ? undefined : plural(results, "result");
+		}
+		case "multi_tool_use.parallel":
+			return Array.isArray(argFields?.tool_uses) ? plural(argFields.tool_uses.length, "call") : undefined;
+		case "task":
+			return Array.isArray(argFields?.tasks) ? plural(argFields.tasks.length, "task") : undefined;
+		case "team_create": {
+			const members = record(argFields?.inline_spec)?.members;
+			return Array.isArray(members) ? plural(members.length, "member") : undefined;
+		}
+		default:
+			return undefined;
+	}
+}
+
+function knownStatus(toolName: string, state: ToolExecutionRenderState): string | undefined {
+	if (STATUS_TOOLS.has(toolName)) {
+		const details = record(state.result?.details);
+		const status = typeof details?.status === "string" ? sanitizeAtomicLabel(details.status) : undefined;
+		if (status) return status;
+		if (state.isPartial) {
+			const activity = record(details?.progress)?.activity;
+			const partial = details?.phase ?? activity;
+			return typeof partial === "string" ? sanitizeAtomicLabel(partial) : undefined;
+		}
+	}
+	return state.result?.isError ? "failed" : undefined;
+}
+
+export function isAtomicToolPassthrough(identity: ToolExecutionIdentity): boolean {
+	return identity.trustedBuiltIn && PASSTHROUGH_TOOLS.has(identity.toolName);
+}
+
+export class AtomicToolMetadata {
+	readonly name: string;
+	readonly supportsProgressSpinner: boolean;
+	target: string | undefined;
+	facts: string | undefined;
+	isError = false;
+	private readonly identity: ToolExecutionIdentity;
+	private retainedLines?: number;
+	private retainedLinesTruncated = false;
+	private retainedCalls?: number;
+
+	constructor(identity: ToolExecutionIdentity, state: ToolExecutionRenderState) {
+		this.identity = identity;
+		this.name = sanitizeAtomicLabel(identity.toolName);
+		this.supportsProgressSpinner =
+			identity.trustedBuiltIn && (identity.toolName === "bash" || identity.toolName === "eval");
+		this.update(state);
+	}
+
+	update(state: ToolExecutionRenderState): void {
+		this.target = undefined;
+		this.facts = undefined;
+		this.isError = false;
+		try {
+			this.isError = state.result?.isError === true;
+			this.target = atomicTarget(this.identity, state.args);
+			if (this.identity.trustedBuiltIn && this.identity.toolName === "bash") {
+				const observed = observedBashLines(state.result);
+				if (observed) {
+					if (observed.count > (this.retainedLines ?? 0)) {
+						this.retainedLines = observed.count;
+						this.retainedLinesTruncated = observed.truncated;
+					} else if (observed.truncated) {
+						this.retainedLinesTruncated = true;
+					}
+				}
+			} else if (this.identity.trustedBuiltIn && this.identity.toolName === "eval") {
+				const calls = record(state.result?.details)?.toolCalls;
+				if (Array.isArray(calls)) this.retainedCalls = Math.max(this.retainedCalls ?? 0, calls.length);
+			}
+			this.facts = this.buildFacts(state);
+		} catch {
+			this.facts = undefined;
+		}
+	}
+
+	private buildFacts(state: ToolExecutionRenderState): string | undefined {
+		if (this.identity.trustedBuiltIn && this.identity.toolName === "bash" && this.retainedLines !== undefined) {
+			const suffix = this.retainedLinesTruncated ? "+" : "";
+			const lines = `${this.retainedLines}${suffix} line${this.retainedLines === 1 ? "" : "s"}`;
+			return [lines, bashFailureStatus(state.result)].filter(Boolean).join(" · ");
+		}
+		if (this.identity.trustedBuiltIn && this.identity.toolName === "eval" && this.retainedCalls !== undefined) {
+			return plural(this.retainedCalls, "call");
+		}
+		if (!this.identity.trustedBuiltIn) return this.isError ? "failed" : undefined;
+		return (
+			[
+				knownCount(this.identity.toolName, state.args, state.result?.details),
+				knownStatus(this.identity.toolName, state),
+			]
+				.filter(Boolean)
+				.join(" · ") || undefined
+		);
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/atomic-tool-observation.ts
+++ b/packages/coding-agent/src/modes/interactive/components/atomic-tool-observation.ts
@@ -1,0 +1,170 @@
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
+import { extractPatchedPaths } from "../../../core/extensions/builtin/gpt-apply-patch/text.ts";
+import type { ToolExecutionIdentity, ToolExecutionResult } from "./tool-execution-types.ts";
+
+const CHAR_LIMIT = 16_384;
+const ITEM_LIMIT = 64;
+const SAMPLE_ITEM_LIMIT = ITEM_LIMIT / 2;
+const TARGET_ITEM_LIMIT = 8;
+const BIDI_CONTROLS = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/gu;
+const TARGET_FIELDS = [
+	"task_summary",
+	"description",
+	"path",
+	"file_path",
+	"filePath",
+	"url",
+	"query",
+	"pattern",
+	"command",
+	"newName",
+	"name",
+	"symbol",
+	"bash_id",
+	"task_id",
+	"team_id",
+	"cell_id",
+	"action",
+] as const;
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+export function sanitizeAtomicLabel(value: string): string {
+	return stripTerminalSequences(value.slice(0, CHAR_LIMIT))
+		.replace(/[\u0000-\u001f\u007f-\u009f]+/g, " ")
+		.replace(BIDI_CONTROLS, "")
+		.replace(/·/g, "∙")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function stringField(value: unknown): string | undefined {
+	if (typeof value === "string") return sanitizeAtomicLabel(value) || undefined;
+	if (typeof value === "number" && Number.isFinite(value)) return String(value);
+	return undefined;
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function resultText(result: ToolExecutionResult | undefined): { text: string; truncated: boolean } {
+	if (!result) return { text: "", truncated: false };
+	let totalChars = 0;
+	const exact: string[] = [];
+	const exactLimit = Math.min(result.content.length, ITEM_LIMIT);
+	for (let index = 0; index < exactLimit; index++) {
+		const item = result.content[index];
+		if (!item) continue;
+		if (item.type !== "text") continue;
+		const text = item.text;
+		totalChars += text.length;
+		exact.push(text);
+	}
+	if (result.content.length <= ITEM_LIMIT && totalChars <= CHAR_LIMIT) {
+		return { text: exact.join("\n"), truncated: false };
+	}
+
+	const sampleLimit = CHAR_LIMIT / 2;
+	let headRemaining = sampleLimit;
+	const head: string[] = [];
+	for (let index = 0; index < result.content.length && index < SAMPLE_ITEM_LIMIT && headRemaining > 0; index++) {
+		const item = result.content[index];
+		if (item?.type !== "text") continue;
+		const itemText = item.text;
+		const text = itemText.slice(0, headRemaining);
+		head.push(text);
+		headRemaining -= text.length;
+	}
+
+	let tailRemaining = sampleLimit;
+	const tail: string[] = [];
+	for (
+		let index = result.content.length - 1, seen = 0;
+		index >= 0 && seen < SAMPLE_ITEM_LIMIT && tailRemaining > 0;
+		index--
+	) {
+		const item = result.content[index];
+		seen++;
+		if (item?.type !== "text") continue;
+		const itemText = item.text;
+		const text = itemText.slice(-tailRemaining);
+		tail.unshift(text);
+		tailRemaining -= text.length;
+	}
+	return { text: head.join("\n") + tail.join("\n"), truncated: true };
+}
+
+function stripBashTrailer(text: string): { output: string; status?: string } {
+	const normalized = text.replace(/\r\n?/g, "\n").trimEnd();
+	const exit = /(?:\n\n?)?Command exited with code (\d+)$/.exec(normalized);
+	if (exit) return { output: normalized.slice(0, exit.index).trimEnd(), status: `exit ${exit[1]}` };
+	const timeout = /(?:\n\n?)?Command timed out(?: after \d+(?:\.\d+)? seconds)?$/.exec(normalized);
+	if (timeout) return { output: normalized.slice(0, timeout.index).trimEnd(), status: "timed out" };
+	const aborted = /(?:\n\n?)?Command aborted$/.exec(normalized);
+	if (aborted) return { output: normalized.slice(0, aborted.index).trimEnd(), status: "aborted" };
+	return { output: normalized };
+}
+
+function countLines(text: string): number {
+	if (!text || text === "(no output)") return 0;
+	return text.replace(/\r\n?/g, "\n").replace(/\n$/, "").split("\n").length;
+}
+
+export function observedBashLines(
+	result: ToolExecutionResult | undefined,
+): { count: number; truncated: boolean } | undefined {
+	if (!result) return undefined;
+	const totalLines = nonNegativeNumber(record(record(result.details)?.truncation)?.totalLines);
+	if (totalLines !== undefined && Number.isInteger(totalLines)) return { count: totalLines, truncated: false };
+	const observed = resultText(result);
+	const text = result.isError ? stripBashTrailer(observed.text).output : observed.text;
+	return { count: countLines(text), truncated: observed.truncated };
+}
+
+export function bashFailureStatus(result: ToolExecutionResult | undefined): string | undefined {
+	return result?.isError ? (stripBashTrailer(resultText(result).text).status ?? "failed") : undefined;
+}
+
+function applyPatchTarget(args: unknown): string | undefined {
+	const input = typeof args === "string" ? args : record(args)?.input;
+	if (typeof input !== "string" || !input) return undefined;
+	const seen = new Set<string>();
+	const names: string[] = [];
+	for (const rawPath of extractPatchedPaths(input.slice(0, CHAR_LIMIT))) {
+		const normalized = rawPath.replace(/\\/g, "/").replace(/\/+$/, "");
+		const name = sanitizeAtomicLabel(normalized.slice(normalized.lastIndexOf("/") + 1));
+		if (!name || seen.has(name)) continue;
+		seen.add(name);
+		names.push(name);
+		if (names.length === TARGET_ITEM_LIMIT) break;
+	}
+	return names.join(", ") || undefined;
+}
+
+export function atomicTarget(identity: ToolExecutionIdentity, args: unknown): string | undefined {
+	const fields = record(args);
+	if (identity.toolName === "apply_patch") return applyPatchTarget(args);
+	if (identity.toolName === "bash") {
+		const description = stringField(fields?.description);
+		if (description !== undefined) return description;
+		const command = fields?.command;
+		if (typeof command !== "string") return undefined;
+		return sanitizeAtomicLabel(command.slice(0, CHAR_LIMIT).split(/\r?\n/, 1)[0] ?? "");
+	}
+	if (identity.toolName === "eval") {
+		const title = stringField(fields?.title);
+		if (title) return title;
+		const action = stringField(fields?.action);
+		const cellId = stringField(fields?.cell_id);
+		if (action && cellId) return `${action} ${cellId}`;
+		return stringField(fields?.language);
+	}
+	for (const field of TARGET_FIELDS) {
+		const value = stringField(fields?.[field]);
+		if (value) return value;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/modes/interactive/components/atomic-tool-row.ts
+++ b/packages/coding-agent/src/modes/interactive/components/atomic-tool-row.ts
@@ -1,0 +1,64 @@
+import { Box, Text, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { theme } from "../theme/theme.ts";
+import { TOOL_PROGRESS_SPINNER_FRAMES } from "../tool-progress.ts";
+import { AtomicToolMetadata } from "./atomic-tool-metadata.ts";
+
+export { isAtomicToolPassthrough } from "./atomic-tool-metadata.ts";
+
+import type { ToolExecutionIdentity, ToolExecutionRenderState } from "./tool-execution-types.ts";
+
+export class AtomicToolRow {
+	private readonly metadata: AtomicToolMetadata;
+	private state: ToolExecutionRenderState;
+
+	constructor(identity: ToolExecutionIdentity, state: ToolExecutionRenderState) {
+		this.metadata = new AtomicToolMetadata(identity, state);
+		this.state = state;
+	}
+
+	update(state: ToolExecutionRenderState): void {
+		this.state = state;
+		this.metadata.update(state);
+	}
+
+	render(width: number): string[] {
+		if (width <= 0) return [];
+		let background = (text: string) => theme.bg("toolSuccessBg", text);
+		if (this.metadata.isError) {
+			background = (text: string) => theme.bg("toolErrorBg", text);
+		} else if (this.state.isPartial || !this.state.result) {
+			background = (text: string) => theme.bg("toolPendingBg", text);
+		}
+
+		const spinning =
+			this.metadata.supportsProgressSpinner &&
+			this.state.executionStarted &&
+			this.state.isPartial &&
+			!this.metadata.isError;
+		const frame = TOOL_PROGRESS_SPINNER_FRAMES[(this.state.spinnerFrame ?? 0) % TOOL_PROGRESS_SPINNER_FRAMES.length];
+		const isEval = this.metadata.name === "eval";
+		const isBash = this.metadata.name === "bash";
+		const name = theme.fg("toolTitle", theme.bold(this.metadata.name));
+		const nameSpinner = isBash && spinning ? ` ${theme.fg("warning", frame)}` : "";
+		const head = `${name}${nameSpinner}`;
+		const tail = [
+			isEval && spinning ? theme.fg("warning", frame) : undefined,
+			this.metadata.facts ? theme.fg("muted", this.metadata.facts) : undefined,
+		]
+			.filter((value): value is string => value !== undefined)
+			.join(" ");
+		const targetSeparatorWidth = this.metadata.target ? 1 : 0;
+		const tailSeparatorWidth = tail ? (this.metadata.target ? 3 : 1) : 0;
+		const targetBudget = width - visibleWidth(head) - visibleWidth(tail) - targetSeparatorWidth - tailSeparatorWidth;
+		const target =
+			this.metadata.target && targetBudget > 0
+				? theme.fg("text", truncateToWidth(this.metadata.target, targetBudget, "…"))
+				: undefined;
+		const targetText = target ? ` ${target}` : "";
+		const tailText = tail ? `${target ? " · " : " "}${tail}` : "";
+		const content = truncateToWidth(`${head}${targetText}${tailText}`, width, "…");
+		const box = new Box(0, 0, background);
+		box.addChild(new Text(content, 0, 0));
+		return box.render(width);
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/shortcut-overlay.ts
+++ b/packages/coding-agent/src/modes/interactive/components/shortcut-overlay.ts
@@ -10,7 +10,7 @@ function renderShortcutGrid(): string {
 		[keyHint("app.interrupt", "interrupt"), keyHint("app.clear", "clear editor")],
 		[keyHint("app.exit", "exit"), keyHint("app.thinking.cycle", "thinking level")],
 		[keyHint("app.model.cycleForward", "next model"), keyHint("app.model.select", "select model")],
-		[keyHint("app.tools.expand", "expand tools"), keyHint("app.editor.external", "external editor")],
+		[keyHint("app.tools.expand", "cycle tool output"), keyHint("app.editor.external", "external editor")],
 		[keyHint("app.message.followUp", "queue follow-up"), keyHint("app.history.search", "search history")],
 		[rawKeyHint("!", "bash"), rawKeyHint("/", "commands")],
 	];

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution-controller.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution-controller.ts
@@ -1,0 +1,146 @@
+import type { GrokToolRow } from "../grok/tool-row.ts";
+import { AtomicToolRow, isAtomicToolPassthrough } from "./atomic-tool-row.ts";
+import { createBoundedRenderSignature } from "./render-signature.ts";
+import type { ToolExecutionImages } from "./tool-execution-images.ts";
+import type { ToolExecutionRenderer } from "./tool-execution-renderer.ts";
+import type { ToolExecutionIdentity, ToolExecutionRenderState, ToolOutputMode } from "./tool-execution-types.ts";
+
+/** Visual shell chosen by interactive chrome; classic remains the default. */
+export type ToolExecutionPresentation = "classic" | "grok";
+
+type DisplayParts = {
+	readonly renderer: ToolExecutionRenderer | undefined;
+	readonly images: ToolExecutionImages | undefined;
+	readonly grokRow: GrokToolRow | undefined;
+	readonly renderContainer: (width: number) => string[];
+};
+
+export class ToolExecutionController {
+	private readonly atomicRow: AtomicToolRow | undefined;
+	private readonly identity: ToolExecutionIdentity;
+	private readonly presentation: ToolExecutionPresentation;
+	private outputMode: ToolOutputMode;
+	private cachedLines?: string[];
+	private cachedSignature?: string;
+	private cachedWidth?: number;
+	private lastDisplaySignature?: string;
+
+	constructor(
+		identity: ToolExecutionIdentity,
+		initialState: ToolExecutionRenderState,
+		outputMode: ToolOutputMode,
+		presentation: ToolExecutionPresentation,
+	) {
+		this.identity = identity;
+		this.outputMode = outputMode;
+		this.presentation = presentation;
+		if (!isAtomicToolPassthrough(identity)) this.atomicRow = new AtomicToolRow(identity, initialState);
+	}
+
+	get expanded(): boolean {
+		return this.outputMode === "expanded";
+	}
+
+	get isAtomic(): boolean {
+		return this.outputMode === "atomic" && this.atomicRow !== undefined;
+	}
+
+	setOutputMode(outputMode: ToolOutputMode): { changed: boolean; leftAtomic: boolean } {
+		if (this.outputMode === outputMode) return { changed: false, leftAtomic: false };
+		const leftAtomic = this.isAtomic;
+		this.outputMode = outputMode;
+		this.lastDisplaySignature = undefined;
+		return { changed: true, leftAtomic };
+	}
+
+	atomicSpinnerPolicy(state: ToolExecutionRenderState): boolean | undefined {
+		if (!this.isAtomic) return undefined;
+		return (
+			this.identity.trustedBuiltIn &&
+			state.executionStarted &&
+			state.isPartial &&
+			state.result?.isError !== true &&
+			(this.identity.toolName === "bash" || this.identity.toolName === "eval")
+		);
+	}
+
+	updateDisplay(state: ToolExecutionRenderState, imageWidthCells: number, display: DisplayParts): void {
+		if (this.isAtomic) {
+			this.lastDisplaySignature = undefined;
+			this.invalidateRenderCache();
+			this.atomicRow!.update(state);
+			display.renderer?.suspend();
+			return;
+		}
+		const displaySignature = this.createRenderSignature(state, imageWidthCells);
+		if (this.lastDisplaySignature === displaySignature) return;
+		this.lastDisplaySignature = displaySignature;
+		this.invalidateRenderCache();
+		if (display.grokRow) {
+			display.grokRow.update({
+				toolName: this.identity.toolName,
+				isPartial: state.isPartial,
+				result: state.result,
+			});
+			return;
+		}
+		const renderer = display.renderer!;
+		renderer.update(state);
+		display.images!.updateOptions({
+			showImages: state.showImages,
+			maxWidthCells: imageWidthCells,
+			showRendererFallback: renderer.hasResultRenderer,
+		});
+	}
+
+	render(width: number, state: ToolExecutionRenderState, imageWidthCells: number, display: DisplayParts): string[] {
+		const signature = this.isAtomic ? undefined : this.createRenderSignature(state, imageWidthCells);
+		if (this.cachedLines && this.cachedWidth === width && (this.isAtomic || this.cachedSignature === signature)) {
+			return [...this.cachedLines];
+		}
+
+		let lines: string[];
+		if (this.isAtomic) {
+			lines = this.atomicRow!.render(width);
+		} else if (this.presentation === "grok") {
+			lines = display.renderContainer(width);
+		} else {
+			const renderer = display.renderer!;
+			const images = display.images!;
+			if (renderer.hasRendererDefinition && renderer.renderShell === "self") {
+				const contentLines = renderer.render(width);
+				const imageLines = images.render(width);
+				if (contentLines.length === 0 && imageLines.length === 0) return [];
+				lines = contentLines.length > 0 ? ["", ...contentLines, ...imageLines] : imageLines;
+			} else {
+				lines = display.renderContainer(width);
+			}
+		}
+
+		this.cachedWidth = width;
+		this.cachedSignature = signature;
+		this.cachedLines = [...lines];
+		return lines;
+	}
+
+	invalidateDisplay(): void {
+		this.invalidateRenderCache();
+		this.lastDisplaySignature = undefined;
+	}
+
+	invalidateRenderCache(): void {
+		this.cachedLines = undefined;
+		this.cachedSignature = undefined;
+		this.cachedWidth = undefined;
+	}
+
+	private createRenderSignature(state: ToolExecutionRenderState, imageWidthCells: number): string {
+		return createBoundedRenderSignature({
+			...state,
+			imageWidthCells,
+			outputMode: this.outputMode,
+			toolCallId: this.identity.toolCallId,
+			toolName: this.identity.toolName,
+		});
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution-renderer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution-renderer.ts
@@ -22,8 +22,10 @@ export class ToolExecutionRenderer extends Container {
 	private readonly contentText: Text;
 	private readonly selfRenderContainer = new Container();
 	private readonly rendererState: Record<string, unknown> = {};
+	private readonly disposedRendererComponents = new WeakSet<Component>();
 	private readonly onInvalidate: () => void;
 	private state: ToolExecutionRenderState;
+	private suspended = false;
 	private callRendererComponent?: Component;
 	private resultRendererComponent?: Component;
 
@@ -32,7 +34,9 @@ export class ToolExecutionRenderer extends Container {
 		this.identity = identity;
 		this.state = state;
 		this.onInvalidate = onInvalidate;
-		this.builtInDefinition = createAllToolDefinitions(identity.cwd)[identity.toolName as ToolName];
+		this.builtInDefinition = identity.trustedBuiltIn
+			? createAllToolDefinitions(identity.cwd)[identity.toolName as ToolName]
+			: undefined;
 		this.contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
 		this.contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
 		this.addChild(
@@ -58,6 +62,7 @@ export class ToolExecutionRenderer extends Container {
 	}
 
 	update(state: ToolExecutionRenderState): void {
+		this.suspended = false;
 		this.state = state;
 		const background = state.isPartial
 			? (text: string) => theme.bg("toolPendingBg", text)
@@ -81,6 +86,26 @@ export class ToolExecutionRenderer extends Container {
 		if (state.result) this.renderResult(container, state.result);
 		if (progress)
 			container.addChild(new Text(formatToolProgressLine(progress, Date.now(), state.spinnerFrame), 0, 0));
+	}
+
+	suspend(): void {
+		if (this.suspended) return;
+		this.suspended = true;
+		const components = new Set([this.callRendererComponent, this.resultRendererComponent]);
+		this.callRendererComponent = undefined;
+		this.resultRendererComponent = undefined;
+		this.selfRenderContainer.detachAll();
+		this.contentBox.detachAll();
+		this.disposeRenderState(this.identity.toolDefinition);
+		if (this.builtInDefinition !== this.identity.toolDefinition) {
+			this.disposeRenderState(this.builtInDefinition);
+		}
+		for (const component of components) this.disposeRendererComponent(component);
+	}
+
+	override dispose(): void {
+		this.suspend();
+		super.dispose();
 	}
 
 	private getCallRenderer(): ToolDef["renderCall"] | undefined {
@@ -122,7 +147,7 @@ export class ToolExecutionRenderer extends Container {
 			const component = renderer(this.state.args, theme, this.getRenderContext(this.callRendererComponent));
 			this.addRendererComponent(container, "call", component, fallback);
 		} catch {
-			this.callRendererComponent = undefined;
+			this.setRendererComponent("call", undefined);
 			container.addChild(fallback);
 		}
 	}
@@ -144,7 +169,7 @@ export class ToolExecutionRenderer extends Container {
 			);
 			this.addRendererComponent(container, "result", component, fallback);
 		} catch {
-			this.resultRendererComponent = undefined;
+			this.setRendererComponent("result", undefined);
 			if (fallback) container.addChild(fallback);
 		}
 	}
@@ -162,9 +187,15 @@ export class ToolExecutionRenderer extends Container {
 		}
 		this.setRendererComponent(slot, value);
 		container.addChild(
-			new ToolRendererBoundary(value, fallback, () => {
-				if (this.getRendererComponent(slot) === value) this.setRendererComponent(slot, undefined);
-			}),
+			new ToolRendererBoundary(
+				value,
+				fallback,
+				() => {
+					if (this.callRendererComponent === value) this.callRendererComponent = undefined;
+					if (this.resultRendererComponent === value) this.resultRendererComponent = undefined;
+				},
+				() => this.disposeRendererComponent(value),
+			),
 		);
 	}
 
@@ -173,7 +204,25 @@ export class ToolExecutionRenderer extends Container {
 	}
 
 	private setRendererComponent(slot: RendererSlot, component: Component | undefined): void {
+		const previous = this.getRendererComponent(slot);
+		const other = slot === "call" ? this.resultRendererComponent : this.callRendererComponent;
 		if (slot === "call") this.callRendererComponent = component;
 		else this.resultRendererComponent = component;
+		if (previous && previous !== component && previous !== other) this.disposeRendererComponent(previous);
+	}
+
+	private disposeRenderState(definition: ToolDef | undefined): void {
+		try {
+			definition?.disposeRenderState?.(this.rendererState);
+		} catch {}
+	}
+
+	private disposeRendererComponent(component: Component | undefined): void {
+		if (!component || this.disposedRendererComponents.has(component)) return;
+		this.disposedRendererComponents.add(component);
+		try {
+			const dispose = Reflect.get(component, "dispose");
+			if (typeof dispose === "function") Reflect.apply(dispose, component, []);
+		} catch {}
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution-types.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution-types.ts
@@ -6,11 +6,25 @@ export type ToolExecutionResult = Omit<AgentToolResult<unknown>, "details"> & {
 	readonly isError: boolean;
 };
 
+export type ToolOutputMode = "collapsed" | "expanded" | "atomic";
+
+export function nextToolOutputMode(mode: ToolOutputMode): ToolOutputMode {
+	switch (mode) {
+		case "collapsed":
+			return "expanded";
+		case "expanded":
+			return "atomic";
+		case "atomic":
+			return "collapsed";
+	}
+}
+
 export type ToolExecutionIdentity = {
 	readonly toolName: string;
 	readonly toolCallId: string;
 	readonly cwd: string;
 	readonly toolDefinition: ToolDef | undefined;
+	readonly trustedBuiltIn: boolean;
 };
 
 export type ToolExecutionRenderState = {

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution.ts
@@ -2,19 +2,25 @@ import { Container, Spacer, type TUI } from "@earendil-works/pi-tui";
 import type { ToolDef } from "../../../core/tools/index.ts";
 import { GrokToolRow } from "../grok/tool-row.ts";
 import { readToolProgress } from "../tool-progress.ts";
-import { createBoundedRenderSignature } from "./render-signature.ts";
 import { hasCompletedTodoTasks, TODO_STRIKE_FRAME_INTERVAL_MS, TODO_STRIKE_TOTAL_FRAMES } from "./todo-strike.ts";
+import { ToolExecutionController, type ToolExecutionPresentation } from "./tool-execution-controller.ts";
 import { ToolExecutionImages } from "./tool-execution-images.ts";
 import { ToolExecutionRenderer } from "./tool-execution-renderer.ts";
-import type { ToolExecutionIdentity, ToolExecutionRenderState, ToolExecutionResult } from "./tool-execution-types.ts";
+import type {
+	ToolExecutionIdentity,
+	ToolExecutionRenderState,
+	ToolExecutionResult,
+	ToolOutputMode,
+} from "./tool-execution-types.ts";
+
+export type { ToolExecutionPresentation } from "./tool-execution-controller.ts";
 
 export interface ToolExecutionOptions {
 	showImages?: boolean;
 	imageWidthCells?: number;
+	outputMode?: ToolOutputMode;
+	trustedBuiltIn?: boolean;
 }
-
-/** Visual shell chosen by interactive chrome; classic remains the default. */
-export type ToolExecutionPresentation = "classic" | "grok";
 
 const PENDING_RENDER_FRAME_INTERVAL_MS = 80;
 
@@ -24,9 +30,8 @@ export class ToolExecutionComponent extends Container {
 	private readonly renderer: ToolExecutionRenderer | undefined;
 	private readonly images: ToolExecutionImages | undefined;
 	private readonly grokRow: GrokToolRow | undefined;
-	private readonly presentation: ToolExecutionPresentation;
+	private readonly controller: ToolExecutionController;
 	private args: unknown;
-	private expanded = false;
 	private showImages: boolean;
 	private imageWidthCells: number;
 	private isPartial = true;
@@ -36,10 +41,6 @@ export class ToolExecutionComponent extends Container {
 	private spinnerInterval?: NodeJS.Timeout;
 	private todoStrikeInterval?: NodeJS.Timeout;
 	private result?: ToolExecutionResult;
-	private cachedLines?: string[];
-	private cachedSignature?: string;
-	private cachedWidth?: number;
-	private lastDisplaySignature?: string;
 
 	constructor(
 		toolName: string,
@@ -52,14 +53,21 @@ export class ToolExecutionComponent extends Container {
 		presentation: ToolExecutionPresentation = "classic",
 	) {
 		super();
-		this.identity = { toolName, toolCallId, cwd, toolDefinition };
+		this.identity = {
+			toolName,
+			toolCallId,
+			cwd,
+			toolDefinition,
+			trustedBuiltIn: options.trustedBuiltIn ?? false,
+		};
 		this.args = args;
+		const outputMode = options.outputMode ?? "collapsed";
 		this.showImages = options.showImages ?? true;
 		this.imageWidthCells = options.imageWidthCells ?? 60;
 		this.ui = ui;
-		this.presentation = presentation;
-		const initialState = this.createRenderState();
-		if (this.presentation === "grok") {
+		const initialState = this.createRenderState(outputMode === "expanded");
+		this.controller = new ToolExecutionController(this.identity, initialState, outputMode, presentation);
+		if (presentation === "grok") {
 			this.grokRow = new GrokToolRow({
 				toolName: this.identity.toolName,
 				isPartial: initialState.isPartial,
@@ -73,7 +81,7 @@ export class ToolExecutionComponent extends Container {
 				this.ui.requestRender();
 			});
 			this.images = new ToolExecutionImages(() => {
-				this.invalidateRenderCache();
+				this.controller.invalidateRenderCache();
 				this.ui.requestRender();
 			});
 			this.addChild(new Spacer(1));
@@ -86,7 +94,7 @@ export class ToolExecutionComponent extends Container {
 
 	updateArgs(args: unknown): void {
 		this.args = args;
-		this.lastDisplaySignature = undefined;
+		this.controller.invalidateDisplay();
 		this.updateSpinnerAnimation();
 		this.updateDisplay();
 	}
@@ -109,12 +117,12 @@ export class ToolExecutionComponent extends Container {
 		this.result = result;
 		this.isPartial = isPartial;
 		if (!isPartial) this.argsComplete = true;
-		this.lastDisplaySignature = undefined;
+		this.controller.invalidateDisplay();
 		this.updateSpinnerAnimation();
 		this.updateTodoStrikeAnimation();
 		this.updateDisplay();
-		this.images?.updateResult(result);
-		this.invalidateRenderCache();
+		if (!this.controller.isAtomic) this.images?.updateResult(result);
+		this.controller.invalidateRenderCache();
 	}
 
 	stopAnimation(): void {
@@ -128,8 +136,16 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	setExpanded(expanded: boolean): void {
-		this.expanded = expanded;
+		this.setOutputMode(expanded ? "expanded" : "collapsed");
+	}
+
+	setOutputMode(outputMode: ToolOutputMode): void {
+		const transition = this.controller.setOutputMode(outputMode);
+		if (!transition.changed) return;
+		if (transition.leftAtomic && this.result) this.images?.updateResult(this.result);
+		this.updateSpinnerAnimation();
 		this.updateDisplay();
+		this.ui.requestRender();
 	}
 
 	setShowImages(show: boolean): void {
@@ -143,84 +159,50 @@ export class ToolExecutionComponent extends Container {
 	}
 
 	override invalidate(): void {
-		this.invalidateRenderCache();
+		this.controller.invalidateDisplay();
 		super.invalidate();
-		this.lastDisplaySignature = undefined;
 		this.updateDisplay();
 	}
 
 	override render(width: number): string[] {
-		if (this.presentation === "grok") return super.render(width);
-
-		const signature = this.createRenderSignature();
-		if (this.cachedLines && this.cachedWidth === width && this.cachedSignature === signature) {
-			return [...this.cachedLines];
-		}
-
-		let lines: string[];
-		const renderer = this.renderer!;
-		const images = this.images!;
-		if (renderer.hasRendererDefinition && renderer.renderShell === "self") {
-			const contentLines = renderer.render(width);
-			const imageLines = images.render(width);
-			if (contentLines.length === 0 && imageLines.length === 0) return [];
-			lines = contentLines.length > 0 ? ["", ...contentLines, ...imageLines] : imageLines;
-		} else {
-			lines = super.render(width);
-		}
-
-		this.cachedWidth = width;
-		this.cachedSignature = signature;
-		this.cachedLines = [...lines];
-		return lines;
-	}
-
-	private updateDisplay(): void {
-		const displaySignature = this.createRenderSignature();
-		if (this.lastDisplaySignature === displaySignature) return;
-		this.lastDisplaySignature = displaySignature;
-		this.invalidateRenderCache();
-		const state = this.createRenderState();
-		if (this.grokRow) {
-			this.grokRow.update({
-				toolName: this.identity.toolName,
-				isPartial: state.isPartial,
-				result: state.result,
-			});
-			return;
-		}
-		const renderer = this.renderer!;
-		this.renderer!.update(state);
-		this.images!.updateOptions({
-			showImages: state.showImages,
-			maxWidthCells: this.imageWidthCells,
-			showRendererFallback: renderer.hasResultRenderer,
+		return this.controller.render(width, this.createRenderState(), this.imageWidthCells, {
+			renderer: this.renderer,
+			images: this.images,
+			grokRow: this.grokRow,
+			renderContainer: (containerWidth) => super.render(containerWidth),
 		});
 	}
 
-	private createRenderState(): ToolExecutionRenderState {
+	private updateDisplay(): void {
+		this.controller.updateDisplay(this.createRenderState(), this.imageWidthCells, {
+			renderer: this.renderer,
+			images: this.images,
+			grokRow: this.grokRow,
+			renderContainer: (width) => super.render(width),
+		});
+	}
+
+	private createRenderState(expanded = this.controller.expanded): ToolExecutionRenderState {
 		return {
 			args: this.args,
 			executionStarted: this.executionStarted,
 			argsComplete: this.argsComplete,
 			isPartial: this.isPartial,
-			expanded: this.expanded,
+			expanded,
 			showImages: this.showImages,
 			spinnerFrame: this.spinnerFrame,
 			result: this.result,
 		};
 	}
 
-	private createRenderSignature(): string {
-		return createBoundedRenderSignature({
-			...this.createRenderState(),
-			imageWidthCells: this.imageWidthCells,
-			toolCallId: this.identity.toolCallId,
-			toolName: this.identity.toolName,
-		});
-	}
-
 	private updateSpinnerAnimation(): void {
+		const atomicPolicy = this.controller.atomicSpinnerPolicy(this.createRenderState());
+		if (atomicPolicy !== undefined) {
+			if (atomicPolicy) this.startSpinnerAnimation();
+			else this.stopSpinnerAnimation();
+			return;
+		}
+
 		const isStreamingArgs = !this.argsComplete && ["edit", "write", "apply_patch"].includes(this.identity.toolName);
 		const isPartialTask = this.isPartial && this.identity.toolName === "task" && this.result !== undefined;
 		const isPartialProgress =
@@ -231,6 +213,7 @@ export class ToolExecutionComponent extends Container {
 
 	private updateTodoStrikeAnimation(): void {
 		const shouldAnimate =
+			this.identity.trustedBuiltIn &&
 			this.identity.toolName === "todo" &&
 			this.executionStarted &&
 			!this.isPartial &&
@@ -251,7 +234,7 @@ export class ToolExecutionComponent extends Container {
 				return;
 			}
 			this.spinnerFrame = next;
-			this.invalidateRenderCache();
+			this.controller.invalidateRenderCache();
 			this.updateDisplay();
 			this.ui.requestRender();
 		}, TODO_STRIKE_FRAME_INTERVAL_MS);
@@ -265,7 +248,7 @@ export class ToolExecutionComponent extends Container {
 		}
 		if (!this.spinnerInterval && this.spinnerFrame !== undefined) {
 			this.spinnerFrame = undefined;
-			this.invalidateRenderCache();
+			this.controller.invalidateRenderCache();
 			this.updateDisplay();
 			this.ui.requestRender();
 		}
@@ -275,7 +258,7 @@ export class ToolExecutionComponent extends Container {
 		if (this.spinnerInterval) return;
 		this.spinnerInterval = setInterval(() => {
 			this.spinnerFrame = ((this.spinnerFrame ?? -1) + 1) % 10;
-			this.invalidateRenderCache();
+			this.controller.invalidateRenderCache();
 			this.updateDisplay();
 			this.ui.requestRender();
 		}, PENDING_RENDER_FRAME_INTERVAL_MS);
@@ -287,12 +270,6 @@ export class ToolExecutionComponent extends Container {
 		clearInterval(this.spinnerInterval);
 		this.spinnerInterval = undefined;
 		if (!this.todoStrikeInterval) this.spinnerFrame = undefined;
-		this.invalidateRenderCache();
-	}
-
-	private invalidateRenderCache(): void {
-		this.cachedLines = undefined;
-		this.cachedSignature = undefined;
-		this.cachedWidth = undefined;
+		this.controller.invalidateRenderCache();
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/components/tool-renderer-boundary.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-renderer-boundary.ts
@@ -15,11 +15,18 @@ export class ToolRendererBoundary implements Component {
 	private fallback?: Component;
 	private failed = false;
 	private onFailure: () => void;
+	private disposeOwnedComponent: () => void;
 
-	constructor(component: Component, fallback: Component | undefined, onFailure: () => void) {
+	constructor(
+		component: Component,
+		fallback: Component | undefined,
+		onFailure: () => void,
+		disposeComponent?: () => void,
+	) {
 		this.component = component;
 		this.fallback = fallback;
 		this.onFailure = onFailure;
+		this.disposeOwnedComponent = disposeComponent ?? (() => this.component.dispose?.());
 	}
 
 	render(width: number): string[] {
@@ -58,21 +65,25 @@ export class ToolRendererBoundary implements Component {
 
 	dispose(): void {
 		this.disposeComponent();
-		this.fallback?.dispose?.();
+		try {
+			this.fallback?.dispose?.();
+		} catch {}
 	}
 
 	private fail(): void {
 		if (this.failed) return;
 		this.failed = true;
-		this.onFailure();
 		this.disposeComponent();
+		try {
+			this.onFailure();
+		} catch {}
 	}
 
 	private disposeComponent(): void {
 		if (this.componentDisposed) return;
 		this.componentDisposed = true;
 		try {
-			this.component.dispose?.();
+			this.disposeOwnedComponent();
 		} catch {
 			return;
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -168,6 +168,7 @@ import {
 	WorkingStatusIndicator,
 } from "./components/status-indicator.ts";
 import { ToolExecutionComponent } from "./components/tool-execution.ts";
+import { nextToolOutputMode, type ToolOutputMode } from "./components/tool-execution-types.ts";
 import { TreeSelectorComponent } from "./components/tree-selector.ts";
 import { TrustSelectorComponent } from "./components/trust-selector.ts";
 import { UserMessageComponent } from "./components/user-message.ts";
@@ -204,6 +205,7 @@ import { resolveStartupTipLine } from "./tips/startup-tip.ts";
 import { resolveWorkingTipLine, WorkingTipCache, type WorkingTipLine } from "./tips/working-tip.ts";
 import { buildTmuxSetupWarning } from "./tmux-setup.ts";
 import { ToolArgsRevealController } from "./tool-args-reveal.ts";
+import { ToolCallProvenance } from "./tool-call-provenance.ts";
 import { readToolProgress } from "./tool-progress.ts";
 import { ToolResultRevealController } from "./tool-result-reveal.ts";
 import {
@@ -553,6 +555,7 @@ export class InteractiveMode {
 
 	// Tool execution tracking: toolCallId -> component
 	private pendingTools = new Map<string, ToolExecutionComponent>();
+	private readonly toolCallProvenance = new ToolCallProvenance();
 	private requestStreamingRender(): void {
 		this.ui.requestRender();
 	}
@@ -563,8 +566,11 @@ export class InteractiveMode {
 		this.ui.setMaxRenderFps(fps);
 	}
 
-	// Tool output expansion state
-	private toolOutputExpanded = false;
+	// Tool output display state
+	private toolOutputMode: ToolOutputMode = "collapsed";
+	private get toolOutputExpanded(): boolean {
+		return this.toolOutputMode === "expanded";
+	}
 
 	// Thinking block visibility state
 	private hideThinkingBlock = false;
@@ -2180,6 +2186,7 @@ export class InteractiveMode {
 	}
 
 	private renderCurrentSessionState(): void {
+		this.clearPendingTools();
 		this.loadedResourcesContainer.clear();
 		this.chatContainer.clear();
 		this.pendingMessagesContainer.clear();
@@ -2193,7 +2200,6 @@ export class InteractiveMode {
 		this.toolResultReveal.stop();
 		this.streamingComponent = undefined;
 		this.streamingMessage = undefined;
-		this.clearPendingTools();
 		this.clearToolHookStatuses();
 		this.renderInitialMessages();
 	}
@@ -2201,8 +2207,27 @@ export class InteractiveMode {
 	/**
 	 * Get a registered tool definition by name (for custom rendering).
 	 */
-	private getRegisteredToolDefinition(toolName: string) {
+	private getRegisteredToolDefinition(toolName: string, trustedBuiltIn: boolean) {
+		if (this.isRegisteredToolTrustedBuiltIn(toolName) !== trustedBuiltIn) {
+			return undefined;
+		}
 		return this.session.getToolDefinition(toolName);
+	}
+
+	private isRegisteredToolTrustedBuiltIn(toolName: string): boolean {
+		return this.session.getAllTools().some((tool) => tool.name === toolName && tool.sourceInfo.source === "builtin");
+	}
+
+	private captureToolCallTrust(toolName: string, toolCallId: string): boolean {
+		return this.toolCallProvenance.capture(
+			this.sessionManager.getSessionId(),
+			toolCallId,
+			this.isRegisteredToolTrustedBuiltIn(toolName),
+		);
+	}
+
+	private getCapturedToolCallTrust(toolCallId: string): boolean {
+		return this.toolCallProvenance.get(this.sessionManager.getSessionId(), toolCallId);
 	}
 
 	private getMarkdownTransformers(): MarkdownTransformer[] {
@@ -3741,7 +3766,6 @@ export class InteractiveMode {
 							let component = this.pendingTools.get(content.id);
 							if (!component) {
 								component = this.createToolExecutionComponent(content.name, content.id, content.arguments);
-								component.setExpanded(this.toolOutputExpanded);
 								this.chatContainer.addChild(component);
 								this.pendingTools.set(content.id, component);
 							}
@@ -3810,16 +3834,23 @@ export class InteractiveMode {
 
 			case "tool_execution_start": {
 				this.handleToolExecutionStart(event);
-				let component = this.pendingTools.get(event.toolCallId);
-				if (!component) {
-					component = this.createToolExecutionComponent(event.toolName, event.toolCallId, event.args);
-					component.setExpanded(this.toolOutputExpanded);
+				this.captureToolCallTrust(event.toolName, event.toolCallId);
+				this.toolArgsReveal.finish(event.toolCallId);
+				const previousComponent = this.pendingTools.get(event.toolCallId);
+				const component = this.createToolExecutionComponent(event.toolName, event.toolCallId, event.args);
+				if (previousComponent) {
+					const childIndex = this.chatContainer.children.indexOf(previousComponent);
+					if (childIndex >= 0) {
+						this.chatContainer.children[childIndex] = component;
+					} else {
+						this.chatContainer.addChild(component);
+					}
+					previousComponent.dispose();
+				} else {
 					this.chatContainer.addChild(component);
-					this.pendingTools.set(event.toolCallId, component);
 				}
-				if (!this.toolArgsReveal.flush(event.toolCallId, event.args)) {
-					component.updateArgs(event.args);
-				}
+				this.pendingTools.set(event.toolCallId, component);
+				component.updateArgs(event.args);
 				component.markExecutionStarted();
 				this.ui.requestRender();
 				break;
@@ -4334,33 +4365,23 @@ export class InteractiveMode {
 	}
 
 	private createToolExecutionComponent(toolName: string, toolCallId: string, args: unknown): ToolExecutionComponent {
-		if (this.chrome) {
-			return new ToolExecutionComponent(
-				toolName,
-				toolCallId,
-				args,
-				{
-					showImages: this.settingsManager.getShowImages(),
-					imageWidthCells: this.settingsManager.getImageWidthCells(),
-				},
-				this.getRegisteredToolDefinition(toolName),
-				this.ui,
-				this.sessionManager.getCwd(),
-				this.chrome.toolPresentation,
-			);
-		}
-		return new ToolExecutionComponent(
+		const trustedBuiltIn = this.getCapturedToolCallTrust(toolCallId);
+		const component = new ToolExecutionComponent(
 			toolName,
 			toolCallId,
 			args,
 			{
 				showImages: this.settingsManager.getShowImages(),
 				imageWidthCells: this.settingsManager.getImageWidthCells(),
+				outputMode: this.toolOutputMode,
+				trustedBuiltIn,
 			},
-			this.getRegisteredToolDefinition(toolName),
+			this.getRegisteredToolDefinition(toolName, trustedBuiltIn),
 			this.ui,
 			this.sessionManager.getCwd(),
+			this.chrome?.toolPresentation,
 		);
+		return component;
 	}
 
 	private renderSessionItems(
@@ -4401,7 +4422,6 @@ export class InteractiveMode {
 				for (const content of message.content) {
 					if (content.type === "toolCall") {
 						const component = this.createToolExecutionComponent(content.name, content.id, content.arguments);
-						component.setExpanded(this.toolOutputExpanded);
 						this.chatContainer.addChild(component);
 
 						if (message.stopReason === "aborted" || message.stopReason === "error") {
@@ -4861,25 +4881,37 @@ export class InteractiveMode {
 	}
 
 	private toggleToolOutputExpansion(): void {
-		this.setToolsExpanded(!this.toolOutputExpanded);
+		this.setToolOutputMode(nextToolOutputMode(this.toolOutputMode));
 	}
 
 	private setToolsExpanded(expanded: boolean): void {
-		if (expanded === this.toolOutputExpanded) return;
+		this.setToolOutputMode(expanded ? "expanded" : "collapsed");
+	}
 
-		this.toolOutputExpanded = expanded;
-		const activeHeader = this.customHeader ?? this.builtInHeader;
-		if (isExpandable(activeHeader)) {
-			activeHeader.setExpanded(expanded);
-		}
-		for (const container of [this.loadedResourcesContainer, this.chatContainer]) {
-			for (const child of container.children) {
-				if (isExpandable(child)) {
-					child.setExpanded(expanded);
-				}
+	private setToolOutputMode(outputMode: ToolOutputMode): void {
+		if (outputMode === this.toolOutputMode) return;
+		this.toolOutputMode = outputMode;
+		const visited = new Set<Component>();
+		const applyMode = (component: Component, expandComponent: boolean): void => {
+			if (visited.has(component)) return;
+			visited.add(component);
+			if (component instanceof ToolExecutionComponent) {
+				component.setOutputMode(outputMode);
+				return;
 			}
+			if (expandComponent && isExpandable(component)) component.setExpanded(this.toolOutputExpanded);
+			if (component instanceof Container) {
+				for (const child of component.children) applyMode(child, false);
+			}
+		};
+
+		const activeHeader = this.customHeader ?? this.builtInHeader;
+		if (isExpandable(activeHeader)) activeHeader.setExpanded(this.toolOutputExpanded);
+		for (const container of [this.loadedResourcesContainer, this.chatContainer]) {
+			for (const child of container.children) applyMode(child, true);
 		}
-		this.showStatus(`Tool output: ${expanded ? "expanded" : "collapsed"}`);
+		for (const component of this.pendingTools.values()) applyMode(component, false);
+		this.showStatus(`Tool output: ${outputMode}`);
 	}
 
 	private toggleThinkingBlockVisibility(): void {
@@ -7053,7 +7085,7 @@ export class InteractiveMode {
 | \`${cycleThinkingLevel}\` | Cycle thinking level |
 | \`${cycleModelForward}\` / \`${cycleModelBackward}\` | Cycle models |
 | \`${selectModel}\` | Open model selector |
-| \`${expandTools}\` | Toggle tool output expansion |
+| \`${expandTools}\` | Cycle tool output: collapsed, expanded, atomic |
 | \`${toggleThinking}\` | Toggle thinking block visibility |
 | \`${externalEditor}\` | Edit message in external editor |
 | \`${copyMessage}\` | Copy last assistant message |

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/input-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/input-tips.ts
@@ -53,7 +53,8 @@ export const INPUT_TIPS = [
 	{
 		id: "expand-tool-output",
 		bindings: ["app.tools.expand"],
-		render: (keys) => `Collapse or expand tool output with ${keys("app.tools.expand")}.`,
+		render: (keys) =>
+			`Cycle tool output through collapsed, expanded, and atomic modes with ${keys("app.tools.expand")}.`,
 	},
 	{
 		id: "thinking-blocks",

--- a/packages/coding-agent/src/modes/interactive/tool-call-provenance.ts
+++ b/packages/coding-agent/src/modes/interactive/tool-call-provenance.ts
@@ -1,0 +1,17 @@
+export class ToolCallProvenance {
+	private readonly sessions = new Map<string, Map<string, boolean>>();
+
+	capture(sessionId: string, toolCallId: string, trustedBuiltIn: boolean): boolean {
+		let calls = this.sessions.get(sessionId);
+		if (!calls) {
+			calls = new Map();
+			this.sessions.set(sessionId, calls);
+		}
+		calls.set(toolCallId, trustedBuiltIn);
+		return trustedBuiltIn;
+	}
+
+	get(sessionId: string, toolCallId: string): boolean {
+		return this.sessions.get(sessionId)?.get(toolCallId) ?? false;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/tool-progress.ts
+++ b/packages/coding-agent/src/modes/interactive/tool-progress.ts
@@ -1,6 +1,6 @@
 import { formatWorkingElapsedSeconds } from "./working-status.ts";
 
-const TOOL_PROGRESS_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+export const TOOL_PROGRESS_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 
 export interface ToolProgressDetails {
 	readonly activity?: string;

--- a/packages/coding-agent/test/atomic-tool-row-runtime.test.ts
+++ b/packages/coding-agent/test/atomic-tool-row-runtime.test.ts
@@ -1,0 +1,190 @@
+import { type TUI, visibleWidth } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function atomicTool(name: string, args: unknown): ToolExecutionComponent {
+	const component = new ToolExecutionComponent(
+		name,
+		name,
+		args,
+		{ outputMode: "atomic", trustedBuiltIn: true },
+		undefined,
+		{ requestRender: () => {} } as TUI,
+		process.cwd(),
+	);
+	return component;
+}
+
+function textResult(text: string, details?: unknown, isError = false) {
+	return {
+		content: [{ type: "text" as const, text }],
+		details,
+		isError,
+	};
+}
+
+describe("atomic tool row runtime boundaries", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("handles degenerate widths without overflow", () => {
+		const component = new ToolExecutionComponent(
+			"read",
+			"read-narrow",
+			{ path: "한글/😀.ts" },
+			{},
+			undefined,
+			{ requestRender: () => {} } as TUI,
+			process.cwd(),
+			"grok",
+		);
+		component.setOutputMode("atomic");
+
+		expect(component.render(0)).toEqual([]);
+		expect(visibleWidth(component.render(1)[0]!)).toBe(1);
+		expect(visibleWidth(component.render(2)[0]!)).toBe(2);
+		expect(component.render(40)).toHaveLength(1);
+	});
+
+	test("strips bidirectional controls from untrusted labels", () => {
+		const component = atomicTool("read", { path: "safe\u202eevil.ts\u2066" });
+
+		expect(stripAnsi(component.render(48)[0]!)).not.toMatch(/[\u202a-\u202e\u2066-\u2069]/u);
+	});
+
+	test("bounds and memoizes apply_patch target extraction", () => {
+		let inputReads = 0;
+		const component = atomicTool("apply_patch", {
+			get input() {
+				inputReads++;
+				return [
+					"*** Begin Patch",
+					"*** Update File: first.ts",
+					"x".repeat(20_000),
+					"*** Update File: late.ts",
+					"*** End Patch",
+				].join("\n");
+			},
+		});
+		const readsAfterUpdate = inputReads;
+
+		const line = stripAnsi(component.render(1024)[0]!);
+		component.render(1024);
+
+		expect(inputReads).toBe(readsAfterUpdate);
+		expect(line).toContain("first.ts");
+		expect(line).not.toContain("late.ts");
+	});
+
+	test("contains throwing metadata accessors", () => {
+		const args = Object.defineProperty({}, "path", {
+			get() {
+				throw new Error("argument getter");
+			},
+		});
+		const component = atomicTool("read", args);
+		const content = Object.defineProperty({ type: "text" as const }, "text", {
+			get() {
+				throw new Error("result getter");
+			},
+		}) as { type: "text"; text: string };
+
+		expect(() => component.updateResult({ content: [content], isError: false })).not.toThrow();
+		expect(stripAnsi(component.render(80)[0]!)).toContain("read");
+	});
+
+	test("prefers Bash descriptions and concrete failures", () => {
+		const component = atomicTool("bash", { description: "Run tests", command: "bun test" });
+		component.markExecutionStarted();
+		component.updateResult(textResult("failure\n\nCommand exited with code 7", undefined, true));
+
+		const line = stripAnsi(component.render(64)[0]!);
+		expect(line).toContain("bash Run tests · 1 line · exit 7");
+		expect(line).not.toContain("bun test");
+		expect(line).not.toContain("failed");
+	});
+
+	test("counts successful Bash output that resembles an error trailer", () => {
+		const component = atomicTool("bash", { command: "printf trailer" });
+		component.updateResult(textResult("Command exited with code 7"));
+
+		const line = stripAnsi(component.render(64)[0]!);
+		expect(line).toContain("1 line");
+		expect(line).not.toContain("exit 7");
+	});
+
+	test("does not animate tools without a visible atomic spinner", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"apply_patch",
+			"apply-patch-animation",
+			{ input: "*** Begin Patch\n*** End Patch" },
+			{},
+			undefined,
+			{ requestRender } as unknown as TUI,
+			process.cwd(),
+		);
+
+		component.setOutputMode("atomic");
+		requestRender.mockClear();
+		vi.advanceTimersByTime(100);
+
+		expect(requestRender).not.toHaveBeenCalled();
+		component.dispose();
+	});
+
+	test("stops hidden classic renderer progress while partial and after disposal", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const component = new ToolExecutionComponent(
+			"bash",
+			"bash-hidden-renderer",
+			{ command: "bun test" },
+			{},
+			undefined,
+			{ requestRender } as unknown as TUI,
+			process.cwd(),
+		);
+		component.markExecutionStarted();
+		component.updateResult(textResult("working", { progress: { activity: "testing" } }), true);
+		component.setOutputMode("atomic");
+		requestRender.mockClear();
+
+		vi.advanceTimersByTime(1_100);
+
+		expect(requestRender).not.toHaveBeenCalled();
+		component.dispose();
+		requestRender.mockClear();
+		vi.advanceTimersByTime(1_100);
+		expect(requestRender).not.toHaveBeenCalled();
+	});
+
+	test("marks bounded Bash line counts and preserves error trailers", () => {
+		const component = atomicTool("bash", { command: "large-output" });
+		const output = `${Array.from({ length: 9_000 }, (_, index) => `line ${index}`).join("\n")}\n\nCommand exited with code 7`;
+		component.updateResult(textResult(output, undefined, true));
+
+		const line = stripAnsi(component.render(200)[0]!);
+		expect(line).toMatch(/\d+\+ lines · exit 7/u);
+	});
+
+	test("keeps bounded multi-block line counts as a true lower bound", () => {
+		const component = atomicTool("bash", { command: "multi-block-output" });
+		component.updateResult({
+			content: Array.from({ length: 65 }, () => ({ type: "text" as const, text: "line" })),
+			isError: false,
+		});
+
+		const line = stripAnsi(component.render(200)[0]!);
+		const count = /(\d+)\+ lines/u.exec(line);
+		expect(count).not.toBeNull();
+		expect(Number(count?.[1])).toBeLessThanOrEqual(65);
+	});
+});

--- a/packages/coding-agent/test/atomic-tool-row.test.ts
+++ b/packages/coding-agent/test/atomic-tool-row.test.ts
@@ -1,0 +1,268 @@
+import { Text, type TUI, visibleWidth } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import type { ToolDefinition } from "../src/core/extensions/types.ts";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import { nextToolOutputMode } from "../src/modes/interactive/components/tool-execution-types.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function selfRenderedTool(name: string): ToolDefinition {
+	return {
+		name,
+		label: name,
+		description: "dedicated renderer fixture",
+		parameters: Type.Any(),
+		execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+		renderShell: "self",
+		renderCall: () => new Text(`dedicated:${name}`, 0, 0),
+	};
+}
+
+function atomicTool(
+	name: string,
+	args: unknown,
+	toolDefinition?: ToolDefinition,
+	trustedBuiltIn = true,
+): ToolExecutionComponent {
+	const component = new ToolExecutionComponent(
+		name,
+		name,
+		args,
+		{ outputMode: "atomic", trustedBuiltIn },
+		toolDefinition,
+		{ requestRender: () => {} } as TUI,
+		process.cwd(),
+	);
+	return component;
+}
+
+function textResult(text: string, details?: unknown, isError = false) {
+	return {
+		content: [{ type: "text" as const, text }],
+		details,
+		isError,
+	};
+}
+
+describe("atomic tool rows", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("cycles collapsed through expanded and atomic", () => {
+		expect(nextToolOutputMode("collapsed")).toBe("expanded");
+		expect(nextToolOutputMode("expanded")).toBe("atomic");
+		expect(nextToolOutputMode("atomic")).toBe("collapsed");
+	});
+
+	test("renders a full-width single line without horizontal padding", () => {
+		const component = atomicTool("read", { path: "src/index.ts" });
+		component.updateResult(textResult("hidden\ncontent", { truncation: { totalLines: 240 } }));
+
+		const lines = component.render(48);
+		expect(lines).toHaveLength(1);
+		expect(visibleWidth(lines[0]!)).toBe(48);
+		expect(stripAnsi(lines[0]!).startsWith("read src/index.ts · 240 lines")).toBe(true);
+		expect(lines[0]).toContain(theme.fg("toolTitle", theme.bold("read")));
+	});
+
+	test("keeps Bash and Eval maxima after their spinners stop", () => {
+		vi.useFakeTimers();
+		try {
+			const bash = atomicTool("bash", { command: "bun test" });
+			bash.markExecutionStarted();
+			bash.updateResult(textResult(Array.from({ length: 18 }, (_, index) => `line ${index}`).join("\n")), true);
+			expect(stripAnsi(bash.render(60)[0]!).startsWith("bash ⠋ bun test · 18 lines")).toBe(true);
+
+			vi.advanceTimersByTime(160);
+			expect(stripAnsi(bash.render(60)[0]!).startsWith("bash ⠙ bun test · 18 lines")).toBe(true);
+
+			bash.updateResult(textResult("done"));
+			expect(stripAnsi(bash.render(60)[0]!).startsWith("bash bun test · 18 lines")).toBe(true);
+
+			const evalTool = atomicTool("eval", { title: "Inspect source" });
+			evalTool.markExecutionStarted();
+			evalTool.updateResult(textResult("", { toolCalls: Array.from({ length: 8 }, () => ({})) }), true);
+			expect(stripAnsi(evalTool.render(60)[0]!).startsWith("eval Inspect source · ⠋ 8 calls")).toBe(true);
+			evalTool.updateResult(textResult("", { toolCalls: [] }));
+			expect(stripAnsi(evalTool.render(60)[0]!).startsWith("eval Inspect source · 8 calls")).toBe(true);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("makes Eval target spoofing unambiguous without changing metadata order", () => {
+		const component = atomicTool("eval", { title: "Inspect · ⠋ 99 calls" });
+		component.markExecutionStarted();
+		component.updateResult(textResult("", { toolCalls: Array.from({ length: 2 }, () => ({})) }), true);
+
+		expect(stripAnsi(component.render(80)[0]!).startsWith("eval Inspect ∙ ⠋ 99 calls · ⠋ 2 calls")).toBe(true);
+	});
+
+	test.each([1.5, Number.MAX_SAFE_INTEGER + 1, -1])("rejects invalid authoritative count %s", (totalLines) => {
+		const component = atomicTool("read", { path: "fixture.ts" });
+		component.updateResult(textResult("hidden", { truncation: { totalLines } }));
+
+		const line = stripAnsi(component.render(80)[0]!);
+		expect(line).toContain("read fixture.ts");
+		expect(line).not.toContain(`${totalLines} line`);
+	});
+
+	test.each([1.5, Number.MAX_SAFE_INTEGER + 1, -1])(
+		"falls back to observed Bash lines for invalid authoritative count %s",
+		(totalLines) => {
+			const component = atomicTool("bash", { command: "printf output" });
+			component.updateResult(textResult("first\nsecond", { truncation: { totalLines } }));
+
+			expect(stripAnsi(component.render(80)[0]!).startsWith("bash printf output · 2 lines")).toBe(true);
+		},
+	);
+
+	test("refreshes metadata when argument and result objects are reused", () => {
+		const args = { path: "first.ts" };
+		const component = atomicTool("read", args);
+		expect(stripAnsi(component.render(80)[0]!)).toContain("first.ts");
+
+		args.path = "second.ts";
+		component.updateArgs(args);
+		expect(stripAnsi(component.render(80)[0]!)).toContain("second.ts");
+
+		const details = { truncation: { totalLines: 4 } };
+		const result = textResult("line", details);
+		component.updateResult(result);
+		expect(stripAnsi(component.render(80)[0]!)).toContain("4 lines");
+
+		details.truncation.totalLines = 9;
+		component.updateResult(result);
+		expect(stripAnsi(component.render(80)[0]!)).toContain("9 lines");
+	});
+
+	test("shows unique cross-platform apply_patch basenames", () => {
+		const component = atomicTool("apply_patch", {
+			input: ["*** Begin Patch", "*** Update File: src/a.ts", "*** Update File: test\\a.ts", "*** End Patch"].join(
+				"\n",
+			),
+		});
+		component.updateResult(textResult("Done!"));
+
+		const line = stripAnsi(component.render(64)[0]!);
+		expect(line).toContain("apply_patch a.ts");
+		expect(line.match(/a\.ts/gu)).toHaveLength(1);
+		expect(line).not.toContain("src/");
+		expect(line).not.toContain("test\\");
+	});
+
+	test.each(["monitor", "todo", "create_goal", "get_goal", "update_goal"])(
+		"keeps %s on its existing renderer",
+		(name) => {
+			const component = atomicTool(name, { op: "view" }, selfRenderedTool(name));
+			component.updateResult(textResult("task one\ntask two"));
+
+			expect(stripAnsi(component.render(48).join("\n"))).toContain(`dedicated:${name}`);
+		},
+	);
+
+	test("does not infer authoritative facts from unknown extension details", () => {
+		const component = atomicTool("custom_tool", { name: "fixture" });
+		component.updateResult(textResult("ok", { status: "complete", items: [{}, {}] }));
+
+		const line = stripAnsi(component.render(80)[0]!);
+		expect(line).toContain("custom_tool fixture");
+		expect(line).not.toContain("complete");
+		expect(line).not.toContain("2 items");
+	});
+
+	test("escapes target delimiters and preserves trusted facts at narrow widths", () => {
+		const component = atomicTool("read", { path: "deploy · exit 0.ts" });
+		component.updateResult(textResult("ok", { truncation: { totalLines: 240 } }));
+
+		const line = stripAnsi(component.render(32)[0]!);
+		expect(line).toContain("deploy ∙");
+		expect(line).toContain("240 lines");
+		expect(line).not.toContain("deploy · exit 0");
+	});
+
+	test("does not trust built-in names for extension overrides", () => {
+		const todo = atomicTool("todo", { name: "fixture" }, selfRenderedTool("todo"), false);
+		todo.updateResult(textResult("ok", { status: "complete", items: [{}, {}] }));
+		const todoLine = stripAnsi(todo.render(80)[0]!);
+		expect(todoLine).toContain("todo fixture");
+		expect(todoLine).not.toContain("dedicated:todo");
+		expect(todoLine).not.toContain("complete");
+		expect(todoLine).not.toContain("2 items");
+
+		const read = atomicTool("read", { path: "fixture.ts" }, selfRenderedTool("read"), false);
+		read.updateResult(textResult("ok", { truncation: { totalLines: 240 } }));
+		expect(stripAnsi(read.render(80)[0]!)).not.toContain("240 lines");
+	});
+
+	test("does not execute hidden extension renderers in atomic mode", () => {
+		const renderCall = vi.fn(() => new Text("extension renderer", 0, 0));
+		const definition = { ...selfRenderedTool("custom_tool"), renderCall };
+		const component = atomicTool("custom_tool", { name: "fixture" }, definition, false);
+
+		expect(renderCall).not.toHaveBeenCalled();
+		component.setOutputMode("expanded");
+		expect(renderCall).toHaveBeenCalledOnce();
+	});
+
+	test("disposes extension renderer state when entering atomic mode", () => {
+		vi.useFakeTimers();
+		const requestRender = vi.fn();
+		const disposeRenderState = vi.fn((state: { interval?: NodeJS.Timeout }) => {
+			if (state.interval) clearInterval(state.interval);
+			state.interval = undefined;
+		});
+		const definition: ToolDefinition<ReturnType<typeof Type.Any>, unknown, { interval?: NodeJS.Timeout }> = {
+			name: "custom_tool",
+			label: "custom_tool",
+			description: "renderer lifecycle fixture",
+			parameters: Type.Any(),
+			execute: async () => ({ content: [{ type: "text", text: "ok" }], details: {} }),
+			renderShell: "self",
+			renderCall: () => new Text("extension call", 0, 0),
+			renderResult: (_result, _options, _theme, context) => {
+				context.state.interval ??= setInterval(context.invalidate, 100);
+				return new Text("extension result", 0, 0);
+			},
+			disposeRenderState,
+		};
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"custom-tool-state",
+			{},
+			{ trustedBuiltIn: false },
+			definition,
+			{ requestRender } as unknown as TUI,
+			process.cwd(),
+		);
+		component.updateResult(textResult("working"), true);
+		component.setOutputMode("atomic");
+		requestRender.mockClear();
+		vi.advanceTimersByTime(200);
+
+		expect(disposeRenderState).toHaveBeenCalledOnce();
+		expect(requestRender).not.toHaveBeenCalled();
+		component.dispose();
+		vi.useRealTimers();
+	});
+
+	test("restores extension self-renderers after leaving atomic mode", () => {
+		const component = new ToolExecutionComponent(
+			"custom_tool",
+			"custom-tool",
+			{},
+			{},
+			selfRenderedTool("custom_tool"),
+			{ requestRender: () => {} } as TUI,
+			process.cwd(),
+		);
+
+		expect(stripAnsi(component.render(48).join("\n"))).toContain("dedicated:custom_tool");
+		component.setOutputMode("atomic");
+		expect(stripAnsi(component.render(48).join("\n"))).not.toContain("dedicated:custom_tool");
+		component.setOutputMode("expanded");
+		expect(stripAnsi(component.render(48).join("\n"))).toContain("dedicated:custom_tool");
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -128,10 +128,19 @@ type ActiveToolLifecyclePrototype = TerminalTitlePrototype & {
 	refreshWorkingLoaderMessage(this: ActiveToolLifecycleThis): void;
 };
 
+type ActiveToolComponent = {
+	dispose(): void;
+	markExecutionStarted(): void;
+	updateArgs(args: unknown): void;
+	updateResult(result: unknown): void;
+};
+
 type ActiveToolLifecycleThis = TerminalTitleThis & {
 	activeToolExecutionTerminalTitle: string | undefined;
 	activeToolExecutions: Map<string, string>;
+	captureToolCallTrust(toolName: string, toolCallId: string): void;
 	chatContainer: Container;
+	createToolExecutionComponent(toolName: string, toolCallId: string, args: unknown): ActiveToolComponent;
 	defaultWorkingMessage: string;
 	footer: {
 		invalidate(): void;
@@ -146,14 +155,7 @@ type ActiveToolLifecycleThis = TerminalTitleThis & {
 				setMessage(message: string): void;
 		  }
 		| undefined;
-	pendingTools: Map<
-		string,
-		{
-			markExecutionStarted(): void;
-			updateArgs(args: unknown): void;
-			updateResult(result: unknown): void;
-		}
-	>;
+	pendingTools: Map<string, ActiveToolComponent>;
 	refreshWorkingLoaderMessage(): void;
 	requestStreamingRender(): void;
 	session: {
@@ -224,6 +226,32 @@ describe("InteractiveMode.showStatus", () => {
 		expect(fakeThis.chatContainer.children).toHaveLength(5);
 		expect(renderLastLine(fakeThis.chatContainer)).toContain("STATUS_TWO");
 	});
+});
+
+test("clears pending reveal state before disposing rebuilt chat components", () => {
+	const order: string[] = [];
+	const fakeThis = {
+		loadedResourcesContainer: { clear: () => order.push("resources") },
+		chatContainer: { clear: () => order.push("chat") },
+		pendingMessagesContainer: { clear: () => order.push("pending-messages") },
+		compactionTransferAbortControllers: new Map(),
+		compactionQueueGeneration: 0,
+		compactionQueueFlushTail: undefined,
+		compactionQueuedMessages: [],
+		compactionInFlightMessages: [],
+		streamingReveal: { stop: () => {} },
+		toolResultReveal: { stop: () => {} },
+		clearPendingTools: () => order.push("reveal"),
+		clearToolHookStatuses: () => {},
+		renderInitialMessages: () => {},
+	};
+	const renderCurrentSessionState = Reflect.get(InteractiveMode.prototype, "renderCurrentSessionState") as (
+		this: typeof fakeThis,
+	) => void;
+
+	renderCurrentSessionState.call(fakeThis);
+
+	expect(order.indexOf("reveal")).toBeLessThan(order.indexOf("chat"));
 });
 
 describe("InteractiveMode terminal title state", () => {
@@ -342,7 +370,9 @@ describe("InteractiveMode terminal title state", () => {
 		const prototype = InteractiveMode.prototype as unknown as ActiveToolLifecyclePrototype;
 		const setTitle = vi.fn();
 		const setMessage = vi.fn();
+		const finishArgsReveal = vi.fn();
 		const toolComponent = {
+			dispose: vi.fn(),
 			markExecutionStarted: vi.fn(),
 			updateArgs: vi.fn(),
 			updateResult: vi.fn(),
@@ -381,7 +411,7 @@ describe("InteractiveMode terminal title state", () => {
 			stopToolHookStatusTimer: vi.fn(),
 			toolArgsReveal: {
 				flush: vi.fn(() => false),
-				finish: vi.fn(),
+				finish: finishArgsReveal,
 				flushAll: vi.fn(),
 			},
 			toolResultReveal: {
@@ -391,6 +421,8 @@ describe("InteractiveMode terminal title state", () => {
 				refresh: vi.fn(),
 			},
 			toolOutputExpanded: false,
+			captureToolCallTrust: vi.fn(),
+			createToolExecutionComponent: vi.fn(() => toolComponent),
 			workingMessage: "Thinking",
 			workingMessageBeforeActiveTool: undefined,
 			applyTerminalTitle: prototype.applyTerminalTitle,
@@ -419,6 +451,10 @@ describe("InteractiveMode terminal title state", () => {
 		await prototype.handleEvent.call(fakeThis, startEvent);
 
 		// Then
+		expect(finishArgsReveal).toHaveBeenCalledWith("call-1");
+		expect(finishArgsReveal.mock.invocationCallOrder[0]).toBeLessThan(
+			toolComponent.dispose.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+		);
 		expect(fakeThis.workingMessage).toBe("Running bash: npm run check -- --watch");
 		expect(setMessage).toHaveBeenLastCalledWith("Running bash: npm run check -- --watch");
 		expect(setTitle).toHaveBeenLastCalledWith(`${APP_TITLE} - Running bash: npm run check -- --watch`);
@@ -434,27 +470,16 @@ describe("InteractiveMode terminal title state", () => {
 });
 
 describe("InteractiveMode.setToolsExpanded", () => {
-	test("applies expansion state to the active header and chat entries", () => {
-		const header = { setExpanded: vi.fn() };
-		const loadedResourcesChild = { setExpanded: vi.fn() };
-		const chatChild = { setExpanded: vi.fn() };
-		const fakeThis: any = {
-			toolOutputExpanded: false,
-			customHeader: undefined,
-			builtInHeader: header,
-			loadedResourcesContainer: { children: [loadedResourcesChild] },
-			chatContainer: { children: [chatChild] },
-			ui: { requestRender: vi.fn() },
-			showStatus: vi.fn(),
+	test("maps the legacy boolean API to the three-state mode owner", () => {
+		const setToolOutputMode = vi.fn();
+		const fakeThis = {
+			setToolOutputMode,
 		};
 
 		(InteractiveMode as any).prototype.setToolsExpanded.call(fakeThis, true);
+		(InteractiveMode as any).prototype.setToolsExpanded.call(fakeThis, false);
 
-		expect(fakeThis.toolOutputExpanded).toBe(true);
-		expect(header.setExpanded).toHaveBeenCalledWith(true);
-		expect(loadedResourcesChild.setExpanded).toHaveBeenCalledWith(true);
-		expect(chatChild.setExpanded).toHaveBeenCalledWith(true);
-		expect(fakeThis.showStatus).toHaveBeenCalledWith("Tool output: expanded");
+		expect(setToolOutputMode.mock.calls).toEqual([["expanded"], ["collapsed"]]);
 	});
 });
 

--- a/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
+++ b/packages/coding-agent/test/suite/regressions/4167-thinking-toggle-pending-tool-render.test.ts
@@ -5,6 +5,7 @@ import { beforeAll, describe, expect, test, vi } from "vitest";
 import type { AgentSessionEvent } from "../../../src/core/agent-session.ts";
 import type { SessionEntry } from "../../../src/core/session-manager.ts";
 import type { ToolExecutionComponent } from "../../../src/modes/interactive/components/tool-execution.ts";
+import type { ToolOutputMode } from "../../../src/modes/interactive/components/tool-execution-types.ts";
 import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
 import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../../../src/utils/ansi.ts";
@@ -53,11 +54,14 @@ type RenderSessionContextThis = {
 	};
 	sessionManager: { getCwd(): string; getEntries(): SessionEntry[] };
 	session: { retryAttempt: number; modelRegistry: { find(provider: string, modelId: string): undefined } };
+	toolOutputMode: ToolOutputMode;
 	toolOutputExpanded: boolean;
 	isInitialized: boolean;
 	chrome: undefined;
 	updateEditorBorderColor(): void;
-	getRegisteredToolDefinition(toolName: string): undefined;
+	getRegisteredToolDefinition(toolName: string, trustedBuiltIn: boolean): undefined;
+	isRegisteredToolTrustedBuiltIn(toolName: string): boolean;
+	getCapturedToolCallTrust(toolCallId: string): boolean;
 	createToolExecutionComponent(toolName: string, toolCallId: string, args: unknown): ToolExecutionComponent;
 	clearPendingTools(): void;
 	handleToolExecutionEnd(event: Extract<AgentSessionEvent, { type: "tool_execution_end" }>): void;
@@ -90,13 +94,16 @@ function createFakeInteractiveModeThis(): RenderSessionContextThis {
 		},
 		sessionManager: { getCwd: () => process.cwd(), getEntries: () => [] },
 		session: { retryAttempt: 0, modelRegistry: { find: () => undefined } },
+		toolOutputMode: "collapsed",
 		toolOutputExpanded: false,
 		isInitialized: true,
 		// Classic chrome: renderSessionItems builds tool components through the
 		// real factory, which consults this field to pick the presentation.
 		chrome: undefined,
 		updateEditorBorderColor: vi.fn(),
-		getRegisteredToolDefinition: (_toolName: string) => undefined,
+		getRegisteredToolDefinition: (_toolName: string, _trustedBuiltIn: boolean) => undefined,
+		isRegisteredToolTrustedBuiltIn: (_toolName: string) => false,
+		getCapturedToolCallTrust: (_toolCallId: string) => false,
 		createToolExecutionComponent: Reflect.get(InteractiveMode.prototype, "createToolExecutionComponent"),
 		clearPendingTools: Reflect.get(InteractiveMode.prototype, "clearPendingTools"),
 		handleToolExecutionEnd: Reflect.get(InteractiveMode.prototype, "handleToolExecutionEnd"),

--- a/packages/coding-agent/test/suite/regressions/codemode-builtin-dedupe.test.ts
+++ b/packages/coding-agent/test/suite/regressions/codemode-builtin-dedupe.test.ts
@@ -2,10 +2,12 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-const CODEMODE_ENTRY = resolve(process.cwd(), "..", "senpi-codemode", "src", "index.ts");
+const CODING_AGENT_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+const REPOSITORY_ROOT = resolve(CODING_AGENT_ROOT, "../..");
+const CODEMODE_ENTRY = resolve(CODING_AGENT_ROOT, "..", "senpi-codemode", "src", "index.ts");
 const CODEMODE_PACKAGE_NAME = "@code-yeongyu/senpi-codemode";
 
 type ProbeResult = {
@@ -13,6 +15,7 @@ type ProbeResult = {
 	evalExtensions: Array<{
 		path: string;
 		sourceInfo: { source: string; scope: string; origin: string };
+		evalSourceInfo: { source: string; scope: string; origin: string } | undefined;
 		description: string | undefined;
 		sessionStartHandlers: number;
 	}>;
@@ -38,8 +41,8 @@ describe("bundled codemode identity and precedence", () => {
 
 	function runProbe(settings: Record<string, unknown>): ProbeResult {
 		const probePath = join(root, "codemode-builtin-probe.mts");
-		const resourceLoaderUrl = pathToFileURL(join(process.cwd(), "src", "core", "resource-loader.ts")).href;
-		const sessionManagerUrl = pathToFileURL(join(process.cwd(), "src", "core", "session-manager.ts")).href;
+		const resourceLoaderUrl = pathToFileURL(join(CODING_AGENT_ROOT, "src", "core", "resource-loader.ts")).href;
+		const sessionManagerUrl = pathToFileURL(join(CODING_AGENT_ROOT, "src", "core", "session-manager.ts")).href;
 		writeFileSync(
 			probePath,
 			`import { readdirSync, rmSync } from "node:fs";
@@ -88,6 +91,7 @@ process.stdout.write(JSON.stringify({
 	evalExtensions: evalExtensions.map((extension) => ({
 		path: extension.path,
 		sourceInfo: extension.sourceInfo,
+		evalSourceInfo: extension.tools.get("eval")?.sourceInfo,
 		description: extension.tools.get("eval")?.definition.description,
 		sessionStartHandlers: extension.handlers.get("session_start")?.length ?? 0,
 	})),
@@ -97,7 +101,7 @@ process.stdout.write(JSON.stringify({
 		);
 		writeFileSync(join(agentDir, "settings.json"), `${JSON.stringify(settings)}\n`);
 		const output = execFileSync(process.execPath, ["--import", "tsx", probePath, agentDir, cwd], {
-			cwd: process.cwd(),
+			cwd: REPOSITORY_ROOT,
 			encoding: "utf8",
 			env: {
 				...process.env,
@@ -118,12 +122,13 @@ process.stdout.write(JSON.stringify({
 		expect(result.evalExtensions).toHaveLength(1);
 		expect(result.evalExtensions[0]).toMatchObject({
 			path: CODEMODE_ENTRY,
-			sourceInfo: { source: "local", scope: "temporary", origin: "top-level" },
+			sourceInfo: { source: "builtin", scope: "temporary", origin: "top-level" },
+			evalSourceInfo: { source: "builtin", scope: "temporary", origin: "top-level" },
 			description: expect.any(String),
 			sessionStartHandlers: 1,
 		});
 		expect(result.sessionStartRefreshes).toBe(1);
-	});
+	}, 30_000);
 
 	it("keeps exactly one eval registration when the npm package is configured by the user", () => {
 		const userPackageDir = join(agentDir, "npm", "node_modules", "@code-yeongyu", "senpi-codemode");
@@ -155,8 +160,9 @@ export default function(pi) {
 		expect(result.evalExtensions).toHaveLength(1);
 		expect(result.evalExtensions[0]).toMatchObject({
 			path: CODEMODE_ENTRY,
-			sourceInfo: { source: "local", scope: "temporary", origin: "top-level" },
+			sourceInfo: { source: "builtin", scope: "temporary", origin: "top-level" },
+			evalSourceInfo: { source: "builtin", scope: "temporary", origin: "top-level" },
 		});
 		expect(result.evalExtensions[0]?.description).not.toBe("user configured codemode");
-	});
+	}, 30_000);
 });

--- a/packages/coding-agent/test/tool-call-provenance.test.ts
+++ b/packages/coding-agent/test/tool-call-provenance.test.ts
@@ -1,0 +1,164 @@
+import { Container, type TUI } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test } from "vitest";
+import type { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import type { ToolOutputMode } from "../src/modes/interactive/components/tool-execution-types.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { ToolCallProvenance } from "../src/modes/interactive/tool-call-provenance.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+type InteractiveModePrototype = {
+	captureToolCallTrust(this: ProvenanceContext, toolName: string, toolCallId: string): boolean;
+	handleEvent(this: Record<string, unknown>, event: object): Promise<void>;
+	createToolExecutionComponent(
+		this: ProvenanceContext,
+		toolName: string,
+		toolCallId: string,
+		args: unknown,
+	): ToolExecutionComponent;
+};
+
+type ProvenanceContext = {
+	toolCallProvenance: ToolCallProvenance;
+	toolOutputMode: ToolOutputMode;
+	isInitialized: boolean;
+	chrome: undefined;
+	settingsManager: {
+		getShowImages(): boolean;
+		getImageWidthCells(): number;
+	};
+	sessionManager: {
+		getSessionId(): string;
+		getCwd(): string;
+	};
+	session: {
+		getAllTools(): Array<{ name: string; sourceInfo: { source: string } }>;
+		getToolDefinition(name: string): undefined;
+	};
+	ui: TUI;
+	isRegisteredToolTrustedBuiltIn(toolName: string): boolean;
+	getRegisteredToolDefinition(toolName: string, trustedBuiltIn: boolean): undefined;
+	getCapturedToolCallTrust(toolCallId: string): boolean;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
+
+function createContext() {
+	let sessionId = "session-a";
+	let currentSource = "builtin";
+	const context: ProvenanceContext = {
+		toolCallProvenance: new ToolCallProvenance(),
+		toolOutputMode: "atomic",
+		isInitialized: true,
+		chrome: undefined,
+		settingsManager: {
+			getShowImages: () => false,
+			getImageWidthCells: () => 60,
+		},
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getCwd: () => process.cwd(),
+		},
+		session: {
+			getAllTools: () => [{ name: "eval", sourceInfo: { source: currentSource } }],
+			getToolDefinition: () => undefined,
+		},
+		ui: { requestRender: () => {} } as TUI,
+		isRegisteredToolTrustedBuiltIn: Reflect.get(InteractiveMode.prototype, "isRegisteredToolTrustedBuiltIn"),
+		getRegisteredToolDefinition: Reflect.get(InteractiveMode.prototype, "getRegisteredToolDefinition"),
+		getCapturedToolCallTrust: Reflect.get(InteractiveMode.prototype, "getCapturedToolCallTrust"),
+	};
+	return {
+		context,
+		setCurrentSource(source: string) {
+			currentSource = source;
+		},
+		setSessionId(id: string) {
+			sessionId = id;
+		},
+	};
+}
+
+function renderEval(component: ToolExecutionComponent): string {
+	component.updateResult({
+		content: [],
+		details: { toolCalls: Array.from({ length: 7 }, () => ({})) },
+		isError: false,
+	});
+	return stripAnsi(component.render(80).join("\n"));
+}
+
+describe("interactive tool-call provenance", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("captures live builtin trust and keeps it across a registry reload in the same session", async () => {
+		const { context, setCurrentSource } = createContext();
+		const chatContainer = new Container();
+		const liveContext = Object.assign(context, {
+			footer: { invalidate: () => {} },
+			pendingTools: new Map<string, ToolExecutionComponent>(),
+			chatContainer,
+			handleToolExecutionStart: () => {},
+			captureToolCallTrust: interactiveModePrototype.captureToolCallTrust,
+			createToolExecutionComponent: interactiveModePrototype.createToolExecutionComponent,
+			toolArgsReveal: { finish: () => {} },
+		});
+		await interactiveModePrototype.handleEvent.call(liveContext as unknown as Record<string, unknown>, {
+			type: "tool_execution_start",
+			toolCallId: "call-1",
+			toolName: "eval",
+			args: { title: "Inspect" },
+		});
+		chatContainer.clear();
+
+		setCurrentSource("local");
+		const rebuilt = interactiveModePrototype.createToolExecutionComponent.call(context, "eval", "call-1", {
+			title: "Inspect",
+		});
+
+		expect(renderEval(rebuilt)).toContain("7 calls");
+		rebuilt.dispose();
+	});
+
+	test("defaults uncaptured historical calls to untrusted even when a builtin now owns the name", () => {
+		const { context } = createContext();
+		const historical = interactiveModePrototype.createToolExecutionComponent.call(context, "eval", "old-call", {
+			title: "Inspect",
+		});
+
+		expect(renderEval(historical)).not.toContain("7 calls");
+	});
+
+	test("does not promote a removed same-name extension call to builtin trust", () => {
+		const { context, setCurrentSource } = createContext();
+		setCurrentSource("local");
+		interactiveModePrototype.captureToolCallTrust.call(context, "eval", "extension-call");
+
+		setCurrentSource("builtin");
+		const rebuilt = interactiveModePrototype.createToolExecutionComponent.call(context, "eval", "extension-call", {
+			title: "Inspect",
+		});
+
+		expect(renderEval(rebuilt)).not.toContain("7 calls");
+	});
+
+	test("namespaces identical call ids by session", () => {
+		const { context, setCurrentSource, setSessionId } = createContext();
+		setCurrentSource("local");
+		interactiveModePrototype.captureToolCallTrust.call(context, "eval", "shared-call");
+
+		setSessionId("session-b");
+		setCurrentSource("builtin");
+		interactiveModePrototype.captureToolCallTrust.call(context, "eval", "shared-call");
+
+		setSessionId("session-a");
+		const sessionA = interactiveModePrototype.createToolExecutionComponent.call(context, "eval", "shared-call", {});
+		setSessionId("session-b");
+		const sessionB = interactiveModePrototype.createToolExecutionComponent.call(context, "eval", "shared-call", {});
+
+		expect(renderEval(sessionA)).not.toContain("7 calls");
+		expect(renderEval(sessionB)).toContain("7 calls");
+	});
+});

--- a/packages/coding-agent/test/tool-execution-component.test.ts
+++ b/packages/coding-agent/test/tool-execution-component.test.ts
@@ -182,6 +182,68 @@ describe("ToolExecutionComponent parity", () => {
 		expect(component.render(120)).toEqual([]);
 	});
 
+	test("restores classic, Grok, and self render selection after atomic mode", () => {
+		const result = { content: [{ type: "text" as const, text: "result body" }], details: {}, isError: false };
+		const classic = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-selection-classic",
+			{ target: "fixture" },
+			{},
+			createBaseToolDefinition(),
+			createFakeTui(),
+			process.cwd(),
+		);
+		classic.updateResult(result);
+		classic.setOutputMode("expanded");
+		const classicBefore = classic.render(72);
+		classic.setOutputMode("atomic");
+		expect(classic.render(72)).not.toEqual(classicBefore);
+		classic.setOutputMode("expanded");
+		expect(classic.render(72)).toEqual(classicBefore);
+
+		const grok = new ToolExecutionComponent(
+			"read",
+			"tool-selection-grok",
+			{ path: "fixture.ts" },
+			{},
+			undefined,
+			createFakeTui(),
+			process.cwd(),
+			"grok",
+		);
+		grok.updateResult(result);
+		const grokBefore = grok.render(72);
+		grok.setOutputMode("atomic");
+		expect(grok.render(72)).not.toEqual(grokBefore);
+		grok.setOutputMode("collapsed");
+		expect(grok.render(72)).toEqual(grokBefore);
+
+		const disposeRenderState = vi.fn();
+		const renderCall = vi.fn(() => new Text("self call", 0, 0));
+		const selfDefinition: ToolDefinition = {
+			...createBaseToolDefinition(),
+			renderShell: "self",
+			renderCall,
+			disposeRenderState,
+		};
+		const self = new ToolExecutionComponent(
+			"custom_tool",
+			"tool-selection-self",
+			{},
+			{},
+			selfDefinition,
+			createFakeTui(),
+			process.cwd(),
+		);
+		const selfBefore = self.render(72);
+		self.setOutputMode("atomic");
+		expect(disposeRenderState).toHaveBeenCalledOnce();
+		expect(self.render(72)).not.toEqual(selfBefore);
+		self.setOutputMode("collapsed");
+		expect(renderCall).toHaveBeenCalledTimes(2);
+		expect(self.render(72)).toEqual(selfBefore);
+	});
+
 	test("advances pending render frames for self-rendered write calls while args stream", () => {
 		vi.useFakeTimers();
 		try {
@@ -231,7 +293,7 @@ describe("ToolExecutionComponent parity", () => {
 			"edit",
 			"tool-2",
 			{ path: "README.md", oldText: "before", newText: "after" },
-			{},
+			{ trustedBuiltIn: true },
 			overrideDefinition,
 			createFakeTui(),
 			process.cwd(),
@@ -415,7 +477,7 @@ describe("ToolExecutionComponent parity", () => {
 			"read",
 			"tool-4c",
 			{ path: "README.md" },
-			{},
+			{ trustedBuiltIn: true },
 			overrideDefinition,
 			createFakeTui(),
 			process.cwd(),
@@ -771,7 +833,7 @@ describe("ToolExecutionComponent parity", () => {
 				"todo",
 				"tool-todo-strike-happy",
 				{},
-				{},
+				{ trustedBuiltIn: true },
 				createBaseToolDefinition("todo"),
 				createFakeTuiWithRenderSpy(requestRender),
 				process.cwd(),
@@ -966,7 +1028,7 @@ describe("ToolExecutionComponent parity", () => {
 				"todo",
 				"tool-todo-strike-memo",
 				{},
-				{},
+				{ trustedBuiltIn: true },
 				toolDefinition,
 				createFakeTuiWithRenderSpy(vi.fn()),
 				process.cwd(),

--- a/packages/coding-agent/test/tool-output-mode-propagation.test.ts
+++ b/packages/coding-agent/test/tool-output-mode-propagation.test.ts
@@ -1,0 +1,63 @@
+import { Container, type TUI } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { ToolExecutionComponent } from "../src/modes/interactive/components/tool-execution.ts";
+import type { ToolOutputMode } from "../src/modes/interactive/components/tool-execution-types.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+function createTool(name: string, id: string): ToolExecutionComponent {
+	return new ToolExecutionComponent(name, id, {}, {}, undefined, { requestRender: () => {} } as TUI, process.cwd());
+}
+
+class ExpandableContainer extends Container {
+	readonly setExpanded = vi.fn();
+}
+
+describe("tool output mode propagation", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("preserves top-level expansion ownership while updating nested and pending tools", () => {
+		const direct = createTool("read", "direct");
+		const nested = createTool("bash", "nested");
+		const pending = createTool("eval", "pending");
+		const wrapper = new ExpandableContainer();
+		wrapper.addChild(nested);
+		const chatContainer = new Container();
+		chatContainer.addChild(direct);
+		chatContainer.addChild(wrapper);
+
+		const mode = Object.create(InteractiveMode.prototype) as InteractiveMode;
+		Reflect.set(mode, "toolOutputMode", "collapsed");
+		Reflect.set(mode, "builtInHeader", undefined);
+		Reflect.set(mode, "loadedResourcesContainer", new Container());
+		Reflect.set(mode, "chatContainer", chatContainer);
+		Reflect.set(
+			mode,
+			"pendingTools",
+			new Map([
+				["nested", nested],
+				["pending", pending],
+			]),
+		);
+		Reflect.set(mode, "showStatus", vi.fn());
+
+		const directMode = vi.spyOn(direct, "setOutputMode");
+		const nestedMode = vi.spyOn(nested, "setOutputMode");
+		const pendingMode = vi.spyOn(pending, "setOutputMode");
+		const setMode = Reflect.get(InteractiveMode.prototype, "setToolOutputMode") as (
+			this: InteractiveMode,
+			outputMode: ToolOutputMode,
+		) => void;
+
+		setMode.call(mode, "expanded");
+		setMode.call(mode, "atomic");
+		setMode.call(mode, "collapsed");
+
+		for (const setOutputMode of [directMode, nestedMode, pendingMode]) {
+			expect(setOutputMode.mock.calls).toEqual([["expanded"], ["atomic"], ["collapsed"]]);
+		}
+		expect(wrapper.setExpanded.mock.calls).toEqual([[true], [false], [false]]);
+	});
+});

--- a/packages/coding-agent/test/tool-renderer-lifecycle.test.ts
+++ b/packages/coding-agent/test/tool-renderer-lifecycle.test.ts
@@ -1,0 +1,176 @@
+import type { Component } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import type { ToolDefinition } from "../src/core/extensions/types.ts";
+import { ToolExecutionRenderer } from "../src/modes/interactive/components/tool-execution-renderer.ts";
+import type {
+	ToolExecutionIdentity,
+	ToolExecutionRenderState,
+} from "../src/modes/interactive/components/tool-execution-types.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function createToolDefinition(overrides: Partial<ToolDefinition> = {}): ToolDefinition {
+	return {
+		name: "custom_tool",
+		label: "custom_tool",
+		description: "custom tool",
+		parameters: Type.Any(),
+		execute: async () => ({ content: [], details: {} }),
+		...overrides,
+	};
+}
+
+function createIdentity(toolDefinition: ToolDefinition, trustedBuiltIn = false): ToolExecutionIdentity {
+	return {
+		toolName: toolDefinition.name,
+		toolCallId: "tool-lifecycle",
+		cwd: process.cwd(),
+		toolDefinition,
+		trustedBuiltIn,
+	};
+}
+
+function createState(result = false): ToolExecutionRenderState {
+	return {
+		args: {},
+		executionStarted: result,
+		argsComplete: result,
+		isPartial: !result,
+		expanded: false,
+		showImages: true,
+		spinnerFrame: undefined,
+		result: result ? { content: [{ type: "text", text: "done" }], details: {}, isError: false } : undefined,
+	};
+}
+
+function createComponent(text: string, dispose: () => void): Component {
+	return {
+		render: () => [text],
+		invalidate: () => {},
+		dispose,
+	};
+}
+
+describe("ToolExecutionRenderer lifecycle", () => {
+	beforeAll(() => initTheme("dark"));
+
+	test("disposes a failed renderer component exactly once even when both slots share it", () => {
+		const dispose = vi.fn();
+		const failedComponent: Component = {
+			render: () => {
+				throw new Error("render failed");
+			},
+			invalidate: () => {},
+			dispose,
+		};
+		const toolDefinition = createToolDefinition({
+			renderCall: () => failedComponent,
+			renderResult: () => failedComponent,
+		});
+		const state = createState(true);
+		const renderer = new ToolExecutionRenderer(createIdentity(toolDefinition), state, () => {});
+
+		renderer.update(state);
+		expect(stripAnsi(renderer.render(120).join("\n"))).toContain("custom_tool");
+		renderer.suspend();
+		renderer.dispose();
+
+		expect(dispose).toHaveBeenCalledTimes(1);
+	});
+
+	test("keeps suspend idempotent until the renderer is updated", () => {
+		const disposeRenderState = vi.fn();
+		const componentDisposals: ReturnType<typeof vi.fn>[] = [];
+		const toolDefinition = createToolDefinition({
+			disposeRenderState,
+			renderCall: () => {
+				const dispose = vi.fn();
+				componentDisposals.push(dispose);
+				return createComponent(`generation ${componentDisposals.length}`, dispose);
+			},
+		});
+		const state = createState(true);
+		const renderer = new ToolExecutionRenderer(createIdentity(toolDefinition), state, () => {});
+
+		renderer.update(state);
+		renderer.suspend();
+		renderer.suspend();
+		expect(disposeRenderState).toHaveBeenCalledTimes(1);
+		expect(componentDisposals).toHaveLength(1);
+		expect(componentDisposals[0]).toHaveBeenCalledTimes(1);
+
+		renderer.update(state);
+		renderer.suspend();
+		renderer.dispose();
+		expect(disposeRenderState).toHaveBeenCalledTimes(2);
+		expect(componentDisposals).toHaveLength(2);
+		expect(componentDisposals[1]).toHaveBeenCalledTimes(1);
+	});
+
+	test("contains cleanup failures while detaching and disposing every component", () => {
+		vi.useFakeTimers();
+		try {
+			const callDispose = vi.fn(() => {
+				throw new Error("call disposal failed");
+			});
+			const resultDispose = vi.fn();
+			const disposeRenderState = vi.fn(() => {
+				throw new Error("custom cleanup failed");
+			});
+			const toolDefinition = createToolDefinition({
+				name: "bash",
+				disposeRenderState,
+				renderCall: (_args, _theme, context) => {
+					Reflect.set(
+						context.state,
+						"interval",
+						setInterval(() => {}, 1_000),
+					);
+					return createComponent("custom call", callDispose);
+				},
+				renderResult: () => createComponent("custom result", resultDispose),
+			});
+			const state = createState(true);
+			const renderer = new ToolExecutionRenderer(createIdentity(toolDefinition, true), state, () => {});
+
+			renderer.update(state);
+			expect(vi.getTimerCount()).toBe(1);
+			expect(stripAnsi(renderer.render(120).join("\n"))).toContain("custom call");
+			expect(stripAnsi(renderer.render(120).join("\n"))).toContain("custom result");
+
+			expect(() => renderer.suspend()).not.toThrow();
+			expect(vi.getTimerCount()).toBe(0);
+			expect(disposeRenderState).toHaveBeenCalledTimes(1);
+			expect(callDispose).toHaveBeenCalledTimes(1);
+			expect(resultDispose).toHaveBeenCalledTimes(1);
+			const suspendedOutput = stripAnsi(renderer.render(120).join("\n"));
+			expect(suspendedOutput).not.toContain("custom call");
+			expect(suspendedOutput).not.toContain("custom result");
+			expect(() => renderer.dispose()).not.toThrow();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	test("contains throwing dispose accessors and continues disposing components", () => {
+		const resultDispose = vi.fn();
+		const callComponent = createComponent("custom call", vi.fn());
+		Object.defineProperty(callComponent, "dispose", {
+			get: () => {
+				throw new Error("dispose accessor failed");
+			},
+		});
+		const toolDefinition = createToolDefinition({
+			renderCall: () => callComponent,
+			renderResult: () => createComponent("custom result", resultDispose),
+		});
+		const state = createState(true);
+		const renderer = new ToolExecutionRenderer(createIdentity(toolDefinition), state, () => {});
+
+		renderer.update(state);
+
+		expect(() => renderer.suspend()).not.toThrow();
+		expect(resultDispose).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

- add a three-state Ctrl+O tool-output cycle: collapsed, expanded, atomic
- render ordinary atomic tools as adjacent full-width one-line status rows with no left padding
- preserve each atomic spinner's original tool-relative position
- propagate mode changes to direct, nested, and pending tool components
- preserve dedicated and extension-provided renderers outside atomic mode
- bound and sanitize untrusted metadata used by compact rows
- require registered built-in provenance for built-in metadata and passthrough
- suspend hidden renderers and release renderer-owned resources in atomic mode

## Contribution process

- proposal: #729
- `CHANGELOG.md` is intentionally unchanged because `CONTRIBUTING.md` assigns changelog entries to maintainers
- the changelog gate therefore requires a maintainer entry or `no-changelog` label

## Test plan

- [x] changed-domain Vitest: 9 files, 127 tests
- [x] required TUI renderer regression: 62 tests
- [x] root TypeScript and `npm run check`
- [x] root build
- [x] `git diff --check`
- [x] native Windows ConPTY smoke: 5/5
- [x] deterministic 80/40-column row capture
- [x] native Ctrl+O cycle and Windows Terminal source launch
- [x] final code-quality and security reviews

## Known upstream/environment test failures

On the current `a2632b7a` base, root `npm test` stops in `test:scripts` with
94 pass / 8 fail on Windows/Node 26. The failures are unrelated local-release,
model-generation, and standalone-binary fixtures; this branch's focused tests,
renderer test, static gate, and build pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an atomic tool output mode and makes Ctrl+O cycle collapsed → expanded → atomic. Atomic shows tools as compact one‑line rows, keeps spinner placement (e.g., Bash after name; Eval after target), and restores classic/Grok/self views when you leave it.

- **New Features**
  - Atomic rows: full-width one‑line per tool with no left padding, bold name, shallow trusted metadata, and original spinner positions.
  - Ctrl+O updates direct, nested, and pending tools; non-tool blocks keep top-level expansion control.
  - Monitor/Todo/Goal keep dedicated renderers; classic, Grok, and extension self-renderers return after atomic.
  - Metadata is bounded and sanitized (strips terminal/Bidi controls; safe-integer counts); only trusted built-ins contribute.
  - Bundled extension entries keep `builtin` provenance so Eval exposes trusted atomic metadata; tool-call trust is tracked per session and gates built-in renderers/metadata.
  - Keybinding and tips/shortcut overlay updated to describe the three-state cycle.

- **Refactors**
  - `ToolDefinition` adds optional `disposeRenderState(state)` for releasing renderer-owned resources when suspended/hidden or disposed.
  - Built-in Bash implements the hook to stop its elapsed-time interval in atomic mode.
  - Renderer shell suspends hidden views, disposes safely, and only loads built-in definitions when the tool call is trusted.

<sup>Written for commit 1939739e6e4b5201207a82c382fd2a0db4907b8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

