### PR TITLE
fix(pty): skip quarantined macOS prebuilds before Gatekeeper blocks the load

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixed
 
+- macOS no longer shows `"senpi_pty.darwin-arm64.node" Not Opened — Apple could not verify ... is free of malware` and the CLI no longer hangs while that dialog waits. When a shipped native PTY prebuild carries the `com.apple.quarantine` attribute (npm tarballs fetched through a browser, AirDrop, or archive extraction), the loader now detects it before `dlopen()` and reports the existing `native-unavailable` diagnostic, so terminals degrade to the pipe fallback instead of blocking the process on Gatekeeper. The attribute is never stripped — that would silently disable the user's malware protection — and non-quarantined installs keep loading the real native PTY unchanged.
 - The footer's git branch keeps updating in reftable repositories on systems where `fs.watch` cannot register (descriptor limits, unsupported filesystems): the `tables.list` polling fallback is now armed even when watcher creation fails, instead of being skipped by an early return ([#970](https://github.com/code-yeongyu/senpi/pull/970)).
 - Pasting multiple images in one turn now ships every image: the second and later pastes no longer write into an orphaned payload map, markers pasted in front of existing ones renumber to stay `[Image #1]`..`[Image #k]` in reading order (so `look_at("[Image #N]")` resolves to the exact image the user sees), undo after deleting a marker restores its image along with the marker, and submitting pasted images during compaction now reports the drop instead of silently discarding them.
 

--- a/packages/pty/src/loader.ts
+++ b/packages/pty/src/loader.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { isQuarantinedNativeFile } from "./quarantine.ts";
 
 export type NativePtyRuntime = "node" | "bun";
 
