### PR TITLE
fix(deps): lock every Claude Agent SDK platform binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,109 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
       "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q=="
     },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "libc": [
+        "glibc"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "libc": [
+        "musl"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "libc": [
+        "glibc"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "libc": [
+        "musl"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@anthropic-ai/sandbox-runtime": {
       "version": "0.0.67",
       "license": "Apache-2.0",

--- a/scripts/claude-sdk-platform-lock.test.mjs
+++ b/scripts/claude-sdk-platform-lock.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+
+const root = join(import.meta.dirname, "..");
+const sdkLockPath = "packages/coding-agent/node_modules/@anthropic-ai/claude-agent-sdk";
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("Claude Agent SDK platform binaries", () => {
+	it("locks every native optional declared by the Claude Agent SDK", () => {
+		const lock = readJson(join(root, "package-lock.json"));
+		const sdk = lock.packages[sdkLockPath];
+		assert.ok(sdk, `${sdkLockPath} must be present in the root lock`);
+
+		for (const [packageName, version] of Object.entries(sdk.optionalDependencies)) {
+			const binary = lock.packages[`node_modules/${packageName}`];
+			assert.ok(
+				binary,
+				`${packageName} must be present in the root lock. CI installs with \`npm ci\`, which resolves ` +
+					"strictly from this file, so a missing entry leaves that platform without the Claude native " +
+					"binary and every claude-sdk-oauth test fails there with an empty transcript.",
+			);
+			assert.equal(binary.version, version);
+			assert.equal(binary.optional, true);
+			assert.match(binary.resolved, /^https:\/\/registry\.npmjs\.org\//u);
+			assert.match(binary.integrity, /^sha512-/u);
+		}
+	});
+
+	it("covers the platforms the executable resolver probes", () => {
+		const lock = readJson(join(root, "package-lock.json"));
+		const sdk = lock.packages[sdkLockPath];
+		const locked = new Set(Object.keys(sdk.optionalDependencies));
+
+		for (const platform of ["darwin-arm64", "darwin-x64", "linux-x64", "linux-x64-musl", "win32-x64"]) {
+			assert.ok(
+				locked.has(`@anthropic-ai/claude-agent-sdk-${platform}`),
+				`the SDK must still declare a ${platform} binary`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Six `claude-sdk-oauth` test files have been failing on `main` on ubuntu and windows since the
v0.84.1 sync. They were invisible until #849 restored the Rolldown bindings and let the Linux
jobs actually execute tests:

```
AssertionError: expected [] to deeply equal [ ObjectContaining{…}, …(1) ]
+ "errorMessage": "Claude native binary not found for linux-x64. Reinstall
  @anthropic-ai/claude-agent-sdk without --omit=optional, or set CLAUDE_CODE_EXECUTABLE."
```

Affected: `claude-sdk-oauth-auth-lane`, `claude-sdk-oauth-diagnostic-render`,
`claude-sdk-oauth-observability`, `claude-sdk-oauth-stream`,
`494-claude-sdk-oauth-installed-sdk-hook-stop`, `6784-claude-sdk-oauth-default-lane`.

## Root cause

Same defect class as #849, this time on the Claude SDK. `@anthropic-ai/claude-agent-sdk@0.3.220`
declares **8** platform binaries in `optionalDependencies`, but `package-lock.json` carried a
resolved entry for only **one** - `darwin-arm64`, the platform the lock was resolved on:

| | resolved lock entries |
|---|---|
| declared by the SDK | 8 |
| present before this PR | 1 (`darwin-arm64`) |

CI installs with `npm ci --ignore-scripts`, which resolves strictly from the lockfile, so Linux and
Windows runners get no native binary. `resolveClaudeCodeExecutable()`
(`builtin/claude-sdk-oauth/executable.ts`) then throws, the SDK query never starts, and every
assertion observes an empty transcript. macOS passed because its single entry existed.

The assertions themselves were never wrong - the subprocess simply never ran.

## Change

1. **Restores the 7 missing platform entries** at the already-pinned `0.3.220`, with the correct
   `os`/`cpu`/`libc` constraints so npm still resolves one binary per install target.
2. **Adds `scripts/claude-sdk-platform-lock.test.mjs`**, mirroring the existing
   `rolldown-platform-lock.test.mjs` guard, so a future lock refresh cannot silently drop them again.

Every restored `resolved` URL and `integrity` hash was verified against the npm registry before
committing - nothing hand-written. The lockfile patch is purely additive:

```
package-lock.json | 103 +++++++++++++++++++++++++++++++++++++++++++
1 file changed, 103 insertions(+)

added=7  removed=0  preexistingModified=0  otherTopLevelChanged=false
```

## Verification

- guard test: **RED** before the lockfile fix (`@anthropic-ai/claude-agent-sdk-darwin-x64 must be present in the root lock`) -> **GREEN** after
- the six affected files: **6 files / 47 tests passed**
- `node --test scripts/*.test.mjs`: **130 passed / 0 failed**
- `npm ci --ignore-scripts --dry-run`: rc=0
- platform coverage check: **8/8** entries valid (`resolved` + `integrity` + `optional`)
- root `npm run check`: rc=0 · changelog gate: PASS

CI on this PR is the real proof: those six files should now pass on ubuntu and windows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks all `@anthropic-ai/claude-agent-sdk` platform binaries in the root `package-lock.json` so `npm ci` resolves the correct native binary on Linux and Windows. Previously only `darwin-arm64` was locked, `resolveClaudeCodeExecutable()` threw on non-macOS, and six OAuth-related tests observed empty transcripts; all declared platforms are now present.

**Review / Rollout**
- Adds 7 missing optional entries at `0.3.220` (`darwin-x64`, `linux-arm64`, `linux-arm64-musl`, `linux-x64`, `linux-x64-musl`, `win32-arm64`, `win32-x64`) with `os`/`cpu`/`libc` constraints; runtime behavior unchanged beyond tests executing.
- Adds `scripts/claude-sdk-platform-lock.test.mjs` to fail fast if any platform binary drops from the lock.
- No migration required; to mirror CI locally, use `npm ci` instead of `npm install`.

<sup>Written for commit 370c3dee434a17d33b80144339698132f9f06a07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

