### PR TITLE
fix(tool-call-middleware): preserve cursor exec marks

### DIFF
--- a/packages/agent/test/cursor-exec-recovery-loop.test.ts
+++ b/packages/agent/test/cursor-exec-recovery-loop.test.ts
@@ -1,0 +1,107 @@
+import {
+	type AssistantMessage,
+	type CursorExecResolvedCarrier,
+	createAssistantMessageEventStream,
+	kCursorExecResolved,
+	type Message,
+	type Model,
+	type ToolCall,
+	wrapStreamWithModelRecovery,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { agentLoop } from "../src/agent-loop.ts";
+import type { AgentContext, AgentLoopConfig, AgentTool } from "../src/types.ts";
+
+const Parameters = Type.Object({ command: Type.String() });
+
+function model(): Model<"cursor-agent"> {
+	return {
+		id: "kimi-k3",
+		name: "kimi-k3",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "kimi-k3",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function resolvedCall(): ToolCall {
+	const block: ToolCall & CursorExecResolvedCarrier = {
+		type: "toolCall",
+		id: "cursor-call-1",
+		name: "bash",
+		arguments: { command: "echo hi" },
+	};
+	block[kCursorExecResolved] = true;
+	return block;
+}
+
+describe("cursor exec marker after model recovery", () => {
+	it("keeps total execution at one", async () => {
+		let executions = 1;
+		const tool: AgentTool<typeof Parameters> = {
+			name: "bash",
+			label: "bash",
+			description: "Run a command",
+			parameters: Parameters,
+			execute: async () => {
+				executions++;
+				return { content: [{ type: "text", text: "ran" }], details: {} };
+			},
+		};
+		const recoveryModel = model();
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [tool] };
+		const config: AgentLoopConfig = {
+			model: recoveryModel,
+			convertToLlm: (messages) => messages.filter((message): message is Message => "role" in message),
+		};
+		let requests = 0;
+
+		const stream = agentLoop([{ role: "user", content: "run it", timestamp: 0 }], context, config, undefined, () => {
+			const response = createAssistantMessageEventStream();
+			const message = requests++ === 0 ? assistant([resolvedCall()]) : assistant([{ type: "text", text: "done" }]);
+			queueMicrotask(() => {
+				response.push({ type: "start", partial: assistant([]) });
+				const toolCall = message.content[0];
+				if (toolCall?.type === "toolCall") {
+					response.push({ type: "toolcall_start", contentIndex: 0, partial: message });
+					response.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: message });
+				}
+				response.push({ type: "done", reason: "stop", message });
+				response.end();
+			});
+			return wrapStreamWithModelRecovery(response, recoveryModel, context.tools ?? []);
+		});
+		for await (const _event of stream) {
+			// consume
+		}
+		await stream.result();
+
+		expect(executions).toBe(1);
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Model recovery now preserves Cursor's in-memory resolved-tool marker on native tool-call blocks, so Claude/Kimi-id
+  Cursor turns do not execute server-resolved bash/write/delete calls a second time
+  ([#939](https://github.com/code-yeongyu/senpi/pull/939)).
 - GPT-5.6 Sol and Sol Fast now default to a 400,000-token context window in both the direct OpenAI and
   ChatGPT OAuth (`openai-codex`) catalogs ([#933](https://github.com/code-yeongyu/senpi/pull/933)).
 - Refreshed Vercel AI Gateway pricing for `alibaba/qwen3.8-27b` from zero-value placeholder metadata to the

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -2,6 +2,21 @@
 
 # Tool Call Middleware Changes
 
+## 2026-08-18 - Cursor exec marker preservation
+
+### What changed and why
+
+- Recovery stream snapshots now retain enumerable symbol-keyed metadata on native
+  content blocks. This preserves Cursor's `kCursorExecResolved` marker through
+  Claude/Kimi model recovery so the agent loop does not execute an already-resolved
+  tool call a second time (fixes #938).
+- String-keyed snapshot cloning and recovered text-tool behavior are unchanged.
+
+### Why the extension system could not handle this
+
+- The marker must survive the provider-neutral model recovery wrapper before the
+  agent loop or extensions consume the assistant stream.
+
 ## 2026-08-09 - Claude missing-angle ANTML invoke recovery
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/recovery-message-snapshot.ts
+++ b/packages/ai/src/tool-call-middleware/recovery-message-snapshot.ts
@@ -23,9 +23,12 @@ function clonePlainGraph<T>(value: T, seen: WeakMap<object, unknown>): T {
 		return clone as T;
 	}
 	if (!isPlainObject(value)) return value;
-	const clone = Object.create(Object.getPrototypeOf(value)) as Record<string, unknown>;
+	const clone = Object.create(Object.getPrototypeOf(value)) as Record<PropertyKey, unknown>;
 	seen.set(value, clone);
-	for (const key of Object.keys(value)) {
+	const enumerableSymbols = Object.getOwnPropertySymbols(value).filter((key) =>
+		Object.prototype.propertyIsEnumerable.call(value, key),
+	);
+	for (const key of [...Object.keys(value), ...enumerableSymbols]) {
 		Object.defineProperty(clone, key, {
 			value: clonePlainGraph(Reflect.get(value, key), seen),
 			writable: true,

--- a/packages/ai/test/tool-call-middleware/cursor-exec-recovery.test.ts
+++ b/packages/ai/test/tool-call-middleware/cursor-exec-recovery.test.ts
@@ -1,0 +1,82 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { wrapStreamWithModelRecovery } from "../../src/tool-call-middleware/index.ts";
+import type { AssistantMessage, Model, Tool, ToolCall } from "../../src/types.ts";
+import {
+	type CursorExecResolvedCarrier,
+	isCursorExecResolved,
+	kCursorExecResolved,
+} from "../../src/utils/block-symbols.ts";
+import { createAssistantMessageEventStream } from "../../src/utils/event-stream.ts";
+
+const bashTool = {
+	name: "bash",
+	description: "Run a command",
+	parameters: Type.Object({ command: Type.String() }),
+} satisfies Tool;
+
+function model(id: string): Model<"cursor-agent"> {
+	return {
+		id,
+		name: id,
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "mock-cursor",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+function resolvedToolCall(): ToolCall {
+	const block: ToolCall & CursorExecResolvedCarrier = {
+		type: "toolCall",
+		id: "cursor-call-1",
+		name: "bash",
+		arguments: { command: "echo hi" },
+	};
+	block[kCursorExecResolved] = true;
+	return block;
+}
+
+describe("cursor exec metadata through model recovery", () => {
+	it.each(["kimi-k3", "claude-opus-4-8"])("preserves the resolved marker for %s", async (modelId) => {
+		const inner = createAssistantMessageEventStream();
+		const wrapped = wrapStreamWithModelRecovery(inner, model(modelId), [bashTool]);
+		const toolCall = resolvedToolCall();
+		const message = assistant([toolCall]);
+
+		inner.push({ type: "start", partial: assistant([]) });
+		inner.push({ type: "toolcall_start", contentIndex: 0, partial: message });
+		inner.push({ type: "toolcall_end", contentIndex: 0, toolCall, partial: message });
+		inner.push({ type: "done", reason: "stop", message });
+		inner.end();
+
+		const result = await wrapped.result();
+		const finalBlock = result.content[0];
+		expect(finalBlock?.type).toBe("toolCall");
+		expect(isCursorExecResolved(finalBlock)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- preserve enumerable symbol-keyed metadata while recovery snapshots clone native tool-call blocks
- keep Cursor's `kCursorExecResolved` marker intact for Claude/Kimi-id model recovery
- cover the model-recovery boundary and the agent-loop duplicate-execution regression

Fixes #938.

## Root cause

1. Cursor's exec channel synthesizes an already-executed `toolCall` and stamps it with `kCursorExecResolved`.
2. `ModelRuntime.stream()` / `streamSimple()` wraps streams with `wrapStreamWithModelRecovery()`.
3. Claude/Kimi-family model IDs activate invoke recovery.
4. Recovery projects native tool calls into a new message, then `RecoveryAssistantMessageEventStream` snapshots each projected event.
5. The snapshot graph clone copied only `Object.keys()`, so the symbol marker disappeared from the terminal assistant message.
6. The agent loop received an unmarked tool call and executed the side-effecting tool again.

The fix extends the existing plain-object snapshot clone to copy enumerable own symbol keys as well. String-keyed cloning, recovered text-tool parsing, object identity isolation, and non-enumerable metadata behavior remain unchanged.

## TDD evidence

### RED

Before the fix:

- `packages/ai/test/tool-call-middleware/cursor-exec-recovery.test.ts`
  - Kimi and Claude cases failed with `expected false to be true` for `isCursorExecResolved(finalBlock)`.
- `packages/agent/test/cursor-exec-recovery-loop.test.ts`
  - the execution-count repro failed with `expected 2 to be 1`, proving the wrapped stream caused a second execution.

### GREEN

After the fix:

- focused AI regression: 2 passed
- focused agent regression: 1 passed; provider execution + local tool counter remains exactly 1
- `packages/ai`: 214 files passed, 2,092 tests passed, 865 skipped
- `packages/agent`: 35 files passed, 501 tests passed, 1 skipped
- `npm run build`: passed
- `npm run check`: passed

`npm run check` rewrote unrelated files under `packages/coding-agent`; those rewrites were restored and are not part of this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Cursor’s resolved-tool exec marker during model recovery so already-executed native tool calls are not run again on Claude/Kimi model IDs. Previously, the snapshot clone dropped the enumerable symbol `kCursorExecResolved`, and the agent loop re-executed the tool; now the clone copies enumerable own symbol keys to keep the marker.

**Review notes**
- Extends the plain-object snapshot clone in `recovery-message-snapshot.ts` to include enumerable symbol keys; string-keyed cloning and non-enumerable metadata stay the same.
- Adds regression tests in `packages/ai/test/tool-call-middleware/cursor-exec-recovery.test.ts` and `packages/agent/test/cursor-exec-recovery-loop.test.ts` validating marker preservation and single execution.
- No migration required; bug fix eliminates duplicate side effects for recovered Cursor turns.

<sup>Written for commit 64541b0d676147b89574a56222b39b603a6ee972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

