### PR TITLE
feat(terminal): emit resumption channel liveness

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- Fixed terminal resumption liveness reporting so monitor snapshots are dual-published through the legacy event and
+  the shared source-keyed channel contract, while live background bash sessions now publish spawn, exit, kill, and
+  session-start snapshots even when terminal completion notifications are disabled.
 - Fixed active Goals resuming immediately while background tasks, detached evals, or background bash sessions were
   still live. Goal continuation now aggregates source-keyed resumption-channel snapshots, preserves the four-minute
   cache-warm check-in, and reports a per-source wait summary while retaining terminal-monitor telemetry compatibility.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,29 @@
 # terminal builtin extension — fork surface
 
+## Terminal monitor and background-bash resumption channels (2026-08-08)
+
+### What changed
+
+- Monitor registry transitions still emit the byte-compatible `terminal_monitor_state` payload and
+  now also emit the shared `resumption_channel_state` snapshot under source
+  `"terminal-monitor"`, with matching counts and channel identity metadata.
+- `TerminalSessionBundle` now owns the live background-session snapshot. Explicit background bash
+  launches and foreground auto-detaches register a channel, while exit, `kill_bash`, and bundle
+  teardown remove it. Every transition emits the complete source snapshot under
+  `"terminal-bash"`.
+- Bundle binding re-publishes both monitor and background snapshots during `session_start`, including
+  after reload, so a goal consumer that clears session-scoped counts sees channels that remained
+  alive across the boundary.
+
+### Notification tradeoff
+
+Background sessions count as live resumption channels unconditionally, including non-interactive
+sessions and terminal `notify: "off"`. The notify setting controls whether completion injects a wake
+notification; it does not change whether work is still alive. A muted session can therefore delay a
+goal continuation even though its completion will not wake the agent, but the existing four-minute
+continuation backstop bounds that delay. Keeping liveness independent from notification policy avoids
+the measured 53ms premature continuation seen with `notify: "off"` (52ms with notifications enabled).
+
 ## Fixed foreground window replaces cache budget; sleep-wait commands detach early (2026-08-07)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -3,6 +3,7 @@ import { SettingsManager } from "../../../settings-manager.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
 import { TERMINAL_MONITOR_STATE_EVENT } from "../monitor-state-event.ts";
+import { RESUMPTION_CHANNEL_STATE_EVENT } from "../resumption-channel-event.ts";
 import { MonitorNotifier } from "./monitor-notify.ts";
 import { MONITOR_STATUS_KEY } from "./monitor-status.ts";
 import { MonitorStatusTicker } from "./monitor-status-ticker.ts";
@@ -65,6 +66,22 @@ function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalE
 					startedAtMs: entry.startedAtMs,
 				})),
 			});
+			pi.events?.emit(RESUMPTION_CHANNEL_STATE_EVENT, {
+				source: "terminal-monitor",
+				activeCount: snapshot.length,
+				channels: snapshot.map((entry) => ({
+					id: entry.id,
+					description: entry.description,
+					startedAtMs: entry.startedAtMs,
+				})),
+			});
+		},
+		onBackgroundState: (snapshot) => {
+			pi.events?.emit(RESUMPTION_CHANNEL_STATE_EVENT, {
+				source: "terminal-bash",
+				activeCount: snapshot.length,
+				channels: snapshot,
+			});
 		},
 		onBackgroundExit: (id, runtime) => state.notifier?.notifyCompletion(id, runtime),
 	};
@@ -107,6 +124,9 @@ function buildToolContext(pi: ExtensionAPI, state: TerminalExtensionState): Term
 		getSessionContext: () => state.ctx,
 		// Exit listeners registered before a reload reach the post-reload owner through the
 		// shared bundle, so this must dispatch via the bundle, never the instance notifier.
