### PR TITLE
fix(coding-agent): bind cursor exec dispatches to the owning run

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Changed
 
+- `AgentLoopConfig.cursorExecHandlers` additionally accepts a factory taking the owning run's abort signal, so
+  a host bridge can bind each Cursor exec stream to the run that opened it. The plain-object form is unchanged.
+
 ### Fixed
 
 ### Removed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -493,7 +493,10 @@ async function streamAssistantResponse(
 			// execute mid-stream; their paired results buffer here.
 			...(config.cursorExecHandlers
 				? {
-						execHandlers: config.cursorExecHandlers,
+						execHandlers:
+							typeof config.cursorExecHandlers === "function"
+								? config.cursorExecHandlers(requestAbortController.signal)
+								: config.cursorExecHandlers,
 						onToolResult: (result: ToolResultMessage) => {
 							providerToolResults.push(result);
 						},

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -18,6 +18,12 @@
   of executing it inside the replacement run.
 - The plain-object form is unchanged, so existing hosts keep working.
 
+### Why an extension could not handle it
+
+- Only the loop knows which run owns the stream it is opening. The owning
+  signal exists solely inside `streamAssistantResponse` at stream creation, so
+  no extension hook can supply it to the host bridge after the fact.
+
 ### Expected merge conflict zones
 
 - `agent-loop.ts` `execHandlers` injection block, `types.ts`

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,28 @@
 # Changes
 
+## Cursor exec handlers bind to their owning run (2026-08-18)
+
+### What changed
+
+- `packages/agent/src/types.ts`: `AgentLoopConfig.cursorExecHandlers` also
+  accepts a `(runSignal: AbortSignal) => CursorExecHandlers` factory.
+- `packages/agent/src/agent-loop.ts`: when a factory is supplied, the loop
+  resolves it with `requestAbortController.signal` — the signal of the run that
+  owns the stream being opened.
+
+### Why
+
+- A host bridge built once per session cannot tell which run an exec frame
+  belongs to. Handing it the owning run's signal at stream creation lets the
+  host refuse a straggler frame from a stream whose run already ended, instead
+  of executing it inside the replacement run.
+- The plain-object form is unchanged, so existing hosts keep working.
+
+### Expected merge conflict zones
+
+- `agent-loop.ts` `execHandlers` injection block, `types.ts`
+  `cursorExecHandlers` declaration.
+
 ## 2026-08-18 - Thinking-selection provenance through the agent loop
 
 ### What changed

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -167,7 +167,7 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * paired `ToolResultMessage` for emission right after the assistant
 	 * message. Other providers ignore this field.
 	 */
-	cursorExecHandlers?: CursorExecHandlers;
+	cursorExecHandlers?: CursorExecHandlers | ((runSignal: AbortSignal) => CursorExecHandlers);
 
 	/**
 	 * Maximum time in milliseconds to wait for the FIRST provider stream event.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - Messages typed while auto-compaction is running are no longer silently dropped: input submitted during `Compacting context...` is queued and delivered after compaction settles instead of being accepted and discarded. Manual `/compact` keeps rejecting unqueueable prompts as before ([#950](https://github.com/code-yeongyu/senpi/pull/950)).
 
+- Cursor exec-bridge dispatches are now bound to the run that opened their stream, so a straggler exec frame from a run that already ended (for example after a provider rate-limit error restarts the turn on a fallback lane) is refused instead of executing a dead run's tool inside the replacement run and leaking its lifecycle events into the new transcript.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -34,6 +34,39 @@
 - `packages/coding-agent/src/core/agent-session.ts`: the `prompt()` queue
   eligibility constants and the queue branches preceding the settled-work wait.
 
+## Cursor bridge dispatches bind to the run that owns the stream (2026-08-18)
+
+### What changed
+
+- `packages/coding-agent/src/core/cursor-exec-bridge-session.ts`: the session
+  adapter accepts the signal of the run that owns the exec stream and resolves
+  `getAbortSignal` from it, returning `undefined` once that run is no longer
+  the agent's live run.
+- `packages/coding-agent/src/core/sdk.ts`: supplies the bridge as a per-run
+  factory so every Cursor stream gets handlers bound to its own run.
+
+### Why
+
+- The bridge is built once per session, but each exec stream belongs to exactly
+  one run. Resolving ownership from the agent's live signal let a straggler
+  frame from a stream whose run had already ended adopt the replacement run's
+  signal, clear the ownership guard in `Agent.emitExternalEvent`, and execute a
+  dead run's tool inside the new run while emitting its lifecycle events into
+  the new run's transcript.
+- This is the shape the crashed 2026-08-18 session hit: a provider rate-limit
+  error restarted the run on a fallback lane while the previous stream still
+  held buffered exec frames.
+
+### Why an extension could not handle it
+
+- Run ownership of provider-driven exec frames is an engine contract between
+  the agent loop and the Cursor stream; no extension hook sits between the
+  straggler frame and the bridge dispatch.
+
+### Expected merge conflict zones
+
+- `cursor-exec-bridge-session.ts` signature and `getAbortSignal` resolution,
+  `sdk.ts` `cursorExecHandlers` wiring.
 ## 2026-08-18 - Cursor reasoning levels: session provenance and legacy id resolution
 
 ### What changed
@@ -136,7 +169,6 @@
 
 - LOW: the `cerebras` row in `defaultModelPerProvider` and the matching pin in `test/model-resolver.test.ts`.
 
-<<<<<<< HEAD
 ## Cursor CLI OAuth provider display name (2026-08-17)
 
 ### What changed
@@ -163,8 +195,6 @@
 
 - LOW: `provider-display-names.ts` map rows (one-line additions in a sorted literal).
 
-||||||| 84514a353
-=======
 ## Repository audit baseline for the core tracker (2026-08-17)
 
 ### What changed
@@ -756,8 +786,6 @@
 ### Expected merge conflict zones
 
 - LOW: additive block after `restoreStdout()`; the stdout takeover above it is the pattern to follow on sync.
-
->>>>>>> origin/main
 ## Expand explicit dollar skill tokens and publish invocation metadata (2026-08-16) ([PR #909](https://github.com/code-yeongyu/senpi/pull/909))
 
 ### What changed

--- a/packages/coding-agent/src/core/cursor-exec-bridge-session.ts
+++ b/packages/coding-agent/src/core/cursor-exec-bridge-session.ts
@@ -8,9 +8,21 @@ export interface CursorExecBridgeSession {
 	preflightToolCall(toolCall: AgentToolCall, args: unknown): Promise<BeforeToolCallResult | undefined>;
 }
 
+/**
+ * Build the exec handlers for ONE Cursor run.
+ *
+ * `runSignal` is the signal of the run that owns this stream, captured when
+ * the loop opens it. Resolving ownership from the agent's live signal instead
+ * would let a straggler frame from a stream whose run already ended (a
+ * provider error or rate-limit fallback restarts the run while its h2 stream
+ * still holds buffered exec frames) adopt the replacement run's signal, clear
+ * the ownership guard in `Agent.emitExternalEvent`, and execute a dead run's
+ * tool inside the new run.
+ */
 export function createSessionCursorExecBridge(
 	sessionRef: { current?: CursorExecBridgeSession },
 	getAgent: () => CursorBridgeAgent,
+	runSignal?: AbortSignal,
 ) {
 	return createCursorExecBridge({
 		getTool: (name) => sessionRef.current?.getRegisteredTool(name),
@@ -26,6 +38,9 @@ export function createSessionCursorExecBridge(
 			),
 		emitEvent: async (event: AgentEvent, runSignal: AbortSignal) =>
 			await getAgent().emitExternalEvent(event, runSignal),
-		getAbortSignal: () => getAgent().signal,
+		getAbortSignal: () => {
+			if (runSignal === undefined) return getAgent().signal;
+			return runSignal === getAgent().signal ? runSignal : undefined;
+		},
 	});
 }

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -447,7 +447,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		timeoutMs: settingsManager.getAgentStreamIdleTimeoutMs(),
 		streamStartTimeoutMs: settingsManager.getAgentStreamStartTimeoutMs(),
 		maxRetryDelayMs: settingsManager.getProviderRetrySettings().maxRetryDelayMs,
-		cursorExecHandlers: createSessionCursorExecBridge(cursorBridgeSessionRef, () => agent),
+		cursorExecHandlers: (runSignal: AbortSignal) =>
+			createSessionCursorExecBridge(cursorBridgeSessionRef, () => agent, runSignal),
 	});
 	// Agent core accepts the field in AgentState but older constructors may not copy it
 	// from initialState; assign the separately computed provenance explicitly.

