### PR TITLE
feat(tui): attach pasted clipboard images through an atomic [Image #N] marker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Pasting a clipboard image in the interactive TUI now attaches the image to the submission instead of inserting its temp file path: the composer shows an atomic `[Image #N]` marker, the bytes ride the user message as an image content part in reading order, and markers transfer between editor instances (or are stripped with their payloads dropped when the destination cannot own them).
+
 - Cursor reasoning levels now drive both Cursor surfaces: the thinking-level selector, `:suffix` model
   patterns, and favorites carry provenance into the wire request, the native protobuf lane sends per-family
   `RequestedModel.parameters`, and the `cursor-cli-oauth` lane spawns with the matching bracket or suffix

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -2164,3 +2164,23 @@ The tip line was teaching a small slice of the product while most of the surface
 - Changed `src/modes/interactive/interactive-mode.ts` and `compaction-queue-transfer.ts` so every terminal `compaction_end` flushes the TUI compaction queue: accepted compactions keep prompt-admission delivery, while failed/rejected/aborted ones route queued input through the native steer/followUp queues (`deferAdmission`) with a visible held-count status and a `compaction_queue_deferred` session-log event. Previously the queue was flushed only on success, so messages typed during a failing compaction were silently parked forever and lost on session switch (field report 2026-07-30).
 - This was changed in core UI because the compaction queue and `compaction_end` handling are internal `InteractiveMode` state; extensions cannot observe or drain that queue.
 - Expected merge-conflict zone on upstream sync: the `compaction_end` handler and `flushCompactionQueue()` in `src/modes/interactive/interactive-mode.ts`, plus `compaction-queue-transfer.ts` transfer options.
+
+## Pasted clipboard images ride the submission channel as attachments (2026-08-18)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `handleClipboardPaste()` now attaches the pasted image instead of inserting its temp path. When the editor is image-aware it calls `insertImageMarker()`, stores the processed bytes in a `pendingImages` map keyed by marker id, and keeps that map aligned with the visible `[Image #N]` numbers through `onImageMarkersChanged` (`reconcilePendingImages`). On submit, `takeSubmissionImages()` reads only the submitted text plus `pendingImages` (never live editor state) to build the ordered `images: ImageContent[]` carried on the user message, with a pre-resolved path for flows whose `setText("")` prune chain would otherwise destroy the payloads before resolution.
+- `packages/coding-agent/src/modes/interactive/editor-paste-transfer.ts`: `transferEditorContent()` now moves the image-marker registry snapshot alongside the text and paste state, returns `{ imageMarkersTransferred }`, and strips `[Image #N]` markers (collapsing leftover whitespace) when the destination editor cannot own them, so the caller can drop the orphaned payloads instead of shipping a dead literal marker with a live attachment behind it.
+
+### Why
+
+- Inserting the raw `pi-clipboard-*.png` path leaked local temp paths into the composer and the transcript, and nothing carried the image bytes to the model. Markers plus a keyed payload map let one user turn carry both text and image parts in reading order.
+
+### Why an extension could not handle it
+
+- The submission pipeline, the editor wiring, and the pending-payload lifecycle are private `InteractiveMode` state; an extension receives no callback that can attach bytes to a submitted user message or re-key payloads when markers are renumbered.
+
+### Expected merge conflict zones
+
+- MEDIUM: the paste handler, submit path, and editor wiring in `packages/coding-agent/src/modes/interactive/interactive-mode.ts`.
+- LOW: `packages/coding-agent/src/modes/interactive/editor-paste-transfer.ts` (small transfer helper, additive return value).

--- a/packages/coding-agent/src/modes/interactive/editor-paste-transfer.ts
+++ b/packages/coding-agent/src/modes/interactive/editor-paste-transfer.ts
@@ -1,14 +1,45 @@
 import { type EditorComponent, expandPasteMarkers } from "@earendil-works/pi-tui";
 
-export function transferEditorContent(source: EditorComponent, target: EditorComponent): void {
+/**
+ * Local copy of pi-tui's image-marker pattern so this transfer never mutates
+ * the shared /g regex's `lastIndex`.
+ */
+const IMAGE_MARKER_PATTERN = /\[Image #[1-9]\d*\]/g;
+
+/**
+ * Move the draft (and any collapsed markers) from one editor instance to
+ * another. Returns whether the image markers survived the move: image payloads
+ * live outside the editor, so the caller must drop them when the destination
+ * cannot own the markers - a dead literal `[Image #N]` with a live attachment
+ * behind it would misnumber every other attachment at submit.
+ */
+export function transferEditorContent(
+	source: EditorComponent,
+	target: EditorComponent,
+): { imageMarkersTransferred: boolean } {
 	const rawText = source.getText();
 	const pasteState = source.getPasteState?.();
+	const imageState = source.getImageMarkerState?.();
+	const imageMarkersTransferred = Boolean(
+		imageState && target.getImageMarkerState && target.setImageMarkerState && target.insertImageMarker,
+	);
 	if (pasteState && target.getPasteState && target.setPasteState) {
-		target.setText(rawText);
+		target.setText(imageMarkersTransferred ? rawText : stripImageMarkers(rawText));
 		target.setPasteState(pasteState);
 	} else {
-		target.setText(source.getExpandedText?.() ?? (pasteState ? expandPasteMarkers(rawText, pasteState) : rawText));
+		const expanded = source.getExpandedText?.() ?? (pasteState ? expandPasteMarkers(rawText, pasteState) : rawText);
+		target.setText(imageMarkersTransferred ? expanded : stripImageMarkers(expanded));
 	}
+	if (imageMarkersTransferred && imageState) target.setImageMarkerState?.(imageState);
+	return { imageMarkersTransferred };
+}
+
+/** Removes every `[Image #N]` marker, collapsing the whitespace it leaves behind. */
+function stripImageMarkers(text: string): string {
+	return text
+		.replace(IMAGE_MARKER_PATTERN, "")
+		.replace(/[ \t]{2,}/g, " ")
+		.trim();
 }
 
 export function expandEditorSubmission(editor: EditorComponent, text: string): string {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -448,6 +448,15 @@ function formatLoginProviderCompletionDescription(provider: LoginProviderComplet
 	return provider.name === provider.id ? authTypes : `${provider.name} · ${authTypes}`;
 }
 
+/** A user submission: editor text plus the images resolved from its `[Image #N]` markers. */
+interface InteractiveUserInput {
+	text: string;
+	images?: ImageContent[];
+}
+
+/** Local copy of pi-tui's image-marker pattern so submission scanning never mutates a shared /g regex. */
+const IMAGE_MARKER_PATTERN = /\[Image #([1-9]\d*)\]/g;
+
 /**
  * The InteractiveMode collaborators {@link attachClipboardImage} needs. Passed
  * explicitly (rather than as `this`) so the paste handler stays a free function
@@ -457,6 +466,8 @@ interface ClipboardImageDeps {
 	editor: EditorComponent;
 	pendingImages: Map<number, ImageContent>;
 	settings: { getBlockImages(): boolean; getImageAutoResize(): boolean };
+	/** True while the compaction queue is active; the queue carries text only, so pasted images are dropped with a visible status. */
+	isCompacting: () => boolean;
 	showStatus: (message: string) => void;
 	requestRender: () => void;
 }
@@ -488,6 +499,16 @@ async function attachClipboardImage(
 		// attachment at submit.
 		deps.showStatus("Image paste is not supported by the active editor");
 		return false;
+	}
+	if (deps.isCompacting()) {
+		// The compaction queue carries text only; an attachment queued behind
+		// compaction would be silently lost at delivery, so drop it here with a
+		// visible status. Consume the paste (true) - the clipboard holds a
+		// bitmap, so the plain-text fallback has nothing useful to insert.
+		deps.showStatus(
+			"Image paste dropped: messages sent during compaction cannot carry images - paste again after compaction finishes",
+		);
+		return true;
 	}
 
 	const processed = await processImage(image.bytes, image.mimeType, {
@@ -640,8 +661,8 @@ export class InteractiveMode {
 	private keybindings: KeybindingsManager;
 	private version: string;
 	private isInitialized = false;
-	private onInputCallback?: (text: string) => void;
-	private pendingUserInputs: string[] = [];
+	private onInputCallback?: (input: InteractiveUserInput) => void;
+	private pendingUserInputs: InteractiveUserInput[] = [];
 	/**
 	 * Clipboard images pasted into the composer, keyed by their visible
 	 * `[Image #N]` marker number. The editor stores marker ids only, so these
@@ -650,6 +671,16 @@ export class InteractiveMode {
 	 * {@link reconcilePendingImages}.
 	 */
 	private pendingImages = new Map<number, ImageContent>();
+	/**
+	 * Images pre-resolved by handleFollowUp's non-streaming branch, which hands
+	 * off through the public string-only `onSubmit(text)` API. Set BEFORE that
+	 * path's `setText("")` (whose prune chain destroys pendingImages) and
+	 * captured-then-cleared UNCONDITIONALLY at the submit-handler entry: slash,
+	 * extension and bash submissions return before the consuming branch, and a
+	 * field cleared only after use would leak a stale image into a later
+	 * ordinary submission that never references it.
+	 */
+	private preResolvedSubmissionImages?: ImageContent[];
 	private activeStatusIndicator: StatusIndicator | undefined = undefined;
 	private readonly idleStatus = new IdleStatus();
 	private workingMessage: string | undefined = undefined;
@@ -1455,7 +1486,10 @@ export class InteractiveMode {
 		while (true) {
 			const userInput = await this.getUserInput();
 			try {
-				await this.session.prompt(userInput, { streamingBehavior: "steer" });
+				await this.session.prompt(userInput.text, {
+					streamingBehavior: "steer",
+					...(userInput.images ? { images: userInput.images } : {}),
+				});
 			} catch (error: unknown) {
 				const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 				this.showError(errorMessage);
@@ -3651,6 +3685,7 @@ export class InteractiveMode {
 						editor: this.editor,
 						pendingImages: this.pendingImages,
 						settings: this.settingsManager,
+						isCompacting: () => (this.session as { isCompacting?: boolean } | undefined)?.isCompacting === true,
 						showStatus: (message) => this.showStatus(message),
 						requestRender: () => this.ui.requestRender(),
 					},
@@ -3694,6 +3729,33 @@ export class InteractiveMode {
 		this.pendingImages = reconciled;
 	}
 
+	/**
+	 * Resolve the `[Image #N]` markers in `submittedText` (in READING order)
+	 * into the image array submitted alongside it, then clear
+	 * {@link pendingImages}.
+	 *
+	 * Reads ONLY the submitted text plus pendingImages - never live editor
+	 * state: pi-tui's `Editor.submitValue()` resets the editor and clears its
+	 * registries BEFORE `onSubmit` fires. A marker with no pending payload (a
+	 * hand-typed `[Image #N]`, or the second half of a kill/yank duplicate) is
+	 * passed through untouched and consumes no slot; a payload-bearing
+	 * marker's FIRST occurrence wins. Slots are assigned 1..k in reading
+	 * order, so the Nth marker in the final text is `images[N-1]`.
+	 */
+	private takeSubmissionImages(submittedText: string): ImageContent[] {
+		const images: ImageContent[] = [];
+		const consumed = new Set<number>();
+		for (const match of submittedText.matchAll(IMAGE_MARKER_PATTERN)) {
+			const id = Number.parseInt(match[1] ?? "0", 10);
+			if (consumed.has(id)) continue;
+			consumed.add(id);
+			const image = this.pendingImages.get(id);
+			if (image) images.push(image);
+		}
+		this.pendingImages.clear();
+		return images;
+	}
+
 	private getSessionLogger(): SessionLogger {
 		this.sessionLogger ??= createSessionLogger(this.runtimeHost.services.agentDir);
 		return this.sessionLogger;
@@ -3706,6 +3768,14 @@ export class InteractiveMode {
 
 	private setupEditorSubmitHandler(): void {
 		this.defaultEditor.onSubmit = async (text: string) => {
+			// Capture-then-clear BEFORE any branch: handleFollowUp's non-streaming
+			// path pre-resolves images and hands off here, but slash / extension /
+			// bash submissions return before the consuming branches below. Clearing
+			// only after use would leak a stale array into a later ordinary
+			// submission whose text never references it.
+			const preResolvedImages = this.preResolvedSubmissionImages;
+			this.preResolvedSubmissionImages = undefined;
+
 			this.hideShortcutOverlay();
 			this.lastEditorText = "";
 			text = text.trim();
@@ -3901,9 +3971,15 @@ export class InteractiveMode {
 			// behavior here applies only to ordinary text, prompt template expansion,
 			// and queueing.
 			if (this.session.isStreaming) {
+				// Resolve BEFORE setText(""): the editor's prune chain fires
+				// onImageMarkersChanged([]) and destroys pendingImages.
+				const images = preResolvedImages ?? this.takeSubmissionImages(text);
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.session.prompt(text, { streamingBehavior: "steer" });
+				await this.session.prompt(text, {
+					streamingBehavior: "steer",
+					...(images.length > 0 ? { images } : {}),
+				});
 				this.updatePendingMessagesDisplay();
 				this.ui.requestRender();
 				return;
@@ -3913,10 +3989,12 @@ export class InteractiveMode {
 			// First, move any pending bash components to chat
 			this.flushPendingBashComponents();
 
+			const images = preResolvedImages ?? this.takeSubmissionImages(text);
+			const submission: InteractiveUserInput = images.length > 0 ? { text, images } : { text };
 			if (this.onInputCallback) {
-				this.onInputCallback(text);
+				this.onInputCallback(submission);
 			} else {
-				this.pendingUserInputs.push(text);
+				this.pendingUserInputs.push(submission);
 			}
 			this.editor.addToHistory?.(text);
 		};
@@ -4852,16 +4930,16 @@ export class InteractiveMode {
 		);
 	}
 
-	async getUserInput(): Promise<string> {
+	async getUserInput(): Promise<InteractiveUserInput> {
 		const queuedInput = this.pendingUserInputs.shift();
 		if (queuedInput !== undefined) {
 			return queuedInput;
 		}
 
 		return new Promise((resolve) => {
-			this.onInputCallback = (text: string) => {
+			this.onInputCallback = (input) => {
 				this.onInputCallback = undefined;
-				resolve(text);
+				resolve(input);
 			};
 		});
 	}
@@ -5087,6 +5165,12 @@ export class InteractiveMode {
 		const text = this.getExpandedEditorText().trim();
 		if (!text) return;
 
+		// Resolve attachments BEFORE any setText("") below: the editor's prune
+		// chain fires onImageMarkersChanged([]) and the reconciler destroys
+		// pendingImages, so resolving after the clear would ship a literal
+		// `[Image #N]` with no attachment behind it.
+		const images = this.takeSubmissionImages(text);
+
 		// Queue non-command input during compaction; dispatch extension commands.
 		// This is the Alt+Enter path (bound directly to app.message.followUp), which
 		// does NOT pass through onSubmit, so the isExtensionCommand check below is the
@@ -5112,12 +5196,20 @@ export class InteractiveMode {
 		if (this.session.isStreaming) {
 			this.editor.addToHistory?.(text);
 			this.editor.setText("");
-			await this.session.prompt(text, { streamingBehavior: "followUp" });
+			await this.session.prompt(text, {
+				streamingBehavior: "followUp",
+				...(images.length > 0 ? { images } : {}),
+			});
 			this.updatePendingMessagesDisplay();
 			this.ui.requestRender();
 		}
 		// If not streaming, Alt+Enter acts like regular Enter (trigger onSubmit)
 		else if (this.editor.onSubmit) {
+			// The public `onSubmit(text: string)` API cannot be widened, so hand
+			// the pre-resolved images over out-of-band; the submit handler
+			// captures-and-clears the field at entry and delivers them through the
+			// widened main-loop channel.
+			this.preResolvedSubmissionImages = images.length > 0 ? images : undefined;
 			this.editor.setText("");
 			this.editor.onSubmit(text);
 		}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3,7 +3,6 @@
  * Handles TUI rendering and user interaction, delegating business logic to AgentSession.
  */
 
-import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -122,8 +121,9 @@ import {
 } from "../../inspector-policy.ts";
 import { getChangelogPath, getNewEntries, normalizeChangelogLinks, parseChangelog } from "../../utils/changelog.ts";
 import { copyToClipboard, readClipboardText } from "../../utils/clipboard.ts";
-import { extensionForImageMimeType, readClipboardImage } from "../../utils/clipboard-image.ts";
+import { readClipboardImage } from "../../utils/clipboard-image.ts";
 import { parseGitUrl } from "../../utils/git.ts";
+import { processImage } from "../../utils/image-process.ts";
 import { openBrowser } from "../../utils/open-browser.ts";
 import { getCwdRelativePath } from "../../utils/paths.ts";
 import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
@@ -449,6 +449,62 @@ function formatLoginProviderCompletionDescription(provider: LoginProviderComplet
 }
 
 /**
+ * The InteractiveMode collaborators {@link attachClipboardImage} needs. Passed
+ * explicitly (rather than as `this`) so the paste handler stays a free function
+ * on the prototype and remains callable with a minimal borrowed receiver.
+ */
+interface ClipboardImageDeps {
+	editor: EditorComponent;
+	pendingImages: Map<number, ImageContent>;
+	settings: { getBlockImages(): boolean; getImageAutoResize(): boolean };
+	showStatus: (message: string) => void;
+	requestRender: () => void;
+}
+
+/**
+ * Attach a clipboard bitmap as an in-memory image behind an atomic
+ * `[Image #N]` marker. Returns false when nothing was attached, so the caller
+ * falls through to the plain-text clipboard path.
+ *
+ * The bytes deliberately never touch the filesystem: writing a temp file and
+ * inserting its path as literal text (the previous behavior) shipped an
+ * unreadable `/var/folders/.../pi-clipboard-<uuid>.png` string to the model and
+ * attached no image at all.
+ */
+async function attachClipboardImage(
+	deps: ClipboardImageDeps,
+	image: { bytes: Uint8Array; mimeType: string },
+): Promise<boolean> {
+	if (deps.settings.getBlockImages()) {
+		// Pinned behavior: nothing is attached and nothing is inserted, but the
+		// paste is never a silent no-op - the user must learn why their screenshot
+		// vanished, and which setting to flip.
+		deps.showStatus("Image paste blocked by the images.blockImages setting");
+		return false;
+	}
+	if (!deps.editor.insertImageMarker) {
+		// A marker-unaware editor cannot keep the marker atomic, and a dead literal
+		// `[Image #N]` with a live payload behind it would misnumber every other
+		// attachment at submit.
+		deps.showStatus("Image paste is not supported by the active editor");
+		return false;
+	}
+
+	const processed = await processImage(image.bytes, image.mimeType, {
+		autoResizeImages: deps.settings.getImageAutoResize(),
+	});
+	if (!processed.ok) {
+		deps.showStatus(processed.message);
+		return false;
+	}
+
+	const id = deps.editor.insertImageMarker();
+	deps.pendingImages.set(id, { type: "image", data: processed.data, mimeType: processed.mimeType });
+	deps.requestRender();
+	return true;
+}
+
+/**
  * Options for InteractiveMode initialization.
  */
 export interface InteractiveModeOptions {
@@ -586,6 +642,14 @@ export class InteractiveMode {
 	private isInitialized = false;
 	private onInputCallback?: (text: string) => void;
 	private pendingUserInputs: string[] = [];
+	/**
+	 * Clipboard images pasted into the composer, keyed by their visible
+	 * `[Image #N]` marker number. The editor stores marker ids only, so these
+	 * bytes must live here (and survive an editor swap, which discards the
+	 * editor instance). Kept aligned with the displayed numbers by
+	 * {@link reconcilePendingImages}.
+	 */
+	private pendingImages = new Map<number, ImageContent>();
 	private activeStatusIndicator: StatusIndicator | undefined = undefined;
 	private readonly idleStatus = new IdleStatus();
 	private workingMessage: string | undefined = undefined;
@@ -3276,8 +3340,13 @@ export class InteractiveMode {
 			};
 			newEditor.onChange = this.defaultEditor.onChange;
 
-			// Copy text (and any collapsed paste markers) from previous editor
-			transferEditorContent(this.editor, newEditor);
+			// Copy text (and any collapsed paste/image markers) from previous editor.
+			// Image payloads live on this instance, so they must be dropped when the
+			// destination cannot own their markers.
+			if (!transferEditorContent(this.editor, newEditor).imageMarkersTransferred) {
+				this.pendingImages.clear();
+			}
+			this.subscribeImageMarkers(newEditor);
 
 			// Copy appearance settings if supported
 			if (newEditor.borderColor !== undefined) {
@@ -3334,7 +3403,10 @@ export class InteractiveMode {
 			// hand-off, and a setText round-trip would be pure churn on the
 			// user's draft.
 			if (this.editor !== this.defaultEditor) {
-				transferEditorContent(this.editor, this.defaultEditor);
+				if (!transferEditorContent(this.editor, this.defaultEditor).imageMarkersTransferred) {
+					this.pendingImages.clear();
+				}
+				this.subscribeImageMarkers(this.defaultEditor);
 			}
 			this.editor = this.defaultEditor;
 		}
@@ -3537,8 +3609,12 @@ export class InteractiveMode {
 			this.updateShortcutOverlay(text);
 		};
 
-		// Handle clipboard paste (triggered on Ctrl+V). Images are attached by path;
-		// otherwise, paste plain text from the system clipboard.
+		// Keep pendingImages aligned with the markers the editor displays.
+		this.subscribeImageMarkers(this.defaultEditor);
+
+		// Handle clipboard paste (triggered on Ctrl+V). Images are attached in
+		// memory behind an atomic `[Image #N]` marker; otherwise, paste plain text
+		// from the system clipboard.
 		this.defaultEditor.onPasteImage = () => {
 			this.lastInputWasPaste = true;
 			void this.handleClipboardPaste();
@@ -3568,17 +3644,19 @@ export class InteractiveMode {
 	private async handleClipboardPaste(): Promise<void> {
 		try {
 			const image = await readClipboardImage();
-			if (image) {
-				const tmpDir = os.tmpdir();
-				const ext = extensionForImageMimeType(image.mimeType) ?? "png";
-				const fileName = `pi-clipboard-${crypto.randomUUID()}.${ext}`;
-				const filePath = path.join(tmpDir, fileName);
-				fs.writeFileSync(filePath, Buffer.from(image.bytes));
-
-				this.editor.insertTextAtCursor?.(filePath);
-				this.ui.requestRender();
-				return;
-			}
+			const attached =
+				image &&
+				(await attachClipboardImage(
+					{
+						editor: this.editor,
+						pendingImages: this.pendingImages,
+						settings: this.settingsManager,
+						showStatus: (message) => this.showStatus(message),
+						requestRender: () => this.ui.requestRender(),
+					},
+					image,
+				));
+			if (attached) return;
 
 			const text = await readClipboardText();
 			if (text) {
@@ -3590,6 +3668,30 @@ export class InteractiveMode {
 			this.getSessionLogger().warn("clipboard_error", { op: "paste", error: message });
 			this.showStatus(`Clipboard paste failed: ${sanitizeTuiErrorMessage(message)}`);
 		}
+	}
+
+	/** Route an editor's image-marker changes into {@link reconcilePendingImages}. */
+	private subscribeImageMarkers(editor: EditorComponent): void {
+		if (!editor.insertImageMarker) return;
+		editor.onImageMarkersChanged = (order) => this.reconcilePendingImages(order);
+	}
+
+	/**
+	 * Re-key {@link pendingImages} onto the marker numbers the editor now
+	 * displays. `order` lists the SURVIVING marker ids (pre-renumber) in text
+	 * reading order, which is exactly the editor's new 1..k display numbering, so
+	 * a payload's new key is its position in that list. Ids absent from `order`
+	 * are dropped; reported ids with no payload (a hand-typed marker) are skipped
+	 * without consuming anyone else's slot.
+	 */
+	private reconcilePendingImages(order: number[]): void {
+		if (this.pendingImages.size === 0) return;
+		const reconciled = new Map<number, ImageContent>();
+		order.forEach((id, index) => {
+			const image = this.pendingImages.get(id);
+			if (image) reconciled.set(index + 1, image);
+		});
+		this.pendingImages = reconciled;
 	}
 
 	private getSessionLogger(): SessionLogger {

--- a/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
+++ b/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
@@ -28,6 +28,7 @@ vi.mock("../src/utils/clipboard.ts", async (importOriginal) => {
 	return { ...original, readClipboardText: clipboardTextMock.readClipboardText };
 });
 
+import type { ImageContent } from "@earendil-works/pi-ai/compat";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
 
 type HandleClipboardPaste = (this: object) => Promise<void>;
@@ -38,14 +39,47 @@ function getHandleClipboardPaste(): HandleClipboardPaste {
 	return handler as HandleClipboardPaste;
 }
 
-function makeContext() {
+/**
+ * A real 16x16 RGB PNG. processImage() genuinely decodes, resizes and re-encodes
+ * the bytes, so the fixture must be a decodable image (the WASM decoder rejects
+ * degenerate 1x1 payloads) - that keeps these cases exercising the production
+ * normalization path instead of its failure branch.
+ */
+const SAMPLE_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAB0klEQVR4nA3LoQ6FIABAURrBjabJ4mjMYtLGZqDRCGw0TBS67QY63c5/vnf6EUIgBUowC1aBFhjBIbgEVuAEXhAESZAFRSDEhJxQE/PEOqEnzMQxcU3YCTfhJ8JEmsgTZfqHBbmgFuaFdUEvmIVj4VqwC27BL4SFtJAXyvIPG3JDbcwb64beMBvHxrVhN9yG3wgbaSNvlO0fduSO2pl31h29Y3aOnWvH7rgdvxN20k7eKfs/nMgTdTKfrCf6xJwcJ9eJPXEn/iScpJN8Us5/uJE36ma+WW/0jbk5bq4be+Nu/E24STf5ptz/4JEe5Zk9q0d7jOfwXB7rcR7vCZ7kyZ7i/yEiIyoyR9aIjpjIEbkiNuIiPhIiKZIjJf7Dg3xQD/PD+qAfzMPxcD3YB/fgH8JDesgP5fmHiqyoylxZK7piKkflqtiKq/hKqKRKrpT6Dy/yRb3ML+uLfjEvx8v1Yl/ci38JL+klv5T3HxqyoRpzY23ohmkcjathG67hG6GRGrlR2j90ZEd15s7a0R3TOTpXx3Zcx3dCJ3Vyp/R/+JAf6mP+WD/0h/k4Pq4P++E+/Ef4SB/5o3z/MJADNZgH60APzOAYXAM7cAM/CIM0yIMy+AEIbAcQK3fUWgAAAABJRU5ErkJggg==";
+
+function samplePngBytes(): Uint8Array {
+	return new Uint8Array(Buffer.from(SAMPLE_PNG_BASE64, "base64"));
+}
+
+function makeContext(options: { blockImages?: boolean; autoResize?: boolean } = {}) {
 	const sessionLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+	let nextMarkerId = 0;
+	const insertedText: string[] = [];
 	return {
-		editor: { insertTextAtCursor: vi.fn() },
+		editor: {
+			insertTextAtCursor: vi.fn((text: string) => {
+				insertedText.push(text);
+			}),
+			insertImageMarker: vi.fn(() => {
+				nextMarkerId += 1;
+				insertedText.push(`[Image #${nextMarkerId}]`);
+				return nextMarkerId;
+			}),
+			onImageMarkersChanged: undefined as ((order: number[]) => void) | undefined,
+		},
+		insertedText,
+		pendingImages: new Map<number, ImageContent>(),
 		ui: { requestRender: vi.fn() },
 		showStatus: vi.fn(),
 		sessionLogger,
 		getSessionLogger: () => sessionLogger,
+		// Borrowed-prototype call: a plain receiver does not inherit InteractiveMode's
+		// `settingsManager` getter, so the fixture stands in for it directly.
+		settingsManager: {
+			getBlockImages: () => options.blockImages ?? false,
+			getImageAutoResize: () => options.autoResize ?? true,
+		},
 	};
 }
 
@@ -89,5 +123,170 @@ describe("InteractiveMode clipboard paste error surfacing", () => {
 		expect(context.showStatus).not.toHaveBeenCalled();
 		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
 		expect(context.sessionLogger.warn).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * Regression: pasting a screenshot used to write the bytes to a temp file and
+ * insert that path as literal text, so the model received an unreadable
+ * `/var/folders/.../pi-clipboard-<uuid>.png` string and never the image. The
+ * bytes must now travel in memory, keyed by the atomic `[Image #N]` marker id.
+ */
+describe("InteractiveMode clipboard paste image attachment", () => {
+	it("attaches the image as a pending payload behind an atomic marker", async () => {
+		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
+			bytes: samplePngBytes(),
+			mimeType: "image/png",
+		});
+		const context = makeContext();
+
+		await getHandleClipboardPaste().call(context);
+
+		expect(context.editor.insertImageMarker).toHaveBeenCalledTimes(1);
+		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(context.showStatus).not.toHaveBeenCalled();
+		expect(context.sessionLogger.warn).not.toHaveBeenCalled();
+
+		expect(context.pendingImages.size).toBe(1);
+		const entry = context.pendingImages.get(1);
+		expect(entry).toBeDefined();
+		expect(entry?.type).toBe("image");
+		expect(entry?.mimeType).toBe("image/png");
+		expect(entry?.data).toMatch(/^[A-Za-z0-9+/=]+$/);
+		expect(Buffer.from(String(entry?.data), "base64").length).toBeGreaterThan(0);
+	});
+
+	it("never inserts a temp-file path for the pasted image", async () => {
+		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
+			bytes: samplePngBytes(),
+			mimeType: "image/png",
+		});
+		const context = makeContext();
+
+		await getHandleClipboardPaste().call(context);
+
+		const inserted = context.insertedText.join("\n");
+		expect(inserted).toContain("[Image #1]");
+		expect(inserted).not.toContain("/tmp");
+		expect(inserted).not.toContain("/var/folders");
+		expect(inserted).not.toContain("pi-clipboard-");
+	});
+
+	it("keeps marker numbering and the payload map aligned across two pastes", async () => {
+		clipboardImageMock.readClipboardImage
+			.mockResolvedValueOnce({ bytes: samplePngBytes(), mimeType: "image/png" })
+			.mockResolvedValueOnce({ bytes: samplePngBytes(), mimeType: "image/png" });
+		const context = makeContext();
+
+		await getHandleClipboardPaste().call(context);
+		await getHandleClipboardPaste().call(context);
+
+		expect(context.editor.insertImageMarker).toHaveBeenCalledTimes(2);
+		expect([...context.pendingImages.keys()]).toEqual([1, 2]);
+		expect(context.insertedText).toEqual(["[Image #1]", "[Image #2]"]);
+	});
+
+	it("drops the attachment when blockImages is enabled and tells the user why", async () => {
+		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
+			bytes: samplePngBytes(),
+			mimeType: "image/png",
+		});
+		clipboardTextMock.readClipboardText.mockResolvedValueOnce(null);
+		const context = makeContext({ blockImages: true });
+
+		await getHandleClipboardPaste().call(context);
+
+		// Pinned behavior: no marker, no attachment, no temp path - and a visible
+		// status so the paste is never a silent no-op.
+		expect(context.editor.insertImageMarker).not.toHaveBeenCalled();
+		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(context.pendingImages.size).toBe(0);
+		expect(context.showStatus).toHaveBeenCalledTimes(1);
+		expect(String(context.showStatus.mock.calls[0]?.[0])).toContain("Image paste blocked");
+		expect(context.sessionLogger.warn).not.toHaveBeenCalled();
+	});
+
+	it("surfaces a status and attaches nothing when the image cannot be processed", async () => {
+		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
+			bytes: new Uint8Array([1, 2, 3, 4]),
+			mimeType: "image/tiff",
+		});
+		const context = makeContext();
+
+		await getHandleClipboardPaste().call(context);
+
+		expect(context.editor.insertImageMarker).not.toHaveBeenCalled();
+		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(context.pendingImages.size).toBe(0);
+		expect(context.showStatus).toHaveBeenCalledTimes(1);
+		expect(String(context.showStatus.mock.calls[0]?.[0])).toContain("Image");
+	});
+});
+
+/**
+ * Regression: the reconciler keeps `pendingImages` aligned with the editor's
+ * visible `[Image #N]` numbers. The editor reports the surviving PRE-renumber
+ * ids in reading order, so the map must be re-keyed to 1..k by position -
+ * otherwise a deleted marker orphans its payload and `[Image #1]` resolves to
+ * the wrong (or a removed) image at submit.
+ */
+describe("InteractiveMode image-marker reconciliation", () => {
+	type Reconcile = (this: { pendingImages: Map<number, ImageContent> }, order: number[]) => void;
+
+	function getReconcile(): Reconcile {
+		const handler = Reflect.get(InteractiveMode.prototype, "reconcilePendingImages");
+		if (typeof handler !== "function") throw new Error("Expected InteractiveMode.reconcilePendingImages");
+		return handler as Reconcile;
+	}
+
+	function image(data: string): ImageContent {
+		return { type: "image", data, mimeType: "image/png" };
+	}
+
+	it("renumbers surviving payloads to match the reported reading order", () => {
+		const context = {
+			pendingImages: new Map<number, ImageContent>([
+				[1, image("AAA")],
+				[2, image("BBB")],
+			]),
+		};
+
+		// `[Image #1]` was deleted; the editor renumbered `[Image #2]` down to 1.
+		getReconcile().call(context, [2]);
+
+		expect([...context.pendingImages.keys()]).toEqual([1]);
+		expect(context.pendingImages.get(1)?.data).toBe("BBB");
+	});
+
+	it("reorders payloads when markers are moved into a different reading order", () => {
+		const context = {
+			pendingImages: new Map<number, ImageContent>([
+				[1, image("AAA")],
+				[2, image("BBB")],
+			]),
+		};
+
+		getReconcile().call(context, [2, 1]);
+
+		expect(context.pendingImages.get(1)?.data).toBe("BBB");
+		expect(context.pendingImages.get(2)?.data).toBe("AAA");
+	});
+
+	it("drops every payload when all markers are gone", () => {
+		const context = { pendingImages: new Map<number, ImageContent>([[1, image("AAA")]]) };
+
+		getReconcile().call(context, []);
+
+		expect(context.pendingImages.size).toBe(0);
+	});
+
+	it("ignores reported ids that have no pending payload (user-typed markers)", () => {
+		const context = { pendingImages: new Map<number, ImageContent>([[2, image("BBB")]]) };
+
+		// `[Image #1]` was typed by hand and owns no attachment.
+		getReconcile().call(context, [1, 2]);
+
+		expect([...context.pendingImages.keys()]).toEqual([2]);
+		expect(context.pendingImages.get(2)?.data).toBe("BBB");
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -578,6 +578,13 @@ describe("InteractiveMode compaction events", () => {
 			turnWorkingTip: { resetForNewTurn: vi.fn(), resolve: vi.fn() },
 			hideShortcutOverlay: vi.fn(),
 			lastEditorText: "",
+			// setupKeyHandlers subscribes the editor's image-marker channel. Borrow the
+			// real method (and the real payload map it reconciles) rather than stubbing
+			// it, so this fixture exercises production plumbing; it no-ops here because
+			// the fake editor exposes no insertImageMarker.
+			pendingImages: new Map<number, unknown>(),
+			subscribeImageMarkers: Reflect.get(InteractiveMode.prototype, "subscribeImageMarkers"),
+			reconcilePendingImages: Reflect.get(InteractiveMode.prototype, "reconcilePendingImages"),
 			ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() }, onDebug: undefined as unknown },
 		};
 

--- a/packages/coding-agent/test/interactive-mode-exit-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-exit-command.test.ts
@@ -24,19 +24,22 @@ type SubmitContext = {
 	hideShortcutOverlay: () => void;
 	isExtensionCommand: (text: string) => boolean;
 	lastEditorText: string;
-	onInputCallback?: (text: string) => void;
-	pendingUserInputs: string[];
+	onInputCallback?: (input: { text: string; images?: unknown[] }) => void;
+	pendingUserInputs: { text: string; images?: unknown[] }[];
+	pendingImages: Map<number, unknown>;
+	takeSubmissionImages: (submittedText: string) => unknown[];
 	shutdown: () => Promise<void>;
 };
 
 type InteractiveModePrivate = {
 	setupEditorSubmitHandler(this: SubmitContext): void;
+	takeSubmissionImages(this: SubmitContext, submittedText: string): unknown[];
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
 
 function createSubmitContext(): SubmitContext {
-	return {
+	const context: SubmitContext = {
 		defaultEditor: {},
 		editor: {
 			addToHistory: vi.fn(),
@@ -53,8 +56,14 @@ function createSubmitContext(): SubmitContext {
 		isExtensionCommand: vi.fn(() => false),
 		lastEditorText: "",
 		pendingUserInputs: [],
+		pendingImages: new Map(),
+		takeSubmissionImages: vi.fn(() => []),
 		shutdown: vi.fn(async () => {}),
 	};
+	// Borrowed receiver: resolve markers with the REAL production helper (its
+	// only dependencies are the pendingImages map above).
+	context.takeSubmissionImages = interactiveModePrototype.takeSubmissionImages.bind(context);
+	return context;
 }
 
 describe("BUILTIN_SLASH_COMMANDS exit alias", () => {

--- a/packages/coding-agent/test/interactive-mode-image-submission.test.ts
+++ b/packages/coding-agent/test/interactive-mode-image-submission.test.ts
@@ -1,0 +1,544 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Submission-channel coverage for pasted images: the `[Image #N]` markers the
+ * paste handler inserts must resolve, at submit time, into the images array
+ * that rides PromptOptions alongside the text - on EVERY submission surface:
+ * the normal onInputCallback/getUserInput channel, the streaming/steer
+ * branch, and Alt+Enter (handleFollowUp), whose non-streaming leg cannot
+ * widen the public onSubmit(text) API and must hand the images over
+ * out-of-band instead.
+ *
+ * Resolution must read ONLY the submitted text plus the pendingImages map:
+ * pi-tui's Editor.submitValue() has already reset the editor and cleared its
+ * registries before onSubmit fires, so live editor state is empty by then.
+ */
+
+const clipboardImageMock = vi.hoisted(() => ({
+	readClipboardImage: vi.fn<() => Promise<{ bytes: Uint8Array; mimeType: string } | null>>(),
+}));
+
+const clipboardTextMock = vi.hoisted(() => ({
+	readClipboardText: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("../src/utils/clipboard-image.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../src/utils/clipboard-image.ts")>();
+	return { ...original, readClipboardImage: clipboardImageMock.readClipboardImage };
+});
+
+vi.mock("../src/utils/clipboard.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../src/utils/clipboard.ts")>();
+	return { ...original, readClipboardText: clipboardTextMock.readClipboardText };
+});
+
+vi.mock("../src/utils/version-check.ts", () => ({
+	checkForNewPiVersion: vi.fn(async () => undefined),
+	getReleaseChangelogUrl: vi.fn((version: string) => `https://example.invalid/releases/${version}`),
+}));
+
+import type { ImageContent } from "@earendil-works/pi-ai/compat";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+/** The widened submission-channel payload: text plus images resolved from markers. */
+type UserSubmission = { text: string; images?: ImageContent[] };
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+interface FakeEditor {
+	getText: MockFn;
+	setText: MockFn;
+	addToHistory: MockFn;
+	insertImageMarker: MockFn;
+	insertTextAtCursor: MockFn;
+	onSubmit?: (text: string) => void | Promise<void>;
+	onImageMarkersChanged?: (order: number[]) => void;
+}
+
+interface FakeSession {
+	isCompacting: boolean;
+	isStreaming: boolean;
+	isBashRunning: boolean;
+	prompt: MockFn;
+	extensionRunner: { getCommand: (name: string) => unknown };
+	modelRuntime: { getError: () => string | undefined; refresh: () => Promise<unknown> };
+	fallbackValidationWarnings: readonly string[];
+}
+
+interface ModeContext {
+	defaultEditor: FakeEditor;
+	editor: FakeEditor;
+	session: FakeSession;
+	pendingImages: Map<number, ImageContent>;
+	pendingUserInputs: UserSubmission[];
+	onInputCallback?: (input: UserSubmission) => void;
+	preResolvedSubmissionImages?: ImageContent[];
+	settingsManager: { getBlockImages: () => boolean; getImageAutoResize: () => boolean };
+	sessionLogger: { warn: MockFn };
+	getSessionLogger: () => ModeContext["sessionLogger"];
+	ui: { requestRender: () => void };
+	showStatus: MockFn;
+	showError: (message: string) => void;
+	showWarning: (message: string) => void;
+	hideShortcutOverlay: () => void;
+	flushPendingBashComponents: () => void;
+	updatePendingMessagesDisplay: () => void;
+	updateEditorBorderColor: () => void;
+	handleModelCommand: (searchTerm?: string) => Promise<void>;
+	handleBashCommand: (command: string, excluded: boolean) => Promise<void>;
+	lastEditorText: string;
+	isBashMode: boolean;
+	options: Record<string, never>;
+	version: string;
+	init: () => Promise<void>;
+	checkForPackageUpdates: () => Promise<string[]>;
+	checkTmuxSetup: () => Promise<string | undefined>;
+	maybeWarnAboutAnthropicSubscriptionAuth: () => Promise<void>;
+	showNewVersionNotification: (version: unknown) => void;
+	showPackageUpdateNotification: (packages: unknown) => void;
+	showRiskyMainModelWarning: () => void;
+	/**
+	 * Real production helpers, bound to the fake receiver (a plain object has
+	 * no prototype chain to resolve private methods through). Missing helpers
+	 * stay undefined so a tree without the implementation fails on assertions
+	 * rather than crashing the harness.
+	 */
+	takeSubmissionImages?: (submittedText: string) => ImageContent[];
+	getUserInput?: () => Promise<UserSubmission>;
+	isExtensionCommand?: (text: string) => boolean;
+	getExpandedEditorText?: () => string;
+}
+
+type ModePrototype = {
+	setupEditorSubmitHandler(this: ModeContext): void;
+	getUserInput(this: ModeContext): Promise<UserSubmission>;
+	run(this: ModeContext): Promise<void>;
+	handleFollowUp(this: ModeContext): Promise<void>;
+	handleClipboardPaste(this: ModeContext): Promise<void>;
+	reconcilePendingImages(this: ModeContext, order: number[]): void;
+	takeSubmissionImages(this: ModeContext, submittedText: string): ImageContent[];
+	isExtensionCommand(this: ModeContext, text: string): boolean;
+	getExpandedEditorText(this: ModeContext): string;
+};
+
+const proto = InteractiveMode.prototype as unknown as ModePrototype;
+
+function image(data: string): ImageContent {
+	return { type: "image", data, mimeType: "image/png" };
+}
+
+/**
+ * A real 16x16 RGB PNG so processImage()'s decoder runs the production
+ * normalization path (mirrors the clipboard-paste fixture).
+ */
+const SAMPLE_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAB0klEQVR4nA3LoQ6FIABAURrBjabJ4mjMYtLGZqDRCGw0TBS67QY63c5/vnf6EUIgBUowC1aBFhjBIbgEVuAEXhAESZAFRSDEhJxQE/PEOqEnzMQxcU3YCTfhJ8JEmsgTZfqHBbmgFuaFdUEvmIVj4VqwC27BL4SFtJAXyvIPG3JDbcwb64beMBvHxrVhN9yG3wgbaSNvlO0fduSO2pl31h29Y3aOnWvH7rgdvzN20k7eKfs/nMgTdTKfrCv6xJwcJ9eJPXEn/iScpJN8Us5/uJE36ma+WW/0jbk5bq4be+Nu/E24STf5ptz/4JEe5Zk9q0d7jOfwXB7rcRZ7vCZ7kyZ7i/yEiIyoyR9aIjpjIEbkSNuIiPhIiKZIjJf7Dg3xQD/PD+qAfzMPxcD3YB/fgH8JDesgP5fmHiqyoylxZK7piKkflqtiKq/hKqKRKrpT6Dy/yRb3ML+uLfjEvx8v1Yl/ci38pa+kpS/3uXwyoRpzY23ohmkcjathZG7hG6GRGrlR2j90ZEd15O7a0R3TOTpXx3Zcx3dCJ3Vyp/R/+JA/6l+WD/0h/k4Pq4P++E+/Ef4SB/5o3z/MJADNZgH60APzOAYXAM7cAM/CIM0yIMy+AEIbAcQK3fUWgAAAABJRU5ErkJggg==";
+
+function samplePngBytes(): Uint8Array {
+	return new Uint8Array(Buffer.from(SAMPLE_PNG_BASE64, "base64"));
+}
+
+function createModeContext(): ModeContext {
+	const sessionLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+	const editor: FakeEditor = {
+		getText: vi.fn(() => ""),
+		setText: vi.fn(() => {}),
+		addToHistory: vi.fn(),
+		insertImageMarker: vi.fn(() => 1),
+		insertTextAtCursor: vi.fn(),
+		onImageMarkersChanged: undefined,
+	};
+	const session: FakeSession = {
+		isCompacting: false,
+		isStreaming: false,
+		isBashRunning: false,
+		prompt: vi.fn(async () => {}),
+		extensionRunner: { getCommand: vi.fn(() => undefined) },
+		modelRuntime: { getError: vi.fn(() => undefined), refresh: vi.fn(async () => undefined) },
+		fallbackValidationWarnings: [],
+	};
+	const context: ModeContext = Object.assign(
+		{
+			defaultEditor: {} as FakeEditor,
+			editor,
+			session,
+			pendingImages: new Map<number, ImageContent>(),
+			pendingUserInputs: [] as UserSubmission[],
+			onInputCallback: undefined,
+			preResolvedSubmissionImages: undefined,
+			settingsManager: {
+				getBlockImages: () => false,
+				getImageAutoResize: () => true,
+			},
+			sessionLogger,
+			getSessionLogger: () => sessionLogger,
+			ui: { requestRender: vi.fn() },
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			showWarning: vi.fn(),
+			hideShortcutOverlay: vi.fn(),
+			flushPendingBashComponents: vi.fn(),
+			updatePendingMessagesDisplay: vi.fn(),
+			updateEditorBorderColor: vi.fn(),
+			handleModelCommand: vi.fn(async () => {}),
+			handleBashCommand: vi.fn(async () => {}),
+			lastEditorText: "",
+			isBashMode: false,
+			options: {},
+			version: "test",
+			init: vi.fn(async () => {}),
+			checkForPackageUpdates: vi.fn(async (): Promise<string[]> => []),
+			checkTmuxSetup: vi.fn(async () => undefined),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(async () => {}),
+			showNewVersionNotification: vi.fn(),
+			showPackageUpdateNotification: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
+		},
+		{} as ModeContext,
+	);
+	// Bind the REAL production helpers onto the fake receiver (a plain object
+	// has no prototype chain to resolve private methods through). Missing
+	// helpers stay undefined so a tree without the implementation fails on
+	// assertions rather than crashing the harness.
+	for (const method of [
+		"takeSubmissionImages",
+		"isExtensionCommand",
+		"getExpandedEditorText",
+		"getUserInput",
+	] as const) {
+		const real = proto[method] as unknown as ((this: ModeContext, ...args: never[]) => unknown) | undefined;
+		if (typeof real === "function") {
+			context[method] = real.bind(context) as never;
+		}
+	}
+
+	// Mirror the real editor: clearing the text prunes every marker and fires
+	// onImageMarkersChanged([]), which the reconciler answers by DESTROYING
+	// pendingImages. Any submission path that resolves images after such a
+	// setText loses the attachment.
+	editor.setText = vi.fn((text: string) => {
+		if (text === "") editor.onImageMarkersChanged?.([]);
+	});
+	editor.onImageMarkersChanged = (order: number[]) => {
+		proto.reconcilePendingImages.call(context, order);
+	};
+	return context;
+}
+
+/** Install the production submit handler; optionally let this.editor BE the default editor. */
+function prepareSubmitHandler(context: ModeContext, options: { shareEditor?: boolean } = {}): void {
+	if (options.shareEditor) context.defaultEditor = context.editor;
+	proto.setupEditorSubmitHandler.call(context);
+}
+
+function submit(context: ModeContext, text: string): Promise<void> {
+	const handler = context.defaultEditor.onSubmit;
+	if (!handler) throw new Error("onSubmit handler not installed");
+	return Promise.resolve(handler(text));
+}
+
+/** Start the real getUserInput() so the widened channel can be observed end-to-end. */
+function beginUserInput(context: ModeContext): Promise<UserSubmission> {
+	return proto.getUserInput.call(context);
+}
+
+describe("InteractiveMode image submission - normal channel", () => {
+	it("delivers a submitted image through the real run() main loop into session.prompt", async () => {
+		const pending = image("QUFBQQ==");
+		const stop = new Error("stop interactive loop");
+		const context = createModeContext();
+		context.session.prompt = vi.fn(async () => {
+			throw stop;
+		});
+		context.showError = vi.fn(() => {
+			throw stop;
+		});
+		context.pendingImages.set(1, pending);
+		prepareSubmitHandler(context);
+
+		const runPromise = proto.run.call(context);
+		await submit(context, "look at [Image #1]");
+		await expect(runPromise).rejects.toBe(stop);
+
+		expect(context.session.prompt).toHaveBeenCalledTimes(1);
+		const [promptText, promptOptions] = context.session.prompt.mock.calls[0] as [
+			string,
+			{ streamingBehavior?: string; images?: ImageContent[] },
+		];
+		expect(promptText).toBe("look at [Image #1]");
+		expect(promptOptions?.streamingBehavior).toBe("steer");
+		expect(promptOptions?.images).toHaveLength(1);
+		expect(promptOptions?.images?.[0]).toMatchObject({
+			type: "image",
+			data: pending.data,
+			mimeType: pending.mimeType,
+		});
+	});
+
+	it("passes NO images key when the main loop drains plain text", async () => {
+		const stop = new Error("stop interactive loop");
+		const context = createModeContext();
+		context.session.prompt = vi.fn(async () => {
+			throw stop;
+		});
+		context.showError = vi.fn(() => {
+			throw stop;
+		});
+		prepareSubmitHandler(context);
+
+		const runPromise = proto.run.call(context);
+		await submit(context, "just text");
+		await expect(runPromise).rejects.toBe(stop);
+
+		expect(context.session.prompt).toHaveBeenCalledTimes(1);
+		const [promptText, promptOptions] = context.session.prompt.mock.calls[0] as [string, Record<string, unknown>];
+		expect(promptText).toBe("just text");
+		expect(promptOptions).toEqual({ streamingBehavior: "steer" });
+	});
+
+	it("resolves markers into the widened getUserInput payload and clears pendingImages", async () => {
+		const pending = image("QUJDRA==");
+		const context = createModeContext();
+		context.pendingImages.set(1, pending);
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "look at [Image #1]");
+
+		await expect(userInput).resolves.toEqual({
+			text: "look at [Image #1]",
+			images: [pending],
+		});
+		expect(context.pendingImages.size).toBe(0);
+	});
+
+	it("returns queued submissions (with images) from getUserInput before installing a callback", async () => {
+		const queued = image("cXVldWVk");
+		const context = createModeContext();
+		context.pendingUserInputs.push({ text: "queued [Image #1]", images: [queued] });
+
+		await expect(proto.getUserInput.call(context)).resolves.toEqual({
+			text: "queued [Image #1]",
+			images: [queued],
+		});
+		expect(context.onInputCallback).toBeUndefined();
+	});
+
+	it("submits two markers in reading order with final text [Image #1] then [Image #2]", async () => {
+		const first = image("RklSU1Q=");
+		const second = image("U0VDT05E");
+		const context = createModeContext();
+		context.pendingImages.set(1, first);
+		context.pendingImages.set(2, second);
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "shot [Image #1] then [Image #2]");
+
+		const resolved = await userInput;
+		expect(resolved.text).toBe("shot [Image #1] then [Image #2]");
+		expect(resolved.images).toEqual([first, second]);
+		expect(context.pendingImages.size).toBe(0);
+	});
+
+	it("orders the array by READING ORDER, not marker number", async () => {
+		const a = image("QUFBQQ==");
+		const b = image("QkJCQg==");
+		const context = createModeContext();
+		context.pendingImages.set(1, a);
+		context.pendingImages.set(2, b);
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "late [Image #2] early [Image #1]");
+
+		// The first marker in the text must be images[0] so look_at's
+		// [Image #1] resolves to what the user sees first.
+		await expect(userInput).resolves.toEqual({
+			text: "late [Image #2] early [Image #1]",
+			images: [b, a],
+		});
+	});
+
+	it("passes no images key when every marker was deleted before submit", async () => {
+		const context = createModeContext();
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "all markers deleted");
+
+		await expect(userInput).resolves.toEqual({ text: "all markers deleted" });
+	});
+
+	it("passes plain text through with no images key", async () => {
+		const context = createModeContext();
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "hello without attachments");
+
+		await expect(userInput).resolves.toEqual({ text: "hello without attachments" });
+	});
+
+	it("lets a hand-typed [Image #1] with no pending entry pass through untouched", async () => {
+		const context = createModeContext();
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "look at [Image #1]");
+
+		await expect(userInput).resolves.toEqual({ text: "look at [Image #1]" });
+	});
+
+	it("lets a hand-typed marker consume no slot in front of a real one", async () => {
+		const pasted = image("UEFTVEVE");
+		const context = createModeContext();
+		context.pendingImages.set(2, pasted);
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "typed [Image #1] pasted [Image #2]");
+
+		await expect(userInput).resolves.toEqual({
+			text: "typed [Image #1] pasted [Image #2]",
+			images: [pasted],
+		});
+	});
+
+	it("attaches the image once when a marker is duplicated by kill/yank", async () => {
+		const pending = image("RFVQTElDQVRF");
+		const context = createModeContext();
+		context.pendingImages.set(1, pending);
+		prepareSubmitHandler(context);
+
+		const userInput = beginUserInput(context);
+		await submit(context, "dup [Image #1] and [Image #1] again");
+
+		const resolved = await userInput;
+		expect(resolved.text).toBe("dup [Image #1] and [Image #1] again");
+		expect(resolved.images).toEqual([pending]);
+	});
+});
+
+describe("InteractiveMode image submission - steer path", () => {
+	it("carries images on the streaming/steer branch and resolves before setText clears the map", async () => {
+		const pending = image("U1RFRVI=");
+		const context = createModeContext();
+		context.session.isStreaming = true;
+		context.pendingImages.set(1, pending);
+		prepareSubmitHandler(context);
+
+		await submit(context, "steer this [Image #1]");
+
+		expect(context.session.prompt).toHaveBeenCalledTimes(1);
+		const [text, options] = context.session.prompt.mock.calls[0] as [
+			string,
+			{ streamingBehavior?: string; images?: ImageContent[] },
+		];
+		expect(text).toBe("steer this [Image #1]");
+		expect(options?.streamingBehavior).toBe("steer");
+		expect(options?.images).toEqual([pending]);
+		expect(context.pendingImages.size).toBe(0);
+	});
+});
+
+describe("InteractiveMode image submission - Alt+Enter followUp", () => {
+	it("resolves images BEFORE setText on the streaming followUp branch", async () => {
+		const pending = image("Rk9MTG9X");
+		const context = createModeContext();
+		context.session.isStreaming = true;
+		context.pendingImages.set(1, pending);
+		context.editor.getText.mockReturnValue("describe [Image #1]");
+		prepareSubmitHandler(context);
+
+		await proto.handleFollowUp.call(context);
+
+		// The setText("") in this branch fires onImageMarkersChanged([]), which
+		// destroys pendingImages - so these assertions only pass if resolution
+		// happened before the clear.
+		expect(context.session.prompt).toHaveBeenCalledTimes(1);
+		const [text, options] = context.session.prompt.mock.calls[0] as [
+			string,
+			{ streamingBehavior?: string; images?: ImageContent[] },
+		];
+		expect(text).toBe("describe [Image #1]");
+		expect(options?.streamingBehavior).toBe("followUp");
+		expect(options?.images).toEqual([pending]);
+		expect(context.editor.setText).toHaveBeenCalledWith("");
+		expect(context.pendingImages.size).toBe(0);
+	});
+
+	it("routes non-streaming followUp through preResolvedSubmissionImages into the widened channel", async () => {
+		const pending = image("Rk9MTE5PTg==");
+		const context = createModeContext();
+		context.pendingImages.set(1, pending);
+		context.editor.getText.mockReturnValue("describe [Image #1]");
+		prepareSubmitHandler(context, { shareEditor: true });
+
+		const userInput = beginUserInput(context);
+		await proto.handleFollowUp.call(context);
+
+		// onSubmit(text) stayed a string-only public API; the images traveled
+		// through the pre-resolved field and out the normal channel.
+		await expect(userInput).resolves.toEqual({
+			text: "describe [Image #1]",
+			images: [pending],
+		});
+		expect(context.editor.setText).toHaveBeenCalledWith("");
+		expect(context.pendingImages.size).toBe(0);
+		expect(context.preResolvedSubmissionImages).toBeUndefined();
+		expect(context.session.prompt).not.toHaveBeenCalled();
+	});
+
+	it("leaves no stale images on the next ordinary submission after Alt+Enter on a slash command", async () => {
+		const stale = image("U1RBTEU=");
+		const context = createModeContext();
+		context.preResolvedSubmissionImages = [stale];
+		prepareSubmitHandler(context);
+
+		// The /model branch returns before the image-consuming branch; the
+		// pre-resolved array must not survive it.
+		await submit(context, "/model");
+		expect(context.preResolvedSubmissionImages).toBeUndefined();
+
+		const userInput = beginUserInput(context);
+		await submit(context, "next ordinary message");
+		await expect(userInput).resolves.toEqual({ text: "next ordinary message" });
+	});
+
+	it("leaves no stale images on the next ordinary submission after Alt+Enter on a bash command", async () => {
+		const stale = image("U1RBTEUy");
+		const context = createModeContext();
+		context.preResolvedSubmissionImages = [stale];
+		prepareSubmitHandler(context);
+
+		await submit(context, "!ls");
+		expect(context.preResolvedSubmissionImages).toBeUndefined();
+
+		const userInput = beginUserInput(context);
+		await submit(context, "next ordinary message");
+		await expect(userInput).resolves.toEqual({ text: "next ordinary message" });
+	});
+});
+
+describe("InteractiveMode image submission - compaction boundary", () => {
+	it("drops a pasted attachment with a visible status while the session is compacting", async () => {
+		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
+			bytes: samplePngBytes(),
+			mimeType: "image/png",
+		});
+		clipboardTextMock.readClipboardText.mockResolvedValueOnce(null);
+		const context = createModeContext();
+		context.session.isCompacting = true;
+
+		await proto.handleClipboardPaste.call(context);
+
+		// Pinned scope boundary: the compaction queue carries text only, so the
+		// attachment is dropped here - visibly, never silently.
+		expect(context.editor.insertImageMarker).not.toHaveBeenCalled();
+		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(context.pendingImages.size).toBe(0);
+		expect(context.showStatus).toHaveBeenCalledTimes(1);
+		expect(String(context.showStatus.mock.calls[0]?.[0])).toMatch(/compact/i);
+	});
+});

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -22,13 +22,15 @@ type SubmitContext = {
 	hideShortcutOverlay: () => void;
 	isExtensionCommand: (text: string) => boolean;
 	lastEditorText: string;
-	onInputCallback?: (text: string) => void;
-	pendingUserInputs: string[];
+	onInputCallback?: (input: { text: string; images?: unknown[] }) => void;
+	pendingUserInputs: { text: string; images?: unknown[] }[];
+	pendingImages: Map<number, unknown>;
+	takeSubmissionImages: (submittedText: string) => unknown[];
 };
 
 type InputContext = {
-	onInputCallback?: (text: string) => void;
-	pendingUserInputs: string[];
+	onInputCallback?: (input: { text: string; images?: unknown[] }) => void;
+	pendingUserInputs: { text: string; images?: unknown[] }[];
 };
 
 type StartupSubmitContext = {
@@ -48,7 +50,7 @@ type RunContext = {
 	checkForPackageUpdates: () => Promise<string[]>;
 	checkTmuxSetup: () => Promise<string | undefined>;
 	maybeWarnAboutAnthropicSubscriptionAuth: () => Promise<void>;
-	getUserInput: () => Promise<string>;
+	getUserInput: () => Promise<{ text: string; images?: unknown[] }>;
 	showNewVersionNotification: (version: string) => void;
 	showPackageUpdateNotification: (packages: string[]) => void;
 	showRiskyMainModelWarning: () => void;
@@ -59,14 +61,15 @@ type RunContext = {
 type InteractiveModePrivate = {
 	handleStartupSubmit(this: StartupSubmitContext, text: string): void;
 	setupEditorSubmitHandler(this: SubmitContext): void;
-	getUserInput(this: InputContext): Promise<string>;
+	getUserInput(this: InputContext): Promise<{ text: string; images?: unknown[] }>;
+	takeSubmissionImages(this: SubmitContext, submittedText: string): unknown[];
 	run(this: RunContext): Promise<void>;
 };
 
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrivate;
 
 function createSubmitContext(): SubmitContext {
-	return {
+	const context: SubmitContext = {
 		defaultEditor: {},
 		editor: {
 			addToHistory: vi.fn(),
@@ -83,7 +86,13 @@ function createSubmitContext(): SubmitContext {
 		isExtensionCommand: vi.fn(() => false),
 		lastEditorText: "",
 		pendingUserInputs: [],
+		pendingImages: new Map(),
+		takeSubmissionImages: vi.fn(() => []),
 	};
+	// Borrowed receiver: resolve markers with the REAL production helper (its
+	// only dependencies are the pendingImages map above).
+	context.takeSubmissionImages = interactiveModePrototype.takeSubmissionImages.bind(context);
+	return context;
 }
 
 describe("InteractiveMode startup input", () => {
@@ -105,17 +114,19 @@ describe("InteractiveMode startup input", () => {
 
 		await context.defaultEditor.onSubmit?.(" early prompt ");
 
-		expect(context.pendingUserInputs).toEqual(["early prompt"]);
+		expect(context.pendingUserInputs).toEqual([{ text: "early prompt" }]);
 		expect(context.flushPendingBashComponents).toHaveBeenCalledTimes(1);
 		expect(context.editor.addToHistory).toHaveBeenCalledWith("early prompt");
 	});
 
 	it("returns queued startup input before installing a new input callback", async () => {
 		const context: InputContext = {
-			pendingUserInputs: ["queued prompt"],
+			pendingUserInputs: [{ text: "queued prompt" }],
 		};
 
-		await expect(interactiveModePrototype.getUserInput.call(context)).resolves.toBe("queued prompt");
+		await expect(interactiveModePrototype.getUserInput.call(context)).resolves.toEqual({
+			text: "queued prompt",
+		});
 		expect(context.onInputCallback).toBeUndefined();
 		expect(context.pendingUserInputs).toEqual([]);
 	});
@@ -125,8 +136,8 @@ describe("InteractiveMode startup input", () => {
 		const stopMainLoop = new Error("stop interactive loop");
 		const prompt = vi.fn(async (_text: string, _options?: unknown) => {});
 		const getUserInput = vi
-			.fn<() => Promise<string>>()
-			.mockResolvedValueOnce("queued prompt")
+			.fn<() => Promise<{ text: string; images?: unknown[] }>>()
+			.mockResolvedValueOnce({ text: "queued prompt" })
 			.mockRejectedValueOnce(stopMainLoop);
 		const context: RunContext = {
 			init: vi.fn(async () => {}),

--- a/packages/coding-agent/test/mcp/connection.test.ts
+++ b/packages/coding-agent/test/mcp/connection.test.ts
@@ -50,14 +50,20 @@ describe("ServerConnection state machine", () => {
 	it("keeps stale slow-start connect results from overwriting a newer reload generation", async () => {
 		const root = await tmpRoot("stale");
 		const counterFile = join(root, "spawns.txt");
-		const connection = createConnection("stale", root, [
-			"--tools",
-			"1",
-			"--slow-start",
-			"250",
-			"--spawn-counter-file",
-			counterFile,
-		]);
+		// The fixture must still be starting when bumpGeneration() lands, since that
+		// is the state under test. A short slow-start made that a race against the
+		// scheduler: the fixture could finish and resolve `pending` before the test
+		// resumed, leaving `rejects.toThrow` awaiting a promise that never rejects.
+		// The window is instead made unreachable (spawn is observed via the counter
+		// below, and the connect timeout is raised past it), so only bumpGeneration()
+		// can settle the connect. The trailing assertNoFixtureProcessArg still proves
+		// the fixture process is reaped rather than leaked for that duration.
+		const connection = createConnection(
+			"stale",
+			root,
+			["--tools", "1", "--slow-start", "30000", "--spawn-counter-file", counterFile],
+			{ connectTimeoutMs: 60_000 },
+		);
 		connections.push(connection);
 		const events = collectEvents(connection);
 
@@ -202,10 +208,15 @@ describe("ServerConnection state machine", () => {
 	});
 });
 
-function createConnection(serverName: string, logDir: string, fixtureArgs: string[]): ServerConnection {
+function createConnection(
+	serverName: string,
+	logDir: string,
+	fixtureArgs: string[],
+	configOverrides: Partial<McpServerConfig> = {},
+): ServerConnection {
 	const fixture = stdioFixtureCommand();
 	return new ServerConnection({
-		config: serverConfig({ args: [...fixture.args, ...fixtureArgs], command: fixture.command }),
+		config: serverConfig({ args: [...fixture.args, ...fixtureArgs], command: fixture.command, ...configOverrides }),
 		logger: createMcpLogger(serverName, { logDir }),
 		serverName,
 	});

--- a/packages/coding-agent/test/mcp/oauth-race.test.ts
+++ b/packages/coding-agent/test/mcp/oauth-race.test.ts
@@ -10,7 +10,10 @@ import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { beginAuthorization, completeAuthorization } from "../../src/core/extensions/builtin/mcp/auth/oauth.ts";
 import { McpOAuthProvider } from "../../src/core/extensions/builtin/mcp/auth/oauth-provider.ts";
 import { McpTokenStore } from "../../src/core/extensions/builtin/mcp/auth/token-store.ts";
+import { assertWorkspaceBuildPrerequisite } from "../support/workspace-build-prerequisite.ts";
 import { type IdpFixture, spawnOAuthIdp } from "./fixtures/spawn-idp.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const execFileAsync = promisify(execFile);
 const workerPath = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "oauth-race-worker.ts");

--- a/packages/coding-agent/test/model-runtime-text-toolcall-recovery.test.ts
+++ b/packages/coding-agent/test/model-runtime-text-toolcall-recovery.test.ts
@@ -13,6 +13,9 @@ import { ModelRuntime } from "../src/core/model-runtime.ts";
 import { probeModelRuntimeImport } from "./helpers/esm-import-graph-probe.ts";
 import { registerModelRuntimeRecoveryRetryBoundaryCase } from "./model-runtime-recovery-retry-boundaries.ts";
 import { registerModelRuntimeRecoveryBoundaryCases } from "./model-runtime-text-toolcall-recovery-boundaries.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const leak = '<invoke name="Echo"><parameter name="value">hello</parameter></invoke>';
 const tools: Context["tools"] = [

--- a/packages/coding-agent/test/qa/app-server/task8-thread-search-support.ts
+++ b/packages/coding-agent/test/qa/app-server/task8-thread-search-support.ts
@@ -56,16 +56,66 @@ export class StdioClient {
 
 	async close(): Promise<void> {
 		this.child.stdin.end();
-		if (this.child.exitCode !== null || this.child.signalCode !== null) return;
-		await new Promise<void>((resolveClose) => {
-			const timer = setTimeout(() => {
-				this.killProcessGroup();
-			}, 5_000);
-			this.child.once("close", () => {
-				clearTimeout(timer);
-				resolveClose();
+		const pid = this.child.pid;
+		if (this.child.exitCode === null && this.child.signalCode === null) {
+			await new Promise<void>((resolveClose) => {
+				const timer = setTimeout(() => {
+					this.killProcessGroup();
+				}, 5_000);
+				this.child.once("close", () => {
+					clearTimeout(timer);
+					resolveClose();
+				});
 			});
-		});
+		}
+		// The leader's `close` event says nothing about the rest of its process
+		// group: SIGKILL delivery and reaping of background members (e.g. a shell's
+		// `sleep &`) complete asynchronously after the leader is gone. Callers rely
+		// on close() meaning "the group is gone" so a spawned app-server leaves no
+		// stragglers holding the vitest fork pool open, so wait for that exact
+		// condition rather than assuming it.
+		await this.waitForProcessGroupExit(pid);
+	}
+
+	/**
+	 * Resolves once no process remains in `pid`'s group, observed through
+	 * `kill(-pid, 0)` (the only signal available: background group members are
+	 * not children of this process, so they emit no event here). Escalates once
+	 * for the case where the leader exited on stdin EOF while background members
+	 * survived, then only observes - re-signalling a group mid-teardown races the
+	 * reaper and reports the transient EPERM of a zombie we may no longer signal.
+	 * Bounded, and yields to the event loop between probes rather than sleeping a
+	 * fixed span.
+	 */
+	private async waitForProcessGroupExit(pid: number | undefined): Promise<void> {
+		if (pid === undefined || process.platform === "win32") return;
+		if (this.processGroupIsGone(pid)) return;
+		try {
+			this.killProcessGroup();
+		} catch (error) {
+			// EPERM: a member survives that we may not signal; the probe below is the
+			// authority on whether it goes away.
+			if ((error as NodeJS.ErrnoException | undefined)?.code !== "EPERM") throw error;
+		}
+		const deadline = Date.now() + 5_000;
+		while (!this.processGroupIsGone(pid)) {
+			if (Date.now() >= deadline) return;
+			await new Promise<void>((resolveTick) => setImmediate(resolveTick));
+		}
+	}
+
+	/**
+	 * True when the group has no members left (`ESRCH`). `EPERM` means a member
+	 * still exists that this process may not signal (typically a zombie awaiting
+	 * reaping), so the group is NOT yet gone.
+	 */
+	private processGroupIsGone(pid: number): boolean {
+		try {
+			process.kill(-pid, 0);
+			return false;
+		} catch (error) {
+			return (error as NodeJS.ErrnoException | undefined)?.code === "ESRCH";
+		}
 	}
 
 	private killProcessGroup(): void {

--- a/packages/coding-agent/test/rpc-get-available-models.test.ts
+++ b/packages/coding-agent/test/rpc-get-available-models.test.ts
@@ -6,6 +6,9 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { RpcClient } from "../src/modes/rpc/rpc-client.ts";
 import { MOCK_API_KEY, MOCK_PROVIDER, startFakeModelServer } from "./helpers/rpc-fake-model.ts";
 import { hermeticProviderEnv } from "./helpers/rpc-hermetic.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const testDirectory = dirname(fileURLToPath(import.meta.url));
 

--- a/packages/coding-agent/test/rpc.test.ts
+++ b/packages/coding-agent/test/rpc.test.ts
@@ -9,6 +9,9 @@ import {
 	startHermeticRpcSession,
 	waitForSessionWrites,
 } from "./helpers/rpc-hermetic.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 describe("RPC mode", () => {
 	let session: RpcHermeticSession | undefined;

--- a/packages/coding-agent/test/session-file-invalid.test.ts
+++ b/packages/coding-agent/test/session-file-invalid.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { APP_NAME, ENV_AGENT_DIR } from "../src/config.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 const tempDirs: string[] = [];

--- a/packages/coding-agent/test/session-id-readonly.test.ts
+++ b/packages/coding-agent/test/session-id-readonly.test.ts
@@ -13,6 +13,9 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 const tempDirs: string[] = [];

--- a/packages/coding-agent/test/setup.ts
+++ b/packages/coding-agent/test/setup.ts
@@ -7,16 +7,8 @@
  * which reads this env var. If unset, it resolves to the developer's real
  * $HOME and leaves faux-provider JSONLs there permanently, where downstream
  * tools (e.g. tokscale) then mis-count them as real usage.
- *
- * Also verifies the suite's workspace-build prerequisite up front: the
- * child-process tests resolve the sibling packages through Node's `exports`
- * maps and need their built `dist/*` entrypoints, which no vitest alias can
- * supply. See `./support/workspace-build-prerequisite.ts`.
  */
 import { resolveQuarantineAgentDir } from "./support/quarantine.ts";
-import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
-
-assertWorkspaceBuildPrerequisite(import.meta.url);
 
 for (const key of ["PI_RULES_DISABLED", "PI_RULES_MAX_RULE_CHARS", "PI_RULES_MAX_RESULT_CHARS"] as const) {
 	delete process.env[key];

--- a/packages/coding-agent/test/setup.ts
+++ b/packages/coding-agent/test/setup.ts
@@ -7,8 +7,16 @@
  * which reads this env var. If unset, it resolves to the developer's real
  * $HOME and leaves faux-provider JSONLs there permanently, where downstream
  * tools (e.g. tokscale) then mis-count them as real usage.
+ *
+ * Also verifies the suite's workspace-build prerequisite up front: the
+ * child-process tests resolve the sibling packages through Node's `exports`
+ * maps and need their built `dist/*` entrypoints, which no vitest alias can
+ * supply. See `./support/workspace-build-prerequisite.ts`.
  */
 import { resolveQuarantineAgentDir } from "./support/quarantine.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 for (const key of ["PI_RULES_DISABLED", "PI_RULES_MAX_RULE_CHARS", "PI_RULES_MAX_RESULT_CHARS"] as const) {
 	delete process.env[key];

--- a/packages/coding-agent/test/startup-session-name.test.ts
+++ b/packages/coding-agent/test/startup-session-name.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 const CLI_TIMEOUT_MS = 60_000;

--- a/packages/coding-agent/test/stdout-cleanliness.test.ts
+++ b/packages/coding-agent/test/stdout-cleanliness.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../src/config.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
 import { allowNetwork } from "./test-network-env.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const cliPath = resolve(__dirname, "../src/cli.ts");
 

--- a/packages/coding-agent/test/suite/look-at-pasted-attachment.test.ts
+++ b/packages/coding-agent/test/suite/look-at-pasted-attachment.test.ts
@@ -1,0 +1,209 @@
+import type { Context, ImageContent as ImageBlock, ImageContent } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import type { FauxModelDefinition } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import lookAtExtension from "../../src/core/extensions/builtin/look-at/index.ts";
+import { InteractiveMode } from "../../src/modes/interactive/interactive-mode.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+/**
+ * End-to-end proof that a PASTED attachment is resolvable by `look_at` with
+ * ZERO production change to the look_at extension: the interactive submission
+ * path turns `[Image #N]` markers into the `images` array, `AgentSession`
+ * stores that array on the user message, and look_at's `lastUserImages` finds
+ * it back by position.
+ *
+ * The images array under test is built by the REAL production helper
+ * (`InteractiveMode#takeSubmissionImages`), never hand-assembled here, so the
+ * position invariant "the Nth marker is images[N-1]" is asserted against
+ * production ordering and fails if that ordering is broken.
+ */
+
+const TOOL_NAME = "look_at";
+
+/** 1x1 PNG. */
+const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl3T2QAAAAASUVORK5CYII=";
+/** 1x1 JPEG - deliberately a different MIME type and byte string than the PNG. */
+const JPEG_BASE64 =
+	"/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAX/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAH/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAEFAqf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAEDAQE/Aaf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oACAECAQE/Aaf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAY/Ap//xAAUEAEAAAAAAAAAAAAAAAAAAAAA/9oACAEBAAE/IX//2gAMAwEAAgADAAAAEP/EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQMBAT8QH//EABQRAQAAAAAAAAAAAAAAAAAAABD/2gAIAQIBAT8QH//EABQQAQAAAAAAAAAAAAAAAAAAABD/2gAIAQEAAT8QH//Z";
+
+const harnesses: Harness[] = [];
+
+function textOnly(id: string): FauxModelDefinition {
+	return { id, input: ["text"] };
+}
+
+function vision(id: string): FauxModelDefinition {
+	return { id, input: ["text", "image"] };
+}
+
+type SubmissionReceiver = { pendingImages: Map<number, ImageContent> };
+
+const takeSubmissionImages = (
+	InteractiveMode.prototype as unknown as {
+		takeSubmissionImages(this: SubmissionReceiver, submittedText: string): ImageContent[];
+	}
+).takeSubmissionImages;
+
+/**
+ * Resolve markers into the submitted `images` array through the production
+ * helper, exactly as the editor submit path does: `pendingImages` is keyed by
+ * marker id and the helper walks the submitted text in reading order.
+ */
+function submissionImages(submittedText: string, pending: ReadonlyArray<[number, ImageContent]>): ImageContent[] {
+	const receiver: SubmissionReceiver = { pendingImages: new Map(pending) };
+	return takeSubmissionImages.call(receiver, submittedText);
+}
+
+function pastedImage(data: string, mimeType: string): ImageContent {
+	return { type: "image", data, mimeType };
+}
+
+async function createLookAtHarness(models: FauxModelDefinition[] = [textOnly("main"), vision("vision")]) {
+	const harness = await createHarness({
+		models,
+		settings: { images: { autoResize: false } },
+		extensionFactories: [lookAtExtension],
+	});
+	harnesses.push(harness);
+	await harness.session.bindExtensions({});
+	return harness;
+}
+
+/**
+ * Send one user turn exactly the way the interactive submission channel does:
+ * the marker text stays literal in the message and the resolved attachments
+ * ride `PromptOptions.images`.
+ */
+async function sendPastedTurn(harness: Harness, text: string, images: ImageContent[]): Promise<void> {
+	harness.setResponses([fauxAssistantMessage("acknowledged")]);
+	await harness.session.prompt(text, { images });
+}
+
+function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter((block): block is { type: "text"; text: string } => block.type === "text")
+		.map((block) => block.text)
+		.join("\n");
+}
+
+/** The media the vision model actually received on the last look_at request. */
+function lastVisionRequest(harness: Harness): { images: ImageBlock[]; text: string } {
+	const call = harness.faux.getCallLog().at(-1);
+	if (!call) throw new Error("No faux provider call was recorded.");
+	expect(call.modelId).toBe("vision");
+	const context: Context = call.context;
+	const content = context.messages.at(-1)?.content;
+	if (!Array.isArray(content)) throw new Error("Vision request had no structured content.");
+	return {
+		images: content.filter((block): block is ImageBlock => block.type === "image"),
+		text: content
+			.filter((block): block is { type: "text"; text: string } => block.type === "text")
+			.map((block) => block.text)
+			.join("\n"),
+	};
+}
+
+async function lookAt(harness: Harness, filePath: string) {
+	harness.setResponses([fauxAssistantMessage("vision analysis")]);
+	return harness.session.executeTool<{ model: string; sources: string[]; mimeTypes: string[] }>(TOOL_NAME, {
+		file_path: filePath,
+		goal: "Describe the attachment",
+	});
+}
+
+describe("look_at resolution of pasted image attachments", () => {
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("resolves the pasted [Image #1] marker to the attachment's own bytes", async () => {
+		const harness = await createLookAtHarness();
+		const pasted = pastedImage(PNG_BASE64, "image/png");
+		const images = submissionImages("describe [Image #1]", [[1, pasted]]);
+		expect(images).toEqual([pasted]);
+		await sendPastedTurn(harness, "describe [Image #1]", images);
+
+		const result = await lookAt(harness, "[Image #1]");
+
+		expect(resultText(result)).toBe("vision analysis");
+		expect(result.details).toEqual({ model: "faux/vision", sources: ["Image #1"], mimeTypes: ["image/png"] });
+		const request = lastVisionRequest(harness);
+		expect(request.images).toEqual([{ type: "image", data: PNG_BASE64, mimeType: "image/png" }]);
+		expect(request.text).toContain("- Image #1");
+	});
+
+	it("resolves attachment://1 to the same pasted attachment", async () => {
+		const harness = await createLookAtHarness();
+		const pasted = pastedImage(PNG_BASE64, "image/png");
+		await sendPastedTurn(harness, "describe [Image #1]", submissionImages("describe [Image #1]", [[1, pasted]]));
+
+		const result = await lookAt(harness, "attachment://1");
+
+		expect(result.details).toEqual({ model: "faux/vision", sources: ["Image #1"], mimeTypes: ["image/png"] });
+		expect(lastVisionRequest(harness).images).toEqual([{ type: "image", data: PNG_BASE64, mimeType: "image/png" }]);
+	});
+
+	it("reports the available attachments when the referenced index does not exist", async () => {
+		const harness = await createLookAtHarness();
+		const pasted = pastedImage(PNG_BASE64, "image/png");
+		await sendPastedTurn(harness, "describe [Image #1]", submissionImages("describe [Image #1]", [[1, pasted]]));
+
+		harness.setResponses([fauxAssistantMessage("must not be reached")]);
+		const result = await harness.session.executeTool(TOOL_NAME, {
+			file_path: "[Image #2]",
+			goal: "Describe the attachment",
+		});
+
+		expect(resultText(result)).toContain("Could not resolve image attachment '[Image #2]'");
+		expect(resultText(result)).toContain("Available image attachments: Image #1 -> attachment://1.");
+		expect(harness.faux.getCallLog().filter((call) => call.modelId === "vision")).toHaveLength(0);
+	});
+
+	it("maps [Image #2] onto the SECOND submitted attachment (position invariant)", async () => {
+		const harness = await createLookAtHarness();
+		const first = pastedImage(PNG_BASE64, "image/png");
+		const second = pastedImage(JPEG_BASE64, "image/jpeg");
+		const text = "compare [Image #1] with [Image #2]";
+		const images = submissionImages(text, [
+			[1, first],
+			[2, second],
+		]);
+		await sendPastedTurn(harness, text, images);
+
+		const result = await lookAt(harness, "[Image #2]");
+
+		expect(result.details).toEqual({ model: "faux/vision", sources: ["Image #2"], mimeTypes: ["image/jpeg"] });
+		expect(lastVisionRequest(harness).images).toEqual([{ type: "image", data: JPEG_BASE64, mimeType: "image/jpeg" }]);
+	});
+
+	it("keeps the reference turn-local: markers point at the latest user message only", async () => {
+		const harness = await createLookAtHarness();
+		const older = pastedImage(PNG_BASE64, "image/png");
+		const newer = pastedImage(JPEG_BASE64, "image/jpeg");
+		await sendPastedTurn(harness, "describe [Image #1]", submissionImages("describe [Image #1]", [[1, older]]));
+		await sendPastedTurn(
+			harness,
+			"now describe [Image #1]",
+			submissionImages("now describe [Image #1]", [[1, newer]]),
+		);
+
+		const result = await lookAt(harness, "[Image #1]");
+
+		expect(result.details?.mimeTypes).toEqual(["image/jpeg"]);
+		expect(lastVisionRequest(harness).images).toEqual([{ type: "image", data: JPEG_BASE64, mimeType: "image/jpeg" }]);
+	});
+
+	it("activates look_at for a text-only model and deactivates it for a vision model", async () => {
+		const gated = await createLookAtHarness();
+		expect(gated.session.getActiveToolNames()).toContain(TOOL_NAME);
+
+		const visionModel = gated.getModel("vision");
+		if (!visionModel) throw new Error("Missing vision model in the faux registry.");
+		await gated.session.setModel(visionModel);
+		expect(gated.session.getActiveToolNames()).not.toContain(TOOL_NAME);
+
+		const withoutVision = await createLookAtHarness([textOnly("main")]);
+		expect(withoutVision.session.getActiveToolNames()).not.toContain(TOOL_NAME);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/0000-editor-paste-marker-transfer.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0000-editor-paste-marker-transfer.test.ts
@@ -1,3 +1,4 @@
+import type { ImageContent } from "@earendil-works/pi-ai/compat";
 import { Editor, type EditorComponent, type EditorPasteState, setKeybindings } from "@earendil-works/pi-tui";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { Container, TUI } from "../../../../tui/src/tui.ts";
@@ -24,6 +25,11 @@ type SetCustomEditorComponentThis = {
 	keybindings: KeybindingsManager;
 	ui: TUI;
 	getExpandedEditorText: () => string;
+	// setCustomEditorComponent also hands image markers over (and drops orphaned
+	// payloads when the destination cannot own them), so the borrowed receiver
+	// must model those members - see 0001-editor-image-marker-transfer.test.ts.
+	pendingImages: Map<number, ImageContent>;
+	subscribeImageMarkers: (editor: EditorComponent) => void;
 	disposeActiveSelector(): void;
 };
 
@@ -63,6 +69,11 @@ function makeFakeThis(): SetCustomEditorComponentThis {
 		keybindings: new KeybindingsManager(),
 		ui,
 		getExpandedEditorText: prototypeMethod<(this: SetCustomEditorComponentThis) => string>("getExpandedEditorText"),
+		pendingImages: new Map<number, ImageContent>(),
+		subscribeImageMarkers:
+			prototypeMethod<(this: SetCustomEditorComponentThis, editor: EditorComponent) => void>(
+				"subscribeImageMarkers",
+			),
 		disposeActiveSelector: () => {},
 	};
 	fakeThis.editorContainer.addChild(defaultEditor);

--- a/packages/coding-agent/test/suite/regressions/0000-editor-paste-submit.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0000-editor-paste-submit.test.ts
@@ -18,6 +18,12 @@ type CustomEditorThis = {
 	ui: TUI;
 	getExpandedEditorText: () => string;
 	disposeActiveSelector(): void;
+	// setCustomEditorComponent reconciles the pasted-image payloads against the
+	// destination editor's markers. The fixture supplies the real map and borrows
+	// the real methods so this exercises production plumbing, not a stub.
+	pendingImages: Map<number, unknown>;
+	subscribeImageMarkers: unknown;
+	reconcilePendingImages: unknown;
 };
 
 function prototypeMethod<T>(name: string): T {
@@ -47,6 +53,9 @@ function makeFakeThis(): CustomEditorThis {
 		ui,
 		getExpandedEditorText: prototypeMethod<(this: CustomEditorThis) => string>("getExpandedEditorText"),
 		disposeActiveSelector: () => {},
+		pendingImages: new Map<number, unknown>(),
+		subscribeImageMarkers: prototypeMethod<unknown>("subscribeImageMarkers"),
+		reconcilePendingImages: prototypeMethod<unknown>("reconcilePendingImages"),
 	};
 	fakeThis.editorContainer.addChild(defaultEditor);
 	return fakeThis;

--- a/packages/coding-agent/test/suite/regressions/0000-multi-session-theme-init.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0000-multi-session-theme-init.test.ts
@@ -4,6 +4,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
+import { assertWorkspaceBuildPrerequisite } from "../../support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 /**
  * Regression: `senpi --mode rpc --multi-session` entered `runMultiSessionHost()`

--- a/packages/coding-agent/test/suite/regressions/0001-editor-image-marker-transfer.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0001-editor-image-marker-transfer.test.ts
@@ -1,5 +1,5 @@
-import { Editor, type EditorComponent, setKeybindings } from "@earendil-works/pi-tui";
 import type { ImageContent } from "@earendil-works/pi-ai/compat";
+import { Editor, type EditorComponent, setKeybindings } from "@earendil-works/pi-tui";
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 import { Container, TUI } from "../../../../tui/src/tui.ts";
 import { VirtualTerminal } from "../../../../tui/test/virtual-terminal.ts";

--- a/packages/coding-agent/test/suite/regressions/0001-editor-image-marker-transfer.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0001-editor-image-marker-transfer.test.ts
@@ -1,0 +1,199 @@
+import { Editor, type EditorComponent, setKeybindings } from "@earendil-works/pi-tui";
+import type { ImageContent } from "@earendil-works/pi-ai/compat";
+import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { Container, TUI } from "../../../../tui/src/tui.ts";
+import { VirtualTerminal } from "../../../../tui/test/virtual-terminal.ts";
+import type { EditorFactory } from "../../../src/core/extensions/types.ts";
+import { KeybindingsManager } from "../../../src/core/keybindings.ts";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+import { getEditorTheme, initTheme } from "../../../src/modes/interactive/theme/theme.ts";
+
+/**
+ * Regression: switching editors (extension custom editor <-> default editor)
+ * must not desynchronize pasted image attachments from their `[Image #N]`
+ * markers. `pendingImages` lives on InteractiveMode so the bytes survive the
+ * swap, but the marker registry and the `onImageMarkersChanged` subscription
+ * live on the editor instance: without an explicit transfer step a marker
+ * either becomes dead literal text (payload orphaned, the model sees
+ * `[Image #1]` with nothing attached) or keeps firing nothing, so later deletes
+ * never reach the reconciler.
+ */
+
+type SetCustomEditorComponentThis = {
+	editorComponentFactory: EditorFactory | undefined;
+	editor: EditorComponent;
+	defaultEditor: Editor;
+	editorContainer: Container;
+	chrome: undefined;
+	autocompleteProvider: undefined;
+	keybindings: KeybindingsManager;
+	ui: TUI;
+	pendingImages: Map<number, ImageContent>;
+	reconcilePendingImages: (order: number[]) => void;
+	subscribeImageMarkers: (editor: EditorComponent) => void;
+	disposeActiveSelector(): void;
+};
+
+function prototypeMethod<T>(name: string): T {
+	const descriptor = Object.getOwnPropertyDescriptor(InteractiveMode.prototype, name);
+	const method = descriptor?.value as T | undefined;
+	if (!method) {
+		throw new Error(`${name} is missing`);
+	}
+	return method;
+}
+
+function callSetCustomEditorComponent(
+	fakeThis: SetCustomEditorComponentThis,
+	factory: EditorFactory | undefined,
+): void {
+	const setCustomEditorComponent =
+		prototypeMethod<(this: SetCustomEditorComponentThis, factory: EditorFactory | undefined) => void>(
+			"setCustomEditorComponent",
+		);
+	setCustomEditorComponent.call(fakeThis, factory);
+}
+
+function image(data: string): ImageContent {
+	return { type: "image", data, mimeType: "image/png" };
+}
+
+function makeFakeThis(): SetCustomEditorComponentThis {
+	const ui = new TUI(new VirtualTerminal(120, 34));
+	const defaultEditor = new Editor(ui, getEditorTheme());
+	const fakeThis: SetCustomEditorComponentThis = {
+		editorComponentFactory: undefined,
+		editor: defaultEditor,
+		defaultEditor,
+		editorContainer: new Container(),
+		chrome: undefined,
+		autocompleteProvider: undefined,
+		keybindings: new KeybindingsManager(),
+		ui,
+		pendingImages: new Map<number, ImageContent>(),
+		reconcilePendingImages:
+			prototypeMethod<(this: SetCustomEditorComponentThis, order: number[]) => void>("reconcilePendingImages"),
+		subscribeImageMarkers:
+			prototypeMethod<(this: SetCustomEditorComponentThis, editor: EditorComponent) => void>(
+				"subscribeImageMarkers",
+			),
+		disposeActiveSelector: () => {},
+	};
+	fakeThis.editorContainer.addChild(defaultEditor);
+	fakeThis.subscribeImageMarkers.call(fakeThis, defaultEditor);
+	return fakeThis;
+}
+
+/** Minimal custom editor with no marker support at all (plain EditorComponent contract). */
+class PlainEditorComponent implements EditorComponent {
+	focused = false;
+	private text = "";
+	onSubmit?: (text: string) => void;
+	onChange?: (text: string) => void;
+
+	getText(): string {
+		return this.text;
+	}
+
+	setText(text: string): void {
+		this.text = text;
+	}
+
+	handleInput(_data: string): void {}
+
+	render(): string[] {
+		return [this.text];
+	}
+
+	invalidate(): void {}
+}
+
+describe("InteractiveMode.setCustomEditorComponent image-marker transfer", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	beforeEach(() => {
+		setKeybindings(new KeybindingsManager());
+	});
+
+	test("transfers markers and the registry to a marker-aware custom editor", () => {
+		const fakeThis = makeFakeThis();
+		const id = fakeThis.defaultEditor.insertImageMarker();
+		fakeThis.pendingImages.set(id, image("AAA"));
+		expect(fakeThis.defaultEditor.getText()).toBe("[Image #1]");
+
+		const factory: EditorFactory = (tui, theme) => new Editor(tui as TUI, theme);
+		callSetCustomEditorComponent(fakeThis, factory);
+
+		const custom = fakeThis.editor as Editor;
+		expect(custom).not.toBe(fakeThis.defaultEditor);
+		expect(custom.getText()).toBe("[Image #1]");
+		// Registry moved with the text, so the marker is still atomic and owned.
+		expect(custom.getImageMarkerState().ids).toEqual([1]);
+		expect(fakeThis.pendingImages.get(1)?.data).toBe("AAA");
+
+		// A second paste inside the custom editor must not collide with id 1.
+		expect(custom.insertImageMarker()).toBe(2);
+	});
+
+	test("keeps the reconciler wired to the custom editor so deletes drop the payload", () => {
+		const fakeThis = makeFakeThis();
+		const id = fakeThis.defaultEditor.insertImageMarker();
+		fakeThis.pendingImages.set(id, image("AAA"));
+
+		callSetCustomEditorComponent(fakeThis, (tui, theme) => new Editor(tui as TUI, theme));
+		const custom = fakeThis.editor as Editor;
+
+		// Backspace over the marker inside the custom editor must reach the
+		// reconciler through the re-bound onImageMarkersChanged callback.
+		custom.handleInput("\x7f");
+		expect(custom.getText()).toBe("");
+		expect(fakeThis.pendingImages.size).toBe(0);
+	});
+
+	test("drops orphaned attachments when the custom editor cannot own markers", () => {
+		const fakeThis = makeFakeThis();
+		const id = fakeThis.defaultEditor.insertImageMarker();
+		fakeThis.pendingImages.set(id, image("AAA"));
+
+		const plain = new PlainEditorComponent();
+		callSetCustomEditorComponent(fakeThis, () => plain);
+
+		expect(fakeThis.editor).toBe(plain);
+		// The marker cannot stay atomic in a marker-unaware editor, so it must not
+		// survive as dead literal text with a live attachment behind it.
+		expect(plain.getText()).not.toContain("[Image #");
+		expect(fakeThis.pendingImages.size).toBe(0);
+	});
+
+	test("restores markers and the registry when switching back to the default editor", () => {
+		const fakeThis = makeFakeThis();
+		const id = fakeThis.defaultEditor.insertImageMarker();
+		fakeThis.pendingImages.set(id, image("AAA"));
+
+		callSetCustomEditorComponent(fakeThis, (tui, theme) => new Editor(tui as TUI, theme));
+		callSetCustomEditorComponent(fakeThis, undefined);
+
+		expect(fakeThis.editor).toBe(fakeThis.defaultEditor);
+		expect(fakeThis.defaultEditor.getText()).toBe("[Image #1]");
+		expect(fakeThis.defaultEditor.getImageMarkerState().ids).toEqual([1]);
+		expect(fakeThis.pendingImages.get(1)?.data).toBe("AAA");
+
+		// And the callback is wired to the default editor again.
+		fakeThis.defaultEditor.handleInput("\x7f");
+		expect(fakeThis.pendingImages.size).toBe(0);
+	});
+
+	test("unset is a draft no-op when the default editor is already active", () => {
+		const fakeThis = makeFakeThis();
+		const id = fakeThis.defaultEditor.insertImageMarker();
+		fakeThis.pendingImages.set(id, image("AAA"));
+
+		callSetCustomEditorComponent(fakeThis, undefined);
+
+		expect(fakeThis.editor).toBe(fakeThis.defaultEditor);
+		expect(fakeThis.defaultEditor.getText()).toBe("[Image #1]");
+		expect(fakeThis.pendingImages.get(1)?.data).toBe("AAA");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/2791-fswatch-error-crash.test.ts
+++ b/packages/coding-agent/test/suite/regressions/2791-fswatch-error-crash.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../../../src/config.ts";
+import { assertWorkspaceBuildPrerequisite } from "../../support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 const CHILD_TIMEOUT_MS = 60_000;
 

--- a/packages/coding-agent/test/suite/regressions/756-session-cross-project-resume.test.ts
+++ b/packages/coding-agent/test/suite/regressions/756-session-cross-project-resume.test.ts
@@ -5,6 +5,9 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { ENV_AGENT_DIR } from "../../../src/config.ts";
+import { assertWorkspaceBuildPrerequisite } from "../../support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
 
 /**
  * Issue #756 - a cross-project `--session` resume must never open the fork

--- a/packages/coding-agent/test/suite/regressions/fallback-abort-double-escape-session-history.test.ts
+++ b/packages/coding-agent/test/suite/regressions/fallback-abort-double-escape-session-history.test.ts
@@ -50,6 +50,11 @@ type EscapeFixture = {
 	abortAndFireQueuedMessages: ReturnType<typeof vi.fn>;
 	hideShortcutOverlay: ReturnType<typeof vi.fn>;
 	updateEditorBorderColor: ReturnType<typeof vi.fn>;
+	// setupKeyHandlers subscribes the editor's image-marker channel; the fixture
+	// borrows the real method plus the real payload map it reconciles.
+	pendingImages: Map<number, unknown>;
+	subscribeImageMarkers: unknown;
+	reconcilePendingImages: unknown;
 };
 
 const setupKeyHandlers = Reflect.get(InteractiveMode.prototype, "setupKeyHandlers") as (this: EscapeFixture) => void;
@@ -97,6 +102,9 @@ describe("fallback abort leaves double-Escape session history usable", () => {
 			abortAndFireQueuedMessages: vi.fn().mockResolvedValue(0),
 			hideShortcutOverlay: vi.fn(),
 			updateEditorBorderColor: vi.fn(),
+			pendingImages: new Map<number, unknown>(),
+			subscribeImageMarkers: Reflect.get(InteractiveMode.prototype, "subscribeImageMarkers"),
+			reconcilePendingImages: Reflect.get(InteractiveMode.prototype, "reconcilePendingImages"),
 		};
 		setupKeyHandlers.call(fixture);
 

--- a/packages/coding-agent/test/suite/regressions/inspector-endpoint-handoff.test.ts
+++ b/packages/coding-agent/test/suite/regressions/inspector-endpoint-handoff.test.ts
@@ -82,9 +82,12 @@ function attachDebugger(url: string, sockets: WebSocket[], states: InspectorStat
 	states.push(state);
 	const socket = new WebSocket(url);
 	sockets.push(socket);
+	// `Runtime.runIfWaitingForDebugger` must not be sent until `Debugger.enable`
+	// has been ACKNOWLEDGED. Pipelining both on `open` lets the child resume before
+	// the debugger domain is active, so `Debugger.paused` never arrives, `resumed`
+	// stays false, and the run hangs until the outer timeout.
 	socket.addEventListener("open", () => {
 		socket.send(JSON.stringify({ id: 1, method: "Debugger.enable" }));
-		socket.send(JSON.stringify({ id: 2, method: "Runtime.runIfWaitingForDebugger" }));
 	});
 	socket.addEventListener("message", (event) => {
 		const message = parseMessage(JSON.parse(String(event.data)));
@@ -92,7 +95,10 @@ function attachDebugger(url: string, sockets: WebSocket[], states: InspectorStat
 			state.error = `CDP error: ${JSON.stringify(message.error)}`;
 			return;
 		}
-		if (message.id === 1) state.enabled = true;
+		if (message.id === 1) {
+			state.enabled = true;
+			socket.send(JSON.stringify({ id: 2, method: "Runtime.runIfWaitingForDebugger" }));
+		}
 		if (message.method === "Debugger.paused") {
 			state.paused = true;
 			socket.send(JSON.stringify({ id: 3, method: "Debugger.resume" }));

--- a/packages/coding-agent/test/support/workspace-build-prerequisite.ts
+++ b/packages/coding-agent/test/support/workspace-build-prerequisite.ts
@@ -11,11 +11,16 @@
  * When they are absent, the child dies during import — before reaching any
  * behavior under test — and the parent test reports only its downstream
  * symptom (`expected 1 to be +0`, an empty stdout, a missing log line). That
- * failure mode is unattributable at the assertion site, which is why this
- * check runs once per worker in the global setup and names the prerequisite
- * plus the exact command that satisfies it. CI already runs `npm run build`
- * before the test shards (`.github/workflows/ci.yml`); this makes the same
- * requirement explicit and self-diagnosing for local runs.
+ * failure mode is unattributable at the assertion site, which is why the
+ * suites that spawn such children opt into this check and it names the
+ * prerequisite plus the exact command that satisfies it.
+ *
+ * The check is OPT-IN, called at the top of each dist-dependent test file, and
+ * deliberately NOT part of the global `test/setup.ts`: CI's `Terminal tools`
+ * job runs a small vitest subset (terminal extension, settings notify, shell
+ * config kind) with no `npm run build` step, and those suites spawn no
+ * workspace-resolving children — a global assertion would fail that job on
+ * every OS. Every other CI vitest job builds the workspace first.
  *
  * Resolution goes through `import.meta.resolve`, not `require.resolve`: these
  * manifests export only the `import` condition, so a CJS-conditioned probe

--- a/packages/coding-agent/test/support/workspace-build-prerequisite.ts
+++ b/packages/coding-agent/test/support/workspace-build-prerequisite.ts
@@ -1,0 +1,66 @@
+/**
+ * Declare and verify this suite's workspace-build prerequisite.
+ *
+ * Vitest resolves `@earendil-works/pi-ai` / `pi-tui` / `pi-agent-core` to the
+ * sibling packages' TypeScript sources via the aliases in `vitest.base.ts`, so
+ * in-process tests never need a build. The CHILD PROCESSES do: the spawned CLI
+ * (`src/cli.ts` under tsx) and the worker fixtures resolve those same
+ * specifiers through Node, which honours each manifest's `exports` map and
+ * therefore requires the built `dist/*` entrypoints.
+ *
+ * When they are absent, the child dies during import — before reaching any
+ * behavior under test — and the parent test reports only its downstream
+ * symptom (`expected 1 to be +0`, an empty stdout, a missing log line). That
+ * failure mode is unattributable at the assertion site, which is why this
+ * check runs once per worker in the global setup and names the prerequisite
+ * plus the exact command that satisfies it. CI already runs `npm run build`
+ * before the test shards (`.github/workflows/ci.yml`); this makes the same
+ * requirement explicit and self-diagnosing for local runs.
+ *
+ * Resolution goes through `import.meta.resolve`, not `require.resolve`: these
+ * manifests export only the `import` condition, so a CJS-conditioned probe
+ * would report a false negative for every specifier. Because
+ * `import.meta.resolve` is spec-compliant and does not touch the filesystem,
+ * the resolved target is then stat-ed — resolving a path proves the `exports`
+ * map, not the build.
+ */
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/** Specifiers that child processes resolve through Node's `exports` maps. */
+const CHILD_PROCESS_SPECIFIERS = [
+	"@earendil-works/pi-ai",
+	"@earendil-works/pi-ai/compat",
+	"@earendil-works/pi-tui",
+	"@earendil-works/pi-agent-core",
+	"@earendil-works/pi-agent-core/node",
+] as const;
+
+/**
+ * Returns the specifiers whose built entrypoint cannot be resolved from
+ * `parentUrl`. Resolution goes through Node's own ESM resolver rather than a
+ * hardcoded `dist/index.js` guess, so this asserts exactly what an ESM child
+ * process will do.
+ */
+export function findUnbuiltWorkspaceSpecifiers(parentUrl: string): string[] {
+	const missing: string[] = [];
+	for (const specifier of CHILD_PROCESS_SPECIFIERS) {
+		try {
+			if (!existsSync(fileURLToPath(import.meta.resolve(specifier, parentUrl)))) missing.push(specifier);
+		} catch {
+			missing.push(specifier);
+		}
+	}
+	return missing;
+}
+
+/** Throws an actionable error when the workspace build prerequisite is unmet. */
+export function assertWorkspaceBuildPrerequisite(parentUrl: string): void {
+	const missing = findUnbuiltWorkspaceSpecifiers(parentUrl);
+	if (missing.length === 0) return;
+	throw new Error(
+		`Unmet test prerequisite: the workspace packages are not built, so child-process tests ` +
+			`(spawned CLI, worker fixtures) cannot resolve ${missing.join(", ")}. ` +
+			`Run \`npm run build\` from the repository root, then re-run this suite.`,
+	);
+}

--- a/packages/coding-agent/test/workspace-build-prerequisite.test.ts
+++ b/packages/coding-agent/test/workspace-build-prerequisite.test.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	assertWorkspaceBuildPrerequisite,
+	findUnbuiltWorkspaceSpecifiers,
+} from "./support/workspace-build-prerequisite.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A module URL outside the monorepo, so no workspace specifier resolves from it. */
+function outsideWorkspaceModuleUrl(): string {
+	const dir = mkdtempSync(join(tmpdir(), "pi-workspace-prereq-"));
+	tempDirs.push(dir);
+	return pathToFileURL(join(dir, "probe.mjs")).href;
+}
+
+describe("workspace build prerequisite", () => {
+	it("reports every child-process specifier as unresolvable outside the workspace", () => {
+		const missing = findUnbuiltWorkspaceSpecifiers(outsideWorkspaceModuleUrl());
+
+		expect(missing).toEqual([
+			"@earendil-works/pi-ai",
+			"@earendil-works/pi-ai/compat",
+			"@earendil-works/pi-tui",
+			"@earendil-works/pi-agent-core",
+			"@earendil-works/pi-agent-core/node",
+		]);
+	});
+
+	it("names the unmet specifiers and the remedy when the prerequisite fails", () => {
+		const probe = outsideWorkspaceModuleUrl();
+
+		expect(() => assertWorkspaceBuildPrerequisite(probe)).toThrowError(/@earendil-works\/pi-agent-core\/node/);
+		expect(() => assertWorkspaceBuildPrerequisite(probe)).toThrowError(/npm run build/);
+	});
+
+	it("passes for this suite, whose child processes require the built entrypoints", () => {
+		// This is the live prerequisite: it holds exactly when the workspace is built,
+		// which is what the spawned-CLI and worker tests in this suite depend on.
+		expect(findUnbuiltWorkspaceSpecifiers(import.meta.url)).toEqual([]);
+		expect(() => assertWorkspaceBuildPrerequisite(import.meta.url)).not.toThrow();
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Atomic `[Image #N]` editor markers for pasted images: a new `ImageMarkerRegistry` (ids only, never bytes) with contiguous renumbering, whole-marker deletion, registry snapshots for editor-to-editor transfer, and a paired optional image-marker API on `EditorComponent`, exported from the package index.
+
 ### Changed
 
 ### Fixed

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -664,3 +664,26 @@ Component-level caching is added in coding-agent components because high-frequen
   - ANSI escape bytes remain below the content-byte budget,
   - every `DECSET 2026` begin has a matching end,
   - no `fullRender(true)` equivalent clear occurs after the init phase.
+
+## Atomic image markers for clipboard-pasted images (2026-08-18)
+
+### What changed
+
+- `packages/tui/src/image-markers.ts` (new): `ImageMarkerRegistry` tracks the ids of atomic `[Image #N]` markers living in editor text, storing ids only and never image bytes. It guarantees the visible numbers stay a contiguous `1..k` sequence (via `canonicalize()`), exposes `authorizedMarkers()` for markers occurring exactly once (the only ones safe to treat as atomic), and supports single-occurrence removal plus `EditorImageState` snapshots for transfer between editor instances.
+- `packages/tui/src/paste-markers.ts`: marker segmentation generalized so paste markers and image markers share the same atomic-segment machinery instead of the paste path owning a private tokenizer.
+- `packages/tui/src/components/editor.ts`: image markers are treated as atomic editor segments. `insertImageMarker()` inserts the next `[Image #N]` marker at the cursor and returns its id, backspace/delete removes a marker whole, `getImageMarkerState()`/`setImageMarkerState()` export and install registry snapshots, and `onImageMarkersChanged` reports the ids in text reading order whenever markers are added, removed, pruned, or renumbered.
+- `packages/tui/src/editor-component.ts`: the `EditorComponent` interface gains the optional image-marker API (`insertImageMarker`, `getImageMarkerState`, `setImageMarkerState`, `onImageMarkersChanged`) with paired-contract docs: an editor exposing insertion without the change callback is treated as image-unaware and receives the plain text path instead.
+- `packages/tui/src/index.ts`: exports the image-marker surface (`ImageMarkerRegistry`, `EditorImageState`, `ImageMarkerCanonicalization`, `ImageMarkerRemoval`, `IMAGE_MARKER_REGEX`, `IMAGE_MARKER_SINGLE`, `formatImageMarker`, `isImageMarker`, `imageMarkerId`).
+
+### Why
+
+- Pasting a clipboard image used to insert the raw temp file path into the composer, leaking local filesystem paths into prompts and transcripts. Atomic markers let the editor display `[Image #1]` while the payload lives outside the text, and contiguous renumbering keeps the Nth marker mapped to the Nth submitted image.
+
+### Why an extension could not handle it
+
+- Cursor discipline, segment atomics, and the editor's text model are TUI internals; an extension can compose components but cannot make backspace delete a marker whole or keep registry ids synchronized with visible numbers across editor instances.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/tui/src/components/editor.ts` (segment handling around cursor movement and deletion) and `packages/tui/src/paste-markers.ts` (the generalized segmentation shared with paste markers).
+- LOW: `packages/tui/src/image-markers.ts` (new fork-owned file, no upstream counterpart), `packages/tui/src/editor-component.ts` (additive optional interface members), and the `packages/tui/src/index.ts` export lists.

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,4 +1,5 @@
 import type { AutocompleteProvider, AutocompleteSuggestions } from "../autocomplete.ts";
+import { type EditorImageState, ImageMarkerRegistry, imageMarkerId, isImageMarker } from "../image-markers.ts";
 import { getKeybindings } from "../keybindings.ts";
 import { decodePrintableKey, matchesKey } from "../keys.ts";
 import { KillRing } from "../kill-ring.ts";
@@ -7,7 +8,7 @@ import {
 	isPasteMarker,
 	PasteMarkerRegistry,
 	pasteMarkerId,
-	segmentWithPasteMarkers,
+	segmentWithMarkers,
 } from "../paste-markers.ts";
 import { type Component, CURSOR_MARKER, type Focusable, type TUI } from "../tui.ts";
 import { UndoStack } from "../undo-stack.ts";
@@ -24,6 +25,24 @@ import { SelectList, type SelectListLayoutOptions, type SelectListTheme } from "
 
 const graphemeSegmenter = getGraphemeSegmenter();
 const wordSegmenter = getWordSegmenter();
+
+/** Which atomic marker family a segment belongs to, if any. */
+export type MarkerKind = "paste" | "image";
+
+/** Atomic-marker predicate covering every marker family the editor treats as one grapheme. */
+function isAtomicMarker(segment: string): boolean {
+	return isPasteMarker(segment) || isImageMarker(segment);
+}
+
+function markerKind(segment: string): MarkerKind | undefined {
+	if (isPasteMarker(segment)) return "paste";
+	if (isImageMarker(segment)) return "image";
+	return undefined;
+}
+
+function containsMarkerPrefix(text: string): boolean {
+	return text.includes("[paste #") || text.includes("[Image #");
+}
 
 /**
  * Represents a chunk of text for word-wrap layout.
@@ -105,7 +124,7 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 	if (!line || maxWidth <= 0) {
 		return [{ text: "", startIndex: 0, endIndex: 0 }];
 	}
-	if (preSegmented === undefined && !/\s/.test(line) && !line.includes("[paste #") && isPrintableAsciiText(line)) {
+	if (preSegmented === undefined && !/\s/.test(line) && !containsMarkerPrefix(line) && isPrintableAsciiText(line)) {
 		return wordWrapAsciiLine(line, maxWidth);
 	}
 
@@ -130,7 +149,7 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 		const grapheme = seg.segment;
 		const gWidth = visibleWidth(grapheme);
 		const charIndex = seg.index;
-		const isWs = !isPasteMarker(grapheme) && isWhitespaceChar(grapheme);
+		const isWs = !isAtomicMarker(grapheme) && isWhitespaceChar(grapheme);
 
 		// Overflow check before advancing.
 		if (currentWidth + gWidth > maxWidth) {
@@ -179,12 +198,12 @@ export function wordWrapLine(line: string, maxWidth: number, preSegmented?: Intl
 		// or at a boundary where either side is CJK (CJK allows breaking
 		// between any adjacent characters).
 		const next = segments[i + 1];
-		if (isWs && next && (isPasteMarker(next.segment) || !isWhitespaceChar(next.segment))) {
+		if (isWs && next && (isAtomicMarker(next.segment) || !isWhitespaceChar(next.segment))) {
 			wrapOppIndex = next.index;
 			wrapOppWidth = currentWidth;
 		} else if (!isWs && next && !isWhitespaceChar(next.segment)) {
-			const isCjk = !isPasteMarker(grapheme) && cjkBreakRegex.test(grapheme);
-			const nextIsCjk = !isPasteMarker(next.segment) && cjkBreakRegex.test(next.segment);
+			const isCjk = !isAtomicMarker(grapheme) && cjkBreakRegex.test(grapheme);
+			const nextIsCjk = !isAtomicMarker(next.segment) && cjkBreakRegex.test(next.segment);
 			if (isCjk || nextIsCjk) {
 				wrapOppIndex = next.index;
 				wrapOppWidth = currentWidth;
@@ -205,10 +224,11 @@ interface EditorState {
 	cursorCol: number;
 }
 
-/** Undo snapshot: editor text state plus the paste registry. */
+/** Undo snapshot: editor text state plus the paste and image registries. */
 interface EditorSnapshot {
 	state: EditorState;
 	pasteState: EditorPasteState;
+	imageState: EditorImageState;
 }
 
 interface LayoutLine {
@@ -306,6 +326,9 @@ export class Editor implements Component, Focusable {
 	// Paste tracking for large pastes
 	private pasteMarkers = new PasteMarkerRegistry();
 
+	// Atomic `[Image #N]` markers; ids only, the owner keeps the image payload
+	private imageMarkers = new ImageMarkerRegistry();
+
 	// Bracketed paste mode buffering
 	private pasteBuffer: string = "";
 	private isInPaste: boolean = false;
@@ -338,6 +361,12 @@ export class Editor implements Component, Focusable {
 
 	public onSubmit?: (text: string) => void;
 	public onChange?: (text: string) => void;
+	/**
+	 * Fired whenever image markers are added, removed, pruned or renumbered.
+	 * Carries the marker ids in text reading order so the owner can keep its
+	 * payload map aligned with the visible numbers.
+	 */
+	public onImageMarkersChanged?: (order: number[]) => void;
 	public disableSubmit: boolean = false;
 
 	constructor(tui: TUI, theme: EditorTheme, options: EditorOptions = {}) {
@@ -350,13 +379,22 @@ export class Editor implements Component, Focusable {
 		this.autocompleteMaxVisible = Number.isFinite(maxVisible) ? Math.max(3, Math.min(20, Math.floor(maxVisible))) : 5;
 	}
 
-	/** Segment text with paste-marker awareness, only merging exact canonical markers. */
+	/** Segment text with marker awareness, only merging exact canonical markers. */
 	private segment(text: string, mode: "word" | "grapheme"): Iterable<Intl.SegmentData> {
-		return segmentWithPasteMarkers(
+		return segmentWithMarkers(
 			text,
 			mode === "word" ? wordSegmenter : graphemeSegmenter,
-			this.pasteMarkers.authorizedMarkers(text),
+			this.authorizedMarkers(text),
 		);
+	}
+
+	/** Union of every marker family that must segment as one atomic grapheme. */
+	private authorizedMarkers(text: string): ReadonlySet<string> {
+		const imageMarkers = this.imageMarkers.authorizedMarkers(text);
+		if (imageMarkers.size === 0) return this.pasteMarkers.authorizedMarkers(text);
+		const merged = new Set(this.pasteMarkers.authorizedMarkers(text));
+		for (const marker of imageMarkers) merged.add(marker);
+		return merged;
 	}
 
 	private removePasteMarker(id: number): boolean {
@@ -364,6 +402,39 @@ export class Editor implements Component, Focusable {
 		if (!removal.removed) return false;
 		this.state.lines = removal.text.split("\n");
 		return true;
+	}
+
+	/** Removes an image marker whole, applying the registry's renumbered text. */
+	private removeImageMarker(id: number): boolean {
+		// The reported order is in PRE-renumber ids: the owner keys its payloads by the
+		// numbers it was handed, so it needs the surviving originals - `[2]` after
+		// deleting `[Image #1]` - to remap them onto the new 1..k display numbers.
+		const survivors = this.imageMarkers.ids(this.getText()).filter((entryId) => entryId !== id);
+		const removal = this.imageMarkers.remove(id, this.getText());
+		if (!removal.removed) return false;
+		this.state.lines = removal.text.split("\n");
+		this.onImageMarkersChanged?.(survivors);
+		return true;
+	}
+
+	/** Removes whichever marker family `segment` belongs to; returns false when it is not a marker. */
+	private removeMarkerSegment(segment: string): boolean {
+		switch (markerKind(segment)) {
+			case "paste": {
+				const id = pasteMarkerId(segment);
+				return id !== undefined && this.removePasteMarker(id);
+			}
+			case "image": {
+				const id = imageMarkerId(segment);
+				return id !== undefined && this.removeImageMarker(id);
+			}
+			default:
+				return false;
+		}
+	}
+
+	private notifyImageMarkersChanged(): void {
+		this.onImageMarkersChanged?.(this.imageMarkers.ids(this.getText()));
 	}
 
 	getPaddingX(): number {
@@ -491,7 +562,7 @@ export class Editor implements Component, Focusable {
 		}
 
 		const width = isPrintableAsciiText(line) ? line.length : visibleWidth(line);
-		if (line.includes("[paste #")) {
+		if (containsMarkerPrefix(line)) {
 			return {
 				width,
 				chunks:
@@ -1061,7 +1132,13 @@ export class Editor implements Component, Focusable {
 			this.pushUndoSnapshot();
 		}
 		this.pasteMarkers.prune(normalized, previousText);
+		const previousImageOrder = this.imageMarkers.ids(previousText);
+		this.imageMarkers.prune(normalized, previousText);
 		this.setTextInternal(normalized);
+		const imageOrder = this.imageMarkers.ids(normalized);
+		if (previousImageOrder.length !== imageOrder.length || previousImageOrder.some((id, i) => id !== imageOrder[i])) {
+			this.onImageMarkersChanged?.(imageOrder);
+		}
 	}
 
 	/**
@@ -1080,6 +1157,40 @@ export class Editor implements Component, Focusable {
 	 */
 	setPasteState(state: EditorPasteState): void {
 		this.pasteMarkers.install(state, this.getText());
+	}
+
+	/**
+	 * Snapshot the image-marker registry (ids only, never image payloads) so
+	 * markers can be transferred to another editor instance alongside getText().
+	 */
+	getImageMarkerState(): EditorImageState {
+		return this.imageMarkers.snapshot();
+	}
+
+	/**
+	 * Install an image-marker registry snapshot taken from another editor
+	 * instance. Call after setText() with the source editor's raw text: ids whose
+	 * markers are absent from the current text are dropped, and the id counter is
+	 * raised so future marker ids cannot collide.
+	 */
+	setImageMarkerState(state: EditorImageState): void {
+		this.imageMarkers.install(state, this.getText());
+	}
+
+	/**
+	 * Insert the next canonical `[Image #N]` marker at the cursor and return its id.
+	 * This is atomic for undo - a single undo restores the entire pre-insert state,
+	 * registry included - matching the insertTextAtCursor() contract.
+	 */
+	insertImageMarker(): number {
+		this.cancelAutocomplete();
+		this.pushUndoSnapshot();
+		this.lastAction = null;
+		this.exitHistoryBrowsing();
+		const marker = this.imageMarkers.add();
+		this.insertTextAtCursorInternal(marker);
+		this.notifyImageMarkersChanged();
+		return imageMarkerId(marker)!;
 	}
 
 	/**
@@ -1315,6 +1426,8 @@ export class Editor implements Component, Focusable {
 
 		this.state = { lines: [""], cursorLine: 0, cursorCol: 0 };
 		this.pasteMarkers.clear();
+		// Marker numbering is turn-local: ids restart at 1 for the next submission.
+		this.imageMarkers.clear();
 		this.exitHistoryBrowsing();
 		this.scrollOffset = 0;
 		this.undoStack.clear();
@@ -1339,9 +1452,7 @@ export class Editor implements Component, Focusable {
 			const graphemes = [...this.segment(beforeCursor, "grapheme")];
 			const lastGrapheme = graphemes[graphemes.length - 1];
 			const graphemeLength = lastGrapheme ? lastGrapheme.segment.length : 1;
-			const targetId = pasteMarkerId(lastGrapheme?.segment ?? "");
-			if (targetId !== undefined) {
-				this.removePasteMarker(targetId);
+			if (this.removeMarkerSegment(lastGrapheme?.segment ?? "")) {
 				this.setCursorCol(Math.max(0, this.state.cursorCol - graphemeLength));
 			} else {
 				line = this.state.lines[this.state.cursorLine] || "";
@@ -1715,10 +1826,7 @@ export class Editor implements Component, Focusable {
 			// Find the first grapheme at cursor
 			const graphemes = [...this.segment(afterCursor, "grapheme")];
 			const firstGrapheme = graphemes[0];
-			const markerId =
-				firstGrapheme && isPasteMarker(firstGrapheme.segment) ? pasteMarkerId(firstGrapheme.segment) : undefined;
-			if (markerId !== undefined) {
-				this.removePasteMarker(markerId);
+			if (this.removeMarkerSegment(firstGrapheme?.segment ?? "")) {
 				this.onChange?.(this.getText());
 				return;
 			}
@@ -1918,7 +2026,7 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(
 			findWordBackward(currentLine, this.state.cursorCol, {
 				segment: (text) => this.segment(text, "word"),
-				isAtomicSegment: isPasteMarker,
+				isAtomicSegment: isAtomicMarker,
 			}),
 		);
 	}
@@ -2048,6 +2156,7 @@ export class Editor implements Component, Focusable {
 		this.undoStack.push({
 			state: this.state,
 			pasteState: this.pasteMarkers.snapshot(),
+			imageState: this.imageMarkers.snapshot(),
 		});
 	}
 
@@ -2057,11 +2166,13 @@ export class Editor implements Component, Focusable {
 		if (!snapshot) return;
 		Object.assign(this.state, snapshot.state);
 		this.pasteMarkers.restore(snapshot.pasteState);
+		this.imageMarkers.restore(snapshot.imageState);
 		this.lastAction = null;
 		this.preferredVisualCol = null;
 		if (this.onChange) {
 			this.onChange(this.getText());
 		}
+		this.notifyImageMarkersChanged();
 	}
 
 	/**
@@ -2114,7 +2225,7 @@ export class Editor implements Component, Focusable {
 		this.setCursorCol(
 			findWordForward(currentLine, this.state.cursorCol, {
 				segment: (text) => this.segment(text, "word"),
-				isAtomicSegment: isPasteMarker,
+				isAtomicSegment: isAtomicMarker,
 			}),
 		);
 	}

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -1,4 +1,5 @@
 import type { AutocompleteProvider } from "./autocomplete.ts";
+import type { EditorImageState } from "./image-markers.ts";
 import type { EditorPasteState } from "./paste-markers.ts";
 import type { Component } from "./tui.ts";
 
@@ -71,6 +72,51 @@ export interface EditorComponent extends Component {
 	 * When not implemented, callers must transfer the expanded text instead.
 	 */
 	setPasteState?(state: EditorPasteState): void;
+
+	// =========================================================================
+	// Image markers (optional)
+	// =========================================================================
+
+	/**
+	 * Insert the next atomic `[Image #N]` marker at the cursor and return its id.
+	 * The editor stores ids only; the caller keeps the image payload keyed by id.
+	 *
+	 * Paired contract: implement insertImageMarker together with
+	 * onImageMarkersChanged. Callers must be told when markers are removed or
+	 * renumbered, otherwise their payload map desynchronizes from the visible
+	 * numbers; an editor exposing insertImageMarker without the callback is
+	 * treated as image-unaware and receives the plain text path instead.
+	 */
+	insertImageMarker?(): number;
+
+	/**
+	 * Snapshot the image-marker registry (ids only, never image bytes) so markers
+	 * can be transferred to another editor instance alongside getText().
+	 *
+	 * Paired contract: implement getImageMarkerState and setImageMarkerState
+	 * together. Callers only hand markers to an editor that can export them
+	 * again; an editor implementing setImageMarkerState without
+	 * getImageMarkerState is treated as marker-unaware and its markers are
+	 * dropped on transfer.
+	 */
+	getImageMarkerState?(): EditorImageState;
+
+	/**
+	 * Install an image-marker registry snapshot taken from another editor
+	 * instance. Called after setText() with that editor's raw (marker) text.
+	 * Paired contract: implement together with getImageMarkerState (see above).
+	 */
+	setImageMarkerState?(state: EditorImageState): void;
+
+	/**
+	 * Called with the image-marker ids in text reading order whenever markers are
+	 * added, removed, pruned or renumbered.
+	 *
+	 * Paired contract: required whenever insertImageMarker is implemented (see
+	 * above) - the reported order is the only signal that keeps the caller's
+	 * payload map aligned with the displayed `[Image #N]` numbers.
+	 */
+	onImageMarkersChanged?: (order: number[]) => void;
 
 	// =========================================================================
 	// Autocomplete support (optional)

--- a/packages/tui/src/image-markers.ts
+++ b/packages/tui/src/image-markers.ts
@@ -1,0 +1,153 @@
+export const IMAGE_MARKER_REGEX = /\[Image #([1-9]\d*)\]/g;
+export const IMAGE_MARKER_SINGLE = /^\[Image #([1-9]\d*)\]$/;
+
+/** Registry state for transfer between editor instances; ids only, never image bytes. */
+export interface EditorImageState {
+	ids: readonly number[];
+	imageCounter: number;
+}
+
+export interface ImageMarkerRemoval {
+	text: string;
+	removed: boolean;
+}
+
+export interface ImageMarkerCanonicalization {
+	text: string;
+	/** Original ids in reading order; index i became marker `[Image #${i + 1}]`. */
+	order: number[];
+}
+
+export function formatImageMarker(id: number): string {
+	return `[Image #${id}]`;
+}
+
+export function isImageMarker(segment: string): boolean {
+	return segment.length >= 10 && IMAGE_MARKER_SINGLE.test(segment);
+}
+
+export function imageMarkerId(segment: string): number | undefined {
+	const match = segment.length >= 10 ? IMAGE_MARKER_SINGLE.exec(segment) : null;
+	return match ? Number.parseInt(match[1]!, 10) : undefined;
+}
+
+function countOccurrences(text: string, marker: string): number {
+	let count = 0;
+	let offset = 0;
+	while (offset <= text.length - marker.length) {
+		const index = text.indexOf(marker, offset);
+		if (index === -1) break;
+		count++;
+		offset = index + marker.length;
+	}
+	return count;
+}
+
+function replaceSingleOccurrence(text: string, marker: string, replacement: string): string {
+	const index = text.indexOf(marker);
+	if (index === -1 || text.indexOf(marker, index + marker.length) !== -1) return text;
+	return text.slice(0, index) + replacement + text.slice(index + marker.length);
+}
+
+/**
+ * Tracks the ids of atomic `[Image #N]` markers living in editor text.
+ *
+ * The registry deliberately stores NO image payload: the owner (interactive mode) keeps the bytes
+ * keyed by id, and this class only guarantees that the visible numbers stay a contiguous
+ * `1..k` sequence so the Nth marker in reading order maps to the Nth submitted image.
+ */
+export class ImageMarkerRegistry {
+	private entries = new Set<number>();
+	private imageCounter = 0;
+
+	/** Registers the next id and returns its canonical marker. */
+	add(): string {
+		const id = ++this.imageCounter;
+		this.entries.add(id);
+		return formatImageMarker(id);
+	}
+
+	/** Registered markers occurring EXACTLY once in `text` - the only ones safe to treat as atomic. */
+	authorizedMarkers(text: string): ReadonlySet<string> {
+		const markers = new Set<string>();
+		for (const id of this.entries) {
+			const marker = formatImageMarker(id);
+			if (countOccurrences(text, marker) === 1) markers.add(marker);
+		}
+		return markers;
+	}
+
+	/** Rewrites authorized markers to `1..k` in reading order, returning the original id order. */
+	canonicalize(text: string): ImageMarkerCanonicalization {
+		const order = this.ids(text);
+		if (order.length === 0) return { text, order };
+
+		const renumbered = new Map<number, number>();
+		for (const [index, id] of order.entries()) renumbered.set(id, index + 1);
+		const updatedText = text.replace(IMAGE_MARKER_REGEX, (marker) => {
+			const id = imageMarkerId(marker);
+			const newId = id === undefined ? undefined : renumbered.get(id);
+			return newId === undefined ? marker : formatImageMarker(newId);
+		});
+		this.entries = new Set(order.map((_, index) => index + 1));
+		this.imageCounter = this.entries.size;
+		return { text: updatedText, order };
+	}
+
+	clear(): void {
+		this.entries.clear();
+		this.imageCounter = 0;
+	}
+
+	/** Registered, authorized ids in TEXT READING ORDER (not insertion order). */
+	ids(text: string): number[] {
+		const authorized = this.authorizedMarkers(text);
+		const ordered: number[] = [];
+		for (const match of text.matchAll(IMAGE_MARKER_REGEX)) {
+			if (!authorized.has(match[0])) continue;
+			ordered.push(Number.parseInt(match[1]!, 10));
+		}
+		return ordered;
+	}
+
+	install(state: EditorImageState, text: string): void {
+		this.restore(state);
+		this.prune(text);
+	}
+
+	prune(text: string, previousText?: string): void {
+		for (const id of [...this.entries]) {
+			const marker = formatImageMarker(id);
+			const wasAuthorized = previousText === undefined || countOccurrences(previousText, marker) === 1;
+			if (!wasAuthorized || countOccurrences(text, marker) !== 1) this.entries.delete(id);
+		}
+		this.imageCounter = Math.max(...this.entries, 0);
+	}
+
+	/** Deletes `id`'s marker from `text` and renumbers every higher id downward by one. */
+	remove(id: number, text: string): ImageMarkerRemoval {
+		if (!this.entries.delete(id)) return { text, removed: false };
+
+		let updatedText = replaceSingleOccurrence(text, formatImageMarker(id), "");
+		const higherIds = [...this.entries].filter((entryId) => entryId > id).sort((a, b) => a - b);
+		for (const oldId of higherIds) {
+			this.entries.delete(oldId);
+			const marker = formatImageMarker(oldId);
+			if (countOccurrences(updatedText, marker) !== 1) continue;
+			const newId = oldId - 1;
+			updatedText = replaceSingleOccurrence(updatedText, marker, formatImageMarker(newId));
+			this.entries.add(newId);
+		}
+		this.imageCounter = Math.max(...this.entries, 0);
+		return { text: updatedText, removed: true };
+	}
+
+	restore(state: EditorImageState): void {
+		this.entries = new Set(state.ids);
+		this.imageCounter = Math.max(state.imageCounter, ...this.entries, 0);
+	}
+
+	snapshot(): EditorImageState {
+		return { ids: [...this.entries].sort((a, b) => a - b), imageCounter: this.imageCounter };
+	}
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -71,6 +71,18 @@ export {
 export type { EditorComponent } from "./editor-component.ts";
 // Fuzzy matching
 export { type FuzzyMatch, fuzzyFilter, fuzzyMatch } from "./fuzzy.ts";
+// Atomic image markers (ids only - never image bytes)
+export {
+	type EditorImageState,
+	formatImageMarker,
+	IMAGE_MARKER_REGEX,
+	IMAGE_MARKER_SINGLE,
+	type ImageMarkerCanonicalization,
+	ImageMarkerRegistry,
+	type ImageMarkerRemoval,
+	imageMarkerId,
+	isImageMarker,
+} from "./image-markers.ts";
 // Keybindings
 export {
 	getKeybindings,

--- a/packages/tui/src/paste-markers.ts
+++ b/packages/tui/src/paste-markers.ts
@@ -102,18 +102,30 @@ export function pasteMarkerId(segment: string): number | undefined {
 	return match ? Number.parseInt(match[1]!, 10) : undefined;
 }
 
-export function segmentWithPasteMarkers(
+/** Segments `text` treating every literal in `validMarkers` as a single atomic segment. */
+export function segmentWithMarkers(
 	text: string,
 	baseSegmenter: Intl.Segmenter,
 	validMarkers: ReadonlySet<string>,
 ): Iterable<Intl.SegmentData> {
-	if (validMarkers.size === 0 || !text.includes("[paste #")) return baseSegmenter.segment(text);
+	if (validMarkers.size === 0) return baseSegmenter.segment(text);
 
-	const markers: Array<{ start: number; end: number }> = [];
-	for (const match of text.matchAll(PASTE_MARKER_REGEX)) {
-		if (validMarkers.has(match[0])) markers.push({ start: match.index, end: match.index + match[0].length });
+	const found: Array<{ start: number; end: number }> = [];
+	for (const marker of validMarkers) {
+		const start = text.indexOf(marker);
+		if (start === -1) continue;
+		found.push({ start, end: start + marker.length });
 	}
-	if (markers.length === 0) return baseSegmenter.segment(text);
+	if (found.length === 0) return baseSegmenter.segment(text);
+	found.sort((a, b) => a.start - b.start || b.end - a.end);
+
+	// Nested/overlapping literals would desync the single-pass walk below; keep the outermost.
+	const markers: Array<{ start: number; end: number }> = [];
+	for (const range of found) {
+		const previous = markers[markers.length - 1];
+		if (previous && range.start < previous.end) continue;
+		markers.push(range);
+	}
 
 	const result: Intl.SegmentData[] = [];
 	let markerIndex = 0;
@@ -127,6 +139,15 @@ export function segmentWithPasteMarkers(
 		}
 	}
 	return result;
+}
+
+/** Backward-compatible wrapper: paste markers are just one atomic marker set. */
+export function segmentWithPasteMarkers(
+	text: string,
+	baseSegmenter: Intl.Segmenter,
+	validMarkers: ReadonlySet<string>,
+): Iterable<Intl.SegmentData> {
+	return segmentWithMarkers(text, baseSegmenter, validMarkers);
 }
 
 export class PasteMarkerRegistry {

--- a/packages/tui/test/editor-image-marker.test.ts
+++ b/packages/tui/test/editor-image-marker.test.ts
@@ -1,0 +1,263 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { stripVTControlCharacters } from "node:util";
+import { Editor } from "../src/components/editor.ts";
+import { TUI } from "../src/tui.ts";
+import { defaultEditorTheme } from "./test-themes.ts";
+import { VirtualTerminal } from "./virtual-terminal.ts";
+
+const UNDO = "\x1b[45;5u"; // Ctrl+-
+const BACKSPACE = "\x7f";
+const FORWARD_DELETE = "\x1b[3~";
+const ALT_LEFT = "\x1bb";
+const ALT_RIGHT = "\x1bf";
+const ARROW_LEFT = "\x1b[D";
+const ARROW_RIGHT = "\x1b[C";
+const LINE_START = "\x01"; // Ctrl+A
+const LINE_END = "\x05"; // Ctrl+E
+
+function createEditor(width = 120): Editor {
+	return new Editor(new TUI(new VirtualTerminal(width, 30)), defaultEditorTheme);
+}
+
+function type(editor: Editor, text: string): void {
+	for (const char of text) editor.handleInput(char);
+}
+
+function trackOrders(editor: Editor): number[][] {
+	const orders: number[][] = [];
+	editor.onImageMarkersChanged = (order) => {
+		orders.push([...order]);
+	};
+	return orders;
+}
+
+describe("editor image markers", () => {
+	it("inserts canonical markers at the cursor and returns increasing ids", () => {
+		const editor = createEditor();
+		type(editor, "look at ");
+
+		assert.strictEqual(editor.insertImageMarker(), 1);
+		assert.strictEqual(editor.getText(), "look at [Image #1]");
+
+		type(editor, " and ");
+		assert.strictEqual(editor.insertImageMarker(), 2);
+		assert.strictEqual(editor.getText(), "look at [Image #1] and [Image #2]");
+	});
+
+	it("reports the marker order whenever markers change", () => {
+		const editor = createEditor();
+		const orders = trackOrders(editor);
+
+		editor.insertImageMarker();
+		editor.insertImageMarker();
+
+		assert.deepStrictEqual(orders, [[1], [1, 2]]);
+	});
+
+	it("deletes the whole marker with a single backspace", () => {
+		const editor = createEditor();
+		type(editor, "a ");
+		editor.insertImageMarker();
+		const orders = trackOrders(editor);
+
+		editor.handleInput(BACKSPACE);
+
+		assert.strictEqual(editor.getText(), "a ");
+		assert.deepStrictEqual(orders, [[]]);
+		assert.deepStrictEqual(editor.getImageMarkerState().ids, []);
+	});
+
+	it("deletes the whole marker with forward delete and drops the registry entry", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		type(editor, " tail");
+		editor.handleInput(LINE_START);
+		const orders = trackOrders(editor);
+
+		editor.handleInput(FORWARD_DELETE);
+
+		assert.strictEqual(editor.getText(), " tail");
+		assert.deepStrictEqual(orders, [[]]);
+		assert.deepStrictEqual(editor.getImageMarkerState().ids, []);
+	});
+
+	it("renumbers the survivor when an earlier marker is deleted", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		type(editor, " ");
+		editor.insertImageMarker();
+		editor.handleInput(LINE_START);
+		const orders = trackOrders(editor);
+
+		editor.handleInput(FORWARD_DELETE);
+
+		assert.strictEqual(editor.getText(), " [Image #1]");
+		assert.deepStrictEqual(orders, [[2]]);
+		assert.deepStrictEqual(editor.getImageMarkerState().ids, [1]);
+	});
+
+	it("renumbers the survivor when a later marker is backspaced", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		type(editor, " ");
+		editor.insertImageMarker();
+		const orders = trackOrders(editor);
+
+		editor.handleInput(BACKSPACE);
+
+		assert.strictEqual(editor.getText(), "[Image #1] ");
+		assert.deepStrictEqual(orders, [[1]]);
+	});
+
+	it("crosses the marker as one unit for alt+left / alt+right word navigation", () => {
+		const editor = createEditor();
+		type(editor, "aa ");
+		editor.insertImageMarker();
+		type(editor, " bb");
+
+		// "aa [Image #1] bb": marker occupies columns 3..13, "bb" starts at 14.
+		assert.strictEqual(editor.getText(), "aa [Image #1] bb");
+
+		editor.handleInput(LINE_END);
+		editor.handleInput(ALT_LEFT); // to start of "bb"
+		assert.strictEqual(editor.getCursor().col, 14);
+		editor.handleInput(ALT_LEFT); // across the whole marker in one jump
+		assert.strictEqual(editor.getCursor().col, 3);
+
+		editor.handleInput(ALT_RIGHT); // back across the whole marker in one jump
+		assert.strictEqual(editor.getCursor().col, 13);
+	});
+
+	it("traverses the marker as one unit with left/right arrows", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		assert.strictEqual(editor.getCursor().col, 10);
+
+		editor.handleInput(ARROW_LEFT);
+		assert.strictEqual(editor.getCursor().col, 0);
+
+		editor.handleInput(ARROW_RIGHT);
+		assert.strictEqual(editor.getCursor().col, 10);
+	});
+
+	it("wraps the marker as one atomic segment and never breaks at its inner space", () => {
+		const width = 14; // 13 usable columns + 1 reserved for the cursor
+		const editor = createEditor(width);
+		type(editor, "ab ");
+		editor.insertImageMarker();
+		type(editor, " cd");
+		assert.strictEqual(editor.getText(), "ab [Image #1] cd");
+
+		const contentLines = editor
+			.render(width)
+			.slice(1, -1)
+			.map((line) => stripVTControlCharacters(line).trimEnd());
+
+		// The whitespace hazard: /\s/.test("[Image #1]") is true, so a marker treated
+		// as whitespace would break as ["ab [Image", "#1] cd"].
+		assert.deepStrictEqual(contentLines, ["ab", "[Image #1] cd"]);
+	});
+
+	it("wraps the marker onto its own visual line when it does not fit", () => {
+		const width = 11; // 10 usable columns + 1 reserved for the cursor
+		const editor = createEditor(width);
+		type(editor, "ab ");
+		editor.insertImageMarker();
+		type(editor, " cd");
+
+		const contentLines = editor
+			.render(width)
+			.slice(1, -1)
+			.map((line) => stripVTControlCharacters(line).trimEnd());
+
+		assert.deepStrictEqual(contentLines, ["ab", "[Image #1]", " cd"]);
+	});
+
+	it("restores marker text and registry entry when undoing a delete", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		editor.handleInput(BACKSPACE);
+		assert.strictEqual(editor.getText(), "");
+		const orders = trackOrders(editor);
+
+		editor.handleInput(UNDO);
+
+		assert.strictEqual(editor.getText(), "[Image #1]");
+		assert.deepStrictEqual(editor.getImageMarkerState().ids, [1]);
+		assert.deepStrictEqual(orders, [[1]]);
+	});
+
+	it("drops the registry entry when undoing an insert", () => {
+		const editor = createEditor();
+		type(editor, "hi");
+		editor.insertImageMarker();
+		const orders = trackOrders(editor);
+
+		editor.handleInput(UNDO);
+
+		assert.strictEqual(editor.getText(), "hi");
+		assert.deepStrictEqual(editor.getImageMarkerState().ids, []);
+		assert.deepStrictEqual(orders, [[]]);
+	});
+
+	it("never expands an image marker in getExpandedText", () => {
+		const editor = createEditor();
+		type(editor, "see ");
+		editor.insertImageMarker();
+
+		assert.strictEqual(editor.getExpandedText(), "see [Image #1]");
+	});
+
+	it("prunes markers absent from setText and reports an empty order", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		const orders = trackOrders(editor);
+
+		editor.setText("plain text");
+
+		assert.deepStrictEqual(editor.getImageMarkerState().ids, []);
+		assert.deepStrictEqual(orders.at(-1), []);
+	});
+
+	it("keeps markers that survive setText", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+
+		editor.setText("kept [Image #1]");
+
+		assert.deepStrictEqual(editor.getImageMarkerState().ids, [1]);
+	});
+
+	it("round-trips image marker state across editor instances", () => {
+		const source = createEditor();
+		source.insertImageMarker();
+		type(source, " x ");
+		source.insertImageMarker();
+
+		const target = createEditor();
+		target.setText(source.getText());
+		target.setImageMarkerState(source.getImageMarkerState());
+
+		assert.deepStrictEqual(target.getImageMarkerState().ids, [1, 2]);
+		target.handleInput(BACKSPACE);
+		assert.strictEqual(target.getText(), "[Image #1] x ");
+		assert.deepStrictEqual(target.getImageMarkerState().ids, [1]);
+	});
+
+	it("keeps paste markers working alongside image markers", () => {
+		const editor = createEditor();
+		const body = Array.from({ length: 12 }, (_, index) => `line-${index + 1}`).join("\n");
+		editor.handleInput(`\x1b[200~${body}\x1b[201~`);
+		const pasteMarker = editor.getText();
+		editor.insertImageMarker();
+
+		assert.strictEqual(editor.getText(), `${pasteMarker}[Image #1]`);
+		assert.strictEqual(editor.getExpandedText(), `${body}[Image #1]`);
+
+		editor.handleInput(BACKSPACE);
+		assert.strictEqual(editor.getText(), pasteMarker);
+		editor.handleInput(BACKSPACE);
+		assert.strictEqual(editor.getText(), "");
+	});
+});

--- a/packages/tui/test/image-markers.test.ts
+++ b/packages/tui/test/image-markers.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import {
+	IMAGE_MARKER_REGEX,
+	IMAGE_MARKER_SINGLE,
+	ImageMarkerRegistry,
+	imageMarkerId,
+	isImageMarker,
+} from "../src/image-markers.ts";
+import { isPasteMarker, segmentWithMarkers, segmentWithPasteMarkers } from "../src/paste-markers.ts";
+
+const graphemeSegmenter = new Intl.Segmenter("en", { granularity: "grapheme" });
+
+function segments(text: string, markers: Iterable<string>): string[] {
+	return [...segmentWithMarkers(text, graphemeSegmenter, new Set(markers))].map((entry) => entry.segment);
+}
+
+describe("image marker primitives", () => {
+	it("recognizes canonical markers and rejects malformed ones", () => {
+		assert.strictEqual(isImageMarker("[Image #1]"), true);
+		assert.strictEqual(isImageMarker("[Image #12]"), true);
+		assert.strictEqual(imageMarkerId("[Image #12]"), 12);
+		assert.strictEqual(imageMarkerId("[Image #1]"), 1);
+
+		for (const invalid of ["[Image #0]", "[Image #]", "[image #1]", "[paste #1 3 chars]", "[Image #1", "Image #1"]) {
+			assert.strictEqual(isImageMarker(invalid), false, invalid);
+			assert.strictEqual(imageMarkerId(invalid), undefined, invalid);
+		}
+	});
+
+	it("keeps the single and global regexes in sync on the canonical form", () => {
+		assert.strictEqual(IMAGE_MARKER_SINGLE.test("[Image #3]"), true);
+		assert.strictEqual(IMAGE_MARKER_SINGLE.test("a [Image #3]"), false);
+		assert.deepStrictEqual(
+			[..."b [Image #2] a [Image #1]".matchAll(IMAGE_MARKER_REGEX)].map((match) => match[0]),
+			["[Image #2]", "[Image #1]"],
+		);
+	});
+
+	it("does not classify paste markers as image markers", () => {
+		assert.strictEqual(isImageMarker("[paste #1 3 chars]"), false);
+		assert.strictEqual(isPasteMarker("[Image #1]"), false);
+	});
+});
+
+describe("ImageMarkerRegistry", () => {
+	it("issues canonical markers in insertion order", () => {
+		const registry = new ImageMarkerRegistry();
+		assert.strictEqual(registry.add(), "[Image #1]");
+		assert.strictEqual(registry.add(), "[Image #2]");
+		assert.deepStrictEqual(registry.snapshot(), { ids: [1, 2], imageCounter: 2 });
+	});
+
+	it("excludes a marker appearing twice from the authorized set", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		const authorized = registry.authorizedMarkers("[Image #1] [Image #2] [Image #1]");
+		assert.strictEqual(authorized.has("[Image #2]"), true);
+		assert.strictEqual(authorized.has("[Image #1]"), false);
+	});
+
+	it("reports ids in text reading order, not insertion order", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		assert.deepStrictEqual(registry.ids("b [Image #2] a [Image #1]"), [2, 1]);
+		assert.deepStrictEqual(registry.ids("[Image #1] [Image #2]"), [1, 2]);
+	});
+
+	it("ignores unregistered and duplicated markers when reading ids", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		assert.deepStrictEqual(registry.ids("[Image #1] [Image #7]"), [1]);
+		assert.deepStrictEqual(registry.ids("[Image #1] [Image #1]"), []);
+	});
+
+	it("removes a marker and renumbers higher ids downward", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		const removal = registry.remove(1, "x [Image #1] y [Image #2]");
+
+		assert.strictEqual(removal.removed, true);
+		assert.strictEqual(removal.text, "x  y [Image #1]");
+		assert.deepStrictEqual(registry.ids(removal.text), [1]);
+		assert.deepStrictEqual(registry.snapshot(), { ids: [1], imageCounter: 1 });
+	});
+
+	it("reports no removal for an unknown id", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		const removal = registry.remove(9, "x [Image #1]");
+		assert.deepStrictEqual(removal, { text: "x [Image #1]", removed: false });
+	});
+
+	it("renumbers so the next add continues after the survivors", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		const removal = registry.remove(1, "[Image #1] [Image #2]");
+		assert.strictEqual(removal.text, " [Image #1]");
+		assert.strictEqual(registry.add(), "[Image #2]");
+	});
+
+	it("canonicalizes markers to reading order and reports the original order", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		const result = registry.canonicalize("b [Image #2] a [Image #1]");
+
+		assert.strictEqual(result.text, "b [Image #1] a [Image #2]");
+		assert.deepStrictEqual(result.order, [2, 1]);
+		assert.deepStrictEqual(registry.ids(result.text), [1, 2]);
+	});
+
+	it("leaves already-canonical text untouched", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		const result = registry.canonicalize("[Image #1] [Image #2]");
+		assert.strictEqual(result.text, "[Image #1] [Image #2]");
+		assert.deepStrictEqual(result.order, [1, 2]);
+	});
+
+	it("prunes markers absent from the text", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		registry.prune("only [Image #2] survives");
+
+		assert.deepStrictEqual(registry.snapshot(), { ids: [2], imageCounter: 2 });
+		assert.deepStrictEqual(registry.ids("only [Image #2] survives"), [2]);
+	});
+
+	it("prunes markers that were not authorized in the previous text", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.prune("[Image #1]", "[Image #1] [Image #1]");
+		assert.deepStrictEqual(registry.snapshot(), { ids: [], imageCounter: 0 });
+	});
+
+	it("round-trips through snapshot and restore", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		const state = registry.snapshot();
+
+		const restored = new ImageMarkerRegistry();
+		restored.restore(state);
+		assert.deepStrictEqual(restored.ids("[Image #1] [Image #2]"), [1, 2]);
+		assert.strictEqual(restored.add(), "[Image #3]");
+	});
+
+	it("prunes on install against the current text", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.add();
+		const state = registry.snapshot();
+
+		const installed = new ImageMarkerRegistry();
+		installed.install(state, "keeps [Image #2]");
+		assert.deepStrictEqual(installed.ids("keeps [Image #2]"), [2]);
+		assert.deepStrictEqual(installed.snapshot(), { ids: [2], imageCounter: 2 });
+	});
+
+	it("clears ids and the counter", () => {
+		const registry = new ImageMarkerRegistry();
+		registry.add();
+		registry.clear();
+		assert.deepStrictEqual(registry.snapshot(), { ids: [], imageCounter: 0 });
+		assert.strictEqual(registry.add(), "[Image #1]");
+	});
+});
+
+describe("segmentWithMarkers", () => {
+	it("returns an image marker as one segment", () => {
+		assert.deepStrictEqual(segments("a[Image #1]b", ["[Image #1]"]), ["a", "[Image #1]", "b"]);
+	});
+
+	it("keeps unauthorized markers split into graphemes", () => {
+		assert.deepStrictEqual(segments("[Image #1]", []), [..."[Image #1]"]);
+		assert.deepStrictEqual(segments("[Image #2]", ["[Image #1]"]), [..."[Image #2]"]);
+	});
+
+	it("segments a mixed marker set atomically", () => {
+		assert.deepStrictEqual(segments("[Image #1][paste #1 3 chars]!", ["[Image #1]", "[paste #1 3 chars]"]), [
+			"[Image #1]",
+			"[paste #1 3 chars]",
+			"!",
+		]);
+	});
+
+	it("keeps segmentWithPasteMarkers behavior for paste markers", () => {
+		const result = [
+			...segmentWithPasteMarkers("a[paste #1 3 chars]b", graphemeSegmenter, new Set(["[paste #1 3 chars]"])),
+		].map((entry) => entry.segment);
+		assert.deepStrictEqual(result, ["a", "[paste #1 3 chars]", "b"]);
+	});
+
+	it("ignores paste markers that are not authorized", () => {
+		const result = [...segmentWithPasteMarkers("a[paste #1 3 chars]b", graphemeSegmenter, new Set())].map(
+			(entry) => entry.segment,
+		);
+		assert.deepStrictEqual(result, [..."a[paste #1 3 chars]b"]);
+	});
+});


### PR DESCRIPTION
## Root cause

Pasting an image into the senpi TUI never attached an image. `handleClipboardPaste()` in `packages/coding-agent/src/modes/interactive/interactive-mode.ts` read the clipboard bitmap, wrote it to a temporary PNG under the OS temp directory, and then called `insertTextAtCursor(filePath)` — so what landed in the composer was an unusable temp-file path as literal text. A code comment in that region claimed images were "attached by path", but no code implementing that claim existed anywhere.

The second half of the defect is on the submit side: no submission path ever passed `images`. The `PromptOptions.images` option already existed on `prompt` / `steer` / `followUp` and was already used by the `--image` CLI startup path, but the interactive submission channel was string-only (`onInputCallback?: (text: string) => void`, `pendingUserInputs: string[]`, `getUserInput(): Promise<string>`). Even if the paste handler had produced real `ImageContent`, there was no channel to carry it to the model. An attachment could not reach a model from the TUI by any route.

## Design

An atomic `[Image #N]` marker in the TUI editor, a pending map on `InteractiveMode` that lives from paste to submit, and resolution at submit into `ImageContent[]` handed to the already-existing `PromptOptions.images`.

- **Marker primitive (`packages/tui`).** The editor already had atomic-segment machinery for large text pastes (`[paste #N ...]` chips). Rather than duplicating it, the segmentation helper was generalized into `segmentWithMarkers(text, baseSegmenter, validMarkers)` — its fast path now bails on an empty marker set instead of on a hardcoded `"[paste #"` substring — and `segmentWithPasteMarkers` remains as a thin wrapper, so paste-marker behavior and format are untouched. A new `packages/tui/src/image-markers.ts` adds `ImageMarkerRegistry` with add / authorize / reading-order ids / prune / remove-with-renumber / canonicalize / snapshot-restore. The registry stores **ids only, never image bytes**: `packages/tui` gains no image, MIME, base64, or `pi-ai` dependency (its dependencies remain exactly `get-east-asian-width` and `marked`).
- **Editor integration.** `insertImageMarker()` inserts the marker inside one undo snapshot; `segment()` receives the union of authorized paste and image markers, so the marker is one grapheme for wrapping, cursor snapping, and highlighting. The marker predicate was hard-wired to `isPasteMarker` at six sites; those now go through a kind-agnostic `isAtomicMarker` / `markerKind`. That generalization is load-bearing, not cosmetic: `[Image #1]` contains a space, so the whitespace classifier would otherwise treat the whole marker as whitespace, and forward-`Delete` would fall through to raw slicing — orphaning an attachment while leaving survivors un-renumbered, i.e. sending `[Image #2]` while `images[1]` is the deleted image. Undo/redo snapshots carry image-marker state alongside paste state.
- **Paste handler.** On a successful clipboard read the bytes are normalized through `processImage` (honoring the `autoResize` setting) into `ImageContent`, `insertImageMarker()` returns the id, and the content is stored in a private `pendingImages` map keyed by that id. The temp-file write is gone; bytes travel in memory. `onImageMarkersChanged` reconciles the map against the editor's reported id order on every add, delete, prune, renumber, and undo. Existing failure semantics are preserved exactly: a thrown read still produces the `Clipboard paste failed: <reason>` status plus the `clipboard_error` session-log entry, and an empty clipboard stays silent.
- **Submission channel.** The interactive channel was widened to `{ text, images? }` end to end (field, pending queue, `getUserInput()`, main loop). At submit, `takeSubmissionImages(submittedText)` scans the *submitted text argument* — never live editor state, because `Editor.submitValue()` clears the editor and its registries before `onSubmit` fires — maps only ids present in `pendingImages`, honors only the first occurrence of a duplicated marker (kill/yank can duplicate one), drops ids absent from the text, canonicalizes the visible numbers to `1..k` in reading order, and clears the map. When the resolved array is empty, no `images` key is passed at all.
- **Alt+Enter follow-up.** `handleFollowUp` bypasses the normal submit handler and calls `setText("")` before handing off, which prunes markers and fires `onImageMarkersChanged([])` — destroying the attachment before the send. Images are now resolved *first* on that path. Its non-streaming branch cannot widen `onSubmit` (that is public pi-tui API consumed by every extension editor), so it stashes a private `preResolvedSubmissionImages`, and the submit handler captures-and-clears that field **unconditionally at entry**. The unconditional clear matters: the handler short-circuits before the ordinary branch on slash commands, extension commands, and bash input, and a field cleared only after use would leak a stale image into a *later* ordinary submission whose text contains no `[Image #N]` — silently falsifying the position invariant and poisoning a subsequent `look_at`.
- **`look_at` is unchanged.** No file under `packages/coding-agent/src/core/extensions/builtin/look-at/` was touched. It already resolves `[Image #N]` and `attachment://N` against the images of the last user message, and a new integration test proves it against a message built exactly the way the new submit path builds one.

## Load-bearing invariant

**The integer N in `[Image #N]` equals the 1-based index of that image in the submitted `images` array, in text reading order.** That is exactly how `look_at` indexes an attachment, and it is why the user message's leading text block does not shift the index (`lastUserImages` filters to image blocks only). Renumber-on-delete, canonicalize-before-build, reading-order (not insertion-order) resolution, first-occurrence-only dedup, and the unconditional pre-resolved clear all exist to keep that one sentence true.

## Evidence per success criterion

Artifacts live under `local-ignore/qa-evidence/20260818-senpi-tui-image-attach/`, which is gitignored — referenced by name only, never attached.

**C1 — Ctrl+V inserts an atomic marker; no temp path reaches the composer.** The real CLI was driven in a pty (senpi-qa Channel 2) with a known distinctive PNG on the clipboard: the composer capture shows `[Image #1]` and contains zero `/tmp`, `/var/folders`, and `pi-clipboard-` substrings (`task-7-channel2-after-composer.txt`). The same scenario against the tree at the merge base shows the raw `pi-clipboard-*.png` temp path with zero markers (`task-7-channel2-before-composer.txt`) — the RED artifact that motivates this PR. Unit coverage in `interactive-mode-clipboard-paste.test.ts`, whose three pre-existing assertions were kept intact and green.

**C2 — The submitted message carries real image parts in reading order.** A senpi-qa Channel 3 mock loop (zero tokens, fake model server) completed one full agent turn; the recorded request carries a text part *and* an image part in the same user message, with the image payload byte-equal to the bytes read from the clipboard (`task-7-channel3-request.json`, compared programmatically, never by eye). Unit coverage in `interactive-mode-image-submission.test.ts` pins the normal `getUserInput` path, the steer path, both Alt+Enter branches, the slash/bash short-circuit leak, reading order across two markers, a user-typed marker consuming no slot, duplicate-marker dedup, and an empty `pendingImages` after submit.

**C3 — `look_at` resolves the pasted attachment with zero production change.** End to end on the wire: a scripted fake-model turn emits `look_at(file_path="[Image #1]")`, and the recorded look_at-to-vision-model request carries the `- Image #1` source label plus an image part whose base64 is byte-equal to the pasted bytes with the pasted MIME type (`task-7-channel3-look-at.json`). The tool-result text is deliberately *not* an assertion surface — in a mock loop it is author-controlled canned output, so asserting on it would prove nothing. At the unit level, `test/suite/look-at-pasted-attachment.test.ts` proves `[Image #1]` and `attachment://1` resolve identically, that `[Image #2]` with a single attachment throws the available-attachment error, that with two attachments `[Image #2]` resolves to the second array element, and that the activation gate flips with the current model's modality. Since a test-only change has no natural RED, the position assertion was proven falsifiable by a **mutation applied to production code** — reversing the array built by `takeSubmissionImages` — captured failing (`task-5-mutation-red.txt`) and reverted before commit (`task-5-green.txt`). Reversing a fixture array was rejected as proof.

**C4 — Whole-marker deletion drops the attachment and renumbers survivors.** One backspace with the cursor after `[Image #1]` removes the entire marker in the pty capture (`task-7-channel2-after-backspace-composer.txt`). `packages/tui/test/editor-image-marker.test.ts` covers single-backspace whole-marker delete, forward-`Delete` whole-marker delete *including* dropping the registry entry, word navigation and arrow traversal crossing the marker as one unit, atomic wrapping at narrow width, undo restoring both the marker text and its registry entry, renumbering the survivor after deleting the first of two, `getExpandedText()` returning the literal and never base64, prune on `setText`, and marker-state round-trip across two editor instances. `test/suite/regressions/0001-editor-image-marker-transfer.test.ts` pins the custom-editor swap.

**C5 — No regression.** The full `packages/coding-agent` suite is green twice back to back with byte-identical summaries — `Test Files 998 passed | 4 skipped (1002)`, `Tests 8207 passed | 36 skipped (8243)` (`task-11-run-a.txt`, `task-11-run-b.txt`) — plus 10/10 consecutive green runs on a previously-flaky file (`task-11-flaky-repeat.txt`). The `packages/tui` node:test suite is green (`task-11-tui-suite.txt`) and root `tsc --noEmit` reports 0 errors. The changelog gate passes from the worktree (`task-6-gate-pass.txt`) after failing as expected without the tracker entries (`task-6-gate-fail.txt`).

Per an explicit in-scope directive, the pre-existing coding-agent test failures observed on pristine `origin/main` were root-caused and fixed properly rather than skipped: each failure was classified individually (`task-10-classification.md`) and repaired at its cause. Notably `StdioClient.close` now resolves only after the process group is gone, and three tests that had been passing on timing luck — awaiting `Debugger.enable` before resuming the inspected child, removing a scheduler race from the stale-generation connect, and declaring the workspace-build prerequisite explicitly — were made deterministic by subscribing to the observable signal instead of sleeping. Nothing was skipped, deleted, weakened, or `xfail`ed to reach green.

**C6 — Delivery.** This PR against `main`, carrying the atomic commits listed in its history.

## Scope honesty

Stated plainly so review is not misled:

- **Non-vision models are not hard-blocked.** Submission proceeds, the `[Image #N]` text stays in the message, and `look_at` covers the gap.
- **Automatic degradation is NOT claimed.** No prompt surface advertises the `[Image #N]` convention to the model. The claim is only that `look_at` *can* resolve the reference; a non-vision model additionally sees `(image omitted: model does not support images)` next to the literal marker. Documenting the convention to the model is deliberately out of scope here.
- **No drag-and-drop, no remote image URLs, no PDF or video attachments.**
- **No provider serialization change.** Nothing under `packages/ai/src/providers` or `packages/ai/src/api/transform-messages.ts` was touched.
- **Attachments are not carried through the compaction queue.** The queue record is `{text, mode, enqueueOrder}` and delivery passes `undefined` for images, so pasting during compaction drops the attachment **with a visible status, never silently** — pinned by a test.
- **References are turn-local.** `lastUserImages` reads only the last user message and marker numbering restarts each submission, so `[Image #1]` in a later turn means that turn's own first image. A test pins this rather than leaving it implicit.

## Explicit non-goals (guardrails held)

- No change to `agent-session.ts` message construction or the `PromptOptions` shape.
- No change to `packages/ai/src/api/transform-messages.ts` or any provider serialization under `packages/ai/src/providers`.
- No change to any file under `packages/coding-agent/src/core/extensions/builtin/look-at/`.
- Image markers are never expanded into a base64 body in the submitted text; `getExpandedText` leaves them literal.
- oh-my-pi's OSC 5522 enhanced-paste protocol is not ported.
- oh-my-pi's hidden vision-description companion message is not added.
- Submission is not hard-blocked on non-vision models.
- No keybinding is added or rebound; `app.clipboard.pasteImage` stays as-is.
- No drag-and-drop, remote image URL, or PDF/video attachment handling.
- No cross-turn attachment references.
- No attachments through the compaction queue in this PR.
- No regression for the `blockImages` user: the new behavior is explicitly decided and pinned by a test.
- No dead markers left in recalled history.
- `packages/tui` gains no image or `pi-ai` dependency.
- No real provider or credential is used by any test; faux provider and the shared harness only.
- The three existing assertions in `interactive-mode-clipboard-paste.test.ts` are not weakened.
- The pre-existing dirty file `packages/ai/src/api/cursor-agent.ts` is not staged or committed, and nothing under `local-ignore/` is committed.

## Pre-existing product gap found during QA (not introduced here, deliberately not fixed)

While driving the real CLI for C1, the TUI dropped `ctrl+v` for roughly 2.4 seconds after launch. The cause is unrelated to this change and is **identical at the merge base**: `setupKeyHandlers()` is gated behind the `ensureTool("fd")` / `ensureTool("rg")` await at `packages/coding-agent/src/modes/interactive/interactive-mode.ts:1324-1332`. During that window the TUI looks fully booted — header rendered, composer visible, cursor blinking — but every keypress routed through those handlers is silently discarded with no feedback. This affects all gated keybindings, not just image paste.

It is out of scope for this PR: fixing it means changing startup input sequencing, which has nothing to do with image attachment and would make this diff harder to review. Recommend a separate follow-up issue to either enable input handlers before the managed-tool await or show an explicit "starting up" indicator so discarded keystrokes are not invisible.

Plan: .omo/plans/senpi-tui-image-attach.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach pasted clipboard images in the TUI as atomic “[Image #N]” markers and submit them as image parts. Previously paste inserted a temp PNG path and no image reached the model; now the editor shows “[Image #N]”, images stay in memory and resolve at submit, and non‑vision models still see the literal marker with “(image omitted…)”.

- Key changes
  - `packages/tui`: add ids‑only `ImageMarkerRegistry`; treat `[Image #N]` as atomic for wrapping/navigation/delete/undo; generalize segmentation to `segmentWithMarkers`; expose optional editor APIs (`insertImageMarker`, `onImageMarkersChanged`) and `EditorImageState` for editor‑to‑editor transfers.
  - `packages/coding-agent`: paste normalizes via `processImage`, inserts a marker, and stores bytes in memory; submit scans the submitted text to build `images` in reading order, deduping first occurrences and canonicalizing numbering; widen the interactive input channel to `{ text, images? }`; pre‑resolve and clear images on Alt+Enter; drop attachments routed through the compaction queue with a visible status; no temp files.
  - Invariants and behavior: the integer N in “[Image #N]” equals the 1‑based index in the submitted `images` array; `look_at` is unchanged and resolves against the last user message; non‑vision models see the literal marker plus an omission note.
  - Tests: add coverage for marker/index invariants, deletion renumbering, editor transfer, and `look_at` resolution; scope the workspace‑build prerequisite check to suites that spawn child processes (local runs of those suites require a build).

- Rollout and migration
  - No changes for existing editors or extensions: `onSubmit(text)` remains.
  - Custom editors that want pasted images should implement optional `insertImageMarker` and `onImageMarkersChanged`, and carry `EditorImageState` across editor swaps; if the destination cannot own markers, drop the image payloads.
  - Code integrating with `InteractiveMode`’s internal input queue must accept `{ text, images? }` instead of a string.

<sup>Written for commit a646928e4e5c8028bf235396c9ce6b813aa8436b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

