### PR TITLE
feat(coding-agent): restore CLI custom system prompts and make presets yield to them

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- `--system-prompt` and `--append-system-prompt` work again on the CLI path, and now compose with per-model prompt presets instead of being clobbered by them. A custom system prompt replaces the generated base and makes the preset step aside (the startup "Optimized system prompt applied" header also stands down); append texts are reattached after a preset replaces the base, so they survive on preset-matching models and across model switches. The CLI flags had been parsed but disconnected since 2026-07-19 because presets overwrote user overrides. Extensions can now read the user overrides via `ctx.getSystemPromptOptions()`, which moved from the command context to the base `ExtensionContext`.
+
 - Settings files now support dependency-free JSONC comments and trailing commas. When both `settings.jsonc` and `settings.json` exist in one config directory, JSONC wins; writes remain on the loaded file, config reload watches both formats, RPC emits `settings_source_selected` with the selected path/format/reason, and the interactive TUI shows the choice at startup or reload.
 - GLM 5.3 prompt preset: a new `glm-5.3` system-prompt preset cloned from `glm-5.2` (thin `tuningSection` wrapper over the shared dynamic core, `workstationDialect: "claude"`). The `hasGlm53Signal`/`isGlm53Model` matcher is checked before the 5.2 matcher, `"glm-5.3"` joins `PromptPresetName`/`VALID_PRESETS`, and the settings.md value list is updated. Models selecting GLM 5.3 now get the tuned system prompt instead of the untuned fallback ([#895](https://github.com/code-yeongyu/senpi/pull/895)).
 

--- a/packages/coding-agent/docs/usage.md
+++ b/packages/coding-agent/docs/usage.md
@@ -262,8 +262,8 @@ senpi --no-extensions -e ./my-extension.ts
 
 | Option | Description |
 |--------|-------------|
-| `--system-prompt <text>` | Replace default prompt; context files and skills are still appended |
-| `--append-system-prompt <text>` | Append to system prompt |
+| `--system-prompt <text>` | Replace the generated base prompt (text or a file path); per-model prompt presets step aside; context files and skills are still appended |
+| `--append-system-prompt <text>` | Append to the system prompt (repeatable; text or a file path); applies after per-model prompt presets |
 | `--tui-mode <mode>` | TUI mode: `regular` (default) or experimental `fullscreen` |
 | `--use-theme <name[/name]>` | Set the initial interactive theme for this run without changing settings |
 | `--verbose` | Force verbose startup |

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## CLI system-prompt overrides rewired into the runtime resource loader (2026-08-17)
+
+### What changed
+
+- `main.ts`: the runtime `resourceLoaderOptions` again forwards `parsed.systemPrompt` / `parsed.appendSystemPrompt` to `DefaultResourceLoader`, re-enabling the documented `--system-prompt` / `--append-system-prompt` flags on the CLI path (the SDK path already honored loader overrides).
+
+### Why
+
+- Commit `0ce8ac312` (2026-07-19, "preserve dynamic prompt policy") disconnected the flags because the prompt-preset extension clobbered user overrides on preset-matching models. The preset extension now yields to a user custom prompt and reapplies user appends (see `core/extensions/builtin/prompt-preset/changes.md`), so the flags can compose with the dynamic prompt policy instead of fighting it.
+
+### Why extension system couldn't handle this
+
+- CLI argv-to-loader wiring is host bootstrap code; extensions load after the resource loader exists.
+
+### Expected merge conflict zones
+
+- LOW: `main.ts` runtime `resourceLoaderOptions` block — keep both fields when upstream reshapes the options.
+
 ## JSONC settings selection and source events (2026-08-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -765,7 +765,13 @@ export class AgentSession {
 	private _currentServiceTier: ServiceTier | undefined = undefined;
 	private _sessionFastMode = false;
 	private readonly _shownHighReasoningWarningKeys = new Set<string>();
-	private _baseSystemPromptOptions!: BuildDynamicSystemPromptOptions;
+	// Widened with the upstream BuildSystemPromptOptions user-override fields so
+	// extensions (prompt-preset) can see CLI/SDK custom prompts via
+	// before_agent_start/model_select systemPromptOptions and ctx.getSystemPromptOptions().
+	private _baseSystemPromptOptions!: BuildDynamicSystemPromptOptions & {
+		customPrompt?: string;
+		appendSystemPrompt?: string;
+	};
 	private _systemPromptOverride?: string;
 
 	constructor(config: AgentSessionConfig) {
@@ -2695,6 +2701,8 @@ export class AgentSession {
 			selectedTools: validToolNames,
 			toolSnippets,
 			promptGuidelines,
+			customPrompt: loaderSystemPrompt,
+			appendSystemPrompt: loaderAppendSystemPrompt.length > 0 ? loaderAppendSystemPrompt.join("\n\n") : undefined,
 		};
 		const basePrompt = loaderSystemPrompt ?? buildDynamicSystemPrompt(this._baseSystemPromptOptions);
 		return loaderAppendSystemPrompt.length > 0

--- a/packages/coding-agent/src/core/dynamic-prompt/changes.md
+++ b/packages/coding-agent/src/core/dynamic-prompt/changes.md
@@ -1,5 +1,24 @@
 # changes.md — dynamic-prompt
 
+## User overrides exposed on `_baseSystemPromptOptions` (2026-08-17)
+
+### What changed
+
+- `agent-session.ts`: `_rebuildSystemPrompt()` now records the loader's user overrides on `_baseSystemPromptOptions` — `customPrompt` (the `--system-prompt` / SDK override) and `appendSystemPrompt` (CLI appends pre-joined with `\n\n`). The field type is widened with those two upstream `BuildSystemPromptOptions` members; `buildDynamicSystemPrompt()` ignores them, so the generated prompt is byte-identical when no overrides exist.
+- The options flow into `before_agent_start` / `model_select` events and the `ctx.getSystemPromptOptions()` getter, letting prompt-preset yield to user overrides (see `extensions/builtin/prompt-preset/changes.md`).
+
+### Why
+
+- The 2026-07-18 restoration made the base prompt honor loader overrides, but extensions could not tell an override-carrying base from a generated one, so presets clobbered user prompts — which is why the CLI wiring was disconnected on 2026-07-19. Exposing the facts on the options closes that loop.
+
+### Why extension system couldn't handle this
+
+- Same as the 2026-07-18 entry: base prompt assembly is core-owned; only the core knows whether the base came from a user override.
+
+### Expected merge conflict zones
+
+- `agent-session.ts` `_rebuildSystemPrompt()` tail and the `_baseSystemPromptOptions` declaration. Resolution: keep the two override fields populated alongside whatever upstream adds.
+
 ## Test-discipline rules: prose-pinning prohibition + behavior wording (2026-08-03)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,26 @@
 # prompt-preset Extension Changes
 
+## Presets yield to user system-prompt overrides (2026-08-17)
+
+### What changed
+
+- `index.ts`: `before_agent_start` returns no replacement when `event.systemPromptOptions.customPrompt` is set (a `--system-prompt` / SDK loader override) — the base prompt already carries the user's prompt plus appends. When only `appendSystemPrompt` is set, the preset still replaces the base but reappends the user text (`preset + "\n\n" + appends`), so appends survive preset replacement.
+- `model_select` applies the same policy: custom prompt present returns `{ systemPrompt: null }` (reset to the user-carrying base); otherwise the preset prompt gets the user appends reattached.
+- The startup header (`getPresetName`) reports no preset when a custom prompt is active, via the new `ctx.getSystemPromptOptions()` base-context getter.
+- `agent-session.ts` populates `customPrompt` / `appendSystemPrompt` (pre-joined) into `_baseSystemPromptOptions`, which flows into both events and the context getter.
+
+### Why
+
+- Before this, a preset-matching model silently discarded explicit user overrides: the preset replaced the entire base prompt (including `--append-system-prompt` text) on every turn. That made the documented flags unusable on gpt-5.x/claude/kimi/glm/deepseek/grok models and forced the 2026-07-19 decision to disconnect the CLI flags entirely.
+
+### Why extension system couldn't handle this differently
+
+- The gate lives in this builtin, but it needs the user-override facts on the event; those fields exist on the upstream `BuildSystemPromptOptions` contract and are now populated by the session core.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `index.ts` handler bodies; keep the customPrompt yield and append reattachment when upstream reshapes handlers.
+
 ## GLM 5.3 preset (2026-08-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/index.ts
@@ -11,6 +11,10 @@ interface SystemPromptOptionsLike {
 	promptGuidelines?: string[];
 	contextFiles?: Array<{ path: string; content: string }>;
 	skills?: BuildDynamicSystemPromptOptions["skills"];
+	/** User override from --system-prompt / SDK loader; outranks any preset. */
+	customPrompt?: string;
+	/** User appends from --append-system-prompt, pre-joined; reapplied after a preset. */
+	appendSystemPrompt?: string;
 }
 
 function eventOptionsToBuilderInput(
@@ -37,7 +41,19 @@ function getPresetName(ctx: ExtensionContext, event?: Pick<ModelSelectEvent, "mo
 	if (!model) {
 		return undefined;
 	}
+	if (hasUserSystemPrompt(ctx.getSystemPromptOptions?.())) {
+		return undefined;
+	}
 	return resolvePresetName(model, getSettings(ctx));
+}
+
+function hasUserSystemPrompt(options: SystemPromptOptionsLike | undefined): boolean {
+	return Boolean(options?.customPrompt);
+}
+
+function withUserAppends(presetPrompt: string, options: SystemPromptOptionsLike | undefined): string {
+	const append = options?.appendSystemPrompt;
+	return append ? `${presetPrompt}\n\n${append}` : presetPrompt;
 }
 
 function refreshHeader(ctx: ExtensionContext, event?: Pick<ModelSelectEvent, "model">): void {
@@ -59,12 +75,18 @@ export default function promptPresetExtension(pi: ExtensionAPI): void {
 			return undefined;
 		}
 
+		// An explicit user system prompt (--system-prompt / SDK loader override)
+		// outranks the per-model preset; the base prompt already carries it.
+		if (hasUserSystemPrompt(event.systemPromptOptions)) {
+			return undefined;
+		}
+
 		const preset = resolvePreset(model, getSettings(ctx), eventOptionsToBuilderInput(event, ctx));
 		if (!preset) {
 			return undefined;
 		}
 
-		return { systemPrompt: preset.prompt };
+		return { systemPrompt: withUserAppends(preset.prompt, event.systemPromptOptions) };
 	});
 
 	pi.on("session_start", async (_event, ctx) => {
@@ -73,9 +95,14 @@ export default function promptPresetExtension(pi: ExtensionAPI): void {
 
 	pi.on("model_select", async (event, ctx) => {
 		refreshHeader(ctx, event);
+		// Returning null resets to the base prompt, which already carries the
+		// user's custom prompt and appends.
+		if (hasUserSystemPrompt(event.systemPromptOptions)) {
+			return { systemPrompt: null };
+		}
 		const preset = resolvePreset(event.model, getSettings(ctx), eventOptionsToBuilderInput(event, ctx));
 		return {
-			systemPrompt: preset?.prompt ?? null,
+			systemPrompt: preset ? withUserAppends(preset.prompt, event.systemPromptOptions) : null,
 			systemPromptName: preset?.name,
 		};
 	});

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,21 @@
 # Core Extensions Changes
 
+## 2026-08-17 - getSystemPromptOptions exposed on the base ExtensionContext
+
+### What changed
+
+- `ExtensionContext` gains OPTIONAL `getSystemPromptOptions?(): BuildSystemPromptOptions`, so event handlers (not just command handlers) can read the base system-prompt construction options. It stays REQUIRED on `ExtensionCommandContext` (now a redeclaration that narrows the optional base member), so existing command-handler callers are unaffected and hand-built test contexts keep compiling.
+- `runner.ts` binds the getter in `createContext()` (it always exists at runtime under the senpi runner); the duplicate binding in `createCommandContext()` is removed because the descriptor copy carries it.
+- The returned options now include the user-override fields already present on `BuildSystemPromptOptions`: `customPrompt` (from `--system-prompt` / SDK loader) and `appendSystemPrompt` (pre-joined `--append-system-prompt` texts), populated by `agent-session.ts` `_rebuildSystemPrompt()`.
+
+### Why
+
+- The prompt-preset builtin must know at `session_start` (header) and in prompt events whether the user supplied an explicit system prompt, so presets yield instead of clobbering it. Per convention, new core data lands as a typed `ExtensionContext` getter; optional-on-base keeps the ~30 hand-built `ExtensionContext` fakes across coding-agent and senpi-codemode tests source-compatible.
+
+### Expected merge-conflict zones
+
+- `types.ts` `ExtensionContext` / `ExtensionCommandContext` member lists; `runner.ts` `createContext()` tail. Resolution: keep the optional base getter plus the required command-context redeclaration.
+
 ## 2026-08-13 - Content-anchored compaction admission
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/runner.ts
+++ b/packages/coding-agent/src/core/extensions/runner.ts
@@ -1149,6 +1149,10 @@ export class ExtensionRunner {
 				runner.assertActive();
 				return runner.getSystemPromptFn();
 			},
+			getSystemPromptOptions: () => {
+				runner.assertActive();
+				return runner.getSystemPromptOptionsFn();
+			},
 			getLoadedHookSources: () => {
 				runner.assertActive();
 				return runner.getLoadedHookSourcesFn();
@@ -1168,10 +1172,6 @@ export class ExtensionRunner {
 			{},
 			Object.getOwnPropertyDescriptors(this.createContext()),
 		) as ExtensionCommandContext;
-		context.getSystemPromptOptions = () => {
-			this.assertActive();
-			return this.getSystemPromptOptionsFn();
-		};
 		context.waitForIdle = () => {
 			this.assertActive();
 			return this.waitForIdleFn();

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -497,6 +497,14 @@ export interface ExtensionContext {
 	applyCompaction(precomputed: CompactionResult, options: ApplyCompactionOptions): Promise<ApplyCompactionResult>;
 	/** Get the current effective system prompt. */
 	getSystemPrompt(): string;
+	/**
+	 * Get the current base system-prompt construction options, including any
+	 * user overrides (`customPrompt` from --system-prompt, `appendSystemPrompt`
+	 * from --append-system-prompt). Optional on the base context for
+	 * compatibility with hand-built contexts; the senpi runner always binds it,
+	 * and it stays required on ExtensionCommandContext.
+	 */
+	getSystemPromptOptions?(): BuildSystemPromptOptions;
 	/** Get hook source paths currently visible to the builtin hooks extension. */
 	getLoadedHookSources?(): LoadedHookSources;
 	/** Get extension-declared MCP servers aggregated across all extensions (first-wins). */
@@ -524,7 +532,6 @@ export interface ProviderRequestPreparation {
 export interface ExtensionCommandContext extends ExtensionContext {
 	/** Get the current base system-prompt construction options. */
 	getSystemPromptOptions(): BuildSystemPromptOptions;
-
 	/** Wait for the agent to finish streaming */
 	waitForIdle(): Promise<void>;
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -932,6 +932,8 @@ export async function main(args: string[], options?: MainOptions) {
 				noPromptTemplates: parsed.noPromptTemplates,
 				noThemes: parsed.noThemes,
 				noContextFiles: parsed.noContextFiles,
+				systemPrompt: parsed.systemPrompt,
+				appendSystemPrompt: parsed.appendSystemPrompt,
 				extensionFactories,
 			},
 		});

--- a/packages/coding-agent/test/suite/prompt-presets-startup-header.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-startup-header.test.ts
@@ -12,6 +12,7 @@ interface ApiMock {
 interface HeaderContext {
 	model: { id: string; provider: string; api: string };
 	cwd: string;
+	getSystemPromptOptions(): { cwd: string; customPrompt?: string };
 	ui: {
 		setHeader(factory: ((tui: never, theme: never) => Component & { dispose?(): void }) | undefined): void;
 	};
@@ -44,12 +45,16 @@ function renderHeaderText(factory: ((tui: never, theme: never) => Component) | u
 		.join("\n");
 }
 
-function createHeaderContext(modelId: string): { context: HeaderContext; getHeaderText(): string } {
+function createHeaderContext(
+	modelId: string,
+	options?: { customPrompt?: string },
+): { context: HeaderContext; getHeaderText(): string } {
 	let headerFactory: ((tui: never, theme: never) => Component) | undefined;
 	return {
 		context: {
 			model: { id: modelId, provider: "openai-codex", api: "openai-codex-responses" },
 			cwd: "/repo",
+			getSystemPromptOptions: () => ({ cwd: "/repo", customPrompt: options?.customPrompt }),
 			ui: {
 				setHeader(factory) {
 					headerFactory = factory;
@@ -131,6 +136,19 @@ describe("prompt preset startup header", () => {
 		// given
 		const { api, handlers } = makeApiMock();
 		const { context, getHeaderText } = createHeaderContext("claude-sonnet-4-5");
+		promptPresetExtension(api as never);
+
+		// when
+		await handlers.session_start[0]({ type: "session_start", reason: "startup" }, context);
+
+		// then
+		expect(getHeaderText()).toBe("");
+	});
+
+	it("shows no startup header when the user provided a custom system prompt", async () => {
+		// given
+		const { api, handlers } = makeApiMock();
+		const { context, getHeaderText } = createHeaderContext("gpt-5.5", { customPrompt: "Custom base prompt." });
 		promptPresetExtension(api as never);
 
 		// when

--- a/packages/coding-agent/test/suite/prompt-presets-system-prompt-override.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-system-prompt-override.test.ts
@@ -1,0 +1,129 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import promptPresetExtension from "../../src/core/extensions/builtin/prompt-preset/index.ts";
+import type { ResourceLoader } from "../../src/core/resource-loader.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../utilities.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const CUSTOM_PROMPT = "Custom base prompt.";
+const APPENDS = ["First CLI append.", "Second CLI append."];
+const JOINED_APPENDS = APPENDS.join("\n\n");
+// Established preset sentinels (same tokens the model-switch suite pins).
+const GPT_55_PRESET_SENTINEL = "outcome-first";
+const OPUS_47_PRESET_SENTINEL = "full set rather than the first item";
+
+async function createPresetLoader(overrides: {
+	systemPrompt?: string;
+	appendSystemPrompt?: string[];
+}): Promise<ResourceLoader> {
+	const extensionsResult = await createTestExtensionsResult([promptPresetExtension]);
+	return {
+		...createTestResourceLoader({ extensionsResult }),
+		getSystemPrompt: () => overrides.systemPrompt,
+		getAppendSystemPrompt: () => overrides.appendSystemPrompt ?? [],
+	};
+}
+
+describe("prompt preset vs user system-prompt overrides", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("keeps the user's custom system prompt on a preset model turn", async () => {
+		// given
+		const harness = await createHarness({
+			models: [{ id: "gpt-5.5", name: "GPT 5.5", reasoning: true }],
+			resourceLoader: await createPresetLoader({ systemPrompt: CUSTOM_PROMPT, appendSystemPrompt: APPENDS }),
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		// when
+		await harness.session.prompt("hi");
+
+		// then
+		expect(harness.session.systemPrompt).toBe(`${CUSTOM_PROMPT}\n\n${JOINED_APPENDS}`);
+		expect(harness.session.systemPrompt).not.toContain(GPT_55_PRESET_SENTINEL);
+	});
+
+	it("reapplies user appends after the preset replaces the base prompt", async () => {
+		// given
+		const harness = await createHarness({
+			models: [{ id: "gpt-5.5", name: "GPT 5.5", reasoning: true }],
+			resourceLoader: await createPresetLoader({ appendSystemPrompt: APPENDS }),
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		// when
+		await harness.session.prompt("hi");
+
+		// then
+		expect(harness.session.systemPrompt).toContain(GPT_55_PRESET_SENTINEL);
+		expect(harness.session.systemPrompt.endsWith(`\n\n${JOINED_APPENDS}`)).toBe(true);
+	});
+
+	it("still applies the preset on a turn when no user overrides exist", async () => {
+		// given
+		const harness = await createHarness({
+			models: [{ id: "gpt-5.5", name: "GPT 5.5", reasoning: true }],
+			resourceLoader: await createPresetLoader({}),
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("ok")]);
+
+		// when
+		await harness.session.prompt("hi");
+
+		// then
+		expect(harness.session.systemPrompt).toContain(GPT_55_PRESET_SENTINEL);
+	});
+
+	it("keeps the user's custom system prompt across a model switch to a preset model", async () => {
+		// given
+		const harness = await createHarness({
+			models: [
+				{ id: "gpt-5.5", name: "GPT 5.5", reasoning: true },
+				{ id: "claude-opus-4-7", name: "Opus 4.7", reasoning: true },
+			],
+			resourceLoader: await createPresetLoader({ systemPrompt: CUSTOM_PROMPT }),
+		});
+		harnesses.push(harness);
+		const opus = harness.getModel("claude-opus-4-7");
+		if (!opus) throw new Error("Missing test model: claude-opus-4-7");
+
+		// when
+		const promptChange = await harness.session.setModel(opus);
+
+		// then
+		expect(promptChange).toBeUndefined();
+		expect(harness.session.systemPrompt).toBe(CUSTOM_PROMPT);
+		expect(harness.session.systemPrompt).not.toContain(OPUS_47_PRESET_SENTINEL);
+	});
+
+	it("reapplies user appends after the preset prompt on model switch", async () => {
+		// given
+		const harness = await createHarness({
+			models: [
+				{ id: "gpt-5.5", name: "GPT 5.5", reasoning: true },
+				{ id: "claude-opus-4-7", name: "Opus 4.7", reasoning: true },
+			],
+			resourceLoader: await createPresetLoader({ appendSystemPrompt: APPENDS }),
+		});
+		harnesses.push(harness);
+		const opus = harness.getModel("claude-opus-4-7");
+		if (!opus) throw new Error("Missing test model: claude-opus-4-7");
+
+		// when
+		const promptChange = await harness.session.setModel(opus);
+
+		// then
+		expect(promptChange?.systemPromptName).toBe("claude-opus-4-7");
+		expect(harness.session.systemPrompt).toContain(OPUS_47_PRESET_SENTINEL);
+		expect(harness.session.systemPrompt.endsWith(`\n\n${JOINED_APPENDS}`)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

`--system-prompt` / `--append-system-prompt` are documented but have been dead on the CLI path since 2026-07-19 (`0ce8ac312`, "preserve dynamic prompt policy"): the flags were parsed and then dropped, because the prompt-preset extension unconditionally replaced the system prompt on preset-matching models, clobbering any user override. This PR restores the wiring and makes the two surfaces compose: an explicit user system prompt now outranks per-model presets, and user appends survive preset replacement.

## Changes

- **Preset interplay (core of the fix)** — `prompt-preset/index.ts`: `before_agent_start` yields (no replacement) when the user supplied a custom system prompt; when only appends exist, the preset still applies but the user appends are reattached after it. `model_select` follows the same policy (`systemPrompt: null` resets to the user-carrying base). The startup "Optimized system prompt applied" header stands down when a custom prompt is active.
- **Override visibility** — `agent-session.ts` populates `customPrompt` / `appendSystemPrompt` (fields that already exist on the upstream `BuildSystemPromptOptions` contract) into `_baseSystemPromptOptions`, which flows into both events. `ExtensionContext` gains an OPTIONAL `getSystemPromptOptions?()` (required on `ExtensionCommandContext` as before; the runner always binds it), keeping every hand-built test context source-compatible.
- **CLI wiring** — `main.ts` forwards `parsed.systemPrompt` / `parsed.appendSystemPrompt` into the runtime `resourceLoaderOptions`, reversing the 2026-07-19 disconnect now that the clobbering root cause is fixed.
- **Docs & fork trackers** — `docs/usage.md` flag rows describe the interplay; entries added to `src/changes.md`, `dynamic-prompt/changes.md`, `prompt-preset/changes.md`, `extensions/changes.md`, and the `[Unreleased]` changelog.

## QA & Evidence

- **What was tested:** senpi-qa mock-loop channel — the REAL CLI driven from source in an isolated sandbox against a local fake model server registering a preset-matching model id (`gpt-5.5`), asserting on the recorded provider request bytes. Three cases: (1) `--system-prompt` + two `--append-system-prompt` on a preset model, (2) appends only, (3) no flags.
- **Observed result:** 12/12 checks PASS — (1) request system message starts with the custom prompt, appends follow in order, no preset content, no generated dynamic base; (2) preset applied AND appends present after preset content; (3) default preset behavior unchanged; real `~/.senpi/agent/auth.json` untouched.
- **Artifact:** `local-ignore/qa-evidence/20260817-custom-system-prompt/` (qa-run.log + per-case captured system prompts; local evidence dir, gitignored by design).
- **Automated:** new `test/suite/prompt-presets-system-prompt-override.test.ts` (5 harness tests: turn path + model-switch path), startup-header suite extended (custom prompt suppresses header), existing `test/agent-session-system-prompt.test.ts` still green. Root `npm run check` green. Full coding-agent suite: 7787 passed; 2 unrelated timing tests (`mcp/startup-race`, `suite/reload-timings`) failed under full-suite load and pass in isolation.

## Risks & Residuals

- Public extension API: the new base-context getter is optional, so existing extensions and hand-built contexts keep compiling — mitigated, covered by `npm run check` across all workspaces.
- No-override path: the generated prompt is byte-identical when no flags are set (asserted by QA case 3 and the existing preset suites) — mitigated.
- `--system-prompt` intentionally replaces the entire engineered base prompt; that is the documented upstream semantic and now also documented in usage.md — accepted.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores CLI `--system-prompt` and `--append-system-prompt` and makes per‑model prompt presets yield to them. Previously, presets replaced the base prompt on matching models and dropped user overrides; now a custom system prompt wins and appends survive preset replacement, and the startup header is suppressed when a custom prompt is active.

**Key changes**
- Preset interplay (`prompt-preset/index.ts`): `before_agent_start` and `model_select` return no replacement when `customPrompt` is present; when only appends exist, presets apply and reattach appends (`preset + "\n\n" + appends`).
- Override visibility (`agent-session.ts`, `extensions/types.ts`, `extensions/runner.ts`): `_baseSystemPromptOptions` now carries `customPrompt` and pre-joined `appendSystemPrompt`; events and a new optional `ctx.getSystemPromptOptions?()` expose them (still required on `ExtensionCommandContext`).
- CLI wiring (`main.ts`): forwards parsed `systemPrompt` and `appendSystemPrompt` into the runtime resource loader.
- Tests and docs: new suite validates override vs preset behavior and header suppression; usage and changelog updated.
- Compatibility: default preset paths are unchanged when no overrides are provided; the new context getter is optional on the base context, so existing extensions remain source-compatible.

<sup>Written for commit 8427bbd15ef8953c09a47413126e84c01c4fcdbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

