### PR TITLE
feat(coding-agent): add persistent-memory and mass-ulw graph tips

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Added
 
+- Tip rotation now covers persistent memory and mass-ulw graph orchestration (88 -> 113 tips). Sixteen
+  memory tips explain in plain English what cross-session memory is and how to use `/remember`,
+  `/search`, `/memory`, `/init`, `/people`, `/reflect`, `/dream`, `/sleeptime`, `/memfs`,
+  `/memory-repository`, `/doctor`, `/facts`, and `/recompile`; nine mass-ulw tips cover dependency
+  ordering, parallel waves, per-node worker categories, the `/dag` status view, and journaled resume.
+  Every entry is command-gated, so the tips appear only for users whose extension registers them.
+
 - `/loop`: recurring and self-paced scheduled prompts, ported from Claude Code as a fork-only builtin extension.
   Fixed loops re-deliver a prompt or loop-file sentinel on an interval; dynamic loops pick their own next delay via
   the new `schedule_wakeup` tool. Loops coalesce missed fires into one catch-up tick, cap at 5 active per session,

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,33 @@
 # changes
 
+## Persistent-memory and mass-ulw graph tips (2026-08-19)
+
+### What changed
+
+- `tips/catalog/memory-tips.ts` (new): 16 tips covering the persistent-memory suite in plain,
+  jargon-free English - what memory is, saving with `/remember` or by just saying it, `/search`,
+  `/memory`, `/init`, `/people`, `/reflect`, `/dream`, `/sleeptime`, `/memfs`,
+  `/memory-repository`, `/doctor`, `/facts`, and `/recompile`.
+- `tips/catalog/dag-tips.ts` (new): 9 tips covering mass-ulw graph orchestration - the one-keyword
+  hook, dependency ordering, parallel waves, per-node categories, the `/dag` status view, journaled
+  resume, and when a graph beats plain parallel subagents.
+- `tips/registry.ts` composes both new catalogs into `TIP_DEFINITIONS` (88 -> 113 tips).
+- Each entry is gated with `requiresCommand` on the command that provides it, mirroring the
+  existing `tasks` gate, so the tips only surface for users whose extension registers them.
+- Coverage: `test/suite/list-tips.test.ts` pins representative IDs, rendered lines, and gates for
+  both catalogs.
+
+### Why
+
+- The rotation advertised workflow skills but never mentioned persistent memory or the dependency-
+  graph orchestration surface, so two of the largest features stayed invisible to users who had
+  them installed.
+
+### Expected merge conflict zones
+
+- LOW: two new catalog files, two import/spread lines in `tips/registry.ts`, and two additive
+  assertions in the existing catalog test.
+
 ## Pasted image markers keep canonical numbering and survive undo with their payloads (2026-08-18)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/dag-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/dag-tips.ts
