### PR TITLE
docs: refresh hierarchical AGENTS.md knowledge base (init-deep)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Senpi Repository Guide
 
-Generated: 2026-07-17
-Commit: `92fc96389`
+Generated: 2026-08-07
+Commit: `4f26b8282`
 Branch: `main`
 
 Metadata above records the source state used for this generation pass.
@@ -40,7 +40,11 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 | `packages/agent/` | Browser-safe agent loop plus optional Node harness |
 | `packages/coding-agent/` | `senpi` CLI, sessions, extensions, RPC, interactive mode |
 | `packages/tui/` | Differential terminal renderer and editor primitives |
-| `packages/server/` | Experimental daemon, IPC, RPC-process supervision |
+| `packages/server/` | Composable protocol server; legacy daemon/IPC under `src/legacy/` |
+| `packages/protocol/` | Transport-neutral CBOR protocol for remote pi sessions |
+| `packages/client/` | Transport-neutral client for remote pi sessions (framed CBOR) |
+| `packages/storage/` | Storage backends; `sqlite-node/` Node sqlite session store |
+| `packages/evals/` | Behavioral, model-backed eval suites over real `AgentSession` |
 | `packages/pty/` | TypeScript PTY loader, sessions, registry, pipe fallback |
 | `packages/senpi-codemode/` | Source-only persistent-kernel `eval` extension |
 | `crates/senpi-pty/` | Rust/N-API native PTY implementation and ABI owner |
@@ -64,6 +68,7 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 | Change eval prompt/rendering | `packages/senpi-codemode/src/prompt/` and `src/tool/` |
 | Audit changelogs | `.github/agent/commands/cl.md` |
 | Prepare a release | `scripts/release.mjs` and `scripts/release-packages.mjs` |
+| Regenerate model catalog data | `packages/ai/src/providers/data/` via root `npm run hydrate:model-data` / `check:model-data` |
 
 ## CODE MAP
 
@@ -97,6 +102,7 @@ Persistent terminals -> packages/pty -> crates/senpi-pty
 - Changing fork-specific source behavior means reading the nearest `changes.md` first and updating it in the same verified increment, not in a follow-up.
 - Each entry records what changed, why, why an extension couldn't do it, and the expected merge-conflict zones. Merges resolve these files to `ours`, so a stale entry misleads the next upstream sync.
 - Changelog edits are release/audit work only. Follow `.github/agent/commands/cl.md` and never edit released sections.
+- PRs must satisfy the changelog gate (`.github/workflows/changelog-gate.yml`, `scripts/check-pr-changelog.mjs`).
 
 ## QUALITY GATES
 

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -7,11 +7,20 @@
 ```text
 src/agent.ts                 Agent state, prompt queue, subscriptions, abort
 src/agent-loop.ts            Provider/tool loop and scheduling
+src/assistant-terminal-state.ts  Terminal-state classification for assistant turns
+src/empty-assistant-recovery.ts  Recovery for empty assistant responses
+src/stream-fn.ts             Injectable stream function abstraction
 src/types.ts                 App messages, events, state, conversion boundary
 src/proxy.ts                 Remote stream proxy
 src/index.ts                 Browser-safe public exports
 src/node.ts                  Node harness public exports
 src/harness/                 Compaction, sessions, skills, prompts, env adapters
+src/harness/tools/           Built-in tools: bash, edit, edit-diff, write, read,
+                             image, file-mutation-queue, path-utils, tool-context, index
+src/harness/messages.ts      Harness message helpers
+src/harness/prompt-templates.ts  Prompt template expansion
+src/harness/system-prompt.ts System prompt assembly
+src/harness/skills.ts        Skill discovery and loading
 src/changes.md               Fork-specific behavior record
 ```
 
@@ -24,7 +33,9 @@ src/changes.md               Fork-specific behavior record
 | Public message/event contract | `src/types.ts` |
 | Harness orchestration | `src/harness/agent-harness.ts` |
 | Node process and filesystem behavior | `src/harness/env/nodejs.ts` |
-| Session persistence | `src/harness/session/` |
+| Session persistence | `src/harness/session/` (`repository.ts`, `jsonl-store.ts`, `memory-store.ts`, `array-session-reader.ts`, `fork.ts`, `keyed-operation-queue.ts`, `search-backend.ts`) |
+| Built-in tool behavior | `src/harness/tools/` |
+| SQLite session storage | `packages/storage/sqlite-node` (`@earendil-works/pi-storage-sqlite-node`) |
 | Compaction | `src/harness/compaction/` |
 
 ## INVARIANTS
@@ -48,4 +59,11 @@ src/changes.md               Fork-specific behavior record
 - Run `npm test` from this package for agent-loop coverage.
 - Run `npm run test:harness` for harness/session/env changes.
 - Runtime changes also require root `npm run check` and the root QA evidence gate.
-- Keep `README.md`, `docs/agent-harness.md`, and `src/changes.md` aligned with public or fork-specific changes.
+- Keep `README.md`, `docs/agent-harness.md`, `docs/harness.md`, `docs/harness-v2.md`, and `src/changes.md` aligned with public or fork-specific changes.
+
+## NOTES
+
+- Session backend refactor: old `jsonl-repo`/`memory-repo`/`repo-utils` are gone. Storage is store-based (`jsonl-store.ts`, `memory-store.ts`, SQLite via `packages/storage/sqlite-node`) behind `repository.ts`.
+
+---
+Generated: 2026-08-07 | Commit `4f26b8282`

--- a/packages/ai/AGENTS.md
+++ b/packages/ai/AGENTS.md
@@ -1,24 +1,48 @@
 # packages/ai
 
+Generated: 2026-08-07. Commit `4f26b8282`.
+
 `@earendil-works/pi-ai` is the provider-neutral streaming, model, auth, tool-call, and image API used across the monorepo. Its root surface must remain browser-safe.
 
 ## STRUCTURE
 
 ```text
 src/types.ts                    Core API/model/message contracts
+src/model.ts                    Model shape; now carries upstreamModelId + serviceTier ("auto"|"flex"|"priority", backs -fast priority variants)
 src/compat.ts                   Temporary legacy dispatch, registry, catalogs
+src/api-registry.ts             API registration/lookup
+src/model-catalog.ts            Catalog assembly over static + dynamic models
+src/models-store.ts             Persisted dynamic-model store
 src/api/                        Wire/API implementations and lazy wrappers
 src/providers/                  Provider factories, catalogs, shared transforms
+src/providers/data/             COMMITTED generated per-provider model JSON (see below)
 src/auth/                       Credential stores, contexts, auth helpers/types
+src/node/provider-scope.ts      Node-only subpath (provider scoping); not root-reachable
+src/oauth.ts                    OAuth surface re-exports
+src/openai-responses-compat.ts  Responses-API compat shims
+src/stream.ts                   Stream entry points
+src/session-resources.ts        Per-session resource plumbing
+src/context-provenance.ts       Context provenance tracking
+src/legacy-api-aliases.ts       Old API-id aliases
+src/compat/                     extension-oauth-types.ts
 src/models.ts                   Models/provider/auth/refresh runtime (owns provider registration, auth resolution, dynamic catalog refresh, stream delegation)
 src/models.generated.ts         Generated static catalog
+src/image-models.ts             Image model surface (+ image-models.generated.ts)
+src/images.ts                   Image generation API (+ images-api-registry.ts, images-models.ts)
 src/env-api-keys.ts             Browser-safe credential detection boundary
 src/tool-call-middleware/       Text-encoded tool protocols
-src/utils/tool-schema-compat.ts OpenAI/Moonshot tool JSON-Schema normalization
+src/utils/                      ~29 files; key: retry.ts, provider-retry.ts, retry-hint.ts, prompt-cache-ttl.ts, stop-details.ts, tool-call-id.ts, tool-schema-compat.ts
 scripts/generate-models.ts      Model catalog source of truth
 scripts/generate-image-models.ts Image catalog source of truth
 test/                           Faux-first and opt-in live tests
 ```
