### PR TITLE
fix(rpc): stop command refresh feedback loops

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/dollar-skill-invocation-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/dollar-skill-invocation-qa.mjs
@@ -42,23 +42,34 @@ writeFileSync(
 	"---\nname: debugging\ndescription: Debug runtime failures\n---\n\n# Debugging\n\nTrace the defect before proposing a fix.",
 );
 
-const extensionPath = join(box.cwd, "dollar-invocation-qa-extension.ts");
-writeFileSync(
-	extensionPath,
-	`export default function dollarInvocationQa(pi) {
+const extensionPath = join(box.agentDir, "extensions", "dollar-invocation-qa-extension.ts");
+mkdirSync(join(box.agentDir, "extensions"), { recursive: true });
+const writeQaExtension = (includeReloadCommand) => {
+	const reloadCommand = includeReloadCommand
+		? `
+  pi.registerCommand("reload-proof", {
+    description: "Reload proof command",
+    handler: () => {},
+  });`
+		: "";
+	writeFileSync(
+		extensionPath,
+		`export default function dollarInvocationQa(pi) {
   pi.registerCommand("echo", {
     description: "Echo QA command",
     handler: () => {},
-  });
+  });${reloadCommand}
 }
 `,
-);
+	);
+};
+writeQaExtension(false);
 
 const client = new TargetRpcClient({
 	env: hermeticEnv(box.env),
 	cwd: box.cwd,
 	targetRoot: root,
-	extraArgs: ["--skill", skillDir, "-e", extensionPath],
+	extraArgs: ["--skill", skillDir],
 });
 const startupTimeoutMs = 240_000;
 
@@ -97,17 +108,26 @@ try {
 		initialCommandsResponse.success === true,
 		JSON.stringify(initialCommandsResponse),
 	);
+	checks.ok(
+		"initial command snapshot does not invalidate clients",
+		client.events.every((event) => event.message.type !== "commands_changed"),
+		JSON.stringify(client.events.map((event) => event.message.type)),
+	);
 
+	const commandsChangedPromise = waitForEventType("commands_changed", 60_000, client.events.length);
+	writeQaExtension(true);
+	const commandsChanged = await commandsChangedPromise;
 	const commandsResponse = await client.send({ type: "get_commands" }, 60_000);
 	const commands = commandsResponse.data?.commands ?? [];
-	const commandsChanged = await waitForEventType("commands_changed");
 	const echoRow = commands.find((command) => command.name === "echo");
+	const reloadProofRow = commands.find((command) => command.name === "reload-proof");
 	const skillRow = commands.find((command) => command.name === "skill:debugging");
 	checks.ok("commands response accepted", commandsResponse.success === true, JSON.stringify(commandsResponse));
 	checks.ok("extension command candidate present", echoRow?.syntax === "slash", JSON.stringify(echoRow));
+	checks.ok("reloaded command candidate present", reloadProofRow?.syntax === "slash", JSON.stringify(reloadProofRow));
 	checks.ok("skill candidate present", skillRow?.syntax === "dollar", JSON.stringify(skillRow));
 	checks.ok(
-		"commands changed matches ordered candidates",
+		"post-baseline commands changed matches ordered candidates",
 		JSON.stringify(commandsChanged.commands) === JSON.stringify(commands),
 		JSON.stringify({ commandsChanged, commands }),
 	);
@@ -183,6 +203,7 @@ try {
 				prompt,
 				accepted,
 				commandAccepted,
+				initialCommands,
 				commandsChanged,
 				commands,
 				commandInvocation,
@@ -205,7 +226,8 @@ try {
 		[
 			"# Dollar Invocation RPC QA",
 			"",
-			"- PASS: `commands_changed` matches the ordered `get_commands` candidate snapshot.",
+			"- PASS: the initial `get_commands` snapshot does not emit `commands_changed`.",
+			"- PASS: an extension reload emits one `commands_changed` snapshot matching the new ordered candidates.",
 			"- PASS: one accepted `/echo` invocation emits exactly one typed `command_invocation` event.",
 			"- PASS: one `$skill:debugging` token emits exactly one typed `skill_invocation` event.",
 			"- PASS: ordinary `$HOME` text remains literal and MCP loaded surfaces remain unchanged.",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,7 +14,8 @@
 
 - RPC discovery sessions no longer emit an initial `commands_changed` invalidation. Clients read the baseline through
   `get_commands`, while actual post-bind extension reloads still emit one deduplicated ordered snapshot, preventing
-  command-surface refresh consumers from creating an unbounded discovery-session feedback loop.
+  command-surface refresh consumers from creating an unbounded discovery-session feedback loop
+  ([#911](https://github.com/code-yeongyu/senpi/pull/911)).
 - Preserved prompt indentation and literal dollar text around explicit skill tokens, bounded adversarial token parsing
   and RPC text inputs, and prevented transformed prompt templates from emitting stale invocation metadata
   ([#909](https://github.com/code-yeongyu/senpi/pull/909)).

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- RPC discovery sessions no longer emit an initial `commands_changed` invalidation. Clients read the baseline through
+  `get_commands`, while actual post-bind extension reloads still emit one deduplicated ordered snapshot, preventing
+  command-surface refresh consumers from creating an unbounded discovery-session feedback loop.
 - Preserved prompt indentation and literal dollar text around explicit skill tokens, bounded adversarial token parsing
   and RPC text inputs, and prevented transformed prompt templates from emitting stale invocation metadata
   ([#909](https://github.com/code-yeongyu/senpi/pull/909)).

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -1468,8 +1468,9 @@ surfaces; clients continue to use `loaded_surfaces_changed` plus `get_loaded_sur
 
 ### commands_changed
 
