### PR TITLE
test(goal): await exact continuation signals

### DIFF
--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -8,7 +8,6 @@ import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
 import { goalFilePath, readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
 import type { SessionEntry } from "../../src/core/session-manager.ts";
-import { waitForGoalContinuationCount } from "./goal-monitor-test-harness.ts";
 
 type AnyTool = ToolDefinition<any, any, any>;
 type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
@@ -768,7 +767,7 @@ describe("goal extension session_start migration-lite admission", () => {
 
 	it("resumes normally on the next clean turn after a real user prompt follows a suppressed load", async () => {
 		vi.useFakeTimers();
-		const { tools, handlers, sent } = createGoalHarness();
+		const { tools, handlers, sent, continuationQueued } = createGoalHarness();
 		const notices: string[] = [];
 		const ctx = await makeNotifyingCtx(notices, "thread-suppressed-then-prompt", [
 			userMessageEntry(),
@@ -798,12 +797,14 @@ describe("goal extension session_start migration-lite admission", () => {
 			ctx,
 		);
 		expect(sent).toHaveLength(0);
-		const graceDeliveryRecorded = waitForGoalContinuationCount(ctx, 1);
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
-		await graceDeliveryRecorded;
+		await continuationQueued;
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
-		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
+		expect(await readGoal(storeRefFor(ctx))).toMatchObject({
+			status: "active",
+			consecutiveContinuations: 1,
+		});
 		vi.useRealTimers();
 	});
 

--- a/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-test-harness.ts
@@ -1,4 +1,3 @@
-import { watch } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,7 +5,6 @@ import { clearTimeout as clearRealTimeout, setTimeout as setRealTimeout } from "
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
-import { readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
 
 type AnyTool = ToolDefinition;
@@ -256,36 +254,6 @@ export function waitForEventCount(
 			clearRealTimeout(timeout);
 			timeout = undefined;
 			unsubscribe();
-			if (error === undefined) resolve();
-			else reject(error);
-		}
-	});
-}
-
-export function waitForGoalContinuationCount(ctx: ExtensionContext, expectedCount: number): Promise<void> {
-	const baseDir = join(ctx.sessionManager.getSessionDir(), "extensions", "goal");
-	const threadId = ctx.sessionManager.getSessionId();
-	const goalFileName = `${encodeURIComponent(threadId)}.json`;
-	return new Promise((resolve, reject) => {
-		let completed = false;
-		let timeout: ReturnType<typeof setRealTimeout> | undefined;
-		const watcher = watch(baseDir, { encoding: "utf8" }, (_eventType, changedFileName) => {
-			if (changedFileName !== goalFileName) return;
-			void readGoal({ baseDir, threadId }).then((goal) => {
-				if (goal?.consecutiveContinuations === expectedCount) complete();
-			}, complete);
-		});
-		timeout = setRealTimeout(
-			() => complete(new Error(`Timed out waiting for continuation count ${expectedCount}`)),
-			5_000,
-		);
-		watcher.once("error", complete);
-
-		function complete(error: Error | undefined = undefined): void {
-			if (completed) return;
-			completed = true;
-			if (timeout !== undefined) clearRealTimeout(timeout);
-			watcher.close();
 			if (error === undefined) resolve();
 			else reject(error);
 		}

--- a/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-506-monitor-delayed-cap.test.ts
@@ -15,7 +15,7 @@ import {
 	createSentMessageHarness,
 	makeGoalContext,
 	TestEventBus,
-	waitForGoalContinuationCount,
+	waitForEventCount,
 	waitForSentCount,
 } from "../goal-monitor-test-harness.ts";
 
@@ -91,9 +91,9 @@ describe("issue #506: monitor-delayed continuation cap", () => {
 			goal: countedGoal,
 			messages: [assistantStopWithText("still waiting")],
 		});
-		const blockedGoalRecorded = waitForGoalContinuationCount(ctx, 0);
+		const guardTripped = waitForEventCount(events, "goal_continuation_guard_tripped", 1);
 		await vi.advanceTimersByTimeAsync(GOAL_MONITOR_CONTINUATION_FALLBACK_DELAY_MS);
-		await blockedGoalRecorded;
+		await guardTripped;
 
 		expect(harness.sent).toHaveLength(1);
 		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({


### PR DESCRIPTION
## Summary

Remove nondeterministic filesystem polling from goal continuation tests and
await exact pre-subscribed delivery/guard events instead.

## Trigger

The canonical `v2026.8.13-2` release failed before commit/tag/push:

```text
goal-extension.test.ts
Timed out waiting for continuation count 1
```

The harness used `fs.watch` plus a fixed real 5-second timeout, which can miss
or coalesce the persisted goal write under full-suite load.

## Changes

- Await the harness `continuationQueued` promise, resolved synchronously when
  the hidden continuation is sent after persisted accounting.
- Subscribe to `goal_continuation_guard_tripped` before advancing fake timers;
  production emits it after the blocked goal is persisted.
- Delete the filesystem watcher and fixed timeout helper.

Runtime source behavior is unchanged.

## QA & Evidence

- Owning tests: 44/44 passed.
- Stress: both event-driven scenarios passed 60/60 combined runs.
- Root static check: passed.
- Root build: passed.
- Full workspace suite: passed.
- Current-main merge rerun: owning tests 44/44 and root static check passed.
- Dedicated reviewer: PASS.
- Evidence:
  `local-ignore/qa-evidence/20260813-upstream-v0.84.1-release/release/goal-continuation-test-signal-summary.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make goal continuation tests deterministic by awaiting explicit events instead of filesystem polling. Previously tests used `fs.watch` with a fixed 5s timeout; now they await `continuationQueued` and pre-subscribe to `goal_continuation_guard_tripped`, removing flakiness without changing runtime behavior.

- Replace `waitForGoalContinuationCount` with event-driven waits (`continuationQueued`, `waitForEventCount(...)`) and delete the file-watcher helper.
- Subscribe to `goal_continuation_guard_tripped` before advancing fake timers to match production emission order.
- Update assertions to include `consecutiveContinuations`; changes are confined to `packages/coding-agent/test/suite/*`.

<sup>Written for commit 20b7a644ccc7289baa6e8ae82170983e95f43838. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