+
+## MODEL DATA GENERATION
+
+- `src/providers/data/` is committed generated source: 38 provider JSONs plus `.manifest.json` (schemaVersion 3, sha256 map per file + structureHash). Never hand-edit.
+- Ordinary build copies `data/` into `dist` (`build:offline` runs `check:model-data` first, then `shx cp -r src/providers/data dist/providers/data`). No network.
+- Networked regeneration is explicit: `npm run generate-models` (full) or `npm run hydrate-model-data` (`--data-only`).
+- Validators: `scripts/model-data.ts` (shared schema/load) and `scripts/check-model-data.ts` (`npm run check:model-data`).
 
 ## ARCHITECTURE
 

--- a/packages/ai/src/api/AGENTS.md
+++ b/packages/ai/src/api/AGENTS.md
@@ -1,5 +1,7 @@
 # packages/ai/src/api
 
+Generated: 2026-08-07. Commit `4f26b8282`.
+
 Provider wire protocol implementations and stream adapters. Each provider ships as a concrete module plus a `.lazy.ts` wrapper that uses `lazyApi()` from `lazy.ts`.
 
 ## MODULE PAIRS
@@ -18,7 +20,9 @@ Provider wire protocol implementations and stream adapters. Each provider ships 
 | `pi-messages.ts` | `pi-messages.lazy.ts` |
 | `openrouter-images.ts` | `openrouter-images.lazy.ts` |
 
-Utility modules with no lazy wrapper: `cloudflare.ts`, `github-copilot-headers.ts`, `openai-prompt-cache.ts`.
+Utility modules with no lazy wrapper: `cloudflare.ts`, `github-copilot-headers.ts`, `openai-prompt-cache.ts`, `anthropic-tool-pairs.ts` (browser-safe Anthropic tool_use/tool_result pair sanitizer; final pre-submit pass), `openai-client-auth.ts` (shared client-auth resolution from credential headers), `constrained-sampling.ts` (JSON-schema-driven constrained sampling helpers).
+
+`openai-codex-responses/` subdir: `fallback-state.ts` (WebSocket fallback state + cooldown), `reasoning.ts` (Codex reasoning summary normalizer).
 
 ## LAZY BOUNDARY
 

--- a/packages/ai/src/auth/AGENTS.md
+++ b/packages/ai/src/auth/AGENTS.md
@@ -1,0 +1,49 @@
+# packages/ai/src/auth
+
+Generated: 2026-08-07. Commit `4f26b8282`.
+
+Credential storage, auth contexts, provider auth resolution, and bundled OAuth flows. Everything here must stay browser-safe; Node access goes through injected/lazy boundaries only.
+
+## FILES
+
+```text
+types.ts             Auth contracts: Credential, CredentialStore, ApiKeyAuth, OAuthAuth, AuthContext
+context.ts           AuthContext construction; fs access through an injected NodeFsModule shape
+credential-store.ts  Default in-memory CredentialStore; apps inject persistent stores; keyed by Provider.id, one credential per provider
+headers.ts           Credential-header contract; case-insensitive (all names lowercased on set and get)
+helpers.ts           Standard api-key auth helper: stored credential wins, else first set env var; includes prompt-based login
+resolve.ts           Provider auth resolution (credential vs env, OAuth refresh paths)
+oauth/               Bundled OAuth flow implementations + loader registry
+```
+
+## oauth/
+
+```text
+load.ts              registerBundledOAuthFlowLoaders(loaders) — registry of per-provider flow loaders
+pkce.ts              Shared PKCE machinery
+device-code.ts       Shared device-code flow
+oauth-page.ts        Local callback/result page rendering
+anthropic.ts         Anthropic OAuth flow
+github-copilot.ts    Copilot device flow
+kimi-coding.ts       Kimi coding-plan flow
+openai-codex.ts      Codex flow
+openrouter.ts        OpenRouter flow
+radius.ts            Radius flow
+xai.ts               xAI flow
+```
+
+## INVARIANTS
+
+- Header names are case-insensitive everywhere; never compare raw header keys, go through `headers.ts`.
+- One credential per provider id in the store. Persistent stores are injected by the app, never assumed.
+- OAuth flows register through `registerBundledOAuthFlowLoaders`; don't import flow modules eagerly from browser-reachable code.
+- Auth resolution order in `helpers.ts` (stored credential, then env) is load-bearing; don't reorder.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| New OAuth provider flow | `oauth/<provider>.ts` + register in `oauth/load.ts` |
+| Header semantics | `headers.ts` |
+| Credential persistence | `credential-store.ts` + app-side injected store |
+| Env-vs-credential precedence | `helpers.ts`, `resolve.ts` |

--- a/packages/ai/src/providers/AGENTS.md
+++ b/packages/ai/src/providers/AGENTS.md
@@ -1,5 +1,7 @@
 # packages/ai/src/providers
 
+Generated: 2026-08-07. Commit `4f26b8282`.
+
 This directory owns provider factories, catalogs, provider metadata, and the faux test provider. API wire implementations, option translation, and message transforms live in sibling `../api/`.
 
 ## FILE MAP
@@ -12,7 +14,16 @@ faux.ts                  Deterministic public test provider
 images/                  Image-provider metadata and factories
 radius.ts                Dynamic Radius provider with persisted model refresh
 radius-config.ts         Radius gateway/model catalog loading
