### PR TITLE
feat(codemode): give eval a bash-parity hard limit that notifies the agent

### DIFF
--- a/.agents/skills/senpi-qa/SKILL.md
+++ b/.agents/skills/senpi-qa/SKILL.md
@@ -152,6 +152,7 @@ node .agents/skills/senpi-qa/scripts/pty-drive.mjs --self-test --force-pipe
 | `scripts/mock-loop.mjs --with-tool` | full loop: two model turns served, bash tool ran, final text returned |
 | `scripts/mock-loop.mjs --with-mcp-tool <tool>` | full loop with a registered sandbox MCP stdio fixture proxy; fails if the requested `mcp_fx_tool_<n>` is not registered, invoked, and fed back to the model |
 | `scripts/mock-loop.mjs --with-eval-hard-limit` | full loop where a never-returning eval cell is killed by its wall-clock hard limit and the kill is reported back to the model |
+| `scripts/eval-hard-limit-rpc-qa.mjs --self-test` | RPC channel: a DETACHED eval cell killed by the hard limit injects its `<system-reminder>` kill notice into the model's next request (print mode cannot show this) |
 | `scripts/tui-smoke.mjs --self-test` | TUI boots, renders, accepts a keystroke, tears down; auth unchanged |
 | `scripts/cli-smoke.mjs --self-test` | `--help`/`--version`/`--list-models` work offline; unknown flag reported; auth unchanged |
 | `scripts/pty-drive.mjs --self-test` | PTY runtime backing the `terminal` tools: background line watch + peek, stdin steering, screen snapshot + resize, registry teardown (no orphans); auth unchanged |

--- a/.agents/skills/senpi-qa/SKILL.md
+++ b/.agents/skills/senpi-qa/SKILL.md
@@ -112,6 +112,7 @@ node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test
 node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test --api anthropic-messages
 node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool --api openai-responses
 node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-mcp-tool mcp_fx_tool_1 --tool-args '{"value":"ok"}'
+node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-eval-hard-limit --evidence eval-hard-limit
 node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario transient-recover
 node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario budget-exhaust
 node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario long-retry-after
@@ -150,6 +151,7 @@ node .agents/skills/senpi-qa/scripts/pty-drive.mjs --self-test --force-pipe
 | `scripts/mock-loop.mjs --self-test` | scripted marker returns through the real loop via the mock provider; retry error injection proves same-model recovery, retry-budget fallback, and long-retry-after fallback; zero real calls; auth unchanged |
 | `scripts/mock-loop.mjs --with-tool` | full loop: two model turns served, bash tool ran, final text returned |
 | `scripts/mock-loop.mjs --with-mcp-tool <tool>` | full loop with a registered sandbox MCP stdio fixture proxy; fails if the requested `mcp_fx_tool_<n>` is not registered, invoked, and fed back to the model |
+| `scripts/mock-loop.mjs --with-eval-hard-limit` | full loop where a never-returning eval cell is killed by its wall-clock hard limit and the kill is reported back to the model |
 | `scripts/tui-smoke.mjs --self-test` | TUI boots, renders, accepts a keystroke, tears down; auth unchanged |
 | `scripts/cli-smoke.mjs --self-test` | `--help`/`--version`/`--list-models` work offline; unknown flag reported; auth unchanged |
 | `scripts/pty-drive.mjs --self-test` | PTY runtime backing the `terminal` tools: background line watch + peek, stdin steering, screen snapshot + resize, registry teardown (no orphans); auth unchanged |

