### PR TITLE
Preserve unresolvable favorite model patterns on persist

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixed
 
+- Favorite models are no longer erased from settings when a favorite's provider is
+  momentarily unauthenticated or unreachable. Both selectors list only models that
+  resolve against the current availability snapshot, and persisting that view
+  overwrote the stored patterns, permanently dropping every favorite that did not
+  resolve at that moment (and removing the `favoriteModels` key entirely when nothing
+  resolved). Stored patterns that resolve to no model are now preserved on persist.
+  ([#833](https://github.com/code-yeongyu/senpi/pull/833))
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,35 @@
 # changes
 
+## Favorite patterns survive a persist while providers are unavailable (2026-08-12)
+
+### What changed
+
+- `mergeFavoritePatternsForPersist()` in `components/model-favorites.ts` merges the
+  selector's visible selection with stored favorite patterns that currently resolve to
+  no model. `interactive-mode.ts` persists through it from both the model selector's
+  `onFavoriteChange` and the favorites selector's `onPersist`.
+- The persisted list keeps unresolvable patterns in their stored order and appends the
+  user's selection without duplicating entries. `undefined` is still written only when
+  the merged result is genuinely empty.
+
+### Why
+
+- Both selectors derive their favorite ids from `session.favoriteModels`, which is
+  `resolveModelScope()` filtered against the current availability snapshot. Persisting
+  that view verbatim erased every stored favorite whose provider was momentarily
+  unauthenticated or unreachable, and an empty result removed the `favoriteModels` key
+  from `settings.json` entirely.
+
+### Why this cannot be expressed externally
+
+- Interactive mode owns the selector callbacks and the settings write, so no extension
+  hook can intervene between the filtered view and the persist.
+
+### Expected merge conflict zones
+
+- LOW: `components/model-favorites.ts` around the merge helper and `interactive-mode.ts`
+  around the two selector persist callbacks.
+
 ## External-editor launch failures remain distinct (2026-08-12)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/model-favorites.ts
+++ b/packages/coding-agent/src/modes/interactive/components/model-favorites.ts
@@ -56,6 +56,22 @@ export function moveFavoriteModel(favoriteIds: FavoriteModelIds, id: string, del
 	return result;
 }
 
+export function mergeFavoritePatternsForPersist(options: {
+	storedPatterns: readonly string[];
+	unresolvedPatterns: readonly string[];
+	selectedIds: FavoriteModelIds;
+	candidateIds: readonly string[];
+}): string[] | undefined {
+	const { storedPatterns, unresolvedPatterns, selectedIds, candidateIds } = options;
+	const unresolved = new Set(unresolvedPatterns);
+	const merged = storedPatterns.filter((pattern) => unresolved.has(pattern));
+	const selected = selectedIds === null ? candidateIds : selectedIds;
+	for (const id of selected) {
+		if (!merged.includes(id)) merged.push(id);
+	}
+	return merged.length > 0 ? merged : undefined;
+}
+
 export function getSortedFavoriteModelIds(favoriteIds: FavoriteModelIds, allIds: string[]): string[] {
 	if (favoriteIds === null) return allIds;
 	const favoriteSet = new Set(favoriteIds);

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -96,6 +96,7 @@ import {
 	defaultModelPerProvider,
 	findExactModelReferenceMatch,
 	resolveModelScope,
+	resolveModelScopeWithDiagnostics,
 	type ScopedModel,
 } from "../../core/model-resolver.ts";
 import type { ResourceDiagnostic } from "../../core/resource-loader.ts";
@@ -150,7 +151,11 @@ import { FavoriteModelsSelectorComponent } from "./components/favorite-models-se
 import { FooterComponent, formatTokens } from "./components/footer.ts";
 import { formatKeyText, keyDisplayText, keyHint, keyText, rawKeyHint } from "./components/keybinding-hints.ts";
 import { LoginDialogComponent } from "./components/login-dialog.ts";
-import { type FavoriteModelIds, getModelFullId } from "./components/model-favorites.ts";
+import {
+	type FavoriteModelIds,
+	getModelFullId,
+	mergeFavoritePatternsForPersist,
+} from "./components/model-favorites.ts";
 import { ModelSelectorComponent } from "./components/model-selector.ts";
 import {
 	type AuthSelectorProvider,
@@ -5654,6 +5659,25 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
+	private async persistFavoritePatterns(
+		favoriteIds: FavoriteModelIds,
+		candidateModels: readonly Model<any>[],
+	): Promise<void> {
+		const storedPatterns = this.settingsManager.getFavoriteModels() ?? [];
+		const { diagnostics } = await resolveModelScopeWithDiagnostics(storedPatterns, this.session.modelRuntime);
+		const unresolvedPatterns = diagnostics
+			.filter((diagnostic) => diagnostic.code === "no-match")
+			.map((diagnostic) => diagnostic.pattern);
+		this.settingsManager.setFavoriteModels(
+			mergeFavoritePatternsForPersist({
+				storedPatterns,
+				unresolvedPatterns,
+				selectedIds: favoriteIds,
+				candidateIds: candidateModels.map(getModelFullId),
+			}),
+		);
+	}
+
 	/** Update the footer's available provider count from the current snapshot without refreshing catalogs. */
 	private updateAvailableProviderCount(): void {
 		const models =
@@ -5766,8 +5790,7 @@ export class InteractiveMode {
 					favoriteModelIds,
 					onFavoriteChange: async (favoriteIds, allModels) => {
 						await this.updateSessionFavoritesFromIds(favoriteIds, allModels);
-						const newPatterns = favoriteIds === null ? allModels.map(getModelFullId) : favoriteIds;
-						this.settingsManager.setFavoriteModels(newPatterns.length > 0 ? [...newPatterns] : undefined);
+						await this.persistFavoritePatterns(favoriteIds, allModels);
 					},
 				},
 			);
@@ -5797,9 +5820,9 @@ export class InteractiveMode {
 						await this.updateSessionFavoritesFromIds(favoriteIds, allModels);
 					},
 					onPersist: (favoriteIds) => {
-						const newPatterns = favoriteIds === null ? allModels.map(getModelFullId) : favoriteIds;
-						this.settingsManager.setFavoriteModels(newPatterns.length > 0 ? [...newPatterns] : undefined);
-						this.showStatus("Favorite models saved to settings");
+						void this.persistFavoritePatterns(favoriteIds, allModels).then(() => {
+							this.showStatus("Favorite models saved to settings");
+						});
 					},
 					onSelect: (model) => {
 						void this.selectModelFromUi(model, done);

--- a/packages/coding-agent/test/favorite-models-preserve-unresolvable.test.ts
+++ b/packages/coding-agent/test/favorite-models-preserve-unresolvable.test.ts
@@ -1,0 +1,101 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { describe, expect, test } from "vitest";
+import { resolveModelScopeWithDiagnostics } from "../src/core/model-resolver.ts";
+import { mergeFavoritePatternsForPersist } from "../src/modes/interactive/components/model-favorites.ts";
+
+const availableModel: Model<"anthropic-messages"> = {
+	id: "claude-fable-5",
+	name: "Fable 5",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+	contextWindow: 200000,
+	maxTokens: 8192,
+};
+
+const availabilitySnapshot = { getAvailable: async () => [availableModel] };
+const candidateIds = ["anthropic/claude-fable-5"];
+
+async function unresolvedPatternsFor(storedPatterns: string[]): Promise<string[]> {
+	const { diagnostics } = await resolveModelScopeWithDiagnostics(storedPatterns, availabilitySnapshot);
+	return diagnostics.filter((diagnostic) => diagnostic.code === "no-match").map((diagnostic) => diagnostic.pattern);
+}
+
+describe("mergeFavoritePatternsForPersist", () => {
+	describe("stored favorites whose providers are momentarily unavailable", () => {
+		test("preserves unresolvable patterns when the selector persists its resolvable view", async () => {
+			const storedPatterns = [
+				"atlascloud/moonshotai/kimi-k3",
+				"anthropic/claude-fable-5",
+				"apitopia/deepseek-v4-flash",
+			];
+			const unresolvedPatterns = await unresolvedPatternsFor(storedPatterns);
+
+			expect(unresolvedPatterns).toContain("atlascloud/moonshotai/kimi-k3");
+			expect(unresolvedPatterns).toContain("apitopia/deepseek-v4-flash");
+
+			const next = mergeFavoritePatternsForPersist({
+				storedPatterns,
+				unresolvedPatterns,
+				selectedIds: ["anthropic/claude-fable-5"],
+				candidateIds,
+			});
+
+			expect(next).toContain("atlascloud/moonshotai/kimi-k3");
+			expect(next).toContain("apitopia/deepseek-v4-flash");
+			expect(next).toContain("anthropic/claude-fable-5");
+		});
+
+		test("does not wipe settings when the visible selection is emptied", async () => {
+			const storedPatterns = ["atlascloud/moonshotai/kimi-k3", "apitopia/deepseek-v4-flash"];
+			const unresolvedPatterns = await unresolvedPatternsFor(storedPatterns);
+
+			const next = mergeFavoritePatternsForPersist({
+				storedPatterns,
+				unresolvedPatterns,
+				selectedIds: [],
+				candidateIds,
+			});
+
+			expect(next).toEqual(storedPatterns);
+		});
+
+		test("preserves unresolvable patterns when every candidate is favorited", () => {
+			const next = mergeFavoritePatternsForPersist({
+				storedPatterns: ["atlascloud/moonshotai/kimi-k3", "anthropic/claude-fable-5"],
+				unresolvedPatterns: ["atlascloud/moonshotai/kimi-k3"],
+				selectedIds: null,
+				candidateIds,
+			});
+
+			expect(next).toEqual(["atlascloud/moonshotai/kimi-k3", "anthropic/claude-fable-5"]);
+		});
+
+		test("keeps a selected pattern that is already stored from being duplicated", () => {
+			const next = mergeFavoritePatternsForPersist({
+				storedPatterns: ["atlascloud/moonshotai/kimi-k3", "anthropic/claude-fable-5"],
+				unresolvedPatterns: ["atlascloud/moonshotai/kimi-k3"],
+				selectedIds: ["anthropic/claude-fable-5"],
+				candidateIds,
+			});
+
+			expect(next).toEqual(["atlascloud/moonshotai/kimi-k3", "anthropic/claude-fable-5"]);
+		});
+	});
+
+	describe("a genuine user clear", () => {
+		test("returns undefined when nothing is stored beyond the cleared selection", () => {
+			const next = mergeFavoritePatternsForPersist({
+				storedPatterns: ["anthropic/claude-fable-5"],
+				unresolvedPatterns: [],
+				selectedIds: [],
+				candidateIds,
+			});
+
+			expect(next).toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
## What

Stored favorite-model patterns are no longer erased when a favorite's provider is momentarily unauthenticated or unreachable.

## Why

Both selectors derive their favorite ids from `session.favoriteModels`, which is `resolveModelScope()` filtered against the *current* availability snapshot:

- `interactive-mode.ts` `showModelSelector` -> `favoriteModelIds` comes from `this.session.favoriteModels`
- `showFavoriteModelsSelector` -> `getFavoriteModelIdsForUi()` filters resolved favorites to visible candidates

Persisting that view verbatim (`setFavoriteModels(newPatterns.length > 0 ? [...newPatterns] : undefined)`) overwrote the stored patterns, so every favorite whose provider did not resolve at that moment was permanently dropped. When nothing resolved, `undefined` removed the `favoriteModels` key from `settings.json` entirely.

Observed in the wild: a settings file went from 9 favorites to none across a session while several providers were temporarily unavailable.

## How

- New pure helper `mergeFavoritePatternsForPersist()` in `components/model-favorites.ts` merges the selector's selection with stored patterns that `resolveModelScopeWithDiagnostics()` reports as `no-match`.
- `interactive-mode.ts` gains `persistFavoritePatterns()` and both persist sites (`onFavoriteChange`, `onPersist`) route through it.
- Unresolvable patterns keep their stored order and the user's selection is appended without duplicates. `undefined` is still written only when the merged result is genuinely empty, so a real "clear all" still clears.

## QA evidence

- RED first: new test failed 5/5 with `mergeFavoritePatternsForPersist is not a function`.
- GREEN: `npx vitest --run test/favorite-models-preserve-unresolvable.test.ts` -> 5 passed.
- Regressions: `favorite-model-selection`, `favorite-models-frozen-order`, `model-selector-favorites-search`, `model-config-controls` -> 24 passed.
- `npx tsc --noEmit` clean; `npx biome check` clean over `src/modes/interactive/`.

The new test drives the real `resolveModelScopeWithDiagnostics()` against an availability snapshot that exposes only one model, so it reproduces the exact production condition (provider present in settings, absent from the snapshot).

## Notes

CHANGELOG `[Unreleased] > Fixed` and `src/modes/interactive/changes.md` updated per repo convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents favorite models from being wiped from settings when a provider is temporarily unauthenticated or unreachable. Unresolvable favorite patterns are now preserved during persist.

- **Bug Fixes**
  - Added mergeFavoritePatternsForPersist to merge the current selection with stored patterns that resolve to no model (via resolveModelScopeWithDiagnostics).
  - Both persist paths now use persistFavoritePatterns in interactive-mode to keep unresolvable patterns in order and avoid duplicates.
  - Only writes undefined when the merged result is truly empty, so a real clear-all still clears while temporary outages don’t erase favorites.

<sup>Written for commit 0033d0db96c779d761b11b6f544eade2f1a71e9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