+data/                    38 provider JSONs + .manifest.json — committed generated artifacts
+data-json.d.ts           Typed import shim for data/ JSON
+ollama.ts                Dynamic provider, no .models.ts; runtime catalog via /api/tags
+cloudflare-auth.ts       Cloudflare auth split out of the two Cloudflare providers
+cloudflare-stream.ts     Shared Cloudflare stream plumbing
+google-shared.ts         Shared google/google-vertex catalog logic
+openai-responses-shared.ts Shared openai/azure Responses catalog logic
 ```
+
+Newer providers on disk (each `<name>.ts` + `<name>.models.ts`): ant-ling, kimi-coding, opencode, opencode-go, vercel-ai-gateway, xiaomi + xiaomi-token-plan-{ams,cn,sgp}, zai, zai-coding-cn.
 
 ## ADD OR CHANGE A PROVIDER
 
@@ -33,6 +44,7 @@ radius-config.ts         Radius gateway/model catalog loading
 - Every API stream must preserve tool calls, thinking blocks, usage accounting, stop reasons, setup errors, and abort semantics.
 - Default tests run with zero credentials. Use the faux provider for deterministic event sequences.
 - Keep image providers structurally separate under `images/`.
+- `data/` is committed generated source; never hand-edit. Regenerate with `npm run hydrate-model-data`, validate with `npm run check:model-data`.
 
 ## ANTI-PATTERNS
 

--- a/packages/ai/src/tool-call-middleware/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/AGENTS.md
@@ -2,6 +2,8 @@
 
 Text-format tool-call protocols for providers that don't support native function calling. Wraps `openai-completions` streams and parses `<tool_call>` / XML / delimiter formats back into pi's canonical `toolCall` events. Fork-modified — see `changes.md`.
 
+Generated: 2026-08-07. Commit `4f26b8282`.
+
 ## FILES
 
 ```
@@ -10,6 +12,15 @@ tool-call-middleware/
 ├── types.ts                    # Protocol interface (parse, format, stream)
 ├── context-transformer.ts      # System-prompt + message rewriting per protocol
 ├── stream-wrapper.ts           # Wraps AssistantMessageEventStream → re-parses chunks
+├── stream-wrapper-shared.ts    # Shared wrapper plumbing (stream-wrapper + recovery wrapper)
+├── stream-message-metadata.ts  # Message metadata carried through wrapped streams
+├── stream-thinking-projection.ts # Thinking-block projection for wrapped streams
+├── recovery-*.ts               # Leaked-invoke recovery subsystem; entry: wrapStreamWithInvokeRecovery
+│                               #   (recovery-stream-wrapper), plus recovery-code-mask,
+│                               #   recovery-content-lifecycle, recovery-diagnostics,
+│                               #   recovery-event-stream, recovery-message-snapshot,
+│                               #   recovery-native-projection, recovery-stream-failure,
+│                               #   recovery-stream-terminal, recovery-text-projection
 ├── protocols/
 │   ├── hermes.ts               # Hermes <tool_call>{json}</tool_call> (Qwen, Mistral fine-tunes)
 │   ├── morph-xml.ts            # <fn><arg>val</arg></fn> XML (canonical "morph-xml"; "xml" deprecated alias)
@@ -17,6 +28,8 @@ tool-call-middleware/
 │   ├── gemma4.ts               # Gemma 4 delimiter format `<|tool_call>call:name{…}<tool_call|>`
 │   ├── json-mix.ts             # Shared JSON-mix helper (Hermes + delimited variants)
 │   ├── xml-tool-tag-scanner.ts # Streaming XML tag boundary scanner
+│   ├── kimi-xtml/              # Kimi K3 XTML channel format (format/parse/stream/markers,
+│   │                           #   recovery-stream.ts, thinking-recovery*.ts)
 │   ├── anthropic-xml/          # Legacy <invoke>/<parameter> parser, coercion, scanner, formatter, stream parser
 │   └── antml/                  # ANTML <function_calls>/<invoke> protocol with Claude-Code-style failure tolerance
 ├── TESTING.md                  # Manual test commands per protocol (OpenRouter live API)

--- a/packages/coding-agent/AGENTS.md
+++ b/packages/coding-agent/AGENTS.md
@@ -17,12 +17,19 @@ src/core/models-store.ts           Persisted model store
 src/core/provider-composer.ts      Provider payload composition
 src/core/remote-catalog-provider.ts Remote model-catalog fetch
 src/core/runtime-credentials.ts    Credential resolution and refresh
+src/core/auth-providers.ts         Provider auth registration
+src/core/provider-timeout-retry.ts Provider timeout/retry policy
+src/core/retry-fallback/           Model fallback chains + billing classification
+src/core/project-trust.ts, trust-manager.ts  Project trust decisions
+src/core/resource-loader.ts        Bundled extension/resource resolution
+src/core/session-resident-store.ts Session-resident state store
 src/core/extensions/               Public extension API and loader
 src/core/extensions/builtin/       In-tree fork extensions; bundled extensions (e.g. codemode) resolved via resource-loader.ts
 src/core/tools/                    Upstream-parity built-in tools
 src/core/compaction/               Core compaction mechanics
 src/modes/interactive/             TUI mode and components
-src/modes/app-server/              App-server transport and RPC registry
+src/modes/app-server/              App-server transport and RPC registry; runtime.ts
+                                   wiring, search/ fuzzy file search
 src/modes/rpc/                     JSONL RPC mode/client/types
 src/modes/print-mode.ts            One-shot mode
 test/suite/harness.ts              Preferred faux-provider harness
@@ -72,3 +79,6 @@ src/changes.md                     Root fork-change record
 - Interactive changes also follow `src/modes/interactive/AGENTS.md`; extension/tool changes follow their nearest child guide.
 - App-server, test, and example changes follow their local `AGENTS.md` files.
 - Keep `src/changes.md`, nested `changes.md`, public docs, and examples aligned with fork behavior.
+
+---
+Generated: 2026-08-07 | Commit: `4f26b8282`

--- a/packages/coding-agent/src/core/extensions/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/AGENTS.md
@@ -15,7 +15,7 @@ extensions/
 │                        # exposes `bindCore()` to wire `pi.*` stubs to real implementations.
 ├── wrapper.ts           # 30-line wrapper utility used to track extension origin per UI message
 ├── index.ts             # Re-exports from runner/loader/types
