### PR TITLE
feat(app-server): bridge extension RPC events

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Added
 
+- App-server clients can now receive extension-owned `extension_event` notifications and call loaded-thread
+  `extension_request` handlers, bringing both directions of the opt-in `pi.rpc` channel to app/editor integrations
+  ([#838](https://github.com/code-yeongyu/senpi/pull/838)).
+
 ### Changed
 
 ### Removed

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -289,8 +289,8 @@
   unknown and duplicate handler errors; documented the additive method and notification wire shapes.
 - Why: app-server had no executable contract for the existing extension-owned RPC channel, even though classic RPC did.
 - What changed: `test/suite/app-server-extension-events.test.ts`,
-  `test/suite/app-server-extension-requests.test.ts`, and `docs/app-server.md` now cover the real runtime surface with
-  isolated temporary extension directories and no network or credentials.
+  `test/suite/app-server-extension-requests.test.ts`, `docs/app-server.md`, and the package `CHANGELOG.md` now cover the
+  real runtime surface and release note with isolated temporary extension directories and no network or credentials.
 - Why the extension system could not handle this: tests and public protocol documentation describe the host connection
   boundary; an extension cannot install or verify those repository-level contracts.
 - Merge-conflict risk: low. The focused test files are new; the supported-method and notification sections in

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -283,6 +283,19 @@
 - Merge-conflict risk: low. `scripts/publish.mjs` temporary manifest staging
   and `stagePublishManifest()` alias rewriting are the expected conflict zones.
 
+## 2026-08-12 — app-server extension RPC coverage and documentation
+
+- Changed: added focused app-server suites for extension event audience/one-frame delivery and request round-trips with
+  unknown and duplicate handler errors; documented the additive method and notification wire shapes.
+- Why: app-server had no executable contract for the existing extension-owned RPC channel, even though classic RPC did.
+- What changed: `test/suite/app-server-extension-events.test.ts`,
+  `test/suite/app-server-extension-requests.test.ts`, and `docs/app-server.md` now cover the real runtime surface with
+  isolated temporary extension directories and no network or credentials.
+- Why the extension system could not handle this: tests and public protocol documentation describe the host connection
+  boundary; an extension cannot install or verify those repository-level contracts.
+- Merge-conflict risk: low. The focused test files are new; the supported-method and notification sections in
+  `docs/app-server.md` are the only shared conflict zones.
+
 ## 2026-07-22 — app-server runtime import test without npm subprocess
 
 - Changed: `test/suite/app-server-protocol.test.ts` now executes its runtime `.js` import probe with

--- a/packages/coding-agent/docs/app-server.md
+++ b/packages/coding-agent/docs/app-server.md
@@ -421,6 +421,7 @@ internal-error path; a listed method is not silently treated as unsupported.
 | `permissionProfile/list` | Senpi's actual single `dangerFullAccess`-equivalent profile. |
 | `experimentalFeature/list` | Numeric-cursor paginated Senpi feature catalog, currently allowed to be empty. |
 | `fuzzyFileSearch` | One-shot subsequence file search over requested roots; an empty query returns no results. |
+| `extension_request` | Routes `{threadId,name,data}` to exactly one `pi.rpc.handle(name, handler)` in the loaded thread and returns the handler result. Unknown or duplicate handlers return a typed internal JSON-RPC error. |
 | `thread/start` | Creates, loads, and subscribes the calling connection to a session-backed thread. |
 | `thread/resume` | Loads a saved thread and subscribes the calling connection. |
 | `thread/read` | Reads a thread, optionally including turns. |
@@ -468,7 +469,11 @@ they have no `id` and may arrive before, between, or after correlated responses 
 - Broadcast notifications include thread lifecycle updates, `thread/unarchived`, name changes, global goal updates, and
   fuzzy-search session updates.
 - Thread-scoped notifications go only to subscribers of that thread. This includes turn lifecycle and item events,
-  `thread/settings/updated`, and `turn/diff/updated`.
+  `thread/settings/updated`, `turn/diff/updated`, and extension-owned `extension_event` notifications.
+- Extensions opt into app-server delivery with `pi.rpc.emit(name, data)`. The notification shape is
+  `{method:"extension_event",params:{type:"extension_event",threadId,name,data},emittedAtMs}`. App-server initialize
+  capabilities do not include RPC mode's `extension_events` capability, so initialized thread subscribers receive these
+  records unconditionally. Ordinary `pi.events` channels remain extension-local and are never forwarded.
 - `turn/diff/updated` is Senpi's cumulative aggregation of the projected file-change unified diffs for a turn, in item
   order. It is intentionally not a byte-for-byte substitute for Codex's git-based diff text.
 - `thread/unarchive`, goal mutation, and a successful settings mutation send their response before the corresponding

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -226,6 +226,36 @@
 
 - LOW: `core/extensions/builtin/gpt-apply-patch/apply.ts` and `tool.ts` completed-result construction.
 
+## App-server extension RPC delivery (2026-08-12)
+
+### What changed
+
+- `modes/app-server/runtime.ts` subscribes to each bound session's opt-in extension RPC events before extension binding,
+  preserves binding-time events until the thread is registered, and routes live events only to that thread's subscribers.
+- `modes/app-server/rpc/registry.ts` registers `extension_request` and dispatches `{threadId,name,data}` to the loaded
+  session's `extensionRunner.requestRpc`, preserving its exactly-one-handler semantics as JSON-RPC errors.
+- `modes/app-server/threads/registry.ts` seeds a new thread's notification queue with binding-time extension records so
+  the connection that started, resumed, or forked the thread receives them after subscription.
+
+### Why
+
+- App-server mode binds and owns separate sessions, so classic RPC's connection-bound extension delivery never reaches
+  app-server clients in either direction.
+- App-server initialize capabilities have no `extension_events` field. Event delivery is therefore unconditional for
+  initialized subscribers, while thread subscriptions provide the required audience boundary.
+
+### Why this cannot be expressed externally
+
+- Both directions cross the app-server's internal thread/session registry and notification router. An extension can opt
+  into delivery with `pi.rpc`, but cannot register an app-server JSON-RPC method or address the owning thread's clients.
+- Ordinary `pi.events` channels remain extension-local; this change forwards only explicit `pi.rpc.emit` records at the
+  connection boundary.
+
+### Expected merge conflict zones
+
+- MEDIUM: `modes/app-server/runtime.ts` session binding and registry wiring.
+- LOW: `modes/app-server/rpc/registry.ts` method registration and `threads/registry.ts` initial notification storage.
+
 ## Backfill: injected app-server turns (2026-08-01)
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/rpc/registry.ts
+++ b/packages/coding-agent/src/modes/app-server/rpc/registry.ts
@@ -50,6 +50,37 @@ export interface MethodRegistry {
 	dispatch(connection: RegistryConnection, request: RpcRequest): Promise<RpcResponse>;
 }
 
+export interface ExtensionRequestTarget {
+	readonly extensionRunner: {
+		requestRpc(name: string, data: unknown): Promise<unknown>;
+	};
+}
+
+export function registerExtensionRequestMethod(
+	registry: MethodRegistry,
+	getThread: (threadId: string) => ExtensionRequestTarget,
+): void {
+	registry.register("extension_request", {
+		scope: "thread",
+		handler: async ({ request }) => {
+			const params = request.params;
+			if (typeof params !== "object" || params === null || Array.isArray(params)) {
+				throw new RpcHandlerError({ code: -32602, message: "Invalid params" });
+			}
+			const threadId = Reflect.get(params, "threadId");
+			const name = Reflect.get(params, "name");
+			if (typeof threadId !== "string" || threadId.length === 0 || typeof name !== "string" || name.length === 0) {
+				throw new RpcHandlerError({ code: -32602, message: "Invalid params" });
+			}
+			try {
+				return await getThread(threadId).extensionRunner.requestRpc(name, Reflect.get(params, "data"));
+			} catch (error) {
+				throw new RpcHandlerError(internalError(error instanceof Error ? error.message : String(error)));
+			}
+		},
+	});
+}
+
 export function createRegistry(): MethodRegistry {
 	return new InMemoryMethodRegistry();
 }

--- a/packages/coding-agent/src/modes/app-server/runtime.ts
+++ b/packages/coding-agent/src/modes/app-server/runtime.ts
@@ -2,7 +2,8 @@ import { ENV_SESSION_DIR, getAgentDir } from "../../config.ts";
 import { getMcpService } from "../../core/extensions/builtin/mcp/service.ts";
 import { DefaultResourceLoader } from "../../core/resource-loader.ts";
 import { type CreateAgentSessionOptions, createAgentSession } from "../../core/sdk.ts";
-import { createRegistry, type MethodRegistry } from "./rpc/registry.ts";
+import type { RpcNotification } from "./rpc/envelope.ts";
+import { createRegistry, type MethodRegistry, registerExtensionRequestMethod } from "./rpc/registry.ts";
 import { registerFuzzyFileSearchMethods } from "./search/fuzzy-search-methods.ts";
 import { FuzzyFileSearchService } from "./search/fuzzy-search-service.ts";
 import { ApprovalBridge, createAppServerUIContext } from "./server/approvals.ts";
@@ -65,6 +66,7 @@ export function createAppServerRuntime(requestShutdown: (reason: string) => void
 		createSession: (options) => createBoundAppServerSession(options, approvals, notifications, requestShutdown),
 		mcpWireStatusAdapter: processMcpWireStatusAdapter,
 	});
+	registerExtensionRequestMethod(registry, (threadId) => threads.getLoadedThread(threadId).session);
 	const core = createRoutedServerCore(
 		registry,
 		notifications,
@@ -130,6 +132,19 @@ async function createBoundAppServerSession(
 ): Promise<AppServerSessionResult> {
 	const result = await createAgentSession(options);
 	const threadId = result.session.sessionId;
+	const initialNotifications: RpcNotification[] = [];
+	let bindingExtensions = true;
+	result.session.extensionRunner.onRpcEvent(({ name, data }) => {
+		const notification = {
+			method: "extension_event",
+			params: { type: "extension_event", name, data, threadId },
+		};
+		if (bindingExtensions) {
+			initialNotifications.push(notification);
+			return;
+		}
+		notifications.toThread(threadId, notification);
+	});
 	await result.session.bindExtensions({
 		uiContext: createAppServerUIContext(approvals, threadId),
 		mode: "app-server",
@@ -138,6 +153,7 @@ async function createBoundAppServerSession(
 			notifications.toThread(threadId, { method: "error", params: error });
 		},
 	});
+	bindingExtensions = false;
 	// The MCP service captures this session's attach state under its session id.
 	// Convert that captured state into a session-owned adapter before the entry is
 	// registered; later requests never consult the service-global lifecycle view.
@@ -148,7 +164,7 @@ async function createBoundAppServerSession(
 			approvals.cancelPendingForThread(threadId);
 		}
 	});
-	return { ...result, mcpWireStatusAdapter };
+	return { ...result, initialNotifications, mcpWireStatusAdapter };
 }
 
 function registerTurnHandlers(registry: MethodRegistry, turns: TurnEngineApi, core: ServerCore): void {

--- a/packages/coding-agent/src/modes/app-server/threads/registry.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/registry.ts
@@ -56,6 +56,7 @@ export interface ThreadEntry {
 }
 
 export type AppServerSessionResult = CreateAgentSessionResult & {
+	readonly initialNotifications?: readonly RpcNotification[];
 	readonly mcpWireStatusAdapter?: McpWireStatusAdapter;
 };
 
@@ -116,7 +117,13 @@ export class ThreadRegistry {
 			model: options.model,
 		});
 		this.deletedThreadIds.delete(result.session.sessionId);
