### PR TITLE
fix(coding-agent): run extension slash commands immediately during active turns

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 ### Changed
 
+- Slash commands provided by extensions (`/todo`, `/goal`, `/help`, `/mcp`, and every
+  other registered command) now run the moment you press Enter, even while the agent
+  is mid-turn or compacting. Previously they were held until the turn finished
+  whenever a queued continuation (such as an active goal chain) owned the session,
+  so `/todo` appeared to do nothing until the agent stopped working.
+- `/ir` now refuses to switch sessions while the agent is working or compacting,
+  reporting that it is unavailable instead of aborting the in-flight run.
+
 - Changed the shipped default model-fallback chain from a provider-pinned literal
   (`anthropic/claude-fable-5` -> `apitopia/kimi-k3-unlocked:max`, `anthropic/claude-opus-5:xhigh`,
   `anthropic/claude-opus-4-8:xhigh`) to provider-agnostic model families

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2552,6 +2552,32 @@ export class AgentSession {
 			await userAbortPromise;
 			throwIfCancelled();
 		}
+
+		// Extension commands are UI actions, not prompts: dispatch them before the
+		// settled-session-work gate below. That gate makes a bare prompt() wait for
+		// _sessionWorkBarrier, which a scheduled continuation (goal chain, queued
+		// follow-up) holds for an entire run, so a command typed mid-turn used to run
+		// only after the turn ended. The registry lookup stays synchronous so ordinary
+		// text beginning with "/" gains no await before the prompt-start bookkeeping.
+		try {
+			if ((options?.expandPromptTemplates ?? true) && text.startsWith("/")) {
+				const spaceIndex = text.indexOf(" ");
+				const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+				if (this._extensionRunner.getCommand(commandName)) {
+					const handled = await this._tryExecuteExtensionCommand(text);
+					throwIfCancelled();
+					if (handled) {
+						options?.promptDisposition?.("handled");
+						options?.preflightResult?.(true);
+						return;
+					}
+				}
+			}
+		} catch (error) {
+			options?.preflightResult?.(false);
+			throw error;
+		}
+
 		const ownsPromptStart =
 			!this.isStreaming && !this._promptStartPending && options?.streamingBehavior === undefined;
 		if (ownsPromptStart) this._promptStartPending = true;
