### PR TITLE
fix(ai): send Cursor catalog variant ids for thinking selections

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Native Cursor Kimi K3 turns with an explicit thinking level now send the accepted catalog variant id
+  (`kimi-k3-low`, `kimi-k3-high`, or `kimi-k3-max`) instead of the bare `kimi-k3` id that Cursor rejected
+  with `not_found`; the Cursor CLI lane keeps its bracket-form model selection.
+
 - Native Cursor turns now report real usage: the billed token split on `turnEnded`
   (input/output/cache read/cache write, taken from the production cursor-agent schema) lands on
   `usage`, and conversation checkpoints feed the server's live `usedTokens` into the in-flight

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,40 @@
 # AI Source Changes
 
+## 2026-08-19 - Native Cursor thinking selections send catalog variant ids
+
+### What changed
+
+- `packages/ai/src/cursor/model-capabilities.ts`: `resolveCursorCatalogVariantId`
+  maps a capability + selected level onto a GetUsableModels / CLI catalog row
+  (`kimi-k3-high`, `claude-fable-5-thinking-low`, `claude-4.6-opus-max-thinking`,
+  `gpt-5.3-codex-xhigh`), looking the candidate up in the existing alias table.
+- `packages/ai/src/cursor/selection-descriptor.ts`: the parameters-encoding
+  branch now puts that catalog id on `modelId` (native Run RPC) and keeps the
+  bare capability id on `cliModelId` so `renderCursorCliModelString` still emits
+  `kimi-k3[reasoning=high]`. Cursor's Connect RPC rejects the bare capability id
+  as `not_found`; the official CLI still accepts the bracket form and resolves
+  it internally. Thinking level is carried by the variant suffix — live probes
+  showed the `reasoning` parameter is ignored when the id already names a level.
+
+### Why
+
+- Selecting any thinking level on `cursor/kimi-k3` (including `:off`) produced
+  `Connect error not_found`. The no-selection path already sent the real
+  representative variant (`kimi-k3-low`) and worked; the explicit-selection path
+  sent `modelId: "kimi-k3"` plus parameters, which is not a catalog model.
+
+### Why an extension could not handle it
+
+- The native RequestedModel encoding lives inside `pi-ai`'s cursor-agent
+  transport. Extensions never see the protobuf `modelId` / parameters split.
+
+### Expected merge conflict zones
+
+- `packages/ai/src/cursor/selection-descriptor.ts` parameters-encoding return
+  (`modelId: bareBase`).
+- `packages/ai/src/cursor/model-capabilities.ts` alias helpers.
+- `packages/ai/test/cursor-reasoning-params.test.ts` pinned `modelId` values.
+
 ## 2026-08-19 - Native Cursor billed usage, live checkpoint context size, and token-gated resource_exhausted overflow
 
 ### What changed

--- a/packages/ai/src/cursor/model-capabilities.ts
+++ b/packages/ai/src/cursor/model-capabilities.ts
@@ -252,6 +252,41 @@ export function getCursorVariantAlias(originalId: string): CursorVariantAlias | 
 	return ALIASES[originalId];
 }
 
