### PR TITLE
fix(release): skip native scripts during npm setup

### DIFF
--- a/.github/changes.md
+++ b/.github/changes.md
@@ -1,0 +1,22 @@
+# changes
+
+## Keep npm release installs independent of native build tooling (2026-08-13)
+
+### What changed
+
+- The npm release workflow now installs dependencies with `--ignore-scripts`.
+- Added a workflow contract test for the no-script install command.
+
+### Why
+
+- The release workflow builds and tests TypeScript packages; it does not need
+  Canvas or other native dependency lifecycle scripts.
+- Canvas lacked a compatible prebuild on the current Linux runner and its
+  source fallback required system `pangocairo` headers, failing before the
+  repository's own build and test gates could run.
+- Native artifacts are rebuilt explicitly in the separate binary release
+  workflow where their system prerequisites are managed.
+
+### Expected merge conflict zones
+
+- LOW: the dependency-install step in `publish-npm.yml`.

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -59,7 +59,7 @@ jobs:
         run: bash scripts/assert-bun-canary.sh
 
       - name: Install dependencies
-        run: npm install --no-audit --no-fund
+        run: npm install --ignore-scripts --no-audit --no-fund
 
       - name: Build all workspaces (so husky pre-commit type check resolves)
         run: npm run build

--- a/scripts/publish-workflow.test.mjs
+++ b/scripts/publish-workflow.test.mjs
@@ -10,6 +10,12 @@ const codingAgentPackage = JSON.parse(
 );
 
 describe("publish-only workflow", () => {
+	it("installs release dependencies without native lifecycle scripts", () => {
+		const installStep = workflow.match(/- name: Install dependencies[\s\S]*?(?=\n      - name: Build all workspaces)/)?.[0];
+		assert.ok(installStep, "expected dependency install step");
+		assert.match(installStep, /npm install --ignore-scripts --no-audit --no-fund/);
+	});
+
 	it("reuses the release validation instead of rerunning the full suite", () => {
 		const publishStep = workflow.match(/- name: Publish prepared version[\s\S]*?(?=\n      - name: Workflow summary)/)?.[0];
 		assert.ok(publishStep, "expected publish-only step");


### PR DESCRIPTION
## Problem

The npm release workflow ran dependency lifecycle scripts even though release validation only needs TypeScript and test dependencies. On the current Linux runner, Canvas had no compatible prebuild and its source fallback failed because `pangocairo` development headers are not installed.

Failed run: https://github.com/code-yeongyu/senpi/actions/runs/31675074971

## Fix

- Install release dependencies with `--ignore-scripts`.
- Add a workflow contract test for the exact install command.
- Record the workflow invariant in `.github/changes.md`.

Native artifacts remain explicitly rebuilt in the separate binary release workflow.

## Verification

- Focused workflow test — 3/3 passed.
- Root script suite — passed.
- `npm run check` — passed.
- Root workspace build — passed.
- `actionlint .github/workflows/publish-npm.yml` — passed.
- Exact no-script install — passed.
- No `v2026.8.13` tag or npm version exists.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip native lifecycle scripts during dependency install in the npm release workflow to keep release validation independent of native toolchains. Previously `npm install` ran package scripts (e.g., `canvas` build) and failed on missing `pangocairo`; now we install with `--ignore-scripts` so TypeScript and test dependencies install cleanly.

- Change: in `.github/workflows/publish-npm.yml`, the install step uses `npm install --ignore-scripts --no-audit --no-fund`.
- Test: `scripts/publish-workflow.test.mjs` asserts the exact no-script install command.
- Docs: record the workflow invariant in `.github/changes.md`.
- Scope: affects only the npm release workflow; native artifacts remain in the separate binary release workflow.
- Migration: none required. If any package relied on install-time scripts for release validation, move that logic into the build step or the binary workflow.

<sup>Written for commit 521b219b0b754688da3d45ad40f17b7edb4c1624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

