### PR TITLE
fix(coding-agent): quarantine agent dir over inherited env in test setup

### DIFF
--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -32,7 +32,7 @@ claude-sdk-oauth-*.test.ts
 
 ## TEST RULES
 
-- `test/setup.ts` quarantines `SENPI_CODING_AGENT_DIR` into a unique temp directory by default; preserve that isolation in all new tests.
+- `test/setup.ts` quarantines `SENPI_CODING_AGENT_DIR` into a unique temp directory on every run; preserve that isolation in all new tests. See the QUARANTINE CONTRACT below for the load-bearing reason the guard always wins.
 - Model catalog refresh tests must stay mocked/offline; only `integration/` and `qa/` surfaces may use real credentials or incur network cost.
 - Prefer `suite/harness.ts` and the faux provider for new lifecycle and extension coverage.
 - Do not use real provider APIs, API keys, network calls, or paid tokens in default tests.
@@ -41,6 +41,15 @@ claude-sdk-oauth-*.test.ts
 - Do not extend the legacy `test-harness.ts` unless the preferred harness lacks a required capability.
 - Keep fixtures deterministic, local, and secret-free. Spawned process tests must clean up children, sockets, and temporary directories.
 - Tests involving PTY, MCP, app-server, or other subprocess-heavy surfaces must remain reliable with `CI=1`, where Vitest uses one fork.
+
+## QUARANTINE CONTRACT (load-bearing)
+
+`test/setup.ts` resolves the agent directory through `test/support/quarantine.ts`'s `resolveQuarantineAgentDir`. The quarantine **always wins** over an inherited `SENPI_CODING_AGENT_DIR`, opting out only with an explicit `SENPI_TEST_USE_REAL_AGENT_DIR=1` paired with the target dir. This is not a courtesy — it is a safety boundary.
+
+- The omo launcher (`omo-ai/bin/lib/launcher.js` → `senpiEnvironment`) sets `SENPI_CODING_AGENT_DIR` for **every** spawned child session. Any `vitest` run launched from inside an omo agent session inherits a value pointing at the user's REAL `~/.omo/agent`.
+- Before this guard always won, an inherited env made the whole suite run against the real config and tests deleted `~/.omo/agent/settings.json` (proven live 2026-08-18: favorite-guard ENOENT crashes matched suite-run windows exactly). Never reintroduce an `if (!process.env.SENPI_CODING_AGENT_DIR)` short-circuit here.
+- To target a specific real directory in a test, pass the agent dir explicitly to `SettingsManager.create` / `SessionManager.create` rather than relying on the ambient env. Use `SENPI_TEST_USE_REAL_AGENT_DIR=1` only for the rare whole-suite opt-in.
+- Tests that spawn the CLI as a subprocess must set `SENPI_CODING_AGENT_DIR` to a temp dir in the child env explicitly (see `test/helpers/rpc-hermetic.ts`); never let the child inherit an unguarded ambient value.
 
 ## LIVE AND MANUAL SURFACES
 

--- a/packages/coding-agent/test/setup-quarantine.test.ts
+++ b/packages/coding-agent/test/setup-quarantine.test.ts
@@ -1,0 +1,31 @@
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "vitest";
+import { resolveQuarantineAgentDir } from "./support/quarantine.ts";
+
+describe("test quarantine resolver", () => {
+	test("overrides an inherited SENPI_CODING_AGENT_DIR (omo launcher dirty env)", () => {
+		const inherited = "/Users/yeongyu/.omo/agent";
+		const result = resolveQuarantineAgentDir({ SENPI_CODING_AGENT_DIR: inherited });
+
+		expect(result).toBeDefined();
+		expect(result).not.toBe(inherited);
+		expect(result).toContain(tmpdir());
+	});
+
+	test("honors SENPI_TEST_USE_REAL_AGENT_DIR=1 opt-in", () => {
+		const inherited = "/Users/yeongyu/.omo/agent";
+		const result = resolveQuarantineAgentDir({
+			SENPI_CODING_AGENT_DIR: inherited,
+			SENPI_TEST_USE_REAL_AGENT_DIR: "1",
+		});
+
+		expect(result).toBe(inherited);
+	});
+
+	test("quarantines when no env is set", () => {
+		const result = resolveQuarantineAgentDir({});
+
+		expect(result).toBeDefined();
+		expect(result).toContain(tmpdir());
+	});
+});

