### PR TITLE
feat(coding-agent): show cache hit in TPS notice

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Changed
 
+- Changed the turn-completion TPS notice to show the turn's cache-hit percentage instead of raw token counters
+  ([#742](https://github.com/code-yeongyu/senpi/pull/742)).
+
 ### Fixed
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,24 @@
 # Builtin extensions changes
 
+## tps: concise turn cache-hit notice (2026-08-06)
+
+- The turn-completion TPS notification now renders
+  `TPS <rate> tok/s. Cache hit <rate>%, <seconds>s` instead of repeating raw
+  output, input, cache-read/write, and total-token counters.
+- Cache hit is aggregated across every assistant message completed in the
+  agent turn, using the same denominator as the lower footer:
+  `cacheRead / (input + cacheRead + cacheWrite)`. A turn notice should describe
+  the whole turn, rather than only the last assistant message within it.
+- Why an extension change: `tps.ts` already owns the transient notification,
+  receives the complete turn's messages through `agent_end`, and can compute
+  the metric without widening the public extension context or changing the
+  persistent footer.
+- Coverage: `test/suite/tps-extension.test.ts` pins a multi-message 70.0% hit
+  rate, a zero-read 0.0% edge, monotonic elapsed time, and exclusion of
+  tool/permission waits.
+- Expected merge conflict zones: LOW in `tps.ts` around the usage aggregation
+  and notification string; LOW in `tps-extension.test.ts`.
+
 ## notice: shared transcript notice kit (2026-08-04)
 
 - New internal module `src/core/extensions/notice/` (`spec.ts`, `box.ts`, `adapters.ts`) owns the loop-guard visual family as a shared widget: a `NoticeSpec` contract (title/tone/why/extra/expandedLine), `buildNoticeBox`, and `noticeMessageRenderer`/`noticeEntryRenderer` adapters.

--- a/packages/coding-agent/src/core/extensions/builtin/tps.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/tps.ts
@@ -7,7 +7,6 @@ type AssistantMessageLike = {
 		output?: number;
 		cacheRead?: number;
 		cacheWrite?: number;
-		totalTokens?: number;
 	};
 };
 
@@ -66,7 +65,6 @@ export default function (pi: ExtensionAPI) {
 		let output = 0;
 		let cacheRead = 0;
 		let cacheWrite = 0;
-		let totalTokens = 0;
 
 		for (const message of event.messages) {
 			if (!isAssistantMessage(message)) continue;
@@ -74,14 +72,15 @@ export default function (pi: ExtensionAPI) {
 			output += message.usage?.output ?? 0;
 			cacheRead += message.usage?.cacheRead ?? 0;
 			cacheWrite += message.usage?.cacheWrite ?? 0;
-			totalTokens += message.usage?.totalTokens ?? 0;
 		}
 
 		if (output <= 0) return;
 
 		const elapsedSeconds = elapsedMs / 1000;
 		const tokensPerSecond = output / elapsedSeconds;
-		const message = `TPS ${tokensPerSecond.toFixed(1)} tok/s. out ${output.toLocaleString()}, in ${input.toLocaleString()}, cache r/w ${cacheRead.toLocaleString()}/${cacheWrite.toLocaleString()}, total ${totalTokens.toLocaleString()}, ${elapsedSeconds.toFixed(1)}s`;
+		const promptTokens = input + cacheRead + cacheWrite;
+		const cacheHitRate = promptTokens > 0 ? (cacheRead / promptTokens) * 100 : 0;
+		const message = `TPS ${tokensPerSecond.toFixed(1)} tok/s. Cache hit ${cacheHitRate.toFixed(1)}%, ${elapsedSeconds.toFixed(1)}s`;
 		ctx.ui.notify(message, "info");
 	});
 }

