### PR TITLE
Codex app-server protocol compatibility for T3 Code

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Added
 
-- App-server accepts repeatable Codex-style `-c <key>=<value>` configuration overrides, preserving raw values for T3 Code spawns.
+- App-server accepts repeatable Codex-style `-c <key>=<value>` configuration overrides; complete `mcp_servers.<name>.url` and bearer-environment pairs become process-local HTTP MCP servers, and `config/mcpServer/reload` reattaches loaded sessions without persisting `mcp.json`.
 
 - `/loop`: recurring and self-paced scheduled prompts, ported from Claude Code as a fork-only builtin extension.
   Fixed loops re-deliver a prompt or loop-file sentinel on an interval; dynamic loops pick their own next delay via

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- App-server accepts repeatable Codex-style `-c <key>=<value>` configuration overrides, preserving raw values for T3 Code spawns.
+
 - `/loop`: recurring and self-paced scheduled prompts, ported from Claude Code as a fork-only builtin extension.
   Fixed loops re-deliver a prompt or loop-file sentinel on an interval; dynamic loops pick their own next delay via
   the new `schedule_wakeup` tool. Loops coalesce missed fires into one catch-up tick, cap at 5 active per session,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- App-server `model/list` now keeps configured models available when T3 Code calls `account/read` before the lazily initialized model registry.
+
 - Pasting multiple images in one turn now ships every image: the second and later pastes no longer write into an orphaned payload map, markers pasted in front of existing ones renumber to stay `[Image #1]`..`[Image #k]` in reading order (so `look_at("[Image #N]")` resolves to the exact image the user sees), undo after deleting a marker restores its image along with the marker, and submitting pasted images during compaction now reports the drop instead of silently discarding them.
 
 ### Removed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- App-server now supports `thread/rollback`, preserving abandoned session entries while moving the persisted conversation leaf and returning the reduced turn snapshot expected by Codex-compatible clients.
+
 - `/loop`: recurring and self-paced scheduled prompts, ported from Claude Code as a fork-only builtin extension.
   Fixed loops re-deliver a prompt or loop-file sentinel on an interval; dynamic loops pick their own next delay via
   the new `schedule_wakeup` tool. Loops coalesce missed fires into one catch-up tick, cap at 5 active per session,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- App-server thread and turn timestamps now emit integer epoch seconds for Codex V2 schema compatibility.
 - Pasting multiple images in one turn now ships every image: the second and later pastes no longer write into an orphaned payload map, markers pasted in front of existing ones renumber to stay `[Image #1]`..`[Image #k]` in reading order (so `look_at("[Image #N]")` resolves to the exact image the user sees), undo after deleting a marker restores its image along with the marker, and submitting pasted images during compaction now reports the drop instead of silently discarding them.
 
 ### Removed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- app-server: emit `turn/plan/updated` from the todo tool's structured plan state at the `tool_execution_end`
