### PR TITLE
fix(release): link nested pnpm workspace dependencies

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -22,6 +22,9 @@ Every remaining audited production path with no nearer tracker than the root:
   `build:npm`/`build:bun`/`build:pnpm` entry points, root `check` swapped `tsgo --noEmit` for
   `tsc --noEmit` and added `check:claude-sdk-platform-lock` plus script-based browser smoke, and
   fork-only `verify:pms` orchestration was added.
+- `pnpm-workspace.yaml`: mirrors the root npm workspace's nested
+  `packages/session-backends/*` glob so the pnpm parity build installs and links the sqlite
+  session backend's workspace dependencies before `scripts/build-all.mjs` builds it.
 - `tsconfig.base.json`: `target`/`lib` raised from `ES2022` to `ES2024`.
 - `tsconfig.json`: reformatted to the fork's biome multi-line layout; workspace path mappings are
   semantically unchanged.
@@ -37,7 +40,8 @@ Every remaining audited production path with no nearer tracker than the root:
 - `packages/session-backends/sqlite-node/package.json`: renamed
   `@earendil-works/pi-session-backend-sqlite-node` ->
   `@earendil-works/pi-storage-sqlite-node`, made private and independently versioned at
-  `0.83.0`, `tsgo` -> `tsc`, and workspace deps switched to `file:` references.
+  `0.83.0`, `tsgo` -> `tsc`, and keeps its runtime `pi-agent-core` / `pi-ai` dependencies on
+  lockstep semver ranges so npm, Bun, and pnpm all link the live workspace packages.
 - `packages/session-backends/sqlite-node/src/sqlite/repo.ts`: optional-chaining refactor of the
   message-target guard.
 - `packages/telemetry/package.json`: private CalVer `2026.8.16`.

--- a/changes.md
+++ b/changes.md
@@ -122,3 +122,34 @@ Every remaining audited production path with no nearer tracker than the root:
 - Builtin registration and widget internals under
   `packages/coding-agent/src/core/extensions/builtin/` if upstream reworks extension loading
   or adds overlapping notices.
+
+## Pnpm parity for the nested SQLite session backend (2026-08-19)
+
+### What changed
+
+- `pnpm-workspace.yaml` now includes `packages/session-backends/*`, matching the root npm
+  workspace and the package set explicitly built by `scripts/build-all.mjs`.
+- `packages/session-backends/sqlite-node/package.json` declares its shipped
+  `pi-agent-core` / `pi-ai` imports as lockstep runtime dependencies instead of packed
+  `file:` dev dependencies.
+- `scripts/sync-versions.js` keeps the backend's own `0.83.0` version independent while
+  synchronizing those lockstep dependency ranges during Senpi releases.
+
+### Why
+
+- The release pre-commit gate verifies npm, Bun, and pnpm. Pnpm previously excluded the
+  nested backend from its workspace and then, once included, packed its `file:` dependencies
+  before their declarations were built. The ordered build therefore reached the backend with
+  unresolved `pi-agent-core` / `pi-ai` types even though npm and Bun passed.
+
+### Why an extension could not handle it
+
+- This is package-manager workspace topology and release-version synchronization. Runtime
+  extensions load only after packages install and build, so they cannot repair missing
+  workspace membership, dependency links, or manifest pins.
+
+### Expected merge conflict zones
+
+- Upstream changes to the SQLite backend's dependency placement or independent-version policy.
+- Future workspace additions under nested `packages/*/*` paths, which must remain aligned
+  across root npm workspaces, `pnpm-workspace.yaml`, and `scripts/build-all.mjs`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8189,9 +8189,11 @@
 			"name": "@earendil-works/pi-storage-sqlite-node",
 			"version": "0.83.0",
 			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-agent-core": "^2026.8.18-3",
+				"@earendil-works/pi-ai": "^2026.8.18-3"
+			},
 			"devDependencies": {
-				"@earendil-works/pi-agent-core": "file:../../agent",
-				"@earendil-works/pi-ai": "file:../../ai",
 				"@vitest/coverage-v8": "4.1.9",
 				"vitest": "4.1.9"
 			},

--- a/packages/session-backends/sqlite-node/package.json
+++ b/packages/session-backends/sqlite-node/package.json
@@ -34,9 +34,11 @@
 	"engines": {
 		"node": ">=22.19.0"
 	},