--- a/packages/coding-agent/test/suite/tps-extension.test.ts
+++ b/packages/coding-agent/test/suite/tps-extension.test.ts
@@ -11,6 +11,13 @@ type ExtensionContextLike = {
 type Handler = (event: unknown, ctx: ExtensionContextLike) => unknown | Promise<unknown>;
 type TpsExtension = (pi: { on(event: string, handler: Handler): void }) => void;
 
+type UsageFixture = {
+	readonly input: number;
+	readonly output: number;
+	readonly cacheRead: number;
+	readonly cacheWrite: number;
+};
+
 function createHarness() {
 	const handlers = new Map<string, Handler[]>();
 	const pi = {
@@ -43,16 +50,13 @@ function createContext(notifications: string[]): ExtensionContextLike {
 	};
 }
 
-function createAssistantMessage(output: number): unknown {
+function createAssistantMessage(usage: UsageFixture): unknown {
 	return {
 		role: "assistant",
 		content: [{ type: "text", text: "done" }],
 		usage: {
-			input: 10,
-			output,
-			cacheRead: 0,
-			cacheWrite: 0,
-			totalTokens: output + 10,
+			...usage,
+			totalTokens: usage.input + usage.output + usage.cacheRead + usage.cacheWrite,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 	};
@@ -63,14 +67,14 @@ describe("tps builtin extension", () => {
 		vi.useRealTimers();
 	});
 
-	it("calculates TPS from assistant response time and excludes tool or permission waits", async () => {
+	it("reports turn-level cache hit rate in the concise TPS notice", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(0);
 		const notifications: string[] = [];
 		const ctx = createContext(notifications);
 		const harness = createHarness();
-		const firstMessage = createAssistantMessage(100);
-		const secondMessage = createAssistantMessage(200);
+		const firstMessage = createAssistantMessage({ input: 10, output: 100, cacheRead: 30, cacheWrite: 0 });
+		const secondMessage = createAssistantMessage({ input: 20, output: 200, cacheRead: 40, cacheWrite: 0 });
 
 		await harness.emit("agent_start", { type: "agent_start" }, ctx);
 		vi.advanceTimersByTime(1_000);
@@ -87,11 +91,26 @@ describe("tps builtin extension", () => {
 
 		await harness.emit("agent_end", { type: "agent_end", messages: [firstMessage, secondMessage] }, ctx);
 
-		expect(notifications).toHaveLength(1);
-		expect(notifications[0]).toContain("TPS 100.0 tok/s");
-		expect(notifications[0]).toContain("out 300");
-		expect(notifications[0]).toContain("3.0s");
+		expect(notifications).toEqual(["TPS 100.0 tok/s. Cache hit 70.0%, 3.0s"]);
 		expect(notifications[0]).not.toContain("21.4 tok/s");
+	});
+
+	it("reports zero cache hit without raw token counters", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		const notifications: string[] = [];
+		const ctx = createContext(notifications);
+		const harness = createHarness();
+		const message = createAssistantMessage({ input: 10, output: 100, cacheRead: 0, cacheWrite: 0 });
+
+		await harness.emit("agent_start", { type: "agent_start" }, ctx);
+		await harness.emit("message_start", { type: "message_start", message }, ctx);
+		vi.advanceTimersByTime(1_000);
+		await harness.emit("message_end", { type: "message_end", message }, ctx);
+		await harness.emit("agent_end", { type: "agent_end", messages: [message] }, ctx);
+
+		expect(notifications).toEqual(["TPS 100.0 tok/s. Cache hit 0.0%, 1.0s"]);
+		expect(notifications[0]).not.toMatch(/\bout |\bin |cache r\/w|total /);
 	});
 
 	it("reports TPS when wall clock jumps backward between message_start and message_end", async () => {
@@ -100,7 +119,7 @@ describe("tps builtin extension", () => {
 		const notifications: string[] = [];
 		const ctx = createContext(notifications);
 		const harness = createHarness();
-		const message = createAssistantMessage(100);
+		const message = createAssistantMessage({ input: 10, output: 100, cacheRead: 0, cacheWrite: 0 });
 
 		await harness.emit("agent_start", { type: "agent_start" }, ctx);
 		vi.advanceTimersByTime(1_000);
@@ -114,9 +133,6 @@ describe("tps builtin extension", () => {
 
 		await harness.emit("agent_end", { type: "agent_end", messages: [message] }, ctx);
 
-		expect(notifications).toHaveLength(1);
-		expect(notifications[0]).toContain("TPS 100.0 tok/s");
-		expect(notifications[0]).toContain("out 100");
-		expect(notifications[0]).toContain("1.0s");
+		expect(notifications).toEqual(["TPS 100.0 tok/s. Cache hit 0.0%, 1.0s"]);
 	});
 });


### PR DESCRIPTION
## Summary

Replace the transient turn-completion TPS notification's raw token counters with
a concise cache-hit percentage:

```text
TPS 40.7 tok/s. Cache hit 98.7%, 1120.0s
```

The percentage aggregates every assistant message completed in the agent turn
and uses the same denominator as the lower footer:
`cacheRead / (input + cacheRead + cacheWrite)`.

## Changes

- Render `TPS <rate> tok/s. Cache hit <rate>%, <seconds>s`.
- Remove the now-unused total-token accumulation from the TPS extension.
- Add deterministic coverage for:
  - multi-message turn aggregation (`70.0%`);
  - zero cache reads (`0.0%`);
  - absence of the old `out` / `in` / `cache r/w` / `total` labels;
  - the existing monotonic timing regression.
- Record the fork-specific behavior and merge-conflict zones.

## QA & Evidence

- Failing-first proof captured before production edits:
  - old multi-message notice showed raw counters instead of `Cache hit 70.0%`;
  - zero-read notice showed `cache r/w 0/0` instead of `Cache hit 0.0%`.
- `npm run check` — PASS.
- `vitest --run test/suite/tps-extension.test.ts` — PASS, 3/3.
- Real source TUI against an isolated localhost Anthropic SSE fixture — PASS:
  - observed `TPS 395.3 tok/s. Cache hit 70.0%, 0.3s`;
  - xterm.js 5.5.0 rendered in headless Chrome;
  - old raw-counter labels absent;
  - tmux session, fake server, port, sandbox, and temporary xterm dependencies
    all cleaned up.
- Senpi TUI smoke — PASS, 5/5.
- Independent visual reviews:
  - design-system / functional integrity — PASS;
  - fidelity / typography / clipping / CJK risk — PASS.

Local evidence root:
`local-ignore/qa-evidence/20260806-tps-cache-hit/`

## Risks & Residuals

- The transient notification now reports a turn-level aggregate, while the
  persistent footer keeps its existing latest-message snapshot semantics.
- No provider, session persistence, or public extension-context API changed.

## Related Issues

None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show cache hit % in the transient TPS notice, aggregated across the agent turn, replacing raw token counters. Aligns with the footer denominator `cacheRead / (input + cacheRead + cacheWrite)` without changing footer behavior.

- **New Features**
  - TPS notice shows: "TPS <tok/s>. Cache hit <rate>%, <seconds>s".
  - Aggregates cache hit across all assistant messages in the turn and excludes tool/permission waits.

- **Refactors**
  - Removed unused `totalTokens` accumulation in `tps.ts`.
  - Updated tests and docs (`changes.md`, `CHANGELOG.md`) to cover and record the new cache-hit notice and timing.

<sup>Written for commit e72a32073b658ef9c046ad2b37058aa2f3d40ea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

