### PR TITLE
fix(coding-agent): queue typed input admitted during auto-compaction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Claude SDK OAuth now selects the glibc Claude Code binary before the musl variant on glibc Linux hosts and when libc detection is unavailable, while retaining musl-first selection on detected musl hosts and fallback to either installed package ([code-yeongyu/oh-my-openagent#6963](https://github.com/code-yeongyu/oh-my-openagent/issues/6963)).
 
+- Messages typed while auto-compaction is running are no longer silently dropped: input submitted during `Compacting context...` is queued and delivered after compaction settles instead of being accepted and discarded. Manual `/compact` keeps rejecting unqueueable prompts as before ([#950](https://github.com/code-yeongyu/senpi/pull/950)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2939,9 +2939,22 @@ export class AgentSession {
 			(this.isStreaming || this._promptStartPending) &&
 			!this.isCompacting &&
 			options?.streamingBehavior !== undefined;
+		// Auto-compaction claims only _autoCompactionAbortController, which the
+		// admission guard above deliberately ignores so background compaction never
+		// rejects typed input. Without a queue route that message matched no branch
+		// below and fell through neither queued nor started (field bug: input typed
+		// while the TUI showed "Compacting context..." was accepted and dropped).
+		// Manual compaction keeps its fail-closed admission path untouched.
+		const canQueueDuringAutoCompaction =
+			this._autoCompactionAbortController !== undefined &&
+			this._compactionAbortController === undefined &&
+			!this.isStreaming &&
+			!this._promptStartPending &&
+			options?.streamingBehavior !== undefined;
 		if (
 			shouldWaitForSessionWork &&
 			!canQueueWhileStreaming &&
+			!canQueueDuringAutoCompaction &&
 			(!this.isStreaming || this.isCompacting || this._sessionWorkBarrier.hasActiveWork)
 		) {
 			await this._waitForSettledSessionWork();
@@ -3048,6 +3061,26 @@ export class AgentSession {
 			// ends while extension input handling or template expansion is pending.
 			// Starting a fresh prompt here would let it overtake the held continuation.
 			if (canQueueWhileStreaming && !this.isStreaming) {
+				if (options?.thinkingLevel !== undefined) {
+					throw new Error("Cannot set thinkingLevel on a queued prompt; set it after the current turn completes.");
+				}
+				if (options?.streamingBehavior === "followUp") {
+					await this._queueFollowUp(expandedText, currentImages);
+				} else {
+					await this._queueSteer(expandedText, currentImages);
+				}
+				emitPendingCommandInvocation();
+				await emitInputDisposition("queued");
+				promptDisposition?.("queued");
+				preflightResult?.(true);
+				return;
+			}
+
+			// Auto-compaction owns the session without claiming the admission controller,
+			// so a queueable submission reaches here with no branch above matching and
+			// would fall through neither queued nor started. Queue it instead of starting
+			// a turn against a context that is still being compacted.
+			if (canQueueDuringAutoCompaction && !this.isStreaming) {
 				if (options?.thinkingLevel !== undefined) {
 					throw new Error("Cannot set thinkingLevel on a queued prompt; set it after the current turn completes.");
 				}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,39 @@
 # changes
 
+## Queue typed input admitted during auto-compaction (2026-08-18)
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `prompt()` gained a
+  `canQueueDuringAutoCompaction` eligibility flag for a queueable submission
+  (`streamingBehavior` set) that arrives while auto-compaction owns the session
+  and no run is streaming. The flag suppresses the settled-session-work wait and
+  routes the message through `_queueSteer`/`_queueFollowUp` beside the existing
+  queue branches, after extension input handling and template expansion.
+
+### Why
+
+- `isCompacting` is true for the auto, manual, and branch-summary controllers,
+  but the admission guard rejects only on `_compactionAbortController`, so
+  auto-compaction never rejected typed input. That input then matched no queue
+  branch — `canQueueWhileStreaming` requires `!isCompacting` — and fell through
+  neither queued nor started, so a message typed while the TUI showed
+  "Compacting context..." was accepted and silently dropped.
+- Gating on the auto controller alone keeps the manual `/compact` fail-closed
+  admission path and the post-compaction recovery continuation unchanged; a
+  broader `isCompacting` relaxation regressed both.
+
+### Why an extension could not handle it
+
+- Prompt admission and queue ownership run inside the session before any
+  extension input hook observes the submission, so an extension cannot recover
+  input the engine has already dropped.
+
+### Expected merge-conflict zones
+
+- `packages/coding-agent/src/core/agent-session.ts`: the `prompt()` queue
+  eligibility constants and the queue branches preceding the settled-work wait.
+
 ## 2026-08-18 - Cursor reasoning levels: session provenance and legacy id resolution
 
 ### What changed

--- a/packages/coding-agent/test/manual-qa/auto-compaction-input-surface.mts
+++ b/packages/coding-agent/test/manual-qa/auto-compaction-input-surface.mts
@@ -1,0 +1,80 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { getModel, streamSimple } from "@earendil-works/pi-ai/compat";
+import { AgentSession } from "../../src/core/agent-session.ts";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+
+type CompactionOwner = "auto" | "compaction";
+
+const tempDir = join(tmpdir(), `pi-qa-auto-compaction-${Date.now()}`);
+mkdirSync(tempDir, { recursive: true });
+
+function claim(session: AgentSession, controller: AbortController, owner: CompactionOwner): void {
+	const fn = Reflect.get(session, "_claimCompactionController") as (
+		c: AbortController,
+		o: CompactionOwner,
+	) => void;
+	fn.call(session, controller, owner);
+}
+
+function release(session: AgentSession, controller: AbortController): void {
+	const fn = Reflect.get(session, "_releaseCompactionController") as (signal: AbortSignal) => void;
+	fn.call(session, controller.signal);
+}
+
+async function main(): Promise<void> {
+	const model = getModel("anthropic", "claude-sonnet-4-5")!;
+	const agent = new Agent({
+		streamFn: streamSimple,
+		initialState: { model, systemPrompt: "QA", tools: [] },
+	});
+	const sessionManager = SessionManager.inMemory();
+	const settingsManager = SettingsManager.create(tempDir, tempDir);
+	const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+	await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "qa-key" }));
+	const { createModelRegistry, getModelRuntime } = await import("../model-runtime-test-utils.ts");
+	const modelRegistry = await createModelRegistry(authStorage, tempDir);
+
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settingsManager,
+		cwd: tempDir,
+		modelRuntime: getModelRuntime(modelRegistry),
+		resourceLoader: (await import("../utilities.ts")).createTestResourceLoader(),
+	});
+
+	const controller = new AbortController();
+	claim(session, controller, "auto");
+
+	const observed: Record<string, unknown> = {
+		isCompactingWhileAuto: session.isCompacting,
+	};
+
+	await session.prompt("QA: typed while Compacting context...", { streamingBehavior: "steer" });
+
+	observed.pendingAfterSubmit = session.pendingMessageCount;
+	observed.steeringVisible = session.getSteeringMessages();
+
+	release(session, controller);
+	observed.isCompactingAfterRelease = session.isCompacting;
+	observed.pendingSurvivesCompactionEnd = session.pendingMessageCount;
+
+	console.log("QA-SURFACE-RESULT", JSON.stringify(observed, null, 2));
+
+	const ok =
+		observed.isCompactingWhileAuto === true &&
+		observed.pendingAfterSubmit === 1 &&
+		observed.pendingSurvivesCompactionEnd === 1;
+	console.log(ok ? "QA-VERDICT: PASS" : "QA-VERDICT: FAIL");
+
+	session.dispose();
+	if (existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	process.exit(ok ? 0 : 1);
+}
+
+void main();

--- a/packages/coding-agent/test/suite/regressions/auto-compaction-input-admission.test.ts
+++ b/packages/coding-agent/test/suite/regressions/auto-compaction-input-admission.test.ts
@@ -1,0 +1,101 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { getModel, streamSimple } from "@earendil-works/pi-ai/compat";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../../../src/core/agent-session.ts";
+import { AuthStorage } from "../../../src/core/auth-storage.ts";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import { SettingsManager } from "../../../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "../../model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "../../utilities.ts";
+
+type CompactionOwner = "auto" | "compaction";
+
+function claimCompactionController(session: AgentSession, controller: AbortController, owner: CompactionOwner): void {
+	const claim = Reflect.get(session, "_claimCompactionController") as (
+		controller: AbortController,
+		owner: CompactionOwner,
+	) => void;
+	if (typeof claim !== "function") throw new Error("Expected AgentSession._claimCompactionController");
+	claim.call(session, controller, owner);
+}
+
+describe("auto-compaction input admission", () => {
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let settingsManager: SettingsManager;
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = join(tmpdir(), `pi-auto-compaction-admission-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			streamFn: streamSimple,
+			initialState: { model, systemPrompt: "Test", tools: [] },
+		});
+
+		sessionManager = SessionManager.inMemory();
+		settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createModelRegistry(authStorage, tempDir);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRuntime: getModelRuntime(modelRegistry),
+			resourceLoader: createTestResourceLoader(),
+		});
+	});
+
+	afterEach(() => {
+		session.dispose();
+		vi.restoreAllMocks();
+		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	});
+
+	it("queues steer input submitted while auto-compaction owns the session", async () => {
+		claimCompactionController(session, new AbortController(), "auto");
+		expect(session.isCompacting).toBe(true);
+
+		await session.prompt("typed while auto-compacting", { streamingBehavior: "steer" });
+
+		expect(session.getSteeringMessages()).toContain("typed while auto-compacting");
+		expect(session.pendingMessageCount).toBe(1);
+	});
+
+	it("queues follow-up input submitted while auto-compaction owns the session", async () => {
+		claimCompactionController(session, new AbortController(), "auto");
+
+		await session.prompt("follow-up while auto-compacting", { streamingBehavior: "followUp" });
+
+		expect(session.getFollowUpMessages()).toContain("follow-up while auto-compacting");
+		expect(session.pendingMessageCount).toBe(1);
+	});
+
+	it("preserves submission order across mixed input during auto-compaction", async () => {
+		claimCompactionController(session, new AbortController(), "auto");
+
+		await session.prompt("first steer", { streamingBehavior: "steer" });
+		await session.prompt("second follow-up", { streamingBehavior: "followUp" });
+
+		expect(session.pendingMessageCount).toBe(2);
+		expect(session.getSteeringMessages()).toEqual(["first steer"]);
+		expect(session.getFollowUpMessages()).toEqual(["second follow-up"]);
+	});
+
+	it("still rejects unqueueable input while manual compaction owns the session", async () => {
+		claimCompactionController(session, new AbortController(), "compaction");
+
+		await expect(session.prompt("typed during manual compact")).rejects.toThrow(
+			/Cannot submit a prompt while compaction is in progress/,
+		);
+		expect(session.pendingMessageCount).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/auto-compaction-input-toctou.test.ts
+++ b/packages/coding-agent/test/suite/regressions/auto-compaction-input-toctou.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Agent } from "@earendil-works/pi-agent-core";
+import { getModel, streamSimple } from "@earendil-works/pi-ai/compat";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentSession } from "../../../src/core/agent-session.ts";
+import { AuthStorage } from "../../../src/core/auth-storage.ts";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import { SettingsManager } from "../../../src/core/settings-manager.ts";
+import { createModelRegistry, getModelRuntime } from "../../model-runtime-test-utils.ts";
+import { createTestResourceLoader } from "../../utilities.ts";
+
+type CompactionOwner = "auto" | "compaction";
+
+function claimCompactionController(session: AgentSession, controller: AbortController, owner: CompactionOwner): void {
+	const claim = Reflect.get(session, "_claimCompactionController") as (
+		controller: AbortController,
+		owner: CompactionOwner,
+	) => void;
+	claim.call(session, controller, owner);
+}
+
+describe("auto-compaction input submitted across the state-check window", () => {
+	let session: AgentSession;
+	let sessionManager: SessionManager;
+	let settingsManager: SettingsManager;
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = join(tmpdir(), `pi-auto-compaction-toctou-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+
+		const model = getModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			streamFn: streamSimple,
+			initialState: { model, systemPrompt: "Test", tools: [] },
+		});
+
+		sessionManager = SessionManager.inMemory();
+		settingsManager = SettingsManager.create(tempDir, tempDir);
+		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
+		await authStorage.modify("anthropic", async () => ({ type: "api_key", key: "test-key" }));
+		const modelRegistry = await createModelRegistry(authStorage, tempDir);
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settingsManager,
+			cwd: tempDir,
+			modelRuntime: getModelRuntime(modelRegistry),
+			resourceLoader: createTestResourceLoader(),
+		});
+	});
+
+	afterEach(() => {
+		session.dispose();
+		vi.restoreAllMocks();
+		if (tempDir && existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	});
+
+	it("retains input when auto-compaction releases the session mid-submission", async () => {
+		const controller = new AbortController();
+		claimCompactionController(session, controller, "auto");
+
+		const submission = session.prompt("typed while compaction was ending", { streamingBehavior: "followUp" });
+		const release = Reflect.get(session, "_releaseCompactionController") as (signal: AbortSignal) => void;
+		release.call(session, controller.signal);
+		await submission;
+
+		expect(session.getFollowUpMessages()).toContain("typed while compaction was ending");
+	});
+});


