### PR TITLE
feat(codemode): emit detached-cell resumption channel liveness

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Added
 
+- Detached eval cells now publish their liveness as a `resumption_channel_state` event (source `eval-detached`) on the
+  host event bus: a full per-source snapshot with `activeCount` and per-cell `id`/`description`/`startedAtMs` entries is
+  emitted whenever a cell detaches, settles, is stopped, or is disposed, and once on `session_start`. The goal builtin
+  consumes this to hold its hidden continuation while detached cells are still computing instead of nagging immediately
+  at turn end. Hosts without an event bus are unaffected (emission is a no-op), and the footer/status rendering is
+  unchanged.
+
 ### Changed
 
 ### Fixed

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,43 @@
 # senpi-codemode fork changes
 
+## Detached eval cell resumption-channel liveness (2026-08-08)
+
+### What changed
+
+- New `src/extension/resumption-channel.ts` duplicates the cross-package `resumption_channel_state` event literal and
+  payload type locally; senpi-codemode is a separate package and must not import from packages/coding-agent, so a
+  sentinel test pins the literal to catch drift.
+- `src/tool/detached-cell-manager.ts`: new optional `onChannelState` callback fires a full per-source snapshot
+  (`{ source: "eval-detached", activeCount, channels: [{ id, description, startedAtMs }] }`) on the same transitions as
+  the existing `#emitStatus` footer seam (detach / settle / stop / dispose). `description` mirrors the footer label
+  fallback (`summary` else cell id). A public `publishChannelState()` re-publishes the current snapshot.
+- `src/index.ts`: the local `CodemodeExtensionAPI` widens with an optional `events?: { emit(name, data) }`; emission
+  goes through `pi.events?.emit(...)` so hosts without an event bus are a harmless no-op. Both cell-manager
+  constructions wire the callback, and the `session_start` handler re-publishes the snapshot because the consuming
+  goal builtin clears its per-session counts there.
+- `test/eval-resumption-channel.test.ts`: pins the single-cell snapshot, the two-cells-settling count sequence, the
+  bus-less host no-op, the `session_start` re-emit plus bus transport, and the event-name sentinel.
+
+### Why
+
+- The goal builtin delays its hidden "keep going" continuation while a live resumption channel is on duty, but it only
+  ever learned about terminal monitors. Detached eval cells are a real live channel that reported nothing, so the goal
+  nagged itself immediately at turn end while a cell was still computing. This change makes codemode EMIT its liveness;
+  a sibling lane owns the consuming side in the goal builtin.
+- The legacy `terminal_monitor_state` event keeps its single-owner full-snapshot semantics; emitting it from a second
+  source would clobber the terminal's count, so only the new source-keyed event is used.
+
+### Why this cannot be expressed externally
+
+- The liveness transitions live inside the detached-cell manager and the extension entry; an external extension cannot
+  observe detach/settle/dispose without reimplementing the cell lifecycle.
+
+### Expected merge conflict zones
+
+- LOW: `src/index.ts` around the cell-manager constructions and the `session_start` handler.
+- LOW: `src/tool/detached-cell-manager.ts` around `#emitStatus`.
+- MEDIUM: `CHANGELOG.md` `[Unreleased]` when sibling lanes land entries; keep both bullets.
+
 ## Compact elapsed labels for simple eval results (2026-08-06)
 
 ### What changed

--- a/packages/senpi-codemode/src/extension/resumption-channel.ts
+++ b/packages/senpi-codemode/src/extension/resumption-channel.ts
@@ -1,0 +1,29 @@
+/**
+ * Resumption-channel liveness contract shared with the goal builtin.
+ *
+ * The goal builtin delays its hidden continuation while any live resumption
+ * channel can still wake the session. Each emitter publishes a full per-source
+ * snapshot on every liveness transition and once on `session_start`.
+ *
+ * The event name is duplicated here on purpose: senpi-codemode is a separate
+ * package and must not import across the packages/coding-agent boundary, so
+ * the sentinel test pins this literal to the exact cross-package contract.
+ */
+export const RESUMPTION_CHANNEL_STATE_EVENT = "resumption_channel_state";
+
+/** Source key identifying detached eval cells in the per-source snapshot. */
+export const EVAL_DETACHED_CHANNEL_SOURCE = "eval-detached";
+
+/** One live channel as broadcast on the resumption channel state event. */
+export interface ResumptionChannelEntry {
+	readonly id: string;
+	readonly description: string;
+	/** Epoch milliseconds when the channel registered; lets consumers render their own elapsed labels. */
+	readonly startedAtMs: number;
+}
+
+export interface ResumptionChannelState {
+	readonly source: string;
+	readonly activeCount: number;
+	readonly channels?: readonly ResumptionChannelEntry[];
+}

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -7,6 +7,7 @@ import { defaultCodemodeSettings } from "./config/settings.ts";
 import { EvalNotifier } from "./extension/eval-notifier.ts";
 import { EVAL_CELLS_STATUS_KEY } from "./extension/eval-status.ts";
 import { EvalStatusTicker } from "./extension/eval-status-ticker.ts";