--- a/packages/coding-agent/test/setup.ts
+++ b/packages/coding-agent/test/setup.ts
@@ -8,22 +8,13 @@
  * $HOME and leaves faux-provider JSONLs there permanently, where downstream
  * tools (e.g. tokscale) then mis-count them as real usage.
  */
-
-import { mkdirSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { resolveQuarantineAgentDir } from "./support/quarantine.ts";
 
 for (const key of ["PI_RULES_DISABLED", "PI_RULES_MAX_RULE_CHARS", "PI_RULES_MAX_RESULT_CHARS"] as const) {
 	delete process.env[key];
 }
 
-// Guarded so an explicit `SENPI_CODING_AGENT_DIR=...` env (CI / opt-in) wins.
-if (!process.env.SENPI_CODING_AGENT_DIR) {
-	const quarantineDir = join(
-		tmpdir(),
-		`senpi-vitest-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-		"agent",
-	);
-	mkdirSync(quarantineDir, { recursive: true });
-	process.env.SENPI_CODING_AGENT_DIR = quarantineDir;
+const quarantineAgentDir = resolveQuarantineAgentDir(process.env);
+if (quarantineAgentDir) {
+	process.env.SENPI_CODING_AGENT_DIR = quarantineAgentDir;
 }

--- a/packages/coding-agent/test/support/quarantine.ts
+++ b/packages/coding-agent/test/support/quarantine.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure resolver for the test suite's agent directory.
+ *
+ * The quarantine MUST win over an inherited `SENPI_CODING_AGENT_DIR`: the omo
+ * launcher (`omo-ai/bin/lib/launcher.js` -> `senpiEnvironment`) sets that
+ * variable for every spawned child session, so a `vitest` run launched from
+ * inside an omo agent session inherits a value pointing at the user's REAL
+ * `~/.omo/agent`. Letting that env win ran the whole suite against the real
+ * config and tests deleted `~/.omo/agent/settings.json` (observed live
+ * 2026-08-18). Opt out explicitly with `SENPI_TEST_USE_REAL_AGENT_DIR=1` for
+ * the rare test that must target a specific real directory.
+ */
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Resolve the agent directory the test suite should run against.
+ *
+ * Returns a fresh unique temp directory unless an explicit opt-in
+ * (`SENPI_TEST_USE_REAL_AGENT_DIR=1`) is set together with a configured
+ * `SENPI_CODING_AGENT_DIR`. Returning `undefined` leaves the env var untouched.
+ */
+export function resolveQuarantineAgentDir(
+	env: Record<string, string | undefined> = process.env,
+): string | undefined {
+	const explicitReal = env.SENPI_TEST_USE_REAL_AGENT_DIR === "1";
+	if (explicitReal && env.SENPI_CODING_AGENT_DIR) {
+		return env.SENPI_CODING_AGENT_DIR;
+	}
+	const quarantineDir = join(
+		tmpdir(),
+		`senpi-vitest-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		"agent",
+	);
+	mkdirSync(quarantineDir, { recursive: true });
+	return quarantineDir;
+}


### PR DESCRIPTION
## What

`test/setup.ts` now always quarantines `SENPI_CODING_AGENT_DIR` into a fresh temp directory, overriding any inherited value. The quarantine opts out only with an explicit `SENPI_TEST_USE_REAL_AGENT_DIR=1` paired with the target dir.

## Why

The omo launcher (`omo-ai/bin/lib/launcher.js` → `senpiEnvironment`) sets `SENPI_CODING_AGENT_DIR` for **every** spawned child session. Any `vitest` run launched from inside an omo agent session inherits a value pointing at the user's REAL `~/.omo/agent`. The old guard (`if (!process.env.SENPI_CODING_AGENT_DIR)`) treated that inherited value as an explicit opt-in and skipped the quarantine, so the whole suite ran against the real config. Tests then deleted `~/.omo/agent/settings.json`.

Proven live 2026-08-18: the favorite-guard daemon's ENOENT crashes matched dirty-env suite-run windows exactly (56 clean absences since Aug 13, zero truncations), and a decoy-dir reproduction caught the deletion in the act. Every run of the suite from an omo session nuked the user's `retry.fallbackChains`, `packages`, `defaultProvider/Model`, and `favoriteModels` (the guard then refilled favorites from a stale 7-entry template, causing the observed 9→7 drift).

## How

- Extract `resolveQuarantineAgentDir` into `test/support/quarantine.ts` as a pure, testable resolver. It returns a fresh tmpdir unless `SENPI_TEST_USE_REAL_AGENT_DIR=1` is set together with a configured `SENPI_CODING_AGENT_DIR`.
- `test/setup.ts` consumes the resolver; the quarantine always wins.
- `test/AGENTS.md` gains a binding **QUARANTINE CONTRACT** section documenting the omo-launcher hazard and the invariant, so the old short-circuit is never reintroduced.

## Verification

- **RED→GREEN**: `test/setup-quarantine.test.ts` fails on the old "env wins" behavior (`expected '/Users/yeongyu/.omo/agent' not to be '/Users/yeongyu/.omo/agent'`) and passes once the quarantine always wins. 3/3 green.
- **Regression**: full coding-agent suite (`CI=1 npx vitest run`) — 975 passed / 4 skipped, 0 regressions vs main (12 files / 42 tests that initially failed were environmental: missing built `dist/` in the fresh worktree; all pass after `npm run build`).
- **Static gate**: `npm run check` exit 0 (biome, tsc --noEmit, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, browser-smoke).

## Operational (already done out-of-band)

- Stopped the rogue dirty-env suite (pid 50480, had run 1h+ and was actively deleting the live config).
- Restored `~/.omo/agent/settings.json` from the legacy flat file: `retry.fallbackChains`, `packages`, `images`, `favoriteModels` unioned 7→9. Backup saved.

## Risk

Test-infra-only change. No runtime source touched. CI does not set `SENPI_CODING_AGENT_DIR` (only `PI_CODING_AGENT_DIR` in a separate `issue-analysis.yml` workflow), so the inversion is CI-safe. The opt-in (`SENPI_TEST_USE_REAL_AGENT_DIR=1`) preserves the rare whole-suite-against-a-real-dir escape hatch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always quarantines the coding-agent dir in tests by overriding any inherited `SENPI_CODING_AGENT_DIR`. Previously, an inherited value (from the omo launcher) disabled quarantine and tests operated on the real `~/.omo/agent`; now a fresh tmpdir is used by default, preventing accidental config deletion. Opt-out requires `SENPI_TEST_USE_REAL_AGENT_DIR=1` with a target dir.

**Review and rollout**
- Introduces `test/support/quarantine.ts` with `resolveQuarantineAgentDir`, used by `test/setup.ts`.
- Adds `test/setup-quarantine.test.ts` to verify override-by-default and explicit opt-in behavior.
- Expands `test/AGENTS.md` with QUARANTINE CONTRACT and guidance for subprocess tests.
- Required action to target a real dir: set `SENPI_TEST_USE_REAL_AGENT_DIR=1` and `SENPI_CODING_AGENT_DIR=/path/to/agent`.
- Required action for spawned CLI tests: set `SENPI_CODING_AGENT_DIR` in the child env explicitly; do not rely on ambient env.

<sup>Written for commit b6b88364911171cbc2ce92a56aebd65c6658f7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