-├── builtin/             # 23 builtin extensions + bundled codemode (`core/resource-loader.ts`) — see builtin/AGENTS.md
+├── builtin/             # 32 builtin extensions + 4 global defaults + bundled codemode (`core/resource-loader.ts`) — see builtin/AGENTS.md
 └── changes.md           # Fork tracker — DENSE. Every public-API change must add a section.
 ```
 
@@ -65,3 +65,6 @@ extensions/
 - The ~1844-line `types.ts` is "the API"; treat its diffs like a public package release.
 - `ToolRenderContext` now includes `imageProtocol` (terminal image protocol, or null when images can't render) and `hasResult` (lets a call renderer yield to the result renderer).
 - `changes.md` already documents major fork-introduced APIs: `ModelSelectEventResult`, `SystemPromptChangeEvent`, `getCompactionSettings`, lazy/shared jiti, default-extension factory resolver. Read it before extending.
+
+---
+Generated: 2026-08-07 | Commit: `4f26b8282`

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions/builtin
 
-27 in-tree extensions. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
+32 in-tree extensions plus 4 global defaults. Each is the canonical answer to "can senpi do X without core changes?". Registration order matters.
 
 ## INVENTORY (registration order from `builtin/index.ts`)
 
@@ -16,25 +16,35 @@
 | 8 | `anthropic-bash` | `anthropic-bash/` | Anthropic-native bash tool variant |
 | 9 | `openai-web-search` | `openai-web-search/` | OpenAI-native web search |
 | 10 | `service-tier` | `service-tier.ts` | Per-model service-tier (e.g., priority-tier mapping) |
-| 11 | `bash-timeout` | `bash-timeout/` | Bash tool timeout + handlers |
-| 12 | `terminal` | `terminal/` | Persistent PTY-backed bash + bash_output/bash_input/bash_resize/kill_bash tools |
-| 13 | `tool-pair-guard` | `tool-pair-guard/` | Repairs orphaned tool_use/tool_result pairs (compaction safety) |
-| 14 | `compaction` | `compaction/` | Plugsuit-style speculative + emergency compaction with restoration |
-| 15 | `history-search` | `history-search/` | Cross-session transcript search overlay (indexes session files) |
-| 16 | `import-repro` | `import-repro.ts` | `/ir` command — import an issue-analysis CI session gist and switch to it |
-| 17 | `websearch` | `websearch/` | Provider-backed `web_search` tool + `/websearch` (providers incl. kimi); vendored from `../pi-extensions/pi-websearch` |
-| 18 | `webfetch` | `webfetch/` | `webfetch` tool (md/text/html, gated by `PI_WEBFETCH`); vendored from `../pi-extensions/pi-webfetch` |
-| 19 | `look-at` | `look-at/` | Vision-model delegation tool for media analysis when the active model cannot accept image input |
-| 20 | `nested-agents-md` | `nested-agents-md/` | Auto-injects nearby `AGENTS.md` + `/nested-agents`; vendored from `../pi-extensions/pi-nested-agents-md` |
-| 21 | `rules` | `rules/` | Rule-file discovery + `/rules`/`/reload-rules`; vendored from `../pi-extensions/pi-rules` |
-| 22 | `goal` | `goal/` | Budget-free goal tools + `/goal`; vendored from `../pi-extensions/pi-goal` |
-| 23 | `btw` | `btw/` | `/btw` side-question command that queries in parallel without touching the main session |
-| 24 | `config-reload` | `config-reload/` | Hash-gated watcher for trusted global/project config surfaces that defers a full session reload until idle and exposes the `config-watch:*` event protocol; registered after settings-dependent builtins so a reload rebuilds their resolved settings, and before final MCP observation |
-| 25 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — see `mcp/changes.md` |
-| 26 | `ttsr` | `ttsr/` | Stream-rule detection (collapse + control-token-leak) with abort→remediate→retry; ported from oh-my-pi — see `ttsr/changes.md` |
-| 27 | `loop-guard` | `loop-guard/` | Tool-call loop detection (identical / near-identical / cyclic) that steers a `<system-reminder>` into the running turn with a cache-warm-style TUI notice — see `loop-guard/changes.md` |
+| 11 | `model-fallback` | `model-fallback/` | Fallback-chain validation + `/model-fallback` menu, `--no-model-fallback` flag (uses `core/retry-fallback/`) |
+| 12 | `recommended-models` | `recommended-models/` | Auto-switches implicit default models to recommended ones; respects explicit `settings` provenance; `--no-recommended-models` |
+| 13 | `bash-timeout` | `bash-timeout/` | Bash tool timeout + handlers |
+| 14 | `terminal` | `terminal/` | Persistent PTY-backed bash + bash_output/bash_input/bash_resize/kill_bash tools; follows bash-timeout (default reaches PTY bash) and anthropic-bash (mutual-exclusion step-aside) |
+| 15 | `tool-pair-guard` | `tool-pair-guard/` | Repairs orphaned tool_use/tool_result pairs (compaction safety) |
+| 16 | `compaction` | `compaction/` | Plugsuit-style speculative + emergency compaction with restoration |
+| 17 | `history-search` | `history-search/` | Cross-session transcript search overlay (indexes session files) |
+| 18 | `help` | `help/` | `/help` + `/keybindings` TUI overlay panel (renders `interactive/help-content.ts`) |
+| 19 | `import-repro` | `import-repro.ts` | `/ir` command — import an issue-analysis CI session gist and switch to it |
+| 20 | `websearch` | `websearch/` | Provider-backed `web_search` tool + `/websearch` (providers incl. kimi); vendored from `../pi-extensions/pi-websearch` |
+| 21 | `webfetch` | `webfetch/` | `webfetch` tool (md/text/html, gated by `PI_WEBFETCH`); vendored from `../pi-extensions/pi-webfetch` |
+| 22 | `video-in` | `video-in/` | Model-gated `read_video` tool (kimi-code ReadMediaFile parity); active only when the model declares the "video" input modality |
+| 23 | `look-at` | `look-at/` | Vision-model delegation tool for media analysis when the active model cannot accept image input |
+| 24 | `nested-agents-md` | `nested-agents-md/` | Auto-injects nearby `AGENTS.md` + `/nested-agents`; vendored from `../pi-extensions/pi-nested-agents-md` |
+| 25 | `rules` | `rules/` | Rule-file discovery + `/rules`/`/reload-rules`; vendored from `../pi-extensions/pi-rules` |
+| 26 | `goal` | `goal/` | Budget-free goal tools + `/goal`; vendored from `../pi-extensions/pi-goal` |
+| 27 | `ttsr` | `ttsr/` | Stream-rule detection (collapse + control-token-leak) with abort→remediate→retry; ported from oh-my-pi — see `ttsr/changes.md` |
+| 28 | `btw` | `btw/` | `/btw` side-question command that queries in parallel without touching the main session |
+| 29 | `claude-sdk-oauth` | `claude-sdk-oauth/` | Claude SDK OAuth provider: multi-account OAuth, resume-first session continuity, stream-safe failover — see `claude-sdk-oauth/AGENTS.md` + `changes.md` |
+| 30 | `loop-guard` | `loop-guard/` | Tool-call loop detection (identical / near-identical / cyclic) that steers a `<system-reminder>` into the running turn with a cache-warm-style TUI notice — see `loop-guard/changes.md`; pure observer, slots before config-reload |
+| 31 | `config-reload` | `config-reload/` | Hash-gated watcher for trusted global/project config surfaces that defers a full session reload until idle and exposes the `config-watch:*` event protocol; registered after settings-dependent builtins so a reload rebuilds their resolved settings, and before final MCP observation |
+| 32 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — kept last so its provider-payload tap observes all co-resident builtin mutations; see `mcp/changes.md` |
 
 Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by resource-loader.ts) and 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`).
+
+Shared non-factory modules in this directory:
+
+- `rule-activation/` — `appendRuleActivation` + renderer/types; consumed by `rules/` and `ttsr/`.
+- `monitor-state-event.ts` — `TerminalMonitorStateEvent` + guard; consumed by `goal/` and `terminal/`.
 
 ## ADDING A NEW BUILTIN EXTENSION
 
@@ -68,3 +78,6 @@ Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by
 - `goal/elapsed-ticker.ts` drives the live 'Pursuing goal...' footer refresh on a one-second cadence.
 - MCP search exposure tool is `tool_search` (mcp/expose/tool-search.ts). Do not reintroduce `mcp_search` references anywhere.
 - Prompt presets routinely append the shared `file-operations.ts` tuning block. Mirror this when adding GPT-5.x presets — see `prompt-preset/changes.md` 2026-05-07.