+import { RESUMPTION_CHANNEL_STATE_EVENT, type ResumptionChannelState } from "./extension/resumption-channel.ts";
 import {
 	createExecuteTool,
 	createRuntime,
@@ -38,6 +39,8 @@ export interface CodemodeExtensionAPI {
 	getActiveTools(): string[];
 	getAllTools(): readonly EvalSchemaToolInfo[];
 	sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
+	/** Optional host event bus; a host without one turns resumption-channel emission into a harmless no-op. */
+	events?: { emit(name: string, data: unknown): void };
 }
 
 export interface SenpiCodemodeOptions {
@@ -78,6 +81,9 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	});
 	const showDetachedCells = (entries: readonly EvalDetachedCellStatusEntry[]): void => {
 		statusTicker.sync(entries);
+	};
+	const emitChannelState = (state: ResumptionChannelState): void => {
+		pi.events?.emit(RESUMPTION_CHANNEL_STATE_EVENT, state);
 	};
 	const registerEvalForRuntime = (
 		runtime: SessionRuntime,
@@ -126,6 +132,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			cellManager: new EvalDetachedCellManager({
 				notifier,
 				onStatusChange: showDetachedCells,
+				onChannelState: emitChannelState,
 				...(options.now === undefined ? {} : { now: options.now }),
 			}),
 			executionTracker: manager,
@@ -156,9 +163,12 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			artifactsDir: runtime.artifactsDir,
 			notifier,
 			onStatusChange: showDetachedCells,
+			onChannelState: emitChannelState,
 			...(options.now === undefined ? {} : { now: options.now }),
 		});
 		activeCells = cellManager;
