### PR TITLE
feat(codemode): publish eval execution metadata events

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/eval-execution-event-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/eval-execution-event-qa.mjs
@@ -147,6 +147,8 @@ async function selfTest() {
 
 		const data = event.data ?? {};
 		checks.ok("event carries version 1", data.version === 1, `version=${JSON.stringify(data.version)}`);
+		checks.ok("RPC event is metadata-only", data.detailLevel === "metadata", `detailLevel=${JSON.stringify(data.detailLevel)}`);
+		checks.ok("RPC projection stayed within its byte cap", data.rpcTruncated === false, `rpcTruncated=${JSON.stringify(data.rpcTruncated)}`);
 		checks.ok("cellId present", typeof data.cellId === "string" && data.cellId.length > 0, `cellId=${JSON.stringify(data.cellId)}`);
 		checks.ok("language reported", data.language === "js", `language=${JSON.stringify(data.language)}`);
 		checks.ok("cell settled ok", data.ok === true, `ok=${JSON.stringify(data.ok)}`);
@@ -164,6 +166,17 @@ async function selfTest() {
 			"each tool call has a nonnegative duration",
 			calls.every((call) => typeof call.durationMs === "number" && call.durationMs >= 0),
 			`durations=${calls.map((call) => call.durationMs).join(",")}`,
+		);
+		checks.ok(
+			"RPC tool calls exclude prompts, arguments, outputs, errors, and call ids",
+			calls.every(
+				(call) =>
+					!("args" in call) &&
+					!("resultPreview" in call) &&
+					!("error" in call) &&
+					!("callId" in call),
+			) && !("error" in data),
+			JSON.stringify(calls),
 		);
 
 		const distinct = Array.isArray(data.distinctToolsCalled) ? [...data.distinctToolsCalled].sort() : [];
@@ -187,11 +200,13 @@ async function selfTest() {
 		checks.ok(
 			"wall-clock fields coherent",
 			typeof data.startedAt === "number" &&
-				typeof data.completedAt === "number" &&
+			typeof data.completedAt === "number" &&
 				data.startedAt <= data.completedAt &&
 				typeof data.durationMs === "number" &&
-				data.durationMs >= 0,
-			`startedAt=${data.startedAt} completedAt=${data.completedAt} durationMs=${data.durationMs}`,
+				data.durationMs === data.completedAt - data.startedAt &&
+				typeof data.kernelDurationMs === "number" &&
+				data.kernelDurationMs >= 0,
+			`startedAt=${data.startedAt} completedAt=${data.completedAt} durationMs=${data.durationMs} kernelDurationMs=${data.kernelDurationMs}`,
 		);
 		const matchingEvents = client.events.filter(
 			(message) => message.type === "extension_event" && message.name === EVENT_NAME,

--- a/.agents/skills/senpi-qa/scripts/scenarios/eval-execution-event-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/eval-execution-event-qa.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// senpi-qa driver for the senpi.eval.execution settle event over the RPC channel.
+//
+// Proves the producer contract end-to-end on a REAL CLI: an RPC session that
+// advertises the `extension_events` capability must receive exactly one
+// `extension_event` named `senpi.eval.execution` when an eval cell performing
+// nested host tool calls settles, with accurate per-tool metadata.
+//
+// Flow: prompt -> fake model calls eval -> the cell calls two distinct host
+// tools (read + bash) through the bridge -> cell settles -> codemode emits
+// senpi.eval.execution via pi.rpc.emit -> EventBus -> connection-handler forwards it
+// (capability-gated) to this client as {type:"extension_event", name:"senpi.eval.execution"}.
+//
+//   node .agents/skills/senpi-qa/scripts/scenarios/eval-execution-event-qa.mjs --self-test
+//   node .agents/skills/senpi-qa/scripts/scenarios/eval-execution-event-qa.mjs --self-test --evidence eval-execution-event
+import { existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox } from "../lib/common.mjs";
+import { startFakeModelServer } from "../lib/fake-model-server.mjs";
+import { API_PRESETS, checkRealAuthUnchanged, hermeticEnv, writeMockModelsJson } from "../lib/mock-loop-support.mjs";
+import { RpcClient } from "../lib/rpc-client.mjs";
+
+const API = "openai-completions";
+const WAIT_TIMEOUT_MS = 120000;
+const EVENT_NAME = "senpi.eval.execution";
+const COMMAND =
+	"node .agents/skills/senpi-qa/scripts/scenarios/eval-execution-event-qa.mjs --self-test --evidence eval-execution-event";
+
+const argv = process.argv.slice(2);
+const evidenceIndex = argv.indexOf("--evidence");
+const evidenceSlug = evidenceIndex >= 0 ? argv[evidenceIndex + 1] : undefined;
+
+function createRecordedChecks(title) {
+	const base = createChecks(title);
+	const lines = [];
+	let passed = 0;
+	let total = 0;
+	return {
+		ok(name, condition, detail = "") {
+			total++;
+			if (condition) passed++;
+			lines.push(`[${condition ? "PASS" : "FAIL"}] ${name}${detail ? ` — ${detail}` : ""}`);
+			return base.ok(name, condition, detail);
+		},
+		finish() {
+			lines.push("", `${title}: ${passed}/${total} passed`);
+			return base.finish();
+		},
+		stdout() {
+			return `${lines.join("\n")}\n`;
+		},
+	};
+}
+
+function waitForChildExit(child, timeoutMs = 10000) {
+	if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true);
+	return new Promise((resolve) => {
+		let settled = false;
+		const finish = (exited) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			child.off("close", onClose);
+			resolve(exited);
+		};
+		const onClose = () => finish(true);
+		const timer = setTimeout(() => finish(false), timeoutMs);
+		child.once("close", onClose);
+	});
+}
+
+async function closeRpcClient(client) {
+	if (!client) return true;
+	client.close();
+	if (await waitForChildExit(client.child)) return true;
+	client.child.kill("SIGKILL");
+	return await waitForChildExit(client.child);
+}
+
+async function selfTest() {
+	installCleanupHooks();
+	if (evidenceIndex >= 0 && !evidenceSlug) throw new Error("--evidence requires a slug");
+
+	const title = "eval-execution-event-qa.mjs --self-test";
+	const checks = createRecordedChecks(title);
+	const guard = guardRealAuth();
+	const preset = API_PRESETS[API];
+	const box = makeSandbox("eval-execution-event");
+	const evidence = evidenceSlug === undefined ? undefined : evidenceDir(evidenceSlug);
+	writeFileSync(join(box.cwd, "note-a.txt"), "eval-execution-qa\n");
+
+	let server;
+	let client;
+	let event;
+	let runError;
+	let cliExited = false;
+	let serverStopped = false;
+	let authUnchanged = false;
+
+	try {
+		server = await startFakeModelServer({
+			turns: [
+				{
+					toolCalls: [
+						{
+							name: "eval",
+							args: {
+								language: "js",
+								code: 'const a = await tool.read({ path: "note-a.txt" });\nconst b = await tool.bash({ command: "echo eval-execution-qa" });\n"tools-done";',
+								summary: "call two distinct host tools, then settle",
+							},
+						},
+					],
+				},
+				{ text: "EVAL-EVENT-SEEN" },
+			],
+		});
+		writeMockModelsJson(box.agentDir, server, API);
+		client = new RpcClient({
+			env: {
+				...hermeticEnv(box.env),
+				// Keep the requested launcher-facing spelling in the receipt environment;
+				// the branded CLI resolves the same suffix through its SENPI_ namespace.
+				RPC_CLIENT_CAPABILITIES: "extension_events",
+				SENPI_RPC_CLIENT_CAPABILITIES: "extension_events",
+			},
+			cwd: box.cwd,
+			extraArgs: ["--provider", preset.provider, "--model", preset.modelId, "--no-extensions", "--approve"],
+		});
+
+		await client.send({ type: "get_state" });
+		const eventPending = client.waitForEvent(
+			(message) => message.type === "extension_event" && message.name === EVENT_NAME,
+			{ timeoutMs: WAIT_TIMEOUT_MS },
+		);
+		const terminalPending = client.waitForEvent(
+			(message) => message.type === "agent_end" || message.type === "agent_aborted",
+			{ timeoutMs: WAIT_TIMEOUT_MS },
+		);
+		const ack = await client.send({ type: "prompt", message: "Run the scripted eval cell." });
+		checks.ok("RPC accepted the prompt", ack.success === true, JSON.stringify(ack.data ?? {}).slice(0, 120));
+
+		event = await eventPending;
+		const terminal = await terminalPending;
+		checks.ok("scripted agent turn completed", terminal.type === "agent_end", `terminal=${terminal.type}`);
+		checks.ok("fake model observed the eval result", server.requests.length === 2, `requests=${server.requests.length}`);
+
+		const data = event.data ?? {};
+		checks.ok("event carries version 1", data.version === 1, `version=${JSON.stringify(data.version)}`);
+		checks.ok("cellId present", typeof data.cellId === "string" && data.cellId.length > 0, `cellId=${JSON.stringify(data.cellId)}`);
+		checks.ok("language reported", data.language === "js", `language=${JSON.stringify(data.language)}`);
+		checks.ok("cell settled ok", data.ok === true, `ok=${JSON.stringify(data.ok)}`);
+		checks.ok(
+			"toolCallCount counts every nested host call",
+			data.toolCallCount === 2,
+			`toolCallCount=${JSON.stringify(data.toolCallCount)}`,
+		);
+
+		const calls = Array.isArray(data.toolCalls) ? data.toolCalls : [];
+		checks.ok("bounded per-call list has both calls", calls.length === 2, `toolCalls.length=${calls.length}`);
+		const names = calls.map((call) => call.name).sort();
+		checks.ok("toolCalls name bash and read", names.join(",") === "bash,read", `names=${names.join(",")}`);
+		checks.ok(
+			"each tool call has a nonnegative duration",
+			calls.every((call) => typeof call.durationMs === "number" && call.durationMs >= 0),
+			`durations=${calls.map((call) => call.durationMs).join(",")}`,
+		);
+
+		const distinct = Array.isArray(data.distinctToolsCalled) ? [...data.distinctToolsCalled].sort() : [];
+		checks.ok("distinctToolsCalled exact", distinct.join(",") === "bash,read", `distinct=${distinct.join(",")}`);
+
+		const aggregates = data.toolAggregates ?? {};
+		const aggregateNames = Object.keys(aggregates).sort();
+		const readAggregate = aggregates.read;
+		const bashAggregate = aggregates.bash;
+		checks.ok(
+			"tool aggregates exact with nonnegative totals",
+			aggregateNames.join(",") === "bash,read" &&
+				readAggregate?.count === 1 &&
+				bashAggregate?.count === 1 &&
+				typeof readAggregate.totalDurationMs === "number" &&
+				readAggregate.totalDurationMs >= 0 &&
+				typeof bashAggregate.totalDurationMs === "number" &&
+				bashAggregate.totalDurationMs >= 0,
+			`read=${JSON.stringify(readAggregate)} bash=${JSON.stringify(bashAggregate)}`,
+		);
+		checks.ok(
+			"wall-clock fields coherent",
+			typeof data.startedAt === "number" &&
+				typeof data.completedAt === "number" &&
+				data.startedAt <= data.completedAt &&
+				typeof data.durationMs === "number" &&
+				data.durationMs >= 0,
+			`startedAt=${data.startedAt} completedAt=${data.completedAt} durationMs=${data.durationMs}`,
+		);
+		const matchingEvents = client.events.filter(
+			(message) => message.type === "extension_event" && message.name === EVENT_NAME,
+		);
+		checks.ok("exactly one senpi.eval.execution event", matchingEvents.length === 1, `${matchingEvents.length} events`);
+	} catch (error) {
+		runError = error;
+	} finally {
+		cliExited = await closeRpcClient(client);
+		if (server) {
+			await server.stop().catch(() => {});
+			serverStopped = true;
+		} else {
+			serverStopped = true;
+		}
+		box.cleanup();
+		try {
+			authUnchanged = guard.assertUnchanged();
+		} catch {}
+	}
+
+	checks.ok(
+		"scenario completed without runtime error",
+		runError === undefined,
+		runError === undefined ? "no runtime error" : runError instanceof Error ? runError.message : String(runError),
+	);
+	checkRealAuthUnchanged(checks, guard);
+	const cleanup = {
+		cliExited,
+		serverStopped,
+		sandboxRemoved: !existsSync(box.dir),
+		authUnchanged,
+	};
+	checks.ok("spawned resources were cleaned up", Object.values(cleanup).every(Boolean), JSON.stringify(cleanup));
+
+	if (evidence) {
+		writeFileSync(join(evidence, "command.txt"), `${COMMAND}\n`);
+		writeFileSync(join(evidence, "rpc-events.jsonl"), `${(client?.events ?? []).map((message) => JSON.stringify(message)).join("\n")}\n`);
+		writeFileSync(join(evidence, "eval-execution-event.json"), `${JSON.stringify(event ?? null, null, 2)}\n`);
+		writeFileSync(join(evidence, "stderr.txt"), `${client?.stderr ?? ""}${runError ? `${runError instanceof Error ? runError.stack : String(runError)}\n` : ""}`);
+		writeFileSync(join(evidence, "cleanup.json"), `${JSON.stringify(cleanup, null, 2)}\n`);
+	}
+
+	const passed = checks.finish() && !runError;
+	if (evidence) {
+		writeFileSync(join(evidence, "stdout.txt"), checks.stdout());
+		process.stderr.write(`evidence: ${evidence}\n`);
+	}
+	if (runError) process.stderr.write(`${runError instanceof Error ? runError.stack : String(runError)}\n`);
+	process.exit(passed ? 0 : 1);
+}
+
+if (argv[0] === "--self-test") {
+	selfTest().catch((error) => {
+		process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+		process.exit(1);
+	});
+} else {
+	process.stderr.write(
+		[
+			"senpi-qa — senpi.eval.execution settle event over the RPC channel",
+			"  node scenarios/eval-execution-event-qa.mjs --self-test [--evidence <slug>]",
+			"",
+		].join("\n"),
+	);
+	process.exitCode = 2;
+}

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- Published one versioned `senpi.eval.execution` event per settled eval cell over the external RPC channel and in-process event bus, with total wall time, terminal status, exact nested tool-call counts, per-tool duration aggregates, and bounded per-call metadata for OMO analytics and future desktop rendering ([#897](https://github.com/code-yeongyu/senpi/pull/897)).
+- Published one versioned `senpi.eval.execution` event per settled eval cell: the in-process bus receives bounded rich call details, while the external RPC projection exposes only byte-capped timing/count metadata for safe OMO analytics; total wall time, kernel runtime, pending calls, exact aggregate totals, and overflow accounting are reported separately ([#897](https://github.com/code-yeongyu/senpi/pull/897)).
 
 ### Changed
 

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Published one versioned `senpi.eval.execution` event per settled eval cell over the external RPC channel and in-process event bus, with total wall time, terminal status, exact nested tool-call counts, per-tool duration aggregates, and bounded per-call metadata for OMO analytics and future desktop rendering ([#897](https://github.com/code-yeongyu/senpi/pull/897)).
+
 ### Changed
 
 ### Fixed

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -20,6 +20,11 @@ task-tool names are known.
 - Loopback, bearer-authenticated kernel bridge with bounded JSONL frames.
 - Structured status events for file operations, environment access, phases,
   bridge activity, and delegated task progress.
+- One versioned `senpi.eval.execution` event at terminal cell settlement. The
+  in-process event bus receives bounded per-call arguments and result previews
+  for extension-owned consumers; external RPC clients receive a 32 KiB-capped
+  metadata-only projection with wall time, kernel time, exact call counts,
+  pending-call counts, and bounded per-tool aggregates.
 - Bounded streaming output with head/tail previews, column clamping, and
   session-adjacent spill files for large streams.
 - TUI and HTML-export rendering for syntax-highlighted cells, status rows,

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -4,22 +4,27 @@
 
 ### What changed
 
-- Every settled eval cell now publishes one versioned `senpi.eval.execution` payload through both
-  the optional external RPC channel and the in-process extension event bus.
-- The payload records producer timestamps, total eval wall time, terminal status, detached status,
-  every nested tool-call count, distinct tool names, per-tool aggregate durations, and a bounded
-  list of per-call ids, arguments, durations, errors, and result previews.
+- Every settled eval cell now publishes one versioned `senpi.eval.execution` event. The in-process
+  event bus receives the full bounded payload, while the external RPC channel receives a
+  metadata-only projection that excludes prompts, arguments, call ids, errors, and result previews.
+- The payload records producer timestamps, true end-to-end eval wall time, kernel-reported runtime,
+  terminal status, detached status, every initiated nested tool-call count (including calls still
+  pending when an error cell settles), distinct tool names, and per-tool aggregate durations.
 - Generic and MCP tools retain the existing 30-call enrichment cap while every call still
   contributes to exact counts and aggregates. Reserved agent/output calls now receive the same
   bounded argument and duration capture; internal schema bridge calls preserve their legacy shape.
+- Captured names and identifiers are length-bounded, at most 64 distinct names receive individual
+  aggregates, excess names roll into an exact overflow aggregate, and the RPC projection has a
+  final 32 KiB serialized-byte ceiling with a deterministic aggregate-only fallback.
 - Session-generation fencing suppresses events from retired codemode runtimes.
 
 ### Why
 
 - OMO needs producer-side timing data to determine whether eval composition and parallel tool calls
   actually reduce round trips and wall-clock time, rather than relying on model-side assumptions.
-- The desktop client also needs structured per-call metadata so it can later render eval-contained
-  tool activity instead of receiving analytics-only aggregates.
+- OMO can consume rich metadata from the in-process event bus and later publish an explicitly
+  redacted or capability-gated desktop projection. The current desktop adapter decodes but ignores
+  unknown extension event names, so desktop rendering remains a separate consumer change.
 
 ### Why this cannot be expressed externally
 

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,38 @@
 # senpi-codemode fork changes
 
+## Eval execution metadata event (2026-08-16)
+
+### What changed
+
+- Every settled eval cell now publishes one versioned `senpi.eval.execution` payload through both
+  the optional external RPC channel and the in-process extension event bus.
+- The payload records producer timestamps, total eval wall time, terminal status, detached status,
+  every nested tool-call count, distinct tool names, per-tool aggregate durations, and a bounded
+  list of per-call ids, arguments, durations, errors, and result previews.
+- Generic and MCP tools retain the existing 30-call enrichment cap while every call still
+  contributes to exact counts and aggregates. Reserved agent/output calls now receive the same
+  bounded argument and duration capture; internal schema bridge calls preserve their legacy shape.
+- Session-generation fencing suppresses events from retired codemode runtimes.
+
+### Why
+
+- OMO needs producer-side timing data to determine whether eval composition and parallel tool calls
+  actually reduce round trips and wall-clock time, rather than relying on model-side assumptions.
+- The desktop client also needs structured per-call metadata so it can later render eval-contained
+  tool activity instead of receiving analytics-only aggregates.
+
+### Why this cannot be expressed externally
+
+- The eval extension owns kernel message dispatch, per-call bridge timing, bounded argument/result
+  capture, detached settlement, and session-generation fencing. An external extension cannot
+  reconstruct those facts accurately after the eval tool result has returned.
+
+### Expected merge conflict zones
+
+- MEDIUM in `src/index.ts`, `src/tool/eval-tool.ts`, and `src/tool/cell-handler.ts` around runtime
+  registration, settlement, and nested tool-call capture.
+- LOW in `src/tool/cell-runtime.ts`, `src/tool/eval-tool-options.ts`, and the new event builder.
+
 ## Eval cell hard limit (2026-08-13)
 
 ### What changed

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -17,6 +17,7 @@ import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
 import { WAKE_SOURCE_STATE_EVENT, type WakeSourceState } from "./extension/wake-source-state.ts";
 import { EvalDetachedCellManager, type EvalDetachedCellStatusEntry } from "./tool/detached-cell-manager.ts";
+import { EVAL_EXECUTION_EVENT, type EvalExecutionEventPayload } from "./tool/eval-execution-event.ts";
 import { createEvalTool } from "./tool/eval-tool.ts";
 import { renderEvalCall, renderEvalResult } from "./tool/render.ts";
 
@@ -39,8 +40,10 @@ export interface CodemodeExtensionAPI {
 	getActiveTools(): string[];
 	getAllTools(): readonly EvalSchemaToolInfo[];
 	sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
-	/** Optional host event bus; a host without one turns wake-source emission into a harmless no-op. */
+	/** Optional host event bus; a host without one turns extension event emission into a harmless no-op. */
 	events?: { emit(name: string, data: unknown): void };
+	/** Optional host RPC surface for forwarding extension-owned events to connected clients. */
+	rpc?: { emit(name: string, data: unknown): void };
 }
 
 export interface SenpiCodemodeOptions {
@@ -90,6 +93,11 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		modelId: string | undefined,
 		cellManager: EvalDetachedCellManager,
 	): void => {
+		const onCellSettled = (payload: EvalExecutionEventPayload): void => {
+			if (activeCells !== cellManager) return;
+			pi.rpc?.emit(EVAL_EXECUTION_EVENT, payload);
+			pi.events?.emit(EVAL_EXECUTION_EVENT, payload);
+		};
 		pi.registerTool(
 			createEvalTool({
 				enabledLanguages: runtime.enabledLanguages,
@@ -102,6 +110,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 				artifactsDir: runtime.artifactsDir,
 				cellManager,
 				executionTracker: manager,
+				onCellSettled,
 				renderers,
 				spawns: runtime.spawns,
 				spawnDefaultAgent: runtime.settings.taskTools.task,

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -17,7 +17,11 @@ import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
 import { WAKE_SOURCE_STATE_EVENT, type WakeSourceState } from "./extension/wake-source-state.ts";
 import { EvalDetachedCellManager, type EvalDetachedCellStatusEntry } from "./tool/detached-cell-manager.ts";
-import { EVAL_EXECUTION_EVENT, type EvalExecutionEventPayload } from "./tool/eval-execution-event.ts";
+import {
+	EVAL_EXECUTION_EVENT,
+	type EvalExecutionEventPayload,
+	toEvalExecutionRpcPayload,
+} from "./tool/eval-execution-event.ts";
 import { createEvalTool } from "./tool/eval-tool.ts";
 import { renderEvalCall, renderEvalResult } from "./tool/render.ts";
 
@@ -95,7 +99,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	): void => {
 		const onCellSettled = (payload: EvalExecutionEventPayload): void => {
 			if (activeCells !== cellManager) return;
-			pi.rpc?.emit(EVAL_EXECUTION_EVENT, payload);
+			pi.rpc?.emit(EVAL_EXECUTION_EVENT, toEvalExecutionRpcPayload(payload));
 			pi.events?.emit(EVAL_EXECUTION_EVENT, payload);
 		};
 		pi.registerTool(

--- a/packages/senpi-codemode/src/tool/call-capture.ts
+++ b/packages/senpi-codemode/src/tool/call-capture.ts
@@ -1,6 +1,11 @@
 import { type AgentToolResult, sanitizeTerminalLabel } from "@code-yeongyu/senpi";
+import type { EvalToolCallSummary } from "./types.ts";
 
 export const MAX_ENRICHED_TOOL_CALLS = 30;
+export const MAX_AGGREGATED_TOOL_NAMES = 64;
+export const MAX_CAPTURED_IDENTIFIER_CODE_POINTS = 128;
+export const MAX_CAPTURED_TOOL_NAME_CODE_POINTS = 128;
+export const MAX_RPC_EVENT_BYTES = 32 * 1024;
 
 const MAX_ARGUMENT_STRING_CODE_POINTS = 512;
 const MAX_ARGUMENT_ENTRIES = 32;
@@ -12,6 +17,22 @@ type BoundedValue = {
 	readonly value: unknown;
 	readonly truncated: boolean;
 };
+
+export interface EvalToolCallMetric {
+	readonly name: string;
+	readonly startedAt: number;
+	ok: boolean | undefined;
+	durationMs: number | undefined;
+}
+
+export interface ToolCallCapture {
+	readonly callId: string;
+	readonly args: unknown;
+	readonly startedAt: number;
+	readonly metric: EvalToolCallMetric;
+	readonly includeDetails: boolean;
+	readonly argsTruncated?: true;
+}
 
 export function capCodePoints(text: string, max: number): string {
 	let end = 0;
@@ -81,6 +102,49 @@ export function boundToolCallArgs(args: unknown): { args: unknown; truncated: bo
 	} catch {
 		return { args: undefined, truncated: true };
 	}
+}
+
+export function createToolCallMetric(name: string, startedAt: number): EvalToolCallMetric {
+	return {
+		name: capCodePoints(name, MAX_CAPTURED_TOOL_NAME_CODE_POINTS),
+		startedAt,
+		ok: undefined,
+		durationMs: undefined,
+	};
+}
+
+export function settleToolCallMetric(metric: EvalToolCallMetric, ok: boolean, completedAt: number): void {
+	metric.ok = ok;
+	metric.durationMs = Math.max(0, completedAt - metric.startedAt);
+}
+
+export function recordToolCall(
+	toolCalls: EvalToolCallSummary[],
+	ok: boolean,
+	capture: ToolCallCapture,
+	resultPreview: string | undefined,
+	error: string | undefined,
+): void {
+	const completedAt = Date.now();
+	settleToolCallMetric(capture.metric, ok, completedAt);
+	const summary = {
+		name: capture.metric.name,
+		ok,
+		...(error === undefined ? {} : { error: capCodePoints(error, 512) }),
+		...(capture.includeDetails ? { durationMs: completedAt - capture.startedAt } : {}),
+	};
+	const enrichedCount = toolCalls.filter((toolCall) => toolCall.callId !== undefined).length;
+	if (!capture.includeDetails || enrichedCount >= MAX_ENRICHED_TOOL_CALLS) {
+		toolCalls.push(summary);
+		return;
+	}
+	toolCalls.push({
+		...summary,
+		callId: capture.callId,
+		args: capture.args,
+		...(capture.argsTruncated === true ? { argsTruncated: true } : {}),
+		...(resultPreview === undefined ? {} : { resultPreview }),
+	});
 }
 
 export function toolCallResultPreview(result: AgentToolResult<unknown>): string | undefined {

--- a/packages/senpi-codemode/src/tool/cell-handler.ts
+++ b/packages/senpi-codemode/src/tool/cell-handler.ts
@@ -1,5 +1,6 @@
 import { type AgentToolResult, type ExtensionContext, sanitizeTerminalLabel } from "@code-yeongyu/senpi";
 import type { KernelToHostMessage } from "../bridge/protocol.ts";
+import { RESERVED_SCHEMA_TOOL } from "../bridge/reserved.ts";
 import type { AgentExecuteTool } from "../bridges/agent-bridge.ts";
 import { isReservedToolName, runReservedTool } from "../bridges/reserved-dispatch.ts";
 import type { EvalSchemaToolInfo } from "../bridges/schema-bridge.ts";
@@ -111,9 +112,16 @@ export class CellHandler {
 	}
 
 	async #handleToolCall(message: Extract<KernelToHostMessage, { type: "tool-call" }>): Promise<void> {
+		const capturedArgs = boundToolCallArgs(message.args);
+		const enrich: ToolCallEnrichment = {
+			callId: message.callId,
+			args: capturedArgs.args,
+			startedAt: Date.now(),
+			...(capturedArgs.truncated ? { argsTruncated: true } : {}),
+		};
 		if (message.toolName === "eval") {
 			const error = "recursive eval is not allowed";
-			this.#state.toolCalls.push({ name: message.toolName, ok: false, error });
+			this.#pushToolCall(message.toolName, false, enrich, undefined, error);
 			this.#kernel.deliverToolReply({
 				type: "tool-reply",
 				callId: message.callId,
@@ -123,20 +131,24 @@ export class CellHandler {
 			return;
 		}
 		if (isReservedToolName(message.toolName)) {
-			await this.#deliverToolReply(message, async () => ({
-				value: await runReservedTool(message.toolName, {
-					callId: message.callId,
-					args: message.args,
-					executeTool: this.#runtime.executeTool,
-					taskToolName: this.#runtime.settings.taskTools.task,
-					taskOutputToolName: this.#runtime.settings.taskTools.output,
-					listTools: this.#runtime.listTools,
-					signal: this.#state.signal,
-					emitStatus: (event) => this.#recordStatus(event),
-					marshalToolResult,
+			await this.#deliverToolReply(
+				message,
+				async () => ({
+					value: await runReservedTool(message.toolName, {
+						callId: message.callId,
+						args: message.args,
+						executeTool: this.#runtime.executeTool,
+						taskToolName: this.#runtime.settings.taskTools.task,
+						taskOutputToolName: this.#runtime.settings.taskTools.output,
+						listTools: this.#runtime.listTools,
+						signal: this.#state.signal,
+						emitStatus: (event) => this.#recordStatus(event),
+						marshalToolResult,
+					}),
+					toolCallOk: true,
 				}),
-				toolCallOk: true,
-			}));
+				message.toolName === RESERVED_SCHEMA_TOOL ? undefined : enrich,
+			);
 			return;
 		}
 		if (message.toolName === "completion" && this.#runtime.complete) {
@@ -148,16 +160,10 @@ export class CellHandler {
 				isActive: () => this.#state.active,
 			});
 			if (!this.#state.active) return;
-			this.#state.toolCalls.push(
-				result.ok
-					? { name: message.toolName, ok: true }
-					: { name: message.toolName, ok: false, error: result.error },
-			);
+			this.#pushToolCall(message.toolName, result.ok, enrich, undefined, result.ok ? undefined : result.error);
 			this.#resultBuilder.emitUpdate(false);
 			return;
 		}
-		const capturedArgs = boundToolCallArgs(message.args);
-		const startedAt = Date.now();
 		await this.#deliverToolReply(
 			message,
 			async () => {
@@ -185,12 +191,7 @@ export class CellHandler {
 					...(errorText === undefined ? {} : { errorText }),
 				};
 			},
-			{
-				callId: message.callId,
-				args: capturedArgs.args,
-				startedAt,
-				...(capturedArgs.truncated ? { argsTruncated: true } : {}),
-			},
+			enrich,
 		);
 	}
 
@@ -229,7 +230,12 @@ export class CellHandler {
 		resultPreview: string | undefined,
 		error: string | undefined,
 	): void {
-		const summary = { name, ok, ...(error === undefined ? {} : { error }) };
+		const summary = {
+			name,
+			ok,
+			...(error === undefined ? {} : { error }),
+			...(enrich === undefined ? {} : { durationMs: Date.now() - enrich.startedAt }),
+		};
 		const enrichedCount = this.#state.toolCalls.filter((toolCall) => toolCall.callId !== undefined).length;
 		if (enrich === undefined || enrichedCount >= MAX_ENRICHED_TOOL_CALLS) {
 			this.#state.toolCalls.push(summary);
@@ -239,7 +245,6 @@ export class CellHandler {
 			...summary,
 			callId: enrich.callId,
 			args: enrich.args,
-			durationMs: Date.now() - enrich.startedAt,
 			...(enrich.argsTruncated === true ? { argsTruncated: true } : {}),
 			...(resultPreview === undefined ? {} : { resultPreview }),
 		});

--- a/packages/senpi-codemode/src/tool/cell-handler.ts
+++ b/packages/senpi-codemode/src/tool/cell-handler.ts
@@ -8,7 +8,15 @@ import { appendSchemaHint } from "../bridges/schema-hint.ts";
 import type { CompletionRequest, CompletionResult } from "../completion/handler.ts";
 import { handleCompletionToolCall } from "../completion/tool-bridge.ts";
 import type { ResolvedCodemodeSettings } from "../config/settings.ts";
-import { boundToolCallArgs, capCodePoints, MAX_ENRICHED_TOOL_CALLS, toolCallResultPreview } from "./call-capture.ts";
+import {
+	boundToolCallArgs,
+	capCodePoints,
+	createToolCallMetric,
+	MAX_CAPTURED_IDENTIFIER_CODE_POINTS,
+	recordToolCall,
+	type ToolCallCapture,
+	toolCallResultPreview,
+} from "./call-capture.ts";
 import { CellResultBuilder, type CellState } from "./cell-runtime.ts";
 import { type EvalImageResizer, marshalToolResult, toolResultIsError } from "./image.ts";
 import { upsertStatusEvent } from "./status-events.ts";
@@ -21,13 +29,6 @@ type ResolvedToolReply = {
 	readonly toolCallOk: boolean;
 	readonly resultPreview?: string;
 	readonly errorText?: string;
-};
-
-type ToolCallEnrichment = {
-	readonly callId: string;
-	readonly args: unknown;
-	readonly startedAt: number;
-	readonly argsTruncated?: true;
 };
 
 export interface CellBridgeRuntime {
@@ -112,16 +113,21 @@ export class CellHandler {
 	}
 
 	async #handleToolCall(message: Extract<KernelToHostMessage, { type: "tool-call" }>): Promise<void> {
+		const startedAt = Date.now();
+		const metric = createToolCallMetric(message.toolName, startedAt);
+		this.#state.toolCallMetrics.push(metric);
 		const capturedArgs = boundToolCallArgs(message.args);
-		const enrich: ToolCallEnrichment = {
-			callId: message.callId,
+		const capture: ToolCallCapture = {
+			callId: capCodePoints(message.callId, MAX_CAPTURED_IDENTIFIER_CODE_POINTS),
 			args: capturedArgs.args,
-			startedAt: Date.now(),
+			startedAt,
+			metric,
+			includeDetails: message.toolName !== RESERVED_SCHEMA_TOOL,
 			...(capturedArgs.truncated ? { argsTruncated: true } : {}),
 		};
 		if (message.toolName === "eval") {
 			const error = "recursive eval is not allowed";
-			this.#pushToolCall(message.toolName, false, enrich, undefined, error);
+			recordToolCall(this.#state.toolCalls, false, capture, undefined, error);
 			this.#kernel.deliverToolReply({
 				type: "tool-reply",
 				callId: message.callId,
@@ -147,7 +153,7 @@ export class CellHandler {
 					}),
 					toolCallOk: true,
 				}),
-				message.toolName === RESERVED_SCHEMA_TOOL ? undefined : enrich,
+				capture,
 			);
 			return;
 		}
@@ -160,7 +166,7 @@ export class CellHandler {
 				isActive: () => this.#state.active,
 			});
 			if (!this.#state.active) return;
-			this.#pushToolCall(message.toolName, result.ok, enrich, undefined, result.ok ? undefined : result.error);
+			recordToolCall(this.#state.toolCalls, result.ok, capture, undefined, result.ok ? undefined : result.error);
 			this.#resultBuilder.emitUpdate(false);
 			return;
 		}
@@ -191,19 +197,19 @@ export class CellHandler {
 					...(errorText === undefined ? {} : { errorText }),
 				};
 			},
-			enrich,
+			capture,
 		);
 	}
 
 	async #deliverToolReply(
 		message: Extract<KernelToHostMessage, { type: "tool-call" }>,
 		resolve: () => Promise<ResolvedToolReply>,
-		enrich?: ToolCallEnrichment,
+		capture: ToolCallCapture,
 	): Promise<void> {
 		try {
 			const reply = await resolve();
 			if (!this.#state.active) return;
-			this.#pushToolCall(message.toolName, reply.toolCallOk, enrich, reply.resultPreview, reply.errorText);
+			recordToolCall(this.#state.toolCalls, reply.toolCallOk, capture, reply.resultPreview, reply.errorText);
 			this.#kernel.deliverToolReply({ type: "tool-reply", callId: message.callId, ok: true, value: reply.value });
 		} catch (error) {
 			if (!this.#state.active) return;
@@ -212,7 +218,7 @@ export class CellHandler {
 				message.toolName,
 				this.#toolParameters(message.toolName),
 			);
-			this.#pushToolCall(message.toolName, false, enrich, undefined, text);
+			recordToolCall(this.#state.toolCalls, false, capture, undefined, text);
 			this.#kernel.deliverToolReply({
 				type: "tool-reply",
 				callId: message.callId,
@@ -221,33 +227,6 @@ export class CellHandler {
 			});
 		}
 		this.#resultBuilder.emitUpdate(false);
-	}
-
-	#pushToolCall(
-		name: string,
-		ok: boolean,
-		enrich: ToolCallEnrichment | undefined,
-		resultPreview: string | undefined,
-		error: string | undefined,
-	): void {
-		const summary = {
-			name,
-			ok,
-			...(error === undefined ? {} : { error }),
-			...(enrich === undefined ? {} : { durationMs: Date.now() - enrich.startedAt }),
-		};
-		const enrichedCount = this.#state.toolCalls.filter((toolCall) => toolCall.callId !== undefined).length;
-		if (enrich === undefined || enrichedCount >= MAX_ENRICHED_TOOL_CALLS) {
-			this.#state.toolCalls.push(summary);
-			return;
-		}
-		this.#state.toolCalls.push({
-			...summary,
-			callId: enrich.callId,
-			args: enrich.args,
-			...(enrich.argsTruncated === true ? { argsTruncated: true } : {}),
-			...(resultPreview === undefined ? {} : { resultPreview }),
-		});
 	}
 
 	#toolParameters(toolName: string): unknown {

--- a/packages/senpi-codemode/src/tool/cell-runtime.ts
+++ b/packages/senpi-codemode/src/tool/cell-runtime.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from "@code-yeongyu/senpi";
 import type { KernelToHostMessage } from "../bridge/protocol.ts";
+import type { EvalToolCallMetric } from "./call-capture.ts";
 import { type EvalImageResizer, EvalOutputCollector, type EvalOutputResult } from "./image.ts";
 import type { EvalStatusEvent, EvalToolDetails, EvalToolInput } from "./types.ts";
 
@@ -13,6 +14,7 @@ export interface CellState {
 	readonly signal: AbortSignal;
 	readonly onUpdate: AgentToolUpdateCallback<EvalToolDetails> | undefined;
 	readonly toolCalls: ToolCall[];
+	readonly toolCallMetrics: EvalToolCallMetric[];
 	readonly pendingBridgeCalls: Promise<void>[];
 	readonly statusEvents: EvalStatusEvent[];
 	active: boolean;

--- a/packages/senpi-codemode/src/tool/cell-runtime.ts
+++ b/packages/senpi-codemode/src/tool/cell-runtime.ts
@@ -9,6 +9,7 @@ type ToolCall = EvalToolDetails["toolCalls"] extends readonly (infer Item)[] ? I
 
 export interface CellState {
 	readonly input: EvalToolInput;
+	readonly startedAt: number;
 	readonly signal: AbortSignal;
 	readonly onUpdate: AgentToolUpdateCallback<EvalToolDetails> | undefined;
 	readonly toolCalls: ToolCall[];
@@ -17,6 +18,7 @@ export interface CellState {
 	active: boolean;
 	output: string;
 	phase: string | undefined;
+	error: string | undefined;
 	durationMs: number;
 	status: "pending" | "running" | "complete" | "error";
 }
@@ -70,6 +72,7 @@ export class CellResultBuilder {
 			if (result.valueRepr) this.#output.push(`${result.valueRepr}\n`);
 			this.#state.status = "complete";
 		} else {
+			this.#state.error = result.error.message;
 			this.#output.push(`${result.error.message}\n`);
 			this.#state.status = "error";
 		}
@@ -77,6 +80,7 @@ export class CellResultBuilder {
 	}
 
 	async finalizeCancellation(error: Error): Promise<AgentToolResult<EvalToolDetails>> {
+		this.#state.error = error.message;
 		this.#output.push(`${error.message}\n`);
 		this.#state.status = "error";
 		return await this.#finish(true);

--- a/packages/senpi-codemode/src/tool/eval-execution-event.ts
+++ b/packages/senpi-codemode/src/tool/eval-execution-event.ts
@@ -1,0 +1,93 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { capCodePoints, MAX_ENRICHED_TOOL_CALLS } from "./call-capture.ts";
+import type { CellState } from "./cell-runtime.ts";
+import type { EvalLanguage, EvalToolCallSummary, EvalToolDetails } from "./types.ts";
+
+export const EVAL_EXECUTION_EVENT = "senpi.eval.execution";
+
+export interface EvalToolAggregate {
+	readonly count: number;
+	readonly totalDurationMs: number;
+	readonly okCount: number;
+	readonly errorCount: number;
+}
+
+export type EvalToolAggregates = Record<string, EvalToolAggregate>;
+
+export interface EvalExecutionEventPayload {
+	readonly version: 1;
+	readonly cellId: string;
+	readonly language: EvalLanguage;
+	readonly ok: boolean;
+	readonly error?: string;
+	readonly startedAt: number;
+	readonly completedAt: number;
+	readonly durationMs: number;
+	readonly detached: boolean;
+	readonly toolCallCount: number;
+	readonly toolCalls: readonly EvalToolCallSummary[];
+	readonly distinctToolsCalled: readonly string[];
+	readonly toolAggregates: EvalToolAggregates;
+}
+
+export type EvalExecutionSettleOutcome =
+	| { readonly result: AgentToolResult<EvalToolDetails> }
+	| { readonly error: unknown };
+
+export interface BuildEvalExecutionEventPayloadOptions {
+	readonly cellId: string;
+	readonly state: CellState;
+	readonly outcome: EvalExecutionSettleOutcome;
+	readonly completedAt: number;
+	readonly detached: boolean;
+}
+
+export function buildEvalExecutionEventPayload(
+	options: BuildEvalExecutionEventPayloadOptions,
+): EvalExecutionEventPayload {
+	const { cellId, state, outcome, completedAt, detached } = options;
+	const result = "result" in outcome ? outcome.result : undefined;
+	const ok = result?.details.isError !== true && !("error" in outcome);
+	const aggregates = new Map<string, EvalToolAggregate>();
+
+	for (const call of state.toolCalls) {
+		const current = aggregates.get(call.name) ?? {
+			count: 0,
+			totalDurationMs: 0,
+			okCount: 0,
+			errorCount: 0,
+		};
+		aggregates.set(call.name, {
+			count: current.count + 1,
+			totalDurationMs: current.totalDurationMs + (call.durationMs ?? 0),
+			okCount: current.okCount + (call.ok ? 1 : 0),
+			errorCount: current.errorCount + (call.ok ? 0 : 1),
+		});
+	}
+
+	const error = ok ? undefined : settleError(state, outcome);
+	return {
+		version: 1,
+		cellId,
+		language: state.input.language,
+		ok,
+		...(error === undefined ? {} : { error: capCodePoints(error, 512) }),
+		startedAt: state.startedAt,
+		completedAt,
+		durationMs: result?.details.durationMs ?? Math.max(0, completedAt - state.startedAt),
+		detached,
+		toolCallCount: state.toolCalls.length,
+		toolCalls: state.toolCalls.slice(0, MAX_ENRICHED_TOOL_CALLS),
+		distinctToolsCalled: [...aggregates.keys()],
+		toolAggregates: Object.fromEntries(aggregates),
+	};
+}
+
+function settleError(state: CellState, outcome: EvalExecutionSettleOutcome): string | undefined {
+	if (state.error !== undefined) return state.error;
+	if ("error" in outcome) return outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+	for (const part of outcome.result.content) {
+		if (part.type === "text" && part.text.length > 0) return part.text.trimEnd();
+	}
+	return undefined;
+}

--- a/packages/senpi-codemode/src/tool/eval-execution-event.ts
+++ b/packages/senpi-codemode/src/tool/eval-execution-event.ts
@@ -1,5 +1,11 @@
 import type { AgentToolResult } from "@code-yeongyu/senpi";
-import { capCodePoints, MAX_ENRICHED_TOOL_CALLS } from "./call-capture.ts";
+import {
+	capCodePoints,
+	MAX_AGGREGATED_TOOL_NAMES,
+	MAX_CAPTURED_IDENTIFIER_CODE_POINTS,
+	MAX_ENRICHED_TOOL_CALLS,
+	MAX_RPC_EVENT_BYTES,
+} from "./call-capture.ts";
 import type { CellState } from "./cell-runtime.ts";
 import type { EvalLanguage, EvalToolCallSummary, EvalToolDetails } from "./types.ts";
 
@@ -10,24 +16,45 @@ export interface EvalToolAggregate {
 	readonly totalDurationMs: number;
 	readonly okCount: number;
 	readonly errorCount: number;
+	readonly pendingCount: number;
 }
 
 export type EvalToolAggregates = Record<string, EvalToolAggregate>;
 
-export interface EvalExecutionEventPayload {
+interface EvalExecutionBasePayload {
 	readonly version: 1;
 	readonly cellId: string;
 	readonly language: EvalLanguage;
 	readonly ok: boolean;
-	readonly error?: string;
 	readonly startedAt: number;
 	readonly completedAt: number;
 	readonly durationMs: number;
+	readonly kernelDurationMs?: number;
 	readonly detached: boolean;
 	readonly toolCallCount: number;
-	readonly toolCalls: readonly EvalToolCallSummary[];
+	readonly pendingToolCallCount: number;
 	readonly distinctToolsCalled: readonly string[];
 	readonly toolAggregates: EvalToolAggregates;
+	readonly toolAggregatesTruncated: boolean;
+	readonly toolAggregateOverflow?: EvalToolAggregate;
+}
+
+export interface EvalExecutionEventPayload extends EvalExecutionBasePayload {
+	readonly detailLevel: "full";
+	readonly error?: string;
+	readonly toolCalls: readonly EvalToolCallSummary[];
+}
+
+export interface EvalExecutionRpcToolCallSummary {
+	readonly name: string;
+	readonly ok: boolean;
+	readonly durationMs?: number;
+}
+
+export interface EvalExecutionRpcPayload extends EvalExecutionBasePayload {
+	readonly detailLevel: "metadata";
+	readonly rpcTruncated: boolean;
+	readonly toolCalls: readonly EvalExecutionRpcToolCallSummary[];
 }
 
 export type EvalExecutionSettleOutcome =
@@ -48,39 +75,120 @@ export function buildEvalExecutionEventPayload(
 	const { cellId, state, outcome, completedAt, detached } = options;
 	const result = "result" in outcome ? outcome.result : undefined;
 	const ok = result?.details.isError !== true && !("error" in outcome);
-	const aggregates = new Map<string, EvalToolAggregate>();
-
-	for (const call of state.toolCalls) {
-		const current = aggregates.get(call.name) ?? {
-			count: 0,
-			totalDurationMs: 0,
-			okCount: 0,
-			errorCount: 0,
-		};
-		aggregates.set(call.name, {
-			count: current.count + 1,
-			totalDurationMs: current.totalDurationMs + (call.durationMs ?? 0),
-			okCount: current.okCount + (call.ok ? 1 : 0),
-			errorCount: current.errorCount + (call.ok ? 0 : 1),
-		});
-	}
-
+	const aggregateState = aggregateToolCalls(state, completedAt);
 	const error = ok ? undefined : settleError(state, outcome);
 	return {
 		version: 1,
-		cellId,
+		detailLevel: "full",
+		cellId: capCodePoints(cellId, MAX_CAPTURED_IDENTIFIER_CODE_POINTS),
 		language: state.input.language,
 		ok,
 		...(error === undefined ? {} : { error: capCodePoints(error, 512) }),
 		startedAt: state.startedAt,
 		completedAt,
-		durationMs: result?.details.durationMs ?? Math.max(0, completedAt - state.startedAt),
+		durationMs: Math.max(0, completedAt - state.startedAt),
+		...(result === undefined ? {} : { kernelDurationMs: result.details.durationMs }),
 		detached,
-		toolCallCount: state.toolCalls.length,
+		toolCallCount: state.toolCallMetrics.length,
+		pendingToolCallCount: aggregateState.pendingCount,
 		toolCalls: state.toolCalls.slice(0, MAX_ENRICHED_TOOL_CALLS),
-		distinctToolsCalled: [...aggregates.keys()],
-		toolAggregates: Object.fromEntries(aggregates),
+		distinctToolsCalled: [...aggregateState.aggregates.keys()],
+		toolAggregates: Object.fromEntries(aggregateState.aggregates),
+		toolAggregatesTruncated: aggregateState.overflow !== undefined,
+		...(aggregateState.overflow === undefined ? {} : { toolAggregateOverflow: aggregateState.overflow }),
 	};
+}
+
+export function toEvalExecutionRpcPayload(payload: EvalExecutionEventPayload): EvalExecutionRpcPayload {
+	const candidate: EvalExecutionRpcPayload = {
+		version: payload.version,
+		detailLevel: "metadata",
+		rpcTruncated: false,
+		cellId: payload.cellId,
+		language: payload.language,
+		ok: payload.ok,
+		startedAt: payload.startedAt,
+		completedAt: payload.completedAt,
+		durationMs: payload.durationMs,
+		...(payload.kernelDurationMs === undefined ? {} : { kernelDurationMs: payload.kernelDurationMs }),
+		detached: payload.detached,
+		toolCallCount: payload.toolCallCount,
+		pendingToolCallCount: payload.pendingToolCallCount,
+		toolCalls: payload.toolCalls.map((call) => ({
+			name: call.name,
+			ok: call.ok,
+			...(call.durationMs === undefined ? {} : { durationMs: call.durationMs }),
+		})),
+		distinctToolsCalled: payload.distinctToolsCalled,
+		toolAggregates: payload.toolAggregates,
+		toolAggregatesTruncated: payload.toolAggregatesTruncated,
+		...(payload.toolAggregateOverflow === undefined ? {} : { toolAggregateOverflow: payload.toolAggregateOverflow }),
+	};
+	if (serializedBytes(candidate) <= MAX_RPC_EVENT_BYTES) return candidate;
+	return {
+		...candidate,
+		rpcTruncated: true,
+		toolCalls: [],
+		distinctToolsCalled: [],
+		toolAggregates: {},
+		toolAggregatesTruncated: true,
+		toolAggregateOverflow: totalAggregate(payload),
+	};
+}
+
+function aggregateToolCalls(
+	state: CellState,
+	completedAt: number,
+): {
+	readonly aggregates: Map<string, EvalToolAggregate>;
+	readonly overflow: EvalToolAggregate | undefined;
+	readonly pendingCount: number;
+} {
+	const aggregates = new Map<string, EvalToolAggregate>();
+	let overflow: EvalToolAggregate | undefined;
+	let pendingCount = 0;
+	for (const metric of state.toolCallMetrics) {
+		const item: EvalToolAggregate = {
+			count: 1,
+			totalDurationMs: metric.durationMs ?? Math.max(0, completedAt - metric.startedAt),
+			okCount: metric.ok === true ? 1 : 0,
+			errorCount: metric.ok === false ? 1 : 0,
+			pendingCount: metric.ok === undefined ? 1 : 0,
+		};
+		pendingCount += item.pendingCount;
+		const existing = aggregates.get(metric.name);
+		if (existing !== undefined) {
+			aggregates.set(metric.name, addAggregate(existing, item));
+			continue;
+		}
+		if (aggregates.size < MAX_AGGREGATED_TOOL_NAMES) {
+			aggregates.set(metric.name, item);
+			continue;
+		}
+		overflow = overflow === undefined ? item : addAggregate(overflow, item);
+	}
+	return { aggregates, overflow, pendingCount };
+}
+
+function addAggregate(left: EvalToolAggregate, right: EvalToolAggregate): EvalToolAggregate {
+	return {
+		count: left.count + right.count,
+		totalDurationMs: left.totalDurationMs + right.totalDurationMs,
+		okCount: left.okCount + right.okCount,
+		errorCount: left.errorCount + right.errorCount,
+		pendingCount: left.pendingCount + right.pendingCount,
+	};
+}
+
+function totalAggregate(payload: EvalExecutionEventPayload): EvalToolAggregate {
+	let total: EvalToolAggregate = { count: 0, totalDurationMs: 0, okCount: 0, errorCount: 0, pendingCount: 0 };
+	for (const aggregate of Object.values(payload.toolAggregates)) total = addAggregate(total, aggregate);
+	if (payload.toolAggregateOverflow !== undefined) total = addAggregate(total, payload.toolAggregateOverflow);
+	return total;
+}
+
+function serializedBytes(value: unknown): number {
+	return new TextEncoder().encode(JSON.stringify(value)).byteLength;
 }
 
 function settleError(state: CellState, outcome: EvalExecutionSettleOutcome): string | undefined {

--- a/packages/senpi-codemode/src/tool/eval-tool-options.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool-options.ts
@@ -5,6 +5,7 @@ import type { ResolvedCodemodeSettings } from "../config/settings.ts";
 import type { EvalExecutionTracker } from "../extension/session-manager.ts";
 import type { EvalTimeoutFactory } from "./cell-execution.ts";
 import type { EvalDetachedCellManager } from "./detached-cell-manager.ts";
+import type { EvalExecutionEventPayload } from "./eval-execution-event.ts";
 import type { EvalImageResizer } from "./image.ts";
 import type {
 	EnabledEvalLanguages,
@@ -29,6 +30,7 @@ export interface CreateEvalToolOptions {
 	readonly imageResizer?: EvalImageResizer;
 	readonly executionTracker?: EvalExecutionTracker;
 	readonly cellManager?: EvalDetachedCellManager;
+	readonly onCellSettled?: (payload: EvalExecutionEventPayload) => void;
 	readonly timeoutFactory?: EvalTimeoutFactory;
 	readonly proxyExecutor?: (params: EvalToolInput, signal?: AbortSignal) => Promise<AgentToolResult<EvalToolDetails>>;
 	readonly renderers?: Pick<ToolDefinition<EvalInputSchema, EvalToolDetails>, "renderCall" | "renderResult">;

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -104,6 +104,7 @@ async function runEvalCell(
 		signal: cellSignal,
 		onUpdate: invocation.onUpdate,
 		toolCalls: [],
+		toolCallMetrics: [],
 		pendingBridgeCalls: [],
 		statusEvents: [],
 		active: true,

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -8,6 +8,7 @@ import { abortError, CellExecution, defaultTimeoutFactory } from "./cell-executi
 import { CellHandler, type CellState } from "./cell-handler.ts";
 import { EvalDetachedCellManager } from "./detached-cell-manager.ts";
 import { detachedKernelBusyError, executeEvalControl, resultAfterDetach } from "./detached-eval-result.ts";
+import { buildEvalExecutionEventPayload, type EvalExecutionSettleOutcome } from "./eval-execution-event.ts";
 import { clampEvalSummary, evalTimeoutBehavior, isEvalControlRequest, parseEvalRequest } from "./eval-request.ts";
 import type { CreateEvalToolOptions, EvalCellInvocation } from "./eval-tool-options.ts";
 import { describeTimeoutState } from "./interrupt-note.ts";
@@ -99,6 +100,7 @@ async function runEvalCell(
 	const bridgeContext: ExtensionContext = { ...invocation.ctx, signal: cellSignal };
 	const state: CellState = {
 		input: invocation.input,
+		startedAt: Date.now(),
 		signal: cellSignal,
 		onUpdate: invocation.onUpdate,
 		toolCalls: [],
@@ -107,10 +109,12 @@ async function runEvalCell(
 		active: true,
 		output: "",
 		phase: undefined,
+		error: undefined,
 		durationMs: 0,
 		status: "pending",
 	};
 	const cell = cellManager.create(invocation.cellId, invocation.input);
+	let detached = false;
 	let execution: CellExecution;
 	execution = new CellExecution({
 		callerSignal: invocation.signal,
@@ -119,6 +123,7 @@ async function runEvalCell(
 		timeoutFactory: options.timeoutFactory ?? defaultTimeoutFactory,
 		onTimeout: (error) => {
 			if (timeoutBehavior === "detach" && cellManager.detach(cell)) {
+				detached = true;
 				execution.detach();
 				return;
 			}
@@ -139,13 +144,29 @@ async function runEvalCell(
 		bridgeContext,
 		bridgeAbortController,
 	);
+	let settleEventEmitted = false;
+	const emitSettled = (outcome: EvalExecutionSettleOutcome): void => {
+		if (settleEventEmitted) return;
+		settleEventEmitted = true;
+		options.onCellSettled?.(
+			buildEvalExecutionEventPayload({
+				cellId: invocation.cellId,
+				state,
+				outcome,
+				completedAt: Date.now(),
+				detached,
+			}),
+		);
+	};
 	const finalized = running.then(
 		(result) => {
 			cellManager.complete(cell, result);
+			emitSettled({ result });
 			return result;
 		},
 		(error: unknown) => {
 			cellManager.fail(cell, error instanceof Error ? error : new Error(String(error)));
+			emitSettled({ error });
 			throw error;
 		},
 	);

--- a/packages/senpi-codemode/test/eval-execution-agent-call.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-agent-call.test.ts
@@ -61,6 +61,7 @@ describe("eval execution agent-call metadata", () => {
 			totalDurationMs: expect.any(Number),
 			okCount: 1,
 			errorCount: 0,
+			pendingCount: 0,
 		});
 	});
 });

--- a/packages/senpi-codemode/test/eval-execution-agent-call.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-agent-call.test.ts
@@ -1,0 +1,66 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { describe, expect, it } from "vitest";
+import { RESERVED_AGENT_TOOL } from "../src/bridge/reserved.ts";
+import type { AgentExecuteTool } from "../src/bridges/agent-bridge.ts";
+import type { EvalExecutionEventPayload } from "../src/tool/eval-execution-event.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { ExecuteTool } from "../src/tool/types.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+function textResult(text: string, details: unknown = {}): AgentToolResult<unknown> {
+	return { content: [{ type: "text", text }], details };
+}
+
+function withAvailability(executeTool: ExecuteTool): AgentExecuteTool {
+	return Object.assign(executeTool, { isToolAvailable: (name: string) => name === "task" });
+}
+
+describe("eval execution agent-call metadata", () => {
+	it("captures args and duration for the reserved agent bridge", async () => {
+		const kernel = new FakeKernel([
+			{
+				type: "tool-call",
+				callId: "agent-call-1",
+				toolName: RESERVED_AGENT_TOOL,
+				args: { prompt: "summarize x", agent: "reviewer" },
+			},
+			result("agent-cell", "done"),
+		]);
+		const executeTool = withAvailability(async () =>
+			textResult("FAKE_RESULT", { task_id: "st_agent", status: "completed" }),
+		);
+		const emissions: EvalExecutionEventPayload[] = [];
+		const tool = createEvalTool({
+			enabledLanguages: { py: false, js: true, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", kernel]]),
+			cellTimeoutSeconds: 30,
+			executeTool,
+			onCellSettled: (payload) => emissions.push(payload),
+		});
+
+		await tool.execute(
+			"agent-cell",
+			{ language: "js", code: "await agent('summarize x')", summary: "spawn summarizer" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		expect(emissions).toHaveLength(1);
+		expect(emissions[0]?.toolCalls).toEqual([
+			expect.objectContaining({
+				name: RESERVED_AGENT_TOOL,
+				ok: true,
+				callId: "agent-call-1",
+				args: { prompt: "summarize x", agent: "reviewer" },
+				durationMs: expect.any(Number),
+			}),
+		]);
+		expect(emissions[0]?.toolAggregates[RESERVED_AGENT_TOOL]).toEqual({
+			count: 1,
+			totalDurationMs: expect.any(Number),
+			okCount: 1,
+			errorCount: 0,
+		});
+	});
+});

--- a/packages/senpi-codemode/test/eval-execution-bounds.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-bounds.test.ts
@@ -1,0 +1,49 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { describe, expect, it } from "vitest";
+import type { KernelToHostMessage } from "../src/bridge/protocol.ts";
+import type { EvalExecutionEventPayload } from "../src/tool/eval-execution-event.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+function textResult(): AgentToolResult<unknown> {
+	return { content: [{ type: "text", text: "ok" }], details: {} };
+}
+
+describe("eval execution event bounds", () => {
+	it("caps aggregate names and preserves overflow totals", async () => {
+		const messages: KernelToHostMessage[] = [];
+		for (let index = 0; index < 70; index += 1) {
+			messages.push({
+				type: "tool-call",
+				callId: `call-${index}`,
+				toolName: `${index}-${"x".repeat(200)}`,
+				args: {},
+			});
+		}
+		messages.push(result("bounded-cell", "done"));
+		const emissions: EvalExecutionEventPayload[] = [];
+		const tool = createEvalTool({
+			enabledLanguages: { py: false, js: true, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", new FakeKernel(messages)]]),
+			cellTimeoutSeconds: 30,
+			executeTool: async () => textResult(),
+			onCellSettled: (payload) => emissions.push(payload),
+		});
+
+		await tool.execute(
+			"bounded-cell",
+			{ language: "js", code: "many distinct calls", summary: "bound aggregate names" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		const payload = emissions[0];
+		expect(payload?.toolCallCount).toBe(70);
+		expect(payload?.distinctToolsCalled).toHaveLength(64);
+		expect(Object.keys(payload?.toolAggregates ?? {})).toHaveLength(64);
+		expect(payload?.toolAggregatesTruncated).toBe(true);
+		expect(payload?.toolAggregateOverflow).toMatchObject({ count: 6 });
+		expect(payload?.distinctToolsCalled.every((name) => [...name].length <= 129)).toBe(true);
+	});
+});

--- a/packages/senpi-codemode/test/eval-execution-error-pending.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-error-pending.test.ts
@@ -1,0 +1,47 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { describe, expect, it } from "vitest";
+import type { EvalExecutionEventPayload } from "../src/tool/eval-execution-event.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { errorResult, FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+describe("eval execution pending-call accounting", () => {
+	it("counts an initiated bridge call when an error cell settles before the call", async () => {
+		const kernel = new FakeKernel([
+			{ type: "tool-call", callId: "pending-read", toolName: "read", args: { path: "slow.txt" } },
+			errorResult("error-cell", "cell failed first"),
+		]);
+		const pending = new Promise<AgentToolResult<unknown>>(() => {});
+		const emissions: EvalExecutionEventPayload[] = [];
+		const tool = createEvalTool({
+			enabledLanguages: { py: false, js: true, rb: false, jl: false },
+			kernelManager: new FakeManager([["js", kernel]]),
+			cellTimeoutSeconds: 30,
+			executeTool: async () => await pending,
+			onCellSettled: (payload) => emissions.push(payload),
+		});
+
+		await tool.execute(
+			"error-cell",
+			{ language: "js", code: "tool.read({ path: 'slow.txt' })", summary: "pending bridge" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		expect(emissions).toHaveLength(1);
+		expect(emissions[0]).toMatchObject({
+			ok: false,
+			toolCallCount: 1,
+			pendingToolCallCount: 1,
+			toolAggregates: {
+				read: {
+					count: 1,
+					totalDurationMs: expect.any(Number),
+					okCount: 0,
+					errorCount: 0,
+					pendingCount: 1,
+				},
+			},
+		});
+	});
+});

--- a/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
@@ -1,0 +1,117 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CodemodeSessionManager } from "../src/extension/session-manager.ts";
+import senpiCodemode, { type CodemodeExtensionAPI } from "../src/index.ts";
+import { EVAL_EXECUTION_EVENT } from "../src/tool/eval-execution-event.ts";
+import type { EvalKernel } from "../src/tool/types.ts";
+import { FakeKernel, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+const directories: string[] = [];
+const artifactsRoot = join(tmpdir(), `senpi-codemode-eval-execution-${process.pid}`);
+
+afterEach(async () => {
+	await Promise.all(directories.splice(0).map(async (path) => await rm(path, { recursive: true, force: true })));
+	await rm(artifactsRoot, { recursive: true, force: true });
+});
+
+interface BusEmission {
+	readonly name: string;
+	readonly data: unknown;
+}
+
+class WiringPi {
+	readonly handlers: Array<{
+		readonly event: string;
+		readonly handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void;
+	}> = [];
+	registeredTool: Parameters<CodemodeExtensionAPI["registerTool"]>[0] | undefined;
+	events?: { emit(name: string, data: unknown): void };
+	rpc?: { emit(name: string, data: unknown): void };
+
+	registerTool(tool: Parameters<CodemodeExtensionAPI["registerTool"]>[0]): void {
+		if (tool.name === "eval") this.registeredTool = tool;
+	}
+	registerRemovedToolHint(): void {}
+	on(event: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void {
+		this.handlers.push({ event, handler });
+	}
+	getActiveTools(): string[] {
+		return ["eval"];
+	}
+	getAllTools(): readonly { readonly name: string }[] {
+		return [{ name: "eval" }];
+	}
+	async executeTool(): Promise<never> {
+		throw new Error("nested tool execution was not expected");
+	}
+	sendUserMessage(): void {}
+	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
+		for (const entry of this.handlers.filter((handler) => handler.event === event)) await entry.handler(payload, ctx);
+	}
+}
+
+class WiringSessionManager implements CodemodeSessionManager {
+	readonly kernel: EvalKernel;
+	constructor(kernel: EvalKernel) {
+		this.kernel = kernel;
+	}
+	async getKernel(): Promise<EvalKernel> {
+		return this.kernel;
+	}
+	async dispose(): Promise<void> {}
+	async complete(): Promise<{
+		readonly text: string;
+		readonly details: { readonly model: string; readonly structured: false };
+	}> {
+		return { text: "ok", details: { model: "fake/fake-model", structured: false } };
+	}
+}
+
+async function sessionCwd(): Promise<string> {
+	const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-eval-execution-"));
+	directories.push(cwd);
+	await mkdir(join(cwd, ".senpi"), { recursive: true });
+	await writeFile(
+		join(cwd, ".senpi", "codemode.json"),
+		JSON.stringify({ languages: { py: false, js: true, rb: false, jl: false }, cellTimeoutSeconds: 1 }),
+	);
+	return cwd;
+}
+
+function wiringContext(cwd: string): ExtensionContext {
+	const base = fakeExtensionContext();
+	const sessionManager = Object.create(null);
+	sessionManager.getSessionFile = (): string => join(artifactsRoot, `${crypto.randomUUID()}.jsonl`);
+	return { ...base, cwd, sessionManager };
+}
+
+describe("eval execution host wiring", () => {
+	it("publishes each session-scoped settle payload to both rpc and the extension event bus", async () => {
+		const cwd = await sessionCwd();
+		const pi = new WiringPi();
+		const rpcEmissions: BusEmission[] = [];
+		const busEmissions: BusEmission[] = [];
+		pi.rpc = { emit: (name, data) => rpcEmissions.push({ name, data }) };
+		pi.events = { emit: (name, data) => busEmissions.push({ name, data }) };
+		const kernel = new FakeKernel([result("wired-cell", "42", 17)]);
+		senpiCodemode(pi, { createSessionManager: () => new WiringSessionManager(kernel) });
+		const ctx = wiringContext(cwd);
+		await pi.emit("session_start", { reason: "startup" }, ctx);
+		const tool = pi.registeredTool;
+		if (tool === undefined) throw new Error("eval tool was not registered");
+
+		await tool.execute("wired-cell", { language: "js", code: "42", summary: "wired" }, undefined, undefined, ctx);
+
+		expect(rpcEmissions).toEqual([
+			{ name: EVAL_EXECUTION_EVENT, data: expect.objectContaining({ cellId: "wired-cell", durationMs: 17 }) },
+		]);
+		expect(busEmissions).toContainEqual({
+			name: EVAL_EXECUTION_EVENT,
+			data: expect.objectContaining({ cellId: "wired-cell", durationMs: 17 }),
+		});
+		await pi.emit("session_shutdown", {}, ctx);
+	});
+});

--- a/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
@@ -1,12 +1,12 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ExtensionContext } from "@code-yeongyu/senpi";
+import type { AgentToolResult, ExtensionContext } from "@code-yeongyu/senpi";
 import { afterEach, describe, expect, it } from "vitest";
+import type { KernelToHostMessage } from "../src/bridge/protocol.ts";
 import type { CodemodeSessionManager } from "../src/extension/session-manager.ts";
 import senpiCodemode, { type CodemodeExtensionAPI } from "../src/index.ts";
 import { EVAL_EXECUTION_EVENT } from "../src/tool/eval-execution-event.ts";
-import type { EvalKernel } from "../src/tool/types.ts";
 import { FakeKernel, fakeExtensionContext, result } from "./eval/fakes.ts";
 
 const directories: string[] = [];
@@ -44,8 +44,11 @@ class WiringPi {
 	getAllTools(): readonly { readonly name: string }[] {
 		return [{ name: "eval" }];
 	}
-	async executeTool(): Promise<never> {
-		throw new Error("nested tool execution was not expected");
+	async executeTool(): Promise<AgentToolResult<unknown>> {
+		return {
+			content: [{ type: "text", text: "PRIVATE RESULT" }],
+			details: {},
+		};
 	}
 	sendUserMessage(): void {}
 	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
@@ -54,11 +57,12 @@ class WiringPi {
 }
 
 class WiringSessionManager implements CodemodeSessionManager {
-	readonly kernel: EvalKernel;
-	constructor(kernel: EvalKernel) {
+	readonly kernel: FakeKernel;
+	constructor(kernel: FakeKernel) {
 		this.kernel = kernel;
 	}
-	async getKernel(): Promise<EvalKernel> {
+	async getKernel(_language: string, onMessage: (message: KernelToHostMessage) => void): Promise<FakeKernel> {
+		this.kernel.onMessage = onMessage;
 		return this.kernel;
 	}
 	async dispose(): Promise<void> {}
@@ -96,7 +100,15 @@ describe("eval execution host wiring", () => {
 		const busEmissions: BusEmission[] = [];
 		pi.rpc = { emit: (name, data) => rpcEmissions.push({ name, data }) };
 		pi.events = { emit: (name, data) => busEmissions.push({ name, data }) };
-		const kernel = new FakeKernel([result("wired-cell", "42", 17)]);
+		const kernel = new FakeKernel([
+			{
+				type: "tool-call",
+				callId: "sensitive-read",
+				toolName: "read",
+				args: { path: "secret.txt", prompt: "PRIVATE PROMPT" },
+			},
+			result("wired-cell", "42", 17),
+		]);
 		senpiCodemode(pi, { createSessionManager: () => new WiringSessionManager(kernel) });
 		const ctx = wiringContext(cwd);
 		await pi.emit("session_start", { reason: "startup" }, ctx);
@@ -106,11 +118,34 @@ describe("eval execution host wiring", () => {
 		await tool.execute("wired-cell", { language: "js", code: "42", summary: "wired" }, undefined, undefined, ctx);
 
 		expect(rpcEmissions).toEqual([
-			{ name: EVAL_EXECUTION_EVENT, data: expect.objectContaining({ cellId: "wired-cell", durationMs: 17 }) },
+			{
+				name: EVAL_EXECUTION_EVENT,
+				data: expect.objectContaining({
+					cellId: "wired-cell",
+					detailLevel: "metadata",
+					toolCalls: [{ name: "read", ok: true, durationMs: expect.any(Number) }],
+				}),
+			},
 		]);
+		expect(rpcEmissions[0]?.data).not.toEqual(
+			expect.objectContaining({
+				error: expect.anything(),
+				toolCalls: [expect.objectContaining({ args: expect.anything() })],
+			}),
+		);
 		expect(busEmissions).toContainEqual({
 			name: EVAL_EXECUTION_EVENT,
-			data: expect.objectContaining({ cellId: "wired-cell", durationMs: 17 }),
+			data: expect.objectContaining({
+				cellId: "wired-cell",
+				detailLevel: "full",
+				toolCalls: [
+					expect.objectContaining({
+						callId: "sensitive-read",
+						args: { path: "secret.txt", prompt: "PRIVATE PROMPT" },
+						resultPreview: "PRIVATE RESULT",
+					}),
+				],
+			}),
 		});
 		await pi.emit("session_shutdown", {}, ctx);
 	});

--- a/packages/senpi-codemode/test/eval-execution-event.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-event.test.ts
@@ -1,0 +1,250 @@
+import type { AgentToolResult, ExtensionContext } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { KernelToHostMessage } from "../src/bridge/protocol.ts";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { EVAL_EXECUTION_EVENT, type EvalExecutionEventPayload } from "../src/tool/eval-execution-event.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { ExecuteTool } from "../src/tool/types.ts";
+import { Deferred, errorResult, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+type SerialResultMessage = Extract<KernelToHostMessage, { type: "result" }>;
+
+class SerialFakeKernel extends FakeKernel {
+	readonly #serialMessages: KernelToHostMessage[];
+	constructor(messages: KernelToHostMessage[]) {
+		super(messages);
+		this.#serialMessages = messages;
+	}
+	/** Emits tool-calls one at a time, waiting for each host reply — deterministic per-call wall-clock durations. */
+	async run(input: { cellId: string; code: string; timeoutMs?: number }): Promise<SerialResultMessage> {
+		this.runs.push(input);
+		for (const message of this.#serialMessages) {
+			if (message.type !== "tool-call") continue;
+			const repliesBefore = this.replies.length;
+			this.onMessage?.(message);
+			while (this.replies.length === repliesBefore) await Promise.resolve();
+		}
+		const settled = this.#serialMessages.find((message): message is SerialResultMessage => message.type === "result");
+		if (!settled) throw new Error("fake kernel missing result");
+		return settled;
+	}
+}
+
+function textResult(text: string): AgentToolResult<unknown> {
+	return { content: [{ type: "text", text }], details: {} };
+}
+
+function createTool(
+	kernel: FakeKernel,
+	executeTool: ExecuteTool = vi.fn(async () => textResult("ok")),
+	onCellSettled?: (payload: EvalExecutionEventPayload) => void,
+	cellManager?: EvalDetachedCellManager,
+) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager: new FakeManager([["js", kernel]]),
+		cellTimeoutSeconds: 1,
+		executeTool,
+		...(onCellSettled === undefined ? {} : { onCellSettled }),
+		...(cellManager === undefined ? {} : { cellManager }),
+	});
+}
+
+function interactiveContext(): ExtensionContext {
+	return { ...fakeExtensionContext(), mode: "tui" };
+}
+
+describe("eval execution event contract", () => {
+	it("pins the exact event literal", () => {
+		expect(EVAL_EXECUTION_EVENT).toBe("senpi.eval.execution");
+	});
+
+	it("builds the full successful payload and exact aggregates from nested tool calls", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000);
+		const kernel = new SerialFakeKernel([
+			{ type: "tool-call", callId: "read-1", toolName: "read", args: { path: "/tmp/a" } },
+			{ type: "tool-call", callId: "bash-1", toolName: "bash", args: { command: "true" } },
+			result("successful-cell", "done", 99),
+		]);
+		const executeTool: ExecuteTool = vi.fn(async (name) => {
+			vi.setSystemTime(Date.now() + (name === "read" ? 11 : 7));
+			return textResult(`${name} result`);
+		});
+		const emissions: EvalExecutionEventPayload[] = [];
+
+		await createTool(kernel, executeTool, (payload) => emissions.push(payload)).execute(
+			"successful-cell",
+			{ language: "js", code: "await Promise.all([tool.read({}), tool.bash({})])", summary: "two calls" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		expect(emissions).toHaveLength(1);
+		expect(emissions[0]).toEqual({
+			version: 1,
+			cellId: "successful-cell",
+			language: "js",
+			ok: true,
+			startedAt: 1_000,
+			completedAt: 1_018,
+			durationMs: 99,
+			detached: false,
+			toolCallCount: 2,
+			toolCalls: [
+				{
+					name: "read",
+					ok: true,
+					callId: "read-1",
+					args: { path: "/tmp/a" },
+					durationMs: 11,
+					resultPreview: "read result",
+				},
+				{
+					name: "bash",
+					ok: true,
+					callId: "bash-1",
+					args: { command: "true" },
+					durationMs: 7,
+					resultPreview: "bash result",
+				},
+			],
+			distinctToolsCalled: ["read", "bash"],
+			toolAggregates: {
+				read: { count: 1, totalDurationMs: 11, okCount: 1, errorCount: 0 },
+				bash: { count: 1, totalDurationMs: 7, okCount: 1, errorCount: 0 },
+			},
+		});
+	});
+
+	it("emits one bounded error payload when the cell settles with an error", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(2_000);
+		const longError = "x".repeat(600);
+		const emissions: EvalExecutionEventPayload[] = [];
+
+		await createTool(new FakeKernel([errorResult("error-cell", longError)]), undefined, (payload) =>
+			emissions.push(payload),
+		).execute(
+			"error-cell",
+			{ language: "js", code: "throw new Error()", summary: "error" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		expect(emissions).toHaveLength(1);
+		expect(emissions[0]).toMatchObject({
+			version: 1,
+			cellId: "error-cell",
+			language: "js",
+			ok: false,
+			startedAt: 2_000,
+			completedAt: 2_000,
+			durationMs: 5,
+			detached: false,
+			toolCallCount: 0,
+			toolCalls: [],
+			distinctToolsCalled: [],
+			toolAggregates: {},
+		});
+		expect(emissions[0]?.error).toBe(`${"x".repeat(512)}…`);
+	});
+
+	it("is a no-op when onCellSettled is absent", async () => {
+		const settledNoCallback = await createTool(new FakeKernel([result("callbackless-cell", "ok")])).execute(
+			"callbackless-cell",
+			{ language: "js", code: "1", summary: "no callback" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+		expect(settledNoCallback.details.isError).toBeUndefined();
+	});
+
+	it("keeps all forty calls in counts and aggregates while capping enriched payload calls at thirty", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(3_000);
+		const messages: KernelToHostMessage[] = [];
+		for (let index = 0; index < 40; index += 1) {
+			messages.push({
+				type: "tool-call",
+				callId: `call-${index}`,
+				toolName: index % 2 === 0 ? "read" : "bash",
+				args: { index, text: "z".repeat(600) },
+			});
+		}
+		messages.push(result("forty-cell", "done", 80));
+		const executeTool: ExecuteTool = vi.fn(async () => {
+			vi.setSystemTime(Date.now() + 2);
+			return textResult("ok");
+		});
+		const emissions: EvalExecutionEventPayload[] = [];
+
+		await createTool(new SerialFakeKernel(messages), executeTool, (payload) => emissions.push(payload)).execute(
+			"forty-cell",
+			{ language: "js", code: "many calls", summary: "forty calls" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		const payload = emissions[0];
+		expect(payload).toBeDefined();
+		expect(payload?.toolCallCount).toBe(40);
+		expect(payload?.distinctToolsCalled).toEqual(["read", "bash"]);
+		expect(payload?.toolCalls).toHaveLength(30);
+		expect(payload?.toolCalls.every((call) => call.args !== undefined && call.argsTruncated === true)).toBe(true);
+		expect(payload?.toolCalls.every((call) => call.durationMs === 2)).toBe(true);
+		expect(payload?.toolAggregates).toEqual({
+			read: { count: 20, totalDurationMs: 40, okCount: 20, errorCount: 0 },
+			bash: { count: 20, totalDurationMs: 40, okCount: 20, errorCount: 0 },
+		});
+		expect(Object.values(payload?.toolAggregates ?? {}).reduce((sum, item) => sum + item.totalDurationMs, 0)).toBe(
+			80,
+		);
+	});
+
+	it("emits exactly once after a detached cell reaches terminal settlement", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(4_000);
+		const kernel = new FakeKernel([]);
+		const manager = new EvalDetachedCellManager();
+		const emissions: EvalExecutionEventPayload[] = [];
+		const settled = new Deferred<EvalExecutionEventPayload>();
+		const tool = createTool(
+			kernel,
+			undefined,
+			(payload) => {
+				emissions.push(payload);
+				settled.resolve(payload);
+			},
+			manager,
+		);
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"detached-cell",
+			{ language: "js", code: "await forever", summary: "detach", on_timeout: "detach" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+		expect(emissions).toEqual([]);
+
+		kernel.completeDeferredRun(result("detached-cell", "done", 73));
+		const payload = await settled.promise;
+
+		expect(payload).toMatchObject({ cellId: "detached-cell", ok: true, detached: true, durationMs: 73 });
+		expect(emissions).toHaveLength(1);
+		await manager.flushNotifications();
+	});
+});

--- a/packages/senpi-codemode/test/eval-execution-event.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-event.test.ts
@@ -89,14 +89,17 @@ describe("eval execution event contract", () => {
 		expect(emissions).toHaveLength(1);
 		expect(emissions[0]).toEqual({
 			version: 1,
+			detailLevel: "full",
 			cellId: "successful-cell",
 			language: "js",
 			ok: true,
 			startedAt: 1_000,
 			completedAt: 1_018,
-			durationMs: 99,
+			durationMs: 18,
+			kernelDurationMs: 99,
 			detached: false,
 			toolCallCount: 2,
+			pendingToolCallCount: 0,
 			toolCalls: [
 				{
 					name: "read",
@@ -117,9 +120,10 @@ describe("eval execution event contract", () => {
 			],
 			distinctToolsCalled: ["read", "bash"],
 			toolAggregates: {
-				read: { count: 1, totalDurationMs: 11, okCount: 1, errorCount: 0 },
-				bash: { count: 1, totalDurationMs: 7, okCount: 1, errorCount: 0 },
+				read: { count: 1, totalDurationMs: 11, okCount: 1, errorCount: 0, pendingCount: 0 },
+				bash: { count: 1, totalDurationMs: 7, okCount: 1, errorCount: 0, pendingCount: 0 },
 			},
+			toolAggregatesTruncated: false,
 		});
 	});
 
@@ -142,14 +146,17 @@ describe("eval execution event contract", () => {
 		expect(emissions).toHaveLength(1);
 		expect(emissions[0]).toMatchObject({
 			version: 1,
+			detailLevel: "full",
 			cellId: "error-cell",
 			language: "js",
 			ok: false,
 			startedAt: 2_000,
 			completedAt: 2_000,
-			durationMs: 5,
+			durationMs: 0,
+			kernelDurationMs: 5,
 			detached: false,
 			toolCallCount: 0,
+			pendingToolCallCount: 0,
 			toolCalls: [],
 			distinctToolsCalled: [],
 			toolAggregates: {},
@@ -203,8 +210,8 @@ describe("eval execution event contract", () => {
 		expect(payload?.toolCalls.every((call) => call.args !== undefined && call.argsTruncated === true)).toBe(true);
 		expect(payload?.toolCalls.every((call) => call.durationMs === 2)).toBe(true);
 		expect(payload?.toolAggregates).toEqual({
-			read: { count: 20, totalDurationMs: 40, okCount: 20, errorCount: 0 },
-			bash: { count: 20, totalDurationMs: 40, okCount: 20, errorCount: 0 },
+			read: { count: 20, totalDurationMs: 40, okCount: 20, errorCount: 0, pendingCount: 0 },
+			bash: { count: 20, totalDurationMs: 40, okCount: 20, errorCount: 0, pendingCount: 0 },
 		});
 		expect(Object.values(payload?.toolAggregates ?? {}).reduce((sum, item) => sum + item.totalDurationMs, 0)).toBe(
 			80,
@@ -243,7 +250,13 @@ describe("eval execution event contract", () => {
 		kernel.completeDeferredRun(result("detached-cell", "done", 73));
 		const payload = await settled.promise;
 
-		expect(payload).toMatchObject({ cellId: "detached-cell", ok: true, detached: true, durationMs: 73 });
+		expect(payload).toMatchObject({
+			cellId: "detached-cell",
+			ok: true,
+			detached: true,
+			durationMs: 1_000,
+			kernelDurationMs: 73,
+		});
 		expect(emissions).toHaveLength(1);
 		await manager.flushNotifications();
 	});

--- a/packages/senpi-codemode/test/eval-tool-call-capture.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-call-capture.test.ts
@@ -148,7 +148,11 @@ describe("eval tool-call capture", () => {
 						summary.resultPreview === "ok",
 				),
 		).toBe(true);
-		expect(toolResult.details.toolCalls[30]).toEqual({ name: "read", ok: true });
+		expect(toolResult.details.toolCalls[30]).toMatchObject({
+			name: "read",
+			ok: true,
+			durationMs: expect.any(Number),
+		});
 	});
 
 	it("capture: streams an enriched summary before finalization", async () => {

--- a/packages/senpi-codemode/test/eval-wake-source.test.ts
+++ b/packages/senpi-codemode/test/eval-wake-source.test.ts
@@ -268,7 +268,7 @@ describe("wake source liveness wiring", () => {
 
 		kernel.completeDeferredRun(result("wire-cell", "42"));
 		await vi.waitFor(() =>
-			expect(busEmissions.at(-1)).toEqual({
+			expect(busEmissions.filter((emission) => emission.name === "wake_source_state").at(-1)).toEqual({
 				name: "wake_source_state",
 				data: { source: "senpi-codemode", activeCount: 0, items: [] },
 			}),


### PR DESCRIPTION
## Summary
- Publish one lightweight, rich, versioned event per settled `eval` cell so downstream consumers (omo analytics, omo-desktop-app timelines) can measure whether eval-based parallel tool calling actually reduces wall-clock time and later render per-tool invocations.
- New namespaced `senpi.eval.execution` event emitted exactly once per settled cell (attached / error / detached paths) through both `pi.rpc?.emit` (RPC `extension_event` forwarding + app-server) and `pi.events?.emit` (in-process bus), optional-chained and generation-safe.
- The in-process bus receives bounded rich call metadata; RPC receives a metadata-only projection with no prompts, arguments, call IDs, errors, or result previews, plus a final 32 KiB serialized-byte ceiling.
- Payload includes true end-to-end wall time, kernel runtime, exact initiated-call and pending-call counts, capped per-name aggregates with an exact overflow bucket, and a 30-entry per-call list.

## Consumer contract
- additive-only v1 envelope; OMO can subscribe in-process for rich details or over RPC for analytics metadata. omo-desktop-app currently decodes and ignores unknown extension events; rich desktop rendering requires a future adapter/projection with explicit content consent.

## Evidence
- Unit RED->GREEN: local-ignore/qa-evidence/20260816-eval-execution-event/unit-{red,green}.txt
- Review-fix RED: local-ignore/qa-evidence/20260816-eval-execution-event/review-red.txt
- Real-RPC QA: local-ignore/qa-evidence/20260816-eval-execution-event/ (scenario + JSONL)

## Testing
- focused contract/wiring/agent/pending/bounds tests: 10 passed
- full senpi-codemode package suite: 545 passed, 6 skipped; root npm run check rc=0
- coding-agent RPC/app-server forwarding tests: 12 passed
- real-CLI RPC QA: 21/21 passed with metadata redaction and cleanup receipts

Closes #896
