### PR TITLE
fix(release): harden publish package staging

### DIFF
--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -11,6 +11,12 @@
 - Publish staging now materializes any missing optional runtime package directly
   from the exact tarball URL and integrity recorded in the root lock before
   preparing the bundled Senpi package.
+- Final tarball validation now requires the publish manifest's actual
+  `bundleDependencies`, excluding platform-constrained optional packages that
+  intentionally remain registry-resolved on the installing machine.
+- Portable hoisted transitive packages are promoted to exact temporary
+  dependencies in the staged publish manifest so npm includes every declared
+  bundle member in the final Senpi tarball.
 
 ### Why
 

--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -1,5 +1,36 @@
 # changes
 
+## Parse npm pack JSON after warning output (2026-08-13)
+
+### What changed
+
+- Added a parser that scans `npm pack --json` output for the final valid JSON
+  array instead of parsing the entire stdout stream directly.
+- Added regression coverage using the workspace/config warnings emitted during
+  the failed first Senpi telemetry publication.
+- Publish staging now materializes any missing optional runtime package directly
+  from the exact tarball URL and integrity recorded in the root lock before
+  preparing the bundled Senpi package.
+
+### Why
+
+- npm can print warnings before its JSON payload. The publish workflow prepared
+  the package successfully but failed before `npm publish` because the warning
+  prefix made raw `JSON.parse` reject the output.
+- Cross-platform native packages are intentionally present in the lock but npm
+  installs only the current host variant. Senpi bundles those platform binaries,
+  so publish staging must reify the missing locked variants without changing
+  manifests or lockfiles.
+
+### Why an extension could not handle it
+
+- Package packing and npm publication run in release tooling before any Senpi
+  runtime or extension is loaded.
+
+### Expected merge conflict zones
+
+- LOW: `prepareAndPackPackage` in `publish.mjs`.
+
 ## Merge concurrent main updates before release push (2026-08-13)
 
 ### What changed

--- a/scripts/materialize-publish-runtime.mjs
+++ b/scripts/materialize-publish-runtime.mjs
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const runtimeRoot = join("packages", "coding-agent", "node_modules");
+
+function verifyIntegrity(buffer, integrity) {
+	const [algorithm, expected] = integrity.split("-", 2);
+	if (!algorithm || !expected) {
+		throw new Error(`Unsupported integrity value: ${integrity}`);
+	}
+	const actual = createHash(algorithm).update(buffer).digest("base64");
+	if (actual !== expected) {
+		throw new Error(`Integrity mismatch: expected ${integrity}, received ${algorithm}-${actual}`);
+	}
+}
+
+export function collectMissingLockedRuntimePackages(lock, root = runtimeRoot) {
+	const missing = [];
+	for (const [lockPath, entry] of Object.entries(lock.packages)) {
+		if (!lockPath.startsWith("node_modules/") || !entry.optional || !entry.resolved || !entry.integrity) {
+			continue;
+		}
+		const packageName = lockPath.slice("node_modules/".length);
+		const target = join(root, packageName);
+		if (!existsSync(target)) {
+			missing.push({ packageName, target, resolved: entry.resolved, integrity: entry.integrity });
+		}
+	}
+	return missing;
+}
+
+export async function materializeMissingPublishRuntime({
+	lockPath = join("packages", "coding-agent", "publish-deps.lock.json"),
+	root = runtimeRoot,
+	fetchImpl = fetch,
+	runCommand = spawnSync,
+	log = console.log,
+} = {}) {
+	const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+	const missing = collectMissingLockedRuntimePackages(lock, root);
+	for (const pkg of missing) {
+		log(`Materializing locked runtime package ${pkg.packageName}`);
+		const response = await fetchImpl(pkg.resolved);
+		if (!response.ok) {
+			throw new Error(`Failed to download ${pkg.packageName}: HTTP ${response.status}`);
+		}
+		const archive = Buffer.from(await response.arrayBuffer());
+		verifyIntegrity(archive, pkg.integrity);
+
+		const temporaryRoot = mkdtempSync(join(tmpdir(), "senpi-runtime-"));
+		const archivePath = join(temporaryRoot, "package.tgz");
+		const extractedPath = join(temporaryRoot, "package");
+		writeFileSync(archivePath, archive);
+		const result = runCommand("tar", ["-xzf", archivePath, "-C", temporaryRoot], { encoding: "utf8" });
+		if (result.status !== 0) {
+			throw new Error(`Failed to extract ${pkg.packageName}: ${result.stderr || result.stdout || result.status}`);
+		}
+		mkdirSync(dirname(pkg.target), { recursive: true });
+		cpSync(extractedPath, pkg.target, { recursive: true });
+		rmSync(temporaryRoot, { recursive: true, force: true });
+	}
+	return missing.map(({ packageName }) => packageName);
+}

