### PR TITLE
fix(coding-agent): alias kimi-k3 into the shipped Fable fallback chain

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/fallback-chains-kimi-k3-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/fallback-chains-kimi-k3-qa.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * Real-surface QA for issue #793: the shipped claude-fable-5 fallback chain
+ * must expand to providers that expose Kimi K3 as `kimi-k3` (e.g. OpenCode Go).
+ *
+ * Drives the REAL interactive CLI in a tmux-backed sandbox whose models.json
+ * registers one provider `opencode-go` serving claude-fable-5, k3, kimi-k3,
+ * claude-opus-5 and claude-opus-4-8, opens `/fallback` -> "Show chains & live
+ * state", and asserts the canonical chain contains `opencode-go/kimi-k3:max`.
+ *
+ * Binary observable:
+ *   - chain display CONTAINS opencode-go/kimi-k3:max  -> fixed
+ *   - chain display OMITS  opencode-go/kimi-k3:max    -> bug present (RED)
+ *
+ * Usage: node fallback-chains-kimi-k3-qa.mjs [--evidence SLUG]
+ */
+
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	cliEntry,
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+	stripAnsi,
+	tsxEntry,
+} from "../lib/common.mjs";
+import { PROVIDER_ENV_KEYS } from "../lib/mock-loop-support.mjs";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function parseArgs(argv) {
+	const options = { evidence: undefined };
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--evidence") {
+			const next = argv[++i];
+			if (!next) throw new Error("--evidence requires a value");
+			options.evidence = next;
+		} else {
+			throw new Error(`Unknown option: ${argv[i]}`);
+		}
+	}
+	return options;
+}
+
+function seedModels(box) {
+	const model = (id) => ({
+		id,
+		reasoning: true,
+		contextWindow: 262144,
+		maxTokens: 8192,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	});
+	const config = {
+		providers: {
+			"opencode-go": {
+				baseUrl: "http://127.0.0.1:9/v1", // never contacted: no turn is driven
+				apiKey: "qa-chains-key",
+				api: "openai-completions",
+				models: ["claude-fable-5", "k3", "kimi-k3", "claude-opus-5", "claude-opus-4-8"].map(model),
+			},
+		},
+	};
+	writeFileSync(join(box.agentDir, "models.json"), JSON.stringify(config, null, 2));
+}
+
+function shq(value) {
+	return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+async function waitFor(read, alive, predicate, attempts = 300) {
+	let capture = "";
+	for (let i = 0; i < attempts && alive(); i++) {
+		await sleep(100);
+		capture = read();
+		if (predicate(capture)) break;
+	}
+	return capture;
+}
+
+async function main() {
+	const options = parseArgs(process.argv.slice(2));
+	const checks = createChecks("fallback-chains-kimi-k3-qa");
+	const guard = guardRealAuth();
+	installCleanupHooks();
+	const root = repoRoot();
+	const box = makeSandbox("fallback-chains-793");
+	seedModels(box);
+
+	const session = `senpi-qa-793-${process.pid}`;
+	const tmux = (...args) => execFileSync("tmux", args, { encoding: "utf8" });
+	const alive = () => {
+		try {
+			execFileSync("tmux", ["has-session", "-t", session], { stdio: "ignore" });
+			return true;
+		} catch {
+			return false;
+		}
+	};
+	const capture = () => {
+		try {
+			return tmux("capture-pane", "-t", session, "-p", "-S", "-");
+		} catch {
+			return "";
+		}
+	};
+	const send = (key, { literal = false } = {}) => {
+		const args = ["send-keys", "-t", session];
+		if (literal) args.push("-l");
+		args.push(key);
+		tmux(...args);
+	};
+
+	const shell = [
+		`cd ${shq(box.cwd)}`,
+		`unset ${PROVIDER_ENV_KEYS.join(" ")}`,
+		`export SENPI_CODING_AGENT_DIR=${shq(box.agentDir)} SENPI_CODING_AGENT_SESSION_DIR=${shq(box.sessionDir)} PI_OFFLINE=1 PI_TELEMETRY=0`,
+		`exec ${shq(process.execPath)} ${shq(tsxEntry(root))} --tsconfig ${shq(join(root, "tsconfig.json"))} ${shq(cliEntry(root))} --no-context-files --no-skills --approve`,
+	].join("; ");
+
+	const artifacts = {};
+	try {
+		try {
+			execFileSync("tmux", ["kill-session", "-t", session], { stdio: "ignore" });
+		} catch {}
+		tmux("new-session", "-d", "-s", session, "-x", "120", "-y", "34", shell);
+
+		await waitFor(
+			capture,
+			alive,
+			(text) => {
+				const plain = stripAnsi(text);
+				return plain.includes("❯") && !plain.includes("Loading senpi");
+			},
+			600,
+		);
+		await sleep(800);
+		artifacts.boot = capture();
+
+		send("/fallback", { literal: true });
+		send("Enter");
+		const menu = await waitFor(capture, alive, (text) => stripAnsi(text).includes("Model fallback"));
+		checks.ok("fallback menu opens", stripAnsi(menu).includes("Model fallback"));
+
+		// First menu entry is "Show chains & live state" — no navigation needed.
+		send("Enter");
+		const chains = await waitFor(capture, alive, (text) => stripAnsi(text).includes("opencode-go/claude-fable-5"));
+		artifacts.chains = chains;
+		const plain = stripAnsi(chains);
+		checks.ok("canonical fable chain renders", plain.includes("opencode-go/claude-fable-5"), plain.slice(0, 400));
+		checks.ok(
+			"chain includes opencode-go/kimi-k3:max (issue #793)",
+			plain.includes("opencode-go/kimi-k3:max"),
+			plain.includes("opencode-go/kimi-k3:max") ? "" : `chain text: ${plain.slice(0, 600)}`,
+		);
+		checks.ok("chain still includes opencode-go/k3:max", plain.includes("opencode-go/k3:max"));
+	} finally {
+		try {
+			execFileSync("tmux", ["kill-session", "-t", session], { stdio: "ignore" });
+		} catch {}
+		if (options.evidence) {
+			const dir = evidenceDir(options.evidence);
+			for (const [name, text] of Object.entries(artifacts)) {
+				writeFileSync(join(dir, `fallback-chains-793-${name}.txt`), stripAnsi(text));
+			}
+			process.stderr.write(`evidence: ${dir}\n`);
+		}
+		checks.ok("real auth unchanged", guard.assertUnchanged(), guard.path);
+		box.cleanup();
+	}
+	process.exit(checks.finish() ? 0 : 1);
+}
+
+await main();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Fixed
 
+- The shipped `claude-fable-5` fallback chain now reaches Kimi K3 on providers that expose the
+  model as `kimi-k3` (for example OpenCode Go), via an explicit `kimi-k3:max` entry. The
+  conservative family matcher is unchanged, so `k3` still cannot capture arbitrary ids
+  ([#793](https://github.com/code-yeongyu/senpi/issues/793)).
+
 - Every registry package source is now private, and every scripted release-publication entrypoint fails
   closed outside the trusted GitHub Actions path, preventing direct or scripted npm publication without
   provenance attestations.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -3,6 +3,33 @@
 The historical-image transport entry moved to `core/changes.md`, beside the
 other provider-bound image transport behavior that owns the same payload path.
 
+## Shipped Fable fallback chain reaches Kimi K3 served as `kimi-k3` (2026-08-13)
+
+### What changed
+
+- `core/retry-fallback/settings.ts`: `DEFAULT_FALLBACK_CHAINS["claude-fable-5"]` gains a bare `kimi-k3:max` entry after
+  `k3:max`, so providers that expose Kimi K3 under the vendor-prefixed id `kimi-k3` (OpenCode Go) join the shipped
+  Fable -> K3 fallback route. `matchesFamily` is untouched: the conservative exact/dash-suffix matcher still cannot
+  capture `kimi-k3` via `k3`, which is why the alias is an explicit entry rather than a matcher change (issue #793).
+- Coverage: `test/suite/retry-fallback-expansion.test.ts` (new alias expansion case + shipped-default pin),
+  `test/settings-manager-retry-fallback.test.ts` and `test/suite/retry-fallback-chains.test.ts` (shipped-default pins),
+  and the real-CLI scenario `.agents/skills/senpi-qa/scripts/scenarios/fallback-chains-kimi-k3-qa.mjs`.
+
+### Why
+
+- On registries serving `opencode-go/kimi-k3`, `/fallback` expanded the shipped Fable chain to Claude entries only:
+  `k3` matches `k3`/`k3-*` but never `kimi-k3`, so OpenCode Go users lost the intended Fable -> K3 route.
+
+### Why an extension could not do this
+
+- The shipped defaults are core policy consumed by `canonicalizeFallbackChains`; an extension can replace a chain per
+  key but cannot amend the shipped default's entries without owning the whole key.
+
+### Expected merge conflict zones on next upstream sync
+
+- `core/retry-fallback/settings.ts` (`DEFAULT_FALLBACK_CHAINS` literal).
+- The three test files pinning the shipped chain contents/length.
+
 ## Provider stream stalls share the bounded retry policy (2026-08-13)
 
 ### What changed

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -34,7 +34,10 @@ export interface ResolvedRetryFallbackSettings {
  * provider, the Claude SDK OAuth extension, a gateway, or Bedrock.
  */
 export const DEFAULT_FALLBACK_CHAINS: FallbackChains = {
-	"claude-fable-5": ["k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
+	// `kimi-k3:max` is an alias entry for providers that expose Kimi K3 under the
+	// vendor-prefixed id `kimi-k3` (e.g. OpenCode Go), which the conservative `k3`
+	// family matcher intentionally cannot capture (issue #793).
+	"claude-fable-5": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 };
 
 function cloneDefaultFallbackChains(): Record<string, readonly string[]> {

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 
 describe("SettingsManager retry fallback settings", () => {
 	const defaultChains = {
-		"claude-fable-5": ["k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
+		"claude-fable-5": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 	};
 
 	it("defaults abortServerSideFallback to true and round-trips an explicit false", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -128,7 +128,7 @@ describe("resolveRetryFallbackSettings chain defaults", () => {
 
 		expect(resolved.chains["example-gateway/unrelated-model"]).toEqual(["example-gateway/unrelated-fallback:max"]);
 		expect(resolved.chains[fableKey]).toEqual(DEFAULT_FALLBACK_CHAINS[fableKey]);
-		expect(DEFAULT_FALLBACK_CHAINS[fableKey]).toHaveLength(3);
+		expect(DEFAULT_FALLBACK_CHAINS[fableKey]).toHaveLength(4);
 		// The shipped default is provider-agnostic: bare ids only, expanded at canonicalization.
 		expect(Object.keys(DEFAULT_FALLBACK_CHAINS).every((key) => !key.includes("/"))).toBe(true);
 	});

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -50,8 +50,17 @@ const sdkAndAnthropic = [
 describe("bare model-id family expansion", () => {
 	it("ships a provider-agnostic default chain with bare model ids", () => {
 		expect(DEFAULT_FALLBACK_CHAINS).toEqual({
-			[FABLE]: ["k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
+			[FABLE]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 		});
+	});
+
+	it("expands the shipped kimi-k3 alias to providers that expose the model as kimi-k3", () => {
+		// Issue #793: OpenCode Go serves Kimi K3 as `kimi-k3`, which the bare `k3`
+		// family cannot match; the shipped chain carries an explicit alias entry.
+		const registry = [...sdkAndAnthropic, model("opencode-go", "kimi-k3")];
+		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(registry));
+
+		expect(chains[`anthropic/${FABLE}`]).toContain("opencode-go/kimi-k3:max");
 	});
 
 	it("expands a bare key into one canonical key per serving provider", () => {


### PR DESCRIPTION
## Summary

Fixes #793.

The shipped `claude-fable-5` fallback chain (`k3:max`, `claude-opus-5:xhigh`, `claude-opus-4-8:xhigh`) never expanded to providers that expose Kimi K3 as `kimi-k3` (OpenCode Go): `matchesFamily()` in `core/retry-fallback/expansion.ts` intentionally matches only an exact family id or a dash-suffixed variant, so `kimi-k3` cannot match the bare `k3` family. OpenCode Go users got a Fable chain of Claude entries only.

Fix (no design change, the issue's own suggested shape): add an explicit bare `kimi-k3:max` alias entry to `DEFAULT_FALLBACK_CHAINS`. The conservative matcher is untouched — `k3` still cannot capture arbitrary ids.

## Evidence

- **RED→GREEN (unit)**: new case in `test/suite/retry-fallback-expansion.test.ts` — registry with `opencode-go/kimi-k3` → canonical Fable chain contains `opencode-go/kimi-k3:max`. RED before (`expected [ 'kimi-coding/k3:max', …(4) ] to include 'opencode-go/kimi-k3:max'`), GREEN after. Shipped-default pins updated in three test files (chain grew 3 → 4 entries).
- **Regression**: 47/47 across `retry-fallback-{chains,expansion}`, `settings-manager-retry-fallback`, `interactive-mode-fallback`. Registries without `kimi-k3` produce byte-identical chains (exact-array pins), and `validateFallbackChains` only audits user-configured chains (`agent-session.ts:740`), so the new default entry warns nobody.
- **Real CLI QA (senpi-qa tmux sandbox, `opencode-go` serving `claude-fable-5`/`k3`/`kimi-k3`/opuses)**: `/fallback` → Show chains — RED on unfixed main (`kimi-k3:max` absent, `k3:max` present), GREEN 5/5 on this branch. New permanent scenario `.agents/skills/senpi-qa/scripts/scenarios/fallback-chains-kimi-k3-qa.mjs`; artifacts in `local-ignore/qa-evidence/20260813-fix-793-kimi-k3-chain/` (and `20260813-fix-793-chains-red/` for the RED run).
- `npm run check` green; changelog gate PASS.

## Test plan

- [x] `npx vitest run packages/coding-agent/test/suite/retry-fallback-*.test.ts packages/coding-agent/test/settings-manager-retry-fallback.test.ts packages/coding-agent/test/interactive-mode-fallback.test.ts` — 47/47
- [x] `node .agents/skills/senpi-qa/scripts/scenarios/fallback-chains-kimi-k3-qa.mjs --evidence fix-793-kimi-k3-chain` — 5/5 on branch, RED on main
- [x] `npm run check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aliases `kimi-k3:max` into the shipped `claude-fable-5` fallback chain so providers that serve Kimi K3 as `kimi-k3` (for example `opencode-go`) join the Fable → K3 route. Previously the `k3` family matcher only matched `k3`/`k3-*`, so those users saw only Claude entries; the matcher remains unchanged.

- Updates `DEFAULT_FALLBACK_CHAINS["claude-fable-5"]` from 3 to 4 entries by adding `kimi-k3:max`; `matchesFamily()` stays exact/dash-suffix only.
- Adds a unit test for alias expansion and refreshes shipped-default pins; asserts `opencode-go/kimi-k3:max` appears in the canonical chain.
- Adds a real CLI QA scenario (`.agents/skills/senpi-qa/scripts/scenarios/fallback-chains-kimi-k3-qa.mjs`) that checks `/fallback` → “Show chains & live state” includes the alias.
- Documents the change in `packages/coding-agent/src/changes.md`; update `CHANGELOG.md` to keep both upstream fixes and the new Kimi K3 entry (resolve conflict markers).
- No migration required; provider-agnostic defaults remain, and `validateFallbackChains` audits only user-configured chains.

<sup>Written for commit 408199a16f72e34fbf350f176a898e193b983f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

