### PR TITLE
fix(ai): retry gateway model-request rejections instead of failing the turn

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/fake-model-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/fake-model-server.mjs
@@ -113,6 +113,9 @@ function validateScriptedTurns(turns) {
 		if (typeof error.message !== "string" || !error.message.trim()) {
 			throw new Error(`${label}: error.message must be a non-empty string`);
 		}
+		if (error.type !== undefined && (typeof error.type !== "string" || !error.type.trim())) {
+			throw new Error(`${label}: error.type must be a non-empty string when given`);
+		}
 		const successField = ["reasoning", "text", "chunks", "chunkDelayMs", "toolCalls"].find((field) => Object.hasOwn(turn, field));
 		if (successField) {
 			throw new Error(`${label}: error turns cannot also define ${successField}`);
@@ -129,7 +132,7 @@ function sendProviderError(res, error) {
 	sendJson(res, error.status, {
 		error: {
 			message: error.message,
-			type: error.status === 429 ? "rate_limit_error" : "server_error",
+			type: error.type ?? (error.status === 429 ? "rate_limit_error" : "server_error"),
 		},
 	});
 }

--- a/.agents/skills/senpi-qa/scripts/lib/fake-model-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/fake-model-server.mjs
@@ -9,9 +9,9 @@
  *   - `/responses`         -> OpenAI Responses         (api "openai-responses")
  *
  * Turns are scripted protocol-independently ({ reasoning?, text?, toolCalls? })
- * or as exclusive provider failures ({ error: { status, message } }). Success
- * handlers render matching SSE; errors return non-200 provider JSON. Run
- * `node fake-model-server.mjs --self-test`.
+ * or as exclusive provider failures ({ error: { status, message, type? } }).
+ * Success handlers render matching SSE; errors return non-200 provider JSON.
+ * Run `node fake-model-server.mjs --self-test`.
  */
 
 import { createServer } from "node:http";
@@ -20,7 +20,7 @@ import { pathToFileURL } from "node:url";
 const isMain = import.meta.url === pathToFileURL(process.argv[1] || "").href;
 
 /**
- * @param {{ port?: number, turns?: Array<{reasoning?:string, text?:string, chunks?:number, chunkDelayMs?:number, toolCalls?:Array<{id?:string,name:string,args:object}>, error?:{status:number,message:string}}> }} opts
+ * @param {{ port?: number, turns?: Array<{reasoning?:string, text?:string, chunks?:number, chunkDelayMs?:number, toolCalls?:Array<{id?:string,name:string,args:object}>, error?:{status:number,message:string,type?:string}}> }} opts
  * @returns {Promise<{url:string, origin:string, port:number, requests:object[], streamLog:Array<{streamId:number,protocol:string,kind:string,delta:string}>, stop:()=>Promise<void>}>}
  *
  * A turn's non-empty `reasoning` and `text` fields are each emitted as ONE delta

--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-retry.mjs
@@ -40,6 +40,20 @@ const STANDARD_RETRY_SCENARIOS = {
 		primaryAttempts: 3,
 		fallbackAttempts: 0,
 	},
+	"model-request-rejected-recover": {
+		// 400 + invalid_request_error keeps every pre-existing status/text pattern
+		// from matching, so recovery can only be credited to the "model request was
+		// rejected" classifier entry.
+		error: {
+			status: 400,
+			message: "The model request was rejected. Check the request and try again.",
+			type: "invalid_request_error",
+		},
+		errorCount: 1,
+		marker: "SENPI-QA-RETRY-MODEL-REQUEST-REJECTED-7d21",
+		primaryAttempts: 2,
+		fallbackAttempts: 0,
+	},
 	"budget-exhaust": {
 		error: { status: 500, message: "overloaded_error" },
 		errorCount: 4,

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -627,7 +627,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
-			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|ttsr-collapse|ttsr-leak|ttsr-repetitive-turns> [--api <name>]",
+			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|model-request-rejected-recover|ttsr-collapse|ttsr-leak|ttsr-repetitive-turns> [--api <name>]",
 			"  node mock-loop.mjs --scenario <hinted-429-in-turn|no-hint-429-fast-fallback|hinted-429-probe-back|no-hint-429-no-chain>",
 			"  node mock-loop.mjs --run <prompt> [--api <name>]",
 			`  APIs: ${ALL_APIS.join(", ")}`,

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Gateway/provider failures reported as `The model request was rejected. Check the request and try again.` now go
+  through the configured bounded retry policy instead of failing immediately or burning the fallback chain
+  ([#806](https://github.com/code-yeongyu/senpi/pull/806)).
 - `OAuthAuth` accepts an optional availability `check` that `checkProviderAuth` consults in the stored-OAuth
   branch, so a provider whose stored credential does not by itself imply usability (for example a zero-account
   sentinel) is no longer reported as configured. When `check` is absent, behavior is unchanged

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,26 @@
 # AI Source Changes
 
+## 2026-08-11 - Retry gateway model-request rejections
+
+### What changed and why
+
+- `utils/retry.ts` classifies `"model request was rejected"` as retryable so a gateway/proxy-side "The model
+  request was rejected. Check the request and try again." response is absorbed by the bounded same-model retry
+  policy (`settings.retry`) instead of failing the turn or immediately burning the fallback chain. Observed in a
+  live session on 2026-08-11. The anchor stays on "model request" so permission denials, content refusals, and
+  request-shape errors remain terminal, and the non-retryable list still wins on overlap.
+
+### Why this cannot be expressed externally
+
+- The transient-vs-terminal message classifier is package-internal; callers and extensions consume its verdict
+  through `retryAssistantCall`/`isRetryableAssistantError` and cannot add a message class without forking the
+  retry loop.
+
+### Expected merge conflict zones
+
+- LOW: additive pattern in `utils/retry.ts`, additive cases in `test/retry.test.ts`, additive mock-loop scenario
+  and optional scripted-error `type` under `.agents/skills/senpi-qa/scripts/`.
+
 ## 2026-08-11 - Optional availability `check` on `OAuthAuth`
 
 ### What changed and why

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -7,8 +7,9 @@
 - `utils/retry.ts` classifies `"model request was rejected"` as retryable so a gateway/proxy-side "The model
   request was rejected. Check the request and try again." response is absorbed by the bounded same-model retry
   policy (`settings.retry`) instead of failing the turn or immediately burning the fallback chain. Observed in a
-  live session on 2026-08-11. The anchor stays on "model request" so permission denials, content refusals, and
-  request-shape errors remain terminal, and the non-retryable list still wins on overlap.
+  live session on 2026-08-11. The classifier couples the rejection sentence to its explicit "Check the request and
+  try again." instruction so permission denials, content refusals, and request-shape errors remain terminal, and
+  the non-retryable list still wins on overlap.
 
 ### Why this cannot be expressed externally
 

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -111,12 +111,11 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
 
 	// Gateway/proxy-side rejection of the whole model request, e.g. "Error: The
 	// model request was rejected. Check the request and try again." (observed in a
-	// live session, 2026-08-11). The upstream lane is momentarily unable to serve
-	// the request; the wording carries no request-shape or quota semantics, so the
-	// bounded retry policy absorbs it instead of killing the turn. Anchored on
-	// "model request" so unrelated rejections (permission denials, request-shape
-	// errors) stay terminal.
-	"model request was rejected",
+	// live session, 2026-08-11). Coupling the rejection sentence to its explicit
+	// retry instruction keeps unrelated permission, request-shape, and content-
+	// policy rejections terminal while the bounded retry policy absorbs this
+	// transient wrapper wording.
+	"the model request was rejected\\.\\s*check the request and try again\\.?",
 
 	// Anthropic server-tool pairing rejections, e.g. "`web_search` tool use with id
 	// `srvtoolu_...` was found without a corresponding `web_search_tool_result`

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -109,6 +109,15 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
 	"try your request again",
 	"please retry your request",
 
+	// Gateway/proxy-side rejection of the whole model request, e.g. "Error: The
+	// model request was rejected. Check the request and try again." (observed in a
+	// live session, 2026-08-11). The upstream lane is momentarily unable to serve
+	// the request; the wording carries no request-shape or quota semantics, so the
+	// bounded retry policy absorbs it instead of killing the turn. Anchored on
+	// "model request" so unrelated rejections (permission denials, request-shape
+	// errors) stay terminal.
+	"model request was rejected",
+
 	// Anthropic server-tool pairing rejections, e.g. "`web_search` tool use with id
 	// `srvtoolu_...` was found without a corresponding `web_search_tool_result`
 	// block". A turn closed before its deferred server tool could answer leaves

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -31,6 +31,11 @@ const apitopiaToolSchemaRejectionMessage =
 const moonshotToolSchemaRejectionMessage =
 	"500 server_error: Invalid request: tools.0.function.parameters: invalid tool schema";
 const gatewayModelRequestRejectedMessage = "Error: The model request was rejected. Check the request and try again.";
+const nonCanonicalModelRequestRejectionMessages = [
+	"Error: The model request was rejected because this API key does not have permission to use it.",
+	"Error: The model request was rejected because max_tokens must be greater than or equal to 1.",
+	"Error: The model request was rejected by the safety classifier.",
+] as const;
 
 describe("provider retry classification", () => {
 	it("matches explicit provider retry guidance", () => {
@@ -274,17 +279,57 @@ describe("provider retry classification", () => {
 		).toBe(true);
 	});
 
-	it("matches gateway-side model-request rejections as transient", () => {
+	it("matches the canonical gateway model-request rejection as transient", () => {
 		// Gateways/proxies answer with "The model request was rejected. Check the
 		// request and try again." when the upstream lane is momentarily unable to
-		// serve the request (observed in a live session, 2026-08-11). The wording
-		// carries no request-shape or quota semantics, so the bounded retry
-		// policy is exactly what should absorb it instead of killing the turn.
+		// serve the request. Coupling both sentences keeps unrelated permission,
+		// request-shape, and content-policy rejections terminal.
 		expect(
 			isRetryableAssistantError(
 				fauxAssistantMessage("", { stopReason: "error", errorMessage: gatewayModelRequestRejectedMessage }),
 			),
 		).toBe(true);
+	});
+
+	it.each(nonCanonicalModelRequestRejectionMessages)(
+		"keeps non-canonical model-request rejections terminal: %s",
+		(errorMessage) => {
+			expect(isRetryableAssistantError(fauxAssistantMessage("", { stopReason: "error", errorMessage }))).toBe(false);
+		},
+	);
+
+	it.each(["refusal", "sensitive"] as const)(
+		"keeps typed %s messages terminal even with the canonical retry wording",
+		(type) => {
+			expect(
+				isRetryableAssistantError(
+					fauxAssistantMessage("", {
+						stopReason: "error",
+						errorMessage: gatewayModelRequestRejectedMessage,
+						stopDetails: { type },
+					}),
+				),
+			).toBe(false);
+		},
+	);
+
+	it("keeps non-retryable overlap precedence over the canonical retry wording", () => {
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: `${gatewayModelRequestRejectedMessage} quota exceeded`,
+				}),
+			),
+		).toBe(false);
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: `${gatewayModelRequestRejectedMessage} Invalid request: tools.0.function.parameters.type is required`,
+				}),
+			),
+		).toBe(false);
 	});
 
 	it("keeps provider limit errors non-retryable", () => {

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -30,6 +30,7 @@ const apitopiaToolSchemaRejectionMessage =
 	'500 data: {"error":{"message":"500 server_error: Invalid request: tools.function.parameters.type is required and must be \\"object\\"","type":"server_error","code":500,"status":500,"statusCode":500,"isRetryable":true}}\n\ndata:[DONE]\n\n';
 const moonshotToolSchemaRejectionMessage =
 	"500 server_error: Invalid request: tools.0.function.parameters: invalid tool schema";
+const gatewayModelRequestRejectedMessage = "Error: The model request was rejected. Check the request and try again.";
 
 describe("provider retry classification", () => {
 	it("matches explicit provider retry guidance", () => {
@@ -273,6 +274,19 @@ describe("provider retry classification", () => {
 		).toBe(true);
 	});
 
+	it("matches gateway-side model-request rejections as transient", () => {
+		// Gateways/proxies answer with "The model request was rejected. Check the
+		// request and try again." when the upstream lane is momentarily unable to
+		// serve the request (observed in a live session, 2026-08-11). The wording
+		// carries no request-shape or quota semantics, so the bounded retry
+		// policy is exactly what should absorb it instead of killing the turn.
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", { stopReason: "error", errorMessage: gatewayModelRequestRejectedMessage }),
+			),
+		).toBe(true);
+	});
+
 	it("keeps provider limit errors non-retryable", () => {
 		expect(
 			isRetryableAssistantError(
@@ -362,6 +376,21 @@ describe("retryAssistantCall", () => {
 		expect(res.content).toEqual([{ type: "text", text: "recovered" }]);
 		expect(produce).toHaveBeenCalledTimes(3);
 		expect(onRetryFinished).toHaveBeenCalledWith(true, 2);
+	});
+
+	it("retries a model-request rejection once then returns the recovered response", async () => {
+		let n = 0;
+		const produce = vi.fn(async () => {
+			n++;
+			return n < 2
+				? fauxAssistantMessage("", { stopReason: "error", errorMessage: gatewayModelRequestRejectedMessage })
+				: fauxAssistantMessage("recovered");
+		});
+		const onRetryScheduled = vi.fn();
+		const res = await retryAssistantCall(produce, enabled, undefined, { onRetryScheduled });
+		expect(res.content).toEqual([{ type: "text", text: "recovered" }]);
+		expect(produce).toHaveBeenCalledTimes(2);
+		expect(onRetryScheduled).toHaveBeenCalledTimes(1);
 	});
 
 	it("reports an aborted retried call as unsuccessful", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Gateway/provider failures reported as `The model request was rejected. Check the request and try again.` now retry
+  the current model according to `settings.retry` before the configured fallback chain is used
+  ([#806](https://github.com/code-yeongyu/senpi/pull/806)).
 - `/goal resume` can explicitly reactivate a completed goal and queue its continuation, while completed goals remain excluded from automatic restart-resume prompts.
 - A launch from a deleted working directory (for example a removed worktree) no longer crashes during
   startup with `uv_cwd`; the CLI recovers into the home directory before any dependency evaluates


### PR DESCRIPTION
## Summary

When a gateway/provider returns the canonical error `The model request was rejected. Check the request and try again.`, senpi now sends that failure through the configured bounded same-model retry policy (`settings.retry`) before the fallback chain. The matcher couples both sentences; unrelated permission, deterministic request-shape, and untyped content-policy rejections remain terminal.

## Changes

- **Retry classification:** recognizes the canonical two-sentence gateway rejection (case-insensitive, whitespace-tolerant, optional final period) without matching merely the first `model request was rejected` clause.
- **Unit coverage:** exact canonical classification + successful retry-loop recovery; negative cases for permission/auth, deterministic parameter, untyped safety, typed refusal/sensitive, quota overlap, and tool-schema overlap.
- **Real CLI scenario:** `model-request-rejected-recover` scripts `400 invalid_request_error` so no pre-existing status/type pattern can make it pass; expects two attempts on the primary model and zero fallback attempts.
- **QA fixture:** fake model server accepts and documents optional scripted `error.type`; default mappings are unchanged.
- **Fork/release notes:** `packages/ai/src/changes.md` and both release-managed `[Unreleased]` changelogs document the behavior.

## QA & Evidence

Artifacts: `local-ignore/qa-evidence/20260811-retry-model-rejected/` (gitignored; no credentials).

- **Original unit RED (observed before implementation):** 2 failed / 37 passed — exact classification returned false and `retryAssistantCall` did not retry.
- **Auditable original-base mutation RED:** final 45-test file against `origin/main`'s pre-fix `retry.ts` → exactly 2 failed / 43 passed (`vitest-retry-original-base-mutation-RED.txt`). Restored final source immediately; 45/45 GREEN (`vitest-retry-final-GREEN.txt`).
- **Specificity RED→GREEN:** broad substring matcher → 3 failed / 42 passed for permanent near-matches (`vitest-retry-specificity-RED.txt`); canonical two-sentence matcher → 45/45 PASS (`vitest-retry-specificity-GREEN.txt`).
- **Real CLI, OpenAI-compatible:** primary attempts 2, fallback 0, `switched=no`, 2/2 PASS (`mock-loop-GREEN-final.txt`).
- **Real CLI, Anthropic Messages:** primary attempts 2, fallback 0, `switched=no`, 2/2 PASS (`mock-loop-GREEN-anthropic-final.txt`).
- **Fixture self-test:** fake model server 9/9 PASS (`fake-model-server-self-test.txt`).
- **Full static validation:** `npm run check` exit 0 (`npm-run-check-final.txt`).
- **Changelog gate:** PASS for `packages/ai/CHANGELOG.md` and `packages/coding-agent/CHANGELOG.md`.
- Every mock-loop run asserted real `~/.senpi/agent/auth.json` unchanged and cleaned up its local server/sandbox.

## Risks & Residuals

- A permanently failing provider that emits the exact canonical retry instruction will consume only the configured bounded retry budget, then surface/fallback normally. This is the requested behavior.
- Non-retryable precedence remains first; quota/billing/credits/tool-schema overlaps remain terminal. Typed refusal/sensitive messages remain terminal before text classification.
- The originating session was not recoverable from any registered store across the five-machine fleet; the authoritative wording is the user's exact pasted error.
