### PR TITLE
fix(cursor): compact large 0-token RE before fallback

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Cursor 0-token `resource_exhausted` is treated as overflow without a local-estimate floor, and Cursor overflow compaction keeps no recent-token tail so the retry payload actually shrinks.
+
 ### Removed
 
 ## [2026.8.19] - 2026-08-19

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,6 +1,20 @@
-## Unreleased
+## Unreleased - Cursor 0-token RE overflow without estimate gate
 
-- Treat large Cursor 0-token resource_exhausted as overflow so the session compacts before rotating or falling back.
+### What changed
+
+- `packages/ai/src/utils/overflow.ts`: 0-token Cursor `resource_exhausted` is overflow even when the local estimate is 0; same-model remint helpers skip provider fallback; Cursor overflow compaction settings force `keepRecentTokens: 0` and disable restoration.
+
+### Why
+
+- The 50k estimate gate missed sessions whose last billed usage was zeroed after an earlier compact, so Cursor still rejected the payload while senpi treated it as a 429 and jumped providers.
+
+### Why an extension could not handle it
+
+- Overflow classification and retry fallback run in core before extension hooks.
+
+### Expected merge conflict zones
+
+- `packages/ai/src/utils/overflow.ts` after `getOverflowPatterns()`.
 
 # AI Source Changes
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Treat large Cursor 0-token resource_exhausted as overflow so the session compacts before rotating or falling back.
+
 # AI Source Changes
 
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,4 +1,4 @@
-## Unreleased - Cursor 0-token RE overflow without estimate gate
+## 2026-08-20 - Cursor 0-token RE overflow without estimate gate
 
 ### What changed
 

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -197,19 +197,53 @@ export function getOverflowPatterns(): RegExp[] {
 	return [...OVERFLOW_PATTERNS];
 }
 
-const CURSOR_PAYLOAD_RE_MIN_ESTIMATE = 50_000;
+function cursorZeroTokenCount(message: {
+	usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number };
+}): number {
+	const usage = message.usage;
+	if (!usage) return 0;
+	return (
+		usage.totalTokens ||
+		(usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0)
+	);
+}
 
 export function isCursorPayloadResourceExhausted(
 	message: { stopReason?: string; errorMessage?: string; usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number } },
-	estimateTokens: number,
+	_estimateTokens: number,
 ): boolean {
 	if (message.stopReason !== "error" || !/resource.?exhausted/i.test(message.errorMessage || "")) {
 		return false;
 	}
-	const usage = message.usage;
-	const tokens = usage
-		? (usage.totalTokens || (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0))
-		: 0;
-	if (tokens > 0) return false;
-	return (estimateTokens || 0) >= CURSOR_PAYLOAD_RE_MIN_ESTIMATE;
+	return !(cursorZeroTokenCount(message) > 0);
+}
+
+export function isCursorZeroTokenResourceExhausted(message: {
+	stopReason?: string;
+	errorMessage?: string;
+	usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number };
+}): boolean {
+	if (message.stopReason !== "error" || !/resource.?exhausted/i.test(message.errorMessage || "")) {
+		return false;
+	}
+	return !(cursorZeroTokenCount(message) > 0);
+}
+
+export function shouldSkipProviderFallbackForCursorZeroRe(options: { sameModelRemint?: boolean } | undefined): boolean {
+	return options?.sameModelRemint === true;
+}
+
+export function shouldRetryOverflowWithoutCompact(compacted: boolean, errorMessage: string): boolean {
+	if (compacted) return false;
+	return /Nothing to compact/i.test(errorMessage || "");
+}
+
+export function cursorOverflowCompactionSettings<T extends { keepRecentTokens?: number; restorationEnabled?: boolean }>(
+	settings: T,
+	provider: string | undefined,
+	reason: string | undefined,
+): T {
+	if (reason !== "overflow") return settings;
+	if (provider !== "cursor" && provider !== "cursor-cli-oauth") return settings;
+	return { ...settings, keepRecentTokens: 0, restorationEnabled: false };
 }

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -196,3 +196,20 @@ export function isRecoverableLength(message: AssistantMessage, desiredMaxOutput:
 export function getOverflowPatterns(): RegExp[] {
 	return [...OVERFLOW_PATTERNS];
 }
+
+const CURSOR_PAYLOAD_RE_MIN_ESTIMATE = 50_000;
+
+export function isCursorPayloadResourceExhausted(
+	message: { stopReason?: string; errorMessage?: string; usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number } },
+	estimateTokens: number,
+): boolean {
+	if (message.stopReason !== "error" || !/resource.?exhausted/i.test(message.errorMessage || "")) {
+		return false;
+	}
+	const usage = message.usage;
+	const tokens = usage
+		? (usage.totalTokens || (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0))
+		: 0;
+	if (tokens > 0) return false;
+	return (estimateTokens || 0) >= CURSOR_PAYLOAD_RE_MIN_ESTIMATE;
+}