-		return this.registerSession(result.session, cwd, undefined, result.mcpWireStatusAdapter);
+		return this.registerSession(
+			result.session,
+			cwd,
+			undefined,
+			result.initialNotifications,
+			result.mcpWireStatusAdapter,
+		);
 	}
 
 	async resumeThread(threadId: string): Promise<ThreadEntry> {
@@ -139,7 +146,13 @@ export class ThreadRegistry {
 			agentDir: this.agentDir,
 			sessionManager,
 		});
-		return this.registerSession(result.session, sessionManager.getCwd(), sessionInfo, result.mcpWireStatusAdapter);
+		return this.registerSession(
+			result.session,
+			sessionManager.getCwd(),
+			sessionInfo,
+			result.initialNotifications,
+			result.mcpWireStatusAdapter,
+		);
 	}
 
 	async forkThread(threadId: string, options: Partial<CreateThreadOptions> = {}): Promise<ThreadEntry> {
@@ -157,7 +170,13 @@ export class ThreadRegistry {
 			model: options.model,
 		});
 		this.deletedThreadIds.delete(result.session.sessionId);
-		return this.registerSession(result.session, cwd, undefined, result.mcpWireStatusAdapter);
+		return this.registerSession(
+			result.session,
+			cwd,
+			undefined,
+			result.initialNotifications,
+			result.mcpWireStatusAdapter,
+		);
 	}
 
 	async deleteThread(threadId: string): Promise<boolean> {
@@ -257,6 +276,7 @@ export class ThreadRegistry {
 		session: AgentSession,
 		cwd: string,
 		sessionInfo?: SessionInfo,
+		initialNotifications: readonly RpcNotification[] = [],
 		mcpWireStatusAdapter?: McpWireStatusAdapter,
 	): ThreadEntry {
 		const existing = this.entries.get(session.sessionId);
@@ -278,7 +298,7 @@ export class ThreadRegistry {
 			cwd,
 			subscribers: new Set<ConnectionId>(),
 			activeTurn: null,
-			queuedTerminalNotifications: [],
+			queuedTerminalNotifications: [...initialNotifications],
 			status: "idle",
 			taskQueue: Promise.resolve(),
 			createdAt: sessionInfo?.created.toISOString() ?? now,

--- a/packages/coding-agent/test/suite/app-server-extension-events.test.ts
+++ b/packages/coding-agent/test/suite/app-server-extension-events.test.ts
@@ -1,0 +1,87 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RpcEnvelope } from "../../src/modes/app-server/rpc/envelope.ts";
+import { createAppServerRuntime } from "../../src/modes/app-server/runtime.ts";
+
+const roots: string[] = [];
+
+function createFixture(): { readonly root: string; readonly agentDir: string } {
+	const root = mkdtempSync(join(tmpdir(), "senpi-app-server-extension-events-"));
+	const agentDir = join(root, "agent");
+	mkdirSync(join(agentDir, "extensions"), { recursive: true });
+	writeFileSync(
+		join(agentDir, "extensions", "rpc-events.ts"),
+		`export default function (pi) {
+			pi.on("session_start", () => pi.rpc.emit("fixture.ready", { ready: true }));
+		}
+`,
+		"utf8",
+	);
+	roots.push(root);
+	return { root, agentDir };
+}
+
+async function request(
+	runtime: ReturnType<typeof createAppServerRuntime>,
+	connectionId: string,
+	id: number,
+	method: string,
+	params: unknown,
+): Promise<void> {
+	await runtime.core.receive(connectionId, { kind: "request", message: { id, method, params } });
+}
+
+describe("app-server extension RPC events", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+	});
+
+	it("forwards one session-start extension event only to the owning thread subscribers", async () => {
+		// Given: two initialized app-server clients and a test extension that emits during binding.
+		const fixture = createFixture();
+		vi.stubEnv("SENPI_CODING_AGENT_DIR", fixture.agentDir);
+		vi.stubEnv("SENPI_CODING_AGENT_SESSION_DIR", join(fixture.root, "sessions"));
+		vi.stubEnv("PI_OFFLINE", "1");
+		const runtime = createAppServerRuntime(() => undefined);
+		const firstFrames: RpcEnvelope[] = [];
+		const secondFrames: RpcEnvelope[] = [];
+		for (const [id, frames] of [
+			["first", firstFrames],
+			["second", secondFrames],
+		] as const) {
+			runtime.core.addConnection({
+				id,
+				transportKind: "stdio",
+				send: (message) => {
+					frames.push(message);
+				},
+				close: () => undefined,
+			});
+			await request(runtime, id, 1, "initialize", {
+				clientInfo: { name: id, version: "1.0.0" },
+				capabilities: {},
+			});
+		}
+
+		// When: only the first client starts and subscribes to a thread.
+		await request(runtime, "first", 2, "thread/start", { cwd: fixture.root });
+
+		// Then: exactly one extension record reaches that owner and no unrelated client.
+		expect(firstFrames.filter((frame) => "method" in frame && frame.method === "extension_event")).toEqual([
+			expect.objectContaining({
+				method: "extension_event",
+				params: {
+					type: "extension_event",
+					name: "fixture.ready",
+					data: { ready: true },
+					threadId: expect.any(String),
+				},
+			}),
+		]);
+		expect(secondFrames.filter((frame) => "method" in frame && frame.method === "extension_event")).toEqual([]);
+		runtime.dispose();
+	});
+});