+
+---
+Generated: 2026-08-07 | Commit: `4f26b8282`

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
@@ -1,0 +1,52 @@
+# claude-sdk-oauth
+
+Claude SDK OAuth provider extension. Registers a builtin provider that runs turns through the `@anthropic-ai/claude-agent-sdk` subprocess with native multi-account OAuth, HRW session affinity, stream-safe account failover, and resume-first session continuity. Renamed from `claude-agent-sdk` on 2026-07-31; old persisted identities are intentionally not aliased.
+
+Generated: 2026-08-07 | Commit: `4f26b8282`
+
+## FILE ROLES (verified subset)
+
+| File | Role |
+|---|---|
+| `index.ts` | Extension entry: registers the `claude-sdk-oauth` provider, `/claude-account` command, session registry wiring, OAuth config |
+| `accounts.ts` | `AccountSlot` / credential types, slot block state (`blockedUntil`, `blockReason`) |
+| `auth-lane.ts` | Lane selection and credential plumbing (`oauth-slots`, `config-dir`, `ambient`); `queryWithAuthLane`, token-file permissions |
+| `failover.ts` | Failover events, rate-limit block windows (default 60s, max 48h), turn-retry suppression prefix |
+| `affinity.ts` | HRW account affinity + expired-block clearing |
+| `stream.ts` | Non-resident streaming path: builds query options, bridges SDK messages to `AssistantMessageEventStream` |
+| `session-stream.ts` | Resident-lane attempts (`createResidentAttempt`), flatten serialization + directive dedupe |
+| `session-continuity.ts` | `decideNativeContinuity` decision table: `delta` / `reattach` / `fork` / `flatten` / `bootstrap` |
+| `session-registry.ts` | Resident SDK query registry: idle reaping, eviction, state transitions (with `session-registry-state/pump/wiring.ts`) |
+| `session-binding.ts` | Branch-local binding checkpoint for restart-time resume verification |
+| `session-commit-boundary.ts` | `message_end` commit boundary; divergence decided against the SDK ledger, not in-flight staging |
+| `session-observability.ts` | `ContinuityObservation` (kind, reason, delta count, `payloadBytes`, `collapsedDirectives`), `session.log` events |
+| `system-prompt.ts` | `systemPromptMode` handling (`full` default, `preset-append` deprecated, `override` from file); no array-splitting, the CLI joins arrays |
+| `prompt-directive-dedupe.ts` | `dedupeUltraworkBlocks`: collapses repeated `<ultrawork-mode>` spans in flatten output; never mutates `context.messages` |
+| `custom-tools.ts` | Senpi tools exposed as an SDK MCP server; execution denied SDK-side (`denyCustomToolExecution`), executed by senpi |
+| `sdk-boundary.ts` | Single import boundary over `@anthropic-ai/claude-agent-sdk` (`query`, `createSdkMcpServer`, types) |
+| `options.ts` | `buildClaudeSdkOauthQueryOptions`: settings + `SENPI_CLAUDE_SDK_OAUTH_*` env resolution, append assembly |
+| `executable.ts` | Claude Code executable resolution |
+| `changes.md` | Fork-change record; read before touching anything here |
+
+## INVARIANTS (from changes.md)
+
+- Resume-first: every query replacement re-attaches with `resume`; flatten is a last resort for a missing transcript or unusable binding. A live session is never abandoned for a flattened re-send.
+- The SDK ledger is authoritative for divergence; decide at the `message_end` commit boundary. Result-only turns are a supported shape, not divergence.
+- Fork point is the last assistant boundary strictly before the divergence.
+- Non-fork reattach passes `resume` and must omit `sessionId` (the SDK rejects the pair). Fork adds `resumeSessionAt` + `forkSession`.
+- Abort never taints and never flattens; `interrupt()` receipts gate keep-vs-close.
+- Fingerprint normalizes the `Current date:` line (no midnight retirement); cwd and other regions stay fail-closed. `config-dir` lane failover is the one declared residual that still flattens.
+- Every main turn emits exactly one continuity observation; TUI notices only for degradations.
+- `resumeMode: "off"` / `SENPI_CLAUDE_SDK_OAUTH_RESUME=off` restores legacy per-turn behavior.
+- `full`/`override` prompt modes default `settingSources` to `[]` (no CLAUDE.md double-injection). The CLI still prepends its own agent preamble; `full` means senpi's prompt arrives intact, not alone.
+- Env precedence: env > project settings > global settings > default. All `SENPI_*` vars are stripped from the subprocess env on every lane.
+- Subscription-limit responses classify as account-failover conditions, not terminal errors.
+- Idle resident sessions retire after 30 minutes; at most 32 stay resident; in-flight sessions are never evicted.
+
+## TESTS
+
+Flat cluster at `test/claude-sdk-oauth-*.test.ts` (35 files at this commit): accounts, affinity, auth-lane, binding, continuity decisions, failover, custom-tools schema, guidance, login, model switch, observability, and more. Keep edited test files below the 250-pure-LOC ceiling (see 2026-07-31 rename entry).
+
+## MERGE RISK
+
+High across this directory (2026-08-01 continuity rework touched most session-* modules). Every behavior change must add a `changes.md` section with expected conflict zones.

--- a/packages/coding-agent/src/modes/app-server/AGENTS.md
+++ b/packages/coding-agent/src/modes/app-server/AGENTS.md
@@ -7,12 +7,23 @@ Codex-compatible app-server mode. It exposes Senpi threads and turns over JSON-R
 ```text
 index.ts              Mode entry and listener selection
 cli-args.ts           app-server argument parsing
-daemon/               Background process probing and lifecycle
+runtime.ts            Wires FuzzyFileSearchService, skill methods, thread lifecycle
+daemon.ts, daemon/    Background process probing and lifecycle
 rpc/                  Envelopes, errors, NDJSON framing, method registry
 server/               Connection state, approvals, notifications, dispatch
-threads/              Session-backed thread registry, projection, turns
+threads/              Session-backed thread registry, projection, turns; split
+                      handler clusters (list-, metadata-, settings-handlers),
+                      projection-*.ts split projections, goal-handlers/goal-wire,
+                      turn runtime (turn-runtime.ts, turn-terminal.ts, turns.ts),
+                      thread-content search (search.ts, search-cache.ts,
+                      search-occurrences.ts, search-params.ts)
+search/               Fuzzy file search (fuzzy-files.ts, fuzzy-search-methods.ts,
+                      fuzzy-search-service.ts, gitignore.ts)
 transports/           stdio, Unix socket, WebSocket auth/backpressure
-protocol/             App-facing facade plus pinned generated Codex evidence
+protocol/             App-facing facade (account.ts, config.ts, thread.ts, turn.ts,
+                      collaboration-mode.ts, fuzzy-search.ts, terminal.ts, …) plus
+                      pinned generated Codex evidence; generated/v2/ is the
+                      second-generation tree (~527 files)
 turn-adapter.ts       Agent/session events to app-server turn events
 ```
 
