### PR TITLE
fix(agent): end the turn when idle after completed Cursor tools

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Provider idle after completed Cursor tools (or buffered exec results) now ends the turn as `stop` instead of hanging until `StreamIdleTimeoutError` ([#999](https://github.com/code-yeongyu/senpi/pull/999)).
 - Cursor often ends a turn as `stop` while the assistant message still contains toolCall blocks. Those turns now continue as `toolUse` so pending tools run instead of being dropped ([#1016](https://github.com/code-yeongyu/senpi/pull/1016)).
 - Cursor exec handler factories now receive the owning run's abort signal instead of the per-request
   idle-timeout controller, so native Cursor exec tool calls pass the run-ownership check again instead

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -16,7 +16,9 @@ import {
 } from "@earendil-works/pi-ai";
 import {
 	createTerminalFailureAssistantMessage,
+	isStreamIdleTimeoutError,
 	normalizeTerminalAssistantMessage,
+	shouldFinalizeIdleAsStop,
 	shouldTerminateAssistantTurn,
 } from "./assistant-terminal-state.ts";
 import { getDefaultStreamFn, withEmptyAssistantRecovery } from "./stream-fn.ts";
@@ -613,6 +615,37 @@ async function streamAssistantResponse(
 		await emit({ type: "message_end", message: finalMessage });
 		return { message: finalMessage, providerToolResults };
 	} catch (error) {
+		if (isStreamIdleTimeoutError(error) && shouldFinalizeIdleAsStop(partialMessage, providerToolResults)) {
+			const finalMessage: AssistantMessage = {
+				role: "assistant",
+				content: partialMessage?.content ?? [{ type: "text", text: "" }],
+				api: partialMessage?.api ?? config.model.api,
+				provider: partialMessage?.provider ?? config.model.provider,
+				model: partialMessage?.model ?? config.model.id,
+				responseModel: partialMessage?.responseModel,
+				responseId: partialMessage?.responseId,
+				diagnostics: partialMessage?.diagnostics,
+				usage: partialMessage?.usage ?? {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: partialMessage?.timestamp ?? Date.now(),
+			};
+			propagateThinkingTiming(finalMessage);
+			if (addedPartial) {
+				context.messages[context.messages.length - 1] = finalMessage;
+			} else {
+				context.messages.push(finalMessage);
+				await emit({ type: "message_start", message: { ...finalMessage } });
+			}
+			await emit({ type: "message_end", message: finalMessage });
+			return { message: finalMessage, providerToolResults };
+		}
 		const finalMessage = createTerminalFailureAssistantMessage(
 			config.model,
 			signal?.aborted ? "aborted" : "error",

--- a/packages/agent/src/assistant-terminal-state.ts
+++ b/packages/agent/src/assistant-terminal-state.ts
@@ -1,4 +1,11 @@
-import { type AssistantMessage, type AssistantMessageEvent, isClassifierRefusal } from "@earendil-works/pi-ai";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	type CursorExecResolvedCarrier,
+	isClassifierRefusal,
+	isCursorExecResolved,
+	type ToolResultMessage,
+} from "@earendil-works/pi-ai";
 import type { AgentLoopConfig } from "./types.ts";
 
 const EMPTY_USAGE = {
@@ -14,6 +21,25 @@ type TerminalAssistantMessageEvent = Extract<AssistantMessageEvent, { type: "don
 
 export function shouldTerminateAssistantTurn(message: AssistantMessage): boolean {
 	return message.stopReason === "error" || message.stopReason === "aborted" || isClassifierRefusal(message);
+}
+
+export function isStreamIdleTimeoutError(error: unknown): boolean {
+	return error instanceof Error && error.name === "StreamIdleTimeoutError";
+}
+
+/**
+ * After tools already finished (Cursor exec-resolved or buffered results),
+ * a silent provider is a finished turn, not a failed one.
+ */
+export function shouldFinalizeIdleAsStop(
+	partialMessage: AssistantMessage | null,
+	providerToolResults: readonly ToolResultMessage[],
+): boolean {
+	if (!partialMessage) return false;
+	const toolCalls = partialMessage.content.filter((block) => block.type === "toolCall");
+	if (toolCalls.length === 0) return false;
+	if (providerToolResults.length > 0) return true;
+	return toolCalls.every((block) => isCursorExecResolved(block as CursorExecResolvedCarrier));
 }
 
 export function createTerminalFailureAssistantMessage(

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,11 @@
 # Changes
 
+## Finalize idle-after-completed-tools as stop (2026-08-19)
+
+If the provider stream goes idle after Cursor-resolved tool calls (or buffered exec results) and there is no pending local work, the turn ends as `stop` instead of `StreamIdleTimeoutError`. A hang with no tools is still an idle error.
+
+Conflict zone: `agent-loop.ts` `streamAssistantResponse` catch.
+
 ## Loop and agent divergence re-established against upstream 59a71b23 (2026-08-19)
 
 ### What changed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,25 @@
 # Changes
 
+## 2026-08-20 - End the turn when idle after completed Cursor tools
+
+### What changed
+
+- `packages/agent/src/agent-loop.ts`: `streamAssistantResponse` catch now treats `StreamIdleTimeoutError` after Cursor-resolved tools or buffered exec results as a finished turn (`stopReason: "stop"`) instead of a terminal error.
+- `packages/agent/src/assistant-terminal-state.ts`: `isStreamIdleTimeoutError` and `shouldFinalizeIdleAsStop` decide when that idle is a completed turn versus a real hang.
+
+### Why
+
+- After Cursor-resolved tools (or buffered exec results) the parent stream can sit silent until the 300s idle timeout and die as `StreamIdleTimeoutError` even though the child work already finished (issue #997).
+
+### Why an extension could not handle it
+
+- The idle reader and `streamAssistantResponse` catch live inside the agent loop; no extension hook sits between the idle timeout and the terminal assistant message it currently emits.
+
+### Expected merge conflict zones
+
+- `packages/agent/src/agent-loop.ts` `streamAssistantResponse` catch
+- `packages/agent/src/assistant-terminal-state.ts` idle helpers appended after `shouldTerminateAssistantTurn`
+
 ## 2026-08-20 - Continue when stop still has pending toolCalls
 
 ### What changed

--- a/packages/agent/test/idle-after-completed-tools.test.ts
+++ b/packages/agent/test/idle-after-completed-tools.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+	isStreamIdleTimeoutError,
+	shouldFinalizeIdleAsStop,
+} from "../src/assistant-terminal-state.ts";
+import { kCursorExecResolved, type AssistantMessage, type ToolResultMessage } from "@earendil-works/pi-ai";
+
+function message(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+describe("shouldFinalizeIdleAsStop", () => {
+	it("finalizes resolved Cursor tools after idle", () => {
+		const tool = { type: "toolCall" as const, id: "t1", name: "task", arguments: {} };
+		(tool as Record<PropertyKey, unknown>)[kCursorExecResolved] = true;
+		expect(shouldFinalizeIdleAsStop(message([tool]), [])).toBe(true);
+	});
+
+	it("does not finalize text-only idle", () => {
+		expect(shouldFinalizeIdleAsStop(message([{ type: "text", text: "hi" }]), [])).toBe(false);
+	});
+
+	it("finalizes when exec results are already buffered", () => {
+		const tool = { type: "toolCall" as const, id: "t1", name: "bash", arguments: {} };
+		const results = [{ role: "toolResult", toolCallId: "t1", toolName: "bash", content: [], details: {} }] as ToolResultMessage[];
+		expect(shouldFinalizeIdleAsStop(message([tool]), results)).toBe(true);
+	});
+
+	it("recognizes the idle error name", () => {
+		const error = new Error("Idle timeout waiting for provider stream after 40ms");
+		error.name = "StreamIdleTimeoutError";
+		expect(isStreamIdleTimeoutError(error)).toBe(true);
+		expect(isStreamIdleTimeoutError(new Error("other"))).toBe(false);
+	});
+});


### PR DESCRIPTION
Closes #997

After Cursor-resolved tools (or buffered exec results) the parent may sit silent for 300s and die as `StreamIdleTimeoutError` even though a child is already running.

Idle + completed tools → `stop`. Text-only hang still errors. Pending `trackLocalWork` still re-arms.

Why not an extension: the idle reader is inside `agent-loop`.

Conflict zone: `agent-loop.ts` `streamAssistantResponse` catch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
End the assistant turn as stop when the provider stream goes idle after Cursor-resolved tools or buffered exec results. Previously it idled up to 300s and ended as StreamIdleTimeoutError; now it finalizes as stop. Text-only idles still error.

- Adjusts `streamAssistantResponse` to detect `StreamIdleTimeoutError` and, when tools are already resolved, emit a final assistant message with `stopReason: "stop"`.
- Adds `isStreamIdleTimeoutError` and `shouldFinalizeIdleAsStop` in `assistant-terminal-state.ts`; includes unit tests for Cursor exec-resolved and buffered result cases.
- Updates `packages/agent/CHANGELOG.md` and `packages/agent/src/changes.md` to document the behavior change.

<sup>Written for commit 21eb7be3cca30f952651008f98164e3766a687ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

