### PR TITLE
docs(changelog): expand upcoming release notes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ### Changed
 
-- Changed the turn-completion TPS notice to show the turn's cache-hit percentage instead of raw token counters
+- Changed the turn-completion TPS notice from a dense list of raw input, output, cache-read, cache-write, and total-token
+  counters to `TPS <rate> tok/s. Cache hit <rate>%, <seconds>s`. The cache-hit percentage is aggregated across every
+  assistant message in the completed turn as `cacheRead / (input + cacheRead + cacheWrite)`, reports `0.0%` when the
+  turn has no cache reads, and keeps tool and permission waits out of the elapsed-time calculation
   ([#742](https://github.com/code-yeongyu/senpi/pull/742)).
 
 ### Fixed

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ### Fixed
 
-- Formatted completed eval durations with compact human-readable units instead of raw millisecond counts in transcript metadata ([#743](https://github.com/code-yeongyu/senpi/pull/743)).
+- Formatted completed eval durations in the simple-result transcript branch with the same compact human-readable units
+  used by detailed cell headers and nested tool widgets, so sub-second, seconds, minutes, and hours values render as
+  labels such as `<1s`, `12s`, `3m 5s`, or `1h 2m` instead of raw millisecond counts. Live footer, working-status, and
+  thinking-duration policies are unchanged ([#743](https://github.com/code-yeongyu/senpi/pull/743)).
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Expand the already-complete Unreleased changelog coverage for the changes merged
after `v2026.8.6` so the next same-day release carries reviewer- and
user-readable behavior details rather than compact one-line summaries.

The release audit found no missing entries or cross-package duplication gaps.
This PR only enriches the existing #742 and #743 bullets; the detailed #744
entry and every released version section remain unchanged.

## Changes

- Explain the TPS notice's exact output shape, whole-turn aggregation,
  cache-hit denominator, zero-cache edge, and exclusion of tool/permission
  waits.
- Explain the eval duration formatter's affected result branch, representative
  compact labels, shared rendering behavior, and unchanged live timing
  policies.

## QA & Evidence

- **What was tested:** Exhaustive `v2026.8.6..main` audit covering all 11
  commits, their changed package paths, every relevant Unreleased section, and
  coding-agent duplication rules.
  - **Observed result:** Three eligible behavior changes (#742, #743, #744);
    zero missing entries; zero required duplications.
  - **Artifact:** `local-ignore/qa-evidence/20260806-release/changelog-audit-before.txt`
  - **Why sufficient:** It proves the full release range was classified before
    the prose change and identifies the two entries that needed more detail.
- **What was tested:** `git diff --check` plus SHA-256 comparison of the
  complete already-released tails of five changelogs.
  - **Observed result:** Diff check exited 0; all five before/after hashes are
    identical.
  - **Artifact:** `local-ignore/qa-evidence/20260806-release/changelog-audit-after.txt`
  - **Why sufficient:** It proves the edit is confined to Unreleased prose and
    does not mutate immutable release history.

## Risks & Residuals

- Runtime risk: none; this is a prose-only change with no machine-consumed
  values.
- Release-history risk: mitigated by byte-identical hashes for every released
  changelog section.
- No text-pinning test was added because changelog wording is not a
  machine-consumed contract.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded Unreleased changelog entries for `coding-agent` and `senpi-codemode` to clearly describe the TPS notice output and eval duration formatting. Notes now specify the TPS message shape, turn-wide cache-hit calculation (including zero-cache edge) and exclusion of tool/permission waits, plus compact time labels in simple-result transcripts (e.g., <1s, 12s, 3m 5s) with unchanged live timing policies.

<sup>Written for commit 3e03a79dfb590eef32c04d11d1f9901df700c50e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

