### PR TITLE
fix(compaction): un-wedge sessions when providers reject oversized summarization requests

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/compaction-body-too-large-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/compaction-body-too-large-qa.mjs
@@ -1,0 +1,479 @@
+#!/usr/bin/env node
+/**
+ * Real-CLI QA for compaction summarization vs gateway HTTP 413 body-size
+ * rejections (incident 2026-08-16, Discord IMG_1221.jpg).
+ *
+ * Two normal turns create a real compactable session, then the RPC `compact`
+ * command enters the builtin extension's summarization route. The local
+ * Anthropic server plays a size-limited gateway: any summarization request
+ * whose HTTP body exceeds LIMIT_BYTES is rejected with the verbatim 413
+ * "Request body too large" shape from the incident. The fixed pipeline must
+ * classify the 413 as overflow, shrink the input across attempts, and apply a
+ * compaction — with every attempt's wire shape satisfying the strict
+ * turn-alternation rule (first message is a user turn, no adjacent assistant
+ * turns) that Gemini's 400 INVALID_ARGUMENT rejection pinned in the same
+ * incident.
+ *
+ * Usage:
+ *   node .agents/skills/senpi-qa/scripts/scenarios/compaction-body-too-large-qa.mjs \
+ *     --evidence compaction-body-too-large
+ */
+
+import { once } from "node:events";
+import { existsSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { join } from "node:path";
+import {
+	createChecks,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	spawnCli,
+} from "../lib/common.mjs";
+import { hermeticEnv } from "../lib/mock-loop-support.mjs";
+
+const CONTEXT_WINDOW = 10_000;
+const PINNED_INPUT_TOKENS = 9_950;
+const LIMIT_BYTES = 45_000;
+const BODY_TOO_LARGE_BODY = JSON.stringify({
+	message: "Request body too large",
+	type: "invalid_request_error",
+	code: "body_too_large",
+});
+const SUMMARY_MARKERS = [
+	"[INTERNAL COMPACTION INSTRUCTION",
+	"[INTERNAL COMPACTION UPDATE INSTRUCTION",
+	"[INTERNAL TURN-PREFIX SUMMARY INSTRUCTION",
+	"[INTERNAL BRANCH SUMMARY INSTRUCTION",
+];
+
+function flag(name, fallback) {
+	const index = process.argv.indexOf(name);
+	return index >= 0 ? (process.argv[index + 1] ?? fallback) : fallback;
+}
+
+function textOfContent(content) {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content.map((part) => (part?.type === "text" ? String(part.text ?? "") : "")).join("\n");
+}
+
+function classifyRequest(body) {
+	const messages = Array.isArray(body.messages) ? body.messages : [];
+	const trailing = messages.at(-1);
+	const trailingText = trailing?.role === "user" ? textOfContent(trailing.content) : "";
+	return {
+		summarization: SUMMARY_MARKERS.some((marker) => trailingText.includes(marker)),
+		trailingPrefix: trailingText.slice(0, 100).replaceAll("\n", "\\n"),
+	};
+}
+
+function wireShapeViolations(body) {
+	const messages = Array.isArray(body.messages) ? body.messages : [];
+	const violations = [];
+	if (messages.length > 0 && messages[0]?.role !== "user") {
+		violations.push(`first message role=${messages[0]?.role ?? "unknown"}`);
+	}
+	for (let index = 1; index < messages.length; index++) {
+		if (messages[index - 1]?.role === "assistant" && messages[index]?.role === "assistant") {
+			violations.push(`adjacent assistant messages at ${index - 1}/${index}`);
+		}
+	}
+	return violations;
+}
+
+function writeAnthropicSse(res, text, modelId, inputTokens) {
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
+	const event = (type, data) =>
+		res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+	event("message_start", {
+		message: {
+			id: `msg_mock_${Date.now()}`,
+			type: "message",
+			role: "assistant",
+			model: modelId,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: inputTokens, output_tokens: 0 },
+		},
+	});
+	event("content_block_start", { index: 0, content_block: { type: "text", text: "" } });
+	event("content_block_delta", { index: 0, delta: { type: "text_delta", text } });
+	event("content_block_stop", { index: 0 });
+	event("message_delta", {
+		delta: { stop_reason: "end_turn", stop_sequence: null },
+		usage: { output_tokens: Math.max(1, Math.ceil(text.length / 4)) },
+	});
+	event("message_stop", {});
+	res.end();
+}
+
+function startScriptedServer() {
+	const requests = [];
+	let normalTurn = 0;
+	const sockets = new Set();
+	const vocab = [
+		"lantern", "quadratic", "sailboat", "ephemeral", "tungsten", "harpsichord", "glacier", "marzipan",
+		"trapezoid", "nightingale", "cinnabar", "windmill", "obsidian", "tangerine", "labyrinth", "firefly",
+	];
+	const historyText = (turn, lines) =>
+		Array.from(
+			{ length: lines },
+			(_, index) =>
+				`turn-${turn} ${vocab[index % vocab.length]}-${vocab[(index * 5 + 3) % vocab.length]} record ${String(index).padStart(4, "0")}: preserve ${vocab[(index * 7 + 1) % vocab.length]} artifact-${turn}-${index * 17 + 3} alongside ${vocab[(index * 11 + 2) % vocab.length]} decision-${index * 29 + 7}.`,
+		).join("\n");
+	const server = createServer((req, res) => {
+		const chunks = [];
+		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("end", () => {
+			const at = Date.now();
+			const raw = Buffer.concat(chunks).toString("utf8");
+			let body = {};
+			try {
+				body = raw ? JSON.parse(raw) : {};
+			} catch {}
+			const shape = classifyRequest(body);
+			const record = {
+				at,
+				method: req.method,
+				url: req.url,
+				summarization: shape.summarization,
+				bodyBytes: Buffer.byteLength(raw),
+				trailingPrefix: shape.trailingPrefix,
+				violations: shape.summarization ? wireShapeViolations(body) : [],
+				response: "",
+			};
+			requests.push(record);
+
+			if (shape.summarization) {
+				if (record.bodyBytes > LIMIT_BYTES) {
+					record.response = `413 ${BODY_TOO_LARGE_BODY}`;
+					res.writeHead(413, { "content-type": "application/json" });
+					res.end(BODY_TOO_LARGE_BODY);
+					return;
+				}
+				record.response = "200 compacted summary";
+				writeAnthropicSse(
+					res,
+					`<task-intent>\nORIGINAL_REQUEST: Continue the QA scenario.\nTASK_TYPE: QA\nMUST_PRESERVE: 413 shrink evidence\nMUST_NOT_LOSE: body-size rejection recovery\n</task-intent>\n<summary>\n## 1. User Requests (Verbatim)\n- Continue the QA scenario.\n## 2. Final Goal\nProve compaction survives gateway 413 body-size rejections.\n## 3. Constraints & Preferences (Verbatim Only)\nNone.\n## 4. Work Completed\nSummarization input shrank until the gateway accepted it.\n## 5. Active Working Context\nReal RPC CLI and local size-limited Anthropic server.\n## 6. Remaining Tasks\nNone.\n## 7. Exact Next Steps\nContinue the admitted turn.\n</summary>`,
+					body.model ?? "mock-claude",
+					500,
+				);
+				return;
+			}
+
+			normalTurn++;
+			record.response = `200 normal turn ${normalTurn}`;
+			const text = normalTurn <= 2 ? historyText(normalTurn, normalTurn === 1 ? 80 : 120) : `QA-TURN-${normalTurn}-OK`;
+			writeAnthropicSse(
+				res,
+				text,
+				body.model ?? "mock-claude",
+				normalTurn === 2 ? PINNED_INPUT_TOKENS : 200,
+			);
+		});
+	});
+	server.on("connection", (socket) => {
+		sockets.add(socket);
+		socket.once("close", () => sockets.delete(socket));
+	});
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			resolve({
+				requests,
+				origin: `http://127.0.0.1:${address.port}`,
+				port: address.port,
+				async stop() {
+					for (const socket of sockets) socket.destroy();
+					if (server.listening) await new Promise((done) => server.close(done));
+				},
+				isListening: () => server.listening,
+			});
+		});
+	});
+}
+
+function writeSandboxConfig(agentDir, server) {
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify(
+			{
+				providers: {
+					anthropic: {
+						baseUrl: server.origin,
+						apiKey: "sk-ant-mock-compaction-413-qa",
+						api: "anthropic-messages",
+						models: [
+							{
+								id: "mock-claude",
+								api: "anthropic-messages",
+								baseUrl: server.origin,
+								contextWindow: CONTEXT_WINDOW,
+								maxTokens: 1_000,
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							},
+						],
+					},
+				},
+			},
+			null,
+			2,
+		),
+	);
+	writeFileSync(
+		join(agentDir, "settings.json"),
+		JSON.stringify(
+			{
+				compaction: {
+					enabled: true,
+					reserveTokens: 100,
+					keepRecentTokens: 1_024,
+					speculativeEnabled: false,
+					idleCompactionEnabled: false,
+				},
+			},
+			null,
+			2,
+		),
+	);
+}
+
+class RpcClient {
+	constructor({ env, cwd }) {
+		this.child = spawnCli(["--mode", "rpc", "--no-context-files"], { env, cwd });
+		this.pending = new Map();
+		this.events = [];
+		this.seq = 0;
+		this.buffer = "";
+		this.stderr = "";
+		this.child.stdout.on("data", (chunk) => this.onData(chunk));
+		this.child.stderr.on("data", (chunk) => {
+			this.stderr += chunk.toString();
+		});
+	}
+
+	onData(chunk) {
+		this.buffer += chunk.toString();
+		let newline;
+		while ((newline = this.buffer.indexOf("\n")) >= 0) {
+			const line = this.buffer.slice(0, newline).trim();
+			this.buffer = this.buffer.slice(newline + 1);
+			if (!line) continue;
+			let message;
+			try {
+				message = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			if (message?.type === "response" && message.id !== undefined && this.pending.has(message.id)) {
+				this.pending.get(message.id)(message);
+				this.pending.delete(message.id);
+			} else if (message?.type) {
+				this.events.push({ at: Date.now(), msg: message });
+			}
+		}
+	}
+
+	send(command, { timeoutMs = 30_000 } = {}) {
+		const id = command.id ?? `qa-${++this.seq}`;
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(new Error(`RPC timeout for ${command.type}; stderr=${this.stderr.slice(-500)}`));
+			}, timeoutMs);
+			this.pending.set(id, (response) => {
+				clearTimeout(timer);
+				if (response.success === false) {
+					reject(new Error(`RPC ${command.type} failed: ${response.error}`));
+					return;
+				}
+				resolve(response);
+			});
+			this.child.stdin.write(`${JSON.stringify({ ...command, id })}\n`);
+		});
+	}
+
+	async waitForEvent(predicate, afterIndex, timeoutMs = 30_000) {
+		const deadline = Date.now() + timeoutMs;
+		for (;;) {
+			const found = this.events.slice(afterIndex).find((entry) => predicate(entry.msg));
+			if (found) return found.msg;
+			if (Date.now() >= deadline) {
+				throw new Error(`event timeout; stderr=${this.stderr.slice(-500)}`);
+			}
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+	}
+
+	async close() {
+		if (this.child.exitCode !== null) return;
+		try {
+			this.child.stdin.end();
+		} catch {}
+		const closed = once(this.child, "close");
+		const timeout = new Promise((resolve) => setTimeout(() => resolve("timeout"), 3_000));
+		if ((await Promise.race([closed, timeout])) === "timeout" && this.child.exitCode === null) {
+			this.child.kill("SIGKILL");
+			await once(this.child, "close");
+		}
+	}
+}
+
+async function runPrompt(client, message, timeoutMs = 30_000) {
+	const afterIndex = client.events.length;
+	const response = await client.send({ type: "prompt", message }, { timeoutMs });
+	const terminal = await client.waitForEvent(
+		(event) => event.type === "agent_settled" || event.type === "agent_aborted",
+		afterIndex,
+		timeoutMs,
+	);
+	return { response, terminal };
+}
+
+function eventDetail(message) {
+	if (message.type === "compaction_start") {
+		return ` reason=${message.reason ?? message.data?.reason ?? "unknown"}`;
+	}
+	if (message.type === "compaction_end") {
+		return ` reason=${message.reason ?? message.data?.reason ?? "unknown"} accepted=${message.accepted ?? message.data?.accepted ?? Boolean(message.result)} aborted=${message.aborted ?? false} error=${JSON.stringify(message.errorMessage ?? message.data?.errorMessage ?? null)}`;
+	}
+	return "";
+}
+
+async function main() {
+	installCleanupHooks();
+	const command =
+		"node .agents/skills/senpi-qa/scripts/scenarios/compaction-body-too-large-qa.mjs --evidence compaction-body-too-large";
+	const evidenceName = flag("--evidence", "compaction-body-too-large");
+	const evidence = evidenceDir(evidenceName.replace(/^\d{8}-/, ""));
+	const evidencePath = join(evidence, "real-cli-timeline.txt");
+	const checks = createChecks("compaction-body-too-large-qa.mjs");
+	const passLines = [];
+	const check = (name, condition, detail) => {
+		checks.ok(name, condition, detail);
+		passLines.push(`[${condition ? "PASS" : "FAIL"}] ${name}${detail ? ` — ${detail}` : ""}`);
+	};
+	const guard = guardRealAuth();
+	const box = makeSandbox("senpi-qa-compaction-body-too-large");
+	const startedAt = Date.now();
+	let server;
+	let client;
+	let cleanupReceipt = "cleanup pending";
+	let runError;
+
+	try {
+		server = await startScriptedServer();
+		writeSandboxConfig(box.agentDir, server);
+		client = new RpcClient({ env: hermeticEnv(box.env), cwd: box.cwd });
+		await client.send({ type: "set_model", provider: "anthropic", modelId: "mock-claude" });
+
+		const seedOne = await runPrompt(client, "Seed the oldest QA context and preserve its decisions.");
+		if (seedOne.terminal.type !== "agent_settled") throw new Error(`seed one ended as ${seedOne.terminal.type}`);
+		const seedTwo = await runPrompt(client, "Add the latest QA context while retaining the earlier turn.");
+		if (seedTwo.terminal.type !== "agent_settled") throw new Error(`seed two ended as ${seedTwo.terminal.type}`);
+
+		await client.send({ type: "compact" }, { timeoutMs: 60_000 });
+	} catch (error) {
+		runError = error;
+	} finally {
+		await client?.close().catch(() => {});
+		await server?.stop().catch(() => {});
+		box.cleanup();
+		cleanupReceipt = `cliExited=${client ? client.child.exitCode !== null : true} serverListening=${server?.isListening() ?? false} sandboxExists=${existsSync(box.dir)}`;
+	}
+
+	const requests = server?.requests ?? [];
+	const summaryRequests = requests.filter((request) => request.summarization);
+	const rejected = summaryRequests.filter((request) => request.response.startsWith("413"));
+	const accepted = summaryRequests.filter((request) => request.response.startsWith("200"));
+	const compactionEnds = (client?.events ?? []).filter((entry) => entry.msg.type === "compaction_end");
+	const acceptedEnds = compactionEnds.filter(
+		(entry) => (entry.msg.accepted ?? entry.msg.data?.accepted ?? Boolean(entry.msg.result)) === true,
+	);
+	const rejectedCompactionText = JSON.stringify(client?.events ?? []);
+	const generatorFailureCount =
+		(rejectedCompactionText.match(/compaction generator failed/g) ?? []).length +
+		(rejectedCompactionText.match(/Compaction rejected/g) ?? []).length;
+	const wireViolations = summaryRequests.flatMap((request) => request.violations);
+	const bodySizes = summaryRequests.map((request) => request.bodyBytes);
+
+	check(
+		"the gateway rejected at least one oversized summarization request with the incident 413 shape",
+		rejected.length > 0 && rejected.every((request) => request.response.includes("body_too_large")),
+		`rejected=${rejected.length} bodies=${rejected.map((request) => request.bodyBytes).join(",")}`,
+	);
+	check(
+		"the 413 routed into shrink-and-retry instead of a terminal rejection",
+		summaryRequests.length > rejected.length && accepted.length > 0,
+		`summarizationRequests=${summaryRequests.length} rejected=${rejected.length} accepted=${accepted.length} bodySizes=${bodySizes.join("->")}`,
+	);
+	check(
+		"summarization bodies shrank across attempts",
+		bodySizes.length > 1 && bodySizes.at(-1) < bodySizes[0],
+		`bodySizes=${bodySizes.join("->")}`,
+	);
+	check(
+		"a compaction was accepted after the 413s",
+		acceptedEnds.length > 0,
+		`acceptedCompactionEnds=${acceptedEnds.length}`,
+	);
+	check(
+		"zero Compaction rejected / compaction generator failed events",
+		generatorFailureCount === 0,
+		`generatorFailureCount=${generatorFailureCount}`,
+	);
+	check(
+		"every summarization request satisfied the strict turn-alternation wire rule",
+		wireViolations.length === 0,
+		wireViolations.length === 0 ? "first=user, no adjacent assistants on every attempt" : wireViolations.join("; "),
+	);
+
+	let authUnchanged = false;
+	try {
+		authUnchanged = guard.assertUnchanged();
+	} catch {}
+	check("real auth unchanged", authUnchanged, guard.path);
+	check(
+		"spawned resources were cleaned up",
+		cleanupReceipt === "cliExited=true serverListening=false sandboxExists=false",
+		cleanupReceipt,
+	);
+
+	const relative = (at) => `${((at - startedAt) / 1_000).toFixed(3)}s`;
+	const lines = [
+		`command: ${command}`,
+		`fakeGateway: ${server?.origin ?? "not-started"}`,
+		`contextWindow=${CONTEXT_WINDOW} pinnedInputTokens=${PINNED_INPUT_TOKENS} limitBytes=${LIMIT_BYTES}`,
+		`runError=${runError instanceof Error ? runError.stack : (runError ?? "none")}`,
+		"",
+		"REQUEST TIMELINE",
+		...requests.map(
+			(request, index) =>
+				`${relative(request.at)} request#${index + 1} ${request.summarization ? "SUMMARIZATION" : "NORMAL"} bodyBytes=${request.bodyBytes} trailing=${JSON.stringify(request.trailingPrefix)} response=${request.response}${request.violations.length ? ` VIOLATIONS=${request.violations.join(";")}` : ""}`,
+		),
+		"",
+		"EVENT TIMELINE",
+		...(client?.events ?? [])
+			.filter((entry) => !["message_update", "message_start"].includes(entry.msg.type))
+			.map((entry) => `${relative(entry.at)} ${entry.msg.type}${eventDetail(entry.msg)}`),
+		"",
+		`summary: summarizationRequests=${summaryRequests.length} rejected413=${rejected.length} accepted200=${accepted.length} acceptedCompactionEnds=${acceptedEnds.length} generatorFailureCount=${generatorFailureCount} wireViolations=${wireViolations.length}`,
+		...passLines,
+		`cleanup: ${cleanupReceipt}`,
+		"",
+	];
+	writeFileSync(evidencePath, `${lines.join("\n")}\n`);
+	process.stdout.write(`evidence: ${evidencePath}\n`);
+	if (runError) process.stderr.write(`${runError instanceof Error ? runError.stack : String(runError)}\n`);
+	process.exit(checks.finish() && !runError ? 0 : 1);
+}
+
+await main();

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `isContextOverflow` now classifies gateway HTTP 413 byte-size rejections — "Request body too large", "Request Entity Too Large", `body_too_large`, and "Payload Too Large" — as overflow, the same recovery class as Anthropic's native `request_too_large`. Sessions whose requests exceed a gateway body limit previously saw these as terminal errors, which wedged compaction on every fallback model ([#884](https://github.com/code-yeongyu/senpi/issues/884)).
+
 ### Removed
 
 ## [2026.8.14] - 2026-08-14

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,27 @@
 # AI Source Changes
 
