### PR TITLE
fix(config-reload): accept filter-safe agent-directory watches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - MCP shutdown no longer risks terminating unrelated processes on macOS when Homebrew `proctools` provides `pgrep`: process-tree collection now passes an explicit match-all pattern, and the kill path skips PID 1 and non-positive PIDs as defense in depth ([#823](https://github.com/code-yeongyu/senpi/issues/823)).
 - `claude-sdk-oauth` sessions no longer re-send the full conversation after a transient content-less user message disappears. Such messages are now excluded from the sent-stream continuity hash, so an unchanged conversation stays a `delta` instead of forking with `sent_stream_diverged` ([#790](https://github.com/code-yeongyu/senpi/issues/790)).
+- `config-reload` now accepts an extension watch rooted at the agent directory when every `filterGlob` is root-anchored and non-protected, so extensions can live-watch safe root config files such as `omo.jsonc`. Unfiltered targets, unanchored filters, and protected paths (`auth.json`, `sessions/`, `logs/`) remain rejected ([#819](https://github.com/code-yeongyu/senpi/issues/819)).
 
 
 ### New Features

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,0 +1,20 @@
+# config-reload Extension Changes
+
+## Filter-aware agent-directory watch guard (2026-08-14)
+
+### What changed
+
+- `registrationHasRestrictedTarget` now accepts a watch rooted exactly at the agent directory when every `filterGlob` is root-anchored (a leading `/`, which matches only an immediate child of the watch root) and none of those anchored names resolves into a protected path (`auth.json`, `sessions/`, `logs/`).
+- Unfiltered agent-dir targets, unanchored filters such as `omo.json` (which match at any depth), and any filter that names a protected path remain rejected (fail-closed).
+
+### Why
+
+- The guard predates root-anchored filters and rejected the agent directory outright even when the filters could only ever select safe root config files, so extensions could not live-watch e.g. `omo.jsonc` and had to tell users to reload manually.
+
+### Why an extension could not handle it
+
+- The protected-target guard runs inside this builtin at registration intake; an external extension cannot relax it.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` `registrationHasRestrictedTarget` and the new `isSafeFilteredAgentDirTarget`; LOW in `config-reload-extension.test.ts`.

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -887,6 +887,32 @@ function registrationFingerprint(registration: ConfigWatchRegistration): string 
 	});
 }
 
+function isProtectedAgentPath(candidate: string, agentDir: string): boolean {
+	const authPath = resolve(agentDir, "auth.json");
+	const sessionsPath = resolve(agentDir, "sessions");
+	const logsPath = resolve(agentDir, "logs");
+	return isWithin(candidate, authPath) || isWithin(candidate, sessionsPath) || isWithin(candidate, logsPath);
+}
+
+// A watch rooted exactly at the agent directory is safe when every filter is
+// root-anchored (a leading `/` matches only an immediate child of the watch root,
+// never a nested path) and none of those anchored names resolves into a protected
+// path. Unfiltered targets, unanchored filters, and any protected filter stay
+// fail-closed.
+function isSafeFilteredAgentDirTarget(
+	target: ConfigWatchTarget,
+	resolvedPath: string,
+	agentDir: string,
+): boolean {
+	if (target.kind !== "dir" || resolvedPath !== resolve(agentDir)) return false;
+	const filterGlobs = target.filterGlobs;
+	if (!filterGlobs || filterGlobs.length === 0) return false;
+	return filterGlobs.every((glob) => {
+		if (!glob.startsWith("/")) return false;
+		return !isProtectedAgentPath(resolve(resolvedPath, glob.slice(1)), agentDir);
+	});
+}
+
 function registrationHasRestrictedTarget(
 	registration: ConfigWatchRegistration,
 	cwd: string,
@@ -897,6 +923,7 @@ function registrationHasRestrictedTarget(
 	const logsPath = resolve(agentDir, "logs");
 	return registration.targets.some((target) => {
 		const path = resolvePath(target.path, cwd, { trim: true });
+		if (isSafeFilteredAgentDirTarget(target, path, agentDir)) return false;
 		return (
 			isWithin(path, authPath) ||
 			isWithin(authPath, path) ||

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -17,6 +17,7 @@ import {
 	CONFIG_WATCH_RELOADED,
 	CONFIG_WATCH_UNREGISTER,
 	type ConfigWatchRegistration,
+	type ConfigWatchTarget,
 	isConfigWatchRegistration,
 	isConfigWatchUnregistration,
 	isConfigWatchValidation,

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -700,6 +700,69 @@ describe("config reload builtin extension", () => {
 		expect(watches.activeListenerCount(restrictedDir)).toBe(0);
 	});
 
+	it("accepts an agent-dir watch whose filters are all root-anchored and non-protected", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-filtered-agent-"));
+		agentDirs.push(agentDir);
+		writeJson(join(agentDir, "settings.json"), { theme: "dark" });
+		writeJson(join(agentDir, "auth.json"), { token: "secret" });
+		mkdirSync(join(agentDir, "sessions"), { recursive: true });
+		const bus = createEventBus();
+		const watches = createWatchProbe();
+		const extension = createManualExtension(bus);
+		configReloadExtension(extension.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir }),
+		);
+		const rejected: unknown[] = [];
+		bus.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+
+		bus.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo",
+			displayName: ".omo config",
+			targets: [{ path: agentDir, kind: "dir" as const, filterGlobs: ["/omo.jsonc", "/omo.json"] }],
+		});
+
+		expect(rejected).toHaveLength(0);
+	});
+
+	it("still rejects unfiltered, unanchored, and protected agent-dir watches", async () => {
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-filtered-reject-"));
+		agentDirs.push(agentDir);
+		writeJson(join(agentDir, "settings.json"), { theme: "dark" });
+		const bus = createEventBus();
+		const watches = createWatchProbe();
+		const extension = createManualExtension(bus);
+		configReloadExtension(extension.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir }),
+		);
+		const rejected: unknown[] = [];
+		bus.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+
+		const cases: Array<{ id: string; filterGlobs?: string[] }> = [
+			{ id: "unfiltered" }, // no filterGlobs at all
+			{ id: "unanchored", filterGlobs: ["omo.json"] }, // matches at any depth
+			{ id: "protected-auth", filterGlobs: ["/auth.json"] },
+			{ id: "protected-sessions", filterGlobs: ["/sessions"] },
+			{ id: "mixed", filterGlobs: ["/omo.jsonc", "/auth.json"] }, // one protected member
+		];
+		for (const c of cases) {
+			bus.emit(CONFIG_WATCH_REGISTER, {
+				id: c.id,
+				displayName: c.id,
+				targets: [{ path: agentDir, kind: "dir" as const, ...(c.filterGlobs ? { filterGlobs: c.filterGlobs } : {}) }],
+			});
+		}
+
+		expect(rejected).toHaveLength(cases.length);
+	});
+
 	it("processes a re-registration with a changed target after a rejection", async () => {
 		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-rejection-repair-"));
 		agentDirs.push(agentDir);


### PR DESCRIPTION
## Summary

`config-reload` rejects an extension watch whose path is the agent directory even when root-anchored `filterGlobs` limit it to safe config files. The protected-target guard resolves only `target.path` and never reads `target.filterGlobs`, and its ancestor-direction `isWithin(authPath, path)` check makes the agent dir itself always restricted — so an extension cannot live-watch a safe root config file like `omo.jsonc` and must fall back to telling the user to reload.

The guard now accepts an agent-directory target when **every** filter is root-anchored (a leading `/`, which `matchesConfigWatchFilter` treats as matching only an immediate child of the watch root) **and** none of those anchored names resolves into a protected path (`auth.json`, `sessions/`, `logs/`).

## Changes

- **`config-reload/index.ts`**: add `isSafeFilteredAgentDirTarget` and consult it in `registrationHasRestrictedTarget`. The exception is narrow: it requires `kind === "dir"`, the resolved path to be exactly the agent dir, a non-empty filter list, and every filter to be root-anchored and non-protected. Unfiltered targets, unanchored filters (`omo.json`, which matches at any depth), and any protected filter (`/auth.json`, `/sessions`) stay rejected — the fail-closed posture is preserved.
- **`test/suite/config-reload-extension.test.ts`**: a safe root-anchored registration is accepted, and five unsafe variants (unfiltered, unanchored, `/auth.json`, `/sessions`, and a mixed safe+protected list) are all still rejected.
- **`config-reload/changes.md`** (new) + **`CHANGELOG.md`**: fork-ledger and `[Unreleased]` entries.

## QA & Evidence

- **What was tested:** the two new guard tests, the full `config-reload-extension` suite, and the real agent loop via senpi-qa mock-loop.
- **Observed result:** the accept test FAILS before the change (safe registration rejected) and PASSES after; all five unsafe variants stay rejected both before and after. Full suite 52/52. mock-loop self-test 48/48.
- **Artifact:** `local-ignore/qa-evidence/20260814-fix819-config-watch/mock-loop.txt`
- **Why sufficient:** the tests drive the real registration intake through the extension's event bus and assert both the accept and the fail-closed reject paths; the full suite confirms no regression in the surrounding watch/reload behavior.

## Risks & Residuals

- This is a security guard, so the exception is deliberately narrow: it only fires for a directory target rooted exactly at the agent dir with every filter root-anchored and non-protected, and it preserves lexical `resolve` (no `realpath` broadening to symlink aliases). Residual: a filter that is root-anchored but names a *nested* path (e.g. `/sessions/x.jsonl`) is rejected because it resolves into a protected path — that is the intended fail-closed behavior.

## Related Issues

Closes #819

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts filter-safe agent-directory watches in `config-reload` so extensions can live‑watch safe root config files. Previously, any watch rooted at the agent directory was rejected; now such watches are accepted only when every filter is root‑anchored and non‑protected. Unfiltered, unanchored, or protected paths remain rejected.

- **Review notes**
  - Allows only `kind: "dir"` targets exactly at the agent directory with non-empty `filterGlobs` where every entry starts with “/” and none resolves to `auth.json`, `sessions/`, or `logs/`; all other cases still fail closed.
  - Adds `isSafeFilteredAgentDirTarget`, `isProtectedAgentPath`, and imports `ConfigWatchTarget`; consulted in `registrationHasRestrictedTarget`. Tests cover one accept and five reject variants; no other behavior changes.

- **Rollout**
  - No migration required. To live‑watch safe root files, register a dir target at the agent directory with root‑anchored `filterGlobs` (e.g., `/omo.jsonc`).

<sup>Written for commit fe7ddec6be6ea40149259771ed71b3d8b8676dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

