### PR TITLE
fix(cursor): persist and retry conversationId after 0-token RE

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -11,6 +11,15 @@
 ### Fixed
 
 - Cursor conversation-id rotation now persists under the agent directory (`CODING_AGENT_DIR` or `~/.senpi/agent`) instead of `$HOME/cursor-conversation-ids.json`, so a reminted wire id survives TUI restart.
+- Cursor 0-token `resource_exhausted` surfaces on the first failure of a `stream()` call so the session layer can compact before any conversation-id rotation; rotation and same-stream retry apply only to later attempts, and the poisoned-conversation error surfaces once the 3-rotation cap is reached.
+- Cursor 0-token `resource_exhausted` is treated as overflow without a local-estimate floor, and Cursor overflow compaction keeps no recent-token tail so the retry payload actually shrinks.
+- Cursor billed `cacheRead` that dwarfs the live conversation window is ignored: checkpoint `usedTokens` is treated as the real context size when dashboard-cumulative `cache_read_tokens` is more than 3× that window, so compaction is not fired against a multi-million cache-read figure (#983).
+
+- Explicit Cursor thinking levels no longer die with `Connect error not_found`: Cursor's Run RPC
+  rejects bare capability ids (`kimi-k3`, `claude-fable-5`, …) with `not_found`, so
+  `resolveCursorSelectionDescriptor` now prefers the catalog-guaranteed suffix variant id
+  (`kimi-k3-high`, `claude-fable-5-thinking-low`) whenever a legacy alias exists, keeping bare
+  base id + ordered parameters only as the fallback for alias-less levels (#1008).
 
 ### Removed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Cursor conversation-id rotation now persists under the agent directory (`CODING_AGENT_DIR` or `~/.senpi/agent`) instead of `$HOME/cursor-conversation-ids.json`, so a reminted wire id survives TUI restart.
+
 ### Removed
 
 ## [2026.8.19] - 2026-08-19

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -493,9 +493,6 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 			}
 
 			baseConversationId = options?.conversationId ?? options?.sessionId ?? randomUUID();
-			if (rotationStore().shouldSkip(baseConversationId)) {
-				throw new Error(CURSOR_CONVERSATION_POISONED_MESSAGE);
-			}
 			conversationId = rotationStore().getWireId(baseConversationId);
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -48,12 +48,6 @@ import {
 } from "../utils/block-symbols.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
-import {
-	CURSOR_CONVERSATION_POISONED_MESSAGE,
-	createConversationRotationStore,
-	isZeroTokenResourceExhausted,
-	resolveConversationRotationPersistPath,
-} from "./cursor-conversation-rotation.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { deterministicUuid } from "./cursor-agent/deterministic-id.ts";
@@ -230,6 +224,12 @@ import type {
 	CursorShellStreamCallbacks,
 	CursorToolResultHandler,
 } from "./cursor-agent/types.ts";
+import {
+	CURSOR_CONVERSATION_POISONED_MESSAGE,
+	createConversationRotationStore,
+	isZeroTokenResourceExhausted,
+	resolveConversationRotationPersistPath,
+} from "./cursor-conversation-rotation.ts";
 
 export type {
 	CursorAgentOptions,
@@ -486,259 +486,279 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				resolveH2 = resolve;
 				rejectH2 = reject;
 			});