+	"dependencies": {
+		"@earendil-works/pi-ai": "^2026.8.18-3",
+		"@earendil-works/pi-agent-core": "^2026.8.18-3"
+	},
 	"devDependencies": {
-		"@earendil-works/pi-ai": "file:../../ai",
-		"@earendil-works/pi-agent-core": "file:../../agent",
 		"@vitest/coverage-v8": "4.1.9",
 		"vitest": "4.1.9"
 	}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "packages/*"
+  - "packages/session-backends/*"
   - "packages/coding-agent/examples/extensions/with-deps"
   - "packages/coding-agent/examples/extensions/custom-provider-anthropic"
   - "packages/coding-agent/examples/extensions/custom-provider-gitlab-duo"

--- a/scripts/build-all.test.mjs
+++ b/scripts/build-all.test.mjs
@@ -51,6 +51,18 @@ describe("build-all", () => {
 		assert.ok(index("packages/server") > index("packages/coding-agent"));
 	});
 
+	it("keeps every explicitly built package inside the pnpm workspace", () => {
+		// Given
+		const pnpmWorkspace = readFileSync(join(root, "pnpm-workspace.yaml"), "utf8");
+
+		// When
+		const nestedBuildPackages = BUILD_PHASES.flat().filter((path) => path.split("/").length > 2);
+
+		// Then
+		assert.deepEqual(nestedBuildPackages, ["packages/session-backends/sqlite-node"]);
+		assert.match(pnpmWorkspace, /^  - "packages\/session-backends\/\*"$|^  - packages\/session-backends\/\*$/m);
+	});
+
 	it("builds pty beside tui in the first native-adjacent phase", () => {
 		// Given
 		const packageJson = JSON.parse(readFileSync(join(root, "packages/pty/package.json"), "utf8"));

--- a/scripts/changes.md
+++ b/scripts/changes.md
@@ -405,3 +405,31 @@
 - Root `package.json` static-check scripts.
 - Release/dependency lock tests under `scripts/`.
 
+## Independent workspace dependency synchronization (2026-08-19)
+
+### What changed
+
+- `scripts/sync-versions.js` now visits independently versioned private workspaces when it
+  synchronizes dependencies, while still excluding their own package versions from the Senpi
+  CalVer lockstep invariant.
+- `scripts/sync-versions.test.mjs` covers the SQLite backend retaining version `0.83.0` while
+  its `pi-agent-core` and `pi-ai` dependency ranges advance to the current lockstep version.
+
+### Why
+
+- The nested SQLite backend ships imports from the lockstep agent and AI packages. Keeping its
+  own upstream version independent must not leave those runtime dependency ranges stale during
+  a Senpi release.
+
+### Why an extension could not handle it
+
+- Version synchronization mutates package manifests before build, commit, tag, and publication.
+  Extensions run only after installation and cannot participate in release-time manifest
+  generation.
+
+### Expected conflict zones
+
+- Future changes to the independent-package allowlist in `scripts/sync-versions.js`.
+- Upstream changes that add more independently versioned workspaces with lockstep runtime
+  dependencies.
+

--- a/scripts/publish-registry-dependencies.test.mjs
+++ b/scripts/publish-registry-dependencies.test.mjs
@@ -48,6 +48,10 @@ describe("npm publish dependency graph", () => {
 			const manifest = readJson(join(repoRoot, workspace.packageJsonPath));
 			assert.equal(manifest.private, true, `${workspace.packageName} must remain excluded from fork publishing`);
 			assert.doesNotMatch(publishScript, new RegExp(`name: "${workspace.packageName}"`));
+			assert.equal(manifest.dependencies["@earendil-works/pi-agent-core"], "^2026.8.18-3");
+			assert.equal(manifest.dependencies["@earendil-works/pi-ai"], "^2026.8.18-3");
+			assert.equal(manifest.devDependencies["@earendil-works/pi-agent-core"], undefined);
+			assert.equal(manifest.devDependencies["@earendil-works/pi-ai"], undefined);
 		}
 		for (const packageName of OWNED_REGISTRY_ALIASES) {
 			assert.match(publishScript, new RegExp(`name: "${packageName}"`));

--- a/scripts/publish-registry-dependencies.test.mjs
+++ b/scripts/publish-registry-dependencies.test.mjs
@@ -46,10 +46,12 @@ describe("npm publish dependency graph", () => {
 		}
 		for (const workspace of INDEPENDENT_UPSTREAM_WORKSPACES) {
 			const manifest = readJson(join(repoRoot, workspace.packageJsonPath));
+			const aiManifest = readJson(join(repoRoot, "packages/ai/package.json"));
+			const agentManifest = readJson(join(repoRoot, "packages/agent/package.json"));
 			assert.equal(manifest.private, true, `${workspace.packageName} must remain excluded from fork publishing`);
 			assert.doesNotMatch(publishScript, new RegExp(`name: "${workspace.packageName}"`));
-			assert.equal(manifest.dependencies["@earendil-works/pi-agent-core"], "^2026.8.18-3");
-			assert.equal(manifest.dependencies["@earendil-works/pi-ai"], "^2026.8.18-3");
+			assert.equal(manifest.dependencies["@earendil-works/pi-agent-core"], `^${agentManifest.version}`);
+			assert.equal(manifest.dependencies["@earendil-works/pi-ai"], `^${aiManifest.version}`);
 			assert.equal(manifest.devDependencies["@earendil-works/pi-agent-core"], undefined);
 			assert.equal(manifest.devDependencies["@earendil-works/pi-ai"], undefined);
 		}

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -38,9 +38,11 @@ const workspacePackages = findPackageDirectories(packageRoot)
 		const path = join(directory, "package.json");
 		const data = JSON.parse(readFileSync(path, "utf8"));
 		return { data, name: data.name, path };
-	})
-	.filter((pkg) => !INDEPENDENT_VERSION_PACKAGE_NAMES.has(pkg.data.name));
-const publishedPackages = resolveRegistryPackages(workspacePackages);
+	});
+const lockstepPackages = workspacePackages.filter(
+	(pkg) => !INDEPENDENT_VERSION_PACKAGE_NAMES.has(pkg.data.name),
+);
+const publishedPackages = resolveRegistryPackages(lockstepPackages);
 const versionMap = new Map(workspacePackages.map((pkg) => [pkg.data.name, pkg.data.version]));
 
 console.log("Current versions:");

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -43,7 +43,7 @@ const lockstepPackages = workspacePackages.filter(
 	(pkg) => !INDEPENDENT_VERSION_PACKAGE_NAMES.has(pkg.data.name),
 );
 const publishedPackages = resolveRegistryPackages(lockstepPackages);
-const versionMap = new Map(workspacePackages.map((pkg) => [pkg.data.name, pkg.data.version]));
+const versionMap = new Map(lockstepPackages.map((pkg) => [pkg.data.name, pkg.data.version]));
 
 console.log("Current versions:");
 for (const pkg of [...publishedPackages].sort((a, b) => a.data.name.localeCompare(b.data.name))) {

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -13,7 +13,7 @@ import { resolveRegistryPackages } from "./registry-packages.mjs";
 const GENERATED_PACKAGE_SUFFIXES = [join("coding-agent", "install-lock")];
 // Fork-specific: `@earendil-works/pi-storage-sqlite-node` follows upstream's independent
 // semver line (see scripts/publish.mjs), so it stays out of this fork's CalVer lockstep
-// validation and its dependency pins are left alone.
+// validation while its dependencies still follow the current workspace package versions.
 const INDEPENDENT_VERSION_PACKAGE_NAMES = new Set([
 	"@earendil-works/pi-storage-sqlite-node",
 ]);

--- a/scripts/sync-versions.test.mjs
+++ b/scripts/sync-versions.test.mjs
@@ -58,6 +58,7 @@ test("synchronizes private dependencies without touching registry aliases, gener
 			dependencies: {
 				"@code-yeongyu/senpi": "^1.0.0",
 				"@mariozechner/pi-ai": "npm:@earendil-works/pi-ai@1.0.0",
+				"@earendil-works/pi-storage-sqlite-node": "^0.70.0",
 			},
 		});
 		await writeManifest(root, "packages/session-backends/sqlite-node", {
@@ -84,6 +85,7 @@ test("synchronizes private dependencies without touching registry aliases, gener
 		const evalsManifest = await readManifest(root, "packages/evals");
 		assert.equal(evalsManifest.dependencies["@code-yeongyu/senpi"], "^2.0.0");
 		assert.equal(evalsManifest.dependencies["@mariozechner/pi-ai"], "npm:@earendil-works/pi-ai@1.0.0");
+		assert.equal(evalsManifest.dependencies["@earendil-works/pi-storage-sqlite-node"], "^0.70.0");
 		const sqliteManifest = await readManifest(root, "packages/session-backends/sqlite-node");
 		assert.equal(sqliteManifest.version, "0.83.0");
 		assert.equal(sqliteManifest.dependencies["@earendil-works/pi-agent-core"], "^2.0.0");

--- a/scripts/sync-versions.test.mjs
+++ b/scripts/sync-versions.test.mjs
@@ -60,6 +60,15 @@ test("synchronizes private dependencies without touching registry aliases, gener
 				"@mariozechner/pi-ai": "npm:@earendil-works/pi-ai@1.0.0",
 			},
 		});
+		await writeManifest(root, "packages/session-backends/sqlite-node", {
+			name: "@earendil-works/pi-storage-sqlite-node",
+			version: "0.83.0",
+			private: true,
+			dependencies: {
+				"@earendil-works/pi-agent-core": "^1.0.0",
+				"@earendil-works/pi-ai": "^1.0.0",
+			},
+		});
 		await writeManifest(root, "packages/coding-agent/install-lock", {
 			name: "generated-install-lock",
 			version: "0.0.0",
@@ -75,6 +84,10 @@ test("synchronizes private dependencies without touching registry aliases, gener
 		const evalsManifest = await readManifest(root, "packages/evals");
 		assert.equal(evalsManifest.dependencies["@code-yeongyu/senpi"], "^2.0.0");
 		assert.equal(evalsManifest.dependencies["@mariozechner/pi-ai"], "npm:@earendil-works/pi-ai@1.0.0");
+		const sqliteManifest = await readManifest(root, "packages/session-backends/sqlite-node");
+		assert.equal(sqliteManifest.version, "0.83.0");
+		assert.equal(sqliteManifest.dependencies["@earendil-works/pi-agent-core"], "^2.0.0");
+		assert.equal(sqliteManifest.dependencies["@earendil-works/pi-ai"], "^2.0.0");
 		const generatedManifest = await readManifest(root, "packages/coding-agent/install-lock");
 		assert.equal(generatedManifest.dependencies["@code-yeongyu/senpi"], "^1.0.0");
 


### PR DESCRIPTION
## Summary

Fix the package-manager parity gate that blocked the Senpi `2026.8.19` release.

The root npm workspace and `build-all.mjs` both include the nested SQLite session backend, but `pnpm-workspace.yaml` did not. After adding the missing workspace glob, pnpm exposed a second cross-manager mismatch: the backend's runtime imports were declared as packed `file:` dev dependencies, so pnpm installed stale copies without built declarations. The backend now uses normal lockstep runtime dependency ranges, and version synchronization updates those dependency pins while preserving the backend's independent `0.83.0` version.

## Changes

- Mirror `packages/session-backends/*` in the pnpm workspace.
- Declare the SQLite backend's `pi-agent-core` and `pi-ai` imports as runtime dependencies.
- Keep the backend outside CalVer version lockstep while still synchronizing its lockstep dependency ranges.
- Add regression coverage for workspace parity, manifest shape, and independent-package dependency synchronization.
- Refresh the npm workspace metadata lock entry and root `changes.md` tracker.

## QA & Evidence

- **Failing-first workspace contract:** `node --test scripts/build-all.test.mjs`
  - Observed failure: `pnpm-workspace.yaml` lacked `packages/session-backends/*`.
- **Failing-first dependency contract:** `node --test scripts/sync-versions.test.mjs scripts/publish-registry-dependencies.test.mjs`
  - Observed failures: SQLite runtime dependencies were absent from `dependencies`; independent-package pins stayed on the old lockstep version.
- **Focused GREEN:** all three script test files pass after the fix.
- **Release parity GREEN:** `node scripts/verify-package-managers.mjs`
  - Observed: `✓ npm`, `✓ bun`, `✓ pnpm`.
- **Static gate:** `npm run check`
  - Observed: check, pinned dependencies, TS imports, generated lock checks, TypeScript, and browser smoke passed.
- **Tracker audit:** `node scripts/audit-changes-md.mjs --format json`
  - Observed: exit 0.
- **Commit hook:** the committed tree repeated all three package-manager builds and browser smoke successfully.

Evidence is retained locally under `local-ignore/qa-evidence/20260819-pnpm-nested-session-backend-workspace/`; no credentials or environment dumps are included.

## Risks & Residuals

- The SQLite backend remains private and independently versioned; only its runtime dependency ranges follow the Senpi lockstep version.
- No runtime agent behavior changed. The affected user surface is the release/install build matrix.

Fixes #964
