### PR TITLE
fix(agent): release aborted tool execution instead of hanging the run

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Aborting a run now releases a tool call that ignores its abort signal and never settles. Tool execution races the run's abort signal instead of awaiting the tool alone, so the run reaches `agent_end` and the session goes idle instead of hanging with an unresponsive ESC while the TUI shows `Running <tool>` ([#970](https://github.com/code-yeongyu/senpi/pull/970)).
+
 ### Removed
 
 ## [2026.8.18-3] - 2026-08-18

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -1104,6 +1104,21 @@ async function prepareToolCall(
 	}
 }
 
+/**
+ * Resolves as soon as `signal` aborts, so a tool that never settles and never
+ * observes its signal cannot pin the run forever. Without this the abort has no
+ * wakeup once `execute()` is entered: no `agent_end`, the session never goes
+ * idle, and every queued prompt parks behind the session work barrier while the
+ * TUI shows "Running <tool>" with a dead ESC.
+ */
+function abortReleasePromise(signal: AbortSignal | undefined): Promise<typeof ABORTED> | undefined {
+	if (signal === undefined) return undefined;
+	if (signal.aborted) return Promise.resolve(ABORTED);
+	return new Promise<typeof ABORTED>((resolve) => {
+		signal.addEventListener("abort", () => resolve(ABORTED), { once: true });
+	});
+}
+
 async function executePreparedToolCall(
 	prepared: PreparedToolCall,
 	signal: AbortSignal | undefined,
@@ -1113,28 +1128,31 @@ async function executePreparedToolCall(
 	let acceptingUpdates = true;
 
 	try {
-		const result = await prepared.tool.execute(
-			prepared.toolCall.id,
-			prepared.args as never,
-			signal,
-			(partialResult) => {
-				if (!acceptingUpdates) return;
-				updateEvents.push(
-					Promise.resolve(
-						emit({
-							type: "tool_execution_update",
-							toolCallId: prepared.toolCall.id,
-							toolName: prepared.toolCall.name,
-							args: prepared.toolCall.arguments,
-							partialResult,
-						}),
-					),
-				);
-			},
-		);
+		const execution = prepared.tool.execute(prepared.toolCall.id, prepared.args as never, signal, (partialResult) => {
+			if (!acceptingUpdates) return;
+			updateEvents.push(
+				Promise.resolve(
+					emit({
+						type: "tool_execution_update",
+						toolCallId: prepared.toolCall.id,
+						toolName: prepared.toolCall.name,
+						args: prepared.toolCall.arguments,
+						partialResult,
+					}),
+				),
+			);
+		});
+		const abortRelease = abortReleasePromise(signal);
+		const settled = abortRelease ? await Promise.race([execution, abortRelease]) : await execution;
+		if (settled === ABORTED) {
+			void Promise.resolve(execution).catch(() => undefined);
+			acceptingUpdates = false;
+			await Promise.all(updateEvents);
+			return { result: createErrorToolResult("Tool execution aborted"), isError: true };
+		}
 		acceptingUpdates = false;
 		await Promise.all(updateEvents);
-		return { result, isError: false };
+		return { result: settled, isError: false };
 	} catch (error) {
 		acceptingUpdates = false;
 		await Promise.all(updateEvents);

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,36 @@
 # Changes
 
+## Aborted tool execution releases the run (2026-08-19)
+
+### What changed
+
+- `packages/agent/src/agent-loop.ts`: `executePreparedToolCall` races the tool
+  promise against the run's abort signal instead of awaiting the tool alone. An
+  abort that lands after `execute()` was entered now resolves the call as an
+  error tool result ("Tool execution aborted") rather than waiting forever.
+
+### Why
+
+- Tools receive `signal` but nothing forces them to observe it. A tool that
+  ignores its signal and never settles pinned the await permanently: the run
+  emitted no `tool_execution_end` and no `agent_end`, the session never went
+  idle, the session work barrier stayed held, and queued prompts parked behind
+  it while the TUI showed "Running <tool>" with an unresponsive ESC.
+- Aborting before execution already short-circuited in `prepareToolCall`, so
+  only the mid-execution window hung, which made the failure look intermittent.
+- The provider stream already races its reads against abort in
+  `readNextAssistantEvent`; tool execution now matches that contract.
+
+### Why an extension could not handle it
+
+- The await that strands the run lives inside the loop's tool-execution step.
+  No extension hook observes or interrupts that await, and a tool cannot fix it
+  for the tools that ignore their signal.
+
+### Expected merge conflict zones
+
+- `agent-loop.ts` `executePreparedToolCall` body and the helper directly above it.
+
 ## Cursor exec handlers bind to their owning run (2026-08-18)
 
 ### What changed

--- a/packages/agent/test/tool-abort-release.test.ts
+++ b/packages/agent/test/tool-abort-release.test.ts
@@ -1,0 +1,160 @@
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type Message,
+	type Model,
+	type UserMessage,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { agentLoop } from "../src/agent-loop.ts";
+import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage, AgentTool } from "../src/types.ts";
+
+/**
+ * Aborting a run must release the agent loop even when the executing tool
+ * ignores its abort signal and never settles.
+ *
+ * `executePreparedToolCall` awaits the tool's own promise, so a tool that never
+ * resolves and never observes `signal` pins that await forever: the run never
+ * reaches `agent_end`, the session never goes idle, the session work barrier
+ * stays held, and queued prompts park behind it. In the TUI that is the
+ * "Running <tool> (25m - esc to interrupt)" hang where ESC does nothing.
+ *
+ * The provider stream already races its reads against abort; tool execution did
+ * not. This pins the tool-agnostic form of the bash-specific hang fixed by
+ * "release aborted bash promptly when killed descendants hold stdio".
+ */
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createUsage() {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createModel(): Model<"openai-responses"> {
+	return {
+		id: "mock",
+		name: "mock",
+		api: "openai-responses",
+		provider: "openai",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+function createAssistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: AssistantMessage["stopReason"] = "stop",
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: createUsage(),
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function createUserMessage(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: Date.now() };
+}
+
+function isLlmMessage(message: AgentMessage): message is Message {
+	return message.role === "user" || message.role === "assistant" || message.role === "toolResult";
+}
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(isLlmMessage);
+}
+
+describe("tool abort release", () => {
+	it("ends the run when an aborted tool ignores its signal and never settles", async () => {
+		const toolSchema = Type.Object({});
+		const controller = new AbortController();
+		let toolStarted = false;
+		let announceToolEntered: (() => void) | undefined;
+		const toolEntered = new Promise<void>((resolve) => {
+			announceToolEntered = resolve;
+		});
+
+		const stuckTool: AgentTool<typeof toolSchema, Record<string, never>> = {
+			name: "stuck",
+			label: "Stuck",
+			description: "Never settles and ignores its abort signal",
+			parameters: toolSchema,
+			async execute() {
+				toolStarted = true;
+				announceToolEntered?.();
+				return await new Promise<never>(() => {});
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [stuckTool] };
+		const config: AgentLoopConfig = { model: createModel(), convertToLlm: identityConverter };
+
+		let llmCalls = 0;
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("start")], context, config, controller.signal, () => {
+			llmCalls++;
+			const mockStream = new MockAssistantStream();
+			queueMicrotask(() => {
+				mockStream.push({
+					type: "done",
+					reason: "toolUse",
+					message: createAssistantMessage(
+						[{ type: "toolCall", id: "tool-1", name: "stuck", arguments: {} }],
+						"toolUse",
+					),
+				});
+			});
+			return mockStream;
+		});
+
+		const drain = (async () => {
+			for await (const event of stream) {
+				events.push(event);
+			}
+		})();
+
+		await toolEntered;
+		controller.abort();
+
+		const settled = await Promise.race([
+			drain.then(() => "settled" as const),
+			new Promise<"hung">((resolve) => {
+				setTimeout(() => resolve("hung"), 2_000);
+			}),
+		]);
+
+		expect(toolStarted).toBe(true);
+		expect(llmCalls).toBe(1);
+		expect(settled).toBe("settled");
+		expect(events.filter((event) => event.type === "agent_end")).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- The footer's git branch keeps updating in reftable repositories on systems where `fs.watch` cannot register (descriptor limits, unsupported filesystems): the `tables.list` polling fallback is now armed even when watcher creation fails, instead of being skipped by an early return ([#970](https://github.com/code-yeongyu/senpi/pull/970)).
 - Pasting multiple images in one turn now ships every image: the second and later pastes no longer write into an orphaned payload map, markers pasted in front of existing ones renumber to stay `[Image #1]`..`[Image #k]` in reading order (so `look_at("[Image #N]")` resolves to the exact image the user sees), undo after deleting a marker restores its image along with the marker, and submitting pasted images during compaction now reports the drop instead of silently discarding them.
 
 ### Removed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,37 @@
 # changes
 
+## Reftable branch detection survives unusable fs.watch (2026-08-19)
+
+### What changed
+
+- `packages/coding-agent/src/core/footer-data-provider.ts`: `setupGitWatcher` no longer
+  returns early when a watcher fails to register. The `tables.list` polling fallback is
+  armed whenever the file exists, and its path is recorded after the watcher attempt
+  because a failed registration synchronously clears watcher state.
+- Coverage: `test/footer-data-provider-watch-fallback.test.ts` forces every
+  `watchWithErrorHandler` call to fail the way the real helper does and asserts the branch
+  still refreshes; it times out pre-fix.
+
+### Why
+
+- `watchWithErrorHandler` returns null when `fs.watch` throws (descriptor limits,
+  unsupported filesystems) and only schedules a retry 5s later. Three early returns skipped
+  the polling fallback in exactly that case, so the provider registered nothing and never
+  observed a branch change until a retry happened to succeed. The footer showed a stale
+  branch indefinitely, and the reftable tests timed out nondeterministically under parallel
+  load, where watch capacity is the first thing to run out.
+- Polling exists precisely to cover unreliable `fs.watch`; making it conditional on
+  `fs.watch` succeeding removed the only fallback at the moment it was needed.
+
+### Why an extension could not handle it
+
+- Watcher setup and the branch cache live inside the core footer data provider, which owns
+  the git-watch lifecycle; no extension hook observes watcher registration failures.
+
+### Expected merge conflict zones
+
+- `footer-data-provider.ts` `setupGitWatcher` reftable block.
+
 ## 2026-08-18 - Resume active goals stuck after suppressed continuation-flood loads
 
 ### What changed

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -335,10 +335,6 @@ export class FooterDataProvider {
 			};
 			watchFile(this.headWatchFilePath, { interval: 1000 }, this.headWatchFileListener);
 		}
-		if (!this.headWatcher && !pollGitHead) {
-			return;
-		}
-
 		// In reftable repos, branch switches update files in the reftable directory
 		// instead of HEAD. Watch it separately so the footer picks up those changes.
 		const reftableDir = join(this.gitPaths.commonGitDir, "reftable");
@@ -350,13 +346,9 @@ export class FooterDataProvider {
 				},
 				() => this.handleGitWatcherError(),
 			);
-			if (!this.reftableWatcher) {
-				return;
-			}
 
 			const tablesListPath = join(reftableDir, "tables.list");
 			if (existsSync(tablesListPath)) {
-				this.reftableTablesListPath = tablesListPath;
 				this.reftableTablesListWatcher = watchWithErrorHandler(
 					tablesListPath,
 					() => {
@@ -364,9 +356,11 @@ export class FooterDataProvider {
 					},
 					() => this.handleGitWatcherError(),
 				);
-				if (!this.reftableTablesListWatcher) {
-					return;
-				}
+				// Polling is the fallback for environments where fs.watch is unusable
+				// (descriptor limits, unsupported filesystems), so it must be armed even
+				// when watcher creation just failed. The path is recorded after the
+				// attempt because a failure synchronously clears watcher state.
+				this.reftableTablesListPath = tablesListPath;
 				watchFile(tablesListPath, { interval: 250 }, (current, previous) => {
 					if (
 						current.mtimeMs !== previous.mtimeMs ||

--- a/packages/coding-agent/test/footer-data-provider-watch-fallback.test.ts
+++ b/packages/coding-agent/test/footer-data-provider-watch-fallback.test.ts
@@ -1,0 +1,129 @@
+import { execFile, spawnSync } from "child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let resolvedBranch = "main";
+let branchResolutionDelivered: (() => void) | null = null;
+
+vi.mock("child_process", () => ({
+	execFile: vi.fn(
+		(
+			_command: string,
+			args: readonly string[],
+			_options: unknown,
+			callback: (error: Error | null, stdout: string, stderr: string) => void,
+		) => {
+			if (args[1] === "symbolic-ref") {
+				queueMicrotask(() => {
+					callback(resolvedBranch ? null : new Error("detached"), resolvedBranch ? `${resolvedBranch}\n` : "", "");
+					queueMicrotask(() => branchResolutionDelivered?.());
+				});
+				return;
+			}
+			queueMicrotask(() => callback(new Error("unsupported"), "", ""));
+		},
+	),
+	spawnSync: vi.fn((_command: string, args: readonly string[]) => {
+		if (args[1] === "symbolic-ref") {
+			return { status: resolvedBranch ? 0 : 1, stdout: resolvedBranch ? `${resolvedBranch}\n` : "", stderr: "" };
+		}
+		return { status: 1, stdout: "", stderr: "" };
+	}),
+}));
+
+/**
+ * Every `fs.watch` registration fails, mirroring an environment where watchers
+ * are unavailable or exhausted (descriptor limits, unsupported filesystem).
+ * The real helper invokes `onError` and returns null in exactly this shape.
+ */
+vi.mock("../src/utils/fs-watch.ts", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/utils/fs-watch.ts")>();
+	return {
+		...actual,
+		watchWithErrorHandler: vi.fn((_path: string, _listener: unknown, onError: () => void) => {
+			onError();
+			return null;
+		}),
+	};
+});
+
+import { FooterDataProvider } from "../src/core/footer-data-provider.ts";
+
+function createReftableWorktree(tempDir: string): { worktreeDir: string; reftableDir: string } {
+	const commonGitDir = join(tempDir, "repo", ".git");
+	const gitDir = join(commonGitDir, "worktrees", "src");
+	const worktreeDir = join(tempDir, "worktree");
+	const reftableDir = join(commonGitDir, "reftable");
+
+	mkdirSync(gitDir, { recursive: true });
+	mkdirSync(reftableDir, { recursive: true });
+	mkdirSync(worktreeDir, { recursive: true });
+
+	writeFileSync(join(worktreeDir, ".git"), `gitdir: ${gitDir}\n`);
+	writeFileSync(join(gitDir, "HEAD"), "ref: refs/heads/.invalid\n");
+	writeFileSync(join(gitDir, "commondir"), "../..\n");
+	writeFileSync(join(reftableDir, "tables.list"), "0\n");
+
+	return { worktreeDir, reftableDir };
+}
+
+async function awaitWithTimeout(event: Promise<void>, description: string, timeoutMs = 10000): Promise<void> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			event,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error(`Timed out waiting for ${description}`)), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+describe("FooterDataProvider reftable detection without usable fs.watch", () => {
+	let originalCwd: string;
+	let tempDir: string;
+
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		tempDir = mkdtempSync(join(tmpdir(), "footer-watch-fallback-"));
+		resolvedBranch = "main";
+		branchResolutionDelivered = null;
+		vi.mocked(spawnSync).mockClear();
+		vi.mocked(execFile).mockClear();
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		if (tempDir && existsSync(tempDir)) {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("still refreshes the branch through the polling fallback", async () => {
+		const { worktreeDir, reftableDir } = createReftableWorktree(tempDir);
+		process.chdir(worktreeDir);
+
+		const provider = new FooterDataProvider(worktreeDir);
+		try {
+			expect(provider.getGitBranch()).toBe("main");
+			resolvedBranch = "foo";
+			const onBranchChange = vi.fn();
+			provider.onBranchChange(onBranchChange);
+
+			const resolutionDelivered = new Promise<void>((resolve) => {
+				branchResolutionDelivered = resolve;
+			});
+			writeFileSync(join(reftableDir, "tables.list"), "1\n");
+			await awaitWithTimeout(resolutionDelivered, "the polled reftable refresh to resolve the branch");
+
+			expect(provider.getGitBranch()).toBe("foo");
+			expect(onBranchChange).toHaveBeenCalledTimes(1);
+		} finally {
+			provider.dispose();
+		}
+	}, 30_000);
+});

--- a/packages/coding-agent/test/suite/regressions/970-abort-releases-stuck-tool.test.ts
+++ b/packages/coding-agent/test/suite/regressions/970-abort-releases-stuck-tool.test.ts
@@ -1,0 +1,88 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * A tool that ignores its abort signal and never settles must not wedge the
+ * session: abort() has to return and the next prompt has to be admitted.
+ *
+ * The agent loop used to await the tool's own promise with no race against the
+ * abort signal, so an abort landing after execute() was entered produced no
+ * agent_end, the session never went idle, the session work barrier stayed held,
+ * and every later prompt parked behind it. In the TUI that surfaced as
+ * "Running <tool>" counting up while ESC did nothing.
+ */
+
+const RELEASE_BOUND_MS = 15_000;
+
+async function boundedOutcome(work: Promise<string>, hungLabel: string): Promise<string> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			work,
+			new Promise<string>((resolve) => {
+				timer = setTimeout(() => resolve(hungLabel), RELEASE_BOUND_MS);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+describe("970: aborting a stuck tool releases the session", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("returns from abort and admits the next prompt", async () => {
+		let announceEntered: (() => void) | undefined;
+		const toolEntered = new Promise<void>((resolve) => {
+			announceEntered = resolve;
+		});
+
+		const stuckTool = {
+			name: "stuck_tool",
+			label: "Stuck",
+			description: "Ignores its abort signal and never settles",
+			parameters: Type.Object({}),
+			async execute() {
+				announceEntered?.();
+				return await new Promise<never>(() => {});
+			},
+		};
+
+		const harness = await createHarness({ tools: [stuckTool as never] });
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("stuck_tool", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("queued prompt ran"),
+		]);
+
+		void harness.session.prompt("start the stuck tool").catch(() => undefined);
+		await toolEntered;
+
+		const abortOutcome = await boundedOutcome(
+			harness.session
+				.abort()
+				.then(() => "abort-returned")
+				.catch((error: unknown) => `abort-threw:${String(error).slice(0, 80)}`),
+			"abort-hung",
+		);
+		expect(abortOutcome).toBe("abort-returned");
+
+		const queuedOutcome = await boundedOutcome(
+			harness.session
+				.prompt("queued after abort")
+				.then(() => "queued-admitted")
+				.catch((error: unknown) => `queued-rejected:${String(error).slice(0, 80)}`),
+			"queued-hung",
+		);
+		expect(queuedOutcome).toBe("queued-admitted");
+	}, 60_000);
+});


### PR DESCRIPTION
## Problem

Cancelling work while a tool call was in flight could hang the session permanently. The TUI sat on `Running <tool> (25m • esc to interrupt)` and **ESC did nothing** — the session was unrecoverable without killing the process.

## Root cause

`executePreparedToolCall` awaited the tool's own promise with no race against the abort signal:

```ts
const result = await prepared.tool.execute(id, args, signal, onUpdate);
```

Tools receive `signal`, but nothing forces them to observe it (the `todo` tool takes `_signal` and ignores it). Once `execute()` was entered, an abort had **no wakeup at all**:

- no `tool_execution_end`, no `agent_end`
- `_isAgentRunActive` stayed `true`, so `_resolveIdleWaitIfIdle()` early-returned
- `waitForIdle()` never resolved → `_abortActiveAgentAndRetry` never returned
- the session work barrier stayed held → every queued prompt parked in `_waitForSettledSessionWork()` forever

Aborting *before* execution was already safe (`prepareToolCall` short-circuits on an aborted signal), so only the already-executing window hung — which is why it looked intermittent.

Reproduced in isolation; aborting after the tool body is entered dead-ends the event stream:

```
EVENT: tool_execution_start
>>> tool is running; aborting now
RESULT settled=HUNG toolStarted=true
```

## Fix

Race the tool promise against the abort signal, mirroring the provider-stream race this file already uses in `readNextAssistantEvent`, and surface the aborted call as an error tool result. Pre-execution abort behaviour is unchanged.

This generalizes the bash-specific fix in `b08522469` ("release aborted bash promptly when killed descendants hold stdio") to **every** signal-ignoring tool.

## Also fixed: reftable branch detection could register no watchers at all

`FooterDataProvider.setupGitWatcher` had three early returns that skipped the `tables.list` polling fallback whenever an `fs.watch` registration failed. `watchWithErrorHandler` returns `null` when `fs.watch` throws (descriptor limits, unsupported filesystems) and only retries after 5s — so in exactly the case the polling fallback exists for, it was skipped and the provider registered nothing. Users on such systems saw a permanently stale git branch in the footer, and the reftable tests timed out nondeterministically under parallel load, where watch capacity is the first thing to run out.

Polling is now armed whenever `tables.list` exists, with its path recorded after the watcher attempt because a failed registration synchronously clears watcher state.

## Verification

Real-surface proof through the actual TUI ESC handler (`InteractiveMode.prototype.abortAndFireQueuedMessages`) driven against a genuinely wedged session:

| | ESC handler | restored draft | time |
|---|---|---|---|
| `main` | `ESC_HUNG` | `undefined` | 8s bound burned |
| this branch | `ESC_COMPLETED:restored=1` | `"queued after esc"` | 2ms |

Tests:

- `packages/agent/test/tool-abort-release.test.ts` — loop-level; RED `expected 'hung' to be 'settled'` → GREEN
- `packages/coding-agent/test/suite/regressions/970-abort-releases-stuck-tool.test.ts` — session-level; fails on `main` (abort never returns), passes here
- `packages/coding-agent/test/footer-data-provider-watch-fallback.test.ts` — RED 10.11s timeout (same error text as the CI flake) → GREEN 755ms
- `packages/agent`: 507 passed, 1 pre-existing skip
- `packages/coding-agent` full suite: **1016 passed | 4 skipped, zero failures** (was 1014 passed | 1 failed on the reftable timeout)
