### PR TITLE
feat(loop): port Claude Code's /loop into senpi as a builtin extension

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Added
 
+- `/loop`: recurring and self-paced scheduled prompts, ported from Claude Code as a fork-only builtin extension.
+  Fixed loops re-deliver a prompt or loop-file sentinel on an interval; dynamic loops pick their own next delay via
+  the new `schedule_wakeup` tool. Loops coalesce missed fires into one catch-up tick, cap at 5 active per session,
+  carry a 2000-tick budget and 7-day expiry, survive restarts (shutdown suspends, session resume re-arms), and show
+  a live countdown in the footer. `/loop stop|status|pause|resume` manage them.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -29,6 +29,32 @@
 - NONE: this tracker is fork-only (upstream has no counterpart file); the inventory names pin-relative paths so it
   stays valid as entries below change.
 
+## /loop builtin extension registered (2026-08-18)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/index.ts`: one registration entry adds the fork-only `/loop`
+  builtin extension (recurring and self-paced scheduled prompts, ported from Claude Code) to the builtin factory
+  list. The extension itself lives entirely under `builtin/loop/**`; its design is documented in
+  `builtin/loop/AGENTS.md`. Both paths are fork-only at pin `914cf1472e715297caa30db4b9535d534a9eb718` (upstream has
+  no `builtin/` registry file or loop tree), so the audit exempts them; this entry records the registration
+  divergence as feature history.
+
+### Why
+
+- The loop extension must be registered for every session like the other builtins (goal, todo, terminal), and the
+  registration list in `builtin/index.ts` is the only file outside `builtin/loop/**` this feature touches.
+
+### Why an extension could not handle it
+
+- It is an extension; builtin registration is the one hook the extension cannot provide for itself, and
+  `builtin/index.ts` is the only place builtins are wired into the loader.
+
+### Expected merge conflict zones
+
+- NONE: `builtin/index.ts` is fork-only (upstream has no counterpart file); the change is one import and one
+  factory-list entry on adjacent lines.
+
 ## /tui redraw diagnostic relocated in-tree (2026-08-17)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/index.ts
@@ -18,6 +18,7 @@ import hooksExtension from "./hooks/index.ts";
 import imageGenExtension from "./imagegen/index.ts";
 import importReproExtension from "./import-repro.ts";
 import lookAtExtension from "./look-at/index.ts";
+import loopExtension from "./loop/index.ts";
 import loopGuardExtension from "./loop-guard/index.ts";
 import mcpExtension from "./mcp/index.ts";
 import modelFallbackExtension from "./model-fallback/index.ts";
@@ -93,6 +94,7 @@ export const builtinExtensions: BuiltinExtensionFactory[] = [
 	{ id: "nested-agents-md", factory: nestedAgentsMdExtension },
 	{ id: "rules", factory: piRulesExtension },
 	{ id: "goal", factory: goalExtension },
+	{ id: "loop", factory: loopExtension },
 	{ id: "cache-keepalive", factory: cacheKeepAliveExtension },
 	{ id: "ttsr", factory: ttsrExtension },
 	{ id: "btw", factory: btwExtension },

--- a/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
@@ -1,0 +1,98 @@
+# builtin/loop
+
+Fork-only builtin extension porting Claude Code's `/loop`: recurring (fixed-interval)
+and self-paced (dynamic) scheduled prompts inside one session. A loop re-delivers a
+prompt or a loop-file sentinel on a cadence; dynamic loops pick their own next delay
+through the `schedule_wakeup` tool. Everything ships in this directory plus one
+registration line in `builtin/index.ts`.
+
+## FILES
+
+```
+loop/
+├── index.ts        # Extension entry: real timers, store wiring, tick dispatch, lifecycle
+├── command.ts      # /loop command registration: routes parsed invocations to the scheduler
+├── types.ts        # Single type home: LoopState, CronEntry, lifecycle, payloads, sentinels
+├── store.ts        # Atomic versioned per-session sidecar (temp file + rename, fail closed)
+├── parse.ts        # Pure /loop argument grammar (subcommands, interval forms, prompt)
+├── cron-planner.ts # normalizeInterval / describeCron / computeNextFireAt (pure)
+├── loopfile.ts     # Loop-file resolution + content fingerprint (injected fs)
+├── tick-prompt.ts  # buildTickMessage: sentinel expansion, full-vs-reminder decision (pure)
+├── tools.ts        # schedule_wakeup: the only model-callable surface (flat TypeBox schema)
+├── scheduler.ts    # Pure state machine: arm/fire/settle/pause/resume/stop/suspend/restore
+└── status.ts       # Footer presenter: formatLoopStatus + 1s LoopStatusTicker
+```
+
+## PURITY SEAM
+
+`scheduler.ts`, `parse.ts`, `cron-planner.ts`, `tick-prompt.ts`, and `status.ts`
+(formatting) are pure. The scheduler never calls `Date.now` or `setTimeout`: a
+`LoopClock` supplies `now` and a `LoopTimerPort` owns the single armed timeout per loop,
+both injected by `index.ts`. `loopfile.ts` takes an injected `fs`/`path`/`cwd` bundle.
+Only `index.ts` and `store.ts` touch the real world (timers, disk, extension events,
+message dispatch). Every scheduling invariant is therefore testable with a fake clock and
+zero real waiting. `types.ts` is the canonical type home; other modules re-export from it
+rather than redeclaring.
+
+## PERSISTENCE
+
+`store.ts` mirrors the goal store's discipline: one sidecar file per session, strict
+`version: 1` validation, atomic write via temp file + rename, and a promise tail
+serializing every mutation so command, timer, tool, and lifecycle writes cannot
+interleave. It FAILS CLOSED: unparseable or wrong-version state returns a typed error,
+arms nothing, and never silently resets. Session custom entries are deliberately not the
+authoritative store (a globally scanned "latest" entry can come from an abandoned
+branch); the `loop-tick` entry exists only for attribution and noop folding.
+
+## SCHEDULING INVARIANTS
+
+- Coalescing: at most ONE queued or running tick per loop. A fire that lands while one
+  is in flight sets `coalescedFirePending` instead of enqueuing a second delivery, so a
+  sleeping laptop or a long turn never produces a tick storm. `nextFireAt` is always
+  recomputed from `now`, never from the stale due time, so missed occurrences collapse
+  into exactly one catch-up tick.
+- 5-loop cap: at most `MAX_ACTIVE_LOOPS` (5) active loops per session; a further
+  creation returns a typed rejection and leaves existing loops armed.
+- Max-ticks valve: each loop carries a dispatched-tick budget (`DEFAULT_MAX_TICKS`,
+  2000); exhausting it ends the loop with `tick_budget_exhausted` so a forgotten fast
+  loop cannot spend without bound.
+- Expiry: loops live at most 7 days from `createdAt`, checked at arm, fire, re-entry,
+  and restore; a new wakeup never extends it.
+- Keepalive: a two-strike device on dynamic loops only. When an attributed dynamic
+  iteration ends without calling `schedule_wakeup`, the first omission burns one
+  keepalive credit and arms a fallback wakeup (`SENPI_LOOP_KEEPALIVE_SECONDS`, default
+  1200s, clamped 60-3600); the second consecutive omission ends the loop with
+  `keepalive_exhausted`. Keepalive never applies after an ordinary user turn, and a user
+  abort PAUSES the loop rather than ending it or counting as an omission.
+- Provider/turn errors are never terminal for a loop.
+
+## TICK DELIVERY
+
+A tick never steers. When the session is idle, `index.ts` dispatches through
+`sendUserMessage` with `expandPromptTemplates: true` so a slash payload reaches the real
+command path; a busy session receives the tick as a follow-up. Sentinel payloads (the
+four `<<...>>` loop/loop-file forms) follow a cache-friendly full-vs-reminder rule: the
+long instruction block is delivered once as an anchor, and later ticks send a short
+reminder pointing back at that anchored delivery, keeping the cached message prefix
+stable. A changed loop-file fingerprint (content hash from `loopfile.ts`) re-anchors
+with a fresh full delivery. Verbatim `prompt` payloads are always sent as-is.
+
+## LIFECYCLE
+
+Shutdown SUSPENDS, it never terminates: every senpi shutdown reason
+(`quit|reload|new|resume|fork`) leaves the session resumable, so `onShutdown` cancels
+timers, disposes the status ticker, and persists the snapshot without a terminal reason.
+There is deliberately no `session_closed` end reason in `LoopEndReason`; the terminal
+reasons are exactly `stopped | keepalive_exhausted | expired | tick_budget_exhausted |
+error`. `restore` re-arms suspended loops on the next session start, re-checking expiry.
+A store failure is not swallowed: affected loops end with `error` and the user is told,
+because a schedule that cannot be persisted must not keep running.
+
+## MODEL SURFACE
+
+`schedule_wakeup` (`tools.ts`) is the only model-callable surface. Its TypeBox schema is
+a flat object with no root union (several provider conversions rebuild schemas from
+top-level `properties`, so a root `anyOf` would arrive empty; same reasoning as
+`terminal/tools/monitor.ts`), and `delaySeconds` carries no schema bounds because the
+executor clamps out-of-range integers (60-3600s) instead of rejecting them. All effects
+go through an injected scheduler port; the tool mutates no state directly.

--- a/packages/coding-agent/src/core/extensions/builtin/loop/command-registration.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/command-registration.ts
@@ -1,0 +1,21 @@
+/**
+ * `/loop` command registration: metadata, argument hint, and subcommand completions.
+ */
+
+import type { ExtensionAPI } from "../../types.ts";
+import {
+	completeLoopArguments,
+	LOOP_ARGUMENT_HINT,
+	LOOP_COMMAND_DESCRIPTION,
+	type LoopCommandDeps,
+	runLoopCommand,
+} from "./command.ts";
+
+export function registerLoopCommand(pi: ExtensionAPI, deps: LoopCommandDeps): void {
+	pi.registerCommand("loop", {
+		description: LOOP_COMMAND_DESCRIPTION,
+		argumentHint: LOOP_ARGUMENT_HINT,
+		getArgumentCompletions: completeLoopArguments,
+		handler: (rawArgs, ctx) => runLoopCommand(rawArgs, ctx, deps),
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/command.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/command.ts
@@ -245,6 +245,10 @@ export async function runLoopCommand(
 ): Promise<void> {
 	if (isHeadlessMode(ctx.mode)) {
 		ctx.ui.notify(LOOP_HEADLESS_REJECTION, "warning");
+		// Headless hosts install a no-op UI context, so `notify` alone leaves the refusal
+		// invisible (empty output, exit 0). Write to stderr as well so the message is actually
+		// seen; real stdout stays reserved for `-p` result data.
+		process.stderr.write(`${LOOP_HEADLESS_REJECTION}\n`);
 		return;
 	}
 

--- a/packages/coding-agent/src/core/extensions/builtin/loop/command.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/command.ts
@@ -1,0 +1,318 @@
+/**
+ * `/loop` command handler: native argument parsing and the user-facing surfaces.
+ *
+ * Parsing is pure native code (`parse.ts`) - the command never expands into a
+ * model-facing parsing prompt. Starting a loop always goes through the extension's
+ * controller, which persists and arms the schedule BEFORE dispatching the first tick,
+ * so a failed first turn can never silently lose the job.
+ *
+ * Headless rejection: print/json modes have no interactive session, so the command
+ * refuses with a one-line message and arms nothing.
+ */
+
+import type { ExtensionCommandContext } from "../../types.ts";
+import type { LoopController, LoopCreateOk } from "./index.ts";
+import { type LoopTarget, parseLoopArgs } from "./parse.ts";
+import type { CronEntry, LoopId, LoopState } from "./types.ts";
+
+export const LOOP_ARGUMENT_HINT = "[interval] [prompt] | stop [id|all] | status | pause | resume";
+export const LOOP_COMMAND_DESCRIPTION =
+	"Repeat a prompt on a fixed interval or a self-paced schedule (e.g. /loop 5m check the deploy)";
+
+const LOOP_SUBCOMMANDS = ["stop", "status", "pause", "resume"] as const;
+
+const LOOP_HEADLESS_REJECTION =
+	"/loop needs an interactive session; it is not available in print mode, so nothing was armed.";
+
+export interface LoopCommandDeps {
+	readonly controller: LoopController;
+}
+
+/** Headless modes: single-shot output streams with no interactive transcript. */
+function isHeadlessMode(mode: ExtensionCommandContext["mode"]): boolean {
+	return mode === "print" || mode === "json";
+}
+
+/**
+ * Argument completions for the subcommand keywords, modeled on the todo extension's
+ * verb completions: prefix-filtered, `null` when nothing matches.
+ */
+export function completeLoopArguments(argumentPrefix: string): Array<{ value: string; label: string }> | null {
+	const prefix = argumentPrefix.trim().toLowerCase();
+	const matches = LOOP_SUBCOMMANDS.filter((subcommand) => subcommand.startsWith(prefix));
+	if (matches.length === 0) return null;
+	return matches.map((subcommand) => ({ value: subcommand, label: subcommand }));
+}
+
+function formatExpiry(expiresAt: number | undefined): string {
+	return expiresAt === undefined ? "after 7 days" : new Date(expiresAt).toISOString();
+}
+
+/** Fixed-loop confirmation: id, cron, effective cadence, rounding notice, expiry, stop command. */
+export function formatFixedLoopConfirmation(outcome: LoopCreateOk, requestedRaw: string): string {
+	const cadence = outcome.effectiveCadence ?? "on schedule";
+	const parenthetical =
+		outcome.roundingNotice === undefined ? `every ${cadence}` : `every ${cadence}; requested ${requestedRaw}`;
+	const lines = [`Loop ${outcome.loopId} scheduled as \`${outcome.cronExpression ?? ""}\` (${parenthetical}).`];
+	if (outcome.roundingNotice !== undefined) lines.push(outcome.roundingNotice);
+	lines.push(`It expires automatically at ${formatExpiry(outcome.expiresAt)} (7 days).`);
+	lines.push(`Stop it with \`/loop stop ${outcome.loopId}\`.`);
+	lines.push("Running the first tick now.");
+	return lines.join("\n");
+}
+
+/** Dynamic-loop confirmation, including the supersession line when one replaced another. */
+export function formatDynamicLoopConfirmation(outcome: LoopCreateOk): string {
+	const lines = [
+		`Loop ${outcome.loopId} started in dynamic mode: the model paces each iteration with \`schedule_wakeup\`.`,
+	];
+	if (outcome.supersededLoopId !== undefined) lines.push(`Superseded dynamic loop ${outcome.supersededLoopId}.`);
+	lines.push(`It expires automatically at ${formatExpiry(outcome.expiresAt)} (7 days).`);
+	lines.push(`Stop it with \`/loop stop ${outcome.loopId}\` or a \`schedule_wakeup\` call with \`{ stop: true }\`.`);
+	lines.push("Running the first iteration now.");
+	return lines.join("\n");
+}
+
+/** Bare-invocation confirmation; the mode comes from the entry the controller created. */
+export function formatBareLoopConfirmation(outcome: LoopCreateOk, entry: CronEntry | undefined): string {
+	const mode = entry?.kind === "fixed" ? `fixed, every ${entry.effectiveInterval.human}` : "dynamic pacing";
+	const lines = [`Loop ${outcome.loopId} started (${mode}).`];
+	lines.push(`It expires automatically at ${formatExpiry(outcome.expiresAt)} (7 days).`);
+	lines.push(`Stop it with \`/loop stop ${outcome.loopId}\`.`);
+	lines.push("Running the first tick now.");
+	return lines.join("\n");
+}
+
+function describeLoopEntry(entry: CronEntry): string {
+	const mode =
+		entry.kind === "fixed"
+			? `fixed, \`${entry.cronExpression}\` (every ${entry.effectiveInterval.human})`
+			: "dynamic";
+	const paused = entry.phase === "suspended" ? " · paused" : "";
+	return `- ${entry.id} (${mode}) · expires ${formatExpiry(entry.expiresAt)}${paused}`;
+}
+
+/**
+ * The `/loop status` listing: the live status line (countdown + stop affordance) plus
+ * one row per active loop.
+ */
+export function formatLoopStatusListing(statusLine: string | undefined, state: LoopState): string {
+	const active = Object.values(state.entries).filter((entry) => entry.phase !== "ended");
+	if (active.length === 0) return "No active loops.";
+	const lines = statusLine === undefined ? [] : [statusLine];
+	lines.push("Active loops:");
+	for (const entry of active) lines.push(describeLoopEntry(entry));
+	return lines.join("\n");
+}
+
+function activeLoopIds(state: LoopState): readonly LoopId[] {
+	return Object.values(state.entries)
+		.filter((entry) => entry.phase !== "ended")
+		.map((entry) => entry.id);
+}
+
+type TargetResolution =
+	| { readonly action: "apply"; readonly value: LoopId | "all" }
+	| { readonly action: "none" }
+	| { readonly action: "ambiguous"; readonly ids: readonly LoopId[] };
+
+/**
+ * Resolves a stop/pause/resume target. An implicit target names the single active loop;
+ * with several armed loops the command must not guess, so it asks for disambiguation.
+ */
+function resolveCommandTarget(target: LoopTarget, state: LoopState): TargetResolution {
+	if (target.type === "all") return { action: "apply", value: "all" };
+	if (target.type === "id") return { action: "apply", value: target.id };
+	const ids = activeLoopIds(state);
+	if (ids.length === 0) return { action: "none" };
+	if (ids.length === 1) return { action: "apply", value: ids[0] };
+	return { action: "ambiguous", ids };
+}
+
+function notifyAmbiguous(
+	ctx: ExtensionCommandContext,
+	verb: "stop" | "pause" | "resume",
+	ids: readonly LoopId[],
+): void {
+	const lines = ["Multiple loops are active:", ...ids.map((id) => `- ${id}`)];
+	lines.push(`Use \`/loop ${verb} <id>\` or \`/loop ${verb} all\`.`);
+	ctx.ui.notify(lines.join("\n"), "warning");
+}
+
+function notifyUnknownId(ctx: ExtensionCommandContext, id: string, state: LoopState): void {
+	const ids = activeLoopIds(state);
+	const lines = [`No active loop with id "${id}".`];
+	if (ids.length > 0) lines.push(`Active loops: ${ids.join(", ")}.`);
+	ctx.ui.notify(lines.join("\n"), "warning");
+}
+
+async function runStop(ctx: ExtensionCommandContext, deps: LoopCommandDeps, target: LoopTarget): Promise<void> {
+	const resolution = resolveCommandTarget(target, deps.controller.getState());
+	if (resolution.action === "none") {
+		ctx.ui.notify("No active loops.", "warning");
+		return;
+	}
+	if (resolution.action === "ambiguous") {
+		notifyAmbiguous(ctx, "stop", resolution.ids);
+		return;
+	}
+	const affected = await deps.controller.stop(resolution.value, "user-stop");
+	if (resolution.value === "all") {
+		if (affected.length === 0) {
+			ctx.ui.notify("No active loops.", "warning");
+			return;
+		}
+		const noun = affected.length === 1 ? "loop" : "loops";
+		ctx.ui.notify(`Stopped ${affected.length} ${noun}: ${affected.join(", ")}.`, "info");
+		return;
+	}
+	if (affected.length === 0) {
+		notifyUnknownId(ctx, resolution.value, deps.controller.getState());
+		return;
+	}
+	ctx.ui.notify(`Stopped loop ${resolution.value}.`, "info");
+}
+
+async function runPause(ctx: ExtensionCommandContext, deps: LoopCommandDeps, target: LoopTarget): Promise<void> {
+	const resolution = resolveCommandTarget(target, deps.controller.getState());
+	if (resolution.action === "none") {
+		ctx.ui.notify("No active loops.", "warning");
+		return;
+	}
+	if (resolution.action === "ambiguous") {
+		notifyAmbiguous(ctx, "pause", resolution.ids);
+		return;
+	}
+	const affected = await deps.controller.pause(resolution.value);
+	if (resolution.value === "all") {
+		if (affected.length === 0) {
+			ctx.ui.notify("No pausable loops.", "warning");
+			return;
+		}
+		const noun = affected.length === 1 ? "loop" : "loops";
+		ctx.ui.notify(`Paused ${affected.length} ${noun}: ${affected.join(", ")}.`, "info");
+		return;
+	}
+	if (affected.length === 0) {
+		ctx.ui.notify(`Loop ${resolution.value} is not pausable (already paused or ended).`, "warning");
+		return;
+	}
+	ctx.ui.notify(`Paused loop ${resolution.value}.`, "info");
+}
+
+async function runResume(ctx: ExtensionCommandContext, deps: LoopCommandDeps, target: LoopTarget): Promise<void> {
+	const resolution = resolveCommandTarget(target, deps.controller.getState());
+	if (resolution.action === "none") {
+		ctx.ui.notify("No active loops.", "warning");
+		return;
+	}
+	if (resolution.action === "ambiguous") {
+		notifyAmbiguous(ctx, "resume", resolution.ids);
+		return;
+	}
+	const affected = await deps.controller.resume(resolution.value);
+	if (resolution.value === "all") {
+		if (affected.length === 0) {
+			ctx.ui.notify("No paused loops to resume.", "warning");
+			return;
+		}
+		const noun = affected.length === 1 ? "loop" : "loops";
+		ctx.ui.notify(`Resumed ${affected.length} ${noun}: ${affected.join(", ")}.`, "info");
+		return;
+	}
+	if (affected.length === 0) {
+		ctx.ui.notify(`Loop ${resolution.value} is not paused.`, "warning");
+		return;
+	}
+	ctx.ui.notify(`Resumed loop ${resolution.value}.`, "info");
+}
+
+async function reportCreateOutcome(
+	ctx: ExtensionCommandContext,
+	deps: LoopCommandDeps,
+	outcome: LoopCreateOk,
+	format: (entry: CronEntry | undefined) => string,
+): Promise<void> {
+	const entry = deps.controller.getState().entries[outcome.loopId];
+	ctx.ui.notify(format(entry), "info");
+}
+
+/** The `/loop` command entry point. */
+export async function runLoopCommand(
+	rawArgs: string,
+	ctx: ExtensionCommandContext,
+	deps: LoopCommandDeps,
+): Promise<void> {
+	if (isHeadlessMode(ctx.mode)) {
+		ctx.ui.notify(LOOP_HEADLESS_REJECTION, "warning");
+		return;
+	}
+
+	const parsed = parseLoopArgs(rawArgs);
+	try {
+		switch (parsed.kind) {
+			case "invalid": {
+				ctx.ui.notify(parsed.usage, "warning");
+				return;
+			}
+			case "fixed": {
+				const outcome = await deps.controller.startFixed({
+					originalArgs: parsed.originalArgs,
+					prompt: parsed.prompt,
+					requestedInterval: parsed.interval,
+				});
+				if (!outcome.ok) {
+					ctx.ui.notify(outcome.message, "error");
+					return;
+				}
+				await reportCreateOutcome(ctx, deps, outcome, () =>
+					formatFixedLoopConfirmation(outcome, parsed.interval.raw),
+				);
+				return;
+			}
+			case "dynamic": {
+				const outcome = await deps.controller.startDynamic({
+					originalArgs: parsed.originalArgs,
+					prompt: parsed.prompt,
+				});
+				if (!outcome.ok) {
+					ctx.ui.notify(outcome.message, "error");
+					return;
+				}
+				await reportCreateOutcome(ctx, deps, outcome, () => formatDynamicLoopConfirmation(outcome));
+				return;
+			}
+			case "bare": {
+				const outcome = await deps.controller.startBare({
+					originalArgs: parsed.originalArgs,
+					...(parsed.interval === undefined ? {} : { interval: parsed.interval }),
+				});
+				if (!outcome.ok) {
+					ctx.ui.notify(outcome.message, "error");
+					return;
+				}
+				await reportCreateOutcome(ctx, deps, outcome, (entry) => formatBareLoopConfirmation(outcome, entry));
+				return;
+			}
+			case "stop": {
+				await runStop(ctx, deps, parsed.target);
+				return;
+			}
+			case "pause": {
+				await runPause(ctx, deps, parsed.target);
+				return;
+			}
+			case "resume": {
+				await runResume(ctx, deps, parsed.target);
+				return;
+			}
+			case "status": {
+				ctx.ui.notify(formatLoopStatusListing(deps.controller.statusLine(), deps.controller.getState()), "info");
+				return;
+			}
+		}
+	} catch (error) {
+		// A failed command must surface, not vanish: notify and stop.
+		ctx.ui.notify(`/loop command failed: ${error instanceof Error ? error.message : String(error)}`, "error");
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/cron-planner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/cron-planner.ts
@@ -19,9 +19,7 @@ function pluralize(count: number, singular: string, plural: string): string {
  * rounding. Whenever the effective value differs from the request, the result
  * carries a notice naming both the requested and effective cadence.
  */
-export function normalizeInterval(
-	requested: RequestedInterval,
-): EffectiveInterval & { intervalMs: number } {
+export function normalizeInterval(requested: RequestedInterval): EffectiveInterval & { intervalMs: number } {
 	let value: number;
 	let unit: EffectiveIntervalUnit;
 	let rounded: boolean;
@@ -72,12 +70,9 @@ export function normalizeInterval(
 				? pluralize(value, "hour", "hours")
 				: pluralize(value, "day", "days");
 
-	const intervalMs =
-		unit === "m" ? value * MS_PER_MINUTE : unit === "h" ? value * MS_PER_HOUR : value * MS_PER_DAY;
+	const intervalMs = unit === "m" ? value * MS_PER_MINUTE : unit === "h" ? value * MS_PER_HOUR : value * MS_PER_DAY;
 
-	const roundingNotice = rounded
-		? `Requested ${requested.raw} rounds to ${human}.`
-		: undefined;
+	const roundingNotice = rounded ? `Requested ${requested.raw} rounds to ${human}.` : undefined;
 
 	return { value, unit, human, rounded, roundingNotice, intervalMs };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/loop/cron-planner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/cron-planner.ts
@@ -1,16 +1,8 @@
-export interface RequestedInterval {
-	readonly value: number;
-	readonly unit: "s" | "m" | "h" | "d";
-	readonly raw: string;
-}
+import type { EffectiveInterval, EffectiveIntervalUnit, RequestedInterval } from "./types.ts";
 
-export interface EffectiveInterval {
-	readonly value: number;
-	readonly unit: "m" | "h" | "d";
-	readonly human: string;
-	readonly rounded: boolean;
-	readonly roundingNotice?: string;
-}
+// `types.ts` is the single type home for the whole extension; these are re-exported so
+// existing consumers of the planner keep importing the canonical declarations.
+export type { EffectiveInterval, RequestedInterval };
 
 const MS_PER_MINUTE = 60_000;
 const MS_PER_HOUR = 60 * MS_PER_MINUTE;
@@ -31,7 +23,7 @@ export function normalizeInterval(
 	requested: RequestedInterval,
 ): EffectiveInterval & { intervalMs: number } {
 	let value: number;
-	let unit: "m" | "h" | "d";
+	let unit: EffectiveIntervalUnit;
 	let rounded: boolean;
 
 	switch (requested.unit) {

--- a/packages/coding-agent/src/core/extensions/builtin/loop/cron-planner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/cron-planner.ts
@@ -1,0 +1,114 @@
+export interface RequestedInterval {
+	readonly value: number;
+	readonly unit: "s" | "m" | "h" | "d";
+	readonly raw: string;
+}
+
+export interface EffectiveInterval {
+	readonly value: number;
+	readonly unit: "m" | "h" | "d";
+	readonly human: string;
+	readonly rounded: boolean;
+	readonly roundingNotice?: string;
+}
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+function pluralize(count: number, singular: string, plural: string): string {
+	return count === 1 ? `${count} ${singular}` : `${count} ${plural}`;
+}
+
+/**
+ * Converts a user-requested interval into an effective cadence the scheduler
+ * can express with the restricted display cron forms. Seconds are coarsened to
+ * minutes; large minute/hour values roll up to hours/days with half-up
+ * rounding. Whenever the effective value differs from the request, the result
+ * carries a notice naming both the requested and effective cadence.
+ */
+export function normalizeInterval(
+	requested: RequestedInterval,
+): EffectiveInterval & { intervalMs: number } {
+	let value: number;
+	let unit: "m" | "h" | "d";
+	let rounded: boolean;
+
+	switch (requested.unit) {
+		case "s": {
+			value = Math.max(1, Math.ceil(requested.value / 60));
+			unit = "m";
+			rounded = true;
+			break;
+		}
+		case "m": {
+			if (requested.value >= 60) {
+				value = Math.round(requested.value / 60);
+				unit = "h";
+				rounded = true;
+			} else {
+				value = requested.value;
+				unit = "m";
+				rounded = false;
+			}
+			break;
+		}
+		case "h": {
+			if (requested.value >= 24) {
+				value = Math.round(requested.value / 24);
+				unit = "d";
+				rounded = true;
+			} else {
+				value = requested.value;
+				unit = "h";
+				rounded = false;
+			}
+			break;
+		}
+		case "d": {
+			value = requested.value;
+			unit = "d";
+			rounded = false;
+			break;
+		}
+	}
+
+	const human =
+		unit === "m"
+			? pluralize(value, "minute", "minutes")
+			: unit === "h"
+				? pluralize(value, "hour", "hours")
+				: pluralize(value, "day", "days");
+
+	const intervalMs =
+		unit === "m" ? value * MS_PER_MINUTE : unit === "h" ? value * MS_PER_HOUR : value * MS_PER_DAY;
+
+	const roundingNotice = rounded
+		? `Requested ${requested.raw} rounds to ${human}.`
+		: undefined;
+
+	return { value, unit, human, rounded, roundingNotice, intervalMs };
+}
+
+/**
+ * Returns a restricted 5-field cron expression for DISPLAY ONLY. The scheduler
+ * uses intervalMs + absolute nextFireAt; this string is shown to the user.
+ */
+export function describeCron(effective: Pick<EffectiveInterval, "value" | "unit">): string {
+	switch (effective.unit) {
+		case "m":
+			return `*/${effective.value} * * * *`;
+		case "h":
+			return `0 */${effective.value} * * *`;
+		case "d":
+			return `0 0 */${effective.value} * *`;
+	}
+}
+
+/**
+ * Computes the absolute timestamp of the next scheduled fire. Pure: takes
+ * nowMs as a parameter and never reads the clock internally.
+ */
+export function computeNextFireAt(nowMs: number, intervalMs: number): number {
+	return nowMs + intervalMs;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
@@ -1,0 +1,879 @@
+/**
+ * `/loop` extension factory and lifecycle wiring.
+ *
+ * This module owns the only impure parts of the feature: real timers, the session store,
+ * the extension event wiring, and message dispatch. Every decision it makes is delegated
+ * to the pure modules beside it (`scheduler.ts`, `tick-prompt.ts`, `cron-planner.ts`,
+ * `loopfile.ts`, `status.ts`), so the runtime here is a thin, testable adapter.
+ *
+ * Load-bearing rules implemented here:
+ * - A tick NEVER steers. Idle dispatch goes through `sendUserMessage(..., {
+ *   expandPromptTemplates: true })` so a slash payload reaches the real command path;
+ *   a busy session receives the tick as a follow-up instead.
+ * - Shutdown SUSPENDS: timers are cancelled, the ticker disposed, and the snapshot is
+ *   persisted without a terminal reason (every senpi shutdown reason is resumable).
+ * - Keepalive is applied only to an attributed dynamic iteration, never after an ordinary
+ *   user turn, and never after a user abort (an abort PAUSES the loop instead).
+ * - A store failure is not swallowed: the affected loops end with `error` and the user is
+ *   told, because a schedule that cannot be persisted must not keep running.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getAgentDir } from "../../../../config.ts";
+import type { SessionEntry } from "../../../session-manager.ts";
+import { noticeEntryRenderer } from "../../notice/index.ts";
+import type { EntryRenderer, ExtensionAPI, ExtensionContext, ExtensionFactory } from "../../types.ts";
+import { describeCron, normalizeInterval } from "./cron-planner.ts";
+import { type LoopFileResult, nodeFs, resolveLoopFile as resolveLoopFileDefault } from "./loopfile.ts";
+import {
+	createLoopScheduler,
+	type LoopClock,
+	type LoopIdFactory,
+	type LoopScheduler,
+	type LoopTick,
+	type LoopTimerPort,
+} from "./scheduler.ts";
+import { formatLoopStatus, formatNoopFold, LoopStatusTicker } from "./status.ts";
+import { readLoopState, writeLoopState } from "./store.ts";
+import { buildTickMessage, type LoopFileSnapshot, type LoopMode, type TickDelivery } from "./tick-prompt.ts";
+import { registerLoopTools, type ScheduleWakeupTarget } from "./tools.ts";
+import type {
+	CronEntry,
+	DeliveryId,
+	EpochMs,
+	LoopEndReason,
+	LoopId,
+	LoopPayload,
+	LoopSentinel,
+	LoopState,
+	LoopStoreRef,
+	RequestedInterval,
+	SentinelDeliveryState,
+} from "./types.ts";
+
+/** Custom entry type carrying one dispatched tick, used for attribution and folding. */
+export const LOOP_TICK_ENTRY_TYPE = "loop-tick";
+
+export interface LoopTickEntryData {
+	readonly loopId: LoopId;
+	readonly deliveryId: DeliveryId;
+	readonly scheduledForAt: EpochMs;
+	readonly mode: LoopMode;
+	readonly delivery: TickDelivery;
+	readonly sentinel?: LoopSentinel;
+	/** Consecutive quiet dynamic iterations at the moment this tick was dispatched. */
+	readonly noopStreak: number;
+	/** True when this tick continues a quiet streak and should render folded. */
+	readonly folded: boolean;
+}
+
+export interface LoopCreateOk {
+	readonly ok: true;
+	readonly loopId: LoopId;
+	/** Present when a new dynamic loop replaced a previous one. */
+	readonly supersededLoopId?: LoopId;
+	/** Human-readable rounding notice when the requested cadence was normalized. */
+	readonly roundingNotice?: string;
+	readonly cronExpression?: string;
+	readonly effectiveCadence?: string;
+	readonly expiresAt?: EpochMs;
+}
+
+export interface LoopCreateRejected {
+	readonly ok: false;
+	readonly message: string;
+}
+
+export type LoopCreateOutcome = LoopCreateOk | LoopCreateRejected;
+
+export interface LoopStoreFailure {
+	readonly endReason: LoopEndReason;
+	readonly message: string;
+	readonly loopIds: readonly LoopId[];
+}
+
+export interface StartFixedRequest {
+	readonly originalArgs: string;
+	readonly prompt: string;
+	readonly requestedInterval: RequestedInterval;
+}
+
+export interface StartDynamicRequest {
+	readonly originalArgs: string;
+	readonly prompt: string;
+}
+
+export interface StartBareRequest {
+	readonly originalArgs: string;
+	readonly interval?: RequestedInterval;
+}
+
+export interface ControllerScheduleWakeupRequest {
+	readonly loopId: LoopId;
+	readonly requestedDelaySeconds: number;
+	readonly delaySeconds: number;
+	readonly reason: string;
+	readonly prompt: string;
+	readonly noop: boolean;
+}
+
+/**
+ * Runtime surface of a live loop extension. The `/loop` command module drives the
+ * extension exclusively through this interface, so command parsing never reaches into
+ * scheduler or store internals.
+ */
+export interface LoopController {
+	startFixed(request: StartFixedRequest): Promise<LoopCreateOutcome>;
+	startDynamic(request: StartDynamicRequest): Promise<LoopCreateOutcome>;
+	startBare(request: StartBareRequest): Promise<LoopCreateOutcome>;
+	/** Runs the due decision for a loop at the current clock reading and dispatches it. */
+	fireDue(loopId: LoopId): Promise<void>;
+	scheduleWakeup(request: ControllerScheduleWakeupRequest): Promise<void>;
+	stop(target: LoopId | "all", detail: string): Promise<readonly LoopId[]>;
+	pause(target: LoopId | "all"): Promise<readonly LoopId[]>;
+	resume(target: LoopId | "all"): Promise<readonly LoopId[]>;
+	getState(): LoopState;
+	statusLine(): string | undefined;
+	/** Set when a store read/write failed and the affected loops were ended with `error`. */
+	lastStoreFailure(): LoopStoreFailure | undefined;
+	/** True when this loop was retired because its state could not be read or written. */
+	isEndedWithError(loopId: LoopId): boolean;
+}
+
+export interface LoopExtensionDeps {
+	readonly clock?: LoopClock;
+	/** Factory so each session gets its own timer port; defaults to real timeouts. */
+	readonly timers?: () => LoopTimerPort;
+	readonly ids?: LoopIdFactory;
+	readonly storeRef?: (ctx: ExtensionContext) => LoopStoreRef;
+	readonly resolveLoopFile?: (options: { cwd: string; homeDir: string }) => Promise<LoopFileResult>;
+	readonly readState?: (ref: LoopStoreRef) => Promise<LoopState | null>;
+	readonly writeState?: (ref: LoopStoreRef, state: LoopState) => Promise<void>;
+	/**
+	 * Published at factory time so a command module (or a test) can drive this instance.
+	 * The controller is bound to the extension's own session state, so it stays valid across
+	 * session starts within one extension generation.
+	 */
+	readonly onControllerReady?: (controller: LoopController) => void;
+}
+
+export const renderLoopTickEntry: EntryRenderer<LoopTickEntryData> = noticeEntryRenderer((entry) => {
+	const data = entry.data;
+	if (data === undefined) return undefined;
+	const folded = data.folded ? formatNoopFold(data.noopStreak) : "";
+	if (folded.length > 0) {
+		return {
+			title: folded,
+			why: "Consecutive loop ticks reported no actionable change.",
+		};
+	}
+	return {
+		title: `↻ loop tick (${data.mode}) · ${data.delivery}`,
+		why: "A /loop schedule dispatched this tick.",
+	};
+});
+
+/**
+ * Real timer port: exactly one live timeout per key, replaced on re-arm.
+ *
+ * Follows the generation-counter discipline of `cache-keepalive/index.ts`: cancelling or
+ * re-arming a key bumps its generation, so a callback whose generation is stale returns
+ * without firing even if it was already scheduled on the event loop.
+ */
+export function createNodeTimerPort(): LoopTimerPort {
+	const handles = new Map<string, ReturnType<typeof setTimeout>>();
+	const generations = new Map<string, number>();
+
+	function cancel(key: string): void {
+		const handle = handles.get(key);
+		if (handle !== undefined) clearTimeout(handle);
+		handles.delete(key);
+		generations.set(key, (generations.get(key) ?? 0) + 1);
+	}
+
+	return {
+		arm(key, dueAt, callback) {
+			cancel(key);
+			const generation = generations.get(key) ?? 0;
+			const delayMs = Math.max(0, dueAt - Date.now());
+			const handle = setTimeout(() => {
+				handles.delete(key);
+				if (generations.get(key) !== generation) return;
+				callback();
+			}, delayMs);
+			handle.unref?.();
+			handles.set(key, handle);
+		},
+		cancel,
+		cancelAll() {
+			for (const key of [...handles.keys()]) cancel(key);
+		},
+	};
+}
+
+function defaultIds(): LoopIdFactory {
+	let sequence = 0;
+	const mint = (prefix: string): string => {
+		sequence += 1;
+		return `${prefix}-${Date.now().toString(36)}-${sequence.toString(36)}`;
+	};
+	return {
+		loopId: () => mint("loop"),
+		wakeupId: () => mint("wakeup"),
+		deliveryId: () => mint("delivery"),
+	};
+}
+
+function defaultStoreRef(ctx: ExtensionContext): LoopStoreRef {
+	const sessionFile = ctx.sessionManager.getSessionFile();
+	const baseDir =
+		sessionFile === undefined
+			? join(getAgentDir(), "extensions", "loop", "no-session")
+			: join(ctx.sessionManager.getSessionDir(), "extensions", "loop");
+	return { baseDir, sessionId: ctx.sessionManager.getSessionId() };
+}
+
+function emptyDeliveryState(): SentinelDeliveryState {
+	return { autonomousPreambleDelivered: false, lastLoopFileDelivered: null, forceFullDelivery: false };
+}
+
+function loopFileSnapshot(result: LoopFileResult): LoopFileSnapshot {
+	if (!result.found) return { present: false };
+	return {
+		present: true,
+		path: result.path,
+		content: result.content,
+		mtimeMs: result.fingerprint.mtimeMs,
+		size: result.fingerprint.size,
+		contentHash: result.fingerprint.contentHash,
+	};
+}
+
+function sentinelFor(mode: LoopMode, loopFilePresent: boolean): LoopSentinel {
+	if (loopFilePresent) return mode === "fixed" ? "<<loop.md>>" : "<<loop.md-dynamic>>";
+	return mode === "fixed" ? "<<autonomous-loop>>" : "<<autonomous-loop-dynamic>>";
+}
+
+function modeOf(entry: CronEntry): LoopMode {
+	return entry.kind === "fixed" ? "fixed" : "dynamic";
+}
+
+interface AnchorPayload {
+	readonly loopId?: string;
+	readonly deliveryId?: string;
+}
+
+/** Reads the tick payload of a `loop-tick` entry, whichever entry kind carries it. */
+function anchorPayloadOf(entry: SessionEntry): AnchorPayload | undefined {
+	if (entry.type === "custom") {
+		return entry.customType === LOOP_TICK_ENTRY_TYPE ? (entry.data as AnchorPayload | undefined) : undefined;
+	}
+	if (entry.type === "custom_message") {
+		return entry.customType === LOOP_TICK_ENTRY_TYPE ? (entry.details as AnchorPayload | undefined) : undefined;
+	}
+	return undefined;
+}
+
+/**
+ * True when the compaction-aware context still contains the delivery that anchored a full
+ * sentinel block. Compaction can drop it, and a reminder's "established earlier in this
+ * conversation" phrasing must never dangle, so a missing anchor forces the next tick back
+ * to full. When no specific anchor id was recorded (the autonomous preamble carries none),
+ * any surviving tick delivery for that loop counts as the anchor.
+ */
+function anchorPresent(ctx: ExtensionContext, loopId: LoopId, deliveryId: DeliveryId | undefined): boolean {
+	return ctx.sessionManager.buildContextEntries().some((entry) => {
+		const payload = anchorPayloadOf(entry);
+		if (payload === undefined) return false;
+		if (payload.loopId !== undefined && payload.loopId !== loopId) return false;
+		return deliveryId === undefined ? true : payload.deliveryId === deliveryId;
+	});
+}
+
+export function createLoopExtension(deps: LoopExtensionDeps = {}): ExtensionFactory {
+	const clock: LoopClock = deps.clock ?? { now: () => Date.now() };
+	const makeTimers = deps.timers ?? createNodeTimerPort;
+	const ids = deps.ids ?? defaultIds();
+	const storeRefOf = deps.storeRef ?? defaultStoreRef;
+	const resolveLoopFile =
+		deps.resolveLoopFile ??
+		((options: { cwd: string; homeDir: string }) =>
+			resolveLoopFileDefault({ cwd: options.cwd, homeDir: options.homeDir, fs: nodeFs, path: { join } }));
+	const readState = deps.readState ?? readLoopState;
+	const writeState = deps.writeState ?? writeLoopState;
+
+	return (pi: ExtensionAPI) => {
+		let ctx: ExtensionContext | undefined;
+		let scheduler: LoopScheduler | undefined;
+		let storeRef: LoopStoreRef | undefined;
+		let timers: LoopTimerPort = makeTimers();
+		let storeFailure: LoopStoreFailure | undefined;
+		let sessionNamed = false;
+		/** Loop the currently running iteration is attributed to, for keepalive + tools. */
+		let attributedLoopId: LoopId | undefined;
+		/** Delivery id of the tick that started the attributed iteration. */
+		let attributedDeliveryId: DeliveryId | undefined;
+		/** True once the attributed iteration rescheduled or stopped itself. */
+		let attributionResolved = false;
+		/** Ticks held back because their slash payload cannot be queued while streaming. */
+		const deferredDispatches: LoopTick[] = [];
+		const deliveryStates = new Map<LoopId, SentinelDeliveryState>();
+		/** Loops retired with `error` because their state could not be read or written. */
+		const endedWithError = new Set<LoopId>();
+		/** True once this session has state worth persisting (loaded or created). */
+		let storeTouched = false;
+		let persistTail: Promise<void> = Promise.resolve();
+
+		const ticker = new LoopStatusTicker({
+			render: (key, text) => {
+				try {
+					ctx?.ui.setStatus(key, text);
+				} catch {
+					// A stale context after session replacement must not break the loop runtime.
+				}
+			},
+			now: () => clock.now(),
+		});
+
+		pi.registerEntryRenderer(LOOP_TICK_ENTRY_TYPE, renderLoopTickEntry);
+		registerLoopTools(pi, {
+			scheduler: {
+				getWakeupTarget: (): ScheduleWakeupTarget => {
+					if (scheduler === undefined || attributedLoopId === undefined) return null;
+					const entry = scheduler.getState().entries[attributedLoopId];
+					if (entry === undefined || entry.phase === "ended") return null;
+					return { kind: entry.kind, loopId: entry.id };
+				},
+				scheduleWakeup: async (request) => {
+					const active = requireScheduler();
+					const result = active.onScheduleWakeup(request);
+					if (!result.ok) throw new Error(`schedule_wakeup rejected: ${result.reason}`);
+					attributionResolved = true;
+					await persist();
+					refreshStatus();
+					return {
+						wakeupId: result.wakeupId,
+						...(result.replacedWakeupId === undefined ? {} : { replacedWakeupId: result.replacedWakeupId }),
+						dueAt: result.dueAt,
+						noopStreak: result.noopStreak,
+					};
+				},
+				stopDynamicLoop: async (request) => {
+					const active = requireScheduler();
+					active.stop(request.loopId, "model-stop");
+					attributionResolved = true;
+					await persist();
+					refreshStatus();
+					return { endedAt: clock.now() };
+				},
+			},
+		});
+
+		function requireScheduler(): LoopScheduler {
+			if (scheduler === undefined) throw new Error("loop extension has no active session");
+			return scheduler;
+		}
+
+		/** Merges extension-owned sentinel delivery state into the scheduler's snapshot. */
+		function withDeliveryOverlay(state: LoopState): LoopState {
+			const entries: Record<LoopId, CronEntry> = {};
+			for (const [id, entry] of Object.entries(state.entries)) {
+				const delivery = deliveryStates.get(id);
+				entries[id] = delivery === undefined ? entry : { ...entry, sentinelDelivery: delivery };
+			}
+			return { ...state, entries };
+		}
+
+		/** Serializes persistence so a timer, tool, and command write cannot interleave. */
+		function persist(): Promise<void> {
+			const ref = storeRef;
+			const active = scheduler;
+			if (ref === undefined || active === undefined) return Promise.resolve();
+			const snapshot = withDeliveryOverlay(active.getState());
+			// The extension is registered for every session, so a session that never ran a loop
+			// must not leave a sidecar behind.
+			if (!storeTouched && Object.keys(snapshot.entries).length === 0) return Promise.resolve();
+			storeTouched = true;
+			persistTail = persistTail.then(async () => {
+				try {
+					await writeState(ref, snapshot);
+				} catch (error) {
+					failStore(error, Object.keys(snapshot.entries));
+				}
+			});
+			return persistTail;
+		}
+
+		/**
+		 * A schedule that cannot be read or written must not keep running: end the affected
+		 * loops with `error` and tell the user, rather than silently losing the schedule. The
+		 * terminal record is kept in memory because the store that would hold it is exactly the
+		 * thing that just failed; what matters is that nothing stays armed and the user knows.
+		 */
+		function failStore(error: unknown, loopIds: readonly LoopId[]): void {
+			const message = error instanceof Error ? error.message : String(error);
+			timers.cancelAll();
+			for (const loopId of loopIds) endedWithError.add(loopId);
+			storeFailure = {
+				endReason: "error",
+				message,
+				loopIds,
+			};
+			ticker.dispose();
+			ctx?.ui.notify(`/loop state could not be used and the affected loops were ended: ${message}`, "error");
+		}
+
+		function refreshStatus(): void {
+			if (scheduler === undefined) return;
+			const state = scheduler.getState();
+			// The ticker owns a repeating render timer, so it only runs while a loop is armed;
+			// a session that never used /loop must not carry one.
+			if (Object.values(state.entries).every((entry) => entry.phase === "ended")) {
+				if (ticker.running) ticker.dispose();
+				return;
+			}
+			ticker.sync(state);
+		}
+
+		function deliveryStateOf(loopId: LoopId): SentinelDeliveryState {
+			return deliveryStates.get(loopId) ?? emptyDeliveryState();
+		}
+
+		function markForceFullDelivery(): void {
+			for (const [id, state] of deliveryStates) {
+				deliveryStates.set(id, { ...state, forceFullDelivery: true });
+			}
+			const active = scheduler;
+			if (active === undefined) return;
+			for (const entry of Object.values(active.getState().entries)) {
+				if (entry.phase === "ended") continue;
+				if (deliveryStates.has(entry.id)) continue;
+				deliveryStates.set(entry.id, { ...entry.sentinelDelivery, forceFullDelivery: true });
+			}
+		}
+
+		function isExtensionCommandPayload(text: string): boolean {
+			if (!text.startsWith("/")) return false;
+			const name = text.slice(1).split(/\s+/)[0];
+			return pi.getCommands().some((command) => command.name === name);
+		}
+
+		/**
+		 * Delivers one tick. Idle dispatch expands prompt templates so a slash payload
+		 * reaches its real command handler; a busy session gets a follow-up instead of
+		 * steering. A slash payload cannot be queued at all, so it waits for the turn to
+		 * settle rather than being rewritten into plain text.
+		 */
+		async function dispatchTick(tick: LoopTick): Promise<void> {
+			const active = requireScheduler();
+			const entry = active.getState().entries[tick.loopId];
+			if (entry === undefined || entry.phase === "ended") return;
+			if (endedWithError.has(tick.loopId)) return;
+			const currentCtx = ctx;
+			if (currentCtx === undefined) return;
+
+			const mode = modeOf(entry);
+			const loopFile =
+				entry.payload.type === "sentinel" ? await resolveLoopFileSafely(currentCtx) : { found: false as const };
+			const built = buildTickMessage({
+				loopId: entry.id,
+				deliveryId: tick.deliveryId,
+				mode,
+				payload: entry.payload,
+				reentryPrompt: entry.reentryPrompt,
+				deliveryState: deliveryStateOf(entry.id),
+				loopFile: loopFileSnapshot(loopFile),
+			});
+			deliveryStates.set(entry.id, built.deliveryState);
+
+			const busy = !currentCtx.isIdle() || currentCtx.hasPendingMessages();
+			if (busy && isExtensionCommandPayload(built.text)) {
+				// Extension commands cannot be queued; hold this delivery until the turn settles.
+				deferredDispatches.push(tick);
+				return;
+			}
+
+			const noopStreak = entry.noopStreak;
+			pi.appendEntry<LoopTickEntryData>(LOOP_TICK_ENTRY_TYPE, {
+				loopId: entry.id,
+				deliveryId: tick.deliveryId,
+				scheduledForAt: tick.scheduledForAt,
+				mode,
+				delivery: built.delivery,
+				...(built.details.sentinel === undefined ? {} : { sentinel: built.details.sentinel }),
+				noopStreak,
+				folded: noopStreak >= 2,
+			});
+
+			attributedLoopId = entry.id;
+			attributedDeliveryId = tick.deliveryId;
+			attributionResolved = false;
+			pi.sendUserMessage(built.text, {
+				expandPromptTemplates: true,
+				...(busy ? { deliverAs: "followUp" as const } : {}),
+			});
+			await persist();
+			refreshStatus();
+		}
+
+		async function resolveLoopFileSafely(currentCtx: ExtensionContext): Promise<LoopFileResult> {
+			try {
+				return await resolveLoopFile({ cwd: currentCtx.cwd, homeDir: homedir() });
+			} catch {
+				// A loop file that cannot be read is treated as absent for this tick; the loop
+				// stays alive and picks the file up again once it is readable.
+				return { found: false };
+			}
+		}
+
+		async function drainDeferred(): Promise<void> {
+			if (deferredDispatches.length === 0) return;
+			const pending = deferredDispatches.splice(0, deferredDispatches.length);
+			for (const tick of pending) await dispatchTick(tick);
+		}
+
+		async function fireDue(loopId: LoopId): Promise<void> {
+			const active = scheduler;
+			const currentCtx = ctx;
+			if (active === undefined || currentCtx === undefined) return;
+			const busy = !currentCtx.isIdle() || currentCtx.hasPendingMessages();
+			const decision = active.onDue(loopId, clock.now(), busy);
+			await persist();
+			if (decision.action === "dispatch") {
+				await dispatchTick(decision.tick);
+				return;
+			}
+			if (decision.action === "expire") {
+				ctx?.ui.notify("Loop expired after 7 days and is no longer armed.", "info");
+			}
+			refreshStatus();
+		}
+
+		function payloadForPrompt(prompt: string): LoopPayload {
+			return { type: "prompt", prompt };
+		}
+
+		async function startFixed(request: StartFixedRequest): Promise<LoopCreateOutcome> {
+			const active = requireScheduler();
+			const effective = normalizeInterval(request.requestedInterval);
+			const created = active.createFixed({
+				originalArgs: request.originalArgs,
+				reentryPrompt: `/loop ${request.originalArgs}`.trimEnd(),
+				payload: payloadForPrompt(request.prompt),
+				requestedInterval: request.requestedInterval,
+				effectiveInterval: effective,
+				cronExpression: describeCron(effective),
+				intervalMs: effective.intervalMs,
+			});
+			if (!created.ok) return { ok: false, message: created.message };
+			deliveryStates.set(created.loopId, emptyDeliveryState());
+			await persist();
+			nameSessionAfterLoop(request.prompt);
+			await fireDue(created.loopId);
+			refreshStatus();
+			return {
+				ok: true,
+				loopId: created.loopId,
+				...(effective.roundingNotice === undefined ? {} : { roundingNotice: effective.roundingNotice }),
+				cronExpression: describeCron(effective),
+				effectiveCadence: effective.human,
+				expiresAt: active.getState().entries[created.loopId]?.expiresAt,
+			};
+		}
+
+		async function startDynamic(request: StartDynamicRequest): Promise<LoopCreateOutcome> {
+			const active = requireScheduler();
+			const created = active.createDynamic({
+				originalArgs: request.originalArgs,
+				reentryPrompt: `/loop ${request.originalArgs}`.trimEnd(),
+				payload: payloadForPrompt(request.prompt),
+			});
+			if (!created.ok) return { ok: false, message: created.message };
+			deliveryStates.set(created.loopId, emptyDeliveryState());
+			await persist();
+			nameSessionAfterLoop(request.prompt);
+			await fireDue(created.loopId);
+			refreshStatus();
+			return {
+				ok: true,
+				loopId: created.loopId,
+				...(created.supersededLoopId === undefined ? {} : { supersededLoopId: created.supersededLoopId }),
+				expiresAt: active.getState().entries[created.loopId]?.expiresAt,
+			};
+		}
+
+		async function startBare(request: StartBareRequest): Promise<LoopCreateOutcome> {
+			const active = requireScheduler();
+			const currentCtx = ctx;
+			if (currentCtx === undefined) return { ok: false, message: "loop extension has no active session" };
+			const loopFile = await resolveLoopFileSafely(currentCtx);
+			const mode: LoopMode = request.interval === undefined ? "dynamic" : "fixed";
+			const payload: LoopPayload = { type: "sentinel", sentinel: sentinelFor(mode, loopFile.found) };
+			const reentryPrompt = request.originalArgs.trim() === "" ? "/loop" : `/loop ${request.originalArgs.trim()}`;
+
+			const created =
+				request.interval === undefined
+					? active.createDynamic({ originalArgs: request.originalArgs, reentryPrompt, payload })
+					: (() => {
+							const effective = normalizeInterval(request.interval);
+							return active.createFixed({
+								originalArgs: request.originalArgs,
+								reentryPrompt,
+								payload,
+								requestedInterval: request.interval,
+								effectiveInterval: effective,
+								cronExpression: describeCron(effective),
+								intervalMs: effective.intervalMs,
+							});
+						})();
+			if (!created.ok) return { ok: false, message: created.message };
+			deliveryStates.set(created.loopId, emptyDeliveryState());
+			await persist();
+			nameSessionAfterLoop(reentryPrompt);
+			await fireDue(created.loopId);
+			refreshStatus();
+			return {
+				ok: true,
+				loopId: created.loopId,
+				expiresAt: active.getState().entries[created.loopId]?.expiresAt,
+			};
+		}
+
+		function nameSessionAfterLoop(prompt: string): void {
+			if (sessionNamed) return;
+			sessionNamed = true;
+			if (pi.getSessionName() !== undefined) return;
+			pi.setSessionName(`loop: ${prompt}`.trim());
+		}
+
+		const controller: LoopController = {
+			startFixed,
+			startDynamic,
+			startBare,
+			fireDue,
+			scheduleWakeup: async (request) => {
+				const active = requireScheduler();
+				const result = active.onScheduleWakeup(request);
+				if (result.ok) attributionResolved = true;
+				await persist();
+				refreshStatus();
+			},
+			stop: async (target, detail) => {
+				const active = requireScheduler();
+				const result = active.stop(target, detail);
+				await persist();
+				refreshStatus();
+				return result.affectedLoopIds;
+			},
+			pause: async (target) => {
+				const active = requireScheduler();
+				const result = active.pause(target);
+				await persist();
+				refreshStatus();
+				return result.affectedLoopIds;
+			},
+			resume: async (target) => {
+				const active = requireScheduler();
+				const result = active.resume(target);
+				await persist();
+				refreshStatus();
+				return result.affectedLoopIds;
+			},
+			getState: () => requireScheduler().getState(),
+			statusLine: () => formatLoopStatus(requireScheduler().getState(), clock.now()),
+			lastStoreFailure: () => storeFailure,
+			isEndedWithError: (loopId) => endedWithError.has(loopId),
+		};
+
+		deps.onControllerReady?.(controller);
+
+		pi.on("session_start", async (_event, nextCtx) => {
+			ctx = nextCtx;
+			timers.cancelAll();
+			timers = makeTimers();
+			storeFailure = undefined;
+			endedWithError.clear();
+			storeTouched = false;
+			sessionNamed = false;
+			attributedLoopId = undefined;
+			attributedDeliveryId = undefined;
+			attributionResolved = false;
+			deferredDispatches.length = 0;
+			deliveryStates.clear();
+			storeRef = storeRefOf(nextCtx);
+
+			let initialState: LoopState | undefined;
+			try {
+				initialState = (await readState(storeRef)) ?? undefined;
+			} catch (error) {
+				// Fail closed: arm nothing, end nothing silently, and tell the user.
+				failStore(error, []);
+				scheduler = createLoopScheduler({
+					sessionId: nextCtx.sessionManager.getSessionId(),
+					clock,
+					timers,
+					ids,
+				});
+				return;
+			}
+
+			scheduler = createLoopScheduler({
+				sessionId: nextCtx.sessionManager.getSessionId(),
+				clock,
+				timers,
+				ids,
+				...(initialState === undefined ? {} : { initialState }),
+			});
+			storeTouched = initialState !== undefined;
+
+			for (const entry of Object.values(scheduler.getState().entries)) {
+				const anchorDeliveryId = entry.sentinelDelivery.lastLoopFileDelivered?.anchorDeliveryId;
+				const anchored = anchorPresent(nextCtx, entry.id, anchorDeliveryId);
+				const needsFull = !anchored && hasAnchoredDelivery(entry.sentinelDelivery);
+				deliveryStates.set(entry.id, {
+					...entry.sentinelDelivery,
+					forceFullDelivery: entry.sentinelDelivery.forceFullDelivery || needsFull,
+				});
+			}
+
+			const restored = scheduler.restore(clock.now());
+			await persist();
+			refreshStatus();
+			for (const tick of restored.recoveryTicks) await dispatchTick(tick);
+			if (restored.expiredLoopIds.length > 0) {
+				nextCtx.ui.notify(`Loop expired after 7 days: ${restored.expiredLoopIds.join(", ")}`, "info");
+			}
+		});
+
+		pi.on("session_compact", async (event) => {
+			// Accepted compaction may have dropped the anchor the reminders point at, so the
+			// next sentinel tick must carry the full instructions again. Timers and phase are
+			// deliberately untouched.
+			if (event.accepted !== true) return;
+			markForceFullDelivery();
+			await persist();
+		});
+
+		pi.on("input", async (event) => {
+			// A user turn is never an attributed loop iteration, so keepalive must not see it.
+			// A tick dispatched by this extension arrives with source "extension" and MUST keep
+			// its attribution, or no dynamic iteration would ever be judged.
+			if (event.source === "extension") return;
+			attributedLoopId = undefined;
+			attributedDeliveryId = undefined;
+			attributionResolved = false;
+		});
+
+		pi.on("agent_end", async (event) => {
+			// A retrying turn is still in progress: neither settle it nor judge its liveness.
+			if (event.willRetry === true) return;
+			if (event.aborted === true && event.abortSource === "user") {
+				await pauseAttributedLoop();
+				return;
+			}
+			await settleAttributedTick(event.aborted === true ? "error" : "completed");
+		});
+
+		pi.on("agent_settled", async () => {
+			await settleAttributedTick("completed");
+			await drainDeferred();
+			refreshStatus();
+		});
+
+		pi.on("session_abort", async () => {
+			await pauseAttributedLoop();
+		});
+
+		pi.on("session_shutdown", async () => {
+			const active = scheduler;
+			if (active !== undefined) {
+				// Shutdown SUSPENDS: every senpi shutdown reason leaves the session resumable,
+				// so the snapshot must carry no terminal reason.
+				active.onShutdown();
+				await persist();
+			}
+			timers.cancelAll();
+			deferredDispatches.length = 0;
+			ticker.dispose();
+			attributedLoopId = undefined;
+			attributedDeliveryId = undefined;
+			attributionResolved = false;
+			ctx = undefined;
+		});
+
+		async function pauseAttributedLoop(): Promise<void> {
+			const active = scheduler;
+			if (active === undefined) return;
+			const targets =
+				attributedLoopId === undefined
+					? Object.values(active.getState().entries)
+							.filter((entry) => entry.phase !== "ended")
+							.map((entry) => entry.id)
+					: [attributedLoopId];
+			const paused: LoopId[] = [];
+			for (const loopId of targets) {
+				if (active.onUserAbort(loopId).action === "paused") paused.push(loopId);
+			}
+			attributedLoopId = undefined;
+			attributedDeliveryId = undefined;
+			attributionResolved = false;
+			if (paused.length === 0) return;
+			await persist();
+			refreshStatus();
+			ctx?.ui.notify("loop paused - /loop resume or /loop stop", "info");
+		}
+
+		/**
+		 * Settles the tick this turn was attributed to, drains a coalesced occurrence, and
+		 * applies the two-strike keepalive to a dynamic iteration that ended without calling
+		 * `schedule_wakeup`. An ordinary user turn clears the attribution first, so keepalive
+		 * can never be charged to it, and a user abort takes the pause path instead.
+		 */
+		async function settleAttributedTick(outcome: "completed" | "error"): Promise<void> {
+			const active = scheduler;
+			const loopId = attributedLoopId;
+			const deliveryId = attributedDeliveryId;
+			if (active === undefined || loopId === undefined) return;
+			const entry = active.getState().entries[loopId];
+			if (entry === undefined) return;
+			const resolved = attributionResolved;
+			attributedLoopId = undefined;
+			attributedDeliveryId = undefined;
+			attributionResolved = false;
+
+			const settled = deliveryId === undefined ? undefined : active.onTickSettled({ loopId, deliveryId, outcome });
+			await persist();
+
+			if (!resolved && entry.kind === "dynamic") {
+				const keepalive = active.onTurnEndedWithoutSchedule(loopId);
+				await persist();
+				refreshStatus();
+				if (keepalive.action === "ended") {
+					ctx?.ui.notify(
+						keepalive.endReason === "keepalive_exhausted"
+							? "Loop ended: the model stopped scheduling wakeups."
+							: "Loop expired after 7 days and is no longer armed.",
+						"info",
+					);
+				}
+				return;
+			}
+
+			if (settled?.action === "dispatch") {
+				// Exactly one delivery drains a coalesced occurrence, however many were missed.
+				await dispatchTick(settled.tick);
+			} else if (settled?.action === "ended") {
+				ctx?.ui.notify(`Loop ended: ${settled.endReason}.`, "info");
+			}
+			refreshStatus();
+		}
+	};
+}
+
+/** True when a reminder would refer back to a full delivery that must still exist. */
+function hasAnchoredDelivery(state: SentinelDeliveryState): boolean {
+	return state.autonomousPreambleDelivered || state.lastLoopFileDelivered !== null;
+}
+
+export default createLoopExtension();

--- a/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
@@ -551,6 +551,16 @@ export function createLoopExtension(deps: LoopExtensionDeps = {}): ExtensionFact
 			refreshStatus();
 		}
 
+		/**
+		 * Timer callbacks are synchronous, so the async due step is scheduled and its failure is
+		 * contained: a rejected dispatch must never take down the timer that owns the loop.
+		 */
+		function handleTimerFire(loopId: LoopId): void {
+			void fireDue(loopId).catch((error) => {
+				ctx?.ui.notify(`Loop tick failed: ${error instanceof Error ? error.message : String(error)}`, "error");
+			});
+		}
+
 		function payloadForPrompt(prompt: string): LoopPayload {
 			return { type: "prompt", prompt };
 		}
@@ -716,6 +726,7 @@ export function createLoopExtension(deps: LoopExtensionDeps = {}): ExtensionFact
 					clock,
 					timers,
 					ids,
+					onFire: handleTimerFire,
 				});
 				return;
 			}
@@ -725,6 +736,7 @@ export function createLoopExtension(deps: LoopExtensionDeps = {}): ExtensionFact
 				clock,
 				timers,
 				ids,
+				onFire: handleTimerFire,
 				...(initialState === undefined ? {} : { initialState }),
 			});
 			storeTouched = initialState !== undefined;

--- a/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
@@ -24,6 +24,7 @@ import { getAgentDir } from "../../../../config.ts";
 import type { SessionEntry } from "../../../session-manager.ts";
 import { noticeEntryRenderer } from "../../notice/index.ts";
 import type { EntryRenderer, ExtensionAPI, ExtensionContext, ExtensionFactory } from "../../types.ts";
+import { registerLoopCommand } from "./command-registration.ts";
 import { describeCron, normalizeInterval } from "./cron-planner.ts";
 import { type LoopFileResult, nodeFs, resolveLoopFile as resolveLoopFileDefault } from "./loopfile.ts";
 import {
@@ -687,6 +688,7 @@ export function createLoopExtension(deps: LoopExtensionDeps = {}): ExtensionFact
 		};
 
 		deps.onControllerReady?.(controller);
+		registerLoopCommand(pi, { controller });
 
 		pi.on("session_start", async (_event, nextCtx) => {
 			ctx = nextCtx;

--- a/packages/coding-agent/src/core/extensions/builtin/loop/loopfile.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/loopfile.ts
@@ -34,12 +34,7 @@ export class LoopFileError extends Error {
 	public readonly code: "stat_failed" | "read_failed";
 	public readonly path: string;
 
-	constructor(
-		message: string,
-		code: "stat_failed" | "read_failed",
-		path: string,
-		options?: { cause?: unknown },
-	) {
+	constructor(message: string, code: "stat_failed" | "read_failed", path: string, options?: { cause?: unknown }) {
 		super(message, options);
 		this.name = "LoopFileError";
 		this.code = code;
@@ -73,7 +68,12 @@ function safeUtf8Truncate(buf: Buffer, maxBytes: number): string {
 }
 
 type TryResolveOutcome =
-	| { readonly found: true; readonly path: string; readonly content: string; readonly fingerprint: LoopFileFingerprint }
+	| {
+			readonly found: true;
+			readonly path: string;
+			readonly content: string;
+			readonly fingerprint: LoopFileFingerprint;
+	  }
 	| { readonly found: false }
 	| { readonly error: LoopFileError };
 
@@ -100,7 +100,7 @@ async function tryResolveOne(path: string, fs: LoopFileResolverDeps["fs"]): Prom
 
 	const truncated = raw.length > MAX_MODEL_BYTES;
 	const modelVisible = truncated
-		? safeUtf8Truncate(raw, MAX_MODEL_BYTES) + "\n" + TRUNCATION_WARNING
+		? `${safeUtf8Truncate(raw, MAX_MODEL_BYTES)}\n${TRUNCATION_WARNING}`
 		: raw.toString("utf-8");
 
 	return {
@@ -118,10 +118,7 @@ async function tryResolveOne(path: string, fs: LoopFileResolverDeps["fs"]): Prom
 
 export async function resolveLoopFile(deps: LoopFileResolverDeps): Promise<LoopFileResult> {
 	const { cwd, homeDir, fs, path } = deps;
-	const candidates = [
-		path.join(cwd, CONFIG_DIR_NAME, "loop.md"),
-		path.join(resolveAgentDir(cwd, homeDir), "loop.md"),
-	];
+	const candidates = [path.join(cwd, CONFIG_DIR_NAME, "loop.md"), path.join(resolveAgentDir(cwd, homeDir), "loop.md")];
 
 	for (const candidate of candidates) {
 		const outcome = await tryResolveOne(candidate, fs);

--- a/packages/coding-agent/src/core/extensions/builtin/loop/loopfile.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/loopfile.ts
@@ -1,0 +1,151 @@
+import { createHash } from "node:crypto";
+import * as fsPromises from "node:fs/promises";
+import { CONFIG_DIR_NAME, resolveAgentDir } from "../../../../config.ts";
+
+export interface LoopFileFingerprint {
+	readonly path: string;
+	readonly mtimeMs: number;
+	readonly size: number;
+	readonly contentHash: string;
+}
+
+export interface LoopFileResolverDeps {
+	readonly cwd: string;
+	readonly homeDir: string;
+	readonly fs: {
+		stat(path: string): Promise<{ mtimeMs: number; size: number }>;
+		readFile(path: string): Promise<Buffer>;
+		readBytes(path: string, maxBytes: number): Promise<Buffer>;
+	};
+	readonly path: { join(...paths: string[]): string };
+}
+
+export type LoopFileResult =
+	| { readonly found: false }
+	| {
+			readonly found: true;
+			readonly path: string;
+			readonly content: string;
+			readonly fingerprint: LoopFileFingerprint;
+	  };
+
+export class LoopFileError extends Error {
+	public readonly code: "stat_failed" | "read_failed";
+	public readonly path: string;
+
+	constructor(
+		message: string,
+		code: "stat_failed" | "read_failed",
+		path: string,
+		options?: { cause?: unknown },
+	) {
+		super(message, options);
+		this.name = "LoopFileError";
+		this.code = code;
+		this.path = path;
+	}
+}
+
+const MAX_MODEL_BYTES = 25000;
+const READ_LIMIT = MAX_MODEL_BYTES + 1;
+const TRUNCATION_WARNING = "[loop.md truncated to the first 25000 bytes]";
+
+function isEnoentError(err: unknown): boolean {
+	return typeof err === "object" && err !== null && (err as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function sha256(text: string): string {
+	return createHash("sha256").update(text).digest("hex");
+}
+
+function safeUtf8Truncate(buf: Buffer, maxBytes: number): string {
+	const decoder = new TextDecoder("utf-8", { fatal: true });
+	let slice = buf.subarray(0, maxBytes);
+	while (slice.length > 0) {
+		try {
+			return decoder.decode(slice);
+		} catch {
+			slice = slice.subarray(0, slice.length - 1);
+		}
+	}
+	return "";
+}
+
+type TryResolveOutcome =
+	| { readonly found: true; readonly path: string; readonly content: string; readonly fingerprint: LoopFileFingerprint }
+	| { readonly found: false }
+	| { readonly error: LoopFileError };
+
+async function tryResolveOne(path: string, fs: LoopFileResolverDeps["fs"]): Promise<TryResolveOutcome> {
+	let stat: { mtimeMs: number; size: number };
+	try {
+		stat = await fs.stat(path);
+	} catch (err) {
+		if (isEnoentError(err)) return { found: false };
+		return {
+			error: new LoopFileError(`Failed to stat loop file ${path}`, "stat_failed", path, { cause: err }),
+		};
+	}
+
+	let raw: Buffer;
+	try {
+		raw = await fs.readBytes(path, READ_LIMIT);
+	} catch (err) {
+		if (isEnoentError(err)) return { found: false };
+		return {
+			error: new LoopFileError(`Failed to read loop file ${path}`, "read_failed", path, { cause: err }),
+		};
+	}
+
+	const truncated = raw.length > MAX_MODEL_BYTES;
+	const modelVisible = truncated
+		? safeUtf8Truncate(raw, MAX_MODEL_BYTES) + "\n" + TRUNCATION_WARNING
+		: raw.toString("utf-8");
+
+	return {
+		found: true,
+		path,
+		content: modelVisible,
+		fingerprint: {
+			path,
+			mtimeMs: stat.mtimeMs,
+			size: stat.size,
+			contentHash: sha256(modelVisible),
+		},
+	};
+}
+
+export async function resolveLoopFile(deps: LoopFileResolverDeps): Promise<LoopFileResult> {
+	const { cwd, homeDir, fs, path } = deps;
+	const candidates = [
+		path.join(cwd, CONFIG_DIR_NAME, "loop.md"),
+		path.join(resolveAgentDir(cwd, homeDir), "loop.md"),
+	];
+
+	for (const candidate of candidates) {
+		const outcome = await tryResolveOne(candidate, fs);
+		if ("error" in outcome) {
+			throw outcome.error;
+		}
+		if (outcome.found) {
+			return outcome;
+		}
+	}
+
+	return { found: false };
+}
+
+export const nodeFs: LoopFileResolverDeps["fs"] = {
+	stat: (path) => fsPromises.stat(path),
+	readFile: (path) => fsPromises.readFile(path),
+	readBytes: async (path, maxBytes) => {
+		const handle = await fsPromises.open(path, "r");
+		try {
+			const buf = Buffer.alloc(maxBytes);
+			const { bytesRead } = await handle.read(buf, 0, maxBytes, 0);
+			return buf.subarray(0, bytesRead);
+		} finally {
+			await handle.close();
+		}
+	},
+};

--- a/packages/coding-agent/src/core/extensions/builtin/loop/loopfile.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/loopfile.ts
@@ -1,13 +1,14 @@
 import { createHash } from "node:crypto";
 import * as fsPromises from "node:fs/promises";
 import { CONFIG_DIR_NAME, resolveAgentDir } from "../../../../config.ts";
+import type { LoopFileFingerprint as AnchoredLoopFileFingerprint } from "./types.ts";
 
-export interface LoopFileFingerprint {
-	readonly path: string;
-	readonly mtimeMs: number;
-	readonly size: number;
-	readonly contentHash: string;
-}
+/**
+ * Content identity of the resolved loop file. `types.ts` owns the canonical, persisted
+ * fingerprint; the resolver cannot know the delivery that anchors it, so it produces the
+ * same shape minus that field and the tick builder anchors it at fire time.
+ */
+export type LoopFileFingerprint = Omit<AnchoredLoopFileFingerprint, "anchorDeliveryId">;
 
 export interface LoopFileResolverDeps {
 	readonly cwd: string;

--- a/packages/coding-agent/src/core/extensions/builtin/loop/parse.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/parse.ts
@@ -107,7 +107,7 @@ export function parseLoopArgs(raw: string): ParsedLoopInvocation {
 	}
 
 	const leadingMatch = /^\s*(\d+[smhd])\b/.exec(raw);
-	if (leadingMatch) {
+	if (leadingMatch !== null && LEADING_INTERVAL_RE.test(leadingMatch[1] ?? "")) {
 		const interval = parseIntervalToken(leadingMatch[1]);
 		const remaining = raw.slice(leadingMatch[0].length).trim();
 		return classifyInterval(interval, remaining, originalArgs);

--- a/packages/coding-agent/src/core/extensions/builtin/loop/parse.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/parse.ts
@@ -1,0 +1,126 @@
+export interface RequestedInterval {
+	readonly value: number;
+	readonly unit: "s" | "m" | "h" | "d";
+	readonly raw: string;
+}
+
+export type LoopTarget =
+	| { readonly type: "all" }
+	| { readonly type: "id"; readonly id: string }
+	| { readonly type: "implicit" };
+
+export type ParsedLoopInvocation =
+	| { readonly kind: "stop"; readonly target: LoopTarget; readonly originalArgs: string }
+	| { readonly kind: "status"; readonly originalArgs: string }
+	| { readonly kind: "pause"; readonly target: LoopTarget; readonly originalArgs: string }
+	| { readonly kind: "resume"; readonly target: LoopTarget; readonly originalArgs: string }
+	| {
+			readonly kind: "fixed";
+			readonly interval: RequestedInterval;
+			readonly prompt: string;
+			readonly originalArgs: string;
+	  }
+	| { readonly kind: "dynamic"; readonly prompt: string; readonly originalArgs: string }
+	| { readonly kind: "bare"; readonly interval?: RequestedInterval; readonly originalArgs: string }
+	| { readonly kind: "invalid"; readonly reason: string; readonly usage: string };
+
+const LEADING_INTERVAL_RE = /^\d+[smhd]$/;
+
+const TRAILING_EVERY_RE =
+	/(?:^|\s)every\s+(\d+)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$/i;
+
+const USAGE = `Usage: /loop [interval] <prompt>
+Examples:
+  /loop 5m check the deploy
+  /loop check the deploy every 20m
+  /loop check the deploy
+  /loop stop [id|all]
+  /loop status
+  /loop pause [id|all]
+  /loop resume [id|all]`;
+
+function normalizeUnit(unit: string): "s" | "m" | "h" | "d" {
+	const lower = unit.toLowerCase();
+	if (lower.startsWith("s")) return "s";
+	if (lower.startsWith("m")) return "m";
+	if (lower.startsWith("h")) return "h";
+	return "d";
+}
+
+function parseIntervalToken(token: string): RequestedInterval {
+	const value = Number.parseInt(token.slice(0, -1), 10);
+	const unit = token.slice(-1) as "s" | "m" | "h" | "d";
+	return { value, unit, raw: token };
+}
+
+function parseTrailingInterval(raw: string): { interval: RequestedInterval; remaining: string } | null {
+	const match = TRAILING_EVERY_RE.exec(raw);
+	if (!match) return null;
+	const value = Number.parseInt(match[1], 10);
+	const unit = normalizeUnit(match[2]);
+	const matchedPrefix = match[0];
+	const remaining = raw.slice(0, raw.length - matchedPrefix.length).trim();
+	return {
+		interval: { value, unit, raw: `${value}${unit}` },
+		remaining,
+	};
+}
+
+function parseTarget(rest: string): LoopTarget {
+	const trimmed = rest.trim();
+	if (trimmed === "" || trimmed.toLowerCase() === "implicit") return { type: "implicit" };
+	if (trimmed.toLowerCase() === "all") return { type: "all" };
+	return { type: "id", id: trimmed.split(/\s+/)[0] };
+}
+
+function makeInvalid(reason: string): ParsedLoopInvocation {
+	return { kind: "invalid", reason, usage: USAGE };
+}
+
+function classifyInterval(interval: RequestedInterval, remaining: string, originalArgs: string): ParsedLoopInvocation {
+	if (interval.value === 0) {
+		return makeInvalid("Interval amount must be greater than zero.");
+	}
+	const prompt = remaining.trim();
+	if (prompt === "") {
+		return { kind: "bare", interval, originalArgs };
+	}
+	return { kind: "fixed", interval, prompt, originalArgs };
+}
+
+export function parseLoopArgs(raw: string): ParsedLoopInvocation {
+	const originalArgs = raw;
+	const trimmed = raw.trim();
+
+	if (trimmed !== "") {
+		const firstToken = trimmed.split(/\s+/)[0].toLowerCase();
+		switch (firstToken) {
+			case "stop":
+				return { kind: "stop", target: parseTarget(trimmed.slice(firstToken.length)), originalArgs };
+			case "status":
+				return { kind: "status", originalArgs };
+			case "pause":
+				return { kind: "pause", target: parseTarget(trimmed.slice(firstToken.length)), originalArgs };
+			case "resume":
+				return { kind: "resume", target: parseTarget(trimmed.slice(firstToken.length)), originalArgs };
+		}
+	}
+
+	const leadingMatch = /^\s*(\d+[smhd])\b/.exec(raw);
+	if (leadingMatch) {
+		const interval = parseIntervalToken(leadingMatch[1]);
+		const remaining = raw.slice(leadingMatch[0].length).trim();
+		return classifyInterval(interval, remaining, originalArgs);
+	}
+
+	const trailing = parseTrailingInterval(raw);
+	if (trailing) {
+		return classifyInterval(trailing.interval, trailing.remaining, originalArgs);
+	}
+
+	if (trimmed === "") {
+		return { kind: "bare", originalArgs };
+	}
+
+	return { kind: "dynamic", prompt: trimmed, originalArgs };
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/parse.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/parse.ts
@@ -1,8 +1,8 @@
-export interface RequestedInterval {
-	readonly value: number;
-	readonly unit: "s" | "m" | "h" | "d";
-	readonly raw: string;
-}
+import type { RequestedInterval, RequestedIntervalUnit } from "./types.ts";
+
+// `types.ts` is the single type home for the whole extension; re-exported so the parser's
+// own consumers keep importing the canonical declaration.
+export type { RequestedInterval };
 
 export type LoopTarget =
 	| { readonly type: "all" }
@@ -39,7 +39,7 @@ Examples:
   /loop pause [id|all]
   /loop resume [id|all]`;
 
-function normalizeUnit(unit: string): "s" | "m" | "h" | "d" {
+function normalizeUnit(unit: string): RequestedIntervalUnit {
 	const lower = unit.toLowerCase();
 	if (lower.startsWith("s")) return "s";
 	if (lower.startsWith("m")) return "m";
@@ -49,7 +49,7 @@ function normalizeUnit(unit: string): "s" | "m" | "h" | "d" {
 
 function parseIntervalToken(token: string): RequestedInterval {
 	const value = Number.parseInt(token.slice(0, -1), 10);
-	const unit = token.slice(-1) as "s" | "m" | "h" | "d";
+	const unit = token.slice(-1) as RequestedIntervalUnit;
 	return { value, unit, raw: token };
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/loop/scheduler.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/scheduler.ts
@@ -93,6 +93,12 @@ export interface LoopSchedulerDeps {
 	readonly initialState?: LoopState;
 	/** Called after every state revision so the caller can persist it. */
 	readonly onStateChanged?: (state: LoopState) => void;
+	/**
+	 * Invoked when an armed timer fires. The owner is expected to run the due decision AND its
+	 * side effects (persist + dispatch). Without it the scheduler only advances its own state,
+	 * which would deliver a loop's first tick and then silently never recur.
+	 */
+	readonly onFire?: (loopId: LoopId) => void;
 }
 
 export interface CreateFixedRequest {
@@ -960,7 +966,14 @@ export function createLoopScheduler(deps: LoopSchedulerDeps): LoopScheduler {
 
 	// The timer port fires with a loop id; the due decision is always re-derived from the
 	// clock so a stale callback cannot dispatch a tick the state machine would refuse.
+	// When an owner supplies `onFire` it performs the whole due step (persist + dispatch), so
+	// calling `onDue` here as well would consume the occurrence and drop the delivery.
 	fireHandler = (loopId) => {
+		const owner = deps.onFire;
+		if (owner !== undefined) {
+			owner(loopId);
+			return;
+		}
 		scheduler.onDue(loopId, deps.clock.now(), false);
 	};
 

--- a/packages/coding-agent/src/core/extensions/builtin/loop/scheduler.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/scheduler.ts
@@ -1,0 +1,968 @@
+/**
+ * Pure state machine behind the `/loop` extension.
+ *
+ * Everything time-related or timer-related is injected: a {@link LoopClock} supplies
+ * `now`, and a {@link LoopTimerPort} owns the single armed timeout per loop. This module
+ * performs NO I/O, never calls `setTimeout`/`Date.now`, and never persists anything
+ * itself — the caller mirrors {@link LoopScheduler.getState} into the sidecar store. That
+ * keeps every invariant below testable with a fake clock and zero real waiting.
+ *
+ * The load-bearing invariants:
+ * - At most ONE queued or running tick per loop. A fire that lands while one is in flight
+ *   sets `coalescedFirePending` instead of enqueuing a second delivery, so a sleeping
+ *   laptop or a long turn can never produce a tick storm.
+ * - `nextFireAt` is ALWAYS recomputed from `now`, never from the stale due time, so all
+ *   occurrences missed during sleep collapse into exactly one catch-up tick.
+ * - 7-day expiry from `createdAt` is checked at arm, fire, re-entry and restore, is never
+ *   extended by a new wakeup, and no tick fires at or after it.
+ * - At most {@link MAX_ACTIVE_LOOPS} active loops; a further creation returns a typed
+ *   rejection and leaves existing loops armed.
+ * - A dispatched-tick budget (default {@link DEFAULT_MAX_TICKS}) ends the loop with
+ *   `tick_budget_exhausted` so a forgotten fast loop cannot spend without bound.
+ * - Keepalive is a two-strike device on dynamic loops only, and a user abort PAUSES a
+ *   loop instead of ending it (and is never counted as a keepalive omission).
+ * - Shutdown SUSPENDS: every senpi shutdown reason leaves the session resumable, so there
+ *   is deliberately no `session_closed` terminal reason.
+ * - A provider/turn error is never terminal.
+ */
+
+import type {
+	CronEntry,
+	DeliveryId,
+	DynamicCronEntry,
+	EffectiveInterval,
+	EpochMs,
+	FixedCronEntry,
+	LoopEndReason,
+	LoopEntryFields,
+	LoopId,
+	LoopPayload,
+	LoopState,
+	PendingWakeup,
+	RequestedInterval,
+	WakeupId,
+} from "./types.ts";
+import { LOOP_STATE_VERSION } from "./types.ts";
+
+/** Absolute lifetime of a loop, measured from `createdAt`. */
+export const LOOP_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Hard cap on simultaneously active loops per session. */
+export const MAX_ACTIVE_LOOPS = 5;
+
+/** Fallback wakeup length when a dynamic iteration forgets to reschedule. */
+export const DEFAULT_KEEPALIVE_SECONDS = 1200;
+export const MIN_KEEPALIVE_SECONDS = 60;
+export const MAX_KEEPALIVE_SECONDS = 3600;
+export const KEEPALIVE_SECONDS_ENV = "SENPI_LOOP_KEEPALIVE_SECONDS";
+
+/** Dispatched-tick budget per loop. */
+export const DEFAULT_MAX_TICKS = 2000;
+export const MIN_MAX_TICKS = 1;
+export const MAX_TICKS_ENV = "SENPI_LOOP_MAX_TICKS";
+
+export interface LoopClock {
+	now(): EpochMs;
+}
+
+/**
+ * Owns the ONE live timeout per loop. Implementations must apply the generation-counter
+ * discipline of `cache-keepalive/index.ts`: re-arming a key replaces its previous
+ * callback, and a cancelled callback must never run.
+ */
+export interface LoopTimerPort {
+	arm(key: string, dueAt: EpochMs, callback: () => void): void;
+	cancel(key: string): void;
+	cancelAll(): void;
+}
+
+export interface LoopIdFactory {
+	loopId(): LoopId;
+	wakeupId(): WakeupId;
+	deliveryId(): DeliveryId;
+}
+
+export interface LoopSchedulerDeps {
+	readonly sessionId: string;
+	readonly clock: LoopClock;
+	readonly timers: LoopTimerPort;
+	readonly ids: LoopIdFactory;
+	/** Defaults to `process.env`; injected so tests never mutate the real environment. */
+	readonly env?: Record<string, string | undefined>;
+	/** Previously persisted state, e.g. on session start. */
+	readonly initialState?: LoopState;
+	/** Called after every state revision so the caller can persist it. */
+	readonly onStateChanged?: (state: LoopState) => void;
+}
+
+export interface CreateFixedRequest {
+	readonly originalArgs: string;
+	readonly reentryPrompt: string;
+	readonly payload: LoopPayload;
+	readonly requestedInterval: RequestedInterval;
+	readonly effectiveInterval: EffectiveInterval;
+	readonly cronExpression: string;
+	readonly intervalMs: number;
+}
+
+export interface CreateDynamicRequest {
+	readonly originalArgs: string;
+	readonly reentryPrompt: string;
+	readonly payload: LoopPayload;
+}
+
+/** One dispatchable delivery. The caller turns this into a message; ticks never steer. */
+export interface LoopTick {
+	readonly loopId: LoopId;
+	readonly deliveryId: DeliveryId;
+	/** Occurrence this delivery represents; equal to the `now` it was decided at. */
+	readonly scheduledForAt: EpochMs;
+	readonly deliverAs: "followUp";
+	/** True when this delivery drains a coalesced or recovered occurrence. */
+	readonly coalesced: boolean;
+}
+
+export type CreateRejectionReason = "active_loop_cap";
+
+export type CreateResult =
+	| { readonly ok: true; readonly loopId: LoopId; readonly supersededLoopId?: LoopId }
+	| {
+			readonly ok: false;
+			readonly reason: CreateRejectionReason;
+			readonly cap: number;
+			readonly activeLoopIds: readonly LoopId[];
+			readonly message: string;
+	  };
+
+export type DueResult =
+	| { readonly action: "dispatch"; readonly tick: LoopTick }
+	| { readonly action: "coalesce" }
+	| { readonly action: "expire" };
+
+export type TickOutcome = "completed" | "error" | "retrying";
+
+export interface TickSettledInput {
+	readonly loopId: LoopId;
+	readonly deliveryId: DeliveryId;
+	readonly outcome: TickOutcome;
+}
+
+export type SettledResult =
+	| { readonly action: "dispatch"; readonly tick: LoopTick }
+	| { readonly action: "coalesce" }
+	| { readonly action: "expire" }
+	| { readonly action: "idle" }
+	| { readonly action: "in_progress" }
+	| { readonly action: "ended"; readonly endReason: LoopEndReason }
+	| { readonly action: "ignored" };
+
+export interface ScheduleWakeupInput {
+	readonly loopId: LoopId;
+	/** Already clamped to `[60, 3600]` by the tool executor. */
+	readonly delaySeconds: number;
+	readonly requestedDelaySeconds: number;
+	readonly reason: string;
+	readonly prompt: string;
+	readonly noop: boolean;
+}
+
+export type ScheduleWakeupResult =
+	| {
+			readonly ok: true;
+			readonly wakeupId: WakeupId;
+			readonly replacedWakeupId?: WakeupId;
+			readonly dueAt: EpochMs;
+			readonly noopStreak: number;
+	  }
+	| { readonly ok: false; readonly reason: "unknown_loop" | "not_dynamic" | "ended" | "expired" };
+
+export type KeepaliveResult =
+	| {
+			readonly action: "keepalive_armed";
+			readonly wakeupId: WakeupId;
+			readonly delaySeconds: number;
+			readonly dueAt: EpochMs;
+	  }
+	| { readonly action: "ended"; readonly endReason: "keepalive_exhausted" | "expired" }
+	| { readonly action: "ignored" };
+
+export interface AbortResult {
+	readonly action: "paused" | "ignored";
+}
+
+export interface TargetedResult {
+	readonly affectedLoopIds: readonly LoopId[];
+}
+
+export interface ShutdownResult {
+	readonly suspendedLoopIds: readonly LoopId[];
+}
+
+export interface RestoreOptions {
+	/**
+	 * Loops the caller knows the user paused explicitly, which must stay paused instead of
+	 * being re-armed. `phase: "suspended"` alone cannot express this: shutdown suspends too,
+	 * and the persisted state has no field distinguishing the two. Omit it and every
+	 * suspended loop is treated as shutdown-suspended and re-armed, per the plan's resume
+	 * rule.
+	 */
+	readonly userPausedLoopIds?: readonly LoopId[];
+}
+
+export interface RestoreResult {
+	readonly recoveryTicks: readonly LoopTick[];
+	readonly expiredLoopIds: readonly LoopId[];
+	readonly rearmedLoopIds: readonly LoopId[];
+	/** Loops left paused because {@link RestoreOptions.userPausedLoopIds} named them. */
+	readonly stillPausedLoopIds: readonly LoopId[];
+}
+
+export interface LoopScheduler {
+	getState(): LoopState;
+	/** State revisions applied so far; lets callers assert atomic multi-entry mutations. */
+	readonly mutationCount: number;
+	/** Effective dispatched-tick budget after the env override and the minimum of 1. */
+	readonly maxTicks: number;
+	/** Effective keepalive fallback length in seconds after clamping. */
+	readonly keepaliveSeconds: number;
+	/** Delivery id of the queued/running tick of a loop, when one is in flight. */
+	currentDeliveryId(loopId: LoopId): DeliveryId | undefined;
+	createFixed(request: CreateFixedRequest): CreateResult;
+	createDynamic(request: CreateDynamicRequest): CreateResult;
+	onDue(loopId: LoopId, nowMs: EpochMs, sessionBusy: boolean): DueResult;
+	onTickSettled(input: TickSettledInput): SettledResult;
+	onScheduleWakeup(request: ScheduleWakeupInput): ScheduleWakeupResult;
+	onTurnEndedWithoutSchedule(loopId: LoopId): KeepaliveResult;
+	onUserAbort(loopId: LoopId): AbortResult;
+	pause(target: LoopId | "all"): TargetedResult;
+	resume(target: LoopId | "all"): TargetedResult;
+	stop(target: LoopId | "all", detail: string): TargetedResult;
+	onShutdown(): ShutdownResult;
+	restore(nowMs: EpochMs, options?: RestoreOptions): RestoreResult;
+}
+
+/** Phases in which a loop already has a delivery in flight. */
+function isInFlight(entry: CronEntry): boolean {
+	return entry.phase === "queued" || entry.phase === "running";
+}
+
+function isActive(entry: CronEntry): boolean {
+	return entry.phase !== "ended";
+}
+
+/** Armed means the loop wants its timer running: not ended, not paused. */
+function isArmable(entry: CronEntry): boolean {
+	return entry.phase !== "ended" && entry.phase !== "suspended";
+}
+
+/**
+ * THE coalescing rule: the next occurrence is always derived from the CURRENT time, never
+ * from the stale due time. That is what makes every occurrence missed during laptop sleep,
+ * a long turn, or a pause collapse into exactly one catch-up tick.
+ */
+function nextOccurrenceAfter(nowMs: EpochMs, intervalMs: number): EpochMs {
+	return nowMs + intervalMs;
+}
+
+type ActivePhase = Exclude<CronEntry["phase"], "ended">;
+
+/** Fields any loop can carry into a non-terminal transition, regardless of kind. */
+type SharedPatch = Partial<Omit<LoopEntryFields, "id" | "createdAt" | "expiresAt">>;
+
+/**
+ * Rebuilds an entry in a non-terminal phase, dropping any terminal fields. Spreading an
+ * `ended` entry and overriding `phase` would leave `endedAt`/`endReason` behind, which the
+ * `LoopLifecycle` union forbids and the store parser rejects, so every non-terminal
+ * transition goes through here.
+ */
+function withPhase(entry: CronEntry, phase: ActivePhase, patch: SharedPatch = {}): CronEntry {
+	const { endedAt: _endedAt, endReason: _endReason, endDetail: _endDetail, ...rest } = entry;
+	return rest.kind === "fixed"
+		? { ...rest, ...patch, kind: "fixed", phase }
+		: { ...rest, ...patch, kind: "dynamic", phase };
+}
+
+/** Non-terminal transition of a fixed loop, including its recomputed next occurrence. */
+function fixedWithPhase(
+	entry: FixedCronEntry,
+	phase: ActivePhase,
+	patch: SharedPatch & { nextFireAt?: EpochMs } = {},
+): FixedCronEntry {
+	const { endedAt: _endedAt, endReason: _endReason, endDetail: _endDetail, ...rest } = entry;
+	return { ...rest, ...patch, kind: "fixed", phase };
+}
+
+/** Non-terminal transition of a dynamic loop, including its wakeup and keepalive fields. */
+function dynamicWithPhase(
+	entry: DynamicCronEntry,
+	phase: ActivePhase,
+	patch: SharedPatch & { pendingWakeup?: PendingWakeup | null; keepaliveCredit?: 0 | 1 } = {},
+): DynamicCronEntry {
+	const { endedAt: _endedAt, endReason: _endReason, endDetail: _endDetail, ...rest } = entry;
+	return { ...rest, ...patch, kind: "dynamic", phase };
+}
+
+function readIntEnv(
+	env: Record<string, string | undefined>,
+	name: string,
+	fallback: number,
+	min: number,
+	max: number,
+): number {
+	const raw = env[name];
+	if (raw === undefined || raw.trim().length === 0) return fallback;
+	const parsed = Number(raw.trim());
+	if (!Number.isInteger(parsed)) return fallback;
+	return Math.min(max, Math.max(min, parsed));
+}
+
+export function createLoopScheduler(deps: LoopSchedulerDeps): LoopScheduler {
+	const env = deps.env ?? process.env;
+	const keepaliveSeconds = readIntEnv(
+		env,
+		KEEPALIVE_SECONDS_ENV,
+		DEFAULT_KEEPALIVE_SECONDS,
+		MIN_KEEPALIVE_SECONDS,
+		MAX_KEEPALIVE_SECONDS,
+	);
+	const maxTicks = readIntEnv(env, MAX_TICKS_ENV, DEFAULT_MAX_TICKS, MIN_MAX_TICKS, Number.MAX_SAFE_INTEGER);
+
+	let state: LoopState = deps.initialState ?? {
+		version: LOOP_STATE_VERSION,
+		sessionId: deps.sessionId,
+		entries: {},
+		activeDynamicId: null,
+		updatedAt: 0,
+	};
+	let mutationCount = 0;
+
+	/** In-memory only: which delivery each loop currently has in flight. */
+	const inFlightDeliveries = new Map<LoopId, DeliveryId>();
+
+	/**
+	 * Applies one atomic state revision. Every transition in this module funnels through
+	 * here, so a multi-entry change (e.g. supersede + create) is a single revision and the
+	 * persistence callback observes no intermediate state.
+	 */
+	function commit(update: (entries: Record<LoopId, CronEntry>) => LoopId | null | undefined): void {
+		const entries: Record<LoopId, CronEntry> = { ...state.entries };
+		const nextDynamicId = update(entries);
+		state = {
+			version: LOOP_STATE_VERSION,
+			sessionId: state.sessionId,
+			entries,
+			activeDynamicId: nextDynamicId === undefined ? state.activeDynamicId : nextDynamicId,
+			updatedAt: deps.clock.now(),
+		};
+		mutationCount += 1;
+		deps.onStateChanged?.(state);
+	}
+
+	function entryOf(loopId: LoopId): CronEntry | undefined {
+		return state.entries[loopId];
+	}
+
+	function activeIds(): LoopId[] {
+		return Object.values(state.entries)
+			.filter(isActive)
+			.map((entry) => entry.id);
+	}
+
+	/** Cancels the timer and clears any pending wakeup, then marks the loop ended. */
+	function endEntry(
+		entries: Record<LoopId, CronEntry>,
+		entry: CronEntry,
+		nowMs: EpochMs,
+		endReason: LoopEndReason,
+		endDetail?: string,
+	): void {
+		deps.timers.cancel(entry.id);
+		inFlightDeliveries.delete(entry.id);
+		const terminal = {
+			phase: "ended" as const,
+			endedAt: nowMs,
+			endReason,
+			...(endDetail === undefined ? {} : { endDetail }),
+		};
+		entries[entry.id] =
+			entry.kind === "fixed" ? { ...entry, ...terminal } : { ...entry, ...terminal, pendingWakeup: null };
+	}
+
+	/**
+	 * Re-arms a loop's single timer, or ends it as `expired` when the next occurrence would
+	 * land at or after expiry. Returns the reason the loop ended, if it did.
+	 */
+	function armEntry(
+		entries: Record<LoopId, CronEntry>,
+		entry: CronEntry,
+		nowMs: EpochMs,
+		onFire: (loopId: LoopId) => void,
+	): LoopEndReason | undefined {
+		if (nowMs >= entry.expiresAt) {
+			endEntry(entries, entry, nowMs, "expired");
+			return "expired";
+		}
+		const dueAt = entry.kind === "fixed" ? entry.nextFireAt : entry.pendingWakeup?.dueAt;
+		if (dueAt === undefined) {
+			deps.timers.cancel(entry.id);
+			return undefined;
+		}
+		if (dueAt >= entry.expiresAt) {
+			// A tick may never fire at or after expiry, so retire the loop now rather than
+			// arming a timer that could only produce an illegal delivery.
+			endEntry(entries, entry, nowMs, "expired");
+			return "expired";
+		}
+		deps.timers.arm(entry.id, dueAt, () => onFire(entry.id));
+		return undefined;
+	}
+
+	/** Fire callback the timer port invokes; the extension re-enters through `onDue`. */
+	let fireHandler: (loopId: LoopId) => void = () => {};
+	function onFire(loopId: LoopId): void {
+		fireHandler(loopId);
+	}
+
+	function baseFields(nowMs: EpochMs, id: LoopId, request: CreateFixedRequest | CreateDynamicRequest) {
+		return {
+			id,
+			originalArgs: request.originalArgs,
+			reentryPrompt: request.reentryPrompt,
+			payload: request.payload,
+			createdAt: nowMs,
+			lastFiredAt: null,
+			expiresAt: nowMs + LOOP_EXPIRY_MS,
+			lastScheduledForAt: null,
+			coalescedFirePending: false,
+			queuedForAt: null,
+			noopStreak: 0,
+			tickCount: 0,
+			sentinelDelivery: {
+				autonomousPreambleDelivered: false,
+				lastLoopFileDelivered: null,
+				forceFullDelivery: false,
+			},
+			wakeSources: [],
+		};
+	}
+
+	function capRejection(): CreateResult {
+		const active = activeIds();
+		return {
+			ok: false,
+			reason: "active_loop_cap",
+			cap: MAX_ACTIVE_LOOPS,
+			activeLoopIds: active,
+			message:
+				`At most ${MAX_ACTIVE_LOOPS} loops can be active at once. Active: ${active.join(", ")}. ` +
+				"Stop one with `/loop stop <id>` or `/loop stop all` first.",
+		};
+	}
+
+	function createFixed(request: CreateFixedRequest): CreateResult {
+		if (activeIds().length >= MAX_ACTIVE_LOOPS) return capRejection();
+		const nowMs = deps.clock.now();
+		const id = deps.ids.loopId();
+		commit((entries) => {
+			const entry: FixedCronEntry = {
+				...baseFields(nowMs, id, request),
+				kind: "fixed",
+				phase: "waiting",
+				requestedInterval: request.requestedInterval,
+				effectiveInterval: request.effectiveInterval,
+				cronExpression: request.cronExpression,
+				nextFireAt: nextOccurrenceAfter(nowMs, request.intervalMs),
+				intervalMs: request.intervalMs,
+			};
+			entries[id] = entry;
+			// Arm before the caller dispatches the immediate first tick, so a failing first
+			// turn cannot silently lose the recurring schedule.
+			armEntry(entries, entry, nowMs, onFire);
+			return undefined;
+		});
+		return { ok: true, loopId: id };
+	}
+
+	function createDynamic(request: CreateDynamicRequest): CreateResult {
+		const existingDynamicId = state.activeDynamicId;
+		const existing = existingDynamicId === null ? undefined : entryOf(existingDynamicId);
+		const supersedes = existing !== undefined && isActive(existing);
+		// A superseded loop frees its slot, so it must not count against the cap.
+		const activeAfterSupersede = activeIds().filter((id) => !(supersedes && id === existingDynamicId));
+		if (activeAfterSupersede.length >= MAX_ACTIVE_LOOPS) return capRejection();
+
+		const nowMs = deps.clock.now();
+		const id = deps.ids.loopId();
+		commit((entries) => {
+			if (supersedes && existing !== undefined) {
+				endEntry(entries, existing, nowMs, "stopped", "superseded");
+			}
+			const entry: DynamicCronEntry = {
+				...baseFields(nowMs, id, request),
+				kind: "dynamic",
+				phase: "waiting",
+				pendingWakeup: null,
+				keepaliveCredit: 1,
+			};
+			entries[id] = entry;
+			return id;
+		});
+		return supersedes && existingDynamicId !== null
+			? { ok: true, loopId: id, supersededLoopId: existingDynamicId }
+			: { ok: true, loopId: id };
+	}
+
+	function onDue(loopId: LoopId, nowMs: EpochMs, sessionBusy: boolean): DueResult {
+		const entry = entryOf(loopId);
+		if (entry === undefined) return { action: "coalesce" };
+
+		if (nowMs >= entry.expiresAt) {
+			if (entry.phase === "ended") return { action: "coalesce" };
+			commit((entries) => {
+				endEntry(entries, entry, nowMs, "expired");
+				return undefined;
+			});
+			return { action: "expire" };
+		}
+		if (entry.phase === "ended" || entry.phase === "suspended") return { action: "coalesce" };
+		if (entry.tickCount >= maxTicks) return { action: "coalesce" };
+
+		if (isInFlight(entry)) {
+			// Invariant: one queued/running tick per loop. Extra occurrences collapse into a
+			// single pending bit and the schedule still moves forward from `now`.
+			commit((entries) => {
+				const coalesced =
+					entry.kind === "fixed"
+						? fixedWithPhase(entry, entry.phase, {
+								coalescedFirePending: true,
+								nextFireAt: nextOccurrenceAfter(nowMs, entry.intervalMs),
+							})
+						: dynamicWithPhase(entry, entry.phase, { coalescedFirePending: true });
+				entries[loopId] = coalesced;
+				armEntry(entries, coalesced, nowMs, onFire);
+				return undefined;
+			});
+			return { action: "coalesce" };
+		}
+
+		const deliveryId = deps.ids.deliveryId();
+		const tick: LoopTick = {
+			loopId,
+			deliveryId,
+			scheduledForAt: nowMs,
+			deliverAs: "followUp",
+			coalesced: entry.coalescedFirePending,
+		};
+		let expired = false;
+		commit((entries) => {
+			const dispatched = {
+				lastFiredAt: nowMs,
+				lastScheduledForAt: nowMs,
+				queuedForAt: nowMs,
+				coalescedFirePending: false,
+				tickCount: entry.tickCount + 1,
+			};
+			const phase = sessionBusy ? ("queued" as const) : ("running" as const);
+			const next =
+				entry.kind === "fixed"
+					? fixedWithPhase(entry, phase, {
+							...dispatched,
+							nextFireAt: nextOccurrenceAfter(nowMs, entry.intervalMs),
+						})
+					: dynamicWithPhase(entry, phase, { ...dispatched, pendingWakeup: null });
+			entries[loopId] = next;
+			// A dynamic loop has no schedule of its own; its next timer comes from
+			// schedule_wakeup or the keepalive fallback.
+			if (next.kind === "fixed") {
+				expired = armEntry(entries, next, nowMs, onFire) === "expired";
+			} else {
+				deps.timers.cancel(loopId);
+			}
+			return undefined;
+		});
+		if (!expired) inFlightDeliveries.set(loopId, deliveryId);
+		return { action: "dispatch", tick };
+	}
+
+	function onTickSettled(input: TickSettledInput): SettledResult {
+		const entry = entryOf(input.loopId);
+		if (entry === undefined) return { action: "ignored" };
+		if (input.outcome === "retrying") return { action: "in_progress" };
+		if (inFlightDeliveries.get(input.loopId) !== input.deliveryId) return { action: "ignored" };
+		inFlightDeliveries.delete(input.loopId);
+		if (entry.phase === "ended") return { action: "ignored" };
+		// A user abort already paused this loop; settling must not resurrect it.
+		if (entry.phase === "suspended") return { action: "idle" };
+
+		const nowMs = deps.clock.now();
+
+		if (nowMs >= entry.expiresAt) {
+			commit((entries) => {
+				endEntry(entries, entry, nowMs, "expired");
+				return undefined;
+			});
+			return { action: "ended", endReason: "expired" };
+		}
+
+		if (entry.tickCount >= maxTicks) {
+			// The budget bounds spend, not wall clock: expiry alone would let a `/loop 1m`
+			// job reach thousands of model turns.
+			commit((entries) => {
+				endEntry(entries, entry, nowMs, "tick_budget_exhausted");
+				return undefined;
+			});
+			return { action: "ended", endReason: "tick_budget_exhausted" };
+		}
+
+		if (entry.coalescedFirePending) {
+			// Exactly one delivery drains the coalesced occurrence, however many were missed.
+			commit((entries) => {
+				entries[input.loopId] = withPhase(entry, "waiting", { coalescedFirePending: false, queuedForAt: null });
+				return undefined;
+			});
+			return onDue(input.loopId, nowMs, false);
+		}
+
+		let expired = false;
+		commit((entries) => {
+			const settled = withPhase(entry, "waiting", { queuedForAt: null });
+			entries[input.loopId] = settled;
+			if (settled.kind === "fixed") {
+				expired = armEntry(entries, settled, nowMs, onFire) === "expired";
+			}
+			return undefined;
+		});
+		return expired ? { action: "ended", endReason: "expired" } : { action: "idle" };
+	}
+
+	function onScheduleWakeup(request: ScheduleWakeupInput): ScheduleWakeupResult {
+		const entry = entryOf(request.loopId);
+		if (entry === undefined) return { ok: false, reason: "unknown_loop" };
+		if (entry.kind !== "dynamic") return { ok: false, reason: "not_dynamic" };
+		if (entry.phase === "ended") return { ok: false, reason: "ended" };
+
+		const nowMs = deps.clock.now();
+		if (nowMs >= entry.expiresAt) {
+			commit((entries) => {
+				endEntry(entries, entry, nowMs, "expired");
+				return undefined;
+			});
+			return { ok: false, reason: "expired" };
+		}
+
+		const wakeupId = deps.ids.wakeupId();
+		const replacedWakeupId = entry.pendingWakeup?.id;
+		// Expiry is absolute: a new wakeup never extends `expiresAt`.
+		const dueAt = nowMs + request.delaySeconds * 1000;
+		const wakeup: PendingWakeup = {
+			id: wakeupId,
+			loopId: entry.id,
+			kind: "dynamic",
+			source: "model",
+			requestedDelaySeconds: request.requestedDelaySeconds,
+			delaySeconds: request.delaySeconds,
+			dueAt,
+			reason: request.reason,
+			prompt: request.prompt,
+			noop: request.noop,
+			createdAt: nowMs,
+		};
+		const noopStreak = request.noop ? entry.noopStreak + 1 : 0;
+		commit((entries) => {
+			const scheduled = dynamicWithPhase(entry, "waiting", {
+				queuedForAt: null,
+				pendingWakeup: wakeup,
+				// A successful model schedule restores the one-omission recovery budget.
+				keepaliveCredit: 1,
+				noopStreak,
+			});
+			entries[entry.id] = scheduled;
+			armEntry(entries, scheduled, nowMs, onFire);
+			return undefined;
+		});
+		return replacedWakeupId === undefined
+			? { ok: true, wakeupId, dueAt, noopStreak }
+			: { ok: true, wakeupId, replacedWakeupId, dueAt, noopStreak };
+	}
+
+	function onTurnEndedWithoutSchedule(loopId: LoopId): KeepaliveResult {
+		const entry = entryOf(loopId);
+		if (entry === undefined || entry.kind !== "dynamic") return { action: "ignored" };
+		// Fixed loops re-arm from their own schedule, and a paused or ended loop has no
+		// liveness to protect. A user abort lands here as `suspended`, which is exactly why
+		// an abort can never be converted into a keepalive omission.
+		if (entry.phase === "ended" || entry.phase === "suspended") return { action: "ignored" };
+
+		const nowMs = deps.clock.now();
+		if (nowMs >= entry.expiresAt) {
+			commit((entries) => {
+				endEntry(entries, entry, nowMs, "expired");
+				return undefined;
+			});
+			return { action: "ended", endReason: "expired" };
+		}
+
+		if (entry.keepaliveCredit === 0) {
+			commit((entries) => {
+				endEntry(entries, entry, nowMs, "keepalive_exhausted");
+				return undefined;
+			});
+			return { action: "ended", endReason: "keepalive_exhausted" };
+		}
+
+		const wakeupId = deps.ids.wakeupId();
+		const dueAt = nowMs + keepaliveSeconds * 1000;
+		const wakeup: PendingWakeup = {
+			id: wakeupId,
+			loopId: entry.id,
+			kind: "dynamic",
+			source: "keepalive",
+			requestedDelaySeconds: keepaliveSeconds,
+			delaySeconds: keepaliveSeconds,
+			dueAt,
+			reason: "keepalive armed (model did not reschedule)",
+			prompt: entry.reentryPrompt,
+			noop: false,
+			createdAt: nowMs,
+		};
+		let expired = false;
+		commit((entries) => {
+			const armed = dynamicWithPhase(entry, "waiting", {
+				queuedForAt: null,
+				pendingWakeup: wakeup,
+				keepaliveCredit: 0,
+			});
+			entries[entry.id] = armed;
+			expired = armEntry(entries, armed, nowMs, onFire) === "expired";
+			return undefined;
+		});
+		return expired
+			? { action: "ended", endReason: "expired" }
+			: { action: "keepalive_armed", wakeupId, delaySeconds: keepaliveSeconds, dueAt };
+	}
+
+	function pauseEntries(ids: readonly LoopId[]): LoopId[] {
+		const affected: LoopId[] = [];
+		const pausable = ids
+			.map((id) => entryOf(id))
+			.filter((entry): entry is CronEntry => entry !== undefined && isArmable(entry));
+		if (pausable.length === 0) return affected;
+		commit((entries) => {
+			for (const entry of pausable) {
+				deps.timers.cancel(entry.id);
+				inFlightDeliveries.delete(entry.id);
+				entries[entry.id] = withPhase(entry, "suspended", { queuedForAt: null });
+				affected.push(entry.id);
+			}
+			return undefined;
+		});
+		return affected;
+	}
+
+	function resolveTargets(target: LoopId | "all"): LoopId[] {
+		if (target !== "all") return [target];
+		return Object.values(state.entries).map((entry) => entry.id);
+	}
+
+	function pause(target: LoopId | "all"): TargetedResult {
+		return { affectedLoopIds: pauseEntries(resolveTargets(target)) };
+	}
+
+	function onUserAbort(loopId: LoopId): AbortResult {
+		// Esc is also how a user interrupts to steer, so an abort PAUSES the loop; the
+		// schedule survives for `/loop resume` and is never a terminal state.
+		const affected = pauseEntries([loopId]);
+		return { action: affected.length > 0 ? "paused" : "ignored" };
+	}
+
+	function resume(target: LoopId | "all"): TargetedResult {
+		const nowMs = deps.clock.now();
+		const resumable = resolveTargets(target)
+			.map((id) => entryOf(id))
+			.filter((entry): entry is CronEntry => entry !== undefined && entry.phase === "suspended");
+		if (resumable.length === 0) return { affectedLoopIds: [] };
+		const affected: LoopId[] = [];
+		commit((entries) => {
+			for (const entry of resumable) {
+				// The occurrence missed while paused is not replayed: the next fire is
+				// recomputed from now, exactly as after a sleep.
+				const rearmed =
+					entry.kind === "fixed"
+						? fixedWithPhase(entry, "waiting", {
+								queuedForAt: null,
+								nextFireAt: nextOccurrenceAfter(nowMs, entry.intervalMs),
+							})
+						: dynamicWithPhase(entry, "waiting", {
+								queuedForAt: null,
+								pendingWakeup:
+									entry.pendingWakeup === null
+										? null
+										: { ...entry.pendingWakeup, dueAt: Math.max(entry.pendingWakeup.dueAt, nowMs) },
+							});
+				entries[entry.id] = rearmed;
+				armEntry(entries, rearmed, nowMs, onFire);
+				affected.push(entry.id);
+			}
+			return undefined;
+		});
+		return { affectedLoopIds: affected };
+	}
+
+	function stop(target: LoopId | "all", detail: string): TargetedResult {
+		const nowMs = deps.clock.now();
+		const stoppable = resolveTargets(target)
+			.map((id) => entryOf(id))
+			.filter((entry): entry is CronEntry => entry !== undefined && isActive(entry));
+		if (stoppable.length === 0) return { affectedLoopIds: [] };
+		const affected: LoopId[] = [];
+		let clearDynamic = false;
+		commit((entries) => {
+			for (const entry of stoppable) {
+				endEntry(entries, entry, nowMs, "stopped", detail);
+				if (entry.id === state.activeDynamicId) clearDynamic = true;
+				affected.push(entry.id);
+			}
+			return clearDynamic ? null : undefined;
+		});
+		return { affectedLoopIds: affected };
+	}
+
+	function onShutdown(): ShutdownResult {
+		// Every senpi shutdown reason (quit|reload|new|resume|fork) leaves the session
+		// resumable, so shutdown SUSPENDS and emits no terminal reason.
+		const suspendable = Object.values(state.entries).filter(isArmable);
+		deps.timers.cancelAll();
+		if (suspendable.length === 0) return { suspendedLoopIds: [] };
+		const suspended: LoopId[] = [];
+		commit((entries) => {
+			for (const entry of suspendable) {
+				entries[entry.id] = withPhase(entry, "suspended", { queuedForAt: null });
+				suspended.push(entry.id);
+			}
+			return undefined;
+		});
+		inFlightDeliveries.clear();
+		return { suspendedLoopIds: suspended };
+	}
+
+	function restore(nowMs: EpochMs, options: RestoreOptions = {}): RestoreResult {
+		const recoveryTicks: LoopTick[] = [];
+		const expiredLoopIds: LoopId[] = [];
+		const rearmedLoopIds: LoopId[] = [];
+		const stillPausedLoopIds: LoopId[] = [];
+		const userPaused = new Set(options.userPausedLoopIds ?? []);
+		// A delivery this process still has in flight is NOT a crash remnant; only state
+		// whose owning process is gone needs recovering.
+		const liveDeliveries = new Set(inFlightDeliveries.keys());
+		deps.timers.cancelAll();
+
+		commit((entries) => {
+			for (const entry of Object.values(state.entries)) {
+				if (entry.phase === "ended") continue;
+				// A delivery this process still owns is in flight, not a crash remnant: leave it
+				// alone so restore can never duplicate a tick that is already running.
+				if (liveDeliveries.has(entry.id)) continue;
+				if (userPaused.has(entry.id)) {
+					// An explicit `/loop pause` outlives a restart: no timer, no recovery tick.
+					entries[entry.id] = withPhase(entry, "suspended", { queuedForAt: null });
+					stillPausedLoopIds.push(entry.id);
+					continue;
+				}
+				if (nowMs >= entry.expiresAt) {
+					endEntry(entries, entry, nowMs, "expired");
+					expiredLoopIds.push(entry.id);
+					continue;
+				}
+				// A crashed `starting`/`queued`/`running` remnant, a pending coalesced fire, and
+				// an overdue occurrence all collapse into ONE recovery delivery per job.
+				const dueAt = entry.kind === "fixed" ? entry.nextFireAt : entry.pendingWakeup?.dueAt;
+				const overdue = dueAt !== undefined && dueAt <= nowMs;
+				const crashRemnant = isInFlight(entry) || entry.phase === "starting";
+				const needsRecovery = (overdue || crashRemnant || entry.coalescedFirePending) && entry.tickCount < maxTicks;
+
+				const recovered =
+					entry.kind === "fixed"
+						? fixedWithPhase(entry, "waiting", {
+								queuedForAt: null,
+								coalescedFirePending: false,
+								nextFireAt: nextOccurrenceAfter(nowMs, entry.intervalMs),
+							})
+						: dynamicWithPhase(entry, "waiting", {
+								queuedForAt: null,
+								coalescedFirePending: false,
+								// The one-shot wakeup is consumed by the recovery delivery.
+								pendingWakeup: overdue ? null : entry.pendingWakeup,
+							});
+				entries[entry.id] = recovered;
+				const ended = armEntry(entries, recovered, nowMs, onFire);
+				if (ended === "expired") {
+					expiredLoopIds.push(entry.id);
+					continue;
+				}
+				if (needsRecovery) {
+					const deliveryId = deps.ids.deliveryId();
+					recoveryTicks.push({
+						loopId: entry.id,
+						deliveryId,
+						scheduledForAt: nowMs,
+						deliverAs: "followUp",
+						coalesced: true,
+					});
+				}
+				rearmedLoopIds.push(entry.id);
+			}
+			return undefined;
+		});
+
+		// Recovery deliveries count as dispatched ticks and occupy the single in-flight slot.
+		// One revision for all of them, so a persisting caller never sees a partial recovery.
+		if (recoveryTicks.length > 0) {
+			commit((entries) => {
+				for (const tick of recoveryTicks) {
+					const entry = entries[tick.loopId];
+					if (entry === undefined || entry.phase === "ended") continue;
+					entries[tick.loopId] = withPhase(entry, "queued", {
+						lastFiredAt: nowMs,
+						lastScheduledForAt: nowMs,
+						queuedForAt: nowMs,
+						tickCount: entry.tickCount + 1,
+					});
+					inFlightDeliveries.set(tick.loopId, tick.deliveryId);
+				}
+				return undefined;
+			});
+		}
+
+		return { recoveryTicks, expiredLoopIds, rearmedLoopIds, stillPausedLoopIds };
+	}
+
+	const scheduler: LoopScheduler = {
+		getState: () => state,
+		get mutationCount() {
+			return mutationCount;
+		},
+		maxTicks,
+		keepaliveSeconds,
+		currentDeliveryId: (loopId) => inFlightDeliveries.get(loopId),
+		createFixed,
+		createDynamic,
+		onDue,
+		onTickSettled,
+		onScheduleWakeup,
+		onTurnEndedWithoutSchedule,
+		onUserAbort,
+		pause,
+		resume,
+		stop,
+		onShutdown,
+		restore,
+	};
+
+	// The timer port fires with a loop id; the due decision is always re-derived from the
+	// clock so a stale callback cannot dispatch a tick the state machine would refuse.
+	fireHandler = (loopId) => {
+		scheduler.onDue(loopId, deps.clock.now(), false);
+	};
+
+	return scheduler;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/status.ts
@@ -82,7 +82,7 @@ export function formatNoopFold(noopStreak: number): string {
 export class LoopStatusTicker {
 	private readonly render: LoopStatusRender;
 	private readonly now: () => number;
-	private intervalId: NodeJS.Timeout | undefined;
+	private timeoutId: NodeJS.Timeout | undefined;
 	private state: LoopState | undefined;
 	private lastRendered: string | undefined;
 
@@ -92,27 +92,39 @@ export class LoopStatusTicker {
 	}
 
 	get running(): boolean {
-		return this.intervalId !== undefined;
+		return this.timeoutId !== undefined;
 	}
 
 	sync(state: LoopState): void {
 		this.state = state;
 		this.lastRendered = undefined;
 		this.tick();
-		if (this.intervalId !== undefined) return;
-		const handle = setInterval(() => this.tick(), LOOP_STATUS_TICK_INTERVAL_MS);
-		handle.unref();
-		this.intervalId = handle;
+		this.scheduleNext();
 	}
 
 	dispose(): void {
-		if (this.intervalId !== undefined) {
-			clearInterval(this.intervalId);
-			this.intervalId = undefined;
+		if (this.timeoutId !== undefined) {
+			clearTimeout(this.timeoutId);
+			this.timeoutId = undefined;
 		}
 		this.state = undefined;
 		this.lastRendered = undefined;
 		this.render(LOOP_STATUS_KEY, undefined);
+	}
+
+	private scheduleNext(): void {
+		if (this.timeoutId !== undefined) {
+			clearTimeout(this.timeoutId);
+		}
+		const handle = setTimeout(() => {
+			this.timeoutId = undefined;
+			this.tick();
+			if (this.state !== undefined) {
+				this.scheduleNext();
+			}
+		}, LOOP_STATUS_TICK_INTERVAL_MS);
+		handle.unref();
+		this.timeoutId = handle;
 	}
 
 	private tick(): void {

--- a/packages/coding-agent/src/core/extensions/builtin/loop/status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/status.ts
@@ -1,0 +1,125 @@
+import type { CronEntry, LoopState } from "./types.ts";
+
+export const LOOP_STATUS_KEY = "loop";
+export const LOOP_STATUS_TICK_INTERVAL_MS = 1000;
+
+export type LoopStatusRender = (key: string, text: string | undefined) => void;
+
+export interface LoopStatusTickerOptions {
+	readonly render: LoopStatusRender;
+	readonly now?: () => number;
+}
+
+function isArmed(entry: CronEntry): boolean {
+	return entry.phase !== "ended";
+}
+
+function formatDuration(ms: number): string {
+	const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+	if (totalSeconds < 60) {
+		return `${totalSeconds}s`;
+	}
+	const minutes = Math.floor(totalSeconds / 60);
+	if (minutes < 60) {
+		const seconds = totalSeconds % 60;
+		return seconds > 0 ? `${minutes}m${seconds}s` : `${minutes}m`;
+	}
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) {
+		const mins = minutes % 60;
+		return mins > 0 ? `${hours}h${mins}m` : `${hours}h`;
+	}
+	const days = Math.floor(hours / 24);
+	const hrs = hours % 24;
+	return hrs > 0 ? `${days}d${hrs}h` : `${days}d`;
+}
+
+function nextDueAt(entry: CronEntry): number | undefined {
+	if (entry.phase === "suspended" || entry.phase === "ended") return undefined;
+	if (entry.kind === "fixed") {
+		return entry.nextFireAt;
+	}
+	return entry.pendingWakeup?.dueAt;
+}
+
+export function formatLoopStatus(state: LoopState, nowMs: number): string | undefined {
+	const armed = Object.values(state.entries).filter(isArmed);
+	if (armed.length === 0) {
+		return undefined;
+	}
+
+	const paused = armed.some((entry) => entry.phase === "suspended");
+	if (paused) {
+		return "Loop paused - /loop resume or /loop stop";
+	}
+
+	let nearest: { entry: CronEntry; dueAt: number } | undefined;
+	for (const entry of armed) {
+		if (entry.phase === "suspended") continue;
+		const dueAt = nextDueAt(entry);
+		if (dueAt === undefined) continue;
+		if (nearest === undefined || dueAt < nearest.dueAt) {
+			nearest = { entry, dueAt };
+		}
+	}
+
+	if (nearest === undefined) {
+		return "Loop active - /loop stop";
+	}
+
+	const remainingMs = Math.max(0, nearest.dueAt - nowMs);
+	const mode = nearest.entry.kind === "fixed" ? "fixed" : "dynamic";
+	return `Loop (${mode}): next in ${formatDuration(remainingMs)} - /loop stop`;
+}
+
+export function formatNoopFold(noopStreak: number): string {
+	if (noopStreak < 2) {
+		return "";
+	}
+	return `↻ ${noopStreak} loop ticks with no actionable change`;
+}
+
+export class LoopStatusTicker {
+	private readonly render: LoopStatusRender;
+	private readonly now: () => number;
+	private intervalId: NodeJS.Timeout | undefined;
+	private state: LoopState | undefined;
+	private lastRendered: string | undefined;
+
+	constructor(options: LoopStatusTickerOptions) {
+		this.render = options.render;
+		this.now = options.now ?? Date.now;
+	}
+
+	get running(): boolean {
+		return this.intervalId !== undefined;
+	}
+
+	sync(state: LoopState): void {
+		this.state = state;
+		this.lastRendered = undefined;
+		this.tick();
+		if (this.intervalId !== undefined) return;
+		const handle = setInterval(() => this.tick(), LOOP_STATUS_TICK_INTERVAL_MS);
+		handle.unref();
+		this.intervalId = handle;
+	}
+
+	dispose(): void {
+		if (this.intervalId !== undefined) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+		this.state = undefined;
+		this.lastRendered = undefined;
+		this.render(LOOP_STATUS_KEY, undefined);
+	}
+
+	private tick(): void {
+		if (this.state === undefined) return;
+		const text = formatLoopStatus(this.state, this.now());
+		if (text === this.lastRendered) return;
+		this.lastRendered = text;
+		this.render(LOOP_STATUS_KEY, text);
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/store.ts
@@ -1,0 +1,498 @@
+/**
+ * Atomic, versioned, per-session sidecar store for `/loop` state.
+ *
+ * Mirrors the goal store's persistence discipline (temp file + rename, per-file mutation
+ * serialization, strict versioned parsing) because scheduler state must never be half
+ * written or silently reset: a corrupt file arms nothing and surfaces a typed error so
+ * the extension can end affected loops with `error` instead of guessing.
+ *
+ * Session custom entries are deliberately NOT the authoritative store: they are branch
+ * nodes, so a globally scanned "latest" entry can come from an abandoned branch, while
+ * loop schedules are session-scoped.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+	type CronEntry,
+	type DynamicCronEntry,
+	EFFECTIVE_INTERVAL_UNITS,
+	type EffectiveInterval,
+	type EffectiveIntervalUnit,
+	type EpochMs,
+	type FixedCronEntry,
+	isRecord,
+	LOOP_END_REASONS,
+	LOOP_PHASES,
+	LOOP_SENTINELS,
+	LOOP_STATE_VERSION,
+	LOOP_WAKE_SOURCE_KINDS,
+	type LoopEndReason,
+	type LoopEntryFields,
+	type LoopFileFingerprint,
+	type LoopLifecycle,
+	type LoopPayload,
+	type LoopPhase,
+	type LoopSentinel,
+	type LoopState,
+	type LoopStoreRef,
+	type LoopWakeSource,
+	type LoopWakeSourceKind,
+	type PendingWakeup,
+	REQUESTED_INTERVAL_UNITS,
+	type RequestedInterval,
+	type RequestedIntervalUnit,
+	type SentinelDeliveryState,
+} from "./types.ts";
+
+export class InvalidLoopStoreError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "InvalidLoopStoreError";
+	}
+}
+
+export class UnsupportedLoopStoreVersionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "UnsupportedLoopStoreVersionError";
+	}
+}
+
+/** Mutation callback. May be async; its result becomes the next persisted state. */
+export type LoopStateMutation = (current: LoopState) => LoopState | Promise<LoopState>;
+
+const mutationTails = new Map<string, Promise<void>>();
+const snapshots = new Map<string, LoopState>();
+
+export function encodedSessionId(ref: LoopStoreRef): string {
+	return encodeURIComponent(ref.sessionId);
+}
+
+export function loopStateFilePath(ref: LoopStoreRef): string {
+	return join(ref.baseDir, `${encodedSessionId(ref)}.json`);
+}
+
+export function emptyLoopState(sessionId: string): LoopState {
+	return { version: LOOP_STATE_VERSION, sessionId, entries: {}, activeDynamicId: null, updatedAt: 0 };
+}
+
+/**
+ * Reads persisted state, or null when this session has never persisted any loop.
+ * Throws {@link InvalidLoopStoreError} / {@link UnsupportedLoopStoreVersionError} on
+ * unusable state so callers fail closed rather than resetting a user's schedule.
+ */
+export async function readLoopState(ref: LoopStoreRef): Promise<LoopState | null> {
+	let raw: string;
+	try {
+		raw = await readFile(loopStateFilePath(ref), "utf8");
+	} catch (error) {
+		if (isFileSystemError(error, "ENOENT")) return null;
+		throw error;
+	}
+	const state = parseLoopState(raw, ref);
+	snapshots.set(loopStateFilePath(ref), state);
+	return state;
+}
+
+/** Like {@link readLoopState}, but returns an empty state when nothing is persisted. */
+export async function loadLoopState(ref: LoopStoreRef): Promise<LoopState> {
+	return (await readLoopState(ref)) ?? emptyLoopState(ref.sessionId);
+}
+
+/**
+ * Last successfully loaded or written state for this ref, for synchronous consumers
+ * (status line, tick attribution). Undefined until the store has been touched.
+ */
+export function snapshotLoopState(ref: LoopStoreRef): LoopState | undefined {
+	return snapshots.get(loopStateFilePath(ref));
+}
+
+/**
+ * Serializes read-modify-write cycles through a per-file promise tail so command,
+ * timer, tool, and lifecycle writes cannot interleave and lose an update.
+ */
+export function mutateLoopState(ref: LoopStoreRef, mutation: LoopStateMutation): Promise<LoopState> {
+	return enqueue(ref, async () => {
+		const current = await loadLoopState(ref);
+		const next = await mutation(current);
+		await writeLoopState(ref, next);
+		return next;
+	});
+}
+
+/** Persists a complete state atomically. Prefer {@link mutateLoopState} for updates. */
+export async function writeLoopState(ref: LoopStoreRef, state: LoopState): Promise<void> {
+	const filePath = loopStateFilePath(ref);
+	await mkdir(dirname(filePath), { recursive: true });
+	await writeAtomic(filePath, `${JSON.stringify(state, null, 2)}\n`);
+	snapshots.set(filePath, state);
+}
+
+/** Drops cached snapshots; used when a session ends or tests reset global state. */
+export function clearLoopStateSnapshot(ref: LoopStoreRef): void {
+	snapshots.delete(loopStateFilePath(ref));
+}
+
+function enqueue<T>(ref: LoopStoreRef, operation: () => Promise<T>): Promise<T> {
+	const key = loopStateFilePath(ref);
+	const previous = mutationTails.get(key) ?? Promise.resolve();
+	const run = previous.then(operation);
+	const tail = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	mutationTails.set(key, tail);
+	void tail.then(() => {
+		if (mutationTails.get(key) === tail) mutationTails.delete(key);
+	});
+	return run;
+}
+
+async function writeAtomic(filePath: string, contents: string): Promise<void> {
+	const tempPath = join(dirname(filePath), `.loop-${randomUUID()}.tmp`);
+	try {
+		await writeFile(tempPath, contents, { encoding: "utf8", mode: 0o600 });
+		await rename(tempPath, filePath);
+	} catch (error) {
+		try {
+			await rm(tempPath, { force: true });
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"loop store write failed and its temporary file could not be removed",
+			);
+		}
+		throw error;
+	}
+}
+
+function parseLoopState(raw: string, ref: LoopStoreRef): LoopState {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw new InvalidLoopStoreError("loop store contains unparseable JSON", { cause: error });
+	}
+	if (!isRecord(parsed)) throw new InvalidLoopStoreError("loop store must be a JSON object");
+	if (parsed.version !== LOOP_STATE_VERSION) {
+		throw new UnsupportedLoopStoreVersionError(
+			`unsupported loop store version: ${JSON.stringify(parsed.version)} (expected ${LOOP_STATE_VERSION})`,
+		);
+	}
+	if (typeof parsed.sessionId !== "string" || parsed.sessionId.length === 0) {
+		throw new InvalidLoopStoreError("loop store is missing a sessionId");
+	}
+	if (parsed.sessionId !== ref.sessionId) {
+		throw new InvalidLoopStoreError(
+			`loop store sessionId ${parsed.sessionId} does not match the session it was loaded for`,
+		);
+	}
+	if (!isEpochMs(parsed.updatedAt)) throw new InvalidLoopStoreError("loop store has an invalid updatedAt");
+	if (!isRecord(parsed.entries)) throw new InvalidLoopStoreError("loop store entries must be an object");
+
+	const entries: Record<string, CronEntry> = {};
+	for (const [id, value] of Object.entries(parsed.entries)) {
+		const entry = parseEntry(id, value);
+		entries[id] = entry;
+	}
+
+	const activeDynamicId = parsed.activeDynamicId;
+	if (activeDynamicId !== null) {
+		if (typeof activeDynamicId !== "string") {
+			throw new InvalidLoopStoreError("loop store activeDynamicId must be a string or null");
+		}
+		const active = entries[activeDynamicId];
+		if (active === undefined || active.kind !== "dynamic") {
+			throw new InvalidLoopStoreError(`loop store activeDynamicId ${activeDynamicId} does not name a dynamic loop`);
+		}
+	}
+
+	return {
+		version: LOOP_STATE_VERSION,
+		sessionId: parsed.sessionId,
+		entries,
+		activeDynamicId,
+		updatedAt: parsed.updatedAt,
+	};
+}
+
+function parseEntry(id: string, value: unknown): CronEntry {
+	if (!isRecord(value)) throw new InvalidLoopStoreError(`loop entry ${id} is not an object`);
+	if (value.id !== id) throw new InvalidLoopStoreError(`loop entry ${id} carries a mismatched id`);
+	const kind = value.kind;
+	if (kind !== "fixed" && kind !== "dynamic") throw new InvalidLoopStoreError(`loop entry ${id} has an unknown kind`);
+
+	const base = parseEntryFields(id, value);
+	if (kind === "fixed") {
+		const fixed: FixedCronEntry = {
+			...base,
+			kind: "fixed",
+			requestedInterval: parseRequestedInterval(id, value.requestedInterval),
+			effectiveInterval: parseEffectiveInterval(id, value.effectiveInterval),
+			cronExpression: requireString(id, "cronExpression", value.cronExpression),
+			nextFireAt: requireEpochMs(id, "nextFireAt", value.nextFireAt),
+			intervalMs: requirePositiveInteger(id, "intervalMs", value.intervalMs),
+		};
+		return fixed;
+	}
+
+	const keepaliveCredit = value.keepaliveCredit;
+	if (keepaliveCredit !== 0 && keepaliveCredit !== 1) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid keepaliveCredit`);
+	}
+	const dynamic: DynamicCronEntry = {
+		...base,
+		kind: "dynamic",
+		pendingWakeup: parsePendingWakeup(id, value.pendingWakeup),
+		keepaliveCredit,
+	};
+	return dynamic;
+}
+
+function parseEntryFields(id: string, value: Record<string, unknown>): LoopEntryFields & LoopLifecycle {
+	const fields = {
+		id,
+		originalArgs: requireString(id, "originalArgs", value.originalArgs, { allowEmpty: true }),
+		reentryPrompt: requireString(id, "reentryPrompt", value.reentryPrompt),
+		payload: parsePayload(id, value.payload),
+		createdAt: requireEpochMs(id, "createdAt", value.createdAt),
+		lastFiredAt: parseNullableEpochMs(id, "lastFiredAt", value.lastFiredAt),
+		expiresAt: requireEpochMs(id, "expiresAt", value.expiresAt),
+		lastScheduledForAt: parseNullableEpochMs(id, "lastScheduledForAt", value.lastScheduledForAt),
+		coalescedFirePending: requireBoolean(id, "coalescedFirePending", value.coalescedFirePending),
+		queuedForAt: parseNullableEpochMs(id, "queuedForAt", value.queuedForAt),
+		noopStreak: requireNonNegativeInteger(id, "noopStreak", value.noopStreak),
+		tickCount: requireNonNegativeInteger(id, "tickCount", value.tickCount),
+		sentinelDelivery: parseSentinelDelivery(id, value.sentinelDelivery),
+		wakeSources: parseWakeSources(id, value.wakeSources),
+	};
+	return { ...fields, ...parseLifecycle(id, value) };
+}
+
+type ParsedLifecycle =
+	| { phase: Exclude<LoopPhase, "ended"> }
+	| { phase: "ended"; endedAt: EpochMs; endReason: LoopEndReason; endDetail?: string };
+
+function parseLifecycle(id: string, value: Record<string, unknown>): ParsedLifecycle {
+	const phase = value.phase;
+	if (typeof phase !== "string" || !isLoopPhase(phase)) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid phase`);
+	}
+	if (phase !== "ended") {
+		if (value.endedAt !== undefined || value.endReason !== undefined || value.endDetail !== undefined) {
+			throw new InvalidLoopStoreError(`loop entry ${id} carries terminal fields while not ended`);
+		}
+		return { phase };
+	}
+	const endReason = value.endReason;
+	if (typeof endReason !== "string" || !isLoopEndReason(endReason)) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid endReason`);
+	}
+	const endDetail = value.endDetail;
+	if (endDetail !== undefined && typeof endDetail !== "string") {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid endDetail`);
+	}
+	return {
+		phase: "ended",
+		endedAt: requireEpochMs(id, "endedAt", value.endedAt),
+		endReason,
+		...(endDetail === undefined ? {} : { endDetail }),
+	};
+}
+
+function parsePayload(id: string, value: unknown): LoopPayload {
+	if (!isRecord(value)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid payload`);
+	if (value.type === "prompt") {
+		return { type: "prompt", prompt: requireString(id, "payload.prompt", value.prompt) };
+	}
+	if (value.type === "sentinel") {
+		const sentinel = value.sentinel;
+		if (typeof sentinel !== "string" || !isLoopSentinel(sentinel)) {
+			throw new InvalidLoopStoreError(`loop entry ${id} has an unknown payload sentinel`);
+		}
+		return { type: "sentinel", sentinel };
+	}
+	throw new InvalidLoopStoreError(`loop entry ${id} has an unknown payload type`);
+}
+
+function parseSentinelDelivery(id: string, value: unknown): SentinelDeliveryState {
+	if (!isRecord(value)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid sentinelDelivery`);
+	return {
+		autonomousPreambleDelivered: requireBoolean(
+			id,
+			"sentinelDelivery.autonomousPreambleDelivered",
+			value.autonomousPreambleDelivered,
+		),
+		lastLoopFileDelivered: parseFingerprint(id, value.lastLoopFileDelivered),
+		forceFullDelivery: requireBoolean(id, "sentinelDelivery.forceFullDelivery", value.forceFullDelivery),
+	};
+}
+
+function parseFingerprint(id: string, value: unknown): LoopFileFingerprint | null {
+	if (value === null) return null;
+	if (!isRecord(value)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid loop-file fingerprint`);
+	return {
+		path: requireString(id, "fingerprint.path", value.path),
+		mtimeMs: requireFiniteNumber(id, "fingerprint.mtimeMs", value.mtimeMs),
+		size: requireNonNegativeInteger(id, "fingerprint.size", value.size),
+		contentHash: requireString(id, "fingerprint.contentHash", value.contentHash),
+		anchorDeliveryId: requireString(id, "fingerprint.anchorDeliveryId", value.anchorDeliveryId),
+	};
+}
+
+function parseWakeSources(id: string, value: unknown): readonly LoopWakeSource[] {
+	if (!Array.isArray(value)) throw new InvalidLoopStoreError(`loop entry ${id} has invalid wakeSources`);
+	return value.map((candidate): LoopWakeSource => {
+		if (!isRecord(candidate)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid wake source`);
+		const source = candidate.source;
+		if (typeof source !== "string" || !isWakeSourceKind(source)) {
+			throw new InvalidLoopStoreError(`loop entry ${id} has an unknown wake source kind`);
+		}
+		const description = candidate.description;
+		if (description !== undefined && typeof description !== "string") {
+			throw new InvalidLoopStoreError(`loop entry ${id} has an invalid wake source description`);
+		}
+		return {
+			source,
+			id: requireString(id, "wakeSource.id", candidate.id),
+			createdAt: requireEpochMs(id, "wakeSource.createdAt", candidate.createdAt),
+			...(description === undefined ? {} : { description }),
+		};
+	});
+}
+
+function parsePendingWakeup(id: string, value: unknown): PendingWakeup | null {
+	if (value === null || value === undefined) return null;
+	if (!isRecord(value)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid pendingWakeup`);
+	const source = value.source;
+	if (source !== "model" && source !== "keepalive") {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid pendingWakeup source`);
+	}
+	if (value.kind !== "dynamic") throw new InvalidLoopStoreError(`loop entry ${id} has an invalid pendingWakeup kind`);
+	return {
+		id: requireString(id, "pendingWakeup.id", value.id),
+		loopId: requireString(id, "pendingWakeup.loopId", value.loopId),
+		kind: "dynamic",
+		source,
+		requestedDelaySeconds: requireFiniteNumber(
+			id,
+			"pendingWakeup.requestedDelaySeconds",
+			value.requestedDelaySeconds,
+		),
+		delaySeconds: requirePositiveInteger(id, "pendingWakeup.delaySeconds", value.delaySeconds),
+		dueAt: requireEpochMs(id, "pendingWakeup.dueAt", value.dueAt),
+		reason: requireString(id, "pendingWakeup.reason", value.reason),
+		prompt: requireString(id, "pendingWakeup.prompt", value.prompt),
+		noop: requireBoolean(id, "pendingWakeup.noop", value.noop),
+		createdAt: requireEpochMs(id, "pendingWakeup.createdAt", value.createdAt),
+	};
+}
+
+function parseRequestedInterval(id: string, value: unknown): RequestedInterval {
+	if (!isRecord(value)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid requestedInterval`);
+	const unit = value.unit;
+	if (typeof unit !== "string" || !isRequestedIntervalUnit(unit)) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid requestedInterval unit`);
+	}
+	return {
+		value: requirePositiveInteger(id, "requestedInterval.value", value.value),
+		unit,
+		raw: requireString(id, "requestedInterval.raw", value.raw),
+	};
+}
+
+function parseEffectiveInterval(id: string, value: unknown): EffectiveInterval {
+	if (!isRecord(value)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid effectiveInterval`);
+	const unit = value.unit;
+	if (typeof unit !== "string" || !isEffectiveIntervalUnit(unit)) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid effectiveInterval unit`);
+	}
+	const roundingNotice = value.roundingNotice;
+	if (roundingNotice !== undefined && typeof roundingNotice !== "string") {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid effectiveInterval roundingNotice`);
+	}
+	return {
+		value: requirePositiveInteger(id, "effectiveInterval.value", value.value),
+		unit,
+		human: requireString(id, "effectiveInterval.human", value.human),
+		rounded: requireBoolean(id, "effectiveInterval.rounded", value.rounded),
+		...(roundingNotice === undefined ? {} : { roundingNotice }),
+	};
+}
+
+function requireString(id: string, field: string, value: unknown, options?: { allowEmpty?: boolean }): string {
+	if (typeof value !== "string" || (options?.allowEmpty !== true && value.length === 0)) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid ${field}`);
+	}
+	return value;
+}
+
+function requireBoolean(id: string, field: string, value: unknown): boolean {
+	if (typeof value !== "boolean") throw new InvalidLoopStoreError(`loop entry ${id} has an invalid ${field}`);
+	return value;
+}
+
+function requireFiniteNumber(id: string, field: string, value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid ${field}`);
+	}
+	return value;
+}
+
+function requireNonNegativeInteger(id: string, field: string, value: unknown): number {
+	if (!Number.isSafeInteger(value) || (value as number) < 0) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid ${field}`);
+	}
+	return value as number;
+}
+
+function requirePositiveInteger(id: string, field: string, value: unknown): number {
+	if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+		throw new InvalidLoopStoreError(`loop entry ${id} has an invalid ${field}`);
+	}
+	return value as number;
+}
+
+function requireEpochMs(id: string, field: string, value: unknown): EpochMs {
+	if (!isEpochMs(value)) throw new InvalidLoopStoreError(`loop entry ${id} has an invalid ${field}`);
+	return value;
+}
+
+function parseNullableEpochMs(id: string, field: string, value: unknown): EpochMs | null {
+	if (value === null || value === undefined) return null;
+	return requireEpochMs(id, field, value);
+}
+
+function isEpochMs(value: unknown): value is EpochMs {
+	return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isLoopPhase(value: string): value is LoopPhase {
+	return (LOOP_PHASES as readonly string[]).includes(value);
+}
+
+function isLoopEndReason(value: string): value is LoopEndReason {
+	return (LOOP_END_REASONS as readonly string[]).includes(value);
+}
+
+function isLoopSentinel(value: string): value is LoopSentinel {
+	return (LOOP_SENTINELS as readonly string[]).includes(value);
+}
+
+function isWakeSourceKind(value: string): value is LoopWakeSourceKind {
+	return (LOOP_WAKE_SOURCE_KINDS as readonly string[]).includes(value);
+}
+
+function isRequestedIntervalUnit(value: string): value is RequestedIntervalUnit {
+	return (REQUESTED_INTERVAL_UNITS as readonly string[]).includes(value);
+}
+
+function isEffectiveIntervalUnit(value: string): value is EffectiveIntervalUnit {
+	return (EFFECTIVE_INTERVAL_UNITS as readonly string[]).includes(value);
+}
+
+function isFileSystemError(error: unknown, code: string): boolean {
+	return error instanceof Error && "code" in error && error.code === code;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/tick-prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/tick-prompt.ts
@@ -1,0 +1,273 @@
+/**
+ * Tick-prompt templates with cache-friendly sentinel expansion.
+ *
+ * `buildTickMessage` is pure: it reads no files, touches no clock, and mutates nothing.
+ * The caller resolves the loop file (see `loopfile.ts`) and hands the snapshot in; this
+ * module decides full-vs-reminder delivery, renders the tick text, and returns the
+ * updated sentinel delivery state to persist.
+ *
+ * Cache discipline: the long instruction blocks are delivered once (the "anchor") and
+ * later ticks send a short reminder that points back at that anchored message, so the
+ * cached message prefix stays stable across fires.
+ */
+
+import type {
+	DeliveryId,
+	LoopFileFingerprint,
+	LoopId,
+	LoopPayload,
+	LoopSentinel,
+	SentinelDeliveryState,
+} from "./types.ts";
+
+export type LoopMode = "fixed" | "dynamic";
+
+/** `prompt` covers a verbatim user prompt; sentinels alternate between full and reminder. */
+export type TickDelivery = "full" | "reminder" | "prompt";
+
+/** Resolved loop-file state for this fire, produced by the caller's loop-file reader. */
+export type LoopFileSnapshot =
+	| { readonly present: false }
+	| {
+			readonly present: true;
+			readonly path: string;
+			/** Model-visible (already truncated) representation. */
+			readonly content: string;
+			readonly mtimeMs: number;
+			readonly size: number;
+			/** SHA-256 of the model-visible representation. */
+			readonly contentHash: string;
+	  };
+
+export interface TickPromptInput {
+	readonly loopId: LoopId;
+	readonly deliveryId: DeliveryId;
+	readonly mode: LoopMode;
+	readonly payload: LoopPayload;
+	/** Canonical re-entry text, e.g. `/loop check the deploy` or `/loop`. */
+	readonly reentryPrompt: string;
+	readonly deliveryState: SentinelDeliveryState;
+	readonly loopFile: LoopFileSnapshot;
+}
+
+export interface LoopTickDetails {
+	readonly loopId: LoopId;
+	readonly deliveryId: DeliveryId;
+	readonly mode: LoopMode;
+	readonly delivery: TickDelivery;
+	readonly sentinel?: LoopSentinel;
+	readonly loopFile?: LoopFileFingerprint;
+}
+
+export interface TickPromptResult {
+	readonly text: string;
+	readonly delivery: TickDelivery;
+	readonly details: LoopTickDetails;
+	/** Delivery state to persist after this tick is dispatched. */
+	readonly deliveryState: SentinelDeliveryState;
+}
+
+const LOOP_FILE_HEADER = "# /loop tick - loop.md tasks";
+const AUTONOMOUS_HEADER = "# Autonomous loop tick";
+const DYNAMIC_PACING_SUFFIX = " (dynamic pacing)";
+
+const FIXED_RESCHEDULE_RULE = [
+	"The fixed recurring schedule fires the next tick automatically - do not call `schedule_wakeup` from this tick.",
+	"If this tick errors, the schedule stays armed and the next occurrence still fires.",
+].join("\n");
+
+function dynamicRescheduleRule(reentryPrompt: string): string {
+	return [
+		`As the last action of this turn, call \`schedule_wakeup\` with \`prompt: ${JSON.stringify(reentryPrompt)}\` so the loop stays alive; a turn that ends without it burns the single keepalive fallback and then the loop ends.`,
+		"To end the loop instead, call `schedule_wakeup` with `{ stop: true }` and a reason.",
+		"When the next step is gated on observable state, do not sleep or poll: watch terminal output with `monitor`, inspect it with `bash_output`, stop the watcher with `kill_bash`, and let task-notification wakeups resume this loop. With one of those armed, the scheduled delay is only a fallback heartbeat (1200-1800s is the normal idle range).",
+		"Set `noop: true` only when this tick found no actionable change, and notify the user only on changes worth acting on - not once per tick.",
+	].join("\n");
+}
+
+function modeRule(mode: LoopMode, reentryPrompt: string): string {
+	return mode === "fixed" ? FIXED_RESCHEDULE_RULE : dynamicRescheduleRule(reentryPrompt);
+}
+
+function header(base: string, mode: LoopMode): string {
+	return mode === "dynamic" ? `${base}${DYNAMIC_PACING_SUFFIX}` : base;
+}
+
+const AUTONOMOUS_FULL_BODY = [
+	"No loop-tasks file is configured, so run the standard autonomous maintenance pass for this tick:",
+	"",
+	"1. Inspect current state: active tasks, running terminal commands and monitors, and any delegated child work.",
+	"2. Make concrete progress where progress is possible; do not merely narrate.",
+	"3. Avoid repeating unchanged status - stay silent when nothing moved.",
+	"4. Surface only actionable state changes to the user, once per state change.",
+].join("\n");
+
+const AUTONOMOUS_REMINDER_BODY =
+	"Continue the autonomous maintenance pass established by the most recent full autonomous loop instruction message in this conversation. Re-read that anchored message and perform the next applicable work.";
+
+const LOOP_FILE_REMINDER_BODY =
+	"Continue the loop.md tasks established by the most recent full loop.md instruction message in this conversation. Re-read that anchored message and perform the next applicable work.";
+
+const LOOP_FILE_INTRO =
+	"The user configured a loop-tasks file. Work through the tasks defined below; these are the instructions for this tick and every subsequent tick (the reminder on later fires refers back to this message).";
+
+const LOOP_FILE_ABSENT_BODY =
+	"The loop-tasks file used by this loop is currently absent. Perform the autonomous maintenance check for this tick. Keep the loop alive so a later tick can pick up the file if it reappears.";
+
+function joinBlocks(blocks: readonly string[]): string {
+	return blocks.filter((block) => block.length > 0).join("\n\n");
+}
+
+function sentinelOf(payload: LoopPayload): LoopSentinel | undefined {
+	return payload.type === "sentinel" ? payload.sentinel : undefined;
+}
+
+function isLoopFileSentinel(sentinel: LoopSentinel): boolean {
+	return sentinel === "<<loop.md>>" || sentinel === "<<loop.md-dynamic>>";
+}
+
+function fingerprintChanged(
+	previous: LoopFileFingerprint,
+	snapshot: Extract<LoopFileSnapshot, { present: true }>,
+): boolean {
+	return (
+		previous.path !== snapshot.path ||
+		previous.mtimeMs !== snapshot.mtimeMs ||
+		previous.size !== snapshot.size ||
+		previous.contentHash !== snapshot.contentHash
+	);
+}
+
+function buildPromptTick(input: TickPromptInput, prompt: string): TickPromptResult {
+	const text = joinBlocks([prompt, modeRule(input.mode, input.reentryPrompt)]);
+	return {
+		text,
+		delivery: "prompt",
+		details: {
+			loopId: input.loopId,
+			deliveryId: input.deliveryId,
+			mode: input.mode,
+			delivery: "prompt",
+		},
+		// A verbatim prompt tick carries no sentinel instructions, so nothing is anchored.
+		deliveryState: input.deliveryState,
+	};
+}
+
+function buildLoopFileTick(input: TickPromptInput, sentinel: LoopSentinel): TickPromptResult {
+	const { deliveryState, loopFile, mode } = input;
+	const rule = modeRule(mode, input.reentryPrompt);
+
+	if (!loopFile.present) {
+		// Absence keeps the loop.md sentinel: a later tick must detect reappearance.
+		const text = joinBlocks([header("# /loop tick - loop.md absent", mode), LOOP_FILE_ABSENT_BODY, rule]);
+		return {
+			text,
+			delivery: "full",
+			details: {
+				loopId: input.loopId,
+				deliveryId: input.deliveryId,
+				mode,
+				delivery: "full",
+				sentinel,
+			},
+			deliveryState: {
+				...deliveryState,
+				lastLoopFileDelivered: null,
+				forceFullDelivery: false,
+			},
+		};
+	}
+
+	const previous = deliveryState.lastLoopFileDelivered;
+	const full = deliveryState.forceFullDelivery || previous === null || fingerprintChanged(previous, loopFile);
+
+	if (!full) {
+		return {
+			text: joinBlocks([LOOP_FILE_HEADER, LOOP_FILE_REMINDER_BODY, rule]),
+			delivery: "reminder",
+			details: {
+				loopId: input.loopId,
+				deliveryId: input.deliveryId,
+				mode,
+				delivery: "reminder",
+				sentinel,
+				loopFile: previous,
+			},
+			deliveryState,
+		};
+	}
+
+	const fingerprint: LoopFileFingerprint = {
+		path: loopFile.path,
+		mtimeMs: loopFile.mtimeMs,
+		size: loopFile.size,
+		contentHash: loopFile.contentHash,
+		anchorDeliveryId: input.deliveryId,
+	};
+
+	const text = joinBlocks([LOOP_FILE_HEADER, LOOP_FILE_INTRO, `---\n${loopFile.content}\n---`, rule]);
+
+	return {
+		text,
+		delivery: "full",
+		details: {
+			loopId: input.loopId,
+			deliveryId: input.deliveryId,
+			mode,
+			delivery: "full",
+			sentinel,
+			loopFile: fingerprint,
+		},
+		deliveryState: {
+			...deliveryState,
+			lastLoopFileDelivered: fingerprint,
+			forceFullDelivery: false,
+		},
+	};
+}
+
+function buildAutonomousTick(input: TickPromptInput, sentinel: LoopSentinel): TickPromptResult {
+	const { deliveryState, mode } = input;
+	const rule = modeRule(mode, input.reentryPrompt);
+	const full = deliveryState.forceFullDelivery || !deliveryState.autonomousPreambleDelivered;
+	const head = header(AUTONOMOUS_HEADER, mode);
+
+	const text = full
+		? joinBlocks([head, AUTONOMOUS_FULL_BODY, rule])
+		: joinBlocks([head, AUTONOMOUS_REMINDER_BODY, rule]);
+
+	return {
+		text,
+		delivery: full ? "full" : "reminder",
+		details: {
+			loopId: input.loopId,
+			deliveryId: input.deliveryId,
+			mode,
+			delivery: full ? "full" : "reminder",
+			sentinel,
+		},
+		deliveryState: full
+			? { ...deliveryState, autonomousPreambleDelivered: true, forceFullDelivery: false }
+			: deliveryState,
+	};
+}
+
+/**
+ * Render one tick message plus the delivery state to persist afterwards.
+ *
+ * Full delivery happens on the first sentinel delivery, when `forceFullDelivery` is set
+ * (accepted compaction or a missing anchor on resume), when the loop file's fingerprint
+ * changed, or when the file reappeared after absence. Otherwise the tick is a short
+ * reminder anchored to the last full message.
+ */
+export function buildTickMessage(input: TickPromptInput): TickPromptResult {
+	if (input.payload.type === "prompt") {
+		return buildPromptTick(input, input.payload.prompt);
+	}
+	const sentinel = sentinelOf(input.payload);
+	if (sentinel === undefined) {
+		throw new Error("loop tick payload is a sentinel without a sentinel value");
+	}
+	return isLoopFileSentinel(sentinel) ? buildLoopFileTick(input, sentinel) : buildAutonomousTick(input, sentinel);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/tools.ts
@@ -1,0 +1,275 @@
+/**
+ * The `schedule_wakeup` model tool: the ONLY model-callable surface of the `/loop`
+ * extension. It lets a dynamic (self-paced) loop pick its own next delay, or end itself.
+ *
+ * Two deliberate shape decisions:
+ * - The TypeBox schema is a FLAT object with no root union. Several provider payload
+ *   conversions rebuild tool schemas from top-level `properties` only, so a root
+ *   `anyOf` would reach the model as an empty schema (same reasoning as
+ *   `terminal/tools/monitor.ts`). Branch requirements are enforced in `execute`.
+ * - `delaySeconds` carries NO schema `minimum`/`maximum`. The contract clamps
+ *   out-of-range integers instead of rejecting them, and schema bounds would make the
+ *   clamp unreachable.
+ *
+ * Scheduler state is never mutated here: every effect goes through the injected
+ * `ScheduleWakeupSchedulerPort`.
+ */
+
+import { Type } from "typebox";
+import type { AgentToolResult, ExtensionAPI } from "../../types.ts";
+import type { EpochMs, LoopId, WakeupId } from "./types.ts";
+
+/** Model-visible tool name. */
+export const SCHEDULE_WAKEUP_TOOL = "schedule_wakeup";
+
+/** Inclusive bounds the executor clamps `delaySeconds` into. */
+export const MIN_WAKEUP_DELAY_SECONDS = 60;
+export const MAX_WAKEUP_DELAY_SECONDS = 3600;
+
+export const SCHEDULE_WAKEUP_DESCRIPTION = `Schedule when to resume work in /loop dynamic mode. Always pass the \`prompt\` argument unless stopping. Call this as the last action before ending a dynamic loop iteration so the loop remains alive; call with \`stop: true\` to end the active dynamic loop immediately.
+
+\`delaySeconds\` is clamped to ${MIN_WAKEUP_DELAY_SECONDS}-${MAX_WAKEUP_DELAY_SECONDS} seconds. For idle polling, normally use 1200-1800 seconds. Avoid choosing 300 seconds merely to poll: short polling repeatedly loses prompt-cache value on many API paths. When work is gated on observable terminal state, use \`monitor\` instead of sleeping or polling; inspect it with \`bash_output\` and stop the watcher with \`kill_bash\`. For delegated work, use the available \`task\` output and control tools and let task completion notifications wake the session. When a monitor or task notification is the primary wake source, the scheduled delay is only a fallback heartbeat.
+
+For normal dynamic re-entry, set \`prompt\` to the complete original command, for example \`/loop check the deploy\`, preserving the user's text verbatim. Set \`noop: true\` only when this iteration found no actionable change; consecutive noop iterations are folded in the terminal view. Omit \`noop\` when stopping. Notify the user only when state changes in a way worth acting on, not once per tick.`;
+
+export const scheduleWakeupSchema = Type.Object(
+	{
+		delaySeconds: Type.Optional(
+			Type.Integer({
+				description: `Dynamic loop delay in seconds. Values are clamped to ${MIN_WAKEUP_DELAY_SECONDS}-${MAX_WAKEUP_DELAY_SECONDS}.`,
+			}),
+		),
+		reason: Type.String({
+			minLength: 1,
+			description: "Why this wakeup or stop is appropriate. Must not be blank.",
+		}),
+		prompt: Type.Optional(
+			Type.String({
+				description:
+					"Prompt to dispatch when the wakeup fires. Required unless stop is true; preserve the original /loop command verbatim for normal dynamic re-entry.",
+			}),
+		),
+		stop: Type.Optional(
+			Type.Boolean({
+				description: "End the active dynamic loop immediately instead of scheduling another wakeup.",
+			}),
+		),
+		noop: Type.Optional(
+			Type.Boolean({
+				description:
+					"True when this iteration observed no actionable change. Consecutive noop iterations are folded in the terminal view. Omit when stopping.",
+			}),
+		),
+	},
+	{ additionalProperties: false },
+);
+
+/** Runtime-validated parameter shape; the schema itself stays flat and permissive. */
+export interface ScheduleWakeupParams {
+	readonly delaySeconds?: number;
+	readonly reason: string;
+	readonly prompt?: string;
+	readonly stop?: boolean;
+	readonly noop?: boolean;
+}
+
+export interface ScheduleWakeupScheduledDetails {
+	readonly ok: true;
+	readonly action: "scheduled";
+	readonly loopId: LoopId;
+	readonly wakeupId: WakeupId;
+	readonly replacedWakeupId?: WakeupId;
+
+	/** Integer the model asked for, before the clamp. */
+	readonly requestedDelaySeconds: number;
+	/** Effective delay after clamping to `[60, 3600]`. */
+	readonly delaySeconds: number;
+	readonly clamped: boolean;
+	readonly dueAt: EpochMs;
+
+	readonly reason: string;
+	/** Preserved verbatim after the non-blank check. */
+	readonly prompt: string;
+	readonly noop: boolean;
+	readonly noopStreak: number;
+}
+
+export interface ScheduleWakeupStoppedDetails {
+	readonly ok: true;
+	readonly action: "stopped";
+	readonly loopId: LoopId;
+	readonly terminalReason: "stopped";
+	readonly reason: string;
+	readonly endedAt: EpochMs;
+	/** Fields accepted for model compatibility but not applied. */
+	readonly ignoredFields: readonly ScheduleWakeupIgnorableField[];
+}
+
+export type ScheduleWakeupIgnorableField = "delaySeconds" | "prompt";
+
+export type ScheduleWakeupDetails = ScheduleWakeupScheduledDetails | ScheduleWakeupStoppedDetails;
+
+/**
+ * Which loop, if any, this tool call belongs to. `null` means no loop context at all;
+ * a `fixed` target means the call came from a fixed tick, whose schedule re-arms itself.
+ */
+export type ScheduleWakeupTarget = { readonly kind: "dynamic" | "fixed"; readonly loopId: LoopId } | null;
+
+export interface ScheduleWakeupRequest {
+	readonly loopId: LoopId;
+	readonly requestedDelaySeconds: number;
+	readonly delaySeconds: number;
+	readonly reason: string;
+	readonly prompt: string;
+	readonly noop: boolean;
+}
+
+export interface ScheduleWakeupOutcome {
+	readonly wakeupId: WakeupId;
+	/** Set when this schedule replaced a still-pending wakeup for the same loop. */
+	readonly replacedWakeupId?: WakeupId;
+	readonly dueAt: EpochMs;
+	readonly noopStreak: number;
+}
+
+export interface StopDynamicLoopRequest {
+	readonly loopId: LoopId;
+	readonly reason: string;
+}
+
+export interface StopDynamicLoopOutcome {
+	readonly endedAt: EpochMs;
+}
+
+/**
+ * Minimal scheduler surface this tool needs. Declared locally so the tool module stays
+ * independent of the scheduler implementation and testable with a fake.
+ */
+export interface ScheduleWakeupSchedulerPort {
+	/** Loop the current turn is attributed to, resolved at call time. */
+	getWakeupTarget(): ScheduleWakeupTarget;
+	scheduleWakeup(request: ScheduleWakeupRequest): Promise<ScheduleWakeupOutcome>;
+	stopDynamicLoop(request: StopDynamicLoopRequest): Promise<StopDynamicLoopOutcome>;
+}
+
+export interface LoopToolRegistrationDeps {
+	readonly scheduler: ScheduleWakeupSchedulerPort;
+}
+
+export const NO_ACTIVE_DYNAMIC_LOOP_ERROR = `${SCHEDULE_WAKEUP_TOOL} can only be used while a dynamic /loop is active.`;
+export const FIXED_TICK_ERROR = `This is a fixed /loop tick; the recurring schedule re-arms automatically. Do not call ${SCHEDULE_WAKEUP_TOOL}.`;
+export const MISSING_PROMPT_ERROR = "prompt is required and must be non-empty unless stop is true.";
+export const MISSING_DELAY_ERROR = "delaySeconds is required unless stop is true.";
+export const NON_INTEGER_DELAY_ERROR = "delaySeconds must be a finite integer number of seconds.";
+export const BLANK_REASON_ERROR = "reason is required and must be non-empty.";
+export const NOOP_WITH_STOP_ERROR = "noop must be omitted when stop is true.";
+
+function clampDelaySeconds(requested: number): number {
+	return Math.min(MAX_WAKEUP_DELAY_SECONDS, Math.max(MIN_WAKEUP_DELAY_SECONDS, requested));
+}
+
+function resolveDynamicLoopId(scheduler: ScheduleWakeupSchedulerPort): LoopId {
+	const target = scheduler.getWakeupTarget();
+	if (target === null) throw new Error(NO_ACTIVE_DYNAMIC_LOOP_ERROR);
+	if (target.kind === "fixed") throw new Error(FIXED_TICK_ERROR);
+	return target.loopId;
+}
+
+function requireReason(reason: string): string {
+	const trimmed = typeof reason === "string" ? reason.trim() : "";
+	if (trimmed.length === 0) throw new Error(BLANK_REASON_ERROR);
+	return trimmed;
+}
+
+function collectIgnoredFields(params: ScheduleWakeupParams): ScheduleWakeupIgnorableField[] {
+	const ignored: ScheduleWakeupIgnorableField[] = [];
+	if (params.delaySeconds !== undefined) ignored.push("delaySeconds");
+	if (params.prompt !== undefined) ignored.push("prompt");
+	return ignored;
+}
+
+async function executeStop(
+	scheduler: ScheduleWakeupSchedulerPort,
+	params: ScheduleWakeupParams,
+): Promise<AgentToolResult<ScheduleWakeupDetails>> {
+	if (params.noop !== undefined) throw new Error(NOOP_WITH_STOP_ERROR);
+	const reason = requireReason(params.reason);
+	const loopId = resolveDynamicLoopId(scheduler);
+	const ignoredFields = collectIgnoredFields(params);
+	const { endedAt } = await scheduler.stopDynamicLoop({ loopId, reason });
+	return {
+		content: [{ type: "text" as const, text: `Stopped dynamic loop ${loopId}.` }],
+		details: {
+			ok: true,
+			action: "stopped",
+			loopId,
+			terminalReason: "stopped",
+			reason,
+			endedAt,
+			ignoredFields,
+		},
+	};
+}
+
+async function executeSchedule(
+	scheduler: ScheduleWakeupSchedulerPort,
+	params: ScheduleWakeupParams,
+): Promise<AgentToolResult<ScheduleWakeupDetails>> {
+	const reason = requireReason(params.reason);
+	const requestedDelaySeconds = params.delaySeconds;
+	if (requestedDelaySeconds === undefined) throw new Error(MISSING_DELAY_ERROR);
+	if (!Number.isInteger(requestedDelaySeconds)) throw new Error(NON_INTEGER_DELAY_ERROR);
+	const prompt = params.prompt;
+	if (prompt === undefined || prompt.trim().length === 0) throw new Error(MISSING_PROMPT_ERROR);
+
+	const loopId = resolveDynamicLoopId(scheduler);
+	const delaySeconds = clampDelaySeconds(requestedDelaySeconds);
+	const clamped = delaySeconds !== requestedDelaySeconds;
+	const noop = params.noop === true;
+
+	const outcome = await scheduler.scheduleWakeup({
+		loopId,
+		requestedDelaySeconds,
+		delaySeconds,
+		reason,
+		prompt,
+		noop,
+	});
+
+	const text = clamped
+		? `Scheduled loop ${loopId} in ${delaySeconds}s; requested ${requestedDelaySeconds}s was clamped to the supported ${MIN_WAKEUP_DELAY_SECONDS}-${MAX_WAKEUP_DELAY_SECONDS}s range.`
+		: `Scheduled loop ${loopId} in ${delaySeconds}s.`;
+
+	return {
+		content: [{ type: "text" as const, text }],
+		details: {
+			ok: true,
+			action: "scheduled",
+			loopId,
+			wakeupId: outcome.wakeupId,
+			...(outcome.replacedWakeupId === undefined ? {} : { replacedWakeupId: outcome.replacedWakeupId }),
+			requestedDelaySeconds,
+			delaySeconds,
+			clamped,
+			dueAt: outcome.dueAt,
+			reason,
+			prompt,
+			noop,
+			noopStreak: outcome.noopStreak,
+		},
+	};
+}
+
+export function registerLoopTools(pi: ExtensionAPI, deps: LoopToolRegistrationDeps): void {
+	pi.registerTool({
+		name: SCHEDULE_WAKEUP_TOOL,
+		label: "Schedule Wakeup",
+		description: SCHEDULE_WAKEUP_DESCRIPTION,
+		parameters: scheduleWakeupSchema,
+		// Sequential so two concurrent model tool calls cannot race scheduler state.
+		executionMode: "sequential",
+		async execute(_toolCallId, params): Promise<AgentToolResult<ScheduleWakeupDetails>> {
+			return params.stop === true ? executeStop(deps.scheduler, params) : executeSchedule(deps.scheduler, params);
+		},
+	});
+}

--- a/packages/coding-agent/src/core/extensions/builtin/loop/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/types.ts
@@ -1,0 +1,270 @@
+/**
+ * Shared state model for the `/loop` builtin extension.
+ *
+ * This module is the single type home for the whole feature: the store, the scheduler,
+ * the `schedule_wakeup` tool, the tick-prompt builder, and the status presenter all
+ * consume these declarations. It is data-only — no clock access, no I/O, no timers.
+ */
+
+/** Milliseconds since the Unix epoch. */
+export type EpochMs = number;
+
+/** Identifier of a single `/loop` job within one session. */
+export type LoopId = string;
+/** Identifier of one dynamic wakeup (model-scheduled or keepalive fallback). */
+export type WakeupId = string;
+/** Identifier of one dispatched tick delivery, used to anchor sentinel reminders. */
+export type DeliveryId = string;
+
+export const LOOP_STATE_VERSION = 1;
+export type LoopStateVersion = typeof LOOP_STATE_VERSION;
+
+export const LOOP_KINDS = ["fixed", "dynamic"] as const;
+export type LoopKind = (typeof LOOP_KINDS)[number];
+
+export const LOOP_SENTINELS = [
+	"<<autonomous-loop>>",
+	"<<autonomous-loop-dynamic>>",
+	"<<loop.md>>",
+	"<<loop.md-dynamic>>",
+] as const;
+export type LoopSentinel = (typeof LOOP_SENTINELS)[number];
+
+export type LoopPayload =
+	| {
+			readonly type: "prompt";
+			/** Exact parsed prompt, including a leading slash command. */
+			readonly prompt: string;
+	  }
+	| {
+			readonly type: "sentinel";
+			readonly sentinel: LoopSentinel;
+	  };
+
+export const LOOP_PHASES = ["starting", "waiting", "queued", "running", "suspended", "ended"] as const;
+export type LoopPhase = (typeof LOOP_PHASES)[number];
+
+/**
+ * Terminal reasons, exhaustively.
+ *
+ * There is deliberately NO `session_closed`: every senpi shutdown reason
+ * (`quit|reload|new|resume|fork`) leaves the session resumable, so shutdown SUSPENDS a
+ * loop instead of ending it, and no code path can reach a session-closed terminal state.
+ */
+export const LOOP_END_REASONS = [
+	"stopped",
+	"keepalive_exhausted",
+	"expired",
+	"tick_budget_exhausted",
+	"error",
+] as const;
+export type LoopEndReason = (typeof LOOP_END_REASONS)[number];
+
+export type LoopLifecycle =
+	| {
+			readonly phase: Exclude<LoopPhase, "ended">;
+			readonly endedAt?: never;
+			readonly endReason?: never;
+			readonly endDetail?: never;
+	  }
+	| {
+			readonly phase: "ended";
+			readonly endedAt: EpochMs;
+			readonly endReason: LoopEndReason;
+			/** Machine-stable subtype (e.g. `superseded`) or human-readable error detail. */
+			readonly endDetail?: string;
+	  };
+
+export interface LoopFileFingerprint {
+	readonly path: string;
+	readonly mtimeMs: number;
+	readonly size: number;
+	/** SHA-256 of the model-visible, truncated representation. */
+	readonly contentHash: string;
+	/** Delivery that carried the full loop-file block a reminder can point back to. */
+	readonly anchorDeliveryId: DeliveryId;
+}
+
+export interface SentinelDeliveryState {
+	/**
+	 * True after a full autonomous preamble has been delivered and its anchor is still
+	 * believed to be present in the compaction-aware context.
+	 */
+	readonly autonomousPreambleDelivered: boolean;
+
+	/**
+	 * Last full loop-file representation delivered. Null before the first delivery and
+	 * after the file disappears.
+	 */
+	readonly lastLoopFileDelivered: LoopFileFingerprint | null;
+
+	/**
+	 * Set by an accepted compaction or a failed anchor reconstruction. The next fire must
+	 * deliver a full preamble regardless of the fields above.
+	 */
+	readonly forceFullDelivery: boolean;
+}
+
+export const REQUESTED_INTERVAL_UNITS = ["s", "m", "h", "d"] as const;
+export type RequestedIntervalUnit = (typeof REQUESTED_INTERVAL_UNITS)[number];
+
+export const EFFECTIVE_INTERVAL_UNITS = ["m", "h", "d"] as const;
+export type EffectiveIntervalUnit = (typeof EFFECTIVE_INTERVAL_UNITS)[number];
+
+export interface RequestedInterval {
+	readonly value: number;
+	readonly unit: RequestedIntervalUnit;
+	/** Exact token parsed from the command, e.g. `90m`. */
+	readonly raw: string;
+}
+
+export interface EffectiveInterval {
+	readonly value: number;
+	readonly unit: EffectiveIntervalUnit;
+	readonly human: string;
+	readonly rounded: boolean;
+	readonly roundingNotice?: string;
+}
+
+export const LOOP_WAKE_SOURCE_KINDS = ["terminal-monitor", "terminal-background-session", "task", "other"] as const;
+export type LoopWakeSourceKind = (typeof LOOP_WAKE_SOURCE_KINDS)[number];
+
+export interface LoopWakeSource {
+	readonly source: LoopWakeSourceKind;
+	readonly id: string;
+	readonly description?: string;
+	readonly createdAt: EpochMs;
+}
+
+export interface PendingWakeup {
+	readonly id: WakeupId;
+	readonly loopId: LoopId;
+	readonly kind: "dynamic";
+	readonly source: "model" | "keepalive";
+
+	readonly requestedDelaySeconds: number;
+	/** Effective delay after the executor clamp to `[60, 3600]`. */
+	readonly delaySeconds: number;
+	readonly dueAt: EpochMs;
+
+	readonly reason: string;
+	/** Preserved verbatim after non-blank validation. */
+	readonly prompt: string;
+	readonly noop: boolean;
+
+	readonly createdAt: EpochMs;
+}
+
+export interface LoopEntryFields {
+	readonly id: LoopId;
+
+	/** Exact arguments after `/loop `, excluding the command name. */
+	readonly originalArgs: string;
+
+	/**
+	 * Canonical re-entry text. A bare invocation is `/loop`; otherwise this is
+	 * `"/loop " + originalArgs`.
+	 */
+	readonly reentryPrompt: string;
+
+	readonly payload: LoopPayload;
+
+	readonly createdAt: EpochMs;
+	readonly lastFiredAt: EpochMs | null;
+	readonly expiresAt: EpochMs;
+
+	/**
+	 * Scheduled wall-clock occurrence most recently delivered. Prevents duplicate delivery
+	 * after sleep, resume, or a stale timer callback.
+	 */
+	readonly lastScheduledForAt: EpochMs | null;
+
+	/**
+	 * At most one extra fire may be pending while this loop already has a queued or
+	 * running delivery. Missed occurrences coalesce into this flag; they are never replayed.
+	 */
+	readonly coalescedFirePending: boolean;
+	readonly queuedForAt: EpochMs | null;
+
+	/**
+	 * Consecutive dynamic iterations that scheduled with `noop: true`. User input or a
+	 * non-noop iteration resets it.
+	 */
+	readonly noopStreak: number;
+
+	/** Ticks dispatched so far; drives the `tick_budget_exhausted` safety valve. */
+	readonly tickCount: number;
+
+	readonly sentinelDelivery: SentinelDeliveryState;
+
+	/**
+	 * Wake-source IDs created or adopted by this loop, used to attribute
+	 * monitor/task notifications to a loop iteration.
+	 */
+	readonly wakeSources: readonly LoopWakeSource[];
+}
+
+export type LoopEntryBase = LoopEntryFields & LoopLifecycle & { readonly kind: LoopKind };
+
+export type FixedCronEntry = LoopEntryFields &
+	LoopLifecycle & {
+		readonly kind: "fixed";
+		readonly requestedInterval: RequestedInterval;
+		readonly effectiveInterval: EffectiveInterval;
+		/** Display-only restricted cron string; scheduling uses `intervalMs` + `nextFireAt`. */
+		readonly cronExpression: string;
+
+		/** Next occurrence strictly later than the last scheduler observation. */
+		readonly nextFireAt: EpochMs;
+		readonly intervalMs: number;
+
+		readonly pendingWakeup?: never;
+		/** Fixed ticks are re-armed by the schedule itself, so keepalive never applies. */
+		readonly keepaliveCredit?: never;
+	};
+
+export type DynamicCronEntry = LoopEntryFields &
+	LoopLifecycle & {
+		readonly kind: "dynamic";
+		readonly requestedInterval?: never;
+		readonly effectiveInterval?: never;
+		readonly cronExpression?: never;
+		readonly nextFireAt?: never;
+		readonly intervalMs?: never;
+
+		readonly pendingWakeup: PendingWakeup | null;
+
+		/**
+		 * One means an omitted `schedule_wakeup` may consume one fallback. Zero means
+		 * another omission ends the loop with `keepalive_exhausted`. A successful model
+		 * schedule resets this to one.
+		 */
+		readonly keepaliveCredit: 0 | 1;
+	};
+
+export type CronEntry = FixedCronEntry | DynamicCronEntry;
+
+export interface LoopState {
+	readonly version: LoopStateVersion;
+	readonly sessionId: string;
+
+	/**
+	 * Includes ended records so a resume never resurrects a terminal loop.
+	 */
+	readonly entries: Readonly<Record<LoopId, CronEntry>>;
+
+	/** At most one dynamic loop; fixed loops may coexist with it and with each other. */
+	readonly activeDynamicId: LoopId | null;
+
+	readonly updatedAt: EpochMs;
+}
+
+/** Locates the per-session sidecar file. Timer handles are never persisted. */
+export interface LoopStoreRef {
+	readonly baseDir: string;
+	readonly sessionId: string;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/test/suite/loop-command.test.ts
+++ b/packages/coding-agent/test/suite/loop-command.test.ts
@@ -422,6 +422,31 @@ describe("/loop command", () => {
 		expect(loopStatusFileExists(loop)).toBe(false);
 	});
 
+	it("print-mode rejection reaches a real output channel, not only ctx.ui.notify", async () => {
+		// Regression: headless hosts install `noOpUIContext` (runner.ts), whose notify() is a literal
+		// no-op. This suite injects a capturing UI, so a notify-only rejection passes here while the
+		// real `-p` run prints nothing at all and exits 0 - violating Scope 18's "clear message".
+		// stderr is the right channel: takeOverStdout() reserves real stdout for -p result data.
+		const written: string[] = [];
+		const originalWrite = process.stderr.write;
+		process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+			written.push(String(chunk));
+			return true;
+		}) as typeof process.stderr.write;
+		let loop: LoopHarness;
+		try {
+			loop = await createLoopHarness({ mode: "print" });
+			await prompt(loop, "/loop 5m ping");
+		} finally {
+			process.stderr.write = originalWrite;
+		}
+
+		const emitted = written.join("");
+		expect(emitted, `nothing reached stderr; captured: ${JSON.stringify(written)}`).toContain("interactive");
+		// The refusal must still arm nothing.
+		expect(await loop.store()).toBeNull();
+	});
+
 	it("a slash-command payload dispatches through the command path via expandPromptTemplates", async () => {
 		const loop = await createLoopHarness();
 		loop.harness.setResponses([]);

--- a/packages/coding-agent/test/suite/loop-command.test.ts
+++ b/packages/coding-agent/test/suite/loop-command.test.ts
@@ -1,0 +1,447 @@
+/**
+ * `/loop` command tests: registration metadata, the fixed/dynamic/bare start surfaces,
+ * stop/pause/resume/status subcommands, usage on invalid input, print-mode rejection,
+ * and slash-payload dispatch through the real command path.
+ *
+ * Everything runs through `createHarness` with the real loop extension factory, so the
+ * command handler is exercised exactly as `session.prompt("/loop ...")` drives it.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { CONFIG_DIR_NAME } from "../../src/config.ts";
+import loopExtension from "../../src/core/extensions/builtin/loop/index.ts";
+import { loopStateFilePath, readLoopState } from "../../src/core/extensions/builtin/loop/store.ts";
+import type { CronEntry, LoopState, LoopStoreRef } from "../../src/core/extensions/builtin/loop/types.ts";
+import type { ExtensionUIContext } from "../../src/core/extensions/types.ts";
+import { theme } from "../../src/modes/interactive/theme/theme.ts";
+import { createHarness, getAssistantTexts, getUserTexts, type Harness } from "./harness.ts";
+
+interface CapturedNotice {
+	readonly message: string;
+	readonly type: string | undefined;
+}
+
+interface LoopHarness {
+	readonly harness: Harness;
+	readonly notices: CapturedNotice[];
+	readonly statuses: Array<string | undefined>;
+	readonly storeRef: LoopStoreRef;
+	noticesText(): string;
+	store(): Promise<LoopState | null>;
+}
+
+const harnesses: LoopHarness[] = [];
+
+function createUi(notices: CapturedNotice[], statuses: Array<string | undefined>): ExtensionUIContext {
+	return {
+		select: async () => undefined,
+		confirm: async () => false,
+		input: async () => undefined,
+		notify: (message, type) => notices.push({ message, type }),
+		onTerminalInput: () => () => {},
+		setStatus: (_key: string, text: string | undefined) => statuses.push(text),
+		setWorkingMessage: () => {},
+		setWorkingVisible: () => {},
+		setWorkingIndicator: () => {},
+		setHiddenThinkingLabel: () => {},
+		setWidget: () => {},
+		setFooter: () => {},
+		setHeader: () => {},
+		setTitle: () => {},
+		custom: async () => undefined as never,
+		pasteToEditor: () => {},
+		setEditorText: () => {},
+		getEditorText: () => "",
+		editor: async () => undefined,
+		addAutocompleteProvider: () => {},
+		setEditorComponent: () => {},
+		getEditorComponent: () => undefined,
+		theme,
+		getAllThemes: () => [],
+		getTheme: () => undefined,
+		setTheme: () => ({ success: false, error: "UI not available" }),
+		getToolsExpanded: () => false,
+		setToolsExpanded: () => {},
+	};
+}
+
+async function createLoopHarness(
+	options: { mode?: "tui" | "print"; loopFileContent?: string } = {},
+): Promise<LoopHarness> {
+	const harness = await createHarness({ extensionFactories: [loopExtension], persistSession: true });
+	const notices: CapturedNotice[] = [];
+	const statuses: Array<string | undefined> = [];
+	await harness.session.bindExtensions({ mode: options.mode ?? "tui", uiContext: createUi(notices, statuses) });
+	if (options.loopFileContent !== undefined) {
+		const configDir = join(harness.tempDir, CONFIG_DIR_NAME);
+		await mkdir(configDir, { recursive: true });
+		await writeFile(join(configDir, "loop.md"), options.loopFileContent, "utf8");
+	}
+	const loop: LoopHarness = {
+		harness,
+		notices,
+		statuses,
+		storeRef: {
+			baseDir: join(harness.sessionManager.getSessionDir(), "extensions", "loop"),
+			sessionId: harness.sessionManager.getSessionId(),
+		},
+		noticesText: () => notices.map((notice) => notice.message).join("\n"),
+		store: () => readLoopState(loop.storeRef),
+	};
+	harnesses.push(loop);
+	return loop;
+}
+
+/** Waits for a state change with a bounded deadline; never a fixed sleep. */
+async function waitFor(condition: () => boolean, label: string, timeoutMs = 8000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!condition()) {
+		if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+}
+
+async function prompt(loop: LoopHarness, text: string): Promise<void> {
+	await loop.harness.session.prompt(text);
+}
+
+/** Arms a fixed loop and waits until its first tick produced a model response. */
+async function armFixedLoop(loop: LoopHarness, args: string, marker: string): Promise<string> {
+	loop.harness.setResponses([fauxAssistantMessage(`done: ${marker}`)]);
+	await prompt(loop, `/loop ${args}`);
+	await waitFor(
+		() => getAssistantTexts(loop.harness).some((text) => text.includes(`done: ${marker}`)),
+		`first tick of /loop ${args}`,
+	);
+	return expectLoopId(loop, "scheduled");
+}
+
+function expectLoopId(loop: LoopHarness, keyword: string): string {
+	const pattern = new RegExp(`Loop (\\S+) ${keyword}`);
+	let found = "";
+	for (const notice of loop.notices) {
+		const match = pattern.exec(notice.message);
+		if (match !== null) found = match[1];
+	}
+	expect(found, `expected a "Loop <id> ${keyword}" notice`).toBeTruthy();
+	return found;
+}
+
+function activeEntries(entries: Record<string, CronEntry>): CronEntry[] {
+	return Object.values(entries).filter((entry) => entry.phase !== "ended");
+}
+
+afterEach(() => {
+	while (harnesses.length > 0) harnesses.pop()?.harness.cleanup();
+});
+
+describe("/loop command", () => {
+	it("registers with a description, the documented argument hint, and subcommand completions", async () => {
+		const loop = await createLoopHarness();
+		const command = loop.harness
+			.getExtensionRunner()
+			.getRegisteredCommands()
+			.find((item) => item.name === "loop");
+		expect(command, "expected /loop to be registered").toBeDefined();
+		expect(command?.description).toBeTruthy();
+		expect(command?.argumentHint).toBe("[interval] [prompt] | stop [id|all] | status | pause | resume");
+
+		const completions = (await command?.getArgumentCompletions?.("")) ?? null;
+		expect(completions?.map((item) => item.value)).toEqual(["stop", "status", "pause", "resume"]);
+		expect((await command?.getArgumentCompletions?.("st"))?.map((item) => item.value)).toEqual(["stop", "status"]);
+		expect((await command?.getArgumentCompletions?.("pause"))?.map((item) => item.value)).toEqual(["pause"]);
+		expect(await command?.getArgumentCompletions?.("zzz")).toBeNull();
+	});
+
+	it("/loop 5m ping confirms cadence, id, expiry, and stop command, then ticks immediately", async () => {
+		const loop = await createLoopHarness();
+		const loopId = await armFixedLoop(loop, "5m ping", "ping");
+
+		const text = loop.noticesText();
+		expect(text).toContain(`Loop ${loopId} scheduled as \`*/5 * * * *\` (every 5 minutes).`);
+		expect(text).toContain("It expires automatically at");
+		expect(text).toContain("(7 days)");
+		expect(text).toContain(`Stop it with \`/loop stop ${loopId}\`.`);
+		expect(text).toContain("Running the first tick now.");
+		// A clean interval must not claim rounding.
+		expect(text).not.toContain("rounds to");
+
+		// The first tick reached the model immediately, carrying the verbatim prompt.
+		const tickText = getUserTexts(loop.harness).at(-1) ?? "";
+		expect(tickText).toContain("ping");
+		expect(tickText).toContain("do not call `schedule_wakeup`");
+
+		// The schedule was persisted and armed before that dispatch.
+		const state = await loop.store();
+		const entry = state?.entries[loopId];
+		expect(entry?.kind).toBe("fixed");
+		expect(entry?.phase === "ended").toBe(false);
+		expect(entry?.payload).toEqual({ type: "prompt", prompt: "ping" });
+		expect((entry as { nextFireAt?: number }).nextFireAt).toBeGreaterThan(0);
+		expect(loop.harness.sessionManager.getSessionId()).toBe(state?.sessionId);
+	});
+
+	it("/loop 90m ping reports the rounding to 2 hours naming both values", async () => {
+		const loop = await createLoopHarness();
+		const loopId = await armFixedLoop(loop, "90m ping", "rounding");
+
+		const text = loop.noticesText();
+		expect(text).toContain(`Loop ${loopId} scheduled as \`0 */2 * * *\` (every 2 hours; requested 90m).`);
+		expect(text).toContain("Requested 90m rounds to 2 hours.");
+	});
+
+	it("/loop ping starts dynamic mode and a second /loop reports superseding the first", async () => {
+		const loop = await createLoopHarness();
+		loop.harness.setResponses([fauxAssistantMessage("dyn one"), fauxAssistantMessage("dyn two")]);
+		await prompt(loop, "/loop ping");
+		await waitFor(
+			() => getAssistantTexts(loop.harness).some((text) => text.includes("dyn one")),
+			"first dynamic tick",
+		);
+		const firstId = expectLoopId(loop, "started");
+
+		await prompt(loop, "/loop other");
+		await waitFor(
+			() => getAssistantTexts(loop.harness).some((text) => text.includes("dyn two")),
+			"second dynamic tick",
+		);
+		const secondId = expectLoopId(loop, "started");
+
+		expect(secondId).not.toBe(firstId);
+		expect(loop.noticesText()).toContain(`Superseded dynamic loop ${firstId}.`);
+
+		const state = await loop.store();
+		const active = state ? activeEntries(state.entries) : [];
+		expect(active).toHaveLength(1);
+		expect(active[0]?.kind).toBe("dynamic");
+		expect(active[0]?.payload).toEqual({ type: "prompt", prompt: "other" });
+		expect(state?.entries[firstId]?.phase).toBe("ended");
+	});
+
+	it("bare /loop with a loop file uses the loop.md-dynamic sentinel and delivers the file", async () => {
+		const loop = await createLoopHarness({ loopFileContent: "WORK THE LOOP FILE TASKS" });
+		loop.harness.setResponses([fauxAssistantMessage("bare file done")]);
+		await prompt(loop, "/loop");
+		await waitFor(
+			() => getAssistantTexts(loop.harness).some((text) => text.includes("bare file done")),
+			"bare tick with loop file",
+		);
+
+		const tickText = getUserTexts(loop.harness).at(-1) ?? "";
+		expect(tickText).toContain("# /loop tick - loop.md tasks");
+		expect(tickText).toContain("WORK THE LOOP FILE TASKS");
+		expect(tickText).toContain("schedule_wakeup");
+
+		const state = await loop.store();
+		const active = state ? activeEntries(state.entries) : [];
+		expect(active).toHaveLength(1);
+		expect(active[0]?.payload).toEqual({ type: "sentinel", sentinel: "<<loop.md-dynamic>>" });
+	});
+
+	it("bare /loop without a loop file uses the autonomous-dynamic sentinel", async () => {
+		const loop = await createLoopHarness();
+		loop.harness.setResponses([fauxAssistantMessage("bare autonomous done")]);
+		await prompt(loop, "/loop");
+		await waitFor(
+			() => getAssistantTexts(loop.harness).some((text) => text.includes("bare autonomous done")),
+			"bare tick without loop file",
+		);
+
+		const tickText = getUserTexts(loop.harness).at(-1) ?? "";
+		expect(tickText).toContain("# Autonomous loop tick (dynamic pacing)");
+		expect(tickText).not.toContain("loop.md tasks");
+
+		const state = await loop.store();
+		const active = state ? activeEntries(state.entries) : [];
+		expect(active).toHaveLength(1);
+		expect(active[0]?.payload).toEqual({ type: "sentinel", sentinel: "<<autonomous-loop-dynamic>>" });
+	});
+
+	it("/loop 5m (interval only) is treated as bare fixed, not invalid", async () => {
+		const loop = await createLoopHarness();
+		loop.harness.setResponses([fauxAssistantMessage("bare fixed done")]);
+		await prompt(loop, "/loop 5m");
+		await waitFor(
+			() => getAssistantTexts(loop.harness).some((text) => text.includes("bare fixed done")),
+			"bare fixed tick",
+		);
+
+		const text = loop.noticesText();
+		expect(text).not.toContain("Usage: /loop");
+		expect(text).toContain("Loop ");
+		expect(text).toContain("started (fixed");
+
+		const state = await loop.store();
+		const active = state ? activeEntries(state.entries) : [];
+		expect(active).toHaveLength(1);
+		expect(active[0]?.kind).toBe("fixed");
+		expect(active[0]?.payload).toEqual({ type: "sentinel", sentinel: "<<autonomous-loop>>" });
+
+		const tickText = getUserTexts(loop.harness).at(-1) ?? "";
+		expect(tickText).toContain("# Autonomous loop tick\n");
+	});
+
+	it("/loop stop with one active loop stops it", async () => {
+		const loop = await createLoopHarness();
+		const loopId = await armFixedLoop(loop, "5m ping", "single-stop");
+
+		await prompt(loop, "/loop stop");
+		await waitFor(() => loop.notices.some((n) => n.message.includes("Stopped")), "stop notice");
+
+		expect(loop.noticesText()).toContain(`Stopped loop ${loopId}.`);
+		const state = await loop.store();
+		expect(state?.entries[loopId]?.phase).toBe("ended");
+		expect(state?.entries[loopId]?.endReason).toBe("stopped");
+	});
+
+	it("/loop stop with several active loops lists the ids and stops nothing", async () => {
+		const loop = await createLoopHarness();
+		const first = await armFixedLoop(loop, "5m ping", "multi-a");
+		const second = await armFixedLoop(loop, "3m pong", "multi-b");
+
+		await prompt(loop, "/loop stop");
+		await waitFor(
+			() => loop.notices.some((n) => n.message.includes("Multiple loops are active")),
+			"disambiguation notice",
+		);
+
+		const text = loop.noticesText();
+		expect(text).toContain(first);
+		expect(text).toContain(second);
+		expect(text).toContain("/loop stop <id>");
+		expect(text).toContain("/loop stop all");
+
+		const state = await loop.store();
+		expect(state?.entries[first]?.phase).not.toBe("ended");
+		expect(state?.entries[second]?.phase).not.toBe("ended");
+	});
+
+	it("/loop stop all stops every active loop", async () => {
+		const loop = await createLoopHarness();
+		const first = await armFixedLoop(loop, "5m ping", "stopall-a");
+		const second = await armFixedLoop(loop, "3m pong", "stopall-b");
+
+		await prompt(loop, "/loop stop all");
+		await waitFor(() => loop.notices.some((n) => n.message.includes("Stopped 2 loops")), "stop all notice");
+
+		const state = await loop.store();
+		expect(state?.entries[first]?.phase).toBe("ended");
+		expect(state?.entries[second]?.phase).toBe("ended");
+		expect(state?.entries[first]?.endReason).toBe("stopped");
+	});
+
+	it("/loop stop <unknown-id> is reported, never silently ignored", async () => {
+		const loop = await createLoopHarness();
+		const loopId = await armFixedLoop(loop, "5m ping", "unknown-id");
+
+		await prompt(loop, "/loop stop does-not-exist");
+		await waitFor(() => loop.notices.some((n) => n.message.includes("does-not-exist")), "unknown id notice");
+
+		const text = loop.noticesText();
+		expect(text).toContain('No active loop with id "does-not-exist".');
+		expect(text).toContain(loopId);
+		const state = await loop.store();
+		expect(state?.entries[loopId]?.phase).not.toBe("ended");
+	});
+
+	it("/loop status lists every active loop with the status-line affordance", async () => {
+		const loop = await createLoopHarness();
+		const loopId = await armFixedLoop(loop, "5m ping", "status");
+
+		await prompt(loop, "/loop status");
+		await waitFor(() => loop.notices.some((n) => n.message.includes("Active loops")), "status notice");
+
+		const text = loop.noticesText();
+		expect(text).toContain("Loop (fixed): next in");
+		expect(text).toContain("/loop stop");
+		expect(text).toContain(loopId);
+		expect(text).toContain("`*/5 * * * *`");
+		expect(text).toContain("every 5 minutes");
+
+		const withTwo = loop;
+		await armFixedLoop(withTwo, "3m pong", "status-two");
+		await prompt(withTwo, "/loop status");
+		await waitFor(
+			() => withTwo.notices.filter((n) => n.message.includes("Active loops")).length >= 2,
+			"second status notice",
+		);
+		const secondStatus = withTwo.notices.filter((n) => n.message.includes("Active loops")).at(-1)?.message ?? "";
+		expect(secondStatus).toContain(loopId);
+	});
+
+	it("/loop pause then /loop resume round-trips a single loop", async () => {
+		const loop = await createLoopHarness();
+		const loopId = await armFixedLoop(loop, "5m ping", "pause-resume");
+
+		await prompt(loop, "/loop pause");
+		await waitFor(() => loop.notices.some((n) => n.message.includes("Paused")), "pause notice");
+		expect(loop.noticesText()).toContain(`Paused loop ${loopId}.`);
+		expect((await loop.store())?.entries[loopId]?.phase).toBe("suspended");
+
+		await prompt(loop, "/loop resume");
+		await waitFor(() => loop.notices.some((n) => n.message.includes("Resumed")), "resume notice");
+		expect(loop.noticesText()).toContain(`Resumed loop ${loopId}.`);
+		const resumed = (await loop.store())?.entries[loopId];
+		expect(resumed?.phase).not.toBe("ended");
+		expect(resumed?.phase).not.toBe("suspended");
+	});
+
+	it("invalid input prints the ported usage block and arms nothing", async () => {
+		const loop = await createLoopHarness();
+		await prompt(loop, "/loop 0m bogusarg");
+
+		const text = loop.noticesText();
+		expect(text).toContain("Usage: /loop [interval] <prompt>");
+		expect(text).toContain("/loop 5m check the deploy");
+		expect(text).toContain("/loop check the deploy every 20m");
+		expect(text).toContain("/loop stop [id|all]");
+		expect(text).toContain("/loop status");
+		expect(text).toContain("/loop pause [id|all]");
+		expect(text).toContain("/loop resume [id|all]");
+
+		expect(await loop.store()).toBeNull();
+		expect(getUserTexts(loop.harness)).toHaveLength(0);
+	});
+
+	it("print mode rejects with a one-line interactive-only message and arms nothing", async () => {
+		const loop = await createLoopHarness({ mode: "print" });
+		await prompt(loop, "/loop 5m ping");
+
+		const rejection = loop.notices.find((n) => n.message.includes("interactive"));
+		expect(rejection, `expected an interactive-only rejection, got: ${loop.noticesText()}`).toBeDefined();
+		expect(rejection?.message.includes("\n")).toBe(false);
+		expect(rejection?.type).toBe("warning");
+
+		expect(await loop.store()).toBeNull();
+		expect(getUserTexts(loop.harness)).toHaveLength(0);
+		expect(getAssistantTexts(loop.harness)).toHaveLength(0);
+		expect(loopStatusFileExists(loop)).toBe(false);
+	});
+
+	it("a slash-command payload dispatches through the command path via expandPromptTemplates", async () => {
+		const loop = await createLoopHarness();
+		loop.harness.setResponses([]);
+		await prompt(loop, "/loop 5m /loop status");
+
+		// The tick payload itself is a /loop invocation: it must be consumed by the
+		// command dispatcher, which renders the status listing as a second notice.
+		await waitFor(
+			() => loop.notices.filter((n) => n.message.includes("Active loops")).length >= 1,
+			"nested status notice from dispatched tick",
+		);
+		const statusNotice = loop.notices.find((n) => n.message.includes("Active loops"))?.message ?? "";
+		expect(statusNotice).toContain("Loop (fixed): next in");
+
+		// Command-path consumption means no model turn and no raw tick text in the transcript.
+		expect(getAssistantTexts(loop.harness)).toHaveLength(0);
+		expect(getUserTexts(loop.harness).some((text) => text.includes("The fixed recurring schedule"))).toBe(false);
+	});
+});
+
+function loopStatusFileExists(loop: LoopHarness): boolean {
+	return existsSync(loopStateFilePath(loop.storeRef));
+}

--- a/packages/coding-agent/test/suite/loop-cron-planner.test.ts
+++ b/packages/coding-agent/test/suite/loop-cron-planner.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-	normalizeInterval,
-	describeCron,
 	computeNextFireAt,
-	type RequestedInterval,
+	describeCron,
 	type EffectiveInterval,
+	normalizeInterval,
+	type RequestedInterval,
 } from "../../src/core/extensions/builtin/loop/cron-planner.ts";
 
 function req(value: number, unit: "s" | "m" | "h" | "d", raw: string): RequestedInterval {

--- a/packages/coding-agent/test/suite/loop-cron-planner.test.ts
+++ b/packages/coding-agent/test/suite/loop-cron-planner.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+	normalizeInterval,
+	describeCron,
+	computeNextFireAt,
+	type RequestedInterval,
+	type EffectiveInterval,
+} from "../../src/core/extensions/builtin/loop/cron-planner.ts";
+
+function req(value: number, unit: "s" | "m" | "h" | "d", raw: string): RequestedInterval {
+	return { value, unit, raw };
+}
+
+function eff(
+	value: number,
+	unit: "m" | "h" | "d",
+	human: string,
+	rounded: boolean,
+	roundingNotice: string | undefined,
+): EffectiveInterval & { intervalMs: number } {
+	const unitMs = { m: 60_000, h: 3_600_000, d: 86_400_000 }[unit];
+	return { value, unit, human, rounded, roundingNotice, intervalMs: value * unitMs };
+}
+
+describe("normalizeInterval", () => {
+	it("5m -> 5 minutes, not rounded", () => {
+		const result = normalizeInterval(req(5, "m", "5m"));
+		expect(result).toEqual(eff(5, "m", "5 minutes", false, undefined));
+		expect(describeCron(result)).toBe("*/5 * * * *");
+	});
+
+	it("45s -> 1 minute rounded with notice naming both cadences", () => {
+		const result = normalizeInterval(req(45, "s", "45s"));
+		expect(result).toEqual(eff(1, "m", "1 minute", true, "Requested 45s rounds to 1 minute."));
+		expect(describeCron(result)).toBe("*/1 * * * *");
+	});
+
+	it("90m -> 2 hours rounded with notice naming both cadences", () => {
+		const result = normalizeInterval(req(90, "m", "90m"));
+		expect(result).toEqual(eff(2, "h", "2 hours", true, "Requested 90m rounds to 2 hours."));
+		expect(describeCron(result)).toBe("0 */2 * * *");
+	});
+
+	it("7m -> 7 minutes with */7 cron and no rounding claim", () => {
+		const result = normalizeInterval(req(7, "m", "7m"));
+		expect(result).toEqual(eff(7, "m", "7 minutes", false, undefined));
+		expect(describeCron(result)).toBe("*/7 * * * *");
+	});
+
+	it("1h -> 0 */1 * * * consistently", () => {
+		const result = normalizeInterval(req(1, "h", "1h"));
+		expect(result).toEqual(eff(1, "h", "1 hour", false, undefined));
+		expect(describeCron(result)).toBe("0 */1 * * *");
+	});
+
+	it("36h -> 2 days rounded with notice naming both cadences", () => {
+		const result = normalizeInterval(req(36, "h", "36h"));
+		expect(result).toEqual(eff(2, "d", "2 days", true, "Requested 36h rounds to 2 days."));
+		expect(describeCron(result)).toBe("0 0 */2 * *");
+	});
+
+	it("1d -> 0 0 */1 * *", () => {
+		const result = normalizeInterval(req(1, "d", "1d"));
+		expect(result).toEqual(eff(1, "d", "1 day", false, undefined));
+		expect(describeCron(result)).toBe("0 0 */1 * *");
+	});
+
+	it("rounds half values upward for minutes-to-hours", () => {
+		// 89m -> 1h, 90m -> 2h, 91m -> 2h (half-up at exactly 1.5)
+		expect(normalizeInterval(req(89, "m", "89m")).value).toBe(1);
+		expect(normalizeInterval(req(89, "m", "89m")).unit).toBe("h");
+		expect(normalizeInterval(req(90, "m", "90m")).value).toBe(2);
+		expect(normalizeInterval(req(91, "m", "91m")).value).toBe(2);
+	});
+
+	it("rounds half values upward for hours-to-days", () => {
+		// 35h -> 1d, 36h -> 2d, 37h -> 2d
+		expect(normalizeInterval(req(35, "h", "35h")).value).toBe(1);
+		expect(normalizeInterval(req(35, "h", "35h")).unit).toBe("d");
+		expect(normalizeInterval(req(36, "h", "36h")).value).toBe(2);
+		expect(normalizeInterval(req(37, "h", "37h")).value).toBe(2);
+	});
+
+	it("seconds always ceil to minutes with a minimum of 1", () => {
+		expect(normalizeInterval(req(1, "s", "1s"))).toEqual(
+			eff(1, "m", "1 minute", true, "Requested 1s rounds to 1 minute."),
+		);
+		expect(normalizeInterval(req(59, "s", "59s")).value).toBe(1);
+		expect(normalizeInterval(req(60, "s", "60s")).value).toBe(1);
+		expect(normalizeInterval(req(61, "s", "61s")).value).toBe(2);
+	});
+
+	it("intervalMs matches the effective unit", () => {
+		expect(normalizeInterval(req(5, "m", "5m")).intervalMs).toBe(5 * 60_000);
+		expect(normalizeInterval(req(90, "m", "90m")).intervalMs).toBe(2 * 60 * 60_000);
+		expect(normalizeInterval(req(36, "h", "36h")).intervalMs).toBe(2 * 24 * 60 * 60_000);
+		expect(normalizeInterval(req(1, "d", "1d")).intervalMs).toBe(24 * 60 * 60_000);
+	});
+});
+
+describe("describeCron", () => {
+	it("produces restricted minute, hour, and day forms only", () => {
+		expect(describeCron({ value: 5, unit: "m" })).toBe("*/5 * * * *");
+		expect(describeCron({ value: 2, unit: "h" })).toBe("0 */2 * * *");
+		expect(describeCron({ value: 3, unit: "d" })).toBe("0 0 */3 * *");
+	});
+});
+
+describe("computeNextFireAt", () => {
+	it("returns nowMs + intervalMs without reading the clock", () => {
+		expect(computeNextFireAt(1_000_000, 300_000)).toBe(1_300_000);
+		expect(computeNextFireAt(0, 86_400_000)).toBe(86_400_000);
+	});
+});

--- a/packages/coding-agent/test/suite/loop-extension.test.ts
+++ b/packages/coding-agent/test/suite/loop-extension.test.ts
@@ -1,0 +1,739 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createLoopExtension,
+	createNodeTimerPort,
+	LOOP_TICK_ENTRY_TYPE,
+	type LoopController,
+	type LoopExtensionDeps,
+	type LoopTickEntryData,
+	renderLoopTickEntry,
+} from "../../src/core/extensions/builtin/loop/index.ts";
+import type { LoopTimerPort } from "../../src/core/extensions/builtin/loop/scheduler.ts";
+import { loopStateFilePath, writeLoopState } from "../../src/core/extensions/builtin/loop/store.ts";
+import type { LoopState, LoopStoreRef } from "../../src/core/extensions/builtin/loop/types.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+
+const MINUTE = 60_000;
+const T0 = 1_700_000_000_000;
+const SESSION_ID = "loop-extension-session";
+/** Stable across fixtures so a resumed fingerprint compares equal to the persisted one. */
+const LOOP_FILE_PATH = "/workspace/.senpi/loop.md";
+
+initTheme("dark");
+
+/** Fake timer port: records armed keys and lets the test fire them explicitly. */
+class FakeTimers implements LoopTimerPort {
+	readonly armed = new Map<string, { dueAt: number; callback: () => void }>();
+	readonly armLog: Array<{ key: string; dueAt: number }> = [];
+	cancelAllCount = 0;
+
+	arm(key: string, dueAt: number, callback: () => void): void {
+		this.armed.set(key, { dueAt, callback });
+		this.armLog.push({ key, dueAt });
+	}
+
+	cancel(key: string): void {
+		this.armed.delete(key);
+	}
+
+	cancelAll(): void {
+		this.cancelAllCount += 1;
+		this.armed.clear();
+	}
+
+	get armedKeys(): string[] {
+		return [...this.armed.keys()];
+	}
+
+	fire(key: string): void {
+		const entry = this.armed.get(key);
+		if (entry === undefined) throw new Error(`no timer armed for ${key}`);
+		entry.callback();
+	}
+}
+
+interface SentUserMessage {
+	readonly text: string;
+	readonly deliverAs: "steer" | "followUp" | undefined;
+	readonly expandPromptTemplates: boolean | undefined;
+}
+
+interface SentCustomMessage {
+	readonly customType: string;
+	readonly details: unknown;
+	readonly deliverAs: "steer" | "followUp" | "nextTurn" | undefined;
+	readonly triggerTurn: boolean | undefined;
+}
+
+type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
+
+interface Fixture {
+	readonly pi: ExtensionAPI;
+	readonly ctx: ExtensionContext;
+	readonly timers: FakeTimers;
+	readonly controller: LoopController;
+	readonly userMessages: SentUserMessage[];
+	readonly customMessages: SentCustomMessage[];
+	readonly entries: Array<{ customType: string; data: unknown }>;
+	readonly notices: Array<{ message: string; type: string | undefined }>;
+	readonly statuses: Array<string | undefined>;
+	readonly sessionNames: string[];
+	readonly storeRef: LoopStoreRef;
+	setNow(value: number): void;
+	advance(ms: number): void;
+	now(): number;
+	setIdle(idle: boolean): void;
+	setPending(pending: boolean): void;
+	setContextEntries(entries: Array<{ customType: string; data?: unknown }>): void;
+	emit(event: string, payload?: Record<string, unknown>): Promise<void>;
+	persisted(): Promise<LoopState | undefined>;
+}
+
+const tempDirs: string[] = [];
+
+async function fixture(
+	options: {
+		now?: number;
+		deps?: Partial<LoopExtensionDeps>;
+		initialState?: LoopState;
+		corruptStore?: string;
+		loopFileContent?: string;
+	} = {},
+): Promise<Fixture> {
+	const dir = await mkdtemp(join(tmpdir(), "senpi-loop-ext-"));
+	tempDirs.push(dir);
+	const storeRef: LoopStoreRef = { baseDir: join(dir, "extensions", "loop"), sessionId: SESSION_ID };
+
+	let current = options.now ?? T0;
+	let idle = true;
+	let pending = false;
+	let contextEntries: Array<{ customType: string; data?: unknown }> = [];
+	const timers = new FakeTimers();
+	const userMessages: SentUserMessage[] = [];
+	const customMessages: SentCustomMessage[] = [];
+	const entries: Array<{ customType: string; data: unknown }> = [];
+	const notices: Array<{ message: string; type: string | undefined }> = [];
+	const statuses: Array<string | undefined> = [];
+	const sessionNames: string[] = [];
+	const handlers = new Map<string, Handler[]>();
+
+	let loopSeq = 0;
+	let wakeupSeq = 0;
+	let deliverySeq = 0;
+
+	if (options.initialState !== undefined) {
+		await writeLoopState(storeRef, options.initialState);
+	}
+	if (options.corruptStore !== undefined) {
+		const path = loopStateFilePath(storeRef);
+		await writeFile(path.replace(/[^/]+$/, ".keep"), "", "utf8").catch(() => {});
+		await writeLoopState(storeRef, emptyState(current));
+		await writeFile(path, options.corruptStore, "utf8");
+	}
+
+	const pi = {
+		on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
+		registerTool: () => {},
+		registerEntryRenderer: () => {},
+		registerCommand: () => {},
+		appendEntry: (customType: string, data: unknown) => entries.push({ customType, data }),
+		sendUserMessage: (
+			content: string,
+			opts?: { deliverAs?: "steer" | "followUp"; expandPromptTemplates?: boolean },
+		) => {
+			userMessages.push({
+				text: content,
+				deliverAs: opts?.deliverAs,
+				expandPromptTemplates: opts?.expandPromptTemplates,
+			});
+			// The real session emits an `input` event for every prompt, including the ones an
+			// extension sends, so the harness does too: attribution must survive its own tick.
+			void emit("input", { text: content, source: "extension", inputId: `extension-${userMessages.length}` });
+		},
+		sendMessage: (
+			message: { customType: string; details?: unknown },
+			opts?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+		) => {
+			customMessages.push({
+				customType: message.customType,
+				details: message.details,
+				deliverAs: opts?.deliverAs,
+				triggerTurn: opts?.triggerTurn,
+			});
+		},
+		setSessionName: (name: string) => sessionNames.push(name),
+		getSessionName: () => sessionNames[sessionNames.length - 1],
+		getCommands: () => [{ name: "loop" }],
+	} as unknown as ExtensionAPI;
+
+	const ctx = {
+		mode: "tui",
+		hasUI: true,
+		cwd: dir,
+		agentDir: join(dir, "agent"),
+		isIdle: () => idle,
+		hasPendingMessages: () => pending,
+		ui: {
+			notify: (message: string, type?: string) => notices.push({ message, type }),
+			setStatus: (_key: string, text: string | undefined) => statuses.push(text),
+		},
+		sessionManager: {
+			getSessionId: () => SESSION_ID,
+			getSessionDir: () => join(dir, "sessions"),
+			getSessionFile: () => join(dir, "sessions", "session.jsonl"),
+			// `appendEntry` produces `type: "custom"` entries carrying `data`, so the harness
+			// mirrors that shape rather than a hand-rolled one.
+			buildContextEntries: () => contextEntries.map((entry) => ({ type: "custom", ...entry })),
+			getBranch: () => [],
+		},
+	} as unknown as ExtensionContext;
+
+	let controller: LoopController | undefined;
+	const deps: LoopExtensionDeps = {
+		clock: { now: () => current },
+		timers: () => timers,
+		ids: {
+			loopId: () => `loop-${++loopSeq}`,
+			wakeupId: () => `wakeup-${++wakeupSeq}`,
+			deliveryId: () => `delivery-${++deliverySeq}`,
+		},
+		storeRef: () => storeRef,
+		resolveLoopFile: async () =>
+			options.loopFileContent === undefined
+				? { found: false }
+				: {
+						found: true,
+						path: LOOP_FILE_PATH,
+						content: options.loopFileContent,
+						fingerprint: {
+							path: LOOP_FILE_PATH,
+							mtimeMs: 1000,
+							size: options.loopFileContent.length,
+							contentHash: `hash-${options.loopFileContent.length}`,
+						},
+					},
+		onControllerReady: (next) => {
+			controller = next;
+		},
+		...options.deps,
+	};
+
+	await createLoopExtension(deps)(pi);
+	if (controller === undefined) throw new Error("loop extension did not publish a controller");
+
+	async function emit(event: string, payload: Record<string, unknown> = {}): Promise<void> {
+		for (const handler of handlers.get(event) ?? []) {
+			await handler({ type: event, ...payload }, ctx);
+		}
+	}
+
+	return {
+		pi,
+		ctx,
+		timers,
+		controller,
+		userMessages,
+		customMessages,
+		entries,
+		notices,
+		statuses,
+		sessionNames,
+		storeRef,
+		setNow: (value) => {
+			current = value;
+		},
+		advance: (ms) => {
+			current += ms;
+		},
+		now: () => current,
+		setIdle: (value) => {
+			idle = value;
+		},
+		setPending: (value) => {
+			pending = value;
+		},
+		setContextEntries: (next) => {
+			contextEntries = next;
+		},
+		emit,
+		persisted: async () => {
+			const { readLoopState } = await import("../../src/core/extensions/builtin/loop/store.ts");
+			return (await readLoopState(storeRef)) ?? undefined;
+		},
+	};
+}
+
+/**
+ * Ends the iteration a tick started, the way a real turn does: the model reschedules the
+ * dynamic loop and the turn settles, so the next fire is not coalesced away.
+ */
+async function settleTurn(f: Fixture, loopId: string): Promise<void> {
+	await f.controller.scheduleWakeup({
+		loopId,
+		requestedDelaySeconds: 1200,
+		delaySeconds: 1200,
+		reason: "keep going",
+		prompt: "/loop",
+		noop: false,
+	});
+	await f.emit("agent_end", { messages: [] });
+	await f.emit("agent_settled");
+}
+
+function emptyState(now: number): LoopState {
+	return { version: 1, sessionId: SESSION_ID, entries: {}, activeDynamicId: null, updatedAt: now };
+}
+
+afterEach(async () => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir !== undefined) await rm(dir, { recursive: true, force: true });
+	}
+});
+
+describe("loop extension tick dispatch", () => {
+	it("dispatches an idle fixed tick through the real command path", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+
+		expect(f.userMessages).toHaveLength(1);
+		expect(f.userMessages[0].expandPromptTemplates).toBe(true);
+		expect(f.userMessages[0].deliverAs).toBeUndefined();
+		expect(f.userMessages[0].text).toContain("ping");
+
+		const persisted = await f.persisted();
+		expect(persisted).toBeDefined();
+		expect(Object.keys(persisted?.entries ?? {})).toHaveLength(1);
+		expect(f.timers.armedKeys).toHaveLength(1);
+	});
+
+	it("delivers a due tick as a follow-up while streaming and never steers", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		// The immediate first tick runs and its turn completes.
+		await f.emit("agent_end", { messages: [] });
+		await f.emit("agent_settled");
+		f.userMessages.length = 0;
+
+		// The user starts their own turn; the next occurrence comes due mid-stream.
+		f.setIdle(false);
+		await f.emit("input", { text: "user question", source: "interactive" });
+		await f.emit("agent_start");
+		f.advance(5 * MINUTE);
+		await f.controller.fireDue(created.loopId);
+
+		expect(f.userMessages).toHaveLength(1);
+		expect(f.userMessages[0].deliverAs).toBe("followUp");
+		expect(f.userMessages.some((message) => message.deliverAs === "steer")).toBe(false);
+	});
+
+	it("attaches loop attribution details to every dispatched tick", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+
+		const tickEntries = f.entries.filter((entry) => entry.customType === LOOP_TICK_ENTRY_TYPE);
+		expect(tickEntries).toHaveLength(1);
+		const data = tickEntries[0].data as LoopTickEntryData;
+		expect(data.loopId).toBe(created.loopId);
+		expect(data.deliveryId).toBe("delivery-1");
+		expect(data.scheduledForAt).toBe(T0);
+		expect(data.mode).toBe("fixed");
+		expect(data.delivery).toBe("prompt");
+	});
+
+	it("names the session after the loop when a loop is the first prompt", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		await f.controller.startFixed({
+			originalArgs: "5m ping the deploy",
+			prompt: "ping the deploy",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+
+		expect(f.sessionNames).toEqual(["loop: ping the deploy"]);
+	});
+});
+
+describe("loop extension lifecycle", () => {
+	it("persists a suspended snapshot and leaves no timer armed after shutdown", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		expect(f.timers.armedKeys).toHaveLength(1);
+
+		await f.emit("session_shutdown", { reason: "quit" });
+
+		expect(f.timers.armedKeys).toEqual([]);
+		const persisted = await f.persisted();
+		const entry = persisted?.entries[created.loopId];
+		expect(entry?.phase).toBe("suspended");
+		expect(entry?.endReason).toBeUndefined();
+	});
+
+	it("re-arms across shutdown and start with exactly one recovery tick for an overdue job", async () => {
+		const first = await fixture();
+		await first.emit("session_start", { reason: "startup" });
+		const created = await first.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		await first.emit("session_shutdown", { reason: "quit" });
+		const suspended = await first.persisted();
+		expect(suspended).toBeDefined();
+		if (suspended === undefined) return;
+
+		// Three days later: many occurrences were missed while the machine slept.
+		const resumed = await fixture({ now: T0 + 3 * 24 * 60 * MINUTE, initialState: suspended });
+		await resumed.emit("session_start", { reason: "resume" });
+
+		expect(resumed.userMessages).toHaveLength(1);
+		expect(resumed.timers.armedKeys).toEqual([created.loopId]);
+		const entry = (await resumed.persisted())?.entries[created.loopId];
+		expect(entry?.kind).toBe("fixed");
+		if (entry?.kind !== "fixed") return;
+		expect(entry.nextFireAt).toBe(resumed.now() + 5 * MINUTE);
+	});
+
+	it("ends the loop with terminal reason error and notifies the user when the store is corrupt", async () => {
+		const f = await fixture({ corruptStore: "{ not json" });
+		await f.emit("session_start", { reason: "resume" });
+
+		expect(f.notices.length).toBeGreaterThan(0);
+		expect(f.notices.map((notice) => notice.message).join("\n")).toMatch(/loop/i);
+		expect(f.notices.some((notice) => notice.type === "error")).toBe(true);
+		expect(f.controller.lastStoreFailure()?.endReason).toBe("error");
+		expect(f.timers.armedKeys).toEqual([]);
+	});
+
+	it("ends a live loop with terminal reason error when its state can no longer be persisted", async () => {
+		let failWrites = false;
+		const f = await fixture({
+			deps: {
+				writeState: async (ref, state) => {
+					if (failWrites) throw new Error("simulated loop store corruption");
+					await writeLoopState(ref, state);
+				},
+			},
+		});
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		f.notices.length = 0;
+		f.userMessages.length = 0;
+
+		failWrites = true;
+		await f.emit("agent_end", { messages: [] });
+		await f.emit("agent_settled");
+
+		expect(f.controller.lastStoreFailure()?.endReason).toBe("error");
+		expect(f.controller.lastStoreFailure()?.loopIds).toContain(created.loopId);
+		expect(f.controller.isEndedWithError(created.loopId)).toBe(true);
+		expect(f.notices.some((notice) => notice.type === "error")).toBe(true);
+		expect(f.timers.armedKeys).toEqual([]);
+
+		// A loop retired with `error` must not dispatch another tick.
+		f.advance(5 * MINUTE);
+		await f.controller.fireDue(created.loopId);
+		expect(f.userMessages).toEqual([]);
+	});
+
+	it("pauses rather than ends the loop on a user abort", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+
+		await f.emit("session_abort");
+
+		const entry = (await f.persisted())?.entries[created.loopId];
+		expect(entry?.phase).toBe("suspended");
+		expect(entry?.endReason).toBeUndefined();
+		expect(f.timers.armedKeys).toEqual([]);
+		expect(f.notices.map((notice) => notice.message).join("\n")).toContain("/loop resume");
+	});
+});
+
+describe("loop extension sentinel delivery", () => {
+	it("forces a full sentinel tick after an accepted compaction", async () => {
+		const f = await fixture({ loopFileContent: "do the tasks" });
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startBare({ originalArgs: "" });
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		expect(f.userMessages).toHaveLength(1);
+		expect(f.userMessages[0].text).toContain("do the tasks");
+		await settleTurn(f, created.loopId);
+
+		// Second tick with an unchanged file is a short reminder.
+		f.advance(20 * MINUTE);
+		await f.controller.fireDue(created.loopId);
+		expect(f.userMessages).toHaveLength(2);
+		expect(f.userMessages[1].text).not.toContain("do the tasks");
+		await settleTurn(f, created.loopId);
+
+		// Compaction must not touch timers or phase, only the delivery decision.
+		const armedBefore = [...f.timers.armedKeys];
+		const phaseBefore = (await f.persisted())?.entries[created.loopId]?.phase;
+		await f.emit("session_compact", { accepted: true, reason: "manual", requestId: "r1" });
+		expect(f.timers.armedKeys).toEqual(armedBefore);
+		expect((await f.persisted())?.entries[created.loopId]?.phase).toBe(phaseBefore);
+
+		f.advance(20 * MINUTE);
+		await f.controller.fireDue(created.loopId);
+		expect(f.userMessages).toHaveLength(3);
+		expect(f.userMessages[2].text).toContain("do the tasks");
+	});
+
+	it("forces a full sentinel tick when the anchor is missing from the compaction-aware context on resume", async () => {
+		const first = await fixture({ loopFileContent: "do the tasks" });
+		await first.emit("session_start", { reason: "startup" });
+		const created = await first.controller.startBare({ originalArgs: "" });
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		await first.emit("session_shutdown", { reason: "quit" });
+		const suspended = await first.persisted();
+		expect(suspended).toBeDefined();
+		if (suspended === undefined) return;
+
+		// Resume with an anchor still present: the next tick stays a reminder.
+		const withAnchor = await fixture({ loopFileContent: "do the tasks", initialState: suspended });
+		withAnchor.setContextEntries([
+			{ customType: LOOP_TICK_ENTRY_TYPE, data: { loopId: created.loopId, deliveryId: "delivery-1" } },
+		]);
+		await withAnchor.emit("session_start", { reason: "resume" });
+		await settleTurn(withAnchor, created.loopId);
+		withAnchor.advance(20 * MINUTE);
+		await withAnchor.controller.fireDue(created.loopId);
+		const anchoredTick = withAnchor.userMessages[withAnchor.userMessages.length - 1];
+		expect(anchoredTick.text).not.toContain("do the tasks");
+
+		// Resume with the anchor gone: compaction dropped it, so the next tick is full again.
+		const withoutAnchor = await fixture({ loopFileContent: "do the tasks", initialState: suspended });
+		withoutAnchor.setContextEntries([]);
+		await withoutAnchor.emit("session_start", { reason: "resume" });
+		await settleTurn(withoutAnchor, created.loopId);
+		withoutAnchor.advance(20 * MINUTE);
+		await withoutAnchor.controller.fireDue(created.loopId);
+		const unanchoredTick = withoutAnchor.userMessages[withoutAnchor.userMessages.length - 1];
+		expect(unanchoredTick.text).toContain("do the tasks");
+	});
+});
+
+describe("loop extension keepalive", () => {
+	it("arms one keepalive on the first omission and ends the loop on the second", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startDynamic({ originalArgs: "watch the queue", prompt: "watch the queue" });
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+
+		// First dynamic iteration ends without schedule_wakeup: one keepalive fallback.
+		await f.emit("agent_end", { messages: [] });
+		await f.emit("agent_settled");
+		let entry = (await f.persisted())?.entries[created.loopId];
+		expect(entry?.kind).toBe("dynamic");
+		if (entry?.kind !== "dynamic") return;
+		expect(entry.keepaliveCredit).toBe(0);
+		expect(entry.pendingWakeup?.source).toBe("keepalive");
+		expect(f.timers.armedKeys).toEqual([created.loopId]);
+
+		// The keepalive iteration also omits it: the loop ends.
+		f.advance(entry.pendingWakeup === null ? MINUTE : entry.pendingWakeup.dueAt - f.now());
+		await f.controller.fireDue(created.loopId);
+		await f.emit("agent_end", { messages: [] });
+		await f.emit("agent_settled");
+
+		entry = (await f.persisted())?.entries[created.loopId];
+		expect(entry?.phase).toBe("ended");
+		expect(entry?.endReason).toBe("keepalive_exhausted");
+		expect(f.timers.armedKeys).toEqual([]);
+	});
+
+	it("never applies keepalive after an ordinary user turn", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startDynamic({ originalArgs: "watch the queue", prompt: "watch the queue" });
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		// Settle the loop's own first iteration by scheduling, so nothing is attributed.
+		await f.controller.scheduleWakeup({
+			loopId: created.loopId,
+			requestedDelaySeconds: 600,
+			delaySeconds: 600,
+			reason: "poll later",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+
+		// An ordinary user turn runs and ends: keepalive must not fire.
+		await f.emit("input", { text: "unrelated user question", source: "interactive" });
+		await f.emit("agent_end", { messages: [] });
+		await f.emit("agent_settled");
+
+		const entry = (await f.persisted())?.entries[created.loopId];
+		expect(entry?.kind).toBe("dynamic");
+		if (entry?.kind !== "dynamic") return;
+		expect(entry.keepaliveCredit).toBe(1);
+		expect(entry.pendingWakeup?.source).toBe("model");
+		expect(entry.phase).toBe("waiting");
+	});
+});
+
+describe("loop extension noop folding", () => {
+	it("folds two consecutive noop ticks and resets the streak on a non-noop tick", async () => {
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startDynamic({ originalArgs: "watch the queue", prompt: "watch the queue" });
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+
+		for (let index = 0; index < 2; index++) {
+			await f.controller.scheduleWakeup({
+				loopId: created.loopId,
+				requestedDelaySeconds: 60,
+				delaySeconds: 60,
+				reason: "quiet",
+				prompt: "/loop watch the queue",
+				noop: true,
+			});
+			await f.emit("agent_settled");
+			f.advance(60_000);
+			await f.controller.fireDue(created.loopId);
+		}
+
+		const folded = f.entries
+			.filter((entry) => entry.customType === LOOP_TICK_ENTRY_TYPE)
+			.map((entry) => entry.data as LoopTickEntryData);
+		const lastFolded = folded[folded.length - 1];
+		expect(lastFolded.noopStreak).toBe(2);
+		expect(lastFolded.folded).toBe(true);
+		const rendered = renderLoopTickEntry(
+			{
+				type: "custom",
+				id: "entry-folded",
+				parentId: null,
+				timestamp: "2026-08-18T00:00:00.000Z",
+				customType: LOOP_TICK_ENTRY_TYPE,
+				data: lastFolded,
+			},
+			{ expanded: false },
+			theme,
+		);
+		expect(rendered?.render(80).join("\n")).toContain("2 loop ticks with no actionable change");
+
+		// A non-noop schedule resets the streak, so the next tick renders unfolded.
+		await f.controller.scheduleWakeup({
+			loopId: created.loopId,
+			requestedDelaySeconds: 60,
+			delaySeconds: 60,
+			reason: "found work",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+		await f.emit("agent_settled");
+		f.advance(60_000);
+		await f.controller.fireDue(created.loopId);
+
+		const after = f.entries
+			.filter((entry) => entry.customType === LOOP_TICK_ENTRY_TYPE)
+			.map((entry) => entry.data as LoopTickEntryData);
+		const latest = after[after.length - 1];
+		expect(latest.noopStreak).toBe(0);
+		expect(latest.folded).toBe(false);
+	});
+});
+
+describe("loop timer port", () => {
+	it("runs the newest arm once and never runs a cancelled or superseded one", async () => {
+		const port = createNodeTimerPort();
+		const fired: string[] = [];
+		const settled = new Promise<void>((resolve) => {
+			port.arm("a", Date.now(), () => fired.push("stale-a"));
+			port.arm("a", Date.now(), () => {
+				fired.push("fresh-a");
+				resolve();
+			});
+			port.arm("b", Date.now(), () => fired.push("cancelled-b"));
+			port.cancel("b");
+		});
+
+		await settled;
+		// A 0ms timeout armed AFTER the ones under test drains behind them in Node's timer
+		// queue, so this observes absence deterministically rather than waiting on a delay.
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		expect(fired).toEqual(["fresh-a"]);
+	});
+
+	it("cancelAll clears every armed key", async () => {
+		const port = createNodeTimerPort();
+		const fired: string[] = [];
+		port.arm("a", Date.now(), () => fired.push("a"));
+		port.arm("b", Date.now(), () => fired.push("b"));
+		port.cancelAll();
+
+		// Same ordering guarantee: this timeout was armed last, so it drains last.
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		expect(fired).toEqual([]);
+	});
+});
+
+describe("loop extension status line", () => {
+	it("publishes the armed status line on session start and clears it on shutdown", async () => {
+		const f = await fixture({ initialState: undefined });
+		await f.emit("session_start", { reason: "startup" });
+		await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+
+		expect(f.statuses.filter((text) => text !== undefined).some((text) => text?.includes("/loop stop"))).toBe(true);
+
+		await f.emit("session_shutdown", { reason: "quit" });
+		expect(f.statuses[f.statuses.length - 1]).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/suite/loop-extension.test.ts
+++ b/packages/coding-agent/test/suite/loop-extension.test.ts
@@ -19,6 +19,19 @@ import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
 
 const MINUTE = 60_000;
 const T0 = 1_700_000_000_000;
+
+/**
+ * Lets a sync timer callback's async dispatch chain finish before assertions run. The chain
+ * resolves the loop file and builds the tick message before sending, so poll for the observable
+ * instead of guessing a fixed number of turns.
+ */
+async function settleUntil(predicate: () => boolean, label: string): Promise<void> {
+	for (let i = 0; i < 200; i += 1) {
+		if (predicate()) return;
+		await new Promise((resolve) => setImmediate(resolve));
+	}
+	throw new Error(`settleUntil timed out waiting for: ${label}`);
+}
 const SESSION_ID = "loop-extension-session";
 /** Stable across fixtures so a resumed fingerprint compares equal to the persisted one. */
 const LOOP_FILE_PATH = "/workspace/.senpi/loop.md";
@@ -343,6 +356,38 @@ describe("loop extension tick dispatch", () => {
 		expect(f.userMessages).toHaveLength(1);
 		expect(f.userMessages[0].deliverAs).toBe("followUp");
 		expect(f.userMessages.some((message) => message.deliverAs === "steer")).toBe(false);
+	});
+
+	it("routes a timer-driven fire through persist-and-dispatch, not scheduler state alone", async () => {
+		// Regression: every other due-tick test calls controller.fireDue() directly, but the real
+		// runtime only ever invokes the armed timer callback. That callback discarded the dispatch
+		// decision, so a recurring loop delivered its first tick and then silently never recurred.
+		const f = await fixture();
+		await f.emit("session_start", { reason: "startup" });
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+
+		// The immediate first tick runs and its turn completes.
+		await f.emit("agent_end", { messages: [] });
+		await f.emit("agent_settled");
+		f.userMessages.length = 0;
+		const tickCountAfterFirst = (await f.persisted())?.entries[created.loopId]?.tickCount ?? 0;
+
+		// Fire through the timer port exactly as the runtime does - never via fireDue().
+		f.advance(5 * MINUTE);
+		f.timers.fire(created.loopId);
+		await settleUntil(() => f.userMessages.length > 0, "timer-driven tick dispatch");
+
+		expect(f.userMessages).toHaveLength(1);
+		expect(f.userMessages[0].text).toContain("ping");
+		const persisted = await f.persisted();
+		expect(persisted?.entries[created.loopId]?.tickCount ?? 0).toBeGreaterThan(tickCountAfterFirst);
+		expect(f.timers.armedKeys).toEqual([created.loopId]);
 	});
 
 	it("attaches loop attribution details to every dispatched tick", async () => {

--- a/packages/coding-agent/test/suite/loop-loopfile.test.ts
+++ b/packages/coding-agent/test/suite/loop-loopfile.test.ts
@@ -1,0 +1,228 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CONFIG_DIR_NAME, resolveAgentDir } from "../../src/config.ts";
+import { resolveLoopFile, LoopFileError } from "../../src/core/extensions/builtin/loop/loopfile.ts";
+
+function sha256(text: string): string {
+	return createHash("sha256").update(text).digest("hex");
+}
+
+interface MockFile {
+	content: Buffer;
+	mtimeMs: number;
+}
+
+function makeFs(files: Record<string, MockFile>) {
+	return {
+		stat: async (path: string): Promise<{ mtimeMs: number; size: number }> => {
+			const entry = files[path];
+			if (!entry) {
+				const err = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException;
+				err.code = "ENOENT";
+				throw err;
+			}
+			return { mtimeMs: entry.mtimeMs, size: entry.content.length };
+		},
+		readFile: async (path: string): Promise<Buffer> => {
+			const entry = files[path];
+			if (!entry) {
+				const err = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException;
+				err.code = "ENOENT";
+				throw err;
+			}
+			return entry.content;
+		},
+		readBytes: async (path: string, maxBytes: number): Promise<Buffer> => {
+			const entry = files[path];
+			if (!entry) {
+				const err = new Error(`ENOENT: ${path}`) as NodeJS.ErrnoException;
+				err.code = "ENOENT";
+				throw err;
+			}
+			return entry.content.subarray(0, maxBytes);
+		},
+	};
+}
+
+function projectLoopPath(cwd: string): string {
+	return join(cwd, CONFIG_DIR_NAME, "loop.md");
+}
+
+function agentLoopPath(cwd: string, homeDir: string): string {
+	return join(resolveAgentDir(cwd, homeDir), "loop.md");
+}
+
+describe("resolveLoopFile", () => {
+	it("prefers the project-level loop.md over the agent-dir loop.md", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const projectPath = projectLoopPath(cwd);
+		const agentPath = agentLoopPath(cwd, homeDir);
+		const fs = makeFs({
+			[projectPath]: { content: Buffer.from("project tasks"), mtimeMs: 1000 },
+			[agentPath]: { content: Buffer.from("agent tasks"), mtimeMs: 2000 },
+		});
+
+		const result = await resolveLoopFile({ cwd, homeDir, fs, path: { join } });
+
+		expect(result.found).toBe(true);
+		if (!result.found) return;
+		expect(result.path).toBe(projectPath);
+		expect(result.content).toBe("project tasks");
+		expect(result.fingerprint.path).toBe(projectPath);
+		expect(result.fingerprint.mtimeMs).toBe(1000);
+		expect(result.fingerprint.size).toBe(13);
+		expect(result.fingerprint.contentHash).toBe(sha256("project tasks"));
+	});
+
+	it("falls back to the agent-dir loop.md when the project file is absent", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const agentPath = agentLoopPath(cwd, homeDir);
+		const fs = makeFs({
+			[agentPath]: { content: Buffer.from("agent tasks"), mtimeMs: 2000 },
+		});
+
+		const result = await resolveLoopFile({ cwd, homeDir, fs, path: { join } });
+
+		expect(result.found).toBe(true);
+		if (!result.found) return;
+		expect(result.path).toBe(agentPath);
+		expect(result.content).toBe("agent tasks");
+		expect(result.fingerprint.path).toBe(agentPath);
+		expect(result.fingerprint.mtimeMs).toBe(2000);
+		expect(result.fingerprint.size).toBe(11);
+	});
+
+	it("returns found:false when both loop.md files are absent", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const fs = makeFs({});
+
+		const result = await resolveLoopFile({ cwd, homeDir, fs, path: { join } });
+
+		expect(result.found).toBe(false);
+	});
+
+	it("truncates a 30000-byte file to at most 25000 bytes with a warning line and hashes the truncated text", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const projectPath = projectLoopPath(cwd);
+		const longContent = "x".repeat(30000);
+		const fs = makeFs({
+			[projectPath]: { content: Buffer.from(longContent), mtimeMs: 1000 },
+		});
+
+		const result = await resolveLoopFile({ cwd, homeDir, fs, path: { join } });
+
+		expect(result.found).toBe(true);
+		if (!result.found) return;
+		expect(result.content).toContain("[loop.md truncated to the first 25000 bytes]");
+		expect(result.content.length).toBeLessThanOrEqual(25000 + "[loop.md truncated to the first 25000 bytes]".length + 1);
+		const expectedTruncated = longContent.slice(0, 25000) + "\n[loop.md truncated to the first 25000 bytes]";
+		expect(result.content).toBe(expectedTruncated);
+		expect(result.fingerprint.contentHash).toBe(sha256(expectedTruncated));
+		expect(result.fingerprint.size).toBe(30000);
+	});
+
+	it("does not split a multi-byte character at the truncation boundary", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const projectPath = projectLoopPath(cwd);
+		// 24999 single-byte chars plus one 3-byte CJK char = 25002 bytes.
+		const content = "a".repeat(24999) + "中";
+		const fs = makeFs({
+			[projectPath]: { content: Buffer.from(content), mtimeMs: 1000 },
+		});
+
+		const result = await resolveLoopFile({ cwd, homeDir, fs, path: { join } });
+
+		expect(result.found).toBe(true);
+		if (!result.found) return;
+		expect(result.content).not.toContain("\uFFFD");
+		expect(result.content.startsWith("a".repeat(24999))).toBe(true);
+		expect(result.content).toContain("[loop.md truncated to the first 25000 bytes]");
+	});
+
+	it("changes fingerprint when mtime or size changes", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const projectPath = projectLoopPath(cwd);
+		const fs = makeFs({
+			[projectPath]: { content: Buffer.from("tasks"), mtimeMs: 1000 },
+		});
+
+		const first = await resolveLoopFile({ cwd, homeDir, fs, path: { join } });
+		expect(first.found).toBe(true);
+		if (!first.found) return;
+
+		// Simulate mtime change only.
+		const fsMtime = makeFs({
+			[projectPath]: { content: Buffer.from("tasks"), mtimeMs: 2000 },
+		});
+		const second = await resolveLoopFile({ cwd, homeDir, fs: fsMtime, path: { join } });
+		expect(second.found).toBe(true);
+		if (!second.found) return;
+		expect(second.fingerprint.contentHash).toBe(first.fingerprint.contentHash);
+		expect(second.fingerprint.mtimeMs).not.toBe(first.fingerprint.mtimeMs);
+		expect(second.fingerprint).not.toEqual(first.fingerprint);
+
+		// Simulate size (and therefore content/hash) change.
+		const fsSize = makeFs({
+			[projectPath]: { content: Buffer.from("tasks extended"), mtimeMs: 2000 },
+		});
+		const third = await resolveLoopFile({ cwd, homeDir, fs: fsSize, path: { join } });
+		expect(third.found).toBe(true);
+		if (!third.found) return;
+		expect(third.fingerprint.size).not.toBe(second.fingerprint.size);
+		expect(third.fingerprint.contentHash).not.toBe(second.fingerprint.contentHash);
+	});
+
+	it("surfaces a non-ENOENT stat error as a typed LoopFileError", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const projectPath = projectLoopPath(cwd);
+		const fs = {
+			stat: async (_path: string): Promise<{ mtimeMs: number; size: number }> => {
+				const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+				err.code = "EACCES";
+				throw err;
+			},
+			readFile: async (_path: string): Promise<Buffer> => Buffer.from(""),
+			readBytes: async (_path: string, _maxBytes: number): Promise<Buffer> => Buffer.from(""),
+		};
+
+		await expect(resolveLoopFile({ cwd, homeDir, fs, path: { join } })).rejects.toThrow(LoopFileError);
+		await expect(resolveLoopFile({ cwd, homeDir, fs, path: { join } })).rejects.toMatchObject({
+			code: "stat_failed",
+		});
+	});
+
+	it("surfaces a non-ENOENT read error as a typed LoopFileError", async () => {
+		const cwd = "/project";
+		const homeDir = "/home/user";
+		const projectPath = projectLoopPath(cwd);
+		const fs = {
+			stat: async (_path: string): Promise<{ mtimeMs: number; size: number }> => ({
+				mtimeMs: 1000,
+				size: 5,
+			}),
+			readFile: async (_path: string): Promise<Buffer> => {
+				const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+				err.code = "EACCES";
+				throw err;
+			},
+			readBytes: async (_path: string, _maxBytes: number): Promise<Buffer> => {
+				const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+				err.code = "EACCES";
+				throw err;
+			},
+		};
+
+		await expect(resolveLoopFile({ cwd, homeDir, fs, path: { join } })).rejects.toThrow(LoopFileError);
+		await expect(resolveLoopFile({ cwd, homeDir, fs, path: { join } })).rejects.toMatchObject({
+			code: "read_failed",
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/loop-loopfile.test.ts
+++ b/packages/coding-agent/test/suite/loop-loopfile.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { CONFIG_DIR_NAME, resolveAgentDir } from "../../src/config.ts";
-import { resolveLoopFile, LoopFileError } from "../../src/core/extensions/builtin/loop/loopfile.ts";
+import { LoopFileError, resolveLoopFile } from "../../src/core/extensions/builtin/loop/loopfile.ts";
 
 function sha256(text: string): string {
 	return createHash("sha256").update(text).digest("hex");
@@ -119,8 +119,10 @@ describe("resolveLoopFile", () => {
 		expect(result.found).toBe(true);
 		if (!result.found) return;
 		expect(result.content).toContain("[loop.md truncated to the first 25000 bytes]");
-		expect(result.content.length).toBeLessThanOrEqual(25000 + "[loop.md truncated to the first 25000 bytes]".length + 1);
-		const expectedTruncated = longContent.slice(0, 25000) + "\n[loop.md truncated to the first 25000 bytes]";
+		expect(result.content.length).toBeLessThanOrEqual(
+			25000 + "[loop.md truncated to the first 25000 bytes]".length + 1,
+		);
+		const expectedTruncated = `${longContent.slice(0, 25000)}\n[loop.md truncated to the first 25000 bytes]`;
 		expect(result.content).toBe(expectedTruncated);
 		expect(result.fingerprint.contentHash).toBe(sha256(expectedTruncated));
 		expect(result.fingerprint.size).toBe(30000);
@@ -131,7 +133,7 @@ describe("resolveLoopFile", () => {
 		const homeDir = "/home/user";
 		const projectPath = projectLoopPath(cwd);
 		// 24999 single-byte chars plus one 3-byte CJK char = 25002 bytes.
-		const content = "a".repeat(24999) + "中";
+		const content = `${"a".repeat(24999)}中`;
 		const fs = makeFs({
 			[projectPath]: { content: Buffer.from(content), mtimeMs: 1000 },
 		});
@@ -182,7 +184,7 @@ describe("resolveLoopFile", () => {
 	it("surfaces a non-ENOENT stat error as a typed LoopFileError", async () => {
 		const cwd = "/project";
 		const homeDir = "/home/user";
-		const projectPath = projectLoopPath(cwd);
+		const _projectPath = projectLoopPath(cwd);
 		const fs = {
 			stat: async (_path: string): Promise<{ mtimeMs: number; size: number }> => {
 				const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
@@ -202,7 +204,7 @@ describe("resolveLoopFile", () => {
 	it("surfaces a non-ENOENT read error as a typed LoopFileError", async () => {
 		const cwd = "/project";
 		const homeDir = "/home/user";
-		const projectPath = projectLoopPath(cwd);
+		const _projectPath = projectLoopPath(cwd);
 		const fs = {
 			stat: async (_path: string): Promise<{ mtimeMs: number; size: number }> => ({
 				mtimeMs: 1000,

--- a/packages/coding-agent/test/suite/loop-parse.test.ts
+++ b/packages/coding-agent/test/suite/loop-parse.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { parseLoopArgs } from "../../src/core/extensions/builtin/loop/parse.ts";
+
+describe("parseLoopArgs", () => {
+	it("parses leading interval token", () => {
+		const result = parseLoopArgs("5m /babysit-prs");
+		expect(result.kind).toBe("fixed");
+		if (result.kind !== "fixed") throw new Error("type guard");
+		expect(result.interval).toEqual({ value: 5, unit: "m", raw: "5m" });
+		expect(result.prompt).toBe("/babysit-prs");
+	});
+
+	it("parses trailing every clause", () => {
+		const result = parseLoopArgs("check the deploy every 20m");
+		expect(result.kind).toBe("fixed");
+		if (result.kind !== "fixed") throw new Error("type guard");
+		expect(result.interval).toEqual({ value: 20, unit: "m", raw: "20m" });
+		expect(result.prompt).toBe("check the deploy");
+	});
+
+	it("parses trailing every clause with unit word", () => {
+		const result = parseLoopArgs("run tests every 5 minutes");
+		expect(result.kind).toBe("fixed");
+		if (result.kind !== "fixed") throw new Error("type guard");
+		expect(result.interval).toEqual({ value: 5, unit: "m", raw: "5m" });
+		expect(result.prompt).toBe("run tests");
+	});
+
+	it("uses dynamic mode when no interval", () => {
+		const result = parseLoopArgs("check the deploy");
+		expect(result.kind).toBe("dynamic");
+		if (result.kind !== "dynamic") throw new Error("type guard");
+		expect(result.prompt).toBe("check the deploy");
+	});
+
+	it("does not treat 'check every PR' as an interval", () => {
+		const result = parseLoopArgs("check every PR");
+		expect(result.kind).toBe("dynamic");
+		if (result.kind !== "dynamic") throw new Error("type guard");
+		expect(result.prompt).toBe("check every PR");
+	});
+
+	it("parses bare interval-only invocation", () => {
+		const result = parseLoopArgs("5m");
+		expect(result.kind).toBe("bare");
+		if (result.kind !== "bare") throw new Error("type guard");
+		expect(result.interval).toEqual({ value: 5, unit: "m", raw: "5m" });
+	});
+
+	it("parses empty invocation as bare", () => {
+		const result = parseLoopArgs("");
+		expect(result.kind).toBe("bare");
+		if (result.kind !== "bare") throw new Error("type guard");
+		expect(result.interval).toBeUndefined();
+	});
+
+	it("rejects zero amount", () => {
+		const result = parseLoopArgs("0m x");
+		expect(result.kind).toBe("invalid");
+		if (result.kind !== "invalid") throw new Error("type guard");
+		expect(result.reason).toMatch(/zero/i);
+	});
+
+	it("parses stop with implicit target", () => {
+		const result = parseLoopArgs("stop");
+		expect(result.kind).toBe("stop");
+		if (result.kind !== "stop") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "implicit" });
+	});
+
+	it("parses stop all", () => {
+		const result = parseLoopArgs("stop all");
+		expect(result.kind).toBe("stop");
+		if (result.kind !== "stop") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "all" });
+	});
+
+	it("parses stop with id", () => {
+		const result = parseLoopArgs("stop 84dabc");
+		expect(result.kind).toBe("stop");
+		if (result.kind !== "stop") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "id", id: "84dabc" });
+	});
+
+	it("parses status", () => {
+		const result = parseLoopArgs("status");
+		expect(result.kind).toBe("status");
+	});
+
+	it("parses pause with implicit target", () => {
+		const result = parseLoopArgs("pause");
+		expect(result.kind).toBe("pause");
+		if (result.kind !== "pause") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "implicit" });
+	});
+
+	it("parses pause with id", () => {
+		const result = parseLoopArgs("pause 84dabc");
+		expect(result.kind).toBe("pause");
+		if (result.kind !== "pause") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "id", id: "84dabc" });
+	});
+
+	it("parses pause all", () => {
+		const result = parseLoopArgs("pause all");
+		expect(result.kind).toBe("pause");
+		if (result.kind !== "pause") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "all" });
+	});
+
+	it("parses resume with implicit target", () => {
+		const result = parseLoopArgs("resume");
+		expect(result.kind).toBe("resume");
+		if (result.kind !== "resume") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "implicit" });
+	});
+
+	it("parses resume with id", () => {
+		const result = parseLoopArgs("resume 84dabc");
+		expect(result.kind).toBe("resume");
+		if (result.kind !== "resume") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "id", id: "84dabc" });
+	});
+
+	it("parses resume all", () => {
+		const result = parseLoopArgs("resume all");
+		expect(result.kind).toBe("resume");
+		if (result.kind !== "resume") throw new Error("type guard");
+		expect(result.target).toEqual({ type: "all" });
+	});
+
+	it("preserves inner spacing of the prompt", () => {
+		const result = parseLoopArgs("2h  spaced   prompt");
+		expect(result.kind).toBe("fixed");
+		if (result.kind !== "fixed") throw new Error("type guard");
+		expect(result.interval).toEqual({ value: 2, unit: "h", raw: "2h" });
+		expect(result.prompt).toBe("spaced   prompt");
+	});
+
+	it("leading interval wins over trailing every clause", () => {
+		const result = parseLoopArgs("5m check every 20m");
+		expect(result.kind).toBe("fixed");
+		if (result.kind !== "fixed") throw new Error("type guard");
+		expect(result.interval).toEqual({ value: 5, unit: "m", raw: "5m" });
+		expect(result.prompt).toBe("check every 20m");
+	});
+
+	it("preserves prompt case and punctuation", () => {
+		const result = parseLoopArgs("1d Check THE Deploy!");
+		expect(result.kind).toBe("fixed");
+		if (result.kind !== "fixed") throw new Error("type guard");
+		expect(result.prompt).toBe("Check THE Deploy!");
+	});
+
+	it("rejects zero in trailing every clause", () => {
+		const result = parseLoopArgs("x every 0 seconds");
+		expect(result.kind).toBe("invalid");
+		if (result.kind !== "invalid") throw new Error("type guard");
+		expect(result.reason).toMatch(/zero/i);
+	});
+
+	it("accepts all supported unit aliases in trailing every clauses", () => {
+		const units: Array<[string, "s" | "m" | "h" | "d"]> = [
+			["1s", "s"],
+			["1sec", "s"],
+			["1secs", "s"],
+			["1second", "s"],
+			["1seconds", "s"],
+			["1m", "m"],
+			["1min", "m"],
+			["1mins", "m"],
+			["1minute", "m"],
+			["1minutes", "m"],
+			["1h", "h"],
+			["1hr", "h"],
+			["1hrs", "h"],
+			["1hour", "h"],
+			["1hours", "h"],
+			["1d", "d"],
+			["1day", "d"],
+			["1days", "d"],
+		];
+		for (const [raw, unit] of units) {
+			const result = parseLoopArgs(`task every ${raw}`);
+			expect(result.kind).toBe("fixed");
+			if (result.kind !== "fixed") throw new Error(`type guard for ${raw}`);
+			expect(result.interval.unit).toBe(unit);
+			expect(result.interval.value).toBe(1);
+		}
+	});
+
+	it("keeps the original argument string on parsed results", () => {
+		const raw = "5m /babysit-prs";
+		const result = parseLoopArgs(raw);
+		expect("originalArgs" in result ? result.originalArgs : undefined).toBe(raw);
+	});
+});

--- a/packages/coding-agent/test/suite/loop-scheduler.test.ts
+++ b/packages/coding-agent/test/suite/loop-scheduler.test.ts
@@ -1,0 +1,929 @@
+import { describe, expect, it } from "vitest";
+import {
+	createLoopScheduler,
+	DEFAULT_KEEPALIVE_SECONDS,
+	DEFAULT_MAX_TICKS,
+	LOOP_EXPIRY_MS,
+	type LoopSchedulerDeps,
+	type LoopTimerPort,
+	MAX_ACTIVE_LOOPS,
+} from "../../src/core/extensions/builtin/loop/scheduler.ts";
+import type {
+	CronEntry,
+	DynamicCronEntry,
+	FixedCronEntry,
+	LoopEndReason,
+	LoopState,
+} from "../../src/core/extensions/builtin/loop/types.ts";
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const T0 = 1_700_000_000_000;
+
+/** Fake timer port: records armed keys and lets the test fire them explicitly. */
+class FakeTimers implements LoopTimerPort {
+	readonly armed = new Map<string, { dueAt: number; callback: () => void }>();
+	readonly armLog: Array<{ key: string; dueAt: number }> = [];
+	readonly cancelLog: string[] = [];
+	cancelAllCount = 0;
+
+	arm(key: string, dueAt: number, callback: () => void): void {
+		this.armed.set(key, { dueAt, callback });
+		this.armLog.push({ key, dueAt });
+	}
+
+	cancel(key: string): void {
+		if (this.armed.delete(key)) this.cancelLog.push(key);
+	}
+
+	cancelAll(): void {
+		this.cancelAllCount += 1;
+		this.armed.clear();
+	}
+
+	dueAt(key: string): number | undefined {
+		return this.armed.get(key)?.dueAt;
+	}
+
+	/** Invokes the armed callback for a key, as a real timeout would. */
+	fire(key: string): void {
+		const entry = this.armed.get(key);
+		if (entry === undefined) throw new Error(`no timer armed for ${key}`);
+		entry.callback();
+	}
+}
+
+interface Harness {
+	readonly scheduler: ReturnType<typeof createLoopScheduler>;
+	readonly timers: FakeTimers;
+	setNow(value: number): void;
+	advance(ms: number): void;
+	now(): number;
+}
+
+function harness(
+	options: {
+		now?: number;
+		env?: Record<string, string | undefined>;
+		initialState?: LoopState;
+		idPrefix?: string;
+	} = {},
+): Harness {
+	let current = options.now ?? T0;
+	const timers = new FakeTimers();
+	const prefix = options.idPrefix ?? "";
+	let loopSeq = 0;
+	let wakeupSeq = 0;
+	let deliverySeq = 0;
+	const deps: LoopSchedulerDeps = {
+		sessionId: "session-under-test",
+		clock: { now: () => current },
+		timers,
+		ids: {
+			loopId: () => `${prefix}loop-${++loopSeq}`,
+			wakeupId: () => `${prefix}wakeup-${++wakeupSeq}`,
+			deliveryId: () => `${prefix}delivery-${++deliverySeq}`,
+		},
+		env: options.env ?? {},
+		...(options.initialState === undefined ? {} : { initialState: options.initialState }),
+	};
+	const scheduler = createLoopScheduler(deps);
+	return {
+		scheduler,
+		timers,
+		setNow: (value) => {
+			current = value;
+		},
+		advance: (ms) => {
+			current += ms;
+		},
+		now: () => current,
+	};
+}
+
+function createFixedLoop(h: Harness, overrides: { intervalMs?: number; prompt?: string } = {}) {
+	const intervalMs = overrides.intervalMs ?? 5 * MINUTE;
+	return h.scheduler.createFixed({
+		originalArgs: `5m ${overrides.prompt ?? "check the deploy"}`,
+		reentryPrompt: `/loop 5m ${overrides.prompt ?? "check the deploy"}`,
+		payload: { type: "prompt", prompt: overrides.prompt ?? "check the deploy" },
+		requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		effectiveInterval: { value: 5, unit: "m", human: "5 minutes", rounded: false },
+		cronExpression: "*/5 * * * *",
+		intervalMs,
+	});
+}
+
+function createDynamicLoop(h: Harness, prompt = "watch the queue") {
+	return h.scheduler.createDynamic({
+		originalArgs: prompt,
+		reentryPrompt: `/loop ${prompt}`,
+		payload: { type: "prompt", prompt },
+	});
+}
+
+function expectFixed(entry: CronEntry | undefined): FixedCronEntry {
+	if (entry === undefined || entry.kind !== "fixed") throw new Error("expected a fixed entry");
+	return entry;
+}
+
+function expectDynamic(entry: CronEntry | undefined): DynamicCronEntry {
+	if (entry === undefined || entry.kind !== "dynamic") throw new Error("expected a dynamic entry");
+	return entry;
+}
+
+function loopEntry(h: Harness, loopId: string): CronEntry {
+	const entry = h.scheduler.getState().entries[loopId];
+	if (entry === undefined) throw new Error(`no entry for ${loopId}`);
+	return entry;
+}
+
+/** Runs a full dispatched tick: due -> dispatch -> settled. */
+function runTick(h: Harness, loopId: string): void {
+	const due = h.scheduler.onDue(loopId, h.now(), false);
+	if (due.action !== "dispatch") throw new Error(`expected dispatch, got ${due.action}`);
+	h.scheduler.onTickSettled({ loopId, deliveryId: due.tick.deliveryId, outcome: "completed" });
+}
+
+describe("createFixed", () => {
+	it("arms the next occurrence recomputed from now and returns the first tick", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+
+		const entry = expectFixed(loopEntry(h, created.loopId));
+		expect(entry.kind).toBe("fixed");
+		expect(entry.phase).toBe("waiting");
+		expect(entry.nextFireAt).toBe(T0 + 5 * MINUTE);
+		expect(entry.expiresAt).toBe(T0 + LOOP_EXPIRY_MS);
+		expect(h.timers.dueAt(created.loopId)).toBe(T0 + 5 * MINUTE);
+	});
+
+	it("recomputes nextFireAt from now on every scheduled fire, never from the stale due time", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+
+		// Timer callback lands 90s late (event-loop lag).
+		h.setNow(T0 + 5 * MINUTE + 90_000);
+		const due = h.scheduler.onDue(created.loopId, h.now(), false);
+		expect(due.action).toBe("dispatch");
+
+		const entry = expectFixed(loopEntry(h, created.loopId));
+		expect(entry.nextFireAt).toBe(h.now() + 5 * MINUTE);
+		expect(entry.nextFireAt).not.toBe(T0 + 10 * MINUTE);
+		expect(h.timers.dueAt(created.loopId)).toBe(h.now() + 5 * MINUTE);
+	});
+
+	it("rejects a 6th active loop with a typed rejection while the 5 existing loops stay armed", () => {
+		const h = harness();
+		const ids: string[] = [];
+		for (let i = 0; i < MAX_ACTIVE_LOOPS; i++) {
+			const created = createFixedLoop(h, { prompt: `job ${i}` });
+			expect(created.ok).toBe(true);
+			if (created.ok) ids.push(created.loopId);
+		}
+		expect(ids).toHaveLength(5);
+
+		const rejected = createFixedLoop(h, { prompt: "job 6" });
+		expect(rejected.ok).toBe(false);
+		if (rejected.ok) return;
+		expect(rejected.reason).toBe("active_loop_cap");
+		expect(rejected.activeLoopIds).toEqual(ids);
+		expect(rejected.cap).toBe(MAX_ACTIVE_LOOPS);
+		expect(rejected.message).toMatch(/\/loop stop/);
+
+		expect(Object.keys(h.scheduler.getState().entries)).toHaveLength(5);
+		for (const id of ids) {
+			expect(loopEntry(h, id).phase).toBe("waiting");
+			expect(h.timers.dueAt(id)).toBe(T0 + 5 * MINUTE);
+		}
+	});
+});
+
+describe("createDynamic", () => {
+	it("starts with keepalive credit 1 and no armed timer until the model schedules", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+
+		const entry = expectDynamic(loopEntry(h, created.loopId));
+		expect(entry.keepaliveCredit).toBe(1);
+		expect(entry.pendingWakeup).toBeNull();
+		expect(h.scheduler.getState().activeDynamicId).toBe(created.loopId);
+		expect(h.timers.armed.has(created.loopId)).toBe(false);
+	});
+
+	it("supersedes an existing dynamic loop in one mutation", () => {
+		const h = harness();
+		const first = createDynamicLoop(h, "first");
+		if (!first.ok) throw new Error("create failed");
+		h.scheduler.onScheduleWakeup({
+			loopId: first.loopId,
+			delaySeconds: 600,
+			requestedDelaySeconds: 600,
+			reason: "poll",
+			prompt: "/loop first",
+			noop: false,
+		});
+		expect(h.timers.armed.has(first.loopId)).toBe(true);
+		const versionBefore = h.scheduler.getState().updatedAt;
+
+		h.advance(MINUTE);
+		const second = createDynamicLoop(h, "second");
+		if (!second.ok) throw new Error("create failed");
+		expect(second.supersededLoopId).toBe(first.loopId);
+
+		const state = h.scheduler.getState();
+		const old = expectDynamic(state.entries[first.loopId]);
+		expect(old.phase).toBe("ended");
+		expect(old.endReason).toBe("stopped");
+		expect(old.endDetail).toBe("superseded");
+		expect(state.activeDynamicId).toBe(second.loopId);
+		expect(h.timers.armed.has(first.loopId)).toBe(false);
+		// Both the end and the creation land in a single state revision.
+		expect(state.updatedAt).toBe(h.now());
+		expect(state.updatedAt).not.toBe(versionBefore);
+		expect(h.scheduler.mutationCount).toBe(3);
+	});
+});
+
+describe("onDue coalescing", () => {
+	it("queues exactly one tick and sets coalescedFirePending for further due occurrences", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.advance(5 * MINUTE);
+		const first = h.scheduler.onDue(loopId, h.now(), true);
+		expect(first.action).toBe("dispatch");
+		if (first.action !== "dispatch") return;
+		expect(first.tick.deliverAs).toBe("followUp");
+		expect(loopEntry(h, loopId).phase).toBe("queued");
+
+		h.advance(5 * MINUTE);
+		const second = h.scheduler.onDue(loopId, h.now(), true);
+		h.advance(5 * MINUTE);
+		const third = h.scheduler.onDue(loopId, h.now(), true);
+		h.advance(5 * MINUTE);
+		const fourth = h.scheduler.onDue(loopId, h.now(), true);
+
+		expect(second.action).toBe("coalesce");
+		expect(third.action).toBe("coalesce");
+		expect(fourth.action).toBe("coalesce");
+
+		const entry = expectFixed(loopEntry(h, loopId));
+		expect(entry.coalescedFirePending).toBe(true);
+		expect(entry.tickCount).toBe(1);
+		// Coalescing still keeps the schedule moving forward from now.
+		expect(entry.nextFireAt).toBe(h.now() + 5 * MINUTE);
+
+		// Settling releases exactly one coalesced tick, and only one.
+		const released = h.scheduler.onTickSettled({
+			loopId,
+			deliveryId: first.tick.deliveryId,
+			outcome: "completed",
+		});
+		expect(released.action).toBe("dispatch");
+		if (released.action !== "dispatch") return;
+		expect(expectFixed(loopEntry(h, loopId)).coalescedFirePending).toBe(false);
+
+		const settledAgain = h.scheduler.onTickSettled({
+			loopId,
+			deliveryId: released.tick.deliveryId,
+			outcome: "completed",
+		});
+		expect(settledAgain.action).toBe("idle");
+		expect(expectFixed(loopEntry(h, loopId)).tickCount).toBe(2);
+	});
+
+	it("dispatches through the injected timer callback and re-arms the replacement timer", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+		expect(h.timers.armLog).toHaveLength(1);
+
+		h.advance(5 * MINUTE);
+		h.timers.fire(loopId);
+
+		// The callback routed through onDue: the tick counted and a fresh timer was armed.
+		expect(loopEntry(h, loopId).tickCount).toBe(1);
+		expect(loopEntry(h, loopId).phase).toBe("running");
+		expect(h.timers.armLog).toHaveLength(2);
+		expect(h.timers.dueAt(loopId)).toBe(h.now() + 5 * MINUTE);
+	});
+
+	it("collapses a 3-day clock jump into exactly ONE tick with the next fire after now", () => {
+		const h = harness();
+		const created = createFixedLoop(h, { intervalMs: MINUTE });
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.advance(3 * DAY);
+		let dispatches = 0;
+		// The laptop wakes and the single armed timer fires once; the scheduler must never
+		// replay the ~4320 missed occurrences.
+		for (let i = 0; i < 10; i++) {
+			const due = h.scheduler.onDue(loopId, h.now(), false);
+			if (due.action === "dispatch") dispatches += 1;
+		}
+		expect(dispatches).toBe(1);
+
+		const entry = expectFixed(loopEntry(h, loopId));
+		expect(entry.tickCount).toBe(1);
+		expect(entry.nextFireAt).toBeGreaterThan(h.now());
+		expect(entry.nextFireAt).toBe(h.now() + MINUTE);
+	});
+});
+
+describe("expiry", () => {
+	it("expires at day 7 with no final tick, and never extends expiry via a new wakeup", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.advance(6 * DAY);
+		const scheduled = h.scheduler.onScheduleWakeup({
+			loopId,
+			delaySeconds: 3600,
+			requestedDelaySeconds: 3600,
+			reason: "poll",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+		expect(scheduled.ok).toBe(true);
+		expect(expectDynamic(loopEntry(h, loopId)).expiresAt).toBe(T0 + LOOP_EXPIRY_MS);
+
+		h.setNow(T0 + LOOP_EXPIRY_MS);
+		const due = h.scheduler.onDue(loopId, h.now(), false);
+		expect(due.action).toBe("expire");
+
+		const entry = loopEntry(h, loopId);
+		expect(entry.phase).toBe("ended");
+		expect(requireEndReason(entry)).toBe("expired");
+		expect(entry.tickCount).toBe(0);
+		expect(entry.lastFiredAt).toBeNull();
+		expect(h.timers.armed.has(loopId)).toBe(false);
+	});
+
+	it("expires a fixed loop at arm time instead of arming a post-expiry timer", () => {
+		const h = harness();
+		const created = createFixedLoop(h, { intervalMs: 12 * HOUR });
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.setNow(T0 + LOOP_EXPIRY_MS - HOUR);
+		const due = h.scheduler.onDue(loopId, h.now(), false);
+		expect(due.action).toBe("dispatch");
+		// The next occurrence would land past expiry, so no timer may be armed for it.
+		expect(loopEntry(h, loopId).phase).toBe("ended");
+		expect(loopEntry(h, loopId).endReason).toBe("expired");
+		expect(h.timers.armed.has(loopId)).toBe(false);
+	});
+
+	it("expires overdue entries on restore without firing a recovery tick", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.scheduler.onShutdown();
+		h.setNow(T0 + LOOP_EXPIRY_MS + DAY);
+		const restored = h.scheduler.restore(h.now());
+		expect(restored.recoveryTicks).toHaveLength(0);
+		expect(restored.expiredLoopIds).toEqual([loopId]);
+		expect(loopEntry(h, loopId).endReason).toBe("expired");
+	});
+});
+
+describe("keepalive two-strike", () => {
+	it("arms exactly one fallback wakeup on the first omission and then ends keepalive_exhausted", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		const first = h.scheduler.onTurnEndedWithoutSchedule(loopId);
+		expect(first.action).toBe("keepalive_armed");
+		if (first.action !== "keepalive_armed") return;
+		expect(first.delaySeconds).toBe(DEFAULT_KEEPALIVE_SECONDS);
+		expect(first.dueAt).toBe(T0 + DEFAULT_KEEPALIVE_SECONDS * 1000);
+
+		const armed = expectDynamic(loopEntry(h, loopId));
+		expect(armed.keepaliveCredit).toBe(0);
+		expect(armed.pendingWakeup?.source).toBe("keepalive");
+		expect(h.timers.dueAt(loopId)).toBe(T0 + DEFAULT_KEEPALIVE_SECONDS * 1000);
+
+		h.advance(DEFAULT_KEEPALIVE_SECONDS * 1000);
+		runTick(h, loopId);
+
+		const second = h.scheduler.onTurnEndedWithoutSchedule(loopId);
+		expect(second.action).toBe("ended");
+		if (second.action !== "ended") return;
+		expect(second.endReason).toBe("keepalive_exhausted");
+
+		const ended = loopEntry(h, loopId);
+		expect(ended.phase).toBe("ended");
+		expect(ended.endReason).toBe("keepalive_exhausted");
+		expect(h.timers.armed.has(loopId)).toBe(false);
+	});
+
+	it("resets the credit to 1 when the model schedules successfully between omissions", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		expect(h.scheduler.onTurnEndedWithoutSchedule(loopId).action).toBe("keepalive_armed");
+		expect(expectDynamic(loopEntry(h, loopId)).keepaliveCredit).toBe(0);
+
+		h.advance(DEFAULT_KEEPALIVE_SECONDS * 1000);
+		runTick(h, loopId);
+		const scheduled = h.scheduler.onScheduleWakeup({
+			loopId,
+			delaySeconds: 900,
+			requestedDelaySeconds: 900,
+			reason: "recheck",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+		expect(scheduled.ok).toBe(true);
+		if (!scheduled.ok) return;
+		expect(scheduled.replacedWakeupId).toBeUndefined();
+		expect(expectDynamic(loopEntry(h, loopId)).keepaliveCredit).toBe(1);
+
+		h.advance(900_000);
+		runTick(h, loopId);
+		const omission = h.scheduler.onTurnEndedWithoutSchedule(loopId);
+		expect(omission.action).toBe("keepalive_armed");
+		expect(loopEntry(h, loopId).phase).not.toBe("ended");
+	});
+
+	it("honors SENPI_LOOP_KEEPALIVE_SECONDS and clamps it to [60,3600]", () => {
+		const low = harness({ env: { SENPI_LOOP_KEEPALIVE_SECONDS: "5" } });
+		const lowLoop = createDynamicLoop(low);
+		if (!lowLoop.ok) throw new Error("create failed");
+		const lowResult = low.scheduler.onTurnEndedWithoutSchedule(lowLoop.loopId);
+		expect(lowResult.action === "keepalive_armed" && lowResult.delaySeconds).toBe(60);
+
+		const high = harness({ env: { SENPI_LOOP_KEEPALIVE_SECONDS: "999999" } });
+		const highLoop = createDynamicLoop(high);
+		if (!highLoop.ok) throw new Error("create failed");
+		const highResult = high.scheduler.onTurnEndedWithoutSchedule(highLoop.loopId);
+		expect(highResult.action === "keepalive_armed" && highResult.delaySeconds).toBe(3600);
+
+		const custom = harness({ env: { SENPI_LOOP_KEEPALIVE_SECONDS: "300" } });
+		const customLoop = createDynamicLoop(custom);
+		if (!customLoop.ok) throw new Error("create failed");
+		const customResult = custom.scheduler.onTurnEndedWithoutSchedule(customLoop.loopId);
+		expect(customResult.action === "keepalive_armed" && customResult.delaySeconds).toBe(300);
+	});
+
+	it("never applies keepalive to a fixed loop", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const result = h.scheduler.onTurnEndedWithoutSchedule(created.loopId);
+		expect(result.action).toBe("ignored");
+		expect(loopEntry(h, created.loopId).phase).toBe("waiting");
+	});
+
+	it("keeps a dynamic loop alive after a provider error, which is never terminal", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+		h.scheduler.onScheduleWakeup({
+			loopId,
+			delaySeconds: 600,
+			requestedDelaySeconds: 600,
+			reason: "poll",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+
+		h.advance(600_000);
+		const due = h.scheduler.onDue(loopId, h.now(), false);
+		if (due.action !== "dispatch") throw new Error("expected dispatch");
+		h.scheduler.onTickSettled({ loopId, deliveryId: due.tick.deliveryId, outcome: "error" });
+
+		expect(loopEntry(h, loopId).phase).not.toBe("ended");
+		expect(expectDynamic(loopEntry(h, loopId)).keepaliveCredit).toBe(1);
+
+		// A fixed loop's provider error is equally nonterminal and leaves the schedule armed.
+		const fixed = createFixedLoop(h);
+		if (!fixed.ok) throw new Error("create failed");
+		h.advance(5 * MINUTE);
+		const fixedDue = h.scheduler.onDue(fixed.loopId, h.now(), false);
+		if (fixedDue.action !== "dispatch") throw new Error("expected dispatch");
+		h.scheduler.onTickSettled({ loopId: fixed.loopId, deliveryId: fixedDue.tick.deliveryId, outcome: "error" });
+		expect(loopEntry(h, fixed.loopId).phase).toBe("waiting");
+		expect(h.timers.armed.has(fixed.loopId)).toBe(true);
+	});
+
+	it("does not run keepalive for a retrying turn that is still in progress", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+		h.scheduler.onScheduleWakeup({
+			loopId,
+			delaySeconds: 600,
+			requestedDelaySeconds: 600,
+			reason: "poll",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+		h.advance(600_000);
+		const due = h.scheduler.onDue(loopId, h.now(), false);
+		if (due.action !== "dispatch") throw new Error("expected dispatch");
+		const settled = h.scheduler.onTickSettled({
+			loopId,
+			deliveryId: due.tick.deliveryId,
+			outcome: "retrying",
+		});
+		expect(settled.action).toBe("in_progress");
+		expect(loopEntry(h, loopId).phase).toBe("running");
+	});
+});
+
+describe("onUserAbort", () => {
+	it("pauses the loop and never consumes keepalive credit", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+		h.scheduler.onScheduleWakeup({
+			loopId,
+			delaySeconds: 600,
+			requestedDelaySeconds: 600,
+			reason: "poll",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+		h.advance(600_000);
+		const due = h.scheduler.onDue(loopId, h.now(), false);
+		if (due.action !== "dispatch") throw new Error("expected dispatch");
+
+		const aborted = h.scheduler.onUserAbort(loopId);
+		expect(aborted.action).toBe("paused");
+		const entry = expectDynamic(loopEntry(h, loopId));
+		expect(entry.phase).toBe("suspended");
+		expect(entry.phase).not.toBe("ended");
+		expect(entry.keepaliveCredit).toBe(1);
+		expect(h.timers.armed.has(loopId)).toBe(false);
+
+		// The aborted turn settles afterwards; that omission must NOT be treated as keepalive.
+		const after = h.scheduler.onTurnEndedWithoutSchedule(loopId);
+		expect(after.action).toBe("ignored");
+		expect(expectDynamic(loopEntry(h, loopId)).keepaliveCredit).toBe(1);
+		expect(loopEntry(h, loopId).phase).toBe("suspended");
+	});
+});
+
+describe("pause, resume, stop", () => {
+	it("pauses and resumes a single loop, recomputing the next fire from now", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		const paused = h.scheduler.pause(loopId);
+		expect(paused.affectedLoopIds).toEqual([loopId]);
+		expect(loopEntry(h, loopId).phase).toBe("suspended");
+		expect(h.timers.armed.has(loopId)).toBe(false);
+
+		// Idempotent: a second pause changes nothing and reports no newly affected loop.
+		expect(h.scheduler.pause(loopId).affectedLoopIds).toEqual([]);
+		expect(loopEntry(h, loopId).phase).toBe("suspended");
+
+		h.advance(DAY);
+		const resumed = h.scheduler.resume(loopId);
+		expect(resumed.affectedLoopIds).toEqual([loopId]);
+		expect(loopEntry(h, loopId).phase).toBe("waiting");
+		expect(expectFixed(loopEntry(h, loopId)).nextFireAt).toBe(h.now() + 5 * MINUTE);
+		expect(h.timers.dueAt(loopId)).toBe(h.now() + 5 * MINUTE);
+		expect(h.scheduler.resume(loopId).affectedLoopIds).toEqual([]);
+	});
+
+	it("pauses and resumes all loops", () => {
+		const h = harness();
+		const a = createFixedLoop(h, { prompt: "a" });
+		const b = createFixedLoop(h, { prompt: "b" });
+		if (!a.ok || !b.ok) throw new Error("create failed");
+
+		expect(sorted(h.scheduler.pause("all").affectedLoopIds)).toEqual([a.loopId, b.loopId].sort());
+		expect(loopEntry(h, a.loopId).phase).toBe("suspended");
+		expect(loopEntry(h, b.loopId).phase).toBe("suspended");
+		expect(h.timers.armed.size).toBe(0);
+
+		expect(sorted(h.scheduler.resume("all").affectedLoopIds)).toEqual([a.loopId, b.loopId].sort());
+		expect(h.timers.armed.size).toBe(2);
+	});
+
+	it("stops a single loop and all loops, idempotently, without resurrecting an ended loop", () => {
+		const h = harness();
+		const a = createFixedLoop(h, { prompt: "a" });
+		const b = createFixedLoop(h, { prompt: "b" });
+		const c = createDynamicLoop(h, "c");
+		if (!a.ok || !b.ok || !c.ok) throw new Error("create failed");
+
+		const stopped = h.scheduler.stop(a.loopId, "user-command");
+		expect(stopped.affectedLoopIds).toEqual([a.loopId]);
+		expect(loopEntry(h, a.loopId).endReason).toBe("stopped");
+		expect(loopEntry(h, a.loopId).endDetail).toBe("user-command");
+		expect(h.scheduler.stop(a.loopId, "user-command").affectedLoopIds).toEqual([]);
+
+		const stoppedAll = h.scheduler.stop("all", "user-command");
+		expect(sorted(stoppedAll.affectedLoopIds)).toEqual([b.loopId, c.loopId].sort());
+		expect(h.timers.armed.size).toBe(0);
+		expect(h.scheduler.getState().activeDynamicId).toBeNull();
+
+		// A stopped loop cannot be resumed back into an armed state.
+		expect(h.scheduler.resume("all").affectedLoopIds).toEqual([]);
+		expect(loopEntry(h, b.loopId).phase).toBe("ended");
+		expect(h.timers.armed.size).toBe(0);
+	});
+
+	it("cancels the timer on stop, and a stale due callback dispatches nothing", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.scheduler.stop(loopId, "user-command");
+		expect(h.timers.cancelLog).toContain(loopId);
+
+		// Defense in depth: even if a port leaked a stale callback, the due decision is
+		// re-derived from state and must refuse to dispatch.
+		h.advance(5 * MINUTE);
+		expect(h.scheduler.onDue(loopId, h.now(), false).action).toBe("coalesce");
+		expect(loopEntry(h, loopId).tickCount).toBe(0);
+		expect(h.scheduler.currentDeliveryId(loopId)).toBeUndefined();
+	});
+
+	it("refuses to dispatch a due tick for a paused loop", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		h.scheduler.pause(created.loopId);
+		h.advance(5 * MINUTE);
+		expect(h.scheduler.onDue(created.loopId, h.now(), false).action).toBe("coalesce");
+		expect(loopEntry(h, created.loopId).tickCount).toBe(0);
+	});
+});
+
+describe("onShutdown and restore", () => {
+	it("suspends every loop with no terminal reason and cancels every timer", () => {
+		const h = harness();
+		const a = createFixedLoop(h, { prompt: "a" });
+		const b = createDynamicLoop(h, "b");
+		if (!a.ok || !b.ok) throw new Error("create failed");
+		h.scheduler.onScheduleWakeup({
+			loopId: b.loopId,
+			delaySeconds: 600,
+			requestedDelaySeconds: 600,
+			reason: "poll",
+			prompt: "/loop b",
+			noop: false,
+		});
+
+		const result = h.scheduler.onShutdown();
+		expect(sorted(result.suspendedLoopIds)).toEqual([a.loopId, b.loopId].sort());
+		for (const id of [a.loopId, b.loopId]) {
+			const entry = loopEntry(h, id);
+			expect(entry.phase).toBe("suspended");
+			expect(entry.endReason).toBeUndefined();
+			expect(entry.endedAt).toBeUndefined();
+		}
+		expect(h.timers.cancelAllCount).toBeGreaterThan(0);
+		expect(h.timers.armed.size).toBe(0);
+	});
+
+	it("re-arms on restore and emits at most one recovery tick per overdue job", () => {
+		const h = harness();
+		const overdue = createFixedLoop(h, { prompt: "overdue" });
+		const future = createFixedLoop(h, { intervalMs: 2 * HOUR, prompt: "future" });
+		if (!overdue.ok || !future.ok) throw new Error("create failed");
+		h.scheduler.onShutdown();
+
+		h.advance(DAY);
+		const restored = h.scheduler.restore(h.now());
+		expect(restored.recoveryTicks.map((tick) => tick.loopId)).toEqual([overdue.loopId, future.loopId]);
+		expect(restored.recoveryTicks.filter((tick) => tick.loopId === overdue.loopId)).toHaveLength(1);
+
+		expect(expectFixed(loopEntry(h, overdue.loopId)).nextFireAt).toBe(h.now() + 5 * MINUTE);
+		expect(expectFixed(loopEntry(h, future.loopId)).nextFireAt).toBe(h.now() + 2 * HOUR);
+		expect(h.timers.dueAt(overdue.loopId)).toBe(h.now() + 5 * MINUTE);
+	});
+
+	it("converts a crashed running tick into exactly one coalesced recovery tick", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.advance(5 * MINUTE);
+		const due = h.scheduler.onDue(loopId, h.now(), false);
+		expect(due.action).toBe("dispatch");
+		expect(loopEntry(h, loopId).phase).toBe("running");
+		h.advance(5 * MINUTE);
+		expect(h.scheduler.onDue(loopId, h.now(), false).action).toBe("coalesce");
+		expect(expectFixed(loopEntry(h, loopId)).coalescedFirePending).toBe(true);
+
+		// Crash: the process dies with no shutdown hook, so a NEW scheduler starts from the
+		// persisted state and must turn that queued/running remnant into ONE recovery tick.
+		const crashed = h.scheduler.getState();
+		const next = harness({
+			now: h.now() + MINUTE,
+			initialState: crashed,
+			idPrefix: "restored-",
+		});
+		const restored = next.scheduler.restore(next.now());
+		expect(restored.recoveryTicks.filter((tick) => tick.loopId === loopId)).toHaveLength(1);
+		expect(expectFixed(loopEntry(next, loopId)).coalescedFirePending).toBe(false);
+		expect(expectFixed(loopEntry(next, loopId)).nextFireAt).toBe(next.now() + 5 * MINUTE);
+		expect(next.timers.dueAt(loopId)).toBe(next.now() + 5 * MINUTE);
+	});
+
+	it("restores an overdue dynamic wakeup exactly once and drops the pending wakeup", () => {
+		const h = harness();
+		const created = createDynamicLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+		h.scheduler.onScheduleWakeup({
+			loopId,
+			delaySeconds: 600,
+			requestedDelaySeconds: 600,
+			reason: "poll",
+			prompt: "/loop watch the queue",
+			noop: false,
+		});
+		h.scheduler.onShutdown();
+
+		h.advance(2 * HOUR);
+		const restored = h.scheduler.restore(h.now());
+		expect(restored.recoveryTicks.map((tick) => tick.loopId)).toEqual([loopId]);
+		expect(expectDynamic(loopEntry(h, loopId)).pendingWakeup).toBeNull();
+
+		// Settle that recovery delivery, then restore again: the one-shot wakeup was
+		// consumed, so nothing may be replayed.
+		h.scheduler.onTickSettled({
+			loopId,
+			deliveryId: restored.recoveryTicks[0]!.deliveryId,
+			outcome: "completed",
+		});
+		const again = h.scheduler.restore(h.now());
+		expect(again.recoveryTicks).toHaveLength(0);
+		expect(loopEntry(h, loopId).tickCount).toBe(1);
+	});
+
+	it("keeps an explicitly user-paused loop paused across restore", () => {
+		const h = harness();
+		const paused = createFixedLoop(h, { prompt: "paused" });
+		const running = createFixedLoop(h, { prompt: "running" });
+		if (!paused.ok || !running.ok) throw new Error("create failed");
+		h.scheduler.pause(paused.loopId);
+		h.scheduler.onShutdown();
+
+		h.advance(DAY);
+		const restored = h.scheduler.restore(h.now(), { userPausedLoopIds: [paused.loopId] });
+
+		expect(restored.stillPausedLoopIds).toEqual([paused.loopId]);
+		expect(loopEntry(h, paused.loopId).phase).toBe("suspended");
+		expect(h.timers.armed.has(paused.loopId)).toBe(false);
+		expect(restored.recoveryTicks.map((tick) => tick.loopId)).toEqual([running.loopId]);
+
+		// The shutdown-suspended loop, by contrast, is re-armed.
+		expect(loopEntry(h, running.loopId).phase).toBe("queued");
+		expect(h.timers.dueAt(running.loopId)).toBe(h.now() + 5 * MINUTE);
+	});
+
+	it("leaves a stopped loop ended across restore", () => {
+		const h = harness();
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		h.scheduler.stop(created.loopId, "user-command");
+		h.scheduler.onShutdown();
+
+		h.advance(DAY);
+		const restored = h.scheduler.restore(h.now());
+		expect(restored.recoveryTicks).toHaveLength(0);
+		expect(loopEntry(h, created.loopId).phase).toBe("ended");
+		expect(h.timers.armed.size).toBe(0);
+	});
+});
+
+describe("max-ticks budget", () => {
+	it("ends the loop with tick_budget_exhausted and arms no further timer", () => {
+		const h = harness({ env: { SENPI_LOOP_MAX_TICKS: "2" } });
+		const created = createFixedLoop(h);
+		if (!created.ok) throw new Error("create failed");
+		const loopId = created.loopId;
+
+		h.advance(5 * MINUTE);
+		expect(h.scheduler.onDue(loopId, h.now(), false).action).toBe("dispatch");
+		runTickSettleFromRunning(h, loopId);
+		expect(loopEntry(h, loopId).phase).toBe("waiting");
+
+		h.advance(5 * MINUTE);
+		const second = h.scheduler.onDue(loopId, h.now(), false);
+		expect(second.action).toBe("dispatch");
+		expect(loopEntry(h, loopId).tickCount).toBe(2);
+		runTickSettleFromRunning(h, loopId);
+
+		const ended = loopEntry(h, loopId);
+		expect(ended.phase).toBe("ended");
+		expect(ended.endReason).toBe("tick_budget_exhausted");
+		expect(h.timers.armed.has(loopId)).toBe(false);
+
+		h.advance(5 * MINUTE);
+		expect(h.scheduler.onDue(loopId, h.now(), false).action).toBe("coalesce");
+		expect(loopEntry(h, loopId).tickCount).toBe(2);
+	});
+
+	it("defaults to 2000 ticks and rejects a sub-1 override", () => {
+		expect(DEFAULT_MAX_TICKS).toBe(2000);
+		const h = harness({ env: { SENPI_LOOP_MAX_TICKS: "0" } });
+		expect(h.scheduler.maxTicks).toBe(1);
+		const bad = harness({ env: { SENPI_LOOP_MAX_TICKS: "not-a-number" } });
+		expect(bad.scheduler.maxTicks).toBe(DEFAULT_MAX_TICKS);
+	});
+});
+
+/** Settles the currently running tick of a loop using its last dispatched delivery id. */
+function runTickSettleFromRunning(h: Harness, loopId: string): void {
+	const deliveryId = h.scheduler.currentDeliveryId(loopId);
+	if (deliveryId === undefined) throw new Error("no running delivery");
+	h.scheduler.onTickSettled({ loopId, deliveryId, outcome: "completed" });
+}
+
+describe("terminal reasons", () => {
+	it("never produces a session_closed reason from any transition", () => {
+		const observed = new Set<LoopEndReason>();
+
+		const stopHarness = harness();
+		const stopped = createFixedLoop(stopHarness, { prompt: "stopped" });
+		if (!stopped.ok) throw new Error("create failed");
+		stopHarness.scheduler.stop(stopped.loopId, "user-command");
+		observed.add(requireEndReason(loopEntry(stopHarness, stopped.loopId)));
+
+		const budgetHarness = harness({ env: { SENPI_LOOP_MAX_TICKS: "1" } });
+		const budget = createFixedLoop(budgetHarness, { prompt: "budget" });
+		if (!budget.ok) throw new Error("create failed");
+		budgetHarness.advance(5 * MINUTE);
+		budgetHarness.scheduler.onDue(budget.loopId, budgetHarness.now(), false);
+		runTickSettleFromRunning(budgetHarness, budget.loopId);
+		observed.add(requireEndReason(loopEntry(budgetHarness, budget.loopId)));
+
+		const keepaliveHarness = harness();
+		const keepalive = createDynamicLoop(keepaliveHarness, "keepalive");
+		if (!keepalive.ok) throw new Error("create failed");
+		keepaliveHarness.scheduler.onTurnEndedWithoutSchedule(keepalive.loopId);
+		keepaliveHarness.advance(DEFAULT_KEEPALIVE_SECONDS * 1000);
+		runTick(keepaliveHarness, keepalive.loopId);
+		keepaliveHarness.scheduler.onTurnEndedWithoutSchedule(keepalive.loopId);
+		observed.add(requireEndReason(loopEntry(keepaliveHarness, keepalive.loopId)));
+
+		const expiryHarness = harness();
+		const expiring = createFixedLoop(expiryHarness, { prompt: "expiring" });
+		if (!expiring.ok) throw new Error("create failed");
+		expiryHarness.setNow(expiryHarness.now() + LOOP_EXPIRY_MS);
+		expiryHarness.scheduler.onDue(expiring.loopId, expiryHarness.now(), false);
+		observed.add(requireEndReason(loopEntry(expiryHarness, expiring.loopId)));
+
+		expect([...observed].sort()).toEqual(["expired", "keepalive_exhausted", "stopped", "tick_budget_exhausted"]);
+		for (const reason of observed) {
+			// Exhaustive switch: adding session_closed to LoopEndReason would fail typecheck here.
+			const label: string = ((value: LoopEndReason): string => {
+				switch (value) {
+					case "stopped":
+						return "stopped";
+					case "keepalive_exhausted":
+						return "keepalive_exhausted";
+					case "expired":
+						return "expired";
+					case "tick_budget_exhausted":
+						return "tick_budget_exhausted";
+					case "error":
+						return "error";
+				}
+			})(reason);
+			expect(label).not.toBe("session_closed");
+		}
+	});
+});
+
+function sorted(ids: readonly string[]): string[] {
+	return [...ids].sort();
+}
+
+function requireEndReason(entry: CronEntry): LoopEndReason {
+	if (entry.phase !== "ended") throw new Error(`loop ${entry.id} is ${entry.phase}, expected ended`);
+	return entry.endReason;
+}

--- a/packages/coding-agent/test/suite/loop-status.test.ts
+++ b/packages/coding-agent/test/suite/loop-status.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	LOOP_STATUS_KEY,
+	LoopStatusTicker,
+	formatLoopStatus,
+	formatNoopFold,
+	type LoopStatusRender,
+} from "../../src/core/extensions/builtin/loop/status.ts";
+import type {
+	CronEntry,
+	DynamicCronEntry,
+	FixedCronEntry,
+	LoopState,
+	PendingWakeup,
+} from "../../src/core/extensions/builtin/loop/types.ts";
+
+function makeFixed(loopId: string, nextFireAt: number, phase: FixedCronEntry["phase"] = "waiting"): CronEntry {
+	return {
+		id: loopId,
+		kind: "fixed",
+		phase,
+		originalArgs: "5m check",
+		reentryPrompt: "/loop 5m check",
+		payload: { type: "prompt", prompt: "check" },
+		createdAt: 0,
+		lastFiredAt: null,
+		expiresAt: 1_000_000_000_000,
+		lastScheduledForAt: null,
+		coalescedFirePending: false,
+		queuedForAt: null,
+		noopStreak: 0,
+		tickCount: 0,
+		sentinelDelivery: {
+			autonomousPreambleDelivered: false,
+			lastLoopFileDelivered: null,
+			forceFullDelivery: false,
+		},
+		wakeSources: [],
+		requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		effectiveInterval: { value: 5, unit: "m", human: "5 minutes", rounded: false },
+		cronExpression: "*/5 * * * *",
+		nextFireAt,
+		intervalMs: 300_000,
+	} as FixedCronEntry;
+}
+
+function makeDynamic(
+	loopId: string,
+	pendingWakeup: PendingWakeup | null,
+	phase: DynamicCronEntry["phase"] = "waiting",
+): CronEntry {
+	return {
+		id: loopId,
+		kind: "dynamic",
+		phase,
+		originalArgs: "check",
+		reentryPrompt: "/loop check",
+		payload: { type: "prompt", prompt: "check" },
+		createdAt: 0,
+		lastFiredAt: null,
+		expiresAt: 1_000_000_000_000,
+		lastScheduledForAt: null,
+		coalescedFirePending: false,
+		queuedForAt: null,
+		noopStreak: 0,
+		tickCount: 0,
+		sentinelDelivery: {
+			autonomousPreambleDelivered: false,
+			lastLoopFileDelivered: null,
+			forceFullDelivery: false,
+		},
+		wakeSources: [],
+		pendingWakeup,
+		keepaliveCredit: 1,
+	} as DynamicCronEntry;
+}
+
+function makeWakeup(loopId: string, dueAt: number): PendingWakeup {
+	return {
+		id: "wakeup-1",
+		loopId,
+		kind: "dynamic",
+		source: "model",
+		requestedDelaySeconds: 300,
+		delaySeconds: 300,
+		dueAt,
+		reason: "continue",
+		prompt: "/loop check",
+		noop: false,
+		createdAt: 0,
+	};
+}
+
+function stateWith(entries: CronEntry[]): LoopState {
+	const record: Record<string, CronEntry> = {};
+	let activeDynamicId: string | null = null;
+	for (const entry of entries) {
+		record[entry.id] = entry;
+		if (entry.kind === "dynamic" && entry.phase !== "ended") {
+			activeDynamicId = entry.id;
+		}
+	}
+	return { version: 1, sessionId: "test", entries: record, activeDynamicId, updatedAt: 0 };
+}
+
+describe("formatLoopStatus", () => {
+	it("returns undefined when nothing is armed", () => {
+		const state = stateWith([
+			{ ...makeFixed("a", 60_000), phase: "ended", endedAt: 100, endReason: "stopped" },
+		]);
+		expect(formatLoopStatus(state, 0)).toBeUndefined();
+	});
+
+	it("renders an armed fixed loop with a countdown", () => {
+		const state = stateWith([makeFixed("a", 60_000)]);
+		expect(formatLoopStatus(state, 0)).toMatch(/fixed/);
+		expect(formatLoopStatus(state, 0)).toMatch(/next in/);
+		expect(formatLoopStatus(state, 0)).toMatch(/\/loop stop/);
+	});
+
+	it("countdown decreases as the fake clock advances", () => {
+		const state = stateWith([makeFixed("a", 300_000)]);
+		const atStart = formatLoopStatus(state, 0)!;
+		const atHalf = formatLoopStatus(state, 150_000)!;
+		expect(parseInt(atStart.match(/(\d+)m/)?.[1] ?? "0", 10)).toBeGreaterThan(
+			parseInt(atHalf.match(/(\d+)m/)?.[1] ?? "0", 10),
+		);
+	});
+
+	it("renders a dynamic pending wakeup countdown", () => {
+		const state = stateWith([makeDynamic("d", makeWakeup("d", 120_000))]);
+		const text = formatLoopStatus(state, 0);
+		expect(text).toMatch(/dynamic/);
+		expect(text).toMatch(/next in/);
+		expect(text).toMatch(/\/loop stop/);
+	});
+
+	it("renders the paused marker when the armed loop is suspended", () => {
+		const state = stateWith([makeFixed("a", 60_000, "suspended")]);
+		const text = formatLoopStatus(state, 0);
+		expect(text).toMatch(/paused/i);
+		expect(text).toMatch(/\/loop resume/);
+		expect(text).toMatch(/\/loop stop/);
+	});
+});
+
+describe("formatNoopFold", () => {
+	it("renders nothing for a streak of 0", () => {
+		expect(formatNoopFold(0)).toBe("");
+	});
+
+	it("renders a streak of 3", () => {
+		expect(formatNoopFold(3)).toMatch(/3/);
+		expect(formatNoopFold(3)).toMatch(/no actionable change/);
+	});
+});
+
+describe("LoopStatusTicker", () => {
+	it("calls the injected setStatus-shaped render callback on sync and on interval", () => {
+		vi.useFakeTimers();
+		try {
+			const render = vi.fn<LoopStatusRender>();
+			let nowMs = 0;
+			const ticker = new LoopStatusTicker({ render, now: () => nowMs });
+			const state = stateWith([makeFixed("a", 60_000)]);
+
+			ticker.sync(state);
+			expect(render).toHaveBeenCalledWith(LOOP_STATUS_KEY, expect.stringMatching(/\/loop stop/));
+			const callsAfterSync = render.mock.calls.length;
+
+			nowMs += 2_000;
+			vi.advanceTimersByTime(2_000);
+			expect(render.mock.calls.length).toBeGreaterThan(callsAfterSync);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("dispose() stops further renders with zero callback invocations afterwards", () => {
+		vi.useFakeTimers();
+		try {
+			const render = vi.fn<LoopStatusRender>();
+			let nowMs = 0;
+			const ticker = new LoopStatusTicker({ render, now: () => nowMs });
+			const state = stateWith([makeFixed("a", 60_000)]);
+
+			ticker.sync(state);
+			const callsAfterSync = render.mock.calls.length;
+			expect(callsAfterSync).toBeGreaterThan(0);
+
+			nowMs += 2_000;
+			vi.advanceTimersByTime(2_000);
+			const callsAfterAdvance = render.mock.calls.length;
+			expect(callsAfterAdvance).toBeGreaterThan(callsAfterSync);
+
+			ticker.dispose();
+			const callsAfterDispose = render.mock.calls.length;
+
+			nowMs += 5_000;
+			vi.advanceTimersByTime(5_000);
+			expect(render.mock.calls.length).toBe(callsAfterDispose);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/loop-status.test.ts
+++ b/packages/coding-agent/test/suite/loop-status.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-	LOOP_STATUS_KEY,
-	LoopStatusTicker,
 	formatLoopStatus,
 	formatNoopFold,
+	LOOP_STATUS_KEY,
 	type LoopStatusRender,
+	LoopStatusTicker,
 } from "../../src/core/extensions/builtin/loop/status.ts";
 import type {
 	CronEntry,
@@ -105,9 +105,7 @@ function stateWith(entries: CronEntry[]): LoopState {
 
 describe("formatLoopStatus", () => {
 	it("returns undefined when nothing is armed", () => {
-		const state = stateWith([
-			{ ...makeFixed("a", 60_000), phase: "ended", endedAt: 100, endReason: "stopped" },
-		]);
+		const state = stateWith([{ ...makeFixed("a", 60_000), phase: "ended", endedAt: 100, endReason: "stopped" }]);
 		expect(formatLoopStatus(state, 0)).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/suite/loop-store.test.ts
+++ b/packages/coding-agent/test/suite/loop-store.test.ts
@@ -1,0 +1,359 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const writeFault = vi.hoisted(() => ({
+	failOnPathContaining: undefined as string | undefined,
+	partialContents: "",
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		writeFile: async (...args: Parameters<typeof actual.writeFile>) => {
+			const target = String(args[0]);
+			if (writeFault.failOnPathContaining !== undefined && target.includes(writeFault.failOnPathContaining)) {
+				writeFault.failOnPathContaining = undefined;
+				// Simulate a crash mid-write: partial bytes hit the temp file, then the write fails.
+				await actual.writeFile(target, writeFault.partialContents, "utf8");
+				throw new Error("simulated mid-write failure");
+			}
+			return actual.writeFile(...args);
+		},
+	};
+});
+
+import {
+	InvalidLoopStoreError,
+	loadLoopState,
+	loopStateFilePath,
+	mutateLoopState,
+	readLoopState,
+	snapshotLoopState,
+	UnsupportedLoopStoreVersionError,
+} from "../../src/core/extensions/builtin/loop/store.ts";
+import type {
+	DynamicCronEntry,
+	FixedCronEntry,
+	LoopEndReason,
+	LoopFileFingerprint,
+	LoopState,
+	LoopStoreRef,
+	SentinelDeliveryState,
+} from "../../src/core/extensions/builtin/loop/types.ts";
+import { LOOP_END_REASONS, LOOP_STATE_VERSION } from "../../src/core/extensions/builtin/loop/types.ts";
+
+const tempDirs: string[] = [];
+
+async function tempStore(sessionId = "session-test"): Promise<LoopStoreRef> {
+	const dir = await mkdtemp(join(tmpdir(), "senpi-loop-store-"));
+	tempDirs.push(dir);
+	return { baseDir: join(dir, "extensions", "loop"), sessionId };
+}
+
+const fingerprint: LoopFileFingerprint = {
+	path: "/repo/.senpi/loop.md",
+	mtimeMs: 1_755_000_000_000,
+	size: 128,
+	contentHash: "a".repeat(64),
+	anchorDeliveryId: "delivery-anchor-1",
+};
+
+const sentinelDelivery: SentinelDeliveryState = {
+	autonomousPreambleDelivered: true,
+	lastLoopFileDelivered: fingerprint,
+	forceFullDelivery: false,
+};
+
+function fixedEntry(overrides: Partial<FixedCronEntry> = {}): FixedCronEntry {
+	return {
+		id: "loop-fixed-1",
+		kind: "fixed",
+		phase: "waiting",
+		originalArgs: "5m /babysit-prs",
+		reentryPrompt: "/loop 5m /babysit-prs",
+		payload: { type: "prompt", prompt: "/babysit-prs" },
+		createdAt: 1_755_000_000_000,
+		lastFiredAt: 1_755_000_300_000,
+		expiresAt: 1_755_604_800_000,
+		lastScheduledForAt: 1_755_000_300_000,
+		coalescedFirePending: true,
+		queuedForAt: 1_755_000_600_000,
+		noopStreak: 0,
+		tickCount: 7,
+		sentinelDelivery,
+		wakeSources: [
+			{ source: "terminal-monitor", id: "monitor-1", description: "watch build", createdAt: 1_755_000_000_000 },
+		],
+		requestedInterval: { value: 90, unit: "m", raw: "90m" },
+		effectiveInterval: {
+			value: 2,
+			unit: "h",
+			human: "every 2 hours",
+			rounded: true,
+			roundingNotice: "requested 90m, rounded to every 2 hours",
+		},
+		cronExpression: "0 */2 * * *",
+		nextFireAt: 1_755_000_600_000,
+		intervalMs: 7_200_000,
+		...overrides,
+	} as FixedCronEntry;
+}
+
+function dynamicEntry(overrides: Partial<DynamicCronEntry> = {}): DynamicCronEntry {
+	return {
+		id: "loop-dynamic-1",
+		kind: "dynamic",
+		phase: "waiting",
+		originalArgs: "",
+		reentryPrompt: "/loop",
+		payload: { type: "sentinel", sentinel: "<<loop.md-dynamic>>" },
+		createdAt: 1_755_000_000_000,
+		lastFiredAt: null,
+		expiresAt: 1_755_604_800_000,
+		lastScheduledForAt: null,
+		coalescedFirePending: false,
+		queuedForAt: null,
+		noopStreak: 3,
+		tickCount: 2,
+		sentinelDelivery: { ...sentinelDelivery, lastLoopFileDelivered: null, forceFullDelivery: true },
+		wakeSources: [],
+		pendingWakeup: {
+			id: "wakeup-1",
+			loopId: "loop-dynamic-1",
+			kind: "dynamic",
+			source: "model",
+			requestedDelaySeconds: 30,
+			delaySeconds: 60,
+			dueAt: 1_755_000_060_000,
+			reason: "poll the deploy",
+			prompt: "check the deploy",
+			noop: true,
+			createdAt: 1_755_000_000_000,
+		},
+		keepaliveCredit: 1,
+		...overrides,
+	} as DynamicCronEntry;
+}
+
+function populatedState(ref: LoopStoreRef): LoopState {
+	const fixed = fixedEntry();
+	const dynamic = dynamicEntry();
+	const ended = fixedEntry({
+		id: "loop-fixed-ended",
+		phase: "ended",
+		endedAt: 1_755_000_900_000,
+		endReason: "tick_budget_exhausted",
+		endDetail: "reached the 2000 tick budget",
+	});
+	return {
+		version: LOOP_STATE_VERSION,
+		sessionId: ref.sessionId,
+		entries: { [fixed.id]: fixed, [dynamic.id]: dynamic, [ended.id]: ended },
+		activeDynamicId: dynamic.id,
+		updatedAt: 1_755_000_900_000,
+	};
+}
+
+async function writeRawLoopFile(ref: LoopStoreRef, contents: string): Promise<void> {
+	const filePath = loopStateFilePath(ref);
+	await rm(filePath, { force: true });
+	await mkdir(dirname(filePath), { recursive: true });
+	await writeFile(filePath, contents, "utf8");
+}
+
+afterEach(async () => {
+	writeFault.failOnPathContaining = undefined;
+	writeFault.partialContents = "";
+	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("loop end reasons", () => {
+	it("has exactly the five supported terminal reasons and no session_closed", () => {
+		// Given / When
+		const reasons: readonly LoopEndReason[] = LOOP_END_REASONS;
+
+		// Then
+		expect([...reasons].sort()).toEqual(
+			["error", "expired", "keepalive_exhausted", "stopped", "tick_budget_exhausted"].sort(),
+		);
+		expect(reasons).not.toContain("session_closed");
+	});
+});
+
+describe("loop store round trip", () => {
+	it("preserves every persisted field across write and load", async () => {
+		// Given
+		const ref = await tempStore("session-round-trip");
+		const state = populatedState(ref);
+
+		// When
+		await mutateLoopState(ref, () => state);
+		const loaded = await loadLoopState(ref);
+
+		// Then
+		expect(loaded).toEqual(state);
+	});
+
+	it("returns an empty versioned state when nothing has been persisted", async () => {
+		// Given
+		const ref = await tempStore("session-empty");
+
+		// When
+		const loaded = await loadLoopState(ref);
+
+		// Then
+		expect(loaded).toEqual({
+			version: LOOP_STATE_VERSION,
+			sessionId: ref.sessionId,
+			entries: {},
+			activeDynamicId: null,
+			updatedAt: 0,
+		});
+		expect(await readLoopState(ref)).toBeNull();
+	});
+
+	it("exposes the last loaded state through a synchronous snapshot", async () => {
+		// Given
+		const ref = await tempStore("session-snapshot");
+		const state = populatedState(ref);
+		expect(snapshotLoopState(ref)).toBeUndefined();
+
+		// When
+		await mutateLoopState(ref, () => state);
+
+		// Then
+		expect(snapshotLoopState(ref)).toEqual(state);
+	});
+});
+
+describe("loop store fail-closed parsing", () => {
+	it("rejects a wrong store version instead of resetting the file", async () => {
+		// Given
+		const ref = await tempStore("session-wrong-version");
+		const raw = `${JSON.stringify({ ...populatedState(ref), version: 2 })}\n`;
+		await writeRawLoopFile(ref, raw);
+
+		// When / Then
+		await expect(loadLoopState(ref)).rejects.toBeInstanceOf(UnsupportedLoopStoreVersionError);
+		expect(await readFile(loopStateFilePath(ref), "utf8")).toBe(raw);
+	});
+
+	it("rejects corrupt JSON instead of resetting the file", async () => {
+		// Given
+		const ref = await tempStore("session-corrupt-json");
+		const raw = '{"version":1,"entries":';
+		await writeRawLoopFile(ref, raw);
+
+		// When / Then
+		await expect(loadLoopState(ref)).rejects.toBeInstanceOf(InvalidLoopStoreError);
+		expect(await readFile(loopStateFilePath(ref), "utf8")).toBe(raw);
+	});
+
+	it("rejects a structurally invalid entry instead of arming a partial state", async () => {
+		// Given
+		const ref = await tempStore("session-invalid-entry");
+		const broken = { ...populatedState(ref) } as unknown as Record<string, unknown>;
+		broken.entries = { "loop-fixed-1": { id: "loop-fixed-1", kind: "fixed" } };
+		await writeRawLoopFile(ref, `${JSON.stringify(broken)}\n`);
+
+		// When / Then
+		await expect(loadLoopState(ref)).rejects.toBeInstanceOf(InvalidLoopStoreError);
+	});
+
+	it("rejects an activeDynamicId that does not name a dynamic entry", async () => {
+		// Given
+		const ref = await tempStore("session-dangling-dynamic");
+		const state = populatedState(ref);
+		await writeRawLoopFile(ref, `${JSON.stringify({ ...state, activeDynamicId: "loop-fixed-1" })}\n`);
+
+		// When / Then
+		await expect(loadLoopState(ref)).rejects.toBeInstanceOf(InvalidLoopStoreError);
+	});
+
+	it("fails a mutation closed when existing state is corrupt", async () => {
+		// Given
+		const ref = await tempStore("session-corrupt-mutate");
+		await writeRawLoopFile(ref, "{not json at all");
+
+		// When / Then
+		await expect(mutateLoopState(ref, (current) => current)).rejects.toBeInstanceOf(InvalidLoopStoreError);
+	});
+});
+
+describe("loop store mutation serialization", () => {
+	it("lands both concurrent mutations without a lost update", async () => {
+		// Given
+		const ref = await tempStore("session-concurrent");
+		await mutateLoopState(ref, (current) => ({ ...current, entries: {} }));
+
+		// When: both mutations are started before either resolves.
+		const first = mutateLoopState(ref, async (current) => {
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			const entry = fixedEntry({ id: "loop-a" });
+			return { ...current, entries: { ...current.entries, [entry.id]: entry }, updatedAt: 1 };
+		});
+		const second = mutateLoopState(ref, async (current) => {
+			const entry = fixedEntry({ id: "loop-b" });
+			return { ...current, entries: { ...current.entries, [entry.id]: entry }, updatedAt: 2 };
+		});
+		await Promise.all([first, second]);
+
+		// Then
+		const loaded = await loadLoopState(ref);
+		expect(Object.keys(loaded.entries).sort()).toEqual(["loop-a", "loop-b"]);
+	});
+
+	it("keeps later mutations running after an earlier mutation throws", async () => {
+		// Given
+		const ref = await tempStore("session-mutation-error");
+
+		// When
+		const failing = mutateLoopState(ref, () => {
+			throw new Error("mutation exploded");
+		});
+		const succeeding = mutateLoopState(ref, (current) => {
+			const entry = dynamicEntry({ id: "loop-after-error" });
+			return {
+				...current,
+				entries: { [entry.id]: entry },
+				activeDynamicId: entry.id,
+				updatedAt: 5,
+			};
+		});
+
+		// Then
+		await expect(failing).rejects.toThrow("mutation exploded");
+		await succeeding;
+		const loaded = await loadLoopState(ref);
+		expect(Object.keys(loaded.entries)).toEqual(["loop-after-error"]);
+		expect(loaded.activeDynamicId).toBe("loop-after-error");
+	});
+});
+
+describe("loop store atomic writes", () => {
+	it("leaves no partial file observable after a simulated mid-write failure", async () => {
+		// Given: a committed state that must survive the failed write.
+		const ref = await tempStore("session-atomic");
+		const committed = populatedState(ref);
+		await mutateLoopState(ref, () => committed);
+
+		// When: the next write dies partway through writing its temp file.
+		writeFault.failOnPathContaining = ".loop-";
+		writeFault.partialContents = '{"version":1,"sessionId":"session-atomic","entr';
+		const failed = mutateLoopState(ref, (current) => ({
+			...current,
+			entries: {},
+			activeDynamicId: null,
+			updatedAt: 9,
+		}));
+
+		// Then: the failure surfaces, the committed file is untouched, and no temp debris remains.
+		await expect(failed).rejects.toThrow("simulated mid-write failure");
+		expect(await loadLoopState(ref)).toEqual(committed);
+		const leftovers = await readdir(dirname(loopStateFilePath(ref)));
+		expect(leftovers).toEqual([`${encodeURIComponent(ref.sessionId)}.json`]);
+	});
+});

--- a/packages/coding-agent/test/suite/loop-tick-prompt.test.ts
+++ b/packages/coding-agent/test/suite/loop-tick-prompt.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildTickMessage,
+	type LoopFileSnapshot,
+	type TickPromptInput,
+} from "../../src/core/extensions/builtin/loop/tick-prompt.ts";
+import type { SentinelDeliveryState } from "../../src/core/extensions/builtin/loop/types.ts";
+
+const CLAUDE_TOOL_NAMES = ["Monitor", "TaskList", "TaskStop"];
+
+const FIRST_DELIVERY: SentinelDeliveryState = {
+	autonomousPreambleDelivered: false,
+	lastLoopFileDelivered: null,
+	forceFullDelivery: false,
+};
+
+function loopFile(overrides: Partial<LoopFileSnapshot> = {}): LoopFileSnapshot {
+	return {
+		present: true,
+		path: "/repo/.senpi/loop.md",
+		content: "- check the deploy dashboard\n- triage flaky tests",
+		mtimeMs: 1_700_000_000_000,
+		size: 52,
+		contentHash: "hash-a",
+		...overrides,
+	} as LoopFileSnapshot;
+}
+
+function sentinelInput(overrides: Partial<TickPromptInput> = {}): TickPromptInput {
+	return {
+		loopId: "loop-1",
+		deliveryId: "delivery-1",
+		mode: "dynamic",
+		payload: { type: "sentinel", sentinel: "<<loop.md-dynamic>>" },
+		reentryPrompt: "/loop",
+		deliveryState: FIRST_DELIVERY,
+		loopFile: loopFile(),
+		...overrides,
+	} as TickPromptInput;
+}
+
+function expectNoClaudeToolNames(text: string): void {
+	for (const name of CLAUDE_TOOL_NAMES) {
+		expect(text).not.toContain(name);
+	}
+}
+
+describe("buildTickMessage - prompt payloads", () => {
+	it("delivers a fixed prompt tick verbatim and forbids schedule_wakeup", () => {
+		const result = buildTickMessage({
+			loopId: "loop-fixed",
+			deliveryId: "d1",
+			mode: "fixed",
+			payload: { type: "prompt", prompt: "/babysit-prs" },
+			reentryPrompt: "/loop 5m /babysit-prs",
+			deliveryState: FIRST_DELIVERY,
+			loopFile: { present: false },
+		});
+
+		expect(result.delivery).toBe("prompt");
+		expect(result.text).toContain("/babysit-prs");
+		expect(result.text).toContain("recurring schedule");
+		expect(result.text).toContain("do not call `schedule_wakeup`");
+		expect(result.details.mode).toBe("fixed");
+		expect(result.details.sentinel).toBeUndefined();
+		expect(result.deliveryState).toEqual(FIRST_DELIVERY);
+		expectNoClaudeToolNames(result.text);
+	});
+
+	it("delivers a dynamic prompt tick with the schedule_wakeup-last contract", () => {
+		const result = buildTickMessage({
+			loopId: "loop-dyn",
+			deliveryId: "d2",
+			mode: "dynamic",
+			payload: { type: "prompt", prompt: "check the deploy" },
+			reentryPrompt: "/loop check the deploy",
+			deliveryState: FIRST_DELIVERY,
+			loopFile: { present: false },
+		});
+
+		expect(result.delivery).toBe("prompt");
+		expect(result.text).toContain("check the deploy");
+		expect(result.text).toContain("last action of this turn");
+		expect(result.text).toContain("`schedule_wakeup`");
+		expect(result.text).toContain("/loop check the deploy");
+		expect(result.text).toContain("{ stop: true }");
+		expect(result.text).toContain("`monitor`");
+		expect(result.text).toContain("`bash_output`");
+		expect(result.text).toContain("`kill_bash`");
+		expect(result.text).toContain("task-notification");
+		expect(result.details.delivery).toBe("prompt");
+		expectNoClaudeToolNames(result.text);
+	});
+});
+
+describe("buildTickMessage - loop.md sentinels", () => {
+	it("sends the full loop.md block with content on the first delivery", () => {
+		const result = buildTickMessage(sentinelInput());
+
+		expect(result.delivery).toBe("full");
+		expect(result.text).toContain("# /loop tick - loop.md tasks");
+		expect(result.text).toContain("- check the deploy dashboard");
+		expect(result.text).toContain("instructions for this tick and every subsequent tick");
+		expect(result.text).toContain("---");
+		expect(result.deliveryState.lastLoopFileDelivered).toEqual({
+			path: "/repo/.senpi/loop.md",
+			mtimeMs: 1_700_000_000_000,
+			size: 52,
+			contentHash: "hash-a",
+			anchorDeliveryId: "delivery-1",
+		});
+		expect(result.deliveryState.forceFullDelivery).toBe(false);
+		expect(result.details.loopFile?.anchorDeliveryId).toBe("delivery-1");
+		expectNoClaudeToolNames(result.text);
+	});
+
+	it("sends a reminder without the file content on an unchanged second tick", () => {
+		const first = buildTickMessage(sentinelInput());
+		const second = buildTickMessage(sentinelInput({ deliveryId: "delivery-2", deliveryState: first.deliveryState }));
+
+		expect(second.delivery).toBe("reminder");
+		expect(second.text).toContain("# /loop tick - loop.md tasks");
+		expect(second.text).not.toContain("- check the deploy dashboard");
+		expect(second.text).toContain("most recent full loop.md instruction message");
+		// The reminder must keep the original anchor, not re-anchor on itself.
+		expect(second.deliveryState.lastLoopFileDelivered?.anchorDeliveryId).toBe("delivery-1");
+		expectNoClaudeToolNames(second.text);
+	});
+
+	it("returns to full when the fingerprint changes", () => {
+		const first = buildTickMessage(sentinelInput());
+
+		const changedHash = buildTickMessage(
+			sentinelInput({
+				deliveryId: "d-hash",
+				deliveryState: first.deliveryState,
+				loopFile: loopFile({ contentHash: "hash-b", content: "- new task" }),
+			}),
+		);
+		expect(changedHash.delivery).toBe("full");
+		expect(changedHash.text).toContain("- new task");
+
+		const changedMtime = buildTickMessage(
+			sentinelInput({
+				deliveryId: "d-mtime",
+				deliveryState: first.deliveryState,
+				loopFile: loopFile({ mtimeMs: 1_700_000_999_000 }),
+			}),
+		);
+		expect(changedMtime.delivery).toBe("full");
+
+		const changedSize = buildTickMessage(
+			sentinelInput({
+				deliveryId: "d-size",
+				deliveryState: first.deliveryState,
+				loopFile: loopFile({ size: 999 }),
+			}),
+		);
+		expect(changedSize.delivery).toBe("full");
+
+		const changedPath = buildTickMessage(
+			sentinelInput({
+				deliveryId: "d-path",
+				deliveryState: first.deliveryState,
+				loopFile: loopFile({ path: "/home/u/.senpi/loop.md" }),
+			}),
+		);
+		expect(changedPath.delivery).toBe("full");
+		expect(changedPath.deliveryState.lastLoopFileDelivered?.path).toBe("/home/u/.senpi/loop.md");
+	});
+
+	it("forces full when forceFullDelivery is set even though nothing changed", () => {
+		const first = buildTickMessage(sentinelInput());
+		const forced = buildTickMessage(
+			sentinelInput({
+				deliveryId: "d-forced",
+				deliveryState: { ...first.deliveryState, forceFullDelivery: true },
+			}),
+		);
+
+		expect(forced.delivery).toBe("full");
+		expect(forced.text).toContain("- check the deploy dashboard");
+		expect(forced.deliveryState.forceFullDelivery).toBe(false);
+		expect(forced.deliveryState.lastLoopFileDelivered?.anchorDeliveryId).toBe("d-forced");
+	});
+
+	it("keeps the loop alive when the loop file is absent and returns to full on reappearance", () => {
+		const first = buildTickMessage(sentinelInput());
+
+		const absent = buildTickMessage(
+			sentinelInput({
+				deliveryId: "d-absent",
+				deliveryState: first.deliveryState,
+				loopFile: { present: false },
+			}),
+		);
+		expect(absent.delivery).toBe("full");
+		expect(absent.text).toContain("# /loop tick - loop.md absent (dynamic pacing)");
+		expect(absent.text).toContain("currently absent");
+		expect(absent.text).toContain("Keep the loop alive");
+		expect(absent.text).toContain("`schedule_wakeup`");
+		expect(absent.deliveryState.lastLoopFileDelivered).toBeNull();
+		expect(absent.details.sentinel).toBe("<<loop.md-dynamic>>");
+		expectNoClaudeToolNames(absent.text);
+
+		const reappeared = buildTickMessage(sentinelInput({ deliveryId: "d-back", deliveryState: absent.deliveryState }));
+		expect(reappeared.delivery).toBe("full");
+		expect(reappeared.text).toContain("- check the deploy dashboard");
+		expect(reappeared.deliveryState.lastLoopFileDelivered?.anchorDeliveryId).toBe("d-back");
+	});
+
+	it("uses the fixed loop.md wording without dynamic pacing", () => {
+		const result = buildTickMessage(
+			sentinelInput({ mode: "fixed", payload: { type: "sentinel", sentinel: "<<loop.md>>" } }),
+		);
+
+		expect(result.delivery).toBe("full");
+		expect(result.text).toContain("recurring schedule");
+		expect(result.text).toContain("do not call `schedule_wakeup`");
+		expect(result.text).not.toContain("dynamic pacing");
+		expectNoClaudeToolNames(result.text);
+
+		const absent = buildTickMessage(
+			sentinelInput({
+				mode: "fixed",
+				payload: { type: "sentinel", sentinel: "<<loop.md>>" },
+				deliveryId: "d-fixed-absent",
+				deliveryState: result.deliveryState,
+				loopFile: { present: false },
+			}),
+		);
+		expect(absent.text).toContain("# /loop tick - loop.md absent");
+		expect(absent.text).not.toContain("dynamic pacing");
+		expect(absent.text).toContain("do not call `schedule_wakeup`");
+	});
+});
+
+describe("buildTickMessage - autonomous sentinels", () => {
+	it("delivers the full dynamic autonomous preamble first, then a reminder", () => {
+		const input = sentinelInput({
+			payload: { type: "sentinel", sentinel: "<<autonomous-loop-dynamic>>" },
+			loopFile: { present: false },
+		});
+
+		const full = buildTickMessage(input);
+		expect(full.delivery).toBe("full");
+		expect(full.text).toContain("# Autonomous loop tick (dynamic pacing)");
+		expect(full.text).toContain("last action of this turn");
+		expect(full.text).toContain("{ stop: true }");
+		expect(full.text).toContain("`monitor`");
+		expect(full.text).toContain("`bash_output`");
+		expect(full.text).toContain("`kill_bash`");
+		expect(full.text).toContain("task-notification");
+		expect(full.deliveryState.autonomousPreambleDelivered).toBe(true);
+		expectNoClaudeToolNames(full.text);
+
+		const reminder = buildTickMessage({
+			...input,
+			deliveryId: "d-auto-2",
+			deliveryState: full.deliveryState,
+		});
+		expect(reminder.delivery).toBe("reminder");
+		expect(reminder.text).toContain("# Autonomous loop tick (dynamic pacing)");
+		expect(reminder.text).not.toContain("Avoid repeating unchanged status");
+		expect(reminder.text).toContain("`schedule_wakeup`");
+		expectNoClaudeToolNames(reminder.text);
+	});
+
+	it("delivers the fixed autonomous preamble and forbids schedule_wakeup", () => {
+		const input = sentinelInput({
+			mode: "fixed",
+			payload: { type: "sentinel", sentinel: "<<autonomous-loop>>" },
+			loopFile: { present: false },
+		});
+
+		const full = buildTickMessage(input);
+		expect(full.delivery).toBe("full");
+		expect(full.text).toContain("# Autonomous loop tick");
+		expect(full.text).not.toContain("(dynamic pacing)");
+		expect(full.text).toContain("recurring schedule");
+		expect(full.text).toContain("do not call `schedule_wakeup`");
+		expectNoClaudeToolNames(full.text);
+
+		const reminder = buildTickMessage({
+			...input,
+			deliveryId: "d-auto-fixed-2",
+			deliveryState: full.deliveryState,
+		});
+		expect(reminder.delivery).toBe("reminder");
+		expect(reminder.text).toContain("do not call `schedule_wakeup`");
+		expectNoClaudeToolNames(reminder.text);
+	});
+
+	it("forces a full autonomous preamble again after compaction", () => {
+		const input = sentinelInput({
+			payload: { type: "sentinel", sentinel: "<<autonomous-loop-dynamic>>" },
+			loopFile: { present: false },
+		});
+		const full = buildTickMessage(input);
+		const forced = buildTickMessage({
+			...input,
+			deliveryId: "d-auto-forced",
+			deliveryState: { ...full.deliveryState, forceFullDelivery: true },
+		});
+
+		expect(forced.delivery).toBe("full");
+		expect(forced.text).toContain("Avoid repeating unchanged status");
+		expect(forced.deliveryState.forceFullDelivery).toBe(false);
+	});
+});
+
+describe("buildTickMessage - invariants across every tick shape", () => {
+	const shapes: TickPromptInput[] = [
+		sentinelInput(),
+		sentinelInput({ mode: "fixed", payload: { type: "sentinel", sentinel: "<<loop.md>>" } }),
+		sentinelInput({
+			payload: { type: "sentinel", sentinel: "<<autonomous-loop-dynamic>>" },
+			loopFile: { present: false },
+		}),
+		sentinelInput({
+			mode: "fixed",
+			payload: { type: "sentinel", sentinel: "<<autonomous-loop>>" },
+			loopFile: { present: false },
+		}),
+		sentinelInput({ loopFile: { present: false } }),
+		sentinelInput({
+			mode: "fixed",
+			payload: { type: "prompt", prompt: "/babysit-prs" },
+			reentryPrompt: "/loop 5m /babysit-prs",
+		}),
+		sentinelInput({ payload: { type: "prompt", prompt: "check the deploy" } }),
+	];
+
+	it("never emits Claude Code tool names and always reports its own delivery details", () => {
+		for (const shape of shapes) {
+			const first = buildTickMessage(shape);
+			const second = buildTickMessage({ ...shape, deliveryState: first.deliveryState });
+			for (const result of [first, second]) {
+				expectNoClaudeToolNames(result.text);
+				expect(result.text.length).toBeGreaterThan(0);
+				expect(result.details.loopId).toBe(shape.loopId);
+				expect(result.details.deliveryId).toBe(shape.deliveryId);
+				expect(result.details.mode).toBe(shape.mode);
+				expect(result.details.delivery).toBe(result.delivery);
+			}
+		}
+	});
+
+	it("states the correct rescheduling rule for every mode", () => {
+		for (const shape of shapes) {
+			const result = buildTickMessage(shape);
+			if (shape.mode === "fixed") {
+				expect(result.text).toContain("do not call `schedule_wakeup`");
+				expect(result.text).not.toContain("last action of this turn");
+			} else {
+				expect(result.text).toContain("last action of this turn");
+				expect(result.text).not.toContain("do not call `schedule_wakeup`");
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/loop-wakeup-tool.test.ts
+++ b/packages/coding-agent/test/suite/loop-wakeup-tool.test.ts
@@ -1,0 +1,320 @@
+import type { Static } from "typebox";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	registerLoopTools,
+	SCHEDULE_WAKEUP_TOOL,
+	type ScheduleWakeupDetails,
+	type ScheduleWakeupParams,
+	type ScheduleWakeupScheduledDetails,
+	type ScheduleWakeupSchedulerPort,
+	type ScheduleWakeupStoppedDetails,
+	scheduleWakeupSchema,
+} from "../../src/core/extensions/builtin/loop/tools.ts";
+import type {
+	AgentToolResult,
+	ExtensionAPI,
+	ExtensionContext,
+	ToolDefinition,
+} from "../../src/core/extensions/types.ts";
+
+type WakeupTool = ToolDefinition<typeof scheduleWakeupSchema, ScheduleWakeupDetails, unknown>;
+type SchemaParams = Static<typeof scheduleWakeupSchema>;
+
+const NOW = 1_755_500_000_000;
+const ctx = {} as ExtensionContext;
+
+type ScheduleCall = Parameters<ScheduleWakeupSchedulerPort["scheduleWakeup"]>[0];
+type StopCall = Parameters<ScheduleWakeupSchedulerPort["stopDynamicLoop"]>[0];
+
+class FakeScheduler implements ScheduleWakeupSchedulerPort {
+	target: ReturnType<ScheduleWakeupSchedulerPort["getWakeupTarget"]> = {
+		kind: "dynamic",
+		loopId: "loop-dyn-1",
+	};
+	replacedWakeupId: string | undefined;
+	noopStreak = 0;
+	scheduleCalls: ScheduleCall[] = [];
+	stopCalls: StopCall[] = [];
+	nextWakeupId = "wake-1";
+
+	getWakeupTarget(): ReturnType<ScheduleWakeupSchedulerPort["getWakeupTarget"]> {
+		return this.target;
+	}
+
+	async scheduleWakeup(request: ScheduleCall) {
+		this.scheduleCalls.push(request);
+		this.noopStreak = request.noop ? this.noopStreak + 1 : 0;
+		return {
+			wakeupId: this.nextWakeupId,
+			...(this.replacedWakeupId === undefined ? {} : { replacedWakeupId: this.replacedWakeupId }),
+			dueAt: NOW + request.delaySeconds * 1000,
+			noopStreak: this.noopStreak,
+		};
+	}
+
+	async stopDynamicLoop(request: StopCall) {
+		this.stopCalls.push(request);
+		return { endedAt: NOW };
+	}
+}
+
+function captureTool(scheduler: ScheduleWakeupSchedulerPort): WakeupTool {
+	let captured: WakeupTool | undefined;
+	const pi = {
+		registerTool(tool: WakeupTool) {
+			captured = tool;
+		},
+	} as Pick<ExtensionAPI, "registerTool"> as ExtensionAPI;
+	registerLoopTools(pi, { scheduler });
+	if (!captured) throw new Error("expected schedule_wakeup to be registered");
+	return captured;
+}
+
+async function run(tool: WakeupTool, params: ScheduleWakeupParams): Promise<AgentToolResult<ScheduleWakeupDetails>> {
+	return tool.execute("call-1", params as SchemaParams, undefined, undefined, ctx);
+}
+
+async function runError(tool: WakeupTool, params: ScheduleWakeupParams): Promise<Error> {
+	try {
+		await run(tool, params);
+	} catch (error) {
+		return error as Error;
+	}
+	throw new Error("expected schedule_wakeup to reject");
+}
+
+function scheduled(result: AgentToolResult<ScheduleWakeupDetails>): ScheduleWakeupScheduledDetails {
+	const details = result.details;
+	if (details.action !== "scheduled") throw new Error(`expected scheduled details, got ${details.action}`);
+	return details;
+}
+
+function stopped(result: AgentToolResult<ScheduleWakeupDetails>): ScheduleWakeupStoppedDetails {
+	const details = result.details;
+	if (details.action !== "stopped") throw new Error(`expected stopped details, got ${details.action}`);
+	return details;
+}
+
+describe("schedule_wakeup tool", () => {
+	let scheduler: FakeScheduler;
+	let tool: WakeupTool;
+
+	beforeEach(() => {
+		scheduler = new FakeScheduler();
+		tool = captureTool(scheduler);
+	});
+
+	describe("registration and schema", () => {
+		it("registers the snake_case tool name with sequential execution", () => {
+			expect(tool.name).toBe(SCHEDULE_WAKEUP_TOOL);
+			expect(tool.name).toBe("schedule_wakeup");
+			expect(tool.executionMode).toBe("sequential");
+		});
+
+		it("exposes a flat object schema with no bounds on delaySeconds and no root union", () => {
+			const json = JSON.parse(JSON.stringify(scheduleWakeupSchema)) as Record<string, unknown>;
+			expect(json.type).toBe("object");
+			expect(json.additionalProperties).toBe(false);
+			expect(json.anyOf).toBeUndefined();
+			expect(json.oneOf).toBeUndefined();
+			expect(json.allOf).toBeUndefined();
+
+			const properties = json.properties as Record<string, Record<string, unknown>>;
+			expect(Object.keys(properties).sort()).toEqual(["delaySeconds", "noop", "prompt", "reason", "stop"]);
+			expect(properties.delaySeconds.type).toBe("integer");
+			expect(properties.delaySeconds.minimum).toBeUndefined();
+			expect(properties.delaySeconds.maximum).toBeUndefined();
+			expect(properties.reason.minLength).toBe(1);
+			expect(json.required).toEqual(["reason"]);
+		});
+
+		it("describes senpi tooling and cache-aware delays, never Claude Code tool names", () => {
+			expect(tool.description).toContain("monitor");
+			expect(tool.description).toContain("bash_output");
+			expect(tool.description).toContain("kill_bash");
+			expect(tool.description).toContain("task");
+			expect(tool.description).toContain("1200-1800");
+			expect(tool.description).not.toContain("Monitor(");
+			expect(tool.description).not.toContain("TaskList");
+			expect(tool.description).not.toContain("TaskStop");
+			expect(tool.description).not.toContain("ScheduleWakeup");
+		});
+	});
+
+	describe("delay clamping", () => {
+		it("clamps a 30s request up to the 60s floor and records both values", async () => {
+			const result = await run(tool, { delaySeconds: 30, reason: "poll deploy", prompt: "/loop check the deploy" });
+			const details = scheduled(result);
+			expect(details.requestedDelaySeconds).toBe(30);
+			expect(details.delaySeconds).toBe(60);
+			expect(details.clamped).toBe(true);
+			expect(scheduler.scheduleCalls[0]?.delaySeconds).toBe(60);
+			expect(result.content[0]).toEqual({
+				type: "text",
+				text: "Scheduled loop loop-dyn-1 in 60s; requested 30s was clamped to the supported 60-3600s range.",
+			});
+		});
+
+		it("clamps a 99999s request down to the 3600s ceiling", async () => {
+			const result = await run(tool, { delaySeconds: 99999, reason: "long hold", prompt: "/loop check the deploy" });
+			const details = scheduled(result);
+			expect(details.requestedDelaySeconds).toBe(99999);
+			expect(details.delaySeconds).toBe(3600);
+			expect(details.clamped).toBe(true);
+		});
+
+		it("keeps an in-range delay unclamped and reports the plain summary", async () => {
+			const result = await run(tool, { delaySeconds: 1200, reason: "idle hold", prompt: "/loop check the deploy" });
+			const details = scheduled(result);
+			expect(details.delaySeconds).toBe(1200);
+			expect(details.requestedDelaySeconds).toBe(1200);
+			expect(details.clamped).toBe(false);
+			expect(details.dueAt).toBe(NOW + 1_200_000);
+			expect(result.content[0]).toEqual({ type: "text", text: "Scheduled loop loop-dyn-1 in 1200s." });
+		});
+
+		it("rejects a fractional delay as a validation error instead of clamping it", async () => {
+			const error = await runError(tool, { delaySeconds: 1.5, reason: "poll", prompt: "/loop check the deploy" });
+			expect(error.message).toContain("delaySeconds");
+			expect(error.message).toContain("integer");
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+		});
+
+		it("rejects a non-finite delay as a validation error", async () => {
+			const error = await runError(tool, {
+				delaySeconds: Number.POSITIVE_INFINITY,
+				reason: "poll",
+				prompt: "/loop check the deploy",
+			});
+			expect(error.message).toContain("delaySeconds");
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+		});
+	});
+
+	describe("schedule branch validation", () => {
+		it("errors naming prompt when a non-stop call omits it", async () => {
+			const error = await runError(tool, { delaySeconds: 900, reason: "poll" });
+			expect(error.message).toBe("prompt is required and must be non-empty unless stop is true.");
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+		});
+
+		it("errors naming prompt when a non-stop call sends only whitespace", async () => {
+			const error = await runError(tool, { delaySeconds: 900, reason: "poll", prompt: "   " });
+			expect(error.message).toContain("prompt");
+		});
+
+		it("errors naming delaySeconds when a non-stop call omits it", async () => {
+			const error = await runError(tool, { reason: "poll", prompt: "/loop check the deploy" });
+			expect(error.message).toBe("delaySeconds is required unless stop is true.");
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+		});
+
+		it("errors naming reason when it is blank", async () => {
+			const error = await runError(tool, { delaySeconds: 900, reason: "  ", prompt: "/loop check the deploy" });
+			expect(error.message).toContain("reason");
+		});
+
+		it("preserves the prompt verbatim, trims the reason, and reports replacement plus noop streak", async () => {
+			scheduler.replacedWakeupId = "wake-0";
+			const result = await run(tool, {
+				delaySeconds: 900,
+				reason: "  nothing changed  ",
+				prompt: "  /loop check the deploy  ",
+				noop: true,
+			});
+			const details = scheduled(result);
+			expect(details.prompt).toBe("  /loop check the deploy  ");
+			expect(details.reason).toBe("nothing changed");
+			expect(details.noop).toBe(true);
+			expect(details.noopStreak).toBe(1);
+			expect(details.replacedWakeupId).toBe("wake-0");
+			expect(details.wakeupId).toBe("wake-1");
+			expect(details.loopId).toBe("loop-dyn-1");
+			expect(details.ok).toBe(true);
+		});
+
+		it("reports noop false and a reset streak for an actionable iteration", async () => {
+			await run(tool, { delaySeconds: 900, reason: "quiet", prompt: "/loop x", noop: true });
+			const result = await run(tool, { delaySeconds: 900, reason: "found work", prompt: "/loop x" });
+			const details = scheduled(result);
+			expect(details.noop).toBe(false);
+			expect(details.noopStreak).toBe(0);
+		});
+	});
+
+	describe("stop branch", () => {
+		it("stops the active dynamic loop with terminalReason stopped", async () => {
+			const result = await run(tool, { stop: true, reason: "deploy finished" });
+			const details = stopped(result);
+			expect(details.ok).toBe(true);
+			expect(details.terminalReason).toBe("stopped");
+			expect(details.loopId).toBe("loop-dyn-1");
+			expect(details.reason).toBe("deploy finished");
+			expect(details.endedAt).toBe(NOW);
+			expect(details.ignoredFields).toEqual([]);
+			expect(result.content[0]).toEqual({ type: "text", text: "Stopped dynamic loop loop-dyn-1." });
+			expect(scheduler.stopCalls).toHaveLength(1);
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+		});
+
+		it("rejects noop on a stop call, naming noop", async () => {
+			const error = await runError(tool, { stop: true, reason: "done", noop: true });
+			expect(error.message).toBe("noop must be omitted when stop is true.");
+			expect(scheduler.stopCalls).toHaveLength(0);
+		});
+
+		it("rejects a stop call with a blank reason", async () => {
+			const error = await runError(tool, { stop: true, reason: "   " });
+			expect(error.message).toContain("reason");
+			expect(scheduler.stopCalls).toHaveLength(0);
+		});
+
+		it("ignores delaySeconds and prompt on a stop call and lists both in ignoredFields", async () => {
+			const result = await run(tool, {
+				stop: true,
+				reason: "done",
+				prompt: "/loop check the deploy",
+				delaySeconds: 900,
+			});
+			const details = stopped(result);
+			expect(details.ignoredFields).toEqual(["delaySeconds", "prompt"]);
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+			expect(scheduler.stopCalls).toHaveLength(1);
+		});
+
+		it("schedules normally when stop is explicitly false", async () => {
+			const result = await run(tool, {
+				stop: false,
+				delaySeconds: 900,
+				reason: "keep going",
+				prompt: "/loop check the deploy",
+			});
+			expect(scheduled(result).delaySeconds).toBe(900);
+		});
+	});
+
+	describe("context rejection", () => {
+		it("rejects when no dynamic loop is active", async () => {
+			scheduler.target = null;
+			const error = await runError(tool, { delaySeconds: 900, reason: "poll", prompt: "/loop x" });
+			expect(error.message).toBe("schedule_wakeup can only be used while a dynamic /loop is active.");
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+		});
+
+		it("rejects a stop call when no dynamic loop is active", async () => {
+			scheduler.target = null;
+			const error = await runError(tool, { stop: true, reason: "done" });
+			expect(error.message).toBe("schedule_wakeup can only be used while a dynamic /loop is active.");
+			expect(scheduler.stopCalls).toHaveLength(0);
+		});
+
+		it("rejects a call made from a fixed tick", async () => {
+			scheduler.target = { kind: "fixed", loopId: "loop-fixed-1" };
+			const error = await runError(tool, { delaySeconds: 900, reason: "poll", prompt: "/loop x" });
+			expect(error.message).toBe(
+				"This is a fixed /loop tick; the recurring schedule re-arms automatically. Do not call schedule_wakeup.",
+			);
+			expect(scheduler.scheduleCalls).toHaveLength(0);
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
@@ -135,6 +135,7 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 			"create_goal",
 			"update_goal",
 			"get_goal",
+			"schedule_wakeup",
 		]);
 		expect(session.systemPrompt).toContain("- todo:");
 		expect(session.systemPrompt).not.toContain("- read:");


### PR DESCRIPTION
## What

Ports Claude Code's `/loop` into senpi as a **fork-only builtin extension** (`packages/coding-agent/src/core/extensions/builtin/loop/`): recurring and self-paced scheduled prompts, driven entirely by native code rather than a model-facing parsing prompt.

- **Fixed-interval mode** - `/loop 5m check the deploy`, `/loop check the deploy every 20m`. Interval grammar is parsed natively; uneven intervals round to a clean cadence and the confirmation names both the requested and effective value.
- **Dynamic self-paced mode** - `/loop check the deploy` (no interval). The model picks each next delay via a new `schedule_wakeup` tool, clamped to [60, 3600] **in the executor** rather than as a schema bound, so the clamp is live code.
- **Loop file** - bare `/loop` runs `<cwd>/<CONFIG_DIR>/loop.md`, falling back to the agent dir, truncated at 25000 bytes on a UTF-8-safe boundary.
- **Sentinel tick prompts** - full instructions on first delivery, on loop-file fingerprint change, on reappearance, and after compaction; a short anchored reminder otherwise, so long instructions stay in the cached prefix.
- **Safety limits Claude Code does not have** - at most 5 active loops per session, and a 2000-tick budget so a forgotten fast loop cannot spend without bound.
- **Lifecycle** - 7-day expiry; shutdown *suspends* rather than terminates (every senpi shutdown reason is resumable); session resume re-arms and emits exactly one catch-up tick; fires missed while asleep coalesce into a single tick instead of a storm.
- **Surfaces** - `/loop stop|status|pause|resume` (never guessing a target when several loops are armed), a live footer countdown, Esc-during-tick *pauses* rather than kills, and print/headless mode refuses with a visible message while arming nothing.

Only **one upstream-owned file** changes - a two-line registration in `builtin/index.ts` - which keeps the fork mergeable. Everything else is new fork-only code.

## Two defects real-CLI QA caught that the test suite could not

Both sat behind a fully green suite, and they share one lesson: **a test that injects a seam the runtime replaces proves nothing about the runtime.**

1. **Recurring loops never recurred.** The scheduler's fire handler called `onDue(...)` and discarded the returned dispatch decision; only the three creation paths ran `fireDue` (persist + dispatch). Timer fires advanced in-memory state, left the entry in flight so every later occurrence coalesced, and stalled the sidecar and footer. A real-CLI trace showed **3 arms and 0 fires reaching the model**, deterministically. The suite missed it because all nine due-tick tests called `controller.fireDue()` directly and **none** fired the timer port. Fixed by giving the scheduler an `onFire` owner wired to `fireDue`; the new regression fires through the timer port itself.
2. **The print-mode refusal was silent** - empty stdout and stderr, exit 0. It was delivered through `ctx.ui.notify`, and headless installs a no-op UI context. The suite missed it because it injects a *capturing* UI. Fixed by also writing to stderr; real stdout stays reserved for `-p` result data.

## Verification

- `npm run check` exits 0.
- `cd packages/coding-agent && npm test` - **8,344 passed**, 36 skipped, across 1,010 files.
- Loop suite - **223 passed** across 17 files; `tsc --noEmit` clean.
- Every todo captured RED before GREEN; waves 2 and 3 REDs are assertion-level (expected-vs-received), not module-not-found.
- **Real-CLI QA: all nine scenarios pass** on the fixed build, driven through a real pty with an isolated agent dir: (a) recurring tick - the second tick fired at 57s spacing with sidecar `tickCount=2` and a future `nextFireAt`; (b) status countdown; (c) stop clears the footer; (d) dynamic `schedule_wakeup` plus `{stop:true}`; (e) loop.md drives the first tick; (f) print-mode refusal visible and nothing armed; (g) resume produces exactly one recovery tick, re-armed, no storm; (h) **Esc-pause through the real TUI keypath**, with `/loop resume` re-arming; (i) a 6th loop rejected while five stay armed.
- QA evidence and the plan live under `local-ignore/` and `.omo/`, which are git-ignored by repo design, so they are intentionally absent from this diff - hence the inline summary above.

## Known latent inconsistency, deliberately not fixed

`loopfile.ts` resolves its agent-dir candidate without the env override that `getAgentDir()` passes. The two are identical for real users and diverge only under test isolation. Changing agent-dir resolution semantics is broader than this feature, and the documented primary path is correct, so this is recorded rather than changed.

## Out-of-scope edit, called out deliberately

`test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts` gains **one line** adding `schedule_wakeup` to its expected builtin-tool list. That regression enumerates builtin tools, so registering the extension necessarily grows the list. No assertion was weakened.

Plan: `.omo/plans/senpi-loop-command.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `/loop` to `packages/coding-agent` as a fork-only builtin extension for recurring and self-paced scheduled prompts. Previously there was no scheduling; now fixed-interval loops fire on a clean cadence and dynamic loops choose delays via the `schedule_wakeup` tool, with safety limits and resumable lifecycle.

- Registers the extension in `src/core/extensions/builtin/index.ts`; all other code is new under `src/core/extensions/builtin/loop/**` (pure parser/planner/scheduler, atomic sidecar store, status ticker, tick-prompt builder, command, and tools).
- Fixed mode: native interval grammar (“5m”, “every 20m”) rounds uneven requests to display cron forms and confirms requested vs effective cadence.
- Dynamic mode: model uses `schedule_wakeup` to set the next delay or stop; delay clamps to 60–3600s in executor code (no schema min/max).
- Bare `/loop` reads `<cwd>/<CONFIG_DIR>/loop.md` (fallback to agent dir), truncated at 25 KB on a UTF‑8 boundary; sentinel prompts alternate long instructions and short reminders.
- Lifecycle and safety: max 5 active loops per session, 2000‑tick budget, 7‑day expiry, shutdown suspends (resume re‑arms and emits exactly one catch‑up tick), missed fires coalesce, Esc pauses `/loop` instead of killing it; `/loop stop|status|pause|resume` manage loops; footer shows a live countdown.
- Headless/print mode: refuses with a visible stderr message and arms nothing.
- Defect fixes found in real CLI QA: timer-driven fires now persist and dispatch ticks (scheduler `onFire` wired to `fireDue`), and print-mode refusal is no longer silent.
- Tests: adds a dedicated loop suite; regression 3592 now expects the new builtin tool `schedule_wakeup`.

<sup>Written for commit 1b86440f0d5cec956c62d0640341e3a5810a3956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

