### PR TITLE
docs(coding-agent): complete v2026.8.9 changelog audit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,10 +24,12 @@
   (`claude-fable-5` -> `k3:max`, `claude-opus-5:xhigh`, `claude-opus-4-8:xhigh`) that expand against the live
   model registry. Fable 5 now keeps a working fallback chain no matter which provider serves it - the builtin
   Anthropic provider, the Claude SDK OAuth extension, a gateway, or Bedrock - instead of silently losing the
-  chain and leaving provider-side fallback aborted with nothing to fall back to. Bare selectors expand to
-  OAuth-credential providers first, then a fixed precedence order, and never to OpenRouter; explicit
-  `provider/model` chains keep exact behavior, and `retry.fallbackChains` accepts a bare model id as a
-  family-wide key with `[]` still opting out ([#761](https://github.com/code-yeongyu/senpi/pull/761)).
+  chain and leaving provider-side fallback aborted with nothing to fall back to. Bare selectors expand to at most two
+  providers, preferring OAuth credentials, then API keys, then a fixed provider precedence, and never OpenRouter.
+  Candidates now resolve only through usable models, and `/fallback` hides family expansions that are unavailable or
+  excluded by the active selectable-model filter instead of advertising dead routes. Explicit `provider/model` chains
+  keep exact behavior, and `retry.fallbackChains` accepts a bare model id as a family-wide key with `[]` still opting
+  out ([#761](https://github.com/code-yeongyu/senpi/pull/761)).
 - Changed `/model` search ranking to a model-aware scorer that matches query tokens against the model id, name,
   provider, and `provider/id` independently instead of one concatenated string. Exact, whole-token, and
   word-boundary matches now beat scattered subsequence matches, so `opus 5` ranks `claude-opus-5` first and an exact


### PR DESCRIPTION
## Summary

- completes the `v2026.8.7..origin/main` changelog audit across all 49 revisions
- expands the fallback-family release note for the final behavior in `40be790b0`
- documents the two-provider cap, auth-tier ordering, usable-model resolution, and selectable-model filtering

## Evidence

- RED: the pre-edit entry omitted the two-provider cap and usable/selectable-model scoping
- GREEN: focused coverage assertion reports `missing: []`
- `node scripts/check-pr-changelog.mjs --base origin/main`
- `git diff --check`

## Scope

Prose-only release preparation. No runtime source or released changelog section changed.

## Release

Target CalVer: `2026.8.9`

Plan: `.omo/plans/release-2026-08-09.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completed the v2026.8.9 changelog audit for `packages/coding-agent`, expanding the fallback-family note and clarifying selector behavior. Added details on the two-provider cap, auth-tier ordering (OAuth first, then API keys, then fixed precedence), usable-model-only resolution, and selectable-model filtering; docs only.

<sup>Written for commit a32c5eba7ed95250beff3e2906ec33ff3397f073. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

