### PR TITLE
feat(coding-agent): support JSONC settings sources

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Settings files now support dependency-free JSONC comments and trailing commas. When both `settings.jsonc` and `settings.json` exist in one config directory, JSONC wins; writes remain on the loaded file, config reload watches both formats, RPC emits `settings_source_selected` with the selected path/format/reason, and the interactive TUI shows the choice at startup or reload.
 - GLM 5.3 prompt preset: a new `glm-5.3` system-prompt preset cloned from `glm-5.2` (thin `tuningSection` wrapper over the shared dynamic core, `workstationDialect: "claude"`). The `hasGlm53Signal`/`isGlm53Model` matcher is checked before the 5.2 matcher, `"glm-5.3"` joins `PromptPresetName`/`VALID_PRESETS`, and the settings.md value list is updated. Models selecting GLM 5.3 now get the tuned system prompt instead of the untuned fallback ([#895](https://github.com/code-yeongyu/senpi/pull/895)).
 
 ### Fixed

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,24 @@
 # Local fork changes
 
+## 2026-08-16 — Dual JSONC/JSON settings coverage
+
+### What changed
+
+- Added deterministic settings-manager coverage for JSONC comments/trailing commas, JSONC-over-JSON precedence, JSON-only compatibility, write-target preservation, and reload reselection.
+- Added real connection-handler coverage for the `settings_source_selected` RPC record, focused interactive notice coverage, and config-reload coverage for valid JSONC edits.
+
+### Why this lives in the fork
+
+- The fork owns the source-selection event and interactive/config-reload integration around the upstream-derived settings manager.
+
+### Why an extension could not do this
+
+- The tests pin pre-extension settings parsing, persistence, host event delivery, and built-in reload behavior.
+
+### Expected merge-conflict zones
+
+- `test/settings-manager.test.ts`, `test/suite/harness.ts`, and `test/suite/config-reload-extension.test.ts`; the two focused source-event tests are additive files.
+
 ## 2026-08-14 — RPC stream regression suites for multi-session compaction
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## JSONC settings selection and source events (2026-08-16)
+
+### What changed
+
+- Settings loading now accepts dependency-free JSONC syntax (line/block comments outside strings and trailing commas) in both `settings.jsonc` and existing settings content.
+- Each global/project config directory prefers `settings.jsonc` over `settings.json`; the selected path remains the write target until the next explicit reload selection.
+- `AgentSessionEvent` gained `settings_source_selected` with `{ path, format, reason, scope }`. Current selections replay once to newly attached host listeners, and reload selections publish through the normal session emitter.
+- The config-reload builtin watches and validates both settings filenames with the same parser.
+
+### Why
+
+- Users need commented settings without losing plain-JSON compatibility, deterministic precedence, or having a UI write silently create the other file flavor.
+- RPC and interactive hosts need an authoritative source decision instead of inferring it from filesystem state.
+
+### Why an extension could not do this
+
+- Settings path selection, parse-before-runtime, merge-before-write, and session listener attachment all occur in core before an extension can replace them. The built-in config watcher also owns reload admission and validation.
+
+### Expected merge conflict zones
+
+- HIGH: `core/settings-manager.ts` around path resolution, storage locking, load/reload, and merge-before-write parsing.
+- MEDIUM: `core/agent-session.ts` event union, subscription replay, and disposal.
+- LOW: additive host handling under `modes/rpc/` and `modes/interactive/`, plus config-reload filename allowlists/validation.
+
 ## Unified lockfile staleness policy across auth and settings storage (2026-08-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -162,7 +162,7 @@ import {
 } from "./session-manager.ts";
 import { generateSessionTitle, sessionTitleRetryPolicy, shouldSkipSessionTitle } from "./session-title-generator.ts";
 import { SessionWorkBarrier } from "./session-work-barrier.ts";
-import type { SettingsManager } from "./settings-manager.ts";
+import type { SettingsManager, SettingsSourceSelection } from "./settings-manager.ts";
 import type { SlashCommandInfo } from "./slash-commands.ts";
 import { createSyntheticSourceInfo, type SourceInfo } from "./source-info.ts";
 import { getSupportedThinkingLevels, supportsMax, supportsXhigh } from "./thinking-levels.ts";
@@ -268,6 +268,7 @@ export type AgentSessionEvent =
 	| SystemPromptChangeEvent
 	| { type: "thinking_level_changed"; level: ThinkingLevel }
 	| { type: "high_reasoning_warning"; modelId: string; provider: string; thinkingLevel: ThinkingLevel }
+	| ({ type: "settings_source_selected" } & SettingsSourceSelection)
 	/** Active model changed; `thinkingLevel` is the level in force AFTER the switch. */
 	| { type: "model_changed"; model: Model<any>; thinkingLevel: ThinkingLevel; source: ModelSelectSource }
 	/** Effective service tier or fast-mode state changed. */
@@ -632,6 +633,7 @@ export class AgentSession {
 
 	// Event subscription state
 	private _unsubscribeAgent?: () => void;
+	private _unsubscribeSettingsSource?: () => void;
 	private _eventListeners: AgentSessionEventListener[] = [];
 	private _agentEventQueue: Promise<void> = Promise.resolve();
 	/**
@@ -770,6 +772,9 @@ export class AgentSession {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
 		this.settingsManager = config.settingsManager;
+		this._unsubscribeSettingsSource = this.settingsManager.subscribeToSourceSelection((source) => {
+			this._emit({ type: "settings_source_selected", ...source });
+		});
 		const noModelFallback =
 			config.resourceLoader.getExtensions().runtime.flagValues.get("no-model-fallback") === true ||
 			envValue("NO_FALLBACK") === "1";
@@ -2184,6 +2189,9 @@ export class AgentSession {
 	 */
 	subscribe(listener: AgentSessionEventListener): () => void {
 		this._eventListeners.push(listener);
+		for (const source of this.settingsManager.getSelectedSettingsSources()) {
+			listener({ type: "settings_source_selected", ...source });
+		}
 
 		// Return unsubscribe function for this specific listener
 		return () => {
@@ -2236,6 +2244,8 @@ export class AgentSession {
 			"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload(). For newSession, fork, and switchSession, move post-replacement work into withSession and use the ctx passed to withSession. For reload, do not use the old ctx after await ctx.reload().",
 		);
 		this._disconnectFromAgent();
+		this._unsubscribeSettingsSource?.();
+		this._unsubscribeSettingsSource = undefined;
 		this._eventListeners = [];
 		cleanupSessionResources(this.sessionId);
 	}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## JSONC settings parser, precedence, and write ownership (2026-08-16)
+
+### What changed
+
+- `settings-manager.ts` now strips line/block comments only outside quoted strings, removes trailing commas before object/array closers, and delegates final validation to `JSON.parse`; no dependency was added.
+- File storage selects `settings.jsonc` before `settings.json`, retains that selected path for writes, and reselects only at create/reload/project-trust load boundaries.
+- Selected-source metadata includes path, format, reason, and scope; `AgentSession` forwards reload decisions and replays startup decisions once to each host subscriber.
+
+### Why
+
+- A per-write filesystem probe could redirect a session to another flavor after load, while JSON-only parsing prevented maintainable commented settings. Selection boundaries make precedence and write ownership explicit.
+
+### Why an extension could not do this
+
+- Parsing and locking happen before extensions load, and the session emitter is the shared transport boundary used by RPC and TUI hosts.
+
+### Expected merge conflict zones
+
+- HIGH: `settings-manager.ts` path/storage/load/save sections.
+- MEDIUM: `agent-session.ts` event and subscription lifecycle.
+
 ## Model and service-tier session events (2026-08-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,5 +1,24 @@
 # config-reload Extension Changes
 
+## Watch and validate JSONC settings (2026-08-16)
+
+### What changed
+
+- Built-in global/project settings watches now admit both `settings.jsonc` and `settings.json`.
+- Validation and routine-change classification use the shared dependency-free settings parser, and content snapshots cover both filenames.
+
+### Why
+
+- Loading JSONC without watching it would make automatic reload behavior depend on the file extension and leave valid JSONC edits inert.
+
+### Why an extension could not handle it
+
+- This builtin owns the protected config watch targets, self-write suppression, validation, and reload handoff.
+
+### Expected merge conflict zones
+
+- LOW: settings filename allowlists and validator in `index.ts`; settings path/snapshot parsing in `routine-settings.ts`.
+
 ## Treat durable last-on reasoning memory as a routine setting (2026-08-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -4,7 +4,7 @@ import { bindToProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 import { CONFIG_DIR_NAME, getAgentDir } from "../../../../config.ts";
 import { resolvePath } from "../../../../utils/paths.ts";
 import { ModelConfig } from "../../../model-config.ts";
-import { type Settings, SettingsManager, wasSelfWrite } from "../../../settings-manager.ts";
+import { parseSettingsJson, type Settings, SettingsManager, wasSelfWrite } from "../../../settings-manager.ts";
 import type { ExtensionAPI, ExtensionContext, SessionStartEvent } from "../../types.ts";
 import { isLoadableExtensionEntry, isScannableExtensionDirectory } from "./extension-watch-scope.ts";
 import { excludeGeneratedExtensionShims } from "./generated-shim-filter.ts";
@@ -44,7 +44,7 @@ const BUILTIN_REGISTRATION_ID = "builtin";
 const DEFAULT_DEBOUNCE_MS = 200;
 const COMPACTION_RECHECK_MS = 250;
 const VETO_RECHECK_MS = 1000;
-const CONFIG_FILE_NAMES = ["settings.json", "models.json", "keybindings.json"] as const;
+const CONFIG_FILE_NAMES = ["settings.jsonc", "settings.json", "models.json", "keybindings.json"] as const;
 
 /**
  * The engine applies one predicate to both file gating and directory descent, so
@@ -613,7 +613,7 @@ function buildWatchTargets(options: {
 	const projectDir = joinConfigDir(cwd);
 
 	const jsonAllowList = CONFIG_FILE_NAMES.filter((name) => {
-		if (name === "settings.json") return settings.watch.settings;
+		if (name === "settings.json" || name === "settings.jsonc") return settings.watch.settings;
 		if (name === "models.json") return settings.watch.models;
 		return settings.watch.keybindings;
 	});
@@ -653,7 +653,7 @@ function buildWatchTargets(options: {
 				addBuiltin("builtin-project-settings", {
 					kind: "dir",
 					path: projectDir,
-					allowList: ["settings.json"],
+					allowList: ["settings.jsonc", "settings.json"],
 				});
 			}
 			if (settings.watch.prompts) {
@@ -849,13 +849,12 @@ function validateBuiltinPaths(paths: readonly string[], agentDir: string, cwd: s
 function validateSettingsFile(path: string): string | undefined {
 	if (!existsSync(path)) return undefined;
 	try {
-		const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
-		if (!isPlainObject(parsed)) return "settings.json must contain an object";
+		const parsed = parseSettingsJson(readFileSync(path, "utf-8"));
 		// Keep validation aligned with SettingsManager's loader and migrations without duplicating migration rules.
 		SettingsManager.inMemory(parsed as Partial<Settings>);
 		return undefined;
 	} catch (error) {
-		return `Invalid settings.json: ${errorMessage(error)}`;
+		return `Invalid ${basename(path)}: ${errorMessage(error)}`;
 	}
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/routine-settings.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { CONFIG_DIR_NAME } from "../../../../config.ts";
+import { parseSettingsJson } from "../../../settings-manager.ts";
 import type { ConfigReloadLogger } from "./log.ts";
 
 /**
@@ -26,9 +27,9 @@ export function joinConfigDir(cwd: string): string {
 }
 
 export function isSettingsPath(path: string, agentDir: string, cwd: string): boolean {
-	return (
-		resolve(path) === resolve(agentDir, "settings.json") ||
-		resolve(path) === resolve(joinConfigDir(cwd), "settings.json")
+	const resolvedPath = resolve(path);
+	return ["settings.jsonc", "settings.json"].some(
+		(name) => resolvedPath === resolve(agentDir, name) || resolvedPath === resolve(joinConfigDir(cwd), name),
 	);
 }
 
@@ -47,14 +48,15 @@ export function updateSettingsContentSnapshot(contents: Map<string, string>, pat
 
 export function refreshSettingsContentSnapshots(contents: Map<string, string>, agentDir: string, cwd: string): void {
 	contents.clear();
-	updateSettingsContentSnapshot(contents, resolve(agentDir, "settings.json"));
-	updateSettingsContentSnapshot(contents, resolve(joinConfigDir(cwd), "settings.json"));
+	for (const name of ["settings.jsonc", "settings.json"]) {
+		updateSettingsContentSnapshot(contents, resolve(agentDir, name));
+		updateSettingsContentSnapshot(contents, resolve(joinConfigDir(cwd), name));
+	}
 }
 
 function parseSettingsObject(content: string): Record<string, unknown> | undefined {
 	try {
-		const parsed: unknown = JSON.parse(content);
-		return isPlainObject(parsed) ? parsed : undefined;
+		return parseSettingsJson(content);
 	} catch {
 		return undefined;
 	}
@@ -107,10 +109,4 @@ export function excludeRoutineOnlySettingsChanges(
 		logger.debug("routine_settings_change_suppressed", { path });
 		return false;
 	});
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	const prototype = Object.getPrototypeOf(value);
-	return prototype === Object.prototype || prototype === null;
 }

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -278,6 +278,95 @@ function parseTimeoutSetting(value: unknown, settingName: string): number | unde
 }
 
 export type SettingsScope = "global" | "project";
+export type SettingsFormat = "jsonc" | "json";
+export type SettingsSourceReason = "explicit-jsonc" | "json-only";
+
+export interface SettingsSourceSelection {
+	path: string;
+	format: SettingsFormat;
+	reason: SettingsSourceReason;
+	scope: SettingsScope;
+}
+
+export type SettingsSourceListener = (source: SettingsSourceSelection) => void;
+
+/** Parse JSON or JSONC without changing comment-like text inside strings. */
+export function parseSettingsJson(content: string): Record<string, unknown> {
+	const withoutComments: string[] = [];
+	let inString = false;
+	let escaped = false;
+
+	for (let index = 0; index < content.length; index += 1) {
+		const char = content[index];
+		const next = content[index + 1];
+		if (inString) {
+			withoutComments.push(char);
+			if (escaped) escaped = false;
+			else if (char === "\\") escaped = true;
+			else if (char === '"') inString = false;
+			continue;
+		}
+		if (char === '"') {
+			inString = true;
+			withoutComments.push(char);
+			continue;
+		}
+		if (char === "/" && next === "/") {
+			withoutComments.push(" ", " ");
+			index += 2;
+			while (index < content.length && content[index] !== "\n" && content[index] !== "\r") {
+				withoutComments.push(" ");
+				index += 1;
+			}
+			if (index < content.length) withoutComments.push(content[index]);
+			continue;
+		}
+		if (char === "/" && next === "*") {
+			withoutComments.push(" ", " ");
+			index += 2;
+			let closed = false;
+			for (; index < content.length; index += 1) {
+				if (content[index] === "*" && content[index + 1] === "/") {
+					withoutComments.push(" ", " ");
+					index += 1;
+					closed = true;
+					break;
+				}
+				withoutComments.push(content[index] === "\n" || content[index] === "\r" ? content[index] : " ");
+			}
+			if (!closed) throw new SyntaxError("Unterminated block comment in settings");
+			continue;
+		}
+		withoutComments.push(char);
+	}
+
+	const normalized = withoutComments;
+	inString = false;
+	escaped = false;
+	for (let index = 0; index < normalized.length; index += 1) {
+		const char = normalized[index];
+		if (inString) {
+			if (escaped) escaped = false;
+			else if (char === "\\") escaped = true;
+			else if (char === '"') inString = false;
+			continue;
+		}
+		if (char === '"') {
+			inString = true;
+			continue;
+		}
+		if (char !== ",") continue;
+		let nextIndex = index + 1;
+		while (nextIndex < normalized.length && /\s/.test(normalized[nextIndex])) nextIndex += 1;
+		if (normalized[nextIndex] === "}" || normalized[nextIndex] === "]") normalized[index] = " ";
+	}
+
+	const parsed: unknown = JSON.parse(normalized.join(""));
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new TypeError("Settings must contain a JSON object");
+	}
+	return parsed as Record<string, unknown>;
+}
 
 const SELF_WRITE_TTL_MS = 15_000;
 const MAX_SELF_WRITES_PER_PATH = 8;
@@ -346,19 +435,42 @@ export function __setSelfWriteTrackerClockForTests(clock: (() => number) | undef
 	selfWriteClock = clock ?? Date.now;
 }
 
-/** Returns the absolute settings path for a filesystem-backed storage scope. */
+function getSettingsDirectory(cwd: string, agentDir: string, scope: SettingsScope, homeDir: string): string {
+	if (scope === "global") return resolvePath(agentDir);
+	const resolvedCwd = resolvePath(cwd);
+	return findNearestParentConfigDir(resolvedCwd, homeDir, CONFIG_DIR_NAME) ?? join(resolvedCwd, CONFIG_DIR_NAME);
+}
+
+/** Resolve the existing settings source, preferring JSONC when both formats exist. */
+export function resolveSettingsSource(
+	cwd: string,
+	agentDir: string,
+	scope: SettingsScope,
+	homeDir: string = homedir(),
+): SettingsSourceSelection | undefined {
+	const directory = getSettingsDirectory(cwd, agentDir, scope, homeDir);
+	const jsoncPath = join(directory, "settings.jsonc");
+	if (existsSync(jsoncPath)) {
+		return { path: jsoncPath, format: "jsonc", reason: "explicit-jsonc", scope };
+	}
+	const jsonPath = join(directory, "settings.json");
+	if (existsSync(jsonPath)) {
+		return { path: jsonPath, format: "json", reason: "json-only", scope };
+	}
+	return undefined;
+}
+
+/** Returns the selected settings path, or the legacy JSON write target when no source exists. */
 export function getSettingsPath(
 	cwd: string,
 	agentDir: string,
 	scope: SettingsScope,
 	homeDir: string = homedir(),
 ): string {
-	if (scope === "global") {
-		return join(resolvePath(agentDir), "settings.json");
-	}
-	const resolvedCwd = resolvePath(cwd);
-	const projectConfigDir = findNearestParentConfigDir(resolvedCwd, homeDir, CONFIG_DIR_NAME);
-	return join(projectConfigDir ?? join(resolvedCwd, CONFIG_DIR_NAME), "settings.json");
+	return (
+		resolveSettingsSource(cwd, agentDir, scope, homeDir)?.path ??
+		join(getSettingsDirectory(cwd, agentDir, scope, homeDir), "settings.json")
+	);
 }
 
 /** Returns the stable virtual path used to identify in-memory settings storage writes. */
@@ -372,6 +484,7 @@ export interface SettingsManagerCreateOptions {
 
 export interface SettingsStorage {
 	withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
+	selectSource?(scope: SettingsScope): SettingsSourceSelection | undefined;
 }
 
 export interface SettingsError {
@@ -382,10 +495,25 @@ export interface SettingsError {
 export class FileSettingsStorage implements SettingsStorage {
 	private globalSettingsPath: string;
 	private projectSettingsPath: string;
+	private readonly cwd: string;
+	private readonly agentDir: string;
+	private readonly homeDir: string;
 
 	constructor(cwd: string, agentDir: string, homeDir: string = homedir()) {
+		this.cwd = cwd;
+		this.agentDir = agentDir;
+		this.homeDir = homeDir;
 		this.globalSettingsPath = getSettingsPath(cwd, agentDir, "global", homeDir);
 		this.projectSettingsPath = getSettingsPath(cwd, agentDir, "project", homeDir);
+	}
+
+	selectSource(scope: SettingsScope): SettingsSourceSelection | undefined {
+		const source = resolveSettingsSource(this.cwd, this.agentDir, scope, this.homeDir);
+		const path =
+			source?.path ?? join(getSettingsDirectory(this.cwd, this.agentDir, scope, this.homeDir), "settings.json");
+		if (scope === "global") this.globalSettingsPath = path;
+		else this.projectSettingsPath = path;
+		return source;
 	}
 
 	private acquireLockSyncWithRetry(path: string): () => void {
@@ -485,6 +613,8 @@ export class SettingsManager {
 	private projectSettingsLoadError: Error | null = null; // Track if project settings file had parse errors
 	private writeQueue: Promise<void> = Promise.resolve();
 	private errors: SettingsError[];
+	private selectedSources = new Map<SettingsScope, SettingsSourceSelection>();
+	private sourceListeners: SettingsSourceListener[] = [];
 
 	private constructor(
 		storage: SettingsStorage,
@@ -494,6 +624,7 @@ export class SettingsManager {
 		projectLoadError: Error | null = null,
 		initialErrors: SettingsError[] = [],
 		projectTrusted = true,
+		initialSources: readonly SettingsSourceSelection[] = [],
 	) {
 		this.storage = storage;
 		this.globalSettings = initialGlobal;
@@ -502,6 +633,7 @@ export class SettingsManager {
 		this.globalSettingsLoadError = globalLoadError;
 		this.projectSettingsLoadError = projectLoadError;
 		this.errors = [...initialErrors];
+		for (const source of initialSources) this.selectedSources.set(source.scope, source);
 		this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
 	}
 
@@ -518,7 +650,12 @@ export class SettingsManager {
 	/** Create a SettingsManager from an arbitrary storage backend */
 	static fromStorage(storage: SettingsStorage, options: SettingsManagerCreateOptions = {}): SettingsManager {
 		const projectTrusted = options.projectTrusted ?? true;
+		const initialSources: SettingsSourceSelection[] = [];
+		const globalSource = storage.selectSource?.("global");
+		if (globalSource) initialSources.push(globalSource);
 		const globalLoad = SettingsManager.tryLoadFromStorage(storage, "global");
+		const projectSource = projectTrusted ? storage.selectSource?.("project") : undefined;
+		if (projectSource) initialSources.push(projectSource);
 		const projectLoad = SettingsManager.tryLoadFromStorage(storage, "project", projectTrusted);
 		const initialErrors: SettingsError[] = [];
 		if (globalLoad.error) {
@@ -536,6 +673,7 @@ export class SettingsManager {
 			projectLoad.error,
 			initialErrors,
 			projectTrusted,
+			initialSources,
 		);
 	}
 
@@ -561,8 +699,7 @@ export class SettingsManager {
 		if (!content) {
 			return {};
 		}
-		const settings = JSON.parse(content);
-		return SettingsManager.migrateSettings(settings);
+		return SettingsManager.migrateSettings(parseSettingsJson(content));
 	}
 
 	private static tryLoadFromStorage(
@@ -685,6 +822,7 @@ export class SettingsManager {
 			return;
 		}
 
+		this.selectAndPublishSource("project");
 		const projectLoad = SettingsManager.tryLoadFromStorage(this.storage, "project", trusted);
 		this.projectSettings = projectLoad.settings;
 		this.projectSettingsLoadError = projectLoad.error;
@@ -696,6 +834,7 @@ export class SettingsManager {
 
 	async reload(): Promise<void> {
 		await this.writeQueue;
+		this.selectAndPublishSource("global");
 		const globalLoad = SettingsManager.tryLoadFromStorage(this.storage, "global");
 		if (!globalLoad.error) {
 			this.globalSettings = globalLoad.settings;
@@ -710,6 +849,7 @@ export class SettingsManager {
 		this.modifiedProjectFields.clear();
 		this.modifiedProjectNestedFields.clear();
 
+		if (this.projectTrusted) this.selectAndPublishSource("project");
 		const projectLoad = SettingsManager.tryLoadFromStorage(this.storage, "project", this.projectTrusted);
 		if (!projectLoad.error) {
 			this.projectSettings = projectLoad.settings;
@@ -720,6 +860,28 @@ export class SettingsManager {
 		}
 
 		this.settings = deepMergeSettings(this.globalSettings, this.projectSettings);
+	}
+
+	getSelectedSettingsSources(): SettingsSourceSelection[] {
+		return [...this.selectedSources.values()].map((source) => ({ ...source }));
+	}
+
+	subscribeToSourceSelection(listener: SettingsSourceListener): () => void {
+		this.sourceListeners.push(listener);
+		return () => {
+			const index = this.sourceListeners.indexOf(listener);
+			if (index !== -1) this.sourceListeners.splice(index, 1);
+		};
+	}
+
+	private selectAndPublishSource(scope: SettingsScope): void {
+		const source = this.storage.selectSource?.(scope);
+		if (!source) {
+			this.selectedSources.delete(scope);
+			return;
+		}
+		this.selectedSources.set(scope, source);
+		for (const listener of this.sourceListeners) listener({ ...source });
 	}
 
 	/** Apply additional overrides on top of current settings */
@@ -800,9 +962,7 @@ export class SettingsManager {
 		modifiedNestedFields: Map<keyof Settings, Set<string>>,
 	): void {
 		this.storage.withLock(scope, (current) => {
-			const currentFileSettings = current
-				? SettingsManager.migrateSettings(JSON.parse(current) as Record<string, unknown>)
-				: {};
+			const currentFileSettings = current ? SettingsManager.migrateSettings(parseSettingsJson(current)) : {};
 			const mergedSettings: Settings = { ...currentFileSettings };
 			for (const field of modifiedFields) {
 				const value = snapshotSettings[field];

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Show the selected settings source (2026-08-16)
+
+### What changed
+
+- Interactive mode renders `settings_source_selected` as a concise dim status such as `Settings: settings.jsonc (JSONC)`.
+- Rendering is event-driven: one startup/reload selection produces one status update, with no polling or input-path emission.
+
+### Why
+
+- JSONC precedence is otherwise invisible, especially when both settings flavors exist.
+
+### Why this cannot be expressed externally
+
+- The event can arrive before extension UI binding and the built-in transcript/status lifecycle owns startup rendering.
+
+### Expected merge conflict zones
+
+- LOW: one additive `handleEvent` case and helper in `interactive-mode.ts`.
+
 ## Favorite persist merges by pattern resolution, keeping `:level` / `:priority` decorators (2026-08-16)
 
 Supersedes "Favorite patterns survive a persist while providers are unavailable (2026-08-12)": the

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3897,6 +3897,10 @@ export class InteractiveMode {
 				this.showHighReasoningWarning(event);
 				break;
 
+			case "settings_source_selected":
+				this.showSettingsSourceSelected(event);
+				break;
+
 			case "message_start":
 				if (event.message.role === "custom") {
 					this.addMessageToChat(event.message);
@@ -5205,6 +5209,10 @@ export class InteractiveMode {
 		);
 		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
 		this.ui.requestRender();
+	}
+
+	showSettingsSourceSelected(event: Extract<AgentSessionEvent, { type: "settings_source_selected" }>): void {
+		this.showStatus(`Settings: ${path.basename(event.path)} (${event.format.toUpperCase()})`);
 	}
 
 	showHighReasoningWarning(event: { modelId: string; provider: string; thinkingLevel: ThinkingLevel }): void {

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Settings source selection event (2026-08-16)
+
+### What changed
+
+- Classic and multi-session RPC now receive the additive `settings_source_selected` session event with `{ path, format, reason, scope }` at startup/rebind and after settings reload selection.
+- The public RPC type surface documents the event; existing session forwarding and routing remain unchanged.
+
+### Why
+
+- Headless clients need to know whether JSONC won precedence and which path subsequent settings writes target.
+
+### Why the extension system could not handle this
+
+- The source is selected before extension binding, while RPC framing/routing is host-owned.
+
+### Expected merge conflict zones
+
+- LOW: additive event typing in `rpc-types.ts`; event forwarding uses the existing unfiltered session subscription.
+
 ## Model/tier events, fast-mode commands, and turn-scope validation (2026-08-16)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -527,6 +527,15 @@ export interface RpcHighReasoningWarningEvent {
 	thinkingLevel: ThinkingLevel;
 }
 
+/** Emitted when startup or reload selects an existing settings file. */
+export interface RpcSettingsSourceSelectedEvent {
+	type: "settings_source_selected";
+	path: string;
+	format: "jsonc" | "json";
+	reason: "explicit-jsonc" | "json-only";
+	scope: "global" | "project";
+}
+
 /**
  * Emitted after the session's active model changed, with the thinking level in force AFTER
  * the switch (per-model memory, a favorite's pinned level, or the clamped previous level).

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -38,6 +38,87 @@ describe("SettingsManager", () => {
 		}
 	});
 
+	describe("JSONC settings sources", () => {
+		it("loads comments and trailing commas without treating comment markers inside strings as syntax", () => {
+			writeFileSync(
+				join(agentDir, "settings.jsonc"),
+				`{
+					// line comment
+					"theme": "dark",
+					"shellCommandPrefix": "echo // literal /* text */",
+					/* block comment */
+					"favoriteModels": ["openai/gpt-5.5",],
+				}`,
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getTheme()).toBe("dark");
+			expect(manager.getShellCommandPrefix()).toBe("echo // literal /* text */");
+			expect(manager.getFavoriteModels()).toEqual(["openai/gpt-5.5"]);
+		});
+
+		it("prefers settings.jsonc when both settings formats exist", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ theme: "light" }));
+			writeFileSync(join(agentDir, "settings.jsonc"), '{ "theme": "dark", }');
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getTheme()).toBe("dark");
+			expect(manager.getSelectedSettingsSources()).toContainEqual({
+				path: join(agentDir, "settings.jsonc"),
+				format: "jsonc",
+				reason: "explicit-jsonc",
+				scope: "global",
+			});
+		});
+
+		it("keeps settings.json as the source when it is the only settings file", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ theme: "light" }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			expect(manager.getTheme()).toBe("light");
+			expect(manager.getSelectedSettingsSources()).toContainEqual({
+				path: join(agentDir, "settings.json"),
+				format: "json",
+				reason: "json-only",
+				scope: "global",
+			});
+		});
+
+		it("writes back to the loaded JSONC path without creating settings.json", async () => {
+			const jsoncPath = join(agentDir, "settings.jsonc");
+			writeFileSync(jsoncPath, '{ "theme": "dark", }');
+			const manager = SettingsManager.create(projectDir, agentDir);
+
+			manager.setDefaultModel("gpt-5.5");
+			await manager.flush();
+
+			expect(existsSync(join(agentDir, "settings.json"))).toBe(false);
+			expect(JSON.parse(readFileSync(jsoncPath, "utf-8"))).toMatchObject({
+				theme: "dark",
+				defaultModel: "gpt-5.5",
+			});
+		});
+
+		it("reselects JSONC on reload and keeps later writes on that path", async () => {
+			const jsonPath = join(agentDir, "settings.json");
+			const jsoncPath = join(agentDir, "settings.jsonc");
+			writeFileSync(jsonPath, JSON.stringify({ theme: "light" }));
+			const manager = SettingsManager.create(projectDir, agentDir);
+			writeFileSync(jsoncPath, '{ "theme": "dark", }');
+
+			await manager.reload();
+			manager.setDefaultModel("gpt-5.5");
+			await manager.flush();
+
+			expect(manager.getTheme()).toBe("dark");
+			expect(JSON.parse(readFileSync(jsonPath, "utf-8"))).toEqual({ theme: "light" });
+			expect(JSON.parse(readFileSync(jsoncPath, "utf-8"))).toMatchObject({ defaultModel: "gpt-5.5" });
+		});
+	});
+
 	describe("preserves externally added settings", () => {
 		it("should preserve enabledModels when changing thinking level", async () => {
 			// Create initial settings file

--- a/packages/coding-agent/test/settings-source-rpc.test.ts
+++ b/packages/coding-agent/test/settings-source-rpc.test.ts
@@ -1,0 +1,54 @@
+import { basename } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionRuntime } from "../src/core/agent-session-runtime.ts";
+import { createRpcConnectionHandler, type RpcConnectionSink } from "../src/modes/rpc/connection-handler.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+describe("settings source RPC event", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+		vi.restoreAllMocks();
+	});
+
+	it("publishes the selected JSONC source when the RPC connection starts", async () => {
+		harness = await createHarness({
+			fileSettings: true,
+			settingsFileName: "settings.jsonc",
+			settingsContent: '{ // comment\n "theme": "dark",\n}',
+		});
+		const chunks: string[] = [];
+		const sink: RpcConnectionSink = {
+			writeRaw: (chunk) => chunks.push(chunk),
+			waitForBackpressure: async () => {},
+		};
+		const runtimeHost = {
+			session: harness.session,
+			newSession: vi.fn(async () => ({ cancelled: true })),
+			switchSession: vi.fn(async () => ({ cancelled: true })),
+			fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
+			dispose: vi.fn(async () => {}),
+			setRebindSession: vi.fn(),
+		} as unknown as AgentSessionRuntime;
+		const handler = createRpcConnectionHandler(runtimeHost, sink);
+
+		await handler.ready;
+		const records = chunks
+			.join("")
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as Record<string, unknown>);
+		const selected = records.filter((record) => record.type === "settings_source_selected");
+
+		expect(selected).toHaveLength(1);
+		expect(basename(String(selected[0].path))).toBe("settings.jsonc");
+		expect(selected[0]).toMatchObject({
+			format: "jsonc",
+			reason: "explicit-jsonc",
+			scope: "global",
+		});
+		await handler.dispose();
+	});
+});

--- a/packages/coding-agent/test/settings-source-tui.test.ts
+++ b/packages/coding-agent/test/settings-source-tui.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+describe("InteractiveMode settings source notice", () => {
+	it("renders one concise JSONC status for one source-selection event", () => {
+		const showStatus = vi.fn();
+		const fakeThis = { showStatus };
+		const event = {
+			type: "settings_source_selected",
+			path: "/tmp/sandbox/agent/settings.jsonc",
+			format: "jsonc",
+			reason: "explicit-jsonc",
+			scope: "global",
+		};
+
+		(
+			InteractiveMode as unknown as {
+				prototype: { showSettingsSourceSelected(this: unknown, event: unknown): void };
+			}
+		).prototype.showSettingsSourceSelected.call(fakeThis, event);
+
+		expect(showStatus).toHaveBeenCalledTimes(1);
+		expect(showStatus).toHaveBeenCalledWith("Settings: settings.jsonc (JSONC)");
+	});
+});

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -46,6 +46,7 @@ type WatchProbe = {
 
 type FixtureOptions = {
 	readonly settingsContent?: string;
+	readonly settingsFileName?: "settings.json" | "settings.jsonc";
 	readonly withReload?: boolean;
 	readonly reload?: () => Promise<void>;
 	readonly extraFactories?: Array<(pi: ExtensionAPI) => void>;
@@ -128,7 +129,7 @@ async function settleChange(fixture: Fixture, path: string, filename: string | n
 async function createFixture(options: FixtureOptions = {}): Promise<Fixture> {
 	const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-extension-"));
 	agentDirs.push(agentDir);
-	const settingsPath = join(agentDir, "settings.json");
+	const settingsPath = join(agentDir, options.settingsFileName ?? "settings.json");
 	writeFileSync(settingsPath, options.settingsContent ?? '{"theme":"dark"}\n', "utf-8");
 	const watches = createWatchProbe();
 	const notifications: string[] = [];
@@ -248,6 +249,20 @@ describe("config reload builtin extension", () => {
 
 		writeFileSync(fixture.settingsPath, '{"theme":"light"}\n');
 		await settleChange(fixture, fixture.agentDir, "settings.json");
+
+		expect(fixture.reload).toHaveBeenCalledTimes(1);
+		expect(fixture.notifications.some((message) => message.startsWith("Hot-reloading:"))).toBe(true);
+	});
+
+	it("requests one reload for a valid JSONC settings change", async () => {
+		vi.useFakeTimers();
+		const fixture = await createFixture({
+			settingsFileName: "settings.jsonc",
+			settingsContent: '{ // initial\n "theme": "dark",\n}\n',
+		});
+
+		writeFileSync(fixture.settingsPath, '{ /* changed */\n "theme": "light",\n}\n');
+		await settleChange(fixture, fixture.agentDir, "settings.jsonc");
 
 		expect(fixture.reload).toHaveBeenCalledTimes(1);
 		expect(fixture.notifications.some((message) => message.startsWith("Hot-reloading:"))).toBe(true);
@@ -578,7 +593,6 @@ describe("config reload builtin extension", () => {
 		["string", '"x"'],
 		["number", "5"],
 		["array", "[]"],
-		["comments", "// not JSON\n{}"],
 	] as const) {
 		it(`rejects a ${label} settings.json root before reload`, async () => {
 			vi.useFakeTimers();

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -85,6 +85,8 @@ export interface HarnessOptions {
 	transportImageBudget?: { budgetBytes: number; alwaysKeepNewest: number };
 	modelsJson?: Record<string, unknown>;
 	fileSettings?: boolean;
+	settingsFileName?: "settings.json" | "settings.jsonc";
+	settingsContent?: string;
 }
 
 export interface Harness {
@@ -133,7 +135,10 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 	const agentDir = join(tempDir, "agent");
 	if (options.fileSettings) {
 		mkdirSync(agentDir, { recursive: true });
-		writeFileSync(join(agentDir, "settings.json"), JSON.stringify(options.settings ?? {}, null, 2));
+		writeFileSync(
+			join(agentDir, options.settingsFileName ?? "settings.json"),
+			options.settingsContent ?? JSON.stringify(options.settings ?? {}, null, 2),
+		);
 	}
 	const settingsManager = options.fileSettings
 		? SettingsManager.create(tempDir, agentDir)


### PR DESCRIPTION
## Summary

- accept dependency-free JSONC comments and trailing commas in settings content
- prefer `settings.jsonc` over `settings.json` per config directory while preserving the selected write target
- publish `settings_source_selected { path, format, reason, scope }` through the session/RPC event stream
- show the selected settings filename/format once in interactive startup/reload status
- watch, validate, and routine-diff both settings filenames in config-reload

## Design

The parser is a small lexical normalizer in `settings-manager.ts`: it removes `//` and `/* */` comments only outside JSON strings, preserves line structure, removes commas only before `}`/`]`, then delegates final validation to `JSON.parse`. No external dependency was added.

File storage resolves an existing source at create/reload boundaries. `settings.jsonc` wins when both files exist; the chosen path remains stable for writes until the next explicit reload selection. Missing settings retain the legacy `settings.json` creation target.

`SettingsManager` retains selected-source metadata and publishes reload selections. `AgentSession` bridges those notifications and replays current startup selections once to each newly attached host listener, so the existing classic/multi-session RPC forwarding and TUI subscription paths receive the same event.

## TDD and verification

RED first:

- JSONC comments/trailing commas and string-literal comment markers
- JSONC-over-JSON precedence and JSON-only compatibility
- write-target preservation and reload reselection
- real connection-handler RPC event publication
- interactive source-status rendering
- config-reload JSONC watch/validation

GREEN:

- `npx vitest --run test/settings-manager.test.ts test/settings-source-rpc.test.ts test/settings-source-tui.test.ts test/suite/config-reload-extension.test.ts` — 149/149 passed
- `npm run check` — passed (Biome, pinned deps/imports/locks, TypeScript, browser smoke)
- `node scripts/check-pr-changelog.mjs --base 2495ba6bdd145fca35f96f217cbca3a9ac3c2839` — passed
- `git diff --check` — passed

A later full coding-agent package run exceeded 10 minutes after the host restarted onto Node 26.7; the same restarted host also made the unchanged main branch RPC self-test time out before responding. No focused failure was reported.

## Real CLI QA

Hermetic QA through `.agents/skills/senpi-qa/` used conflicting sandbox files:

- `settings.json`: `steeringMode: "all"`
- `settings.jsonc`: comments, trailing comma, `steeringMode: "one-at-a-time"`

The real source RPC CLI returned `steeringMode: "one-at-a-time"` and emitted exactly one global `settings_source_selected` event with the JSONC path, `format: "jsonc"`, and `reason: "explicit-jsonc"`. The harness self-check passed 9/9 and verified the real auth file remained unchanged.

Evidence is retained locally under `local-ignore/qa-evidence/20260816-jsonc-settings/` (not committed). The official TUI smoke reported SKIP because node-pty failed with `posix_spawnp failed` and tmux was absent; a second direct node-pty attempt hit the same host capability failure. Interactive rendering remains covered by the focused deterministic test.

## Fork change records / conflict zones

Updated the package, root source, core, config-reload, RPC, and interactive `changes.md` files. Expected conflict zones are highest around `settings-manager.ts` path/storage/load/save logic, medium in `AgentSession` event subscription lifecycle, and low in additive RPC/TUI/config-reload handling.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Support JSONC settings with clear source selection and host visibility. Previously only strict JSON in `settings.json` was accepted; now JSONC (comments and trailing commas) loads, `settings.jsonc` wins over `settings.json`, and hosts receive a source-selected event.

- When both files exist in a scope, `settings.jsonc` is selected; if only `settings.json` exists, it remains selected. Writes stay on the selected path until the next explicit reload. If no file exists, the creation target remains `settings.json`.
- Emits `settings_source_selected { path, format, reason, scope }` through the session/RPC stream; the current selection replays once to new listeners. Interactive mode shows a concise status like “Settings: settings.jsonc (JSONC)”.
- Config reload watches and validates both filenames using the same dependency-free parser; valid JSONC edits trigger a single reload.
- Internal: `SettingsManager` parses JSONC outside strings and strips trailing commas, selects sources, and exposes selection subscriptions. `AgentSession` forwards/replays the event; RPC types are extended additively.

<sup>Written for commit 0666c12b5ee6b09298f6780368f6624ecd20220c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

