### PR TITLE
fix(cursor): keep usable task args and draw late cards

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Cursor MCP `task` complete no longer overwrites streamed arguments with `{}`; the last usable task args are kept (#1011).
 - Cursor conversation-id rotation now persists under the agent directory (`CODING_AGENT_DIR` or `~/.senpi/agent`) instead of `$HOME/cursor-conversation-ids.json`, so a reminted wire id survives TUI restart.
 - Cursor 0-token `resource_exhausted` surfaces on the first failure of a `stream()` call so the session layer can compact before any conversation-id rotation; rotation and same-stream retry apply only to later attempts, and the poisoned-conversation error surfaces once the 3-rotation cap is reached.
 - Cursor 0-token `resource_exhausted` is treated as overflow without a local-estimate floor, and Cursor overflow compaction keeps no recent-token tail so the retry payload actually shrinks.

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -21,6 +21,7 @@ import * as http2 from "node:http2";
 import { create, fromBinary, fromJson, type JsonValue as PbJsonValue, toBinary, toJson } from "@bufbuild/protobuf";
 import { ValueSchema } from "@bufbuild/protobuf/wkt";
 import { calculateCost } from "../models.ts";
+import { keepUsableCursorTaskArgs } from "./cursor-task-args.ts";
 import type {
 	Api,
 	AssistantMessage,
@@ -3318,6 +3319,7 @@ export function processInteractionUpdate(
 			const toolCall = update.message.value.toolCall;
 			if (settled[kStreamingBlockKind] === "mcp") {
 				// Authoritative full parse of the accumulated argument buffer.
+				const previousArgs = settled.arguments;
 				const partial = settled[kStreamingPartialJson];
 				if (partial !== undefined) {
 					settled.arguments = parseStreamingJson(partial);
@@ -3327,6 +3329,9 @@ export function processInteractionUpdate(
 					settled.arguments as Record<string, unknown> | undefined,
 					decodedArgs,
 				);
+				if (settled.name === "task") {
+					settled.arguments = keepUsableCursorTaskArgs(previousArgs, settled.arguments);
+				}
 			} else if (settled[kStreamingBlockKind] === "connect-scm") {
 				// The authoritative outcome arrives only here. Late args are merged
 				// too — a start frame may announce the call before the target

--- a/packages/ai/src/api/cursor-task-args.ts
+++ b/packages/ai/src/api/cursor-task-args.ts
@@ -1,0 +1,16 @@
+export function isUsableCursorTaskArgs(args: unknown): args is Record<string, unknown> {
+	if (!args || typeof args !== "object" || Array.isArray(args)) return false;
+	const rec = args as Record<string, unknown>;
+	return Boolean(
+		rec.category ||
+			rec.subagent_type ||
+			(typeof rec.prompt === "string" && rec.prompt.trim()) ||
+			(Array.isArray(rec.tasks) && rec.tasks.length > 0),
+	);
+}
+
+export function keepUsableCursorTaskArgs<T>(previous: T, next: T): T {
+	if (isUsableCursorTaskArgs(next)) return next;
+	if (isUsableCursorTaskArgs(previous)) return previous;
+	return next;
+}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Keep usable Cursor task tool arguments when the complete frame parses as empty.
+
 # AI Source Changes
 
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin

--- a/packages/ai/test/cursor-task-args.test.ts
+++ b/packages/ai/test/cursor-task-args.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { isUsableCursorTaskArgs, keepUsableCursorTaskArgs } from "../src/api/cursor-task-args.ts";
+
+describe("keepUsableCursorTaskArgs", () => {
+	it("rejects empty objects", () => {
+		expect(isUsableCursorTaskArgs({})).toBe(false);
+	});
+
+	it("keeps previous usable task args when the complete frame is empty", () => {
+		const prev = { category: "deep", prompt: "Gap analysis", task_summary: "Gap analysis" };
+		expect(keepUsableCursorTaskArgs(prev, {})).toEqual(prev);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Late Cursor `tool_execution_end` events now create a TUI tool card when none is pending, so a result is not rendered without a card (#1011).
 - Session title generation now uses the session model's summarization auth instead of remapped compaction auth, so an explicit compaction model no longer produces `unauthenticated` Cursor title calls (#980).
 - Cursor 0-token `resource_exhausted` retries the same model after remint/compact instead of falling back to another provider, and too-small overflow compact now drops to the last user turn.
 - Cursor native `todo`/`updateTodos` calls now persist as `senpi.todo-state` even when the server resolves them without a local `op`, so the `/todo` widget no longer stays empty after a successful native todo update (#991).

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-20 - Late tool_execution_end still draws a TUI card
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: on `tool_execution_end`, create a tool execution card when `pendingTools` misses the id, then reveal and update the result.
+
+### Why
+
+- Cursor can emit `tool_execution_end` without a matching start card, so the result never appeared in the TUI.
+
+### Why an extension could not handle it
+
+- Tool-execution cards are constructed inside InteractiveMode from session events; no extension hook sits between `tool_execution_end` and the chat container.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` `tool_execution_end` case.
+
 ## Large-session retry indicator cadence (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4331,13 +4331,17 @@ export class InteractiveMode {
 			case "tool_execution_end": {
 				this.handleToolExecutionEnd(event);
 				this.toolArgsReveal.finish(event.toolCallId);
-				const component = this.pendingTools.get(event.toolCallId);
-				if (component) {
-					this.toolResultReveal.finish(event.toolCallId);
-					component.updateResult({ ...event.result, isError: event.isError });
-					this.pendingTools.delete(event.toolCallId);
-					this.ui.requestRender();
+				let component = this.pendingTools.get(event.toolCallId);
+				if (!component) {
+					component = this.createToolExecutionComponent(event.toolName, event.toolCallId, event.args ?? {});
+					component.setExpanded(this.toolOutputExpanded);
+					this.chatContainer.addChild(component);
+					this.pendingTools.set(event.toolCallId, component);
 				}
+				this.toolResultReveal.finish(event.toolCallId);
+				component.updateResult({ ...event.result, isError: event.isError });
+				this.pendingTools.delete(event.toolCallId);
+				this.ui.requestRender();
 				break;
 			}
 


### PR DESCRIPTION
Closes #1011

Cursor MCP complete can parse `{}` after a usable stream. Keep the last usable task arguments, and create a TUI card on `tool_execution_end` if none is pending.

Conflict zone: `cursor-agent.ts` MCP complete, `interactive-mode.ts` tool_execution_end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Cursor MCP `task` complete from wiping streamed task arguments with {} and always draws a TUI card for late `tool_execution_end`. Previously, complete could overwrite usable args and late tool results could render without a card; now we keep the last usable task args and create a card if none is pending.

- `packages/ai/src/api/cursor-agent.ts`: On MCP complete for `task`, applies `keepUsableCursorTaskArgs(previous, current)` to retain previously streamed args if the final parse is empty/invalid. Other tools unchanged.
- `packages/ai/src/api/cursor-task-args.ts`: Defines “usable” args as having `category`, `subagent_type`, a non-empty `prompt`, or a non-empty `tasks` array.
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: On `tool_execution_end`, creates a tool execution card when none is pending, then reveals and updates the result.
- Tests added; no migration actions.

<sup>Written for commit a0ded32de01f6c20e24388da7bfe68025c0af5cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

