### PR TITLE
docs(changelog): complete v2026.8.18 release audit

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Late Cursor exec-bridge lifecycle events that settle after an abort or timeout are tied to their originating run, so they neither raise an unhandled `Agent listener invoked outside active run` error nor leak into a replacement run.
+- Late Cursor exec-bridge lifecycle events that settle after an abort or timeout are tied to their originating run, so they neither raise an unhandled `Agent listener invoked outside active run` error nor leak into a replacement run ([#935](https://github.com/code-yeongyu/senpi/pull/935)).
 
 ### Removed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,14 @@
 - Goals no longer stall after a settings hot-reload: a reload `session_start` now re-engages an active goal (re-arming the monitor backstop while wake sources are live, or queueing a continuation through the existing sessionStart admission) instead of parking it until the next user message; stopped goals still never auto-start on reload ([#936](https://github.com/code-yeongyu/senpi/pull/936)).
 - Cursor CLI OAuth is now available by default when its real prerequisites exist: with `cursor-agent` installed and no managed CLI account, a native `cursor` OAuth credential is copied automatically into one canonical `native` slot without modifying the primary credential; explicit `enabled: false` remains a hard opt-out, repeated/concurrent startup is idempotent, and `/login cursor` refreshes the CLI fallback in the same session ([#931](https://github.com/code-yeongyu/senpi/pull/931)).
 
-- Cursor exec-bridge lifecycle events now require their originating run signal and await listener delivery, preventing delayed completions from entering a replacement run or becoming detached unhandled rejections.
+- Cursor exec-bridge lifecycle events now require their originating run signal and await listener delivery, preventing delayed completions from entering a replacement run or becoming detached unhandled rejections ([#935](https://github.com/code-yeongyu/senpi/pull/935)).
+- Model recovery now preserves Cursor's in-memory resolved-tool marker on native tool-call blocks, so Claude/Kimi-id
+  Cursor turns do not execute server-resolved bash/write/delete calls a second time
+  ([#939](https://github.com/code-yeongyu/senpi/pull/939)).
+- GPT-5.6 Sol and Sol Fast now default to a 400,000-token context window in both the direct OpenAI and
+  ChatGPT OAuth (`openai-codex`) catalogs ([#933](https://github.com/code-yeongyu/senpi/pull/933)).
+- Refreshed Vercel AI Gateway pricing for `alibaba/qwen3.8-27b` from zero-value placeholder metadata to the
+  current upstream input, output, and cache-read rates ([#933](https://github.com/code-yeongyu/senpi/pull/933)).
 
 ### New Features
 


### PR DESCRIPTION
## Summary
- add the missing coding-agent duplicates for user-facing AI changes in #933 and #939
- add missing internal PR attribution for #935 in agent and coding-agent
- audit all 29 commits in `v2026.8.18..origin/main`

## Audit coverage
| PR / commits | Result |
| --- | --- |
| #931 | Covered in coding-agent |
| #932 | Skipped: test-only Baseten expectation update |
| #933 | Covered in AI; duplicated user-facing catalog/model metadata changes to coding-agent |
| #935 | Covered in agent and coding-agent; attribution repaired |
| #936 | Covered in coding-agent |
| #937 | Skipped: test-only quarantine infrastructure |
| #939 | Covered in AI; duplicated user-facing recovery fix to coding-agent |
| release/unreleased setup, changelog commits, branch sync merges, QA/test follow-ups | Skipped per audit guide |

## Verification
- `git diff --check`
- only `packages/*/CHANGELOG.md` files changed
- all user-facing ai/agent changes now have coding-agent coverage


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes the v2026.8.18 changelog audit by duplicating user-facing changes into `packages/coding-agent/CHANGELOG.md` and repairing missing attribution in `packages/agent/CHANGELOG.md`. Users of `coding-agent` now see the exec-bridge run-signal requirement (#935), model recovery that preserves Cursor’s resolved-tool marker so server-resolved bash/write/delete calls are not executed twice (was possible before; now prevented) (#939), 400k-token defaults for GPT-5.6 Sol/Sol Fast in both OpenAI and `openai-codex` catalogs (#933), and refreshed Vercel AI Gateway pricing for `alibaba/qwen3.8-27b` (#933). The `agent` changelog adds a link to #935 for the late exec-bridge event fix. Docs only; no runtime changes.

**Review notes**
- Verify only `packages/*/CHANGELOG.md` changed and links (#933, #935, #939) point to the correct PRs.
- Confirm the duplicated `coding-agent` entries accurately reflect the underlying behavior changes described above.

<sup>Written for commit 97ddb43d58f9630cf218a202b6792711ec1f0711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

