### PR TITLE
test(ai): update Baseten vision capability expectation

### DIFF
--- a/packages/ai/test/baseten-models.test.ts
+++ b/packages/ai/test/baseten-models.test.ts
@@ -31,7 +31,7 @@ describe("Baseten models", () => {
 				xhigh: null,
 				max: "max",
 			},
-			input: ["text"],
+			input: ["text", "image"],
 			contextWindow: 1048576,
 			maxTokens: 262144,
 			cost: {


### PR DESCRIPTION
## Summary

- update the Baseten GLM 5.2 test to match the committed v2026.8.18 generated catalog, which now advertises text and image input
- restore current-main `Test (workspaces + scripts)` and unblock unrelated PRs without changing generated provider data

## Root cause

The release regenerated `packages/ai/src/providers/data/baseten.json` with:

```json
"input": ["text", "image"]
```

The focused model contract test still expected text-only input. Current main CI and PR #931 fail identically; PR #931 has no `packages/ai` diff.

## RED → GREEN

- RED on unchanged main: Baseten test received `["text", "image"]`, expected `["text"]`
- GREEN: focused Baseten 5/5
- full AI package: 213 files passed, 25 skipped; 2089 tests passed, 865 skipped
- full workspace build passed
- Biome and `git diff --check` passed

## Scope

One test expectation only. Generated model data is the committed source of truth and is not edited.

Plan: `.omo/plans/baseten-release-catalog-test.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Baseten GLM 5.2 test to expect text and image input, matching the generated provider catalog and restoring green CI. Previously the test expected text-only; now it expects ["text", "image"]. No provider data or runtime behavior changed.

- Single-line change in `packages/ai/test/baseten-models.test.ts`; aligns with `packages/ai/src/providers/data/baseten.json`.
- Unblocks CI by fixing the failing Baseten capability check; no API or migration impact.

<sup>Written for commit 4085c69e3394693c90c2c47bb82cc60619f1322f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

