### PR TITLE
fix(ai): normalize Responses tool schemas

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Fixed OpenAI Responses function tools forwarding unnormalized object-shaped
+  root unions, so MCP parameter schemas retain a required `type: "object"`
+  root (follow-up to [#718](https://github.com/code-yeongyu/senpi/pull/718)).
+
 ### Removed
 
 ## [2026.8.5-2] - 2026-08-05

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -40,6 +40,7 @@ import type { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { shortHash } from "../utils/hash.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
+import { normalizeToolParametersForOpenAICompat } from "../utils/tool-schema-compat.ts";
 import {
 	appendGrammarToolInputJsonDelta,
 	type GrammarToolInputJsonBuffer,
@@ -526,6 +527,7 @@ export function convertResponsesTools(tools: readonly Tool[], options?: ConvertR
 			} as OpenAITool;
 		}
 
+		const parameters = normalizeToolParametersForOpenAICompat(tool.parameters as Record<string, unknown>);
 		const constrainedStrict = resolveJsonSchemaStrictSampling(tool, supportsStrictMode);
 		const functionTool: Omit<ResponseFunctionTool, "strict"> & {
 			strict?: ResponseFunctionTool["strict"];
@@ -533,7 +535,7 @@ export function convertResponsesTools(tools: readonly Tool[], options?: ConvertR
 			type: "function",
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters as ResponseFunctionTool["parameters"], // TypeBox already generates JSON Schema
+			parameters: parameters as ResponseFunctionTool["parameters"],
 			...(options?.deferLoading ? { defer_loading: true } : {}),
 		};
 		if (supportsStrictMode) {

--- a/packages/ai/test/xai-responses.test.ts
+++ b/packages/ai/test/xai-responses.test.ts
@@ -114,4 +114,55 @@ describe("xAI Responses provider", () => {
 			]),
 		);
 	});
+
+	it("normalizes root-union function schemas for Grok 4.5", async () => {
+		const captured = await captureRequest(
+			XAI_MODELS["grok-4.5"],
+			{
+				messages: [{ role: "user", content: "scan the repository", timestamp: 1 }],
+				tools: [
+					{
+						name: "mcp__ast_grep_scan",
+						description: "Scan files with an ast-grep rule",
+						parameters: {
+							anyOf: [
+								{
+									type: "object",
+									properties: { ruleFile: { type: "string" } },
+									required: ["ruleFile"],
+								},
+								{
+									type: "object",
+									properties: { inlineRules: { type: "string" } },
+									required: ["inlineRules"],
+								},
+							],
+						},
+					},
+				],
+			},
+			{ apiKey: "xai-test-token" },
+		);
+
+		expect(captured.body.tools).toMatchObject([
+			{
+				type: "function",
+				name: "mcp__ast_grep_scan",
+				parameters: {
+					type: "object",
+					properties: {
+						ruleFile: { type: "string" },
+						inlineRules: { type: "string" },
+					},
+				},
+			},
+		]);
+		expect(captured.body.tools).not.toMatchObject([
+			{
+				parameters: {
+					anyOf: expect.anything(),
+				},
+			},
+		]);
+	});
 });


### PR DESCRIPTION
## Summary
- apply the existing OpenAI-compatible tool-schema normalizer to Responses function tools
- cover the xAI Grok 4.5 request path with an object-shaped root-union regression
- document this as the Responses-path follow-up to #718

## Validation
- `npm --prefix packages/ai run test -- xai-responses.test.ts`
- `npm --prefix packages/ai test`
- repository TypeScript validation
- pre-commit `npm run check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Responses function tool schemas to always send an object-root `parameters`, preventing unnormalized root unions from being forwarded. Fixes the xAI `grok-4.5` request path and preserves MCP schemas with a required `type: "object"` root (follow-up to #718).

- **Bug Fixes**
  - Applied `normalizeToolParametersForOpenAICompat` in `convertResponsesTools` so top-level `anyOf` is flattened into an object-root schema.
  - Added a test for `grok-4.5` to verify normalized function tool `parameters`.
  - Updated `packages/ai/CHANGELOG.md`.

<sup>Written for commit f59ded74c8357877db6dcb3857d1412ab3ac4c5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

