### PR TITLE
docs(changelog): normalize unreleased fixes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- A brand profile carrying an unsafe `configDir` (a path separator, `.` or `..`) is rejected instead of redirecting agent state and its migration outside the intended directory.
-- A branded install without an update channel no longer falls back to checking the engine's own releases, which it cannot install.
-
 ### New Features
 
 ### Breaking Changes
@@ -27,8 +22,13 @@
 
 ### Fixed
 
+- A brand profile carrying an unsafe `configDir` (a path separator, `.` or `..`) is rejected instead of redirecting
+  agent state and its migration outside the intended directory
+  ([#787](https://github.com/code-yeongyu/senpi/pull/787)).
+- A branded install without an update channel no longer falls back to checking the engine's own releases, which it
+  cannot install ([#787](https://github.com/code-yeongyu/senpi/pull/787)).
 - Prevented an asynchronous goal continuation from restoring a goal after `thread/goal/clear` or recording delivery
-  against a replacement goal.
+  against a replacement goal ([#788](https://github.com/code-yeongyu/senpi/pull/788)).
 - Prevented Claude Agent SDK OAuth sessions from scheduling `assistant_rewritten` forks when only host-side thinking
   timing annotations changed, preserving resident-session and prompt-cache continuity for reasoning-heavy turns
   ([#751](https://github.com/code-yeongyu/senpi/pull/751) by [@goldtg](https://github.com/goldtg)).


### PR DESCRIPTION
## Summary

- consolidate `[Unreleased]` to one `### Fixed` subsection
- add internal PR references for the #787 brand-hardening fixes
- add the #788 reference to the goal-mutation serialization fix

## Why

The final release audit found no content blocker, but `.github/agent/commands/cl.md`
requires entries to append to existing subsections rather than creating
duplicates and shows internal entries with PR references. This removes the last
guide-format deviations before `v2026.8.11-2`.

## Validation

- one `[Unreleased] > ### Fixed` heading
- two #787 references
- one #788 reference
- `node scripts/check-pr-changelog.mjs --base v2026.8.11` — passed
- `node scripts/check-pr-changelog.mjs --base origin/main` — passed
- `git diff --check` — passed
- released sections unchanged

Pure changelog formatting only; no runtime behavior changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the `[Unreleased]` changelog in `packages/coding-agent/CHANGELOG.md`: merge duplicate “Fixed” entries into one section and add internal PR links for #787 and #788. Docs-only; no runtime changes.

<sup>Written for commit 6c93caba153322e1dd614832740bcddad41df381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

