### PR TITLE
docs(coding-agent): record the RPC stream regression suites in the package log

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,37 @@
 # Local fork changes
 
+## 2026-08-14 — RPC stream regression suites for multi-session compaction
+
+### What changed
+
+- `test/rpc-multi-session-events.test.ts` gained the coverage for the multi-session
+  event writer's per-session compaction and single-flight drain: a 1000-update
+  stalled-writer load case that asserts no assistant transition is lost and the
+  retained bytes stay far below the sum of the cumulative records, latest-wins
+  coalescing keyed by `toolCallId` in occurrence order, barrier isolation, and
+  the seal/late-enqueue contract.
+- `test/rpc-event-coalescing.test.ts` gained two characterization pins for the
+  CLASSIC single-session path: every delta survives same-tick batching into one
+  raw write, and immediate barriers keep event/UI-request/response ordering.
+  Both were proven to bite under their own targeted mutation.
+- The behavior these suites cover is described in `src/modes/rpc/changes.md`
+  (2026-08-14 entry); this entry exists so the package-level log records the
+  test surface that guards it.
+
+### Why this lives in the fork
+
+The compaction and single-flight drain are fork-specific: upstream writes every
+record straight through, so these suites have no upstream counterpart and would
+be dropped by a naive merge resolution.
+
+### Expected merge-conflict zones
+
+`test/rpc-multi-session-events.test.ts` and `test/rpc-event-coalescing.test.ts`
+resolve to `ours`. If upstream adds cases to either file, port them INTO these
+suites rather than replacing them - deleting the compaction or classic-pin cases
+silently removes the only guard against reintroducing the O(n^2) wire
+amplification or dropping classic per-event backpressure.
+
 ## 2026-08-12 — Distinguish external-editor launch failures
 
 ### What changed


### PR DESCRIPTION
PR #881 changed `packages/coding-agent/test/rpc-multi-session-events.test.ts` and `test/rpc-event-coalescing.test.ts` but only recorded the behavior in `src/modes/rpc/changes.md`. The nearest ancestor log for those test files is the package-level `packages/coding-agent/changes.md`, which received no entry - a gap a compliance audit of that merge caught.

This adds the missing entry: what the two suites now cover (the stalled-writer compaction load case, `toolCallId` latest-wins ordering, barrier isolation, the seal contract, and the two classic-mode characterization pins), why the surface is fork-specific, and the merge-conflict guidance - if upstream adds cases to either file, port them in rather than replacing, because deleting these suites silently removes the only guard against reintroducing the O(n^2) wire amplification or dropping classic per-event backpressure.

Documentation only; no source or test behavior changes.

Generated with omo (senpi engine), model GPT-5.6 Terra.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the RPC stream regression suites in `packages/coding-agent/changes.md` to close a package-level logging gap and align with `src/modes/rpc/changes.md`. Documentation only; no runtime or test behavior changes.

- Captures coverage for multi-session compaction and single-flight drain (stalled-writer load), latest-wins coalescing keyed by `toolCallId`, barrier isolation, seal contract, and two CLASSIC-path pins (delta batching survives same-tick write; immediate barriers preserve ordering).
- Notes fork-specific surface (upstream writes through without compaction), so these suites have no upstream counterpart.
- Merge guidance: resolve `test/rpc-multi-session-events.test.ts` and `test/rpc-event-coalescing.test.ts` to ours; if upstream adds cases, port them into these suites rather than replacing them.

<sup>Written for commit 680bf046b6ddd134ff0d8cd34f9c6f0950178ed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

