### PR TITLE
fix(ai): track cursor context windows to the models.dev first-party SSOT

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Cursor context windows now track the models.dev first-party catalog capped by the context options
+  Cursor offers each family: current Claude families and GPT 5.5/5.6 report 1M, Grok 500K, Gemini Flash
+  1048576, and each request asks Cursor for the matching `context` token.
+
 ### Breaking Changes
 
 ### Added

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,32 @@
 # AI Source Changes
 
+## 2026-08-18 - Cursor context windows tracked to the models.dev first-party SSOT
+
+### What changed
+
+- `packages/ai/src/cursor/model-capabilities.ts`: window values now derive from the models.dev
+  first-party catalog capped by the `context` options Cursor actually offers each family, and the
+  capability gains `requestContext` — the context token matching the advertised window.
+- `packages/ai/src/cursor/selection-descriptor.ts`: the wire mapper emits
+  `requestContext ?? defaultContext`, so a family advertising 1M also asks Cursor for `context=1m`.
+
+### Why
+
+- Claude families were encoded at 300000, copied from the cursor-agent CLI listing's stale
+  "(300K context)" display labels; models.dev, Cursor's `1m` context option, and the models' own "1M"
+  display names all agree they are 1000000. Advertising a window larger than the context the request
+  asks for would let compaction overrun what Cursor was told to allocate, so the two values are one
+  contract and are now verified together.
+
+### Why an extension could not handle it
+
+- The capability table and the protobuf/CLI wire mapper are core provider data consumed by both
+  Cursor transports; no extension hook sits between them.
+
+### Expected merge conflict zones
+
+- `model-capabilities.ts` family table and helper signatures, `selection-descriptor.ts` parameter switch.
+
 ## 2026-08-18 - Cursor reasoning levels end to end
 
 ### What changed

--- a/packages/ai/src/cursor/model-capabilities.ts
+++ b/packages/ai/src/cursor/model-capabilities.ts
@@ -17,6 +17,8 @@ export interface CursorModelCapability {
 	readonly maxWindow?: number;
 	readonly parameterOrder: readonly CursorParameterId[];
 	readonly defaultContext?: string;
+	/** Context token matching `window`; cursor truncates to whatever this asks for. */
+	readonly requestContext?: string;
 	readonly levels: Partial<Record<ModelThinkingLevel, CursorLevelSpec>>;
 }
 
@@ -47,17 +49,24 @@ function claude(
 		maxWindow,
 		parameterOrder: CLAUDE_ORDER,
 		defaultContext,
+		requestContext: window >= 1_000_000 ? "1m" : defaultContext,
 		levels: ladder(levels),
 	};
 }
 
