### PR TITLE
fix(tui,coding-agent): keep pasted image payloads aligned with their markers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Pasting multiple images in one turn now ships every image: the second and later pastes no longer write into an orphaned payload map, markers pasted in front of existing ones renumber to stay `[Image #1]`..`[Image #k]` in reading order (so `look_at("[Image #N]")` resolves to the exact image the user sees), undo after deleting a marker restores its image along with the marker, and submitting pasted images during compaction now reports the drop instead of silently discarding them.
+
 ### Removed
 
 ## [2026.8.18-3] - 2026-08-18

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,49 @@
 # changes
 
+## Pasted image markers keep canonical numbering and survive undo with their payloads (2026-08-18)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`:
+  `reconcilePendingImages()` now clears and refills the SAME `pendingImages`
+  map instead of reassigning it, so `handleClipboardPaste`'s by-reference handoff
+  into `attachClipboardImage` can never write into an orphaned map;
+  `subscribeImageMarkers()` wires the editor's new
+  `snapshotAttachmentState`/`restoreAttachmentState` hooks so undo restores
+  the payload map alongside the marker text; `queueCompactionSubmission()`
+  (called from the submit handler's steer branch and `handleFollowUp`)
+  consumes image-bearing submissions during compaction with a visible drop
+  status and strips their dead literal markers from the queued text.
+- Regression coverage: `test/interactive-mode-clipboard-paste.test.ts` and
+  `test/interactive-mode-image-submission.test.ts` now drive a REAL pi-tui
+  `Editor` through the REAL paste/notify/submit path (two in-order pastes,
+  paste-before-marker, delete+undo payload restore, compaction drops).
+
+### Why
+
+- The second paste in a turn destroyed its own image:
+  `insertImageMarker()` fired `onImageMarkersChanged` synchronously, the
+  reconciler replaced the map's identity, and the subsequent
+  `pendingImages.set(id, ...)` wrote into the orphaned map - shipping
+  `[Image #1][Image #2]` with one image. An out-of-order paste (Home then
+  paste) shipped `[Image #2][Image #1]` and mispaired the survivor, so
+  `look_at("[Image #1]")` resolved to the wrong attachment or threw. Undo
+  after a whole-marker delete restored the marker text but not its payload,
+  permanently destroying that image. Alt+Enter during compaction consumed and
+  silently discarded pasted images.
+
+### Why an extension could not handle it
+
+- `pendingImages`, the marker notification wiring, and the compaction queue
+  are private `InteractiveMode` composer state; extensions receive neither the
+  marker-id stream nor a hook into the submit/compaction decision points.
+
+### Expected merge conflict zones
+
+- MEDIUM: `reconcilePendingImages()` and `subscribeImageMarkers()` in
+  `interactive-mode.ts` (adjacent to the paste handler wiring), and
+  `queueCompactionSubmission()` next to `queueCompactionMessage()`.
+
 ## Native Cursor login refreshes the CLI fallback lane in the same session (2026-08-18)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -519,6 +519,12 @@ async function attachClipboardImage(
 		return false;
 	}
 
+	// insertImageMarker fires onImageMarkersChanged (with the pre-renumber
+	// ids) synchronously and only then returns the marker's FINAL canonical id,
+	// whose slot the reconcile pass just vacated - so this write can neither
+	// land in an orphaned map (reconcile mutates pendingImages in place) nor
+	// overwrite a surviving payload (the new marker had no payload when the
+	// reconcile ran, so nothing was keyed onto its slot).
 	const id = deps.editor.insertImageMarker();
 	deps.pendingImages.set(id, { type: "image", data: processed.data, mimeType: processed.mimeType });
 	deps.requestRender();
