### PR TITLE
fix(codemode): drop eval throughput badge without tool calls

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Eval cells that initiated no tool calls no longer render a `0 calls · 0.00 calls/s`
+  throughput badge; the footer shows only the elapsed time. Positive call counts are
+  unchanged.
+
 ### Removed
 
 ## [2026.8.18-2] - 2026-08-18

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -11,8 +11,8 @@
   kernel-reported `durationMs`; the renderer uses wall time for final elapsed and throughput while
   preserving kernel duration for consumers that need interpreter timing.
 - A cell that initiated no tool calls renders no throughput badge at all: both the count and the
-  rate segments are dropped, so the header reads `eval py done · <1s` instead of
-  `eval py done · 0 calls · 0.00 calls/s · <1s`. Positive calls without a positive wall duration
+  rate segments are dropped, so the header reads `eval py done ✓ · <1s` instead of
+  `eval py done ✓ · 0 calls · 0.00 calls/s · <1s`. Positive calls without a positive wall duration
   render `n/a calls/s`, so the TUI never displays `Infinity` or `NaN`.
 - Partial, pending, running, error, and synthetic multi-cell frames do not show a misleading final
   aggregate. The legacy no-cells result path renders the same final metadata when the new fields are

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -10,8 +10,10 @@
 - `EvalToolDetails` carries `wallDurationMs` and `toolCallCount` alongside the existing
   kernel-reported `durationMs`; the renderer uses wall time for final elapsed and throughput while
   preserving kernel duration for consumers that need interpreter timing.