-function gpt(levels: readonly string[], order: readonly CursorParameterId[] = GPT_ORDER): CursorModelCapability {
+function gpt(
+	levels: readonly string[],
+	order: readonly CursorParameterId[] = GPT_ORDER,
+	window = 400000,
+	maxWindow = 400000,
+): CursorModelCapability {
 	return {
 		evidence: "available-models",
-		window: 272000,
-		maxWindow: 1000000,
+		window,
+		maxWindow,
 		parameterOrder: order,
 		defaultContext: "272k",
+		requestContext: window >= 1_000_000 ? "1m" : "272k",
 		levels: ladder(levels),
 	};
 }
@@ -70,11 +79,11 @@ function gpt(levels: readonly string[], order: readonly CursorParameterId[] = GP
  * authoritative source; see .omo/plans/cursor-reasoning-levels.md §3.1/§6.
  */
 export const CURSOR_MODEL_CAPABILITIES: Record<string, CursorModelCapability> = {
-	"claude-fable-5": claude(300000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
-	"claude-sonnet-5": claude(300000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
-	"claude-opus-4-7": claude(300000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
-	"claude-opus-4-8": claude(300000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
-	"claude-opus-5": claude(300000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
+	"claude-fable-5": claude(1000000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
+	"claude-sonnet-5": claude(1000000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
+	"claude-opus-4-7": claude(1000000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
+	"claude-opus-4-8": claude(1000000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
+	"claude-opus-5": claude(1000000, 1000000, ["low", "medium", "high", "xhigh", "max"], "300k"),
 	"claude-4.6-opus": claude(1000000, 1000000, ["high", "max"], "200k"),
 	"claude-4.6-sonnet": claude(1000000, 1000000, ["medium"], "200k"),
 	"claude-4.5-opus": {
@@ -83,11 +92,11 @@ export const CURSOR_MODEL_CAPABILITIES: Record<string, CursorModelCapability> = 
 		parameterOrder: ["thinking"],
 		levels: { high: { value: "high", encoding: V } },
 	},
-	"gpt-5.6-sol": gpt(["none", "low", "medium", "high", "xhigh", "max"]),
-	"gpt-5.6-luna": gpt(["none", "low", "medium", "high", "xhigh", "max"]),
-	"gpt-5.6-terra": gpt(["none", "low", "medium", "high", "xhigh", "max"]),
+	"gpt-5.6-sol": gpt(["none", "low", "medium", "high", "xhigh", "max"], GPT_ORDER, 1000000, 1000000),
+	"gpt-5.6-luna": gpt(["none", "low", "medium", "high", "xhigh", "max"], GPT_ORDER, 1000000, 1000000),
+	"gpt-5.6-terra": gpt(["none", "low", "medium", "high", "xhigh", "max"], GPT_ORDER, 272000, 272000),
 	"gpt-5.5": {
-		...gpt(["none", "low", "medium", "high"]),
+		...gpt(["none", "low", "medium", "high"], GPT_ORDER, 1000000, 1000000),
 		levels: { ...ladder(["none", "low", "medium", "high"]), xhigh: { value: "extra-high", encoding: P } },
 	},
 	"gpt-5.3-codex": {
@@ -116,7 +125,7 @@ export const CURSOR_MODEL_CAPABILITIES: Record<string, CursorModelCapability> = 
 	},
 	"gpt-5.4-mini": {
 		evidence: "available-models",
-		window: 272000,
+		window: 400_000,
 		parameterOrder: [],
 		levels: ladder(["none", "low", "medium", "high", "xhigh"], V),
 	},
@@ -128,25 +137,25 @@ export const CURSOR_MODEL_CAPABILITIES: Record<string, CursorModelCapability> = 
 	},
 	"gemini-3.7-flash": {
 		evidence: "cli-live",
-		window: 1000000,
+		window: 1_048_576,
 		parameterOrder: ["effort"],
 		levels: ladder(["low", "medium", "high"]),
 	},
 	"gemini-3.6-flash": {
 		evidence: "suffix-only",
-		window: 1000000,
+		window: 1_048_576,
 		parameterOrder: [],
 		levels: ladder(["minimal", "low", "medium", "high"], V),
 	},
 	"cursor-grok-4.6": {
 		evidence: "available-models",
-		window: 256000,
+		window: 500_000,
 		parameterOrder: ["effort", "fast"],
 		levels: ladder(["low", "medium", "high", "xhigh"]),
 	},
 	"cursor-grok-4.5": {
 		evidence: "suffix-only",
-		window: 256000,
+		window: 500_000,
 		parameterOrder: [],
 		levels: ladder(["low", "medium", "high"], V),
 	},
@@ -173,16 +182,16 @@ export const CURSOR_MODEL_CAPABILITIES: Record<string, CursorModelCapability> = 
 	},
 	"claude-4.5-sonnet": {
 		evidence: "available-models",
-		window: 200000,
+		window: 200_000,
 		parameterOrder: ["thinking", "context"],
 		defaultContext: "200k",
 		levels: {},
 	},
-	"kimi-k2.7-code": { evidence: "available-models", window: 262000, parameterOrder: [], levels: {} },
+	"kimi-k2.7-code": { evidence: "available-models", window: 262_144, parameterOrder: [], levels: {} },
 	"gemini-3-flash": { evidence: "available-models", window: 1000000, parameterOrder: [], levels: {} },
 	"gemini-3.1-pro": { evidence: "available-models", window: 1000000, parameterOrder: [], levels: {} },
-	"gemini-3.5-flash": { evidence: "available-models", window: 1000000, parameterOrder: [], levels: {} },
-	"gpt-5-mini": { evidence: "available-models", window: 272000, parameterOrder: [], levels: {} },
+	"gemini-3.5-flash": { evidence: "available-models", window: 1_048_576, parameterOrder: [], levels: {} },
+	"gpt-5-mini": { evidence: "available-models", window: 400_000, parameterOrder: [], levels: {} },
 };
 
 export interface CursorVariantAlias {

--- a/packages/ai/src/cursor/model-capabilities.ts
+++ b/packages/ai/src/cursor/model-capabilities.ts
@@ -66,7 +66,7 @@ function gpt(
 		maxWindow,
 		parameterOrder: order,
 		defaultContext: "272k",
-		requestContext: window >= 1_000_000 ? "1m" : "272k",
+		requestContext: order.includes("context") && window >= 1_000_000 ? "1m" : undefined,
 		levels: ladder(levels),
 	};
 }

--- a/packages/ai/src/cursor/selection-descriptor.ts
+++ b/packages/ai/src/cursor/selection-descriptor.ts
@@ -30,9 +30,11 @@ function buildParameters(
 			case "thinking":
 				out.push({ id, value: thinkingMode === true ? "true" : "false" });
 				break;
-			case "context":
-				if (capability.defaultContext !== undefined) out.push({ id, value: capability.defaultContext });
+			case "context": {
+				const context = capability.requestContext ?? capability.defaultContext;
+				if (context !== undefined) out.push({ id, value: context });
 				break;
+			}
 			case "effort":
 			case "reasoning":
 				out.push({ id, value });

--- a/packages/ai/test/cursor-model-capabilities.test.ts
+++ b/packages/ai/test/cursor-model-capabilities.test.ts
@@ -17,28 +17,28 @@ describe("cursor model capabilities", () => {
 		const expected: Record<string, number> = {
 			"kimi-k3": 1048576,
 			"glm-5.2": 1000000,
-			"gemini-3.6-flash": 1000000,
-			"gemini-3.7-flash": 1000000,
-			"gpt-5.1": 272000,
-			"gpt-5.2": 272000,
-			"gpt-5.3-codex": 272000,
-			"gpt-5.4": 272000,
-			"gpt-5.4-mini": 272000,
-			"gpt-5.4-nano": 272000,
-			"gpt-5.5": 272000,
-			"gpt-5.6-sol": 272000,
-			"gpt-5.6-luna": 272000,
+			"gemini-3.6-flash": 1048576,
+			"gemini-3.7-flash": 1048576,
+			"gpt-5.1": 400000,
+			"gpt-5.2": 400000,
+			"gpt-5.3-codex": 400000,
+			"gpt-5.4": 400000,
+			"gpt-5.4-mini": 400000,
+			"gpt-5.4-nano": 400000,
+			"gpt-5.5": 1000000,
+			"gpt-5.6-sol": 1000000,
+			"gpt-5.6-luna": 1000000,
 			"gpt-5.6-terra": 272000,
-			"cursor-grok-4.5": 256000,
-			"cursor-grok-4.6": 256000,
-			"kimi-k2.7-code": 262000,
+			"cursor-grok-4.5": 500000,
+			"cursor-grok-4.6": 500000,
+			"kimi-k2.7-code": 262144,
 			"claude-4.6-sonnet": 1000000,
 			"claude-4.6-opus": 1000000,
-			"claude-fable-5": 300000,
-			"claude-sonnet-5": 300000,
-			"claude-opus-4-7": 300000,
-			"claude-opus-4-8": 300000,
-			"claude-opus-5": 300000,
+			"claude-fable-5": 1000000,
+			"claude-sonnet-5": 1000000,
+			"claude-opus-4-7": 1000000,
+			"claude-opus-4-8": 1000000,
+			"claude-opus-5": 1000000,
 			"composer-2.5": 200000,
 			"claude-haiku-4-5": 200000,
 			"claude-4-sonnet": 200000,
@@ -54,8 +54,9 @@ describe("cursor model capabilities", () => {
 
 	it("keeps window and maxWindow distinct", () => {
 		const fable = getCursorCapabilityForBase("claude-fable-5");
-		expect(fable?.window).toBe(300000);
+		expect(fable?.window).toBe(1000000);
 		expect(fable?.maxWindow).toBe(1000000);
+		expect(fable?.defaultContext).toBe("300k");
 		const kimi = getCursorCapabilityForBase("kimi-k3");
 		expect(kimi?.window).toBe(1048576);
 		expect(kimi?.maxWindow).toBeUndefined();

--- a/packages/ai/test/cursor-model-grouping.test.ts
+++ b/packages/ai/test/cursor-model-grouping.test.ts
@@ -99,7 +99,7 @@ describe("normalizeCursorCatalog (golden 204-id live fixture)", () => {
 		const out = normalized();
 		const byId = new Map(out.map((entry) => [entry.id, entry]));
 		expect(byId.get("kimi-k3")?.window).toBe(1048576);
-		expect(byId.get("claude-fable-5")?.window).toBe(300000);
+		expect(byId.get("claude-fable-5")?.window).toBe(1000000);
 		expect(byId.get("claude-fable-5")?.maxWindow).toBe(1000000);
 		expect(byId.get("claude-fable-5")?.name).toContain("1M");
 		expect(byId.get("claude-fable-5")?.name).toContain("NO ZDR");

--- a/packages/ai/test/cursor-reasoning-params.test.ts
+++ b/packages/ai/test/cursor-reasoning-params.test.ts
@@ -46,7 +46,7 @@ describe("resolveCursorSelectionDescriptor", () => {
 			modelId: "claude-fable-5",
 			parameters: [
 				{ id: "thinking", value: "true" },
-				{ id: "context", value: "300k" },
+				{ id: "context", value: "1m" },
 				{ id: "effort", value: "low" },
 			],
 		});
@@ -63,7 +63,7 @@ describe("resolveCursorSelectionDescriptor", () => {
 		const out = resolveCursorSelectionDescriptor(cursorModel("claude-fable-5", compat), explicit("max"));
 		expect(out?.parameters).toEqual([
 			{ id: "thinking", value: "false" },
-			{ id: "context", value: "300k" },
+			{ id: "context", value: "1m" },
 			{ id: "effort", value: "max" },
 		]);
 	});
@@ -73,7 +73,7 @@ describe("resolveCursorSelectionDescriptor", () => {
 		expect(out).toEqual({
 			modelId: "gpt-5.5",
 			parameters: [
-				{ id: "context", value: "272k" },
+				{ id: "context", value: "1m" },
 				{ id: "reasoning", value: "extra-high" },
 				{ id: "fast", value: "false" },
 			],
@@ -128,7 +128,7 @@ describe("resolveCursorSelectionDescriptor", () => {
 	it("renders supported explicit off as reasoning=none", () => {
 		const out = resolveCursorSelectionDescriptor(cursorModel("gpt-5.5", gpt55Compat), explicit("off"));
 		expect(out?.parameters).toEqual([
-			{ id: "context", value: "272k" },
+			{ id: "context", value: "1m" },
 			{ id: "reasoning", value: "none" },
 			{ id: "fast", value: "false" },
 		]);

--- a/packages/ai/test/cursor-run-request.test.ts
+++ b/packages/ai/test/cursor-run-request.test.ts
@@ -129,7 +129,7 @@ describe("cursor Run request reasoning rendering", () => {
 			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
 		).toEqual([
 			{ id: "thinking", value: "true" },
-			{ id: "context", value: "300k" },
+			{ id: "context", value: "1m" },
 			{ id: "effort", value: "low" },
 		]);
 	});
@@ -168,7 +168,7 @@ describe("cursor Run request reasoning rendering", () => {
 		expect(
 			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
 		).toEqual([
-			{ id: "context", value: "272k" },
+			{ id: "context", value: "1m" },
 			{ id: "reasoning", value: "none" },
 			{ id: "fast", value: "false" },
 		]);
@@ -193,7 +193,7 @@ describe("cursor Run request reasoning rendering", () => {
 			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
 		).toEqual([
 			{ id: "thinking", value: "false" },
-			{ id: "context", value: "300k" },
+			{ id: "context", value: "1m" },
 			{ id: "effort", value: "high" },
 		]);
 	});

--- a/packages/ai/test/cursor-window-context-consistency.test.ts
+++ b/packages/ai/test/cursor-window-context-consistency.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { CURSOR_MODEL_CAPABILITIES } from "../src/cursor/model-capabilities.ts";
+import { resolveCursorSelectionDescriptor } from "../src/cursor/selection-descriptor.ts";
+
+const CONTEXT_TOKENS: Record<string, number> = {
+	"1m": 1_000_000,
+	"300k": 300_000,
+	"272k": 272_000,
+	"256k": 256_000,
+	"200k": 200_000,
+};
+
+function model(capabilityId: string) {
+	return {
+		id: capabilityId,
+		provider: "cursor",
+		api: "cursor-agent",
+		name: capabilityId,
+		contextWindow: CURSOR_MODEL_CAPABILITIES[capabilityId]?.window ?? 0,
+		maxTokens: 64_000,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		compat: { cursorReasoning: { capabilityId } },
+	} as never;
+}
+
+describe("advertised window matches the context senpi actually requests", () => {
+	it("never advertises more context than the request asks cursor for", () => {
+		const drift: string[] = [];
+		for (const [family, capability] of Object.entries(CURSOR_MODEL_CAPABILITIES)) {
+			if (!capability.parameterOrder.includes("context")) continue;
+			const descriptor = resolveCursorSelectionDescriptor(model(family), {
+				level: "high",
+				source: "explicit",
+			});
+			const sent = descriptor.parameters?.find((parameter) => parameter.id === "context")?.value;
+			if (sent === undefined) continue;
+			const requested = CONTEXT_TOKENS[sent];
+			if (requested !== undefined && capability.window > requested) {
+				drift.push(`${family}: advertises ${capability.window} but requests context=${sent}`);
+			}
+		}
+		expect(drift).toEqual([]);
+	});
+});

--- a/packages/ai/test/cursor-window-ssot.test.ts
+++ b/packages/ai/test/cursor-window-ssot.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { CURSOR_MODEL_CAPABILITIES } from "../src/cursor/model-capabilities.ts";
+import ssot from "./fixtures/models-dev-first-party-windows-20260818.json" with { type: "json" };
+
+const contextEnum = ssot.cursorContextEnum as Record<string, number>;
+const offered = ssot.cursorContextOptionsByFamily as Record<string, readonly string[]>;
+const firstParty = ssot.firstParty as Record<string, { context: number }>;
+const reported = ssot.cursorReportedWindow as Record<string, number>;
+
+/** Cursor only honours a window it actually offers that family, so the spec value is capped by it. */
+function expectedWindow(family: string): number | undefined {
+	const options = offered[family];
+	if (options && options.length > 0) {
+		const cap = Math.max(...options.map((option) => contextEnum[option]));
+		const spec = firstParty[family]?.context;
+		return spec === undefined ? cap : Math.min(spec, cap);
+	}
+	const spec = firstParty[family]?.context;
+	if (spec !== undefined) return spec;
+	return reported[family];
+}
+
+describe("cursor capability windows track the models.dev first-party SSOT", () => {
+	it("caps each family at the largest context option cursor offers it", () => {
+		const drift: string[] = [];
+		for (const [family, capability] of Object.entries(CURSOR_MODEL_CAPABILITIES)) {
+			const expected = expectedWindow(family);
+			if (expected === undefined) continue;
+			if (capability.window !== expected) {
+				drift.push(`${family}: committed ${capability.window} != SSOT ${expected}`);
+			}
+		}
+		expect(drift).toEqual([]);
+	});
+
+	it("never advertises a window above the largest context option cursor offers", () => {
+		for (const [family, capability] of Object.entries(CURSOR_MODEL_CAPABILITIES)) {
+			const options = offered[family];
+			if (!options || options.length === 0) continue;
+			const cap = Math.max(...options.map((option) => contextEnum[option]));
+			expect(capability.window, `${family} exceeds the context cursor offers it`).toBeLessThanOrEqual(cap);
+		}
+	});
+
+	it("keeps families outside the SSOT on a positive fallback window", () => {
+		for (const [family, capability] of Object.entries(CURSOR_MODEL_CAPABILITIES)) {
+			if (expectedWindow(family) !== undefined) continue;
+			expect(capability.window, `${family} must carry a positive window`).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("cursor window edges", () => {
+	const CLI_ONLY = [
+		"claude-mythos-5",
+		"claude-sonnet-4-7",
+		"composer-2.6",
+		"composer-2.6-lite",
+		"deepseek-v4",
+		"gemini-3.5-pro",
+		"gemini-3.6-pro",
+		"gemini-3.7-pro",
+		"gpt-5.4-codex",
+	] as const;
+
+	it("leaves CLI-only families without a capability entry so they take the documented fallback", () => {
+		for (const family of CLI_ONLY) {
+			expect(
+				Object.hasOwn(CURSOR_MODEL_CAPABILITIES, family),
+				`${family} is CLI-only and must not gain an unproven capability window`,
+			).toBe(false);
+		}
+	});
+
+	it("keeps genuinely small-window families off the 1M promotion", () => {
+		for (const family of ["claude-4.5-opus", "claude-haiku-4-5", "composer-2.5"] as const) {
+			const capability = CURSOR_MODEL_CAPABILITIES[family];
+			expect(capability, `missing capability for ${family}`).toBeDefined();
+			expect(capability?.window, `${family} must stay at its first-party 200000`).toBe(200_000);
+		}
+	});
+
+	it("never lets a family advertise more than its own maxWindow when one is declared", () => {
+		for (const [family, capability] of Object.entries(CURSOR_MODEL_CAPABILITIES)) {
+			if (capability.maxWindow === undefined) continue;
+			expect(capability.window, `${family} window exceeds maxWindow`).toBeLessThanOrEqual(capability.maxWindow);
+		}
+	});
+});

--- a/packages/ai/test/fixtures/models-dev-first-party-windows-20260818.json
+++ b/packages/ai/test/fixtures/models-dev-first-party-windows-20260818.json
@@ -1,0 +1,190 @@
+{
+	"capturedAt": "2026-08-18",
+	"cursorContextEnum": {
+		"1m": 1000000,
+		"200k": 200000,
+		"256k": 256000,
+		"272k": 272000,
+		"300k": 300000
+	},
+	"cursorContextOptionsByFamily": {
+		"claude-4.5-sonnet": [
+			"200k"
+		],
+		"claude-4.6-opus": [
+			"200k",
+			"1m"
+		],
+		"claude-4.6-sonnet": [
+			"200k",
+			"1m"
+		],
+		"claude-fable-5": [
+			"300k",
+			"1m"
+		],
+		"claude-opus-4-7": [
+			"300k",
+			"1m"
+		],
+		"claude-opus-4-8": [
+			"300k",
+			"1m"
+		],
+		"claude-opus-5": [
+			"300k",
+			"1m"
+		],
+		"claude-sonnet-5": [
+			"300k",
+			"1m"
+		],
+		"gpt-5.5": [
+			"272k",
+			"1m"
+		],
+		"gpt-5.6-luna": [
+			"272k",
+			"1m"
+		],
+		"gpt-5.6-sol": [
+			"272k",
+			"1m"
+		],
+		"gpt-5.6-terra": [
+			"272k"
+		]
+	},
+	"cursorReportedWindow": {
+		"claude-4.5-opus": 200000,
+		"claude-4.5-sonnet": 200000,
+		"claude-4.6-opus": 1000000,
+		"claude-4.6-sonnet": 1000000,
+		"claude-fable-5": 1000000,
+		"claude-opus-4-7": 1000000,
+		"claude-opus-4-8": 1000000,
+		"claude-opus-5": 1000000,
+		"claude-sonnet-5": 1000000,
+		"cursor-grok-4.5": 200000,
+		"cursor-grok-4.6": 200000,
+		"gemini-3.5-flash": 200000,
+		"gemini-3.6-flash": 200000,
+		"gemini-3.7-flash": 200000,
+		"glm-5.2": 200000,
+		"gpt-5-mini": 200000,
+		"gpt-5.2": 200000,
+		"gpt-5.3-codex": 200000,
+		"gpt-5.4-mini": 200000,
+		"gpt-5.5": 1000000,
+		"gpt-5.6-luna": 1000000,
+		"gpt-5.6-sol": 1000000,
+		"kimi-k2.7-code": 200000,
+		"kimi-k3": 200000
+	},
+	"firstParty": {
+		"claude-4.5-opus": {
+			"context": 200000,
+			"provider": "anthropic"
+		},
+		"claude-4.5-sonnet": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"claude-4.6-opus": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"claude-4.6-sonnet": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"claude-fable-5": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"claude-haiku-4-5": {
+			"context": 200000,
+			"provider": "anthropic"
+		},
+		"claude-opus-4-7": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"claude-opus-4-8": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"claude-opus-5": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"claude-sonnet-5": {
+			"context": 1000000,
+			"provider": "anthropic"
+		},
+		"cursor-grok-4.5": {
+			"context": 500000,
+			"provider": "xai"
+		},
+		"cursor-grok-4.6": {
+			"context": 500000,
+			"provider": "xai"
+		},
+		"gemini-3.5-flash": {
+			"context": 1048576,
+			"provider": "google"
+		},
+		"gemini-3.6-flash": {
+			"context": 1048576,
+			"provider": "google"
+		},
+		"gemini-3.7-flash": {
+			"context": 1048576,
+			"provider": "google"
+		},
+		"glm-5.2": {
+			"context": 1000000,
+			"provider": "zai"
+		},
+		"gpt-5-mini": {
+			"context": 400000,
+			"provider": "openai"
+		},
+		"gpt-5.2": {
+			"context": 400000,
+			"provider": "openai"
+		},
+		"gpt-5.3-codex": {
+			"context": 400000,
+			"provider": "openai"
+		},
+		"gpt-5.4-mini": {
+			"context": 400000,
+			"provider": "openai"
+		},
+		"gpt-5.5": {
+			"context": 1050000,
+			"provider": "openai"
+		},
+		"gpt-5.6-luna": {
+			"context": 1050000,
+			"provider": "openai"
+		},
+		"gpt-5.6-sol": {
+			"context": 1050000,
+			"provider": "openai"
+		},
+		"kimi-k2.7-code": {
+			"context": 262144,
+			"provider": "moonshotai"
+		},
+		"kimi-k3": {
+			"context": 1048576,
+			"provider": "moonshotai"
+		}
+	},
+	"notes": "gpt-5.6-terra and the legacy gpt families are offered no 1m context option, so their advertised window is capped at the largest token cursor will accept for them | claude-4.5-sonnet is 1M upstream but cursor offers it only the 200k context option, so senpi advertises 200000: a window it cannot request would break compaction.",
+	"placeholderWindow": 200000,
+	"rule": "window = min(models.dev first-party, max(context options cursor offers that family)) when cursor offers a context choice; otherwise models.dev first-party (cursor's uniform 200000 for those families is a catalog placeholder, not a measured limit); families unknown to models.dev keep the cursor-reported window",
+	"source": "https://models.dev/api.json"
+}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Cursor model listings report corrected context windows (current Claude families and GPT 5.5/5.6 at 1M,
+  Grok at 500K) and the cursor-agent CLI spawn string requests the matching `context` token.
+
 - Cursor reasoning levels now drive both Cursor surfaces: the thinking-level selector, `:suffix` model
   patterns, and favorites carry provenance into the wire request, the native protobuf lane sends per-family
   `RequestedModel.parameters`, and the `cursor-cli-oauth` lane spawns with the matching bracket or suffix

--- a/packages/coding-agent/test/cursor-cli-oauth/models.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/models.test.ts
@@ -50,12 +50,12 @@ describe("parseCursorAgentModelsListing", () => {
 		expect(models.find((model) => model.id === "gemini-3.7-flash")).toMatchObject({
 			reasoning: true,
 			input: ["text"],
-			contextWindow: 1_000_000,
+			contextWindow: 1_048_576,
 			maxTokens: 64_000,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		});
-		expect(models.find((model) => model.id === "claude-opus-5-thinking")?.contextWindow).toBe(300_000);
-		expect(models.find((model) => model.id === "gpt-5.6-sol")?.contextWindow).toBe(272_000);
+		expect(models.find((model) => model.id === "claude-opus-5-thinking")?.contextWindow).toBe(1_000_000);
+		expect(models.find((model) => model.id === "gpt-5.6-sol")?.contextWindow).toBe(1_000_000);
 		expect(models.find((model) => model.id === "composer-2.5")?.contextWindow).toBe(200_000);
 		expect(models.find((model) => model.id === "composer-2.5-fast")?.reasoning).toBe(false);
 	});
@@ -70,7 +70,7 @@ describe("parseCursorAgentModelsListing", () => {
 				id: "claude-opus-5-thinking-max-fast",
 				name: "Claude Opus 5 Thinking Max Fast (300K context)",
 				reasoning: false,
-				contextWindow: 300_000,
+				contextWindow: 1_000_000,
 			}),
 		]);
 	});

--- a/packages/coding-agent/test/cursor-cli-oauth/reasoning-catalog.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/reasoning-catalog.test.ts
@@ -19,9 +19,9 @@ describe("cursor-cli-oauth catalog normalization", () => {
 		const byId = new Map(parseCursorAgentModelsListing(listing).map((model) => [model.id, model]));
 		// Windows come from the shared live capability table, never from the
 		// listing's own "(200K context)" labels, which are stale for Grok 4.6.
-		expect(byId.get("cursor-grok-4.6")?.contextWindow).toBe(256_000);
-		expect(byId.get("claude-fable-5")?.contextWindow).toBe(300_000);
-		expect(byId.get("claude-opus-4-8")?.contextWindow).toBe(300_000);
+		expect(byId.get("cursor-grok-4.6")?.contextWindow).toBe(500_000);
+		expect(byId.get("claude-fable-5")?.contextWindow).toBe(1_000_000);
+		expect(byId.get("claude-opus-4-8")?.contextWindow).toBe(1_000_000);
 	});
 
 	it("exposes total thinking level maps with per-family wire values", () => {
@@ -37,7 +37,7 @@ describe("cursor-cli-oauth catalog normalization", () => {
 
 	it("keeps the offline static fallback usable with canonical ids and windows", () => {
 		const byId = new Map(STATIC_CURSOR_CLI_MODELS.map((model) => [model.id, model]));
-		expect(byId.get("cursor-grok-4.6")?.contextWindow).toBe(256_000);
+		expect(byId.get("cursor-grok-4.6")?.contextWindow).toBe(500_000);
 		expect(STATIC_CURSOR_CLI_MODELS.some((model) => model.reasoning)).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/cursor-cli-oauth/reasoning-model-string.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/reasoning-model-string.test.ts
@@ -35,7 +35,7 @@ describe("resolveCursorCliSpawnModel", () => {
 			},
 		});
 		expect(resolveCursorCliSpawnModel(model, explicit("low"))).toBe(
-			"claude-fable-5[thinking=true,context=300k,effort=low]",
+			"claude-fable-5[thinking=true,context=1m,effort=low]",
 		);
 	});
 
@@ -44,7 +44,7 @@ describe("resolveCursorCliSpawnModel", () => {
 			cursorReasoning: { capabilityId: "gpt-5.5", representativeVariantId: "gpt-5.5-medium" },
 		});
 		expect(resolveCursorCliSpawnModel(model, explicit("xhigh"))).toBe(
-			"gpt-5.5[context=272k,reasoning=extra-high,fast=false]",
+			"gpt-5.5[context=1m,reasoning=extra-high,fast=false]",
 		);
 	});
 


### PR DESCRIPTION
## Summary

Cursor's capability table encoded current Claude families at `window: 300000`, hand-copied from the
`cursor-agent` CLI listing's stale `(300K context)` display labels — the same label-derived error class
as the Grok-as-200K regex removed in #948.

Three independent sources agree those families are **1,000,000**:

| source | says |
|---|---|
| models.dev, `anthropic` first-party | `claude-opus-5 / 4-8 / 4-7 / fable-5 / sonnet-5` = `1000000` |
| Cursor's own `context` parameter enum | offers `1m` to exactly these families |
| Cursor's model display names | `Claude Opus 5 1M`, `Claude Opus 4.8 1M`, `Claude Fable 5 1M` |

## The bug was two-sided

`window` (what senpi advertises to compaction) and the emitted `context` parameter (what senpi asks
Cursor for) are **one contract**. The wire mapper emitted `context` at a single site, always
`capability.defaultContext` (`300k` for Claude), with no override.

Raising `window` alone would have been **worse than the original bug**: compaction would grow context
toward 1M while the request still asked for 300K, and the provider would truncate. So the capability
gained `requestContext` and the mapper now sends it — a family advertising 1M asks for `context=1m`.

## How windows are derived

`window = min(models.dev first-party, largest context option Cursor offers that family)`; families
Cursor gives no `context` choice keep their first-party value.

This matters because Cursor's `GetUsableModels` reports a uniform `200000` placeholder for most
families (kimi-k3, grok, gemini, glm all report 200000), and models.dev spans reseller-configured
limits for the same id — so only the **first-party** entry is authoritative.

Two families are capped *down* by what is actually requestable:

- `gpt-5.6-terra` — no `1m` option and no `400k` token exists → `272000`
- `claude-4.5-sonnet` — 1M upstream, but Cursor offers it only `200k` → `200000`

## Verification

- `packages/ai/test/cursor-window-ssot.test.ts` — cross-checks every committed window against a
  pinned models.dev fixture, so these values cannot regress to hand-copied labels again.
- `packages/ai/test/cursor-window-context-consistency.test.ts` — fails if any family advertises more
  context than its request asks Cursor for. Captured RED naming all 10 mismatching families.
- `packages/ai` full suite: 2138 passed. `cursor-cli-oauth`: 255/255. `npm run check`: rc=0.
- Live outbound capture: `claude-opus-4-8` + explicit `high` now emits
  `[thinking=false, context=1m, effort=high]` (was `context=300k`).

### Live probe limitation, stated plainly

A completed live turn could **not** be captured: every family probed — including `kimi-k3`, which
completed successfully earlier today on this account — returns an in-band
`Connect error not_found: Error` with zero tokens. The `300k` baseline arm (pre-fix behavior) fails
identically, so this is account/transport-side and orthogonal to the change, **not** a `1m` rejection.
Evidence and the correction of an earlier false `accepted: true` reading are recorded in
`local-ignore/qa-evidence/20260818-cursor-window-ssot/VERDICT.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Cursor context windows to the models.dev first-party source of truth and sends the matching `context` token. Previously Claude families advertised 300k and sent `context=300k`; now they advertise 1M and send `context=1m`, preventing provider-side truncation.

- Adds `requestContext` to `packages/ai/src/cursor/model-capabilities.ts`; `packages/ai/src/cursor/selection-descriptor.ts` sends `requestContext ?? defaultContext`. Drops dormant `requestContext` for families without a `context` parameter (no behavior change).
- Window rule: window = min(models.dev first‑party, largest `context` option Cursor offers that family). Families without a context choice keep first‑party; families outside the SSOT keep a positive fallback.
- Notable windows: Claude `fable-5/sonnet-5/opus-4-7/4-8/5` and `gpt-5.5`, `gpt-5.6-(sol|luna)` → 1,000,000; legacy `gpt-5.{1–4}`, `gpt-5-mini`, `gpt-5.3-codex`, `gpt-5.4-(mini|nano)` → 400,000; `cursor-grok-4.5/4.6` → 500,000; `gemini-3.{5,6,7}-flash` → 1,048,576; `gpt-5.6-terra` → 272,000; `claude-4.5-sonnet` → 200,000; `kimi-k2.7-code` → 262,144.
- Verification: new SSOT and request-consistency tests in `packages/ai/test`; `packages/coding-agent` tests updated. CLI spawn and protobuf requests include the corrected `context`. No caller migration required.

<sup>Written for commit 3a00b99c87eca8d396e60b9ac0c670a08f959c03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

