### PR TITLE
fix(cursor): keep ModelDetails on the concrete catalog identity

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ### Fixed
 
+- Native Cursor grouped reasoning selections now keep `ModelDetails.modelId` on the concrete catalog
+  variant while `RequestedModel` carries the bare capability id and reasoning parameters, preventing
+  available models from failing with `not_found`
+  ([#987](https://github.com/code-yeongyu/senpi/pull/987) by
+  [@ThewindMom](https://github.com/ThewindMom)).
+
 - Native Cursor turns now report real usage: the billed token split on `turnEnded`
   (input/output/cache read/cache write, taken from the production cursor-agent schema) lands on
   `usage`, and conversation checkpoints feed the server's live `usedTokens` into the in-flight

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -4024,10 +4024,9 @@ async function buildGrpcRequest(
 	});
 
 	const requestedModel = buildRequestedModel(model, options?.thinkingSelection);
-	const wireModelId = requestedModel.modelId;
 	const cursorMaxMode = model.compat?.cursorMaxMode === true;
 	const modelDetails = create(ModelDetailsSchema, {
-		modelId: wireModelId,
+		modelId: model.upstreamModelId ?? model.id,
 		displayModelId: model.id,
 		displayName: model.name,
 		...(cursorMaxMode ? { maxMode: true } : undefined),

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,31 @@
 # AI Source Changes
 
+## 2026-08-19 - Cursor ModelDetails retains the concrete catalog identity
+
+### What changed
+
+- `packages/ai/src/api/cursor-agent.ts`: `ModelDetails.modelId` now keeps the model's concrete
+  `upstreamModelId` (falling back to `model.id`) instead of reusing the resolved
+  `RequestedModel.modelId`. Explicit grouped reasoning selections still send their bare capability id
+  plus ordered parameters through `RequestedModel`.
+
+### Why
+
+- Cursor uses the fields for different identities. `RequestedModel` describes the parameterized
+  selection, while `ModelDetails` identifies a concrete catalog model. Reusing the grouped capability
+  id in both fields made explicit grouped selections fail with `not_found`, even though the same
+  concrete model remained available.
+
+### Why an extension could not handle it
+
+- Both protobuf fields are assembled inside the native Cursor provider before the request reaches any
+  extension-visible hook.
+
+### Expected merge conflict zones
+
+- LOW: `packages/ai/src/api/cursor-agent.ts` Run-request model construction beside Cursor reasoning
+  parameter rendering.
+
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin
 
 ### What changed

--- a/packages/ai/test/cursor-run-request.test.ts
+++ b/packages/ai/test/cursor-run-request.test.ts
@@ -122,8 +122,10 @@ describe("cursor Run request reasoning rendering", () => {
 		const model = buildModel("claude-fable-5-thinking", "", fableCompat, "claude-fable-5-thinking-medium");
 		const frame = await captureRunRequest(model, { thinkingSelection: { level: "low", source: "explicit" } });
 		const request = frame.message.value as {
+			modelDetails?: { modelId: string };
 			requestedModel?: { modelId: string; maxMode: boolean; parameters: { id: string; value: string }[] };
 		};
+		expect(request.modelDetails?.modelId).toBe("claude-fable-5-thinking-medium");
 		expect(request.requestedModel?.modelId).toBe("claude-fable-5");
 		expect(
 			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
@@ -138,8 +140,10 @@ describe("cursor Run request reasoning rendering", () => {
 		const model = buildModel("gpt-5.5-medium", "");
 		const withSelection = await captureRunRequest(model, {});
 		const request = withSelection.message.value as {
+			modelDetails?: { modelId: string };
 			requestedModel?: { modelId: string; maxMode: boolean; parameters: { id: string; value: string }[] };
 		};
+		expect(request.modelDetails?.modelId).toBe("gpt-5.5-medium");
 		expect(request.requestedModel?.modelId).toBe("gpt-5.5-medium");
 		expect(request.requestedModel?.parameters ?? []).toEqual([]);
 	});
@@ -150,7 +154,11 @@ describe("cursor Run request reasoning rendering", () => {
 		};
 		const model = buildModel("gpt-5.5", "", compat, "gpt-5.5-medium");
 		const frame = await captureRunRequest(model, {});
-		const request = frame.message.value as { requestedModel?: { modelId: string; parameters?: unknown[] } };
+		const request = frame.message.value as {
+			modelDetails?: { modelId: string };
+			requestedModel?: { modelId: string; parameters?: unknown[] };
+		};
+		expect(request.modelDetails?.modelId).toBe("gpt-5.5-medium");
 		expect(request.requestedModel?.modelId).toBe("gpt-5.5-medium");
 		expect(request.requestedModel?.parameters ?? []).toEqual([]);
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Fixed
 
+- Native Cursor grouped reasoning selections now keep the concrete catalog identity in
+  `ModelDetails`, so available Claude and GPT models no longer fail with `not_found`
+  ([#987](https://github.com/code-yeongyu/senpi/pull/987) by
+  [@ThewindMom](https://github.com/ThewindMom)).
+
 - Auto-compaction can no longer be starved by a provider that reports a small context while the
   local transcript keeps growing (native Cursor's server-side summarized usage): the threshold
   check now takes the larger of the provider-reported context and the local transcript estimate.


### PR DESCRIPTION
## What this fixes

Explicit Cursor reasoning selections currently use the resolved `RequestedModel.modelId` for two different protobuf fields:

| Field | What it represents | Grouped Fable example |
| --- | --- | --- |
| `RequestedModel.modelId` | Parameterized reasoning capability | `claude-fable-5` + `thinking/context/effort` parameters |
| `ModelDetails.modelId` | Concrete model from Cursor's catalog | `claude-fable-5-thinking-medium` |

After grouped reasoning support landed in #948, `buildGrpcRequest()` began copying the first identity into both fields. An explicit grouped selection therefore sent the bare capability id as `ModelDetails.modelId`, and Cursor rejected the otherwise available model with `not_found`.

## Root cause

`buildRequestedModel()` is working as designed:

- explicit grouped selection -> bare capability id plus ordered parameters;
- no selection -> representative concrete variant;
- ungrouped model -> original model id.

The regression is the next assignment in `buildGrpcRequest()`:

```ts
const wireModelId = requestedModel.modelId;

const modelDetails = create(ModelDetailsSchema, {
  modelId: wireModelId,
});
```

That conflates selection identity with catalog identity.

## Fix

Keep the two identities independent:

```ts
const requestedModel = buildRequestedModel(model, options?.thinkingSelection);

const modelDetails = create(ModelDetailsSchema, {
  modelId: model.upstreamModelId ?? model.id,
});
```

This intentionally leaves `RequestedModel` and the reasoning resolver unchanged. Only `ModelDetails` returns to the concrete identity already retained on the grouped model.

## Behavior matrix

| Case | `ModelDetails.modelId` | `RequestedModel.modelId` | Parameters |
| --- | --- | --- | --- |
| Explicit grouped Fable `low` | `claude-fable-5-thinking-medium` | `claude-fable-5` | `thinking=true`, `context=1m`, `effort=low` |
| Grouped GPT, no selection | `gpt-5.5-medium` | `gpt-5.5-medium` | none |
| Ungrouped GPT | `gpt-5.5-medium` | `gpt-5.5-medium` | none |

## Regression coverage

`packages/ai/test/cursor-run-request.test.ts` decodes the actual `AgentClientMessage` emitted over the local HTTP/2 test server and asserts both protobuf fields independently.

The new explicit-grouped assertion was observed failing before the production change:

```text
Expected: claude-fable-5-thinking-medium
Received: claude-fable-5
```

It passes after the fix, alongside the grouped no-selection and ungrouped boundary cases.

## Validation

- `npm test -- cursor-run-request.test.ts` from `packages/ai`: **5/5 passed**
- `npm run build`: **passed** across all six build phases
- `npm run check`: **passed** (Biome, dependency/import/lock gates, TypeScript, browser smoke)
- `npm test --workspace @earendil-works/pi-ai`: **228 files passed, 2,184 tests passed, 25 files / 866 tests skipped by the existing suite**
- Standalone Bun request driver decoded:
  ```json
  {
    "modelDetails": "claude-fable-5-thinking-medium",
    "requestedModel": "claude-fable-5",
    "parameters": ["thinking=true", "context=1m", "effort=low"]
  }
  ```
- Senpi source QA harness:
  - common isolation check: **9/9 passed**
  - deterministic real mock loop: **48/48 passed**
  - CLI smoke: **8/8 passed**
  - real auth hash unchanged; temporary sandboxes and processes cleaned up
- Live native Cursor canaries using the equivalent built-file patch:
  - Claude Fable 5 high -> `LOCAL_FABLE_FIX_OK`
  - GPT-5.5 high -> `LOCAL_GPT_FIX_OK`
  - neither returned `not_found`

## Risk and scope

Low and intentionally narrow:

- no catalog grouping changes;
- no reasoning parameter changes;
- no protobuf schema changes;
- no auth, transport, tool, or retry changes;
- no behavior change for grouped no-selection or ungrouped models.

`packages/ai/src/changes.md` records the provider-internal identity contract and merge-conflict zone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Cursor `ModelDetails.modelId` on the concrete catalog identity to prevent not_found on explicit grouped selections. Previously copied the capability id from `RequestedModel.modelId`; now uses `model.upstreamModelId ?? model.id` while leaving `RequestedModel` and reasoning parameters unchanged.

- In `packages/ai/src/api/cursor-agent.ts`, set `ModelDetails.modelId = model.upstreamModelId ?? model.id`; keep `RequestedModel` construction as-is.
- Extend `packages/ai/test/cursor-run-request.test.ts` to assert both identities for explicit grouped, grouped no-selection, and ungrouped models.
- Update `packages/ai/CHANGELOG.md`, `packages/coding-agent/CHANGELOG.md`, and `packages/ai/src/changes.md`.
- No schema, grouping, or parameter changes; risk low and scoped to Cursor.

<sup>Written for commit 380daef2f8919902f31168cff591a39030adefa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

