### PR TITLE
docs(changelog): link Windows taskkill fix

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - Windows pipe-fallback shutdown no longer crashes with an uncaught `spawn taskkill ENOENT` when the helper cannot
   resolve. Senpi now invokes `taskkill.exe` explicitly and falls back to direct child termination if helper startup
-  fails.
+  fails ([#792](https://github.com/code-yeongyu/senpi/pull/792)).
 - A brand profile carrying an unsafe `configDir` (a path separator, `.` or `..`) is rejected instead of redirecting
   agent state and its migration outside the intended directory
   ([#787](https://github.com/code-yeongyu/senpi/pull/787)).


### PR DESCRIPTION
## Summary

- add the missing internal PR #792 reference to the Windows `taskkill.exe` fix

## Why

The final release audit confirmed complete content coverage but found the new
PR #792 entry lacked the internal PR-link format used by
`.github/agent/commands/cl.md`. This removes the last known changelog-format
deviation before `v2026.8.11-2`.

## Validation

- one `[Unreleased] > ### Fixed` heading
- one #792 reference
- tag-range changelog gate passed
- PR changelog gate passed
- `git diff --check` passed
- released sections unchanged

Pure changelog formatting only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing PR #792 link to the Windows `taskkill.exe` fix entry in `packages/coding-agent/CHANGELOG.md`, aligning it with our standard changelog link format.

<sup>Written for commit dae31d30110f4e20d9a8a0cea7008b206dbf6941. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

