### PR TITLE
fix(tool-call-middleware): recover wire-aliased tool names in leaked invokes

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -21,6 +21,13 @@
 
 ### Fixed
 
+- Leaked-invoke recovery now resolves upstream wire-aliased tool names (ccapi
+  PascalCase disguises like `TaskSend`, CC-pool hashed prefixes like
+  `mcp_49f0-Todo`, CC-SDK `mcp__server__tool` forms), so a text-leaked
+  `<invoke name="mcp_49f0-Todo">` recovers into the registered `todo` tool
+  call instead of rendering as literal text. Alias collisions between
+  registered tools stay literal text.
+
 ### Removed
 
 ## [2026.8.18-2] - 2026-08-18

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -2,6 +2,25 @@
 
 # Tool Call Middleware Changes
 
+## 2026-08-18 - Wire-alias tool-name resolution in invoke recovery
+
+### What changed and why
+
+- Upstream gateways disguise tool names on the wire: ccapi-cf Pascal-cases
+  `todo` to `Todo`, and CC-pool layers expose non-native tools as
+  `mcp_<hash>-<Name>` (observed live: `mcp_49f0-Todo`). Reverse mapping only
+  rewrites native `tool_use` blocks, so a leaked text invoke keeps the wire
+  alias and the recovery resolver vetoed it as an unknown tool, emitting the
+  raw XML as literal text (incident: session 01a01381, event 1214,
+  `ccapi-clb/claude-opus-5`, stop_reason `tool_use` with zero tool calls).
+- `createToolResolver` now falls back to an alias map that strips CC-SDK
+  `mcp__server__tool` prefixes, hashed `mcp_<hash>-` prefixes, and collapses
+  remaining separators/case onto the registered name's alphanumerics.
+- The fallback runs only after exact and case-insensitive matching miss, so
+  existing precedence is unchanged. Two registered tools collapsing onto the
+  same alias key resolve to neither (mirrors the insensitive-map collision
+  rule), keeping hallucinated names as literal text.
+
 ## 2026-08-18 - Cursor exec marker preservation
 
 ### What changed and why

--- a/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/tool-resolver.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/anthropic-xml/tool-resolver.ts
@@ -2,13 +2,31 @@ import type { Tool } from "../../../types.ts";
 
 export type ToolResolver = (toolName: string) => Tool | undefined;
 
