### PR TITLE
fix(coding-agent): survive an unresolvable Windows taskkill

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -165,10 +165,11 @@
 - Refresh `abortServerSideFallback` from the host's next-turn snapshot so an active agent run cannot carry a prior
   model's server-fallback policy into the next provider request
   ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
-- The Node harness Windows process-tree kill no longer raises an uncaught `spawn taskkill ENOENT`. It runs the absolute
-  `System32\taskkill.exe` synchronously and falls back to killing the direct child when the launcher cannot start, so a
-  teardown that exits in the same tick still terminates its children
-  ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
+- The Node harness Windows process-tree kill no longer raises an uncaught `spawn taskkill ENOENT`. It tries every
+  absolute `System32` / `Sysnative` `taskkill.exe` before the PATH-resolved name, runs synchronously so a teardown
+  that exits in the same tick still terminates its children, and degrades to killing the direct child only when no
+  launcher starts at all ([#812](https://github.com/code-yeongyu/senpi/issues/812),
+  [#807](https://github.com/code-yeongyu/senpi/pull/807)).
 
 ### Removed
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -165,9 +165,10 @@
 - Refresh `abortServerSideFallback` from the host's next-turn snapshot so an active agent run cannot carry a prior
   model's server-fallback policy into the next provider request
   ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
-- The Node harness Windows process-tree kill no longer raises an uncaught `spawn taskkill ENOENT`. It launches the
-  absolute `System32\taskkill.exe`, handles the asynchronous spawn `error` event, and falls back to killing the direct
-  child so the target still dies ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
+- The Node harness Windows process-tree kill no longer raises an uncaught `spawn taskkill ENOENT`. It runs the absolute
+  `System32\taskkill.exe` synchronously and falls back to killing the direct child when the launcher cannot start, so a
+  teardown that exits in the same tick still terminates its children
+  ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
 
 ### Removed
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -167,7 +167,7 @@
   ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
 - The Node harness Windows process-tree kill no longer raises an uncaught `spawn taskkill ENOENT`. It launches the
   absolute `System32\taskkill.exe`, handles the asynchronous spawn `error` event, and falls back to killing the direct
-  child so the target still dies.
+  child so the target still dies ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
 
 ### Removed
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -165,6 +165,9 @@
 - Refresh `abortServerSideFallback` from the host's next-turn snapshot so an active agent run cannot carry a prior
   model's server-fallback policy into the next provider request
   ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
+- The Node harness Windows process-tree kill no longer raises an uncaught `spawn taskkill ENOENT`. It launches the
+  absolute `System32\taskkill.exe`, handles the asynchronous spawn `error` event, and falls back to killing the direct
+  child so the target still dies.
 
 ### Removed
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -59,14 +59,15 @@
 ### What changed and why
 
 - `harness/env/nodejs.ts`: the Windows branch of the harness `killProcessTree` moved into the exported
-  `killWindowsProcessTree`, which resolves `%SystemRoot%\System32\taskkill.exe` through the new
-  `resolveWindowsTaskkillPath`, runs the killer with `spawnSync` under a 5s timeout, and falls back to
-  `process.kill(pid)` when the launcher never started or the timeout fired.
+  `killWindowsProcessTree`, which walks the ordered launcher list from the new `windowsTaskkillCandidates` export
+  (every existing absolute `System32` / `Sysnative` `taskkill.exe`, then the bare PATH-resolved name), runs each with
+  `spawnSync` under a 5s timeout, and only degrades to `process.kill(pid)` when no launcher starts at all.
 - `spawn("taskkill", ...)` resolves through PATH and reports a failed lookup asynchronously on the child's `error`
   event, so the surrounding `try`/`catch` never observed it. Without a listener Node re-emits ENOENT as an uncaught
   exception, killing the host process instead of the target tree whenever PATH had lost `%SystemRoot%\System32`.
 - The kill is synchronous so a caller that tears down and exits in the same tick still terminates its children;
-  `spawnSync` also reports a failed lookup on its returned `error` field instead of emitting it.
+  `spawnSync` also reports a failed lookup on its returned `error` field instead of emitting it. The direct
+  `process.kill` stays a last resort because `TerminateProcess` leaves descendants orphaned.
 - The same fix lands in `packages/coding-agent/src/utils/shell.ts`; the two harnesses keep independent copies of this
   helper as they already do for `getShellEnv` and bash resolution.
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -60,11 +60,13 @@
 
 - `harness/env/nodejs.ts`: the Windows branch of the harness `killProcessTree` moved into the exported
   `killWindowsProcessTree`, which resolves `%SystemRoot%\System32\taskkill.exe` through the new
-  `resolveWindowsTaskkillPath`, registers an `error` listener on the spawned killer, falls back to
-  `process.kill(pid)` when the launcher never starts, and `unref()`s the detached child.
+  `resolveWindowsTaskkillPath`, runs the killer with `spawnSync` under a 5s timeout, and falls back to
+  `process.kill(pid)` when the launcher never started or the timeout fired.
 - `spawn("taskkill", ...)` resolves through PATH and reports a failed lookup asynchronously on the child's `error`
   event, so the surrounding `try`/`catch` never observed it. Without a listener Node re-emits ENOENT as an uncaught
   exception, killing the host process instead of the target tree whenever PATH had lost `%SystemRoot%\System32`.
+- The kill is synchronous so a caller that tears down and exits in the same tick still terminates its children;
+  `spawnSync` also reports a failed lookup on its returned `error` field instead of emitting it.
 - The same fix lands in `packages/coding-agent/src/utils/shell.ts`; the two harnesses keep independent copies of this
   helper as they already do for `getShellEnv` and bash resolution.
 
@@ -74,7 +76,8 @@
 
 ### Expected merge conflict zones on next upstream sync
 
-- LOW: the Windows branch of `killProcessTree` and the `node:fs` import line in `harness/env/nodejs.ts`.
+- LOW: the Windows branch of `killProcessTree` and the `node:child_process` / `node:fs` import lines in
+  `harness/env/nodejs.ts`.
 
 ## 2026-08-10 - Refresh server-fallback policy between tool turns
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -54,6 +54,28 @@
 - LOW: `agent-loop.ts` unknown-tool preparation branch.
 - LOW: `agent.ts` loop-config forwarding.
 
+## 2026-08-11 - Windows process-tree kill survives an unresolvable taskkill
+
+### What changed and why
+
+- `harness/env/nodejs.ts`: the Windows branch of the harness `killProcessTree` moved into the exported
+  `killWindowsProcessTree`, which resolves `%SystemRoot%\System32\taskkill.exe` through the new
+  `resolveWindowsTaskkillPath`, registers an `error` listener on the spawned killer, falls back to
+  `process.kill(pid)` when the launcher never starts, and `unref()`s the detached child.
+- `spawn("taskkill", ...)` resolves through PATH and reports a failed lookup asynchronously on the child's `error`
+  event, so the surrounding `try`/`catch` never observed it. Without a listener Node re-emits ENOENT as an uncaught
+  exception, killing the host process instead of the target tree whenever PATH had lost `%SystemRoot%\System32`.
+- The same fix lands in `packages/coding-agent/src/utils/shell.ts`; the two harnesses keep independent copies of this
+  helper as they already do for `getShellEnv` and bash resolution.
+
+### Why the extension system could not handle this
+
+- The kill runs inside the Node harness's own process supervision, below every extension hook.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: the Windows branch of `killProcessTree` and the `node:fs` import line in `harness/env/nodejs.ts`.
+
 ## 2026-08-10 - Refresh server-fallback policy between tool turns
 
 ### What changed and why

--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { constants, createReadStream } from "node:fs";
+import { constants, createReadStream, existsSync } from "node:fs";
 import {
 	access,
 	appendFile,
@@ -250,17 +250,61 @@ function getShellEnv(
 	};
 }
 
+/**
+ * Resolve the Windows `taskkill` executable.
+ *
+ * `spawn("taskkill", ...)` relies on a PATH lookup, so any session whose PATH lost
+ * `%SystemRoot%\System32` (a POSIX-style PATH inherited from a Git Bash/MSYS launcher,
+ * a truncated user PATH, a locked-down service account) fails to resolve it. Prefer the
+ * absolute System32 path and keep the bare executable name as the last resort.
+ */
+export function resolveWindowsTaskkillPath(env: NodeJS.ProcessEnv = process.env): string {
+	const systemRoot = env.SystemRoot ?? env.SYSTEMROOT ?? env.windir;
+	if (systemRoot) {
+		const absolute = join(systemRoot, "System32", "taskkill.exe");
+		if (existsSync(absolute)) return absolute;
+	}
+	return "taskkill.exe";
+}
+
+function killProcessDirectly(pid: number): void {
+	try {
+		process.kill(pid);
+	} catch {
+		// Process already dead.
+	}
+}
+
+/**
+ * Kill a process and all its children on Windows via `taskkill /T`.
+ *
+ * `spawn()` reports a failed executable lookup asynchronously through the child's
+ * `error` event, never by throwing — so a surrounding `try`/`catch` cannot see it.
+ * Without an `error` listener Node re-emits ENOENT as an uncaught exception that
+ * takes down the host process. Handle the event and fall back to the direct child.
+ */
+export function killWindowsProcessTree(pid: number, taskkillPath = resolveWindowsTaskkillPath()): void {
+	let killer: ChildProcess;
+	try {
+		killer = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
+			stdio: "ignore",
+			detached: true,
+			windowsHide: true,
+		});
+	} catch {
+		killProcessDirectly(pid);
+		return;
+	}
+	killer.once("error", () => {
+		killProcessDirectly(pid);
+	});
+	// Fire-and-forget: a detached killer must not hold the event loop open during exit.
+	killer.unref();
+}
+
 function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
-		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
-				stdio: "ignore",
-				detached: true,
-				windowsHide: true,
-			});
-		} catch {
-			// Ignore errors.
-		}
+		killWindowsProcessTree(pid);
 		return;
 	}
 

