### PR TITLE
fix(ai): sanitize JSON-Schema composition keywords from advertised cursor tool schemas

### DIFF
--- a/.agents/skills/senpi-qa/scripts/scenarios/cursor-composition-schema-qa.mjs
+++ b/.agents/skills/senpi-qa/scripts/scenarios/cursor-composition-schema-qa.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * QA scenario: a tool whose inputSchema carries a JSON-Schema composition
+ * keyword (`oneOf`/`anyOf`/`allOf`) must NOT break the cursor provider.
+ *
+ * Root cause (2026-08-18): Cursor's gateway forwards advertised MCP tool
+ * schemas upstream and rejects the WHOLE request with a wrapped provider 400
+ * (zero tokens, `resource_exhausted` end-stream) when any schema contains a
+ * composition keyword. ast-grep MCP's `scan` tool ships a top-level `oneOf`,
+ * so every session that registered it failed on cursor from turn 1.
+ * Fixed by `sanitizeCursorToolSchema` in packages/ai/src/api/cursor-agent.ts.
+ *
+ * This drives the REAL CLI in a hermetic sandbox with an extension registering
+ * one MCP stdio server exposing a poisoned `scan`-style tool, then asks the
+ * cursor model to reply. Binary observable:
+ *   - answer text arrives, no provider error  -> fixed
+ *   - "Connect error resource_exhausted"      -> regression
+ *
+ * Live-gated: requires SENPI_QA_CURSOR_TOKEN (a Cursor session access token)
+ * and SKIPS otherwise (hermetic default runs never touch real credentials).
+
+ * Usage: node cursor-composition-schema-qa.mjs [--evidence SLUG]
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox, repoRoot } from "../lib/common.mjs";
+
+const MODEL = "claude-fable-5-thinking-xhigh";
+
+function parseArgs(argv) {
+	const options = { evidence: undefined };
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === "--evidence") {
+			const next = argv[++i];
+			if (!next) throw new Error("--evidence requires a value");
+			options.evidence = next;
+		} else {
+			throw new Error(`Unknown option: ${argv[i]}`);
+		}
+	}
+	return options;
+}
+
+const { evidence } = parseArgs(process.argv.slice(2));
+
+if (!process.env.SENPI_QA_CURSOR_TOKEN) {
+	console.log("SKIP: set SENPI_QA_CURSOR_TOKEN to run the live cursor composition-schema check");
+	process.exit(0);
+}
+
+const box = makeSandbox();
+installCleanupHooks(box);
+const authGuard = guardRealAuth();
+
+const checks = createChecks(evidence ? evidenceDir(evidence) : undefined);
+
+// One MCP stdio server exposing a scan-style poisoned schema plus a clean tool.
+const serverDir = join(box.dir, "asg-mcp");
+mkdirSync(serverDir, { recursive: true });
+writeFileSync(
+	join(serverDir, "server.mjs"),
+	[
+		'import { createInterface } from "node:readline";',
+		"const tools = [",
+		"  { name: 'scan', description: 'scan things', inputSchema: { type: 'object', properties: { ruleFile: { type: 'string' }, inlineRules: { type: 'string' } }, required: ['ruleFile'], oneOf: [ { type: 'object', required: ['ruleFile'], not: { required: ['inlineRules'] } }, { type: 'object', required: ['inlineRules'], not: { required: ['ruleFile'] } } ] } },",
+		"  { name: 'search', description: 'search things', inputSchema: { type: 'object', properties: { pattern: { type: 'string' } }, required: ['pattern'] } },",
+		"];",
+		'const rl = createInterface({ input: process.stdin });',
+		'const send = (msg) => process.stdout.write(JSON.stringify(msg) + "\\n");',
+		'rl.on("line", (line) => {',
+		"  let req; try { req = JSON.parse(line); } catch { return; }",
+		'  if (req.method === "initialize") send({ jsonrpc: "2.0", id: req.id, result: { protocolVersion: "2024-11-05", capabilities: { tools: {} }, serverInfo: { name: "poisoned", version: "1.0" } } });',
+		'  else if (req.method === "tools/list") send({ jsonrpc: "2.0", id: req.id, result: { tools } });',
+		"  else if (req.id !== undefined) send({ jsonrpc: \"2.0\", id: req.id, result: {} });",
+		"});",
+	].join("\n"),
+);
+
+const extDir = join(box.dir, "ext");
+mkdirSync(extDir, { recursive: true });
+writeFileSync(
+	join(extDir, "index.ts"),
+	[
+		'import { join, dirname } from "node:path";',
+		'import { fileURLToPath } from "node:url";',
+		'const here = dirname(fileURLToPath(import.meta.url));',
+		"export default function (pi) {",
+		'  pi.registerMcpServer("_poison_grep", { type: "stdio", command: process.execPath, args: [join(here, "..", "asg-mcp", "server.mjs")], env: {}, enabled: true, lifecycle: "eager" });',
+		"}",
+	].join("\n"),
+);
+
+// Sandbox agent dir already exists (makeSandbox); point the cursor provider at the live API.
+const modelsPath = join(box.env.SENPI_CODING_AGENT_DIR, "models.json");
+let models = { providers: {} };
+try {
+	models = JSON.parse(readFileSync(modelsPath, "utf8"));
+} catch {
+	// fresh sandbox: start from an empty catalog
+}
+models.providers = models.providers ?? {};
+models.providers.cursor = {
+	name: "Cursor (QA)",
+	api: "cursor-agent",
+	baseUrl: "https://api2.cursor.sh",
+	models: [
+		{
+			id: MODEL,
+			name: "Claude Fable 5 1M Extra High Thinking (QA)",
+			reasoning: true,
+			input: ["text", "image"],
+			contextWindow: 1000000,
+			maxTokens: 64000,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		},
+	],
+};
+writeFileSync(modelsPath, JSON.stringify(models, null, 1));
+
+// Explicit opt-in credential: the token arrives via SENPI_QA_CURSOR_TOKEN and is
+// written only into the hermetic sandbox's auth store (never the real one).
+const authPath = join(box.env.SENPI_CODING_AGENT_DIR, "auth.json");
+let auth = {};
+try {
+	auth = JSON.parse(readFileSync(authPath, "utf8"));
+} catch {
+	// fresh sandbox: start from an empty auth store
+}
+auth.cursor = {
+	type: "oauth",
+	access: process.env.SENPI_QA_CURSOR_TOKEN,
+	refresh: "qa-unused",
+	expires: Date.now() + 3_600_000,
+};
+writeFileSync(authPath, JSON.stringify(auth, null, 1));
+
+const runRoot = join(box.dir, "run");
+mkdirSync(runRoot, { recursive: true });
+const { status, stdout, stderr } = (() => {
+	try {
+		const out = execFileSync(
+			process.execPath,
+			[
+				join(repoRoot(), "packages", "coding-agent", "dist", "cli.js"),
+				"-p",
+				"Reply with exactly: OK",
+				"--extension",
+				join(extDir, "index.ts"),
+				"--provider",
+				"cursor",
+				"--model",
+				MODEL,
+			],
+			{ cwd: runRoot, env: box.env, encoding: "utf8", timeout: 120_000 },
+		);
+		return { status: 0, stdout: out, stderr: "" };
+	} catch (error) {
+		return { status: error.status ?? 1, stdout: error.stdout ?? "", stderr: error.stderr ?? "" };
+	}
+})();
+
+const combined = `${stdout}\n${stderr}`;
+const answered = /OK/.test(stdout);
+const poisoned = /resource_exhausted/.test(combined);
+
+checks.ok(
+	"cursor answers with poisoned-schema tool registered",
+	answered && !poisoned,
+	`exit=${status} poisoned=${poisoned} tail=${JSON.stringify(stdout.slice(-80))}`,
+);
+
+authGuard.assertUnchanged();
+rmSync(box.dir, { recursive: true, force: true });
+checks.finish();

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -21,6 +21,11 @@
 
 ### Fixed
 
