### PR TITLE
test(cursor-cli-oauth): fix the grandchild-reap flake at its root (pid 0 from a partial read)

### DIFF
--- a/packages/coding-agent/test/cursor-cli-oauth/transport.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/transport.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, watch, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -55,10 +55,27 @@ function start(
 	});
 }
 
+/**
+ * A non-positive pid is never a real process: POSIX `kill(0, sig)` targets the CALLER'S OWN
+ * process group, so probing pid 0 reports "alive" forever and times out 2s later blaming the
+ * fixture. Fail loudly on an unusable pid instead of letting it masquerade as a live process.
+ */
+function readGrandchildPid(pidFile: string): number {
+	const raw = readFileSync(pidFile, "utf8").trim();
+	const pid = Number(raw);
+	if (!Number.isInteger(pid) || pid <= 0) {
+		throw new Error(`fixture published an unusable grandchild pid: ${JSON.stringify(raw)}`);
+	}
+	return pid;
+}
+
 // Group SIGTERM reaches the grandchild asynchronously after the leader exits, so an
 // instant liveness probe races on loaded CI runners. Poll under a bounded deadline,
 // matching assertProcessDead in test/mcp/fixtures/spawn-fixture.ts.
 async function assertDead(pid: number): Promise<void> {
+	if (!Number.isInteger(pid) || pid <= 0) {
+		throw new Error(`refusing to probe pid ${pid}: kill(0) would target this test's own process group`);
+	}
 	const deadline = Date.now() + 2000;
 	while (Date.now() < deadline) {
 		try {
@@ -104,24 +121,20 @@ describe("cursor CLI transport", () => {
 		const directory = temporaryDirectory();
 		const fixture = fixtureExecutable(directory, "grandchild");
 		const controller = new AbortController();
-		const pidFileReady = new Promise<void>((resolveReady, rejectReady) => {
-			const watcher = watch(directory);
-			const deadline = setTimeout(() => {
-				watcher.close();
-				rejectReady(new Error("fixture did not report its grandchild"));
-			}, 2_000);
-			watcher.on("change", (_eventType, filename) => {
-				if (filename !== "grandchild.pid") return;
-				clearTimeout(deadline);
-				watcher.close();
-				resolveReady();
-			});
-		});
 		const handle = start(directory, fixture.executable, "slow", controller.signal);
-		await pidFileReady;
-		const grandchildPid = Number(readFileSync(fixture.pidFile, "utf8").trim());
+
+		// The fixture publishes the pid file BEFORE it writes its first stdout event, so
+		// observing any event already orders the pid file as complete. That happens-before
+		// edge replaces watching the directory, which fired on file CREATION and raced the
+		// content write - yielding an empty read, Number("") === 0, and a bogus pid probe.
+		const iterator = handle.events[Symbol.asyncIterator]();
+		const firstEvent = await iterator.next();
+		const grandchildPid = readGrandchildPid(fixture.pidFile);
 		controller.abort();
-		const events = await collect(handle);
+
+		const events: unknown[] = [];
+		if (!firstEvent.done) events.push(firstEvent.value);
+		for (let next = await iterator.next(); !next.done; next = await iterator.next()) events.push(next.value);
 		const outcome = await handle.completed;
 
 		expect(events.at(-1)).toBeInstanceOf(CursorCliAbortError);

--- a/packages/coding-agent/test/fixtures/fake-cursor-agent.mjs
+++ b/packages/coding-agent/test/fixtures/fake-cursor-agent.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { writeFileSync } from "node:fs";
+import { renameSync, writeFileSync } from "node:fs";
 
 const SESSION_ID = "fake-session-001";
 const REQUEST_ID = "fake-request-001";
@@ -271,7 +271,12 @@ async function main() {
 			if (!grandchild.pid) {
 				throw new Error("Failed to spawn fake cursor-agent grandchild");
 			}
-			writeFileSync(pidFile, `${grandchild.pid}\n`, "utf8");
+			// Atomic publish: writeFileSync creates the path first and fills it second, so a
+			// watcher waking on creation can read an empty file. rename(2) makes the pid file
+			// appear only once it already holds the complete pid.
+			const pendingPidFile = `${pidFile}.pending`;
+			writeFileSync(pendingPidFile, `${grandchild.pid}\n`, "utf8");
+			renameSync(pendingPidFile, pidFile);
 			grandchild.unref();
 			emitHappy();
 			break;


### PR DESCRIPTION
## The failure

CI failed shard `Test (coding-agent 3/3)` with:

```
FAIL test/cursor-cli-oauth/transport.test.ts > aborts the exact process group and reaps both leader and descendant
Error: process still alive after abort: 0
```

That `0` is the entire defect, and **no timeout increase could have fixed it**.

`writeFileSync` is `open(O_CREAT|O_TRUNC)` followed by `write`, so the pid file exists and is **empty** between the two syscalls. The test watched the directory and resolved on the first `change` event — which fires on **creation**, inside that empty window. It read `""`, and `Number("")` is `0`, not `NaN`, so pid `0` reached the liveness probe. POSIX `kill(0, sig)` targets **the caller's own process group**, so the probe reported the process alive forever, exhausted its 2s deadline, and blamed the fixture. The grandchild's real liveness was never asserted. A slower runner only widens the window.

Reproduced deterministically, with no test infrastructure and no timing luck:

```
raw read during race      = ""
Number(raw)               = 0        <-- Number("") is 0, NOT NaN
Number.isInteger(parsed)  = true     <-- a naive integer check STILL passes
process.kill(0, 0)        = SUCCEEDS (reported ALIVE)
=> assertDead(0) can never observe ESRCH => "process still alive after abort: 0"
```

Note `Number.isInteger(0)` is `true`, so only a `> 0` check catches this.

## The fix — remove the race, do not widen the deadline

- **The fixture publishes atomically.** It writes `<pidFile>.pending` and renames it onto the pid file. `rename(2)` is atomic, so a partially-written pid file can never be observed.
- **The test drops `fs.watch`.** It uses a happens-before edge that already existed: the fixture publishes the pid *before* emitting its first stdout event. Awaiting the first stream event therefore orders the pid file as complete — no watcher, no polling, no wall clock. The test then aborts and drains the remaining events through the same iterator.
- **Bogus pids fail loudly.** The pid parser and the liveness probe both reject non-integer and non-positive pids, naming the `kill(0)` process-group hazard, so a regression fails immediately instead of masquerading as a 2s flake.

The bounded poll for the grandchild's death is kept: a non-child process cannot be `waitpid`-ed, and polling is the portable mechanism (matching `assertProcessDead` in `test/mcp/fixtures/spawn-fixture.ts`). It was never the cause — it was the victim of a pid that could never die.

## Verification

`test/cursor-cli-oauth/transport.test.ts` run **25 consecutive times**: **25 passed, 0 failed** (confirmed by parsing each run log individually, not just the summary), executed concurrently with another vitest stress loop so the runs competed for CPU — load being the condition that surfaced the flake.

## Scope

Test-only: touches `test/cursor-cli-oauth/transport.test.ts` and `test/fixtures/fake-cursor-agent.mjs`. No production source, so the changelog gate reports no runtime source changes (verified locally post-commit).

`test/footer-data-provider.test.ts` was also suspected, but is **not** touched here: it did not reproduce in **30 consecutive runs under the same concurrent load**, and shipping a speculative fix for an unproven race would be the kind of guesswork this PR is removing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the grandchild-reap flake by removing the pid-file race and rejecting unusable pids. Previously the test watched for file creation, sometimes read an empty pid file as 0, and `kill(0)` probed the test’s own process group, leading to false “process still alive after abort: 0” failures.

- Fixture publishes the pid atomically: writes `<pidFile>.pending` and renames it to the pid file so a partial write cannot be observed.
- Test drops `fs.watch` and relies on an existing happens-before: waits for the first stdout event, then reads the pid; drains remaining events via the same iterator.
- Parser and liveness probe now validate pid is an integer > 0; fail fast with a clear error to avoid masked timeouts.
- Retains the bounded poll for grandchild death; no production code changes.

<sup>Written for commit 1e539a3843116b40c093d8e2bf5493a02d1c5bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