--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -251,20 +251,30 @@ function getShellEnv(
 }
 
 /**
- * Resolve the Windows `taskkill` executable.
+ * Ordered `taskkill` launchers to try, most reliable first.
  *
  * `spawn("taskkill", ...)` relies on a PATH lookup, so any session whose PATH lost
  * `%SystemRoot%\System32` (a POSIX-style PATH inherited from a Git Bash/MSYS launcher,
- * a truncated user PATH, a locked-down service account) fails to resolve it. Prefer the
- * absolute System32 path and keep the bare executable name as the last resort.
+ * a truncated user PATH, a locked-down service account) fails to resolve it. A broken PATH
+ * must not cost us the process-tree kill, so every absolute System32 location that actually
+ * exists is tried before the bare PATH-resolved name.
  */
-export function resolveWindowsTaskkillPath(env: NodeJS.ProcessEnv = process.env): string {
-	const systemRoot = env.SystemRoot ?? env.SYSTEMROOT ?? env.windir;
-	if (systemRoot) {
-		const absolute = join(systemRoot, "System32", "taskkill.exe");
-		if (existsSync(absolute)) return absolute;
+export function windowsTaskkillCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+	// A bare `SystemDrive` is drive-relative ("C:"), so anchor it before joining.
+	const systemDrive = env.SystemDrive ? `${env.SystemDrive}\\` : undefined;
+	const roots = [env.SystemRoot, env.SYSTEMROOT, env.windir, systemDrive && join(systemDrive, "Windows")];
+	const candidates: string[] = [];
+	for (const root of roots) {
+		if (!root) continue;
+		// Sysnative reaches the real 64-bit System32 from a 32-bit process, where System32
+		// is redirected to SysWOW64.
+		for (const systemDir of ["System32", "Sysnative"]) {
+			const absolute = join(root, systemDir, "taskkill.exe");
+			if (!candidates.includes(absolute) && existsSync(absolute)) candidates.push(absolute);
+		}
 	}
-	return "taskkill.exe";
+	candidates.push("taskkill.exe");
+	return candidates;
 }
 
 function killProcessDirectly(pid: number): void {
@@ -301,9 +311,16 @@ function taskkillHandledTree(pid: number, taskkillPath: string): boolean {
  * also reports a failed executable lookup on its returned `error` field instead of
  * emitting it, so a PATH without `%SystemRoot%\System32` can no longer surface as an
  * uncaught `spawn taskkill ENOENT`.
+ *
+ * The direct `process.kill` at the end is a degraded last resort reached only when no
+ * `taskkill.exe` can be launched at all. It maps to `TerminateProcess`, which does not
+ * touch descendants; nothing in-process can walk a Windows process tree without an
+ * external tool, so this still beats leaving the whole tree running.
  */
-export function killWindowsProcessTree(pid: number, taskkillPath = resolveWindowsTaskkillPath()): void {
-	if (taskkillHandledTree(pid, taskkillPath)) return;
+export function killWindowsProcessTree(pid: number, taskkillPaths = windowsTaskkillCandidates()): void {
+	for (const taskkillPath of taskkillPaths) {
+		if (taskkillHandledTree(pid, taskkillPath)) return;
+	}
 	killProcessDirectly(pid);
 }
 

--- a/packages/agent/src/harness/env/nodejs.ts
+++ b/packages/agent/src/harness/env/nodejs.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { constants, createReadStream, existsSync } from "node:fs";
 import {
@@ -275,31 +275,36 @@ function killProcessDirectly(pid: number): void {
 	}
 }
 
+/** Upper bound on how long a teardown may block waiting for `taskkill` to finish. */
+const TASKKILL_TIMEOUT_MS = 5_000;
+
+function taskkillHandledTree(pid: number, taskkillPath: string): boolean {
+	try {
+		const result = spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
+			stdio: "ignore",
+			windowsHide: true,
+			timeout: TASKKILL_TIMEOUT_MS,
+		});
+		// `error` means the launcher never started (ENOENT, EACCES); a null status means
+		// the timeout killed it. Any real taskkill exit code counts as handled.
+		return result.error === undefined && result.status !== null;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Kill a process and all its children on Windows via `taskkill /T`.
  *
- * `spawn()` reports a failed executable lookup asynchronously through the child's
- * `error` event, never by throwing — so a surrounding `try`/`catch` cannot see it.
- * Without an `error` listener Node re-emits ENOENT as an uncaught exception that
- * takes down the host process. Handle the event and fall back to the direct child.
+ * Synchronous on purpose. A caller that tears down and exits in the same tick would never
+ * observe an asynchronous killer's `error` event, leaving the target alive. `spawnSync`
+ * also reports a failed executable lookup on its returned `error` field instead of
+ * emitting it, so a PATH without `%SystemRoot%\System32` can no longer surface as an
+ * uncaught `spawn taskkill ENOENT`.
  */
 export function killWindowsProcessTree(pid: number, taskkillPath = resolveWindowsTaskkillPath()): void {
-	let killer: ChildProcess;
-	try {
-		killer = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
-			stdio: "ignore",
-			detached: true,
-			windowsHide: true,
-		});
-	} catch {
-		killProcessDirectly(pid);
-		return;
-	}
-	killer.once("error", () => {
-		killProcessDirectly(pid);
-	});
-	// Fire-and-forget: a detached killer must not hold the event loop open during exit.
-	killer.unref();
+	if (taskkillHandledTree(pid, taskkillPath)) return;
+	killProcessDirectly(pid);
 }
 
 function killProcessTree(pid: number): void {

--- a/packages/agent/test/harness/kill-process-tree-windows.test.ts
+++ b/packages/agent/test/harness/kill-process-tree-windows.test.ts
@@ -53,7 +53,7 @@ describe("killWindowsProcessTree", () => {
 		process.on("uncaughtException", onUncaught);
 
 		try {
-			// spawn() surfaces ENOENT asynchronously through the child's 'error' event.
+			// An asynchronous spawn() surfaces ENOENT through the child's 'error' event.
 			// Before the fix this became an uncaughtException that killed the host process.
 			killWindowsProcessTree(pid as number, UNRESOLVABLE_TASKKILL);
 			await once(child, "exit");
@@ -62,5 +62,24 @@ describe("killWindowsProcessTree", () => {
 			process.off("uncaughtException", onUncaught);
 			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
 		}
+	});
+
+	it("issues the fallback kill synchronously, before the caller can exit", () => {
+		// A caller that tears down and exits in the same tick never reaches a later
+		// event-loop turn, so the fallback must be issued before this call returns.
+		const calls: Array<[number, NodeJS.Signals | number | undefined]> = [];
+		const realKill = process.kill.bind(process);
+		process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+			calls.push([pid, signal]);
+			return true;
+		}) as typeof process.kill;
+
+		try {
+			killWindowsProcessTree(4242, UNRESOLVABLE_TASKKILL);
+		} finally {
+			process.kill = realKill;
+		}
+
+		expect(calls).toEqual([[4242, undefined]]);
 	});
 });

--- a/packages/agent/test/harness/kill-process-tree-windows.test.ts
+++ b/packages/agent/test/harness/kill-process-tree-windows.test.ts
@@ -4,10 +4,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { killWindowsProcessTree, resolveWindowsTaskkillPath } from "../../src/harness/env/nodejs.ts";
+import { killWindowsProcessTree, windowsTaskkillCandidates } from "../../src/harness/env/nodejs.ts";
 
-/** A name that can never resolve on PATH, so spawn() fails with ENOENT on every platform. */
-const UNRESOLVABLE_TASKKILL = "senpi-nonexistent-taskkill-binary.exe";
+/** Names that can never resolve on PATH, so spawn() fails with ENOENT on every platform. */
+const UNRESOLVABLE_TASKKILL = ["senpi-nonexistent-taskkill-binary.exe"];
 
 const tempRoots: string[] = [];
 
@@ -28,16 +28,19 @@ afterEach(() => {
 	}
 });
 
