### PR TITLE
test(ai): use current Google model fixtures

### DIFF
--- a/packages/ai/test/context-overflow.test.ts
+++ b/packages/ai/test/context-overflow.test.ts
@@ -211,8 +211,8 @@ describe("Context overflow error handling", () => {
 	// =============================================================================
 
 	describe.skipIf(!process.env.GEMINI_API_KEY)("Google", () => {
-		it("gemini-2.0-flash - should detect overflow via isContextOverflow", async () => {
-			const model = getModel("google", "gemini-2.0-flash");
+		it("gemini-2.5-flash - should detect overflow via isContextOverflow", async () => {
+			const model = getModel("google", "gemini-2.5-flash");
 			const result = await testContextOverflow(model, process.env.GEMINI_API_KEY!);
 			logResult(result);
 

--- a/packages/ai/test/total-tokens.test.ts
+++ b/packages/ai/test/total-tokens.test.ts
@@ -219,11 +219,11 @@ describe("totalTokens field", () => {
 	// =========================================================================
 
 	describe.skipIf(!process.env.GEMINI_API_KEY)("Google", () => {
-		it("gemini-2.0-flash - should return totalTokens equal to sum of components", {
+		it("gemini-2.5-flash - should return totalTokens equal to sum of components", {
 			retry: 3,
 			timeout: 60000,
 		}, async () => {
-			const llm = getModel("google", "gemini-2.0-flash");
+			const llm = getModel("google", "gemini-2.5-flash");
 
 			console.log(`\nGoogle / ${llm.id}:`);
 			const { first, second } = await testTotalTokensWithCache(llm);


### PR DESCRIPTION
## Summary

- replace the retired `gemini-2.0-flash` fixture in two credential-gated Google integration tests
- use `gemini-2.5-flash`, the current stable Google fixture already used throughout the AI test suite
- unblock the canonical release/local-release `npm run check` gate

## RED → GREEN

RED on parent commit `661e8bea3` through the faithful release seam:

```text
npm --prefix packages/ai run generate-models
npx tsc --noEmit

packages/ai/test/context-overflow.test.ts(215,37): error TS2345
packages/ai/test/total-tokens.test.ts(226,35): error TS2345
Argument of type '"gemini-2.0-flash"' is not assignable to the generated Google ModelId type.
```

The committed snapshot still contains `gemini-2.0-flash`, so a plain pre-regeneration check passes. The release/local-release scripts regenerate from Google’s mutable live catalog first; the initial release smoke received a refreshed snapshot that omitted the retired ID and exposed the stale fixtures. Subsequent live snapshots may temporarily include it again, so aligning the tests with the suite’s established current fixture removes that release-time instability.

GREEN after this commit through the same seam:

```text
npm --prefix packages/ai run generate-models
npm run check
# exit 0
```

## Validation

- `npm run check`
- `npm --prefix packages/ai run generate-models` followed by `npx tsc --noEmit`
- `npm --prefix packages/ai test -- context-overflow.test.ts total-tokens.test.ts`
  - both files import/typecheck successfully
  - live cases skip without real provider credentials, as designed
- `git diff --check`

## Changelog

Test-only fixture maintenance; no runtime or user-facing behavior changes.
