### PR TITLE
feat(interactive): cat OmO Native badge + detection for omo-ai installs

### DIFF
--- a/packages/coding-agent/src/core/omo-native-detect.test.ts
+++ b/packages/coding-agent/src/core/omo-native-detect.test.ts
@@ -1,0 +1,59 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectOmoNativeInstall } from "./omo-native-detect.ts";
+
+// The omo-ai global install loads the plugin through the launcher's --extension flag, never through a
+// settings.packages entry, so detection must also honor the launcher-set OMO_NATIVE env marker or the
+// footer badge can never render for shipped installs.
+
+const roots: string[] = [];
+
+function omoRepoFixture(): { pluginPath: string } {
+	const root = mkdtempSync(join(tmpdir(), "omo-detect-"));
+	roots.push(root);
+	const pluginPath = join(root, "packages", "omo-senpi", "plugin");
+	mkdirSync(pluginPath, { recursive: true });
+	writeFileSync(join(pluginPath, "package.json"), JSON.stringify({ name: "@code-yeongyu/omo-senpi" }));
+	writeFileSync(
+		join(root, "packages", "omo-senpi", "package.json"),
+		JSON.stringify({ name: "@oh-my-opencode/omo-senpi" }),
+	);
+	mkdirSync(join(root, "packages", "senpi-task"), { recursive: true });
+	writeFileSync(
+		join(root, "packages", "senpi-task", "package.json"),
+		JSON.stringify({ name: "@oh-my-opencode/senpi-task" }),
+	);
+	return { pluginPath };
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("detectOmoNativeInstall", () => {
+	describe("#given the launcher-set OMO_NATIVE env marker", () => {
+		it("#when packages carry no omo entry #then detection still fires", () => {
+			expect(detectOmoNativeInstall([], "/tmp/agent", { OMO_NATIVE: "1" })).toBe(true);
+		});
+
+		it("#when the marker holds any other value #then detection ignores it", () => {
+			expect(detectOmoNativeInstall([], "/tmp/agent", { OMO_NATIVE: "0" })).toBe(false);
+			expect(detectOmoNativeInstall([], "/tmp/agent", {})).toBe(false);
+		});
+	});
+
+	describe("#given a settings.packages local-path omo plugin entry", () => {
+		it("#when the repo gates all pass #then detection fires without the env marker", () => {
+			const { pluginPath } = omoRepoFixture();
+			expect(detectOmoNativeInstall([pluginPath], "/tmp/agent", {})).toBe(true);
+		});
+	});
+
+	describe("#given neither the marker nor a matching package entry", () => {
+		it("#when detection runs #then it stays false", () => {
+			expect(detectOmoNativeInstall(undefined, "/tmp/agent", {})).toBe(false);
+		});
+	});
+});

--- a/packages/coding-agent/src/core/omo-native-detect.ts
+++ b/packages/coding-agent/src/core/omo-native-detect.ts
@@ -33,7 +33,17 @@ function readPackageName(packageJsonPath: string): string | undefined {
 	}
 }
 
