### PR TITLE
fix(coding-agent): keep extension widget stacking order stable across updates

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Fixed
 
+- Extension widgets no longer change stacking order when their content updates: `setWidget` now replaces the
+  component in place, so two live widgets with independent refresh timers (for example omo-senpi's `omo-task` and
+  `omo-dag` status widgets) stay in a fixed vertical order instead of bouncing on every refresh
+  ([#929](https://github.com/code-yeongyu/senpi/pull/929)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Extension widget updates preserve stacking order (2026-08-18)
+
+### What changed
+
+- `setExtensionWidget()` in `interactive-mode.ts` no longer deletes and re-appends the updated key on every call. It now removes the key only from the OTHER placement map, disposes the replaced component, and writes through `Map.set`, which keeps an existing key at its insertion position. Removal (`content === undefined`) still deletes from both maps, and a placement change still appends the key at the end of the new placement.
+- Regression coverage: `test/interactive-mode-widget-order.test.ts` drives the real `setExtensionWidget` / `renderWidgets` / `renderWidgetContainer` methods and pins that belowEditor and aboveEditor stacking order survives content updates, removals, and placement moves.
+
+### Why
+
+- Every widget refresh used to move the refreshed key to the end of its placement map, so two live widgets with independent refresh timers swapped vertical positions on every paint. With omo-senpi's `omo-task` (250 ms live refresh) and `omo-dag` (1 s live refresh) widgets both active, the below-editor region visibly bounced up and down several times per second.
+
+### Why this cannot be expressed externally
+
+- The stacking maps and `renderWidgets()` are private core state; extensions can only call `setWidget`, not control where an update lands.
+
+### Expected merge conflict zones
+
+- LOW: the body of `setExtensionWidget()` in `interactive-mode.ts` only.
+
 ## Repository-wide changes.md audit backfill for interactive rendering, selectors, and editor surfaces (2026-08-17)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2768,16 +2768,18 @@ export class InteractiveMode {
 		options?: ExtensionWidgetOptions,
 	): void {
 		const placement = options?.placement ?? "aboveEditor";
-		const removeExisting = (map: Map<string, Component & { dispose?(): void }>) => {
+		const targetMap = placement === "belowEditor" ? this.extensionWidgetsBelow : this.extensionWidgetsAbove;
+		const otherMap = placement === "belowEditor" ? this.extensionWidgetsAbove : this.extensionWidgetsBelow;
+		const removeFrom = (map: Map<string, Component & { dispose?(): void }>) => {
 			const existing = map.get(key);
 			if (existing?.dispose) existing.dispose();
 			map.delete(key);
 		};
 
-		removeExisting(this.extensionWidgetsAbove);
-		removeExisting(this.extensionWidgetsBelow);
+		removeFrom(otherMap);
 
 		if (content === undefined) {
+			removeFrom(targetMap);
 			this.renderWidgets();
 			return;
 		}
@@ -2799,7 +2801,10 @@ export class InteractiveMode {
 			component = content(this.ui, theme);
 		}
 
-		const targetMap = placement === "belowEditor" ? this.extensionWidgetsBelow : this.extensionWidgetsAbove;
+		// Map.set on an existing key keeps its insertion position, so a refreshing widget stays
+		// put instead of moving past its neighbours and reshuffling the stacking order each paint.
+		const existing = targetMap.get(key);
+		if (existing?.dispose) existing.dispose();
 		targetMap.set(key, component);
 		this.renderWidgets();
 	}

--- a/packages/coding-agent/test/interactive-mode-widget-order.test.ts
+++ b/packages/coding-agent/test/interactive-mode-widget-order.test.ts
@@ -1,0 +1,120 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { Container } from "../../tui/src/tui.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+
+type WidgetComponent = Container & { dispose?(): void };
+
+type WidgetThis = {
+	extensionWidgetsAbove: Map<string, WidgetComponent>;
+	extensionWidgetsBelow: Map<string, WidgetComponent>;
+	widgetContainerAbove: Container;
+	widgetContainerBelow: Container;
+	ui: { requestRender(): void };
+	renderWidgets(): void;
+	renderWidgetContainer(
+		container: Container,
+		widgets: Map<string, WidgetComponent>,
+		spacerWhenEmpty: boolean,
+		leadingSpacer: boolean,
+	): void;
+};
+
+type WidgetPrototype = {
+	setExtensionWidget(
+		this: WidgetThis,
+		key: string,
+		content: string[] | undefined,
+		options?: { placement?: "aboveEditor" | "belowEditor" },
+	): void;
+	renderWidgets(this: WidgetThis): void;
+	renderWidgetContainer(
+		this: WidgetThis,
+		container: Container,
+		widgets: Map<string, WidgetComponent>,
+		spacerWhenEmpty: boolean,
+		leadingSpacer: boolean,
+	): void;
+};
+
+const prototype = InteractiveMode.prototype as unknown as WidgetPrototype;
+
+function createWidgetThis(): WidgetThis {
+	const self: WidgetThis = {
+		extensionWidgetsAbove: new Map(),
+		extensionWidgetsBelow: new Map(),
+		widgetContainerAbove: new Container(),
+		widgetContainerBelow: new Container(),
+		ui: { requestRender: () => {} },
+		renderWidgets: () => prototype.renderWidgets.call(self),
+		renderWidgetContainer: (container, widgets, spacerWhenEmpty, leadingSpacer) =>
+			prototype.renderWidgetContainer.call(self, container, widgets, spacerWhenEmpty, leadingSpacer),
+	};
+	return self;
+}
+
+function setWidget(
+	self: WidgetThis,
+	key: string,
+	content: string[] | undefined,
+	options?: { placement?: "aboveEditor" | "belowEditor" },
+): void {
+	prototype.setExtensionWidget.call(self, key, content, options);
+}
+
+function renderedRows(container: Container, width = 120): string[] {
+	return container.children.flatMap((child) => child.render(width)).map((row) => row.trim());
+}
+
+describe("InteractiveMode.setExtensionWidget stacking order", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("keeps belowEditor stacking order stable when an existing widget updates", () => {
+		const self = createWidgetThis();
+		const below = { placement: "belowEditor" as const };
+
+		setWidget(self, "omo-dag", ["dag header"], below);
+		setWidget(self, "omo-task", ["task row"], below);
+		setWidget(self, "omo-dag", ["dag header v2"], below);
+
+		expect(renderedRows(self.widgetContainerBelow)).toEqual(["dag header v2", "task row"]);
+	});
+
+	test("keeps aboveEditor stacking order stable across repeated updates of both widgets", () => {
+		const self = createWidgetThis();
+
+		setWidget(self, "first", ["first v1"]);
+		setWidget(self, "second", ["second v1"]);
+		setWidget(self, "first", ["first v2"]);
+		setWidget(self, "second", ["second v2"]);
+
+		// The above container renders a leading spacer before widgets.
+		expect(renderedRows(self.widgetContainerAbove)).toEqual(["", "first v2", "second v2"]);
+	});
+
+	test("removal does not disturb the remaining widgets' order", () => {
+		const self = createWidgetThis();
+		const below = { placement: "belowEditor" as const };
+
+		setWidget(self, "one", ["one"], below);
+		setWidget(self, "two", ["two"], below);
+		setWidget(self, "three", ["three"], below);
+		setWidget(self, "one", undefined, below);
+
+		expect(renderedRows(self.widgetContainerBelow)).toEqual(["two", "three"]);
+	});
+
+	test("moving a widget to the other placement removes it from the previous container", () => {
+		const self = createWidgetThis();
+		const below = { placement: "belowEditor" as const };
+
+		setWidget(self, "pinned", ["pinned"], below);
+		setWidget(self, "mover", ["mover above"]);
+		setWidget(self, "mover", ["mover below"], below);
+
+		expect(renderedRows(self.widgetContainerBelow)).toEqual(["pinned", "mover below"]);
+		expect(renderedRows(self.widgetContainerAbove)).toEqual([""]);
+	});
+});


### PR DESCRIPTION
## What

`setExtensionWidget()` deleted and re-appended the updated key on every call, moving the refreshed widget to the end of its placement `Map`. Two live widgets with independent refresh timers swapped vertical positions on every paint.

Concrete report from omo-senpi: the `omo-task` status widget live-refreshes at 250ms and the `omo-dag` run widget at 1Hz, both `belowEditor`. With a background task and a dag run active at the same time, the below-editor region visibly bounced up and down several times per second as the two widgets traded positions.

## Fix

Replace in place: remove the key only from the *other* placement map, dispose the replaced component, and write through `Map.set`, which keeps an existing key at its insertion position. Removal (`content === undefined`) still deletes from both maps; a placement change still appends at the end of the new placement. No public API change.

## Evidence

- **RED→GREEN unit:** `test/interactive-mode-widget-order.test.ts` drives the real `setExtensionWidget` / `renderWidgets` / `renderWidgetContainer` methods. Before the fix, updating `omo-dag` flipped the rendered order to `["task row", "dag header v2"]`; after, order is stable. 4/4 pass. Adjacent scopes (`interactive-mode-status`, `todo-widget-component`, `interactive-mode-fallback`): 49/49 pass.
- **RED→GREEN real surface (senpi-qa, tmux + real TUI):** a sandbox extension paints two `belowEditor` widgets refreshing at 200ms/200ms+100ms phase offset (the omo-task/omo-dag pattern). Unfixed code: captured stacking order flips across frames (`alpha-first, alpha-first, beta-first, ...`, probe exit 1). Fixed code: order constant across all 12 captures (exit 0). Artifacts: `local-ignore/qa-evidence/20260818-widget-order/{red,green}/` (probe script, per-frame captures, `probe-result.json`).
- **Static gates:** root `npm run check` green (biome + tsc + shrinkwrap/install-lock/platform-lock); `packages/tui` `render-contract` node:test 7/7 pass (renderer untouched, sanity only).
- **Isolation:** probe ran with `SENPI_CODING_AGENT_DIR` in a temp sandbox and `PI_OFFLINE=1`; real `~/.senpi/agent/auth.json` sha256 asserted unchanged before/after.

## Risk

Low. The only behavioral change is *where* an updated key lands in the stacking order: it now stays put instead of moving to the end. First-time insertion, removal, and placement moves are unchanged. `changes.md` entry added in `src/modes/interactive/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps extension widget stacking order stable across updates. Previously, each update deleted and re-appended the key, pushing it to the end and making widgets with different refresh rates swap; now updates replace in place so the key keeps its position. No public API change.

**Review notes**
- In `setExtensionWidget()`: remove the key only from the other placement; on `content === undefined` also remove from the target map; dispose any replaced component; then `Map.set` to preserve insertion position. Placement moves still append at the end of the new placement.
- Adds `packages/coding-agent/test/interactive-mode-widget-order.test.ts` to pin stable order for `belowEditor`/`aboveEditor`, removals, and placement moves.
- Updates `packages/coding-agent/src/modes/interactive/changes.md` and `packages/coding-agent/CHANGELOG.md`; no migration required.

<sup>Written for commit dc37fd12d57d5e0644bd7b2ef161294502d2b804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

