### PR TITLE
test(deps): lock every Rolldown platform binding

### DIFF
--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## Lock every Rolldown platform binding (2026-08-13)
+
+### What changed
+
+- Added a root-lock regression that requires every native optional declared by
+  Rolldown to carry its exact version, registry URL, integrity hash, and
+  `optional` marker.
+- Recorded the cross-platform lock restoration merged in PR #849.
+
+### Why
+
+- The upstream sync left only the host Darwin ARM64 binding in
+  `package-lock.json`. Linux and Windows Vitest processes failed at startup
+  before executing tests because their Rolldown native package was absent.
+
+### Why an extension could not handle it
+
+- Vitest loads Rolldown before tests or the Senpi runtime can start.
+
+### Expected merge conflict zones
+
+- MEDIUM: root `package-lock.json` optional dependency entries.
+
 ## Reconcile native optionals after release lock refresh (2026-08-13)
 
 ### What changed

--- a/scripts/rolldown-platform-lock.test.mjs
+++ b/scripts/rolldown-platform-lock.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const root = join(import.meta.dirname, "..");
+const rolldownVersion = "1.0.3";
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("Rolldown platform bindings", () => {
+	it("locks every native optional declared by Rolldown", () => {
+		const lock = readJson(join(root, "package-lock.json"));
+		const rolldown = lock.packages["node_modules/rolldown"];
+
+		for (const [packageName, version] of Object.entries(rolldown.optionalDependencies)) {
+			const binding = lock.packages[`node_modules/${packageName}`];
+			assert.ok(binding, `${packageName} must be present in the root lock`);
+			assert.equal(version, rolldownVersion);
+			assert.equal(binding.version, rolldownVersion);
+			assert.equal(binding.optional, true);
+			assert.match(binding.resolved, /^https:\/\/registry\.npmjs\.org\//u);
+			assert.match(binding.integrity, /^sha512-/u);
+		}
+	});
+});


### PR DESCRIPTION
## Purpose

PR #849 restored all 14 missing Rolldown platform binding entries in the root lock, unblocking Linux and Windows Vitest startup. This follow-up adds the repository-required durable `changes.md` record and prevents future host-only lock refreshes from silently dropping other platforms again.

## Verification

- Focused Rolldown lock contract — passed.
- Root script suite — passed.
- `npm run check` — passed.
- PR #849 CI is green across static checks and affected Linux/Windows test jobs.
- No `v2026.8.13` tag or npm version exists, so release retry remains safe.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks every `rolldown` native platform binding in the root lockfile and adds a test to prevent host-only lock refreshes from dropping non-host bindings. Previously host-only refreshes kept only the local binding; now CI fails if any declared binding is missing or malformed.

- Adds `scripts/rolldown-platform-lock.test.mjs`, which reads `package-lock.json` and asserts each `rolldown.optionalDependencies` binding is present with version 1.0.3, optional=true, npm registry URL, and sha512 integrity.
- Updates `scripts/changes.md` to document the lock policy and expected conflict zones.
- No runtime behavior change. If the `rolldown` version changes, update the test’s pinned version.

<sup>Written for commit f60aeb973e5052482b2e9da90e5bc2ccf470c9c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

