### PR TITLE
fix(coding-agent): bound btw side-query context

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- `/btw` side queries now budget captured session context against the selected model's window instead of replaying the
+  full snapshot, so large sessions no longer fail with a context-window overflow ([#823](https://github.com/code-yeongyu/senpi/pull/823)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - `/btw` side queries now budget captured session context against the selected model's window instead of replaying the
-  full snapshot, so large sessions no longer fail with a context-window overflow ([#823](https://github.com/code-yeongyu/senpi/pull/823)).
+  full snapshot, so large sessions no longer fail with a context-window overflow ([#826](https://github.com/code-yeongyu/senpi/pull/826)).
 
 ### New Features
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1212,6 +1212,9 @@
 
 ### What changed
 
+- `/btw` side queries now use model-aware prompt budgeting before provider dispatch. Large captured sessions are reduced,
+  structurally repaired, and pruned oldest-first while preserving the final question and newest usable context, avoiding
+  provider context-window rejection without changing normal small-session behavior.
 - New builtin extension `core/extensions/builtin/btw/` adds `/btw <question>`: a read-only side LLM query against a synchronously captured snapshot of the current conversation, running in parallel with any in-flight main turn without writing to session history. Details in `core/extensions/builtin/btw/changes.md`.
 - TUI: the answer streams into a dismissable widget above the editor; Escape dismisses the side panel without touching main-turn Escape behavior. Non-TUI modes deliver the answer via `ctx.ui.notify`.
 - `core/extensions/builtin/index.ts` registers the extension between `goal` and `mcp`.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,3 +1,29 @@
+## Model-aware `/btw` side-query context budgeting (2026-08-12)
+
+### What changed
+
+- `/btw` side queries now budget the complete ephemeral prompt against the selected model's context window. Oversized
+  snapshots reuse the deterministic context reducer, repair orphaned tool results, and prune oldest context while
+  preserving the final question and newest usable messages.
+- Mandatory prompt content that still cannot fit now fails locally with an actionable `/compact` suggestion instead of
+  sending a provider request that is guaranteed to be rejected.
+
+### Why
+
+- The builtin `/btw` path bypassed the main-turn context pipeline and replayed the captured session snapshot directly to
+  the provider. Large sessions could therefore fail with a context-window overflow even while the main turn continued.
+
+### Why an extension could not do this
+
+- The oversized payload is assembled inside the builtin command's private snapshot-to-provider path. An external
+  extension cannot intercept and structurally budget that ephemeral request without replacing the builtin.
+
+### Expected merge conflict zones on next upstream sync
+
+- `core/extensions/builtin/btw/index.ts` around snapshot construction and side-query dispatch.
+- `core/extensions/builtin/btw/side-query.ts` around context assembly and model runtime options.
+- `test/suite/btw-side-query.test.ts` around context-builder and command regression coverage.
+
 ## Control protocol exposes loaded extensions and MCP inventory (2026-08-11)
 
 ### What changed
@@ -1212,9 +1238,6 @@
 
 ### What changed
 
-- `/btw` side queries now use model-aware prompt budgeting before provider dispatch. Large captured sessions are reduced,
-  structurally repaired, and pruned oldest-first while preserving the final question and newest usable context, avoiding
-  provider context-window rejection without changing normal small-session behavior.
 - New builtin extension `core/extensions/builtin/btw/` adds `/btw <question>`: a read-only side LLM query against a synchronously captured snapshot of the current conversation, running in parallel with any in-flight main turn without writing to session history. Details in `core/extensions/builtin/btw/changes.md`.
 - TUI: the answer streams into a dismissable widget above the editor; Escape dismisses the side panel without touching main-turn Escape behavior. Non-TUI modes deliver the answer via `ctx.ui.notify`.
 - `core/extensions/builtin/index.ts` registers the extension between `goal` and `mcp`.

--- a/packages/coding-agent/src/core/extensions/builtin/btw/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/changes.md
@@ -1,5 +1,33 @@
 # changes — btw
 
+## Model-aware side-query context budgeting (2026-08-12)
+
+### What changed
+
+- `/btw` now budgets the complete side-query prompt against the selected model's context window, including output
+  reserve, the session system prompt, the side-query instruction, captured history, and the final question.
+- Oversized captured snapshots run through the existing deterministic context reducer, orphaned tool-result repair, and
+  oldest-first pruning before provider dispatch. Small snapshots remain unchanged.
+- If mandatory prompt content cannot fit, `/btw` fails locally with an actionable `/compact` suggestion instead of
+  sending a provider request that is guaranteed to be rejected.
+
+### Why
+
+- `/btw` previously bypassed the main-turn context pipeline and replayed the full captured session snapshot directly to
+  the provider. Large sessions could therefore fail with `Your input exceeds the context window of this model` even
+  while normal main turns continued successfully.
+
+### Why an extension could not do this
+
+- The failure is inside the builtin command's private snapshot-to-provider path. An external extension cannot intercept
+  and structurally budget that ephemeral provider payload without replacing the builtin command.
+
+### Expected merge-conflict zones
+
+- `index.ts` around captured snapshot construction and side-query dispatch.
+- `side-query.ts` around context assembly and model runtime options.
+- `test/suite/btw-side-query.test.ts` around the builtin command and context-builder regression coverage.
+
 ## Runtime provider dispatch for side queries (2026-07-30)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/btw/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/index.ts
@@ -2,7 +2,7 @@ import { convertToLlm, filterContextExcludedMessages } from "../../../messages.t
 import { buildSessionContext } from "../../../session-manager.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { BtwPanel } from "./panel.ts";
-import { buildSideQueryContext, runSideQuery } from "./side-query.ts";
+import { buildSideQueryContext, getSideQueryPromptContextWindow, runSideQuery } from "./side-query.ts";
 
 const WIDGET_KEY = "btw";
 const ESCAPE = "";
@@ -62,7 +62,6 @@ export default function btwExtension(pi: ExtensionAPI) {
 			const systemPrompt = ctx.getSystemPrompt();
 			const thinkingLevel = pi.getThinkingLevel();
 			const sessionId = ctx.sessionManager.getSessionId();
-			const context = buildSideQueryContext({ systemPrompt, history, question });
 
 			dismiss(ctx, { abort: true });
 			const controller = new AbortController();
@@ -91,6 +90,12 @@ export default function btwExtension(pi: ExtensionAPI) {
 			}
 
 			try {
+				const context = buildSideQueryContext({
+					systemPrompt,
+					history,
+					question,
+					promptContextWindow: getSideQueryPromptContextWindow(model),
+				});
 				const { replyText } = await runSideQuery(
 					{
 						model,

--- a/packages/coding-agent/src/core/extensions/builtin/btw/side-query.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/side-query.ts
@@ -7,6 +7,11 @@ import type {
 	ThinkingLevel,
 } from "@earendil-works/pi-ai/compat";
 import { streamSimple } from "@earendil-works/pi-ai/compat";
+import { estimateTokens } from "../../../compaction/index.ts";
+import { convertToLlm } from "../../../messages.ts";
+import { BUILTIN_CONTEXT_REDUCTION_OPTIONS, reduceContextMessages } from "../compaction/context-reduction.ts";
+import { pruneOldMessagesToBudget } from "../compaction/overflow-retry.ts";
+import { repairOrphanedToolResults } from "../compaction/repair-tool-pairs.ts";
 
 export const SIDE_QUERY_INSTRUCTION = [
 	"The user is asking a side question about the conversation so far, outside the main task.",
@@ -15,17 +20,68 @@ export const SIDE_QUERY_INSTRUCTION = [
 ].join(" ");
 
 export const DEFAULT_ESTABLISHMENT_TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_RESERVE_RATIO = 0.5;
 
 export interface SideQueryContextInput {
 	systemPrompt: string;
 	history: readonly Message[];
 	question: string;
+	promptContextWindow?: number;
+}
+
+function estimateMessagesTokens(messages: readonly Message[]): number {
+	return messages.reduce((total, message) => total + estimateTokens(message), 0);
+}
+
+function estimateSystemPromptTokens(systemPrompt: string): number {
+	return estimateTokens({ role: "user", content: systemPrompt, timestamp: 0 });
+}
+
+function boundSideQueryMessages(
+	messages: Message[],
+	systemPrompt: string,
+	promptContextWindow: number | undefined,
+): Message[] {
+	if (typeof promptContextWindow !== "number" || !Number.isFinite(promptContextWindow) || promptContextWindow <= 0) {
+		return messages;
+	}
+
+	const messageBudget = promptContextWindow - estimateSystemPromptTokens(systemPrompt);
+	const question = messages.at(-1);
+	if (question === undefined || messageBudget < estimateMessagesTokens([question])) {
+		throw new Error("/btw question does not fit this model's context window; shorten it or run /compact first.");
+	}
+	if (estimateMessagesTokens(messages) <= messageBudget) return messages;
+
+	const reduced = convertToLlm(reduceContextMessages(messages, BUILTIN_CONTEXT_REDUCTION_OPTIONS).messages);
+	const repaired = repairOrphanedToolResults(reduced);
+	const pruned = convertToLlm(pruneOldMessagesToBudget(repaired, messageBudget));
+	const bounded = repairOrphanedToolResults(pruned);
+	if (estimateMessagesTokens(bounded) > messageBudget) {
+		throw new Error("/btw context is too large for this model; run /compact first.");
+	}
+	return bounded;
+}
+
+export function getSideQueryPromptContextWindow(model: Pick<Model<string>, "contextWindow" | "maxTokens">): number {
+	const { contextWindow, maxTokens } = model;
+	if (typeof maxTokens !== "number" || !Number.isFinite(maxTokens) || maxTokens <= 0 || contextWindow <= 0) {
+		return contextWindow;
+	}
+	const outputReserve = Math.min(maxTokens, Math.floor(contextWindow * MAX_OUTPUT_RESERVE_RATIO));
+	return contextWindow - outputReserve;
 }
 
 export function buildSideQueryContext(input: SideQueryContextInput): Context {
+	const systemPrompt = `${input.systemPrompt}\n\n${SIDE_QUERY_INSTRUCTION}`;
+	const messages = boundSideQueryMessages(
+		[...input.history, { role: "user", content: input.question, timestamp: Date.now() }],
+		systemPrompt,
+		input.promptContextWindow,
+	);
 	return {
-		systemPrompt: `${input.systemPrompt}\n\n${SIDE_QUERY_INSTRUCTION}`,
-		messages: [...input.history, { role: "user", content: input.question, timestamp: Date.now() }],
+		systemPrompt,
+		messages,
 		tools: [],
 	};
 }

--- a/packages/coding-agent/src/core/extensions/builtin/btw/side-query.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/btw/side-query.ts
@@ -10,6 +10,7 @@ import { streamSimple } from "@earendil-works/pi-ai/compat";
 import { estimateTokens } from "../../../compaction/index.ts";
 import { convertToLlm } from "../../../messages.ts";
 import { BUILTIN_CONTEXT_REDUCTION_OPTIONS, reduceContextMessages } from "../compaction/context-reduction.ts";
+import { getPromptContextWindow } from "../compaction/index.ts";
 import { pruneOldMessagesToBudget } from "../compaction/overflow-retry.ts";
 import { repairOrphanedToolResults } from "../compaction/repair-tool-pairs.ts";
 
@@ -20,7 +21,6 @@ export const SIDE_QUERY_INSTRUCTION = [
 ].join(" ");
 
 export const DEFAULT_ESTABLISHMENT_TIMEOUT_MS = 30_000;
-const MAX_OUTPUT_RESERVE_RATIO = 0.5;
 
 export interface SideQueryContextInput {
 	systemPrompt: string;
@@ -64,12 +64,7 @@ function boundSideQueryMessages(
 }
 
 export function getSideQueryPromptContextWindow(model: Pick<Model<string>, "contextWindow" | "maxTokens">): number {
-	const { contextWindow, maxTokens } = model;
-	if (typeof maxTokens !== "number" || !Number.isFinite(maxTokens) || maxTokens <= 0 || contextWindow <= 0) {
-		return contextWindow;
-	}
-	const outputReserve = Math.min(maxTokens, Math.floor(contextWindow * MAX_OUTPUT_RESERVE_RATIO));
-	return contextWindow - outputReserve;
+	return getPromptContextWindow(model.contextWindow, model.maxTokens);
 }
 
 export function buildSideQueryContext(input: SideQueryContextInput): Context {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -91,7 +91,7 @@ function estimatePendingPromptTokens(event: { prompt?: string; images?: readonly
 	return approxTokens(event.prompt ?? "") + (event.images?.length ?? 0) * IMAGE_PROMPT_TOKEN_ESTIMATE;
 }
 
-function getPromptContextWindow(contextWindow: number, maxTokens: number | undefined): number {
+export function getPromptContextWindow(contextWindow: number, maxTokens: number | undefined): number {
 	if (typeof maxTokens !== "number" || !Number.isFinite(maxTokens) || maxTokens <= 0 || contextWindow <= 0) {
 		return contextWindow;
 	}

--- a/packages/coding-agent/test/suite/btw-side-query.test.ts
+++ b/packages/coding-agent/test/suite/btw-side-query.test.ts
@@ -1,7 +1,7 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it } from "vitest";
-import { estimateContextTokens } from "../../src/core/compaction/index.ts";
+import { estimateTokens } from "../../src/core/compaction/index.ts";
 import btwExtension from "../../src/core/extensions/builtin/btw/index.ts";
 import {
 	buildSideQueryContext,
@@ -10,6 +10,16 @@ import {
 	SIDE_QUERY_INSTRUCTION,
 } from "../../src/core/extensions/builtin/btw/side-query.ts";
 import { createHarness, getMessageText, type Harness } from "./harness.ts";
+
+function estimatePromptTokens(context: {
+	systemPrompt?: string;
+	messages: Parameters<typeof estimateTokens>[0][];
+}): number {
+	return (
+		estimateTokens({ role: "user", content: context.systemPrompt ?? "", timestamp: 0 }) +
+		context.messages.reduce((total, message) => total + estimateTokens(message), 0)
+	);
+}
 
 describe("buildSideQueryContext", () => {
 	it("appends the side instruction to the system prompt and the question as the final user message", () => {
@@ -41,9 +51,9 @@ describe("buildSideQueryContext", () => {
 			systemPrompt: "BASE",
 			history: [
 				{ role: "user" as const, content: oldestMarker, timestamp: 1 },
-				{ role: "assistant" as const, content: "old answer", timestamp: 2 },
+				fauxAssistantMessage("old answer", { timestamp: 2 }),
 				{ role: "user" as const, content: newestMarker, timestamp: 3 },
-				{ role: "assistant" as const, content: "new answer", timestamp: 4 },
+				fauxAssistantMessage("new answer", { timestamp: 4 }),
 			],
 			question: "what is newest?",
 			promptContextWindow,
@@ -51,10 +61,7 @@ describe("buildSideQueryContext", () => {
 
 		const context = buildSideQueryContext(input);
 
-		const promptTokens =
-			estimateContextTokens(context.messages).tokens +
-			estimateContextTokens([{ role: "user", content: context.systemPrompt, timestamp: 0 }]).tokens;
-		expect(promptTokens).toBeLessThanOrEqual(promptContextWindow);
+		expect(estimatePromptTokens(context)).toBeLessThanOrEqual(promptContextWindow);
 		expect(context.messages.some((message) => getMessageText(message) === oldestMarker)).toBe(false);
 		expect(context.messages.some((message) => getMessageText(message) === newestMarker)).toBe(true);
 		expect(getMessageText(context.messages.at(-1))).toBe("what is newest?");
@@ -74,11 +81,11 @@ describe("buildSideQueryContext", () => {
 					provider: "faux",
 					model: "faux-1",
 					usage: {
-						input: 0,
+						input: 125,
 						output: 0,
 						cacheRead: 0,
 						cacheWrite: 0,
-						totalTokens: 0,
+						totalTokens: 125,
 						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 					},
 					stopReason: "toolUse",
@@ -101,10 +108,7 @@ describe("buildSideQueryContext", () => {
 		expect(context.systemPrompt).toContain("BASE-");
 		expect(context.systemPrompt).toContain(SIDE_QUERY_INSTRUCTION);
 		expect(getMessageText(context.messages.at(-1))).toBe(question);
-		const promptTokens =
-			estimateContextTokens(context.messages).tokens +
-			estimateContextTokens([{ role: "user", content: context.systemPrompt, timestamp: 0 }]).tokens;
-		expect(promptTokens).toBeLessThanOrEqual(promptContextWindow);
+		expect(estimatePromptTokens(context)).toBeLessThanOrEqual(promptContextWindow);
 		const toolCallIds = new Set(
 			context.messages.flatMap((message) =>
 				message.role === "assistant"

--- a/packages/coding-agent/test/suite/btw-side-query.test.ts
+++ b/packages/coding-agent/test/suite/btw-side-query.test.ts
@@ -123,6 +123,19 @@ describe("buildSideQueryContext", () => {
 		).toBe(true);
 	});
 
+	it("counts a large system prompt against the side-query budget", () => {
+		const promptContextWindow = 14_000;
+		const context = buildSideQueryContext({
+			systemPrompt: `BASE-${"s".repeat(10_000)}`,
+			history: [{ role: "user", content: `old-${"o".repeat(6_000)}`, timestamp: 1 }],
+			question: "keep the newest question",
+			promptContextWindow,
+		});
+
+		expect(estimatePromptTokens(context)).toBeLessThanOrEqual(promptContextWindow);
+		expect(getMessageText(context.messages.at(-1))).toBe("keep the newest question");
+	});
+
 	it("reserves at most half the context window for side-query output", () => {
 		expect(getSideQueryPromptContextWindow({ contextWindow: 2_000, maxTokens: 256 })).toBe(1_744);
 		expect(getSideQueryPromptContextWindow({ contextWindow: 2_000, maxTokens: 4_000 })).toBe(1_000);

--- a/packages/coding-agent/test/suite/btw-side-query.test.ts
+++ b/packages/coding-agent/test/suite/btw-side-query.test.ts
@@ -1,9 +1,11 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it } from "vitest";
+import { estimateContextTokens } from "../../src/core/compaction/index.ts";
 import btwExtension from "../../src/core/extensions/builtin/btw/index.ts";
 import {
 	buildSideQueryContext,
+	getSideQueryPromptContextWindow,
 	runSideQuery,
 	SIDE_QUERY_INSTRUCTION,
 } from "../../src/core/extensions/builtin/btw/side-query.ts";
@@ -29,6 +31,98 @@ describe("buildSideQueryContext", () => {
 		const mutable = [...history];
 		buildSideQueryContext({ systemPrompt: "BASE", history: mutable, question: "q" });
 		expect(mutable).toHaveLength(1);
+	});
+
+	it("bounds an oversized snapshot to the selected model prompt window", () => {
+		const promptContextWindow = 4_500;
+		const oldestMarker = `oldest-${"a".repeat(4_000)}`;
+		const newestMarker = `newest-${"b".repeat(4_000)}`;
+		const input = {
+			systemPrompt: "BASE",
+			history: [
+				{ role: "user" as const, content: oldestMarker, timestamp: 1 },
+				{ role: "assistant" as const, content: "old answer", timestamp: 2 },
+				{ role: "user" as const, content: newestMarker, timestamp: 3 },
+				{ role: "assistant" as const, content: "new answer", timestamp: 4 },
+			],
+			question: "what is newest?",
+			promptContextWindow,
+		};
+
+		const context = buildSideQueryContext(input);
+
+		const promptTokens =
+			estimateContextTokens(context.messages).tokens +
+			estimateContextTokens([{ role: "user", content: context.systemPrompt, timestamp: 0 }]).tokens;
+		expect(promptTokens).toBeLessThanOrEqual(promptContextWindow);
+		expect(context.messages.some((message) => getMessageText(message) === oldestMarker)).toBe(false);
+		expect(context.messages.some((message) => getMessageText(message) === newestMarker)).toBe(true);
+		expect(getMessageText(context.messages.at(-1))).toBe("what is newest?");
+	});
+
+	it("keeps mandatory prompt content and valid tool pairs at the budget boundary", () => {
+		const promptContextWindow = 900;
+		const question = "keep this exact question";
+		const context = buildSideQueryContext({
+			systemPrompt: `BASE-${"s".repeat(800)}`,
+			history: [
+				{ role: "user", content: `old-${"o".repeat(2_000)}`, timestamp: 1 },
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "call-1", name: "read", arguments: { path: "notes.md" } }],
+					api: "faux",
+					provider: "faux",
+					model: "faux-1",
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "toolUse",
+					timestamp: 2,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call-1",
+					toolName: "read",
+					content: [{ type: "text", text: `result-${"r".repeat(2_000)}` }],
+					isError: false,
+					timestamp: 3,
+				},
+				{ role: "user", content: "newest context", timestamp: 4 },
+			],
+			question,
+			promptContextWindow,
+		});
+
+		expect(context.systemPrompt).toContain("BASE-");
+		expect(context.systemPrompt).toContain(SIDE_QUERY_INSTRUCTION);
+		expect(getMessageText(context.messages.at(-1))).toBe(question);
+		const promptTokens =
+			estimateContextTokens(context.messages).tokens +
+			estimateContextTokens([{ role: "user", content: context.systemPrompt, timestamp: 0 }]).tokens;
+		expect(promptTokens).toBeLessThanOrEqual(promptContextWindow);
+		const toolCallIds = new Set(
+			context.messages.flatMap((message) =>
+				message.role === "assistant"
+					? message.content.filter((part) => part.type === "toolCall").map((part) => part.id)
+					: [],
+			),
+		);
+		expect(
+			context.messages
+				.filter((message) => message.role === "toolResult")
+				.every((message) => toolCallIds.has(message.toolCallId)),
+		).toBe(true);
+	});
+
+	it("reserves at most half the context window for side-query output", () => {
+		expect(getSideQueryPromptContextWindow({ contextWindow: 2_000, maxTokens: 256 })).toBe(1_744);
+		expect(getSideQueryPromptContextWindow({ contextWindow: 2_000, maxTokens: 4_000 })).toBe(1_000);
+		expect(getSideQueryPromptContextWindow({ contextWindow: 2_000, maxTokens: 0 })).toBe(2_000);
 	});
 });
 


### PR DESCRIPTION
## Summary

- budget `/btw` side-query prompts against the selected model's effective prompt window
- reuse Senpi's deterministic reducer, structural tool-pair repair, and oldest-first pruning
- preserve the newest usable context and final question while leaving main-session history untouched
- fail locally with an actionable `/compact` message when mandatory prompt content cannot fit

## Root cause

`/btw` captured and converted the current branch, then called the provider runtime directly without passing through the main-turn context pipeline. A large session could therefore send a raw side-query snapshot larger than the selected model accepted, even while the main turn's reduced context remained healthy.

The reported screenshot reproduced the user-visible symptom:

```text
/btw 이거 draft PR은 이미 만들어져있는건가?
Codex error: Your input exceeds the context window of this model.
```

## Design

- Derive the side-query prompt window from the shared compaction `getPromptContextWindow()` policy.
- Include system prompt, BTW instruction, history, and the final question in token accounting.
- Preserve small snapshots unchanged.
- For oversized snapshots: deterministic reduction -> tool-pair repair -> oldest-first pruning -> final repair and budget re-check.
- Keep dynamic `modelRuntime.streamSimple`, credential/header routing, no-tools mode, cancellation, synchronous snapshotting, and ephemeral history behavior unchanged.

The refreshed `gajae-code` implementation corroborates newest-first retention and oldest-context removal, but uses fixed 12-turn/64 KiB bounds. This PR intentionally uses Senpi's model-aware token machinery instead of copying those fixed limits.

## RED -> GREEN evidence

- Overflow RED: `red-overflow.log` — pre-fix context estimated 8,018 tokens against a 1,744-token budget.
- Boundary RED: `red-boundary.log` — pre-fix context estimated 4,027 tokens against a 900-token budget.
- Exact-metric mutation RED after review: disabling the budget guard failed both tests at 8,083 > 4,500 and 4,890 > 900.
- System-prompt mutation RED: omitting system-prompt subtraction failed at 16,073 > 14,000.
- Focused GREEN: `btw-side-query.test.ts` plus regression #488, 16/16 passing.

Evidence is preserved under:

```text
local-ignore/qa-evidence/20260812-btw-context-budget/
local-ignore/qa-evidence/20260812-btw-rpc-baseline/
```

## Real CLI QA

Source-built Senpi RPC mode ran against an isolated local fake provider with a persisted oversized session.

Observed:

- `/btw 이거 draft PR은 이미 만들어져있는건가?` returned an `info` notification
- one side provider request
- newest large context preserved
- oldest overflow context removed
- empty `/btw` returned `Usage: /btw <question>` with no extra provider request
- main history remained at four messages
- fake server, RPC process, and sandbox were removed

Independent hands-on review also exercised a 1.08 MB / 49-entry real session: the unbounded request was approximately 293,511 tokens against a 56,000-token prompt window; the bounded request was 50,038 tokens and completed successfully.

## Validation

- `npm run check`
- `npm run build`
- root `npx tsc --noEmit`
- focused BTW tests: 16/16
- changelog gate against `origin/main`
- Senpi QA helper self-tests: RPC, mock-loop, TUI, CLI
- real seeded-session RPC BTW scenario

The full coding-agent suite completed with 7,228 passed / 35 skipped and four load-sensitive failures outside this diff. Each failed test passed on isolated rerun:

- footer reftable debounce: 1/1
- MCP connection races: 2/2
- app-server goal cleanup: 1/1

## Known conflict: PR #746

Open PR #746 changes the same BTW context builder to add prior BTW continuity. The features are complementary, not duplicates.

When resolving the landing order, `priorBtw` messages from #746 must be included in the message list *before* the final question and then flow through `boundSideQueryMessages()`. Taking either PR's `buildSideQueryContext()` body wholesale would silently drop the other feature or reintroduce unbounded BTW growth.

## Reviewer results

- goal/constraint review: approved after type/test blocker fixes
- code-quality review: approved after exact-metric assertions and shared prompt-window policy
- security review: pass
- independent hands-on QA: pass
- repository/GitHub context review: changelog placement fixed; PR-number citation will be corrected to this PR number immediately after creation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `/btw` side-query prompts to the selected model’s effective prompt window to prevent context-window overflows on large sessions. Preserves newest relevant context and the final question while leaving the main session history unchanged.

- **Bug Fixes**
  - Budgets system prompt, BTW instruction, history, and question against the model’s prompt window with output reserve via `getPromptContextWindow`.
  - For oversized snapshots: deterministic reduction → tool-pair repair → oldest-first pruning → final repair.
  - Fails locally with an actionable `/compact` message when mandatory content cannot fit.
  - Keeps provider dispatch, no-tools mode, cancellation, and ephemeral history behavior unchanged.

<sup>Written for commit 86b719dafc0db429ad7d53ad7638397fec885314. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