-Emitted once after initial RPC bind and again whenever a runtime reload changes the ordered command surface. The
-`commands` payload has the same shape and ordering as `get_commands`; identical snapshots are not re-emitted.
+Emitted whenever a post-bind runtime reload changes the ordered command surface. The initial surface is available
+through `get_commands` and does not emit this invalidation event. The `commands` payload has the same shape and
+ordering as `get_commands`; identical snapshots are not re-emitted.
 
 ```json
 {

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## Suppress initial command-surface invalidation events (2026-08-17)
+
+### What changed
+
+- RPC records the initial ordered command digest without publishing `commands_changed`.
+- Later distinct command snapshots still publish once, while identical reload snapshots remain deduplicated.
+- Focused coverage distinguishes baseline initialization from an actual post-bind command-surface change.
+
+### Why
+
+- Discovery sessions already fetch their initial command surface with `get_commands`. Treating that baseline as an
+  invalidation made clients refresh provider discovery, whose new sessions emitted another baseline invalidation and
+  created an unbounded refresh loop.
+
+### Why extension system couldn't handle this
+
+- Baseline establishment and JSONL event emission are owned by the built-in RPC transport.
+
+### Expected merge conflict zones
+
+- LOW: `rpc-command-surface.ts` initial-digest guard and its focused regression.
+
 ## Publish typed command surfaces and invocation events without disturbing MCP inventory (2026-08-16) ([PR #909](https://github.com/code-yeongyu/senpi/pull/909))
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/rpc-command-surface.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-command-surface.ts
@@ -89,6 +89,6 @@ export function createCommandsChangedEvent(
 	previousDigest: string | undefined,
 	commands: readonly RpcSlashCommand[],
 ): RpcCommandsChangedEvent | undefined {
-	if (previousDigest === rpcCommandListDigest(commands)) return undefined;
+	if (previousDigest === undefined || previousDigest === rpcCommandListDigest(commands)) return undefined;
 	return { type: "commands_changed", commands };
 }

--- a/packages/coding-agent/test/rpc-commands-changed.test.ts
+++ b/packages/coding-agent/test/rpc-commands-changed.test.ts
@@ -9,7 +9,7 @@ import {
 const sourceInfo = createSyntheticSourceInfo("rpc-commands-changed-test", { source: "test" });
 
 describe("RPC command surface updates", () => {
-	it("publishes the ordered command surface once per distinct snapshot", () => {
+	it("publishes only post-baseline command surface changes", () => {
 		const commands = buildRpcCommands({
 			extensionCommands: [{ name: "hooks", description: "Manage hooks", sourceInfo }],
 			promptTemplates: [{ name: "review", description: "Review work", sourceInfo }],
@@ -22,8 +22,20 @@ describe("RPC command surface updates", () => {
 			{ name: "skill:debugging", source: "skill", syntax: "dollar" },
 		]);
 
-		const event = createCommandsChangedEvent(undefined, commands);
-		expect(event).toEqual({ type: "commands_changed", commands });
+		expect(createCommandsChangedEvent(undefined, commands)).toBeUndefined();
 		expect(createCommandsChangedEvent(rpcCommandListDigest(commands), commands)).toBeUndefined();
+
+		const changedCommands = buildRpcCommands({
+			extensionCommands: [
+				{ name: "hooks", description: "Manage hooks", sourceInfo },
+				{ name: "reload", description: "Reload extensions", sourceInfo },
+			],
+			promptTemplates: [{ name: "review", description: "Review work", sourceInfo }],
+			skills: [{ name: "debugging", description: "Debug runtime failures", sourceInfo }],
+		});
+		expect(createCommandsChangedEvent(rpcCommandListDigest(commands), changedCommands)).toEqual({
+			type: "commands_changed",
+			commands: changedCommands,
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Stops RPC command-surface consumers from entering a self-sustaining refresh loop. Initial RPC sessions now establish their command digest silently through `get_commands`; only actual post-bind command changes emit `commands_changed`.

## Changes

- suppress the initial `commands_changed` notification while preserving distinct post-bind updates
- extend focused coverage for baseline suppression, identical-snapshot deduplication, and changed-snapshot emission
- upgrade the real RPC QA scenario to mutate a sandboxed extension and prove exactly one live reload event
- align the public RPC specification, fork change ledger, and package changelog with the corrected lifecycle

## QA & Evidence

- **Focused regression:** `npx vitest run test/rpc-commands-changed.test.ts`
  - Result: 1/1 passed
- **Static validation:** `npm run check`
  - Result: passed with no warnings or generated lock drift
- **Build:** `npm run build`
  - Result: all workspace phases passed
- **Real RPC QA:** `node .agents/skills/senpi-qa/scripts/scenarios/dollar-skill-invocation-qa.mjs --evidence 20260817-commands-changed-loop-fix-rerun`
  - Result: 18/18 passed
  - Proved no initial invalidation, one post-reload ordered snapshot, and exactly one command/skill invocation event
- **Changelog gate:** `node scripts/check-pr-changelog.mjs --base origin/main`
  - Result: passed

## Risks & Residuals

- Clients must obtain their initial command inventory with `get_commands`; this was already the request/response contract used by provider discovery.
- Post-bind extension reloads remain observable and deduplicated.
- The desktop runtime pin will advance to this merge before the dependent desktop follow-up ships.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the initial RPC command-surface invalidation to stop self-sustaining refresh loops. Previously we emitted `commands_changed` on initial bind; now clients read the baseline via `get_commands`, and only post-bind changes emit one deduplicated `commands_changed`.

- Review the guard in `packages/coding-agent/src/modes/rpc/rpc-command-surface.ts` (skip emit when `previousDigest` is undefined or unchanged).
- Tests assert baseline suppression and single post-reload emission; the QA scenario verifies no initial invalidation and exactly one `commands_changed` matching `get_commands`.
- Docs and changelog updated in `packages/coding-agent` to reflect the lifecycle; clients should fetch the initial command inventory with `get_commands` instead of waiting for an initial event.

<sup>Written for commit 71b8f06ebeedd56fc7e3cde3e475f808bb917f9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