+		// The goal builtin clears its per-session counts at session_start; re-publish our snapshot.
+		cellManager.publishChannelState();
 		activeRuntime = runtime;
 		activeModelId = ctx.model?.id;
 		registerEvalForRuntime(runtime, activeModelId, cellManager);

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { EVAL_DETACHED_CHANNEL_SOURCE, type ResumptionChannelState } from "../extension/resumption-channel.ts";
 import { detachedNotificationSpillPath } from "./detached-cell-notification.ts";
 import { currentDetachedResult, detachedErrorResult, snapshotDetachedCell } from "./detached-cell-snapshot.ts";
 import {
@@ -58,12 +59,15 @@ export interface EvalDetachedCellManagerOptions {
 	readonly artifactsDir?: string;
 	readonly notifier?: EvalDetachedCellNotifier;
 	readonly onStatusChange?: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
+	/** Receives a full per-source liveness snapshot on every detached-cell transition; used by the goal builtin. */
+	readonly onChannelState?: (state: ResumptionChannelState) => void;
 	readonly now?: () => number;
 }
 
 export class EvalDetachedCellManager {
 	readonly #artifactsDir: string | undefined;
 	readonly #onStatusChange: ((entries: readonly EvalDetachedCellStatusEntry[]) => void) | undefined;
+	readonly #onChannelState: ((state: ResumptionChannelState) => void) | undefined;
 	readonly #cells = new Map<string, ManagedCell>();
 	readonly #detachedByLanguage = new Map<EvalLanguage, ManagedCell>();
 	readonly #notificationQueue: DetachedNotificationQueue;
@@ -72,6 +76,7 @@ export class EvalDetachedCellManager {
 	constructor(options: EvalDetachedCellManagerOptions = {}) {
 		this.#artifactsDir = options.artifactsDir;
 		this.#onStatusChange = options.onStatusChange;
+		this.#onChannelState = options.onChannelState;
 		this.#notificationQueue = new DetachedNotificationQueue(options.notifier, options.artifactsDir);
 		this.#now = options.now ?? Date.now;
 	}
@@ -162,6 +167,11 @@ export class EvalDetachedCellManager {
 		await this.#notificationQueue.flush();
 	}
 
+	/** Re-publish the current snapshot; consumers reset their per-source counts at session_start. */
+	publishChannelState(): void {
+		this.#emitChannelState([...this.#detachedByLanguage.values()]);
+	}
+
 	#settle(
 		cell: ManagedCell,
 		state: "completed" | "failed" | "cancelled",
@@ -188,14 +198,29 @@ export class EvalDetachedCellManager {
 	}
 
 	#emitStatus(): void {
+		const liveCells = [...this.#detachedByLanguage.values()];
 		this.#onStatusChange?.(
-			[...this.#detachedByLanguage.values()].map((cell) => ({
+			liveCells.map((cell) => ({
 				cellId: cell.cellId,
 				language: cell.input.language,
 				startedAtMs: cell.startedAtMs,
 				...(cell.input.summary === undefined ? {} : { summary: cell.input.summary }),
 			})),
 		);
+		this.#emitChannelState(liveCells);
+	}
+
+	#emitChannelState(liveCells: readonly ManagedCell[]): void {
+		this.#onChannelState?.({
+			source: EVAL_DETACHED_CHANNEL_SOURCE,
+			activeCount: liveCells.length,
+			channels: liveCells.map((cell) => ({
+				id: cell.cellId,
+				description:
+					cell.input.summary === undefined || cell.input.summary.length === 0 ? cell.cellId : cell.input.summary,
+				startedAtMs: cell.startedAtMs,
+			})),
+		});
 	}
 
 	#snapshot(cell: ManagedCell): EvalDetachedCellSnapshot {