-		try {
-			const apiKey = options?.apiKey;
-			if (!apiKey) {
-				throw new Error("Cursor access token is required; run /login cursor");
-			}
-
-			baseConversationId = options?.conversationId ?? options?.sessionId ?? randomUUID();
-			conversationId = rotationStore().getWireId(baseConversationId);
-			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
-			conversationBlobStores.set(conversationId, blobStore);
-			const cachedState = conversationStateCache.get(conversationId);
-			const { requestBytes, conversationState } = await buildGrpcRequest(model, context, options, {
-				conversationId,
-				blobStore,
-				conversationState: cachedState,
-			});
-			conversationStateCache.set(conversationId, conversationState);
-			const requestContextTools = buildMcpToolDefinitions(context.tools);
-
-			const baseUrl = model.baseUrl || CURSOR_API_URL;
-			const requestPath = "/agent.v1.AgentService/Run";
-			// Caller headers are additive, and are spread FIRST so the protocol
-			// framing, auth, and request id below always win.
-			const callerHeaders = sanitizeCursorCallerHeaders(providerHeadersToRecord(options?.headers));
-			const requestHeaders = {
-				...callerHeaders,
-				":method": "POST",
-				":path": requestPath,
-				"content-type": "application/connect+proto",
-				"connect-protocol-version": "1",
-				te: "trailers",
-				authorization: `Bearer ${apiKey}`,
-				"x-ghost-mode": "true",
-				"x-cursor-client-version": CURSOR_CLIENT_VERSION,
-				"x-cursor-client-type": "cli",
-				"x-request-id": randomUUID(),
-			};
-
-			h2Client = http2.connect(baseUrl);
-			h2Client.on("error", (error) => settleH2(mapH2TransportError(error, baseUrl)));
-
-			h2Request = h2Client.request(requestHeaders);
-
-			if (attempt === 1) {
-				stream.push({ type: "start", partial: output });
-			}
-
-			let pendingBuffer: Buffer = Buffer.alloc(0);
-			let currentTextBlock: (TextContent & { [kStreamingBlockIndex]: number }) | null = null;
-			let currentThinkingBlock: (ThinkingContent & { [kStreamingBlockIndex]: number }) | null = null;
-			let currentToolCall: ToolCallState | null = null;
-			const resolvedMcpToolCallIds = new Set<string>();
-			usageState = { sawTokenDelta: false, sawTurnEndedUsage: false };
-
-			const state: BlockState = {
-				get currentTextBlock() {
-					return currentTextBlock;
-				},
-				get currentThinkingBlock() {
-					return currentThinkingBlock;
-				},
-				get currentToolCall() {
-					return currentToolCall;
-				},
-				openToolCalls: new Map<string, ToolCallState>(),
-				resolvedMcpToolCallIds,
-				setTextBlock: (b) => {
-					currentTextBlock = b;
-				},
-				setThinkingBlock: (b) => {
-					currentThinkingBlock = b;
-				},
-				setToolCall: (t) => {
-					currentToolCall = t;
-				},
-				onToolResult: options?.onToolResult ?? options?.execHandlers?.onToolResult,
-			};
-			openBlockState = state;
-
-			const onConversationCheckpoint = (checkpoint: ConversationStateStructure) => {
-				conversationStateCache.set(conversationId!, checkpoint);
-			};
-
-			h2Request.on("data", (chunk: Buffer) => {
-				// Steady state drains fully per chunk; alias the fresh h2 chunk
-				// instead of copying it through Buffer.concat.
-				pendingBuffer = pendingBuffer.length === 0 ? chunk : Buffer.concat([pendingBuffer, chunk]);
-
-				while (pendingBuffer.length >= 5) {
-					const flags = pendingBuffer[0];
-					const msgLen = pendingBuffer.readUInt32BE(1);
-					if (pendingBuffer.length < 5 + msgLen) break;
-
-					const messageBytes = pendingBuffer.subarray(5, 5 + msgLen);
-					pendingBuffer = pendingBuffer.subarray(5 + msgLen);
-
-					if (flags & CONNECT_END_STREAM_FLAG) {
-						const endError = parseConnectEndStream(messageBytes);
-						if (endError) {
-							endStreamError = endError;
-							h2Request?.close();
-						}
-						continue;
-					}
-
-					try {
-						const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
-						const isTurnEnded =
-							serverMessage.message.case === "interactionUpdate" &&
-							serverMessage.message.value.message?.case === "turnEnded";
-						// Dispatch is fire-and-forget so the socket keeps draining
-						// while a handler runs, but the promise is tracked: `done`
-						// must not be pushed while an exec handler is still resolving,
-						// or the buffered tool result is delivered after the turn
-						// already finalized and the call is left unpaired.
-						const dispatch = handleServerMessage(
-							serverMessage,
-							output,
-							stream,
-							state,
-							blobStore,
-							h2Request!,
-							options?.execHandlers,
-							state.onToolResult,
-							usageState!,
-							requestContextTools,
-							onConversationCheckpoint,
-						).catch((error) => {
-							log("error", "handleServerMessage", { error: String(error) });
-						});
-						inFlightDispatches.add(dispatch);
-						void dispatch.finally(() => inFlightDispatches.delete(dispatch));
-
-						// Application completion is not protocol success; wait for a
-						// clean HTTP/2 end.
-						if (isTurnEnded) {
-							sawTurnEnded = true;
-						}
-					} catch (e) {
-						log("error", "parseServerMessage", { error: String(e) });
-					}
+			try {
+				const apiKey = options?.apiKey;
+				if (!apiKey) {
+					throw new Error("Cursor access token is required; run /login cursor");
 				}
-			});
 
-			const sendHeartbeat = () => {
-				if (!h2Request || h2Request.closed) {
-					return;
-				}
-				const heartbeatMessage = create(AgentClientMessageSchema, {
-					message: { case: "clientHeartbeat", value: create(ClientHeartbeatSchema, {}) },
-				});
-				const heartbeatBytes = toBinary(AgentClientMessageSchema, heartbeatMessage);
-				h2Request.write(frameConnectMessage(heartbeatBytes));
-			};
-
-			h2Request.on("trailers", (trailers) => {
-				const status = trailers["grpc-status"];
-				const msg = trailers["grpc-message"];
-				if (status && status !== "0" && !endStreamError) {
-					endStreamError = new Error(`gRPC error ${status}: ${decodeURIComponent(String(msg || ""))}`);
-				}
-			});
-
-			h2Request.on("end", () => {
-				settleH2();
-			});
-
-			h2Request.on("error", (error) => {
-				settleH2(mapH2TransportError(error, baseUrl));
-			});
-
-			if (options?.signal) {
-				options.signal.addEventListener("abort", () => {
-					h2Request?.close();
-					settleH2(new Error("Request was aborted"));
-				});
-			}
-
-			h2Request.write(frameConnectMessage(requestBytes));
-			heartbeatTimer = setInterval(sendHeartbeat, 5000);
-			await h2Completion;
-			// The transport is done, but a handler decoded from the last chunk
-			// may still be running. Pushing `done` now would let the host drain
-			// its buffered tool results before such a handler reserved its entry,
-			// leaving the call unpaired and stripped from rebuilt transcripts.
-			await drainInFlightDispatches();
-
-			endCurrentTextBlock(output, stream, state);
-			endCurrentThinkingBlock(output, stream, state);
-			flushOpenToolCalls(output, stream, state);
-
-			calculateCost(model, output.usage);
-
-			stream.push({
-				type: "done",
-				reason: output.stopReason as "stop" | "length" | "toolUse",
-				message: output,
-			});
-			stream.end();
-		} catch (error) {
-			// Same reason as the success path: a handler still running would land
-			// its real result after the turn finalized and be discarded — even
-			// though the tool may already have run side effects. On abort the
-			// drain returns immediately.
-			await drainInFlightDispatches();
-			// A stream that dies mid-turn leaves blocks open. Closing them here
-			// settles their live cards and pairs the server-owned calls that
-			// nothing else answers — an unpaired call is stripped from every
-			// rebuilt transcript.
-			if (openBlockState) {
-				endCurrentTextBlock(output, stream, openBlockState);
-				endCurrentThinkingBlock(output, stream, openBlockState);
-				flushOpenToolCalls(output, stream, openBlockState);
-			}
-			const message = error instanceof Error ? error.message : JSON.stringify(error);
-			// A server-side per-conversation rejection surfaces as a bare
-			// resource_exhausted with zero tokens — the conversation is poisoned,
-			// not the account. Rotate the wire id, persist it, and retry this
-			// stream() before the model-fallback chain jumps providers.
-			if (
-				conversationId !== undefined &&
-				baseConversationId !== undefined &&
-				usageState !== undefined &&
-				isZeroTokenResourceExhausted(message, usageState.sawTokenDelta)
-			) {
-				const decision = rotationStore().recordZeroTokenPoison(
-					baseConversationId,
+				baseConversationId = options?.conversationId ?? options?.sessionId ?? randomUUID();
+				conversationId = rotationStore().getWireId(baseConversationId);
+				const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
+				conversationBlobStores.set(conversationId, blobStore);
+				const cachedState = conversationStateCache.get(conversationId);
+				const { requestBytes, conversationState } = await buildGrpcRequest(model, context, options, {
 					conversationId,
-				);
-				if (decision.kind === "rotated") {
-					const cached = conversationStateCache.get(conversationId);
-					if (cached) conversationStateCache.set(decision.wireId, cached);
-					const blobs = conversationBlobStores.get(conversationId);
-					if (blobs) conversationBlobStores.set(decision.wireId, blobs);
-					retryPoisonedConversation = true;
+					blobStore,
+					conversationState: cachedState,
+				});
+				conversationStateCache.set(conversationId, conversationState);
+				const requestContextTools = buildMcpToolDefinitions(context.tools);
+
+				const baseUrl = model.baseUrl || CURSOR_API_URL;
+				const requestPath = "/agent.v1.AgentService/Run";
+				// Caller headers are additive, and are spread FIRST so the protocol
+				// framing, auth, and request id below always win.
+				const callerHeaders = sanitizeCursorCallerHeaders(providerHeadersToRecord(options?.headers));
+				const requestHeaders = {
+					...callerHeaders,
+					":method": "POST",
+					":path": requestPath,
+					"content-type": "application/connect+proto",
+					"connect-protocol-version": "1",
+					te: "trailers",
+					authorization: `Bearer ${apiKey}`,
+					"x-ghost-mode": "true",
+					"x-cursor-client-version": CURSOR_CLIENT_VERSION,
+					"x-cursor-client-type": "cli",
+					"x-request-id": randomUUID(),
+				};
+
+				h2Client = http2.connect(baseUrl);
+				h2Client.on("error", (error) => settleH2(mapH2TransportError(error, baseUrl)));
+
+				h2Request = h2Client.request(requestHeaders);
+
+				if (attempt === 1) {
+					stream.push({ type: "start", partial: output });
 				}
-			}
-			if (!retryPoisonedConversation) {
-				output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-				output.errorMessage = message;
-				stream.push({ type: "error", reason: output.stopReason, error: output });
+
+				let pendingBuffer: Buffer = Buffer.alloc(0);
+				let currentTextBlock: (TextContent & { [kStreamingBlockIndex]: number }) | null = null;
+				let currentThinkingBlock: (ThinkingContent & { [kStreamingBlockIndex]: number }) | null = null;
+				let currentToolCall: ToolCallState | null = null;
+				const resolvedMcpToolCallIds = new Set<string>();
+				usageState = { sawTokenDelta: false, sawTurnEndedUsage: false };
+
+				const state: BlockState = {
+					get currentTextBlock() {
+						return currentTextBlock;
+					},
+					get currentThinkingBlock() {
+						return currentThinkingBlock;
+					},
+					get currentToolCall() {
+						return currentToolCall;
+					},
+					openToolCalls: new Map<string, ToolCallState>(),
+					resolvedMcpToolCallIds,
+					setTextBlock: (b) => {
+						currentTextBlock = b;
+					},
+					setThinkingBlock: (b) => {
+						currentThinkingBlock = b;
+					},
+					setToolCall: (t) => {
+						currentToolCall = t;
+					},
+					onToolResult: options?.onToolResult ?? options?.execHandlers?.onToolResult,
+				};
+				openBlockState = state;
+
+				const onConversationCheckpoint = (checkpoint: ConversationStateStructure) => {
+					conversationStateCache.set(conversationId!, checkpoint);
+				};
+
+				h2Request.on("data", (chunk: Buffer) => {
+					// Steady state drains fully per chunk; alias the fresh h2 chunk
+					// instead of copying it through Buffer.concat.
+					pendingBuffer = pendingBuffer.length === 0 ? chunk : Buffer.concat([pendingBuffer, chunk]);
+
+					while (pendingBuffer.length >= 5) {
+						const flags = pendingBuffer[0];
+						const msgLen = pendingBuffer.readUInt32BE(1);
+						if (pendingBuffer.length < 5 + msgLen) break;
+
+						const messageBytes = pendingBuffer.subarray(5, 5 + msgLen);
+						pendingBuffer = pendingBuffer.subarray(5 + msgLen);
+
+						if (flags & CONNECT_END_STREAM_FLAG) {
+							const endError = parseConnectEndStream(messageBytes);
+							if (endError) {
+								endStreamError = endError;
+								h2Request?.close();
+							}
+							continue;
+						}
+
+						try {
+							const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
+							const isTurnEnded =
+								serverMessage.message.case === "interactionUpdate" &&
+								serverMessage.message.value.message?.case === "turnEnded";
+							// Dispatch is fire-and-forget so the socket keeps draining
+							// while a handler runs, but the promise is tracked: `done`
+							// must not be pushed while an exec handler is still resolving,
+							// or the buffered tool result is delivered after the turn
+							// already finalized and the call is left unpaired.
+							const dispatch = handleServerMessage(
+								serverMessage,
+								output,
+								stream,
+								state,
+								blobStore,
+								h2Request!,
+								options?.execHandlers,
+								state.onToolResult,
+								usageState!,
+								requestContextTools,
+								onConversationCheckpoint,
+							).catch((error) => {
+								log("error", "handleServerMessage", { error: String(error) });
+							});
+							inFlightDispatches.add(dispatch);
+							void dispatch.finally(() => inFlightDispatches.delete(dispatch));
+
+							// Application completion is not protocol success; wait for a
+							// clean HTTP/2 end.
+							if (isTurnEnded) {
+								sawTurnEnded = true;
+							}
+						} catch (e) {
+							log("error", "parseServerMessage", { error: String(e) });
+						}
+					}
+				});
+
+				const sendHeartbeat = () => {
+					if (!h2Request || h2Request.closed) {
+						return;
+					}
+					const heartbeatMessage = create(AgentClientMessageSchema, {
+						message: { case: "clientHeartbeat", value: create(ClientHeartbeatSchema, {}) },
+					});
+					const heartbeatBytes = toBinary(AgentClientMessageSchema, heartbeatMessage);
+					h2Request.write(frameConnectMessage(heartbeatBytes));
+				};
+
+				h2Request.on("trailers", (trailers) => {
+					const status = trailers["grpc-status"];
+					const msg = trailers["grpc-message"];
+					if (status && status !== "0" && !endStreamError) {
+						endStreamError = new Error(`gRPC error ${status}: ${decodeURIComponent(String(msg || ""))}`);
+					}
+				});
+
+				h2Request.on("end", () => {
+					settleH2();
+				});
+
+				h2Request.on("error", (error) => {
+					settleH2(mapH2TransportError(error, baseUrl));
+				});
+
+				if (options?.signal) {
+					options.signal.addEventListener("abort", () => {
+						h2Request?.close();
+						settleH2(new Error("Request was aborted"));
+					});
+				}
+
+				h2Request.write(frameConnectMessage(requestBytes));
+				heartbeatTimer = setInterval(sendHeartbeat, 5000);
+				await h2Completion;
+				// The transport is done, but a handler decoded from the last chunk
+				// may still be running. Pushing `done` now would let the host drain
+				// its buffered tool results before such a handler reserved its entry,
+				// leaving the call unpaired and stripped from rebuilt transcripts.
+				await drainInFlightDispatches();
+
+				endCurrentTextBlock(output, stream, state);
+				endCurrentThinkingBlock(output, stream, state);
+				flushOpenToolCalls(output, stream, state);
+
+				calculateCost(model, output.usage);
+
+				stream.push({
+					type: "done",
+					reason: output.stopReason as "stop" | "length" | "toolUse",
+					message: output,
+				});
 				stream.end();
+			} catch (error) {
+				// Same reason as the success path: a handler still running would land
+				// its real result after the turn finalized and be discarded — even
+				// though the tool may already have run side effects. On abort the
+				// drain returns immediately.
+				await drainInFlightDispatches();
+				// A stream that dies mid-turn leaves blocks open. Closing them here
+				// settles their live cards and pairs the server-owned calls that
+				// nothing else answers — an unpaired call is stripped from every
+				// rebuilt transcript.
+				if (openBlockState) {
+					endCurrentTextBlock(output, stream, openBlockState);
+					endCurrentThinkingBlock(output, stream, openBlockState);
+					flushOpenToolCalls(output, stream, openBlockState);
+				}
+				let message = error instanceof Error ? error.message : JSON.stringify(error);
+				// A server-side per-conversation rejection surfaces as a bare
+				// resource_exhausted with zero tokens. That has two distinct causes:
+				// an oversized payload, and a genuinely poisoned conversationId.
+				// Only the second is fixed by rotating the wire id.
+				//
+				// The FIRST 0-token RE for a base conversation always surfaces without
+				// rotating, so the session layer gets first refusal: agent-session
+				// classifies a surfaced 0-token RE as overflow and compacts before
+				// retrying. Rotating here instead would swallow the error, make that
+				// compaction dead code, and burn the 3-rotation budget replaying the
+				// same oversized payload. Once that surface has happened (the flag is
+				// persisted with the wire id), compaction has had its turn and further
+				// 0-token REs rotate and retry in-call, up to the cap.
+				if (
+					conversationId !== undefined &&
+					baseConversationId !== undefined &&
+					usageState !== undefined &&
+					isZeroTokenResourceExhausted(message, usageState.sawTokenDelta)
+				) {
+					if (rotationStore().shouldSkip(baseConversationId)) {
+						// The base conversation burned its rotation cap; another wire id
+						// will not help, so surface the poisoned-conversation error and
+						// let the session move to a different provider.
+						message = CURSOR_CONVERSATION_POISONED_MESSAGE;
+					} else if (rotationStore().shouldSurfaceBeforeRotating(baseConversationId)) {
+						// First 0-token RE for this conversation: surface it so the
+						// session layer can compact. If the payload really was oversized,
+						// the compacted retry succeeds and no rotation is ever spent.
+						rotationStore().markSurfaced(baseConversationId, conversationId);
+					} else {
+						const decision = rotationStore().recordZeroTokenPoison(baseConversationId, conversationId);
+						if (decision.kind === "rotated") {
+							const cached = conversationStateCache.get(conversationId);
+							if (cached) conversationStateCache.set(decision.wireId, cached);
+							const blobs = conversationBlobStores.get(conversationId);
+							if (blobs) conversationBlobStores.set(decision.wireId, blobs);
+							retryPoisonedConversation = true;
+						} else {
+							message = CURSOR_CONVERSATION_POISONED_MESSAGE;
+						}
+					}
+				}
+				if (!retryPoisonedConversation) {
+					output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+					output.errorMessage = message;
+					stream.push({ type: "error", reason: output.stopReason, error: output });
+					stream.end();
+				}
+			} finally {
+				if (heartbeatTimer) {
+					clearInterval(heartbeatTimer);
+					heartbeatTimer = null;
+				}
+				h2Request?.close();
+				h2Client?.close();
+				h2Request = null;
+				h2Client = null;
 			}
-		} finally {
-			if (heartbeatTimer) {
-				clearInterval(heartbeatTimer);
-				heartbeatTimer = null;
-			}
-			h2Request?.close();
-			h2Client?.close();
-			h2Request = null;
-			h2Client = null;
-		}
 		} while (retryPoisonedConversation);
 	})();
 
