### PR TITLE
feat(coding-agent): expose loaded surfaces over control protocol

### DIFF
--- a/.agents/skills/senpi-qa/references/rpc-protocol.md
+++ b/.agents/skills/senpi-qa/references/rpc-protocol.md
@@ -21,6 +21,8 @@ response. Common ones:
 | `get_messages` | — | `{ messages: AgentMessage[] }` |
 | `set_model` | `provider`, `modelId` | the resolved `Model` |
 | `get_available_models` | — | `{ models: Model[] }` |
+| `get_commands` | — | `{ commands }` (including one row per loaded skill) |
+| `get_loaded_surfaces` | — | `{ extensions, mcpServers }` from the live session runtime |
 | `bash` | `command`, `excludeFromContext?` | `BashResult` |
 | `new_session` | `parentSession?` | `{ cancelled }` |
 
@@ -29,8 +31,9 @@ Full union: `RpcCommand` in `rpc-types.ts`.
 ## Responses & events (stdout)
 
 - Response: `{ id?, type:"response", command, success, data? | error }`.
-- Events: any other `{ type, ... }` line is an `AgentSessionEvent` (assistant
-  text deltas, tool calls/results, `agent_end`, `agent_aborted`, …).
+- Events: any other `{ type, ... }` line is an `AgentSessionEvent` or RPC host
+  invalidation event (assistant text deltas, tool calls/results, `agent_end`,
+  `loaded_surfaces_changed`, …).
 
 ## Detecting turn completion
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 ### New Features
 
