### PR TITLE
fix(terminal): make monitor pause burst-aware

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Terminal monitor wake budgets now treat widely spaced progress as separate bursts instead of eventually pausing,
+  while a true budget pause immediately steers the main session even when ordinary notifications wait for the next
+  turn ([#815](https://github.com/code-yeongyu/senpi/pull/815)).
 - Model switches no longer fail before generation when persisted tool-call IDs contain provider-specific characters
   such as the colon in Kimi's `eval:18`; replay now preserves call/result pairing while satisfying strict
   Anthropic-backed gateway constraints ([#810](https://github.com/code-yeongyu/senpi/pull/810)).

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,29 @@
 # terminal builtin extension — fork surface
 
+## Burst-aware monitor pauses force a wake (2026-08-11)
+
+### What changed
+
+- The monitor wake budget now counts a burst of actual model-visible injections instead of accumulating every update since the last user or tool action. A strict gap greater than twice the resolved monitor rate limit resets the streak before the next nonduplicate batch consumes budget.
+- Deferred and byte-identical batches do not update the streak timestamp. The existing budget, sticky pause, summary delivery, fresh-monitor reset, and explicit rearm behavior remain unchanged.
+- The batch that reaches the wake budget now forces `steer` delivery when terminal notifications use `next-turn`. Ordinary `next-turn` monitor updates remain follow-ups, while `off`, noninteractive modes, and sessions without an active model remain suppressed.
+
+### Why
+
+A real `gh pr checks --watch --interval 30` monitor delivered useful progress snapshots (`5 -> 6 -> 8 -> 10 -> 13 -> 14` successful checks) over several minutes. The previous lifetime counter treated those widely spaced updates as one unbroken wake storm and paused after five injections. Raising the budget would only postpone the same failure while weakening protection against actual bursts.
+
+When a true burst does exhaust the budget, entering the sticky paused state is an actionable session-state change. It must wake the main session immediately even when ordinary monitor notifications are configured to wait for the next turn.
+
+### Why this cannot be expressed externally
+
+The streak counter, duplicate suppression, rate-limit readiness, pause transition, and hidden message delivery mode are private state inside the builtin terminal notifier. An extension or wrapper command cannot distinguish actual injections from deferred or suppressed batches, nor can it upgrade only the pause-triggering hidden message from follow-up to steer without bypassing terminal notification guards.
+
+### Expected merge conflict zones
+
+- `monitor-notify.ts` around the notifier's wake-budget state and `#flush()` injection boundary.
+- `notify.ts` around the internal `TerminalNotificationDelivery.send` options and `deliverAs` selection.
+- `terminal-monitor-notify.test.ts` and `terminal-monitor-dup-suppression.test.ts` around wake-budget timing assertions.
+
 ## Terminal wake-source snapshots (2026-08-09)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-notify.ts
@@ -7,6 +7,7 @@ const SYSTEM_REMINDER_OPEN = "<system-reminder>";
 const SYSTEM_REMINDER_CLOSE = "</system-reminder>";
 const QUEUE_OVERHEAD_CHARS = 512;
 const MONITOR_NOTIFICATION_CUSTOM_TYPE = "senpi-monitor:notification";
+const WAKE_STREAK_QUIET_GAP_MULTIPLIER = 2;
 
 export interface MonitorNotificationScheduler {
 	now(): number;
@@ -87,6 +88,7 @@ export class MonitorNotifier {
 	#timer: unknown;
 	#scheduledAt: number | undefined;
 	#consecutiveWakes = 0;
+	#lastWakeAt: number | undefined;
 	#wakeBudgetPaused = false;
 
 	constructor(deps: MonitorNotifierDeps) {
@@ -195,6 +197,12 @@ export class MonitorNotifier {
 		const overflowCount = [...this.#overflow.values()]
 			.filter((overflow) => injectedIds.has(overflow.id))
 			.reduce((total, overflow) => total + overflow.count, 0);
+		if (
+			this.#lastWakeAt !== undefined &&
+			now - this.#lastWakeAt > settings.rateLimitMs * WAKE_STREAK_QUIET_GAP_MULTIPLIER
+		) {
+			this.#consecutiveWakes = 0;
+		}
 		const deliversSummary = selected.some((event) => event.type === "summary");
 		const reachesBudget = !deliversSummary && this.#consecutiveWakes + 1 >= settings.wakeBudget;
 		const pauseNotice = reachesBudget
@@ -202,7 +210,8 @@ export class MonitorNotifier {
 			: "";
 		const content = this.#buildMessage(selected, overflowCount, pauseNotice, settings.maxCharsPerInjection);
 
-		delivery.send(content);
+		delivery.send(content, reachesBudget ? { forceWake: true } : undefined);
+		this.#lastWakeAt = now;
 		for (const id of injectedIds) {
 			this.#lastInjectionAt.set(id, now);
 			this.#overflow.delete(id);

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/notify.ts
@@ -22,7 +22,7 @@ export interface TerminalNotifierDeps {
 export const NOTICE_TAIL_MAX_CHARS = 2000;
 
 export interface TerminalNotificationDelivery {
-	readonly send: (content: string) => void;
+	readonly send: (content: string, options?: { readonly forceWake?: boolean }) => void;
 }
 
 /** Shared terminal-notification guard and notify-mode mapping. */
@@ -35,10 +35,13 @@ export function getTerminalNotificationDelivery(
 	const ctx = deps.getContext();
 	if (!ctx || NON_INTERACTIVE_MODES.has(ctx.mode) || !ctx.model) return undefined;
 	return {
-		send: (content) =>
+		send: (content, options) =>
 			deps.sendMessage(
 				{ customType, content, display: false },
-				{ triggerTurn: true, deliverAs: mode === "wake" ? "steer" : "followUp" },
+				{
+					triggerTurn: true,
+					deliverAs: mode === "wake" || options?.forceWake === true ? "steer" : "followUp",
+				},
 			),
 	};
 }

--- a/packages/coding-agent/test/suite/terminal-monitor-dup-suppression.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-dup-suppression.test.ts
@@ -90,20 +90,20 @@ describe("monitor duplicate-batch suppression", () => {
 	});
 
 	it("suppressed refreshes never consume the wake budget", () => {
-		const { notifier, pauseMonitors, scheduler, sent } = createNotifier({ settings: { wakeBudget: 2 } });
+		const { notifier, pauseMonitors, scheduler, sent } = createNotifier({
+			settings: { coalesceWindowMs: 10, rateLimitMs: 100, wakeBudget: 2 },
+		});
 		notifier.notifyEvent(line("bash_budget", "budget", "state A"));
-		scheduler.advanceBy(2000);
+		scheduler.advanceBy(10);
 		expect(sent).toHaveLength(1);
 
-		for (let index = 0; index < 3; index++) {
-			notifier.notifyEvent(line("bash_budget", "budget", "state A"));
-			scheduler.advanceBy(10_000);
-		}
+		notifier.notifyEvent(line("bash_budget", "budget", "state A"));
+		scheduler.advanceBy(100);
 		expect(sent).toHaveLength(1);
 		expect(pauseMonitors).not.toHaveBeenCalled();
 
 		notifier.notifyEvent(line("bash_budget", "budget", "state B"));
-		scheduler.advanceBy(10_000);
+		scheduler.advanceBy(10);
 		expect(sent).toHaveLength(2);
 		expect(sent[1]?.message.content).toContain("state B");
 		expect(pauseMonitors).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
@@ -29,6 +29,24 @@ describe("terminal monitor event delivery", () => {
 		expect(sent[0]?.options).toEqual({ triggerTurn: true, deliverAs: "followUp" });
 	});
 
+	it("forces only the pause-triggering next-turn batch to steer", () => {
+		const { notifier, pauseMonitors, scheduler, sent } = createNotifier({
+			mode: "next-turn",
+			settings: { coalesceWindowMs: 10, rateLimitMs: 100, wakeBudget: 2 },
+		});
+		notifier.notifyEvent(line("bash_next_pause", "next-pause", "wake-1"));
+		scheduler.advanceBy(10);
+		expect(sent[0]?.options).toEqual({ triggerTurn: true, deliverAs: "followUp" });
+
+		notifier.notifyEvent(line("bash_next_pause", "next-pause", "wake-2"));
+		scheduler.advanceBy(100);
+
+		expect(sent).toHaveLength(2);
+		expect(sent[1]?.message.content).toContain("Monitor paused after repeated updates");
+		expect(sent[1]?.options).toEqual({ triggerTurn: true, deliverAs: "steer" });
+		expect(pauseMonitors).toHaveBeenCalledTimes(1);
+	});
+
 	it("enforces the per-monitor rate limit while retaining an overflow event for the next wake", () => {
 		const { notifier, scheduler, sent } = createNotifier();
 		notifier.notifyEvent(line("bash_rate", "rate", "first"));
@@ -40,6 +58,21 @@ describe("terminal monitor event delivery", () => {
 		scheduler.advanceBy(3000);
 		expect(sent).toHaveLength(2);
 		expect(sent[1]?.message.content).toContain("second");
+	});
+
+	it("breaks the wake streak after a gap longer than twice the rate limit", () => {
+		const { notifier, pauseMonitors, scheduler, sent } = createNotifier({
+			settings: { coalesceWindowMs: 10, rateLimitMs: 100, wakeBudget: 2 },
+		});
+		for (let index = 1; index <= 3; index++) {
+			notifier.notifyEvent(line("bash_progress", "progress", `step-${index}`));
+			scheduler.advanceBy(10);
+			if (index < 3) scheduler.advanceBy(201);
+		}
+
+		expect(sent).toHaveLength(3);
+		expect(sent.every(({ message }) => !message.content.includes("Monitor paused"))).toBe(true);
+		expect(pauseMonitors).not.toHaveBeenCalled();
 	});
 
 	it("coalesces monitors that fire in the same wake window", () => {


### PR DESCRIPTION
## Summary

- make the monitor wake budget burst-aware by resetting its streak after a strict quiet gap greater than twice the resolved rate limit
- force only the batch that actually enters the sticky paused state to `steer` the main session under `notify: "next-turn"`
- preserve duplicate suppression, summary delivery, explicit/fresh-monitor rearm, ordinary wake/follow-up behavior, and all notification suppression guards

## Incident

A real `gh pr checks --watch --interval 30` monitor delivered useful progress snapshots:

`5 -> 6 -> 8 -> 10 -> 13 -> 14` successful checks

The previous lifetime counter treated those roughly 30-second updates as one wake storm and paused after five model-visible injections. Raising the budget would only postpone the same failure while weakening protection against actual bursts.

## Design

- `#lastWakeAt` records only successful model-visible monitor injections
- a strict gap `> 2 * rateLimitMs` resets the consecutive wake streak before the next nonduplicate batch consumes budget
- deferred, empty, duplicate, disabled, and suppressed batches do not update the timestamp
- `forceWake` is an optional internal delivery option; it only upgrades the pause-triggering `next-turn` batch from `followUp` to `steer`
- `notify: "off"`, noninteractive modes, and no-model sessions still return no delivery object

Rejected alternatives:

- clearing sticky pause on arbitrary user/tool activity would desynchronize notifier and registry pause state or implicitly rearm noisy monitors
- resetting on every `agent_end` would effectively disable the wake budget
- increasing `wakeBudget` would only delay slow accumulation and amplify real storms

## RED -> GREEN

- `breaks the wake streak after a gap longer than twice the rate limit`
  - RED: expected 3 deliveries, received 2
  - GREEN: 3 quiet-spaced deliveries, no pause notice, no `pauseMonitors`
- `forces only the pause-triggering next-turn batch to steer`
  - RED: expected `steer`, received `followUp`
  - GREEN: ordinary update remains `followUp`; pause batch is `steer` and pauses exactly once

Focused regression suite:

```text
Test Files  3 passed (3)
Tests       27 passed (27)
```

## Real CLI QA

Source CLI RPC QA used an isolated sandbox and deterministic fake model server:

- slow gap / `wake`: fourth marker reached the provider; no pause content or paused footer
- burst / `next-turn`: exactly one post-baseline provider request contained the pause notice; paused footer observed
- burst / `off`: zero post-baseline requests; no monitor notification or paused footer
- real auth SHA-256 unchanged
- all CLI processes, emitter processes, sandboxes, and fake servers cleaned

Evidence: `local-ignore/qa-evidence/20260811-monitor-pause-wake/`

## Validation

- focused monitor suite: 27/27
- `npm run check`
- `git diff --check`
- changed-source LSP directory diagnostics: 0 errors
- post-merge focused suite and root check
- eight independent review lanes: state machine, delivery semantics, QA evidence, goal compliance, code quality, security, hands-on QA, and historical context

## Fork surface

`packages/coding-agent/src/core/extensions/builtin/terminal/changes.md` records the private builtin behavior, rationale, external-boundary limitation, and expected merge-conflict zones.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the terminal monitor pause burst-aware to prevent pauses on slow, spaced updates. Resets the wake streak after a quiet gap (> 2× the rate limit) and forces a wake only for the pause-triggering `next-turn` batch; documents the change in the `packages/coding-agent` changelog.

- **Bug Fixes**
  - Count only successful model-visible injections toward the wake budget; deferred, duplicate, disabled, or suppressed batches don’t advance the streak.
  - Add `forceWake` delivery option to upgrade the pause-triggering `next-turn` batch to `steer` without bypassing terminal notification guards; ordinary updates stay `followUp`.
  - Preserve duplicate suppression, summary delivery, explicit/fresh-monitor rearm, ordinary wake behavior, and all notification guards.
  - Update `packages/coding-agent/CHANGELOG.md` to record the burst-aware pause and immediate wake behavior.

<sup>Written for commit 22cee2f8d0e9987cc41e3924f8d62f2048e5e865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