+		onBackgroundStart: (id: string, description: string, startedAtMs: number) => {
+			state.bundle?.notifyBackgroundStart(id, description, startedAtMs);
+		},
 		onBackgroundExit: (id: string, runtime: TerminalRuntimeSession) => {
 			state.bundle?.notifyBackgroundExit(id, runtime);
 		},

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/session-bundle.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/session-bundle.ts
@@ -1,3 +1,4 @@
+import type { ResumptionChannelEntry } from "../resumption-channel-event.ts";
 import { TerminalManager, type TerminalManagerOptions } from "./manager.ts";
 import { type MonitorEvent, MonitorRegistry, type MonitorSnapshotEntry } from "./monitor-registry.ts";
 import type { TerminalRuntimeSession } from "./runtime-session.ts";
@@ -5,6 +6,7 @@ import type { TerminalRuntimeSession } from "./runtime-session.ts";
 export interface TerminalEventSinks {
 	readonly onMonitorEvent: (event: MonitorEvent) => void;
 	readonly onMonitorState: (snapshot: readonly MonitorSnapshotEntry[]) => void;
+	readonly onBackgroundState: (snapshot: readonly ResumptionChannelEntry[]) => void;
 	readonly onBackgroundExit: (id: string, runtime: TerminalRuntimeSession) => void;
 }
 
@@ -24,6 +26,7 @@ export class TerminalSessionBundle {
 	#sinks: TerminalEventSinks | null = null;
 	#parkedMonitorEvents: MonitorEvent[] = [];
 	#parkedExits = new Map<string, TerminalRuntimeSession>();
+	#backgrounds = new Map<string, ResumptionChannelEntry>();
 	#torndown = false;
 
 	constructor(options: TerminalManagerOptions) {
@@ -33,7 +36,7 @@ export class TerminalSessionBundle {
 		});
 	}
 
