### PR TITLE
feat(compaction): optional compaction.model override + re-enable senpi compaction on SDK-native claude-sdk-oauth lanes

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -860,6 +860,24 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Resolve the model used for compaction summarization. When the user sets a
+	 * `compaction.model` override ("provider/model"), that model is used for the
+	 * summarization call instead of the session model — this is what lets an
+	 * SDK-owned lane (claude-sdk-oauth) compact on a cheaper/different model.
+	 * Any resolution failure (unset, malformed, unknown model) falls back to the
+	 * session model so compaction never silently breaks.
+	 */
+	private _resolveCompactionModel(sessionModel: Model<any>): Model<any> {
+		const override = this.settingsManager.getCompactionSettings().model;
+		if (!override) return sessionModel;
+		const slash = override.indexOf("/");
+		if (slash <= 0 || slash === override.length - 1) return sessionModel;
+		const provider = override.slice(0, slash);
+		const modelId = override.slice(slash + 1);
+		return this._modelRuntime.getModel(provider, modelId) ?? sessionModel;
+	}
+
 	private async _getCompactionRequestAuth(model: Model<any>): Promise<{
 		apiKey?: string;
 		headers?: Record<string, string>;
@@ -4193,10 +4211,16 @@ export class AgentSession {
 				}
 
 				if (!compactionResult) {
-					const { apiKey, headers, extraBody, env } = await this._getCompactionRequestAuth(model);
+					// A configured compaction.model override redirects only the
+					// summarization call to that model; every other part of the session
+					// (lifecycle record, preparation, branch) still tracks the session
+					// model. Falls back to the session model when the override is unset
+					// or cannot be resolved.
+					const compactionModel = this._resolveCompactionModel(model);
+					const { apiKey, headers, extraBody, env } = await this._getCompactionRequestAuth(compactionModel);
 					compactionResult = await compact(
 						preparation,
-						model,
+						compactionModel,
 						apiKey,
 						headers,
 						request.customInstructions,

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -161,6 +161,8 @@ export interface CompactionSettings {
 	restorationMaxTotalTokens?: number;
 	restorationContextRatio?: number;
 	idleCompactionEnabled?: boolean;
+	/** Optional "provider/model" override for the compaction summarization model. */
+	model?: string;
 }
 
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/lane-policy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/lane-policy.ts
@@ -46,6 +46,13 @@ export interface SdkNativeLaneInput {
 export interface LaneContext {
 	cwd: string;
 	model: LaneModel | undefined;
+	/**
+	 * Optional resolved-settings getter (present on the real ExtensionContext).
+	 * Used to read a configured `compaction.model` override. When an override is
+	 * set the lane hands summarization to a senpi-owned model, so the SDK-native
+	 * stand-down no longer applies even with a resident SDK session.
+	 */
+	getCompactionSettings?: () => { model?: string };
 }
 
 export interface CompactionLanePolicy {
@@ -87,6 +94,10 @@ export function createCompactionLanePolicy(
 	return {
 		disablesSenpiCompaction(context: LaneContext): boolean {
 			if (context.model?.provider !== CLAUDE_SDK_OAUTH_PROVIDER_ID) return false;
+			// A configured compaction model override makes senpi own summarization
+			// for the lane, so the SDK-native stand-down no longer applies. This is
+			// the escape hatch for lanes whose SDK never fires native compaction.
+			if (context.getCompactionSettings?.().model) return false;
 			// Per-cwd cache is the intended contract (pinned by lane-policy.test.ts):
 			// resumeMode is read once per cwd. A mid-session switch takes effect on
 			// the next cwd or session.

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -39,6 +39,13 @@ export interface CompactionSettings {
 	restorationMaxTotalTokens?: number; // default: 50000
 	restorationContextRatio?: number; // default: 0.15
 	idleCompactionEnabled?: boolean; // default: true
+	/**
+	 * Optional compaction model override as "provider/model" (e.g. "deepseek/deepseek-chat").
+	 * When set, compaction summarization runs on this model instead of the session model,
+	 * and a configured override re-enables senpi compaction on SDK-owned lanes
+	 * (claude-sdk-oauth with a resident session) whose own compaction never fires.
+	 */
+	model?: string; // default: undefined (use session model)
 }
 
 export interface BranchSummarySettings {
@@ -947,6 +954,7 @@ export class SettingsManager {
 		restorationMaxTotalTokens: number;
 		restorationContextRatio: number;
 		idleCompactionEnabled: boolean;
+		model?: string;
 	} {
 		return {
 			enabled: this.getCompactionEnabled(),
@@ -961,6 +969,7 @@ export class SettingsManager {
 			restorationMaxTotalTokens: this.settings.compaction?.restorationMaxTotalTokens ?? 50_000,
 			restorationContextRatio: this.settings.compaction?.restorationContextRatio ?? 0.15,
 			idleCompactionEnabled: this.settings.compaction?.idleCompactionEnabled ?? true,
+			model: this.settings.compaction?.model,
 		};
 	}
 

--- a/packages/coding-agent/test/compaction/idle-settings.test.ts
+++ b/packages/coding-agent/test/compaction/idle-settings.test.ts
@@ -12,3 +12,15 @@ describe("idleCompactionEnabled setting", () => {
 		expect(sm.getCompactionSettings().idleCompactionEnabled).toBe(false);
 	});
 });
+
+describe("compaction model override setting", () => {
+	it("defaults to undefined", () => {
+		const sm = SettingsManager.inMemory();
+		expect(sm.getCompactionSettings().model).toBeUndefined();
+	});
+
+	it("passes through a configured provider/model override", () => {
+		const sm = SettingsManager.inMemory({ compaction: { model: "deepseek/deepseek-chat" } });
+		expect(sm.getCompactionSettings().model).toBe("deepseek/deepseek-chat");
+	});
+});

--- a/packages/coding-agent/test/compaction/lane-policy.test.ts
+++ b/packages/coding-agent/test/compaction/lane-policy.test.ts
@@ -105,6 +105,41 @@ describe("compaction lane policy — instance policy", () => {
 
 		expect(policy.disablesSenpiCompaction({ cwd: "/repo", model: { provider: "claude-sdk-oauth" } })).toBe(false);
 	});
+
+	it("re-enables senpi compaction on the SDK-native lane when a compaction model override is set", () => {
+		const policy = createCompactionLanePolicy({
+			loadProviderSettings: () => ({ resumeMode: "auto" }),
+		});
+		const ctx = {
+			cwd: "/repo",
+			model: { provider: "claude-sdk-oauth" },
+			getCompactionSettings: () => ({ model: "deepseek/deepseek-chat" }),
+		};
+
+		// The override makes senpi own summarization, so the stand-down lifts.
+		expect(policy.disablesSenpiCompaction(ctx)).toBe(false);
+	});
+
+	it("still stands down on the SDK-native lane when the override resolves to no model", () => {
+		const policy = createCompactionLanePolicy({
+			loadProviderSettings: () => ({ resumeMode: "auto" }),
+		});
+
+		expect(
+			policy.disablesSenpiCompaction({
+				cwd: "/repo",
+				model: { provider: "claude-sdk-oauth" },
+				getCompactionSettings: () => ({ model: undefined }),
+			}),
+		).toBe(true);
+		expect(
+			policy.disablesSenpiCompaction({
+				cwd: "/repo",
+				model: { provider: "claude-sdk-oauth" },
+				getCompactionSettings: () => ({}),
+			}),
+		).toBe(true);
+	});
 });
 
 describe("compaction lane policy — compact_boundary mirroring", () => {


### PR DESCRIPTION
## Problem

The `claude-sdk-oauth` lane keeps a resident Claude Agent SDK session, and the compaction lane policy (`lane-policy.ts`) stands down senpi compaction entirely on the assumption that the SDK runs its own native compaction. In practice that native compaction **never fires** for these sessions — senpi's `session.log` shows `threshold`/`pre_prompt` compactions repeatedly rejected with `the Claude Agent SDK owns compaction for this session` while context grows unbounded (observed past 335k tokens) until overflow, with no recovery path.

## Change

Add an optional **`compaction.model`** setting (`"provider/model"`, e.g. `deepseek/deepseek-chat`) that redirects *only* the compaction summarization call to a different model. When set:

1. **Lane policy** (`lane-policy.ts`): the SDK-native stand-down lifts, so senpi auto/threshold compaction runs on the lane again. This is the escape hatch for lanes whose SDK never compacts.
2. **Execution** (`agent-session.ts` → `_executeCompaction`): a new `_resolveCompactionModel()` resolves the override through the model runtime and uses it for the summarization auth (`_getCompactionRequestAuth`) + `compact()` call. Session bookkeeping (lifecycle record, preparation, branch) still tracks the *session* model, so history/diagnostics are unaffected.
3. **Safe fallback**: any resolution failure (unset / malformed `provider/model` / unknown model) falls back to the session model, so compaction can never silently break.

Default behavior is unchanged for every provider — with no override, nothing changes.

## Surface

- `CompactionSettings.model?: string` (`settings-manager.ts`, `compaction/compaction.ts`), exposed through `getCompactionSettings()`.
- `LaneContext` gains an optional `getCompactionSettings` getter so the lane policy can read the override.

## Validation

- New tests: lane-policy stand-down lift with override + continued stand-down when the override resolves to no model; settings `model` passthrough.
- `test/compaction/` suite: **47 files / 339 tests pass**.
- Root `npm run check` (biome + pinned-deps + ts-imports + shrinkwrap + `tsc --noEmit`): clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `compaction.model` override that redirects only the compaction summarization call to a specified model and re-enables senpi compaction on `claude-sdk-oauth` lanes when set. Prevents unbounded context growth when SDK-native compaction never fires, with no change to default behavior when unset.

- **New Features**
  - `compaction.model` accepts "provider/model" (e.g., `deepseek/deepseek-chat`); used only for summarization and falls back to the session model if invalid or unresolved.
  - Lane policy: when an override is set on `claude-sdk-oauth` lanes, senpi auto/threshold compaction runs again instead of standing down.
  - Setting is exposed via `getCompactionSettings()` and resolved at execution time without affecting session bookkeeping or diagnostics.

<sup>Written for commit 95f7dfb4cae4932ee14204e29c609782842e2250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

