### PR TITLE
feat(settings): configure default Codex fast mode

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,9 @@
 # changes
 
+## Configurable default OpenAI Codex Fast mode
+
+`/settings` now exposes **Default Fast mode**, enabled by default. The preference is stored in global settings and applies when a new OpenAI Codex session starts; `/fast` remains a per-session override.
+
 The historical-image transport entry moved to `core/changes.md`, beside the
 other provider-bound image transport behavior that owns the same payload path.
 

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -83,16 +83,21 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 	pi.on("session_start", async (_event, ctx) => {
 		const settingsManager = SettingsManager.create(ctx.cwd);
 		settingsServiceTier = settingsManager.getOpenAIServiceTier();
-		sessionFastMode = false;
-		pi.setSessionFastMode(false);
 
 		const model = ctx.model;
 		if (model?.api !== OPENAI_CODEX_RESPONSES_API) {
+			sessionFastMode = false;
+			pi.setSessionFastMode(false);
 			return;
 		}
 
 		const baseModel = findBaseModel(ctx.modelRegistry, model);
-		if (baseModel) {
+		const fastModel = findFastModel(ctx.modelRegistry, model);
+		sessionFastMode = settingsManager.getOpenAIDefaultFastMode();
+		pi.setSessionFastMode(sessionFastMode);
+		if (sessionFastMode && fastModel) {
+			await pi.setSessionModel(fastModel);
+		} else if (!sessionFastMode && baseModel) {
 			await pi.setSessionModel(baseModel);
 		}
 	});
@@ -106,10 +111,11 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 				return;
 			}
 
+			const enabled = !sessionFastMode;
 			const baseModel = findBaseModel(ctx.modelRegistry, model);
-			const targetModel = baseModel ?? findFastModel(ctx.modelRegistry, model);
+			const targetModel = enabled ? findFastModel(ctx.modelRegistry, model) : baseModel;
 			if (!targetModel) {
-				sessionFastMode = !sessionFastMode;
+				sessionFastMode = enabled;
 				pi.setSessionFastMode(sessionFastMode);
 				ctx.ui.notify(`Fast mode ${sessionFastMode ? "enabled" : "disabled"}: ${model.id}`, "info");
 				return;
@@ -120,7 +126,8 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 				return;
 			}
 
