### PR TITLE
fix(goal): re-engage active goals after a config reload

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/goal-reload-reengagement-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/goal-reload-reengagement-qa.mjs
@@ -1,0 +1,374 @@
+#!/usr/bin/env node
+/**
+ * Real-CLI QA for issue #934: an active goal stalls after a settings hot-reload.
+ *
+ * Flow: prompt one makes the model call create_goal and stop cleanly. The
+ * mock then answers every continuation with one identical string, so the
+ * goal's own stale-signature guard parks the loop after two continuation
+ * turns: goal active, session idle, nothing armed — the exact state a reload
+ * used to strand forever. A sandbox extension then drives
+ * `ctx.requestReload()` — the SAME entry point the builtin config-reload
+ * watcher uses in production — retiring the extension generation mid-park.
+ *
+ * PASS (fixed source) = at least one provider request arrives AFTER the reload
+ * with no user prompt in between (the re-engaged goal continuation), the CLI
+ * stays alive, a post-reload user prompt is still answered, and no
+ * `stale extension generation` / `uncaughtException` surfaces.
+ *
+ * RED (origin/main) = zero provider requests in the post-reload window: the
+ * goal is parked until the user types. The post-reload sanity prompt still
+ * answers, proving the stall is goal-specific, not a dead session.
+ *
+ * Usage:
+ *   node .agents/skills/senpi-qa/scripts/scenarios/goal-reload-reengagement-qa.mjs \
+ *     --evidence goal-reload-stall [--target-root /path/to/other/checkout]
+ */
+
+import { createServer } from "node:http";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import {
+	createChecks,
+	guardRealAuth,
+	installCleanupHooks,
+	makeSandbox,
+	repoRoot,
+} from "../lib/common.mjs";
+import { checkRealAuthUnchanged, hermeticEnv } from "../lib/mock-loop-support.mjs";
+import { TargetRpcClient } from "../lib/target-rpc-client.mjs";
+
+const GOAL_OBJECTIVE = "QA reload goal";
+const NEXT_REPLY = "POST RELOAD REPLY DELIVERED";
+const IDENTICAL_OUTPUT = "IDENTICAL GOAL OUTPUT";
+// After two identical continuation answers the goal's stale-signature guard
+// parks the loop; the reload must land in that idle parked state, and the
+// post-reload window must be generous enough for any honest re-arm.
+const POST_RELOAD_WINDOW_MS = 18_000;
+
+function arg(name, fallback) {
+	const index = process.argv.indexOf(name);
+	return index >= 0 ? process.argv[index + 1] : fallback;
+}
+
+function writeAnthropicSse(res, text, modelId, inputTokens) {
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
+	const event = (type, data) =>
+		res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+	event("message_start", {
+		message: {
+			id: `msg_${Date.now()}`,
+			type: "message",
+			role: "assistant",
+			model: modelId,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: inputTokens, output_tokens: 0 },
+		},
+	});
+	event("content_block_start", { index: 0, content_block: { type: "text", text: "" } });
+	event("content_block_delta", { index: 0, delta: { type: "text_delta", text } });
+	event("content_block_stop", { index: 0 });
+	event("message_delta", { delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 40 } });
+	event("message_stop", {});
+	res.end();
+}
+
+function writeAnthropicToolUseSse(res, modelId) {
+	res.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
+	const event = (type, data) =>
+		res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+	event("message_start", {
+		message: {
+			id: `msg_${Date.now()}`,
+			type: "message",
+			role: "assistant",
+			model: modelId,
+			content: [],
+			stop_reason: null,
+			stop_sequence: null,
+			usage: { input_tokens: 1_000, output_tokens: 0 },
+		},
+	});
+	event("content_block_start", {
+		index: 0,
+		content_block: { type: "tool_use", id: "toolu_qa_goal_1", name: "create_goal", input: {} },
+	});
+	event("content_block_delta", {
+		index: 0,
+		delta: { type: "input_json_delta", partial_json: JSON.stringify({ objective: GOAL_OBJECTIVE }) },
+	});
+	event("content_block_stop", { index: 0 });
+	event("message_delta", { delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 30 } });
+	event("message_stop", {});
+	res.end();
+}
+
+async function startProvider() {
+	const requests = [];
+	let callIndex = 0;
+	const server = createServer((req, res) => {
+		const chunks = [];
+		req.on("data", (chunk) => chunks.push(chunk));
+		req.on("end", () => {
+			const body = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+			callIndex++;
+			const lastMessage = Array.isArray(body.messages) ? body.messages.at(-1) : undefined;
+			const lastText = JSON.stringify(lastMessage?.content ?? "");
+			const isPostReloadPrompt = lastText.includes("POST RELOAD PROMPT");
+			requests.push({ at: Date.now(), callIndex, url: req.url, model: body.model, isPostReloadPrompt });
+			console.log(`[qa] provider request ${callIndex} postReloadPrompt=${isPostReloadPrompt}`);
+			if (callIndex === 1) {
+				writeAnthropicToolUseSse(res, body.model ?? "mock-claude");
+				return;
+			}
+			const text = isPostReloadPrompt ? NEXT_REPLY : callIndex === 2 ? "GOAL REGISTERED" : IDENTICAL_OUTPUT;
+			writeAnthropicSse(res, text, body.model ?? "mock-claude", 1_000);
+		});
+	});
+	await new Promise((resolveListen, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolveListen);
+	});
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("provider address unavailable");
+	return {
+		origin: `http://127.0.0.1:${address.port}`,
+		requests,
+		stop: () => new Promise((resolveStop) => server.close(resolveStop)),
+	};
+}
+
+function writeConfig(agentDir, provider) {
+	writeFileSync(
+		join(agentDir, "models.json"),
+		JSON.stringify({
+			providers: {
+				anthropic: {
+					baseUrl: provider.origin,
+					apiKey: "sk-mock-goal-reload",
+					api: "anthropic-messages",
+					models: [
+						{
+							id: "mock-claude",
+							api: "anthropic-messages",
+							baseUrl: provider.origin,
+							contextWindow: 128_000,
+							maxTokens: 4_096,
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						},
+					],
+				},
+			},
+		}),
+	);
+	writeFileSync(join(agentDir, "settings.json"), JSON.stringify({}));
+}
+
+/**
+ * Sandbox extension exposing the host reload action over the RPC
+ * `extension_request` channel. `ctx.requestReload()` is the SAME entry point the
+ * builtin config-reload watcher uses in production (config-reload/index.ts), so
+ * driving it directly exercises the real reload path without depending on the
+ * watcher's project-trust gate, which a hermetic sandbox never grants.
+ */
+function writeReloadExtension(cwd) {
+	const dir = join(cwd, "qa-extensions");
+	mkdirSync(dir, { recursive: true });
+	const file = join(dir, "qa-reload.ts");
+	writeFileSync(
+		file,
+		[
+			"export default function qaReload(pi: any) {",
+			"	let latest: any;",
+			'	pi.on("session_start", (_event: unknown, ctx: any) => {',
+			"		latest = ctx;",
+			"	});",
+			'	pi.on("agent_end", (_event: unknown, ctx: any) => {',
+			"		latest = ctx;",
+			"	});",
+			'	pi.rpc.handle("qa.reload", async () => {',
+			"		if (!latest?.requestReload) return { reloaded: false, reason: \"requestReload unavailable\" };",
+			"		await latest.requestReload();",
+			"		return { reloaded: true };",
+			"	});",
+			"}",
+			"",
+		].join("\n"),
+	);
+	return file;
+}
+
+function readAgentLogs(agentDir) {
+	const logsDir = join(agentDir, "logs");
+	let text = "";
+	try {
+		for (const name of readdirSync(logsDir)) text += readFileSync(join(logsDir, name), "utf8");
+	} catch {
+		return text;
+	}
+	return text;
+}
+
+function readSessionEntries(sessionDir) {
+	const file = readdirSync(sessionDir).find((name) => name.endsWith(".jsonl"));
+	if (!file) throw new Error(`no session JSONL in ${sessionDir}`);
+	return readFileSync(join(sessionDir, file), "utf8")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+}
+
+async function main() {
+	installCleanupHooks();
+	const checks = createChecks("goal-reload-reengagement-qa.mjs");
+	const guard = guardRealAuth();
+	const targetRoot = resolve(arg("--target-root", repoRoot()));
+	const label = arg("--evidence", "goal-reload-stall");
+	const box = makeSandbox("goal-reload-reengagement");
+	const provider = await startProvider();
+	writeConfig(box.agentDir, provider);
+	const reloadExtension = writeReloadExtension(box.cwd);
+	const client = new TargetRpcClient({
+		env: hermeticEnv(box.env),
+		cwd: box.cwd,
+		targetRoot,
+		extraArgs: ["-e", reloadExtension],
+	});
+
+	try {
+		console.log("[qa] rpc started");
+		await client.send({ type: "set_model", provider: "anthropic", modelId: "mock-claude" });
+		console.log("[qa] model selected");
+		const firstEnd = client.waitFor((event) => event.message.type === "agent_end");
+		await client.send({ type: "prompt", message: "turn one: register the goal" });
+		console.log("[qa] first prompt accepted");
+		await firstEnd;
+		console.log("[qa] first agent_end observed (goal active, continuation loop running)");
+
+		// Wait for the goal loop to park itself: the identical continuation
+		// answers trip the stale-signature guard, leaving the goal active with
+		// the session idle and nothing armed. Quiescence = no new provider
+		// request for a quiet stretch after at least the two continuation turns.
+		let lastCount = 0;
+		let quietSince = Date.now();
+		while (client.child.exitCode === null) {
+			const count = provider.requests.length;
+			if (count !== lastCount) {
+				lastCount = count;
+				quietSince = Date.now();
+			} else if (count >= 3 && Date.now() - quietSince >= 2_000) {
+				break;
+			}
+			await new Promise((resolveTick) => setTimeout(resolveTick, 200));
+		}
+		const requestsBeforeReload = provider.requests.length;
+		console.log(`[qa] goal loop parked at ${requestsBeforeReload} provider requests; reloading`);
+		const reloadResponse = await client.send({ type: "extension_request", name: "qa.reload", data: null }, 60_000);
+		console.log(`[qa] reload requested: ${JSON.stringify(reloadResponse?.data ?? reloadResponse)}`);
+
+		// Watch for goal-driven provider requests after the reload with no user
+		// prompt. Fixed source: the re-engagement queues a continuation almost
+		// immediately. Unfixed: nothing ever arrives (the stall).
+		const deadline = Date.now() + POST_RELOAD_WINDOW_MS;
+		let postReloadRequests = 0;
+		while (Date.now() < deadline && client.child.exitCode === null) {
+			postReloadRequests = provider.requests.length - requestsBeforeReload;
+			if (postReloadRequests > 0) break;
+			await new Promise((resolveTick) => setTimeout(resolveTick, 250));
+		}
+		postReloadRequests = provider.requests.length - requestsBeforeReload;
+		const aliveAfterWindow = client.child.exitCode === null;
+		console.log(`[qa] post-reload window: postReloadRequests=${postReloadRequests} alive=${aliveAfterWindow}`);
+
+		// Sanity: the session itself still answers a real user prompt after the
+		// reload, so a missing continuation is a goal stall, not a dead session.
+		// Wait for the continuation turn to fully settle first: prompting into
+		// the settlement race can strand the queued prompt behind a drain that
+		// already ran. Then poll the session entries for the distinct reply
+		// instead of racing continuation agent_end events.
+		let replyDelivered = false;
+		if (aliveAfterWindow) {
+			const lastRequestAt = provider.requests.at(-1)?.at ?? Date.now();
+			const settleDeadline = Date.now() + 10_000;
+			while (Date.now() < settleDeadline && client.child.exitCode === null) {
+				const settled = client.events.some(
+					(event) => event.message.type === "agent_settled" && event.at >= lastRequestAt,
+				);
+				if (settled) break;
+				await new Promise((resolveTick) => setTimeout(resolveTick, 200));
+			}
+			await client.send({ type: "prompt", message: "POST RELOAD PROMPT" });
+			console.log("[qa] post-reload prompt accepted");
+			const replyDeadline = Date.now() + 15_000;
+			while (Date.now() < replyDeadline && client.child.exitCode === null) {
+				try {
+					if (JSON.stringify(readSessionEntries(box.sessionDir)).includes(NEXT_REPLY)) {
+						replyDelivered = true;
+						break;
+					}
+				} catch {
+					// session file may not exist yet
+				}
+				await new Promise((resolveTick) => setTimeout(resolveTick, 250));
+			}
+			console.log(`[qa] post-reload reply delivered=${replyDelivered}`);
+		}
+
+		const combined = `${client.stderr}\n${readAgentLogs(box.agentDir)}`;
+		const staleHits = combined.split("stale extension generation").length - 1;
+		const uncaughtHits = combined.split("uncaughtException").length - 1;
+
+		checks.ok("goal continued after reload with no user input", postReloadRequests > 0, `postReloadRequests=${postReloadRequests}`);
+		checks.ok("cli survived the reload window", aliveAfterWindow, `exitCode=${client.child.exitCode}`);
+		checks.ok("post-reload prompt answered", replyDelivered, `replyDelivered=${replyDelivered}`);
+		checks.ok("no stale-generation error surfaced", staleHits === 0, `hits=${staleHits}`);
+		checks.ok("no uncaughtException surfaced", uncaughtHits === 0, `hits=${uncaughtHits}`);
+		checkRealAuthUnchanged(checks, guard);
+
+		const outDir = join(
+			repoRoot(),
+			"local-ignore",
+			"qa-evidence",
+			"20260818-goal-reload-stall",
+			label,
+		);
+		mkdirSync(outDir, { recursive: true });
+		writeFileSync(
+			join(outDir, "result.json"),
+			JSON.stringify(
+				{
+					targetRoot,
+					requestsBeforeReload,
+					postReloadRequests,
+					aliveAfterWindow,
+					replyDelivered,
+					staleHits,
+					uncaughtHits,
+					exitCode: client.child.exitCode,
+					requests: provider.requests,
+					events: client.events.map((event) => ({ at: event.at, type: event.message.type })),
+				},
+				null,
+				2,
+			),
+		);
+		writeFileSync(join(outDir, "stderr.txt"), client.stderr);
+		console.log(`[qa] evidence written to ${outDir}`);
+		process.exitCode = checks.finish() ? 0 : 1;
+	} finally {
+		await client.close();
+		await provider.stop();
+		box.cleanup();
+	}
+}
+
+await main();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Goals no longer stall after a settings hot-reload: a reload `session_start` now re-engages an active goal (re-arming the monitor backstop while wake sources are live, or queueing a continuation through the existing sessionStart admission) instead of parking it until the next user message; stopped goals still never auto-start on reload ([#936](https://github.com/code-yeongyu/senpi/pull/936)).
 - Cursor CLI OAuth is now available by default when its real prerequisites exist: with `cursor-agent` installed and no managed CLI account, a native `cursor` OAuth credential is copied automatically into one canonical `native` slot without modifying the primary credential; explicit `enabled: false` remains a hard opt-out, repeated/concurrent startup is idempotent, and `/login cursor` refreshes the CLI fallback in the same session ([#931](https://github.com/code-yeongyu/senpi/pull/931)).
 
 ### New Features

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,49 @@
 # goal Extension Changes
 
+## Reload re-engages active goals instead of parking them (2026-08-18, fixes #934)
+
+### What changed
+
+- `session_start` with reason `"reload"` now routes through
+  `reload-reengagement.ts` (`reengageGoalAfterReload`) instead of skipping every
+  goal. A non-active goal (paused/blocked/complete) is still skipped, so a
+  reload never auto-starts an agent the user stopped. An active goal with live
+  wake sources re-arms the monitor-delayed backstop via the new
+  `MonitorAwareGoalContinuation.rearmMonitorBackstop`; an active goal without
+  wake sources queues a continuation through the existing sessionStart
+  admission, trailing-flood suppression included.
+- `MonitorAwareGoalContinuation` gains `hasActiveWakeSources()` and
+  `rearmMonitorBackstop(goal)`. The terminal builtin's reload `session_start`
+  replays its monitor snapshots before Goal's handler runs (builtin order is
+  load-bearing), so live-channel counts are already restored when the
+  re-engagement decision reads them.
+
+### Why
+
+- A config reload retires the extension generation: `session_shutdown` disposes
+  the continuation monitor, cancelling every armed timer (user grace, monitor
+  backstop) with it. The 2026-07-27 guard then skipped re-engagement for ANY
+  goal on reload, so an active goal mid-wait parked until the next user
+  message; wake-source drain could not self-heal because drain-fire requires a
+  scheduled monitor-kind continuation that never existed post-reload.
+- The guard's protective case is already covered by status: every user stop
+  marks the goal blocked via `session_abort` / `agent_end` abortSource "user",
+  and the continuation evaluator denies non-active goals. Skipping active goals
+  as well was over-broad and produced the reported stall.
+
+### Why an extension could not handle it
+
+- The continuation timers, wake-source counts, and the reload admission
+  decision are private to this builtin's monitor and `session_start` handler;
+  an external extension cannot re-arm a disposed timer or observe the reload
+  reason with the goal's continuation state.
+
+### Expected merge conflict zones
+
+- LOW in `index.ts` around the `session_start` reload branch; LOW in
+  `monitor-continuation.ts` around the new public accessors; LOW in the new
+  `reload-reengagement.ts`.
+
 ## External continuation holds pause Goal monitor recovery until release (2026-08-18)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -13,6 +13,7 @@ import { formatGoalForTool, goalStatusLabel } from "./format.ts";
 import { isResumeOfStoppedGoal, queueGoalContinuation } from "./lifecycle-helpers.ts";
 import { GOAL_CONTINUATION_SCHEDULED_EVENT, MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
 import { migrateLegacyGoalFile } from "./persistence.ts";
+import { reengageGoalAfterReload } from "./reload-reengagement.ts";
 import { accountGoalUsage, readGoal, updateGoal } from "./store.ts";
 import { GOAL_STORE_CHANGED_EVENT, isGoalStoreChangedEvent } from "./store-changed-event.ts";
 import { goalStoreRef as buildGoalStoreRef } from "./store-ref.ts";
@@ -145,9 +146,18 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		if (await maybePromptResumeStoppedGoal(pi, ctx, event.reason, goal)) {
 			return;
 		}
-		// A config reload must not auto-start an agent that was stopped. Only a fresh
-		// startup or explicit resume may re-engage an active goal via a continuation.
-		if (goal && event.reason !== "reload") {
+		if (goal && event.reason === "reload") {
+			// A reload retires the extension generation and every armed continuation
+			// timer with it. Re-engage through the reload path: stopped goals stay
+			// stopped, active goals resume the wait the reload tore down.
+			await reengageGoalAfterReload({
+				ctx,
+				goal,
+				monitor: monitorContinuation,
+				countTrailingContinuations: () => countTrailingGoalContinuationEntries(ctx.sessionManager.getBranch()),
+				queueContinuation: () => queueGoalContinuationForCurrentSession(pi, ctx, goal),
+			});
+		} else if (goal) {
 			// Migration-lite admission: a resumed session carrying a trailing flood of
 			// historical continuations must not reignite on load. Skip the auto-queue,
 			// leave the goal active (no status rewrite), and tell the user how to resume.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -198,6 +198,23 @@ export class MonitorAwareGoalContinuation {
 		}
 	}
 
+	/** Live resumption channels known to this generation (e.g. terminal snapshots replayed on reload). */
+	hasActiveWakeSources(): boolean {
+		return this.#activeWakeSourceCount() > 0;
+	}
+
+	/**
+	 * Re-arms the monitor-delayed backstop a reload tore down with the retired
+	 * generation, so a later wake-source drain can still deliver the goal
+	 * continuation. No-op unless the goal is active, a wake source is live, and
+	 * no continuation is already scheduled.
+	 */
+	rearmMonitorBackstop(goal: Goal): void {
+		if (goal.status !== "active" || this.#activeWakeSourceCount() === 0) return;
+		this.#goal = goal;
+		this.#schedule(goal, "monitor");
+	}
+
 	/** Temporarily prevents a scheduled continuation from racing unresolved direct-input admission. */
 	holdDirectInput(inputId: string): void {
 		if (this.#directInputHolds.has(inputId)) return;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/reload-reengagement.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/reload-reengagement.ts
@@ -1,0 +1,53 @@
+import type { ExtensionContext } from "../../types.ts";
+import { GOAL_CONTINUATION_CAP } from "./continuation.ts";
+import type { MonitorAwareGoalContinuation } from "./monitor-continuation.ts";
+import type { Goal } from "./types.ts";
+
+export type ReloadReengagementOutcome =
+	| "skipped-inactive"
+	| "backstop-rearmed"
+	| "suppressed-flood"
+	| "continuation-queued";
+
+/**
+ * Re-engages a goal after a config reload retired the previous extension
+ * generation. Reload disposes every armed continuation timer with the old
+ * generation, so without this the goal would park until the next user message.
+ *
+ * The 2026-07-27 contract (a reload must not auto-start an agent the user
+ * stopped) is preserved through goal status: every user stop marks the goal
+ * blocked via `session_abort` / `agent_end` abortSource "user", and the
+ * continuation evaluator denies non-active goals, so only genuinely active
+ * goals are re-engaged here.
+ *
+ * A goal with live wake sources keeps waiting on them: the terminal builtin
+ * replays its monitor snapshots before this handler runs (builtin order is
+ * load-bearing), so the monitor-delayed backstop is re-armed instead of
+ * queueing an immediate continuation. Without wake sources the goal resumes
+ * through the same sessionStart admission as startup/resume, including the
+ * trailing-flood suppression.
+ */
+export async function reengageGoalAfterReload(options: {
+	readonly ctx: ExtensionContext;
+	readonly goal: Goal;
+	readonly monitor: MonitorAwareGoalContinuation;
+	readonly countTrailingContinuations: () => number;
+	readonly queueContinuation: () => Promise<void>;
+}): Promise<ReloadReengagementOutcome> {
+	const { ctx, goal, monitor } = options;
+	if (goal.status !== "active") return "skipped-inactive";
+	if (monitor.hasActiveWakeSources()) {
+		monitor.rearmMonitorBackstop(goal);
+		return "backstop-rearmed";
+	}
+	const trailingContinuations = options.countTrailingContinuations();
+	if (trailingContinuations >= GOAL_CONTINUATION_CAP) {
+		ctx.ui.notify(
+			`Goal auto-continuation suppressed for this resumed session (${trailingContinuations} historical continuations). Send a message to resume.`,
+			"info",
+		);
+		return "suppressed-flood";
+	}
+	await options.queueContinuation();
+	return "continuation-queued";
+}

--- a/packages/coding-agent/test/suite/goal-cache-warm-ownership.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-ownership.test.ts
@@ -26,8 +26,8 @@ describe("goal cache-warm rendering ownership", () => {
 		const harness = createGoalHarness();
 		const { tools, handlers, events, entries } = harness;
 		const ctx = await makeGoalContext(notices, "thread-cache-warm-ownership");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 		events.emit("terminal_monitor_state", { activeCount: 1 });
 		await events.flush();
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);

--- a/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warmup.test.ts
@@ -40,8 +40,8 @@ async function setupWarmHarness(
 		model: cacheModel(),
 		cacheSafeWaitSeconds: 270,
 	});
-	await harness.tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+	await harness.tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 	harness.events.emit("terminal_monitor_state", { activeCount: 1 });
 	await harness.events.flush();
 	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
@@ -230,10 +230,10 @@ describe("goal cache-warm continuation story", () => {
 		const notices: string[] = [];
 		const harness = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-cache-warm-plain");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 		await harness.tools
 			.get("create_goal")
 			?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
-		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
 		await harness.events.flush();
 		await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -648,14 +648,18 @@ function textOf(result: { content?: Array<{ type: string; text?: string }> } | u
 }
 
 describe("goal extension reload does not auto-start a stopped agent", () => {
-	it("does not queue a continuation on session_start reason 'reload'", async () => {
+	it("does not queue a continuation on session_start reason 'reload' for a blocked goal", async () => {
 		const { tools, handlers, sent } = createGoalHarness();
 		const ctx = await makeCtx("thread-reload-noop");
 		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+		await tools
+			.get("update_goal")
+			?.execute("u1", { status: "blocked", reason: "user interrupted the turn" }, undefined, undefined, ctx);
 
 		await runHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
 		expect(sent).toHaveLength(0);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("blocked");
 	});
 
 	it("still queues a continuation on session_start reason 'startup'", async () => {
@@ -844,7 +848,7 @@ describe("goal extension session_start migration-lite admission", () => {
 		vi.useRealTimers();
 	});
 
-	it("keeps reload sessions inert even with a flooded branch (no queue, no suppression notice)", async () => {
+	it("suppresses with a notice on reload when a flooded branch parks an active goal", async () => {
 		const { tools, handlers, sent } = createGoalHarness();
 		const notices: string[] = [];
 		const ctx = await makeNotifyingCtx(notices, "thread-flooded-reload", [
@@ -856,7 +860,9 @@ describe("goal extension session_start migration-lite admission", () => {
 		await runHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 
 		expect(sent).toHaveLength(0);
-		expect(notices).toEqual([]);
+		expect(notices).toContainEqual(
+			"Goal auto-continuation suppressed for this resumed session (300 historical continuations). Send a message to resume.",
+		);
 		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
 	});
 });

--- a/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-continuation.test.ts
@@ -271,8 +271,8 @@ describe("goal continuation while a monitor is active", () => {
 		const notices: string[] = [];
 		const { tools, handlers } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-follow-up-pause");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await markCurrentGoalStale(ctx);
 		const before = await readGoal(goalStoreRef(ctx));
 		if (before === null) throw new Error("Expected persisted goal");
@@ -317,8 +317,8 @@ describe("goal continuation while a monitor is active", () => {
 			pendingMessages: false,
 			cacheSafeWaitSeconds: 270,
 		});
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		events.emit("terminal_monitor_state", { activeCount: 1 });
 		await events.flush();
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
@@ -357,8 +357,8 @@ describe("goal continuation while a monitor is active", () => {
 			cacheSafeWaitSeconds: 3570,
 			goalBackstopMaxSeconds: 900,
 		});
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		events.emit("terminal_monitor_state", { activeCount: 1 });
 		await events.flush();
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
@@ -382,8 +382,8 @@ describe("goal continuation while a monitor is active", () => {
 		const harness = createGoalHarness();
 		const { tools, handlers, sent, events } = harness;
 		const ctx = await makeGoalContext(notices, "thread-overlapping-input-holds");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		events.emit("terminal_monitor_state", { activeCount: 1 });
 		await events.flush();
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
@@ -424,8 +424,8 @@ describe("goal continuation while a monitor is active", () => {
 		const harness = createGoalHarness();
 		const { tools, handlers, sent, events } = harness;
 		const ctx = await makeGoalContext(notices, "thread-input-read-failure");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		events.emit("terminal_monitor_state", { activeCount: 1 });
 		await events.flush();
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
@@ -464,8 +464,8 @@ describe("goal continuation while a monitor is active", () => {
 		const harness = createGoalHarness();
 		const { tools, handlers, sent, events } = harness;
 		const ctx = await makeGoalContext(notices, "thread-monitor-cadence");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 		events.emit("terminal_monitor_state", { activeCount: 1 });
 		await events.flush();
 
@@ -494,8 +494,8 @@ describe("goal continuation while a monitor is active", () => {
 		const harness = createGoalHarness();
 		const { tools, handlers, sent } = harness;
 		const ctx = await makeGoalContext(notices, "thread-no-monitor");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 		const deliveryRecorded = waitForSentCount(harness, 1);
@@ -522,8 +522,8 @@ describe("goal continuation while a monitor is active", () => {
 			pendingMessages: false,
 			status,
 		});
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		const countdownStarted = waitForGoalStatus(
 			status,
@@ -562,8 +562,8 @@ describe("goal continuation while a monitor is active", () => {
 			pendingMessages: false,
 			status,
 		});
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		const countdownStarted = waitForGoalStatus(
 			status,
@@ -670,8 +670,8 @@ describe("goal continuation while a monitor is active", () => {
 		const notices: string[] = [];
 		const { tools, handlers, sent } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-length-minimal");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 		await runGoalHandlers(
@@ -692,8 +692,8 @@ describe("goal continuation while a monitor is active", () => {
 		const notices: string[] = [];
 		const { tools, handlers, sent, events } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-length-exhausted");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 		await runGoalHandlers(
@@ -725,8 +725,8 @@ describe("goal continuation while a monitor is active", () => {
 		const notices: string[] = [];
 		const { tools, handlers, sent } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-length-reset");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 		await runGoalHandlers(
@@ -774,8 +774,8 @@ describe("goal continuation while a monitor is active", () => {
 		const notices: string[] = [];
 		const { tools, handlers, sent, events } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-immediate-tool-progress");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		for (let turn = 1; turn <= 9; turn++) {
 			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
@@ -804,8 +804,8 @@ describe("goal continuation while a monitor is active", () => {
 		const notices: string[] = [];
 		const { tools, handlers, sent, events } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-immediate-distinct-progress");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		for (let turn = 1; turn <= 9; turn++) {
 			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
@@ -834,8 +834,8 @@ describe("goal continuation while a monitor is active", () => {
 		const notices: string[] = [];
 		const { tools, handlers, sent, events } = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "thread-stale-real-cycles");
-		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await tools.get("create_goal")?.execute("create", { objective: "Keep moving" }, undefined, undefined, ctx);
 
 		await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);
 		await runGoalHandlers(

--- a/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-lifecycle.test.ts
@@ -29,10 +29,10 @@ async function createActiveMonitorHarness(threadId: string): Promise<ActiveMonit
 	const state: GoalContextState = { pendingMessages: false, status, cacheSafeWaitSeconds: 270 };
 	const harness = createGoalHarness();
 	const ctx = await makeGoalContext(notices, threadId, state);
+	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 	await harness.tools
 		.get("create_goal")
 		?.execute("create", { objective: "Keep monitoring" }, undefined, undefined, ctx);
-	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 	harness.events.emit("terminal_monitor_state", { activeCount: 1 });
 	await harness.events.flush();
 	return { harness, ctx, notices, state, status };
@@ -108,7 +108,7 @@ describe("goal monitor continuation lifecycle", () => {
 		expect(harness.sent).toHaveLength(0);
 	});
 
-	it("disposes the delayed continuation on session reload", async () => {
+	it("disposes the delayed continuation on session reload and re-engages the active goal", async () => {
 		vi.useFakeTimers();
 		const { harness, ctx, status } = await createActiveMonitorHarness("thread-monitor-reload");
 		const countdownStarted = waitForGoalStatus(
@@ -124,9 +124,12 @@ describe("goal monitor continuation lifecycle", () => {
 		);
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 		await countdownCleared;
+		// The reload re-engagement (issue #934) queues one continuation for the still-active goal.
+		expect(harness.sent).toHaveLength(1);
 
+		// The retired generation's delayed timer stays disposed: no second delivery.
 		await vi.advanceTimersByTimeAsync(270_000);
-		expect(harness.sent).toHaveLength(0);
+		expect(harness.sent).toHaveLength(1);
 
 		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
 		await harness.events.flush();

--- a/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
+++ b/packages/coding-agent/test/suite/goal-monitor-stall.test.ts
@@ -26,10 +26,10 @@ async function createStallHarness(threadId: string, monitorsActive = true): Prom
 	const notices: string[] = [];
 	const harness = createGoalHarness();
 	const ctx = await makeGoalContext(notices, threadId);
+	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 	await harness.tools
 		.get("create_goal")
 		?.execute("create", { objective: "Keep monitoring" }, undefined, undefined, ctx);
-	await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 	if (monitorsActive) {
 		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
 		await harness.events.flush();

--- a/packages/coding-agent/test/suite/goal-system-abort-monitor.test.ts
+++ b/packages/coding-agent/test/suite/goal-system-abort-monitor.test.ts
@@ -24,8 +24,8 @@ describe("goal state after a system-owned abort", () => {
 			const harness = createGoalHarness();
 			const { tools, handlers, sent, events } = harness;
 			const ctx = await makeGoalContext(notices, "thread-system-abort-monitor");
-			await tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 			await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+			await tools.get("create_goal")?.execute("create", { objective: "Keep watching" }, undefined, undefined, ctx);
 			events.emit("terminal_monitor_state", { activeCount: 1 });
 			await events.flush();
 			await runGoalHandlers(handlers, "agent_start", { type: "agent_start" }, ctx);

--- a/packages/coding-agent/test/suite/loop-guard-goal-isolation.test.ts
+++ b/packages/coding-agent/test/suite/loop-guard-goal-isolation.test.ts
@@ -54,10 +54,10 @@ describe("loop-guard Goal isolation", () => {
 			pendingMessages: false,
 			goalBackstopMaxSeconds: 240,
 		});
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 		await harness.tools
 			.get("create_goal")
 			?.execute("create", { objective: "Recover from loop guard" }, undefined, undefined, ctx);
-		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
 		harness.events.emit("continuation_hold_state", {
 			source: "loop-guard-hard-stop",
 			active: true,

--- a/packages/coding-agent/test/suite/regressions/934-goal-reload-reengagement.test.ts
+++ b/packages/coding-agent/test/suite/regressions/934-goal-reload-reengagement.test.ts
@@ -1,0 +1,172 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GOAL_CONTINUATION_SCHEDULED_EVENT } from "../../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import { readGoal, writeGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
+import type { Goal } from "../../../src/core/extensions/builtin/goal/types.ts";
+import { WAKE_SOURCE_STATE_EVENT } from "../../../src/core/extensions/builtin/monitor-state-event.ts";
+import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
+import type { SessionEntry } from "../../../src/core/session-manager.ts";
+import {
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	makeGoalContext,
+	runGoalHandlers,
+	waitForSentCount,
+} from "../goal-monitor-test-harness.ts";
+
+const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
+
+function userMessageEntry(): SessionEntry {
+	return {
+		type: "message",
+		message: {
+			role: "user",
+			content: [{ type: "text", text: "a real user message" }],
+			timestamp: Date.now(),
+		},
+	} as unknown as SessionEntry;
+}
+
+function goalContinuationEntries(count: number): SessionEntry[] {
+	return Array.from({ length: count }, () => ({
+		type: "custom_message",
+		customType: GOAL_CONTINUATION_MESSAGE_TYPE,
+		content: "continue the goal",
+		display: false,
+	})) as unknown as SessionEntry[];
+}
+
+function goalWithStatus(id: string, status: Goal["status"]): Goal {
+	return {
+		id,
+		threadId: `${id}-thread`,
+		objective: "Keep moving across a config reload",
+		status,
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+function storeRefFor(ctx: ExtensionContext): { baseDir: string; threadId: string } {
+	return {
+		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+		threadId: ctx.sessionManager.getSessionId(),
+	};
+}
+
+function withBranchEntries(ctx: ExtensionContext, entries: SessionEntry[]): ExtensionContext {
+	return {
+		...ctx,
+		sessionManager: { ...ctx.sessionManager, getBranch: () => entries },
+	} as ExtensionContext;
+}
+
+describe("goal reload re-engagement (issue #934)", () => {
+	afterEach(async () => {
+		await cleanupGoalMonitorTempDirs();
+	});
+
+	it("queues a continuation on reload for an active goal without wake sources", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-934-active-reload");
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+		expect(sent).toHaveLength(0);
+
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe(GOAL_CONTINUATION_MESSAGE_TYPE);
+	});
+
+	it("re-arms the monitor backstop on reload while wake sources are live", async () => {
+		vi.useFakeTimers();
+		try {
+			const { tools, handlers, events, sent } = createGoalHarness();
+			const notices: string[] = [];
+			const ctx = await makeGoalContext(notices, "thread-934-wake-reload");
+			await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+			events.emit(WAKE_SOURCE_STATE_EVENT, { source: "terminal-monitors", activeCount: 1 });
+			await events.flush();
+
+			await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+			const scheduled = events.emitted.filter((event) => event.channel === GOAL_CONTINUATION_SCHEDULED_EVENT);
+			expect(scheduled).toHaveLength(1);
+			expect(sent).toHaveLength(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("delivers the continuation when wake sources drain after a reload re-arm", async () => {
+		vi.useFakeTimers();
+		try {
+			const harness = createGoalHarness();
+			const { tools, handlers, events, sent } = harness;
+			const notices: string[] = [];
+			const ctx = await makeGoalContext(notices, "thread-934-drain-reload");
+			await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+			events.emit(WAKE_SOURCE_STATE_EVENT, { source: "terminal-monitors", activeCount: 1 });
+			await events.flush();
+			await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+			expect(sent).toHaveLength(0);
+
+			events.emit(WAKE_SOURCE_STATE_EVENT, { source: "terminal-monitors", activeCount: 0 });
+			await events.flush();
+			await vi.advanceTimersByTimeAsync(1_000);
+
+			await waitForSentCount(harness, 1, { timeoutMs: 2_000 });
+			expect(sent[0]?.message.customType).toBe(GOAL_CONTINUATION_MESSAGE_TYPE);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not re-engage a blocked goal on reload", async () => {
+		const { tools, handlers, events, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-934-blocked-reload");
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+		await tools
+			.get("update_goal")
+			?.execute("u1", { status: "blocked", reason: "user interrupted the turn" }, undefined, undefined, ctx);
+
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		expect(sent).toHaveLength(0);
+		expect(events.emitted.filter((event) => event.channel === GOAL_CONTINUATION_SCHEDULED_EVENT)).toHaveLength(0);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("blocked");
+	});
+
+	it("does not re-engage a paused goal on reload", async () => {
+		const { handlers, events, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-934-paused-reload");
+		await writeGoal(storeRefFor(ctx), goalWithStatus("thread-934-paused-reload", "paused"));
+
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+
+		expect(sent).toHaveLength(0);
+		expect(events.emitted.filter((event) => event.channel === GOAL_CONTINUATION_SCHEDULED_EVENT)).toHaveLength(0);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("paused");
+	});
+
+	it("suppresses with a notice on reload when the branch ends in a continuation flood", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeGoalContext(notices, "thread-934-flooded-reload");
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+		const floodedCtx = withBranchEntries(ctx, [userMessageEntry(), ...goalContinuationEntries(300)]);
+
+		await runGoalHandlers(handlers, "session_start", { type: "session_start", reason: "reload" }, floodedCtx);
+
+		expect(sent).toHaveLength(0);
+		expect(notices).toContainEqual(
+			"Goal auto-continuation suppressed for this resumed session (300 historical continuations). Send a message to resume.",
+		);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("active");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
@@ -99,8 +99,8 @@ describe("issue #447: goal continuation guardrails", () => {
 		const notices: string[] = [];
 		const harness = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "issue-447-distinct-progress");
-		await createActiveGoal(harness, ctx, "Finish the issue #447 regression");
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await createActiveGoal(harness, ctx, "Finish the issue #447 regression");
 
 		for (let turn = 1; turn <= 50; turn++) {
 			const promptsBeforeTurn = harness.sent.length;
@@ -148,8 +148,8 @@ describe("issue #447: goal continuation guardrails", () => {
 		const notices: string[] = [];
 		const harness = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "issue-447-length");
-		await createActiveGoal(harness, ctx, "Finish the truncated response");
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await createActiveGoal(harness, ctx, "Finish the truncated response");
 
 		await runContinuationTurn(harness, ctx, assistantStopWithReason("length", "first response cut off"));
 		expect(harness.sent).toHaveLength(1);
@@ -169,8 +169,8 @@ describe("issue #447: goal continuation guardrails", () => {
 		const notices: string[] = [];
 		const harness = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "issue-447-user-grace");
-		await createActiveGoal(harness, ctx, "Answer the direct user question first");
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await createActiveGoal(harness, ctx, "Answer the direct user question first");
 
 		await runGoalHandlers(
 			harness.handlers,
@@ -204,8 +204,8 @@ describe("issue #447: goal continuation guardrails", () => {
 		const notices: string[] = [];
 		const harness = createGoalHarness();
 		const ctx = await makeGoalContext(notices, "issue-447-terminal-error");
-		await createActiveGoal(harness, ctx, "Recover only when the provider can retry");
 		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await createActiveGoal(harness, ctx, "Recover only when the provider can retry");
 
 		await runContinuationTurn(harness, ctx, assistantStopWithReason("error", "provider exhausted retries"), false);
 


### PR DESCRIPTION
fixes #934

## Symptom

While a goal is active, a settings hot-reload (the config-reload builtin, or an omo `.omo` config change forwarded through the config-watch protocol) silently stops the goal loop: the goal stays `active`, the session sits idle, and no continuation fires until the user types.

## Root cause

A reload retires the extension generation. `session_shutdown { reason: "reload" }` disposes the goal's `MonitorAwareGoalContinuation`, cancelling every armed continuation timer (user grace, monitor backstop). The new generation's `session_start` then skipped re-engagement for **any** goal via `if (goal && event.reason !== "reload")` — a 2026-07-27 guard against auto-starting a user-stopped agent. That guard is over-broad:

- The same 2026-07-27 change routes every user stop through `session_abort` / `agent_end abortSource: "user"`, which marks the goal `blocked`, and `evaluateGoalContinuation` already denies non-active goals. Stopped goals cannot auto-start even without the guard.
- Wake-source drain cannot self-heal post-reload: `#armDrainFire` only fires when a monitor-kind continuation is scheduled, and after reload none ever is.

Net effect: any active goal mid-wait at reload time parked permanently.

## Fix

`goal/reload-reengagement.ts` owns the reload `session_start` decision:

| Goal state at reload | Behavior |
|---|---|
| paused / blocked / complete | skipped — stopped agents stay stopped (2026-07-27 contract preserved via status) |
| active + live wake sources | `rearmMonitorBackstop` re-arms the monitor-delayed backstop (terminal replays snapshots before goal's handler; builtin order load-bearing) — drain-fire self-heal restored |
| active + no wake sources + flooded branch | trailing-flood suppression notice, no queue (same admission as startup/resume) |
| active + no wake sources | continuation queued through the existing sessionStart path |

`MonitorAwareGoalContinuation` gains two small accessors (`hasActiveWakeSources`, `rearmMonitorBackstop`). Non-reload session starts are byte-identical.

## Test repair note

24 existing setups across 7 files used `session_start reason: "reload"` as an *inert* starting state after creating an active goal — precisely the behavior this fix changes. Those setups were reordered (reload start now precedes goal creation), preserving their original intent; `goal-monitor-lifecycle`'s reload-disposal test now also asserts the re-engagement continuation while proving the retired timer stays disposed.

## Evidence

- RED (unpatched, `934-goal-reload-reengagement.test.ts`): 4 failed | 2 passed — active+reload queued nothing, no backstop re-arm, drain delivery timed out, no flood notice; blocked/paused pins green.
- GREEN (patched): **171/171 across 15 goal/reload suites** (goal-extension, goal-monitor-continuation/stall/lifecycle, cache-warmup/ownership, system-abort-monitor, terminal-reload-survival, terminal-resumption-channel-state, reload-efficiency, config-reload-extension, issue-447, goal-created-turn, 934 regression).
- `npx tsc --noEmit -p packages/coding-agent/tsconfig.build.json`: clean.
- `npm run check`: green (one unrelated biome drift in `cursor-cli-oauth/native-bootstrap.ts` reverted, kept out of this PR).
- Real-CLI QA (`goal-reload-reengagement-qa.mjs`, senpi-qa hermetic sandbox, Anthropic mock, `ctx.requestReload()` driven via RPC `extension_request`): the mock answers every continuation identically so the goal's own stale guard parks the loop (goal active, session idle) before the reload lands.
  - RED (origin/main @ ef5a9655a): goal parked at 4 provider requests, reload, **0 requests in the 18s post-reload window** — the stall; the sanity prompt still answered (request 5), proving the session was alive. `local-ignore/qa-evidence/20260818-goal-reload-stall/red/`
  - GREEN (this branch): same setup, **1 provider request post-reload with zero user input** (the re-engaged continuation), sanity prompt answered, no stale-generation errors, 6/6 PASS. `local-ignore/qa-evidence/20260818-goal-reload-stall/green/`

## Contract changes

None to the extension API. One deliberate behavior change: a reload `session_start` with an active goal and a flooded branch now shows the trailing-flood suppression notice (previously silent). The two updated contract tests in `goal-extension.test.ts` document this.
