### PR TITLE
fix(coding-agent): require authenticated fallback responses

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Provider-specific OAuth availability checks can now reject empty sentinel credentials and recognize usable ambient
+  auth without refreshing or exposing tokens ([#803](https://github.com/code-yeongyu/senpi/pull/803)).
+
 ### Removed
 
 ## [2026.8.11-2] - 2026-08-10

--- a/packages/ai/src/auth/types.ts
+++ b/packages/ai/src/auth/types.ts
@@ -193,6 +193,13 @@ export interface OAuthAuth {
 	/** Selector label for the subscription login option, e.g. "Sign in with SuperGrok or X Premium". */
 	loginLabel?: string;
 
+	/**
+	 * Side-effect-free availability check. Providers with ambient OAuth or
+	 * sentinel credential envelopes can use this to decide whether they are
+	 * currently usable without refreshing or exposing credentials.
+	 */
+	check?(input: { ctx: AuthContext; credential?: OAuthCredential }): Promise<AuthCheck | undefined>;
+
 	login(interaction: AuthInteraction): Promise<OAuthCredential>;
 
 	/**

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,25 @@
 # AI Source Changes
 
+## 2026-08-11 - Provider-specific OAuth availability checks
+
+### What changed and why
+
+- `OAuthAuth` now supports an optional side-effect-free `check()` hook, symmetric with `ApiKeyAuth.check()`.
+- `Models.checkAuth()` invokes that hook for stored OAuth credentials and ambient no-credential providers. Providers
+  without a hook retain the previous behavior where any matching stored OAuth credential is configured.
+- This lets providers reject sentinel credential envelopes or confirm ambient OAuth without refreshing, resolving, or
+  exposing token material.
+
+### Why this cannot be expressed externally
+
+- Provider availability and model filtering happen inside `Models` before host registries and fallback controllers see
+  the provider, so an extension-only post-filter would leave `checkAuth()` and `getAvailable()` inconsistent.
+
+### Expected merge conflict zones
+
+- LOW: the additive `OAuthAuth.check` contract in `auth/types.ts`.
+- MEDIUM: the auth precedence branches in `models.ts`.
+
 ## 2026-08-09 - Native Anthropic prompt-cache warming primitive
 
 ### What changed and why

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -365,24 +365,39 @@ class ModelsImpl implements MutableModels {
 		provider: Provider,
 		credential: Credential | undefined,
 	): Promise<AuthCheck | undefined> {
+		const oauth = provider.auth.oauth;
 		if (credential?.type === "oauth") {
-			return provider.auth.oauth ? { source: "OAuth", type: "oauth" } : undefined;
-		}
-		const apiKey = provider.auth.apiKey;
-		if (!apiKey) return undefined;
-		if (apiKey.check) {
+			if (!oauth) return undefined;
+			if (!oauth.check) return { source: "OAuth", type: "oauth" };
 			try {
-				return await apiKey.check({
-					ctx: this.authContext,
-					credential: credential?.type === "api_key" ? credential : undefined,
-				});
+				return await oauth.check({ ctx: this.authContext, credential });
 			} catch (error) {
-				throw new ModelsError("auth", `API key auth check failed for provider ${provider.id}`, { cause: error });
+				throw new ModelsError("auth", `OAuth auth check failed for provider ${provider.id}`, { cause: error });
 			}
 		}
-
-		const resolution = await resolveProviderAuth(provider, this.credentials, this.authContext);
-		return resolution ? { source: resolution.source, type: "api_key" } : undefined;
+		const apiKey = provider.auth.apiKey;
+		if (apiKey) {
+			if (apiKey.check) {
+				try {
+					const result = await apiKey.check({
+						ctx: this.authContext,
+						credential: credential?.type === "api_key" ? credential : undefined,
+					});
+					if (result) return result;
+				} catch (error) {
+					throw new ModelsError("auth", `API key auth check failed for provider ${provider.id}`, { cause: error });
+				}
+			} else {
+				const resolution = await resolveProviderAuth(provider, this.credentials, this.authContext);
+				if (resolution) return { source: resolution.source, type: "api_key" };
+			}
+		}
+		if (!oauth?.check) return undefined;
+		try {
+			return await oauth.check({ ctx: this.authContext });
+		} catch (error) {
+			throw new ModelsError("auth", `OAuth auth check failed for provider ${provider.id}`, { cause: error });
+		}
 	}
 
 	async checkAuth(providerId: string): Promise<AuthCheck | undefined> {

--- a/packages/ai/test/models-runtime.test.ts
+++ b/packages/ai/test/models-runtime.test.ts
@@ -429,6 +429,40 @@ describe("Models runtime", () => {
 		expect((await models.getAvailable("ambient")).map((model) => model.provider)).toEqual(["ambient"]);
 	});
 
+	it("uses an OAuth availability check for stored and ambient auth", async () => {
+		const credentials = new InMemoryCredentialStore();
+		const check = vi.fn(async ({ credential }: { credential?: { access: string } }) =>
+			credential?.access === "usable" ? { source: "checked", type: "oauth" as const } : undefined,
+		);
+		const models = createModels({ credentials });
+		models.setProvider(
+			testProvider({
+				id: "oauth",
+				auth: { oauth: testOAuth({ check } as unknown as Partial<OAuthAuth>) },
+			}),
+		);
+
+		expect(await models.checkAuth("oauth")).toBeUndefined();
+		expect(check).toHaveBeenCalledTimes(1);
+		expect(check.mock.calls[0]?.[0].credential).toBeUndefined();
+
+		await credentials.modify("oauth", async () => ({
+			type: "oauth",
+			access: "empty",
+			refresh: "refresh",
+			expires: 0,
+		}));
+		expect(await models.checkAuth("oauth")).toBeUndefined();
+
+		await credentials.modify("oauth", async () => ({
+			type: "oauth",
+			access: "usable",
+			refresh: "refresh",
+			expires: 0,
+		}));
+		expect(await models.checkAuth("oauth")).toEqual({ source: "checked", type: "oauth" });
+	});
+
 	it("runs provider login and logout through the credential store", async () => {
 		const credentials = new InMemoryCredentialStore();
 		const apiKey = envKeyAuth(undefined);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,9 @@
 - A launch from a deleted working directory (for example a removed worktree) no longer crashes during
   startup with `uv_cwd`; the CLI recovers into the home directory before any dependency evaluates
   `process.cwd()`.
+- Claude SDK OAuth models are no longer selected as fallback candidates until a real local OAuth account exists,
+  and fallback responses carrying errors such as `Not logged in` no longer emit the green
+  `Fallback model responded` notice ([#803](https://github.com/code-yeongyu/senpi/pull/803)).
 
 ### New Features
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,8 +8,9 @@
 - A launch from a deleted working directory (for example a removed worktree) no longer crashes during
   startup with `uv_cwd`; the CLI recovers into the home directory before any dependency evaluates
   `process.cwd()`.
-- Claude SDK OAuth models are no longer selected as fallback candidates until a real local OAuth account exists,
-  and fallback responses carrying errors such as `Not logged in` no longer emit the green
+- Claude SDK OAuth models are selected as fallback candidates only when a stored account, environment token, or
+  authenticated ambient Claude CLI is usable. Empty sentinel credentials and logged-out local CLIs are skipped, and
+  fallback responses carrying errors such as `Not logged in` cannot emit an immediate or delayed green
   `Fallback model responded` notice ([#803](https://github.com/code-yeongyu/senpi/pull/803)).
 
 ### New Features

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,22 @@
+## Fallback responses with errors no longer emit success (2026-08-11)
+
+### What changed
+
+- `core/agent-session.ts` now requires an assistant response to have no `errorMessage` before it emits
+  `retry_fallback_succeeded` and `auto_retry_end { success: true }`.
+- A fallback provider response such as `Not logged in · Please run /login` can no longer produce the green
+  `Fallback model responded` notice merely because its stop reason was not normalized to `error`.
+
+### Why this cannot be expressed externally
+
+- Retry-attempt settlement and `retry_fallback_succeeded` emission occur inside private `AgentSession` lifecycle
+  state before extensions or interactive renderers can correct the classification.
+
+### Expected merge conflict zones
+
+- LOW: the assistant `message_end` success gate in `core/agent-session.ts`.
+- LOW: the focused hard-error fallback cases in `test/suite/retry-fallback-hard-error.test.ts`.
+
 ## Public filesystem policy exports (2026-08-09)
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -6,6 +6,8 @@
   `retry_fallback_succeeded` and `auto_retry_end { success: true }`.
 - A fallback provider response such as `Not logged in · Please run /login` can no longer produce the green
   `Fallback model responded` notice merely because its stop reason was not normalized to `error`.
+- A terminal errored fallback response also closes the active retry attempt with `auto_retry_end { success: false }`,
+  so a later successful user turn cannot emit a delayed success notice for the earlier failed fallback.
 
 ### Why this cannot be expressed externally
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1772,6 +1772,12 @@ export class AgentSession {
 				return;
 			}
 
+			if (retryOutcome === "not-handled" && this._retryAttempt > 0 && msg.errorMessage) {
+				const attempt = this._retryAttempt;
+				this._retryAttempt = 0;
+				this._resetHintTierState();
+				this._emit({ type: "auto_retry_end", success: false, attempt, finalError: msg.errorMessage });
+			}
 			this._resolveRetry();
 			retryContinuationBlocked ||= retryOutcome === "blocked";
 			if (!retryContinuationBlocked && !userAbortSuppressedQueuedContinuation) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1689,6 +1689,7 @@ export class AgentSession {
 
 				const assistantMsg = event.message as AssistantMessage;
 				const succeeded =
+					!assistantMsg.errorMessage &&
 					assistantMsg.stopReason !== "error" &&
 					assistantMsg.stopReason !== "aborted" &&
 					!isClassifierRefusal(assistantMsg);

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,22 @@
 # changes
 
+## Preserve extension OAuth availability checks (2026-08-11)
+
+### What changed
+
+- Extension provider OAuth configs can expose the additive `check()` availability hook from `pi-ai`.
+- `provider-composer.ts` carries that hook through `adaptOAuth()` so the canonical model runtime can classify stored
+  sentinel credentials and ambient OAuth sources without provider-specific core branches.
+
+### Why this cannot be expressed externally
+
+- Extension registration is normalized into canonical provider auth inside the core composer; without this adapter
+  field, the provider's hook is discarded before `Models.checkAuth()` runs.
+
+### Expected merge conflict zones
+
+- LOW: the additive `ExtensionOAuthConfig.check` field and `adaptOAuth()` spread in `provider-composer.ts`.
+
 ## Refresh server-fallback policy for active-turn model changes (2026-08-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/availability.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/availability.ts
@@ -1,0 +1,23 @@
+import { spawn } from "node:child_process";
+import { defaultExecutableDeps, resolveClaudeCodeExecutable } from "./executable.ts";
+
+export async function readAmbientClaudeAuthStatus(): Promise<boolean> {
+	let executable: string;
+	try {
+		executable = resolveClaudeCodeExecutable(defaultExecutableDeps());
+	} catch {
+		return false;
+	}
+
+	return new Promise((resolve) => {
+		let settled = false;
+		const finish = (available: boolean) => {
+			if (settled) return;
+			settled = true;
+			resolve(available);
+		};
+		const child = spawn(executable, ["auth", "status"], { stdio: "ignore" });
+		child.once("error", () => finish(false));
+		child.once("close", (code) => finish(code === 0));
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,17 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-11 - Require a real OAuth login for runtime availability
+
+- Removed the literal `apiKey: "claude-sdk-oauth-managed"` registration placeholder. Provider composition treated
+  that sentinel as configured API-key authentication, so a machine with no Claude SDK OAuth account still admitted
+  `claude-sdk-oauth` models into retry fallback selection before the subprocess returned `Not logged in`.
+- Kept OAuth registration, catalog discovery, login selection, and the SDK stream unchanged. A stored OAuth account
+  still makes the provider available; an empty credential store now leaves it registered but unavailable.
+- This cannot be implemented by an external extension: the false availability was created by this builtin provider's
+  own `registerProvider` authentication metadata before retry fallback evaluates candidates.
+- Expected merge conflict zones: LOW in `index.ts` provider registration and LOW in
+  `test/suite/claude-sdk-oauth-extension.test.ts`.
+
 ## 2026-08-07 - Ignore volatile thinking timing in continuity hashes
 
 - Removed `startedAt` and `endedAt` from thinking blocks before hashing the provider-final and committed assistant

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -5,12 +5,15 @@
 - Removed the literal `apiKey: "claude-sdk-oauth-managed"` registration placeholder. Provider composition treated
   that sentinel as configured API-key authentication, so a machine with no Claude SDK OAuth account still admitted
   `claude-sdk-oauth` models into retry fallback selection before the subprocess returned `Not logged in`.
-- Kept OAuth registration, catalog discovery, login selection, and the SDK stream unchanged. A stored OAuth account
-  still makes the provider available; an empty credential store now leaves it registered but unavailable.
+- Added a provider OAuth availability check that accepts a stored account, any `CLAUDE_CODE_OAUTH_TOKEN` slot, or a
+  successful `claude auth status` exit code. Empty and persisted `accounts: []` credentials remain unavailable.
+- The ambient probe resolves the same bundled/overridden Claude executable used by requests, discards its output, and
+  decides only from the documented exit status, so account identity and credentials never enter logs.
+- Kept OAuth registration, catalog discovery, login selection, and SDK streaming unchanged for every usable auth lane.
 - This cannot be implemented by an external extension: the false availability was created by this builtin provider's
-  own `registerProvider` authentication metadata before retry fallback evaluates candidates.
-- Expected merge conflict zones: LOW in `index.ts` provider registration and LOW in
-  `test/suite/claude-sdk-oauth-extension.test.ts`.
+  own auth metadata and must be resolved before retry fallback evaluates candidates.
+- Expected merge conflict zones: LOW in `index.ts`, `oauth-login.ts`, and `availability.ts`; LOW in the focused auth
+  status and extension registration tests.
 
 ## 2026-08-07 - Ignore volatile thinking timing in continuity hashes
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
@@ -43,7 +43,6 @@ export default function claudeSdkOauthExtension(pi: ExtensionAPI): void {
 	pi.registerProvider(CLAUDE_SDK_OAUTH_PROVIDER_ID, {
 		baseUrl: CLAUDE_SDK_OAUTH_PROVIDER_ID,
 		api: CLAUDE_SDK_OAUTH_PROVIDER_ID,
-		apiKey: "claude-sdk-oauth-managed",
 		models: MODELS,
 		streamSimple: streamClaudeSdkOauth,
 		oauth: createOAuthConfig({

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
@@ -11,6 +11,9 @@ import { registerSessionRegistry } from "./session-registry-wiring.ts";
 import { streamClaudeSdkOauth } from "./stream.ts";
 
 export { CLAUDE_SDK_OAUTH_PROVIDER_ID } from "./account-management.ts";
+export type ClaudeSdkOauthExtensionDeps = {
+	readAmbientAuthStatus?: () => Promise<boolean>;
+};
 
 const MODELS = getModels("anthropic").map((model) => ({
 	id: model.id,
@@ -37,7 +40,7 @@ function readStoredCredential(providerId: string): ClaudeSdkOauthCredential | un
 	}
 }
 
-export default function claudeSdkOauthExtension(pi: ExtensionAPI): void {
+export function registerClaudeSdkOauthExtension(pi: ExtensionAPI, deps: ClaudeSdkOauthExtensionDeps = {}): void {
 	registerClaudeAccountCommand(pi);
 	registerSessionRegistry(pi);
 	pi.registerProvider(CLAUDE_SDK_OAUTH_PROVIDER_ID, {
@@ -47,6 +50,7 @@ export default function claudeSdkOauthExtension(pi: ExtensionAPI): void {
 		streamSimple: streamClaudeSdkOauth,
 		oauth: createOAuthConfig({
 			readCurrent: async () => readStoredCredential(CLAUDE_SDK_OAUTH_PROVIDER_ID),
+			readAmbientAuthStatus: deps.readAmbientAuthStatus,
 			readAnthropicCredential: async () => {
 				const credential = readStoredCredential("anthropic");
 				return credential && typeof credential.access === "string"
@@ -55,4 +59,8 @@ export default function claudeSdkOauthExtension(pi: ExtensionAPI): void {
 			},
 		}),
 	});
+}
+
+export default function claudeSdkOauthExtension(pi: ExtensionAPI): void {
+	registerClaudeSdkOauthExtension(pi);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
@@ -1,4 +1,11 @@
-import type { AuthInteraction, OAuthAuth, OAuthCredentials } from "@earendil-works/pi-ai";
+import type {
+	AuthCheck,
+	AuthContext,
+	AuthInteraction,
+	OAuthAuth,
+	OAuthCredential,
+	OAuthCredentials,
+} from "@earendil-works/pi-ai";
 import { loadAnthropicOAuth } from "@earendil-works/pi-ai/oauth";
 import {
 	type AccountSlot,
@@ -8,6 +15,7 @@ import {
 	listAccounts,
 	SENTINEL_OAUTH_FIELDS,
 } from "./accounts.ts";
+import { readAmbientClaudeAuthStatus } from "./availability.ts";
 
 export type OAuthLoginCallbacks = {
 	signal?: AbortSignal;
@@ -21,12 +29,18 @@ export type CurrentCredentialReader = () => Promise<ClaudeSdkOauthCredential | u
 
 export type OAuthConfigShape = {
 	name: string;
+	check(input: { ctx: AuthContext; credential?: OAuthCredential }): Promise<AuthCheck | undefined>;
 	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;
 	refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
 	getApiKey(credentials: OAuthCredentials): string;
 };
 
 export const CLAUDE_SDK_OAUTH_NAME = "Claude SDK OAuth (Claude Pro/Max)";
+const ENV_TOKEN_NAMES = [
+	"CLAUDE_CODE_OAUTH_TOKEN",
+	...Array.from({ length: 15 }, (_, index) => `CLAUDE_CODE_OAUTH_TOKEN_${index + 2}`),
+] as const;
+const AUTH_CHECK = { source: "Claude SDK OAuth", type: "oauth" } as const;
 
 function toSlot(
 	credential: { access: string; refresh: string; expires: number },
@@ -51,10 +65,21 @@ async function promptAccountName(callbacks: OAuthLoginCallbacks, existing: Accou
 export function createOAuthConfig(deps: {
 	readCurrent: CurrentCredentialReader;
 	readAnthropicCredential?: () => Promise<{ access: string; refresh: string; expires: number } | undefined>;
+	readAmbientAuthStatus?: () => Promise<boolean>;
 	loginFlow?: OAuthAuth;
 }): OAuthConfigShape {
 	return {
 		name: CLAUDE_SDK_OAUTH_NAME,
+
+		async check({ ctx, credential }) {
+			const stored = credential as ClaudeSdkOauthCredential | undefined;
+			if (stored?.type === "oauth" && Array.isArray(stored.accounts) && stored.accounts.length > 0) {
+				return AUTH_CHECK;
+			}
+			const envTokens = await Promise.all(ENV_TOKEN_NAMES.map((name) => ctx.env(name)));
+			if (envTokens.some((token) => token !== undefined && token.length > 0)) return AUTH_CHECK;
+			return (await (deps.readAmbientAuthStatus ?? readAmbientClaudeAuthStatus)()) ? AUTH_CHECK : undefined;
+		},
 
 		async login(callbacks) {
 			const current = (await deps.readCurrent()) ?? emptyCredential();

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -1,6 +1,8 @@
 import {
 	type Api,
 	type AssistantMessageEventStream,
+	type AuthCheck,
+	type AuthContext,
 	type Context,
 	type Credential,
 	getApiProvider,
@@ -9,6 +11,7 @@ import {
 	lazyStream,
 	type Model,
 	type OAuthAuth,
+	type OAuthCredential,
 	type OAuthCredentials,
 	type OAuthLoginCallbacks,
 	type Provider,
@@ -34,6 +37,7 @@ export interface ExtensionOAuthConfig {
 	name: string;
 	/** @deprecated Retained for extension source compatibility; ignored by canonical auth flows. */
 	usesCallbackServer?: boolean;
+	check?(input: { ctx: AuthContext; credential?: OAuthCredential }): Promise<AuthCheck | undefined>;
 	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;
 	refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
 	getApiKey(credentials: OAuthCredentials): string;
@@ -266,6 +270,7 @@ function applyExtension(
 function adaptOAuth(config: ExtensionOAuthConfig): OAuthAuth {
 	return {
 		name: config.name,
+		...(config.check ? { check: config.check } : {}),
 		login: async (callbacks) => {
 			const credential = await config.login({
 				onAuth: (info) => callbacks.notify({ type: "auth_url", ...info }),

--- a/packages/coding-agent/test/claude-sdk-oauth-auth-status.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-auth-status.test.ts
@@ -1,0 +1,80 @@
+import type { AuthCheck, AuthContext, OAuthCredential } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { emptyCredential } from "../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
+import { createOAuthConfig } from "../src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts";
+
+type OAuthAvailabilityCheck = (input: {
+	ctx: AuthContext;
+	credential?: OAuthCredential;
+}) => Promise<AuthCheck | undefined>;
+
+function authContext(environment: Record<string, string> = {}): AuthContext {
+	return {
+		env: async (name) => environment[name],
+		fileExists: async () => false,
+	};
+}
+
+function availabilityCheck(readAmbientAuthStatus: () => Promise<boolean>): OAuthAvailabilityCheck {
+	const config = createOAuthConfig({
+		readCurrent: async () => undefined,
+		readAmbientAuthStatus,
+	} as Parameters<typeof createOAuthConfig>[0] & {
+		readAmbientAuthStatus: () => Promise<boolean>;
+	}) as ReturnType<typeof createOAuthConfig> & { check?: OAuthAvailabilityCheck };
+	expect(config.check).toBeTypeOf("function");
+	return config.check as OAuthAvailabilityCheck;
+}
+
+describe("claude-sdk-oauth availability", () => {
+	it("accepts a stored managed account without probing ambient auth", async () => {
+		const readAmbientAuthStatus = vi.fn(async () => false);
+		const check = availabilityCheck(readAmbientAuthStatus);
+		const credential = {
+			...emptyCredential(),
+			accounts: [
+				{
+					name: "managed",
+					refresh: "refresh",
+					access: "access",
+					expires: Date.now() + 60_000,
+					source: "login" as const,
+				},
+			],
+		};
+
+		expect(await check({ ctx: authContext(), credential })).toEqual({
+			type: "oauth",
+			source: "Claude SDK OAuth",
+		});
+		expect(readAmbientAuthStatus).not.toHaveBeenCalled();
+	});
+
+	it("rejects a persisted empty managed credential when ambient auth is logged out", async () => {
+		const check = availabilityCheck(async () => false);
+		expect(await check({ ctx: authContext(), credential: emptyCredential() })).toBeUndefined();
+	});
+
+	it("accepts an environment OAuth token without probing ambient auth", async () => {
+		const readAmbientAuthStatus = vi.fn(async () => false);
+		const check = availabilityCheck(readAmbientAuthStatus);
+		expect(await check({ ctx: authContext({ CLAUDE_CODE_OAUTH_TOKEN: "env-token" }) })).toEqual({
+			type: "oauth",
+			source: "Claude SDK OAuth",
+		});
+		expect(readAmbientAuthStatus).not.toHaveBeenCalled();
+	});
+
+	it("accepts an authenticated ambient Claude CLI", async () => {
+		const check = availabilityCheck(async () => true);
+		expect(await check({ ctx: authContext() })).toEqual({
+			type: "oauth",
+			source: "Claude SDK OAuth",
+		});
+	});
+
+	it("rejects a logged-out ambient Claude CLI", async () => {
+		const check = availabilityCheck(async () => false);
+		expect(await check({ ctx: authContext() })).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/suite/claude-sdk-oauth-extension.test.ts
+++ b/packages/coding-agent/test/suite/claude-sdk-oauth-extension.test.ts
@@ -1,10 +1,10 @@
 import { type Api, type Context, createAssistantMessageEventStream, type Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { emptyCredential } from "../../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
 import claudeSdkOauthExtension, {
 	CLAUDE_SDK_OAUTH_PROVIDER_ID,
 } from "../../src/core/extensions/builtin/claude-sdk-oauth/index.ts";
-import { emptyCredential } from "../../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
 import type { ExtensionAPI } from "../../src/core/extensions/types.ts";
 import { ModelRuntime } from "../../src/core/model-runtime.ts";

--- a/packages/coding-agent/test/suite/claude-sdk-oauth-extension.test.ts
+++ b/packages/coding-agent/test/suite/claude-sdk-oauth-extension.test.ts
@@ -1,9 +1,10 @@
 import { type Api, type Context, createAssistantMessageEventStream, type Model } from "@earendil-works/pi-ai";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { emptyCredential } from "../../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
-import claudeSdkOauthExtension, {
+import {
 	CLAUDE_SDK_OAUTH_PROVIDER_ID,
+	registerClaudeSdkOauthExtension,
 } from "../../src/core/extensions/builtin/claude-sdk-oauth/index.ts";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
 import type { ExtensionAPI } from "../../src/core/extensions/types.ts";
@@ -12,7 +13,9 @@ import type { ProviderConfigInput } from "../../src/core/provider-composer.ts";
 
 type Registration = { name: string; config: ProviderConfigInput };
 
-function captureRegistration(): { registration: Registration } {
+function captureRegistration(readAmbientAuthStatus: () => Promise<boolean> = async () => false): {
+	registration: Registration;
+} {
 	let captured: Registration | undefined;
 	const pi = {
 		registerProvider: (name: string, config: ProviderConfigInput) => {
@@ -23,7 +26,7 @@ function captureRegistration(): { registration: Registration } {
 		getFlag: () => undefined,
 		on: (..._args: unknown[]) => {},
 	} as unknown as ExtensionAPI;
-	claudeSdkOauthExtension(pi);
+	registerClaudeSdkOauthExtension(pi, { readAmbientAuthStatus });
 	if (!captured) throw new Error("extension did not register a provider");
 	return { registration: captured };
 }
@@ -61,6 +64,10 @@ function authenticatedStorage(): AuthStorage {
 }
 
 describe("claude-sdk-oauth builtin provider", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
 	it("registers the provider with OAuth, catalog models and a stream fn", () => {
 		const { registration } = captureRegistration();
 		const builtinIds = builtinExtensions.map((extension) => extension.id);
@@ -82,11 +89,34 @@ describe("claude-sdk-oauth builtin provider", () => {
 		expect(await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toEqual([]);
 	});
 
+	it("keeps claude-sdk-oauth unavailable with a persisted empty credential", async () => {
+		const { registration } = captureRegistration();
+		const storage = AuthStorage.inMemory({ [CLAUDE_SDK_OAUTH_PROVIDER_ID]: emptyCredential() });
+		const runtime = await createRuntimeWithProvider(registration.config, storage);
+		expect(runtime.hasConfiguredAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(false);
+		expect(await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toEqual([]);
+	});
+
 	it("keeps claude-sdk-oauth available with a stored login", async () => {
 		const { registration } = captureRegistration();
 		const runtime = await createRuntimeWithProvider(registration.config, authenticatedStorage());
 		expect(runtime.hasConfiguredAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(true);
 		expect(runtime.isUsingOAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(true);
+		expect(await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID)).not.toEqual([]);
+	});
+
+	it("keeps claude-sdk-oauth available with an environment token", async () => {
+		vi.stubEnv("CLAUDE_CODE_OAUTH_TOKEN", "env-token");
+		const { registration } = captureRegistration();
+		const runtime = await createRuntimeWithProvider(registration.config);
+		expect(runtime.hasConfiguredAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(true);
+		expect(await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID)).not.toEqual([]);
+	});
+
+	it("keeps claude-sdk-oauth available with an authenticated ambient CLI", async () => {
+		const { registration } = captureRegistration(async () => true);
+		const runtime = await createRuntimeWithProvider(registration.config);
+		expect(runtime.hasConfiguredAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(true);
 		expect(await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID)).not.toEqual([]);
 	});
 

--- a/packages/coding-agent/test/suite/claude-sdk-oauth-extension.test.ts
+++ b/packages/coding-agent/test/suite/claude-sdk-oauth-extension.test.ts
@@ -4,6 +4,7 @@ import { AuthStorage } from "../../src/core/auth-storage.ts";
 import claudeSdkOauthExtension, {
 	CLAUDE_SDK_OAUTH_PROVIDER_ID,
 } from "../../src/core/extensions/builtin/claude-sdk-oauth/index.ts";
+import { emptyCredential } from "../../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
 import type { ExtensionAPI } from "../../src/core/extensions/types.ts";
 import { ModelRuntime } from "../../src/core/model-runtime.ts";
@@ -42,8 +43,25 @@ async function createRuntimeWithProvider(config: ProviderConfigInput, storage = 
 	return runtime;
 }
 
+function authenticatedStorage(): AuthStorage {
+	return AuthStorage.inMemory({
+		[CLAUDE_SDK_OAUTH_PROVIDER_ID]: {
+			...emptyCredential(),
+			accounts: [
+				{
+					name: "test",
+					refresh: "test-refresh",
+					access: "test-access",
+					expires: Date.now() + 60_000,
+					source: "login",
+				},
+			],
+		},
+	});
+}
+
 describe("claude-sdk-oauth builtin provider", () => {
-	it("registers the provider with sentinel auth, catalog models and a stream fn", () => {
+	it("registers the provider with OAuth, catalog models and a stream fn", () => {
 		const { registration } = captureRegistration();
 		const builtinIds = builtinExtensions.map((extension) => extension.id);
 		expect(CLAUDE_SDK_OAUTH_PROVIDER_ID).toBe("claude-sdk-oauth");
@@ -52,15 +70,24 @@ describe("claude-sdk-oauth builtin provider", () => {
 		expect(builtinIds).not.toContain("claude-oauth");
 		expect(registration.name).toBe(CLAUDE_SDK_OAUTH_PROVIDER_ID);
 		expect(registration.config.baseUrl).toBe(CLAUDE_SDK_OAUTH_PROVIDER_ID);
+		expect(registration.config.apiKey).toBeUndefined();
 		expect(registration.config.models?.length).toBeGreaterThan(0);
 		expect(typeof registration.config.streamSimple).toBe("function");
 	});
 
-	it("lists claude-sdk-oauth models in the runtime registry", async () => {
+	it("keeps claude-sdk-oauth unavailable without a stored login", async () => {
 		const { registration } = captureRegistration();
 		const runtime = await createRuntimeWithProvider(registration.config);
-		const ids = (await runtime.getAvailable()).map((model) => `${model.provider}/${model.id}`);
-		expect(ids.some((id) => id.startsWith(`${CLAUDE_SDK_OAUTH_PROVIDER_ID}/`))).toBe(true);
+		expect(runtime.hasConfiguredAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(false);
+		expect(await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toEqual([]);
+	});
+
+	it("keeps claude-sdk-oauth available with a stored login", async () => {
+		const { registration } = captureRegistration();
+		const runtime = await createRuntimeWithProvider(registration.config, authenticatedStorage());
+		expect(runtime.hasConfiguredAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(true);
+		expect(runtime.isUsingOAuth(CLAUDE_SDK_OAUTH_PROVIDER_ID)).toBe(true);
+		expect(await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID)).not.toEqual([]);
 	});
 
 	it("login selector lists the provider as oauth after registration", async () => {
@@ -73,7 +100,7 @@ describe("claude-sdk-oauth builtin provider", () => {
 		});
 	});
 
-	it("preflight reaches streamSimple with zero stored credentials", async () => {
+	it("preflight reaches streamSimple with a stored login", async () => {
 		const { registration } = captureRegistration();
 		let called = false;
 		const config: ProviderConfigInput = {
@@ -83,7 +110,7 @@ describe("claude-sdk-oauth builtin provider", () => {
 				return fakeStreamSimple()(model, context);
 			},
 		};
-		const runtime = await createRuntimeWithProvider(config);
+		const runtime = await createRuntimeWithProvider(config, authenticatedStorage());
 		const model = (await runtime.getAvailable(CLAUDE_SDK_OAUTH_PROVIDER_ID))[0];
 		expect(model).toBeDefined();
 		const stream = runtime.streamSimple(model as Model<Api>, { messages: [], tools: [] } as unknown as Context);

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -70,12 +70,18 @@ describe("retry fallback hard errors", () => {
 		harness.setResponses([
 			fauxAssistantMessage("", { stopReason: "error", errorMessage: insufficientQuota }),
 			fauxAssistantMessage(authError, { stopReason: "stop", errorMessage: authError }),
+			fauxAssistantMessage("next turn succeeds"),
 		]);
 
 		await harness.session.prompt("hello");
 
 		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
 		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(1);
+		expect(harness.eventsOfType("retry_fallback_succeeded")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_end").filter((event) => event.success)).toEqual([]);
+
+		await harness.session.prompt("next");
+
 		expect(harness.eventsOfType("retry_fallback_succeeded")).toEqual([]);
 		expect(harness.eventsOfType("auto_retry_end").filter((event) => event.success)).toEqual([]);
 	});

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -58,6 +58,28 @@ describe("retry fallback hard errors", () => {
 		expect(cooldownsFor(harness).isSuppressed(primary)).toBe(true);
 	});
 
+	it("does not report a fallback auth error as a successful response", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 60_000, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		const authError = "Not logged in · Please run /login";
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: insufficientQuota }),
+			fauxAssistantMessage(authError, { stopReason: "stop", errorMessage: authError }),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(1);
+		expect(harness.eventsOfType("retry_fallback_succeeded")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_end").filter((event) => event.success)).toEqual([]);
+	});
+
 	it("settles an insufficient-quota error without a configured fallback", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, baseDelayMs: 1 } } });
 		harnesses.push(harness);


### PR DESCRIPTION
## Summary

- exclude `claude-sdk-oauth` fallback candidates when the local Claude CLI is logged out or the persisted OAuth envelope has no accounts
- preserve availability for stored accounts, `CLAUDE_CODE_OAUTH_TOKEN` slots, and an authenticated ambient Claude CLI
- prevent errored fallback responses from emitting `retry_fallback_succeeded`, including a delayed false success on the next user turn
- add provider-neutral optional `OAuthAuth.check` support and preserve it through extension provider composition

## RED -> GREEN

- no stored login: `criterion-1-red.txt` -> `criterion-1-green.txt`
- immediate auth-error false success: `criterion-2-red.txt` -> `criterion-2-green.txt`
- delayed next-turn false success: `review-delayed-success-red.txt` -> `review-delayed-success-green.txt`
- persisted `accounts: []` sentinel: `review-empty-sentinel-red.txt` -> final auth matrix GREEN
- provider-neutral OAuth check dispatch: `review-ai-oauth-check-red.txt` -> `review-ai-oauth-check-green.txt`
- managed/env/ambient Claude auth matrix: `review-claude-auth-status-red.txt` -> `review-claude-auth-status-green.txt`

Evidence root:
`local-ignore/qa-evidence/20260811-claude-sdk-oauth-fallback/`

## Verification

- AI auth regressions: 5 files / 63 tests passed
- coding-agent Claude/fallback regressions: 41 files / 375 passed, 3 pre-existing skipped
- retry-state adjacent regressions: 4 files / 48 tests passed
- root `npm run check`: Biome, pinned dependencies, TS imports, shrinkwrap/install-lock, TypeScript, and browser smoke passed
- changelog gate: both `packages/ai` and `packages/coding-agent` Unreleased entries linked to #803

## Real-surface QA

Final real-host driver:

```text
localClaudeLoggedIn=false
unauthenticatedCandidate=false
emptySentinelCandidate=false
envTokenCandidate=true
authenticatedCandidate=true
authErrorSuccessEvents=0
successfulRetryEnds=0
```

- real CLI mock-loop `server-error-fallback`: 2/2 passed
- real tmux TUI smoke: 5/5 passed
- real auth file unchanged
- no QA process, listener, or tmux leak; cleanup receipts retained

## Review

Final review-work verdicts:

- goal / constraints: PASS
- hands-on QA: PASS
- code quality: PASS
- security: PASS
- repository / PR context: PASS

Review blockers found during the first round were fixed and re-reviewed: persisted empty credentials, env/ambient availability, and delayed retry-state success.

## Upstream movement

PR #804 merged while this PR was under review. This branch merged current `origin/main` with a two-parent merge commit, preserved #804's historical changelog/ledger entries, and deliberately retained #803's stricter logged-out ambient check plus the fallback-success fixes. Post-merge regressions, root checks, real-host driver, mock-loop, TUI smoke, and cleanup all passed.

## Residual risk

`claude auth status` is a local exit-code probe with stdout/stderr discarded. It currently has no explicit timeout; spawn errors and non-zero exits fail closed.