+  projection seam, mapping senpi todo statuses to Codex V2 plan-step statuses (`abandoned` collapses to
+  `completed`) so Codex-compatible clients render the plan panel. Turns without a plan emit nothing.
 - `/loop`: recurring and self-paced scheduled prompts, ported from Claude Code as a fork-only builtin extension.
   Fixed loops re-deliver a prompt or loop-file sentinel on an interval; dynamic loops pick their own next delay via
   the new `schedule_wakeup` tool. Loops coalesce missed fires into one catch-up tick, cap at 5 active per session,

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -365,6 +365,7 @@ export class AuthStorage implements CredentialStore {
 		this.authPath = authPath;
 		this.readState =
 			authPath && sharedAuthFileReadState?.authPath === authPath ? sharedAuthFileReadState.readState : { data: {} };
+		this.data = this.readState.data;
 		if (authPath && !sharedAuthFileReadState) {
 			sharedAuthFileReadState = { authPath, readState: this.readState };
 		}

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,31 @@
 # changes
 
+## 2026-08-19 - Reused auth-file snapshots initialize new storage instances
+
+### What changed
+
+- `packages/coding-agent/src/core/auth-storage.ts`: a new `AuthStorage` instance now initializes its synchronous
+  credential data from the matching shared auth-file read state before the unchanged-revision fast path returns.
+- Coverage: `packages/coding-agent/test/suite/regressions/codex-appserver-model-list-after-account-read.test.ts`
+  compares model IDs from fresh real app-server processes with and without T3's preceding `account/read` request.
+
+### Why
+
+- `account/read` opened `auth.json` before the lazily-created model registry. The second `AuthStorage` reused the
+  first instance's populated read state, but returned on the matching file revision while its own synchronous
+  credential map was still empty. `ModelRegistry.getAvailable()` therefore treated every provider as unconfigured
+  and returned an empty catalog.
+
+### Why an extension could not handle it
+
+- Credential snapshot initialization happens inside the core storage constructor before extension loading, and the
+  app-server model registry consumes that synchronous core state directly.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/auth-storage.ts`: constructor initialization around the shared auth-file read-state
+  and unchanged-revision fast path.
+
 ## 2026-08-18 - Resume active goals stuck after suppressed continuation-flood loads
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/additional-config.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/additional-config.ts
@@ -1,0 +1,26 @@
+import type { RegisteredMcpServerDeclaration } from "../../types.ts";
+import { resolveExtensionMcpServer } from "./config.ts";
+import type { ResolvedMcpConfig } from "./config-schema.ts";
+
+export const APP_SERVER_MCP_CONFIG_SOURCE_PATH = "<inline:app-server-config-overrides>";
+
+/** Merge process-local declarations after persisted and ordinary extension sources. */
+export function mergeAdditionalMcpServers(
+	result: ResolvedMcpConfig,
+	declarations: readonly RegisteredMcpServerDeclaration[],
+): void {
+	for (const declaration of declarations) {
+		const existing = result.servers[declaration.name];
+		if (existing !== undefined) {
+			result.diagnostics.push(
+				`Process-local MCP server '${declaration.name}' replaces ${existing.source} config at ${existing.sourcePath}.`,
+			);
+		}
+		result.servers[declaration.name] = resolveExtensionMcpServer(
+			declaration.name,
+			declaration.config,
+			declaration.extensionPath,
+			declaration.registrationCwd,
+		);
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -1,5 +1,25 @@
 # mcp Extension Changes
 
+## App-server process-local config source and targeted reload (2026-08-19)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/mcp/additional-config.ts` merges the named process-local app-server source after persisted and ordinary extension declarations.
+- `packages/coding-agent/src/core/extensions/builtin/mcp/service.ts` retains session attach inputs for targeted reloads, reconnects each configured server through the existing connection, refreshes session wire status, and reports a missing bearer environment variable as unauthenticated.
+
+### Why
+
+- Codex-compatible app-server clients need ephemeral MCP configuration and reload behavior without writing `mcp.json` or constructing a parallel MCP client.
+
+### Why an extension could not handle it
+
+- The MCP service owns resolved-source precedence, connection reuse, attach serialization, authentication state, and wire snapshots.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/extensions/builtin/mcp/additional-config.ts`, an additive source-merging module.
+- MEDIUM: `packages/coding-agent/src/core/extensions/builtin/mcp/service.ts`, around attach state, reconnect, and wire auth projection.
+
 ## Explicit pgrep match-all pattern for process-tree collection (2026-08-12)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/service.ts
@@ -5,6 +5,7 @@ import {
 	resetToolSearchServiceForTests,
 	type ToolSearchService,
 } from "../tool-search/service.ts";
+import { APP_SERVER_MCP_CONFIG_SOURCE_PATH, mergeAdditionalMcpServers } from "./additional-config.ts";
 import { detectLiteralBearerWarnings, resolveAuthMode, resolveServerAuth } from "./auth/context.ts";
 import { collectToolCatalog } from "./catalog.ts";
 import { getValidCachedServer, readMcpCatalogCache } from "./catalog-cache.ts";
@@ -58,6 +59,12 @@ type ListedTool = Awaited<ReturnType<Client["listTools"]>>["tools"][number];
 type ListedResource = Awaited<ReturnType<Client["listResources"]>>["resources"][number];
 type ListedResourceTemplate = Awaited<ReturnType<Client["listResourceTemplates"]>>["resourceTemplates"][number];
 type McpElicitationUi = Pick<ExtensionUIContext, "input" | "select" | "confirm">;
+type McpServicePi = Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool">;
+type McpSessionAttachment = {
+	readonly context: McpSessionContext;
+	readonly options: McpSessionOptions;
+	readonly pi: McpServicePi | undefined;
+};
 
 export { registerToolsPreservingActiveSet } from "./active-set.ts";
 
@@ -84,8 +91,9 @@ export class McpService {
 	#tierBRegistration: McpSessionRegistration | undefined;
 	#toolSearchService: ToolSearchService | undefined;
 	#sessionOptions: McpSessionOptions = {};
-	#pi: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool"> | undefined;
+	#pi: McpServicePi | undefined;
 	#attachQueue: Promise<void> = Promise.resolve();
+	readonly #attachmentsBySession = new Map<string, McpSessionAttachment>();
 	#latestWireStatus: McpWireStatusSnapshot = { servers: [] };
 	readonly #wireStatusBySession = new Map<string, McpWireStatusSnapshot>();
 	readonly #connections = new Map<string, McpConnectionEntry>();
@@ -95,11 +103,15 @@ export class McpService {
 	async attachSession(
 		event: SessionStartEvent,
 		ctx: McpSessionContext,
-		_pi?: Pick<ExtensionAPI, "getActiveTools" | "setActiveTools" | "registerTool">,
+		_pi?: McpServicePi,
 		options: McpSessionOptions = {},
 	): Promise<void> {
 		const attach = this.#attachQueue.then(async () => {
 			this.#sessionContext = ctx;
+			const sessionId = ctx.sessionManager?.getSessionId?.();
+			if (sessionId !== undefined) {
+				this.#attachmentsBySession.set(sessionId, { context: ctx, options, pi: _pi });
+			}
 			this.#sessionStartCount += 1;
 			this.#lastSessionStartReason = event.reason;
 			const config = loadMcpConfig({
@@ -108,7 +120,15 @@ export class McpService {
 				env: options.env,
 				projectTrusted: options.projectTrusted ?? ctx.isProjectTrusted(),
 			});
-			mergeExtensionMcpServers(config, ctx.getRegisteredMcpServers?.() ?? []);
+			const declarations = ctx.getRegisteredMcpServers?.() ?? [];
+			const appServerDeclarations = declarations.filter(
+				(declaration) => declaration.extensionPath === APP_SERVER_MCP_CONFIG_SOURCE_PATH,
+			);
+			mergeExtensionMcpServers(
+				config,
+				declarations.filter((declaration) => declaration.extensionPath !== APP_SERVER_MCP_CONFIG_SOURCE_PATH),
+			);
+			mergeAdditionalMcpServers(config, appServerDeclarations);
 			this.#config = config;
 			this.#pi = _pi;
 			if (_pi !== undefined) {
@@ -124,7 +144,7 @@ export class McpService {
 				}
 			}
 			this.#authAgentDir = options.agentDir;
-			this.#authEnv = options.env;
+			this.#authEnv = options.env ?? process.env;
 			this.#sessionOptions = options;
 			const toolRefreshGeneration = this.#toolRefreshGeneration + 1;
 			this.#toolRefreshGeneration = toolRefreshGeneration;
@@ -257,6 +277,7 @@ export class McpService {
 		this.#registrationListeners.clear();
 		this.#wireStatusListeners.clear();
 		this.#wireStatusBySession.clear();
+		this.#attachmentsBySession.clear();
 		this.#latestWireStatus = { servers: [] };
 		const entries = [...this.#connections.values()];
 		this.#connections.clear();
@@ -282,6 +303,30 @@ export class McpService {
 		const entry = this.#entryForName(name);
 		if (entry === undefined) throw new Error(`Unknown MCP server: ${name || "<missing>"}`);
 		await reconnectMcpNow(entry.connection);
+	}
+
+	async reloadSession(sessionId: string): Promise<McpWireStatusSnapshot> {
+		const attachment = this.#attachmentsBySession.get(sessionId);
+		if (attachment === undefined) return { servers: [] };
+		await this.attachSession(
+			{ type: "session_start", reason: "reload" },
+			attachment.context,
+			attachment.pi,
+			attachment.options,
+		);
+		await Promise.all(
+			[...this.#connectionKeysByName.values()].map(async (key) => {
+				const entry = this.#connections.get(key);
+				if (entry === undefined) return;
+				try {
+					await reconnectMcpNow(entry.connection);
+				} catch (error: unknown) {
+					if (!(error instanceof Error)) throw error;
+					entry.logger.debug("MCP reload reconnect failed", error);
+				}
+			}),
+		);
+		return await this.refreshWireStatusSnapshot(sessionId);
 	}
 
 	getServerSnapshots(): McpServerSnapshot[] {
@@ -601,7 +646,7 @@ export class McpService {
 			tools: tools.map(mapWireTool),
 			resources: resources.map(mapWireResource),
 			resourceTemplates: resourceTemplates.map(mapWireResourceTemplate),
-			authStatus: wireAuthStatus(entry, server),
+			authStatus: wireAuthStatus(entry, server, this.#authEnv),
 			...(connection?.state === undefined && server?.state === undefined
 				? {}
 				: { status: connection?.state ?? server?.state }),
@@ -680,13 +725,18 @@ export class McpService {
 function wireAuthStatus(
 	entry: McpConnectionEntry | undefined,
 	server: ResolvedMcpServer | undefined,
+	env: Record<string, string | undefined> | undefined,
 ): McpWireAuthStatus {
 	const mode = entry?.authPlan?.mode ?? (server?.config === undefined ? "none" : resolveAuthMode(server.config));
 	switch (mode) {
 		case "none":
 			return "unsupported";
-		case "bearer":
-			return entry?.connection.state === "needs_auth" ? "notLoggedIn" : "bearerToken";
+		case "bearer": {
+			const envName = server?.config?.bearerTokenEnv;
+			return entry?.connection.state === "needs_auth" || (envName !== undefined && env?.[envName] === undefined)
+				? "notLoggedIn"
+				: "bearerToken";
+		}
 		case "oauth":
 			return entry?.authPlan?.provider?.tokens() === undefined ? "notLoggedIn" : "oAuth";
 		default:

--- a/packages/coding-agent/src/modes/app-server/changes.md
+++ b/packages/coding-agent/src/modes/app-server/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## Process-local Codex MCP overrides and reload (2026-08-19)
+
+### What changed
+
+- `packages/coding-agent/src/modes/app-server/index.ts` passes parsed `-c` overrides into the runtime.
+- `packages/coding-agent/src/modes/app-server/runtime.ts` binds the immutable process-local MCP source to every created session and implements `config/mcpServer/reload` through the existing MCP service.
+- `packages/coding-agent/src/modes/app-server/mcp-config-overrides.ts` materializes complete `mcp_servers.<name>.url` and `bearer_token_env_var` pairs without persistence, while redacting malformed-input diagnostics.
+- `packages/coding-agent/src/modes/app-server/threads/mcp-wire-status.ts` includes the process-local source in threadless status queries and reports absent bearer environment variables as unauthenticated.
+
+### Why
+
+- T3 Code supplies its local MCP endpoint and bearer environment variable through Codex-compatible app-server arguments and refreshes that catalog before turns.
+
+### Why an extension could not handle it
+
+- The source originates in app-server CLI options and the reload request must coordinate all loaded app-server thread adapters; ordinary extensions cannot access either host-owned surface.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/modes/app-server/index.ts`, around runtime construction.
+- MEDIUM: `packages/coding-agent/src/modes/app-server/runtime.ts`, around session construction and method registration.
+- LOW: `packages/coding-agent/src/modes/app-server/mcp-config-overrides.ts`, an additive app-server boundary module.
+- LOW: `packages/coding-agent/src/modes/app-server/threads/mcp-wire-status.ts`, around process-scope adapter construction.
+
 ## Integer wire timestamps (2026-08-19)
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/changes.md
+++ b/packages/coding-agent/src/modes/app-server/changes.md
@@ -1,5 +1,32 @@
 # changes
 
+## Persistent append-only thread rollback (2026-08-19)
+
+### What changed
+
+- `packages/coding-agent/src/modes/app-server/protocol/thread.ts` exposes the existing V2 rollback request and response shape through the app-server facade.
+- `packages/coding-agent/src/modes/app-server/threads/handlers.ts` registers the rollback handler and captures compaction cutoffs.
+- `packages/coding-agent/src/modes/app-server/threads/rollback-handler.ts` validates rollback requests, moves the session leaf, persists the selected branch, and returns the updated thread snapshot.
+- `packages/coding-agent/src/modes/app-server/threads/turn-log.ts` retains each turn's pre-turn leaf and truncates only the in-process wire view.
+- `packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts` exposes the narrow session-manager checkpoint surface to the turn engine.
+- `packages/coding-agent/src/modes/app-server/threads/turns.ts` records the session leaf at each turn-start seam.
+- `packages/coding-agent/src/modes/app-server/threads/wire-thread.ts` reconstructs persisted turn cutoffs from user-message parent links.
+
+### Why
+
+- Codex-compatible clients use `thread/rollback` to restore a prior conversational checkpoint without reverting workspace files.
+- The selected history must survive session unload/resume while abandoned session entries remain available in the append-only tree.
+
+### Why an extension could not handle it
+
+- Only app-server owns V2 method registration, wire-turn projection, and the in-process turn log.
+- Only the core turn lifecycle can capture the exact session leaf before a requested turn starts.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/modes/app-server/threads/handlers.ts`, `packages/coding-agent/src/modes/app-server/threads/turns.ts`, and `packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts` around lifecycle registration and turn-start state.
+- LOW: `packages/coding-agent/src/modes/app-server/protocol/thread.ts`, `packages/coding-agent/src/modes/app-server/threads/rollback-handler.ts`, `packages/coding-agent/src/modes/app-server/threads/turn-log.ts`, and `packages/coding-agent/src/modes/app-server/threads/wire-thread.ts` around rollback-specific types and history projection.
+
 ## Registry-owned thread teardown (2026-08-13)
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/changes.md
+++ b/packages/coding-agent/src/modes/app-server/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Integer wire timestamps (2026-08-19)
+
+### What changed
+
+- `packages/coding-agent/src/modes/app-server/threads/wire-thread.ts` and `packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts` now floor parsed or live timestamps to integer epoch seconds for thread and turn wire fields.
+
+### Why
+
+- Codex V2 clients require timestamp values to satisfy their int64 schema.
+
+### Why an extension could not handle it
+
+- Timestamp projection is owned by the app-server wire serializer before extension code can run.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/modes/app-server/threads/wire-thread.ts` and `packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts`, around timestamp projection.
+
 ## Registry-owned thread teardown (2026-08-13)
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/changes.md
+++ b/packages/coding-agent/src/modes/app-server/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Codex-style app-server config overrides (2026-08-19)
+
+### What changed
+
+- `packages/coding-agent/src/modes/app-server/cli-args.ts` now accepts repeatable `-c <key>=<value>` app-server arguments and preserves raw override values in order.
+
+### Why
+
+- T3 Code spawns app-server with Codex-style configuration overrides.
+
+### Why an extension could not handle it
+
+- CLI argument parsing occurs before app-server extensions are loaded.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/modes/app-server/cli-args.ts`, beside server argument parsing.
+
 ## Registry-owned thread teardown (2026-08-13)
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/changes.md
+++ b/packages/coding-agent/src/modes/app-server/changes.md
@@ -1,5 +1,37 @@
 # changes
 
+## turn/plan/updated from todo-tool plan state (2026-08-19)
+
+### What changed
+
+- `threads/projection.ts` `completeTool()` (the existing `tool_execution_end`
+  seam) now also emits `turn/plan/updated` when the completed tool is the todo
+  tool and its structured `details.phases` parses into plan steps.
+- New `threads/projection-plan.ts` maps senpi todo statuses to Codex V2
+  (`pending`/`in_progress`/`completed`/`abandoned` ->
+  `pending`/`inProgress`/`completed`/`completed`) and skips malformed phases,
+  tasks, and unknown statuses instead of inventing steps.
+- `protocol/notifications.ts` gains facade types `TurnPlanStepStatus`,
+  `TurnPlanStep`, `TurnPlanUpdatedNotification` and a typed union member for
+  `turn/plan/updated` (already enumerated in `protocol/methods.ts`).
+
+### Why
+
+- Codex/T3 clients render a plan panel from `turn/plan/updated`; senpi's todo
+  tool already owns structured plan state, but `senpi.todo-state` entries never
+  reach the `EventProjector`, so the notification had to be projected from the
+  completed tool result at the projection seam.
+
+### Why an extension could not handle it
+
+- The projection seam and notification dispatch are private to the app-server
+  thread runtime; extensions only see tool execution, not wire notifications.
+
+### Expected merge conflict zones
+
+- LOW: `threads/projection.ts` `completeTool()` notification list, beside the
+  `turn/diff/updated` emission; `protocol/notifications.ts` union tail.
+
 ## Registry-owned thread teardown (2026-08-13)
 
 ### What changed

--- a/packages/coding-agent/src/modes/app-server/cli-args.ts
+++ b/packages/coding-agent/src/modes/app-server/cli-args.ts
@@ -15,6 +15,8 @@ export interface AppServerModeOptions {
 	readonly listen: AppServerListen;
 	readonly wsAuth?: AppServerWsAuth;
 	readonly jsonLogs: boolean;
+	/** Raw Codex-style key/value text, including any literal double quotes. */
+	readonly configOverrides: ReadonlyArray<{ readonly key: string; readonly value: string }>;
 }
 
 export interface AppServerDaemonCommandOptions {
@@ -36,7 +38,7 @@ export const APP_SERVER_LISTEN_USAGE =
 export function formatAppServerUsage(): string {
 	const listenForms = "stdio://|unix://|unix:///abs/path|ws://IP:PORT";
 	return [
-		`Usage: ${APP_NAME} app-server [--listen <${listenForms}>] [--ws-auth <token-file|off>] [--json-logs]`,
+		`Usage: ${APP_NAME} app-server [--listen <${listenForms}>] [--ws-auth <token-file|off>] [--json-logs] [-c <key>=<value>]`,
 		`       ${APP_NAME} app-server daemon <start|stop|status|restart> [--listen <${listenForms}>]`,
 	].join("\n");
 }
@@ -112,6 +114,7 @@ function parseServerArgs(args: readonly string[]): AppServerModeOptions | AppSer
 	let listen: AppServerListen = { kind: "stdio", url: "stdio://" };
 	let wsAuth: AppServerWsAuth | undefined;
 	let jsonLogs = false;
+	const configOverrides: Array<{ readonly key: string; readonly value: string }> = [];
 
 	for (let index = 0; index < args.length; index++) {
 		const arg = args[index];
@@ -141,10 +144,23 @@ function parseServerArgs(args: readonly string[]): AppServerModeOptions | AppSer
 			jsonLogs = true;
 			continue;
 		}
+		if (arg === "-c") {
+			const override = args[index + 1];
+			if (override === undefined) {
+				return { kind: "usage-error", message: "-c requires <key>=<value>." };
+			}
+			const separator = override.indexOf("=");
+			if (separator < 0) {
+				return { kind: "usage-error", message: "-c requires <key>=<value>." };
+			}
+			configOverrides.push({ key: override.slice(0, separator), value: override.slice(separator + 1) });
+			index++;
+			continue;
+		}
 		return { kind: "usage-error", message: `Unexpected app-server argument: ${arg}` };
 	}
 
-	return { kind: "server", listen, wsAuth, jsonLogs };
+	return { kind: "server", listen, wsAuth, jsonLogs, configOverrides };
 }
 
 function parseDaemonArgs(args: readonly string[]): AppServerDaemonCommandOptions | AppServerUsageError {

--- a/packages/coding-agent/src/modes/app-server/index.ts
+++ b/packages/coding-agent/src/modes/app-server/index.ts
@@ -61,7 +61,7 @@ export async function runAppServerMode(options: AppServerModeOptions): Promise<v
 	process.on("SIGINT", handleSignal);
 	process.on("SIGTERM", handleSignal);
 
-	const runtime = createAppServerRuntime(requestShutdown);
+	const runtime = createAppServerRuntime(requestShutdown, { configOverrides: options.configOverrides });
 	let stdio: StdioTransport | undefined;
 	let unix: UnixSocketListenerHandle | undefined;
 	let websocket: WebSocketListenerHandle | undefined;

--- a/packages/coding-agent/src/modes/app-server/mcp-config-overrides.ts
+++ b/packages/coding-agent/src/modes/app-server/mcp-config-overrides.ts
@@ -1,0 +1,103 @@
+import { APP_SERVER_MCP_CONFIG_SOURCE_PATH } from "../../core/extensions/builtin/mcp/additional-config.ts";
+import type { McpServerDeclaration } from "../../core/extensions/builtin/mcp/config-schema.ts";
+import { createMcpLogger } from "../../core/extensions/builtin/mcp/log.ts";
+import type { InlineExtension } from "../../core/extensions/types.ts";
+
+export const APP_SERVER_MCP_CONFIG_SOURCE_NAME = APP_SERVER_MCP_CONFIG_SOURCE_PATH.slice("<inline:".length, -1);
+
+export type AppServerConfigOverride = { readonly key: string; readonly value: string };
+
+export type AppServerMcpConfigSource = {
+	readonly servers: Readonly<Record<string, McpServerDeclaration>>;
+	readonly diagnostics: readonly string[];
+	readonly extensionFactories: readonly InlineExtension[];
+};
+
+type PendingServer = {
+	url?: string;
+	bearerTokenEnv?: string;
+};
+
+const MCP_OVERRIDE_PATTERN = /^mcp_servers\.([A-Za-z0-9._-]+)\.(url|bearer_token_env_var)$/u;
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+export function materializeAppServerMcpConfigSource(
+	overrides: readonly AppServerConfigOverride[],
+): AppServerMcpConfigSource {
+	const pending = new Map<string, PendingServer>();
+	let malformed = false;
+	let unsupported = false;
+	for (const override of overrides) {
+		const match = MCP_OVERRIDE_PATTERN.exec(override.key);
+		if (match === null) {
+			if (override.key.startsWith("mcp_servers.")) malformed = true;
+			else unsupported = true;
+			continue;
+		}
+		const name = match[1];
+		const field = match[2];
+		if (name === undefined || field === undefined) {
+			malformed = true;
+			continue;
+		}
+		const server = pending.get(name) ?? {};
+		if (field === "url") server.url = override.value;
+		else server.bearerTokenEnv = stripSurroundingDoubleQuotes(override.value);
+		pending.set(name, server);
+	}
+
+	const servers: Record<string, McpServerDeclaration> = {};
+	let incomplete = false;
+	for (const [name, server] of pending) {
+		if (server.url === undefined || server.bearerTokenEnv === undefined) {
+			incomplete = true;
+			continue;
+		}
+		if (!isHttpUrl(server.url) || !ENV_NAME_PATTERN.test(server.bearerTokenEnv)) {
+			malformed = true;
+			continue;
+		}
+		servers[name] = Object.freeze({
+			type: "http",
+			url: server.url,
+			auth: "bearer",
+			bearerTokenEnv: server.bearerTokenEnv,
+		});
+	}
+	Object.freeze(servers);
+
+	const diagnostics = Object.freeze([
+		...(incomplete ? ["ignored incomplete app-server MCP config override"] : []),
+		...(malformed ? ["ignored malformed app-server MCP config override"] : []),
+		...(unsupported ? ["ignored unsupported app-server config override"] : []),
+	]);
+	const extensionFactories: readonly InlineExtension[] =
+		Object.keys(servers).length === 0 && diagnostics.length === 0
+			? []
+			: [
+					{
+						name: APP_SERVER_MCP_CONFIG_SOURCE_NAME,
+						hidden: true,
+						factory: (pi) => {
+							const logger = createMcpLogger(APP_SERVER_MCP_CONFIG_SOURCE_NAME);
+							for (const diagnostic of diagnostics) logger.debug(diagnostic, { value: "<redacted>" });
+							for (const [name, config] of Object.entries(servers)) pi.registerMcpServer(name, config);
+						},
+					},
+				];
+	return Object.freeze({ servers, diagnostics, extensionFactories: Object.freeze(extensionFactories) });
+}
+
+function stripSurroundingDoubleQuotes(value: string): string {
+	return value.length >= 2 && value.startsWith('"') && value.endsWith('"') ? value.slice(1, -1) : value;
+}
+
+function isHttpUrl(value: string): boolean {
+	try {
+		const url = new URL(value);
+		return (url.protocol === "http:" || url.protocol === "https:") && url.username === "" && url.password === "";
+	} catch (error: unknown) {
+		if (error instanceof TypeError) return false;
+		throw error;
+	}
+}

--- a/packages/coding-agent/src/modes/app-server/protocol/notifications.ts
+++ b/packages/coding-agent/src/modes/app-server/protocol/notifications.ts
@@ -27,6 +27,17 @@ export type TurnDiffUpdatedNotification = {
 	readonly diff: string;
 };
 
+// Shape mirrors generated/v2/TurnPlanUpdatedNotification; defined here so runtime
+// code imports the facade instead of the generated evidence tree.
+export type TurnPlanStepStatus = "pending" | "inProgress" | "completed";
+export type TurnPlanStep = { readonly step: string; readonly status: TurnPlanStepStatus };
+export type TurnPlanUpdatedNotification = {
+	readonly threadId: string;
+	readonly turnId: string;
+	readonly explanation: string | null;
+	readonly plan: readonly TurnPlanStep[];
+};
+
 export type AppServerPlanNotification =
 	| { readonly method: "account/providerAccounts/updated"; readonly params: ProviderAccountsUpdatedNotification }
 	| { readonly method: "account/providerAccounts/failover"; readonly params: ProviderAccountFailoverNotification }
@@ -35,6 +46,7 @@ export type AppServerPlanNotification =
 	| { readonly method: "thread/goal/cleared"; readonly params: ThreadGoalClearedNotification }
 	| { readonly method: "thread/settings/updated"; readonly params: ThreadSettingsUpdatedNotification }
 	| { readonly method: "turn/diff/updated"; readonly params: TurnDiffUpdatedNotification }
+	| { readonly method: "turn/plan/updated"; readonly params: TurnPlanUpdatedNotification }
 	| {
 			readonly method: "fuzzyFileSearch/sessionUpdated";
 			readonly params: FuzzyFileSearchSessionUpdatedNotification;

--- a/packages/coding-agent/src/modes/app-server/protocol/thread.ts
+++ b/packages/coding-agent/src/modes/app-server/protocol/thread.ts
@@ -124,6 +124,8 @@ export type ThreadForkResponse = ThreadRuntimeResponse;
 
 export type ThreadReadParams = { readonly threadId: ThreadId; readonly includeTurns?: boolean };
 export type ThreadReadResponse = { readonly thread: Thread };
+export type ThreadRollbackParams = { readonly threadId: ThreadId; readonly numTurns: number };
+export type ThreadRollbackResponse = { readonly thread: Thread };
 export type ThreadListParams = {
 	readonly cursor?: string | null;
 	readonly limit?: number | null;

--- a/packages/coding-agent/src/modes/app-server/runtime.ts
+++ b/packages/coding-agent/src/modes/app-server/runtime.ts
@@ -2,6 +2,12 @@ import { ENV_SESSION_DIR, getAgentDir } from "../../config.ts";
 import { getMcpService } from "../../core/extensions/builtin/mcp/service.ts";
 import { DefaultResourceLoader } from "../../core/resource-loader.ts";
 import { type CreateAgentSessionOptions, createAgentSession } from "../../core/sdk.ts";
+import { SettingsManager } from "../../core/settings-manager.ts";
+import {
+	type AppServerConfigOverride,
+	type AppServerMcpConfigSource,
+	materializeAppServerMcpConfigSource,
+} from "./mcp-config-overrides.ts";
 import type { RpcNotification } from "./rpc/envelope.ts";
 import { createRegistry, type MethodRegistry, registerExtensionRequestMethod } from "./rpc/registry.ts";
 import { registerFuzzyFileSearchMethods } from "./search/fuzzy-search-methods.ts";
@@ -33,8 +39,12 @@ export type AppServerRuntime = {
 	readonly dispose: () => void;
 };
 
-export function createAppServerRuntime(requestShutdown: (reason: string) => void): AppServerRuntime {
+export function createAppServerRuntime(
+	requestShutdown: (reason: string) => void,
+	options: { readonly configOverrides?: readonly AppServerConfigOverride[] } = {},
+): AppServerRuntime {
 	const notifications = new NotificationRouter();
+	const mcpConfigSource = materializeAppServerMcpConfigSource(options.configOverrides ?? []);
 	const registry = createRegistry();
 	const fuzzySearch = new FuzzyFileSearchService({
 		broadcast: (notification) => notifications.broadcast(notification),
@@ -42,6 +52,7 @@ export function createAppServerRuntime(requestShutdown: (reason: string) => void
 	registerFuzzyFileSearchMethods(registry, fuzzySearch);
 	let threads: ThreadRegistry;
 	const processMcpWireStatusAdapter = createProcessMcpWireStatusAdapter({
+		additionalServers: mcpConfigSource.servers,
 		agentDir: getAgentDir(),
 		cwd: process.cwd(),
 		env: process.env,
@@ -63,9 +74,16 @@ export function createAppServerRuntime(requestShutdown: (reason: string) => void
 	threads = new ThreadRegistry({
 		agentDir: getAgentDir(),
 		sessionDir: process.env[ENV_SESSION_DIR],
-		createSession: (options) => createBoundAppServerSession(options, approvals, notifications, requestShutdown),
+		createSession: (sessionOptions) =>
+			createBoundAppServerSession(sessionOptions, {
+				approvals,
+				mcpConfigSource,
+				notifications,
+				requestShutdown,
+			}),
 		mcpWireStatusAdapter: processMcpWireStatusAdapter,
 	});
+	registerMcpReloadMethod(registry, threads);
 	registerExtensionRequestMethod(registry, (threadId) => threads.getLoadedThread(threadId).session);
 	const core = createRoutedServerCore(
 		registry,
@@ -124,13 +142,28 @@ export function createAppServerRuntime(requestShutdown: (reason: string) => void
 	};
 }
 
+type AppServerSessionBindings = {
+	readonly approvals: ApprovalBridge;
+	readonly mcpConfigSource: AppServerMcpConfigSource;
+	readonly notifications: NotificationRouter;
+	readonly requestShutdown: (reason: string) => void;
+};
+
 async function createBoundAppServerSession(
 	options: CreateAgentSessionOptions,
-	approvals: ApprovalBridge,
-	notifications: NotificationRouter,
-	requestShutdown: (reason: string) => void,
+	bindings: AppServerSessionBindings,
 ): Promise<AppServerSessionResult> {
-	const result = await createAgentSession(options);
+	const cwd = options.cwd ?? process.cwd();
+	const agentDir = options.agentDir ?? getAgentDir();
+	const settingsManager = SettingsManager.create(cwd, agentDir);
+	const resourceLoader = new DefaultResourceLoader({
+		cwd,
+		agentDir,
+		extensionFactories: [...bindings.mcpConfigSource.extensionFactories],
+		settingsManager,
+	});
+	await resourceLoader.reload();
+	const result = await createAgentSession({ ...options, resourceLoader, settingsManager });
 	const threadId = result.session.sessionId;
 	const initialNotifications: RpcNotification[] = [];
 	let bindingExtensions = true;
@@ -143,14 +176,14 @@ async function createBoundAppServerSession(
 			initialNotifications.push(notification);
 			return;
 		}
-		notifications.toThread(threadId, notification);
+		bindings.notifications.toThread(threadId, notification);
 	});
 	await result.session.bindExtensions({
-		uiContext: createAppServerUIContext(approvals, threadId),
+		uiContext: createAppServerUIContext(bindings.approvals, threadId),
 		mode: "app-server",
-		shutdownHandler: () => requestShutdown("extension shutdown"),
+		shutdownHandler: () => bindings.requestShutdown("extension shutdown"),
 		onError: (error) => {
-			notifications.toThread(threadId, { method: "error", params: error });
+			bindings.notifications.toThread(threadId, { method: "error", params: error });
 		},
 	});
 	bindingExtensions = false;
@@ -161,10 +194,24 @@ async function createBoundAppServerSession(
 	const mcpWireStatusAdapter = createMcpWireStatusAdapter(mcpService.getWireStatusSnapshot(threadId));
 	result.session.subscribe((event) => {
 		if (event.type === "agent_end") {
-			approvals.cancelPendingForThread(threadId);
+			bindings.approvals.cancelPendingForThread(threadId);
 		}
 	});
 	return { ...result, initialNotifications, mcpWireStatusAdapter };
+}
+
+function registerMcpReloadMethod(registry: MethodRegistry, threads: ThreadRegistry): void {
+	registry.register("config/mcpServer/reload", {
+		scope: "global",
+		handler: async () => {
+			const service = getMcpService();
+			for (const thread of threads.listLoaded()) {
+				const entry = threads.getLoadedThread(thread.id);
+				entry.mcpWireStatusAdapter?.update(await service.reloadSession(thread.id));
+			}
+			return {};
+		},
+	});
 }
 
 function registerTurnHandlers(registry: MethodRegistry, turns: TurnEngineApi, core: ServerCore): void {

--- a/packages/coding-agent/src/modes/app-server/threads/handlers.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/handlers.ts
@@ -16,6 +16,7 @@ import { threadItemsListResponse, threadTurnsListResponse } from "./history.ts";
 import { listThreadsResponse, loadedThreadsResponse } from "./list-handlers.ts";
 import { registerThreadMetadataHandlers } from "./metadata-handlers.ts";
 import { type ThreadEntry, ThreadNotFoundError, type ThreadRegistry, type WireThread } from "./registry.ts";
+import { registerThreadRollbackHandler } from "./rollback-handler.ts";
 import { threadSearchResponse } from "./search.ts";
 import { ThreadSearchCache } from "./search-cache.ts";
 import { threadSearchOccurrencesResponse } from "./search-occurrences.ts";
@@ -56,6 +57,7 @@ export function registerThreadLifecycleHandlers(
 ): ThreadLifecycleController {
 	registerThreadGoalHandlers(registry, options);
 	registerThreadSettingsHandlers(registry, options);
+	registerThreadRollbackHandler(registry, options.threads, options.turnLog);
 	const archiveState = new ThreadArchiveState(options.threads.getSessionDir());
 	registerThreadMetadataHandlers(registry, {
 		threads: options.threads,
@@ -279,6 +281,7 @@ class ThreadLifecycleHandlers {
 			const startedAtMs = Date.now();
 			this.turnLog.recordTurn(threadId, {
 				turnId,
+				rollbackLeafId: entry.session.sessionManager.getLeafId(),
 				startedAt: new Date(startedAtMs).toISOString(),
 				status: "running",
 			});

--- a/packages/coding-agent/src/modes/app-server/threads/mcp-wire-status.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/mcp-wire-status.ts
@@ -1,6 +1,6 @@
 import { resolveAuthMode } from "../../../core/extensions/builtin/mcp/auth/context.ts";
 import { loadMcpConfig } from "../../../core/extensions/builtin/mcp/config.ts";
-import type { ResolvedMcpServer } from "../../../core/extensions/builtin/mcp/config-schema.ts";
+import type { McpServerDeclaration, ResolvedMcpServer } from "../../../core/extensions/builtin/mcp/config-schema.ts";
 import type {
 	McpWireAuthStatus,
 	McpWireJsonValue,
@@ -40,6 +40,7 @@ export function createMcpWireStatusAdapter(snapshot: McpWireStatusSnapshot): Mcp
 }
 
 export type ProcessMcpWireStatusOptions = {
+	readonly additionalServers?: Readonly<Record<string, McpServerDeclaration>>;
 	readonly agentDir?: string;
 	readonly cwd: string;
 	readonly env?: Record<string, string | undefined>;
@@ -54,10 +55,25 @@ export type ProcessMcpWireStatusOptions = {
  */
 export function createProcessMcpWireStatusAdapter(options: ProcessMcpWireStatusOptions): McpWireStatusAdapter {
 	const config = loadMcpConfig({ ...options, projectTrusted: false });
-	const servers = Object.values(config.servers)
-		.filter((server) => server.source === "global")
-		.map(toConfiguredServer);
-	return createMcpWireStatusAdapter({ servers });
+	const servers = new Map<string, McpWireStatusServer>(
+		Object.values(config.servers)
+			.filter((server) => server.source === "global")
+			.map((server) => [server.name, toConfiguredServer(server)]),
+	);
+	for (const [name, server] of Object.entries(options.additionalServers ?? {})) {
+		servers.set(name, {
+			name,
+			serverInfo: null,
+			tools: [],
+			resources: [],
+			resourceTemplates: [],
+			authStatus:
+				server.bearerTokenEnv !== undefined && options.env?.[server.bearerTokenEnv] === undefined
+					? "notLoggedIn"
+					: "bearerToken",
+		});
+	}
+	return createMcpWireStatusAdapter({ servers: [...servers.values()] });
 }
 
 /** Resolves loaded-thread adapters while retaining an explicit process scope. */

--- a/packages/coding-agent/src/modes/app-server/threads/projection-plan.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/projection-plan.ts
@@ -1,0 +1,44 @@
+import type { TurnPlanStep, TurnPlanStepStatus } from "../protocol/notifications.ts";
+
+const TODO_TOOL_NAME = "todo";
+
+/**
+ * Extracts Codex plan steps from a completed todo tool result. Returns
+ * `undefined` when the result carries no structured `details.phases` array, so
+ * turns without a plan emit nothing. Malformed phases/tasks are skipped rather
+ * than invented.
+ */
+export function todoPlanSteps(toolName: string, result: unknown): TurnPlanStep[] | undefined {
+	if (toolName !== TODO_TOOL_NAME || !isRecord(result) || !isRecord(result.details)) return undefined;
+	const phases = result.details.phases;
+	if (!Array.isArray(phases)) return undefined;
+	const steps: TurnPlanStep[] = [];
+	for (const phase of phases) {
+		if (!isRecord(phase) || !Array.isArray(phase.tasks)) continue;
+		for (const task of phase.tasks) {
+			if (!isRecord(task) || typeof task.content !== "string") continue;
+			const status = planStepStatus(task.status);
+			if (status === undefined) continue;
+			steps.push({ step: task.content, status });
+		}
+	}
+	return steps;
+}
+
+function planStepStatus(status: unknown): TurnPlanStepStatus | undefined {
+	switch (status) {
+		case "pending":
+			return "pending";
+		case "in_progress":
+			return "inProgress";
+		case "completed":
+		case "abandoned":
+			return "completed";
+		default:
+			return undefined;
+	}
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/coding-agent/src/modes/app-server/threads/projection.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/projection.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, ToolCall } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "../../../core/agent-session.ts";
 import { MessageItemProjector } from "./projection-message-items.ts";
+import { todoPlanSteps } from "./projection-plan.ts";
 import { TurnDiffTracker } from "./projection-turn-diff.ts";
 import {
 	type AssistantMessageEvent,
@@ -187,9 +188,13 @@ export class EventProjector {
 		}
 		const projection = this.projectToolItem(tool, true, isError, result);
 		const cumulativeDiff = this.turnDiff.update(tool.id, projection.diff, this.toolItems.keys());
+		const planSteps = todoPlanSteps(tool.name, result);
 		return [
 			this.completed(projection.item),
 			...(cumulativeDiff === undefined ? [] : [this.notification("turn/diff/updated", { diff: cumulativeDiff })]),
+			...(planSteps === undefined
+				? []
+				: [this.notification("turn/plan/updated", { explanation: null, plan: planSteps })]),
 		];
 	}
 

--- a/packages/coding-agent/src/modes/app-server/threads/rollback-handler.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/rollback-handler.ts
@@ -1,0 +1,74 @@
+import type { ThreadRollbackResponse } from "../protocol/index.ts";
+import type { MethodRegistry, RpcRequest } from "../rpc/registry.ts";
+import { type ThreadEntry, ThreadNotFoundError, type ThreadRegistry } from "./registry.ts";
+import type { TurnLog } from "./turn-log.ts";
+import { invalidRequest } from "./turn-runtime.ts";
+import { buildWireThread, turnsForEntry } from "./wire-thread.ts";
+
+const ROLLBACK_ENTRY_TYPE = "senpi.app-server.rollback";
+
+export function registerThreadRollbackHandler(
+	registry: MethodRegistry,
+	threads: ThreadRegistry,
+	turnLog: TurnLog,
+): void {
+	registry.register("thread/rollback", {
+		scope: "thread",
+		handler: async ({ request }) => rollbackThread(request, threads, turnLog),
+	});
+}
+
+async function rollbackThread(
+	request: RpcRequest,
+	threads: ThreadRegistry,
+	turnLog: TurnLog,
+): Promise<ThreadRollbackResponse> {
+	const params = rollbackParams(request.params);
+	let entry: ThreadEntry;
+	try {
+		entry = await threads.resumeThread(params.threadId);
+	} catch (error) {
+		if (error instanceof ThreadNotFoundError) {
+			throw invalidRequest(`thread not found: ${params.threadId}`);
+		}
+		throw error;
+	}
+	if (entry.activeTurn) {
+		throw invalidRequest(`cannot roll back thread ${params.threadId} with an active turn`);
+	}
+
+	const turns = turnsForEntry(entry, turnLog);
+	const firstRemoved = turns.at(-params.numTurns);
+	if (!firstRemoved) {
+		throw invalidRequest(`cannot roll back ${params.numTurns} turns from a thread with ${turns.length} turns`);
+	}
+
+	const sessionManager = entry.session.sessionManager;
+	if (firstRemoved.rollbackLeafId === null) {
+		sessionManager.resetLeaf();
+	} else {
+		sessionManager.branch(firstRemoved.rollbackLeafId);
+	}
+	if (turnLog.readTurns(entry.id).length > 0) {
+		turnLog.rollbackTurns(entry.id, params.numTurns);
+	}
+	sessionManager.appendCustomEntry(ROLLBACK_ENTRY_TYPE, { numTurns: params.numTurns });
+	entry.updatedAt = new Date().toISOString();
+
+	return { thread: await buildWireThread(entry, turnLog, true) };
+}
+
+function rollbackParams(value: unknown): { readonly threadId: string; readonly numTurns: number } {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw invalidRequest("thread/rollback params must be an object");
+	}
+	const threadId = Reflect.get(value, "threadId");
+	if (typeof threadId !== "string" || threadId.length === 0) {
+		throw invalidRequest("threadId is required");
+	}
+	const numTurns = Reflect.get(value, "numTurns");
+	if (typeof numTurns !== "number" || !Number.isInteger(numTurns) || numTurns < 1) {
+		throw invalidRequest("numTurns must be an integer greater than or equal to 1");
+	}
+	return { threadId, numTurns };
+}

--- a/packages/coding-agent/src/modes/app-server/threads/turn-log.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/turn-log.ts
@@ -4,6 +4,7 @@ export type WireItem = Record<string, unknown>;
 
 export interface LoggedTurn {
 	turnId: string;
+	rollbackLeafId: string | null;
 	startedAt: string;
 	completedAt: string | null;
 	durationMs: number | null;
@@ -14,6 +15,7 @@ export interface LoggedTurn {
 
 export interface RecordTurnOptions {
 	turnId: string;
+	rollbackLeafId?: string | null;
 	startedAt: string;
 	status?: TurnStatus;
 	completedAt?: string | null;
@@ -33,6 +35,7 @@ export class TurnLog {
 		const turns = this.getThreadTurns(threadId);
 		const loggedTurn: LoggedTurn = {
 			turnId: turn.turnId,
+			rollbackLeafId: turn.rollbackLeafId ?? null,
 			startedAt: turn.startedAt,
 			completedAt: turn.completedAt ?? null,
 			durationMs: durationBetween(turn.startedAt, turn.completedAt ?? null),
@@ -67,6 +70,15 @@ export class TurnLog {
 		return this.getThreadTurns(threadId).map(cloneTurn);
 	}
 
+	rollbackTurns(threadId: string, numTurns: number): void {
+		const turns = this.getThreadTurns(threadId);
+		const firstRemoved = turns.at(-numTurns);
+		if (!firstRemoved) {
+			throw new Error(`Cannot roll back ${numTurns} turns from a thread with ${turns.length} turns`);
+		}
+		turns.splice(turns.length - numTurns, numTurns);
+	}
+
 	private getThreadTurns(threadId: string): LoggedTurn[] {
 		let turns = this.turnsByThreadId.get(threadId);
 		if (!turns) {
@@ -80,6 +92,7 @@ export class TurnLog {
 function cloneTurn(turn: LoggedTurn): LoggedTurn {
 	return {
 		turnId: turn.turnId,
+		rollbackLeafId: turn.rollbackLeafId,
 		startedAt: turn.startedAt,
 		completedAt: turn.completedAt,
 		durationMs: turn.durationMs,

--- a/packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts
@@ -165,8 +165,8 @@ export function buildTurn(
 						additionalDetails: null,
 					}
 				: null,
-		startedAt: startedAtMs / 1000,
-		completedAt: completedAtMs === null ? null : completedAtMs / 1000,
+		startedAt: Math.floor(startedAtMs / 1000),
+		completedAt: completedAtMs === null ? null : Math.floor(completedAtMs / 1000),
 		durationMs: completedAtMs === null ? null : completedAtMs - startedAtMs,
 	};
 }

--- a/packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/turn-runtime.ts
@@ -20,6 +20,10 @@ export type LoggedStartStatus = "running";
 export type TurnEngineSessionEvent = { readonly type: string };
 
 export interface TurnEngineSession {
+	readonly sessionManager?: {
+		getLeafId(): string | null;
+		getLeafEntry(): { readonly parentId: string | null } | undefined;
+	};
 	prompt(
 		text: string,
 		options?: { readonly source?: "rpc"; readonly preflightResult?: (success: boolean) => void },

--- a/packages/coding-agent/src/modes/app-server/threads/turns.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/turns.ts
@@ -92,12 +92,14 @@ class TurnEngine<Entry extends TurnEngineThreadEntry> {
 					const startedAt = new Date(startedAtMs).toISOString();
 					const turn = buildTurn(turnId, "inProgress", startedAtMs, null, []);
 					const userMessage = buildUserMessage(params.clientUserMessageId ?? null, parsedInput.content);
+					const rollbackLeafId = entry.session.sessionManager?.getLeafId() ?? null;
 
 					entry.activeTurn = { turnId, startedAt };
 					entry.status = "active";
 					entry.updatedAt = startedAt;
 					this.turnLog.recordTurn(params.threadId, {
 						turnId,
+						rollbackLeafId,
 						startedAt,
 						status: "running" satisfies LoggedStartStatus,
 					});
@@ -354,7 +356,12 @@ class TurnEngine<Entry extends TurnEngineThreadEntry> {
 		entry.activeTurn = { turnId, startedAt };
 		entry.status = "active";
 		entry.updatedAt = startedAt;
-		this.turnLog.recordTurn(threadId, { turnId, startedAt, status: "running" });
+		this.turnLog.recordTurn(threadId, {
+			turnId,
+			rollbackLeafId: entry.session.sessionManager?.getLeafEntry()?.parentId ?? null,
+			startedAt,
+			status: "running",
+		});
 		this.pendingByThreadId.set(threadId, {
 			turnId,
 			startedAt,

--- a/packages/coding-agent/src/modes/app-server/threads/wire-thread.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/wire-thread.ts
@@ -218,5 +218,5 @@ function toGeneratedStatus(status: WireThread["status"]["type"]): ThreadStatus {
 
 function isoSeconds(value: string): number {
 	const parsed = Date.parse(value);
-	return Number.isFinite(parsed) ? parsed / 1000 : 0;
+	return Number.isFinite(parsed) ? Math.floor(parsed / 1000) : 0;
 }

--- a/packages/coding-agent/src/modes/app-server/threads/wire-thread.ts
+++ b/packages/coding-agent/src/modes/app-server/threads/wire-thread.ts
@@ -91,7 +91,7 @@ export function turnsForEntry(entry: ThreadEntry | WireThread | ThreadHistorySou
 		return loggedTurns;
 	}
 	const entries =
-		"session" in entry ? entry.session.sessionManager.getEntries() : "entries" in entry ? entry.entries : [];
+		"session" in entry ? entry.session.sessionManager.getBranch() : "entries" in entry ? entry.entries : [];
 	return turnsFromSessionEntries(entries, entry.createdAt);
 }
 
@@ -103,6 +103,7 @@ function turnsFromSessionEntries(entries: readonly SessionEntry[], fallbackStart
 		if (entry.message.role === "user") {
 			current = {
 				turnId: `turn-${turns.length + 1}`,
+				rollbackLeafId: entry.parentId,
 				startedAt: entry.timestamp || fallbackStartedAt,
 				completedAt: null,
 				durationMs: null,

--- a/packages/coding-agent/test/suite/app-server-cli.test.ts
+++ b/packages/coding-agent/test/suite/app-server-cli.test.ts
@@ -15,6 +15,7 @@ describe("app-server CLI subcommand parsing", () => {
 			listen: { kind: "stdio", url: "stdio://" },
 			wsAuth: undefined,
 			jsonLogs: false,
+			configOverrides: [],
 		});
 	});
 
@@ -29,6 +30,7 @@ describe("app-server CLI subcommand parsing", () => {
 			listen: { kind: "ws", url: "ws://127.0.0.1:18991", host: "127.0.0.1", port: 18991 },
 			wsAuth: undefined,
 			jsonLogs: false,
+			configOverrides: [],
 		});
 	});
 
@@ -43,7 +45,56 @@ describe("app-server CLI subcommand parsing", () => {
 			listen: { kind: "unix", url: "unix:///tmp/senpi-app.sock", path: "/tmp/senpi-app.sock" },
 			wsAuth: undefined,
 			jsonLogs: false,
+			configOverrides: [],
 		});
+	});
+
+	it("accepts one config override", () => {
+		// Given: one Codex-style key/value override.
+		// When: the subcommand args are parsed.
+		const result = parseAppServerCliArgs(["-c", "key=value"]);
+
+		// Then: the raw key and value are exposed.
+		expect(result).toEqual({
+			kind: "server",
+			listen: { kind: "stdio", url: "stdio://" },
+			wsAuth: undefined,
+			jsonLogs: false,
+			configOverrides: [{ key: "key", value: "value" }],
+		});
+	});
+
+	it("accumulates config overrides in order and preserves quoted values", () => {
+		// Given: repeated Codex-style overrides, including a literal quoted value.
+		// When: the subcommand args are parsed.
+		const result = parseAppServerCliArgs([
+			"-c",
+			"first=one",
+			"-c",
+			'mcp_servers.t3-code.bearer_token_env_var="T3_MCP_BEARER_TOKEN"',
+		]);
+
+		// Then: overrides retain argv order and raw value text.
+		expect(result).toMatchObject({
+			kind: "server",
+			configOverrides: [
+				{ key: "first", value: "one" },
+				{ key: "mcp_servers.t3-code.bearer_token_env_var", value: '"T3_MCP_BEARER_TOKEN"' },
+			],
+		});
+	});
+
+	it.each([
+		["missing value", ["-c"], "-c requires <key>=<value>."],
+		["missing equals", ["-c", "key"], "-c requires <key>=<value>."],
+		["unknown argument", ["--bogus"], "Unexpected app-server argument: --bogus"],
+	] as const)("returns a usage error for %s", (_name, args, message) => {
+		// Given: malformed or unknown app-server arguments.
+		// When: the subcommand args are parsed.
+		const result = parseAppServerCliArgs(args);
+
+		// Then: parsing returns the specific usage error.
+		expect(result).toEqual({ kind: "usage-error", message });
 	});
 
 	it("returns a usage error for invalid listen URLs", () => {

--- a/packages/coding-agent/test/suite/app-server-mcp-overrides.test.ts
+++ b/packages/coding-agent/test/suite/app-server-mcp-overrides.test.ts
@@ -1,0 +1,254 @@
+import { randomUUID } from "node:crypto";
+import { access } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { CallToolRequestSchema, isInitializeRequest, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it, vi } from "vitest";
+import { CONFIG_DIR_NAME } from "../../src/config.ts";
+import { materializeAppServerMcpConfigSource } from "../../src/modes/app-server/mcp-config-overrides.ts";
+import {
+	configureModeEnv,
+	scratchRoot,
+	seedFauxConfig,
+	startWsAppServerMode,
+	stopWsAppServerMode,
+	threadIdFromResponse,
+} from "./app-server-mode-harness.ts";
+import { BufferedSocketReader, initializeSocket, openSocket } from "./app-server-mode-socket.ts";
+
+describe("app-server Codex MCP config overrides", () => {
+	it("uses last-wins complete valid pairs and ignores malformed or unsupported overrides", () => {
+		// Given: duplicate, malformed, incomplete, and unrelated Codex overrides.
+		const overrides = [
+			{ key: "mcp_servers.t3-code.url", value: "https://stale.example/mcp" },
+			{ key: "mcp_servers.t3-code.url", value: "http://127.0.0.1:1234/mcp" },
+			{ key: "mcp_servers.t3-code.bearer_token_env_var", value: '"T3_MCP_BEARER_TOKEN"' },
+			{ key: "mcp_servers.incomplete.url", value: "http://127.0.0.1:1234/mcp" },
+			{ key: "mcp_servers.bad-url.url", value: "ftp://127.0.0.1/mcp" },
+			{ key: "mcp_servers.bad-url.bearer_token_env_var", value: "TOKEN" },
+			{ key: "mcp_servers.bad name.url", value: "http://127.0.0.1:1234/mcp" },
+			{ key: "model", value: "ignored" },
+		] as const;
+
+		// When: the immutable app-server source is materialized.
+		const source = materializeAppServerMcpConfigSource(overrides);
+
+		// Then: only the final complete pair is registered and diagnostics contain no values.
+		expect(source.servers).toEqual({
+			"t3-code": {
+				type: "http",
+				url: "http://127.0.0.1:1234/mcp",
+				auth: "bearer",
+				bearerTokenEnv: "T3_MCP_BEARER_TOKEN",
+			},
+		});
+		expect(source.diagnostics).toEqual([
+			"ignored incomplete app-server MCP config override",
+			"ignored malformed app-server MCP config override",
+			"ignored unsupported app-server config override",
+		]);
+		expect(JSON.stringify(source.diagnostics)).not.toContain("1234");
+	});
+
+	it("authenticates a discovered tool, reloads it, reports status, and carries its result into the next model request", async () => {
+		// Given: a local HTTP MCP server and faux model turn with one concrete MCP tool call.
+		const root = await scratchRoot();
+		const token = `test-${randomUUID()}`;
+		const mcp = await startAuthenticatedMcpServer(token);
+		const faux = registerFauxProvider();
+		let resultReachedNextRequest = false;
+		faux.setResponses([
+			fauxAssistantMessage(fauxToolCall("mcp_t3-code_verify_auth", {}, { id: "mcp-auth-call" }), {
+				stopReason: "toolUse",
+			}),
+			(context) => {
+				resultReachedNextRequest = context.messages.some(
+					(message) =>
+						message.role === "toolResult" &&
+						message.content.some(
+							(part) => part.type === "text" && /authorizationVerified[^a-zA-Z]+true/u.test(part.text),
+						),
+				);
+				return fauxAssistantMessage("complete");
+			},
+		]);
+		await seedFauxConfig(root, faux);
+		configureModeEnv(root);
+		vi.stubEnv("T3_MCP_BEARER_TOKEN", token);
+		const running = await startWsAppServerMode(18992, [
+			{ key: "mcp_servers.t3-code.url", value: mcp.url },
+			{ key: "mcp_servers.t3-code.bearer_token_env_var", value: '"T3_MCP_BEARER_TOKEN"' },
+		]);
+		const socket = await openSocket(running.port);
+		const reader = new BufferedSocketReader(socket);
+		try {
+			await initializeSocket(socket, reader);
+			socket.send(JSON.stringify({ id: 2, method: "thread/start", params: { cwd: root } }));
+			const threadId = threadIdFromResponse(await reader.readUntilResponse(2));
+
+			// When: T3's reload/status sequence runs and a faux turn invokes the announced tool.
+			socket.send(JSON.stringify({ id: 3, method: "config/mcpServer/reload" }));
+			expect(await reader.readUntilResponse(3)).toEqual({ id: 3, result: {} });
+			socket.send(JSON.stringify({ id: 4, method: "mcpServerStatus/list", params: { threadId } }));
+			expect(await reader.readUntilResponse(4)).toMatchObject({
+				id: 4,
+				result: { data: [expect.objectContaining({ name: "t3-code", authStatus: "bearerToken" })] },
+			});
+			socket.send(JSON.stringify({ id: 40, method: "mcpServerStatus/list", params: {} }));
+			expect(await reader.readUntilResponse(40)).toMatchObject({
+				id: 40,
+				result: { data: [expect.objectContaining({ name: "t3-code", authStatus: "bearerToken" })] },
+			});
+			socket.send(
+				JSON.stringify({
+					id: 5,
+					method: "turn/start",
+					params: { threadId, input: [{ type: "text", text: "invoke configured MCP tool" }] },
+				}),
+			);
+			const turnResponse = await reader.readUntilResponse(5);
+			const completed = await reader.readUntilNotification("turn/completed");
+
+			// Then: authorization was checked inside the fake and its sentinel reached model request two.
+			expect(turnResponse).toMatchObject({ id: 5, result: { turn: { status: "inProgress" } } });
+			expect(completed).toMatchObject({ method: "turn/completed", params: { turn: { status: "completed" } } });
+			expect(mcp.authorizationVerified()).toBe(true);
+			expect(resultReachedNextRequest).toBe(true);
+			await expect(access(`${root}/${CONFIG_DIR_NAME}/mcp.json`)).rejects.toMatchObject({ code: "ENOENT" });
+			await expect(access(`${root}/agent/mcp.json`)).rejects.toMatchObject({ code: "ENOENT" });
+		} finally {
+			reader.dispose();
+			socket.close();
+			faux.unregister();
+			await stopWsAppServerMode(running);
+			await mcp.close();
+		}
+	});
+
+	it("keeps a missing bearer environment variable non-fatal and reports unauthenticated status", async () => {
+		// Given: a configured bearer env name that is absent from the process.
+		const root = await scratchRoot();
+		const mcp = await startAuthenticatedMcpServer(`test-${randomUUID()}`);
+		configureModeEnv(root);
+		vi.stubEnv("MISSING_MCP_TOKEN", undefined);
+		const running = await startWsAppServerMode(18993, [
+			{ key: "mcp_servers.missing-auth.url", value: mcp.url },
+			{ key: "mcp_servers.missing-auth.bearer_token_env_var", value: '"MISSING_MCP_TOKEN"' },
+		]);
+		const socket = await openSocket(running.port);
+		const reader = new BufferedSocketReader(socket);
+		try {
+			await initializeSocket(socket, reader);
+
+			// When: a thread attaches and its MCP status is requested.
+			socket.send(JSON.stringify({ id: 2, method: "thread/start", params: { cwd: root } }));
+			const threadId = threadIdFromResponse(await reader.readUntilResponse(2));
+			socket.send(JSON.stringify({ id: 3, method: "mcpServerStatus/list", params: { threadId } }));
+			const response = await reader.readUntilResponse(3);
+
+			// Then: the server remains alive and exposes an unauthenticated entry without sending credentials.
+			expect(response).toMatchObject({
+				id: 3,
+				result: { data: [expect.objectContaining({ name: "missing-auth", authStatus: "notLoggedIn" })] },
+			});
+			expect(mcp.authorizationVerified()).toBe(false);
+		} finally {
+			reader.dispose();
+			socket.close();
+			await stopWsAppServerMode(running);
+			await mcp.close();
+		}
+	});
+});
+
+type AuthenticatedMcpServer = {
+	readonly url: string;
+	readonly authorizationVerified: () => boolean;
+	readonly close: () => Promise<void>;
+};
+
+async function startAuthenticatedMcpServer(expectedToken: string): Promise<AuthenticatedMcpServer> {
+	const sessions = new Map<string, { readonly server: Server; readonly transport: StreamableHTTPServerTransport }>();
+	let verified = false;
+	const httpServer = createServer(async (request, response) => {
+		if (request.headers.authorization !== `Bearer ${expectedToken}`) {
+			writeJson(response, 401, { error: "unauthorized" });
+			return;
+		}
+		const body = await readJsonBody(request);
+		if (isToolCall(body)) verified = true;
+		const session = createOrFindMcpSession(body, request, sessions);
+		if (session === undefined) {
+			writeJson(response, 404, { error: "unknown session" });
+			return;
+		}
+		await session.transport.handleRequest(request, response, body);
+		const sessionId = session.transport.sessionId;
+		if (sessionId !== undefined) sessions.set(sessionId, session);
+	});
+	await new Promise<void>((resolve, reject) => {
+		httpServer.once("error", reject);
+		httpServer.listen(0, "127.0.0.1", resolve);
+	});
+	const address = httpServer.address();
+	if (address === null || typeof address === "string") throw new Error("MCP test server did not bind");
+	return {
+		url: `http://127.0.0.1:${address.port}/mcp`,
+		authorizationVerified: () => verified,
+		close: async () => {
+			for (const session of sessions.values()) {
+				await session.transport.close();
+				await session.server.close();
+			}
+			await new Promise<void>((resolve, reject) => httpServer.close((error) => (error ? reject(error) : resolve())));
+		},
+	};
+}
+
+function createOrFindMcpSession(
+	body: unknown,
+	request: IncomingMessage,
+	sessions: ReadonlyMap<string, { readonly server: Server; readonly transport: StreamableHTTPServerTransport }>,
+): { readonly server: Server; readonly transport: StreamableHTTPServerTransport } | undefined {
+	const header = request.headers["mcp-session-id"];
+	const sessionId = Array.isArray(header) ? header[0] : header;
+	if (sessionId !== undefined) return sessions.get(sessionId);
+	if (!isInitializeRequest(body)) return undefined;
+	const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => `app-${randomUUID()}` });
+	const server = new Server({ name: "app-server-auth-fixture", version: "1.0.0" }, { capabilities: { tools: {} } });
+	server.setRequestHandler(ListToolsRequestSchema, () => ({
+		tools: [{ name: "verify_auth", description: "verify request auth", inputSchema: { type: "object" } }],
+	}));
+	server.setRequestHandler(CallToolRequestSchema, () => ({
+		content: [{ type: "text", text: JSON.stringify({ authorizationVerified: true }) }],
+	}));
+	void server.connect(transport);
+	return { server, transport };
+}
+
+function isToolCall(body: unknown): boolean {
+	return typeof body === "object" && body !== null && Reflect.get(body, "method") === "tools/call";
+}
+
+function readJsonBody(request: IncomingMessage): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk: Buffer) => chunks.push(chunk));
+		request.on("end", () => {
+			try {
+				const text = Buffer.concat(chunks).toString("utf8");
+				resolve(text.length === 0 ? undefined : JSON.parse(text));
+			} catch (error: unknown) {
+				reject(error instanceof Error ? error : new Error(String(error)));
+			}
+		});
+		request.on("error", reject);
+	});
+}
+
+function writeJson(response: ServerResponse, status: number, body: unknown): void {
+	response.writeHead(status, { "content-type": "application/json" });
+	response.end(JSON.stringify(body));
+}

