### PR TITLE
feat(coding-agent): provider-agnostic default fallback chain

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,17 @@
 
 ### Changed
 
+- Changed the shipped default model-fallback chain from a provider-pinned literal
+  (`anthropic/claude-fable-5` -> `apitopia/kimi-k3-unlocked:max`, `anthropic/claude-opus-5:xhigh`,
+  `anthropic/claude-opus-4-8:xhigh`) to provider-agnostic model families
+  (`claude-fable-5` -> `k3:max`, `claude-opus-5:xhigh`, `claude-opus-4-8:xhigh`) that expand against the live
+  model registry. Fable 5 now keeps a working fallback chain no matter which provider serves it - the builtin
+  Anthropic provider, the Claude SDK OAuth extension, a gateway, or Bedrock - instead of silently losing the
+  chain and leaving provider-side fallback aborted with nothing to fall back to. Bare selectors expand to
+  OAuth-credential providers first, then a fixed precedence order, and never to OpenRouter; explicit
+  `provider/model` chains keep exact behavior, and `retry.fallbackChains` accepts a bare model id as a
+  family-wide key with `[]` still opting out ([#761](https://github.com/code-yeongyu/senpi/pull/761)).
+
 ### Fixed
 
 - Fixed config reloads discarding live terminal monitor and background-bash snapshots before Goal continuation

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -247,7 +247,7 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
 
 #### Model fallback chains
 
-`retry.fallbackChains` maps one exact primary-model selector to an ordered list of fallback selectors. A selector is `provider/model` with an optional `:thinking-level` suffix. For example, this switches Fable 5 to Kimi K3 at `max` thinking when an eligible failure occurs:
+`retry.fallbackChains` maps a primary-model selector to an ordered list of fallback selectors. A selector is `provider/model` with an optional `:thinking-level` suffix, or a bare `model` id that applies to every provider serving that model family. Bare selectors expand against the models you actually have: providers holding an OAuth credential are preferred, then a fixed precedence order, and OpenRouter is never chosen by expansion. Senpi ships a bare default chain for `claude-fable-5`, so Fable 5 keeps a fallback chain whichever provider serves it; set that key to `[]` to opt out entirely, or set one `provider/claude-fable-5` key to override just that provider. For example, this switches Fable 5 to Kimi K3 at `max` thinking when an eligible failure occurs:
 
 ```json
 {

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -434,6 +434,49 @@
 - LOW: additive `core/provider-header-auth.ts`, `core/provider-api-key-auth.ts`, and focused regression coverage.
 - MEDIUM: `core/provider-composer.ts` auth composition and status projection.
 
+## Provider-agnostic default fallback chain via bare model-id families (2026-08-09)
+
+### What changed
+
+- `core/retry-fallback/expansion.ts` (new): conservative model-family matching (`id === bare ||
+  id.startsWith(bare + "-")` after stripping a `.`/`/` namespace, never a substring `includes`), per-provider
+  variant selection (exact id > shortest > alphabetical), and provider ranking for bare selectors: providers
+  holding an OAuth credential first, then the fixed table `[claude-sdk-oauth, anthropic, kimi-coding]`, then
+  alphabetical. `openrouter` / `openrouter-images` are excluded from bare expansion.
+- `core/retry-fallback/settings.ts`: the shipped default is now declared with bare model ids -
+  `{"claude-fable-5": ["k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"]}`. The previous literal
+  `anthropic/claude-fable-5 -> apitopia/kimi-k3-unlocked:max, ...` is gone, including the `apitopia` gateway id.
+  An empty entry list is no longer deleted at resolve time; it is preserved as a tombstone.
+- `core/retry-fallback/chains.ts`: `canonicalizeFallbackChains` expands bare keys into one canonical
+  `<provider>/<id>` key per serving provider and bare entries into a ranked, model-major candidate list.
+  Explicit provider-qualified keys are applied after expansion so they override it, and tombstones are honored
+  at both bare-family and canonical-provider granularity.
+- `core/retry-fallback/controller.ts`: the registry dep accepts an optional `isUsingOAuth(model)` so runtime
+  candidate selection ranks the same way the `/fallback` display does.
+- `core/retry-fallback/validate.ts`: a bare key naming a registered family is valid configuration; a bare key
+  matching nothing keeps the original "roles are unsupported" guidance.
+
+### Why
+
+- The default chain was keyed on the literal provider id `anthropic`. Fable 5 attached through any other
+  provider - the builtin `claude-sdk-oauth` extension (which mirrors the whole Anthropic catalog via
+  `getModels("anthropic")`), a gateway, or Bedrock's namespaced ids - never matched the key, so
+  `canonicalizeFallbackChains` dropped the chain, `hasConfiguredChain()` went false, and the default
+  `abortServerSideFallback: true` left the session with provider-side fallback blocked and no client chain:
+  the exact dead end the 2026-07-29 default was introduced to remove.
+- Ranking by auth tier also fixes same-account thrash: when both `claude-sdk-oauth` and `anthropic` serve
+  `claude-opus-5`, both now appear as candidates, so a dead account is skipped by cooldown and the live one
+  is used instead of exhausting the chain inside one account.
+- `apitopia/kimi-k3-unlocked` is a personal gateway id that should never have shipped as a product default.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `core/retry-fallback/expansion.ts` is additive and fork-local with no upstream counterpart.
+- LOW: the default chain literal in `core/retry-fallback/settings.ts`.
+- MEDIUM: `canonicalizeFallbackChains` in `core/retry-fallback/chains.ts` was restructured (two passes plus
+  tombstones) rather than edited in place.
+- LOW: the optional `isUsingOAuth` member on the controller registry dep.
+
 ## Anthropic credits_required 429 pins the billing fallback (2026-07-29)
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -455,6 +455,13 @@
   candidate selection ranks the same way the `/fallback` display does.
 - `core/retry-fallback/validate.ts`: a bare key naming a registered family is valid configuration; a bare key
   matching nothing keeps the original "roles are unsupported" guidance.
+- Bare candidates fan out to at most `MAX_PROVIDERS_PER_FAMILY` (2) providers, ranked by auth tier
+  (OAuth credential, then any configured credential, then the rest). Auth ranks candidates and never filters
+  them: the runtime already skips unauthenticated candidates, and filtering during canonicalization erased the
+  chain whenever an availability snapshot was not populated yet.
+- `core/extensions/builtin/model-fallback/settings.ts`: `/fallback` renders chains canonicalized against
+  `modelRegistry.getAvailable()` so the menu lists only models the user can select, while the runtime keeps
+  resolving against the full registry.
 
 ### Why
 
@@ -469,6 +476,14 @@
   is used instead of exhausting the chain inside one account.
 - `apitopia/kimi-k3-unlocked` is a personal gateway id that should never have shipped as a product default.
 
+### QA
+
+- Real-CLI QA (senpi-qa Channel 2, TUI in a pty, isolated sandbox, `PI_OFFLINE=1`): with Fable 5 served only by
+  `claude-sdk-oauth` and no `retry.fallbackChains` configured, `/fallback` renders
+  `claude-sdk-oauth/claude-fable-5 -> kimi-coding/k3:max, claude-sdk-oauth/claude-opus-5:xhigh,
+  claude-sdk-oauth/claude-opus-4-8:xhigh` where the previous default produced no chain at all. That QA run is
+  what surfaced both the fan-out cap and the display scoping above; neither was visible to unit fixtures.
+
 ### Expected merge conflict zones on next upstream sync
 
 - LOW: `core/retry-fallback/expansion.ts` is additive and fork-local with no upstream counterpart.
@@ -476,6 +491,7 @@
 - MEDIUM: `canonicalizeFallbackChains` in `core/retry-fallback/chains.ts` was restructured (two passes plus
   tombstones) rather than edited in place.
 - LOW: the optional `isUsingOAuth` member on the controller registry dep.
+- LOW: the display-scoping helper in `core/extensions/builtin/model-fallback/settings.ts`.
 
 ## Anthropic credits_required 429 pins the billing fallback (2026-07-29)
 

--- a/packages/coding-agent/src/core/extensions/builtin/model-fallback/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/model-fallback/settings.ts
@@ -1,12 +1,37 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
 import { canonicalizeFallbackChains, type FallbackModelLookup } from "../../../retry-fallback/chains.ts";
 import type { ExtensionSessionSettings, RetryFallbackSettings } from "../../types.ts";
 
 export type FallbackSettings = RetryFallbackSettings;
 
+/**
+ * `/fallback` shows what the user can act on. A bare default expands across every
+ * provider in the builtin catalog that publishes the model, so canonicalizing
+ * against the full registry listed chains for providers the user cannot select
+ * (no credentials). Scope the display to selectable models; the runtime keeps
+ * using the full registry so a chain still resolves for the active model.
+ */
+function displayLookup(models: FallbackModelLookup): FallbackModelLookup {
+	if (Array.isArray(models)) return models;
+	const registry = models as {
+		getAll(): Model<Api>[];
+		getAvailable?(): Model<Api>[];
+		isUsingOAuth?(model: Model<Api>): boolean;
+		hasConfiguredAuth?(model: Model<Api>): boolean;
+	};
+	if (typeof registry.getAvailable !== "function") return models;
+	const available = registry.getAvailable();
+	return {
+		getAll: () => (available.length > 0 ? available : registry.getAll()),
+		isUsingOAuth: (model) => registry.isUsingOAuth?.(model) === true,
+		hasConfiguredAuth: (model) => registry.hasConfiguredAuth?.(model) === true,
+	};
+}
+
 function withAvailableChains(settings: FallbackSettings, models: FallbackModelLookup): FallbackSettings {
 	return {
 		...settings,
-		chains: canonicalizeFallbackChains(settings.chains, models),
+		chains: canonicalizeFallbackChains(settings.chains, displayLookup(models)),
 	};
 }
 

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -2,7 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { isValidThinkingLevel } from "../../cli/args.ts";
 import { findExactModelReferenceMatch, parseModelPattern } from "../model-resolver.ts";
-import { type FallbackAuthLookup, parseBareSelector, rankFamilyModels } from "./expansion.ts";
+import { type FallbackAuthTiers, MAX_PROVIDERS_PER_FAMILY, parseBareSelector, rankFamilyModels } from "./expansion.ts";
 
 export interface FallbackSelector {
 	raw: string;
@@ -15,7 +15,11 @@ export type FallbackChains = Readonly<Record<string, readonly string[]>>;
 
 export type FallbackModelLookup =
 	| readonly Model<Api>[]
-	| { getAll(): Model<Api>[]; isUsingOAuth?(model: Model<Api>): boolean };
+	| {
+			getAll(): Model<Api>[];
+			isUsingOAuth?(model: Model<Api>): boolean;
+			hasConfiguredAuth?(model: Model<Api>): boolean;
+	  };
 
 function availableModels(lookup: FallbackModelLookup): Model<Api>[] {
 	return "getAll" in lookup ? lookup.getAll() : [...lookup];
@@ -25,12 +29,19 @@ function availableModels(lookup: FallbackModelLookup): Model<Api>[] {
  * Auth tier is optional so array lookups and older callers keep working; without
  * it every provider lands in the non-OAuth tier and the precedence table decides.
  */
-function authLookup(lookup: FallbackModelLookup): FallbackAuthLookup {
-	if (Array.isArray(lookup)) return () => false;
-	const registry = lookup as { isUsingOAuth?(model: Model<Api>): boolean };
-	return typeof registry.isUsingOAuth === "function"
-		? (model) => registry.isUsingOAuth?.(model) === true
-		: () => false;
+function authTiers(lookup: FallbackModelLookup): FallbackAuthTiers {
+	if (Array.isArray(lookup)) return { isUsingOAuth: () => false };
+	const registry = lookup as {
+		isUsingOAuth?(model: Model<Api>): boolean;
+		hasConfiguredAuth?(model: Model<Api>): boolean;
+	};
+	return {
+		isUsingOAuth: (model) => registry.isUsingOAuth?.(model) === true,
+		hasConfiguredAuth:
+			typeof registry.hasConfiguredAuth === "function"
+				? (model) => registry.hasConfiguredAuth?.(model) === true
+				: undefined,
+	};
 }
 
 /** An empty entry list is the documented opt-out; it survives as a tombstone. */
@@ -112,7 +123,7 @@ export function baseSelector(selector: Pick<FallbackSelector, "provider" | "id">
  */
 export function canonicalizeFallbackChains(chains: FallbackChains, lookup: FallbackModelLookup): FallbackChains {
 	const models = availableModels(lookup);
-	const isUsingOAuth = authLookup(lookup);
+	const tiers = authTiers(lookup);
 	const canonical: Record<string, readonly string[]> = {};
 	const explicitKeys = new Set<string>();
 	const tombstones = new Set<string>();
@@ -121,7 +132,7 @@ export function canonicalizeFallbackChains(chains: FallbackChains, lookup: Fallb
 		entries.flatMap((entry) => {
 			const bare = parseBareSelector(entry);
 			if (bare) {
-				return rankFamilyModels(models, bare.family, isUsingOAuth)
+				return rankFamilyModels(models, bare.family, tiers, { limit: MAX_PROVIDERS_PER_FAMILY })
 					.map((model) =>
 						bare.thinkingLevel ? `${formatSelector(model)}:${bare.thinkingLevel}` : formatSelector(model),
 					)
@@ -136,12 +147,12 @@ export function canonicalizeFallbackChains(chains: FallbackChains, lookup: Fallb
 		const bareKey = parseBareSelector(key);
 		if (!bareKey || !Array.isArray(entries)) continue;
 		if (isChainTombstone(entries)) {
-			for (const model of rankFamilyModels(models, bareKey.family, isUsingOAuth)) {
+			for (const model of rankFamilyModels(models, bareKey.family, tiers)) {
 				tombstones.add(formatSelector(model).toLowerCase());
 			}
 			continue;
 		}
-		for (const model of rankFamilyModels(models, bareKey.family, isUsingOAuth)) {
+		for (const model of rankFamilyModels(models, bareKey.family, tiers)) {
 			const keySelector = bareKey.thinkingLevel
 				? `${formatSelector(model)}:${bareKey.thinkingLevel}`
 				: formatSelector(model);

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -2,6 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { isValidThinkingLevel } from "../../cli/args.ts";
 import { findExactModelReferenceMatch, parseModelPattern } from "../model-resolver.ts";
+import { type FallbackAuthLookup, parseBareSelector, rankFamilyModels } from "./expansion.ts";
 
 export interface FallbackSelector {
 	raw: string;
@@ -12,10 +13,29 @@ export interface FallbackSelector {
 
 export type FallbackChains = Readonly<Record<string, readonly string[]>>;
 
-export type FallbackModelLookup = readonly Model<Api>[] | { getAll(): Model<Api>[] };
+export type FallbackModelLookup =
+	| readonly Model<Api>[]
+	| { getAll(): Model<Api>[]; isUsingOAuth?(model: Model<Api>): boolean };
 
 function availableModels(lookup: FallbackModelLookup): Model<Api>[] {
 	return "getAll" in lookup ? lookup.getAll() : [...lookup];
+}
+
+/**
+ * Auth tier is optional so array lookups and older callers keep working; without
+ * it every provider lands in the non-OAuth tier and the precedence table decides.
+ */
+function authLookup(lookup: FallbackModelLookup): FallbackAuthLookup {
+	if (Array.isArray(lookup)) return () => false;
+	const registry = lookup as { isUsingOAuth?(model: Model<Api>): boolean };
+	return typeof registry.isUsingOAuth === "function"
+		? (model) => registry.isUsingOAuth?.(model) === true
+		: () => false;
+}
+
+/** An empty entry list is the documented opt-out; it survives as a tombstone. */
+export function isChainTombstone(entries: readonly string[] | undefined): boolean {
+	return Array.isArray(entries) && entries.length === 0;
 }
 
 function selectorReference(raw: string): { reference: string; thinkingLevel?: ThinkingLevel } | undefined {
@@ -81,21 +101,72 @@ export function baseSelector(selector: Pick<FallbackSelector, "provider" | "id">
 	return `${selector.provider}/${selector.id}`;
 }
 
-/** Converts validated configuration to canonical selector strings for runtime lookup. */
+/**
+ * Converts validated configuration to canonical selector strings for runtime lookup.
+ *
+ * A bare key (no provider prefix) is a model-family policy: it expands to one
+ * canonical key per provider serving that family, so a chain shipped for
+ * `claude-fable-5` applies no matter which provider the user attached it through.
+ * Provider-qualified keys and entries keep exact semantics, and an explicit key
+ * always overrides the expansion it collides with.
+ */
 export function canonicalizeFallbackChains(chains: FallbackChains, lookup: FallbackModelLookup): FallbackChains {
+	const models = availableModels(lookup);
+	const isUsingOAuth = authLookup(lookup);
 	const canonical: Record<string, readonly string[]> = {};
+	const explicitKeys = new Set<string>();
+	const tombstones = new Set<string>();
 
-	for (const [key, entries] of Object.entries(chains)) {
-		const parsedKey = parseFallbackSelector(key, lookup);
-		if (!parsedKey || !Array.isArray(entries)) continue;
-
-		const canonicalEntries = entries.flatMap((entry) => {
-			const parsedEntry = parseFallbackSelector(entry, lookup);
+	const expandEntries = (entries: readonly string[], keySelector: string): string[] =>
+		entries.flatMap((entry) => {
+			const bare = parseBareSelector(entry);
+			if (bare) {
+				return rankFamilyModels(models, bare.family, isUsingOAuth)
+					.map((model) =>
+						bare.thinkingLevel ? `${formatSelector(model)}:${bare.thinkingLevel}` : formatSelector(model),
+					)
+					.filter((selector) => normalizedBase(selector) !== normalizedBase(keySelector));
+			}
+			const parsedEntry = parseFallbackSelector(entry, models);
 			return parsedEntry ? [formatParsedSelector(parsedEntry)] : [];
 		});
-		if (canonicalEntries.length > 0) {
-			canonical[formatParsedSelector(parsedKey)] = canonicalEntries;
+
+	// Bare keys expand first so a same-named explicit key can overwrite them.
+	for (const [key, entries] of Object.entries(chains)) {
+		const bareKey = parseBareSelector(key);
+		if (!bareKey || !Array.isArray(entries)) continue;
+		if (isChainTombstone(entries)) {
+			for (const model of rankFamilyModels(models, bareKey.family, isUsingOAuth)) {
+				tombstones.add(formatSelector(model).toLowerCase());
+			}
+			continue;
 		}
+		for (const model of rankFamilyModels(models, bareKey.family, isUsingOAuth)) {
+			const keySelector = bareKey.thinkingLevel
+				? `${formatSelector(model)}:${bareKey.thinkingLevel}`
+				: formatSelector(model);
+			const canonicalEntries = expandEntries(entries, keySelector);
+			if (canonicalEntries.length > 0) canonical[keySelector] = canonicalEntries;
+		}
+	}
+
+	for (const [key, entries] of Object.entries(chains)) {
+		if (parseBareSelector(key)) continue;
+		const parsedKey = parseFallbackSelector(key, models);
+		if (!parsedKey || !Array.isArray(entries)) continue;
+		const keySelector = formatParsedSelector(parsedKey);
+		if (isChainTombstone(entries)) {
+			tombstones.add(normalizedBase(keySelector));
+			continue;
+		}
+		explicitKeys.add(keySelector.toLowerCase());
+		const canonicalEntries = expandEntries(entries, keySelector);
+		if (canonicalEntries.length > 0) canonical[keySelector] = canonicalEntries;
+	}
+
+	for (const key of Object.keys(canonical)) {
+		if (explicitKeys.has(key.toLowerCase())) continue;
+		if (tombstones.has(normalizedBase(key))) delete canonical[key];
 	}
 
 	return canonical;

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -30,7 +30,12 @@ interface FallbackSettings {
 
 export interface RetryFallbackControllerDeps {
 	getSettings(): FallbackSettings;
-	registry: { find(provider: string, id: string): Model<Api> | undefined; getAll(): Model<Api>[] };
+	registry: {
+		find(provider: string, id: string): Model<Api> | undefined;
+		getAll(): Model<Api>[];
+		/** Ranks bare-selector expansion: OAuth-credential providers come first. */
+		isUsingOAuth?(model: Model<Api>): boolean;
+	};
 	cooldowns: SelectorCooldowns;
 	logger: FallbackLogger;
 	switchModel(model: Model<Api>, thinking: ThinkingLevel, reason: "fallback" | "fallback-revert"): Promise<void>;

--- a/packages/coding-agent/src/core/retry-fallback/expansion.ts
+++ b/packages/coding-agent/src/core/retry-fallback/expansion.ts
@@ -1,0 +1,109 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { isValidThinkingLevel } from "../../cli/args.ts";
+
+/**
+ * Providers that never receive a bare selector. OpenRouter re-publishes other
+ * vendors' catalogs under namespaced ids, so family expansion would silently
+ * route a shipped default through a third-party reseller the user never chose.
+ * An explicit `openrouter/...` selector the user wrote is unaffected.
+ */
+const BARE_EXPANSION_DENYLIST: ReadonlySet<string> = new Set(["openrouter", "openrouter-images"]);
+
+/**
+ * Deterministic tie-break inside one auth tier. Earlier wins. Providers absent
+ * from the table sort after every listed one, alphabetically.
+ */
+const PROVIDER_PRECEDENCE: readonly string[] = ["claude-sdk-oauth", "anthropic", "kimi-coding"];
+
+export interface BareSelectorParts {
+	/** Model id without a provider prefix, e.g. `claude-opus-5`. */
+	family: string;
+	thinkingLevel?: string;
+}
+
+/** Auth-tier probe. Providers holding an OAuth credential outrank API-key ones. */
+export type FallbackAuthLookup = (model: Model<Api>) => boolean;
+
+/** A selector is bare when it carries no provider prefix and no wildcard. */
+export function parseBareSelector(raw: string): BareSelectorParts | undefined {
+	const trimmed = raw.trim();
+	if (!trimmed || trimmed.includes("/") || trimmed.includes("*")) return undefined;
+
+	const lastColon = trimmed.lastIndexOf(":");
+	if (lastColon === -1) return { family: trimmed.toLowerCase() };
+
+	const suffix = trimmed.slice(lastColon + 1).toLowerCase();
+	if (!isValidThinkingLevel(suffix)) return { family: trimmed.toLowerCase() };
+	const family = trimmed.slice(0, lastColon).trim().toLowerCase();
+	return family ? { family, thinkingLevel: suffix } : undefined;
+}
+
+/**
+ * Strips a provider-side namespace so Bedrock's `global.anthropic.claude-opus-5`
+ * and a gateway's `anthropic/claude-opus-5` both reduce to `claude-opus-5`.
+ */
+function withoutNamespace(modelId: string): string {
+	const cut = Math.max(modelId.lastIndexOf("."), modelId.lastIndexOf("/"));
+	return cut === -1 ? modelId : modelId.slice(cut + 1);
+}
+
+/**
+ * Conservative family match. A bare id matches its exact model and dash-suffixed
+ * variants (`k3` -> `k3-256k`) but never an arbitrary substring, so `claude-fable-5`
+ * cannot capture `not-claude-fable-5`.
+ */
+export function matchesFamily(model: Model<Api>, family: string): boolean {
+	const candidates = [model.id.toLowerCase(), withoutNamespace(model.id.toLowerCase())];
+	return candidates.some((id) => id === family || id.startsWith(`${family}-`));
+}
+
+/** Exact id wins, then the shortest variant, then alphabetical. */
+function pickVariant(models: readonly Model<Api>[], family: string): Model<Api> | undefined {
+	const ranked = [...models].sort((left, right) => {
+		const exact =
+			Number(withoutNamespace(right.id.toLowerCase()) === family) -
+			Number(withoutNamespace(left.id.toLowerCase()) === family);
+		if (exact !== 0) return exact;
+		if (left.id.length !== right.id.length) return left.id.length - right.id.length;
+		return left.id.localeCompare(right.id);
+	});
+	return ranked[0];
+}
+
+function precedenceIndex(provider: string): number {
+	const index = PROVIDER_PRECEDENCE.indexOf(provider.toLowerCase());
+	return index === -1 ? PROVIDER_PRECEDENCE.length : index;
+}
+
+/**
+ * Ranks one model per eligible provider: OAuth-credential providers first (a
+ * logged-in subscription is the account the user actually wants used), then the
+ * fixed precedence table, then alphabetically.
+ */
+export function rankFamilyModels(
+	models: readonly Model<Api>[],
+	family: string,
+	isUsingOAuth: FallbackAuthLookup,
+): Model<Api>[] {
+	const byProvider = new Map<string, Model<Api>[]>();
+	for (const model of models) {
+		if (BARE_EXPANSION_DENYLIST.has(model.provider.toLowerCase())) continue;
+		if (!matchesFamily(model, family)) continue;
+		const bucket = byProvider.get(model.provider);
+		if (bucket) bucket.push(model);
+		else byProvider.set(model.provider, [model]);
+	}
+
+	const picked = [...byProvider.values()].flatMap((variants) => {
+		const variant = pickVariant(variants, family);
+		return variant ? [variant] : [];
+	});
+
+	return picked.sort((left, right) => {
+		const oauth = Number(isUsingOAuth(right)) - Number(isUsingOAuth(left));
+		if (oauth !== 0) return oauth;
+		const precedence = precedenceIndex(left.provider) - precedenceIndex(right.provider);
+		if (precedence !== 0) return precedence;
+		return left.provider.localeCompare(right.provider);
+	});
+}

--- a/packages/coding-agent/src/core/retry-fallback/expansion.ts
+++ b/packages/coding-agent/src/core/retry-fallback/expansion.ts
@@ -24,6 +24,34 @@ export interface BareSelectorParts {
 /** Auth-tier probe. Providers holding an OAuth credential outrank API-key ones. */
 export type FallbackAuthLookup = (model: Model<Api>) => boolean;
 
+/**
+ * Auth tiers for bare expansion. OAuth first (a logged-in subscription is the
+ * account the user actually wants used), then any configured credential, then
+ * everything else. This ranks rather than filters: the runtime already skips
+ * unauthenticated candidates, and dropping them here would erase the chain
+ * whenever availability is not yet known.
+ */
+export interface FallbackAuthTiers {
+	isUsingOAuth: FallbackAuthLookup;
+	hasConfiguredAuth?: FallbackAuthLookup;
+}
+
+function authTier(model: Model<Api>, tiers: FallbackAuthTiers): number {
+	if (tiers.isUsingOAuth(model)) return 0;
+	if (tiers.hasConfiguredAuth?.(model) === true) return 1;
+	return 2;
+}
+
+/**
+ * How many providers one bare selector may fan out to. A shipped default must
+ * stay a short, readable chain: senpi's builtin catalog publishes popular models
+ * under a dozen providers, and expanding to all of them turned `/fallback` into
+ * an unreadable wall and the policy into "try every gateway that resells this".
+ * Two keeps the useful property - a second account for the same model - without
+ * the noise.
+ */
+const MAX_PROVIDERS_PER_FAMILY = 2;
+
 /** A selector is bare when it carries no provider prefix and no wildcard. */
 export function parseBareSelector(raw: string): BareSelectorParts | undefined {
 	const trimmed = raw.trim();
@@ -83,7 +111,8 @@ function precedenceIndex(provider: string): number {
 export function rankFamilyModels(
 	models: readonly Model<Api>[],
 	family: string,
-	isUsingOAuth: FallbackAuthLookup,
+	tiers: FallbackAuthTiers,
+	options: { limit?: number } = {},
 ): Model<Api>[] {
 	const byProvider = new Map<string, Model<Api>[]>();
 	for (const model of models) {
@@ -99,11 +128,16 @@ export function rankFamilyModels(
 		return variant ? [variant] : [];
 	});
 
-	return picked.sort((left, right) => {
-		const oauth = Number(isUsingOAuth(right)) - Number(isUsingOAuth(left));
-		if (oauth !== 0) return oauth;
+	const ranked = picked.sort((left, right) => {
+		const tier = authTier(left, tiers) - authTier(right, tiers);
+		if (tier !== 0) return tier;
 		const precedence = precedenceIndex(left.provider) - precedenceIndex(right.provider);
 		if (precedence !== 0) return precedence;
 		return left.provider.localeCompare(right.provider);
 	});
+
+	const limit = options.limit ?? ranked.length;
+	return ranked.slice(0, limit);
 }
+
+export { MAX_PROVIDERS_PER_FAMILY };

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -27,12 +27,14 @@ export interface ResolvedRetryFallbackSettings {
 	revertPolicy: "cooldown-expiry" | "never";
 }
 
+/**
+ * Shipped defaults are declared as model families (bare ids, no provider prefix).
+ * `canonicalizeFallbackChains` expands them against the live registry, so the
+ * chain follows Fable 5 whichever provider serves it - the builtin Anthropic
+ * provider, the Claude SDK OAuth extension, a gateway, or Bedrock.
+ */
 export const DEFAULT_FALLBACK_CHAINS: FallbackChains = {
-	"anthropic/claude-fable-5": [
-		"apitopia/kimi-k3-unlocked:max",
-		"anthropic/claude-opus-5:xhigh",
-		"anthropic/claude-opus-4-8:xhigh",
-	],
+	"claude-fable-5": ["k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 };
 
 function cloneDefaultFallbackChains(): Record<string, readonly string[]> {
@@ -57,7 +59,8 @@ function isStringArray(value: unknown): value is string[] {
  * chain: that left the defaulted model with no client chain at all, which in
  * turn disabled the server-fallback abort and handed model choice back to the
  * provider. A same-named key still replaces that default outright (never a
- * union), and an explicit empty array removes a default the user does not want.
+ * union), and an explicit empty array removes a default the user does not want -
+ * as a tombstone honored at both bare-family and canonical-provider granularity.
  *
  * Cross-scope replacement (global vs project) stays wholesale and is handled by
  * `deepMergeSettings`; this only resolves defaults against the merged result.
@@ -69,10 +72,9 @@ function resolveFallbackChains(value: unknown): FallbackChains {
 	const chains: Record<string, readonly string[]> = cloneDefaultFallbackChains();
 	for (const [key, entries] of Object.entries(value)) {
 		if (!isStringArray(entries)) return cloneDefaultFallbackChains();
-		if (entries.length === 0) {
-			delete chains[key];
-			continue;
-		}
+		// An empty list stays in the map as a tombstone: canonicalization needs it to
+		// suppress the expanded default for that family or provider variant, and
+		// dropping it here would let the shipped default reappear after expansion.
 		chains[key] = [...entries];
 	}
 	return chains;

--- a/packages/coding-agent/src/core/retry-fallback/validate.ts
+++ b/packages/coding-agent/src/core/retry-fallback/validate.ts
@@ -2,6 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getSupportedThinkingLevels } from "../thinking-levels.ts";
 import { baseSelector, parseFallbackSelector } from "./chains.ts";
+import { matchesFamily, parseBareSelector } from "./expansion.ts";
 
 export interface FallbackModelRegistry {
 	find(provider: string, id: string): Model<Api> | undefined;
@@ -55,7 +56,12 @@ export function validateFallbackChains(chains: unknown, registry: FallbackModelR
 	for (const [key, entries] of Object.entries(chains)) {
 		const hasProvider = key.includes("/");
 		const hasWildcard = key.includes("*");
-		if (!hasProvider) {
+		// A bare key names a model family and applies to every provider serving it.
+		const bareKey = hasWildcard ? undefined : parseBareSelector(key);
+		const bareKeyMatches = bareKey ? models.some((model) => matchesFamily(model, bareKey.family)) : false;
+		if (!hasProvider && !bareKeyMatches && !hasWildcard) {
+			// A bare key naming no registered model is indistinguishable from the old
+			// role syntax, so it keeps the message that tells the user what to write.
 			warnings.push(`Fallback chain key "${key}" must use a provider/model selector; roles are unsupported.`);
 		}
 		if (hasWildcard) warnings.push(`Fallback chain key "${key}" cannot contain wildcards.`);
@@ -80,6 +86,13 @@ export function validateFallbackChains(chains: unknown, registry: FallbackModelR
 		}
 
 		for (const entry of entries) {
+			const bareEntry = parseBareSelector(entry);
+			if (bareEntry) {
+				if (!models.some((model) => matchesFamily(model, bareEntry.family))) {
+					warnings.push(invalidSelectorWarning("entry", entry, key));
+				}
+				continue;
+			}
 			const parsedEntry = parseFallbackSelector(entry, models);
 			const entryModel = parsedEntry ? registry.find(parsedEntry.provider, parsedEntry.id) : undefined;
 			if (!parsedEntry || !entryModel) {

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -30,11 +30,7 @@ afterEach(() => {
 
 describe("SettingsManager retry fallback settings", () => {
 	const defaultChains = {
-		"anthropic/claude-fable-5": [
-			"apitopia/kimi-k3-unlocked:max",
-			"anthropic/claude-opus-5:xhigh",
-			"anthropic/claude-opus-4-8:xhigh",
-		],
+		"claude-fable-5": ["k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 	};
 
 	it("defaults abortServerSideFallback to true and round-trips an explicit false", () => {
@@ -79,13 +75,13 @@ describe("SettingsManager retry fallback settings", () => {
 		const manager = SettingsManager.create(projectDir, agentDir);
 		manager.setModelFallbackEnabled(false);
 		manager.setFallbackRevertPolicy("never");
-		manager.setFallbackChain("anthropic/claude-fable-5", ["ccapi/kimi-k3:max"]);
+		manager.setFallbackChain("claude-fable-5", ["ccapi/kimi-k3:max"]);
 		await manager.flush();
 
 		const reloaded = SettingsManager.create(projectDir, agentDir);
 		expect(reloaded.getRetryFallbackSettings()).toEqual({
 			modelFallback: false,
-			chains: { "anthropic/claude-fable-5": ["ccapi/kimi-k3:max"] },
+			chains: { "claude-fable-5": ["ccapi/kimi-k3:max"] },
 			revertPolicy: "never",
 		});
 
@@ -95,7 +91,7 @@ describe("SettingsManager retry fallback settings", () => {
 
 		// Removing the user's override restores the shipped default for that key
 		// rather than leaving the model with no chain at all.
-		reloaded.removeFallbackChain("anthropic/claude-fable-5");
+		reloaded.removeFallbackChain("claude-fable-5");
 		await reloaded.flush();
 		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).toEqual(defaultChains);
 	});
@@ -107,7 +103,7 @@ describe("SettingsManager retry fallback settings", () => {
 
 		writeFileSync(
 			join(agentDir, "settings.json"),
-			JSON.stringify({ retry: { fallbackChains: { "anthropic/claude-fable-5": ["ccapi/kimi-k3:max"] } } }),
+			JSON.stringify({ retry: { fallbackChains: { "claude-fable-5": ["ccapi/kimi-k3:max"] } } }),
 		);
 		expect(SettingsManager.create(projectDir, agentDir).getFallbackChainsScope()).toBe("global");
 
@@ -143,7 +139,7 @@ describe("SettingsManager retry fallback settings", () => {
 		const chains = SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains;
 
 		expect(chains["apitopia/kimi-k3-unlocked"]).toEqual(["apitopia/kimi-k3-ultrafast-unlocked:max"]);
-		expect(chains["anthropic/claude-fable-5"]).toEqual(defaultChains["anthropic/claude-fable-5"]);
+		expect(chains["claude-fable-5"]).toEqual(defaultChains["claude-fable-5"]);
 	});
 
 	it("lets a user chain replace a default outright and an empty array delete it", () => {
@@ -151,19 +147,21 @@ describe("SettingsManager retry fallback settings", () => {
 		writeFileSync(
 			join(agentDir, "settings.json"),
 			JSON.stringify({
-				retry: { fallbackChains: { "anthropic/claude-fable-5": ["ccapi/kimi-k3:max"] } },
+				retry: { fallbackChains: { "claude-fable-5": ["ccapi/kimi-k3:max"] } },
 			}),
 		);
-		expect(
-			SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains["anthropic/claude-fable-5"],
-		).toEqual(["ccapi/kimi-k3:max"]);
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains["claude-fable-5"]).toEqual([
+			"ccapi/kimi-k3:max",
+		]);
 
 		writeFileSync(
 			join(agentDir, "settings.json"),
-			JSON.stringify({ retry: { fallbackChains: { "anthropic/claude-fable-5": [] } } }),
+			JSON.stringify({ retry: { fallbackChains: { "claude-fable-5": [] } } }),
 		);
-		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).not.toHaveProperty(
-			"anthropic/claude-fable-5",
+		// Tombstone: the empty list is preserved through resolution and consumed by
+		// canonicalization, which drops every expanded provider variant of the family.
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains["claude-fable-5"]).toEqual(
+			[],
 		);
 	});
 

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -130,7 +130,7 @@ describe("SettingsManager retry fallback settings", () => {
 			JSON.stringify({
 				retry: {
 					fallbackChains: {
-						"apitopia/kimi-k3-unlocked": ["apitopia/kimi-k3-ultrafast-unlocked:max"],
+						"example-gateway/unrelated-model": ["example-gateway/unrelated-fallback:max"],
 					},
 				},
 			}),
@@ -138,7 +138,7 @@ describe("SettingsManager retry fallback settings", () => {
 
 		const chains = SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains;
 
-		expect(chains["apitopia/kimi-k3-unlocked"]).toEqual(["apitopia/kimi-k3-ultrafast-unlocked:max"]);
+		expect(chains["example-gateway/unrelated-model"]).toEqual(["example-gateway/unrelated-fallback:max"]);
 		expect(chains["claude-fable-5"]).toEqual(defaultChains["claude-fable-5"]);
 	});
 

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -93,10 +93,13 @@ function createUi(notices: string[], choices: string[]): ExtensionUIContext {
 	};
 }
 
-function createModelRegistry(registeredModels: Model<Api>[] = [primary, fallback]): ModelRegistry {
+function createModelRegistry(
+	registeredModels: Model<Api>[] = [primary, fallback],
+	availableModels: Model<Api>[] = registeredModels,
+): ModelRegistry {
 	const modelRegistry = ModelRegistry.inMemory(AuthStorage.inMemory());
 	modelRegistry.getAll = () => registeredModels;
-	modelRegistry.getAvailable = () => registeredModels;
+	modelRegistry.getAvailable = () => availableModels;
 	modelRegistry.find = (provider: string, id: string) =>
 		registeredModels.find((registeredModel) => registeredModel.provider === provider && registeredModel.id === id);
 	return modelRegistry;
@@ -107,9 +110,10 @@ async function context(
 	notices: string[],
 	choices: string[] = [],
 	registeredModels?: Model<Api>[],
+	availableModels?: Model<Api>[],
 ): Promise<ExtensionCommandContext> {
 	const settings = SettingsManager.create(dir);
-	const modelRegistry = createModelRegistry(registeredModels);
+	const modelRegistry = createModelRegistry(registeredModels, availableModels ?? registeredModels);
 	return {
 		ui: createUi(notices, choices),
 		mode: choices.length > 0 ? "tui" : "print",
@@ -183,6 +187,28 @@ describe("model fallback builtin command", () => {
 		const command = (await harness()).get("fallback");
 		expect(command?.argumentHint).toBe("[target [fallback1 fallback2 ...]]");
 		expect(command?.description).toContain("fallback");
+	});
+
+	it("lists a default chain only for models the user can actually select", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
+		dirs.push(dir);
+		const notices: string[] = [];
+		const catalogOnly = model("github-copilot", "claude-fable-5", true);
+		// The builtin catalog publishes Fable 5 under many providers; only the SDK
+		// OAuth one is actually usable here, so only its chain belongs on screen.
+		const ctx = await context(
+			dir,
+			notices,
+			["Show chains & live state"],
+			[sdkFable, sdkOpus5, kimiK3, catalogOnly],
+			[sdkFable, sdkOpus5, kimiK3],
+		);
+
+		await (await harness()).get("fallback")?.handler("", ctx);
+
+		const rendered = notices.join("\n");
+		expect(rendered).toContain("claude-sdk-oauth/claude-fable-5 -> kimi-coding/k3:max");
+		expect(rendered).not.toContain("github-copilot/claude-fable-5 ->");
 	});
 
 	it("quick-set validates and persists a chain visible after a session-side reload", async () => {

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -20,7 +20,9 @@ const dirs: string[] = [];
 let previousAgentDir: string | undefined;
 const primary = model("anthropic", "claude-fable-5", true);
 const fallback = model("ccapi", "kimi-k3", true);
-const kimiK3 = model("apitopia", "kimi-k3-unlocked", true);
+const kimiK3 = model("kimi-coding", "k3", true);
+const sdkFable = model("claude-sdk-oauth", "claude-fable-5", true);
+const sdkOpus5 = model("claude-sdk-oauth", "claude-opus-5", true);
 const opus5 = model("anthropic", "claude-opus-5", true);
 const opus48 = model("anthropic", "claude-opus-4-8", true);
 
@@ -191,9 +193,11 @@ describe("model fallback builtin command", () => {
 		const sessionSideSettings = SettingsManager.create(dir);
 		await command?.handler("anthropic/claude-fable-5 ccapi/kimi-k3:max", await context(dir, notices));
 		await sessionSideSettings.reload();
-		expect(sessionSideSettings.getRetryFallbackSettings().chains).toEqual({
-			"anthropic/claude-fable-5": ["ccapi/kimi-k3:max"],
-		});
+		// The user's canonical key wins for that provider; the bare shipped default
+		// stays in the raw map so other providers serving the family keep a chain.
+		expect(sessionSideSettings.getRetryFallbackSettings().chains["anthropic/claude-fable-5"]).toEqual([
+			"ccapi/kimi-k3:max",
+		]);
 		expect(notices).toContain("Fallback chain saved for anthropic/claude-fable-5.");
 	});
 
@@ -217,7 +221,12 @@ describe("model fallback builtin command", () => {
 			name: "all default models are available",
 			models: [primary, kimiK3, opus5, opus48],
 			expected:
-				"anthropic/claude-fable-5 -> apitopia/kimi-k3-unlocked:max, anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
+				"anthropic/claude-fable-5 -> kimi-coding/k3:max, anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
+		},
+		{
+			name: "Fable 5 is attached through the Claude SDK OAuth provider instead of anthropic",
+			models: [sdkFable, kimiK3, sdkOpus5],
+			expected: "claude-sdk-oauth/claude-fable-5 -> kimi-coding/k3:max, claude-sdk-oauth/claude-opus-5:xhigh",
 		},
 		{
 			name: "Kimi K3 is unavailable",

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -119,7 +119,7 @@ describe("fallback chain selectors", () => {
 });
 
 describe("resolveRetryFallbackSettings chain defaults", () => {
-	const fableKey = "anthropic/claude-fable-5";
+	const fableKey = "claude-fable-5";
 
 	it("keeps a shipped default chain when the user configures an unrelated model", () => {
 		const resolved = resolveRetryFallbackSettings({
@@ -129,6 +129,8 @@ describe("resolveRetryFallbackSettings chain defaults", () => {
 		expect(resolved.chains["apitopia/kimi-k3-unlocked"]).toEqual(["apitopia/kimi-k3-ultrafast-unlocked:max"]);
 		expect(resolved.chains[fableKey]).toEqual(DEFAULT_FALLBACK_CHAINS[fableKey]);
 		expect(DEFAULT_FALLBACK_CHAINS[fableKey]).toHaveLength(3);
+		// The shipped default is provider-agnostic: bare ids only, expanded at canonicalization.
+		expect(Object.keys(DEFAULT_FALLBACK_CHAINS).every((key) => !key.includes("/"))).toBe(true);
 	});
 
 	it("replaces a colliding default outright and removes one set to an empty array", () => {
@@ -136,7 +138,9 @@ describe("resolveRetryFallbackSettings chain defaults", () => {
 			resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: ["ccapi/kimi-k3:max"] } }).chains[fableKey],
 		).toEqual(["ccapi/kimi-k3:max"]);
 
-		expect(resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: [] } }).chains).not.toHaveProperty(fableKey);
+		// An empty list survives resolution as a tombstone; canonicalization is what
+		// removes the expanded default (see retry-fallback-expansion.test.ts).
+		expect(resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: [] } }).chains[fableKey]).toEqual([]);
 	});
 
 	it("falls back to the shipped defaults for a malformed chain map", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -123,10 +123,10 @@ describe("resolveRetryFallbackSettings chain defaults", () => {
 
 	it("keeps a shipped default chain when the user configures an unrelated model", () => {
 		const resolved = resolveRetryFallbackSettings({
-			fallbackChains: { "apitopia/kimi-k3-unlocked": ["apitopia/kimi-k3-ultrafast-unlocked:max"] },
+			fallbackChains: { "example-gateway/unrelated-model": ["example-gateway/unrelated-fallback:max"] },
 		});
 
-		expect(resolved.chains["apitopia/kimi-k3-unlocked"]).toEqual(["apitopia/kimi-k3-ultrafast-unlocked:max"]);
+		expect(resolved.chains["example-gateway/unrelated-model"]).toEqual(["example-gateway/unrelated-fallback:max"]);
 		expect(resolved.chains[fableKey]).toEqual(DEFAULT_FALLBACK_CHAINS[fableKey]);
 		expect(DEFAULT_FALLBACK_CHAINS[fableKey]).toHaveLength(3);
 		// The shipped default is provider-agnostic: bare ids only, expanded at canonicalization.

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -24,10 +24,15 @@ const OPUS5 = "claude-opus-5";
 const OPUS48 = "claude-opus-4-8";
 
 /** Registry stand-in: `oauthProviders` marks which providers hold an OAuth credential. */
-function lookup(models: Model<Api>[], oauthProviders: string[] = []) {
+function lookup(models: Model<Api>[], oauthProviders: string[] = [], unauthenticated: string[] = []) {
 	return {
 		getAll: () => models,
 		isUsingOAuth: (candidate: Model<Api>) => oauthProviders.includes(candidate.provider),
+		hasConfiguredAuth: (candidate: Model<Api>) => !unauthenticated.includes(candidate.provider),
+	} as {
+		getAll(): Model<Api>[];
+		isUsingOAuth(model: Model<Api>): boolean;
+		hasConfiguredAuth(model: Model<Api>): boolean;
 	};
 }
 
@@ -169,5 +174,58 @@ describe("bare-key opt-out tombstones", () => {
 
 		expect(chains[`anthropic/${FABLE}`]).toEqual([`anthropic/${OPUS48}:max`]);
 		expect(chains[`claude-sdk-oauth/${FABLE}`]?.[0]).toBe("kimi-coding/k3:max");
+	});
+});
+
+describe("expansion stays scoped to models the user can actually use", () => {
+	const catalog = [
+		model("claude-sdk-oauth", FABLE),
+		model("claude-sdk-oauth", OPUS5),
+		model("anthropic", FABLE),
+		model("anthropic", OPUS5),
+		model("github-copilot", FABLE),
+		model("github-copilot", OPUS5),
+		model("opencode", FABLE),
+		model("opencode", OPUS5),
+		model("cloudflare-ai-gateway", FABLE),
+		model("cloudflare-ai-gateway", OPUS5),
+		model("kimi-coding", "k3"),
+	];
+
+	it("prefers authenticated providers over unauthenticated ones for bare candidates", () => {
+		const unauthenticated = ["github-copilot", "opencode", "cloudflare-ai-gateway"];
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(catalog, [], unauthenticated));
+
+		// Ranking, never filtering: an unauthenticated provider must not outrank a
+		// configured one, but the chain still exists when availability is unknown.
+		for (const entries of Object.values(chains)) {
+			for (const provider of unauthenticated) {
+				expect(entries.some((entry) => entry.startsWith(`${provider}/`))).toBe(false);
+			}
+		}
+	});
+
+	it("still expands when no provider reports configured auth yet", () => {
+		const chains = canonicalizeFallbackChains(
+			DEFAULT_FALLBACK_CHAINS,
+			lookup(
+				catalog,
+				[],
+				catalog.map((m) => m.provider),
+			),
+		);
+
+		expect(Object.keys(chains).length).toBeGreaterThan(0);
+	});
+
+	it("caps how many providers one bare candidate fans out to", () => {
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(catalog));
+		const entries = chains[`anthropic/${FABLE}`] ?? [];
+		const opus5Providers = entries.filter((entry) => entry.includes(OPUS5));
+
+		// A shipped default must stay a short, readable chain rather than every
+		// provider in the builtin catalog that happens to publish the model.
+		expect(opus5Providers.length).toBeLessThanOrEqual(2);
+		expect(entries.length).toBeLessThanOrEqual(5);
 	});
 });

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -1,0 +1,173 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { canonicalizeFallbackChains } from "../../src/core/retry-fallback/chains.ts";
+import { DEFAULT_FALLBACK_CHAINS, resolveRetryFallbackSettings } from "../../src/core/retry-fallback/settings.ts";
+
+function model(provider: string, id: string): Model<Api> {
+	return {
+		provider,
+		id,
+		name: id,
+		api: "faux",
+		baseUrl: "https://models.example.test/v1",
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+		input: ["text"],
+		contextWindow: 1,
+		maxTokens: 1,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	};
+}
+
+const FABLE = "claude-fable-5";
+const OPUS5 = "claude-opus-5";
+const OPUS48 = "claude-opus-4-8";
+
+/** Registry stand-in: `oauthProviders` marks which providers hold an OAuth credential. */
+function lookup(models: Model<Api>[], oauthProviders: string[] = []) {
+	return {
+		getAll: () => models,
+		isUsingOAuth: (candidate: Model<Api>) => oauthProviders.includes(candidate.provider),
+	};
+}
+
+const sdkAndAnthropic = [
+	model("claude-sdk-oauth", FABLE),
+	model("claude-sdk-oauth", OPUS5),
+	model("claude-sdk-oauth", OPUS48),
+	model("anthropic", FABLE),
+	model("anthropic", OPUS5),
+	model("anthropic", OPUS48),
+	model("kimi-coding", "k3"),
+	model("kimi-coding", "k3-256k"),
+];
+
+describe("bare model-id family expansion", () => {
+	it("ships a provider-agnostic default chain with bare model ids", () => {
+		expect(DEFAULT_FALLBACK_CHAINS).toEqual({
+			[FABLE]: ["k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
+		});
+	});
+
+	it("expands a bare key into one canonical key per serving provider", () => {
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+
+		expect(Object.keys(chains).sort()).toEqual([`anthropic/${FABLE}`, `claude-sdk-oauth/${FABLE}`]);
+	});
+
+	it("ranks OAuth-credential providers ahead of API-key providers for bare candidates", () => {
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic, ["anthropic"]));
+
+		// anthropic holds the OAuth credential here, so it outranks the sdk provider
+		// even though the tie-break table would otherwise prefer claude-sdk-oauth.
+		expect(chains[`claude-sdk-oauth/${FABLE}`]?.slice(0, 3)).toEqual([
+			"kimi-coding/k3:max",
+			`anthropic/${OPUS5}:xhigh`,
+			`claude-sdk-oauth/${OPUS5}:xhigh`,
+		]);
+	});
+
+	it("breaks ties with the fixed provider table when no provider holds OAuth", () => {
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+
+		expect(chains[`anthropic/${FABLE}`]).toEqual([
+			"kimi-coding/k3:max",
+			`claude-sdk-oauth/${OPUS5}:xhigh`,
+			`anthropic/${OPUS5}:xhigh`,
+			`claude-sdk-oauth/${OPUS48}:xhigh`,
+			`anthropic/${OPUS48}:xhigh`,
+		]);
+	});
+
+	it("keeps model-major ordering so every provider for one model precedes the next model", () => {
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+		const entries = chains[`anthropic/${FABLE}`] ?? [];
+		const lastOpus5 = entries.findLastIndex((entry) => entry.includes(OPUS5));
+		const firstOpus48 = entries.findIndex((entry) => entry.includes(OPUS48));
+
+		expect(lastOpus5).toBeLessThan(firstOpus48);
+	});
+
+	it("prefers the exact model id over a longer family variant inside one provider", () => {
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+
+		expect(chains[`anthropic/${FABLE}`]?.[0]).toBe("kimi-coding/k3:max");
+		expect(chains[`anthropic/${FABLE}`]).not.toContain("kimi-coding/k3-256k:max");
+	});
+
+	it("matches namespaced provider ids by family without substring false positives", () => {
+		const models = [
+			model("amazon-bedrock", `global.anthropic.${FABLE}`),
+			model("amazon-bedrock", `global.anthropic.${OPUS5}`),
+			model("other", `not-${FABLE}`),
+		];
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
+
+		expect(Object.keys(chains)).toEqual([`amazon-bedrock/global.anthropic.${FABLE}`]);
+		expect(chains[`amazon-bedrock/global.anthropic.${FABLE}`]).toEqual([
+			`amazon-bedrock/global.anthropic.${OPUS5}:xhigh`,
+		]);
+	});
+
+	it("never expands a bare selector onto openrouter", () => {
+		const models = [
+			model("openrouter", `anthropic/${FABLE}`),
+			model("openrouter", `anthropic/${OPUS5}`),
+			model("anthropic", FABLE),
+			model("anthropic", OPUS5),
+		];
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
+
+		expect(Object.keys(chains)).toEqual([`anthropic/${FABLE}`]);
+		expect(chains[`anthropic/${FABLE}`]).toEqual([`anthropic/${OPUS5}:xhigh`]);
+	});
+
+	it("still honors an explicit openrouter selector written by the user", () => {
+		const models = [model("anthropic", FABLE), model("openrouter", "qwen/qwen3-coder:exacto")];
+		const chains = canonicalizeFallbackChains(
+			{ [`anthropic/${FABLE}`]: ["openrouter/qwen/qwen3-coder:exacto:max"] },
+			lookup(models),
+		);
+
+		expect(chains).toEqual({ [`anthropic/${FABLE}`]: ["openrouter/qwen/qwen3-coder:exacto:max"] });
+	});
+
+	it("drops a bare key whose family no provider serves", () => {
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup([model("openai", "gpt-5.4")]));
+
+		expect(chains).toEqual({});
+	});
+
+	it("never lists the key model itself as its own candidate", () => {
+		const chains = canonicalizeFallbackChains({ [FABLE]: [FABLE, `${OPUS5}:xhigh`] }, lookup(sdkAndAnthropic));
+
+		for (const [key, entries] of Object.entries(chains)) {
+			expect(entries).not.toContain(key);
+		}
+	});
+});
+
+describe("bare-key opt-out tombstones", () => {
+	it("removes the shipped default when the user empties the bare key", () => {
+		const resolved = resolveRetryFallbackSettings({ fallbackChains: { [FABLE]: [] } });
+
+		expect(canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic))).toEqual({});
+	});
+
+	it("removes only one provider variant when the user empties a canonical key", () => {
+		const resolved = resolveRetryFallbackSettings({ fallbackChains: { [`anthropic/${FABLE}`]: [] } });
+		const chains = canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic));
+
+		expect(Object.keys(chains)).toEqual([`claude-sdk-oauth/${FABLE}`]);
+	});
+
+	it("lets an explicit canonical chain override the expanded default for that provider only", () => {
+		const resolved = resolveRetryFallbackSettings({
+			fallbackChains: { [`anthropic/${FABLE}`]: [`anthropic/${OPUS48}:max`] },
+		});
+		const chains = canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic));
+
+		expect(chains[`anthropic/${FABLE}`]).toEqual([`anthropic/${OPUS48}:max`]);
+		expect(chains[`claude-sdk-oauth/${FABLE}`]?.[0]).toBe("kimi-coding/k3:max");
+	});
+});


### PR DESCRIPTION
## Problem

The shipped default fallback chain was keyed on the literal provider id `anthropic`:

```ts
{ "anthropic/claude-fable-5": ["apitopia/kimi-k3-unlocked:max", "anthropic/claude-opus-5:xhigh", "anthropic/claude-opus-4-8:xhigh"] }
```

Attach Fable 5 through anything else — the builtin `claude-sdk-oauth` extension (which mirrors the whole
Anthropic catalog), a gateway, or Bedrock's namespaced ids — and the key never matches. `canonicalizeFallbackChains`
then drops the chain, `hasConfiguredChain()` goes false, and the default `abortServerSideFallback: true` leaves the
session with provider-side fallback blocked and nothing to fall back to: exactly the dead end the default was
introduced to remove. The default also shipped `apitopia/kimi-k3-unlocked`, a personal gateway id.

## Change

Declare the default as model families and expand against the live registry:

```ts
{ "claude-fable-5": ["k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"] }
```

- **Bare keys** expand to one canonical `provider/model` key per serving provider.
- **Bare candidates** expand ranked: OAuth credential first, then any configured credential, then the rest;
  ties broken by `[claude-sdk-oauth, anthropic, kimi-coding]` then alphabetically. Capped at 2 providers per
  family so a chain keeps its second-account hop without listing every reseller.
- **Family matching is conservative**: strip a `.`/`/` namespace, then `id === bare || id.startsWith(bare + "-")`.
  Never a substring, so `claude-fable-5` cannot capture `not-claude-fable-5`. Exact id beats a longer variant
  (`k3` over `k3-256k`).
- **`openrouter` is excluded** from bare expansion; an explicit `openrouter/...` selector still works exactly as before.
- **Explicit `provider/model` keys and entries are unchanged**, and `[]` still opts out — now as a tombstone honored
  at both bare-family and canonical-provider granularity.
- Auth **ranks** candidates, never filters them: the runtime already skips unauthenticated candidates, and filtering
  during canonicalization erased the chain before an availability snapshot existed.
- `/fallback` renders chains scoped to `getAvailable()` so the menu lists only selectable models.

A side effect worth naming: when both `claude-sdk-oauth` and `anthropic` serve `claude-opus-5`, both now appear as
candidates, so a dead account is skipped by cooldown instead of the chain exhausting itself inside one account.

## Verification

- `npm run check` — exit 0.
- Fallback scope: **23 files / 232 tests passed**, including a new `test/suite/retry-fallback-expansion.test.ts`
  (key expansion, auth-tier ranking, precedence tie-break, openrouter denylist, variant collision, namespaced ids,
  tombstones, fan-out cap).
- **Real-CLI QA** (senpi-qa Channel 2 — the actual TUI in a pty, isolated `SENPI_CODING_AGENT_DIR`, `PI_OFFLINE=1`,
  real `~/.senpi` untouched and hash-verified). Fable 5 served *only* by `claude-sdk-oauth`, no `retry.fallbackChains`
  configured:

  ```
  claude-sdk-oauth/claude-fable-5 -> kimi-coding/k3:max, claude-sdk-oauth/claude-opus-5:xhigh, claude-sdk-oauth/claude-opus-4-8:xhigh
  Model fallback: enabled
  Revert policy: cooldown-expiry
  ```

  Before this change that model had **no chain at all**. That QA run is also what surfaced the fan-out cap and the
  display scoping — neither was visible to unit fixtures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the default model-fallback chain provider-agnostic using bare model families. Fable 5 now keeps a working chain across providers, and `/fallback` only lists selectable models.

- **New Features**
  - Default chain uses bare model ids that expand against the live registry; explicit `provider/model` selectors keep exact behavior.
  - Candidate ranking favors OAuth-credential providers, then a fixed precedence; fan-out capped at 2 providers per model; `openrouter` excluded from bare expansion.
  - Empty arrays `[]` are opt-out tombstones at both family and provider scopes; explicit canonical keys override the expanded default per provider.
  - Conservative family matching (exact id or dash-variant after stripping namespaces) prevents substring false positives.
  - `/fallback` display is scoped to `getAvailable()`; runtime still resolves against the full registry.
  - Drops the personal gateway id in favor of the `k3` family; docs and tests cover expansion, ranking, and tombstones.

- **Refactors**
  - Test fixtures replace `apitopia/...` with neutral `example-gateway/...` ids.

<sup>Written for commit ab849e858e1f0978b05d771bc10cb300fbac12e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