@@ -52,3 +63,6 @@ turn-adapter.ts       Agent/session events to app-server turn events
 - Run the matching `packages/coding-agent/test/qa/app-server/` driver for focused Unix-socket, malformed-input, and lifecycle scenarios.
 - Protocol or documentation changes must keep `packages/coding-agent/docs/app-server.md` examples and `packages/coding-agent/test/qa/app-server/` checks aligned.
 - Runtime changes also require root `npm run check` and the applicable real CLI QA evidence gate.
+
+---
+Generated: 2026-08-07 | Commit: `4f26b8282`

--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -13,6 +13,11 @@ compaction/        Compaction mechanics and policy
 session-manager/   Persistence, branching, context construction
 dynamic-prompt/    Dynamic system-prompt + workstation fact coverage
 tool-pair-guard/   Provider payload tool-pair sanitization tests
+client/            RPC/app-server client coverage
+extensions/        Extension loading and API behavior
+grok/              Grok provider coverage
+ttsr/              Stream-rule (ttsr) extension coverage
+support/           Shared test support modules
 helpers/           Shared subprocess/QA/fixture helpers
 manual-qa/         Explicit manual QA scripts (not part of default suite)
 qa/app-server/     Real app-server surface drivers
@@ -20,6 +25,9 @@ integration/       Explicitly gated real-provider tests
 fixtures/, goldens/ Shared deterministic inputs and snapshots
 model-runtime*.test.ts / models-store.test.ts / remote-catalog-provider.test.ts / runtime-credentials.test.ts
                    Model/catalog/auth runtime coverage
+claude-sdk-oauth-*.test.ts
+                   Flat cluster (33+ files) at test/ root covering the Claude SDK
+                   OAuth provider extension
 ```
 
 ## TEST RULES
@@ -45,3 +53,6 @@ model-runtime*.test.ts / models-store.test.ts / remote-catalog-provider.test.ts 
 - Run every added or changed test file directly until green.
 - Run the narrow owning directory or package suite when shared harnesses, fixtures, or lifecycle behavior change.
 - Root `npm run check` is static validation and does not replace tests.
+
+---
+Generated: 2026-08-07 | Commit: `4f26b8282`

--- a/packages/senpi-codemode/AGENTS.md
+++ b/packages/senpi-codemode/AGENTS.md
@@ -8,6 +8,7 @@ the persistent-kernel `eval` tool for JavaScript, Python, Ruby, and Julia.
 ```text
 src/index.ts                     Extension factory: registers baseline eval, re-registers at session_start after runtime resolution, re-registers on model_select when active model changes
 src/prompt/                      Model-aware eval prompt templates and batching dialect selection
+src/interpreters/                Interpreter availability detection (detect.ts)
 src/config/                      Settings schema, defaults, env overrides
 src/extension/                   Session generations and kernel ownership
 src/tool/                        Eval schema, cell execution, status events, rendering
@@ -35,6 +36,8 @@ test/                            Vitest contracts and the omp parity ledger
   must not emit into a newer session.
 - Kernels persist state per language, while per-cell callbacks are rebound for
   each execution.
+- Eval runs require a `summary` written in the user's conversational language.
+  Detached cells are labeled with that summary; the old `title` field is dropped.
 - Every cell settles exactly once across success, error, timeout, abort, bridge
   failure, and kernel crash.
 - Timeout and abort cleanup retires child work before ownership is released.
@@ -61,6 +64,8 @@ test/                            Vitest contracts and the omp parity ledger
 | Prompt behavior | `src/prompt/eval-prompt.ts` |
 | Call/result rendering | `src/tool/render.ts` |
 | Cell settlement and output | `src/tool/cell-handler.ts`, `src/output/` |
+| Detached cells | `src/tool/detached-cell-manager.ts`, `detached-cell-notification.ts`, `detached-cell-snapshot.ts`, `detached-cell-state.ts`, `detached-eval-result.ts`, `detached-notification-queue.ts`, `cell-runtime.ts` |
+| Interpreter detection | `src/interpreters/detect.ts` |
 | Session and kernel ownership | `src/extension/session-manager.ts`, `src/index.ts` |
 | Bridge auth and protocol | `src/bridge/` |
 | Agent/output task composition | `src/bridges/` |
@@ -89,3 +94,6 @@ test/                            Vitest contracts and the omp parity ledger
   lockfile policy permits the intentional change.
 - Documentation must describe the current tool contract. Update README settings
   and helper tables with every user-visible surface change.
+
+---
+Generated: 2026-08-07 | Commit `4f26b8282`

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,45 +1,61 @@
 # packages/server
 
-`@code-yeongyu/senpi-server` is an experimental private package for daemon configuration, IPC, supervised Senpi RPC processes, storage, and Radius connectivity.
+Commit: `4f26b8282` (2026-08-07)
+
+`@code-yeongyu/senpi-server` is an experimental private package. Top level is a composable, transport-neutral protocol server built on `@earendil-works/pi-protocol`. The old daemon/IPC/Radius stack lives on under `src/legacy/` and still backs the `server` CLI bin (`dist/legacy/cli.js`). Node `>=22.19.0`.
 
 ## STRUCTURE
 
 ```text
-src/serve.ts          Daemon/service entry
-src/ipc/protocol.ts   IPC request and response contracts
-src/ipc/server.ts     Serialized JSONL server
-src/ipc/client.ts     IPC client
-src/rpc-process.ts    Child Senpi RPC process wrapper
-src/supervisor.ts     Process ownership and cleanup
-src/radius.ts         Radius connection lifecycle
-src/config.ts         Config parsing
-src/storage.ts        Persistent state
-src/cli.ts            CLI entrypoint exposed as `server`
+src/index.ts             Re-exports errors, listener, protocol, server, types, legacy
+src/server.ts            PiServer: handshake, auth token hash, message dispatch
+src/protocol.ts          pi-ai <-> pi-protocol type bridging and transcript mapping
+src/listener.ts          PiServerListener interface (start/close, accept)
+src/connection.ts        ByteConnection, handler, ConnectionState stages
+src/sessions.ts          LiveSessionManager: session runtimes + subscriber fanout
+src/snapshots.ts         ServerSnapshotPublisher: revisioned server-snapshot broadcast
+src/errors.ts            PiServerError
+src/types.ts             PiServerOptions, PiSessionBackend, PiSessionRuntime
+src/transports/unix/     createUnixListener, createUnixServer preset
+src/testing/             TestSessionBackend, ProtocolTestClient, createTestServer
+src/legacy/              Old daemon: serve, ipc/, rpc-process, supervisor, radius,
+                         config, storage, cli (the `server` bin)
 ```
+
+Package exports: `.` (core + legacy re-export), `./testing`, `./unix`, `./legacy`.
 
 ## INVARIANTS
 
