### PR TITLE
fix(release): validate private registry sources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,11 +64,12 @@ npm run release -- --dry-run   # preview without committing
 The release script (`scripts/release.mjs`) imports `scripts/calver.mjs` to compute the next version, then:
 1. Bumps every workspace listed in `scripts/release-packages.mjs` in lockstep.
 2. Updates each package's `CHANGELOG.md`: `## [Unreleased]` → `## [<version>] - YYYY-MM-DD`.
-3. Commits `release: v<version>`, tags it, and pushes `main` and the tag to `origin`.
-4. The tag-triggered binary workflow builds and stages public artifacts.
-5. The trusted `publish-npm.yml` workflow publishes all registry packages through GitHub OIDC with npm provenance.
-6. After npm succeeds, the binary workflow makes the staged GitHub Release public.
-7. The release script re-inserts a fresh `## [Unreleased]` section in a next-cycle commit.
+3. Commits `release: v<version>`, tags it, and creates the fresh next-cycle
+   `## [Unreleased]` commit.
+4. Pushes `main` and the tag to `origin`.
+5. The tag-triggered binary workflow builds and stages public artifacts.
+6. The trusted `publish-npm.yml` workflow publishes all registry packages through GitHub OIDC with npm provenance.
+7. After npm succeeds, the binary workflow makes the staged GitHub Release public.
 
 Source workspace manifests are intentionally private. Real npm publication is
 only supported through the trusted workflow; use `npm run publish:dry` for local

--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -9,6 +9,9 @@
 - All seven registry package source manifests are private; the canonical
   publisher creates temporary public manifests only inside its validated
   release flow.
+- Lockstep validation and release-announcement enumeration now use one explicit
+  source-to-registry package map instead of inferring publication from
+  `private`.
 - Root `publish` and `publish:dry` scripts now route through the guarded
   publisher instead of calling npm workspaces directly.
 - The trusted workflow continues to publish every package with

--- a/scripts/prepare-senpi-publish-manifest.mjs
+++ b/scripts/prepare-senpi-publish-manifest.mjs
@@ -1,13 +1,10 @@
 import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { registryPackageNames } from "./registry-packages.mjs";
 
-export const ownedRegistryAliases = new Map([
-	["@earendil-works/pi-ai", "@code-yeongyu/senpi-ai"],
-	["@earendil-works/pi-agent-core", "@code-yeongyu/senpi-agent-core"],
-	["@earendil-works/pi-tui", "@code-yeongyu/senpi-tui"],
-	["@earendil-works/pi-pty", "@code-yeongyu/senpi-pty"],
-	["@earendil-works/pi-telemetry", "@code-yeongyu/senpi-telemetry"],
-]);
+export const ownedRegistryAliases = new Map(
+	[...registryPackageNames].filter(([sourceName, registryName]) => sourceName !== registryName),
+);
 const ownedRegistryPackageNames = new Set([...ownedRegistryAliases.values(), "@code-yeongyu/senpi-codemode"]);
 const vendoredOnlyPackageNames = ["@earendil-works/pi-client", "@earendil-works/pi-protocol"];
 

--- a/scripts/registry-packages.mjs
+++ b/scripts/registry-packages.mjs
@@ -1,0 +1,34 @@
+export const registryPackageNames = new Map([
+	["@earendil-works/pi-ai", "@code-yeongyu/senpi-ai"],
+	["@earendil-works/pi-agent-core", "@code-yeongyu/senpi-agent-core"],
+	["@earendil-works/pi-tui", "@code-yeongyu/senpi-tui"],
+	["@earendil-works/pi-pty", "@code-yeongyu/senpi-pty"],
+	["@earendil-works/pi-telemetry", "@code-yeongyu/senpi-telemetry"],
+	["@code-yeongyu/senpi-codemode", "@code-yeongyu/senpi-codemode"],
+	["@code-yeongyu/senpi", "@code-yeongyu/senpi"],
+]);
+
+export const registrySourcePackageNames = new Set(registryPackageNames.keys());
+
+export function resolveRegistryPackages(packages) {
+	const resolved = new Map();
+	for (const pkg of packages) {
+		if (!registrySourcePackageNames.has(pkg.name)) {
+			continue;
+		}
+		if (resolved.has(pkg.name)) {
+			throw new Error(`Duplicate registry package source: ${pkg.name}`);
+		}
+		resolved.set(pkg.name, pkg);
+	}
+
+	const missing = [...registrySourcePackageNames].filter((name) => !resolved.has(name));
+	if (missing.length > 0) {
+		throw new Error(`Missing registry package sources: ${missing.join(", ")}`);
+	}
+
+	return [...resolved.values()].map((pkg) => ({
+		...pkg,
+		registryName: registryPackageNames.get(pkg.name),
+	}));
+}

