### PR TITLE
feat(coding-agent): resume completed goals explicitly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- `/goal resume` can explicitly reactivate a completed goal and queue its continuation, while completed goals remain excluded from automatic restart-resume prompts.
 - A launch from a deleted working directory (for example a removed worktree) no longer crashes during
   startup with `uv_cwd`; the CLI recovers into the home directory before any dependency evaluates
   `process.cwd()`.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -76,8 +76,9 @@ unfinished — `paused` or `blocked`. `isResumeOfStoppedGoal` (lifecycle-helpers
 owns that admission and `maybePromptResumeStoppedGoal` (index.ts) renders it;
 the title names the actual status (`Resume blocked goal?`). Accepting flips the
 goal to `active` as a `"user"` mutation and queues a continuation; declining
-leaves the status untouched. `active` and `complete` goals never prompt. This
-mirrors codex `maybe_prompt_resume_paused_goal_after_resume`, minus its
+leaves the status untouched. `active` and `complete` goals never prompt; a completed
+goal is revived only by an explicit `/goal resume`. This mirrors codex
+`maybe_prompt_resume_paused_goal_after_resume`, minus its
 `UsageLimited` arm, which senpi has no counterpart for.
 
 ## PERSISTENCE

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,26 @@
 # goal Extension Changes
 
+## Explicit resume revives completed goals (2026-08-11)
+
+### What changed
+
+- User-originated status mutations may transition a completed goal back to `active`, so `/goal resume` and app-server `thread/goal/set {status:"active"}` revive the existing goal and queue the normal continuation path.
+- Resuming clears `completedAt`, stamps `lastStartedAt`, and resets persisted continuation streak state through the existing status-transition behavior.
+- Model-originated transitions remain unchanged, `complete -> paused` remains illegal, and restart-resume prompting still excludes completed goals.
+
+### Why
+
+Codex permits an explicit user action to reactivate a completed thread goal. Senpi parsed `/goal resume` and wired continuation delivery correctly, but its user transition guard rejected `complete -> active` before that path could run.
+
+### Why this is not extension-only
+
+The transition guard is private to the builtin goal store and controls both the command and app-server wire paths. An external extension cannot authorize a new persisted status edge.
+
+### Merge-conflict zones
+
+- LOW in `transitions.ts` around the user transition set.
+- LOW in goal store and command-path tests covering completed-goal resume.
+
 ## Serialized goal mutations and stale-continuation cancellation (2026-08-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/transitions.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/transitions.ts
@@ -39,7 +39,8 @@ function isAllowedTransition(current: GoalStatus, next: GoalStatus, source: Goal
 	return (
 		(current === "active" && next === "paused") ||
 		(current === "paused" && next === "active") ||
-		(current === "blocked" && next === "active")
+		(current === "blocked" && next === "active") ||
+		(current === "complete" && next === "active")
 	);
 }
 

--- a/packages/coding-agent/test/suite/app-server-thread-goal.test.ts
+++ b/packages/coding-agent/test/suite/app-server-thread-goal.test.ts
@@ -107,6 +107,33 @@ describe("app-server thread goal handlers", () => {
 		});
 	});
 