-- Preserve newline-delimited JSON framing and serialize writes per connection; interleaved response bytes corrupt the protocol.
-- Correlate requests and responses explicitly and close pending operations on disconnect.
-- The supervisor owns spawned children and must clean them up on stop, error, and partial startup.
-- Radius disconnect/reconnect paths settle listeners and pending work without leaking sockets.
-- Radius presence owns machine/Pi heartbeat retry backoff and re-registration after repeated 404s; credential lookup uses coding-agent stored credentials (`readStoredCredential("radius")`) with `SENPI_RADIUS_API_KEY` as fallback.
-- Never log credentials, tokens, raw auth headers, or secret-bearing environments.
-- Treat the package as unstable and private. The package exposes the `server` CLI entrypoint, but its APIs and behavior remain unstable.
+- Transports are byte-level only. `ByteConnection` gives an ordered byte sink; all framing, hello handshake, and protocol-version checks belong to `PiServer` in `src/server.ts`.
+- Handshake is bounded (5s default timeout) and auth compares token hashes with `timingSafeEqual`; never short-circuit with string equality.
+- Connection stages progress `awaitingHello -> handshaking -> ready -> closing -> closed`; dispatch only after `ready`.
+- `LiveSessionManager` owns runtime lifecycle: unsubscribe on dispose, settle in-flight operations on disconnect, guard double-dispose via the `disposing` promise.
+- Snapshot broadcasts serialize through `broadcastQueue` and carry a monotonic revision; do not publish out of order.
+- Keep type bridging in `src/protocol.ts` exhaustive; the compile-time `Assert`/`ExactKeys` checks there must stay so pi-ai/pi-protocol drift fails typecheck.
+- Tests are Vitest (`npm test` runs `vitest --run`), not the Node test runner.
 
 ## WHERE TO LOOK
 
 | Task | Path |
 |---|---|
-| IPC schema/framing | `src/ipc/` |
-| Child RPC lifecycle | `src/rpc-process.ts` and `src/supervisor.ts` |
-| Daemon request handling | `src/handler.ts` and `src/serve.ts` |
-| Radius credentials + heartbeat/re-registration | `src/radius.ts` |
-| Config/storage | `src/config.ts`, `src/storage.ts` |
+| Handshake, auth, dispatch | `src/server.ts` |
+| Session runtime lifecycle | `src/sessions.ts`, `src/types.ts` |
+| Server snapshot fanout | `src/snapshots.ts` |
+| Add a transport | `src/listener.ts`, `src/connection.ts`, `src/transports/unix/` as template |
+| Unix socket specifics (stale sockets) | `src/transports/unix/listener.ts`, `test/unix.test.ts`, `test/fixtures/stale-socket-server.mjs` |
+| Test harness/backend fakes | `src/testing/` |
+| Protocol conformance | `test/conformance.test.ts`, `test/protocol.test.ts` |
+
+## LEGACY (`src/legacy/`)
+
+- Daemon entry `serve.ts`, JSONL IPC under `ipc/`, child RPC in `rpc-process.ts` + `supervisor.ts`, Radius in `radius.ts`, plus `config.ts`, `storage.ts`, `cli.ts`.
+- Preserve newline-delimited JSON framing and per-connection write serialization; interleaved bytes corrupt the protocol.
+- Supervisor owns spawned children; clean up on stop, error, and partial startup.
+- Radius handles heartbeat retry backoff and re-registration after repeated 404s; credentials via `readStoredCredential("radius")`, fallback `SENPI_RADIUS_API_KEY`.
+- Never log credentials, tokens, raw auth headers, or secret-bearing environments.
 
 ## VALIDATION
 
-- Run focused Node tests with `npm test` from this package.
-- Run root `npm run check` after code changes.
-- Add lifecycle tests for startup failure, disconnect, duplicate stop, and child exit races.
+- `npm test` (Vitest) from this package; root `npm run check` after code changes.
+- Add lifecycle tests for handshake timeout, disconnect mid-operation, duplicate close, and stale-socket takeover.
 - Inspect logs and fixtures for secret safety before committing.

--- a/packages/tui/AGENTS.md
+++ b/packages/tui/AGENTS.md
@@ -1,21 +1,35 @@
 # packages/tui
 
+Commit: `4f26b8282` (2026-08-07)
+
 `@earendil-works/pi-tui` is the standalone terminal renderer/editor library used by Senpi interactive mode. Rendering uses synchronized, differential frames and must preserve terminal ownership boundaries.
 
 ## STRUCTURE
 
 ```text
-src/tui.ts                  Render scheduler, viewport strategies, cursor state
+src/tui.ts                  TuiBase, Container, CURSOR_MARKER, ViewportTUI contract
+src/TuiMainScreen.ts        Main-screen/scrollback TUI (thin TuiBase subclass)
+src/TuiAltScreen.ts         Alt-screen TUI: layout frames, scroll routing, flash
+src/layout.ts               Layout frame rendering, rects, clipping, scrollbar geometry
+src/layout-node.ts          Per-component layout node attachment
 src/terminal.ts             Terminal capabilities and lifecycle
 src/editor-component.ts     Multiline editor primitive
 src/components/             Text, markdown, loader, selectors, image components
+src/components/stack.ts     Stack size allocation shared by v-stack/h-stack
+src/components/v-stack.ts   VStack; h-stack.ts HStack; spacer.ts Spacer
+src/components/scroll-view.ts  ScrollView with scrollbar options
 src/keybindings.ts          Configurable default bindings
 src/keys.ts                 Key parsing and matching
 src/stdin-buffer.ts         Paste/input framing
 src/terminal-image.ts       Kitty/iTerm image paths
 src/changes.md              Fork render behavior
 test/*.test.ts              Node test-runner coverage
+bench/frame-cost.ts         Frame cost benchmark (see test/frame-cost-harness.test.ts)
 ```
+
+Root `tui-plan.md` is the design doc for the alternate-screen layout system (landed 2026-07-31).
+
+Public exports include `VStack`, `HStack`, `ScrollView`, `Spacer`, `TuiAltScreen`, `TuiMainScreen`, `Container`, `CURSOR_MARKER`, `isViewportTUI`, and `ViewportTUI` (see `src/index.ts`).
 
 ## RENDERING CONTRACT
 
