### PR TITLE
docs(coding-agent): document cache retention lanes, affinity, and goal backstop timing

### DIFF
--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -88,8 +88,17 @@ If your Claude Pro/Max subscription usage through `claude-sdk-oauth` feels unexp
 1. **Upgrade to v2026.8.3 or later.** Resume-first session continuity (#634-637) landed on 2026-08-03. On older builds, every turn after a divergence (compaction, abort, model switch, restart, failover) re-sends the entire conversation, which is the dominant token-burn mechanism.
 2. **Check which lane you are on.** The `ambient` lane (default) inherits the environment. `oauth-slots` and `config-dir` are managed lanes set via `SENPI_CLAUDE_SDK_OAUTH_TOKEN_INJECTION`. The `config-dir` lane keeps each account's credentials in its own `CLAUDE_CONFIG_DIR`; no official SDK API moves a transcript across roots, so account failover on that lane always flattens (re-sends the full history) — this is a declared residual, not a bug.
 3. **Read the continuity observations.** Tail the session log and filter for `flatten` — each `flatten` line means the lane re-sent the whole conversation and lost prompt-cache hits. A healthy conversation shows one `bootstrap` followed by `delta` lines. Common flatten reasons: `transcript_missing`, `registry_miss`, `resume_initialization_failed`, `cross_root_unsupported` (config-dir only).
-4. **Prompt-cache retention.** On the direct Anthropic API path (`anthropic` provider with an OAuth token), cache retention defaults to `long` with a 1-hour TTL on the native endpoint. Set `PI_CACHE_RETENTION=long` to ensure 1h caching. The SDK OAuth lane manages its own caching internally and senpi cannot add `cache_control` breakpoints to it.
-5. **Directive-block deduplication.** As of v2026.8.4, the flatten serialization collapses repeated `<ultrawork-mode>` directive blocks to a single copy, preventing the issue-#494 scenario where duplicated ~17KB directive blocks consumed up to 73% of the re-sent prompt. The continuity observation reports how many were collapsed and the payload size.
+4. **Prompt-cache retention.** Effective cache TTL depends on which lane you are on:
+
+   | Lane | Effective TTL | Who controls it | How to override |
+   | --- | --- | --- | --- |
+   | Claude SDK OAuth (subscription, `claude-sdk-oauth`) | 5 minutes | The Claude SDK owns `cache_control`; senpi cannot add breakpoints. senpi reports 300s for this lane so cache-aware budgets (tool waits, goal timing) size themselves correctly. | Not overridable |
+   | Direct Anthropic API (`api.anthropic.com`, API key or OAuth token) | 1 hour | senpi defaults retention to `long` on this lane. Note: Anthropic's own API default is 5 minutes; the 1h TTL is senpi's choice, and 1h cache writes cost 2x base input vs 1.25x for 5m ([Anthropic prompt caching](https://docs.claude.com/en/docs/build-with-claude/prompt-caching)). | `PI_CACHE_RETENTION`, `cacheRetention` |
+   | Anthropic-compatible providers (kimi-coding, fireworks, gateways) | 5 minutes | The 1h TTL is gated on the native `api.anthropic.com` base URL, so these lanes stay short. | `cacheRetention` |
+
+   Override precedence: `cacheRetention` in `models.json` / the model catalog wins over everything. `PI_CACHE_RETENTION=long` selects long; any other set value forces short; unset falls back to the lane default above.
+5. **Goal-monitor timing.** The goal monitor's continuation backstop is derived from the model's cache-safe wait (TTL minus `promptCache.safetyBufferSeconds`, default 30), capped by `promptCache.goalBackstopMaxSeconds` (default 3570), instead of a fixed 4 minutes. On 5m lanes that means wakes every ~4m30s; on the 1h direct-API lane, up to 59m30s. Cache-warm notices show which warm iteration you are on.
+6. **Directive-block deduplication.** As of v2026.8.4, the flatten serialization collapses repeated `<ultrawork-mode>` directive blocks to a single copy, preventing the issue-#494 scenario where duplicated ~17KB directive blocks consumed up to 73% of the re-sent prompt. The continuity observation reports how many were collapsed and the payload size.
 
 ### GitHub Copilot
 
@@ -107,6 +116,16 @@ If your Claude Pro/Max subscription usage through `claude-sdk-oauth` feels unexp
 - The authorization creates a user-controlled OpenRouter API key billed from your OpenRouter credits
 - On remote/headless machines (e.g. over SSH) the browser cannot reach the loopback callback; paste the final redirect URL (or the authorization code) into the login prompt instead
 - `OPENROUTER_API_KEY` remains available through **Use an API key**
+
+#### OpenRouter prompt caching and sticky routing
+
+senpi pins every OpenRouter request to the same upstream from the first call by sending the session id both as the `x-session-id` header and as the request-body `session_id` field. OpenRouter's precedence is body > header > `prompt_cache_key`, with a 256-character limit on the value; specifying a manual `provider.order` disables sticky routing entirely ([OpenRouter prompt caching](https://openrouter.ai/docs/guides/best-practices/prompt-caching)).
+
+Upstreams that require explicit cache breakpoints get `cache_control` blocks through OpenRouter: model ids starting with `anthropic/`, `qwen/`, or `google/` (catalog ids carrying one leading `~` are matched after stripping it). Other upstreams (OpenAI, DeepSeek, Moonshot, Groq, Z.AI, Grok) cache automatically and need no markers.
+
+#### Moonshot / Kimi prompt caching
+
+senpi sends `prompt_cache_key` (set to the session id) on Moonshot requests. Kimi documents the field as required for the Kimi Code Plan and recommended for any multi-turn agent ([Kimi context caching](https://platform.kimi.ai/docs/guide/use-context-caching-feature-of-kimi-api)). Kimi reports cache hits as a flat `usage.cached_tokens` field, which senpi parses as cache-read tokens.
 
 ### Radius
 
@@ -296,7 +315,7 @@ Also supports ECS task roles (`AWS_CONTAINER_CREDENTIALS_*`) and IRSA (`AWS_WEB_
 pi --provider amazon-bedrock --model us.anthropic.claude-sonnet-4-20250514-v1:0
 ```
 
-Prompt caching is enabled automatically for Claude models whose ID contains a recognizable model name (base models and system-defined inference profiles). For application inference profiles (whose ARNs don't contain the model name), set `AWS_BEDROCK_FORCE_CACHE=1` to enable cache points:
+Prompt caching is enabled automatically for Claude models whose ID contains a recognizable model name (base models and system-defined inference profiles). With `PI_CACHE_RETENTION=long`, the 1-hour cache TTL is only requested for Claude Opus 4.5, Sonnet 4.5, and Haiku 4.5, the models AWS documents as supporting it ([Bedrock prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)); every other cacheable Bedrock Claude model uses 5 minutes on both the wire and the TTL estimate. For application inference profiles (whose ARNs don't contain the model name), set `AWS_BEDROCK_FORCE_CACHE=1` to enable cache points:
 
 ```bash
 export AWS_BEDROCK_FORCE_CACHE=1


### PR DESCRIPTION
## Summary

Docs-only PR (PR-E, T17 of `.omo/plans/cache-hit-maximization.md`). Rewrites the misleading prompt-cache retention note in `packages/coding-agent/docs/providers.md` and documents the cache behavior that already merged to main.

- Retention truth table per lane: Claude SDK OAuth (5m, SDK-owned, senpi reports 300s), direct Anthropic API (senpi defaults `long` = 1h; Anthropic's own default is 5m; 1h writes cost 2x vs 1.25x), Anthropic-compatible providers (5m), plus `PI_CACHE_RETENTION` / `cacheRetention` override precedence.
- OpenRouter subsection: `x-session-id` header + body `session_id`, body > header > `prompt_cache_key` precedence, 256-char limit, `provider.order` disables sticky routing, `cache_control` allowlist (`anthropic/`, `qwen/`, `google/` with one leading `~` stripped).
- Moonshot/Kimi: `prompt_cache_key` emission and flat `usage.cached_tokens` parsing.
- Bedrock: 1h TTL only for Opus/Sonnet/Haiku 4.5; kept `AWS_BEDROCK_FORCE_CACHE` guidance.
- Goal-timing note: backstop derived from cache-safe wait (TTL minus `promptCache.safetyBufferSeconds`, default 30) capped by `promptCache.goalBackstopMaxSeconds` (default 3570); cache-warm notices show the warm iteration ordinal.

## Evidence (claims verified in this worktree)

- `packages/ai/src/utils/prompt-cache-ttl.ts:327` — `case "claude-sdk-oauth"` returns `PROMPT_CACHE_TTL_SHORT_SECONDS` (300s)
- `packages/ai/src/utils/prompt-cache-ttl.ts:332-339` — direct Anthropic lane: `long` fallback default, 1h gated on `isAnthropicApiBaseUrl`
- `packages/ai/src/utils/prompt-cache-ttl.ts:278-292` — `PI_CACHE_RETENTION` semantics: `long` selects long, any other set value forces short, unset uses lane fallback; explicit `cacheRetention` wins
- `packages/ai/src/utils/prompt-cache-ttl.ts:238-243,344-347` — `supportsOneHourCacheTtl` allowlist {opus-4-5, sonnet-4-5, haiku-4-5} used by the bedrock resolver branch
- `packages/ai/src/utils/prompt-cache-ttl.ts:175,178` — `sendSessionAffinityHeaders: isOpenRouter`; `supportsPromptCacheKey: isMoonshot || baseUrl.includes("api.openai.com")`
- `packages/ai/src/utils/prompt-cache-ttl.ts:130-135` — OpenRouter `cache_control` prefix allowlist `["anthropic/", "qwen/", "google/"]` with one leading `~` stripped
- `packages/ai/src/api/openai-completions.ts:899,952-955` — `x-session-id`-style header + body `session_id` for the openrouter affinity format
- `packages/ai/src/api/openai-completions.ts:945-950` — `prompt_cache_key` sent when `supportsPromptCacheKey`
- `packages/ai/src/api/openai-completions.ts:1635-1643` — flat `usage.cached_tokens` parsed last in the cache-read fallback chain
- `packages/coding-agent/src/core/settings-manager.ts:70-71` — `safetyBufferSeconds` (default 30), `goalBackstopMaxSeconds` (default 3570)
- `packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts:8-21` — fallback 240_000 backstop constant + `resolveGoalMonitorContinuationDelayMs`
- `packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts:274-291,340-371` — cache-warm iteration ordinal on events/entries

Provider contract URLs cited in the doc come from the plan appendix (E2-E5): Anthropic prompt caching, OpenRouter prompt caching, Kimi context caching, Bedrock prompt caching.

## Changelog

Docs-only, no runtime source touched; `no-changelog` label applied.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents prompt cache retention by lane, OpenRouter session affinity, Moonshot/Kimi cache keys, Bedrock 1h TTL support, and goal backstop timing. Aligns provider docs with current behavior so teams size waits and overrides correctly.

- **Migration**
  - Retention per lane: direct Anthropic defaults to 1h; `claude-sdk-oauth` is fixed at 5m; Anthropic‑compatible providers stay 5m. Override with `cacheRetention` (catalog) or `PI_CACHE_RETENTION` (`long` forces long; any other value forces short).
  - OpenRouter: body `session_id` > `x-session-id` > `prompt_cache_key`; `provider.order` disables sticky routing; `cache_control` allowed for `anthropic/`, `qwen/`, `google/` (one leading `~` ignored); 256‑char limit.
  - Moonshot/Kimi: send `prompt_cache_key` (session id). Kimi reports hits via `usage.cached_tokens`.
  - Bedrock: request 1h TTL only for Claude Opus/Sonnet/Haiku 4.5; others use 5m. Use `AWS_BEDROCK_FORCE_CACHE=1` to enable cache points for app profile ARNs.
  - Goal timing: backstop = TTL minus 30s buffer, capped at 3570s; cache‑warm notices include the warm iteration number.

<sup>Written for commit 81781a25dbbd1f042d9d7c9ede7fb38ee6db9154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