--- a/packages/coding-agent/test/suite/app-server-extension-requests.test.ts
+++ b/packages/coding-agent/test/suite/app-server-extension-requests.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RpcEnvelope } from "../../src/modes/app-server/rpc/envelope.ts";
+import { createAppServerRuntime } from "../../src/modes/app-server/runtime.ts";
+
+const roots: string[] = [];
+
+function fixture(extensionSources: readonly string[]): { readonly root: string; readonly agentDir: string } {
+	const root = mkdtempSync(join(tmpdir(), "senpi-app-server-extension-requests-"));
+	const agentDir = join(root, "agent");
+	const extensionsDir = join(agentDir, "extensions");
+	mkdirSync(extensionsDir, { recursive: true });
+	for (const [index, source] of extensionSources.entries()) {
+		writeFileSync(join(extensionsDir, `rpc-request-${index}.ts`), source, "utf8");
+	}
+	roots.push(root);
+	return { root, agentDir };
+}
+
+async function startRuntime(extensionSources: readonly string[]) {
+	const created = fixture(extensionSources);
+	vi.stubEnv("SENPI_CODING_AGENT_DIR", created.agentDir);
+	vi.stubEnv("SENPI_CODING_AGENT_SESSION_DIR", join(created.root, "sessions"));
+	vi.stubEnv("PI_OFFLINE", "1");
+	const runtime = createAppServerRuntime(() => undefined);
+	const frames: RpcEnvelope[] = [];
+	const connection = runtime.core.addConnection({
+		id: "client",
+		transportKind: "stdio",
+		send: (message) => {
+			frames.push(message);
+		},
+		close: () => undefined,
+	});
+	await runtime.core.receive(connection.id, {
+		kind: "request",
+		message: {
+			id: 1,
+			method: "initialize",
+			params: { clientInfo: { name: "request-test", version: "1.0.0" }, capabilities: {} },
+		},
+	});
+	await runtime.core.receive(connection.id, {
+		kind: "request",
+		message: { id: 2, method: "thread/start", params: { cwd: created.root } },
+	});
+	const started = frames.find((frame) => "id" in frame && frame.id === 2);
+	if (!started || !("result" in started) || typeof started.result !== "object" || started.result === null) {
+		throw new Error("thread/start response missing");
+	}
+	const thread = Reflect.get(started.result, "thread");
+	const threadId = typeof thread === "object" && thread !== null ? Reflect.get(thread, "id") : undefined;
+	if (typeof threadId !== "string") throw new Error("thread/start response missing thread id");
+	return { runtime, frames, connectionId: connection.id, threadId };
+}
+
+async function extensionRequest(
+	harness: Awaited<ReturnType<typeof startRuntime>>,
+	id: number,
+	name: string,
+	data?: unknown,
+): Promise<RpcEnvelope> {
+	await harness.runtime.core.receive(harness.connectionId, {
+		kind: "request",
+		message: { id, method: "extension_request", params: { threadId: harness.threadId, name, data } },
+	});
+	const response = harness.frames.find((frame) => "id" in frame && frame.id === id);
+	if (!response) throw new Error(`missing extension_request response ${id}`);
+	return response;
+}
+
+describe("app-server extension RPC requests", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+		for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+	});
+
+	it("round-trips structured data through the owning thread extension handler", async () => {
+		// Given: an app-server thread whose extension handles fixture.echo.
+		const harness = await startRuntime([
+			`export default function (pi) { pi.rpc.handle("fixture.echo", async (data) => ({ echoed: data })); }`,
+		]);
+
+		// When: the client sends an extension_request for that thread.
+		const response = await extensionRequest(harness, 3, "fixture.echo", { text: "hello" });
+
+		// Then: the handler result is returned as the JSON-RPC result.
+		expect(response).toEqual({ id: 3, result: { echoed: { text: "hello" } } });
+		harness.runtime.dispose();
+	});
+
+	it("returns a typed JSON-RPC error for an unknown handler", async () => {
+		// Given: an app-server thread with no matching extension handler.
+		const harness = await startRuntime([]);
+
+		// When: the client requests an unknown extension RPC name.
+		const response = await extensionRequest(harness, 3, "fixture.missing");
+
+		// Then: the registry returns a bounded typed error instead of throwing through the server.
+		expect(response).toEqual({
+			id: 3,
+			error: { code: -32603, message: "Unknown extension RPC request: fixture.missing" },
+		});
+		harness.runtime.dispose();
+	});
+
+	it("returns a typed JSON-RPC error when multiple handlers share one name", async () => {
+		// Given: two extensions registering the same request name.
+		const source = `export default function (pi) { pi.rpc.handle("fixture.duplicate", () => null); }`;
+		const harness = await startRuntime([source, source]);
+
+		// When: the client requests that ambiguous name.
+		const response = await extensionRequest(harness, 3, "fixture.duplicate");
+
+		// Then: single-handler semantics surface as a typed JSON-RPC error.
+		expect(response).toEqual({
+			id: 3,
+			error: { code: -32603, message: "Multiple extension RPC request handlers registered: fixture.duplicate" },
+		});
+		harness.runtime.dispose();
+	});
+});


