### PR TITLE
docs(changelog): complete v2026.8.11-2 audit

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Added
 
+- Added `getWireIdentity()` and `setWireIdentity()` for configuring the product token used on outgoing requests, so
+  distributions repackaging the engine can supply their own wire identity
+  ([#783](https://github.com/code-yeongyu/senpi/pull/783)).
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,17 +2,21 @@
 
 ## [Unreleased]
 
-### Added
-
-- Distributions repackaging senpi can set their own product identity through a `SENPI_BRAND` profile: name, display version, config directory (optionally flat), environment prefix, wire identity and update channel. The profile is consumed and scrubbed at startup, so nested senpi processes keep the engine identity. A standalone install is unchanged.
-- Product settings are read across the brand prefix and the legacy `SENPI_`/`PI_` prefixes, so existing environments keep working after a rebrand.
-- A branded install checks its own release channel for updates, and the update notice, changelog link and self-update paths point at the distribution's own command instead of `senpi update`.
-
 ### New Features
 
 ### Breaking Changes
 
 ### Added
+
+- Distributions repackaging senpi can set their own product identity through a `SENPI_BRAND` profile: name, display
+  version, config directory (optionally flat), environment prefix, wire identity and update channel. The profile is
+  consumed and scrubbed at startup, so nested senpi processes keep the engine identity. A standalone install is
+  unchanged ([#783](https://github.com/code-yeongyu/senpi/pull/783)).
+- Product settings are read across the brand prefix and the legacy `SENPI_`/`PI_` prefixes, so existing environments
+  keep working after a rebrand ([#783](https://github.com/code-yeongyu/senpi/pull/783)).
+- A branded install checks its own release channel for updates, and the update notice, changelog link and self-update
+  paths point at the distribution's own command instead of `senpi update`
+  ([#783](https://github.com/code-yeongyu/senpi/pull/783)).
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- document the new `@earendil-works/pi-ai` wire-identity exports from PR #783
- consolidate the coding-agent `[Unreleased]` section to one `### Added` heading
- add the missing internal PR #783 references to all three brand entries

## Why

The final manual `/cl` audit of every commit since `v2026.8.11` found that
commit `fd567ffb` added public `getWireIdentity()` / `setWireIdentity()` exports
to the AI package, but only the coding-agent changelog described the behavior.
The automated gate passed because it accepts any changed package changelog; the
release guide requires an entry in every affected package.

## Validation

- all 13 non-merge commits in `v2026.8.11..e5dd27fe8` accounted for
- `node scripts/check-pr-changelog.mjs --base v2026.8.11` — passed
- `node scripts/check-pr-changelog.mjs --base origin/main` — passed
- `git diff --check` — passed
- AI `[Unreleased]`: one Added heading, one #783 reference, both wire exports named
- coding-agent `[Unreleased]`: one Added heading, three #783 references
- released changelog sections unchanged
- independent re-audit — unconditional PASS

This is a pure changelog correction; no runtime code changed and no prose-pinning
test was added.

## Release

After merge, the audited release target remains `v2026.8.11-2`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the v2026.8.11-2 changelog audit and aligns docs across packages. Documents `getWireIdentity()` and `setWireIdentity()` in `@earendil-works/pi-ai`, consolidates `coding-agent` [Unreleased] under one Added section, and adds missing PR #783 references; no runtime changes.

<sup>Written for commit 906a71ab3b356ad906d3594d94900908070723ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

