### PR TITLE
fix(config-reload): preserve routine settings handoffs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Settings hot-reload no longer cascades across sessions that share an agent directory when another session saves a routine preference such as `defaultModel` during a reload. The replacement watcher now compares reload-window changes with the request-time settings snapshot, so routine-only writes remain suppressed while substantive configuration edits still reload.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Settings hot-reload no longer cascades across sessions that share an agent directory when another session saves a routine preference such as `defaultModel` during a reload. The replacement watcher now compares reload-window changes with the request-time settings snapshot, so routine-only writes remain suppressed while substantive configuration edits still reload.
+- Settings hot-reload now clears the reload handoff unconditionally after `requestReload()` settles, preventing a stale plaintext settings snapshot from surviving when the reload successor omits the config-reload builtin.
 
 ### Added
 

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,5 +1,33 @@
 # config-reload Extension Changes
 
+## Preserve cross-process routine filtering through reload handoff (2026-08-20)
+
+### What changed
+
+- `index.ts` now carries the pre-reload settings-content snapshots through each
+  session-keyed reload handoff and restores them before classifying filesystem
+  changes found during the reload window.
+- A regression verifies that a concurrent `defaultModel` write does not cause
+  the replacement extension to request a second full reload.
+
+### Why
+
+- Rebuilding a watcher refreshed its settings snapshot before handoff changes
+  were classified. A peer process's routine-only write then compared current
+  content to itself, bypassed routine filtering, and could cascade into reload
+  storms across sessions sharing an agent directory.
+
+### Why an extension could not handle it
+
+- This builtin owns both the session reload handoff and the routine-settings
+  snapshot used by the protected config watcher.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` `ReloadHandoff`, reload request state capture, and
+  `processReloadHandoff`; LOW in `config-reload-extension.test.ts` around the
+  existing reload-window coverage.
+
 ## Watch and validate JSONC settings (2026-08-16)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,5 +1,33 @@
 # config-reload Extension Changes
 
+## Clear orphaned handoff unconditionally after reload (2026-08-20)
+
+### What changed
+
+- `index.ts` now captures the handoff key before `requestReload()` and deletes
+  the registry entry unconditionally when the promise settles, removing the
+  `tornDown` guard that skipped deletion after a real reload.
+- The `tornDown` closure variable was removed entirely; it was only read by
+  the deleted guard.
+- A regression test verifies that a reload whose successor omits config-reload
+  does not leave a stale handoff for a later reload to consume.
+
+### Why
+
+- If the settings change disabled config-reload, the successor never called
+  `take()`, so the handoff survived for the process lifetime — now including
+  plaintext settings contents. A later reload that re-enabled the builtin
+  consumed and replayed the stale change.
+
+### Why an extension could not handle it
+
+- This builtin owns both the session reload handoff and the routine-settings
+  snapshot used by the protected config watcher.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` `flushPending` try/catch block and `session_shutdown` handler.
+
 ## Preserve cross-process routine filtering through reload handoff (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -173,7 +173,6 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	let activeTargets: ActiveTarget[] = [];
 	let currentContext: ExtensionContext | undefined;
 	let started = false;
-	let tornDown = false;
 	let reloadInFlight = false;
 	let deferredNoticeShown = false;
 	let unavailableReloadLogged = false;
@@ -387,7 +386,6 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		const changes = pendingChanges(pending);
 		const paths = uniquePaths(changes.flatMap((change) => change.paths));
 		reloadInFlight = true;
