### PR TITLE
fix(changelog): drop stray conflict marker from the Unreleased section

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,15 +2,13 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
 ### Added
 
 - Cursor context windows now track the models.dev first-party catalog capped by the context options
   Cursor offers each family: current Claude families and GPT 5.5/5.6 report 1M, Grok 500K, Gemini Flash
   1048576, and each request asks Cursor for the matching `context` token.
-
-### Breaking Changes
-
-### Added
 
 - Cursor reasoning levels: the dynamic Cursor catalog now collapses the 204 account variant ids into
   selectable base identities (Claude `base` / `base-thinking` boolean identities) with exact

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
 ### Added
 
 - Cursor model listings report corrected context windows (current Claude families and GPT 5.5/5.6 at 1M,
@@ -13,6 +15,8 @@
   model string. Cursor catalogs collapse the expanded variant ids into selectable identities with correct
   live-catalog context windows (Kimi K3 1M, Grok 256K, GPT 272K), while legacy variant ids, stored catalogs,
   and wildcard enabled/favorite patterns keep resolving to the new identities with their level preserved.
+
+### Changed
 
 ### Fixed
 
@@ -34,15 +38,6 @@
 - Messages typed while auto-compaction is running are no longer silently dropped: input submitted during `Compacting context...` is queued and delivered after compaction settles instead of being accepted and discarded. Manual `/compact` keeps rejecting unqueueable prompts as before ([#950](https://github.com/code-yeongyu/senpi/pull/950)).
 
 - Cursor exec-bridge dispatches are now bound to the run that opened their stream, so a straggler exec frame from a run that already ended (for example after a provider rate-limit error restarts the turn on a fallback lane) is refused instead of executing a dead run's tool inside the replacement run and leaking its lifecycle events into the new transcript.
-
->>>>>>> origin/main
-### New Features
-
-### Breaking Changes
-
-### Added
-
-### Changed
 
 ### Removed
 


### PR DESCRIPTION
## What changed

A merge resolution left a bare `>>>>>>> origin/main` conflict marker committed inside the `## [Unreleased]` section of `packages/coding-agent/CHANGELOG.md`, together with a duplicated set of empty `### Added` / `### Breaking Changes` / `### Changed` headings and a non-canonical `### New Features` heading. `packages/ai/CHANGELOG.md` carried the same duplicated `### Added` / `### Breaking Changes` pair.

This PR deletes the stray marker and de-duplicates the headings, leaving the canonical `Breaking Changes` / `Added` / `Changed` / `Fixed` / `Removed` order from `.github/agent/commands/cl.md` in both packages.

## Why

`scripts/release.mjs` rewrites `## [Unreleased]` into `## [<version>] - <date>` verbatim. Releasing in this state would freeze the conflict marker and the duplicate empty scaffolding into a released section — and the changelog policy makes released sections immutable, so it could not be cleaned up afterwards. The next release (`2026.8.18-3`) is blocked on this.

Precedent for this exact bug class: bcc72468a "fix(changelog): drop stray conflict marker from the 2026.8.4 section".

## Observed behavior

Before (on `origin/main` @ a62861894):

```
packages/coding-agent/CHANGELOG.md:38:>>>>>>> origin/main
```

`## [Unreleased]` headings were `Added, Fixed, New Features, Breaking Changes, Added, Changed, Removed` (`Added` twice).

After:

```
$ git grep -n -E '^(<<<<<<< |=======$|>>>>>>> )' -- 'packages/*/CHANGELOG.md'
exit=1   (no output)
```

`## [Unreleased]` headings are now `Breaking Changes, Added, Changed, Fixed, Removed` in both `coding-agent` and `ai`, with no duplicates.

## QA / evidence

- Marker sweep: `git grep -n -E '^(<<<<<<< |=======$|>>>>>>> )' -- 'packages/*/CHANGELOG.md'` -> exit 1, no output.
- Changelog gate: `node scripts/check-pr-changelog.mjs --base a62861894` -> `changelog-gate: PASS - changes.md coverage complete (0 production path(s) covered); no runtime source changes detected`, exit 0.
- Tracker audit: `node scripts/audit-changes-md.mjs --format markdown` -> exit 0, coverage complete.
- Entry integrity: all 14 existing entries retained (coding-agent 10, ai 4). Zero `- ` entry lines added or removed in the diff — the reasoning-levels entry only changes position because the duplicate headings above it were deleted.
- Released-section invariant: `## [2026.8.18-2] - 2026-08-18` appears in the diff only as unchanged context; every `+`/`-` line is inside `## [Unreleased]`.

## Residual risk

Documentation-only change to two changelog files. No runtime source touched, so no behavioral risk. The `[Unreleased]` entry wording is untouched, so the upcoming release notes read exactly as their authors wrote them.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a stray conflict marker and duplicate headings from the Unreleased sections of the changelogs to restore the canonical order. This prevents release tooling from freezing these artifacts into an immutable released section and unblocks the next release.

- `packages/coding-agent/CHANGELOG.md`: deletes the `>>>>>>> origin/main` marker, removes a non-canonical “New Features” heading, and deduplicates empty headings; sets order to Breaking Changes, Added, Changed, Fixed, Removed.
- `packages/ai/CHANGELOG.md`: removes a duplicated Added/Breaking Changes pair; sets the same canonical order.
- Keeps all entry wording intact; only headings and their order changed. No runtime code touched.

<sup>Written for commit fb5f18b5528415010f671db6e50f66a1962a5161. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

