### PR TITLE
feat(coding-agent): expose session cwd on ExtensionAPI

### DIFF
--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,22 @@
 # Core Extensions Changes
 
+## 2026-08-12 - Expose session cwd during extension registration
+
+### What changed
+
+- `ExtensionAPI.cwd` exposes the absolute cwd of the session that loaded the extension instance.
+
+### Why
+
+- Extension factories may need to initialize per-project state at registration time, before any event
+  supplies an `ExtensionContext`.
+- In multi-session hosts, `process.cwd()` is the shared process launch directory rather than the
+  project root for each extension instance.
+
+### Expected merge conflict zones
+
+- LOW: `types.ts` ExtensionAPI interface, `loader.ts` createExtensionAPI return literal.
+
 ## 2026-08-12 - Reject stale in-flight RPC request results
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/loader.ts
+++ b/packages/coding-agent/src/core/extensions/loader.ts
@@ -344,6 +344,8 @@ function createExtensionAPI(
 	eventBus: EventBus,
 ): ExtensionAPI {
 	const api = {
+		cwd,
+
 		// Registration methods - write to extension
 		on(event: string, handler: HandlerFn): void {
 			runtime.assertActive();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1554,6 +1554,13 @@ export type ExtensionHandler<E, R = undefined> = (event: E, ctx: ExtensionContex
  */
 export interface ExtensionAPI {
 	// =========================================================================
+	// Session Context
+	// =========================================================================
+
+	/** Absolute cwd of the session this extension instance was loaded for. */
+	readonly cwd: string;
+
+	// =========================================================================
 	// Event Subscription
 	// =========================================================================
 

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -232,6 +232,7 @@ function captureCompactionHandlers(): CapturedCompactionHandlers {
 	let messageEnd: MessageEndHandler | undefined;
 	let modelSelect: ModelSelectHandler | undefined;
 	const api: ExtensionAPI = Object.assign(Object.create(null), {
+		cwd: "/tmp/senpi-compaction-test",
 		on: (event: string, currentHandler: BeforeAgentStartHandler | MessageEndHandler | ModelSelectHandler) => {
 			if (event === "before_agent_start") {
 				beforeAgentStart = currentHandler as BeforeAgentStartHandler;

--- a/packages/coding-agent/test/extensions-loader.test.ts
+++ b/packages/coding-agent/test/extensions-loader.test.ts
@@ -35,6 +35,28 @@ describe("extension loader", () => {
 		expect(createJiti).toHaveBeenCalledTimes(1);
 	});
 
+	it("exposes the session cwd to the extension factory", async () => {
+		const sessionCwd = path.resolve("/tmp/senpi-extension-session-cwd");
+		expect(sessionCwd).not.toBe(process.cwd());
+
+		let capturedApi: ExtensionAPI | undefined;
+		const extensionFactory: ExtensionFactory = (pi) => {
+			capturedApi = pi;
+		};
+		const importExtension = vi.fn(async () => extensionFactory);
+		const createJiti = vi.fn(() => ({
+			import: importExtension,
+		}));
+
+		vi.doMock("jiti/static", () => ({ createJiti }));
+		const { loadExtensions } = await import("../src/core/extensions/loader.ts");
+
+		const result = await loadExtensions(["first.js"], sessionCwd);
+
+		expect(result.errors).toHaveLength(0);
+		expect(capturedApi?.cwd).toBe(sessionCwd);
+	});
+
 	it("prefers bundled package aliases when the local coding-agent package carries dependencies", async () => {
 		// given a linked local senpi install where dependencies live under
 		// packages/coding-agent/node_modules instead of the workspace root

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -41,6 +41,7 @@ describe("trigger-compact example extension", () => {
 			| undefined;
 
 		const api: ExtensionAPI = Object.assign(Object.create(null), {
+			cwd: "/tmp/senpi-trigger-compact-test",
 			on: (event: string, handler: (event: { type: "turn_end" }, ctx: ExtensionContext) => void) => {
 				if (event === "turn_end") {
 					turnEndHandler = handler;


### PR DESCRIPTION
## Summary

- expose the resolved session cwd as readonly `ExtensionAPI.cwd`
- populate it from the cwd already passed to `createExtensionAPI`
- cover factory-time access with a loader regression test and update directly typed test fakes

## Why `cwd` is also on `pi`

`ExtensionContext.cwd` remains the per-event source of session context. However, extension factories need the session cwd at registration time, before any event has fired and therefore before any `ExtensionContext` exists. In a multi-session host, falling back to `process.cwd()` returns the shared process launch directory rather than the project root for the specific extension instance.

## Verification

- RED before implementation: `cd packages/coding-agent && npx vitest --run test/extensions-loader.test.ts` failed with `expected undefined to be '/tmp/senpi-extension-session-cwd'`
- GREEN after implementation: focused loader suite passed, 8/8 tests
- related typed-fake suites passed, 39/39 tests
- `npx tsc --noEmit` passed with no output
- Biome check passed on changed source/test files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the session working directory on `ExtensionAPI.cwd` so extension factories can access the correct project root during registration. The loader now populates it with the resolved session cwd, avoiding `process.cwd()` in multi-session hosts.

<sup>Written for commit 04a6a3fbea107f11c609242e75899c264e6c3dde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

