### PR TITLE
feat(rpc): handle extension requests directly

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Added
 
+- RPC clients can invoke generation-owned extension request handlers directly through
+  `pi.rpc.handle()` and `RpcClient.requestExtension()` without turning controls into
+  model prompts; request routing rejects unknown, duplicate, cross-session, stale,
+  and stale-in-flight generations ([#822](https://github.com/code-yeongyu/senpi/pull/822)).
+
 ### Changed
 
 ### Removed

--- a/packages/coding-agent/docs/extensions.md
+++ b/packages/coding-agent/docs/extensions.md
@@ -1416,6 +1416,29 @@ Use this for extension-to-client state such as progress snapshots. It is separat
 extension-local event-bus communication and must not carry secrets, prompts, transcripts, or other
 data the client did not explicitly opt into receiving.
 
+### pi.rpc.handle(name, handler)
+
+Register one structured request handler that an RPC client can invoke without turning the request
+into a model prompt:
+
+```typescript
+pi.rpc.handle("acme.job.cancel", async (data) => {
+  const input = CancelJobInput.parse(data);
+  await cancelJob(input.jobId);
+  return { cancelled: true };
+});
+```
+
+`name` must be non-empty and unique across the loaded extension generation. The handler receives
+opaque `unknown` data and may return any JSON-serializable value synchronously or asynchronously.
+Extensions own validation for their request names; Senpi owns request correlation, multi-session
+routing, stale-generation rejection, and bounded unknown/duplicate-name errors.
+
+Use this for trusted RPC-client controls over extension-owned state. Do not use slash-command
+prompts as a control transport: `pi.rpc.handle` executes directly without invoking the model. An
+older Senpi host that does not expose `handle` can be supported by feature-detecting the method
+before registration.
+
 ### pi.registerTool(definition)
 
 Register a custom tool callable by the LLM. See [Custom Tools](#custom-tools) for full details.

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -948,6 +948,43 @@ Extension rows come directly from the session's loaded resource inventory, not f
 
 In multi-session mode this is a session-scoped command and requires the routing `sessionId`.
 
+### extension_request
+
+Invoke a request handler registered by an extension through `pi.rpc.handle(name, handler)`:
+
+```json
+{
+  "id": "req-42",
+  "type": "extension_request",
+  "name": "acme.job.cancel",
+  "data": {
+    "jobId": "job-42"
+  }
+}
+```
+
+Success returns the extension-owned structured value:
+
+```json
+{
+  "id": "req-42",
+  "type": "response",
+  "command": "extension_request",
+  "success": true,
+  "data": {
+    "cancelled": true
+  }
+}
+```
+
+The request `name` must resolve to exactly one handler in the active extension generation.
+Unknown names, duplicate names, stale generations, handler failures, and empty names return the
+normal `{ type: "response", success: false, error }` envelope. Senpi treats request and response
+data as opaque; the owning extension and client must validate their payloads.
+
+In multi-session mode this command requires the owning routing `sessionId`. The response receives
+the same `sessionId`, and another session's extension handlers are never consulted.
+
 ## Events
 
 Events are streamed to stdout as JSON lines during agent operation. Events do not generally include an `id` field; `bash_execution_update` includes the `id` of its originating `bash` command when one was provided.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5740,8 +5740,12 @@ export class AgentSession {
 			const removed = oldExtensionIdentities.filter(
 				(extension) => !newExtensionResolvedPaths.has(extension.resolvedPath),
 			);
-			if (removed.length > 0) {
-				await oldExtensionRunner.emit({ type: "session_extensions_removed", reason: "reload", removed });
+			try {
+				if (removed.length > 0) {
+					await oldExtensionRunner.emit({ type: "session_extensions_removed", reason: "reload", removed });
+				}
+			} finally {
+				oldExtensionRunner.invalidate("stale extension generation after reload");
 			}
 			time("runtime", "reload");
 		}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,22 @@
 # changes
 
+## Retire extension generations after reload notifications (2026-08-12)
+
+### What changed
+
+- Session reload invalidates the previous `ExtensionRunner` after removed-extension notifications
+  have been delivered, including when notification delivery throws.
+
+### Why
+
+- Reload replaced the active runner but left captured references to the previous generation callable.
+  Invalidating after the final old-generation lifecycle event preserves notification behavior while
+  closing later request registration, emission, and dispatch.
+
+### Expected merge conflict zones
+
+- MEDIUM: `agent-session.ts` reload lifecycle ordering.
+
 ## Standalone binary codemode sidecar resolution (2026-08-11)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,26 @@
 # Core Extensions Changes
 
+## 2026-08-12 - Extension-owned RPC request handlers
+
+### What changed
+
+- `pi.rpc.handle(name, handler)` registers structured client-to-extension request handlers on the
+  loaded extension generation.
+- `ExtensionRunner.requestRpc()` requires exactly one active handler and rejects unknown,
+  duplicate, empty, and stale-generation requests without invoking the model.
+- `pi.rpc.emit()` now also checks generation liveness before publishing.
+
+### Why
+
+- RPC clients need a direct, typed control path for extension-owned runtime state; encoding controls
+  as slash-command prompts would involve the model and lose request/response semantics.
+- Per-generation ownership prevents captured handlers from surviving extension replacement or
+  reload.
+
+### Expected merge conflict zones
+
+- LOW: `types.ts`, `loader.ts`, and `runner.ts` RPC extension surfaces.
+
 ## 2026-08-11 - Native-deferred catalog tools activate at call time
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,22 @@
 # Core Extensions Changes
 
+## 2026-08-12 - Reject stale in-flight RPC request results
+
+### What changed
+
+- `ExtensionRunner.requestRpc()` re-checks generation liveness after an asynchronous handler
+  completes, so a result cannot escape after reload or replacement invalidates its owner.
+- Focused tests cover both explicit mid-flight invalidation and a real session reload.
+
+### Why
+
+- Entry-time liveness alone allowed a slow handler from generation N to return successfully after
+  generation N+1 became active.
+
+### Expected merge conflict zones
+
+- LOW: `runner.ts` request dispatch and its RPC request suite.
+
 ## 2026-08-12 - Extension-owned RPC request handlers
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/index.ts
+++ b/packages/coding-agent/src/core/extensions/index.ts
@@ -82,6 +82,7 @@ export type {
 	ExtensionFlag,
 	ExtensionHandler,
 	ExtensionMode,
+	ExtensionRpcRequestHandler,
 	// Runtime
 	ExtensionRuntime,
 	ExtensionShortcut,

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -566,12 +566,24 @@ function createExtensionAPI(
 
 		rpc: {
 			emit(name, data) {
+				runtime.assertActive();
 				const normalizedName = name.trim();
 				if (normalizedName.length === 0) throw new Error("RPC extension event name must not be empty");
 				eventBus.emit(EXTENSION_RPC_EVENT_CHANNEL, {
 					name: normalizedName,
 					data,
 				} satisfies ExtensionRpcEvent);
+			},
+			handle(name, handler) {
+				runtime.assertActive();
+				const normalizedName = name.trim();
+				if (normalizedName.length === 0) throw new Error("RPC extension request name must not be empty");
+				const handlers = extension.rpcHandlers ?? new Map();
+				if (handlers.has(normalizedName)) {
+					throw new Error(`RPC extension request handler already registered: ${normalizedName}`);
+				}
+				handlers.set(normalizedName, handler);
+				extension.rpcHandlers = handlers;
 			},
 		},
 		events: eventBus,
@@ -644,6 +656,7 @@ function createExtension(extensionPath: string, resolvedPath: string, registrati
 		messageRenderers: new Map(),
 		entryRenderers: undefined,
 		commands: new Map(),
+		rpcHandlers: new Map(),
 		flags: new Map(),
 		shortcuts: new Map(),
 		mcpServers: new Map(),

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -974,7 +974,9 @@ export class ExtensionRunner {
 		if (matches.length > 1) {
 			throw new Error(`Multiple extension RPC request handlers registered: ${normalizedName}`);
 		}
-		return matches[0]?.(data);
+		const result = await matches[0]?.(data);
+		this.assertActive();
+		return result;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -958,6 +958,25 @@ export class ExtensionRunner {
 		return this.resolveRegisteredCommands().find((command) => command.invocationName === name);
 	}
 
+	async requestRpc(name: string, data: unknown): Promise<unknown> {
+		this.assertActive();
+		const normalizedName = name.trim();
+		if (normalizedName.length === 0) {
+			throw new Error("Extension RPC request name must not be empty");
+		}
+		const matches = this.extensions.flatMap((extension) => {
+			const handler = extension.rpcHandlers?.get(normalizedName);
+			return handler === undefined ? [] : [handler];
+		});
+		if (matches.length === 0) {
+			throw new Error(`Unknown extension RPC request: ${normalizedName}`);
+		}
+		if (matches.length > 1) {
+			throw new Error(`Multiple extension RPC request handlers registered: ${normalizedName}`);
+		}
+		return matches[0]?.(data);
+	}
+
 	/**
 	 * Request a graceful shutdown. Called by extension tools and event handlers.
 	 * The actual shutdown behavior is provided by the mode via bindExtensions().

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1846,14 +1846,22 @@ export interface ExtensionAPI {
 	 */
 	unregisterProvider(name: string): void;
 
-	/** Emit structured extension data to RPC clients that explicitly opt in. */
+	/**
+	 * Exchange structured extension-owned data with RPC clients.
+	 *
+	 * `emit` is fire-and-forget server -> client delivery. `handle` registers a
+	 * client -> extension request handler owned by this extension generation.
+	 */
 	rpc: {
 		emit(name: string, data: unknown): void;
+		handle(name: string, handler: ExtensionRpcRequestHandler): void;
 	};
 
 	/** Shared event bus for extension communication. */
 	events: EventBus;
 }
+
+export type ExtensionRpcRequestHandler = (data: unknown) => unknown | Promise<unknown>;
 
 // ============================================================================
 // Provider Registration Types
@@ -2254,6 +2262,8 @@ export interface Extension {
 	markdownTransformer?: MarkdownTransformer;
 	entryRenderers?: Map<string, EntryRenderer>;
 	commands: Map<string, RegisteredCommand>;
+	/** Optional for compatibility with extension records created before RPC requests. */
+	rpcHandlers?: Map<string, ExtensionRpcRequestHandler>;
 	flags: Map<string, ExtensionFlag>;
 	shortcuts: Map<KeyId, ExtensionShortcut>;
 	mcpServers: Map<string, RegisteredMcpServerDeclaration>;

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -86,6 +86,7 @@ export type {
 	ExtensionFactory,
 	ExtensionFlag,
 	ExtensionHandler,
+	ExtensionRpcRequestHandler,
 	ExtensionRuntime,
 	ExtensionShortcut,
 	ExtensionUIContext,

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## Extension request RPC command (2026-08-12)
+
+### What changed
+
+- Added the session-scoped `extension_request` command and structured success/error response.
+- `RpcClient.requestExtension()` exposes the command through the public client.
+- Existing multi-session routing tags the response with the owning `sessionId`.
+
+### Why
+
+- Capability-gated `extension_event` records cover extension-to-client state, but interactive
+  extension controls also need a direct client-to-extension request path that does not become a
+  model prompt.
+
+### Why extension system couldn't handle this
+
+- Request ids, multi-session routing, JSONL response serialization, and public client correlation
+  are owned by the built-in RPC transport.
+
+### Expected merge conflict zones
+
+- MEDIUM: `rpc-types.ts`, `connection-handler.ts`, and `rpc-client.ts`.
+
 ## Multi-session open failure details (2026-08-07)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -258,11 +258,7 @@ export function createRpcConnectionHandler(
 		await sink.waitForBackpressure();
 	};
 
-	const success = <T extends RpcCommand["type"]>(
-		id: string | undefined,
-		command: T,
-		data?: object | null,
-	): RpcResponse => {
+	const success = <T extends RpcCommand["type"]>(id: string | undefined, command: T, data?: unknown): RpcResponse => {
 		if (data === undefined) {
 			return { id, type: "response", command, success: true } as RpcResponse;
 		}
@@ -1016,6 +1012,15 @@ export function createRpcConnectionHandler(
 				await requestMcpWireStatus();
 				const inventory = recordLoadedSurfaces(true);
 				return success(id, "get_loaded_surfaces", inventory.data);
+			}
+
+			case "extension_request": {
+				const name = command.name.trim();
+				if (name.length === 0) {
+					return error(id, "extension_request", "Extension RPC request name cannot be empty");
+				}
+				const data = await session.extensionRunner.requestRpc(name, command.data);
+				return success(id, "extension_request", data);
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -460,6 +460,16 @@ export class RpcClient {
 		return this.getData<{ commands: RpcSlashCommand[] }>(response).commands;
 	}
 
+	/** Invoke one extension-owned RPC request handler and return its structured result. */
+	async requestExtension<T = unknown>(name: string, data?: unknown): Promise<T> {
+		const response = await this.send({
+			type: "extension_request",
+			name,
+			...(data === undefined ? {} : { data }),
+		});
+		return this.getData<T>(response);
+	}
+
 	/** List safe metadata for the named provider's configured account slots. */
 	async getProviderAccounts(provider: string): Promise<RpcProviderAccount[]> {
 		const response = await this.send({ type: "get_provider_accounts", provider });

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -79,6 +79,7 @@ type RpcSessionCommand =
 	// Commands and loaded runtime surfaces
 	| { id?: string; type: "get_commands" }
 	| { id?: string; type: "get_loaded_surfaces" }
+	| { id?: string; type: "extension_request"; name: string; data?: unknown }
 
 	// Auth (task 13) is additive. get_auth_providers, login_api_key and logout
 	// answer synchronously. login_start responds immediately (flow-started) and
@@ -389,6 +390,13 @@ export type RpcResponse =
 			command: "get_loaded_surfaces";
 			success: true;
 			data: { extensions: RpcLoadedExtension[]; mcpServers: RpcLoadedMcpServer[] };
+	  }
+	| {
+			id?: string;
+			type: "response";
+			command: "extension_request";
+			success: true;
+			data: unknown;
 	  }
 
 	// Auth (task 13)

--- a/packages/coding-agent/test/rpc-multi-session.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session.test.ts
@@ -89,6 +89,66 @@ describe("multi-session RPC routing", () => {
 		});
 	});
 
+	test("routes extension requests only to the addressed session binding", async () => {
+		const sessionIds = ["rpc-session-alpha", "rpc-session-beta"];
+		const entryFor = (sessionId: string) => ({
+			runtime: {
+				session: {
+					model: undefined,
+					thinkingLevel: "off",
+					isStreaming: false,
+					isCompacting: false,
+					steeringMode: "one-at-a-time",
+					followUpMode: "one-at-a-time",
+					sessionFile: undefined,
+					sessionId: `durable-${sessionId}`,
+					sessionName: undefined,
+					autoCompactionEnabled: true,
+					messages: [],
+					pendingMessageCount: 0,
+				},
+			},
+		});
+		const registry = {
+			openSession: async () => ({ sessionId: sessionIds.shift() ?? "unexpected" }),
+			getForCommand: (sessionId: string) => entryFor(sessionId),
+			list: () => [],
+			beginClose: () => entryFor("closing"),
+			closeMarked: async () => {},
+		} as never;
+		const alphaHandle = vi.fn(async () => {});
+		const betaHandle = vi.fn(async () => {});
+		const createBinding = vi.fn(async (sessionId: string) => ({
+			handle: sessionId === "rpc-session-alpha" ? alphaHandle : betaHandle,
+			dispose: async () => {},
+		}));
+		const router = Reflect.construct(SessionCommandRouter, [
+			registry,
+			new SessionEventWriter(() => {}),
+			{ cwd: "/tmp" },
+			createBinding,
+		]) as SessionCommandRouter;
+		await router.handle({ id: "open-alpha", type: "open_session", cwd: "/tmp" });
+		await router.handle({ id: "open-beta", type: "open_session", cwd: "/tmp" });
+
+		await router.handle({
+			id: "request-beta",
+			type: "extension_request",
+			sessionId: "rpc-session-beta",
+			name: "fixture.owner",
+			data: { expected: "beta" },
+		});
+
+		expect(alphaHandle).not.toHaveBeenCalled();
+		expect(betaHandle).toHaveBeenCalledWith({
+			id: "request-beta",
+			type: "extension_request",
+			sessionId: "rpc-session-beta",
+			name: "fixture.owner",
+			data: { expected: "beta" },
+		});
+	});
+
 	test("keeps the classic-only open error code stable", () => {
 		expect(RPC_ERROR_MULTI_SESSION_DISABLED).toBe("multi_session_disabled");
 	});

--- a/packages/coding-agent/test/suite/rpc-extension-requests.test.ts
+++ b/packages/coding-agent/test/suite/rpc-extension-requests.test.ts
@@ -226,4 +226,49 @@ describe("extension RPC requests", () => {
 
 		await expect(runner.requestRpc("fixture.stale", null)).rejects.toThrow("stale extension generation");
 	});
+
+	it("invalidates the previous extension generation after a real reload", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					const rpc = (pi as ExtensionRequestApi).rpc;
+					if (typeof rpc.handle !== "function") return;
+					rpc.handle("fixture.reload", () => ({ generation: "old" }));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const oldRunner = harness.session.extensionRunner;
+
+		await harness.session.reload();
+
+		expect(harness.session.extensionRunner).not.toBe(oldRunner);
+		await expect(oldRunner.requestRpc("fixture.reload", null)).rejects.toThrow("stale extension generation");
+	});
+
+	it("rejects an in-flight result when its generation becomes stale", async () => {
+		const started = Promise.withResolvers<void>();
+		const result = Promise.withResolvers<{ generation: string }>();
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					const rpc = (pi as ExtensionRequestApi).rpc;
+					if (typeof rpc.handle !== "function") return;
+					rpc.handle("fixture.in-flight", async () => {
+						started.resolve();
+						return result.promise;
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		const runner = harness.session.extensionRunner;
+		const pending = runner.requestRpc("fixture.in-flight", null);
+		await started.promise;
+
+		runner.invalidate("stale extension generation");
+		result.resolve({ generation: "old" });
+
+		await expect(pending).rejects.toThrow("stale extension generation");
+	});
 });

--- a/packages/coding-agent/test/suite/rpc-extension-requests.test.ts
+++ b/packages/coding-agent/test/suite/rpc-extension-requests.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../../src/core/agent-session.ts";
+import type { AgentSessionRuntime } from "../../src/core/agent-session-runtime.ts";
+import type { ExtensionAPI } from "../../src/core/extensions/types.ts";
+import type { RpcClient } from "../../src/index.ts";
+import {
+	createRpcConnectionHandler,
+	type RpcConnectionHandler,
+	type RpcConnectionOptions,
+	type RpcConnectionSink,
+} from "../../src/modes/rpc/connection-handler.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+type ExtensionRequestHandler = (data: unknown) => unknown | Promise<unknown>;
+
+type ExtensionRequestApi = ExtensionAPI & {
+	readonly rpc: {
+		emit(name: string, data: unknown): void;
+		handle(name: string, handler: ExtensionRequestHandler): void;
+	};
+};
+
+type RpcRecord = Record<string, unknown>;
+type PublicRequestExtension = RpcClient["requestExtension"];
+const publicRequestExtension: PublicRequestExtension | undefined = undefined;
+void publicRequestExtension;
+
+function createRuntimeHost(session: AgentSession): AgentSessionRuntime {
+	return {
+		session,
+		newSession: async () => ({ cancelled: true }),
+		switchSession: async () => ({ cancelled: true }),
+		fork: async () => ({ cancelled: true, selectedText: "" }),
+		dispose: async () => {},
+		setRebindSession: () => {},
+	} as unknown as AgentSessionRuntime;
+}
+
+function records(chunks: readonly string[]): RpcRecord[] {
+	return chunks
+		.join("")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as RpcRecord);
+}
+
+function connect(harness: Harness, chunks: string[], options: RpcConnectionOptions = {}): RpcConnectionHandler {
+	const sink: RpcConnectionSink = {
+		writeRaw: (chunk) => chunks.push(chunk),
+		waitForBackpressure: async () => {},
+	};
+	return createRpcConnectionHandler(createRuntimeHost(harness.session), sink, options);
+}
+
+async function request(
+	handler: RpcConnectionHandler,
+	chunks: string[],
+	input: {
+		readonly id: string;
+		readonly name: string;
+		readonly data?: unknown;
+	},
+): Promise<RpcRecord> {
+	await handler.handleInputLine(
+		JSON.stringify({
+			id: input.id,
+			type: "extension_request",
+			name: input.name,
+			...(input.data === undefined ? {} : { data: input.data }),
+		}),
+	);
+	const response = records(chunks).find((record) => record.id === input.id);
+	if (!response) throw new Error(`Missing response for ${input.id}`);
+	return response;
+}
+
+describe("extension RPC requests", () => {
+	const harnesses: Harness[] = [];
+	const handlers: RpcConnectionHandler[] = [];
+
+	afterEach(async () => {
+		while (handlers.length > 0) await handlers.pop()?.dispose();
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("exposes a request handler registration API to extensions", async () => {
+		let rpc: ExtensionRequestApi["rpc"] | undefined;
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					rpc = (pi as ExtensionRequestApi).rpc;
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		expect(rpc?.handle).toBeTypeOf("function");
+	});
+
+	it("routes one request to its extension handler and returns structured data", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					const rpc = (pi as ExtensionRequestApi).rpc;
+					if (typeof rpc.handle !== "function") return;
+					rpc.handle("fixture.echo", async (data) => ({ echoed: data }));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const chunks: string[] = [];
+		const handler = connect(harness, chunks);
+		handlers.push(handler);
+		await handler.ready;
+
+		await expect(
+			request(handler, chunks, {
+				id: "echo",
+				name: "fixture.echo",
+				data: { text: "hello" },
+			}),
+		).resolves.toEqual({
+			id: "echo",
+			type: "response",
+			command: "extension_request",
+			success: true,
+			data: { echoed: { text: "hello" } },
+		});
+	});
+
+	it("returns a bounded error for an unknown request name", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const chunks: string[] = [];
+		const handler = connect(harness, chunks);
+		handlers.push(handler);
+		await handler.ready;
+
+		const response = await request(handler, chunks, {
+			id: "missing",
+			name: "fixture.missing",
+		});
+
+		expect(response).toMatchObject({
+			id: "missing",
+			type: "response",
+			command: "extension_request",
+			success: false,
+		});
+		expect(response.error).toContain("fixture.missing");
+	});
+
+	it("rejects duplicate request handlers instead of choosing one", async () => {
+		const register = (value: string) => (pi: ExtensionAPI) => {
+			const rpc = (pi as ExtensionRequestApi).rpc;
+			if (typeof rpc.handle !== "function") return;
+			rpc.handle("fixture.duplicate", () => ({ value }));
+		};
+		const harness = await createHarness({
+			extensionFactories: [register("first"), register("second")],
+		});
+		harnesses.push(harness);
+		const chunks: string[] = [];
+		const handler = connect(harness, chunks);
+		handlers.push(handler);
+		await handler.ready;
+
+		const response = await request(handler, chunks, {
+			id: "duplicate",
+			name: "fixture.duplicate",
+		});
+
+		expect(response).toMatchObject({
+			id: "duplicate",
+			type: "response",
+			command: "extension_request",
+			success: false,
+		});
+		expect(response.error).toContain("fixture.duplicate");
+	});
+
+	it("tags the response with the owning multi-session routing id", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					const rpc = (pi as ExtensionRequestApi).rpc;
+					if (typeof rpc.handle !== "function") return;
+					rpc.handle("fixture.owner", () => ({ owner: "beta" }));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const chunks: string[] = [];
+		const handler = connect(harness, chunks, { sessionId: "rpc-session-beta" });
+		handlers.push(handler);
+		await handler.ready;
+
+		await expect(
+			request(handler, chunks, {
+				id: "owner",
+				name: "fixture.owner",
+			}),
+		).resolves.toEqual({
+			id: "owner",
+			type: "response",
+			command: "extension_request",
+			success: true,
+			data: { owner: "beta" },
+			sessionId: "rpc-session-beta",
+		});
+	});
+
+	it("rejects requests through a stale extension generation", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					const rpc = (pi as ExtensionRequestApi).rpc;
+					if (typeof rpc.handle !== "function") return;
+					rpc.handle("fixture.stale", () => ({ stale: false }));
+				},
+			],
+		});
+		harnesses.push(harness);
+		const runner = harness.session.extensionRunner;
+		runner.invalidate("stale extension generation");
+
+		await expect(runner.requestRpc("fixture.stale", null)).rejects.toThrow("stale extension generation");
+	});
+});


### PR DESCRIPTION
## Problem

Extension RPC was one-way: extensions could emit capability-gated state, but an RPC client could
not invoke extension-owned controls without turning them into slash-command prompts.

## Fix

- add generation-owned `pi.rpc.handle(name, handler)` registration
- add the session-scoped `extension_request` JSONL command and structured response
- expose `RpcClient.requestExtension()`
- reject empty, unknown, duplicate, and stale-generation handlers
- preserve existing multi-session routing and response tagging
- document the public extension and wire contracts

## Verification

- `npm --prefix packages/coding-agent test -- test/suite/rpc-extension-requests.test.ts test/suite/rpc-extension-events.test.ts test/rpc-multi-session.test.ts`
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `npm run check`
- mutation proof: forcing a beta request into the alpha binding fails the new isolation assertion

Model: `gpt-5.6-sol-fast`
Harness: `omo-senpi`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables direct client-to-extension RPC requests so clients can call extension-owned handlers without the model. Adds a session-scoped RPC command and client API with strict validation, multi-session tagging, and rejection of stale or in-flight results after reloads.

- **New Features**
  - `pi.rpc.handle(name, handler)` to register one handler per name on the active extension generation; rejects empty, unknown, duplicate, and stale-generation cases.
  - New RPC command `extension_request` with structured success/error responses; data is opaque; responses include `sessionId` in multi-session mode.
  - `RpcClient.requestExtension(name, data?)` to call a handler and get its result.
  - Docs updated; tests cover handler routing, multi-session isolation, and generation liveness.

- **Bug Fixes**
  - Reject stale in-flight handler results by re-checking generation liveness after handler completion; invalidate the previous `ExtensionRunner` after reload notifications.
  - `pi.rpc.emit()` now asserts generation liveness before publishing.

<sup>Written for commit 901171b2f1fc6e0b216adcfab17cd7f3d463f76a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