--- a/scripts/materialize-publish-runtime.test.mjs
+++ b/scripts/materialize-publish-runtime.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { collectMissingLockedRuntimePackages, materializeMissingPublishRuntime } from "./materialize-publish-runtime.mjs";
+
+describe("publish runtime materialization", () => {
+	it("selects only absent locked optional registry packages", () => {
+		const root = mkdtempSync(join(tmpdir(), "senpi-runtime-test-"));
+		const lock = {
+			packages: {
+				"node_modules/@scope/missing": {
+					optional: true,
+					resolved: "https://registry.example/missing.tgz",
+					integrity: "sha512-example",
+				},
+				"node_modules/ordinary": {
+					optional: false,
+					resolved: "https://registry.example/ordinary.tgz",
+					integrity: "sha512-example",
+				},
+				"node_modules/build-only": {
+					optional: true,
+					resolved: "https://registry.example/build-only.tgz",
+					integrity: "sha512-example",
+				},
+			},
+		};
+		const publishLock = {
+			packages: {
+				"node_modules/@scope/missing": lock.packages["node_modules/@scope/missing"],
+				"node_modules/ordinary": lock.packages["node_modules/ordinary"],
+			},
+		};
+
+		assert.deepEqual(collectMissingLockedRuntimePackages(publishLock, root), [
+			{
+				packageName: "@scope/missing",
+				target: join(root, "@scope/missing"),
+				resolved: "https://registry.example/missing.tgz",
+				integrity: "sha512-example",
+			},
+		]);
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("verifies and extracts an exact locked tarball", async () => {
+		const root = mkdtempSync(join(tmpdir(), "senpi-runtime-test-"));
+		const fixture = mkdtempSync(join(tmpdir(), "senpi-runtime-fixture-"));
+		const packageDir = join(fixture, "package");
+		const archivePath = join(fixture, "fixture.tgz");
+		await import("node:fs/promises").then(({ mkdir, writeFile }) =>
+			mkdir(packageDir).then(() => writeFile(join(packageDir, "package.json"), '{"name":"@scope/native"}\n')),
+		);
+		const { spawnSync } = await import("node:child_process");
+		assert.equal(spawnSync("tar", ["-czf", archivePath, "-C", fixture, "package"]).status, 0);
+		const archive = readFileSync(archivePath);
+		const integrity = `sha512-${createHash("sha512").update(archive).digest("base64")}`;
+		const lockPath = join(root, "package-lock.json");
+		writeFileSync(
+			lockPath,
+			JSON.stringify({
+				packages: {
+					"node_modules/@scope/native": {
+						optional: true,
+						resolved: "https://registry.example/native.tgz",
+						integrity,
+					},
+				},
+			}),
+		);
+
+		const materialized = await materializeMissingPublishRuntime({
+			lockPath,
+			root: join(root, "node_modules"),
+			fetchImpl: async () => new Response(archive),
+			log: () => {},
+		});
+
+		assert.deepEqual(materialized, ["@scope/native"]);
+		assert.equal(existsSync(join(root, "node_modules/@scope/native/package.json")), true);
+		assert.equal(existsSync(packageDir), true, "materialization must copy before cleaning its own extraction root");
+		rmSync(root, { recursive: true, force: true });
+		rmSync(fixture, { recursive: true, force: true });
+	});
+});

--- a/scripts/npm-pack-json.mjs
+++ b/scripts/npm-pack-json.mjs
@@ -1,0 +1,13 @@
+export function parseNpmPackJson(output) {
+	for (let index = output.indexOf("["); index !== -1; index = output.indexOf("[", index + 1)) {
+		try {
+			const parsed = JSON.parse(output.slice(index));
+			if (Array.isArray(parsed)) {
+				return parsed;
+			}
+		} catch {
+			// npm may print warnings before the final JSON payload.
+		}
+	}
+	throw new Error("npm pack --json did not return a JSON array");
+}

--- a/scripts/npm-pack-json.test.mjs
+++ b/scripts/npm-pack-json.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseNpmPackJson } from "./npm-pack-json.mjs";
+
+describe("npm pack JSON parsing", () => {
+	it("ignores npm workspace warnings before the pack result", () => {
+		const output = `npm warn config ignoring workspace config at /tmp/package/.npmrc
+npm warn Unknown user config "auto-install-peers". This will stop working in the next major version of npm.
+[
+  {
+    "id": "@code-yeongyu/senpi-telemetry@2026.8.13",
+    "filename": "code-yeongyu-senpi-telemetry-2026.8.13.tgz"
+  }
+]`;
+
+		assert.deepEqual(parseNpmPackJson(output), [
+			{
+				id: "@code-yeongyu/senpi-telemetry@2026.8.13",
+				filename: "code-yeongyu-senpi-telemetry-2026.8.13.tgz",
+			},
+		]);
+	});
+
+	it("rejects output without a pack-result array", () => {
+		assert.throws(() => parseNpmPackJson("npm warn no json followed"), /did not return a JSON array/u);
+	});
+});

--- a/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
@@ -261,6 +261,8 @@ describe("prepareSenpiBundledWorkspaces", () => {
 			"@earendil-works/pi-pty": "npm:@code-yeongyu/senpi-pty@2026.7.22",
 			"@earendil-works/pi-telemetry": "npm:@code-yeongyu/senpi-telemetry@2026.7.22",
 			"@earendil-works/pi-tui": "npm:@code-yeongyu/senpi-tui@2026.7.22",
+			"cross-spawn": "1.0.0",
+			which: "1.0.0",
 		});
 		const stagedAgentManifest = JSON.parse(
 			readFileSync(

--- a/scripts/prepare-senpi-publish-manifest.mjs
+++ b/scripts/prepare-senpi-publish-manifest.mjs
@@ -180,6 +180,17 @@ export function stagePublishManifest(repoRoot) {
 		...promotePlatformOptionalDependencyFamilies(codingAgentNodeModules, stagedPackageNames),
 		...(manifest.optionalDependencies ?? {}),
 	};
+	manifest.dependencies ??= {};
+	for (const packageName of bundlablePackageNames) {
+		if (manifest.dependencies[packageName] !== undefined || manifest.optionalDependencies[packageName] !== undefined) {
+			continue;
+		}
+		const packageManifest = readPackageManifest(join(codingAgentNodeModules, packageName));
+		if (typeof packageManifest?.version !== "string") {
+			throw new Error(`Bundled runtime package ${packageName} must declare an exact version`);
+		}
+		manifest.dependencies[packageName] = packageManifest.version;
+	}
 	const bundlableSet = new Set(bundlablePackageNames);
 	for (const packageName of stagedPackageNames) {
 		if (!bundlableSet.has(packageName)) {

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -11,6 +11,8 @@ import {
 } from "./prepare-senpi-bundled-workspaces.mjs";
 import { buildPublishArgs } from "./publish-command.mjs";
 import { rewritePublishManifest } from "./publish-manifest.mjs";
+import { materializeMissingPublishRuntime } from "./materialize-publish-runtime.mjs";
+import { parseNpmPackJson } from "./npm-pack-json.mjs";
 
 // Source packages retain their upstream names and private guard. Registry-backed
 // packages are published from temporary manifests under our scope, while bundled-only
@@ -98,7 +100,7 @@ function assertBuildOutputExists(directory) {
 
 function validatePack(directory) {
 	const result = run("npm", ["pack", "--dry-run", "--ignore-scripts", "--json"], { capture: true, cwd: directory });
-	const packed = JSON.parse(result.stdout)[0];
+	const packed = parseNpmPackJson(result.stdout)[0];
 	const packageJson = readPackageJson(directory);
 	if (directory === "packages/coding-agent") {
 		assertSenpiPackedWorkspaceFiles(packed, {
@@ -157,6 +159,7 @@ if (versions.length !== 1) {
 
 console.log(`Publishing senpi packages at ${versions[0]}${dryRun ? " (dry run)" : ""}\n`);
 
+await materializeMissingPublishRuntime();
 prepareSenpiBundledWorkspaces();
 
 const packageStates = packages.map((pkg) => ({


### PR DESCRIPTION
## Problem

The first `v2026.8.13` publish-only run failed before publishing any package:

1. npm emitted workspace/config warnings before `npm pack --json`, so raw `JSON.parse(stdout)` rejected the warning prefix.
2. Cross-platform native optional packages existed in the publish lock but npm installed only the current host variant.
3. npm bundles only dependencies reachable from the staged root manifest, so portable hoisted transitives listed in `bundleDependencies` were omitted from the final Senpi tarball.

Failed run: https://github.com/code-yeongyu/senpi/actions/runs/31683310097

## Fix

- Parse the final valid JSON array from warning-prefixed npm pack output.
- Materialize only missing optional packages from the authoritative `packages/coding-agent/publish-deps.lock.json`, verifying exact SRI before extraction.
- Copy extracted packages safely across filesystems.
- Promote portable hoisted bundle members to exact temporary publish-manifest dependencies so npm includes their complete runtime closure.

## Verification

- Focused parser/materializer tests: 4/4 passed.
- Focused bundled-workspace tests: 24/24 passed.
- Root script suite: 134/134 passed.
- Canonical `npm run check`: passed.
- Fresh detached worktree from `b1041f9a3`:
  - no-script install: passed
  - full build: passed
  - seven-package `publish.mjs --dry-run`: passed
  - telemetry tarball: 26 files
  - final Senpi tarball: 29,651 files, 32,324,355 bytes packed, 161,138,834 bytes unpacked
- Registry audit confirmed none of the seven `2026.8.13` packages were partially published.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened publish staging to tolerate npm pack warnings, reify locked optional runtime packages, and include the full portable bundled runtime closure. Previously: `JSON.parse(stdout)` failed on warning-prefixed `npm pack --json` output, only the host’s optional native variant was installed, and hoisted transitives listed in `bundleDependencies` were omitted. Now: a resilient parser, SRI-verified materialization from the publish lock, and temporary dependency promotion ensure complete, consistent tarballs.

- Reviewer focus:
  - `scripts/publish.mjs`: calls `materializeMissingPublishRuntime()` before bundling; `validatePack` now uses `parseNpmPackJson`.
  - `scripts/npm-pack-json.mjs`: scans stdout to parse the final JSON array; tests cover warning-prefixed output.
  - `scripts/materialize-publish-runtime.mjs`: downloads absent optional packages from `packages/coding-agent/publish-deps.lock.json`, verifies integrity, extracts via `tar`, and copies safely; tests added.
  - `scripts/prepare-senpi-publish-manifest.mjs`: promotes portable, hoisted bundled members to exact temporary `dependencies` so npm includes their full runtime closure.

- Operational impact:
  - Release env must have `tar` in PATH and registry access during publish staging; no lockfile or consumer changes required.

<sup>Written for commit b1041f9a3b3e00a218e1d0a34d7a5231682627cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

