### PR TITLE
feat(coding-agent): derive goal backstop delay from prompt-cache budget and count warm iterations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,11 @@
 
 ### Added
 
+- Goal cache-warm wait and wake entries now show an in-memory iteration number for each accepted monitor cycle, resetting when the Goal or wake epoch changes while remaining compatible with legacy persisted entries.
+
 ### Changed
+
+- Goal monitor continuation backstops now derive from the active model's prompt-cache safe-wait budget instead of a fixed four-minute delay, capped by `promptCache.goalBackstopMaxSeconds` (default 3570 seconds). Held direct-input admission now consumes wall-clock time, and cache-warm notices no longer claim warmth or savings after the cache TTL may have elapsed.
 
 ### Fixed
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5313,8 +5313,7 @@ export class AgentSession {
 				getContextUsage: () => this.getContextUsage(),
 				getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
 				getPromptCacheSafeWaitSeconds: () => this.resolvePromptCacheSafeWaitSeconds(),
-				getPromptCacheGoalBackstopMaxSeconds: () =>
-					this.settingsManager.getPromptCacheGoalBackstopMaxSeconds(),
+				getPromptCacheGoalBackstopMaxSeconds: () => this.settingsManager.getPromptCacheGoalBackstopMaxSeconds(),
 				getLookAtSettings: () => {
 					const global = this.settingsManager.getGlobalSettings().lookAt;
 					const project = this.settingsManager.getProjectSettings().lookAt;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5313,6 +5313,8 @@ export class AgentSession {
 				getContextUsage: () => this.getContextUsage(),
 				getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
 				getPromptCacheSafeWaitSeconds: () => this.resolvePromptCacheSafeWaitSeconds(),
+				getPromptCacheGoalBackstopMaxSeconds: () =>
+					this.settingsManager.getPromptCacheGoalBackstopMaxSeconds(),
 				getLookAtSettings: () => {
 					const global = this.settingsManager.getGlobalSettings().lookAt;
 					const project = this.settingsManager.getProjectSettings().lookAt;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
@@ -5,15 +5,13 @@ import {
 	formatSavedUsd,
 	formatWakeDuration,
 	formatWarmTokenCount,
-	type GoalCacheWarmMetrics,
 	type GoalCacheWarmupEntryData,
-	type GoalCacheWarmupPhase,
 } from "./cache-warm.ts";
 
 export const renderGoalCacheWarmupEntry: EntryRenderer<GoalCacheWarmupEntryData> = noticeEntryRenderer((entry) => {
 	const data = entry.data;
 	if (data === undefined) return undefined;
-	const warm = warmLine(data.phase, data.cache);
+	const warm = warmLine(data);
 	return {
 		title: titleLine(data),
 		why: whyLine(data),
@@ -36,19 +34,28 @@ function whyLine(data: GoalCacheWarmupEntryData): string {
 	switch (data.phase) {
 		case "scheduled": {
 			const deferred = `Continuation deferred ${formatWakeDuration(data.delayMs)}`;
-			return data.cache?.ttlSeconds !== undefined
+			if (data.cache?.ttlSeconds === undefined) {
+				return `${deferred} - the monitor wakes the goal the moment decisive output lands.`;
+			}
+			return data.delayMs < data.cache.ttlSeconds * 1000
 				? `${deferred} - the timed wake stays inside the ${formatCacheTtl(data.cache.ttlSeconds)} prompt-cache TTL.`
-				: `${deferred} - the monitor wakes the goal the moment decisive output lands.`;
+				: `${deferred} - the prompt-cache TTL may elapse before the timed wake.`;
 		}
 		case "resumed":
 			return "Woke on schedule to keep pursuing the goal.";
 	}
 }
 
-function warmLine(phase: GoalCacheWarmupPhase, cache: GoalCacheWarmMetrics | undefined): string | undefined {
+function warmLine(data: GoalCacheWarmupEntryData): string | undefined {
+	const cache = data.cache;
 	if (cache === undefined || cache.cachedTokens <= 0) return undefined;
 	const tokens = `~${formatWarmTokenCount(cache.cachedTokens)} tokens`;
-	const body = phase === "scheduled" ? `${tokens} kept warm` : `${tokens} stayed warm in the prompt cache`;
+	const ttlMayHaveElapsed =
+		cache.ttlSeconds !== undefined && (data.waitedMs ?? data.delayMs) >= cache.ttlSeconds * 1000;
+	if (ttlMayHaveElapsed) {
+		return `${tokens} were cached after the prior turn · prompt-cache TTL may have elapsed before this wake`;
+	}
+	const body = data.phase === "scheduled" ? `${tokens} kept warm` : `${tokens} stayed warm in the prompt cache`;
 	const saved =
 		cache.estimatedSavedUsd !== undefined && cache.estimatedSavedUsd > 0
 			? ` · est. ${formatSavedUsd(cache.estimatedSavedUsd)} saved vs a cold re-read`

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
@@ -22,12 +22,18 @@ export const renderGoalCacheWarmupEntry: EntryRenderer<GoalCacheWarmupEntryData>
 
 function titleLine(data: GoalCacheWarmupEntryData): string {
 	const monitors = data.activeMonitorCount === 1 ? "1 monitor on duty" : `${data.activeMonitorCount} monitors on duty`;
+	const iteration = validIteration(data.iteration);
+	const iterationText = iteration === undefined ? "" : ` · iteration ${iteration}`;
 	switch (data.phase) {
 		case "scheduled":
-			return `⚡ Cache-warm wait · ${monitors}`;
+			return `⚡ Cache-warm wait${iterationText} · ${monitors}`;
 		case "resumed":
-			return `⚡ Cache-warm wake · waited ${formatWakeDuration(data.waitedMs ?? data.delayMs)} · ${monitors}`;
+			return `⚡ Cache-warm wake${iterationText} · waited ${formatWakeDuration(data.waitedMs ?? data.delayMs)} · ${monitors}`;
 	}
+}
+
+function validIteration(value: number | undefined): number | undefined {
+	return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
 }
 
 function whyLine(data: GoalCacheWarmupEntryData): string {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
@@ -21,13 +21,12 @@ export function resolveGoalMonitorContinuationDelayMs(
 		return GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS;
 	}
 	const configuredCeilingMs =
-		typeof goalBackstopMaxSeconds === "number" && Number.isFinite(goalBackstopMaxSeconds) && goalBackstopMaxSeconds > 0
+		typeof goalBackstopMaxSeconds === "number" &&
+		Number.isFinite(goalBackstopMaxSeconds) &&
+		goalBackstopMaxSeconds > 0
 			? Math.min(goalBackstopMaxSeconds * 1000, GOAL_MONITOR_CONTINUATION_HARD_CEILING_MS)
 			: GOAL_MONITOR_CONTINUATION_HARD_CEILING_MS;
-	return Math.max(
-		GOAL_MONITOR_CONTINUATION_MIN_DELAY_MS,
-		Math.min(cacheSafeWaitSeconds * 1000, configuredCeilingMs),
-	);
+	return Math.max(GOAL_MONITOR_CONTINUATION_MIN_DELAY_MS, Math.min(cacheSafeWaitSeconds * 1000, configuredCeilingMs));
 }
 
 /** Cache context captured when a monitor-wait continuation is scheduled. */
@@ -50,6 +49,8 @@ export type GoalCacheWarmupPhase = "scheduled" | "resumed";
 export interface GoalCacheWarmupEntryData {
 	readonly phase: GoalCacheWarmupPhase;
 	readonly goalId: string;
+	/** Display ordinal within the current in-memory Goal/wake epoch; absent on legacy persisted entries. */
+	readonly iteration?: number;
 	/** Planned continuation delay in milliseconds. */
 	readonly delayMs: number;
 	/** Actual wait in milliseconds; present on the `resumed` phase only. */
@@ -59,6 +60,9 @@ export interface GoalCacheWarmupEntryData {
 	readonly channelCounts?: Readonly<Record<string, number>>;
 	readonly cache?: GoalCacheWarmMetrics;
 }
+
+/** Live entries always carry an iteration; the ordinal is intentionally not persisted into Goal state. */
+export type LiveGoalCacheWarmupEntryData = GoalCacheWarmupEntryData & { readonly iteration: number };
 
 const TOKENS_PER_PRICE_UNIT = 1_000_000;
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
@@ -5,6 +5,31 @@ import type { TokenUsageSnapshot } from "./types.ts";
 /** Custom session-entry type carrying the cache-warm continuation story. */
 export const GOAL_CACHE_WARMUP_ENTRY_TYPE = "goal-cache-warmup";
 
+export const GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS = 240_000;
+const GOAL_MONITOR_CONTINUATION_MIN_DELAY_MS = 1_000;
+const GOAL_MONITOR_CONTINUATION_HARD_CEILING_MS = 3_600_000;
+
+export function resolveGoalMonitorContinuationDelayMs(
+	cacheSafeWaitSeconds: number | undefined,
+	goalBackstopMaxSeconds?: number,
+): number {
+	if (
+		typeof cacheSafeWaitSeconds !== "number" ||
+		!Number.isFinite(cacheSafeWaitSeconds) ||
+		cacheSafeWaitSeconds <= 0
+	) {
+		return GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS;
+	}
+	const configuredCeilingMs =
+		typeof goalBackstopMaxSeconds === "number" && Number.isFinite(goalBackstopMaxSeconds) && goalBackstopMaxSeconds > 0
+			? Math.min(goalBackstopMaxSeconds * 1000, GOAL_MONITOR_CONTINUATION_HARD_CEILING_MS)
+			: GOAL_MONITOR_CONTINUATION_HARD_CEILING_MS;
+	return Math.max(
+		GOAL_MONITOR_CONTINUATION_MIN_DELAY_MS,
+		Math.min(cacheSafeWaitSeconds * 1000, configuredCeilingMs),
+	);
+}
+
 /** Cache context captured when a monitor-wait continuation is scheduled. */
 export interface GoalCacheWarmMetrics {
 	/** Prompt-cache TTL of the active model in seconds, when known. */

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,30 @@
 # goal Extension Changes
 
+## Cache-safe backstops and warm-iteration ordinals (2026-08-09)
+
+### What changed
+
+- Monitor continuation delays snapshot the active extension context's prompt-cache safe-wait budget and apply the configured `promptCache.goalBackstopMaxSeconds` ceiling, with the former four-minute value retained only as the unknown-budget fallback.
+- Direct-input holds now consume elapsed wall-clock time instead of restarting the held remainder, and wait progress keeps the originally scheduled total.
+- Cache-warm rendering stops claiming that tokens remained warm or produced savings when the planned or actual wait reaches the displayed cache TTL.
+- Cache-warm scheduled/resumed events and durable entries carry an optional per-epoch iteration ordinal; legacy entries omit the iteration wording.
+
+### Why
+
+- Provider lanes expose materially different cache-safe budgets. A fixed four-minute backstop wakes long-TTL lanes too often and ignores the existing provider-aware budget resolver.
+- Input admission time is still real cache age, so pausing the timer during admission could overrun the captured budget.
+- Iteration ordinals make repeated warm cycles understandable without persisting session-global state or mislabeling old entries.
+
+### Why an extension couldn't do it
+
+- The resolved prompt-cache budget and merged settings are owned by the session core and must cross the typed extension-context boundary.
+- Goal's monitor timer, durable entry payload, and renderer are private builtin implementation surfaces.
+
+### Expected merge conflict zones
+
+- MEDIUM in `monitor-continuation.ts`, `cache-warm.ts`, and `cache-warm-renderer.ts` around scheduling and entry payloads.
+- LOW in `settings-manager.ts`, extension context plumbing, and goal-monitor test harnesses.
+
 ## Reload snapshots survive first session start (2026-08-09)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -8,9 +8,12 @@ import {
 	GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS,
 	type GoalCacheWarmMetrics,
 	type GoalCacheWarmupEntryData,
+	type LiveGoalCacheWarmupEntryData,
 	resolveGoalMonitorContinuationDelayMs,
 } from "./cache-warm.ts";
+
 export { GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS } from "./cache-warm.ts";
+
 import {
 	continuationTurnUsedTools,
 	evaluateGoalContinuation,
@@ -69,9 +72,9 @@ export class MonitorAwareGoalContinuation {
 	#scheduledDueAtMs: number | undefined;
 	#scheduledCache: GoalCacheWarmMetrics | undefined;
 	#scheduledDelayMs: number | undefined;
-	#heldTimer:
-		| { kind: DelayedContinuationKind; remainingMs: number; heldAtMs: number; totalMs: number }
-		| undefined;
+	#cacheWarmIteration = 0;
+	#scheduledCacheWarmIteration: number | undefined;
+	#heldTimer: { kind: DelayedContinuationKind; remainingMs: number; heldAtMs: number; totalMs: number } | undefined;
 	#directInputHolds = new Set<string>();
 	#pendingSystemRecovery: SystemAbortOptions | undefined;
 
@@ -100,7 +103,7 @@ export class MonitorAwareGoalContinuation {
 	}
 
 	async afterAgentEnd(options: AgentEndOptions): Promise<Goal | null> {
-		if (options.goal?.id !== this.#goal?.id) this.#resetToollessContinuationStreak();
+		if (options.goal?.id !== this.#goal?.id) this.#resetContinuationState();
 		this.#ctx = options.ctx;
 		this.#goal = options.goal;
 		this.#lastAgentEndMessages = options.messages;
@@ -110,6 +113,7 @@ export class MonitorAwareGoalContinuation {
 		this.#recordAssistantOutput(options.messages, turnUsedTools);
 		if (options.goal?.status !== "active") {
 			this.#cancelTimer();
+			this.#resetContinuationState();
 			return options.goal;
 		}
 		this.#recordToollessContinuationTurn(options.goal, turnUsedTools);
@@ -157,12 +161,17 @@ export class MonitorAwareGoalContinuation {
 
 	async afterSystemAbort(options: SystemAbortOptions): Promise<Goal | null> {
 		this.noteContinuationStarted();
+		if (options.goal?.id !== this.#goal?.id) this.#resetContinuationState();
 		this.#pendingSystemRecovery = undefined;
 		this.#ctx = options.ctx;
 		this.#goal = options.goal;
 		this.#lastAgentEndMessages = options.messages;
 		this.#lastTurnUsage = collectAssistantUsage([...options.messages]);
-		if (options.willRetry || options.goal?.status !== "active") return options.goal;
+		if (options.goal?.status !== "active") {
+			this.#resetContinuationState();
+			return options.goal;
+		}
+		if (options.willRetry) return options.goal;
 		if (this.#activeChannelCount() > 0) this.#schedule(options.goal, "monitor");
 		else if (lastAssistantMessage(options.messages)?.stopReason === "error") {
 			this.#pendingSystemRecovery = options;
@@ -260,6 +269,9 @@ export class MonitorAwareGoalContinuation {
 				: GOAL_USER_GRACE_DELAY_MS;
 		this.#scheduledDelayMs = delayMs;
 		if (kind === "monitor") {
+			this.#cacheWarmIteration += 1;
+			this.#scheduledCacheWarmIteration = this.#cacheWarmIteration;
+			const iteration = this.#scheduledCacheWarmIteration;
 			const cache = estimateCacheWarmMetrics(this.#ctx?.model, process.env, this.#lastTurnUsage);
 			const channelCounts = this.#channelCountSnapshot();
 			this.#scheduledCache = cache;
@@ -267,6 +279,7 @@ export class MonitorAwareGoalContinuation {
 			this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
 				goalId: goal.id,
 				delayMs,
+				iteration,
 				activeMonitorCount: this.#activeTerminalMonitorCount(),
 				channelCounts,
 				cache,
@@ -275,6 +288,7 @@ export class MonitorAwareGoalContinuation {
 				phase: "scheduled",
 				goalId: goal.id,
 				delayMs,
+				iteration,
 				activeMonitorCount: this.#activeTerminalMonitorCount(),
 				channelCounts,
 				...(cache !== undefined ? { cache } : {}),
@@ -282,6 +296,7 @@ export class MonitorAwareGoalContinuation {
 		} else {
 			this.#scheduledAtMs = undefined;
 			this.#scheduledCache = undefined;
+			this.#scheduledCacheWarmIteration = undefined;
 		}
 		this.#scheduledContinuationKind = kind;
 		if (this.#directInputHolds.size > 0) {
@@ -317,13 +332,16 @@ export class MonitorAwareGoalContinuation {
 		this.#scheduledDueAtMs = undefined;
 		this.#scheduledContinuationKind = undefined;
 		this.#waitTicker?.stop();
-		const delayMs = this.#scheduledDelayMs ??
+		const delayMs =
+			this.#scheduledDelayMs ??
 			(kind === "monitor" ? GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS : GOAL_USER_GRACE_DELAY_MS);
 		const waitedMs = this.#scheduledAtMs === undefined ? delayMs : Math.max(0, Date.now() - this.#scheduledAtMs);
 		const cache = this.#scheduledCache;
+		const iteration = this.#scheduledCacheWarmIteration;
 		this.#scheduledAtMs = undefined;
 		this.#scheduledCache = undefined;
 		this.#scheduledDelayMs = undefined;
+		this.#scheduledCacheWarmIteration = undefined;
 		const ctx = this.#ctx;
 		const goal = this.#goal;
 		if (ctx === undefined || goal?.status !== "active" || !ctx.isIdle() || ctx.hasPendingMessages()) return;
@@ -334,12 +352,13 @@ export class MonitorAwareGoalContinuation {
 			kind === "monitor" ? "monitorDelayed" : "userGrace",
 			this.#lastAgentEndMessages,
 		);
-		if (kind !== "monitor" || !admission.admitted) return;
+		if (kind !== "monitor" || !admission.admitted || iteration === undefined) return;
 		const channelCounts = this.#channelCountSnapshot();
 		this.#pi.events?.emit(GOAL_CONTINUATION_RESUMED_EVENT, {
 			goalId: goal.id,
 			delayMs,
 			waitedMs,
+			iteration,
 			activeMonitorCount: this.#activeTerminalMonitorCount(),
 			channelCounts,
 			cache,
@@ -349,10 +368,12 @@ export class MonitorAwareGoalContinuation {
 			goalId: goal.id,
 			delayMs,
 			waitedMs,
+			iteration,
 			activeMonitorCount: this.#activeTerminalMonitorCount(),
 			channelCounts,
 			...(cache !== undefined ? { cache } : {}),
 		});
+		if (admission.goal.status !== "active") this.#resetCacheWarmIteration();
 	}
 
 	async #admitAndQueue(
@@ -379,7 +400,7 @@ export class MonitorAwareGoalContinuation {
 		return { goal: admittedGoal, admitted: verdict.kind === "continue" };
 	}
 
-	#appendWarmupEntry(data: GoalCacheWarmupEntryData): void {
+	#appendWarmupEntry(data: LiveGoalCacheWarmupEntryData): void {
 		this.#pi.appendEntry?.<GoalCacheWarmupEntryData>(GOAL_CACHE_WARMUP_ENTRY_TYPE, data);
 	}
 
@@ -478,6 +499,7 @@ export class MonitorAwareGoalContinuation {
 		if (previousTotal > 0 && nextTotal === 0) {
 			if (this.#scheduledContinuationKind === "monitor") this.#cancelTimer();
 			this.#resetToollessContinuationStreak();
+			this.#resetCacheWarmIteration();
 			return;
 		}
 		if (this.#scheduledContinuationKind === "monitor") {
@@ -513,6 +535,12 @@ export class MonitorAwareGoalContinuation {
 		this.#consecutiveLengthRecoveries.clear();
 		this.#recentNormalizedOutputHashes = [];
 		this.#resetToollessContinuationStreak();
+		this.#resetCacheWarmIteration();
+	}
+
+	#resetCacheWarmIteration(): void {
+		this.#cacheWarmIteration = 0;
+		this.#scheduledCacheWarmIteration = undefined;
 	}
 
 	#resetToollessContinuationStreak(): void {
@@ -525,6 +553,7 @@ export class MonitorAwareGoalContinuation {
 		this.#scheduledDueAtMs = undefined;
 		this.#scheduledCache = undefined;
 		this.#scheduledDelayMs = undefined;
+		this.#scheduledCacheWarmIteration = undefined;
 		this.#heldTimer = undefined;
 		if (this.#timer !== undefined) clearTimeout(this.#timer);
 		this.#timer = undefined;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -5,9 +5,12 @@ import { isResumptionChannelStateEvent, RESUMPTION_CHANNEL_STATE_EVENT } from ".
 import {
 	estimateCacheWarmMetrics,
 	GOAL_CACHE_WARMUP_ENTRY_TYPE,
+	GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS,
 	type GoalCacheWarmMetrics,
 	type GoalCacheWarmupEntryData,
+	resolveGoalMonitorContinuationDelayMs,
 } from "./cache-warm.ts";
+export { GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS } from "./cache-warm.ts";
 import {
 	continuationTurnUsedTools,
 	evaluateGoalContinuation,
@@ -39,7 +42,6 @@ import { collectAssistantUsage } from "./turn-usage.ts";
 import type { Goal, TokenUsageSnapshot } from "./types.ts";
 import type { GoalWaitTicker } from "./wait-ticker.ts";
 
-export const GOAL_MONITOR_CONTINUATION_DELAY_MS = 240_000;
 export const GOAL_CONTINUATION_SCHEDULED_EVENT = "goal_continuation_scheduled";
 export const GOAL_CONTINUATION_RESUMED_EVENT = "goal_continuation_resumed";
 export const GOAL_MONITOR_STALL_EVENT = "goal_monitor_continuation_stall";
@@ -66,7 +68,10 @@ export class MonitorAwareGoalContinuation {
 	#scheduledAtMs: number | undefined;
 	#scheduledDueAtMs: number | undefined;
 	#scheduledCache: GoalCacheWarmMetrics | undefined;
-	#heldTimer: { kind: DelayedContinuationKind; remainingMs: number } | undefined;
+	#scheduledDelayMs: number | undefined;
+	#heldTimer:
+		| { kind: DelayedContinuationKind; remainingMs: number; heldAtMs: number; totalMs: number }
+		| undefined;
 	#directInputHolds = new Set<string>();
 	#pendingSystemRecovery: SystemAbortOptions | undefined;
 
@@ -192,9 +197,12 @@ export class MonitorAwareGoalContinuation {
 		) {
 			return;
 		}
+		const heldAtMs = Date.now();
 		this.#heldTimer = {
 			kind: this.#scheduledContinuationKind,
-			remainingMs: Math.max(0, (this.#scheduledDueAtMs ?? Date.now()) - Date.now()),
+			remainingMs: Math.max(0, (this.#scheduledDueAtMs ?? heldAtMs) - heldAtMs),
+			heldAtMs,
+			totalMs: this.#scheduledDelayMs ?? GOAL_USER_GRACE_DELAY_MS,
 		};
 		clearTimeout(this.#timer);
 		this.#timer = undefined;
@@ -213,7 +221,8 @@ export class MonitorAwareGoalContinuation {
 		if (this.#directInputHolds.size > 0 || this.#heldTimer === undefined) return;
 		const held = this.#heldTimer;
 		this.#heldTimer = undefined;
-		this.#armTimer(held.kind, held.remainingMs);
+		const elapsedWhileHeldMs = Math.max(0, Date.now() - held.heldAtMs);
+		this.#armTimer(held.kind, Math.max(0, held.remainingMs - elapsedWhileHeldMs), held.totalMs);
 	}
 
 	/** An accepted real user prompt starts a grace-governed user turn. */
@@ -242,7 +251,14 @@ export class MonitorAwareGoalContinuation {
 
 	#schedule(goal: Goal, kind: DelayedContinuationKind): void {
 		if (this.#scheduledContinuationKind !== undefined) return;
-		const delayMs = kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS;
+		const delayMs =
+			kind === "monitor"
+				? resolveGoalMonitorContinuationDelayMs(
+						this.#ctx?.getPromptCacheSafeWaitSeconds?.(),
+						this.#ctx?.getPromptCacheGoalBackstopMaxSeconds?.(),
+					)
+				: GOAL_USER_GRACE_DELAY_MS;
+		this.#scheduledDelayMs = delayMs;
 		if (kind === "monitor") {
 			const cache = estimateCacheWarmMetrics(this.#ctx?.model, process.env, this.#lastTurnUsage);
 			const channelCounts = this.#channelCountSnapshot();
@@ -269,20 +285,20 @@ export class MonitorAwareGoalContinuation {
 		}
 		this.#scheduledContinuationKind = kind;
 		if (this.#directInputHolds.size > 0) {
-			this.#heldTimer = { kind, remainingMs: delayMs };
+			this.#heldTimer = { kind, remainingMs: delayMs, heldAtMs: Date.now(), totalMs: delayMs };
 			return;
 		}
-		this.#armTimer(kind, delayMs);
+		this.#armTimer(kind, delayMs, delayMs);
 	}
 
-	#armTimer(kind: DelayedContinuationKind, delayMs: number): void {
+	#armTimer(kind: DelayedContinuationKind, delayMs: number, totalMs: number): void {
 		this.#scheduledDueAtMs = Date.now() + delayMs;
 		const ctx = this.#ctx;
 		if (ctx?.hasUI) {
 			this.#waitTicker?.sync(ctx, {
 				kind,
 				remainingMs: delayMs,
-				totalMs: kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS,
+				totalMs,
 				channelCounts: this.#channelCountSnapshot(),
 			});
 		}
@@ -301,11 +317,13 @@ export class MonitorAwareGoalContinuation {
 		this.#scheduledDueAtMs = undefined;
 		this.#scheduledContinuationKind = undefined;
 		this.#waitTicker?.stop();
-		const delayMs = kind === "monitor" ? GOAL_MONITOR_CONTINUATION_DELAY_MS : GOAL_USER_GRACE_DELAY_MS;
+		const delayMs = this.#scheduledDelayMs ??
+			(kind === "monitor" ? GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS : GOAL_USER_GRACE_DELAY_MS);
 		const waitedMs = this.#scheduledAtMs === undefined ? delayMs : Math.max(0, Date.now() - this.#scheduledAtMs);
 		const cache = this.#scheduledCache;
 		this.#scheduledAtMs = undefined;
 		this.#scheduledCache = undefined;
+		this.#scheduledDelayMs = undefined;
 		const ctx = this.#ctx;
 		const goal = this.#goal;
 		if (ctx === undefined || goal?.status !== "active" || !ctx.isIdle() || ctx.hasPendingMessages()) return;
@@ -506,6 +524,7 @@ export class MonitorAwareGoalContinuation {
 		this.#scheduledAtMs = undefined;
 		this.#scheduledDueAtMs = undefined;
 		this.#scheduledCache = undefined;
+		this.#scheduledDelayMs = undefined;
 		this.#heldTimer = undefined;
 		if (this.#timer !== undefined) clearTimeout(this.#timer);
 		this.#timer = undefined;

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -391,6 +391,7 @@ export class ExtensionRunner {
 		keepRecentTokens: 20000,
 	});
 	private getPromptCacheSafeWaitSecondsFn: () => number | undefined = () => undefined;
+	private getPromptCacheGoalBackstopMaxSecondsFn: () => number = () => 3570;
 	private getLookAtSettingsFn: ExtensionContextActions["getLookAtSettings"] = () => ({
 		enabled: true,
 		models: undefined,
@@ -496,8 +497,9 @@ export class ExtensionRunner {
 		this.getContextUsageFn = contextActions.getContextUsage;
 		this.getCompactionSettingsFn = contextActions.getCompactionSettings;
 		if (contextActions.getPromptCacheSafeWaitSeconds)
-			if (contextActions.getPromptCacheSafeWaitSeconds)
-				this.getPromptCacheSafeWaitSecondsFn = contextActions.getPromptCacheSafeWaitSeconds;
+			this.getPromptCacheSafeWaitSecondsFn = contextActions.getPromptCacheSafeWaitSeconds;
+		if (contextActions.getPromptCacheGoalBackstopMaxSeconds)
+			this.getPromptCacheGoalBackstopMaxSecondsFn = contextActions.getPromptCacheGoalBackstopMaxSeconds;
 		this.getLookAtSettingsFn = contextActions.getLookAtSettings;
 		this.getImageSettingsFn = contextActions.getImageSettings;
 		this.sessionSettingsFn = contextActions.sessionSettings;
@@ -1051,6 +1053,10 @@ export class ExtensionRunner {
 			getPromptCacheSafeWaitSeconds: () => {
 				runner.assertActive();
 				return runner.getPromptCacheSafeWaitSecondsFn();
+			},
+			getPromptCacheGoalBackstopMaxSeconds: () => {
+				runner.assertActive();
+				return runner.getPromptCacheGoalBackstopMaxSecondsFn();
 			},
 			getLookAtSettings: () => {
 				runner.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -428,6 +428,8 @@ export interface ExtensionContext {
 	 * LIVE current model, so callers must not snapshot the value.
 	 */
 	getPromptCacheSafeWaitSeconds?(): number | undefined;
+	/** Maximum Goal monitor continuation backstop configured for prompt-cache waits. */
+	getPromptCacheGoalBackstopMaxSeconds?(): number;
 	/** Get resolved look-at settings from global/project/user overrides. */
 	getLookAtSettings(): { enabled: boolean; models: string[] | undefined };
 	/** Get resolved image settings from global/project/user overrides. */
@@ -2061,6 +2063,7 @@ export interface ExtensionContextActions {
 	getContextUsage: () => ContextUsage | undefined;
 	getCompactionSettings: () => CompactionPreparation["settings"];
 	getPromptCacheSafeWaitSeconds?: () => number | undefined;
+	getPromptCacheGoalBackstopMaxSeconds?: () => number;
 	getLookAtSettings: () => { enabled: boolean; models: string[] | undefined };
 	getImageSettings: () => { autoResize: boolean; blockImages: boolean };
 	sessionSettings: ExtensionSessionSettings;

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -68,6 +68,7 @@ export interface TerminalSettings {
 export interface PromptCacheSettings {
 	cacheAwareTimeouts?: boolean; // default: true (size foreground tool waits by the model's prompt-cache TTL)
 	safetyBufferSeconds?: number; // default: 30 (headroom subtracted from the cache TTL)
+	goalBackstopMaxSeconds?: number; // default: 3570 (maximum Goal monitor continuation backstop)
 }
 
 export interface ImageSettings {
@@ -597,6 +598,14 @@ export class SettingsManager {
 
 	getProjectSettings(): Settings {
 		return structuredClone(this.projectSettings);
+	}
+
+	getPromptCacheGoalBackstopMaxSeconds(): number {
+		return (
+			this.projectSettings.promptCache?.goalBackstopMaxSeconds ??
+			this.globalSettings.promptCache?.goalBackstopMaxSeconds ??
+			3570
+		);
 	}
 
 	isProjectTrusted(): boolean {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2242,6 +2242,8 @@ export class InteractiveMode {
 			getContextUsage: () => this.session.getContextUsage(),
 			getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
 			getPromptCacheSafeWaitSeconds: () => this.session.resolvePromptCacheSafeWaitSeconds(),
+			getPromptCacheGoalBackstopMaxSeconds: () =>
+				this.settingsManager.getPromptCacheGoalBackstopMaxSeconds(),
 			getLookAtSettings: () => {
 				const global = this.settingsManager.getGlobalSettings().lookAt;
 				const project = this.settingsManager.getProjectSettings().lookAt;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2242,8 +2242,7 @@ export class InteractiveMode {
 			getContextUsage: () => this.session.getContextUsage(),
 			getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
 			getPromptCacheSafeWaitSeconds: () => this.session.resolvePromptCacheSafeWaitSeconds(),
-			getPromptCacheGoalBackstopMaxSeconds: () =>
-				this.settingsManager.getPromptCacheGoalBackstopMaxSeconds(),
+			getPromptCacheGoalBackstopMaxSeconds: () => this.settingsManager.getPromptCacheGoalBackstopMaxSeconds(),
 			getLookAtSettings: () => {
 				const global = this.settingsManager.getGlobalSettings().lookAt;
 				const project = this.settingsManager.getProjectSettings().lookAt;

--- a/packages/coding-agent/test/suite/goal-abort-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-abort-extension.test.ts
@@ -154,7 +154,7 @@ describe("goal abort lifecycle through the agent session", () => {
 		expect(abortSources).toContain(undefined);
 		expect(harness.faux.getCallLog()).toHaveLength(2);
 		expect(await readGoal(ref)).toMatchObject({ status: "active" });
-		expect(await scheduledContinuation).toEqual(expect.objectContaining({ delayMs: 240_000 }));
+		expect(await scheduledContinuation).toEqual(expect.objectContaining({ delayMs: 240_000, iteration: 1 }));
 	});
 
 	it("keeps a model-authored block blocked on ordinary direct input", async () => {

--- a/packages/coding-agent/test/suite/goal-cache-warm-metrics.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-metrics.test.ts
@@ -1,6 +1,9 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import { estimateCacheWarmMetrics } from "../../src/core/extensions/builtin/goal/cache-warm.ts";
+import {
+	estimateCacheWarmMetrics,
+	resolveGoalMonitorContinuationDelayMs,
+} from "../../src/core/extensions/builtin/goal/cache-warm.ts";
 
 function anthropicModel(costOverrides: Partial<Model<Api>["cost"]> = {}): Model<Api> {
 	return {
@@ -16,6 +19,22 @@ function anthropicModel(costOverrides: Partial<Model<Api>["cost"]> = {}): Model<
 		maxTokens: 8192,
 	} as Model<Api>;
 }
+
+describe("goal monitor continuation delay", () => {
+	it.each([
+		[undefined, undefined, 240_000],
+		[270, undefined, 270_000],
+		[3570, undefined, 3_570_000],
+		[3570, 900, 900_000],
+		[5, undefined, 5_000],
+		[7200, undefined, 3_600_000],
+		[270, 0, 270_000],
+		[0, undefined, 240_000],
+		[Number.NaN, undefined, 240_000],
+	] as const)("resolves cache-safe wait %s with ceiling %s to %sms", (safeWait, ceiling, expected) => {
+		expect(resolveGoalMonitorContinuationDelayMs(safeWait, ceiling)).toBe(expected);
+	});
+});
 
 describe("goal cache-warm metrics", () => {
 	it("returns undefined when neither ttl nor cached tokens are knowable", () => {

--- a/packages/coding-agent/test/suite/goal-cache-warm-ownership.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-ownership.test.ts
@@ -34,20 +34,26 @@ describe("goal cache-warm rendering ownership", () => {
 		await runGoalHandlers(handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
 
 		expect(notices).toEqual([]);
-		expect(warmupPhases(entries)).toEqual(["scheduled"]);
+		expect(warmupPhases(entries)).toEqual([{ phase: "scheduled", iteration: 1 }]);
 
 		const delivered = waitForSentCount(harness, 1);
 		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await delivered;
 		await vi.advanceTimersByTimeAsync(0);
 		expect(notices).toEqual([]);
-		expect(warmupPhases(entries)).toEqual(["scheduled", "resumed"]);
+		expect(warmupPhases(entries)).toEqual([
+			{ phase: "scheduled", iteration: 1 },
+			{ phase: "resumed", iteration: 1 },
+		]);
 	});
 });
 
-function warmupPhases(entries: readonly AppendedGoalEntry[]): string[] {
+function warmupPhases(
+	entries: readonly AppendedGoalEntry[],
+): Array<Pick<GoalCacheWarmupEntryData, "phase" | "iteration">> {
 	return entries
 		.filter((entry) => entry.customType === GOAL_CACHE_WARMUP_ENTRY_TYPE)
-		.map((entry) => (entry.data as GoalCacheWarmupEntryData | undefined)?.phase)
-		.filter((phase): phase is GoalCacheWarmupEntryData["phase"] => phase !== undefined);
+		.map((entry) => entry.data as GoalCacheWarmupEntryData | undefined)
+		.filter((data): data is GoalCacheWarmupEntryData => data !== undefined)
+		.map(({ phase, iteration }) => ({ phase, iteration }));
 }

--- a/packages/coding-agent/test/suite/goal-cache-warm-ownership.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-ownership.test.ts
@@ -3,7 +3,7 @@ import {
 	GOAL_CACHE_WARMUP_ENTRY_TYPE,
 	type GoalCacheWarmupEntryData,
 } from "../../src/core/extensions/builtin/goal/cache-warm.ts";
-import { GOAL_MONITOR_CONTINUATION_DELAY_MS } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import { GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
 import {
 	type AppendedGoalEntry,
 	cleanAssistantStop,
@@ -37,7 +37,7 @@ describe("goal cache-warm rendering ownership", () => {
 		expect(warmupPhases(entries)).toEqual(["scheduled"]);
 
 		const delivered = waitForSentCount(harness, 1);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await delivered;
 		await vi.advanceTimersByTimeAsync(0);
 		expect(notices).toEqual([]);

--- a/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
@@ -34,9 +34,10 @@ describe("goal cache-warm entry renderer", () => {
 			goalId: "goal-1",
 			delayMs: 270_000,
 			activeMonitorCount: 1,
+			iteration: 2,
 			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
 		});
-		expect(text).toContain("Cache-warm wait");
+		expect(text).toContain("Cache-warm wait · iteration 2");
 		expect(text).toContain("1 monitor on duty");
 		expect(text).toContain("5m prompt-cache TTL");
 		expect(text).toContain("~120K tokens kept warm");
@@ -50,9 +51,10 @@ describe("goal cache-warm entry renderer", () => {
 			delayMs: 270_000,
 			waitedMs: 270_000,
 			activeMonitorCount: 2,
+			iteration: 3,
 			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
 		});
-		expect(text).toContain("Cache-warm wake");
+		expect(text).toContain("Cache-warm wake · iteration 3");
 		expect(text).toContain("waited 4m 30s");
 		expect(text).toContain("2 monitors on duty");
 		expect(text).toContain("~120K tokens stayed warm");
@@ -95,6 +97,17 @@ describe("goal cache-warm entry renderer", () => {
 		expect(text).toContain("Cache-warm wait");
 		expect(text).toContain("1 monitor on duty");
 		expect(text).not.toContain("tokens");
+	});
+
+	it("renders legacy persisted entries without inventing an iteration", () => {
+		const text = renderToText({
+			phase: "scheduled",
+			goalId: "legacy-goal",
+			delayMs: 240_000,
+			activeMonitorCount: 1,
+		});
+		expect(text).toContain("Cache-warm wait");
+		expect(text).not.toContain("iteration");
 	});
 
 	it("reveals goal details when expanded", () => {

--- a/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
@@ -32,7 +32,7 @@ describe("goal cache-warm entry renderer", () => {
 		const text = renderToText({
 			phase: "scheduled",
 			goalId: "goal-1",
-			delayMs: 240_000,
+			delayMs: 270_000,
 			activeMonitorCount: 1,
 			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
 		});
@@ -47,16 +47,42 @@ describe("goal cache-warm entry renderer", () => {
 		const text = renderToText({
 			phase: "resumed",
 			goalId: "goal-1",
-			delayMs: 240_000,
-			waitedMs: 240_000,
+			delayMs: 270_000,
+			waitedMs: 270_000,
 			activeMonitorCount: 2,
 			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
 		});
 		expect(text).toContain("Cache-warm wake");
-		expect(text).toContain("waited 4m");
+		expect(text).toContain("waited 4m 30s");
 		expect(text).toContain("2 monitors on duty");
 		expect(text).toContain("~120K tokens stayed warm");
 		expect(text).toContain("$0.324 saved");
+	});
+
+	it("does not claim warmth or savings when the cache TTL may have elapsed", () => {
+		const scheduled = renderToText({
+			phase: "scheduled",
+			goalId: "goal-expired-scheduled",
+			delayMs: 300_000,
+			activeMonitorCount: 1,
+			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
+		});
+		expect(scheduled).toContain("TTL may elapse");
+		expect(scheduled).not.toContain("stays inside");
+		expect(scheduled).not.toContain("kept warm");
+		expect(scheduled).not.toContain("saved");
+
+		const resumed = renderToText({
+			phase: "resumed",
+			goalId: "goal-expired-resumed",
+			delayMs: 270_000,
+			waitedMs: 300_000,
+			activeMonitorCount: 1,
+			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
+		});
+		expect(resumed).toContain("TTL may have elapsed");
+		expect(resumed).not.toContain("stayed warm");
+		expect(resumed).not.toContain("saved");
 	});
 
 	it("stays readable without cache metrics", () => {

--- a/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
@@ -80,6 +80,7 @@ describe("goal cache-warm continuation story", () => {
 			expect.objectContaining({
 				goalId: expect.any(String),
 				delayMs: 270_000,
+				iteration: 1,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),
 			}),
@@ -92,6 +93,7 @@ describe("goal cache-warm continuation story", () => {
 				phase: "scheduled",
 				goalId: expect.any(String),
 				delayMs: 270_000,
+				iteration: 1,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),
 			}),
@@ -115,6 +117,7 @@ describe("goal cache-warm continuation story", () => {
 				goalId: expect.any(String),
 				delayMs: 270_000,
 				waitedMs: 270_000,
+				iteration: 1,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({
 					cachedTokens: 120_000,
@@ -130,12 +133,93 @@ describe("goal cache-warm continuation story", () => {
 			expect.objectContaining({
 				phase: "resumed",
 				waitedMs: 270_000,
+				iteration: 1,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000 }),
 			}),
 		);
 
 		expect(notices).toEqual([]);
+	});
+
+	it("increments accepted monitor schedules and resets after the wake epoch drains", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx } = await setupWarmHarness("thread-cache-warm-iterations");
+
+		for (let iteration = 1; iteration <= 2; iteration++) {
+			const delivered = waitForSentCount(harness, iteration);
+			const resumed = waitForEventCount(harness.events, "goal_continuation_resumed", iteration);
+			await vi.advanceTimersByTimeAsync(270_000);
+			await Promise.all([delivered, resumed]);
+			if (iteration < 2) {
+				await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+				await runGoalHandlers(
+					harness.handlers,
+					"agent_end",
+					{ type: "agent_end", messages: [cleanAssistantStop()] },
+					ctx,
+				);
+			}
+		}
+
+		expect(warmupEntryData(harness).map(({ phase, iteration }) => ({ phase, iteration }))).toEqual([
+			{ phase: "scheduled", iteration: 1 },
+			{ phase: "resumed", iteration: 1 },
+			{ phase: "scheduled", iteration: 2 },
+			{ phase: "resumed", iteration: 2 },
+		]);
+
+		harness.events.emit("terminal_monitor_state", { activeCount: 0 });
+		await harness.events.flush();
+		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+		await harness.events.flush();
+		await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStop()] },
+			ctx,
+		);
+
+		expect(warmupEntryData(harness).at(-1)).toEqual(expect.objectContaining({ phase: "scheduled", iteration: 1 }));
+	});
+
+	it("resets the warm iteration after an accepted user prompt", async () => {
+		vi.useFakeTimers();
+		const { harness, ctx } = await setupWarmHarness("thread-cache-warm-user-reset");
+		const firstResumed = waitForEventCount(harness.events, "goal_continuation_resumed", 1);
+		await vi.advanceTimersByTimeAsync(270_000);
+		await firstResumed;
+
+		await runGoalHandlers(
+			harness.handlers,
+			"input",
+			{ type: "input", inputId: "reset-iteration", text: "new direction", source: "interactive" },
+			ctx,
+		);
+		await runGoalHandlers(
+			harness.handlers,
+			"input_disposition",
+			{ type: "input_disposition", inputId: "reset-iteration", disposition: "started" },
+			ctx,
+		);
+		await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStop()] },
+			ctx,
+		);
+		await vi.advanceTimersByTimeAsync(10_000);
+		await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStop()] },
+			ctx,
+		);
+
+		expect(warmupEntryData(harness).at(-1)).toEqual(expect.objectContaining({ phase: "scheduled", iteration: 1 }));
 	});
 
 	it("keeps a plain explanation when no cache context exists", async () => {

--- a/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
@@ -35,7 +35,11 @@ async function setupWarmHarness(
 ): Promise<{ harness: GoalHarness; notices: string[]; ctx: Awaited<ReturnType<typeof makeGoalContext>> }> {
 	const notices: string[] = [];
 	const harness = createGoalHarness();
-	const ctx = await makeGoalContext(notices, threadId, { pendingMessages: false, model: cacheModel() });
+	const ctx = await makeGoalContext(notices, threadId, {
+		pendingMessages: false,
+		model: cacheModel(),
+		cacheSafeWaitSeconds: 270,
+	});
 	await harness.tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 	harness.events.emit("terminal_monitor_state", { activeCount: 1 });
@@ -75,7 +79,7 @@ describe("goal cache-warm continuation story", () => {
 		expect(channelEvents(harness, "goal_continuation_scheduled")).toEqual([
 			expect.objectContaining({
 				goalId: expect.any(String),
-				delayMs: 240_000,
+				delayMs: 270_000,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),
 			}),
@@ -87,7 +91,7 @@ describe("goal cache-warm continuation story", () => {
 			expect.objectContaining({
 				phase: "scheduled",
 				goalId: expect.any(String),
-				delayMs: 240_000,
+				delayMs: 270_000,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),
 			}),
@@ -100,7 +104,7 @@ describe("goal cache-warm continuation story", () => {
 
 		const delayedDeliveryRecorded = waitForSentCount(harness, 1);
 		const resumedEventRecorded = waitForEventCount(harness.events, "goal_continuation_resumed", 1);
-		await vi.advanceTimersByTimeAsync(240_000);
+		await vi.advanceTimersByTimeAsync(270_000);
 		await Promise.all([delayedDeliveryRecorded, resumedEventRecorded]);
 
 		expect(harness.sent).toHaveLength(1);
@@ -109,8 +113,8 @@ describe("goal cache-warm continuation story", () => {
 		expect(channelEvents(harness, "goal_continuation_resumed")).toEqual([
 			expect.objectContaining({
 				goalId: expect.any(String),
-				delayMs: 240_000,
-				waitedMs: 240_000,
+				delayMs: 270_000,
+				waitedMs: 270_000,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({
 					cachedTokens: 120_000,
@@ -125,7 +129,7 @@ describe("goal cache-warm continuation story", () => {
 		expect(resumed[0]).toEqual(
 			expect.objectContaining({
 				phase: "resumed",
-				waitedMs: 240_000,
+				waitedMs: 270_000,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000 }),
 			}),

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GOAL_USER_GRACE_DELAY_MS } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import { admitAndQueueGoalContinuation } from "../../src/core/extensions/builtin/goal/lifecycle-helpers.ts";
 import {
-	GOAL_MONITOR_CONTINUATION_DELAY_MS,
+	GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS,
 	MonitorAwareGoalContinuation,
 } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
 import {
@@ -308,6 +308,74 @@ describe("goal continuation while a monitor is active", () => {
 		expect((after?.tokensUsed ?? 0) - before.tokensUsed).toBe(150);
 	});
 
+	it("decays a held monitor timer by wall-clock time before restoring it", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const { tools, handlers, sent, events } = harness;
+		const ctx = await makeGoalContext(notices, "thread-held-timer-decay", {
+			pendingMessages: false,
+			cacheSafeWaitSeconds: 270,
+		});
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		events.emit("terminal_monitor_state", { activeCount: 1 });
+		await events.flush();
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
+
+		await vi.advanceTimersByTimeAsync(100_000);
+		await runGoalHandlers(
+			handlers,
+			"input",
+			{ type: "input", inputId: "held", text: "candidate", source: "interactive" },
+			ctx,
+		);
+		await vi.advanceTimersByTimeAsync(30_000);
+		await runGoalHandlers(
+			handlers,
+			"input_disposition",
+			{ type: "input_disposition", inputId: "held", disposition: "rejected" },
+			ctx,
+		);
+
+		await vi.advanceTimersByTimeAsync(139_999);
+		expect(sent).toHaveLength(0);
+		const delivered = waitForSentCount(harness, 1);
+		await vi.advanceTimersByTimeAsync(1);
+		await delivered;
+		expect(sent).toHaveLength(1);
+	});
+
+	it("honors the configured goal backstop ceiling", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const { tools, handlers, sent, events } = harness;
+		const ctx = await makeGoalContext(notices, "thread-goal-backstop-ceiling", {
+			pendingMessages: false,
+			cacheSafeWaitSeconds: 3570,
+			goalBackstopMaxSeconds: 900,
+		});
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		events.emit("terminal_monitor_state", { activeCount: 1 });
+		await events.flush();
+		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		await runGoalHandlers(handlers, "agent_end", { type: "agent_end", messages: [cleanAssistantStop()] }, ctx);
+
+		expect(events.emitted).toContainEqual({
+			channel: "goal_continuation_scheduled",
+			data: expect.objectContaining({ delayMs: 900_000 }),
+		});
+		await vi.advanceTimersByTimeAsync(899_999);
+		expect(sent).toHaveLength(0);
+		const delivered = waitForSentCount(harness, 1);
+		await vi.advanceTimersByTimeAsync(1);
+		await delivered;
+		expect(sent).toHaveLength(1);
+	});
+
 	it("keeps overlapping rejected and handled inputs keyed while restoring the armed timer", async () => {
 		vi.useFakeTimers();
 		const notices: string[] = [];
@@ -335,7 +403,7 @@ describe("goal continuation while a monitor is active", () => {
 			{ type: "input_disposition", inputId: "first", disposition: "handled" },
 			ctx,
 		);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		expect(sent).toHaveLength(0);
 		const restoredDelivery = waitForSentCount(harness, 1);
 		await runGoalHandlers(
@@ -344,7 +412,7 @@ describe("goal continuation while a monitor is active", () => {
 			{ type: "input_disposition", inputId: "second", disposition: "rejected" },
 			ctx,
 		);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await restoredDelivery;
 		expect(sent).toHaveLength(1);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ status: "active" });
@@ -385,7 +453,7 @@ describe("goal continuation while a monitor is active", () => {
 			{ type: "input_disposition", inputId: "read-failure", disposition: "rejected" },
 			ctx,
 		);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await restoredDelivery;
 		expect(sent).toHaveLength(1);
 	});
@@ -547,7 +615,7 @@ describe("goal continuation while a monitor is active", () => {
 				messages: [cleanAssistantStopWithText("unchanged monitor output")],
 			});
 			const delayedDeliveryRecorded = waitForSentCount(harness, turn);
-			await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+			await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 			await delayedDeliveryRecorded;
 		}
 
@@ -561,7 +629,7 @@ describe("goal continuation while a monitor is active", () => {
 			messages: [cleanAssistantStopWithText("unchanged monitor output")],
 		});
 		const resumedDeliveryRecorded = waitForSentCount(harness, 3);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await resumedDeliveryRecorded;
 
 		expect(sent).toHaveLength(3);

--- a/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
@@ -26,7 +26,7 @@ interface ActiveMonitorHarness {
 async function createActiveMonitorHarness(threadId: string): Promise<ActiveMonitorHarness> {
 	const notices: string[] = [];
 	const status = createGoalStatusHarness();
-	const state: GoalContextState = { pendingMessages: false, status };
+	const state: GoalContextState = { pendingMessages: false, status, cacheSafeWaitSeconds: 270 };
 	const harness = createGoalHarness();
 	const ctx = await makeGoalContext(notices, threadId, state);
 	await harness.tools
@@ -59,7 +59,7 @@ describe("goal monitor continuation lifecycle", () => {
 		expect(harness.sent).toHaveLength(0);
 		expect(notices).toHaveLength(0);
 		const delayedDeliveryRecorded = waitForSentCount(harness, 1);
-		await vi.advanceTimersByTimeAsync(240_000);
+		await vi.advanceTimersByTimeAsync(270_000);
 		await delayedDeliveryRecorded;
 		expect(harness.sent).toHaveLength(1);
 	});
@@ -74,7 +74,7 @@ describe("goal monitor continuation lifecycle", () => {
 		await harness.events.flush();
 
 		expect(harness.sent).toHaveLength(0);
-		await vi.advanceTimersByTimeAsync(240_000);
+		await vi.advanceTimersByTimeAsync(270_000);
 		expect(harness.sent).toHaveLength(0);
 	});
 
@@ -85,13 +85,13 @@ describe("goal monitor continuation lifecycle", () => {
 		await completed.harness.tools
 			.get("update_goal")
 			?.execute("complete", { status: "complete" }, undefined, undefined, completed.ctx);
-		await vi.advanceTimersByTimeAsync(240_000);
+		await vi.advanceTimersByTimeAsync(270_000);
 		expect(completed.harness.sent).toHaveLength(0);
 
 		const pending = await createActiveMonitorHarness("thread-pending-message");
 		await endCleanTurn(pending.harness, pending.ctx);
 		pending.state.pendingMessages = true;
-		await vi.advanceTimersByTimeAsync(240_000);
+		await vi.advanceTimersByTimeAsync(270_000);
 		expect(pending.harness.sent).toHaveLength(0);
 	});
 
@@ -101,7 +101,7 @@ describe("goal monitor continuation lifecycle", () => {
 		await endCleanTurn(harness, ctx);
 
 		await runGoalHandlers(harness.handlers, "session_shutdown", { type: "session_shutdown" }, ctx);
-		await vi.advanceTimersByTimeAsync(240_000);
+		await vi.advanceTimersByTimeAsync(270_000);
 
 		expect(harness.sent).toHaveLength(0);
 	});
@@ -111,7 +111,7 @@ describe("goal monitor continuation lifecycle", () => {
 		const { harness, ctx, status } = await createActiveMonitorHarness("thread-monitor-reload");
 		const countdownStarted = waitForGoalStatus(
 			status,
-			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal continues in 4m") === true,
+			(update) => update.key === GOAL_WAIT_STATUS_KEY && update.text?.includes("goal continues in 4m 30s") === true,
 		);
 		await endCleanTurn(harness, ctx);
 		await countdownStarted;
@@ -123,7 +123,15 @@ describe("goal monitor continuation lifecycle", () => {
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 		await countdownCleared;
 
-		await vi.advanceTimersByTimeAsync(240_000);
+		await vi.advanceTimersByTimeAsync(270_000);
 		expect(harness.sent).toHaveLength(0);
+
+		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+		await harness.events.flush();
+		await endCleanTurn(harness, ctx);
+		const scheduledIterations = harness.events.emitted
+			.filter((event) => event.channel === "goal_continuation_scheduled")
+			.map((event) => (event.data as { iteration?: number }).iteration);
+		expect(scheduledIterations).toEqual([1, 1]);
 	});
 });

--- a/packages/coding-agent/test/suite/goal-monitor-rpc-notice.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-rpc-notice.test.ts
@@ -15,7 +15,10 @@ interface RpcRecord {
 	readonly method?: string;
 	readonly message?: string;
 	readonly notifyType?: string;
-	readonly entry?: { readonly customType?: string; readonly data?: { readonly phase?: string } };
+	readonly entry?: {
+		readonly customType?: string;
+		readonly data?: { readonly phase?: string; readonly iteration?: number };
+	};
 }
 
 function createRuntimeHost(session: AgentSession): AgentSessionRuntime {
@@ -83,7 +86,7 @@ describe("goal monitor scheduling notice over RPC", () => {
 				type: "entry_appended",
 				entry: expect.objectContaining({
 					customType: "goal-cache-warmup",
-					data: expect.objectContaining({ phase: "scheduled" }),
+					data: expect.objectContaining({ phase: "scheduled", iteration: 1 }),
 				}),
 			}),
 		);

--- a/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
@@ -89,6 +89,8 @@ export interface GoalContextState {
 	pendingMessages: boolean;
 	model?: Model<Api>;
 	status?: GoalStatusHarness;
+	cacheSafeWaitSeconds?: number;
+	goalBackstopMaxSeconds?: number;
 }
 
 export function createSentMessageHarness(): SentMessageHarness {
@@ -154,6 +156,8 @@ export async function makeGoalContext(
 		model: state.model,
 		isIdle: () => true,
 		hasPendingMessages: () => state.pendingMessages,
+		getPromptCacheSafeWaitSeconds: () => state.cacheSafeWaitSeconds,
+		getPromptCacheGoalBackstopMaxSeconds: () => state.goalBackstopMaxSeconds ?? 3570,
 		ui: {
 			notify: (message: string) => notices.push(message),
 			select: async () => undefined,

--- a/packages/coding-agent/test/suite/goal-resumption-channels.test.ts
+++ b/packages/coding-agent/test/suite/goal-resumption-channels.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	GOAL_CONTINUATION_RESUMED_EVENT,
 	GOAL_CONTINUATION_SCHEDULED_EVENT,
-	GOAL_MONITOR_CONTINUATION_DELAY_MS,
+	GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS,
 	MonitorAwareGoalContinuation,
 } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
 import { writeGoal } from "../../src/core/extensions/builtin/goal/store.ts";
@@ -137,7 +137,7 @@ describe("goal continuation resumption channels", () => {
 		for (let turn = 1; turn <= 2; turn++) {
 			await endTurn(monitor, ctx, goal);
 			const delivered = waitForSentCount(harness, turn);
-			await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+			await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 			await delivered;
 		}
 
@@ -145,14 +145,14 @@ describe("goal continuation resumption channels", () => {
 		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "senpi-task", activeCount: 0 });
 		await events.flush();
 		const thirdDelivery = waitForSentCount(harness, 3);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await thirdDelivery;
 		expect(sent[2]?.message.content).toContain("<goal_stall_check>");
 
 		await endTurn(monitor, ctx, goal);
 		events.emit(RESUMPTION_CHANNEL_STATE_EVENT, { source: "terminal-bash", activeCount: 0 });
 		await events.flush();
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		expect(sent).toHaveLength(3);
 	});
 
@@ -225,7 +225,7 @@ describe("goal continuation resumption channels", () => {
 
 		const delivered = waitForSentCount(harness, 1);
 		const resumed = waitForEventCount(events, GOAL_CONTINUATION_RESUMED_EVENT, 1);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await Promise.all([delivered, resumed]);
 		expect(channelEvents(events, GOAL_CONTINUATION_RESUMED_EVENT)[0]).toMatchObject(expected);
 		expect(entries[1]?.data).toMatchObject(expected);

--- a/packages/coding-agent/test/suite/goal-system-abort-monitor.test.ts
+++ b/packages/coding-agent/test/suite/goal-system-abort-monitor.test.ts
@@ -47,7 +47,7 @@ describe("goal state after a system-owned abort", () => {
 			expect(sent).toHaveLength(0);
 			expect(events.emitted).toContainEqual({
 				channel: "goal_continuation_scheduled",
-				data: expect.objectContaining({ activeMonitorCount: 1, delayMs: 240_000 }),
+				data: expect.objectContaining({ activeMonitorCount: 1, delayMs: 240_000, iteration: 1 }),
 			});
 		},
 	);

--- a/packages/coding-agent/test/suite/goal-ttsr-user-abort-race.test.ts
+++ b/packages/coding-agent/test/suite/goal-ttsr-user-abort-race.test.ts
@@ -115,7 +115,7 @@ describe("user abort racing a TTSR system abort", () => {
 		expect(abortSpy).toHaveBeenCalledTimes(2);
 		expect(await readGoal(ref)).toMatchObject({ status: "active" });
 		expect(scheduledContinuations).toContainEqual(
-			expect.objectContaining({ activeMonitorCount: 1, delayMs: 240_000 }),
+			expect.objectContaining({ activeMonitorCount: 1, delayMs: 240_000, iteration: 1 }),
 		);
 	});
 });

--- a/packages/coding-agent/test/suite/goal-wait-progress.test.ts
+++ b/packages/coding-agent/test/suite/goal-wait-progress.test.ts
@@ -47,15 +47,15 @@ describe("goal wait label", () => {
 		expect(label).toContain(EMPTY);
 	});
 
-	it("keeps the monitors-only rendering byte-identical", () => {
+	it("renders a cache-budget-derived monitor wait", () => {
 		const label = formatGoalWaitLabel({
 			kind: "monitor",
-			remainingMs: 192_000,
-			totalMs: 240_000,
+			remainingMs: 216_000,
+			totalMs: 270_000,
 			channelCounts: { "terminal-monitor": 2 },
 		});
 
-		expect(label).toBe("▰▰▱▱▱▱▱▱▱▱▱▱ goal continues in 3m 12s · 2 monitors on duty");
+		expect(label).toBe("▰▰▱▱▱▱▱▱▱▱▱▱ goal continues in 3m 36s · 2 monitors on duty");
 	});
 
 	it("uses a stable singular and plural breakdown for mixed live sources", () => {

--- a/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
@@ -3,7 +3,7 @@ import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { admitAndQueueGoalContinuation } from "../../../src/core/extensions/builtin/goal/lifecycle-helpers.ts";
 import {
-	GOAL_MONITOR_CONTINUATION_DELAY_MS,
+	GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS,
 	MonitorAwareGoalContinuation,
 } from "../../../src/core/extensions/builtin/goal/monitor-continuation.ts";
 import { readGoal, writeGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
@@ -75,7 +75,7 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 			messages: [assistantStopWithText("still waiting")],
 		});
 		const delayedDeliveryRecorded = waitForSentCount(harness, 1);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await delayedDeliveryRecorded;
 
 		expect(harness.sent).toHaveLength(1);
@@ -92,7 +92,7 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 			messages: [assistantStopWithText("still waiting")],
 		});
 		const blockedGoalRecorded = waitForGoalContinuationCount(ctx, 0);
-		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_DELAY_MS);
+		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
 		await blockedGoalRecorded;
 
 		expect(harness.sent).toHaveLength(1);


### PR DESCRIPTION
## Summary

- derive Goal monitor continuation backstop timing from the active model's prompt-cache safe-wait budget, with a configurable `promptCache.goalBackstopMaxSeconds` ceiling and a 240-second fallback for unknown budgets
- snapshot each accepted schedule's delay, preserve its total through direct-input holds, and decay held timers by elapsed wall-clock time
- avoid cache-warm/savings claims when the planned or actual wait reaches the displayed cache TTL
- add per-epoch cache-warm iteration ordinals to scheduled/resumed events, durable entries, and TUI titles while preserving legacy entry rendering

## Behavior

- 5-minute cache lanes schedule at 270 seconds
- 1-hour cache lanes schedule at 3570 seconds by default
- unknown TTL/budget lanes retain the 240-second fallback
- a 270-second timer held after 100 seconds for 30 seconds resumes with 140 seconds remaining
- monitor cycles share the same iteration between scheduled and resumed records, increment only on accepted monitor schedules, and reset on Goal/wake/user/session lifecycle boundaries

## Verification

- `cd packages/coding-agent && npm test -- test/suite/goal-` (25 files, 282 tests)
- focused T6+T7 surface (14 files, 90 tests)
- `npm run check`
- `node scripts/check-pr-changelog.mjs --base origin/main`
- `git diff --check`
- senpi QA mock-loop `ttsr-collapse` (4/4)
- senpi QA TUI smoke (5/5)

## Evidence

- `.omo/evidence/cache-hit-maximization/task-6-red.txt`
- `.omo/evidence/cache-hit-maximization/task-6-green.txt`
- `.omo/evidence/cache-hit-maximization/task-7-red.txt`
- `.omo/evidence/cache-hit-maximization/task-7-green.txt`
- `local-ignore/qa-evidence/20260809-cache-hit-goal-timing/`
- `local-ignore/qa-evidence/20260809-cache-hit-goal-timing-tui/`

Plan: `.omo/plans/cache-hit-maximization.md` (T6, then T7 only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the goal monitor wake delay from the model’s prompt-cache safe-wait budget and adds an iteration counter to cache-warm events for clearer timing. Also decays held timers by wall-clock time and stops warmth/savings claims when the TTL may have elapsed.

- **New Features**
  - Backstop delay now uses the resolved prompt-cache safe-wait budget, capped by `promptCache.goalBackstopMaxSeconds` (default 3570s); unknown budgets fall back to 240s.
  - Examples: 5-minute TTL → 270s; 1-hour TTL → 3570s (default cap).
  - Direct-input holds preserve the original total delay and subtract elapsed time while held.
  - Cache-warm entries omit warm-token/savings claims if the planned or actual wait reaches the TTL.
  - Per-epoch iteration ordinals added to scheduled/resumed events, durable entries, and TUI titles; reset on Goal/wake/user/session boundaries; legacy entries render without iteration.
  - Extension context exposes `getPromptCacheGoalBackstopMaxSeconds()`; settings resolved via `promptCache.goalBackstopMaxSeconds`.

<sup>Written for commit cf0ba4887127de96931c31a1b7fa020b527cf819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