+- Multi-session RPC clients can read loaded extensions and live MCP server inventory with
+  `get_loaded_surfaces`, and receive `loaded_surfaces_changed` invalidations when skills, extensions, or MCP
+  inventory changes ([#805](https://github.com/code-yeongyu/senpi/pull/805)).
+
 ### Breaking Changes
 
 ### Added

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -889,6 +889,51 @@ Each command has:
 
 **Note**: Built-in TUI commands (`/settings`, `/hotkeys`, etc.) are not included. They are handled only in interactive mode and would not execute if sent via `prompt`.
 
+#### get_loaded_surfaces
+
+Get the extensions and MCP servers loaded by the active runtime. Skills remain available through `get_commands`, where each loaded skill is represented by one `source: "skill"` row.
+
+```json
+{"type": "get_loaded_surfaces"}
+```
+
+Response:
+
+```json
+{
+  "type": "response",
+  "command": "get_loaded_surfaces",
+  "success": true,
+  "data": {
+    "extensions": [
+      {
+        "name": "my-extension",
+        "path": "/home/user/.senpi/agent/extensions/my-extension.ts",
+        "sourceInfo": {
+          "path": "/home/user/.senpi/agent/extensions/my-extension.ts",
+          "source": "auto",
+          "scope": "user",
+          "origin": "top-level"
+        },
+        "enabled": true
+      }
+    ],
+    "mcpServers": [
+      {
+        "name": "filesystem",
+        "toolCount": 12,
+        "status": "connected",
+        "authStatus": "unsupported"
+      }
+    ]
+  }
+}
+```
+
+Extension rows come directly from the session's loaded resource inventory, not from registered slash commands. A commandless extension therefore appears once, and an extension registering several commands is not duplicated. MCP rows come from the live session-owned MCP service and expose its current server state, listed tool count, and non-secret auth status.
+
+In multi-session mode this is a session-scoped command and requires the routing `sessionId`.
+
 ## Events
 
 Events are streamed to stdout as JSON lines during agent operation. Events do not generally include an `id` field; `bash_execution_update` includes the `id` of its originating `bash` command when one was provided.
@@ -918,6 +963,7 @@ Events are streamed to stdout as JSON lines during agent operation. Events do no
 | `summarization_retry_attempt_start` | Retried summarization request starts |
 | `summarization_retry_finished` | Summarization retry loop completes |
 | `extension_error` | Extension threw an error |
+| `loaded_surfaces_changed` | Loaded skills, extensions, or MCP inventory changed; re-read `get_commands` and `get_loaded_surfaces` |
 
 ### agent_start
 
@@ -1185,6 +1231,14 @@ For branch summaries, `source` is `"branchSummary"` and no `reason` is present.
 {
   "type": "summarization_retry_finished"
 }
+```
+
+### loaded_surfaces_changed
+
+Emitted without a request id when the loaded skill, extension, or MCP inventory changes. The event carries no inventory payload; clients re-read `get_commands` for skills and `get_loaded_surfaces` for extensions/MCP, mirroring the app-server `skills/changed` invalidation model.
+
+```json
+{"type": "loaded_surfaces_changed"}
 ```
 
 ### extension_error

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,27 @@
+## Control protocol exposes loaded extensions and MCP inventory (2026-08-11)
+
+### What changed
+
+- RPC gained the session-scoped `get_loaded_surfaces` request. Extension rows come from
+  `resourceLoader.getExtensions().extensions`, so commandless extensions remain visible and multi-command extensions
+  appear once; skills remain one-row-per-skill through `get_commands`.
+- MCP rows come from the live session-owned MCP service and report server name, tool count, connection/config status,
+  and non-secret auth status. A session-local event-bus bridge preserves multi-session isolation instead of consulting
+  the classic process singleton.
+- RPC emits `loaded_surfaces_changed` when the loaded skill, extension, or MCP snapshot changes. The event is an
+  invalidation notice with no payload, matching the app-server `skills/changed` read-after-notify model.
+
+### Why this cannot be expressed externally
+
+- The control host owns session routing and response/event ordering, while the loaded extension inventory and scoped
+  MCP service are private runtime state. An extension cannot add a correlated control request or safely address another
+  session's service.
+
+### Expected merge conflict zones
+
+- MEDIUM: additive request/event handling in `modes/rpc/rpc-types.ts` and `connection-handler.ts`.
+- LOW: the MCP control-inventory bridge and wire-status refresh hooks under `core/extensions/builtin/mcp/`.
+
 ## Fallback responses with errors no longer emit success (2026-08-11)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,29 @@
 # mcp Extension Changes
 
+## Session-scoped control inventory bridge (2026-08-11)
+
+### What changed
+- The MCP service now captures wire inventory for RPC sessions as well as app-server threads and serializes explicit
+  refreshes so concurrent connection/catalog transitions cannot overwrite a newer snapshot.
+- Live snapshots include the server's connection/config state and notify session-local listeners only after the
+  machine-readable inventory changes.
+- The builtin registers a private resource-event-bus bridge for the control host to request and subscribe to its own
+  session's snapshot. Lifecycle teardown removes both request and change listeners on reload, replacement, and quit.
+
+### Why
+- Multi-session RPC creates one MCP service inside each provider scope, so the process-global classic getter cannot
+  identify the service belonging to a routing handle. The bridge keeps MCP status/tool inventory attached to the same
+  session that loaded it and prevents cross-session leakage.
+
+### Why extension system couldn't handle this alone
+- The MCP builtin can expose its private service through the extension event bus, but only the RPC host can correlate
+  that inventory with control requests and emit routed invalidation events.
+
+### Expected merge conflict zones
+- LOW: `index.ts` session lifecycle wiring.
+- MEDIUM: `service.ts` wire-status refresh and notification paths.
+- LOW: additive `control-inventory.ts` and status metadata in `service-types.ts`.
+
 ## Strip invalid null-valued MCP schema types (2026-08-04)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/control-inventory.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/control-inventory.ts
@@ -1,0 +1,40 @@
+import type { McpWireStatusSnapshot } from "./service-types.ts";
+
+export const MCP_CONTROL_INVENTORY_REQUEST_EVENT = "senpi.rpc.mcp_inventory.request";
+export const MCP_CONTROL_INVENTORY_CHANGED_EVENT = "senpi.rpc.mcp_inventory.changed";
+
+export interface McpControlInventoryRequest {
+	readonly sessionId: string;
+	respond(snapshot: Promise<McpWireStatusSnapshot>): void;
+}
+
+export interface McpControlInventoryChanged {
+	readonly sessionId: string;
+	readonly snapshot: McpWireStatusSnapshot;
+}
+
+export function isMcpControlInventoryRequest(value: unknown): value is McpControlInventoryRequest {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"sessionId" in value &&
+		typeof value.sessionId === "string" &&
+		"respond" in value &&
+		typeof value.respond === "function"
+	);
+}
+
+export function isMcpControlInventoryChanged(value: unknown): value is McpControlInventoryChanged {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"sessionId" in value &&
+		typeof value.sessionId === "string" &&
+		"snapshot" in value &&
+		isMcpWireStatusSnapshot(value.snapshot)
+	);
+}
+
+function isMcpWireStatusSnapshot(value: unknown): value is McpWireStatusSnapshot {
+	return typeof value === "object" && value !== null && "servers" in value && Array.isArray(value.servers);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -1,6 +1,11 @@
 import { bindToProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 import type { ExtensionAPI, ExtensionContext, ExtensionFactory, SessionStartEvent } from "../../types.ts";
 import { registerMcpCommands } from "./commands.ts";
+import {
+	isMcpControlInventoryRequest,
+	MCP_CONTROL_INVENTORY_CHANGED_EVENT,
+	MCP_CONTROL_INVENTORY_REQUEST_EVENT,
+} from "./control-inventory.ts";
 import { createLazyToolActivator } from "./expose/lazy-activate.ts";
 import { AnthropicNativeToolSearchAdapter } from "./expose/native-search.ts";
 import { TOOL_SEARCH_TOOL_NAME } from "./expose/tool-search.ts";
@@ -22,6 +27,22 @@ const MCP_BUILTIN_EXTENSION_PATH = "<builtin:mcp>";
 export function createMcpExtension(service: McpService, sessionOwned = true): ExtensionFactory {
 	return (pi: ExtensionAPI): void => {
 		let attachPromise: Promise<void> | undefined;
+		let attachedSessionId: string | undefined;
+		let controlInventoryDisposed = false;
+		const unsubscribeControlInventoryRequest = pi.events.on(MCP_CONTROL_INVENTORY_REQUEST_EVENT, (data) => {
+			if (!isMcpControlInventoryRequest(data) || data.sessionId !== attachedSessionId) return;
+			data.respond(service.refreshWireStatusSnapshot(data.sessionId));
+		});
+		const unsubscribeWireStatus = service.onWireStatusChanged((sessionId, snapshot) => {
+			if (sessionId === undefined || sessionId !== attachedSessionId) return;
+			pi.events.emit(MCP_CONTROL_INVENTORY_CHANGED_EVENT, { sessionId, snapshot });
+		});
+		const disposeControlInventory = (): void => {
+			if (controlInventoryDisposed) return;
+			controlInventoryDisposed = true;
+			unsubscribeControlInventoryRequest();
+			unsubscribeWireStatus();
+		};
 		const sink = {
 			logger: {
 				error(message: string, data?: unknown): void {
@@ -121,6 +142,7 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 		// the first turn's payload deterministically carries the MCP tool set.
 		// session_start always starts a fresh attach (reloads must re-sync config).
 		const attach = (event: SessionStartEvent, ctx: ExtensionContext): Promise<void> => {
+			attachedSessionId = ctx.sessionManager.getSessionId();
 			attachPromise = (async () => {
 				await service.attachSession(event, ctx, pi);
 				refreshMcpInstructionsForSession(service);
@@ -164,6 +186,7 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 			wrapAsync(
 				"mcp.session_shutdown",
 				async (event) => {
+					disposeControlInventory();
 					if (event.reason === "reload" && !sessionOwned) return;
 					await service.handleSessionShutdown(event);
 				},

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -20,7 +20,7 @@ import {
 	type SkillMcpDeclarations,
 	skillActivationTargets,
 } from "./skills.ts";
-import { reportMcpAsyncError, wrapAsync } from "./wrap.ts";
+import { reportMcpAsyncError, safeEventBusOn, wrapAsync } from "./wrap.ts";
 
 const MCP_BUILTIN_EXTENSION_PATH = "<builtin:mcp>";
 
@@ -29,10 +29,14 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 		let attachPromise: Promise<void> | undefined;
 		let attachedSessionId: string | undefined;
 		let controlInventoryDisposed = false;
-		const unsubscribeControlInventoryRequest = pi.events.on(MCP_CONTROL_INVENTORY_REQUEST_EVENT, (data) => {
-			if (!isMcpControlInventoryRequest(data) || data.sessionId !== attachedSessionId) return;
-			data.respond(service.refreshWireStatusSnapshot(data.sessionId));
-		});
+		const unsubscribeControlInventoryRequest = safeEventBusOn(
+			pi.events,
+			MCP_CONTROL_INVENTORY_REQUEST_EVENT,
+			(data) => {
+				if (!isMcpControlInventoryRequest(data) || data.sessionId !== attachedSessionId) return;
+				data.respond(service.refreshWireStatusSnapshot(data.sessionId));
+			},
+		);
 		const unsubscribeWireStatus = service.onWireStatusChanged((sessionId, snapshot) => {
 			if (sessionId === undefined || sessionId !== attachedSessionId) return;
 			pi.events.emit(MCP_CONTROL_INVENTORY_CHANGED_EVENT, { sessionId, snapshot });
@@ -142,7 +146,7 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 		// the first turn's payload deterministically carries the MCP tool set.
 		// session_start always starts a fresh attach (reloads must re-sync config).
 		const attach = (event: SessionStartEvent, ctx: ExtensionContext): Promise<void> => {
-			attachedSessionId = ctx.sessionManager.getSessionId();
+			attachedSessionId = ctx.sessionManager?.getSessionId?.();
 			attachPromise = (async () => {
 				await service.attachSession(event, ctx, pi);
 				refreshMcpInstructionsForSession(service);
@@ -186,8 +190,8 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 			wrapAsync(
 				"mcp.session_shutdown",
 				async (event) => {
-					disposeControlInventory();
 					if (event.reason === "reload" && !sessionOwned) return;
+					disposeControlInventory();
 					await service.handleSessionShutdown(event);
 				},
 				sink,
@@ -199,6 +203,7 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 				"mcp.session_extensions_removed",
 				async (event) => {
 					if (event.removed.some((extension) => extension.path === MCP_BUILTIN_EXTENSION_PATH)) {
+						disposeControlInventory();
 						await service.dispose("reload");
 					}
 				},

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service-types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service-types.ts
@@ -17,6 +17,7 @@ export type McpWireJsonValue =
 	| { readonly [key: string]: McpWireJsonValue | undefined };
 
 export type McpWireAuthStatus = "unsupported" | "notLoggedIn" | "bearerToken" | "oAuth";
+export type McpWireServerStatus = ServerConnectionState | ResolvedMcpServer["state"];
 
 export type McpWireServerInfo = {
 	readonly name: string;
@@ -68,6 +69,7 @@ export type McpWireStatusServer = {
 	readonly resources: readonly McpWireResource[];
 	readonly resourceTemplates: readonly McpWireResourceTemplate[];
 	readonly authStatus: McpWireAuthStatus;
+	readonly status?: McpWireServerStatus;
 };
 
 export type McpWireStatusSnapshot = {
@@ -153,4 +155,6 @@ export interface McpConnectionEntry {
 	lastListChangedDelta?: string;
 	/** Teardown for the list_changed coalescer + subscription. */
 	disposeListChanged?: () => void;
+	/** Teardown for the control-inventory connection-state subscription. */
+	disposeWireStatus?: () => void;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -73,6 +73,8 @@ export class McpService {
 	readonly #interactiveAuthServers = new Set<string>();
 	readonly #promptCommandNames = new Set<string>();
 	readonly #registrationListeners = new Set<() => void>();
+	readonly #wireStatusListeners = new Set<(sessionId: string | undefined, snapshot: McpWireStatusSnapshot) => void>();
+	#wireStatusRefreshQueue: Promise<void> = Promise.resolve();
 	#refreshActiveSetWhenNoTools = false;
 	#tierBRegistration: McpSessionRegistration | undefined;
 	#historyScanned = false;
@@ -117,7 +119,7 @@ export class McpService {
 			// one turn late. Doing it here puts restored tools on the very first
 			// wire payload after a --continue/resume.
 			if (_pi !== undefined) this.#rehydrateFromSessionHistory(ctx);
-			if (shouldCaptureWireStatus(ctx)) await this.#captureWireStatus(ctx.sessionManager?.getSessionId?.());
+			if (shouldCaptureWireStatus(ctx)) await this.refreshWireStatusSnapshot(ctx.sessionManager?.getSessionId?.());
 		});
 		this.#attachQueue = attach.then(
 			() => undefined,
@@ -160,7 +162,7 @@ export class McpService {
 			await this.#syncFromConfig(config, this.#sessionOptions, false, pi, toolRefreshGeneration);
 			await this.#registerDirectTools(pi);
 			if (this.#sessionContext !== null && shouldCaptureWireStatus(this.#sessionContext)) {
-				await this.#captureWireStatus(this.#sessionContext.sessionManager?.getSessionId?.());
+				await this.refreshWireStatusSnapshot(this.#sessionContext.sessionManager?.getSessionId?.());
 			}
 		}
 		return warnings;
@@ -188,6 +190,23 @@ export class McpService {
 	onMcpRegistrationChanged(listener: () => void): () => void {
 		this.#registrationListeners.add(listener);
 		return () => this.#registrationListeners.delete(listener);
+	}
+
+	/** Subscribe to live MCP inventory transitions for session-scoped hosts. */
+	onWireStatusChanged(listener: (sessionId: string | undefined, snapshot: McpWireStatusSnapshot) => void): () => void {
+		this.#wireStatusListeners.add(listener);
+		return () => this.#wireStatusListeners.delete(listener);
+	}
+
+	/** Refresh and return the current session-owned MCP wire inventory. */
+	async refreshWireStatusSnapshot(sessionId?: string): Promise<McpWireStatusSnapshot> {
+		const refresh = this.#wireStatusRefreshQueue.then(() => this.#captureWireStatus(sessionId));
+		this.#wireStatusRefreshQueue = refresh.then(
+			() => undefined,
+			() => undefined,
+		);
+		await refresh;
+		return this.getWireStatusSnapshot(sessionId);
 	}
 
 	/** Reveal skill-owned tools (todo 37): activation is effective the next
@@ -219,6 +238,7 @@ export class McpService {
 		this.#interactiveAuthServers.clear();
 		this.#promptCommandNames.clear();
 		this.#registrationListeners.clear();
+		this.#wireStatusListeners.clear();
 		this.#wireStatusBySession.clear();
 		this.#latestWireStatus = { servers: [] };
 		const entries = [...this.#connections.values()];
@@ -422,10 +442,18 @@ export class McpService {
 			sink,
 		});
 		const unsubscribe = entry.connection.onToolsChanged(() => coalescer.notify());
+		const unsubscribeState = entry.connection.onStateChange(() => {
+			const ctx = this.#sessionContext;
+			if (ctx?.mode !== "rpc") return;
+			void this.refreshWireStatusSnapshot(ctx.sessionManager?.getSessionId?.()).catch((error: unknown) => {
+				entry.logger.error("Failed to refresh MCP control inventory", error);
+			});
+		});
 		entry.disposeListChanged = () => {
 			unsubscribe();
 			coalescer.dispose();
 		};
+		entry.disposeWireStatus = unsubscribeState;
 	}
 
 	// Re-list a server on a coalesced list_changed and re-register: added tools
@@ -459,6 +487,10 @@ export class McpService {
 		this.#tierBRegistration = await registerMcpServiceDirectTools(pi, config, this.#connections.values(), {
 			refreshActiveSetWhenEmpty: this.#refreshActiveSetWhenNoTools,
 		});
+		const ctx = this.#sessionContext;
+		if (ctx?.mode === "rpc") {
+			await this.refreshWireStatusSnapshot(ctx.sessionManager?.getSessionId?.());
+		}
 		for (const listener of this.#registrationListeners) listener();
 		// A (re-)registration recomputes the active set from config alone, so any
 		// promotions recorded in history are worth replaying on the next scan.
@@ -501,8 +533,11 @@ export class McpService {
 				.map((name) => this.#captureWireStatusServer(name, config.servers[name])),
 		);
 		const snapshot: McpWireStatusSnapshot = { servers };
+		const previous = this.getWireStatusSnapshot(sessionId);
 		this.#latestWireStatus = snapshot;
 		if (sessionId !== undefined) this.#wireStatusBySession.set(sessionId, snapshot);
+		if (JSON.stringify(previous) === JSON.stringify(snapshot)) return;
+		for (const listener of this.#wireStatusListeners) listener(sessionId, snapshot);
 	}
 
 	async #captureWireStatusServer(name: string, server: ResolvedMcpServer | undefined): Promise<McpWireStatusServer> {
@@ -519,27 +554,23 @@ export class McpService {
 			const client = connection.client;
 			const version = client.getServerVersion();
 			if (version !== undefined) serverInfo = mapWireServerInfo(version);
-			if (cached === undefined) {
-				try {
-					tools = (
-						await collectAllPages<ListedTool>((cursor) =>
-							client.listTools(cursor === undefined ? {} : { cursor }),
-						)
-					).items;
-				} catch (error: unknown) {
-					if (!(error instanceof Error)) throw error;
-					tools = [];
-				}
-				try {
-					resources = (
-						await collectAllPages<ListedResource>((cursor) =>
-							client.listResources(cursor === undefined ? {} : { cursor }),
-						)
-					).items;
-				} catch (error: unknown) {
-					if (!(error instanceof Error)) throw error;
-					resources = [];
-				}
+			try {
+				tools = (
+					await collectAllPages<ListedTool>((cursor) => client.listTools(cursor === undefined ? {} : { cursor }))
+				).items;
+			} catch (error: unknown) {
+				if (!(error instanceof Error)) throw error;
+				tools = cached?.tools ?? [];
+			}
+			try {
+				resources = (
+					await collectAllPages<ListedResource>((cursor) =>
+						client.listResources(cursor === undefined ? {} : { cursor }),
+					)
+				).items;
+			} catch (error: unknown) {
+				if (!(error instanceof Error)) throw error;
+				resources = cached?.resources ?? [];
 			}
 			try {
 				resourceTemplates = (
@@ -560,6 +591,9 @@ export class McpService {
 			resources: resources.map(mapWireResource),
 			resourceTemplates: resourceTemplates.map(mapWireResourceTemplate),
 			authStatus: wireAuthStatus(entry, server),
+			...(connection?.state === undefined && server?.state === undefined
+				? {}
+				: { status: connection?.state ?? server?.state }),
 		};
 	}
 
@@ -650,7 +684,7 @@ function wireAuthStatus(
 }
 
 function shouldCaptureWireStatus(ctx: McpSessionContext): boolean {
-	return ctx.mode === "app-server";
+	return ctx.mode === "app-server" || ctx.mode === "rpc";
 }
 
 function mapWireServerInfo(info: NonNullable<ReturnType<Client["getServerVersion"]>>): McpWireServerInfo {
@@ -740,6 +774,7 @@ export function shouldDisposeMcpService(reason: SessionShutdownEvent["reason"]):
 
 async function disposeEntryConnection(entry: McpConnectionEntry): Promise<void> {
 	entry.disposeListChanged?.();
+	entry.disposeWireStatus?.();
 	disposeMcpReconnect(entry.connection);
 	disposeMcpConnectionLifecycle(entry.connection);
 	await entry.connection.dispose();

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/wrap.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/wrap.ts
@@ -3,6 +3,7 @@ export { Server } from "@modelcontextprotocol/sdk/server/index.js";
 export type { CallToolResult, ListToolsResult } from "@modelcontextprotocol/sdk/types.js";
 
 import type { EventEmitter } from "node:events";
+import type { EventBus } from "../../../event-bus.ts";
 import { redactMcpLogText } from "./log.ts";
 
 type MaybePromise<T> = T | Promise<T>;
@@ -79,6 +80,10 @@ export function safeOn(
 	return () => {
 		emitter.off(eventName, wrapped);
 	};
+}
+
+export function safeEventBusOn(bus: EventBus, channel: string, handler: (data: unknown) => void): () => void {
+	return bus.on(channel, handler);
 }
 
 export async function reportMcpAsyncError(scope: string, error: unknown, sink: McpAsyncErrorSink): Promise<void> {

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -16,7 +16,9 @@
  */
 
 import * as crypto from "node:crypto";
+import { basename, dirname, extname } from "node:path";
 import type { OAuthProviderId } from "@earendil-works/pi-ai/compat";
+import type { AgentSession } from "../../core/agent-session.ts";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.ts";
 import { buildLoginProviderInfos } from "../../core/auth-providers.ts";
 import {
@@ -29,6 +31,13 @@ import {
 	pinProviderAccount,
 	removeProviderAccount,
 } from "../../core/extensions/builtin/claude-sdk-oauth/account-management.ts";
+import {
+	isMcpControlInventoryChanged,
+	MCP_CONTROL_INVENTORY_CHANGED_EVENT,
+	MCP_CONTROL_INVENTORY_REQUEST_EVENT,
+	type McpControlInventoryRequest,
+} from "../../core/extensions/builtin/mcp/control-inventory.ts";
+import type { McpWireStatusServer, McpWireStatusSnapshot } from "../../core/extensions/builtin/mcp/service-types.ts";
 import type {
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
@@ -44,6 +53,9 @@ import type {
 	RpcCommand,
 	RpcExtensionUIRequest,
 	RpcExtensionUIResponse,
+	RpcLoadedExtension,
+	RpcLoadedMcpServer,
+	RpcMcpServerStatus,
 	RpcResponse,
 	RpcSessionState,
 	RpcSlashCommand,
@@ -89,6 +101,58 @@ export interface RpcConnectionHandler {
 	dispose(): Promise<void>;
 }
 
+function loadedExtensionName(path: string): string {
+	const synthetic = /^<(?:builtin|inline):([^>]+)>$/.exec(path);
+	if (synthetic) return synthetic[1];
+	const withoutExtension = basename(path, extname(path));
+	if (withoutExtension !== "index") return withoutExtension;
+	const parent = dirname(path);
+	const parentName = basename(parent);
+	return parentName === "src" || parentName === "dist" ? basename(dirname(parent)) : parentName;
+}
+
+function loadedExtensions(session: AgentSession): RpcLoadedExtension[] {
+	return session.resourceLoader.getExtensions().extensions.map((extension) => ({
+		name: loadedExtensionName(extension.path),
+		path: extension.path,
+		sourceInfo: extension.sourceInfo,
+		enabled: true,
+	}));
+}
+
+function loadedMcpStatus(server: McpWireStatusServer): RpcMcpServerStatus {
+	if (server.status !== undefined) return server.status;
+	if (server.serverInfo !== null) return "connected";
+	if (server.authStatus === "notLoggedIn") return "needs_auth";
+	return "enabled";
+}
+
+function loadedMcpServers(snapshot: McpWireStatusSnapshot): RpcLoadedMcpServer[] {
+	return snapshot.servers.map((server) => ({
+		name: server.name,
+		toolCount: server.tools.length,
+		status: loadedMcpStatus(server),
+		authStatus: server.authStatus,
+	}));
+}
+
+function loadedSurfacesFingerprint(
+	session: AgentSession,
+	extensions: readonly RpcLoadedExtension[],
+	mcpServers: readonly RpcLoadedMcpServer[],
+): string {
+	return JSON.stringify({
+		skills: session.resourceLoader.getSkills().skills.map((skill) => ({
+			name: skill.name,
+			path: skill.filePath,
+			sourceInfo: skill.sourceInfo,
+			enabled: !skill.disableModelInvocation,
+		})),
+		extensions,
+		mcpServers,
+	});
+}
+
 /**
  * Create a per-connection RPC handler bound to one runtime host and one sink.
  *
@@ -106,6 +170,10 @@ export function createRpcConnectionHandler(
 	let session = runtimeHost.session;
 	let unsubscribe: (() => void) | undefined;
 	let unsubscribeBackpressure: (() => void) | undefined;
+	let unsubscribeLoadedSurfaces: (() => void) | undefined;
+	let mcpWireStatus: McpWireStatusSnapshot = { servers: [] };
+	let loadedSurfacesDigest: string | undefined;
+	let suppressLoadedSurfaceEvents = false;
 	const eventOutput = createRpcEventOutputBuffer(sink.writeRaw);
 
 	const tagSessionRecord = <T extends object>(value: T): T | (T & { sessionId: string }) =>
@@ -118,6 +186,53 @@ export function createRpcConnectionHandler(
 	const outputEvent = (event: object) => {
 		eventOutput.enqueueEvent(tagSessionRecord(event));
 	};
+
+	const currentLoadedSurfaces = (): {
+		data: { extensions: RpcLoadedExtension[]; mcpServers: RpcLoadedMcpServer[] };
+		digest: string;
+	} => {
+		const extensions = loadedExtensions(session);
+		const mcpServers = loadedMcpServers(mcpWireStatus);
+		return {
+			data: { extensions, mcpServers },
+			digest: loadedSurfacesFingerprint(session, extensions, mcpServers),
+		};
+	};
+
+	const recordLoadedSurfaces = (emitChange: boolean): ReturnType<typeof currentLoadedSurfaces> => {
+		const current = currentLoadedSurfaces();
+		const changed = loadedSurfacesDigest !== undefined && loadedSurfacesDigest !== current.digest;
+		loadedSurfacesDigest = current.digest;
+		if (emitChange && changed && !suppressLoadedSurfaceEvents) {
+			outputEvent({ type: "loaded_surfaces_changed" });
+		}
+		return current;
+	};
+
+	const requestMcpWireStatus = async (): Promise<void> => {
+		let response: Promise<McpWireStatusSnapshot> | undefined;
+		const request: McpControlInventoryRequest = {
+			sessionId: session.sessionId,
+			respond(snapshot) {
+				response ??= snapshot;
+			},
+		};
+		session.resourceLoader.emitExtensionEvent?.(MCP_CONTROL_INVENTORY_REQUEST_EVENT, request);
+		mcpWireStatus = response === undefined ? { servers: [] } : await response;
+	};
+
+	const subscribeLoadedSurfaceEvents = (): void => {
+		unsubscribeLoadedSurfaces?.();
+		unsubscribeLoadedSurfaces = session.resourceLoader.onExtensionEvent?.(
+			MCP_CONTROL_INVENTORY_CHANGED_EVENT,
+			(data) => {
+				if (!isMcpControlInventoryChanged(data) || data.sessionId !== session.sessionId) return;
+				mcpWireStatus = data.snapshot;
+				if (!suppressLoadedSurfaceEvents) recordLoadedSurfaces(true);
+			},
+		);
+	};
+
 	const unsubscribeProviderAccountEvents = subscribeProviderAccountEvents((event) => {
 		if (event.type === "accounts_changed") {
 			outputEvent({ type: "auth_accounts_changed", provider: event.provider });
@@ -396,49 +511,79 @@ export function createRpcConnectionHandler(
 		},
 	});
 
+	const refreshLoadedSurfacesAfter = async (operation: () => Promise<void>, resetMcp: boolean): Promise<void> => {
+		const previousDigest = loadedSurfacesDigest;
+		const wasSuppressed = suppressLoadedSurfaceEvents;
+		suppressLoadedSurfaceEvents = true;
+		if (resetMcp) mcpWireStatus = { servers: [] };
+		try {
+			await operation();
+			await requestMcpWireStatus();
+			loadedSurfacesDigest = currentLoadedSurfaces().digest;
+		} finally {
+			suppressLoadedSurfaceEvents = wasSuppressed;
+		}
+		if (!wasSuppressed && previousDigest !== undefined && previousDigest !== loadedSurfacesDigest) {
+			outputEvent({ type: "loaded_surfaces_changed" });
+		}
+	};
+
 	runtimeHost.setRebindSession(async () => {
 		await rebindSession();
 	});
 
 	const rebindSession = async (): Promise<void> => {
+		unsubscribeLoadedSurfaces?.();
 		session = runtimeHost.session;
-		await session.bindExtensions({
-			uiContext: createExtensionUIContext(),
-			mode: "rpc",
-			commandContextActions: {
-				waitForIdle: () => session.agent.waitForIdle(),
-				newSession: async (options) => runtimeHost.newSession(options),
-				fork: async (entryId, forkOptions) => {
-					const result = await runtimeHost.fork(entryId, forkOptions);
-					return { cancelled: result.cancelled };
-				},
-				navigateTree: async (targetId, options) => {
-					const result = await session.navigateTree(targetId, {
-						summarize: options?.summarize,
-						customInstructions: options?.customInstructions,
-						replaceInstructions: options?.replaceInstructions,
-						label: options?.label,
-					});
-					return { cancelled: result.cancelled };
-				},
-				switchSession: async (sessionPath, options) => {
-					return runtimeHost.switchSession(sessionPath, options);
-				},
-				reload: async () => {
-					await session.reload();
-				},
-			},
-			shutdownHandler: () => {
-				if (options.shutdownHandler) {
-					options.shutdownHandler();
-				} else {
-					shutdownRequested = true;
-				}
-			},
-			onError: (err) => {
-				output({ type: "extension_error", extensionPath: err.extensionPath, event: err.event, error: err.error });
-			},
-		});
+		subscribeLoadedSurfaceEvents();
+		await refreshLoadedSurfacesAfter(
+			() =>
+				session.bindExtensions({
+					uiContext: createExtensionUIContext(),
+					mode: "rpc",
+					commandContextActions: {
+						waitForIdle: () => session.agent.waitForIdle(),
+						newSession: async (options) => runtimeHost.newSession(options),
+						fork: async (entryId, forkOptions) => {
+							const result = await runtimeHost.fork(entryId, forkOptions);
+							return { cancelled: result.cancelled };
+						},
+						navigateTree: async (targetId, options) => {
+							const result = await session.navigateTree(targetId, {
+								summarize: options?.summarize,
+								customInstructions: options?.customInstructions,
+								replaceInstructions: options?.replaceInstructions,
+								label: options?.label,
+							});
+							return { cancelled: result.cancelled };
+						},
+						switchSession: async (sessionPath, options) => {
+							return runtimeHost.switchSession(sessionPath, options);
+						},
+						reload: async () => {
+							await refreshLoadedSurfacesAfter(async () => {
+								await session.reload();
+							}, false);
+						},
+					},
+					shutdownHandler: () => {
+						if (options.shutdownHandler) {
+							options.shutdownHandler();
+						} else {
+							shutdownRequested = true;
+						}
+					},
+					onError: (err) => {
+						output({
+							type: "extension_error",
+							extensionPath: err.extensionPath,
+							event: err.event,
+							error: err.error,
+						});
+					},
+				}),
+			true,
+		);
 
 		unsubscribe?.();
 		unsubscribeBackpressure?.();
@@ -856,6 +1001,12 @@ export function createRpcConnectionHandler(
 				return success(id, "get_commands", { commands });
 			}
 
+			case "get_loaded_surfaces": {
+				await requestMcpWireStatus();
+				const inventory = recordLoadedSurfaces(true);
+				return success(id, "get_loaded_surfaces", inventory.data);
+			}
+
 			// =================================================================
 			// Auth (task 13)
 			// =================================================================
@@ -978,8 +1129,10 @@ export function createRpcConnectionHandler(
 		unsubscribeProviderAccountEvents();
 		unsubscribe?.();
 		unsubscribeBackpressure?.();
+		unsubscribeLoadedSurfaces?.();
 		unsubscribe = undefined;
 		unsubscribeBackpressure = undefined;
+		unsubscribeLoadedSurfaces = undefined;
 		if (options.disposeRuntime !== false) {
 			await runtimeHost.dispose();
 		}

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -76,8 +76,9 @@ type RpcSessionCommand =
 	// Messages
 	| { id?: string; type: "get_messages" }
 
-	// Commands (available for invocation via prompt)
+	// Commands and loaded runtime surfaces
 	| { id?: string; type: "get_commands" }
+	| { id?: string; type: "get_loaded_surfaces" }
 
 	// Auth (task 13) is additive. get_auth_providers, login_api_key and logout
 	// answer synchronously. login_start responds immediately (flow-started) and
@@ -183,6 +184,34 @@ export interface RpcSlashCommand {
 	source: "extension" | "prompt" | "skill";
 	/** Source metadata for the owning resource */
 	sourceInfo: SourceInfo;
+}
+
+/** One extension module loaded by the session resource loader. */
+export interface RpcLoadedExtension {
+	name: string;
+	path: string;
+	sourceInfo: SourceInfo;
+	enabled: boolean;
+}
+
+export type RpcMcpServerStatus =
+	| "enabled"
+	| "disabled"
+	| "untrusted"
+	| "idle"
+	| "connecting"
+	| "connected"
+	| "degraded"
+	| "suspended"
+	| "needs_auth"
+	| "needs_client_registration";
+
+/** Runtime MCP server state projected from the session-owned MCP service. */
+export interface RpcLoadedMcpServer {
+	name: string;
+	toolCount: number;
+	status: RpcMcpServerStatus;
+	authStatus: "unsupported" | "notLoggedIn" | "bearerToken" | "oAuth";
 }
 
 // ============================================================================
@@ -346,13 +375,20 @@ export type RpcResponse =
 	// Messages
 	| { id?: string; type: "response"; command: "get_messages"; success: true; data: { messages: AgentMessage[] } }
 
-	// Commands
+	// Commands and loaded runtime surfaces
 	| {
 			id?: string;
 			type: "response";
 			command: "get_commands";
 			success: true;
 			data: { commands: RpcSlashCommand[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "get_loaded_surfaces";
+			success: true;
+			data: { extensions: RpcLoadedExtension[]; mcpServers: RpcLoadedMcpServer[] };
 	  }
 
 	// Auth (task 13)
@@ -450,6 +486,11 @@ export interface RpcHighReasoningWarningEvent {
 	modelId: string;
 	provider: string;
 	thinkingLevel: ThinkingLevel;
+}
+
+/** Emitted after the loaded skill, extension, or MCP inventory changes. */
+export interface RpcLoadedSurfacesChangedEvent {
+	type: "loaded_surfaces_changed";
 }
 
 /** Emitted after an account is added, removed, pinned, or blocked by refresh failure. */

--- a/packages/coding-agent/test/rpc-loaded-surfaces.test.ts
+++ b/packages/coding-agent/test/rpc-loaded-surfaces.test.ts
@@ -1,0 +1,420 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { getModel } from "@earendil-works/pi-ai/compat";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ENV_AGENT_DIR } from "../src/config.ts";
+import { AgentSession } from "../src/core/agent-session.ts";
+import type { AgentSessionRuntime } from "../src/core/agent-session-runtime.ts";
+import { AuthStorage } from "../src/core/auth-storage.ts";
+import { createEventBus } from "../src/core/event-bus.ts";
+import { createMcpExtension } from "../src/core/extensions/builtin/mcp/index.ts";
+import { McpService } from "../src/core/extensions/builtin/mcp/service.ts";
+import type { ExtensionAPI, LoadExtensionsResult } from "../src/core/extensions/index.ts";
+import { ModelRegistry } from "../src/core/model-registry.ts";
+import { DefaultResourceLoader, type ResourceLoader } from "../src/core/resource-loader.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import type { Skill } from "../src/core/skills.ts";
+import { createRpcConnectionHandler, type RpcConnectionSink } from "../src/modes/rpc/connection-handler.ts";
+import { createTestExtensionsResult } from "./utilities.ts";
+
+const MCP_INVENTORY_REQUEST_EVENT = "senpi.rpc.mcp_inventory.request";
+const MCP_INVENTORY_CHANGED_EVENT = "senpi.rpc.mcp_inventory.changed";
+
+type RpcRecord = Record<string, unknown>;
+type McpSnapshot = {
+	servers: Array<{
+		name: string;
+		serverInfo: {
+			name: string;
+			title: null;
+			version: string;
+			description: null;
+			icons: null;
+			websiteUrl: null;
+		} | null;
+		tools: Array<{ name: string; inputSchema: Record<string, never> }>;
+		resources: [];
+		resourceTemplates: [];
+		authStatus: "unsupported" | "notLoggedIn" | "bearerToken" | "oAuth";
+		status?: string;
+	}>;
+};
+
+interface MutableResourceLoader extends ResourceLoader {
+	readonly extensionsResult: LoadExtensionsResult;
+	readonly skills: Skill[];
+	mcpSnapshot: McpSnapshot;
+}
+
+interface Harness {
+	runtimeHost: AgentSessionRuntime;
+	resourceLoader: MutableResourceLoader;
+	rebind: () => Promise<void>;
+	cleanup: () => void;
+}
+
+interface CollectedSink {
+	sink: RpcConnectionSink;
+	messages: () => readonly RpcRecord[];
+	waitFor: (predicate: (message: RpcRecord) => boolean, afterIndex?: number, timeoutMs?: number) => Promise<RpcRecord>;
+}
+
+function makeSink(): CollectedSink {
+	const records: RpcRecord[] = [];
+	const waiters: Array<{
+		predicate: (message: RpcRecord) => boolean;
+		afterIndex: number;
+		resolve: (message: RpcRecord) => void;
+	}> = [];
+	let buffer = "";
+
+	const dispatch = (record: RpcRecord) => {
+		const index = records.push(record) - 1;
+		for (const waiter of [...waiters]) {
+			if (index < waiter.afterIndex || !waiter.predicate(record)) continue;
+			waiters.splice(waiters.indexOf(waiter), 1);
+			waiter.resolve(record);
+		}
+	};
+
+	return {
+		sink: {
+			writeRaw(chunk) {
+				buffer += chunk;
+				let newline = buffer.indexOf("\n");
+				while (newline !== -1) {
+					const line = buffer.slice(0, newline);
+					buffer = buffer.slice(newline + 1);
+					if (line) dispatch(JSON.parse(line) as RpcRecord);
+					newline = buffer.indexOf("\n");
+				}
+			},
+			waitForBackpressure: async () => {},
+		},
+		messages: () => records,
+		waitFor(predicate, afterIndex = 0, timeoutMs = 1_000) {
+			const existing = records.slice(afterIndex).find(predicate);
+			if (existing) return Promise.resolve(existing);
+			return new Promise((resolve, reject) => {
+				let waiter!: (typeof waiters)[number];
+				const timer = setTimeout(() => {
+					const index = waiters.indexOf(waiter);
+					if (index !== -1) waiters.splice(index, 1);
+					reject(new Error("Timed out waiting for the expected RPC record"));
+				}, timeoutMs);
+				waiter = {
+					predicate,
+					afterIndex,
+					resolve: (message) => {
+						clearTimeout(timer);
+						resolve(message);
+					},
+				};
+				waiters.push(waiter);
+			});
+		},
+	};
+}
+
+function sourceInfo(path: string, source = "local") {
+	return { path, source, scope: "project" as const, origin: "top-level" as const };
+}
+
+function skill(name: string): Skill {
+	const filePath = `/fixture/skills/${name}/SKILL.md`;
+	return {
+		name,
+		description: `${name} skill`,
+		filePath,
+		baseDir: `/fixture/skills/${name}`,
+		sourceInfo: sourceInfo(filePath),
+		disableModelInvocation: false,
+	};
+}
+
+function mcpServer(
+	name: string,
+	toolNames: string[],
+	authStatus: McpSnapshot["servers"][number]["authStatus"],
+	status: string,
+): McpSnapshot["servers"][number] {
+	return {
+		name,
+		serverInfo:
+			status === "connected"
+				? { name, title: null, version: "1.0.0", description: null, icons: null, websiteUrl: null }
+				: null,
+		tools: toolNames.map((toolName) => ({ name: toolName, inputSchema: {} })),
+		resources: [],
+		resourceTemplates: [],
+		authStatus,
+		status,
+	};
+}
+
+async function makeHarness(tempDir: string): Promise<Harness> {
+	const commandlessPath = join(tempDir, "commandless-extension.ts");
+	const commandfulPath = join(tempDir, "commandful-extension.ts");
+	const extensionsResult = await createTestExtensionsResult(
+		[
+			{ path: commandlessPath, factory: () => {} },
+			{
+				path: commandfulPath,
+				factory: (pi: ExtensionAPI) => {
+					pi.registerCommand("first", { handler: async () => {} });
+					pi.registerCommand("second", { handler: async () => {} });
+				},
+			},
+		],
+		tempDir,
+	);
+	for (const extension of extensionsResult.extensions) {
+		extension.sourceInfo = sourceInfo(extension.path);
+	}
+	const eventBus = createEventBus();
+	const skills = [skill("alpha")];
+	const resourceLoader: MutableResourceLoader = {
+		extensionsResult,
+		skills,
+		mcpSnapshot: {
+			servers: [
+				mcpServer("connected-server", ["one", "two"], "bearerToken", "connected"),
+				mcpServer("login-server", [], "notLoggedIn", "needs_auth"),
+			],
+		},
+		getExtensions: () => extensionsResult,
+		emitExtensionEvent: eventBus.emit,
+		onExtensionEvent: eventBus.on,
+		getSkills: () => ({ skills, diagnostics: [] }),
+		getPrompts: () => ({ prompts: [], diagnostics: [] }),
+		getThemes: () => ({ themes: [], diagnostics: [] }),
+		getAgentsFiles: () => ({ agentsFiles: [] }),
+		getSystemPrompt: () => undefined,
+		getSystemPromptSource: () => undefined,
+		getAppendSystemPrompt: () => [],
+		getAppendSystemPromptSources: () => [],
+		extendResources: () => {},
+		reload: async () => {},
+	};
+	eventBus.on(MCP_INVENTORY_REQUEST_EVENT, (data) => {
+		const request = data as {
+			sessionId: string;
+			respond: (snapshot: Promise<McpSnapshot>) => void;
+		};
+		request.respond(Promise.resolve(resourceLoader.mcpSnapshot));
+	});
+
+	const model = getModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("model not found");
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: { model, systemPrompt: "Test", tools: [] },
+		streamFn: () => {
+			throw new Error("RPC inventory tests must not call a model");
+		},
+	});
+	const sessionManager = SessionManager.inMemory(tempDir);
+	const settingsManager = SettingsManager.create(tempDir, tempDir);
+	const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settingsManager,
+		cwd: tempDir,
+		modelRegistry: ModelRegistry.create(authStorage, tempDir),
+		resourceLoader,
+	});
+	let rebind: (() => Promise<void>) | undefined;
+	const runtimeHost = {
+		session,
+		newSession: vi.fn(async () => ({ cancelled: true })),
+		switchSession: vi.fn(async () => ({ cancelled: true })),
+		fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
+		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn((callback: () => Promise<void>) => {
+			rebind = callback;
+		}),
+	} as unknown as AgentSessionRuntime;
+	return {
+		runtimeHost,
+		resourceLoader,
+		rebind: async () => {
+			if (!rebind) throw new Error("RPC handler did not register its rebind callback");
+			await rebind();
+		},
+		cleanup: () => session.dispose(),
+	};
+}
+
+describe("RPC loaded surfaces", () => {
+	let tempDir: string;
+	let cleanup: () => void = () => {};
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `rpc-loaded-surfaces-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		cleanup();
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("returns one loaded extension row per ResourceLoader extension, including commandless extensions", async () => {
+		const collected = makeSink();
+		const harness = await makeHarness(tempDir);
+		cleanup = harness.cleanup;
+		const handler = createRpcConnectionHandler(harness.runtimeHost, collected.sink);
+
+		await handler.handleInputLine(JSON.stringify({ id: "surfaces", type: "get_loaded_surfaces" }));
+
+		expect(await collected.waitFor((message) => message.id === "surfaces")).toMatchObject({
+			type: "response",
+			command: "get_loaded_surfaces",
+			success: true,
+			data: {
+				extensions: [
+					{
+						name: "commandless-extension",
+						path: join(tempDir, "commandless-extension.ts"),
+						enabled: true,
+						sourceInfo: sourceInfo(join(tempDir, "commandless-extension.ts")),
+					},
+					{
+						name: "commandful-extension",
+						path: join(tempDir, "commandful-extension.ts"),
+						enabled: true,
+					},
+				],
+				mcpServers: [
+					{ name: "connected-server", toolCount: 2, authStatus: "bearerToken", status: "connected" },
+					{ name: "login-server", toolCount: 0, authStatus: "notLoggedIn", status: "needs_auth" },
+				],
+			},
+		});
+		await handler.dispose();
+	});
+
+	it("reads configured MCP servers from the session-owned live service bridge", async () => {
+		const cwd = join(tempDir, "project");
+		const agentDir = join(tempDir, "agent");
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(
+			join(agentDir, "mcp.json"),
+			`${JSON.stringify({
+				mcpServers: {
+					"configured-disabled": { type: "stdio", command: "unused", enabled: false },
+				},
+			})}\n`,
+		);
+		vi.stubEnv(ENV_AGENT_DIR, agentDir);
+		const service = new McpService();
+		const settingsManager = SettingsManager.inMemory({ enabledBuiltinExtensions: [] });
+		const resourceLoader = new DefaultResourceLoader({
+			cwd,
+			agentDir,
+			settingsManager,
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+			noContextFiles: true,
+			extensionFactories: [{ name: "mcp-control-test", factory: createMcpExtension(service) }],
+		});
+		await resourceLoader.reload();
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("model not found");
+		const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const session = new AgentSession({
+			agent: new Agent({
+				getApiKey: () => "test-key",
+				initialState: { model, systemPrompt: "Test", tools: [] },
+				streamFn: () => {
+					throw new Error("RPC inventory tests must not call a model");
+				},
+			}),
+			sessionManager: SessionManager.inMemory(cwd),
+			settingsManager,
+			cwd,
+			modelRegistry: ModelRegistry.create(authStorage, agentDir),
+			resourceLoader,
+		});
+		const runtimeHost = {
+			session,
+			newSession: vi.fn(async () => ({ cancelled: true })),
+			switchSession: vi.fn(async () => ({ cancelled: true })),
+			fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
+			dispose: vi.fn(async () => {}),
+			setRebindSession: vi.fn(),
+		} as unknown as AgentSessionRuntime;
+		const collected = makeSink();
+		const handler = createRpcConnectionHandler(runtimeHost, collected.sink);
+		try {
+			await handler.handleInputLine(JSON.stringify({ id: "live-mcp", type: "get_loaded_surfaces" }));
+			expect(await collected.waitFor((message) => message.id === "live-mcp")).toMatchObject({
+				success: true,
+				data: {
+					mcpServers: [
+						{
+							name: "configured-disabled",
+							toolCount: 0,
+							status: "disabled",
+							authStatus: "unsupported",
+						},
+					],
+				},
+			});
+		} finally {
+			await handler.dispose();
+			session.dispose();
+			await service.dispose("quit");
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("emits loaded_surfaces_changed for skill, extension, and MCP inventory transitions but not initial bind", async () => {
+		const collected = makeSink();
+		const harness = await makeHarness(tempDir);
+		cleanup = harness.cleanup;
+		const handler = createRpcConnectionHandler(harness.runtimeHost, collected.sink);
+		await handler.ready;
+		expect(collected.messages().filter((message) => message.type === "loaded_surfaces_changed")).toEqual([]);
+
+		let afterIndex = collected.messages().length;
+		const skillChanged = collected.waitFor((message) => message.type === "loaded_surfaces_changed", afterIndex);
+		harness.resourceLoader.skills.push(skill("beta"));
+		await harness.rebind();
+		expect(await skillChanged).toEqual({ type: "loaded_surfaces_changed" });
+
+		afterIndex = collected.messages().length;
+		const extensionChanged = collected.waitFor((message) => message.type === "loaded_surfaces_changed", afterIndex);
+		harness.resourceLoader.extensionsResult.extensions.push(
+			(
+				await createTestExtensionsResult(
+					[{ path: join(tempDir, "later-commandless.ts"), factory: () => {} }],
+					tempDir,
+				)
+			).extensions[0]!,
+		);
+		await harness.rebind();
+		expect(await extensionChanged).toEqual({ type: "loaded_surfaces_changed" });
+
+		afterIndex = collected.messages().length;
+		const mcpChanged = collected.waitFor((message) => message.type === "loaded_surfaces_changed", afterIndex);
+		harness.resourceLoader.mcpSnapshot = {
+			servers: [mcpServer("connected-server", ["one", "two", "three"], "oAuth", "connected")],
+		};
+		harness.resourceLoader.emitExtensionEvent?.(MCP_INVENTORY_CHANGED_EVENT, {
+			sessionId: harness.runtimeHost.session.sessionId,
+			snapshot: harness.resourceLoader.mcpSnapshot,
+		});
+		expect(await mcpChanged).toEqual({ type: "loaded_surfaces_changed" });
+
+		await handler.dispose();
+	});
+});

--- a/packages/coding-agent/test/rpc-session-registry.test.ts
+++ b/packages/coding-agent/test/rpc-session-registry.test.ts
@@ -197,6 +197,20 @@ describe("RPC session registry", () => {
 	test("returns unknown_session for an unknown or terminal handle", async () => {
 		const { dir, registry } = await createRegistry();
 		await expect(registry.close("does-not-exist")).rejects.toMatchObject({ code: "unknown_session" });
+		const router = new SessionCommandRouter(registry, new SessionEventWriter(() => {}), { cwd: dir });
+		expect(
+			await router.handle({
+				id: "missing-surfaces",
+				type: "get_loaded_surfaces",
+				sessionId: "does-not-exist",
+			}),
+		).toEqual({
+			id: "missing-surfaces",
+			type: "response",
+			command: "get_loaded_surfaces",
+			success: false,
+			error: "unknown_session",
+		});
 		const opened = await registry.openSession(profile(dir, join(dir, "closed.jsonl")));
 		await registry.close(opened.sessionId);
 		await expect(registry.close(opened.sessionId)).rejects.toMatchObject({ code: "unknown_session" });


### PR DESCRIPTION
## Summary

- add the session-scoped `get_loaded_surfaces` control request
- report loaded extensions directly from `session.resourceLoader.getExtensions().extensions`
- report live MCP server name, tool count, connection/config status, and non-secret auth status from the session-owned MCP service
- emit `loaded_surfaces_changed` when the loaded skills, extensions, or MCP inventory changes

## Why

`get_commands` is the correct skill inventory because it emits one row per loaded skill. It is not a valid extension inventory: it emits one row per registered command, which hides commandless extensions and duplicates extensions that register multiple commands.

Multi-session RPC also owns one MCP service per session/provider scope, so consulting the classic process singleton would return the wrong runtime. This PR bridges each scoped MCP service through its session-local resource event bus instead.

## Wire shape

```json
{"type":"get_loaded_surfaces","sessionId":"rpc-1"}
```

```json
{
  "type": "response",
  "command": "get_loaded_surfaces",
  "success": true,
  "data": {
    "extensions": [{ "name": "example", "path": "/path/example.ts", "sourceInfo": {}, "enabled": true }],
    "mcpServers": [{ "name": "filesystem", "toolCount": 12, "status": "connected", "authStatus": "unsupported" }]
  },
  "sessionId": "rpc-1"
}
```

The invalidation event is payload-free:

```json
{"type":"loaded_surfaces_changed","sessionId":"rpc-1"}
```

Clients then re-read `get_commands` for skills and `get_loaded_surfaces` for extensions/MCP, matching the app-server `skills/changed` model.

## Verification

- failing-first focused coverage for commandless and multi-command extensions, live MCP projection, all three inventory-change sources, startup suppression, and unknown session routing
- `npm run check`
- 26 focused RPC/MCP tests
- full workspace build, followed by a successful coding-agent package rebuild
- isolated `senpi-qa` RPC self-test
- raw built-CLI multi-session QA: `open_session`, `get_commands`, and `get_loaded_surfaces`
  - exactly 21 OmO builtin skill rows observed through `get_commands`
  - commandless extension observed exactly once through `get_loaded_surfaces`
  - configured live MCP servers observed with tool count/status/auth
  - unknown `sessionId` returned `unknown_session` and the process remained alive

## Compatibility

- app-server wire behavior is unchanged
- classic RPC remains untagged and gains only the additive request/event
- MCP auth values and credentials are never exposed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose loaded extensions and MCP servers over the session‑scoped RPC control protocol with `get_loaded_surfaces`, plus `loaded_surfaces_changed` invalidations. Live MCP status now includes connection/config state and uses serialized refresh to keep snapshots accurate.

- **New Features**
  - Added `get_loaded_surfaces` returning `{ extensions, mcpServers }`. Extensions come from `resourceLoader.getExtensions()` (commandless included; no duplicates). MCP rows include `name`, `toolCount`, `status`, and `authStatus`.
  - Emitted `loaded_surfaces_changed` when skills, extensions, or MCP inventory change; clients should re‑read `get_commands` and `get_loaded_surfaces`.
  - Bridged MCP inventory through the session event bus from the session‑owned MCP service; initial bind suppresses the invalidation event.
  - Unknown `sessionId` returns `unknown_session`; no secrets or credentials are exposed.

- **Bug Fixes**
  - Preserved MCP attach lifecycle and serialized wire‑status refreshes to prevent races and stale snapshots; status now reflects connection or config state. Listeners are torn down on reload/quit to avoid leaks.

<sup>Written for commit 4836c55b8c16a0127c3edb1ed97a656441136a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

