### PR TITLE
fix(agent): bind cursor exec handlers to owning run

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Cursor exec handler factories now receive the owning run's abort signal instead of the per-request
+  idle-timeout controller, so native Cursor exec tool calls pass the run-ownership check again instead
+  of failing every call with `Tool execution has no active run`.
+
 ### Removed
 
 ## [2026.8.19] - 2026-08-19

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -507,7 +507,7 @@ async function streamAssistantResponse(
 				? {
 						execHandlers:
 							typeof config.cursorExecHandlers === "function"
-								? config.cursorExecHandlers(requestAbortController.signal)
+								? config.cursorExecHandlers(signal ?? requestAbortController.signal)
 								: config.cursorExecHandlers,
 						onToolResult: (result: ToolResultMessage) => {
 							providerToolResults.push(result);
@@ -629,6 +629,7 @@ async function streamAssistantResponse(
 		await emit({ type: "message_end", message: finalMessage });
 		return { message: finalMessage, providerToolResults };
 	} finally {
+		requestAbortController.abort();
 		detachCallerAbort?.();
 	}
 }

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,31 @@
 # Changes
 
+## 2026-08-20 - Cursor exec handlers bind to the owning run signal
+
+### What changed
+
+- `packages/agent/src/agent-loop.ts`: when `config.cursorExecHandlers` is a factory, the loop now
+  resolves it with the outer owning-run signal (`signal ?? requestAbortController.signal`) instead of
+  the per-request idle-timeout controller, and normal request completion aborts the request-scoped
+  fallback so signal-less direct loop callers cannot leave stale handlers live.
+
+### Why
+
+- The bridge session (`cursor-exec-bridge-session.ts`) verifies ownership by identity against the
+  agent's live run signal. The per-request controller is a different object by construction, so every
+  native Cursor exec frame failed the check and returned `Tool execution has no active run`
+  (issues #979/#1000/#1003, regression from 31a71f0c5).
+
+### Why an extension could not handle it
+
+- The factory resolution happens inside the loop's provider-request assembly; no extension hook sits
+  between `streamAssistantResponse` and the provider options it constructs.
+
+### Expected merge conflict zones
+
+- `agent-loop.ts` provider-request assembly and the request `finally` teardown (fork-only Cursor exec
+  channel; upstream has no cursor provider).
+
 ## Loop and agent divergence re-established against upstream 59a71b23 (2026-08-19)
 
 ### What changed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -14,7 +14,8 @@
   of dropping them); `streamKind: "main"` stamped on the loop's own provider request so auxiliary calls
   stay distinguishable downstream; thinking-block `startedAt` / `endedAt` stamping from the
   `thinkingTiming` map at stream-event receipt; the Cursor exec-channel bridge (handler factory resolved
-  with the owning run's signal, mid-stream tool results buffered and appended, `kCursorExecResolved`
+  with the outer owning-run signal rather than the provider request's idle-timeout signal, mid-stream
+  tool results buffered and appended, `kCursorExecResolved`
   blocks excluded from the executable tool batch); `withEmptyAssistantRecovery` around the stream fn; and
   the `prepareNextTurn` merge of `thinkingSelection` and `abortServerSideFallback`.
 - `packages/agent/src/agent.ts` stays divergent on the run-ownership surface those loop features require:
@@ -56,8 +57,9 @@
 - `packages/agent/src/types.ts`: `AgentLoopConfig.cursorExecHandlers` also
   accepts a `(runSignal: AbortSignal) => CursorExecHandlers` factory.
 - `packages/agent/src/agent-loop.ts`: when a factory is supplied, the loop
-  resolves it with `requestAbortController.signal` — the signal of the run that
-  owns the stream being opened.
+  resolves it with the outer owning-run signal. Direct loop callers without an
+  outer signal retain the request controller as a scoped fallback, and normal
+  request completion aborts that fallback so stale handlers cannot remain live.
 
 ### Why
 

--- a/packages/agent/test/cursor-exec-loop.test.ts
+++ b/packages/agent/test/cursor-exec-loop.test.ts
@@ -282,4 +282,99 @@ describe("cursor exec-channel integration in the agent loop", () => {
 		expect(assistantMessage?.stopReason).toBe("error");
 		expect(assistantMessage?.errorMessage).toContain("Idle timeout");
 	});
+
+	it("passes the run abort signal into cursorExecHandlers, not the per-request controller", async () => {
+		const run = new AbortController();
+		let seen: AbortSignal | undefined;
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: model(),
+			convertToLlm: (messages) => messages.filter((message): message is Message => "role" in message),
+			cursorExecHandlers: (signal) => {
+				seen = signal;
+				return {};
+			},
+		};
+		const stream = agentLoop([{ role: "user", content: "hi", timestamp: 0 }], context, config, run.signal, () => {
+			const response = createAssistantMessageEventStream();
+			const partial = assistant([{ type: "text", text: "ok" }]);
+			response.push({ type: "start", partial });
+			response.push({ type: "text_end", contentIndex: 0, content: "ok", partial });
+			response.end({ ...partial, stopReason: "stop" });
+			return response;
+		});
+		for await (const _event of stream) {
+			// consume
+		}
+		expect(seen).toBe(run.signal);
+	});
+
+	it("keeps concurrent cursor handler factories bound to their respective run signals", async () => {
+		const runA = new AbortController();
+		const runB = new AbortController();
+		let seenA: AbortSignal | undefined;
+		let seenB: AbortSignal | undefined;
+
+		const runLoop = async (run: AbortController, capture: (signal: AbortSignal) => void) => {
+			const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+			const config: AgentLoopConfig = {
+				model: model(),
+				convertToLlm: (messages) => messages.filter((message): message is Message => "role" in message),
+				cursorExecHandlers: (signal) => {
+					capture(signal);
+					return {};
+				},
+			};
+			const stream = agentLoop([{ role: "user", content: "hi", timestamp: 0 }], context, config, run.signal, () => {
+				const response = createAssistantMessageEventStream();
+				const message = assistant([{ type: "text", text: "ok" }]);
+				response.push({ type: "done", reason: "stop", message });
+				response.end();
+				return response;
+			});
+			for await (const _event of stream) {
+				// consume
+			}
+		};
+
+		await Promise.all([
+			runLoop(runA, (signal) => {
+				seenA = signal;
+			}),
+			runLoop(runB, (signal) => {
+				seenB = signal;
+			}),
+		]);
+
+		expect(seenA).toBe(runA.signal);
+		expect(seenB).toBe(runB.signal);
+		expect(seenA).not.toBe(seenB);
+	});
+
+	it("revokes the request-scoped fallback signal after a signal-less loop completes", async () => {
+		let seen: AbortSignal | undefined;
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [] };
+		const config: AgentLoopConfig = {
+			model: model(),
+			convertToLlm: (messages) => messages.filter((message): message is Message => "role" in message),
+			cursorExecHandlers: (signal) => {
+				seen = signal;
+				return {};
+			},
+		};
+		const stream = agentLoop([{ role: "user", content: "hi", timestamp: 0 }], context, config, undefined, () => {
+			const response = createAssistantMessageEventStream();
+			const message = assistant([{ type: "text", text: "ok" }]);
+			response.push({ type: "done", reason: "stop", message });
+			response.end();
+			return response;
+		});
+
+		for await (const _event of stream) {
+			// consume
+		}
+
+		expect(seen).toBeDefined();
+		expect(seen?.aborted).toBe(true);
+	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Fixed
 
+- The Cursor exec bridge fails closed when a session bridge has no captured owning run, and rechecks
+  run ownership after awaited preflight work so a run that ends during an approval prompt cannot start
+  a tool side effect afterward.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -216,7 +216,11 @@
 - `packages/coding-agent/src/core/cursor-exec-bridge-session.ts`: the session
   adapter accepts the signal of the run that owns the exec stream and resolves
   `getAbortSignal` from it, returning `undefined` once that run is no longer
-  the agent's live run.
+  the agent's live run. Adapters created without a captured owner fail closed
+  instead of adopting whichever run is currently live.
+- `packages/coding-agent/src/core/cursor-exec-bridge.ts`: dispatch rechecks the
+  captured signal after awaited preflight work and before `tool.execute()`, so
+  a run that ends during approval cannot start a side effect afterward.
 - `packages/coding-agent/src/core/sdk.ts`: supplies the bridge as a per-run
   factory so every Cursor stream gets handlers bound to its own run.
 

--- a/packages/coding-agent/src/core/cursor-exec-bridge-session.ts
+++ b/packages/coding-agent/src/core/cursor-exec-bridge-session.ts
@@ -39,7 +39,7 @@ export function createSessionCursorExecBridge(
 		emitEvent: async (event: AgentEvent, runSignal: AbortSignal) =>
 			await getAgent().emitExternalEvent(event, runSignal),
 		getAbortSignal: () => {
-			if (runSignal === undefined) return getAgent().signal;
+			if (runSignal === undefined || runSignal.aborted) return undefined;
 			return runSignal === getAgent().signal ? runSignal : undefined;
 		},
 	});

--- a/packages/coding-agent/src/core/cursor-exec-bridge.ts
+++ b/packages/coding-agent/src/core/cursor-exec-bridge.ts
@@ -126,9 +126,16 @@ async function executeTool(
 			input: params,
 		});
 		if (runSignal.aborted || options.getAbortSignal() !== runSignal) {
-			return errorResult(toolCallId, toolName, "Tool execution has no active run");
-		}
-		if (preflight?.block) {
+			const message = "Tool execution has no active run";
+			toolResult = errorResult(toolCallId, toolName, message);
+			endEvent = {
+				type: "tool_execution_end",
+				toolCallId,
+				toolName,
+				result: { content: [{ type: "text", text: message }], details: undefined },
+				isError: true,
+			};
+		} else if (preflight?.block) {
 			const message = preflight.reason || "Tool execution was blocked";
 			toolResult = errorResult(toolCallId, toolName, message);
 			endEvent = {

--- a/packages/coding-agent/src/core/cursor-exec-bridge.ts
+++ b/packages/coding-agent/src/core/cursor-exec-bridge.ts
@@ -82,7 +82,7 @@ async function executeTool(
 	args: Record<string, unknown>,
 ): Promise<ToolResultMessage> {
 	const runSignal = options.getAbortSignal();
-	if (!runSignal) {
+	if (!runSignal || runSignal.aborted) {
 		return errorResult(toolCallId, toolName, "Tool execution has no active run");
 	}
 
@@ -125,6 +125,9 @@ async function executeTool(
 			toolName,
 			input: params,
 		});
+		if (runSignal.aborted || options.getAbortSignal() !== runSignal) {
+			return errorResult(toolCallId, toolName, "Tool execution has no active run");
+		}
 		if (preflight?.block) {
 			const message = preflight.reason || "Tool execution was blocked";
 			toolResult = errorResult(toolCallId, toolName, message);

--- a/packages/coding-agent/test/cursor-exec-bridge-preflight.test.ts
+++ b/packages/coding-agent/test/cursor-exec-bridge-preflight.test.ts
@@ -55,7 +55,7 @@ describe("cursor exec bridge tool_call preflight", () => {
 				});
 			},
 		};
-		const bridge = createSessionCursorExecBridge({ current: session }, () => agent);
+		const bridge = createSessionCursorExecBridge({ current: session }, () => agent, runSignal);
 
 		const results: ToolResultMessage[] = [];
 		for (let attempt = 1; attempt <= 9; attempt++) {

--- a/packages/coding-agent/test/cursor-exec-bridge-run-ownership.test.ts
+++ b/packages/coding-agent/test/cursor-exec-bridge-run-ownership.test.ts
@@ -133,4 +133,27 @@ describe("cursor exec bridge run ownership across runs", () => {
 		runBStream.push({ type: "done", reason: "stop", message: createAssistantMessage("run B done") });
 		await runB;
 	});
+
+	it("fails closed when a session bridge has no captured owning run", async () => {
+		const execute = vi.fn();
+		const tool = stubReadTool(execute);
+		const sessionRef: { current?: CursorExecBridgeSession } = {
+			current: {
+				getRegisteredTool: (name) => (name === "read" ? tool : undefined),
+				preflightToolCall: async () => undefined,
+			},
+		};
+		const emitExternalEvent = vi.fn();
+		const agent = {
+			signal: new AbortController().signal,
+			emitExternalEvent,
+		};
+		const bridge = createSessionCursorExecBridge(sessionRef, () => agent);
+
+		const result = await bridge.read?.({ path: "a.ts", toolCallId: "unbound-frame" } as never);
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(emitExternalEvent).not.toHaveBeenCalled();
+		expect(isToolResult(result) && result.isError).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/cursor-exec-bridge.test.ts
+++ b/packages/coding-agent/test/cursor-exec-bridge.test.ts
@@ -249,6 +249,43 @@ describe("cursor exec bridge", () => {
 		expect(emitEvent).not.toHaveBeenCalled();
 	});
 
+	it("rechecks run ownership after preflight before executing the tool", async () => {
+		const owner = new AbortController();
+		const replacement = new AbortController();
+		let activeSignal: AbortSignal | undefined = owner.signal;
+		let releasePreflight!: () => void;
+		let markPreflightStarted!: () => void;
+		const preflightStarted = new Promise<void>((resolve) => {
+			markPreflightStarted = resolve;
+		});
+		const preflightGate = new Promise<void>((resolve) => {
+			releasePreflight = resolve;
+		});
+		const execute = vi.fn();
+		const emitEvent = vi.fn();
+		const tool = stubTool("read", Type.Object({ path: Type.String() }), execute);
+		const bridge = createCursorExecBridge({
+			getTool: (name) => (name === "read" ? tool : undefined),
+			getAbortSignal: () => activeSignal,
+			preflightToolCall: async () => {
+				markPreflightStarted();
+				await preflightGate;
+				return undefined;
+			},
+			emitEvent,
+		});
+
+		const resultPromise = bridge.read?.({ path: "a.ts", toolCallId: "call-owner-ended" } as never);
+		await preflightStarted;
+		owner.abort();
+		activeSignal = replacement.signal;
+		releasePreflight();
+		const result = asToolResult(await resultPromise);
+
+		expect(result.isError).toBe(true);
+		expect(execute).not.toHaveBeenCalled();
+	});
+
 	it("propagates lifecycle listener failures through the bridge dispatch", async () => {
 		const runSignal = new AbortController().signal;
 		const execute = vi.fn();


### PR DESCRIPTION
## Summary

- bind Cursor exec handler factories to the outer signal that owns the run instead of the per-request idle-timeout controller
- fail closed when a session bridge has no captured owner or the owner changes during awaited preflight work
- revoke request-scoped fallback signals when signal-less loop calls finish
- add deterministic regression coverage for concurrent run binding, unbound bridges, preflight ownership races, and fallback revocation

## Why

A Cursor exec frame can arrive after its original provider run has ended. Using a request controller or dynamically resolving the current agent signal lets the frame fail ownership checks or, in unsafe fallback paths, execute under a replacement run.

This replacement preserves the captured-run identity guard and closes the additional ownership races found during review.

## Validation

- `npm test --workspace=@earendil-works/pi-agent-core -- test/cursor-exec-loop.test.ts` — 8/8 passed
- bridge ownership/preflight tests — 16/16 passed
- full agent package — 512 passed, 1 pre-existing skipped
- `npm run check` — passed
- `npm run build` — passed
- `npm run build --workspace=@earendil-works/pi-agent-core` — passed
- real CLI: `cursor/auto` executed bash and returned `CURSOR_PR_TOOL_OK` without `Tool execution has no active run`

The full coding-agent suite completed 8,462 passing tests. Eighteen unrelated live model-catalog/provider fixture tests failed in files outside this diff, including Ollama, Radius, app-server catalog/model-list, and favorites-search coverage. All Cursor ownership and preflight suites pass.

## Related work and attribution

Supersedes #981 and preserves the original fix by @leeseunguk, with co-author attribution in commit `a28d835f2`.

Closes #979
Closes #1000

PR #999 also touches `packages/agent/src/agent-loop.ts` and `packages/agent/src/changes.md`, so it is a known merge-conflict zone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds Cursor exec handler factories to the owning run’s AbortSignal so native exec calls pass run-ownership checks. Previously handlers were bound to the per-request controller and every call failed with “Tool execution has no active run”; now they bind to the run signal, revoke the request-scoped fallback at stream end, and the bridge fails closed and emits `tool_execution_end` if ownership is missing or ends (including after preflight).

- Review focus:
  - `packages/agent/src/agent-loop.ts`: resolve `cursorExecHandlers` with `signal ?? requestAbortController.signal`; abort the request-scoped fallback in `finally`.
  - `packages/coding-agent/src/core/cursor-exec-bridge-session.ts`: `getAbortSignal` returns `undefined` when the owner is missing or aborted; never adopts a new run.
  - `packages/coding-agent/src/core/cursor-exec-bridge.ts`: recheck ownership after preflight and before `tool.execute()`; on loss or aborted signal, return an error and emit `tool_execution_end`.

<sup>Written for commit ce69afb05047135ad7938daf71ac8a356954e3d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

