### PR TITLE
fix(release): clean builds and serialize goal mutations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Fixed
 
+- Prevented an asynchronous goal continuation from restoring a goal after `thread/goal/clear` or recording delivery
+  against a replacement goal.
 - Prevented Claude Agent SDK OAuth sessions from scheduling `assistant_rewritten` forks when only host-side thinking
   timing annotations changed, preserving resident-session and prompt-cache continuity for reasoning-heavy turns
   ([#751](https://github.com/code-yeongyu/senpi/pull/751) by [@goldtg](https://github.com/goldtg)).

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,27 @@
 # goal Extension Changes
 
+## Serialized goal mutations and stale-continuation cancellation (2026-08-10)
+
+### What changed
+
+- Goal read/modify/write operations now serialize per persisted goal file while unrelated threads remain parallel.
+- Continuation delivery records only when the admitted goal id is still current; a clear or replacement cancels stale delivery before any hidden prompt is queued.
+- App-server clear no longer races asynchronous `goal_store_changed` continuation accounting and cannot resurrect a cleared goal.
+
+### Why
+
+`goal_store_changed` listeners are asynchronous and fire outside the app-server thread task queue. A continuation could read an active goal, then overwrite a later clear with its stale snapshot. Store-level serialization is required because commands, tools, lifecycle callbacks, monitors, and RPC handlers all mutate the same persisted goal outside one shared handler queue.
+
+### Why this is not extension-only
+
+The race is inside the builtin goal persistence contract and app-server event path. An external extension cannot make core store mutations linearizable or prevent the builtin continuation listener from committing a stale read.
+
+### Merge-conflict zones
+
+- `store.ts`: per-goal mutation queue and serialized mutation functions.
+- `lifecycle-helpers.ts`: expected goal-id fence and stale cancellation.
+- `index.ts`, `monitor-continuation.ts`: nullable stale-admission handling.
+
 ## Unified wake-source continuation gating (2026-08-09)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -317,6 +317,11 @@ export default function goalExtension(pi: ExtensionAPI): void {
 				continuationPending = true;
 			},
 		});
+		if (continuedGoal === null) {
+			clearAgentGoalAccounting();
+			refreshGoalUiBestEffort(ctx, null);
+			return;
+		}
 		if (continuedGoal.status === goal.status) return;
 		if (continuedGoal.status === "active") beginAgentGoalAccounting(continuedGoal);
 		else clearAgentGoalAccounting();

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -68,19 +68,20 @@ export async function admitAndQueueGoalContinuation(
 	ctx: ExtensionContext,
 	goal: Goal,
 	options: GoalContinuationDeliveryOptions,
-): Promise<Goal> {
+): Promise<Goal | null> {
 	const verdict = evaluateGoalContinuation({ goal, ...options.input });
 	if (verdict.kind === "deny") return handleDeniedContinuation(pi, ctx, goal, options.input, verdict.reason);
 
 	if (options.input.currentSignature === undefined) {
 		throw new Error("Cannot queue a goal continuation without a progress signature");
 	}
-	options.markContinuationPending();
 	const recordedGoal = await recordContinuationDelivered(
 		goalStoreRef(ctx.sessionManager, ctx.cwd),
 		options.input.currentSignature,
+		goal.id,
 	);
-	if (recordedGoal === null) throw new Error("Cannot persist goal continuation delivery without an active goal");
+	if (recordedGoal === null) return null;
+	options.markContinuationPending();
 	queueHiddenGoalPrompt(pi, options.content(verdict));
 	return recordedGoal;
 }
