### PR TITLE
fix(claude-sdk-oauth): persist headless restart continuity

### DIFF
--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-headless-restart-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-headless-restart-probe.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	bootHermeticStack,
+	SOURCE_ROOT,
+} from "./lib/claude-sdk-oauth-fullstack-harness.mjs";
+import { safeDetail } from "./lib/output-safety.mjs";
+
+const TURN_TIMEOUT_MS = 180_000;
+const marker = "ISSUE6981-HEADLESS-RESTART";
+const tsxImport = fileURLToPath(import.meta.resolve("tsx"));
+const evidenceArg = process.argv.indexOf("--evidence");
+const evidenceSlug = evidenceArg === -1 ? undefined : process.argv[evidenceArg + 1];
+
+function killTree(child) {
+	if (child.exitCode !== null) return;
+	try {
+		if (process.platform === "win32") child.kill("SIGKILL");
+		else process.kill(-child.pid, "SIGKILL");
+	} catch {
+		child.kill("SIGKILL");
+	}
+}
+
+function runCli(stack, args) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(
+			process.execPath,
+			["--import", tsxImport, join(SOURCE_ROOT, "cli.ts"), ...args],
+			{
+				cwd: stack.box.cwd,
+				detached: process.platform !== "win32",
+				env: { ...process.env },
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		const timeout = setTimeout(() => {
+			killTree(child);
+			reject(new Error(`CLI turn exceeded ${TURN_TIMEOUT_MS}ms`));
+		}, TURN_TIMEOUT_MS);
+		child.once("error", (error) => {
+			clearTimeout(timeout);
+			reject(error);
+		});
+		child.once("close", (code) => {
+			clearTimeout(timeout);
+			resolve({ code: code ?? -1, stdout, stderr });
+		});
+	});
+}
+
+function continuityFrom(stdout) {
+	const observations = [];
+	const visit = (value) => {
+		if (Array.isArray(value)) {
+			for (const item of value) visit(item);
+			return;
+		}
+		if (!value || typeof value !== "object") return;
+		if (value.type === "claude_sdk_oauth_session_continuity" && value.details) {
+			observations.push(value.details);
+		}
+		if (Array.isArray(value.diagnostics)) {
+			for (const diagnostic of value.diagnostics) {
+				if (diagnostic?.type === "claude_sdk_oauth_session_continuity") {
+					observations.push(diagnostic.details);
+				}
+			}
+		}
+		for (const nested of Object.values(value)) visit(nested);
+	};
+	for (const line of stdout.split("\n")) {
+		if (!line.trim()) continue;
+		try {
+			visit(JSON.parse(line));
+		} catch {}
+	}
+	return observations.filter(
+		(observation, index, all) =>
+			index ===
+			all.findIndex(
+				(candidate) =>
+					candidate.kind === observation.kind &&
+					candidate.reason === observation.reason &&
+					candidate.deltaMessages === observation.deltaMessages,
+			),
+	);
+}
+
+function listFiles(root) {
+	const files = [];
+	const walk = (directory) => {
+		for (const entry of readdirSync(directory, { withFileTypes: true })) {
+			const path = join(directory, entry.name);
+			if (entry.isDirectory()) walk(path);
+			else files.push(path);
+		}
+	};
+	walk(root);
+	return files;
+}
+
+const common = (sessionDir) => [
+	"-p",
+	"--provider",
+	"claude-sdk-oauth",
+	"--model",
+	"claude-haiku-4-5",
+	"--thinking",
+	"off",
+	"--mode",
+	"json",
+	"--session-dir",
+	sessionDir,
+	"--no-tools",
+	"--no-context-files",
+	"--offline",
+	"--no-model-fallback",
+	"--no-recommended-models",
+	"--system-prompt",
+	"Reply with the requested marker only.",
+];
+
+let stack;
+let summary;
+try {
+	stack = await bootHermeticStack({ sandboxLabel: "issue-6981-headless-restart" });
+	const first = await runCli(stack, [...common(stack.box.sessionDir), `Reply exactly ${marker}-1.`]);
+	const second = await runCli(stack, [
+		...common(stack.box.sessionDir),
+		"-c",
+		`Reply exactly ${marker}-2.`,
+	]);
+	const firstContinuity = continuityFrom(first.stdout);
+	const secondContinuity = continuityFrom(second.stdout);
+	const sessionFiles = listFiles(stack.box.sessionDir);
+	const resumed = secondContinuity.some(
+		(observation) => observation.kind === "fork" && observation.reason === "registry_miss",
+	);
+	const flattened = secondContinuity.some(
+		(observation) => observation.kind === "flatten" || observation.kind === "bootstrap",
+	);
+	const passed =
+		first.code === 0 &&
+		second.code === 0 &&
+		sessionFiles.length > 0 &&
+		stack.providerRequests.length >= 2 &&
+		resumed &&
+		!flattened;
+	summary = {
+		passed,
+		first: { code: first.code, continuity: firstContinuity },
+		second: { code: second.code, continuity: secondContinuity },
+		sessionFileCount: sessionFiles.length,
+		providerRequests: stack.providerRequests.length,
+		stderr: {
+			first: [
+				...first.stderr.split("\n").filter(Boolean).slice(0, 5),
+				...first.stderr.split("\n").filter(Boolean).slice(-5),
+			].map((line) => safeDetail(line)),
+			second: [
+				...second.stderr.split("\n").filter(Boolean).slice(0, 5),
+				...second.stderr.split("\n").filter(Boolean).slice(-5),
+			].map((line) => safeDetail(line)),
+		},
+	};
+	if (evidenceSlug) {
+		const directory = join(
+			process.cwd(),
+			"local-ignore",
+			"qa-evidence",
+			`${new Date().toISOString().slice(0, 10).replaceAll("-", "")}-${evidenceSlug}`,
+		);
+		mkdirSync(directory, { recursive: true });
+		writeFileSync(join(directory, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+		process.stdout.write(`EVIDENCE ${join(directory, "summary.json")}\n`);
+	}
+	process.stdout.write(`${JSON.stringify(summary)}\n`);
+	process.stdout.write(
+		passed
+			? "VERDICT: PASS claude-sdk-oauth headless restart continuity\n"
+			: "VERDICT: FAIL claude-sdk-oauth headless restart continuity\n",
+	);
+	process.exitCode = passed ? 0 : 1;
+} catch (error) {
+	process.stderr.write(`PROBE ERROR: ${safeDetail(error instanceof Error ? error.stack : String(error))}\n`);
+	process.exitCode = 2;
+} finally {
+	await stack?.shutdown();
+	stack?.authGuard.assertUnchanged();
+	stack?.box.cleanup();
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Headless Claude SDK OAuth continuation now restores its persisted SDK binding across separate CLI processes, so
+  `-p -c` resumes the existing lineage instead of resending the full conversation after a `registry_miss`.
 - Goals no longer stall after a settings hot-reload: a reload `session_start` now re-engages an active goal (re-arming the monitor backstop while wake sources are live, or queueing a continuation through the existing sessionStart admission) instead of parking it until the next user message; stopped goals still never auto-start on reload ([#936](https://github.com/code-yeongyu/senpi/pull/936)).
 - Cursor CLI OAuth is now available by default when its real prerequisites exist: with `cursor-agent` installed and no managed CLI account, a native `cursor` OAuth credential is copied automatically into one canonical `native` slot without modifying the primary credential; explicit `enabled: false` remains a hard opt-out, repeated/concurrent startup is idempotent, and `/login cursor` refreshes the CLI fallback in the same session ([#931](https://github.com/code-yeongyu/senpi/pull/931)).
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,32 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-18 - Persist restart bindings for headless continuation (issue #6981)
+
+### What changed
+
+- Successful resident Claude SDK OAuth turns now append the complete continuity binding as a branch-local custom
+  session entry, including the SDK session id, sent-message hashes, assistant boundaries, account/model identity,
+  and prompt/tool fingerprints.
+- `session_start` restores the newest valid checkpoint into the resident binding map before the first resumed turn.
+  A missing, invalidated, or malformed checkpoint still fails closed to the existing bootstrap/flatten path.
+- Assistant rewrites and terminal failures do not persist a clean checkpoint.
+
+### Why
+
+- `omo -p -c` restores the Senpi JSONL session in a new process, but the SDK registry and binding maps are module
+  memory. The existing checkpoint parser was never wired into runtime append or restore, so every headless
+  continuation started without a binding and re-sent the full conversation with `registry_miss`.
+
+### Why an extension could not handle it
+
+- The binding contains private SDK lineage and sent-stream hashes created inside this builtin provider. No external
+  extension can reconstruct that state after the provider process exits.
+
+### Expected merge-conflict zones
+
+- MEDIUM in `session-binding.ts` and `session-registry-wiring.ts`; LOW in their focused tests and issue #6981
+  regression.
+
 ## Repository audit baseline for the claude-sdk-oauth tracker (2026-08-17)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts
@@ -1,4 +1,4 @@
-import type { ContinuityDecision } from "./session-continuity.ts";
+import type { ContinuityBinding } from "./session-reattach.ts";
 
 export const BINDING_ENTRY_TYPE = "claude-sdk-oauth-binding";
 
@@ -6,30 +6,47 @@ export type BindingCheckpoint = {
 	schemaVersion: 1;
 	sdkSessionId: string;
 	sentCount: number;
-	sentPrefixHash: string;
+	sentHashes: string[];
 	lastAssistantUuid: string | null;
+	assistantUuidByIndex: [number, string][];
 	accountName: string;
-	claudeConfigDir: string;
 	modelId: string;
+	systemPromptHash: string;
+	toolsetHash: string;
 };
 
 export type BindingInvalidation = { schemaVersion: 1; invalidated: true; reason: string };
 
 type BranchEntry = { type: string; customType?: string; data?: unknown };
 
-export type BindingVerificationInput = {
-	binding: BindingCheckpoint;
-	transcriptExists: boolean;
-	transcriptHasBoundaryUuid: boolean;
-	currentSentPrefixHash: string;
-};
-
 function isInvalidation(data: unknown): data is BindingInvalidation {
 	return typeof data === "object" && data !== null && (data as BindingInvalidation).invalidated === true;
 }
 
 function isCheckpoint(data: unknown): data is BindingCheckpoint {
-	return typeof data === "object" && data !== null && typeof (data as BindingCheckpoint).sdkSessionId === "string";
+	if (typeof data !== "object" || data === null) return false;
+	const checkpoint = data as Partial<BindingCheckpoint>;
+	return (
+		checkpoint.schemaVersion === 1 &&
+		typeof checkpoint.sdkSessionId === "string" &&
+		Number.isInteger(checkpoint.sentCount) &&
+		(checkpoint.sentCount ?? -1) >= 0 &&
+		Array.isArray(checkpoint.sentHashes) &&
+		checkpoint.sentHashes.every((hash) => typeof hash === "string") &&
+		(checkpoint.lastAssistantUuid === null || typeof checkpoint.lastAssistantUuid === "string") &&
+		Array.isArray(checkpoint.assistantUuidByIndex) &&
+		checkpoint.assistantUuidByIndex.every(
+			(boundary) =>
+				Array.isArray(boundary) &&
+				boundary.length === 2 &&
+				Number.isInteger(boundary[0]) &&
+				typeof boundary[1] === "string",
+		) &&
+		typeof checkpoint.accountName === "string" &&
+		typeof checkpoint.modelId === "string" &&
+		typeof checkpoint.systemPromptHash === "string" &&
+		typeof checkpoint.toolsetHash === "string"
+	);
 }
 
 export function latestBindingOnBranch(branch: readonly BranchEntry[]): BindingCheckpoint | undefined {
@@ -42,25 +59,32 @@ export function latestBindingOnBranch(branch: readonly BranchEntry[]): BindingCh
 	return undefined;
 }
 
-export function verifyBindingAgainstTranscript(input: BindingVerificationInput): ContinuityDecision {
-	const { binding } = input;
-	if (!input.transcriptExists) return { kind: "flatten", reason: "transcript_missing" };
-	if (!binding.lastAssistantUuid || !input.transcriptHasBoundaryUuid) {
-		return { kind: "flatten", reason: "branch_boundary_unavailable" };
-	}
-	if (input.currentSentPrefixHash === binding.sentPrefixHash) {
-		return {
-			kind: "reattach",
-			sdkSessionId: binding.sdkSessionId,
-			from: binding.sentCount,
-			reason: "registry_miss",
-		};
-	}
+export function checkpointFromBinding(binding: ContinuityBinding): BindingCheckpoint {
 	return {
-		kind: "fork",
+		schemaVersion: 1,
 		sdkSessionId: binding.sdkSessionId,
-		atUuid: binding.lastAssistantUuid,
-		from: binding.sentCount,
-		reason: "sent_stream_diverged",
+		sentCount: binding.sentCount,
+		sentHashes: [...binding.sentHashes],
+		lastAssistantUuid: binding.lastAssistantUuid,
+		assistantUuidByIndex: binding.assistantUuidByIndex?.map(([index, uuid]) => [index, uuid]) ?? [],
+		accountName: binding.accountName,
+		modelId: binding.modelId,
+		systemPromptHash: binding.systemPromptHash,
+		toolsetHash: binding.toolsetHash,
+	};
+}
+
+export function bindingFromCheckpoint(senpiSessionId: string, checkpoint: BindingCheckpoint): ContinuityBinding {
+	return {
+		senpiSessionId,
+		sdkSessionId: checkpoint.sdkSessionId,
+		sentCount: checkpoint.sentCount,
+		sentHashes: [...checkpoint.sentHashes],
+		lastAssistantUuid: checkpoint.lastAssistantUuid,
+		assistantUuidByIndex: checkpoint.assistantUuidByIndex.map(([index, uuid]) => [index, uuid]),
+		accountName: checkpoint.accountName,
+		modelId: checkpoint.modelId,
+		systemPromptHash: checkpoint.systemPromptHash,
+		toolsetHash: checkpoint.toolsetHash,
 	};
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-wiring.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-wiring.ts
@@ -1,8 +1,14 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "../../types.ts";
 import { CLAUDE_SDK_OAUTH_PROVIDER_ID } from "./account-management.ts";
+import {
+	BINDING_ENTRY_TYPE,
+	bindingFromCheckpoint,
+	checkpointFromBinding,
+	latestBindingOnBranch,
+} from "./session-binding.ts";
 import { AssistantCommitBoundary, isResidentAssistant, isTerminalFailure } from "./session-commit-boundary.ts";
-import { bindingFromEntry, rememberBinding } from "./session-reattach.ts";
+import { bindingFromEntry, getBinding, rememberBinding } from "./session-reattach.ts";
 import {
 	closeSession,
 	getSession,
@@ -25,7 +31,14 @@ function residentEntryFor(sessionId: string, message: AssistantMessage) {
 	return entry;
 }
 
-export function registerSessionRegistry(pi: Pick<ExtensionAPI, "on">): void {
+export function registerSessionRegistry(
+	pi: Pick<ExtensionAPI, "on"> & Partial<Pick<ExtensionAPI, "appendEntry">>,
+): void {
+	pi.on("session_start", (_event, ctx) => {
+		const checkpoint = latestBindingOnBranch(ctx.sessionManager.getBranch());
+		if (!checkpoint) return;
+		rememberBinding(bindingFromCheckpoint(ctx.sessionManager.getSessionId(), checkpoint));
+	});
 	pi.on("session_compact", (event, ctx) => {
 		if (!event.accepted) return;
 		recordPendingFork(ctx.sessionManager.getSessionId(), "compaction");
@@ -71,7 +84,10 @@ export function registerSessionRegistry(pi: Pick<ExtensionAPI, "on">): void {
 		}
 		if (commitBoundary.commit(sessionId, event.message, entry.modelId) === "rewritten") {
 			recordPendingFork(sessionId, "assistant_rewritten");
+			return;
 		}
+		const binding = getBinding(sessionId);
+		if (binding) pi.appendEntry?.(BINDING_ENTRY_TYPE, checkpointFromBinding(binding));
 	});
 	pi.on("session_shutdown", (event, ctx) => {
 		closeSession(ctx.sessionManager.getSessionId(), event.reason);

--- a/packages/coding-agent/test/claude-sdk-oauth-binding.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-binding.test.ts
@@ -2,20 +2,27 @@ import { describe, expect, it } from "vitest";
 import {
 	BINDING_ENTRY_TYPE,
 	type BindingCheckpoint,
+	bindingFromCheckpoint,
+	checkpointFromBinding,
 	latestBindingOnBranch,
-	verifyBindingAgainstTranscript,
 } from "../src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts";
+import type { ContinuityBinding } from "../src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts";
 
 function checkpoint(overrides: Partial<BindingCheckpoint> = {}): BindingCheckpoint {
 	return {
 		schemaVersion: 1,
 		sdkSessionId: "sdk-1",
 		sentCount: 2,
-		sentPrefixHash: "prefix-hash",
+		sentHashes: ["hash-1", "hash-2"],
 		lastAssistantUuid: "uuid-a2",
+		assistantUuidByIndex: [
+			[1, "uuid-a1"],
+			[2, "uuid-a2"],
+		],
 		accountName: "primary",
-		claudeConfigDir: "/home/user/.claude",
 		modelId: "claude-opus-4-5",
+		systemPromptHash: "prompt-v1",
+		toolsetHash: "tools-v1",
 		...overrides,
 	};
 }
@@ -48,47 +55,27 @@ describe("claude-sdk-oauth continuity binding", () => {
 		expect(latestBindingOnBranch(branch)).toBeUndefined();
 	});
 
-	it("reattaches when the transcript still holds the recorded boundary and prefix", () => {
-		const decision = verifyBindingAgainstTranscript({
-			binding: checkpoint(),
-			transcriptExists: true,
-			transcriptHasBoundaryUuid: true,
-			currentSentPrefixHash: "prefix-hash",
-		});
+	it("round-trips a process-local binding through a serializable checkpoint", () => {
+		const binding: ContinuityBinding = {
+			senpiSessionId: "senpi-1",
+			sdkSessionId: "sdk-1",
+			sentCount: 2,
+			sentHashes: ["hash-1", "hash-2"],
+			lastAssistantUuid: "uuid-a2",
+			assistantUuidByIndex: [
+				[1, "uuid-a1"],
+				[2, "uuid-a2"],
+			],
+			accountName: "primary",
+			modelId: "claude-opus-4-5",
+			systemPromptHash: "prompt-v1",
+			toolsetHash: "tools-v1",
+		};
 
-		expect(decision).toMatchObject({ kind: "reattach", sdkSessionId: "sdk-1", from: 2 });
+		expect(bindingFromCheckpoint("senpi-1", checkpointFromBinding(binding))).toEqual(binding);
 	});
 
-	it("forks at the boundary when the local prefix advanced past the checkpoint", () => {
-		const decision = verifyBindingAgainstTranscript({
-			binding: checkpoint(),
-			transcriptExists: true,
-			transcriptHasBoundaryUuid: true,
-			currentSentPrefixHash: "prefix-hash-moved",
-		});
-
-		expect(decision).toMatchObject({ kind: "fork", atUuid: "uuid-a2", reason: "sent_stream_diverged" });
-	});
-
-	it("flattens only when the SDK transcript is gone", () => {
-		const decision = verifyBindingAgainstTranscript({
-			binding: checkpoint(),
-			transcriptExists: false,
-			transcriptHasBoundaryUuid: false,
-			currentSentPrefixHash: "prefix-hash",
-		});
-
-		expect(decision).toEqual({ kind: "flatten", reason: "transcript_missing" });
-	});
-
-	it("flattens when the boundary uuid vanished from an existing transcript", () => {
-		const decision = verifyBindingAgainstTranscript({
-			binding: checkpoint(),
-			transcriptExists: true,
-			transcriptHasBoundaryUuid: false,
-			currentSentPrefixHash: "prefix-hash",
-		});
-
-		expect(decision).toMatchObject({ kind: "flatten", reason: "branch_boundary_unavailable" });
+	it("ignores malformed checkpoints instead of restoring partial state", () => {
+		expect(latestBindingOnBranch([entry(BINDING_ENTRY_TYPE, { ...checkpoint(), sentHashes: [42] })])).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/6981-claude-sdk-oauth-headless-restart-continuity.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6981-claude-sdk-oauth-headless-restart-continuity.test.ts
@@ -1,0 +1,151 @@
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SdkQueryHandle } from "../../../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import { BINDING_ENTRY_TYPE } from "../../../src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts";
+import { decideNativeContinuity } from "../../../src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts";
+import {
+	bindingFromEntry,
+	forgetBinding,
+	getBinding,
+	rememberBinding,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts";
+import {
+	closeSession,
+	getOrCreateSession,
+	overrideSessionRegistryBoundary,
+	resetSessionRegistryBoundary,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/session-registry.ts";
+import { registerSessionRegistry } from "../../../src/core/extensions/builtin/claude-sdk-oauth/session-registry-wiring.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../../src/core/extensions/types.ts";
+
+type EventHandler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function fakeQuery(): SdkQueryHandle {
+	return {
+		async *[Symbol.asyncIterator](): AsyncGenerator<SDKMessage> {},
+		async interrupt() {},
+		close() {},
+	};
+}
+
+function fakeExtension() {
+	const handlers = new Map<string, EventHandler[]>();
+	const persisted: Array<{ customType: string; data: unknown }> = [];
+	const api = {
+		on(event: string, handler: EventHandler): void {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		appendEntry(customType: string, data: unknown): void {
+			persisted.push({ customType, data });
+		},
+	} as unknown as ExtensionAPI;
+	return { api, handlers, persisted };
+}
+
+function assistant(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "turn one" }],
+		api: "claude-sdk-oauth",
+		provider: "claude-sdk-oauth",
+		model: "claude-test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+async function emit(
+	handlers: Map<string, EventHandler[]>,
+	eventName: string,
+	event: unknown,
+	ctx: ExtensionContext,
+): Promise<void> {
+	const registered = handlers.get(eventName) ?? [];
+	expect(registered).toHaveLength(1);
+	for (const handler of registered) await handler(event, ctx);
+}
+
+afterEach(() => {
+	closeSession("issue-6981", "test_cleanup");
+	forgetBinding("issue-6981");
+	resetSessionRegistryBoundary();
+});
+
+describe("issue #6981 headless restart continuity", () => {
+	it("persists the SDK binding in the session branch and restores it on startup", async () => {
+		overrideSessionRegistryBoundary({ queryFactory: () => fakeQuery() });
+		const entry = getOrCreateSession({
+			senpiSessionId: "issue-6981",
+			accountName: "default",
+			modelId: "claude-test",
+			systemPromptHash: "prompt-v1",
+			toolsetHash: "tools-v1",
+			options: {},
+		});
+		entry.sentCount = 1;
+		entry.assistantUuidByIndex.set(1, "assistant-uuid-1");
+		rememberBinding(bindingFromEntry(entry, ["user-hash-1"]));
+
+		const extension = fakeExtension();
+		registerSessionRegistry(extension.api);
+		const firstContext = {
+			sessionManager: {
+				getSessionId: () => "issue-6981",
+				getBranch: () => [],
+			},
+		} as unknown as ExtensionContext;
+
+		await emit(extension.handlers, "message_end", { type: "message_end", message: assistant() }, firstContext);
+
+		expect(extension.persisted).toHaveLength(1);
+		expect(extension.persisted[0]).toMatchObject({ customType: BINDING_ENTRY_TYPE });
+
+		closeSession("issue-6981", "process_exit");
+		forgetBinding("issue-6981");
+		expect(getBinding("issue-6981")).toBeUndefined();
+
+		const restarted = fakeExtension();
+		registerSessionRegistry(restarted.api);
+		const restartContext = {
+			sessionManager: {
+				getSessionId: () => "issue-6981",
+				getBranch: () => [
+					{
+						type: "custom",
+						customType: extension.persisted[0]!.customType,
+						data: extension.persisted[0]!.data,
+					},
+				],
+			},
+		} as unknown as ExtensionContext;
+
+		await emit(restarted.handlers, "session_start", { type: "session_start", reason: "resume" }, restartContext);
+
+		const restored = getBinding("issue-6981");
+		expect(restored).toMatchObject({
+			sdkSessionId: entry.sdkSessionId,
+			sentCount: 1,
+			lastAssistantUuid: "assistant-uuid-1",
+		});
+		expect(
+			decideNativeContinuity({
+				entry: undefined,
+				binding: restored,
+				currentHashes: ["user-hash-1"],
+				accountName: "default",
+				modelId: "claude-test",
+				fingerprint: { systemPromptHash: "prompt-v1", toolsetHash: "tools-v1" },
+				transcriptAvailable: true,
+			}),
+		).toMatchObject({ kind: "reattach", reason: "registry_miss" });
+	});
+});


### PR DESCRIPTION
## Summary

Fix headless Claude SDK OAuth continuation losing prompt-cache continuity across separate `senpi` / `omo -p -c` processes.

The coding-agent session JSONL was restored correctly, but the Claude SDK session registry and continuity binding were process-local maps. Although `session-binding.ts` already defined a branch-local checkpoint format, production never wrote or restored that checkpoint. A resumed process therefore cold-seeded with `registry_miss` and resent the full conversation.

## Changes

- Persist the complete `ContinuityBinding` as a branch-local custom session entry after clean resident assistant commits.
- Restore the newest valid checkpoint during `session_start` before the resumed provider turn.
- Strictly reject malformed checkpoints and retain the existing fail-closed flatten behavior.
- Avoid persisting terminal failures and rewritten assistant messages as clean checkpoints.
- Add issue-specific restart regression coverage.
- Add a permanent hermetic probe that launches two separate source CLI processes against the real Claude SDK subprocess path with loopback-only Anthropic traffic.
- Record the user-facing fix under the coding-agent `[Unreleased]` changelog.

## QA & Evidence

- Focused continuity validation:
  - `4` test files passed.
  - `31` tests passed.
- Adjacent continuity validation:
  - `8` test files passed.
  - `62` tests passed.
- Full coding-agent suite:
  - `988` files passed, `4` pre-existing skipped.
  - `8,133` tests passed, `36` pre-existing skipped.
- Static/build:
  - `npm run check`
  - `npm run build -w packages/coding-agent`
- Real two-process surface:

```text
first process  -> bootstrap / registry_miss
second -p -c   -> fork / registry_miss
second flatten -> false
session files  -> 1
provider calls -> 2
stderr         -> empty
```

Command:

```bash
node .agents/skills/senpi-qa/scripts/claude-sdk-oauth-headless-restart-probe.mjs \
  --evidence issue-6981-headless-restart
```

The probe uses an isolated agent directory and loopback SSE server, starts two independent CLI OS processes, and cleans its subprocesses, server, credentials sandbox, and temporary files.

## Risks & Residuals

- The checkpoint is internal provider state and does not participate in model context.
- Invalid or missing persisted state still takes the existing bootstrap/flatten path.
- The direct live Fable reproduction was attempted twice, but both bounded runs hung before the first NDJSON event. The regression and permanent QA probe therefore use the actual Claude SDK subprocess and two real CLI process boundaries with loopback-only provider traffic.
- No cache policy or intentional `options_changed`, model-change, fork, abort, or failover behavior is relaxed.

## Related Issues

- Related: https://github.com/code-yeongyu/oh-my-openagent/issues/6981
- Supersedes #941, whose merge-history-only diff confused the changelog gate despite an identical six-file implementation diff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores headless Claude SDK OAuth continuation across CLI restarts by persisting and restoring the provider continuity binding. Previously `omo -p -c`/`senpi` restarted with a `registry_miss` and resent the full conversation; now the resumed process reattaches to the existing lineage, falling back to bootstrap/flatten only when a checkpoint is missing or invalid.

**Review notes**
- On clean assistant commit, append the full continuity binding as a branch-local custom session entry; exclude terminal failures and rewritten messages.
- On `session_start`, restore the newest valid checkpoint into the in-memory binding map before the next provider turn; strict schema validation rejects malformed entries.
- Probe and tests: adds a hermetic two-process restart probe (`.agents/skills/senpi-qa/scripts/claude-sdk-oauth-headless-restart-probe.mjs`) and a focused regression test.
- Main diffs: `session-binding.ts` (checkpoint serialize/deserialize) and `session-registry-wiring.ts` (persist on commit, restore on start); minor docs and `CHANGELOG.md`.

<sup>Written for commit e476fc79c5135ebbc74c80f8af7345d3f4f4b4a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

