### PR TITLE
test(ai): retarget Cloudflare gateway Anthropic tests to claude-sonnet-5

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Fixed
 
-- Cloudflare AI Gateway live tests now pin `claude-sonnet-5` instead of the retired `claude-sonnet-4-5` id, so root typecheck still passes after model-catalog hydration.
+- Cloudflare AI Gateway live tests now pin `claude-sonnet-5` instead of the retired `claude-sonnet-4-5` id, so root typecheck still passes after model-catalog hydration ([#925](https://github.com/code-yeongyu/senpi/pull/925)).
 - Cursor's server-driven exec channel now keeps pending local tools alive with write-completion-chained 3-second
   exec heartbeats and closes every normal typed result sequence exactly once. Read, shell, MCP, and modern `pi_*`
   tool turns no longer leave the server-side exec pending until the Run stream ends before `turnEnded`

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Cloudflare AI Gateway live tests now pin `claude-sonnet-5` instead of the retired `claude-sonnet-4-5` id, so root typecheck still passes after model-catalog hydration.
 - Cursor's server-driven exec channel now keeps pending local tools alive with write-completion-chained 3-second
   exec heartbeats and closes every normal typed result sequence exactly once. Read, shell, MCP, and modern `pi_*`
   tool turns no longer leave the server-side exec pending until the Run stream ends before `turnEnded`

--- a/packages/ai/test/cross-provider-handoff.test.ts
+++ b/packages/ai/test/cross-provider-handoff.test.ts
@@ -93,8 +93,8 @@ const PROVIDER_MODEL_PAIRS: ProviderModelPair[] = [
 	},
 	{
 		provider: "cloudflare-ai-gateway",
-		model: "claude-sonnet-4-5",
-		label: "cloudflare-gateway-claude-sonnet-4-5",
+		model: "claude-sonnet-5",
+		label: "cloudflare-gateway-claude-sonnet-5",
 		upstreamApiKeyEnv: "ANTHROPIC_API_KEY",
 	},
 	{

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -713,9 +713,9 @@ describe("Generate E2E Tests", () => {
 	);
 
 	describe.skipIf(!hasCloudflareAiGatewayCredentials() || !process.env.ANTHROPIC_API_KEY)(
-		"Cloudflare AI Gateway → Anthropic BYOK (claude-sonnet-4-5 via /anthropic messages)",
+		"Cloudflare AI Gateway → Anthropic BYOK (claude-sonnet-5 via /anthropic messages)",
 		() => {
-			const llm = getModel("cloudflare-ai-gateway", "claude-sonnet-4-5");
+			const llm = getModel("cloudflare-ai-gateway", "claude-sonnet-5");
 			const options = { headers: { Authorization: `Bearer ${process.env.ANTHROPIC_API_KEY}` } };
 			const thinkingOptions = {
 				...options,


### PR DESCRIPTION
## Summary

Unblocks the 2026.8.x release pipeline. `npm run release:local` (and the canonical release path) runs `packages/ai` `generate-models` before `npm run check`. After that hydration, the live Cloudflare AI Gateway catalog no longer carries `claude-sonnet-4-5`, so root `tsc --noEmit` fails:

```
packages/ai/test/stream.test.ts(718,50): error TS2345: Argument of type '"claude-sonnet-4-5"' is not assignable to parameter of type 'ModelId<...>'.
```

Pristine `origin/main` still typechecks because the git-tracked snapshot still has the hyphenated id. The failure only appears after regeneration.

## Fix

Retarget the env-gated Cloudflare AI Gateway to Anthropic BYOK live tests to `claude-sonnet-5`:

- `packages/ai/test/stream.test.ts` — typed `getModel("cloudflare-ai-gateway", ...)` (the TS2345)
- `packages/ai/test/cross-provider-handoff.test.ts` — same gateway pair (runtime string; would report the model missing after hydration)

`claude-sonnet-5` is in **both** the committed snapshot and the live hydrated `anthropic-messages` catalog. The live catalog renamed the old id to dotted `claude-sonnet-4.5`, but that dotted id is **not** in the committed snapshot. CI runs `npm run check` without regenerating catalogs, so pinning `claude-sonnet-4.5` would fail tsc on the checked-in JSON. `claude-sonnet-5` keeps both the hydrated release typecheck and the unhydrated CI typecheck green.

No provider JSON, `getModel` types, or catalog generation logic changed.

## Evidence

Local-ignore path (not in this PR):

`local-ignore/qa-evidence/20260817-senpi-omo-beta-release/01-senpi-changelog/hydration-fix/`

- `red-tsc.log` — TS2345 after `generate-models`, before the id swap
- `green-tsc.log` — `tsc --noEmit` exit 0 after the swap, catalog still hydrated
- `green-npm-check.log` — full `npm run check` exit 0
- `vitest-ai-files.log` — focused files collect and skip without live creds
- `hydrated-cloudflare-ai-gateway-ids.txt` — live gateway ids (`claude-sonnet-4.5`, `claude-sonnet-5`; no `claude-sonnet-4-5`)
- Prior release-blocker log: `local-ignore/qa-evidence/20260817-senpi-omo-beta-release/02-senpi-release/preflight/release-local.log`

## Changelog

`packages/ai/CHANGELOG.md` `[Unreleased]` → `### Fixed`. Test-only; not duplicated to `coding-agent` (no end-user behavior change). Tracker `changes.md` not required: the changelog gate treats `*.test.ts` as non-production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retargets Cloudflare AI Gateway → Anthropic BYOK tests from `claude-sonnet-4-5` to `claude-sonnet-5` to keep typecheck green after model-catalog hydration. The old id was retired/renamed; `claude-sonnet-5` exists in both the committed snapshot and the hydrated catalog.

- Updates model id and label in `packages/ai/test/stream.test.ts` and `packages/ai/test/cross-provider-handoff.test.ts`.
- Adds a `packages/ai/CHANGELOG.md` entry linking the fix to PR #925.
- No provider JSON or generation logic changes; no runtime behavior change. Env-gated tests remain skipped without credentials.
- Keeps `npm run check` passing in CI (unhydrated) and release paths (hydrated).

<sup>Written for commit ee569fb3a9130f474bacc274d7f749ff03c916f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