@@ -91,7 +92,7 @@ export async function queueGoalContinuation(
 	ctx: ExtensionContext,
 	goal: Goal,
 	options: SessionStartContinuationOptions,
-): Promise<Goal> {
+): Promise<Goal | null> {
 	const signature = buildCurrentGoalContinuationSignature(
 		ctx,
 		goal,

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -399,6 +399,12 @@ export class MonitorAwareGoalContinuation {
 			content: (continuationVerdict) => this.#buildContinuationContent(ctx, goal, continuationVerdict),
 			markContinuationPending: this.#markContinuationPending,
 		});
+		if (admittedGoal === null) {
+			this.#goal = null;
+			this.#cancelTimer();
+			this.#resetToollessContinuationStreak();
+			return { goal, admitted: false };
+		}
 		if (verdict.kind === "continue" && input.lastStopReason === "length") {
 			this.#consecutiveLengthRecoveries.set(goal.id, input.consecutiveLengthRecoveries + 1);
 		}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { GoalAlreadyExistsError, GoalNotFoundError } from "./errors.ts";
-import { encodedThreadId, readGoalFile, writeGoalFile } from "./persistence.ts";
+import { encodedThreadId, goalFilePath, readGoalFile, writeGoalFile } from "./persistence.ts";
 import { transitionGoalStatus } from "./transitions.ts";
 import type {
 	Goal,
@@ -14,7 +14,24 @@ import type {
 } from "./types.ts";
 import { resolveTokenBudget, validateObjective, validateTokenBudget } from "./validation.ts";
 
-export { goalFilePath } from "./persistence.ts";
+export { goalFilePath };
+
+const goalMutationTails = new Map<string, Promise<void>>();
+
+function enqueueGoalMutation<T>(ref: GoalStoreRef, mutation: () => Promise<T>): Promise<T> {
+	const key = goalFilePath(ref);
+	const previous = goalMutationTails.get(key) ?? Promise.resolve();
+	const run = previous.then(mutation);
+	const tail = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	goalMutationTails.set(key, tail);
+	void tail.then(() => {
+		if (goalMutationTails.get(key) === tail) goalMutationTails.delete(key);
+	});
+	return run;
+}
 
 export function goalHistoryFilePath(ref: GoalStoreRef): string {
 	return join(ref.baseDir, `${encodedThreadId(ref)}.history.jsonl`);
@@ -33,33 +50,35 @@ export async function readGoal(ref: GoalStoreRef): Promise<Goal | null> {
 }
 
 export async function writeGoal(ref: GoalStoreRef, goal: Goal | null): Promise<void> {
-	await writeGoalFile(ref, goal);
+	await enqueueGoalMutation(ref, () => writeGoalFile(ref, goal));
 }
 
 export async function createGoal(ref: GoalStoreRef, objective: string, tokenBudget?: number): Promise<Goal> {
-	const validatedObjective = validateObjective(objective, objectiveFullTextFileName(ref));
-	const current = await readGoal(ref);
-	if (current !== null && current.status !== "complete") {
-		throw new GoalAlreadyExistsError("cannot create a new goal because this thread already has a goal");
-	}
-	if (validatedObjective.truncated) await writeFullObjectiveText(ref, objective);
-	if (current?.status === "complete") await archiveGoal(ref, current);
-	const now = nowSeconds();
-	const goal: Goal = {
-		id: randomUUID(),
-		threadId: ref.threadId,
-		objective: validatedObjective.objective,
-		status: "active",
-		tokensUsed: 0,
-		timeUsedSeconds: 0,
-		consecutiveContinuations: 0,
-		createdAt: now,
-		updatedAt: now,
-		lastStartedAt: now,
-		...(tokenBudget === undefined ? {} : { tokenBudget: validateTokenBudget(tokenBudget) }),
-	};
-	await writeGoal(ref, goal);
-	return goal;
+	return enqueueGoalMutation(ref, async () => {
+		const validatedObjective = validateObjective(objective, objectiveFullTextFileName(ref));
+		const current = await readGoalFile(ref);
+		if (current !== null && current.status !== "complete") {
+			throw new GoalAlreadyExistsError("cannot create a new goal because this thread already has a goal");
+		}
+		if (validatedObjective.truncated) await writeFullObjectiveText(ref, objective);
+		if (current?.status === "complete") await archiveGoal(ref, current);
+		const now = nowSeconds();
+		const goal: Goal = {
+			id: randomUUID(),
+			threadId: ref.threadId,
+			objective: validatedObjective.objective,
+			status: "active",
+			tokensUsed: 0,
+			timeUsedSeconds: 0,
+			consecutiveContinuations: 0,
+			createdAt: now,
+			updatedAt: now,
+			lastStartedAt: now,
+			...(tokenBudget === undefined ? {} : { tokenBudget: validateTokenBudget(tokenBudget) }),
+		};
+		await writeGoalFile(ref, goal);
+		return goal;
+	});
 }
 
 export async function updateGoal(
@@ -67,56 +86,60 @@ export async function updateGoal(
 	update: GoalUpdate,
 	source: GoalUpdateSource = "model",
 ): Promise<Goal> {
-	const current = await readGoal(ref);
-	if (!current) throw new GoalNotFoundError("cannot update goal: no goal exists");
+	return enqueueGoalMutation(ref, async () => {
+		const current = await readGoalFile(ref);
+		if (!current) throw new GoalNotFoundError("cannot update goal: no goal exists");
 
-	const validatedObjective =
-		update.objective === undefined ? undefined : validateObjective(update.objective, objectiveFullTextFileName(ref));
-	const objective = validatedObjective?.objective ?? current.objective;
-	const tokenBudget = resolveTokenBudget(current.tokenBudget, update.tokenBudget);
-	const now = nextUpdatedAt(current.updatedAt);
-	const hasObjectiveUpdate = update.objective !== undefined;
-	const replacesGoal = hasObjectiveUpdate && (objective !== current.objective || current.status === "complete");
-	const requestedStatus = update.status ?? (hasObjectiveUpdate ? "active" : undefined);
+		const validatedObjective =
+			update.objective === undefined
+				? undefined
+				: validateObjective(update.objective, objectiveFullTextFileName(ref));
+		const objective = validatedObjective?.objective ?? current.objective;
+		const tokenBudget = resolveTokenBudget(current.tokenBudget, update.tokenBudget);
+		const now = nextUpdatedAt(current.updatedAt);
+		const hasObjectiveUpdate = update.objective !== undefined;
+		const replacesGoal = hasObjectiveUpdate && (objective !== current.objective || current.status === "complete");
+		const requestedStatus = update.status ?? (hasObjectiveUpdate ? "active" : undefined);
 
-	if (replacesGoal) {
-		const status = requestedStatus ?? "active";
-		if (status === "blocked") throw new Error("objective replacement cannot create a blocked goal");
-		const next: Goal = {
-			id: randomUUID(),
-			threadId: ref.threadId,
-			objective,
-			status,
-			tokensUsed: 0,
-			timeUsedSeconds: 0,
-			consecutiveContinuations: 0,
-			createdAt: now,
-			updatedAt: now,
-			...(tokenBudget === undefined ? {} : { tokenBudget }),
-		};
-		if (status === "active") next.lastStartedAt = now;
-		if (status === "complete") next.completedAt = now;
+		if (replacesGoal) {
+			const status = requestedStatus ?? "active";
+			if (status === "blocked") throw new Error("objective replacement cannot create a blocked goal");
+			const next: Goal = {
+				id: randomUUID(),
+				threadId: ref.threadId,
+				objective,
+				status,
+				tokensUsed: 0,
+				timeUsedSeconds: 0,
+				consecutiveContinuations: 0,
+				createdAt: now,
+				updatedAt: now,
+				...(tokenBudget === undefined ? {} : { tokenBudget }),
+			};
+			if (status === "active") next.lastStartedAt = now;
+			if (status === "complete") next.completedAt = now;
+			if (validatedObjective?.truncated) await writeFullObjectiveText(ref, update.objective ?? "");
+			await writeGoalFile(ref, next);
+			return next;
+		}
+
+		const next = transitionGoalStatus(
+			{ ...current, objective },
+			requestedStatus ?? current.status,
+			source,
+			update.reason,
+			now,
+		);
+		if (next.status !== current.status) {
+			next.consecutiveContinuations = 0;
+			delete next.lastContinuationSignature;
+		}
+		if (tokenBudget === undefined) delete next.tokenBudget;
+		else next.tokenBudget = tokenBudget;
 		if (validatedObjective?.truncated) await writeFullObjectiveText(ref, update.objective ?? "");
-		await writeGoal(ref, next);
+		await writeGoalFile(ref, next);
 		return next;
-	}
-
-	const next = transitionGoalStatus(
-		{ ...current, objective },
-		requestedStatus ?? current.status,
-		source,
-		update.reason,
-		now,
-	);
-	if (next.status !== current.status) {
-		next.consecutiveContinuations = 0;
-		delete next.lastContinuationSignature;
-	}
-	if (tokenBudget === undefined) delete next.tokenBudget;
-	else next.tokenBudget = tokenBudget;
-	if (validatedObjective?.truncated) await writeFullObjectiveText(ref, update.objective ?? "");
-	await writeGoal(ref, next);
-	return next;
+	});
 }
 
 export async function archiveGoal(ref: GoalStoreRef, goal: Goal): Promise<void> {
@@ -132,9 +155,11 @@ async function writeFullObjectiveText(ref: GoalStoreRef, objective: string): Pro
 }
 
 export async function clearGoal(ref: GoalStoreRef): Promise<boolean> {
-	const hadGoal = (await readGoal(ref)) !== null;
-	await writeGoal(ref, null);
-	return hadGoal;
+	return enqueueGoalMutation(ref, async () => {
+		const hadGoal = (await readGoalFile(ref)) !== null;
+		await writeGoalFile(ref, null);
+		return hadGoal;
+	});
 }
 
 export async function accountGoalUsage(
@@ -144,39 +169,49 @@ export async function accountGoalUsage(
 	mode: GoalAccountingMode = "active",
 	expectedGoalId?: string,
 ): Promise<Goal | null> {
-	const goal = await readGoal(ref);
-	if (!goal || (expectedGoalId !== undefined && goal.id !== expectedGoalId) || !canAccountGoalUsage(goal, mode)) {
-		return goal;
-	}
-	const next: Goal = {
-		...goal,
-		tokensUsed: goal.tokensUsed + Math.max(0, usage.input) + Math.max(0, usage.output),
-		timeUsedSeconds: goal.timeUsedSeconds + Math.max(0, Math.trunc(elapsedSeconds)),
-		updatedAt: nextUpdatedAt(goal.updatedAt),
-	};
-	await writeGoal(ref, next);
-	return next;
+	return enqueueGoalMutation(ref, async () => {
+		const goal = await readGoalFile(ref);
+		if (!goal || (expectedGoalId !== undefined && goal.id !== expectedGoalId) || !canAccountGoalUsage(goal, mode)) {
+			return goal;
+		}
+		const next: Goal = {
+			...goal,
+			tokensUsed: goal.tokensUsed + Math.max(0, usage.input) + Math.max(0, usage.output),
+			timeUsedSeconds: goal.timeUsedSeconds + Math.max(0, Math.trunc(elapsedSeconds)),
+			updatedAt: nextUpdatedAt(goal.updatedAt),
+		};
+		await writeGoalFile(ref, next);
+		return next;
+	});
 }
 
-export async function recordContinuationDelivered(ref: GoalStoreRef, signature: string): Promise<Goal | null> {
-	const goal = await readGoal(ref);
-	if (!goal) return goal;
-	const next: Goal = {
-		...goal,
-		consecutiveContinuations: (goal.consecutiveContinuations ?? 0) + 1,
-		lastContinuationSignature: signature,
-	};
-	await writeGoal(ref, next);
-	return next;
+export async function recordContinuationDelivered(
+	ref: GoalStoreRef,
+	signature: string,
+	expectedGoalId?: string,
+): Promise<Goal | null> {
+	return enqueueGoalMutation(ref, async () => {
+		const goal = await readGoalFile(ref);
+		if (!goal || (expectedGoalId !== undefined && goal.id !== expectedGoalId)) return null;
+		const next: Goal = {
+			...goal,
+			consecutiveContinuations: (goal.consecutiveContinuations ?? 0) + 1,
+			lastContinuationSignature: signature,
+		};
+		await writeGoalFile(ref, next);
+		return next;
+	});
 }
 
 export async function resetContinuationStreak(ref: GoalStoreRef): Promise<Goal | null> {
-	const goal = await readGoal(ref);
-	if (!goal) return goal;
-	const next: Goal = { ...goal, consecutiveContinuations: 0 };
-	delete next.lastContinuationSignature;
-	await writeGoal(ref, next);
-	return next;
+	return enqueueGoalMutation(ref, async () => {
+		const goal = await readGoalFile(ref);
+		if (!goal) return goal;
+		const next: Goal = { ...goal, consecutiveContinuations: 0 };
+		delete next.lastContinuationSignature;
+		await writeGoalFile(ref, next);
+		return next;
+	});
 }
 
 function canAccountGoalUsage(goal: Goal, mode: GoalAccountingMode): boolean {

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -911,4 +911,15 @@ describe("goal continuation streak persistence", () => {
 		expect(await recordContinuationDelivered(ref, "sig")).toBeNull();
 		expect(await resetContinuationStreak(ref)).toBeNull();
 	});
+
+	it("does not record a continuation admitted for a replaced goal", async () => {
+		const ref = await tempStore("thread-streak-replaced-goal");
+		const original = await createGoal(ref, "Original goal");
+		const replacement = await updateGoal(ref, { objective: "Replacement goal" }, "user");
+
+		const recorded = await recordContinuationDelivered(ref, "stale-signature", original.id);
+
+		expect(recorded).toBeNull();
+		expect(await readGoal(ref)).toEqual(replacement);
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
@@ -102,7 +102,7 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 		});
 	});
 
-	it("fails closed when delivery accounting cannot be persisted", async () => {
+	it("cancels when delivery accounting no longer has a current goal", async () => {
 		const notices: string[] = [];
 		const ctx = await makeGoalContext(notices, "issue-506-persistence-failure");
 		const goal = activeGoal("goal-issue-506-missing-store");
@@ -135,7 +135,7 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 					markContinuationPending: () => {},
 				},
 			),
-		).rejects.toThrow("Cannot persist goal continuation delivery");
+		).resolves.toBeNull();
 		expect(queued).toBe(false);
 	});
 });

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -257,6 +257,15 @@ function runCheck(dryRun) {
 	runCommand("npm", ["run", "check"]);
 }
 
+function runClean(dryRun) {
+	if (dryRun) {
+		dryRunLog("npm run clean");
+		return;
+	}
+	log("npm run clean");
+	runCommand("npm", ["run", "clean"]);
+}
+
 function runBuild(dryRun) {
 	if (dryRun) {
 		dryRunLog("npm run build");
@@ -341,6 +350,7 @@ function main() {
 	runInstallLock(args.dryRun, runCommand, log, dryRunLog);
 	stampChangelogs(version, date, args.dryRun, capturedChangelogSubsections, log, dryRunLog);
 	runCheck(args.dryRun);
+	runClean(args.dryRun);
 	runBuild(args.dryRun);
 	runTests(args.dryRun, args.forceTests);
 


### PR DESCRIPTION
## Summary

- clean all workspace outputs before the release build/test gate
- serialize persisted goal mutations per goal file
- cancel continuation delivery when the admitted goal was cleared or replaced
- update regression coverage and fork change/changelog records

## Root causes

The first `v2026.8.11-2` release attempt aborted before any commit, tag, or push.

1. `npm run build` does not remove deleted outputs. Vitest 4 discovers
   `dist/**/*.test.js`, so stale compiled OmO footer tests executed.
2. `goal_store_changed` is fire-and-forget. `recordContinuationDelivered()`
   could read an active goal, race `thread/goal/clear`, and write its stale
   snapshot after clear, resurrecting the goal.

## Fix

- release now runs `npm run clean` after static checks and before build
- goal read/modify/write operations queue per persisted goal file
- continuation accounting validates the expected goal id inside that queue
- stale delivery returns without marking pending or queueing a hidden prompt
- unrelated goal files remain parallel; persistence format and protocol are unchanged

## RED → GREEN

### RED

- seeded `dist/stale-release-probe.test.js` survived `npm run build` and failed under Vitest
- app-server goal test: second clear returned `true`
- write trace: create → clear null → stale continuation rewrite → second clear
- replacement-goal regression: continuation for goal A mutated goal B

### GREEN

- clean-before-build removes the stale probe and it does not reappear
- app-server goal: 8/8 passed
- goal store: 54/54 passed
- goal monitor/modules: 45/45 passed
- issue-506 stale cancellation: 2/2 passed
- release/CalVer scripts: 9/9 passed
- `npm run check` passed
- `npm run clean` passed
- `npm run build` passed
- final `CI=1 npm test` passed:
  - coding-agent: 7,034 passed, 35 skipped
  - every workspace group passed

## Manual QA

- Senpi QA common self-check: sandbox cleanup and real auth unchanged
- CLI smoke: 8/8 passed
- deterministic mock loop: passed with zero real tokens
- app-server task14 goal:
  - `GOAL_ROUNDTRIP=1`
  - `BUDGET_TRISTATE=1`
  - `CLEARED_NOTIF_CONDITIONAL=1`
- release CLI help: passed

Evidence:
`local-ignore/qa-evidence/20260810-release/release-recovery-red.txt`
`local-ignore/qa-evidence/20260810-release/recovery-green.txt`
`local-ignore/qa-evidence/20260810-release/recovery-manual-qa.txt`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the release build and fixed a race in goal persistence that could resurrect cleared goals. The build now runs clean, and continuation delivery is canceled if the goal was cleared or replaced.

- **Bug Fixes**
  - Release: run `npm run clean` before build in `scripts/release.mjs` to remove stale outputs and prevent `Vitest` from running `dist/**/*.test.js`.
  - Goal store: serialize per-goal read/modify/write in `packages/coding-agent` so mutations to the same goal file run in order; unrelated goals stay parallel (persistence format unchanged).
  - Continuation accounting: record delivery only when the expected goal id matches; otherwise cancel without queuing a hidden prompt, preventing cleared/replaced goals from being restored.

<sup>Written for commit f84ec1edcb2c752393af4f5ccb4263c870678580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