-describe("resolveWindowsTaskkillPath", () => {
-	it("prefers the absolute System32 executable over a bare PATH lookup", () => {
+describe("windowsTaskkillCandidates", () => {
+	it("puts the absolute System32 executable ahead of the bare PATH lookup", () => {
 		const root = createFakeSystemRoot(true);
-		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe(join(root, "System32", "taskkill.exe"));
+		expect(windowsTaskkillCandidates({ SystemRoot: root })).toEqual([
+			join(root, "System32", "taskkill.exe"),
+			"taskkill.exe",
+		]);
 	});
 
-	it("falls back to the bare executable name when System32 has no taskkill", () => {
+	it("falls back to the bare executable name when no absolute candidate exists", () => {
 		const root = createFakeSystemRoot(false);
-		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe("taskkill.exe");
-		expect(resolveWindowsTaskkillPath({})).toBe("taskkill.exe");
+		expect(windowsTaskkillCandidates({ SystemRoot: root })).toEqual(["taskkill.exe"]);
+		expect(windowsTaskkillCandidates({})).toEqual(["taskkill.exe"]);
 	});
 });
 

--- a/packages/agent/test/harness/kill-process-tree-windows.test.ts
+++ b/packages/agent/test/harness/kill-process-tree-windows.test.ts
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { killWindowsProcessTree, resolveWindowsTaskkillPath } from "../../src/harness/env/nodejs.ts";
+
+/** A name that can never resolve on PATH, so spawn() fails with ENOENT on every platform. */
+const UNRESOLVABLE_TASKKILL = "senpi-nonexistent-taskkill-binary.exe";
+
+const tempRoots: string[] = [];
+
+function createFakeSystemRoot(withTaskkill: boolean): string {
+	const root = mkdtempSync(join(tmpdir(), "senpi-systemroot-"));
+	tempRoots.push(root);
+	if (withTaskkill) {
+		mkdirSync(join(root, "System32"), { recursive: true });
+		writeFileSync(join(root, "System32", "taskkill.exe"), "");
+	}
+	return root;
+}
+
+afterEach(() => {
+	while (tempRoots.length > 0) {
+		const root = tempRoots.pop();
+		if (root) rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("resolveWindowsTaskkillPath", () => {
+	it("prefers the absolute System32 executable over a bare PATH lookup", () => {
+		const root = createFakeSystemRoot(true);
+		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe(join(root, "System32", "taskkill.exe"));
+	});
+
+	it("falls back to the bare executable name when System32 has no taskkill", () => {
+		const root = createFakeSystemRoot(false);
+		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe("taskkill.exe");
+		expect(resolveWindowsTaskkillPath({})).toBe("taskkill.exe");
+	});
+});
+
+describe("killWindowsProcessTree", () => {
+	it("kills the child instead of crashing the process when taskkill cannot be spawned", async () => {
+		const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], { stdio: "ignore" });
+		await once(child, "spawn");
+		const pid = child.pid;
+		expect(pid).toBeDefined();
+
+		const uncaught: unknown[] = [];
+		const onUncaught = (error: unknown) => uncaught.push(error);
+		process.on("uncaughtException", onUncaught);
+
+		try {
+			// spawn() surfaces ENOENT asynchronously through the child's 'error' event.
+			// Before the fix this became an uncaughtException that killed the host process.
+			killWindowsProcessTree(pid as number, UNRESOLVABLE_TASKKILL);
+			await once(child, "exit");
+			expect(uncaught).toEqual([]);
+		} finally {
+			process.off("uncaughtException", onUncaught);
+			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+		}
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,9 +7,11 @@
 - The ambient Claude auth availability probe now passes `windowsHide: true` when spawning `claude auth status`, so the background check no longer opens a console window on Windows ([#870](https://github.com/code-yeongyu/senpi/issues/870)).
 - `senpi --help` now lists the `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` environment settings that the built-in rules extension reads, so the two environment-only character limits are discoverable from the CLI ([#678](https://github.com/code-yeongyu/senpi/issues/678)).
 - Windows shutdown no longer dies with an uncaught `Error: spawn taskkill ENOENT` when `%SystemRoot%\System32` is
-  missing from PATH. The tracked-detached-child kill now runs the absolute `System32\taskkill.exe` synchronously, so a
-  shutdown that exits in the same tick still terminates the tree, and falls back to killing the direct child when the
-  launcher cannot start ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
+  missing from PATH. The tracked-detached-child kill now tries every absolute `System32` / `Sysnative` `taskkill.exe`
+  before the PATH-resolved name, runs synchronously so a shutdown that exits in the same tick still terminates the
+  tree, and degrades to killing the direct child only when no launcher starts at all
+  ([#812](https://github.com/code-yeongyu/senpi/issues/812),
+  [#807](https://github.com/code-yeongyu/senpi/pull/807)).
 
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - The ambient Claude auth availability probe now passes `windowsHide: true` when spawning `claude auth status`, so the background check no longer opens a console window on Windows ([#870](https://github.com/code-yeongyu/senpi/issues/870)).
 - `senpi --help` now lists the `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` environment settings that the built-in rules extension reads, so the two environment-only character limits are discoverable from the CLI ([#678](https://github.com/code-yeongyu/senpi/issues/678)).
+- Windows shutdown no longer dies with an uncaught `Error: spawn taskkill ENOENT` when `%SystemRoot%\System32` is
+  missing from PATH.
+
 
 ### New Features
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,10 +7,9 @@
 - The ambient Claude auth availability probe now passes `windowsHide: true` when spawning `claude auth status`, so the background check no longer opens a console window on Windows ([#870](https://github.com/code-yeongyu/senpi/issues/870)).
 - `senpi --help` now lists the `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` environment settings that the built-in rules extension reads, so the two environment-only character limits are discoverable from the CLI ([#678](https://github.com/code-yeongyu/senpi/issues/678)).
 - Windows shutdown no longer dies with an uncaught `Error: spawn taskkill ENOENT` when `%SystemRoot%\System32` is
-  missing from PATH. The tracked-detached-child kill now launches the absolute `System32\taskkill.exe`, handles the
-  asynchronous spawn `error` event that the previous `try`/`catch` could never observe, and falls back to killing the
-  direct child so shutdown still terminates it
-  ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
+  missing from PATH. The tracked-detached-child kill now runs the absolute `System32\taskkill.exe` synchronously, so a
+  shutdown that exits in the same tick still terminates the tree, and falls back to killing the direct child when the
+  launcher cannot start ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
 
 
 ### New Features

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,10 @@
 - The ambient Claude auth availability probe now passes `windowsHide: true` when spawning `claude auth status`, so the background check no longer opens a console window on Windows ([#870](https://github.com/code-yeongyu/senpi/issues/870)).
 - `senpi --help` now lists the `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` environment settings that the built-in rules extension reads, so the two environment-only character limits are discoverable from the CLI ([#678](https://github.com/code-yeongyu/senpi/issues/678)).
 - Windows shutdown no longer dies with an uncaught `Error: spawn taskkill ENOENT` when `%SystemRoot%\System32` is
-  missing from PATH.
+  missing from PATH. The tracked-detached-child kill now launches the absolute `System32\taskkill.exe`, handles the
+  asynchronous spawn `error` event that the previous `try`/`catch` could never observe, and falls back to killing the
+  direct child so shutdown still terminates it
+  ([#807](https://github.com/code-yeongyu/senpi/pull/807)).
 
 
 ### New Features

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -28,10 +28,10 @@
 
 ### What changed
 
-- `shell.ts`: the Windows branch of `killProcessTree` moved into `killWindowsProcessTree`, which resolves
-  `%SystemRoot%\System32\taskkill.exe` through the new `resolveWindowsTaskkillPath` export, runs the killer with
-  `spawnSync` under a 5s timeout, and falls back to `process.kill(pid)` when the launcher never started or the
-  timeout fired. Both new functions are exported for direct regression coverage.
+- `shell.ts`: the Windows branch of `killProcessTree` moved into `killWindowsProcessTree`, which walks the ordered
+  launcher list from the new `windowsTaskkillCandidates` export (every existing absolute `System32` / `Sysnative`
+  `taskkill.exe`, then the bare PATH-resolved name), runs each with `spawnSync` under a 5s timeout, and only degrades
+  to `process.kill(pid)` when no launcher starts at all. Both new functions are exported for regression coverage.
 
 ### Why
 
@@ -44,6 +44,9 @@
   `process.exit(129)` in the same tick. An asynchronous killer — or a fallback wired to the child's `error` event —
   never runs on that path, so the tracked child would survive. `spawnSync` reports a failed lookup on its returned
   `error` field instead of emitting it, so ENOENT can no longer become an uncaught exception either.
+- The candidate list exists because the reported failure was PATH resolution, not a missing binary: a broken PATH must
+  not downgrade a tree kill to a direct kill. `process.kill` maps to `TerminateProcess` and leaves descendants
+  orphaned, the same limitation `packages/pty/src/pipe-fallback.ts` documents, so it stays a last resort.
 
 ### Why extension system couldn't handle this
 

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -24,6 +24,32 @@
 - LOW: `tools-manager.ts`, at the offline environment gate and `downloadFile`
   response-body handling.
 
+## Windows process-tree kill survives an unresolvable taskkill (2026-08-11)
+
+### What changed
+
+- `shell.ts`: the Windows branch of `killProcessTree` moved into `killWindowsProcessTree`, which resolves
+  `%SystemRoot%\System32\taskkill.exe` through the new `resolveWindowsTaskkillPath` export, registers an `error`
+  listener on the spawned killer, falls back to `process.kill(pid)` when the launcher never starts, and `unref()`s
+  the detached child. Both new functions are exported for direct regression coverage.
+
+### Why
+
+- `spawn("taskkill", ...)` resolves the executable through PATH and reports a failed lookup asynchronously on the
+  child's `error` event, so the surrounding `try`/`catch` never saw it. On a session whose PATH had lost
+  `%SystemRoot%\System32`, `killTrackedDetachedChildren()` during shutdown raised
+  `Error: spawn taskkill ENOENT` as an uncaught exception and took the CLI down instead of exiting, and no tracked
+  child was killed. This mirrors the already-correct launcher handling in `open-browser.ts`.
+
+### Why extension system couldn't handle this
+
+- Detached-child bookkeeping and the shutdown signal handlers live in core modes; no extension hook runs inside the
+  signal path that kills tracked children.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: the Windows branch of `killProcessTree` and the `node:path` / `child_process` import lines in `shell.ts`.
+
 ## Config-reload recursive watch option (2026-07-21)
 
 ### What changed

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -29,9 +29,9 @@
 ### What changed
 
 - `shell.ts`: the Windows branch of `killProcessTree` moved into `killWindowsProcessTree`, which resolves
-  `%SystemRoot%\System32\taskkill.exe` through the new `resolveWindowsTaskkillPath` export, registers an `error`
-  listener on the spawned killer, falls back to `process.kill(pid)` when the launcher never starts, and `unref()`s
-  the detached child. Both new functions are exported for direct regression coverage.
+  `%SystemRoot%\System32\taskkill.exe` through the new `resolveWindowsTaskkillPath` export, runs the killer with
+  `spawnSync` under a 5s timeout, and falls back to `process.kill(pid)` when the launcher never started or the
+  timeout fired. Both new functions are exported for direct regression coverage.
 
 ### Why
 
@@ -39,7 +39,11 @@
   child's `error` event, so the surrounding `try`/`catch` never saw it. On a session whose PATH had lost
   `%SystemRoot%\System32`, `killTrackedDetachedChildren()` during shutdown raised
   `Error: spawn taskkill ENOENT` as an uncaught exception and took the CLI down instead of exiting, and no tracked
-  child was killed. This mirrors the already-correct launcher handling in `open-browser.ts`.
+  child was killed.
+- The kill is synchronous because `emergencyTerminalExit()` calls `killTrackedDetachedChildren()` and then
+  `process.exit(129)` in the same tick. An asynchronous killer — or a fallback wired to the child's `error` event —
+  never runs on that path, so the tracked child would survive. `spawnSync` reports a failed lookup on its returned
+  `error` field instead of emitting it, so ENOENT can no longer become an uncaught exception either.
 
 ### Why extension system couldn't handle this
 

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -261,20 +261,30 @@ export function killTrackedDetachedChildren(): void {
 }
 
 /**
- * Resolve the Windows `taskkill` executable.
+ * Ordered `taskkill` launchers to try, most reliable first.
  *
  * `spawn("taskkill", ...)` relies on a PATH lookup, so any session whose PATH lost
  * `%SystemRoot%\System32` (a POSIX-style PATH inherited from a Git Bash/MSYS launcher,
- * a truncated user PATH, a locked-down service account) fails to resolve it. Prefer the
- * absolute System32 path and keep the bare executable name as the last resort.
+ * a truncated user PATH, a locked-down service account) fails to resolve it. A broken PATH
+ * must not cost us the process-tree kill, so every absolute System32 location that actually
+ * exists is tried before the bare PATH-resolved name.
  */
-export function resolveWindowsTaskkillPath(env: NodeJS.ProcessEnv = process.env): string {
-	const systemRoot = env.SystemRoot ?? env.SYSTEMROOT ?? env.windir;
-	if (systemRoot) {
-		const absolute = join(systemRoot, "System32", "taskkill.exe");
-		if (existsSync(absolute)) return absolute;
+export function windowsTaskkillCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+	// A bare `SystemDrive` is drive-relative ("C:"), so anchor it before joining.
+	const systemDrive = env.SystemDrive ? `${env.SystemDrive}\\` : undefined;
+	const roots = [env.SystemRoot, env.SYSTEMROOT, env.windir, systemDrive && join(systemDrive, "Windows")];
+	const candidates: string[] = [];
+	for (const root of roots) {
+		if (!root) continue;
+		// Sysnative reaches the real 64-bit System32 from a 32-bit process, where System32
+		// is redirected to SysWOW64.
+		for (const systemDir of ["System32", "Sysnative"]) {
+			const absolute = join(root, systemDir, "taskkill.exe");
+			if (!candidates.includes(absolute) && existsSync(absolute)) candidates.push(absolute);
+		}
 	}
-	return "taskkill.exe";
+	candidates.push("taskkill.exe");
+	return candidates;
 }
 
 function killProcessDirectly(pid: number): void {
@@ -312,9 +322,17 @@ function taskkillHandledTree(pid: number, taskkillPath: string): boolean {
  * the tracked child would survive. `spawnSync` also reports a failed executable lookup on
  * its returned `error` field instead of emitting it, so a PATH without
  * `%SystemRoot%\System32` can no longer surface as an uncaught `spawn taskkill ENOENT`.
+ *
+ * The direct `process.kill` at the end is a degraded last resort reached only when no
+ * `taskkill.exe` can be launched at all. It maps to `TerminateProcess`, which does not
+ * touch descendants — the same limitation `packages/pty/src/pipe-fallback.ts` documents.
+ * Nothing in-process can walk a Windows process tree without an external tool, so this
+ * still beats leaving the whole tree running.
  */
-export function killWindowsProcessTree(pid: number, taskkillPath = resolveWindowsTaskkillPath()): void {
-	if (taskkillHandledTree(pid, taskkillPath)) return;
+export function killWindowsProcessTree(pid: number, taskkillPaths = windowsTaskkillCandidates()): void {
+	for (const taskkillPath of taskkillPaths) {
+		if (taskkillHandledTree(pid, taskkillPath)) return;
+	}
 	killProcessDirectly(pid);
 }
 

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { delimiter, join } from "node:path";
-import { type ChildProcess, spawn, spawnSync } from "child_process";
+import { spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
 
 /** Family of a resolved shell executable, used to pick invocation arguments. */
@@ -285,32 +285,37 @@ function killProcessDirectly(pid: number): void {
 	}
 }
 
+/** Upper bound on how long a shutdown may block waiting for `taskkill` to finish. */
+const TASKKILL_TIMEOUT_MS = 5_000;
+
+function taskkillHandledTree(pid: number, taskkillPath: string): boolean {
+	try {
+		const result = spawnSync(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
+			stdio: "ignore",
+			windowsHide: true,
+			timeout: TASKKILL_TIMEOUT_MS,
+		});
+		// `error` means the launcher never started (ENOENT, EACCES); a null status means
+		// the timeout killed it. Any real taskkill exit code counts as handled.
+		return result.error === undefined && result.status !== null;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Kill a process and all its children on Windows via `taskkill /T`.
  *
- * `spawn()` reports a failed executable lookup asynchronously through the child's
- * `error` event, never by throwing — so a surrounding `try`/`catch` cannot see it.
- * Without an `error` listener Node re-emits ENOENT as an uncaught exception, which
- * killed the whole CLI during shutdown (`killTrackedDetachedChildren`). Handle the
- * event and fall back to killing the direct child.
+ * Synchronous on purpose. Shutdown paths call `killTrackedDetachedChildren()` and then
+ * `process.exit()` in the same tick (`emergencyTerminalExit()`), so neither an
+ * asynchronous killer nor a fallback wired to a child's `error` event would ever run and
+ * the tracked child would survive. `spawnSync` also reports a failed executable lookup on
+ * its returned `error` field instead of emitting it, so a PATH without
+ * `%SystemRoot%\System32` can no longer surface as an uncaught `spawn taskkill ENOENT`.
  */
 export function killWindowsProcessTree(pid: number, taskkillPath = resolveWindowsTaskkillPath()): void {
-	let killer: ChildProcess;
-	try {
-		killer = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
-			stdio: "ignore",
-			detached: true,
-			windowsHide: true,
-		});
-	} catch {
-		killProcessDirectly(pid);
-		return;
-	}
-	killer.once("error", () => {
-		killProcessDirectly(pid);
-	});
-	// Fire-and-forget: a detached killer must not hold the event loop open during exit.
-	killer.unref();
+	if (taskkillHandledTree(pid, taskkillPath)) return;
+	killProcessDirectly(pid);
 }
 
 /**

--- a/packages/coding-agent/src/utils/shell.ts
+++ b/packages/coding-agent/src/utils/shell.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
-import { delimiter } from "node:path";
-import { spawn, spawnSync } from "child_process";
+import { delimiter, join } from "node:path";
+import { type ChildProcess, spawn, spawnSync } from "child_process";
 import { getBinDir } from "../config.ts";
 
 /** Family of a resolved shell executable, used to pick invocation arguments. */
@@ -261,20 +261,64 @@ export function killTrackedDetachedChildren(): void {
 }
 
 /**
+ * Resolve the Windows `taskkill` executable.
+ *
+ * `spawn("taskkill", ...)` relies on a PATH lookup, so any session whose PATH lost
+ * `%SystemRoot%\System32` (a POSIX-style PATH inherited from a Git Bash/MSYS launcher,
+ * a truncated user PATH, a locked-down service account) fails to resolve it. Prefer the
+ * absolute System32 path and keep the bare executable name as the last resort.
+ */
+export function resolveWindowsTaskkillPath(env: NodeJS.ProcessEnv = process.env): string {
+	const systemRoot = env.SystemRoot ?? env.SYSTEMROOT ?? env.windir;
+	if (systemRoot) {
+		const absolute = join(systemRoot, "System32", "taskkill.exe");
+		if (existsSync(absolute)) return absolute;
+	}
+	return "taskkill.exe";
+}
+
+function killProcessDirectly(pid: number): void {
+	try {
+		process.kill(pid);
+	} catch {
+		// Process already dead.
+	}
+}
+
+/**
+ * Kill a process and all its children on Windows via `taskkill /T`.
+ *
+ * `spawn()` reports a failed executable lookup asynchronously through the child's
+ * `error` event, never by throwing — so a surrounding `try`/`catch` cannot see it.
+ * Without an `error` listener Node re-emits ENOENT as an uncaught exception, which
+ * killed the whole CLI during shutdown (`killTrackedDetachedChildren`). Handle the
+ * event and fall back to killing the direct child.
+ */
+export function killWindowsProcessTree(pid: number, taskkillPath = resolveWindowsTaskkillPath()): void {
+	let killer: ChildProcess;
+	try {
+		killer = spawn(taskkillPath, ["/F", "/T", "/PID", String(pid)], {
+			stdio: "ignore",
+			detached: true,
+			windowsHide: true,
+		});
+	} catch {
+		killProcessDirectly(pid);
+		return;
+	}
+	killer.once("error", () => {
+		killProcessDirectly(pid);
+	});
+	// Fire-and-forget: a detached killer must not hold the event loop open during exit.
+	killer.unref();
+}
+
+/**
  * Kill a process and all its children (cross-platform)
  */
 export function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
-		// Use taskkill on Windows to kill process tree
-		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
-				stdio: "ignore",
-				detached: true,
-				windowsHide: true,
-			});
-		} catch {
-			// Ignore errors if taskkill fails
-		}
+		killWindowsProcessTree(pid);
 	} else {
 		// Use SIGKILL on Unix/Linux/Mac
 		try {

--- a/packages/coding-agent/test/kill-process-tree-windows.test.ts
+++ b/packages/coding-agent/test/kill-process-tree-windows.test.ts
@@ -60,7 +60,7 @@ describe("killWindowsProcessTree", () => {
 		process.on("uncaughtException", onUncaught);
 
 		try {
-			// spawn() surfaces ENOENT asynchronously through the child's 'error' event.
+			// An asynchronous spawn() surfaces ENOENT through the child's 'error' event.
 			// Before the fix this became an uncaughtException that killed the whole CLI.
 			killWindowsProcessTree(pid as number, UNRESOLVABLE_TASKKILL);
 			await once(child, "exit");
@@ -69,6 +69,26 @@ describe("killWindowsProcessTree", () => {
 			process.off("uncaughtException", onUncaught);
 			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
 		}
+	});
+
+	it("issues the fallback kill synchronously, before the caller can exit", () => {
+		// emergencyTerminalExit() runs killTrackedDetachedChildren() and then process.exit(129)
+		// in the same tick, so a fallback deferred to a later event-loop turn never runs and the
+		// tracked child survives. The kill must therefore be issued before this call returns.
+		const calls: Array<[number, NodeJS.Signals | number | undefined]> = [];
+		const realKill = process.kill.bind(process);
+		process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+			calls.push([pid, signal]);
+			return true;
+		}) as typeof process.kill;
+
+		try {
+			killWindowsProcessTree(4242, UNRESOLVABLE_TASKKILL);
+		} finally {
+			process.kill = realKill;
+		}
+
+		expect(calls).toEqual([[4242, undefined]]);
 	});
 
 	it("tolerates a pid that is already gone", async () => {

--- a/packages/coding-agent/test/kill-process-tree-windows.test.ts
+++ b/packages/coding-agent/test/kill-process-tree-windows.test.ts
@@ -1,0 +1,90 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { killWindowsProcessTree, resolveWindowsTaskkillPath } from "../src/utils/shell.ts";
+
+/** A name that can never resolve on PATH, so spawn() fails with ENOENT on every platform. */
+const UNRESOLVABLE_TASKKILL = "senpi-nonexistent-taskkill-binary.exe";
+
+const tempRoots: string[] = [];
+
+function createFakeSystemRoot(withTaskkill: boolean): string {
+	const root = mkdtempSync(join(tmpdir(), "senpi-systemroot-"));
+	tempRoots.push(root);
+	if (withTaskkill) {
+		mkdirSync(join(root, "System32"), { recursive: true });
+		writeFileSync(join(root, "System32", "taskkill.exe"), "");
+	}
+	return root;
+}
+
+afterEach(() => {
+	while (tempRoots.length > 0) {
+		const root = tempRoots.pop();
+		if (root) rmSync(root, { recursive: true, force: true });
+	}
+});
+
+describe("resolveWindowsTaskkillPath", () => {
+	it("prefers the absolute System32 executable over a bare PATH lookup", () => {
+		const root = createFakeSystemRoot(true);
+		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe(join(root, "System32", "taskkill.exe"));
+	});
+
+	it("accepts the uppercase SYSTEMROOT and windir spellings", () => {
+		const upper = createFakeSystemRoot(true);
+		const windir = createFakeSystemRoot(true);
+		expect(resolveWindowsTaskkillPath({ SYSTEMROOT: upper })).toBe(join(upper, "System32", "taskkill.exe"));
+		expect(resolveWindowsTaskkillPath({ windir })).toBe(join(windir, "System32", "taskkill.exe"));
+	});
+
+	it("falls back to the bare executable name when System32 has no taskkill", () => {
+		const root = createFakeSystemRoot(false);
+		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe("taskkill.exe");
+		expect(resolveWindowsTaskkillPath({})).toBe("taskkill.exe");
+	});
+});
+
+describe("killWindowsProcessTree", () => {
+	it("kills the child instead of crashing the process when taskkill cannot be spawned", async () => {
+		const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], { stdio: "ignore" });
+		await once(child, "spawn");
+		const pid = child.pid;
+		expect(pid).toBeDefined();
+
+		const uncaught: unknown[] = [];
+		const onUncaught = (error: unknown) => uncaught.push(error);
+		process.on("uncaughtException", onUncaught);
+
+		try {
+			// spawn() surfaces ENOENT asynchronously through the child's 'error' event.
+			// Before the fix this became an uncaughtException that killed the whole CLI.
+			killWindowsProcessTree(pid as number, UNRESOLVABLE_TASKKILL);
+			await once(child, "exit");
+			expect(uncaught).toEqual([]);
+		} finally {
+			process.off("uncaughtException", onUncaught);
+			if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+		}
+	});
+
+	it("tolerates a pid that is already gone", async () => {
+		const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+		await once(child, "exit");
+		const pid = child.pid as number;
+
+		const uncaught: unknown[] = [];
+		const onUncaught = (error: unknown) => uncaught.push(error);
+		process.on("uncaughtException", onUncaught);
+		try {
+			expect(() => killWindowsProcessTree(pid, UNRESOLVABLE_TASKKILL)).not.toThrow();
+			await new Promise((resolve) => setTimeout(resolve, 200));
+			expect(uncaught).toEqual([]);
+		} finally {
+			process.off("uncaughtException", onUncaught);
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/issue-812-windows-taskkill-enoent.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-812-windows-taskkill-enoent.test.ts
@@ -4,10 +4,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { killWindowsProcessTree, resolveWindowsTaskkillPath } from "../src/utils/shell.ts";
+import { killWindowsProcessTree, windowsTaskkillCandidates } from "../../../src/utils/shell.ts";
 
-/** A name that can never resolve on PATH, so spawn() fails with ENOENT on every platform. */
-const UNRESOLVABLE_TASKKILL = "senpi-nonexistent-taskkill-binary.exe";
+/** Names that can never resolve on PATH, so spawn() fails with ENOENT on every platform. */
+const UNRESOLVABLE_TASKKILL = ["senpi-nonexistent-taskkill-binary.exe"];
 
 const tempRoots: string[] = [];
 
@@ -28,23 +28,46 @@ afterEach(() => {
 	}
 });
 
-describe("resolveWindowsTaskkillPath", () => {
-	it("prefers the absolute System32 executable over a bare PATH lookup", () => {
+describe("windowsTaskkillCandidates", () => {
+	it("puts every existing absolute System32 executable ahead of the bare PATH lookup", () => {
 		const root = createFakeSystemRoot(true);
-		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe(join(root, "System32", "taskkill.exe"));
+		expect(windowsTaskkillCandidates({ SystemRoot: root })).toEqual([
+			join(root, "System32", "taskkill.exe"),
+			"taskkill.exe",
+		]);
 	});
 
-	it("accepts the uppercase SYSTEMROOT and windir spellings", () => {
+	it("accepts the uppercase SYSTEMROOT, windir, and SystemDrive spellings", () => {
 		const upper = createFakeSystemRoot(true);
 		const windir = createFakeSystemRoot(true);
-		expect(resolveWindowsTaskkillPath({ SYSTEMROOT: upper })).toBe(join(upper, "System32", "taskkill.exe"));
-		expect(resolveWindowsTaskkillPath({ windir })).toBe(join(windir, "System32", "taskkill.exe"));
+		expect(windowsTaskkillCandidates({ SYSTEMROOT: upper })[0]).toBe(join(upper, "System32", "taskkill.exe"));
+		expect(windowsTaskkillCandidates({ windir })[0]).toBe(join(windir, "System32", "taskkill.exe"));
 	});
 
-	it("falls back to the bare executable name when System32 has no taskkill", () => {
+	it("collects Sysnative and deduplicates repeated roots", () => {
+		const root = mkdtempSync(join(tmpdir(), "senpi-systemroot-"));
+		tempRoots.push(root);
+		for (const systemDir of ["System32", "Sysnative"]) {
+			mkdirSync(join(root, systemDir), { recursive: true });
+			writeFileSync(join(root, systemDir, "taskkill.exe"), "");
+		}
+		expect(windowsTaskkillCandidates({ SystemRoot: root, SYSTEMROOT: root, windir: root })).toEqual([
+			join(root, "System32", "taskkill.exe"),
+			join(root, "Sysnative", "taskkill.exe"),
+			"taskkill.exe",
+		]);
+	});
+
+	it("falls back to the bare executable name when no absolute candidate exists", () => {
 		const root = createFakeSystemRoot(false);
-		expect(resolveWindowsTaskkillPath({ SystemRoot: root })).toBe("taskkill.exe");
-		expect(resolveWindowsTaskkillPath({})).toBe("taskkill.exe");
+		expect(windowsTaskkillCandidates({ SystemRoot: root })).toEqual(["taskkill.exe"]);
+		expect(windowsTaskkillCandidates({})).toEqual(["taskkill.exe"]);
+	});
+
+	it("ignores an empty SystemDrive instead of probing a drive-relative path", () => {
+		// `join("\\", "Windows", ...)` resolves against the current drive, which would silently
+		// reintroduce a candidate the environment does not actually declare.
+		expect(windowsTaskkillCandidates({ SystemDrive: "" })).toEqual(["taskkill.exe"]);
 	});
 });
 
@@ -89,6 +112,26 @@ describe("killWindowsProcessTree", () => {
 		}
 
 		expect(calls).toEqual([[4242, undefined]]);
+	});
+
+	it("tries every candidate before degrading to the direct kill", () => {
+		const attempted: string[] = [];
+		const realKill = process.kill.bind(process);
+		const candidates = ["senpi-missing-a.exe", "senpi-missing-b.exe", process.execPath];
+		process.kill = (() => {
+			attempted.push("direct");
+			return true;
+		}) as typeof process.kill;
+
+		try {
+			// process.execPath launches successfully, so the tree kill is considered handled
+			// and the direct fallback must not run.
+			killWindowsProcessTree(4242, candidates);
+		} finally {
+			process.kill = realKill;
+		}
+
+		expect(attempted).toEqual([]);
 	});
 
 	it("tolerates a pid that is already gone", async () => {


### PR DESCRIPTION
fixes #812

## Problem

On Windows the CLI can die on exit instead of exiting:

```
pi exiting due to uncaughtException:
Error: spawn taskkill ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:287:19)
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn taskkill',
  path: 'taskkill',
  spawnargs: [ '/F', '/T', '/PID', '19808' ]
```

Reported against `omo-ai@5.0.0-0.beta.5`, which ships `@code-yeongyu/senpi@2026.8.11-2`.
The `spawnargs` identify the call site exactly: `killProcessTree` in
`packages/coding-agent/src/utils/shell.ts`, reached from `killTrackedDetachedChildren()`
in the interactive-mode signal handler.

Two independent defects:

1. **The `try`/`catch` is dead code.** `child_process.spawn()` never throws on a failed
   executable lookup; it reports ENOENT asynchronously on the child's `error` event. With no
   listener, Node re-emits it as an uncaught exception and takes the process down.
2. **`taskkill` is resolved through PATH.** Any session whose PATH lost
   `%SystemRoot%\System32` — a POSIX-style PATH inherited from a Git Bash/MSYS launcher, a
   truncated user PATH, a locked-down service account — cannot resolve it. The tracked child
   is then never killed either, because there is no fallback.

#792 fixed the same class of bug in `packages/pty/src/pipe-fallback.ts` (`taskkill.exe` plus an
`error` listener). These two copies were missed:

- `packages/coding-agent/src/utils/shell.ts` — `killProcessTree` (the crash in the report)
- `packages/agent/src/harness/env/nodejs.ts` — an identical private copy in the Node harness

## Review follow-up (dafbbe4e)

Codex flagged that an `error`-event fallback still cannot run on `emergencyTerminalExit()`, which calls
`killTrackedDetachedChildren()` and then `process.exit(129)` in the same tick. Confirmed and fixed: both copies
now use `spawnSync` under a 5s timeout, so the `process.kill(pid)` fallback is issued before the call returns.
`spawnSync` also reports a failed lookup on its returned `error` field instead of emitting it, so ENOENT still
cannot become an uncaught exception.

Measured with PATH cleared and `SystemRoot` pointed at a directory without `System32\taskkill.exe`, probing the
child synchronously right after the kill returns:

```
main         : child alive=true   FAIL uncaughtException: spawn taskkill ENOENT
efdb1c1      : child alive=true   PASS no uncaught exception   <- the review finding
dafbbe4e     : child alive=false  PASS no uncaught exception
```

Pinned by `issues the fallback kill synchronously, before the caller can exit` in both packages.

## Review round 2 (7d93d1be)

- **P2, orphaned descendants.** The direct kill must not be reached just because PATH cannot resolve `taskkill` —
  which was the reported failure. `windowsTaskkillCandidates()` now returns every absolute `System32` / `Sysnative`
  `taskkill.exe` that exists under `SystemRoot`, `SYSTEMROOT`, `windir`, or `SystemDrive`, then the bare
  PATH-resolved name; `killWindowsProcessTree` tries each until one launches. `existsSync` filters first, so the
  normal case still runs exactly one `spawnSync`.

  ```
  PATH cleared + SystemRoot bogus, SystemDrive intact
    candidates: [C:\Windows\System32\taskkill.exe, taskkill.exe]
    child exit 134   <- real taskkill /T, tree preserved
  no launcher reachable at all
    candidates: [taskkill.exe]
    kill issued before return, child exit 1   <- degraded direct kill
  ```

  Only the second state reaches `process.kill`, and it cannot be made tree-capable in-process: enumerating Windows
  descendants needs an external tool that lives in the same unreachable `System32` (and `wmic` is gone on current
  Windows 11). It is documented as degraded, citing the same limitation `pipe-fallback.ts:242-246` records.

- Writing that check found a bug in my own candidate list: an empty `SystemDrive` produced `\Windows\...`, which
  Windows resolves drive-relative and silently reintroduced an undeclared candidate. Fixed, with coverage.

- **P1, test location.** Filed the crash as #812 and moved the regression to
  `packages/coding-agent/test/suite/regressions/issue-812-windows-taskkill-enoent.test.ts`.

Scoped runs after the change: coding-agent 31 passed | 4 skipped, agent 4 passed, `npm run check` clean.

## Fix

Both copies now:

- resolve `%SystemRoot%\System32\taskkill.exe` (`SystemRoot` / `SYSTEMROOT` / `windir`) and keep
  the bare `taskkill.exe` only as a last resort,
- register `killer.once("error", ...)` and fall back to `process.kill(pid)` so shutdown still
  terminates the target,
- `unref()` the detached killer so a fire-and-forget kill cannot hold the event loop open during exit.

This is the pattern `packages/coding-agent/src/utils/open-browser.ts` already uses
(`.on("error", () => {}).unref()`), so no new convention is introduced. The two harnesses keep
independent copies, as they already do for `getShellEnv` and bash resolution; unifying them would
mean widening `@earendil-works/pi-agent-core`'s public surface for a platform detail.

`resolveWindowsTaskkillPath` and `killWindowsProcessTree` are exported so the failure is testable
without mocking the module registry (the repo has no `mock.module` usage).

## Verification

`resolveWindowsTaskkillPath` and the ENOENT fallback are covered on every platform: the tests pass a
deliberately unresolvable launcher name, so `spawn` fails the same way on Windows, macOS, and Linux.

```
packages/coding-agent $ npx vitest --run test/kill-process-tree-windows.test.ts
  Test Files  1 passed (1)   Tests  5 passed (5)

packages/agent $ npx vitest --run test/harness/kill-process-tree-windows.test.ts
  Test Files  1 passed (1)   Tests  3 passed (3)

packages/coding-agent $ npx vitest --run test/kill-process-tree-windows.test.ts \
    test/resolve-config-value.test.ts test/sanitize-binary-output.test.ts \
    test/suite/shell-config-kind.test.ts test/bash-close-hang-windows.test.ts test/bash-abort-hang.test.ts
  Test Files  5 passed | 1 skipped (6)   Tests  27 passed | 4 skipped (31)

$ npm run check
  Checked 2804 files in 7s.
  packages/coding-agent/publish-deps.lock.json is up to date.
  packages/coding-agent/install-lock is up to date.
```

**Regression proof.** Removing only the `killer.once("error", ...)` handler makes the new test fail
with the exact reported payload:

```
AssertionError: expected [ …(1) ] to deeply equal []
+   Error {
+     "message": "spawn senpi-nonexistent-taskkill-binary.exe ENOENT",
+     "errno": -4058,
+     "code": "ENOENT",
```

**End-to-end repro** through the real shutdown chain (`killTrackedDetachedChildren` →
`killProcessTree`), with PATH cleared and `SystemRoot` pointed at a directory without
`System32\taskkill.exe`, on Windows 11 / Node v24.18.0:

```
--- before (main) ---
tracked child pid=23408
FAIL uncaughtException: spawn taskkill ENOENT      # and the tracked child survives

--- after ---
tracked child pid=27020
child exited code=1 signal=null
PASS: shutdown kill completed without an uncaught exception
```

**Pre-existing failures.** `packages/agent $ npx vitest --run test/harness/` on Windows fails
5 files / 15 tests both with and without this change (reverting only
`packages/agent/src/harness/env/nodejs.ts` to `main` gives 6 files / 17 tests, the extra one being
this branch's new test importing helpers that do not exist there). Those are Windows path-separator
and `ignore`-package failures in `skills.test.ts`, `sqlite-node.test.ts`, and `tools.test.ts`,
unrelated to process termination.

QA evidence is saved under `local-ignore/qa-evidence/20260811-windows-taskkill-enoent/`.

`changes.md` fork-tracker entries and `[Unreleased]` changelog entries are included for both packages.