### PR DESCRIPTION
## Problem

Typing a message while the TUI shows `Compacting context...` could silently drop the input: it was accepted with no error and never queued, never sent.

`isCompacting` is true for **four** controllers (auto, manual, branch-summary, lifecycle-running), but the `prompt()` admission guard rejects only on `_compactionAbortController`:

```ts
if (options?.source !== "extension" && this._compactionAbortController !== undefined) {
  throw new Error("Cannot submit a prompt while compaction is in progress. ...");
}
```

Auto-compaction claims `_autoCompactionAbortController`, so it never rejected typed input. But every queue branch is gated behind `canQueueWhileStreaming`, which requires `!this.isCompacting`. With an idle stream during auto-compaction the message therefore matched **no** branch and fell through `prompt()` neither queued nor started.

Measured on `654caf4ed` before the fix:

```
{"isCompacting":true,"autoClaimed":true,"manualClaimed":false,
 "admissionRejection":null,"pendingMessageCount":0}
```

Accepted (`admissionRejection: null`), yet gone (`pendingMessageCount: 0`).

## Fix

A narrow `canQueueDuringAutoCompaction` eligibility flag for a queueable submission (`streamingBehavior` set) arriving while **only** the auto controller owns an idle session. It suppresses the settled-session-work wait and queues via `_queueSteer`/`_queueFollowUp` beside the sibling queue branches — after extension input handling and template expansion, so hooks, `emitPendingCommandInvocation`, and `emitInputDisposition("queued")` all behave like the existing branches.

