### PR TITLE
fix(release): build telemetry before AI

### DIFF
--- a/scripts/build-all.mjs
+++ b/scripts/build-all.mjs
@@ -21,8 +21,9 @@ const root = dirname(__dirname);
 const SUPPORTED_PMS = new Set(["npm", "bun", "pnpm"]);
 
 export const BUILD_PHASES = [
-	["packages/tui", "packages/pty", "packages/telemetry", "packages/ai", "packages/protocol"],
-	["packages/agent", "packages/client"],
+	["packages/tui", "packages/pty", "packages/telemetry", "packages/protocol"],
+	["packages/ai", "packages/client"],
+	["packages/agent"],
 	["packages/session-backends/sqlite-node"],
 	["packages/coding-agent"],
 	["packages/server"],

--- a/scripts/build-all.test.mjs
+++ b/scripts/build-all.test.mjs
@@ -41,7 +41,7 @@ describe("build-all", () => {
 			"packages/coding-agent",
 			"packages/server",
 		]);
-		assert.ok(index("packages/ai") >= index("packages/telemetry"));
+		assert.ok(index("packages/ai") > index("packages/telemetry"));
 		assert.ok(index("packages/agent") > index("packages/ai"));
 		assert.ok(index("packages/client") > index("packages/protocol"));
 		assert.ok(index("packages/session-backends/sqlite-node") > index("packages/agent"));
@@ -58,13 +58,7 @@ describe("build-all", () => {
 
 		// Then
 		assert.equal(packageJson.name, "@earendil-works/pi-pty");
-		assert.deepEqual(phaseOne, [
-			"packages/tui",
-			"packages/pty",
-			"packages/telemetry",
-			"packages/ai",
-			"packages/protocol",
-		]);
+		assert.deepEqual(phaseOne, ["packages/tui", "packages/pty", "packages/telemetry", "packages/protocol"]);
 	});
 
 	it("wires the pty package export surface for workspace imports", () => {

--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## Build telemetry before its consumers (2026-08-13)
+
+### What changed
+
+- Moved AI into the build phase after telemetry, and agent into the following
+  phase after AI.
+- Strengthened the build-order regression so direct workspace dependencies must
+  be in strictly later phases instead of merely the same phase.
+
+### Why
+
+- Release preparation runs `npm run clean` before its second workspace build.
+  With telemetry and AI in the same parallel phase, AI could resolve telemetry
+  before `dist/index.d.ts` existed and fail deterministically on a clean runner.
+
+### Why an extension could not handle it
+
+- Workspace compilation order is release/build tooling that runs before the
+  Senpi runtime or extension loader exists.
+
+### Expected merge conflict zones
+
+- LOW: `BUILD_PHASES` and its dependency-order assertions.
+
 ## Install the compiler used by workspace builds (2026-08-13)
 
 ### What changed


### PR DESCRIPTION
## Problem

Release preparation runs a second `clean -> build` transaction after version and lock refresh. Telemetry and AI were in the same parallel build phase even though AI imports telemetry types, so clean runners could compile AI before `packages/telemetry/dist/index.d.ts` existed.

Failed run: https://github.com/code-yeongyu/senpi/actions/runs/31671619179

## Fix

- Build telemetry in phase 1.
- Build AI in phase 2 after telemetry.
- Build agent in phase 3 after AI.
- Strengthen the dependency-order test from same-or-later to strictly later for AI versus telemetry.

## Verification

- Failing phase regression reproduced before the edit.
- `node --test scripts/build-all.test.mjs` — passed.
- Root script suite — passed.
- `npm run check` — passed.
- Exact `npm install -> npm run clean -> npm run build` release sequence — passed.
- Observed order: telemetry phase 1, AI phase 2, agent phase 3, coding-agent phase 5.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds `packages/telemetry` before its consumers in the release sequence to prevent clean runners compiling consumers before telemetry types exist. Previously `packages/telemetry` and `packages/ai` built in the same phase; now `packages/ai` builds after telemetry, and `packages/agent` builds after `packages/ai`.

- Update `BUILD_PHASES`: phase 1 includes `packages/telemetry` (with `packages/tui`, `packages/pty`, `packages/protocol`); phase 2 includes `packages/ai`, `packages/client`; phase 3 includes `packages/agent`.
- Strengthen the dependency-order test so `packages/ai` must build strictly later than `packages/telemetry`.
- Review focus: `scripts/build-all.mjs`, `scripts/build-all.test.mjs`. Potential conflicts are limited to `BUILD_PHASES` and related assertions.

<sup>Written for commit 3066759dac0d054205a84292e59bc6f0f1839005. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

