### PR TITLE
fix(mcp): open the browser and keep the authorization URL visible for /mcp auth

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Fixed
 
+- `/mcp auth <server>` now completes an interactive OAuth login instead of stalling forever. The command announced
+  `Opening browser to authorize <server>...` but never launched a browser, and the notification carrying the
+  authorization URL was emitted immediately before that announcement, so the TUI's consecutive-status coalescing
+  overwrote it. With no browser and no reachable URL, the flow waited on its loopback callback until the session
+  ended. The auth command bridge now calls the real browser launcher, and each branch emits a single notification
+  that includes the authorization URL as a fallback for when the launch fails.
 - Steering queued while a provider stream-start timeout retry is running now starts automatically when that managed
   retry exhausts its budget, instead of remaining parked until another user prompt. Generic terminal provider errors
   and user-aborted retries keep their existing queue-retention behavior

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth-dispatch.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth-dispatch.ts
@@ -1,3 +1,4 @@
+import { openBrowser as launchBrowser } from "../../../../../utils/open-browser.ts";
 import type { ExtensionAPI, ExtensionCommandContext } from "../../../types.ts";
 import { createMcpLogger } from "../log.ts";
 import type { McpService } from "../service.ts";
@@ -34,7 +35,9 @@ export async function handleMcpAuthCommand(
 			}
 			await service.attachSession({ type: "session_start", reason: "reload" }, ctx, pi).catch(() => undefined);
 		},