--- a/packages/senpi-codemode/test/eval-resumption-channel.test.ts
+++ b/packages/senpi-codemode/test/eval-resumption-channel.test.ts
@@ -1,0 +1,305 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RESUMPTION_CHANNEL_STATE_EVENT, type ResumptionChannelState } from "../src/extension/resumption-channel.ts";
+import type { CodemodeSessionManager } from "../src/extension/session-manager.ts";
+import senpiCodemode, { type CodemodeExtensionAPI } from "../src/index.ts";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { EvalKernel } from "../src/tool/types.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+	vi.useRealTimers();
+	await Promise.all(directories.splice(0).map(async (path) => await rm(path, { recursive: true, force: true })));
+});
+
+function channelRecorder(): {
+	readonly emissions: ResumptionChannelState[];
+	readonly onChannelState: (state: ResumptionChannelState) => void;
+} {
+	const emissions: ResumptionChannelState[] = [];
+	return { emissions, onChannelState: (state) => emissions.push(state) };
+}
+
+function interactiveContext() {
+	return { ...fakeExtensionContext(), mode: "tui" as const };
+}
+
+function createTool(manager: EvalDetachedCellManager, entries: Array<readonly [string, FakeKernel]>) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: true, rb: false, jl: false },
+		kernelManager: new FakeManager(entries),
+		cellTimeoutSeconds: 1,
+		executeTool: vi.fn(),
+		cellManager: manager,
+	});
+}
+
+async function detach(
+	tool: ReturnType<typeof createTool>,
+	kernel: FakeKernel,
+	cellId: string,
+	summary: string,
+	language: "js" | "py" = "js",
+): Promise<void> {
+	const started = kernel.deferNextRun();
+	const execution = tool.execute(
+		cellId,
+		{ language, code: "await forever", summary, on_timeout: "detach" },
+		undefined,
+		undefined,
+		interactiveContext(),
+	);
+	await started;
+	await vi.advanceTimersByTimeAsync(1_000);
+	await execution;
+}
+
+describe("eval detached cell resumption channel liveness", () => {
+	it("emits a full snapshot with the channel entry when one cell detaches", async () => {
+		vi.useFakeTimers();
+		const channel = channelRecorder();
+		const manager = new EvalDetachedCellManager({ onChannelState: channel.onChannelState });
+		const kernel = new FakeKernel([]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		await detach(tool, kernel, "channel-cell", "numpy feather rerun");
+
+		expect(channel.emissions).toEqual([
+			{
+				source: "eval-detached",
+				activeCount: 1,
+				channels: [{ id: "channel-cell", description: "numpy feather rerun", startedAtMs: expect.any(Number) }],
+			},
+		]);
+		await manager.stop("channel-cell");
+		await manager.flushNotifications();
+	});
+
+	it("tracks activeCount as two live cells settle one by one", async () => {
+		vi.useFakeTimers();
+		const channel = channelRecorder();
+		const manager = new EvalDetachedCellManager({ onChannelState: channel.onChannelState });
+		const js = new FakeKernel([]);
+		const py = new FakeKernel([]);
+		const tool = createTool(manager, [
+			["js", js],
+			["py", py],
+		]);
+
+		await detach(tool, js, "js-cell", "bundle build", "js");
+		await detach(tool, py, "py-cell", "strip repairs", "py");
+
+		expect(channel.emissions.at(-1)).toEqual({
+			source: "eval-detached",
+			activeCount: 2,
+			channels: [
+				{ id: "js-cell", description: "bundle build", startedAtMs: expect.any(Number) },
+				{ id: "py-cell", description: "strip repairs", startedAtMs: expect.any(Number) },
+			],
+		});
+
+		await manager.stop("js-cell");
+
+		expect(channel.emissions.at(-1)).toEqual({
+			source: "eval-detached",
+			activeCount: 1,
+			channels: [{ id: "py-cell", description: "strip repairs", startedAtMs: expect.any(Number) }],
+		});
+
+		await manager.stop("py-cell");
+
+		expect(channel.emissions.at(-1)).toEqual({ source: "eval-detached", activeCount: 0, channels: [] });
+		await manager.flushNotifications();
+	});
+});
+
+interface StatusCall {
+	readonly key: string;
+	readonly text: string | undefined;
+}
+
+interface BusEmission {
+	readonly name: string;
+	readonly data: unknown;
+}
+
+class WiringPi {
+	readonly handlers: Array<{
+		readonly event: string;
+		readonly handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void;
+	}> = [];
+	readonly messages: string[] = [];
+	registeredTool: Parameters<CodemodeExtensionAPI["registerTool"]>[0] | undefined;
+	events?: { emit(name: string, data: unknown): void };
+
+	registerTool(tool: Parameters<CodemodeExtensionAPI["registerTool"]>[0]): void {
+		if (tool.name === "eval") this.registeredTool = tool;
+	}
+	registerRemovedToolHint(): void {}
+	on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void {
+		this.handlers.push({ event, handler });
+	}
+	getActiveTools(): string[] {
+		return ["eval"];
+	}
+	getAllTools(): readonly { readonly name: string }[] {
+		return [{ name: "eval" }];
+	}
+	async executeTool(): Promise<never> {
+		throw new Error("nested tool execution was not expected");
+	}
+	sendUserMessage(content: string): void {
+		this.messages.push(content);
+	}
+	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
+		for (const entry of this.handlers.filter((handler) => handler.event === event)) await entry.handler(payload, ctx);
+	}
+}
+
+class WiringSessionManager implements CodemodeSessionManager {
+	readonly kernel: FakeKernel;
+
+	constructor(kernel: FakeKernel) {
+		this.kernel = kernel;
+	}
+	async getKernel(): Promise<EvalKernel> {
+		return this.kernel;
+	}
+	async dispose(): Promise<void> {}
+	async complete(): Promise<{
+		readonly text: string;
+		readonly details: { readonly model: string; readonly structured: false };
+	}> {
+		return { text: "ok", details: { model: "fake/fake-model", structured: false } };
+	}
+}
+
+const artifactsRoot = join(tmpdir(), `senpi-codemode-channel-wiring-${process.pid}`);
+
+afterEach(async () => {
+	await rm(artifactsRoot, { recursive: true, force: true });
+});
+
+async function sessionCwd(): Promise<string> {
+	const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-channel-"));
+	directories.push(cwd);
+	await mkdir(join(cwd, ".senpi"), { recursive: true });
+	await writeFile(
+		join(cwd, ".senpi", "codemode.json"),
+		JSON.stringify({ languages: { py: false, js: true, rb: false, jl: false }, cellTimeoutSeconds: 1 }),
+	);
+	return cwd;
+}
+
+function wiringContext(cwd: string, calls: StatusCall[]): ExtensionContext {
+	const base = fakeExtensionContext();
+	const theme = Object.create(null);
+	theme.fg = (_color: string, text: string): string => text;
+	theme.bg = (_color: string, text: string): string => text;
+	const ui = Object.create(null);
+	ui.setStatus = (key: string, text: string | undefined): void => {
+		calls.push({ key, text });
+	};
+	ui.theme = theme;
+	const sessionManager = Object.create(null);
+	sessionManager.getSessionFile = (): string => join(artifactsRoot, `${crypto.randomUUID()}.jsonl`);
+	return { ...base, cwd, mode: "tui", hasUI: true, ui, sessionManager };
+}
+
+async function detachOne(
+	pi: WiringPi,
+	kernel: FakeKernel,
+	ctx: ExtensionContext,
+	cellId: string,
+	summary: string,
+): Promise<void> {
+	const tool = pi.registeredTool;
+	if (!tool) throw new Error("eval tool was not registered");
+	const started = kernel.deferNextRun();
+	const execution = tool.execute(
+		cellId,
+		{ language: "js", code: "await forever", summary, on_timeout: "detach" },
+		undefined,
+		undefined,
+		ctx,
+	);
+	await started;
+	await vi.advanceTimersByTimeAsync(1_000);
+	await execution;
+}
+
+describe("resumption channel liveness wiring", () => {
+	it("re-emits the current snapshot on session_start and publishes detach transitions on the host bus", async () => {
+		const cwd = await sessionCwd();
+		const pi = new WiringPi();
+		const busEmissions: BusEmission[] = [];
+		pi.events = { emit: (name, data) => busEmissions.push({ name, data }) };
+		const kernel = new FakeKernel([]);
+		senpiCodemode(pi, { createSessionManager: () => new WiringSessionManager(kernel) });
+		const calls: StatusCall[] = [];
+		const ctx = wiringContext(cwd, calls);
+
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+
+		expect(busEmissions).toEqual([
+			{
+				name: "resumption_channel_state",
+				data: { source: "eval-detached", activeCount: 0, channels: [] },
+			},
+		]);
+
+		vi.useFakeTimers();
+		await detachOne(pi, kernel, ctx, "wire-cell", "wire probe");
+
+		expect(busEmissions.at(-1)).toEqual({
+			name: "resumption_channel_state",
+			data: {
+				source: "eval-detached",
+				activeCount: 1,
+				channels: [{ id: "wire-cell", description: "wire probe", startedAtMs: expect.any(Number) }],
+			},
+		});
+
+		kernel.completeDeferredRun(result("wire-cell", "42"));
+		await vi.waitFor(() =>
+			expect(busEmissions.at(-1)).toEqual({
+				name: "resumption_channel_state",
+				data: { source: "eval-detached", activeCount: 0, channels: [] },
+			}),
+		);
+
+		await pi.emit("session_shutdown", {}, ctx);
+	});
+
+	it("keeps the cell lifecycle intact when the host has no event bus", async () => {
+		const cwd = await sessionCwd();
+		const pi = new WiringPi();
+		const kernel = new FakeKernel([]);
+		senpiCodemode(pi, { createSessionManager: () => new WiringSessionManager(kernel) });
+		const calls: StatusCall[] = [];
+		const ctx = wiringContext(cwd, calls);
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+
+		vi.useFakeTimers();
+		await detachOne(pi, kernel, ctx, "busless-cell", "busless probe");
+
+		expect(calls.at(-1)).toEqual({ key: "eval-cells", text: "↗ js · busless probe (0s)" });
+
+		kernel.completeDeferredRun(result("busless-cell", "7"));
+		await vi.waitFor(() => expect(calls.at(-1)).toEqual({ key: "eval-cells", text: undefined }));
+
+		await pi.emit("session_shutdown", {}, ctx);
+	});
+});
+
+describe("resumption channel event contract", () => {
+	it("pins the duplicated event literal to the exact cross-package contract", () => {
+		expect(RESUMPTION_CHANNEL_STATE_EVENT).toBe("resumption_channel_state");
+	});
+});