-	/** Install live sinks, re-publish monitor state, and flush everything buffered while parked. */
+	/** Install live sinks, re-publish channel state, and flush everything buffered while parked. */
 	bind(sinks: TerminalEventSinks): void {
 		if (this.#torndown) return;
 		this.#sinks = sinks;
@@ -42,6 +45,7 @@ export class TerminalSessionBundle {
 		const parkedExits = [...this.#parkedExits];
 		this.#parkedExits.clear();
 		sinks.onMonitorState(this.monitors.snapshot());
+		sinks.onBackgroundState(this.backgroundSnapshot());
 		for (const event of parkedMonitorEvents) sinks.onMonitorEvent(event);
 		for (const [id, runtime] of parkedExits) sinks.onBackgroundExit(id, runtime);
 	}
@@ -50,8 +54,19 @@ export class TerminalSessionBundle {
 		this.#sinks = null;
 	}
 
+	backgroundSnapshot(): readonly ResumptionChannelEntry[] {
+		return [...this.#backgrounds.values()];
+	}
+
+	notifyBackgroundStart(id: string, description: string, startedAtMs = Date.now()): void {
+		if (this.#torndown) return;
+		this.#backgrounds.set(id, { id, description, startedAtMs });
+		this.#sinks?.onBackgroundState(this.backgroundSnapshot());
+	}
+
 	notifyBackgroundExit(id: string, runtime: TerminalRuntimeSession): void {
 		if (this.#torndown) return;
+		if (this.#backgrounds.delete(id)) this.#sinks?.onBackgroundState(this.backgroundSnapshot());
 		if (this.#sinks) {
 			this.#sinks.onBackgroundExit(id, runtime);
 			return;
@@ -62,10 +77,14 @@ export class TerminalSessionBundle {
 
 	async teardown(): Promise<void> {
 		if (this.#torndown) return;
-		this.#torndown = true;
 		this.#parkedMonitorEvents = [];
 		this.#parkedExits.clear();
 		this.monitors.dispose();
+		if (this.#backgrounds.size > 0) {
+			this.#backgrounds.clear();
+			this.#sinks?.onBackgroundState([]);
+		}
+		this.#torndown = true;
 		this.#sinks = null;
 		await this.manager.teardown();
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash.ts
@@ -306,6 +306,7 @@ async function runForeground(
 
 	if (outcome === "detached") {
 		scheduleDetachedSweep(ctx, id, runtime, timeoutMs, startedAt);
+		ctx.onBackgroundStart?.(id, input.description ?? input.command, startedAt);
 		if (ctx.onBackgroundExit) runtime.session.onExit(() => ctx.onBackgroundExit?.(id, runtime));
 		const delta = runtime.readDelta();
 		const partialOutput = formatTerminalToolOutput(delta.text).text || "(no output yet)";
@@ -377,6 +378,7 @@ async function runBackground(
 		cwd,
 		envOverrides: sessionEnvOverrides(ctx, execCtx),
 	});
+	ctx.onBackgroundStart?.(id, input.description ?? input.command, Date.now());
 	if (ctx.onBackgroundExit) runtime.session.onExit(() => ctx.onBackgroundExit?.(id, runtime));
 
 	// Capture any output the command emits within a short grace window (or its exit).

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
@@ -20,6 +20,8 @@ export interface TerminalToolContext {
 	 * expose PI_* session metadata to spawned commands like the core bash tool does.
 	 */
 	readonly getSessionContext?: () => import("../../../types.ts").ExtensionContext | undefined;
+	/** Registers a session when it transitions to background liveness. */
+	readonly onBackgroundStart?: (id: string, description: string, startedAtMs: number) => void;
 	/** Notified when a background session exits, so the notify layer can wake the agent. */
 	readonly onBackgroundExit?: (id: string, runtime: TerminalRuntimeSession) => void;
 	/** Session-scoped monitor state, sharing the terminal manager's bash-id namespace. */

--- a/packages/coding-agent/test/suite/terminal-resumption-channel-state.test.ts
+++ b/packages/coding-agent/test/suite/terminal-resumption-channel-state.test.ts
@@ -1,0 +1,294 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	RESUMPTION_CHANNEL_STATE_EVENT,
+	type ResumptionChannelStateEvent,
+} from "../../src/core/extensions/builtin/resumption-channel-event.ts";
+import { registerTerminalExtension } from "../../src/core/extensions/builtin/terminal/extension.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+
+type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+type EventListener = (data: unknown) => void;
+
+interface ToolResultLike {
+	content: Array<{ type: string; text?: string }>;
+	isError?: boolean;
+}
+
+interface ToolLike {
+	name: string;
+	execute: (id: string, input: Record<string, unknown>) => Promise<ToolResultLike>;
+}
+
+interface LegacyMonitorStateEvent {
+	readonly activeCount: number;
+	readonly monitors: readonly unknown[];
+}
+
+interface FakeRunner {
+	readonly pi: ExtensionAPI;
+	readonly tools: Map<string, ToolLike>;
+	readonly channelStates: ResumptionChannelStateEvent[];
+	readonly legacyMonitorStates: LegacyMonitorStateEvent[];
+	emitLifecycle(eventType: string, payload: Record<string, unknown>, ctx: ExtensionContext): Promise<void>;
+	waitForChannel(source: string, activeCount: number): Promise<ResumptionChannelStateEvent>;
+}
+
+function isChannelState(data: unknown): data is ResumptionChannelStateEvent {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		"source" in data &&
+		typeof data.source === "string" &&
+		"activeCount" in data &&
+		typeof data.activeCount === "number"
+	);
+}
+
+function createRunner(): FakeRunner {
+	const handlers = new Map<string, Handler[]>();
+	const tools = new Map<string, ToolLike>();
+	const eventListeners = new Map<string, Set<EventListener>>();
+	const channelStates: ResumptionChannelStateEvent[] = [];
+	const legacyMonitorStates: LegacyMonitorStateEvent[] = [];
+	let activeTools: string[] = [];
+
+	const events = {
+		on(eventType: string, listener: EventListener) {
+			const listeners = eventListeners.get(eventType) ?? new Set<EventListener>();
+			listeners.add(listener);
+			eventListeners.set(eventType, listeners);
+			return () => listeners.delete(listener);
+		},
+		emit(eventType: string, data: unknown) {
+			if (eventType === RESUMPTION_CHANNEL_STATE_EVENT && isChannelState(data)) channelStates.push(data);
+			if (
+				eventType === "terminal_monitor_state" &&
+				typeof data === "object" &&
+				data !== null &&
+				"activeCount" in data &&
+				typeof data.activeCount === "number" &&
+				"monitors" in data &&
+				Array.isArray(data.monitors)
+			) {
+				legacyMonitorStates.push({ activeCount: data.activeCount, monitors: data.monitors });
+			}
+			for (const listener of eventListeners.get(eventType) ?? []) listener(data);
+		},
+	};
+
+	const pi = {
+		registerTool: (tool: ToolLike) => tools.set(tool.name, tool),
+		on: (eventType: string, handler: Handler) => {
+			const registered = handlers.get(eventType) ?? [];
+			registered.push(handler);
+			handlers.set(eventType, registered);
+		},
+		events,
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		getActiveTools: () => activeTools,
+		setActiveTools: (next: string[]) => {
+			activeTools = next;
+		},
+	} as unknown as ExtensionAPI;
+
+	return {
+		pi,
+		tools,
+		channelStates,
+		legacyMonitorStates,
+		async emitLifecycle(eventType, payload, ctx) {
+			for (const handler of handlers.get(eventType) ?? []) await handler(payload, ctx);
+		},
+		waitForChannel(source, activeCount) {
+			return new Promise<ResumptionChannelStateEvent>((resolve, reject) => {
+				const timeout = setTimeout(() => {
+					unsubscribe();
+					reject(new Error(`Timed out waiting for ${source} activeCount=${activeCount}`));
+				}, 5000);
+				const unsubscribe = events.on(RESUMPTION_CHANNEL_STATE_EVENT, (data) => {
+					if (!isChannelState(data) || data.source !== source || data.activeCount !== activeCount) return;
+					clearTimeout(timeout);
+					unsubscribe();
+					resolve(data);
+				});
+			});
+		},
+	};
+}
+
+function firstText(result: ToolResultLike | undefined): string {
+	return result?.content.find((block) => block.type === "text")?.text ?? "";
+}
+
+function extractBashId(result: ToolResultLike | undefined): string {
+	const match = /ID: (bash_\d+)/.exec(firstText(result));
+	if (!match?.[1]) throw new Error(`No bash id in tool result: ${firstText(result)}`);
+	return match[1];
+}
+
+function makeContext(cwd: string, sessionId: string): ExtensionContext {
+	return {
+		cwd,
+		mode: "tui",
+		model: { id: "test-model", api: "openai-completions" },
+		ui: { setStatus: () => {}, notify: () => {}, theme },
+		sessionManager: { getSessionId: () => sessionId, getSessionFile: () => undefined },
+	} as unknown as ExtensionContext;
+}
+
+describe("terminal resumption channel state", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+	const savedAgentDir = process.env.SENPI_CODING_AGENT_DIR;
+	let tmp: string;
+	let cwd: string;
+	let sessionCounter = 0;
+	let live: Array<{ runner: FakeRunner; ctx: ExtensionContext }> = [];
+
+	beforeEach(() => {
+		initTheme("dark");
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		tmp = mkdtempSync(join(tmpdir(), "senpi-terminal-channel-"));
+		process.env.SENPI_CODING_AGENT_DIR = join(tmp, "agent-home");
+		cwd = join(tmp, "project");
+		mkdirSync(join(cwd, ".senpi"), { recursive: true });
+		live = [];
+	});
+
+	afterEach(async () => {
+		for (const generation of live) {
+			await generation.runner.emitLifecycle(
+				"session_shutdown",
+				{ type: "session_shutdown", reason: "quit" },
+				generation.ctx,
+			);
+		}
+		rmSync(tmp, { recursive: true, force: true });
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+		if (savedAgentDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+		else process.env.SENPI_CODING_AGENT_DIR = savedAgentDir;
+	});
+
+	async function start(reason = "startup", notify: "wake" | "off" = "wake", sessionId?: string) {
+		writeFileSync(join(cwd, ".senpi", "settings.json"), JSON.stringify({ terminal: { notify } }));
+		const runner = createRunner();
+		registerTerminalExtension(runner.pi);
+		const ctx = makeContext(cwd, sessionId ?? `terminal-channel-${++sessionCounter}`);
+		await runner.emitLifecycle("session_start", { type: "session_start", reason }, ctx);
+		live.push({ runner, ctx });
+		return { runner, ctx };
+	}
+
+	it("emits matching legacy and resumption snapshots for monitor transitions", async () => {
+		const { runner } = await start();
+		const monitor = runner.tools.get("monitor");
+		const started = await monitor?.execute("monitor", {
+			description: "dual emit monitor",
+			command: "cat",
+			persistent: true,
+		});
+		const bashId = extractBashId(started);
+
+		const legacy = runner.legacyMonitorStates.at(-1);
+		const channel = runner.channelStates.filter((state) => state.source === "terminal-monitor").at(-1);
+		expect(legacy?.activeCount).toBe(1);
+		expect(channel).toEqual({
+			source: "terminal-monitor",
+			activeCount: legacy?.activeCount,
+			channels: [{ id: bashId, description: "dual emit monitor", startedAtMs: expect.any(Number) }],
+		});
+	});
+
+	it("emits terminal-bash snapshots on spawn, exit, and kill", async () => {
+		const { runner } = await start();
+		const bash = runner.tools.get("bash");
+		const exited = await bash?.execute("quick", {
+			command: "printf done",
+			description: "quick background",
+			run_in_background: true,
+		});
+		const exitedId = extractBashId(exited);
+		expect(runner.channelStates).toContainEqual({
+			source: "terminal-bash",
+			activeCount: 1,
+			channels: [{ id: exitedId, description: "quick background", startedAtMs: expect.any(Number) }],
+		});
+		expect(runner.channelStates.filter((state) => state.source === "terminal-bash").at(-1)?.activeCount).toBe(0);
+
+		const started = await bash?.execute("long", {
+			command: "cat",
+			description: "kill background",
+			run_in_background: true,
+		});
+		const bashId = extractBashId(started);
+		expect(runner.channelStates.filter((state) => state.source === "terminal-bash").at(-1)?.activeCount).toBe(1);
+		const killedState = runner.waitForChannel("terminal-bash", 0);
+		await runner.tools.get("kill_bash")?.execute("kill", { bash_id: bashId });
+		expect(await killedState).toMatchObject({ source: "terminal-bash", activeCount: 0, channels: [] });
+	});
+
+	it("tracks two concurrent backgrounds and decrements when one exits", async () => {
+		const { runner } = await start();
+		const bash = runner.tools.get("bash");
+		const first = extractBashId(
+			await bash?.execute("first", { command: "read line", description: "first", run_in_background: true }),
+		);
+		const second = extractBashId(
+			await bash?.execute("second", { command: "cat", description: "second", run_in_background: true }),
+		);
+		expect(runner.channelStates.filter((state) => state.source === "terminal-bash").at(-1)?.activeCount).toBe(2);
+
+		const decremented = runner.waitForChannel("terminal-bash", 1);
+		await runner.tools.get("bash_input")?.execute("exit-first", { bash_id: first, input: "\n" });
+		expect(await decremented).toMatchObject({
+			source: "terminal-bash",
+			activeCount: 1,
+			channels: [{ id: second, description: "second", startedAtMs: expect.any(Number) }],
+		});
+	});
+
+	it('counts background sessions even when terminal notify is "off"', async () => {
+		const { runner } = await start("startup", "off");
+		const started = await runner.tools.get("bash")?.execute("muted", {
+			command: "cat",
+			description: "muted background",
+			run_in_background: true,
+		});
+		const bashId = extractBashId(started);
+		expect(runner.channelStates.filter((state) => state.source === "terminal-bash").at(-1)).toEqual({
+			source: "terminal-bash",
+			activeCount: 1,
+			channels: [{ id: bashId, description: "muted background", startedAtMs: expect.any(Number) }],
+		});
+	});
+
+	it("session_start re-emits both current source snapshots without a prior transition", async () => {
+		const sessionId = `terminal-channel-reload-${++sessionCounter}`;
+		const first = await start("startup", "wake", sessionId);
+		await first.runner.tools.get("monitor")?.execute("monitor", {
+			description: "reload monitor",
+			command: "cat",
+			persistent: true,
+		});
+		await first.runner.tools.get("bash")?.execute("bash", {
+			command: "cat",
+			description: "reload bash",
+			run_in_background: true,
+		});
+		await first.runner.emitLifecycle("session_shutdown", { type: "session_shutdown", reason: "reload" }, first.ctx);
+		live = [];
+
+		const second = await start("reload", "wake", sessionId);
+		expect(second.runner.channelStates).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ source: "terminal-monitor", activeCount: 1 }),
+				expect.objectContaining({ source: "terminal-bash", activeCount: 1 }),
+			]),
+		);
+	});
+});


### PR DESCRIPTION
## What changed

- Dual-emit terminal monitor snapshots through the legacy `terminal_monitor_state` event and the shared `resumption_channel_state` contract under source `terminal-monitor`.
- Track live explicit background bash sessions and foreground auto-detaches in `TerminalSessionBundle`, emitting full `terminal-bash` snapshots on spawn/detach, exit, kill, teardown, and bundle rebind.
- Re-publish both terminal source snapshots on `session_start`, including reloads where channels survive across the extension runner boundary.
- Count background bash liveness independently of terminal notification policy, including `notify: "off"` and non-interactive sessions.

## Why

The real harness baseline showed goal continuation firing prematurely with live non-monitor work: background bash at 52ms, background bash with `notify: "off"` at 53ms, detached eval at 51ms, and a task child at 70ms. The monitor control correctly scheduled the 240000ms continuation wait. Lane A made goal continuation aggregate source-keyed channel counts; this PR supplies the missing terminal sources so background terminal work receives the same bounded wait semantics.

## Contract

Uses the shared `RESUMPTION_CHANNEL_STATE_EVENT` contract from Lane A. Each source publishes a complete snapshot, so repeated writes for the same source remain idempotent. The legacy monitor payload is retained unchanged for external consumers and Lane A's compatibility mapping.

## QA

- RED captured before implementation: all 5 new terminal channel tests failed because no shared channel events existed.
- New focused suite: 5/5 passed.
- Terminal regression selection: 6 files, 43/43 tests passed (`terminal-resumption-channel-state`, monitor state, extension, reload survival, settings/notify, and auto-detach).
- Root `npm run check`: passed.
- The `notify: "off"` liveness decision is pinned through real terminal settings and a live background session.

## Residual risk

The liveness registry is platform-neutral, but PTY exit/kill callback ordering varies by backend. The terminal tools CI matrix on Ubuntu, macOS, and Windows is the primary cross-platform authority. Muted channels can defer goal continuation without waking on completion; the existing four-minute backstop bounds that tradeoff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit shared resumption-channel liveness from the terminal extension and track background bash sessions so goal continuation waits while terminal work is still active.

- **New Features**
  - Dual-publish monitor snapshots via `terminal_monitor_state` and `RESUMPTION_CHANNEL_STATE_EVENT` (source `terminal-monitor`) with channel metadata.
  - Track background bash liveness in `TerminalSessionBundle` and emit `RESUMPTION_CHANNEL_STATE_EVENT` (source `terminal-bash`) on spawn/detach, exit/kill, teardown, and `session_start` (incl. reloads).

- **Bug Fixes**
  - Count background sessions regardless of notification policy (incl. `notify: "off"` and non-interactive) to prevent premature goal continuation.

<sup>Written for commit 97a67f030ab2283feae5ea8903f1f0dbb8072226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