+const CC_MCP_PREFIX = /^mcp(?:__[^_]+)*__/;
+const HASHED_MCP_PREFIX = /^mcp_[a-z0-9]+-/i;
+
+/**
+ * Reduces a tool name to its alias key: the wire-name decorations upstream
+ * gateways add (CC-SDK `mcp__server__tool`, hashed `mcp_<hash>-Name`,
+ * PascalCase disguises) collapse onto the same alphanumerics as the
+ * registered snake_case name.
+ */
+function toAliasKey(name: string): string {
+	const stripped = name.replace(CC_MCP_PREFIX, "").replace(HASHED_MCP_PREFIX, "");
+	return stripped.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 export function createToolResolver(tools: readonly Tool[]): ToolResolver {
 	const exactToolMap = new Map(tools.map((tool) => [tool.name, tool]));
 	const insensitiveToolMap = new Map<string, Tool | null>();
+	const aliasToolMap = new Map<string, Tool | null>();
 	for (const tool of tools) {
 		const normalizedName = tool.name.toLowerCase();
 		const existing = insensitiveToolMap.get(normalizedName);
 		insensitiveToolMap.set(normalizedName, existing === undefined ? tool : existing === tool ? tool : null);
+		const aliasKey = toAliasKey(tool.name);
+		const existingAlias = aliasToolMap.get(aliasKey);
+		aliasToolMap.set(aliasKey, existingAlias === undefined ? tool : existingAlias === tool ? tool : null);
 	}
 
 	return (toolName: string): Tool | undefined => {
@@ -17,6 +35,11 @@ export function createToolResolver(tools: readonly Tool[]): ToolResolver {
 			return exactTool;
 		}
 
-		return insensitiveToolMap.get(toolName.toLowerCase()) ?? undefined;
+		const insensitiveTool = insensitiveToolMap.get(toolName.toLowerCase());
+		if (insensitiveTool) {
+			return insensitiveTool;
+		}
+
+		return aliasToolMap.get(toAliasKey(toolName)) ?? undefined;
 	};
 }

--- a/packages/ai/test/tool-call-middleware/invoke-recovery-tool-alias.test.ts
+++ b/packages/ai/test/tool-call-middleware/invoke-recovery-tool-alias.test.ts
@@ -1,0 +1,131 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { wrapStreamWithInvokeRecovery } from "../../src/index.ts";
+import type { AssistantMessage, Tool, ToolCall } from "../../src/types.ts";
+import { bashTool, terminal, toolEvents } from "./invoke-recovery-scenario-fixtures.ts";
+import { collectEvents, TextStreamHarness } from "./invoke-recovery-stream-fixtures.ts";
+
+// Upstream gateways disguise tool names on the wire: ccapi-cf pascal-cases
+// `todo` -> `Todo`, and CC-pool layers expose non-native tools as
+// `mcp_<hash>-<Name>` (e.g. `mcp_49f0-Todo`). Reverse mapping only covers
+// native tool_use blocks, so a leaked text invoke keeps the wire alias and the
+// recovery resolver must still recognize the registered tool behind it.
+
+const todoTool = {
+	name: "todo",
+	description: "Manage todos",
+	parameters: Type.Object({
+		op: Type.String(),
+		task: Type.Optional(Type.String()),
+	}),
+} satisfies Tool;
+
+const taskSendTool = {
+	name: "task_send",
+	description: "Send to a task",
+	parameters: Type.Object({ to: Type.String() }),
+} satisfies Tool;
+
+const todoTwinTool = {
+	name: "to_do",
+	description: "Ambiguous twin of todo",
+	parameters: Type.Object({ op: Type.String() }),
+} satisfies Tool;
+
+// Exact bytes captured from session 01a01381 event 1214 (ccapi-clb claude-opus-5),
+// including the stray `count` text prefix the model emitted before the invoke.
+const leakedTodoInvoke =
+	'count\n<invoke name="mcp_49f0-Todo">\n<parameter name="op">done</parameter>\n<parameter name="task">Review loop until mergeable</parameter>\n</invoke>';
+
+async function runLeak(input: string, tools: readonly Tool[]) {
+	const producer = new TextStreamHarness();
+	const wrapped = wrapStreamWithInvokeRecovery(producer.inner, tools);
+	producer.start();
+	producer.delta(input);
+	producer.finish();
+	const events = await collectEvents(wrapped);
+	return { events, result: await wrapped.result() };
+}
+
+function callBlocks(result: AssistantMessage): ToolCall[] {
+	const calls: ToolCall[] = [];
+	for (const block of result.content) {
+		if (block.type === "toolCall") calls.push(block);
+	}
+	return calls;
+}
+
+function textContent(result: AssistantMessage): string {
+	let text = "";
+	for (const block of result.content) {
+		if (block.type === "text") text += block.text;
+	}
+	return text;
+}
+
+describe("invoke recovery with upstream wire-aliased tool names", () => {
+	it("recovers the exact ccapi-clb leak: mcp_49f0-Todo -> todo", async () => {
+		const { events, result } = await runLeak(leakedTodoInvoke, [todoTool]);
+		const calls = callBlocks(result);
+		expect(calls, textContent(result)).toHaveLength(1);
+		expect(calls[0]?.name).toBe("todo");
+		expect(calls[0]?.arguments).toEqual({ op: "done", task: "Review loop until mergeable" });
+		expect(toolEvents(events)).toHaveLength(3);
+		expect(textContent(result)).toBe("count\n");
+		expect(terminal(events)[0]?.type).toBe("done");
+	});
+
+	it("resolves hash-variant prefixes, bare pascal aliases, and CC-SDK MCP names", async () => {
+		const cases: Array<[string, string, readonly Tool[]]> = [
+			['<invoke name="mcp_deadbeef-Todo"><parameter name="op">done</parameter></invoke>', "todo", [todoTool]],
+			['<invoke name="Todo"><parameter name="op">done</parameter></invoke>', "todo", [todoTool]],
+			['<invoke name="TaskSend"><parameter name="to">st_1</parameter></invoke>', "task_send", [taskSendTool]],
+			[
+				'<invoke name="mcp_49f0-TaskSend"><parameter name="to">st_1</parameter></invoke>',
+				"task_send",
+				[taskSendTool],
+			],
+			['<invoke name="mcp__custom-tools__todo"><parameter name="op">done</parameter></invoke>', "todo", [todoTool]],
+		];
+		for (const [input, expected, tools] of cases) {
+			const { result } = await runLeak(input, tools);
+			const calls = callBlocks(result);
+			expect(calls, `alias case ${input}`).toHaveLength(1);
+			expect(calls[0]?.name, `alias case ${input}`).toBe(expected);
+		}
+	});
+
+	it("keeps hallucinated and ambiguous names as literal text", async () => {
+		const unknown = await runLeak(
+			'<invoke name="mcp_49f0-DoesNotExist"><parameter name="op">done</parameter></invoke>',
+			[todoTool],
+		);
+		expect(callBlocks(unknown.result)).toHaveLength(0);
+		expect(textContent(unknown.result)).toContain("mcp_49f0-DoesNotExist");
+
+		const sendTwinTool = { ...taskSendTool, name: "tasksend" } satisfies Tool;
+		const ambiguous = await runLeak('<invoke name="mcp_1-TaskSend"><parameter name="to">st_1</parameter></invoke>', [
+			taskSendTool,
+			sendTwinTool,
+		]);
+		expect(callBlocks(ambiguous.result)).toHaveLength(0);
+		expect(textContent(ambiguous.result)).toContain('name="mcp_1-TaskSend"');
+
+		const exact = await runLeak('<invoke name="todo"><parameter name="op">done</parameter></invoke>', [
+			todoTool,
+			todoTwinTool,
+		]);
+		const exactCalls = callBlocks(exact.result);
+		expect(exactCalls).toHaveLength(1);
+		expect(exactCalls[0]?.name).toBe("todo");
+	});
+
+	it("preserves the classic exact-name recovery path", async () => {
+		const { result } = await runLeak('<invoke name="Bash"><parameter name="command">echo hi</parameter></invoke>', [
+			bashTool,
+		]);
+		const calls = callBlocks(result);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.name).toBe("Bash");
+	});
+});


