### PR TITLE
fix(cursor): send suffixed Run model ids

### DIFF
--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Send Cursor Run suffixed variant ids (claude-fable-5-medium) instead of bare capability ids.
+
 # AI Source Changes
 
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin

--- a/packages/ai/src/cursor/selection-descriptor.ts
+++ b/packages/ai/src/cursor/selection-descriptor.ts
@@ -79,10 +79,12 @@ export function resolveCursorSelectionDescriptor(
 		return { modelId: compat.representativeVariantId, parameters: [] };
 	}
 
-	if (spec.encoding === "variant-id") {
-		const suffixId = legacySuffixId(compat.capabilityId, selection.level, spec.value);
-		if (suffixId === undefined) return { modelId: compat.representativeVariantId, parameters: [] };
+	const suffixId = legacySuffixId(compat.capabilityId, selection.level, spec.value);
+	if (suffixId !== undefined) {
 		return { modelId: suffixId, parameters: [] };
+	}
+	if (spec.encoding === "variant-id") {
+		return { modelId: compat.representativeVariantId, parameters: [] };
 	}
 
 	const bareBase = compat.capabilityId;

--- a/packages/ai/test/cursor-selection-suffix.test.ts
+++ b/packages/ai/test/cursor-selection-suffix.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveCursorSelectionDescriptor } from "../src/cursor/selection-descriptor.ts";
+import type { Model } from "../src/types.ts";
+
+describe("resolveCursorSelectionDescriptor suffix ids", () => {
+	it("sends claude-fable-5-medium instead of the bare capability id", () => {
+		const model = {
+			id: "claude-fable-5",
+			name: "fable",
+			api: "cursor-agent",
+			provider: "cursor",
+			baseUrl: "https://api2.cursor.sh",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200000,
+			maxTokens: 16,
+			compat: {
+				cursorReasoning: {
+					capabilityId: "claude-fable-5",
+					thinkingMode: true,
+					representativeVariantId: "claude-fable-5-medium",
+				},
+			},
+		} as Model<"cursor-agent">;
+		const resolved = resolveCursorSelectionDescriptor(model, { source: "explicit", level: "medium" });
+		expect(resolved.modelId).toBe("claude-fable-5-medium");
+		expect(resolved.parameters).toEqual([]);
+	});
+});


### PR DESCRIPTION
Closes #1004

Bare `claude-fable-5` is `not_found` on Cursor Run. Prefer the legacy suffix alias (`claude-fable-5-medium`).

Conflict zone: `resolveCursorSelectionDescriptor`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use suffixed Cursor Run model IDs (e.g., claude-fable-5-medium) instead of bare capability IDs (e.g., claude-fable-5) to avoid not_found errors. Previously we only used the suffix for variant-id selections; now we prefer the suffix whenever available.

- resolveCursorSelectionDescriptor now returns the legacy suffixed ID first when present; otherwise falls back to the representative variant for variant-id, or to the bare capability ID.
- Adds a unit test ensuring claude-fable-5 resolves to claude-fable-5-medium.
- Notes the behavior change in changes.md. No migration required.

<sup>Written for commit 1ed9603efc68e6d59e7ba561a5b43354decd9ad3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

