### PR TITLE
fix(coding-agent): retarget Cerebras default after catalog drift

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Fixed
 
+- Session reload no longer repeats a full model-availability scan when extensions re-register a provider that is already in a fresh snapshot. Overlapping `refresh()` calls are serialized so an unawaited registration refresh cannot leak a second credential listing into the next reload.
+
 - Cerebras no longer defaults to `zai-glm-4.7`, which the live catalog dropped. The bundled default is now `gpt-oss-120b`, which remains in both the committed snapshot and the regenerated catalog, so `npm test` after a live model-data hydrate no longer fails provider-default resolution.
 
 - Steering queued while a provider stream-start timeout retry is running now starts automatically when that managed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Fixed
 
+- Cerebras no longer defaults to `zai-glm-4.7`, which the live catalog dropped. The bundled default is now `gpt-oss-120b`, which remains in both the committed snapshot and the regenerated catalog, so `npm test` after a live model-data hydrate no longer fails provider-default resolution.
+
 - Steering queued while a provider stream-start timeout retry is running now starts automatically when that managed
   retry exhausts its budget, instead of remaining parked until another user prompt. Generic terminal provider errors
   and user-aborted retries keep their existing queue-retention behavior

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,9 +18,9 @@
 
 ### Fixed
 
-- Session reload no longer repeats a full model-availability scan when extensions re-register a provider that is already in a fresh snapshot. Overlapping `refresh()` calls are serialized so an unawaited registration refresh cannot leak a second credential listing into the next reload.
+- Session reload no longer repeats a full model-availability scan when extensions re-register a provider that is already in a fresh snapshot. Overlapping `refresh()` calls are serialized so an unawaited registration refresh cannot leak a second credential listing into the next reload ([#926](https://github.com/code-yeongyu/senpi/pull/926)).
 
-- Cerebras no longer defaults to `zai-glm-4.7`, which the live catalog dropped. The bundled default is now `gpt-oss-120b`, which remains in both the committed snapshot and the regenerated catalog, so `npm test` after a live model-data hydrate no longer fails provider-default resolution.
+- Cerebras no longer defaults to `zai-glm-4.7`, which the live catalog dropped. The bundled default is now `gpt-oss-120b`, which remains in both the committed snapshot and the regenerated catalog, so `npm test` after a live model-data hydrate no longer fails provider-default resolution ([#926](https://github.com/code-yeongyu/senpi/pull/926)).
 
 - Steering queued while a provider stream-start timeout retry is running now starts automatically when that managed
   retry exhausts its budget, instead of remaining parked until another user prompt. Generic terminal provider errors

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### Fixed
 
-- Session reload no longer repeats a full model-availability scan when extensions re-register a provider that is already in a fresh snapshot. Overlapping `refresh()` calls are serialized so an unawaited registration refresh cannot leak a second credential listing into the next reload ([#926](https://github.com/code-yeongyu/senpi/pull/926)).
+- Session reload no longer repeats a full model-availability scan when extensions re-register a provider that is already registered in a fresh snapshot. Startup registration batching defers that refresh until the one post-bind `refresh()`, so create-time leftover scans cannot leak into the next reload ([#926](https://github.com/code-yeongyu/senpi/pull/926)).
 
 - Cerebras no longer defaults to `zai-glm-4.7`, which the live catalog dropped. The bundled default is now `gpt-oss-120b`, which remains in both the committed snapshot and the regenerated catalog, so `npm test` after a live model-data hydrate no longer fails provider-default resolution ([#926](https://github.com/code-yeongyu/senpi/pull/926)).
 

--- a/packages/coding-agent/src/core/agent-session-services.ts
+++ b/packages/coding-agent/src/core/agent-session-services.ts
@@ -172,9 +172,9 @@ export async function createAgentSessionServices(
 	for (const registration of drainPendingProviderRegistrations(extensionsResult.runtime)) {
 		try {
 			if (registration.kind === "config") {
-				modelRuntime.registerProvider(registration.name, registration.config);
+				void modelRuntime.registerProvider(registration.name, registration.config, { refresh: false });
 			} else {
-				modelRuntime.registerNativeProvider(registration.provider);
+				void modelRuntime.registerNativeProvider(registration.provider, { refresh: false });
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## Single availability scan across overlapping refresh and provider re-register (2026-08-18)
+
+### What changed
+
+- `model-runtime.ts`: `refresh()` is serialized so an unawaited registration refresh cannot overlap a later `refresh()`/`reloadConfig()`.
+- `model-runtime.ts`: `registerProvider` / `registerNativeProvider` skip `refreshAfterRegistration` when the provider is already present in a fresh availability snapshot.
+- `test/model-runtime-registration-refresh.test.ts`: re-registering a native provider already in a fresh snapshot does not run another catalog refresh.
+
+### Why
+
+- Session create fire-and-forgets `registerProvider()` and then awaits `refresh()`. The leftover registration refresh called `credentials.list()` after create returned. Session reload then re-binds the same extension provider and started a second full scan. `reload-efficiency` expected one `list()` per reload and failed deterministically on current main, which blocked `release:local` `npm test`.
+
+### Why an extension could not handle it
+
+- Availability refresh and provider registration are core `ModelRuntime` contracts. Extensions cannot coalesce those scans.
+
+### Expected merge-conflict zones
+
+- MEDIUM: `refresh()`, `registerProvider`, and `registerNativeProvider` in `model-runtime.ts`.
+
 ## Cerebras default retarget after live catalog drift (2026-08-18)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## Cerebras default retarget after live catalog drift (2026-08-18)
+
+### What changed
+
+- `model-resolver.ts`: `defaultModelPerProvider.cerebras` is now `gpt-oss-120b` instead of `zai-glm-4.7`.
+- `test/model-resolver.test.ts`: the pinned Cerebras default expectation matches the retarget.
+
+### Why
+
+- The live Cerebras catalog dropped `zai-glm-4.7` and now ships only `gemma-4-31b` and `gpt-oss-120b`. The old default failed `every bundled provider default resolves in its catalog` after `hydrate:model-data` / `release:local` regeneration, which blocked the release smoke.
+- `gpt-oss-120b` is present in both the committed snapshot and the live regenerated catalog, so the default stays resolvable across regen.
+
+### Why an extension could not handle it
+
+- `defaultModelPerProvider` is a core-owned exhaustive `Record<KnownProvider, string>` used by initial model selection. There is no extension hook for bundled provider defaults.
+
+### Expected merge-conflict zones
+
+- LOW: the `cerebras` row in `defaultModelPerProvider` and the matching pin in `test/model-resolver.test.ts`.
+
 <<<<<<< HEAD
 ## Cursor CLI OAuth provider display name (2026-08-17)
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,16 +1,16 @@
 # changes
 
-## Single availability scan across overlapping refresh and provider re-register (2026-08-18)
+## Single availability scan across provider re-register (2026-08-18)
 
 ### What changed
 
-- `model-runtime.ts`: `refresh()` is serialized so an unawaited registration refresh cannot overlap a later `refresh()`/`reloadConfig()`.
-- `model-runtime.ts`: `registerProvider` / `registerNativeProvider` skip `refreshAfterRegistration` when the provider is already present in a fresh availability snapshot.
+- `model-runtime.ts`: `registerProvider` / `registerNativeProvider` skip `refreshAfterRegistration` when the provider is already registered and the availability snapshot is fresh. An optional `{ refresh: false }` defers the scan so a caller can do one refresh after a batch.
+- `agent-session-services.ts`: the create-time pending-registration drain uses `{ refresh: false }`, then keeps the existing single `refresh({ allowNetwork: false })`.
 - `test/model-runtime-registration-refresh.test.ts`: re-registering a native provider already in a fresh snapshot does not run another catalog refresh.
 
 ### Why
 
-- Session create fire-and-forgets `registerProvider()` and then awaits `refresh()`. The leftover registration refresh called `credentials.list()` after create returned. Session reload then re-binds the same extension provider and started a second full scan. `reload-efficiency` expected one `list()` per reload and failed deterministically on current main, which blocked `release:local` `npm test`.
+- Session reload re-binds the same extension provider and started a second full availability scan. Create-time drain also fire-and-forgot a registration refresh that could `credentials.list()` after create returned. `reload-efficiency` expected one `list()` per reload and failed deterministically on current main, which blocked `release:local` `npm test`.
 
 ### Why an extension could not handle it
 
@@ -18,7 +18,7 @@
 
 ### Expected merge-conflict zones
 
-- MEDIUM: `refresh()`, `registerProvider`, and `registerNativeProvider` in `model-runtime.ts`.
+- MEDIUM: `registerProvider` / `registerNativeProvider` in `model-runtime.ts` and the drain loop in `agent-session-services.ts`.
 
 ## Cerebras default retarget after live catalog drift (2026-08-18)
 

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -55,7 +55,7 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	opengateway: "moonshotai/kimi-k3",
 	xai: "grok-4.5",
 	groq: "openai/gpt-oss-120b",
-	cerebras: "zai-glm-4.7",
+	cerebras: "gpt-oss-120b",
 	zai: "glm-5.2",
 	"zai-coding-cn": "glm-5.2",
 	mistral: "devstral-medium-latest",

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -169,6 +169,8 @@ export class ModelRuntime implements Models {
 	private readonly providerAvailabilitySeq = new Map<string, number>();
 	private availabilityError: string | undefined;
 	private readonly credentialOperations = new Map<string, Promise<unknown>>();
+	/** Serializes refresh() so an unawaited registration refresh cannot leak a later availability scan. */
+	private refreshChain: Promise<void> = Promise.resolve();
 	private constructor(
 		credentials: RuntimeCredentials,
 		config: ModelConfig,
@@ -777,6 +779,18 @@ export class ModelRuntime implements Models {
 	}
 
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {
+		const prior = this.refreshChain;
+		const current = Promise.withResolvers<void>();
+		this.refreshChain = current.promise;
+		await prior;
+		try {
+			return await this.executeRefresh(options);
+		} finally {
+			current.resolve();
+		}
+	}
+
+	private async executeRefresh(options: ModelsRefreshOptions): Promise<ModelsRefreshResult> {
 		this.config = await ModelConfig.load(this.modelsPath);
 		this.configureRadiusProviders();
 		if (options.providers) {
@@ -825,6 +839,14 @@ export class ModelRuntime implements Models {
 	 * usable without a manual refresh. Offline policy restores from the store only and never
 	 * touches the network.
 	 */
+	private providerAlreadyInFreshSnapshot(providerId: string): boolean {
+		if (!this.hasFreshAvailabilitySnapshot()) return false;
+		if (this.snapshot.configuredProviders.has(providerId) || this.snapshot.storedProviders.has(providerId)) {
+			return true;
+		}
+		return this.snapshot.all.some((model) => model.provider === providerId);
+	}
+
 	private refreshAfterRegistration(): Promise<ModelsRefreshResult> {
 		if (!this.modelNetworkEnabled) return this.refresh({ allowNetwork: false });
 		const controller = new AbortController();
@@ -834,6 +856,7 @@ export class ModelRuntime implements Models {
 
 	registerNativeProvider(provider: Provider): Promise<ModelsRefreshResult> {
 		if (!provider.id.trim()) throw new Error("Provider id must not be empty.");
+		const alreadyFresh = this.providerAlreadyInFreshSnapshot(provider.id);
 		this.extensionProviders.delete(provider.id);
 		this.nativeExtensionProviders.set(provider.id, provider);
 		this.recomposeProvider(provider.id);
@@ -841,6 +864,9 @@ export class ModelRuntime implements Models {
 		if (composedOAuth) this.credentials.registerOAuthProvider(provider.id, composedOAuth);
 		else this.credentials.unregisterOAuthProvider(provider.id);
 		this.updateModelSnapshot();
+		if (alreadyFresh) {
+			return Promise.resolve({ aborted: false, errors: new Map() });
+		}
 		return this.refreshAfterRegistration();
 	}
 
@@ -848,6 +874,7 @@ export class ModelRuntime implements Models {
 		// Validate the incoming registration on its own, like the legacy registry:
 		// a broken re-registration must throw without touching the stored config.
 		validateExtensionProvider(providerId, this.builtins.get(providerId), this.config.getProvider(providerId), config);
+		const alreadyFresh = this.providerAlreadyInFreshSnapshot(providerId);
 		this.nativeExtensionProviders.delete(providerId);
 		// Re-registration merges defined values over the previous registration and
 		// preserves undefined ones, matching the legacy ModelRegistry contract.
@@ -881,6 +908,9 @@ export class ModelRuntime implements Models {
 				configuredProviders,
 				available: this.snapshot.all.filter((model) => configuredProviders.has(model.provider)),
 			};
+		}
+		if (alreadyFresh) {
+			return Promise.resolve({ aborted: false, errors: new Map() });
 		}
 		return this.refreshAfterRegistration();
 	}

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -169,8 +169,6 @@ export class ModelRuntime implements Models {
 	private readonly providerAvailabilitySeq = new Map<string, number>();
 	private availabilityError: string | undefined;
 	private readonly credentialOperations = new Map<string, Promise<unknown>>();
-	/** Serializes refresh() so an unawaited registration refresh cannot leak a later availability scan. */
-	private refreshChain: Promise<void> = Promise.resolve();
 	private constructor(
 		credentials: RuntimeCredentials,
 		config: ModelConfig,
@@ -779,18 +777,6 @@ export class ModelRuntime implements Models {
 	}
 
 	async refresh(options: ModelsRefreshOptions = {}): Promise<ModelsRefreshResult> {
-		const prior = this.refreshChain;
-		const current = Promise.withResolvers<void>();
-		this.refreshChain = current.promise;
-		await prior;
-		try {
-			return await this.executeRefresh(options);
-		} finally {
-			current.resolve();
-		}
-	}
-
-	private async executeRefresh(options: ModelsRefreshOptions): Promise<ModelsRefreshResult> {
 		this.config = await ModelConfig.load(this.modelsPath);
 		this.configureRadiusProviders();
 		if (options.providers) {
@@ -839,12 +825,11 @@ export class ModelRuntime implements Models {
 	 * usable without a manual refresh. Offline policy restores from the store only and never
 	 * touches the network.
 	 */
-	private providerAlreadyInFreshSnapshot(providerId: string): boolean {
-		if (!this.hasFreshAvailabilitySnapshot()) return false;
-		if (this.snapshot.configuredProviders.has(providerId) || this.snapshot.storedProviders.has(providerId)) {
-			return true;
-		}
-		return this.snapshot.all.some((model) => model.provider === providerId);
+	private shouldSkipRegistrationRefresh(providerId: string): boolean {
+		return (
+			this.hasFreshAvailabilitySnapshot() &&
+			(this.nativeExtensionProviders.has(providerId) || this.extensionProviders.has(providerId))
+		);
 	}
 
 	private refreshAfterRegistration(): Promise<ModelsRefreshResult> {
@@ -854,9 +839,9 @@ export class ModelRuntime implements Models {
 		return this.refresh({ allowNetwork: true, signal: controller.signal }).finally(() => clearTimeout(timeout));
 	}
 
-	registerNativeProvider(provider: Provider): Promise<ModelsRefreshResult> {
+	registerNativeProvider(provider: Provider, options?: { refresh?: boolean }): Promise<ModelsRefreshResult> {
 		if (!provider.id.trim()) throw new Error("Provider id must not be empty.");
-		const alreadyFresh = this.providerAlreadyInFreshSnapshot(provider.id);
+		const alreadyFresh = this.shouldSkipRegistrationRefresh(provider.id);
 		this.extensionProviders.delete(provider.id);
 		this.nativeExtensionProviders.set(provider.id, provider);
 		this.recomposeProvider(provider.id);
@@ -864,17 +849,21 @@ export class ModelRuntime implements Models {
 		if (composedOAuth) this.credentials.registerOAuthProvider(provider.id, composedOAuth);
 		else this.credentials.unregisterOAuthProvider(provider.id);
 		this.updateModelSnapshot();
-		if (alreadyFresh) {
+		if (alreadyFresh || options?.refresh === false) {
 			return Promise.resolve({ aborted: false, errors: new Map() });
 		}
 		return this.refreshAfterRegistration();
 	}
 
-	registerProvider(providerId: string, config: ProviderConfigInput): Promise<ModelsRefreshResult> {
+	registerProvider(
+		providerId: string,
+		config: ProviderConfigInput,
+		options?: { refresh?: boolean },
+	): Promise<ModelsRefreshResult> {
 		// Validate the incoming registration on its own, like the legacy registry:
 		// a broken re-registration must throw without touching the stored config.
 		validateExtensionProvider(providerId, this.builtins.get(providerId), this.config.getProvider(providerId), config);
-		const alreadyFresh = this.providerAlreadyInFreshSnapshot(providerId);
+		const alreadyFresh = this.shouldSkipRegistrationRefresh(providerId);
 		this.nativeExtensionProviders.delete(providerId);
 		// Re-registration merges defined values over the previous registration and
 		// preserves undefined ones, matching the legacy ModelRegistry contract.
@@ -909,7 +898,7 @@ export class ModelRuntime implements Models {
 				available: this.snapshot.all.filter((model) => configuredProviders.has(model.provider)),
 			};
 		}
-		if (alreadyFresh) {
+		if (alreadyFresh || options?.refresh === false) {
 			return Promise.resolve({ aborted: false, errors: new Map() });
 		}
 		return this.refreshAfterRegistration();

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -705,7 +705,7 @@ describe("default model selection", () => {
 		expect(defaultModelPerProvider["zai-coding-cn"]).toBe("glm-5.2");
 		expect(defaultModelPerProvider.minimax).toBe("MiniMax-M2.7");
 		expect(defaultModelPerProvider["minimax-cn"]).toBe("MiniMax-M2.7");
-		expect(defaultModelPerProvider.cerebras).toBe("zai-glm-4.7");
+		expect(defaultModelPerProvider.cerebras).toBe("gpt-oss-120b");
 		expect(defaultModelPerProvider["ant-ling"]).toBe("Ring-2.6-1T");
 	});
 

--- a/packages/coding-agent/test/model-runtime-registration-refresh.test.ts
+++ b/packages/coding-agent/test/model-runtime-registration-refresh.test.ts
@@ -81,4 +81,21 @@ describe("ModelRuntime post-startup provider registration", () => {
 		expect(refreshPolicies.every((allowNetwork) => allowNetwork === false)).toBe(true);
 		expect(runtime.getModel("test-dynamic", "test-dynamic-model")).toBeUndefined();
 	});
+
+	it("skips a redundant catalog refresh when re-registering a provider already in a fresh snapshot", async () => {
+		const runtime = await ModelRuntime.create({
+			credentials: new InMemoryCredentialStore(),
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		const { provider, refreshPolicies } = createDynamicProvider("test-dynamic");
+
+		await runtime.registerNativeProvider(provider);
+		const afterFirst = refreshPolicies.length;
+		expect(afterFirst).toBeGreaterThan(0);
+
+		await runtime.registerNativeProvider(provider);
+
+		expect(refreshPolicies.length).toBe(afterFirst);
+	});
 });


### PR DESCRIPTION
## Summary

Unblocks `npm run release:local` on current `origin/main` (`ebd0603b`). After a live model-data hydrate, `npm test` failed exactly two coding-agent tests. This PR fixes both; it does not merge generated catalog JSON.

### 1. Cerebras default dropped out of the live catalog

`hydrate:model-data` / `release:local` regeneration now ships Cerebras as `gemma-4-31b` + `gpt-oss-120b` only. The bundled default was still `zai-glm-4.7`, so this assertion failed:

```
FAIL  test/model-resolver.test.ts > default model selection > every bundled provider default resolves in its catalog
AssertionError: cerebras should include its default zai-glm-4.7: expected [ 'gemma-4-31b', 'gpt-oss-120b' ] to include 'zai-glm-4.7'
```

The default is now `gpt-oss-120b`, which is present in both the committed snapshot and the live regenerated catalog.

### 2. Reload-efficiency was an independent, deterministic main failure

The second failure was **not** caused by the Cerebras default. It reproduces on pristine HEAD + pristine catalog:

```
FAIL  test/suite/reload-efficiency.test.ts > reload does redundant work only once > runs a single model-availability scan per session reload
AssertionError: expected "list" to be called 1 times, but got 2 times
```

Root cause: session create fire-and-forgets `registerProvider()` (a full `refresh()`), and session reload re-binds the same extension provider and starts another full availability scan. `credentials.list()` from the leftover/re-register scan lands during `session.reload()`, so the test sees two scans.

Fix: serialize `ModelRuntime.refresh()`, and skip `refreshAfterRegistration` when the provider is already in a fresh availability snapshot. First-time post-startup registration still refreshes (existing registration-refresh tests stay green).

## Evidence

Local RED/GREEN receipts (not committed):

`local-ignore/qa-evidence/20260817-senpi-omo-beta-release/02-senpi-release/cerebras-default-fix/`

- RED: live hydrate dropped `zai-glm-4.7`; both assertions failed verbatim.
- GREEN: same two files plus registration-refresh / model-runtime suites passed against the live-hydrated catalog (`gpt-oss-120b` present, `zai-glm-4.7` absent).
- Generated `packages/ai/src/providers/data/*` was restored and is not in this PR.

## Test plan

- [x] `npx vitest --run test/model-resolver.test.ts test/suite/reload-efficiency.test.ts` on live-hydrated catalog
- [x] `npx vitest --run test/model-runtime-registration-refresh.test.ts` (including re-register skip)
- [x] `npx tsc --noEmit`
- [x] `node scripts/check-browser-smoke.mjs`
- [ ] CI on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retargets the Cerebras default to `gpt-oss-120b` and ensures session reload runs a single availability scan by skipping refresh on provider re-registers and enabling batched registration. This fixes deterministic test failures after live catalog regeneration.

- Cerebras default changes from `zai-glm-4.7` to `gpt-oss-120b`; resolver test updated to match live and committed catalogs.
- `registerProvider` and `registerNativeProvider` accept `{ refresh: false }`. Session create drains pending registrations without refreshing and performs one `refresh({ allowNetwork: false })`.
- Re-registering a provider already present in a fresh availability snapshot no longer triggers a catalog refresh. First-time registration still refreshes when model network is enabled.

**Review notes**
- Focus on `src/core/model-resolver.ts`, `src/core/model-runtime.ts`, and `src/core/agent-session-services.ts`. Tests cover both behaviors (`test/model-resolver.test.ts`, `test/model-runtime-registration-refresh.test.ts`).
- No generated catalog JSON is included.
- No migration required.

<sup>Written for commit 0c86b6a8a30245776d5d2df2bfe1620e78f65453. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