-- Zero calls over zero elapsed time render `0.00 calls/s`; positive calls without a positive wall
-  duration render `n/a calls/s`, so the TUI never displays `Infinity` or `NaN`.
+- A cell that initiated no tool calls renders no throughput badge at all: both the count and the
+  rate segments are dropped, so the header reads `eval py done · <1s` instead of
+  `eval py done · 0 calls · 0.00 calls/s · <1s`. Positive calls without a positive wall duration
+  render `n/a calls/s`, so the TUI never displays `Infinity` or `NaN`.
 - Partial, pending, running, error, and synthetic multi-cell frames do not show a misleading final
   aggregate. The legacy no-cells result path renders the same final metadata when the new fields are
   available and preserves old output when they are absent.

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -262,7 +262,8 @@ function renderPrefixed(text: string, environment: RenderEnvironment, prefixStyl
 function cellHeader(cell: EvalCellResult, environment: RenderEnvironment, badges: CellBadges): string {
 	const presentation = cellPresentation(cell.status, environment.spinnerFrame);
 	let header = `eval ${cell.language} ${presentation.label} ${presentation.icon}`;
-	if (badges.throughput !== undefined) header += ` · ${formatThroughputBadge(badges.throughput)}`;
+	const throughputBadge = badges.throughput === undefined ? undefined : formatThroughputBadge(badges.throughput);
+	if (throughputBadge !== undefined) header += ` · ${throughputBadge}`;
 	const elapsedMs = badges.throughput?.wallDurationMs ?? cell.durationMs;
 	if (elapsedMs !== undefined) header += ` · ${formatDuration(elapsedMs)}`;
 	if (badges.reset) header += " · reset";
@@ -293,11 +294,14 @@ function plural(count: number, singular: string, pluralNoun: string): string {
 
 function formatCallsPerSecond(calls: number, wallDurationMs: number | undefined): string {
 	const seconds = typeof wallDurationMs === "number" && Number.isFinite(wallDurationMs) ? wallDurationMs / 1_000 : 0;
-	if (seconds <= 0) return calls === 0 ? "0.00 calls/s" : "n/a calls/s";
+	if (seconds <= 0) return "n/a calls/s";
 	return `${(calls / seconds).toFixed(2)} calls/s`;
 }
 
-function formatThroughputBadge(throughput: CellThroughput): string {
+// A cell that issued no tool calls has no throughput to report: emitting
+// "0 calls · 0.00 calls/s" is noise, so the whole badge is dropped instead.
+function formatThroughputBadge(throughput: CellThroughput): string | undefined {
+	if (throughput.calls <= 0) return undefined;
 	return `${plural(throughput.calls, "call", "calls")} · ${formatCallsPerSecond(
 		throughput.calls,
 		throughput.wallDurationMs,
@@ -789,8 +793,10 @@ function resultMetadata(
 	if (details?.phase) metadata.push(`phase ${details.phase}`);
 	const elapsedMs = details?.wallDurationMs ?? details?.durationMs;
 	if (!options.isPartial && typeof elapsedMs === "number") metadata.push(`took ${formatDuration(elapsedMs)}`);
-	if (status === "done" && typeof details?.toolCallCount === "number")
-		metadata.push(formatThroughputBadge({ calls: details.toolCallCount, wallDurationMs: details.wallDurationMs }));
+	if (status === "done" && typeof details?.toolCallCount === "number") {
+		const badge = formatThroughputBadge({ calls: details.toolCallCount, wallDurationMs: details.wallDurationMs });
+		if (badge !== undefined) metadata.push(badge);
+	}
 	if (metadata.length === 0) return [];
 	return [{ kind: "text", text: style(theme, "muted", metadata.join(" | ")) }];
 }

--- a/packages/senpi-codemode/test/eval-render-state.test.ts
+++ b/packages/senpi-codemode/test/eval-render-state.test.ts
@@ -368,6 +368,46 @@ describe("eval completed-cell throughput badge", () => {
 		expect(text).toContain("eval py done ✓ · 2 calls · 1.00 calls/s · 2s · timeout 420s");
 	});
 
+	it("Given zero tool calls when rendered finally then header omits the calls and calls-per-second segments", () => {
+		// Given
+		const givenResult = evalResult(
+			{
+				language: "py",
+				durationMs: 1_250,
+				toolCallCount: 0,
+				wallDurationMs: 0,
+				toolCalls: [],
+				truncated: false,
+				cells: [
+					{
+						index: 0,
+						code: "work()",
+						language: "py",
+						output: "ok",
+						status: "complete",
+						durationMs: 1_250,
+					},
+				],
+			},
+			"ok",
+		);
+
+		// When
+		const text = renderEvalResult(
+			givenResult,
+			{ expanded: false, isPartial: false },
+			undefined,
+			resultContext({ args: { language: "py", code: "work()", summary: "throughput" } }),
+		)
+			.render(120)
+			.join("\n");
+
+		// Then
+		expect(text).not.toContain("calls/s");
+		expect(text).not.toContain("0 calls");
+		expect(text).toContain("eval py done ✓ · <1s");
+	});
+
 	it("Given singular tool-call count when rendered then call noun stays singular", () => {
 		// Given
 		const givenResult = evalResult(

--- a/packages/senpi-codemode/test/eval-result-duration.test.ts
+++ b/packages/senpi-codemode/test/eval-result-duration.test.ts
@@ -50,8 +50,6 @@ describe("eval result throughput rendering", () => {
 		{ calls: 2, wallDurationMs: 2_000, expected: "2 calls · 1.00 calls/s" },
 		{ calls: 3, wallDurationMs: 1_500, expected: "3 calls · 2.00 calls/s" },
 		{ calls: 1, wallDurationMs: 400, expected: "1 call · 2.50 calls/s" },
-		{ calls: 0, wallDurationMs: 0, expected: "0 calls · 0.00 calls/s" },
-		{ calls: 0, wallDurationMs: 900, expected: "0 calls · 0.00 calls/s" },
 		{ calls: 5, wallDurationMs: 0, expected: "5 calls · n/a calls/s" },
 		{ calls: 7, wallDurationMs: undefined, expected: "7 calls · n/a calls/s" },
 	])("renders $calls calls over $wallDurationMs wall ms as $expected", ({ calls, wallDurationMs, expected }) => {
@@ -76,6 +74,38 @@ describe("eval result throughput rendering", () => {
 		// Then
 		expect(rendered.join("\n")).toContain(expected);
 	});
+
+	it.each([
+		{ wallDurationMs: 0, expectedElapsed: "took <1s" },
+		{ wallDurationMs: 900, expectedElapsed: "took <1s" },
+	])(
+		"omits both throughput segments when no tool calls ran over $wallDurationMs wall ms",
+		({ wallDurationMs, expectedElapsed }) => {
+			// Given
+			const result = evalResult(
+				{
+					language: "js",
+					durationMs: 2_000,
+					toolCallCount: 0,
+					wallDurationMs,
+					toolCalls: [],
+					truncated: false,
+				},
+				"complete",
+			);
+
+			// When
+			const rendered = renderLines(
+				renderEvalResult(result, { expanded: false, isPartial: false }, undefined, resultContext(undefined, false)),
+			);
+
+			// Then
+			const text = rendered.join("\n");
+			expect(text).not.toContain("calls/s");
+			expect(text).not.toContain("0 calls");
+			expect(text).toContain(expectedElapsed);
+		},
+	);
 
 	it("uses wall-clock elapsed time for final metadata while preserving kernel duration in details", () => {
 		// Given


### PR DESCRIPTION
## What

An eval cell that initiated no tool calls rendered `0 calls · 0.00 calls/s` in its footer. Neither segment carries information at a zero count, so both are now dropped and the footer shows only the elapsed time:

```
before:  ╭─ eval py done ✓ · 0 calls · 0.00 calls/s · <1s
after:   ╭─ eval py done ✓ · <1s
```

`formatThroughputBadge` returns `undefined` for a non-positive count; `cellHeader` and `resultMetadata` skip the segment when it is absent. The badge still carries the wall-clock source, so suppressing the text leaves the elapsed label on wall time rather than silently falling back to kernel duration. The `calls === 0` branch inside `formatCallsPerSecond` becomes unreachable and collapses into the existing `n/a calls/s` guard.

## Behavior

| toolCallCount | wall ms | footer |
| --- | --- | --- |
| 0 | any | *(no badge)* |
| 1 | 400 | `1 call · 2.50 calls/s` |
| 2 | 2000 | `2 calls · 1.00 calls/s` |
| 5 | 0 | `5 calls · n/a calls/s` |

Every positive-call string is unchanged.

## Verification

- `test(codemode)` commit lands first and fails RED on both render paths (cell header + result metadata), asserting the segments are absent while the old code still emitted them: `3 failed | 29 passed`.
- After the fix, the full package suite is green: **566 passed, 6 skipped** (the 6 are pre-existing `skipIf` interpreter gates for Julia/Ruby/Python; none added here).
- `biome check --error-on-warnings` clean on all changed files.
- `tsc --noEmit` reports no errors in any changed file.
- Real-surface QA: a genuine `createAgentSession` + real `eval` tool run reported `toolCallCount: 0`, and the production renderer's frame was parsed through `scripts/qa/xterm-render.mjs` into a cell grid. Header row reads `╭─ eval py done ✓ · <1s` — no `calls` token, no `calls/s`, no dangling `·` separator. 6/6 grid assertions PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the eval throughput badge in `senpi-codemode` when a cell made zero tool calls. Previously the footer showed “0 calls · 0.00 calls/s”; now it omits both segments and shows only elapsed wall time.

- Implementation: `formatThroughputBadge` returns undefined for non‑positive counts; `cellHeader` and `resultMetadata` skip absent badges; `formatCallsPerSecond` collapses the zero-case into the existing “n/a calls/s” guard.
- Behavior: zero‑call cells show no throughput; elapsed uses wall-clock time; positive‑call output unchanged; no “Infinity”/“NaN”.
- Tests/docs: added assertions for header/metadata omission; updated footer examples to keep the status glyph; updated `changes.md` and `CHANGELOG.md`. No API changes or migration required.

<sup>Written for commit 502a9589c1f6f3fc169c6bd88c9b615decfea5fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

