### PR TITLE
fix(agent): bind bridge events to owning run

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Late Cursor exec-bridge lifecycle events that settle after an abort or timeout are tied to their originating run, so they neither raise an unhandled `Agent listener invoked outside active run` error nor leak into a replacement run.
+
 ### Removed
 
 ## [2026.8.18] - 2026-08-18

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -786,9 +786,12 @@ export class Agent {
 	 * provider stream, outside the loop's executor, so their
 	 * `tool_execution_start`/`tool_execution_end` lifecycle must be injected
 	 * here or the live tool card for a synthesized call never resolves.
-	 * Only valid during an active run (bridge executions always are).
+	 * A bridge execution may settle after an aborted run has already ended; its
+	 * late lifecycle event belongs to that finished run and must be discarded.
 	 */
-	async emitExternalEvent(event: AgentEvent): Promise<void> {
+	async emitExternalEvent(event: AgentEvent, runSignal?: AbortSignal): Promise<void> {
+		const activeSignal = this.activeRun?.abortController.signal;
+		if (!activeSignal || (runSignal && runSignal !== activeSignal)) return;
 		await this.processEvents(event);
 	}
 }

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,35 @@
 # Changes
 
+## Late Cursor bridge lifecycle events after run teardown (2026-08-18)
+
+### What changed
+
+- `packages/agent/src/agent.ts`: `Agent.emitExternalEvent()` now accepts the
+  originating run signal and
+  discards bridge-generated lifecycle events when that signal no longer owns
+  the active run.
+
+### Why
+
+- Cursor exec handlers can outlive an aborted provider stream. Their final
+  `tool_execution_end` event previously reached `processEvents()` after
+  `finishRun()` cleared `activeRun`, producing an unhandled
+  `Agent listener invoked outside active run` rejection.
+- The ownership guard remains specific to externally injected events. Internal
+  loop events still require an active run, and listener failures during the
+  owning active run still propagate.
+
+### Why the extension system could not handle this
+
+- The race occurs in the engine contract between the provider-owned Cursor exec
+  handler and the agent run lifecycle, before an extension can intercept or
+  recover the rejected event promise.
+
+### Expected merge conflict zones
+
+- `packages/agent/src/agent.ts`: the external event entry point and active-run
+  ownership checks.
+
 > Audit backfill (2026-08-17): the canonical four-section records added today were recorded during
 > the repository-wide changes.md audit of divergences from the upstream pin (v0.84.2, `914cf1472e`)
 > so every audited production path assigned to this tracker carries a canonical record; they are

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -263,6 +263,121 @@ describe("Agent", () => {
 		expect(agent.state.isStreaming).toBe(false);
 	});
 
+	it("absorbs external lifecycle events after the run ends", async () => {
+		const agent = new Agent({
+			streamFn: () => {
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					stream.push({ type: "done", reason: "stop", message: createAssistantMessage("ok") });
+				});
+				return stream;
+			},
+		});
+		const listener = vi.fn();
+		agent.subscribe(listener);
+
+		await agent.prompt("hello");
+		listener.mockClear();
+
+		await expect(
+			agent.emitExternalEvent({
+				type: "tool_execution_end",
+				toolCallId: "late-bridge-call",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "late" }], details: {} },
+				isError: false,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(listener).not.toHaveBeenCalled();
+		expect(agent.state.pendingToolCalls).toEqual(new Set());
+	});
+
+	it("propagates external event listener failures during an active run", async () => {
+		const streamStarted = createDeferred();
+		const stream = new MockAssistantStream();
+		const agent = new Agent({
+			streamFn: () => {
+				streamStarted.resolve();
+				return stream;
+			},
+		});
+		agent.subscribe((event) => {
+			if (event.type === "tool_execution_start") throw new Error("listener failed");
+		});
+
+		const prompt = agent.prompt("hello");
+		await streamStarted.promise;
+
+		await expect(
+			agent.emitExternalEvent({
+				type: "tool_execution_start",
+				toolCallId: "active-bridge-call",
+				toolName: "bash",
+				args: {},
+			}),
+		).rejects.toThrow("listener failed");
+
+		const message = createAssistantMessage("ok");
+		stream.push({ type: "done", reason: "stop", message });
+		await prompt;
+	});
+
+	it("drops external events owned by a finished run while a new run is active", async () => {
+		const runAStarted = createDeferred();
+		const runBStarted = createDeferred();
+		const runAStream = new MockAssistantStream();
+		const runBStream = new MockAssistantStream();
+		let streamIndex = 0;
+		const agent = new Agent({
+			streamFn: () => {
+				if (streamIndex++ === 0) {
+					runAStarted.resolve();
+					return runAStream;
+				}
+				runBStarted.resolve();
+				return runBStream;
+			},
+		});
+		const externalEvents: AgentEvent[] = [];
+		agent.subscribe((event) => {
+			if (event.type === "tool_execution_start" || event.type === "tool_execution_end") {
+				externalEvents.push(event);
+			}
+		});
+
+		const runA = agent.prompt("run A");
+		await runAStarted.promise;
+		const runASignal = agent.signal;
+		await agent.emitExternalEvent({
+			type: "tool_execution_start",
+			toolCallId: "run-a-call",
+			toolName: "bash",
+			args: {},
+		});
+		runAStream.push({ type: "done", reason: "stop", message: createAssistantMessage("run A done") });
+		await runA;
+
+		const runB = agent.prompt("run B");
+		await runBStarted.promise;
+		externalEvents.length = 0;
+
+		await Reflect.apply(agent.emitExternalEvent, agent, [
+			{
+				type: "tool_execution_end",
+				toolCallId: "run-a-call",
+				toolName: "bash",
+				result: { content: [{ type: "text", text: "late" }], details: {} },
+				isError: false,
+			},
+			runASignal,
+		]);
+
+		expect(externalEvents).toEqual([]);
+		runBStream.push({ type: "done", reason: "stop", message: createAssistantMessage("run B done") });
+		await runB;
+	});
+
 	it("waitForIdle should wait for async subscribers", async () => {
 		const barrier = createDeferred();
 		const agent = new Agent({

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Cursor CLI OAuth is now available by default when its real prerequisites exist: with `cursor-agent` installed and no managed CLI account, a native `cursor` OAuth credential is copied automatically into one canonical `native` slot without modifying the primary credential; explicit `enabled: false` remains a hard opt-out, repeated/concurrent startup is idempotent, and `/login cursor` refreshes the CLI fallback in the same session ([#931](https://github.com/code-yeongyu/senpi/pull/931)).
 
+- Cursor exec-bridge lifecycle events now require their originating run signal and await listener delivery, preventing delayed completions from entering a replacement run or becoming detached unhandled rejections.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,39 @@
 # changes
 
+## Cursor bridge lifecycle events retain run ownership (2026-08-18)
+
+### What changed
+
+- `packages/coding-agent/src/core/cursor-exec-bridge.ts`: bridge executions
+  require and capture the active run signal before emitting
+  `tool_execution_start`, pass that same signal through every matching
+  `tool_execution_end` path, and await lifecycle delivery.
+- `packages/coding-agent/src/core/cursor-exec-bridge-session.ts`: the session
+  adapter forwards that captured signal to agent-core and returns its promise
+  to the bridge.
+
+### Why
+
+- An aborted bridge tool can settle after a replacement run has started. The
+  signal lets agent-core discard the stale lifecycle event instead of
+  delivering it to the replacement run.
+- A bridge dispatch with no active run is refused before tool execution, and
+  active-run listener failures stay attached to the dispatch instead of
+  becoming detached unhandled rejections.
+
+### Why an extension could not handle it
+
+- The run signal is owned by the engine bridge before extension preflight and
+  tool execution, so an extension cannot reliably reconstruct the originating
+  run after the asynchronous tool settles.
+
+### Expected merge-conflict zones
+
+- `packages/coding-agent/src/core/cursor-exec-bridge.ts`: lifecycle emission
+  around preflight and tool execution.
+- `packages/coding-agent/src/core/cursor-exec-bridge-session.ts`: the
+  agent-core event forwarding adapter.
+
 ## Single availability scan across provider re-register (2026-08-18)
 
 ### What changed

--- a/packages/coding-agent/src/core/cursor-exec-bridge-session.ts
+++ b/packages/coding-agent/src/core/cursor-exec-bridge-session.ts
@@ -24,9 +24,8 @@ export function createSessionCursorExecBridge(
 				},
 				event.input,
 			),
-		emitEvent: (event: AgentEvent) => {
-			void getAgent().emitExternalEvent(event);
-		},
+		emitEvent: async (event: AgentEvent, runSignal: AbortSignal) =>
+			await getAgent().emitExternalEvent(event, runSignal),
 		getAbortSignal: () => getAgent().signal,
 	});
 }

--- a/packages/coding-agent/src/core/cursor-exec-bridge.ts
+++ b/packages/coding-agent/src/core/cursor-exec-bridge.ts
@@ -42,11 +42,11 @@ export interface CursorExecBridgeOptions {
 	 * the agent loop's executor, so without these the live tool card for a
 	 * synthesized call never resolves.
 	 */
-	emitEvent?: (event: AgentEvent) => void;
+	emitEvent: (event: AgentEvent, runSignal: AbortSignal) => Promise<void>;
 	/** Run the session's vetoable extension preflight before tool execution. */
 	preflightToolCall?: (event: ToolCallEvent) => Promise<ToolCallEventResult | undefined>;
 	/** Abort signal for in-flight bridge executions (the active run's signal). */
-	getAbortSignal?: () => AbortSignal | undefined;
+	getAbortSignal: () => AbortSignal | undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -81,6 +81,11 @@ async function executeTool(
 	toolCallId: string,
 	args: Record<string, unknown>,
 ): Promise<ToolResultMessage> {
+	const runSignal = options.getAbortSignal();
+	if (!runSignal) {
+		return errorResult(toolCallId, toolName, "Tool execution has no active run");
+	}
+
 	const tool = options.getTool(toolName);
 	if (!tool) {
 		return errorResult(toolCallId, toolName, `Tool "${toolName}" is not available in this session`);
@@ -107,7 +112,9 @@ async function executeTool(
 		return errorResult(toolCallId, toolName, error instanceof Error ? error.message : String(error));
 	}
 
-	options.emitEvent?.({ type: "tool_execution_start", toolCallId, toolName, args: cleanArgs });
+	await options.emitEvent({ type: "tool_execution_start", toolCallId, toolName, args: cleanArgs }, runSignal);
+	let toolResult: ToolResultMessage;
+	let endEvent: AgentEvent;
 	try {
 		if (!isRecord(params)) {
 			throw new Error(`Tool "${toolName}" prepared non-object arguments`);
@@ -120,39 +127,41 @@ async function executeTool(
 		});
 		if (preflight?.block) {
 			const message = preflight.reason || "Tool execution was blocked";
-			options.emitEvent?.({
+			toolResult = errorResult(toolCallId, toolName, message);
+			endEvent = {
 				type: "tool_execution_end",
 				toolCallId,
 				toolName,
 				result: { content: [{ type: "text", text: message }], details: undefined },
 				isError: true,
-			});
-			return errorResult(toolCallId, toolName, message);
+			};
+		} else {
+			const result = await tool.execute(toolCallId, params, runSignal, undefined);
+			toolResult = {
+				role: "toolResult",
+				toolCallId,
+				toolName,
+				content: result.content ?? [],
+				details: result.details,
+				usage: result.usage,
+				isError: false,
+				timestamp: Date.now(),
+			};
+			endEvent = { type: "tool_execution_end", toolCallId, toolName, result, isError: false };
 		}
-		const result = await tool.execute(toolCallId, params, options.getAbortSignal?.(), undefined);
-		const toolResult: ToolResultMessage = {
-			role: "toolResult",
-			toolCallId,
-			toolName,
-			content: result.content ?? [],
-			details: result.details,
-			usage: result.usage,
-			isError: false,
-			timestamp: Date.now(),
-		};
-		options.emitEvent?.({ type: "tool_execution_end", toolCallId, toolName, result, isError: false });
-		return toolResult;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		options.emitEvent?.({
+		toolResult = errorResult(toolCallId, toolName, message);
+		endEvent = {
 			type: "tool_execution_end",
 			toolCallId,
 			toolName,
 			result: { content: [{ type: "text", text: message }], details: undefined },
 			isError: true,
-		});
-		return errorResult(toolCallId, toolName, message);
+		};
 	}
+	await options.emitEvent(endEvent, runSignal);
+	return toolResult;
 }
 
 /**

--- a/packages/coding-agent/test/cursor-exec-bridge-preflight.test.ts
+++ b/packages/coding-agent/test/cursor-exec-bridge-preflight.test.ts
@@ -45,8 +45,9 @@ describe("cursor exec bridge tool_call preflight", () => {
 				};
 			},
 		};
+		const runSignal = new AbortController().signal;
 		const agent = {
-			signal: undefined,
+			signal: runSignal,
 			async emitExternalEvent(event: AgentEvent) {
 				events.push(event);
 				eventQueue = eventQueue.then(async () => {

--- a/packages/coding-agent/test/cursor-exec-bridge.test.ts
+++ b/packages/coding-agent/test/cursor-exec-bridge.test.ts
@@ -23,9 +23,11 @@ function stubTool(
 
 function makeBridge(tools: AgentTool[], events: AgentEvent[] = []) {
 	const byName = new Map(tools.map((tool) => [tool.name, tool]));
+	const runSignal = new AbortController().signal;
 	return createCursorExecBridge({
 		getTool: (name) => byName.get(name),
-		emitEvent: (event) => {
+		getAbortSignal: () => runSignal,
+		emitEvent: async (event) => {
 			events.push(event);
 		},
 	});
@@ -211,6 +213,58 @@ describe("cursor exec bridge", () => {
 		expect(events.map((event) => event.type)).toEqual(["tool_execution_start", "tool_execution_end"]);
 		const end = events[1];
 		expect(end.type === "tool_execution_end" && end.isError).toBe(false);
+	});
+
+	it("keeps the originating run signal on both lifecycle events", async () => {
+		const runSignal = new AbortController().signal;
+		const emitEvent = vi.fn();
+		const tool = stubTool("read", Type.Object({ path: Type.String() }), vi.fn());
+		const bridge = createCursorExecBridge({
+			getTool: (name) => (name === "read" ? tool : undefined),
+			getAbortSignal: () => runSignal,
+			emitEvent,
+		});
+
+		await bridge.read?.({ path: "a.ts", toolCallId: "call-owned" } as never);
+
+		expect(emitEvent).toHaveBeenCalledTimes(2);
+		expect(emitEvent.mock.calls.map((call) => call[1])).toEqual([runSignal, runSignal]);
+	});
+
+	it("refuses to execute when no active run signal owns the bridge dispatch", async () => {
+		const execute = vi.fn();
+		const emitEvent = vi.fn();
+		const tool = stubTool("read", Type.Object({ path: Type.String() }), execute);
+		const bridge = createCursorExecBridge({
+			getTool: (name) => (name === "read" ? tool : undefined),
+			getAbortSignal: () => undefined,
+			emitEvent,
+		});
+
+		const result = asToolResult(await bridge.read?.({ path: "a.ts", toolCallId: "call-unowned" } as never));
+
+		expect(result.isError).toBe(true);
+		expect(result.content[0]).toMatchObject({ text: expect.stringContaining("active run") });
+		expect(execute).not.toHaveBeenCalled();
+		expect(emitEvent).not.toHaveBeenCalled();
+	});
+
+	it("propagates lifecycle listener failures through the bridge dispatch", async () => {
+		const runSignal = new AbortController().signal;
+		const execute = vi.fn();
+		const tool = stubTool("read", Type.Object({ path: Type.String() }), execute);
+		const bridge = createCursorExecBridge({
+			getTool: (name) => (name === "read" ? tool : undefined),
+			getAbortSignal: () => runSignal,
+			emitEvent: async () => {
+				throw new Error("listener failed");
+			},
+		});
+
+		await expect(bridge.read?.({ path: "a.ts", toolCallId: "call-listener-failure" } as never)).rejects.toThrow(
+			"listener failed",
+		);
+		expect(execute).not.toHaveBeenCalled();
 	});
 
 	it("reports missing tools without throwing", async () => {


### PR DESCRIPTION
## Summary

Fixes the Cursor exec-bridge lifecycle race reported in code-yeongyu/oh-my-openagent#6985.

Bridge tools can outlive an aborted provider run. A delayed lifecycle event previously reached `Agent.processEvents()` after the owning run ended, causing `Agent listener invoked outside active run` to escape from the fire-and-forget bridge callback. An idle-only guard was also insufficient because a stale event from run A could arrive while replacement run B was active.

## What changed

- Bind every bridge lifecycle event to the originating run's `AbortSignal`.
- Refuse bridge dispatch before tool execution when no active run owns it.
- Drop lifecycle events whose originating signal no longer matches the active run.
- Await lifecycle delivery through the session adapter so listener failures stay attached to the bridge dispatch instead of becoming unhandled rejections.
- Add deterministic coverage for:
  - an event arriving after the run is idle;
  - a run-A event arriving while run B is active;
  - active listener failures remaining visible;
  - missing run ownership preventing execution;
  - start/end events carrying the same run signal;
  - bridge preflight behavior under the required signal contract.

## Verification

- RED: late idle event rejected with `Agent listener invoked outside active run`.
- RED: run-A `tool_execution_end` was delivered to run B.
- RED: missing signal still executed the tool and detached listener failures as unhandled rejections.
- GREEN: `packages/agent/test/agent.test.ts` — 50 passed.
- GREEN: Cursor bridge + preflight scope — 13 passed.
- GREEN: `npm run build`.
- GREEN: `npm run check`.
- GREEN: committed changelog policy gate — 1 production path covered.
- Real compiled process: no unhandled rejection, zero run-A deliveries into run B, zero pending-state mutation.
- Isolated real Cursor bridge CLI: read lifecycle and gated-shell heartbeat scenarios passed; fake servers closed, sandboxes/FIFO removed, and the real auth hash stayed unchanged.

The aggregate local suite completed 8,124 coding-agent tests per run but encountered two different pre-existing process-reaping flakes on separate runs:

- `cursor-cli-oauth/transport.test.ts` process-group reap assertion;
- `hooks-command-runner.test.ts` abort cleanup assertion.

Each exact failing test passed immediately in isolation. This change does not touch either area; CI remains the authoritative full-suite gate and will not be bypassed.

## Risk

Low and localized to the Cursor exec bridge lifecycle contract. Internal agent-loop events retain their strict active-run invariant, and active-run listener errors continue to propagate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds Cursor exec-bridge lifecycle events to the owning run and drops stale events. Previously, late `tool_execution_*` from an aborted run could throw “Agent listener invoked outside active run” or land in a replacement run; now events carry the originating run signal, and the agent discards mismatches and refuses unowned bridge dispatches.

- Ensures `Agent.emitExternalEvent(event, runSignal?)` gates delivery by the active run and awaits listener completion. Bridge now captures the active run `AbortSignal`, emits start/end with it, and awaits delivery so listener failures surface on the dispatch.

**Migration**
- Update bridge/session wiring: `emitEvent` must be async and accept `(event, runSignal)`, and `getAbortSignal` must return the active run signal.
- If calling `Agent.emitExternalEvent` directly, pass the run signal when available.

<sup>Written for commit 6d2601abaeae411c6e2b1a39083b2e14c98b9fca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

