### PR TITLE
test(interactive): retarget footer fixtures at the cat badge

### DIFF
--- a/packages/coding-agent/test/footer-width.test.ts
+++ b/packages/coding-agent/test/footer-width.test.ts
@@ -129,7 +129,7 @@ describe("FooterComponent width handling", () => {
 		for (const line of lines) {
 			expect(visibleWidth(line)).toBeLessThanOrEqual(width);
 		}
-		expect(plain).toContain("(🏴‍☠️ OmO Native)");
+		expect(plain).toContain("(😺 OmO Native)");
 		expect(plain).toContain("coding-agent");
 		expect(plain).not.toContain("/workspace/client");
 		expect(plain).toContain("CH25.0%");

--- a/packages/coding-agent/test/omo-native-footer.test.ts
+++ b/packages/coding-agent/test/omo-native-footer.test.ts
@@ -39,22 +39,22 @@ function createFooterData(omoNative: boolean): ReadonlyFooterDataProvider {
 	};
 }
 
-describe("FooterComponent (🏴‍☠️ OmO Native) indicator", () => {
+describe("FooterComponent (😺 OmO Native) indicator", () => {
 	beforeAll(() => {
 		initTheme(undefined, false);
 	});
 
-	it("prepends (🏴‍☠️ OmO Native) as the leftmost segment when isOmoNative is true", () => {
+	it("prepends (😺 OmO Native) as the leftmost segment when isOmoNative is true", () => {
 		const footer = new FooterComponent(createSession(), createFooterData(true));
 		const lines = footer.render(120);
 		const firstLine = lines[0] ?? "";
-		expect(stripAnsi(firstLine).startsWith("(🏴‍☠️ OmO Native)")).toBe(true);
+		expect(stripAnsi(firstLine).startsWith("(😺 OmO Native)")).toBe(true);
 	});
 
-	it("omits (🏴‍☠️ OmO Native) when isOmoNative is false", () => {
+	it("omits (😺 OmO Native) when isOmoNative is false", () => {
 		const footer = new FooterComponent(createSession(), createFooterData(false));
 		const lines = footer.render(120);
 		const firstLine = lines[0] ?? "";
-		expect(stripAnsi(firstLine).includes("(🏴‍☠️ OmO Native)")).toBe(false);
+		expect(stripAnsi(firstLine).includes("(😺 OmO Native)")).toBe(false);
 	});
 });


### PR DESCRIPTION
The two pre-existing footer suites pinned the pirate emoji and failed the release test gate after PR #778 changed the badge. Both now assert the cat badge; zero pirate references remain in src or test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update footer tests to expect the cat badge (😺 OmO Native) instead of the pirate, aligning with the badge change from PR #778 and fixing release gate failures. No source changes; both footer suites now assert the cat badge and remove all pirate references.

<sup>Written for commit 53c12b0b0d2ee1c148261b51e7b0415b9fa75bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