@@ -33,6 +47,10 @@ test/*.test.ts              Node test-runner coverage
 | Task | File |
 |---|---|
 | Flicker, cursor, viewport | `src/tui.ts` |
+| Alt-screen rendering, scroll wheel/keys routing | `src/TuiAltScreen.ts` |
+| Layout rects, clipping, scrollbar geometry | `src/layout.ts`, `src/layout-node.ts` |
+| Stack sizing, scrollable regions | `src/components/stack.ts`, `src/components/scroll-view.ts` |
+| Viewport contract checks | `src/tui.ts` (`isViewportTUI`, `VIEWPORT_TUI`) |
 | Terminal lifecycle/title | `src/terminal.ts` |
 | Child process terminal | `src/terminal.ts` (`ProcessTerminal`) |
 | Key parsing/defaults | `src/keys.ts`, `src/keybindings.ts` |
@@ -51,7 +69,8 @@ test/*.test.ts              Node test-runner coverage
 
 ## VALIDATION
 
-- Tests use `node --test --import tsx`, not Vitest. Run `npm test` from this package.
+- Tests use `node --test --import tsx`, not Vitest; the test script also imports `test/setup-multiplexer-env.mjs`. Run `npm test` from this package.
+- Alt-screen/layout changes: see `test/tui-alt-screen.test.ts`, `test/layout.test.ts`, `test/viewport-render.test.ts`.
 - Rendering changes must include focused headless-terminal assertions and preserve flicker budgets.
 - Runtime changes require root `npm run check`, `senpi-qa` TUI smoke evidence, and visual terminal QA.
 - Read `src/changes.md` before altering renderer or loader behavior.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -7,6 +7,8 @@ Build, validation, release, publish, lockfile, and environment tooling for the s
 All `.mjs` files carry `#!/usr/bin/env node` and run as ES modules.
 Shell wrappers `devenv-setup.sh` and `devenv-setup.ps1` locate Node and delegate to `devenv-setup.mjs`; they own no logic of their own.
 Colocated `*.test.mjs` files run via root `npm run test:scripts` (`node --test scripts/*.test.mjs`).
+Root `package.json` runs `preinstall: node scripts/create-bin-stubs.mjs`.
+`scripts/qa/` holds QA render drivers and fixtures.
 
 ## Naming convention
 
@@ -14,6 +16,7 @@ Colocated `*.test.mjs` files run via root `npm run test:scripts` (`node --test s
 |--------|------|
 | `build-*` | Compile and bundle steps |
 | `check-*` | Validation and gate scripts |
+| `create-*` | Stub/wrapper creation (`create-bin-stubs.mjs`, `create-root-senpi-wrapper.mjs`) |
 | `generate-*` | Artifact generation (shrinkwrap, install-lock) |
 | `prepare-*` | Publish staging |
 | `release-*` | Sub-tasks composed by `release.mjs` |
@@ -47,6 +50,17 @@ Colocated `*.test.mjs` files run via root `npm run test:scripts` (`node --test s
 
 - `devenv-setup.mjs`: Universal, idempotent dev-environment setup. Both shell wrappers
   delegate here after locating Node.
+
+- Release/publish helpers: `prepare-senpi-publish-manifest.mjs`, `publish-command.mjs`,
+  `publish-manifest.mjs`, `release-notes.mjs`, `release-test-gate.mjs`,
+  `local-release-runner.mjs`.
+
+- Standalone binaries: `prepare-bun-compile-assets.mjs`, `smoke-standalone-binary.mjs`.
+
+- Gates and upstream: `check-pr-changelog.mjs`, `check-upstream-release.mjs`.
+
+- Model catalog: `diff-model-catalog.mjs`, `publish-model-catalog.mjs`,
+  `generate-thinking-capabilities.mjs`.
 
 ## prepare-senpi-bundled-workspaces.mjs
 
@@ -85,3 +99,6 @@ EBADPLATFORM everywhere else. They remain optional registry deps, resolved per i
 - Never invoke `node scripts/publish.mjs` without a prior build. The script checks for
   `dist/` existence but not for stale output.
 - Never commit `.env` files or print credentials in build log output.
+
+---
+Generated: 2026-08-07 | Commit `4f26b8282`


### PR DESCRIPTION
## Summary

init-deep update pass refreshing the hierarchical `AGENTS.md` knowledge base. The previous generation was stamped at `92fc96389` (2026-07-17); HEAD is `4f26b8282` with 2265 commits of drift.

**Updated (15 guides):**
- Root `AGENTS.md` — metadata, four new packages in STRUCTURE (`protocol`, `client`, `storage`, `evals`), server row fixed to composable-server reality, model-data regen row, changelog-gate convention.
- `packages/server` — full rewrite: composable protocol server (server/protocol/listener/connection/sessions/snapshots, `transports/unix/`, `testing/`); legacy daemon documented under `src/legacy/`.
- `packages/tui` — alternate-screen layout system (TuiAltScreen/TuiMainScreen, layout engine, VStack/HStack/ScrollView), public export drift, `tui-plan.md` reference.
- `packages/agent` — `harness/tools/` dir, session store refactor (repository/jsonl-store/memory-store/fork/search-backend), SQLite storage backend, new harness modules.
- `packages/ai` (root, providers, api, tool-call-middleware) — committed `src/providers/data/` model-catalog flow + validators, new providers (ollama et al.), `openai-codex-responses/` subpackage, recovery-* middleware subsystem, `protocols/kimi-xtml/`.
- `packages/coding-agent` (root, extensions, builtin, app-server, test) — extension inventory regenerated from `builtin/index.ts` (32 + 4 global defaults), app-server `runtime.ts`/`search/`/threads clusters/protocol generated v2, test tree additions.
- `packages/senpi-codemode` — required user-language eval summary invariant, `interpreters/`, detached-cell cluster.
- `scripts` — `create-*` prefix, preinstall bin-stub hook, new release/model-catalog/QA entry points.

**Created (2 guides):**
- `packages/ai/src/auth/AGENTS.md` — credential/header contracts + 11 bundled OAuth flows.
- `packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md` — 44-file subsystem: resume-first continuity, failover, invariants from `changes.md`.

Unchanged (verified current): `packages/pty`, `crates/senpi-pty`, remaining subdir guides.

## Validation

- Docs-only change: every claim verified against the tree at `4f26b8282` (file lists, `builtin/index.ts` registration order, package.json scripts/exports).
- `git diff --check` clean.
- Changelog gate: exempt (`.md` files are excluded by `scripts/check-pr-changelog.mjs`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the hierarchical `AGENTS.md` knowledge base across the monorepo. Aligns docs with the composable server, TUI alt‑screen layout, model-catalog flow/auth, and the expanded coding‑agent extensions.

- **Refactors**
  - Root `AGENTS.md` updated: adds `packages/protocol`, `packages/client`, `packages/storage`, `packages/evals`; fixes server row; documents model-catalog regeneration and changelog gate.
  - `packages/server`: rewritten for a composable protocol server (`server/protocol/listener/connection/sessions/snapshots`, `transports/unix/`, `testing/`); legacy daemon kept under `src/legacy/`.
  - `packages/tui`: documents the alt‑screen layout system (`TuiAltScreen`, `TuiMainScreen`, `VStack`, `HStack`, `ScrollView`) and public exports.
  - `packages/agent`: adds `harness/tools/`, session‑store refactor (repository/jsonl/memory/fork/search‑backend), and SQLite storage via `@earendil-works/pi-storage-sqlite-node`.
  - `packages/ai`: committed provider model data under `src/providers/data/` with generation/validators; notes new providers and recovery middleware.
  - `packages/coding-agent`: inventory is now 32 built‑ins + 4 global defaults; app‑server updates (runtime, search, threads, protocol v2); core additions (auth providers, timeout/retry, fallback chains, trust).
  - `packages/senpi-codemode`: requires user‑language eval summary; adds `interpreters/` and detached‑cell docs.
  - `scripts`: introduces `create-*` stubs, a preinstall bin‑stub hook, and model‑catalog/QA entries.

- **New Features**
  - `packages/ai/src/auth/AGENTS.md`: documents credential/header contracts and bundled OAuth flows.
  - `packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md`: documents the Claude SDK OAuth provider (multi‑account OAuth, failover, session continuity).

<sup>Written for commit 133a795bd01f6feb6f0bb4f0c90ddb98446447d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