--- a/packages/coding-agent/test/suite/app-server-mode-harness.ts
+++ b/packages/coding-agent/test/suite/app-server-mode-harness.ts
@@ -5,6 +5,7 @@ import type { registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { afterEach, expect, vi } from "vitest";
 import { restoreStdout } from "../../src/core/output-guard.ts";
 import { runAppServerMode } from "../../src/modes/app-server/index.ts";
+import type { AppServerConfigOverride } from "../../src/modes/app-server/mcp-config-overrides.ts";
 import { captureStderrPort } from "./app-server-mode-socket.ts";
 
 const runningModes: Array<Promise<void>> = [];
@@ -45,7 +46,10 @@ export function configureModeEnv(root: string): void {
 	vi.spyOn(process, "exit").mockImplementation(exitThrows);
 }
 
-export async function startWsAppServerMode(preferredPort: QaPort): Promise<RunningAppServerMode> {
+export async function startWsAppServerMode(
+	preferredPort: QaPort,
+	configOverrides: readonly AppServerConfigOverride[] = [],
+): Promise<RunningAppServerMode> {
 	const ports = [preferredPort, ...QA_PORTS.filter((port) => port !== preferredPort)];
 	for (const port of ports) {
 		const banner = captureStderrPort();
@@ -59,6 +63,7 @@ export async function startWsAppServerMode(preferredPort: QaPort): Promise<Runni
 			},
 			wsAuth: { kind: "off" },
 			jsonLogs: false,
+			configOverrides,
 		});
 		runningModes.push(mode);
 		try {
@@ -127,7 +132,7 @@ export async function eventually(assertion: () => void | Promise<void>): Promise
 			await assertion();
 			return;
 		} catch (error: unknown) {
-			lastError = error;
+			lastError = error instanceof Error ? error : new Error(String(error));
 			await deferOneTick();
 		}
 	}

