### PR TITLE
fix(ai): normalize replayed tool call ids

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Replayed tool-call IDs are normalized to the strict OpenAI-compatible character and length constraints while
+  preserving paired tool results, so Kimi histories containing IDs such as `eval:18` no longer fail when a
+  conversation switches to an Anthropic-backed gateway ([#810](https://github.com/code-yeongyu/senpi/pull/810)).
 - Gateway/provider failures reported as `The model request was rejected. Check the request and try again.` now go
   through the configured bounded retry policy instead of failing immediately or burning the fallback chain
   ([#806](https://github.com/code-yeongyu/senpi/pull/806)).

--- a/packages/ai/src/api/openai-completions.ts
+++ b/packages/ai/src/api/openai-completions.ts
@@ -1295,12 +1295,17 @@ export function convertMessages(
 			return `${prefix}_${hash}`;
 		}
 
-		if (model.provider === "openai") return id.length > 40 ? id.slice(0, 40) : id;
-		return id;
+		const sanitizedId = id.replace(/[^a-zA-Z0-9_-]/g, "_") || "tool_call";
+		if (sanitizedId === id && sanitizedId.length <= 40) return id;
+
+		const hash = shortHash(id).slice(0, 8);
+		const prefix = sanitizedId.slice(0, Math.max(1, 40 - hash.length - 1));
+		return `${prefix}_${hash}`;
 	};
 
 	const transformedMessages = transformMessages(context.messages, model, (id) => normalizeToolCallId(id), {
 		preserveThinking: options.preserveThinking,
+		normalizeSameModelToolCallIds: true,
 	});
 
 	if (context.systemPrompt) {

--- a/packages/ai/src/api/transform-messages.ts
+++ b/packages/ai/src/api/transform-messages.ts
@@ -116,6 +116,11 @@ export interface TransformMessagesOptions {
 	 * compatibility payloads.
 	 */
 	preserveUnsignedThinking?: boolean;
+	/**
+	 * Normalize tool-call IDs even when stored provider/API/model metadata match
+	 * the target. Enable only for target protocols whose wire contract requires it.
+	 */
+	normalizeSameModelToolCallIds?: boolean;
 }
 
 /**
@@ -138,6 +143,7 @@ export function transformMessages<TApi extends Api>(
 	const preserveThinking = options.preserveThinking ?? true;
 	const preserveTextSignatures = options.preserveTextSignatures ?? false;
 	const preserveUnsignedThinking = options.preserveUnsignedThinking ?? false;
+	const normalizeSameModelToolCallIds = options.normalizeSameModelToolCallIds ?? false;
 
 	// First pass: transform messages (unsupported image downgrade, thinking blocks, tool call ID normalization)
 	const transformed = imageAwareMessages.map((msg) => {
@@ -206,7 +212,7 @@ export function transformMessages<TApi extends Api>(
 						delete (normalizedToolCall as { thoughtSignature?: string }).thoughtSignature;
 					}
 
-					if (!isSameModel && normalizeToolCallId) {
+					if ((!isSameModel || normalizeSameModelToolCallIds) && normalizeToolCallId) {
 						const normalizedId = normalizeToolCallId(toolCall.id, model, assistantMsg);
 						if (normalizedId !== toolCall.id) {
 							toolCallIdMap.set(toolCall.id, normalizedId);

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,28 @@
 # AI Source Changes
 
+## 2026-08-11 - Normalize replayed tool IDs for strict OpenAI-compatible gateways
+
+### What changed and why
+
+- `api/openai-completions.ts` now sanitizes every replayed non-Responses tool-call ID to the OpenAI-compatible
+  alphanumeric/underscore/dash shape, preserves already-valid bounded IDs, and uses a deterministic hash suffix when
+  sanitization or the 40-character bound changes the ID.
+- `api/transform-messages.ts` lets strict target adapters opt into applying their supplied tool-call ID normalizer to
+  same-model history as well as cross-model history. OpenAI completions enables that opt-in and remaps the paired
+  tool result through the existing ID map; Responses retains its provider-native IDs.
+- A persisted `apitopia/kimi-k3-unlocked` session stored tool-call IDs such as `eval:18`. After switching to
+  `opengateway/anthropic/claude-fable-5`, the gateway rejected the request before generation with
+  `messages.36.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'`.
+- This cannot be extension-local: tool-call IDs and their paired results are transformed inside provider request
+  serialization before an extension can safely rewrite the complete outbound history. Rewriting persisted session
+  files would also leave other histories and future provider handoffs exposed.
+
+### Expected merge conflict zones
+
+- MEDIUM: `api/openai-completions.ts` near the local `normalizeToolCallId` function in `convertMessages`.
+- LOW: `api/transform-messages.ts` in the assistant `toolCall` transformation branch.
+- LOW: `../test/model-switch-replay-characterization.test.ts` near the non-Responses replay cases.
+
 ## 2026-08-11 - Optional availability `check` on `OAuthAuth`
 
 ### What changed and why

--- a/packages/ai/test/model-switch-replay-characterization.test.ts
+++ b/packages/ai/test/model-switch-replay-characterization.test.ts
@@ -7,6 +7,7 @@ import type { Context } from "../src/types.ts";
 import {
 	APPLY_PATCH_TOOL,
 	COMPLETIONS_COMPAT,
+	EMPTY_USAGE,
 	HISTORY,
 	makeModel,
 	makePatchHistory,
@@ -211,5 +212,100 @@ describe("model-switch replay characterization", () => {
 			{ role: "model", parts: [{ functionCall: { name: "apply_patch", args: { input: PATCH } } }] },
 			{ role: "user", parts: [{ functionResponse: { name: "apply_patch", response: { output: "Done!" } } }] },
 		]);
+	});
+
+	it("normalizes Kimi tool call ids for Anthropic-backed OpenAI gateways", () => {
+		// Given: this reproduces ~/.omo session 019fef2f-0c70-7074-a03a-f47d29b7a7ec,
+		// where Kimi stored `eval:18` before the conversation switched to OpenGateway Fable.
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Inspecting the session." },
+						{ type: "toolCall", id: "eval:18", name: "eval", arguments: { code: "1 + 1" } },
+					],
+					api: "openai-completions",
+					provider: "apitopia",
+					model: "kimi-k3-unlocked",
+					usage: EMPTY_USAGE,
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "eval:18",
+					toolName: "eval",
+					content: [{ type: "text", text: "2" }],
+					isError: false,
+					timestamp: 2,
+				},
+			],
+		};
+
+		// When
+		const replay = convertCompletionMessages(
+			makeModel("openai-completions", "opengateway", "anthropic/claude-fable-5"),
+			context,
+			COMPLETIONS_COMPAT,
+		);
+
+		// Then
+		const assistant = replay[0];
+		const toolResult = replay[1];
+		if (assistant?.role !== "assistant" || assistant.tool_calls?.[0] === undefined || toolResult?.role !== "tool") {
+			throw new Error("unexpected OpenAI completions replay shape");
+		}
+		const normalizedId = assistant.tool_calls[0].id;
+		expect(normalizedId).toMatch(/^[a-zA-Z0-9_-]+$/);
+		expect(normalizedId.length).toBeLessThanOrEqual(40);
+		expect(normalizedId).not.toContain(":");
+		expect(toolResult.tool_call_id).toBe(normalizedId);
+	});
+
+	it("normalizes invalid same-model OpenAI completions tool call ids", () => {
+		// Given: a resumed OpenGateway conversation can contain an invalid ID from an
+		// older client even when its stored provider/model already match the target.
+		const context: Context = {
+			messages: [
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "eval:18", name: "eval", arguments: { code: "1 + 1" } }],
+					api: "openai-completions",
+					provider: "opengateway",
+					model: "anthropic/claude-fable-5",
+					usage: EMPTY_USAGE,
+					stopReason: "toolUse",
+					timestamp: 1,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "eval:18",
+					toolName: "eval",
+					content: [{ type: "text", text: "2" }],
+					isError: false,
+					timestamp: 2,
+				},
+			],
+		};
+
+		// When
+		const replay = convertCompletionMessages(
+			makeModel("openai-completions", "opengateway", "anthropic/claude-fable-5"),
+			context,
+			COMPLETIONS_COMPAT,
+		);
+
+		// Then
+		const assistant = replay[0];
+		const toolResult = replay[1];
+		if (assistant?.role !== "assistant" || assistant.tool_calls?.[0] === undefined || toolResult?.role !== "tool") {
+			throw new Error("unexpected OpenAI completions replay shape");
+		}
+		const normalizedId = assistant.tool_calls[0].id;
+		expect(normalizedId).toMatch(/^[a-zA-Z0-9_-]+$/);
+		expect(normalizedId.length).toBeLessThanOrEqual(40);
+		expect(normalizedId).not.toContain(":");
+		expect(toolResult.tool_call_id).toBe(normalizedId);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Model switches no longer fail before generation when persisted tool-call IDs contain provider-specific characters
+  such as the colon in Kimi's `eval:18`; replay now preserves call/result pairing while satisfying strict
+  Anthropic-backed gateway constraints ([#810](https://github.com/code-yeongyu/senpi/pull/810)).
 - Gateway/provider failures reported as `The model request was rejected. Check the request and try again.` now retry
   the current model according to `settings.retry` before the configured fallback chain is used
   ([#806](https://github.com/code-yeongyu/senpi/pull/806)).


### PR DESCRIPTION
## Summary

Fix persisted tool-call IDs such as `eval:18` breaking model handoffs to
Anthropic-backed OpenAI-compatible gateways.

The failure was recovered from a real `~/.omo` session:

```text
messages.36.content.1.tool_use.id:
String should match pattern '^[a-zA-Z0-9_-]+$'
```

The source history came from `apitopia/kimi-k3-unlocked`; the rejected target
was `opengateway/anthropic/claude-fable-5`.

## Changes

- Sanitize non-Responses OpenAI-completions tool-call IDs to the strict
  alphanumeric/underscore/dash shape.
- Preserve already-valid IDs and use a deterministic hash suffix when
  sanitization or the 40-character bound changes an ID.
- Let strict adapters opt into normalizing same-model legacy history; only
  OpenAI completions enables the new opt-in.
- Remap paired tool results through the existing ID map.
- Add characterization coverage for the real Kimi-to-Fable handoff and
  same-model legacy replay.
- Record the fork-specific source behavior in `packages/ai/src/changes.md`.

## RED -> GREEN evidence

- RED cross-model: `expected 'eval:18' to match /^[a-zA-Z0-9_-]+$/`
- RED same-model: `expected 'eval:18' to match /^[a-zA-Z0-9_-]+$/`
- GREEN: both new regressions passed, 0 failed.
- Real source driver: `eval:18` -> `eval_18_zxzbpm3b`; pattern, length, and
  call/result pairing all passed.

Evidence is saved locally under:

```text
local-ignore/qa-evidence/20260811-anthropic-tool-id/
```

## Validation

- `npm run build`
- `cd packages/ai && npm test`
- `npm run check`
- TypeScript LSP diagnostics: 0 on all changed TS files
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`
- `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool --api openai-completions --evidence anthropic-tool-id`
- Changelog gate PASS for both `packages/ai/CHANGELOG.md` and
  `packages/coding-agent/CHANGELOG.md`.
- review-work: PASS 5/5 (goal, hands-on QA, code quality, security, and context).
