### PR TITLE
refactor(coding-agent): drop the leftover omo marker comment

### DIFF
--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -6,7 +6,6 @@ import { theme } from "../theme/theme.ts";
 import { type FooterSegment, planFooterLayout } from "./footer-layout.ts";
 
 const FAST_MODE_INDICATOR = "\u26a1 ";
-/** Bottom-left marker identifying a session running the omo native distribution. */
 
 /**
  * Sanitize text for display in a single-line status.


### PR DESCRIPTION
Removes the dangling `/** Bottom-left marker identifying a session running the omo native distribution. */`
comment left behind by #780. With it gone, `packages/coding-agent/src` and `test` contain no
OmO references outside historical `changes.md` notes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the leftover `omo` distribution marker comment from the coding agent footer. This cleans up downstream branding and keeps `packages/coding-agent/src` free of `omo` references.

<sup>Written for commit 9c77623a034c1c97ea35a41fc24f7230b8805f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

