### PR TITLE
fix(coding-agent): hide Claude auth probe window

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- The ambient Claude auth availability probe now passes `windowsHide: true` when spawning `claude auth status`, so the background check no longer opens a console window on Windows ([#870](https://github.com/code-yeongyu/senpi/issues/870)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/availability.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/availability.ts
@@ -16,7 +16,10 @@ export async function readAmbientClaudeAuthStatus(): Promise<boolean> {
 			settled = true;
 			resolve(available);
 		};
-		const child = spawn(executable, ["auth", "status"], { stdio: "ignore" });
+		const child = spawn(executable, ["auth", "status"], {
+			stdio: "ignore",
+			windowsHide: true,
+		});
 		child.once("error", () => finish(false));
 		child.once("close", (code) => finish(code === 0));
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -47,6 +47,20 @@
 
 - LOW: `session-registry-wiring.ts` at the `session_compact` handler and its focused wiring test.
 
+||||||| parent of 2c6a09919 (fix(coding-agent): hide Claude auth probe window)
+
+## 2026-08-14 - Hide ambient auth probes on Windows
+
+### What changed
+
+- `readAmbientClaudeAuthStatus()` now passes `windowsHide: true` when spawning
+  `claude auth status`, preventing the availability check from opening a console
+  window on Windows.
+
+### Expected merge-conflict zones
+
+- LOW: `availability.ts` spawn options.
+
 ## 2026-08-13 - Preserve request cancellation through OAuth refresh
 
 ### What changed

--- a/packages/coding-agent/test/claude-sdk-oauth-availability.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-availability.test.ts
@@ -1,0 +1,62 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.mocked(spawn);
+
+vi.mock("node:child_process", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:child_process")>();
+	return { ...actual, spawn: vi.fn() };
+});
+
+import { readAmbientClaudeAuthStatus } from "../src/core/extensions/builtin/claude-sdk-oauth/availability.ts";
+
+const executable = "C:/fixture/claude.exe";
+const previousExecutable = process.env.CLAUDE_CODE_EXECUTABLE;
+
+function fakeChild(outcome: 0 | 1 | "error"): ChildProcess {
+	const child = new EventEmitter() as unknown as ChildProcess;
+	queueMicrotask(() => {
+		if (outcome === "error") {
+			child.emit("error", Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+			return;
+		}
+		child.emit("close", outcome);
+	});
+	return child;
+}
+
+beforeEach(() => {
+	spawnMock.mockReset();
+	process.env.CLAUDE_CODE_EXECUTABLE = executable;
+});
+
+afterEach(() => {
+	if (previousExecutable === undefined) {
+		delete process.env.CLAUDE_CODE_EXECUTABLE;
+		return;
+	}
+	process.env.CLAUDE_CODE_EXECUTABLE = previousExecutable;
+});
+
+describe("readAmbientClaudeAuthStatus", () => {
+	it("hides the Claude auth status probe window", async () => {
+		spawnMock.mockReturnValue(fakeChild(0));
+
+		await expect(readAmbientClaudeAuthStatus()).resolves.toBe(true);
+		expect(spawnMock).toHaveBeenCalledWith(executable, ["auth", "status"], {
+			stdio: "ignore",
+			windowsHide: true,
+		});
+	});
+
+	it("returns false for a non-zero exit", async () => {
+		spawnMock.mockReturnValue(fakeChild(1));
+		await expect(readAmbientClaudeAuthStatus()).resolves.toBe(false);
+	});
+
+	it("returns false when the probe cannot spawn", async () => {
+		spawnMock.mockReturnValue(fakeChild("error"));
+		await expect(readAmbientClaudeAuthStatus()).resolves.toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- Hide the ambient `claude auth status` availability probe on Windows.
- Add direct regression coverage for the spawn options and existing false-result
  behavior.
- Record the extension change and expected conflict zone.

## QA & Evidence

- `npm test -- test/claude-sdk-oauth-availability.test.ts`
  - RED before the implementation: 1 failed, 2 passed because the actual spawn
    options contained only `stdio: "ignore"`.
  - GREEN after the implementation: 3 passed.
- `npm test -- test/claude-sdk-oauth-availability.test.ts test/claude-sdk-oauth-auth-status.test.ts test/claude-sdk-oauth-executable.test.ts`
  - 3 files passed, 21 tests passed.
- `npm run build`
  - All workspace build phases completed.
- `npx tsc -p packages/coding-agent/tsconfig.build.json --noEmit`
  - Exit code 0 after building workspace dependencies.

## Risk

Low. `windowsHide` is a supported Node child-process option on every platform;
it changes visible-window behavior only on Windows and does not alter exit-code
or error handling.

Closes #870

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the Windows console window opened by the Claude OAuth availability probe. Previously, `readAmbientClaudeAuthStatus()` could flash a console when running `claude auth status`; now it runs hidden on Windows without changing exit/return behavior.

- Pass `{ stdio: "ignore", windowsHide: true }` to `spawn` in `packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/availability.ts`.
- Add `packages/coding-agent/test/claude-sdk-oauth-availability.test.ts` to assert hidden spawn options and false returns on non-zero exit or spawn errors.
- Update `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md`.
- No migration required.

<sup>Written for commit 3ca55a0cad043ccfbe2c0641f55443758b71c4a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