+- Cursor provider: advertised MCP tool schemas are now sanitized of JSON-Schema composition
+  keywords (`oneOf`/`anyOf`/`allOf`) before reaching the Run request — a single tool carrying one
+  (e.g. ast-grep MCP's `scan`) made Cursor's gateway reject the whole request with a wrapped
+  provider 400 (`resource_exhausted`, zero tokens) from turn 1.
+
 ### Removed
 
 ## [2026.8.18-2] - 2026-08-18

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -3402,6 +3402,28 @@ function toolParametersToJsonSchema(tool: Tool): unknown {
 	}
 }
 
+/**
+ * JSON-Schema composition keywords Cursor's gateway cannot carry: an
+ * advertised tool whose inputSchema contains `oneOf`, `anyOf`, or `allOf` is
+ * rejected upstream with a wrapped provider 400 for the WHOLE request
+ * (zero tokens, `resource_exhausted` end-stream). MCP tools imported from
+ * external servers routinely ship such schemas (e.g. ast-grep's `scan`).
+ * `not` is tolerated upstream and kept. Returns a new structure; the input is
+ * never mutated.
+ */
+const CURSOR_UNSUPPORTED_SCHEMA_KEYS = new Set(["oneOf", "anyOf", "allOf"]);
+
+export function sanitizeCursorToolSchema(schema: unknown): unknown {
+	if (Array.isArray(schema)) return schema.map(sanitizeCursorToolSchema);
+	if (schema === null || typeof schema !== "object") return schema;
+	const sanitized: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		if (CURSOR_UNSUPPORTED_SCHEMA_KEYS.has(key)) continue;
+		sanitized[key] = sanitizeCursorToolSchema(value);
+	}
+	return sanitized;
+}
+
 export function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[] {
 	if (!tools || tools.length === 0) {
 		return [];
@@ -3413,7 +3435,7 @@ export function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefin
 	}
 
 	return advertisedTools.map((tool) => {
-		const jsonSchema = toolParametersToJsonSchema(tool);
+		const jsonSchema = sanitizeCursorToolSchema(toolParametersToJsonSchema(tool));
 		const schemaValue: PbJsonValue =
 			jsonSchema && typeof jsonSchema === "object"
 				? (jsonSchema as PbJsonValue)

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,34 @@
 # AI Source Changes
 
+## 2026-08-18 - Sanitize JSON-Schema composition keywords from advertised Cursor tool schemas
+
+### What changed
+
+- `packages/ai/src/api/cursor-agent.ts`: new exported `sanitizeCursorToolSchema` helper plus
+  `CURSOR_UNSUPPORTED_SCHEMA_KEYS`; `buildMcpToolDefinitions` now recursively strips `oneOf`,
+  `anyOf`, and `allOf` from every advertised tool's inputSchema before proto encoding. `not` and
+  all other keywords pass through untouched. Returns new structures (input never mutated).
+
+### Why
+
+- An advertised tool whose inputSchema carries a composition keyword makes Cursor's gateway
+  reject the ENTIRE request upstream with a wrapped provider 400 (`ERROR_PROVIDER_ERROR`, zero
+  tokens, `resource_exhausted` end-stream) — proven by live A/B on 2026-08-18 with a minimal
+  single-tool `oneOf`/`anyOf`/`allOf` repro against `claude-fable-5-thinking-xhigh`. External MCP
+  servers ship such schemas routinely (ast-grep's `scan` uses a top-level `oneOf`), so every
+  session registering one failed on the cursor provider from turn 1.
+
+### Why an extension could not handle it
+
+- `buildMcpToolDefinitions` runs inside the cursor-agent Run-request construction path; the
+  advertised schema bytes are serialized before any extension-visible surface exists.
+
+### Expected merge-conflict zones
+
+- `packages/ai/src/api/cursor-agent.ts` (`buildMcpToolDefinitions` / schema helpers) — same zone
+  as the reasoning-levels entry; test file
+  `packages/ai/test/cursor-tool-schema-sanitize.test.ts` is new.
+
 ## 2026-08-18 - Cursor reasoning levels end to end
 
 ### What changed

--- a/packages/ai/test/cursor-tool-schema-sanitize.test.ts
+++ b/packages/ai/test/cursor-tool-schema-sanitize.test.ts
@@ -1,0 +1,89 @@
+import { fromBinary, toJson } from "@bufbuild/protobuf";
+import { ValueSchema } from "@bufbuild/protobuf/wkt";
+import { describe, expect, it } from "vitest";
+import { buildMcpToolDefinitions } from "../src/api/cursor-agent.ts";
+
+function decodeInputSchema(inputSchema: Uint8Array): unknown {
+	return toJson(ValueSchema, fromBinary(ValueSchema, inputSchema));
+}
+
+describe("cursor MCP tool schema sanitization", () => {
+	it("strips oneOf/anyOf/allOf from advertised tool schemas", () => {
+		const tools = [
+			{
+				name: "scan",
+				description: "scan things",
+				parameters: {
+					type: "object",
+					properties: {
+						ruleFile: { type: "string", minLength: 1 },
+						inlineRules: { type: "string" },
+					},
+					required: ["ruleFile"],
+					oneOf: [
+						{ type: "object", required: ["ruleFile"], not: { required: ["inlineRules"] } },
+						{ type: "object", required: ["inlineRules"], not: { required: ["ruleFile"] } },
+					],
+				},
+			},
+		];
+		const definitions = buildMcpToolDefinitions(tools);
+		expect(definitions).toHaveLength(1);
+		const decoded = decodeInputSchema(definitions[0].inputSchema) as Record<string, unknown>;
+		expect(decoded.oneOf).toBeUndefined();
+		expect(decoded.type).toBe("object");
+		expect((decoded.properties as Record<string, unknown>).ruleFile).toEqual({
+			type: "string",
+			minLength: 1,
+		});
+		expect(decoded.required).toEqual(["ruleFile"]);
+	});
+
+	it("strips nested composition keywords inside property schemas", () => {
+		const tools = [
+			{
+				name: "nested",
+				description: "nested",
+				parameters: {
+					type: "object",
+					properties: {
+						filter: {
+							type: "object",
+							properties: { kind: { type: "string" } },
+							anyOf: [{ required: ["kind"] }],
+						},
+						list: {
+							type: "array",
+							items: { type: "object", allOf: [{ required: ["x"] }] },
+						},
+					},
+				},
+			},
+		];
+		const definitions = buildMcpToolDefinitions(tools);
+		const decoded = decodeInputSchema(definitions[0].inputSchema) as {
+			properties: Record<string, Record<string, unknown>>;
+		};
+		expect(decoded.properties.filter.anyOf).toBeUndefined();
+		expect(decoded.properties.filter.properties.kind).toEqual({ type: "string" });
+		expect(decoded.properties.list.items.allOf).toBeUndefined();
+	});
+
+	it("passes clean schemas through unchanged", () => {
+		const parameters = {
+			type: "object",
+			properties: {
+				pattern: { type: "string", maxLength: 16384 },
+				lang: { enum: ["ts", "py"] },
+				not: { required: ["other"] },
+			},
+			required: ["pattern"],
+			additionalProperties: false,
+		};
+		const definitions = buildMcpToolDefinitions([
+			{ name: "clean", description: "clean tool", parameters },
+		]);
+		const decoded = decodeInputSchema(definitions[0].inputSchema);
+		expect(decoded).toEqual(parameters);
+	});
+});

--- a/packages/ai/test/cursor-tool-schema-sanitize.test.ts
+++ b/packages/ai/test/cursor-tool-schema-sanitize.test.ts
@@ -62,11 +62,13 @@ describe("cursor MCP tool schema sanitization", () => {
 		];
 		const definitions = buildMcpToolDefinitions(tools);
 		const decoded = decodeInputSchema(definitions[0].inputSchema) as {
-			properties: Record<string, Record<string, unknown>>;
+			properties: Record<string, Record<string, unknown> & { items?: Record<string, unknown> }>;
 		};
-		expect(decoded.properties.filter.anyOf).toBeUndefined();
-		expect(decoded.properties.filter.properties.kind).toEqual({ type: "string" });
-		expect(decoded.properties.list.items.allOf).toBeUndefined();
+		const filter = decoded.properties.filter as Record<string, unknown>;
+		expect(filter.anyOf).toBeUndefined();
+		expect((filter.properties as Record<string, unknown>).kind).toEqual({ type: "string" });
+		const items = decoded.properties.list.items as Record<string, unknown>;
+		expect(items.allOf).toBeUndefined();
 	});
 
 	it("passes clean schemas through unchanged", () => {
@@ -80,9 +82,7 @@ describe("cursor MCP tool schema sanitization", () => {
 			required: ["pattern"],
 			additionalProperties: false,
 		};
-		const definitions = buildMcpToolDefinitions([
-			{ name: "clean", description: "clean tool", parameters },
-		]);
+		const definitions = buildMcpToolDefinitions([{ name: "clean", description: "clean tool", parameters }]);
 		const decoded = decodeInputSchema(definitions[0].inputSchema);
 		expect(decoded).toEqual(parameters);
 	});


### PR DESCRIPTION
Fixes #952

## Root cause

A tool whose `inputSchema` carries a JSON-Schema composition keyword (`oneOf`, `anyOf`,
`allOf`) makes Cursor's gateway reject the ENTIRE Run request upstream with a wrapped
provider 400 — surfaced as `Connect error resource_exhausted` with zero tokens after
`stepCompleted`. External MCP servers ship such schemas routinely (ast-grep MCP's `scan`
has a top-level `oneOf`), so any session registering one failed on the cursor provider
from turn 1 (every omo stack with the ast-grep component) while bare senpi passed.

Live A/B against `claude-fable-5-thinking-xhigh` (real account, 2026-08-18, one minimal
tool each): `oneOf`/`anyOf`/`allOf` all reproduce; `not` alone, enums, min/maxLength,
min/maxItems all pass.

## Change

- `packages/ai/src/api/cursor-agent.ts`: new exported `sanitizeCursorToolSchema` +
  `CURSOR_UNSUPPORTED_SCHEMA_KEYS`; `buildMcpToolDefinitions` now recursively strips
  `oneOf`/`anyOf`/`allOf` from every advertised tool's inputSchema before proto
  encoding. `not` and everything else pass through. Returns new structures; input
  never mutated. Local argument validation is unaffected (tools still validate on
  execution; only the advertised schema loses the keywords Cursor cannot carry).

## Tests

- `packages/ai/test/cursor-tool-schema-sanitize.test.ts` (new): strips top-level and
  nested composition keywords, preserves everything else byte-for-byte; control schema
  passes through unchanged. Mutation proof: without the fix 2/3 RED (control stays
  green), with the fix 3/3.
- Existing cursor suites: `cursor-agent`, `cursor-run-request`, `cursor-model-capabilities`,
  `cursor-model-grouping`, `cursor-reasoning-params` — 62/62 green.

## QA

- New scenario `.agents/skills/senpi-qa/scripts/scenarios/cursor-composition-schema-qa.mjs`
  (live-gated on `SENPI_QA_CURSOR_TOKEN`, skips hermetically otherwise): real CLI in a
  sandbox with one MCP server exposing the poisoned `scan`-style tool → cursor answers.
  Result: 1/1 PASS.
- Real TUI (tmux) on the fixed build with the FULL omo plugin loaded,
  `cursor/claude-fable-5-thinking-xhigh`:
  - fresh session booted directly on the model → real cursor answer ("OK"), zero errors;
  - switched from `apitopia/kimi-k3-unlocked` to cursor fable mid-session → real cursor
    answer ("YES"), zero errors. Both surfaces failed deterministically before the fix.
- Evidence: `local-ignore/qa-evidence/20260818-cursor-composition-schema/`.

## Notes

- Root `npm run check` green; changelog gate PASS (changes.md + packages/ai/CHANGELOG.md).
- The `not` keyword is tolerated upstream and deliberately kept.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes JSON-Schema composition keywords from advertised Cursor MCP tool input schemas to prevent upstream request rejection. Previously, tools with `oneOf`/`anyOf`/`allOf` caused Cursor to reject the entire Run (`resource_exhausted`, zero tokens); now those keys are stripped before sending, so sessions with external MCP tools (e.g., ast-grep `scan`) start successfully.

- `packages/ai/src/api/cursor-agent.ts`: adds `sanitizeCursorToolSchema` and `CURSOR_UNSUPPORTED_SCHEMA_KEYS`; `buildMcpToolDefinitions` now recursively removes `oneOf`/`anyOf`/`allOf`. Returns new objects; does not mutate inputs. `not` and other keywords are preserved. Execution-time argument validation is unchanged.
- Tests: `packages/ai/test/cursor-tool-schema-sanitize.test.ts` covers top-level and nested removals; existing Cursor suites remain green.
- QA: live scenario `.agents/skills/senpi-qa/scripts/scenarios/cursor-composition-schema-qa.mjs` (gated by `SENPI_QA_CURSOR_TOKEN`) verifies Cursor answers with a poisoned-schema MCP tool registered. No migration required.

<sup>Written for commit b9c3a8a82d826fac2aaddfebee2425b42093c3e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

