### PR TITLE
fix(compaction): regenerate fresh summary when a warm result goes stale

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,7 @@
   dead. Native waits are now settled from a dedicated reaper thread, keeping the libuv pool free; synchronous wait errors,
   exit payloads, and process-tree kill behavior are unchanged. Added native regression coverage for threadpool exhaustion
   and Worker teardown ([#768](https://github.com/code-yeongyu/senpi/pull/768)).
+- Fixed threshold-triggered compaction giving up with "Compaction did not apply" when an idle-warmed summary became stale after a message-revision change. The blocking route now discards the stale warm result and regenerates a fresh summary against the current session instead of allowing context to keep growing.
 
 ### Removed
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,27 @@
 # Builtin compaction extension changes
 
+## Regenerate after a warm summary goes stale (2026-08-09)
+
+### What changed
+
+- `applyBlockingCompaction()` now discards a stale warmed speculative result and falls through to fresh core-route summary generation while retaining the active compaction feedback signal.
+- Applied warm results remain terminal, rejected results retain their existing feedback restart, and the `speculative_stale` debug event remains unchanged.
+- The separate OpenAI remote blocking generation-race branch is intentionally unchanged: that path owns and advances its generation directly, while this fix targets idle/speculative warm-summary consumption after an external message-revision bump.
+
+### Why
+
+- Idle warm-up snapshots pin the current message revision. A hidden extension message, bash update, model reselection, tool-set change, or other idle revision bump can make the completed warm summary stale before the next threshold-triggered blocking compaction.
+- Treating that stale result as terminal ended feedback as "Compaction did not apply" without reducing context, so repeated warm/stale cycles let the context keep growing. A blocking route is running because the current session requires compaction and must regenerate against current state.
+
+### Why an extension could not do this
+
+- This is the builtin compaction extension's private warm-job consumption and feedback lifecycle; an external extension cannot replace its in-flight speculative job or continue its blocking route.
+
+### Expected merge-conflict zones
+
+- `index.ts` inside `applyBlockingCompaction()` around pending speculative-job result handling.
+- `test/compaction/stale-warm-blocking-repro.test.ts` is focused regression coverage for this path.
+
 ## Remove the fatal per-turn compaction soft cap (2026-08-05)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -401,18 +401,18 @@ export default function compactionExtension(
 					compaction,
 					feedbackSignal,
 				);
-				if (result.applied || result.reason === "stale") {
+				if (result.applied) {
 					speculativeJob = undefined;
-					if (result.applied)
-						getLogger(ctx).debug("speculative_applied", {
-							generation: pendingJob.generation,
-							origin: "speculative",
-						});
-					else getLogger(ctx).debug("speculative_stale", { generation: pendingJob.generation });
+					getLogger(ctx).debug("speculative_applied", {
+						generation: pendingJob.generation,
+						origin: "speculative",
+					});
 					endCompactionFeedback(ctx, feedbackSignal, result);
 					return result;
 				}
-				if (result.reason === "rejected") {
+				if (result.reason === "stale") {
+					getLogger(ctx).debug("speculative_stale", { generation: pendingJob.generation });
+				} else if (result.reason === "rejected") {
 					feedbackSignal = ctx.beginCompaction?.({ reason: "extension" });
 				}
 				speculativeJob = undefined;

--- a/packages/coding-agent/test/compaction/stale-warm-blocking-repro.test.ts
+++ b/packages/coding-agent/test/compaction/stale-warm-blocking-repro.test.ts
@@ -1,0 +1,67 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, type Mock } from "vitest";
+import {
+	createBeforeAgentStartEvent,
+	createBlockingContext,
+	createCompactionHandlers,
+} from "../helpers/blocking-compaction-harness.ts";
+
+const registrations: Array<{ unregister: () => void }> = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+/**
+ * Reproduction for the Discord-reported "Compaction did not apply" loop:
+ * an idle/speculative warm summary pins `expectedRevision` at snapshot time
+ * (speculative.ts createSpeculativeCompactionSnapshot). Any revision bump
+ * while idle — e.g. an extension appending a hidden custom message via
+ * `ctx.sendMessage` (agent-session.ts sendCustomMessage immediate-append
+ * branch increments `_messageRevision`) — makes the warm result stale.
+ *
+ * `applyBlockingCompaction` (builtin/compaction/index.ts) then treats the
+ * stale warm result as TERMINAL: it ends feedback (which the session surfaces
+ * as "Compaction did not apply") and returns WITHOUT regenerating a fresh
+ * summary, even though the whole point of the blocking route is that the
+ * session is over the compaction threshold right now. "rejected" and
+ * "unavailable" results fall through to fresh core-route generation; "stale"
+ * does not. Context then keeps growing and the same failure repeats on every
+ * later trigger, matching the field logs (warm_consumed -> speculative_stale
+ * with no apply, tokens climbing).
+ */
+describe("Given a warm speculative summary made stale by an idle revision bump", () => {
+	it("Then the blocking route still compacts instead of giving up with 'Compaction did not apply'", async () => {
+		// Given: a session in the speculative warm-up band starts a warm job.
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 4_000 });
+		registrations.push(harness.registration);
+		let revision = 1;
+		harness.ctx.getMessageRevision = () => revision;
+		harness.registration.setResponses([
+			fauxAssistantMessage("warm summary of the old context"),
+			fauxAssistantMessage("fresh summary of the old context"),
+		]);
+		await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+
+		// When: a hidden custom message bumps the message revision while idle,
+		// then the next prompt crosses the compaction threshold.
+		revision = 2;
+		harness.setUsageTokens(6_000);
+		await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+
+		// Then: the blocking route must still apply a compaction (fresh
+		// regeneration after discarding the stale warm result) ...
+		const applyCompaction = harness.ctx.applyCompaction as unknown as Mock;
+		expect(applyCompaction).toHaveBeenCalled();
+
+		// ... and must not end feedback without an applied entry, which the
+		// session reports to the user as "Compaction did not apply".
+		const didNotApplyEndings = harness.endCompaction.mock.calls.filter(
+			([options]) => (options as { errorMessage?: string }).errorMessage === undefined,
+		);
+		expect(didNotApplyEndings).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

Fix threshold-triggered blocking compaction so a stale idle-warmed summary is discarded and replaced with a fresh core-route summary instead of ending with `Compaction did not apply`.

## Root cause

In `packages/coding-agent/src/core/extensions/builtin/compaction/index.ts` around lines 397-418, `applyBlockingCompaction()` consumed a warmed speculative job and treated `reason: "stale"` as terminal alongside an applied result. It cleared the job, ended compaction feedback, and returned without generating a summary against current session state.

The warm snapshot pins `expectedRevision` when created. Any idle message-revision bump (for example a hidden custom extension message, bash/session message, model reselection, or tool-set change) makes that result stale. The next over-threshold prompt then followed this loop:

1. idle warm summary completes;
2. session revision advances;
3. blocking threshold route consumes the warm result;
4. admission returns `stale`;
5. feedback ends as `Compaction did not apply`;
6. no context is removed, so later prompts repeat the cycle with a larger context.

Field compaction logs from one affected machine showed 10 stale warm consumptions versus 4 applied results (10/14 stale).

## Fix

- Keep applied warm results terminal exactly as before.
- Keep rejected-result feedback restart behavior exactly as before.
- For a stale warm result, preserve the existing `speculative_stale` debug log, clear the stale job, keep the same active feedback signal, and fall through to fresh core-route generation.

The earlier OpenAI remote blocking generation-race branch is intentionally unchanged. That branch owns and advances the generation used by its remote request; this PR is scoped to consumption of idle/speculative warm jobs made stale by an external message-revision bump.

## Regression evidence

The adopted deterministic reproduction warms at 4000/10000 tokens with revision 1, advances the revision to 2, re-enters over threshold at 6000 tokens, and asserts that fresh compaction applies without a no-error feedback ending.

- RED before the fix: `local-ignore/qa-evidence/20260809-compaction-stale-fallthrough/repro-red.txt` (`applyCompaction` was never called; exit 1)
- GREEN after the fix on `3689633577de9682578206cedf98b1f0be39d4b8`: `local-ignore/qa-evidence/20260809-compaction-stale-fallthrough/repro-green.txt` (1/1 passed)

## Verification

- Focused repro: 1/1 passed
- `test/compaction/`: 48 files, 336 tests passed
- `test/suite/compaction-feedback-lifecycle.test.ts` + `test/compaction.test.ts`: 2 files, 48 tests passed
- Root `npm run check`: passed
- Changelog gate against `origin/main`: passed
- Real CLI QA: common harness 9/9 and mock-loop 43/43 passed, deterministic localhost-only model traffic, real auth unchanged

Receipts:

- `local-ignore/qa-evidence/20260809-compaction-stale-fallthrough/compaction-suite.txt`
- `local-ignore/qa-evidence/20260809-compaction-stale-fallthrough/named-compaction-tests.txt`
- `local-ignore/qa-evidence/20260809-compaction-stale-fallthrough/root-check.txt`
- `local-ignore/qa-evidence/20260809-compaction-stale-fallthrough/changelog-gate.txt`
- `local-ignore/qa-evidence/20260809-compaction-stale-fallthrough/mock-loop-qa.txt`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix blocking compaction to regenerate a fresh summary when an idle-warmed result is stale after a message-revision bump. This prevents the “Compaction did not apply” loop and compacts against the current session state.

- **Bug Fixes**
  - In `packages/coding-agent/src/core/extensions/builtin/compaction/index.ts`, treat a warmed result with `reason: "stale"` as non‑terminal: clear the job, keep the active feedback, and fall through to fresh core-route generation.
  - Keep applied results terminal and rejected results’ feedback restart behavior unchanged; preserve the `speculative_stale` debug log. The OpenAI remote blocking generation path is unchanged.
  - Added focused regression: `packages/coding-agent/test/compaction/stale-warm-blocking-repro.test.ts`.

<sup>Written for commit 3689633577de9682578206cedf98b1f0be39d4b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

