### PR TITLE
docs(changelog): complete v2026.8.9-2 release audit

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -21,6 +21,9 @@
 - Restricted Bedrock one-hour prompt-cache TTLs to Claude Opus 4.5, Sonnet 4.5, and Haiku 4.5; other cacheable
   Bedrock Claude models now consistently use the five-minute wire and resolver TTL.
 - Reported the Claude SDK OAuth lane's SDK-managed prompt-cache TTL as five minutes.
+- Fixed `warmPromptCache` eagerly loading the Anthropic SDK and message implementation for models that cannot use
+  Anthropic prompt-cache warming. Capability checks now run first, so unsupported provider lanes avoid the optional
+  Anthropic dependency entirely while supported models preserve the same pre-warm request and usage accounting.
 
 - Recovered Claude tool calls that omit the opening `<` before a lowercase
   `antml:invoke` and append a stray `</function_results>` trailer, dispatching

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Added opt-in native Anthropic prompt-cache keep-alive pings, disabled by default and bounded per session by request and estimated-cost caps. Idle pings stay dormant while any Goal continuation wait is armed and render as `⚡ Warm ping #N` transcript entries.
 
+- Added provider-native prompt-cache identity and first-request affinity for the interactive agent: Moonshot/Kimi Chat
+  Completions now send `prompt_cache_key`, while OpenRouter sends both `x-session-id` and the request body's `session_id`
+  so repeated turns consistently target the same upstream cache lane.
+
 - Goal continuation now aggregates terminal monitors, background terminal sessions, detached eval cells, and other producers through the shared `wake_source_state` contract. Scheduled/resumed telemetry keeps `activeMonitorCount` as the aggregate compatibility field and adds a per-source `wakeSources` snapshot.
 
 - Goal cache-warm wait and wake entries now show an in-memory iteration number for each accepted monitor cycle, resetting when the Goal or wake epoch changes while remaining compatible with legacy persisted entries.
@@ -18,9 +22,21 @@
 
 - Goal monitor continuation backstops now derive from the active model's prompt-cache safe-wait budget instead of a fixed four-minute delay, capped by `promptCache.goalBackstopMaxSeconds` (default 3570 seconds). Held direct-input admission now consumes wall-clock time, and cache-warm notices no longer claim warmth or savings after the cache TTL may have elapsed.
 
+- Expanded explicit OpenRouter prompt-cache markers beyond Anthropic model names to Qwen and Google prefixes, including
+  catalog IDs with one leading `~`, so those provider families reuse the intended cache boundary instead of sending
+  otherwise equivalent prompts without cache-control markers.
+
 ### Fixed
 
 - Fixed active goals becoming stranded when the final wake source drained: an armed monitor wait now fires after a one-second micro-grace even at zero active sources. Activating a goal through app-server `thread/goal/set` also queues work for an otherwise idle session.
+
+- Fixed provider cache accounting and TTL reporting used by Senpi's status, cost, and cache-warm decisions: flat Kimi
+  `usage.cached_tokens` now counts as cache-read tokens; Bedrock requests one-hour retention only for Claude Opus 4.5,
+  Sonnet 4.5, and Haiku 4.5 while other cacheable Claude models stay at five minutes; and the Claude SDK OAuth lane now
+  reports its SDK-managed cache lifetime as 300 seconds.
+- Fixed Anthropic prompt-cache pre-warming importing the Anthropic SDK before Senpi knew whether the selected model
+  supported warming. Unsupported providers now remain dependency-lazy, while supported Anthropic models preserve the
+  same zero-output warm request and normalized cache-usage accounting.
 
 - Fixed a full session freeze when four or more long-lived background terminal sessions were active. Each native terminal
   `waitExit()` previously parked one of the four default libuv workers on a blocking thread join for the child's lifetime,


### PR DESCRIPTION
## Summary

- completes the `v2026.8.9..origin/main` changelog audit across all 31 revisions
- duplicates six user-facing AI provider-cache changes into the coding-agent release surface
- documents capability-gated lazy Anthropic SDK loading for `warmPromptCache`

## Coverage

- revisions audited: 31/31
- non-merge commits: 22
- merge commits: 9
- omissions/extras: 0/0
- released changelog sections modified: none

## RED

- coding-agent omitted Kimi cache accounting, Bedrock/Claude cache TTL behavior,
  Moonshot/Kimi cache keys, OpenRouter affinity, and expanded cache-control markers
- AI and coding-agent omitted the lazy Anthropic SDK loading fix

## GREEN

- semantic concept audit: no missing AI or coding-agent groups
- `node scripts/check-pr-changelog.mjs --base origin/main`
- `git diff --check`
- only `packages/ai/CHANGELOG.md` and
  `packages/coding-agent/CHANGELOG.md` changed

## Release

Target CalVer: `2026.8.9-2`

Plan: `.omo/plans/release-2026-08-09-2.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the v2026.8.9-2 changelog audit and adds the missing provider-cache notes plus the capability-gated Anthropic SDK lazy-load fix for `warmPromptCache` in `packages/ai` and `packages/coding-agent`. Clarifies cache TTLs/accounting, affinity/identity markers for OpenRouter and Moonshot/Kimi, and prompt-cache warm behavior to match what shipped.

<sup>Written for commit 558f5c014bc3566fda08c2fd82b18e95d1011bcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