@@ -1,0 +1,66 @@
+import type { TipDefinition } from "./types.ts";
+
+export const DAG_TIPS = [
+	{
+		id: "dag.one-keyword-mastery",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			'One keyword makes you a master of graph engineering: say "mass-ulw" and your work becomes a dependency graph that schedules itself.',
+	},
+	{
+		id: "dag.what-it-is",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			'Trigger "mass-ulw" when some tasks must wait for others - describe the work, get a graph that runs in the right order.',
+	},
+	{
+		id: "dag.parallel-waves",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			"A graph run executes in waves: everything with no pending dependency starts at once, the rest starts the moment it is unblocked.",
+	},
+	{
+		id: "dag.depends-on",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			"Say what needs what - review after implementation, docs after both - and the ordering is enforced for you.",
+	},
+	{
+		id: "dag.categories",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			"Each node in the graph picks its own worker category, so cheap steps stay cheap and hard steps get the strong model.",
+	},
+	{
+		id: "dag.status-view",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () => "Use /dag to watch a run: which nodes finished, which are running, and which one failed.",
+	},
+	{
+		id: "dag.resume",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			"Graph runs are journaled - if the session dies mid-run it resumes later and never redoes the nodes that already finished.",
+	},
+	{
+		id: "dag.vs-parallel",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			"Fully independent jobs just need parallel subagents; reach for a graph when the ordering between them is the whole point.",
+	},
+	{
+		id: "dag.scale",
+		bindings: [],
+		requiresCommand: "dag",
+		render: () =>
+			"Stop hand-running steps in sequence. Describe the dependencies once and let a dozen agents fan out and rejoin on their own.",
+	},
+] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/src/modes/interactive/tips/catalog/memory-tips.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/catalog/memory-tips.ts
@@ -1,0 +1,105 @@
+import { APP_NAME } from "../../../../config.ts";
+import type { TipDefinition } from "./types.ts";
+
+export const MEMORY_TIPS = [
+	{
+		id: "memory.persistent",
+		bindings: [],
+		requiresCommand: "memory",
+		render: () =>
+			`${APP_NAME} remembers across sessions. Close the terminal, come back tomorrow, and the context is still there.`,
+	},
+	{
+		id: "memory.remember-command",
+		bindings: [],
+		requiresCommand: "remember",
+		render: () => "Use /remember to save something you want kept - a preference, a decision, a fact worth reusing.",
+	},
+	{
+		id: "memory.just-tell-it",
+		bindings: [],
+		requiresCommand: "remember",
+		render: () =>
+			'You can also just say it: "remember that we deploy on Fridays" is enough. No syntax, no file to open.',
+	},
+	{
+		id: "memory.search-command",
+		bindings: [],
+		requiresCommand: "search",
+		render: () => "Use /search to look through everything remembered so far, in plain words.",
+	},
+	{
+		id: "memory.memory-command",
+		bindings: [],
+		requiresCommand: "memory",
+		render: () => "Use /memory to see what is currently remembered about you and this project.",
+	},
+	{
+		id: "memory.init-command",
+		bindings: [],
+		requiresCommand: "init",
+		render: () => "Use /init to start memory for a new project, so it learns this codebase from the first session.",
+	},
+	{
+		id: "memory.people-command",
+		bindings: [],
+		requiresCommand: "people",
+		render: () => "Use /people to keep notes on teammates - who owns what, who to ask, what they prefer.",
+	},
+	{
+		id: "memory.reflect-command",
+		bindings: [],
+		requiresCommand: "reflect",
+		render: () => "Use /reflect to have the session reviewed now and the parts worth keeping written down.",
+	},
+	{
+		id: "memory.dream-command",
+		bindings: [],
+		requiresCommand: "dream",
+		render: () =>
+			"Memory tidies itself in the background between turns - /dream shows that work and lets you start it yourself.",
+	},
+	{
+		id: "memory.sleeptime-command",
+		bindings: [],
+		requiresCommand: "sleeptime",
+		render: () => "Use /sleeptime to decide how often memory reorganizes itself while you are not looking.",
+	},
+	{
+		id: "memory.memfs-command",
+		bindings: [],
+		requiresCommand: "memfs",
+		render: () => "Memory is plain files you own - browse them with /memfs and edit anything that looks wrong.",
+	},
+	{
+		id: "memory.repository-command",
+		bindings: [],
+		requiresCommand: "memory-repository",
+		render: () =>
+			"Every memory change is a git commit - use /memory-repository to see the history and undo a bad one.",
+	},
+	{
+		id: "memory.doctor-command",
+		bindings: [],
+		requiresCommand: "doctor",
+		render: () => "Use /doctor when memory feels off; it checks the setup and tells you what to fix.",
+	},
+	{
+		id: "memory.facts-command",
+		bindings: [],
+		requiresCommand: "facts",
+		render: () => "Use /facts to see the individual things learned about you, and drop the ones that no longer hold.",
+	},
+	{
+		id: "memory.recompile-command",
+		bindings: [],
+		requiresCommand: "recompile",
+		render: () => "Edited memory files by hand? Run /recompile so this session picks the changes up right away.",
+	},
+	{
+		id: "memory.stop-repeating",
+		bindings: [],
+		requiresCommand: "memory",
+		render: () => "Explain your setup once. Memory means you stop re-explaining it at the start of every session.",
+	},
+] satisfies readonly TipDefinition[];

--- a/packages/coding-agent/src/modes/interactive/tips/registry.ts
+++ b/packages/coding-agent/src/modes/interactive/tips/registry.ts
@@ -1,6 +1,8 @@
 import { CLI_TIPS } from "./catalog/cli-tips.ts";
+import { DAG_TIPS } from "./catalog/dag-tips.ts";
 import { ETHOS_TIPS } from "./catalog/ethos-tips.ts";
 import { INPUT_TIPS } from "./catalog/input-tips.ts";
+import { MEMORY_TIPS } from "./catalog/memory-tips.ts";
 import { MODEL_TIPS } from "./catalog/model-tips.ts";
 import { SESSION_TIPS } from "./catalog/session-tips.ts";
 import { SETTINGS_TIPS } from "./catalog/settings-tips.ts";
@@ -18,5 +20,7 @@ export const TIP_DEFINITIONS: readonly TipDefinition[] = [
 	...SETTINGS_TIPS,
 	...CLI_TIPS,
 	...SUBAGENT_TIPS,
+	...MEMORY_TIPS,
+	...DAG_TIPS,
 	...ETHOS_TIPS,
 ];

--- a/packages/coding-agent/test/suite/list-tips.test.ts
+++ b/packages/coding-agent/test/suite/list-tips.test.ts
@@ -52,6 +52,57 @@ describe("collectTips", () => {
 		expect(collectTips().filter((tip) => expectedIds.has(tip.id))).toEqual(expectedTips);
 	});
 
