### PR TITLE
test(ai): update retired Anthropic abort model

### DIFF
--- a/packages/ai/test/abort.test.ts
+++ b/packages/ai/test/abort.test.ts
@@ -154,7 +154,7 @@ describe("AI Providers Abort Tests", () => {
 	});
 
 	describe.skipIf(!process.env.ANTHROPIC_OAUTH_TOKEN)("Anthropic Provider Abort", () => {
-		const llm = getModel("anthropic", "claude-opus-4-1-20250805");
+		const llm = getModel("anthropic", "claude-opus-4-6");
 
 		it("should abort mid-stream", { retry: 3 }, async () => {
 			await testAbortSignal(llm, { thinkingEnabled: true, thinkingBudgetTokens: 2048 });


### PR DESCRIPTION
## Summary

- replace the retired Anthropic OAuth abort-test model with current `claude-opus-4-6`
- unblock release-time catalog regeneration and TypeScript validation
- preserve the existing abort scenarios and thinking options unchanged

## Failing-first proof

After `npm --prefix packages/ai run generate-models`, `npm run check` failed with:

```text
packages/ai/test/abort.test.ts(157,37): error TS2345:
Argument of type '"claude-opus-4-1-20250805"' is not assignable...
```

## Verification

- `npm --prefix packages/ai run generate-models`
- `npm run check` — PASS
- `npm --prefix packages/ai test -- abort.test.ts` — PASS

The generated provider-data drift is intentionally not part of this PR; release automation owns regeneration.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Anthropic abort test to use `claude-opus-4-6` instead of the retired model. This keeps the abort scenarios intact and unblocks model catalog generation and TypeScript validation.

<sup>Written for commit eafb58629a145d4e19bc49d7d8267de47a9d0d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

