### PR TITLE
fix(pty): serialize xterm screen writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Persistent terminals now serialize headless xterm screen writes through parser callbacks,
+  preventing fast PTY output from exceeding xterm's pending-write watermark and terminating
+  Senpi with `write data discarded, use flow control to avoid losing data` ([#837](https://github.com/code-yeongyu/senpi/pull/837)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/pty/src/screen.ts
+++ b/packages/pty/src/screen.ts
@@ -31,6 +31,7 @@ export class TerminalScreen {
 	private terminal: XtermTerminalType;
 	private readonly history: string[] = [];
 	private historyLength = 0;
+	private writeQueue: Promise<void> = Promise.resolve();
 	private readonly maxReplayHistoryLength: number;
 	private readonly scrollback: number;
 
@@ -46,19 +47,22 @@ export class TerminalScreen {
 		const payload = decodeInput(data);
 		const sanitizedPayload = sanitizeString(payload);
 		if (sanitizedPayload.length > 0) this.appendHistory(sanitizedPayload);
-		return this.write(payload);
+		return this.enqueueWrite(payload);
 	}
 
 	resize(cols: number, rows: number): Promise<void> {
 		const nextCols = normalizeDimension(cols, this.terminal.cols);
 		const nextRows = normalizeDimension(rows, this.terminal.rows);
-		this.terminal.dispose();
-		this.terminal = this.createTerminal(nextCols, nextRows);
-		return this.write(this.history.join(""));
+		const replay = this.history.join("");
+		return this.enqueue(async () => {
+			this.terminal.dispose();
+			this.terminal = this.createTerminal(nextCols, nextRows);
+			await this.write(replay);
+		});
 	}
 
 	flush(): Promise<void> {
-		return this.write("");
+		return this.enqueueWrite("");
 	}
 
 	snapshot(): TerminalScreenSnapshot {
@@ -100,6 +104,19 @@ export class TerminalScreen {
 			allowProposedApi: true,
 			logLevel: "off",
 		});
+	}
+
+	private enqueueWrite(payload: string): Promise<void> {
+		return this.enqueue(() => this.write(payload));
+	}
+
+	private enqueue(operation: () => Promise<void>): Promise<void> {
+		const result = this.writeQueue.then(operation);
+		this.writeQueue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
 	}
 
 	private write(payload: string): Promise<void> {

--- a/packages/pty/test/screen.test.ts
+++ b/packages/pty/test/screen.test.ts
@@ -92,6 +92,45 @@ describe("TerminalScreen", () => {
 		}
 	});
 
+	it("serializes concurrent feeds through xterm write callbacks", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		let writePending = false;
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			if (writePending) {
+				throw new Error("write data discarded, use flow control to avoid losing data");
+			}
+			writePending = true;
+			originalWrite.call(this, data, () => {
+				writePending = false;
+				callback?.();
+			});
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 2, scrollback: 10 });
+			await Promise.all([screen.feed("first"), screen.feed(" second"), screen.feed(" third")]);
+
+			expect(screen.snapshot().visibleGrid[0]).toBe("first second third");
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
+
+	it("orders resize replay between concurrent feeds", async () => {
+		const screen = new TerminalScreen({ cols: 6, rows: 4, scrollback: 10 });
+
+		await Promise.all([screen.feed("abcdef"), screen.resize(3, 4), screen.feed("ghi")]);
+
+		const snapshot = screen.snapshot();
+		expect(snapshot.cols).toBe(3);
+		expect(snapshot.visibleGrid).toEqual(["abc", "def", "ghi", ""]);
+	});
+
 	it("bounds resize replay history in long sessions", async () => {
 		const originalWrite = xterm.Terminal.prototype.write;
 		const replayLengths: number[] = [];


### PR DESCRIPTION
## Summary
- serialize `TerminalScreen` writes through xterm parse callbacks
- order resize recreation and replay with concurrent feeds
- keep the queue usable after an individual write rejection

## Root cause
`TerminalRuntimeSession` intentionally does not await `screen.feed()`, so fast PTY output could enqueue more than xterm's 50 MB pending-write watermark. xterm then rejected a feed with `write data discarded, use flow control to avoid losing data`; the discarded promise became an uncaught exception and exited Senpi.

## Verification
- regression test fails before the fix with the exact xterm error
- `npm test -- test/screen.test.ts`: 45 passed, 7 skipped
- `npm run check`: passed
- 20,000 concurrent 4 KB feeds: 20,000 fulfilled, 0 rejected
- `.agents/skills/senpi-qa/scripts/pty-drive.mjs --self-test`: 8/8 passed (pipe fallback on Windows)

Related xterm guidance: https://github.com/xtermjs/xtermjs.org/blob/f8670249e22dac222c428654d9fb39a957555f0b/_docs/guides/flowcontrol.md