### PR TITLE
feat(goal): aggregate live resumption channels

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- Fixed active Goals resuming immediately while background tasks, detached evals, or background bash sessions were
+  still live. Goal continuation now aggregates source-keyed resumption-channel snapshots, preserves the four-minute
+  cache-warm check-in, and reports a per-source wait summary while retaining terminal-monitor telemetry compatibility.
 - Fixed multi-session RPC `open_session` failures returning only a bare `open_failed` code. Responses now preserve the
   stable prefix and include the underlying workspace or runtime cause as `open_failed: <reason>`, while all other
   transport error codes remain exact strings ([#750](https://github.com/code-yeongyu/senpi/pull/750)).

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -170,17 +170,14 @@
 - Expected merge conflict zones: MEDIUM in `service-tier.ts` around the command
   and `before_provider_request` handler.
 
-## terminal + goal: monitor liveness event contract (2026-07-28)
+## resumption channels + goal: source-keyed liveness contract (2026-08-08, supersedes 2026-07-28)
 
-- New `monitor-state-event.ts` defines the internal `terminal_monitor_state` pi-event
-  payload (`activeCount`).
-- The terminal extension publishes the live registry count on every existing
-  `MonitorRegistry.onChange` transition (register, pause/rearm snapshot change,
-  settle, dispose) while preserving the monitor footer update.
-- The goal builtin consumes this internal event to select immediate versus delayed
-  continuation policy; no public `ExtensionContext` or RPC protocol type changed.
-- Expected merge conflict zones: LOW in `terminal/extension.ts` around the monitor
-  registry `onChange` callback; NONE in `extensions/types.ts`.
+- New `resumption-channel-event.ts` defines the internal `resumption_channel_state` pi-event as a full snapshot for one open-set `source`: `{source, activeCount, channels?}`. Sources are strings rather than an enum so terminal monitors, background bash, detached evals, senpi tasks, and future producers can share the contract without central registration.
+- Goal stores one count per source and writes each incoming snapshot to that key. Legacy `terminal_monitor_state` and generalized `resumption_channel_state` emissions both write `"terminal-monitor"`, making dual emission idempotent: a count of two remains two and is never summed to four.
+- Immediate-versus-delayed continuation, system-abort recovery, timer eligibility, wait labels, and stall context use the total across source keys. Timer cancellation and toolless-streak reset occur only when that total transitions from positive to zero; one source draining while another remains live has no zero-transition side effect.
+- Goal subscribes at extension factory/construction scope rather than inside `session_start`, and keeps both subscriptions until disposal. `start()` clears prior-session counts. Every emitter must therefore publish transitions while live and re-emit its full current snapshot on `session_start` after Goal has reset, so the new session cannot inherit stale counts or miss live channels.
+- Scheduled/resumed pi-events and `goal-cache-warmup` entries retain backward-compatible `activeMonitorCount` (terminal monitors only) and add `channelCounts` for the source-keyed snapshot. No public `ExtensionContext` or RPC protocol type changed.
+- Expected merge conflict zones: emitters in sibling-owned terminal/task/eval modules; LOW in Goal continuation telemetry and wait presentation; NONE in `extensions/types.ts`.
 
 ## bash-timeout: beyond-max routing to run_in_background + monitor (2026-07-28)
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
@@ -30,6 +30,8 @@ export interface GoalCacheWarmupEntryData {
 	/** Actual wait in milliseconds; present on the `resumed` phase only. */
 	readonly waitedMs?: number;
 	readonly activeMonitorCount: number;
+	/** Full source-keyed snapshot; absent on entries written before resumption channels were generalized. */
+	readonly channelCounts?: Readonly<Record<string, number>>;
 	readonly cache?: GoalCacheWarmMetrics;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation-types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation-types.ts
@@ -17,6 +17,7 @@ export interface SystemAbortOptions extends AgentEndOptions {
 
 export type ContinuingGoalContinuationVerdict = Extract<GoalContinuationVerdict, { kind: "continue" }>;
 export type DelayedContinuationKind = GoalWaitKind;
+export type ResumptionChannelCounts = Readonly<Record<string, number>>;
 
 export type GoalContinuationAdmission = {
 	readonly goal: Goal;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isTerminalMonitorStateEvent, TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
+import { isResumptionChannelStateEvent, RESUMPTION_CHANNEL_STATE_EVENT } from "../resumption-channel-event.ts";
 import {
 	estimateCacheWarmMetrics,
 	GOAL_CACHE_WARMUP_ENTRY_TYPE,
@@ -28,6 +29,7 @@ import type {
 	ContinuingGoalContinuationVerdict,
 	DelayedContinuationKind,
 	GoalContinuationAdmission,
+	ResumptionChannelCounts,
 	SystemAbortOptions,
 } from "./monitor-continuation-types.ts";
 import { buildContinuationPrompt, buildGoalStallNotice, buildTruncationRecoveryPrompt } from "./prompt.ts";
@@ -47,12 +49,12 @@ export class MonitorAwareGoalContinuation {
 	readonly #isContinuationPending: () => boolean;
 	readonly #markContinuationPending: () => void;
 	readonly #waitTicker: GoalWaitTicker | undefined;
-	#activeMonitorCount = 0;
+	#channelCounts = new Map<string, number>();
 	#ctx: ExtensionContext | undefined;
 	#goal: Goal | null = null;
 	#timer: ReturnType<typeof setTimeout> | undefined;
 	#scheduledContinuationKind: DelayedContinuationKind | undefined;
-	#unsubscribeMonitorState: (() => void) | undefined;
+	#channelStateUnsubscribers: Array<() => void> = [];
 	#lastAgentEndMessages: readonly AgentMessage[] = [];
 	#consecutiveLengthRecoveries = new Map<string, number>();
 	#recentNormalizedOutputHashes: string[] = [];
@@ -77,31 +79,17 @@ export class MonitorAwareGoalContinuation {
 		this.#isContinuationPending = isContinuationPending;
 		this.#markContinuationPending = markContinuationPending;
 		this.#waitTicker = waitTicker;
+		this.#subscribeToChannelState();
 	}
 
 	start(ctx: ExtensionContext): void {
 		this.#cancelTimer();
-		this.#unsubscribeMonitorState?.();
 		this.#ctx = ctx;
-		this.#activeMonitorCount = 0;
+		this.#channelCounts.clear();
 		this.#goal = null;
 		this.#lastAgentEndMessages = [];
 		this.#directInputHolds.clear();
 		this.#resetContinuationState();
-		const events = this.#pi.events;
-		if (events === undefined) return;
-		this.#unsubscribeMonitorState = events.on(TERMINAL_MONITOR_STATE_EVENT, (data) => {
-			if (!isTerminalMonitorStateEvent(data)) return;
-			this.#activeMonitorCount = data.activeCount;
-			if (data.activeCount === 0) {
-				if (this.#scheduledContinuationKind === "monitor") this.#cancelTimer();
-				this.#resetToollessContinuationStreak();
-				return;
-			}
-			if (this.#scheduledContinuationKind === "monitor") {
-				this.#waitTicker?.setActiveMonitorCount(data.activeCount);
-			}
-		});
 	}
 
 	async afterAgentEnd(options: AgentEndOptions): Promise<Goal | null> {
@@ -151,7 +139,7 @@ export class MonitorAwareGoalContinuation {
 		}
 		if (immediateVerdict.kind === "deny" && immediateVerdict.reason === "not-eligible") return goal;
 
-		if (this.#activeMonitorCount === 0) {
+		if (this.#activeChannelCount() === 0) {
 			this.#cancelTimer();
 			const admission = await this.#admitAndQueue(options.ctx, goal, "immediate", options.messages);
 			return admission.goal;
@@ -168,7 +156,7 @@ export class MonitorAwareGoalContinuation {
 		this.#lastAgentEndMessages = options.messages;
 		this.#lastTurnUsage = collectAssistantUsage([...options.messages]);
 		if (options.willRetry || options.goal?.status !== "active") return options.goal;
-		if (this.#activeMonitorCount > 0) this.#schedule(options.goal, "monitor");
+		if (this.#activeChannelCount() > 0) this.#schedule(options.goal, "monitor");
 		else if (lastAssistantMessage(options.messages)?.stopReason === "error") {
 			this.#pendingSystemRecovery = options;
 		}
@@ -240,11 +228,11 @@ export class MonitorAwareGoalContinuation {
 
 	dispose(): void {
 		this.#cancelTimer();
-		this.#unsubscribeMonitorState?.();
-		this.#unsubscribeMonitorState = undefined;
+		for (const unsubscribe of this.#channelStateUnsubscribers) unsubscribe();
+		this.#channelStateUnsubscribers = [];
 		this.#ctx = undefined;
 		this.#goal = null;
-		this.#activeMonitorCount = 0;
+		this.#channelCounts.clear();
 		this.#lastAgentEndMessages = [];
 		this.#directInputHolds.clear();
 		this.#resetContinuationState();
@@ -255,19 +243,22 @@ export class MonitorAwareGoalContinuation {
 		const delayMs = kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS;
 		if (kind === "monitor") {
 			const cache = estimateCacheWarmMetrics(this.#ctx?.model, process.env, this.#lastTurnUsage);
+			const channelCounts = this.#channelCountSnapshot();
 			this.#scheduledCache = cache;
 			this.#scheduledAtMs = Date.now();
 			this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
 				goalId: goal.id,
 				delayMs,
-				activeMonitorCount: this.#activeMonitorCount,
+				activeMonitorCount: this.#activeTerminalMonitorCount(),
+				channelCounts,
 				cache,
 			});
 			this.#appendWarmupEntry({
 				phase: "scheduled",
 				goalId: goal.id,
 				delayMs,
-				activeMonitorCount: this.#activeMonitorCount,
+				activeMonitorCount: this.#activeTerminalMonitorCount(),
+				channelCounts,
 				...(cache !== undefined ? { cache } : {}),
 			});
 		} else {
@@ -290,7 +281,7 @@ export class MonitorAwareGoalContinuation {
 				kind,
 				remainingMs: delayMs,
 				totalMs: kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS,
-				activeMonitorCount: this.#activeMonitorCount,
+				channelCounts: this.#channelCountSnapshot(),
 			});
 		}
 		this.#timer = setTimeout(() => {
@@ -316,7 +307,7 @@ export class MonitorAwareGoalContinuation {
 		const ctx = this.#ctx;
 		const goal = this.#goal;
 		if (ctx === undefined || goal?.status !== "active" || !ctx.isIdle() || ctx.hasPendingMessages()) return;
-		if (kind === "monitor" && this.#activeMonitorCount === 0) return;
+		if (kind === "monitor" && this.#activeChannelCount() === 0) return;
 		const admission = await this.#admitAndQueue(
 			ctx,
 			goal,
@@ -324,11 +315,13 @@ export class MonitorAwareGoalContinuation {
 			this.#lastAgentEndMessages,
 		);
 		if (kind !== "monitor" || !admission.admitted) return;
+		const channelCounts = this.#channelCountSnapshot();
 		this.#pi.events?.emit(GOAL_CONTINUATION_RESUMED_EVENT, {
 			goalId: goal.id,
 			delayMs,
 			waitedMs,
-			activeMonitorCount: this.#activeMonitorCount,
+			activeMonitorCount: this.#activeTerminalMonitorCount(),
+			channelCounts,
 			cache,
 		});
 		this.#appendWarmupEntry({
@@ -336,7 +329,8 @@ export class MonitorAwareGoalContinuation {
 			goalId: goal.id,
 			delayMs,
 			waitedMs,
-			activeMonitorCount: this.#activeMonitorCount,
+			activeMonitorCount: this.#activeTerminalMonitorCount(),
+			channelCounts,
 			...(cache !== undefined ? { cache } : {}),
 		});
 	}
@@ -395,20 +389,21 @@ export class MonitorAwareGoalContinuation {
 		let content = verdict.prompt === "minimal" ? buildTruncationRecoveryPrompt() : buildContinuationPrompt(goal);
 		if (!verdict.stallNotice) return content;
 
-		const monitorsActive = this.#activeMonitorCount > 0;
+		const liveSources = this.#liveChannelSources();
 		this.#pi.events?.emit(GOAL_MONITOR_STALL_EVENT, {
 			goalId: goal.id,
 			consecutiveContinuations: this.#toollessContinuationStreak,
 			toolless: true,
 		});
 		if (ctx.hasUI) {
-			const context = monitorsActive ? "while monitors stayed active" : "without tool use";
+			const context =
+				liveSources.length > 0 ? `while ${liveSources.join(", ")} channels stayed active` : "without tool use";
 			ctx.ui.notify(
 				`Goal continuation repeated ${this.#toollessContinuationStreak} toolless turns ${context} - injected a stall check.`,
 				"info",
 			);
 		}
-		content = `${buildGoalStallNotice(this.#toollessContinuationStreak, { monitorsActive })}\n\n${content}`;
+		content = `${buildGoalStallNotice(this.#toollessContinuationStreak, { liveSources })}\n\n${content}`;
 		return content;
 	}
 
@@ -439,6 +434,58 @@ export class MonitorAwareGoalContinuation {
 	#resetLengthRecoveryAfterCleanStop(goal: Goal | null, messages: readonly AgentMessage[]): void {
 		if (goal === null || lastAssistantMessage(messages)?.stopReason !== "stop") return;
 		this.#consecutiveLengthRecoveries.delete(goal.id);
+	}
+
+	#subscribeToChannelState(): void {
+		const events = this.#pi.events;
+		if (events === undefined) return;
+		this.#channelStateUnsubscribers.push(
+			events.on(TERMINAL_MONITOR_STATE_EVENT, (data) => {
+				if (!isTerminalMonitorStateEvent(data)) return;
+				this.#setChannelCount("terminal-monitor", data.activeCount);
+			}),
+			events.on(RESUMPTION_CHANNEL_STATE_EVENT, (data) => {
+				if (!isResumptionChannelStateEvent(data)) return;
+				this.#setChannelCount(data.source, data.activeCount);
+			}),
+		);
+	}
+
+	#setChannelCount(source: string, activeCount: number): void {
+		const previousTotal = this.#activeChannelCount();
+		this.#channelCounts.set(source, activeCount);
+		const nextTotal = this.#activeChannelCount();
+		if (previousTotal > 0 && nextTotal === 0) {
+			if (this.#scheduledContinuationKind === "monitor") this.#cancelTimer();
+			this.#resetToollessContinuationStreak();
+			return;
+		}
+		if (this.#scheduledContinuationKind === "monitor") {
+			this.#waitTicker?.setChannelCounts(this.#channelCountSnapshot());
+		}
+	}
+
+	#activeChannelCount(): number {
+		let total = 0;
+		for (const count of this.#channelCounts.values()) total += count;
+		return total;
+	}
+
+	#activeTerminalMonitorCount(): number {
+		return this.#channelCounts.get("terminal-monitor") ?? 0;
+	}
+
+	#channelCountSnapshot(): ResumptionChannelCounts {
+		return Object.fromEntries(
+			[...this.#channelCounts.entries()].sort(([left], [right]) => left.localeCompare(right)),
+		);
+	}
+
+	#liveChannelSources(): string[] {
+		return [...this.#channelCounts.entries()]
+			.filter(([, count]) => count > 0)
+			.map(([source]) => source)
+			.sort();
 	}
 
 	#resetContinuationState(): void {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/prompt.ts
@@ -50,15 +50,39 @@ export function buildTruncationRecoveryPrompt(): string {
 	].join("\n");
 }
 
-export function buildGoalStallNotice(consecutiveToollessTurns: number, options: { monitorsActive: boolean }): string {
-	if (options.monitorsActive) {
+export function buildGoalStallNotice(
+	consecutiveToollessTurns: number,
+	options: { liveSources: readonly string[] },
+): string {
+	if (options.liveSources.length > 0) {
+		const sources = new Set(options.liveSources);
+		const advice: string[] = [];
+		if (sources.has("terminal-monitor") || sources.has("terminal-bash")) {
+			advice.push(
+				"- Inspect the terminal sessions' output now (bash_output), verify the watched condition can still occur, and stop obsolete or hung sessions (kill_bash).",
+			);
+		}
+		if (sources.has("senpi-task")) {
+			advice.push(
+				"- Inspect each child task now (task_output); if it needs correction or cancellation, send it a concrete instruction (task_send).",
+			);
+		}
+		if (sources.has("eval-detached")) {
+			advice.push(
+				"- Inspect detached eval cells now (eval peek); stop cells that are stalled, obsolete, or waiting on impossible conditions (eval stop).",
+			);
+		}
+		for (const source of sources) {
+			if (["terminal-monitor", "terminal-bash", "senpi-task", "eval-detached"].includes(source)) continue;
+			advice.push(
+				`- Inspect the live ${source} channel now and stop or replace it if it can no longer make progress.`,
+			);
+		}
 		return [
 			"<goal_stall_check>",
-			`System check: this is monitor-wait goal continuation #${consecutiveToollessTurns} in a row. The same monitor(s) stayed active across ${consecutiveToollessTurns} consecutive continuation turns with no new user input and no monitor completion. The current situation is likely abnormal - a stalled or dead wait.`,
-			"Before waiting on the monitors again, actively investigate:",
-			"- Inspect the monitored sessions' output now (bash_output) and verify the watched condition can still occur.",
-			"- Check whether the underlying process is hung, exited silently, or waiting on input; restart or replace it if so.",
-			"- If the wait target is wrong or no longer needed, kill the monitor (kill_bash) and pursue the goal another way.",
+			`System check: this is resumption-channel goal continuation #${consecutiveToollessTurns} in a row. Live channel kinds (${[...sources].join(", ")}) persisted across ${consecutiveToollessTurns} consecutive continuation turns with no new user input and no completion. The current situation is likely abnormal - a stalled or dead wait.`,
+			"Before waiting on these channels again, actively investigate:",
+			...advice,
 			"- If the goal truly cannot progress, run the blocked audit instead of waiting again.",
 			"Do not end this turn with only another passive wait.",
 			"</goal_stall_check>",
@@ -77,7 +101,7 @@ export function buildGoalStallNotice(consecutiveToollessTurns: number, options: 
 }
 
 export function buildMonitorStallNotice(consecutiveContinuations: number): string {
-	return buildGoalStallNotice(consecutiveContinuations, { monitorsActive: true });
+	return buildGoalStallNotice(consecutiveContinuations, { liveSources: ["terminal-monitor"] });
 }
 
 function escapeXmlText(value: string): string {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/wait-progress.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/wait-progress.ts
@@ -1,4 +1,5 @@
 import { formatWakeDuration } from "./cache-warm.ts";
+import type { ResumptionChannelCounts } from "./monitor-continuation-types.ts";
 
 export type GoalWaitKind = "monitor" | "userGrace";
 
@@ -6,13 +7,14 @@ export interface GoalWaitLabelInput {
 	readonly kind: GoalWaitKind;
 	readonly remainingMs: number;
 	readonly totalMs: number;
-	readonly activeMonitorCount: number;
+	readonly channelCounts: ResumptionChannelCounts;
 }
 
 export const GOAL_WAIT_BAR_CELLS = 12;
 
 const FILLED_CELL = "\u25b0";
 const EMPTY_CELL = "\u25b1";
+const SOURCE_ORDER = ["terminal-monitor", "senpi-task", "eval-detached", "terminal-bash"] as const;
 
 function clampRatio(value: number): number {
 	if (!Number.isFinite(value)) return 0;
@@ -29,15 +31,40 @@ function elapsedRatioOf(remainingMs: number, totalMs: number): number {
 	return clampRatio((totalMs - Math.max(0, remainingMs)) / totalMs);
 }
 
-function monitorsOnDuty(count: number): string {
-	return count === 1 ? "1 monitor on duty" : `${count} monitors on duty`;
+function sourceSortIndex(source: string): number {
+	const index = SOURCE_ORDER.indexOf(source as (typeof SOURCE_ORDER)[number]);
+	return index < 0 ? SOURCE_ORDER.length : index;
+}
+
+function formatSourceCount(source: string, count: number): string {
+	switch (source) {
+		case "terminal-monitor":
+			return count === 1 ? "1 monitor" : `${count} monitors`;
+		case "senpi-task":
+			return count === 1 ? "1 task" : `${count} tasks`;
+		case "eval-detached":
+			return count === 1 ? "1 eval" : `${count} evals`;
+		case "terminal-bash":
+			return count === 1 ? "1 bash" : `${count} bash sessions`;
+		default: {
+			const label = source.replaceAll("-", " ");
+			return count === 1 ? `1 ${label}` : `${count} ${label} channels`;
+		}
+	}
+}
+
+export function channelsOnDuty(channelCounts: ResumptionChannelCounts): string {
+	const liveSources = Object.entries(channelCounts)
+		.filter(([, count]) => count > 0)
+		.sort(([left], [right]) => sourceSortIndex(left) - sourceSortIndex(right) || left.localeCompare(right));
+	return `${liveSources.map(([source, count]) => formatSourceCount(source, count)).join(" \u00b7 ")} on duty`;
 }
 
 export function formatGoalWaitLabel(input: GoalWaitLabelInput): string {
 	const bar = renderGoalWaitBar(elapsedRatioOf(input.remainingMs, input.totalMs));
 	const remaining = formatWakeDuration(Math.max(0, input.remainingMs));
 	if (input.kind === "monitor") {
-		return `${bar} goal continues in ${remaining} \u00b7 ${monitorsOnDuty(input.activeMonitorCount)}`;
+		return `${bar} goal continues in ${remaining} \u00b7 ${channelsOnDuty(input.channelCounts)}`;
 	}
 	return `${bar} goal resumes in ${remaining}`;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "../../types.ts";
+import type { ResumptionChannelCounts } from "./monitor-continuation-types.ts";
 import { formatGoalWaitLabel, type GoalWaitKind, type GoalWaitLabelInput } from "./wait-progress.ts";
 
 /** Footer countdown refresh cadence while a Goal continuation is delayed. */
@@ -27,7 +28,7 @@ export class GoalWaitTicker {
 	private kind: GoalWaitKind | undefined;
 	private dueAtMs = 0;
 	private totalMs = 0;
-	private activeMonitorCount = 0;
+	private channelCounts: ResumptionChannelCounts = {};
 	private lastRenderedStatus: string | undefined;
 
 	constructor(options: GoalWaitTickerOptions) {
@@ -45,7 +46,7 @@ export class GoalWaitTicker {
 		this.kind = input.kind;
 		this.dueAtMs = this.now() + Math.max(0, input.remainingMs);
 		this.totalMs = input.totalMs;
-		this.activeMonitorCount = input.activeMonitorCount;
+		this.channelCounts = { ...input.channelCounts };
 		this.lastRenderedStatus = undefined;
 		this.tick();
 		if (this.intervalId !== undefined) return;
@@ -54,10 +55,10 @@ export class GoalWaitTicker {
 		this.intervalId = handle;
 	}
 
-	/** Refresh monitor wording without changing the countdown deadline. */
-	setActiveMonitorCount(activeMonitorCount: number): void {
+	/** Refresh channel wording without changing the countdown deadline. */
+	setChannelCounts(channelCounts: ResumptionChannelCounts): void {
 		if (this.ctx === undefined || this.kind !== "monitor") return;
-		this.activeMonitorCount = activeMonitorCount;
+		this.channelCounts = { ...channelCounts };
 		this.tick();
 	}
 
@@ -80,7 +81,7 @@ export class GoalWaitTicker {
 			kind: this.kind,
 			remainingMs: Math.max(0, this.dueAtMs - this.now()),
 			totalMs: this.totalMs,
-			activeMonitorCount: this.activeMonitorCount,
+			channelCounts: this.channelCounts,
 		});
 		if (status === this.lastRenderedStatus) return;
 		this.lastRenderedStatus = status;

--- a/packages/coding-agent/src/core/extensions/builtin/resumption-channel-event.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/resumption-channel-event.ts
@@ -1,0 +1,27 @@
+export const RESUMPTION_CHANNEL_STATE_EVENT = "resumption_channel_state";
+
+export interface ResumptionChannelEntry {
+	readonly id: string;
+	readonly description: string;
+	readonly startedAtMs: number;
+}
+
+export interface ResumptionChannelStateEvent {
+	readonly source: string;
+	readonly activeCount: number;
+	readonly channels?: readonly ResumptionChannelEntry[];
+}
+
+export function isResumptionChannelStateEvent(data: unknown): data is ResumptionChannelStateEvent {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		"source" in data &&
+		typeof data.source === "string" &&
+		data.source.length > 0 &&
+		"activeCount" in data &&
+		typeof data.activeCount === "number" &&
+		Number.isInteger(data.activeCount) &&
+		data.activeCount >= 0
+	);
+}

--- a/packages/coding-agent/test/suite/goal-modules.test.ts
+++ b/packages/coding-agent/test/suite/goal-modules.test.ts
@@ -262,8 +262,8 @@ describe("goal truncation recovery prompt", () => {
 });
 
 describe("goal stall notice", () => {
-	it("emits generic toolless-stall bullets when no monitors are active", () => {
-		const notice = buildGoalStallNotice(3, { monitorsActive: false });
+	it("emits generic toolless-stall bullets when no channels are active", () => {
+		const notice = buildGoalStallNotice(3, { liveSources: [] });
 		expect(notice).toContain("<goal_stall_check>");
 		expect(notice).toContain("</goal_stall_check>");
 		expect(notice).toContain("3");
@@ -271,18 +271,25 @@ describe("goal stall notice", () => {
 		expect(notice).not.toContain("kill_bash");
 	});
 
-	it("keeps the monitor-investigation bullets while monitors are active", () => {
-		const notice = buildGoalStallNotice(4, { monitorsActive: true });
+	it("matches investigation advice to every live channel kind", () => {
+		const notice = buildGoalStallNotice(4, {
+			liveSources: ["terminal-monitor", "senpi-task", "eval-detached", "terminal-bash"],
+		});
 		expect(notice).toContain("<goal_stall_check>");
 		expect(notice).toContain("bash_output");
 		expect(notice).toContain("kill_bash");
+		expect(notice).toContain("task_output");
+		expect(notice).toContain("task_send");
+		expect(notice).toContain("eval");
+		expect(notice).toContain("peek");
+		expect(notice).toContain("stop");
 		expect(notice).toContain("4");
 	});
 
 	it("keeps buildMonitorStallNotice as a legacy wrapper over the generalized notice", () => {
 		const legacy = buildMonitorStallNotice(5);
 		expect(legacy).toContain("<goal_stall_check>");
-		expect(legacy).toBe(buildGoalStallNotice(5, { monitorsActive: true }));
+		expect(legacy).toBe(buildGoalStallNotice(5, { liveSources: ["terminal-monitor"] }));
 	});
 });
 

--- a/packages/coding-agent/test/suite/goal-resumption-channels.test.ts
+++ b/packages/coding-agent/test/suite/goal-resumption-channels.test.ts
@@ -1,0 +1,232 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	GOAL_CONTINUATION_RESUMED_EVENT,
+	GOAL_CONTINUATION_SCHEDULED_EVENT,
+	GOAL_MONITOR_CONTINUATION_DELAY_MS,
+	MonitorAwareGoalContinuation,
+} from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import { writeGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+import { GoalWaitTicker } from "../../src/core/extensions/builtin/goal/wait-ticker.ts";
+import {
+	isResumptionChannelStateEvent,
+	RESUMPTION_CHANNEL_STATE_EVENT,
+} from "../../src/core/extensions/builtin/resumption-channel-event.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+import {
+	cleanAssistantStop,
+	cleanupGoalMonitorTempDirs,
+	createGoalStatusHarness,
+	createSentMessageHarness,
+	makeGoalContext,
+	TestEventBus,
+	waitForEventCount,
+	waitForSentCount,
+} from "./goal-monitor-test-harness.ts";
+
+function activeGoal(id: string): Goal {
+	return {
+		id,
+		threadId: `${id}-thread`,
+		objective: "Keep moving",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+async function persistGoal(ctx: ExtensionContext, goal: Goal): Promise<void> {
+	await writeGoal(
+		{
+			baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+			threadId: ctx.sessionManager.getSessionId(),
+		},
+		goal,
+	);
+}
+
+function createHarness(status = createGoalStatusHarness()) {
+	const messages = createSentMessageHarness();
+	const events = new TestEventBus();
+	const entries: Array<{ customType: string; data: unknown }> = [];
+	const ticker = new GoalWaitTicker({ render: (ctx, text) => ctx.ui.setStatus("goal-wait", text) });
+	const pi = {
+		sendMessage: messages.sendMessage,
+		events,
+		appendEntry: (customType: string, data: unknown) => entries.push({ customType, data }),
+	} as unknown as ExtensionAPI;
+	return {
+		monitor: new MonitorAwareGoalContinuation(
+			pi,
+			() => false,
+			() => {},
+			ticker,
+		),
+		events,
+		entries,
+		status,
+		...messages,
+	};
+}
+
+async function endTurn(monitor: MonitorAwareGoalContinuation, ctx: ExtensionContext, goal: Goal): Promise<void> {
+	await monitor.afterAgentEnd({ ctx, goal, messages: [cleanAssistantStop()] });
+}
+
+function channelEvents(events: TestEventBus, channel: string): Record<string, unknown>[] {
+	return events.emitted
+		.filter((event) => event.channel === channel)
+		.map((event) => event.data as Record<string, unknown>);
+}
+
+describe("resumption channel state contract", () => {
+	it("accepts open source names and rejects malformed snapshots", () => {
+		expect(isResumptionChannelStateEvent({ source: "custom-worker", activeCount: 0 })).toBe(true);
+		expect(
+			isResumptionChannelStateEvent({
+				source: "senpi-task",
+				activeCount: 1,
+				channels: [{ id: "task-1", description: "child", startedAtMs: 123 }],
+			}),
+		).toBe(true);
+		expect(isResumptionChannelStateEvent({ source: "", activeCount: 1 })).toBe(false);
+		expect(isResumptionChannelStateEvent({ source: "senpi-task", activeCount: 0.5 })).toBe(false);
+		expect(isResumptionChannelStateEvent(null)).toBe(false);
+	});
+});
+
+describe("goal continuation resumption channels", () => {
+	afterEach(async () => {
+		vi.useRealTimers();
+		await cleanupGoalMonitorTempDirs();
+	});
+
+	it("delays an active goal while a senpi task channel is live", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-task-channel");
+		const { monitor, events, sent } = createHarness();
+		const goal = activeGoal("goal-task-channel");
+		await persistGoal(ctx, goal);
+		monitor.start(ctx);
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "senpi-task", activeCount: 1 });
+		await events.flush();
+
+		await endTurn(monitor, ctx, goal);
+
+		expect(sent).toHaveLength(0);
+		expect(channelEvents(events, GOAL_CONTINUATION_SCHEDULED_EVENT)).toHaveLength(1);
+	});
+
+	it("keeps the timer and toolless streak until the total across sources reaches zero", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-total-zero");
+		const harness = createHarness();
+		const { monitor, events, sent } = harness;
+		const goal = activeGoal("goal-total-zero");
+		await persistGoal(ctx, goal);
+		monitor.start(ctx);
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "senpi-task", activeCount: 1 });
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "terminal-bash", activeCount: 1 });
+		await events.flush();
+
+		for (let turn = 1; turn <= 2; turn++) {
+			await endTurn(monitor, ctx, goal);
+			const delivered = waitForSentCount(harness, turn);
+			await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+			await delivered;
+		}
+
+		await endTurn(monitor, ctx, goal);
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "senpi-task", activeCount: 0 });
+		await events.flush();
+		const thirdDelivery = waitForSentCount(harness, 3);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await thirdDelivery;
+		expect(sent[2]?.message.content).toContain("<goal_stall_check>");
+
+		await endTurn(monitor, ctx, goal);
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "terminal-bash", activeCount: 0 });
+		await events.flush();
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		expect(sent).toHaveLength(3);
+	});
+
+	it("treats legacy and generalized terminal-monitor snapshots as idempotent writes", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const status = createGoalStatusHarness();
+		const ctx = await makeGoalContext(notices, "thread-dual-terminal", { pendingMessages: false, status });
+		const { monitor, events } = createHarness(status);
+		const goal = activeGoal("goal-dual-terminal");
+		await persistGoal(ctx, goal);
+		monitor.start(ctx);
+		events.emit("terminal_monitor_state", { activeCount: 2 });
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "terminal-monitor", activeCount: 2 });
+		await events.flush();
+
+		await endTurn(monitor, ctx, goal);
+
+		expect(status.updates.at(-1)?.text).toContain("2 monitors on duty");
+		expect(status.updates.at(-1)?.text).not.toContain("4 monitors");
+		expect(channelEvents(events, GOAL_CONTINUATION_SCHEDULED_EVENT)[0]).toMatchObject({
+			activeMonitorCount: 2,
+			channelCounts: { "terminal-monitor": 2 },
+		});
+	});
+
+	it("subscribes before start and clears prior-session snapshots when start resets the session", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-pre-start");
+		const harness = createHarness();
+		const { monitor, events, sent } = harness;
+		const beforeStartGoal = activeGoal("goal-before-start");
+		await persistGoal(ctx, beforeStartGoal);
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "eval-detached", activeCount: 1 });
+		await events.flush();
+
+		await endTurn(monitor, ctx, beforeStartGoal);
+		expect(channelEvents(events, GOAL_CONTINUATION_SCHEDULED_EVENT)).toHaveLength(1);
+		expect(sent).toHaveLength(0);
+
+		monitor.start(ctx);
+		const afterStartGoal = activeGoal("goal-after-start");
+		await persistGoal(ctx, afterStartGoal);
+		await endTurn(monitor, ctx, afterStartGoal);
+		expect(sent).toHaveLength(1);
+	});
+
+	it("keeps terminal monitor telemetry and adds per-source counts on schedule and resume", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-channel-telemetry");
+		const harness = createHarness();
+		const { monitor, events, entries } = harness;
+		const goal = activeGoal("goal-channel-telemetry");
+		await persistGoal(ctx, goal);
+		monitor.start(ctx);
+		events.emit("terminal_monitor_state", { activeCount: 2 });
+		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "senpi-task", activeCount: 1 });
+		await events.flush();
+
+		await endTurn(monitor, ctx, goal);
+		const expected = {
+			activeMonitorCount: 2,
+			channelCounts: { "senpi-task": 1, "terminal-monitor": 2 },
+		};
+		expect(channelEvents(events, GOAL_CONTINUATION_SCHEDULED_EVENT)[0]).toMatchObject(expected);
+		expect(entries[0]?.data).toMatchObject(expected);
+
+		const delivered = waitForSentCount(harness, 1);
+		const resumed = waitForEventCount(events, GOAL_CONTINUATION_RESUMED_EVENT, 1);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await Promise.all([delivered, resumed]);
+		expect(channelEvents(events, GOAL_CONTINUATION_RESUMED_EVENT)[0]).toMatchObject(expected);
+		expect(entries[1]?.data).toMatchObject(expected);
+	});
+});

--- a/packages/coding-agent/test/suite/goal-wait-progress.test.ts
+++ b/packages/coding-agent/test/suite/goal-wait-progress.test.ts
@@ -39,7 +39,7 @@ describe("goal wait label", () => {
 			kind: "userGrace",
 			remainingMs: 47_000,
 			totalMs: 60_000,
-			activeMonitorCount: 0,
+			channelCounts: {},
 		});
 
 		expect(label).toContain("47s");
@@ -47,28 +47,31 @@ describe("goal wait label", () => {
 		expect(label).toContain(EMPTY);
 	});
 
-	it("formats a multi-minute monitor wait and names the monitors on duty", () => {
+	it("keeps the monitors-only rendering byte-identical", () => {
 		const label = formatGoalWaitLabel({
 			kind: "monitor",
 			remainingMs: 192_000,
 			totalMs: 240_000,
-			activeMonitorCount: 2,
+			channelCounts: { "terminal-monitor": 2 },
 		});
 
-		expect(label).toContain("3m 12s");
-		expect(label).toContain("2 monitors");
+		expect(label).toBe("▰▰▱▱▱▱▱▱▱▱▱▱ goal continues in 3m 12s · 2 monitors on duty");
 	});
 
-	it("uses the singular monitor wording for a single monitor", () => {
+	it("uses a stable singular and plural breakdown for mixed live sources", () => {
 		const label = formatGoalWaitLabel({
 			kind: "monitor",
 			remainingMs: 60_000,
 			totalMs: 240_000,
-			activeMonitorCount: 1,
+			channelCounts: {
+				"terminal-bash": 1,
+				"senpi-task": 2,
+				"terminal-monitor": 1,
+				"eval-detached": 2,
+			},
 		});
 
-		expect(label).toContain("1 monitor");
-		expect(label).not.toContain("1 monitors");
+		expect(label).toContain("1 monitor · 2 tasks · 2 evals · 1 bash on duty");
 	});
 
 	it("never renders a negative remaining time", () => {
@@ -76,7 +79,7 @@ describe("goal wait label", () => {
 			kind: "userGrace",
 			remainingMs: -5_000,
 			totalMs: 60_000,
-			activeMonitorCount: 0,
+			channelCounts: {},
 		});
 
 		expect(label).toContain("0s");
@@ -88,7 +91,7 @@ describe("goal wait label", () => {
 			kind: "userGrace",
 			remainingMs: 30_000,
 			totalMs: 60_000,
-			activeMonitorCount: 3,
+			channelCounts: { "terminal-monitor": 3 },
 		});
 
 		expect(label).not.toContain("monitor");


### PR DESCRIPTION
## What changed
- added the open-set `resumption_channel_state` contract with source-keyed full snapshots
- changed Goal continuation liveness from one terminal-monitor scalar to idempotent per-source writes and a derived total
- subscribed at extension construction scope, clearing counts on session start and disposing subscriptions with the extension
- generalized wait labels, stall guidance, and scheduled/resumed cache-warm telemetry while preserving `activeMonitorCount` compatibility

## Why
The real pre-fix harness measured hidden Goal continuation delivery only 70 ms after turn end with a live task child, 51 ms with a detached eval cell, and 52 ms with background bash. Those immediate continuations raced each source's own completion wake. The terminal-monitor control correctly scheduled the existing 240,000 ms cache-warm wait.

This lane supplies the generalized liveness contract and Goal-side aggregation so sibling emitters can report those live sources without changing the deliberate four-minute check-in semantics.

## Contract
- event: `resumption_channel_state`
- payload: `{ source: string, activeCount: integer >= 0, channels? }`
- `source` is an open string set, not an enum
- each payload is a full snapshot for one source
- consumers write, rather than add, each source key; legacy `terminal_monitor_state` and generalized terminal-monitor emission both map to `"terminal-monitor"`, making dual emission idempotent
- timer cancellation and toolless-streak reset happen only when the total across all sources transitions to zero
- Goal subscribes at extension construction scope; `start()` clears prior-session counts, so emitters must replay their snapshot on `session_start`

## QA evidence
- RED/GREEN record: `/Users/yeongyu/local-workspaces/senpi/evidence/20260808-goal-resumption-channels-laneA.md`
- new/changed targeted suites: 35 tests passed
- all named Goal regression suites passed
- independent critical-suite run: 6 files, 47 tests, EXIT=0 (`/tmp/laneA-goal-suites.log`)
- clean local repository gate: `npm run check`, EXIT=0
- full coding-agent suite is running in the background; CI runs the authoritative suite in three shards plus workspace and cross-OS jobs

## Residual risk
Emitter implementations land in sibling lanes. Until each producer emits this contract and replays its snapshot on `session_start`, Goal behavior for that source remains unchanged. The legacy terminal-monitor path remains supported throughout the transition.