-		openBrowser: (url) => ctx.ui.notify(`Open this URL to authorize ${name}:\n${url.toString()}`),
+		// Actually launch the browser. The URL is surfaced by the auth flow itself in a single
+		// status line, because consecutive ui.notify() status lines overwrite each other in the TUI.
+		openBrowser: (url) => launchBrowser(url.toString()),
 		pending: service.getPendingAuth(),
 		interactiveGuard: {
 			begin: (serverName) => service.beginInteractiveAuth(serverName),

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/auth/commands-auth.ts
@@ -121,7 +121,8 @@ async function runInteractive(deps: AuthCommandDeps): Promise<void> {
 		const loopbackResult = channel.usesLoopback ? channel.waitForCode() : undefined;
 		provider = buildProvider(deps, channel.redirectUrl, (url) => deps.openBrowser?.(url));
 		const begin = await beginAuthorization(provider, deps.flow);
-		if (begin.authorizationUrl !== undefined) deps.notify(`Opening browser to authorize ${deps.serverName}...`);
+		// One notification per branch: consecutive status lines overwrite each other in the TUI, so a
+		// separate "opening browser" line would erase the URL the user needs when the launch fails.
 		if (!channel.usesLoopback) {
 			deps.pending.set(deps.serverName, provider);
 			if (begin.authorizationUrl === undefined) {
@@ -134,9 +135,14 @@ async function runInteractive(deps: AuthCommandDeps): Promise<void> {
 				);
 			}
 			deps.notify(
-				`Complete the browser flow, then run /mcp auth-complete ${deps.serverName} <redirect-url> with the final redirect URL.`,
+				`Opening browser to authorize ${deps.serverName}. If it does not open, visit:\n${begin.authorizationUrl.toString()}\nComplete the browser flow, then run /mcp auth-complete ${deps.serverName} <redirect-url> with the final redirect URL.`,
 			);
 			return;
+		}
+		if (begin.authorizationUrl !== undefined) {
+			deps.notify(
+				`Opening browser to authorize ${deps.serverName}. If it does not open, visit:\n${begin.authorizationUrl.toString()}`,
+			);
 		}
 		const { code } = await (loopbackResult ?? channel.waitForCode());
 		await finishAuthorization(provider, code, deps.flow);

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,21 @@
 # mcp Extension Changes
 
+## Interactive OAuth actually opens a browser and keeps the URL visible (2026-08-17)
+
+### What changed
+- `auth/commands-auth-dispatch.ts` wires `openBrowser` to `utils/open-browser.ts` instead of emitting a notification; the launch now really happens.
+- `auth/commands-auth.ts` `runInteractive` emits exactly one notification per branch, carrying the authorization URL, instead of an announcement line that followed and erased the URL line.
+- `test/mcp/oauth-callback.test.ts` asserts the single announcement contains the authorization URL for both the loopback and the callback-override branch.
+
+### Why
+- `/mcp auth <server>` said "Opening browser..." but nothing ever spawned a browser, and the preceding URL notification was overwritten: consecutive `ui.notify` status lines coalesce in the TUI (`showStatus` replaces the trailing status text in place). The flow then blocked on the loopback callback with no reachable authorization URL, so interactive login could never complete.
+
+### Why extension system couldn't handle this alone
+- The auth command bridge owns the `AuthCommandDeps` wiring and the notification sequence of the built-in `/mcp` command namespace; no external extension can reorder them.
+
+### Expected merge conflict zones
+- LOW: `auth/commands-auth-dispatch.ts` deps literal; `auth/commands-auth.ts` `runInteractive` notification block.
+
 ## Explicit pgrep match-all pattern for process-tree collection (2026-08-12)
 
 ### What changed

--- a/packages/coding-agent/test/mcp/oauth-callback.test.ts
+++ b/packages/coding-agent/test/mcp/oauth-callback.test.ts
@@ -54,11 +54,13 @@ async function agentDir(): Promise<string> {
 interface Harness {
 	deps: AuthCommandDeps;
 	browsered: URL[];
+	notified: string[];
 	store: McpTokenStore;
 }
 
 function makeHarness(dir: string, mcpUrl: string, overrides: Partial<McpServerConfig> = {}): Harness {
 	const browsered: URL[] = [];
+	const notified: string[] = [];
 	const config: McpServerConfig = {
 		type: "http",
 		url: mcpUrl,
@@ -78,14 +80,21 @@ function makeHarness(dir: string, mcpUrl: string, overrides: Partial<McpServerCo
 		config,
 		agentDir: dir,
 		hasUI: true,
-		notify: () => undefined,
+		notify: (message) => {
+			notified.push(message);
+		},
 		openBrowser: (url) => {
 			browsered.push(url);
 		},
 		onReconnect: () => Promise.resolve(),
 		pending: new Map<string, McpOAuthProvider>(),
 	};
-	return { deps, browsered, store: new McpTokenStore({ agentDir: dir, serverName: "fix", serverUrl: mcpUrl }) };
+	return {
+		deps,
+		browsered,
+		notified,
+		store: new McpTokenStore({ agentDir: dir, serverName: "fix", serverUrl: mcpUrl }),
+	};
 }
 
 async function followAuthorize(url: URL): Promise<Response> {
@@ -242,6 +251,26 @@ describe("LoopbackCallbackServer", () => {
 		expect(harness.browsered).toHaveLength(0);
 	});
 
+	// Regression: the authorization URL used to be announced in its own notification, immediately
+	// followed by a second status line. Consecutive status lines overwrite each other in the TUI, so
+	// the URL vanished and a failed browser launch left the flow waiting forever with no way out.
+	it("carries the authorization URL in the same single notification that announces the browser", async () => {
+		const fixture = await idp();
+		const dir = await agentDir();
+		const harness = makeHarness(dir, fixture.mcpUrl);
+
+		const auth = runAuth(harness.deps);
+		await vi.waitFor(() => expect(harness.browsered).toHaveLength(1));
+		const authorizationUrl = harness.browsered[0];
+		if (authorizationUrl === undefined) throw new Error("no authorization URL");
+		await vi.waitFor(() => expect(harness.notified).toHaveLength(1));
+		expect(harness.notified[0]).toContain(authorizationUrl.toString());
+
+		const callback = await followAuthorize(authorizationUrl);
+		expect(callback.status).toBe(200);
+		await auth;
+	});
+
 	it("runAuth with a callback URL override opens no listener and completes through pasted redirect", async () => {
 		const fixture = await idp();
 		const dir = await agentDir();
@@ -256,6 +285,9 @@ describe("LoopbackCallbackServer", () => {
 		expect(harness.deps.pending.has(harness.deps.serverName)).toBe(true);
 		const authorizationUrl = harness.browsered[0];
 		if (authorizationUrl === undefined) throw new Error("no authorization URL");
+		expect(harness.notified).toHaveLength(1);
+		expect(harness.notified[0]).toContain(authorizationUrl.toString());
+		expect(harness.notified[0]).toContain("/mcp auth-complete fix");
 		const redirect = await authorizeRedirectLocation(authorizationUrl);
 		await runAuthComplete(harness.deps, redirect);
 		expect(await portOpen(port)).toBe(false);


### PR DESCRIPTION
## Problem

`/mcp auth <server>` can never complete an interactive OAuth login. It prints

```
Opening browser to authorize sentry...
```

and then hangs forever with no further output.

Two bugs compound:

1. **No browser is ever launched.** `auth/commands-auth-dispatch.ts` wired the `openBrowser` dependency to `ctx.ui.notify(...)`, so the announcement was simply untrue. The repo already ships a real launcher at `src/utils/open-browser.ts` (used by the provider login dialog).
2. **The fallback URL is erased.** The URL notification is emitted from `redirectToAuthorization` *inside* `beginAuthorization`, and the `Opening browser…` line was emitted immediately after it. Consecutive status notifications coalesce in the TUI — `showStatus` rewrites the trailing status text in place when the last two chat children are the previous status spacer/text — so the second line overwrote the URL milliseconds after it appeared.

With no browser and no reachable authorization URL, `runInteractive` parks on `channel.waitForCode()` until the session ends.

## Fix

- `auth/commands-auth-dispatch.ts` — `openBrowser` calls `utils/open-browser.ts` for real.
- `auth/commands-auth.ts` — each branch of `runInteractive` emits exactly one notification, carrying the authorization URL, so a failed launch still leaves a copy-pasteable link. Behavior for the `callbackUrl`-override (paste) branch is unchanged apart from the merged message.
- `builtin/mcp/changes.md` — fork ledger entry.

No config, transport, or token-storage behavior changes.

## Tests

`test/mcp/oauth-callback.test.ts` gains an assertion that the single announcement contains the authorization URL, for both the loopback and the callback-override branch. Both assertions fail on `main` and pass with the fix (verified by reverting the two source files with the test in place).

## Verification

| Gate | Result |
|---|---|
| `npm run check` | exit 0 |
| `test/mcp/oauth-callback.test.ts`, `oauth-headless.test.ts`, `auth-modes.test.ts` | 33 passed |
| `senpi-qa` Channel 4 (`cli-smoke.mjs --self-test`) | 8/8 passed, real auth unchanged |
| `senpi-qa` flow driver (evidence `20260817-mcp-oauth-browser-launch`) | 5/5 passed |

The QA driver runs `runAuth` from source against the repo's fake IdP fixture, with a recording stub named `open` first on `PATH` so no real browser opens:

```
{
 "interactive flow completes (token stored, no hang)": true,
 "single announcement before the authorized message": true,
 "announcement carries the authorization URL": true,
 "browser launcher exec'd with the URL": true,
 "real auth.json untouched": true
}

--- notification as the user sees it ---
Opening browser to authorize fix. If it does not open, visit:
<authorization-url>
```

Note: `test/mcp/oauth-race.test.ts` fails identically with and without this change in my environment (`@earendil-works/pi-tui` workspace dist not built); unrelated to this PR.
