### PR TITLE
feat(codemode): show eval tool-call throughput

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/eval-throughput-badge-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/eval-throughput-badge-qa.mjs
@@ -1,0 +1,392 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, watch, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+	cliEntry,
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+	stripAnsi,
+	tsxEntry,
+} from "../lib/common.mjs";
+import { startFakeModelServer } from "../lib/fake-model-server.mjs";
+import { API_PRESETS, hermeticEnv, writeMockModelsJson } from "../lib/mock-loop-support.mjs";
+
+const API = "openai-completions";
+const COLS = 120;
+const ROWS = 34;
+const FINAL_MARKER = "EVAL-THROUGHPUT-DONE";
+const COMMAND =
+	"node .agents/skills/senpi-qa/scripts/scenarios/eval-throughput-badge-qa.mjs --self-test --evidence eval-throughput-badge";
+
+const argv = process.argv.slice(2);
+const evidenceIndex = argv.indexOf("--evidence");
+const evidenceSlug = evidenceIndex >= 0 ? argv[evidenceIndex + 1] : undefined;
+if (!argv.includes("--self-test")) throw new Error("pass --self-test");
+if (!evidenceSlug) throw new Error("--evidence requires a slug");
+
+function recordedChecks(title) {
+	const rows = [];
+	return {
+		ok(name, pass, detail = "") {
+			rows.push({ name, pass: Boolean(pass), detail });
+			process.stdout.write(`[${pass ? "PASS" : "FAIL"}] ${name}${detail ? ` — ${detail}` : ""}\n`);
+		},
+		finish() {
+			const failed = rows.filter((row) => !row.pass).length;
+			process.stdout.write(`\n${title}: ${rows.length - failed}/${rows.length} passed\n`);
+			return { passed: failed === 0, rows };
+		},
+	};
+}
+
+function waitForCapture(term, read, predicate, timeoutMs, label) {
+	return new Promise((resolveWait, rejectWait) => {
+		let settled = false;
+		const finish = (error) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			dataDisposable.dispose();
+			exitDisposable.dispose();
+			if (error) rejectWait(error);
+			else resolveWait();
+		};
+		const inspect = () => {
+			if (predicate(stripAnsi(read()))) finish();
+		};
+		const dataDisposable = term.onData(inspect);
+		const exitDisposable = term.onExit(() => finish(new Error(`TUI exited while waiting for ${label}`)));
+		const timer = setTimeout(() => finish(new Error(`Timed out waiting for ${label}`)), timeoutMs);
+		inspect();
+	});
+}
+
+function waitForExit(term, timeoutMs) {
+	return new Promise((resolveWait) => {
+		let settled = false;
+		const finish = (exited) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			disposable.dispose();
+			resolveWait(exited);
+		};
+		const disposable = term.onExit(() => finish(true));
+		const timer = setTimeout(() => finish(false), timeoutMs);
+	});
+}
+
+async function spawnTerminal(command, args, options) {
+	if (process.platform !== "darwin") {
+		const ptyModule = await import("node-pty");
+		const pty = ptyModule.default ?? ptyModule;
+		return pty.spawn(command, args, options);
+	}
+	const id = `senpi-qa-eval-throughput-${process.pid}`;
+	const session = id;
+	const startChannel = `${id}-start`;
+	const exitChannel = `${id}-exit`;
+	const pipePath = options.pipePath;
+	writeFileSync(pipePath, "");
+	const quote = (value) => `'${String(value).replaceAll("'", `'\\''`)}'`;
+	const commandLine = [command, ...args].map(quote).join(" ");
+	const envNames = [
+		"SENPI_CODING_AGENT_DIR",
+		"SENPI_CODING_AGENT_SESSION_DIR",
+		"HOME",
+		"USERPROFILE",
+		"PI_OFFLINE",
+		"PI_TELEMETRY",
+		"SENPI_OMO_LOCAL_UPDATE",
+		"PAGER",
+		"GIT_PAGER",
+		"PATH",
+		"TERM",
+		"COLORTERM",
+	];
+	const envPrefix = envNames
+		.filter((name) => options.env[name] !== undefined)
+		.map((name) => `${name}=${quote(options.env[name])}`)
+		.join(" ");
+	const shell = `tmux wait-for ${quote(startChannel)}; ${envPrefix} ${commandLine}; status=$?; tmux wait-for -S ${quote(exitChannel)}; exit $status`;
+	const runTmux = (tmuxArgs, allowFailure = false) => {
+		const result = spawnSync("tmux", tmuxArgs, { encoding: "utf8" });
+		if (!allowFailure && result.status !== 0) {
+			throw new Error(`tmux ${tmuxArgs[0]} failed: ${result.stderr || result.stdout}`);
+		}
+	};
+	runTmux([
+		"new-session",
+		"-d",
+		"-s",
+		session,
+		"-x",
+		String(options.cols),
+		"-y",
+		String(options.rows),
+		"-c",
+		options.cwd,
+		"/bin/sh",
+		"-lc",
+		shell,
+	]);
+	runTmux(["pipe-pane", "-O", "-t", session, `cat > ${quote(pipePath)}`]);
+	const exitWaiter = spawn("tmux", ["wait-for", exitChannel], { stdio: "ignore" });
+	const dataListeners = new Set();
+	const exitListeners = new Set();
+	let offset = 0;
+	let exited = false;
+	const emitNewData = () => {
+		const data = readFileSync(pipePath);
+		if (data.length <= offset) return;
+		const chunk = data.subarray(offset).toString();
+		offset = data.length;
+		for (const listener of dataListeners) listener(chunk);
+	};
+	const watcher = watch(pipePath, emitNewData);
+	exitWaiter.once("exit", (exitCode, signal) => {
+		emitNewData();
+		exited = true;
+		for (const listener of exitListeners) listener({ exitCode: exitCode ?? 1, signal: signal ?? 0 });
+	});
+	runTmux(["wait-for", "-S", startChannel]);
+	return {
+		onData(listener) {
+			dataListeners.add(listener);
+			return { dispose: () => dataListeners.delete(listener) };
+		},
+		onExit(listener) {
+			if (exited) queueMicrotask(() => listener({ exitCode: 0, signal: 0 }));
+			exitListeners.add(listener);
+			return { dispose: () => exitListeners.delete(listener) };
+		},
+		write(data) {
+			if (data === "\x03\x03") {
+				runTmux(["send-keys", "-t", session, "C-c", "C-c"], true);
+				return;
+			}
+			const text = data.endsWith("\r") ? data.slice(0, -1) : data;
+			if (text.length > 0) runTmux(["send-keys", "-t", session, "-l", text]);
+			if (data.endsWith("\r")) runTmux(["send-keys", "-t", session, "-l", "\r"]);
+		},
+		kill() {
+			emitNewData();
+			watcher.close();
+			runTmux(["kill-session", "-t", session], true);
+			runTmux(["wait-for", "-S", exitChannel], true);
+			exitWaiter.kill();
+		},
+	};
+}
+
+function chromeExecutable() {
+	const candidates = [
+		process.env.CHROME_PATH,
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+		"/usr/bin/google-chrome",
+		"/usr/bin/chromium",
+		"/usr/bin/chromium-browser",
+	].filter((candidate) => typeof candidate === "string");
+	return candidates.find((candidate) => existsSync(candidate));
+}
+
+function gridRows(grid) {
+	return grid.cells.map((row) => row.map((cell) => cell.glyph).join("").trimEnd());
+}
+
+function sanitizedRequests(requests) {
+	return requests.map((request) => ({
+		method: request.method,
+		url: request.url,
+		model: request.model,
+		toolNames: Array.isArray(request.tools) ? request.tools.map((tool) => tool.function?.name ?? tool.name) : [],
+	}));
+}
+
+async function main() {
+	installCleanupHooks();
+	const checks = recordedChecks("eval-throughput-badge-qa.mjs --self-test");
+	const guard = guardRealAuth();
+	const root = repoRoot();
+	const evidence = evidenceDir(evidenceSlug);
+	const box = makeSandbox("eval-throughput-badge");
+	writeFileSync(join(box.cwd, "note.txt"), "throughput-qa\n");
+
+	let server;
+	let term;
+	let raw = "";
+	let finalRaw = "";
+	let runError;
+	const cleanup = {
+		ptyExited: false,
+		serverStopped: false,
+		sandboxRemoved: false,
+		authUnchanged: false,
+	};
+
+	try {
+		server = await startFakeModelServer({
+			turns: [
+				{
+					toolCalls: [
+						{
+							name: "eval",
+							args: {
+								language: "js",
+								summary: "measure eval nested tool throughput",
+								code: [
+									'const note = await tool.read({ path: "note.txt" });',
+									'const shell = await tool.bash({ command: "printf throughput-qa" });',
+									'"tools-done";',
+								].join("\n"),
+							},
+						},
+					],
+				},
+				{ text: FINAL_MARKER },
+			],
+		});
+		writeMockModelsJson(box.agentDir, server, API);
+		const preset = API_PRESETS[API];
+		term = await spawnTerminal(
+			process.execPath,
+			[
+				tsxEntry(root),
+				"--tsconfig",
+				join(root, "tsconfig.json"),
+				cliEntry(root),
+				"--no-context-files",
+				"--no-skills",
+				"--no-extensions",
+				"--approve",
+				"--provider",
+				preset.provider,
+				"--model",
+				preset.modelId,
+				"Run the eval throughput probe.",
+			],
+			{
+				name: "xterm-color",
+				cols: COLS,
+				rows: ROWS,
+				cwd: box.cwd,
+				env: hermeticEnv(box.env),
+				pipePath: join(box.dir, "eval-throughput-pty.ans"),
+			},
+		);
+		term.onData((data) => {
+			raw += data;
+		});
+		await waitForCapture(term, () => raw, (text) => text.includes(FINAL_MARKER), 120_000, "final model marker");
+		finalRaw = raw;
+	} catch (error) {
+		runError = error;
+	} finally {
+		if (term) {
+			const exited = waitForExit(term, 5_000);
+			try {
+				term.write("\x03\x03");
+				term.kill();
+			} catch {}
+			cleanup.ptyExited = await exited;
+		} else cleanup.ptyExited = true;
+		if (server) {
+			await server.stop().catch(() => {});
+			cleanup.serverStopped = true;
+		} else cleanup.serverStopped = true;
+		box.cleanup();
+		cleanup.sandboxRemoved = !existsSync(box.dir);
+		try {
+			cleanup.authUnchanged = guard.assertUnchanged();
+		} catch {}
+	}
+	if (finalRaw.length === 0) finalRaw = raw;
+
+	const rawPath = join(evidence, "eval-throughput-badge.ans");
+	const gridPath = join(evidence, "eval-throughput-badge.grid.json");
+	const htmlPath = join(evidence, "eval-throughput-badge.html");
+	const screenshotPath = join(evidence, "eval-throughput-badge.png");
+	const transcriptPath = join(evidence, "eval-throughput-badge.txt");
+	writeFileSync(rawPath, finalRaw);
+
+	const xterm = spawnSync(
+		process.execPath,
+		[
+			join(root, "scripts", "qa", "xterm-render.mjs"),
+			"render",
+			rawPath,
+			"--cols",
+			String(COLS),
+			"--rows",
+			String(ROWS),
+			"--out-json",
+			gridPath,
+			"--out-html",
+			htmlPath,
+			"--title",
+			"Senpi eval throughput badge",
+		],
+		{ cwd: root, encoding: "utf8" },
+	);
+	const grid = existsSync(gridPath) ? JSON.parse(readFileSync(gridPath, "utf8")) : undefined;
+	const visibleRows = grid ? gridRows(grid) : [];
+	const visibleText = visibleRows.join("\n");
+	writeFileSync(transcriptPath, `${visibleText}\n`);
+	const header = visibleRows.find((row) => row.includes("eval js done")) ?? "";
+	const rate = header.match(/\b\d+\.\d{2} calls\/s\b/u)?.[0];
+	const agentRequests =
+		server?.requests.filter(
+			(request) =>
+				Array.isArray(request.tools) &&
+				request.tools.some((tool) => (tool.function?.name ?? tool.name) === "eval"),
+		) ?? [];
+	const chrome = chromeExecutable();
+	const screenshot =
+		chrome === undefined
+			? undefined
+			: spawnSync(
+					chrome,
+					[
+						"--headless=new",
+						"--disable-gpu",
+						"--hide-scrollbars",
+						"--window-size=1280,720",
+						"--virtual-time-budget=2000",
+						`--screenshot=${screenshotPath}`,
+						pathToFileURL(resolve(htmlPath)).href,
+					],
+					{ encoding: "utf8" },
+				);
+
+	checks.ok("scenario completed without runtime error", runError === undefined, runError instanceof Error ? runError.message : "");
+	checks.ok(
+		"fake provider handled eval and final agent turns",
+		agentRequests.length === 2,
+		`agentRequests=${agentRequests.length} totalRequests=${server?.requests.length ?? 0}`,
+	);
+	checks.ok("xterm.js rendered raw PTY bytes", xterm.status === 0 && grid !== undefined, xterm.stderr || xterm.stdout);
+	checks.ok("final grid contains completed eval header", header.includes("eval js done ✓"), header);
+	checks.ok("final grid contains exact nested call count", header.includes("2 calls"), header);
+	checks.ok("final grid contains finite two-decimal calls/s", rate !== undefined, header);
+	checks.ok("final grid contains elapsed time after throughput", /calls\/s · (?:<1s|\d+(?:s|m|h)(?: \d+[sm])?)/u.test(header), header);
+	checks.ok("Chrome produced xterm screenshot", screenshot?.status === 0 && existsSync(screenshotPath), screenshot?.stderr ?? "");
+	checks.ok("all spawned resources and auth guard cleaned", Object.values(cleanup).every(Boolean), JSON.stringify(cleanup));
+	const result = checks.finish();
+
+	writeFileSync(join(evidence, "command.txt"), `${COMMAND}\n`);
+	writeFileSync(join(evidence, "requests.json"), `${JSON.stringify(sanitizedRequests(server?.requests ?? []), null, 2)}\n`);
+	writeFileSync(join(evidence, "cleanup.json"), `${JSON.stringify(cleanup, null, 2)}\n`);
+	writeFileSync(join(evidence, "checks.json"), `${JSON.stringify(result.rows, null, 2)}\n`);
+	if (runError) writeFileSync(join(evidence, "error.txt"), `${runError instanceof Error ? runError.stack : String(runError)}\n`);
+	process.stderr.write(`evidence: ${evidence}\n`);
+	process.exit(result.passed ? 0 : 1);
+}
+
+await main();

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Show exact nested tool-call count and calls-per-second in completed eval TUI headers, using true wall-clock elapsed time for both the visible duration and throughput denominator while preserving kernel-reported timing separately ([#916](https://github.com/code-yeongyu/senpi/pull/916)).
+
 ### Changed
 
 ### Fixed

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,42 @@
 # senpi-codemode fork changes
 
+## Eval completion throughput badge (2026-08-17)
+
+### What changed
+
+- Final single-cell eval frames now append the exact initiated nested tool-call count, a two-decimal
+  calls-per-second rate, and true wall-clock elapsed time to the completed header, for example
+  `eval py done ✓ · 2 calls · 1.00 calls/s · 2s · timeout 420s`.
+- `EvalToolDetails` carries `wallDurationMs` and `toolCallCount` alongside the existing
+  kernel-reported `durationMs`; the renderer uses wall time for final elapsed and throughput while
+  preserving kernel duration for consumers that need interpreter timing.
+- Zero calls over zero elapsed time render `0.00 calls/s`; positive calls without a positive wall
+  duration render `n/a calls/s`, so the TUI never displays `Infinity` or `NaN`.
+- Partial, pending, running, error, and synthetic multi-cell frames do not show a misleading final
+  aggregate. The legacy no-cells result path renders the same final metadata when the new fields are
+  available and preserves old output when they are absent.
+
+### Why
+
+- The eval extension already measures every nested tool invocation and true end-to-end wall time,
+  but users could only see completion duration and per-call rows. Surfacing count and throughput in
+  the final header makes eval composition efficiency observable without opening an analytics view.
+- Dividing by kernel-reported duration would overstate throughput whenever host tool calls wait
+  outside interpreter timing, so the visible elapsed label and the rate denominator share the same
+  wall-clock source.
+
+### Why this cannot be expressed externally
+
+- The completed frame is owned by the eval renderer, while exact initiated-call counts and cell
+  start time are owned by the eval runtime before the generic tool result reaches any external
+  extension. An external renderer cannot reconstruct both facts reliably.
+
+### Expected merge conflict zones
+
+- MEDIUM in `src/tool/render.ts` around `cellHeader`, `renderDetailedLines`, and final result metadata.
+- LOW in `src/tool/types.ts` and `src/tool/cell-runtime.ts` around `EvalToolDetails` construction.
+- LOW in eval renderer and execution-event tests.
+
 ## Eval execution metadata event (2026-08-16)
 
 ### What changed

--- a/packages/senpi-codemode/scripts/qa-render-dump.ts
+++ b/packages/senpi-codemode/scripts/qa-render-dump.ts
@@ -107,6 +107,7 @@ const details: EvalToolDetails = {
 	language: "py",
 	...(fixture === "success" ? { summary: "load config" } : {}),
 	durationMs: fixture === "success" ? 1_250 : 900,
+	...(fixture === "success" ? { wallDurationMs: 2_000, toolCallCount: 3 } : {}),
 	toolCalls:
 		fixture === "success"
 			? [

--- a/packages/senpi-codemode/src/tool/cell-runtime.ts
+++ b/packages/senpi-codemode/src/tool/cell-runtime.ts
@@ -127,6 +127,8 @@ export class CellResultBuilder {
 			languages: [this.#state.input.language],
 			...(this.#state.input.summary === undefined ? {} : { summary: this.#state.input.summary }),
 			durationMs: this.#state.durationMs,
+			wallDurationMs: Math.max(0, Date.now() - this.#state.startedAt),
+			toolCallCount: this.#state.toolCallMetrics.length,
 			toolCalls: [...this.#state.toolCalls],
 			truncated: output?.truncated ?? false,
 			...(isError ? { isError: true } : {}),

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -188,12 +188,18 @@ type RenderEnvironment = {
 	readonly width: number;
 	readonly meta: TruncationMeta | undefined;
 };
-type CellBadges = { readonly reset: boolean; readonly timeout: number | undefined };
+type CellBadges = {
+	readonly reset: boolean;
+	readonly timeout: number | undefined;
+	readonly throughput: CellThroughput | undefined;
+};
+type CellThroughput = { readonly calls: number; readonly wallDurationMs: number | undefined };
 type PrefixStyle = { readonly prefix: string; readonly continuation: string; readonly color: ThemeColor };
 type DetailedRenderContext = {
 	readonly environment: RenderEnvironment;
 	readonly args: EvalToolRequest;
 	readonly showImageFallback: boolean;
+	readonly isFinal: boolean;
 };
 
 function assertNever(value: never): never {
@@ -256,7 +262,9 @@ function renderPrefixed(text: string, environment: RenderEnvironment, prefixStyl
 function cellHeader(cell: EvalCellResult, environment: RenderEnvironment, badges: CellBadges): string {
 	const presentation = cellPresentation(cell.status, environment.spinnerFrame);
 	let header = `eval ${cell.language} ${presentation.label} ${presentation.icon}`;
-	if (cell.durationMs !== undefined) header += ` · ${formatDuration(cell.durationMs)}`;
+	if (badges.throughput !== undefined) header += ` · ${formatThroughputBadge(badges.throughput)}`;
+	const elapsedMs = badges.throughput?.wallDurationMs ?? cell.durationMs;
+	if (elapsedMs !== undefined) header += ` · ${formatDuration(elapsedMs)}`;
 	if (badges.reset) header += " · reset";
 	if (badges.timeout !== undefined) header += ` · timeout ${badges.timeout}s`;
 	return style(environment.theme, presentation.color, header);
@@ -281,6 +289,19 @@ function eventNumber(value: unknown): number {
 
 function plural(count: number, singular: string, pluralNoun: string): string {
 	return `${count} ${count === 1 ? singular : pluralNoun}`;
+}
+
+function formatCallsPerSecond(calls: number, wallDurationMs: number | undefined): string {
+	const seconds = typeof wallDurationMs === "number" && Number.isFinite(wallDurationMs) ? wallDurationMs / 1_000 : 0;
+	if (seconds <= 0) return calls === 0 ? "0.00 calls/s" : "n/a calls/s";
+	return `${(calls / seconds).toFixed(2)} calls/s`;
+}
+
+function formatThroughputBadge(throughput: CellThroughput): string {
+	return `${plural(throughput.calls, "call", "calls")} · ${formatCallsPerSecond(
+		throughput.calls,
+		throughput.wallDurationMs,
+	)}`;
 }
 
 function statusIcon(op: string): string {
@@ -613,9 +634,17 @@ function renderDetailedLines(
 	const cells = details.cells ?? [];
 	for (const [index, cell] of cells.entries()) {
 		const run = isEvalRunInput(context.args) ? context.args : undefined;
+		const throughput =
+			context.isFinal &&
+			cells.length === 1 &&
+			cell.status === "complete" &&
+			typeof details.toolCallCount === "number"
+				? { calls: details.toolCallCount, wallDurationMs: details.wallDurationMs }
+				: undefined;
 		const badges = {
 			reset: index === 0 && run?.reset === true,
 			timeout: index === 0 ? run?.timeout : undefined,
+			throughput,
 		};
 		appendLines(lines, renderCell(cell, context.environment, badges));
 		if (index < cells.length - 1) lines.push("");
@@ -754,11 +783,14 @@ function resultMetadata(
 	details: EvalToolDetails | undefined,
 	options: ToolRenderResultOptions,
 	theme: Theme | undefined,
+	status: "running" | "done" | "error",
 ): RenderBlock[] {
 	const metadata: string[] = [];
 	if (details?.phase) metadata.push(`phase ${details.phase}`);
-	if (!options.isPartial && typeof details?.durationMs === "number")
-		metadata.push(`took ${formatDuration(details.durationMs)}`);
+	const elapsedMs = details?.wallDurationMs ?? details?.durationMs;
+	if (!options.isPartial && typeof elapsedMs === "number") metadata.push(`took ${formatDuration(elapsedMs)}`);
+	if (status === "done" && typeof details?.toolCallCount === "number")
+		metadata.push(formatThroughputBadge({ calls: details.toolCallCount, wallDurationMs: details.wallDurationMs }));
 	if (metadata.length === 0) return [];
 	return [{ kind: "text", text: style(theme, "muted", metadata.join(" | ")) }];
 }
@@ -814,7 +846,11 @@ export function renderEvalCall(
 					output: "",
 					status: context.spinnerFrame === undefined ? "pending" : "running",
 				};
-				return renderCell(cell, environment, { reset: args.reset === true, timeout: args.timeout });
+				return renderCell(cell, environment, {
+					reset: args.reset === true,
+					timeout: args.timeout,
+					throughput: undefined,
+				});
 			},
 		},
 	]);
@@ -846,6 +882,7 @@ export function renderEvalResult(
 						},
 						args: context.args,
 						showImageFallback: context.showImages && imageProtocol === null,
+						isFinal: !options.isPartial,
 					}),
 			},
 		];
@@ -862,7 +899,7 @@ export function renderEvalResult(
 		...(details?.summary === undefined
 			? []
 			: [{ kind: "text" as const, text: style(theme, "muted", details.summary) }]),
-		...resultMetadata(details, options, theme),
+		...resultMetadata(details, options, theme, status),
 		{ kind: "blank" },
 	];
 	const rawOutput = textOutput(result, context.showImages && imageProtocol === null);

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -164,6 +164,10 @@ export interface EvalToolDetails {
 	readonly languages?: readonly EvalLanguage[];
 	readonly summary?: string;
 	readonly durationMs: number;
+	/** True wall-clock elapsed time since the cell started; `durationMs` stays kernel-reported. */
+	readonly wallDurationMs?: number;
+	/** Exact count of initiated nested tool calls, including calls still pending at settlement. */
+	readonly toolCallCount?: number;
 	readonly toolCalls: readonly EvalToolCallSummary[];
 	readonly truncated: boolean;
 	readonly isError?: boolean;

--- a/packages/senpi-codemode/test/eval-execution-event.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-event.test.ts
@@ -218,6 +218,33 @@ describe("eval execution event contract", () => {
 		);
 	});
 
+	it("derives wall duration and exact nested tool-call count in returned details separately from kernel duration", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000);
+		const kernel = new SerialFakeKernel([
+			{ type: "tool-call", callId: "read-1", toolName: "read", args: { path: "/tmp/a" } },
+			{ type: "tool-call", callId: "bash-1", toolName: "bash", args: { command: "true" } },
+			result("throughput-cell", "done", 99),
+		]);
+		const executeTool: ExecuteTool = vi.fn(async (name) => {
+			vi.setSystemTime(Date.now() + (name === "read" ? 11 : 7));
+			return textResult(`${name} result`);
+		});
+
+		const settled = await createTool(kernel, executeTool).execute(
+			"throughput-cell",
+			{ language: "js", code: "await Promise.all([tool.read({}), tool.bash({})])", summary: "two calls" },
+			undefined,
+			undefined,
+			fakeExtensionContext(),
+		);
+
+		expect(settled.details.toolCallCount).toBe(2);
+		expect(settled.details.wallDurationMs).toBe(18);
+		expect(settled.details.durationMs).toBe(99);
+		expect(settled.details.cells?.[0]?.durationMs).toBe(99);
+	});
+
 	it("emits exactly once after a detached cell reaches terminal settlement", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(4_000);

--- a/packages/senpi-codemode/test/eval-render-state.test.ts
+++ b/packages/senpi-codemode/test/eval-render-state.test.ts
@@ -328,3 +328,208 @@ describe("eval renderer state", () => {
 		expect.soft(resultText).toContain("eval py error ✗ · 1h 2m");
 	});
 });
+
+describe("eval completed-cell throughput badge", () => {
+	it("Given one completed cell when rendered finally then header shows exact calls and calls-per-second before duration and timeout", () => {
+		// Given
+		const givenResult = evalResult(
+			{
+				language: "py",
+				durationMs: 1_250,
+				toolCallCount: 2,
+				wallDurationMs: 2_000,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "work()",
+						language: "py",
+						output: "ok",
+						status: "complete",
+						durationMs: 1_250,
+					},
+				],
+			},
+			"ok",
+		);
+
+		// When
+		const text = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext({ args: { language: "py", code: "work()", summary: "throughput", timeout: 420 } }),
+		)
+			.render(120)
+			.join("\n");
+
+		// Then
+		expect(text).toContain("eval py done ✓ · 2 calls · 1.00 calls/s · 2s · timeout 420s");
+	});
+
+	it("Given singular tool-call count when rendered then call noun stays singular", () => {
+		// Given
+		const givenResult = evalResult(
+			{
+				language: "py",
+				durationMs: 400,
+				toolCallCount: 1,
+				wallDurationMs: 400,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "work()",
+						language: "py",
+						output: "ok",
+						status: "complete",
+						durationMs: 400,
+					},
+				],
+			},
+			"ok",
+		);
+
+		// When
+		const text = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext({ args: { language: "py", code: "work()", summary: "throughput" } }),
+		)
+			.render(120)
+			.join("\n");
+
+		// Then
+		expect(text).toContain("1 call · 2.50 calls/s");
+		expect(text).not.toContain("1 calls");
+	});
+
+	it.each(["pending", "running", "error"] as const)(
+		"Given a single %s cell when rendered finally then no throughput badge is attached",
+		(status) => {
+			// Given
+			const givenResult = evalResult(
+				{
+					language: "py",
+					durationMs: 2_000,
+					toolCallCount: 2,
+					wallDurationMs: 2_000,
+					toolCalls: [],
+					truncated: false,
+					cells: [
+						{
+							index: 0,
+							code: "work()",
+							language: "py",
+							output: "boom",
+							status,
+							durationMs: 2_000,
+						},
+					],
+				},
+				"boom",
+			);
+
+			// When
+			const text = renderEvalResult(
+				givenResult,
+				{ expanded: false, isPartial: false },
+				undefined,
+				resultContext({ args: { language: "py", code: "work()", summary: "throughput" } }),
+			)
+				.render(120)
+				.join("\n");
+
+			// Then
+			expect(text).not.toContain("calls/s");
+			expect(text).not.toContain("2 calls");
+		},
+	);
+
+	it("Given multiple synthetic cells when rendered finally then the aggregate is not repeated on every header", () => {
+		// Given
+		const givenResult = evalResult(
+			{
+				language: "py",
+				durationMs: 2_000,
+				toolCallCount: 2,
+				wallDurationMs: 2_000,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "first()",
+						language: "py",
+						output: "one",
+						status: "complete",
+						durationMs: 1_000,
+					},
+					{
+						index: 1,
+						code: "second()",
+						language: "py",
+						output: "two",
+						status: "complete",
+						durationMs: 1_000,
+					},
+				],
+			},
+			"two",
+		);
+
+		// When
+		const text = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext({ args: { language: "py", code: "first()", summary: "multi" } }),
+		)
+			.render(120)
+			.join("\n");
+
+		// Then
+		expect(text).not.toContain("calls/s");
+		expect((text.match(/eval py done ✓/gu) ?? []).length).toBe(2);
+	});
+
+	it("Given legacy details without throughput fields when rendered finally then headers stay unchanged", () => {
+		// Given
+		const givenResult = evalResult(
+			{
+				language: "py",
+				durationMs: 2_000,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "work()",
+						language: "py",
+						output: "ok",
+						status: "complete",
+						durationMs: 2_000,
+					},
+				],
+			},
+			"ok",
+		);
+
+		// When
+		const text = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext({ args: { language: "py", code: "work()", summary: "throughput" } }),
+		)
+			.render(120)
+			.join("\n");
+
+		// Then
+		expect(text).toContain("eval py done ✓ · 2s");
+		expect(text).not.toContain("calls/s");
+	});
+});

--- a/packages/senpi-codemode/test/eval-render-streaming.test.ts
+++ b/packages/senpi-codemode/test/eval-render-streaming.test.ts
@@ -253,6 +253,46 @@ describe("eval renderer streaming reuse", () => {
 		expect.soft(renderLines(final).slice(0, 4)).toEqual(["eval js done", "phase complete | took <1s", "", "final"]);
 	});
 
+	it("Given a partial result with an already-complete single cell when rendered then throughput stays hidden", () => {
+		// Given
+		const givenResult = evalResult(
+			{
+				language: "py",
+				phase: "settling",
+				durationMs: 0,
+				toolCallCount: 2,
+				wallDurationMs: 2_000,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "work()",
+						language: "py",
+						output: "ok",
+						status: "complete",
+						durationMs: 2_000,
+					},
+				],
+			},
+			"partial",
+		);
+
+		// When
+		const text = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: true },
+			undefined,
+			resultContext({ args: { language: "py", code: "work()", summary: "throughput" } }),
+		)
+			.render(120)
+			.join("\n");
+
+		// Then
+		expect(text).toContain("eval py done ✓ · 2s");
+		expect(text).not.toContain("calls/s");
+	});
+
 	it("Given running completed and failed agent events when rendered then progress rows expose state detail and duration", () => {
 		// Given
 		const givenResult = evalResult(

--- a/packages/senpi-codemode/test/eval-render-width.test.ts
+++ b/packages/senpi-codemode/test/eval-render-width.test.ts
@@ -149,6 +149,48 @@ describe.each(WIDTHS)("eval renderer width %i", (width) => {
 		expect(visibleText).toContain("[eval output truncated]");
 		expect(visibleText).not.toContain(outputLines[0]);
 	});
+
+	it("Given completed throughput badges when rendered then the wall-clock header remains visible within width", () => {
+		// Given
+		const givenResult = evalResult(
+			{
+				language: "py",
+				durationMs: 1_250,
+				wallDurationMs: 2_000,
+				toolCallCount: 2,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "work()",
+						language: "py",
+						output: "ok",
+						status: "complete",
+						durationMs: 1_250,
+					},
+				],
+			},
+			"ok",
+		);
+
+		// When
+		const lines = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext({ args: { language: "py", code: "work()", summary: "throughput", timeout: 420 } }),
+		).render(width);
+		const text = lines.join("\n");
+
+		// Then
+		expectLinesWithinWidth(lines, width, "throughput badge");
+		expect.soft(text).toContain("2 calls");
+		expect.soft(text).toContain("1.00");
+		expect.soft(text).toContain("calls/s");
+		expect.soft(text).toContain("2s");
+		expect(text).toContain("timeout 420s");
+	});
 });
 
 describe("eval renderer rerender width behavior", () => {

--- a/packages/senpi-codemode/test/eval-result-duration.test.ts
+++ b/packages/senpi-codemode/test/eval-result-duration.test.ts
@@ -44,3 +44,60 @@ describe("eval result duration rendering", () => {
 		expect(rendered).toEqual(["eval js done", "dependency scan", "phase summarizing | took 1s", "", "complete"]);
 	});
 });
+
+describe("eval result throughput rendering", () => {
+	it.each([
+		{ calls: 2, wallDurationMs: 2_000, expected: "2 calls · 1.00 calls/s" },
+		{ calls: 3, wallDurationMs: 1_500, expected: "3 calls · 2.00 calls/s" },
+		{ calls: 1, wallDurationMs: 400, expected: "1 call · 2.50 calls/s" },
+		{ calls: 0, wallDurationMs: 0, expected: "0 calls · 0.00 calls/s" },
+		{ calls: 0, wallDurationMs: 900, expected: "0 calls · 0.00 calls/s" },
+		{ calls: 5, wallDurationMs: 0, expected: "5 calls · n/a calls/s" },
+		{ calls: 7, wallDurationMs: undefined, expected: "7 calls · n/a calls/s" },
+	])("renders $calls calls over $wallDurationMs wall ms as $expected", ({ calls, wallDurationMs, expected }) => {
+		// Given
+		const result = evalResult(
+			{
+				language: "js",
+				durationMs: 2_000,
+				toolCallCount: calls,
+				wallDurationMs,
+				toolCalls: [],
+				truncated: false,
+			},
+			"complete",
+		);
+
+		// When
+		const rendered = renderLines(
+			renderEvalResult(result, { expanded: false, isPartial: false }, undefined, resultContext(undefined, false)),
+		);
+
+		// Then
+		expect(rendered.join("\n")).toContain(expected);
+	});
+
+	it("uses wall-clock elapsed time for final metadata while preserving kernel duration in details", () => {
+		// Given
+		const result = evalResult(
+			{
+				language: "js",
+				durationMs: 99,
+				toolCallCount: 2,
+				wallDurationMs: 2_000,
+				toolCalls: [],
+				truncated: false,
+			},
+			"complete",
+		);
+
+		// When
+		const rendered = renderLines(
+			renderEvalResult(result, { expanded: false, isPartial: false }, undefined, resultContext(undefined, false)),
+		);
+
+		// Then
+		expect(rendered).toContain("took 2s | 2 calls · 1.00 calls/s");
+		expect(rendered).not.toContain("took <1s");
+	});
+});


### PR DESCRIPTION
## Summary

- show exact nested tool-call count and calls/second in completed eval TUI headers
- use true wall-clock elapsed time for both the visible duration and throughput denominator
- preserve kernel-reported duration and the existing `senpi.eval.execution` event contract
- cover zero-duration, partial/error, multi-cell, legacy, and 40/80/120-column cases
- add hermetic real-source PTY/xterm/Chrome QA

## Test evidence

- RED: renderer assertions saw `... 1.00 calls/s · 1s ...` when wall time was 2s; runtime details lacked `toolCallCount`
- GREEN: focused renderer suites 58/58; runtime metadata suites 8/8
- Full `@code-yeongyu/senpi-codemode` suite: 565 passed, 6 skipped
- `npm run check`: passed
- `npm run build`: passed

## Manual QA

Command:

```text
node .agents/skills/senpi-qa/scripts/scenarios/eval-throughput-badge-qa.mjs --self-test --evidence eval-throughput-badge
```

Result: 9/9 passed.

Observed real TUI header:

```text
╭─ eval js done ✓ · 2 calls · 25.32 calls/s · <1s
```

Evidence includes raw PTY bytes, xterm.js grid JSON/HTML, Chrome PNG, sanitized fake-provider requests, and cleanup/auth receipts under `local-ignore/qa-evidence/20260817-eval-throughput-badge/`.

Dual visual QA verdicts: PASS / PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows eval tool-call throughput in the TUI header using wall-clock time. Previously the header showed only kernel duration; now it displays “N calls · X.XX calls/s · elapsed”, making throughput visible while preserving the `senpi.eval.execution` event contract.

- Rendering: Badge appears only for final, single-cell, completed evals; hidden for partial/running/error and multi-cell results. Pluralization is correct; zero elapsed shows “0.00 calls/s”; positive calls without positive wall time show “n/a calls/s”. The final metadata line now uses wall time for “took …” and also includes calls and calls/s; timeout/reset badges remain after elapsed.
- Data model: `EvalToolDetails` adds `wallDurationMs` and `toolCallCount` (additive). Kernel `durationMs` is unchanged; the renderer prefers `wallDurationMs` for visible elapsed and throughput.
- Docs and tests: `packages/senpi-codemode/CHANGELOG.md` and `packages/senpi-codemode/changes.md` document behavior and expected conflict zones. Tests updated; added hermetic PTY/xterm/Chrome QA scenario at `.agents/skills/senpi-qa/scripts/scenarios/eval-throughput-badge-qa.mjs`. No migration required.

<sup>Written for commit 3908a8c8b4ac22e858d17bf845bdf93f3d6e7e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

