### PR TITLE
fix(claude-sdk-oauth): harden persisted restart checkpoints

### DIFF
--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-headless-restart-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-headless-restart-probe.mjs
@@ -148,19 +148,24 @@ try {
 	const firstContinuity = continuityFrom(first.stdout);
 	const secondContinuity = continuityFrom(second.stdout);
 	const sessionFiles = listFiles(stack.box.sessionDir);
-	const resumed = secondContinuity.some(
-		(observation) => observation.kind === "fork" && observation.reason === "registry_miss",
+	const deltaOnlyResume = secondContinuity.some(
+		(observation) => observation.reason === "registry_miss" && observation.deltaMessages === 1,
 	);
 	const flattened = secondContinuity.some(
 		(observation) => observation.kind === "flatten" || observation.kind === "bootstrap",
+	);
+	const replayedHistory = secondContinuity.some(
+		(observation) =>
+			typeof observation.deltaMessages === "number" && observation.deltaMessages > 1,
 	);
 	const passed =
 		first.code === 0 &&
 		second.code === 0 &&
 		sessionFiles.length > 0 &&
 		stack.providerRequests.length >= 2 &&
-		resumed &&
-		!flattened;
+		deltaOnlyResume &&
+		!flattened &&
+		!replayedHistory;
 	summary = {
 		passed,
 		first: { code: first.code, continuity: firstContinuity },

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Fixed
 
-- Headless Claude SDK OAuth continuation now restores its persisted SDK binding across separate CLI processes, so
-  `-p -c` resumes the existing lineage instead of resending the full conversation after a `registry_miss`.
+- Headless Claude SDK OAuth continuation now restores a bounded, ledger-verified SDK checkpoint across separate CLI
+  processes, so `-p -c` sends only the new turn after a `registry_miss`; rewrites, compaction, malformed state, and
+  inherited branches invalidate or reject stale continuity instead of resuming it.
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
@@ -17,7 +17,7 @@ Generated: 2026-08-07 | Commit: `4f26b8282`
 | `session-stream.ts` | Resident-lane attempts (`createResidentAttempt`), flatten serialization + directive dedupe |
 | `session-continuity.ts` | `decideNativeContinuity` decision table: `delta` / `reattach` / `fork` / `flatten` / `bootstrap` |
 | `session-registry.ts` | Resident SDK query registry: idle reaping, eviction, state transitions (with `session-registry-state/pump/wiring.ts`) |
-| `session-binding.ts` | Branch-local binding checkpoint for restart-time resume verification |
+| `session-binding.ts` | Bounded branch-local restart checkpoint with fail-closed prefix and ledger verification |
 | `session-commit-boundary.ts` | `message_end` commit boundary; divergence decided against the SDK ledger, not in-flight staging |
 | `session-observability.ts` | `ContinuityObservation` (kind, reason, delta count, `payloadBytes`, `collapsedDirectives`), `session.log` events |
 | `system-prompt.ts` | `systemPromptMode` handling (`full` default, `preset-append` deprecated, `override` from file); no array-splitting, the CLI joins arrays |
@@ -30,7 +30,7 @@ Generated: 2026-08-07 | Commit: `4f26b8282`
 
 ## INVARIANTS (from changes.md)
 
-- Resume-first: every query replacement re-attaches with `resume`; flatten is a last resort for a missing transcript or unusable binding. A live session is never abandoned for a flattened re-send.
+- Resume-first: every query replacement re-attaches with `resume`; persisted restarts reattach only when the branch ledger and bounded prefix checkpoint agree. A live session is never abandoned for a flattened re-send.
 - The SDK ledger is authoritative for divergence; decide at the `message_end` commit boundary. Result-only turns are a supported shape, not divergence.
 - Fork point is the last assistant boundary strictly before the divergence.
 - Non-fork reattach passes `resume` and must omit `sessionId` (the SDK rejects the pair). Fork adds `resumeSessionAt` + `forkSession`.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -4,12 +4,12 @@
 
 ### What changed
 
-- Successful resident Claude SDK OAuth turns now append the complete continuity binding as a branch-local custom
-  session entry, including the SDK session id, sent-message hashes, assistant boundaries, account/model identity,
-  and prompt/tool fingerprints.
-- `session_start` restores the newest valid checkpoint into the resident binding map before the first resumed turn.
-  A missing, invalidated, or malformed checkpoint still fails closed to the existing bootstrap/flatten path.
-- Assistant rewrites and terminal failures do not persist a clean checkpoint.
+- Successful resident turns now append a fixed-size branch checkpoint containing the SDK lineage, sent-prefix digest,
+  last assistant boundary, account/model identity, and prompt/tool fingerprints.
+- Startup/resume restores only the newest authoritative checkpoint, only after its assistant ledger entry is present;
+  malformed entries, divergent prefixes, and inherited new/fork branches fail closed instead of guessing a boundary.
+- Assistant rewrites, compaction, forks, and tree navigation append durable invalidations. Reload keeps the fresher
+  process binding, restored identity drift is explicit, and nested binding state is copied at the registry boundary.
 
 ### Why
 
@@ -24,8 +24,8 @@
 
 ### Expected merge-conflict zones
 
-- MEDIUM in `session-binding.ts` and `session-registry-wiring.ts`; LOW in their focused tests and issue #6981
-  regression.
+- MEDIUM in `session-binding.ts`, `session-registry-wiring.ts`, and `session-continuity.ts`; LOW in their focused tests
+  and issue #6981 regression.
 
 ## Repository audit baseline for the claude-sdk-oauth tracker (2026-08-17)
 
@@ -342,7 +342,7 @@ LOW in `oauth-login.ts` (added `check` to the returned shape + optional `readSet
 - **Abort.** `interrupt()` receipts gate the outcome: `still_queued: []` keeps the live session; a legacy or uncertain receipt closes the query but keeps the binding for reattach. Abort never taints and never flattens. Teardown during resume-initialization is synchronous, so an aborted initialization is torn down before the next assertion point.
 - **Fingerprint.** The generated `Current date:` line is normalized before hashing, so a UTC midnight rollover no longer retires a live conversation; cwd and every other prompt region stay fail-closed. Host tool policy is fingerprinted by an explicit `HOST_TOOL_POLICY_FINGERPRINT` version instead of callback source text, and the executable path plus `includePartialMessages` now participate.
 - **Account failover.** Shared-root lanes (`oauth-slots`, `ambient`) reattach, or fork at the last verified boundary when cross-account resume is denied. The `config-dir` lane keeps per-account credentials inside its own `CLAUDE_CONFIG_DIR` and no official SDK API moves a transcript across roots, so its failover is the one declared residual that still flattens.
-- **Restart.** A branch-local binding checkpoint records `{sdkSessionId, sentCount, sentPrefixHash, lastAssistantUuid, accountName, claudeConfigDir, modelId}`; on the first turn after a restart it is verified against the SDK transcript before resuming, forks at the boundary when the local prefix advanced, and flattens only when the transcript or boundary is gone.
+- **Restart.** A bounded branch-local checkpoint records the SDK lineage, sent-prefix digest, last assistant boundary, account/model identity, and prompt/tool fingerprints. Startup/resume restores it only when the checkpoint is followed by its committed assistant and the current prefix digest matches; malformed, invalidated, divergent, or unavailable SDK state falls back without guessing a fork boundary.
 - **Observability.** Every main turn emits exactly one continuity observation (kind + sanitized reason + delta count) as an assistant diagnostic and a structured `claude_sdk_oauth_session_continuity` `session.log` event (paired with `claude_sdk_oauth_session_close`); the TUI shows a muted notice only for degradations. `closeSession` no longer discards its reason — the retained cause is attributed to the next admission.
 - **Escape hatch.** `resumeMode: "off"` (or `SENPI_CLAUDE_SDK_OAUTH_RESUME=off`) still restores the legacy per-turn behaviour and reports `disabled` observations.
 - Merge-conflict risk: high across this directory. New modules: session-continuity.ts, session-reattach.ts, session-binding.ts, session-commit-boundary.ts, session-observability.ts, session-reaper.ts, session-entry-annotations.ts.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts
@@ -1,4 +1,5 @@
 import type { ContinuityBinding } from "./session-reattach.ts";
+import { sentHashPrefixDigest } from "./session-sync.ts";
 
 export const BINDING_ENTRY_TYPE = "claude-sdk-oauth-binding";
 
@@ -6,9 +7,8 @@ export type BindingCheckpoint = {
 	schemaVersion: 1;
 	sdkSessionId: string;
 	sentCount: number;
-	sentHashes: string[];
+	sentPrefixHash: string;
 	lastAssistantUuid: string | null;
-	assistantUuidByIndex: [number, string][];
 	accountName: string;
 	modelId: string;
 	systemPromptHash: string;
@@ -17,10 +17,24 @@ export type BindingCheckpoint = {
 
 export type BindingInvalidation = { schemaVersion: 1; invalidated: true; reason: string };
 
-type BranchEntry = { type: string; customType?: string; data?: unknown };
+type BranchEntry = {
+	type: string;
+	customType?: string;
+	data?: unknown;
+	message?: { role?: unknown };
+};
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const MAX_CHECKPOINT_TEXT_LENGTH = 256;
+
+function isBoundedText(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0 && value.length <= MAX_CHECKPOINT_TEXT_LENGTH;
+}
 
 function isInvalidation(data: unknown): data is BindingInvalidation {
-	return typeof data === "object" && data !== null && (data as BindingInvalidation).invalidated === true;
+	if (typeof data !== "object" || data === null) return false;
+	const invalidation = data as Partial<BindingInvalidation>;
+	return invalidation.schemaVersion === 1 && invalidation.invalidated === true && isBoundedText(invalidation.reason);
 }
 
 function isCheckpoint(data: unknown): data is BindingCheckpoint {
@@ -28,24 +42,18 @@ function isCheckpoint(data: unknown): data is BindingCheckpoint {
 	const checkpoint = data as Partial<BindingCheckpoint>;
 	return (
 		checkpoint.schemaVersion === 1 &&
-		typeof checkpoint.sdkSessionId === "string" &&
-		Number.isInteger(checkpoint.sentCount) &&
+		isBoundedText(checkpoint.sdkSessionId) &&
+		Number.isSafeInteger(checkpoint.sentCount) &&
 		(checkpoint.sentCount ?? -1) >= 0 &&
-		Array.isArray(checkpoint.sentHashes) &&
-		checkpoint.sentHashes.every((hash) => typeof hash === "string") &&
-		(checkpoint.lastAssistantUuid === null || typeof checkpoint.lastAssistantUuid === "string") &&
-		Array.isArray(checkpoint.assistantUuidByIndex) &&
-		checkpoint.assistantUuidByIndex.every(
-			(boundary) =>
-				Array.isArray(boundary) &&
-				boundary.length === 2 &&
-				Number.isInteger(boundary[0]) &&
-				typeof boundary[1] === "string",
-		) &&
-		typeof checkpoint.accountName === "string" &&
-		typeof checkpoint.modelId === "string" &&
+		typeof checkpoint.sentPrefixHash === "string" &&
+		SHA256_HEX.test(checkpoint.sentPrefixHash) &&
+		(checkpoint.lastAssistantUuid === null || isBoundedText(checkpoint.lastAssistantUuid)) &&
+		isBoundedText(checkpoint.accountName) &&
+		isBoundedText(checkpoint.modelId) &&
 		typeof checkpoint.systemPromptHash === "string" &&
-		typeof checkpoint.toolsetHash === "string"
+		SHA256_HEX.test(checkpoint.systemPromptHash) &&
+		typeof checkpoint.toolsetHash === "string" &&
+		SHA256_HEX.test(checkpoint.toolsetHash)
 	);
 }
 
@@ -54,7 +62,14 @@ export function latestBindingOnBranch(branch: readonly BranchEntry[]): BindingCh
 		const entry = branch[index];
 		if (entry?.type !== "custom" || entry.customType !== BINDING_ENTRY_TYPE) continue;
 		if (isInvalidation(entry.data)) return undefined;
-		if (isCheckpoint(entry.data)) return entry.data;
+		if (isCheckpoint(entry.data)) {
+			const committedAssistant = branch[index + 1];
+			if (committedAssistant?.type !== "message" || committedAssistant.message?.role !== "assistant") {
+				return undefined;
+			}
+			return entry.data;
+		}
+		return undefined;
 	}
 	return undefined;
 }
@@ -64,9 +79,8 @@ export function checkpointFromBinding(binding: ContinuityBinding): BindingCheckp
 		schemaVersion: 1,
 		sdkSessionId: binding.sdkSessionId,
 		sentCount: binding.sentCount,
-		sentHashes: [...binding.sentHashes],
+		sentPrefixHash: sentHashPrefixDigest(binding.sentHashes, binding.sentCount),
 		lastAssistantUuid: binding.lastAssistantUuid,
-		assistantUuidByIndex: binding.assistantUuidByIndex?.map(([index, uuid]) => [index, uuid]) ?? [],
 		accountName: binding.accountName,
 		modelId: binding.modelId,
 		systemPromptHash: binding.systemPromptHash,
@@ -79,9 +93,11 @@ export function bindingFromCheckpoint(senpiSessionId: string, checkpoint: Bindin
 		senpiSessionId,
 		sdkSessionId: checkpoint.sdkSessionId,
 		sentCount: checkpoint.sentCount,
-		sentHashes: [...checkpoint.sentHashes],
+		sentHashes: [],
+		sentPrefixHash: checkpoint.sentPrefixHash,
 		lastAssistantUuid: checkpoint.lastAssistantUuid,
-		assistantUuidByIndex: checkpoint.assistantUuidByIndex.map(([index, uuid]) => [index, uuid]),
+		assistantUuidByIndex:
+			checkpoint.lastAssistantUuid === null ? [] : [[checkpoint.sentCount, checkpoint.lastAssistantUuid]],
 		accountName: checkpoint.accountName,
 		modelId: checkpoint.modelId,
 		systemPromptHash: checkpoint.systemPromptHash,

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts
@@ -1,4 +1,5 @@
 import type { ContinuityReason } from "./session-observability.ts";
+import { sentHashPrefixDigest } from "./session-sync.ts";
 
 export type ContinuityEntrySnapshot = {
 	sdkSessionId: string;
@@ -18,6 +19,7 @@ export type ContinuityBindingSnapshot = {
 	sdkSessionId: string;
 	sentCount: number;
 	sentHashes: readonly string[];
+	sentPrefixHash?: string;
 	lastAssistantUuid: string | null;
 	accountName: string;
 	modelId: string;
@@ -86,7 +88,10 @@ function forkOrFlatten(
 	};
 }
 
-function identityDrift(input: ContinuityDecisionInput, entry: ContinuityEntrySnapshot): ContinuityReason | null {
+function identityDrift(
+	input: ContinuityDecisionInput,
+	entry: Pick<ContinuityEntrySnapshot, "accountName" | "modelId" | "systemPromptHash" | "toolsetHash">,
+): ContinuityReason | null {
 	if (entry.accountName !== input.accountName) return "account_changed";
 	if (entry.modelId !== input.modelId) return "model_changed";
 	if (entry.systemPromptHash !== input.fingerprint.systemPromptHash) return "options_changed";
@@ -96,6 +101,23 @@ function identityDrift(input: ContinuityDecisionInput, entry: ContinuityEntrySna
 
 function decideFromBinding(input: ContinuityDecisionInput, binding: ContinuityBindingSnapshot): ContinuityDecision {
 	if (!input.transcriptAvailable) return { kind: "flatten", reason: "transcript_missing" };
+	if (binding.sentPrefixHash !== undefined) {
+		const prefixMatches =
+			input.currentHashes.length >= binding.sentCount &&
+			sentHashPrefixDigest(input.currentHashes, binding.sentCount) === binding.sentPrefixHash;
+		if (prefixMatches) {
+			return {
+				kind: "reattach",
+				sdkSessionId: binding.sdkSessionId,
+				from: binding.sentCount,
+				reason: identityDrift(input, binding) ?? "registry_miss",
+			};
+		}
+		return {
+			kind: "flatten",
+			reason: input.currentHashes.length < binding.sentCount ? "history_rolled_back" : "sent_stream_diverged",
+		};
+	}
 	const shared = commonPrefixLength(binding.sentHashes, input.currentHashes);
 	if (shared === binding.sentCount) {
 		return { kind: "reattach", sdkSessionId: binding.sdkSessionId, from: binding.sentCount, reason: "registry_miss" };

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts
@@ -7,6 +7,7 @@ export type ContinuityBinding = {
 	sdkSessionId: string;
 	sentCount: number;
 	sentHashes: readonly string[];
+	sentPrefixHash?: string;
 	lastAssistantUuid: string | null;
 	accountName: string;
 	modelId: string;
@@ -27,6 +28,14 @@ const bindings = new Map<string, ContinuityBinding>();
 
 export type AbortOutcome = "keep" | "reattach";
 
+function cloneBinding(binding: ContinuityBinding): ContinuityBinding {
+	return {
+		...binding,
+		sentHashes: [...binding.sentHashes],
+		assistantUuidByIndex: binding.assistantUuidByIndex?.map(([index, uuid]) => [index, uuid]),
+	};
+}
+
 export function evaluateAbortOutcome(receipt: unknown): AbortOutcome {
 	if (!receipt || typeof receipt !== "object") return "reattach";
 	const queued = (receipt as { still_queued?: unknown }).still_queued;
@@ -34,11 +43,12 @@ export function evaluateAbortOutcome(receipt: unknown): AbortOutcome {
 }
 
 export function rememberBinding(binding: ContinuityBinding): void {
-	bindings.set(binding.senpiSessionId, { ...binding, sentHashes: [...binding.sentHashes] });
+	bindings.set(binding.senpiSessionId, cloneBinding(binding));
 }
 
 export function getBinding(senpiSessionId: string): ContinuityBinding | undefined {
-	return bindings.get(senpiSessionId);
+	const binding = bindings.get(senpiSessionId);
+	return binding ? cloneBinding(binding) : undefined;
 }
 
 export function forgetBinding(senpiSessionId: string): void {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-wiring.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-wiring.ts
@@ -3,12 +3,13 @@ import type { ExtensionAPI } from "../../types.ts";
 import { CLAUDE_SDK_OAUTH_PROVIDER_ID } from "./account-management.ts";
 import {
 	BINDING_ENTRY_TYPE,
+	type BindingInvalidation,
 	bindingFromCheckpoint,
 	checkpointFromBinding,
 	latestBindingOnBranch,
 } from "./session-binding.ts";
 import { AssistantCommitBoundary, isResidentAssistant, isTerminalFailure } from "./session-commit-boundary.ts";
-import { bindingFromEntry, getBinding, rememberBinding } from "./session-reattach.ts";
+import { bindingFromEntry, forgetBinding, getBinding, rememberBinding } from "./session-reattach.ts";
 import {
 	closeSession,
 	getSession,
@@ -18,6 +19,10 @@ import {
 } from "./session-registry.ts";
 
 const commitBoundary = new AssistantCommitBoundary();
+
+function persistBindingInvalidation(pi: Partial<Pick<ExtensionAPI, "appendEntry">>, reason: string): void {
+	pi.appendEntry?.(BINDING_ENTRY_TYPE, { schemaVersion: 1, invalidated: true, reason } satisfies BindingInvalidation);
+}
 
 function keepBindingThenClose(sessionId: string, reason: string): void {
 	const entry = getSession(sessionId);
@@ -34,17 +39,23 @@ function residentEntryFor(sessionId: string, message: AssistantMessage) {
 export function registerSessionRegistry(
 	pi: Pick<ExtensionAPI, "on"> & Partial<Pick<ExtensionAPI, "appendEntry">>,
 ): void {
-	pi.on("session_start", (_event, ctx) => {
+	pi.on("session_start", (event, ctx) => {
+		if (event.reason === "reload") return;
+		const sessionId = ctx.sessionManager.getSessionId();
+		forgetBinding(sessionId);
+		if (event.reason === "new" || event.reason === "fork") return;
 		const checkpoint = latestBindingOnBranch(ctx.sessionManager.getBranch());
 		if (!checkpoint) return;
-		rememberBinding(bindingFromCheckpoint(ctx.sessionManager.getSessionId(), checkpoint));
+		rememberBinding(bindingFromCheckpoint(sessionId, checkpoint));
 	});
 	pi.on("session_compact", (event, ctx) => {
 		if (!event.accepted) return;
 		recordPendingFork(ctx.sessionManager.getSessionId(), "compaction");
+		persistBindingInvalidation(pi, "compaction");
 	});
 	pi.on("session_before_fork", (_event, ctx) => {
 		recordPendingFork(ctx.sessionManager.getSessionId(), "fork");
+		persistBindingInvalidation(pi, "fork");
 	});
 	pi.on("session_tree", (event, ctx) => {
 		if (event.oldLeafId === null || event.newLeafId === null) return;
@@ -52,6 +63,7 @@ export function registerSessionRegistry(
 			oldLeafId: event.oldLeafId,
 			newLeafId: event.newLeafId,
 		});
+		persistBindingInvalidation(pi, "tree_changed");
 	});
 	pi.on("model_select", async (event, ctx) => {
 		const sessionId = ctx.sessionManager.getSessionId();
@@ -84,6 +96,7 @@ export function registerSessionRegistry(
 		}
 		if (commitBoundary.commit(sessionId, event.message, entry.modelId) === "rewritten") {
 			recordPendingFork(sessionId, "assistant_rewritten");
+			persistBindingInvalidation(pi, "assistant_rewritten");
 			return;
 		}
 		const binding = getBinding(sessionId);

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-stream.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-stream.ts
@@ -163,13 +163,17 @@ async function createResidentAttempt(
 	} else if (decision.kind === "reattach" || decision.kind === "fork") {
 		const source = getBinding(sessionId) ?? (existing ? bindingFromEntry(existing, residentHashes) : undefined);
 		const binding = source
-			? {
-					...source,
+			? (({ sentPrefixHash: _persistedPrefix, ...rest }) => ({
+					...rest,
 					sentCount: decision.from,
-					sentHashes: source.sentHashes.slice(0, decision.from),
+					sentHashes: hashes.slice(0, decision.from),
 					assistantUuidByIndex: (source.assistantUuidByIndex ?? []).filter(([index]) => index <= decision.from),
+					accountName: auth.accountName,
+					modelId: input.model.id,
+					systemPromptHash: fingerprint.systemPromptHash,
+					toolsetHash: fingerprint.toolsetHash,
 					...(decision.kind === "fork" ? { lastAssistantUuid: decision.atUuid } : {}),
-				}
+				}))(source)
 			: undefined;
 		try {
 			if (!binding) throw new Error("Claude SDK OAuth continuity binding is unavailable");

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
@@ -82,7 +82,7 @@ export function sentMessageHashes(messages: readonly SentMessage[]): string[] {
 	return hashes;
 }
 
-function prefixDigest(hashes: readonly string[], count = hashes.length): string {
+export function sentHashPrefixDigest(hashes: readonly string[], count = hashes.length): string {
 	return digest(hashes.slice(0, count));
 }
 
@@ -96,7 +96,7 @@ export function recordSyncedStream(entry: ClaudeSdkOauthSessionEntry, hashes: re
 	const copy = [...hashes];
 	sentHashesByEntry.set(entry, copy);
 	entry.sentCount = copy.length;
-	entry.syncedPrefixHash = prefixDigest(copy);
+	entry.syncedPrefixHash = sentHashPrefixDigest(copy);
 	entry.branchInfo = null;
 }
 

--- a/packages/coding-agent/test/claude-sdk-oauth-binding-persistence.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-binding-persistence.test.ts
@@ -1,0 +1,178 @@
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import type { SdkQueryHandle } from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import {
+	BINDING_ENTRY_TYPE,
+	checkpointFromBinding,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts";
+import {
+	type ContinuityBinding,
+	forgetBinding,
+	getBinding,
+	rememberBinding,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts";
+import {
+	closeSession,
+	getOrCreateSession,
+	overrideSessionRegistryBoundary,
+	resetSessionRegistryBoundary,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-registry.ts";
+import { registerSessionRegistry } from "../src/core/extensions/builtin/claude-sdk-oauth/session-registry-wiring.ts";
+import type { ExtensionAPI, ExtensionContext } from "../src/core/extensions/types.ts";
+
+type EventHandler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+function fakeQuery(): SdkQueryHandle {
+	return {
+		async *[Symbol.asyncIterator](): AsyncGenerator<SDKMessage> {},
+		async interrupt() {},
+		close() {},
+	};
+}
+
+function fakeExtension() {
+	const handlers = new Map<string, EventHandler[]>();
+	const persisted: Array<{ customType: string; data: unknown }> = [];
+	const api = {
+		on(event: string, handler: EventHandler): void {
+			handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+		},
+		appendEntry(customType: string, data: unknown): void {
+			persisted.push({ customType, data });
+		},
+	} as unknown as ExtensionAPI;
+	return { api, handlers, persisted };
+}
+
+function binding(sdkSessionId: string): ContinuityBinding {
+	return {
+		senpiSessionId: "binding-persistence",
+		sdkSessionId,
+		sentCount: 1,
+		sentHashes: ["hash-1"],
+		lastAssistantUuid: "assistant-1",
+		accountName: "default",
+		modelId: "claude-test",
+		systemPromptHash: "1".repeat(64),
+		toolsetHash: "2".repeat(64),
+	};
+}
+
+function persistedBranch(sdkSessionId: string) {
+	return [
+		{
+			type: "custom",
+			customType: BINDING_ENTRY_TYPE,
+			data: checkpointFromBinding(binding(sdkSessionId)),
+		},
+		{ type: "message", message: { role: "assistant" } },
+	];
+}
+
+function context(branch: ReturnType<typeof persistedBranch> | [] = []) {
+	return {
+		sessionManager: {
+			getSessionId: () => "binding-persistence",
+			getBranch: () => branch,
+		},
+	} as unknown as ExtensionContext;
+}
+
+async function emit(
+	handlers: Map<string, EventHandler[]>,
+	eventName: string,
+	event: unknown,
+	eventContext = context(),
+): Promise<void> {
+	const registered = handlers.get(eventName) ?? [];
+	expect(registered).toHaveLength(1);
+	for (const handler of registered) await handler(event, eventContext);
+}
+
+afterEach(() => {
+	closeSession("binding-persistence", "test_cleanup");
+	forgetBinding("binding-persistence");
+	resetSessionRegistryBoundary();
+});
+
+describe("Claude SDK OAuth persisted binding lifecycle", () => {
+	it.each(["startup", "resume"] as const)("restores a valid checkpoint on %s", async (reason) => {
+		const extension = fakeExtension();
+		registerSessionRegistry(extension.api);
+
+		await emit(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason },
+			context(persistedBranch("persisted-sdk")),
+		);
+
+		expect(getBinding("binding-persistence")).toMatchObject({ sdkSessionId: "persisted-sdk" });
+	});
+
+	it.each(["new", "fork"] as const)("does not inherit a persisted checkpoint on %s", async (reason) => {
+		const extension = fakeExtension();
+		registerSessionRegistry(extension.api);
+
+		await emit(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason },
+			context(persistedBranch("parent-sdk")),
+		);
+
+		expect(getBinding("binding-persistence")).toBeUndefined();
+	});
+
+	it("keeps the fresher process binding on reload", async () => {
+		rememberBinding(binding("live-sdk"));
+		const extension = fakeExtension();
+		registerSessionRegistry(extension.api);
+
+		await emit(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "reload" },
+			context(persistedBranch("older-disk-sdk")),
+		);
+
+		expect(getBinding("binding-persistence")).toMatchObject({ sdkSessionId: "live-sdk" });
+	});
+
+	it("clears a stale process-local binding when startup has no valid checkpoint", async () => {
+		rememberBinding(binding("stale-sdk"));
+		const extension = fakeExtension();
+		registerSessionRegistry(extension.api);
+
+		await emit(extension.handlers, "session_start", { type: "session_start", reason: "resume" });
+
+		expect(getBinding("binding-persistence")).toBeUndefined();
+	});
+
+	it.each([
+		["accepted compaction", "session_compact", { type: "session_compact", accepted: true }, "compaction"],
+		["explicit fork", "session_before_fork", { type: "session_before_fork" }, "fork"],
+		["tree navigation", "session_tree", { type: "session_tree", oldLeafId: "old", newLeafId: "new" }, "tree_changed"],
+	])("invalidates the checkpoint after %s", async (_label, eventName, event, reason) => {
+		overrideSessionRegistryBoundary({ queryFactory: () => fakeQuery() });
+		getOrCreateSession({
+			senpiSessionId: "binding-persistence",
+			accountName: "default",
+			modelId: "claude-test",
+			systemPromptHash: "1".repeat(64),
+			toolsetHash: "2".repeat(64),
+			options: {},
+		});
+		const extension = fakeExtension();
+		registerSessionRegistry(extension.api);
+
+		await emit(extension.handlers, eventName, event);
+
+		expect(extension.persisted).toEqual([
+			{
+				customType: BINDING_ENTRY_TYPE,
+				data: { schemaVersion: 1, invalidated: true, reason },
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/test/claude-sdk-oauth-binding.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-binding.test.ts
@@ -8,21 +8,20 @@ import {
 } from "../src/core/extensions/builtin/claude-sdk-oauth/session-binding.ts";
 import type { ContinuityBinding } from "../src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts";
 
+const PROMPT_HASH = "1".repeat(64);
+const TOOLSET_HASH = "2".repeat(64);
+
 function checkpoint(overrides: Partial<BindingCheckpoint> = {}): BindingCheckpoint {
 	return {
 		schemaVersion: 1,
 		sdkSessionId: "sdk-1",
 		sentCount: 2,
-		sentHashes: ["hash-1", "hash-2"],
+		sentPrefixHash: "3".repeat(64),
 		lastAssistantUuid: "uuid-a2",
-		assistantUuidByIndex: [
-			[1, "uuid-a1"],
-			[2, "uuid-a2"],
-		],
 		accountName: "primary",
 		modelId: "claude-opus-4-5",
-		systemPromptHash: "prompt-v1",
-		toolsetHash: "tools-v1",
+		systemPromptHash: PROMPT_HASH,
+		toolsetHash: TOOLSET_HASH,
 		...overrides,
 	};
 }
@@ -31,12 +30,18 @@ function entry(customType: string, data: unknown) {
 	return { type: "custom" as const, customType, data };
 }
 
+function messageEntry(role: "assistant" | "user") {
+	return { type: "message" as const, message: { role } };
+}
+
 describe("claude-sdk-oauth continuity binding", () => {
 	it("reads the newest binding checkpoint on the active branch", () => {
 		const branch = [
 			entry(BINDING_ENTRY_TYPE, checkpoint({ sentCount: 1 })),
+			messageEntry("assistant"),
 			entry("unrelated", { noise: true }),
 			entry(BINDING_ENTRY_TYPE, checkpoint({ sentCount: 2 })),
+			messageEntry("assistant"),
 		];
 
 		expect(latestBindingOnBranch(branch)).toMatchObject({ sentCount: 2 });
@@ -44,6 +49,10 @@ describe("claude-sdk-oauth continuity binding", () => {
 
 	it("returns nothing when the branch carries no checkpoint", () => {
 		expect(latestBindingOnBranch([entry("unrelated", {})])).toBeUndefined();
+	});
+
+	it("does not restore a checkpoint before its assistant ledger entry is committed", () => {
+		expect(latestBindingOnBranch([entry(BINDING_ENTRY_TYPE, checkpoint())])).toBeUndefined();
 	});
 
 	it("treats an invalidation entry as erasing the earlier checkpoint", () => {
@@ -55,7 +64,7 @@ describe("claude-sdk-oauth continuity binding", () => {
 		expect(latestBindingOnBranch(branch)).toBeUndefined();
 	});
 
-	it("round-trips a process-local binding through a serializable checkpoint", () => {
+	it("restores bounded restart state from a process-local binding", () => {
 		const binding: ContinuityBinding = {
 			senpiSessionId: "senpi-1",
 			sdkSessionId: "sdk-1",
@@ -68,14 +77,74 @@ describe("claude-sdk-oauth continuity binding", () => {
 			],
 			accountName: "primary",
 			modelId: "claude-opus-4-5",
-			systemPromptHash: "prompt-v1",
-			toolsetHash: "tools-v1",
+			systemPromptHash: PROMPT_HASH,
+			toolsetHash: TOOLSET_HASH,
 		};
 
-		expect(bindingFromCheckpoint("senpi-1", checkpointFromBinding(binding))).toEqual(binding);
+		const restored = bindingFromCheckpoint("senpi-1", checkpointFromBinding(binding));
+
+		expect(restored).toMatchObject({
+			senpiSessionId: "senpi-1",
+			sdkSessionId: "sdk-1",
+			sentCount: 2,
+			lastAssistantUuid: "uuid-a2",
+			accountName: "primary",
+			modelId: "claude-opus-4-5",
+			systemPromptHash: PROMPT_HASH,
+			toolsetHash: TOOLSET_HASH,
+		});
+		expect(restored.sentHashes).toEqual([]);
+		expect(restored.sentPrefixHash).toMatch(/^[0-9a-f]{64}$/);
+		expect(restored.assistantUuidByIndex).toEqual([[2, "uuid-a2"]]);
+	});
+
+	it("keeps persisted checkpoint size bounded as the conversation grows", () => {
+		const sentCount = 10_000;
+		const binding: ContinuityBinding = {
+			senpiSessionId: "senpi-long",
+			sdkSessionId: "sdk-long",
+			sentCount,
+			sentHashes: Array.from({ length: sentCount }, (_value, index) => `hash-${index}`),
+			lastAssistantUuid: `uuid-${sentCount}`,
+			assistantUuidByIndex: Array.from(
+				{ length: sentCount },
+				(_value, index) => [index + 1, `uuid-${index + 1}`] as const,
+			),
+			accountName: "primary",
+			modelId: "claude-opus-4-5",
+			systemPromptHash: PROMPT_HASH,
+			toolsetHash: TOOLSET_HASH,
+		};
+
+		const persisted = checkpointFromBinding(binding);
+
+		expect(persisted).not.toHaveProperty("sentHashes");
+		expect(persisted).not.toHaveProperty("assistantUuidByIndex");
+		expect(JSON.stringify(persisted).length).toBeLessThan(1_024);
 	});
 
 	it("ignores malformed checkpoints instead of restoring partial state", () => {
-		expect(latestBindingOnBranch([entry(BINDING_ENTRY_TYPE, { ...checkpoint(), sentHashes: [42] })])).toBeUndefined();
+		expect(
+			latestBindingOnBranch([entry(BINDING_ENTRY_TYPE, { ...checkpoint(), sentPrefixHash: 42 })]),
+		).toBeUndefined();
+	});
+
+	it("does not fall back to an older checkpoint when the newest binding entry is malformed", () => {
+		const branch = [
+			entry(BINDING_ENTRY_TYPE, checkpoint({ sdkSessionId: "stale-sdk" })),
+			messageEntry("assistant"),
+			entry(BINDING_ENTRY_TYPE, { ...checkpoint(), sentPrefixHash: 42 }),
+		];
+
+		expect(latestBindingOnBranch(branch)).toBeUndefined();
+	});
+
+	it.each([
+		["sent count is negative", checkpoint({ sentCount: -1 })],
+		["prefix hash is not a SHA-256 digest", checkpoint({ sentPrefixHash: "not-a-digest" })],
+		["assistant identifier is empty", checkpoint({ lastAssistantUuid: "" })],
+		["account identifier exceeds the boundary", checkpoint({ accountName: "a".repeat(257) })],
+	])("rejects a checkpoint when %s", (_label, malformed) => {
+		expect(latestBindingOnBranch([entry(BINDING_ENTRY_TYPE, malformed)])).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/claude-sdk-oauth-continuity-decision.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-continuity-decision.test.ts
@@ -3,6 +3,7 @@ import {
 	type ContinuityDecisionInput,
 	decideNativeContinuity,
 } from "../src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts";
+import { sentHashPrefixDigest } from "../src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts";
 
 const FINGERPRINT = { systemPromptHash: "prompt-v1", toolsetHash: "tools-v1" };
 
@@ -173,6 +174,58 @@ describe("claude-sdk-oauth native continuity decisions", () => {
 		);
 
 		expect(decision).toEqual({ kind: "flatten", reason: "registry_miss" });
+	});
+
+	it("fails closed instead of pairing a restored divergence with the wrong assistant boundary", () => {
+		const decision = decideNativeContinuity(
+			input({
+				entry: undefined,
+				binding: {
+					sdkSessionId: "sdk-restored",
+					sentCount: 2,
+					sentHashes: [],
+					sentPrefixHash: sentHashPrefixDigest(["h1", "h2"]),
+					lastAssistantUuid: "uuid-a2",
+					accountName: "primary",
+					modelId: "claude-opus-4-5",
+					systemPromptHash: FINGERPRINT.systemPromptHash,
+					toolsetHash: FINGERPRINT.toolsetHash,
+				},
+				currentHashes: ["h1", "h2-rewritten", "h3"],
+			}),
+		);
+
+		expect(decision).toEqual({ kind: "flatten", reason: "sent_stream_diverged" });
+	});
+
+	it.each([
+		["account", { accountName: "secondary" }, "account_changed"],
+		["model", { modelId: "claude-sonnet-5" }, "model_changed"],
+		[
+			"options",
+			{ fingerprint: { systemPromptHash: "prompt-v2", toolsetHash: FINGERPRINT.toolsetHash } },
+			"options_changed",
+		],
+	] as const)("reports restored %s drift before reattaching", (_label, override, reason) => {
+		const decision = decideNativeContinuity(
+			input({
+				entry: undefined,
+				binding: {
+					sdkSessionId: "sdk-restored",
+					sentCount: 2,
+					sentHashes: [],
+					sentPrefixHash: sentHashPrefixDigest(["h1", "h2"]),
+					lastAssistantUuid: "uuid-a2",
+					accountName: "primary",
+					modelId: "claude-opus-4-5",
+					systemPromptHash: FINGERPRINT.systemPromptHash,
+					toolsetHash: FINGERPRINT.toolsetHash,
+				},
+				...override,
+			}),
+		);
+
+		expect(decision).toMatchObject({ kind: "reattach", reason, from: 2 });
 	});
 
 	it("flattens when a hash divergence has no assistant boundary to fork at", () => {

--- a/packages/coding-agent/test/claude-sdk-oauth-reattach.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-reattach.test.ts
@@ -2,6 +2,7 @@ import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Options, SdkQueryHandle } from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
 import {
+	type ContinuityBinding,
 	forgetBinding,
 	getBinding,
 	reattachSession,
@@ -28,7 +29,7 @@ function fakeQuery(): SdkQueryHandle {
 	};
 }
 
-function binding() {
+function binding(): ContinuityBinding {
 	return {
 		senpiSessionId: SESSION_ID,
 		sdkSessionId: SDK_SESSION_ID,
@@ -93,6 +94,31 @@ describe("claude-sdk-oauth session reattach", () => {
 		closeSession(SESSION_ID, "idle_ttl");
 
 		expect(getBinding(SESSION_ID)).toMatchObject({ sdkSessionId: SDK_SESSION_ID, sentCount: 2 });
+	});
+
+	it("owns nested binding state across registry writes and reads", () => {
+		const original: ContinuityBinding = {
+			...binding(),
+			assistantUuidByIndex: [
+				[1, "uuid-a1"],
+				[2, "uuid-a2"],
+			],
+		};
+		rememberBinding(original);
+		Reflect.set(original.sentHashes, 0, "mutated-input");
+		Reflect.set(original.assistantUuidByIndex?.[0] ?? [], 1, "mutated-input");
+
+		const first = getBinding(SESSION_ID);
+		expect(first).toBeDefined();
+		if (!first) return;
+		expect(first.sentHashes[0]).toBe("h1");
+		expect(first.assistantUuidByIndex?.[0]?.[1]).toBe("uuid-a1");
+		Reflect.set(first.sentHashes, 0, "mutated-read");
+		Reflect.set(first.assistantUuidByIndex?.[0] ?? [], 1, "mutated-read");
+
+		const second = getBinding(SESSION_ID);
+		expect(second?.sentHashes[0]).toBe("h1");
+		expect(second?.assistantUuidByIndex?.[0]?.[1]).toBe("uuid-a1");
 	});
 
 	it("restores the synchronized prefix onto the reattached entry", async () => {

--- a/packages/coding-agent/test/suite/regressions/6981-claude-sdk-oauth-headless-restart-continuity.test.ts
+++ b/packages/coding-agent/test/suite/regressions/6981-claude-sdk-oauth-headless-restart-continuity.test.ts
@@ -21,6 +21,9 @@ import type { ExtensionAPI, ExtensionContext } from "../../../src/core/extension
 
 type EventHandler = (event: unknown, ctx: ExtensionContext) => unknown;
 
+const PROMPT_HASH = "1".repeat(64);
+const TOOLSET_HASH = "2".repeat(64);
+
 function fakeQuery(): SdkQueryHandle {
 	return {
 		async *[Symbol.asyncIterator](): AsyncGenerator<SDKMessage> {},
@@ -43,10 +46,10 @@ function fakeExtension() {
 	return { api, handlers, persisted };
 }
 
-function assistant(): AssistantMessage {
+function assistant(text = "turn one"): AssistantMessage {
 	return {
 		role: "assistant",
-		content: [{ type: "text", text: "turn one" }],
+		content: [{ type: "text", text }],
 		api: "claude-sdk-oauth",
 		provider: "claude-sdk-oauth",
 		model: "claude-test",
@@ -81,14 +84,54 @@ afterEach(() => {
 });
 
 describe("issue #6981 headless restart continuity", () => {
+	it("persists an invalidation when the committed assistant rewrites the provider final", async () => {
+		overrideSessionRegistryBoundary({ queryFactory: () => fakeQuery() });
+		const entry = getOrCreateSession({
+			senpiSessionId: "issue-6981",
+			accountName: "default",
+			modelId: "claude-test",
+			systemPromptHash: PROMPT_HASH,
+			toolsetHash: TOOLSET_HASH,
+			options: {},
+		});
+		entry.sentCount = 1;
+		entry.assistantUuidByIndex.set(1, "assistant-uuid-1");
+		rememberBinding(bindingFromEntry(entry, ["user-hash-1"]));
+
+		const extension = fakeExtension();
+		registerSessionRegistry(extension.api);
+		const context = {
+			sessionManager: {
+				getSessionId: () => "issue-6981",
+				getBranch: () => [],
+			},
+		} as unknown as ExtensionContext;
+		const providerFinal = assistant("provider final");
+
+		await emit(extension.handlers, "message_update", { type: "message_update", message: providerFinal }, context);
+		await emit(
+			extension.handlers,
+			"message_end",
+			{ type: "message_end", message: assistant("committed rewrite") },
+			context,
+		);
+
+		expect(extension.persisted).toEqual([
+			{
+				customType: BINDING_ENTRY_TYPE,
+				data: { schemaVersion: 1, invalidated: true, reason: "assistant_rewritten" },
+			},
+		]);
+	});
+
 	it("persists the SDK binding in the session branch and restores it on startup", async () => {
 		overrideSessionRegistryBoundary({ queryFactory: () => fakeQuery() });
 		const entry = getOrCreateSession({
 			senpiSessionId: "issue-6981",
 			accountName: "default",
 			modelId: "claude-test",
-			systemPromptHash: "prompt-v1",
-			toolsetHash: "tools-v1",
+			systemPromptHash: PROMPT_HASH,
+			toolsetHash: TOOLSET_HASH,
 			options: {},
 		});
 		entry.sentCount = 1;
@@ -124,6 +167,7 @@ describe("issue #6981 headless restart continuity", () => {
 						customType: extension.persisted[0]!.customType,
 						data: extension.persisted[0]!.data,
 					},
+					{ type: "message", message: assistant() },
 				],
 			},
 		} as unknown as ExtensionContext;
@@ -143,7 +187,7 @@ describe("issue #6981 headless restart continuity", () => {
 				currentHashes: ["user-hash-1"],
 				accountName: "default",
 				modelId: "claude-test",
-				fingerprint: { systemPromptHash: "prompt-v1", toolsetHash: "tools-v1" },
+				fingerprint: { systemPromptHash: PROMPT_HASH, toolsetHash: TOOLSET_HASH },
 				transcriptAvailable: true,
 			}),
 		).toMatchObject({ kind: "reattach", reason: "registry_miss" });


### PR DESCRIPTION
## Summary

- replace unbounded persisted message/assistant arrays with a fixed-size prefix digest checkpoint
- restore restart continuity only when the newest checkpoint is well-formed, followed by its committed assistant ledger entry, and matches the current branch prefix
- durably invalidate persisted continuity after assistant rewrites, compaction, forks, and tree navigation
- keep reload-time live bindings authoritative while clearing stale process state on startup/resume
- strengthen the real two-process probe so full-history replay cannot be mistaken for successful continuation

## Why

PR #943 fixed headless Claude SDK OAuth continuation across separate CLI processes. This follow-up hardens that persisted state against stale or malformed checkpoints, branch-history changes, unbounded session growth, and incorrect boundary reuse.

## Validation

- `npm run check`
- focused Claude SDK OAuth binding, continuity, reattach, lifecycle, and issue #6981 regression tests
- real two-process headless restart probe
- full coding-agent suite from `packages/coding-agent` with bounded parallelism:
  - 989 test files passed, 4 skipped
  - 8,155 tests passed, 36 skipped
- unrelated timing-sensitive failures seen under unconstrained workstation contention all passed independently:
  - Cursor process-group transport: 8/8
  - footer reftable debounce: 9/9
  - cross-process OAuth refresh race: 2/2

## Relationship

Security and durability follow-up to #943 and issue #6981.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened headless `claude-sdk-oauth` restart continuity by replacing unbounded persisted state with a bounded, ledger-verified checkpoint. Previously we restored from any latest binding array; now we restore only when a well‑formed checkpoint is immediately followed by its committed assistant and the branch prefix digest matches, otherwise we fail closed to avoid stale or cross‑branch resumes (issue #6981).

- Persist a fixed-size checkpoint: `{sdkSessionId, sentCount, sentPrefixHash, lastAssistantUuid, accountName, modelId, systemPromptHash, toolsetHash}`; remove persisted sent-hash arrays and assistant maps.
- Restoration rules: require SHA‑256 fields, bounded text, and the next ledger entry to be the committed assistant; reject malformed entries, rolled-back history, divergent prefixes, and inherited branches.
- Invalidate persistence on assistant rewrites, compaction, forks, and tree navigation; append durable invalidation entries instead of guessing a boundary.
- Keep reload-time live bindings authoritative; on non-reload start, clear stale process bindings unless a valid checkpoint exists.
- Continuity decisions use `sentPrefixHash` to reattach only the new turn; fallback to flatten with explicit reasons when verification fails.
- Strengthen the two-process restart probe to fail when history is replayed; add focused tests for persistence, decisions, reattach cloning, and regression `#6981`.
- Internal API notes: new `sentHashPrefixDigest` in `session-sync.ts`; checkpoint schema changed in `session-binding.ts`; wiring persists invalidations in `session-registry-wiring.ts`. No migration required for users.

<sup>Written for commit 8f41e063e9dbcbb4aa228b9ed31172a57bd54346. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