+	it("reactivates a completed goal through thread/goal/set with user transition semantics", async () => {
+		// Given: a persistent thread whose goal was completed through the wire.
+		const { connection, registry, root } = await createHarness();
+		const threadId = threadIdFromResponse(
+			await registry.dispatch(connection, { id: 14, method: "thread/start", params: { cwd: root } }),
+		);
+		await registry.dispatch(connection, {
+			id: 15,
+			method: "thread/goal/set",
+			params: { threadId, objective: "Resume through app-server", status: "complete" },
+		});
+
+		// When: the client explicitly sets that completed goal back to active.
+		const resumed = await registry.dispatch(connection, {
+			id: 16,
+			method: "thread/goal/set",
+			params: { threadId, status: "active" },
+		});
+
+		// Then: the shared store accepts the same user transition as /goal resume.
+		expect(objectAt(responseResult(resumed), "goal")).toMatchObject({
+			threadId,
+			objective: "Resume through app-server",
+			status: "active",
+		});
+	});
+
 	it("broadcasts goal updates globally only after the response", async () => {
 		// Given: two initialized connections, with only the requester subscribed to the thread.
 		const deferredActions: Array<() => Promise<void> | void> = [];

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -19,6 +19,7 @@ interface GoalHarness {
 	commands: Map<string, { handler: (args: string, ctx: ExtensionContext) => Promise<void> }>;
 	handlers: Map<string, Handler[]>;
 	sent: SentMessage[];
+	continuationQueued: Promise<void>;
 }
 
 function createGoalHarness(): GoalHarness {
@@ -26,6 +27,10 @@ function createGoalHarness(): GoalHarness {
 	const commands = new Map<string, { handler: (args: string, ctx: ExtensionContext) => Promise<void> }>();
 	const handlers = new Map<string, Handler[]>();
 	const sent: SentMessage[] = [];
+	let markContinuationQueued: () => void = () => {};
+	const continuationQueued = new Promise<void>((resolve) => {
+		markContinuationQueued = resolve;
+	});
 	const pi = {
 		registerTool: (tool: AnyTool) => tools.set(tool.name, tool),
 		registerCommand: (name: string, options: { handler: (args: string, ctx: ExtensionContext) => Promise<void> }) =>
@@ -35,12 +40,15 @@ function createGoalHarness(): GoalHarness {
 			list.push(handler);
 			handlers.set(event, list);
 		},
-		sendMessage: (message: SentMessage["message"], options: unknown) => sent.push({ message, options }),
+		sendMessage: (message: SentMessage["message"], options: unknown) => {
+			sent.push({ message, options });
+			markContinuationQueued();
+		},
 		registerEntryRenderer: () => {},
 		appendEntry: () => {},
 	} as unknown as ExtensionAPI;
 	goalExtension(pi);
-	return { tools, commands, handlers, sent };
+	return { tools, commands, handlers, sent, continuationQueued };
 }
 
 const tempDirs: string[] = [];
@@ -557,6 +565,29 @@ describe("goal extension contract (budget-free)", () => {
 		await tools.get("create_goal")?.execute("c1", { objective: "Ship latest" }, undefined, undefined, ctx);
 		await tools.get("update_goal")?.execute("u1", { status: "complete" }, undefined, undefined, ctx);
 		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("complete");
+	});
+
+	it("resumes a completed goal through /goal and queues a continuation", async () => {
+		const notices: string[] = [];
+		const { tools, commands, sent, continuationQueued } = createGoalHarness();
+		const ctx = await makeNotifyingCtx(notices, "thread-command-resume-complete");
+		const ref = storeRefFor(ctx);
+		await tools
+			.get("create_goal")
+			?.execute("c1", { objective: "Resume through the command" }, undefined, undefined, ctx);
+		await tools.get("update_goal")?.execute("u1", { status: "complete" }, undefined, undefined, ctx);
+		const completed = await readGoal(ref);
+
+		await commands.get("goal")?.handler("resume", ctx);
+
+		const resumed = await readGoal(ref);
+		expect(resumed).toMatchObject({ id: completed?.id, status: "active" });
+		expect(resumed?.completedAt).toBeUndefined();
+		expect(resumed?.lastStartedAt).toBeGreaterThan(completed?.updatedAt ?? 0);
+		await continuationQueued;
+		expect(await readGoal(ref)).toMatchObject({ status: "active", consecutiveContinuations: 1 });
+		expect(sent.map((entry) => entry.message.customType)).toEqual(["goal-continuation"]);
+		expect(notices).not.toContain("illegal goal transition: complete -> active");
 	});
 
 	it("renders a live elapsed footer segment while a goal is actively pursued", async () => {

--- a/packages/coding-agent/test/suite/goal-store.test.ts
+++ b/packages/coding-agent/test/suite/goal-store.test.ts
@@ -773,6 +773,37 @@ describe("goal store (budget-free)", () => {
 		expect(completed.lastStartedAt).toBeUndefined();
 	});
 
+	it("lets a user resume a completed goal as the same active goal", async () => {
+		const ref = await tempStore("thread-resume-complete");
+		const created = await createGoal(ref, "Resume completed work");
+		const completed = await updateGoal(ref, { status: "complete" });
+		await recordContinuationDelivered(ref, `${created.id}:completed`);
+
+		const resumed = await updateGoal(ref, { status: "active" }, "user");
+
+		expect(resumed).toMatchObject({
+			id: created.id,
+			objective: created.objective,
+			status: "active",
+			consecutiveContinuations: 0,
+		});
+		expect(resumed.completedAt).toBeUndefined();
+		expect(resumed.lastStartedAt).toBeGreaterThan(completed.updatedAt);
+		expect(resumed.lastContinuationSignature).toBeUndefined();
+		expect(await readGoal(ref)).toEqual(resumed);
+	});
+
+	it("still rejects pausing a completed goal", async () => {
+		const ref = await tempStore("thread-pause-complete");
+		await createGoal(ref, "Keep completion terminal by default");
+		await updateGoal(ref, { status: "complete" });
+
+		await expect(updateGoal(ref, { status: "paused" }, "user")).rejects.toThrow(
+			"illegal goal transition: complete -> paused",
+		);
+		expect((await readGoal(ref))?.status).toBe("complete");
+	});
+
 	it("clears the store while preserving the versioned file", async () => {
 		const ref = await tempStore();
 		await createGoal(ref, "Temporary");


### PR DESCRIPTION
## Summary

- allow an explicit user transition from `complete` back to `active`
- make `/goal resume` revive the existing completed goal and queue the normal continuation
- preserve terminal-by-default behavior: model transitions are unchanged, `complete -> paused` is still illegal, and restart-resume prompts still exclude completed goals
- verify the app-server `thread/goal/set { status: "active" }` path shares the same behavior

## Why

Senpi already parsed `/goal resume` and wired accounting, UI refresh, and continuation delivery, but the goal transition guard rejected completed goals with `illegal goal transition: complete -> active`. Codex allows explicit user reactivation while still excluding completed goals from automatic restart prompting.

## Verification

- RED captured before production change: store and command tests failed on `complete -> active`
- focused GREEN: 4 passed
- required goal suites plus app-server parity: 166 passed across 8 files
- `npm run check`
- changelog gate: PASS
- isolated real-CLI QA: `create_goal` -> `update_goal complete` -> `/goal resume`
  - persisted status: `active`
  - `completedAt` cleared
  - continuation model request observed
  - continuation count recorded
  - sandbox removed, tmux session removed, real auth unchanged

QA receipts: `local-ignore/qa-evidence/20260811-goal-resume-completed/` (local, intentionally not committed).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable explicit resume of completed goals. Supports `/goal resume` and app-server `thread/goal/set { status: "active" }`, without changing model-driven transitions or restart prompts.

- **New Features**
  - Allow user-only transition `complete -> active`; `complete -> paused` remains illegal.
  - Resuming clears `completedAt`, updates `lastStartedAt`, resets continuation state, and queues a continuation.
  - Completed goals stay excluded from automatic restart-resume prompts; only explicit resume revives them.

<sup>Written for commit 1c2ffe3d276b76ea854936bb2cc38f3a871ab913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