### PR DESCRIPTION
## What changed

Detached eval cells now report their liveness on the host event bus so the goal builtin can hold its hidden continuation while cells are still computing.

- **`src/extension/resumption-channel.ts` (new)**: the `resumption_channel_state` event literal, the `eval-detached` source key, and the payload types.
- **`src/tool/detached-cell-manager.ts`**: a new optional `onChannelState` callback fires a full per-source snapshot (`{ source: "eval-detached", activeCount, channels: [{ id, description, startedAtMs }] }`) on the same transitions as the existing `#emitStatus` footer seam — detach, settle, stop, dispose. `description` mirrors the footer label fallback (`summary`, else cell id). A public `publishChannelState()` re-publishes the current snapshot.
- **`src/index.ts`**: the local `CodemodeExtensionAPI` widens with an optional `events?: { emit(name, data) }`; emission goes through `pi.events?.emit(...)`. Both cell-manager constructions wire the callback, and the `session_start` handler re-publishes the snapshot.
- **Tests**: `test/eval-resumption-channel.test.ts` (5 tests, written failing-first).
- **Changelogs**: `CHANGELOG.md` `[Unreleased]` + `changes.md`.

## Why

The goal builtin delays its hidden "keep going" continuation while a live resumption channel is on duty, but it only ever learns about terminal monitors. Detached eval cells (`eval` tool cells that keep running after the turn) are a real live channel that reported nothing, so the goal nagged itself immediately at turn end while a cell was still computing. This PR is the emit side only; a sibling lane owns the consuming side in the goal builtin.

