### PR TITLE
fix(coding-agent): reject unsafe brand config dirs and engine update fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A brand profile carrying an unsafe `configDir` (a path separator, `.` or `..`) is rejected instead of redirecting agent state and its migration outside the intended directory.
+- A branded install without an update channel no longer falls back to checking the engine's own releases, which it cannot install.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/brand.ts
+++ b/packages/coding-agent/src/core/brand.ts
@@ -64,6 +64,15 @@ function readUpdateChannel(source: Record<string, unknown>): BrandUpdateChannel 
 	};
 }
 
+/**
+ * A config directory names ONE entry inside the home directory. Anything carrying a separator or
+ * a parent reference would move agent state - and the migration that copies into it - somewhere
+ * the user never agreed to, so such a profile is rejected rather than sanitised.
+ */
+function isSafeConfigDirName(value: string): boolean {
+	return value !== "." && value !== ".." && !/[\\/]/.test(value);
+}
+
 function readString(source: Record<string, unknown>, key: string): string | undefined {
 	const value = source[key];
 	return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -97,10 +106,16 @@ export function parseBrandProfile(raw: string | undefined): BrandProfile | undef
 		return undefined;
 	}
 
+	const configDir = readString(source, "configDir") || `.${name}`;
+	if (!isSafeConfigDirName(configDir)) {
+		process.stderr.write(`warning: ignoring ${BRAND_ENV_VAR} with an unsafe "configDir"\n`);
+		return undefined;
+	}
+
 	return {
 		name,
 		displayVersion: readString(source, "displayVersion"),
-		configDir: readString(source, "configDir") || `.${name}`,
+		configDir,
 		flatLayout: source.flatLayout === true,
 		envPrefix: (readString(source, "envPrefix") || name).toUpperCase(),
 		userAgent: readString(source, "userAgent") || name,

--- a/packages/coding-agent/src/utils/version-check.ts
+++ b/packages/coding-agent/src/utils/version-check.ts
@@ -85,7 +85,13 @@ export async function getLatestPiRelease(
 ): Promise<LatestPiRelease | undefined> {
 	if (envValue("OFFLINE")) return undefined;
 
-	const channel = brandProfile()?.update;
+	const brand = brandProfile();
+	const channel = brand?.update;
+	if (brand && !channel) {
+		// The engine's own releases are not installable from inside a branded distribution, so
+		// advertising them would send the user after an update they cannot apply.
+		return undefined;
+	}
 	const response = await fetch(latestVersionUrl(channel), {
 		headers: {
 			"User-Agent": getPiUserAgent(currentVersion),

--- a/packages/coding-agent/test/brand-hardening.test.ts
+++ b/packages/coding-agent/test/brand-hardening.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { BRAND_ENV_VAR, parseBrandProfile, resetBrandProfileForTests } from "../src/core/brand.ts";
+import { getLatestPiRelease } from "../src/utils/version-check.ts";
+
+describe("brand profile safety", () => {
+	let stderr: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		stderr.mockRestore();
+		delete process.env[BRAND_ENV_VAR];
+		resetBrandProfileForTests();
+	});
+
+	test.each([
+		["parent reference", ".."],
+		["current directory", "."],
+		["posix path", "../../etc"],
+		["nested path", "omo/agent"],
+		["windows path", "..\\omo"],
+		["absolute path", "/tmp/omo"],
+	])("rejects a profile whose configDir is a %s", (_label, configDir) => {
+		expect(parseBrandProfile(JSON.stringify({ name: "omo", configDir }))).toBeUndefined();
+	});
+
+	test("accepts a plain directory name inside the home directory", () => {
+		expect(parseBrandProfile('{"name":"omo","configDir":".omo"}')?.configDir).toBe(".omo");
+	});
+});
+
+describe("branded update checks", () => {
+	afterEach(() => {
+		delete process.env[BRAND_ENV_VAR];
+		resetBrandProfileForTests();
+	});
+
+	test("a brand without an update channel never advertises an engine release", async () => {
+		process.env[BRAND_ENV_VAR] = '{"name":"omo","configDir":".omo"}';
+		resetBrandProfileForTests();
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+		await expect(getLatestPiRelease("1.0.0")).resolves.toBeUndefined();
+		expect(fetchSpy).not.toHaveBeenCalled();
+
+		fetchSpy.mockRestore();
+	});
+});


### PR DESCRIPTION
## What

Two hardening fixes on the brand contract added in #783, both found by an adversarial review of that diff.

### An unsafe `configDir` is rejected instead of honoured

`configDir` names one entry inside the home directory. A profile carrying a separator, `.` or `..` would relocate agent state - and the copy-forward migration that writes into it - somewhere the user never agreed to. Such a profile is now rejected as a whole, falling back to standalone behavior, rather than being sanitised into something the caller did not ask for.

### A branded install no longer advertises engine releases it cannot install

When a brand is active but declares no update channel, the check previously fell back to the engine's own `latest` endpoint. A distribution pins the engine, so that update is not installable from inside it, and the notice would send the user after something that cannot be applied. The check is now skipped entirely in that case; a brand that *does* declare a channel is unaffected.

## Verification

```
npx vitest --run test/brand-hardening.test.ts test/brand.test.ts test/brand-update-channel.test.ts test/brand-dirs.test.ts
  -> 4 files, 35 tests passed
```

New `test/brand-hardening.test.ts` covers six rejected `configDir` shapes (`..`, `.`, `../../etc`, `omo/agent`, `..\omo`, `/tmp/omo`), the accepted plain-name case, and asserts that a channel-less brand performs no registry request at all (`fetch` is never called).

`npm run check` passes via the pre-commit gate. Standalone behavior is unchanged: with no profile present neither path is reachable.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened brand handling in `coding-agent` to reject unsafe `configDir` values and to skip engine update checks when a brand has no update channel. Prevents writing agent state outside the home directory and avoids update notices that can’t be installed.

- **Bug Fixes**
  - Reject `configDir` with separators, `.` or `..`; brand profile is ignored and standalone mode is used.
  - Skip engine “latest” check when a brand is active without an `update` channel; no `fetch` call is made.

<sup>Written for commit 649d92fb465e78b36d176e80a8ed408a6bf06041. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