--- a/.agents/skills/senpi-qa/scripts/eval-hard-limit-rpc-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/eval-hard-limit-rpc-qa.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// senpi-qa driver for the eval hard limit on the DETACHED path.
+//
+// `--print` cannot prove this path: EvalNotifier suppresses injected notices in
+// print/json modes, and eval defaults to "error" timeout semantics there. RPC mode
+// (`mode: "rpc"`) is interactive as far as both are concerned, so it is the cheapest
+// real surface where a cell can detach AND its kill notice can reach the agent.
+//
+// Flow: model calls eval -> the cell outlives cellTimeoutSeconds and DETACHES ->
+// the wall-clock hard limit kills it -> the notice is injected as a user message ->
+// the agent starts a new turn, so the fake model's NEXT request body carries the
+// <system-reminder> naming the cell and the hard limit. That request body is the proof.
+//
+//   node .agents/skills/senpi-qa/scripts/eval-hard-limit-rpc-qa.mjs --self-test
+//   node .agents/skills/senpi-qa/scripts/eval-hard-limit-rpc-qa.mjs --self-test --evidence eval-hard-limit-rpc
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox } from "./lib/common.mjs";
+import { startFakeModelServer } from "./lib/fake-model-server.mjs";
+import { API_PRESETS, checkRealAuthUnchanged, hermeticEnv, writeMockModelsJson } from "./lib/mock-loop-support.mjs";
+import { RpcClient } from "./lib/rpc-client.mjs";
+
+const API = "openai-completions";
+const CELL_TIMEOUT_SECONDS = 2;
+const HARD_LIMIT_SECONDS = 5;
+const KILL_PHRASE = `${HARD_LIMIT_SECONDS}s hard limit`;
+const WAIT_TIMEOUT_MS = 120000;
+
+const argv = process.argv.slice(2);
+const evidenceSlug = argv.includes("--evidence") ? argv[argv.indexOf("--evidence") + 1] : undefined;
+
+function bodyOf(request) {
+	return request.raw ?? JSON.stringify(request.body ?? {});
+}
+
+/** The notice must arrive as an injected user message, not merely somewhere in the payload. */
+function carriesKillNotice(request) {
+	const messages = request.body?.messages;
+	if (!Array.isArray(messages)) return false;
+	return messages.some((message) => {
+		if (message.role !== "user") return false;
+		const parts = Array.isArray(message.content)
+			? message.content.map((part) => (typeof part?.text === "string" ? part.text : ""))
+			: [typeof message.content === "string" ? message.content : ""];
+		return parts.some((text) => text.includes(KILL_PHRASE) && text.includes("Detached eval cell"));
+	});
+}
+
+/** Bounded wait on an observable condition; never a blind sleep. */
+async function waitFor(predicate, { timeoutMs = WAIT_TIMEOUT_MS, label = "condition" } = {}) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const value = predicate();
+		if (value) return value;
+		await new Promise((resolve) => setTimeout(resolve, 250));
+	}
+	throw new Error(`timed out after ${timeoutMs}ms waiting for ${label}`);
+}
+
+async function selfTest() {
+	installCleanupHooks();
+	const checks = createChecks("eval-hard-limit-rpc-qa.mjs --self-test");
+	const guard = guardRealAuth();
+	const preset = API_PRESETS[API];
+	const box = makeSandbox("eval-hard-limit-rpc");
+	// Only the hard limit may end this cell: the detach window is short, the deadline is longer.
+	mkdirSync(join(box.cwd, ".senpi"), { recursive: true });
+	writeFileSync(
+		join(box.cwd, ".senpi", "codemode.json"),
+		JSON.stringify({ cellTimeoutSeconds: CELL_TIMEOUT_SECONDS, hardLimitSeconds: HARD_LIMIT_SECONDS }, null, 2),
+	);
+	const server = await startFakeModelServer({
+		turns: [
+			{
+				toolCalls: [
+					{
+						name: "eval",
+						args: {
+							language: "js",
+							code: "await new Promise(() => {});",
+							summary: "detach, then outlive the hard limit",
+							on_timeout: "detach",
+						},
+					},
+				],
+			},
+			{ text: "DETACH-ACK" },
+			{ text: "KILL-NOTICE-SEEN" },
+		],
+	});
+	writeMockModelsJson(box.agentDir, server, API);
+	const client = new RpcClient({
+		env: hermeticEnv(box.env),
+		cwd: box.cwd,
+		extraArgs: ["--provider", preset.provider, "--model", preset.modelId, "--no-extensions", "--approve"],
+	});
+	try {
+		await client.send({ type: "get_state" });
+		const ack = await client.send({ type: "prompt", message: "Run the scripted eval cell." });
+		checks.ok("RPC accepted the prompt", ack.success === true, JSON.stringify(ack.data ?? {}).slice(0, 120));
+
+		await waitFor(() => server.requests.length >= 2, { label: "the detached cell to return control to the model" });
+		checks.ok(
+			"cell detached instead of blocking the turn",
+			server.requests.length >= 2,
+			`requests=${server.requests.length}`,
+		);
+
+		const hit = await waitFor(
+			() => {
+				const index = server.requests.findIndex((request, i) => i >= 1 && carriesKillNotice(request));
+				return index >= 0 ? { index } : undefined;
+			},
+			{ label: `the "${KILL_PHRASE}" notice to reach the model` },
+		);
+		checks.ok(
+			"hard-limit kill notice reached the model as an injected user message",
+			hit.index >= 1,
+			`hitAt=request[${hit.index}] of ${server.requests.length}`,
+		);
+		checks.ok(
+			"notice names the cell and the configured deadline",
+			bodyOf(server.requests[hit.index]).includes(KILL_PHRASE),
+			KILL_PHRASE,
+		);
+
+		if (evidenceSlug !== undefined) {
+			const dir = evidenceDir(evidenceSlug);
+			writeFileSync(
+				join(dir, "rpc-request-bodies.json"),
+				JSON.stringify(
+					{
+						hitAt: hit.index,
+						cellTimeoutSeconds: CELL_TIMEOUT_SECONDS,
+						hardLimitSeconds: HARD_LIMIT_SECONDS,
+						requests: server.requests.map((request, index) => ({ index, url: request.url, raw: bodyOf(request) })),
+					},
+					null,
+					2,
+				),
+			);
+			writeFileSync(join(dir, "rpc-events.jsonl"), client.events.map((event) => JSON.stringify(event)).join("\n"));
+			process.stderr.write(`evidence: ${dir}\n`);
+		}
+	} finally {
+		client.close();
+		await server.stop();
+		checkRealAuthUnchanged(checks, guard);
+		box.cleanup();
+	}
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+if (argv[0] === "--self-test") {
+	selfTest().catch((error) => {
+		process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+		process.exit(1);
+	});
+} else {
+	process.stderr.write(
+		[
+			"senpi-qa — eval hard limit on the detached path (RPC channel)",
+			"  node eval-hard-limit-rpc-qa.mjs --self-test [--evidence <slug>]",
+			"",
+		].join("\n"),
+	);
+	process.exitCode = 2;
+}

--- a/.agents/skills/senpi-qa/scripts/lib/rpc-client.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/rpc-client.mjs
@@ -1,0 +1,101 @@
+// Shared JSON-lines RPC client over a spawned `--mode rpc` child.
+//
+// Lives in lib/ so scenario scripts can drive RPC without importing rpc-drive.mjs,
+// whose module body dispatches on argv the moment it is imported.
+import { spawnCli } from "./common.mjs";
+
+/**
+ * Minimal JSON-lines RPC client over a spawned `--mode rpc` child.
+ * Resolves send() promises by matching the response `id`; buffers events.
+ */
+export class RpcClient {
+	constructor({ env, cwd, extraArgs = [] } = {}) {
+		this.child = spawnCli(["--mode", "rpc", "--no-session", "--no-context-files", ...extraArgs], { env, cwd });
+		this.pending = new Map();
+		this.events = [];
+		this.eventWaiters = [];
+		this.responses = [];
+		this.seq = 0;
+		this._buf = "";
+		this.child.stdout.on("data", (chunk) => this._onData(chunk));
+		this.stderr = "";
+		this.child.stderr.on("data", (d) => {
+			this.stderr += d.toString();
+		});
+	}
+
+	_onData(chunk) {
+		this._buf += chunk.toString();
+		let nl;
+		while ((nl = this._buf.indexOf("\n")) >= 0) {
+			const line = this._buf.slice(0, nl).trim();
+			this._buf = this._buf.slice(nl + 1);
+			if (!line) continue;
+			let msg;
+			try {
+				msg = JSON.parse(line);
+			} catch {
+				continue; // non-protocol noise (tsx/startup) — ignore
+			}
+			if (msg && msg.type === "response") {
+				this.responses.push(msg);
+				const waiter = msg.id !== undefined ? this.pending.get(msg.id) : undefined;
+				if (waiter) {
+					this.pending.delete(msg.id);
+					waiter.resolve(msg);
+				}
+			} else if (msg && msg.type) {
+				this.events.push(msg);
+				for (const waiter of [...this.eventWaiters]) {
+					if (!waiter.pred(msg)) continue;
+					clearTimeout(waiter.timer);
+					this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
+					waiter.resolve(msg);
+				}
+			}
+		}
+	}
+
+	/** Send a command; resolves with the correlated response line. */
+	send(cmd, { timeoutMs = 45000 } = {}) {
+		const id = cmd.id ?? `req-${++this.seq}`;
+		const payload = { ...cmd, id };
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`RPC timeout after ${timeoutMs}ms for ${cmd.type} (stderr: ${this.stderr.slice(-400)})`));
+			}, timeoutMs);
+			this.pending.set(id, {
+				resolve: (m) => {
+					clearTimeout(timer);
+					resolve(m);
+				},
+			});
+			this.child.stdin.write(`${JSON.stringify(payload)}\n`);
+		});
+	}
+
+	/** Wait until an event matching `pred` is observed (or already was). */
+	waitForEvent(pred, { timeoutMs = 60000 } = {}) {
+		const found = this.events.find(pred);
+		if (found) return Promise.resolve(found);
+		return new Promise((resolve, reject) => {
+			const waiter = {
+				pred,
+				resolve,
+				timer: setTimeout(() => {
+					this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
+					reject(new Error(`event wait timeout after ${timeoutMs}ms`));
+				}, timeoutMs),
+			};
+			this.eventWaiters.push(waiter);
+		});
+	}
+
+	/** End stdin so the RPC process exits cleanly. */
+	close() {
+		try {
+			this.child.stdin.end();
+		} catch {}
+	}
+}

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -211,6 +211,47 @@ async function withTool(apiName) {
 	});
 }
 
