### PR TITLE
feat(interactive): favorites-first /model search, stable ordering, and a real relevance fix

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,17 @@
 
 ### Changed
 
+- Changed `/model` search ranking to a model-aware scorer that matches query tokens against the model id, name,
+  provider, and `provider/id` independently instead of one concatenated string. Exact, whole-token, and
+  word-boundary matches now beat scattered subsequence matches, so `opus 5` ranks `claude-opus-5` first and an exact
+  `provider/id` query still outranks proxy providers that merely reuse the id. Favorite models are ranked above
+  non-favorites in `/model` search results, with relevance preserved inside each group.
+
 ### Fixed
+
+- Fixed the model rows jumping while toggling favorites. `/model` and `/favorite-models` now freeze their row order
+  when the screen opens: toggling a favorite only updates the `*` marker, and the order is recomputed the next time
+  the screen is opened. Explicit reorder keys still move rows immediately.
 
 - Fixed config reloads discarding live terminal monitor and background-bash snapshots before Goal continuation
   scheduling. Fresh Goal instances now retain Terminal's pre-start replay, while later same-instance session starts

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,14 @@
 # changes
 
+## model selector search ranking and frozen ordering
+
+- Added `src/modes/interactive/model-search-rank.ts` so model search ranks each query token against the independent fields `id`, `name`, `provider`, and `provider/id` through a tier ladder (exact, whole token, boundary substring, substring, then `fuzzyMatch` as a last resort), with a canonical provider-path check and a favorites-first partition ahead of the relevance costs in the composite sort key.
+- Changed `src/modes/interactive/components/model-selector.ts` so `/model` search ranks through `rankModelSearchItems` with favorites-first partitioning in the all-models scope, and so both the base sort and the search partition read a favorite-ids snapshot taken when the selector opens; a `Ctrl+F` toggle updates only the favorite marker and no longer re-sorts rows mid-session.
+- Changed `src/modes/interactive/components/favorite-models-selector.ts` so `/favorite-models` row order is frozen at screen open (a `displayIds` snapshot), favoriting or unfavoriting flips only the marker, explicit reorder keys mirror-swap the snapshot so rows still visibly move, and search ranks through the same module without a favorites partition.
+- Why: user-reported UX bugs. Unfavoriting a row made the whole list jump under the cursor, and the query `opus` ranked `claude-sonnet-4-5` above `claude-opus-5` because the old concatenated-string `fuzzyFilter` let a greedy subsequence match scattered letters across "anthropic…claude…sonnet" and score better than the literal word in the opus id.
+- This was changed in core UI because the selector components and their ranking are internal `InteractiveMode` behavior; no extension hook can replace selector search ranking or row ordering without reimplementing the built-in selectors.
+- Expected merge-conflict zone on upstream sync: `src/modes/interactive/components/model-selector.ts` and `favorite-models-selector.ts` (extending the zone already declared by the favorite model cycling entry), plus `src/modes/interactive/model-search.ts` and the new `src/modes/interactive/model-search-rank.ts`.
+
 ## Server fallback abort uses one TUI notice (2026-08-05)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/favorite-models-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/favorite-models-selector.ts
@@ -2,7 +2,6 @@ import { type Model, modelsAreEqual } from "@earendil-works/pi-ai";
 import {
 	Container,
 	type Focusable,
-	fuzzyFilter,
 	getKeybindings,
 	Input,
 	Key,
@@ -10,7 +9,7 @@ import {
 	Spacer,
 	Text,
 } from "@earendil-works/pi-tui";
-import { getModelSearchText } from "../model-search.ts";
+import { rankModelSearchItems } from "../model-search-rank.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyText } from "./keybinding-hints.ts";
@@ -54,6 +53,8 @@ export class FavoriteModelsSelectorComponent extends Container implements Focusa
 	private modelsById: Map<string, Model<any>> = new Map();
 	private allIds: string[] = [];
 	private favoriteIds: FavoriteModelIds = null;
+	/** Row order frozen at construction; membership toggles never move rows, only reorder keys do. */
+	private displayIds: string[] = [];
 	private filteredItems: ModelItem[] = [];
 	private selectedIndex = 0;
 	private searchInput: Input;
@@ -87,6 +88,7 @@ export class FavoriteModelsSelectorComponent extends Container implements Focusa
 		}
 
 		this.favoriteIds = config.favoriteModelIds === null ? null : [...config.favoriteModelIds];
+		this.displayIds = getSortedFavoriteModelIds(this.favoriteIds, this.allIds);
 		this.filteredItems = this.buildItems();
 
 		// Header
