### PR TITLE
test(release): expect the staged transitive in the alias manifest

### DIFF
--- a/scripts/prepare-senpi-bundled-workspaces.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.test.mjs
@@ -191,6 +191,7 @@ describe("stagePublishManifest", () => {
 		assert.deepEqual(manifest.dependencies, {
 			"@earendil-works/pi-ai": "npm:@code-yeongyu/senpi-ai@2026.7.22",
 			"cross-spawn": "7.0.6",
+			which: "1.0.0",
 		});
 		assert.deepEqual(manifest.optionalDependencies, { "@mariozechner/clipboard": "0.3.9" });
 		assert.ok(manifest.bundleDependencies.includes("@earendil-works/pi-ai"));


### PR DESCRIPTION
## Problem

`Test (workspaces + scripts)` is red on `main`. `scripts/prepare-senpi-bundled-workspaces.test.mjs` fails at the alias-resolution case:

```
+ actual - expected
  {
    '@earendil-works/pi-ai': 'npm:@code-yeongyu/senpi-ai@2026.7.22',
    'cross-spawn': '7.0.6',
+   which: '1.0.0'
  }
```

Reproduced on pristine `origin/main` (`3358d48ff`): `138 pass / 1 fail`.

## Why the expectation was stale, not the behavior

`which` is cross-spawn's transitive dependency and is staged deliberately — the sibling test in the same file says so in its own comment ("cross-spawn's transitive dep `which` is staged but only reachable via an edge") and asserts it in `staged`, `bundleDependencies` and `bundledDependencies`. A bundled dependency has to appear in `dependencies` for npm to extract it, so the manifest is correct; only this one assertion still expected the two direct entries.

## Fix

Expect the staged transitive in that assertion too. One added line, nothing removed.

`npm run test:scripts`: **139 pass / 0 fail** (was 138 / 1).

This unblocks every PR currently red on that job.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the alias-resolution test to expect the staged transitive `which` in the manifest `dependencies`, matching current bundling behavior. Previously the test expected only `@earendil-works/pi-ai` and `cross-spawn`; now it also expects `which`, restoring a green CI.

- Adjusts one assertion in `scripts/prepare-senpi-bundled-workspaces.test.mjs` to include `which: 1.0.0`.
- Aligns with existing expectations in the same file for staged runtime and bundled dependencies.
- Result: `npm run test:scripts` is 139 pass / 0 fail; unblocks the “Test (workspaces + scripts)” job on `main`.
- No runtime or release changes.

<sup>Written for commit 5816bd3c7ea5c36994d2007f1d16a610ea9c445b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