-			const enabled = baseModel === undefined;
+			sessionFastMode = enabled;
+			pi.setSessionFastMode(sessionFastMode);
 			ctx.ui.notify(`Fast mode ${enabled ? "enabled" : "disabled"}: ${targetModel.id}`, "info");
 		},
 	});

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -106,6 +106,7 @@ export interface MarkdownSettings {
 
 export interface OpenAISettings {
 	serviceTier?: "auto" | "flex" | "priority";
+	defaultFastMode?: boolean; // default: true for OpenAI Codex sessions
 }
 
 export interface WarningSettings {
@@ -937,6 +938,19 @@ export class SettingsManager {
 
 	getOpenAIServiceTier(): OpenAISettings["serviceTier"] {
 		return this.settings.openai?.serviceTier;
+	}
+
+	getOpenAIDefaultFastMode(): boolean {
+		return this.settings.openai?.defaultFastMode ?? true;
+	}
+
+	setOpenAIDefaultFastMode(enabled: boolean): void {
+		if (!this.globalSettings.openai) {
+			this.globalSettings.openai = {};
+		}
+		this.globalSettings.openai.defaultFastMode = enabled;
+		this.markModified("openai", "defaultFastMode");
+		this.save();
 	}
 
 	setTransport(transport: TransportSetting): void {

--- a/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/interactive/components/settings-selector.ts
@@ -57,6 +57,7 @@ const DEFAULT_PROJECT_TRUST_BY_LABEL = new Map(
 
 export interface SettingsConfig {
 	autoCompact: boolean;
+	defaultFastMode: boolean;
 	showImages: boolean;
 	imageWidthCells: number;
 	autoResizeImages: boolean;
@@ -95,6 +96,7 @@ export interface SettingsConfig {
 
 export interface SettingsCallbacks {
 	onAutoCompactChange: (enabled: boolean) => void;
+	onDefaultFastModeChange: (enabled: boolean) => void;
 	onShowImagesChange: (enabled: boolean) => void;
 	onImageWidthCellsChange: (width: number) => void;
 	onAutoResizeImagesChange: (enabled: boolean) => void;
@@ -504,6 +506,13 @@ export class SettingsSelectorComponent extends Container {
 				values: ["true", "false"],
 			},
 			{
+				id: "default-fast-mode",
+				label: "Default Fast mode",
+				description: "Enable OpenAI Codex Fast mode when starting a new session",
+				currentValue: config.defaultFastMode ? "true" : "false",
+				values: ["true", "false"],
+			},
+			{
 				id: "steering-mode",
 				label: "Steering mode",
 				description:
@@ -790,6 +799,9 @@ export class SettingsSelectorComponent extends Container {
 				switch (id) {
 					case "autocompact":
 						callbacks.onAutoCompactChange(newValue === "true");
+						break;
+					case "default-fast-mode":
+						callbacks.onDefaultFastModeChange(newValue === "true");
 						break;
 					case "show-images":
 						callbacks.onShowImagesChange(newValue === "true");

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5488,6 +5488,7 @@ export class InteractiveMode {
 			selector = new SettingsSelectorComponent(
 				{
 					autoCompact: this.session.autoCompactionEnabled,
+					defaultFastMode: this.settingsManager.getOpenAIDefaultFastMode(),
 					showImages: this.settingsManager.getShowImages(),
 					imageWidthCells: this.settingsManager.getImageWidthCells(),
 					autoResizeImages: this.settingsManager.getImageAutoResize(),
@@ -5527,6 +5528,9 @@ export class InteractiveMode {
 					onAutoCompactChange: (enabled) => {
 						this.session.setAutoCompactionEnabled(enabled);
 						this.footer.setAutoCompactEnabled(enabled);
+					},
+					onDefaultFastModeChange: (enabled) => {
+						this.settingsManager.setOpenAIDefaultFastMode(enabled);
 					},
 					onShowImagesChange: (enabled) => {
 						this.settingsManager.setShowImages(enabled);

--- a/packages/coding-agent/test/settings-selector.test.ts
+++ b/packages/coding-agent/test/settings-selector.test.ts
@@ -19,6 +19,7 @@ describe("SettingsSelectorComponent", () => {
 		const selector = new SettingsSelectorComponent(
 			{
 				fullscreenScrollbar: "auto",
+				defaultFastMode: true,
 				warnings: {},
 				availableThinkingLevels: [],
 				availableThemes: [],
@@ -33,5 +34,24 @@ describe("SettingsSelectorComponent", () => {
 		settingsList.handleInput("\r");
 
 		expect(onChange.mock.calls.flat()).toEqual(["always", "hidden", "auto"]);
+	});
+
+	it("toggles the default Fast mode preference", () => {
+		const onChange = vi.fn();
+		const selector = new SettingsSelectorComponent(
+			{
+				defaultFastMode: true,
+				warnings: {},
+				availableThinkingLevels: [],
+				availableThemes: [],
+			} as unknown as SettingsConfig,
+			{ onDefaultFastModeChange: onChange } as unknown as SettingsCallbacks,
+		);
+		const settingsList = selector.getSettingsList();
+
+		for (const character of "Default Fast mode") settingsList.handleInput(character);
+		settingsList.handleInput("\r");
+
+		expect(onChange).toHaveBeenCalledWith(false);
 	});
 });

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -3,6 +3,7 @@ import serviceTierExtension, {
 	addServiceTierToPayload,
 	type ServiceTier,
 } from "../../src/core/extensions/builtin/service-tier.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
 import { createHarness, type Harness } from "./harness.ts";
 
 const CODEX_PROVIDER = "openai-codex";
@@ -67,7 +68,7 @@ describe("service-tier builtin extension", () => {
 		expect(result.service_tier).toBe("priority");
 	});
 
-	it("resets a fast model on session_start, then toggles the catalog variant within the session", async () => {
+	it("keeps a fast model on session_start, then toggles the catalog variant within the session", async () => {
 		// given
 		const harness = await createHarness({
 			api: CODEX_API,
@@ -90,11 +91,20 @@ describe("service-tier builtin extension", () => {
 		await harness.session.bindExtensions({});
 
 		// then
-		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
-		expect(harness.session.serviceTier).toBeUndefined();
-		expect(harness.session.isFastModeActive()).toBe(false);
+		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
+		expect(harness.session.serviceTier).toBe("priority");
+		expect(harness.session.isFastModeActive()).toBe(true);
 		expect(harness.settingsManager.getDefaultProvider()).toBe(CODEX_PROVIDER);
 		expect(harness.settingsManager.getDefaultModel()).toBe(BASE_MODEL_ID);
+
+		// when
+		await harness.session.prompt("/fast");
+
+		// then
+		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
+		expect(harness.session.serviceTier).toBeUndefined();
+		const defaultPayload = { model: BASE_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
 
 		// when
 		await harness.session.prompt("/fast");
@@ -102,25 +112,15 @@ describe("service-tier builtin extension", () => {
 		// then
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
 		expect(harness.session.serviceTier).toBe("priority");
+		expect(harness.settingsManager.getDefaultProvider()).toBe(CODEX_PROVIDER);
+		expect(harness.settingsManager.getDefaultModel()).toBe(BASE_MODEL_ID);
 		const fastModel = harness.session.model;
 		expect(fastModel).toBeDefined();
 		const upstreamModelId = harness.modelRegistry.getUpstreamModelId(fastModel!) ?? fastModel!.id;
-		const priorityPayload = await runner.emitBeforeProviderRequest({ model: upstreamModelId });
-		expect(priorityPayload).toEqual({
+		expect(await runner.emitBeforeProviderRequest({ model: upstreamModelId })).toEqual({
 			model: BASE_MODEL_ID,
 			service_tier: "priority",
 		});
-
-		// when
-		await harness.session.prompt("/fast");
-
-		// then
-		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
-		expect(harness.session.serviceTier).toBeUndefined();
-		expect(harness.settingsManager.getDefaultProvider()).toBe(CODEX_PROVIDER);
-		expect(harness.settingsManager.getDefaultModel()).toBe(BASE_MODEL_ID);
-		const defaultPayload = { model: BASE_MODEL_ID };
-		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
 	});
 
 	it("is a clear no-op for non-Codex providers", async () => {
@@ -307,16 +307,17 @@ describe("service-tier builtin extension", () => {
 
 	it("drops session fast mode when a new session starts", async () => {
 		// given
-		// The toggle is session-scoped and never persisted, so a fresh session_start must not
-		// inherit a priority tier from the previous one.
+		// An explicit preference disables Fast mode for each new Codex session.
 		const harness = await createHarness({
 			api: CODEX_API,
 			provider: CODEX_PROVIDER,
 			models: [{ id: BASE_MODEL_ID }, { id: FAST_MODEL_ID }],
+			settings: { openai: { defaultFastMode: false } },
 			extensionFactories: [serviceTierExtension],
 		});
 		harnesses.push(harness);
 		const runner = harness.getExtensionRunner();
+		SettingsManager.create(harness.tempDir).setOpenAIDefaultFastMode(false);
 		await harness.session.prompt("/fast");
 		expect(await runner.emitBeforeProviderRequest({ model: BASE_MODEL_ID })).toEqual({
 			model: BASE_MODEL_ID,

--- a/packages/coding-agent/test/suite/service-tier-settings.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-settings.test.ts
@@ -27,4 +27,16 @@ describe("SettingsManager service tier settings", () => {
 		// then
 		expect(serviceTier).toBe("priority");
 	});
+
+	it("enables OpenAI Codex fast mode by default", () => {
+		expect(SettingsManager.inMemory().getOpenAIDefaultFastMode()).toBe(true);
+	});
+
+	it("persists an explicit OpenAI Codex fast mode preference", () => {
+		const manager = SettingsManager.inMemory();
+
+		manager.setOpenAIDefaultFastMode(false);
+
+		expect(manager.getOpenAIDefaultFastMode()).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary
- add a persisted `/settings` toggle for the default OpenAI Codex Fast mode
- enable Fast mode by default for new Codex sessions while preserving `/fast` as a session override
- cover preference persistence, selector changes, and session reset behavior

## Validation
- `npx vitest run test/suite/service-tier-settings.test.ts test/suite/service-tier-extension.test.ts test/settings-selector.test.ts`
- `npm run check`
- isolated `mock-loop.mjs --run` QA (no real provider calls)

Linear: https://linear.app/ublanks/issue/UBL-118/senpi-enable-default-fast-mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OpenAI Codex Fast mode configurable and enabled by default for new sessions. Previously, new sessions reset to the base model; now they start in Fast mode when preferred, selecting the fast catalog variant and using `service_tier: "priority"`.

- Adds `openai.defaultFastMode` (default: true) to global settings in `packages/coding-agent`, with `SettingsManager.getOpenAIDefaultFastMode()` and `.setOpenAIDefaultFastMode()`.
- On `session_start`, the `service-tier` extension reads the preference and sets session Fast mode and model (fast or base) for Codex only; non-Codex sessions are unchanged.
- Keeps `/fast` as a per-session toggle that switches between fast and base variants and updates the session Fast flag.
- Exposes the preference in `/settings` as “Default Fast mode”.
- Updates tests to cover preference persistence, selector behavior, and session start logic. Linear: UBL-118.

**Rollout/Migration**
- If you want the old default (start in base mode), set `openai.defaultFastMode` to `false` via `/settings` or in the global settings file.

<sup>Written for commit 6f7e0996652913b39627975b947662853e262db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

