### PR TITLE
fix(release): keep automatic CalVer monotonic

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Prevented Claude Agent SDK OAuth sessions from scheduling `assistant_rewritten` forks when only host-side thinking
   timing annotations changed, preserving resident-session and prompt-cache continuity for reasoning-heavy turns
-  ([#751](https://github.com/code-yeongyu/senpi/pull/751)).
+  ([#751](https://github.com/code-yeongyu/senpi/pull/751) by [@goldtg](https://github.com/goldtg)).
 
 ### Removed
 

--- a/scripts/calver.mjs
+++ b/scripts/calver.mjs
@@ -12,6 +12,9 @@
  * - Subsequent same-day releases increment the suffix: `-2`, `-3`, ...
  *   The suffix is `max(existing N values) + 1`, where same-day `YYYY.M.D`
  *   (no suffix) is treated as N = 1 for the purposes of "next" computation.
+ * - Automatic computation is globally monotonic. If an explicit prior release
+ *   used a later date than today, the next version increments that latest
+ *   release's suffix instead of returning a lower calendar version.
  *
  * Tolerance:
  * - Registry/git failures (404, network, timeout, ENOTFOUND, etc.) are
@@ -41,6 +44,7 @@ const DEFAULT_PACKAGES = [
 ];
 
 const REGISTRY_TIMEOUT_MS = 30000;
+const CALVER_RE = /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:-(\d+))?$/;
 
 /**
  * Compute today's CalVer date stamp in `YYYY.M.D`.
@@ -85,15 +89,14 @@ function fetchRegistryVersions(pkg) {
 }
 
 /**
- * Fetch git tags matching `v<today>*` and strip the leading `"v"`.
+ * Fetch CalVer-shaped git tags and strip the leading `"v"`.
  * Returns an empty array on any failure (not a git repo, git missing, etc.).
  *
- * @param {string} today `YYYY.M.D` prefix.
  * @returns {string[]}
  */
-function fetchGitTagVersions(today) {
+function fetchGitTagVersions() {
 	try {
-		const stdout = execFileSync("git", ["tag", "--list", `v${today}*`], {
+		const stdout = execFileSync("git", ["tag", "--list", "v[0-9]*"], {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "pipe"],
 			timeout: REGISTRY_TIMEOUT_MS,
@@ -105,9 +108,32 @@ function fetchGitTagVersions(today) {
 			.map((line) => line.slice(1));
 	} catch (err) {
 		const message = err && typeof err === "object" && "message" in err ? err.message : String(err);
-		process.stderr.write(`[calver] warn: failed to list git tags for v${today}*: ${message}\n`);
+		process.stderr.write(`[calver] warn: failed to list CalVer git tags: ${message}\n`);
 		return [];
 	}
+}
+
+function parseCalver(version) {
+	const match = CALVER_RE.exec(version);
+	if (!match) {
+		return undefined;
+	}
+	return {
+		version,
+		year: Number(match[1]),
+		month: Number(match[2]),
+		day: Number(match[3]),
+		suffix: Number(match[4] ?? 1),
+	};
+}
+
+function compareCalver(left, right) {
+	return (
+		left.year - right.year ||
+		left.month - right.month ||
+		left.day - right.day ||
+		left.suffix - right.suffix
+	);
 }
 
 /**
@@ -128,16 +154,12 @@ export function computeNextVersion(opts = {}) {
 			all.add(v);
 		}
 	}
-	for (const v of fetchGitTagVersions(today)) {
+	for (const v of fetchGitTagVersions()) {
 		all.add(v);
 	}
 
 	const prefix = `${today}-`;
 	const sameDay = [...all].filter((v) => v === today || v.startsWith(prefix));
-	if (sameDay.length === 0) {
-		return today;
-	}
-
 	const suffixes = [];
 	for (const v of sameDay) {
 		if (v === today) {
@@ -151,11 +173,19 @@ export function computeNextVersion(opts = {}) {
 		}
 	}
 
-	if (suffixes.length === 0) {
-		return today;
+	const candidate = suffixes.length === 0 ? today : `${today}-${Math.max(...suffixes) + 1}`;
+	const parsedCandidate = parseCalver(candidate);
+	const latest = [...all]
+		.map(parseCalver)
+		.filter((version) => version !== undefined)
+		.sort(compareCalver)
+		.at(-1);
+
+	if (!latest || compareCalver(parsedCandidate, latest) > 0) {
+		return candidate;
 	}
 
-	return `${today}-${Math.max(...suffixes) + 1}`;
+	return `${latest.year}.${latest.month}.${latest.day}-${latest.suffix + 1}`;
 }
 
 /**
@@ -174,7 +204,7 @@ function gatherReport(opts = {}) {
 			all.add(v);
 		}
 	}
-	for (const v of fetchGitTagVersions(today)) {
+	for (const v of fetchGitTagVersions()) {
 		all.add(v);
 	}
 

--- a/scripts/calver.test.mjs
+++ b/scripts/calver.test.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { computeNextVersion } from "./calver.mjs";
+
+let tempDir;
+let previousPath;
+
+afterEach(() => {
+	if (previousPath !== undefined) {
+		process.env.PATH = previousPath;
+		previousPath = undefined;
+	}
+	if (tempDir) {
+		rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+describe("computeNextVersion", () => {
+	it("stays above a future-dated published version", () => {
+		installFakeVersionSources(["2026.8.11"]);
+
+		const version = computeNextVersion({
+			date: "2026.8.10",
+			packages: ["@example/senpi"],
+		});
+
+		assert.equal(version, "2026.8.11-2");
+	});
+
+	it("increments the highest suffix for the current date", () => {
+		installFakeVersionSources(["2026.8.10", "2026.8.10-3"]);
+
+		const version = computeNextVersion({
+			date: "2026.8.10",
+			packages: ["@example/senpi"],
+		});
+
+		assert.equal(version, "2026.8.10-4");
+	});
+
+	it("uses a later current date without carrying an old suffix forward", () => {
+		installFakeVersionSources(["2026.8.11-3"]);
+
+		const version = computeNextVersion({
+			date: "2026.8.12",
+			packages: ["@example/senpi"],
+		});
+
+		assert.equal(version, "2026.8.12");
+	});
+});
+
+function installFakeVersionSources(versions) {
+	tempDir = mkdtempSync(join(tmpdir(), "senpi-calver-"));
+	writeFakeCommand("npm", `process.stdout.write(${JSON.stringify(JSON.stringify(versions))});`);
+	writeFakeCommand("git", "");
+	previousPath = process.env.PATH;
+	process.env.PATH = `${tempDir}${delimiter}${dirname(process.execPath)}`;
+}
+
+function writeFakeCommand(name, body) {
+	const runner = join(tempDir, `${name}.mjs`);
+	writeFileSync(runner, `${body}\n`);
+	if (process.platform === "win32") {
+		writeFileSync(join(tempDir, `${name}.cmd`), `@"${process.execPath}" "${runner}" %*\r\n`);
+		return;
+	}
+	const executable = join(tempDir, name);
+	writeFileSync(executable, `#!${process.execPath}\n${body}\n`);
+	chmodSync(executable, 0o755);
+}


### PR DESCRIPTION
## Summary

- make automatic CalVer computation globally monotonic across published versions and all local CalVer tags
- add deterministic cross-platform coverage for future-dated releases, same-day suffixes, and later calendar dates
- add the required external contributor attribution for PR #751

## Why

`v2026.8.11` was explicitly released on 2026-08-10 UTC. The existing
same-day-only calculator therefore proposed `v2026.8.10-2`, which is lower than
the published latest version. This change preserves normal calendar behavior
but increments the global latest version when the current-day candidate would
regress.

The smallest valid next release after merge is `v2026.8.11-2`.

## Validation

- `node --test scripts/calver.test.mjs` — 3 passed
- `node --test scripts/release.test.mjs scripts/calver.test.mjs` — 9 passed
- `npm run check` — passed
- `npm run build` — passed
- `npx biome check --error-on-warnings scripts/calver.mjs scripts/calver.test.mjs` — passed
- `node scripts/check-pr-changelog.mjs --base origin/main` — passed
- `git diff --check` — passed
- `node scripts/calver.mjs --json` — returned `2026.8.11-2`
- `node scripts/release.mjs --help` — passed
- feature-branch `node scripts/release.mjs --dry-run` — correctly refused non-`main`

The post-build full workspace test run reached 6,976 passing coding-agent tests
with one unrelated existing reftable watcher timeout in
`test/footer-data-provider.test.ts`. Its immediate isolated rerun passed 9/9.
Required clean-checkout PR CI remains a merge gate.

## Release evidence

Local RED/GREEN and manual QA receipts are saved under:

`local-ignore/qa-evidence/20260810-release/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures automatic CalVer never goes backward by making next-version computation globally monotonic across published versions and local tags. Also adds deterministic coverage and updates the changelog attribution.

- **Bug Fixes**
  - If today’s candidate is lower than the latest published/tagged CalVer, increment that latest version’s suffix instead (e.g., after `2026.8.11` exists, return `2026.8.11-2`).
  - Scan all CalVer-shaped git tags (`vYYYY.M.D[-N]`) and use a parser/comparator for consistent results; includes deterministic tests for future-dated releases and same-day suffixes.
  - Update changelog to credit the external contributor for PR #751.

<sup>Written for commit f33f6467eb8f1b7649bf5999fd087633b121738d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