-		tornDown = false;
 		reloadHandoffs.set(handoffKey(ctx), {
 			hashesAtRequest: engine?.getBaselineSnapshot() ?? new Map<string, string>(),
 			settingsContentsAtRequest: new Map(settingsContents),
@@ -397,15 +395,14 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		ctx.ui.notify(`Hot-reloading: ${formatPaths(paths)}`, "info");
 		logger.info("reload_requested", { reason: "config changed", paths });
 
+		const handoffKeyForReload = handoffKey(ctx);
 		try {
 			await ctx.requestReload();
-			if (!tornDown) {
-				reloadInFlight = false;
-				reloadHandoffs.delete(handoffKey(ctx));
-			}
+			reloadInFlight = false;
+			reloadHandoffs.delete(handoffKeyForReload);
 		} catch (error) {
 			reloadInFlight = false;
-			reloadHandoffs.delete(handoffKey(ctx));
+			reloadHandoffs.delete(handoffKeyForReload);
 			logger.error("watcher_error", { path: "reload", message: errorMessage(error) });
 		}
 	};
@@ -455,7 +452,6 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	eventUnsubscribes.push(pi.events.on(CONFIG_WATCH_UNREGISTER, handleUnregistration));
 
 	pi.on("session_start", async (event, ctx) => {
-		tornDown = false;
 		started = true;
 		currentContext = ctx;
 		rebuildWatchers(ctx);
@@ -476,7 +472,6 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	});
 	pi.on("session_shutdown", (event) => {
 		const closingContext = currentContext;
-		tornDown = true;
 		started = false;
 		currentContext = undefined;
 		closeWatchers();

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -99,6 +99,7 @@ type PendingChange = {
 
 type ReloadHandoff = {
 	readonly hashesAtRequest: ReadonlyMap<string, string>;
+	readonly settingsContentsAtRequest: ReadonlyMap<string, string>;
 	readonly requestedAt: number;
 	readonly changes: readonly { readonly registrationId: string; readonly paths: readonly string[] }[];
 };
@@ -389,6 +390,7 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 		tornDown = false;
 		reloadHandoffs.set(handoffKey(ctx), {
 			hashesAtRequest: engine?.getBaselineSnapshot() ?? new Map<string, string>(),
+			settingsContentsAtRequest: new Map(settingsContents),
 			requestedAt: Date.now(),
 			changes,
 		});
@@ -442,6 +444,8 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 
 		const changedPaths = compareSnapshots(handoff.hashesAtRequest, engine?.getBaselineSnapshot() ?? new Map());
 		if (changedPaths.length > 0) {
+			settingsContents.clear();
+			for (const [path, content] of handoff.settingsContentsAtRequest) settingsContents.set(path, content);
 			enqueueChange({ changedPaths, created: [], deleted: [] });
 			await changeChain;
 		}

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -1207,6 +1207,55 @@ describe("config reload builtin extension", () => {
 		expect(reloaded).toContainEqual({ registrationId: "builtin", paths: [settingsPath] });
 	});
 
+	it("suppresses a routine settings change discovered during reload handoff", async () => {
+		vi.useFakeTimers();
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-routine-handoff-"));
+		agentDirs.push(agentDir);
+		const settingsPath = join(agentDir, "settings.json");
+		writeJson(settingsPath, { theme: "dark", defaultModel: "m1" });
+		const bus = createEventBus();
+		const watches = createWatchProbe();
+		const first = createManualExtension(bus);
+		let firstContext: ExtensionContext | undefined;
+		let second: ManualExtension | undefined;
+		const secondReload = vi.fn(async () => {});
+		const firstReload = vi.fn(async () => {
+			if (!firstContext) throw new Error("Missing first context");
+			await invoke(
+				first.handlers,
+				"session_shutdown",
+				{ type: "session_shutdown", reason: "reload" } satisfies SessionShutdownEvent,
+				firstContext,
+			);
+			writeJson(settingsPath, { theme: "light", defaultModel: "m2" });
+			second = createManualExtension(bus);
+			configReloadExtension(second.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+			await invoke(
+				second.handlers,
+				"session_start",
+				{ type: "session_start", reason: "reload" } satisfies SessionStartEvent,
+				fakeContext({ cwd: agentDir, requestReload: secondReload }),
+			);
+		});
+		configReloadExtension(first.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		firstContext = fakeContext({ cwd: agentDir, requestReload: firstReload });
+		await invoke(
+			first.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			firstContext,
+		);
+		writeJson(settingsPath, { theme: "light", defaultModel: "m1" });
+		watches.emit(agentDir, "settings.json");
+		await vi.advanceTimersByTimeAsync(200);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(firstReload).toHaveBeenCalledTimes(1);
+		expect(second).toBeDefined();
+		expect(secondReload).not.toHaveBeenCalled();
+	});
+
 	it("rejects credential and protected registration targets without filesystem or hash access", async () => {
 		vi.useFakeTimers();
 		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-credential-"));

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -1256,6 +1256,62 @@ describe("config reload builtin extension", () => {
 		expect(secondReload).not.toHaveBeenCalled();
 	});
 
+	it("clears the reload handoff when the successor omits config-reload", async () => {
+		vi.useFakeTimers();
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-orphan-handoff-"));
+		agentDirs.push(agentDir);
+		const settingsPath = join(agentDir, "settings.json");
+		writeJson(settingsPath, { theme: "dark", httpProxy: "http://user:secret@example.invalid" });
+		const bus = createEventBus();
+		const watches = createWatchProbe();
+		const reloaded: unknown[] = [];
+		bus.on(CONFIG_WATCH_RELOADED, (payload) => reloaded.push(payload));
+		const first = createManualExtension(bus);
+		let firstContext: ExtensionContext | undefined;
+		const firstReload = vi.fn(async () => {
+			if (!firstContext) throw new Error("Missing first context");
+			await invoke(
+				first.handlers,
+				"session_shutdown",
+				{ type: "session_shutdown", reason: "reload" } satisfies SessionShutdownEvent,
+				firstContext,
+			);
+			// Successor intentionally omits config-reload (it was disabled in settings).
+		});
+		configReloadExtension(first.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		firstContext = fakeContext({ cwd: agentDir, requestReload: firstReload });
+		await invoke(
+			first.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			firstContext,
+		);
+		writeJson(settingsPath, {
+			theme: "light",
+			httpProxy: "http://user:secret@example.invalid",
+			disabledBuiltinExtensions: ["config-reload"],
+		});
+		watches.emit(agentDir, "settings.json");
+		await vi.advanceTimersByTimeAsync(200);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(firstReload).toHaveBeenCalledTimes(1);
+		expect(reloaded).toHaveLength(0);
+
+		// A later reload re-enables config-reload. It must not consume a stale handoff.
+		const later = createManualExtension(bus);
+		configReloadExtension(later.api, { agentDir, subscribe: watches.subscribe, logger: silentLogger() });
+		await invoke(
+			later.handlers,
+			"session_start",
+			{ type: "session_start", reason: "reload" } satisfies SessionStartEvent,
+			fakeContext({ cwd: agentDir, requestReload: async () => {} }),
+		);
+
+		expect(reloaded).toHaveLength(0);
+	});
+
 	it("rejects credential and protected registration targets without filesystem or hash access", async () => {
 		vi.useFakeTimers();
 		const agentDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-credential-"));


### PR DESCRIPTION
## Summary
- preserve request-time settings snapshots through config-reload handoff
- classify changes discovered during reload against that snapshot so a peer session's routine settings write does not request a second full reload
- cover routine suppression alongside the existing non-routine reload-window regression

## Root cause
Replacement watchers refreshed their settings-content snapshot before reload-window changes were classified. A concurrent `defaultModel` write from another OMO/Senpi process therefore compared current content to itself, bypassed routine-settings filtering, and could cascade into shared-agent-directory reload storms.

## Verification
- [x] Red: new routine handoff regression fails before the fix (`secondReload` called once)
- [x] `node ./node_modules/vitest/vitest.mjs run packages/coding-agent/test/suite/config-reload-extension.test.ts` — 53 passed
- [x] `npm run check` under Node 24 — passed (Biome, pinned deps, import checks, shrinkwrap/install locks, TypeScript, browser smoke)
- [x] isolated real CLI smoke — passed
- [x] isolated tmux TUI smoke — input reached composer; no leaked process
- [x] independent scoped review — no blockers

## Scope
Routine-only changes remain suppressed. The existing regression verifies a non-routine change during the same handoff window still causes one follow-up reload.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the request-time settings snapshot through reload handoffs and clears orphaned handoffs to prevent cross‑session reload storms and stale replays. Old: routine writes during the reload window could trigger a second full reload, and if the successor omitted config-reload the handoff persisted and later replayed stale changes. New: the replacement watcher restores the pre-reload snapshot so routine-only writes stay suppressed, and the handoff is deleted unconditionally after reload.

- Adds `settingsContentsAtRequest` to `ReloadHandoff` and restores it before classifying handoff changes in `index.ts`.
- Captures the handoff key before `requestReload()` and deletes the registry entry when it settles; removes the `tornDown` guard.
- Adds tests for routine-change suppression during handoff and for clearing the handoff when the successor omits the builtin.
- No API or config changes. No migration.

<sup>Written for commit d22eb0a7bd8c317e4360da8ddb1755e6b00dce8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

