### PR TITLE
fix(coding-agent): activate Cursor OAuth catalogs after login

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh-qa.mjs
@@ -169,6 +169,10 @@ async function main() {
 				setup.acknowledged === true &&
 				setup.refreshRequested === true &&
 				setup.successNotice === true &&
+				setup.postLoginCatalog?.allowNetworkObserved === true &&
+				setup.postLoginCatalog?.catalogRequests === 1 &&
+				setup.postLoginCatalog?.modelVisibleBefore === false &&
+				setup.postLoginCatalog?.modelVisibleAfter === true &&
 				cliPass,
 		};
 		writeFileSync(join(evidencePath, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
@@ -180,6 +184,10 @@ async function main() {
 				`setup.accountName=${setup.accountName}`,
 				`setup.enabled=${setup.enabled}`,
 				`setup.refreshRequested=${setup.refreshRequested}`,
+				`setup.postLoginAllowNetwork=${setup.postLoginCatalog?.allowNetworkObserved}`,
+				`setup.postLoginCatalogRequests=${setup.postLoginCatalog?.catalogRequests}`,
+				`setup.postLoginModelVisibleBefore=${setup.postLoginCatalog?.modelVisibleBefore}`,
+				`setup.postLoginModelVisibleAfter=${setup.postLoginCatalog?.modelVisibleAfter}`,
 				`cli.code=${turn.code}`,
 				`cli.timedOut=${turn.timedOut}`,
 				`cli.resultMarker=${combined.includes("STREAMTEST OK")}`,
@@ -197,7 +205,7 @@ async function main() {
 	process.stdout.write(
 		`[${result.pass && cleanupRemoved ? "PASS" : "FAIL"}] native copy preserved primary credential; ` +
 			`target=${result.setup.accountName}; enabled=${result.setup.enabled}; refresh=${result.setup.refreshRequested}; ` +
-			`CLI marker=${result.cli.resultMarker}\n`,
+			`post-login HTTP catalog=${result.setup.postLoginCatalog?.modelVisibleAfter}; CLI marker=${result.cli.resultMarker}\n`,
 	);
 	process.stdout.write(`auth guard: UNCHANGED (${result.authGuard.before} -> ${result.authGuard.after})\n`);
 	process.stdout.write(`cleanup: sandbox removed=${cleanupRemoved}\n`);

--- a/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh-qa.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * Hermetic real-source-CLI proof for Cursor OAuth catalog activation.
+ *
+ * Usage:
+ *   node .agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh-qa.mjs \
+ *     --evidence cursor-oauth-catalog-refresh
+ *
+ * PASS requires:
+ * - explicit `/cursor-account import native` behavior copies, never moves,
+ *   the native `cursor` OAuth credential into canonical managed accounts;
+ * - provider enablement, acknowledgement, and scoped availability refresh
+ *   persist in the sandbox;
+ * - the real Senpi source CLI completes a print turn through the hermetic
+ *   fake cursor-agent fixture;
+ * - the user's real auth store remains byte-identical and the sandbox is
+ *   removed.
+ */
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	evidenceDir,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+	runCli,
+} from "../lib/common.mjs";
+import { hermeticEnv } from "../lib/mock-loop-support.mjs";
+
+const MODEL = "composer-2.5-fast";
+
+function parseArgs(argv) {
+	let evidence = "cursor-oauth-catalog-refresh";
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		if (arg !== "--evidence") throw new Error(`unknown argument: ${arg}`);
+		const value = argv[++index];
+		if (!value) throw new Error("--evidence requires a value");
+		evidence = value;
+	}
+	return { evidence };
+}
+
+function digest16(value) {
+	return value === null ? null : `${value.slice(0, 16)}…`;
+}
+
+function sha256(path) {
+	try {
+		return createHash("sha256").update(readFileSync(path)).digest("hex");
+	} catch {
+		return null;
+	}
+}
+
+function runSetup(root, box) {
+	const tsx = join(root, "node_modules", "tsx", "dist", "cli.mjs");
+	const setup = join(
+		root,
+		".agents",
+		"skills",
+		"senpi-qa",
+		"scripts",
+		"scenarios",
+		"cursor-oauth-catalog-refresh",
+		"setup.ts",
+	);
+	const result = spawnSync(
+		process.execPath,
+		[tsx, "--tsconfig", join(root, "tsconfig.json"), setup, box.agentDir, box.cwd],
+		{
+			cwd: root,
+			env: hermeticEnv(box.env),
+			encoding: "utf8",
+			timeout: 120_000,
+			maxBuffer: 1024 * 1024,
+		},
+	);
+	if (result.error) throw result.error;
+	if (result.status !== 0) {
+		throw new Error(`setup failed (status=${result.status}): ${(result.stderr ?? "").trim()}`);
+	}
+	return JSON.parse((result.stdout ?? "").trim());
+}
+
+async function main() {
+	const { evidence } = parseArgs(process.argv.slice(2));
+	const root = repoRoot();
+	const evidencePath = evidenceDir(evidence);
+	const box = makeSandbox("cursor-oauth-catalog-refresh");
+	const guard = guardRealAuth();
+	installCleanupHooks();
+	let cleanupRemoved = false;
+	let result;
+	try {
+		const setup = runSetup(root, box);
+		const argvDump = join(box.dir, "fake-cursor-invocation.json");
+		const fixture = join(root, "packages", "coding-agent", "test", "fixtures", "fake-cursor-agent.mjs");
+		const executable = join(box.dir, "fake-cursor-agent");
+		writeFileSync(
+			executable,
+			[
+				"#!/bin/sh",
+				`FAKE_CURSOR_ARGV_DUMP=${JSON.stringify(argvDump)} FAKE_CURSOR_SCENARIO=happy exec ${JSON.stringify(process.execPath)} ${JSON.stringify(fixture)} "$@"`,
+				"",
+			].join("\n"),
+			{ mode: 0o755 },
+		);
+		chmodSync(executable, 0o755);
+		const env = {
+			...hermeticEnv(box.env),
+			SENPI_CURSOR_CLI_OAUTH_EXECUTABLE: executable,
+		};
+		const turn = await runCli(
+			[
+				"--provider",
+				"cursor-cli-oauth",
+				"--model",
+				MODEL,
+				"--print",
+				"Reply with the deterministic fixture result.",
+			],
+			{ env, cwd: box.cwd, timeoutMs: 120_000 },
+		);
+		const combined = `${turn.stdout}\n${turn.stderr}`;
+		const invocation = JSON.parse(readFileSync(argvDump, "utf8"));
+		const cliPass =
+			turn.code === 0 &&
+			turn.timedOut === false &&
+			combined.includes("STREAMTEST OK") &&
+			invocation.argv.includes("--model") &&
+			invocation.argv.includes(MODEL);
+		guard.assertUnchanged();
+		result = {
+			scenario: "cursor-oauth-catalog-refresh-qa",
+			generatedAt: new Date().toISOString(),
+			setup,
+			cli: {
+				code: turn.code,
+				timedOut: turn.timedOut,
+				resultMarker: combined.includes("STREAMTEST OK"),
+				requestedModel: MODEL,
+				modelArgObserved: invocation.argv.includes(MODEL),
+				stdoutExcerpt: turn.stdout.slice(0, 500),
+				stderrExcerpt: turn.stderr.slice(0, 500),
+			},
+			liveProbe: {
+				status: "gated-skip",
+				reason:
+					"the hermetic scenario never reads live credentials; run the existing cursor-cli-oauth live scenario with SENPI_CURSOR_CLI_LIVE=1",
+			},
+			authGuard: {
+				path: guard.path,
+				before: digest16(guard.before),
+				after: digest16(sha256(guard.path)),
+				unchanged: true,
+			},
+			pass:
+				setup.nativePreserved === true &&
+				setup.targetCreated === true &&
+				setup.accountName === "native" &&
+				setup.accountSource === "import" &&
+				setup.accountMatchesNative === true &&
+				setup.enabled === true &&
+				setup.acknowledged === true &&
+				setup.refreshRequested === true &&
+				setup.successNotice === true &&
+				cliPass,
+		};
+		writeFileSync(join(evidencePath, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+		writeFileSync(
+			join(evidencePath, "transcript.txt"),
+			[
+				`setup.nativePreserved=${setup.nativePreserved}`,
+				`setup.targetCreated=${setup.targetCreated}`,
+				`setup.accountName=${setup.accountName}`,
+				`setup.enabled=${setup.enabled}`,
+				`setup.refreshRequested=${setup.refreshRequested}`,
+				`cli.code=${turn.code}`,
+				`cli.timedOut=${turn.timedOut}`,
+				`cli.resultMarker=${combined.includes("STREAMTEST OK")}`,
+				`authGuard.unchanged=true`,
+			].join("\n") + "\n",
+		);
+	} finally {
+		box.cleanup();
+		rmSync(box.dir, { recursive: true, force: true });
+		cleanupRemoved = !existsSync(box.dir);
+	}
+	if (!result) throw new Error("scenario produced no result");
+	result.cleanup = { sandbox: box.dir, removed: cleanupRemoved };
+	writeFileSync(join(evidencePath, "result.json"), `${JSON.stringify(result, null, 2)}\n`);
+	process.stdout.write(
+		`[${result.pass && cleanupRemoved ? "PASS" : "FAIL"}] native copy preserved primary credential; ` +
+			`target=${result.setup.accountName}; enabled=${result.setup.enabled}; refresh=${result.setup.refreshRequested}; ` +
+			`CLI marker=${result.cli.resultMarker}\n`,
+	);
+	process.stdout.write(`auth guard: UNCHANGED (${result.authGuard.before} -> ${result.authGuard.after})\n`);
+	process.stdout.write(`cleanup: sandbox removed=${cleanupRemoved}\n`);
+	process.stdout.write(`evidence: ${evidencePath}\n`);
+	return result.pass && cleanupRemoved ? 0 : 1;
+}
+
+main()
+	.then((code) => {
+		process.exitCode = code;
+	})
+	.catch((error) => {
+		process.stderr.write(`scenario failure: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+		process.exitCode = 1;
+	});

--- a/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh-qa.mjs
@@ -98,14 +98,16 @@ async function main() {
 	let result;
 	try {
 		const setup = runSetup(root, box);
-		const argvDump = join(box.dir, "fake-cursor-invocation.json");
+		const catalogArgvDump = join(box.dir, "fake-cursor-catalog-invocation.json");
+		const turnArgvDump = join(box.dir, "fake-cursor-turn-invocation.json");
 		const fixture = join(root, "packages", "coding-agent", "test", "fixtures", "fake-cursor-agent.mjs");
 		const executable = join(box.dir, "fake-cursor-agent");
 		writeFileSync(
 			executable,
 			[
 				"#!/bin/sh",
-				`FAKE_CURSOR_ARGV_DUMP=${JSON.stringify(argvDump)} FAKE_CURSOR_SCENARIO=happy exec ${JSON.stringify(process.execPath)} ${JSON.stringify(fixture)} "$@"`,
+				`if [ "$1" = "models" ]; then dump=${JSON.stringify(catalogArgvDump)}; else dump=${JSON.stringify(turnArgvDump)}; fi`,
+				`FAKE_CURSOR_ARGV_DUMP="$dump" FAKE_CURSOR_SCENARIO=happy exec ${JSON.stringify(process.execPath)} ${JSON.stringify(fixture)} "$@"`,
 				"",
 			].join("\n"),
 			{ mode: 0o755 },
@@ -127,7 +129,22 @@ async function main() {
 			{ env, cwd: box.cwd, timeoutMs: 120_000 },
 		);
 		const combined = `${turn.stdout}\n${turn.stderr}`;
-		const invocation = JSON.parse(readFileSync(argvDump, "utf8"));
+		const invocation = JSON.parse(readFileSync(turnArgvDump, "utf8"));
+		const catalogInvocation = existsSync(catalogArgvDump)
+			? JSON.parse(readFileSync(catalogArgvDump, "utf8"))
+			: null;
+		writeFileSync(
+			join(evidencePath, "invocation.json"),
+			`${JSON.stringify(
+				{
+					turnArgv: invocation.argv,
+					turnEnvKeys: Object.keys(invocation.env ?? {}).sort(),
+					catalogArgv: catalogInvocation?.argv ?? null,
+				},
+				null,
+				2,
+			)}\n`,
+		);
 		const cliPass =
 			turn.code === 0 &&
 			turn.timedOut === false &&
@@ -169,6 +186,8 @@ async function main() {
 				setup.acknowledged === true &&
 				setup.refreshRequested === true &&
 				setup.successNotice === true &&
+				setup.modelVisibleBeforeImport === false &&
+				setup.modelVisibleAfterImport === true &&
 				setup.postLoginCatalog?.allowNetworkObserved === true &&
 				setup.postLoginCatalog?.catalogRequests === 1 &&
 				setup.postLoginCatalog?.modelVisibleBefore === false &&
@@ -184,6 +203,8 @@ async function main() {
 				`setup.accountName=${setup.accountName}`,
 				`setup.enabled=${setup.enabled}`,
 				`setup.refreshRequested=${setup.refreshRequested}`,
+				`setup.modelVisibleBeforeImport=${setup.modelVisibleBeforeImport}`,
+				`setup.modelVisibleAfterImport=${setup.modelVisibleAfterImport}`,
 				`setup.postLoginAllowNetwork=${setup.postLoginCatalog?.allowNetworkObserved}`,
 				`setup.postLoginCatalogRequests=${setup.postLoginCatalog?.catalogRequests}`,
 				`setup.postLoginModelVisibleBefore=${setup.postLoginCatalog?.modelVisibleBefore}`,

--- a/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Credential } from "@earendil-works/pi-ai";
+import { AuthStorage } from "../../../../../../packages/coding-agent/src/core/auth-storage.ts";
+import {
+	registerCursorCliAccountCommand,
+} from "../../../../../../packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/account-command.ts";
+import {
+	persistCursorCliNoApprovalAcknowledgement,
+} from "../../../../../../packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/settings.ts";
+import type {
+	ExtensionAPI,
+	ExtensionCommandContext,
+	RegisteredCommand,
+} from "../../../../../../packages/coding-agent/src/core/extensions/types.ts";
+
+type Command = Pick<RegisteredCommand, "handler">;
+
+const [agentDir, cwd] = process.argv.slice(2);
+if (!agentDir || !cwd) throw new Error("usage: setup.ts <agent-dir> <cwd>");
+process.env.SENPI_CODING_AGENT_DIR = agentDir;
+
+const nativeCredential: Credential = {
+	type: "oauth",
+	access: "qa-native-access",
+	refresh: "qa-native-refresh",
+	expires: Date.now() + 3_600_000,
+};
+const authPath = join(agentDir, "auth.json");
+const storage = AuthStorage.create(authPath);
+storage.set("cursor", nativeCredential);
+const nativeBefore = JSON.stringify(storage.get("cursor"));
+
+let command: Command | undefined;
+const pi = {
+	registerCommand: (name: string, registered: Command) => {
+		if (name === "cursor-account") command = registered;
+	},
+	on: () => {},
+} as unknown as ExtensionAPI;
+registerCursorCliAccountCommand(pi);
+if (!command) throw new Error("/cursor-account was not registered");
+
+const notices: Array<{ message: string; type?: string }> = [];
+const refreshCalls: unknown[] = [];
+const ctx = {
+	hasUI: false,
+	cwd,
+	signal: undefined,
+	isIdle: () => true,
+	sessionManager: { getSessionId: () => "cursor-oauth-catalog-refresh-qa" },
+	modelRegistry: {
+		authStorage: storage,
+		modelRuntime: {
+			refresh: async (options: unknown) => {
+				refreshCalls.push(options);
+				return { aborted: false, errors: new Map() };
+			},
+		},
+	},
+	ui: {
+		notify: (message: string, type?: string) => notices.push({ message, type }),
+		input: async () => undefined,
+	},
+} as unknown as ExtensionCommandContext;
+
+await command.handler("import native", ctx);
+persistCursorCliNoApprovalAcknowledgement(cwd, "2026-08-18T02:45:00.000Z");
+
+const stored = JSON.parse(readFileSync(authPath, "utf8")) as Record<string, unknown>;
+const target = stored["cursor-cli-oauth"] as
+	| {
+			accounts?: Array<{ name?: unknown; source?: unknown; access?: unknown; refresh?: unknown }>;
+		}
+	| undefined;
+const settings = JSON.parse(readFileSync(join(agentDir, "settings.json"), "utf8")) as {
+	cursorCliOauthProvider?: { enabled?: unknown; noApprovalAcknowledgedAt?: unknown };
+};
+const account = target?.accounts?.[0];
+
+process.stdout.write(
+	`${JSON.stringify({
+		nativePreserved: JSON.stringify(storage.get("cursor")) === nativeBefore,
+		targetCreated: target !== undefined,
+		accountName: account?.name,
+		accountSource: account?.source,
+		accountMatchesNative:
+			account?.access === nativeCredential.access && account?.refresh === nativeCredential.refresh,
+		enabled: settings.cursorCliOauthProvider?.enabled === true,
+		acknowledged:
+			settings.cursorCliOauthProvider?.noApprovalAcknowledgedAt === "2026-08-18T02:45:00.000Z",
+		refreshRequested: refreshCalls.some(
+			(value) =>
+				typeof value === "object" &&
+				value !== null &&
+				(value as { allowNetwork?: unknown }).allowNetwork === false &&
+				Array.isArray((value as { providers?: unknown }).providers) &&
+				(value as { providers: unknown[] }).providers.includes("cursor-cli-oauth"),
+		),
+		successNotice: notices.some(
+			(notice) => notice.type === "info" && notice.message.includes("Imported native Cursor credential"),
+		),
+	})}\n`,
+);

--- a/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { join } from "node:path";
-import type { Credential } from "@earendil-works/pi-ai";
+import type { Api, Credential, Model, Provider } from "@earendil-works/pi-ai";
 import { AuthStorage } from "../../../../../../packages/coding-agent/src/core/auth-storage.ts";
+import { ModelRuntime } from "../../../../../../packages/coding-agent/src/core/model-runtime.ts";
 import {
 	registerCursorCliAccountCommand,
 } from "../../../../../../packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/account-command.ts";
@@ -13,12 +15,139 @@ import type {
 	ExtensionCommandContext,
 	RegisteredCommand,
 } from "../../../../../../packages/coding-agent/src/core/extensions/types.ts";
+import { InteractiveMode } from "../../../../../../packages/coding-agent/src/modes/interactive/interactive-mode.ts";
 
 type Command = Pick<RegisteredCommand, "handler">;
 
 const [agentDir, cwd] = process.argv.slice(2);
 if (!agentDir || !cwd) throw new Error("usage: setup.ts <agent-dir> <cwd>");
 process.env.SENPI_CODING_AGENT_DIR = agentDir;
+
+async function provePostLoginCatalog(): Promise<{
+	allowNetworkObserved: boolean;
+	catalogRequests: number;
+	modelVisibleBefore: boolean;
+	modelVisibleAfter: boolean;
+}> {
+	let catalogRequests = 0;
+	const server = createServer((request, response) => {
+		if (request.method !== "GET" || request.url !== "/models") {
+			response.writeHead(404).end();
+			return;
+		}
+		catalogRequests++;
+		response.writeHead(200, { "content-type": "application/json" });
+		response.end(JSON.stringify({ models: [{ id: "cursor-http-dynamic" }] }));
+	});
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	try {
+		const address = server.address();
+		if (address === null || typeof address === "string") throw new Error("catalog server has no TCP address");
+		const catalogUrl = `http://127.0.0.1:${address.port}/models`;
+		let allowNetworkObserved = false;
+		let catalogReady = false;
+		const model: Model<"openai-completions"> = {
+			id: "cursor-http-dynamic",
+			name: "Cursor HTTP Dynamic",
+			api: "openai-completions",
+			provider: "cursor-http-catalog-qa",
+			baseUrl: catalogUrl,
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 64_000,
+		};
+		const provider: Provider<"openai-completions"> = {
+			id: model.provider,
+			name: "Cursor HTTP Catalog QA",
+			auth: {
+				apiKey: {
+					name: "Cursor QA token",
+					login: async () => ({ type: "api_key", key: "qa-cursor-token" }),
+					check: async ({ credential }) =>
+						credential?.key ? { type: "api_key", source: "stored QA token" } : undefined,
+					resolve: async ({ credential }) => ({
+						auth: { apiKey: credential?.key ?? "" },
+						source: "stored QA token",
+					}),
+				},
+			},
+			getModels: () => (catalogReady ? [model] : []),
+			refreshModels: async ({ allowNetwork }) => {
+				if (!allowNetwork) return;
+				allowNetworkObserved = true;
+				const response = await fetch(catalogUrl);
+				if (!response.ok) throw new Error(`catalog server returned ${response.status}`);
+				const payload = (await response.json()) as { models?: Array<{ id?: unknown }> };
+				catalogReady = payload.models?.some((entry) => entry.id === model.id) === true;
+			},
+			stream: () => {
+				throw new Error("unused");
+			},
+			streamSimple: () => {
+				throw new Error("unused");
+			},
+		};
+		const credentials = AuthStorage.inMemory();
+		const runtime = await ModelRuntime.create({
+			credentials,
+			modelsPath: null,
+			allowModelNetwork: false,
+		});
+		await runtime.registerNativeProvider(provider, { refresh: false });
+		await runtime.login(provider.id, "api_key", {
+			prompt: async () => "unused",
+			notify: () => {},
+		});
+		const modelVisibleBefore = runtime.getAvailableSnapshot().some((entry) => entry.id === model.id);
+		let markRendered: (() => void) | undefined;
+		const rendered = new Promise<void>((resolve) => {
+			markRendered = resolve;
+		});
+		const context = {
+			session: { modelRuntime: runtime },
+			updateAvailableProviderCount: () => {},
+			footer: { invalidate: () => {} },
+			updateEditorBorderColor: () => {},
+			showStatus: () => {},
+			showError: () => {},
+			showWarning: () => {},
+			maybeWarnAboutAnthropicSubscriptionAuth: () => {},
+			checkDaxnutsEasterEgg: () => {},
+			ui: { requestRender: () => markRendered?.() },
+		};
+		const complete = Reflect.get(InteractiveMode.prototype, "completeProviderAuthentication") as (
+			this: object,
+			providerId: string,
+			providerName: string,
+			authType: "oauth" | "api_key",
+			previousModel: Model<Api>,
+		) => Promise<void>;
+		await complete.call(context, provider.id, provider.name, "api_key", {
+			...model,
+			id: "previous-model",
+			provider: "previous-provider",
+		});
+		await Promise.race([
+			rendered,
+			new Promise<never>((_, reject) => {
+				setTimeout(() => reject(new Error("post-login catalog refresh did not render within 5s")), 5_000);
+			}),
+		]);
+		return {
+			allowNetworkObserved,
+			catalogRequests,
+			modelVisibleBefore,
+			modelVisibleAfter: runtime.getAvailableSnapshot().some((entry) => entry.id === model.id),
+		};
+	} finally {
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	}
+}
 
 const nativeCredential: Credential = {
 	type: "oauth",
@@ -66,6 +195,7 @@ const ctx = {
 
 await command.handler("import native", ctx);
 persistCursorCliNoApprovalAcknowledgement(cwd, "2026-08-18T02:45:00.000Z");
+const postLoginCatalog = await provePostLoginCatalog();
 
 const stored = JSON.parse(readFileSync(authPath, "utf8")) as Record<string, unknown>;
 const target = stored["cursor-cli-oauth"] as
@@ -100,5 +230,6 @@ process.stdout.write(
 		successNotice: notices.some(
 			(notice) => notice.type === "info" && notice.message.includes("Imported native Cursor credential"),
 		),
+		postLoginCatalog,
 	})}\n`,
 );

--- a/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts
@@ -159,6 +159,61 @@ const authPath = join(agentDir, "auth.json");
 const storage = AuthStorage.create(authPath);
 storage.set("cursor", nativeCredential);
 const nativeBefore = JSON.stringify(storage.get("cursor"));
+let importRefreshObserved = false;
+const fallbackModel: Model<"openai-completions"> = {
+	id: "cursor-cli-import-visible",
+	name: "Cursor CLI Import Visible",
+	api: "openai-completions",
+	provider: "cursor-cli-oauth",
+	baseUrl: "cursor-cli-oauth",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 64_000,
+};
+const fallbackProvider: Provider<"openai-completions"> = {
+	id: fallbackModel.provider,
+	name: "Cursor CLI Import QA",
+	auth: {
+		oauth: {
+			name: "Cursor CLI Import QA",
+			isSubscription: true,
+			login: async () => {
+				throw new Error("unused");
+			},
+			refresh: async (credential) => credential,
+			toAuth: async () => ({ apiKey: "cursor-cli-oauth-managed" }),
+			check: async ({ credential }) => {
+				if (credential?.type !== "oauth") return undefined;
+				const accounts = (credential as { accounts?: unknown }).accounts;
+				return Array.isArray(accounts) && accounts.length > 0
+					? { type: "oauth", source: "managed QA account" }
+					: undefined;
+			},
+		},
+	},
+	getModels: () => [fallbackModel],
+	refreshModels: async ({ allowNetwork }) => {
+		if (!allowNetwork) importRefreshObserved = true;
+	},
+	stream: () => {
+		throw new Error("unused");
+	},
+	streamSimple: () => {
+		throw new Error("unused");
+	},
+};
+const importRuntime = await ModelRuntime.create({
+	credentials: storage,
+	modelsPath: null,
+	allowModelNetwork: false,
+});
+await importRuntime.registerNativeProvider(fallbackProvider, { refresh: false });
+await importRuntime.refresh({ allowNetwork: false, providers: [fallbackProvider.id] });
+const modelVisibleBeforeImport = importRuntime
+	.getAvailableSnapshot()
+	.some((entry) => entry.id === fallbackModel.id);
 
 let command: Command | undefined;
 const pi = {
@@ -171,7 +226,6 @@ registerCursorCliAccountCommand(pi);
 if (!command) throw new Error("/cursor-account was not registered");
 
 const notices: Array<{ message: string; type?: string }> = [];
-const refreshCalls: unknown[] = [];
 const ctx = {
 	hasUI: false,
 	cwd,
@@ -180,12 +234,7 @@ const ctx = {
 	sessionManager: { getSessionId: () => "cursor-oauth-catalog-refresh-qa" },
 	modelRegistry: {
 		authStorage: storage,
-		modelRuntime: {
-			refresh: async (options: unknown) => {
-				refreshCalls.push(options);
-				return { aborted: false, errors: new Map() };
-			},
-		},
+		modelRuntime: importRuntime,
 	},
 	ui: {
 		notify: (message: string, type?: string) => notices.push({ message, type }),
@@ -194,6 +243,9 @@ const ctx = {
 } as unknown as ExtensionCommandContext;
 
 await command.handler("import native", ctx);
+const modelVisibleAfterImport = importRuntime
+	.getAvailableSnapshot()
+	.some((entry) => entry.id === fallbackModel.id);
 persistCursorCliNoApprovalAcknowledgement(cwd, "2026-08-18T02:45:00.000Z");
 const postLoginCatalog = await provePostLoginCatalog();
 
@@ -219,14 +271,9 @@ process.stdout.write(
 		enabled: settings.cursorCliOauthProvider?.enabled === true,
 		acknowledged:
 			settings.cursorCliOauthProvider?.noApprovalAcknowledgedAt === "2026-08-18T02:45:00.000Z",
-		refreshRequested: refreshCalls.some(
-			(value) =>
-				typeof value === "object" &&
-				value !== null &&
-				(value as { allowNetwork?: unknown }).allowNetwork === false &&
-				Array.isArray((value as { providers?: unknown }).providers) &&
-				(value as { providers: unknown[] }).providers.includes("cursor-cli-oauth"),
-		),
+		refreshRequested: importRefreshObserved,
+		modelVisibleBeforeImport,
+		modelVisibleAfterImport,
 		successNotice: notices.some(
 			(notice) => notice.type === "info" && notice.message.includes("Imported native Cursor credential"),
 		),

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Cursor model catalogs now become available immediately after authentication: dynamic providers perform their scoped network refresh after login, while explicit Cursor CLI fallback login/import enables the lane, `/cursor-account import native` safely copies the primary OAuth credential into managed accounts, and imported accounts refresh model availability in the current session ([#928](https://github.com/code-yeongyu/senpi/pull/928)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/docs/providers.md
+++ b/packages/coding-agent/docs/providers.md
@@ -159,7 +159,7 @@ Use the native `cursor` provider above by default - it is the first-party, prima
 | Auth | senpi OAuth (`/login cursor`), tokens in `auth.json` | The same senpi OAuth flow; this lane stores multiple named accounts and injects each into a per-account file-store HOME immediately before every turn |
 | Tool execution | Cursor's server-driven exec channel bridges onto senpi's real tools (`read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`, MCP/extension tools), so approvals, sandboxing, and truncation behave like model-issued calls | Runs INSIDE the Cursor CLI with no senpi approval, no senpi sandboxing, and no tool-level audit - a one-time acknowledgement is required before unattended execution |
 | Model catalog | Per-account `GetUsableModels` discovery, refreshed with `senpi update --models` | `cursor-agent models` listing (the full suffix-expanded effort x thinking x `-fast` ladder, 204 ids on the reference build), cached with a TTL; static fallback list when the CLI is missing or the probe fails |
-| Requirements | None beyond `/login cursor` | The `cursor-agent` CLI installed and logged in, plus the lane enabled in settings |
+| Requirements | None beyond `/login cursor` | The `cursor-agent` CLI installed, plus an explicit fallback-lane login or import |
 
 #### Setup
 
@@ -169,15 +169,17 @@ Use the native `cursor` provider above by default - it is the first-party, prima
 curl https://cursor.com/install -fsS | bash
 ```
 
-2. Enable the lane (off by default): set `cursorCliOauthProvider.enabled: true` in senpi settings, or export `SENPI_CURSOR_CLI_OAUTH_ENABLED=1`.
-3. Sign in: `/login cursor-cli-oauth` runs the same Cursor OAuth flow as the native provider and stores the account as a named slot (the first slot is named `default`; later logins prompt for a name).
+2. Sign in: `/login cursor-cli-oauth` runs the same Cursor OAuth flow as the native provider, stores the account as a named slot (the first slot is named `default`; later logins prompt for a name), and enables the fallback lane.
+3. Or reuse an existing credential explicitly: `/cursor-account import native` copies the OAuth credential already stored for the primary `cursor` provider into a managed `native` slot. The primary credential is preserved unchanged. Bare `/cursor-account import` (or `import local`) keeps copying the locally logged-in Cursor desktop/CLI credential.
 4. Manage accounts with `/cursor-account`:
 
 ```
-/cursor-account [list | add | remove <name> | pin <name> | unpin | import | acknowledge | status]
+/cursor-account [list | add | remove <name> | pin <name> | unpin | import [local | native] | acknowledge | status]
 ```
 
-- `import` copies the locally logged-in Cursor desktop credential into a new slot: the source is read once, on this explicit request only, and copied - never referenced live.
+- `add`, `import local`, and `import native` are explicit opt-in actions: each enables the lane and refreshes its model availability. Set `cursorCliOauthProvider.enabled: false` (or `SENPI_CURSOR_CLI_OAUTH_ENABLED=0`) to disable it again.
+- `import local` copies the locally logged-in Cursor desktop credential into a new slot: the source is read once, on this explicit request only, and copied - never referenced live.
+- `import native` copies the primary Senpi `cursor` provider's OAuth credential into a separate managed slot without moving, deleting, or refreshing the primary entry.
 - `pin <name>` (or the `cursorCliOauthProvider.pinnedAccount` setting) fixes one account for the session.
 - `status` reports the lane, the active account, and the context owner of a resumed CLI chat.
 

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/account-command.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/account-command.ts
@@ -21,6 +21,7 @@ import {
 	CURSOR_CLI_OAUTH_PROVIDER_ID,
 	confirmCursorCliNoApprovalAcknowledgement,
 	importLocalCursorCredential,
+	importNativeCursorCredential,
 	type LocalCursorImportDeps,
 } from "./oauth-login.ts";
 import { type CursorCliSessionRouter, cursorCliSessionRouter } from "./session-router.ts";
@@ -28,6 +29,7 @@ import {
 	type CursorCliOauthProviderSettings,
 	loadCursorCliOauthProviderSettingsFromDisk,
 	persistCursorCliNoApprovalAcknowledgement,
+	persistCursorCliOauthEnabled,
 } from "./settings.ts";
 
 /** Injectable seams; every default resolves real on-disk state at invocation time. */
@@ -38,15 +40,18 @@ export type CursorCliAccountCommandDeps = {
 	readonly probeVersion?: (executable: string) => Promise<string>;
 	readonly readNativeCredential?: () => Credential | undefined | Promise<Credential | undefined>;
 	readonly importCredential?: typeof importLocalCursorCredential;
+	readonly importNativeCredential?: typeof importNativeCursorCredential;
 	readonly importDeps?: LocalCursorImportDeps;
 	/** Acknowledgement persistence seam; the default read-modify-writes the global settings file. */
 	readonly persistAcknowledgement?: (cwd: string, acknowledgedAt: string) => void;
+	/** Enablement persistence seam; explicit login/import actions activate the fallback lane. */
+	readonly persistEnabled?: (cwd: string, enabled: boolean) => void;
 	readonly now?: () => number;
 	readonly generation?: CursorCliGenerationGuard;
 };
 
 const USAGE =
-	"Usage: /cursor-account [list | add | remove <name> | pin <name> | unpin | import | acknowledge | status]";
+	"Usage: /cursor-account [list | add | remove <name> | pin <name> | unpin | import [local | native] | acknowledge | status]";
 
 function asCursorCredential(value: Credential | undefined): CursorCliOauthCredential {
 	return value !== undefined && value.type === "oauth" ? (value as CursorCliOauthCredential) : emptyCredential();
@@ -117,7 +122,12 @@ export function registerCursorCliAccountCommand(pi: ExtensionAPI, deps: CursorCl
 					return;
 				}
 				if (action === "import") {
-					await importAccount(ctx, deps);
+					const source = args[1] ?? "local";
+					if (source !== "local" && source !== "native") {
+						ctx.ui.notify(USAGE, "error");
+						return;
+					}
+					await importAccount(ctx, deps, source);
 					return;
 				}
 				if (action === "acknowledge") {
@@ -261,8 +271,13 @@ async function unpinAccount(ctx: ExtensionCommandContext): Promise<void> {
 	ctx.ui.notify("Unpinned Cursor CLI (OAuth) account.", "info");
 }
 
-async function importAccount(ctx: ExtensionCommandContext, deps: CursorCliAccountCommandDeps): Promise<void> {
+async function importAccount(
+	ctx: ExtensionCommandContext,
+	deps: CursorCliAccountCommandDeps,
+	source: "local" | "native",
+): Promise<void> {
 	const importCredential = deps.importCredential ?? importLocalCursorCredential;
+	const importNativeCredential = deps.importNativeCredential ?? importNativeCursorCredential;
 	const importDeps: LocalCursorImportDeps = { ...deps.importDeps };
 	if (importDeps.onPrompt === undefined && ctx.hasUI) {
 		importDeps.onPrompt = async (prompt: { message: string }) => {
@@ -275,7 +290,13 @@ async function importAccount(ctx: ExtensionCommandContext, deps: CursorCliAccoun
 	try {
 		await ctx.modelRegistry.authStorage.modify(CURSOR_CLI_OAUTH_PROVIDER_ID, async (current) => {
 			const before = asCursorCredential(current);
-			const updated = await importCredential(before, importDeps);
+			const updated =
+				source === "native"
+					? await importNativeCredential(
+							before,
+							deps.readNativeCredential ?? (() => ctx.modelRegistry.authStorage.get(NATIVE_CURSOR_PROVIDER_ID)),
+						)
+					: await importCredential(before, importDeps);
 			const existing = new Set(listAccounts(before).map((account) => account.name));
 			importedName = listAccounts(updated).find((account) => !existing.has(account.name))?.name;
 			return updated;
@@ -287,9 +308,23 @@ async function importAccount(ctx: ExtensionCommandContext, deps: CursorCliAccoun
 		);
 		return;
 	}
+	const persistEnabled = deps.persistEnabled ?? persistCursorCliOauthEnabled;
+	try {
+		persistEnabled(ctx.cwd, true);
+		await ctx.modelRegistry.modelRuntime.refresh({
+			allowNetwork: false,
+			providers: [CURSOR_CLI_OAUTH_PROVIDER_ID],
+		});
+	} catch (error) {
+		ctx.ui.notify(
+			`Imported ${source === "native" ? "native " : ""}Cursor credential, but provider activation failed: ${error instanceof Error ? error.message : String(error)}`,
+			"warning",
+		);
+		return;
+	}
 	emitProviderAccountsChanged(CURSOR_CLI_OAUTH_PROVIDER_ID);
 	ctx.ui.notify(
-		`Imported local Cursor credential as '${importedName ?? "a new account"}' (copied into this provider's store).`,
+		`Imported ${source === "native" ? "native " : "local "}Cursor credential as '${importedName ?? "a new account"}' (copied into this provider's store).`,
 		"info",
 	);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/changes.md
@@ -1,5 +1,51 @@
 # cursor-cli-oauth extension changes
 
+## 2026-08-18 - Activate explicit login/import and copy native Cursor credentials
+
+### What changed
+
+- `settings.ts`: provider activation now uses the same locked
+  read-modify-write path as the no-approval acknowledgement.
+  `persistCursorCliOauthEnabled()` preserves every sibling setting, and a
+  successful acknowledgement writes `enabled: true` together with
+  `noApprovalAcknowledgedAt`.
+- `oauth-login.ts`: successful OAuth login requests persisted enablement even
+  when the user declines unattended tool execution. The new
+  `importNativeCursorCredential()` copies a usable flat OAuth credential from
+  the primary `cursor` provider into a canonical named account slot; it never
+  writes or deletes the source credential.
+- `index.ts`: the real builtin registration now wires both acknowledgement
+  and enablement persistence into the OAuth config, instead of leaving the
+  login-time acknowledgement as an unwritten optional callback.
+- `account-command.ts`: `/cursor-account import native` explicitly copies the
+  primary provider credential. Local and native imports persist enablement
+  and run a scoped offline availability refresh so the current session's
+  model selector updates without restart.
+
+### Why
+
+- The fallback provider registered its model catalog but remained hidden after
+  successful login/import because `cursorCliOauthProvider.enabled` defaulted
+  false and the explicit actions never changed it.
+- Users with a valid native `cursor` OAuth credential had to copy token
+  material by hand into the fallback provider's sentinel `accounts[]` shape,
+  risking accidental removal of the primary credential.
+- The login acknowledgement prompt claimed success but the production
+  registration did not supply the persistence callback.
+
+### Why an extension could not handle it
+
+- These are the fallback extension's private OAuth, settings, account-command,
+  and provider-registration boundaries. No external extension can rewrite the
+  builtin provider's credential shape, add persistence to its login callback,
+  or refresh its private model-runtime availability after import.
+
+### Expected merge conflict zones
+
+- LOW: fork-only `settings.ts`, `oauth-login.ts`, `index.ts`, and
+  `account-command.ts`; conflicts are expected only with concurrent hardening
+  of the same Cursor CLI OAuth lane.
+
 ## 2026-08-17 - Initial builtin fallback lane
 
 Plan: `.omo/plans/cursor-cli-oauth.md`. Probe evidence: `local-ignore/qa-evidence/20260817-cursor-cli-p-lane/`.

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/index.ts
@@ -6,7 +6,12 @@ import { registerCursorCliAccountCommand } from "./account-command.ts";
 import { defaultCursorAgentExecutableDeps, resolveCursorAgentExecutable } from "./executable.ts";
 import { resolveCursorCliModelCatalog, STATIC_CURSOR_CLI_MODELS } from "./models.ts";
 import { CURSOR_CLI_OAUTH_PROVIDER_ID, createCursorCliOauthConfig } from "./oauth-login.ts";
-import { type CursorCliOauthProviderSettings, loadCursorCliOauthProviderSettingsFromDisk } from "./settings.ts";
+import {
+	type CursorCliOauthProviderSettings,
+	loadCursorCliOauthProviderSettingsFromDisk,
+	persistCursorCliNoApprovalAcknowledgement,
+	persistCursorCliOauthEnabled,
+} from "./settings.ts";
 import { streamCursorCliOauth } from "./stream.ts";
 
 export { CURSOR_CLI_OAUTH_PROVIDER_ID } from "./oauth-login.ts";
@@ -56,6 +61,8 @@ export function registerCursorCliOauthExtension(pi: ExtensionAPI, deps: CursorCl
 				readCurrent,
 				readSettings: () => loadSettings(cwd),
 				resolveExecutable,
+				persistAcknowledgement: (acknowledgedAt) => persistCursorCliNoApprovalAcknowledgement(cwd, acknowledgedAt),
+				persistEnabled: (enabled) => persistCursorCliOauthEnabled(cwd, enabled),
 			}),
 		});
 	};

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/oauth-login.ts
@@ -31,6 +31,7 @@ import {
 	type CursorCliOauthProviderSettings,
 	loadCursorCliOauthProviderSettingsFromDisk,
 	persistCursorCliNoApprovalAcknowledgement,
+	persistCursorCliOauthEnabled,
 } from "./settings.ts";
 
 export const CURSOR_CLI_OAUTH_PROVIDER_ID = "cursor-cli-oauth";
@@ -60,6 +61,8 @@ export type CursorCliOauthConfigDeps = {
 	now?: () => Date;
 	/** Persists the no-approval acknowledgement; the disk default is wired in defaultCursorCliOauthConfig. */
 	persistAcknowledgement?: (acknowledgedAt: string) => void;
+	/** Persists explicit provider activation after a successful login. */
+	persistEnabled?: (enabled: boolean) => void;
 };
 
 export type CursorCliOauthLaneResolution = {
@@ -323,7 +326,9 @@ export function createCursorCliOauthConfig(deps: CursorCliOauthConfigDeps): Curs
 				deps.now ?? (() => new Date()),
 			);
 			if (acknowledgedAt !== undefined) deps.persistAcknowledgement?.(acknowledgedAt);
-			return addAccount(current, slotFromCredential(loggedIn, name, "login"));
+			const credential = addAccount(current, slotFromCredential(loggedIn, name, "login"));
+			deps.persistEnabled?.(true);
+			return credential;
 		},
 
 		async refreshToken(credentials, signal) {
@@ -441,6 +446,40 @@ export async function importLocalCursorCredential(
 	);
 }
 
+function isUsableFlatOAuthCredential(value: Credential | undefined): value is OAuthCredential {
+	return (
+		value?.type === "oauth" &&
+		typeof value.access === "string" &&
+		value.access.length > 0 &&
+		typeof value.refresh === "string" &&
+		value.refresh.length > 0 &&
+		typeof value.expires === "number" &&
+		Number.isFinite(value.expires)
+	);
+}
+
+function nativeAccountName(existing: readonly CursorCliAccountSlot[]): string {
+	const names = new Set(existing.map((account) => account.name));
+	if (!names.has("native")) return "native";
+	for (let index = 2; index <= 10_000; index++) {
+		const candidate = `native-${index}`;
+		if (!names.has(candidate)) return candidate;
+	}
+	throw new Error("Could not allocate a Cursor CLI OAuth native account name");
+}
+
+/** Explicitly copy Senpi's native `cursor` OAuth credential into a managed CLI account slot. */
+export async function importNativeCursorCredential(
+	current: CursorCliOauthCredential,
+	readNativeCredential: () => Credential | undefined | Promise<Credential | undefined>,
+): Promise<CursorCliOauthCredential> {
+	const native = await readNativeCredential();
+	if (!isUsableFlatOAuthCredential(native)) {
+		throw new Error("No stored native Cursor OAuth credential found");
+	}
+	return addAccount(current, slotFromCredential(native, nativeAccountName(listAccounts(current)), "import"));
+}
+
 export function defaultCursorCliOauthConfig(
 	cwd: string,
 	readCurrent: () => Promise<Credential | undefined>,
@@ -458,5 +497,6 @@ export function defaultCursorCliOauthConfig(
 		now: () => new Date(),
 		persistAcknowledgement: (acknowledgedAt: string) =>
 			persistCursorCliNoApprovalAcknowledgement(cwd, acknowledgedAt),
+		persistEnabled: (enabled: boolean) => persistCursorCliOauthEnabled(cwd, enabled),
 	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/settings.ts
@@ -209,13 +209,11 @@ export function loadCursorCliOauthProviderSettingsFromDisk(cwd: string): CursorC
 	);
 }
 
-/**
- * Read-modify-write `noApprovalAcknowledgedAt` into the provider block of the
- * global settings file, preserving every other key. An unparseable file is
- * reported instead of silently clobbered, so an acknowledgement can never
- * claim success while leaving the settings unwritten.
- */
-export function persistCursorCliNoApprovalAcknowledgement(cwd: string, acknowledgedAt: string): void {
+function persistCursorCliOauthProviderPatch(
+	cwd: string,
+	action: string,
+	patch: Readonly<Record<string, unknown>>,
+): void {
 	const storage = new FileSettingsStorage(cwd, getAgentDir());
 	storage.selectSource("global");
 	storage.withLock("global", (current) => {
@@ -224,7 +222,7 @@ export function persistCursorCliNoApprovalAcknowledgement(cwd: string, acknowled
 			root = current === undefined ? {} : parseSettingsJson(current);
 		} catch (error) {
 			throw new Error(
-				`Cannot persist the cursor-cli-oauth acknowledgement: the settings file is unparseable (${error instanceof Error ? error.message : String(error)})`,
+				`Cannot persist the cursor-cli-oauth ${action}: the settings file is unparseable (${error instanceof Error ? error.message : String(error)})`,
 			);
 		}
 		const provider =
@@ -233,10 +231,24 @@ export function persistCursorCliNoApprovalAcknowledgement(cwd: string, acknowled
 			!Array.isArray(root.cursorCliOauthProvider)
 				? { ...(root.cursorCliOauthProvider as Record<string, unknown>) }
 				: {};
-		return JSON.stringify(
-			{ ...root, cursorCliOauthProvider: { ...provider, noApprovalAcknowledgedAt: acknowledgedAt } },
-			null,
-			2,
-		);
+		return JSON.stringify({ ...root, cursorCliOauthProvider: { ...provider, ...patch } }, null, 2);
+	});
+}
+
+/** Persist explicit provider activation while preserving every sibling setting. */
+export function persistCursorCliOauthEnabled(cwd: string, enabled: boolean): void {
+	persistCursorCliOauthProviderPatch(cwd, "enabled state", { enabled });
+}
+
+/**
+ * Read-modify-write `noApprovalAcknowledgedAt` into the provider block of the
+ * global settings file, preserving every other key. An unparseable file is
+ * reported instead of silently clobbered, so an acknowledgement can never
+ * claim success while leaving the settings unwritten.
+ */
+export function persistCursorCliNoApprovalAcknowledgement(cwd: string, acknowledgedAt: string): void {
+	persistCursorCliOauthProviderPatch(cwd, "acknowledgement", {
+		enabled: true,
+		noApprovalAcknowledgedAt: acknowledgedAt,
 	});
 }

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,32 @@
 # changes
 
+## Post-login provider catalog refresh explicitly allows network discovery (2026-08-18)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`:
+  `completeProviderAuthentication()` now passes `allowNetwork: true` to its
+  existing provider-scoped, 15-second background refresh after successful
+  OAuth/API-key login.
+
+### Why
+
+- Ordinary interactive runtimes default model networking off. The post-login
+  refresh inherited that default, so dynamic providers such as native Cursor
+  stored valid credentials but restored only cached models instead of
+  fetching the authenticated account catalog immediately.
+
+### Why an extension could not handle it
+
+- Login completion, its bounded refresh controller, and the status/warning UI
+  are private `InteractiveMode` lifecycle code. Provider extensions cannot
+  alter the options on the core refresh that runs after their login returns.
+
+### Expected merge conflict zones
+
+- LOW: the single `modelRuntime.refresh()` option object inside
+  `completeProviderAuthentication()`.
+
 ## Repository-wide changes.md audit backfill for interactive rendering, selectors, and editor surfaces (2026-08-17)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6781,7 +6781,7 @@ export class InteractiveMode {
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), 15_000);
 		void this.session.modelRuntime
-			.refresh({ providers: [providerId], signal: controller.signal })
+			.refresh({ allowNetwork: true, providers: [providerId], signal: controller.signal })
 			.then((result) => {
 				if (result.aborted) {
 					this.showWarning(`${actionLabel}, but its model catalog refresh timed out; using cached models.`);

--- a/packages/coding-agent/test/cursor-cli-oauth/account-command.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/account-command.test.ts
@@ -84,9 +84,15 @@ function createContext(
 	storage: AuthStorage,
 	sessionId = "session-01",
 	extra: { hasUI?: boolean; login?: () => Promise<void>; input?: (title: string) => Promise<string | undefined> } = {},
-): { ctx: ExtensionCommandContext; notices: Notice[]; login: ReturnType<typeof vi.fn> } {
+): {
+	ctx: ExtensionCommandContext;
+	notices: Notice[];
+	login: ReturnType<typeof vi.fn>;
+	refresh: ReturnType<typeof vi.fn>;
+} {
 	const notices: Notice[] = [];
 	const login = vi.fn(extra.login ?? (async () => {}));
+	const refresh = vi.fn(async () => ({ aborted: false, errors: new Map() }));
 	return {
 		ctx: {
 			hasUI: extra.hasUI ?? true,
@@ -96,7 +102,7 @@ function createContext(
 			sessionManager: { getSessionId: () => sessionId },
 			modelRegistry: {
 				authStorage: storage,
-				modelRuntime: { login },
+				modelRuntime: { login, refresh },
 			},
 			ui: {
 				notify: (message: string, type?: Notice["type"]) => notices.push({ message, type }),
@@ -105,6 +111,7 @@ function createContext(
 		} as unknown as ExtensionCommandContext,
 		notices,
 		login,
+		refresh,
 	};
 }
 
@@ -266,18 +273,58 @@ describe("/cursor-account", () => {
 
 	it("invokes the local-credential import function and stores the copied slot", async () => {
 		const storage = AuthStorage.inMemory({ [PROVIDER_ID]: credential(slot("alpha")) });
-		const { ctx, notices } = createContext(storage);
+		const { ctx, notices, refresh } = createContext(storage);
 		const importCredential = vi.fn<typeof importLocalCursorCredential>(async (current) =>
 			addAccount(current, slot("imported", { source: "import" })),
 		);
-		const harness = createHarness({ importCredential });
+		const persistEnabled = vi.fn();
+		const harness = createHarness({ importCredential, persistEnabled });
 
 		await command(harness).handler("import", ctx);
 
 		expect(importCredential).toHaveBeenCalledTimes(1);
 		expect(asCredential(importCredential.mock.calls[0]?.[0]).accounts?.map((a) => a.name)).toEqual(["alpha"]);
 		expect((asCredential(storage.get(PROVIDER_ID)).accounts ?? []).map((a) => a.name)).toEqual(["alpha", "imported"]);
+		expect(persistEnabled).toHaveBeenCalledWith("/tmp/cursor-account-command", true);
+		expect(refresh).toHaveBeenCalledWith({ allowNetwork: false, providers: [PROVIDER_ID] });
 		expect(lastNotice(notices)).toContain("imported");
+	});
+
+	it("imports the native cursor credential without modifying the primary provider", async () => {
+		const nativeCredential: Credential = {
+			type: "oauth",
+			access: "native-access-token",
+			refresh: "native-refresh-token",
+			expires: FIXED_NOW + 3_600_000,
+		};
+		const storage = AuthStorage.inMemory({ cursor: nativeCredential });
+		const nativeBefore = JSON.stringify(storage.get("cursor"));
+		const { ctx, notices, refresh } = createContext(storage);
+		const persistEnabled = vi.fn();
+		const harness = createHarness({
+			importDeps: {
+				platform: "linux",
+				readCursorFile: async () => undefined,
+				readCursorKeychain: async () => undefined,
+			},
+			persistEnabled,
+			readNativeCredential: () => storage.get("cursor"),
+		});
+
+		await command(harness).handler("import native", ctx);
+
+		expect(asCredential(storage.get(PROVIDER_ID)).accounts ?? []).toMatchObject([
+			{
+				name: "native",
+				access: "native-access-token",
+				refresh: "native-refresh-token",
+				source: "import",
+			},
+		]);
+		expect(JSON.stringify(storage.get("cursor"))).toBe(nativeBefore);
+		expect(persistEnabled).toHaveBeenCalledWith("/tmp/cursor-account-command", true);
+		expect(refresh).toHaveBeenCalledWith({ allowNetwork: false, providers: [PROVIDER_ID] });
+		expect(lastNotice(notices)).toContain("native");
 	});
 
 	it("surfaces an import failure as an error without changing the store", async () => {

--- a/packages/coding-agent/test/cursor-cli-oauth/oauth-login.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/oauth-login.test.ts
@@ -192,6 +192,25 @@ describe("cursor-cli-oauth login and availability", () => {
 		expect(login).toHaveBeenCalledTimes(2);
 	});
 
+	it("requests provider enablement after a successful login", async () => {
+		const persistEnabled = vi.fn();
+		const config = createCursorCliOauthConfig({
+			...dependencies(async () => undefined),
+			loadOAuth: async () => oauthFlow(),
+			persistEnabled,
+		});
+
+		await config.login({
+			onAuth: vi.fn(),
+			onDeviceCode: vi.fn(),
+			onPrompt: vi.fn(async () => "no"),
+			onSelect: vi.fn(async () => undefined),
+		});
+
+		expect(persistEnabled).toHaveBeenCalledOnce();
+		expect(persistEnabled).toHaveBeenCalledWith(true);
+	});
+
 	it("delegates expired slot refresh to the Cursor OAuth loader", async () => {
 		const refresh = vi.fn(
 			async (_stored: OAuthCredential, _signal: AbortSignal): Promise<OAuthCredential> => ({

--- a/packages/coding-agent/test/cursor-cli-oauth/settings.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/settings.test.ts
@@ -282,7 +282,10 @@ describe("persisting the Cursor CLI OAuth no-approval acknowledgement", () => {
 		persistCursorCliNoApprovalAcknowledgement(cwd, "2026-08-17T12:05:00.000Z");
 
 		expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual({
-			cursorCliOauthProvider: { noApprovalAcknowledgedAt: "2026-08-17T12:05:00.000Z" },
+			cursorCliOauthProvider: {
+				enabled: true,
+				noApprovalAcknowledgedAt: "2026-08-17T12:05:00.000Z",
+			},
 		});
 	});
 

--- a/packages/coding-agent/test/suite/regressions/7027-credential-refresh-hang.test.ts
+++ b/packages/coding-agent/test/suite/regressions/7027-credential-refresh-hang.test.ts
@@ -112,6 +112,7 @@ describe("issues #7027 and #7113 credential refresh hang", () => {
 
 		await complete.call(context, dynamicModel.provider, "Stalled Login", "api_key", harness.getModel());
 		expect(runtime.refresh).toHaveBeenCalledWith({
+			allowNetwork: true,
 			providers: [dynamicModel.provider],
 			signal: expect.any(AbortSignal),
 		});

--- a/packages/coding-agent/test/suite/regressions/cursor-login-catalog-refresh.test.ts
+++ b/packages/coding-agent/test/suite/regressions/cursor-login-catalog-refresh.test.ts
@@ -1,0 +1,94 @@
+import type { Api, Model, Provider } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const cursorModel: Model<"cursor-agent"> = {
+	id: "cursor-dynamic",
+	name: "Cursor Dynamic",
+	api: "cursor-agent",
+	provider: "cursor-catalog-test",
+	baseUrl: "https://api2.cursor.sh",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 64_000,
+};
+
+describe("Cursor OAuth catalog refresh", () => {
+	let harness: Harness | undefined;
+
+	afterEach(() => {
+		harness?.cleanup();
+		harness = undefined;
+		vi.restoreAllMocks();
+	});
+
+	it("enables network model discovery immediately after login", async () => {
+		harness = await createHarness();
+		const runtime = harness.session.modelRuntime;
+		let catalogNetworkAllowed = false;
+		const provider: Provider<"cursor-agent"> = {
+			id: cursorModel.provider,
+			name: "Cursor Catalog Test",
+			auth: {
+				apiKey: {
+					name: "Cursor access token",
+					login: async () => ({ type: "api_key", key: "secret" }),
+					check: async ({ credential }) =>
+						credential?.key ? { type: "api_key", source: "stored token" } : undefined,
+					resolve: async ({ credential }) => ({
+						auth: { apiKey: credential?.key ?? "" },
+						source: "stored token",
+					}),
+				},
+			},
+			getModels: () => (catalogNetworkAllowed ? [cursorModel] : []),
+			refreshModels: async ({ allowNetwork }) => {
+				catalogNetworkAllowed = allowNetwork;
+			},
+			stream: () => {
+				throw new Error("unused");
+			},
+			streamSimple: () => {
+				throw new Error("unused");
+			},
+		};
+		await runtime.registerNativeProvider(provider, { refresh: false });
+		await runtime.login(provider.id, "api_key", { prompt: async () => "unused", notify: () => {} });
+		expect(runtime.getAvailableSnapshot().map((model) => model.id)).not.toContain(cursorModel.id);
+
+		let markRefreshRendered: (() => void) | undefined;
+		const refreshRendered = new Promise<void>((resolve) => {
+			markRefreshRendered = resolve;
+		});
+		const context = {
+			session: harness.session,
+			updateAvailableProviderCount: vi.fn(),
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			showWarning: vi.fn(),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(),
+			checkDaxnutsEasterEgg: vi.fn(),
+			ui: {
+				requestRender: vi.fn(() => markRefreshRendered?.()),
+			},
+		};
+		const complete = Reflect.get(InteractiveMode.prototype, "completeProviderAuthentication") as (
+			this: object,
+			providerId: string,
+			providerName: string,
+			authType: "oauth" | "api_key",
+			previousModel: Model<Api>,
+		) => Promise<void>;
+
+		await complete.call(context, provider.id, provider.name, "oauth", harness.getModel());
+		await refreshRendered;
+
+		expect(catalogNetworkAllowed).toBe(true);
+		expect(runtime.getAvailableSnapshot().map((model) => model.id)).toContain(cursorModel.id);
+	});
+});


### PR DESCRIPTION
## Summary

- make successful interactive provider login perform the authenticated network refresh required by dynamic catalogs such as native Cursor
- make explicit `cursor-cli-oauth` login/import actions activate the fallback lane, add `/cursor-account import native`, preserve the primary `cursor` credential, and refresh availability in the current session
- add hermetic and live Cursor CLI QA covering canonical account copy, real model catalog visibility, streaming, forced tool execution, model-switch resume, auth integrity, and cleanup

## Root cause

The interactive post-login refresh inherited the CLI's default network-disabled policy, so dynamic account catalogs restored cache only. Separately, the optional Cursor CLI fallback lane kept `enabled: false` after successful login/import and had no explicit path to copy Senpi's primary `cursor` OAuth credential into its managed `accounts[]` shape.

## Verification

- RED: native post-login regression failed at `expected false to be true`
- GREEN: native focused regression 1/1; adjacent credential refresh 3/3
- RED: Cursor CLI activation/import suite failed 4 intended assertions with 54 adjacent tests green
- GREEN: Cursor CLI OAuth suite 237/237
- `npx tsc --noEmit -p packages/coding-agent/tsconfig.build.json`
- `npm run build -w @code-yeongyu/senpi`
- hermetic source CLI QA: PASS; primary credential preserved; canonical `native` account; enabled/refresh persisted; fake cursor-agent turn completed
- live installed `cursor-agent 2026.08.11-e8db854`: 4/4 PASS; real model catalog 206 lines with representative Composer/GPT/Claude ids; real auth hash unchanged
- cleanup: exact QA-owned orphan language-server PIDs terminated; no matching process or sandbox path remained

Evidence: `local-ignore/qa-evidence/20260818-cursor-oauth-catalog-refresh/`

## Safety

- `cursor-cli-oauth` remains default-off; only explicit login/import enables it
- `import native` copies and never removes or mutates the primary `cursor` OAuth entry
- unattended Cursor CLI tools still require the separate no-approval acknowledgement
- no credential value is logged or included in evidence

Plan: `.omo/plans/cursor-oauth-catalog-refresh.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates Cursor OAuth model catalogs immediately after authentication and exposes the fallback lane in-session. Previously, post-login refresh ignored network discovery and the `cursor-cli-oauth` lane stayed disabled; now login/import enables it and catalogs populate without restart.

- Interactive: post-login `modelRuntime.refresh()` passes `allowNetwork: true` (15s bounded); adds a regression proving network discovery and model visibility.
- `cursor-cli-oauth`: successful `/login` and `/cursor-account import [local|native]` persist `enabled: true` and trigger a provider-scoped offline refresh; `import native` copies the primary `cursor` OAuth credential into a managed account without changing the source; acknowledgement also persists `enabled: true`.
- Docs/Tests/QA: updates `providers.md` with `import [local|native]` and enable-on-login/import; adds unit/regression tests (including same-session availability) and a hermetic QA scenario validating native copy, enablement, catalog visibility, and cleanup.

<sup>Written for commit a578d299e0204e1cc93ca3986a97119600c8c81b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