Gating on the auto controller alone is deliberate. An earlier, broader attempt simply dropped the `!isCompacting` veto; that fixed the bug but regressed two contracts (verified against a clean baseline worktree):

- `agent-session-queue`: fail-closed extension follow-up after a rejected/aborted **manual** compaction (`barrierStatesAtExtensionAdmission[0]` expected `true`, got `false`)
- `post-compaction-recovery-bounds`: recovery continuation stopped firing (`callCount` expected `3`, got `2`)

Both stay green with the narrowed gate. The change is additive — no existing line altered.

## Verification

**RED → GREEN** (new regression tests, run against clean baseline `654caf4ed` vs this branch):

| Test | Baseline | This branch |
|---|---|---|
| `auto-compaction-input-admission` (4 cases) | 3 failed / 1 passed | **4 passed** |
| `auto-compaction-input-toctou` (release mid-submission) | `expected [] to include 'typed while compaction was ending'` | **1 passed** |

The admission suite's 4th case (manual `/compact` still rejects) passed on baseline too — kept as a guardrail proving the defect is auto-only.

**Real-surface proof** — `test/manual-qa/auto-compaction-input-surface.mts`:

```
QA-SURFACE-RESULT {
  "isCompactingWhileAuto": true,
  "pendingAfterSubmit": 1,
  "steeringVisible": ["QA: typed while Compacting context..."],
  "isCompactingAfterRelease": false,
  "pendingSurvivesCompactionEnd": 1
}
QA-VERDICT: PASS
```

