### PR TITLE
fix(compaction): admit compaction up to the absolute session cap

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/compaction-absolute-cap-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/compaction-absolute-cap-qa.mjs
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+/**
+ * Absolute compaction cap QA scenario.
+ *
+ * Drives the real senpi CLI from source over RPC with a local fake Anthropic
+ * server and proves the post-#728 admission policy end to end:
+ *   - compactions past the former per-turn soft cap (3) are admitted and
+ *     accepted up to the absolute session cap (10),
+ *   - the 11th compaction is rejected with the absolute-session-cap message
+ *     (not the misleading per-turn wording), and
+ *   - the rejection is non-fatal: the session keeps serving prompts.
+ *
+ * Usage: node compaction-absolute-cap-qa.mjs --self-test [--evidence SLUG]
+ */
+
+import { writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import {
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	spawnCli,
+} from "../lib/common.mjs";
+import { checkRealAuthUnchanged, hermeticEnv } from "../lib/mock-loop-support.mjs";
+
+const SUMMARY_MARKER = "context summarization assistant";
+const ABSOLUTE_CAP = 10;
+const FORMER_SOFT_CAP = 3;
+const REJECTION_NEEDLE = "absolute compaction cap reached for this session";
+const CONTEXT_WINDOW = 128_000;
+
+function flag(name) {
+	const index = process.argv.indexOf(name);
+	return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function writeAnthropicSse(res, text, modelId, inputTokens) {
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
+	const ev = (event, data) => res.write(`event: ${event}\ndata: ${JSON.stringify({ type: event, ...data })}\n\n`);
+	ev("message_start", {
+		message: {
+			id: "msg_mock",
+			type: "message",
+			role: "assistant",
+			model: modelId,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: inputTokens, output_tokens: 0 },
+		},
+	});
+	ev("content_block_start", { index: 0, content_block: { type: "text", text: "" } });
+	ev("content_block_delta", { index: 0, delta: { type: "text_delta", text } });
+	ev("content_block_stop", { index: 0 });
+	ev("message_delta", { delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 40 } });
+	ev("message_stop", {});
+	res.end();
+}
+
+function startScriptedServer() {
+	const requests = [];
+	const server = createServer((req, res) => {
+		const chunks = [];
+		req.on("data", (c) => chunks.push(c));
+		req.on("end", () => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			let body = {};
+			try {
+				body = raw ? JSON.parse(raw) : {};
+			} catch {}
+			const systemText = typeof body.system === "string" ? body.system : JSON.stringify(body.system ?? "");
+			const isSummarization = systemText.includes(SUMMARY_MARKER);
+			requests.push({ at: Date.now(), summarization: isSummarization });
+			if (isSummarization) {
+				return writeAnthropicSse(
+					res,
+					"## Goal\nQA compaction summary\n## Constraints\nnone\n## State\nabsolute-cap qa",
+					body.model ?? "mock-claude",
+					500,
+				);
+			}
+			return writeAnthropicSse(res, `QA-TURN-OK-${requests.length}`, body.model ?? "mock-claude", 1_000);
+		});
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address();
+			resolve({
+				requests,
+				origin: `http://127.0.0.1:${port}`,
+				stop: () => new Promise((done) => server.close(done)),
+			});
+		});
+	});
+}
+
+function writeSandboxConfig(agentDir, server) {
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				anthropic: {
+					baseUrl: server.origin,
+					apiKey: "sk-mock-qa-cap",
+					api: "anthropic-messages",
+					models: [
+						{
+							id: "mock-claude",
+							api: "anthropic-messages",
+							baseUrl: server.origin,
+							contextWindow: CONTEXT_WINDOW,
+							maxTokens: 4_096,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						},
+					],
+				},
+			},
+		}),
+	);
+	writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ compaction: { keepRecentTokens: 40 } }));
+}
+
+class RpcClient {
+	constructor({ env, cwd }) {
+		this.child = spawnCli(["--mode", "rpc", "--no-context-files"], { env, cwd });
+		this.pending = new Map();
+		this.events = [];
+		this.seq = 0;
+		this._buf = "";
+		this.stderr = "";
+		this.child.stdout.on("data", (chunk) => this._onData(chunk));
+		this.child.stderr.on("data", (d) => {
+			this.stderr += d.toString();
+		});
+	}
+
+	_onData(chunk) {
+		this._buf += chunk.toString();
+		let nl;
+		while ((nl = this._buf.indexOf("\n")) >= 0) {
+			const line = this._buf.slice(0, nl).trim();
+			this._buf = this._buf.slice(nl + 1);
+			if (!line) continue;
+			let msg;
+			try {
+				msg = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (msg && msg.type === "response" && msg.id !== undefined && this.pending.has(msg.id)) {
+				this.pending.get(msg.id)(msg);
+				this.pending.delete(msg.id);
+			} else if (msg && msg.type) {
+				this.events.push({ at: Date.now(), msg });
+			}
+		}
+	}
+
+	send(cmd, { timeoutMs = 30_000 } = {}) {
+		const id = cmd.id ?? `req-${++this.seq}`;
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`RPC timeout ${cmd.type} (stderr: ${this.stderr.slice(-400)})`));
+			}, timeoutMs);
+			this.pending.set(id, (m) => {
+				clearTimeout(timer);
+				resolve(m);
+			});
+			this.child.stdin.write(`${JSON.stringify({ ...cmd, id })}\n`);
+		});
+	}
+
+	async waitForEvent(predicate, afterIndex, timeoutMs) {
+		const deadline = Date.now() + timeoutMs;
+		for (;;) {
+			const hit = this.events.slice(afterIndex).find((e) => predicate(e.msg));
+			if (hit) return hit.msg;
+			if (Date.now() > deadline) throw new Error(`event wait timed out (stderr: ${this.stderr.slice(-400)})`);
+			await new Promise((r) => setTimeout(r, 25));
+		}
+	}
+
+	close() {
+		try {
+			this.child.stdin.end();
+		} catch {}
+	}
+}
+
+async function runPrompt(client, message) {
+	const afterIndex = client.events.length;
+	const ack = await client.send({ type: "prompt", message });
+	const terminal = await client.waitForEvent(
+		(m) => m.type === "agent_end" || m.type === "agent_aborted",
+		afterIndex,
+		30_000,
+	);
+	return { ack, terminal };
+}
+
+async function main() {
+	if (!process.argv.includes("--self-test")) {
+		process.stderr.write("usage: compaction-absolute-cap-qa.mjs --self-test [--evidence SLUG]\n");
+		process.exitCode = 2;
+		return;
+	}
+
+	installCleanupHooks();
+	const checks = createChecks("compaction-absolute-cap-qa.mjs --self-test");
+	const evidence = evidenceDir(flag("--evidence") ?? "compaction-absolute-cap");
+	const guard = guardRealAuth();
+	const box = makeSandbox("senpi-qa-compaction-absolute-cap");
+	const observed = { compactOutcomes: [], rejection: null, promptAfterRejection: null };
+	let server;
+	let client;
+
+	try {
+		server = await startScriptedServer();
+		writeSandboxConfig(box.agentDir, server);
+		client = new RpcClient({ env: hermeticEnv(box.env), cwd: box.cwd });
+
+		await client.send({ type: "set_model", provider: "anthropic", modelId: "mock-claude" });
+		const seed = await runPrompt(client, `seed turn for compaction qa: ${"lorem ipsum ".repeat(400)}`);
+		checks.ok("seed turn completed through agent_end", seed.terminal.type === "agent_end");
+
+		let accepted = 0;
+		for (let round = 1; accepted < ABSOLUTE_CAP && round <= ABSOLUTE_CAP + 3; round++) {
+			const result = await client.send({ type: "compact" });
+			observed.compactOutcomes.push({ round, success: result.success === true, error: result.error ?? null });
+			if (result.success === true) accepted++;
+			await runPrompt(client, `post-compact filler ${round}: ${"qa content ".repeat(120)}`);
+		}
+		checks.ok(
+			`${ABSOLUTE_CAP} compactions were accepted in one session (former soft cap was ${FORMER_SOFT_CAP})`,
+			accepted === ABSOLUTE_CAP,
+			`accepted=${accepted}`,
+		);
+
+		const rejected = await client.send({ type: "compact" });
+		observed.rejection = { success: rejected.success, error: rejected.error ?? null };
+		checks.ok("compaction past the absolute cap is rejected", rejected.success === false);
+		checks.ok(
+			"the rejection names the absolute session cap, not the per-turn cap",
+			String(rejected.error ?? "").includes(REJECTION_NEEDLE),
+			`error=${String(rejected.error ?? "").slice(0, 160)}`,
+		);
+
+		const afterRejection = await runPrompt(client, "post-rejection prompt: the session must keep working");
+		observed.promptAfterRejection = afterRejection.terminal.type;
+		checks.ok(
+			"the cap rejection is non-fatal: the next prompt completes through agent_end",
+			afterRejection.ack.success === true && afterRejection.terminal.type === "agent_end",
+		);
+	} finally {
+		client?.close();
+		await server?.stop();
+	}
+
+	checkRealAuthUnchanged(checks, guard);
+	writeFileSync(join(evidence, "observed.json"), `${JSON.stringify(observed, null, 2)}\n`);
+	box.cleanup();
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+await main();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Fixed
 
+- Fixed required compaction fatally ending a turn once the per-turn soft cap (3 accepted or ineffective
+  compactions) was reached. Compaction admission is now bounded only by the absolute session cap (10) and the
+  failure circuit breaker, so long turns that legitimately need more than three compactions keep running
+  (supersedes [#728](https://github.com/code-yeongyu/senpi/pull/728)).
 - Fixed interactive shutdown crashing with `setRawMode failed with errno: 5` when an SSH or PTY peer disappears before
   terminal raw-mode restoration. Senpi now completes the requested exit for dead terminals without hiding unexpected
   restoration failures ([#726](https://github.com/code-yeongyu/senpi/pull/726)).

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -374,7 +374,9 @@ function describeCompactionRejection(cause: CompactionRejectionCause): string {
 		case "circuit-breaker":
 			return "Compaction rejected: the compaction circuit breaker is open after repeated failures. Wait for the cooldown and retry.";
 		case "per-turn-cap":
-			return "Compaction rejected: per-turn compaction cap reached for this turn.";
+			// Historical cause identifier kept for extension-API stability; since the
+			// per-turn soft cap was removed it fires only at the absolute session cap.
+			return "Compaction rejected: absolute compaction cap reached for this session.";
 		case "stale-revision":
 			return "Compaction rejected: the session changed while the summary was being prepared. Retry compaction against the latest context.";
 	}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,12 @@
 # changes
 
+## Absolute-cap compaction rejection message (2026-08-05)
+
+- `describeCompactionRejection()` for `"per-turn-cap"` now reads "absolute compaction cap reached for
+  this session." The cause identifier is unchanged for extension-API stability; only the per-turn soft
+  cap was removed (see `extensions/builtin/compaction/changes.md`).
+- Expected merge-conflict zone: `agent-session.ts` around `describeCompactionRejection`.
+
 ## Bound provider-timeout retry continuations (2026-08-05)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/compaction
 
-Builtin extension #23 (last). Owns senpi's compaction pipeline: speculative compaction running in parallel with the next turn, blocking compaction at the hard context limit, proactive compaction near the soft limit, degradation monitoring, circuit breaker, per-turn cap, todo bridging, checkpoint state, restoration tracker, and tool-result truncation. Policy-rich; touch with policy tests in lock-step. See `changes.md` for the restoration tracker rationale.
+Builtin extension #23 (last). Owns senpi's compaction pipeline: speculative compaction running in parallel with the next turn, blocking compaction at the hard context limit, proactive compaction near the soft limit, degradation monitoring, circuit breaker, absolute session cap, todo bridging, checkpoint state, restoration tracker, and tool-result truncation. Policy-rich; touch with policy tests in lock-step. See `changes.md` for the restoration tracker rationale.
 
 ## FILES
 
@@ -19,7 +19,7 @@ compaction/
 ├── circuit-breaker.ts        # N consecutive failures → halt automatic compaction
 ├── degradation-monitor.ts    # Detects post-compact assistant degradation (all-tool, no-text turns)
 ├── log.ts                    # Always-on compaction logging + debug stderr mirror
-├── per-turn-cap.ts           # Max compactions per turn rate-limiter
+├── per-turn-cap.ts           # Absolute session compaction cap (per-turn soft cap removed 2026-08-05)
 ├── task-intent.ts            # Extracts/persists/reinjects task-intent anchors across compaction
 ├── tool-truncation.ts        # Emergency/compaction-budget truncation for oversized bash/read results
 ├── yield.ts                  # Structural yield capture and ineffective-compaction accounting

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,40 @@
 # Builtin compaction extension changes
 
+## Remove the fatal per-turn compaction soft cap (2026-08-05)
+
+### What changed
+
+- `per-turn-cap.ts` no longer exports `softCap`/`isOverSoftCap`; `shouldRejectByCap()` takes only the
+  state and rejects solely on the absolute session cap (`hardCap = 10` accepted compactions).
+- The manual/extension bypass options were removed together with the soft cap: below the absolute cap
+  there is nothing left to bypass, and the absolute cap already bound every route since 2026-08-03.
+- The `session_before_compact` cap rejection keeps the historical `rejectionCause: "per-turn-cap"`
+  identifier for extension-API stability but now reports `absolute compaction cap reached for this
+  session` and logs `acceptedAbsolute` instead of the per-turn counter.
+- Turn-end zero-yield recovery is admitted again after ineffective attempts (bounded by the absolute cap
+  and the circuit breaker) instead of being starved by the combined per-turn counter.
+- `acceptedThisTurn`/`ineffectiveAttemptsThisTurn` remain in state as per-turn observability counters and
+  still reset on `turn_end`/`agent_end`.
+
+### Why
+
+- The soft cap counted accepted + ineffective compactions per turn and rejected required
+  (overflow/blocking) compactions once it reached 3. A long tool-heavy turn that legitimately needed a
+  fourth compaction had its required compaction rejected, fatally ending the turn. First reported and
+  attempted in [#728](https://github.com/code-yeongyu/senpi/pull/728) by @realsigridjin; this entry lands
+  the same intent with the changelog/docs/QA gates satisfied.
+- Runaway protection is preserved by the absolute session cap (10) and the failure circuit breaker.
+
+### Why an extension could not do this
+
+- Cap admission runs inside the builtin compaction extension's own `session_before_compact` and blocking
+  routes; an external extension cannot override another extension's cancel decision.
+
+### Expected merge-conflict zones
+
+- `per-turn-cap.ts` (whole file), `index.ts` around the `session_before_compact` cap check, and the cap
+  tests under `test/compaction/`.
+
 ## Treat caller-aborted summary stream failures as cancellation (2026-08-03)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -475,12 +475,12 @@ export default function compactionExtension(
 		if (lanePolicy.disablesSenpiCompaction(ctx)) {
 			return { cancel: true, reason: SDK_NATIVE_LANE_REJECTION_REASON };
 		}
-		if (cap.shouldRejectByCap(state, { reason: event.reason }).cancel) {
-			getLogger(ctx).debug("skip_cap", { reason: event.reason, count: state.acceptedThisTurn });
+		if (cap.shouldRejectByCap(state).cancel) {
+			getLogger(ctx).debug("skip_cap", { reason: event.reason, count: state.acceptedAbsolute });
 			return {
 				cancel: true,
 				rejectionCause: "per-turn-cap",
-				reason: "per-turn compaction cap reached for this turn",
+				reason: "absolute compaction cap reached for this session",
 			};
 		}
 		const now = Date.now();

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/per-turn-cap.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/per-turn-cap.ts
@@ -1,13 +1,6 @@
-import type { CompactionReason } from "../../types.ts";
 import type { CompactionExtensionState } from "./state.ts";
 
-export const softCap = 3;
 export const hardCap = 10;
-
-export interface ShouldRejectByCapOptions {
-	manual?: boolean;
-	reason?: CompactionReason;
-}
 
 export function incrementAccepted(state: CompactionExtensionState): CompactionExtensionState {
 	return {
@@ -24,27 +17,17 @@ export function incrementIneffective(state: CompactionExtensionState): Compactio
 	};
 }
 
-export function isOverSoftCap(state: CompactionExtensionState): boolean {
-	return state.acceptedThisTurn + (state.ineffectiveAttemptsThisTurn ?? 0) >= softCap;
-}
-
 export function isOverHardCap(state: CompactionExtensionState): boolean {
 	return state.acceptedAbsolute >= hardCap;
 }
 
-export function shouldRejectByCap(
-	state: CompactionExtensionState,
-	opts?: ShouldRejectByCapOptions,
-): { cancel: boolean } {
-	if (isOverHardCap(state)) {
-		return { cancel: true };
-	}
-	const bypass = opts?.manual === true || opts?.reason === "manual" || opts?.reason === "extension";
-	if (bypass) {
-		return { cancel: false };
-	}
-	if (isOverSoftCap(state)) {
-		return { cancel: true };
-	}
-	return { cancel: false };
+/**
+ * Admission is bounded only by the absolute session cap. The former per-turn
+ * soft cap (3 accepted + ineffective attempts) rejected required compactions
+ * mid-turn, which fatally ended turns that legitimately needed more than three
+ * compactions. Runaway protection remains: `hardCap` bounds accepted
+ * compactions per session and the circuit breaker halts repeated failures.
+ */
+export function shouldRejectByCap(state: CompactionExtensionState): { cancel: boolean } {
+	return { cancel: isOverHardCap(state) };
 }

--- a/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
@@ -2,13 +2,15 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FAILURE_TRIP_THRESHOLD } from "../../src/core/extensions/builtin/compaction/circuit-breaker.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
-import { softCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
+import { hardCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
 import type { ExtensionHandler } from "../../src/core/extensions/index.ts";
 import {
 	connectionErrorResponse,
 	createBeforeAgentStartEvent,
 	createBlockingContext,
 } from "../helpers/blocking-compaction-harness.ts";
+
+const FORMER_SOFT_CAP = 3;
 
 const registrations: Array<{ unregister: () => void }> = [];
 
@@ -64,7 +66,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 		expect(harness.registration.state.callCount).toBe(FAILURE_TRIP_THRESHOLD);
 	});
 
-	it("bounds successful hard-limit blocking compactions by the soft cap", async () => {
+	it("bounds successful hard-limit blocking compactions by the absolute session cap", async () => {
 		const handlers = captureHandlers();
 		const beforeAgentStart = handlers.get("before_agent_start");
 		const sessionCompact = handlers.get("session_compact");
@@ -72,7 +74,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 		expect(sessionCompact).toBeDefined();
 		const harness = createBlockingContext({ usageTokens: 9_950 });
 		registrations.push(harness.registration);
-		const attempts = softCap * 4;
+		const attempts = hardCap + 2;
 		harness.registration.setResponses(
 			Array.from({ length: attempts }, () => fauxAssistantMessage("## Goal\ncompact summary")),
 		);
@@ -86,34 +88,31 @@ describe("blocking compaction route guards (issue #527)", () => {
 			}
 		}
 
-		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(softCap);
+		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(hardCap);
 	});
 
-	it("admits compaction again after the provider turn ends", async () => {
+	it("admits a compaction past the former soft cap within the same provider turn", async () => {
 		const handlers = captureHandlers();
 		const beforeAgentStart = handlers.get("before_agent_start");
 		const sessionCompact = handlers.get("session_compact");
-		const turnEnd = handlers.get("turn_end");
 		expect(beforeAgentStart).toBeDefined();
 		expect(sessionCompact).toBeDefined();
-		expect(turnEnd).toBeDefined();
 		const harness = createBlockingContext({ usageTokens: 9_950 });
 		registrations.push(harness.registration);
 		harness.registration.setResponses(
-			Array.from({ length: softCap + 1 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
+			Array.from({ length: FORMER_SOFT_CAP + 1 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
 		);
 
-		for (let round = 0; round < softCap; round++) {
+		for (let round = 0; round < FORMER_SOFT_CAP; round++) {
 			await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
 			await sessionCompact?.(acceptedCompactionEvent(round, 8_000) as never, harness.ctx);
 		}
-		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
 		await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
 
-		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(softCap + 1);
+		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(FORMER_SOFT_CAP + 1);
 	});
 
-	it("resets the soft cap on turn_end even after degradation recovery fires", async () => {
+	it("keeps admission open across turn_end even after degradation recovery fires", async () => {
 		const handlers = captureHandlers();
 		const beforeAgentStart = handlers.get("before_agent_start");
 		const sessionCompact = handlers.get("session_compact");
@@ -126,11 +125,11 @@ describe("blocking compaction route guards (issue #527)", () => {
 		const harness = createBlockingContext({ usageTokens: 9_950 });
 		registrations.push(harness.registration);
 		harness.registration.setResponses(
-			Array.from({ length: softCap + 2 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
+			Array.from({ length: FORMER_SOFT_CAP + 2 }, () => fauxAssistantMessage("## Goal\ncompact summary")),
 		);
 
-		// Fill the soft cap with accepted compactions this provider turn.
-		for (let round = 0; round < softCap; round++) {
+		// Fill the former soft cap with accepted compactions this provider turn.
+		for (let round = 0; round < FORMER_SOFT_CAP; round++) {
 			await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
 			await sessionCompact?.(acceptedCompactionEvent(round, 8_000) as never, harness.ctx);
 		}
@@ -150,12 +149,12 @@ describe("blocking compaction route guards (issue #527)", () => {
 		}
 		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
 
-		// The next provider turn must open at a fresh soft counter and admit.
+		// The next provider turn must still admit below the absolute cap.
 		await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
 		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(appliedAtCap);
 	});
 
-	it("counts zero-yield attempts before admitting turn-end recovery", async () => {
+	it("admits turn-end recovery after zero-yield attempts", async () => {
 		const handlers = captureHandlers();
 		const turnEnd = handlers.get("turn_end");
 		const sessionCompact = handlers.get("session_compact");
@@ -172,6 +171,6 @@ describe("blocking compaction route guards (issue #527)", () => {
 		await sessionCompact?.(acceptedCompactionEvent(1, 0) as never, harness.ctx);
 		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
 
-		expect(beginCompaction).not.toHaveBeenCalled();
+		expect(beginCompaction).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/compaction/ineffective-cap.test.ts
+++ b/packages/coding-agent/test/compaction/ineffective-cap.test.ts
@@ -1,6 +1,6 @@
 import { registerFauxProvider } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
-import { incrementAccepted, isOverSoftCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
+import { incrementAccepted, shouldRejectByCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
 import { createInitialState, resetTurnCounter } from "../../src/core/extensions/builtin/compaction/state.ts";
 import { computeStructuralYield, isIneffectiveCompaction } from "../../src/core/extensions/builtin/compaction/yield.ts";
 
@@ -79,14 +79,14 @@ describe("compaction ineffective cap", () => {
 	});
 
 	describe("Given a turn with two accepted compactions and one ineffective attempt", () => {
-		it("Then the 4th auto compaction is rejected by the cap", () => {
+		it("Then the next auto compaction stays admitted and turn counters still reset", () => {
 			registerFauxProvider();
 			let state = createInitialState();
 			state = acceptN(state, 2);
 			state = { ...state, ineffectiveAttemptsThisTurn: 1 };
-			expect(isOverSoftCap(state)).toBe(true);
+			expect(shouldRejectByCap(state)).toEqual({ cancel: false });
 			state = incrementAccepted(state);
-			expect(isOverSoftCap(state)).toBe(true);
+			expect(shouldRejectByCap(state)).toEqual({ cancel: false });
 			state = resetTurnCounter(state, "turn-1");
 			expect(state.acceptedThisTurn).toBe(0);
 			expect(state.ineffectiveAttemptsThisTurn).toBe(0);

--- a/packages/coding-agent/test/compaction/per-turn-cap.test.ts
+++ b/packages/coding-agent/test/compaction/per-turn-cap.test.ts
@@ -5,39 +5,31 @@ import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
 	hardCap,
 	incrementAccepted,
+	incrementIneffective,
 	shouldRejectByCap,
-	softCap,
 } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
-import { resetTurnCounter } from "../../src/core/extensions/builtin/compaction/state.ts";
+import {
+	type CompactionExtensionState,
+	createInitialState,
+	resetTurnCounter,
+} from "../../src/core/extensions/builtin/compaction/state.ts";
 import { migrateSessionEntries, parseSessionEntries, type SessionEntry } from "../../src/core/session-manager.ts";
 
-interface FutureCapState {
-	acceptedThisTurn: number;
-	acceptedAbsolute: number;
-}
-
-type IncrementAcceptedFn = (state: FutureCapState) => FutureCapState;
-type ShouldRejectByCapFn = (
-	state: FutureCapState,
-	opts?: { manual?: boolean; reason?: "manual" | "extension" },
-) => { cancel: boolean };
-type ResetTurnCounterFn = (state: FutureCapState) => FutureCapState;
-
-const incrementAcceptedFuture = incrementAccepted as unknown as IncrementAcceptedFn;
-const shouldRejectByCapFuture = shouldRejectByCap as unknown as ShouldRejectByCapFn;
-const resetTurnCounterFuture = resetTurnCounter as unknown as ResetTurnCounterFn;
-
-const EXPECTED_SOFT_CAP = 3;
+const FORMER_SOFT_CAP = 3;
 const EXPECTED_HARD_CAP = 10;
 
-function createInitialCapState(): FutureCapState {
-	return { acceptedThisTurn: 0, acceptedAbsolute: 0 };
-}
-
-function acceptN(state: FutureCapState, n: number): FutureCapState {
+function acceptN(state: CompactionExtensionState, n: number): CompactionExtensionState {
 	let next = state;
 	for (let i = 0; i < n; i++) {
-		next = incrementAcceptedFuture(next);
+		next = incrementAccepted(next);
+	}
+	return next;
+}
+
+function ineffectiveN(state: CompactionExtensionState, n: number): CompactionExtensionState {
+	let next = state;
+	for (let i = 0; i < n; i++) {
+		next = incrementIneffective(next);
 	}
 	return next;
 }
@@ -67,96 +59,82 @@ beforeAll(() => {
 	perTurnFixtureEntries = entries.filter((entry): entry is SessionEntry => entry.type !== "session");
 });
 
-describe("compaction per-turn cap", () => {
-	describe("Given a fresh turn with the soft cap of 3 accepted compactions", () => {
-		describe("When 3 compactions are accepted and a 4th is checked", () => {
-			it("Then the 4th compaction is rejected with { cancel: true }", () => {
+describe("compaction absolute cap", () => {
+	describe("Given the former per-turn soft cap of 3 accepted compactions this turn", () => {
+		describe("When a 4th required compaction is checked in the same turn", () => {
+			it("Then it is admitted instead of fatally ending the turn", () => {
 				const registration = registerFauxProvider();
 				registrations.push(registration);
 
-				expect(softCap).toBe(EXPECTED_SOFT_CAP);
 				const compactionEntries = perTurnFixtureEntries.filter((entry) => entry.type === "compaction");
-				expect(compactionEntries.length).toBeGreaterThanOrEqual(EXPECTED_SOFT_CAP + 1);
+				expect(compactionEntries.length).toBeGreaterThanOrEqual(FORMER_SOFT_CAP + 1);
 
-				const stateAfterThree = acceptN(createInitialCapState(), EXPECTED_SOFT_CAP);
-				const decision = shouldRejectByCapFuture(stateAfterThree);
+				const stateAfterThree = acceptN(createInitialState(), FORMER_SOFT_CAP);
 
-				expect(stateAfterThree.acceptedThisTurn).toBe(EXPECTED_SOFT_CAP);
-				expect(decision).toEqual({ cancel: true });
+				expect(stateAfterThree.acceptedThisTurn).toBe(FORMER_SOFT_CAP);
+				expect(stateAfterThree.acceptedAbsolute).toBe(FORMER_SOFT_CAP);
+				expect(shouldRejectByCap(stateAfterThree)).toEqual({ cancel: false });
 			});
 		});
 	});
 
-	describe("Given the soft cap has been reached this turn", () => {
+	describe("Given 3 ineffective compaction attempts this turn", () => {
+		describe("When the next required compaction is checked", () => {
+			it("Then it is admitted instead of fatally ending the turn", () => {
+				const stateAfterIneffective = ineffectiveN(createInitialState(), FORMER_SOFT_CAP);
+
+				expect(stateAfterIneffective.ineffectiveAttemptsThisTurn).toBe(FORMER_SOFT_CAP);
+				expect(shouldRejectByCap(stateAfterIneffective)).toEqual({ cancel: false });
+			});
+		});
+	});
+
+	describe("Given accepted compactions below the absolute cap", () => {
 		describe("When the turn ends and resetTurnCounter is applied", () => {
-			it("Then the per-turn counter resets to 0 and the next compaction is accepted", () => {
+			it("Then admission is open before and after the reset", () => {
 				const registration = registerFauxProvider();
 				registrations.push(registration);
 
-				const stateAtCap = acceptN(createInitialCapState(), EXPECTED_SOFT_CAP);
-				expect(shouldRejectByCapFuture(stateAtCap)).toEqual({ cancel: true });
+				const stateBeforeReset = acceptN(createInitialState(), FORMER_SOFT_CAP);
+				expect(shouldRejectByCap(stateBeforeReset)).toEqual({ cancel: false });
 
-				const stateAfterTurnEnd = resetTurnCounterFuture(stateAtCap);
+				const stateAfterTurnEnd = resetTurnCounter(stateBeforeReset, "turn-1");
 
 				expect(stateAfterTurnEnd.acceptedThisTurn).toBe(0);
-				expect(shouldRejectByCapFuture(stateAfterTurnEnd)).toEqual({ cancel: false });
-			});
-		});
-	});
-
-	describe("Given the soft cap has been reached and the absolute hard cap is 10", () => {
-		describe("When a manual /compact is checked with manual: true", () => {
-			it("Then the cap is bypassed and the manual compaction is accepted", () => {
-				const registration = registerFauxProvider();
-				registrations.push(registration);
-
-				expect(hardCap).toBe(EXPECTED_HARD_CAP);
-
-				const stateAtSoftCap: FutureCapState = {
-					acceptedThisTurn: EXPECTED_SOFT_CAP,
-					acceptedAbsolute: EXPECTED_SOFT_CAP,
-				};
-				expect(shouldRejectByCapFuture(stateAtSoftCap)).toEqual({ cancel: true });
-
-				const manualDecision = shouldRejectByCapFuture(stateAtSoftCap, { manual: true });
-
-				expect(manualDecision).toEqual({ cancel: false });
-				expect(stateAtSoftCap.acceptedAbsolute).toBeLessThan(EXPECTED_HARD_CAP);
+				expect(stateAfterTurnEnd.acceptedAbsolute).toBe(FORMER_SOFT_CAP);
+				expect(shouldRejectByCap(stateAfterTurnEnd)).toEqual({ cancel: false });
 			});
 		});
 	});
 
 	describe("Given accepted compactions reach the absolute cap across provider turns", () => {
-		it("Then the next automatic compaction is rejected after each soft counter reset", () => {
-			let state = createInitialCapState();
+		it("Then every further compaction is rejected, even after a turn reset", () => {
+			expect(hardCap).toBe(EXPECTED_HARD_CAP);
+
+			let state = createInitialState();
 			for (let accepted = 0; accepted < EXPECTED_HARD_CAP; accepted++) {
-				state = incrementAcceptedFuture(state);
-				state = resetTurnCounterFuture(state);
+				state = incrementAccepted(state);
+				state = resetTurnCounter(state, `turn-${accepted}`);
 			}
 
 			expect(state.acceptedThisTurn).toBe(0);
 			expect(state.acceptedAbsolute).toBe(EXPECTED_HARD_CAP);
-			expect(shouldRejectByCapFuture(state)).toEqual({ cancel: true });
-			expect(shouldRejectByCapFuture(state, { manual: true })).toEqual({ cancel: true });
-			expect(shouldRejectByCapFuture(state, { reason: "manual" })).toEqual({ cancel: true });
-			expect(shouldRejectByCapFuture(state, { reason: "extension" })).toEqual({ cancel: true });
+			expect(shouldRejectByCap(state)).toEqual({ cancel: true });
+			expect(shouldRejectByCap(resetTurnCounter(state, "turn-final"))).toEqual({ cancel: true });
 		});
 	});
 
-	describe("Given the soft cap was reached and the session is reloaded with fresh in-memory state", () => {
-		describe("When the per-turn counter is read on the reloaded state", () => {
-			it("Then the counter is 0 and the next compaction is accepted", () => {
+	describe("Given the session is reloaded with fresh in-memory state", () => {
+		describe("When admission is checked on the reloaded state", () => {
+			it("Then the counters are 0 and the next compaction is accepted", () => {
 				const registration = registerFauxProvider();
 				registrations.push(registration);
 
-				const preReloadState = acceptN(createInitialCapState(), EXPECTED_SOFT_CAP);
-				expect(preReloadState.acceptedThisTurn).toBe(EXPECTED_SOFT_CAP);
-
-				const reloadedState = createInitialCapState();
+				const reloadedState = createInitialState();
 
 				expect(reloadedState.acceptedThisTurn).toBe(0);
 				expect(reloadedState.acceptedAbsolute).toBe(0);
-				expect(shouldRejectByCapFuture(reloadedState)).toEqual({ cancel: false });
+				expect(shouldRejectByCap(reloadedState)).toEqual({ cancel: false });
 			});
 		});
 	});

--- a/packages/coding-agent/test/fixtures/compaction/README.md
+++ b/packages/coding-agent/test/fixtures/compaction/README.md
@@ -13,7 +13,7 @@ Per-feature fixtures establish a **behavioral contract** between each subsystem 
 | # | Directory | File | Purpose | Entries |
 |---|-----------|------|---------|---------|
 | 1 | `adaptive-threshold/` | `16k-near-threshold.jsonl` | Context near 16k limit, triggers proactive compaction | 7 |
-| 2 | `per-turn-cap/` | `four-back-to-back-compactions.jsonl` | Four compactions in one turn, tests rate limiting | 11 |
+| 2 | `per-turn-cap/` | `four-back-to-back-compactions.jsonl` | Four compactions in one turn, tests absolute-cap admission | 11 |
 | 3 | `circuit-breaker/` | `three-failures-then-success.jsonl` | Three failed compactions then recovery | 11 |
 | 4 | `pre-prune/` | `oversized-with-pairs.jsonl` | Interleaved tool_call/tool_result with large content | 20 |
 | 5 | `tool-truncation/` | `large-bash-output.jsonl` | Bash output exceeding token limits | 7 |

--- a/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/compaction-rejection-feedback.test.ts
@@ -94,7 +94,7 @@ describe("Regression: manual /compact silent rejection", () => {
 					pi.on("session_before_compact", async () => ({
 						cancel: true,
 						rejectionCause: "per-turn-cap" as const,
-						reason: "per-turn compaction cap reached",
+						reason: "absolute compaction cap reached for this session",
 					}));
 				},
 			],
@@ -108,7 +108,7 @@ describe("Regression: manual /compact silent rejection", () => {
 		expect(compactionEnd).toBeDefined();
 		expect(compactionEnd?.accepted).toBe(false);
 		expect(compactionEnd?.rejectionCause).toBe("per-turn-cap");
-		expect(compactionEnd?.errorMessage ?? "").toContain("per-turn compaction cap reached");
+		expect(compactionEnd?.errorMessage ?? "").toContain("absolute compaction cap reached for this session");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Remove the fatal per-turn compaction soft cap (3 accepted + ineffective attempts per turn): required compactions mid-turn are no longer rejected, so long tool-heavy turns that legitimately need more than three compactions keep running.
- Admission is now bounded only by the absolute session cap (10 accepted compactions) plus the existing failure circuit breaker.
- The rejection keeps the historical `per-turn-cap` cause identifier for extension-API stability but now reports "absolute compaction cap reached for this session" (previously the absolute-cap rejection was mislabeled as a per-turn cap).
- Turn-end zero-yield recovery is admitted again after ineffective attempts instead of being starved by the combined per-turn counter.

## Credit

This lands the intent of #728 by @realsigridjin — same policy outcome, reworked to clear the repository gates that PR could not pass:

- `CHANGELOG.md` `[Unreleased]` entry (the Changelog gate failure on #728),
- fork-tracker entries in `builtin/compaction/changes.md` and `core/changes.md`,
- `AGENTS.md`/fixtures doc sync,
- a committed senpi-qa RPC scenario with captured evidence.

Closes #728.

## Validation

- RED->GREEN: rewritten `test/compaction/per-turn-cap.test.ts`, `ineffective-cap.test.ts`, `blocking-compaction-route-guards.test.ts` captured failing on unchanged source (6 failures for the right reason), green after the change.
- `npx vitest run test/compaction test/suite/regressions/compaction-rejection-feedback.test.ts`: 53 files / 394 tests pass.
- `npm run check`: exit 0.
- senpi-qa (RPC channel, fake Anthropic server, hermetic sandbox): `node .agents/skills/senpi-qa/scripts/scenarios/compaction-absolute-cap-qa.mjs --self-test` -> 6/6 PASS: 10 compactions accepted in one session (former soft cap 3), the 11th rejected with "Compaction rejected: absolute compaction cap reached for this session.", rejection non-fatal (next prompt completes). Baseline run on unchanged `main` fails exactly the message check with the old "per-turn compaction cap reached for this turn." wording, proving the user-visible delta. Evidence under `local-ignore/qa-evidence/20260805-*` (gitignored receipts).
- `mock-loop.mjs --self-test`: PASS (generic agent-loop regression).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the per‑turn compaction soft cap so required compactions are admitted mid‑turn up to the absolute session cap (10), preventing fatal turn ends on long tool‑heavy turns. The rejection now names the absolute session cap and remains non‑fatal.

- **Bug Fixes**
  - Admit required/proactive/blocking compactions until 10 accepted per session; still guarded by the failure circuit breaker.
  - Keep the `per-turn-cap` cause for extension API stability; message now says "absolute compaction cap reached for this session".
  - Restore turn‑end zero‑yield recovery admission (no starvation from a per‑turn counter).
  - Update docs/tests and add an RPC QA scenario to verify 10 accepts and a non‑fatal 11th rejection.

- **Migration**
  - No changes needed. If you check rejection text, update to the new message; the cause identifier stays `per-turn-cap`.

<sup>Written for commit 4a71af325d6cb096afae5a6d656c329ecd216451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