--- a/packages/coding-agent/test/suite/app-server-mode-rollback.test.ts
+++ b/packages/coding-agent/test/suite/app-server-mode-rollback.test.ts
@@ -1,0 +1,88 @@
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import {
+	configureModeEnv,
+	scratchRoot,
+	seedFauxConfig,
+	startWsAppServerMode,
+	stopWsAppServerMode,
+	threadIdFromResponse,
+} from "./app-server-mode-harness.ts";
+import { BufferedSocketReader, initializeSocket, openSocket } from "./app-server-mode-socket.ts";
+
+describe("app-server thread rollback mode", () => {
+	it("reduces completed faux-provider turns through the real RPC surface", async () => {
+		// Given: an initialized app-server with two deterministic faux-provider responses.
+		const root = await scratchRoot();
+		const faux = registerFauxProvider();
+		faux.setResponses([fauxAssistantMessage("first answer"), fauxAssistantMessage("second answer")]);
+		await seedFauxConfig(root, faux);
+		configureModeEnv(root);
+		const running = await startWsAppServerMode(18997);
+		const socket = await openSocket(running.port);
+		const reader = new BufferedSocketReader(socket);
+		try {
+			await initializeSocket(socket, reader);
+			socket.send(JSON.stringify({ id: 2, method: "thread/start", params: { cwd: root } }));
+			const threadId = threadIdFromResponse(await reader.readUntilResponse(2));
+			const rpc = { socket, reader };
+			await completeTurn(rpc, { threadId, requestId: 3, text: "first turn" });
+			await completeTurn(rpc, { threadId, requestId: 4, text: "second turn" });
+			socket.send(JSON.stringify({ id: 5, method: "thread/read", params: { threadId, includeTurns: true } }));
+			const beforeRollback = await reader.readUntilResponse(5);
+
+			// When: the client rolls back the latest turn.
+			socket.send(JSON.stringify({ id: 6, method: "thread/rollback", params: { threadId, numTurns: 1 } }));
+			const rollback = await reader.readUntilResponse(6);
+			socket.send(JSON.stringify({ id: 7, method: "thread/read", params: { threadId, includeTurns: true } }));
+			const afterRollback = await reader.readUntilResponse(7);
+
+			// Then: the two-turn history is reduced to exactly the retained first turn.
+			expect(turnCount(beforeRollback)).toBe(2);
+			expect(turnCount(rollback)).toBe(1);
+			expect(turnCount(afterRollback)).toBe(1);
+		} finally {
+			reader.dispose();
+			socket.close();
+			faux.unregister();
+			await stopWsAppServerMode(running);
+		}
+	});
+});
+
+type RollbackRpc = {
+	readonly socket: { send(data: string): void };
+	readonly reader: BufferedSocketReader;
+};
+
+type TurnRequest = {
+	readonly threadId: string;
+	readonly requestId: number;
+	readonly text: string;
+};
+
+async function completeTurn(rpc: RollbackRpc, request: TurnRequest): Promise<void> {
+	rpc.socket.send(
+		JSON.stringify({
+			id: request.requestId,
+			method: "turn/start",
+			params: { threadId: request.threadId, input: [{ type: "text", text: request.text }] },
+		}),
+	);
+	await rpc.reader.readUntilResponse(request.requestId);
+	for (let index = 0; index < 128; index += 1) {
+		const message = await rpc.reader.read();
+		if (message.method === "turn/completed") return;
+	}
+	throw new Error("turn/completed not observed");
+}
+
+function turnCount(response: Record<string, unknown>): number {
+	const result = response.result;
+	if (typeof result !== "object" || result === null || !("thread" in result)) throw new Error("missing thread");
+	const thread = result.thread;
+	if (typeof thread !== "object" || thread === null || !("turns" in thread) || !Array.isArray(thread.turns)) {
+		throw new Error("missing turns");
+	}
+	return thread.turns.length;
+}

