### PR TITLE
fix(release): isolate npm pack JSON payload

### DIFF
--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -5,7 +5,8 @@
 ### What changed
 
 - Added a parser that scans `npm pack --json` output for the final valid JSON
-  array instead of parsing the entire stdout stream directly.
+  array instead of parsing the entire stdout stream directly, including when npm
+  emits warnings after the JSON payload.
 - Added regression coverage using the workspace/config warnings emitted during
   the failed first Senpi telemetry publication.
 - Publish staging now materializes any missing optional runtime package directly

--- a/scripts/npm-pack-json.mjs
+++ b/scripts/npm-pack-json.mjs
@@ -1,12 +1,37 @@
 export function parseNpmPackJson(output) {
 	for (let index = output.indexOf("["); index !== -1; index = output.indexOf("[", index + 1)) {
-		try {
-			const parsed = JSON.parse(output.slice(index));
-			if (Array.isArray(parsed)) {
-				return parsed;
+		let depth = 0;
+		let inString = false;
+		let escaped = false;
+		for (let cursor = index; cursor < output.length; cursor += 1) {
+			const character = output[cursor];
+			if (inString) {
+				if (escaped) {
+					escaped = false;
+				} else if (character === "\\") {
+					escaped = true;
+				} else if (character === '"') {
+					inString = false;
+				}
+				continue;
 			}
-		} catch {
-			// npm may print warnings before the final JSON payload.
+			if (character === '"') {
+				inString = true;
+			} else if (character === "[") {
+				depth += 1;
+			} else if (character === "]") {
+				depth -= 1;
+				if (depth === 0) {
+					try {
+						const parsed = JSON.parse(output.slice(index, cursor + 1));
+						if (Array.isArray(parsed)) {
+							return parsed;
+						}
+					} catch {
+						break;
+					}
+				}
+			}
 		}
 	}
 	throw new Error("npm pack --json did not return a JSON array");

--- a/scripts/npm-pack-json.test.mjs
+++ b/scripts/npm-pack-json.test.mjs
@@ -11,7 +11,8 @@ npm warn Unknown user config "auto-install-peers". This will stop working in the
     "id": "@code-yeongyu/senpi-telemetry@2026.8.13",
     "filename": "code-yeongyu-senpi-telemetry-2026.8.13.tgz"
   }
-]`;
+]
+npm warn Unknown project config "legacy-peer-deps". This will stop working in the next major version of npm.`;
 
 		assert.deepEqual(parseNpmPackJson(output), [
 			{


### PR DESCRIPTION
## Problem

The first recovery run published the first four packages, then failed because npm emitted warnings both before and after its `npm pack --json` payload. Parsing from the first `[` through end-of-output contaminated the tarball filename with trailing warning text.

Failed run: https://github.com/code-yeongyu/senpi/actions/runs/31685347863

## Fix

- Parse a balanced JSON array with string/escape awareness, ignoring warnings on either side.
- Keep the previously verified locked-runtime materialization and portable bundle closure fixes.

## Verification

- Focused publish recovery tests: 24/24 passed.
- Root script suite: 134/134 passed.
- Fresh detached worktree at `e7316f08d`:
  - no-script install: passed
  - full build: passed
  - seven-package publish dry-run: passed
  - existing AI/agent/TUI/PTY versions were detected and skipped safely
  - missing telemetry, codemode, and Senpi tarballs validated successfully
  - final Senpi tarball: 29,651 files, 32,324,355 bytes packed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates the `npm pack --json` array from surrounding warnings to prevent corrupted tarball filenames during publish. Previously we parsed from the first “[” to end of output; now we extract the first balanced JSON array and ignore text before or after it.

- Parser now tracks bracket depth and honors string escaping to slice the exact array; throws if no array found.
- Adds a test with warnings after the JSON payload; updates `scripts/changes.md` to reflect the behavior.
- No changes to call sites or publish flow; no migration required.

<sup>Written for commit e7316f08d40fd13340695d66bef3bd75fd4a4bab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

