### PR TITLE
fix(ai): recover angle-less ANTML tool calls

### DIFF
--- a/.agents/skills/senpi-qa/references/mock-loop.md
+++ b/.agents/skills/senpi-qa/references/mock-loop.md
@@ -135,12 +135,14 @@ node .agents/skills/senpi-qa/scripts/mock-loop.mjs \
   --api openai-completions
 ```
 
-The complete mode emits a leaked `<invoke name="bash">` as assistant text,
-asserts that Bash executes exactly once, verifies the second model request
-contains the tool output without leaked XML, and completes on a scripted final
-turn. The truncated mode emits a started call without `</invoke>`, uses a
-sentinel-writing command, and proves that the sentinel is never created while
-the second request contains `Re-issue the tool call with complete arguments.`
+The complete mode emits the observed malformed
+`antml:invoke name="bash">... </invoke></function_results>` shape as assistant
+text, asserts that Bash executes exactly once, verifies both the second model
+request and user-visible CLI output contain no leaked tool-protocol markup, and
+completes on a scripted final turn. The truncated mode emits a started call
+without `</invoke>`, uses a sentinel-writing command, and proves that the
+sentinel is never created while the second request contains
+`Re-issue the tool call with complete arguments.`
 
 Each run hashes the real auth file before and after, uses only the isolated
 `models.json` mock credential, removes its sandbox, and writes a sanitized

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-text-leak.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-text-leak.mjs
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks } from "./common.mjs";
 
 const REISSUE_GUIDANCE = "Re-issue the tool call with complete arguments.";
-const XML_PATTERN = /<\/?(?:antml:)?(?:invoke|parameter)/u;
+const LEAK_PATTERN = /antml:invoke|<\/?(?:antml:)?(?:invoke|parameter)|<\/?function_results/u;
 export const TEXT_LEAK_APIS = ["anthropic-messages", "openai-completions"];
 
 export function appendTextToolLeakChecks(checks, outcome) {
@@ -44,10 +44,11 @@ export async function runTextToolLeakScenario({ apiName, truncated, driveTurn, e
 			const command = truncated
 				? `printf '%s\\n' '${executionMarker}' >> ${shellQuote(sentinelPath)}`
 				: `printf '%s\\n' '${executionMarker}' >> ${shellQuote(sentinelPath)}; printf '%s\\n' '${executionMarker}'`;
-			const close = truncated ? "" : "</invoke>";
+			const open = truncated ? '<invoke name="bash">' : 'antml:invoke name="bash">';
+			const close = truncated ? "" : "</invoke></function_results>";
 			return [
 				{
-					text: `Preparing tool call.\n<invoke name="bash"><parameter name="command">${escapeXml(command)}</parameter>${close}`,
+					text: `Preparing tool call.\n${open}<parameter name="command">${escapeXml(command)}</parameter>${close}`,
 				},
 				{ text: finalMarker },
 			];
@@ -76,9 +77,14 @@ export async function runTextToolLeakScenario({ apiName, truncated, driveTurn, e
 			check(`${apiName}: ${mode} leak performs two turns`, requests.length === 2, `requests=${requests.length}`),
 			check(`${apiName}: ${mode} leak returns final text`, output.includes(finalMarker), `marker=${finalMarker}`),
 			check(
-				`${apiName}: ${mode} replay contains no leaked XML`,
-				!XML_PATTERN.test(replayBody),
-				`xmlPresent=${XML_PATTERN.test(replayBody)}`,
+				`${apiName}: ${mode} replay contains no leaked tool protocol`,
+				!LEAK_PATTERN.test(replayBody),
+				`protocolPresent=${LEAK_PATTERN.test(replayBody)}`,
+			),
+			check(
+				`${apiName}: ${mode} visible output contains no leaked tool protocol`,
+				!LEAK_PATTERN.test(output),
+				`protocolPresent=${LEAK_PATTERN.test(output)}`,
 			),
 			check(`${apiName}: ${mode} preserves real auth`, authUnchanged, guard.path),
 		];

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -21,6 +21,10 @@
   Bedrock Claude models now consistently use the five-minute wire and resolver TTL.
 - Reported the Claude SDK OAuth lane's SDK-managed prompt-cache TTL as five minutes.
 
+- Recovered Claude tool calls that omit the opening `<` before a lowercase
+  `antml:invoke` and append a stray `</function_results>` trailer, dispatching
+  the validated tool call instead of exposing internal protocol markup.
+
 ### Removed
 
 ## [2026.8.9] - 2026-08-09

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -2,6 +2,33 @@
 
 # Tool Call Middleware Changes
 
+## 2026-08-09 - Claude missing-angle ANTML invoke recovery
+
+### What changed and why
+
+- Claude normal-mode recovery now recognizes the observed transcript shape
+  `antml:invoke name="...">` when the opening `<` is missing, including openings
+  split at every internal stream boundary.
+- The tolerance is intentionally ANTML-specific, exact-case, and boundary-gated.
+  Unknown tools, malformed openings, code examples, and non-exact markers remain
+  literal text.
+- After a successfully recovered missing-angle call, the parser consumes the exact
+  stray `</function_results>` trailer observed in the leaked turn plus at most 127
+  interstitial whitespace characters. Longer whitespace runs are flushed as text,
+  and a standalone or mismatched trailer is preserved.
+
+### Why the extension system could not handle this
+
+- Recovery must transform raw assistant text into a canonical tool call before the
+  agent loop persists or renders the assistant message. Extensions only observe the
+  already-decoded stream, after this boundary.
+
+### Expected merge conflict zones
+
+- `protocols/antml/recovery-stream.ts`
+- `packages/ai/test/tool-call-middleware/claude-invoke-recovery.test.ts`
+- `.agents/skills/senpi-qa/scripts/lib/mock-loop-text-leak.mjs`
+
 ## 2026-07-30 - Kimi XTML unnamed channel recovery hardening
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/protocols/antml/recovery-stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/antml/recovery-stream.ts
@@ -1,11 +1,143 @@
 import type { Tool } from "../../../types.ts";
-import type { ParserOptions } from "../../types.ts";
+import type { ParserOptions, StreamParserEvent } from "../../types.ts";
 import { createInvokeRecoveryStreamParser, type RecoveryStreamParser } from "../anthropic-xml/recovery-stream.ts";
 import { antmlInvokeConfig } from "./config.ts";
+
+const MISSING_ANGLE_INVOKE_PREFIX = "antml:invoke";
+const STRAY_FUNCTION_RESULTS_CLOSE = "</function_results>";
+const MAX_MISSING_ANGLE_OPENING_LENGTH = 128;
+
+type PendingState = { readonly kind: "none" } | { kind: "opening"; value: string } | { kind: "trailer"; value: string };
+
+function isOpeningBoundary(character: string): boolean {
+	return character.length === 0 || (!["<", "/"].includes(character) && !/[A-Za-z0-9_]/u.test(character));
+}
 
 export function createAntmlInvokeRecoveryStreamParser(
 	tools: readonly Tool[],
 	options?: ParserOptions,
 ): RecoveryStreamParser {
-	return createInvokeRecoveryStreamParser(tools, antmlInvokeConfig, options);
+	const inner = createInvokeRecoveryStreamParser(tools, antmlInvokeConfig, options);
+	let pending: PendingState = { kind: "none" };
+	let previousCharacter = "";
+	let activeMissingAngleInvoke = false;
+	let syntheticAnglePending = false;
+
+	function collectEvents(events: StreamParserEvent[], innerEvents: StreamParserEvent[]): void {
+		for (const event of innerEvents) {
+			if (
+				syntheticAnglePending &&
+				event.type === "text" &&
+				event.text.startsWith(`<${MISSING_ANGLE_INVOKE_PREFIX}`)
+			) {
+				syntheticAnglePending = false;
+				const text = event.text.slice(1);
+				if (text.length > 0) {
+					events.push({ type: "text", text });
+				}
+				continue;
+			}
+			if (syntheticAnglePending && event.type === "toolcall_start") {
+				syntheticAnglePending = false;
+				activeMissingAngleInvoke = true;
+			}
+			if (activeMissingAngleInvoke && event.type === "toolcall_end") {
+				activeMissingAngleInvoke = false;
+				if (!event.incomplete) {
+					pending = { kind: "trailer", value: "" };
+				}
+			}
+			events.push(event);
+		}
+	}
+
+	function collectInner(events: StreamParserEvent[], input: string, syntheticAngle = false): void {
+		syntheticAnglePending = syntheticAnglePending || syntheticAngle;
+		collectEvents(events, inner.feed(input));
+	}
+
+	function flushPending(events: StreamParserEvent[]): void {
+		if (pending.kind === "none") {
+			return;
+		}
+		const value = pending.value;
+		pending = { kind: "none" };
+		collectInner(events, value);
+	}
+
+	function feedCharacter(events: StreamParserEvent[], character: string, openingBoundary: boolean): void {
+		if (pending.kind === "trailer") {
+			pending.value += character;
+			const candidate = pending.value.trimStart();
+			if (candidate.length === 0 || STRAY_FUNCTION_RESULTS_CLOSE.startsWith(candidate)) {
+				if (candidate === STRAY_FUNCTION_RESULTS_CLOSE) {
+					pending = { kind: "none" };
+				} else if (pending.value.length >= MAX_MISSING_ANGLE_OPENING_LENGTH) {
+					flushPending(events);
+				}
+				return;
+			}
+			const leadingWhitespace = pending.value.slice(0, pending.value.length - candidate.length);
+			pending = { kind: "none" };
+			collectInner(events, leadingWhitespace);
+			if (character === "a" && openingBoundary) {
+				pending = { kind: "opening", value: character };
+			} else {
+				collectInner(events, candidate);
+			}
+			return;
+		}
+
+		if (pending.kind === "opening") {
+			pending.value += character;
+			if (
+				pending.value.length <= MISSING_ANGLE_INVOKE_PREFIX.length &&
+				!MISSING_ANGLE_INVOKE_PREFIX.startsWith(pending.value)
+			) {
+				flushPending(events);
+				return;
+			}
+			if (pending.value.length > MISSING_ANGLE_INVOKE_PREFIX.length && character === ">") {
+				const opening = pending.value;
+				pending = { kind: "none" };
+				collectInner(events, `<${opening}`, true);
+				return;
+			}
+			if (pending.value.length >= MAX_MISSING_ANGLE_OPENING_LENGTH) {
+				flushPending(events);
+			}
+			return;
+		}
+
+		if (character === "a" && openingBoundary) {
+			pending = { kind: "opening", value: character };
+			return;
+		}
+		collectInner(events, character);
+	}
+
+	return {
+		feed(textDelta: string): StreamParserEvent[] {
+			const events: StreamParserEvent[] = [];
+			for (const character of textDelta) {
+				const openingBoundary = isOpeningBoundary(previousCharacter);
+				previousCharacter = character;
+				feedCharacter(events, character, openingBoundary);
+			}
+			return events;
+		},
+		interrupt(): StreamParserEvent[] {
+			const events: StreamParserEvent[] = [];
+			flushPending(events);
+			collectEvents(events, inner.interrupt());
+			previousCharacter = "";
+			return events;
+		},
+		finish(): StreamParserEvent[] {
+			const events: StreamParserEvent[] = [];
+			flushPending(events);
+			collectEvents(events, inner.finish());
+			return events;
+		},
+	};
 }

--- a/packages/ai/test/tool-call-middleware/claude-invoke-recovery.test.ts
+++ b/packages/ai/test/tool-call-middleware/claude-invoke-recovery.test.ts
@@ -1,0 +1,246 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { wrapStreamWithInvokeRecovery } from "../../src/index.ts";
+import { createAntmlInvokeRecoveryStreamParser } from "../../src/tool-call-middleware/protocols/antml/recovery-stream.ts";
+import type { AssistantMessageEvent, Tool } from "../../src/types.ts";
+import { collectEvents, TextStreamHarness, textFrom } from "./invoke-recovery-stream-fixtures.ts";
+
+const taskTool = {
+	name: "Task",
+	description: "Spawn a child task",
+	parameters: Type.Object({
+		category: Type.String(),
+		name: Type.String(),
+		description: Type.String(),
+		run_in_background: Type.Boolean(),
+		task_summary: Type.String(),
+		prompt: Type.String(),
+	}),
+} satisfies Tool;
+
+function toolEvents(events: readonly AssistantMessageEvent[]): AssistantMessageEvent[] {
+	return events.filter((event) => event.type.startsWith("toolcall_"));
+}
+
+async function runText(chunks: readonly string[], tools: readonly Tool[] = [taskTool]) {
+	const producer = new TextStreamHarness();
+	const wrapped = wrapStreamWithInvokeRecovery(producer.inner, tools);
+	producer.start();
+	for (const chunk of chunks) {
+		producer.delta(chunk);
+	}
+	producer.finish();
+	const events = await collectEvents(wrapped);
+	return { events, result: await wrapped.result() };
+}
+
+describe("Claude malformed invoke recovery", () => {
+	it("recovers transcript-shaped antml task invocation", async () => {
+		// Given
+		const leakedInvocation = [
+			'antml:invoke name="Task">',
+			'<parameter name="category">visual-engineering</parameter>',
+			'<parameter name="name">w5-monitor</parameter>',
+			'<parameter name="description">T25 Monitor activity log section</parameter>',
+			'<parameter name="run_in_background">true</parameter>',
+			'<parameter name="task_summary">T25 activity log</parameter>',
+			'<parameter name="prompt">Add the activity log section.</parameter>',
+			"</invoke>",
+			"</function_results>",
+		].join("\n");
+
+		// When
+		const { events, result } = await runText([`Before\n${leakedInvocation}\nAfter`]);
+
+		// Then
+		expect(toolEvents(events).map((event) => event.type)).toEqual([
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+		]);
+		expect(result.content).toEqual([
+			{ type: "text", text: "Before\n" },
+			{
+				type: "toolCall",
+				id: "recovered-antml-0",
+				name: "Task",
+				arguments: {
+					category: "visual-engineering",
+					name: "w5-monitor",
+					description: "T25 Monitor activity log section",
+					run_in_background: true,
+					task_summary: "T25 activity log",
+					prompt: "Add the activity log section.",
+				},
+			},
+			{ type: "text", text: "\nAfter" },
+		]);
+		expect(textFrom(result)).not.toContain("antml:invoke");
+		expect(textFrom(result)).not.toContain("function_results");
+		expect(result.stopReason).toBe("toolUse");
+	});
+
+	it("recovers the malformed opening and trailer across stream boundaries", async () => {
+		// Given
+		const opening = 'antml:invoke name="Task">';
+		const body = [
+			'<parameter name="category">visual-engineering</parameter>',
+			'<parameter name="name">w5-monitor</parameter>',
+			'<parameter name="description">T25 Monitor activity log section</parameter>',
+			'<parameter name="run_in_background">true</parameter>',
+			'<parameter name="task_summary">T25 activity log</parameter>',
+			'<parameter name="prompt">Add the activity log section.</parameter>',
+			"</invoke>",
+		].join("");
+		const trailer = "</function_results>";
+
+		for (let split = 0; split <= opening.length; split += 1) {
+			// When
+			const { events, result } = await runText([opening.slice(0, split), opening.slice(split), body, trailer]);
+
+			// Then
+			expect(toolEvents(events), `opening split ${split}`).toHaveLength(3);
+			expect(textFrom(result), `opening split ${split}`).toBe("");
+		}
+
+		for (let split = 0; split <= trailer.length; split += 1) {
+			// When
+			const { events, result } = await runText([opening, body, trailer.slice(0, split), trailer.slice(split)]);
+
+			// Then
+			expect(toolEvents(events), `trailer split ${split}`).toHaveLength(3);
+			expect(textFrom(result), `trailer split ${split}`).toBe("");
+		}
+	});
+
+	it("keeps code examples and non-exact markers literal", async () => {
+		// Given
+		const invocation =
+			'antml:invoke name="Task"><parameter name="prompt">literal</parameter></invoke></function_results>';
+		const inputs = [
+			`inline \`${invocation}\` example`,
+			`\`\`\`xml\n${invocation}\n\`\`\``,
+			`prefix x${invocation}`,
+			invocation.replace("antml:invoke", "ANTML:invoke"),
+			"</function_results>",
+		];
+
+		for (const input of inputs) {
+			// When
+			const { events, result } = await runText([...input]);
+
+			// Then
+			expect(toolEvents(events)).toEqual([]);
+			expect(textFrom(result)).toBe(input);
+		}
+	});
+
+	it("preserves unknown malformed invokes without consuming their trailer", async () => {
+		// Given
+		const input =
+			'antml:invoke name="Missing"><parameter name="prompt">literal</parameter></invoke></function_results>';
+
+		// When
+		const { events, result } = await runText([input]);
+
+		// Then
+		expect(toolEvents(events)).toEqual([]);
+		expect(textFrom(result)).toBe(input);
+		expect(result.stopReason).toBe("stop");
+	});
+
+	it("recovers adjacent malformed invokes when no stray trailer follows", async () => {
+		// Given
+		const invocation = (name: string) =>
+			[
+				'antml:invoke name="Task">',
+				'<parameter name="category">quick</parameter>',
+				`<parameter name="name">${name}</parameter>`,
+				'<parameter name="description">Adjacent task</parameter>',
+				'<parameter name="run_in_background">true</parameter>',
+				'<parameter name="task_summary">Adjacent task</parameter>',
+				'<parameter name="prompt">Run the adjacent task.</parameter>',
+				"</invoke>",
+			].join("");
+
+		// When
+		const { events, result } = await runText([`${invocation("first")}\n${invocation("second")}`]);
+
+		// Then
+		expect(toolEvents(events).map((event) => event.type)).toEqual([
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+			"toolcall_start",
+			"toolcall_delta",
+			"toolcall_end",
+		]);
+		expect(result.content.filter((block) => block.type === "toolCall").map((block) => block.arguments.name)).toEqual([
+			"first",
+			"second",
+		]);
+		expect(textFrom(result)).toBe("\n");
+	});
+
+	it("bounds whitespace retained while probing for a stray trailer", () => {
+		// Given
+		const parser = createAntmlInvokeRecoveryStreamParser([taskTool]);
+		const invocation = [
+			'antml:invoke name="Task">',
+			'<parameter name="category">quick</parameter>',
+			'<parameter name="name">bounded</parameter>',
+			'<parameter name="description">Bounded trailer probe</parameter>',
+			'<parameter name="run_in_background">true</parameter>',
+			'<parameter name="task_summary">Bounded trailer probe</parameter>',
+			'<parameter name="prompt">Run the bounded task.</parameter>',
+			"</invoke>",
+		].join("");
+		parser.feed(invocation);
+
+		// When
+		const whitespace = " ".repeat(128);
+		const events = parser.feed(whitespace);
+
+		// Then
+		expect(
+			events
+				.filter((event) => event.type === "text")
+				.map((event) => event.text)
+				.join(""),
+		).toBe(whitespace);
+		expect(events.length).toBeGreaterThan(0);
+		expect(parser.finish()).toEqual([]);
+	});
+
+	it("recovers a malformed invoke after wrapper text and consumes its trailer", () => {
+		// Given
+		const parser = createAntmlInvokeRecoveryStreamParser([taskTool]);
+		const invocation = [
+			'antml:invoke name="Task">',
+			'<parameter name="category">quick</parameter>',
+			'<parameter name="name">wrapped</parameter>',
+			'<parameter name="description">Wrapped malformed call</parameter>',
+			'<parameter name="run_in_background">true</parameter>',
+			'<parameter name="task_summary">Wrapped malformed call</parameter>',
+			'<parameter name="prompt">Run the wrapped task.</parameter>',
+			"</invoke>",
+		].join("");
+
+		// When
+		const events = [
+			...parser.feed("<function_calls>prefix "),
+			...parser.feed(invocation),
+			...parser.feed("</function_results></function_calls>"),
+			...parser.finish(),
+		];
+
+		// Then
+		expect(events.filter((event) => event.type.startsWith("toolcall_"))).toHaveLength(3);
+		expect(
+			events
+				.filter((event) => event.type === "text")
+				.map((event) => event.text)
+				.join(""),
+		).toBe("prefix ");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,10 @@
   exit payloads, and process-tree kill behavior are unchanged. Added native regression coverage for threadpool exhaustion
   and Worker teardown ([#768](https://github.com/code-yeongyu/senpi/pull/768)).
 
+- Recovered malformed Claude tool-call text that starts with an angle-less
+  `antml:invoke` and ends with a stray `</function_results>`, so Senpi executes
+  the validated call once without printing internal protocol markup.
+
 ### Removed
 
 ## [2026.8.9] - 2026-08-09


### PR DESCRIPTION
## Summary

- recover Claude tool calls emitted as `antml:invoke ...` when the opening `<` is missing
- consume the observed stray `</function_results>` trailer without leaking protocol text
- preserve code examples, unknown tools, malformed calls, native calls, and ordinary text
- strengthen deterministic mock-loop QA and document the exact scenario

## Root cause

The originating session persisted the complete invocation as assistant text with
`stopReason="stop"` and no structured tool-call block. Claude normal-mode recovery
was enabled, but the existing scanner only retained candidates beginning with `<`;
the initial `a` in `antml:invoke` was therefore emitted as ordinary text before the
canonical parser could recover the call.

This change keeps the shared Anthropic-XML parser unchanged. The ANTML factory adds
an exact-case, boundary-gated adapter that supplies the missing synthetic `<`, then
delegates tool resolution, schema validation, coercion, stream limits, and canonical
event generation to the existing parser.

## Verification

- RED: exact transcript fixture produced zero tool-call events before the fix
- GREEN: focused recovery family — 8 files, 74 tests passed
- full AI package suite — 192 files passed, 1,823 tests passed
- `npm run check` — passed
- `npm run build` — passed
- changelog gate — passed
- real source CLI:
  - `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-text-tool-leak --api openai-completions`
  - 9/9 passed
  - tool executed exactly once
  - no `antml:invoke` or `function_results` in replay or visible output
  - real auth unchanged
  - sandbox removed

Evidence is stored under:
`local-ignore/qa-evidence/20260809-antml-task-leak/`

## Review

Independent goal, hands-on QA, code-quality, security, and repository-context
reviews passed. Review-driven follow-ups included:

- bounding post-call trailer whitespace retention
- preserving synthetic-angle state across wrapper `textBefore` events
- adjacent malformed-call regression coverage
- updating the mock-loop reference and both package changelogs

## Risk

Low. Recovery remains limited to exact lowercase `antml:invoke` at a non-word
boundary, outside code masks, followed by a declared tool and schema-valid arguments.
Unknown or malformed calls remain literal text.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover malformed Claude tool calls that start with angle-less `antml:invoke` and end with a stray `</function_results>`, so the validated tool runs once without leaking protocol markup. Also hardens stream-boundary handling during recovery.

- **Bug Fixes**
  - Recover missing `<` before lowercase `antml:invoke`, including across stream splits.
  - Consume the exact trailing `</function_results>` after a valid call; cap whitespace probing at 127 chars.
  - Keep code examples, unknown tools, malformed openings, and normal text literal.
  - Add focused tests and update the mock-loop QA to assert no leaked protocol in replay or CLI output.

<sup>Written for commit 6e59875e99623bfdf85840a1b9102923871921da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

