### PR TITLE
fix(goal): resume active goals stuck after suppressed continuation-flood loads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Fixed
 
+- goal: resume an active goal when the user sends a message after a continuation-flooded session load suppressed auto-continuation; previously the "Send a message to resume" notice parked the goal because the follow-up user message only reset the continuation streak without queueing a continuation.
+- session: `sendCustomMessage` with `triggerTurn` no longer waits on the session-work barrier while the session-start binding itself holds it, unblocking goal continuations queued from `session_start` handlers during resume.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3578,7 +3578,11 @@ export class AgentSession {
 			options?.triggerTurn === true &&
 			options.deliverAs !== "nextTurn" &&
 			!this.isStreaming &&
-			this._sessionWorkBarrier.hasActiveWork;
+			this._sessionWorkBarrier.hasActiveWork &&
+			// The session-start binding itself holds the barrier while it emits
+			// session_start; a triggerTurn message queued from that emission (e.g. a
+			// goal continuation) must not wait on the very work that is delivering it.
+			this._extensionBindingPromptReadiness === undefined;
 		const pendingCompactionAdmission = this._pendingCompactionAdmission;
 		const activeCompactionGeneration =
 			this._compactionLifecycle.state.status === "running" ? this._compactionLifecycle.state.generation : undefined;

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,40 @@
 # changes
 
+## 2026-08-18 - Resume active goals stuck after suppressed continuation-flood loads
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `sendCustomMessage` with `triggerTurn` no longer waits on
+  `_sessionWorkBarrier` while the session-start binding itself holds it (`_extensionBindingPromptReadiness`
+  active). A trigger-turn message queued from the `session_start` emission — a goal continuation queued on
+  resume — previously waited on the very work that was delivering it, so the resumed session rendered the TUI
+  but never started a turn.
+- `core/extensions/builtin/goal/index.ts` + `direct-input-lifecycle.ts`: a suppressed flooded load now arms a
+  one-shot latch; the next accepted user message (the "Send a message to resume" the notice promises) queues
+  the goal continuation immediately instead of only resetting the continuation streak.
+- Coverage: `test/suite/goal-extension.test.ts` (queues a continuation when the user sends a message after a
+  suppressed flooded load) and `test/suite/agent-session-queue.test.ts` (triggerTurn send does not wait on the
+  binding-phase barrier; fails pre-fix via a deadlock race).
+
+### Why
+
+- A resumed session whose branch ends in >= `GOAL_CONTINUATION_CAP` trailing continuations suppresses
+  auto-continuation by design, but the documented resume path was a dead end: the user message reset the
+  streak without queueing a continuation, and even once queued the continuation deadlocked on the
+  binding-held barrier. Reproduced against a clone of the stuck session; post-fix the continuation is
+  delivered and the agent resumes.
+
+### Why an extension could not handle it
+
+- The barrier admission condition lives in `AgentSession.sendCustomMessage`, and the resume latch lives in the
+  builtin goal extension's own load/disposition path; both are core session-lifecycle surfaces.
+
+### Expected merge conflict zones
+
+- `core/agent-session.ts` `sendCustomMessage` wait condition, and the goal extension `session_start`
+  suppressed-load branch in `core/extensions/builtin/goal/index.ts`.
+
+
 ## 2026-08-18 - Retry continuation watchdog reconciled with the guards it grants
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/direct-input-lifecycle.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/direct-input-lifecycle.ts
@@ -13,12 +13,19 @@ type DirectInputLifecycleDependencies = {
 	readonly goalStoreRef: (ctx: ExtensionContext) => GoalStoreRef;
 	readonly beginAgentGoalAccounting: (goal: Goal) => void;
 	readonly refreshGoalUi: (ctx: ExtensionContext, goal: Goal) => void;
+	/**
+	 * One-shot resume fired when the first user message after a suppressed
+	 * flooded load is accepted. The load-time suppression notice tells the user
+	 * to "send a message to resume"; this callback is what keeps that promise.
+	 */
+	readonly resumeAfterSuppressedLoad?: (ctx: ExtensionContext, goal: Goal) => Promise<void>;
 };
 
 /** Correlates raw input with admission before changing persisted Goal state. */
 export class GoalDirectInputLifecycle {
 	readonly #dependencies: DirectInputLifecycleDependencies;
 	readonly #candidates = new Map<string, DirectInputCandidate>();
+	#suppressedLoadResumeArmed = false;
 
 	constructor(dependencies: DirectInputLifecycleDependencies) {
 		this.#dependencies = dependencies;
@@ -26,6 +33,12 @@ export class GoalDirectInputLifecycle {
 
 	reset(): void {
 		this.#candidates.clear();
+		this.#suppressedLoadResumeArmed = false;
+	}
+
+	/** Arms the one-shot resume for a goal parked by load-time flood suppression. */
+	armSuppressedLoadResume(): void {
+		this.#suppressedLoadResumeArmed = true;
 	}
 
 	async onInput(event: InputEvent, ctx: ExtensionContext): Promise<void> {
@@ -60,5 +73,9 @@ export class GoalDirectInputLifecycle {
 		if (currentGoal.status !== "active") return;
 		const reset = await resetContinuationStreak(ref);
 		if (reset !== null) this.#dependencies.refreshGoalUi(ctx, reset);
+		if (this.#suppressedLoadResumeArmed) {
+			this.#suppressedLoadResumeArmed = false;
+			await this.#dependencies.resumeAfterSuppressedLoad?.(ctx, reset ?? currentGoal);
+		}
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -66,6 +66,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		goalStoreRef,
 		beginAgentGoalAccounting,
 		refreshGoalUi: refreshGoalUiBestEffort,
+		resumeAfterSuppressedLoad: (resumeCtx, goal) => queueGoalContinuationForCurrentSession(pi, resumeCtx, goal),
 	});
 
 	const goalTicker = new GoalElapsedTicker({
@@ -163,6 +164,12 @@ export default function goalExtension(pi: ExtensionAPI): void {
 			// leave the goal active (no status rewrite), and tell the user how to resume.
 			const trailingContinuations = countTrailingGoalContinuationEntries(ctx.sessionManager.getBranch());
 			if (trailingContinuations >= GOAL_CONTINUATION_CAP) {
+				// The load-time flood suppression parks the goal without rewriting its
+				// status, so the only resume signal left is the user's next message.
+				// Arm the one-shot latch the direct-input lifecycle fires when that
+				// message is accepted; without it the promise in the notice is a lie
+				// and the resumed session sits idle until the goal is recreated.
+				directInputLifecycle.armSuppressedLoadResume();
 				ctx.ui.notify(
 					`Goal auto-continuation suppressed for this resumed session (${trailingContinuations} historical continuations). Send a message to resume.`,
 					"info",

--- a/packages/coding-agent/test/suite/agent-session-queue.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-queue.test.ts
@@ -731,4 +731,47 @@ describe("AgentSession queue characterization", () => {
 
 		expect(getUserTexts(harness)).toEqual(["hello", "conflict report"]);
 	});
+
+	it("sendCustomMessage with triggerTurn does not wait on the session-work barrier during extension binding", async () => {
+		// Repro of the resume-stuck deadlock: bindExtensions holds the session-work
+		// barrier while it emits session_start (readiness set + barrier held). A
+		// triggerTurn custom message sent from that emission (e.g. a goal continuation
+		// queued on resume) must not wait for the barrier to settle — the work it
+		// would wait on is the very emission that is delivering it.
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("resumed")]);
+
+		const barrier = Reflect.get(harness.session, "_sessionWorkBarrier") as { begin(): () => void };
+		Reflect.set(harness.session, "_extensionBindingPromptReadiness", new Set());
+		const finishBindingWork = barrier.begin();
+		try {
+			// Pre-fix this send waits on the held barrier forever; the race turns a
+			// hang into a failure.
+			await Promise.race([
+				harness.session.sendCustomMessage(
+					{
+						customType: "goal-continuation",
+						content: [{ type: "text", text: "resume goal" }],
+						display: false,
+						details: {},
+					},
+					{ triggerTurn: true, deliverAs: "followUp" },
+				),
+				new Promise<never>((_, reject) =>
+					setTimeout(() => reject(new Error("sendCustomMessage deadlocked on the binding-phase barrier")), 1000),
+				),
+			]);
+		} finally {
+			finishBindingWork();
+		}
+		await harness.session.agent.waitForIdle();
+
+		expect(
+			harness.session.messages.some(
+				(message) => message.role === "custom" && message.customType === "goal-continuation",
+			),
+		).toBe(true);
+		expect(getAssistantTexts(harness)).toContain("resumed");
+	});
 });

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -807,7 +807,7 @@ describe("goal extension session_start migration-lite admission", () => {
 
 	it("resumes normally on the next clean turn after a real user prompt follows a suppressed load", async () => {
 		vi.useFakeTimers();
-		const { tools, handlers, sent, continuationQueued } = createGoalHarness();
+		const { tools, handlers, sent } = createGoalHarness();
 		const notices: string[] = [];
 		const ctx = await makeNotifyingCtx(notices, "thread-suppressed-then-prompt", [
 			userMessageEntry(),
@@ -836,9 +836,10 @@ describe("goal extension session_start migration-lite admission", () => {
 			{ type: "agent_end", messages: [assistantMessageWithStopReason("stop")] },
 			ctx,
 		);
-		expect(sent).toHaveLength(0);
+		// The accepted user message after a suppressed load resumes the goal
+		// immediately, so the post-turn user-grace path has nothing left to do.
+		expect(sent).toHaveLength(1);
 		await vi.advanceTimersByTimeAsync(GOAL_USER_GRACE_DELAY_MS);
-		await continuationQueued;
 		expect(sent).toHaveLength(1);
 		expect(sent[0]?.message.customType).toBe("goal-continuation");
 		expect(await readGoal(storeRefFor(ctx))).toMatchObject({
@@ -846,6 +847,40 @@ describe("goal extension session_start migration-lite admission", () => {
 			consecutiveContinuations: 1,
 		});
 		vi.useRealTimers();
+	});
+
+	it("queues a continuation when the user sends a message after a suppressed flooded load", async () => {
+		// Repro of the resume-stuck report: a session whose branch ends in >= GOAL_CONTINUATION_CAP
+		// trailing continuations is suppressed at load (no continuation queued), and the notice says
+		// "Send a message to resume." When the user then sends that message, the goal must resume
+		// immediately instead of parking: the user message is the resume signal the notice promised.
+		const { tools, handlers, sent } = createGoalHarness();
+		const notices: string[] = [];
+		const ctx = await makeNotifyingCtx(notices, "thread-suppressed-then-user-message", [
+			userMessageEntry(),
+			...goalContinuationEntries(300),
+		]);
+		await tools.get("create_goal")?.execute("c1", { objective: "Keep going" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "startup" }, ctx);
+		expect(sent).toHaveLength(0);
+		expect(notices.some((n) => n.includes("suppressed for this resumed session"))).toBe(true);
+
+		await runHandlers(
+			handlers,
+			"input",
+			{ type: "input", inputId: "resume-after-suppression", text: "continue", source: "interactive" },
+			ctx,
+		);
+		await runHandlers(
+			handlers,
+			"input_disposition",
+			{ type: "input_disposition", inputId: "resume-after-suppression", disposition: "started" },
+			ctx,
+		);
+
+		expect(sent).toHaveLength(1);
+		expect(sent[0]?.message.customType).toBe("goal-continuation");
 	});
 
 	it("suppresses with a notice on reload when a flooded branch parks an active goal", async () => {


### PR DESCRIPTION
## Summary

Fixes `omo --session <id>` rendering the TUI but never resuming when the loaded session has an **active goal** whose branch ends in >= `GOAL_CONTINUATION_CAP` (8) trailing `goal-continuation` entries.

Root cause (two defects on the same resume path):

1. **Missing resume trigger** — `goal/index.ts` `session_start` suppresses auto-continuation for flooded branches and tells the user *"Send a message to resume"*, but `direct-input-lifecycle.ts` only reset the continuation streak on that message; nothing queued a new continuation, so the goal stayed parked forever. The fix arms a one-shot latch (`armSuppressedLoadResume`) at suppressed load; when the promised user message is accepted, `onDisposition` queues the continuation immediately.
2. **Session-work barrier deadlock** — the queued continuation is delivered via `sendCustomMessage({ triggerTurn: true })`, which awaited `_sessionWorkBarrier` while `bindExtensions` itself held the barrier to emit `session_start` — the message waited on the very work that was delivering it. `sendCustomMessage` now skips that wait while the binding-phase prompt-readiness set is active (`agent-session.ts`).

## Evidence

- **Repro**: cloned the stuck session (`01a0143b-…` → clone id) including its goal extension state; pre-fix the resumed TUI rendered but never started a turn (instrumented `sendCustomMessage` decision log showed `wait:true` against the binding-held barrier).
- **Real-surface GREEN**: with the fix, the same clone logs the `goal-continuation` custom message, increments `consecutiveContinuations`, and the agent visibly resumes working in the TUI.
- **Regression tests (RED→GREEN)**:
  - `goal-extension.test.ts`: "queues a continuation when the user sends a message after a suppressed flooded load".
  - `agent-session-queue.test.ts`: "sendCustomMessage with triggerTurn does not wait on the session-work barrier during extension binding" — fails pre-fix via a 1s deadlock race, passes post-fix.
- Full `goal-extension` (44) and `agent-session-queue` (23) suites pass; pre-commit biome/tsc/lock checks green.

## Test plan

- [x] `npx vitest run packages/coding-agent/test/suite/goal-extension.test.ts`
- [x] `npx vitest run packages/coding-agent/test/suite/agent-session-queue.test.ts`
- [x] Real-surface: resumed a clone of the originally stuck session in a PTY and confirmed the agent turn starts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumes active goals that were stuck after continuation-flooded session loads and removes a session-start deadlock. Previously the load notice asked users to “Send a message to resume,” but no continuation was queued and trigger-turn messages could block on the binding-held session-work barrier.

- Arms a one-shot resume on suppressed load; the next accepted user message resets the continuation streak and enqueues a `goal-continuation` via `queueGoalContinuationForCurrentSession`.
- `sendCustomMessage({ triggerTurn: true })` skips the session-work barrier while `_extensionBindingPromptReadiness` is set, so continuations queued from `session_start` deliver immediately.
- Adds tests covering the resume and barrier cases in `goal-extension.test.ts` and `agent-session-queue.test.ts`.
- Updates `CHANGELOG.md` and `src/core/changes.md`; remove leftover merge markers in `CHANGELOG.md`.

<sup>Written for commit e7507821b9b5bbf99483757aff344ffc8abcdaf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

