### PR TITLE
fix(release): install the native tsgo compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@anthropic-ai/sandbox-runtime": "0.0.67",
         "@biomejs/biome": "2.5.5",
         "@types/node": "26.1.1",
-        "@typescript/native": "npm:typescript@7.0.2",
+        "@typescript/native": "npm:@typescript/native-preview@7.0.0-dev.20260707.2",
         "@typescript/typescript6": "6.0.2",
         "esbuild": "0.28.1",
         "husky": "9.1.7",
@@ -1919,40 +1919,146 @@
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="
     },
     "node_modules/@typescript/native": {
-      "name": "typescript",
-      "version": "7.0.2",
+      "name": "@typescript/native-preview",
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc"
+        "tsgo": "bin/tsgo"
       },
       "engines": {
         "node": ">=16.20.0"
       },
       "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
-      },
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260707.2",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260707.2"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20260707.2",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260707.2.tgz",
+      "integrity": "sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@typescript/old": {
       "name": "typescript",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"@anthropic-ai/sandbox-runtime": "0.0.67",
 		"@biomejs/biome": "2.5.5",
 		"@types/node": "26.1.1",
-		"@typescript/native": "npm:typescript@7.0.2",
+		"@typescript/native": "npm:@typescript/native-preview@7.0.0-dev.20260707.2",
 		"@typescript/typescript6": "6.0.2",
 		"esbuild": "0.28.1",
 		"husky": "9.1.7",

--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## Install the compiler used by workspace builds (2026-08-13)
+
+### What changed
+
+- Pointed the root `@typescript/native` alias at
+  `@typescript/native-preview`, the package that actually provides the `tsgo`
+  binary invoked by workspace build scripts.
+- Added a dependency-contract test covering the manifest alias, lockfile
+  package identity, pinned native compiler version, and installed `tsgo` bin.
+
+### Why
+
+- Clean release runners do not have a globally installed `tsgo`; telemetry must
+  build before coding-agent can consume its generated declarations.
+
+### Why an extension could not handle it
+
+- Compiler installation and workspace build ordering happen before any Senpi
+  runtime or extension is loaded.
+
+### Expected merge conflict zones
+
+- LOW: root development dependencies in `package.json` and `package-lock.json`.
+
 ## Registry-complete locks and owned telemetry publishing (2026-08-13)
 
 ### What changed

--- a/scripts/tsgo-dependency.test.mjs
+++ b/scripts/tsgo-dependency.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const root = join(import.meta.dirname, "..");
+const nativeCompiler = "npm:@typescript/native-preview@7.0.0-dev.20260707.2";
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("root tsgo dependency", () => {
+	it("installs the native compiler binary used by workspace build scripts", () => {
+		const manifest = readJson(join(root, "package.json"));
+		const installLock = readJson(join(root, "package-lock.json"));
+		const installedCompiler = installLock.packages["node_modules/@typescript/native"];
+
+		assert.equal(manifest.devDependencies["@typescript/native"], nativeCompiler);
+		assert.equal(installLock.packages[""].devDependencies["@typescript/native"], nativeCompiler);
+		assert.equal(installedCompiler.name, "@typescript/native-preview");
+		assert.equal(installedCompiler.version, "7.0.0-dev.20260707.2");
+		assert.equal(installedCompiler.bin.tsgo, "bin/tsgo");
+	});
+});


### PR DESCRIPTION
## Problem

The trusted release dry-run on merged `main` failed before version/tag mutation because clean GitHub runners had no `tsgo` binary. Root `npm run build` invokes `tsgo` for telemetry, but `@typescript/native` incorrectly aliased ordinary `typescript@7.0.2`, which only provides `tsc`.

Failed run: https://github.com/code-yeongyu/senpi/actions/runs/31670455645

## Fix

- Point `@typescript/native` at pinned `@typescript/native-preview@7.0.0-dev.20260707.2`.
- Record its seven cross-platform native optional packages in the root lock.
- Add a dependency-contract regression for the manifest alias, lock identity/version, and `tsgo` bin.
- Document the clean-release invariant in `scripts/changes.md`.

## Verification

- `npm ci --ignore-scripts --no-audit --no-fund` — passed from a pristine worktree.
- `node_modules/.bin/tsgo --version` — `7.0.0-dev.20260707.2`.
- Telemetry build — passed.
- Root workspace build — passed.
- Root script suite — 124/124 passed.
- `npm run check` — passed.
- Package lock JSON and `git diff --check` — clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Installs the native `tsgo` compiler used by workspace builds by aliasing `@typescript/native` to `@typescript/native-preview@7.0.0-dev.20260707.2`. This fixes release dry runs on clean runners where `tsgo` was missing (old alias to `typescript@7.0.2` only provided `tsc`).

**Review and rollout**
- Update `package.json` to point `@typescript/native` at `npm:@typescript/native-preview@7.0.0-dev.20260707.2`; lockfile now includes seven platform-specific optional packages.
- Add `scripts/tsgo-dependency.test.mjs` to assert the alias, lock identity/version, and presence of the `tsgo` bin.
- Document the clean-release invariant in `scripts/changes.md`.
- Required action: run `npm ci` at the repo root to pick up the new lock; no global `tsgo` is needed. Potential low-conflict area: root devDependencies and lockfile.

<sup>Written for commit ddf42e3076ab66ffb3e4825ec9ab1d0152be5722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