--- a/packages/coding-agent/test/suite/app-server-projection-plan.test.ts
+++ b/packages/coding-agent/test/suite/app-server-projection-plan.test.ts
@@ -1,0 +1,183 @@
+import type { AssistantMessage, Usage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import type { AgentSessionEvent } from "../../src/core/agent-session.ts";
+import { EventProjector } from "../../src/modes/app-server/threads/projection.ts";
+import { TurnLog } from "../../src/modes/app-server/threads/turn-log.ts";
+
+const usage: Usage = {
+	input: 1,
+	output: 1,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 2,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function assistant(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-completions",
+		provider: "openai",
+		model: "test-model",
+		responseId: "msg-1",
+		usage,
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function collect(events: readonly AgentSessionEvent[]) {
+	const turnLog = new TurnLog();
+	turnLog.recordTurn("thread-1", { turnId: "turn-1", startedAt: "2026-07-02T00:00:00.000Z" });
+	const projector = new EventProjector({
+		threadId: "thread-1",
+		turnId: "turn-1",
+		turnLog,
+		cwd: "/tmp/project",
+		nowMs: () => 1234,
+	});
+	return events.flatMap((event) => projector.project(event).notifications);
+}
+
+function toolEvents(toolName: string, result: unknown): AgentSessionEvent[] {
+	const message = assistant([{ type: "toolCall", id: "tool-1", name: toolName, arguments: {} }]);
+	return [
+		{
+			type: "message_update",
+			message,
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 0,
+				toolCall: { type: "toolCall", id: "tool-1", name: toolName, arguments: {} },
+				partial: message,
+			},
+		},
+		{ type: "tool_execution_end", toolCallId: "tool-1", toolName, result, isError: false },
+	];
+}
+
+type PlanParams = {
+	readonly threadId?: string;
+	readonly turnId?: string;
+	readonly explanation?: string | null;
+	readonly plan?: readonly unknown[];
+};
+
+function planNotifications(outputs: readonly { method: string; params: unknown }[]): PlanParams[] {
+	return outputs
+		.filter((output) => output.method === "turn/plan/updated")
+		.map((output) => output.params as PlanParams);
+}
+
+describe("app-server turn/plan/updated projection", () => {
+	it("emits turn/plan/updated with V2 statuses when the todo tool completes with phases", () => {
+		// Given: a todo tool execution whose structured details carry every senpi status.
+		const result = {
+			content: [{ type: "text", text: "summary" }],
+			details: {
+				op: "init",
+				storage: "memory",
+				phases: [
+					{
+						name: "Setup",
+						tasks: [
+							{ content: "pending task", status: "pending" },
+							{ content: "active task", status: "in_progress" },
+							{ content: "done task", status: "completed" },
+							{ content: "dropped task", status: "abandoned" },
+						],
+					},
+				],
+			},
+		};
+
+		// When: the events are projected.
+		const outputs = collect(toolEvents("todo", result));
+
+		// Then: exactly one plan notification carries the flattened steps, and every
+		// status is a V2 status (abandoned collapses to completed).
+		const plan = planNotifications(outputs);
+		expect(plan).toHaveLength(1);
+		expect(plan[0]).toEqual({
+			threadId: "thread-1",
+			turnId: "turn-1",
+			explanation: null,
+			plan: [
+				{ step: "pending task", status: "pending" },
+				{ step: "active task", status: "inProgress" },
+				{ step: "done task", status: "completed" },
+				{ step: "dropped task", status: "completed" },
+			],
+		});
+		// And: the original tool item still completes normally alongside the plan.
+		expect(outputs.some((output) => output.method === "item/completed")).toBe(true);
+	});
+
+	it("emits an empty plan when the todo tool clears all phases", () => {
+		// Given: a todo rm result whose details carry an empty phases array.
+		const result = {
+			content: [{ type: "text", text: "cleared" }],
+			details: { op: "rm", storage: "memory", phases: [] },
+		};
+
+		// When: the events are projected.
+		const outputs = collect(toolEvents("todo", result));
+
+		// Then: the cleared plan state is emitted as an empty step list.
+		const plan = planNotifications(outputs);
+		expect(plan).toHaveLength(1);
+		expect(plan[0]?.plan).toEqual([]);
+	});
+
+	it("emits no turn/plan/updated for a turn without the todo tool", () => {
+		// Given: a bash tool execution with no plan state.
+		const result = { content: [{ type: "text", text: "ok" }], details: { exitCode: 0 } };
+
+		// When: the events are projected.
+		const outputs = collect(toolEvents("bash", result));
+
+		// Then: no plan notification is invented.
+		expect(planNotifications(outputs)).toEqual([]);
+	});
+
+	it("emits no turn/plan/updated when the todo result lacks structured phases", () => {
+		// Given: a todo tool error result with no details payload.
+		const result = { content: [{ type: "text", text: "Missing op" }] };
+
+		// When: the events are projected.
+		const outputs = collect(toolEvents("todo", result));
+
+		// Then: missing details produce no notification and no invented steps.
+		expect(planNotifications(outputs)).toEqual([]);
+	});
+
+	it("skips malformed phases and unknown statuses without crashing", () => {
+		// Given: todo details mixing valid tasks with malformed phases and an unknown status.
+		const result = {
+			content: [{ type: "text", text: "summary" }],
+			details: {
+				phases: [
+					"not-a-phase",
+					{ name: "Broken" },
+					{
+						name: "Setup",
+						tasks: [
+							{ content: "real task", status: "pending" },
+							{ content: "mystery task", status: "mystery" },
+							{ status: "pending" },
+						],
+					},
+				],
+			},
+		};
+
+		// When: the events are projected.
+		const outputs = collect(toolEvents("todo", result));
+
+		// Then: only the well-formed task is projected; nothing is invented.
+		const plan = planNotifications(outputs);
+		expect(plan).toHaveLength(1);
+		expect(plan[0]?.plan).toEqual([{ step: "real task", status: "pending" }]);
+	});
+});

--- a/packages/coding-agent/test/suite/app-server-thread-rollback.test.ts
+++ b/packages/coding-agent/test/suite/app-server-thread-rollback.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { ThreadEntry } from "../../src/modes/app-server/threads/registry.ts";
+import type { TurnLog } from "../../src/modes/app-server/threads/turn-log.ts";
+import {
+	cleanupRoots,
+	createHarness,
+	createHarnessForRoot,
+	dataArray,
+	objectAt,
+	responseResult,
+	writePersistedSession,
+} from "./app-server-thread-handlers-harness.ts";
+
+afterEach(async () => {
+	await cleanupRoots();
+});
+
+describe("app-server thread/rollback", () => {
+	it("drops the requested wire turns while retaining abandoned session entries", async () => {
+		// Given: a loaded thread with two completed turns and persisted pre-turn leaf checkpoints.
+		const { connection, registry, root, threads, turnLog } = await createHarness();
+		const entry = await threads.createThread({ cwd: root });
+		recordCompletedTurn(entry, turnLog, "turn-1");
+		recordCompletedTurn(entry, turnLog, "turn-2");
+		const retainedEntryIds = entry.session.sessionManager.getEntries().map((sessionEntry) => sessionEntry.id);
+
+		// When: the client rolls back the latest turn.
+		const response = await registry.dispatch(connection, {
+			id: 1,
+			method: "thread/rollback",
+			params: { threadId: entry.id, numTurns: 1 },
+		});
+
+		// Then: only one wire turn remains and every abandoned session entry is retained.
+		expect(dataArray(objectAt(responseResult(response), "thread"), "turns")).toHaveLength(1);
+		expect(entry.session.sessionManager.getEntries().map((sessionEntry) => sessionEntry.id)).toEqual(
+			expect.arrayContaining(retainedEntryIds),
+		);
+	});
+
+	it("persists the selected leaf across unload and resume", async () => {
+		// Given: a two-turn thread rolled back to the first turn.
+		const { connection, registry, root, threads, turnLog } = await createHarness();
+		const threadId = "56565656-5656-4656-8656-565656565656";
+		await writePersistedSession(root, threadId);
+		const entry = await threads.resumeThread(threadId);
+		const retainedTurnEntryId = recordCompletedTurn(entry, turnLog, "turn-1");
+		const abandonedTurnEntryId = recordCompletedTurn(entry, turnLog, "turn-2");
+		await registry.dispatch(connection, {
+			id: 2,
+			method: "thread/rollback",
+			params: { threadId: entry.id, numTurns: 1 },
+		});
+		expect(threads.unloadThread(entry.id)).toBe(true);
+
+		// When: a fresh registry with an empty TurnLog resumes the persisted thread.
+		const restarted = createHarnessForRoot(root);
+		const response = await restarted.registry.dispatch(restarted.connection, {
+			id: 3,
+			method: "thread/resume",
+			params: { threadId: entry.id },
+		});
+
+		// Then: the resumed snapshot and persisted branch both reflect the selected cutoff.
+		expect(dataArray(objectAt(responseResult(response), "thread"), "turns")).toHaveLength(1);
+		const resumedBranchIds = restarted.threads
+			.getLoadedThread(entry.id)
+			.session.sessionManager.getBranch()
+			.map((sessionEntry) => sessionEntry.id);
+		expect(resumedBranchIds).toContain(retainedTurnEntryId);
+		expect(resumedBranchIds).not.toContain(abandonedTurnEntryId);
+	});
+
+	it("returns an RPC error when the thread does not exist", async () => {
+		// Given: a registry without the requested thread.
+		const { connection, registry } = await createHarness();
+
+		// When: rollback targets an unknown thread id.
+		const response = await registry.dispatch(connection, {
+			id: 4,
+			method: "thread/rollback",
+			params: { threadId: "missing-thread", numTurns: 1 },
+		});
+
+		// Then: dispatch returns a scoped RPC error instead of crashing.
+		expect(response).toMatchObject({
+			id: 4,
+			error: { code: -32600, message: expect.stringContaining("thread not found") },
+		});
+	});
+
+	it("returns an RPC error when a turn is active", async () => {
+		// Given: a loaded thread with an active turn.
+		const { connection, registry, root, threads } = await createHarness();
+		const entry = await threads.createThread({ cwd: root });
+		entry.activeTurn = { turnId: "active-turn", startedAt: "2026-08-19T00:00:00.000Z" };
+
+		// When: rollback targets the active thread.
+		const response = await registry.dispatch(connection, {
+			id: 5,
+			method: "thread/rollback",
+			params: { threadId: entry.id, numTurns: 1 },
+		});
+
+		// Then: dispatch rejects the mutation with an RPC error.
+		expect(response).toMatchObject({
+			id: 5,
+			error: { code: -32600, message: expect.stringContaining("active turn") },
+		});
+	});
+
+	it("returns an RPC error when threadId is missing", async () => {
+		// Given: a valid rollback count without a thread identifier.
+		const { connection, registry } = await createHarness();
+
+		// When: rollback receives malformed params.
+		const response = await registry.dispatch(connection, {
+			id: 6,
+			method: "thread/rollback",
+			params: { numTurns: 1 },
+		});
+
+		// Then: dispatch returns an invalid-params RPC error.
+		expect(response).toMatchObject({ id: 6, error: { code: -32600 } });
+	});
+
+	it("returns an RPC error when numTurns is not a positive integer", async () => {
+		// Given: an existing idle thread.
+		const { connection, registry, root, threads } = await createHarness();
+		const entry = await threads.createThread({ cwd: root });
+
+		// When: rollback receives an invalid turn count.
+		const response = await registry.dispatch(connection, {
+			id: 7,
+			method: "thread/rollback",
+			params: { threadId: entry.id, numTurns: 0 },
+		});
+
+		// Then: dispatch returns an invalid-params RPC error.
+		expect(response).toMatchObject({ id: 7, error: { code: -32600 } });
+	});
+});
+
+function recordCompletedTurn(entry: ThreadEntry, turnLog: TurnLog, turnId: string): string {
+	const rollbackLeafId = entry.session.sessionManager.getLeafId();
+	const sessionEntryId = entry.session.sessionManager.appendMessage({
+		role: "user",
+		content: turnId,
+		timestamp: Date.parse("2026-08-19T00:00:00.000Z"),
+	});
+	turnLog.recordTurn(entry.id, {
+		turnId,
+		startedAt: "2026-08-19T00:00:00.000Z",
+		status: "completed",
+		rollbackLeafId,
+	});
+	return sessionEntryId;
+}

--- a/packages/coding-agent/test/suite/app-server-wire-thread.test.ts
+++ b/packages/coding-agent/test/suite/app-server-wire-thread.test.ts
@@ -82,7 +82,7 @@ describe("app-server wire thread history", () => {
 				additionalDetails: null,
 			},
 			startedAt: 1_784_505_600,
-			completedAt: 1_784_505_601.25,
+			completedAt: 1_784_505_601,
 			durationMs: 1_250,
 		});
 	});