### PR DESCRIPTION
## Problem

A live session (`ccapi-clb/claude-opus-5`, senpi repo cwd) ended its turn with `stop_reason: tool_use` but **zero tool calls** — the model leaked the call as literal text (session `01a01381-b333`, event 1214):

```
count
<invoke name="mcp_49f0-Todo">
<parameter name="op">done</parameter>
<parameter name="task">Review loop until mergeable</parameter>
</invoke>
```

Invoke recovery is armed for claude-family ids and the tag parser matched the bare `<invoke>` — the call was vetoed by the tool-name resolver.

## Root cause

Three layers alias tool names on the wire, but only native `tool_use` blocks get reverse-mapped:

1. senpi registers `todo`
2. ccapi-cf pascal-disguises it to `Todo` (`transformToolNamesToPascalCase`)
3. the CC-pool upstream exposes non-CC-native tools as `mcp_<hash>-<Name>` → `mcp_49f0-Todo`

When the model emits the tool call as **text**, no layer translates the alias back. `createToolResolver` (exact + case-insensitive only) missed `mcp_49f0-Todo` vs `todo`, and `handleIdleTag`'s unknown-tool branch re-emitted the invoke as plain text — by design, as an anti-hallucination gate.

## Fix

`createToolResolver` gains a **fallback alias map**, consulted only after exact and case-insensitive matching miss:

- strip CC-SDK `mcp__server__tool` prefixes, then hashed `mcp_<hash>-` prefixes
- collapse remaining case/separators onto the alphanumerics of the registered name (`TaskSend` ≡ `task_send`)

Safety properties (all pinned by tests):

- exact and case-insensitive precedence unchanged (fallback only on miss)
- two registered tools collapsing onto the same alias key resolve to **neither** (mirrors the existing insensitive-map collision rule)
- unregistered/hallucinated names still stay literal text

## Evidence

- RED at base `524d2cc72`: new suite `invoke-recovery-tool-alias.test.ts` → 3 failed / 1 passed (leak recovered 0 calls, alias matrix 0 calls — failing for the right reason)
- GREEN after fix: 4/4; full middleware suite 41 files / **497 passed** (base 40/493)
- packages/ai full suite: **2135 passed** | 865 skipped (pre-existing live-API key gates); `tsc -p tsconfig.build.json --noEmit` clean; `biome check --error-on-warnings` clean on changed files
- Real-surface replay through the production entrypoint `wrapStreamWithModelRecovery` (claude-opus-5 model id, exact incident bytes incl. the `count` prefix):
  - recovered: `{"type":"toolCall","id":"recovered-antml-0","name":"todo","arguments":{"op":"done","task":"Review loop until mergeable"}}`
  - residual text: `"count\n"` → QA PASS
- Local changelog gate: `CHANGELOG_GATE_BASE=524d2cc72` → PASS

Closes the incident class where ccapi/CC-pool sessions surface raw invoke XML in the TUI and stall the turn.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers leaked invoke XML that used upstream wire-aliased tool names, so they resolve to registered tools instead of rendering as literal text. Previously, `<invoke name="mcp_49f0-Todo">` was vetoed as unknown; now it resolves to `todo` without changing match precedence or hallucination safeguards.

- `createToolResolver` now falls back to an alias map only after exact and case-insensitive matches miss.
- Alias rules: strip CC-SDK `mcp__server__tool` and hashed `mcp_<hash>-` prefixes, then collapse case/separators to alphanumerics (e.g., `mcp_49f0-Todo` → `todo`, `TaskSend` → `task_send`).
- Safety: precedence unchanged; collisions between registered tools resolve to neither; unregistered names stay literal text.
- Tests and docs: added `invoke-recovery-tool-alias.test.ts`; updated `packages/ai/CHANGELOG.md` and middleware changes notes; resolved CHANGELOG merge conflict with the recent cursor schema sanitization entry.

<sup>Written for commit 2c880f5df54400b42108a79796fc70f8ebcfad0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