+/**
+ * Eval hard limit: a cell that never returns must be killed by the wall-clock deadline and the
+ * kill must be reported back to the model. `cellTimeoutSeconds` is deliberately far larger than
+ * `hardLimitSeconds`, so only the hard limit can end this cell.
+ */
+async function withEvalHardLimit(apiName, evidenceSlug) {
+	const hardLimitSeconds = 3;
+	return withNamedTool({
+		apiName,
+		checkName: `mock-loop.mjs --with-eval-hard-limit (${apiName})`,
+		toolName: "eval",
+		toolArgs: {
+			language: "js",
+			code: "await new Promise(() => {});",
+			summary: "hang forever so the hard limit must kill this cell",
+		},
+		marker: "EVAL-HARD-LIMIT-OK-7f31",
+		extraArgs: ["--approve"],
+		prepareSandbox: (box) => {
+			const settingsDir = join(box.cwd, ".senpi");
+			mkdirSync(settingsDir, { recursive: true });
+			writeFileSync(
+				join(settingsDir, "codemode.json"),
+				JSON.stringify({ cellTimeoutSeconds: 600, hardLimitSeconds }, null, 2),
+			);
+			return { hardLimitSeconds };
+		},
+		validateToolResult: ({ server }) => {
+			const bodies = server.requests.map((request) => JSON.stringify(request.body ?? {}));
+			const killed = bodies.some((body) => body.includes("hard limit"));
+			const named = bodies.some((body) => body.includes(`${hardLimitSeconds}s hard limit`));
+			return {
+				name: `eval cell killed at the ${hardLimitSeconds}s hard limit and reported to the model`,
+				pass: killed && named,
+				detail: `requests=${server.requests.length} killed=${killed} named=${named}`,
+			};
+		},
+		evidenceSlug,
+	});
+}
+
 async function withReasoning(apiName, slow) {
 	installCleanupHooks();
 	const checks = createChecks(`mock-loop.mjs --with-reasoning${slow ? " --slow" : ""} (${apiName})`);
@@ -593,6 +634,11 @@ if (argv[0] === "--self-test") {
 		process.exit(2);
 	}
 	dispatchTextToolLeakCommand(leakApi, true, driveTurn, flagValue(argv, "--evidence"));
+} else if (argv[0] === "--with-eval-hard-limit") {
+	withEvalHardLimit(api || "openai-completions", flagValue(argv, "--evidence")).catch((e) => {
+		process.stderr.write(`${e instanceof Error ? e.stack : String(e)}\n`);
+		process.exit(1);
+	});
 } else if (argv[0] === "--with-mcp-tool") {
 	Promise.resolve()
 		.then(() => {
@@ -626,6 +672,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-reasoning --serve --serve-env <path> [--slow] [--api <name>]",
 			"  node mock-loop.mjs --with-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
+			"  node mock-loop.mjs --with-eval-hard-limit [--api <name>]  eval cell killed by the wall-clock hard limit",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
 			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|model-request-rejected-recover|ttsr-collapse|ttsr-leak|ttsr-repetitive-turns> [--api <name>]",
 			"  node mock-loop.mjs --scenario <hinted-429-in-turn|no-hint-429-fast-fallback|hinted-429-probe-back|no-hint-429-no-chain>",

--- a/.agents/skills/senpi-qa/scripts/rpc-drive.mjs
+++ b/.agents/skills/senpi-qa/scripts/rpc-drive.mjs
@@ -20,8 +20,11 @@
 
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox, spawnCli } from "./lib/common.mjs";
+import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox } from "./lib/common.mjs";
 import { startFakeModelServer } from "./lib/fake-model-server.mjs";
+import { RpcClient } from "./lib/rpc-client.mjs";
+
+export { RpcClient };
 import {
 	ALL_APIS,
 	API_PRESETS,
@@ -33,102 +36,6 @@ import {
 
 const SCENARIO_PROVIDER = "claude-sdk-oauth";
 const SCENARIO_MODEL_ID = "claude-sonnet-4-5";
-
-/**
- * Minimal JSON-lines RPC client over a spawned `--mode rpc` child.
- * Resolves send() promises by matching the response `id`; buffers events.
- */
-export class RpcClient {
-	constructor({ env, cwd, extraArgs = [] } = {}) {
-		this.child = spawnCli(["--mode", "rpc", "--no-session", "--no-context-files", ...extraArgs], { env, cwd });
-		this.pending = new Map();
-		this.events = [];
-		this.eventWaiters = [];
-		this.responses = [];
-		this.seq = 0;
-		this._buf = "";
-		this.child.stdout.on("data", (chunk) => this._onData(chunk));
-		this.stderr = "";
-		this.child.stderr.on("data", (d) => {
-			this.stderr += d.toString();
-		});
-	}
-
-	_onData(chunk) {
-		this._buf += chunk.toString();
-		let nl;
-		while ((nl = this._buf.indexOf("\n")) >= 0) {
-			const line = this._buf.slice(0, nl).trim();
-			this._buf = this._buf.slice(nl + 1);
-			if (!line) continue;
-			let msg;
-			try {
-				msg = JSON.parse(line);
-			} catch {
-				continue; // non-protocol noise (tsx/startup) — ignore
-			}
-			if (msg && msg.type === "response") {
-				this.responses.push(msg);
-				const waiter = msg.id !== undefined ? this.pending.get(msg.id) : undefined;
-				if (waiter) {
-					this.pending.delete(msg.id);
-					waiter.resolve(msg);
-				}
-			} else if (msg && msg.type) {
-				this.events.push(msg);
-				for (const waiter of [...this.eventWaiters]) {
-					if (!waiter.pred(msg)) continue;
-					clearTimeout(waiter.timer);
-					this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
-					waiter.resolve(msg);
-				}
-			}
-		}
-	}
-
-	/** Send a command; resolves with the correlated response line. */
-	send(cmd, { timeoutMs = 45000 } = {}) {
-		const id = cmd.id ?? `req-${++this.seq}`;
-		const payload = { ...cmd, id };
-		return new Promise((resolve, reject) => {
-			const timer = setTimeout(() => {
-				this.pending.delete(id);
-				reject(new Error(`RPC timeout after ${timeoutMs}ms for ${cmd.type} (stderr: ${this.stderr.slice(-400)})`));
-			}, timeoutMs);
-			this.pending.set(id, {
-				resolve: (m) => {
-					clearTimeout(timer);
-					resolve(m);
-				},
-			});
-			this.child.stdin.write(`${JSON.stringify(payload)}\n`);
-		});
-	}
-
-	/** Wait until an event matching `pred` is observed (or already was). */
-	waitForEvent(pred, { timeoutMs = 60000 } = {}) {
-		const found = this.events.find(pred);
-		if (found) return Promise.resolve(found);
-		return new Promise((resolve, reject) => {
-			const waiter = {
-				pred,
-				resolve,
-				timer: setTimeout(() => {
-					this.eventWaiters.splice(this.eventWaiters.indexOf(waiter), 1);
-					reject(new Error(`event wait timeout after ${timeoutMs}ms`));
-				}, timeoutMs),
-			};
-			this.eventWaiters.push(waiter);
-		});
-	}
-
-	/** End stdin so the RPC process exits cleanly. */
-	close() {
-		try {
-			this.child.stdin.end();
-		} catch {}
-	}
-}
 
 async function selfTest() {
 	installCleanupHooks();

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Gave every eval cell a wall-clock hard limit (`hardLimitSeconds`, default 1800s, overridable with `SENPI_CODEMODE_HARD_LIMIT_SECONDS`) so a detached or tool-call-heavy cell can no longer run unbounded: the deadline survives `detach()` and is never paused by bridge tool calls, and a cell it kills reports itself to the agent as killed at the hard limit ([#857](https://github.com/code-yeongyu/senpi/pull/857)).
+
 ### Changed
 
 ### Fixed

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,34 @@
 # senpi-codemode fork changes
 
+## Eval cell hard limit (2026-08-13)
+
+### What changed
+
+- A cell now carries a wall-clock kill deadline resolved from the new `hardLimitSeconds` setting
+  (default 1800s, `SENPI_CODEMODE_HARD_LIMIT_SECONDS` override), raised per call by an explicit
+  larger `timeout`.
+- `EvalDetachedCellManager` arms that deadline when the cell is created and clears it only on
+  settlement, so it survives `detach()` and is never paused by bridge tool calls. On expiry the cell
+  is interrupted, settles as cancelled, and the detached-cell notification tells the main agent it
+  was killed at the hard limit.
+
+### Why
+
+- `cellTimeoutSeconds` only feeds the idle watchdog: `CellExecution.detach()` disposes that watchdog
+  and `withBridgeTimeoutPause` pauses it for the whole duration of every host tool call, so a
+  detached or tool-call-heavy cell had no upper bound at all — one observed cell ran 1h13m. The bash
+  tool has enforced a kill deadline since `bash-timeout/timeout.ts`; eval now matches it.
+
+### Why this cannot be expressed externally
+
+- Cell lifetime, kernel interruption, and the detached-cell notification queue all live inside the
+  package; an extension cannot observe a detached cell, let alone kill it.
+
+### Expected merge conflict zones
+
+- MEDIUM in `src/tool/detached-cell-manager.ts` around cell creation and settlement.
+- LOW in `src/config/settings.ts` schema/defaults and the prompt timeout wording.
+
 ## Compiled binary runner sidecar resolution (2026-08-11)
 
 ### What changed

--- a/packages/senpi-codemode/src/config/settings.ts
+++ b/packages/senpi-codemode/src/config/settings.ts
@@ -19,6 +19,7 @@ export const codemodeSettingsSchema = Type.Object(
 			),
 		),
 		cellTimeoutSeconds: Type.Optional(Type.Number({ minimum: 1 })),
+		hardLimitSeconds: Type.Optional(Type.Number({ minimum: 1 })),
 		parallelPoolWidth: Type.Optional(Type.Number({ minimum: 1 })),
 		taskTools: Type.Optional(
 			Type.Object(
@@ -63,6 +64,8 @@ export interface CodemodeSettings {
 		readonly jl: boolean;
 	};
 	readonly cellTimeoutSeconds: number;
+	/** Wall-clock kill deadline for a single cell; bounds detached cells too. */
+	readonly hardLimitSeconds: number;
 	readonly parallelPoolWidth: number;
 	readonly taskTools?: CodemodeTaskTools;
 	readonly outputSink?: CodemodeOutputSink;
@@ -86,6 +89,15 @@ export interface LoadedCodemodeSettings {
 	readonly warnings: readonly string[];
 }
 
+/**
+ * Bash parity: `bash-timeout/timeout.ts` kills a command at 1800s. An eval cell gets the same
+ * unconditional wall-clock kill deadline, which — unlike `cellTimeoutSeconds` — is neither paused by
+ * host tool calls nor discarded when the cell detaches.
+ */
+export const DEFAULT_HARD_LIMIT_SECONDS = 1800;
+
+export const HARD_LIMIT_ENVIRONMENT_FLAG = "SENPI_CODEMODE_HARD_LIMIT_SECONDS";
+
 // OMP settings-schema.ts:3211-3299 has language/path settings only; eval.ts:427
 // defaults timeout to 30s, and codemode pins concurrency-bridge.ts:30 width to 4.
 export const defaultCodemodeSettings: ResolvedCodemodeSettings = {
@@ -96,6 +108,7 @@ export const defaultCodemodeSettings: ResolvedCodemodeSettings = {
 		jl: false,
 	},
 	cellTimeoutSeconds: 30,
+	hardLimitSeconds: DEFAULT_HARD_LIMIT_SECONDS,
 	parallelPoolWidth: 4,
 	taskTools: {
 		task: "task",
@@ -144,6 +157,15 @@ export function resolveEnabledLanguages(
 	};
 }
 
+/** Environment override wins over the settings file; a non-positive or malformed value is ignored. */
+export function resolveHardLimitSeconds(settings: CodemodeSettings, env: Environment = process.env): number {
+	const override = env[HARD_LIMIT_ENVIRONMENT_FLAG];
+	if (override === undefined) return settings.hardLimitSeconds;
+	const parsed = Number.parseInt(override, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return settings.hardLimitSeconds;
+	return parsed;
+}
+
 async function loadSettingsFile(path: string): Promise<LoadedCodemodeSettings> {
 	const raw = await readFile(path, "utf8");
 	let parsed: unknown;
@@ -178,6 +200,7 @@ function mergeSettings(input: CodemodeSettingsInput): ResolvedCodemodeSettings {
 			jl: input.languages?.jl ?? defaultCodemodeSettings.languages.jl,
 		},
 		cellTimeoutSeconds: input.cellTimeoutSeconds ?? defaultCodemodeSettings.cellTimeoutSeconds,
+		hardLimitSeconds: input.hardLimitSeconds ?? defaultCodemodeSettings.hardLimitSeconds,
 		parallelPoolWidth: input.parallelPoolWidth ?? defaultCodemodeSettings.parallelPoolWidth,
 		taskTools: {
 			task: input.taskTools?.task ?? defaultCodemodeSettings.taskTools.task,

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -3,7 +3,7 @@ import type { ExtensionContext } from "@code-yeongyu/senpi";
 import type { AgentExecuteTool } from "./bridges/agent-bridge.ts";
 import type { EvalSchemaToolInfo } from "./bridges/schema-bridge.ts";
 import { type CompletionRequest, type CompletionResult, createCompletionHandler } from "./completion/handler.ts";
-import { defaultCodemodeSettings } from "./config/settings.ts";
+import { defaultCodemodeSettings, resolveHardLimitSeconds } from "./config/settings.ts";
 import { EvalNotifier } from "./extension/eval-notifier.ts";
 import { EVAL_CELLS_STATUS_KEY } from "./extension/eval-status.ts";
 import { EvalStatusTicker } from "./extension/eval-status-ticker.ts";
@@ -131,6 +131,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			settings: defaultCodemodeSettings,
 			cellManager: new EvalDetachedCellManager({
 				notifier,
+				hardLimitSeconds: resolveHardLimitSeconds(defaultCodemodeSettings),
 				onStatusChange: showDetachedCells,
 				onWakeSourceState: emitWakeSourceState,
 				...(options.now === undefined ? {} : { now: options.now }),
@@ -162,6 +163,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		const cellManager = new EvalDetachedCellManager({
 			artifactsDir: runtime.artifactsDir,
 			notifier,
+			hardLimitSeconds: resolveHardLimitSeconds(runtime.settings),
 			onStatusChange: showDetachedCells,
 			onWakeSourceState: emitWakeSourceState,
 			...(options.now === undefined ? {} : { now: options.now }),

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -125,6 +125,7 @@ Fields:
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long{{#if spawns}} non-agent{{/if}} tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { DEFAULT_HARD_LIMIT_SECONDS } from "../config/settings.ts";
 import { SENPI_CODEMODE_WAKE_SOURCE, type WakeSourceState } from "../extension/wake-source-state.ts";
 import { detachedNotificationSpillPath } from "./detached-cell-notification.ts";
 import { currentDetachedResult, detachedErrorResult, snapshotDetachedCell } from "./detached-cell-snapshot.ts";
@@ -28,6 +29,10 @@ type ManagedCell = {
 	liveResult: LiveResultProvider | undefined;
 	terminalResult: AgentToolResult<EvalToolDetails> | undefined;
 	notificationQueued: boolean;
+	hardLimitSeconds: number;
+	hardLimitTimer: ReturnType<typeof setTimeout> | undefined;
+	hardLimited: boolean;
+	onHardLimit: ((error: Error) => void) | undefined;
 };
 
 export interface EvalDetachedCellSnapshot {
@@ -37,6 +42,8 @@ export interface EvalDetachedCellSnapshot {
 	readonly outputTail: string;
 	readonly result: AgentToolResult<EvalToolDetails>;
 	readonly stateRetained: boolean | undefined;
+	/** Set only when the wall-clock kill deadline ended this cell. */
+	readonly hardLimitSeconds?: number;
 }
 
 export interface EvalDetachedCellNotification {
@@ -58,10 +65,18 @@ export interface EvalDetachedCellStatusEntry {
 export interface EvalDetachedCellManagerOptions {
 	readonly artifactsDir?: string;
 	readonly notifier?: EvalDetachedCellNotifier;
+	/** Wall-clock kill deadline in seconds; defaults to the bash-parity 1800s. */
+	readonly hardLimitSeconds?: number;
 	readonly onStatusChange?: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
 	/** Receives a full per-source liveness snapshot on every detached-cell transition; used by the goal builtin. */
 	readonly onWakeSourceState?: (state: WakeSourceState) => void;
 	readonly now?: () => number;
+}
+
+export function hardLimitError(cellId: string, hardLimitSeconds: number): Error {
+	const error = new Error(`Eval cell ${cellId} was killed at the ${hardLimitSeconds}s hard limit.`);
+	error.name = "TimeoutError";
+	return error;
 }
 
 export class EvalDetachedCellManager {
@@ -72,6 +87,7 @@ export class EvalDetachedCellManager {
 	readonly #detachedByLanguage = new Map<EvalLanguage, ManagedCell>();
 	readonly #notificationQueue: DetachedNotificationQueue;
 	readonly #now: () => number;
+	readonly #hardLimitSeconds: number;
 
 	constructor(options: EvalDetachedCellManagerOptions = {}) {
 		this.#artifactsDir = options.artifactsDir;
@@ -79,6 +95,7 @@ export class EvalDetachedCellManager {
 		this.#onWakeSourceState = options.onWakeSourceState;
 		this.#notificationQueue = new DetachedNotificationQueue(options.notifier, options.artifactsDir);
 		this.#now = options.now ?? Date.now;
+		this.#hardLimitSeconds = options.hardLimitSeconds ?? DEFAULT_HARD_LIMIT_SECONDS;
 	}
 
 	create(cellId: string, input: EvalToolInput): ManagedCell {
@@ -100,14 +117,27 @@ export class EvalDetachedCellManager {
 			liveResult: undefined,
 			terminalResult: undefined,
 			notificationQueued: false,
+			// An explicit longer per-call timeout raises the deadline, mirroring bash keeping explicit timeouts.
+			hardLimitSeconds: Math.max(this.#hardLimitSeconds, input.timeout ?? 0),
+			hardLimitTimer: undefined,
+			hardLimited: false,
+			onHardLimit: undefined,
 			terminal: Promise.withResolvers<EvalDetachedCellSnapshot>(),
 		};
 		this.#cells.set(cellId, cell);
+		this.#armHardLimit(cell);
 		return cell;
 	}
 
-	markRunning(cell: ManagedCell, kernel: EvalKernel, liveResult: LiveResultProvider): void {
+	markRunning(
+		cell: ManagedCell,
+		kernel: EvalKernel,
+		liveResult: LiveResultProvider,
+		/** Foreground killer: the still-awaited CellExecution owns interrupting and rejecting its own call. */
+		onHardLimit?: (error: Error) => void,
+	): void {
 		if (cell.state !== "running") return;
+		cell.onHardLimit = onHardLimit;
 		cell.kernel = kernel;
 		cell.liveResult = liveResult;
 		cell.canDetach = true;
@@ -179,6 +209,7 @@ export class EvalDetachedCellManager {
 		result: AgentToolResult<EvalToolDetails>,
 	): boolean {
 		if (!allowsDetachedCellTransition(cell.state, state)) return false;
+		this.#clearHardLimit(cell);
 		cell.state = state;
 		cell.terminalResult = result;
 		cell.liveResult = undefined;
@@ -196,6 +227,37 @@ export class EvalDetachedCellManager {
 			}
 		}
 		return true;
+	}
+
+	#armHardLimit(cell: ManagedCell): void {
+		const timer = setTimeout(() => void this.#expireHardLimit(cell), cell.hardLimitSeconds * 1_000);
+		timer.unref?.();
+		cell.hardLimitTimer = timer;
+	}
+
+	#clearHardLimit(cell: ManagedCell): void {
+		if (cell.hardLimitTimer === undefined) return;
+		clearTimeout(cell.hardLimitTimer);
+		cell.hardLimitTimer = undefined;
+	}
+
+	/**
+	 * The wall-clock kill deadline. Unlike the idle watchdog it is never paused by a bridge tool call and
+	 * survives detach, so it is the only bound a detached cell has.
+	 */
+	async #expireHardLimit(cell: ManagedCell): Promise<void> {
+		if (!detachedCellIsActive(cell.state)) return;
+		const foreground = cell.state === "running" && cell.onHardLimit !== undefined;
+		cell.hardLimited = true;
+		const error = hardLimitError(cell.cellId, cell.hardLimitSeconds);
+		if (!this.#settle(cell, "cancelled", currentDetachedResult(cell))) return;
+		if (foreground) {
+			cell.onHardLimit?.(error);
+			return;
+		}
+		if (cell.kernel === undefined) return;
+		const handle = await cell.kernel.interrupt(error.message);
+		cell.stateRetained = await handle.stateRetained;
 	}
 
 	#emitStatus(): void {

--- a/packages/senpi-codemode/src/tool/detached-cell-notification.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-notification.ts
@@ -66,6 +66,7 @@ function textContent(cell: EvalDetachedCellSnapshot): string {
 }
 
 function outcomeOf(cell: EvalDetachedCellSnapshot): string {
+	if (cell.hardLimitSeconds !== undefined) return `was killed at the ${cell.hardLimitSeconds}s hard limit`;
 	if (cell.state === "completed") return "completed";
 	if (cell.state === "cancelled") return "cancelled";
 	return "failed";

--- a/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
@@ -12,6 +12,8 @@ export interface DetachedCellResultSource {
 	stateRetained: boolean | undefined;
 	liveResult: (() => AgentToolResult<EvalToolDetails>) | undefined;
 	terminalResult: AgentToolResult<EvalToolDetails> | undefined;
+	hardLimited?: boolean;
+	hardLimitSeconds?: number;
 }
 
 export function snapshotDetachedCell(cell: DetachedCellResultSource, nowMs: number): EvalDetachedCellSnapshot {
@@ -24,6 +26,9 @@ export function snapshotDetachedCell(cell: DetachedCellResultSource, nowMs: numb
 		outputTail: detachedOutputTail(result),
 		result,
 		stateRetained: cell.stateRetained,
+		...(cell.hardLimited === true && cell.hardLimitSeconds !== undefined
+			? { hardLimitSeconds: cell.hardLimitSeconds }
+			: {}),
 	};
 }
 

--- a/packages/senpi-codemode/src/tool/eval-tool-options.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool-options.ts
@@ -19,6 +19,8 @@ export interface CreateEvalToolOptions {
 	readonly enabledLanguages: EnabledEvalLanguages;
 	readonly kernelManager: EvalKernelManager;
 	readonly cellTimeoutSeconds: number;
+	/** Wall-clock kill deadline applied to every cell; only used when this factory creates its own manager. */
+	readonly hardLimitSeconds?: number;
 	readonly executeTool: ExecuteTool;
 	readonly listTools?: () => readonly EvalSchemaToolInfo[];
 	readonly complete?: (request: CompletionRequest, ctx: ExtensionContext) => Promise<CompletionResult>;

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -32,7 +32,12 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 		...(options.hostLine === undefined ? {} : { hostLine: options.hostLine }),
 	});
 	const languages = enabledLanguageList(options.enabledLanguages);
-	const cellManager = options.cellManager ?? new EvalDetachedCellManager({ artifactsDir: options.artifactsDir });
+	const cellManager =
+		options.cellManager ??
+		new EvalDetachedCellManager({
+			...(options.artifactsDir === undefined ? {} : { artifactsDir: options.artifactsDir }),
+			...(options.hardLimitSeconds === undefined ? {} : { hardLimitSeconds: options.hardLimitSeconds }),
+		});
 	return {
 		name: "eval",
 		label: "Eval",
@@ -194,7 +199,12 @@ async function executeCell(
 			...(options.imageResizer === undefined ? {} : { imageResizer: options.imageResizer }),
 		});
 		handler = activeHandler;
-		cellManager.markRunning(cell, kernel, () => activeHandler.liveResult());
+		cellManager.markRunning(
+			cell,
+			kernel,
+			() => activeHandler.liveResult(),
+			(error) => execution.cancel(error),
+		);
 		if ("setContext" in options.kernelManager && typeof options.kernelManager.setContext === "function") {
 			options.kernelManager.setContext(bridgeContext);
 		}

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -21,6 +21,7 @@ Fields:
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long non-agent tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
@@ -141,6 +142,7 @@ Fields:
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
@@ -216,6 +218,7 @@ Fields:
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
 - \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
 - \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 

--- a/packages/senpi-codemode/test/config.test.ts
+++ b/packages/senpi-codemode/test/config.test.ts
@@ -2,7 +2,12 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { defaultCodemodeSettings, loadCodemodeSettings, resolveEnabledLanguages } from "../src/config/settings.ts";
+import {
+	defaultCodemodeSettings,
+	loadCodemodeSettings,
+	resolveEnabledLanguages,
+	resolveHardLimitSeconds,
+} from "../src/config/settings.ts";
 
 describe("codemode settings", () => {
 	it("uses project config before global config before defaults", async () => {
@@ -29,6 +34,7 @@ describe("codemode settings", () => {
 			expect(loaded.settings).toEqual({
 				languages: { py: false, js: true, rb: true, jl: false },
 				cellTimeoutSeconds: 30,
+				hardLimitSeconds: 1800,
 				parallelPoolWidth: 9,
 				taskTools: { task: "task", output: "task_output" },
 				outputSink: { headBytes: 20480, maxColumns: 768 },
@@ -57,6 +63,7 @@ describe("codemode settings", () => {
 			expect(loaded.settings).toEqual({
 				languages: { py: true, js: false, rb: false, jl: true },
 				cellTimeoutSeconds: 12,
+				hardLimitSeconds: 1800,
 				parallelPoolWidth: 4,
 				taskTools: { task: "task", output: "task_output" },
 				outputSink: { headBytes: 20480, maxColumns: 768 },
@@ -180,6 +187,49 @@ describe("codemode settings", () => {
 			expect(invalid.warnings[0]).toContain("Invalid codemode settings");
 		} finally {
 			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("defaults hardLimitSeconds to the bash-parity kill deadline", async () => {
+		const root = await mkdtemp(join(tmpdir(), "senpi-codemode-config-"));
+		try {
+			const loaded = await loadCodemodeSettings({ cwd: join(root, "project"), homeDir: join(root, "home") });
+
+			expect(loaded.settings.hardLimitSeconds).toBe(1800);
+			expect(defaultCodemodeSettings.hardLimitSeconds).toBe(1800);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reads hardLimitSeconds from the settings file", async () => {
+		const root = await mkdtemp(join(tmpdir(), "senpi-codemode-config-"));
+		try {
+			const projectDir = join(root, "project");
+			await mkdir(join(projectDir, ".senpi"), { recursive: true });
+			await writeFile(join(projectDir, ".senpi", "codemode.json"), JSON.stringify({ hardLimitSeconds: 90 }));
+
+			const loaded = await loadCodemodeSettings({ cwd: projectDir, homeDir: join(root, "home") });
+
+			expect(loaded.warnings).toEqual([]);
+			expect(loaded.settings.hardLimitSeconds).toBe(90);
+			expect(resolveHardLimitSeconds(loaded.settings, {})).toBe(90);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("lets the environment override beat the settings file hard limit", () => {
+		const settings = { ...defaultCodemodeSettings, hardLimitSeconds: 90 };
+
+		expect(resolveHardLimitSeconds(settings, { SENPI_CODEMODE_HARD_LIMIT_SECONDS: "45" })).toBe(45);
+	});
+
+	it("ignores a non-positive or malformed hard limit environment value", () => {
+		const settings = { ...defaultCodemodeSettings, hardLimitSeconds: 90 };
+
+		for (const value of ["0", "-5", "abc", ""]) {
+			expect(resolveHardLimitSeconds(settings, { SENPI_CODEMODE_HARD_LIMIT_SECONDS: value })).toBe(90);
 		}
 	});
 });

--- a/packages/senpi-codemode/test/eval-hard-limit.test.ts
+++ b/packages/senpi-codemode/test/eval-hard-limit.test.ts
@@ -1,0 +1,189 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager, type EvalDetachedCellNotification } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { EvalToolDetails } from "../src/tool/types.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+class NotificationRecorder {
+	readonly batches: EvalDetachedCellNotification[][] = [];
+
+	notify(cells: readonly EvalDetachedCellNotification[]): void {
+		this.batches.push([...cells]);
+	}
+
+	get notices(): EvalDetachedCellNotification[] {
+		return this.batches.flat();
+	}
+}
+
+function liveResultFor(cellId: string, output: string): () => AgentToolResult<EvalToolDetails> {
+	return () => ({
+		content: [{ type: "text", text: output }],
+		details: {
+			language: "js",
+			languages: ["js"],
+			durationMs: 0,
+			toolCalls: [],
+			truncated: false,
+			cells: [{ index: 0, code: "await forever", language: "js", output, status: "running", durationMs: 0 }],
+		},
+	});
+}
+
+function input(overrides: { timeout?: number } = {}) {
+	return {
+		language: "js" as const,
+		code: "await forever",
+		summary: "long running cell",
+		...(overrides.timeout === undefined ? {} : { timeout: overrides.timeout }),
+	};
+}
+
+describe("eval hard limit", () => {
+	it("kills a detached cell that outlives the hard limit", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2 });
+		const kernel = new FakeKernel([]);
+		const cell = manager.create("runaway-cell", input());
+		manager.markRunning(cell, kernel, liveResultFor("runaway-cell", "still computing"));
+		manager.detach(cell);
+
+		await vi.advanceTimersByTimeAsync(1_999);
+		expect(kernel.interrupts).toEqual([]);
+		expect(manager.peek("runaway-cell").state).toBe("detached");
+
+		await vi.advanceTimersByTimeAsync(1);
+
+		expect(kernel.interrupts).toHaveLength(1);
+		expect(manager.peek("runaway-cell").state).toBe("cancelled");
+		expect(manager.peek("runaway-cell").hardLimitSeconds).toBe(2);
+		expect(manager.busyFor("js")).toBeUndefined();
+	});
+
+	it("tells the main agent the cell was killed by the hard limit", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2, notifier: recorder });
+		const kernel = new FakeKernel([]);
+		const cell = manager.create("notified-cell", input());
+		manager.markRunning(cell, kernel, liveResultFor("notified-cell", "buffered print"));
+		manager.detach(cell);
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await manager.flushNotifications();
+
+		expect(recorder.notices).toHaveLength(1);
+		const content = recorder.notices[0]?.content ?? "";
+		expect(recorder.notices[0]?.cellId).toBe("notified-cell");
+		expect(content).toContain("notified-cell");
+		expect(content).toContain("hard limit");
+		expect(content).toContain("buffered print");
+	});
+
+	it("kills a cell whose idle watchdog is paused by bridge tool calls", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2 });
+		const kernel = new FakeKernel([]);
+		const killed: Error[] = [];
+		const cell = manager.create("bridge-bound-cell", input());
+		manager.markRunning(cell, kernel, liveResultFor("bridge-bound-cell", "tool calls"), (error) =>
+			killed.push(error),
+		);
+
+		await vi.advanceTimersByTimeAsync(2_000);
+
+		expect(killed).toHaveLength(1);
+		expect(killed[0]?.message).toContain("hard limit");
+		expect(killed[0]?.message).toContain("bridge-bound-cell");
+		expect(manager.peek("bridge-bound-cell").state).toBe("cancelled");
+		// The still-awaited CellExecution owns interrupting the kernel and rejecting its own tool call,
+		// so the manager must not fire a second interrupt at it.
+		expect(kernel.interrupts).toEqual([]);
+	});
+
+	it("kills a foreground cell itself when no execution owns it yet", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2 });
+		const kernel = new FakeKernel([]);
+		const cell = manager.create("orphan-cell", input());
+		manager.markRunning(cell, kernel, liveResultFor("orphan-cell", "booted"));
+
+		await vi.advanceTimersByTimeAsync(2_000);
+
+		expect(kernel.interrupts).toHaveLength(1);
+		expect(kernel.interrupts[0]).toContain("hard limit");
+		expect(manager.peek("orphan-cell").state).toBe("cancelled");
+	});
+
+	it("never kills a cell that settles before the limit", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2, notifier: recorder });
+		const kernel = new FakeKernel([]);
+		const cell = manager.create("fast-cell", input());
+		manager.markRunning(cell, kernel, liveResultFor("fast-cell", "done"));
+		manager.detach(cell);
+		manager.complete(cell, liveResultFor("fast-cell", "done")());
+
+		await vi.advanceTimersByTimeAsync(10_000);
+		await manager.flushNotifications();
+
+		expect(kernel.interrupts).toEqual([]);
+		expect(manager.peek("fast-cell").state).toBe("completed");
+		expect(manager.peek("fast-cell").hardLimitSeconds).toBeUndefined();
+		expect(recorder.notices).toHaveLength(1);
+		expect(recorder.notices[0]?.content).not.toContain("hard limit");
+	});
+
+	it("lets an explicit longer timeout raise the effective hard limit", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2 });
+		const kernel = new FakeKernel([]);
+		const cell = manager.create("explicit-cell", input({ timeout: 5 }));
+		manager.markRunning(cell, kernel, liveResultFor("explicit-cell", "long by request"));
+		manager.detach(cell);
+
+		await vi.advanceTimersByTimeAsync(4_999);
+		expect(kernel.interrupts).toEqual([]);
+
+		await vi.advanceTimersByTimeAsync(1);
+
+		expect(kernel.interrupts).toHaveLength(1);
+		expect(manager.peek("explicit-cell").hardLimitSeconds).toBe(5);
+	});
+
+	it("delivers the hard-limit notice through the real eval tool path", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 3, notifier: recorder });
+		const kernel = new FakeKernel([{ type: "text", stream: "stdout", data: "partial output\n" }]);
+		const tool = createEvalTool({
+			enabledLanguages: { js: true, py: false, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", kernel]]),
+			cellTimeoutSeconds: 1,
+			executeTool: vi.fn(),
+			cellManager: manager,
+		});
+		const started = kernel.deferNextRun();
+		const execution = tool.execute("tool-path-cell", { ...input(), on_timeout: "detach" }, undefined, undefined, {
+			...fakeExtensionContext(),
+			mode: "tui" as const,
+		});
+		await started;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+		expect(manager.peek("tool-path-cell").state).toBe("detached");
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await manager.flushNotifications();
+
+		expect(manager.peek("tool-path-cell").state).toBe("cancelled");
+		expect(recorder.notices[0]?.content).toContain("hard limit");
+		expect(recorder.notices[0]?.content).toContain("partial output");
+	});
+});

--- a/packages/senpi-codemode/test/eval-hard-limit.test.ts
+++ b/packages/senpi-codemode/test/eval-hard-limit.test.ts
@@ -21,7 +21,7 @@ class NotificationRecorder {
 	}
 }
 
-function liveResultFor(cellId: string, output: string): () => AgentToolResult<EvalToolDetails> {
+function liveResultFor(output: string): () => AgentToolResult<EvalToolDetails> {
 	return () => ({
 		content: [{ type: "text", text: output }],
 		details: {
@@ -50,7 +50,7 @@ describe("eval hard limit", () => {
 		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2 });
 		const kernel = new FakeKernel([]);
 		const cell = manager.create("runaway-cell", input());
-		manager.markRunning(cell, kernel, liveResultFor("runaway-cell", "still computing"));
+		manager.markRunning(cell, kernel, liveResultFor("still computing"));
 		manager.detach(cell);
 
 		await vi.advanceTimersByTimeAsync(1_999);
@@ -71,7 +71,7 @@ describe("eval hard limit", () => {
 		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2, notifier: recorder });
 		const kernel = new FakeKernel([]);
 		const cell = manager.create("notified-cell", input());
-		manager.markRunning(cell, kernel, liveResultFor("notified-cell", "buffered print"));
+		manager.markRunning(cell, kernel, liveResultFor("buffered print"));
 		manager.detach(cell);
 
 		await vi.advanceTimersByTimeAsync(2_000);
@@ -91,9 +91,7 @@ describe("eval hard limit", () => {
 		const kernel = new FakeKernel([]);
 		const killed: Error[] = [];
 		const cell = manager.create("bridge-bound-cell", input());
-		manager.markRunning(cell, kernel, liveResultFor("bridge-bound-cell", "tool calls"), (error) =>
-			killed.push(error),
-		);
+		manager.markRunning(cell, kernel, liveResultFor("tool calls"), (error) => killed.push(error));
 
 		await vi.advanceTimersByTimeAsync(2_000);
 
@@ -111,7 +109,7 @@ describe("eval hard limit", () => {
 		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2 });
 		const kernel = new FakeKernel([]);
 		const cell = manager.create("orphan-cell", input());
-		manager.markRunning(cell, kernel, liveResultFor("orphan-cell", "booted"));
+		manager.markRunning(cell, kernel, liveResultFor("booted"));
 
 		await vi.advanceTimersByTimeAsync(2_000);
 
@@ -126,9 +124,9 @@ describe("eval hard limit", () => {
 		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2, notifier: recorder });
 		const kernel = new FakeKernel([]);
 		const cell = manager.create("fast-cell", input());
-		manager.markRunning(cell, kernel, liveResultFor("fast-cell", "done"));
+		manager.markRunning(cell, kernel, liveResultFor("done"));
 		manager.detach(cell);
-		manager.complete(cell, liveResultFor("fast-cell", "done")());
+		manager.complete(cell, liveResultFor("done")());
 
 		await vi.advanceTimersByTimeAsync(10_000);
 		await manager.flushNotifications();
@@ -145,7 +143,7 @@ describe("eval hard limit", () => {
 		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2 });
 		const kernel = new FakeKernel([]);
 		const cell = manager.create("explicit-cell", input({ timeout: 5 }));
-		manager.markRunning(cell, kernel, liveResultFor("explicit-cell", "long by request"));
+		manager.markRunning(cell, kernel, liveResultFor("long by request"));
 		manager.detach(cell);
 
 		await vi.advanceTimersByTimeAsync(4_999);

--- a/packages/senpi-codemode/test/eval-notifier.test.ts
+++ b/packages/senpi-codemode/test/eval-notifier.test.ts
@@ -1,7 +1,12 @@
 import type { Api, Model } from "@earendil-works/pi-ai/compat";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EvalNotifier } from "../src/extension/eval-notifier.ts";
-import { fakeExtensionContext } from "./eval/fakes.ts";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { FakeKernel, fakeExtensionContext } from "./eval/fakes.ts";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe("EvalNotifier", () => {
 	it("scopes once-per-cell delivery to one session generation", () => {
@@ -18,6 +23,32 @@ describe("EvalNotifier", () => {
 		notifier.notify([{ cellId: "reused-cell", content: "second session" }]);
 
 		expect(messages).toEqual(["first session", "second session"]);
+	});
+
+	it("wakes the main agent when a detached cell is killed by the hard limit", async () => {
+		vi.useFakeTimers();
+		const delivered: Array<{ content: string; deliverAs?: string }> = [];
+		const notifier = new EvalNotifier({
+			sendUserMessage: (content, options) =>
+				delivered.push({ content, ...(options?.deliverAs === undefined ? {} : { deliverAs: options.deliverAs }) }),
+			getContext: () => ({ ...fakeExtensionContext(), mode: "tui", model: fakeModel() }),
+			getMode: () => "wake",
+		});
+		const manager = new EvalDetachedCellManager({ hardLimitSeconds: 2, notifier });
+		const cell = manager.create("killed-cell", { language: "js", code: "await forever", summary: "runaway" });
+		manager.markRunning(cell, new FakeKernel([]), () => ({
+			content: [{ type: "text", text: "partial" }],
+			details: { language: "js", languages: ["js"], durationMs: 0, toolCalls: [], truncated: false },
+		}));
+		manager.detach(cell);
+
+		await vi.advanceTimersByTimeAsync(2_000);
+		await manager.flushNotifications();
+
+		expect(delivered).toHaveLength(1);
+		expect(delivered[0]?.deliverAs).toBe("steer");
+		expect(delivered[0]?.content).toContain("killed-cell");
+		expect(delivered[0]?.content).toContain("2s hard limit");
 	});
 });
 

--- a/packages/senpi-codemode/test/interpreter.test.ts
+++ b/packages/senpi-codemode/test/interpreter.test.ts
@@ -91,7 +91,8 @@ describe("interpreter detection", () => {
 		});
 
 		const availability = await getInterpreterAvailability(
-			{ languages: { py: true, js: true, rb: false, jl: false }, cellTimeoutSeconds: 30, parallelPoolWidth: 4 },
+			{ languages: { py: true, js: true, rb: false, jl: false }, cellTimeoutSeconds: 30,
+			hardLimitSeconds: 1800, parallelPoolWidth: 4 },
 			detector,
 		);
 

--- a/packages/senpi-codemode/test/interpreter.test.ts
+++ b/packages/senpi-codemode/test/interpreter.test.ts
@@ -91,8 +91,12 @@ describe("interpreter detection", () => {
 		});
 
 		const availability = await getInterpreterAvailability(
-			{ languages: { py: true, js: true, rb: false, jl: false }, cellTimeoutSeconds: 30,
-			hardLimitSeconds: 1800, parallelPoolWidth: 4 },
+			{
+				languages: { py: true, js: true, rb: false, jl: false },
+				cellTimeoutSeconds: 30,
+				hardLimitSeconds: 1800,
+				parallelPoolWidth: 4,
+			},
 			detector,
 		);
 


### PR DESCRIPTION
## Problem

A detached eval cell had **no upper bound at all**. One observed cell ran **1h13m** while the TUI
showed nothing but `↗ py … (1h 13m)`.

Two independent paths leave a cell unbounded today:

- `CellExecution.detach()` (`cell-execution.ts`) **disposes** the idle watchdog, so once a cell detaches
  nothing is watching it again — ever.
- `withBridgeTimeoutPause` (`timeouts/bridge-timeout.ts`) **pauses** that same watchdog for the entire
  duration of every host tool call, so a tool-call-heavy cell never reaches its own timeout either.

`bash` has never had this problem: `bash-timeout/timeout.ts` gives every command an unconditional kill
deadline (default/max 1800s, env-overridable, described in the system prompt). This PR gives `eval` the
same guarantee.

## What changed

- **`hardLimitSeconds` setting** (default **1800**, bash parity) with a
  `SENPI_CODEMODE_HARD_LIMIT_SECONDS` override that ignores non-positive/malformed values.
- **A wall-clock kill deadline owned by `EvalDetachedCellManager`**, armed when the cell is created and
  cleared only on settlement. It is never paused by bridge tool calls and survives `detach()`, so it is
  the only bound a detached cell has. An explicit larger per-call `timeout` raises it, mirroring bash
  preserving explicit timeouts.
- **The main agent is told.** A detached cell killed by the deadline settles as cancelled and its
  notification says it `was killed at the <n>s hard limit`, carrying the buffered output tail. A cell
  still in the foreground is handed to its own `CellExecution`, which already owns interrupting the
  kernel and rejecting the tool call — so the kernel is never interrupted twice.
- **Prompt policy line** stating the deadline, the way the bash timeout policy states its own.

## Verification

| Criterion | Proof |
|---|---|
| Detached cell past the limit is killed | `test/eval-hard-limit.test.ts` — interrupt fires once, state `cancelled`, `hardLimitSeconds` reported |
| Main agent is notified | same suite + `test/eval-notifier.test.ts` — notice reaches `sendUserMessage` as a `steer` containing `2s hard limit` |
| Config precedence | `test/config.test.ts` — default 1800, settings override, env beats settings, malformed env ignored |
| Regression | a cell settling early is never killed and emits no hard-limit notice; foreground/bridge-paused and orphaned-cell paths each pinned |
| Real CLI | `node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-eval-hard-limit` → **5/5 PASS** |

Every behavior change was captured RED before the production edit (`resolveHardLimitSeconds is not a
function`, then 5 failing hard-limit assertions) and GREEN after.

The real-CLI run plants `cellTimeoutSeconds: 600` with `hardLimitSeconds: 3` into the sandbox settings so
**only** the hard limit can end the cell, runs a `js` cell that awaits forever, and proves the kill reached
the model's context — the literal tool message in the next request:

```
{"role":"tool","content":"Eval cell call_1 was killed at the 3s hard limit. The kernel was unresponsive and restarted; variables from earlier cells are lost.","tool_call_id":"call_1"}
```

Package suite 535 passed / 0 failed, `tsc --noEmit` clean, biome clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a wall-clock hard limit to eval cells to stop unbounded runs. Previously, detached or tool-call-heavy cells could run indefinitely; now each cell has a deadline (default 1800s) that kills the cell and informs the agent when hit.

- Introduces `hardLimitSeconds` (default 1800) with `SENPI_CODEMODE_HARD_LIMIT_SECONDS` override; non-positive/malformed env values are ignored. An explicit per-call `timeout` raises this limit.
- `EvalDetachedCellManager` arms a deadline at cell creation that survives `detach()` and is never paused by bridge tool calls. On expiry: foreground cells hand off to their `CellExecution` (no double interrupt); detached cells interrupt the kernel, settle as cancelled, and queue a notice naming the cell and limit with the buffered output tail.
- Wires the resolved limit into bootstrap and runtime; updates the eval prompt to state the policy.
- QA: adds `scripts/mock-loop.mjs --with-eval-hard-limit` and an RPC proof `scripts/eval-hard-limit-rpc-qa.mjs --self-test` that a DETACHED cell’s kill notice is injected into the next model request; factors a shared `scripts/lib/rpc-client.mjs`.

**Migration**
- If work must run longer than 30 minutes, raise the limit by:
  - Setting `hardLimitSeconds` in `.senpi/codemode.json` or `SENPI_CODEMODE_HARD_LIMIT_SECONDS`, or
  - Passing a larger `timeout` in individual `eval` calls.

<sup>Written for commit 28f35749107bc36a5179059bc15883673e72d5c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Real-CLI QA — both kill paths

`--print` can only prove the foreground kill: `EvalNotifier` suppresses injected notices in print/json
modes, and eval defaults to `error` timeout semantics there. So the detached path — the shape of the
incident that motivated this PR — is proven separately over RPC, which is interactive for both.

```
node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-eval-hard-limit        # 5/5 PASS (foreground)
node .agents/skills/senpi-qa/scripts/eval-hard-limit-rpc-qa.mjs --self-test      # 5/5 PASS (detached)
```

Foreground: the tool message the real CLI sent back to the model.

```
{"role":"tool","content":"Eval cell call_1 was killed at the 3s hard limit. The kernel was unresponsive and restarted; variables from earlier cells are lost.","tool_call_id":"call_1"}
```

Detached: the cell detached (turn returned control at request 2), the deadline killed it, and the notice
landed in request 3 as an injected user message.

```
<system-reminder>Detached eval cell call_1 (js) was killed at the 5s hard limit.
1/1 cells running
[1] js detach, then outlive the hard limit running
JavaScript worker was restarted; VM state was lost.</system-reminder>
```

Both scenarios are hermetic (sandboxed agent dir, every provider env key stripped, `guardRealAuth`
asserting `auth.json` is untouched) and tear down their server, sandbox, and child process.
`rpc-drive.mjs --self-test` still passes 4/4 after `RpcClient` moved to `lib/rpc-client.mjs`.