### PR TITLE
fix(ai): make optional keyword stripping schema-position-aware

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ### Fixed
 
+- Made `optional` keyword stripping in `google-shared.ts` schema-position-aware:
+  `stripOptional()` now preserves legitimate properties named `optional` under
+  `properties`/`patternProperties`/`$defs`/`definitions` and passes through value
+  keywords (`const`/`default`/`examples`/`enum`) without traversing them.
+  `sanitizeForOpenApi()` now recurses into array branches so `optional` inside
+  `anyOf`/`oneOf`/`allOf` is stripped on the legacy Gemini `parameters` path.
+
 ### Removed
 
 ## [2026.8.1] - 2026-08-01

--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -282,6 +282,7 @@ const JSON_SCHEMA_META_DECLARATIONS = new Set([
 	"$comment",
 	"$defs",
 	"definitions", // pre-draft-2019-09 equivalent of $defs
+	"optional",
 ]);
 
 /**
@@ -296,6 +297,26 @@ function sanitizeForOpenApi(schema: unknown): unknown {
 	for (const [key, value] of Object.entries(schema)) {
 		if (JSON_SCHEMA_META_DECLARATIONS.has(key)) continue;
 		result[key] = sanitizeForOpenApi(value);
+	}
+	return result;
+}
+
+/**
+ * Strip non-standard 'optional' keyword recursively from a JSON schema object.
+ */
+function stripOptional(schema: unknown): unknown {
+	if (typeof schema !== "object" || schema === null) {
+		return schema;
+	}
+
+	if (Array.isArray(schema)) {
+		return schema.map(stripOptional);
+	}
+
+	const result: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		if (key === "optional") continue;
+		result[key] = stripOptional(value);
 	}
 	return result;
 }
@@ -320,7 +341,7 @@ export function convertTools(
 				description: tool.description,
 				...(useParameters
 					? { parameters: sanitizeForOpenApi(tool.parameters) }
-					: { parametersJsonSchema: tool.parameters }),
+					: { parametersJsonSchema: stripOptional(tool.parameters) }),
 			})),
 		},
 	];

--- a/packages/ai/src/api/google-shared.ts
+++ b/packages/ai/src/api/google-shared.ts
@@ -282,15 +282,18 @@ const JSON_SCHEMA_META_DECLARATIONS = new Set([
 	"$comment",
 	"$defs",
 	"definitions", // pre-draft-2019-09 equivalent of $defs
-	"optional",
 ]);
 
 /**
  * Strip meta-declarations from a schema obj
  */
 function sanitizeForOpenApi(schema: unknown): unknown {
-	if (typeof schema !== "object" || schema === null || Array.isArray(schema)) {
+	if (typeof schema !== "object" || schema === null) {
 		return schema;
+	}
+
+	if (Array.isArray(schema)) {
+		return schema.map(sanitizeForOpenApi);
 	}
 
 	const result: Record<string, unknown> = {};
@@ -302,7 +305,27 @@ function sanitizeForOpenApi(schema: unknown): unknown {
 }
 
 /**
- * Strip non-standard 'optional' keyword recursively from a JSON schema object.
+ * Keywords whose values hold instance data, not subschemas. These must be
+ * passed through untouched so that e.g. `const: { optional: true }` is
+ * preserved as legitimate data.
+ */
+const SCHEMA_VALUE_KEYWORDS = new Set(["const", "default", "examples", "enum"]);
+
+/**
+ * Keywords whose values are maps of name → subschema (e.g. `properties`).
+ * The map keys are instance property / definition names and must be
+ * preserved even if one happens to be named `optional`.
+ */
+const SCHEMA_MAP_KEYS_STRIP = new Set(["properties", "patternProperties", "$defs", "definitions"]);
+
+/**
+ * Strip the non-standard 'optional' keyword from a JSON schema object.
+ *
+ * Position-aware: only strips `optional` when it appears as a schema keyword
+ * (a sibling of `type`, `properties`, etc.). Preserves `optional` when it is
+ * a property name inside `properties`/`patternProperties`/`$defs`/`definitions`,
+ * and does not traverse value keywords (`const`/`default`/`examples`/`enum`)
+ * whose contents are instance data, not subschemas.
  */
 function stripOptional(schema: unknown): unknown {
 	if (typeof schema !== "object" || schema === null) {
@@ -315,7 +338,27 @@ function stripOptional(schema: unknown): unknown {
 
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(schema)) {
+		// Strip the non-standard 'optional' keyword from schema keyword position.
 		if (key === "optional") continue;
+
+		// Value keywords hold instance data, not schemas — pass through untouched.
+		if (SCHEMA_VALUE_KEYWORDS.has(key)) {
+			result[key] = value;
+			continue;
+		}
+
+		// Map keys hold instance property names / definition names as keys.
+		// Preserve each key but recurse into the subschema value.
+		if (SCHEMA_MAP_KEYS_STRIP.has(key) && typeof value === "object" && value !== null && !Array.isArray(value)) {
+			const map: Record<string, unknown> = {};
+			for (const [name, subschema] of Object.entries(value as Record<string, unknown>)) {
+				map[name] = stripOptional(subschema);
+			}
+			result[key] = map;
+			continue;
+		}
+
+		// All other keywords hold schemas (or schema arrays) — recurse.
 		result[key] = stripOptional(value);
 	}
 	return result;
@@ -340,7 +383,7 @@ export function convertTools(
 				name: tool.name,
 				description: tool.description,
 				...(useParameters
-					? { parameters: sanitizeForOpenApi(tool.parameters) }
+					? { parameters: stripOptional(sanitizeForOpenApi(tool.parameters)) }
 					: { parametersJsonSchema: stripOptional(tool.parameters) }),
 			})),
 		},

--- a/packages/ai/src/utils/tool-schema-compat.ts
+++ b/packages/ai/src/utils/tool-schema-compat.ts
@@ -145,6 +145,8 @@ function normalizeNode(node: unknown): unknown {
 		return node;
 	}
 
+	delete node.optional;
+
 	const hasCombiner = COMBINER_KEYS.some((key) => Array.isArray(node[key]));
 	if (hasCombiner) {
 		moveTypeIntoCombinerBranches(node);

--- a/packages/ai/test/google-shared-convert-tools.test.ts
+++ b/packages/ai/test/google-shared-convert-tools.test.ts
@@ -160,6 +160,32 @@ describe("google-shared convertTools", () => {
 		});
 	});
 