--- a/packages/coding-agent/test/cursor-exec-bridge-run-ownership.test.ts
+++ b/packages/coding-agent/test/cursor-exec-bridge-run-ownership.test.ts
@@ -1,0 +1,136 @@
+import { Agent, type AgentEvent, type AgentTool } from "@earendil-works/pi-agent-core";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type ToolResultMessage,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { type CursorExecBridgeSession, createSessionCursorExecBridge } from "../src/core/cursor-exec-bridge-session.ts";
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+function isToolResult(value: unknown): value is ToolResultMessage {
+	return typeof value === "object" && value !== null && "role" in value && value.role === "toolResult";
+}
+
+function stubReadTool(execute: () => void): AgentTool {
+	const parameters = Type.Object({ path: Type.String() });
+	return {
+		name: "read",
+		label: "read",
+		description: "stub read",
+		parameters,
+		execute: async () => {
+			execute();
+			return { content: [{ type: "text", text: "read ok" }], details: undefined };
+		},
+	} as unknown as AgentTool;
+}
+
+describe("cursor exec bridge run ownership across runs", () => {
+	it("refuses a late exec frame from a finished run instead of leaking it into the replacement run", async () => {
+		const runAStarted = createDeferred();
+		const runBStarted = createDeferred();
+		const runAStream = new MockAssistantStream();
+		const runBStream = new MockAssistantStream();
+		let streamIndex = 0;
+
+		const agent = new Agent({
+			streamFn: () => {
+				if (streamIndex++ === 0) {
+					runAStarted.resolve();
+					return runAStream;
+				}
+				runBStarted.resolve();
+				return runBStream;
+			},
+		});
+
+		const externalEvents: AgentEvent[] = [];
+		agent.subscribe((event) => {
+			if (event.type === "tool_execution_start" || event.type === "tool_execution_end") {
+				externalEvents.push(event);
+			}
+		});
+
+		const execute = vi.fn();
+		const tool = stubReadTool(execute);
+		const session: CursorExecBridgeSession = {
+			getRegisteredTool: (name) => (name === "read" ? tool : undefined),
+			preflightToolCall: async () => undefined,
+		};
+		const sessionRef = { current: session };
+
+		// given run A is streaming and owns the Cursor exec stream
+		const runA = agent.prompt("run A");
+		await runAStarted.promise;
+		const runASignal = agent.signal;
+		expect(runASignal).toBeDefined();
+		const bridge = createSessionCursorExecBridge(sessionRef, () => agent, runASignal);
+
+		// and run A has ended while its stream still holds a buffered exec frame
+		runAStream.push({ type: "done", reason: "stop", message: createAssistantMessage("run A done") });
+		await runA;
+
+		// and the fallback lane has started run B on another provider
+		const runB = agent.prompt("run B");
+		await runBStarted.promise;
+		const runBSignal = agent.signal;
+		expect(runBSignal).toBeDefined();
+		expect(runBSignal).not.toBe(runASignal);
+		externalEvents.length = 0;
+
+		// when run A's straggler exec frame arrives during run B
+		const late = await bridge.read?.({ path: "a.ts", toolCallId: "late-run-a-frame" } as never);
+
+		// then it neither executes a tool nor leaks lifecycle events into run B
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(externalEvents).toEqual([]);
+		expect(isToolResult(late) && late.isError).toBe(true);
+
+		runBStream.push({ type: "done", reason: "stop", message: createAssistantMessage("run B done") });
+		await runB;
+	});
+});