-export function detectOmoNativeInstall(packages: PackageSource[] | undefined, agentDir: string): boolean {
+export function detectOmoNativeInstall(
+	packages: PackageSource[] | undefined,
+	agentDir: string,
+	env: Record<string, string | undefined> = process.env,
+): boolean {
+	// The omo launcher marks every senpi spawn it owns; omo-ai global installs load the plugin via
+	// --extension, so no settings.packages entry ever exists for them and the env marker is the only
+	// signal available at footer-render time.
+	if (env.OMO_NATIVE === "1") {
+		return true;
+	}
 	if (!packages) {
 		return false;
 	}

--- a/packages/coding-agent/src/modes/interactive/components/footer-omo-native-badge.test.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer-omo-native-badge.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { AgentSession } from "../../../core/agent-session.ts";
+import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
+import { initTheme } from "../theme/theme.ts";
+import { FooterComponent } from "./footer.ts";
+
+// The badge is the only visible marker that a session is running the omo native distribution, so it is
+// pinned here at the render() boundary: emoji, wording, and bottom-left anchoring all matter to users.
+const OMO_NATIVE_BADGE = "(😺 OmO Native)";
+
+function footerData(isOmoNative: boolean): ReadonlyFooterDataProvider {
+	return {
+		getGitBranch: () => undefined,
+		getExtensionStatuses: () => [],
+		getAvailableProviderCount: () => 1,
+		onBranchChange: () => () => {},
+		isOmoNative: () => isOmoNative,
+	} as unknown as ReadonlyFooterDataProvider;
+}
+
+function session(): AgentSession {
+	return {
+		state: { model: undefined, thinkingLevel: "off" },
+		sessionManager: {
+			getCwd: () => "/tmp/omo-footer-fixture",
+			getSessionName: () => undefined,
+			getUsageTotals: () => ({ cacheRead: 0, cacheWrite: 0, cost: 0, latestCacheHitRate: undefined }),
+		},
+		getContextUsage: () => undefined,
+		isFastModeActive: () => false,
+		modelRuntime: { isUsingOAuth: () => false },
+	} as unknown as AgentSession;
+}
+
+function renderFooter(isOmoNative: boolean): string {
+	return new FooterComponent(session(), footerData(isOmoNative)).render(200).join("\n");
+}
+
+describe("footer omo native badge", () => {
+	beforeAll(() => initTheme("dark"));
+
+	describe("#given a session running the omo native distribution", () => {
+		it("#when the footer renders #then the cat badge appears", () => {
+			expect(renderFooter(true)).toContain(OMO_NATIVE_BADGE);
+		});
+
+		it("#when the footer renders #then the badge leads the left anchor row", () => {
+			const line = renderFooter(true);
+			const badgeAt = line.indexOf(OMO_NATIVE_BADGE);
+			const cwdAt = line.indexOf("omo-footer-fixture");
+			expect(badgeAt).toBeGreaterThanOrEqual(0);
+			expect(badgeAt).toBeLessThan(cwdAt);
+		});
+	});
+
+	describe("#given a session that is not omo native", () => {
+		it("#when the footer renders #then no badge appears", () => {
+			expect(renderFooter(false)).not.toContain("OmO Native");
+		});
+	});
+});

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -6,6 +6,8 @@ import { theme } from "../theme/theme.ts";
 import { type FooterSegment, planFooterLayout } from "./footer-layout.ts";
 
 const FAST_MODE_INDICATOR = "\u26a1 ";
+/** Bottom-left marker identifying a session running the omo native distribution. */
+const OMO_NATIVE_BADGE = "(😺 OmO Native)";
 
 /**
  * Sanitize text for display in a single-line status.
@@ -145,7 +147,7 @@ export class FooterComponent implements Component {
 		const sessionName = this.session.sessionManager.getSessionName();
 
 		const omoNativeBadge: FooterSegment | undefined = this.footerData.isOmoNative()
-			? { plain: "(🏴‍☠️ OmO Native)", colored: theme.fg("success", "(🏴‍☠️ OmO Native)") }
+			? { plain: OMO_NATIVE_BADGE, colored: theme.fg("success", OMO_NATIVE_BADGE) }
 			: undefined;
 
 		const anchor: [FooterSegment, ...FooterSegment[]] = [{ plain: pwdRaw, colored: theme.fg("accent", pwdRaw) }];


### PR DESCRIPTION
## What
Two changes shipping the OmO Native footer badge end-to-end:

1. **Cat badge** (`(😺 OmO Native)` replacing the pirate flag) - literal hoisted to a named constant; first-ever tests on the badge pin emoji, wording, left-anchor-leading placement, and absence for non-omo-native sessions. Live tmux TUI capture verified the badge bottom-left with genuine detection gating.
2. **Detection for shipped installs** - omo-ai global installs load via the launcher's `--extension` flag, so the settings-packages gate never fires and the badge was invisible for every shipped install. `detectOmoNativeInstall()` now honors the launcher-set `OMO_NATIVE=1` env marker ahead of the existing settings gates (which remain for dev worktrees). New `omo-native-detect.test.ts` covers marker/no-marker/settings-path/no-signal.

## QA
- `footer-omo-native-badge.test.ts` 3/3, `omo-native-detect.test.ts` 4/4, `tsc --noEmit` clean, biome clean.
- Live TUI: fork build in tmux 200x45 rendered `(😺 OmO Native) • <cwd> • ...` bottom-left.

## Residual risk
Low: additive detection path; the env value must be exactly "1".

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new "(😺 OmO Native)" footer badge and fixes detection so the badge shows up for shipped `omo-ai` installs marked by the launcher.

- New Features
  - Replaced the pirate flag with a cat badge "(😺 OmO Native)" in `FooterComponent`; hoisted to a constant and shown bottom-left only for native sessions.
  - Added tests to pin emoji, wording, placement, and absence for non-native sessions.

- Bug Fixes
  - `detectOmoNativeInstall()` now recognizes `omo-ai` global installs via `OMO_NATIVE=1` before settings-based checks; existing settings path remains for dev worktrees. Added tests for marker/no-marker and settings-path cases.

<sup>Written for commit 20620a8fd7799a5f487c25caec44b44f15f3b3ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

