### PR TITLE
fix(rpc): include open session failure reason

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Fixed
 
+- Fixed multi-session RPC `open_session` failures returning only a bare `open_failed` code. Responses now preserve the
+  stable prefix and include the underlying workspace or runtime cause as `open_failed: <reason>`, while all other
+  transport error codes remain exact strings ([#750](https://github.com/code-yeongyu/senpi/pull/750)).
+
 ### Removed
 
 ## [2026.8.7] - 2026-08-07

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Multi-session open failure details (2026-08-07)
+
+### What changed
+
+- Multi-session `open_session` failures retain the typed `open_failed` registry code while returning the underlying
+  error message on the wire as `open_failed: <reason>` when one is available.
+- All other stable RPC error codes remain exact strings without detail suffixes.
+
+### Why
+
+- The registry rollback path discarded the runtime/session construction error, leaving RPC clients with a bare
+  `open_failed` response that did not identify invalid workspace directories or other actionable causes.
+
+### Why extension system couldn't handle this
+
+- Multi-session lifecycle errors and JSONL response serialization are owned by the built-in RPC transport and are not
+  exposed through extension hooks.
+
+### Expected merge conflict zones
+
+- LOW: `session-registry.ts` error construction and `session-command-router.ts` registry-error serialization.
+
 ## high_reasoning_warning RPC event (2026-07-30)
 
 - New `RpcHighReasoningWarningEvent` contract (`{ type: "high_reasoning_warning"; modelId; provider; thinkingLevel }`), auto-published to RPC stdout via the existing `session.subscribe -> outputEvent` seam. No new wiring; the event is a session event forwarded like `thinking_level_changed`.

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -175,7 +175,9 @@ export class SessionCommandRouter {
 	}
 
 	private code(cause: unknown): string {
-		if (cause instanceof RpcSessionRegistryError) return cause.code;
+		if (cause instanceof RpcSessionRegistryError) {
+			return cause.code === RPC_ERROR_OPEN_FAILED ? cause.message : cause.code;
+		}
 		if (cause instanceof Error && [RPC_ERROR_UNKNOWN_SESSION, RPC_ERROR_SESSION_CLOSING].includes(cause.message)) {
 			return cause.message;
 		}

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -30,8 +30,8 @@ export interface RpcSessionEntry {
 export class RpcSessionRegistryError extends Error {
 	readonly code: "unknown_session" | "session_closing" | "session_path_in_use" | "invalid_path" | "open_failed";
 
-	constructor(code: RpcSessionRegistryError["code"]) {
-		super(code);
+	constructor(code: RpcSessionRegistryError["code"], reason?: string) {
+		super(code === "open_failed" && reason ? `${code}: ${reason}` : code);
 		this.code = code;
 		this.name = "RpcSessionRegistryError";
 	}
@@ -131,7 +131,7 @@ export class RpcSessionRegistry {
 				}
 			}
 			if (error instanceof RpcSessionRegistryError) throw error;
-			throw new RpcSessionRegistryError("open_failed");
+			throw new RpcSessionRegistryError("open_failed", error instanceof Error ? error.message : undefined);
 		}
 	}
 

--- a/packages/coding-agent/test/rpc-open-session-resume.test.ts
+++ b/packages/coding-agent/test/rpc-open-session-resume.test.ts
@@ -7,6 +7,8 @@ import type {
 	CreateAgentSessionRuntimeResult,
 } from "../src/core/agent-session-runtime.ts";
 import type { SessionManager } from "../src/core/session-manager.ts";
+import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
 import {
 	type RpcSessionLaunchProfile,
 	RpcSessionRegistry,
@@ -171,6 +173,31 @@ describe("open_session resume/create parity + close semantics", () => {
 
 		expect(calls).toHaveLength(0);
 		expect(registry.list()).toHaveLength(0);
+	});
+
+	test("missing cwd returns an open_failed wire error with the underlying reason", async () => {
+		const calls: CapturedFactoryCall[] = [];
+		const { dir, registry } = await makeRegistry(calls);
+		const missingCwd = join(dir, "missing-workspace");
+		const router = new SessionCommandRouter(registry, new SessionEventWriter(() => {}), { cwd: dir });
+
+		const response = await router.handle({
+			id: "missing-cwd",
+			type: "open_session",
+			cwd: missingCwd,
+			sessionPath: join(dir, "missing-cwd.jsonl"),
+			permissionPreset: "full",
+		});
+
+		expect(response).toMatchObject({
+			id: "missing-cwd",
+			type: "response",
+			command: "open_session",
+			success: false,
+			error: expect.stringMatching(/^open_failed: /),
+		});
+		expect(response && "error" in response ? response.error : "").toContain(missingCwd);
+		expect(calls).toHaveLength(0);
 	});
 
 	test("per-session cwd: each runtime receives its own cwd", async () => {


### PR DESCRIPTION
## Summary

- preserve the underlying multi-session `open_session` failure reason through registry rollback
- emit registry open failures as `open_failed: <reason>` while keeping the typed registry `code` as `open_failed`
- keep every other stable transport code exact and add a missing-cwd wire regression test

## Root cause

`RpcSessionRegistry.openSession()` caught runtime/session construction failures, completed rollback, then replaced the caught error with `new RpcSessionRegistryError("open_failed")`. `SessionCommandRouter` serializes registry errors from their stable `code`, so the original actionable message never reached the JSONL response.

The fix lets `RpcSessionRegistryError` retain an optional reason in its message and makes the router use that detailed message only when `code === "open_failed"`. Other registry errors still serialize directly from `cause.code`.

## Wire compatibility

- `open_failed` remains the stable prefix and typed registry code.
- Detailed failures now match the documented `open_failed: ${string}` shape.
- Bare `open_failed` remains the fallback when no `Error.message` exists.
- `unknown_session`, `session_closing`, `session_path_in_use`, `invalid_path`, `missing_session_id`, and `multi_session_disabled` are untouched and remain exact strings.

## Repro

Before, against the unmodified locally built CLI:

```json
{"id":"2","type":"response","command":"open_session","success":false,"error":"open_failed"}
```

After, against the rebuilt CLI in this worktree:

```json
{"id":"2","type":"response","command":"open_session","success":false,"error":"open_failed: Stored session working directory does not exist: /nonexistent/definitely-missing\nSession file: /private/tmp/s1.jsonl\nCurrent working directory: /nonexistent/definitely-missing"}
```

A second request with `cwd: "/tmp"` still returns `success: true`.

## Verification

- RED: focused test received bare `open_failed`
- GREEN: `rpc-open-session-resume.test.ts` (15/15)
- `rpc-session-registry.test.ts` (8/8)
- `npm run check`
- `npm run build`
- built CLI JSONL repro: missing cwd detailed failure + valid cwd success
- senpi QA common self-check (9/9)
- senpi QA RPC self-test (4/4)
- senpi QA mock-loop self-test (43/43)

Local broad `npm test` reached 6,882 passing coding-agent tests but the workstation repeatedly exhausted the macOS FSEvents watcher ceiling (`EMFILE`) in six unrelated watcher tests. This PR relies on GitHub CI for the clean broad-suite result; no unrelated test behavior was changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the underlying reason for `open_session` failures in RPC responses as `open_failed: <reason>`. Keep the stable registry code `open_failed` and all other error codes unchanged.

- **Bug Fixes**
  - Preserve failure reason in `RpcSessionRegistryError` and serialize the detailed message only for `open_failed`.
  - Keep all other transport codes exact (`unknown_session`, `session_closing`, etc.).
  - Add a regression test for missing cwd and update `changes.md` and `CHANGELOG.md`.

<sup>Written for commit 1c1566fbcd90c49d8fc370b3abc74f588ea5cd80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

