### PR TITLE
fix(coding-agent): compact multi-session RPC events and drain single-flight

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Fixed
 
+- Multi-session RPC no longer amplifies a streaming answer into hundreds of megabytes of stdout, which made
+  clients freeze and then render walls of text at once. Each `message_update` carried a full cumulative snapshot,
+  so a single 96-second answer measured 140 MB on the wire (median line 72 KB, peak 95 KB) for 12 KB of assistant
+  content. Superseded snapshots pending in a session queue are now demoted to `message: null` /
+  `assistantMessageEvent.partial: null` and adjacent same-index text/thinking/toolcall deltas merge, while
+  `tool_execution_update` keeps only the latest record per `toolCallId`; every boundary, delta-only, error,
+  lifecycle, UI-request and response record stays untouched, so no assistant transition is lost. The event writer
+  also drains single-flight - one complete record in flight at a time, round-robin fairness preserved, host control
+  responses routed through their own non-coalescing lane, and shutdown flushing the writer before stdout. Classic
+  single-session RPC is unchanged and now pinned by regression tests, including its per-event backpressure.
 - The ambient Claude auth availability probe now passes `windowsHide: true` when spawning `claude auth status`, so the background check no longer opens a console window on Windows ([#870](https://github.com/code-yeongyu/senpi/issues/870)).
 - `senpi --help` now lists the `PI_RULES_DISABLED`, `PI_RULES_MAX_RULE_CHARS`, and `PI_RULES_MAX_RESULT_CHARS` environment settings that the built-in rules extension reads, so the two environment-only character limits are discoverable from the CLI ([#678](https://github.com/code-yeongyu/senpi/issues/678)).
 - Windows shutdown no longer dies with an uncaught `Error: spawn taskkill ENOENT` when `%SystemRoot%\System32` is

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Pin classic RPC delta batching and immediate barriers (2026-08-14)
+
+### What changed
+
+- Characterization coverage now proves 1000 classic delta-only `message_update` records remain complete while sharing one same-tick raw write.
+- Event, extension-UI request, event, and response ordering is pinned across consecutive immediate-write barriers.
+- Classic connection-handler backpressure remains deliberately attached to every agent-loop event.
+
+### Why
+
+- Classic RPC projects cumulative assistant updates into delta-only public wire records. Those deltas cannot be compacted safely, so per-event backpressure is its flow control and must not be removed as part of the multi-session writer redesign.
+- `RpcClient` consumers depend on the documented delta sequence and on immediate UI/response records never overtaking pending events.
+
+### Why extension system couldn't handle this
+
+- Classic JSONL projection, batching, and agent-loop backpressure are built-in RPC transport contracts below extension hooks.
+
+### Expected merge conflict zones
+
+- LOW: characterization-only additions in `rpc-event-coalescing.test.ts`.
+- NONE: classic runtime code remains unchanged.
+
 ## Single-flight multi-session RPC drain and control lane (2026-08-14)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Compact cumulative multi-session RPC events per session (2026-08-14)
+
+### What changed
+
+- Multi-session RPC queues now retain structured records until drain time and compact cumulative assistant snapshots within each session and ordering segment.
+- Superseded full snapshots keep their delta while replacing cumulative `message` and `partial` fields with present `null` values; adjacent compatible deltas merge, and the newest update remains the sole full snapshot.
+- Tool progress is latest-wins per tool-call id, with retained updates appended in occurrence order. Protocol, lifecycle, error, delta-only, and unknown records remain barriers and are never coalesced.
+
+### Why
+
+- Long cumulative assistant snapshots produced quadratic queued bytes when a desktop RPC reader stalled, causing visible freezes followed by large output bursts.
+- Delta content and transition boundaries must remain lossless, while repeated cumulative snapshots and accumulated tool progress are redundant before they reach stdout.
+
+### Why extension system couldn't handle this
+
+- Session tagging, JSONL framing, and pending stdout scheduling are owned by the built-in multi-session RPC transport below extension hooks.
+
+### Expected merge conflict zones
+
+- MEDIUM: `session-event-writer.ts` queue representation, compaction keys, and drain serialization.
+- LOW: focused multi-session event-writer tests.
+
 ## Extension request RPC command (2026-08-12)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## Single-flight multi-session RPC drain and control lane (2026-08-14)
+
+### What changed
+
+- The multi-session writer now hands exactly one complete record to stdout, awaits backpressure, and then selects the next ready session in round-robin order.
+- Untagged host responses use a dedicated non-coalescing control lane, and shutdown waits for all retained and in-flight records before flushing raw stdout.
+- Deterministic buffered-record/byte counters include the in-flight record, control enqueues resolve after their own backpressure boundary, and permanent stdout failures reject the active drain and pending control completions.
+
+### Why
+
+- Direct host response writes could bypass session ordering, while synchronous queue draining still fed an unbounded downstream promise chain during stdout stalls.
+- Keeping the backlog in typed lanes lets per-session compaction remain effective and prevents one busy session from monopolizing the raw writer.
+
+### Why extension system couldn't handle this
+
+- Process-wide stdout ownership, host control responses, session fairness, and shutdown flushing are built-in RPC transport responsibilities.
+
+### Expected merge conflict zones
+
+- HIGH: `session-event-writer.ts` drain lifecycle and constructor contract.
+- MEDIUM: `multi-session-host.ts` output and shutdown wiring.
+- LOW: deterministic multi-session drain tests.
+
 ## Compact cumulative multi-session RPC events per session (2026-08-14)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/multi-session-host.ts
+++ b/packages/coding-agent/src/modes/rpc/multi-session-host.ts
@@ -28,7 +28,7 @@ export interface MultiSessionHostOptions {
 export async function runMultiSessionHost(options: MultiSessionHostOptions): Promise<never> {
 	takeOverStdout();
 	const sink: RpcConnectionSink = { writeRaw: writeRawStdout, waitForBackpressure: waitForRawStdoutBackpressure };
-	const writer = new SessionEventWriter(sink.writeRaw);
+	const writer = new SessionEventWriter(sink.writeRaw, sink.waitForBackpressure);
 	const capabilities = parseClientCapabilities(envValue("RPC_CLIENT_CAPABILITIES"));
 	const router = new SessionCommandRouter(
 		new RpcSessionRegistry({ agentDir: options.agentDir, createRuntime: options.createRuntime }),
@@ -39,8 +39,7 @@ export async function runMultiSessionHost(options: MultiSessionHostOptions): Pro
 	);
 	let shuttingDown = false;
 	const output = async (response: RpcResponse) => {
-		sink.writeRaw(`${JSON.stringify(response)}\n`);
-		await sink.waitForBackpressure();
+		await writer.enqueueControl(response);
 	};
 	const handle = async (line: string) => {
 		let command: RpcCommand;
@@ -63,6 +62,7 @@ export async function runMultiSessionHost(options: MultiSessionHostOptions): Pro
 		shuttingDown = true;
 		detach();
 		await router.dispose();
+		await writer.flush();
 		await flushRawStdout();
 		process.exit(exitCode);
 	};

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -1,7 +1,8 @@
 import { serializeJsonLine } from "./jsonl.ts";
 
 type RawWriter = (chunk: string) => void;
-type FlushScheduler = (flush: () => void) => void;
+type BackpressureWaiter = () => Promise<void>;
+type FlushScheduler = (flush: () => Promise<void>) => void;
 type RpcRecord = Record<string, unknown>;
 type CompactDeltaType = "text_delta" | "thinking_delta" | "toolcall_delta";
 
@@ -10,12 +11,16 @@ type QueueNode = {
 	key?: string;
 	previous?: QueueNode;
 	next?: QueueNode;
+	resolve?: () => void;
+	reject?: (cause: unknown) => void;
 };
 
-type SessionQueue = {
+type RecordQueue = {
+	sessionId?: string;
 	head?: QueueNode;
 	tail?: QueueNode;
 	latestByKey: Map<string, QueueNode>;
+	ready: boolean;
 };
 
 const MESSAGE_KEY = "message";
@@ -51,23 +56,56 @@ function toolUpdateKey(value: RpcRecord): string | undefined {
  * Process-wide stdout scheduler for multi-session RPC mode.
  *
  * Each queue contains complete structured JSONL records for one routing handle.
- * Draining takes one record per queue in round-robin order, so a busy session
- * cannot reorder another ready session's next complete record. A record is
- * deliberately written by itself: coalescing records from different sessions
- * would obscure the scheduling boundary and violate D9.
+ * Draining takes one record per queue in round-robin order and waits for stdout
+ * backpressure before selecting the next one. A record is deliberately written
+ * by itself: coalescing records from different sessions would obscure the
+ * scheduling boundary and violate D9.
  */
 export class SessionEventWriter {
-	private readonly queues = new Map<string, SessionQueue>();
-	private readonly readySessions: string[] = [];
+	private readonly queues = new Map<string, RecordQueue>();
+	private readonly controlQueue: RecordQueue = { latestByKey: new Map(), ready: false };
+	private readonly readyQueues: RecordQueue[] = [];
 	private readonly sealedSessions = new Set<string>();
 	private readonly writeRaw: RawWriter;
+	private readonly waitForBackpressure?: BackpressureWaiter;
 	private readonly scheduleFlush: FlushScheduler;
 	private flushScheduled = false;
-	private flushing = false;
+	private drainPromise?: Promise<void>;
+	private inFlight?: { queue: RecordQueue; node: QueueNode };
+	private failure?: unknown;
 
-	constructor(writeRaw: RawWriter, scheduleFlush: FlushScheduler = queueMicrotask) {
+	constructor(writeRaw: RawWriter, scheduleFlush?: FlushScheduler);
+	constructor(writeRaw: RawWriter, waitForBackpressure: BackpressureWaiter, scheduleFlush?: FlushScheduler);
+	constructor(
+		writeRaw: RawWriter,
+		waitOrSchedule?: BackpressureWaiter | FlushScheduler,
+		scheduleFlush?: FlushScheduler,
+	) {
 		this.writeRaw = writeRaw;
-		this.scheduleFlush = scheduleFlush;
+		if (waitOrSchedule && scheduleFlush === undefined && waitOrSchedule.length > 0) {
+			this.scheduleFlush = waitOrSchedule as FlushScheduler;
+		} else {
+			this.waitForBackpressure = waitOrSchedule as BackpressureWaiter | undefined;
+			this.scheduleFlush = scheduleFlush ?? ((flush) => queueMicrotask(() => void flush()));
+		}
+	}
+
+	get bufferedRecordCount(): number {
+		let count = this.inFlight ? 1 : 0;
+		for (const queue of this.allQueues()) {
+			for (let node = queue.head; node; node = node.next) count++;
+		}
+		return count;
+	}
+
+	get bufferedByteLength(): number {
+		let bytes = this.inFlight ? Buffer.byteLength(serializeJsonLine(this.inFlight.node.value)) : 0;
+		for (const queue of this.allQueues()) {
+			for (let node = queue.head; node; node = node.next) {
+				bytes += Buffer.byteLength(serializeJsonLine(node.value));
+			}
+		}
+		return bytes;
 	}
 
 	/** Queue one session-owned response, event, or extension UI request. */
@@ -76,6 +114,17 @@ export class SessionEventWriter {
 		this.appendSessionRecord(sessionId, { ...value, sessionId });
 		this.requestFlush();
 		return true;
+	}
+
+	/** Queue one untagged host-control response without compaction. */
+	enqueueControl(value: object): Promise<void> {
+		if (this.failure !== undefined) return Promise.reject(this.failure);
+		const completion = new Promise<void>((resolve, reject) => {
+			this.append(this.controlQueue, { ...value }, undefined, resolve, reject);
+		});
+		this.markReady(this.controlQueue);
+		this.requestFlush();
+		return completion;
 	}
 
 	/**
@@ -90,39 +139,73 @@ export class SessionEventWriter {
 		this.requestFlush();
 	}
 
-	/** Synchronously drain all currently complete records in fair queue order. */
-	flush(): void {
-		if (this.flushing) return;
+	/** Drain every retained lane and the current in-flight record. */
+	flush(): Promise<void> {
+		if (this.failure !== undefined) return Promise.reject(this.failure);
 		this.flushScheduled = false;
-		this.flushing = true;
-		try {
-			while (this.readySessions.length > 0) {
-				const sessionId = this.readySessions.shift()!;
-				const queue = this.queues.get(sessionId);
-				const node = queue?.head;
-				if (!queue || !node) continue;
+		if (this.drainPromise) return this.drainPromise;
+		if (this.readyQueues.length === 0) return Promise.resolve();
+		let resolveDrain!: () => void;
+		let rejectDrain!: (cause: unknown) => void;
+		const drain = new Promise<void>((resolve, reject) => {
+			resolveDrain = resolve;
+			rejectDrain = reject;
+		});
+		this.drainPromise = drain;
+		void this.drainUntilEmpty().then(resolveDrain, rejectDrain);
+		void drain.then(
+			() => {
+				if (this.drainPromise === drain) this.drainPromise = undefined;
+			},
+			(cause) => {
+				if (this.drainPromise === drain) this.drainPromise = undefined;
+				this.fail(cause);
+			},
+		);
+		return drain;
+	}
 
-				this.unlink(queue, node);
-				// Exactly one complete record per write. In particular, records from
-				// different sessions must never share a batch.
+	private async drainUntilEmpty(): Promise<void> {
+		do {
+			await this.drainReadyQueues();
+		} while (this.readyQueues.length > 0);
+	}
+
+	private async drainReadyQueues(): Promise<void> {
+		while (this.readyQueues.length > 0) {
+			const queue = this.readyQueues.shift()!;
+			queue.ready = false;
+			const node = queue.head;
+			if (!node) continue;
+
+			this.unlink(queue, node);
+			this.inFlight = { queue, node };
+			try {
+				// D9: exactly one complete record per raw write. The next lane is not
+				// selected until this record has cleared stdout backpressure.
 				this.writeRaw(serializeJsonLine(node.value));
-				if (queue.head) {
-					this.readySessions.push(sessionId);
-				} else {
-					this.queues.delete(sessionId);
-				}
+				if (this.waitForBackpressure) await this.waitForBackpressure();
+				node.resolve?.();
+			} catch (cause) {
+				node.reject?.(cause);
+				throw cause;
+			} finally {
+				this.inFlight = undefined;
 			}
-		} finally {
-			this.flushing = false;
+
+			if (queue.head) {
+				this.markReady(queue);
+			} else if (queue.sessionId) {
+				this.queues.delete(queue.sessionId);
+			}
 		}
 	}
 
 	private appendSessionRecord(sessionId: string, value: RpcRecord): void {
 		let queue = this.queues.get(sessionId);
 		if (!queue) {
-			queue = { latestByKey: new Map() };
+			queue = { sessionId, latestByKey: new Map(), ready: false };
 			this.queues.set(sessionId, queue);
-			this.readySessions.push(sessionId);
 		}
 
 		const delta = compactDelta(value);
@@ -131,6 +214,7 @@ export class SessionEventWriter {
 			if (previousFull) this.demoteAndMerge(queue, previousFull);
 			const node = this.append(queue, value, MESSAGE_KEY);
 			queue.latestByKey.set(MESSAGE_KEY, node);
+			this.markReady(queue);
 			return;
 		}
 
@@ -140,6 +224,7 @@ export class SessionEventWriter {
 			if (previous) this.unlink(queue, previous);
 			const node = this.append(queue, value, toolKey);
 			queue.latestByKey.set(toolKey, node);
+			this.markReady(queue);
 			return;
 		}
 
@@ -148,9 +233,10 @@ export class SessionEventWriter {
 		// extension UI requests, errors, retries, lifecycle, and unknown records.
 		queue.latestByKey.clear();
 		this.append(queue, value);
+		this.markReady(queue);
 	}
 
-	private demoteAndMerge(queue: SessionQueue, node: QueueNode): void {
+	private demoteAndMerge(queue: RecordQueue, node: QueueNode): void {
 		const event = node.value.assistantMessageEvent as Record<string, unknown>;
 		node.value = {
 			...node.value,
@@ -177,15 +263,21 @@ export class SessionEventWriter {
 		}
 	}
 
-	private append(queue: SessionQueue, value: RpcRecord, key?: string): QueueNode {
-		const node: QueueNode = { value, key, previous: queue.tail };
+	private append(
+		queue: RecordQueue,
+		value: RpcRecord,
+		key?: string,
+		resolve?: () => void,
+		reject?: (cause: unknown) => void,
+	): QueueNode {
+		const node: QueueNode = { value, key, previous: queue.tail, resolve, reject };
 		if (queue.tail) queue.tail.next = node;
 		else queue.head = node;
 		queue.tail = node;
 		return node;
 	}
 
-	private unlink(queue: SessionQueue, node: QueueNode): void {
+	private unlink(queue: RecordQueue, node: QueueNode): void {
 		if (node.previous) node.previous.next = node.next;
 		else queue.head = node.next;
 		if (node.next) node.next.previous = node.previous;
@@ -195,9 +287,28 @@ export class SessionEventWriter {
 		node.next = undefined;
 	}
 
+	private markReady(queue: RecordQueue): void {
+		if (queue.ready || this.inFlight?.queue === queue || !queue.head) return;
+		queue.ready = true;
+		this.readyQueues.push(queue);
+	}
+
 	private requestFlush(): void {
-		if (this.flushScheduled || this.flushing) return;
+		if (this.failure !== undefined || this.flushScheduled || this.drainPromise) return;
 		this.flushScheduled = true;
 		this.scheduleFlush(() => this.flush());
+	}
+
+	private fail(cause: unknown): void {
+		if (this.failure !== undefined) return;
+		this.failure = cause;
+		for (const queue of this.allQueues()) {
+			for (let node = queue.head; node; node = node.next) node.reject?.(cause);
+		}
+	}
+
+	private *allQueues(): Iterable<RecordQueue> {
+		yield* this.queues.values();
+		yield this.controlQueue;
 	}
 }

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -2,18 +2,62 @@ import { serializeJsonLine } from "./jsonl.ts";
 
 type RawWriter = (chunk: string) => void;
 type FlushScheduler = (flush: () => void) => void;
+type RpcRecord = Record<string, unknown>;
+type CompactDeltaType = "text_delta" | "thinking_delta" | "toolcall_delta";
+
+type QueueNode = {
+	value: RpcRecord;
+	key?: string;
+	previous?: QueueNode;
+	next?: QueueNode;
+};
+
+type SessionQueue = {
+	head?: QueueNode;
+	tail?: QueueNode;
+	latestByKey: Map<string, QueueNode>;
+};
+
+const MESSAGE_KEY = "message";
+const COMPACT_DELTA_TYPES = new Set<CompactDeltaType>(["text_delta", "thinking_delta", "toolcall_delta"]);
+
+function compactDelta(value: RpcRecord): { type: CompactDeltaType; contentIndex: number; delta: string } | undefined {
+	if (value.type !== "message_update" || !Object.hasOwn(value, "message")) return undefined;
+	const event = value.assistantMessageEvent;
+	if (typeof event !== "object" || event === null) return undefined;
+	const typedEvent = event as Record<string, unknown>;
+	if (
+		typeof typedEvent.type !== "string" ||
+		!COMPACT_DELTA_TYPES.has(typedEvent.type as CompactDeltaType) ||
+		typeof typedEvent.contentIndex !== "number" ||
+		typeof typedEvent.delta !== "string"
+	) {
+		return undefined;
+	}
+	return {
+		type: typedEvent.type as CompactDeltaType,
+		contentIndex: typedEvent.contentIndex,
+		delta: typedEvent.delta,
+	};
+}
+
+function toolUpdateKey(value: RpcRecord): string | undefined {
+	return value.type === "tool_execution_update" && typeof value.toolCallId === "string"
+		? `tool:${value.toolCallId}`
+		: undefined;
+}
 
 /**
  * Process-wide stdout scheduler for multi-session RPC mode.
  *
- * Each queue contains complete JSONL records for one routing handle. Draining
- * takes one record per queue in round-robin order, so a busy session cannot
- * reorder another ready session's next complete record. A record is deliberately
- * written by itself: coalescing records from different sessions would obscure
- * the scheduling boundary and violate D9.
+ * Each queue contains complete structured JSONL records for one routing handle.
+ * Draining takes one record per queue in round-robin order, so a busy session
+ * cannot reorder another ready session's next complete record. A record is
+ * deliberately written by itself: coalescing records from different sessions
+ * would obscure the scheduling boundary and violate D9.
  */
 export class SessionEventWriter {
-	private readonly queues = new Map<string, string[]>();
+	private readonly queues = new Map<string, SessionQueue>();
 	private readonly readySessions: string[] = [];
 	private readonly sealedSessions = new Set<string>();
 	private readonly writeRaw: RawWriter;
@@ -29,14 +73,7 @@ export class SessionEventWriter {
 	/** Queue one session-owned response, event, or extension UI request. */
 	enqueue(sessionId: string, value: object): boolean {
 		if (this.sealedSessions.has(sessionId)) return false;
-		const queue = this.queues.get(sessionId);
-		const record = serializeJsonLine({ ...value, sessionId });
-		if (queue) {
-			queue.push(record);
-		} else {
-			this.queues.set(sessionId, [record]);
-			this.readySessions.push(sessionId);
-		}
+		this.appendSessionRecord(sessionId, { ...value, sessionId });
 		this.requestFlush();
 		return true;
 	}
@@ -49,14 +86,7 @@ export class SessionEventWriter {
 	closeSession(sessionId: string, response: object): void {
 		if (this.sealedSessions.has(sessionId)) return;
 		this.sealedSessions.add(sessionId);
-		const queue = this.queues.get(sessionId);
-		const record = serializeJsonLine({ ...response, sessionId });
-		if (queue) {
-			queue.push(record);
-		} else {
-			this.queues.set(sessionId, [record]);
-			this.readySessions.push(sessionId);
-		}
+		this.appendSessionRecord(sessionId, { ...response, sessionId });
 		this.requestFlush();
 	}
 
@@ -69,13 +99,14 @@ export class SessionEventWriter {
 			while (this.readySessions.length > 0) {
 				const sessionId = this.readySessions.shift()!;
 				const queue = this.queues.get(sessionId);
-				const record = queue?.shift();
-				if (!record) continue;
+				const node = queue?.head;
+				if (!queue || !node) continue;
 
+				this.unlink(queue, node);
 				// Exactly one complete record per write. In particular, records from
 				// different sessions must never share a batch.
-				this.writeRaw(record);
-				if (queue && queue.length > 0) {
+				this.writeRaw(serializeJsonLine(node.value));
+				if (queue.head) {
 					this.readySessions.push(sessionId);
 				} else {
 					this.queues.delete(sessionId);
@@ -84,6 +115,84 @@ export class SessionEventWriter {
 		} finally {
 			this.flushing = false;
 		}
+	}
+
+	private appendSessionRecord(sessionId: string, value: RpcRecord): void {
+		let queue = this.queues.get(sessionId);
+		if (!queue) {
+			queue = { latestByKey: new Map() };
+			this.queues.set(sessionId, queue);
+			this.readySessions.push(sessionId);
+		}
+
+		const delta = compactDelta(value);
+		if (delta) {
+			const previousFull = queue.latestByKey.get(MESSAGE_KEY);
+			if (previousFull) this.demoteAndMerge(queue, previousFull);
+			const node = this.append(queue, value, MESSAGE_KEY);
+			queue.latestByKey.set(MESSAGE_KEY, node);
+			return;
+		}
+
+		const toolKey = toolUpdateKey(value);
+		if (toolKey) {
+			const previous = queue.latestByKey.get(toolKey);
+			if (previous) this.unlink(queue, previous);
+			const node = this.append(queue, value, toolKey);
+			queue.latestByKey.set(toolKey, node);
+			return;
+		}
+
+		// All non-compactable records are ordering barriers. In particular this
+		// includes delta-only/full non-delta message updates, protocol responses,
+		// extension UI requests, errors, retries, lifecycle, and unknown records.
+		queue.latestByKey.clear();
+		this.append(queue, value);
+	}
+
+	private demoteAndMerge(queue: SessionQueue, node: QueueNode): void {
+		const event = node.value.assistantMessageEvent as Record<string, unknown>;
+		node.value = {
+			...node.value,
+			message: null,
+			assistantMessageEvent: { ...event, partial: null },
+		};
+		const current = compactDelta(node.value);
+		const preceding = node.previous;
+		const previous = preceding ? compactDelta(preceding.value) : undefined;
+		if (
+			preceding &&
+			previous &&
+			current &&
+			preceding.value.message === null &&
+			previous.type === current.type &&
+			previous.contentIndex === current.contentIndex
+		) {
+			const precedingEvent = preceding.value.assistantMessageEvent as Record<string, unknown>;
+			preceding.value = {
+				...preceding.value,
+				assistantMessageEvent: { ...precedingEvent, delta: previous.delta + current.delta },
+			};
+			this.unlink(queue, node);
+		}
+	}
+
+	private append(queue: SessionQueue, value: RpcRecord, key?: string): QueueNode {
+		const node: QueueNode = { value, key, previous: queue.tail };
+		if (queue.tail) queue.tail.next = node;
+		else queue.head = node;
+		queue.tail = node;
+		return node;
+	}
+
+	private unlink(queue: SessionQueue, node: QueueNode): void {
+		if (node.previous) node.previous.next = node.next;
+		else queue.head = node.next;
+		if (node.next) node.next.previous = node.previous;
+		else queue.tail = node.previous;
+		if (node.key && queue.latestByKey.get(node.key) === node) queue.latestByKey.delete(node.key);
+		node.previous = undefined;
+		node.next = undefined;
 	}
 
 	private requestFlush(): void {

--- a/packages/coding-agent/test/rpc-event-coalescing.test.ts
+++ b/packages/coding-agent/test/rpc-event-coalescing.test.ts
@@ -10,6 +10,53 @@ function parseLines(chunks: readonly string[]): Array<Record<string, unknown>> {
 }
 
 describe("RPC event output coalescing", () => {
+	it("keeps every classic message delta while batching one raw write", () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => void> = [];
+		const buffer = createRpcEventOutputBuffer(
+			(chunk) => chunks.push(chunk),
+			(flush) => scheduled.push(flush),
+		);
+		const source = Array.from({ length: 1000 }, (_, index) => String.fromCharCode(97 + (index % 26))).join("");
+
+		for (const delta of source) {
+			buffer.enqueueEvent({
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta },
+			});
+		}
+		scheduled[0]!();
+
+		const output = parseLines(chunks);
+		expect(chunks).toHaveLength(1);
+		expect(output).toHaveLength(1000);
+		expect(output.map((record) => (record.assistantMessageEvent as { delta: string }).delta).join("")).toBe(source);
+		expect(output.every((record) => !Object.hasOwn(record, "message"))).toBe(true);
+		expect(output.every((record) => !Object.hasOwn(record.assistantMessageEvent as object, "partial"))).toBe(true);
+	});
+
+	it("preserves event, UI-request, event, response ordering across immediate barriers", () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => void> = [];
+		const buffer = createRpcEventOutputBuffer(
+			(chunk) => chunks.push(chunk),
+			(flush) => scheduled.push(flush),
+		);
+
+		buffer.enqueueEvent({ type: "event", sequence: 1 });
+		buffer.writeImmediate({ type: "extension_ui_request", id: "ui-1" });
+		buffer.enqueueEvent({ type: "event", sequence: 2 });
+		buffer.writeImmediate({ type: "response", id: "cmd-1" });
+
+		expect(chunks).toHaveLength(4);
+		expect(parseLines(chunks)).toEqual([
+			{ type: "event", sequence: 1 },
+			{ type: "extension_ui_request", id: "ui-1" },
+			{ type: "event", sequence: 2 },
+			{ type: "response", id: "cmd-1" },
+		]);
+	});
+
 	it("flushes pending events before immediate response writes", () => {
 		const chunks: string[] = [];
 		const scheduled: Array<() => void> = [];

--- a/packages/coding-agent/test/rpc-multi-session-events.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-events.test.ts
@@ -30,8 +30,22 @@ function flushedDeltas(output: readonly Record<string, unknown>[]): string {
 		.join("");
 }
 
+function deferred<T = void>(): {
+	promise: Promise<T>;
+	resolve: (value: T | PromiseLike<T>) => void;
+	reject: (reason?: unknown) => void;
+} {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
 describe("multi-session RPC event writer", () => {
-	it("compacts 1000 stalled message snapshots without losing assistant transitions", () => {
+	it("compacts 1000 stalled message snapshots without losing assistant transitions", async () => {
 		const chunks: string[] = [];
 		const scheduled: Array<() => void> = [];
 		const writer = new SessionEventWriter(
@@ -53,7 +67,7 @@ describe("multi-session RPC event writer", () => {
 			type: "message_end",
 			message: { role: "assistant", content: [{ type: "text", text: source }] },
 		});
-		scheduled[0]!();
+		await scheduled[0]!();
 
 		const output = records(chunks);
 		const updates = output.filter((record) => record.type === "message_update");
@@ -68,7 +82,7 @@ describe("multi-session RPC event writer", () => {
 		expect(Buffer.byteLength(chunks.join(""))).toBeLessThan(cumulativeBytes / 20);
 	});
 
-	it("latest-wins coalesces tool progress independently by toolCallId", () => {
+	it("latest-wins coalesces tool progress independently by toolCallId", async () => {
 		const chunks: string[] = [];
 		const scheduled: Array<() => void> = [];
 		const writer = new SessionEventWriter(
@@ -82,7 +96,7 @@ describe("multi-session RPC event writer", () => {
 		writer.enqueue("a", { type: "tool_execution_update", toolCallId: "A", partialResult: "A2" });
 		writer.enqueue("a", { type: "tool_execution_update", toolCallId: "B", partialResult: "B2" });
 		writer.enqueue("a", { type: "tool_execution_end", toolCallId: "A" });
-		scheduled[0]!();
+		await scheduled[0]!();
 
 		expect(
 			records(chunks).map(({ type, toolCallId, partialResult }) => ({ type, toolCallId, partialResult })),
@@ -94,7 +108,7 @@ describe("multi-session RPC event writer", () => {
 		]);
 	});
 
-	it("does not merge across assistant or protocol barriers", () => {
+	it("does not merge across assistant or protocol barriers", async () => {
 		const chunks: string[] = [];
 		const scheduled: Array<() => void> = [];
 		const writer = new SessionEventWriter(
@@ -117,7 +131,7 @@ describe("multi-session RPC event writer", () => {
 		writer.enqueue("a", { type: "response", id: "command", success: true });
 		writer.enqueue("a", cumulativeTextUpdate("g", "abcdefg"));
 		writer.enqueue("a", cumulativeTextUpdate("h", "abcdefgh"));
-		scheduled[0]!();
+		await scheduled[0]!();
 
 		const output = records(chunks);
 		expect(output.map((record) => record.type)).toEqual([
@@ -151,7 +165,7 @@ describe("multi-session RPC event writer", () => {
 		]);
 	});
 
-	it("never coalesces delta-only, error, lifecycle, or unknown records", () => {
+	it("never coalesces delta-only, error, lifecycle, or unknown records", async () => {
 		const chunks: string[] = [];
 		const scheduled: Array<() => void> = [];
 		const writer = new SessionEventWriter(
@@ -174,7 +188,7 @@ describe("multi-session RPC event writer", () => {
 			writer.enqueue(sessionId, barrier);
 			writer.enqueue(sessionId, cumulativeTextUpdate("y", "xy"));
 		});
-		scheduled[0]!();
+		await scheduled[0]!();
 
 		const output = records(chunks);
 		expect(output).toHaveLength(12);
@@ -182,7 +196,7 @@ describe("multi-session RPC event writer", () => {
 		expect(output.filter((record) => record.type === "message_update")).toHaveLength(9);
 	});
 
-	it("tags every record, preserves per-session FIFO, and round-robins complete records", () => {
+	it("tags every record, preserves per-session FIFO, and round-robins complete records", async () => {
 		const chunks: string[] = [];
 		const scheduled: Array<() => void> = [];
 		const writer = new SessionEventWriter(
@@ -195,7 +209,7 @@ describe("multi-session RPC event writer", () => {
 		writer.enqueue("b", { type: "message_update", sequence: 1 });
 		writer.enqueue("a", { type: "agent_settled", sequence: 2 });
 		writer.enqueue("b", { type: "agent_settled", sequence: 2 });
-		scheduled[0]!();
+		await scheduled[0]!();
 
 		expect(records(chunks)).toEqual([
 			{ type: "message_update", sequence: 1, sessionId: "a" },
@@ -228,7 +242,7 @@ describe("multi-session RPC event writer", () => {
 		expect(resolvedB).toBe(true);
 	});
 
-	it("does not emit after a session is sealed, while allowing its terminal close response", () => {
+	it("does not emit after a session is sealed, while allowing its terminal close response", async () => {
 		const chunks: string[] = [];
 		const writer = new SessionEventWriter(
 			(chunk) => chunks.push(chunk),
@@ -239,12 +253,151 @@ describe("multi-session RPC event writer", () => {
 		writer.closeSession("a", { id: "close-a", type: "response", command: "close_session", success: true });
 		writer.enqueue("a", { type: "agent_settled" });
 		writer.enqueue("b", { type: "agent_settled" });
-		writer.flush();
+		await writer.flush();
 
 		expect(records(chunks)).toEqual([
 			{ type: "message_update", sessionId: "a" },
 			{ id: "close-a", type: "response", command: "close_session", success: true, sessionId: "a" },
 			{ type: "agent_settled", sessionId: "b" },
 		]);
+	});
+
+	it("keeps one raw write in flight while round-robining ready sessions", async () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => Promise<void>> = [];
+		const releases = [deferred(), deferred(), deferred()];
+		const writes = [deferred(), deferred(), deferred()];
+		let writeIndex = 0;
+		let waitIndex = 0;
+		const writer = new SessionEventWriter(
+			(chunk) => {
+				chunks.push(chunk);
+				writes[writeIndex++]?.resolve();
+			},
+			() => releases[waitIndex++]!.promise,
+			(flush) => scheduled.push(flush),
+		);
+
+		writer.enqueue("a", { type: "event", sequence: "A1" });
+		const draining = scheduled[0]!();
+		await writes[0]!.promise;
+		writer.enqueue("a", { type: "event", sequence: "A2" });
+		writer.enqueue("b", { type: "event", sequence: "B1" });
+		expect(chunks).toHaveLength(1);
+		expect(writer.bufferedRecordCount).toBe(3);
+
+		releases[0]!.resolve();
+		await writes[1]!.promise;
+		expect(records(chunks).map((record) => record.sequence)).toEqual(["A1", "B1"]);
+		expect(chunks).toHaveLength(2);
+
+		releases[1]!.resolve();
+		await writes[2]!.promise;
+		expect(records(chunks).map((record) => record.sequence)).toEqual(["A1", "B1", "A2"]);
+		releases[2]!.resolve();
+		await draining;
+		expect(writer.bufferedRecordCount).toBe(0);
+		expect(writer.bufferedByteLength).toBe(0);
+	});
+
+	it("never drops or coalesces untagged control responses", async () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => Promise<void>> = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			async () => {},
+			(flush) => scheduled.push(flush),
+		);
+
+		writer.enqueue("a", { type: "event", sequence: 1 });
+		const first = writer.enqueueControl({ type: "response", id: "control-1", success: true });
+		writer.enqueue("a", { type: "event", sequence: 2 });
+		const second = writer.enqueueControl({ type: "response", id: "control-2", success: false });
+		await scheduled[0]!();
+		await Promise.all([first, second]);
+
+		expect(records(chunks)).toEqual([
+			{ type: "event", sequence: 1, sessionId: "a" },
+			{ type: "response", id: "control-1", success: true },
+			{ type: "event", sequence: 2, sessionId: "a" },
+			{ type: "response", id: "control-2", success: false },
+		]);
+		expect(chunks).toHaveLength(4);
+	});
+
+	it("flush waits for the in-flight record and all retained records", async () => {
+		const chunks: string[] = [];
+		const releases = [deferred(), deferred()];
+		const writes = [deferred(), deferred()];
+		let writeIndex = 0;
+		let waitIndex = 0;
+		const writer = new SessionEventWriter(
+			(chunk) => {
+				chunks.push(chunk);
+				writes[writeIndex++]?.resolve();
+			},
+			() => releases[waitIndex++]!.promise,
+		);
+		writer.enqueue("a", { type: "event", sequence: 1 });
+		writer.enqueue("a", { type: "event", sequence: 2 });
+
+		let flushed = false;
+		const flush = writer.flush().then(() => {
+			flushed = true;
+		});
+		await writes[0]!.promise;
+		expect(flushed).toBe(false);
+		expect(writer.bufferedRecordCount).toBe(2);
+		expect(writer.bufferedByteLength).toBeGreaterThan(0);
+
+		releases[0]!.resolve();
+		await writes[1]!.promise;
+		expect(flushed).toBe(false);
+		releases[1]!.resolve();
+		await flush;
+		expect(flushed).toBe(true);
+		expect(records(chunks).map((record) => record.sequence)).toEqual([1, 2]);
+	});
+
+	it("seals close_session after the retained stream and rejects late enqueue", async () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => Promise<void>> = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			async () => {},
+			(flush) => scheduled.push(flush),
+		);
+
+		writer.enqueue("a", cumulativeTextUpdate("a", "a"));
+		writer.enqueue("a", cumulativeTextUpdate("b", "ab"));
+		writer.closeSession("a", { id: "close-a", type: "response", command: "close_session", success: true });
+		expect(writer.enqueue("a", cumulativeTextUpdate("late", "ablate"))).toBe(false);
+		await scheduled[0]!();
+
+		const output = records(chunks);
+		expect(flushedDeltas(output)).toBe("ab");
+		expect(output.at(-1)).toEqual({
+			id: "close-a",
+			type: "response",
+			command: "close_session",
+			success: true,
+			sessionId: "a",
+		});
+	});
+
+	it("rejects flush and control completion on permanent stdout errors", async () => {
+		const failure = new Error("EPIPE: permanent stdout failure");
+		const writer = new SessionEventWriter(
+			() => {},
+			async () => {
+				throw failure;
+			},
+		);
+		writer.enqueue("a", { type: "event" });
+		const control = writer.enqueueControl({ type: "response", id: "control" });
+
+		await expect(writer.flush()).rejects.toBe(failure);
+		await expect(control).rejects.toBe(failure);
+		await expect(writer.flush()).rejects.toBe(failure);
 	});
 });

--- a/packages/coding-agent/test/rpc-multi-session-events.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-events.test.ts
@@ -10,7 +10,178 @@ function records(chunks: readonly string[]): Array<Record<string, unknown>> {
 		.map((line) => JSON.parse(line) as Record<string, unknown>);
 }
 
+function cumulativeTextUpdate(delta: string, text: string, contentIndex = 0): Record<string, unknown> {
+	return {
+		type: "message_update",
+		assistantMessageEvent: {
+			type: "text_delta",
+			contentIndex,
+			delta,
+			partial: { role: "assistant", content: [{ type: "text", text }] },
+		},
+		message: { role: "assistant", content: [{ type: "text", text }] },
+	};
+}
+
+function flushedDeltas(output: readonly Record<string, unknown>[]): string {
+	return output
+		.filter((record) => record.type === "message_update")
+		.map((record) => (record.assistantMessageEvent as { delta?: string }).delta ?? "")
+		.join("");
+}
+
 describe("multi-session RPC event writer", () => {
+	it("compacts 1000 stalled message snapshots without losing assistant transitions", () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => void> = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => scheduled.push(flush),
+		);
+		const source = Array.from({ length: 1000 }, (_, index) => String.fromCharCode(97 + (index % 26))).join("");
+		let cumulative = "";
+		let cumulativeBytes = 0;
+
+		writer.enqueue("a", { type: "message_start", message: { role: "assistant", content: [] } });
+		for (const delta of source) {
+			cumulative += delta;
+			const update = cumulativeTextUpdate(delta, cumulative);
+			cumulativeBytes += Buffer.byteLength(JSON.stringify({ ...update, sessionId: "a" }) + "\n");
+			writer.enqueue("a", update);
+		}
+		writer.enqueue("a", {
+			type: "message_end",
+			message: { role: "assistant", content: [{ type: "text", text: source }] },
+		});
+		scheduled[0]!();
+
+		const output = records(chunks);
+		const updates = output.filter((record) => record.type === "message_update");
+		expect(output[0]?.type).toBe("message_start");
+		expect(output.at(-1)?.type).toBe("message_end");
+		expect(flushedDeltas(output)).toBe(source);
+		expect(updates.at(-1)?.message).toEqual({
+			role: "assistant",
+			content: [{ type: "text", text: source }],
+		});
+		expect(updates.slice(0, -1).every((record) => record.message === null)).toBe(true);
+		expect(Buffer.byteLength(chunks.join(""))).toBeLessThan(cumulativeBytes / 20);
+	});
+
+	it("latest-wins coalesces tool progress independently by toolCallId", () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => void> = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => scheduled.push(flush),
+		);
+
+		writer.enqueue("a", { type: "tool_execution_start", toolCallId: "A" });
+		writer.enqueue("a", { type: "tool_execution_update", toolCallId: "A", partialResult: "A1" });
+		writer.enqueue("a", { type: "tool_execution_update", toolCallId: "B", partialResult: "B1" });
+		writer.enqueue("a", { type: "tool_execution_update", toolCallId: "A", partialResult: "A2" });
+		writer.enqueue("a", { type: "tool_execution_update", toolCallId: "B", partialResult: "B2" });
+		writer.enqueue("a", { type: "tool_execution_end", toolCallId: "A" });
+		scheduled[0]!();
+
+		expect(
+			records(chunks).map(({ type, toolCallId, partialResult }) => ({ type, toolCallId, partialResult })),
+		).toEqual([
+			{ type: "tool_execution_start", toolCallId: "A", partialResult: undefined },
+			{ type: "tool_execution_update", toolCallId: "A", partialResult: "A2" },
+			{ type: "tool_execution_update", toolCallId: "B", partialResult: "B2" },
+			{ type: "tool_execution_end", toolCallId: "A", partialResult: undefined },
+		]);
+	});
+
+	it("does not merge across assistant or protocol barriers", () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => void> = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => scheduled.push(flush),
+		);
+
+		writer.enqueue("a", cumulativeTextUpdate("a", "a"));
+		writer.enqueue("a", cumulativeTextUpdate("b", "ab"));
+		writer.enqueue("a", {
+			type: "message_update",
+			assistantMessageEvent: { type: "text_end", contentIndex: 0 },
+			message: {},
+		});
+		writer.enqueue("a", cumulativeTextUpdate("c", "abc"));
+		writer.enqueue("a", cumulativeTextUpdate("d", "abcd"));
+		writer.enqueue("a", { type: "extension_ui_request", id: "ui" });
+		writer.enqueue("a", cumulativeTextUpdate("e", "abcde"));
+		writer.enqueue("a", cumulativeTextUpdate("f", "abcdef"));
+		writer.enqueue("a", { type: "response", id: "command", success: true });
+		writer.enqueue("a", cumulativeTextUpdate("g", "abcdefg"));
+		writer.enqueue("a", cumulativeTextUpdate("h", "abcdefgh"));
+		scheduled[0]!();
+
+		const output = records(chunks);
+		expect(output.map((record) => record.type)).toEqual([
+			"message_update",
+			"message_update",
+			"message_update",
+			"message_update",
+			"message_update",
+			"extension_ui_request",
+			"message_update",
+			"message_update",
+			"response",
+			"message_update",
+			"message_update",
+		]);
+		expect(flushedDeltas(output)).toBe("abcdefgh");
+		expect(
+			output
+				.filter((record) => record.type === "message_update")
+				.map((record) => (record.assistantMessageEvent as { type: string }).type),
+		).toEqual([
+			"text_delta",
+			"text_delta",
+			"text_end",
+			"text_delta",
+			"text_delta",
+			"text_delta",
+			"text_delta",
+			"text_delta",
+			"text_delta",
+		]);
+	});
+
+	it("never coalesces delta-only, error, lifecycle, or unknown records", () => {
+		const chunks: string[] = [];
+		const scheduled: Array<() => void> = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => scheduled.push(flush),
+		);
+		const barriers = [
+			{
+				type: "message_update",
+				assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "delta-only" },
+			},
+			{ type: "extension_error", error: "boom" },
+			{ type: "agent_settled" },
+			{ type: "future_record", value: 1 },
+		];
+
+		barriers.forEach((barrier, index) => {
+			const sessionId = `barrier-${index}`;
+			writer.enqueue(sessionId, cumulativeTextUpdate("x", "x"));
+			writer.enqueue(sessionId, barrier);
+			writer.enqueue(sessionId, cumulativeTextUpdate("y", "xy"));
+		});
+		scheduled[0]!();
+
+		const output = records(chunks);
+		expect(output).toHaveLength(12);
+		expect(output.filter((record) => record.message === null)).toHaveLength(0);
+		expect(output.filter((record) => record.type === "message_update")).toHaveLength(9);
+	});
+
 	it("tags every record, preserves per-session FIFO, and round-robins complete records", () => {
 		const chunks: string[] = [];
 		const scheduled: Array<() => void> = [];


### PR DESCRIPTION
The multi-session RPC event stream amplified a single streaming answer into hundreds of megabytes of stdout, and clients reading it appeared to freeze and then render walls of text at once.

Every `message_update` carries a full cumulative snapshot of the assistant message, so the wire cost grows quadratically over an item's life. Measured against this branch's merge base with a bare RPC client (no wrapper, no proxy in the path): one 96-second answer delivering 12 KB of assistant content pushed **140 MB** of stdout, median line **72 KB**, peak **95 KB** - larger than the 64 KB pipe itself. Because `writeRawStdout` appends every write to an unbounded promise chain while the head write retries on `ENOBUFS`, a consumer that pauses lets records pile up in memory and arrive in one flush.

`SessionEventWriter` now compacts each session's pending queue instead of holding redundant snapshots:

- a superseded pending `message_update` is demoted to `message: null` / `assistantMessageEvent.partial: null` (the fields stay present, so decoders requiring presence keep working), and adjacent demoted deltas of the same type and content index merge by concatenating `delta`;
- `tool_execution_update` keeps only the latest record per `toolCallId`, unlinked and re-appended so retained records stay in occurrence order;
- message and tool boundaries, delta-only updates, bash and compaction progress, UI requests, responses, and every error/lifecycle/unknown record are barriers that are never merged or dropped.

The drain is now single-flight: exactly one complete record reaches the raw writer at a time and the next lane waits for stdout backpressure, so the promise chain can no longer bank an unbounded backlog. Host control responses moved onto their own non-coalescing lane (previously they bypassed the writer entirely), shutdown flushes the writer before flushing stdout, and permanent stdout failures reject the active drain instead of being swallowed. Round-robin fairness and the one-record-per-write invariant are unchanged.

Same probe against this branch: **18.5 MB instead of 121 MB** for a comparable answer under a deliberately slow reader (-85%), wire amplification down from 9,840x to 1,295x (-87%), median line 60 KB -> 22 KB, and the whole answer settles in 94 s instead of 209 s.

Classic single-session RPC is untouched - it emits delta-only records that must never be coalesced, and its per-event agent-loop backpressure is its flow control. Both properties are now pinned by regression tests, each proven to bite under its own mutation, so a future cleanup cannot quietly remove them.

Generated with omo (senpi engine), model GPT-5.6 Terra.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compacts multi-session RPC event queues and makes stdout drain single-flight to prevent quadratic wire amplification and client freezes. Previously each `message_update` emitted a full cumulative snapshot and writes accumulated behind backpressure; now redundant snapshots are merged or dropped and only one complete record is in flight at a time.

- Compaction per session: superseded `message_update` snapshots are demoted to `message: null` with `assistantMessageEvent.partial: null`, adjacent same-index deltas merge, and `tool_execution_update` is latest-wins per `toolCallId`. Message/protocol boundaries, delta-only updates, UI requests, responses, errors, lifecycle, and unknown records are barriers and never merged.
- Drain and control lane: the writer selects one record at a time, awaits stdout backpressure, and preserves round-robin fairness and the one-record-per-write invariant. Host control responses use `enqueueControl` (non-coalescing), `flush()` waits for the in-flight record and retained queues, and permanent stdout failures reject the active drain and pending control completions.
- Integration and tests: `multi-session-host` passes the backpressure waiter to `SessionEventWriter`, routes host responses through the writer, and flushes the writer before stdout on shutdown. Classic single-session RPC remains unchanged; tests pin its delta-only wire, barrier ordering, and per-event backpressure, and cover multi-session compaction and drain behavior.
- Impact: comparable slow-reader runs drop from ~121–140 MB to 18.5 MB (-85% to -87%), with median line size ~22 KB and total latency reduced (e.g., 94 s vs 209 s), while event ordering and fairness are preserved.

<sup>Written for commit 7b560f4280fac5e864e156cd323c057204025476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

