### PR TITLE
fix(packaging): preserve codemode Babel closure

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Published Senpi tarballs now retain the lockfile-recorded Babel 8 dependency closure inside the bundled codemode sidecar, preventing `@babel/parser` resolution failures during extension startup ([#923](https://github.com/code-yeongyu/senpi/issues/923)).
 - Headless Claude SDK OAuth continuation now restores its persisted SDK binding across separate CLI processes, so
   `-p -c` resumes the existing lineage instead of resending the full conversation after a `registry_miss`.
 

--- a/scripts/prepare-senpi-bundled-workspaces-pack.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces-pack.test.mjs
@@ -111,6 +111,7 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json" },
 				{ path: "package/node_modules/cross-spawn/package.json" },
 				{ path: "package/node_modules/@modelcontextprotocol/sdk/package.json" },
 			],
@@ -157,7 +158,7 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 		);
 	});
 
-	it("accepts senpi package metadata that includes bundled workspace entrypoints", () => {
+	it("rejects senpi package metadata that omits the codemode Babel parser", () => {
 		// Given
 		const hostPrebuild = nativePrebuildFile(nativePrebuildTarget());
 		const packed = {
@@ -182,7 +183,10 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 		};
 
 		// When / Then
-		assert.doesNotThrow(() => assertSenpiPackedWorkspaceFiles(packed));
+		assert.throws(
+			() => assertSenpiPackedWorkspaceFiles(packed),
+			/missing bundled workspace files: .*senpi-codemode\/node_modules\/@babel\/parser\/package\.json/,
+		);
 	});
 
 	it("accepts npm dry-run package metadata with unprefixed paths", () => {
@@ -206,6 +210,7 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 				{ path: "node_modules/@code-yeongyu/senpi-codemode/package.json" },
 				{ path: "node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
 				{ path: "node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json" },
 			],
 		};
 
@@ -257,6 +262,7 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json" },
 			],
 		};
 
@@ -291,6 +297,7 @@ describe("assertSenpiPackedWorkspaceFiles", () => {
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
 				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+				{ path: "package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json" },
 			],
 		};
 

--- a/scripts/prepare-senpi-bundled-workspaces.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.mjs
@@ -252,6 +252,32 @@ export function directNodeModulesPackageName(lockPath) {
 	return parts.length === 1 ? parts[0] : undefined;
 }
 
+function nestedWorkspacePackageName(lockPath, workspacePackageName) {
+	const prefix = `node_modules/${workspacePackageName}/node_modules/`;
+	if (!lockPath.startsWith(prefix)) return undefined;
+	const packageName = directNodeModulesPackageName(`node_modules/${lockPath.slice(prefix.length)}`);
+	return packageName?.startsWith(".") ? undefined : packageName;
+}
+
+function copyNestedWorkspaceDependencies(repoRoot, manifest, workspace, targetRoot) {
+	const sourceNodeModules = join(repoRoot, workspace.source, "node_modules");
+	const targetNodeModules = join(targetRoot, "node_modules");
+	for (const [lockPath, entry] of Object.entries(manifest.packages ?? {}).sort(([a], [b]) => a.localeCompare(b))) {
+		const packageName = nestedWorkspacePackageName(lockPath, workspace.packageName);
+		if (!packageName) continue;
+
+		const sourcePath = join(sourceNodeModules, packageName);
+		if (!existsSync(sourcePath)) {
+			if (entry && typeof entry === "object" && entry.optional === true) continue;
+			throw new Error(`Missing ${sourcePath}. Run npm install before publishing.`);
+		}
+
+		const targetPath = join(targetNodeModules, packageName);
+		mkdirSync(dirname(targetPath), { recursive: true });
+		cpSync(sourcePath, targetPath, { recursive: true });
+	}
+}
+
 export function copyPublishDependencies(repoRoot) {
 	// Staging manifest for the bundled publish tree. NOT npm-shrinkwrap.json: shipping a
 	// file named npm-shrinkwrap.json breaks bundleDependencies installs (see the guard in
@@ -280,6 +306,7 @@ export function copyPublishDependencies(repoRoot) {
 		mkdirSync(dirname(targetPath), { recursive: true });
 		cpSync(sourcePath, targetPath, { recursive: true });
 	}
+	return manifest;
 }
 
 export function assertSenpiPackedWorkspaceFiles(packed, options = {}) {
@@ -342,6 +369,10 @@ export function assertSenpiPackedWorkspaceFiles(packed, options = {}) {
 			missing.push(`${path} or ${dryRunPath}`);
 		}
 	}
+	const codemodeParserPackageJson = "node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json";
+	if (!filePaths.has(`package/${codemodeParserPackageJson}`) && !filePaths.has(codemodeParserPackageJson)) {
+		missing.push(`package/${codemodeParserPackageJson} or ${codemodeParserPackageJson}`);
+	}
 	for (const { target, requiredFiles } of vendoredWorkspacePackageChecks()) {
 		const packageRoot = `package/vendor/${target}`;
 		const dryRunPackageRoot = `vendor/${target}`;
@@ -360,7 +391,7 @@ export function assertSenpiPackedWorkspaceFiles(packed, options = {}) {
 }
 
 export function prepareSenpiBundledWorkspaces(repoRoot = root) {
-	copyPublishDependencies(repoRoot);
+	const publishDependencies = copyPublishDependencies(repoRoot);
 	const codingAgentNodeModules = join(repoRoot, "packages/coding-agent/node_modules");
 
 	for (const workspace of bundledWorkspaces) {
@@ -399,6 +430,9 @@ export function prepareSenpiBundledWorkspaces(repoRoot = root) {
 			recursive: true,
 			filter: (sourcePath) => shouldCopyWorkspaceFile(sourceRoot, sourcePath, workspace.sourceOnly),
 		});
+		if (workspace.sourceOnly) {
+			copyNestedWorkspaceDependencies(repoRoot, publishDependencies, workspace, targetRoot);
+		}
 		rewriteBundledWorkspaceManifest(targetRoot);
 	}
 

--- a/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
+++ b/scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
@@ -193,6 +193,9 @@ describe("prepareSenpiBundledWorkspaces", () => {
 			"": { dependencies: { "cross-spawn": "7.0.6" } },
 			"node_modules/cross-spawn": { version: "7.0.6" },
 			"node_modules/which": { version: "2.0.2" },
+			"node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser": { version: "8.0.4" },
+			"node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/types": { version: "8.0.4" },
+			"node_modules/@code-yeongyu/senpi-codemode/node_modules/typebox": { version: "1.3.8" },
 		});
 		writeCodingAgentManifest(tempDir);
 		const publicDeclarationPath = join(tempDir, "packages", "coding-agent", "dist", "client", "remote-session.d.ts");
@@ -225,6 +228,17 @@ describe("prepareSenpiBundledWorkspaces", () => {
 		for (const name of ["cross-spawn", "which"]) {
 			writeJson(join(tempDir, "node_modules", name, "package.json"), { name, version: "1.0.0" });
 		}
+		for (const name of ["@babel/parser", "@babel/types", "@babel/unlocked", "typebox"]) {
+			writeJson(join(tempDir, "packages", "senpi-codemode", "node_modules", name, "package.json"), {
+				name,
+				version: "8.0.4",
+			});
+		}
+		for (const artifact of [".bin", ".vite"]) {
+			writeJson(join(tempDir, "packages", "senpi-codemode", "node_modules", artifact, "package.json"), {
+				name: `${artifact}-artifact`,
+			});
+		}
 
 		// When
 		prepareSenpiBundledWorkspaces(tempDir);
@@ -246,6 +260,21 @@ describe("prepareSenpiBundledWorkspaces", () => {
 				name,
 			);
 		}
+		const stagedCodemodeNodeModules = join(
+			tempDir,
+			"packages",
+			"coding-agent",
+			"node_modules",
+			"@code-yeongyu",
+			"senpi-codemode",
+			"node_modules",
+		);
+		for (const name of ["@babel/parser", "@babel/types", "typebox"]) {
+			assert.equal(JSON.parse(readFileSync(join(stagedCodemodeNodeModules, name, "package.json"), "utf8")).name, name);
+		}
+		assert.equal(existsSync(join(stagedCodemodeNodeModules, "@babel/unlocked")), false);
+		assert.equal(existsSync(join(stagedCodemodeNodeModules, ".bin")), false);
+		assert.equal(existsSync(join(stagedCodemodeNodeModules, ".vite")), false);
 		// ...and the manifest lists every registry-backed staged package. Client and
 		// protocol are ordinary vendored files with relative declaration imports, so
 		// Bun never sees registry edges for their unpublished upstream package names.

--- a/scripts/prepare-senpi-publish-optionals.test.mjs
+++ b/scripts/prepare-senpi-publish-optionals.test.mjs
@@ -32,6 +32,7 @@ it("accepts consumer-resolved platform optionals outside the packed bundle", () 
 			{ path: "package/node_modules/@code-yeongyu/senpi-codemode/package.json" },
 			{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/index.ts" },
 			{ path: "package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/py/prelude.py" },
+			{ path: "package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json" },
 			{ path: "package/node_modules/@anthropic-ai/claude-agent-sdk/package.json" },
 		],
 	};


### PR DESCRIPTION
## Root cause

`packages/senpi-codemode/src/kernels/js/rewrite-imports.ts:1` imports `@babel/parser`, but publish staging only accepted direct lock paths through `directNodeModulesPackageName()` at `scripts/prepare-senpi-bundled-workspaces.mjs:243-252`. The codemode closure is recorded under `node_modules/@code-yeongyu/senpi-codemode/node_modules/**`, so `copyPublishDependencies()` at `scripts/prepare-senpi-bundled-workspaces.mjs:281-309` skipped every Babel 8 package. The subsequent source-only workspace copy filtered out `node_modules`, leaving the packed sidecar unable to resolve its parser.

## What changed

- Preserve package roots recorded beneath the source-only workspace's nested lock path and copy them from `packages/senpi-codemode/node_modules` into the staged sidecar's own `node_modules`.
- Keep the nested layout, so codemode's Babel 8 closure does not conflict with root Babel 7 packages.
- Drive staging only from `publish-deps.lock.json`; fixture coverage confirms unrecorded packages, `.bin`, and `.vite` are not copied.
- Require `node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json` in packed-file validation.
- Add the coding-agent changelog entry.

## RED evidence

```text
$ node --test scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs
✖ rewrites the publish manifest so bundleDependencies covers every staged package
Error: ENOENT: no such file or directory, open '.../packages/coding-agent/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json'
ℹ tests 6
ℹ pass 5
ℹ fail 1
```

```text
$ node --test scripts/prepare-senpi-bundled-workspaces-pack.test.mjs
✖ rejects senpi package metadata that omits the codemode Babel parser
AssertionError [ERR_ASSERTION]: Missing expected exception.
ℹ tests 12
ℹ pass 11
ℹ fail 1
```

## GREEN evidence

```text
$ node --test scripts/prepare-senpi-bundled-workspaces.test.mjs scripts/prepare-senpi-bundled-workspaces.prepare.test.mjs scripts/prepare-senpi-bundled-workspaces-pack.test.mjs scripts/prepare-senpi-publish-optionals.test.mjs
ℹ tests 31
ℹ suites 7
ℹ pass 31
ℹ fail 0
```

```text
$ npm run test:scripts
ℹ tests 179
ℹ suites 47
ℹ pass 179
ℹ fail 0
```

```text
$ npx tsx node_modules/vitest/dist/cli.js --run packages/senpi-codemode/test/js-rewrite-imports.test.ts
Test Files  1 passed (1)
Tests  12 passed (12)
```

```text
$ npm run check
Checked 3097 files in 3s. No fixes applied.
packages/coding-agent/publish-deps.lock.json is up to date.
packages/coding-agent/install-lock is up to date.
Claude Agent SDK platform packages are locked.
(exit 0, including tsc --noEmit and browser smoke)
```

```text
$ npm run publish:dry
Staged 240 bundled packages for @code-yeongyu/senpi publish.
@code-yeongyu/senpi@2026.8.18-2 is already published; validating package contents only.
$ npm pack --dry-run --ignore-scripts --json
  code-yeongyu-senpi-2026.8.18-2.tgz: 31603 files, 33975272 bytes packed, 172335005 bytes unpacked
```

```text
$ npm pack --ignore-scripts --json
code-yeongyu-senpi-2026.8.18-2.tgz: 31603 files, 33975277 bytes packed, 172335023 bytes unpacked

$ tar -tzf code-yeongyu-senpi-2026.8.18-2.tgz | rg 'senpi-codemode/node_modules/@babel/parser/package.json'
package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json

$ tar -tzf code-yeongyu-senpi-2026.8.18-2.tgz | rg 'senpi-codemode/node_modules/@babel/(helper-string-parser|helper-validator-identifier|parser|types)/package.json'
package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/helper-string-parser/package.json
package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/helper-validator-identifier/package.json
package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json
package/node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/types/package.json

$ <extract tarball and load rewrite-imports.ts through the tarball's bundled jiti>
Loaded .../package/node_modules/@code-yeongyu/senpi-codemode/src/kernels/js/rewrite-imports.ts
rewriteImports export: function
```

The packed archive also reports `No codemode node_modules/.bin or .vite entries`.

## Risk assessment

Low and limited to publish staging/tarball contents. The copy set comes from the generated publish lock, preserves npm's nested dependency boundary, and leaves root runtime dependencies and root Babel versions unchanged. This does not promote Babel to Senpi's root runtime manifest, alter codemode source behavior, or change standalone-binary sidecar assembly.

Fixes #923


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the codemode’s Babel 8 dependency closure in the bundled publish tree so `@babel/parser` resolves during extension startup. Previously, staging skipped nested workspace `node_modules`, so `@code-yeongyu/senpi-codemode` shipped without its parser.

- Copy nested workspace dependencies recorded under `node_modules/@code-yeongyu/senpi-codemode/node_modules/*` from `publish-deps.lock.json`, pulling from `packages/senpi-codemode/node_modules` and preserving the nested layout to avoid conflicts with root Babel 7.
- Exclude unrecorded packages and tooling artifacts; `.bin` and `.vite` are not copied.
- Require `node_modules/@code-yeongyu/senpi-codemode/node_modules/@babel/parser/package.json` in `assertSenpiPackedWorkspaceFiles`; tests updated accordingly.
- Scope is packaging only; root runtime dependencies and Babel versions are unchanged. No migration required.

<sup>Written for commit f589713394f27956b6310c6c8b356bf3ebd9bcc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