--- a/packages/coding-agent/test/suite/regressions/codex-appserver-integer-timestamps.test.ts
+++ b/packages/coding-agent/test/suite/regressions/codex-appserver-integer-timestamps.test.ts
@@ -18,6 +18,7 @@ const wireThread: WireThread = {
 
 const loggedTurn: LoggedTurn = {
 	turnId: "turn-1",
+	rollbackLeafId: null,
 	startedAt: "2026-07-20T00:00:00.125Z",
 	completedAt: "2026-07-20T00:00:01.250Z",
 	durationMs: 1_125,

--- a/packages/coding-agent/test/suite/regressions/codex-appserver-integer-timestamps.test.ts
+++ b/packages/coding-agent/test/suite/regressions/codex-appserver-integer-timestamps.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { buildTurn } from "../../../src/modes/app-server/threads/turn-runtime.ts";
+import { buildWireThread, loggedTurnToWireTurn } from "../../../src/modes/app-server/threads/wire-thread.ts";
+import type { WireThread } from "../../../src/modes/app-server/threads/registry.ts";
+import { TurnLog, type LoggedTurn } from "../../../src/modes/app-server/threads/turn-log.ts";
+
+const wireThread: WireThread = {
+	id: "thread-1",
+	sessionId: "session-1",
+	sessionPath: "/tmp/senpi-codex-integer-timestamps.session",
+	cwd: process.cwd(),
+	createdAt: "2026-07-20T00:00:00.125Z",
+	updatedAt: "2026-07-20T00:00:01.250Z",
+	status: { type: "idle" },
+	preview: null,
+	name: null,
+};
+
+const loggedTurn: LoggedTurn = {
+	turnId: "turn-1",
+	startedAt: "2026-07-20T00:00:00.125Z",
+	completedAt: "2026-07-20T00:00:01.250Z",
+	durationMs: 1_125,
+	error: null,
+	status: "completed",
+	items: [],
+};
+
+describe("Codex app-server integer timestamps", () => {
+	it("returns integer thread timestamps for millisecond-bearing and invalid ISO values", async () => {
+		// Given: a wire thread with millisecond-bearing timestamps and an invalid recency timestamp.
+		// When: the public thread projection builds the app-server response.
+		const projected = await buildWireThread(wireThread, new TurnLog(), false, {
+			recencyAt: "not-an-iso-date",
+		});
+
+		// Then: all thread timestamp fields are integer epoch seconds, with invalid input as zero.
+		expect(projected.createdAt).toBe(1_784_505_600);
+		expect(projected.updatedAt).toBe(1_784_505_601);
+		expect(projected.recencyAt).toBe(0);
+		expect(Number.isInteger(projected.createdAt)).toBe(true);
+		expect(Number.isInteger(projected.updatedAt)).toBe(true);
+		expect(Number.isInteger(projected.recencyAt)).toBe(true);
+
+		const invalid = await buildWireThread(
+			{ ...wireThread, createdAt: "invalid", updatedAt: "invalid" },
+			new TurnLog(),
+			false,
+		);
+		expect(invalid.createdAt).toBe(0);
+		expect(invalid.updatedAt).toBe(0);
+	});
+
+	it("returns integer turn timestamps for millisecond-bearing and invalid ISO values", () => {
+		// Given: a logged turn whose lifecycle timestamps include milliseconds.
+		// When: the public turn projection builds the app-server response.
+		const projected = loggedTurnToWireTurn(loggedTurn);
+
+		// Then: both turn timestamp fields are integer epoch seconds.
+		expect(projected.startedAt).toBe(1_784_505_600);
+		expect(projected.completedAt).toBe(1_784_505_601);
+		expect(Number.isInteger(projected.startedAt)).toBe(true);
+		expect(Number.isInteger(projected.completedAt)).toBe(true);
+
+		// Given: invalid lifecycle timestamps.
+		// When: the public turn projection handles them.
+		const invalid = loggedTurnToWireTurn({ ...loggedTurn, startedAt: "invalid", completedAt: "invalid" });
+
+		// Then: invalid timestamps use the wire fallback zero.
+		expect(invalid.startedAt).toBe(0);
+		expect(invalid.completedAt).toBe(0);
+	});
+
+	it("returns integer timestamps for live in-process turns", () => {
+		// Given: a live turn with millisecond epoch inputs and no completion yet.
+		// When: the live turn wire payload is built.
+		const inProgress = buildTurn("turn-live", "inProgress", 1_784_505_600_125, null, []);
+
+		// Then: startedAt is an integer and completedAt remains null.
+		expect(inProgress.startedAt).toBe(1_784_505_600);
+		expect(Number.isInteger(inProgress.startedAt)).toBe(true);
+		expect(inProgress.completedAt).toBeNull();
+
+		// Given: the same turn completes at a millisecond-bearing epoch time.
+		// When: the completed live payload is built.
+		const completed = buildTurn("turn-live", "completed", 1_784_505_600_125, 1_784_505_601_250, []);
+
+		// Then: both live timestamp fields are integer epoch seconds.
+		expect(completed.startedAt).toBe(1_784_505_600);
+		expect(completed.completedAt).toBe(1_784_505_601);
+		expect(Number.isInteger(completed.startedAt)).toBe(true);
+		expect(Number.isInteger(completed.completedAt)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/codex-appserver-interrupt-completed.test.ts
+++ b/packages/coding-agent/test/suite/regressions/codex-appserver-interrupt-completed.test.ts
@@ -1,0 +1,275 @@
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, it } from "vitest";
+import type { RpcEnvelope } from "../../../src/modes/app-server/rpc/envelope.ts";
+import { createAppServerRuntime } from "../../../src/modes/app-server/runtime.ts";
+import { configureModeEnv, createDeferred, scratchRoot, seedFauxConfig } from "../app-server-mode-harness.ts";
+
+const runtimes: Array<ReturnType<typeof createAppServerRuntime>> = [];
+const fauxProviders: Array<{ unregister(): void }> = [];
+
+describe("codex app-server interrupt -> turn/completed(interrupted)", () => {
+	afterEach(() => {
+		while (runtimes.length > 0) {
+			runtimes.pop()?.dispose();
+		}
+		while (fauxProviders.length > 0) {
+			fauxProviders.pop()?.unregister();
+		}
+	});
+
+	it("writes the turn/interrupt response before turn/completed interrupted with emittedAtMs", async () => {
+		// Given: an in-process app-server whose faux provider is held mid-turn.
+		const providerEntered = createDeferred();
+		const hold = createDeferred();
+		const client = await startClient({
+			schedulerHook: async () => {
+				providerEntered.resolve();
+				await hold.promise;
+			},
+			assistantText: "should not finish before interrupt",
+		});
+		try {
+			const { threadId, turnId } = await startGatedTurn(client, providerEntered);
+
+			// When: the client interrupts the still-active turn.
+			const interruptStartedAt = client.frames.length;
+			await client.request(5, "turn/interrupt", { threadId, turnId });
+
+			// Then: the interrupt RPC result precedes turn/completed(interrupted) and the notification is stamped.
+			const interruptSlice = client.frames.slice(interruptStartedAt);
+			const responseIndex = interruptSlice.findIndex((frame) => "id" in frame && frame.id === 5);
+			const completedIndex = interruptSlice.findIndex(isTurnCompleted);
+			expect(responseIndex).toBeGreaterThan(-1);
+			expect(completedIndex).toBeGreaterThan(responseIndex);
+			expect(interruptSlice[responseIndex]).toEqual({ id: 5, result: {} });
+			const completed = interruptSlice[completedIndex];
+			expect(completed).toMatchObject({
+				method: "turn/completed",
+				params: {
+					threadId,
+					turn: { id: turnId, status: "interrupted" },
+				},
+			});
+			expect(isStampedNotification(completed)).toBe(true);
+			expect(interruptSlice.some(isTurnAborted)).toBe(false);
+		} finally {
+			hold.resolve();
+		}
+	});
+
+	it("still emits turn/completed with status completed on a normal finish", async () => {
+		// Given: an in-process app-server whose faux provider will finish the turn.
+		const client = await startClient({ assistantText: "normal completion" });
+		const completed = client.frames.waitUntil(isTurnCompleted);
+
+		// When: a turn starts and the faux provider is allowed to finish.
+		const started = await startTurn(client, "finish normally");
+
+		// Then: the terminal notification stays completed and is still stamped.
+		const notification = await completed;
+		expect(notification).toMatchObject({
+			method: "turn/completed",
+			params: {
+				threadId: started.threadId,
+				turn: { id: started.turnId, status: "completed" },
+			},
+		});
+		expect(isStampedNotification(notification)).toBe(true);
+		expect(client.frames.some(isTurnAborted)).toBe(false);
+	});
+
+	it("returns a no-op interrupt result without a spurious turn/completed when no turn is active", async () => {
+		// Given: a subscribed idle thread with no active turn.
+		const client = await startClient({ assistantText: "unused" });
+		const threadId = await startThread(client);
+
+		// When: the client interrupts a turn that is not running.
+		const interruptStartedAt = client.frames.length;
+		await client.request(4, "turn/interrupt", { threadId, turnId: "no-active-turn" });
+
+		// Then: the documented no-op result is returned and no terminal turn notification is synthesized.
+		const interruptSlice = client.frames.slice(interruptStartedAt);
+		expect(interruptSlice.filter((frame) => "id" in frame && frame.id === 4)).toEqual([{ id: 4, result: {} }]);
+		expect(interruptSlice.some(isTurnCompleted)).toBe(false);
+		expect(interruptSlice.some(isTurnAborted)).toBe(false);
+		expect(client.frames.some(isTurnCompleted)).toBe(false);
+	});
+});
+
+type Client = {
+	readonly runtime: ReturnType<typeof createAppServerRuntime>;
+	readonly faux: ReturnType<typeof registerFauxProvider>;
+	readonly frames: FrameSink;
+	readonly root: string;
+	request(id: number, method: string, params?: unknown): Promise<void>;
+};
+
+async function startClient(options: {
+	readonly assistantText: string;
+	readonly schedulerHook?: () => void | Promise<void>;
+}): Promise<Client> {
+	const root = await scratchRoot();
+	const faux = registerFauxProvider({ schedulerHook: options.schedulerHook });
+	faux.setResponses([fauxAssistantMessage(options.assistantText)]);
+	await seedFauxConfig(root, faux);
+	configureModeEnv(root);
+	const runtime = createAppServerRuntime(() => undefined);
+	runtimes.push(runtime);
+	fauxProviders.push(faux);
+	const frames = new FrameSink();
+	const connection = runtime.core.addConnection({
+		id: "interrupt-client",
+		transportKind: "stdio",
+		send: (message) => {
+			frames.push(message);
+		},
+		close: () => undefined,
+	});
+	const request = async (id: number, method: string, params?: unknown): Promise<void> => {
+		await runtime.core.receive(connection.id, { kind: "request", message: { id, method, params } });
+	};
+	await request(1, "initialize", {
+		clientInfo: { name: "codex-interrupt-pin", title: "Codex interrupt pin", version: "0.0.1" },
+		capabilities: { experimentalApi: true, requestAttestation: false },
+	});
+	return { runtime, faux, frames, root, request };
+}
+
+async function startThread(client: Client): Promise<string> {
+	await client.request(2, "thread/start", { cwd: client.root });
+	return threadIdFromResponse(client.frames.mustFind((frame) => "id" in frame && frame.id === 2));
+}
+
+async function startTurn(client: Client, text: string): Promise<{ readonly threadId: string; readonly turnId: string }> {
+	const threadId = await startThread(client);
+	await client.request(3, "turn/start", { threadId, input: [{ type: "text", text }] });
+	const turnId = turnIdFromResponse(client.frames.mustFind((frame) => "id" in frame && frame.id === 3));
+	return { threadId, turnId };
+}
+
+async function startGatedTurn(
+	client: Client,
+	providerEntered: { readonly promise: Promise<void> },
+): Promise<{ readonly threadId: string; readonly turnId: string }> {
+	const started = await startTurn(client, "interrupt me");
+	await withTimeout(providerEntered.promise, "faux provider did not enter the gated stream");
+	return started;
+}
+
+function isTurnCompleted(frame: RpcEnvelope): frame is RpcEnvelope & {
+	readonly method: "turn/completed";
+	readonly emittedAtMs?: number;
+} {
+	return "method" in frame && !("id" in frame) && frame.method === "turn/completed";
+}
+
+function isTurnAborted(frame: RpcEnvelope): boolean {
+	return "method" in frame && frame.method === "turn/aborted";
+}
+
+function isStampedNotification(frame: RpcEnvelope | undefined): boolean {
+	return frame !== undefined && "emittedAtMs" in frame && Number.isFinite(frame.emittedAtMs);
+}
+
+function threadIdFromResponse(frame: RpcEnvelope): string {
+	return stringAt(objectAt(successResult(frame), "thread"), "id");
+}
+
+function turnIdFromResponse(frame: RpcEnvelope): string {
+	return stringAt(objectAt(successResult(frame), "turn"), "id");
+}
+
+function successResult(frame: RpcEnvelope): Record<string, unknown> {
+	if (!("result" in frame)) {
+		throw new Error("expected JSON-RPC success response");
+	}
+	return objectValue(frame.result);
+}
+
+function objectAt(value: Record<string, unknown>, key: string): Record<string, unknown> {
+	return objectValue(value[key]);
+}
+
+function stringAt(value: Record<string, unknown>, key: string): string {
+	const child = value[key];
+	if (typeof child !== "string") {
+		throw new Error(`Expected ${key} to be a string`);
+	}
+	return child;
+}
+
+function objectValue(value: unknown): Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		throw new Error("Expected an object");
+	}
+	return Object.fromEntries(Object.entries(value));
+}
+
+function withTimeout(promise: Promise<void>, message: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(() => reject(new Error(message)), 5_000);
+		promise.then(
+			() => {
+				clearTimeout(timeout);
+				resolve();
+			},
+			(error: unknown) => {
+				clearTimeout(timeout);
+				reject(error);
+			},
+		);
+	});
+}
+
+class FrameSink {
+	readonly frames: RpcEnvelope[] = [];
+	private readonly listeners = new Set<(frame: RpcEnvelope) => void>();
+
+	get length(): number {
+		return this.frames.length;
+	}
+
+	push(frame: RpcEnvelope): void {
+		this.frames.push(frame);
+		for (const listener of this.listeners) {
+			listener(frame);
+		}
+	}
+
+	slice(start: number): RpcEnvelope[] {
+		return this.frames.slice(start);
+	}
+
+	some(predicate: (frame: RpcEnvelope) => boolean): boolean {
+		return this.frames.some(predicate);
+	}
+
+	mustFind(predicate: (frame: RpcEnvelope) => boolean): RpcEnvelope {
+		const frame = this.frames.find(predicate);
+		if (frame === undefined) {
+			throw new Error("expected matching frame");
+		}
+		return frame;
+	}
+
+	waitUntil(predicate: (frame: RpcEnvelope) => boolean): Promise<RpcEnvelope> {
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.listeners.delete(onFrame);
+				reject(new Error("expected frame was not observed"));
+			}, 5_000);
+			const onFrame = (frame: RpcEnvelope): void => {
+				if (!predicate(frame)) {
+					return;
+				}
+				clearTimeout(timeout);
+				this.listeners.delete(onFrame);
+				resolve(frame);
+			};
+			this.listeners.add(onFrame);
+			for (const existing of this.frames) {
+				onFrame(existing);
+			}
+		});
+	}
+}