--- a/packages/ai/test/cursor-payload-resource-exhausted.test.ts
+++ b/packages/ai/test/cursor-payload-resource-exhausted.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { isContextOverflow, isCursorPayloadResourceExhausted } from "../src/utils/overflow.ts";
+
+const zeroRe = {
+	stopReason: "error" as const,
+	errorMessage: "Connect error resource_exhausted: Error",
+	usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+};
+
+describe("isCursorPayloadResourceExhausted", () => {
+	it("treats large 0-token Cursor RE as payload overflow", () => {
+		expect(isContextOverflow(zeroRe, 1_000_000)).toBe(false);
+		expect(isCursorPayloadResourceExhausted(zeroRe, 150_000)).toBe(true);
+		expect(isCursorPayloadResourceExhausted(zeroRe, 1_000)).toBe(false);
+	});
+});

--- a/packages/ai/test/cursor-payload-resource-exhausted.test.ts
+++ b/packages/ai/test/cursor-payload-resource-exhausted.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isContextOverflow, isCursorPayloadResourceExhausted } from "../src/utils/overflow.ts";
+import {
+	cursorOverflowCompactionSettings,
+	isContextOverflow,
+	isCursorPayloadResourceExhausted,
+	isCursorZeroTokenResourceExhausted,
+	shouldSkipProviderFallbackForCursorZeroRe,
+} from "../src/utils/overflow.ts";
 
 const zeroRe = {
 	stopReason: "error" as const,
@@ -8,9 +14,15 @@ const zeroRe = {
 };
 
 describe("isCursorPayloadResourceExhausted", () => {
-	it("treats large 0-token Cursor RE as payload overflow", () => {
+	it("treats 0-token Cursor RE as payload overflow even when estimate is zeroed", () => {
 		expect(isContextOverflow(zeroRe, 1_000_000)).toBe(false);
 		expect(isCursorPayloadResourceExhausted(zeroRe, 150_000)).toBe(true);
-		expect(isCursorPayloadResourceExhausted(zeroRe, 1_000)).toBe(false);
+		expect(isCursorPayloadResourceExhausted(zeroRe, 0)).toBe(true);
+		expect(isCursorZeroTokenResourceExhausted(zeroRe)).toBe(true);
+		expect(shouldSkipProviderFallbackForCursorZeroRe({ sameModelRemint: true })).toBe(true);
+		expect(
+			cursorOverflowCompactionSettings({ keepRecentTokens: 20_000, restorationEnabled: true }, "cursor", "overflow")
+			.keepRecentTokens,
+		).toBe(0);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Cursor 0-token `resource_exhausted` retries the same model after remint/compact instead of falling back to another provider, and too-small overflow compact now drops to the last user turn.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Unreleased - Cursor 0-token RE stays on the same model and shrinks
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: 0-token Cursor `resource_exhausted` retries with `sameModelRemint` instead of 429/k3 fallback; overflow compact uses Cursor keep-recent-0 settings; too-small compact truncates to the last user turn.
+
+### Why
+
+- `resource.?exhausted` was classified as a 429 transient fallback, and overflow compact that saved <1% still retried the same Cursor payload.
+
+### Why an extension could not handle it
+
+- Retry fallback and pre-prompt compaction are core AgentSession admission paths.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/agent-session.ts` `_handleRetryableError`, `_executeCompaction`, `_isHardErrorFallbackEligible`.
+
 ## Entry surface and CLI coordinator re-diverge from upstream 59a71b23 (2026-08-19)
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,6 +1,6 @@
 # changes
 
-## Unreleased - Cursor 0-token RE stays on the same model and shrinks
+## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
 
 ### What changed
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -49,6 +49,7 @@ import {
 	cleanupSessionResources,
 	isClassifierRefusal,
 	isContextOverflow,
+	isCursorPayloadResourceExhausted,
 	isProviderStreamStallError,
 	isProviderTimeoutError,
 	isRecoverableLength,
@@ -1791,6 +1792,9 @@ export class AgentSession {
 			contextUsage.tokens !== null &&
 			shouldCompact(contextUsage.tokens, contextUsage.contextWindow, settings);
 		if (isContextOverflow(message, model.contextWindow) && (sameModel || currentContextNeedsCompaction)) {
+			return "overflow";
+		}
+		if (this._isCursorPayloadOverflow(message)) {
 			return "overflow";
 		}
 
@@ -5418,7 +5422,8 @@ export class AgentSession {
 		const recoverableLength = sameModel && isRecoverableLength(assistantMessage, this.model?.maxTokens ?? 0);
 		const isOverflow =
 			(isContextOverflow(assistantMessage, contextWindow) && (sameModel || currentContextNeedsCompaction)) ||
-			recoverableLength;
+			recoverableLength ||
+			this._isCursorPayloadOverflow(assistantMessage);
 		if (
 			isOverflow &&
 			assistantMessage.stopReason === "stop" &&
@@ -6653,11 +6658,17 @@ export class AgentSession {
 		return isRetryableAssistantError(message);
 	}
 
+	private _isCursorPayloadOverflow(message: AssistantMessage): boolean {
+		const estimate = estimateContextTokens(this.agent.state.messages ?? []);
+		return isCursorPayloadResourceExhausted(message, estimate.tokens ?? 0);
+	}
+
 	private _isHardErrorFallbackEligible(message: AssistantMessage): boolean {
 		return (
 			!message.errorMessage?.startsWith(TURN_RETRY_SUPPRESSION_PREFIX) &&
 			message.stopReason === "error" &&
 			!isContextOverflow(message, this.model?.contextWindow ?? 0) &&
+			!this._isCursorPayloadOverflow(message) &&
 			!isClassifierRefusal(message) &&
 			!message.content.some((content) => content.type === "toolCall") &&
 			this._retryFallback.canTryFallback()

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2097,7 +2097,7 @@ export class AgentSession {
 				!(requiredAutoCompaction === "threshold" && this._hasPendingPostCompactionUsageExemption(msg))
 			) {
 				this._retireFailedRetryAssistant(msg);
-				compactedBeforeRetry = await this._runPrePromptCompaction(msg, true, "threshold", true);
+				compactedBeforeRetry = await this._runPrePromptCompaction(msg, true, requiredAutoCompaction, true);
 				retryContinuationBlocked = !compactedBeforeRetry && !this._isCompactionDelegated();
 			}
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -47,9 +47,11 @@ import type {
 } from "@earendil-works/pi-ai/compat";
 import {
 	cleanupSessionResources,
+	cursorOverflowCompactionSettings,
 	isClassifierRefusal,
 	isContextOverflow,
 	isCursorPayloadResourceExhausted,
+	isCursorZeroTokenResourceExhausted,
 	isProviderStreamStallError,
 	isProviderTimeoutError,
 	isRecoverableLength,
@@ -57,6 +59,7 @@ import {
 	modelsAreEqual,
 	type RetryCallbacks,
 	resetApiProviders,
+	shouldRetryOverflowWithoutCompact,
 	streamSimple,
 } from "@earendil-works/pi-ai/compat";
 import { extract429RetryAfterMs, parseRetryAfterMsMarker } from "@earendil-works/pi-ai/utils/retry-hint";
@@ -864,6 +867,7 @@ export class AgentSession {
 	private readonly _compactionLifecycle = new CompactionLifecycleCoordinator();
 	private readonly _sessionWorkBarrier = new SessionWorkBarrier();
 	private _overflowRecoveryAttempted = false;
+	private _compactionSkippedTooSmall = false;
 	private _requiredCompactionAdmissionError: RequiredCompactionError | undefined;
 	// Preserve provenance across agent-core's conversion of our admission error
 	// into an assistant error message. Matching provider text alone is not proof
@@ -1702,7 +1706,9 @@ export class AgentSession {
 		const lastAssistant = this._findLastAssistantInMessages(event.messages);
 		if (
 			!lastAssistant ||
-			(!this._isRetryableError(lastAssistant) && !this._isHardErrorFallbackEligible(lastAssistant))
+			(!this._isRetryableError(lastAssistant) &&
+				!this._isHardErrorFallbackEligible(lastAssistant) &&
+				!isCursorZeroTokenResourceExhausted(lastAssistant))
 		) {
 			return;
 		}
@@ -1901,6 +1907,9 @@ export class AgentSession {
 		}
 
 		const retryableError = this._isRetryableError(lastAssistant);
+		if (isCursorZeroTokenResourceExhausted(lastAssistant)) {
+			return true;
+		}
 		if (!retryableError && this._isHardErrorFallbackEligible(lastAssistant)) {
 			return true;
 		}
@@ -2069,10 +2078,11 @@ export class AgentSession {
 			// Retry transient failures normally and eligible hard errors only through a fallback.
 			const retryableError = this._isRetryableError(msg);
 			const hardErrorFallbackEligible = this._isHardErrorFallbackEligible(msg);
+			const cursorZeroTokenRe = isCursorZeroTokenResourceExhausted(msg);
 			const retryCanAdmitProvider =
 				!userAbortSuppressedQueuedContinuation &&
 				this.settingsManager.getRetrySettings().enabled &&
-				(retryableError || hardErrorFallbackEligible);
+				(retryableError || hardErrorFallbackEligible || cursorZeroTokenRe);
 			let compactedBeforeRetry = false;
 			if (
 				retryCanAdmitProvider &&
@@ -2088,7 +2098,9 @@ export class AgentSession {
 			const retryOwnedDeferredQueue = DEFERRED_RETRY_QUEUE_OWNERS.has(this);
 			DEFERRED_RETRY_QUEUE_OWNERS.delete(this);
 			if (!retryContinuationBlocked && !userAbortSuppressedQueuedContinuation) {
-				if (retryableError) {
+				if (cursorZeroTokenRe) {
+					retryOutcome = await this._handleRetryableError(msg, { sameModelRemint: true });
+				} else if (retryableError) {
 					retryOutcome = await this._handleRetryableError(msg);
 				} else if (hardErrorFallbackEligible) {
 					retryOutcome = await this._handleRetryableError(msg, {
@@ -4906,7 +4918,11 @@ export class AgentSession {
 				throw new CompactionCancelledError();
 			}
 			const pathEntries = this.sessionManager.getBranch();
-			const settings = this.settingsManager.getCompactionSettings();
+			const settings = cursorOverflowCompactionSettings(
+				this.settingsManager.getCompactionSettings(),
+				this.model?.provider,
+				request.reason,
+			);
 
 			let compactionResult = request.precomputed;
 			let fromExtension = request.precomputed !== undefined;
@@ -5490,6 +5506,14 @@ export class AgentSession {
 				this._incrementMessageRevision();
 			}
 			if (!compacted && inlineReason && !this._isCompactionDelegated() && !this._hasSupersedingCompactionClaim()) {
+				if (this._compactionSkippedTooSmall) {
+					this._compactionSkippedTooSmall = false;
+					const provider = this.model?.provider;
+					if (provider === "cursor" || provider === "cursor-cli-oauth") {
+						this._truncateAgentMessagesToLastUserTurn();
+					}
+					return true;
+				}
 				throw new RequiredCompactionError();
 			}
 			return compacted;
@@ -5628,6 +5652,7 @@ export class AgentSession {
 				this._overflowRecoveryAttempted = false;
 			}
 			const errorMessage = error instanceof Error ? error.message : "compaction failed";
+			this._compactionSkippedTooSmall = shouldRetryOverflowWithoutCompact(false, errorMessage);
 			const aborted = isCompactionExecutionAborted(error);
 			this._emit({
 				type: "compaction_end",
@@ -5822,7 +5847,11 @@ export class AgentSession {
 
 			const preparation = prepareCompaction(
 				this.sessionManager.getBranch(),
-				this.settingsManager.getCompactionSettings(),
+				cursorOverflowCompactionSettings(
+					this.settingsManager.getCompactionSettings(),
+					this.model?.provider,
+					reason,
+				),
 				reason === "overflow",
 			);
 			if (!preparation) {
@@ -6659,8 +6688,22 @@ export class AgentSession {
 	}
 
 	private _isCursorPayloadOverflow(message: AssistantMessage): boolean {
-		const estimate = estimateContextTokens(this.agent.state.messages ?? []);
-		return isCursorPayloadResourceExhausted(message, estimate.tokens ?? 0);
+		return isCursorPayloadResourceExhausted(message, 0);
+	}
+
+	private _truncateAgentMessagesToLastUserTurn(): boolean {
+		const messages = this.agent?.state?.messages;
+		if (!Array.isArray(messages) || messages.length === 0) return false;
+		let lastUser = -1;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			if (messages[i]?.role === "user") {
+				lastUser = i;
+				break;
+			}
+		}
+		if (lastUser <= 0) return false;
+		this.agent.state.messages = messages.slice(lastUser);
+		return true;
 	}
 
 	private _isHardErrorFallbackEligible(message: AssistantMessage): boolean {
@@ -6669,6 +6712,7 @@ export class AgentSession {
 			message.stopReason === "error" &&
 			!isContextOverflow(message, this.model?.contextWindow ?? 0) &&
 			!this._isCursorPayloadOverflow(message) &&
+			!isCursorZeroTokenResourceExhausted(message) &&
 			!isClassifierRefusal(message) &&
 			!message.content.some((content) => content.type === "toolCall") &&
 			this._retryFallback.canTryFallback()
@@ -6778,7 +6822,7 @@ export class AgentSession {
 	 */
 	private async _handleRetryableError(
 		message: AssistantMessage,
-		options: { hardErrorFallback?: boolean } = {},
+		options: { hardErrorFallback?: boolean; sameModelRemint?: boolean } = {},
 	): Promise<"continued" | "blocked" | "not-handled" | "cancelled"> {
 		const settings = this.settingsManager.getRetrySettings();
 		if (!settings.enabled) {
@@ -6797,10 +6841,27 @@ export class AgentSession {
 		const errorMessage = message.errorMessage || "Unknown error";
 		const isRefusal = isClassifierRefusal(message);
 		const hardErrorFallback = options.hardErrorFallback === true;
+		const sameModelRemint = options.sameModelRemint === true;
 		let switchedFallback = false;
 		let is429TierRouted = false;
 		let hintTierDelayMs: number | undefined;
-		if (hardErrorFallback) {
+		if (sameModelRemint) {
+			this._retryAttempt++;
+			if (this._retryAttempt > settings.maxRetries) {
+				if (this._retryAttempt > 1) {
+					this._emit({
+						type: "auto_retry_end",
+						success: false,
+						attempt: this._retryAttempt,
+						finalError: message.errorMessage,
+					});
+				}
+				this._retryAttempt = 0;
+				this._resetHintTierState();
+				this._resolveRetry();
+				return "not-handled";
+			}
+		} else if (hardErrorFallback) {
 			// A non-retryable provider failure must never replay on the same model.
 			// Billing-class failures never recover on this account, so the fallback
 			// switch pins as the session model instead of reverting after the cooldown.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: 0-token Cursor `resource_exhausted` retries with `sameModelRemint` instead of 429/k3 fallback; overflow compact uses Cursor keep-recent-0 settings; too-small compact truncates to the last user turn.
+
+### Why
+
+- `resource.?exhausted` was classified as a 429 transient fallback, and overflow compact that saved <1% still retried the same Cursor payload.
+
+### Why an extension could not handle it
+
+- Retry fallback and pre-prompt compaction are core AgentSession admission paths.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/agent-session.ts` `_handleRetryableError`, `_executeCompaction`, `_isHardErrorFallbackEligible`.
+
 ## 2026-08-20 - streamRetryTimeoutMs docstring aligned with the reconciled watchdog (issue #723 lane)
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/1009-cursor-payload-re-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1009-cursor-payload-re-compaction.test.ts
@@ -1,0 +1,183 @@
+import type { StreamFn } from "@earendil-works/pi-agent-core";
+import { type AssistantMessage, type AssistantMessageEvent, fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { estimateContextTokens } from "../../../src/core/compaction/index.ts";
+import compactionExtension from "../../../src/core/extensions/builtin/compaction/index.ts";
+import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import type { CompactionReason } from "../../../src/core/extensions/types.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const CURSOR_PAYLOAD_RE_MIN_ESTIMATE = 50_000;
+const ZERO_TOKEN_RE = "Connect error resource_exhausted: Error";
+const PRIMARY = "cursor/composer";
+const FALLBACK = "cursor/k3";
+
+/** Prose-like payload so the chars/4 estimate stays >= 50k without the 4x base64-run weight. */
+const LARGE_TRANSCRIPT = Array.from({ length: 12_000 }, (_, index) => `turn-${index} context payload`).join(" ");
+
+function zeroUsage(): AssistantMessage["usage"] {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function isResourceExhausted(message: { errorMessage?: string } | undefined): boolean {
+	return /resource.?exhausted/i.test(message?.errorMessage ?? "");
+}
+
+function zeroUsageIfResourceExhausted(message: AssistantMessage): AssistantMessage {
+	if (!isResourceExhausted(message)) return message;
+	return { ...message, usage: zeroUsage() };
+}
+
+function zeroUsageEvent(event: AssistantMessageEvent): AssistantMessageEvent {
+	if (event.type === "error" && isResourceExhausted(event.error)) {
+		return { ...event, error: zeroUsageIfResourceExhausted(event.error) };
+	}
+	if (event.type === "done" && isResourceExhausted(event.message)) {
+		return { ...event, message: zeroUsageIfResourceExhausted(event.message) };
+	}
+	if ("partial" in event && event.partial && isResourceExhausted(event.partial)) {
+		return { ...event, partial: zeroUsageIfResourceExhausted(event.partial) };
+	}
+	return event;
+}
+
+/**
+ * Faux streams stamp estimated prompt usage onto every terminal message.
+ * Issue #1009 is a 0-token Cursor RE, so strip that estimate after the faux provider returns.
+ */
+function forceZeroTokenResourceExhausted(streamFn: StreamFn): StreamFn {
+	return async (model, context, options) => {
+		const stream = await streamFn(model, context, options);
+		const originalResult = stream.result.bind(stream);
+		const originalIterator = stream[Symbol.asyncIterator].bind(stream);
+		stream.result = async () => zeroUsageIfResourceExhausted(await originalResult());
+		stream[Symbol.asyncIterator] = () => {
+			const iterator = originalIterator();
+			return {
+				async next() {
+					const result = await iterator.next();
+					if (result.done) return result;
+					return { done: false, value: zeroUsageEvent(result.value) };
+				},
+			};
+		};
+		return stream;
+	};
+}
+
+function seedLargeCursorTranscript(harness: Harness): void {
+	const now = Date.now();
+	const model = harness.getModel();
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: LARGE_TRANSCRIPT }],
+		timestamp: now - 4_000,
+	});
+	harness.sessionManager.appendMessage({
+		...fauxAssistantMessage("prior turn", { timestamp: now - 3_000 }),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+	});
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "keep going" }],
+		timestamp: now - 2_000,
+	});
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+}
+
+describe("issue #1009: Cursor 0-token RE still overflow-compacts under idle guards", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("reaches overflow auto-compaction for a large Cursor 0-token RE without falling back", async () => {
+		const compactReasons: CompactionReason[] = [];
+		const idleAtCompactionStart: boolean[] = [];
+		const harness = await createHarness({
+			provider: "cursor",
+			models: [
+				{ id: "composer", contextWindow: 200_000, maxTokens: 16_384 },
+				{ id: "k3", contextWindow: 200_000, maxTokens: 16_384 },
+			],
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 16_384 },
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					fallbackChains: { [PRIMARY]: [FALLBACK] },
+				},
+			},
+			extensionFactories: [
+				compactionExtension,
+				(pi: ExtensionAPI) => {
+					pi.on("session_before_compact", (event) => {
+						compactReasons.push(event.reason);
+						return {
+							compaction: {
+								summary: "overflow recovery summary",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		expect(harness.getModel().provider).toBe("cursor");
+		harness.agent.streamFunction = forceZeroTokenResourceExhausted(harness.agent.streamFunction);
+		seedLargeCursorTranscript(harness);
+		expect(estimateContextTokens(harness.session.agent.state.messages).tokens).toBeGreaterThanOrEqual(
+			CURSOR_PAYLOAD_RE_MIN_ESTIMATE,
+		);
+
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_start") {
+				idleAtCompactionStart.push(harness.session.isIdle);
+			}
+		});
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: ZERO_TOKEN_RE }),
+			fauxAssistantMessage("compact summary"),
+			fauxAssistantMessage("compact summary"),
+			fauxAssistantMessage("recovered after overflow compact"),
+			fauxAssistantMessage("recovered after overflow compact"),
+		]);
+
+		await harness.session.prompt("continue the large session");
+
+		const overflowStarts = harness.eventsOfType("compaction_start").filter((event) => event.reason === "overflow");
+		const zeroTokenRe = harness
+			.eventsOfType("message_end")
+			.find(
+				(event) =>
+					event.message.role === "assistant" &&
+					/resource.?exhausted/i.test("errorMessage" in event.message ? (event.message.errorMessage ?? "") : ""),
+			);
+
+		expect(zeroTokenRe?.message).toMatchObject({
+			stopReason: "error",
+			usage: expect.objectContaining({ input: 0, output: 0, totalTokens: 0 }),
+		});
+		expect(compactReasons).toContain("overflow");
+		expect(overflowStarts.length).toBeGreaterThan(0);
+		expect(idleAtCompactionStart).toContain(false);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.faux.getCallLog().every((call) => call.modelId === "composer")).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #1009

0-token `resource_exhausted` on a large Cursor session is payload size. Treat it as overflow (estimate >= 50k) instead of hard-error fallback to k3.

Conflict zone: `overflow.ts`, `agent-session.ts` overflow/hard-error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats Cursor 0-token resource_exhausted as overflow and compacts before any provider fallback, then retries on the same model. Previously we treated it as transient/hard error and sometimes fell back to k3 or resent the same oversized payload; now we force a shrink and avoid provider rotation.

- `packages/ai/src/utils/overflow.ts`: adds zero‑token Cursor RE classifiers; removes the local‑estimate gate; forces Cursor overflow compaction to `keepRecentTokens: 0` with restoration disabled via `cursorOverflowCompactionSettings`; adds `shouldRetryOverflowWithoutCompact` to handle “Nothing to compact.”
- `packages/coding-agent/src/core/agent-session.ts`: detects 0‑token Cursor RE as overflow; propagates `requiredAutoCompaction` into pre‑retry compaction; uses Cursor compaction settings; retries with `sameModelRemint` and skips provider fallback; truncates to the last user turn when compaction is too small; excludes these errors from hard‑error fallback eligibility.
- Tests: adds `packages/ai/test/cursor-payload-resource-exhausted.test.ts` and `packages/coding-agent/test/suite/regressions/1009-cursor-payload-re-compaction.test.ts`.
- No migration required; behavior change is limited to Cursor sessions with 0‑token resource_exhausted.

<sup>Written for commit 403d5907bf23617fdaf9973a3e330fdae60f9312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