@@ -797,6 +817,8 @@ function markCursorExecResolved(block: CursorExecResolvedCarrier): void {
 export interface UsageState {
 	sawTokenDelta: boolean;
 	sawTurnEndedUsage: boolean;
+	/** Last checkpoint `usedTokens`; conversation window, not billed cache. */
+	liveUsedTokens?: number;
 }
 
 /** Exported for tests: drives one Cursor server message through the stream (exec waits mark the stream busy). */
@@ -3432,8 +3454,24 @@ function applyBilledTurnEndedUsage(update: TurnEndedUpdate, output: AssistantMes
 	}
 	usageState.sawTurnEndedUsage = true;
 	const usage = output.usage;
-	usage.cacheRead = Number(cacheReadTokens ?? 0n);
-	usage.cacheWrite = Number(cacheWriteTokens ?? 0n);
+	const cacheRead = Number(cacheReadTokens ?? 0n);
+	const cacheWrite = Number(cacheWriteTokens ?? 0n);
+	const liveUsed = usageState.liveUsedTokens ?? 0;
+	// Cursor sometimes reports dashboard-cumulative cache_read (millions) while
+	// usedTokens stays at the real window (~150k). Folding that into totalTokens
+	// forces a useless compact and then a 0-token resource_exhausted.
+	if (liveUsed > 0 && cacheRead > liveUsed * 3) {
+		if (outputTokens !== undefined) {
+			usage.output = Number(outputTokens);
+		}
+		usage.cacheRead = 0;
+		usage.cacheWrite = cacheWrite <= liveUsed ? cacheWrite : 0;
+		usage.input = Math.max(0, liveUsed - usage.output - usage.cacheWrite);
+		usage.totalTokens = liveUsed;
+		return;
+	}
+	usage.cacheRead = cacheRead;
+	usage.cacheWrite = cacheWrite;
 	usage.input = Math.max(0, Number(inputTokens ?? 0n) - usage.cacheRead - usage.cacheWrite);
 	if (outputTokens !== undefined) {
 		usage.output = Number(outputTokens);
@@ -3454,6 +3492,7 @@ function applyCheckpointTokenDetails(
 	if (usageState.sawTurnEndedUsage) return;
 	const usedTokens = checkpoint.tokenDetails?.usedTokens ?? 0;
 	if (usedTokens <= 0) return;
+	usageState.liveUsedTokens = usedTokens;
 	const usage = output.usage;
 	usage.input = Math.max(0, usedTokens - usage.output - usage.cacheRead - usage.cacheWrite);
 	usage.totalTokens = usage.input + usage.output + usage.cacheRead + usage.cacheWrite;

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -48,6 +48,12 @@ import {
 } from "../utils/block-symbols.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { providerHeadersToRecord } from "../utils/headers.ts";
+import {
+	CURSOR_CONVERSATION_POISONED_MESSAGE,
+	createConversationRotationStore,
+	isZeroTokenResourceExhausted,
+	resolveConversationRotationPersistPath,
+} from "./cursor-conversation-rotation.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.ts";
 import { deterministicUuid } from "./cursor-agent/deterministic-id.ts";
@@ -297,8 +303,6 @@ export function sanitizeCursorCallerHeaders(headers: Record<string, string> | un
 const NOT_IMPLEMENTED_SUFFIX = "not implemented by this client";
 const NOT_IMPLEMENTED = "Not implemented by this client";
 /** Bare gRPC `resource_exhausted` end-streams (also inside a Connect error message). */
-const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
-
 const conversationStateCache = new Map<string, ConversationStateStructure>();
 const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
 /**
@@ -308,7 +312,18 @@ const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
  * and the cached state migrates, so the retry loop's next attempt starts a
  * fresh conversation. Keyed by the base id so a failed rotation never repeats.
  */
-const rotatedConversationIds = new Map<string, string>();
+let conversationRotationStore = createConversationRotationStore({
+	persistPath: resolveConversationRotationPersistPath(),
+});
+let conversationRotationPersistPath = resolveConversationRotationPersistPath();
+function rotationStore() {
+	const persistPath = resolveConversationRotationPersistPath();
+	if (persistPath !== conversationRotationPersistPath) {
+		conversationRotationPersistPath = persistPath;
+		conversationRotationStore = createConversationRotationStore({ persistPath });
+	}
+	return conversationRotationStore;
+}
 
 const CONNECT_END_STREAM_FLAG = 0b00000010;
 
@@ -435,10 +450,6 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 		let openBlockState: BlockState | undefined;
 		let resolveH2: () => void = () => {};
 		let rejectH2: (error: unknown) => void = () => {};
-		const h2Completion = new Promise<void>((resolve, reject) => {
-			resolveH2 = resolve;
-			rejectH2 = reject;
-		});
 		const settleH2 = (error?: unknown): void => {
 			if (h2Settled) return;
 			h2Settled = true;
@@ -462,6 +473,19 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 		let baseConversationId: string | undefined;
 		let conversationId: string | undefined;
 		let usageState: UsageState | undefined;
+		let retryPoisonedConversation = false;
+		let attempt = 0;
+		do {
+			retryPoisonedConversation = false;
+			attempt += 1;
+			h2Settled = false;
+			sawTurnEnded = false;
+			endStreamError = null;
+			openBlockState = undefined;
+			const h2Completion = new Promise<void>((resolve, reject) => {
+				resolveH2 = resolve;
+				rejectH2 = reject;
+			});
 		try {
 			const apiKey = options?.apiKey;
 			if (!apiKey) {
@@ -469,7 +493,10 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 			}
 
 			baseConversationId = options?.conversationId ?? options?.sessionId ?? randomUUID();
-			conversationId = rotatedConversationIds.get(baseConversationId) ?? baseConversationId;
+			if (rotationStore().shouldSkip(baseConversationId)) {
+				throw new Error(CURSOR_CONVERSATION_POISONED_MESSAGE);
+			}
+			conversationId = rotationStore().getWireId(baseConversationId);
 			const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 			conversationBlobStores.set(conversationId, blobStore);
 			const cachedState = conversationStateCache.get(conversationId);
@@ -505,7 +532,9 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 
 			h2Request = h2Client.request(requestHeaders);
 
-			stream.push({ type: "start", partial: output });
+			if (attempt === 1) {
+				stream.push({ type: "start", partial: output });
+			}
 
 			let pendingBuffer: Buffer = Buffer.alloc(0);
 			let currentTextBlock: (TextContent & { [kStreamingBlockIndex]: number }) | null = null;
@@ -677,27 +706,32 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 			const message = error instanceof Error ? error.message : JSON.stringify(error);
 			// A server-side per-conversation rejection surfaces as a bare
 			// resource_exhausted with zero tokens — the conversation is poisoned,
-			// not the account. Rotate the wire id once and migrate cached state
-			// so the caller's retry loop starts a fresh conversation.
+			// not the account. Rotate the wire id, persist it, and retry this
+			// stream() before the model-fallback chain jumps providers.
 			if (
 				conversationId !== undefined &&
 				baseConversationId !== undefined &&
 				usageState !== undefined &&
-				!usageState.sawTokenDelta &&
-				RESOURCE_EXHAUSTED_PATTERN.test(message) &&
-				!rotatedConversationIds.has(baseConversationId)
+				isZeroTokenResourceExhausted(message, usageState.sawTokenDelta)
 			) {
-				const rotated = randomUUID();
-				rotatedConversationIds.set(baseConversationId, rotated);
-				const cached = conversationStateCache.get(conversationId);
-				if (cached) conversationStateCache.set(rotated, cached);
-				const blobs = conversationBlobStores.get(conversationId);
-				if (blobs) conversationBlobStores.set(rotated, blobs);
+				const decision = rotationStore().recordZeroTokenPoison(
+					baseConversationId,
+					conversationId,
+				);
+				if (decision.kind === "rotated") {
+					const cached = conversationStateCache.get(conversationId);
+					if (cached) conversationStateCache.set(decision.wireId, cached);
+					const blobs = conversationBlobStores.get(conversationId);
+					if (blobs) conversationBlobStores.set(decision.wireId, blobs);
+					retryPoisonedConversation = true;
+				}
 			}
-			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = message;
-			stream.push({ type: "error", reason: output.stopReason, error: output });
-			stream.end();
+			if (!retryPoisonedConversation) {
+				output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+				output.errorMessage = message;
+				stream.push({ type: "error", reason: output.stopReason, error: output });
+				stream.end();
+			}
 		} finally {
 			if (heartbeatTimer) {
 				clearInterval(heartbeatTimer);
@@ -705,7 +739,10 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 			}
 			h2Request?.close();
 			h2Client?.close();
+			h2Request = null;
+			h2Client = null;
 		}
+		} while (retryPoisonedConversation);
 	})();
 
 	return stream;

--- a/packages/ai/src/api/cursor-conversation-rotation.ts
+++ b/packages/ai/src/api/cursor-conversation-rotation.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { randomUUID } from "node:crypto";
 
 export const MAX_CURSOR_CONVERSATION_ROTATIONS = 3;
 export const CURSOR_CONVERSATION_POISONED_MESSAGE =
@@ -12,21 +12,32 @@ export type ConversationRotationRecord = {
 	readonly wireId: string;
 	readonly poisonCount: number;
 	readonly skip: boolean;
+	/**
+	 * A 0-token RE was already surfaced to the session layer for this base
+	 * conversation, so compaction has had its turn and rotation may proceed.
+	 */
+	readonly surfaced: boolean;
 };
 
-export type PoisonDecision =
-	| { readonly kind: "rotated"; readonly wireId: string }
-	| { readonly kind: "exhausted" };
+export type PoisonDecision = { readonly kind: "rotated"; readonly wireId: string } | { readonly kind: "exhausted" };
 
 type MutableRecord = {
 	wireId: string;
 	poisonCount: number;
 	skip: boolean;
+	surfaced: boolean;
 };
 
 export type ConversationRotationStore = {
 	getWireId(baseId: string): string;
 	shouldSkip(baseId: string): boolean;
+	/**
+	 * True until a 0-token RE has been surfaced once for `baseId`. The first
+	 * failure must reach the session layer so compact-before-rotate can shrink
+	 * an oversized payload; only after that is rotation the right remedy.
+	 */
+	shouldSurfaceBeforeRotating(baseId: string): boolean;
+	markSurfaced(baseId: string, currentWireId: string): void;
 	recordZeroTokenPoison(baseId: string, currentWireId: string): PoisonDecision;
 };
 
@@ -55,6 +66,9 @@ export function createConversationRotationStore(options: {
 			existing.wireId = wireId;
 			existing.skip = false;
 			existing.poisonCount = 0;
+			// A reminted id is a fresh conversation: it earns its own surface-first
+			// pass so compaction runs again before rotation resumes.
+			existing.surfaced = false;
 			records[baseId] = existing;
 			persist();
 			return wireId;
@@ -62,11 +76,27 @@ export function createConversationRotationStore(options: {
 		shouldSkip(baseId: string): boolean {
 			return records[baseId]?.skip === true;
 		},
+		shouldSurfaceBeforeRotating(baseId: string): boolean {
+			return records[baseId]?.surfaced !== true;
+		},
+		markSurfaced(baseId: string, currentWireId: string): void {
+			const existing = records[baseId] ?? {
+				wireId: currentWireId,
+				poisonCount: 0,
+				skip: false,
+				surfaced: false,
+			};
+			if (existing.surfaced) return;
+			existing.surfaced = true;
+			records[baseId] = existing;
+			persist();
+		},
 		recordZeroTokenPoison(baseId: string, currentWireId: string): PoisonDecision {
 			const existing = records[baseId] ?? {
 				wireId: currentWireId,
 				poisonCount: 0,
 				skip: false,
+				surfaced: false,
 			};
 			if (existing.skip || existing.poisonCount >= MAX_CURSOR_CONVERSATION_ROTATIONS) {
 				existing.skip = true;
@@ -90,9 +120,7 @@ export function resolveConversationRotationPersistPath(env: NodeJS.ProcessEnv = 
 		return env.CURSOR_CONVERSATION_ID_STORE;
 	}
 	const agentDir =
-		env.SENPI_CODING_AGENT_DIR ??
-		env.CODING_AGENT_DIR ??
-		`${(env.HOME ?? ".").replace(/\/$/, "")}/.senpi/agent`;
+		env.SENPI_CODING_AGENT_DIR ?? env.CODING_AGENT_DIR ?? `${(env.HOME ?? ".").replace(/\/$/, "")}/.senpi/agent`;
 	return `${agentDir.replace(/\/$/, "")}/cursor-conversation-ids.json`;
 }
 
@@ -105,12 +133,13 @@ function loadRecords(persistPath: string): Record<string, MutableRecord> {
 		const records: Record<string, MutableRecord> = {};
 		for (const [baseId, value] of Object.entries(parsed)) {
 			if (!value || typeof value !== "object") continue;
-			const raw = value as { wireId?: unknown; poisonCount?: unknown; skip?: unknown };
+			const raw = value as { wireId?: unknown; poisonCount?: unknown; skip?: unknown; surfaced?: unknown };
 			if (typeof raw.wireId !== "string" || raw.wireId.length === 0) continue;
 			records[baseId] = {
 				wireId: raw.wireId,
 				poisonCount: typeof raw.poisonCount === "number" && raw.poisonCount >= 0 ? raw.poisonCount : 0,
 				skip: raw.skip === true,
+				surfaced: raw.surfaced === true,
 			};
 		}
 		return records;

--- a/packages/ai/src/api/cursor-conversation-rotation.ts
+++ b/packages/ai/src/api/cursor-conversation-rotation.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+
+export const MAX_CURSOR_CONVERSATION_ROTATIONS = 3;
+export const CURSOR_CONVERSATION_POISONED_MESSAGE =
+	"Cursor conversation is poisoned for this session; use another provider";
+
+const RESOURCE_EXHAUSTED_PATTERN = /resource.?exhausted/i;
+
+export type ConversationRotationRecord = {
+	readonly wireId: string;
+	readonly poisonCount: number;
+	readonly skip: boolean;
+};
+
+export type PoisonDecision =
+	| { readonly kind: "rotated"; readonly wireId: string }
+	| { readonly kind: "exhausted" };
+
+type MutableRecord = {
+	wireId: string;
+	poisonCount: number;
+	skip: boolean;
+};
+
+export type ConversationRotationStore = {
+	getWireId(baseId: string): string;
+	shouldSkip(baseId: string): boolean;
+	recordZeroTokenPoison(baseId: string, currentWireId: string): PoisonDecision;
+};
+
+export function isZeroTokenResourceExhausted(errorMessage: string, sawTokenDelta: boolean): boolean {
+	return !sawTokenDelta && RESOURCE_EXHAUSTED_PATTERN.test(errorMessage);
+}
+
+export function createConversationRotationStore(options: {
+	readonly persistPath: string;
+	readonly randomId?: () => string;
+}): ConversationRotationStore {
+	const randomId = options.randomId ?? randomUUID;
+	const records = loadRecords(options.persistPath);
+
+	const persist = (): void => {
+		mkdirSync(dirname(options.persistPath), { recursive: true });
+		writeFileSync(options.persistPath, `${JSON.stringify(records, null, 2)}\n`);
+	};
+
+	return {
+		getWireId(baseId: string): string {
+			return records[baseId]?.wireId ?? baseId;
+		},
+		shouldSkip(baseId: string): boolean {
+			return records[baseId]?.skip === true;
+		},
+		recordZeroTokenPoison(baseId: string, currentWireId: string): PoisonDecision {
+			const existing = records[baseId] ?? {
+				wireId: currentWireId,
+				poisonCount: 0,
+				skip: false,
+			};
+			if (existing.skip || existing.poisonCount >= MAX_CURSOR_CONVERSATION_ROTATIONS) {
+				existing.skip = true;
+				existing.wireId = currentWireId;
+				records[baseId] = existing;
+				persist();
+				return { kind: "exhausted" };
+			}
+			const wireId = randomId();
+			existing.wireId = wireId;
+			existing.poisonCount += 1;
+			records[baseId] = existing;
+			persist();
+			return { kind: "rotated", wireId };
+		},
+	};
+}
+
+export function resolveConversationRotationPersistPath(env: NodeJS.ProcessEnv = process.env): string {
+	if (env.CURSOR_CONVERSATION_ID_STORE) {
+		return env.CURSOR_CONVERSATION_ID_STORE;
+	}
+	const agentDir = env.SENPI_CODING_AGENT_DIR ?? env.HOME ?? ".";
+	return `${agentDir.replace(/\/$/, "")}/cursor-conversation-ids.json`;
+}
+
+function loadRecords(persistPath: string): Record<string, MutableRecord> {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(persistPath, "utf8"));
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			return {};
+		}
+		const records: Record<string, MutableRecord> = {};
+		for (const [baseId, value] of Object.entries(parsed)) {
+			if (!value || typeof value !== "object") continue;
+			const raw = value as { wireId?: unknown; poisonCount?: unknown; skip?: unknown };
+			if (typeof raw.wireId !== "string" || raw.wireId.length === 0) continue;
+			records[baseId] = {
+				wireId: raw.wireId,
+				poisonCount: typeof raw.poisonCount === "number" && raw.poisonCount >= 0 ? raw.poisonCount : 0,
+				skip: raw.skip === true,
+			};
+		}
+		return records;
+	} catch {
+		return {};
+	}
+}

--- a/packages/ai/src/api/cursor-conversation-rotation.ts
+++ b/packages/ai/src/api/cursor-conversation-rotation.ts
@@ -48,7 +48,16 @@ export function createConversationRotationStore(options: {
 
 	return {
 		getWireId(baseId: string): string {
-			return records[baseId]?.wireId ?? baseId;
+			const existing = records[baseId];
+			if (!existing) return baseId;
+			if (!existing.skip) return existing.wireId;
+			const wireId = randomId();
+			existing.wireId = wireId;
+			existing.skip = false;
+			existing.poisonCount = 0;
+			records[baseId] = existing;
+			persist();
+			return wireId;
 		},
 		shouldSkip(baseId: string): boolean {
 			return records[baseId]?.skip === true;

--- a/packages/ai/src/api/cursor-conversation-rotation.ts
+++ b/packages/ai/src/api/cursor-conversation-rotation.ts
@@ -89,7 +89,10 @@ export function resolveConversationRotationPersistPath(env: NodeJS.ProcessEnv = 
 	if (env.CURSOR_CONVERSATION_ID_STORE) {
 		return env.CURSOR_CONVERSATION_ID_STORE;
 	}
-	const agentDir = env.SENPI_CODING_AGENT_DIR ?? env.HOME ?? ".";
+	const agentDir =
+		env.SENPI_CODING_AGENT_DIR ??
+		env.CODING_AGENT_DIR ??
+		`${(env.HOME ?? ".").replace(/\/$/, "")}/.senpi/agent`;
 	return `${agentDir.replace(/\/$/, "")}/cursor-conversation-ids.json`;
 }
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Remint a Cursor conversation wire id after the 3-rotation skip instead of blocking the whole session.
+- Persist Cursor conversation-id rotation under the agent dir (`CODING_AGENT_DIR` / `~/.senpi/agent`), not `$HOME/cursor-conversation-ids.json`.
 
 # AI Source Changes
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Remint a Cursor conversation wire id after the 3-rotation skip instead of blocking the whole session.
+
 # AI Source Changes
 
 ## 2026-08-19 - Persist and retry Cursor conversation-id rotation

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -2,14 +2,92 @@
 
 - Remint a Cursor conversation wire id after the 3-rotation skip instead of blocking the whole session.
 - Persist Cursor conversation-id rotation under the agent dir (`CODING_AGENT_DIR` / `~/.senpi/agent`), not `$HOME/cursor-conversation-ids.json`.
+- Surface the first 0-token `resource_exhausted` of a `stream()` call so session-layer compaction runs before rotation.
+
+## 2026-08-20 - Cursor 0-token RE overflow without estimate gate
+
+### What changed
+
+- `packages/ai/src/utils/overflow.ts`: 0-token Cursor `resource_exhausted` is overflow even when the local estimate is 0; same-model remint helpers skip provider fallback; Cursor overflow compaction settings force `keepRecentTokens: 0` and disable restoration.
+
+### Why
+
+- The 50k estimate gate missed sessions whose last billed usage was zeroed after an earlier compact, so Cursor still rejected the payload while senpi treated it as a 429 and jumped providers.
+
+### Why an extension could not handle it
+
+- Overflow classification and retry fallback run in core before extension hooks.
+
+### Expected merge conflict zones
+
+- `packages/ai/src/utils/overflow.ts` after `getOverflowPatterns()`.
 
 # AI Source Changes
 
-## 2026-08-19 - Persist and retry Cursor conversation-id rotation
+## 2026-08-20 - Cursor conversation rotation composes with compact-before-rotate
 
-Zero-token `resource_exhausted` now rotates the wire conversation id up to three times, retries the same `stream()` before model fallback, and persists the mapping under the agent dir so a TUI restart does not reuse the poisoned id. Token-evidence RE still does not rotate.
+### What changed
 
-Conflict zone: `cursor-agent.ts` `stream()` try/catch.
+- `packages/ai/src/api/cursor-conversation-rotation.ts` (new): persists the base-id to wire-id mapping under the agent dir (`CODING_AGENT_DIR` / `~/.senpi/agent`, overridable with `CURSOR_CONVERSATION_ID_STORE`), caps rotation at `MAX_CURSOR_CONVERSATION_ROTATIONS` (3), and remints a fresh wire id after the skip so a session is never permanently blocked.
+- `packages/ai/src/api/cursor-agent.ts` `stream()`: the FIRST 0-token `resource_exhausted` of a `stream()` call surfaces as an error with no rotation, so the session layer gets first refusal and can compact. Rotation, cache/blob migration, and same-stream retry apply only to attempts after the first within one `stream()` call. Once the base conversation has burned its 3 rotations, `shouldSkip()` surfaces `CURSOR_CONVERSATION_POISONED_MESSAGE` instead of rotating again.
+
+### Why
+
+- Rotating on the first failure swallowed the error inside `stream()`, so the compact-before-rotate policy added by #1015 (which fires in `agent-session` on a SURFACED 0-token RE via `isCursorPayloadResourceExhausted`) never ran. A large-payload rejection then burned all three rotations replaying the same oversized payload and still failed. Surfacing attempt 1 lets compaction shrink the payload first; rotation remains the fallback for a genuinely poisoned conversation id, which compaction cannot fix.
+
+### Why an extension could not handle it
+
+- The rotation map, the persisted wire id, and the h2 retry loop live inside `cursor-agent` `stream()`, below every extension hook; the retry must reuse the same in-flight event stream so `start` is emitted once.
+
+### Expected merge conflict zones
+
+- `packages/ai/src/api/cursor-agent.ts` `stream()` retry loop and its `catch` block.
+- `packages/ai/src/api/cursor-conversation-rotation.ts` (whole file).
+
+## 2026-08-20 - Cursor explicit levels prefer catalog suffix variant ids
+
+### What changed
+
+- `packages/ai/src/cursor/selection-descriptor.ts`: `resolveCursorSelectionDescriptor` now resolves an
+  explicit thinking level to the catalog-guaranteed legacy suffix alias (`kimi-k3-high`,
+  `claude-fable-5-thinking-low`, `gpt-5.3-codex-xhigh`) whenever one exists, via a new
+  `suffixAliasId` that tries the level's wire value then the level token, with thinking-infixed
+  candidates for thinking Claude identities. Bare base id + ordered parameters remains only as the
+  fallback for levels without any alias; `legacySuffixId` is subsumed.
+
+### Why
+
+- Cursor's Run RPC now rejects bare capability ids with Connect `not_found` for every family
+  (issue #1008; live probes 2026-08-20 in
+  `local-ignore/qa-evidence/20260820-cursor-bare-id-notfound/`: bare `kimi-k3`+parameters and bare
+  `claude-fable-5`+parameters both `not_found`, while `kimi-k3-high` and
+  `claude-fable-5-thinking-low` complete), so every explicit level rendered as base+parameters died
+  at turn start.
+
+### Why an extension could not handle it
+
+- The selection descriptor is core provider data consumed by both Cursor transports (protobuf
+  `RequestedModel` and the CLI model string); no extension hook sits between them.
+
+### Expected merge conflict zones
+
+- `selection-descriptor.ts` resolver body and helper block (fork-only file; upstream has no cursor
+  provider).
+
+## 2026-08-19 - Ignore Cursor billed cacheRead that dwarfs usedTokens
+
+### What changed
+
+- `applyCheckpointTokenDetails` records `UsageState.liveUsedTokens`.
+- `applyBilledTurnEndedUsage` ignores `cache_read_tokens` when it is more than 3× that live window and keeps `totalTokens` at `usedTokens`.
+
+### Why
+
+- Session 01a01879 jumped 148k → 4.09M because field 3 was dashboard-cumulative cache read, not conversation size. `max(usage, estimate)` then forced a useless compact and a 0-token `resource_exhausted`.
+
+### Conflict zone
+
+- `packages/ai/src/api/cursor-agent.ts` `applyBilledTurnEndedUsage` / `UsageState`.
 
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,11 @@
 # AI Source Changes
 
+## 2026-08-19 - Persist and retry Cursor conversation-id rotation
+
+Zero-token `resource_exhausted` now rotates the wire conversation id up to three times, retries the same `stream()` before model fallback, and persists the mapping under the agent dir so a TUI restart does not reuse the poisoned id. Token-evidence RE still does not rotate.
+
+Conflict zone: `cursor-agent.ts` `stream()` try/catch.
+
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin
 
 ### What changed

--- a/packages/ai/test/cursor-conversation-rotation-stream.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation-stream.test.ts
@@ -49,9 +49,17 @@ function endStreamErrorFrame(code: string, message: string): Buffer {
 }
 
 let server: http2.Http2Server | undefined;
+let sessions: http2.ServerHttp2Session[] = [];
 
 async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): Promise<string> {
 	server = http2.createServer();
+	sessions = [];
+	// These cases drive several stream() calls against one server, so each leaves
+	// an idle h2 session behind. server.close() waits for every session to end and
+	// would never resolve, so the sessions are tracked and destroyed at teardown.
+	server.on("session", (session) => {
+		sessions.push(session);
+	});
 	server.on("stream", (stream: http2.ServerHttp2Stream) => {
 		stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
 		handler(stream);
@@ -82,8 +90,12 @@ describe("cursor-agent zero-token RE retry", () => {
 
 	afterEach(async () => {
 		if (!server) return;
-		await new Promise<void>((resolve) => server!.close(() => resolve()));
+		const closing = server;
 		server = undefined;
+		for (const session of sessions.splice(0)) {
+			session.destroy();
+		}
+		await new Promise<void>((resolve) => closing.close(() => resolve()));
 	});
 
 	// The compact-before-rotate policy (#1015) reacts to a SURFACED 0-token RE in

--- a/packages/ai/test/cursor-conversation-rotation-stream.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation-stream.test.ts
@@ -1,0 +1,94 @@
+import * as http2 from "node:http2";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { afterEach, describe, expect, it } from "vitest";
+import { AgentServerMessageSchema } from "../src/api/cursor-agent/gen/agent_pb.ts";
+import { frameConnectMessage, stream as streamCursorAgent } from "../src/api/cursor-agent.ts";
+import type { Model } from "../src/types.ts";
+
+process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-rotate-")), "ids.json");
+
+const neverAbortedSignal = new AbortController().signal;
+const CONNECT_END_STREAM_FLAG = 0b00000010;
+
+function buildModel(baseUrl: string): Model<"cursor-agent"> {
+	return {
+		id: "claude-4.6-opus-high",
+		name: "Opus 4.6",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	};
+}
+
+function turnEndedFrame(): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: { case: "interactionUpdate", value: { message: { case: "turnEnded", value: {} } } },
+			}),
+		),
+	);
+}
+
+function endStreamErrorFrame(code: string, message: string): Buffer {
+	return frameConnectMessage(
+		new TextEncoder().encode(JSON.stringify({ error: { code, message } })),
+		CONNECT_END_STREAM_FLAG,
+	);
+}
+
+let server: http2.Http2Server | undefined;
+
+async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): Promise<string> {
+	server = http2.createServer();
+	server.on("stream", (stream) => {
+		stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+		handler(stream);
+	});
+	await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+	const address = server.address() as AddressInfo;
+	return `http://127.0.0.1:${address.port}`;
+}
+
+describe("cursor-agent zero-token RE retry", () => {
+	afterEach(async () => {
+		if (!server) return;
+		await new Promise<void>((resolve) => server!.close(() => resolve()));
+		server = undefined;
+	});
+
+	it("retries the same stream() with a new conversation id", async () => {
+		let runs = 0;
+		const baseUrl = await startServer((stream) => {
+			runs += 1;
+			if (runs === 1) {
+				stream.write(endStreamErrorFrame("resource_exhausted", "Error"));
+				stream.end();
+				return;
+			}
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+		const result = streamCursorAgent(
+			buildModel(baseUrl),
+			{ messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+			{ apiKey: "test-token", sessionId: "sess-rotate-stream", signal: neverAbortedSignal },
+		);
+		for await (const _event of result) {
+			// drain
+		}
+		const message = await result.result();
+		expect(runs).toBe(2);
+		expect(message.stopReason).not.toBe("error");
+	});
+});

--- a/packages/ai/test/cursor-conversation-rotation-stream.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation-stream.test.ts
@@ -1,12 +1,13 @@
+import { mkdtempSync } from "node:fs";
 import * as http2 from "node:http2";
 import type { AddressInfo } from "node:net";
-import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { create, toBinary } from "@bufbuild/protobuf";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { AgentServerMessageSchema } from "../src/api/cursor-agent/gen/agent_pb.ts";
 import { frameConnectMessage, stream as streamCursorAgent } from "../src/api/cursor-agent.ts";
+import { CURSOR_CONVERSATION_POISONED_MESSAGE } from "../src/api/cursor-conversation-rotation.ts";
 import type { Model } from "../src/types.ts";
 
 process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-rotate-")), "ids.json");
@@ -51,7 +52,7 @@ let server: http2.Http2Server | undefined;
 
 async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): Promise<string> {
 	server = http2.createServer();
-	server.on("stream", (stream) => {
+	server.on("stream", (stream: http2.ServerHttp2Stream) => {
 		stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
 		handler(stream);
 	});
@@ -60,18 +61,52 @@ async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): 
 	return `http://127.0.0.1:${address.port}`;
 }
 
+async function runStream(baseUrl: string, sessionId: string) {
+	const result = streamCursorAgent(
+		buildModel(baseUrl),
+		{ messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+		{ apiKey: "test-token", sessionId, signal: neverAbortedSignal },
+	);
+	for await (const _event of result) {
+		// drain
+	}
+	return await result.result();
+}
+
 describe("cursor-agent zero-token RE retry", () => {
+	beforeEach(() => {
+		// Rotation state is persisted per base conversation id, so each test needs
+		// its own store or the 3-rotation cap leaks across cases.
+		process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-rotate-")), "ids.json");
+	});
+
 	afterEach(async () => {
 		if (!server) return;
 		await new Promise<void>((resolve) => server!.close(() => resolve()));
 		server = undefined;
 	});
 
-	it("retries the same stream() with a new conversation id", async () => {
+	// The compact-before-rotate policy (#1015) reacts to a SURFACED 0-token RE in
+	// agent-session. Rotating inside the first stream() attempt would swallow that
+	// error and make compaction dead code, so attempt 1 must surface.
+	it("surfaces the first 0-token RE without rotating so the session layer can compact", async () => {
 		let runs = 0;
 		const baseUrl = await startServer((stream) => {
 			runs += 1;
-			if (runs === 1) {
+			stream.write(endStreamErrorFrame("resource_exhausted", "Error"));
+			stream.end();
+		});
+		const message = await runStream(baseUrl, "sess-first-surface");
+		expect(runs).toBe(1);
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toMatch(/resource.?exhausted/i);
+	});
+
+	it("retries the same stream() with a new conversation id once the session retries", async () => {
+		let runs = 0;
+		const baseUrl = await startServer((stream) => {
+			runs += 1;
+			if (runs <= 2) {
 				stream.write(endStreamErrorFrame("resource_exhausted", "Error"));
 				stream.end();
 				return;
@@ -79,16 +114,30 @@ describe("cursor-agent zero-token RE retry", () => {
 			stream.write(turnEndedFrame());
 			stream.end();
 		});
-		const result = streamCursorAgent(
-			buildModel(baseUrl),
-			{ messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-			{ apiKey: "test-token", sessionId: "sess-rotate-stream", signal: neverAbortedSignal },
-		);
-		for await (const _event of result) {
-			// drain
+		// First stream() call surfaces without rotating (session layer compacts).
+		const first = await runStream(baseUrl, "sess-rotate-stream");
+		expect(first.stopReason).toBe("error");
+		expect(runs).toBe(1);
+
+		// The session's retry re-enters stream(); its own attempt 1 surfaces-or-rotates
+		// per the same rule, and the in-call retry rotates onto a fresh wire id.
+		const second = await runStream(baseUrl, "sess-rotate-stream");
+		expect(runs).toBe(3);
+		expect(second.stopReason).not.toBe("error");
+	});
+
+	it("surfaces the poisoned-conversation error after the rotation cap", async () => {
+		const baseUrl = await startServer((stream) => {
+			stream.write(endStreamErrorFrame("resource_exhausted", "Error"));
+			stream.end();
+		});
+		let message = await runStream(baseUrl, "sess-poisoned");
+		// Each subsequent stream() call burns rotations until the cap is reached.
+		for (let call = 0; call < 4; call++) {
+			message = await runStream(baseUrl, "sess-poisoned");
+			if (message.errorMessage === CURSOR_CONVERSATION_POISONED_MESSAGE) break;
 		}
-		const message = await result.result();
-		expect(runs).toBe(2);
-		expect(message.stopReason).not.toBe("error");
+		expect(message.stopReason).toBe("error");
+		expect(message.errorMessage).toBe(CURSOR_CONVERSATION_POISONED_MESSAGE);
 	});
 });

--- a/packages/ai/test/cursor-conversation-rotation.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation.test.ts
@@ -6,6 +6,7 @@ import {
 	createConversationRotationStore,
 	isZeroTokenResourceExhausted,
 	MAX_CURSOR_CONVERSATION_ROTATIONS,
+	resolveConversationRotationPersistPath,
 } from "../src/api/cursor-conversation-rotation.ts";
 
 function storePath(): string {
@@ -56,5 +57,23 @@ describe("cursor conversation rotation", () => {
 		expect(store.shouldSkip("session-c")).toBe(false);
 		expect(isZeroTokenResourceExhausted("Connect error resource_exhausted: Error", true)).toBe(false);
 		expect(isZeroTokenResourceExhausted("Connect error resource_exhausted: Error", false)).toBe(true);
+	});
+
+	it("persists under the agent dir, not $HOME", () => {
+		expect(resolveConversationRotationPersistPath({ HOME: "/home/u" })).toBe(
+			"/home/u/.senpi/agent/cursor-conversation-ids.json",
+		);
+		expect(
+			resolveConversationRotationPersistPath({
+				HOME: "/home/u",
+				CODING_AGENT_DIR: "/home/u/.omo/agent",
+			}),
+		).toBe("/home/u/.omo/agent/cursor-conversation-ids.json");
+		expect(
+			resolveConversationRotationPersistPath({
+				HOME: "/home/u",
+				CURSOR_CONVERSATION_ID_STORE: "/tmp/store.json",
+			}),
+		).toBe("/tmp/store.json");
 	});
 });

--- a/packages/ai/test/cursor-conversation-rotation.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation.test.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	createConversationRotationStore,
+	isZeroTokenResourceExhausted,
+	MAX_CURSOR_CONVERSATION_ROTATIONS,
+} from "../src/api/cursor-conversation-rotation.ts";
+
+function storePath(): string {
+	return join(mkdtempSync(join(tmpdir(), "cursor-rotate-")), "cursor-conversation-ids.json");
+}
+
+describe("cursor conversation rotation", () => {
+	it("retries a zero-token resource_exhausted with a new wire id", () => {
+		const persistPath = storePath();
+		const ids = ["rot-1", "rot-2", "rot-3"];
+		const store = createConversationRotationStore({
+			persistPath,
+			randomId: () => ids.shift() ?? "overflow",
+		});
+		expect(store.getWireId("session-a")).toBe("session-a");
+		const first = store.recordZeroTokenPoison("session-a", "session-a");
+		expect(first).toEqual({ kind: "rotated", wireId: "rot-1" });
+		expect(store.getWireId("session-a")).toBe("rot-1");
+	});
+
+	it("loads the last wire id from disk after a new store is created", () => {
+		const persistPath = storePath();
+		const first = createConversationRotationStore({
+			persistPath,
+			randomId: () => "persisted-wire",
+		});
+		first.recordZeroTokenPoison("session-b", "session-b");
+		const reloaded = createConversationRotationStore({ persistPath, randomId: () => "unused" });
+		expect(reloaded.getWireId("session-b")).toBe("persisted-wire");
+		expect(JSON.parse(readFileSync(persistPath, "utf8"))["session-b"].wireId).toBe("persisted-wire");
+	});
+
+	it("stops minting ids after three rotations and ignores token-evidence RE", () => {
+		const persistPath = storePath();
+		let n = 0;
+		const store = createConversationRotationStore({
+			persistPath,
+			randomId: () => `rot-${++n}`,
+		});
+		expect(store.recordZeroTokenPoison("session-c", "session-c").kind).toBe("rotated");
+		expect(store.recordZeroTokenPoison("session-c", "rot-1").kind).toBe("rotated");
+		expect(store.recordZeroTokenPoison("session-c", "rot-2").kind).toBe("rotated");
+		expect(store.recordZeroTokenPoison("session-c", "rot-3")).toEqual({ kind: "exhausted" });
+		expect(n).toBe(MAX_CURSOR_CONVERSATION_ROTATIONS);
+		expect(store.shouldSkip("session-c")).toBe(true);
+		expect(store.getWireId("session-c")).toBe("rot-3");
+		expect(isZeroTokenResourceExhausted("Connect error resource_exhausted: Error", true)).toBe(false);
+		expect(isZeroTokenResourceExhausted("Connect error resource_exhausted: Error", false)).toBe(true);
+	});
+});

--- a/packages/ai/test/cursor-conversation-rotation.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation.test.ts
@@ -51,7 +51,9 @@ describe("cursor conversation rotation", () => {
 		expect(store.recordZeroTokenPoison("session-c", "rot-3")).toEqual({ kind: "exhausted" });
 		expect(n).toBe(MAX_CURSOR_CONVERSATION_ROTATIONS);
 		expect(store.shouldSkip("session-c")).toBe(true);
-		expect(store.getWireId("session-c")).toBe("rot-3");
+		const reopened = store.getWireId("session-c");
+		expect(reopened).not.toBe("rot-3");
+		expect(store.shouldSkip("session-c")).toBe(false);
 		expect(isZeroTokenResourceExhausted("Connect error resource_exhausted: Error", true)).toBe(false);
 		expect(isZeroTokenResourceExhausted("Connect error resource_exhausted: Error", false)).toBe(true);
 	});


### PR DESCRIPTION
Closes #996

Zero-token `resource_exhausted` is a poisoned conversation, not account quota. Rotate the wire id, persist it, and retry the same `stream()` before the model-fallback chain jumps providers. Cap is 3; token-evidence RE does not rotate.

Why not an extension: the rotate Map and h2 retry live inside `cursor-agent` `stream()`.

Conflict zone: `cursor-agent.ts` `stream()` try/catch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the first zero‑token Cursor `resource_exhausted` from `stream()` so session‑level compaction can run, then rotates the wire conversation ID and retries on later zero‑token failures. Previously repeated failures errored and could block the session; now we retry up to three times, then return a poisoned‑conversation error, and the next call remints a fresh wire ID instead of blocking.

- Persists the base→wire ID map to `${CODING_AGENT_DIR || ~/.senpi/agent}/cursor-conversation-ids.json` (override with `CURSOR_CONVERSATION_ID_STORE`); the persist path is re‑resolved on each call so env changes take effect.
- Rotation triggers only on zero‑token `resource_exhausted`; any token delta disables rotation. First such failure surfaces; later ones rotate and same‑stream retry migrates cached state and blobs, emitting `start` only once.
- Caps rotations at 3; once exhausted, surfaces “Cursor conversation is poisoned for this session; use another provider,” and the next `stream()` remints a fresh wire ID.
- Review focus: the retry/rotation logic in `packages/ai/src/api/cursor-agent.ts` `stream()` and the new store in `packages/ai/src/api/cursor-conversation-rotation.ts`. Tests also destroy idle HTTP/2 sessions in teardown to avoid suite hangs.

<sup>Written for commit 3dfc938d1b4a43c489e6f30021a476342b8ad289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

