### PR TITLE
[Draft] feat(prompt-preset): add delegation + skill gates to deepseek-v4 and kimi-k3 (canary measuring)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1219,6 +1219,8 @@
 
 ### Fixed
 
+- DeepSeek V4 (flash/flash-0731/pro) presets now carry delegation and visible-skill gates; Kimi K3 adds the skill gate alongside the redesigned core's existing bounded delegation rule. This remains a draft canary pending at least 20 qualified turns (see PR #912).
+
 - Extension selectors (including the `/fallback` model picker) now window long option lists around the
   highlighted row instead of rendering every entry. On large model registries the full list overflowed the
   viewport and the moved highlight was never painted, so arrow keys and j/k appeared to do nothing even

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/deepseek-v4.ts
@@ -22,9 +22,11 @@ export type DeepseekV4RuleId =
 	| "todo-discipline"
 	| "missing-info"
 	| "settled-reading"
-	| "reasoning-aim";
+	| "reasoning-aim"
+	| "delegate-separable-work"
+	| "load-matching-skills";
 
-export type DeepseekV4Concern = "harness-contract" | "todo" | "grounding" | "deliberation";
+export type DeepseekV4Concern = "harness-contract" | "todo" | "grounding" | "deliberation" | "subagent-delegation" | "skill-utilization";
 
 export type DeepseekV4PresetName = "deepseek-v4-flash" | "deepseek-v4-flash-0731" | "deepseek-v4-pro";
 
@@ -73,6 +75,20 @@ export const DEEPSEEK_V4_RULES: readonly DeepseekV4Rule[] = [
 		presets: ["deepseek-v4-pro"],
 		directive:
 			"Aim extended reasoning at the problem - the code, the design, the failure - and end it in an action. When reasoning stalls on a missing fact, stop deliberating and fetch the fact; a cheap read beats a long internal debate. Deliver a conclusion and a recommendation, not a survey of options.",
+	},
+	{
+		id: "delegate-separable-work",
+		concern: "subagent-delegation",
+		presets: ALL_PRESETS,
+		directive:
+			"At task intake, partition the work into the local critical path and separable workstreams. A bounded workstream that does not depend on the parent's in-progress edits is a `task` call: spawn it before local implementation, and submit independent workstreams in one batch. Keep only trivial lookups and tightly coupled edits local. Delegation is complete only after every child result has been read and its evidence integrated into the parent answer.",
+	},
+	{
+		id: "load-matching-skills",
+		concern: "skill-utilization",
+		presets: ALL_PRESETS,
+		directive:
+			"Before the first non-discovery action, compare the task with every visible skill description. For each loose match, read that skill's listed `SKILL.md` and follow it; when matching work is delegated, include the skill name in `load_skills`. Proceed without a skill only after this scan finds no match - recognizing a match without loading it does not complete the gate.",
 	},
 ];
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/kimi-k3.ts
@@ -80,6 +80,8 @@ Before each response, list what you need next, then request every item that does
 
 ${buildExecutionToolingParagraph({ toolNames: context.tools.map((tool) => tool.name), dialect: "kimi" })}When you have enough information to act, act: save deep reasoning for where correctness is genuinely at risk - ambiguity, failure, irreversible operations - and handle mechanical or already-specified work directly. Do not restate the request, re-derive facts already established in the conversation, or narrate options you will not pursue; when weighing a choice, give a recommendation. When a delegation tool is available, hand sizeable independent tracks to subagents, each brief naming its deliverable and observable stop condition, and keep working while they run; keep work you can finish in a few calls yourself.
 
+Make the visible-skill scan a terminal gate before substantive work: compare the task with every listed description, read each loosely matching \`SKILL.md\`, and apply it. If matching work is delegated, pass its skill name in \`load_skills\`. The gate is complete only when all matches are loaded or the scan finds none.
+
 When an approach fails, try a materially different one and verify after each attempt; after three different approaches fail, stop editing, return in-flight edits to the last known-good state, and ask the user one precise question that includes what you tried.
 
 ## Verification


### PR DESCRIPTION
## Draft — canary measuring, ready on M1-M4

This PR switches to ready when the **canary (personal extension `omo-subagent-skill-correction`)** passes the behavior gates.

- **Background**: GPT presets have delegation rules such as `DELEGATION`, but DeepSeek V4 (3 variants) and K3 do not. Observed: K3 delegation rate 0.21% (1/470), DeepSeek first delegation at 62.3 messages, SKILL.md read 0 times (`.omo/plans/omo-model-presets-deepseek-k3.md` Findings).
- **Changes**:
  - `deepseek-v4.ts` 5→7 rules: `delegate-separable-work` + `load-matching-skills` (ALL_PRESETS, 2 of 4 rules)
  - `kimi-k3.ts` core `Working the Task`: add one-shot delegation decision + skill terminal gate, 2 paragraphs (canary Appendix A verbatim)
- **Tests**: `prompt-presets-deepseek-v4` 66/66, including `prompt-presets-kimi-k3` — same IDs as existing canary rules (`deepseek-v4.delegate-separable-work` etc.), structure parsing only (no pinned prose).
- **Gate**: Appendix B — ready after `≥20 qualified turns or 2 weeks, M1 +10%p, M2 +10%p, M3 ≤+5%p, M4 ≤+2%p`. Do not merge before pass (G13).

**Canary**: `~/.omo/agent/extensions/omo-subagent-skill-correction.ts` (DISABLED=false) — the same 4 rules are already being injected on this machine. Measurement and reports go daily at 09:00 to the Discord collection-susemi channel.

**Related**: .omo/plans/omo-model-presets-deepseek-k3.md, .omo/scripts/omo-subagent-skill-correction.mjs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds delegation and visible-skill gates to DeepSeek V4 and Kimi K3 presets to address under-delegation and missed `SKILL.md` usage. Previously these presets kept work local and skipped the skill scan; now they partition work at intake, batch separable `task` calls, and enforce a terminal visible-skill scan that loads matching skills and passes `load_skills` when delegating.

**Review and rollout**
- Changes are limited to `deepseek-v4.ts`, `kimi-k3.ts`, and a fix note in `CHANGELOG.md` under `packages/coding-agent`.
- DeepSeek V4 grows from 5 to 7 rules, adding `delegate-separable-work` and `load-matching-skills` across all three presets; Kimi K3 adds one visible-skill gate paragraph under "Working the Task".
- Tests pass 66/66. Verify each preset renders the new rules exactly once and that no non-rule prose is pinned.
- Canary measuring only. Hold promotion until gates pass: ≥20 qualified turns or 2 weeks, with M1 +10pp, M2 +10pp, M3 ≤+5pp, M4 ≤+2pp vs baseline.

<sup>Written for commit 412544881d1db4ffaff8fbd08cf36695c8b91532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

