### PR TITLE
fix(agent): continue when stop still has toolCalls

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Cursor often ends a turn as `stop` while the assistant message still contains toolCall blocks. Those turns now continue as `toolUse` so pending tools run instead of being dropped ([#1016](https://github.com/code-yeongyu/senpi/pull/1016)).
 - Cursor exec handler factories now receive the owning run's abort signal instead of the per-request
   idle-timeout controller, so native Cursor exec tool calls pass the run-ownership check again instead
   of failing every call with `Tool execution has no active run`.

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -17,6 +17,7 @@ import {
 import {
 	createTerminalFailureAssistantMessage,
 	normalizeTerminalAssistantMessage,
+	promoteStopWithPendingToolCalls,
 	shouldTerminateAssistantTurn,
 } from "./assistant-terminal-state.ts";
 import { getDefaultStreamFn, withEmptyAssistantRecovery } from "./stream-fn.ts";
@@ -250,7 +251,7 @@ async function runLoop(
 					}
 				: config;
 			const streamIdleTimeoutMs = isInitialProviderRequest ? config.timeoutMs : requestConfig.timeoutMs;
-			const { message, providerToolResults } = await streamAssistantResponse(
+			const streamed = await streamAssistantResponse(
 				currentContext,
 				requestConfig,
 				signal,
@@ -258,6 +259,8 @@ async function runLoop(
 				withEmptyAssistantRecovery(requestConfig.model, streamFunction),
 				streamIdleTimeoutMs,
 			);
+			const message = promoteStopWithPendingToolCalls(streamed.message);
+			const providerToolResults = streamed.providerToolResults;
 			newMessages.push(message);
 
 			// Provider-resolved (Cursor exec-channel) tool results pair with
@@ -290,6 +293,9 @@ async function runLoop(
 
 			hasMoreToolCalls = false;
 			let toolBatchTerminated = false;
+			if (toolCalls.length === 0 && message.content.some((c) => c.type === "toolCall")) {
+				hasMoreToolCalls = true;
+			}
 			if (toolCalls.length > 0) {
 				// A native "length" stop means the output was cut off by the token limit,
 				// so every tool call in the message may carry truncated arguments. Text

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -293,9 +293,6 @@ async function runLoop(
 
 			hasMoreToolCalls = false;
 			let toolBatchTerminated = false;
-			if (toolCalls.length === 0 && message.content.some((c) => c.type === "toolCall")) {
-				hasMoreToolCalls = true;
-			}
 			if (toolCalls.length > 0) {
 				// A native "length" stop means the output was cut off by the token limit,
 				// so every tool call in the message may carry truncated arguments. Text

--- a/packages/agent/src/assistant-terminal-state.ts
+++ b/packages/agent/src/assistant-terminal-state.ts
@@ -12,6 +12,12 @@ const EMPTY_USAGE = {
 
 type TerminalAssistantMessageEvent = Extract<AssistantMessageEvent, { type: "done" | "error" }>;
 
+export function promoteStopWithPendingToolCalls(message: AssistantMessage): AssistantMessage {
+	if (message.stopReason !== "stop") return message;
+	if (!message.content.some((block) => block.type === "toolCall")) return message;
+	return { ...message, stopReason: "toolUse" };
+}
+
 export function shouldTerminateAssistantTurn(message: AssistantMessage): boolean {
 	return message.stopReason === "error" || message.stopReason === "aborted" || isClassifierRefusal(message);
 }

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,8 +1,24 @@
-## Unreleased
-
-- Promote assistant stopReason stop to toolUse when the message still has toolCall blocks.
-
 # Changes
+
+## 2026-08-20 - Continue when stop still has pending toolCalls
+
+### What changed
+
+- `packages/agent/src/assistant-terminal-state.ts`: `promoteStopWithPendingToolCalls` rewrites assistant `stopReason` from `stop` to `toolUse` when the message still contains `toolCall` blocks; text-only stop stays terminal.
+- `packages/agent/src/agent-loop.ts`: apply that promotion after streaming so pending (non-exec-channel) tool calls execute in the same turn and their results go back to the model. Cursor exec-resolved blocks stay filtered out of the local batch and do not re-enter the loop.
+
+### Why
+
+- Cursor often ends a turn as `stop` while toolCall blocks are still present. The loop treated that as a finished turn and dropped the pending tools (issue #1010).
+
+### Why an extension could not handle it
+
+- Stop-reason classification lives inside the agent loop after the stream returns; no extension hook sits between stream completion and tool-batch execution.
+
+### Expected merge conflict zones
+
+- `packages/agent/src/assistant-terminal-state.ts` promotion helper
+- `packages/agent/src/agent-loop.ts` success path after `streamAssistantResponse`
 
 ## 2026-08-20 - Cursor exec handlers bind to the owning run signal
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Promote assistant stopReason stop to toolUse when the message still has toolCall blocks.
+
 # Changes
 
 ## Loop and agent divergence re-established against upstream 59a71b23 (2026-08-19)

--- a/packages/agent/test/promote-stop-pending-tools.test.ts
+++ b/packages/agent/test/promote-stop-pending-tools.test.ts
@@ -1,6 +1,15 @@
-import { describe, expect, it } from "vitest";
+import {
+	type AssistantMessage,
+	createAssistantMessageEventStream,
+	type Message,
+	type Model,
+	type ToolResultMessage,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { agentLoop } from "../src/agent-loop.ts";
 import { promoteStopWithPendingToolCalls, shouldTerminateAssistantTurn } from "../src/assistant-terminal-state.ts";
-import type { AssistantMessage } from "@earendil-works/pi-ai";
+import type { AgentContext, AgentLoopConfig, AgentTool } from "../src/types.ts";
 
 function msg(stopReason: AssistantMessage["stopReason"], content: AssistantMessage["content"]): AssistantMessage {
 	return {
@@ -10,7 +19,14 @@ function msg(stopReason: AssistantMessage["stopReason"], content: AssistantMessa
 		api: "cursor-agent",
 		provider: "cursor",
 		model: "claude-fable-5-medium",
-		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
 		timestamp: 0,
 	} as AssistantMessage;
 }
@@ -28,7 +44,80 @@ describe("promoteStopWithPendingToolCalls", () => {
 	});
 
 	it("leaves text-only stop alone", () => {
-		const next = promoteStopWithPendingToolCalls(msg("stop", [{ type: "text", text: "done" }] as AssistantMessage["content"]));
+		const next = promoteStopWithPendingToolCalls(
+			msg("stop", [{ type: "text", text: "done" }] as AssistantMessage["content"]),
+		);
 		expect(next.stopReason).toBe("stop");
+	});
+});
+
+function model(): Model<"cursor-agent"> {
+	return {
+		id: "mock-cursor",
+		name: "mock-cursor",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl: "https://example.invalid",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 8192,
+		maxTokens: 2048,
+	};
+}
+
+const ToolParameters = Type.Object({ command: Type.String() });
+
+function bashTool(execute: (params: unknown) => void): AgentTool<typeof ToolParameters> {
+	return {
+		name: "bash",
+		label: "bash",
+		description: "Run a command",
+		parameters: ToolParameters,
+		execute: async (_id, params) => {
+			execute(params);
+			return { content: [{ type: "text", text: "ran" }], details: {} };
+		},
+	};
+}
+
+describe("agent loop continues stop with pending toolCalls", () => {
+	it("executes unresolved toolCalls when the provider ends as stop", async () => {
+		const execute = vi.fn();
+		const context: AgentContext = { systemPrompt: "", messages: [], tools: [bashTool(execute)] };
+		const config: AgentLoopConfig = {
+			model: model(),
+			convertToLlm: (messages) => messages.filter((message): message is Message => "role" in message),
+		};
+
+		let request = 0;
+		const stream = agentLoop([{ role: "user", content: "run it", timestamp: 0 }], context, config, undefined, () => {
+			const response = createAssistantMessageEventStream();
+			if (request++ === 0) {
+				const message = msg("stop", [
+					{ type: "toolCall", id: "local-call-1", name: "bash", arguments: { command: "echo local" } },
+				] as AssistantMessage["content"]);
+				queueMicrotask(() => {
+					response.push({ type: "done", reason: "stop", message });
+					response.end();
+				});
+			} else {
+				const message = msg("stop", [{ type: "text", text: "done" }]);
+				queueMicrotask(() => {
+					response.push({ type: "done", reason: "stop", message });
+					response.end();
+				});
+			}
+			return response;
+		});
+		for await (const _event of stream) {
+			// consume
+		}
+		const messages = await stream.result();
+
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(execute).toHaveBeenCalledWith({ command: "echo local" });
+		expect(request).toBe(2);
+		expect(messages.filter((message): message is ToolResultMessage => message.role === "toolResult")).toHaveLength(1);
 	});
 });

--- a/packages/agent/test/promote-stop-pending-tools.test.ts
+++ b/packages/agent/test/promote-stop-pending-tools.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { promoteStopWithPendingToolCalls, shouldTerminateAssistantTurn } from "../src/assistant-terminal-state.ts";
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+
+function msg(stopReason: AssistantMessage["stopReason"], content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		stopReason,
+		content,
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "claude-fable-5-medium",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+		timestamp: 0,
+	} as AssistantMessage;
+}
+
+describe("promoteStopWithPendingToolCalls", () => {
+	it("promotes stop with toolCalls to toolUse", () => {
+		const next = promoteStopWithPendingToolCalls(
+			msg("stop", [
+				{ type: "text", text: "ok" },
+				{ type: "toolCall", id: "1", name: "eval", arguments: {} },
+			] as AssistantMessage["content"]),
+		);
+		expect(next.stopReason).toBe("toolUse");
+		expect(shouldTerminateAssistantTurn(next)).toBe(false);
+	});
+
+	it("leaves text-only stop alone", () => {
+		const next = promoteStopWithPendingToolCalls(msg("stop", [{ type: "text", text: "done" }] as AssistantMessage["content"]));
+		expect(next.stopReason).toBe("stop");
+	});
+});


### PR DESCRIPTION
Fixes #1010.

Closes #1006

Cursor often ends as `stop` while toolCalls are present. Promote that to `toolUse` so the loop sends results back. Text-only stop stays terminal.

Conflict zone: `assistant-terminal-state.ts`, `agent-loop.ts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Continues the agent loop when a provider ends a turn as stop but the assistant message still contains toolCall blocks. Previously these turns terminated and dropped pending tool calls; now stop is promoted to toolUse so tools run and results return to the model. Text‑only stop remains terminal.

- Add `promoteStopWithPendingToolCalls` and apply it after streaming in the agent loop.
- Do not re‑enter the loop when all toolCalls are already exec‑channel resolved; only unresolved toolCalls trigger execution.
- Termination on error/aborted unchanged; no public API changes.
- Tests added for promotion and loop behavior; changelog and `changes.md` updated.

<sup>Written for commit b40399bffd80f82417a0232fc048c472f9c29db7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

