### PR TITLE
fix(coding-agent): pin callable signal-exit dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7904,6 +7904,7 @@
 				"proper-lockfile": "4.1.2",
 				"proxy-from-env": "2.1.0",
 				"semver": "7.8.5",
+				"signal-exit": "3.0.7",
 				"turndown": "7.2.4",
 				"typebox": "1.3.8",
 				"undici": "8.9.0",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,11 @@
   ([#828](https://github.com/code-yeongyu/senpi/pull/828),
   oh-my-openagent#6784).
 
+- Bun global installs no longer let a sibling `signal-exit@4` shadow the
+  callable `signal-exit@3` required by `proper-lockfile`, preventing
+  `TypeError: onExit is not a function` during Senpi and `omo` startup
+  ([#829](https://github.com/code-yeongyu/senpi/pull/829)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/install-lock/package-lock.json
+++ b/packages/coding-agent/install-lock/package-lock.json
@@ -588,6 +588,7 @@
 				"proper-lockfile": "4.1.2",
 				"proxy-from-env": "2.1.0",
 				"semver": "7.8.5",
+				"signal-exit": "3.0.7",
 				"turndown": "7.2.4",
 				"typebox": "1.3.8",
 				"undici": "8.9.0",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -81,6 +81,7 @@
 		"proper-lockfile": "4.1.2",
 		"proxy-from-env": "2.1.0",
 		"semver": "7.8.5",
+		"signal-exit": "3.0.7",
 		"turndown": "7.2.4",
 		"typebox": "1.3.8",
 		"undici": "8.9.0",

--- a/packages/coding-agent/publish-deps.lock.json
+++ b/packages/coding-agent/publish-deps.lock.json
@@ -45,6 +45,7 @@
 				"proper-lockfile": "4.1.2",
 				"proxy-from-env": "2.1.0",
 				"semver": "7.8.5",
+				"signal-exit": "3.0.7",
 				"turndown": "7.2.4",
 				"typebox": "1.3.8",
 				"undici": "8.9.0",

--- a/scripts/signal-exit-dependency.test.mjs
+++ b/scripts/signal-exit-dependency.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const root = join(import.meta.dirname, "..");
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("coding-agent signal-exit dependency", () => {
+	it("pins the callable major required by proper-lockfile", () => {
+		const manifest = readJson(join(root, "packages", "coding-agent", "package.json"));
+		const installLock = readJson(join(root, "package-lock.json"));
+		const isolatedInstallLock = readJson(
+			join(root, "packages", "coding-agent", "install-lock", "package-lock.json"),
+		);
+		const publishLock = readJson(join(root, "packages", "coding-agent", "publish-deps.lock.json"));
+
+		assert.equal(manifest.dependencies["proper-lockfile"], "4.1.2");
+		assert.equal(manifest.dependencies["signal-exit"], "3.0.7");
+		assert.equal(installLock.packages["packages/coding-agent"].dependencies["signal-exit"], "3.0.7");
+		assert.equal(
+			isolatedInstallLock.packages["node_modules/@code-yeongyu/senpi"].dependencies["signal-exit"],
+			"3.0.7",
+		);
+		assert.equal(isolatedInstallLock.packages["node_modules/signal-exit"].version, "3.0.7");
+		assert.equal(publishLock.packages[""].dependencies["signal-exit"], "3.0.7");
+		assert.equal(publishLock.packages["node_modules/signal-exit"].version, "3.0.7");
+	});
+});


### PR DESCRIPTION
## Summary

- pin `signal-exit@3.0.7` as a direct Senpi runtime dependency
- keep the root, isolated installer, and publish dependency locks aligned
- add a regression test covering all four dependency surfaces

## Why

`proper-lockfile@4.1.2` consumes `signal-exit` as a callable CommonJS export. In Bun's shared global `node_modules`, a sibling global package can place `signal-exit@4` at `@code-yeongyu/senpi/node_modules/signal-exit`, shadowing the callable v3 that `proper-lockfile` requires. `omo` then crashes on startup with `TypeError: onExit is not a function`.

The exact direct dependency makes the required major part of Senpi's package contract and preserves the callable v3 at Senpi's resolution level.

## Verification

- RED: `node --test scripts/signal-exit-dependency.test.mjs` failed before the dependency pin
- GREEN: the same test passes across package manifest, root lock, isolated install lock, and publish lock
- `npm run check`
- `npm run test:scripts`
- focused auth-storage suite: 14 passed
- full `CI=1 npm test`: script tests 112 passed; coding-agent 1872 passed with existing skips; all other workspace suites green
- local release build, pack, npm install, and Bun install completed
- packed Bun install loaded `proper-lockfile` and reached normal `senpi auth` usage before and after adding sibling `signal-exit@4.0.2`

## Risk

Low. The runtime code is unchanged; this only makes the transitive compatibility requirement explicit and regenerates machine-consumed lock surfaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `signal-exit@3.0.7` as a direct runtime dependency of `packages/coding-agent` to keep the callable CJS export required by `proper-lockfile@4.1.2` and prevent Bun startup crashes when `signal-exit@4` is resolved. Adds a regression test to enforce v3 across the manifest and all lockfiles.

- **Bug Fixes**
  - Pin `signal-exit@3.0.7` and align root, installer, and publish lockfiles to avoid Bun global shadowing and the “onExit is not a function” crash.
  - Add `scripts/signal-exit-dependency.test.mjs` to assert `signal-exit` v3 and `proper-lockfile@4.1.2` are consistently used.

<sup>Written for commit 8239d794cc802b8238c9b14678a27e4a098cdfad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

