### PR TITLE
fix(pty): detach pipe-fallback children from the controlling terminal

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Fixed
 
+- Fixed the pipe-fallback terminal backend letting shell children take over the user's terminal. When no native PTY
+  prebuild is available, `bash` children ran inside senpi's own session, so a tty-reading program (such as a `sudo`
+  password prompt) opened `/dev/tty` and raced the TUI's raw-mode stdin reader - the password swallowed stolen escape
+  bytes and the editor then showed Kitty key-release fragments like `[49;1:3u` as literal text (reported on Ubuntu +
+  kitty). Pipe-fallback children are now detached on POSIX with no controlling terminal, and `kill()` signals the whole
+  process group so backgrounded grandchildren can no longer hold the output pipe open.
 - Fixed multi-session RPC `open_session` failures returning only a bare `open_failed` code. Responses now preserve the
   stable prefix and include the underlying workspace or runtime cause as `open_failed: <reason>`, while all other
   transport error codes remain exact strings ([#750](https://github.com/code-yeongyu/senpi/pull/750)).

--- a/packages/pty/src/pipe-fallback.ts
+++ b/packages/pty/src/pipe-fallback.ts
@@ -51,6 +51,25 @@ export function shouldUsePipeFallback(
 	return isPipeFallbackForced(env) || nativeLoadResult.native === null;
 }
 
+/**
+ * Signal the child's whole process group on POSIX. The detached child is its
+ * own group leader, and grandchildren inherit the stdio pipes — leaving them
+ * alive after a kill keeps 'close' from ever firing (the POSIX twin of the
+ * Windows taskkill /T branch below). Returns false when the group signal was
+ * not delivered so callers can fall back to a direct kill.
+ */
+function signalDetachedTree(child: ChildProcessHandle, signal: NodeJS.Signals): boolean {
+	const pid = child.pid;
+	if (pid === undefined || process.platform === "win32") return false;
+	try {
+		process.kill(-pid, signal);
+		return true;
+	} catch {
+		// Group already gone — let the caller fall back to a direct kill.
+		return false;
+	}
+}
+
 function normalizeSpawnError(command: string, error: Error): PipeFallbackSessionError {
 	return {
 		code: "spawn_error",
@@ -104,6 +123,13 @@ export class PipeFallbackSession {
 				cwd: this.options.cwd,
 				env: this.options.env ? { ...process.env, ...this.options.env } : process.env,
 				stdio: ["pipe", "pipe", "pipe"],
+				// Detach on POSIX so the child leads its own session with no
+				// controlling terminal. Without this, a tty-reading program (e.g. a
+				// sudo password prompt) opens /dev/tty — the user's real terminal —
+				// and races the TUI's raw-mode stdin reader byte-by-byte, splitting
+				// keystrokes and Kitty escape sequences between the two readers.
+				// Detached, the /dev/tty open fails with a clear error instead.
+				detached: process.platform !== "win32",
 				windowsHide: true,
 			});
 			this.child = child;
@@ -124,7 +150,7 @@ export class PipeFallbackSession {
 			if (this.options.timeoutMs !== undefined) {
 				this.timeoutHandle = setTimeout(() => {
 					this.timedOut = true;
-					child.kill("SIGTERM");
+					signalDetachedTree(child, "SIGTERM");
 				}, this.options.timeoutMs);
 			}
 		} catch (error) {
@@ -216,6 +242,9 @@ export class PipeFallbackSession {
 			} catch {
 				// Fall through to the direct kill if taskkill is unavailable.
 			}
+		}
+		if (signalDetachedTree(this.child, signal)) {
+			return { ok: true, note: `Sent ${signal} to child_process pipe fallback process group (pgid ${pid}).` };
 		}
 		this.child.kill(signal);
 		return { ok: true, note: `Sent ${signal} to child_process pipe fallback session.` };

--- a/packages/pty/src/pipe-fallback.ts
+++ b/packages/pty/src/pipe-fallback.ts
@@ -52,22 +52,29 @@ export function shouldUsePipeFallback(
 }
 
 /**
- * Signal the child's whole process group on POSIX. The detached child is its
- * own group leader, and grandchildren inherit the stdio pipes — leaving them
- * alive after a kill keeps 'close' from ever firing (the POSIX twin of the
- * Windows taskkill /T branch below). Returns false when the group signal was
- * not delivered so callers can fall back to a direct kill.
+ * Terminate the child, preferring its whole process group on POSIX. The
+ * detached child is its own group leader and grandchildren inherit the stdio
+ * pipes, so leaving them alive keeps 'close' from ever firing (the POSIX twin
+ * of the Windows taskkill /T branch below). Every path that stops a child must
+ * go through here: when the group signal is unavailable (Windows, no pid) or
+ * the group is already gone, it still falls back to a direct kill, so the
+ * child is never left running.
  */
-function signalDetachedTree(child: ChildProcessHandle, signal: NodeJS.Signals): boolean {
+export function terminateChildTree(
+	child: Pick<ChildProcessHandle, "pid" | "kill">,
+	signal: NodeJS.Signals,
+): "group" | "direct" {
 	const pid = child.pid;
-	if (pid === undefined || process.platform === "win32") return false;
-	try {
-		process.kill(-pid, signal);
-		return true;
-	} catch {
-		// Group already gone — let the caller fall back to a direct kill.
-		return false;
+	if (pid !== undefined && process.platform !== "win32") {
+		try {
+			process.kill(-pid, signal);
+			return "group";
+		} catch {
+			// Group already gone — fall through to the direct kill.
+		}
 	}
+	child.kill(signal);
+	return "direct";
 }
 
 function normalizeSpawnError(command: string, error: Error): PipeFallbackSessionError {
@@ -150,7 +157,7 @@ export class PipeFallbackSession {
 			if (this.options.timeoutMs !== undefined) {
 				this.timeoutHandle = setTimeout(() => {
 					this.timedOut = true;
-					signalDetachedTree(child, "SIGTERM");
+					terminateChildTree(child, "SIGTERM");
 				}, this.options.timeoutMs);
 			}
 		} catch (error) {
@@ -243,10 +250,9 @@ export class PipeFallbackSession {
 				// Fall through to the direct kill if taskkill is unavailable.
 			}
 		}
-		if (signalDetachedTree(this.child, signal)) {
+		if (terminateChildTree(this.child, signal) === "group") {
 			return { ok: true, note: `Sent ${signal} to child_process pipe fallback process group (pgid ${pid}).` };
 		}
-		this.child.kill(signal);
 		return { ok: true, note: `Sent ${signal} to child_process pipe fallback session.` };
 	}
 

--- a/packages/pty/test/pipe-fallback.test.ts
+++ b/packages/pty/test/pipe-fallback.test.ts
@@ -142,3 +142,57 @@ describe("PipeFallbackSession", () => {
 		expect(session.write("late").ok).toBe(false);
 	});
 });
+
+describe("PipeFallbackSession terminal detachment", () => {
+	const posixIt = it.skipIf(process.platform === "win32");
+
+	posixIt("runs the child in its own process group so it cannot read senpi's controlling terminal", async () => {
+		// A child sharing senpi's session keeps the user's terminal as its
+		// controlling tty, so a sudo-style /dev/tty read races the TUI's raw
+		// stdin reader and corrupts both inputs. Detached children lead their
+		// own session: pgid equals the child pid.
+		const session = new PipeFallbackSession({
+			command: "sh",
+			args: [
+				"-c",
+				'pgid=$(ps -o pgid= -p $$); pgid=$(echo $pgid); if [ "$pgid" = "$$" ]; then echo OWN_GROUP; else echo "SHARED_GROUP pgid=$pgid pid=$$"; fi',
+			],
+		});
+		session.start();
+
+		const result = await collectOutput(session);
+
+		expect(result.output).toContain("OWN_GROUP");
+		expect(result.exitCode).toBe(0);
+	});
+
+	posixIt(
+		"kill() terminates grandchildren so waitExit settles even when they hold the stdout pipe",
+		async () => {
+			// Without a group kill, SIGTERM reaches only the direct shell; the
+			// backgrounded grandchild keeps the stdout pipe open and 'close'
+			// never fires (the POSIX twin of the Windows taskkill /T branch).
+			const session = new PipeFallbackSession({
+				command: "sh",
+				args: ["-c", "sleep 300 & echo READY; wait"],
+			});
+			session.start();
+
+			await new Promise<void>((resolve) => {
+				let buffered = "";
+				session.onData((chunk) => {
+					buffered += chunk.toString("utf8");
+					if (buffered.includes("READY")) resolve();
+				});
+			});
+
+			const kill = session.kill("SIGTERM");
+			expect(kill.ok).toBe(true);
+
+			const exit = await session.waitExit();
+			expect(exit.signal).toBe("SIGTERM");
+			expect(exit.exitCode).toBeNull();
+		},
+		5000,
+	);
+});

--- a/packages/pty/test/pipe-fallback.test.ts
+++ b/packages/pty/test/pipe-fallback.test.ts
@@ -6,6 +6,7 @@ import {
 	isPipeFallbackForced,
 	PipeFallbackSession,
 	shouldUsePipeFallback,
+	terminateChildTree,
 } from "../src/pipe-fallback.ts";
 
 function nodeSession(script: string, options: { timeoutMs?: number } = {}): PipeFallbackSession {
@@ -195,4 +196,25 @@ describe("PipeFallbackSession terminal detachment", () => {
 		},
 		5000,
 	);
+});
+
+describe("terminateChildTree", () => {
+	it("falls back to a direct kill when no process-group signal is available", () => {
+		// The branch Windows always takes (and POSIX takes once the group is
+		// gone). Every stop path routes through here, so losing the fallback
+		// would leave timed-out children running forever.
+		const signals: NodeJS.Signals[] = [];
+		const child = {
+			pid: undefined,
+			kill: (signal?: NodeJS.Signals) => {
+				signals.push(signal ?? "SIGTERM");
+				return true;
+			},
+		};
+
+		const route = terminateChildTree(child, "SIGTERM");
+
+		expect(route).toBe("direct");
+		expect(signals).toEqual(["SIGTERM"]);
+	});
 });


### PR DESCRIPTION
## Summary

A senpi user on Ubuntu + kitty reported that after answering a `sudo` password prompt, typing in the composer produced garbage: the editor filled with Kitty key-release fragments like `4312[49;1:3u[52;1:3u[51;1:3u...`.

Root cause is not the TUI key parser. When no native PTY prebuild is available, `PipeFallbackSession` spawned bash-tool children with plain pipes **inside senpi's own session**, so the child kept the user's terminal as its controlling tty. A tty-reading program (`sudo`) then opened `/dev/tty` — the user's real terminal — and raced the TUI's raw-mode stdin reader byte-by-byte while the Kitty keyboard protocol was active. Each reader got a slice of every keystroke, so the password absorbed stolen escape bytes and the leftovers of split `CSI <cp>;1:3u` release sequences rendered in the editor as literal text (the truncated tail `3;1:3u` in the report is the signature of a stolen prefix).

The native path is immune (portable-pty does setsid + TIOCSCTTY), and `core/tools/bash.ts` already spawns `detached: process.platform !== "win32"`. This applies the same treatment to the pipe fallback.

## Changes

- `packages/pty/src/pipe-fallback.ts`: spawn children detached on POSIX so they lead their own session with no controlling terminal — `/dev/tty` now fails with a clear error instead of stealing keystrokes.
- Because the detached child leads its own process group, `kill()` and the timeout path now signal the whole group (the POSIX twin of the existing Windows `taskkill /T` branch), so a backgrounded grandchild can no longer hold the stdout pipe open and hang `waitExit()`.

## Tests (RED first)

Both tests were captured failing before the fix:

- detach: `SHARED_GROUP pgid=25486 pid=52212` (expected `OWN_GROUP`)
- group kill: `Test timed out in 5000ms` — the grandchild held the pipe open

After the fix: `packages/pty` 46/46 tests pass, root `npm run check` exits 0.

## Manual QA — real surface, A/B

`inner.mts` runs inside a real PTY, spawns a `PipeFallbackSession` child running `sh -c 'if read -r x < /dev/tty ...'`, then the operator types a secret into the host pty.

**A — unfixed (main):**
```
CHILD_SPAWNED
stolenpass
TTY_READ:stolenpass          <-- child consumed the user's keystrokes (the reported bug)
```

**B — fixed (this branch):**
```
CHILD_SPAWNED
sh: /dev/tty: Device not configured     <-- ENXIO: no controlling terminal
TTY_OPEN_FAILED
CHILD_EXIT code=0 signal=null
```

`senpi-qa` Channel 5 with `--force-pipe`: 8/8 pass (line watch, peek, `bash_input` steering, screen snapshot, resize reflow, registry teardown with no orphans, auth.json sha256 unchanged). Evidence: `local-ignore/qa-evidence/20260809-pipe-fallback-tty/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keystrokes being stolen in the pipe-fallback PTY by detaching POSIX children from the controlling TTY. Also makes termination robust across platforms by signaling the process group and always falling back to a direct kill, so Windows timeouts don’t hang and grandchildren can’t hold pipes open.

- **Bug Fixes**
  - Spawn `PipeFallbackSession` children with `detached: process.platform !== "win32"` so they lead their own session with no controlling TTY; `/dev/tty` now fails cleanly instead of racing TUI input (e.g., `sudo` on Ubuntu + kitty).
  - Route all stop paths through `terminateChildTree()` to send POSIX signals to the child’s process group with a guaranteed direct `kill()` fallback (including timeouts), preventing stdout pipe hangs and fixing the Windows timeout hang.

<sup>Written for commit dcf61a3eff91110294e8445a2daef1b5a158b67c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