### PR DESCRIPTION
## Summary

- forward opt-in `pi.rpc.emit(name, data)` records from each app-server session to that thread's subscribed clients
- preserve extension events emitted during initial `session_start` binding and deliver exactly one `extension_event` notification after subscription
- add the `extension_request` app-server method, routing `{ threadId, name, data }` to the owning session's `extensionRunner.requestRpc`
- preserve unknown and duplicate-handler failures as typed JSON-RPC errors

## Why

Classic `--mode rpc` already exposes both extension RPC directions, but app-server binds its own sessions and never crossed that connection boundary. This left app/editor clients unable to receive extension-owned state or invoke extension-owned handlers.

App-server initialization has no generic `extension_events` capability. Delivery is therefore unconditional for initialized subscribers of the owning thread. Ordinary `pi.events` channels remain extension-local and are not forwarded.

## Observed behavior

A real built CLI was driven over app-server stdio with a temporary extension that emits during `session_start` and handles a request. The client observed:

```json
{"method":"extension_event","params":{"type":"extension_event","name":"manual.ready","data":{"source":"app-server"},"threadId":"..."},"emittedAtMs":...}
{"id":3,"result":{"echoed":{"text":"round-trip"},"handled":true}}
```

Evidence: `.omo/evidence/st_019ff5c3/manual-app-server-extension-rpc.log` in the task worktree.

