### PR TITLE
fix(coding-agent): reconcile retry watchdog with granted stream guards

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 ### Fixed
 
+- Transient provider stream-start timeouts now spend the full configured `retry.maxRetries` budget instead of
+  ending the turn after a single attempt. The retry-continuation watchdog was bounded by
+  `retry.provider.streamRetryTimeoutMs` (30s) while the same retry was granted the configured
+  `streamStartTimeoutMs` (90s), so a slow-but-alive provider was aborted 60s before its own deadline and the
+  turn surfaced `Provider stream start timed out after 90000ms` followed by `Aborted after 1 retry attempt`.
+  The watchdog is now reconciled to the guard it grants, while still cancelling a retry that outlives it.
 - Published Senpi tarballs now retain the lockfile-recorded Babel 8 dependency closure inside the bundled codemode sidecar, preventing `@babel/parser` resolution failures during extension startup ([#923](https://github.com/code-yeongyu/senpi/issues/923)).
 - Headless Claude SDK OAuth continuation now restores its persisted SDK binding across separate CLI processes, so
   `-p -c` resumes the existing lineage instead of resending the full conversation after a `registry_miss`.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,41 @@
 # changes
 
+## 2026-08-18 - Retry continuation watchdog reconciled with the guards it grants
+
+### What changed
+
+- `core/provider-timeout-retry.ts`: `createProviderTimeoutRetryPlan` now reconciles the retry-continuation
+  liveness cap against the stream-start guard the same retry is handed:
+  `watchdogTimeoutMs = max(streamRetryTimeoutMs, streamStartTimeoutMs)`. An explicitly disabled cap
+  (`undefined`) stays disabled, and a cap that already outlasts the granted guard is returned unchanged.
+- Coverage: `test/provider-timeout-retry-continuation.test.ts` (new; first direct coverage of
+  `runBoundedRetryContinuation`), extended `test/provider-timeout-retry.test.ts`, and updated
+  `test/suite/regressions/provider-idle-recovery.test.ts`.
+
+### Why
+
+- This completes the 2026-08-13 fix below. That change stopped clamping the retry *request* guards to
+  `retry.provider.streamRetryTimeoutMs`, but left the same 30s cap bounding the retry *continuation*, which
+  reproduced the identical defect one layer up: `runBoundedRetryContinuation` aborted the attempt at 30s while
+  the request still had 60s of its configured 90s stream-start budget left.
+- No attempt could therefore finish, so the bounded `retry.maxRetries` budget (default 3) collapsed into the
+  single user-visible `Provider stream start timed out after 90000ms` / `Aborted after 1 retry attempt`
+  outcome. A slow-but-alive provider was again judged dead on a deadline it was never given.
+- Raising the watchdog to the granted guard preserves the wedge protection it was added for: the provider
+  guards still fail a dead upstream, and the watchdog still cancels a retry that outlives every guard it was
+  granted.
+
+### Why an extension could not handle it
+
+- The retry continuation bound and its abort ownership are core session-lifecycle surfaces with no extension
+  hook.
+
+### Expected merge conflict zones
+
+- `core/provider-timeout-retry.ts` plan construction, and the retry-bound constants in
+  `test/suite/regressions/provider-idle-recovery.test.ts`.
+
+
 ## Queue typed input admitted during auto-compaction (2026-08-18)
 
 ### What changed

--- a/packages/coding-agent/src/core/provider-timeout-retry.ts
+++ b/packages/coding-agent/src/core/provider-timeout-retry.ts
@@ -14,6 +14,25 @@ export interface ProviderTimeoutRetryPlanInput {
 	streamStartTimeoutMs: number | undefined;
 }
 
+/**
+ * Raise the retry-continuation liveness cap to the stream-start budget granted to
+ * the same retry, so the watchdog can never cancel an attempt on a deadline the
+ * attempt was never given.
+ *
+ * An explicitly disabled cap (`undefined`) stays disabled: the operator opted out
+ * of the wedge guard, and the provider guards still bound the request. A cap that
+ * already outlasts the granted guard is returned unchanged, so an operator who
+ * configured a longer cap keeps it.
+ */
+function reconcileWatchdogTimeoutMs(
+	streamRetryTimeoutMs: number | undefined,
+	streamStartTimeoutMs: number | undefined,
+): number | undefined {
+	if (streamRetryTimeoutMs === undefined) return undefined;
+	if (streamStartTimeoutMs === undefined) return streamRetryTimeoutMs;
+	return Math.max(streamRetryTimeoutMs, streamStartTimeoutMs);
+}
+
 export interface BoundedRetryContinuation {
 	continueRun(): Promise<void>;
 	getActiveSignal(): AbortSignal | undefined;
@@ -37,13 +56,24 @@ export function createProviderTimeoutRetryPlan({
 	// it was configured with. `streamRetryTimeoutMs` still bounds the retry
 	// continuation itself (see `runBoundedRetryContinuation`), which cancels a
 	// wedged retry without lying to the provider about its deadline.
+	//
+	// The cap is reconciled against the guards this same retry was granted. A cap
+	// shorter than the stream-start budget re-created the very defect the guards
+	// were kept for, one layer up: the continuation was aborted at 30s while the
+	// request still had 60s of its configured 90s budget left, so no attempt could
+	// ever finish and the bounded `retry.maxRetries` budget collapsed into the
+	// single "Aborted after 1 retry attempt" outcome. Raising the watchdog to the
+	// granted guard keeps the wedge protection (the guards themselves still fail a
+	// dead upstream, and the watchdog still cancels a retry that outlives them)
+	// while letting a slow-but-alive provider spend the budget it was configured
+	// with across the full retry budget.
 	return {
 		options: {
 			deferQueuedMessages: true,
 			...(timeoutMs === undefined ? {} : { timeoutMs }),
 			...(streamStartTimeoutMs === undefined ? {} : { streamStartTimeoutMs }),
 		},
-		watchdogTimeoutMs: streamRetryTimeoutMs,
+		watchdogTimeoutMs: reconcileWatchdogTimeoutMs(streamRetryTimeoutMs, streamStartTimeoutMs),
 	};
 }
 

--- a/packages/coding-agent/test/cursor-cli-oauth/transport.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/transport.test.ts
@@ -55,8 +55,20 @@ function start(
 	});
 }
 
-function assertDead(pid: number): void {
-	expect(() => process.kill(pid, 0)).toThrow();
+// Group SIGTERM reaches the grandchild asynchronously after the leader exits, so an
+// instant liveness probe races on loaded CI runners. Poll under a bounded deadline,
+// matching assertProcessDead in test/mcp/fixtures/spawn-fixture.ts.
+async function assertDead(pid: number): Promise<void> {
+	const deadline = Date.now() + 2000;
+	while (Date.now() < deadline) {
+		try {
+			process.kill(pid, 0);
+		} catch {
+			return;
+		}
+		await new Promise((resolve) => setTimeout(resolve, 25));
+	}
+	throw new Error(`process still alive after abort: ${pid}`);
 }
 
 async function collect(handle: CursorCliTransportHandle): Promise<unknown[]> {
@@ -85,7 +97,7 @@ describe("cursor CLI transport", () => {
 			),
 		).toBe(true);
 		expect(outcome).toMatchObject({ type: "completed", exitCode: 0 });
-		assertDead(handle.pid);
+		await assertDead(handle.pid);
 	});
 
 	it("aborts the exact process group and reaps both leader and descendant", async () => {
@@ -114,8 +126,8 @@ describe("cursor CLI transport", () => {
 
 		expect(events.at(-1)).toBeInstanceOf(CursorCliAbortError);
 		expect(outcome.type).toBe("aborted");
-		assertDead(handle.pid);
-		assertDead(grandchildPid);
+		await assertDead(handle.pid);
+		await assertDead(grandchildPid);
 	});
 
 	it("escalates to SIGKILL when the process ignores SIGTERM", async () => {
@@ -135,7 +147,7 @@ describe("cursor CLI transport", () => {
 		const outcome = await handle.completed;
 
 		expect(outcome.type).toBe("aborted");
-		assertDead(handle.pid);
+		await assertDead(handle.pid);
 	}, 8_000);
 
 	it("passes only the explicit environment allowlist", async () => {

--- a/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
+++ b/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
@@ -1,0 +1,95 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createProviderTimeoutRetryPlan, runBoundedRetryContinuation } from "../src/core/provider-timeout-retry.ts";
+
+const STREAM_START_TIMEOUT_MS = 90_000;
+const IDLE_TIMEOUT_MS = 300_000;
+const STREAM_RETRY_TIMEOUT_MS = 30_000;
+
+function stallMessage() {
+	return fauxAssistantMessage("", {
+		stopReason: "error",
+		errorMessage: `Provider stream start timed out after ${STREAM_START_TIMEOUT_MS}ms`,
+	});
+}
+
+/**
+ * Drives one retry continuation whose provider answers after `respondsAfterMs`,
+ * using the watchdog the plan actually produced. Returns whether the watchdog
+ * aborted the attempt before the provider answered.
+ */
+async function runRetryAttempt(watchdogTimeoutMs: number | undefined, respondsAfterMs: number) {
+	const controller = new AbortController();
+	let aborted = false;
+
+	const continuation = runBoundedRetryContinuation({
+		continueRun: () =>
+			new Promise<void>((resolve) => {
+				setTimeout(resolve, respondsAfterMs);
+			}),
+		getActiveSignal: () => controller.signal,
+		abortActive: () => {
+			aborted = true;
+			controller.abort();
+		},
+		timeoutMs: watchdogTimeoutMs,
+	});
+
+	await vi.advanceTimersByTimeAsync(Math.max(respondsAfterMs, watchdogTimeoutMs ?? 0) + 1);
+	await continuation;
+	return aborted;
+}
+
+describe("bounded retry continuation", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("lets a slow-but-alive provider answer inside the stream-start budget it was granted", async () => {
+		const plan = createProviderTimeoutRetryPlan({
+			message: stallMessage(),
+			streamRetryTimeoutMs: STREAM_RETRY_TIMEOUT_MS,
+			timeoutMs: IDLE_TIMEOUT_MS,
+			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
+		});
+
+		// The provider answers at 60s: past the 30s liveness cap, but well inside
+		// the 90s stream-start budget this same retry was handed. Aborting here is
+		// what collapsed the bounded retry budget into "Aborted after 1 retry
+		// attempt" — the attempt was killed on a deadline it was never given.
+		const aborted = await runRetryAttempt(plan.watchdogTimeoutMs, 60_000);
+
+		expect(aborted).toBe(false);
+	});
+
+	it("still cancels a retry that outlives every guard it was granted", async () => {
+		const plan = createProviderTimeoutRetryPlan({
+			message: stallMessage(),
+			streamRetryTimeoutMs: STREAM_RETRY_TIMEOUT_MS,
+			timeoutMs: IDLE_TIMEOUT_MS,
+			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
+		});
+
+		// A wedged retry that blows past the granted stream-start budget is still
+		// cancelled: the reconciliation raises the cap, it never removes it.
+		const aborted = await runRetryAttempt(plan.watchdogTimeoutMs, STREAM_START_TIMEOUT_MS * 3);
+
+		expect(aborted).toBe(true);
+	});
+
+	it("does not arm a watchdog when the operator disabled the liveness cap", async () => {
+		const plan = createProviderTimeoutRetryPlan({
+			message: stallMessage(),
+			streamRetryTimeoutMs: undefined,
+			timeoutMs: IDLE_TIMEOUT_MS,
+			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
+		});
+
+		const aborted = await runRetryAttempt(plan.watchdogTimeoutMs, STREAM_START_TIMEOUT_MS * 3);
+
+		expect(aborted).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/provider-timeout-retry.test.ts
+++ b/packages/coding-agent/test/provider-timeout-retry.test.ts
@@ -29,7 +29,7 @@ describe("provider timeout retry plan", () => {
 		});
 	});
 
-	it("bounds the retry continuation with the liveness cap without shortening provider guards", () => {
+	it("never cancels the retry before the stream-start budget it granted", () => {
 		const plan = createProviderTimeoutRetryPlan({
 			message: stallMessage(),
 			streamRetryTimeoutMs: STREAM_RETRY_TIMEOUT_MS,
@@ -37,7 +37,22 @@ describe("provider timeout retry plan", () => {
 			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
 		});
 
-		expect(plan.watchdogTimeoutMs).toBe(STREAM_RETRY_TIMEOUT_MS);
+		// The continuation watchdog must outlast the guard the same retry was handed,
+		// otherwise the retry is aborted on a deadline it was never given and the
+		// bounded retry budget collapses to a single attempt.
+		expect(plan.watchdogTimeoutMs).toBeGreaterThanOrEqual(STREAM_START_TIMEOUT_MS);
+	});
+
+	it("keeps a liveness cap that already outlasts the granted guards", () => {
+		const generousCapMs = STREAM_START_TIMEOUT_MS * 2;
+		const plan = createProviderTimeoutRetryPlan({
+			message: stallMessage(),
+			streamRetryTimeoutMs: generousCapMs,
+			timeoutMs: IDLE_TIMEOUT_MS,
+			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
+		});
+
+		expect(plan.watchdogTimeoutMs).toBe(generousCapMs);
 	});
 
 	it("never re-enables a disabled provider guard", () => {
@@ -49,7 +64,30 @@ describe("provider timeout retry plan", () => {
 		});
 
 		expect(plan.options).toEqual({ deferQueuedMessages: true });
+		// With no provider guard to outlast, the configured cap is the only bound.
 		expect(plan.watchdogTimeoutMs).toBe(STREAM_RETRY_TIMEOUT_MS);
+	});
+
+	it("reconciles the cap against a stream-start guard reported with no idle guard", () => {
+		const plan = createProviderTimeoutRetryPlan({
+			message: stallMessage(),
+			streamRetryTimeoutMs: STREAM_RETRY_TIMEOUT_MS,
+			timeoutMs: undefined,
+			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
+		});
+
+		expect(plan.watchdogTimeoutMs).toBeGreaterThanOrEqual(STREAM_START_TIMEOUT_MS);
+	});
+
+	it("disables the cap when the operator disabled it, even with guards configured", () => {
+		const plan = createProviderTimeoutRetryPlan({
+			message: stallMessage(),
+			streamRetryTimeoutMs: undefined,
+			timeoutMs: IDLE_TIMEOUT_MS,
+			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
+		});
+
+		expect(plan.watchdogTimeoutMs).toBeUndefined();
 	});
 
 	it("ignores messages that are not provider timeouts", () => {

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -9,7 +9,10 @@ import { createHarness, type Harness } from "../harness.ts";
 
 const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
 const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
-const RETRY_CONTINUATION_BOUND_MS = 30_000;
+const STREAM_RETRY_LIVENESS_CAP_MS = 30_000;
+// The continuation watchdog is reconciled against the guards the same retry was
+// granted, so it expires with the stream-start budget instead of the shorter cap.
+const RETRY_CONTINUATION_BOUND_MS = Math.max(STREAM_RETRY_LIVENESS_CAP_MS, DEFAULT_STREAM_START_TIMEOUT_MS);
 
 function createAssistantStream(): EventStream<AssistantMessageEvent, AssistantMessage> {
 	return new EventStream<AssistantMessageEvent, AssistantMessage>(
@@ -167,7 +170,7 @@ describe("provider idle recovery", () => {
 		}
 	});
 
-	it("expires a no-first-event retry at the continuation bound without shortening the provider guards", async () => {
+	it("expires a no-first-event retry at the reconciled continuation bound without shortening the provider guards", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({
 			settings: { retry: { enabled: true, maxRetries: 1, baseDelayMs: 0 } },


### PR DESCRIPTION
## Summary

A transient `Provider stream start timed out after 90000ms` ended the turn as `Aborted after 1 retry attempt` even though `retry.maxRetries` defaults to 3.

**Root cause** — the retry-continuation watchdog contradicted the guards the same retry was granted:

- `createProviderTimeoutRetryPlan` hands the retry the full configured `streamStartTimeoutMs` (90s default)
- but bounded the *continuation* with `retry.provider.streamRetryTimeoutMs` (30s default)
- so `runBoundedRetryContinuation` aborted the attempt 60s before its own deadline — no attempt could ever finish, collapsing the bounded retry budget into a single attempt

This is the residue of 218ea2806: that fix stopped clamping the retry **request** guards but left the same 30s cap bounding the **continuation**, reproducing the identical defect one layer up. Reference policies (`codex-rs` `stream_max_retries=5` / exponential backoff with jitter; no watchdog that pre-empts an in-flight attempt's own timeout) never cancel an attempt earlier than the deadline that attempt was given.

## Changes

- `src/core/provider-timeout-retry.ts`: `watchdogTimeoutMs = max(streamRetryTimeoutMs, streamStartTimeoutMs)`
  - explicitly disabled cap (`undefined`) stays disabled
  - a longer configured cap is kept unchanged
  - a retry that outlives every guard it was granted is **still cancelled** (wedge protection preserved)
- `test/provider-timeout-retry-continuation.test.ts` (new): first direct coverage of `runBoundedRetryContinuation` — a slow-but-alive provider answering at 60s (past the 30s cap, inside its 90s budget) is no longer aborted; a wedged retry past all guards still is
- `test/provider-timeout-retry.test.ts`: the assertion pinning `watchdogTimeoutMs === 30_000` while granting 90s encoded the contradiction; now asserts the reconciled contract plus override/disabled edge cases
- `test/suite/regressions/provider-idle-recovery.test.ts`: retry-bound constant reconciled the same way
- `changes.md` + `CHANGELOG.md` entries

## Verification

- **RED→GREEN, plan contract** (`test/provider-timeout-retry.test.ts`): `expected 30000 to be greater than or equal to 90000` before the fix → 7/7 after
- **RED→GREEN, continuation seam** (new file, mutation-proved against the unfixed watchdog): provider answering at 60s was aborted (`expected true to be false`) → 3/3 after
- **Regression**: 10 suites / 150 tests green (retry-fallback-stall-shared-budget, provider-idle-recovery/steering, provider-timeout-classification, provider-retry-recompaction, agent-session-retry-events, aborted-error-label, settings-manager, both provider-timeout-retry files)
- **Real surface** (real `SettingsManager` defaults, exit 0): `{streamStartTimeoutMs: 90000, streamRetryTimeoutMs: 30000, watchdogTimeoutMs: 90000}` — watchdog ≥ granted guard; retry budget 3 attempts with `[2000, 4000, 8000]` backoff intact
- Root `npm run check` (biome 3114 files, tsc, shrinkwrap, install/platform locks, browser-smoke) green in both commits' pre-commit gates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents premature cancellation of provider stream-start retries by reconciling the retry watchdog with the guards granted to the same attempt. Previously the 30s watchdog aborted attempts despite a 90s stream-start budget, collapsing retries to one attempt; now the watchdog is max(streamRetryTimeoutMs, streamStartTimeoutMs), so attempts can run to their own deadline while wedge protection remains.

- `packages/coding-agent/src/core/provider-timeout-retry.ts`: sets watchdogTimeoutMs = max(streamRetryTimeoutMs, streamStartTimeoutMs); a disabled cap stays disabled; longer configured caps are preserved; a retry that outlives all granted guards is still canceled.
- Tests: new `test/provider-timeout-retry-continuation.test.ts` covering `runBoundedRetryContinuation`; extended `test/provider-timeout-retry.test.ts`; reconciled retry-bound in `test/suite/regressions/provider-idle-recovery.test.ts`; stabilized `test/cursor-cli-oauth/transport.test.ts` by polling for process death under a 2s deadline to remove CI races.
- Docs: updated `CHANGELOG.md` and `src/core/changes.md`.
- No migration. Defaults now yield {streamStartTimeoutMs: 90000, streamRetryTimeoutMs: 30000, watchdogTimeoutMs: 90000} and spend the full `retry.maxRetries` budget.

<sup>Written for commit 0a544be4b6a146688d3d605e2304b60cf0dd7e21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