@@ -2612,19 +2638,6 @@ export class AgentSession {
 		};
 
 		try {
-			// Handle extension commands first (execute immediately, even during streaming)
-			// Extension commands manage their own LLM interaction via pi.sendMessage()
-			if (expandPromptTemplates && text.startsWith("/")) {
-				const handled = await this._tryExecuteExtensionCommand(text);
-				throwIfCancelled();
-				if (handled) {
-					// Extension command executed, no prompt to send
-					promptDisposition?.("handled");
-					preflightResult?.(true);
-					return;
-				}
-			}
-
 			// Emit input event for extension interception (before skill/template expansion)
 			let currentText = text;
 			let currentImages = options?.images;

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,39 @@
 # changes
 
+## Dispatch extension commands before settled session work (2026-08-09)
+
+### What changed
+
+- Registered extension slash commands now dispatch at the head of `AgentSession.prompt()`, after any
+  in-flight user-abort wait but before prompt-start ownership and the settled-session-work gate.
+- A synchronous command lookup avoids adding an await or widening prompt-start admission for unknown
+  leading-slash text. Handled commands preserve the existing `promptDisposition("handled")` and
+  `preflightResult(true)` callbacks; post-handler cancellation reports `preflightResult(false)` and
+  rethrows.
+
+### Why
+
+- Extension commands are UI actions, not prompts. Serializing them behind compaction or the
+  session-work barrier delayed command output until an active continuation run ended, even though
+  the same commands were intended to execute immediately.
+
+### Accepted behavior deltas
+
+- Idle extension commands now skip `_maybeRestoreFallbackPrimary()`. `/fast` and `/fallback` may
+  observe a fallback model whose cooldown has expired; the primary is still restored by the next
+  real prompt.
+- In print mode, a slash command in a scripted `-m` message list executes immediately rather than
+  after pending continuations.
+- App-server handled-command turn lifecycle behavior is unchanged, but command handling can now
+  complete earlier relative to its pre-existing started/user-message events.
+
+### Why this cannot be expressed externally
+
+- The settled-work admission gate and prompt-start bookkeeping live inside `AgentSession.prompt()`;
+  an extension command handler cannot run until core dispatch reaches it.
+- Expected merge-conflict zone: `agent-session.ts` at the head of `prompt()` around user-abort,
+  extension-command dispatch, prompt-start ownership, and settled-work admission.
+
 ## Degrade fallback-unavailable 429s to in-turn retry (2026-08-06)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,13 @@
 # Builtin extensions changes
 
+## import-repro: guard /ir against mid-run and mid-compaction dispatch (2026-08-09)
+
+- Extension commands now dispatch immediately inside `AgentSession.prompt()` (immediate-extension-commands plan), including while a run is streaming and while compaction is active. `/ir` replaces the live session through `ctx.switchSession()`, which aborts the in-flight turn without confirmation and — during compaction — fire-and-forget aborts the compaction task and disposes the session while that task is still unwinding (`agent-session-runtime.ts` `teardownCurrent` -> `abort()` -> `dispose()`).
+- The `/ir` handler now refuses with a warning notification (`/ir is unavailable while the agent is working`) when `ctx.isIdle()` is false or `ctx.isCompacting?.()` is true; idle behavior is unchanged, and the guard sits above argument validation so no fetch/write/switch work starts.
+- Why a per-handler guard instead of a core gate: the mid-turn audit of all builtin commands found only session-replacing `/ir` unsafe under immediate dispatch; the rest are read-only/UI, append-only (`appendCustomEntry` does not bump the message revision and survives compaction as a branch ancestor), host-guarded (`ctx.reload()` vetoes streaming and compaction), or defended by core design (model and tool-set changes invalidate/abort compaction deliberately). Verdict table: `.omo/evidence/task-3-immediate-extension-commands.md`.
+- Coverage: `test/suite/import-repro-builtin-extension.test.ts` asserts the notify+return path while streaming and while compacting, plus an idle passthrough control.
+- Expected merge conflict zones: LOW in `import-repro.ts` at the top of the `/ir` handler; LOW in `import-repro-builtin-extension.test.ts` around the new probe helpers.
+
 ## tps: concise turn cache-hit notice (2026-08-06)
 
 - The turn-completion TPS notification now renders

--- a/packages/coding-agent/src/core/extensions/builtin/import-repro.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/import-repro.ts
@@ -295,8 +295,10 @@ export default function (pi: ExtensionAPI) {
 		description: "Import a CI issue-analysis session from a gist ID, share URL, or issue URL and switch to it",
 		handler: async (args: string, ctx: ExtensionCommandContext) => {
 			// Session replacement aborts and disposes the live session; never start
-			// that while a run or compaction is active (immediate-dispatch audit,
-			// .omo/plans/immediate-extension-commands.md todo 3).
+			// that while a run or compaction is active. Commands dispatch immediately
+			// now (see extensions/builtin/changes.md), so this handler can be entered
+			// mid-turn. isCompacting is checked separately because isIdle() is true
+			// during compaction without streaming.
 			if (!ctx.isIdle() || ctx.isCompacting?.() === true) {
 				ctx.ui.notify("/ir is unavailable while the agent is working", "warning");
 				return;

--- a/packages/coding-agent/src/core/extensions/builtin/import-repro.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/import-repro.ts
@@ -294,6 +294,13 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("ir", {
 		description: "Import a CI issue-analysis session from a gist ID, share URL, or issue URL and switch to it",
 		handler: async (args: string, ctx: ExtensionCommandContext) => {
+			// Session replacement aborts and disposes the live session; never start
+			// that while a run or compaction is active (immediate-dispatch audit,
+			// .omo/plans/immediate-extension-commands.md todo 3).
+			if (!ctx.isIdle() || ctx.isCompacting?.() === true) {
+				ctx.ui.notify("/ir is unavailable while the agent is working", "warning");
+				return;
+			}
 			const ref = args.trim();
 			if (!ref) {
 				ctx.ui.notify("Usage: /ir <gist-id | gist-url | pi.dev/session URL | issue URL>", "error");

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## Correct extension-command immediate-dispatch comments (2026-08-09)
+
+### What changed
+
+- Updated the comments in the `onSubmit` handler and in `handleFollowUp` inside `src/modes/interactive/interactive-mode.ts` so they describe the post-fix dispatch flow accurately: extension commands short-circuit at the `isExtensionCommand` branch (the Enter path returns there) and dispatch immediately inside `AgentSession.prompt()` — including during compaction and barrier-held continuation runs — because `prompt()` now hoists the extension-command branch above the settled-work gate.
+- The `onSubmit` compaction branch comment now states that only non-command text reaches it (queued for post-compaction delivery) and notes that its `isExtensionCommand` re-check is already unreachable today (the earlier `isExtensionCommand` branch returns first) and stays harmless after the fix.
+- `handleFollowUp` is bound directly to `app.message.followUp` (Alt+Enter) and does NOT pass through `onSubmit`, so its `isExtensionCommand` check IS reachable and is the live dispatch point on that path; its comments say so explicitly instead of claiming an `onSubmit` short-circuit.
+- The streaming branch comment now clarifies that the steer/followUp behavior applies only to ordinary text, prompt template expansion, and queueing — extension commands are already dispatched immediately by `prompt()`.
+
+### Why
+
+- The previous comments claimed "extension commands execute immediately" in the compaction and streaming paths, which was false for the barrier-held and compaction cases until the parallel `AgentSession.prompt()` hoist landed. The corrected comments align the code's narrative with the actual post-fix control flow.
+
+### Why extension system couldn't handle this
+
+- The gate that serialized extension commands lives inside `AgentSession.prompt()` (core), not in the interactive mode. The TUI comments merely needed to stop asserting a behavior the TUI does not control.
+
+### Expected merge conflict zones
+
+- `src/modes/interactive/interactive-mode.ts`: the `onSubmit` dispatch block (compaction branch comment ~line 3591, streaming branch comment ~line 3608) and the `handleFollowUp` comments (~line 4785, ~line 4808).
+
 ## model selector search ranking and frozen ordering
 
 - Added `src/modes/interactive/model-search-rank.ts` so model search ranks each query token against the independent fields `id`, `name`, `provider`, and `provider/id` through a tier ladder (exact, whole token, boundary substring, substring, then `fuzzyMatch` as a last resort), with a canonical provider-path check and a favorites-first partition ahead of the relevance costs in the composite sort key.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3588,7 +3588,15 @@ export class InteractiveMode {
 				}
 			}
 
-			// Queue input during compaction (extension commands execute immediately)
+			// Queue non-command input during compaction.
+			// Extension commands short-circuit at the isExtensionCommand branch above and
+			// dispatch immediately inside AgentSession.prompt(), so the only text that
+			// reaches this compaction branch is non-command user input, which is queued
+			// for delivery after compaction settles.
+			//
+			// Note: the isExtensionCommand re-check below is already unreachable today
+			// (the branch above returns first) and stays harmless after the
+			// immediate-dispatch hoist in prompt().
 			if (this.session.isCompacting) {
 				if (this.isExtensionCommand(text)) {
 					this.editor.addToHistory?.(text);
@@ -3600,8 +3608,11 @@ export class InteractiveMode {
 				return;
 			}
 
-			// If streaming, use prompt() with steer behavior
-			// This handles extension commands (execute immediately), prompt template expansion, and queueing
+			// If streaming, use prompt() with steer behavior.
+			// Extension commands are dispatched immediately by AgentSession.prompt()
+			// (short-circuited at the isExtensionCommand branch above); the steer
+			// behavior here applies only to ordinary text, prompt template expansion,
+			// and queueing.
 			if (this.session.isStreaming) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
@@ -4771,7 +4782,12 @@ export class InteractiveMode {
 		const text = this.getExpandedEditorText().trim();
 		if (!text) return;
 
-		// Queue input during compaction (extension commands execute immediately)
+		// Queue non-command input during compaction; dispatch extension commands.
+		// This is the Alt+Enter path (bound directly to app.message.followUp), which
+		// does NOT pass through onSubmit, so the isExtensionCommand check below is the
+		// live dispatch point here: commands go straight to AgentSession.prompt(),
+		// which runs them immediately even while compaction is active, while ordinary
+		// text is queued for delivery after compaction settles.
 		if (this.session.isCompacting) {
 			if (this.isExtensionCommand(text)) {
 				this.editor.addToHistory?.(text);
@@ -4783,8 +4799,11 @@ export class InteractiveMode {
 			return;
 		}
 
-		// Alt+Enter queues a follow-up message (waits until agent finishes)
-		// This handles extension commands (execute immediately), prompt template expansion, and queueing
+		// Alt+Enter queues a follow-up message (waits until agent finishes).
+		// Extension commands never reach this branch: the compaction branch above
+		// dispatches them while compacting, and otherwise prompt() runs them
+		// immediately. The followUp behavior here applies only to ordinary text,
+		// prompt template expansion, and queueing.
 		if (this.session.isStreaming) {
 			this.editor.addToHistory?.(text);
 			this.editor.setText("");

--- a/packages/coding-agent/test/suite/import-repro-builtin-extension.test.ts
+++ b/packages/coding-agent/test/suite/import-repro-builtin-extension.test.ts
@@ -1,18 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
-import type { ExtensionAPI, ExtensionFactory } from "../../src/core/extensions/types.ts";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionFactory } from "../../src/core/extensions/types.ts";
+
+type CommandHandler = (args: string, ctx: ExtensionCommandContext) => Promise<void>;
 
 interface FactoryProbe {
 	readonly commands: Set<string>;
+	readonly handlers: Map<string, CommandHandler>;
 }
 
 function runFactory(factory: ExtensionFactory): FactoryProbe {
-	const probe: FactoryProbe = { commands: new Set() };
+	const probe: FactoryProbe = { commands: new Set(), handlers: new Map() };
 	const pi = new Proxy(
 		{},
 		{
 			get(_target, prop) {
-				if (prop === "registerCommand") return (name: string) => probe.commands.add(name);
+				if (prop === "registerCommand") {
+					return (name: string, spec?: { handler?: CommandHandler }) => {
+						probe.commands.add(name);
+						if (spec?.handler) probe.handlers.set(name, spec.handler);
+					};
+				}
 				return () => undefined;
 			},
 		},
@@ -21,15 +29,82 @@ function runFactory(factory: ExtensionFactory): FactoryProbe {
 	return probe;
 }
 
+function importReproFactory(): ExtensionFactory {
+	const entry = builtinExtensions.find((extension) => extension.id === "import-repro");
+	if (entry === undefined) {
+		throw new Error("missing import-repro builtin extension");
+	}
+	return entry.factory;
+}
+
+interface Notification {
+	readonly message: string;
+	readonly severity?: string;
+}
+
+/** Minimal command ctx: idle/compacting knobs, a notify sink, and a switchSession tripwire. */
+function busyCtx(options: {
+	idle: boolean;
+	compacting: boolean;
+	notifications: Notification[];
+}): ExtensionCommandContext {
+	return {
+		isIdle: () => options.idle,
+		isCompacting: () => options.compacting,
+		ui: {
+			notify: (message: string, severity?: string) => {
+				options.notifications.push({ message, severity });
+			},
+		},
+		switchSession: () => {
+			throw new Error("switchSession must not run while the agent is busy");
+		},
+	} as unknown as ExtensionCommandContext;
+}
+
 describe("import-repro builtin extension", () => {
 	it("registers the /ir command", () => {
-		const entry = builtinExtensions.find((extension) => extension.id === "import-repro");
-		if (entry === undefined) {
-			throw new Error("missing import-repro builtin extension");
-		}
-
-		const probe = runFactory(entry.factory);
+		const probe = runFactory(importReproFactory());
 
 		expect(probe.commands.has("ir")).toBe(true);
+	});
+
+	it("warns and returns without importing when the session is not idle", async () => {
+		const probe = runFactory(importReproFactory());
+		const handler = probe.handlers.get("ir");
+		if (handler === undefined) throw new Error("missing /ir handler");
+		const notifications: Notification[] = [];
+
+		await handler("", busyCtx({ idle: false, compacting: false, notifications }));
+
+		expect(notifications).toEqual([
+			{ message: "/ir is unavailable while the agent is working", severity: "warning" },
+		]);
+	});
+
+	it("warns and returns without importing while compaction is running", async () => {
+		const probe = runFactory(importReproFactory());
+		const handler = probe.handlers.get("ir");
+		if (handler === undefined) throw new Error("missing /ir handler");
+		const notifications: Notification[] = [];
+
+		await handler("", busyCtx({ idle: true, compacting: true, notifications }));
+
+		expect(notifications).toEqual([
+			{ message: "/ir is unavailable while the agent is working", severity: "warning" },
+		]);
+	});
+
+	it("still runs when the session is idle and not compacting", async () => {
+		const probe = runFactory(importReproFactory());
+		const handler = probe.handlers.get("ir");
+		if (handler === undefined) throw new Error("missing /ir handler");
+		const notifications: Notification[] = [];
+
+		await handler("", busyCtx({ idle: true, compacting: false, notifications }));
+
+		expect(notifications).toEqual([
+			{ message: "Usage: /ir <gist-id | gist-url | pi.dev/session URL | issue URL>", severity: "error" },
+		]);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/extension-command-immediate-dispatch.test.ts
+++ b/packages/coding-agent/test/suite/regressions/extension-command-immediate-dispatch.test.ts
@@ -1,0 +1,231 @@
+import { setImmediate as waitForImmediate } from "node:timers/promises";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "../../../src/index.ts";
+import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "../harness.ts";
+
+type Deferred = {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+};
+
+type SessionWorkBarrier = {
+	readonly hasActiveWork: boolean;
+	begin(): () => void;
+};
+
+function createDeferred(): Deferred {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+function continuationExtension(pi: ExtensionAPI): void {
+	let queued = false;
+	pi.on("agent_end", async () => {
+		if (queued) return;
+		queued = true;
+		await waitForImmediate();
+		pi.sendMessage(
+			{ customType: "test-continuation", content: "continue the test", display: false },
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
+	});
+}
+
+function commandExtension(commandRuns: string[]) {
+	return (pi: ExtensionAPI): void => {
+		pi.registerCommand("testcmd", {
+			description: "Test command",
+			handler: async (args) => {
+				commandRuns.push(args);
+			},
+		});
+	};
+}
+
+function getSessionWorkBarrier(harness: Harness): SessionWorkBarrier {
+	const barrier = Reflect.get(harness.session, "_sessionWorkBarrier");
+	if (
+		!barrier ||
+		typeof barrier !== "object" ||
+		!("hasActiveWork" in barrier) ||
+		!("begin" in barrier) ||
+		typeof barrier.begin !== "function"
+	) {
+		throw new Error("Expected AgentSession._sessionWorkBarrier");
+	}
+	return barrier as SessionWorkBarrier;
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs = 250): Promise<boolean> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise.then(() => true),
+			new Promise<boolean>((resolve) => {
+				timeout = setTimeout(() => resolve(false), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout);
+	}
+}
+
+describe("extension command immediate dispatch", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("dispatches during a barrier-held continuation run", async () => {
+		const commandRuns: string[] = [];
+		const toolStarted = createDeferred();
+		const toolRelease = createDeferred();
+		const waitTool: AgentTool = {
+			name: "wait",
+			label: "Wait",
+			description: "Wait for release",
+			parameters: Type.Object({}),
+			execute: async () => {
+				toolStarted.resolve();
+				await toolRelease.promise;
+				return { content: [{ type: "text", text: "released" }], details: {} };
+			},
+		};
+		const harness = await createHarness({
+			tools: [waitTool],
+			extensionFactories: [continuationExtension, commandExtension(commandRuns)],
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("turn one done"),
+			fauxAssistantMessage(fauxToolCall("wait", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("continuation completed"),
+		]);
+
+		const runPromise = harness.session.prompt("start");
+		await toolStarted.promise;
+		expect(harness.session.isStreaming).toBe(true);
+		expect(getSessionWorkBarrier(harness).hasActiveWork).toBe(true);
+
+		const userTextsBeforeCommand = getUserTexts(harness);
+		const preflightResults: boolean[] = [];
+		const dispositions: string[] = [];
+		const commandPrompt = harness.session.prompt("/testcmd now", {
+			preflightResult: (accepted) => preflightResults.push(accepted),
+			promptDisposition: (disposition) => dispositions.push(disposition),
+		});
+
+		try {
+			expect(await settlesWithin(commandPrompt), "command prompt must resolve before the run is released").toBe(
+				true,
+			);
+			expect(commandRuns).toEqual(["now"]);
+			expect(getUserTexts(harness)).toEqual(userTextsBeforeCommand);
+			expect(preflightResults).toEqual([true]);
+			expect(dispositions).toEqual(["handled"]);
+			expect(harness.session.isStreaming).toBe(true);
+		} finally {
+			toolRelease.resolve();
+			await Promise.allSettled([runPromise, commandPrompt]);
+		}
+
+		await harness.session.waitForIdle();
+		expect(getAssistantTexts(harness)).toContain("continuation completed");
+	});
+
+	it("dispatches while compaction is blocked in session_before_compact", async () => {
+		const commandRuns: string[] = [];
+		const compactionStarted = createDeferred();
+		const compactionRelease = createDeferred();
+		const harness = await createHarness({
+			models: [{ id: "tiny-context", contextWindow: 128, maxTokens: 64 }],
+			settings: { compaction: { enabled: true, reserveTokens: 64, keepRecentTokens: 1 } },
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", async (event) => {
+						compactionStarted.resolve();
+						await compactionRelease.promise;
+						return {
+							compaction: {
+								summary: "blocked compaction summary",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+							},
+						};
+					});
+				},
+				commandExtension(commandRuns),
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("prompt completed after compaction")]);
+
+		const runPromise = harness.session.prompt("initial prompt ".repeat(120));
+		await compactionStarted.promise;
+		expect(harness.session.isCompacting).toBe(true);
+
+		const userTextsBeforeCommand = getUserTexts(harness);
+		const preflightResults: boolean[] = [];
+		const dispositions: string[] = [];
+		const commandPrompt = harness.session.prompt("/testcmd during-compaction", {
+			preflightResult: (accepted) => preflightResults.push(accepted),
+			promptDisposition: (disposition) => dispositions.push(disposition),
+		});
+
+		try {
+			expect(await settlesWithin(commandPrompt), "command prompt must resolve before compaction is released").toBe(
+				true,
+			);
+			expect(commandRuns).toEqual(["during-compaction"]);
+			expect(getUserTexts(harness)).toEqual(userTextsBeforeCommand);
+			expect(preflightResults).toEqual([true]);
+			expect(dispositions).toEqual(["handled"]);
+			expect(harness.session.isCompacting).toBe(true);
+		} finally {
+			compactionRelease.resolve();
+			await Promise.allSettled([runPromise, commandPrompt]);
+		}
+
+		expect(getAssistantTexts(harness)).toContain("prompt completed after compaction");
+	});
+
+	it("dispatches while idle with session work held", async () => {
+		const commandRuns: string[] = [];
+		const harness = await createHarness({ extensionFactories: [commandExtension(commandRuns)] });
+		harnesses.push(harness);
+		const barrier = getSessionWorkBarrier(harness);
+		const finishHeldWork = barrier.begin();
+		expect(harness.session.isStreaming).toBe(false);
+		expect(barrier.hasActiveWork).toBe(true);
+
+		const userTextsBeforeCommand = getUserTexts(harness);
+		const preflightResults: boolean[] = [];
+		const dispositions: string[] = [];
+		const commandPrompt = harness.session.prompt("/testcmd idle-work", {
+			preflightResult: (accepted) => preflightResults.push(accepted),
+			promptDisposition: (disposition) => dispositions.push(disposition),
+		});
+
+		try {
+			expect(await settlesWithin(commandPrompt), "command prompt must resolve before held work is released").toBe(
+				true,
+			);
+			expect(commandRuns).toEqual(["idle-work"]);
+			expect(getUserTexts(harness)).toEqual(userTextsBeforeCommand);
+			expect(preflightResults).toEqual([true]);
+			expect(dispositions).toEqual(["handled"]);
+			expect(barrier.hasActiveWork).toBe(true);
+		} finally {
+			finishHeldWork();
+			await Promise.allSettled([commandPrompt]);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Typing an extension slash command (e.g. `/todo`) while the agent is mid-turn showed its output only **after the turn ended**.

`AgentSession.prompt()` dispatched extension commands *below* the settled-session-work gate:

- `interactive-mode.ts:3566` routes Enter-submitted commands to `session.prompt(text)` with no `streamingBehavior`.
- `agent-session.ts:2580-2588` then awaits `_waitForSettledSessionWork()` before reaching the command dispatch.
- `_scheduleContinuationAfterCurrentEvent()` (`agent-session.ts:4904`) holds the `SessionWorkBarrier` for an **entire** continued run, so in goal-armed sessions every turn deferred commands to turn end. The same happened during compaction.

Two asymmetries showed this was unintended: the Alt+Enter path passes `streamingBehavior`, hits the `canQueueWhileStreaming` exemption, and already ran commands immediately; and builtin TUI commands (`/model`, `/fork`, …) were always immediate. The in-code comments claimed "extension commands execute immediately" — false for exactly these cases.

## Change

1. **Hoist the dispatch** above the prompt-start bookkeeping and the settled-work gate. A **synchronous** `getCommand()` lookup runs first, so ordinary `/`-leading text gains no new await; a dedicated catch mirrors the existing `preflightResult(false)` + rethrow contract. Fixes every caller at once — TUI Enter path, the compaction path, RPC, print mode.
2. **Guard `/ir`.** Immediate dispatch newly exposes handlers to running turns *and* active compaction. An audit of all 23 registered command handlers found `/ir` alone unsafe (it aborts + disposes the live session; during compaction the fire-and-forget `abortCompaction()` races `dispose()`). Both `ctx.isIdle()` and `ctx.isCompacting?.()` are needed — `isIdle()` is true during compaction without streaming. Every other handler is safe or already reachable mid-turn via Alt+Enter.
3. **Corrected comments** in `onSubmit` / `handleFollowUp`. Note `handleFollowUp` is bound directly to `app.message.followUp` and never traverses `onSubmit`, so its command check is genuinely reachable.

## Verification

**Regression tests** (`test/suite/regressions/extension-command-immediate-dispatch.test.ts`, TDD — RED captured before the fix, plus a mutation proof that reverting the hoist re-reds all three):

- Case A barrier-held continuation run · Case B blocked `session_before_compact` compaction · Case C idle with a held barrier
- Each asserts dispatch resolves *before* the held work is released, the run/compaction completes intact, no slash-command user message is appended, and `preflightResult(true)` / `promptDisposition("handled")` fire.

**Pinned contracts stay green:** `2023-queued-slash-command-followup`, `goal-continuation-streaming-prompt-trap`, `agent-session-prompt`, `agent-session-queue` (queueing semantics untouched).

**Scoped run:** 9 files, 67/67 passing. **`npm run check`:** exit 0.

**Full suite:** 11 files fail on this branch — a strict **subset** of the 12 that fail on the base commit `ec17cfc8a` (rpc, stdout-cleanliness, session-*, mcp oauth-race, fswatch flakes). Zero new failures; `footer-data-provider` fails on base but passes here.

**Real-CLI QA** (senpi-qa tool-serve mock + tmux driver, hermetic sandbox, zero tokens) — captured ordering from the live TUI:

| event | index in capture |
|---|---|
| `/todo append` notify | 49879 |
| `/todo` markdown `- [ ] Qa item` | 54694 |
| final assistant text | 77335 |

The mid-turn screenshot shows the rendered todo widget while the status line still reads `● Working (16s • esc to interrupt)`. Pre-fix both outputs appeared only after index 77335. Teardown receipt recorded: tmux session killed, serve process dead, sandbox removed, real `auth.json` sha256 unchanged.

Plan: `.omo/plans/immediate-extension-commands.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run extension slash commands immediately during active turns and compaction by hoisting dispatch in `AgentSession.prompt()`. Also block `/ir` while the agent is busy to prevent unsafe session switches, and update comments/docs to match.

- **Bug Fixes**
  - Slash commands typed mid-turn (or during compaction) now execute immediately; they were previously delayed by the session-work barrier.
  - Dispatch occurs before the settled-work gate; unknown “/”-leading text is unaffected. Handled commands still call `promptDisposition("handled")` and `preflightResult(true)` with no user message added.
  - Guarded `/ir`: warn and return when streaming or compacting to avoid replacing the live session mid-run.
  - Updated comments in interactive mode and the `/ir` handler (now pointing to `extensions/builtin/changes.md`), and added a `CHANGELOG.md` entry.

<sup>Written for commit 846e074c9d29a47ea220fc1cd55f7c07b7f051c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