Failing-first captures:

- `.omo/evidence/st_019ff5c3/events-red.log`
- `.omo/evidence/st_019ff5c3/requests-red.log`

## Verification

- `npm run build`
- `npm run check`
- `npx vitest run test/suite/app-server-extension-events.test.ts test/suite/app-server-extension-requests.test.ts test/rpc-classic-compat.test.ts`
- `npx vitest run test/suite/app-server-*.test.ts` (60 files; 313 passed, 1 skipped)
- `npm run qa:app-server`
- real built-CLI stdio QA described above

## Residual risk

Low. The additive notification method is Senpi-specific rather than part of the pinned Codex notification manifest, so only clients that intentionally consume `extension_event` will use it. Binding-time records can precede the correlated `thread/start` response, consistent with the app-server's documented notification ordering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridges extension RPC in app-server: forwards `pi.rpc.emit` events to the owning thread’s subscribers and adds `extension_request` so clients can call extension handlers. This matches classic RPC behavior for app/editor clients.

- **New Features**
  - Forwards opt-in extension events as `extension_event` to thread subscribers. Events emitted during `session_start` are buffered and delivered once after subscription. `pi.events` channels are not forwarded.
  - Adds `extension_request` method that routes `{ threadId, name, data }` to the thread’s `pi.rpc.handle` handler and returns its result. Unknown or duplicate handlers return typed JSON-RPC errors.
  - Documents the wire shape in `docs/app-server.md` and adds release notes in `CHANGELOG.md`.

- **Migration**
  - To consume: listen for `extension_event` notifications and call `extension_request` with the thread id. No capability flag is required.

<sup>Written for commit 4b5d2a75c1be3f549ccbe55001ae2453db51b3c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