**Suites**
- `test/compaction/` + interactive compaction + queue-transfer + abort-queued: **496 passed / 70 files**
- Full `test/suite`: `7 failed | 2831 passed` → **`4 failed | 2834 passed`**
- The 4 remaining failures are pre-existing and environmental (`ERR_MODULE_NOT_FOUND` in spawned children from a fresh worktree install) — they fail identically on untouched `654caf4ed`: `0000-multi-session-theme-init`, `2791-fswatch-error-crash`, `756-session-cross-project-resume` (x2).
- `npm run check`: **exit 0**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queues typed input during auto-compaction instead of dropping it. Previously, input typed while “Compacting context…” was accepted but not queued or sent; now steer/follow-up input is queued and runs after compaction settles.

- Add a canQueueDuringAutoCompaction path in prompt() for queueable submissions when only the auto controller owns an idle, non-streaming session; skip the settled-work wait and route to _queueSteer/_queueFollowUp.
- Leave manual /compact unchanged: unqueueable input still rejects and recovery continuation behavior remains intact.
- Preserve existing queued-input signals (emitPendingCommandInvocation, emitInputDisposition("queued")).
- Add focused regression tests and a manual QA script; update changes.md and CHANGELOG.

<sup>Written for commit 52c4288a4e48ba8dae1e4b665b376be679c95943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