## Contract + duplicated-literal rationale

- Event `resumption_channel_state`, payload `{ source, activeCount, channels? }` where `activeCount` is a **full snapshot for this source only** (`eval-detached`), published on every liveness transition and once on `session_start` (the consumer clears per-session counts there).
- The literal is **duplicated locally, not imported**: `packages/senpi-codemode` is a separate package and must not import across the `packages/coding-agent` boundary. A sentinel test pins the literal to exactly `"resumption_channel_state"` so drift fails CI.
- The legacy `terminal_monitor_state` event is deliberately **not** emitted: it has single-owner full-snapshot semantics and a second emitter would clobber the terminal's count.
- Emission can never break a cell: optional chaining makes bus-less hosts a no-op, and the host event bus already isolates listener errors from `emit`.

## QA evidence

- Failing-first: new test file failed before implementation (`Cannot find module '../src/extension/resumption-channel.ts'`, suite 515 passed baseline); after implementation the same file passes.
- `packages/senpi-codemode` suite: **520 passed / 6 skipped** (75 files).
- Repo root `npm run check` (biome `--error-on-warnings`, pinned-deps, ts-imports, shrinkwrap, install-lock, `tsc --noEmit`, browser-smoke): **exit 0**.
- Full evidence log: `evidence/20260808-goal-resumption-channels-laneC.md` (repo-local, not committed).

## Residual risk

- Low. The footer/status rendering and elapsed-label logic are untouched; the new callback rides the exact transitions the footer already used. Hosts without an event bus (tests, SDK partial contexts) behave exactly as before. The only new cross-package surface is the additive event, which no consumer depends on until the sibling lane lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detached eval cells now emit `resumption_channel_state` liveness snapshots (`source: "eval-detached"`) so the goal builtin can hold its hidden continuation while cells are still running. Hosts without an event bus are unchanged.

- New Features
  - Emit a full per-source snapshot on detach, settle, stop, dispose, and once on `session_start`: `{ source: "eval-detached", activeCount, channels: [{ id, description, startedAtMs }] }`.
  - Added `events?: { emit(name, data) }` to the local `CodemodeExtensionAPI`; emissions go through `pi.events?.emit(...)`.
  - `detached-cell-manager`: new `onChannelState` callback and `publishChannelState()`; `description` mirrors footer fallback (`summary` else cell id).
  - Does not emit `terminal_monitor_state` to avoid clobbering the terminal’s count.

<sup>Written for commit 15b9e2a7c6a811bf874c6062f0d06a4b13651779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

