### PR TITLE
fix(compaction): surface the concrete reason a compaction did not apply

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 - An active Goal no longer auto-continues in a loop when the `claude-sdk-oauth` account-rotating proxy reports that every account is exhausted. The zero-token `stop` response is now classified as a terminal provider error, so the Goal blocks and resumes on the next user message instead of queueing repeated failed requests ([#748](https://github.com/code-yeongyu/senpi/issues/748)).
 
+- A failed compaction now reports the concrete reason — for example `Compaction did not apply: remote-compaction-timeout; local fallback unavailable` — instead of the generic `Compaction did not apply`, so the cause is diagnosable in the TUI and decision log ([#765](https://github.com/code-yeongyu/senpi/issues/765)).
+
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,24 @@
 # Builtin compaction extension changes
 
+## Surface the concrete reason a compaction did not apply (2026-08-14)
+
+### What changed
+
+- `endCompactionFeedback` now threads the remote stage's fallback reason (captured from the `remote_fallback` event) and the terminal local reason (`unavailable` / `stale`) into `ctx.endCompaction`'s `errorMessage`, so the decision log and TUI show e.g. `Compaction did not apply: remote-compaction-timeout; local fallback unavailable` instead of the bare generic string.
+- An aborted compaction still renders `Compaction cancelled` downstream and carries no failure message.
+
+### Why
+
+- Both the remote-timeout path and the `unavailable`/`stale` fallback collapsed into the generic `Compaction did not apply`, so the actual cause was not diagnosable after the fact. The remote reason was previously emitted only on an event bus with no subscriber.
+
+### Why an extension could not handle it
+
+- The reason is produced inside this builtin's blocking route; an external extension cannot observe the remote stage's fallback event or the feedback call site.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` `endCompactionFeedback` and the remote-capture emit in `applyBlockingCompaction`; LOW in the compaction tests that pinned silent degradation.
+
 ## Report provider-owned compaction as delegated (2026-08-14)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -149,7 +149,9 @@ function endCompactionFeedback(
 		const localReason = result.applied ? undefined : result.reason;
 		const parts = [remoteFallbackReason, localReason].filter((part): part is string => Boolean(part));
 		const errorMessage =
-			signal?.aborted || parts.length === 0 ? undefined : `Compaction did not apply: ${parts.join("; local fallback ")}`;
+			signal?.aborted || parts.length === 0
+				? undefined
+				: `Compaction did not apply: ${parts.join("; local fallback ")}`;
 		ctx.endCompaction?.({ reason: "extension", signal, aborted: signal?.aborted, errorMessage });
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -138,9 +138,19 @@ function endCompactionFeedback(
 	ctx: ExtensionContext,
 	signal: AbortSignal | undefined,
 	result: SpeculativeCompactionResult,
+	remoteFallbackReason?: string,
 ): void {
 	if (shouldEndFeedback(result)) {
-		ctx.endCompaction?.({ reason: "extension", signal, aborted: signal?.aborted });
+		// Surface the concrete failure instead of the generic "Compaction did not
+		// apply": the remote stage's reason (e.g. remote-compaction-timeout) and the
+		// terminal local reason (unavailable / stale), so the decision log and TUI
+		// show what actually happened. An aborted compaction renders "Compaction
+		// cancelled" downstream and must not carry a failure message.
+		const localReason = result.applied ? undefined : result.reason;
+		const parts = [remoteFallbackReason, localReason].filter((part): part is string => Boolean(part));
+		const errorMessage =
+			signal?.aborted || parts.length === 0 ? undefined : `Compaction did not apply: ${parts.join("; local fallback ")}`;
+		ctx.endCompaction?.({ reason: "extension", signal, aborted: signal?.aborted, errorMessage });
 	}
 }
 
@@ -398,6 +408,7 @@ export default function compactionExtension(
 		}
 		let feedbackSignal = ctx.beginCompaction?.({ reason: "extension" });
 		try {
+			let remoteFallbackReason: string | undefined;
 			if (isOpenAiRemoteCompactionModel(ctx.model)) {
 				const remoteGeneration = speculativeGeneration + 1;
 				const remoteSnapshot = createSpeculativeCompactionSnapshot(ctx, {
@@ -411,7 +422,12 @@ export default function compactionExtension(
 					const remoteCompaction = await runOpenAiRemoteCompaction(
 						ctx,
 						createBlockingRemoteCompactionEvent(ctx, remoteSnapshot, customInstructions, remoteSignal),
-						(data) => pi.events.emit(SENPI_COMPACTION_EVENT, data),
+						(data) => {
+							if (data?.action === "remote_fallback" && typeof data.reason === "string") {
+								remoteFallbackReason = data.reason;
+							}
+							pi.events.emit(SENPI_COMPACTION_EVENT, data);
+						},
 						remoteCompactionDependencies,
 					);
 					if (remoteCompaction) {
@@ -498,7 +514,7 @@ export default function compactionExtension(
 			if (!snapshot) {
 				const result = { applied: false, reason: "unavailable" } as const;
 				getLogger(ctx).debug("summary_failed", { reason: "unavailable" });
-				endCompactionFeedback(ctx, feedbackSignal, result);
+				endCompactionFeedback(ctx, feedbackSignal, result, remoteFallbackReason);
 				return result;
 			}
 			let compaction: CompactionResult | undefined;
@@ -521,7 +537,7 @@ export default function compactionExtension(
 				compaction,
 				feedbackSignal,
 			);
-			endCompactionFeedback(ctx, feedbackSignal, result);
+			endCompactionFeedback(ctx, feedbackSignal, result, remoteFallbackReason);
 			return result;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-network-degrade.test.ts
@@ -108,12 +108,11 @@ describe("blocking compaction network-failure degradation", () => {
 			harness.registration.setResponses([fauxAssistantMessage("never reached")]);
 
 			// When / Then: SummaryGenerationError keeps its degrade-to-unavailable
-			// contract, with no error message on the compaction feedback.
+			// contract, and the concrete reason is surfaced on the compaction feedback
+			// (issue #765) instead of the bare generic message.
 			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
-			const callsWithError = harness.endCompaction.mock.calls.filter(
-				(call) => typeof call[0]?.errorMessage === "string",
-			);
-			expect(callsWithError).toHaveLength(0);
+			const messages = harness.endCompaction.mock.calls.map((call) => call[0]?.errorMessage);
+			expect(messages).toContain("Compaction did not apply: unavailable");
 		});
 	});
 });

--- a/packages/coding-agent/test/compaction/blocking-compaction-review-hardening.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-review-hardening.test.ts
@@ -126,16 +126,19 @@ describe("blocking compaction review hardening", () => {
 	});
 
 	describe("Given the summarization response has no text", () => {
-		it("Then blocking compaction degrades silently as before", async () => {
+		it("Then blocking compaction surfaces the unavailable reason", async () => {
 			// Given
 			const { beforeAgentStart } = createCompactionHandlers();
 			const harness = createBlockingContext({ usageTokens: 9_950 });
 			registrations.push(harness.registration);
 			harness.registration.setResponses([fauxAssistantMessage("", { stopReason: "stop" })]);
 
-			// When / Then
+			// When / Then: the concrete reason is surfaced instead of the bare generic
+			// message (issue #765), so the failure is diagnosable after the fact.
 			await expect(beforeAgentStart(createBeforeAgentStartEvent(), harness.ctx)).resolves.toBeUndefined();
-			expect(errorMessages(harness.endCompaction)).toHaveLength(0);
+			expect(
+				errorMessages(harness.endCompaction).map((call) => (call as [{ errorMessage: string }])[0].errorMessage),
+			).toEqual(["Compaction did not apply: unavailable"]);
 		});
 	});
 

--- a/packages/coding-agent/test/compaction/compaction-reason-surfacing.test.ts
+++ b/packages/coding-agent/test/compaction/compaction-reason-surfacing.test.ts
@@ -39,7 +39,11 @@ function createOpenAiHarness(options: { usageTokens: number }) {
 	// Enough content for prepareCompaction to produce a snapshot so the remote
 	// stage runs and times out; the local fallback then reports "unavailable"
 	// because applyCompaction is stubbed to decline.
-	sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "Summarize old context" }], timestamp: 1 });
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "Summarize old context" }],
+		timestamp: 1,
+	});
 	sessionManager.appendMessage({
 		role: "assistant",
 		content: [{ type: "text", text: "Old assistant context ".repeat(6_000) }],
@@ -48,13 +52,17 @@ function createOpenAiHarness(options: { usageTokens: number }) {
 		model: OPENAI_REMOTE_MODEL.id,
 		timestamp: 2,
 	});
-	sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "Keep latest request" }], timestamp: 3 });
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "Keep latest request" }],
+		timestamp: 3,
+	});
 	const modelRegistry = Object.create(null) as ExtensionContext["modelRegistry"];
 	// No usable credential: the remote stage reports its fallback with this reason and
 	// the local summarization throws SummaryGenerationError("auth"), which the blocking
 	// route catches and degrades to "unavailable" — both ends of the threaded message.
 	modelRegistry.getApiKeyAndHeaders = (async () => ({ ok: false as const, error: "no API key configured" })) as never;
-	let usageTokens = options.usageTokens;
+	const usageTokens = options.usageTokens;
 	const ctx = {
 		hasUI: false,
 		mode: "print",
@@ -121,6 +129,8 @@ describe("compaction failure reason surfacing (issue #765)", () => {
 		const withReason = calls.find((call) => typeof call.errorMessage === "string");
 		// The remote stage's fallback reason and the terminal local reason are both
 		// surfaced, joined into one diagnosable message instead of the bare generic one.
-		expect(withReason?.errorMessage).toBe("Compaction did not apply: no API key configured; local fallback unavailable");
+		expect(withReason?.errorMessage).toBe(
+			"Compaction did not apply: no API key configured; local fallback unavailable",
+		);
 	});
 });

--- a/packages/coding-agent/test/compaction/compaction-reason-surfacing.test.ts
+++ b/packages/coding-agent/test/compaction/compaction-reason-surfacing.test.ts
@@ -1,0 +1,126 @@
+import type { Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
+import type {
+	BeforeAgentStartEvent,
+	ExtensionAPI,
+	ExtensionContext,
+	ExtensionHandler,
+} from "../../src/core/extensions/index.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
+
+// An OpenAI Responses model that qualifies for the remote-compaction route.
+const OPENAI_REMOTE_MODEL = {
+	id: "gpt-5.6-sol",
+	name: "GPT 5.6 Sol",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 16_384,
+} as unknown as Model<"openai-responses">;
+
+function createBeforeAgentStartEvent(): BeforeAgentStartEvent {
+	return {
+		type: "before_agent_start",
+		prompt: "continue",
+		systemPrompt: "system",
+		systemPromptOptions: Object.create(null) as BeforeAgentStartEvent["systemPromptOptions"],
+	};
+}
+
+function createOpenAiHarness(options: { usageTokens: number }) {
+	const endCompaction = vi.fn();
+	const sessionManager = SessionManager.inMemory();
+	// Enough content for prepareCompaction to produce a snapshot so the remote
+	// stage runs and times out; the local fallback then reports "unavailable"
+	// because applyCompaction is stubbed to decline.
+	sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "Summarize old context" }], timestamp: 1 });
+	sessionManager.appendMessage({
+		role: "assistant",
+		content: [{ type: "text", text: "Old assistant context ".repeat(6_000) }],
+		api: "openai-responses",
+		provider: "openai",
+		model: OPENAI_REMOTE_MODEL.id,
+		timestamp: 2,
+	});
+	sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "Keep latest request" }], timestamp: 3 });
+	const modelRegistry = Object.create(null) as ExtensionContext["modelRegistry"];
+	// No usable credential: the remote stage reports its fallback with this reason and
+	// the local summarization throws SummaryGenerationError("auth"), which the blocking
+	// route catches and degrades to "unavailable" — both ends of the threaded message.
+	modelRegistry.getApiKeyAndHeaders = (async () => ({ ok: false as const, error: "no API key configured" })) as never;
+	let usageTokens = options.usageTokens;
+	const ctx = {
+		hasUI: false,
+		mode: "print",
+		ui: { notify: () => undefined } as unknown as ExtensionContext["ui"],
+		cwd: process.cwd(),
+		isProjectTrusted: () => true,
+		sessionManager,
+		modelRegistry,
+		model: OPENAI_REMOTE_MODEL,
+		serviceTier: undefined,
+		isIdle: () => true,
+		signal: undefined,
+		abort: vi.fn(),
+		hasPendingMessages: () => false,
+		shutdown: vi.fn(),
+		getContextUsage: () => ({
+			tokens: usageTokens,
+			contextWindow: 10_000,
+			percent: (usageTokens / 10_000) * 100,
+		}),
+		getCompactionSettings: () => ({ enabled: true, reserveTokens: 100, keepRecentTokens: 2_000 }),
+		getLookAtSettings: () => ({ enabled: true, models: undefined }),
+		getImageSettings: () => ({ autoResize: true, blockImages: false }),
+		sessionSettings: createInMemoryExtensionSessionSettings(),
+		compact: vi.fn(),
+		getMessageRevision: () => 1,
+		applyCompaction: vi.fn(async () => ({ applied: false as const, reason: "unavailable" as const })),
+		beginCompaction: () => undefined,
+		endCompaction,
+		getSystemPrompt: () => "",
+	} as unknown as ExtensionContext;
+	return { ctx, endCompaction };
+}
+
+describe("compaction failure reason surfacing (issue #765)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("surfaces the remote fallback reason and the local reason instead of the generic message", async () => {
+		let beforeAgentStart: ExtensionHandler<BeforeAgentStartEvent, unknown> | undefined;
+		// A fetch that never resolves, so the remote stage aborts on its timeout.
+		const timeoutFetch = vi.fn(
+			(_url: unknown, init?: { signal?: AbortSignal }) =>
+				new Promise<Response>((_resolve, reject) => {
+					init?.signal?.addEventListener("abort", () => reject(new Error("fetch aborted")), { once: true });
+				}),
+		);
+		const api = {
+			events: { emit: () => undefined },
+			on: (event: string, handler: unknown) => {
+				if (event === "before_agent_start") {
+					beforeAgentStart = handler as ExtensionHandler<BeforeAgentStartEvent, unknown>;
+				}
+			},
+		} as unknown as ExtensionAPI;
+		compactionExtension(api, { fetch: timeoutFetch as never, remoteTimeoutMs: 1 });
+		expect(beforeAgentStart).toBeDefined();
+
+		const harness = createOpenAiHarness({ usageTokens: 9_950 });
+		await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
+
+		const calls = harness.endCompaction.mock.calls.map((call) => call[0] as { errorMessage?: string });
+		const withReason = calls.find((call) => typeof call.errorMessage === "string");
+		// The remote stage's fallback reason and the terminal local reason are both
+		// surfaced, joined into one diagnosable message instead of the bare generic one.
+		expect(withReason?.errorMessage).toBe("Compaction did not apply: no API key configured; local fallback unavailable");
+	});
+});

--- a/packages/coding-agent/test/compaction/compaction-reason-surfacing.test.ts
+++ b/packages/coding-agent/test/compaction/compaction-reason-surfacing.test.ts
@@ -50,6 +50,15 @@ function createOpenAiHarness(options: { usageTokens: number }) {
 		api: "openai-responses",
 		provider: "openai",
 		model: OPENAI_REMOTE_MODEL.id,
+		usage: {
+			input: 30_000,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 30_000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
 		timestamp: 2,
 	});
 	sessionManager.appendMessage({

--- a/packages/coding-agent/test/suite/regressions/issue-823-mcp-pgrep-pattern.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-823-mcp-pgrep-pattern.test.ts
@@ -49,9 +49,13 @@ printf '%s\\n' 1
 			const originalPath = process.env.PATH;
 			const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 			try {
-				await writeFile(fakePgrepPath, `#!/bin/sh
+				await writeFile(
+					fakePgrepPath,
+					`#!/bin/sh
 printf '%s\\n' 1
-`, "utf8");
+`,
+					"utf8",
+				);
 				await chmod(fakePgrepPath, 0o755);
 				process.env.PATH = `${fakeBinDir}${delimiter}${originalPath ?? ""}`;
 


### PR DESCRIPTION
## Summary

When an OpenAI remote compaction times out and the local fallback also cannot apply, the TUI and decision log showed only the generic `Compaction did not apply`. The concrete reason — the remote stage's `remote-compaction-timeout` and the local `unavailable`/`stale` outcome — was lost: the remote reason was emitted on an event bus with no subscriber, and `endCompactionFeedback` passed no `errorMessage`, so `agent-session` substituted the generic default for every failure mode.

The blocking route now captures the remote stage's `remote_fallback` reason and threads it, joined with the terminal local reason, into `ctx.endCompaction`'s `errorMessage`. A failed compaction now reads e.g. `Compaction did not apply: remote-compaction-timeout; local fallback unavailable`.

## Changes

- **`compaction/index.ts`**: capture the `remote_fallback` reason in `applyBlockingCompaction` and pass it to `endCompactionFeedback`, which builds a specific `errorMessage` from the remote reason + the local terminal reason. An aborted compaction still renders `Compaction cancelled` and carries no failure message. The 15s remote timeout is intentionally unchanged (out of scope — it falls back to local summarization by design).
- **`test/compaction/compaction-reason-surfacing.test.ts`** (new): drives the blocking route and asserts the joined reason reaches `endCompaction`.
- **`blocking-compaction-review-hardening.test.ts`** + **`blocking-compaction-network-degrade.test.ts`**: two tests that pinned the old silent-degradation behavior now assert the surfaced reason — that silence is exactly what #765 asks to fix.
- **`compaction/changes.md`** + **`CHANGELOG.md`**: fork-ledger and `[Unreleased]` entries.

## QA & Evidence

- **What was tested:** the new reason-surfacing test, the full `test/compaction` suite, and the real agent loop via senpi-qa mock-loop.
- **Observed result:** the new test FAILS before the change (no specific message) and PASSES after. Full suite 407/407 across 58 files. mock-loop self-test 48/48.
- **Artifact:** `local-ignore/qa-evidence/20260814-fix765-compaction-reason/mock-loop.txt`
- **Why sufficient:** the test drives the real blocking route through the extension and asserts the joined reason reaches the user-facing `endCompaction` call; the full suite confirms no regression in the surrounding compaction policy.

## Risks & Residuals

- Two pre-existing tests pinned silent degradation for local-only `unavailable`; they now assert the surfaced reason, which is the intended behavior change from #765. The aborted path is unchanged (still `Compaction cancelled`). Residual: the 15s remote timeout is still hardcoded (configurability is a separate feature, not this fix).

## Related Issues

Closes #765

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces concrete compaction failure reasons so users can diagnose why a compaction didn’t apply. Previously every failure showed “Compaction did not apply”; now failures include the remote stage’s fallback reason joined with the terminal local reason (e.g., “remote-compaction-timeout; local fallback unavailable”). Aborted runs still show “Compaction cancelled”; successful runs are unchanged.

- Capture the remote-stage `remote_fallback` reason during blocking OpenAI compaction and pass it to `endCompactionFeedback`, which builds `errorMessage` from the remote + local reasons and omits it when aborted; remote timeout and apply logic are unchanged.
- Tests: added `compaction-reason-surfacing.test.ts`; updated two blocking-compaction tests to assert surfaced reasons; completed the assistant-message fixture shape; minor formatting in the `issue-823` regression test.
- Docs: updated `compaction/changes.md` and `CHANGELOG.md`.
- Rollout: no migration; consumers of `endCompaction` may now receive a populated `errorMessage` on failures.

<sup>Written for commit 3f4bbc627960db14eeb24b0176d9e4bfb30d87f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

