### PR TITLE
fix(coding-agent): refresh active-turn fallback policy

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Refresh `abortServerSideFallback` from the host's next-turn snapshot so an active agent run cannot carry a prior
+  model's server-fallback policy into the next provider request
+  ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
+
 ### Removed
 
 ## [2026.8.11-2] - 2026-08-10

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -341,6 +341,7 @@ async function runLoop(
 							: nextTurnSnapshot.thinkingLevel === "off"
 								? undefined
 								: nextTurnSnapshot.thinkingLevel,
+					abortServerSideFallback: nextTurnSnapshot.abortServerSideFallback ?? config.abortServerSideFallback,
 				};
 			}
 			if (signal?.aborted) {

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,26 @@
 # Changes
 
+## 2026-08-10 - Refresh server-fallback policy between tool turns
+
+### What changed and why
+
+- `AgentLoopTurnUpdate` can now replace `abortServerSideFallback` together with the model and thinking level before
+  the next provider request in an active run.
+- `agent-loop.ts` applies the refreshed value when rebuilding its request config after tool execution. Previously the
+  loop snapshotted the option at run start, so a host that changed models mid-turn could send the next request with
+  the prior model's server-fallback policy.
+- An explicit `false` remains authoritative because the update uses nullish fallback rather than truthiness.
+
+### Why the extension system could not handle this
+
+- The provider options object is owned and snapshotted inside agent-core before extensions observe the next request;
+  only the loop can replace request policy between tool turns.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `types.ts` `AgentLoopTurnUpdate`.
+- LOW: `agent-loop.ts` next-turn config replacement.
+
 ## 2026-08-09 - Recover invisible text-protocol assistant stops
 
 ### What changed and why

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -139,6 +139,8 @@ export interface AgentLoopTurnUpdate {
 	model?: Model<any>;
 	/** Thinking level for the next provider request. */
 	thinkingLevel?: ThinkingLevel;
+	/** Whether the next provider request should abort a server-selected fallback. */
+	abortServerSideFallback?: boolean;
 }
 
 export interface PrepareNextTurnContext extends ShouldStopAfterTurnContext {}

--- a/packages/ai/test/anthropic-server-fallback-abort.test.ts
+++ b/packages/ai/test/anthropic-server-fallback-abort.test.ts
@@ -155,6 +155,41 @@ describe("Anthropic server-side fallback receipt abort", () => {
 		expect(JSON.stringify(result.content)).toContain(SUBSTITUTE_TEXT);
 	});
 
+	it("keeps a malformed fallback receipt when the client abort policy is on", async () => {
+		const model = getModel("anthropic", "claude-fable-5");
+		const malformedReceipt: SseEvent = {
+			event: "content_block_start",
+			data: JSON.stringify({
+				type: "content_block_start",
+				index: 0,
+				content_block: {
+					type: "fallback",
+					from: { model: "claude-fable-5" },
+				},
+			}),
+		};
+		const body = createChunkedSseResponse([
+			messageStart("claude-fable-5"),
+			malformedReceipt,
+			...substituteOutputEvents,
+		]);
+
+		const result = await streamAnthropic(model, context, {
+			abortServerSideFallback: true,
+			client: createFakeAnthropicClient(body.response),
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		const receipt = result.content.find(
+			(block): block is ProviderNativeContent => block.type === "providerNative" && block.subtype === "fallback",
+		);
+		expect(receipt?.raw).toEqual({
+			type: "fallback",
+			from: { model: "claude-fable-5" },
+		});
+		expect(JSON.stringify(result.content)).toContain(SUBSTITUTE_TEXT);
+	});
+
 	it("aborts at the receipt and classifies the turn as a classifier refusal", async () => {
 		const model = getModel("anthropic", "claude-fable-5");
 		let transportSignal: AbortSignal | undefined;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Fixed
 
+- Route Anthropic provider-native refusal fallbacks through the configured Senpi chain after an active-turn model
+  change, instead of persisting the server-selected substitute because the run retained the previous model's policy
+  ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
+
 ### Removed
 
 ## [2026.8.11-2] - 2026-08-10

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1072,6 +1072,8 @@ export class AgentSession {
 				},
 				model: this.agent.state.model,
 				thinkingLevel: this.agent.state.thinkingLevel,
+				abortServerSideFallback:
+					this.settingsManager.getAbortServerSideFallback() && this._retryFallback.hasConfiguredChain(),
 			};
 		};
 	}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## Refresh server-fallback policy for active-turn model changes (2026-08-10)
+
+### What changed
+
+- `AgentSession` now recomputes `abortServerSideFallback` in its next-turn refresh snapshot from the live retry
+  settings and the newly active model's configured fallback chain.
+- Favorite-model cycling during tool execution previously changed the next request's model but left the agent loop's
+  run-start server-fallback option unchanged. A Fable request entered from an unchained model could therefore accept
+  and persist Anthropic's provider-native Fable-to-Opus fallback instead of routing the refusal through Senpi's
+  configured chain.
+- The explicit `retry.abortServerSideFallback: false` opt-out remains false after the same in-turn model cycle.
+- Coverage reproduces the real request order with a faux tool: unchained model request, favorite cycle during tool
+  execution, then a chained-model continuation.
+
+### Why this cannot be expressed externally
+
+- Extensions can trigger or observe model selection, but the live provider option is assembled by agent-core from the
+  session's next-turn snapshot before the continuation request is sent.
+
+### Expected merge conflict zones
+
+- LOW: `_installAgentNextTurnRefresh()` next-turn snapshot fields in `agent-session.ts`.
+- LOW: `server-fallback-abort-option.test.ts` continuation-policy coverage.
+
 ## Extension filesystem policy binding (2026-08-09)
 
 ### What changed

--- a/packages/coding-agent/test/suite/server-fallback-abort-option.test.ts
+++ b/packages/coding-agent/test/suite/server-fallback-abort-option.test.ts
@@ -1,5 +1,7 @@
+import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { SimpleStreamOptions } from "@earendil-works/pi-ai";
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import { createHarness, type Harness } from "./harness.ts";
 
@@ -52,6 +54,87 @@ describe("abortServerSideFallback reaches the provider options", () => {
 		harnesses.push(harness);
 		const captured = await captureStreamOptions(harness);
 		expect(captured[0]?.abortServerSideFallback).toBe(false);
+	});
+
+	it("enables the abort after cycling onto a model with a configured chain", async () => {
+		let harness: Harness;
+		const cycleTool: AgentTool = {
+			name: "cycle_model",
+			label: "Cycle model",
+			description: "Cycle to the next favorite model",
+			parameters: Type.Object({}),
+			execute: async () => {
+				const cycled = await harness.session.cycleModel("forward");
+				expect(cycled?.model.id).toBe("faux-1");
+				return { content: [{ type: "text", text: "cycled" }], details: {} };
+			},
+		};
+		harness = await createHarness({
+			models: [{ id: "faux-0" }, { id: "faux-1" }, { id: "faux-2" }],
+			tools: [cycleTool],
+			settings: {
+				retry: { fallbackChains: { "faux/faux-1": ["faux/faux-2"] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.session.setFavoriteModels([{ model: harness.models[0] }, { model: harness.models[1] }]);
+
+		const captured: Array<{ model: string; options: SimpleStreamOptions }> = [];
+		const inner = harness.session.agent.streamFunction;
+		harness.session.agent.streamFunction = (model, context, options) => {
+			captured.push({ model: model.id, options: options ?? {} });
+			return inner(model, context, options);
+		};
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("cycle_model", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(captured.map((request) => request.model)).toEqual(["faux-0", "faux-1"]);
+		expect(captured[1]?.options.abortServerSideFallback).toBe(true);
+	});
+
+	it("keeps an explicit opt-out after cycling onto a configured chain", async () => {
+		let harness: Harness;
+		const cycleTool: AgentTool = {
+			name: "cycle_model",
+			label: "Cycle model",
+			description: "Cycle to the next favorite model",
+			parameters: Type.Object({}),
+			execute: async () => {
+				await harness.session.cycleModel("forward");
+				return { content: [{ type: "text", text: "cycled" }], details: {} };
+			},
+		};
+		harness = await createHarness({
+			models: [{ id: "faux-0" }, { id: "faux-1" }, { id: "faux-2" }],
+			tools: [cycleTool],
+			settings: {
+				retry: {
+					abortServerSideFallback: false,
+					fallbackChains: { "faux/faux-1": ["faux/faux-2"] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.session.setFavoriteModels([{ model: harness.models[0] }, { model: harness.models[1] }]);
+
+		const captured: SimpleStreamOptions[] = [];
+		const inner = harness.session.agent.streamFunction;
+		harness.session.agent.streamFunction = (model, context, options) => {
+			captured.push(options ?? {});
+			return inner(model, context, options);
+		};
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("cycle_model", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(captured[1]?.abortServerSideFallback).toBe(false);
 	});
 
 	it("refreshes the policy after a model switch", async () => {


### PR DESCRIPTION
## Summary

- refresh `abortServerSideFallback` in the agent loop's next-turn snapshot instead of keeping the run-start value
- make active-turn model changes route Anthropic provider-native refusal fallbacks through the newly selected model's configured Senpi chain
- preserve explicit opt-out and malformed/unconfigured receipt behavior

## Root cause

Affected sessions changed models while a tool-driven turn was still active:

- `019fe56d-cd32-7a2c-9be0-5b3d462e04dd` (`cyber`)
- `019fe526-9917-78a1-8a88-e5733a696f3d` (`reasoning_extraction`)
- `019fea1f-f97d-7998-8137-2e2d3a08b18b` (`cyber`)

`AgentSession` refreshed the active model, but `Agent.createLoopConfig()` had snapshotted `abortServerSideFallback` at run start. The next provider request used the new Fable model with the prior model's `false` policy, so Anthropic's Fable-to-Opus provider-native fallback was persisted instead of aborted and reconciled into Senpi's configured chain.

## Verification

- RED: active turn `faux-0 -> faux-1` continuation observed `abortServerSideFallback: false`, expected `true`
- GREEN: focused coding-agent regression, 6/6
- malformed receipt suite, 9/9; mutation to a valid receipt failed on `stopReason: error` as expected
- `npm run check`
- `npm run build`
- `npm test`
- real source CLI RPC QA:
  - requests: `mock-unchained -> claude-fable-5 -> mock-client-fallback`
  - emitted `server_fallback_aborted` for `claude-fable-5 -> claude-opus-5`
  - emitted configured `retry_fallback_applied` with reason `refusal`
  - persisted no `providerNative/fallback` block
  - cleanup receipt confirmed server stopped and sandbox removed

## Notes

- Explicit `retry.abortServerSideFallback: false` remains authoritative.
- The change is limited to the existing typed next-turn refresh boundary and mandatory fork change records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes server-side fallback handling when the model changes mid-turn. We now refresh `abortServerSideFallback` between tool turns so Anthropic fallbacks are aborted and routed through the configured chain when applicable.

- Bug Fixes
  - Refresh `abortServerSideFallback` in the agent loop before each post-tool request using the next-turn snapshot (not the run-start value).
  - Add `abortServerSideFallback` to `AgentLoopTurnUpdate` and apply it in `agent-loop.ts` with nullish fallback to preserve an explicit `false`.
  - In `coding-agent` `AgentSession`, recompute the policy from live retry settings and the newly selected model’s configured fallback chain; favorite-model cycling is covered.
  - Preserve explicit opt-out and leave malformed/unconfigured provider receipts unchanged (tests added).

<sup>Written for commit 107f17b37c3d151d9e524aa82e056677d9d13751. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

