### PR TITLE
docs(changelog): complete v2026.8.11-3 audit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,10 +13,11 @@
 - Gateway/provider failures reported as `The model request was rejected. Check the request and try again.` now retry
   the current model according to `settings.retry` before the configured fallback chain is used
   ([#806](https://github.com/code-yeongyu/senpi/pull/806)).
-- `/goal resume` can explicitly reactivate a completed goal and queue its continuation, while completed goals remain excluded from automatic restart-resume prompts.
+- `/goal resume` can explicitly reactivate a completed goal and queue its continuation, while completed goals remain
+  excluded from automatic restart-resume prompts ([#802](https://github.com/code-yeongyu/senpi/pull/802)).
 - A launch from a deleted working directory (for example a removed worktree) no longer crashes during
   startup with `uv_cwd`; the CLI recovers into the home directory before any dependency evaluates
-  `process.cwd()`.
+  `process.cwd()` ([#799](https://github.com/code-yeongyu/senpi/pull/799)).
 - `claude-sdk-oauth` is now skipped as an unauthenticated fallback candidate on a managed lane
   (`oauth-slots`/`config-dir`) when no account is logged in, instead of always counting as configured because its
   stored credential is a zero-account sentinel. The ambient lane is unchanged and still defers to the spawned
@@ -25,6 +26,9 @@
   authenticated ambient Claude CLI is usable. Empty sentinel credentials and logged-out local CLIs are skipped, and
   fallback responses carrying errors such as `Not logged in` cannot emit an immediate or delayed green
   `Fallback model responded` notice ([#803](https://github.com/code-yeongyu/senpi/pull/803)).
+- Route Anthropic provider-native refusal fallbacks through the configured Senpi chain after an active-turn model
+  change, instead of persisting the server-selected substitute because the run retained the previous model's policy
+  ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
 
 ### New Features
 
@@ -52,15 +56,12 @@
   setup guidance instead of failing ([#813](https://github.com/code-yeongyu/senpi/pull/813)).
 - Added a conditionally contributed `gpt-image-gen` skill with a detailed prompt-crafting guide that is listed
   only while image-generation credentials exist ([#813](https://github.com/code-yeongyu/senpi/pull/813)).
-- **Extension Tool Search**: Extension tools can opt into a shared searchable catalog by setting `exposure: "search"` on `pi.registerTool()`. Searchable tools stay inactive and cost zero prompt tokens until the model finds them with the shared `tool_search` tool, which promotes matches into the active set for the next model request.
+- **Extension Tool Search**: Extension tools can opt into a shared searchable catalog by setting
+  `exposure: "search"` on `pi.registerTool()`. Searchable tools stay inactive and cost zero prompt tokens until the
+  model finds them with the shared `tool_search` tool, which promotes matches into the active set for the next model
+  request ([#811](https://github.com/code-yeongyu/senpi/pull/811)).
 
 ### Changed
-
-### Fixed
-
-- Route Anthropic provider-native refusal fallbacks through the configured Senpi chain after an active-turn model
-  change, instead of persisting the server-selected substitute because the run retained the previous model's policy
-  ([#796](https://github.com/code-yeongyu/senpi/pull/796)).
 
 ### Removed
 


### PR DESCRIPTION
## Summary

- complete the changelog audit for every merged PR since `v2026.8.11-2`
- add the missing `[#799]`, `[#802]`, and `[#811]` attributions
- consolidate the duplicate `### Fixed` subsection without changing any released section

## RED → GREEN evidence

RED, before the edit:

```text
missing: [799, 802, 811]
duplicates: ["Fixed"]
RED: changelog completeness/structure audit failed
```

GREEN, after the edit:

```text
missing: []
duplicates: []
GREEN: changelog completeness/structure audit passed
```

## Validation

- `node scripts/check-pr-changelog.mjs --base 67a03f5c74b8d4420747b2ab7854572163faac14`
- custom since-tag completeness/duplicate-subsection audit for PRs `#796`, `#799`, `#802`, `#803`, `#804`, `#805`, `#806`, `#810`, `#811`, `#813`, `#814`, and `#815`
- `git diff --check`
- byte-for-byte comparison from `## [2026.8.11-2]` onward: unchanged (`583468` bytes on both sides)

## Release intent

This PR is the changelog gate for the canonical `v2026.8.11-3` release. After merge, the release will be cut only through `scripts/release.mjs` from clean updated `main`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completed the v2026.8.11-3 changelog audit by adding missing attributions for #799, #802, and #811 and consolidating a duplicate “Fixed” section, without changing any released content. This ensures the changelog is complete and structured correctly for the release gate.

<sup>Written for commit 1db518532f38608e64bbc2d0f1ae54af07695502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

