### PR TITLE
fix(goal): preserve reload channel snapshots

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- Fixed config reloads discarding live terminal monitor and background-bash snapshots before Goal continuation
+  scheduling. Fresh Goal instances now retain Terminal's pre-start replay, while later same-instance session starts
+  still clear stale channel state.
 - Fixed terminal resumption liveness reporting so monitor snapshots are dual-published through the legacy event and
   the shared source-keyed channel contract, while live background bash sessions now publish spawn, exit, kill, and
   session-start snapshots even when terminal completion notifications are disabled.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,31 @@
 # goal Extension Changes
 
+## Reload snapshots survive first session start (2026-08-09)
+
+### What changed
+
+- `MonitorAwareGoalContinuation` preserves source-keyed channel snapshots received
+  before its first `start()`, while a subsequent `start()` on the same instance
+  still clears counts from the replaced session.
+- Integration coverage runs Terminal before Goal on one event bus, parks live
+  monitor and background-bash state across a real reload lifecycle, and verifies
+  both replayed snapshots delay Goal continuation after the new runner starts.
+
+### Why
+
+- Builtin order is load-bearing: Terminal's reload `session_start` claims and binds
+  its parked bundle before Goal's handler runs. `bind()` immediately replays both
+  terminal snapshots to the newly constructed Goal instance, so clearing counts on
+  that instance's first `start()` discarded current-session liveness with no later
+  transition available to restore it.
+- Pre-first-start snapshots belong to the fresh runner generation. Only a later
+  same-instance `start()` represents a genuine session replacement whose old
+  snapshots must be discarded.
+
+### Expected merge conflict zones
+
+- LOW in `monitor-continuation.ts` around `start()` lifecycle reset behavior.
+
 ## System-owned aborts stay active through Goal recovery (2026-08-05)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -50,6 +50,7 @@ export class MonitorAwareGoalContinuation {
 	readonly #markContinuationPending: () => void;
 	readonly #waitTicker: GoalWaitTicker | undefined;
 	#channelCounts = new Map<string, number>();
+	#hasStarted = false;
 	#ctx: ExtensionContext | undefined;
 	#goal: Goal | null = null;
 	#timer: ReturnType<typeof setTimeout> | undefined;
@@ -85,7 +86,8 @@ export class MonitorAwareGoalContinuation {
 	start(ctx: ExtensionContext): void {
 		this.#cancelTimer();
 		this.#ctx = ctx;
-		this.#channelCounts.clear();
+		if (this.#hasStarted) this.#channelCounts.clear();
+		else this.#hasStarted = true;
 		this.#goal = null;
 		this.#lastAgentEndMessages = [];
 		this.#directInputHolds.clear();

--- a/packages/coding-agent/test/suite/goal-resumption-channels.test.ts
+++ b/packages/coding-agent/test/suite/goal-resumption-channels.test.ts
@@ -179,25 +179,26 @@ describe("goal continuation resumption channels", () => {
 		});
 	});
 
-	it("subscribes before start and clears prior-session snapshots when start resets the session", async () => {
+	it("preserves first-start snapshots but clears them on a same-instance session replacement", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
 		const ctx = await makeGoalContext(notices, "thread-pre-start");
 		const harness = createHarness();
 		const { monitor, events, sent } = harness;
-		const beforeStartGoal = activeGoal("goal-before-start");
-		await persistGoal(ctx, beforeStartGoal);
 		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "eval-detached", activeCount: 1 });
 		await events.flush();
 
-		await endTurn(monitor, ctx, beforeStartGoal);
+		monitor.start(ctx);
+		const firstSessionGoal = activeGoal("goal-first-session");
+		await persistGoal(ctx, firstSessionGoal);
+		await endTurn(monitor, ctx, firstSessionGoal);
 		expect(channelEvents(events, GOAL_CONTINUATION_SCHEDULED_EVENT)).toHaveLength(1);
 		expect(sent).toHaveLength(0);
 
 		monitor.start(ctx);
-		const afterStartGoal = activeGoal("goal-after-start");
-		await persistGoal(ctx, afterStartGoal);
-		await endTurn(monitor, ctx, afterStartGoal);
+		const replacementSessionGoal = activeGoal("goal-replacement-session");
+		await persistGoal(ctx, replacementSessionGoal);
+		await endTurn(monitor, ctx, replacementSessionGoal);
 		expect(sent).toHaveLength(1);
 	});
 

