### PR TITLE
fix(cursor): skip ANTML invoke recovery on cursor-agent

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Skip ANTML invoke recovery when `model.api === "cursor-agent"` so native Cursor tool starts are not rejected as invalid event order (#1007).
 - Cursor MCP `task` complete no longer overwrites streamed arguments with `{}`; the last usable task args are kept (#1011).
 - Cursor conversation-id rotation now persists under the agent directory (`CODING_AGENT_DIR` or `~/.senpi/agent`) instead of `$HOME/cursor-conversation-ids.json`, so a reminted wire id survives TUI restart.
 - Cursor 0-token `resource_exhausted` surfaces on the first failure of a `stream()` call so the session layer can compact before any conversation-id rotation; rotation and same-stream retry apply only to later attempts, and the poisoned-conversation error surfaces once the 3-rotation cap is reached.

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Skip ANTML invoke recovery when `model.api === "cursor-agent"` so native Cursor tool starts are not rejected as invalid event order.
+
 # AI Source Changes
 
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin

--- a/packages/ai/src/tool-call-middleware/index.ts
+++ b/packages/ai/src/tool-call-middleware/index.ts
@@ -50,6 +50,7 @@ export function shouldRecoverTextToolCalls<TApi extends Api>(model: Model<TApi>)
 	if (model.recoverTextToolCalls !== undefined) {
 		return typeof model.recoverTextToolCalls === "boolean" ? model.recoverTextToolCalls : false;
 	}
+	if (model.api === "cursor-agent") return false;
 	return CLAUDE_MODEL_ID_PATTERN.test(model.id) || KIMI_MODEL_ID_PATTERN.test(model.id);
 }
 

--- a/packages/ai/test/tool-call-middleware/invoke-recovery-activation.test.ts
+++ b/packages/ai/test/tool-call-middleware/invoke-recovery-activation.test.ts
@@ -37,6 +37,23 @@ function createMalformedRecoveryModel(value: unknown): Model<"openai-completions
 }
 
 describe("invoke recovery activation", () => {
+	it("does not activate ANTML recovery on cursor-agent Claude ids", () => {
+		const cursorFable: Model<"cursor-agent"> = {
+			id: "claude-fable-5-medium",
+			name: "claude-fable-5-medium",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "https://api2.cursor.sh",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 8192,
+		};
+		expect(shouldRecoverTextToolCalls(cursorFable)).toBe(false);
+		expect(shouldRecoverTextToolCalls({ ...cursorFable, recoverTextToolCalls: true })).toBe(true);
+	});
+
 	it("matches the locked Claude-family identifiers across APIs", () => {
 		for (const id of [
 			"claude-opus-4-8",


### PR DESCRIPTION
Closes #1007

`claude-fable-5-*` matched ANTML recovery by name. Native cursor-agent tool starts then failed as invalid event order.

Skip recovery when `api === "cursor-agent"` unless `recoverTextToolCalls` is explicit.

Conflict zone: `shouldRecoverTextToolCalls`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip ANTML invoke recovery for `cursor-agent` models so native Cursor tool starts are not rejected as invalid event order. Previously, Claude-named Cursor models activated recovery and flagged parallel `toolcall_start` as invalid; now recovery is off by default for `cursor-agent` unless explicitly enabled.

- In `packages/ai/src/tool-call-middleware/index.ts`, `shouldRecoverTextToolCalls` returns false when `model.api === "cursor-agent"` unless `recoverTextToolCalls` is true.
- To enable recovery on `cursor-agent`, set `recoverTextToolCalls: true` on the model; other APIs are unchanged.
- Tests added to assert the new default; changelog updated.

<sup>Written for commit 198b89d30e6fca1bb22c3021dde2ad839ab80005. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

