### PR TITLE
fix(coding-agent): select Claude binary by host libc

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Claude SDK OAuth now selects the glibc Claude Code binary before the musl variant on glibc Linux hosts and when libc detection is unavailable, while retaining musl-first selection on detected musl hosts and fallback to either installed package ([code-yeongyu/oh-my-openagent#6963](https://github.com/code-yeongyu/oh-my-openagent/issues/6963)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,24 @@
 # claude-sdk-oauth extension changes
 
+## 2026-08-18 - Select the Claude binary for the host libc
+
+### What changed
+
+- Linux executable resolution now tries the glibc package first on glibc hosts and when libc detection is unavailable, and tries the musl package first only when `process.report` identifies musl.
+- The libc detector is injectable for deterministic coverage, while the non-preferred Linux package remains a fallback and `CLAUDE_CODE_EXECUTABLE` remains the highest-priority override.
+
+### Why
+
+- The resolver previously selected the musl package first on every Linux host. When both optional packages were installed on glibc, the chosen binary exited with code 127 because `/lib/ld-musl-*` was unavailable.
+
+### Why an extension could not handle it
+
+- The executable path is resolved inside this builtin provider before SDK query construction and ambient authentication probes; no external extension hook can replace that private boundary.
+
+### Expected merge conflict zones
+
+- LOW: `executable.ts` around Linux candidate ordering and default dependency detection.
+
 ## Repository audit baseline for the claude-sdk-oauth tracker (2026-08-17)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/executable.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/executable.ts
@@ -6,17 +6,17 @@ export type ExecutableDeps = {
 	arch: string;
 	env: (name: string) => string | undefined;
 	resolve: (spec: string) => string;
+	isMusl?: () => boolean;
 	isCompiledBun?: () => boolean;
 	extractFromBunfs?: (embeddedPath: string) => string;
 };
 
-export function claudeCodeExecutableCandidates(platform: string, arch: string): string[] {
+export function claudeCodeExecutableCandidates(platform: string, arch: string, preferMusl = false): string[] {
 	const ext = platform === "win32" ? ".exe" : "";
 	if (platform === "linux") {
-		return [
-			`@anthropic-ai/claude-agent-sdk-linux-${arch}-musl/claude${ext}`,
-			`@anthropic-ai/claude-agent-sdk-linux-${arch}/claude${ext}`,
-		];
+		const glibc = `@anthropic-ai/claude-agent-sdk-linux-${arch}/claude${ext}`;
+		const musl = `@anthropic-ai/claude-agent-sdk-linux-${arch}-musl/claude${ext}`;
+		return preferMusl ? [musl, glibc] : [glibc, musl];
 	}
 	return [`@anthropic-ai/claude-agent-sdk-${platform}-${arch}/claude${ext}`];
 }
@@ -36,7 +36,11 @@ export function resolveClaudeCodeExecutable(deps: ExecutableDeps): string {
 	const override = deps.env("CLAUDE_CODE_EXECUTABLE");
 	if (override) return override;
 
-	const candidates = claudeCodeExecutableCandidates(deps.platform, deps.arch);
+	const candidates = claudeCodeExecutableCandidates(
+		deps.platform,
+		deps.arch,
+		deps.platform === "linux" && deps.isMusl?.() === true,
+	);
 
 	if (deps.isCompiledBun?.() && deps.extractFromBunfs) {
 		const embedded = firstResolvable(candidates, deps.resolve);
@@ -63,11 +67,21 @@ let defaultRequire: ReturnType<typeof createRequire> | null = null;
 const isCompiledBunBinary =
 	import.meta.url.includes("$bunfs") || import.meta.url.includes("~BUN") || import.meta.url.includes("%7EBUN");
 
+function isMuslLinuxRuntime(): boolean {
+	if (process.platform !== "linux" || typeof process.report?.getReport !== "function") return false;
+	const report = process.report.getReport();
+	if (report === null || !("header" in report) || typeof report.header !== "object" || report.header === null) {
+		return false;
+	}
+	return !("glibcVersionRuntime" in report.header) || report.header.glibcVersionRuntime === undefined;
+}
+
 export function defaultExecutableDeps(): ExecutableDeps {
 	return {
 		platform: process.platform,
 		arch: process.arch,
 		env: (name) => process.env[name],
+		isMusl: isMuslLinuxRuntime,
 		isCompiledBun: () => isCompiledBunBinary,
 		extractFromBunfs,
 		resolve: (spec) => {

--- a/packages/coding-agent/test/claude-sdk-oauth-executable.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-executable.test.ts
@@ -30,15 +30,15 @@ describe("claudeCodeExecutableCandidates", () => {
 		]);
 	});
 
-	it("tries musl first, then glibc on linux-x64", () => {
+	it("tries glibc first, then musl on linux-x64 by default", () => {
 		expect(claudeCodeExecutableCandidates("linux", "x64")).toEqual([
-			"@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude",
 			"@anthropic-ai/claude-agent-sdk-linux-x64/claude",
+			"@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude",
 		]);
 	});
 
-	it("tries musl first, then glibc on linux-arm64", () => {
-		expect(claudeCodeExecutableCandidates("linux", "arm64")).toEqual([
+	it("tries musl first, then glibc on a musl linux-arm64 host", () => {
+		expect(claudeCodeExecutableCandidates("linux", "arm64", true)).toEqual([
 			"@anthropic-ai/claude-agent-sdk-linux-arm64-musl/claude",
 			"@anthropic-ai/claude-agent-sdk-linux-arm64/claude",
 		]);
@@ -55,15 +55,74 @@ describe("resolveClaudeCodeExecutable", () => {
 	it("honors CLAUDE_CODE_EXECUTABLE before anything else", () => {
 		const deps = makeDeps({
 			env: (name) => (name === "CLAUDE_CODE_EXECUTABLE" ? "/custom/claude" : undefined),
+			isMusl: () => {
+				throw new Error("must not detect libc when overridden");
+			},
 		});
 		expect(resolveClaudeCodeExecutable(deps)).toBe("/custom/claude");
 	});
 
-	it("resolves the first candidate that exists", () => {
+	it("prefers glibc on a glibc Linux host", () => {
 		const seen: string[] = [];
 		const deps = makeDeps({
 			platform: "linux",
 			arch: "x64",
+			isMusl: () => false,
+			resolve: (spec) => {
+				seen.push(spec);
+				return `/resolved/${spec}`;
+			},
+		});
+		expect(resolveClaudeCodeExecutable(deps)).toBe("/resolved/@anthropic-ai/claude-agent-sdk-linux-x64/claude");
+		expect(seen).toEqual(["@anthropic-ai/claude-agent-sdk-linux-x64/claude"]);
+	});
+
+	it("prefers musl on a musl Linux host", () => {
+		const deps = makeDeps({
+			platform: "linux",
+			arch: "arm64",
+			isMusl: () => true,
+			resolve: (spec) => `/resolved/${spec}`,
+		});
+		expect(resolveClaudeCodeExecutable(deps)).toBe(
+			"/resolved/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/claude",
+		);
+	});
+
+	it("defaults to glibc when libc detection is inconclusive", () => {
+		const deps = makeDeps({
+			platform: "linux",
+			arch: "x64",
+			resolve: (spec) => `/resolved/${spec}`,
+		});
+		expect(resolveClaudeCodeExecutable(deps)).toBe("/resolved/@anthropic-ai/claude-agent-sdk-linux-x64/claude");
+	});
+
+	it("falls back to musl when only that Linux package is installed", () => {
+		const seen: string[] = [];
+		const deps = makeDeps({
+			platform: "linux",
+			arch: "x64",
+			isMusl: () => false,
+			resolve: (spec) => {
+				seen.push(spec);
+				if (!spec.includes("musl")) throw new Error("not found");
+				return `/resolved/${spec}`;
+			},
+		});
+		expect(resolveClaudeCodeExecutable(deps)).toBe("/resolved/@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude");
+		expect(seen).toEqual([
+			"@anthropic-ai/claude-agent-sdk-linux-x64/claude",
+			"@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude",
+		]);
+	});
+
+	it("falls back to glibc when only that Linux package is installed", () => {
+		const seen: string[] = [];
+		const deps = makeDeps({
+			platform: "linux",
+			arch: "x64",
+			isMusl: () => true,
 			resolve: (spec) => {
 				seen.push(spec);
 				if (spec.includes("musl")) throw new Error("not found");


### PR DESCRIPTION
## Root cause

`packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/executable.ts:13-19` ordered the musl package before the glibc package on every Linux host. `resolveClaudeCodeExecutable` then accepted the first installed candidate and supplied that concrete path to both SDK queries and the ambient auth probe. With both optional packages installed on glibc Linux, the musl binary therefore won and exited 127 because `/lib/ld-musl-*` was absent.

## What changed

- Added an injectable `isMusl` dependency to the existing executable resolver dependencies.
- Matched the pinned Anthropic SDK's libc preference: glibc-first when glibc is reported or detection is inconclusive, musl-first only when musl is detected.
- Retained the non-preferred Linux package as a fallback for single-package installs.
- Kept `CLAUDE_CODE_EXECUTABLE` as the highest-priority override and left non-Linux selection unchanged.
- Added focused glibc, musl, inconclusive, bidirectional fallback, and override-precedence coverage.
- Added the required package changelog and extension tracker entries.

## RED evidence

Command:

```text
cd packages/coding-agent && npm test -- claude-sdk-oauth-executable.test.ts
```

Result before the runtime fix: **1 file failed; 3 tests failed, 10 passed**.

Failing assertion:

```text
FAIL  test/claude-sdk-oauth-executable.test.ts > claudeCodeExecutableCandidates > tries glibc first, then musl on linux-x64 by default
AssertionError: expected [ …(2) ] to deeply equal [ …(2) ]

- Expected
+ Received

  [
-   "@anthropic-ai/claude-agent-sdk-linux-x64/claude",
    "@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude",
+   "@anthropic-ai/claude-agent-sdk-linux-x64/claude",
  ]
```

The glibc-host and inconclusive-detection resolver assertions likewise received `@anthropic-ai/claude-agent-sdk-linux-x64-musl/claude` instead of the glibc path.

## GREEN evidence

```text
cd packages/coding-agent && npm test -- claude-sdk-oauth-executable.test.ts
```

- **1 test file passed; 14 tests passed, 0 failed**

```text
cd packages/coding-agent && npm test -- test/claude-sdk-oauth-*.test.ts test/suite/claude-sdk-oauth-*.test.ts
```

- **46 test files passed; 373 tests passed, 3 skipped, 0 failed**

```text
npm run check
```

- **PASS**: Biome checked 3,096 files with no fixes; pinned dependency, TS import, shrinkwrap, install-lock, Claude SDK platform-lock, repository `tsc --noEmit`, and browser-smoke checks all passed.

```text
node scripts/check-pr-changelog.mjs --base origin/main
```

- **PASS**: changelog entry present and changes.md coverage complete.

```text
node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test
```

- **8/8 passed**

```text
node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test
```

- **48/48 passed**

## Risk assessment

Low and Linux-only. The change affects candidate order, not package resolution or process spawning. Unknown libc defaults to glibc-first, matching the SDK; the alternate package remains available as fallback. The environment override, compiled-Bun extraction path, ambient auth probe, and all non-Linux package names are deliberately unchanged.

Fixes code-yeongyu/oh-my-openagent#6963

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selects the Claude Code binary by host libc on Linux. Previously the resolver always tried the musl package first; now it prefers glibc unless musl is detected, preventing exit 127 on glibc hosts when both packages are installed.

- Reorders Linux candidates in `claudeCodeExecutableCandidates(platform, arch, preferMusl)` to `[glibc, musl]` by default and `[musl, glibc]` only when `isMusl` is true; retains fallback to the other package if the first is missing.
- Adds an injectable `isMusl` (defaults to glibc-first when detection is absent or inconclusive) and wires it into `resolveClaudeCodeExecutable`.
- Keeps `CLAUDE_CODE_EXECUTABLE` as the highest-priority override and leaves non-Linux and Bun extraction behavior unchanged.
- Updates tests and docs to cover glibc-first, musl-first, inconclusive detection, bidirectional fallbacks, and override precedence.
- Risk is low and Linux-only; package names involved: `@anthropic-ai/claude-agent-sdk-linux-${arch}` and `@anthropic-ai/claude-agent-sdk-linux-${arch}-musl`.

<sup>Written for commit b23a08ee2b28f423d10d93fd17eac074fd891c41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

