### PR TITLE
docs(changelog): complete 2026.8.6 release attribution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,11 +25,14 @@
 - Fixed required compaction fatally ending a turn once the per-turn soft cap (3 accepted or ineffective
   compactions) was reached. Compaction admission is now bounded only by the absolute session cap (10) and the
   failure circuit breaker, so long turns that legitimately need more than three compactions keep running
-  (supersedes [#728](https://github.com/code-yeongyu/senpi/pull/728)).
+  ([#731](https://github.com/code-yeongyu/senpi/pull/731), superseding
+  [#728](https://github.com/code-yeongyu/senpi/pull/728)).
 - Fixed interactive shutdown crashing with `setRawMode failed with errno: 5` when an SSH or PTY peer disappears before
   terminal raw-mode restoration. Senpi now completes the requested exit for dead terminals without hiding unexpected
   restoration failures ([#726](https://github.com/code-yeongyu/senpi/pull/726)).
-- Fixed `apply_patch` binary-file previews so delete and move operations render a concise marker instead of decoded byte garbage, with move-only patches preserving the original bytes.
+- Fixed `apply_patch` binary-file previews so delete and move operations render a concise marker instead of
+  decoded byte garbage, with move-only patches preserving the original bytes
+  ([#725](https://github.com/code-yeongyu/senpi/pull/725)).
 - Fixed client-policy server fallback aborts rendering both a refusal-shaped assistant `Error:` row and the dedicated
   fallback notice box. Diagnosed aborts now leave the notice box as the single visible explanation while preserving
   the original message diagnostics and incremental render-cache updates


### PR DESCRIPTION
## Summary

- link the shipped binary-preview fix to PR #725
- link the absolute compaction-cap fix to PR #731 while preserving credit to superseded PR #728
- complete the release audit for every commit after v2026.8.5-2

## Verification

- `git diff --check`
- `node scripts/check-pr-changelog.mjs --base main --labels ""`
- exhaustive 34-commit audit: `local-ignore/qa-evidence/20260806-release/changelog-audit.md` (local, gitignored)

## Scope

Documentation-only release audit correction. No runtime behavior changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the 2026.8.6 release attribution in `packages/coding-agent/CHANGELOG.md`, adding correct PR links for the binary-preview fix (#725) and the compaction cap fix (#731, superseding #728), and auditing all commits after v2026.8.5-2. Documentation-only change; no runtime behavior impact.

<sup>Written for commit de1f122052da5ba034499d0610fab7f61d8e48b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