@@ -3709,15 +3715,34 @@ export class InteractiveMode {
 	private subscribeImageMarkers(editor: EditorComponent): void {
 		if (!editor.insertImageMarker) return;
 		editor.onImageMarkersChanged = (order) => this.reconcilePendingImages(order);
+		// The editor's undo stack restores marker TEXT and registry ids, but the
+		// payloads live HERE; mirror them into every undo snapshot so undo restores
+		// both halves of the pairing. Without this, deleting a marker re-keys the
+		// survivors onto its number and a later undo re-displays the deleted marker
+		// with no (or the wrong) payload behind it.
+		editor.snapshotAttachmentState = () => new Map(this.pendingImages);
+		editor.restoreAttachmentState = (state) => {
+			if (!(state instanceof Map)) return;
+			this.pendingImages.clear();
+			for (const [key, image] of state) {
+				this.pendingImages.set(key, image as ImageContent);
+			}
+		};
 	}
 
 	/**
 	 * Re-key {@link pendingImages} onto the marker numbers the editor now
-	 * displays. `order` lists the SURVIVING marker ids (pre-renumber) in text
-	 * reading order, which is exactly the editor's new 1..k display numbering, so
-	 * a payload's new key is its position in that list. Ids absent from `order`
+	 * displays. `order` lists the SURVIVING marker ids (pre-renumber, i.e. the
+	 * keys the payloads currently sit under) in text reading order, and the
+	 * editor keeps the visible numbers canonical 1..k in reading order, so a
+	 * payload's new key is its position in that list. Ids absent from `order`
 	 * are dropped; reported ids with no payload (a hand-typed marker) are skipped
 	 * without consuming anyone else's slot.
+	 *
+	 * The map is mutated IN PLACE, never replaced: handleClipboardPaste hands
+	 * this.pendingImages by reference into attachClipboardImage's deps, and a
+	 * fresh identity would orphan that reference - the second paste in a turn
+	 * then wrote into the dead map and silently destroyed its image.
 	 */
 	private reconcilePendingImages(order: number[]): void {
 		if (this.pendingImages.size === 0) return;
@@ -3726,7 +3751,10 @@ export class InteractiveMode {
 			const image = this.pendingImages.get(id);
 			if (image) reconciled.set(index + 1, image);
 		});
-		this.pendingImages = reconciled;
+		this.pendingImages.clear();
+		for (const [key, image] of reconciled) {
+			this.pendingImages.set(key, image);
+		}
 	}
 
 	/**
@@ -3960,7 +3988,7 @@ export class InteractiveMode {
 					this.editor.setText("");
 					await this.session.prompt(text);
 				} else {
-					this.queueCompactionMessage(text, "steer");
+					this.queueCompactionSubmission(text, "steer");
 				}
 				return;
 			}
@@ -5165,28 +5193,31 @@ export class InteractiveMode {
 		const text = this.getExpandedEditorText().trim();
 		if (!text) return;
 
-		// Resolve attachments BEFORE any setText("") below: the editor's prune
-		// chain fires onImageMarkersChanged([]) and the reconciler destroys
-		// pendingImages, so resolving after the clear would ship a literal
-		// `[Image #N]` with no attachment behind it.
-		const images = this.takeSubmissionImages(text);
-
 		// Queue non-command input during compaction; dispatch extension commands.
 		// This is the Alt+Enter path (bound directly to app.message.followUp), which
 		// does NOT pass through onSubmit, so the isExtensionCommand check below is the
 		// live dispatch point here: commands go straight to AgentSession.prompt(),
 		// which runs them immediately even while compaction is active, while ordinary
-		// text is queued for delivery after compaction settles.
+		// text is queued for delivery after compaction settles. Image attachments
+		// are consumed and dropped VISIBLY inside queueCompactionSubmission - the
+		// queue is text-only, so resolving them here and queueing the text with a
+		// dead marker would lose the images without telling the user.
 		if (this.session.isCompacting) {
 			if (this.isExtensionCommand(text)) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
 				await this.session.prompt(text);
 			} else {
-				this.queueCompactionMessage(text, "followUp");
+				this.queueCompactionSubmission(text, "followUp");
 			}
 			return;
 		}
+
+		// Resolve attachments BEFORE any setText("") below: the editor's prune
+		// chain fires onImageMarkersChanged([]) and the reconciler destroys
+		// pendingImages, so resolving after the clear would ship a literal
+		// `[Image #N]` with no attachment behind it.
+		const images = this.takeSubmissionImages(text);
 
 		// Alt+Enter queues a follow-up message (waits until agent finishes).
 		// Extension commands never reach this branch: the compaction branch above
@@ -5581,13 +5612,41 @@ export class InteractiveMode {
 		return allQueued.length;
 	}
 
-	private queueCompactionMessage(text: string, mode: "steer" | "followUp"): void {
+	private queueCompactionMessage(text: string, mode: "steer" | "followUp", droppedImageCount = 0): void {
 		this.compactionQueuedMessages.push({ text, mode, enqueueOrder: this.session.reserveQueuedInputOrder() });
 		this.getSessionLogger().debug("compaction_queue_enqueue", { mode, count: this.compactionQueuedMessages.length });
 		this.editor.addToHistory?.(text);
 		this.editor.setText("");
 		this.updatePendingMessagesDisplay();
-		this.showStatus("Queued message for after compaction");
+		this.showStatus(
+			droppedImageCount > 0
+				? `Queued message for after compaction; dropped ${droppedImageCount} image${droppedImageCount > 1 ? "s" : ""}: messages sent during compaction cannot carry images - paste again after compaction finishes`
+				: "Queued message for after compaction",
+		);
+	}
+
+	/**
+	 * Queue a user submission for delivery after compaction. The compaction
+	 * queue carries text only, so pasted attachments are dropped here -
+	 * VISIBLY, never silently, mirroring attachClipboardImage's paste-time
+	 * contract - and their `[Image #N]` markers are stripped, because a queued
+	 * literal marker has no payload behind it and would ship an unreadable
+	 * `[Image #N]` string to the model once the queue drains.
+	 */
+	private queueCompactionSubmission(text: string, mode: "steer" | "followUp"): void {
+		const images = this.takeSubmissionImages(text);
+		if (images.length === 0) {
+			this.queueCompactionMessage(text, mode);
+			return;
+		}
+		const queued = text.replace(IMAGE_MARKER_PATTERN, "").trim();
+		if (queued) {
+			this.queueCompactionMessage(queued, mode, images.length);
+			return;
+		}
+		this.showStatus(
+			`Dropped ${images.length} image${images.length > 1 ? "s" : ""}: messages sent during compaction cannot carry images - paste again after compaction finishes`,
+		);
 	}
 
 	private hasRegisteredCommand(command: string): boolean {

--- a/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
+++ b/packages/coding-agent/test/interactive-mode-clipboard-paste.test.ts
@@ -8,6 +8,15 @@ import { describe, expect, it, vi } from "vitest";
  * catch block dropped every error, so permission failures, native-clipboard
  * errors, and tmp-file write failures were indistinguishable from "nothing
  * on the clipboard".
+ *
+ * The attachment cases below drive a REAL pi-tui `Editor` (headless
+ * `ProcessTerminal`) wired through the REAL `subscribeImageMarkers`
+ * notification path. The first version of this suite faked
+ * `insertImageMarker` with a counter that never fired
+ * `onImageMarkersChanged`, so the reconcile-before-set collision in the
+ * multi-paste flow was structurally unreachable from the tests - exactly the
+ * gap that let an always-broken multi-image path merge green. Never replace
+ * the real editor here with a marker-unaware fake.
  */
 
 const clipboardImageMock = vi.hoisted(() => ({
@@ -29,47 +38,103 @@ vi.mock("../src/utils/clipboard.ts", async (importOriginal) => {
 });
 
 import type { ImageContent } from "@earendil-works/pi-ai/compat";
+import { Editor, ProcessTerminal, TUI } from "@earendil-works/pi-tui";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { getEditorTheme, initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { processImage } from "../src/utils/image-process.ts";
 
-type HandleClipboardPaste = (this: object) => Promise<void>;
+type HandleClipboardPaste = (this: PasteReceiver) => Promise<void>;
+type SubscribeImageMarkers = (this: PasteReceiver, editor: Editor) => void;
+type Reconcile = (this: { pendingImages: Map<number, ImageContent> }, order: number[]) => void;
+type TakeSubmissionImages = (this: { pendingImages: Map<number, ImageContent> }, text: string) => ImageContent[];
+
+/** Borrowed-receiver shape for the private interactive-mode methods under test. */
+interface PasteReceiver {
+	editor: Editor;
+	pendingImages: Map<number, ImageContent>;
+	/** Stood in for the prototype method the notify handler resolves through `this`. */
+	reconcilePendingImages: (order: number[]) => void;
+	ui: { requestRender: () => void };
+	showStatus: ReturnType<typeof vi.fn>;
+	sessionLogger: { debug: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+	getSessionLogger: () => PasteReceiver["sessionLogger"];
+	settingsManager: { getBlockImages: () => boolean; getImageAutoResize: () => boolean };
+	session?: unknown;
+	lastInputWasPaste?: boolean;
+}
+
+function getPrototypeMethod<T>(name: string): T {
+	const handler = Reflect.get(InteractiveMode.prototype, name);
+	if (typeof handler !== "function") throw new Error(`Expected InteractiveMode.${name}`);
+	return handler as T;
+}
 
 function getHandleClipboardPaste(): HandleClipboardPaste {
-	const handler = Reflect.get(InteractiveMode.prototype, "handleClipboardPaste");
-	if (typeof handler !== "function") throw new Error("Expected InteractiveMode.handleClipboardPaste");
-	return handler as HandleClipboardPaste;
+	return getPrototypeMethod<HandleClipboardPaste>("handleClipboardPaste");
+}
+
+function getSubscribeImageMarkers(): SubscribeImageMarkers {
+	return getPrototypeMethod<SubscribeImageMarkers>("subscribeImageMarkers");
+}
+
+function getReconcile(): Reconcile {
+	return getPrototypeMethod<Reconcile>("reconcilePendingImages");
+}
+
+function getTakeSubmissionImages(): TakeSubmissionImages {
+	return getPrototypeMethod<TakeSubmissionImages>("takeSubmissionImages");
 }
 
 /**
- * A real 16x16 RGB PNG. processImage() genuinely decodes, resizes and re-encodes
- * the bytes, so the fixture must be a decodable image (the WASM decoder rejects
- * degenerate 1x1 payloads) - that keeps these cases exercising the production
- * normalization path instead of its failure branch.
+ * Real 16x16 RGB PNGs (solid red / blue / green) so processImage() genuinely
+ * decodes and normalizes three DISTINGUISHABLE payloads: the multi-paste
+ * cases must be able to tell which image survived and which was destroyed or
+ * mispaired.
  */
-const SAMPLE_PNG_BASE64 =
-	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAB0klEQVR4nA3LoQ6FIABAURrBjabJ4mjMYtLGZqDRCGw0TBS67QY63c5/vnf6EUIgBUowC1aBFhjBIbgEVuAEXhAESZAFRSDEhJxQE/PEOqEnzMQxcU3YCTfhJ8JEmsgTZfqHBbmgFuaFdUEvmIVj4VqwC27BL4SFtJAXyvIPG3JDbcwb64beMBvHxrVhN9yG3wgbaSNvlO0fduSO2pl31h29Y3aOnWvH7rgdvxN20k7eKfs/nMgTdTKfrCf6xJwcJ9eJPXEn/iScpJN8Us5/uJE36ma+WW/0jbk5bq4be+Nu/E24STf5ptz/4JEe5Zk9q0d7jOfwXB7rcR7vCZ7kyZ7i/yEiIyoyR9aIjpjIEbkiNuIiPhIiKZIjJf7Dg3xQD/PD+qAfzMPxcD3YB/fgH8JDesgP5fmHiqyoylxZK7piKkflqtiKq/hKqKRKrpT6Dy/yRb3ML+uLfjEvx8v1Yl/ci38JL+klv5T3HxqyoRpzY23ohmkcjathG67hG6GRGrlR2j90ZEd15s7a0R3TOTpXx3Zcx3dCJ3Vyp/R/+JAf6mP+WD/0h/k4Pq4P++E+/Ef4SB/5o3z/MJADNZgH60APzOAYXAM7cAM/CIM0yIMy+AEIbAcQK3fUWgAAAABJRU5ErkJggg==";
+const PNG_RED_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mN4YGBAEmIY1TCqYfhqAADPxkAQTDYcEAAAAABJRU5ErkJggg==";
+const PNG_BLUE_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mMwSHhAEmIY1TCqYfhqAADz/nAQ/ArooAAAAABJRU5ErkJggg==";
+const PNG_GREEN_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mMwOBBAEmIY1TCqYfhqAAD/t0AQSkxbfAAAAABJRU5ErkJggg==";
 
-function samplePngBytes(): Uint8Array {
-	return new Uint8Array(Buffer.from(SAMPLE_PNG_BASE64, "base64"));
+function pngBytes(base64: string): Uint8Array {
+	return new Uint8Array(Buffer.from(base64, "base64"));
 }
 
+/** The base64 payload attachClipboardImage stores for a given clipboard bitmap. */
+async function processedData(base64: string): Promise<string> {
+	const processed = await processImage(pngBytes(base64), "image/png", { autoResizeImages: true });
+	if (!processed.ok) throw new Error(`fixture image failed to process: ${processed.message}`);
+	return processed.data;
+}
+
+let themeInitialized = false;
+
+/** A REAL pi-tui Editor on a headless terminal - the same class production uses. */
+function createRealEditor(): Editor {
+	if (!themeInitialized) {
+		initTheme("dark");
+		themeInitialized = true;
+	}
+	return new Editor(new TUI(new ProcessTerminal()), getEditorTheme());
+}
+
+/**
+ * Borrowed-prototype receiver whose editor is the real pi-tui `Editor`,
+ * subscribed exactly like production (`subscribeImageMarkers` wires the
+ * notify -> reconcile path and the undo payload mirroring).
+ */
 function makeContext(options: { blockImages?: boolean; autoResize?: boolean } = {}) {
+	const editor = createRealEditor();
 	const sessionLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
-	let nextMarkerId = 0;
-	const insertedText: string[] = [];
-	return {
-		editor: {
-			insertTextAtCursor: vi.fn((text: string) => {
-				insertedText.push(text);
-			}),
-			insertImageMarker: vi.fn(() => {
-				nextMarkerId += 1;
-				insertedText.push(`[Image #${nextMarkerId}]`);
-				return nextMarkerId;
-			}),
-			onImageMarkersChanged: undefined as ((order: number[]) => void) | undefined,
-		},
-		insertedText,
+	const context: PasteReceiver = {
+		editor,
 		pendingImages: new Map<number, ImageContent>(),
+		// The notify handler resolves `this.reconcilePendingImages` through the
+		// receiver, exactly like a real InteractiveMode instance does through its
+		// prototype - a plain object has no prototype chain, so stand in for it.
+		reconcilePendingImages: (order: number[]) => getReconcile().call(context, order),
 		ui: { requestRender: vi.fn() },
 		showStatus: vi.fn(),
 		sessionLogger,
@@ -81,17 +146,32 @@ function makeContext(options: { blockImages?: boolean; autoResize?: boolean } = 
 			getImageAutoResize: () => options.autoResize ?? true,
 		},
 	};
+	getSubscribeImageMarkers().call(context, editor);
+	return { context, editor };
 }
+
+/** Simulate one Ctrl+V image paste of the given bitmap into `receiver`. */
+async function pasteImage(receiver: PasteReceiver, base64: string): Promise<void> {
+	clipboardImageMock.readClipboardImage.mockResolvedValueOnce({ bytes: pngBytes(base64), mimeType: "image/png" });
+	clipboardTextMock.readClipboardText.mockResolvedValue(null);
+	await getHandleClipboardPaste().call(receiver);
+}
+
+const LINE_START = "\x01"; // Ctrl+A
+const ARROW_LEFT = "\x1b[D";
+const BACKSPACE = "\x7f";
+const UNDO = "\x1b[45;5u"; // Ctrl+-
 
 describe("InteractiveMode clipboard paste error surfacing", () => {
 	it("surfaces a status message when clipboard image read fails", async () => {
 		clipboardImageMock.readClipboardImage.mockRejectedValueOnce(new Error("pasteboard permission denied"));
 		clipboardTextMock.readClipboardText.mockResolvedValue(null);
-		const context = makeContext();
+		const { context, editor } = makeContext();
+		const insertText = vi.spyOn(editor, "insertTextAtCursor");
 
 		await getHandleClipboardPaste().call(context);
 
-		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(insertText).not.toHaveBeenCalled();
 		expect(context.showStatus).toHaveBeenCalledTimes(1);
 		const status = context.showStatus.mock.calls[0]?.[0];
 		expect(String(status)).toContain("Clipboard paste failed");
@@ -105,7 +185,7 @@ describe("InteractiveMode clipboard paste error surfacing", () => {
 	it("surfaces a status message when clipboard text read fails after empty image", async () => {
 		clipboardImageMock.readClipboardImage.mockResolvedValueOnce(null);
 		clipboardTextMock.readClipboardText.mockRejectedValueOnce(new Error("text unavailable"));
-		const context = makeContext();
+		const { context } = makeContext();
 
 		await getHandleClipboardPaste().call(context);
 
@@ -116,12 +196,13 @@ describe("InteractiveMode clipboard paste error surfacing", () => {
 	it("stays quiet when the clipboard is simply empty", async () => {
 		clipboardImageMock.readClipboardImage.mockResolvedValueOnce(null);
 		clipboardTextMock.readClipboardText.mockResolvedValueOnce(null);
-		const context = makeContext();
+		const { context, editor } = makeContext();
+		const insertText = vi.spyOn(editor, "insertTextAtCursor");
 
 		await getHandleClipboardPaste().call(context);
 
 		expect(context.showStatus).not.toHaveBeenCalled();
-		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(insertText).not.toHaveBeenCalled();
 		expect(context.sessionLogger.warn).not.toHaveBeenCalled();
 	});
 });
@@ -134,38 +215,31 @@ describe("InteractiveMode clipboard paste error surfacing", () => {
  */
 describe("InteractiveMode clipboard paste image attachment", () => {
 	it("attaches the image as a pending payload behind an atomic marker", async () => {
-		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
-			bytes: samplePngBytes(),
-			mimeType: "image/png",
-		});
-		const context = makeContext();
+		const { context, editor } = makeContext();
+		const insertMarker = vi.spyOn(editor, "insertImageMarker");
+		const [redData] = await Promise.all([processedData(PNG_RED_BASE64)]);
 
-		await getHandleClipboardPaste().call(context);
+		await pasteImage(context, PNG_RED_BASE64);
 
-		expect(context.editor.insertImageMarker).toHaveBeenCalledTimes(1);
-		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
-		expect(context.showStatus).not.toHaveBeenCalled();
-		expect(context.sessionLogger.warn).not.toHaveBeenCalled();
+		expect(insertMarker).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("[Image #1]");
 
 		expect(context.pendingImages.size).toBe(1);
 		const entry = context.pendingImages.get(1);
 		expect(entry).toBeDefined();
 		expect(entry?.type).toBe("image");
 		expect(entry?.mimeType).toBe("image/png");
-		expect(entry?.data).toMatch(/^[A-Za-z0-9+/=]+$/);
-		expect(Buffer.from(String(entry?.data), "base64").length).toBeGreaterThan(0);
+		expect(entry?.data).toBe(redData);
+		expect(context.showStatus).not.toHaveBeenCalled();
+		expect(context.sessionLogger.warn).not.toHaveBeenCalled();
 	});
 
 	it("never inserts a temp-file path for the pasted image", async () => {
-		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
-			bytes: samplePngBytes(),
-			mimeType: "image/png",
-		});
-		const context = makeContext();
+		const { context, editor } = makeContext();
 
-		await getHandleClipboardPaste().call(context);
+		await pasteImage(context, PNG_RED_BASE64);
 
-		const inserted = context.insertedText.join("\n");
+		const inserted = editor.getText();
 		expect(inserted).toContain("[Image #1]");
 		expect(inserted).not.toContain("/tmp");
 		expect(inserted).not.toContain("/var/folders");
@@ -173,33 +247,104 @@ describe("InteractiveMode clipboard paste image attachment", () => {
 	});
 
 	it("keeps marker numbering and the payload map aligned across two pastes", async () => {
-		clipboardImageMock.readClipboardImage
-			.mockResolvedValueOnce({ bytes: samplePngBytes(), mimeType: "image/png" })
-			.mockResolvedValueOnce({ bytes: samplePngBytes(), mimeType: "image/png" });
-		const context = makeContext();
+		const { context, editor } = makeContext();
+		const insertMarker = vi.spyOn(editor, "insertImageMarker");
+		const [redData, blueData] = await Promise.all([processedData(PNG_RED_BASE64), processedData(PNG_BLUE_BASE64)]);
 
-		await getHandleClipboardPaste().call(context);
-		await getHandleClipboardPaste().call(context);
+		await pasteImage(context, PNG_RED_BASE64);
+		await pasteImage(context, PNG_BLUE_BASE64);
 
-		expect(context.editor.insertImageMarker).toHaveBeenCalledTimes(2);
+		// THE load-bearing invariant: the integer N in `[Image #N]` is the
+		// 1-based index of that image in the submitted images array. Two
+		// ordinary in-order pastes must ship BOTH images.
+		expect(insertMarker).toHaveBeenCalledTimes(2);
+		expect(editor.getText()).toBe("[Image #1][Image #2]");
 		expect([...context.pendingImages.keys()]).toEqual([1, 2]);
-		expect(context.insertedText).toEqual(["[Image #1]", "[Image #2]"]);
+
+		const images = getTakeSubmissionImages().call(context, editor.getText());
+		expect(images).toHaveLength(2);
+		expect(images[0]).toMatchObject({ type: "image", data: redData, mimeType: "image/png" });
+		expect(images[1]).toMatchObject({ type: "image", data: blueData, mimeType: "image/png" });
+		expect(context.pendingImages.size).toBe(0);
+	});
+
+	it("pairs each marker with its own payload when a paste lands before an existing marker", async () => {
+		const { context, editor } = makeContext();
+		const [redData, blueData] = await Promise.all([processedData(PNG_RED_BASE64), processedData(PNG_BLUE_BASE64)]);
+
+		await pasteImage(context, PNG_RED_BASE64);
+		editor.handleInput(LINE_START); // cursor now sits BEFORE the first marker
+		await pasteImage(context, PNG_BLUE_BASE64);
+
+		// The visible numbers must stay canonical 1..k in reading order, so
+		// `[Image #1]` is the pasted-at-the-front image and `[Image #2]` the
+		// original one. A stale "[Image #2][Image #1]" text means the survivor
+		// resolves to the WRONG attachment in look_at("[Image #1]").
+		expect(editor.getText()).toBe("[Image #1][Image #2]");
+
+		const images = getTakeSubmissionImages().call(context, editor.getText());
+		expect(images).toHaveLength(2);
+		expect(images[0]).toMatchObject({ type: "image", data: blueData });
+		expect(images[1]).toMatchObject({ type: "image", data: redData });
+	});
+
+	it("restores the payload map when an undo brings a deleted marker back", async () => {
+		const { context, editor } = makeContext();
+		const [redData, blueData, greenData] = await Promise.all([
+			processedData(PNG_RED_BASE64),
+			processedData(PNG_BLUE_BASE64),
+			processedData(PNG_GREEN_BASE64),
+		]);
+
+		// The F2 audit's exact reproduction: pending {1:A, 2:B, 3:C} behind
+		// "[Image #1] [Image #2] [Image #3]".
+		await pasteImage(context, PNG_RED_BASE64);
+		editor.handleInput(" ");
+		await pasteImage(context, PNG_BLUE_BASE64);
+		editor.handleInput(" ");
+		await pasteImage(context, PNG_GREEN_BASE64);
+		expect(editor.getText()).toBe("[Image #1] [Image #2] [Image #3]");
+
+		// Backspace over the MIDDLE marker (cursor is after #3; two left-arrow
+		// crossings land right after #2, so backspace deletes marker #2 whole).
+		// Correct intermediate state: {1:A, 2:C} after the survivor renumbers.
+		editor.handleInput(ARROW_LEFT);
+		editor.handleInput(ARROW_LEFT);
+		editor.handleInput(BACKSPACE);
+		// Deleting the middle marker leaves its two neighboring spaces adjacent.
+		expect(editor.getText()).toBe("[Image #1]  [Image #2]");
+		expect([...context.pendingImages.keys()]).toEqual([1, 2]);
+		expect(context.pendingImages.get(2)?.data).toBe(greenData);
+
+		// Undo must restore BOTH halves of the pairing: the marker text AND its
+		// payload. Pre-fix, undo restored the text/registry but NOT the map, so
+		// pending stayed {1:A, 2:C}: submit shipped 3 markers / 2 images,
+		// "[Image #2]" resolved to C (B permanently lost) and "[Image #3]" was
+		// unresolvable.
+		editor.handleInput(UNDO);
+		expect(editor.getText()).toBe("[Image #1] [Image #2] [Image #3]");
+		expect([...context.pendingImages.keys()]).toEqual([1, 2, 3]);
+
+		// Submit: every marker resolves to ITS OWN image, in order.
+		const images = getTakeSubmissionImages().call(context, editor.getText());
+		expect(images).toHaveLength(3);
+		expect(images[0]).toMatchObject({ type: "image", data: redData });
+		expect(images[1]).toMatchObject({ type: "image", data: blueData });
+		expect(images[2]).toMatchObject({ type: "image", data: greenData });
 	});
 
 	it("drops the attachment when blockImages is enabled and tells the user why", async () => {
-		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
-			bytes: samplePngBytes(),
-			mimeType: "image/png",
-		});
 		clipboardTextMock.readClipboardText.mockResolvedValueOnce(null);
-		const context = makeContext({ blockImages: true });
+		const { context, editor } = makeContext({ blockImages: true });
+		const insertMarker = vi.spyOn(editor, "insertImageMarker");
+		const insertText = vi.spyOn(editor, "insertTextAtCursor");
 
-		await getHandleClipboardPaste().call(context);
+		await pasteImage(context, PNG_RED_BASE64);
 
 		// Pinned behavior: no marker, no attachment, no temp path - and a visible
 		// status so the paste is never a silent no-op.
-		expect(context.editor.insertImageMarker).not.toHaveBeenCalled();
-		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(insertMarker).not.toHaveBeenCalled();
+		expect(insertText).not.toHaveBeenCalled();
 		expect(context.pendingImages.size).toBe(0);
 		expect(context.showStatus).toHaveBeenCalledTimes(1);
 		expect(String(context.showStatus.mock.calls[0]?.[0])).toContain("Image paste blocked");
@@ -207,16 +352,19 @@ describe("InteractiveMode clipboard paste image attachment", () => {
 	});
 
 	it("surfaces a status and attaches nothing when the image cannot be processed", async () => {
+		const { context, editor } = makeContext();
+		const insertMarker = vi.spyOn(editor, "insertImageMarker");
+		const insertText = vi.spyOn(editor, "insertTextAtCursor");
+
 		clipboardImageMock.readClipboardImage.mockResolvedValueOnce({
 			bytes: new Uint8Array([1, 2, 3, 4]),
 			mimeType: "image/tiff",
 		});
-		const context = makeContext();
-
+		clipboardTextMock.readClipboardText.mockResolvedValue(null);
 		await getHandleClipboardPaste().call(context);
 
-		expect(context.editor.insertImageMarker).not.toHaveBeenCalled();
-		expect(context.editor.insertTextAtCursor).not.toHaveBeenCalled();
+		expect(insertMarker).not.toHaveBeenCalled();
+		expect(insertText).not.toHaveBeenCalled();
 		expect(context.pendingImages.size).toBe(0);
 		expect(context.showStatus).toHaveBeenCalledTimes(1);
 		expect(String(context.showStatus.mock.calls[0]?.[0])).toContain("Image");
@@ -231,14 +379,6 @@ describe("InteractiveMode clipboard paste image attachment", () => {
  * the wrong (or a removed) image at submit.
  */
 describe("InteractiveMode image-marker reconciliation", () => {
-	type Reconcile = (this: { pendingImages: Map<number, ImageContent> }, order: number[]) => void;
-
-	function getReconcile(): Reconcile {
-		const handler = Reflect.get(InteractiveMode.prototype, "reconcilePendingImages");
-		if (typeof handler !== "function") throw new Error("Expected InteractiveMode.reconcilePendingImages");
-		return handler as Reconcile;
-	}
-
 	function image(data: string): ImageContent {
 		return { type: "image", data, mimeType: "image/png" };
 	}
@@ -258,18 +398,20 @@ describe("InteractiveMode image-marker reconciliation", () => {
 		expect(context.pendingImages.get(1)?.data).toBe("BBB");
 	});
 
-	it("reorders payloads when markers are moved into a different reading order", () => {
-		const context = {
-			pendingImages: new Map<number, ImageContent>([
-				[1, image("AAA")],
-				[2, image("BBB")],
-			]),
-		};
+	it("re-keys the very map object every holder captured, never a fresh identity", async () => {
+		// handleClipboardPaste hands `pendingImages` BY REFERENCE into
+		// attachClipboardImage's deps; a reconciler that reassigns the field
+		// orphans that reference and the second paste in a turn writes into a
+		// dead map - silently destroying the image.
+		const { context, editor } = makeContext();
+		const capturedByPasteDeps = context.pendingImages;
 
-		getReconcile().call(context, [2, 1]);
+		await pasteImage(context, PNG_RED_BASE64);
+		await pasteImage(context, PNG_BLUE_BASE64);
 
-		expect(context.pendingImages.get(1)?.data).toBe("BBB");
-		expect(context.pendingImages.get(2)?.data).toBe("AAA");
+		expect(context.pendingImages).toBe(capturedByPasteDeps);
+		expect(context.pendingImages.size).toBe(2);
+		expect(editor.getText()).toBe("[Image #1][Image #2]");
 	});
 
 	it("drops every payload when all markers are gone", () => {

--- a/packages/coding-agent/test/interactive-mode-image-submission.test.ts
+++ b/packages/coding-agent/test/interactive-mode-image-submission.test.ts
@@ -38,7 +38,10 @@ vi.mock("../src/utils/version-check.ts", () => ({
 }));
 
 import type { ImageContent } from "@earendil-works/pi-ai/compat";
+import { Editor, ProcessTerminal, TUI } from "@earendil-works/pi-tui";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { getEditorTheme, initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { processImage } from "../src/utils/image-process.ts";
 
 /** The widened submission-channel payload: text plus images resolved from markers. */
 type UserSubmission = { text: string; images?: ImageContent[] };
@@ -60,6 +63,7 @@ interface FakeSession {
 	isStreaming: boolean;
 	isBashRunning: boolean;
 	prompt: MockFn;
+	reserveQueuedInputOrder: MockFn;
 	extensionRunner: { getCommand: (name: string) => unknown };
 	modelRuntime: { getError: () => string | undefined; refresh: () => Promise<unknown> };
 	fallbackValidationWarnings: readonly string[];
@@ -70,6 +74,7 @@ interface ModeContext {
 	editor: FakeEditor;
 	session: FakeSession;
 	pendingImages: Map<number, ImageContent>;
+	compactionQueuedMessages: { text: string; mode: string; enqueueOrder: number }[];
 	pendingUserInputs: UserSubmission[];
 	onInputCallback?: (input: UserSubmission) => void;
 	preResolvedSubmissionImages?: ImageContent[];
@@ -104,6 +109,9 @@ interface ModeContext {
 	 * rather than crashing the harness.
 	 */
 	takeSubmissionImages?: (submittedText: string) => ImageContent[];
+	reconcilePendingImages?: (order: number[]) => void;
+	queueCompactionSubmission?: (text: string, mode: "steer" | "followUp") => void;
+	queueCompactionMessage?: (text: string, mode: "steer" | "followUp", droppedImageCount?: number) => void;
 	getUserInput?: () => Promise<UserSubmission>;
 	isExtensionCommand?: (text: string) => boolean;
 	getExpandedEditorText?: () => string;
@@ -116,6 +124,14 @@ type ModePrototype = {
 	handleFollowUp(this: ModeContext): Promise<void>;
 	handleClipboardPaste(this: ModeContext): Promise<void>;
 	reconcilePendingImages(this: ModeContext, order: number[]): void;
+	subscribeImageMarkers(this: ModeContext, editor: unknown): void;
+	queueCompactionSubmission(this: ModeContext, text: string, mode: "steer" | "followUp"): void;
+	queueCompactionMessage(
+		this: ModeContext,
+		text: string,
+		mode: "steer" | "followUp",
+		droppedImageCount?: number,
+	): void;
 	takeSubmissionImages(this: ModeContext, submittedText: string): ImageContent[];
 	isExtensionCommand(this: ModeContext, text: string): boolean;
 	getExpandedEditorText(this: ModeContext): string;
@@ -153,6 +169,7 @@ function createModeContext(): ModeContext {
 		isStreaming: false,
 		isBashRunning: false,
 		prompt: vi.fn(async () => {}),
+		reserveQueuedInputOrder: vi.fn(() => 0),
 		extensionRunner: { getCommand: vi.fn(() => undefined) },
 		modelRuntime: { getError: vi.fn(() => undefined), refresh: vi.fn(async () => undefined) },
 		fallbackValidationWarnings: [],
@@ -163,6 +180,7 @@ function createModeContext(): ModeContext {
 			editor,
 			session,
 			pendingImages: new Map<number, ImageContent>(),
+			compactionQueuedMessages: [],
 			pendingUserInputs: [] as UserSubmission[],
 			onInputCallback: undefined,
 			preResolvedSubmissionImages: undefined,
@@ -222,6 +240,12 @@ function createModeContext(): ModeContext {
 	editor.onImageMarkersChanged = (order: number[]) => {
 		proto.reconcilePendingImages.call(context, order);
 	};
+	// The real subscribeImageMarkers resolves this.reconcilePendingImages
+	// through the receiver; a plain object has no prototype chain, so stand in.
+	context.reconcilePendingImages = (order: number[]) => proto.reconcilePendingImages.call(context, order);
+	context.queueCompactionSubmission = (text, mode) => proto.queueCompactionSubmission.call(context, text, mode);
+	context.queueCompactionMessage = (text, mode, droppedImageCount) =>
+		proto.queueCompactionMessage.call(context, text, mode, droppedImageCount);
 	return context;
 }
 
@@ -240,6 +264,50 @@ function submit(context: ModeContext, text: string): Promise<void> {
 /** Start the real getUserInput() so the widened channel can be observed end-to-end. */
 function beginUserInput(context: ModeContext): Promise<UserSubmission> {
 	return proto.getUserInput.call(context);
+}
+
+/** Distinct solid-color 16x16 PNGs so mispairing is observable, not just count loss. */
+const PNG_RED_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mN4YGBAEmIY1TCqYfhqAADPxkAQTDYcEAAAAABJRU5ErkJggg==";
+const PNG_BLUE_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAFklEQVR42mMwSHhAEmIY1TCqYfhqAADz/nAQ/ArooAAAAABJRU5ErkJggg==";
+
+function pngBytes(base64: string): Uint8Array {
+	return new Uint8Array(Buffer.from(base64, "base64"));
+}
+
+async function processedData(base64: string): Promise<string> {
+	const processed = await processImage(pngBytes(base64), "image/png", { autoResizeImages: true });
+	if (!processed.ok) throw new Error(`fixture image failed to process: ${processed.message}`);
+	return processed.data;
+}
+
+let themeInitialized = false;
+
+/** Simulate one Ctrl+V image paste of the given bitmap into `context`. */
+async function pasteImage(context: ModeContext, base64: string): Promise<void> {
+	clipboardImageMock.readClipboardImage.mockResolvedValueOnce({ bytes: pngBytes(base64), mimeType: "image/png" });
+	clipboardTextMock.readClipboardText.mockResolvedValue(null);
+	await proto.handleClipboardPaste.call(context);
+}
+
+/**
+ * A ModeContext whose editor is the REAL pi-tui `Editor` on a headless
+ * terminal, subscribed exactly like production. The fake-editor harness above
+ * cannot exercise the notify path inside `insertImageMarker` - the fake's
+ * `insertImageMarker` never fires `onImageMarkersChanged` - and that blind
+ * spot is exactly how a broken multi-image flow shipped green.
+ */
+function createRealEditorContext(): { context: ModeContext; editor: Editor } {
+	if (!themeInitialized) {
+		initTheme("dark");
+		themeInitialized = true;
+	}
+	const context = createModeContext();
+	const editor = new Editor(new TUI(new ProcessTerminal()), getEditorTheme());
+	context.editor = editor as unknown as FakeEditor;
+	proto.subscribeImageMarkers.call(context, editor);
+	return { context, editor };
 }
 
 describe("InteractiveMode image submission - normal channel", () => {
@@ -341,23 +409,30 @@ describe("InteractiveMode image submission - normal channel", () => {
 		expect(context.pendingImages.size).toBe(0);
 	});
 
-	it("orders the array by READING ORDER, not marker number", async () => {
-		const a = image("QUFBQQ==");
-		const b = image("QkJCQg==");
-		const context = createModeContext();
-		context.pendingImages.set(1, a);
-		context.pendingImages.set(2, b);
-		prepareSubmitHandler(context);
+	it("numbers markers canonically so the Nth marker pairs with images[N-1] after an out-of-order paste", async () => {
+		const [redData, blueData] = await Promise.all([processedData(PNG_RED_BASE64), processedData(PNG_BLUE_BASE64)]);
+		const { context, editor } = createRealEditorContext();
+
+		await pasteImage(context, PNG_RED_BASE64);
+		editor.handleInput("\x01"); // Home: the next paste lands BEFORE the marker
+		await pasteImage(context, PNG_BLUE_BASE64);
+
+		// The visible numbers must be canonical 1..k in reading order, so the
+		// marker the user sees first ([Image #1]) is images[0]. The pre-fix text
+		// "[Image #2][Image #1]" shipped one image and mispaired the survivor.
+		expect(editor.getText()).toBe("[Image #1][Image #2]");
+		prepareSubmitHandler(context, { shareEditor: true });
 
 		const userInput = beginUserInput(context);
-		await submit(context, "late [Image #2] early [Image #1]");
+		editor.handleInput("\r"); // the real Enter -> submitValue -> onSubmit path
+		const resolved = await vi.waitFor(async () => await userInput);
 
-		// The first marker in the text must be images[0] so look_at's
-		// [Image #1] resolves to what the user sees first.
-		await expect(userInput).resolves.toEqual({
-			text: "late [Image #2] early [Image #1]",
-			images: [b, a],
-		});
+		expect(resolved.text).toBe("[Image #1][Image #2]");
+		expect(resolved.images).toEqual([
+			{ type: "image", data: blueData, mimeType: "image/png" },
+			{ type: "image", data: redData, mimeType: "image/png" },
+		]);
+		expect(context.pendingImages.size).toBe(0);
 	});
 
 	it("passes no images key when every marker was deleted before submit", async () => {
@@ -390,17 +465,21 @@ describe("InteractiveMode image submission - normal channel", () => {
 		await expect(userInput).resolves.toEqual({ text: "look at [Image #1]" });
 	});
 
-	it("lets a hand-typed marker consume no slot in front of a real one", async () => {
+	it("lets a hand-typed marker with no pending entry consume no slot before a real one", async () => {
 		const pasted = image("UEFTVEVE");
 		const context = createModeContext();
-		context.pendingImages.set(2, pasted);
+		// Reachable state: the user pastes an image ([Image #1], payload-bearing)
+		// and also hand-types a literal [Image #2] in front of it. The hand-typed
+		// marker owns no attachment, so it passes through untouched and the real
+		// marker still resolves to images[0].
+		context.pendingImages.set(1, pasted);
 		prepareSubmitHandler(context);
 
 		const userInput = beginUserInput(context);
-		await submit(context, "typed [Image #1] pasted [Image #2]");
+		await submit(context, "typed [Image #2] by hand then pasted [Image #1]");
 
 		await expect(userInput).resolves.toEqual({
-			text: "typed [Image #1] pasted [Image #2]",
+			text: "typed [Image #2] by hand then pasted [Image #1]",
 			images: [pasted],
 		});
 	});
@@ -540,5 +619,45 @@ describe("InteractiveMode image submission - compaction boundary", () => {
 		expect(context.pendingImages.size).toBe(0);
 		expect(context.showStatus).toHaveBeenCalledTimes(1);
 		expect(String(context.showStatus.mock.calls[0]?.[0])).toMatch(/compact/i);
+	});
+
+	it("shows a visible drop status when Alt+Enter queues an image-bearing message during compaction", async () => {
+		const pending = image("Rk9MTExXUVVFVUU=");
+		const context = createModeContext();
+		context.session.isCompacting = true;
+		context.pendingImages.set(1, pending);
+		context.editor.getText.mockReturnValue("look at [Image #1]");
+
+		await proto.handleFollowUp.call(context);
+
+		// The compaction queue carries text only: the attachment is dropped
+		// VISIBLY (never a silent loss), its dead literal marker never ships in
+		// the queued text, and pendingImages does not leak into a later turn.
+		expect(context.compactionQueuedMessages).toHaveLength(1);
+		expect(context.compactionQueuedMessages[0]?.text).toBe("look at");
+		expect(context.compactionQueuedMessages[0]?.mode).toBe("followUp");
+		expect(context.pendingImages.size).toBe(0);
+		expect(context.showStatus).toHaveBeenCalledTimes(1);
+		const status = String(context.showStatus.mock.calls[0]?.[0]);
+		expect(status).toMatch(/compact/i);
+		expect(status).toMatch(/image/i);
+	});
+
+	it("shows a visible drop status when Enter queues an image-bearing message during compaction", async () => {
+		const pending = image("U1RFRVJRVUVVRR==");
+		const context = createModeContext();
+		context.session.isCompacting = true;
+		context.pendingImages.set(1, pending);
+		prepareSubmitHandler(context);
+
+		await submit(context, "look at [Image #1]");
+
+		expect(context.compactionQueuedMessages).toHaveLength(1);
+		expect(context.compactionQueuedMessages[0]?.text).toBe("look at");
+		expect(context.compactionQueuedMessages[0]?.mode).toBe("steer");
+		expect(context.pendingImages.size).toBe(0);
+		const status = String(context.showStatus.mock.calls[0]?.[0]);
+		expect(status).toMatch(/compact/i);
+		expect(status).toMatch(/image/i);
 	});
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,9 +8,13 @@
 
 - Atomic `[Image #N]` editor markers for pasted images: a new `ImageMarkerRegistry` (ids only, never bytes) with contiguous renumbering, whole-marker deletion, registry snapshots for editor-to-editor transfer, and a paired optional image-marker API on `EditorComponent`, exported from the package index.
 
+- Optional paired `snapshotAttachmentState`/`restoreAttachmentState` owner hooks on `Editor` and `EditorComponent`: the editor's undo stack captures the caller's marker-keyed attachment payloads opaquely and restores them before the marker-order notification, so undoing a marker delete revives its image along with its text.
+
 ### Changed
 
 ### Fixed
+
+- `insertImageMarker()` now renumbers the visible markers to canonical `1..k` in reading order and returns the marker's final canonical id (previously the insertion counter), so a paste in front of an existing marker displays `[Image #1][Image #2]` instead of `[Image #2][Image #1]`, and the id the caller keys its payload under matches the number the user sees; `setText()` applies the same canonicalization after pruning so a surviving high id displays as `[Image #1]`.
 
 ### Removed
 

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,46 @@
 # TUI delta rendering fork changes
 
+## Image markers canonicalize on insert/prune and carry owner payloads across undo (2026-08-18)
+
+### What changed
+
+- `packages/tui/src/components/editor.ts`: `insertImageMarker()` renumbers the
+  visible markers to canonical 1..k in reading order (via
+  `ImageMarkerRegistry.canonicalize`, previously dead code) and returns the
+  marker's FINAL canonical id instead of the insertion counter; `setText()`
+  canonicalizes after pruning so a surviving high id displays as `[Image #1]`;
+  `EditorSnapshot` carries an opaque `attachmentState` captured through the new
+  owner hooks and `undo()` restores it BEFORE firing the marker-order
+  notification; cursor position is preserved across the renumbering rewrite.
+- `packages/tui/src/editor-component.ts`: new optional paired
+  `snapshotAttachmentState`/`restoreAttachmentState` contract next to
+  `onImageMarkersChanged`, documented together with the tightened
+  `insertImageMarker` id semantics.
+- Regression coverage: `test/editor-image-marker.test.ts` pins out-of-order
+  insert canonicalization, post-prune renumbering, and multi-marker
+  delete+undo payload restoration.
+
+### Why
+
+- The insertion counter only produces reading-order numbers when the cursor
+  sits after every existing marker, so pasting in front of one displayed
+  `[Image #2][Image #1]`; the owner's reconcile-by-position then mispaired or
+  destroyed payloads. Undo restored marker text and registry ids but the
+  payloads live with the owner, so a delete+undo permanently lost the deleted
+  marker's image.
+
+### Why an extension could not handle it
+
+- The marker registry, undo stack, and the id semantics of
+  `insertImageMarker` are `Editor` internals below the component contract;
+  extensions cannot renumber marker text or hook the undo pop.
+
+### Expected merge conflict zones
+
+- MEDIUM: `insertImageMarker()` and the undo snapshot/restore block in
+  `packages/tui/src/components/editor.ts`.
+- LOW: the image-marker section of `packages/tui/src/editor-component.ts`.
+
 ## Repository-wide changes.md audit backfill for renderer, terminal, and component surfaces (2026-08-17)
 
 ### What changed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,5 +1,13 @@
 import type { AutocompleteProvider, AutocompleteSuggestions } from "../autocomplete.ts";
-import { type EditorImageState, ImageMarkerRegistry, imageMarkerId, isImageMarker } from "../image-markers.ts";
+import {
+	type EditorImageState,
+	formatImageMarker,
+	IMAGE_MARKER_REGEX,
+	type ImageMarkerCanonicalization,
+	ImageMarkerRegistry,
+	imageMarkerId,
+	isImageMarker,
+} from "../image-markers.ts";
 import { getKeybindings } from "../keybindings.ts";
 import { decodePrintableKey, matchesKey } from "../keys.ts";
 import { KillRing } from "../kill-ring.ts";
@@ -229,6 +237,8 @@ interface EditorSnapshot {
 	state: EditorState;
 	pasteState: EditorPasteState;
 	imageState: EditorImageState;
+	/** Opaque attachment payload snapshot captured from the owner, restored on undo. */
+	attachmentState?: unknown;
 }
 
 interface LayoutLine {
@@ -365,8 +375,28 @@ export class Editor implements Component, Focusable {
 	 * Fired whenever image markers are added, removed, pruned or renumbered.
 	 * Carries the marker ids in text reading order so the owner can keep its
 	 * payload map aligned with the visible numbers.
+	 *
+	 * The reported ids are the ids the OWNER CURRENTLY KEYS ITS PAYLOADS BY -
+	 * i.e. the PRE-renumber ids - and the visible numbers are always canonical
+	 * 1..k in reading order after the change, so the owner re-keys payload
+	 * `order[i]` onto slot `i + 1`.
 	 */
 	public onImageMarkersChanged?: (order: number[]) => void;
+	/**
+	 * Owner hook: capture the attachment payloads keyed by marker id so an undo
+	 * can restore them alongside the editor snapshot. The value is stored
+	 * opaquely - image bytes never cross into the editor - and is handed back
+	 * through {@link restoreAttachmentState} when the matching snapshot is
+	 * popped. Return `undefined` to store nothing (restores are skipped).
+	 */
+	public snapshotAttachmentState?: () => unknown;
+	/**
+	 * Owner hook: restore the attachment payloads captured by
+	 * {@link snapshotAttachmentState} for the snapshot an undo just popped.
+	 * Called BEFORE {@link onImageMarkersChanged} fires for that undo so the
+	 * reconcile pass maps the restored payloads, not the post-delete ones.
+	 */
+	public restoreAttachmentState?: (state: unknown) => void;
 	public disableSubmit: boolean = false;
 
 	constructor(tui: TUI, theme: EditorTheme, options: EditorOptions = {}) {
@@ -1135,7 +1165,11 @@ export class Editor implements Component, Focusable {
 		const previousImageOrder = this.imageMarkers.ids(previousText);
 		this.imageMarkers.prune(normalized, previousText);
 		this.setTextInternal(normalized);
-		const imageOrder = this.imageMarkers.ids(normalized);
+		// A prune can leave a gap (e.g. only id 2 surviving); renumber so the
+		// visible numbers stay 1..k in reading order.
+		const canonicalization = this.imageMarkers.canonicalize(normalized);
+		this.applyCanonicalizedText(canonicalization);
+		const imageOrder = canonicalization.order;
 		if (previousImageOrder.length !== imageOrder.length || previousImageOrder.some((id, i) => id !== imageOrder[i])) {
 			this.onImageMarkersChanged?.(imageOrder);
 		}
@@ -1181,6 +1215,16 @@ export class Editor implements Component, Focusable {
 	 * Insert the next canonical `[Image #N]` marker at the cursor and return its id.
 	 * This is atomic for undo - a single undo restores the entire pre-insert state,
 	 * registry included - matching the insertTextAtCursor() contract.
+	 *
+	 * The text is canonicalized before returning: the insertion counter only
+	 * produces reading-order numbers when the cursor sat after every existing
+	 * marker, so a paste in front of an earlier marker renumbers the visible
+	 * markers to stay 1..k in reading order. The returned id is the marker's
+	 * FINAL canonical number (its 1-based reading position), which is the slot
+	 * the owner must key its payload under; the notification fires with the
+	 * PRE-renumber ids, so that slot is guaranteed vacant by the time this
+	 * returns and a caller registering its payload right after cannot orphan
+	 * or overwrite a surviving payload.
 	 */
 	insertImageMarker(): number {
 		this.cancelAutocomplete();
@@ -1189,8 +1233,44 @@ export class Editor implements Component, Focusable {
 		this.exitHistoryBrowsing();
 		const marker = this.imageMarkers.add();
 		this.insertTextAtCursorInternal(marker);
-		this.notifyImageMarkersChanged();
-		return imageMarkerId(marker)!;
+		const canonicalization = this.imageMarkers.canonicalize(this.getText());
+		this.applyCanonicalizedText(canonicalization);
+		const insertionId = imageMarkerId(marker)!;
+		// An id missing from the order means the inserted marker duplicates a
+		// hand-typed literal, so the registry treats both occurrences as
+		// unauthorized; keep the insertion id so first-occurrence-wins still
+		// attaches the payload at submit.
+		const finalId = canonicalization.order.includes(insertionId)
+			? canonicalization.order.indexOf(insertionId) + 1
+			: insertionId;
+		this.onImageMarkersChanged?.(canonicalization.order);
+		return finalId;
+	}
+
+	/**
+	 * Rewrite the buffer with a canonicalized marker numbering, preserving the
+	 * cursor by folding the length delta of every marker rewrite that ended at
+	 * or before the cursor on the cursor's line (markers never span lines, and
+	 * rewrites never change the line count).
+	 */
+	private applyCanonicalizedText(canonicalization: ImageMarkerCanonicalization): void {
+		if (canonicalization.text === this.getText()) return;
+		const oldLine = this.state.lines[this.state.cursorLine] ?? "";
+		const cursorCol = this.state.cursorCol;
+		const renumbered = new Map<number, number>();
+		for (const [index, id] of canonicalization.order.entries()) {
+			renumbered.set(id, index + 1);
+		}
+		let delta = 0;
+		for (const match of oldLine.matchAll(IMAGE_MARKER_REGEX)) {
+			const end = (match.index ?? 0) + match[0].length;
+			if (end > cursorCol) break;
+			const newId = renumbered.get(Number.parseInt(match[1] ?? "0", 10));
+			if (newId === undefined) continue;
+			delta += formatImageMarker(newId).length - match[0].length;
+		}
+		this.state.lines = canonicalization.text.split("\n");
+		this.setCursorCol(Math.max(0, cursorCol + delta));
 	}
 
 	/**
@@ -2157,6 +2237,7 @@ export class Editor implements Component, Focusable {
 			state: this.state,
 			pasteState: this.pasteMarkers.snapshot(),
 			imageState: this.imageMarkers.snapshot(),
+			attachmentState: this.snapshotAttachmentState?.(),
 		});
 	}
 
@@ -2167,6 +2248,13 @@ export class Editor implements Component, Focusable {
 		Object.assign(this.state, snapshot.state);
 		this.pasteMarkers.restore(snapshot.pasteState);
 		this.imageMarkers.restore(snapshot.imageState);
+		// Restore the owner's payload snapshot BEFORE the marker-order
+		// notification: the reconcile pass maps payloads by the restored ids, so
+		// restoring after it would re-key the post-delete survivors onto the
+		// restored marker set and permanently drop the deleted marker's image.
+		if (snapshot.attachmentState !== undefined) {
+			this.restoreAttachmentState?.(snapshot.attachmentState);
+		}
 		this.lastAction = null;
 		this.preferredVisualCol = null;
 		if (this.onChange) {

--- a/packages/tui/src/editor-component.ts
+++ b/packages/tui/src/editor-component.ts
@@ -81,6 +81,13 @@ export interface EditorComponent extends Component {
 	 * Insert the next atomic `[Image #N]` marker at the cursor and return its id.
 	 * The editor stores ids only; the caller keeps the image payload keyed by id.
 	 *
+	 * The returned id is the marker's FINAL canonical number - its 1-based
+	 * reading position after the editor renumbers the visible markers to stay
+	 * 1..k in reading order - and `onImageMarkersChanged` fires (with the
+	 * PRE-renumber ids) before the id is returned, so the caller registering its
+	 * payload under the returned id immediately after the call always lands on
+	 * a vacant slot.
+	 *
 	 * Paired contract: implement insertImageMarker together with
 	 * onImageMarkersChanged. Callers must be told when markers are removed or
 	 * renumbered, otherwise their payload map desynchronizes from the visible
@@ -112,11 +119,37 @@ export interface EditorComponent extends Component {
 	 * Called with the image-marker ids in text reading order whenever markers are
 	 * added, removed, pruned or renumbered.
 	 *
+	 * The reported ids are the keys the caller currently keys its payloads by
+	 * (the PRE-renumber ids), and after every change the visible numbers are
+	 * canonical 1..k in reading order, so the caller re-keys payload
+	 * `order[i]` onto slot `i + 1`.
+	 *
 	 * Paired contract: required whenever insertImageMarker is implemented (see
 	 * above) - the reported order is the only signal that keeps the caller's
 	 * payload map aligned with the displayed `[Image #N]` numbers.
 	 */
 	onImageMarkersChanged?: (order: number[]) => void;
+
+	/**
+	 * Snapshot the attachment payloads keyed by marker id so the editor's undo
+	 * stack can restore them together with the marker text and registry ids.
+	 * The editor stores the returned value opaquely; return `undefined` to store
+	 * nothing.
+	 *
+	 * Paired contract: implement together with restoreAttachmentState. Without
+	 * these hooks an undo that revives a deleted marker displays it with no (or
+	 * the wrong) payload behind it, because the delete re-keyed the survivors.
+	 */
+	snapshotAttachmentState?: () => unknown;
+
+	/**
+	 * Restore the attachment payloads captured by {@link snapshotAttachmentState}
+	 * when the editor's undo pops the matching snapshot. Called before
+	 * `onImageMarkersChanged` fires for that undo.
+	 *
+	 * Paired contract: implement together with snapshotAttachmentState.
+	 */
+	restoreAttachmentState?: (state: unknown) => void;
 
 	// =========================================================================
 	// Autocomplete support (optional)

--- a/packages/tui/test/editor-image-marker.test.ts
+++ b/packages/tui/test/editor-image-marker.test.ts
@@ -55,6 +55,78 @@ describe("editor image markers", () => {
 		assert.deepStrictEqual(orders, [[1], [1, 2]]);
 	});
 
+	it("renumbers the visible markers when one is inserted before existing ones", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		editor.handleInput(LINE_START);
+		const orders = trackOrders(editor);
+
+		const id = editor.insertImageMarker();
+
+		// The visible numbers must stay canonical 1..k in reading order, and the
+		// returned id must be the FINAL number: the owner registers its payload
+		// under that id, so returning the insertion counter here mispairs every
+		// attachment after an out-of-order insert. The notification carries the
+		// PRE-renumber ids (id 2 inserted in front of id 1) - the keys the owner's
+		// payloads currently sit under - matching removeImageMarker's survivor
+		// contract.
+		assert.strictEqual(editor.getText(), "[Image #1][Image #2]");
+		assert.strictEqual(id, 1);
+		assert.deepStrictEqual(orders, [[2, 1]]);
+	});
+
+	it("canonicalizes the numbering after a setText prune leaves a gap", () => {
+		const editor = createEditor();
+		editor.insertImageMarker();
+		editor.insertImageMarker();
+		const orders = trackOrders(editor);
+
+		editor.setText("tail [Image #2]");
+
+		// Only id 2 survived the prune; it must display as [Image #1] so the
+		// Nth marker in reading order still equals the Nth submitted image.
+		assert.strictEqual(editor.getText(), "tail [Image #1]");
+		assert.deepStrictEqual(orders.at(-1), [2]);
+	});
+
+	it("restores the owner's attachment payloads when undoing a marker delete", () => {
+		const editor = createEditor();
+		const payloads = new Map<number, string>();
+		const restored: Map<number, string>[] = [];
+		editor.snapshotAttachmentState = () => new Map(payloads);
+		editor.restoreAttachmentState = (state) => {
+			restored.push(state as Map<number, string>);
+		};
+
+		editor.insertImageMarker();
+		payloads.set(1, "A");
+		editor.insertImageMarker();
+		payloads.set(2, "B");
+		editor.insertImageMarker();
+		payloads.set(3, "C");
+		editor.handleInput(ARROW_LEFT);
+		editor.handleInput(BACKSPACE);
+		assert.strictEqual(editor.getText(), "[Image #1][Image #2]");
+
+		editor.handleInput(UNDO);
+
+		// The editor's undo restores marker text and registry ids; the PAYLOADS
+		// live with the owner, so undo must hand the captured snapshot back
+		// BEFORE the marker-order notification fires, or the delete's re-keying
+		// permanently destroys the middle image.
+		assert.strictEqual(editor.getText(), "[Image #1][Image #2][Image #3]");
+		const last = restored.at(-1);
+		assert.ok(last);
+		assert.deepStrictEqual(
+			[...last.entries()],
+			[
+				[1, "A"],
+				[2, "B"],
+				[3, "C"],
+			],
+		);
+	});
+
 	it("deletes the whole marker with a single backspace", () => {
 		const editor = createEditor();
 		type(editor, "a ");


### PR DESCRIPTION
## Summary

Pasting **two** images in one turn shipped the model `[Image #1][Image #2]` as text with only **one** (or zero) image payload attached. The second paste was silently destroyed, and related flows (paste before an existing marker, delete+undo of a marker) mispaired or dropped payloads. This PR fixes the alignment between the editor's atomic `[Image #N]` markers and the owner's pending-payload map across every path that can renumber or rewind them.

## The defect: four cooperating sites

The bug needed all four of these to be true at once:

1. **`insertImageMarker()` notifies synchronously.** It fires `onImageMarkersChanged` (with the pre-renumber ids) *before* returning the marker's final id, so the owner's reconcile pass runs while the paste call is still on the stack.
2. **`reconcilePendingImages()` swapped Map identity.** It built a fresh `Map` and reassigned the `pendingImages` field. But `handleClipboardPaste` hands `this.pendingImages` **by reference** into `attachClipboardImage`'s deps — so on the second paste in a turn the reconciler replaced the map first and the subsequent `pendingImages.set(id, ...)` wrote into the orphaned map. The image never reached the submit path.
3. **`EditorSnapshot` never captured payloads.** The image payloads live with the owner, not the editor registry; undo after a whole-marker delete revived `[Image #N]` with no (or the wrong) payload behind it.
4. **`followUp` consumed the queue before compaction.** A submission carrying images, queued (Alt+Enter) while compaction was running, was delivered through the text-only compaction queue and its images were silently lost — the paste-time contract ("a compaction drop is never silent") had no submit-time counterpart.

There was also a numbering hole underneath: `insertImageMarker()` inserted using the registry's insertion counter and never renumbered, so a paste landing **in front of** an earlier marker displayed `[Image #2][Image #1]`, and the owner's reconcile-by-position then mispaired or destroyed payloads.

## Why the prior tests could not catch it

The old "keeps marker numbering and the payload map aligned across two pastes" test was **unfalsifiable**: its fake editor's `insertImageMarker` never invoked `onImageMarkersChanged`, so the reconcile-before-set collision was structurally unreachable — it asserted `[1,2]` while the real editor yielded `[1]`. The reconciliation cases called `reconcilePendingImages` directly with hand-built maps, and "orders the array by READING ORDER" actually encoded `marker N != images[N-1]` as *intended* behavior.

## The fix

- **`reconcilePendingImages()` mutates in place** (clear + refill). No live caller can ever hold an orphaned reference, regardless of notification ordering.
- **`ImageMarkerRegistry.canonicalize()` is wired in** at both real callers — `insertImageMarker()` and the `setText()` prune path — and the marker's **final canonical id** is returned so the owner keys its payload under the number the user sees.
- **Paired `snapshotAttachmentState` / `restoreAttachmentState` hooks**: `pushUndoSnapshot()` captures the owner's payload map opaquely; `undo()` restores it *before* firing the marker-order notification so the reconcile pass maps the restored payloads. Cursor position survives the renumbering rewrite via marker-length deltas.
- **`queueCompactionSubmission()`** on both submit paths: an image-bearing submission queued during compaction is consumed with a *visible* drop status and its dead literal markers are stripped from the queued text.
- **Tests rewritten to be falsifiable**: a real `pi-tui` `Editor` (headless `ProcessTerminal`) wired to the real `attachClipboardImage` / `reconcilePendingImages` / submit path via `subscribeImageMarkers`, pinning the invariant (marker ↔ payload pairing) instead of the implementation.

## Verification

- Gates: root `tsc` 0 errors; `npm run check` idempotent across two runs; tui suite green; coding-agent suite (1005 files / 8259 tests) byte-identical across run 1 and run 2. See `GATE-root-tsc.txt`, `GATE-root-check-run1.txt`, `GATE-root-check-run2-idempotence.txt`, `GATE-tui-test.txt`, `GATE-coding-agent-test-run1.txt`, `GATE-coding-agent-test-run2.txt`.
- Regression proofs on `origin/main` before the fix: `RED-1-clipboard-paste-on-origin-main.txt`, `RED-2-image-submission-on-origin-main.txt`, `RED-3-tui-editor-image-marker-on-origin-main.txt`.
- Undo-payload restore proof (the B2 reproduction): `PROOF-blocker2-undo-payload-restore.txt` (33/33).
- **Manual QA on the real CLI** (real TUI in a pty, `ctrl+v` pastes from the real pasteboard, temp sandbox, `PI_OFFLINE=1`, faux openai-completions recorder, `~/.omo/agent/auth.json` sha256 unchanged, zero real tokens):
  - Case 1 — two in-order pastes, one submit: `wire-requests.jsonl` request 0 shows `content = [text, image_url, image_url]`; marker `#1` pairs with the first pasted bytes, `#2` with the second (`wire-case1-in-order.json`, `expected-clipboard-payloads.json`).
  - Case 2 — paste A, press Home, paste B: canonical `[Image #1][Image #2]` with the payloads following the renumbering (`#1` = the image now at the front) — `wire-case2-front-paste.json`.
  - Run summary: `QA-MANUAL-RESULTS.txt`, `manual-qa-summary.json`, `tui-transcript.log`.
- Changelog gate: `GATE-changelog.txt`.

## Notes

The evidence files above live under `local-ignore/qa-evidence/20260818-fix-pending-images-identity/` (gitignored by design; referenced by filename only).

Plan: .omo/plans/senpi-tui-image-attach.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image marker ↔ payload misalignment so every pasted image ships and resolves to the marker the user sees. Previously, pasting multiple images often sent “[Image #1][Image #2]” with one (or zero) images, pasting before an existing marker produced “[#2][#1]”, undo after deleting a marker revived text without its image, and submissions queued during compaction silently lost images. Now markers renumber to 1..k in reading order, the returned id matches the visible number, undo restores payloads, and compaction drops are visible.

- `tui` `Editor`: canonicalizes marker numbering on insert and after prune; `insertImageMarker()` returns the final canonical id; `onImageMarkersChanged` fires with pre-renumber ids; adds optional `snapshotAttachmentState`/`restoreAttachmentState` hooks so undo restores owner payloads; preserves cursor across renumbering.
- `coding-agent`: `reconcilePendingImages()` mutates the same `pendingImages` map (no orphaned references); wires the new attachment snapshot/restore hooks; `queueCompactionSubmission()` drops images visibly and strips dead markers when queuing during compaction; submit paths call it.
- Tests: rewrite to drive a real `pi-tui` `Editor`; add TUI tests for out-of-order inserts, post-prune renumbering, and delete+undo payload restore.

**Migration notes**
- If you implement a custom `EditorComponent` with image markers: return the final canonical id from `insertImageMarker()`, renumber visible markers to 1..k in reading order, fire `onImageMarkersChanged` with pre-renumber ids, and implement `snapshotAttachmentState`/`restoreAttachmentState` so undo restores attachments.
- Update any editor mocks/fakes in tests to emit `onImageMarkersChanged` and to return the canonical id from `insertImageMarker()`.

<sup>Written for commit 483868422db6b1b1fb6ccafd95bd4fedf4a2ba23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

