### PR TITLE
fix(goal): block on claude-sdk-oauth account exhaustion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,8 @@
 - MCP shutdown no longer risks terminating unrelated processes on macOS when Homebrew `proctools` provides `pgrep`: process-tree collection now passes an explicit match-all pattern, and the kill path skips PID 1 and non-positive PIDs as defense in depth ([#823](https://github.com/code-yeongyu/senpi/issues/823)).
 - `claude-sdk-oauth` sessions no longer re-send the full conversation after a transient content-less user message disappears. Such messages are now excluded from the sent-stream continuity hash, so an unchanged conversation stays a `delta` instead of forking with `sent_stream_diverged` ([#790](https://github.com/code-yeongyu/senpi/issues/790)).
 
+- An active Goal no longer auto-continues in a loop when the `claude-sdk-oauth` account-rotating proxy reports that every account is exhausted. The zero-token `stop` response is now classified as a terminal provider error, so the Goal blocks and resumes on the next user message instead of queueing repeated failed requests ([#748](https://github.com/code-yeongyu/senpi/issues/748)).
+
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,24 @@
 # goal Extension Changes
 
+## Claude SDK OAuth account exhaustion blocks the goal (2026-08-14)
+
+### What changed
+
+- `didTerminalProviderErrorEndTurn` now also classifies the claude-sdk-oauth account-rotating proxy's total-exhaustion response as a terminal provider error. The proxy returns it as an assistant message with `stopReason: "stop"` and zero usage, so it previously slipped past the stopReason checks and the goal kept auto-continuing.
+- The match requires `api: "claude-sdk-oauth"`, `stopReason: "stop"`, and both stable phrases (`API Error: Server is temporarily limiting requests` and `accounts exhausted`); the account count and the `Retry in NNNs` suffix vary and are not matched.
+
+### Why
+
+- An active goal treated the exhaustion response as a clean turn end and queued another hidden continuation, looping failed zero-token requests until the continuation cap fired. The goal now blocks mechanically and resumes on the next accepted user message.
+
+### Why an extension could not handle it
+
+- Terminal provider-error classification lives in this builtin's `terminal-provider-error.ts`; an external extension cannot intercept the goal's block decision.
+
+### Expected merge conflict zones
+
+- LOW: `terminal-provider-error.ts` classification; LOW in `goal-extension.test.ts`.
+
 ## Explicit resume revives completed goals (2026-08-11)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
@@ -1,9 +1,25 @@
 import type { AgentEndEvent } from "../../types.ts";
 import { lastAssistantMessage } from "./last-assistant-message.ts";
 
+// The claude-sdk-oauth account-rotating proxy reports total account exhaustion as
+// an assistant message with `stopReason: "stop"` and zero usage, so it slips past
+// the stopReason checks below and the goal reads it as a clean turn end. Match the
+// two stable phrases of that exact response; the account count and the `Retry in
+// NNNs` suffix vary, so they are not part of the match.
+const SDK_OAUTH_EXHAUSTION_MARKERS = ["API Error: Server is temporarily limiting requests", "accounts exhausted"];
+
+function isSdkOauthAccountExhaustion(message: { api?: string; stopReason?: string; content?: unknown } | undefined): boolean {
+	if (message?.api !== "claude-sdk-oauth" || message.stopReason !== "stop") return false;
+	const text = Array.isArray(message.content)
+		? message.content.map((part) => (part?.type === "text" ? part.text : "")).join("\n")
+		: "";
+	return SDK_OAUTH_EXHAUSTION_MARKERS.every((marker) => text.includes(marker));
+}
+
 export function didTerminalProviderErrorEndTurn(event: AgentEndEvent): boolean {
 	if (event.abortSource === "system") return false;
 	if (event.willRetry !== false) return false;
 	const message = lastAssistantMessage(event.messages);
+	if (isSdkOauthAccountExhaustion(message)) return true;
 	return message?.stopReason === "error" || (message?.stopReason === "aborted" && event.abortSource === undefined);
 }

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -350,6 +350,37 @@ describe("goal extension contract (budget-free)", () => {
 		expect(sent).toHaveLength(0);
 	});
 
+	it("blocks a claude-sdk-oauth goal when every account is exhausted on a zero-token stop", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-sdk-oauth-exhausted");
+		await tools
+			.get("create_goal")
+			?.execute("c1", { objective: "Survive account exhaustion" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
+		// The account-rotating proxy reports exhaustion as an assistant message with
+		// stopReason "stop" and zero usage, so the goal must treat it as a terminal
+		// provider error, not a clean turn end.
+		const exhaustionMessage = {
+			...assistantMessageWithStopReason("stop"),
+			api: "claude-sdk-oauth",
+			content: [
+				{
+					type: "text",
+					text: "API Error: Server is temporarily limiting requests (not your usage limit) · All 3 accounts exhausted. Retry in 300s.",
+				},
+			],
+		};
+		await runHandlers(handlers, "agent_end", { type: "agent_end", messages: [exhaustionMessage], willRetry: false }, ctx);
+
+		expect(await readGoal(storeRefFor(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: "provider error ended the turn (retries exhausted)",
+		});
+		expect(sent).toHaveLength(0);
+	});
+
 	it("keeps a goal active while a provider-error retry is pending", async () => {
 		const { tools, handlers, sent } = createGoalHarness();
 		const notices: string[] = [];


### PR DESCRIPTION
## Summary

An active Goal auto-continues in a loop when the `claude-sdk-oauth` account-rotating proxy reports that every account is exhausted. The proxy delivers the exhaustion as an assistant message with `stopReason: "stop"` and zero usage, so the goal's terminal-provider-error classifier (which only accepts `stopReason: "error"` or a provenance-free `aborted`) reads it as a clean turn end and queues another hidden continuation. One production session recorded 27 exhaustion responses in four clusters.

The classifier now also treats this exact response as a terminal provider error, so the Goal blocks mechanically and resumes on the next accepted user message instead of queueing repeated failed zero-token requests.

## Changes

- **`terminal-provider-error.ts`**: add a narrow `isSdkOauthAccountExhaustion` check ahead of the existing stopReason checks. It requires `api: "claude-sdk-oauth"`, `stopReason: "stop"`, and both stable phrases (`API Error: Server is temporarily limiting requests` and `accounts exhausted`). The account count and the `Retry in NNNs` suffix vary and are deliberately not matched. No generic zero-token guard was added — zero usage is supporting evidence, not the failure identity, and a legitimate zero-token stop must not be blocked.
- **`test/suite/goal-extension.test.ts`**: regression proving the goal blocks and no continuation is queued for the exhaustion response.
- **`goal/changes.md`** + **`CHANGELOG.md`**: fork-ledger and `[Unreleased]` entries.

## QA & Evidence

- **What was tested:** the new regression (`blocks a claude-sdk-oauth goal when every account is exhausted on a zero-token stop`) and the full `goal-extension` suite; the real agent loop via senpi-qa mock-loop.
- **Observed result:** the new test FAILS before the fix (goal stays `active`) and PASSES after (goal `blocked`, zero continuations). Full suite 43/43. mock-loop self-test 48/48.
- **Artifact:** `local-ignore/qa-evidence/20260814-fix748-goal-exhaustion/mock-loop.txt`
- **Why sufficient:** the regression drives the exact `agent_end` event shape from the issue through the real goal handler, and the mock loop proves the agent still completes a turn end to end.

## Risks & Residuals

- The match is intentionally narrow (provider + two phrases). A false positive would wrongly block a user's Goal, so the predicate requires the claude-sdk-oauth API and both stable phrases; other providers and ordinary stop text are unaffected. Residual: a differently-worded exhaustion response from another proxy would not be caught — that would be a follow-up if it ever appears.

## Related Issues

Closes #748

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks Goal auto-continue loops when the `claude-sdk-oauth` proxy reports total account exhaustion. Previously a zero‑token `stop` was treated as a clean turn end and re-queued; now it’s a terminal provider error, so the Goal blocks and only resumes on the next user message. Addresses #748.

- Classifies exhaustion only when `api: "claude-sdk-oauth"`, `stopReason: "stop"`, and content includes both: "API Error: Server is temporarily limiting requests" and "accounts exhausted"; ignores account count and "Retry in NNNs". No generic zero-usage guard; legitimate zero-token stops still pass.
- Adds a regression in `goal-extension.test.ts` proving the Goal blocks; suite remains green. Other providers and ordinary stops are unaffected.

<sup>Written for commit f05301c8ffdc41b36a41324f14d40b941b87dcb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

