### PR TITLE
fix(compaction): stand the idle warm-up watcher down on a retired generation

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/target-rpc-client.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/target-rpc-client.mjs
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { cliEntry, track, tsxEntry } from "./common.mjs";
 
 export class TargetRpcClient {
-	constructor({ env, cwd, targetRoot }) {
+	constructor({ env, cwd, targetRoot, extraArgs = [] }) {
 		const argv = [
 			tsxEntry(targetRoot),
 			"--tsconfig",
@@ -12,6 +12,7 @@ export class TargetRpcClient {
 			"--mode",
 			"rpc",
 			"--no-context-files",
+			...extraArgs,
 		];
 		this.child = track(spawn(process.execPath, argv, { cwd, env, stdio: ["pipe", "pipe", "pipe"] }));
 		this.pending = new Map();

--- a/.agents/skills/senpi-qa/scripts/scenarios/reload-stale-warmup-crash-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/reload-stale-warmup-crash-qa.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * Real-CLI QA for the reload-vs-idle-warm-up crash.
+ *
+ * Field crash:
+ *   pi exiting due to uncaughtException:
+ *   Error: stale extension generation after reload
+ *       at ExtensionRunner.assertActive (core/extensions/runner.js)
+ *       at Object.getContextUsage (core/extensions/runner.js)
+ *       at core/extensions/builtin/compaction/index.js
+ *
+ * The builtin compaction extension arms an idle warm-up retry after a transient
+ * summarization failure. `AgentSession.reload()` retires that extension
+ * generation, after which every `ExtensionContext` getter throws. The armed
+ * continuation and its timer used to read the retired context anyway, which
+ * killed the process.
+ *
+ * Flow: one turn pins the session over the idle threshold; the idle warm-up
+ * summarization fails transiently (arming the retry); rewriting the watched
+ * `settings.json` makes the builtin config-reload extension call
+ * `ctx.requestReload()` (the production reload path); the retry delay then
+ * elapses against the retired generation.
+ *
+ * PASS = the process stays alive, still answers a prompt after the reload, and
+ * neither stderr nor the sandbox logs contain `stale extension generation` or
+ * `uncaughtException`.
+ *
+ * SCOPE (verified, do not overclaim): this is a NON-REGRESSION PROBE of the
+ * reload path, not a crash reproduction. The reload really does retire the
+ * generation here — the `qa.reload` response itself comes back as
+ * `stale extension generation after reload` — but a scripted RPC run cannot pin
+ * the narrow interleaving the field crash needed: the warm job is invalidated
+ * and replaced within ~30ms, so `armIdleWarmupRetry`'s own
+ * `speculativeJob !== job` fence returns before the continuation touches the
+ * context. Running this scenario against the unfixed source therefore also
+ * passes. The faithful reproduction, with a mutation proof, lives in
+ * `packages/coding-agent/test/compaction/stale-context-idle-warmup.test.ts`.
+ *
+ * Usage:
+ *   node .agents/skills/senpi-qa/scripts/scenarios/reload-stale-warmup-crash-qa.mjs \
+ *     --evidence reload-stale-warmup
+ */
+
+import { createServer } from "node:http";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+	createChecks,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+} from "../lib/common.mjs";
+import { checkRealAuthUnchanged, hermeticEnv } from "../lib/mock-loop-support.mjs";
+import { TargetRpcClient } from "../lib/target-rpc-client.mjs";
+
+const CONTEXT_WINDOW = 128_000;
+const PINNED_INPUT_TOKENS = 120_000;
+const NEXT_PROMPT = "POST RELOAD PROMPT";
+const NEXT_REPLY = "POST RELOAD REPLY DELIVERED";
+// idle-retry.ts IDLE_WARMUP_RETRY_DELAY_MS is 15s; wait past it so the armed
+// timer actually fires while the generation is dead.
+const RETRY_WINDOW_MS = 20_000;
+
+function arg(name, fallback) {
+	const index = process.argv.indexOf(name);
+	return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+function writeAnthropicSse(res, text, modelId, inputTokens) {
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
+	const event = (type, data) =>
+		res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+	event("message_start", {
+		message: {
+			id: `msg_${Date.now()}`,
+			type: "message",
+			role: "assistant",
+			model: modelId,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: inputTokens, output_tokens: 0 },
+		},
+	});
+	event("content_block_start", { index: 0, content_block: { type: "text", text: "" } });
+	event("content_block_delta", { index: 0, delta: { type: "text_delta", text } });
+	event("content_block_stop", { index: 0 });
+	event("message_delta", { delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 40 } });
+	event("message_stop", {});
+	res.end();
+}
+
+function deferred() {
+	let resolvePromise;
+	const promise = new Promise((resolveNext) => {
+		resolvePromise = resolveNext;
+	});
+	if (!resolvePromise) throw new Error("deferred resolver missing");
+	return { promise, resolve: resolvePromise };
+}
+
+async function startProvider() {
+	const requests = [];
+	const firstSummary = deferred();
+	let callIndex = 0;
+	const server = createServer((req, res) => {
+		const chunks = [];
+		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("end", () => {
+			const body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+			const systemText = typeof body.system === "string" ? body.system : JSON.stringify(body.system ?? "");
+			callIndex++;
+			const summarization = callIndex === 2;
+			requests.push({ at: Date.now(), callIndex, summarization, url: req.url, systemPrefix: systemText.slice(0, 80) });
+			console.log(`[qa] provider request ${callIndex} summarization=${summarization}`);
+			if (summarization) {
+				// Fail the warm-up transiently: this is what arms the idle retry
+				// watcher whose continuation later reads the retired context.
+				res.writeHead(529, { "content-type": "application/json" });
+				res.end(JSON.stringify({ type: "error", error: { type: "overloaded_error", message: "Overloaded" } }));
+				firstSummary.resolve();
+				return;
+			}
+			const text = callIndex === 1 ? "x".repeat(40_000) : NEXT_REPLY;
+			const inputTokens = callIndex === 1 ? PINNED_INPUT_TOKENS : 1_000;
+			writeAnthropicSse(res, text, body.model ?? "mock-claude", inputTokens);
+		});
+	});
+	await new Promise((resolveListen, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolveListen);
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("provider address unavailable");
+	return {
+		origin: `http://127.0.0.1:${address.port}`,
+		requests,
+		firstSummary: firstSummary.promise,
+		stop: () => new Promise((resolveStop) => server.close(resolveStop)),
+	};
+}
+
+function writeConfig(agentDir, provider) {
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				anthropic: {
+					baseUrl: provider.origin,
+					apiKey: "sk-mock-idle-compaction",
+					api: "anthropic-messages",
+					models: [
+						{
+							id: "mock-claude",
+							api: "anthropic-messages",
+							baseUrl: provider.origin,
+							contextWindow: CONTEXT_WINDOW,
+							maxTokens: 4_096,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						},
+					],
+				},
+			},
+		}),
+	);
+	writeFileSync(
+		join(agentDir, "settings.json"),
+		JSON.stringify({
+			compaction: {
+				enabled: true,
+				speculativeEnabled: true,
+				idleCompactionEnabled: true,
+				keepRecentTokens: 40,
+			},
+		}),
+	);
+}
+
+/**
+ * Sandbox extension exposing the host reload action over the RPC
+ * `extension_request` channel. `ctx.requestReload()` is the SAME entry point the
+ * builtin config-reload watcher uses in production (config-reload/index.ts), so
+ * driving it directly exercises the real reload path without depending on the
+ * watcher's project-trust gate, which a hermetic sandbox never grants.
+ */
+function writeReloadExtension(cwd) {
+	const dir = join(cwd, "qa-extensions");
+	mkdirSync(dir, { recursive: true });
+	const file = join(dir, "qa-reload.ts");
+	writeFileSync(
+		file,
+		[
+			"export default function qaReload(pi: any) {",
+			"	let latest: any;",
+			'	pi.on("session_start", (_event: unknown, ctx: any) => {',
+			"		latest = ctx;",
+			"	});",
+			'	pi.on("agent_end", (_event: unknown, ctx: any) => {',
+			"		latest = ctx;",
+			"	});",
+			'	pi.rpc.handle("qa.reload", async () => {',
+			"		if (!latest?.requestReload) return { reloaded: false, reason: \"requestReload unavailable\" };",
+			"		await latest.requestReload();",
+			"		return { reloaded: true };",
+			"	});",
+			"}",
+			"",
+		].join("\n"),
+	);
+	return file;
+}
+
+function readAgentLogs(agentDir) {
+	const logsDir = join(agentDir, "logs");
+	let text = "";
+	try {
+		for (const name of readdirSync(logsDir)) text += readFileSync(join(logsDir, name), "utf8");
+	} catch {
+		return text;
+	}
+	return text;
+}
+
+function readSessionEntries(sessionDir) {
+	const file = readdirSync(sessionDir).find((name) => name.endsWith(".jsonl"));
+	if (!file) throw new Error(`no session JSONL in ${sessionDir}`);
+	return readFileSync(join(sessionDir, file), "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+}
+
+async function main() {
+	installCleanupHooks();
+	const checks = createChecks("reload-stale-warmup-crash-qa.mjs");
+	const guard = guardRealAuth();
+	const targetRoot = resolve(arg("--target-root", repoRoot()));
+	const label = arg("--evidence", "reload-stale-warmup");
+	const box = makeSandbox("reload-stale-warmup");
+	const provider = await startProvider();
+	writeConfig(box.agentDir, provider);
+	const reloadExtension = writeReloadExtension(box.cwd);
+	const client = new TargetRpcClient({
+		env: hermeticEnv(box.env),
+		cwd: box.cwd,
+		targetRoot,
+		extraArgs: ["-e", reloadExtension],
+	});
+
+	try {
+		console.log("[qa] rpc started");
+		await client.send({ type: "set_model", provider: "anthropic", modelId: "mock-claude" });
+		console.log("[qa] model selected");
+		const firstEnd = client.waitFor((event) => event.message.type === "agent_end");
+		await client.send({ type: "prompt", message: "turn one" });
+		console.log("[qa] first prompt accepted");
+		await firstEnd;
+		console.log("[qa] first agent_end observed");
+		await provider.firstSummary;
+		console.log("[qa] idle warm-up summarization failed (retry armed)");
+
+		// Production reload path: ctx.requestReload() retires this extension
+		// generation exactly as a /reload or a config-watch reload does.
+		const reloadResponse = await client.send({ type: "extension_request", name: "qa.reload", data: null }, 60_000);
+		console.log(`[qa] reload requested: ${JSON.stringify(reloadResponse?.data ?? reloadResponse)}`);
+
+		// Hold past the 15s retry delay so the armed timer fires against the
+		// retired generation. Before the fix this is where the process died.
+		const deadline = Date.now() + RETRY_WINDOW_MS;
+		while (Date.now() < deadline && client.child.exitCode === null) {
+			await new Promise((resolveTick) => setTimeout(resolveTick, 500));
+		}
+		const aliveAfterWindow = client.child.exitCode === null;
+		console.log(`[qa] retry window elapsed aliveAfterWindow=${aliveAfterWindow}`);
+
+		let replyDelivered = false;
+		if (aliveAfterWindow) {
+			const secondEnd = client.waitFor((event) => event.message.type === "agent_end" && event.at >= deadline);
+			await client.send({ type: "prompt", message: NEXT_PROMPT });
+			console.log("[qa] post-reload prompt accepted");
+			await secondEnd;
+			console.log("[qa] post-reload agent_end observed");
+			replyDelivered = JSON.stringify(readSessionEntries(box.sessionDir)).includes(NEXT_REPLY);
+		}
+
+		const combined = `${client.stderr}\n${readAgentLogs(box.agentDir)}`;
+		const staleHits = combined.split("stale extension generation").length - 1;
+		const uncaughtHits = combined.split("uncaughtException").length - 1;
+
+		checks.ok("cli survived reload + retry window", aliveAfterWindow, `exitCode=${client.child.exitCode}`);
+		checks.ok("post-reload prompt answered", replyDelivered, `replyDelivered=${replyDelivered}`);
+		checks.ok("no stale-generation error surfaced", staleHits === 0, `hits=${staleHits}`);
+		checks.ok("no uncaughtException surfaced", uncaughtHits === 0, `hits=${uncaughtHits}`);
+		checkRealAuthUnchanged(checks, guard);
+
+		const outDir = join(repoRoot(), "local-ignore", "qa-evidence", `${new Date().toISOString().slice(0, 10).replaceAll("-", "")}-reload-stale-warmup`, label);
+		mkdirSync(outDir, { recursive: true });
+		writeFileSync(
+			join(outDir, "result.json"),
+			JSON.stringify(
+				{
+					targetRoot,
+					aliveAfterWindow,
+					replyDelivered,
+					staleHits,
+					uncaughtHits,
+					exitCode: client.child.exitCode,
+					requests: provider.requests,
+					events: client.events.map((event) => ({ at: event.at, type: event.message.type })),
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(join(outDir, "stderr.txt"), client.stderr);
+		console.log(`[qa] evidence written to ${outDir}`);
+		process.exitCode = checks.finish() ? 0 : 1;
+	} finally {
+		await client.close();
+		await provider.stop();
+		box.cleanup();
+	}
+}
+
+await main();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,7 @@
   rejection from the failure continuation and as an `uncaughtException` from the armed retry timer, killing the
   process. The watcher now stands down on `session_shutdown` and re-checks that its generation is still live before
   either continuation touches the context
-  ([#865](https://github.com/code-yeongyu/senpi/pull/865)).
+  ([#866](https://github.com/code-yeongyu/senpi/pull/866)).
 
 - Every registry package source is now private, and every scripted release-publication entrypoint fails
   closed outside the trusted GitHub Actions path, preventing direct or scripted npm publication without

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Fixed
 
+- A session reload no longer crashes the CLI while a compaction idle warm-up retry is pending. The warm-up watcher
+  armed after a transient summarization failure kept reading its `ExtensionContext` after `reload()` retired that
+  extension generation, and the resulting `stale extension generation after reload` escaped as an unhandled
+  rejection from the failure continuation and as an `uncaughtException` from the armed retry timer, killing the
+  process. The watcher now stands down on `session_shutdown` and re-checks that its generation is still live before
+  either continuation touches the context
+  ([#865](https://github.com/code-yeongyu/senpi/pull/865)).
+
 - Every registry package source is now private, and every scripted release-publication entrypoint fails
   closed outside the trusted GitHub Actions path, preventing direct or scripted npm publication without
   provenance attestations.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,48 @@
 # Builtin compaction extension changes
 
+## Stand the idle warm-up watcher down on a retired generation (2026-08-13)
+
+### What changed
+
+- `index.ts` gained `isContextRetired(ctx)`, and `armIdleWarmupRetry` now consults it in BOTH continuations that
+  outlive the runner generation that armed them: the `job.failure` continuation and the armed retry `setTimeout`.
+- `index.ts` registers a `session_shutdown` handler that cancels the pending warm-up timer, resets the attempt
+  counter, and aborts the in-flight speculative job.
+
+### Why
+
+- `AgentSession.reload()` retires the old extension generation (`oldExtensionRunner.invalidate("stale extension
+  generation after reload")`), after which every `ExtensionContext` getter throws. The warm-up watcher outlived that
+  invalidation and read the retired context anyway, and neither call site had a caller left to receive the throw:
+  the failure continuation is spawned with `void` (an unhandled rejection) and the timer callback throws straight
+  into the timer queue. Interactive mode promotes that to `uncaughtCrash`, so a reload landing inside the warm-up
+  retry window killed the CLI with:
+
+  ```
+  pi exiting due to uncaughtException:
+  Error: stale extension generation after reload
+      at ExtensionRunner.assertActive (core/extensions/runner.js)
+      at Object.getContextUsage (core/extensions/runner.js)
+      at core/extensions/builtin/compaction/index.js
+  ```
+
+- `session_shutdown` fires on the reload path BEFORE the invalidation, so tearing the watcher down there is the
+  deterministic fix; `isContextRetired` remains the backstop for any path that retires a generation without
+  emitting the event.
+- The probe reads a getter inside `try`/`catch` because `ExtensionContext` deliberately exposes no liveness flag.
+  Adding one is a public-API change that this crash does not justify.
+
+### Why an extension could not do this
+
+- This is the builtin extension's own private warm-up watcher. No external extension can observe, cancel, or guard
+  another extension's armed timer or in-flight summarization continuation.
+
+### Expected merge-conflict zones
+
+- MEDIUM: `index.ts` `armIdleWarmupRetry` (both guard sites) — upstream has no such watcher, so a sync that
+  rewrites this function will drop the guards.
+- LOW: the trailing `session_shutdown` handler at the end of the extension factory.
+
 ## 2026-08-13 - Let the core route claim the idle warm summary
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -220,8 +220,28 @@ export default function compactionExtension(
 		idleWarmupTimer = undefined;
 	}
 
-	// Fenced on the observed job: a prompt, invalidation, or newer warm-up
-	// stands this watcher down before it can start a duplicate summarization.
+	// A session reload retires this extension generation while the warm-up
+	// watcher below is still armed: `AgentSession.reload()` invalidates the old
+	// runner, after which every `ExtensionContext` getter throws
+	// "stale extension generation after reload". The watcher outlives that
+	// invalidation in two places — the `job.failure` continuation and the armed
+	// retry timer — and neither had a caller left to receive the throw: the
+	// continuation is spawned with `void` (unhandled rejection) and the timer
+	// callback throws straight into the timer queue, which terminates the
+	// process. The context carries no liveness flag, so a retired generation is
+	// only observable by reading a getter and catching the assertion.
+	function isContextRetired(ctx: ExtensionContext): boolean {
+		try {
+			ctx.isIdle();
+			return false;
+		} catch {
+			return true;
+		}
+	}
+
+	// Fenced on the observed job: a prompt, invalidation, a reload, or a newer
+	// warm-up stands this watcher down before it can start a duplicate
+	// summarization.
 	function armIdleWarmupRetry(ctx: ExtensionContext): void {
 		const job = speculativeJob;
 		if (!job) return;
@@ -231,6 +251,11 @@ export default function compactionExtension(
 				return;
 			}
 			if (speculativeJob !== job) return;
+			// A reload between arming and this continuation retires the context.
+			if (isContextRetired(ctx)) {
+				cancelIdleWarmupRetry();
+				return;
+			}
 			const usage = ctx.getContextUsage();
 			const contextWindow = usage?.contextWindow ?? ctx.model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
 			const retryDecision: idleRetry.IdleWarmupRetryDecision = {
@@ -252,6 +277,9 @@ export default function compactionExtension(
 			idleWarmupTimer = setTimeout(() => {
 				idleWarmupTimer = undefined;
 				if (speculativeJob !== job) return;
+				// The reload may land after the timer was armed; a throw here would
+				// escape into the timer queue as an uncaughtException.
+				if (isContextRetired(ctx)) return;
 				if (!ctx.isIdle()) return;
 				idleWarmupAttempt += 1;
 				getLogger(ctx).debug("idle_trigger", {
@@ -897,5 +925,16 @@ export default function compactionExtension(
 
 	pi.on("tool_call", (event) => {
 		restoration.trackToolCall(restorationState, event);
+	});
+
+	// The reload path retires this extension generation right after this event
+	// (`AgentSession.reload()` invalidates the old runner), so stand the idle
+	// warm-up watcher down here rather than leaving a timer armed against a
+	// context that is about to start throwing on every read.
+	pi.on("session_shutdown", () => {
+		cancelIdleWarmupRetry();
+		idleWarmupAttempt = 0;
+		speculativeJob?.controller.abort();
+		speculativeJob = undefined;
 	});
 }

--- a/packages/coding-agent/test/compaction/stale-context-idle-warmup.test.ts
+++ b/packages/coding-agent/test/compaction/stale-context-idle-warmup.test.ts
@@ -1,0 +1,268 @@
+import { type FauxProviderRegistration, fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
+import type {
+	AgentEndEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	SessionShutdownEvent,
+} from "../../src/core/extensions/index.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+/**
+ * Reproduction for the field crash
+ *
+ *   pi exiting due to uncaughtException:
+ *   Error: stale extension generation after reload
+ *       at ExtensionRunner.assertActive (core/extensions/runner.js)
+ *       at Object.getContextUsage (core/extensions/runner.js)
+ *       at core/extensions/builtin/compaction/index.js
+ *
+ * `armIdleWarmupRetry` captures an `ExtensionContext` and reuses it from two
+ * continuations that outlive the runner generation that produced it:
+ *
+ *  1. `job.failure.then(...)` reads `ctx.getContextUsage()`, and
+ *  2. the armed `setTimeout` reads `ctx.isIdle()` and starts a new warm-up.
+ *
+ * `AgentSession.reload()` invalidates the OLD runner
+ * (agent-session.ts: `oldExtensionRunner.invalidate("stale extension
+ * generation after reload")`), after which every context getter throws. The
+ * failure continuation is spawned with `void`, so the throw becomes an
+ * unhandled rejection; the timer callback throws straight into the timer
+ * queue, which is a genuine uncaughtException that kills the process.
+ */
+
+type Registration = FauxProviderRegistration;
+const registrations: Registration[] = [];
+
+afterEach(() => {
+	vi.useRealTimers();
+	for (const registration of registrations.splice(0)) registration.unregister();
+});
+
+const RETRY_ADVANCE_MS = 60_000;
+
+interface StaleContextHarness {
+	agentEnd: (event: AgentEndEvent, ctx: ExtensionContext) => Promise<void> | void;
+	sessionShutdown: ((event: SessionShutdownEvent, ctx: ExtensionContext) => Promise<void> | void) | undefined;
+	registration: Registration;
+	ctx: ExtensionContext;
+	/** Mirrors `ExtensionRunner.invalidate()`: every later context read throws. */
+	invalidateRunnerGeneration: () => void;
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+/**
+ * Builds the compaction extension over a context whose getters are guarded by
+ * the same stale-generation check the real `ExtensionRunner` applies
+ * (runner.ts `assertActive()`), so invalidation reproduces production exactly.
+ */
+function createStaleContextHarness(): StaleContextHarness {
+	const registration = registerFauxProvider();
+	registrations.push(registration);
+	const model = registration.getModel();
+	const authStorage = AuthStorage.inMemory();
+	authStorage.setRuntimeApiKey(model.provider, "faux-key");
+	const modelRegistry = ModelRegistry.inMemory(authStorage);
+	modelRegistry.registerProvider(model.provider, {
+		baseUrl: model.baseUrl,
+		apiKey: "faux-key",
+		api: registration.api,
+		models: registration.models.map((registeredModel) => ({
+			id: registeredModel.id,
+			name: registeredModel.name,
+			api: registeredModel.api,
+			reasoning: registeredModel.reasoning,
+			input: registeredModel.input,
+			cost: registeredModel.cost,
+			contextWindow: registeredModel.contextWindow,
+			maxTokens: registeredModel.maxTokens,
+			baseUrl: registeredModel.baseUrl,
+		})),
+	});
+
+	const sessionManager = SessionManager.inMemory();
+	const now = Date.now();
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "seed user" }],
+		timestamp: now - 2000,
+	});
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "seed user two" }],
+		timestamp: now - 1000,
+	});
+	sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "keep" }], timestamp: now });
+
+	let agentEnd: StaleContextHarness["agentEnd"] | undefined;
+	let sessionShutdown: StaleContextHarness["sessionShutdown"];
+	const api = Object.assign(Object.create(null), {
+		on: (event: string, handler: unknown) => {
+			if (event === "agent_end") agentEnd = handler as StaleContextHarness["agentEnd"];
+			if (event === "session_shutdown") sessionShutdown = handler as StaleContextHarness["sessionShutdown"];
+		},
+		appendEntry: vi.fn(),
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		getThinkingLevel: () => "off" as const,
+		events: { emit: vi.fn() },
+		sendMessage: vi.fn(),
+	}) as ExtensionAPI;
+	compactionExtension(api);
+	if (!agentEnd) throw new Error("agent_end handler was not registered");
+
+	const contextWindow = 100_000;
+	const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 1 };
+
+	// Exactly the message AgentSession.reload() passes to invalidate().
+	const STALE_MESSAGE = "stale extension generation after reload";
+	let staleMessage: string | undefined;
+	const assertActive = (): void => {
+		if (staleMessage) throw new Error(staleMessage);
+	};
+
+	const ctx = {
+		mode: "tui" as const,
+		model,
+		modelRegistry,
+		sessionManager,
+		agentDir: undefined,
+		get isIdle() {
+			assertActive();
+			return () => true;
+		},
+		get getContextUsage() {
+			assertActive();
+			return () => ({ tokens: 80_000, contextWindow, percent: 80 });
+		},
+		get getCompactionSettings() {
+			assertActive();
+			return () => settings;
+		},
+		compact: vi.fn(),
+		getMessageRevision: () => 1,
+		applyCompaction: vi.fn(async () => ({ applied: true, reason: "ok" })),
+		beginCompaction: vi.fn(() => undefined),
+		endCompaction: vi.fn(),
+		updateCompaction: vi.fn(),
+		getSystemPrompt: () => "TEST AGENT SYSTEM PROMPT",
+	} as unknown as ExtensionContext;
+
+	return {
+		agentEnd,
+		sessionShutdown,
+		registration,
+		ctx,
+		invalidateRunnerGeneration: () => {
+			staleMessage = STALE_MESSAGE;
+		},
+	};
+}
+
+function createAgentEndEvent(overrides?: Partial<AgentEndEvent>): AgentEndEvent {
+	return { type: "agent_end", messages: [], ...overrides };
+}
+
+/** Fails the test if the process observes an unhandled rejection. */
+function trackUnhandledRejections(): { errors: unknown[]; stop: () => void } {
+	const errors: unknown[] = [];
+	const onUnhandled = (reason: unknown): void => {
+		errors.push(reason);
+	};
+	process.on("unhandledRejection", onUnhandled);
+	return { errors, stop: () => process.off("unhandledRejection", onUnhandled) };
+}
+
+describe("Given a reload invalidates the runner while an idle warm-up retry is pending", () => {
+	it("Then the failure continuation must not throw a stale-generation error", async () => {
+		const harness = createStaleContextHarness();
+		const tracker = trackUnhandledRejections();
+		const firstRequested = createDeferred();
+		harness.registration.setResponses([
+			() => {
+				firstRequested.resolve();
+				return fauxAssistantMessage("summary failure", {
+					stopReason: "error",
+					errorMessage: "provider overloaded",
+				});
+			},
+			() => fauxAssistantMessage("should never be requested"),
+		]);
+
+		// Given: an idle warm-up job is in flight and about to fail transiently.
+		await harness.agentEnd(createAgentEndEvent(), harness.ctx);
+		await firstRequested.promise;
+
+		// When: a session reload retires this extension generation before the
+		// warm-up failure continuation runs.
+		harness.invalidateRunnerGeneration();
+
+		// Then: draining the continuation must not raise the stale-generation
+		// error the field crash reported.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		tracker.stop();
+
+		const staleErrors = tracker.errors.filter(
+			(error) => error instanceof Error && error.message.includes("stale extension generation"),
+		);
+		expect(staleErrors).toEqual([]);
+	});
+
+	it("Then the armed retry timer must not fire a stale-generation error", async () => {
+		vi.useFakeTimers();
+		const harness = createStaleContextHarness();
+		const tracker = trackUnhandledRejections();
+		const firstRequested = createDeferred();
+		harness.registration.setResponses([
+			() => {
+				firstRequested.resolve();
+				return fauxAssistantMessage("summary failure", {
+					stopReason: "error",
+					errorMessage: "provider overloaded",
+				});
+			},
+			() => fauxAssistantMessage("should never be requested"),
+		]);
+
+		// Given: the transient warm-up failure has armed the retry timer.
+		await harness.agentEnd(createAgentEndEvent(), harness.ctx);
+		await firstRequested.promise;
+		await vi.advanceTimersByTimeAsync(0);
+		const callsBeforeReload = harness.registration.state.callCount;
+
+		// When: the reload retires this generation and the timer then fires.
+		harness.invalidateRunnerGeneration();
+
+		// Then: the timer callback is a no-op instead of an uncaughtException,
+		// and it must not start another warm-up on the dead generation. A throw
+		// inside the timer callback surfaces here as a rejection, so capturing it
+		// is what distinguishes the fixed watcher from the crashing one.
+		let timerError: unknown;
+		try {
+			await vi.advanceTimersByTimeAsync(RETRY_ADVANCE_MS);
+		} catch (error) {
+			timerError = error;
+		}
+		tracker.stop();
+		expect(timerError).toBeUndefined();
+
+		const staleErrors = tracker.errors.filter(
+			(error) => error instanceof Error && error.message.includes("stale extension generation"),
+		);
+		expect(staleErrors).toEqual([]);
+		expect(harness.registration.state.callCount).toBe(callsBeforeReload);
+	});
+});


### PR DESCRIPTION
## Problem

A session reload landing inside the compaction idle warm-up retry window killed the CLI:

```
pi exiting due to uncaughtException:
Error: stale extension generation after reload
    at ExtensionRunner.assertActive (core/extensions/runner.js:513:19)
    at Object.getContextUsage (core/extensions/runner.js:784:24)
    at core/extensions/builtin/compaction/index.js:147:31
```

Reported from a real session right after a `/reload` ("Reloaded keybindings, extensions, skills, prompts, themes, and context files").

## Root cause

`armIdleWarmupRetry` (`builtin/compaction/index.ts`) captures an `ExtensionContext` and reuses it from **two continuations that outlive the runner generation which armed them**:

1. `void job.failure.then(...)` → reads `ctx.getContextUsage()`
2. the armed retry `setTimeout` → reads `ctx.isIdle()`, then starts a fresh warm-up

`AgentSession.reload()` retires the old generation (`oldExtensionRunner.invalidate("stale extension generation after reload")`), after which **every** context getter throws via `assertActive()`. Neither call site had a caller left to receive that throw:

- the failure continuation is spawned with `void` → **unhandled rejection**
- the timer callback throws straight into the timer queue → **true `uncaughtException`**, which interactive mode promotes to `uncaughtCrash` and exits the process.

The compaction extension registered no `session_shutdown` handler, so its timer and continuation survived the reload untouched.

## Fix

- `isContextRetired(ctx)` — both continuations re-check that their generation is still live before touching the context. The probe catches the assertion because `ExtensionContext` deliberately exposes no liveness flag; adding one is a public-API change this crash does not justify.
- `session_shutdown` handler — the reload path emits this **before** invalidating the old runner, so it deterministically cancels the pending timer, resets the attempt counter, and aborts the in-flight warm job. `isContextRetired` remains the backstop for any path that retires a generation without emitting the event.

Deliberately narrow: no behavior change on the live-context path, so the bounded idle retry policy (`idle-retry.ts`) is untouched.

## Verification

**RED → GREEN (faithful repro).** `test/compaction/stale-context-idle-warmup.test.ts` guards its context getters with the same stale check the real runner applies. Before the fix both cases failed with the production error, the timer case pointing at `compaction/index.ts:255` via `isIdle`:

```
AssertionError: expected [ Error: stale extension generation after reload ] to deeply equal []
Caused by: Error: stale extension generation after reload
  ❯ assertActive → Object.get isIdle → src/core/extensions/builtin/compaction/index.ts:255:14
```

**Mutation proof.** With `isContextRetired` forced to `false` and the `session_shutdown` handler emptied, **both** tests go RED with that exact error; restoring the fix returns them to GREEN. The assertions genuinely detect the regression rather than passing by construction.

**Gates.**

- `vitest --run test/compaction/` → **52 files / 350 tests passed** (baseline 349 + 2 new, none skipped)
- `tsc --noEmit -p tsconfig.build.json` → exit 0
- root `npm run check` → exit 0
- changelog gate → PASS

**Real-CLI QA** (`scenarios/reload-stale-warmup-crash-qa.mjs`, 5/5 PASS): pins the session over the idle threshold, fails the warm-up transiently to arm the retry, then calls `ctx.requestReload()` through a sandbox extension — the same entry point the builtin config-reload watcher uses. Process stays alive, answers the post-reload prompt, zero `stale extension generation` / `uncaughtException` hits, real auth unchanged.

**Scope, stated honestly:** that RPC scenario is a **non-regression probe, not a crash reproduction**, and it is documented as such in the script. The reload really does retire the generation there — the `qa.reload` response itself returns `stale extension generation after reload` — but the warm job is invalidated and replaced within ~30ms, so `armIdleWarmupRetry`'s own `speculativeJob !== job` fence returns before the continuation reads the context. Running it against unfixed source therefore also passes. The faithful reproduction, with the mutation proof above, is the unit test.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a CLI crash when a session reload lands during the compaction idle warm-up retry window. Previously the failure continuation and retry timer read a retired ExtensionContext and threw; now the watcher re-checks liveness and stands down on session shutdown.

- Adds `isContextRetired(ctx)` in `compaction/index.ts` and guards both `job.failure.then(...)` and the retry timer before any context read; registers a `session_shutdown` handler to cancel the timer, reset attempts, and abort the speculative job. Idle retry policy and live-context behavior are unchanged.
- Adds `packages/coding-agent/test/compaction/stale-context-idle-warmup.test.ts` to faithfully reproduce the stale-context paths and assert no unhandled rejection/uncaughtException.
- Adds a real-CLI QA scenario (`.agents/.../reload-stale-warmup-crash-qa.mjs`) that exercises the reload path; `TargetRpcClient` gains `extraArgs` to load a sandbox extension.
- Updates compaction change notes and the changelog.

<sup>Written for commit ca19f171e9be374dc8e9fa5b04f8f7daccc2d1cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

