### PR TITLE
fix(goal): show cache-warm ready time

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/cache-warm-ready-rpc.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/cache-warm-ready-rpc.mjs
@@ -1,0 +1,90 @@
+import { existsSync, readFileSync } from "node:fs";
+
+export function collectRpc(child) {
+	const lines = [];
+	const responses = new Map();
+	let buffer = "";
+	let sequence = 0;
+	let stderr = "";
+	child.stdout.on("data", (chunk) => {
+		buffer += chunk.toString();
+		let newline;
+		while ((newline = buffer.indexOf("\n")) >= 0) {
+			const line = buffer.slice(0, newline).trim();
+			buffer = buffer.slice(newline + 1);
+			if (!line) continue;
+			let message;
+			try {
+				message = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			lines.push(message);
+			const waiter = message.type === "response" ? responses.get(message.id) : undefined;
+			if (waiter) {
+				responses.delete(message.id);
+				waiter(message);
+			}
+		}
+	});
+	child.stderr.on("data", (chunk) => {
+		stderr += chunk.toString();
+	});
+	const send = (command, timeoutMs = 120_000) => {
+		const id = `req-${++sequence}`;
+		return new Promise((resolveCommand, reject) => {
+			const timer = setTimeout(() => reject(new Error(`timeout ${command.type}: ${stderr.slice(-300)}`)), timeoutMs);
+			responses.set(id, (message) => {
+				clearTimeout(timer);
+				resolveCommand(message);
+			});
+			child.stdin.write(`${JSON.stringify({ ...command, id })}\n`);
+		});
+	};
+	const waitFor = (predicate, label, timeoutMs = 90_000) =>
+		new Promise((resolveRecord, reject) => {
+			const startedAt = Date.now();
+			const check = () => {
+				const record = lines.find(predicate);
+				if (record) return resolveRecord(record);
+				if (Date.now() - startedAt > timeoutMs) return reject(new Error(`timed out waiting for ${label}: ${stderr.slice(-300)}`));
+				setTimeout(check, 50);
+			};
+			check();
+		});
+	return { lines, send, waitFor };
+}
+
+export function buildRpcReport(entry, scheduleEvents) {
+	const data = entry.data;
+	const schedule = scheduleEvents.at(-1)?.data;
+	const basisDeltaMs = data.dueAtMs - data.delayMs - Date.parse(entry.timestamp);
+	const assertions = {
+		delayMsPositiveFinite: Number.isFinite(data.delayMs) && data.delayMs > 0,
+		delayMsWithinCacheTtl: data.cache?.ttlSeconds === undefined || data.delayMs <= data.cache.ttlSeconds * 1000,
+		dueAtMsFinite: Number.isFinite(data.dueAtMs),
+		dueAtEqualsTimestampBasisPlusDelay: Number.isFinite(basisDeltaMs) && Math.abs(basisDeltaMs) <= 2000,
+		iterationIsOne: data.iteration === 1,
+		activeMonitorCountIsOne: data.activeMonitorCount === 1,
+		scheduleEventMatchesEntry: schedule?.dueAtMs === data.dueAtMs && schedule?.delayMs === data.delayMs,
+	};
+	return { pass: Object.values(assertions).every(Boolean), assertions, entry, scheduleEvents, basisDeltaMs };
+}
+
+export function readJsonlFile(path) {
+	if (!existsSync(path)) return [];
+	return readFileSync(path, "utf8")
+		.split(/\r?\n/)
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+}
+
+export function waitForClose(child) {
+	return new Promise((resolveClose) => {
+		const timer = setTimeout(resolveClose, 5000);
+		child.once("close", () => {
+			clearTimeout(timer);
+			resolveClose();
+		});
+	});
+}

--- a/.agents/skills/senpi-qa/scripts/lib/cache-warm-ready-scenario.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/cache-warm-ready-scenario.mjs
@@ -1,0 +1,182 @@
+import { execFileSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import {
+	cliEntry,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+	spawnCli,
+	stripAnsi,
+	tsxEntry,
+} from "./common.mjs";
+import { startFakeModelServer } from "./fake-model-server.mjs";
+import { hermeticEnv, writeMockModelsJson } from "./mock-loop-support.mjs";
+import { renderTerminalScreenshot } from "./terminal-screenshot.mjs";
+import { startTmuxTui } from "./tmux-tui-driver.mjs";
+import { buildRpcReport, collectRpc, readJsonlFile, waitForClose } from "./cache-warm-ready-rpc.mjs";
+
+const OBJECTIVE = "qa cache-warm goal: keep watching the terminal monitor until decisive output lands";
+const TURNS = [
+	{ toolCalls: [{ name: "create_goal", args: { objective: OBJECTIVE } }] },
+	{ text: "Goal created; the monitor watch is live." },
+	{ text: "Continuation check-in: still watching." },
+];
+const PROMPT = "Create a goal and keep watching the monitor.";
+
+export async function runCacheWarmReadyScenario() {
+	installCleanupHooks();
+	const root = repoRoot();
+	const guard = guardRealAuth();
+	const evidence = sharedEvidenceDir(root);
+	const cleanup = createCleanupState();
+	const startedAt = new Date().toISOString();
+	try {
+		const rpc = await runRpcSurface({ cleanup, evidence });
+		const tui = await runTuiSurface({ cleanup, evidence, root });
+		guard.assertUnchanged();
+		cleanup.authUnchanged = true;
+		writeFileSync(
+			join(evidence, "summary.json"),
+			`${JSON.stringify({ pass: true, command: "node .agents/skills/senpi-qa/scripts/scenarios/cache-warm-ready-rpc-tui.mjs", startedAt, rpc, tui, evidence }, null, 2)}\n`,
+		);
+		process.stdout.write(`PASS cache-warm-ready-rpc-tui (evidence: ${evidence})\n`);
+	} finally {
+		writeFileSync(join(evidence, "cleanup.json"), `${JSON.stringify(cleanup, null, 2)}\n`);
+		if (Object.values(cleanup).some((done) => !done)) {
+			process.stderr.write(`CLEANUP_INCOMPLETE: ${JSON.stringify(cleanup)}\n`);
+			process.exitCode = 2;
+		}
+	}
+}
+
+function createCleanupState() {
+	return {
+		rpcChildExited: false,
+		terminalExited: false,
+		rpcServerStopped: false,
+		tuiServerStopped: false,
+		rpcSandboxRemoved: false,
+		tuiSandboxRemoved: false,
+		authUnchanged: false,
+	};
+}
+
+function writeMonitorFixture(box) {
+	const eventLogPath = join(box.dir, "goal-monitor-events.jsonl");
+	const extensionPath = join(box.dir, "goal-monitor-extension.mjs");
+	writeFileSync(
+		extensionPath,
+		`import { appendFileSync } from "node:fs";
+const eventLogPath = ${JSON.stringify(eventLogPath)};
+export default function(pi) {
+	pi.on("session_start", () => pi.events?.emit("terminal_monitor_state", { activeCount: 1 }));
+	pi.events?.on("goal_continuation_scheduled", (data) => {
+		appendFileSync(eventLogPath, JSON.stringify({ type: "goal_continuation_scheduled", observedAtMs: Date.now(), data }) + "\\n");
+	});
+}
+`,
+	);
+	return { extensionPath, eventLogPath };
+}
+
+async function runRpcSurface({ cleanup, evidence }) {
+	const box = makeSandbox("rpc-cache-warm-ready");
+	const server = await startFakeModelServer({ turns: TURNS });
+	const fixture = writeMonitorFixture(box);
+	writeMockModelsJson(box.agentDir, server, "openai-completions");
+	const child = spawnCli(
+		["--mode", "rpc", "--no-session", "--no-context-files", "--no-skills", "--approve", "--extension", fixture.extensionPath],
+		{ env: hermeticEnv(box.env), cwd: box.cwd },
+	);
+	const rpc = collectRpc(child);
+	try {
+		await rpc.send({ type: "get_state" });
+		await rpc.send({ type: "set_model", provider: "mock", modelId: "mock-model" });
+		await rpc.send({ type: "prompt", message: PROMPT });
+		const record = await rpc.waitFor(
+			(message) =>
+				message.type === "entry_appended" &&
+				message.entry?.customType === "goal-cache-warmup" &&
+				message.entry?.data?.phase === "scheduled",
+			"goal-cache-warmup scheduled entry_appended",
+		);
+		const report = buildRpcReport(record.entry, readJsonlFile(fixture.eventLogPath));
+		writeFileSync(join(evidence, "rpc-cache-warm-entry.json"), `${JSON.stringify(report, null, 2)}\n`);
+		writeFileSync(join(evidence, "rpc-session.jsonl"), `${rpc.lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
+		if (!report.pass) throw new Error(`RPC cache-warm assertions failed: ${JSON.stringify(report.assertions)}`);
+		const { dueAtMs, delayMs } = report.entry.data;
+		process.stdout.write(
+			`[PASS] rpc: goal-cache-warmup scheduled entry appended (dueAtMs=${dueAtMs} delayMs=${delayMs} basisDeltaMs=${report.basisDeltaMs})\n`,
+		);
+		return { entryTimestamp: report.entry.timestamp, dueAtMs, delayMs };
+	} finally {
+		child.kill("SIGTERM");
+		await waitForClose(child);
+		cleanup.rpcChildExited = child.exitCode !== null || child.signalCode !== null;
+		await server.stop();
+		cleanup.rpcServerStopped = !server.listening;
+		box.cleanup();
+		cleanup.rpcSandboxRemoved = !existsSync(box.dir);
+	}
+}
+
+async function runTuiSurface({ cleanup, evidence, root }) {
+	const box = makeSandbox("tui-cache-warm-ready");
+	const server = await startFakeModelServer({ turns: TURNS });
+	const fixture = writeMonitorFixture(box);
+	writeMockModelsJson(box.agentDir, server, "openai-completions");
+	const terminal = startTmuxTui({
+		cwd: box.cwd,
+		env: hermeticEnv(box.env),
+		command: process.execPath,
+		args: [
+			tsxEntry(root),
+			"--tsconfig",
+			join(root, "tsconfig.json"),
+			cliEntry(root),
+			"--provider",
+			"mock",
+			"--model",
+			"mock-model",
+			"--no-context-files",
+			"--no-skills",
+			"--no-extensions",
+			"--extension",
+			fixture.extensionPath,
+			"--approve",
+		],
+		capturePath: join(box.dir, "terminal.ansi"),
+		cols: 120,
+		rows: 36,
+	});
+	try {
+		await terminal.waitFor((text) => text.includes("mock-model"), "initial TUI model render");
+		terminal.submit(PROMPT);
+		const pattern = /ready \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC \(\d+[smh][^)]*\)/;
+		const text = await terminal.waitFor((value) => pattern.test(value), "durable cache-warm ready notice", 120_000);
+		const noticeLine = text.split("\n").find((line) => pattern.test(line.trim()))?.trim();
+		const raw = terminal.getRaw();
+		writeFileSync(join(evidence, "terminal.ansi"), raw);
+		writeFileSync(join(evidence, "terminal.txt"), stripAnsi(raw));
+		await renderTerminalScreenshot(root, evidence, raw);
+		copyFileSync(fixture.eventLogPath, join(evidence, "tui-goal-monitor-events.jsonl"));
+		process.stdout.write(`[PASS] tui: durable cache-warm notice rendered: ${noticeLine}\n`);
+		process.stdout.write(`[PASS] tui: screenshot: ${join(evidence, "terminal.png")}\n`);
+		return { noticeLine };
+	} finally {
+		cleanup.terminalExited = terminal.stop();
+		await server.stop();
+		cleanup.tuiServerStopped = !server.listening;
+		box.cleanup();
+		cleanup.tuiSandboxRemoved = !existsSync(box.dir);
+	}
+}
+
+function sharedEvidenceDir(root) {
+	const commonGitDir = execFileSync("git", ["rev-parse", "--git-common-dir"], { cwd: root, encoding: "utf8" }).trim();
+	const dir = join(dirname(resolve(root, commonGitDir)), "local-ignore", "qa-evidence", "20260813-cache-warm-ready");
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}

--- a/.agents/skills/senpi-qa/scripts/scenarios/cache-warm-ready-rpc-tui.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cache-warm-ready-rpc-tui.mjs
@@ -1,0 +1,9 @@
+/**
+ * Real RPC + TUI proof for cache-warm expected-ready notices.
+ *
+ * Run:
+ *   node .agents/skills/senpi-qa/scripts/scenarios/cache-warm-ready-rpc-tui.mjs
+ */
+import { runCacheWarmReadyScenario } from "../lib/cache-warm-ready-scenario.mjs";
+
+await runCacheWarmReadyScenario();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Cache-warm Goal wait and wake entries now show the expected UTC completion time while retaining
+  the planned or actual elapsed duration in parentheses; RPC entry consumers receive the same
+  authoritative `dueAtMs` timestamp.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
@@ -16,7 +16,7 @@ export const renderGoalCacheWarmupEntry: EntryRenderer<GoalCacheWarmupEntryData>
 		title: titleLine(data),
 		why: whyLine(data),
 		extra: warm === undefined ? [] : [{ text: warm, tone: "success" }],
-		expandedLine: `goal ${data.goalId} · planned delay ${formatWakeDuration(data.delayMs)}`,
+		expandedLine: expandedLine(data),
 	};
 });
 
@@ -29,7 +29,7 @@ function titleLine(data: GoalCacheWarmupEntryData): string {
 		case "scheduled":
 			return `⚡ Cache-warm wait${iterationText} · ${wakeSources}`;
 		case "resumed":
-			return `⚡ Cache-warm wake${iterationText} · waited ${formatWakeDuration(data.waitedMs ?? data.delayMs)} · ${wakeSources}`;
+			return `⚡ Cache-warm wake${iterationText} · ${formatExpectedWake(data.dueAtMs, data.waitedMs ?? data.delayMs)} · ${wakeSources}`;
 	}
 }
 
@@ -40,17 +40,29 @@ function validIteration(value: number | undefined): number | undefined {
 function whyLine(data: GoalCacheWarmupEntryData): string {
 	switch (data.phase) {
 		case "scheduled": {
-			const deferred = `Continuation deferred ${formatWakeDuration(data.delayMs)}`;
+			const expected = `Continuation expected ${formatExpectedWake(data.dueAtMs, data.delayMs)}`;
 			if (data.cache?.ttlSeconds === undefined) {
-				return `${deferred} - the monitor wakes the goal the moment decisive output lands.`;
+				return `${expected} - the monitor wakes the goal the moment decisive output lands.`;
 			}
 			return data.delayMs < data.cache.ttlSeconds * 1000
-				? `${deferred} - the timed wake stays inside the ${formatCacheTtl(data.cache.ttlSeconds)} prompt-cache TTL.`
-				: `${deferred} - the prompt-cache TTL may elapse before the timed wake.`;
+				? `${expected} - the timed wake stays inside the ${formatCacheTtl(data.cache.ttlSeconds)} prompt-cache TTL.`
+				: `${expected} - the prompt-cache TTL may elapse before the timed wake.`;
 		}
 		case "resumed":
 			return "Woke on schedule to keep pursuing the goal.";
 	}
+}
+
+function formatExpectedWake(dueAtMs: number | undefined, elapsedMs: number): string {
+	if (dueAtMs === undefined || !Number.isFinite(dueAtMs)) return `waited ${formatWakeDuration(elapsedMs)}`;
+	const timestamp = new Date(dueAtMs).toISOString().slice(0, 16).replace("T", " ");
+	return `ready ${timestamp} UTC (${formatWakeDuration(elapsedMs)})`;
+}
+
+function expandedLine(data: GoalCacheWarmupEntryData): string {
+	const planned = `goal ${data.goalId} · planned delay ${formatWakeDuration(data.delayMs)}`;
+	if (data.phase === "scheduled") return `${planned} · ${formatExpectedWake(data.dueAtMs, data.delayMs)}`;
+	return `${planned} · ${formatExpectedWake(data.dueAtMs, data.waitedMs ?? data.delayMs)}`;
 }
 
 function warmLine(data: GoalCacheWarmupEntryData): string | undefined {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
@@ -53,6 +53,8 @@ export interface GoalCacheWarmupEntryData {
 	readonly iteration?: number;
 	/** Planned continuation delay in milliseconds. */
 	readonly delayMs: number;
+	/** Epoch milliseconds when the scheduled continuation is expected to resume. */
+	readonly dueAtMs?: number;
 	/** Actual wait in milliseconds; present on the `resumed` phase only. */
 	readonly waitedMs?: number;
 	/** Backward-compatible field containing the total active wake-source count. */
@@ -64,6 +66,28 @@ export interface GoalCacheWarmupEntryData {
 
 /** Live entries always carry an iteration; the ordinal is intentionally not persisted into Goal state. */
 export type LiveGoalCacheWarmupEntryData = GoalCacheWarmupEntryData & { readonly iteration: number };
+
+export type GoalCacheWarmScheduleData = Omit<LiveGoalCacheWarmupEntryData, "phase" | "waitedMs">;
+
+export function createGoalCacheWarmScheduleData(options: {
+	readonly goalId: string;
+	readonly delayMs: number;
+	readonly scheduledAtMs: number;
+	readonly iteration: number;
+	readonly activeMonitorCount: number;
+	readonly wakeSources: Readonly<Record<string, number>>;
+	readonly cache?: GoalCacheWarmMetrics;
+}): GoalCacheWarmScheduleData {
+	return {
+		goalId: options.goalId,
+		delayMs: options.delayMs,
+		dueAtMs: options.scheduledAtMs + options.delayMs,
+		iteration: options.iteration,
+		activeMonitorCount: options.activeMonitorCount,
+		wakeSources: options.wakeSources,
+		...(options.cache !== undefined ? { cache: options.cache } : {}),
+	};
+}
 
 const TOKENS_PER_PRICE_UNIT = 1_000_000;
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -572,6 +572,30 @@ surface; no core extension API change is required.
 
 ## Cache-warm continuation story: enriched events + durable entry + TUI renderer (2026-07-29)
 
+### Follow-up: expected-ready timestamps in cache-warm status (2026-08-13)
+
+- Scheduled cache-warm pi-events and durable `goal-cache-warmup` entries now carry an optional
+  additive `dueAtMs` epoch timestamp derived from the producer's scheduling clock and `delayMs`.
+  RPC consumers no longer need to approximate the completion point from receipt time.
+- The TUI renderer names that expected UTC completion point and keeps the planned or actual
+  elapsed duration in parentheses. Legacy entries and invalid timestamps retain the existing
+  elapsed-only `waited ...` wording.
+- The schedule payload builder lives in `cache-warm.ts` so the already oversized monitor
+  orchestrator does not absorb another formatting/contract responsibility.
+- Coverage: `goal-cache-warmup.test.ts`, `goal-monitor-rpc-notice.test.ts`, and
+  `goal-cache-warm-renderer.test.ts`.
+
+#### Why this lives in the fork
+
+- Cache-warm continuation entries, monitor-aware scheduling, and their TUI renderer are
+  fork-owned builtin Goal behavior. A consumer extension cannot amend an already-emitted
+  durable entry with the producer's authoritative due timestamp.
+
+#### Expected merge conflict zones on the next sync
+
+- LOW in `cache-warm.ts` and `cache-warm-renderer.ts`, both fork-owned cache-warm surfaces.
+- LOW in `monitor-continuation.ts` around the scheduled payload construction.
+
 ### What changed
 
 - New `cache-warm.ts`: `estimateCacheWarmMetrics(model, env, lastTurnUsage)` derives

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -7,6 +7,7 @@ import {
 	WAKE_SOURCE_STATE_EVENT,
 } from "../monitor-state-event.ts";
 import {
+	createGoalCacheWarmScheduleData,
 	estimateCacheWarmMetrics,
 	GOAL_CACHE_WARMUP_ENTRY_TYPE,
 	GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS,
@@ -284,22 +285,19 @@ export class MonitorAwareGoalContinuation {
 			const wakeSources = this.#wakeSourceSnapshot();
 			this.#scheduledCache = cache;
 			this.#scheduledAtMs = Date.now();
-			this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, {
+			const scheduleData = createGoalCacheWarmScheduleData({
 				goalId: goal.id,
 				delayMs,
-				iteration,
-				activeMonitorCount: this.#activeWakeSourceCount(),
-				wakeSources,
-				cache,
-			});
-			this.#appendWarmupEntry({
-				phase: "scheduled",
-				goalId: goal.id,
-				delayMs,
+				scheduledAtMs: this.#scheduledAtMs,
 				iteration,
 				activeMonitorCount: this.#activeWakeSourceCount(),
 				wakeSources,
 				...(cache !== undefined ? { cache } : {}),
+			});
+			this.#pi.events?.emit(GOAL_CONTINUATION_SCHEDULED_EVENT, scheduleData);
+			this.#appendWarmupEntry({
+				phase: "scheduled",
+				...scheduleData,
 			});
 		} else {
 			this.#scheduledAtMs = undefined;

--- a/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { GoalCacheWarmupEntryData } from "../../src/core/extensions/builtin/goal/cache-warm.ts";
 import { renderGoalCacheWarmupEntry } from "../../src/core/extensions/builtin/goal/cache-warm-renderer.ts";
 import type { CustomEntry } from "../../src/core/session-manager.ts";
@@ -28,18 +28,26 @@ describe("goal cache-warm entry renderer", () => {
 		initTheme("dark");
 	});
 
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("renders the scheduled wait with the cache story", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime("2026-07-29T00:00:00.000Z");
 		const text = renderToText({
 			phase: "scheduled",
 			goalId: "goal-1",
 			delayMs: 270_000,
+			dueAtMs: Date.parse("2026-07-29T00:04:30.000Z"),
 			activeMonitorCount: 1,
 			iteration: 2,
 			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
 		});
 		expect(text).toContain("Cache-warm wait · iteration 2");
+		expect(text).toContain("ready 2026-07-29 00:04 UTC (4m 30s)");
 		expect(text).toContain("1 wake source on duty");
-		expect(text).toContain("5m prompt-cache TTL");
+		expect(text).toMatch(/5m\s+prompt-cache TTL/);
 		expect(text).toContain("~120K tokens kept warm");
 		expect(text).toContain("$0.324 saved");
 	});
@@ -49,13 +57,14 @@ describe("goal cache-warm entry renderer", () => {
 			phase: "resumed",
 			goalId: "goal-1",
 			delayMs: 270_000,
+			dueAtMs: Date.parse("2026-07-29T00:04:30.000Z"),
 			waitedMs: 270_000,
 			activeMonitorCount: 2,
 			iteration: 3,
 			cache: { ttlSeconds: 300, cachedTokens: 120_000, estimatedSavedUsd: 0.324 },
 		});
 		expect(text).toContain("Cache-warm wake · iteration 3");
-		expect(text).toContain("waited 4m 30s");
+		expect(text).toContain("ready 2026-07-29 00:04 UTC (4m 30s)");
 		expect(text).toContain("2 wake sources on duty");
 		expect(text).toContain("~120K tokens stayed warm");
 		expect(text).toContain("$0.324 saved");
@@ -110,11 +119,25 @@ describe("goal cache-warm entry renderer", () => {
 		expect(text).not.toContain("iteration");
 	});
 
+	it("falls back to elapsed-only wording for an invalid due time", () => {
+		const text = renderToText({
+			phase: "resumed",
+			goalId: "legacy-invalid-due",
+			delayMs: 270_000,
+			dueAtMs: Number.NaN,
+			waitedMs: 270_000,
+			activeMonitorCount: 1,
+		});
+		expect(text).toContain("waited 4m 30s");
+		expect(text).not.toContain("ready ");
+	});
+
 	it("reveals goal details when expanded", () => {
 		const collapsed = renderToText({
 			phase: "resumed",
 			goalId: "goal-42",
 			delayMs: 240_000,
+			dueAtMs: Date.parse("2026-07-29T00:04:00.000Z"),
 			waitedMs: 200_000,
 			activeMonitorCount: 1,
 			cache: { cachedTokens: 500 },
@@ -126,6 +149,7 @@ describe("goal cache-warm entry renderer", () => {
 				phase: "resumed",
 				goalId: "goal-42",
 				delayMs: 240_000,
+				dueAtMs: Date.parse("2026-07-29T00:04:00.000Z"),
 				waitedMs: 200_000,
 				activeMonitorCount: 1,
 				cache: { cachedTokens: 500 },
@@ -133,6 +157,6 @@ describe("goal cache-warm entry renderer", () => {
 			true,
 		);
 		expect(expanded).toContain("goal-42");
-		expect(expanded).toContain("waited 3m 20s");
+		expect(expanded).toContain("ready 2026-07-29 00:04 UTC (3m 20s)");
 	});
 });

--- a/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
@@ -72,6 +72,7 @@ describe("goal cache-warm continuation story", () => {
 
 	it("tells the cache-warm story when the continuation is scheduled", async () => {
 		vi.useFakeTimers();
+		vi.setSystemTime(0);
 		const { harness, notices } = await setupWarmHarness("thread-cache-warm-scheduled");
 
 		expect(notices).toEqual([]);
@@ -80,6 +81,7 @@ describe("goal cache-warm continuation story", () => {
 			expect.objectContaining({
 				goalId: expect.any(String),
 				delayMs: 270_000,
+				dueAtMs: 270_000,
 				iteration: 1,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),
@@ -93,6 +95,7 @@ describe("goal cache-warm continuation story", () => {
 				phase: "scheduled",
 				goalId: expect.any(String),
 				delayMs: 270_000,
+				dueAtMs: 270_000,
 				iteration: 1,
 				activeMonitorCount: 1,
 				cache: expect.objectContaining({ cachedTokens: 120_000, ttlSeconds: 300 }),

--- a/packages/coding-agent/test/suite/goal-monitor-rpc-notice.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-rpc-notice.test.ts
@@ -52,6 +52,7 @@ describe("goal monitor scheduling notice over RPC", () => {
 
 	it("emits a scheduling event and one durable RPC entry", async () => {
 		vi.useFakeTimers();
+		vi.setSystemTime(0);
 		const scheduleEvents: unknown[] = [];
 		const harness = await createHarness({
 			extensionFactories: [
@@ -79,14 +80,14 @@ describe("goal monitor scheduling notice over RPC", () => {
 		await runner.emit({ type: "agent_start" });
 		await runner.emit({ type: "agent_end", messages: [fauxAssistantMessage("clean stop")] });
 
-		expect(scheduleEvents).toEqual([expect.objectContaining({ delayMs: 240_000 })]);
+		expect(scheduleEvents).toEqual([expect.objectContaining({ delayMs: 240_000, dueAtMs: 240_000 })]);
 		const records = rpcRecords(chunks);
 		expect(records).toContainEqual(
 			expect.objectContaining({
 				type: "entry_appended",
 				entry: expect.objectContaining({
 					customType: "goal-cache-warmup",
-					data: expect.objectContaining({ phase: "scheduled", iteration: 1 }),
+					data: expect.objectContaining({ phase: "scheduled", dueAtMs: 240_000, iteration: 1 }),
 				}),
 			}),
 		);


### PR DESCRIPTION
## Summary
- add authoritative `dueAtMs` to scheduled cache-warm Goal events and durable RPC entries
- render cache-warm waits/wakes as expected UTC completion time with elapsed duration in parentheses
- retain elapsed-only fallback for legacy or invalid timestamps
- add deterministic real-CLI RPC and xterm.js TUI QA coverage

## Verification
- RED: `goal-cache-warmup.test.ts` failed because scheduled payload lacked `dueAtMs`
- RED: renderer tests failed because notices only showed deferred/waited duration
- GREEN: 8 scoped files / 67 tests passed
- `npm run build`
- `npm run check` after final QA module split
- `node .agents/skills/senpi-qa/scripts/scenarios/cache-warm-ready-rpc-tui.mjs`

## QA evidence
- `local-ignore/qa-evidence/20260813-cache-warm-ready/rpc-cache-warm-entry.json`
- `local-ignore/qa-evidence/20260813-cache-warm-ready/terminal.png`
- `local-ignore/qa-evidence/20260813-cache-warm-ready/cleanup.json` (all cleanup flags true)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the expected UTC “ready” time for cache‑warm Goal waits/wakes and include an authoritative `dueAtMs` in scheduled events and durable RPC entries. Previously we showed only deferred/waited duration; now the UI renders “ready YYYY‑MM‑DD HH:MM UTC (duration)”, and RPC consumers get `dueAtMs` with a safe elapsed‑only fallback for legacy/invalid timestamps.

- `packages/coding-agent`: add `dueAtMs` via `createGoalCacheWarmScheduleData`; update `goal-cache-warmup` renderer to display the ready time; retain “waited …” when `dueAtMs` is missing or invalid.
- Tests/QA: extend unit tests to assert `dueAtMs` and new wording; add deterministic real CLI RPC + xterm.js TUI scenario and evidence.
- Migration: no required changes. RPC consumers may start reading `entry.data.dueAtMs` instead of approximating from receipt time.

<sup>Written for commit 9626004440bb97b0a97439777ee2d2edf0462fe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

