### PR TITLE
docs: add Cursor Cloud specific instructions for env setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,3 +141,13 @@ Persistent terminals -> packages/pty -> crates/senpi-pty
 - Releases use CalVer and lockstep-version the packages listed in `scripts/release-packages.mjs`.
 - Release only from clean `main` after changelog audit and local release smoke tests. `scripts/release.mjs` owns versioning, generated artifacts, checks, commits, tag, and push.
 - Never rerun the release script after its tag is pushed; failed publishing is retried from the existing tag workflow.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious caveats for cloud agents. Standard commands live in `## COMMANDS` and `.agents/skills/senpi-qa/SKILL.md`; this section only records what is easy to get wrong.
+
+- **Node runtime is the main gotcha.** The VM's ambient `node` (`/exec-daemon/node`, first-ish in `PATH`) is v22, but `package.json#engines` requires `>=24`. Node 24 is installed via `nvm` and exposed to every shell (login and non-login) by symlinks in `/usr/local/cargo/bin` — the first, writable `PATH` entry — so bare `node`/`npm`/`npx` already resolve to v24. Don't "fix" a version mismatch by pointing at `/exec-daemon/node`; if bare `node` ever reports v22, re-run the update script or re-create the symlinks (`ln -sf "$(nvm which 24)" /usr/local/cargo/bin/node`, likewise `npm`/`npx`). `/exec-daemon` is read-only sandbox infra — never modify it.
+- **No provider API keys are configured by default.** The CLI boots and renders but shows "No models available", so real agent turns can't run. Exercise the full agent loop with zero tokens via the senpi-qa mock-loop channel (`node .agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool`) — it spins up a local fake model server and needs no credentials. Add a real key (e.g. `ANTHROPIC_API_KEY`) to `.env.local` or the environment only if you need live-provider QA.
+- **Run the app from source** with `./pi-test.sh` (TUI) — no build step needed; it runs via `tsx`.
+- **`npm run check` uses `biome --write`** and will silently reformat files. On the current tree it reformats a couple of pre-existing drifted files, leaving the working tree dirty even though it exits 0 — revert those with `git checkout -- <path>` if you didn't intend to touch them.
+- **`npm test` runs the entire workspace suite and takes several minutes** (~9 min observed); scope to a single package's test command during iteration.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Cloud Agent development environment for the `senpi` monorepo and records the durable, non-obvious caveats for future cloud agents under a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

This PR contains a single docs change (`AGENTS.md`). No runtime source is touched, so the changelog gate passes. The remaining setup lives in the VM update script (Node 24 provisioning + `npm install --ignore-scripts` + `node scripts/devenv-setup.mjs`), not in the repo.

## Environment findings

- **Node runtime gotcha:** the VM's ambient `node` (`/exec-daemon/node`) is v22, but `package.json#engines` requires `>=24`. Node 24 is installed via `nvm` and symlinked into `/usr/local/cargo/bin` (first, writable `PATH` entry) so bare `node`/`npm`/`npx` resolve to v24 for every shell. `/exec-daemon` is read-only sandbox infra and is never modified.
- **No provider keys configured:** the CLI boots but shows "No models available". The full agent loop is exercised with zero tokens via the senpi-qa mock-loop channel (local fake model server).

## Verification

| Step | Command | Result |
|---|---|---|
| Install | `node scripts/devenv-setup.mjs` | 508 pkgs + skill deps, exit 0 |
| Lint / static | `npm run check` | exit 0 (biome, pinned-deps, ts-imports, shrinkwrap/install-lock, tsc --noEmit, browser-smoke) |
| Tests | `npm test` | exit 0 (all workspaces, e.g. tui + sqlite-node 87/87) |
| QA self-tests | common / cli-smoke / rpc-drive / mock-loop | 9/9, 8/8, 4/4, 48/48 |
| Hello-world | `mock-loop.mjs --with-tool` | 4/4 — full agent turn (model → bash tool → final text) |
| App run | `./pi-test.sh` (TUI) | boots, renders header + extensions, accepts composer input |

### Demo

Full agent turn (executes a `bash` tool end-to-end) then the real interactive TUI booting from source:

[senpi_agent_turn_and_tui_demo.mp4](https://cursor.com/agents/bc-2fd5b510-18ce-445e-9f88-61a8e494666d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsenpi_agent_turn_and_tui_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd5b510-18ce-445e-9f88-61a8e494666d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd5b510-18ce-445e-9f88-61a8e494666d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Cursor Cloud specific instructions" section to `AGENTS.md` to document Cloud Agent environment setup and prevent common pitfalls. Previously the docs lacked cloud-specific guidance; now they cover Node 24 setup, running without provider keys, and tooling behavior.

**Cursor Cloud caveats**
- Node runtime: the VM’s ambient `node` is v22 but `package.json#engines` requires >=24. Use `nvm`-installed Node 24 symlinked in `/usr/local/cargo/bin`; if `node` shows v22, rerun the VM update script or recreate symlinks. Do not modify `/exec-daemon`.
- Provider keys: none are configured by default. Use the senpi-qa mock loop (`.agents/skills/senpi-qa/scripts/mock-loop.mjs --with-tool`) for full agent turns without credentials; add real keys (e.g., `ANTHROPIC_API_KEY`) to `.env.local` only if needed.
- Run from source: launch the TUI via `./pi-test.sh`; no build step required.
- Lint/tests: `npm run check` formats files and may leave the tree dirty; `npm test` runs the full workspace and is slow—scope to a single package during iteration.

<sup>Written for commit 19f0a1fab61f982b63a7edea4ed10b40c73ea0af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

