### PR TITLE
fix(agent): recover invisible text-protocol assistant stops

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-kimi-thinking-recovery.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-kimi-thinking-recovery.mjs
@@ -22,7 +22,7 @@ export async function runKimiThinkingRecoveryScenario(driveTurn, evidenceSlug) {
 	const guard = guardRealAuth();
 	const { box, server, result } = await driveTurn({
 		apiName: "openai-completions",
-		turns: [{ reasoning: MALFORMED_THINKING }, { text: RECOVERED_MARKER }],
+		turns: [{ reasoning: MALFORMED_THINKING, text: "\u200b" }, { text: RECOVERED_MARKER }],
 		prompt: `Return ${RECOVERED_MARKER} after recovering from the malformed empty response.`,
 		extraArgs: ["--model", "kimi-k3-ultrafast"],
 		mockModels: [{ id: "kimi-k3-ultrafast", reasoning: true }],
@@ -36,10 +36,15 @@ export async function runKimiThinkingRecoveryScenario(driveTurn, evidenceSlug) {
 			.filter((entry) => entry.streamId === 0 && entry.kind === "reasoning_delta")
 			.map((entry) => entry.delta)
 			.join("");
+		const firstText = server.streamLog
+			.filter((entry) => entry.streamId === 0 && entry.kind === "text_delta")
+			.map((entry) => entry.delta)
+			.join("");
 		const replayBody = JSON.stringify(server.requests[1]?.body ?? {});
 		checks.ok("real CLI exits zero after one empty-response retry", result.code === 0 && !result.timedOut, `code=${result.code}`);
 		checks.ok("fake provider receives exactly two requests", server.requests.length === 2, `requests=${server.requests.length}`);
 		checks.ok("malformed reasoning payload reached the real provider parser", firstReasoning === MALFORMED_THINKING, `bytes=${firstReasoning.length}`);
+		checks.ok("production zero-width text block reached the real provider parser", firstText === "\u200b", `bytes=${firstText.length}`);
 		checks.ok("recovered answer is visible exactly once", markerCount === 1, `markerCount=${markerCount}`);
 		checks.ok("raw XTML markers never reach visible CLI output", !XTML_PATTERN.test(output), `markersVisible=${XTML_PATTERN.test(output)}`);
 		checks.ok("discarded empty attempt is not replayed into request two", !replayBody.includes("<|close|>"), `markerReplayed=${replayBody.includes("<|close|>")}`);
@@ -54,6 +59,7 @@ export async function runKimiThinkingRecoveryScenario(driveTurn, evidenceSlug) {
 					requestCount: server.requests.length,
 					markerCount,
 					firstReasoning,
+					firstText,
 					replayedMalformedAttempt: replayBody.includes("<|close|>"),
 					authPath: guard.path,
 					authHash: guard.before,

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Retry one assistant `stop` response with no visible text or tool call for Claude, Kimi, and configured text-tool
+  protocols instead of only Kimi. Unicode format-only output such as zero-width spaces stays buffered with the
+  discarded attempt, and a second invisible response remains a bounded explicit error.
+
 ### Removed
 
 ## [2026.8.7] - 2026-08-07

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,32 @@
 # Changes
 
+## 2026-08-09 - Recover invisible text-protocol assistant stops
+
+### What changed and why
+
+- Empty-assistant recovery now covers every model selected for text-tool-call recovery or configured with a text tool
+  format, expanding the previous Kimi-only gate to Claude, ANTML, Hermes, morph-XML, YAML-XML, Gemma delimiters, and
+  other configured text protocols. A `stop` turn with no visible text and no tool call is discarded and retried once;
+  a second invisible stop retains the existing explicit `Model returned an empty response twice` failure.
+- Both the completed-message gate and the first-visible-event gate use pi-ai's shared Unicode visibility predicates.
+  Unicode format-only deltas such as the U+200B block emitted by the Apitopia Kimi-K3 gateway remain buffered, so
+  malformed thinking/tool-marker events from the discarded attempt never reach subscribers.
+- The approved universal gate was narrowed after the full-suite audit: buffering all model streams suppressed ordinary
+  thinking updates, changed provider stream-start/idle-timeout semantics, and prevented coding-agent TTSR from
+  observing and aborting malformed reasoning streams. Plain native-protocol models therefore keep direct streaming,
+  while every model exposed to the text-protocol failure mode receives bounded recovery.
+- Healthy visible text, tool calls, and non-`stop` terminal states retain their existing pass-through behavior.
+
+### Why the extension system could not handle this
+
+- Provider stream buffering and retry happen inside agent-core before message-update events are forwarded or an
+  assistant turn is committed; extensions cannot retract leaked attempt-one events or replace the committed turn.
+
+### Expected merge conflict zones on next upstream sync
+
+- MEDIUM: `empty-assistant-recovery.ts` visibility checks and stream wrapper gate.
+- LOW: `agent-loop.ts` at the recovery wrapper call site.
+
 ## 2026-07-30 - Bound empty Kimi assistant responses
 
 ### What changed and why

--- a/packages/agent/src/empty-assistant-recovery.ts
+++ b/packages/agent/src/empty-assistant-recovery.ts
@@ -4,8 +4,11 @@ import {
 	type AssistantMessageEvent,
 	type AssistantMessageEventStream,
 	createAssistantMessageEventStream,
-	hasKimiTextToolCallRecovery,
+	getToolCallFormat,
+	hasVisibleAssistantContent,
+	hasVisibleText,
 	type Model,
+	shouldRecoverTextToolCalls,
 } from "@earendil-works/pi-ai";
 import type { StreamFn } from "./types.ts";
 
@@ -13,18 +16,12 @@ type StreamFactory = () => AssistantMessageEventStream | Promise<AssistantMessag
 
 const EMPTY_RESPONSE_ERROR = "Model returned an empty response twice";
 
-function hasVisibleContent(message: AssistantMessage): boolean {
-	return message.content.some(
-		(block) => block.type === "toolCall" || (block.type === "text" && block.text.trim().length > 0),
-	);
-}
-
 function isEmptyStop(message: AssistantMessage): boolean {
-	return message.stopReason === "stop" && !hasVisibleContent(message);
+	return message.stopReason === "stop" && !hasVisibleAssistantContent(message);
 }
 
 function eventStartsVisibleContent(event: AssistantMessageEvent): boolean {
-	return event.type === "toolcall_start" || (event.type === "text_delta" && event.delta.trim().length > 0);
+	return event.type === "toolcall_start" || (event.type === "text_delta" && hasVisibleText(event.delta));
 }
 
 function appendRetryDiagnostic(message: AssistantMessage): AssistantMessage {
@@ -115,7 +112,7 @@ function createRetryingStream(firstStream: AssistantMessageEventStream, createSt
 }
 
 export function withEmptyAssistantRecovery<TApi extends Api>(model: Model<TApi>, streamFunction: StreamFn): StreamFn {
-	if (!hasKimiTextToolCallRecovery(model)) return streamFunction;
+	if (!shouldRecoverTextToolCalls(model) && getToolCallFormat(model) === undefined) return streamFunction;
 	return async (requestedModel, context, options) => {
 		const createStream = (): ReturnType<StreamFn> => streamFunction(requestedModel, context, options);
 		return createRetryingStream(await createStream(), createStream);

--- a/packages/agent/test/agent-loop-empty-assistant-recovery.test.ts
+++ b/packages/agent/test/agent-loop-empty-assistant-recovery.test.ts
@@ -1,5 +1,6 @@
 import {
 	type AssistantMessage,
+	type AssistantMessageEvent,
 	createAssistantMessageEventStream,
 	type Message,
 	type Model,
@@ -8,6 +9,9 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import { agentLoop } from "../src/agent-loop.ts";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
+
+const REAL_MALFORMED_THINKING =
+	'vue install vtracer 2>&1 | tail -5; command -v vtracer; ls /opt/homebrew/bin | grep -iE \'vtrace|vtracer\'<|close|>argument<|sep|><|open|>argument key="description" type="string"<|sep|>Check vtracer brew formula availability<|close|>argument<|sep|><|close|>call<|sep|><|close|>tools<|sep|><|close|>message<|sep|>';
 
 function assistant(
 	content: AssistantMessage["content"],
@@ -18,7 +22,7 @@ function assistant(
 		role: "assistant",
 		api: "openai-completions",
 		provider: "test",
-		model: "kimi-test",
+		model: "test-model",
 		content,
 		usage: {
 			input: 0,
@@ -34,9 +38,9 @@ function assistant(
 	};
 }
 
-function model(): Model<"openai-completions"> {
+function model(id = "kimi-test", toolCallFormat?: "antml"): Model<"openai-completions"> {
 	return {
-		id: "kimi-test",
+		id,
 		name: "Test Model",
 		api: "openai-completions",
 		provider: "test",
@@ -46,6 +50,7 @@ function model(): Model<"openai-completions"> {
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: 8192,
 		maxTokens: 1024,
+		...(toolCallFormat === undefined ? {} : { compat: { toolCallFormat } }),
 	};
 }
 
@@ -59,6 +64,35 @@ function streamMessage(message: AssistantMessage) {
 	return stream;
 }
 
+function streamContent(message: AssistantMessage) {
+	if (message.stopReason === "error" || message.stopReason === "aborted" || message.stopReason === "pending") {
+		throw new Error("Streamed content fixture requires a successful terminal stop reason");
+	}
+	const stopReason = message.stopReason;
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		const partial: AssistantMessage = { ...message, content: [] };
+		stream.push({ type: "start", partial });
+		for (const [contentIndex, block] of message.content.entries()) {
+			if (block.type === "text") {
+				partial.content = [...partial.content, { type: "text", text: "" }];
+				stream.push({ type: "text_start", contentIndex, partial });
+				partial.content[contentIndex] = block;
+				stream.push({ type: "text_delta", contentIndex, delta: block.text, partial });
+				stream.push({ type: "text_end", contentIndex, content: block.text, partial });
+			} else if (block.type === "thinking") {
+				partial.content = [...partial.content, { type: "thinking", thinking: "" }];
+				stream.push({ type: "thinking_start", contentIndex, partial });
+				partial.content[contentIndex] = block;
+				stream.push({ type: "thinking_delta", contentIndex, delta: block.thinking, partial });
+				stream.push({ type: "thinking_end", contentIndex, content: block.thinking, partial });
+			}
+		}
+		stream.push({ type: "done", reason: stopReason, message });
+	});
+	return stream;
+}
+
 function visibleText(message: AssistantMessage): string {
 	return message.content
 		.filter((block) => block.type === "text")
@@ -68,6 +102,10 @@ function visibleText(message: AssistantMessage): string {
 
 function isLlmMessage(message: AgentMessage): message is Message {
 	return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
+}
+
+function assistantStreamEvents(events: AgentEvent[]): AssistantMessageEvent[] {
+	return events.flatMap((event) => (event.type === "message_update" ? [event.assistantMessageEvent] : []));
 }
 
 async function collectBounded(stream: ReturnType<typeof agentLoop>) {
@@ -88,35 +126,97 @@ async function collectBounded(stream: ReturnType<typeof agentLoop>) {
 	}
 }
 
-function config(): AgentLoopConfig {
-	return { model: model(), convertToLlm: (messages) => messages.filter(isLlmMessage) };
+function config(modelId = "kimi-test", toolCallFormat?: "antml"): AgentLoopConfig {
+	return { model: model(modelId, toolCallFormat), convertToLlm: (messages) => messages.filter(isLlmMessage) };
 }
 
 describe("agent loop empty assistant recovery", () => {
-	it("retries one thinking-only stop before committing the assistant turn", async () => {
-		const responses = [
-			assistant([{ type: "thinking", thinking: "No visible answer." }]),
-			assistant([{ type: "text", text: "Recovered after retry" }]),
-		];
+	it("discards and retries the real zero-width Kimi fixture without forwarding attempt-one events", async () => {
+		const malformed = assistant([
+			{ type: "text", text: "\u200b" },
+			{ type: "thinking", thinking: REAL_MALFORMED_THINKING },
+		]);
+		const recovered = assistant([{ type: "text", text: "Recovered after retry" }]);
+		const responses = [malformed, recovered];
 		let streamCalls = 0;
 		const stream = agentLoop(
 			[{ role: "user", content: "answer", timestamp: 1 }],
 			{ systemPrompt: "", messages: [], tools: [] },
 			config(),
 			undefined,
-			() => streamMessage(responses[streamCalls++] ?? responses[1]),
+			() => streamContent(responses[streamCalls++] ?? recovered),
+		);
+		const { events, messages } = await collectBounded(stream);
+		const assistants = messages.filter((message) => message.role === "assistant");
+		const streamed = assistantStreamEvents(events);
+
+		expect(streamCalls).toBe(2);
+		expect(assistants).toHaveLength(1);
+		expect(visibleText(assistants[0])).toBe("Recovered after retry");
+		expect(assistants[0].diagnostics).toContainEqual({
+			type: "empty_assistant_response_recovery",
+			timestamp: expect.any(Number),
+			details: { retries: 1 },
+		});
+		expect(streamed.some((event) => event.type === "thinking_delta" && event.delta === REAL_MALFORMED_THINKING)).toBe(
+			false,
+		);
+		expect(streamed.some((event) => event.type === "text_delta" && event.delta === "\u200b")).toBe(false);
+		expect(
+			streamed.filter((event) => event.type === "text_delta" && event.delta === "Recovered after retry"),
+		).toHaveLength(1);
+	});
+
+	it.each([
+		["claude-sonnet-test", undefined],
+		["generic-model-test", "antml"],
+	] as const)("retries an invisible stop for text-protocol model %s", async (modelId, toolCallFormat) => {
+		const empty = assistant([{ type: "thinking", thinking: "No visible answer." }]);
+		const recovered = assistant([{ type: "text", text: `Recovered ${modelId}` }]);
+		const responses = [empty, recovered];
+		let streamCalls = 0;
+		const stream = agentLoop(
+			[{ role: "user", content: "answer", timestamp: 1 }],
+			{ systemPrompt: "", messages: [], tools: [] },
+			config(modelId, toolCallFormat),
+			undefined,
+			() => streamMessage(responses[streamCalls++] ?? recovered),
 		);
 		const { messages } = await collectBounded(stream);
 		const assistants = messages.filter((message) => message.role === "assistant");
 
 		expect(streamCalls).toBe(2);
 		expect(assistants).toHaveLength(1);
-		expect(visibleText(assistants[0])).toBe("Recovered after retry");
+		expect(visibleText(assistants[0])).toBe(`Recovered ${modelId}`);
 	});
 
-	it("turns a second empty stop into a visible bounded failure", async () => {
+	it("leaves a plain generic thinking-only stream unbuffered for downstream observers", async () => {
+		const thinkingOnly = assistant([{ type: "thinking", thinking: "Observable downstream reasoning." }]);
+		let streamCalls = 0;
+		const stream = agentLoop(
+			[{ role: "user", content: "answer", timestamp: 1 }],
+			{ systemPrompt: "", messages: [], tools: [] },
+			config("generic-model-test"),
+			undefined,
+			() => {
+				streamCalls += 1;
+				return streamContent(thinkingOnly);
+			},
+		);
+		const { events, messages } = await collectBounded(stream);
+
+		expect(streamCalls).toBe(1);
+		expect(messages.filter((message) => message.role === "assistant")).toEqual([thinkingOnly]);
+		expect(
+			assistantStreamEvents(events).some(
+				(event) => event.type === "thinking_delta" && event.delta === "Observable downstream reasoning.",
+			),
+		).toBe(true);
+	});
+
+	it("turns a second invisible stop into a visible bounded failure", async () => {
 		const empty = assistant([
-			{ type: "text", text: "" },
+			{ type: "text", text: "\u2060" },
 			{ type: "thinking", thinking: "Still empty." },
 		]);
 		let streamCalls = 0;
@@ -140,6 +240,30 @@ describe("agent loop empty assistant recovery", () => {
 			errorMessage: "Model returned an empty response twice",
 		});
 		expect(visibleText(assistants[0])).toBe("Model returned an empty response twice");
+	});
+
+	it("passes a normal visible response through unchanged with one set of streamed events", async () => {
+		const visible = assistant([{ type: "text", text: "Ordinary response" }]);
+		let streamCalls = 0;
+		const stream = agentLoop(
+			[{ role: "user", content: "answer", timestamp: 1 }],
+			{ systemPrompt: "", messages: [], tools: [] },
+			config("generic-model-test"),
+			undefined,
+			() => {
+				streamCalls += 1;
+				return streamContent(visible);
+			},
+		);
+		const { events, messages } = await collectBounded(stream);
+		const assistants = messages.filter((message) => message.role === "assistant");
+		const streamed = assistantStreamEvents(events);
+
+		expect(streamCalls).toBe(1);
+		expect(assistants).toEqual([visible]);
+		expect(
+			streamed.filter((event) => event.type === "text_delta" && event.delta === "Ordinary response"),
+		).toHaveLength(1);
 	});
 
 	it("does not retry terminal errors, aborts, refusals, or length stops", async () => {

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Added shared assistant-content visibility classification that ignores Unicode format characters before checking
+  text, preventing zero-width-only output from being treated as a visible response while preserving emoji ZWJ
+  sequences and tool calls.
+
 ### Removed
 
 ## [2026.8.7] - 2026-08-07

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,26 @@
 # AI Source Changes
 
+## 2026-08-09 - Shared visible assistant-content classification
+
+### What changed and why
+
+- `utils/visible-text.ts` defines the shared visibility boundary for assistant text: Unicode format characters
+  (`\p{Cf}`) are removed before whitespace trimming, so zero-width spaces, joiners, word joiners, byte-order marks,
+  and directional formatting marks cannot make an otherwise empty response appear user-visible.
+- `hasVisibleAssistantContent` treats a tool call or text containing a visible scalar as assistant output. Emoji ZWJ
+  sequences remain visible because removing the joiner leaves visible emoji scalars.
+- The browser-safe root exports both predicates so agent-core and other consumers use one classification instead of
+  duplicating JavaScript `trim()` checks that miss U+200B.
+
+### Why this cannot be expressed externally
+
+- Assistant response visibility is a shared message-level contract consumed before coding-agent extensions receive a
+  committed turn; external hooks cannot reliably repair divergent classifiers in each core consumer.
+
+### Expected merge conflict zones
+
+- LOW: additive `utils/visible-text.ts` module and root export in `index.ts`.
+
 ## 2026-08-05 - Root-object tool schemas and request-shape error classification
 
 ### What changed and why

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -77,3 +77,4 @@ export * from "./utils/tool-pair-repair.ts";
 export * from "./utils/typebox-helpers.ts";
 export { uuidv7 } from "./utils/uuid.ts";
 export * from "./utils/validation.ts";
+export * from "./utils/visible-text.ts";

--- a/packages/ai/src/utils/visible-text.ts
+++ b/packages/ai/src/utils/visible-text.ts
@@ -1,0 +1,13 @@
+import type { AssistantMessage } from "../types.ts";
+
+const INVISIBLE_FORMAT_CHARS = /\p{Cf}/gu;
+
+export function hasVisibleText(text: string): boolean {
+	return text.replace(INVISIBLE_FORMAT_CHARS, "").trim().length > 0;
+}
+
+export function hasVisibleAssistantContent(message: AssistantMessage): boolean {
+	return message.content.some(
+		(block) => block.type === "toolCall" || (block.type === "text" && hasVisibleText(block.text)),
+	);
+}

--- a/packages/ai/test/visible-text.test.ts
+++ b/packages/ai/test/visible-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage } from "../src/types.ts";
+import { hasVisibleAssistantContent, hasVisibleText } from "../src/utils/visible-text.ts";
+
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-completions",
+		provider: "test",
+		model: "test-model",
+		content,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+describe("hasVisibleText", () => {
+	it.each(["\u200b", "\u200c", "\u200d", "\u2060", "\ufeff"])(
+		"treats format-character-only text %j as invisible",
+		(text) => {
+			expect(hasVisibleText(text)).toBe(false);
+		},
+	);
+
+	it("treats whitespace-only text as invisible", () => {
+		expect(hasVisibleText(" \t\n\r")).toBe(false);
+	});
+
+	it("keeps emoji ZWJ sequences visible", () => {
+		expect(hasVisibleText("👨‍👩‍👧‍👦")).toBe(true);
+	});
+
+	it("keeps letters mixed with zero-width spaces visible", () => {
+		expect(hasVisibleText("\u200bvisible\u200b")).toBe(true);
+	});
+
+	it("treats an empty string as invisible", () => {
+		expect(hasVisibleText("")).toBe(false);
+	});
+});
+
+describe("hasVisibleAssistantContent", () => {
+	it("accepts visible text or a tool call and rejects thinking plus invisible text", () => {
+		expect(hasVisibleAssistantContent(assistant([{ type: "text", text: "answer" }]))).toBe(true);
+		expect(
+			hasVisibleAssistantContent(
+				assistant([{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "README.md" } }]),
+			),
+		).toBe(true);
+		expect(
+			hasVisibleAssistantContent(
+				assistant([
+					{ type: "text", text: "\u200b" },
+					{ type: "thinking", thinking: "private" },
+				]),
+			),
+		).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/kimi-xtml-thinking-recovery-runtime-boundary.test.ts
+++ b/packages/coding-agent/test/kimi-xtml-thinking-recovery-runtime-boundary.test.ts
@@ -1,8 +1,10 @@
+import { type AgentEvent, type AgentMessage, agentLoop } from "@earendil-works/pi-agent-core";
 import {
 	type Api,
 	type AssistantMessage,
 	type AssistantMessageEventStream as AssistantStream,
 	createAssistantMessageEventStream,
+	type Message,
 	type Model,
 	type Provider,
 } from "@earendil-works/pi-ai";
@@ -45,22 +47,53 @@ function blankMessage(selected: Model<Api>): AssistantMessage {
 	};
 }
 
-function thinkingStream(selected: Model<Api>, chunks: readonly string[]): AssistantStream {
+function thinkingStream(selected: Model<Api>, chunks: readonly string[], leadingText?: string): AssistantStream {
 	const stream = createAssistantMessageEventStream();
 	queueMicrotask(() => {
 		const partial = blankMessage(selected);
 		stream.push({ type: "start", partial });
-		partial.content = [{ type: "thinking", thinking: "" }];
-		stream.push({ type: "thinking_start", contentIndex: 0, partial });
+		const thinkingIndex = leadingText === undefined ? 0 : 1;
+		if (leadingText !== undefined) {
+			partial.content = [{ type: "text", text: "" }];
+			stream.push({ type: "text_start", contentIndex: 0, partial });
+			partial.content = [{ type: "text", text: leadingText }];
+			stream.push({ type: "text_delta", contentIndex: 0, delta: leadingText, partial });
+			stream.push({ type: "text_end", contentIndex: 0, content: leadingText, partial });
+		}
+		partial.content = [
+			...(leadingText === undefined ? [] : [{ type: "text" as const, text: leadingText }]),
+			{ type: "thinking", thinking: "" },
+		];
+		stream.push({ type: "thinking_start", contentIndex: thinkingIndex, partial });
 		let thinking = "";
 		for (const chunk of chunks) {
 			thinking += chunk;
-			partial.content = [{ type: "thinking", thinking }];
-			stream.push({ type: "thinking_delta", contentIndex: 0, delta: chunk, partial });
+			partial.content[thinkingIndex] = { type: "thinking", thinking };
+			stream.push({ type: "thinking_delta", contentIndex: thinkingIndex, delta: chunk, partial });
 		}
-		stream.push({ type: "thinking_end", contentIndex: 0, content: thinking, partial });
+		stream.push({ type: "thinking_end", contentIndex: thinkingIndex, content: thinking, partial });
 		const message = blankMessage(selected);
-		message.content = [{ type: "thinking", thinking }];
+		message.content = [
+			...(leadingText === undefined ? [] : [{ type: "text" as const, text: leadingText }]),
+			{ type: "thinking", thinking },
+		];
+		stream.push({ type: "done", reason: "stop", message });
+	});
+	return stream;
+}
+
+function textStream(selected: Model<Api>, text: string): AssistantStream {
+	const stream = createAssistantMessageEventStream();
+	queueMicrotask(() => {
+		const partial = blankMessage(selected);
+		stream.push({ type: "start", partial });
+		partial.content = [{ type: "text", text: "" }];
+		stream.push({ type: "text_start", contentIndex: 0, partial });
+		partial.content = [{ type: "text", text }];
+		stream.push({ type: "text_delta", contentIndex: 0, delta: text, partial });
+		stream.push({ type: "text_end", contentIndex: 0, content: text, partial });
+		const message = blankMessage(selected);
+		message.content = [{ type: "text", text }];
 		stream.push({ type: "done", reason: "stop", message });
 	});
 	return stream;
@@ -101,7 +134,70 @@ function thinkingText(message: AssistantMessage): string {
 		.join("");
 }
 
+function isLlmMessage(message: AgentMessage): message is Message {
+	return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
+}
+
+async function recoveredAgentTurn(firstThinking: string, recoveredText: string) {
+	const selectedModel = model("kimi-k3");
+	let requests = 0;
+	const provider: Provider = {
+		id: selectedModel.provider,
+		name: "Thinking recovery provider",
+		auth: { apiKey: { name: "test", resolve: async () => ({ auth: { apiKey: "test" }, source: "test" }) } },
+		getModels: () => [selectedModel],
+		stream: (selected) => {
+			requests += 1;
+			return requests === 1
+				? thinkingStream(selected, [firstThinking], "\u200b")
+				: textStream(selected, recoveredText);
+		},
+		streamSimple: (selected) => textStream(selected, recoveredText),
+	};
+	const runtime = await ModelRuntime.create({
+		credentials: AuthStorage.inMemory(),
+		modelsPath: null,
+		allowModelNetwork: false,
+	});
+	runtime.registerNativeProvider(provider);
+	const selected = runtime.getModel(provider.id, selectedModel.id);
+	if (!selected) throw new Error("model not registered");
+	const stream = agentLoop(
+		[{ role: "user", content: "continue", timestamp: 1 }],
+		{ systemPrompt: "", messages: [], tools: [] },
+		{ model: selected, convertToLlm: (messages) => messages.filter(isLlmMessage) },
+		undefined,
+		(streamModel, context, options) => runtime.stream(streamModel, context, options),
+	);
+	const events: AgentEvent[] = [];
+	for await (const event of stream) events.push(event);
+	const messages = await stream.result();
+	return { requests, events, messages };
+}
+
+const REAL_MALFORMED_THINKING =
+	'vue install vtracer 2>&1 | tail -5; command -v vtracer; ls /opt/homebrew/bin | grep -iE \'vtrace|vtracer\'<|close|>argument<|sep|><|open|>argument key="description" type="string"<|sep|>Check vtracer brew formula availability<|close|>argument<|sep|><|close|>call<|sep|><|close|>tools<|sep|><|close|>message<|sep|>';
+
 describe("Kimi XTML thinking recovery runtime boundary", () => {
+	it("discards the real zero-width malformed turn and exposes the retry exactly once", async () => {
+		const recovered = "Recovered visible answer";
+		const result = await recoveredAgentTurn(REAL_MALFORMED_THINKING, recovered);
+		const assistants = result.messages.filter((message) => message.role === "assistant");
+		const eventBytes = JSON.stringify(result.events);
+		const recoveredDeltas = result.events.filter(
+			(event) =>
+				event.type === "message_update" &&
+				event.assistantMessageEvent.type === "text_delta" &&
+				event.assistantMessageEvent.delta === recovered,
+		);
+
+		expect(result.requests).toBe(2);
+		expect(assistants).toHaveLength(1);
+		expect(visibleText(assistants[0])).toBe(recovered);
+		expect(recoveredDeltas).toHaveLength(1);
+		expect(eventBytes).not.toContain("<|close|>");
+		expect(eventBytes).not.toContain("\u200b");
+	});
 	it("promotes an explicit response channel without registered tools", async () => {
 		const result = await runtimeResult("kimi-k3", [
 			"Reasoning stays private.",


### PR DESCRIPTION
## Problem

A production Kimi-K3 turn (apitopia gateway, `openai-completions`) emitted its entire output into `reasoning_content`: a headless XTML tool-call fragment in the thinking channel plus a single U+200B zero-width-space text block, ending with `stopReason: "stop"`. The empty-assistant discard-and-retry never fired because `hasVisibleContent()` used `text.trim().length > 0` and JS `trim()` does not strip U+200B (a `Cf` format character, not Unicode whitespace). The malformed turn was accepted as a normal completion: raw XTML markers streamed into the TUI and the agent went idle mid-task.

The mock for the `kimi-xtml-thinking-recover` QA scenario emitted thinking-only responses *without* the zwsp block the real gateway prepends, which is why this shipped.

## Fix

- **packages/ai**: shared visibility predicates `hasVisibleText` / `hasVisibleAssistantContent` — strip `/\p{Cf}/gu` before `trim()` (U+200B/200C/200D/2060/FEFF, directional marks). Emoji ZWJ sequences stay visible.
- **packages/agent**: empty-assistant recovery now covers every text-tool-protocol model — `shouldRecoverTextToolCalls(model)` (Claude + Kimi ids or explicit opt-in) or `compat.toolCallFormat` set (antml, hermes, morph-xml, yaml-xml, gemma4, anthropic-xml, kimi-xtml) — instead of Kimi only. Both gates fixed: the completed-message `isEmptyStop` check and the first-visible-event forwarding gate, so format-only deltas stay buffered and a discarded attempt's events never reach subscribers.
- Retry budget unchanged: one retry, then the explicit `Model returned an empty response twice` error.

## Plan deviation (documented in `packages/agent/src/changes.md`)

The initially approved universal gate was narrowed to text-protocol models after the full-suite audit: buffering all model streams suppressed native thinking updates, changed stream-start/idle-timeout liveness semantics, and prevented TTSR from observing/aborting malformed reasoning streams. A dedicated regression pins plain native streams as unbuffered.

## Tests (all captured RED before GREEN)

- `packages/ai/test/visible-text.test.ts` (10): Cf-only invisible, whitespace invisible, emoji ZWJ visible, mixed visible.
- `packages/agent/test/agent-loop-empty-assistant-recovery.test.ts`: real production fixture (zwsp text + leaked-marker thinking) discarded + retried with attempt-1 events suppressed; claude-id and generic-antml retry coverage; unbuffered-native regression; double-invisible bounded error (U+2060 variant); visible passthrough exactly once.
- `packages/coding-agent/test/kimi-xtml-thinking-recovery-runtime-boundary.test.ts`: real `ModelRuntime` + `agentLoop` wiring replays the production stream; asserts 2 provider requests and exactly-once recovered output.
- QA mock (`.agents/skills/senpi-qa` mock-loop `kimi-xtml-thinking-recover`) now emits the production U+200B text block and asserts it reaches the real parser.

## Verification

- `npm run check` exit 0 (lead re-run)
- packages/ai 10/10 · packages/agent 27 files / 354 passed · runtime-boundary 6/6 (lead re-runs)
- Full coding-agent suite `CI=1`: 836 files / 6901 passed (implementation run)
- Real CLI QA `mock-loop --scenario kimi-xtml-thinking-recover`: 9/9 PASS — retry visible exactly once, no marker leak, discarded attempt not replayed into request two, real auth untouched, sandbox cleaned
- Changelog gate: `[Unreleased]` entries in `packages/ai/CHANGELOG.md` and `packages/agent/CHANGELOG.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invisible assistant “stop” responses for text-protocol models by ignoring zero‑width format characters and expanding the empty-response retry beyond Kimi. Prevents leaked thinking/tool markers from attempt one and keeps native streams unchanged.

- **Bug Fixes**
  - `packages/ai`: Add `hasVisibleText` and `hasVisibleAssistantContent` that remove Unicode format chars (`/\p{Cf}/gu`) before trimming so zero‑width output doesn’t count as visible; emoji ZWJ sequences remain visible.
  - `packages/agent`: Apply empty-assistant retry to all text-protocol models (`shouldRecoverTextToolCalls(model)` or `compat.toolCallFormat` set), not just Kimi. Buffer format-only deltas so discarded attempt events don’t reach subscribers. Keep retry budget to one; a second invisible stop becomes `Model returned an empty response twice`. Visible text/tool calls still pass through; native-protocol streams stay unbuffered.

<sup>Written for commit 302bf196d7ec0fff43281337fdaa2a79a1da2d2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