+## 2026-08-16 - Classify gateway 413 body-size rejections as overflow
+
+### What changed and why
+
+- `isContextOverflow` now recognizes gateway HTTP 413 byte-size rejections — "Request body too
+  large", "Request Entity Too Large", `body_too_large`, and "Payload Too Large" — as the same
+  recovery class as Anthropic's native `request_too_large`. Both wordings were captured from a
+  live session whose compaction summarization request exceeded a gateway body limit on every
+  fallback model ([#884](https://github.com/code-yeongyu/senpi/issues/884)).
+- Without the classification, a byte-size rejection never reached input-shrinking recovery: it
+  surfaced as a terminal error and wedged sessions above the compaction threshold.
+
+### Why this cannot be expressed externally
+
+- Overflow classification is the provider-neutral boundary every caller (compaction shrink-retry,
+  agent-session overflow admission) keys off; an extension can only observe the final error.
+
+### Expected merge conflict zones
+
+- LOW: `utils/overflow.ts` pattern list and its header documentation; LOW in
+  `test/overflow.test.ts` where the new cases sit beside existing provider patterns.
+
 ## 2026-08-13 - Preserve explicit request compatibility fields
 
 ### What changed and why

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -26,6 +26,7 @@ import type { AssistantMessage } from "../types.ts";
  * - Kimi For Coding: "Your request exceeded model token limit: X (requested: Y)"
  * - DS4: "Prompt has X tokens, but the configured context size is Y tokens"
  * - Cerebras: "400/413 status code (no body)"
+ * - Gateways: "413 Request body too large" / "Request Entity Too Large" / "Payload Too Large" (byte-size overflow)
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - z.ai: Does NOT error, accepts overflow silently - handled via usage.input > contextWindow
  * - Xiaomi MiMo: Truncates input to fill contextWindow exactly, then returns finish_reason "length"
@@ -60,6 +61,7 @@ const OVERFLOW_PATTERNS = [
 	/too many tokens/i, // Generic fallback
 	/token limit exceeded/i, // Generic fallback
 	/^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
+	/(?:request[ _])?(?:body|entity|payload)[_ ]too[_ ]large/i, // Gateway HTTP 413 byte-size rejections ("Request body too large", "Request Entity Too Large", "body_too_large", "Payload Too Large")
 ];
 
 /**

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -61,7 +61,7 @@ const OVERFLOW_PATTERNS = [
 	/too many tokens/i, // Generic fallback
 	/token limit exceeded/i, // Generic fallback
 	/^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
-	/(?:request[ _])?(?:body|entity|payload)[_ ]too[_ ]large/i, // Gateway HTTP 413 byte-size rejections ("Request body too large", "Request Entity Too Large", "body_too_large", "Payload Too Large")
+	/(?:request[ _])?(?:body|entity|payload)[_ ]too[_ ]large/i, // Gateway HTTP 413 byte-size rejections ("Request body too large", "Request Entity Too Large", "body_too_large", "Payload Too Large"). Substring-anchored by design (JSON bodies lack an adjacent status code); a non-context size rejection (e.g. an oversized image) can over-match, which costs one bounded shrink-retry, never a wedge.
 ];
 
 /**

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -75,6 +75,25 @@ describe("isContextOverflow", () => {
 		expect(isContextOverflow(commaMessage, 256000)).toBe(true);
 	});
 
+	it("detects gateway 413 body-size rejections as byte-size overflow", () => {
+		// Real gateway rejections captured 2026-08-16: a compaction summarization
+		// request whose HTTP body exceeded the provider/gateway limit. These are
+		// byte-size overflows — the same class as Anthropic's request_too_large —
+		// and must route into input-shrinking recovery, not a terminal error.
+		const openAiStyle = createErrorMessage(
+			'413: {"message":"Request body too large","type":"invalid_request_error","code":"body_too_large"}',
+		);
+		expect(isContextOverflow(openAiStyle, 200000)).toBe(true);
+
+		const aiSdkStyle = createErrorMessage(
+			'413: {"message":"Request Entity Too Large","type":"AI_APICallError","param":{"error":"Request Entity Too Large","statusCode":413,"name":"AI_APICallError","message":"Request Entity Too Large","isRetryable":false,"type":"AI_APICallError"}}',
+		);
+		expect(isContextOverflow(aiSdkStyle, 200000)).toBe(true);
+
+		const rfcStyle = createErrorMessage("413 Payload Too Large");
+		expect(isContextOverflow(rfcStyle, 200000)).toBe(true);
+	});
+
 	it("does not treat generic non-overflow Ollama errors as overflow", () => {
 		const message = createErrorMessage("500 `model runner crashed unexpectedly`");
 		expect(isContextOverflow(message, 32768)).toBe(false);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Compaction no longer wedges when providers reject the summarization request for its size. Gateway HTTP 413 body-size rejections now route into the overflow shrink-retry (geometric halving, bounded attempts) and exhaust into the deterministic fallback, the summarization request's turn order is normalized so strict-alternation providers (Gemini's `function call turn must come immediately after a user turn` 400) accept it, and request sizing counts CJK text at its real token density so Korean-heavy sessions stop sending oversized first attempts. Previously every fallback-chain model failed the same oversized request and the session stuck on `Compaction rejected: compaction generator failed` ([#884](https://github.com/code-yeongyu/senpi/issues/884)).
 - Multi-session RPC no longer amplifies a streaming answer into hundreds of megabytes of stdout, which made
   clients freeze and then render walls of text at once. Each `message_update` carried a full cumulative snapshot,
   so a single 96-second answer measured 140 MB on the wire (median line 72 KB, peak 95 KB) for 12 KB of assistant

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
@@ -16,6 +16,7 @@ compaction/
 ├── context-reduction.ts      # Deterministic no-LLM reductions (collapse tool-result runs, shrink old answers, clear old tool results)
 ├── openai-remote.ts          # OpenAI Responses remote-compaction route (`senpi.compaction.openai-remote.v1` schema)
 ├── repair-tool-pairs.ts      # Replaces orphaned tool-call/result pairs left by pruning with placeholders
+├── summarization-turn-order.ts # Merges adjacent assistants + guarantees a leading user turn in summarization requests (Gemini alternation rule)
 ├── circuit-breaker.ts        # N consecutive failures → halt automatic compaction
 ├── degradation-monitor.ts    # Detects post-compact assistant degradation (all-tool, no-text turns)
 ├── log.ts                    # Always-on compaction logging + debug stderr mirror

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,45 @@
 # Builtin compaction extension changes
 
+## Survive provider body-size rejections and strict turn alternation in summarization requests (2026-08-16)
+
+### What changed
+
+- Gateway HTTP 413 body-size rejections ("Request body too large", "Request Entity Too Large")
+  now flow into the existing overflow shrink-retry: the summarization input halves across
+  attempts and exhaustion throws the classifiable `SummarizationOverflowExhaustedError`, so
+  threshold/overflow compactions degrade through the deterministic fallback instead of wedging
+  the session on `Compaction rejected: compaction generator failed: 413 ...`
+  ([#884](https://github.com/code-yeongyu/senpi/issues/884)).
+- New `summarization-turn-order.ts` normalizes the final summarization message list at the
+  `generateSummaryMessage` seam (after `convertToLlm` + pair repair, where roles are final):
+  adjacent assistant messages merge, and content before the first user message is dropped.
+  Gemini's 400 `function call turn must come immediately after a user turn` fired twice in the
+  incident because sessions carry adjacent assistants (split turns, retries) and budget pruning
+  can drop the leading user message.
+- `overflow-retry.ts` request sizing now adds a CJK density correction (weight 3, mirroring the
+  base64-run weighting) to the chars/4 estimate: Korean text tokenizes near 1 token per 1.5
+  characters, and the 4.00 chars/token estimate let Korean-heavy sessions send first attempts
+  far over provider size limits.
+
+### Why
+
+- A live session hit all three defects in one compaction: two gateway 413 shapes never reached
+  the shrink path (unclassified), gemini-3.7-flash-high rejected the request's turn order twice,
+  and the final model stalled the 120s wall-clock on the oversized input. Every fallback model
+  retried the same payload and failed identically, permanently wedging the session.
+
+### Why an extension could not handle it
+
+- The shrink-retry classification, the request message construction, and the input sizing all
+  live inside this builtin's summarization pipeline; an external extension observes only the
+  final cancel reason.
+
+### Expected merge conflict zones
+
+- LOW: `speculative.ts` at the `requestContext` construction (one wrapped call site);
+  `overflow-retry.ts` estimator internals. New module `summarization-turn-order.ts` is
+  fork-only with no upstream counterpart.
+
 ## Surface the concrete reason a compaction did not apply (2026-08-14)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -19,7 +19,9 @@
 - `overflow-retry.ts` request sizing now adds a CJK density correction (weight 3, mirroring the
   base64-run weighting) to the chars/4 estimate: Korean text tokenizes near 1 token per 1.5
   characters, and the 4.00 chars/token estimate let Korean-heavy sessions send first attempts
-  far over provider size limits.
+  far over provider size limits. The correction rides `estimateTotalTokens`, so it also reaches
+  `hardLimitEmergencyPrune` and the `/btw` side-query bound — both prune Korean-heavy sessions
+  slightly earlier, which is the same undercount corrected in the safe direction.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/overflow-retry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/overflow-retry.ts
@@ -21,6 +21,42 @@ import { estimateTokens } from "../../../compaction/index.ts";
 export const MAX_SUMMARIZATION_OVERFLOW_RETRIES = 3;
 
 /**
+ * CJK text tokenizes far denser than the chars/4 prose heuristic (roughly one
+ * token per 1.5 Korean characters, not four). The shared estimator undercounts
+ * such text by ~2.7x, so a Korean-heavy session whose estimate "fits" could
+ * still produce a summarization request over provider size limits (observed
+ * 2026-08-16 as gateway HTTP 413 rejections on every fallback model). Weight
+ * CJK runs so request sizing stays conservative for them, mirroring the
+ * estimator's existing base64-run weighting.
+ */
+const CJK_RUN_RE = /[\u1100-\u11FF\u2E80-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF\uFF00-\uFFEF\u{20000}-\u{2FA1F}]+/gu;
+const CJK_CHAR_WEIGHT = 3;
+
+function cjkExtraChars(text: string): number {
+	let extra = 0;
+	for (const match of text.matchAll(CJK_RUN_RE)) {
+		extra += match[0].length * (CJK_CHAR_WEIGHT - 1);
+	}
+	return extra;
+}
+
+/**
+ * Request-sizing estimate: the shared chars/4 estimate plus a CJK density
+ * correction. JSON serialization carries every content field, so CJK runs are
+ * counted wherever they appear (text, tool arguments, outputs, summaries).
+ */
+function estimateWireTokens(message: AgentMessage): number {
+	const base = estimateTokens(message);
+	let serialized: string;
+	try {
+		serialized = JSON.stringify(message);
+	} catch {
+		return base;
+	}
+	return base + Math.ceil(cjkExtraChars(serialized) / 4);
+}
+
+/**
  * Cumulative wall-clock budget across all overflow retries of one compaction
  * run. Twice the per-attempt stream budget: a slow provider may consume the
  * per-attempt watchdog on each attempt, and the retry loop must still end
@@ -56,7 +92,7 @@ export interface PruneStep {
 
 export function estimateTotalTokens(messages: AgentMessage[]): number {
 	let total = 0;
-	for (const message of messages) total += estimateTokens(message);
+	for (const message of messages) total += estimateWireTokens(message);
 	return total;
 }
 
@@ -82,7 +118,7 @@ function removeAssistantToolPair(messages: AgentMessage[], assistantIndex: numbe
 	let removedTokens = 0;
 	const pruned = messages.filter((message, index) => {
 		const remove = index === assistantIndex || (message.role === "toolResult" && ids.has(message.toolCallId));
-		if (remove) removedTokens += estimateTokens(message);
+		if (remove) removedTokens += estimateWireTokens(message);
 		return !remove;
 	});
 	return { messages: pruned, removedTokens };
@@ -97,7 +133,7 @@ function removeFirstOldToolPair(messages: AgentMessage[], boundaryIndex: number)
 		if (message.role === "toolResult") {
 			return {
 				messages: messages.filter((_message, candidateIndex) => candidateIndex !== index),
-				removedTokens: estimateTokens(message),
+				removedTokens: estimateWireTokens(message),
 			};
 		}
 	}
@@ -112,7 +148,7 @@ function removeFirstOldMessage(messages: AgentMessage[], boundaryIndex: number):
 			return removeAssistantToolPair(messages, index);
 		return {
 			messages: messages.filter((_candidate, candidateIndex) => candidateIndex !== index),
-			removedTokens: estimateTokens(message),
+			removedTokens: estimateWireTokens(message),
 		};
 	}
 	return undefined;

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -289,8 +289,8 @@ async function generateSummaryMessage(options: {
 		const providerRequest = await options.context.prepareProviderRequest?.(requestMessages);
 		const requestContext = {
 			systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
-			messages: normalizeSummarizationTurnOrder(
-				repairOrphanedToolResults(convertToLlm(providerRequest?.messages ?? requestMessages)),
+			messages: repairOrphanedToolResults(
+				normalizeSummarizationTurnOrder(convertToLlm(providerRequest?.messages ?? requestMessages)),
 			),
 			...(options.snapshot.tools && options.snapshot.tools.length > 0 ? { tools: options.snapshot.tools } : {}),
 		};

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/speculative.ts
@@ -53,6 +53,7 @@ import { computeEffectiveKeepRecentTokens, computeEffectiveThreshold } from "./p
 import { buildPrompt, type MergedCompactionPromptVariant } from "./prompts.ts";
 import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";
 import { allowSummarizationRetry, DEFAULT_SUMMARIZATION_RETRY_POLICY } from "./summarization-retry.ts";
+import { normalizeSummarizationTurnOrder } from "./summarization-turn-order.ts";
 import { extractTaskIntent, resolveInheritedTaskIntent } from "./task-intent.ts";
 import * as truncation from "./tool-truncation.ts";
 import { computeStructuralYield } from "./yield.ts";
@@ -288,7 +289,9 @@ async function generateSummaryMessage(options: {
 		const providerRequest = await options.context.prepareProviderRequest?.(requestMessages);
 		const requestContext = {
 			systemPrompt: options.snapshot.systemPrompt ?? options.prompt.system,
-			messages: repairOrphanedToolResults(convertToLlm(providerRequest?.messages ?? requestMessages)),
+			messages: normalizeSummarizationTurnOrder(
+				repairOrphanedToolResults(convertToLlm(providerRequest?.messages ?? requestMessages)),
+			),
 			...(options.snapshot.tools && options.snapshot.tools.length > 0 ? { tools: options.snapshot.tools } : {}),
 		};
 		const headers = providerRequest

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/summarization-turn-order.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/summarization-turn-order.ts
@@ -10,48 +10,54 @@ import type { Message } from "@earendil-works/pi-ai";
  * - sessions contain adjacent assistant messages (split turns, retries), and
  * - budget pruning / overflow shrinking can drop the leading user message.
  *
- * This runs on the converted LLM message list (after convertToLlm and pair
- * repair), where context-excluded entries are already dropped and roles are
- * final. Two repairs, in order:
+ * This runs on the converted LLM message list (after convertToLlm, where
+ * context-excluded entries are already dropped and roles are final), and the
+ * caller re-runs pair repair on the result so the leading drop cannot leave an
+ * orphaned toolResult behind. Two repairs, in order:
  *
  * 1. Adjacent assistant messages are merged into one (content concatenated).
  *    Messages with stopReason error/aborted are left alone: downstream
  *    provider transforms drop them, which heals the ordering on its own, and
  *    merging would replay partial content those transforms intentionally
- *    discard.
+ *    discard. The merged message keeps the first message's metadata
+ *    (stopReason, usage): these messages are outbound request payloads only,
+ *    where usage is never read and stopReason is consumed solely as the
+ *    error/aborted drop filter this merge already excludes.
  * 2. Everything before the first user message is dropped. Budget pruning has
  *    already judged the oldest content expendable; a leading assistant /
- *    toolResult fragment would only produce a provider rejection.
+ *    toolResult fragment would only produce a provider rejection. The list
+ *    passes through unchanged when no user message exists, and when the only
+ *    user message is the trailing summarization instruction itself — dropping
+ *    there would summarize nothing, so both paths are defensive only.
  */
 export function normalizeSummarizationTurnOrder(messages: Message[]): Message[] {
 	const merged: Message[] = [];
 	for (const message of messages) {
 		const previous = merged[merged.length - 1];
-		if (
-			previous?.role === "assistant" &&
-			message.role === "assistant" &&
-			isMergeable(previous) &&
-			isMergeable(message)
-		) {
-			merged[merged.length - 1] = mergeAssistantPair(previous, message);
-			continue;
+		if (previous?.role === "assistant" && message.role === "assistant") {
+			const mergedPair = mergeAssistantPair(previous, message);
+			if (mergedPair !== undefined) {
+				merged[merged.length - 1] = mergedPair;
+				continue;
+			}
 		}
 		merged.push(message);
 	}
 	const firstUserIndex = merged.findIndex((message) => message.role === "user");
 	if (firstUserIndex === -1) return merged;
+	// When the only user turn is the trailing summarization instruction, the
+	// drop would leave a summary of nothing; keeping the content preserves the
+	// pre-normalization behavior for that narrow case on every provider.
+	if (firstUserIndex === merged.length - 1) return merged;
 	return merged.slice(firstUserIndex);
 }
 
-function isMergeable(message: Message): boolean {
-	if (message.role !== "assistant") return false;
-	const stopReason = (message as { stopReason?: string }).stopReason;
-	return stopReason !== "error" && stopReason !== "aborted";
-}
-
-function mergeAssistantPair(first: Message, second: Message): Message {
-	const firstContent = (first as { content?: unknown }).content;
-	const secondContent = (second as { content?: unknown }).content;
-	if (!Array.isArray(firstContent) || !Array.isArray(secondContent)) return second;
-	return { ...first, content: [...firstContent, ...secondContent] } as Message;
+function mergeAssistantPair(first: Message, second: Message): Message | undefined {
+	if (first.role !== "assistant" || second.role !== "assistant") return undefined;
+	if (first.stopReason === "error" || first.stopReason === "aborted") return undefined;
+	if (second.stopReason === "error" || second.stopReason === "aborted") return undefined;
+	// AssistantMessage.content is an array by type; the runtime check guards
+	// against corrupted persisted session data, which arrives unvalidated.
+	if (!Array.isArray(first.content) || !Array.isArray(second.content)) return undefined;
+	return { ...first, content: [...first.content, ...second.content] };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/summarization-turn-order.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/summarization-turn-order.ts
@@ -1,0 +1,57 @@
+import type { Message } from "@earendil-works/pi-ai";
+
+/**
+ * Normalizes a summarization request's final message list so strict
+ * turn-alternation providers (Gemini) accept it. Gemini rejects a functionCall
+ * model turn that follows another model turn, and rejects any conversation
+ * whose first turn is not a user turn — both shapes occur in real
+ * summarization inputs:
+ *
+ * - sessions contain adjacent assistant messages (split turns, retries), and
+ * - budget pruning / overflow shrinking can drop the leading user message.
+ *
+ * This runs on the converted LLM message list (after convertToLlm and pair
+ * repair), where context-excluded entries are already dropped and roles are
+ * final. Two repairs, in order:
+ *
+ * 1. Adjacent assistant messages are merged into one (content concatenated).
+ *    Messages with stopReason error/aborted are left alone: downstream
+ *    provider transforms drop them, which heals the ordering on its own, and
+ *    merging would replay partial content those transforms intentionally
+ *    discard.
+ * 2. Everything before the first user message is dropped. Budget pruning has
+ *    already judged the oldest content expendable; a leading assistant /
+ *    toolResult fragment would only produce a provider rejection.
+ */
+export function normalizeSummarizationTurnOrder(messages: Message[]): Message[] {
+	const merged: Message[] = [];
+	for (const message of messages) {
+		const previous = merged[merged.length - 1];
+		if (
+			previous?.role === "assistant" &&
+			message.role === "assistant" &&
+			isMergeable(previous) &&
+			isMergeable(message)
+		) {
+			merged[merged.length - 1] = mergeAssistantPair(previous, message);
+			continue;
+		}
+		merged.push(message);
+	}
+	const firstUserIndex = merged.findIndex((message) => message.role === "user");
+	if (firstUserIndex === -1) return merged;
+	return merged.slice(firstUserIndex);
+}
+
+function isMergeable(message: Message): boolean {
+	if (message.role !== "assistant") return false;
+	const stopReason = (message as { stopReason?: string }).stopReason;
+	return stopReason !== "error" && stopReason !== "aborted";
+}
+
+function mergeAssistantPair(first: Message, second: Message): Message {
+	const firstContent = (first as { content?: unknown }).content;
+	const secondContent = (second as { content?: unknown }).content;
+	if (!Array.isArray(firstContent) || !Array.isArray(secondContent)) return second;
+	return { ...first, content: [...firstContent, ...secondContent] } as Message;
+}

--- a/packages/coding-agent/test/compaction/summarization-body-too-large.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-body-too-large.test.ts
@@ -154,13 +154,18 @@ describe("summarization input sizing for CJK transcripts", () => {
 		expect(estimateTotalTokens(messages)).toBeGreaterThanOrEqual(Math.floor(korean.length / 1.6));
 	});
 
-	it("Given a Korean-heavy oversized history When the input is bounded Then the wire estimate respects the history budget", () => {
-		const messages = Array.from({ length: 30 }, (_, index) => ({
-			role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
-			content: [{ type: "text" as const, text: `히스토리 ${index} ${"한국어 내용 ".repeat(200)}` }],
-			timestamp: index,
-		})) as unknown as AgentMessage[];
-		const bounded = boundSummarizationInput(messages, CONTEXT_WINDOW, 100);
-		expect(estimateTotalTokens(bounded)).toBeLessThanOrEqual(summarizationHistoryBudget(CONTEXT_WINDOW, 100));
+	it("Given equal-length Korean and ASCII histories When the input is bounded Then the Korean history is pruned harder", () => {
+		const buildHistory = (text: (index: number) => string) =>
+			Array.from({ length: 30 }, (_, index) => ({
+				role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+				content: [{ type: "text" as const, text: text(index) }],
+				timestamp: index,
+			})) as unknown as AgentMessage[];
+		const korean = buildHistory((index) => `히스토리 ${index} ${"한국어 내용 ".repeat(200)}`);
+		const ascii = buildHistory((index) => `history ${index} ${"english prose ".repeat(200)}`);
+		const boundedKorean = boundSummarizationInput(korean, CONTEXT_WINDOW, 100);
+		const boundedAscii = boundSummarizationInput(ascii, CONTEXT_WINDOW, 100);
+		expect(boundedKorean.length).toBeLessThan(boundedAscii.length);
+		expect(estimateTotalTokens(boundedKorean)).toBeLessThanOrEqual(summarizationHistoryBudget(CONTEXT_WINDOW, 100));
 	});
 });

--- a/packages/coding-agent/test/compaction/summarization-body-too-large.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-body-too-large.test.ts
@@ -1,0 +1,166 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createFileOps, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import { classifyRequiredCompactionFallbackFailure } from "../../src/core/extensions/builtin/compaction/deterministic-fallback.ts";
+import {
+	boundSummarizationInput,
+	estimateTotalTokens,
+	summarizationHistoryBudget,
+} from "../../src/core/extensions/builtin/compaction/overflow-retry.ts";
+import {
+	runExtensionCompaction,
+	type SpeculativeCompactionContext,
+	type SpeculativeCompactionSnapshot,
+} from "../../src/core/extensions/builtin/compaction/speculative.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+/**
+ * Incident 2026-08-16 (Discord IMG_1221.jpg): a session over the compaction
+ * threshold had its summarization request rejected by every fallback-chain
+ * model — gateway 413 "Request body too large" / "Request Entity Too Large",
+ * then a 120s wall-clock stall — wedging the session on
+ * "Compaction rejected: compaction generator failed: 413 ...".
+ *
+ * Root cause: those 413 wordings were not classified as context overflow, so
+ * the halving shrink-retry never engaged and the failure never reached the
+ * deterministic fallback classifier. A byte-size rejection is the same
+ * recovery class as a token-window overflow: shrink the input and retry, then
+ * degrade deterministically.
+ */
+
+const CONTEXT_WINDOW = 8_000;
+const HISTORY_MESSAGE_COUNT = 40;
+const HISTORY_MESSAGE_CHARS = 1_200;
+
+const GATEWAY_413_OPENAI_STYLE =
+	'413: {"message":"Request body too large","type":"invalid_request_error","code":"body_too_large"}';
+const GATEWAY_413_AI_SDK_STYLE =
+	'413: {"message":"Request Entity Too Large","type":"AI_APICallError","param":{"error":"Request Entity Too Large","statusCode":413,"name":"AI_APICallError","message":"Request Entity Too Large","isRetryable":false,"type":"AI_APICallError"}}';
+
+function oversizedHistory(count: number) {
+	return Array.from({ length: count }, (_, index) => ({
+		role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+		content: [{ type: "text" as const, text: `history-${index} ${"x".repeat(HISTORY_MESSAGE_CHARS)}` }],
+		timestamp: index,
+	}));
+}
+
+function createModelContext() {
+	const registration = registerFauxProvider({ models: [{ id: "gateway-model", contextWindow: CONTEXT_WINDOW }] });
+	const model = registration.getModel();
+	const sessionManager = SessionManager.inMemory();
+	const modelRegistry = Object.create(null) as SpeculativeCompactionContext["modelRegistry"];
+	if (modelRegistry) {
+		modelRegistry.getApiKeyAndHeaders = vi.fn(async () => ({ ok: true as const, apiKey: "test-key" }));
+	}
+	const context = {
+		model,
+		sessionManager,
+		modelRegistry,
+		getContextUsage: () => ({ tokens: 0, percent: 0, contextWindow: CONTEXT_WINDOW }),
+		getMessageRevision: () => 1,
+		applyCompaction: vi.fn(async () => ({ applied: true as const, reason: "ok" as const })),
+	} as unknown as SpeculativeCompactionContext;
+	const snapshot = {
+		generation: 1,
+		expectedRevision: 1,
+		model,
+		contextWindow: CONTEXT_WINDOW,
+		preparation: {
+			firstKeptEntryId: "keep",
+			messagesToSummarize: oversizedHistory(HISTORY_MESSAGE_COUNT),
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 12_000,
+			fileOps: createFileOps(),
+			settings: { ...DEFAULT_COMPACTION_SETTINGS },
+		},
+		promptVariant: "default" as const,
+		origin: "blocking" as const,
+		systemPrompt: "",
+	} as unknown as SpeculativeCompactionSnapshot;
+	return { registration, context, snapshot };
+}
+
+function queue413(registration: ReturnType<typeof registerFauxProvider>, count: number, message: string): void {
+	registration.setResponses(
+		Array.from(
+			{ length: count },
+			() => () => fauxAssistantMessage("discarded", { stopReason: "error", errorMessage: message }),
+		),
+	);
+}
+
+describe("compaction summarization vs gateway 413 body-size rejections", () => {
+	it("Given a provider that 413s twice then accepts When compaction runs Then the input shrinks per attempt and a summary is produced", async () => {
+		const { registration, context, snapshot } = createModelContext();
+		registration.setResponses([
+			() => fauxAssistantMessage("discarded", { stopReason: "error", errorMessage: GATEWAY_413_OPENAI_STYLE }),
+			() => fauxAssistantMessage("discarded", { stopReason: "error", errorMessage: GATEWAY_413_OPENAI_STYLE }),
+			() => fauxAssistantMessage("A compact summary of the conversation."),
+		]);
+
+		const result = await runExtensionCompaction(context, snapshot);
+
+		expect(result).toBeDefined();
+		expect(result?.summary).toContain("compact summary");
+		expect(registration.state.callCount).toBe(3);
+		const messageCounts = registration.getCallLog().map((call) => call.context.messages.length);
+		for (let index = 1; index < messageCounts.length; index++) {
+			expect(messageCounts[index]).toBeLessThan(messageCounts[index - 1] ?? 0);
+		}
+	});
+
+	it("Given a provider that always 413s (AI SDK wording) When compaction runs Then attempts shrink and exhaustion degrades classifiably", async () => {
+		const { registration, context, snapshot } = createModelContext();
+		queue413(registration, 12, GATEWAY_413_AI_SDK_STYLE);
+
+		const failure = await runExtensionCompaction(context, snapshot).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		// The shrink-retry must engage (more than the single first attempt) and
+		// exhaustion must be classifiable for the deterministic fallback — the
+		// two properties whose absence wedged the incident session.
+		expect(registration.state.callCount).toBeGreaterThan(1);
+		expect(failure).toBeInstanceOf(Error);
+		expect(classifyRequiredCompactionFallbackFailure(failure)).not.toBeUndefined();
+	});
+
+	it("Given a provider that always 413s (OpenAI wording) When compaction runs Then exhaustion degrades classifiably", async () => {
+		const { registration, context, snapshot } = createModelContext();
+		queue413(registration, 12, GATEWAY_413_OPENAI_STYLE);
+
+		const failure = await runExtensionCompaction(context, snapshot).then(
+			() => undefined,
+			(error: unknown) => error,
+		);
+
+		expect(registration.state.callCount).toBeGreaterThan(1);
+		expect(failure).toBeInstanceOf(Error);
+		expect(classifyRequiredCompactionFallbackFailure(failure)).not.toBeUndefined();
+	});
+});
+
+describe("summarization input sizing for CJK transcripts", () => {
+	it("Given Korean-heavy messages When estimating the input size Then the estimate reflects real token density", () => {
+		// Korean tokenizes near one token per 1.5 characters; a chars/4
+		// estimate claims ~4x fewer tokens and undersizes the request bound,
+		// which is how the incident session's first attempt went out oversized.
+		const korean = "안녕하세요 컴팩션 요약 요청이 너무 커서 실패했습니다 ".repeat(80);
+		const messages = [{ role: "user" as const, content: [{ type: "text" as const, text: korean }], timestamp: 1 }];
+		expect(estimateTotalTokens(messages)).toBeGreaterThanOrEqual(Math.floor(korean.length / 1.6));
+	});
+
+	it("Given a Korean-heavy oversized history When the input is bounded Then the wire estimate respects the history budget", () => {
+		const messages = Array.from({ length: 30 }, (_, index) => ({
+			role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+			content: [{ type: "text" as const, text: `히스토리 ${index} ${"한국어 내용 ".repeat(200)}` }],
+			timestamp: index,
+		})) as unknown as AgentMessage[];
+		const bounded = boundSummarizationInput(messages, CONTEXT_WINDOW, 100);
+		expect(estimateTotalTokens(bounded)).toBeLessThanOrEqual(summarizationHistoryBudget(CONTEXT_WINDOW, 100));
+	});
+});

--- a/packages/coding-agent/test/compaction/summarization-turn-order.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-turn-order.test.ts
@@ -1,0 +1,138 @@
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createFileOps, DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import {
+	runExtensionCompaction,
+	type SpeculativeCompactionContext,
+	type SpeculativeCompactionSnapshot,
+} from "../../src/core/extensions/builtin/compaction/speculative.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+/**
+ * Incident 2026-08-16 (Discord IMG_1221.jpg): gemini-3.7-flash-high rejected
+ * the compaction summarization request twice with
+ * "400 INVALID_ARGUMENT: Please ensure that function call turn comes
+ * immediately after a user turn or after a function response turn".
+ *
+ * Gemini rejects a functionCall model turn that follows another model turn,
+ * and rejects a conversation whose first turn is not a user turn. Real
+ * sessions contain adjacent assistant messages (split turns, retries), and
+ * budget pruning/shrinking can drop the leading user message — both shapes
+ * flow straight into the request today.
+ */
+
+const CONTEXT_WINDOW = 8_000;
+
+function textMessage(role: "user" | "assistant", text: string, timestamp: number) {
+	return { role, content: [{ type: "text" as const, text }], timestamp };
+}
+
+function toolCallingAssistant(text: string, callId: string, timestamp: number) {
+	return {
+		role: "assistant" as const,
+		content: [
+			{ type: "text" as const, text },
+			{ type: "toolCall" as const, id: callId, name: "bash", arguments: { command: "ls" } },
+		],
+		timestamp,
+	};
+}
+
+function toolResultMessage(callId: string, timestamp: number) {
+	return {
+		role: "toolResult" as const,
+		toolCallId: callId,
+		toolName: "bash",
+		content: [{ type: "text" as const, text: "ok" }],
+		timestamp,
+	};
+}
+
+function createModelContext(messagesToSummarize: ReturnType<typeof Array.prototype.concat.call>) {
+	const registration = registerFauxProvider({ models: [{ id: "gateway-model", contextWindow: CONTEXT_WINDOW }] });
+	const model = registration.getModel();
+	const sessionManager = SessionManager.inMemory();
+	const modelRegistry = Object.create(null) as SpeculativeCompactionContext["modelRegistry"];
+	if (modelRegistry) {
+		modelRegistry.getApiKeyAndHeaders = vi.fn(async () => ({ ok: true as const, apiKey: "test-key" }));
+	}
+	const context = {
+		model,
+		sessionManager,
+		modelRegistry,
+		getContextUsage: () => ({ tokens: 0, percent: 0, contextWindow: CONTEXT_WINDOW }),
+		getMessageRevision: () => 1,
+		applyCompaction: vi.fn(async () => ({ applied: true as const, reason: "ok" as const })),
+	} as unknown as SpeculativeCompactionContext;
+	const snapshot = {
+		generation: 1,
+		expectedRevision: 1,
+		model,
+		contextWindow: CONTEXT_WINDOW,
+		preparation: {
+			firstKeptEntryId: "keep",
+			messagesToSummarize,
+			turnPrefixMessages: [],
+			isSplitTurn: false,
+			tokensBefore: 4_000,
+			fileOps: createFileOps(),
+			settings: { ...DEFAULT_COMPACTION_SETTINGS },
+		},
+		promptVariant: "default" as const,
+		origin: "blocking" as const,
+		systemPrompt: "",
+	} as unknown as SpeculativeCompactionSnapshot;
+	return { registration, context, snapshot };
+}
+
+function requestRoles(registration: ReturnType<typeof registerFauxProvider>, callIndex: number): string[] {
+	const call = registration.getCallLog()[callIndex];
+	if (!call) throw new Error(`expected provider call ${callIndex}`);
+	return call.context.messages.map((message) => (message as { role: string }).role);
+}
+
+describe("compaction summarization request turn order (Gemini function-call rule)", () => {
+	it("Given adjacent assistant messages in the history When compaction runs Then the request has no adjacent assistants and starts with a user message", async () => {
+		const history = [
+			textMessage("user", "please continue", 1),
+			textMessage("assistant", "first half of the answer", 2),
+			toolCallingAssistant("second half, calling a tool", "call-1", 3),
+			toolResultMessage("call-1", 4),
+			textMessage("user", "thanks", 5),
+		];
+		const { registration, context, snapshot } = createModelContext(history);
+		registration.setResponses([() => fauxAssistantMessage("A compact summary.")]);
+
+		const result = await runExtensionCompaction(context, snapshot);
+
+		expect(result).toBeDefined();
+		const roles = requestRoles(registration, 0);
+		expect(roles[0]).toBe("user");
+		for (let index = 1; index < roles.length; index++) {
+			expect(!(roles[index - 1] === "assistant" && roles[index] === "assistant")).toBe(true);
+		}
+	});
+
+	it("Given an overflow retry whose shrink drops the leading user message When compaction runs Then every attempt still starts with a user message", async () => {
+		const history = Array.from({ length: 40 }, (_, index) =>
+			textMessage(index % 2 === 0 ? "user" : "assistant", `entry-${index} ${"y".repeat(1_200)}`, index),
+		);
+		const { registration, context, snapshot } = createModelContext(history);
+		registration.setResponses([
+			() =>
+				fauxAssistantMessage("discarded", {
+					stopReason: "error",
+					errorMessage: "Your input exceeds the context window of this model",
+				}),
+			() => fauxAssistantMessage("A compact summary."),
+		]);
+
+		const result = await runExtensionCompaction(context, snapshot);
+
+		expect(result).toBeDefined();
+		expect(registration.state.callCount).toBeGreaterThan(1);
+		for (let callIndex = 0; callIndex < registration.state.callCount; callIndex++) {
+			expect(requestRoles(registration, callIndex)[0]).toBe("user");
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #884 — a session whose summarization payload exceeds provider size limits could not compact at all: every fallback-chain model rejected the same oversized request (two gateway 413 shapes, a Gemini 400 turn-order rejection, a 120s wall-clock stall on the oversized input), wedging the session on `Compaction rejected: compaction generator failed`.

## Root causes (each verified at runtime before the fix)

1. **Gateway 413 wordings were not classified as context overflow.** `isContextOverflow` recognized Anthropic-native `request_too_large` but returned `false` for the incident's `Request body too large` / `body_too_large` and `Request Entity Too Large` (probed against the shipped dist). The overflow shrink-retry never engaged, the failure never reached the deterministic-fallback classifier, and the extension cancelled — the wedge.
2. **Summarization request turn order violated Gemini's function-call rule.** A fuzz probe through the shipped pipeline (prune → `convertToLlm` → `repairOrphanedToolResults` → google `convertMessages`) produced 8 violations in two classes: adjacent assistant messages → `model -> model(functionCall)`, and overflow shrinking/budget pruning dropping the leading user message → model-first conversation.
3. **Input sizing undercounts CJK text ~2.7x.** The chars/4 estimate measures Korean at 4.00 chars/token (real ≈ 1.5), so Korean-heavy sessions sent first attempts far over provider limits.

## Changes

- **`packages/ai`**: `OVERFLOW_PATTERNS` gains `/(?:request[ _])?(?:body|entity|payload)[_ ]too[_ ]large/i`, routing gateway 413s into the same recovery as token-window overflow.
- **`packages/coding-agent`**: new `summarization-turn-order.ts` normalizes the final request list at the `generateSummaryMessage` seam (after `convertToLlm` + pair repair, where roles are final): adjacent assistants merge, content before the first user message is dropped. `overflow-retry.ts` sizing adds a CJK density correction (weight 3, mirroring the base64-run weighting). With the classification fix, 413s now shrink geometrically and exhaust into the classifiable `SummarizationOverflowExhaustedError` → deterministic fallback for threshold/overflow compactions.
- **QA**: new real-CLI scenario `compaction-body-too-large-qa.mjs` with a size-limited mock gateway.

The core summarization route (`generateSummaryWithUsage`) is not exposed to the ordering defect — it serializes the conversation into a single user text message.

## Evidence

- **RED→GREEN (unit/integration)**: `packages/ai/test/overflow.test.ts` (both incident strings: fail→pass), `test/compaction/summarization-body-too-large.test.ts` (413→shrink→success; 413×N→classifiable exhaustion; CJK density + bounded budget: 5 tests, fail→pass), `test/compaction/summarization-turn-order.test.ts` (adjacent assistants; leading-user after shrink: 2 tests, fail→pass — RED included `expected 'assistant' to be 'user'`).
- **Real-CLI, incident replayed end to end** (senpi-qa mock gateway, 45 KB body limit, verbatim incident 413 shape):
  - `origin/main` (unfixed): 1 summarization request → 413 → terminal `Compaction rejected: compaction generator failed`, no shrink, no compaction — `local-ignore/qa-evidence/20260816-compaction-body-too-large-red/` (4/8 checks).
  - This branch: 2 requests, 50664→41885 bytes shrink, 200, compaction accepted, zero `Compaction rejected` events, strict turn-alternation rule holds on every attempt — `local-ignore/qa-evidence/20260816-compaction-body-too-large/` (8/8 checks).
- **Scopes**: `test/compaction/` 358/358; `packages/ai` 1984 passed / 0 failed; `npm run check` rc=0; changelog gate PASS locally.

## Test plan

- [x] `npx vitest run test/overflow.test.ts` (packages/ai)
- [x] `npx vitest run test/compaction/` (packages/coding-agent)
- [x] `node .agents/skills/senpi-qa/scripts/scenarios/compaction-body-too-large-qa.mjs --evidence compaction-body-too-large` (8/8)
- [x] Same scenario on `origin/main` fails as the incident (RED capture)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Un-wedges compaction when providers reject oversized summarization payloads or strict turn order. Previously: gateway 413s and Gemini’s 400 turn-order rule made every fallback model fail the same request, wedging sessions on “Compaction rejected: compaction generator failed.” Now: 413s classify as overflow and trigger shrink‑and‑retry; requests normalize turn order; CJK-heavy inputs size conservatively; and normalization is hardened to avoid orphaned tool results and preserve edge cases.

- `packages/ai`: `isContextOverflow` treats gateway HTTP 413 byte-size errors (“Request body too large”, “Request Entity Too Large”, `body_too_large`, “Payload Too Large”) as overflow so shrink‑retry engages instead of a terminal error.
- `packages/coding-agent`: normalizes summarization turn order (merge adjacent assistants; drop content before the first user) and then repairs tool pairs to prevent orphaned `toolResult`; adds a CJK density correction to request-size estimates; on exhaustion, throws a classifiable summarization‑overflow error so deterministic fallback applies; minor hardening (decline merging on non-array content; skip the leading drop when the only user turn is the trailing instruction).
- Tests/QA: unit tests for new overflow patterns, turn‑order normalization, and CJK sizing; strengthened budget test; a real‑CLI scenario with a size‑limited mock gateway verifies shrink across attempts, accepted compaction, and strict turn alternation on every attempt.

<sup>Written for commit febd0e669ff810908f684d4b947cf0117b66f5bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

