### PR TITLE
fix(tui): replay above-viewport growth in the viewport-remap branch

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Expanding several tool results at once (Ctrl+O) no longer renders mismatched or truncated content: when a frame grows above the viewport and a visible row also changes, the renderer now replays the canonical transcript instead of repainting only the visible rows, so every expanded result reaches scrollback under its own header ([#701](https://github.com/code-yeongyu/senpi/issues/701)).
+
 ### Removed
 
 ## [2026.8.14] - 2026-08-14

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,19 @@
 # TUI delta rendering fork changes
 
+## 2026-08-14: replay above-viewport growth in the viewport-remap branch
+
+### What changed
+
+- When a frame's content grows above the viewport and a visible row also changes (`viewportTop !== prevViewportTop` with `lineCountDelta !== 0`), the renderer now falls back to the canonical `renderScrollbackReplay` / mux dispatch instead of repainting only the visible rows in place.
+
+### Why
+
+- The in-place repaint emitted exactly `height` rows and returned, so rows inserted above the viewport (e.g. Ctrl+O expanding several tool blocks in one frame) never reached terminal scrollback even though `setPreviousLines` marked them painted — leaving mismatched headers and truncated results. The replay path re-emits the full canonical transcript.
+
+### Expected merge conflict zones
+
+- LOW: `tui.ts` the `viewportTop !== prevViewportTop` branch; LOW in `tui-render.test.ts`.
+
 ## 2026-08-05: dead-terminal raw-mode restoration is best-effort during shutdown
 
 ### What changed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2263,6 +2263,30 @@ export abstract class TuiBase extends Container {
 			}
 
 			if (viewportTop !== prevViewportTop) {
+				// Content grew above the viewport (e.g. Ctrl+O expanding several tool
+				// blocks at once). Repainting only the visible rows would drop the
+				// inserted above-viewport rows from scrollback while marking them painted,
+				// so fall back to the canonical replay / mux dispatch used by the
+				// firstVisibleChanged === -1 path, which re-emits the full transcript.
+				if (lineCountDelta !== 0) {
+					if (preserveMuxScrollback) {
+						if (!this.renderMuxViewportRepaint(newLines, rawLines, cursorPos, width, height, viewportTop)) {
+							fullRender(true, false);
+						}
+					} else {
+						this.renderScrollbackReplay(
+							newLines,
+							rawLines,
+							cursorPos,
+							width,
+							height,
+							prevViewportTop,
+							hardwareCursorRow,
+						);
+					}
+					return;
+				}
+
 				const previousViewportBottom = Math.min(this.previousLines.length - 1, prevViewportTop + height - 1);
 				let buffer = TUI.FRAME_BEGIN;
 				buffer += this.deleteChangedKittyImages(prevViewportTop, previousViewportBottom);

--- a/packages/tui/test/tui-render.test.ts
+++ b/packages/tui/test/tui-render.test.ts
@@ -101,6 +101,38 @@ class MultipleExpandableToolTranscriptComponent implements Component {
 	invalidate(): void {}
 }
 
+// A component whose expansion grows two offscreen blocks AND changes a visible
+// status row in the same frame, so the renderer takes the viewport-remap repaint
+// branch (firstVisibleChanged !== -1) rather than the replay escape.
+class VisibleChangeExpandableComponent implements Component {
+	private expanded = false;
+	readonly tail = Array.from({ length: 3 }, (_, index) => `tail row ${index}`);
+
+	setExpanded(expanded: boolean): void {
+		this.expanded = expanded;
+	}
+
+	render(_width: number): string[] {
+		const readBlock = this.expanded
+			? [
+					"read expanded lib.rs:210",
+					"pub until: Option<String>,",
+					"pub year: Option<String>,",
+					"pub scanner_settings: scanner::ScannerSettings,",
+					"pub struct DailyTotals {",
+					"pub tokens: i64,",
+				]
+			: ["read collapsed lib.rs:210-329"];
+		const toolBlock = this.expanded
+			? ["tool expanded bash", "stdout line 0", "stdout line 1", "stdout line 2", "stdout line 3", "stdout line 4"]
+			: ["tool collapsed bash output"];
+		const status = this.expanded ? "status expanded" : "status collapsed";
+		return [...readBlock, ...toolBlock, status, ...this.tail];
+	}
+
+	invalidate(): void {}
+}
+
 class ExpandedStreamingOutputComponent implements Component {
 	private outputLineCount = 12;
 	readonly stableTail = ["loader row", "editor row", "footer row"];
@@ -939,6 +971,53 @@ describe("TUI viewport remap for above-viewport growth", () => {
 			"tail row 6",
 			"tail row 7",
 		]);
+
+		tui.stop();
+	});
+
+	it("replays every offscreen Ctrl+O block when expansion also changes a visible row", async () => {
+		// Geometry that hits the viewport-remap repaint branch (firstVisibleChanged !== -1):
+		// the tail is short enough that a visible row changes when the blocks expand,
+		// unlike the stable-tail case above which routes to the replay escape.
+		const terminal = new LoggingVirtualTerminal(72, 5);
+		const tui = new TUI(terminal);
+		const component = new VisibleChangeExpandableComponent();
+		tui.addChild(component);
+
+		component.setExpanded(false);
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		component.setExpanded(true);
+		tui.requestRender();
+		await terminal.waitForRender();
+
+		const scrollback = terminal.getScrollBuffer();
+		// The failing branch repaints only the visible rows and marks the inserted
+		// above-viewport rows as painted, so the expanded blocks never reach scrollback.
+		assert.deepStrictEqual(
+			getScrollbackSuffix(scrollback, 16),
+			[
+				"read expanded lib.rs:210",
+				"pub until: Option<String>,",
+				"pub year: Option<String>,",
+				"pub scanner_settings: scanner::ScannerSettings,",
+				"pub struct DailyTotals {",
+				"pub tokens: i64,",
+				"tool expanded bash",
+				"stdout line 0",
+				"stdout line 1",
+				"stdout line 2",
+				"stdout line 3",
+				"stdout line 4",
+				"status expanded",
+				"tail row 0",
+				"tail row 1",
+				"tail row 2",
+			],
+			"Expanded offscreen blocks must reach scrollback even when a visible row also changed",
+		);
 
 		tui.stop();
 	});


### PR DESCRIPTION
## Summary

In the interactive TUI, expanding several completed tool results with Ctrl+O can render incomplete or mismatched content — some entries stay as headers or error summaries while another shows only a trailing fragment. The collapsed list renders fine; the problem appears only after expansion.

The cause is in the differential renderer. `setToolsExpanded` flips every expandable child in one frame, so several tool blocks grow above the viewport at once. When a visible row also changes, the renderer takes the `viewportTop !== prevViewportTop` branch, which repaints exactly `height` visible rows in place and returns — never emitting the rows the expansion inserted *above* the viewport, while `setPreviousLines` marks them as painted. The canonical replay escape (`renderScrollbackReplay`) is only reachable when `firstVisibleChanged === -1`, which multi-block expansion never satisfies.

## Changes

- **`tui/src/tui.ts`**: in the `viewportTop !== prevViewportTop` branch, when `lineCountDelta !== 0` (content grew above the viewport), fall back to the same canonical dispatch the `firstVisibleChanged === -1` path uses — `renderScrollbackReplay` for non-mux, or `renderMuxViewportRepaint` with a `fullRender` fallback for mux panes. The in-place repaint is kept for the `lineCountDelta === 0` case (a pure remap with no inserted rows).
- **`tui/test/tui-render.test.ts`**: a new regression whose geometry forces `firstVisibleChanged !== -1` (a visible status row changes during expansion, unlike the existing stable-tail test) and asserts every expanded block reaches scrollback under its own header.
- **`tui/src/changes.md`** + **`tui/CHANGELOG.md`**: fork-ledger and `[Unreleased]` entries.

## QA & Evidence

- **What was tested:** the new regression, the full `tui` test suite, and a real TUI boot via senpi-qa tui-smoke.
- **Observed result:** the new test FAILS before the change (expanded blocks never reach scrollback) and PASSES after. Full `tui` suite green (39 render tests + the rest). tui-smoke self-test 5/5 (real TUI boots, renders, takes input, tears down cleanly).
- **Artifact:** `local-ignore/qa-evidence/20260814-fix701-ctrl-o-expansion/tui-smoke.txt`
- **Why sufficient:** the regression drives the exact failing branch through the real renderer with a virtual terminal and asserts the canonical scrollback; the full suite confirms no regression in the delicate differential renderer.

## Risks & Residuals

- The differential renderer is delicate, so the change is scoped to the `lineCountDelta !== 0` growth case and reuses the existing, tested replay dispatch rather than a new code path; mux-pane behavior is preserved via `renderMuxViewportRepaint`. Residual: a full replay repaints the transcript, which is slightly more output than the in-place path — acceptable for a frame that already grew.

## Related Issues

Closes #701


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mismatched or truncated content after Ctrl+O expansion in the interactive TUI. Previously, when multiple tool blocks expanded and a visible row changed, the renderer repainted only the visible rows and dropped rows inserted above the viewport; now it replays the canonical transcript so every expanded block reaches scrollback.

- Change is isolated to `packages/tui/src/tui.ts`: in the `viewportTop !== prevViewportTop` path, if `lineCountDelta !== 0`, dispatch to `renderScrollbackReplay` (non-mux) or `renderMuxViewportRepaint` with a `fullRender` fallback; keep the in-place repaint for `lineCountDelta === 0`.
- Adds a regression in `packages/tui/test/tui-render.test.ts` that forces a visible-row change during expansion; it failed before this change and now passes.
- Preserves mux-pane behavior; side effect is a one-frame full replay when content grows above the viewport, which is acceptable.
- Changelog and fork notes updated in `packages/tui/CHANGELOG.md` and `packages/tui/src/changes.md`.

<sup>Written for commit 43c0f10ebeab58637455ab93cec702e0bf81e313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

