### PR TITLE
fix(release): reconcile native optional packages

### DIFF
--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,32 @@
 # changes
 
+## Reconcile native optionals after release lock refresh (2026-08-13)
+
+### What changed
+
+- Release preparation now runs a no-script install immediately after the
+  package-lock-only refresh.
+- Added a release-artifact regression covering both executed and dry-run command
+  sequences.
+
+### Why
+
+- npm refreshes optional dependencies for the current host in the lock, but a
+  package-lock-only operation does not update `node_modules`. Linux release
+  tests could therefore retain the old dependency tree and miss Rolldown's
+  `@rolldown/binding-linux-x64-gnu` native package.
+- Reconciliation is no-script and network-auditing disabled; it only makes the
+  installed tree match the freshly generated host lock before clean/build/test.
+
+### Why an extension could not handle it
+
+- Native package installation and release lock refresh happen before the Senpi
+  runtime or extension loader exists.
+
+### Expected merge conflict zones
+
+- LOW: `runPackageLockRefresh` in `release-artifacts.mjs`.
+
 ## Build telemetry before its consumers (2026-08-13)
 
 ### What changed

--- a/scripts/release-artifacts.mjs
+++ b/scripts/release-artifacts.mjs
@@ -1,10 +1,13 @@
 export function runPackageLockRefresh(dryRun, runCommand, log, dryRunLog) {
 	if (dryRun) {
 		dryRunLog("npm install --package-lock-only --ignore-scripts");
+		dryRunLog("npm install --ignore-scripts --no-audit --no-fund");
 		return;
 	}
 	log("npm install --package-lock-only --ignore-scripts");
 	runCommand("npm", ["install", "--package-lock-only", "--ignore-scripts"]);
+	log("npm install --ignore-scripts --no-audit --no-fund");
+	runCommand("npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"]);
 }
 
 export function runGenerateModels(dryRun, runCommand, log, dryRunLog) {

--- a/scripts/release-artifacts.test.mjs
+++ b/scripts/release-artifacts.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { runPackageLockRefresh } from "./release-artifacts.mjs";
+
+describe("release package-lock refresh", () => {
+	it("reconciles native optional packages after the host-specific lock refresh", () => {
+		const commands = [];
+		runPackageLockRefresh(
+			false,
+			(command, args) => commands.push([command, args]),
+			() => {},
+			() => {},
+		);
+
+		assert.deepEqual(commands, [
+			["npm", ["install", "--package-lock-only", "--ignore-scripts"]],
+			["npm", ["install", "--ignore-scripts", "--no-audit", "--no-fund"]],
+		]);
+	});
+
+	it("previews both lock refresh and native optional reconciliation", () => {
+		const previews = [];
+		runPackageLockRefresh(
+			true,
+			() => assert.fail("dry-run must not execute commands"),
+			() => {},
+			(message) => previews.push(message),
+		);
+
+		assert.deepEqual(previews, [
+			"npm install --package-lock-only --ignore-scripts",
+			"npm install --ignore-scripts --no-audit --no-fund",
+		]);
+	});
+});


### PR DESCRIPTION
## Problem

Release preparation refreshes `package-lock.json` for the Linux runner using `--package-lock-only`, but that does not update the already-installed `node_modules`. The serial test gate then started Vitest with a stale dependency tree and no `@rolldown/binding-linux-x64-gnu` native optional binding.

Failed run: https://github.com/code-yeongyu/senpi/actions/runs/31673725917

## Fix

- Immediately reconcile `node_modules` with a no-script install after the host-specific lock refresh.
- Preview both commands in release dry-run mode.
- Add focused release-artifact tests for real and dry-run command sequences.

## Verification

- Regression was red before implementation and 2/2 green after.
- Deleted local Rolldown native binding was restored by the exact lock-refresh + reconciliation sequence.
- Sequential root build passed.
- `npm run check` passed.
- Root script suite: 126/126 passed.
- No `v2026.8.13` tag or npm version exists, so release retry is safe.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles native optional packages during release prep to prevent missing Rolldown bindings on Linux. Previously we refreshed the lock with `npm install --package-lock-only` and ran tests with a stale `node_modules`, omitting `@rolldown/binding-linux-x64-gnu`. Now we immediately run `npm install --ignore-scripts --no-audit --no-fund` to align the installed tree; dry runs preview both commands.

**Review notes**
- Updates `runPackageLockRefresh` in `scripts/release-artifacts.mjs`; adds `scripts/release-artifacts.test.mjs`; updates `scripts/changes.md`.
- Execution order: lock refresh, then reconciliation install; dry-run logs both lines.
- Scope is release prep only; no runtime changes. Uses `--ignore-scripts --no-audit --no-fund` to avoid scripts and extra network checks.

<sup>Written for commit c92b6e15aa8e0681456db8feb5d958fe43929546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

