### PR TITLE
fix(claude-sdk-oauth): ignore content-less user messages in continuity hashes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 
 - MCP shutdown no longer risks terminating unrelated processes on macOS when Homebrew `proctools` provides `pgrep`: process-tree collection now passes an explicit match-all pattern, and the kill path skips PID 1 and non-positive PIDs as defense in depth ([#823](https://github.com/code-yeongyu/senpi/issues/823)).
+- `claude-sdk-oauth` sessions no longer re-send the full conversation after a transient content-less user message disappears. Such messages are now excluded from the sent-stream continuity hash, so an unchanged conversation stays a `delta` instead of forking with `sent_stream_diverged` ([#790](https://github.com/code-yeongyu/senpi/issues/790)).
+
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -149,6 +149,24 @@ The stored-OAuth branch in `ModelsImpl.checkProviderAuth` is a structural short-
 
 LOW in `oauth-login.ts` (added `check` to the returned shape + optional `readSettings` dep); LOW in `index.ts` (one added `readSettings` line); LOW in `provider-composer.ts` (`ExtensionOAuthConfig.check` + `adaptOAuth` forwarding, both additive).
 
+||||||| parent of 5baf13f11 (fix(claude-sdk-oauth): ignore content-less user messages in continuity hashes)
+
+## 2026-08-10 - Ignore content-less user messages in sent-stream continuity
+
+- `sentMessages()` now drops user messages whose `content` array is empty. Such a message carries nothing to transmit
+  and is transient: it is present for a single provider call and gone by the next. Hashing one shifted every later
+  index, so the following turn reported `sent_stream_diverged` and re-sent the entire history even though the
+  conversation had not changed.
+- Observed live on `2026.8.9-2`: consecutive prefix snapshots of one session held 203 messages both times, with the
+  only difference an empty user message at index 201 that vanished on the next call, forcing a 203-message flatten.
+- Tool results are never filtered. An empty tool result is a real observation, and its `toolCallId` and `toolName`
+  stay hash-significant, so genuine rewrites of already-sent history still resolve to `sent_stream_diverged`.
+- This cannot be implemented by an external extension: the transmitted set is computed inside the builtin provider
+  before session-registry continuity is decided, and no extension hook can replace it.
+- Added `test/suite/regressions/790-claude-sdk-oauth-empty-user-continuity.test.ts` covering the transient empty
+  message, a plain append, a genuine rewrite, and the filter itself.
+- Expected merge conflict zones: LOW in `session-sync.ts` (`sentMessages`); LOW in the new regression test.
+
 ## 2026-08-07 - Ignore volatile thinking timing in continuity hashes
 
 - Removed `startedAt` and `endedAt` from thinking blocks before hashing the provider-final and committed assistant

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
@@ -52,7 +52,10 @@ export function sessionSyncDigest(value: unknown): string {
  */
 function isContentlessUserMessage(message: SentMessage): boolean {
 	if (message.role !== "user") return false;
-	return message.content.length === 0;
+	// Only a literal zero-block array is content-less. Whitespace-only text and
+	// explicit empty-text blocks still emit transport blocks, so they must stay
+	// hash-significant to keep divergence detection fail-closed.
+	return Array.isArray(message.content) && message.content.length === 0;
 }
 
 export function sentMessages(context: Context): SentMessage[] {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
@@ -42,9 +42,23 @@ export function sessionSyncDigest(value: unknown): string {
 	return digest(value);
 }
 
+/**
+ * A user message with no content blocks carries nothing to transmit and is
+ * transient: it is present for a single provider call and gone by the next.
+ * Hashing one shifts every later index, so the following turn reports
+ * `sent_stream_diverged` and re-sends the whole history even though the
+ * conversation never changed. Tool results are never filtered - an empty tool
+ * result is a real observation, and its id and name stay hash-significant.
+ */
+function isContentlessUserMessage(message: SentMessage): boolean {
+	if (message.role !== "user") return false;
+	return message.content.length === 0;
+}
+
 export function sentMessages(context: Context): SentMessage[] {
 	const messages = context.messages.filter(
-		(message): message is SentMessage => message.role === "user" || message.role === "toolResult",
+		(message): message is SentMessage =>
+			(message.role === "user" || message.role === "toolResult") && !isContentlessUserMessage(message),
 	);
 	return messages;
 }

--- a/packages/coding-agent/test/suite/regressions/790-claude-sdk-oauth-empty-user-continuity.test.ts
+++ b/packages/coding-agent/test/suite/regressions/790-claude-sdk-oauth-empty-user-continuity.test.ts
@@ -109,4 +109,29 @@ describe("claude-sdk-oauth: content-less user messages must not break sent-strea
 			reason: "sent_stream_diverged",
 		});
 	});
+
+	// The predicate must stay narrow: only a literal zero-block array is excluded.
+	// Whitespace-only text and explicit empty-text blocks still produce transport
+	// blocks, so dropping them would weaken fail-closed divergence detection.
+	it("keeps whitespace-only and empty-text-block user messages hashed (fail-closed)", () => {
+		const whitespaceOnly = { role: "user", content: [{ type: "text", text: "   " }], timestamp: 1 };
+		const emptyTextBlock = { role: "user", content: [{ type: "text", text: "" }], timestamp: 1 };
+		const realTurn = userMessage("real turn");
+
+		const messages = [realTurn, whitespaceOnly, emptyTextBlock, toolResultMessage("call-1", "output")];
+
+		// Only a literal content: [] message is dropped; these three stay.
+		expect(sentMessages(contextOf(messages))).toHaveLength(4);
+	});
+
+	it("treats the disappearance of a whitespace-only user message as divergence", () => {
+		const whitespaceOnly = { role: "user", content: [{ type: "text", text: "   " }], timestamp: 1 };
+		const turnOne = [toolResultMessage("call-0", "out"), whitespaceOnly, userMessage("next")];
+		const turnTwo = [toolResultMessage("call-0", "out"), userMessage("next"), toolResultMessage("call-1", "new")];
+
+		// A whitespace-only message WAS transmitted, so its removal is a real rewrite.
+		expect(decide(hashesFor(turnOne), hashesFor(turnTwo))).toMatchObject({
+			reason: "sent_stream_diverged",
+		});
+	});
 });

--- a/packages/coding-agent/test/suite/regressions/790-claude-sdk-oauth-empty-user-continuity.test.ts
+++ b/packages/coding-agent/test/suite/regressions/790-claude-sdk-oauth-empty-user-continuity.test.ts
@@ -1,0 +1,112 @@
+import type { Context } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import {
+	type ContinuityEntrySnapshot,
+	decideNativeContinuity,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts";
+import { sentMessageHashes, sentMessages } from "../../../src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts";
+
+const ACCOUNT = "default";
+const MODEL = "claude-opus-5";
+const SYSTEM_PROMPT_HASH = "system-prompt-hash";
+const TOOLSET_HASH = "toolset-hash";
+
+function contextOf(messages: readonly unknown[]): Context {
+	return { messages } as unknown as Context;
+}
+
+function userMessage(text: string) {
+	return { role: "user", content: [{ type: "text", text }], timestamp: 1 };
+}
+
+/**
+ * A user message carrying no content blocks. These appear transiently in
+ * `context.messages` and are gone by the next provider call, so hashing one
+ * shifts every later index and forces a full-history re-send.
+ */
+function emptyUserMessage() {
+	return { role: "user", content: [], timestamp: 1 };
+}
+
+function toolResultMessage(toolCallId: string, text: string) {
+	return { role: "toolResult", toolCallId, toolName: "bash", content: [{ type: "text", text }], timestamp: 1 };
+}
+
+function entryFrom(sentHashes: readonly string[]): ContinuityEntrySnapshot {
+	return {
+		sdkSessionId: "sdk-session",
+		accountName: ACCOUNT,
+		modelId: MODEL,
+		systemPromptHash: SYSTEM_PROMPT_HASH,
+		toolsetHash: TOOLSET_HASH,
+		sentCount: sentHashes.length,
+		sentHashes,
+		lastAssistantUuid: "assistant-uuid",
+		assistantUuidByIndex: new Map([[1, "assistant-uuid"]]),
+		pendingForkReason: null,
+		taintedReason: null,
+	};
+}
+
+function decide(sentHashes: readonly string[], currentHashes: readonly string[]) {
+	const decision = decideNativeContinuity({
+		entry: entryFrom(sentHashes),
+		binding: undefined,
+		currentHashes,
+		accountName: ACCOUNT,
+		modelId: MODEL,
+		fingerprint: { systemPromptHash: SYSTEM_PROMPT_HASH, toolsetHash: TOOLSET_HASH },
+		transcriptAvailable: true,
+		idleExpired: false,
+	});
+	// Compared as an explicit shape so the observed reason is printed on failure
+	// instead of being collapsed into "omitted properties".
+	return { kind: decision.kind, reason: "reason" in decision ? decision.reason : null };
+}
+
+function hashesFor(messages: readonly unknown[]): string[] {
+	return sentMessageHashes(sentMessages(contextOf(messages)));
+}
+
+describe("claude-sdk-oauth: content-less user messages must not break sent-stream continuity", () => {
+	it("excludes a content-less user message from the transmitted set", () => {
+		const messages = [userMessage("real turn"), emptyUserMessage(), toolResultMessage("call-1", "output")];
+
+		expect(sentMessages(contextOf(messages))).toHaveLength(2);
+	});
+
+	it("stays a delta when a transient content-less user message disappears", () => {
+		// Turn 1: an empty user message sits between a tool result and the next
+		// real user turn, exactly as observed in a live session.
+		const turnOne = [
+			toolResultMessage("call-0", "earlier output"),
+			emptyUserMessage(),
+			userMessage("Continue working toward the active thread goal"),
+		];
+		// Turn 2: the empty message is gone and a tool result is appended. The
+		// real conversation is unchanged, so this must not be a divergence.
+		const turnTwo = [
+			toolResultMessage("call-0", "earlier output"),
+			userMessage("Continue working toward the active thread goal"),
+			toolResultMessage("call-1", "new output"),
+		];
+
+		expect(decide(hashesFor(turnOne), hashesFor(turnTwo))).toEqual({ kind: "delta", reason: null });
+	});
+
+	it("treats a plain append as a delta", () => {
+		const turnOne = [userMessage("do the task")];
+		const turnTwo = [...turnOne, toolResultMessage("call-1", "tool output")];
+
+		expect(decide(hashesFor(turnOne), hashesFor(turnTwo))).toEqual({ kind: "delta", reason: null });
+	});
+
+	it("still detects a genuine rewrite of already-sent history", () => {
+		const turnOne = [userMessage("do the task"), toolResultMessage("call-1", "tool output")];
+		const rewritten = [userMessage("do the task"), toolResultMessage("call-1", "DIFFERENT output")];
+
+		expect(decide(hashesFor(turnOne), hashesFor(rewritten))).toMatchObject({
+			reason: "sent_stream_diverged",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- ignore user messages with no content blocks when computing the claude-sdk-oauth sent-stream hashes
- add a regression covering the transient empty message, a plain append, a genuine rewrite, and the filter itself
- record the change in the extension's `changes.md`

## Root cause

`sentMessages()` hashes every `user` and `toolResult` message. A user message whose `content`
array is empty carries nothing to transmit and is transient: it is present for one provider call
and gone by the next.

Because it is hashed, its removal shifts every later index, `commonPrefixLength` stops short of
`sentCount`, and `decideNativeContinuity` resolves the turn to `sent_stream_diverged` — forking the
session and re-sending the whole history even though the conversation never changed.

Captured on `2026.8.9-2` from two consecutive provider calls of one session, both 203 messages:

```text
call N      [200] toolResult bash  len=159   sha b518dd86
            [201] user             len=0     sha 12ae32cb   <- content: []
            [202] user             len=8194  sha 5c1ea814

call N+1    [200] toolResult bash  len=159   sha b518dd86
            [201] user             len=8194  sha 5c1ea814   <- shifted up one slot
            [202] toolResult bash  len=3191  sha aec978fe
```

Index 200 is byte-identical. Only the empty message disappears, and the next decision is
`flatten / sent_stream_diverged` at 203 messages.

Cost on one affected turn: `cacheRead` collapsed 582,409 → 61,594 with `cacheWrite` 524,339, about
8x its neighbouring turns. The same session logged 12 `sent_stream_diverged` events in 12 minutes.

Independent of #691 — this reproduces on `5275da1f5`, well after #751 merged.

## Fix

- `sentMessages()` drops user messages whose `content` array is empty
- tool results are never filtered: an empty tool result is a real observation, and its `toolCallId`
  and `toolName` stay hash-significant
- no change to the divergence decision table, the fork boundary, or the transmitted prompt for any
  message that carries content

Why this cannot be an extension: the transmitted set is computed inside the builtin provider before
session-registry continuity is decided, and no extension hook can replace it. A `changes.md` section
records the modification and its expected merge-conflict zones.

## RED → GREEN

### RED

Against `5275da1f5` with only the test added:

```text
× excludes a content-less user message from the transmitted set
    expected length 2, received 3
× stays a delta when a transient content-less user message disappears
    - "kind": "delta",   "reason": null
    + "kind": "fork",    "reason": "sent_stream_diverged"

Tests  2 failed | 2 passed (4)
```

### GREEN

```text
Tests  4 passed (4)
```

The two control cases pass in both runs, so the guard still fails closed: a plain append stays a
`delta`, and a genuine rewrite of already-sent history still reports `sent_stream_diverged`.

## Verification

```text
npm run check                                   -> exit 0
npx vitest run test/suite/regressions/790-claude-sdk-oauth-empty-user-continuity.test.ts
                                                -> 4 passed
npx vitest run test/claude-sdk-oauth-*.test.ts  -> 35 files, 314 passed, 3 skipped
```

A deterministic container reproduces the bug and verifies the fix with no credentials and no tokens
spent. It clones `5275da1f5`, runs the regression unpatched, applies the production patch, and
re-runs; it exits 0 only when the unpatched tree fails specifically with `sent_stream_diverged` and
the patched tree reports all four tests passing:

```text
== ARM 1: unpatched ==
  Tests  2 failed | 2 passed (4)
  +   "reason": "sent_stream_diverged"

== ARM 2: with fix applied ==
  Applied patch ... cleanly.
  Tests  4 passed (4)

PASS: reproduced on 5275da1f5 and verified the fix resolves it.
```