+/**
+ * Map a capability + selected level onto a GetUsableModels / CLI catalog variant
+ * id. Cursor's native Run RPC rejects the bare capability id (`kimi-k3`) as
+ * `not_found`; only the suffixed catalog rows (`kimi-k3-high`) are accepted.
+ * The official CLI still accepts `kimi-k3[reasoning=high]` and resolves it
+ * internally — that path is `cliModelId`, not this function.
+ */
+export function resolveCursorCatalogVariantId(
+	capabilityId: string,
+	specValue: string,
+	level: ModelThinkingLevel,
+	thinkingMode: boolean | undefined,
+): string | undefined {
+	const candidates: string[] = [];
+	if (thinkingMode === true) {
+		candidates.push(`${capabilityId}-thinking-${specValue}`);
+		candidates.push(`${capabilityId}-${specValue}-thinking`);
+	}
+	candidates.push(`${capabilityId}-${specValue}`);
+	if (level !== specValue && level !== "off") {
+		candidates.push(`${capabilityId}-${level}`);
+	}
+	if (specValue === "extra-high" || level === "xhigh") {
+		candidates.push(`${capabilityId}-xhigh`);
+	}
+	if (level === "off") {
+		candidates.push(`${capabilityId}-none`);
+	}
+	for (const candidate of candidates) {
+		const alias = getCursorVariantAlias(candidate);
+		if (alias !== undefined) return alias.legacyVariantId;
+	}
+	return undefined;
+}
+
 /** Resolve any known variant id to its selectable base identity; unknown ids return undefined. */
 export function getCursorBaseIdForVariant(originalId: string): string | undefined {
 	const alias = ALIASES[originalId];

--- a/packages/ai/src/cursor/selection-descriptor.ts
+++ b/packages/ai/src/cursor/selection-descriptor.ts
@@ -1,9 +1,16 @@
 import type { CursorAgentCompat, Model } from "../model.ts";
 import type { ModelThinkingLevel, ThinkingSelection } from "../types.ts";
-import { CURSOR_MODEL_CAPABILITIES, type CursorParameterId, getCursorVariantAlias } from "./model-capabilities.ts";
+import {
+	CURSOR_MODEL_CAPABILITIES,
+	type CursorParameterId,
+	getCursorVariantAlias,
+	resolveCursorCatalogVariantId,
+} from "./model-capabilities.ts";
 
 export interface CursorResolvedSelection {
 	readonly modelId: string;
+	/** Bare capability id for the CLI `--model` bracket form. Native RPC uses `modelId`. */
+	readonly cliModelId?: string;
 	readonly parameters: readonly { readonly id: CursorParameterId; readonly value: string }[];
 }
 
@@ -49,10 +56,11 @@ function buildParameters(
 
 /**
  * Resolve a Cursor model + thinking selection to its wire descriptor: the exact
- * model id plus ordered parameters. Both Cursor transports consume this; the
- * native lane renders parameters into protobuf, the CLI lane renders a model
- * string. Absent/unsupported selections return the representative or upstream
- * id with zero parameters.
+ * native catalog variant id plus ordered parameters. The native lane sends
+ * `modelId` on the protobuf Run RPC; the CLI lane renders `cliModelId ?? modelId`
+ * as a `--model` string (bracket form still uses the bare capability id).
+ * Absent/unsupported selections return the representative or upstream id with
+ * zero parameters.
  */
 export function resolveCursorSelectionDescriptor(
 	model: Model<"cursor-agent">,
@@ -85,9 +93,15 @@ export function resolveCursorSelectionDescriptor(
 		return { modelId: suffixId, parameters: [] };
 	}
 
-	const bareBase = compat.capabilityId;
 	return {
-		modelId: bareBase,
+		modelId:
+			resolveCursorCatalogVariantId(
+				compat.capabilityId,
+				spec.value,
+				selection.level,
+				compat.thinkingMode,
+			) ?? compat.representativeVariantId,
+		cliModelId: compat.capabilityId,
 		parameters: buildParameters(compat.capabilityId, spec.value, compat.thinkingMode),
 	};
 }
@@ -98,7 +112,8 @@ export function renderCursorCliModelString(
 	selection: ThinkingSelection | undefined,
 ): string {
 	const resolved = resolveCursorSelectionDescriptor(model, selection);
-	if (resolved.parameters.length === 0) return resolved.modelId;
+	const modelId = resolved.cliModelId ?? resolved.modelId;
+	if (resolved.parameters.length === 0) return modelId;
 	const args = resolved.parameters.map((parameter) => `${parameter.id}=${parameter.value}`).join(",");
-	return `${resolved.modelId}[${args}]`;
+	return `${modelId}[${args}]`;
 }

--- a/packages/ai/test/cursor-reasoning-params.test.ts
+++ b/packages/ai/test/cursor-reasoning-params.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveCursorSelectionDescriptor } from "../src/cursor/selection-descriptor.ts";
+import {
+	renderCursorCliModelString,
+	resolveCursorSelectionDescriptor,
+} from "../src/cursor/selection-descriptor.ts";
 import type { CursorAgentCompat, Model } from "../src/model.ts";
 import type { ThinkingSelection } from "../src/types.ts";
 
@@ -43,13 +46,30 @@ describe("resolveCursorSelectionDescriptor", () => {
 			explicit("low"),
 		);
 		expect(out).toEqual({
-			modelId: "claude-fable-5",
+			modelId: "claude-fable-5-thinking-low",
+			cliModelId: "claude-fable-5",
 			parameters: [
 				{ id: "thinking", value: "true" },
 				{ id: "context", value: "1m" },
 				{ id: "effort", value: "low" },
 			],
 		});
+	});
+
+	it("renders the Claude 4.6 thinking infix after the level", () => {
+		const compat: CursorAgentCompat = {
+			cursorReasoning: {
+				capabilityId: "claude-4.6-opus",
+				thinkingMode: true,
+				representativeVariantId: "claude-4.6-opus-high-thinking",
+			},
+		};
+		const out = resolveCursorSelectionDescriptor(
+			cursorModel("claude-4.6-opus-thinking", compat),
+			explicit("max"),
+		);
+		expect(out?.modelId).toBe("claude-4.6-opus-max-thinking");
+		expect(out?.cliModelId).toBe("claude-4.6-opus");
 	});
 
 	it("fixes thinking=false for the non-thinking Claude identity", () => {
@@ -61,17 +81,22 @@ describe("resolveCursorSelectionDescriptor", () => {
 			},
 		};
 		const out = resolveCursorSelectionDescriptor(cursorModel("claude-fable-5", compat), explicit("max"));
-		expect(out?.parameters).toEqual([
-			{ id: "thinking", value: "false" },
-			{ id: "context", value: "1m" },
-			{ id: "effort", value: "max" },
-		]);
+		expect(out).toEqual({
+			modelId: "claude-fable-5-max",
+			cliModelId: "claude-fable-5",
+			parameters: [
+				{ id: "thinking", value: "false" },
+				{ id: "context", value: "1m" },
+				{ id: "effort", value: "max" },
+			],
+		});
 	});
 
 	it("renders the gpt template with context/reasoning/fast and translates xhigh to extra-high for gpt-5.5", () => {
 		const out = resolveCursorSelectionDescriptor(cursorModel("gpt-5.5", gpt55Compat), explicit("xhigh"));
 		expect(out).toEqual({
-			modelId: "gpt-5.5",
+			modelId: "gpt-5.5-extra-high",
+			cliModelId: "gpt-5.5",
 			parameters: [
 				{ id: "context", value: "1m" },
 				{ id: "reasoning", value: "extra-high" },
@@ -85,10 +110,14 @@ describe("resolveCursorSelectionDescriptor", () => {
 			cursorReasoning: { capabilityId: "gpt-5.3-codex", representativeVariantId: "gpt-5.3-codex-high" },
 		};
 		const out = resolveCursorSelectionDescriptor(cursorModel("gpt-5.3-codex", compat), explicit("xhigh"));
-		expect(out?.parameters).toEqual([
-			{ id: "reasoning", value: "extra-high" },
-			{ id: "fast", value: "false" },
-		]);
+		expect(out).toEqual({
+			modelId: "gpt-5.3-codex-xhigh",
+			cliModelId: "gpt-5.3-codex",
+			parameters: [
+				{ id: "reasoning", value: "extra-high" },
+				{ id: "fast", value: "false" },
+			],
+		});
 	});
 
 	it("renders gemini/grok/glm/kimi families", () => {
@@ -98,40 +127,60 @@ describe("resolveCursorSelectionDescriptor", () => {
 			}),
 			explicit("low"),
 		);
-		expect(gemini?.parameters).toEqual([{ id: "effort", value: "low" }]);
+		expect(gemini).toEqual({
+			modelId: "gemini-3.7-flash-low",
+			cliModelId: "gemini-3.7-flash",
+			parameters: [{ id: "effort", value: "low" }],
+		});
 		const grok = resolveCursorSelectionDescriptor(
 			cursorModel("cursor-grok-4.6", {
 				cursorReasoning: { capabilityId: "cursor-grok-4.6", representativeVariantId: "cursor-grok-4.6-medium" },
 			}),
 			explicit("xhigh"),
 		);
-		expect(grok?.parameters).toEqual([
-			{ id: "effort", value: "xhigh" },
-			{ id: "fast", value: "false" },
-		]);
+		expect(grok).toEqual({
+			modelId: "cursor-grok-4.6-xhigh",
+			cliModelId: "cursor-grok-4.6",
+			parameters: [
+				{ id: "effort", value: "xhigh" },
+				{ id: "fast", value: "false" },
+			],
+		});
 		const glm = resolveCursorSelectionDescriptor(
 			cursorModel("glm-5.2", {
 				cursorReasoning: { capabilityId: "glm-5.2", representativeVariantId: "glm-5.2-high" },
 			}),
 			explicit("max"),
 		);
-		expect(glm?.parameters).toEqual([{ id: "reasoning", value: "max" }]);
+		expect(glm).toEqual({
+			modelId: "glm-5.2-max",
+			cliModelId: "glm-5.2",
+			parameters: [{ id: "reasoning", value: "max" }],
+		});
 		const kimi = resolveCursorSelectionDescriptor(
 			cursorModel("kimi-k3", {
 				cursorReasoning: { capabilityId: "kimi-k3", representativeVariantId: "kimi-k3-high" },
 			}),
 			explicit("low"),
 		);
-		expect(kimi?.parameters).toEqual([{ id: "reasoning", value: "low" }]);
+		expect(kimi).toEqual({
+			modelId: "kimi-k3-low",
+			cliModelId: "kimi-k3",
+			parameters: [{ id: "reasoning", value: "low" }],
+		});
 	});
 
 	it("renders supported explicit off as reasoning=none", () => {
 		const out = resolveCursorSelectionDescriptor(cursorModel("gpt-5.5", gpt55Compat), explicit("off"));
-		expect(out?.parameters).toEqual([
-			{ id: "context", value: "1m" },
-			{ id: "reasoning", value: "none" },
-			{ id: "fast", value: "false" },
-		]);
+		expect(out).toEqual({
+			modelId: "gpt-5.5-none",
+			cliModelId: "gpt-5.5",
+			parameters: [
+				{ id: "context", value: "1m" },
+				{ id: "reasoning", value: "none" },
+				{ id: "fast", value: "false" },
+			],
+		});
 	});
 
 	it("emits no parameters for off on descriptors without none", () => {
@@ -199,6 +248,21 @@ describe("resolveCursorSelectionDescriptor", () => {
 			explicit("minimal"),
 		);
 		expect(out).toEqual({ modelId: "glm-5.2-high", parameters: [] });
+	});
+
+	it("keeps the CLI bracket form on the bare capability id", () => {
+		expect(
+			renderCursorCliModelString(
+				cursorModel("kimi-k3", {
+					cursorReasoning: { capabilityId: "kimi-k3", representativeVariantId: "kimi-k3-high" },
+				}),
+				explicit("high"),
+			),
+		).toBe("kimi-k3[reasoning=high]");
+		expect(
+			renderCursorCliModelString(cursorModel("claude-fable-5-thinking", fableThinkingCompat), explicit("low")),
+		).toBe("claude-fable-5[thinking=true,context=1m,effort=low]");
+		expect(renderCursorCliModelString(cursorModel("gpt-5.5", gpt55Compat), undefined)).toBe("gpt-5.5-medium");
 	});
 
 	it("does not mutate inputs and is byte-order stable across calls", () => {

--- a/packages/ai/test/cursor-run-request.test.ts
+++ b/packages/ai/test/cursor-run-request.test.ts
@@ -118,13 +118,13 @@ describe("cursor Run request reasoning rendering", () => {
 		},
 	};
 
-	it("renders an explicit selection as bare base id plus ordered parameters", async () => {
+	it("renders an explicit selection as the catalog variant id plus ordered parameters", async () => {
 		const model = buildModel("claude-fable-5-thinking", "", fableCompat, "claude-fable-5-thinking-medium");
 		const frame = await captureRunRequest(model, { thinkingSelection: { level: "low", source: "explicit" } });
 		const request = frame.message.value as {
 			requestedModel?: { modelId: string; maxMode: boolean; parameters: { id: string; value: string }[] };
 		};
-		expect(request.requestedModel?.modelId).toBe("claude-fable-5");
+		expect(request.requestedModel?.modelId).toBe("claude-fable-5-thinking-low");
 		expect(
 			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
 		).toEqual([
@@ -164,7 +164,7 @@ describe("cursor Run request reasoning rendering", () => {
 		const request = frame.message.value as {
 			requestedModel?: { modelId: string; parameters: { id: string; value: string }[] };
 		};
-		expect(request.requestedModel?.modelId).toBe("gpt-5.5");
+		expect(request.requestedModel?.modelId).toBe("gpt-5.5-none");
 		expect(
 			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
 		).toEqual([
@@ -188,6 +188,7 @@ describe("cursor Run request reasoning rendering", () => {
 		const request = frame.message.value as {
 			requestedModel?: { modelId: string; maxMode: boolean; parameters: { id: string; value: string }[] };
 		};
+		expect(request.requestedModel?.modelId).toBe("claude-fable-5-high");
 		expect(request.requestedModel?.maxMode).toBe(true);
 		expect(
 			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),

--- a/packages/ai/test/cursor-run-request.test.ts
+++ b/packages/ai/test/cursor-run-request.test.ts
@@ -134,6 +134,21 @@ describe("cursor Run request reasoning rendering", () => {
 		]);
 	});
 
+	it("renders an explicit Kimi K3 selection with the accepted native catalog id", async () => {
+		const compat: CursorAgentCompat = {
+			cursorReasoning: { capabilityId: "kimi-k3", representativeVariantId: "kimi-k3-high" },
+		};
+		const model = buildModel("kimi-k3", "", compat, "kimi-k3-high");
+		const frame = await captureRunRequest(model, { thinkingSelection: { level: "low", source: "explicit" } });
+		const request = frame.message.value as {
+			requestedModel?: { modelId: string; parameters: { id: string; value: string }[] };
+		};
+		expect(request.requestedModel?.modelId).toBe("kimi-k3-low");
+		expect(
+			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
+		).toEqual([{ id: "reasoning", value: "low" }]);
+	});
+
 	it("keeps the legacy request shape byte-exact when no selection exists", async () => {
 		const model = buildModel("gpt-5.5-medium", "");
 		const withSelection = await captureRunRequest(model, {});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 ### Fixed
 
+- Cursor Kimi K3 requests with an explicit thinking level no longer fail with `Connect error not_found`:
+  native turns now use the accepted catalog variant ids while Cursor CLI OAuth retains its bracket-form
+  model selection.
+
 - The footer's git branch keeps updating in reftable repositories on systems where `fs.watch` cannot register (descriptor limits, unsupported filesystems): the `tables.list` polling fallback is now armed even when watcher creation fails, instead of being skipped by an early return ([#970](https://github.com/code-yeongyu/senpi/pull/970)).
 - Pasting multiple images in one turn now ships every image: the second and later pastes no longer write into an orphaned payload map, markers pasted in front of existing ones renumber to stay `[Image #1]`..`[Image #k]` in reading order (so `look_at("[Image #N]")` resolves to the exact image the user sees), undo after deleting a marker restores its image along with the marker, and submitting pasted images during compaction now reports the drop instead of silently discarding them.
 


### PR DESCRIPTION
## Summary

- resolve explicit native Cursor thinking selections to accepted catalog variant ids instead of bare capability ids
- preserve Cursor CLI bracket rendering and legacy variant behavior
- add a focused native Kimi K3 Run-request regression and Unreleased changelog entries

## Verification

- focused Cursor tests: 3 files, 22 tests passed
- TypeScript build check: passed
- Senpi QA: common 9/9, RPC 4/4, mock loop 48/48, CLI smoke 8/8
- real dedicated-worktree Cursor request: `CURSOR_KIMI_WORKTREE_OK`
- real auth unchanged; temporary sandbox removed
- changelog/changes.md gate: passed
- five-agent final review gate: passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send catalog variant ids for native Cursor thinking selections to prevent not_found errors. Previously we sent the bare capability id plus parameters; now we send the accepted variant id while keeping the CLI’s bracket-form behavior.

- Resolve the catalog variant via `resolveCursorCatalogVariantId` in `packages/ai` and set it on `requestedModel.modelId` for the Run RPC; fall back to the representative variant if needed.
- Preserve the CLI path by carrying the bare capability id on `cliModelId`, so `renderCursorCliModelString` continues to emit bracket-form selections.
- Update tests to assert variant ids (e.g., `kimi-k3-low`, `claude-fable-5-thinking-low`, `gpt-5.5-none`) and verify CLI output; add changelog entries in `packages/ai` and `packages/coding-agent`.

<sup>Written for commit 89b13e3935879747e282e6033e0d8c528f9a51c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

