### PR TITLE
fix(release): merge concurrent main updates

### DIFF
--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,32 @@
 # changes
 
+## Merge concurrent main updates before release push (2026-08-13)
+
+### What changed
+
+- Release preparation now fetches `origin/main` after creating the verified
+  release tag and next-cycle commit.
+- If remote main advanced during the long release test transaction, the release
+  branch creates a normal merge commit before pushing `main`.
+- Added focused tests for advanced, already-contained, and dry-run paths.
+
+### Why
+
+- The release workflow can run for several minutes while other verified PRs
+  merge. A non-fast-forward main push previously failed after all release build
+  and test work had completed.
+- The release tag remains anchored to the already verified release commit;
+  only the post-release next-cycle branch absorbs concurrent main history.
+
+### Why an extension could not handle it
+
+- Git synchronization and tag/branch publication happen before any Senpi
+  runtime or extension is loaded.
+
+### Expected merge conflict zones
+
+- MEDIUM: the final tag/next-cycle/push sequence in `release.mjs`.
+
 ## Lock every Rolldown platform binding (2026-08-13)
 
 ### What changed

--- a/scripts/release-git.mjs
+++ b/scripts/release-git.mjs
@@ -1,0 +1,18 @@
+export function syncRemoteMainBeforePush(dryRun, runCommand, log, dryRunLog) {
+	if (dryRun) {
+		dryRunLog("git fetch origin main");
+		dryRunLog("git merge --no-edit origin/main (if remote main advanced)");
+		return;
+	}
+
+	log("git fetch origin main");
+	runCommand("git", ["fetch", "origin", "main"]);
+
+	try {
+		runCommand("git", ["merge-base", "--is-ancestor", "origin/main", "HEAD"]);
+		log("remote main is already an ancestor of the release branch");
+	} catch {
+		log("git merge --no-edit origin/main");
+		runCommand("git", ["merge", "--no-edit", "origin/main"]);
+	}
+}

--- a/scripts/release-git.test.mjs
+++ b/scripts/release-git.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { syncRemoteMainBeforePush } from "./release-git.mjs";
+
+describe("release main synchronization", () => {
+	it("merges a concurrently advanced remote main before pushing", () => {
+		const commands = [];
+		syncRemoteMainBeforePush(
+			false,
+			(command, args) => {
+				commands.push([command, args]);
+				if (args[0] === "merge-base") {
+					throw new Error("remote main advanced");
+				}
+			},
+			() => {},
+			() => {},
+		);
+
+		assert.deepEqual(commands, [
+			["git", ["fetch", "origin", "main"]],
+			["git", ["merge-base", "--is-ancestor", "origin/main", "HEAD"]],
+			["git", ["merge", "--no-edit", "origin/main"]],
+		]);
+	});
+
+	it("does not create a merge when remote main is already included", () => {
+		const commands = [];
+		syncRemoteMainBeforePush(
+			false,
+			(command, args) => commands.push([command, args]),
+			() => {},
+			() => {},
+		);
+
+		assert.deepEqual(commands, [
+			["git", ["fetch", "origin", "main"]],
+			["git", ["merge-base", "--is-ancestor", "origin/main", "HEAD"]],
+		]);
+	});
+
+	it("previews the fetch and conditional merge", () => {
+		const previews = [];
+		syncRemoteMainBeforePush(
+			true,
+			() => assert.fail("dry-run must not execute commands"),
+			() => {},
+			(message) => previews.push(message),
+		);
+
+		assert.deepEqual(previews, [
+			"git fetch origin main",
+			"git merge --no-edit origin/main (if remote main advanced)",
+		]);
+	});
+
+	it("synchronizes remote main after the next-cycle commit and before either push", () => {
+		const releaseSource = readFileSync(new URL("./release.mjs", import.meta.url), "utf8");
+		const nextCycleCommit = releaseSource.indexOf('gitCommit("Add [Unreleased] section for next cycle"');
+		const synchronize = releaseSource.indexOf("syncRemoteMainBeforePush(");
+		const pushMain = releaseSource.indexOf('gitPush("main"');
+		const pushTag = releaseSource.indexOf("gitPush(`v${version}`");
+
+		assert.ok(nextCycleCommit < synchronize);
+		assert.ok(synchronize < pushMain);
+		assert.ok(pushMain < pushTag);
+	});
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -35,6 +35,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, lstatSync } from "node:fs";
 import { join } from "node:path";
 import { computeNextVersion } from "./calver.mjs";
+import { syncRemoteMainBeforePush } from "./release-git.mjs";
 import {
 	runGenerateImageModels,
 	runGenerateModels,
@@ -362,6 +363,7 @@ function main() {
 	stageChangedFiles(args.dryRun);
 	gitCommit("Add [Unreleased] section for next cycle", args.dryRun);
 
+	syncRemoteMainBeforePush(args.dryRun, runCommand, log, dryRunLog);
 	gitPush("main", args.dryRun);
 	gitPush(`v${version}`, args.dryRun);
 


### PR DESCRIPTION
## Problem

Release preparation completed versioning, clean build, and the full serial test gate, then failed at `git push origin main` because PR #853 merged while the release was running. The release branch was non-fast-forward even though every release artifact was already verified.

Failed run: https://github.com/code-yeongyu/senpi/actions/runs/31680010156

## Fix

- Fetch `origin/main` after the release tag and next-cycle commit are created.
- If remote main advanced, merge it with a normal two-parent commit before pushing main.
- Keep the release tag anchored to the already verified release commit.
- Add unit coverage for advanced, already-contained, dry-run, and call-order paths.

## Verification

- Failing-first source proof confirms the old release flow had no pre-push synchronization.
- Focused tests: 4/4 passed.
- Root script suite: passed.
- `npm run check`: passed.
- Real two-clone Git simulation: concurrent main commit was preserved, next-cycle HEAD became a two-parent merge, and the release tag remained on the verified release commit.
- No `v2026.8.13` tag or npm version exists.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes and merges concurrent `origin/main` updates during release before pushing to prevent non-fast-forward failures. Previously we pushed without syncing; now we fetch `origin/main` after creating the release tag and next-cycle commit and merge if needed, keeping the tag on the verified commit.

- Adds `scripts/release-git.mjs` and calls `syncRemoteMainBeforePush` in `scripts/release.mjs` after the next-cycle commit and before both pushes.
- If `origin/main` is not an ancestor, creates a two-parent merge on `main`; release artifacts and tag remain unchanged.
- Dry-run previews the fetch and conditional merge; unit tests cover advanced, already-contained, dry-run, and call order.

<sup>Written for commit 54bcd7148097ec180d48bcdd65bde232eb6f6492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

