### PR TITLE
fix(coding-agent): recover from a deleted working directory at startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- A launch from a deleted working directory (for example a removed worktree) no longer crashes during
+  startup with `uv_cwd`; the CLI recovers into the home directory before any dependency evaluates
+  `process.cwd()`.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/dist/cli.js
+++ b/packages/coding-agent/dist/cli.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./valid-cwd.js";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";

--- a/packages/coding-agent/src/cli-main.ts
+++ b/packages/coding-agent/src/cli-main.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./valid-cwd.ts";
 import { APP_NAME } from "./config.ts";
 import { scrubBrandFromEnvironment } from "./core/brand.ts";
 import { configureHttpDispatcher } from "./core/http-dispatcher.ts";

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./valid-cwd.ts";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";

--- a/packages/coding-agent/src/valid-cwd.ts
+++ b/packages/coding-agent/src/valid-cwd.ts
@@ -1,0 +1,13 @@
+import { homedir } from "node:os";
+
+// A shell whose working directory was deleted (a removed worktree or checkout) still starts this
+// process: Node boots with the stale handle and only throws `uv_cwd` when something evaluates
+// process.cwd(). The bundled agent SDK does that during module evaluation, before any user code
+// can recover, so the guard must run before every other import - keep it dependency-free.
+try {
+	process.cwd();
+} catch {
+	const fallback = homedir();
+	process.chdir(fallback);
+	console.error(`the current working directory no longer exists; continuing from ${fallback}`);
+}

--- a/packages/coding-agent/test/valid-cwd-guard.test.ts
+++ b/packages/coding-agent/test/valid-cwd-guard.test.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * A shell whose cwd was deleted (a removed worktree or checkout) still starts our CLI: Node boots
+ * with the stale handle and only throws uv_cwd when something evaluates process.cwd(). The bundled
+ * agent SDK does that at module-evaluation time, so the process dies before any user code can
+ * recover. These tests reproduce that exact shape in a child process and pin the recovery guard.
+ */
+
+const driverSource = `import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+const dir = mkdtempSync(join(tmpdir(), "senpi-cwd-guard-"));
+process.chdir(dir);
+rmSync(dir, { recursive: true, force: true });
+if (process.env.WITH_GUARD === "1") await import(process.env.GUARD_URL);
+await import(process.env.PROBE_URL);
+console.log("CWD_OK=" + process.cwd());
+`;
+
+const probeSource = `// Mimics the bundled agent SDK: resolves the cwd during module evaluation.
+process.cwd();
+`;
+
+function runChild(withGuard: boolean) {
+	const dir = mkdtempSync(join(tmpdir(), "senpi-cwd-guard-host-"));
+	try {
+		const driver = join(dir, "driver.mjs");
+		const probe = join(dir, "probe.mjs");
+		writeFileSync(driver, driverSource);
+		writeFileSync(probe, probeSource);
+		return spawnSync(process.execPath, [driver], {
+			encoding: "utf8",
+			env: {
+				...process.env,
+				WITH_GUARD: withGuard ? "1" : "0",
+				GUARD_URL: resolve(__dirname, "..", "src", "valid-cwd.ts"),
+				PROBE_URL: probe,
+			},
+		});
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("valid-cwd startup guard", () => {
+	describe("#given a process whose cwd was deleted before launch", () => {
+		test("#when a module resolves process.cwd() without the guard #then it crashes with uv_cwd", () => {
+			const result = runChild(false);
+			expect(result.status).not.toBe(0);
+			expect(result.stderr).toContain("uv_cwd");
+		});
+
+		test("#when the guard is imported first #then startup recovers into the home directory", () => {
+			const result = runChild(true);
+			expect(result.status, result.stderr).toBe(0);
+			expect(result.stdout).toContain("CWD_OK=");
+			expect(result.stdout).not.toContain("senpi-cwd-guard-");
+		});
+	});
+
+	describe("#given the CLI entrypoints", () => {
+		test.each(["src/cli.ts", "src/cli-main.ts"])("#when %s is read #then the guard is its first import", (entry) => {
+			const source = require("node:fs").readFileSync(resolve(__dirname, "..", entry), "utf8");
+			const firstImport = source.split("\n").find((line: string) => line.startsWith("import "));
+			expect(firstImport).toBe('import "./valid-cwd.ts";');
+		});
+	});
+});


### PR DESCRIPTION
## What

A dependency-free startup guard, imported first in both CLI entrypoints (`cli.ts`, `cli-main.ts`), that recovers when the process was launched from a deleted working directory.

## Why

A shell whose cwd was removed (a deleted worktree or checkout - the user's omo checkout was wiped and recreated under a live shell) still launches the CLI: Node boots with the stale handle and only throws `uv_cwd` when something evaluates `process.cwd()`. The bundled agent SDK does exactly that during module evaluation, so the process dies in `run_main` before any user code can run:

```
Error: ENOENT: process.cwd failed ... uv_cwd
    at wrappedCwd (node:internal/bootstrap/switches/does_own_process_state:142:28)
    at .../node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs
```

The guard validates `process.cwd()` before any other import evaluates and, on failure, chdirs to the home directory with a one-line warning. The re-spawned agent child inherits the repaired cwd, so nothing downstream can observe the deleted directory.

## Verification

TDD via a child-process reproduction in `test/valid-cwd-guard.test.ts` (4 tests):

| case | result |
| --- | --- |
| deleted cwd + top-level `process.cwd()` probe, no guard | crashes with `uv_cwd` (proves the failure mode) |
| deleted cwd + guard imported first | recovers into the home directory, exit 0 |
| `src/cli.ts` / `src/cli-main.ts` | guard is the first import (wiring pinned) |

Also verified against a real installed engine (patched locally ahead of release): entering a temp dir, removing it, then launching `cli.js` / `cli-main.js` from the stale cwd prints the recovery line and exits 0.

`npm run build` and `npm run check` pass.

## Notes

- The guard is intentionally dependency-free and side-effect-only: any import it made could itself touch the cwd first.
- A neutral message (no product name) keeps the brand contract intact for rebranded distributions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent CLI crashes when launched from a deleted working directory. We validate `process.cwd()` at startup and fall back to the home directory on failure to avoid `uv_cwd` errors.

- **Bug Fixes**
  - Add a dependency-free startup guard (`src/valid-cwd.ts`) imported first in `src/cli.ts`, `src/cli-main.ts`, and `dist/cli.js`.
  - On error, switch to `homedir()` and log a one-line warning; child processes inherit the fixed cwd.
  - Add tests (`test/valid-cwd-guard.test.ts`) to reproduce the crash and verify recovery; update changelog.

<sup>Written for commit 699115152e49a8a96ad1a00ea4be255d896c7677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