+	it("lists the persistent-memory tips behind their own command gates", () => {
+		const expectedTips = [
+			{
+				id: "memory.remember-command",
+				text: "Use /remember to save something you want kept - a preference, a decision, a fact worth reusing.",
+				requiresCommand: "remember",
+			},
+			{
+				id: "memory.search-command",
+				text: "Use /search to look through everything remembered so far, in plain words.",
+				requiresCommand: "search",
+			},
+			{
+				id: "memory.people-command",
+				text: "Use /people to keep notes on teammates - who owns what, who to ask, what they prefer.",
+				requiresCommand: "people",
+			},
+			{
+				id: "memory.repository-command",
+				text: "Every memory change is a git commit - use /memory-repository to see the history and undo a bad one.",
+				requiresCommand: "memory-repository",
+			},
+		];
+		const expectedIds = new Set(expectedTips.map((tip) => tip.id));
+
+		expect(collectTips().filter((tip) => expectedIds.has(tip.id))).toEqual(expectedTips);
+	});
+
+	it("lists the mass-ulw graph tips behind the dag command gate", () => {
+		const expectedTips = [
+			{
+				id: "dag.one-keyword-mastery",
+				text: 'One keyword makes you a master of graph engineering: say "mass-ulw" and your work becomes a dependency graph that schedules itself.',
+				requiresCommand: "dag",
+			},
+			{
+				id: "dag.what-it-is",
+				text: 'Trigger "mass-ulw" when some tasks must wait for others - describe the work, get a graph that runs in the right order.',
+				requiresCommand: "dag",
+			},
+			{
+				id: "dag.status-view",
+				text: "Use /dag to watch a run: which nodes finished, which are running, and which one failed.",
+				requiresCommand: "dag",
+			},
+		];
+		const expectedIds = new Set(expectedTips.map((tip) => tip.id));
+
+		expect(collectTips().filter((tip) => expectedIds.has(tip.id))).toEqual(expectedTips);
+	});
+
 	it("carries requiresCommand only for command-gated tips", () => {
 		const tips = collectTips();
 		const gated = tips.filter((tip) => tip.requiresCommand !== undefined);


### PR DESCRIPTION
## What

Two of the largest features shipped with this fork never appeared in the tip rotation: **persistent memory** and **mass-ulw dependency-graph orchestration**. Users who had them installed had no way to discover them from the TUI.

This adds 25 tips across two new catalogs (88 -> 113 total).

### `tips/catalog/memory-tips.ts` (16 tips)

Plain, jargon-free English aimed at someone who has never heard of agent memory - what it is, and the surfaces behind it: `/remember` (plus "you can also just say it"), `/search`, `/memory`, `/init`, `/people`, `/reflect`, `/dream`, `/sleeptime`, `/memfs`, `/memory-repository`, `/doctor`, `/facts`, `/recompile`.

### `tips/catalog/dag-tips.ts` (9 tips)

The mass-ulw graph surface: the one-keyword hook, dependency ordering, parallel waves, per-node worker categories, the `/dag` status view, journaled resume, and when a graph beats plain parallel subagents.

## Gating

Every entry declares `requiresCommand` on the command that actually provides it, mirroring the existing `tasks` gate in `subagent-tips.ts`. A user whose extension does not register `/dag` or the memory commands never sees these tips, so the rotation cannot advertise features that are not present.

## Verification

- `test/suite/list-tips.test.ts` pins representative ids, **verbatim** rendered copy, and command gates for both catalogs.
- Mutation-checked: altering a single word of the pinned copy fails the assertion; reverting passes it. The pins are real coverage, not tautologies.
- Full tips scope green: 8 files, 56 tests (`list-tips`, `tips-registry`, `ethos-tips`, `settings-tips`, `startup-tip`, `working-tip`, `tips-scheduler`, `startup-tip-extension-header`).
- `biome check` clean on all changed files.
- Real surface: `collectTips()` - the exact function behind `--list-tips` - emits all 113 tips with zero duplicate ids.
- `tsc --noEmit` introduces no new errors (identical count against a pristine `origin/main` baseline in the same worktree; the existing errors are unbuilt workspace siblings).

## Conflict risk

LOW - two new files, two import/spread lines in `registry.ts`, two additive test assertions, one `changes.md` entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tip coverage for persistent memory and mass‑ulw dependency‑graph orchestration so users see them only when their commands are available. Previously, the rotation omitted these features; now it includes them when the extension registers the commands.

- New catalogs: 16 memory tips and 9 DAG tips; added to the registry (88 -> 113 tips). Each tip is gated with requiresCommand (e.g., remember, memory, dag), so users without those commands never see them.
- Tests: list-tips.test.ts pins representative IDs, exact text, and command gates for both catalogs; validates 113 unique tips from collectTips.
- Code touch points: two new catalog files and two import/spread lines in the tips registry; CHANGELOG and changes.md updated.
- Rollout: no migration; tips appear automatically when memory and DAG commands are registered.

<sup>Written for commit 88f355113b060030d7b6969508ac4244773f707c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

