### PR TITLE
fix(pty): handle missing taskkill on Windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Windows pipe-fallback shutdown no longer crashes with an uncaught `spawn taskkill ENOENT` when the helper cannot
+  resolve. Senpi now invokes `taskkill.exe` explicitly and falls back to direct child termination if helper startup
+  fails.
 - A brand profile carrying an unsafe `configDir` (a path separator, `.` or `..`) is rejected instead of redirecting agent state and its migration outside the intended directory.
 - A branded install without an update channel no longer falls back to checking the engine's own releases, which it cannot install.
 

--- a/packages/pty/src/pipe-fallback.ts
+++ b/packages/pty/src/pipe-fallback.ts
@@ -237,17 +237,25 @@ export class PipeFallbackSession {
 		if (this.child === null) {
 			return { ok: false, code: "not_started", note: "Cannot kill pipe fallback session: session has not started." };
 		}
-		const pid = this.child.pid;
+		const child = this.child;
+		const pid = child.pid;
 		if (process.platform === "win32" && pid !== undefined) {
 			// On Windows child.kill() TerminateProcess-es only the direct child, leaving
 			// grandchildren (e.g. `sleep` under `bash.exe -c`) alive and holding the stdout
 			// pipe open — so 'close' never fires and waitExit() hangs teardown. taskkill /T /F
 			// terminates the whole tree so the pipe EOFs and the session settles.
 			try {
-				spawn("taskkill", ["/pid", String(pid), "/T", "/F"], { stdio: "ignore", windowsHide: true });
+				const killer = spawn("taskkill.exe", ["/pid", String(pid), "/T", "/F"], {
+					stdio: "ignore",
+					windowsHide: true,
+				});
+				killer.once("error", () => {
+					terminateChildTree(child, signal);
+				});
 				return { ok: true, note: `Terminated child_process pipe fallback process tree (pid ${pid}).` };
 			} catch {
-				// Fall through to the direct kill if taskkill is unavailable.
+				terminateChildTree(child, signal);
+				return { ok: true, note: `Sent ${signal} to child_process pipe fallback session.` };
 			}
 		}
 		if (terminateChildTree(this.child, signal) === "group") {

--- a/packages/pty/test/pipe-fallback.test.ts
+++ b/packages/pty/test/pipe-fallback.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 import type { NativePtyLoadResult } from "../src/native-loader.ts";
@@ -196,6 +197,46 @@ describe("PipeFallbackSession terminal detachment", () => {
 		},
 		5000,
 	);
+});
+
+describe("PipeFallbackSession Windows process-tree cleanup", () => {
+	it("does not crash when taskkill is unavailable during kill", () => {
+		const moduleUrl = new URL("../src/pipe-fallback.ts", import.meta.url).href;
+		const script = `
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			process.env.PATH = "";
+			const { PipeFallbackSession } = await import(${JSON.stringify(moduleUrl)});
+			const session = new PipeFallbackSession({
+				command: process.execPath,
+				args: ["-e", "setInterval(() => {}, 1000)"],
+			}).start();
+			const timeout = setTimeout(() => {
+				process.stderr.write("PIPE_FALLBACK_KILL_TIMEOUT\\n");
+				process.exit(2);
+			}, 2000);
+			session.kill("SIGTERM");
+			await session.waitExit();
+			clearTimeout(timeout);
+			process.stdout.write("DIRECT_FALLBACK_SETTLED\\n");
+		`;
+
+		const result = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script], {
+			encoding: "utf8",
+			timeout: 5000,
+		});
+
+		expect({
+			signal: result.signal,
+			status: result.status,
+			stderr: result.stderr,
+			stdout: result.stdout,
+		}).toEqual({
+			signal: null,
+			status: 0,
+			stderr: "",
+			stdout: "DIRECT_FALLBACK_SETTLED\n",
+		});
+	});
 });
 
 describe("terminateChildTree", () => {


### PR DESCRIPTION
## Summary

Fix the Windows pipe-fallback shutdown crash where Senpi could exit with an uncaught `Error: spawn taskkill ENOENT`.

`PipeFallbackSession.kill()` now invokes `taskkill.exe`, attaches the helper process error listener immediately, and falls back to direct child termination if the helper cannot start. This keeps process-tree cleanup best-effort without allowing an asynchronous spawn error to terminate Senpi.

## Changes

- Harden Windows pipe-fallback termination against missing or unresolvable `taskkill.exe`.
- Add a real subprocess regression that reproduces the exact uncaught ENOENT and argv shape.
- Document the user-visible fix in the coding-agent `[Unreleased]` changelog.

## QA & Evidence

### RED -> GREEN regression

- **Command:** `npm --prefix packages/pty test -- test/pipe-fallback.test.ts`
- **Before:** exit 1 with unhandled `spawn taskkill ENOENT`, `syscall: 'spawn taskkill'`, and `spawnargs: ['/pid', pid, '/T', '/F']`.
- **After:** subprocess exit 0, empty stderr, and `DIRECT_FALLBACK_SETTLED`.
- **Why sufficient:** the unchanged test toggles the exact mechanism shown in the report.

### Static, test, and build gates

- `npm run check` - passed, including Biome, dependency/import/lock checks, TypeScript no-emit, and browser smoke.
- `npm --prefix packages/pty test` - 8 files, 50 tests passed.
- `npm --prefix packages/pty run build` - passed.
- `node scripts/check-pr-changelog.mjs --base <merge-base>` - passed.

### Real Windows runtime

- **Surface:** Parallels Windows 11 VM, Node `C:\Program Files\nodejs\node.exe`.
- **Scenario:** built PTY module with `PATH` cleared so `taskkill.exe` deterministically returns `ENOENT`.
- **Observed:** `platform=win32`, `probeCode=ENOENT`, `DIRECT_FALLBACK_SETTLED`, exit signal `SIGTERM`, `timedOut=false`, process exit 0, no uncaught output.
- **Cleanup:** QA child absent, Windows temp removed, remote staging removed, VM restored to its baseline stopped state.

### Senpi PTY surface

- `node .agents/skills/senpi-qa/scripts/pty-drive.mjs --self-test --force-pipe --evidence taskkill-enoent`
- 8/8 passed: monitor/peek, stdin steering, screen resize, registry teardown with no orphans, and unchanged real auth hash.

## Risks & Residuals

- The successful-taskkill note remains optimistic while the helper is in flight; that existing behavior is unchanged.
- `packages/pty/src/pipe-fallback.ts` is at 250 non-blank, non-line-comment lines, so future growth should split a cohesive responsibility before adding more code.

## Related Issues

- Reported from a Windows Senpi crash screenshot; no issue number was provided.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows crash in the PTY pipe-fallback when `taskkill` isn’t found (`ENOENT`). We now call `taskkill.exe`, handle spawn errors, and fall back to direct child termination so shutdown doesn’t crash.

- **Bug Fixes**
  - Use `taskkill.exe` with an immediate error listener; on failure, fall back to direct child termination.
  - Add regression test that clears `PATH` to reproduce `ENOENT` and verifies clean exit.
  - Document the fix in `packages/coding-agent/CHANGELOG.md`.

<sup>Written for commit 9fe0c5ccb81bd0faf6bc3ea19672340c2a2ca45b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

