### PR TITLE
fix(claude-sdk-oauth): skip fallback when a managed lane has no account

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Fixed
 
+- `OAuthAuth` accepts an optional availability `check` that `checkProviderAuth` consults in the stored-OAuth
+  branch, so a provider whose stored credential does not by itself imply usability (for example a zero-account
+  sentinel) is no longer reported as configured. When `check` is absent, behavior is unchanged
+  ([#804](https://github.com/code-yeongyu/senpi/pull/804)).
+
 ### Removed
 
 ## [2026.8.11-2] - 2026-08-10

--- a/packages/ai/src/auth/types.ts
+++ b/packages/ai/src/auth/types.ts
@@ -202,6 +202,14 @@ export interface OAuthAuth {
 	refresh(credential: OAuthCredential, signal?: AbortSignal): Promise<OAuthCredential>;
 
 	/**
+	 * Optional side-effect-free availability check, mirroring `ApiKeyAuth.check`.
+	 * Supply this when a stored OAuth credential does not by itself imply the
+	 * provider is usable — for example a sentinel envelope that carries zero
+	 * accounts. When absent, any stored OAuth credential counts as configured.
+	 */
+	check?(input: { ctx: AuthContext; credential?: OAuthCredential }): Promise<AuthCheck | undefined>;
+
+	/**
 	 * Side-effect-free derivation of request auth from a valid credential.
 	 * Covers per-credential baseUrl (GitHub Copilot). Async so lazy wrappers
 	 * can load the implementation on first use.

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,15 @@
 # AI Source Changes
 
+## 2026-08-11 - Optional availability `check` on `OAuthAuth`
+
+### What changed and why
+
+Added an optional `check?(input)` to `OAuthAuth` (`auth/types.ts`) and taught `checkProviderAuth` (`models.ts`) to consult it in the stored-OAuth-credential branch. Previously that branch was a pure structural short-circuit — `provider.auth.oauth ? {configured} : undefined` — so any stored OAuth credential, including an empty sentinel envelope with zero accounts, reported the provider as configured. The fallback engine reads configured-ness through `hasConfiguredAuth`, so such a provider was never skipped as `unauthenticated`. `ApiKeyAuth` already exposes an equivalent `check`; this makes the OAuth path symmetric. When `check` is absent, behavior is byte-identical to before, so every existing OAuth provider is unaffected. This cannot be extension-local: the short-circuit lives in `ModelsImpl.checkProviderAuth`, which no extension hook reaches, and `OAuthAuth` had no `check` to supply.
+
+### Expected merge-conflict zones
+
+LOW in `auth/types.ts` (additive optional field on `OAuthAuth`); LOW in `models.ts` `checkProviderAuth` (one stored-OAuth branch expanded, existing behavior preserved when `check` is undefined).
+
 ## 2026-08-09 - Native Anthropic prompt-cache warming primitive
 
 ### What changed and why

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -366,7 +366,11 @@ class ModelsImpl implements MutableModels {
 		credential: Credential | undefined,
 	): Promise<AuthCheck | undefined> {
 		if (credential?.type === "oauth") {
-			return provider.auth.oauth ? { source: "OAuth", type: "oauth" } : undefined;
+			if (!provider.auth.oauth) return undefined;
+			if (provider.auth.oauth.check) {
+				return provider.auth.oauth.check({ ctx: this.authContext, credential });
+			}
+			return { source: "OAuth", type: "oauth" };
 		}
 		const apiKey = provider.auth.apiKey;
 		if (!apiKey) return undefined;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,10 @@
 - A launch from a deleted working directory (for example a removed worktree) no longer crashes during
   startup with `uv_cwd`; the CLI recovers into the home directory before any dependency evaluates
   `process.cwd()`.
+- `claude-sdk-oauth` is now skipped as an unauthenticated fallback candidate on a managed lane
+  (`oauth-slots`/`config-dir`) when no account is logged in, instead of always counting as configured because its
+  stored credential is a zero-account sentinel. The ambient lane is unchanged and still defers to the spawned
+  Claude Code engine ([#804](https://github.com/code-yeongyu/senpi/pull/804)).
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,23 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-11 - Account-aware auth availability for fallback
+
+### What changed
+
+`createOAuthConfig` (`oauth-login.ts`) now supplies an OAuth `check`, and `index.ts` passes a `readSettings` dep so that check can read the configured `tokenInjection` lane. `ExtensionOAuthConfig` (`provider-composer.ts`) gained an optional `check` that `adaptOAuth` forwards to the composed `OAuthAuth`. The provider still registers the `claude-sdk-oauth-managed` api-key sentinel, which keeps the ambient default configured (see below); only the stored-OAuth-credential path becomes account-aware.
+
+### Why
+
+The fallback engine never skipped this provider as `unauthenticated`. A stored `emptyCredential()` is `{ type: "oauth", ...SENTINEL_OAUTH_FIELDS, accounts: [] }`, and the upstream stored-OAuth branch in `ModelsImpl.checkProviderAuth` reported configured for any OAuth credential without inspecting `accounts`, so a zero-account sentinel still counted as logged in. The new `check` returns configured only when `listAccounts` finds at least one account (stored login/import or a `CLAUDE_CODE_OAUTH_TOKEN` env slot); on a managed lane (`oauth-slots`/`config-dir`) with zero accounts it returns unconfigured so the candidate is skipped. The ambient lane stays configured with zero accounts because the spawned Claude Code engine may hold its own login that senpi cannot see — that deferral is intentional (`auth-lane.ts`, `docs/providers.md`).
+
+### Why an extension could not handle it
+
+The stored-OAuth branch in `ModelsImpl.checkProviderAuth` is a structural short-circuit with no extension hook, and `OAuthAuth` had no `check` field (unlike `ApiKeyAuth`). `Provider.filterModels` filters the catalog in `getAvailable()` but cannot influence `configuredProviders` / `hasConfiguredAuth`, which the fallback controller reads. So the availability decision required the upstream `OAuthAuth.check` added in the companion `packages/ai` change; this extension only supplies the account-aware implementation.
+
+### Expected merge-conflict zones
+
+LOW in `oauth-login.ts` (added `check` to the returned shape + optional `readSettings` dep); LOW in `index.ts` (one added `readSettings` line); LOW in `provider-composer.ts` (`ExtensionOAuthConfig.check` + `adaptOAuth` forwarding, both additive).
+
 ## 2026-08-07 - Ignore volatile thinking timing in continuity hashes
 
 - Removed `startedAt` and `endedAt` from thinking blocks before hashing the provider-final and committed assistant

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/index.ts
@@ -8,6 +8,7 @@ import { CLAUDE_SDK_OAUTH_PROVIDER_ID } from "./account-management.ts";
 import type { ClaudeSdkOauthCredential } from "./accounts.ts";
 import { createOAuthConfig } from "./oauth-login.ts";
 import { registerSessionRegistry } from "./session-registry-wiring.ts";
+import { loadClaudeSdkOauthProviderSettingsFromDisk } from "./settings.ts";
 import { streamClaudeSdkOauth } from "./stream.ts";
 
 export { CLAUDE_SDK_OAUTH_PROVIDER_ID } from "./account-management.ts";
@@ -54,6 +55,7 @@ export default function claudeSdkOauthExtension(pi: ExtensionAPI): void {
 					? { access: credential.access, refresh: credential.refresh, expires: credential.expires }
 					: undefined;
 			},
+			readSettings: () => loadClaudeSdkOauthProviderSettingsFromDisk(process.cwd()),
 		}),
 	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
@@ -1,4 +1,4 @@
-import type { AuthInteraction, OAuthAuth, OAuthCredentials } from "@earendil-works/pi-ai";
+import type { AuthContext, AuthInteraction, OAuthAuth, OAuthCredentials } from "@earendil-works/pi-ai";
 import { loadAnthropicOAuth } from "@earendil-works/pi-ai/oauth";
 import {
 	type AccountSlot,
@@ -24,9 +24,15 @@ export type OAuthConfigShape = {
 	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;
 	refreshToken(credentials: OAuthCredentials): Promise<OAuthCredentials>;
 	getApiKey(credentials: OAuthCredentials): string;
+	check(input: {
+		ctx: AuthContext;
+		credential?: OAuthCredentials;
+	}): Promise<{ source: string; type: "oauth" } | undefined>;
 };
 
 export const CLAUDE_SDK_OAUTH_NAME = "Claude SDK OAuth (Claude Pro/Max)";
+
+const OAUTH_CONFIGURED: { source: string; type: "oauth" } = { source: "OAuth", type: "oauth" };
 
 function toSlot(
 	credential: { access: string; refresh: string; expires: number },
@@ -52,9 +58,19 @@ export function createOAuthConfig(deps: {
 	readCurrent: CurrentCredentialReader;
 	readAnthropicCredential?: () => Promise<{ access: string; refresh: string; expires: number } | undefined>;
 	loginFlow?: OAuthAuth;
+	readSettings?: () => { tokenInjection?: "ambient" | "oauth-slots" | "config-dir" } | undefined;
 }): OAuthConfigShape {
 	return {
 		name: CLAUDE_SDK_OAUTH_NAME,
+
+		async check({ credential }) {
+			const stored = credential as ClaudeSdkOauthCredential | undefined;
+			const env = (name: string) => process.env[name];
+			const accounts = listAccounts(stored ?? emptyCredential(), env);
+			if (accounts.length > 0) return OAUTH_CONFIGURED;
+			const lane = deps.readSettings?.()?.tokenInjection ?? "ambient";
+			return lane === "ambient" ? OAUTH_CONFIGURED : undefined;
+		},
 
 		async login(callbacks) {
 			const current = (await deps.readCurrent()) ?? emptyCredential();

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -1,6 +1,8 @@
 import {
 	type Api,
 	type AssistantMessageEventStream,
+	type AuthCheck,
+	type AuthContext,
 	type Context,
 	type Credential,
 	getApiProvider,
@@ -32,6 +34,8 @@ import {
 
 export interface ExtensionOAuthConfig {
 	name: string;
+	/** Optional availability check forwarded to `OAuthAuth.check`; absent means any stored OAuth credential counts as configured. */
+	check?(input: { ctx: AuthContext; credential?: OAuthCredentials }): Promise<AuthCheck | undefined>;
 	/** @deprecated Retained for extension source compatibility; ignored by canonical auth flows. */
 	usesCallbackServer?: boolean;
 	login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials>;
@@ -280,6 +284,14 @@ function adaptOAuth(config: ExtensionOAuthConfig): OAuthAuth {
 		},
 		refresh: async (credential) => ({ ...(await config.refreshToken(credential)), type: "oauth" }),
 		toAuth: async (credential) => ({ apiKey: config.getApiKey(credential) }),
+		...(config.check
+			? {
+					check: (input: { ctx: AuthContext; credential?: OAuthCredentials }) => {
+						const check = config.check;
+						return check ? check(input) : Promise.resolve(undefined);
+					},
+				}
+			: {}),
 	};
 }
 

--- a/packages/coding-agent/test/claude-sdk-oauth-auth-status.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-auth-status.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createModels, InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type ClaudeSdkOauthCredential,
+	emptyCredential,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
+import { createOAuthConfig } from "../src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts";
+import { ModelConfig } from "../src/core/model-config.ts";
+import { composeModelProvider } from "../src/core/provider-composer.ts";
+
+const PROVIDER = "claude-sdk-oauth";
+const SENTINEL_API_KEY = "claude-sdk-oauth-managed";
+const MODELS = [
+	{
+		id: "claude-opus-5",
+		name: "Opus",
+		reasoning: true,
+		input: ["text"] as "text"[],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+	},
+];
+const temporaryDirectories: string[] = [];
+
+function makeConfig(): ModelConfig {
+	const directory = mkdtempSync(join(tmpdir(), "senpi-claude-sdk-oauth-auth-status-"));
+	temporaryDirectories.push(directory);
+	const modelsPath = join(directory, "models.json");
+	writeFileSync(modelsPath, JSON.stringify({ providers: {} }), "utf8");
+	return ModelConfig.loadSync(modelsPath);
+}
+
+function oneAccount(): ClaudeSdkOauthCredential {
+	return {
+		...emptyCredential(),
+		accounts: [{ name: "default", access: "a", refresh: "r", expires: Date.now() + 60_000, source: "login" }],
+	};
+}
+
+type Lane = "ambient" | "oauth-slots";
+
+function extension(lane: Lane) {
+	return {
+		baseUrl: PROVIDER,
+		api: PROVIDER,
+		apiKey: SENTINEL_API_KEY,
+		models: MODELS,
+		streamSimple: () => {
+			throw new Error("unused in auth-status tests");
+		},
+		oauth: createOAuthConfig({
+			readCurrent: async () => undefined,
+			readSettings: () => ({ tokenInjection: lane }),
+		}),
+	};
+}
+
+async function checkAuth(lane: Lane, credential: ClaudeSdkOauthCredential | undefined) {
+	const provider = composeModelProvider(PROVIDER, undefined, makeConfig(), extension(lane));
+	const store = new InMemoryCredentialStore();
+	if (credential) await store.modify(PROVIDER, async () => credential);
+	const models = createModels({ credentials: store });
+	models.setProvider(provider);
+	return models.checkAuth(PROVIDER);
+}
+
+afterEach(() => {
+	while (temporaryDirectories.length > 0) {
+		const directory = temporaryDirectories.pop();
+		if (directory) rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("claude-sdk-oauth fallback auth status", () => {
+	describe("#given a managed lane and an empty sentinel credential", () => {
+		describe("#when the fallback runtime checks auth", () => {
+			it("#then the provider is unconfigured so the candidate is skipped", async () => {
+				// given the zero-account sentinel envelope
+				const credential = emptyCredential();
+
+				// when
+				const result = await checkAuth("oauth-slots", credential);
+
+				// then
+				expect(result).toBeUndefined();
+			});
+		});
+	});
+
+	describe("#given a managed lane and one stored login account", () => {
+		describe("#when the fallback runtime checks auth", () => {
+			it("#then the provider stays configured", async () => {
+				// given
+				const credential = oneAccount();
+
+				// when
+				const result = await checkAuth("oauth-slots", credential);
+
+				// then
+				expect(result).toEqual({ source: "OAuth", type: "oauth" });
+			});
+		});
+	});
+
+	describe("#given the ambient lane and an empty sentinel credential", () => {
+		describe("#when the fallback runtime checks auth", () => {
+			it("#then the provider stays configured because the spawned engine may hold its own login", async () => {
+				// given
+				const credential = emptyCredential();
+
+				// when
+				const result = await checkAuth("ambient", credential);
+
+				// then
+				expect(result).toEqual({ source: "OAuth", type: "oauth" });
+			});
+		});
+	});
+
+	describe("#given the ambient lane and no stored credential", () => {
+		describe("#when the fallback runtime checks auth", () => {
+			it("#then the provider stays configured via the sentinel api key", async () => {
+				// given no stored credential
+
+				// when
+				const result = await checkAuth("ambient", undefined);
+
+				// then
+				expect(result).toEqual({ type: "api_key", source: "configured API key" });
+			});
+		});
+	});
+});


### PR DESCRIPTION
## What

Fixes the retry-fallback engine never skipping `claude-sdk-oauth` as `unauthenticated`, so a run with no Claude login kept falling back to `claude-sdk-oauth/claude-opus-5` instead of a genuinely usable alternative.

## Why

A stored `emptyCredential()` is an OAuth-typed sentinel (`{ type: "oauth", ...SENTINEL_OAUTH_FIELDS, accounts: [] }`, `accounts.ts`). The stored-OAuth branch in `ModelsImpl.checkProviderAuth` (`packages/ai/src/models.ts`) reported **configured for any OAuth credential without inspecting `accounts`**, so a zero-account sentinel still counted as logged in. The fallback controller reads configured-ness through `hasConfiguredAuth`, so the candidate was never skipped.

## How (additive, 4 files)

- `packages/ai/src/auth/types.ts` — `OAuthAuth` gains an optional `check?` (mirrors the existing `ApiKeyAuth.check`).
- `packages/ai/src/models.ts` — `checkProviderAuth`'s stored-OAuth branch consults `oauth.check` when present; behavior is unchanged when absent.
- `packages/coding-agent/src/core/provider-composer.ts` — `ExtensionOAuthConfig.check` added; `adaptOAuth` forwards it.
- `claude-sdk-oauth/oauth-login.ts` + `index.ts` — `createOAuthConfig` supplies a lane-aware `check`, fed a `readSettings` dep.

**Semantics:** configured when `listAccounts` finds a stored login/import or a `CLAUDE_CODE_OAUTH_TOKEN` env slot; **unconfigured on a managed lane (`oauth-slots`/`config-dir`) with zero accounts** (→ skipped); **still configured on the ambient lane**, which intentionally defers auth to the spawned Claude Code engine.

## Why not extension-local

The stored-OAuth branch is a structural short-circuit with no extension hook, and `OAuthAuth` had no `check` (unlike `ApiKeyAuth`). `Provider.filterModels` filters the catalog in `getAvailable()` but cannot influence `hasConfiguredAuth`, which is what the fallback controller reads. `changes.md` entries added in both `packages/ai/src` and the extension dir.

## Evidence

- **RED→GREEN:** `test/claude-sdk-oauth-auth-status.test.ts` drives the real composed provider through `checkAuth` across managed/ambient × empty/one-account. Before: `managed+empty` returned configured (the bug). After: **4/4 pass** — `managed+empty` is now unconfigured; `managed+1acct`, `ambient+empty`, `ambient+none` stay configured.
- **Regression:** `claude-sdk-oauth-*` suite 318 passed / 3 skipped (36 files); login 5/5; `settings-manager-retry-fallback` 12/12.
- **Static:** biome clean (2801 files); `coding-agent` `tsc` 0 errors; root `npm run check` green (ran as the pre-commit hook).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fallback so runs without a Claude login skip `claude-sdk-oauth` on managed lanes. Adds a lane- and account-aware OAuth availability check; ambient lane behavior is unchanged.

- **Bug Fixes**
  - Added optional `check?` to `OAuthAuth`; `models.ts` now consults it for stored OAuth credentials.
  - Implemented lane-aware `check` in `claude-sdk-oauth`: configured if an account exists or an env token is present; unconfigured on managed lanes with zero accounts; ambient stays configured.
  - Plumbed `check` through `provider-composer` (`ExtensionOAuthConfig.check` ➝ `adaptOAuth`).
  - Added tests for managed/ambient × empty/one-account to ensure fallback skips when appropriate.
  - Updated `CHANGELOG.md` in `packages/ai` and `packages/coding-agent`.

<sup>Written for commit 4381c4307a92236d764edb826928c5afa4a14b55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

