### PR TITLE
fix(release): bundle transitive runtime dependencies

### DIFF
--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -251,4 +251,30 @@
 - `package-lock.json` entries for `@anthropic-ai/claude-agent-sdk-*`.
 - Root `package.json` static-check scripts.
 - Release/dependency lock tests under `scripts/`.
+# Complete the bundled publish manifest dependency closure
+
+## What changed
+
+- The Senpi publish manifest now declares every portable staged transitive package at its exact staged version,
+  in addition to listing it in `bundleDependencies`.
+- The focused bundled-workspace test now pins both halves of npm's contract: the transitive package must be
+  staged and bundled, and it must also have a manifest dependency edge so `npm pack` includes it.
+
+## Why
+
+- npm ignores a copied `node_modules/<package>` directory when the package appears only in
+  `bundleDependencies` and has no matching `dependencies` or `optionalDependencies` entry.
+- The `v2026.8.13` publish-only workflow therefore copied the full lock closure but packed only direct runtime
+  packages; tarball validation correctly rejected 33 missing Google auth/protobuf transitive dependencies.
+
+## Why not an extension
+
+- npm decides tarball membership before Senpi or an extension can execute. The staged publish manifest is the
+  only boundary that can make the copied closure part of the package.
+
+## Expected conflict zones
+
+- `prepare-senpi-publish-manifest.mjs` staged dependency generation.
+- `prepare-senpi-bundled-workspaces.prepare.test.mjs` publish-manifest expectations.
+
 

--- a/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
@@ -261,6 +261,8 @@ describe("prepareSenpiBundledWorkspaces", () => {
 			"@earendil-works/pi-pty": "npm:@code-yeongyu/senpi-pty@2026.7.22",
 			"@earendil-works/pi-telemetry": "npm:@code-yeongyu/senpi-telemetry@2026.7.22",
 			"@earendil-works/pi-tui": "npm:@code-yeongyu/senpi-tui@2026.7.22",
+			"cross-spawn": "1.0.0",
+			which: "1.0.0",
 		});
 		const stagedAgentManifest = JSON.parse(
 			readFileSync(

--- a/scripts/prepare-senpi-publish-manifest.mjs
+++ b/scripts/prepare-senpi-publish-manifest.mjs
@@ -186,6 +186,19 @@ export function stagePublishManifest(repoRoot) {
 			rmSync(join(codingAgentNodeModules, packageName), { recursive: true, force: true });
 		}
 	}
+	manifest.dependencies ??= {};
+	const declaredPackageNames = new Set([
+		...Object.keys(manifest.dependencies),
+		...Object.keys(manifest.optionalDependencies ?? {}),
+	]);
+	for (const packageName of bundlablePackageNames) {
+		if (declaredPackageNames.has(packageName)) continue;
+		const stagedManifest = readPackageManifest(join(codingAgentNodeModules, packageName));
+		if (typeof stagedManifest?.version !== "string") {
+			throw new Error(`Staged package ${packageName} is missing an exact version for the publish manifest.`);
+		}
+		manifest.dependencies[packageName] = stagedManifest.version;
+	}
 	// Keep the original dependency keys so npm packs the modules at the import paths
 	// the compiled source uses. Resolve those keys through fork-owned aliases instead
 	// of attempting to fetch lockstep versions from the upstream-owned namespace.


### PR DESCRIPTION
## Summary

- Add exact staged dependency edges for every portable transitive package copied into the Senpi publish tree.
- Keep bundleDependencies and the staged manifest dependency map aligned so npm pack includes the full runtime closure.
- Strengthen the focused manifest test with a direct package plus hoisted transitive package.

## Root cause

The v2026.8.13 publish workflow copied the complete staged lock closure and listed it in bundleDependencies, but npm omitted transitive packages that had no matching manifest dependency edge. Tarball validation correctly rejected 33 missing Google auth/protobuf runtime dependencies.

## Verification

- RED: focused manifest test failed because cross-spawn and which were absent from dependencies.
- GREEN: focused pack/manifest tests PASS.
- Complete script suite PASS.
- npm run check PASS.
- Full publish dry-run now advances past the repaired assertion; disposable clean-install validation follows in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `npm pack` includes all transitive runtime dependencies by declaring every staged portable package as an exact `dependencies` entry in the Senpi publish manifest. Previously we only listed them in `bundleDependencies`, so npm omitted transitive packages without manifest edges; now `dependencies` and `bundleDependencies` stay aligned to pack the full runtime closure.

- scripts/prepare-senpi-publish-manifest.mjs: adds missing transitive packages to `dependencies` with exact staged versions, throws if a staged package lacks a version, and preserves original dependency keys.
- scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs: strengthens the test by requiring `cross-spawn` and `which` to assert both staging and manifest edges.
- Packaging-only change; dry-run publish and pack/manifest tests pass.

<sup>Written for commit cdbfc1d0e1e3c771b5a95031057e819396dffd75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

