### PR TITLE
fix(agent): pass run abort signal into Cursor exec handlers

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -495,7 +495,7 @@ async function streamAssistantResponse(
 				? {
 						execHandlers:
 							typeof config.cursorExecHandlers === "function"
-								? config.cursorExecHandlers(requestAbortController.signal)
+								? config.cursorExecHandlers(signal ?? requestAbortController.signal)
 								: config.cursorExecHandlers,
 						onToolResult: (result: ToolResultMessage) => {
 							providerToolResults.push(result);

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,20 @@
 # Changes
 
+## Cursor exec uses the run abort signal (2026-08-19)
+
+`runAgentLoop` passed `requestAbortController.signal` into `cursorExecHandlers`.
+That controller is per LLM request. `createSessionCursorExecBridge` treats the
+argument as the owning run signal and rejects exec when it is not
+`agent.signal`. Those two objects are never the same on a healthy turn, so
+Cursor native `read`/`bash` fail with `Tool execution has no active run` on a
+new session.
+
+Why not an extension: the factory is invoked inside `packages/agent` before any
+coding-agent hook sees the stream.
+
+Conflict zone: `packages/agent/src/agent-loop.ts` `cursorExecHandlers(...)`
+argument.
+
 ## Aborted tool execution releases the run (2026-08-19)
 
 ### What changed

--- a/packages/agent/test/cursor-exec-loop.test.ts
+++ b/packages/agent/test/cursor-exec-loop.test.ts
@@ -282,4 +282,30 @@ describe("cursor exec-channel integration in the agent loop", () => {
 		expect(assistantMessage?.stopReason).toBe("error");
 		expect(assistantMessage?.errorMessage).toContain("Idle timeout");
 	});
+
+	it("passes the run abort signal into cursorExecHandlers, not the per-request controller", async () => {
+		const run = new AbortController();
+		let seen: AbortSignal | undefined;
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: model(),
+			convertToLlm: (messages) => messages.filter((message): message is Message => "role" in message),
+			cursorExecHandlers: (signal) => {
+				seen = signal;
+				return {};
+			},
+		};
+		const stream = agentLoop([{ role: "user", content: "hi", timestamp: 0 }], context, config, run.signal, () => {
+			const response = createAssistantMessageEventStream();
+			const partial = assistant([{ type: "text", text: "ok" }]);
+			response.push({ type: "start", partial });
+			response.push({ type: "text_end", contentIndex: 0, content: "ok" });
+			response.end({ ...partial, stopReason: "stop" });
+			return response;
+		});
+		for await (const _event of stream) {
+			// consume
+		}
+		expect(seen).toBe(run.signal);
+	});
 });


### PR DESCRIPTION
Closes #979

`cursorExecHandlers` received `requestAbortController.signal`. The session bridge compares that to `agent.signal` (the run controller). They are never the same object, so a new Cursor session rejects every native exec with `Tool execution has no active run`.

This passes the run-level `signal` (falling back to the request controller only when the loop has no run signal).

Why not an extension: the factory is invoked inside `packages/agent`.

Conflict zone: `packages/agent/src/agent-loop.ts` `cursorExecHandlers(...)` argument.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Cursor native exec by passing the run-level abort signal to `cursorExecHandlers`. Previously it used the per-request controller, so the session bridge compared it to `agent.signal` and rejected exec with "Tool execution has no active run" on new sessions.

- In `packages/agent/src/agent-loop.ts`, `cursorExecHandlers` now receives `signal ?? requestAbortController.signal`.
- Adds a test in `packages/agent/test/cursor-exec-loop.test.ts` verifying the run signal is passed through.
- No API changes; behavior now matches `createSessionCursorExecBridge` expectations. Potential conflict around the `cursorExecHandlers(...)` argument in `packages/agent/src/agent-loop.ts`.

<sup>Written for commit 933a2fca16e18904d1a5bb93f1775607baae85c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

