### PR TITLE
fix(senpi-codemode): format eval elapsed duration

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Formatted completed eval durations with compact human-readable units instead of raw millisecond counts in transcript metadata ([#743](https://github.com/code-yeongyu/senpi/pull/743)).
+
 ### Removed
 
 ## [2026.8.6] - 2026-08-06

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,27 @@
 # senpi-codemode fork changes
 
+## Compact elapsed labels for simple eval results (2026-08-06)
+
+### What changed
+
+- `src/tool/render.ts`: final eval results without detailed cell records now route `durationMs` through the same compact formatter already used by cell headers, agent progress, and nested tool-call widgets.
+- `test/eval-result-duration.test.ts`: focused coverage pins sub-second, seconds, minutes, and hours output plus the surrounding status/summary/phase/output frame.
+- Existing renderer-state expectations now preserve the compact `<1s` label for very short completed and failed evaluations.
+
+### Why
+
+- The simple-result branch was the only eval duration surface that interpolated raw milliseconds, producing labels such as `took 3720000ms` while the detailed branch rendered the same duration as `1h 2m`.
+- Consistent compact labels make completed tool-call timing readable without changing live footer, working-status, or thinking-duration policies.
+
+### Why this cannot be expressed externally
+
+- The inconsistency lives inside the eval tool's result renderer and must be corrected at the branch that builds transcript metadata.
+
+### Expected merge conflict zones
+
+- LOW: `src/tool/render.ts` around `resultMetadata()`.
+- LOW: `test/eval-render-state.test.ts` and `test/eval-result-duration.test.ts`.
+
 ## Eval `summary` replaces `title` (2026-08-04)
 
 ### What changed

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -757,7 +757,8 @@ function resultMetadata(
 ): RenderBlock[] {
 	const metadata: string[] = [];
 	if (details?.phase) metadata.push(`phase ${details.phase}`);
-	if (!options.isPartial && typeof details?.durationMs === "number") metadata.push(`took ${details.durationMs}ms`);
+	if (!options.isPartial && typeof details?.durationMs === "number")
+		metadata.push(`took ${formatDuration(details.durationMs)}`);
 	if (metadata.length === 0) return [];
 	return [{ kind: "text", text: style(theme, "muted", metadata.join(" | ")) }];
 }

--- a/packages/senpi-codemode/test/eval-render-state.test.ts
+++ b/packages/senpi-codemode/test/eval-render-state.test.ts
@@ -46,7 +46,7 @@ describe("eval renderer state", () => {
 		expect.soft(metadataText).toContain("analysis");
 		expect.soft(metadataText).toContain("phase");
 		expect.soft(metadataText).toContain("summarizing");
-		expect.soft(metadataText).toContain("took 11ms");
+		expect.soft(metadataText).toContain("took <1s");
 	});
 
 	it("Given a final result that completed within one millisecond when rendered then zero duration is shown", () => {
@@ -62,7 +62,7 @@ describe("eval renderer state", () => {
 		);
 
 		// Then
-		expect(renderLines(component)).toContain("took 0ms");
+		expect(renderLines(component)).toContain("took <1s");
 	});
 
 	it("Given a partial result with elapsed duration when rendered then timing remains hidden", () => {
@@ -256,7 +256,7 @@ describe("eval renderer state", () => {
 		const header = lines[0] ?? "";
 		const metadataText = lines.join("\n");
 		expect.soft(header).toContain("error");
-		expect.soft(metadataText).toContain("took 5ms");
+		expect.soft(metadataText).toContain("took <1s");
 	});
 
 	it("Given call badges and cells in every lifecycle state when rendered then headers expose icons and formatted durations", () => {

--- a/packages/senpi-codemode/test/eval-render-streaming.test.ts
+++ b/packages/senpi-codemode/test/eval-render-streaming.test.ts
@@ -128,7 +128,7 @@ describe("eval renderer streaming reuse", () => {
 		const lines = renderLines(final);
 		const visibleText = lines.join("\n");
 		expect.soft(final).toBe(partial);
-		expect.soft(lines.slice(0, 5)).toEqual(["eval py done", "stream", "phase complete | took 9ms", "", "final-only"]);
+		expect.soft(lines.slice(0, 5)).toEqual(["eval py done", "stream", "phase complete | took <1s", "", "final-only"]);
 		expect.soft(visibleText).not.toContain("partial-two");
 		expect.soft(visibleText).not.toContain("running");
 		expect.soft(visibleText).not.toContain("tool.search");
@@ -174,7 +174,7 @@ describe("eval renderer streaming reuse", () => {
 		const lines = renderLines(error);
 		const visibleText = lines.join("\n");
 		expect.soft(error).toBe(partial);
-		expect.soft(lines.slice(0, 4)).toEqual(["eval rb error", "phase failed | took 5ms", "", "boom"]);
+		expect.soft(lines.slice(0, 4)).toEqual(["eval rb error", "phase failed | took <1s", "", "boom"]);
 		expect.soft(visibleText).not.toContain("still running");
 		expect.soft(visibleText).not.toContain("running script");
 	});
@@ -250,7 +250,7 @@ describe("eval renderer streaming reuse", () => {
 		expect.soft(final).not.toBe(call);
 		expect.soft(renderLines(call)).toEqual(callPreview);
 		expect.soft(renderLines(call)).toEqual(["eval js", "assign constant", "const value = 1"]);
-		expect.soft(renderLines(final).slice(0, 4)).toEqual(["eval js done", "phase complete | took 3ms", "", "final"]);
+		expect.soft(renderLines(final).slice(0, 4)).toEqual(["eval js done", "phase complete | took <1s", "", "final"]);
 	});
 
 	it("Given running completed and failed agent events when rendered then progress rows expose state detail and duration", () => {

--- a/packages/senpi-codemode/test/eval-render.test.ts
+++ b/packages/senpi-codemode/test/eval-render.test.ts
@@ -73,7 +73,7 @@ describe("eval renderer", () => {
 		expect(renderLines(component)).toEqual([
 			"eval js done",
 			"chart",
-			"took 11ms",
+			"took <1s",
 			"",
 			"stdout",
 			"value",
@@ -138,7 +138,7 @@ describe("eval renderer", () => {
 		);
 
 		// Then
-		expect(renderLines(component).slice(0, 2)).toEqual(["eval rb error", "took 5ms"]);
+		expect(renderLines(component).slice(0, 2)).toEqual(["eval rb error", "took <1s"]);
 	});
 
 	it("renders a running result header", () => {
@@ -266,7 +266,7 @@ describe("eval renderer", () => {
 
 		// Then
 		expect(final).toBe(partial);
-		expect(renderLines(final)).toEqual(["eval js done", "took 4ms", "", "complete"]);
+		expect(renderLines(final)).toEqual(["eval js done", "took <1s", "", "complete"]);
 	});
 
 	it("keeps call and result lanes distinct when the result lane starts without lastComponent", () => {
@@ -284,7 +284,7 @@ describe("eval renderer", () => {
 		// Then
 		expect(result).not.toBe(call);
 		expect(renderLines(call)).toEqual(["eval js", "quick math", "1 + 1"]);
-		expect(renderLines(result)).toEqual(["eval js done", "took 1ms", "", "2"]);
+		expect(renderLines(result)).toEqual(["eval js done", "took <1s", "", "2"]);
 	});
 
 	it("Given a streaming result exists when the framed call lane renders then it yields an empty component", () => {

--- a/packages/senpi-codemode/test/eval-result-duration.test.ts
+++ b/packages/senpi-codemode/test/eval-result-duration.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { renderEvalResult } from "../src/tool/render.ts";
+import { evalResult, renderLines, resultContext } from "./eval-render-fixtures.ts";
+
+describe("eval result duration rendering", () => {
+	it.each([
+		{ durationMs: 0, expected: "took <1s" },
+		{ durationMs: 1_250, expected: "took 1s" },
+		{ durationMs: 61_000, expected: "took 1m 1s" },
+		{ durationMs: 3_720_000, expected: "took 1h 2m" },
+	])("formats $durationMs milliseconds as $expected", ({ durationMs, expected }) => {
+		// Given
+		const result = evalResult({ language: "js", durationMs, toolCalls: [], truncated: false }, "complete");
+
+		// When
+		const rendered = renderLines(
+			renderEvalResult(result, { expanded: false, isPartial: false }, undefined, resultContext(undefined, false)),
+		);
+
+		// Then
+		expect(rendered).toContain(expected);
+	});
+
+	it("preserves result status summary phase and output around formatted timing", () => {
+		// Given
+		const result = evalResult(
+			{
+				language: "js",
+				summary: "dependency scan",
+				phase: "summarizing",
+				durationMs: 1_250,
+				toolCalls: [],
+				truncated: false,
+			},
+			"complete",
+		);
+
+		// When
+		const rendered = renderLines(
+			renderEvalResult(result, { expanded: false, isPartial: false }, undefined, resultContext(undefined, false)),
+		);
+
+		// Then
+		expect(rendered).toEqual(["eval js done", "dependency scan", "phase summarizing | took 1s", "", "complete"]);
+	});
+});


### PR DESCRIPTION
## Summary

- format completed eval durations with the existing compact elapsed formatter
- keep the simple-result path consistent with cell headers, agent progress, and nested tool-call widgets
- add focused boundary and adjacent-frame regression coverage

## Changes

- `resultMetadata()` now renders values such as `1_250ms`, `61_000ms`, and `3_720_000ms` as `1s`, `1m 1s`, and `1h 2m`
- very short completed/error results consistently render `<1s`
- fork behavior is recorded in `packages/senpi-codemode/changes.md`

## QA & Evidence

- RED: focused boundary test failed 4/4 on raw `took <N>ms`
- RED: integrated frame differed only at `took 1250ms` versus `took 1s`
- GREEN: focused elapsed suite 5/5
- GREEN: full `@code-yeongyu/senpi-codemode` suite 515 passed, 6 pre-existing skipped
- `npm run check` passed
- package build passed
- xterm.js parsed-cell assertions passed 2/2
- agent-browser screenshot confirmed `phase summarizing | took 1h 2m`
- two independent visual QA reviewers returned PASS with no blockers

Local evidence: `local-ignore/qa-evidence/20260806-eval-elapsed-rendering/`

## Risks & Residuals

- intentionally does not change live footer, working-status, thinking-duration, or timeout-error formatting
- no schema, persistence, API, or concurrency behavior changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix inconsistent eval duration labels by using the compact formatter for final results, so times show as “took 1s”, “1m 1s”, etc., instead of raw milliseconds. This matches cell headers and nested tool-call widgets in `senpi-codemode`, and is documented in the changelog.

- **Bug Fixes**
  - Route `durationMs` through the compact formatter in `resultMetadata()` to render “took 1s”, “1m 1s”, “1h 2m”.
  - Show “took <1s” for very short completed/error results.
  - Add `test/eval-result-duration.test.ts` and update existing tests; record the change in `packages/senpi-codemode/CHANGELOG.md` and `changes.md`.
  - Scope: no changes to live footer, working-status, thinking-duration, or timeout-error formatting.

<sup>Written for commit 250f8f9ee7f735626602a0c230106cfbfc22ab77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

