### PR TITLE
fix(process): resolve taskkill outside PATH

### DIFF
--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -250,10 +250,18 @@ function getShellEnv(
 function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const taskkillPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe");
+			const taskkill = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
 				windowsHide: true,
+			});
+			taskkill.once("error", () => {
+				try {
+					process.kill(pid, "SIGKILL");
+				} catch {
+					// Process already dead.
+				}
 			});
 		} catch {
 			// Ignore errors.

--- a/packages/agent/test/fixtures/windows-taskkill-path.ts
+++ b/packages/agent/test/fixtures/windows-taskkill-path.ts
@@ -1,0 +1,16 @@
+import { dirname, join } from "node:path";
+import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
+
+const env = new NodeExecutionEnv({
+	cwd: process.cwd(),
+	shellPath: join(process.env.ProgramFiles ?? "C:\\Program Files", "Git", "bin", "bash.exe"),
+});
+const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+process.env[pathKey] = dirname(process.execPath);
+
+const result = await env.exec(`"${process.execPath}" -e "require('node:net').createServer().listen(0)"`, {
+	timeout: 1,
+});
+if (result.ok || result.error.code !== "timeout") {
+	throw new Error(`Expected timeout result, received ${JSON.stringify(result)}`);
+}

--- a/packages/agent/test/harness/nodejs-env.test.ts
+++ b/packages/agent/test/harness/nodejs-env.test.ts
@@ -1,9 +1,9 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { access, chmod, realpath, symlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
 import { FileError, getOrThrow } from "../../src/harness/types.ts";
@@ -394,6 +394,16 @@ describe("NodeExecutionEnv", () => {
 		const result = await env.exec("sleep 5", { timeout: 0.01 });
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.error).toMatchObject({ code: "timeout" });
+	});
+
+	it.skipIf(process.platform !== "win32")("does not crash when timeout cleanup cannot find taskkill on PATH", () => {
+		const fixturePath = fileURLToPath(new URL("../fixtures/windows-taskkill-path.ts", import.meta.url));
+		const result = spawnSync(process.execPath, ["--import", "tsx", fixturePath], {
+			encoding: "utf8",
+			windowsHide: true,
+		});
+
+		expect({ status: result.status, stderr: result.stderr }).toEqual({ status: 0, stderr: "" });
 	});
 
 	it("returns callback errors from exec stream handlers", async () => {

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { delimiter } from "node:path";
+import { delimiter, join } from "node:path";
 import { spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
 
@@ -267,10 +267,18 @@ export function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
 		// Use taskkill on Windows to kill process tree
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const taskkillPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe");
+			const taskkill = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
 				detached: true,
 				windowsHide: true,
+			});
+			taskkill.once("error", () => {
+				try {
+					process.kill(pid, "SIGKILL");
+				} catch {
+					// Process already dead
+				}
 			});
 		} catch {
 			// Ignore errors if taskkill fails

--- a/packages/coding-agent/test/fixtures/windows-taskkill-path.ts
+++ b/packages/coding-agent/test/fixtures/windows-taskkill-path.ts
@@ -1,0 +1,17 @@
+import { spawn } from "node:child_process";
+import { dirname } from "node:path";
+import { killProcessTree } from "../../src/utils/shell.ts";
+
+const child = spawn(process.execPath, ["-e", "process.stdin.resume()"]);
+if (child.pid === undefined) {
+	throw new Error("Expected the child process to have a pid");
+}
+
+const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+process.env[pathKey] = dirname(process.execPath);
+killProcessTree(child.pid);
+
+await new Promise<void>((resolve, reject) => {
+	child.once("error", reject);
+	child.once("close", () => resolve());
+});

--- a/packages/coding-agent/test/suite/shell-config-kind.test.ts
+++ b/packages/coding-agent/test/suite/shell-config-kind.test.ts
@@ -1,6 +1,8 @@
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getShellConfig, resolveShellKind } from "../../src/utils/shell.ts";
 
@@ -12,6 +14,8 @@ import { getShellConfig, resolveShellKind } from "../../src/utils/shell.ts";
  * `getShellConfig` only inspects the supplied path string, not the host OS.
  */
 describe("shell config kind resolution", () => {
+	const windowsIt = it.skipIf(process.platform !== "win32");
+
 	let dir: string;
 	const savedEnv = process.env.SENPI_GIT_BASH_PATH;
 
@@ -65,5 +69,15 @@ describe("shell config kind resolution", () => {
 		const config = getShellConfig();
 		expect(config.shell).toBe(bash);
 		expect(config.kind).toBe("bash");
+	});
+
+	windowsIt("killProcessTree survives when taskkill is absent from PATH", () => {
+		const fixturePath = fileURLToPath(new URL("../fixtures/windows-taskkill-path.ts", import.meta.url));
+		const result = spawnSync(process.execPath, ["--import", "tsx", fixturePath], {
+			encoding: "utf8",
+			windowsHide: true,
+		});
+
+		expect({ status: result.status, stderr: result.stderr }).toEqual({ status: 0, stderr: "" });
 	});
 });

--- a/packages/pty/src/pipe-fallback.ts
+++ b/packages/pty/src/pipe-fallback.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { join } from "node:path";
 import type { NativePtyLoadResult } from "./native-loader.ts";
 
 export interface PipeFallbackSessionOptions {
@@ -244,7 +245,13 @@ export class PipeFallbackSession {
 			// pipe open — so 'close' never fires and waitExit() hangs teardown. taskkill /T /F
 			// terminates the whole tree so the pipe EOFs and the session settles.
 			try {
-				spawn("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+				const child = this.child;
+				const taskkillPath = join(process.env.SystemRoot ?? "C:\\Windows", "System32", "taskkill.exe");
+				const taskkill = spawn(taskkillPath, ["/pid", String(pid), "/T", "/F"], {
+					stdio: "ignore",
+					windowsHide: true,
+				});
+				taskkill.once("error", () => terminateChildTree(child, signal));
 				return { ok: true, note: `Terminated child_process pipe fallback process tree (pid ${pid}).` };
 			} catch {
 				// Fall through to the direct kill if taskkill is unavailable.

--- a/packages/pty/test/fixtures/windows-taskkill-path.ts
+++ b/packages/pty/test/fixtures/windows-taskkill-path.ts
@@ -1,0 +1,21 @@
+import { dirname } from "node:path";
+import { PipeFallbackSession } from "../../src/pipe-fallback.ts";
+
+const session = new PipeFallbackSession({
+	command: process.execPath,
+	args: ["-e", "process.stdin.resume()"],
+});
+session.start();
+
+const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+process.env[pathKey] = dirname(process.execPath);
+
+const kill = session.kill();
+if (!kill.ok) {
+	throw new Error(kill.note);
+}
+
+const exit = await session.waitExit();
+if (exit.error) {
+	throw new Error(exit.error.message);
+}

--- a/packages/pty/test/pipe-fallback.test.ts
+++ b/packages/pty/test/pipe-fallback.test.ts
@@ -1,4 +1,6 @@
+import { spawn } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { NativePtyLoadResult } from "../src/native-loader.ts";
 import {
@@ -146,6 +148,27 @@ describe("PipeFallbackSession", () => {
 
 describe("PipeFallbackSession terminal detachment", () => {
 	const posixIt = it.skipIf(process.platform === "win32");
+	const windowsIt = it.skipIf(process.platform !== "win32");
+
+	windowsIt("kill() does not crash when taskkill is absent from PATH", async () => {
+		const fixturePath = fileURLToPath(new URL("./fixtures/windows-taskkill-path.ts", import.meta.url));
+		const fixture = spawn(process.execPath, ["--import", "tsx", fixturePath], {
+			stdio: ["ignore", "ignore", "pipe"],
+			windowsHide: true,
+		});
+		let stderr = "";
+		fixture.stderr.setEncoding("utf8");
+		fixture.stderr.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+
+		const exitCode = await new Promise<number | null>((resolve, reject) => {
+			fixture.once("error", reject);
+			fixture.once("close", resolve);
+		});
+
+		expect({ exitCode, stderr }).toEqual({ exitCode: 0, stderr: "" });
+	});
 
 	posixIt("runs the child in its own process group so it cannot read senpi's controlling terminal", async () => {
 		// A child sharing senpi's session keeps the user's terminal as its


### PR DESCRIPTION
## Summary

- resolve `taskkill.exe` from `%SystemRoot%\System32` in every Windows process-tree termination path
- handle asynchronous spawn errors and fall back to direct child termination
- cover all three call sites with real stripped-PATH subprocess regressions:
  - coding-agent `killProcessTree()` (`/F /T /PID`)
  - agent harness timeout/abort cleanup (`/F /T /PID`)
  - PTY pipe fallback (`/pid /T /F`)

## Root cause

`spawn("taskkill")` relied on PATH. When Senpi inherited an environment without System32, Node emitted `ENOENT` asynchronously on the child process. The surrounding synchronous `try/catch` could not intercept the unhandled `error` event, so Senpi exited through `uncaughtException`.

The first report exposed the PTY argument order. A later real session (`019fe986-c3de-7602-b4cb-078fff1ca698`) crashed after a task-output batch while 16 subagents and a background bash session were active; its `spawnargs: ["/F", "/T", "/PID", "25580"]` identified the separate coding-agent process cleanup path. The expanded patch now covers every bare `spawn("taskkill")` occurrence.

Related upstream report: https://github.com/earendil-works/pi/issues/6596

## Verification

- Red: all three regression fixtures exited 1 with `Error: spawn taskkill ENOENT` and their exact argument order
- Green: coding-agent shell regression — 6/6 passed
- Green: agent harness taskkill regression — passed
- Green: PTY package — 43 passed, 7 skipped
- `npm run check` — passed, including Biome, dependency locks, TypeScript, and browser smoke
- LSP diagnostics — clean for every changed TypeScript file
- AST audit — zero remaining bare `spawn("taskkill")` calls under `packages/`
- Installed OMO and standalone Senpi runtimes were manually exercised with System32 removed from PATH across coding-agent, agent harness timeout, and PTY paths; all completed without uncaught exceptions

## Existing Windows test failures

The complete `packages/agent/test/harness/nodejs-env.test.ts` file still has four unrelated pre-existing Windows failures around symlink/file metadata and cwd/env expectations. The new taskkill regression passes independently and the repository-wide static check is green.