@@ -57,8 +58,15 @@ export interface NativePtyCandidatePathOptions {
 
 export type NativePtyRequireBinding = (modulePath: string) => unknown;
 
+/**
+ * Reports whether a candidate prebuild carries macOS `com.apple.quarantine`.
+ * Injectable so tests can exercise the guard without a quarantined artifact.
+ */
+export type NativePtyQuarantineProbe = (modulePath: string) => boolean;
+
 export interface NativePtyLoaderOptions extends NativePtyCandidatePathOptions {
 	readonly requireBinding?: NativePtyRequireBinding;
+	readonly isQuarantined?: NativePtyQuarantineProbe;
 }
 
 const cjsRequire = createRequire(import.meta.url);
@@ -123,9 +131,20 @@ export function loadNativePty(options: NativePtyLoaderOptions = {}): NativePtyLo
 	const host = getNativePtyHost(options.platform, options.arch);
 	const attemptedPaths = getNativePtyCandidatePaths({ ...options, runtime });
 	const requireBinding = options.requireBinding ?? cjsRequire;
+	const platform = options.platform ?? process.platform;
+	const isQuarantined = options.isQuarantined ?? (platform === "darwin" ? isQuarantinedNativeFile : undefined);
 	const causes: string[] = [];
 
 	for (const modulePath of attemptedPaths) {
+		// `dlopen()` on a quarantined, non-notarized addon hands control to Gatekeeper,
+		// which blocks the process behind a "could not verify ... free of malware" dialog
+		// instead of returning an error. Detect that state first and keep the diagnostic
+		// path, so the caller degrades to the pipe fallback rather than hanging.
+		if (isQuarantined?.(modulePath) === true) {
+			causes.push(`${modulePath}: blocked because com.apple.quarantine is present (macOS Gatekeeper)`);
+			continue;
+		}
+
 		try {
 			const native = requireBinding(modulePath);
 			return {

--- a/packages/pty/src/quarantine.ts
+++ b/packages/pty/src/quarantine.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+export const QUARANTINE_ATTRIBUTE = "com.apple.quarantine";
+
+/**
+ * SECURITY: `dlopen()` on a quarantined, non-notarized addon hands control to
+ * Gatekeeper, which suspends the process behind an "Apple could not verify ... is
+ * free of malware" dialog instead of returning an error. Senpi's prebuilds carry
+ * only a linker ad-hoc signature, so a quarantined prebuild is never auto-approved.
+ * Detection MUST NOT become removal: clearing the attribute would silently defeat
+ * the user's malware protection.
+ *
+ * Node exposes no `getxattr` binding, so `xattr -p` is the only available channel;
+ * it exits 0 only when the attribute is present. Any spawn failure returns `false`
+ * so an unreadable attribute never rejects an otherwise loadable prebuild.
+ */
+export function isQuarantinedNativeFile(modulePath: string, platform: string = process.platform): boolean {
+	if (platform !== "darwin") return false;
+	if (!existsSync(modulePath)) return false;
+
+	const probe = spawnSync("/usr/bin/xattr", ["-p", QUARANTINE_ATTRIBUTE, modulePath], {
+		stdio: ["ignore", "ignore", "ignore"],
+		timeout: 2000,
+	});
+
+	return probe.error === undefined && probe.status === 0;
+}

--- a/packages/pty/test/loader.test.ts
+++ b/packages/pty/test/loader.test.ts
@@ -96,6 +96,35 @@ describe("loadNativePty", () => {
 		expect(attempted).toEqual(expectedPaths);
 	});
 
+	it("skips quarantined macOS prebuilds before require can trigger Gatekeeper", () => {
+		const host = "darwin-arm64";
+		const attempted: string[] = [];
+		const quarantined: string[] = [];
+
+		const result = loadNativePty({
+			arch: "arm64",
+			execDir,
+			moduleDir,
+			platform: "darwin",
+			isQuarantined(modulePath) {
+				quarantined.push(modulePath);
+				return modulePath === candidate(host);
+			},
+			requireBinding(modulePath) {
+				attempted.push(modulePath);
+				throw new Error(`Gatekeeper should have been avoided for ${modulePath}`);
+			},
+			runtime: "node",
+		});
+
+		expect(result.native).toBeNull();
+		expect(quarantined).toEqual(
+			getNativePtyCandidatePaths({ arch: "arm64", execDir, moduleDir, platform: "darwin" }),
+		);
+		expect(attempted).not.toContain(candidate(host));
+		expect(result.diagnostic?.cause).toContain(`${candidate(host)}: blocked because com.apple.quarantine is present`);
+	});
+
 	it("throws a typed sentinel mismatch error when a candidate loads without the versioned sentinel", () => {
 		const host = "darwin-arm64";
 


### PR DESCRIPTION
## Problem

On macOS, launching the CLI could surface:

> **"senpi_pty.darwin-arm64.node" Not Opened** — Apple could not verify "senpi_pty.darwin-arm64.node" is free of malware that may harm your Mac or compromise your privacy

and the process would **hang** while that dialog waited for a human.

## Root cause

The shipped prebuild carries only a **linker ad-hoc signature**:

```
Identifier=libsenpi_pty.dylib
CodeDirectory ... flags=0x20002(adhoc,linker-signed)
Signature=adhoc
TeamIdentifier=not set
```

macOS 10.15+ loads a *quarantined plug-in* only if it is **notarized**. An ad-hoc signature never qualifies, so when the prebuild arrives with `com.apple.quarantine` (npm tarball fetched via a browser, AirDrop, archive extraction), `dlopen()` hands control to Gatekeeper. Gatekeeper **suspends the process** behind the dialog rather than returning an error — so `loadNativePty()` never reached its own `native-unavailable` diagnostic, and the terminal never fell back.

I verified `spctl --assess` is `rejected` for every reachable variant (as-shipped, re-ad-hoc-signed, unsigned, and even with quarantine cleared). Real notarization needs Apple Developer credentials, which this repo does not hold (`gh secret list` shows no `APPLE_*` secrets), so signing is out of scope here.

## Fix

Detect `com.apple.quarantine` **before** `require()`, and reuse the existing `native-unavailable` diagnostic so sessions degrade to the pipe fallback instead of blocking.

Two deliberate constraints:

- **Never strip the attribute.** Clearing quarantine would silently disable the user's malware protection. This only *detects*.
- **Fail open.** Node exposes no `getxattr` binding, and `/..namedfork/<attr>#S` returns `ENOTDIR` on a regular file, so `/usr/bin/xattr -p` is the only viable probe. Any spawn failure returns `false`, so an unreadable attribute never rejects a loadable prebuild.

Non-quarantined installs are completely unaffected and still load the real native PTY.

## Evidence (RED → GREEN)

**RED — before the fix**, `require()` on a quarantined copy blocked until a watchdog killed it:

```
status=142 elapsed_seconds=6
RED_PASS: require stayed blocked until watchdog alarm; Gatekeeper intercepted the quarantined plug-in
```

The new unit test also failed for the right reason — the quarantine probe was never consulted (`[]` vs 3 candidate paths).

**GREEN — after the fix**, the same artifact returns control immediately:

```
SURFACE_OK code=native-unavailable
cause=...: blocked because com.apple.quarantine is present (macOS Gatekeeper)
status=0 elapsed_seconds=0
```

**Real surface — `TerminalSession` public API, both directions:**

```
## A: QUARANTINED prebuild (the reported failure condition)
sentinel_seen=true exit=0   -> PASS: terminal works, no dialog, no hang (0s, was a 15s hang)

## B: CLEAN prebuild (no regression)
sentinel_seen=true exit=0   -> PASS: still drives the real native PTY
```

Case B is the important control: it proves the guard does not degrade normal installs.

## Validation

- `packages/pty` tests: **8 files, 51 tests passed**, exit 0 (no skips)
- `tsc -p tsconfig.build.json`: exit 0
- `biome check` on all changed files: clean
- Committed prebuild binary verified **byte-for-byte pristine**; all QA xattrs and temp files cleaned up

## Scope

`packages/pty/src/loader.ts` and the new `packages/pty/src/quarantine.ts` are both absent from the pinned upstream tree (`badlogic/pi-mono` v0.84.2), so they are fork-only and exempt from `changes.md` tracker coverage. A CHANGELOG entry is included.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids macOS Gatekeeper hangs by skipping quarantined native PTY prebuilds. Previously, requiring a quarantined addon showed the “not opened” dialog and blocked the CLI; now the loader detects `com.apple.quarantine`, reports `native-unavailable`, and falls back to the pipe. Clean installs keep loading the native PTY unchanged.

- Adds `isQuarantinedNativeFile` in `packages/pty/src/quarantine.ts` using `/usr/bin/xattr -p`; `packages/pty/src/loader.ts` calls it on Darwin before `require()`. Detection is injectable via `isQuarantined` for tests.
- Never removes the attribute; probe fails open so unreadable attributes don’t block a loadable binary.
- Adds a unit test to confirm quarantined candidates are skipped; updates `packages/coding-agent/CHANGELOG.md`. No API or migration changes.

<sup>Written for commit 32432b6d8d9767e33ef0135b61768d93f2aba0e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