@@ -126,9 +128,10 @@ export class FavoriteModelsSelectorComponent extends Container implements Focusa
 	}
 
 	private buildItems(): ModelItem[] {
-		// Filter out IDs that no longer have a corresponding model (e.g., after logout)
+		// Filter out IDs that no longer have a corresponding model (e.g., after logout).
+		// Iterates the frozen displayIds snapshot; the favorite flag reads live membership.
 		const items: ModelItem[] = [];
-		for (const id of getSortedFavoriteModelIds(this.favoriteIds, this.allIds)) {
+		for (const id of this.displayIds) {
 			const model = this.modelsById.get(id);
 			if (!model) continue;
 			items.push({
@@ -169,17 +172,30 @@ export class FavoriteModelsSelectorComponent extends Container implements Focusa
 		const query = this.searchInput.getValue();
 		const selectedId = preferredSelectedId ?? this.filteredItems[this.selectedIndex]?.fullId;
 		const items = this.buildItems();
-		this.filteredItems = query
-			? fuzzyFilter(items, query, (i) =>
-					getModelSearchText({ id: i.model.id, provider: i.model.provider, name: i.model.name }),
-				)
-			: items;
+		// Management surface: relevance ranking without a favorites partition (empty query keeps base order).
+		this.filteredItems = rankModelSearchItems(
+			items,
+			query,
+			(i) => ({ id: i.model.id, provider: i.model.provider, name: i.model.name }),
+			{ favoritesFirst: false, isFavorite: () => false },
+		);
 		const selectedIndex = selectedId ? this.filteredItems.findIndex((item) => item.fullId === selectedId) : -1;
 		this.selectedIndex =
 			selectedIndex >= 0 ? selectedIndex : Math.min(this.selectedIndex, Math.max(0, this.filteredItems.length - 1));
 		this.updateList();
 		this.footerText.setText(this.getFooterText());
 		this.secondaryFooterText.setText(this.getSecondaryFooterText());
+	}
+
+	/** Mirror a favoriteIds reorder swap onto the frozen display order so the row visibly moves. */
+	private swapDisplayIds(firstId: string, secondId: string): void {
+		const firstIndex = this.displayIds.indexOf(firstId);
+		const secondIndex = this.displayIds.indexOf(secondId);
+		if (firstIndex < 0 || secondIndex < 0) return;
+		[this.displayIds[firstIndex], this.displayIds[secondIndex]] = [
+			this.displayIds[secondIndex],
+			this.displayIds[firstIndex],
+		];
 	}
 
 	private notifyChange(): void {
@@ -259,7 +275,9 @@ export class FavoriteModelsSelectorComponent extends Container implements Focusa
 				const newIndex = currentIndex + delta;
 				// Only move if within bounds
 				if (newIndex >= 0 && newIndex < this.favoriteIds.length) {
+					const displacedId = this.favoriteIds[newIndex];
 					this.favoriteIds = moveFavoriteModel(this.favoriteIds, item.fullId, delta);
+					this.swapDisplayIds(item.fullId, displacedId);
 					this.isDirty = true;
 					this.selectedIndex += delta;
 					this.refresh(item.fullId);

--- a/packages/coding-agent/src/modes/interactive/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-selector.ts
@@ -1,18 +1,9 @@
 import { type Model, modelsAreEqual } from "@earendil-works/pi-ai";
-import {
-	Container,
-	type Focusable,
-	fuzzyFilter,
-	getKeybindings,
-	Input,
-	Spacer,
-	Text,
-	type TUI,
-} from "@earendil-works/pi-tui";
+import { Container, type Focusable, getKeybindings, Input, Spacer, Text, type TUI } from "@earendil-works/pi-tui";
 import { ModelRegistry } from "../../../core/model-registry.ts";
 import type { ModelRuntime } from "../../../core/model-runtime.ts";
 import type { SettingsManager } from "../../../core/settings-manager.ts";
-import { getModelSelectorSearchText } from "../model-search.ts";
+import { rankModelSearchItems } from "../model-search-rank.ts";
 import { theme } from "../theme/theme.ts";
 import { DynamicBorder } from "./dynamic-border.ts";
 import { keyHint } from "./keybinding-hints.ts";
@@ -70,6 +61,10 @@ export class ModelSelectorComponent extends Container implements Focusable {
 	private onSelectCallback: (model: Model<any>) => void;
 	private onCancelCallback: () => void;
 	private favoriteIds: FavoriteModelIds = [];
+	// Favorite membership snapshot taken when the selector opens. Ordering
+	// (base sort and search partition) is frozen against this basis for the
+	// whole session; live `favoriteIds` only drives markers and callbacks.
+	private readonly favoriteIdsAtOpen: FavoriteModelIds;
 	private onFavoriteChangeCallback?: ModelSelectorFavoriteOptions["onFavoriteChange"];
 	private errorMessage?: string;
 	private refreshStatusMessage = "Refreshing model catalogs…";
@@ -105,6 +100,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
 		this.onSelectCallback = onSelect;
 		this.onCancelCallback = onCancel;
 		this.favoriteIds = favorites?.favoriteModelIds === null ? null : [...(favorites?.favoriteModelIds ?? [])];
+		this.favoriteIdsAtOpen = this.favoriteIds === null ? null : [...this.favoriteIds];
 		this.onFavoriteChangeCallback = favorites?.onFavoriteChange;
 
 		// Add top border
@@ -246,8 +242,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 			const bIsCurrent = modelsAreEqual(this.currentModel, b.model);
 			if (aIsCurrent && !bIsCurrent) return -1;
 			if (!aIsCurrent && bIsCurrent) return 1;
-			const aIsFavorite = isFavoriteModel(this.favoriteIds, a.fullId);
-			const bIsFavorite = isFavoriteModel(this.favoriteIds, b.fullId);
+			const aIsFavorite = isFavoriteModel(this.favoriteIdsAtOpen, a.fullId);
+			const bIsFavorite = isFavoriteModel(this.favoriteIdsAtOpen, b.fullId);
 			if (aIsFavorite && !bIsFavorite) return -1;
 			if (!aIsFavorite && bIsFavorite) return 1;
 			const providerCompare = a.provider.localeCompare(b.provider);
@@ -281,8 +277,14 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 	private filterModels(query: string): void {
 		this.filteredModels = query
-			? fuzzyFilter(this.activeModels, query, ({ id, provider, model }) =>
-					getModelSelectorSearchText({ id, provider, name: model.name }),
+			? rankModelSearchItems(
+					this.activeModels,
+					query,
+					({ id, provider, model }) => ({ id, provider, name: model.name }),
+					{
+						favoritesFirst: this.scope === "all",
+						isFavorite: (item) => isFavoriteModel(this.favoriteIdsAtOpen, item.fullId),
+					},
 				)
 			: this.activeModels;
 		// When filtering by a query, move the selector to the top row so the best
@@ -418,8 +420,8 @@ export class ModelSelectorComponent extends Container implements Focusable {
 
 		const allModelIds = this.allModels.map((model) => model.fullId);
 		this.favoriteIds = toggleFavoriteModel(this.favoriteIds, allModelIds, selectedModel.fullId);
-		this.allModels = this.sortModels(this.allModels);
-		this.activeModels = this.scope === "narrowed" ? this.scopedModelItems : this.allModels;
+		// Row order is frozen for the session: no re-sort here. The marker
+		// re-renders from live favoriteIds via filterModels/updateList.
 		this.filterModels(this.searchInput.getValue());
 		const selectedIndex = this.filteredModels.findIndex((item) => item.fullId === selectedModel.fullId);
 		if (selectedIndex >= 0) {

--- a/packages/coding-agent/src/modes/interactive/model-search-rank.ts
+++ b/packages/coding-agent/src/modes/interactive/model-search-rank.ts
@@ -1,0 +1,247 @@
+/**
+ * Favorites-aware relevance ranking for model search.
+ *
+ * Implements .omo/drafts/model-selector-favorites-search-ux-ranking-spec.md:
+ * dual query token plans (compound keeps slashes, legacy splits them), a
+ * per-token tier ladder over independently matched lowercased fields,
+ * worst-tier-first aggregation, and a composite sort key whose canonical
+ * provider-path and favorites partitions precede all relevance costs.
+ */
+import { fuzzyMatch } from "@earendil-works/pi-tui";
+import type { ModelSearchItem } from "./model-search.ts";
+
+type FieldName = "id" | "name" | "provider" | "providerId";
+
+const FIELD_NAMES: readonly FieldName[] = ["id", "name", "provider", "providerId"];
+
+/** Exact tier: provider/id < id < provider < name (direct provider/id beats proxy id). */
+const EXACT_FIELD_WEIGHTS: Record<FieldName, number> = { providerId: 0, id: 1, provider: 2, name: 3 };
+/** Tiers 1-4: id < name < provider < provider/id. */
+const RANKED_FIELD_WEIGHTS: Record<FieldName, number> = { id: 0, name: 1, provider: 2, providerId: 3 };
+
+interface FieldMatch {
+	tier: number;
+	occurrenceStart: number;
+	fuzzyScore: number;
+}
+
+interface TokenMatch {
+	tier: number;
+	fieldWeight: number;
+	/** fuzzyScore for tier 4, occurrenceStart otherwise. */
+	cost: number;
+}
+
+interface PlanScore {
+	fuzzyCount: number;
+	substringCount: number;
+	boundarySubstringCount: number;
+	wholeTokenCount: number;
+	fieldCost: number;
+	fuzzyCost: number;
+	positionCost: number;
+}
+
+export interface RankModelSearchOptions<T> {
+	/** When true, favorite matches partition above non-favorites (relevance preserved within each partition). */
+	favoritesFirst: boolean;
+	/** Callers with a null favorite-ids sentinel return true for all items, making the partition a no-op. */
+	isFavorite: (item: T) => boolean;
+}
+
+function isAlphanumeric(char: string | undefined): boolean {
+	if (!char) {
+		return false;
+	}
+	const code = char.charCodeAt(0);
+	return (code >= 97 && code <= 122) || (code >= 48 && code <= 57);
+}
+
+/** Best tier for a token inside one field; multiple occurrences pick best tier, then earliest. */
+function matchField(token: string, field: string): FieldMatch | null {
+	if (field.length === 0) {
+		return null;
+	}
+	if (field === token) {
+		return { tier: 0, occurrenceStart: 0, fuzzyScore: 0 };
+	}
+	let best: FieldMatch | null = null;
+	let index = field.indexOf(token);
+	while (index !== -1) {
+		const leftBoundary = index === 0 || !isAlphanumeric(field[index - 1]);
+		const end = index + token.length;
+		const rightBoundary = end === field.length || !isAlphanumeric(field[end]);
+		const tier = leftBoundary && rightBoundary ? 1 : leftBoundary || rightBoundary ? 2 : 3;
+		if (!best || tier < best.tier) {
+			best = { tier, occurrenceStart: index, fuzzyScore: 0 };
+		}
+		index = field.indexOf(token, index + 1);
+	}
+	if (best) {
+		return best;
+	}
+	const fuzzy = fuzzyMatch(token, field);
+	return fuzzy.matches ? { tier: 4, occurrenceStart: 0, fuzzyScore: fuzzy.score } : null;
+}
+
+function compareTokenMatches(a: TokenMatch, b: TokenMatch): number {
+	return a.tier - b.tier || a.fieldWeight - b.fieldWeight || a.cost - b.cost;
+}
+
+/** Token's best field by [tier, fieldWeight, tier === 4 ? fuzzyScore : occurrenceStart]. */
+function matchToken(token: string, fields: Record<FieldName, string>): TokenMatch | null {
+	let best: TokenMatch | null = null;
+	for (const fieldName of FIELD_NAMES) {
+		const match = matchField(token, fields[fieldName]);
+		if (!match) {
+			continue;
+		}
+		const fieldWeight = match.tier === 0 ? EXACT_FIELD_WEIGHTS[fieldName] : RANKED_FIELD_WEIGHTS[fieldName];
+		const candidate: TokenMatch = {
+			tier: match.tier,
+			fieldWeight,
+			cost: match.tier === 4 ? match.fuzzyScore : match.occurrenceStart,
+		};
+		if (!best || compareTokenMatches(candidate, best) < 0) {
+			best = candidate;
+		}
+	}
+	return best;
+}
+
+/** Aggregate a plan's token matches worst-tier-first; null if any token matches no field. */
+function scorePlan(tokens: string[], fields: Record<FieldName, string>): PlanScore | null {
+	const score: PlanScore = {
+		fuzzyCount: 0,
+		substringCount: 0,
+		boundarySubstringCount: 0,
+		wholeTokenCount: 0,
+		fieldCost: 0,
+		fuzzyCost: 0,
+		positionCost: 0,
+	};
+	for (const token of tokens) {
+		const match = matchToken(token, fields);
+		if (!match) {
+			return null;
+		}
+		if (match.tier === 4) {
+			score.fuzzyCount += 1;
+			score.fuzzyCost += match.cost;
+		} else if (match.tier === 3) {
+			score.substringCount += 1;
+			score.positionCost += match.cost;
+		} else if (match.tier === 2) {
+			score.boundarySubstringCount += 1;
+			score.positionCost += match.cost;
+		} else if (match.tier === 1) {
+			score.wholeTokenCount += 1;
+			score.positionCost += match.cost;
+		} else {
+			score.positionCost += match.cost;
+		}
+		score.fieldCost += match.fieldWeight;
+	}
+	return score;
+}
+
+const PLAN_SCORE_KEYS = [
+	"fuzzyCount",
+	"substringCount",
+	"boundarySubstringCount",
+	"wholeTokenCount",
+	"fieldCost",
+	"fuzzyCost",
+	"positionCost",
+] as const;
+
+function comparePlanScores(a: PlanScore, b: PlanScore): number {
+	for (const key of PLAN_SCORE_KEYS) {
+		const diff = a[key] - b[key];
+		if (diff !== 0) {
+			return diff;
+		}
+	}
+	return 0;
+}
+
+function compareKeys(a: readonly number[], b: readonly number[]): number {
+	for (let i = 0; i < a.length && i < b.length; i++) {
+		const diff = a[i]! - b[i]!;
+		if (diff !== 0) {
+			return diff;
+		}
+	}
+	return a.length - b.length;
+}
+
+function sameTokens(a: readonly string[], b: readonly string[]): boolean {
+	return a.length === b.length && a.every((token, index) => token === b[index]);
+}
+
+/**
+ * Filter and rank items by search relevance, optionally partitioning favorites first.
+ * Empty trimmed query returns the input unchanged (caller base order is authoritative).
+ */
+export function rankModelSearchItems<T>(
+	items: T[],
+	query: string,
+	getModel: (item: T) => ModelSearchItem,
+	options: RankModelSearchOptions<T>,
+): T[] {
+	const normalizedQuery = query
+		.trim()
+		.toLowerCase()
+		.replace(/\s*\/\s*/g, "/");
+	if (!normalizedQuery) {
+		return items;
+	}
+
+	const compoundTokens = normalizedQuery.split(/\s+/).filter((token) => token.length > 0);
+	const legacyTokens = normalizedQuery.split(/[\s/]+/).filter((token) => token.length > 0);
+	const plans = sameTokens(compoundTokens, legacyTokens) ? [compoundTokens] : [compoundTokens, legacyTokens];
+
+	const ranked: { item: T; key: number[] }[] = [];
+	for (let index = 0; index < items.length; index++) {
+		const item = items[index]!;
+		const model = getModel(item);
+		const id = model.id.toLowerCase();
+		const provider = model.provider.toLowerCase();
+		const fields: Record<FieldName, string> = {
+			id,
+			name: (model.name ?? "").toLowerCase(),
+			provider,
+			providerId: `${provider}/${id}`,
+		};
+		let bestPlan: PlanScore | null = null;
+		for (const plan of plans) {
+			const score = scorePlan(plan, fields);
+			if (score && (!bestPlan || comparePlanScores(score, bestPlan) < 0)) {
+				bestPlan = score;
+			}
+		}
+		if (!bestPlan) {
+			continue;
+		}
+		const canonicalProviderPathMiss = normalizedQuery === fields.providerId ? 0 : 1;
+		const favoritePartition = options.favoritesFirst ? (options.isFavorite(item) ? 0 : 1) : 0;
+		ranked.push({
+			item,
+			key: [
+				canonicalProviderPathMiss,
+				favoritePartition,
+				bestPlan.fuzzyCount,
+				bestPlan.substringCount,
+				bestPlan.boundarySubstringCount,
+				bestPlan.wholeTokenCount,
+				bestPlan.fieldCost,
+				bestPlan.fuzzyCost,
+				bestPlan.positionCost,
+				id.length,
+				index,
+			],
+		});
+	}
+	ranked.sort((a, b) => compareKeys(a.key, b.key));
+	return ranked.map((entry) => entry.item);
+}

--- a/packages/coding-agent/src/modes/interactive/model-search.ts
+++ b/packages/coding-agent/src/modes/interactive/model-search.ts
@@ -9,13 +9,3 @@ export function getModelSearchText(item: ModelSearchItem): string {
 	const name = item.name ? ` ${item.name}` : "";
 	return `${id} ${provider} ${provider}/${id} ${provider} ${id}${name}`;
 }
-
-/**
- * The /model selector search should rank exact provider-prefixed queries before proxy-provider IDs
- * like openrouter/openai/gpt-5, so keep the bare model ID out of the leading position.
- */
-export function getModelSelectorSearchText(item: ModelSearchItem): string {
-	const { id, provider } = item;
-	const name = item.name ? ` ${item.name}` : "";
-	return `${provider} ${provider}/${id} ${provider} ${id}${name}`;
-}

--- a/packages/coding-agent/test/favorite-models-frozen-order.test.ts
+++ b/packages/coding-agent/test/favorite-models-frozen-order.test.ts
@@ -1,0 +1,163 @@
+import { setKeybindings } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { KeybindingsManager } from "../src/core/keybindings.ts";
+import { FavoriteModelsSelectorComponent } from "../src/modes/interactive/components/favorite-models-selector.ts";
+import type { FavoriteModelIds } from "../src/modes/interactive/components/model-favorites.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+interface RenderedRow {
+	selected: boolean;
+	favorite: boolean;
+	id: string;
+}
+
+function parseRenderedRows(selector: FavoriteModelsSelectorComponent, provider: string): RenderedRow[] {
+	return stripAnsi(selector.render(120).join("\n"))
+		.split("\n")
+		.filter((line) => line.includes(`[${provider}]`))
+		.map((line) => {
+			const trimmed = line.trim();
+			const selected = trimmed.startsWith("→");
+			const body = selected ? trimmed.replace(/^→\s*/, "") : trimmed;
+			const favorite = body.startsWith("*");
+			const id = body.slice(1).trim().split(" [")[0]?.trim() ?? "";
+			return { selected, favorite, id };
+		});
+}
+
+function createSelector(
+	harness: Harness,
+	favoriteModelIds: FavoriteModelIds,
+	changes: Array<string[] | null>,
+): FavoriteModelsSelectorComponent {
+	return new FavoriteModelsSelectorComponent(
+		{
+			allModels: [...harness.models],
+			favoriteModelIds,
+		},
+		{
+			onChange: (nextFavoriteIds) => {
+				changes.push(nextFavoriteIds);
+			},
+			onPersist: () => {},
+			onSelect: () => {},
+			onCancel: () => {},
+		},
+	);
+}
+
+describe("favorite models frozen order", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		// Ensure test isolation: keybindings are a global singleton
+		setKeybindings(new KeybindingsManager());
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	async function createThreeModelHarness(): Promise<{ harness: Harness; ids: string[]; provider: string }> {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", reasoning: true },
+				{ id: "faux-2", name: "Two", reasoning: true },
+				{ id: "faux-3", name: "Three", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const provider = harness.models[0]?.provider ?? "faux";
+		const ids = harness.models.map((model) => `${model.provider}/${model.id}`);
+		return { harness, ids, provider };
+	}
+
+	it("freezes row order when unfavoriting a middle row, flipping only the marker", async () => {
+		const { harness, ids, provider } = await createThreeModelHarness();
+		const changes: Array<string[] | null> = [];
+		const selector = createSelector(harness, [...ids], changes);
+
+		selector.handleInput("\x1b[B"); // select the middle row
+		selector.handleInput("\x06"); // Ctrl+F: unfavorite it
+
+		const rows = parseRenderedRows(selector, provider);
+		expect(rows.map((row) => row.id)).toEqual(["faux-1", "faux-2", "faux-3"]);
+		expect(rows[1]).toMatchObject({ selected: true, favorite: false, id: "faux-2" });
+		expect(changes).toEqual([[ids[0], ids[2]]]);
+	});
+
+	it("keeps frozen order when re-favoriting, appending the id last in the change payload", async () => {
+		const { harness, ids, provider } = await createThreeModelHarness();
+		const changes: Array<string[] | null> = [];
+		const selector = createSelector(harness, [...ids], changes);
+
+		selector.handleInput("\x1b[B"); // select the middle row
+		selector.handleInput("\x06"); // Ctrl+F: unfavorite it
+		selector.handleInput("\x06"); // Ctrl+F: re-favorite it
+
+		const rows = parseRenderedRows(selector, provider);
+		expect(rows.map((row) => row.id)).toEqual(["faux-1", "faux-2", "faux-3"]);
+		expect(rows[1]).toMatchObject({ selected: true, favorite: true, id: "faux-2" });
+		expect(changes).toEqual([
+			[ids[0], ids[2]],
+			[ids[0], ids[2], ids[1]],
+		]);
+	});
+
+	it("still swaps rendered rows with reorder keys and emits the scoped order payload", async () => {
+		const { harness, ids, provider } = await createThreeModelHarness();
+		const changes: Array<string[] | null> = [];
+		const selector = createSelector(harness, [...ids], changes);
+
+		selector.handleInput("\x1b[1;3B"); // Alt+Down: move the first row down
+
+		const rows = parseRenderedRows(selector, provider);
+		expect(rows.map((row) => row.id)).toEqual(["faux-2", "faux-1", "faux-3"]);
+		expect(rows[1]).toMatchObject({ selected: true, favorite: true, id: "faux-1" });
+		expect(changes).toEqual([[ids[1], ids[0], ids[2]]]);
+	});
+
+	it("reflects the new membership order when reopened with mutated favorite ids", async () => {
+		const { harness, ids, provider } = await createThreeModelHarness();
+		const changes: Array<string[] | null> = [];
+		const selector = createSelector(harness, [...ids], changes);
+
+		selector.handleInput("\x1b[B"); // select the middle row
+		selector.handleInput("\x06"); // Ctrl+F: unfavorite it
+		const mutated = changes[changes.length - 1] ?? null;
+
+		const reopened = createSelector(harness, mutated === null ? null : [...mutated], []);
+		const rows = parseRenderedRows(reopened, provider);
+		expect(rows.map((row) => row.id)).toEqual(["faux-1", "faux-3", "faux-2"]);
+		expect(rows.map((row) => row.favorite)).toEqual([true, true, false]);
+	});
+
+	it("still matches the canonical provider/id recall query from issue #3217", async () => {
+		const harness = await createHarness({
+			provider: "openai",
+			models: [
+				{ id: "gpt-5-4-mini-fast", name: "GPT 5.4 Mini Fast", reasoning: true },
+				{ id: "gpt-5.4", name: "GPT 5.4", reasoning: true },
+				{ id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const selector = createSelector(harness, null, []);
+
+		for (const char of "openai/gpt 5 4 mini fast") {
+			selector.handleInput(char);
+		}
+
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		expect(rendered).toContain("gpt-5-4-mini-fast [openai]");
+		expect(rendered).not.toContain("claude-sonnet-4-5");
+	});
+});

--- a/packages/coding-agent/test/model-search-rank.test.ts
+++ b/packages/coding-agent/test/model-search-rank.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { rankModelSearchItems } from "../src/modes/interactive/model-search-rank.ts";
+
+interface FixtureModel {
+	provider: string;
+	id: string;
+	name?: string;
+}
+
+function fullId(model: FixtureModel): string {
+	return `${model.provider}/${model.id}`;
+}
+
+function rankIds(
+	models: FixtureModel[],
+	query: string,
+	options?: { favoritesFirst?: boolean; favorites?: string[] },
+): string[] {
+	const favorites = new Set(options?.favorites ?? []);
+	const ranked = rankModelSearchItems(models, query, (model) => model, {
+		favoritesFirst: options?.favoritesFirst ?? false,
+		isFavorite: (model) => favorites.has(fullId(model)),
+	});
+	return ranked.map(fullId);
+}
+
+/**
+ * Pinned 16-model fixture catalog from the plan's grounding simulation
+ * (.omo/plans/model-selector-favorites-search-ux.md, todo 1).
+ */
+const PINNED_CATALOG: FixtureModel[] = [
+	{ provider: "anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
+	{ provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+	{ provider: "anthropic", id: "claude-opus-4-1", name: "Claude Opus 4.1" },
+	{ provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+	{ provider: "anthropic", id: "claude-fable-5", name: "Claude Fable 5" },
+	{ provider: "openrouter", id: "anthropic/claude-opus-5", name: "Anthropic: Claude Opus 5" },
+	{ provider: "openrouter", id: "anthropic/claude-opus-4.5", name: "Anthropic: Claude Opus 4.5" },
+	{ provider: "openrouter", id: "openai/gpt-5.2", name: "OpenAI: GPT-5.2" },
+	{ provider: "quotio-anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
+	{ provider: "quotio-openai", id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },
+	{ provider: "openai", id: "gpt-5.2", name: "GPT-5.2" },
+	{ provider: "openai", id: "gpt-5.6-sol", name: "GPT-5.6 Sol" },
+	{ provider: "openai", id: "gpt-5-4-mini-fast", name: "GPT 5.4 Mini Fast" },
+	{ provider: "google", id: "gemini-3-pro-preview", name: "Gemini 3 Pro Preview" },
+	{ provider: "zai", id: "glm-5.2", name: "GLM-5.2" },
+	{ provider: "groq", id: "moonshotai/kimi-k3", name: "Kimi K3" },
+];
+
+describe("rankModelSearchItems spec cases", () => {
+	it("spec 1: 'opus 5' ranks anthropic/claude-opus-5 over 4-5, proxy, and open-pulse-5", () => {
+		const models: FixtureModel[] = [
+			{ provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+			{ provider: "openrouter", id: "anthropic/claude-opus-5", name: "Anthropic: Claude Opus 5" },
+			{ provider: "anthropic", id: "open-pulse-5", name: "Open Pulse 5" },
+			{ provider: "anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
+		];
+		expect(rankIds(models, "opus 5")).toEqual([
+			"anthropic/claude-opus-5",
+			"anthropic/claude-opus-4-5",
+			"openrouter/anthropic/claude-opus-5",
+			"anthropic/open-pulse-5",
+		]);
+	});
+
+	it("spec 2: 'anthropic/claude-opus-5' ranks the direct provider over the openrouter proxy", () => {
+		const models: FixtureModel[] = [
+			{ provider: "openrouter", id: "anthropic/claude-opus-5", name: "Anthropic: Claude Opus 5" },
+			{ provider: "anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
+		];
+		expect(rankIds(models, "anthropic/claude-opus-5")).toEqual([
+			"anthropic/claude-opus-5",
+			"openrouter/anthropic/claude-opus-5",
+		]);
+	});
+
+	it("spec 3: 'openrouter opus' matches only the openrouter proxy", () => {
+		const models: FixtureModel[] = [
+			{ provider: "anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
+			{ provider: "openrouter", id: "anthropic/claude-opus-5", name: "Anthropic: Claude Opus 5" },
+		];
+		expect(rankIds(models, "openrouter opus")).toEqual(["openrouter/anthropic/claude-opus-5"]);
+	});
+
+	it("spec 4: 'opus5' keeps alphanumeric-swap recall for claude-5-opus over claude-sonnet-5", () => {
+		const models: FixtureModel[] = [
+			{ provider: "anthropic", id: "claude-sonnet-5", name: "Claude Sonnet 5" },
+			{ provider: "anthropic", id: "claude-5-opus", name: "Claude 5 Opus" },
+		];
+		expect(rankIds(models, "opus5")).toEqual(["anthropic/claude-5-opus", "anthropic/claude-sonnet-5"]);
+	});
+
+	it("spec 5: 'gpt5' ranks gpt-5 over gpt-4.5", () => {
+		const models: FixtureModel[] = [
+			{ provider: "openai", id: "gpt-4.5", name: "GPT-4.5" },
+			{ provider: "openai", id: "gpt-5", name: "GPT-5" },
+		];
+		expect(rankIds(models, "gpt5")).toEqual(["openai/gpt-5", "openai/gpt-4.5"]);
+	});
+
+	it("spec 6: 'openai/gpt 5 4 mini fast' recalls gpt-5-4-mini-fast", () => {
+		const models: FixtureModel[] = [
+			{ provider: "openai", id: "gpt-5-4-mini-fast", name: "GPT 5.4 Mini Fast" },
+			{ provider: "openai", id: "gpt-5.4", name: "GPT 5.4" },
+			{ provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+		];
+		expect(rankIds(models, "openai/gpt 5 4 mini fast")).toEqual(["openai/gpt-5-4-mini-fast"]);
+	});
+
+	it("spec 7: 'opus' exact id x/opus beats whole-token claude-opus-5", () => {
+		const models: FixtureModel[] = [
+			{ provider: "anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
+			{ provider: "x", id: "opus" },
+		];
+		expect(rankIds(models, "opus")).toEqual(["x/opus", "anthropic/claude-opus-5"]);
+	});
+
+	it("spec 8: 'opus' whole-token claude-opus-5 beats boundary-substring opusmax", () => {
+		const models: FixtureModel[] = [
+			{ provider: "zai", id: "opusmax", name: "OpusMax" },
+			{ provider: "anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
+		];
+		expect(rankIds(models, "opus")).toEqual(["anthropic/claude-opus-5", "zai/opusmax"]);
+	});
+
+	it("spec 9: 'opus' boundary-substring opusmax beats substring myopusmodel", () => {
+		const models: FixtureModel[] = [
+			{ provider: "acme", id: "myopusmodel" },
+			{ provider: "zai", id: "opusmax" },
+		];
+		expect(rankIds(models, "opus")).toEqual(["zai/opusmax", "acme/myopusmodel"]);
+	});
+
+	it("spec 10: 'opus' substring myopusmodel beats fuzzy open-pulse", () => {
+		const models: FixtureModel[] = [
+			{ provider: "acme", id: "open-pulse" },
+			{ provider: "acme", id: "myopusmodel" },
+		];
+		expect(rankIds(models, "opus")).toEqual(["acme/myopusmodel", "acme/open-pulse"]);
+	});
+
+	it("spec 11: 'opus 5' favoritesFirst partitions a favorite above an equal non-favorite", () => {
+		const models: FixtureModel[] = [
+			{ provider: "alpha", id: "claude-opus-5", name: "Claude Opus 5" },
+			{ provider: "beta", id: "claude-opus-5", name: "Claude Opus 5" },
+		];
+		expect(rankIds(models, "opus 5", { favoritesFirst: true, favorites: ["beta/claude-opus-5"] })).toEqual([
+			"beta/claude-opus-5",
+			"alpha/claude-opus-5",
+		]);
+	});
+
+	it("spec 12: 'opus 5' with no favorites preserves input order on a full tie", () => {
+		const models: FixtureModel[] = [
+			{ provider: "alpha", id: "claude-opus-5", name: "Claude Opus 5" },
+			{ provider: "beta", id: "claude-opus-5", name: "Claude Opus 5" },
+		];
+		expect(rankIds(models, "opus 5", { favoritesFirst: true })).toEqual([
+			"alpha/claude-opus-5",
+			"beta/claude-opus-5",
+		]);
+	});
+});
+
+describe("rankModelSearchItems current-bug regressions (pinned 16-model catalog)", () => {
+	it("regression: 'opus' does not rank claude-sonnet-4-5 above claude-opus-5", () => {
+		const ranked = rankIds(PINNED_CATALOG, "opus");
+		expect(ranked).toContain("anthropic/claude-sonnet-4-5");
+		expect(ranked.indexOf("anthropic/claude-opus-5")).toBeLessThan(ranked.indexOf("anthropic/claude-sonnet-4-5"));
+	});
+
+	it("regression: 'opus 5' top-1 is anthropic/claude-opus-5", () => {
+		expect(rankIds(PINNED_CATALOG, "opus 5")[0]).toBe("anthropic/claude-opus-5");
+	});
+
+	it("regression: 'claude-opus-5' direct beats the openrouter proxy", () => {
+		const ranked = rankIds(PINNED_CATALOG, "claude-opus-5");
+		expect(ranked.indexOf("anthropic/claude-opus-5")).toBeLessThan(
+			ranked.indexOf("openrouter/anthropic/claude-opus-5"),
+		);
+	});
+
+	it("regression: 'anthropic opus' top-1 is anthropic/claude-opus-5", () => {
+		expect(rankIds(PINNED_CATALOG, "anthropic opus")[0]).toBe("anthropic/claude-opus-5");
+	});
+});
+
+describe("rankModelSearchItems query handling", () => {
+	it("returns the input unchanged for an empty query", () => {
+		const result = rankModelSearchItems(PINNED_CATALOG, "   ", (model) => model, {
+			favoritesFirst: true,
+			isFavorite: () => false,
+		});
+		expect(result).toBe(PINNED_CATALOG);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/model-selector-favorites-search.test.ts
+++ b/packages/coding-agent/test/suite/regressions/model-selector-favorites-search.test.ts
@@ -1,0 +1,224 @@
+import { setKeybindings, type TUI } from "@earendil-works/pi-tui";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { KeybindingsManager } from "../../../src/core/keybindings.ts";
+import { ModelSelectorComponent } from "../../../src/modes/interactive/components/model-selector.ts";
+import { initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../../../src/utils/ansi.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+function createFakeTui(): TUI {
+	return { requestRender: () => {} } as unknown as TUI;
+}
+
+/** Ordered model ids of the rendered list rows (rows carry a `[provider]` badge). */
+function listRowIds(rendered: string, provider: string): string[] {
+	return rendered
+		.split("\n")
+		.filter((line) => line.includes(`[${provider}]`))
+		.map(
+			(line) =>
+				line
+					.trim()
+					.replace(/^→\s*/, "")
+					.replace(/^\*\s*/, "")
+					.split(" [")[0]
+					?.trim() ?? "",
+		);
+}
+
+async function waitForRefresh(selector: ModelSelectorComponent): Promise<void> {
+	await vi.waitFor(() => {
+		expect(stripAnsi(selector.render(120).join("\n"))).toContain("Model catalogs refreshed.");
+	});
+}
+
+function typeQuery(selector: ModelSelectorComponent, query: string): void {
+	for (const char of query) {
+		selector.handleInput(char);
+	}
+}
+
+describe("model selector favorites-first search with frozen session ordering", () => {
+	const harnesses: Harness[] = [];
+
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		setKeybindings(new KeybindingsManager());
+	});
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	// Plan todo 2 case (i): a favorite and a non-favorite with identical relevance
+	// must order favorite-first. The current model is the non-favorite tie-partner,
+	// so it leads the base order and only the favorites partition can flip the
+	// result (relevance costs and id length tie; inputIndex never gets to decide).
+	it("ranks a favorite above the non-favorite current model when search relevance ties", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "opus-a", name: "Claude Opus 5", reasoning: true },
+				{ id: "opus-b", name: "Claude Opus 5", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const provider = harness.models[0].provider;
+		const current = harness.getModel("opus-a")!;
+
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			current,
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+			undefined,
+			{ favoriteModelIds: [`${provider}/opus-b`] },
+		);
+		await waitForRefresh(selector);
+
+		typeQuery(selector, "claude opus 5");
+
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		expect(listRowIds(rendered, provider)).toEqual(["opus-b", "opus-a"]);
+	});
+
+	// Plan todo 2 case (ii): Ctrl+F mid-session must not reorder rows; only the
+	// `*` marker changes. Without the fix the toggled row (omega-1) jumps above
+	// beta-1 because the list is re-sorted favorites-first on every toggle.
+	it("keeps row order frozen when toggling a favorite mid-session", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "alpha-1", name: "Alpha One", reasoning: true },
+				{ id: "beta-1", name: "Beta One", reasoning: true },
+				{ id: "omega-1", name: "Omega One", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const provider = harness.models[0].provider;
+		const current = harness.getModel("alpha-1")!;
+		const changes: Array<string[] | null> = [];
+
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			current,
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+			undefined,
+			{
+				favoriteModelIds: [],
+				onFavoriteChange: (favoriteModelIds) => {
+					changes.push(favoriteModelIds === null ? null : [...favoriteModelIds]);
+				},
+			},
+		);
+		await waitForRefresh(selector);
+
+		const before = stripAnsi(selector.render(120).join("\n"));
+		expect(listRowIds(before, provider)).toEqual(["alpha-1", "beta-1", "omega-1"]);
+		expect(before).not.toContain("* omega-1");
+
+		// Select omega-1 (bottom row) and favorite it with Ctrl+F.
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x06");
+
+		const after = stripAnsi(selector.render(120).join("\n"));
+		expect(listRowIds(after, provider)).toEqual(["alpha-1", "beta-1", "omega-1"]);
+		expect(after).toContain("* omega-1");
+		expect(changes).toEqual([[`${provider}/omega-1`]]);
+	});
+
+	// Plan todo 2 case (iii), search half: with the null all-favorite sentinel the
+	// partition is a no-op, so search order is pure relevance (the current model
+	// gets no favorites boost and loses to the more relevant row).
+	it("orders search by pure relevance when favoriteModelIds is null", async () => {
+		const harness = await createHarness({
+			provider: "anthropic",
+			models: [
+				{ id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", reasoning: true },
+				{ id: "claude-opus-5", name: "Claude Opus 5", reasoning: true },
+				{ id: "claude-fable-5", name: "Claude Fable 5", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const current = harness.getModel("claude-sonnet-4-5")!;
+
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			current,
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+			undefined,
+			{ favoriteModelIds: null },
+		);
+		await waitForRefresh(selector);
+
+		typeQuery(selector, "opus");
+
+		const rendered = stripAnsi(selector.render(120).join("\n"));
+		expect(listRowIds(rendered, "anthropic")).toEqual(["claude-opus-5", "claude-sonnet-4-5"]);
+		// Null sentinel: every row keeps the all-favorite marker.
+		expect(rendered).toContain("* claude-opus-5");
+		expect(rendered).toContain("* claude-sonnet-4-5");
+	});
+
+	// Plan todo 2 case (iii), toggle half: the first toggle materializes the null
+	// sentinel into an explicit list; rows must not reshuffle when that happens.
+	it("does not reshuffle rows on the first toggle from the null favorites sentinel", async () => {
+		const harness = await createHarness({
+			provider: "anthropic",
+			models: [
+				{ id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", reasoning: true },
+				{ id: "claude-opus-5", name: "Claude Opus 5", reasoning: true },
+				{ id: "claude-fable-5", name: "Claude Fable 5", reasoning: true },
+			],
+		});
+		harnesses.push(harness);
+		const current = harness.getModel("claude-sonnet-4-5")!;
+		const changes: Array<string[] | null> = [];
+
+		const selector = new ModelSelectorComponent(
+			createFakeTui(),
+			current,
+			harness.settingsManager,
+			harness.session.modelRuntime,
+			[],
+			() => {},
+			() => {},
+			undefined,
+			{
+				favoriteModelIds: null,
+				onFavoriteChange: (favoriteModelIds) => {
+					changes.push(favoriteModelIds === null ? null : [...favoriteModelIds]);
+				},
+			},
+		);
+		await waitForRefresh(selector);
+
+		const before = stripAnsi(selector.render(120).join("\n"));
+		expect(listRowIds(before, "anthropic")).toEqual(["claude-sonnet-4-5", "claude-fable-5", "claude-opus-5"]);
+		expect(before).toContain("* claude-fable-5");
+
+		// Unfavorite claude-fable-5 (middle row): null -> explicit list.
+		selector.handleInput("\x1b[B");
+		selector.handleInput("\x06");
+
+		const after = stripAnsi(selector.render(120).join("\n"));
+		expect(listRowIds(after, "anthropic")).toEqual(["claude-sonnet-4-5", "claude-fable-5", "claude-opus-5"]);
+		expect(after).not.toContain("* claude-fable-5");
+		expect(changes).toEqual([["anthropic/claude-sonnet-4-5", "anthropic/claude-opus-5"]]);
+	});
+});


### PR DESCRIPTION
## What & why

Three UX fixes for the interactive model selectors, all user-reported:

1. **`/model` search now ranks favorites first** — favorite models sort above non-favorites, with fuzzy relevance preserved inside each group.
2. **Toggling a favorite no longer reorders rows mid-session** — in both `/model` and `/favorite-models`, row order is frozen when the screen opens; toggling only flips the `*` marker, and the order is recomputed the next time you open the screen. Explicit reorder keys (`ctrl+↑/↓`) still move rows immediately.
3. **`opus 5` now ranks `claude-opus-5` first** — the search ranking was structurally broken.

### The search bug was real, not cosmetic

The old path concatenated `provider provider/id provider id name` into one string and ran a greedy first-subsequence fuzzy match over it. Measured against the real code before the fix:

| query | old #1 | why |
|---|---|---|
| `opus` | `claude-sonnet-4-5` | `op` in anthr**op**ic + `u` in cla**u**de + `s` in **s**onnet scored better than the literal word `opus` |
| `opus 5` | `claude-sonnet-4-5` | same scattered-match win |
| `claude-opus-5` (exact id) | `openrouter/anthropic/claude-opus-5` | proxy beat the direct provider, violating the documented intent in `model-search.ts` |

## How

New `model-search-rank.ts` (`rankModelSearchItems`) matches each query token **independently against the id, name, provider, and `provider/id`** — never a concatenated blob — with a strict priority ladder: exact field > whole token > boundary substring > substring > fuzzy-subsequence fallback. The fallback reuses the already-exported `fuzzyMatch`, so alphanumeric-swap recall (`opus5`, `gpt5`) is preserved. The composite sort key compares `canonicalProviderPathMiss` **before** the favorites partition, so an exact `provider/id` query can never be outranked by a favorited proxy.

`packages/tui/` is untouched — the shared `fuzzyFilter` keeps its exact current behavior for slash-command autocomplete, the session selector, settings list, and every other consumer.

## Verification

TDD throughout: a genuine RED was captured for each behavioral change *before* the production edit, then GREEN, then a mutation probe proving the tests actually fail when the fix is reverted.

- **37/37** tests green across 7 files, including the pre-existing `3217`, `7209`, `favorite-model-selection`, and `favorite-empty-state` suites — all unmodified.
- `npm run check` exit 0; changelog gate PASS.
- **Real-surface TUI QA** — the CLI driven from source in an isolated sandbox (never `~/.senpi`), captured via `tmux capture-pane -e` and asserted against the parsed cell grid with `scripts/qa/xterm-render.mjs`:

| scenario | asserted top row | proves |
|---|---|---|
| S1 `opus 5` | `→ * claude-opus-5 [qa-anthropic]` | ranking fix |
| S1 control `sonnet` | `→ * claude-sonnet-4-5` | harness exercises live ranking, not a static frame |
| S2 before → after `ctrl+f` | `→ * claude-opus-5` → `→   claude-opus-5` | marker flips, **row does not move** |
| S2b | favorite `[qa-quotio]` above non-favorite current model `[qa-anthropic] ✓` | identical ids, so **only** the favorites partition can produce this order |
| S3 before → toggle → reopen | `* opus-5` → `- opus-5` (same row) → `* sonnet-4-5` now row 1 | frozen during the session, recomputed on next entry |

All 8 grid assertions exit 0, and a negative control (asserting the post-toggle grid against the pre-toggle spec) correctly exits 1 — the assertions are falsifiable, not tautological. Teardown verified: no tmux session, no sandbox, no temp dirs left behind.

Plan: `.omo/plans/model-selector-favorites-search-ux.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the interactive model selectors with favorites-first ranking in `/model` search, stable row order while toggling favorites, and a true relevance fix so queries like "opus 5" rank `claude-opus-5` first and exact `provider/id` wins.

- **New Features**
  - `/model` search ranks favorites first; relevance is preserved within favorite/non-favorite groups.
  - New `rankModelSearchItems` scorer matches tokens against `id`, `name`, `provider`, and `provider/id` with strict priority: exact > whole token > boundary substring > substring > fuzzy; exact `provider/id` beats proxies and "opus5"/"gpt5" recall is preserved.
  - Stable ordering in `/model` and `/favorite-models`: toggling favorite only flips the `*` marker; rows don’t move until you reopen (explicit reorder keys still move rows immediately).
  - Other surfaces keep using `fuzzyFilter` in `@earendil-works/pi-tui`; behavior there is unchanged.

- **Refactors**
  - Removed `getModelSelectorSearchText` (unused after switching `/model` search to `rankModelSearchItems`); `getModelSearchText` stays for command autocomplete.

<sup>Written for commit 444f900d0b86ca054c7d273dc2ac01f7c4d7e5fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