+	it("strips non-standard 'optional' keyword from parametersJsonSchema when useParameters=false", () => {
+		const tools = [
+			makeTool({
+				$schema: "http://json-schema.org/draft-07/schema#",
+				type: "object",
+				properties: {
+					command: { type: "string", optional: true },
+				},
+				required: ["command"],
+			}),
+		];
+
+		const result = convertTools(tools, false);
+		const decl = result?.[0]?.functionDeclarations?.[0];
+
+		expect(decl).toBeDefined();
+		expect(decl?.parametersJsonSchema).toEqual({
+			$schema: "http://json-schema.org/draft-07/schema#",
+			type: "object",
+			properties: {
+				command: { type: "string" },
+			},
+			required: ["command"],
+		});
+	});
+
 	it("handles tools without $schema gracefully", () => {
 		const tools = [
 			makeTool({

--- a/packages/ai/test/google-shared-convert-tools.test.ts
+++ b/packages/ai/test/google-shared-convert-tools.test.ts
@@ -226,4 +226,102 @@ describe("google-shared convertTools", () => {
 		expect(convertTools([])).toBeUndefined();
 		expect(convertTools([], true)).toBeUndefined();
 	});
+	it("preserves a legitimate property named 'optional' in parametersJsonSchema when useParameters=false", () => {
+		const tools = [
+			makeTool({
+				type: "object",
+				properties: {
+					optional: { type: "boolean", description: "legitimate parameter" },
+				},
+				required: ["optional"],
+			}),
+		];
+
+		const result = convertTools(tools, false);
+		const decl = result?.[0]?.functionDeclarations?.[0];
+
+		expect(decl).toBeDefined();
+		expect(decl?.parametersJsonSchema).toEqual({
+			type: "object",
+			properties: {
+				optional: { type: "boolean", description: "legitimate parameter" },
+			},
+			required: ["optional"],
+		});
+	});
+
+	it("preserves a legitimate property named 'optional' in parameters when useParameters=true", () => {
+		const tools = [
+			makeTool({
+				type: "object",
+				properties: {
+					optional: { type: "boolean", description: "legitimate parameter" },
+				},
+				required: ["optional"],
+			}),
+		];
+
+		const result = convertTools(tools, true);
+		const decl = result?.[0]?.functionDeclarations?.[0];
+
+		expect(decl).toBeDefined();
+		expect(decl?.parameters).toEqual({
+			type: "object",
+			properties: {
+				optional: { type: "boolean", description: "legitimate parameter" },
+			},
+			required: ["optional"],
+		});
+	});
+
+	it("preserves object-valued const/default/examples containing 'optional' key in parametersJsonSchema", () => {
+		const tools = [
+			makeTool({
+				type: "object",
+				properties: {
+					mode: {
+						type: "object",
+						const: { optional: true, keep: 1 },
+						default: { optional: false, keep: 2 },
+						examples: [{ optional: true, keep: 3 }],
+					},
+				},
+			}),
+		];
+
+		const result = convertTools(tools, false);
+		const decl = result?.[0]?.functionDeclarations?.[0];
+
+		expect(decl).toBeDefined();
+		expect(decl?.parametersJsonSchema).toEqual({
+			type: "object",
+			properties: {
+				mode: {
+					type: "object",
+					const: { optional: true, keep: 1 },
+					default: { optional: false, keep: 2 },
+					examples: [{ optional: true, keep: 3 }],
+				},
+			},
+		});
+	});
+
+	it("strips 'optional' from anyOf branches on both useParameters paths", () => {
+		const schema = {
+			anyOf: [{ type: "string", optional: true }, { type: "number" }],
+		};
+		const tools = [makeTool(schema)];
+
+		const falseResult = convertTools(tools, false);
+		const falseDecl = falseResult?.[0]?.functionDeclarations?.[0];
+		expect(falseDecl?.parametersJsonSchema).toEqual({
+			anyOf: [{ type: "string" }, { type: "number" }],
+		});
+
+		const trueResult = convertTools(tools, true);
+		const trueDecl = trueResult?.[0]?.functionDeclarations?.[0];
+		expect(trueDecl?.parameters).toEqual({
+			anyOf: [{ type: "string" }, { type: "number" }],
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the two review findings on #647: schema-position-unaware `optional` stripping (P1) and legacy Gemini `sanitizeForOpenApi` skipping arrays (P2).

### P1: Preserve legitimate properties and data named `optional`

`stripOptional()` previously deleted every object key named `optional` regardless of JSON Schema position. This corrupted:
- Tool parameters legitimately named `optional` under `properties` (the property schema disappeared while `required` still referenced it)
- Instance data inside `const`/`default`/`examples` value keywords

**Fix:** `stripOptional` is now schema-position-aware:
- Strips `optional` only from schema keyword position (sibling of `type`, `properties`, etc.)
- Preserves map keys under `properties`/`patternProperties`/`$defs`/`definitions`
- Passes through value keywords (`const`/`default`/`examples`/`enum`) without traversing them

### P2: Strip `optional` inside array branches on the legacy Gemini path

`sanitizeForOpenApi()` returned arrays unchanged, so `optional` inside `anyOf`/`oneOf`/`allOf` branches survived on the `useParameters=true` path while being stripped on the `parametersJsonSchema` path.

**Fix:** `sanitizeForOpenApi` now recurses into arrays via `schema.map(sanitizeForOpenApi)`. Also removed `"optional"` from `JSON_SCHEMA_META_DECLARATIONS` (so it no longer blindly strips from property name positions) and composed `stripOptional(sanitizeForOpenApi(...))` in `convertTools` for the `useParameters=true` path.

### Tests

Added 4 regression tests:
- Property named `optional` preserved in `parametersJsonSchema` (useParameters=false)
- Property named `optional` preserved in `parameters` (useParameters=true)
- Object-valued `const`/`default`/`examples` containing `optional` key preserved
- `optional` in `anyOf` branches stripped on both paths

### Evidence

- TDD: 4 new tests captured RED before fix, GREEN after
- Focused schema tests: 20/20 passed (16 original + 4 new)
- Full AI suite: 175 files / 1584 passed / 800 skipped
- `npm run check`: exit 0
- Real CLI mock loop: 4/4 passed
- Real module driver: all 7 predicates pass (property preserved both modes, const/default/examples preserved, anyOf stripped both paths)

Fixes #647.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `optional` keyword stripping in Gemini tool JSON Schema position-aware to prevent corrupting legitimate parameters and instance data. Previously we removed any key named `optional` and skipped arrays on the legacy `parameters` path; now we strip only when `optional` is a schema keyword, traverse arrays, and keep both paths consistent.

- `stripOptional` preserves `optional` under `properties`/`patternProperties`/`$defs`/`definitions`, does not traverse `const`/`default`/`examples`/`enum`, and recurses into arrays.
- `sanitizeForOpenApi` maps arrays; `convertTools` composes `stripOptional(sanitizeForOpenApi(...))` when `useParameters=true` and applies `stripOptional` to `parametersJsonSchema` when false.
- `normalizeNode` in `tool-schema-compat` deletes top-level `optional`.
- Tests: preserve a property named `optional`, preserve object-valued `const`/`default`/`examples` containing `optional`, and strip `optional` inside `anyOf` on both paths.
- `CHANGELOG.md`: added an Unreleased entry documenting this fix.

<sup>Written for commit 7c712d439d04b5e84bca156c04fdb746c1876774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