--- a/packages/coding-agent/test/suite/goal-terminal-reload-resumption.test.ts
+++ b/packages/coding-agent/test/suite/goal-terminal-reload-resumption.test.ts
@@ -1,0 +1,188 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
+import { GOAL_CONTINUATION_SCHEDULED_EVENT } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import { writeGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+import { registerTerminalExtension } from "../../src/core/extensions/builtin/terminal/extension.ts";
+import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+import { cleanAssistantStop } from "./goal-monitor-test-harness.ts";
+
+type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+type EventListener = (data: unknown) => void;
+type ToolLike = ToolDefinition & {
+	execute: (id: string, input: Record<string, unknown>) => Promise<unknown>;
+};
+
+interface Generation {
+	readonly ctx: ExtensionContext;
+	readonly emitted: Array<{ channel: string; data: unknown }>;
+	readonly sentMessages: unknown[];
+	readonly tools: Map<string, ToolLike>;
+	emitLifecycle(eventType: string, payload: Record<string, unknown>): Promise<void>;
+}
+
+function activeGoal(id: string): Goal {
+	return {
+		id,
+		threadId: `${id}-thread`,
+		objective: "Keep moving while terminal work is live",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+function createGeneration(cwd: string, sessionId: string): Generation {
+	const handlers = new Map<string, Handler[]>();
+	const listeners = new Map<string, EventListener[]>();
+	const tools = new Map<string, ToolLike>();
+	const emitted: Array<{ channel: string; data: unknown }> = [];
+	const sentMessages: unknown[] = [];
+	let activeTools: string[] = [];
+	const events = {
+		on(channel: string, listener: EventListener) {
+			const registered = listeners.get(channel) ?? [];
+			registered.push(listener);
+			listeners.set(channel, registered);
+			return () => {
+				const index = registered.indexOf(listener);
+				if (index >= 0) registered.splice(index, 1);
+			};
+		},
+		emit(channel: string, data: unknown) {
+			emitted.push({ channel, data });
+			for (const listener of listeners.get(channel) ?? []) listener(data);
+		},
+	};
+	const pi = {
+		registerTool: (tool: ToolLike) => tools.set(tool.name, tool),
+		registerCommand: () => {},
+		registerEntryRenderer: () => {},
+		appendEntry: () => {},
+		on: (eventType: string, handler: Handler) => {
+			const registered = handlers.get(eventType) ?? [];
+			registered.push(handler);
+			handlers.set(eventType, registered);
+		},
+		events,
+		sendMessage: (message: unknown) => sentMessages.push(message),
+		sendUserMessage: () => {},
+		getActiveTools: () => activeTools,
+		setActiveTools: (next: string[]) => {
+			activeTools = next;
+		},
+	} as unknown as ExtensionAPI;
+
+	// Match builtin/index.ts: terminal registers before goal, so lifecycle handlers run in that order.
+	registerTerminalExtension(pi);
+	goalExtension(pi);
+
+	const ctx = {
+		hasUI: true,
+		cwd,
+		mode: "tui",
+		model: undefined,
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		ui: { notify: () => {}, select: async () => undefined, setStatus: () => {}, theme },
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => join(cwd, "session.jsonl"),
+			getSessionDir: () => cwd,
+			getBranch: () => [],
+		},
+	} as unknown as ExtensionContext;
+
+	return {
+		ctx,
+		emitted,
+		sentMessages,
+		tools,
+		async emitLifecycle(eventType, payload) {
+			for (const handler of handlers.get(eventType) ?? []) await handler(payload, ctx);
+		},
+	};
+}
+
+function scheduledEvents(generation: Generation): Array<Record<string, unknown>> {
+	return generation.emitted
+		.filter((event) => event.channel === GOAL_CONTINUATION_SCHEDULED_EVENT)
+		.map((event) => event.data as Record<string, unknown>);
+}
+
+describe("goal + terminal resumption state across reload", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+	const savedAgentDir = process.env.SENPI_CODING_AGENT_DIR;
+	let tmp: string;
+	let cwd: string;
+	let current: Generation | undefined;
+
+	beforeEach(() => {
+		initTheme("dark");
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		tmp = mkdtempSync(join(tmpdir(), "senpi-goal-terminal-reload-"));
+		process.env.SENPI_CODING_AGENT_DIR = join(tmp, "agent-home");
+		cwd = join(tmp, "project");
+		mkdirSync(join(cwd, ".senpi"), { recursive: true });
+		writeFileSync(join(cwd, ".senpi", "settings.json"), JSON.stringify({ terminal: { notify: "off" } }));
+		current = undefined;
+	});
+
+	afterEach(async () => {
+		if (current !== undefined) {
+			await current.emitLifecycle("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		}
+		rmSync(tmp, { recursive: true, force: true });
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+		if (savedAgentDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+		else process.env.SENPI_CODING_AGENT_DIR = savedAgentDir;
+	});
+
+	it("preserves both terminal snapshots when terminal rebinds before goal session_start", async () => {
+		const sessionId = "goal-terminal-reload";
+		const first = createGeneration(cwd, sessionId);
+		current = first;
+		await first.emitLifecycle("session_start", { type: "session_start", reason: "startup" });
+		await first.tools.get("monitor")?.execute("monitor", {
+			description: "reload monitor",
+			command: "cat",
+			persistent: true,
+		});
+		await first.tools.get("bash")?.execute("bash", {
+			command: "cat",
+			description: "reload background bash",
+			run_in_background: true,
+		});
+		await writeGoal(
+			{ baseDir: join(cwd, "extensions", "goal"), threadId: sessionId },
+			activeGoal("goal-terminal-reload"),
+		);
+
+		await first.emitLifecycle("session_shutdown", { type: "session_shutdown", reason: "reload" });
+		const second = createGeneration(cwd, sessionId);
+		current = second;
+		await second.emitLifecycle("session_start", { type: "session_start", reason: "reload" });
+		await second.emitLifecycle("agent_end", {
+			type: "agent_end",
+			messages: [cleanAssistantStop()],
+			aborted: false,
+		});
+
+		expect(second.sentMessages).toHaveLength(0);
+		expect(scheduledEvents(second)).toContainEqual(
+			expect.objectContaining({
+				channelCounts: expect.objectContaining({
+					"terminal-monitor": 1,
+					"terminal-bash": 1,
+				}),
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fix Goal continuation losing live terminal resumption channels during a config reload.

## Exact reload failure sequence

1. Terminal is registered before Goal in the builtin list (terminal at the current `builtin/index.ts` line 69 area; Goal at line 81), and lifecycle handlers are awaited in extension order.
2. The old runner shuts down for reload: Terminal parks its live session bundle and the old Goal continuation is disposed, clearing and unsubscribing the old instance.
3. The new runner constructs Terminal and then Goal on one shared event bus. Goal subscribes to channel state in its constructor.
4. During new-runner `session_start`, Terminal runs first, claims the parked bundle, and `TerminalSessionBundle.bind()` immediately republishes the current `terminal-monitor` and `terminal-bash` snapshots.
5. Goal receives both current-generation snapshots, but its later `session_start` previously called `start()`, which unconditionally cleared them.
6. Because the surviving monitor/background bash does not transition again, Goal saw zero live channels at the next active-goal turn end and injected its hidden continuation immediately instead of scheduling the four-minute backstop.

## Fix

`MonitorAwareGoalContinuation.start()` now preserves snapshots received before the first start of a newly constructed instance. A subsequent `start()` on the same instance still clears channel counts, preserving the genuine session-replacement stale-state reset. No builtin ordering, continuation delay, cap, grace, stall/repetition behavior, or telemetry shape changed.

## Failing-first regression

Added `goal-terminal-reload-resumption.test.ts`, which registers Terminal before Goal on a shared event bus, starts both a persistent monitor and a live background bash session, performs old-runner reload shutdown plus fresh construction, dispatches new-runner `session_start` in builtin order, and ends an active-goal turn.

Before the production fix, the test failed exactly at the immediate-send assertion:

```text
AssertionError: expected [ { …(3) } ] to have a length of +0 but got 1
- Expected
+ Received
- 0
+ 1
```

After the fix it asserts zero immediate sends and a `goal_continuation_scheduled` event containing nonzero `terminal-monitor` and `terminal-bash` counts.

## Existing pre-start test

I did not delete the pre-existing test. Its stale-state intent remains valid only for a subsequent same-instance `start()`, not the first start of a fresh runner generation. I reshaped it to assert both sides deliberately: pre-first-start snapshots survive and delay continuation, then a second `start()` on that same instance clears those counts and permits immediate continuation.

## Verification

- New integration + reshaped unit coverage: 2 files, 7 tests passed.
- Required targeted regression set: 9 files, 55 tests passed.
- Root `npm run check`: passed (`EXIT=0`).
- Root TypeScript no-emit check: passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves terminal monitor and background-bash snapshots across config reload. Prevents Goal from sending an immediate continuation when Terminal rebinds before Goal’s first start.

- **Bug Fixes**
  - `MonitorAwareGoalContinuation.start()` now keeps pre-start channel snapshots on the first start; subsequent starts still clear counts to reset stale state.
  - Added `goal-terminal-reload-resumption.test.ts` to cover Terminal-before-Goal reload with snapshot replay; updated `goal-resumption-channels.test.ts` to assert first-start preserve and later clear.
  - No changes to builtin ordering, delays, caps, grace, stall logic, or telemetry.

<sup>Written for commit 34e4a526cc46298dcc01085fe5114b95bddf3c1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

