### PR TITLE
feat(terminal): auto-detach long bash calls instead of blocking or killing them

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 ### Changed
 
+- Changed the `bash` tool so a long-running foreground command is handed to a live background session instead of
+  blocking the turn or being killed. Foreground blocking now stops at a fixed window (`PI_BASH_FOREGROUND_SECONDS`,
+  default 60s) rather than tracking the prompt-cache budget, and `timeout` becomes the process kill deadline
+  (default 1800s) enforced after the hand-off. Commands whose purpose is waiting — a bare `sleep 30`,
+  `sleep 45; gh pr view ...`, or a `while`/`for` poll loop — detach after 5s and report back with guidance to end the
+  turn and wait for the completion notification, or to use `monitor({ command, filter })` for output-pattern waits;
+  short settle sleeps such as `pkill; sleep 1` still run in the foreground. Sessions started with
+  `run_in_background: true` are unchanged ([#747](https://github.com/code-yeongyu/senpi/pull/747)).
 - Changed the turn-completion TPS notice from a dense list of raw input, output, cache-read, cache-write, and total-token
   counters to `TPS <rate> tok/s. Cache hit <rate>%, <seconds>s`. The cache-hit percentage is aggregated across every
   assistant message in the completed turn as `cacheRead / (input + cacheRead + cacheWrite)`, reports `0.0%` when the

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/changes.md
@@ -3,6 +3,33 @@
 Injects the default `timeout` into every `bash` call and appends the "Bash Tool Timeout Policy"
 section to the system prompt.
 
+## Kill-deadline semantics (2026-08-07)
+
+### What changed
+
+- `timeout.ts`: the built-in default and recommended maximum are both 1800s (30 min). The
+  prompt-cache safe-wait capping is removed: the terminal extension now bounds foreground
+  blocking at the ~60s window and auto-detaches survivors alive to background sessions, so
+  `timeout` is purely the process kill deadline. The prompt rider teaches the
+  detach → notification → monitor model.
+- `index.ts`: both handlers use the env-resolved defaults directly. The live-model budget
+  lookup and the native-Anthropic-bash exception are gone.
+
+### Why
+
+A 60s foreground window sits far below every cache lifetime, so blocking can no longer breach a
+cache-derived ceiling. The deadline that still applies after detach is enforced by
+`scheduleDetachedSweep` in `terminal/tools/bash.ts`.
+
+### Supersedes
+
+This replaces the 2026-07-28 cache-aware-ceiling entry below. The ceiling math is gone, but its
+native-Anthropic-bash exception survives in a narrower form: when `PI_ANTHROPIC_BASH` is active for
+an `anthropic-messages` model the PTY `bash` tool steps aside, so `buildBashTimeoutPrompt` receives
+an `undefined` window and omits the auto-detach bullets rather than promising behavior nothing
+implements. The policy also names the *configured* window (`PI_BASH_FOREGROUND_SECONDS`) instead of
+a hardcoded 60s.
+
 ## Cache-aware ceiling and native-Anthropic-bash exception (2026-07-28)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/index.ts
@@ -1,53 +1,48 @@
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
+import { resolveForegroundWindowSeconds } from "../terminal/tools/foreground-window.ts";
 
 import {
 	applyBashTimeout,
 	type BashToolInputLike,
 	buildBashTimeoutPrompt,
 	resolveBashTimeoutDefaults,
-	resolveEffectiveBashTimeouts,
 } from "./timeout.ts";
 
-export type { BashTimeoutDefaults, BashToolInputLike, EffectiveBashTimeouts } from "./timeout.ts";
+export type { BashTimeoutDefaults, BashToolInputLike } from "./timeout.ts";
 export {
 	applyBashTimeout,
 	BASH_DEFAULT_TIMEOUT_SECONDS,
 	BASH_MAX_TIMEOUT_SECONDS,
 	buildBashTimeoutPrompt,
 	resolveBashTimeoutDefaults,
-	resolveEffectiveBashTimeouts,
 } from "./timeout.ts";
 
 export default function bashTimeoutExtension(pi: ExtensionAPI): void {
 	const env = typeof process !== "undefined" ? process.env : {};
-	const baseDefaults = resolveBashTimeoutDefaults(env);
-	let effective = resolveEffectiveBashTimeouts(baseDefaults, undefined);
+	const defaults = resolveBashTimeoutDefaults(env);
 
-	/**
-	 * Native Anthropic bash replaces the PTY `bash` tool, and the terminal
-	 * extension steps aside with it — so nothing implements the cache-deadline
-	 * detach. Advertising a cache ceiling there would promise behavior that
-	 * cannot happen, so the budget only applies while the PTY tool is live.
-	 */
-	const resolveBudget = (ctx: ExtensionContext | undefined): number | undefined => {
-		if (isAnthropicBashEnabled() && ctx?.model?.api === "anthropic-messages") return undefined;
-		return ctx?.getPromptCacheSafeWaitSeconds?.();
-	};
-
-	pi.on("tool_call", async (event, ctx) => {
+	pi.on("tool_call", async (event) => {
 		if (event.toolName !== "bash") return;
-		effective = resolveEffectiveBashTimeouts(baseDefaults, resolveBudget(ctx));
 		const input = event.input as BashToolInputLike;
-		const updated = applyBashTimeout(input, effective);
+		const updated = applyBashTimeout(input, defaults);
 		if (updated !== input) {
 			const timeout = updated.timeout;
 			if (timeout !== undefined) input.timeout = timeout;
 		}
 	});
 
+	/**
+	 * Native Anthropic bash replaces the PTY `bash` tool and the terminal
+	 * extension steps aside with it, so nothing implements the auto-detach the
+	 * policy would otherwise advertise.
+	 */
+	const resolveWindow = (ctx: ExtensionContext | undefined): number | undefined => {
+		if (isAnthropicBashEnabled() && ctx?.model?.api === "anthropic-messages") return undefined;
+		return resolveForegroundWindowSeconds(env);
+	};
+
 	pi.on("before_agent_start", async (event, ctx) => {
-		effective = resolveEffectiveBashTimeouts(baseDefaults, resolveBudget(ctx));
-		return { systemPrompt: `${event.systemPrompt}${buildBashTimeoutPrompt(effective)}` };
+		return { systemPrompt: `${event.systemPrompt}${buildBashTimeoutPrompt(defaults, resolveWindow(ctx))}` };
 	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
@@ -1,5 +1,5 @@
-export const BASH_DEFAULT_TIMEOUT_SECONDS = 120;
-export const BASH_MAX_TIMEOUT_SECONDS = 600;
+export const BASH_DEFAULT_TIMEOUT_SECONDS = 1800;
+export const BASH_MAX_TIMEOUT_SECONDS = 1800;
 
 export interface BashTimeoutDefaults {
 	defaultSeconds: number;
@@ -40,32 +40,20 @@ export function applyBashTimeout<TInput extends BashToolInputLike>(
 	return input;
 }
 
-export interface EffectiveBashTimeouts extends BashTimeoutDefaults {
-	cacheCapped?: boolean;
-}
-
 /**
- * Lower the recommended maximum to the prompt-cache safe-wait budget, so the
- * model is never told to block past the point where the cache expires. The two
- * `min()` expressions are the complete policy: a budget below the injected
- * default pulls that default down with it, keeping the prompt, the injected
- * value, and the terminal detach deadline consistent.
+ * `foregroundWindowSeconds` is `undefined` when no PTY bash tool is live (native
+ * Anthropic bash replaces it). Nothing implements auto-detach then, so the
+ * policy must not promise it — a prompt that describes impossible behavior is
+ * worse than a silent one.
  */
-export function resolveEffectiveBashTimeouts(
+export function buildBashTimeoutPrompt(
 	defaults: BashTimeoutDefaults,
-	safeWaitSeconds: number | undefined,
-): Required<EffectiveBashTimeouts> {
-	if (safeWaitSeconds === undefined || safeWaitSeconds >= defaults.maxSeconds) {
-		return { ...defaults, cacheCapped: false };
-	}
-	const maxSeconds = Math.min(defaults.maxSeconds, safeWaitSeconds);
-	return { defaultSeconds: Math.min(defaults.defaultSeconds, maxSeconds), maxSeconds, cacheCapped: true };
-}
-
-export function buildBashTimeoutPrompt(defaults: EffectiveBashTimeouts): string {
+	foregroundWindowSeconds?: number,
+): string {
 	const minutes = (seconds: number): string => (seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds}s`);
-	const maxReason = defaults.cacheCapped
-		? ` This ceiling is the prompt cache lifetime of the active model minus a safety buffer: blocking past it expires the cache and forces a full re-read on the next request. A foreground command still running at that point is handed to a background session alive instead of being killed; those sessions stay live, so stop the ones you no longer need with \`kill_bash\`.`
-		: "";
-	return `\n## Bash Tool Timeout Policy\n\nThe \`bash\` tool enforces timeouts even when you omit the \`timeout\` parameter:\n\n- Default timeout: ${defaults.defaultSeconds}s (${minutes(defaults.defaultSeconds)}). Applied automatically when you do not set \`timeout\`.\n- Recommended maximum timeout: ${defaults.maxSeconds}s (${minutes(defaults.maxSeconds)}).${maxReason} Explicit \`timeout\` values are preserved because different hosts may use different timeout units.\n- For long-running commands (builds, installs, test suites), set an explicit \`timeout\` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, start them with \`run_in_background: true\` and watch the decisive output with \`monitor\` instead of raising the timeout.\n`;
+	const detachRules =
+		foregroundWindowSeconds === undefined
+			? ""
+			: `\n- Foreground blocking stops at the ~${foregroundWindowSeconds}s window. A command still running then auto-detaches alive to a background session with a \`bash_id\` and keeps running until it exits, hits the kill deadline, or is stopped with \`kill_bash\`.\n- Completion arrives automatically as a notification carrying the exit status and output tail, so end your turn rather than poll. Use \`bash_output\` only for a midpoint peek.`;
+	return `\n## Bash Tool Timeout Policy\n\nThe \`bash\` tool's \`timeout\` parameter is the process kill deadline, not how long you wait for output: the command is killed when it reaches the deadline.\n\n- Default timeout: ${defaults.defaultSeconds}s (${minutes(defaults.defaultSeconds)}). Applied automatically when you do not set \`timeout\`.\n- Recommended maximum timeout: ${defaults.maxSeconds}s (${minutes(defaults.maxSeconds)}). Explicit \`timeout\` values are preserved because different hosts may use different timeout units.${detachRules}\n- Waiting on an observable condition (a log line, a CI check, a server coming up) belongs to \`monitor({command, filter})\`, never a foreground \`sleep\` or poll loop.\n- Sessions started with \`run_in_background: true\` ignore \`timeout\` and live until exit or \`kill_bash\`.\n`;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/bash-timeout/timeout.ts
@@ -46,10 +46,7 @@ export function applyBashTimeout<TInput extends BashToolInputLike>(
  * policy must not promise it — a prompt that describes impossible behavior is
  * worse than a silent one.
  */
-export function buildBashTimeoutPrompt(
-	defaults: BashTimeoutDefaults,
-	foregroundWindowSeconds?: number,
-): string {
+export function buildBashTimeoutPrompt(defaults: BashTimeoutDefaults, foregroundWindowSeconds?: number): string {
 	const minutes = (seconds: number): string => (seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds}s`);
 	const detachRules =
 		foregroundWindowSeconds === undefined

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,62 @@
 # terminal builtin extension — fork surface
 
+## Fixed foreground window replaces cache budget; sleep-wait commands detach early (2026-08-07)
+
+### What changed
+
+- `tools/foreground-window.ts` (new): the foreground blocking window is a fixed value —
+  `PI_BASH_FOREGROUND_SECONDS`, default 60s (`DEFAULT_FOREGROUND_WINDOW_SECONDS`) — no longer
+  tied to the prompt-cache safe-wait budget. A classified sleep-wait uses a shorter 5s window
+  (`SLEEP_WAIT_WINDOW_SECONDS`) because its remaining time is pure waiting with nothing to show.
+  `resolveForegroundWindowSeconds(env)` parses the env override with a positive-finite guard,
+  falling back to the default.
+- `tools/sleep-wait.ts` (new): `classifySleepWait(command)` detects four wait-shaped patterns —
+  R1 bare `sleep N`, R2 leading `sleep N; cmd`, R3 polling loop (`while`/`until`/`for` containing
+  `sleep`), R4 trailing `cmd; sleep N` — after stripping `bash -lc` / `env A=1 sh -c` wrappers
+  (up to three levels deep via `unwrap()`). `longestSleepSeconds()` extracts the largest `sleep`
+  argument. A 10s threshold (`SLEEP_WAIT_THRESHOLD_SECONDS`) keeps short settle sleeps like
+  `pkill; sleep 1` foreground; inside a loop the threshold drops to 2s
+  (`SLEEP_WAIT_LOOP_THRESHOLD_SECONDS`). The `POWER_MANAGEMENT` guard (`pmset`/`caffeinate`/
+  `systemsetup`/`displaysleep`/`disksleep`) prevents power-management arguments from matching.
+- `tools/bash.ts`: `resolveAutoDetachDelayMs` takes a new `sleepWait: SleepWaitClassification |
+  undefined` parameter and returns the sleep-wait window (5s) when classified, otherwise the
+  foreground window (60s). The old `ctx.getSessionContext?.()?.getPromptCacheSafeWaitSeconds?.()`
+  budget call is removed. `runForeground` calls `classifySleepWait(input.command)` before resolving
+  the detach delay. A sleep-wait detach gets a dedicated `guidance` string that tells the model to
+  end its turn and wait for the completion notification — explicitly not to poll
+  `bash_output` — and recommends `monitor({command, filter})` for pattern waits. Non-sleep-wait
+  detaches keep the existing guidance. The tool result `details` gains `sleep_wait: true` for
+  classified commands. The `timeout` schema description and the bash tool `description` are
+  rewritten to describe the window + auto-detach + kill-deadline semantics.
+- Auto-detach mechanism is unchanged: `createForegroundDetachGate` + `scheduleDetachedSweep` move
+  a still-running process to a live background session, and `timeout` remains the process kill
+  deadline enforced after detach.
+
+### Why
+
+A census of real local coding-agent session stores found ~7,073 sleep-wait bash commands — poll
+loops, `sleep 45; gh pr view ...`, bare `sleep 30` — where agents burned foreground turn time on
+waiting. The runtime now hands such waits to the background instead of blocking or killing them:
+a sleep-wait detaches at 5s, an ordinary command still running at the 60s window detaches then.
+The completion notification delivers exit status and output tail, so polling `bash_output` is
+unnecessary.
+
+### Why this cannot be expressed externally
+
+- The foreground window replaces the session-context `getPromptCacheSafeWaitSeconds` hook that
+  only the built-in `bash` tool reads inside `runForeground`. An extension cannot intercept the
+  foreground wait lifecycle, inject a per-command classification before the detach gate commits,
+  or author the handoff `guidance` message that `runForeground` returns.
+
+### Expected merge conflict zones
+
+- `tools/bash.ts` `resolveAutoDetachDelayMs` (signature change, budget removal) and the
+  detached-result `guidance` block where the sleep-wait message branch lives.
+- `tools/foreground-window.ts` and `tools/sleep-wait.ts` (new fork-owned files; upstream has no
+  equivalent).
+- `test/suite/sleep-wait.test.ts` (new) and `test/suite/terminal-bash-auto-detach.test.ts`
+  (`setup()` drops `safeWaitSeconds`, describe block renamed to "foreground window auto-detach").
+
 ## Paused monitors still deliver completion (2026-08-04)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
@@ -12,6 +12,8 @@ import {
 } from "../shared.ts";
 import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
 import { createForegroundDetachGate } from "./foreground-detach.ts";
+import { resolveForegroundWindowSeconds, SLEEP_WAIT_WINDOW_SECONDS } from "./foreground-window.ts";
+import { classifySleepWait, type SleepWaitClassification } from "./sleep-wait.ts";
 import { describeExit, spawnCommandSession } from "./spawn.ts";
 
 export const ptyBashSchema = Type.Object({
@@ -19,7 +21,7 @@ export const ptyBashSchema = Type.Object({
 	timeout: Type.Optional(
 		Type.Number({
 			description:
-				"Foreground kill deadline in seconds. Ignored for run_in_background sessions (they live until exit or kill_bash).",
+				"Process kill deadline in seconds (default 1800). Foreground blocking stops at the ~60s window: a command still running then auto-detaches to a live background session instead of being killed. Ignored for run_in_background sessions (they live until exit or kill_bash).",
 		}),
 	),
 	description: Type.Optional(Type.String({ description: "Short human-readable label for this command." })),
@@ -172,13 +174,23 @@ function raceExitWithKillGrace(
 	});
 }
 
-function resolveAutoDetachDelayMs(ctx: TerminalToolContext, input: PtyBashInput): number | undefined {
+/**
+ * How long the model blocks before a still-running command is handed to a live
+ * background session. A sleep-wait detaches almost immediately: its remaining
+ * time is pure waiting, which the completion notification delivers for free.
+ */
+function resolveAutoDetachDelayMs(
+	ctx: TerminalToolContext,
+	input: PtyBashInput,
+	sleepWait: SleepWaitClassification | undefined,
+): number | undefined {
 	if (ctx.timeoutAction === "kill") return undefined;
-	const budgetSeconds = ctx.getSessionContext?.()?.getPromptCacheSafeWaitSeconds?.();
-	if (budgetSeconds === undefined || !Number.isFinite(budgetSeconds)) return undefined;
+	const windowSeconds = sleepWait
+		? Math.min(SLEEP_WAIT_WINDOW_SECONDS, resolveForegroundWindowSeconds(process.env))
+		: resolveForegroundWindowSeconds(process.env);
 	const timeoutSeconds = input.timeout !== undefined && Number.isFinite(input.timeout) ? input.timeout : Infinity;
-	if (timeoutSeconds <= budgetSeconds) return undefined;
-	return Math.max(0, Math.trunc(budgetSeconds * 1000));
+	if (timeoutSeconds <= windowSeconds) return undefined;
+	return Math.max(0, Math.trunc(windowSeconds * 1000));
 }
 
 function scheduleDetachedSweep(
@@ -242,7 +254,8 @@ async function runForeground(
 	onUpdate?.({ content: [], details: undefined });
 	const unsubscribeOutput = onUpdate ? runtime.onOutput(() => updateEmitter?.schedule()) : undefined;
 
-	const detachDelayMs = resolveAutoDetachDelayMs(ctx, input);
+	const sleepWait = classifySleepWait(input.command);
+	const detachDelayMs = resolveAutoDetachDelayMs(ctx, input, sleepWait);
 	let outcome: ForegroundWaitOutcome | "detached";
 	if (detachDelayMs === undefined) {
 		// Interrupt means "stop now": SIGKILL the whole process group in one shot.
@@ -300,13 +313,17 @@ async function runForeground(
 			input.timeout !== undefined && Number.isFinite(input.timeout)
 				? `not killed; the original ${input.timeout}s timeout still applies`
 				: "not killed; it will run until exit or kill_bash";
+		const guidance = sleepWait
+			? `This command is a wait (${sleepWait.seconds}s sleep), so it detached immediately; the wait continues in the background. Do nothing and end your turn — completion will be reported automatically with exit status and output tail. Do NOT poll bash_output({ bash_id: "${id}" }) for it. When you are waiting for a pattern in a command's output, launch it with monitor({ command, filter }) instead so matching lines arrive as events. Use kill_bash({ bash_id: "${id}" }) to stop this session.`
+			: `Continue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: "${id}" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: "${id}" }) to stop this session.`;
 		return textResult(
-			`Command is still running; auto-detached to background with ID: ${id} (${timeoutNote}).\n\nPartial output:\n${partialOutput}\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: "${id}" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: "${id}" }) to stop this session.`,
+			`Command is still running; auto-detached to background with ID: ${id} (${timeoutNote}).\n\nPartial output:\n${partialOutput}\n\n${guidance}`,
 			{
 				details: {
 					bash_id: id,
 					background: true,
 					auto_detached: true,
+					...(sleepWait ? { sleep_wait: true } : {}),
 					status: "running",
 					...(delta.droppedChars > 0 ? { droppedChars: delta.droppedChars } : {}),
 				},
@@ -380,7 +397,7 @@ export function createPtyBashTool(ctx: TerminalToolContext) {
 		name: TERMINAL_BASH_TOOL,
 		label: "bash",
 		description:
-			"Execute a shell command in a persistent PTY-backed session. Set run_in_background:true for long-lived or interactive sessions; steer them with bash_input, snapshot with bash_output, tear down with kill_bash. To wait on observable state (a build finishing, a server coming up, a log line), never run sleep or poll loops — subscribe with the monitor tool instead. Foreground timeout is a kill deadline in seconds.",
+			"Execute a shell command in a persistent PTY-backed session. Set run_in_background:true for long-lived or interactive sessions; steer them with bash_input, snapshot with bash_output, tear down with kill_bash. To wait on observable state (a build finishing, a server coming up, a log line), never run sleep or poll loops — subscribe with the monitor tool instead. Foreground blocking stops at the ~60s window and a still-running command auto-detaches to a live background session; `timeout` is the process kill deadline in seconds.",
 		promptSnippet: "Run shell commands; run_in_background:true for long-lived/interactive PTY sessions",
 		promptGuidelines: ["Inspect PI_* environment variables for current model and session details."],
 		parameters: ptyBashSchema,

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/foreground-window.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/foreground-window.ts
@@ -1,0 +1,16 @@
+/**
+ * The foreground window is how long a bash tool call may block the model, which
+ * is a different concern from `timeout` — the deadline that kills the process.
+ * A command still running at the window is handed to a live background session
+ * instead of being killed, so the turn is freed without losing the work.
+ */
+
+export const DEFAULT_FOREGROUND_WINDOW_SECONDS = 60;
+/** A wait has nothing to show in the foreground; detach it almost at once. */
+export const SLEEP_WAIT_WINDOW_SECONDS = 5;
+
+export function resolveForegroundWindowSeconds(env: Record<string, string | undefined>): number {
+	const parsed = Number.parseFloat(env.PI_BASH_FOREGROUND_SECONDS ?? "");
+	if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_FOREGROUND_WINDOW_SECONDS;
+	return parsed;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/sleep-wait.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/sleep-wait.ts
@@ -1,0 +1,82 @@
+/**
+ * Detects commands whose whole purpose is to *wait* — `sleep 270; git log`,
+ * `for ...; do ...; sleep 5; done`, a bare `sleep 30`. Such a command should not
+ * hold the foreground: it detaches early so the session can keep working while
+ * the wait finishes in the background and its completion notification lands.
+ *
+ * Settle sleeps (`pkill; sleep 1`, a 2s server warm-up) are deliberately NOT
+ * sleep-waits: they are short by construction and detaching them would cost a
+ * notification round-trip for nothing.
+ */
+
+/** Minimum `sleep` seconds for a non-loop command to count as a wait. */
+export const SLEEP_WAIT_THRESHOLD_SECONDS = 10;
+/** Minimum per-iteration `sleep` seconds for a polling loop to count as a wait. */
+export const SLEEP_WAIT_LOOP_THRESHOLD_SECONDS = 2;
+
+export type SleepWaitRule = "R1" | "R2" | "R3" | "R4";
+
+export interface SleepWaitClassification {
+	readonly kind: "sleep-wait";
+	/** R1 pure, R2 leading chain, R3 polling loop, R4 trailing. */
+	readonly rule: SleepWaitRule;
+	/** Longest `sleep` argument that made the command match. */
+	readonly seconds: number;
+}
+
+/** `env A=1 bash -lc '...'` wrappers hide the real command from every rule below. */
+const SHELL_WRAPPER = /^(?:env\s+(?:[\w.]+=[^\s]*\s+)*)?(?:\/(?:usr\/)?bin\/)?(?:ba|z|da|k)?sh\s+-[a-z]*c\s+/i;
+/** Power management takes a `sleep` argument that has nothing to do with waiting. */
+const POWER_MANAGEMENT = /\b(?:pmset|systemsetup|caffeinate|displaysleep|disksleep)\b/;
+/** `sleep N` as a real command word — never `./sleepless 300` or `--sleep=3`. */
+const SLEEP_CALL = /(?<![\w.\-/])(?:\/(?:usr\/)?bin\/)?sleep\s+(\d+(?:\.\d+)?)/g;
+
+const PURE = /^sleep\s+\d+(?:\.\d+)?$/;
+const LEADING = /^\(?\s*(?:\/(?:usr\/)?bin\/)?sleep\s+\d+(?:\.\d+)?\s*(?:[;&|]|$)/;
+const LOOP = /\b(?:while|until|for)\b[\s\S]*?(?<![\w.\-/])(?:\/(?:usr\/)?bin\/)?sleep\s+\d/;
+const TRAILING = /[;&|]\s*(?:\/(?:usr\/)?bin\/)?sleep\s+\d+(?:\.\d+)?\s*\)?\s*$/;
+
+function unwrap(command: string): string {
+	let current = command.trim();
+	for (let depth = 0; depth < 3; depth += 1) {
+		const stripped = current.replace(SHELL_WRAPPER, "");
+		if (stripped === current) break;
+		current = stripped.trim();
+		const quote = current[0];
+		if ((quote === "'" || quote === '"') && current.endsWith(quote) && current.length > 1) {
+			current = current.slice(1, -1).trim();
+		}
+	}
+	return current;
+}
+
+function longestSleepSeconds(command: string): number | undefined {
+	SLEEP_CALL.lastIndex = 0;
+	let longest: number | undefined;
+	for (const match of command.matchAll(SLEEP_CALL)) {
+		const seconds = Number.parseFloat(match[1] ?? "");
+		if (!Number.isFinite(seconds)) continue;
+		if (longest === undefined || seconds > longest) longest = seconds;
+	}
+	return longest;
+}
+
+/**
+ * Classify a bash command as a sleep-wait, or `undefined` when it is ordinary
+ * work (including short settle sleeps below the thresholds).
+ */
+export function classifySleepWait(command: string): SleepWaitClassification | undefined {
+	if (POWER_MANAGEMENT.test(command)) return undefined;
+	const unwrapped = unwrap(command);
+	const seconds = longestSleepSeconds(unwrapped);
+	if (seconds === undefined) return undefined;
+
+	if (LOOP.test(unwrapped)) {
+		return seconds >= SLEEP_WAIT_LOOP_THRESHOLD_SECONDS ? { kind: "sleep-wait", rule: "R3", seconds } : undefined;
+	}
+	if (seconds < SLEEP_WAIT_THRESHOLD_SECONDS) return undefined;
+	if (PURE.test(unwrapped)) return { kind: "sleep-wait", rule: "R1", seconds };
+	if (LEADING.test(unwrapped)) return { kind: "sleep-wait", rule: "R2", seconds };
+	if (TRAILING.test(unwrapped)) return { kind: "sleep-wait", rule: "R4", seconds };
+	return undefined;
+}

--- a/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
+++ b/packages/coding-agent/test/suite/bash-timeout-extension.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from "vitest";
-import bashTimeoutExtension from "../../src/core/extensions/builtin/bash-timeout/index.ts";
 import {
 	applyBashTimeout,
 	BASH_DEFAULT_TIMEOUT_SECONDS,
 	BASH_MAX_TIMEOUT_SECONDS,
 	buildBashTimeoutPrompt,
 	resolveBashTimeoutDefaults,
-	resolveEffectiveBashTimeouts,
 } from "../../src/core/extensions/builtin/bash-timeout/timeout.ts";
 
 describe("resolveBashTimeoutDefaults", () => {
+	it("ships a 1800s (30 min) default and maximum kill deadline", () => {
+		expect(BASH_DEFAULT_TIMEOUT_SECONDS).toBe(1800);
+		expect(BASH_MAX_TIMEOUT_SECONDS).toBe(1800);
+		expect(resolveBashTimeoutDefaults({})).toEqual({ defaultSeconds: 1800, maxSeconds: 1800 });
+	});
+
 	it("returns built-in defaults when env vars are absent", () => {
 		const result = resolveBashTimeoutDefaults({});
 
@@ -24,9 +28,9 @@ describe("resolveBashTimeoutDefaults", () => {
 	});
 
 	it("reads PI_BASH_MAX_TIMEOUT_SECONDS from env", () => {
-		const result = resolveBashTimeoutDefaults({ PI_BASH_MAX_TIMEOUT_SECONDS: "900" });
+		const result = resolveBashTimeoutDefaults({ PI_BASH_MAX_TIMEOUT_SECONDS: "3600" });
 
-		expect(result.maxSeconds).toBe(900);
+		expect(result.maxSeconds).toBe(3600);
 	});
 
 	it("ignores PI_BASH_DEFAULT_TIMEOUT_SECONDS when value is not a positive integer", () => {
@@ -59,14 +63,14 @@ describe("resolveBashTimeoutDefaults", () => {
 });
 
 describe("applyBashTimeout", () => {
-	const defaults = { defaultSeconds: 120, maxSeconds: 600 };
+	const defaults = { defaultSeconds: 1800, maxSeconds: 1800 };
 
 	it("injects the default timeout when none is provided", () => {
 		const input: { command: string; timeout?: number } = { command: "echo hi" };
 
 		const result = applyBashTimeout(input, defaults);
 
-		expect(result).toEqual({ command: "echo hi", timeout: 120 });
+		expect(result).toEqual({ command: "echo hi", timeout: 1800 });
 	});
 
 	it("preserves a user-supplied timeout below the maximum", () => {
@@ -98,8 +102,8 @@ describe("applyBashTimeout", () => {
 		const zero = applyBashTimeout({ command: "noop", timeout: 0 }, defaults);
 		const negative = applyBashTimeout({ command: "noop", timeout: -5 }, defaults);
 
-		expect(zero).toEqual({ command: "noop", timeout: 120 });
-		expect(negative).toEqual({ command: "noop", timeout: 120 });
+		expect(zero).toEqual({ command: "noop", timeout: 1800 });
+		expect(negative).toEqual({ command: "noop", timeout: 1800 });
 	});
 
 	it("does not mutate the original input object", () => {
@@ -112,11 +116,36 @@ describe("applyBashTimeout", () => {
 });
 
 describe("buildBashTimeoutPrompt", () => {
-	it("includes the resolved default and max in the prompt rider", () => {
-		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
+	const SHIPPED_POLICY =
+		"\n## Bash Tool Timeout Policy\n\nThe `bash` tool's `timeout` parameter is the process kill deadline, not how long you wait for output: the command is killed when it reaches the deadline.\n\n- Default timeout: 1800s (30 min). Applied automatically when you do not set `timeout`.\n- Recommended maximum timeout: 1800s (30 min). Explicit `timeout` values are preserved because different hosts may use different timeout units.\n- Foreground blocking stops at the ~60s window. A command still running then auto-detaches alive to a background session with a `bash_id` and keeps running until it exits, hits the kill deadline, or is stopped with `kill_bash`.\n- Completion arrives automatically as a notification carrying the exit status and output tail, so end your turn rather than poll. Use `bash_output` only for a midpoint peek.\n- Waiting on an observable condition (a log line, a CI check, a server coming up) belongs to `monitor({command, filter})`, never a foreground `sleep` or poll loop.\n- Sessions started with `run_in_background: true` ignore `timeout` and live until exit or `kill_bash`.\n";
 
-		expect(prompt).toContain("Default timeout: 120s (2 min)");
-		expect(prompt).toContain("Recommended maximum timeout: 600s (10 min)");
+	it("is byte-identical to the shipped kill-deadline policy", () => {
+		expect(buildBashTimeoutPrompt({ defaultSeconds: 1800, maxSeconds: 1800 }, 60)).toBe(SHIPPED_POLICY);
+	});
+
+	it("states that timeout is the process kill deadline, not the wait budget", () => {
+		const prompt = buildBashTimeoutPrompt(resolveBashTimeoutDefaults({}), 60);
+
+		expect(prompt).toContain("## Bash Tool Timeout Policy");
+		expect(prompt).toContain("process kill deadline");
+		expect(prompt).toContain("not how long you wait");
+		expect(prompt).toContain("Default timeout: 1800s (30 min)");
+	});
+
+	it("contains the auto-detach and monitor guidance and never mentions the prompt cache", () => {
+		const prompt = buildBashTimeoutPrompt(resolveBashTimeoutDefaults({}), 60);
+
+		expect(prompt).toContain("~60s window");
+		expect(prompt).toContain("auto-detaches alive");
+		expect(prompt).toContain("bash_id");
+		expect(prompt).toContain("exit status and output tail");
+		expect(prompt).toContain("end your turn rather than poll");
+		expect(prompt).toContain("bash_output` only for a midpoint peek");
+		expect(prompt).toContain("monitor({command, filter})");
+		expect(prompt).toContain("run_in_background: true");
+		expect(prompt).toContain("kill_bash");
+		expect(prompt).not.toContain("tmux");
+		expect(prompt.toLowerCase()).not.toContain("prompt cache");
 	});
 
 	it("falls back to seconds for non-minute-aligned values", () => {
@@ -124,136 +153,5 @@ describe("buildBashTimeoutPrompt", () => {
 
 		expect(prompt).toContain("Default timeout: 45s (45s)");
 		expect(prompt).toContain("Recommended maximum timeout: 90s (90s)");
-	});
-
-	it("routes beyond-max workloads to background sessions and monitor, not tmux", () => {
-		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 });
-
-		expect(prompt).toContain("run_in_background");
-		expect(prompt).toContain("monitor");
-		expect(prompt).not.toContain("tmux");
-	});
-});
-
-describe("resolveEffectiveBashTimeouts", () => {
-	const base = { defaultSeconds: 120, maxSeconds: 600 };
-
-	it("leaves the defaults untouched when no cache budget applies", () => {
-		const result = resolveEffectiveBashTimeouts(base, undefined);
-
-		expect(result).toEqual({ defaultSeconds: 120, maxSeconds: 600, cacheCapped: false });
-	});
-
-	it("caps the recommended maximum at a 270s cache budget while keeping the injected default", () => {
-		const result = resolveEffectiveBashTimeouts(base, 270);
-
-		expect(result).toEqual({ defaultSeconds: 120, maxSeconds: 270, cacheCapped: true });
-	});
-
-	it("does not cap when the cache budget exceeds the configured maximum", () => {
-		const result = resolveEffectiveBashTimeouts(base, 3570);
-
-		expect(result).toEqual({ defaultSeconds: 120, maxSeconds: 600, cacheCapped: false });
-	});
-
-	it("pulls the default down with the max when the budget is below it", () => {
-		expect(resolveEffectiveBashTimeouts(base, 60)).toEqual({
-			defaultSeconds: 60,
-			maxSeconds: 60,
-			cacheCapped: true,
-		});
-		expect(resolveEffectiveBashTimeouts(base, 20)).toEqual({
-			defaultSeconds: 20,
-			maxSeconds: 20,
-			cacheCapped: true,
-		});
-	});
-
-	it("respects env-derived bases as the pre-cap values", () => {
-		const envBase = resolveBashTimeoutDefaults({
-			PI_BASH_DEFAULT_TIMEOUT_SECONDS: "30",
-			PI_BASH_MAX_TIMEOUT_SECONDS: "900",
-		});
-
-		expect(resolveEffectiveBashTimeouts(envBase, 270)).toEqual({
-			defaultSeconds: 30,
-			maxSeconds: 270,
-			cacheCapped: true,
-		});
-	});
-});
-
-describe("buildBashTimeoutPrompt cache awareness", () => {
-	const LEGACY_PROMPT =
-		"\n## Bash Tool Timeout Policy\n\nThe `bash` tool enforces timeouts even when you omit the `timeout` parameter:\n\n- Default timeout: 120s (2 min). Applied automatically when you do not set `timeout`.\n- Recommended maximum timeout: 600s (10 min). Explicit `timeout` values are preserved because different hosts may use different timeout units.\n- For long-running commands (builds, installs, test suites), set an explicit `timeout` that fits the workload. Do not assume commands run forever.\n- For commands that legitimately need to run beyond the recommended maximum, start them with `run_in_background: true` and watch the decisive output with `monitor` instead of raising the timeout.\n";
-
-	it("is byte-identical to the legacy policy when no cache budget applies", () => {
-		expect(buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600, cacheCapped: false })).toBe(LEGACY_PROMPT);
-	});
-
-	it("names the cache-safe ceiling and the prompt-cache reason when capped", () => {
-		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 270, cacheCapped: true });
-
-		expect(prompt).toContain("270s");
-		expect(prompt).toMatch(/prompt cache/i);
-		expect(prompt).toContain("run_in_background");
-		expect(prompt).toContain("monitor");
-	});
-
-	it("names a tiny ceiling when the budget collapses default and max together", () => {
-		const prompt = buildBashTimeoutPrompt({ defaultSeconds: 20, maxSeconds: 20, cacheCapped: true });
-
-		expect(prompt).toContain("20s");
-		expect(prompt).not.toContain("600s");
-	});
-
-	it("still accepts the legacy two-field defaults shape", () => {
-		expect(buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 })).toBe(LEGACY_PROMPT);
-	});
-});
-
-describe("bashTimeoutExtension with native Anthropic bash active", () => {
-	it("keeps the legacy policy when the PTY bash tool has stepped aside", async () => {
-		const previous = process.env.PI_ANTHROPIC_BASH;
-		process.env.PI_ANTHROPIC_BASH = "1";
-		try {
-			const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
-			const pi = {
-				on: (name: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
-					handlers.set(name, handler);
-				},
-			};
-			bashTimeoutExtension(pi as never);
-
-			const ctx = {
-				model: { api: "anthropic-messages" },
-				getPromptCacheSafeWaitSeconds: () => 270,
-			};
-			const result = (await handlers.get("before_agent_start")?.({ systemPrompt: "BASE" }, ctx)) as {
-				systemPrompt: string;
-			};
-
-			expect(result.systemPrompt).toBe(`BASE${buildBashTimeoutPrompt({ defaultSeconds: 120, maxSeconds: 600 })}`);
-		} finally {
-			if (previous === undefined) delete process.env.PI_ANTHROPIC_BASH;
-			else process.env.PI_ANTHROPIC_BASH = previous;
-		}
-	});
-
-	it("still caps the ceiling when native Anthropic bash is not active", async () => {
-		const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
-		const pi = {
-			on: (name: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
-				handlers.set(name, handler);
-			},
-		};
-		bashTimeoutExtension(pi as never);
-
-		const ctx = { model: { api: "anthropic-messages" }, getPromptCacheSafeWaitSeconds: () => 270 };
-		const result = (await handlers.get("before_agent_start")?.({ systemPrompt: "BASE" }, ctx)) as {
-			systemPrompt: string;
-		};
-
-		expect(result.systemPrompt).toContain("270s");
 	});
 });

--- a/packages/coding-agent/test/suite/bash-timeout-handlers.test.ts
+++ b/packages/coding-agent/test/suite/bash-timeout-handlers.test.ts
@@ -88,6 +88,8 @@ describe("bashTimeoutExtension factory wiring", () => {
 		expect(result.systemPrompt).toContain("Bash Tool Timeout Policy");
 		expect(result.systemPrompt).toContain(`Default timeout: ${BASH_DEFAULT_TIMEOUT_SECONDS}s`);
 		expect(result.systemPrompt).toContain(`Recommended maximum timeout: ${BASH_MAX_TIMEOUT_SECONDS}s`);
+		expect(result.systemPrompt).toContain("process kill deadline");
+		expect(result.systemPrompt.toLowerCase()).not.toContain("prompt cache");
 	});
 
 	it("respects PI_BASH_DEFAULT_TIMEOUT_SECONDS env override at factory load time", async () => {
@@ -109,6 +111,59 @@ describe("bashTimeoutExtension factory wiring", () => {
 		} finally {
 			if (original === undefined) delete process.env.PI_BASH_DEFAULT_TIMEOUT_SECONDS;
 			else process.env.PI_BASH_DEFAULT_TIMEOUT_SECONDS = original;
+		}
+	});
+
+	it("omits the auto-detach promise when native Anthropic bash makes the PTY tool step aside", async () => {
+		process.env.PI_ANTHROPIC_BASH = "1";
+		try {
+			const { api, handlers } = makeApiMock();
+			bashTimeoutExtension(api as never);
+
+			const result = (await handlers.before_agent_start[0]({
+				systemPrompt: "BASE",
+				// biome-ignore lint/suspicious/noExplicitAny: minimal ctx stub for the handler
+			} as any, { model: { api: "anthropic-messages" } } as any)) as { systemPrompt: string };
+
+			expect(result.systemPrompt).toContain("Bash Tool Timeout Policy");
+			expect(result.systemPrompt).not.toContain("auto-detaches");
+			expect(result.systemPrompt).not.toContain("Foreground blocking stops");
+		} finally {
+			delete process.env.PI_ANTHROPIC_BASH;
+		}
+	});
+
+	it("keeps the auto-detach promise for a non-anthropic model while native bash is enabled", async () => {
+		process.env.PI_ANTHROPIC_BASH = "1";
+		try {
+			const { api, handlers } = makeApiMock();
+			bashTimeoutExtension(api as never);
+
+			const result = (await handlers.before_agent_start[0]({
+				systemPrompt: "BASE",
+				// biome-ignore lint/suspicious/noExplicitAny: minimal ctx stub for the handler
+			} as any, { model: { api: "openai-completions" } } as any)) as { systemPrompt: string };
+
+			expect(result.systemPrompt).toContain("auto-detaches");
+		} finally {
+			delete process.env.PI_ANTHROPIC_BASH;
+		}
+	});
+
+	it("names the configured foreground window instead of a hardcoded 60s", async () => {
+		process.env.PI_BASH_FOREGROUND_SECONDS = "25";
+		try {
+			const { api, handlers } = makeApiMock();
+			bashTimeoutExtension(api as never);
+
+			const result = (await handlers.before_agent_start[0]({ systemPrompt: "BASE" })) as {
+				systemPrompt: string;
+			};
+
+			expect(result.systemPrompt).toContain("25s window");
+			expect(result.systemPrompt).not.toContain("60s window");
+		} finally {
+			delete process.env.PI_BASH_FOREGROUND_SECONDS;
 		}
 	});
 });

--- a/packages/coding-agent/test/suite/bash-timeout-handlers.test.ts
+++ b/packages/coding-agent/test/suite/bash-timeout-handlers.test.ts
@@ -5,7 +5,11 @@ import bashTimeoutExtension, {
 	type BashToolInputLike,
 } from "../../src/core/extensions/builtin/bash-timeout/index.ts";
 
-type Handler = (event: unknown) => Promise<unknown> | unknown;
+type Handler = (event: unknown, ctx?: unknown) => Promise<unknown> | unknown;
+
+function ctxWithApi(api: string): { model: { api: string } } {
+	return { model: { api } };
+}
 
 interface ApiMock {
 	api: { on(event: string, handler: Handler): void };
@@ -120,10 +124,10 @@ describe("bashTimeoutExtension factory wiring", () => {
 			const { api, handlers } = makeApiMock();
 			bashTimeoutExtension(api as never);
 
-			const result = (await handlers.before_agent_start[0]({
-				systemPrompt: "BASE",
-				// biome-ignore lint/suspicious/noExplicitAny: minimal ctx stub for the handler
-			} as any, { model: { api: "anthropic-messages" } } as any)) as { systemPrompt: string };
+			const result = (await handlers.before_agent_start[0](
+				{ systemPrompt: "BASE" },
+				ctxWithApi("anthropic-messages"),
+			)) as { systemPrompt: string };
 
 			expect(result.systemPrompt).toContain("Bash Tool Timeout Policy");
 			expect(result.systemPrompt).not.toContain("auto-detaches");
@@ -139,10 +143,10 @@ describe("bashTimeoutExtension factory wiring", () => {
 			const { api, handlers } = makeApiMock();
 			bashTimeoutExtension(api as never);
 
-			const result = (await handlers.before_agent_start[0]({
-				systemPrompt: "BASE",
-				// biome-ignore lint/suspicious/noExplicitAny: minimal ctx stub for the handler
-			} as any, { model: { api: "openai-completions" } } as any)) as { systemPrompt: string };
+			const result = (await handlers.before_agent_start[0](
+				{ systemPrompt: "BASE" },
+				ctxWithApi("openai-completions"),
+			)) as { systemPrompt: string };
 
 			expect(result.systemPrompt).toContain("auto-detaches");
 		} finally {

--- a/packages/coding-agent/test/suite/sleep-wait.test.ts
+++ b/packages/coding-agent/test/suite/sleep-wait.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { classifySleepWait } from "../../src/core/extensions/builtin/terminal/tools/sleep-wait.ts";
+
+describe("classifySleepWait", () => {
+	describe("R1 pure sleep", () => {
+		it("matches a bare long sleep", () => {
+			expect(classifySleepWait("sleep 270")).toEqual({ kind: "sleep-wait", rule: "R1", seconds: 270 });
+		});
+
+		it("ignores a short settle sleep below the threshold", () => {
+			expect(classifySleepWait("sleep 3")).toBeUndefined();
+		});
+
+		it("matches exactly at the threshold", () => {
+			expect(classifySleepWait("sleep 10")).toEqual({ kind: "sleep-wait", rule: "R1", seconds: 10 });
+		});
+	});
+
+	describe("R2 leading sleep chained into a check", () => {
+		it("matches the canonical poll-then-check command", () => {
+			expect(classifySleepWait("sleep 270; git log --oneline -2")).toEqual({
+				kind: "sleep-wait",
+				rule: "R2",
+				seconds: 270,
+			});
+		});
+
+		it("matches an && chain", () => {
+			expect(classifySleepWait("sleep 45 && gh pr view 6127 --json mergeStateStatus")).toEqual({
+				kind: "sleep-wait",
+				rule: "R2",
+				seconds: 45,
+			});
+		});
+
+		it("ignores a short leading settle sleep", () => {
+			expect(classifySleepWait("sleep 2 && curl -s http://localhost:3000/health")).toBeUndefined();
+		});
+	});
+
+	describe("R3 polling loop", () => {
+		it("matches a for-loop poll with a short sleep", () => {
+			expect(classifySleepWait("for i in {1..6}; do kill -0 15598 || break; sleep 5; done")).toEqual({
+				kind: "sleep-wait",
+				rule: "R3",
+				seconds: 5,
+			});
+		});
+
+		it("matches a while-true poll", () => {
+			expect(classifySleepWait("while true; do\n  sleep 30\n  ls /tmp/out || true\ndone")).toEqual({
+				kind: "sleep-wait",
+				rule: "R3",
+				seconds: 30,
+			});
+		});
+
+		it("ignores a sub-second loop delay below the loop threshold", () => {
+			expect(classifySleepWait("for i in {1..5}; do sleep 0.1; done")).toBeUndefined();
+		});
+	});
+
+	describe("R4 trailing sleep", () => {
+		it("matches a long trailing sleep", () => {
+			expect(classifySleepWait("bun run dev & sleep 30")).toEqual({ kind: "sleep-wait", rule: "R4", seconds: 30 });
+		});
+
+		it("ignores a short trailing settle sleep", () => {
+			expect(classifySleepWait("pkill -9 bun 2>/dev/null; sleep 1")).toBeUndefined();
+		});
+	});
+
+	describe("shell wrapper stripping", () => {
+		it("sees through bash -lc quoting", () => {
+			expect(classifySleepWait("bash -lc 'sleep 270; git log --oneline -2'")).toEqual({
+				kind: "sleep-wait",
+				rule: "R2",
+				seconds: 270,
+			});
+		});
+
+		it("sees through an env-prefixed sh -c wrapper", () => {
+			expect(classifySleepWait('env FOO=1 sh -c "sleep 120"')).toEqual({
+				kind: "sleep-wait",
+				rule: "R1",
+				seconds: 120,
+			});
+		});
+	});
+
+	describe("non-sleep commands and guards", () => {
+		it("returns undefined for a command with no sleep", () => {
+			expect(classifySleepWait("npm run check")).toBeUndefined();
+		});
+
+		it("does not match sleep-like words inside other tokens", () => {
+			expect(classifySleepWait("./sleepless 300")).toBeUndefined();
+		});
+
+		it("never matches power-management commands", () => {
+			expect(classifySleepWait("pmset -g sleep 300")).toBeUndefined();
+			expect(classifySleepWait("caffeinate -i sleep 600")).toBeUndefined();
+		});
+
+		it("takes the longest sleep when several appear", () => {
+			expect(classifySleepWait("sleep 15; echo mid; sleep 90")).toEqual({
+				kind: "sleep-wait",
+				rule: "R2",
+				seconds: 90,
+			});
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
+++ b/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
@@ -118,7 +118,7 @@ async function flushMicrotasks(): Promise<void> {
 	await Promise.resolve();
 }
 
-function setup(options: { safeWaitSeconds?: number; timeoutAction?: "background" | "kill" } = {}) {
+function setup(options: { timeoutAction?: "background" | "kill" } = {}) {
 	const runtime = new FakeRuntime();
 	const backgroundExit = vi.fn();
 	const manager = {
@@ -132,10 +132,7 @@ function setup(options: { safeWaitSeconds?: number; timeoutAction?: "background"
 		defaultRows: 40,
 		getEnv: () => ({}),
 		timeoutAction: options.timeoutAction ?? "background",
-		getSessionContext: () =>
-			({
-				getPromptCacheSafeWaitSeconds: () => options.safeWaitSeconds,
-			}) as ExtensionContext,
+		getSessionContext: () => ({}) as ExtensionContext,
 		onBackgroundExit: backgroundExit,
 	} as TerminalToolContext;
 	spawned.runtime = runtime;
@@ -155,8 +152,8 @@ afterEach(() => {
 	vi.useRealTimers();
 });
 
-describe("terminal bash foreground cache-deadline auto-detach", () => {
-	it("keeps native foreground behavior when no cache-safe budget is available", async () => {
+describe("terminal bash foreground window auto-detach", () => {
+	it("keeps native foreground behavior when the command exits inside the window", async () => {
 		const { bash, runtime } = setup();
 		const execution = bash.execute("no-budget", { command: "echo done", timeout: 10 });
 		await flushMicrotasks();
@@ -170,25 +167,25 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 	});
 
 	it("does not auto-detach when timeoutAction is kill", async () => {
-		const { bash, runtime } = setup({ safeWaitSeconds: 5, timeoutAction: "kill" });
-		const execution = bash.execute("kill-policy", { command: "sleep", timeout: 10 });
+		const { bash, runtime } = setup({ timeoutAction: "kill" });
+		const execution = bash.execute("kill-policy", { command: "wait for it", timeout: 900 });
 		await flushMicrotasks();
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 		expect(runtime.exited).toBe(false);
 		expect(runtime.readDeltaCalls).toBe(0);
 
 		runtime.exit({ timedOut: true, exitCode: 124 });
 		const result = await execution;
 		expect(result.isError).toBe(true);
-		expect(firstText(result)).toBe("Command timed out after 10 seconds");
+		expect(firstText(result)).toBe("Command timed out after 900 seconds");
 		expect(result.details).toBeUndefined();
 	});
 
-	it("keeps native foreground behavior when the configured timeout equals the budget", async () => {
-		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
-		const execution = bash.execute("equal-budget", { command: "echo exact", timeout: 5 });
+	it("keeps native foreground behavior when the timeout is shorter than the window", async () => {
+		const { bash, runtime } = setup();
+		const execution = bash.execute("short-timeout", { command: "echo exact", timeout: 30 });
 		await flushMicrotasks();
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(29_000);
 		expect(runtime.readDeltaCalls).toBe(0);
 
 		runtime.emit("exact\n");
@@ -198,27 +195,27 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 		expect(result.details).toEqual({ status: "completed" });
 	});
 
-	it("returns the exact completed result when a command exits before the budget", async () => {
-		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
-		const execution = bash.execute("early-exit", { command: "echo early", timeout: 10 });
+	it("returns the exact completed result when a command exits before the window", async () => {
+		const { bash, runtime } = setup();
+		const execution = bash.execute("early-exit", { command: "echo early", timeout: 900 });
 		await flushMicrotasks();
 		runtime.emit("early\n");
 		runtime.exit();
 
 		const result = await execution;
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 		expect(firstText(result)).toBe("early");
 		expect(result.details).toEqual({ status: "completed" });
 		expect(runtime.readDeltaCalls).toBe(0);
 	});
 
-	it("linearizes an exit exactly at D ahead of detachment", async () => {
-		spawned.exitAtMs = 5_000;
-		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
-		const execution = bash.execute("exit-at-deadline", { command: "echo same-tick", timeout: 10 });
+	it("linearizes an exit exactly at the window ahead of detachment", async () => {
+		spawned.exitAtMs = 60_000;
+		const { bash, runtime } = setup();
+		const execution = bash.execute("exit-at-deadline", { command: "echo same-tick", timeout: 900 });
 		await flushMicrotasks();
 		runtime.emit("same-tick\n");
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 
 		const result = await execution;
 		expect(firstText(result)).toBe("same-tick");
@@ -227,20 +224,20 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 	});
 
 	it("auto-detaches a still-running finite-timeout command, preserves T, and sweeps after its native grace", async () => {
-		const { bash, runtime, manager, backgroundExit } = setup({ safeWaitSeconds: 5 });
-		const execution = bash.execute("detach", { command: "sleep", timeout: 10 });
+		const { bash, runtime, manager, backgroundExit } = setup();
+		const execution = bash.execute("detach", { command: "wait for it", timeout: 900 });
 		await flushMicrotasks();
 		runtime.emit("READY\n");
 		runtime.nextDeltaDroppedChars = 3;
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 
 		const result = await execution;
-		expect(spawned.request).toMatchObject({ timeoutMs: 10_000 });
+		expect(spawned.request).toMatchObject({ timeoutMs: 900_000 });
 		expect(result).toEqual({
 			content: [
 				{
 					type: "text",
-					text: 'Command is still running; auto-detached to background with ID: bash_1 (not killed; the original 10s timeout still applies).\n\nPartial output:\nREADY\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: "bash_1" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: "bash_1" }) to stop this session.',
+					text: 'Command is still running; auto-detached to background with ID: bash_1 (not killed; the original 900s timeout still applies).\n\nPartial output:\nREADY\n\nContinue other work; completion will be reported automatically with exit status and output tail. Use bash_output({ bash_id: "bash_1" }) only to peek at new output. monitor cannot attach to this session; use it for future event-driven launches. Use kill_bash({ bash_id: "bash_1" }) to stop this session.',
 				},
 			],
 			details: { bash_id: "bash_1", background: true, auto_detached: true, status: "running", droppedChars: 3 },
@@ -250,16 +247,16 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 		expect(runtime.session.kill).not.toHaveBeenCalled();
 		expect(backgroundExit).not.toHaveBeenCalled();
 
-		await vi.advanceTimersByTimeAsync(10_000);
+		await vi.advanceTimersByTimeAsync(900_000);
 		expect(manager.stop).toHaveBeenCalledWith("bash_1");
 	});
 
 	it("uses the no-timeout parenthetical and keeps the delta cursor continuous after detachment", async () => {
-		const { bash, output, runtime } = setup({ safeWaitSeconds: 5 });
+		const { bash, output, runtime } = setup();
 		const execution = bash.execute("no-timeout", { command: "wait forever" });
 		await flushMicrotasks();
 		runtime.emit("BEFORE\n");
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 
 		const detached = await execution;
 		expect(firstText(detached)).toBe(
@@ -277,10 +274,10 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 
 	it("ignores an abort after the detach commit and notifies once when the detached session exits", async () => {
 		const controller = new AbortController();
-		const { bash, runtime, backgroundExit } = setup({ safeWaitSeconds: 5 });
-		const execution = bash.execute("abort-after-detach", { command: "sleep", timeout: 10 }, controller.signal);
+		const { bash, runtime, backgroundExit } = setup();
+		const execution = bash.execute("abort-after-detach", { command: "wait for it", timeout: 900 }, controller.signal);
 		await flushMicrotasks();
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 		await execution;
 
 		controller.abort();
@@ -291,13 +288,13 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 		expect(backgroundExit).toHaveBeenCalledWith("bash_1", runtime);
 	});
 
-	it("linearizes an abort exactly at D ahead of detachment", async () => {
+	it("linearizes an abort exactly at the window ahead of detachment", async () => {
 		const controller = new AbortController();
-		setTimeout(() => controller.abort(), 5_000);
-		const { bash, runtime } = setup({ safeWaitSeconds: 5 });
-		const execution = bash.execute("abort-at-deadline", { command: "sleep", timeout: 10 }, controller.signal);
+		setTimeout(() => controller.abort(), 60_000);
+		const { bash, runtime } = setup();
+		const execution = bash.execute("abort-at-deadline", { command: "wait for it", timeout: 900 }, controller.signal);
 		await flushMicrotasks();
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 		expect(runtime.session.kill).toHaveBeenCalledWith("SIGKILL");
 		expect(runtime.readDeltaCalls).toBe(0);
 
@@ -305,5 +302,48 @@ describe("terminal bash foreground cache-deadline auto-detach", () => {
 		const result = await execution;
 		expect(result.isError).toBe(true);
 		expect(firstText(result)).toBe("Command aborted");
+	});
+
+	it("honors PI_BASH_FOREGROUND_SECONDS for the blocking window", async () => {
+		vi.stubEnv("PI_BASH_FOREGROUND_SECONDS", "20");
+		const { bash, runtime } = setup();
+		const execution = bash.execute("env-window", { command: "long build", timeout: 900 });
+		await flushMicrotasks();
+		runtime.emit("BUILDING\n");
+		await vi.advanceTimersByTimeAsync(20_000);
+
+		const result = await execution;
+		expect(firstText(result)).toContain("auto-detached to background with ID: bash_1");
+		expect(result.details).toMatchObject({ auto_detached: true, status: "running" });
+		vi.unstubAllEnvs();
+	});
+
+	it("detaches a sleep-wait command at the short sleep window instead of the full window", async () => {
+		const { bash, runtime } = setup();
+		const execution = bash.execute("sleep-wait", { command: "sleep 270; git log --oneline -2", timeout: 900 });
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(5_000);
+
+		const result = await execution;
+		const text = firstText(result);
+		expect(text).toContain("auto-detached to background with ID: bash_1");
+		expect(text).toContain("end your turn");
+		expect(text).toContain("monitor(");
+		expect(result.details).toMatchObject({ auto_detached: true, sleep_wait: true, status: "running" });
+		expect(runtime.session.kill).not.toHaveBeenCalled();
+	});
+
+	it("keeps the full window for a settle sleep below the sleep-wait threshold", async () => {
+		const { bash, runtime } = setup();
+		const execution = bash.execute("settle", { command: "pkill -9 bun 2>/dev/null; sleep 1", timeout: 900 });
+		await flushMicrotasks();
+		await vi.advanceTimersByTimeAsync(5_000);
+		expect(runtime.readDeltaCalls).toBe(0);
+
+		runtime.emit("gone\n");
+		runtime.exit();
+		const result = await execution;
+		expect(firstText(result)).toBe("gone");
+		expect(result.details).toEqual({ status: "completed" });
 	});
 });

--- a/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
+++ b/packages/coding-agent/test/suite/terminal-bash-auto-detach.test.ts
@@ -346,4 +346,20 @@ describe("terminal bash foreground window auto-detach", () => {
 		expect(firstText(result)).toBe("gone");
 		expect(result.details).toEqual({ status: "completed" });
 	});
+
+	it("never hands a process deadline to an explicit background session", async () => {
+		const { bash } = setup();
+
+		const execution = bash.execute("bg-unlimited", {
+			command: "tail -f /var/log/system.log",
+			run_in_background: true,
+			timeout: 1800,
+		});
+		await vi.advanceTimersByTimeAsync(500);
+		const started = await execution;
+
+		expect(firstText(started)).toContain("Command running in background with ID: bash_1");
+		expect(spawned.request).toMatchObject({ command: "tail -f /var/log/system.log" });
+		expect((spawned.request as { timeoutMs?: number }).timeoutMs).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/suite/terminal-extension.test.ts
+++ b/packages/coding-agent/test/suite/terminal-extension.test.ts
@@ -280,7 +280,7 @@ describe("terminal extension auto-detach wiring", () => {
 		vi.useRealTimers();
 	});
 
-	it("promotes READY at the live cache deadline, preserves delta continuity, and notifies exactly once on kill", async () => {
+	it("promotes READY at the foreground window, preserves delta continuity, and notifies exactly once on kill", async () => {
 		vi.useFakeTimers();
 		let output = "";
 		let consumed = 0;
@@ -376,7 +376,6 @@ describe("terminal extension auto-detach wiring", () => {
 			cwd: process.cwd(),
 			mode: "tui",
 			model: { id: "fixture", api: "anthropic-messages" },
-			getPromptCacheSafeWaitSeconds: () => 5,
 			ui: { notify: () => {}, setStatus: () => {} },
 		} as unknown as ExtensionContext;
 		for (const handler of handlers.get("session_start") ?? []) await handler({}, ctx);
@@ -390,11 +389,11 @@ describe("terminal extension auto-detach wiring", () => {
 		const kill = tools.get("kill_bash") as unknown as {
 			execute: (id: string, input: { bash_id: string }) => Promise<TerminalToolResult>;
 		};
-		const execution = bash.execute("foreground", { command: "fixture", timeout: 10 });
+		const execution = bash.execute("foreground", { command: "fixture", timeout: 900 });
 		await Promise.resolve();
 		await Promise.resolve();
 		emit("READY\n");
-		await vi.advanceTimersByTimeAsync(5_000);
+		await vi.advanceTimersByTimeAsync(60_000);
 
 		const detached = await execution;
 		expect(firstText(detached)).toContain("auto-detached to background with ID: bash_1");


### PR DESCRIPTION
## What

Splits the bash tool's two conflated concerns: how long the **model blocks** and how long the **process lives**.

- **Foreground window** — blocking now stops at a fixed window (`PI_BASH_FOREGROUND_SECONDS`, default 60s) instead of tracking the prompt-cache safe-wait budget. A command still running at the window auto-detaches **alive** to a background session; its completion arrives as a notification. New `terminal/tools/foreground-window.ts`.
- **`timeout` = process kill deadline** — default 1800s (30 min), enforced after detach by the existing `scheduleDetachedSweep`. The cache-ceiling logic (`resolveEffectiveBashTimeouts`, `cacheCapped`) is removed: a 60s window sits far below every cache lifetime, so it can no longer breach one.
- **Sleep-aware early detach** — new `terminal/tools/sleep-wait.ts` classifies wait-shaped commands (R1 bare `sleep N`, R2 `sleep N; cmd`, R3 polling loop, R4 trailing `sleep N`) after stripping `bash -lc` wrappers. A match detaches at 5s and the handoff message branches: end your turn and wait for the completion notification, and use `monitor({command, filter})` for pattern waits. Short settle sleeps (`pkill; sleep 1`) stay foreground via a 10s threshold (2s inside a loop); `pmset`/`caffeinate` never match.

## Why

A census of real local coding-agent session stores found **~7,073 sleep-wait bash commands** — polling loops, `sleep 45; gh pr view ...`, bare `sleep 30` — i.e. agents burning foreground turn time waiting. The old behavior made this worse: a command that outlived its timeout was **killed**, so the wait was spent and then thrown away.

Guidance alone does not fix it — the PTY bash description and `monitor`'s `promptGuidelines` already said "never run sleep or poll loops", and the census still found 346 such commands in senpi's own sessions. This makes the runtime do the right thing instead: the wait finishes in the background and its result comes back.

## Behavior change

| | before | after |
|---|---|---|
| foreground blocking | prompt-cache budget (270s on Anthropic) | 60s window (`PI_BASH_FOREGROUND_SECONDS`) |
| `timeout` meaning | foreground kill deadline | process kill deadline, default 1800s |
| >window command | killed at timeout | auto-detached alive, completion notified |
| `sleep 270; git log` | blocks 270s | detaches at 5s, result delivered later |
| `run_in_background: true` | unlimited | unlimited (unchanged) |

One deliberate cost: a 61-120s command now takes one extra notification round-trip. The turn is freed at 60s in exchange.

## Honesty guard

`buildBashTimeoutPrompt` takes the window and omits the auto-detach bullets when it is `undefined` — which is what happens when `PI_ANTHROPIC_BASH` is active for an `anthropic-messages` model and the terminal extension steps aside (`terminal/extension.ts:117-119`). Nothing implements detach there, so the policy must not promise it. This preserves, in narrower form, the exception documented in the 2026-07-28 fork-tracker entry (kept and marked superseded).

## Verification

- **Scoped suites: 68 passed / 7 files** — `sleep-wait`, `terminal-bash-auto-detach`, `terminal-detach-gate`, `terminal-bash-abort`, `bash-timeout-extension`, `bash-timeout-handlers`, `prompt-surface-stale-wait-idioms`. Every behavior change went RED first.
- **`npm run check`: green, warning-free.**
- **Real-CLI QA** via `.agents/skills/senpi-qa` mock-loop (zero provider tokens, sandboxed HOME, real `~/.senpi` verified unchanged):
  - `sleep 45; echo WOKE-UP-MARKER` -> detached at **6.7s**, tool result carries the sleep branch + `monitor(` recommendation + `1800s timeout still applies`. 5/5.
  - 90s CPU-bound non-sleep command with `PI_BASH_FOREGROUND_SECONDS=8` -> detached at the window with the **generic** wording and no sleep phrasing. 4/4.
  - Evidence: `local-ignore/qa-evidence/20260807-bash-async-wait-{sleep,long}/`.

`changes.md` updated for `terminal/` and `bash-timeout/`. `core/tools/bash.ts` is untouched — the non-PTY fallback has no background-session infrastructure, so it keeps kill semantics.

Plan: `.omo/plans/bash-async-wait.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detaches long `bash` commands instead of blocking or killing them. A fixed foreground window (default 60s) frees the turn, while `timeout` now means the process kill deadline (default 1800s).

- **New Features**
  - Foreground window: blocks for ~60s (`PI_BASH_FOREGROUND_SECONDS`), then auto-detaches to a live background session; completion arrives as a notification with the output tail. Partial output is included; use `bash_output` only to peek.
  - Sleep-wait detection: classifies `sleep`/poll loops (R1–R4) and detaches at ~5s; short settle sleeps stay foreground. Detached results include `sleep_wait: true` and guidance to end the turn and prefer `monitor({ command, filter })`.
  - `timeout` semantics: is now the process kill deadline (default/max 1800s). `run_in_background: true` sessions spawn without a process deadline and live until exit or `kill_bash`. Non-PTY `core/tools/bash.ts` keeps kill semantics.
  - Prompts/docs: policy updated to name the configured window and omit auto-detach when native Anthropic bash replaces the PTY tool.

- **Migration**
  - Expect a notification round-trip for 61–120s commands; the turn frees at ~60s.
  - Replace foreground `sleep`/poll loops with `monitor({ command, filter })`; do not poll `bash_output` for completions.
  - Tune the window with `PI_BASH_FOREGROUND_SECONDS`; stop sessions with `kill_bash`.

<sup>Written for commit 7a73c4e4016aa37e23320e9ec18c840a61df0294. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