--- a/packages/coding-agent/test/suite/regressions/codex-appserver-model-list-after-account-read.test.ts
+++ b/packages/coding-agent/test/suite/regressions/codex-appserver-model-list-after-account-read.test.ts
@@ -1,0 +1,110 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const temporaryRoots: string[] = [];
+const APP_SERVER_SCENARIO = `
+const { createAppServerRuntime } = await import("./src/modes/app-server/runtime.ts");
+const accountFirst = process.argv[1] === "account-first";
+const sent = [];
+const runtime = createAppServerRuntime(() => undefined);
+const connection = runtime.core.addConnection({
+  id: accountFirst ? "account-first" : "direct",
+  transportKind: "stdio",
+  send: (message) => sent.push(message),
+  close: () => undefined,
+});
+let nextId = 1;
+const request = async (method, params) => {
+  const id = nextId++;
+  await runtime.core.receive(connection.id, {
+    kind: "request",
+    message: params === undefined ? { id, method } : { id, method, params },
+  });
+  const response = sent.find((message) => "id" in message && message.id === id);
+  if (response === undefined || !("result" in response)) {
+    throw new Error(method + " failed: " + JSON.stringify(response));
+  }
+  return response.result;
+};
+try {
+  await request("initialize", {
+    clientInfo: { name: "t3code_desktop", title: "T3 Code", version: "0" },
+    capabilities: { experimentalApi: true, requestAttestation: false },
+  });
+  await runtime.core.receive(connection.id, { kind: "notification", message: { method: "initialized" } });
+  if (accountFirst) await request("account/read", {});
+  const result = await request("model/list", {});
+  const ids = result.data.map((model) => model.id).sort();
+  process.stdout.write(JSON.stringify(ids));
+} finally {
+  runtime.core.removeConnection(connection.id);
+  runtime.dispose();
+}
+`;
+
+afterEach(async () => {
+	await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function runModelListSequence(root: string, accountFirst: boolean): Promise<readonly string[]> {
+	const home = join(root, "home");
+	const agentDir = join(root, "agent");
+	await mkdir(home, { recursive: true });
+	await mkdir(agentDir, { recursive: true });
+	await writeFile(
+		join(agentDir, "auth.json"),
+		JSON.stringify({ anthropic: { type: "api_key", key: "fake-isolated-key" } }),
+		{ mode: 0o600 },
+	);
+	await writeFile(join(agentDir, "models.json"), JSON.stringify({ providers: {} }), { mode: 0o600 });
+	const { stdout } = await execFileAsync(
+		process.execPath,
+		[
+			"--import",
+			"tsx",
+			"--input-type=module",
+			"--eval",
+			APP_SERVER_SCENARIO,
+			accountFirst ? "account-first" : "direct",
+		],
+		{
+			cwd: new URL("../../../", import.meta.url),
+			env: {
+				HOME: home,
+				PATH: process.env.PATH ?? "",
+				SENPI_CODING_AGENT_DIR: agentDir,
+				SENPI_CODING_AGENT_SESSION_DIR: join(root, "sessions"),
+				PI_OFFLINE: "1",
+				NO_COLOR: "1",
+			},
+		},
+	);
+	const parsed: unknown = JSON.parse(stdout);
+	if (!Array.isArray(parsed) || !parsed.every((id) => typeof id === "string")) {
+		throw new Error("model/list scenario returned invalid model ids");
+	}
+	return parsed;
+}
+
+describe("Codex app-server model/list after account/read", () => {
+	it("returns the same configured catalog when account/read runs first", async () => {
+		// Given: two fresh real app-server processes with identical isolated on-disk auth and model configuration.
+		const root = await mkdtemp(join(tmpdir(), "senpi-model-list-account-read-"));
+		temporaryRoots.push(root);
+
+		// When: one process lists directly and the other follows T3's account/read-first request order.
+		const [directIds, accountFirstIds] = await Promise.all([
+			runModelListSequence(join(root, "direct"), false),
+			runModelListSequence(join(root, "account-first"), true),
+		]);
+
+		// Then: account/read preserves the same non-empty model catalog.
+		expect(directIds.length).toBeGreaterThan(0);
+		expect(accountFirstIds).toEqual(directIds);
+	});
+});


### PR DESCRIPTION
## Summary

Makes omo/senpi's Codex-compatible app-server speak the protocol T3 Code already implements. T3 Code is not modified.

T3 can now:

- auto-populate models after `account/read`
- spawn with Codex-style `-c mcp_servers.*` without exit 2
- see integer epoch-second timestamps (V2 int64)
- interrupt a turn and receive `turn/completed` with `status: "interrupted"` (never `turn/aborted`)
- restore a checkpoint via append-only `thread/rollback`
- render a plan panel from `turn/plan/updated` (todo-tool phases)
- attach T3's browser MCP via process-local overrides + `config/mcpServer/reload`

## What changed

1. **Integer timestamps** — `isoSeconds` and live `buildTurn` floor to epoch seconds so T3's int64 schema accepts `createdAt` / `startedAt` / `completedAt`.
2. **`-c key=value` parser** — repeatable Codex-style overrides; raw quoted values preserved.
3. **`model/list` after `account/read`** — second `AuthStorage` now copies shared read-state data before the unchanged-revision early return (13 models instead of 0).
4. **`thread/rollback`** — branch/leaf-move; abandoned SessionManager history retained; wire view truncated.
5. **MCP overrides + reload** — `mcp_servers.<name>.url` + `bearer_token_env_var` become process-local HTTP servers via existing `McpService`; `config/mcpServer/reload` returns `{}`; no `mcp.json` written.
6. **Interrupt contract pin** — response `{}` before `turn/completed(interrupted)` with `emittedAtMs`; idle interrupt is a no-op.
7. **`turn/plan/updated`** — projected at the existing `tool_execution_end` seam from todo `details.phases` (`abandoned` → `completed`).

## Verification

- F1 Plan compliance: APPROVE (todo → evidence → conventional commit table)
- F2 Code quality: APPROVE (`npm run check` exit 0; 12 files / 43 tests)
- F3 Real CLI QA: APPROVE (T3 JSON-RPC stdio sequence against patched CLI; integer timestamps; catalog length 1; `authorizationVerified`; interrupt-after-response; rollback 2→1; reload `{}`; no tokens/headers)
- F4 Scope fidelity: APPROVE (32 files, 0 out of scope; no `turn/aborted` emission, no compaction/exec, no `protocol/generated/**`)

## Test plan

- [x] Focused coding-agent suites for todos 1–7
- [x] `npm run check` on the integration branch
- [x] Isolated stdio app-server sequence matching T3's initialize → account/read → model/list → thread/start → todo+MCP turn → interrupt → rollback → mcp status/reload
- [ ] Optional post-merge: user's T3 Code instance (not an acceptance gate)

## Notes

- Compaction, exec, `thread/compacted`, and generated protocol files are untouched.
- SessionManager stays append-only; rollback is a leaf move.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the Codex-compatible app-server in line with T3 Code’s protocol so T3 can start, list models, and run turns without patches. Old behavior emitted ISO timestamps, lacked Codex-style `-c` overrides, returned empty models after `account/read`, had no `thread/rollback`, and sometimes used `turn/aborted`; new behavior fixes all of these and adds `turn/plan/updated` from the todo tool.

- Integer timestamps in all thread/turn fields (old: ISO strings/fractions; new: epoch seconds; invalid inputs → 0).
- Codex-style `-c <key>=<value>` parsing; complete `mcp_servers.<name>.(url|bearer_token_env_var)` pairs become process-local HTTP MCP servers; `config/mcpServer/reload` reconnects without writing mcp.json; missing bearer env reports `authStatus: "notLoggedIn"` but is non-fatal.
- `model/list` now returns configured models even when T3 calls `account/read` first (fixes reused auth snapshot init).
- `thread/rollback` restores a prior checkpoint by moving the session leaf and truncating only the in-memory wire view; abandoned session entries remain persisted; returns the reduced thread snapshot.
- Interrupts return `{}` before `turn/completed` with `status: "interrupted"` and `emittedAtMs`; idle interrupts are no-ops; `turn/aborted` is never emitted.
- Emits `turn/plan/updated` from the todo tool at `tool_execution_end`, mapping `pending|in_progress|completed|abandoned` → `pending|inProgress|completed|completed`; turns without a plan emit nothing.

- Migration: Listeners for aborted turns must now handle `turn/completed` with `status: "interrupted"`. Integrations using MCP over HTTP should supply both `-c mcp_servers.<name>.url` and `-c mcp_servers.<name>.bearer_token_env_var` and can call `config/mcpServer/reload` to reattach.

<sup>Written for commit 2ff718ed0223866e14c3decf77d718850fa3b632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Validation against official codex-rs (post-review audit)

All 7 behaviors were re-validated against OpenAI's **official** `codex-rs/app-server-protocol` source ([`openai/codex` @ `956f590`](https://github.com/openai/codex/tree/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/app-server-protocol)) — not just T3's client re-implementation. **7/7 MATCH, zero wire drift.**

| # | Behavior | Verdict | Official source |
|---|---|---|---|
| 1 | Integer epoch-second timestamps | MATCH — `i64` unix secs, nullable where we emit null | [`v2/thread_data.rs:177-291`](https://github.com/openai/codex/blob/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs#L177-L291) |
| 2 | `-c key=value` overrides | MATCH — deliberate subset of `CliConfigOverrides` (only the two-token `-c` form T3 emits; no `--config`/TOML typing) | [`utils/cli/src/config_override.rs`](https://github.com/openai/codex/blob/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/utils/cli/src/config_override.rs#L1-L74) |
| 3 | `model/list` `{data, nextCursor}` | MATCH | [`v2/model.rs:35-110`](https://github.com/openai/codex/blob/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/app-server-protocol/src/protocol/v2/model.rs#L35-L110) |
| 4 | `thread/rollback` (`threadId` + `numTurns` → `{thread}` with turns) | MATCH — see deprecation note below | [`v2/thread.rs:425-444`](https://github.com/openai/codex/blob/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L425-L444) |
| 5 | `config/mcpServer/reload` → `{}` | MATCH — `McpServerRefreshResponse {}` | [`v2/mcp.rs:167-176`](https://github.com/openai/codex/blob/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs#L167-L176) |
| 6 | Interrupt → `turn/completed(status: "interrupted")`, no `turn/aborted` | MATCH — `TurnStatus::{Completed, Interrupted, Failed, InProgress}`; `turn/aborted` does not exist in the official notification registry | [`v2/turn.rs:22-113`](https://github.com/openai/codex/blob/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L22-L113) |
| 7 | `turn/plan/updated` with `pending/inProgress/completed` | MATCH — official enum has no `abandoned`, so our `abandoned → completed` collapse is correct | [`v2/turn.rs:225-253`](https://github.com/openai/codex/blob/956f590ad549e75913894614ce0cbec4d5fd677a/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L225-L253) |

**Forward-compat note for the merger:** official main now marks `thread/rollback` as `DEPRECATED: will be removed soon`. It is valid against this repo's pinned protocol (`9fc715c0`, 2026-07-22) and T3 consumes it today, but the next protocol regen should watch for its replacement. This is post-pin upstream evolution, not drift in this PR.