### PR TITLE
fix(compaction): let the core route claim the idle warm summary

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/core-route-warm-handoff-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/core-route-warm-handoff-qa.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import { createServer } from "node:http";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { createChecks, guardRealAuth, installCleanupHooks, makeSandbox, repoRoot } from "../lib/common.mjs";
+import { checkRealAuthUnchanged, hermeticEnv } from "../lib/mock-loop-support.mjs";
+import { TargetRpcClient } from "../lib/target-rpc-client.mjs";
+
+const CONTEXT_WINDOW = 128_000;
+const PINNED_INPUT_TOKENS = 120_000;
+const NEXT_PROMPT = "NEXT PROMPT";
+const NEXT_REPLY = "REPLY DELIVERED";
+const SUMMARY_MARKER = "IDLE SUMMARY";
+
+function arg(name, fallback) {
+	const index = process.argv.indexOf(name);
+	return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+function writeAnthropicSse(res, text, modelId, inputTokens) {
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
+	const event = (type, data) => res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+	event("message_start", {
+		message: {
+			id: `msg_${Date.now()}`,
+			type: "message",
+			role: "assistant",
+			model: modelId,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: inputTokens, output_tokens: 0 },
+		},
+	});
+	event("content_block_start", { index: 0, content_block: { type: "text", text: "" } });
+	event("content_block_delta", { index: 0, delta: { type: "text_delta", text } });
+	event("content_block_stop", { index: 0 });
+	event("message_delta", { delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 40 } });
+	event("message_stop", {});
+	res.end();
+}
+
+function deferred() {
+	let resolvePromise;
+	const promise = new Promise((resolveNext) => {
+		resolvePromise = resolveNext;
+	});
+	if (!resolvePromise) throw new Error("deferred resolver missing");
+	return { promise, resolve: resolvePromise };
+}
+
+function isSummarizationRequest(body) {
+	const messages = Array.isArray(body.messages) ? body.messages : [];
+	const last = messages[messages.length - 1];
+	const text = JSON.stringify(last?.content ?? "");
+	return text.includes("compact") || text.includes("summar");
+}
+
+async function startProvider() {
+	const requests = [];
+	const firstSummary = deferred();
+	let summarizationCount = 0;
+	const server = createServer((req, res) => {
+		const chunks = [];
+		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("end", () => {
+			const body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+			const summarization = isSummarizationRequest(body);
+			const turnIndex = requests.length + 1;
+			if (summarization) {
+				summarizationCount++;
+				requests.push({ at: Date.now(), turnIndex, kind: "summarization" });
+				console.log(`[qa] summarization request #${summarizationCount}`);
+				firstSummary.resolve();
+				writeAnthropicSse(res, SUMMARY_MARKER, body.model ?? "mock-claude", 1_000);
+				return;
+			}
+			requests.push({ at: Date.now(), turnIndex, kind: "turn" });
+			const firstTurn = requests.filter((entry) => entry.kind === "turn").length === 1;
+			writeAnthropicSse(
+				res,
+				firstTurn ? "x".repeat(40_000) : NEXT_REPLY,
+				body.model ?? "mock-claude",
+				firstTurn ? PINNED_INPUT_TOKENS : 1_000,
+			);
+		});
+	});
+	await new Promise((resolveListen, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolveListen);
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("provider address unavailable");
+	return {
+		origin: `http://127.0.0.1:${address.port}`,
+		requests,
+		firstSummary: firstSummary.promise,
+		summarizationCount: () => summarizationCount,
+		stop: () => new Promise((resolveStop) => server.close(resolveStop)),
+	};
+}
+
+function writeConfig(agentDir, provider) {
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				anthropic: {
+					baseUrl: provider.origin,
+					apiKey: "sk-mock-warm-anchor",
+					api: "anthropic-messages",
+					models: [
+						{
+							id: "mock-claude",
+							api: "anthropic-messages",
+							baseUrl: provider.origin,
+							contextWindow: CONTEXT_WINDOW,
+							maxTokens: 4_096,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						},
+					],
+				},
+			},
+		}),
+	);
+	writeFileSync(
+		join(agentDir, "settings.json"),
+		JSON.stringify({
+			compaction: {
+				enabled: true,
+				speculativeEnabled: true,
+				idleCompactionEnabled: true,
+				keepRecentTokens: 40,
+			},
+		}),
+	);
+}
+
+function readSessionEntries(sessionDir) {
+	const file = readdirSync(sessionDir).find((name) => name.endsWith(".jsonl"));
+	if (!file) throw new Error(`no session JSONL in ${sessionDir}`);
+	return readFileSync(join(sessionDir, file), "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+}
+
+async function main() {
+	installCleanupHooks();
+	const checks = createChecks("core-route-warm-handoff-qa.mjs");
+	const guard = guardRealAuth();
+	const targetRoot = resolve(arg("--target-root", repoRoot()));
+	const label = arg("--evidence", "after-fix");
+	const box = makeSandbox("core-route-warm-handoff");
+	const provider = await startProvider();
+	writeConfig(box.agentDir, provider);
+	const client = new TargetRpcClient({ env: hermeticEnv(box.env), cwd: box.cwd, targetRoot });
+
+	try {
+		await client.send({ type: "set_model", provider: "anthropic", modelId: "mock-claude" });
+		const firstEnd = client.waitFor((event) => event.message.type === "agent_end");
+		await client.send({ type: "prompt", message: "turn one" });
+		await firstEnd;
+		console.log("[qa] first agent_end observed");
+		await provider.firstSummary;
+		console.log("[qa] idle warm-up summarization observed");
+		const summarizationsAfterWarmup = provider.summarizationCount();
+
+		await client.send({ type: "follow_up", message: "idle-time note while the session waits" });
+		console.log("[qa] idle-time append delivered (revision bumped)");
+
+		const secondPromptAt = Date.now();
+		const secondEnd = client.waitFor((event) => event.message.type === "agent_end" && event.at >= secondPromptAt);
+		await client.send({ type: "prompt", message: NEXT_PROMPT });
+		await secondEnd;
+		console.log("[qa] second agent_end observed");
+
+		const summarizationsTotal = provider.summarizationCount();
+globalThis.compactionLogPath = join(box.agentDir, "logs", "compaction.log");
+globalThis.compactionLog = existsSync(compactionLogPath) ? readFileSync(compactionLogPath, "utf8") : "";
+globalThis.logEvents = compactionLog
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line))
+			.map((entry) => entry.event);
+globalThis.warmApplied = logEvents.includes("speculative_applied");
+globalThis.warmStale = logEvents.includes("speculative_stale");
+		const entries = readSessionEntries(box.sessionDir);
+		const compactions = entries.filter((entry) => entry.type === "compaction");
+		const serialized = JSON.stringify(entries);
+
+		checks.ok("idle warm-up billed exactly one summarization", summarizationsAfterWarmup === 1, `count=${summarizationsAfterWarmup}`);
+		const warmConsumed = logEvents.includes("warm_consumed");
+		const warmConsumedCount = logEvents.filter((event) => event === "warm_consumed").length;
+globalThis.coreRouteGenerated = logEvents.includes("core_route_generated");
+		checks.ok(
+			"the idle warm-up result was not thrown away",
+			warmConsumedCount >= 1,
+			`warm_consumed=${warmConsumedCount} afterWarmup=${summarizationsAfterWarmup} total=${summarizationsTotal}`,
+		);
+		checks.ok("compaction log records warm_consumed", warmConsumed, `events=${logEvents.join(",")}`);
+		checks.ok("core route did not regenerate a summary", !coreRouteGenerated, `events=${logEvents.join(",")}`);
+		checks.ok("compaction log records no speculative_stale", !warmStale, `events=${logEvents.join(",")}`);
+		void warmApplied;
+		checks.ok("exactly one durable compaction", compactions.length === 1, `count=${compactions.length}`);
+		checks.ok("warm summary is the applied summary", serialized.includes(SUMMARY_MARKER), "marker present");
+		checks.ok("second reply delivered", serialized.includes(NEXT_REPLY), "reply present");
+		checkRealAuthUnchanged(checks, guard);
+
+		const evidenceDir = join(repoRoot(), "local-ignore", "qa-evidence", "20260813-core-route-warm-handoff", label);
+		mkdirSync(evidenceDir, { recursive: true });
+		writeFileSync(
+			join(evidenceDir, "result.json"),
+			JSON.stringify(
+				{
+					targetRoot,
+					summarizationsAfterWarmup,
+					summarizationsTotal,
+					compactions: compactions.length,
+					logEvents,
+					requests: provider.requests,
+					events: client.events.map((event) => ({ at: event.at, type: event.message.type })),
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(join(evidenceDir, "child-stderr.log"), client.stderr ?? "");
+		process.exitCode = checks.finish() ? 0 : 1;
+	} finally {
+		await client.close();
+		await provider.stop();
+		box.cleanup();
+	}
+}
+
+await main();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- The compaction prepared while your session sat idle is now reused no matter which internal path runs
+  the compaction. Previously the path that runs first on a new prompt threw that finished summary away
+  and summarized again while you waited, so the idle head start was wasted in exactly the case it was
+  built for.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,36 @@
 # Builtin compaction extension changes
 
+## 2026-08-13 - Let the core route claim the idle warm summary
+
+### What changed
+
+- `session_before_compact` now attempts `claimWarmSummaryForCoreRoute()` BEFORE invalidating, and
+  returns the warm result as its `compaction` when the claim holds. The claim detaches the job
+  synchronously (before any `await`) so exactly one route can own it, and deliberately does NOT abort
+  its controller - aborting is what threw the already-paid summarization away.
+- A claim requires: no custom instructions (manual compaction keeps its own wording), a speculative
+  origin, the same model identity, a valid `WarmAnchorSnapshot` against the event branch, and a
+  boundary equal to the core preparation's `firstKeptEntryId`. Anything else falls through to the
+  existing fresh generation, unchanged.
+- The claimed job's generation is logged as `warm_consumed` with `route: "core-route"`.
+
+### Why
+
+On a new prompt the ordering is deterministic, not a race: `_enforceCompactionBeforeProvider` runs
+before `emitBeforeAgentStart`, so the CORE route always reaches compaction first. Its handler called
+`invalidateSpeculativeCompaction()` as its first statement, so the idle warm-up - whose entire purpose
+is to keep summarization off the user's critical path - was destroyed and re-billed exactly when it
+was needed. PR #853 fixed the extension route only; this closes the other half.
+
+### Why an extension could not do it
+
+The warm job lives in this extension, but the route that discarded it is the core-driven
+`session_before_compact` emission; the fix has to happen inside that handler.
+
+### Expected merge-conflict zones
+
+- `index.ts` `session_before_compact` handler head and the block preceding core-route snapshot creation.
+
 ## 2026-08-13 - Anchor warm summaries to the summarized prefix
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Tool } from "@earendil-works/pi-ai";
 import type { CompactionResult } from "../../../compaction/index.ts";
+import { createWarmAnchorSnapshot, isWarmSummaryAnchorValid } from "../../../compaction/warm-anchor.ts";
 import { convertToLlm } from "../../../messages.ts";
 import type {
 	ContextUsage,
@@ -265,6 +266,47 @@ export default function compactionExtension(
 		});
 	}
 
+	function isSameModelIdentity(
+		left: SpeculativeCompactionSnapshot["model"],
+		right: ExtensionContext["model"],
+	): boolean {
+		return (
+			right !== undefined &&
+			left.api === right.api &&
+			left.provider === right.provider &&
+			left.id === right.id &&
+			left.baseUrl === right.baseUrl &&
+			left.contextWindow === right.contextWindow
+		);
+	}
+
+	/**
+	 * Detach the warm job for the core route before any `await`, so exactly one
+	 * claimant can own it. The controller is deliberately NOT aborted: the whole
+	 * point is to keep the already-paid summarization alive and hand its result to
+	 * core, and clearing the reference is what stands the idle-retry watcher down.
+	 */
+	function claimWarmSummaryForCoreRoute(
+		event: SessionBeforeCompactEvent,
+		ctx: ExtensionContext,
+	): typeof speculativeJob {
+		const job = speculativeJob;
+		if (!job) return undefined;
+		if (event.customInstructions !== undefined) return undefined;
+		if (job.snapshot.origin !== "speculative") return undefined;
+		if (job.snapshot.preparation.firstKeptEntryId !== event.preparation.firstKeptEntryId) return undefined;
+		if (!isSameModelIdentity(job.snapshot.model, ctx.model)) return undefined;
+		const anchor = createWarmAnchorSnapshot(
+			job.snapshot.preparation.firstKeptEntryId,
+			job.snapshot.branchEntries ?? [],
+		);
+		if (!anchor || !isWarmSummaryAnchorValid(anchor, event.branchEntries ?? ctx.sessionManager.getBranch())) {
+			return undefined;
+		}
+		speculativeJob = undefined;
+		return job;
+	}
+
 	function invalidateSpeculativeCompaction(ctx: ExtensionContext): void {
 		const previousGeneration = speculativeGeneration;
 		speculativeGeneration++;
@@ -471,6 +513,7 @@ export default function compactionExtension(
 	}
 
 	pi.on("session_before_compact", async (event: SessionBeforeCompactEvent, ctx) => {
+		const claimedWarmJob = claimWarmSummaryForCoreRoute(event, ctx);
 		invalidateSpeculativeCompaction(ctx);
 		if (lanePolicy.disablesSenpiCompaction(ctx)) {
 			return { cancel: true, reason: SDK_NATIVE_LANE_REJECTION_REASON };
@@ -507,6 +550,22 @@ export default function compactionExtension(
 		if (remoteCompaction) {
 			getLogger(ctx).debug("core_route_generated", { route: "core-route", requestId: event.requestId });
 			return { compaction: remoteCompaction };
+		}
+
+		if (claimedWarmJob) {
+			const unlinkAbort = linkAbortSignal(event.signal, claimedWarmJob.controller);
+			let warmCompaction: CompactionResult | undefined;
+			let warmFailure: Error | undefined;
+			try {
+				warmCompaction = await claimedWarmJob.promise;
+				warmFailure = await claimedWarmJob.failure;
+			} finally {
+				unlinkAbort();
+			}
+			if (warmFailure === undefined && warmCompaction && !event.signal.aborted) {
+				getLogger(ctx).debug("warm_consumed", { generation: claimedWarmJob.generation, route: "core-route" });
+				return { compaction: warmCompaction };
+			}
 		}
 
 		const snapshot = {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -514,123 +514,128 @@ export default function compactionExtension(
 
 	pi.on("session_before_compact", async (event: SessionBeforeCompactEvent, ctx) => {
 		const claimedWarmJob = claimWarmSummaryForCoreRoute(event, ctx);
-		// A claim detaches the job without aborting it, so every path that leaves
-		// without consuming the result must still stop the request it is paying for.
-		const releaseUnusedWarmJob = () => claimedWarmJob?.controller.abort();
+		// The claim detaches the job without aborting it, so ownership must survive every
+		// exit from this handler - including a throw - or the request it already paid for
+		// keeps streaming for a result nobody will read.
+		let warmJobConsumed = false;
 		invalidateSpeculativeCompaction(ctx);
-		if (lanePolicy.disablesSenpiCompaction(ctx)) {
-			releaseUnusedWarmJob();
-			return { cancel: true, reason: SDK_NATIVE_LANE_REJECTION_REASON };
-		}
-		if (cap.shouldRejectByCap(state).cancel) {
-			getLogger(ctx).debug("skip_cap", { reason: event.reason, count: state.acceptedAbsolute });
-			releaseUnusedWarmJob();
-			return {
-				cancel: true,
-				rejectionCause: "per-turn-cap",
-				reason: "absolute compaction cap reached for this session",
-			};
-		}
-		const now = Date.now();
-		if (breaker.isTripped(state, now) && !breaker.shouldBypass(state, { reason: event.reason })) {
-			const remainingMs = state.trippedAt !== null ? Math.max(0, state.trippedAt + breaker.COOLDOWN_MS - now) : 0;
-			getLogger(ctx).debug("skip_breaker", { reason: event.reason, remainingSec: Math.ceil(remainingMs / 1000) });
-			releaseUnusedWarmJob();
-			return {
-				cancel: true,
-				rejectionCause: "circuit-breaker",
-				reason: `compaction circuit breaker cooling down (${Math.ceil(remainingMs / 1000)}s left)`,
-			};
-		}
-
-		capturePendingMetadata(event.requestId, ctx);
-
-		const model = ctx.model;
-		if (!model) {
-			releaseUnusedWarmJob();
-			return undefined;
-		}
-		const remoteCompaction = await runOpenAiRemoteCompaction(
-			ctx,
-			event,
-			(data) => pi.events.emit(SENPI_COMPACTION_EVENT, data),
-			remoteCompactionDependencies,
-		);
-		if (remoteCompaction) {
-			getLogger(ctx).debug("core_route_generated", { route: "core-route", requestId: event.requestId });
-			releaseUnusedWarmJob();
-			return { compaction: remoteCompaction };
-		}
-
-		if (claimedWarmJob) {
-			const unlinkAbort = linkAbortSignal(event.signal, claimedWarmJob.controller);
-			let warmCompaction: CompactionResult | undefined;
-			let warmFailure: Error | undefined;
-			try {
-				warmCompaction = await claimedWarmJob.promise;
-				warmFailure = await claimedWarmJob.failure;
-			} finally {
-				unlinkAbort();
-			}
-			if (warmFailure === undefined && warmCompaction && !event.signal.aborted) {
-				getLogger(ctx).debug("warm_consumed", { generation: claimedWarmJob.generation, route: "core-route" });
-				return { compaction: warmCompaction };
-			}
-		}
-
-		const snapshot = {
-			generation: ++speculativeGeneration,
-			expectedRevision: ctx.getMessageRevision(),
-			model,
-			contextWindow: ctx.getContextUsage()?.contextWindow ?? model.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-			preparation: event.preparation,
-			branchEntries: event.branchEntries,
-			promptVariant: getPromptVariant(event),
-			origin: "core-route" as const,
-			customInstructions: event.customInstructions,
-			systemPrompt: ctx.getSystemPrompt(),
-			tools: getSummarizationTools(),
-		};
-		let compaction: CompactionResult | undefined;
 		try {
-			compaction = await runExtensionCompaction(ctx, snapshot, event.signal, (delta) =>
-				ctx.updateCompaction?.({ reason: event.reason, signal: event.signal, delta }),
-			);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			const failureKind = classifyRequiredCompactionFallbackFailure(error);
-			if (isRequiredCompactionFallbackReason(event.reason) && failureKind !== undefined && !event.signal.aborted) {
-				const fallback = createRequiredCompactionFallback(
-					snapshot.preparation,
-					snapshot.contextWindow,
-					failureKind,
-					{ taskIntent: resolveInheritedTaskIntent(event.branchEntries) },
-					event.branchEntries,
-				);
-				if (fallback) return { compaction: fallback };
-				pendingMetadata.delete(event.requestId);
+			if (lanePolicy.disablesSenpiCompaction(ctx)) {
+				return { cancel: true, reason: SDK_NATIVE_LANE_REJECTION_REASON };
+			}
+			if (cap.shouldRejectByCap(state).cancel) {
+				getLogger(ctx).debug("skip_cap", { reason: event.reason, count: state.acceptedAbsolute });
 				return {
 					cancel: true,
-					reason: "deterministic compaction fallback cannot retain the prepared suffix",
+					rejectionCause: "per-turn-cap",
+					reason: "absolute compaction cap reached for this session",
 				};
 			}
-			pendingMetadata.delete(event.requestId);
-			if (error instanceof SummaryGenerationError) {
-				return { cancel: true, reason: error.message };
+			const now = Date.now();
+			if (breaker.isTripped(state, now) && !breaker.shouldBypass(state, { reason: event.reason })) {
+				const remainingMs = state.trippedAt !== null ? Math.max(0, state.trippedAt + breaker.COOLDOWN_MS - now) : 0;
+				getLogger(ctx).debug("skip_breaker", { reason: event.reason, remainingSec: Math.ceil(remainingMs / 1000) });
+				return {
+					cancel: true,
+					rejectionCause: "circuit-breaker",
+					reason: `compaction circuit breaker cooling down (${Math.ceil(remainingMs / 1000)}s left)`,
+				};
 			}
-			return { cancel: true, reason: `compaction generator failed: ${message}` };
-		}
-		if (!compaction) {
-			pendingMetadata.delete(event.requestId);
-			if (event.signal.aborted) {
-				return { cancel: true };
-			}
-			return { cancel: true, reason: "compaction generator returned no summary" };
-		}
 
-		return {
-			compaction,
-		};
+			capturePendingMetadata(event.requestId, ctx);
+
+			const model = ctx.model;
+			if (!model) {
+				return undefined;
+			}
+			const remoteCompaction = await runOpenAiRemoteCompaction(
+				ctx,
+				event,
+				(data) => pi.events.emit(SENPI_COMPACTION_EVENT, data),
+				remoteCompactionDependencies,
+			);
+			if (remoteCompaction) {
+				getLogger(ctx).debug("core_route_generated", { route: "core-route", requestId: event.requestId });
+				return { compaction: remoteCompaction };
+			}
+
+			if (claimedWarmJob) {
+				const unlinkAbort = linkAbortSignal(event.signal, claimedWarmJob.controller);
+				let warmCompaction: CompactionResult | undefined;
+				let warmFailure: Error | undefined;
+				try {
+					warmCompaction = await claimedWarmJob.promise;
+					warmFailure = await claimedWarmJob.failure;
+				} finally {
+					unlinkAbort();
+				}
+				if (warmFailure === undefined && warmCompaction && !event.signal.aborted) {
+					getLogger(ctx).debug("warm_consumed", { generation: claimedWarmJob.generation, route: "core-route" });
+					warmJobConsumed = true;
+					return { compaction: warmCompaction };
+				}
+			}
+
+			const snapshot = {
+				generation: ++speculativeGeneration,
+				expectedRevision: ctx.getMessageRevision(),
+				model,
+				contextWindow: ctx.getContextUsage()?.contextWindow ?? model.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+				preparation: event.preparation,
+				branchEntries: event.branchEntries,
+				promptVariant: getPromptVariant(event),
+				origin: "core-route" as const,
+				customInstructions: event.customInstructions,
+				systemPrompt: ctx.getSystemPrompt(),
+				tools: getSummarizationTools(),
+			};
+			let compaction: CompactionResult | undefined;
+			try {
+				compaction = await runExtensionCompaction(ctx, snapshot, event.signal, (delta) =>
+					ctx.updateCompaction?.({ reason: event.reason, signal: event.signal, delta }),
+				);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				const failureKind = classifyRequiredCompactionFallbackFailure(error);
+				if (
+					isRequiredCompactionFallbackReason(event.reason) &&
+					failureKind !== undefined &&
+					!event.signal.aborted
+				) {
+					const fallback = createRequiredCompactionFallback(
+						snapshot.preparation,
+						snapshot.contextWindow,
+						failureKind,
+						{ taskIntent: resolveInheritedTaskIntent(event.branchEntries) },
+						event.branchEntries,
+					);
+					if (fallback) return { compaction: fallback };
+					pendingMetadata.delete(event.requestId);
+					return {
+						cancel: true,
+						reason: "deterministic compaction fallback cannot retain the prepared suffix",
+					};
+				}
+				pendingMetadata.delete(event.requestId);
+				if (error instanceof SummaryGenerationError) {
+					return { cancel: true, reason: error.message };
+				}
+				return { cancel: true, reason: `compaction generator failed: ${message}` };
+			}
+			if (!compaction) {
+				pendingMetadata.delete(event.requestId);
+				if (event.signal.aborted) {
+					return { cancel: true };
+				}
+				return { cancel: true, reason: "compaction generator returned no summary" };
+			}
+
+			return {
+				compaction,
+			};
+		} finally {
+			if (!warmJobConsumed) claimedWarmJob?.controller.abort();
+		}
 	});
 
 	pi.on("model_select", (event, ctx) => {

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -514,12 +514,17 @@ export default function compactionExtension(
 
 	pi.on("session_before_compact", async (event: SessionBeforeCompactEvent, ctx) => {
 		const claimedWarmJob = claimWarmSummaryForCoreRoute(event, ctx);
+		// A claim detaches the job without aborting it, so every path that leaves
+		// without consuming the result must still stop the request it is paying for.
+		const releaseUnusedWarmJob = () => claimedWarmJob?.controller.abort();
 		invalidateSpeculativeCompaction(ctx);
 		if (lanePolicy.disablesSenpiCompaction(ctx)) {
+			releaseUnusedWarmJob();
 			return { cancel: true, reason: SDK_NATIVE_LANE_REJECTION_REASON };
 		}
 		if (cap.shouldRejectByCap(state).cancel) {
 			getLogger(ctx).debug("skip_cap", { reason: event.reason, count: state.acceptedAbsolute });
+			releaseUnusedWarmJob();
 			return {
 				cancel: true,
 				rejectionCause: "per-turn-cap",
@@ -530,6 +535,7 @@ export default function compactionExtension(
 		if (breaker.isTripped(state, now) && !breaker.shouldBypass(state, { reason: event.reason })) {
 			const remainingMs = state.trippedAt !== null ? Math.max(0, state.trippedAt + breaker.COOLDOWN_MS - now) : 0;
 			getLogger(ctx).debug("skip_breaker", { reason: event.reason, remainingSec: Math.ceil(remainingMs / 1000) });
+			releaseUnusedWarmJob();
 			return {
 				cancel: true,
 				rejectionCause: "circuit-breaker",
@@ -540,7 +546,10 @@ export default function compactionExtension(
 		capturePendingMetadata(event.requestId, ctx);
 
 		const model = ctx.model;
-		if (!model) return undefined;
+		if (!model) {
+			releaseUnusedWarmJob();
+			return undefined;
+		}
 		const remoteCompaction = await runOpenAiRemoteCompaction(
 			ctx,
 			event,
@@ -549,6 +558,7 @@ export default function compactionExtension(
 		);
 		if (remoteCompaction) {
 			getLogger(ctx).debug("core_route_generated", { route: "core-route", requestId: event.requestId });
+			releaseUnusedWarmJob();
 			return { compaction: remoteCompaction };
 		}
 

--- a/packages/coding-agent/test/compaction/core-route-warm-handoff.test.ts
+++ b/packages/coding-agent/test/compaction/core-route-warm-handoff.test.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { prepareCompaction } from "../../src/core/compaction/index.ts";
+import type { SessionBeforeCompactEvent } from "../../src/core/extensions/index.ts";
+import {
+	createBeforeAgentStartEvent,
+	createBlockingContext,
+	createCompactionHandlers,
+} from "../helpers/blocking-compaction-harness.ts";
+
+const registrations: Array<{ unregister: () => void }> = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) {
+		registration.unregister();
+	}
+});
+
+function coreCompactEvent(
+	harness: ReturnType<typeof createBlockingContext>,
+	overrides: Partial<SessionBeforeCompactEvent> = {},
+): SessionBeforeCompactEvent {
+	const branchEntries = harness.sessionManager.getBranch();
+	const preparation = prepareCompaction(branchEntries, harness.ctx.getCompactionSettings());
+	if (!preparation) throw new Error("fixture is not compactable");
+	return {
+		type: "session_before_compact",
+		reason: "threshold",
+		willRetry: false,
+		requestId: randomUUID(),
+		preparation,
+		branchEntries,
+		signal: new AbortController().signal,
+		...overrides,
+	};
+}
+
+/**
+ * On a new prompt the core admission path runs BEFORE `before_agent_start`
+ * (agent-session.ts `_enforceCompactionBeforeProvider` precedes
+ * `emitBeforeAgentStart`), so the core route reaches compaction first and its
+ * `session_before_compact` handler decides the fate of any warm summary the
+ * idle warm-up already paid for.
+ */
+describe("Given a completed idle warm summary and a core-route compaction", () => {
+	it("Then the core route consumes the warm summary instead of billing a second one", async () => {
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 4_000 });
+		registrations.push(harness.registration);
+		harness.registration.setResponses([
+			fauxAssistantMessage("warm summary paid for while the user was away"),
+			fauxAssistantMessage("fresh summary the user should never wait for"),
+		]);
+
+		// Given: the warm-up band starts a speculative job and it settles.
+		await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// When: the core route asks the extension for a summary.
+		const result = await handlers.sessionBeforeCompact(coreCompactEvent(harness), harness.ctx);
+
+		// Then: the warm result is handed over, so only the warm-up was billed.
+		expect(result?.compaction?.summary).toContain("warm summary paid for while the user was away");
+		expect(harness.registration.state.callCount).toBe(1);
+	});
+
+	it("Then a warm summary cut at a different boundary is refused and regenerated once", async () => {
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 4_000 });
+		registrations.push(harness.registration);
+		harness.registration.setResponses([
+			fauxAssistantMessage("warm summary for a different cut"),
+			fauxAssistantMessage("fresh summary matching the core preparation"),
+		]);
+
+		await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// When: core's own preparation cuts somewhere the warm summary does not cover.
+		const event = coreCompactEvent(harness);
+		const mismatched: SessionBeforeCompactEvent = {
+			...event,
+			preparation: { ...event.preparation, firstKeptEntryId: "a-boundary-the-warm-summary-never-covered" },
+		};
+		const result = await handlers.sessionBeforeCompact(mismatched, harness.ctx);
+
+		// Then: the stale-cut warm result must never be handed to core.
+		expect(result?.compaction?.summary).not.toContain("warm summary for a different cut");
+		expect(harness.registration.state.callCount).toBe(2);
+	});
+
+	it("Then a manual compaction carrying custom instructions never reuses the idle summary", async () => {
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 4_000 });
+		registrations.push(harness.registration);
+		harness.registration.setResponses([
+			fauxAssistantMessage("warm summary written for the automatic policy"),
+			fauxAssistantMessage("fresh summary honouring the user's instructions"),
+		]);
+
+		await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// When: the user asks for a compaction with their own instructions.
+		const result = await handlers.sessionBeforeCompact(
+			coreCompactEvent(harness, { reason: "manual", customInstructions: "focus on the API decisions" }),
+			harness.ctx,
+		);
+
+		// Then: an idle summary written under different instructions is not substituted.
+		expect(result?.compaction?.summary).not.toContain("warm summary written for the automatic policy");
+		expect(harness.registration.state.callCount).toBe(2);
+	});
+
+	it("Then a warm summary is refused after a compaction boundary lands", async () => {
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 4_000 });
+		registrations.push(harness.registration);
+		harness.registration.setResponses([
+			fauxAssistantMessage("warm summary describing pre-boundary history"),
+			fauxAssistantMessage("fresh summary for the rewritten history"),
+		]);
+
+		await handlers.beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// When: another route commits a compaction before this one is admitted.
+		harness.sessionManager.appendCompaction(
+			"a boundary committed by another route",
+			harness.sessionManager.getBranch()[0].id,
+			1_000,
+		);
+		// prepareCompaction refuses a branch whose tip is a compaction record, so the
+		// session must carry work past the new boundary to be compactable again.
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "work after the new boundary" }],
+			timestamp: 9,
+		});
+		const event = coreCompactEvent(harness);
+		const result = await handlers.sessionBeforeCompact(event, harness.ctx);
+
+		// Then: the warm summary describes history that no longer exists.
+		expect(result?.compaction?.summary).not.toContain("warm summary describing pre-boundary history");
+	});
+});


### PR DESCRIPTION
## Problem

senpi pre-generates a summary while your session sits idle so you never wait for compaction. PR #853 taught the **extension** route to reuse it. The **core** route still threw it away.

The ordering is deterministic, not a race — on a new prompt `_enforceCompactionBeforeProvider` runs before `emitBeforeAgentStart`, so core always reaches compaction first, and its handler called `invalidateSpeculativeCompaction()` as its **first statement**. Measured with a file probe on the real CLI:

```
IDLE_TRIGGER
CORE_ROUTE_ENTER reason=threshold hasJob=true   # core arrives first, job alive
BLOCKING_ROUTE_ENTER hasJob=false               # already destroyed
```

So the warm-up was aborted and re-billed in exactly the case it exists for.

## Fix

Claim the job for the core route instead of invalidating it:

- **Atomic** — detached synchronously before any `await`, so exactly one route can own it.
- **Not aborted** — the controller is deliberately left alive; aborting is what destroyed the finished work.
- **Narrow** — the claim holds only for an automatic compaction with no custom instructions, a speculative origin, the same model identity, a valid `WarmAnchorSnapshot`, and a boundary equal to core's own `preparation.firstKeptEntryId`. Every other case falls through to the existing fresh generation, unchanged.

Manual compaction keeps its own instructions, a landed boundary still forces regeneration, and a mismatched cut is refused — each covered by a test.

## Verification

**Real-CLI A/B** (`core-route-warm-handoff-qa.mjs`, RPC + mock provider, sandboxed HOME) — a genuine defect reproduction:

| | baseline `3358d48ff` | this branch |
|---|---|---|
| result | **7/9** | **9/9** |
| `warm_consumed` | **0** | **1** |

- Unit: RED `expected 'fresh summary…' to contain 'warm summary…'` → GREEN; 4 cases incl. three safety paths.
- `test/compaction/` **346 passed** (344 before).
- Invariant files green: `speculative-budget-handoff`, `required-compaction-deterministic-fallback`, `warm-summary-anchor`, `stale-warm-blocking-repro`, `metadata-side-effects`, `lifecycle`, `idle-compaction`, `speculative-abort-cancellation`, `suite/compaction-race`, `suite/agent-session-compaction` — 88 tests.
- Root `npm run check` exit 0.

## Scope note

An `AgentSession`-level test cannot drive this: `shouldRunIdleCompaction` requires a persistent mode (tui/rpc/app-server) and the vitest harness runs in `print`, so the warm-up never starts there. The end-to-end proof is the RPC QA scenario above, which runs in a real persistent mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses the idle warm summary in the core route so users don’t wait for a second compaction. Previously core always invalidated the speculative job and regenerated; now it claims the job when safe, returns its result, and reliably aborts any unused claim, including on thrown exits.

- `session_before_compact` calls `claimWarmSummaryForCoreRoute()` before invalidation. The claim detaches the job synchronously, logs `warm_consumed` with `route: "core-route"` on success, and uses a try/finally to abort the controller unless the result is consumed (covers early returns and exceptions).
- Claim conditions: automatic compaction (no custom instructions), speculative origin, same model identity, valid warm anchor on the current branch, and a boundary equal to `preparation.firstKeptEntryId`. Otherwise it regenerates.
- Manual compaction, landed boundaries, and mismatched cuts still regenerate. Covered by `core-route-warm-handoff.test.ts`. Adds a real-CLI QA scenario to verify `warm_consumed` and that core does not regenerate.

<sup>Written for commit 4c91dfd0ce7349ee210a4cf18d65d48212d540cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