--- a/packages/coding-agent/test/manual-qa/cursor-bridge-late-frame-qa.mjs
+++ b/packages/coding-agent/test/manual-qa/cursor-bridge-late-frame-qa.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { Agent } from "@earendil-works/pi-agent-core";
+import { EventStream } from "@earendil-works/pi-ai";
+import { createSessionCursorExecBridge } from "../../dist/core/cursor-exec-bridge-session.js";
+
+const MODE = process.argv.includes("--unbound") ? "unbound" : "bound";
+
+class MockStream extends EventStream {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => (event.type === "done" ? event.message : event.error),
+		);
+	}
+}
+
+function assistantMessage(text) {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function deferred() {
+	let resolve;
+	const promise = new Promise((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+const runAStarted = deferred();
+const runBStarted = deferred();
+const runAStream = new MockStream();
+const runBStream = new MockStream();
+let index = 0;
+
+const agent = new Agent({
+	streamFn: () => {
+		if (index++ === 0) {
+			runAStarted.resolve();
+			return runAStream;
+		}
+		runBStarted.resolve();
+		return runBStream;
+	},
+});
+
+let toolRuns = 0;
+const leakedEvents = [];
+agent.subscribe((event) => {
+	if (event.type === "tool_execution_start" || event.type === "tool_execution_end") {
+		leakedEvents.push(event.type);
+	}
+});
+
+const session = {
+	getRegisteredTool: (name) =>
+		name === "read"
+			? {
+					name: "read",
+					label: "read",
+					description: "qa read",
+					parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+					execute: async () => {
+						toolRuns++;
+						return { content: [{ type: "text", text: "read ok" }], details: undefined };
+					},
+				}
+			: undefined,
+	preflightToolCall: async () => undefined,
+};
+
+const runA = agent.prompt("run A");
+await runAStarted.promise;
+const runASignal = agent.signal;
+
+const bridge = createSessionCursorExecBridge(
+	{ current: session },
+	() => agent,
+	MODE === "bound" ? runASignal : undefined,
+);
+
+runAStream.push({ type: "done", reason: "stop", message: assistantMessage("run A done") });
+await runA;
+
+const runB = agent.prompt("run B");
+await runBStarted.promise;
+leakedEvents.length = 0;
+
+const late = await bridge.read({ path: "qa.txt", toolCallId: "late-frame" });
+
+runBStream.push({ type: "done", reason: "stop", message: assistantMessage("run B done") });
+await runB;
+
+const leaked = toolRuns > 0 || leakedEvents.length > 0;
+console.log(JSON.stringify({ mode: MODE, toolRuns, leakedEvents, lateIsError: late?.isError === true, leaked }, null, 1));
+console.log(leaked ? "RESULT: LEAKED (dead run executed inside replacement run)" : "RESULT: CONTAINED (late frame refused)");
+process.exit(leaked ? 1 : 0);


### PR DESCRIPTION
## Problem

A senpi session crashed the whole process with:

```
omo exiting due to uncaughtException:
Error: Agent listener invoked outside active run
    at Agent.processEvents (pi-agent-core/dist/agent.js:512)
    at Agent.emitExternalEvent (pi-agent-core/dist/agent.js:528)
    at Object.emitEvent (senpi/dist/core/cursor-exec-bridge-session.js:12)
    at executeTool (senpi/dist/core/cursor-exec-bridge.js:66)
    at Object.read (senpi/dist/core/cursor-exec-bridge.js:128)
    at resolveExecHandler (pi-ai/dist/api/cursor-agent.js:1448)
```

The crashing build was `@code-yeongyu/senpi` 2026.8.17, which predates the guard in 6d2601aba. The transcript of the crashed session shows the exact shape:

1. `claude-fable-5` returns HTTP 429 (`All tokens rate limited`, retry-after 1656s)
2. the fallback lane restarts the turn on `cursor/kimi-k3-low`
3. that run ends with `Invalid native tool call event order`
4. every buffered bridge tool result lands in the same instant as the run tears down
5. process dies

The guard shipped in 6d2601aba closes the crash itself. **But the ownership check it relies on can still be satisfied by the wrong run.**

## Remaining defect this PR fixes

`createSessionCursorExecBridge` wired ownership as:

```ts
getAbortSignal: () => getAgent().signal
```

That re-reads whichever run is active **now**. The bridge is built once per session, but each Cursor exec stream belongs to exactly one run. After a fallback restart, a straggler frame from the dead run's stream captures the **replacement** run's signal, so `Agent.emitExternalEvent`'s ownership comparison matches, and the dead run's tool really executes inside the new run — emitting its lifecycle events into the new transcript.

The existing test `keeps the originating run signal on both lifecycle events` cannot catch this: it passes a fixed `runSignal` closure and never crosses a run boundary.

## Fix

- `AgentLoopConfig.cursorExecHandlers` also accepts `(runSignal: AbortSignal) => CursorExecHandlers`; the loop resolves it with `requestAbortController.signal` — the run that owns the stream. The plain-object form is unchanged, so other hosts are unaffected.
- `createSessionCursorExecBridge` takes that signal and returns `undefined` from `getAbortSignal` once it is no longer the live run, which makes the bridge refuse the dispatch before executing anything.
- `sdk.ts` supplies the bridge as a per-run factory.

## Verification

**Failing-first regression** (`packages/coding-agent/test/cursor-exec-bridge-run-ownership.test.ts`), on unmodified `main`:

```
FAIL > refuses a late exec frame from a finished run instead of leaking it into the replacement run
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

It fails for the right reason: the dead run's frame executed a real tool inside the replacement run. Green after the fix.

**Real-surface QA** against the built `dist` (`test/manual-qa/cursor-bridge-late-frame-qa.mjs`), real `Agent` + real bridge across a run boundary:

| mode | result |
|---|---|
| `--unbound` (pre-fix wiring) | `{"toolRuns":1,"leakedEvents":["tool_execution_start","tool_execution_end"],"lateIsError":false}` → LEAKED, exit 1 |
| default (bound wiring) | `{"toolRuns":0,"leakedEvents":[],"lateIsError":true}` → CONTAINED, exit 0 |

**Suites**

- `packages/agent`: 36 files, 506 passed, 1 pre-existing skip
- focused bridge + loop coverage: 69 passed
- `packages/agent`, `packages/ai`, `packages/coding-agent` builds: exit 0

Two `packages/coding-agent` fork/session CLI test files fail identically on unmodified `main` in this environment (`8 failed | 82 passed` both with and without the change), so they are pre-existing and unrelated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind Cursor exec dispatches to the run that opened their stream to stop late frames from a finished run executing in a replacement run and leaking lifecycle events. Previously the bridge re-read the agent’s live signal; now each stream uses its owning run’s AbortSignal and late frames return an error ToolResult instead of executing. 

- `packages/agent`: `AgentLoopConfig.cursorExecHandlers` also accepts `(runSignal: AbortSignal) => CursorExecHandlers`; `agent-loop` resolves it with `requestAbortController.signal` for the owning run. Plain-object form is unchanged.
- `packages/coding-agent`: `createSessionCursorExecBridge(sessionRef, getAgent, runSignal)` binds to the owning run; `getAbortSignal` returns `undefined` once that run is no longer live; `sdk.ts` supplies a per-run factory.
- Migration: No changes for hosts using the object form. To bind per-run, pass the new factory and use `runSignal`.
- Tests/QA: Adds a regression unit test that previously leaked into a replacement run (now passing) and a manual QA driver (`--unbound` reproduces leak, default refuses late frames).
- Docs: Adds the missing canonical section in `packages/agent/src/changes.md` to satisfy the changelog gate (no runtime impact).

<sup>Written for commit 198082ba97a38cd1996dc776b004fe48da565b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