--- a/scripts/registry-packages.test.mjs
+++ b/scripts/registry-packages.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	registrySourcePackageNames,
+	resolveRegistryPackages,
+} from "./registry-packages.mjs";
+
+const completeSources = [...registrySourcePackageNames].map((name) => ({ name }));
+
+test("resolves every registry package source exactly once", () => {
+	assert.equal(resolveRegistryPackages(completeSources).length, 7);
+});
+
+test("rejects a missing registry package source", () => {
+	assert.throws(
+		() => resolveRegistryPackages(completeSources.slice(1)),
+		/Missing registry package sources/,
+	);
+});
+
+test("rejects a duplicate registry package source", () => {
+	assert.throws(
+		() => resolveRegistryPackages([...completeSources, completeSources[0]]),
+		/Duplicate registry package source/,
+	);
+});

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { findPackageDirectories } from "./package-workspaces.mjs";
-import { ownedRegistryAliases } from "./prepare-senpi-publish-manifest.mjs";
+import { resolveRegistryPackages } from "./registry-packages.mjs";
 
 export const WORKSPACE_PACKAGES = [
 	"packages/ai/package.json",
@@ -50,20 +50,14 @@ export function runSyncVersions(dryRun, runCommand, log, dryRunLog) {
 }
 
 export function getPublicWorkspacePackages() {
-	const publishedPackageNames = new Map([
-		...ownedRegistryAliases.entries(),
-		["@code-yeongyu/senpi-codemode", "@code-yeongyu/senpi-codemode"],
-		["@code-yeongyu/senpi", "@code-yeongyu/senpi"],
-	]);
-	return findPackageDirectories()
+	const workspacePackages = findPackageDirectories()
 		.map((directory) => ({
 			directory,
 			...JSON.parse(readFileSync(join(directory, "package.json"), "utf8")),
-		}))
-		.filter((pkg) => publishedPackageNames.has(pkg.name))
-		.map(({ directory, name, version }) => ({
+		}));
+	return resolveRegistryPackages(workspacePackages).map(({ directory, registryName, version }) => ({
 			directory,
-			name: publishedPackageNames.get(name),
+			name: registryName,
 			version,
 		}));
 }

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -8,6 +8,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { findPackageDirectories } from "./package-workspaces.mjs";
+import { resolveRegistryPackages } from "./registry-packages.mjs";
 
 const GENERATED_PACKAGE_SUFFIXES = [join("coding-agent", "install-lock")];
 // Fork-specific: `@earendil-works/pi-storage-sqlite-node` follows upstream's independent
@@ -35,10 +36,11 @@ const workspacePackages = findPackageDirectories(packageRoot)
 	.filter((directory) => !GENERATED_PACKAGE_SUFFIXES.some((suffix) => directory.endsWith(suffix)))
 	.map((directory) => {
 		const path = join(directory, "package.json");
-		return { data: JSON.parse(readFileSync(path, "utf8")), path };
+		const data = JSON.parse(readFileSync(path, "utf8"));
+		return { data, name: data.name, path };
 	})
 	.filter((pkg) => !INDEPENDENT_VERSION_PACKAGE_NAMES.has(pkg.data.name));
-const publishedPackages = workspacePackages.filter((pkg) => pkg.data.private !== true);
+const publishedPackages = resolveRegistryPackages(workspacePackages);
 const versionMap = new Map(workspacePackages.map((pkg) => [pkg.data.name, pkg.data.version]));
 
 console.log("Current versions:");
@@ -48,7 +50,7 @@ for (const pkg of [...publishedPackages].sort((a, b) => a.data.name.localeCompar
 
 const versions = new Set(publishedPackages.map((pkg) => pkg.data.version));
 if (versions.size > 1) {
-	console.error("\nERROR: Not all non-private packages have the same version.");
+	console.error("\nERROR: Not all registry packages have the same version.");
 	console.error("Expected lockstep versioning. Run one of:");
 	console.error("  npm run version:patch");
 	console.error("  npm run version:minor");
@@ -56,7 +58,7 @@ if (versions.size > 1) {
 	process.exit(1);
 }
 
-console.log("\nAll non-private packages are at the same version (lockstep).");
+console.log("\nAll registry packages are at the same version (lockstep).");
 
 // Source manifests must stay on local lockstep workspace versions so local
 // builds and tests resolve the current workspace packages. The release script

--- a/scripts/sync-versions.test.mjs
+++ b/scripts/sync-versions.test.mjs
@@ -31,17 +31,32 @@ test("synchronizes private dependencies without touching registry aliases, gener
 		await writeManifest(root, "packages/ai", {
 			name: "@earendil-works/pi-ai",
 			version: "2.0.0",
+			private: true,
 		});
 		await writeManifest(root, "packages/coding-agent", {
-			name: "@earendil-works/pi-coding-agent",
+			name: "@code-yeongyu/senpi",
 			version: "2.0.0",
+			private: true,
 		});
+		for (const [directory, name] of [
+			["agent", "@earendil-works/pi-agent-core"],
+			["tui", "@earendil-works/pi-tui"],
+			["pty", "@earendil-works/pi-pty"],
+			["telemetry", "@earendil-works/pi-telemetry"],
+			["senpi-codemode", "@code-yeongyu/senpi-codemode"],
+		]) {
+			await writeManifest(root, `packages/${directory}`, {
+				name,
+				version: "2.0.0",
+				private: true,
+			});
+		}
 		await writeManifest(root, "packages/evals", {
 			name: "@earendil-works/pi-evals",
 			version: "9.9.9",
 			private: true,
 			dependencies: {
-				"@earendil-works/pi-coding-agent": "^1.0.0",
+				"@code-yeongyu/senpi": "^1.0.0",
 				"@mariozechner/pi-ai": "npm:@earendil-works/pi-ai@1.0.0",
 			},
 		});
@@ -50,7 +65,7 @@ test("synchronizes private dependencies without touching registry aliases, gener
 			version: "0.0.0",
 			private: true,
 			dependencies: {
-				"@earendil-works/pi-coding-agent": "^1.0.0",
+				"@code-yeongyu/senpi": "^1.0.0",
 			},
 		});
 
@@ -58,14 +73,15 @@ test("synchronizes private dependencies without touching registry aliases, gener
 		assert.equal(result.status, 0, result.stderr);
 
 		const evalsManifest = await readManifest(root, "packages/evals");
-		assert.equal(evalsManifest.dependencies["@earendil-works/pi-coding-agent"], "^2.0.0");
+		assert.equal(evalsManifest.dependencies["@code-yeongyu/senpi"], "^2.0.0");
 		assert.equal(evalsManifest.dependencies["@mariozechner/pi-ai"], "npm:@earendil-works/pi-ai@1.0.0");
 		const generatedManifest = await readManifest(root, "packages/coding-agent/install-lock");
-		assert.equal(generatedManifest.dependencies["@earendil-works/pi-coding-agent"], "^1.0.0");
+		assert.equal(generatedManifest.dependencies["@code-yeongyu/senpi"], "^1.0.0");
 
 		await writeManifest(root, "packages/ai", {
 			name: "@earendil-works/pi-ai",
 			version: "3.0.0",
+			private: true,
 		});
 		const lockstepFailure = runSyncVersions(root);
 		assert.equal(lockstepFailure.status, 1, lockstepFailure.stderr);


### PR DESCRIPTION
## Summary

Keep release lockstep validation and release announcements aligned with the
seven registry packages now that every source workspace is private.

## Changes

- Add one explicit source-package to registry-package identity map.
- Use that map for lockstep version validation and release announcement
  enumeration instead of inferring publication from `private`.
- Update the regression fixture to model private AI and Senpi sources and prove
  divergent registry versions fail.
- Correct the documented order of the next-cycle changelog commit.

## QA & Evidence

- **RED:** private AI and Senpi fixtures at divergent versions incorrectly
  exited 0.
- **Focused GREEN:** sync-version and publication identity tests pass.
- **Release tooling:** `npm run test:scripts` passes 144/144.
- **Static gate:** `npm run check` passes.
- **Build gate:** `npm run build` passes.
- **Full suite:** `CI=1 npm test` passes.

## Risk

Low. The change centralizes existing registry identity data and does not alter
package contents or runtime behavior. `scripts/publish.mjs` retains its own
lockstep validation as a second publication boundary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces lockstep release validation and announcements using an explicit source→registry map now that all source manifests are private. Previously, we inferred “published” from non-private and could miss divergence; now we resolve all seven registry packages from private sources and fail fast on missing/duplicates.

- Reviewer notes:
  - Adds scripts/registry-packages.mjs with `registryPackageNames`, `registrySourcePackageNames`, and `resolveRegistryPackages`.
  - Refactors sync-versions.js and release-packages.mjs to use `resolveRegistryPackages` for lockstep checks and release enumeration; updates error text from “non-private” to “registry.”
  - Updates prepare-senpi-publish-manifest.mjs to derive `ownedRegistryAliases` from the central map.
  - Adds focused tests for resolving, missing, and duplicate registry sources; adjusts fixtures to model all private sources; ensures divergent versions fail.
  - Documentation: corrects release step order in CONTRIBUTING and notes the mapping in scripts/changes.md.

<sup>Written for commit 76624bb350a25c2b234967f60d00831a4e865ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

