### PR TITLE
fix(ai): resolve explicit cursor levels to catalog suffix variant ids

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+- Explicit Cursor thinking levels no longer die with `Connect error not_found`: Cursor's Run RPC
+  rejects bare capability ids (`kimi-k3`, `claude-fable-5`, …) with `not_found`, so
+  `resolveCursorSelectionDescriptor` now prefers the catalog-guaranteed suffix variant id
+  (`kimi-k3-high`, `claude-fable-5-thinking-low`) whenever a legacy alias exists, keeping bare
+  base id + ordered parameters only as the fallback for alias-less levels (#1008).
+
 ### Removed
 
 ## [2026.8.19] - 2026-08-19

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,35 @@
 # AI Source Changes
 
+## 2026-08-20 - Cursor explicit levels prefer catalog suffix variant ids
+
+### What changed
+
+- `packages/ai/src/cursor/selection-descriptor.ts`: `resolveCursorSelectionDescriptor` now resolves an
+  explicit thinking level to the catalog-guaranteed legacy suffix alias (`kimi-k3-high`,
+  `claude-fable-5-thinking-low`, `gpt-5.3-codex-xhigh`) whenever one exists, via a new
+  `suffixAliasId` that tries the level's wire value then the level token, with thinking-infixed
+  candidates for thinking Claude identities. Bare base id + ordered parameters remains only as the
+  fallback for levels without any alias; `legacySuffixId` is subsumed.
+
+### Why
+
+- Cursor's Run RPC now rejects bare capability ids with Connect `not_found` for every family
+  (issue #1008; live probes 2026-08-20 in
+  `local-ignore/qa-evidence/20260820-cursor-bare-id-notfound/`: bare `kimi-k3`+parameters and bare
+  `claude-fable-5`+parameters both `not_found`, while `kimi-k3-high` and
+  `claude-fable-5-thinking-low` complete), so every explicit level rendered as base+parameters died
+  at turn start.
+
+### Why an extension could not handle it
+
+- The selection descriptor is core provider data consumed by both Cursor transports (protobuf
+  `RequestedModel` and the CLI model string); no extension hook sits between them.
+
+### Expected merge conflict zones
+
+- `selection-descriptor.ts` resolver body and helper block (fork-only file; upstream has no cursor
+  provider).
+
 ## 2026-08-19 - OpenAI-family adapters re-diverge from the 59a71b23 pin
 
 ### What changed

--- a/packages/ai/src/cursor/selection-descriptor.ts
+++ b/packages/ai/src/cursor/selection-descriptor.ts
@@ -1,6 +1,11 @@
 import type { CursorAgentCompat, Model } from "../model.ts";
 import type { ModelThinkingLevel, ThinkingSelection } from "../types.ts";
-import { CURSOR_MODEL_CAPABILITIES, type CursorParameterId, getCursorVariantAlias } from "./model-capabilities.ts";
+import {
+	CURSOR_MODEL_CAPABILITIES,
+	type CursorLevelSpec,
+	type CursorParameterId,
+	getCursorVariantAlias,
+} from "./model-capabilities.ts";
 
 export interface CursorResolvedSelection {
 	readonly modelId: string;
@@ -11,10 +16,33 @@ function identityCompat(model: Model<"cursor-agent">): CursorAgentCompat["cursor
 	return model.compat?.cursorReasoning;
 }
 
-function legacySuffixId(baseId: string, level: ModelThinkingLevel, value: string): string | undefined {
-	const suffix = level === "off" ? "none" : value;
-	const candidate = `${baseId}-${suffix}`;
-	return getCursorVariantAlias(candidate)?.legacyVariantId;
+type CursorReasoningIdentity = NonNullable<CursorAgentCompat["cursorReasoning"]>;
+
+/**
+ * Catalog-guaranteed suffix alias for a base + level, or undefined. Cursor Run
+ * rejects bare capability ids with Connect `not_found` (issue #1008; live
+ * probes 2026-08-20), so every resolvable level prefers the suffix variant id
+ * the `GetUsableModels` catalog actually serves. Candidates try the level's
+ * wire value first, then the level token itself (`extra-high` vs `xhigh`),
+ * with thinking-infixed forms for thinking Claude identities.
+ */
+function suffixAliasId(
+	compat: CursorReasoningIdentity,
+	level: ModelThinkingLevel,
+	spec: CursorLevelSpec,
+): string | undefined {
+	const suffixes = level === "off" ? ["none"] : spec.value === level ? [spec.value] : [spec.value, level];
+	for (const suffix of suffixes) {
+		const candidates =
+			compat.thinkingMode === true
+				? [`${compat.capabilityId}-thinking-${suffix}`, `${compat.capabilityId}-${suffix}-thinking`]
+				: [`${compat.capabilityId}-${suffix}`];
+		for (const candidate of candidates) {
+			const alias = getCursorVariantAlias(candidate);
+			if (alias) return alias.legacyVariantId;
+		}
+	}
+	return undefined;
 }
 
 function buildParameters(
@@ -79,15 +107,15 @@ export function resolveCursorSelectionDescriptor(
 		return { modelId: compat.representativeVariantId, parameters: [] };
 	}
 
+	const suffixId = suffixAliasId(compat, selection.level, spec);
+	if (suffixId !== undefined) return { modelId: suffixId, parameters: [] };
+
 	if (spec.encoding === "variant-id") {
-		const suffixId = legacySuffixId(compat.capabilityId, selection.level, spec.value);
-		if (suffixId === undefined) return { modelId: compat.representativeVariantId, parameters: [] };
-		return { modelId: suffixId, parameters: [] };
+		return { modelId: compat.representativeVariantId, parameters: [] };
 	}
 
-	const bareBase = compat.capabilityId;
 	return {
-		modelId: bareBase,
+		modelId: compat.capabilityId,
 		parameters: buildParameters(compat.capabilityId, spec.value, compat.thinkingMode),
 	};
 }

--- a/packages/ai/test/cursor-reasoning-params.test.ts
+++ b/packages/ai/test/cursor-reasoning-params.test.ts
@@ -37,22 +37,15 @@ function explicit(level: ThinkingSelection["level"]): ThinkingSelection {
 }
 
 describe("resolveCursorSelectionDescriptor", () => {
-	it("renders the anthropic template in canonical order", () => {
+	it("prefers the thinking suffix alias for anthropic explicit levels", () => {
 		const out = resolveCursorSelectionDescriptor(
 			cursorModel("claude-fable-5-thinking", fableThinkingCompat),
 			explicit("low"),
 		);
-		expect(out).toEqual({
-			modelId: "claude-fable-5",
-			parameters: [
-				{ id: "thinking", value: "true" },
-				{ id: "context", value: "1m" },
-				{ id: "effort", value: "low" },
-			],
-		});
+		expect(out).toEqual({ modelId: "claude-fable-5-thinking-low", parameters: [] });
 	});
 
-	it("fixes thinking=false for the non-thinking Claude identity", () => {
+	it("prefers the plain suffix alias for the non-thinking Claude identity", () => {
 		const compat: CursorAgentCompat = {
 			cursorReasoning: {
 				capabilityId: "claude-fable-5",
@@ -61,77 +54,77 @@ describe("resolveCursorSelectionDescriptor", () => {
 			},
 		};
 		const out = resolveCursorSelectionDescriptor(cursorModel("claude-fable-5", compat), explicit("max"));
-		expect(out?.parameters).toEqual([
-			{ id: "thinking", value: "false" },
-			{ id: "context", value: "1m" },
-			{ id: "effort", value: "max" },
-		]);
+		expect(out).toEqual({ modelId: "claude-fable-5-max", parameters: [] });
 	});
 
-	it("renders the gpt template with context/reasoning/fast and translates xhigh to extra-high for gpt-5.5", () => {
+	it("translates xhigh to the extra-high suffix alias for gpt-5.5", () => {
 		const out = resolveCursorSelectionDescriptor(cursorModel("gpt-5.5", gpt55Compat), explicit("xhigh"));
-		expect(out).toEqual({
-			modelId: "gpt-5.5",
-			parameters: [
-				{ id: "context", value: "1m" },
-				{ id: "reasoning", value: "extra-high" },
-				{ id: "fast", value: "false" },
-			],
-		});
+		expect(out).toEqual({ modelId: "gpt-5.5-extra-high", parameters: [] });
 	});
 
-	it("renders codex without a context parameter", () => {
+	it("falls back to the level-token suffix alias when the value suffix is absent (codex xhigh)", () => {
 		const compat: CursorAgentCompat = {
 			cursorReasoning: { capabilityId: "gpt-5.3-codex", representativeVariantId: "gpt-5.3-codex-high" },
 		};
 		const out = resolveCursorSelectionDescriptor(cursorModel("gpt-5.3-codex", compat), explicit("xhigh"));
-		expect(out?.parameters).toEqual([
-			{ id: "reasoning", value: "extra-high" },
-			{ id: "fast", value: "false" },
-		]);
+		expect(out).toEqual({ modelId: "gpt-5.3-codex-xhigh", parameters: [] });
 	});
 
-	it("renders gemini/grok/glm/kimi families", () => {
+	it("renders gemini/grok/glm/kimi families as catalog suffix variant ids", () => {
 		const gemini = resolveCursorSelectionDescriptor(
 			cursorModel("gemini-3.7-flash", {
 				cursorReasoning: { capabilityId: "gemini-3.7-flash", representativeVariantId: "gemini-3.7-flash-medium" },
 			}),
 			explicit("low"),
 		);
-		expect(gemini?.parameters).toEqual([{ id: "effort", value: "low" }]);
+		expect(gemini).toEqual({ modelId: "gemini-3.7-flash-low", parameters: [] });
 		const grok = resolveCursorSelectionDescriptor(
 			cursorModel("cursor-grok-4.6", {
 				cursorReasoning: { capabilityId: "cursor-grok-4.6", representativeVariantId: "cursor-grok-4.6-medium" },
 			}),
 			explicit("xhigh"),
 		);
-		expect(grok?.parameters).toEqual([
-			{ id: "effort", value: "xhigh" },
-			{ id: "fast", value: "false" },
-		]);
+		expect(grok).toEqual({ modelId: "cursor-grok-4.6-xhigh", parameters: [] });
 		const glm = resolveCursorSelectionDescriptor(
 			cursorModel("glm-5.2", {
 				cursorReasoning: { capabilityId: "glm-5.2", representativeVariantId: "glm-5.2-high" },
 			}),
 			explicit("max"),
 		);
-		expect(glm?.parameters).toEqual([{ id: "reasoning", value: "max" }]);
+		expect(glm).toEqual({ modelId: "glm-5.2-max", parameters: [] });
 		const kimi = resolveCursorSelectionDescriptor(
 			cursorModel("kimi-k3", {
 				cursorReasoning: { capabilityId: "kimi-k3", representativeVariantId: "kimi-k3-high" },
 			}),
 			explicit("low"),
 		);
-		expect(kimi?.parameters).toEqual([{ id: "reasoning", value: "low" }]);
+		expect(kimi).toEqual({ modelId: "kimi-k3-low", parameters: [] });
 	});
 
-	it("renders supported explicit off as reasoning=none", () => {
+	it("falls back to bare base id plus ordered parameters when no suffix alias exists", () => {
+		const out = resolveCursorSelectionDescriptor(
+			cursorModel("claude-opus-5", {
+				cursorReasoning: {
+					capabilityId: "claude-opus-5",
+					thinkingMode: false,
+					representativeVariantId: "claude-opus-5-medium",
+				},
+			}),
+			explicit("xhigh"),
+		);
+		expect(out).toEqual({
+			modelId: "claude-opus-5",
+			parameters: [
+				{ id: "thinking", value: "false" },
+				{ id: "context", value: "1m" },
+				{ id: "effort", value: "xhigh" },
+			],
+		});
+	});
+
+	it("renders supported explicit off as the none suffix alias", () => {
 		const out = resolveCursorSelectionDescriptor(cursorModel("gpt-5.5", gpt55Compat), explicit("off"));
-		expect(out?.parameters).toEqual([
-			{ id: "context", value: "1m" },
-			{ id: "reasoning", value: "none" },
-			{ id: "fast", value: "false" },
-		]);
+		expect(out).toEqual({ modelId: "gpt-5.5-none", parameters: [] });
 	});
 
 	it("emits no parameters for off on descriptors without none", () => {

--- a/packages/ai/test/cursor-run-request.test.ts
+++ b/packages/ai/test/cursor-run-request.test.ts
@@ -118,20 +118,14 @@ describe("cursor Run request reasoning rendering", () => {
 		},
 	};
 
-	it("renders an explicit selection as bare base id plus ordered parameters", async () => {
+	it("renders an explicit selection as the catalog suffix variant id", async () => {
 		const model = buildModel("claude-fable-5-thinking", "", fableCompat, "claude-fable-5-thinking-medium");
 		const frame = await captureRunRequest(model, { thinkingSelection: { level: "low", source: "explicit" } });
 		const request = frame.message.value as {
 			requestedModel?: { modelId: string; maxMode: boolean; parameters: { id: string; value: string }[] };
 		};
-		expect(request.requestedModel?.modelId).toBe("claude-fable-5");
-		expect(
-			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
-		).toEqual([
-			{ id: "thinking", value: "true" },
-			{ id: "context", value: "1m" },
-			{ id: "effort", value: "low" },
-		]);
+		expect(request.requestedModel?.modelId).toBe("claude-fable-5-thinking-low");
+		expect(request.requestedModel?.parameters ?? []).toEqual([]);
 	});
 
 	it("keeps the legacy request shape byte-exact when no selection exists", async () => {
@@ -155,7 +149,7 @@ describe("cursor Run request reasoning rendering", () => {
 		expect(request.requestedModel?.parameters ?? []).toEqual([]);
 	});
 
-	it("renders gpt off as reasoning=none with the family template", async () => {
+	it("renders gpt off as the none suffix variant id", async () => {
 		const compat: CursorAgentCompat = {
 			cursorReasoning: { capabilityId: "gpt-5.5", representativeVariantId: "gpt-5.5-medium" },
 		};
@@ -164,17 +158,11 @@ describe("cursor Run request reasoning rendering", () => {
 		const request = frame.message.value as {
 			requestedModel?: { modelId: string; parameters: { id: string; value: string }[] };
 		};
-		expect(request.requestedModel?.modelId).toBe("gpt-5.5");
-		expect(
-			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
-		).toEqual([
-			{ id: "context", value: "1m" },
-			{ id: "reasoning", value: "none" },
-			{ id: "fast", value: "false" },
-		]);
+		expect(request.requestedModel?.modelId).toBe("gpt-5.5-none");
+		expect(request.requestedModel?.parameters ?? []).toEqual([]);
 	});
 
-	it("keeps maxMode orthogonal to parameters", async () => {
+	it("keeps maxMode orthogonal to the suffix variant id", async () => {
 		const compat: CursorAgentCompat = {
 			cursorMaxMode: true,
 			cursorReasoning: {
@@ -189,12 +177,7 @@ describe("cursor Run request reasoning rendering", () => {
 			requestedModel?: { modelId: string; maxMode: boolean; parameters: { id: string; value: string }[] };
 		};
 		expect(request.requestedModel?.maxMode).toBe(true);
-		expect(
-			request.requestedModel?.parameters.map((parameter) => ({ id: parameter.id, value: parameter.value })),
-		).toEqual([
-			{ id: "thinking", value: "false" },
-			{ id: "context", value: "1m" },
-			{ id: "effort", value: "high" },
-		]);
+		expect(request.requestedModel?.modelId).toBe("claude-fable-5-high");
+		expect(request.requestedModel?.parameters ?? []).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/cursor-cli-oauth/reasoning-model-string.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/reasoning-model-string.test.ts
@@ -26,7 +26,7 @@ function cliModel(
 const explicit = (level: ThinkingSelection["level"]): ThinkingSelection => ({ level, source: "explicit" });
 
 describe("resolveCursorCliSpawnModel", () => {
-	it("renders bracket parameters for a parameter-encoded selection", () => {
+	it("renders the catalog suffix variant id for an explicit selection", () => {
 		const model = cliModel("claude-fable-5-thinking", {
 			cursorReasoning: {
 				capabilityId: "claude-fable-5",
@@ -34,18 +34,14 @@ describe("resolveCursorCliSpawnModel", () => {
 				representativeVariantId: "claude-fable-5-thinking-medium",
 			},
 		});
-		expect(resolveCursorCliSpawnModel(model, explicit("low"))).toBe(
-			"claude-fable-5[thinking=true,context=1m,effort=low]",
-		);
+		expect(resolveCursorCliSpawnModel(model, explicit("low"))).toBe("claude-fable-5-thinking-low");
 	});
 
-	it("translates gpt-5.5 xhigh to extra-high in the bracket form", () => {
+	it("translates gpt-5.5 xhigh to the extra-high suffix id", () => {
 		const model = cliModel("gpt-5.5", {
 			cursorReasoning: { capabilityId: "gpt-5.5", representativeVariantId: "gpt-5.5-medium" },
 		});
-		expect(resolveCursorCliSpawnModel(model, explicit("xhigh"))).toBe(
-			"gpt-5.5[context=1m,reasoning=extra-high,fast=false]",
-		);
+		expect(resolveCursorCliSpawnModel(model, explicit("xhigh"))).toBe("gpt-5.5-extra-high");
 	});
 
 	it("renders a suffix id for variant-encoded levels", () => {


### PR DESCRIPTION
## Summary

Explicit Cursor thinking levels (e.g. `kimi-k3` + `high`) died at turn start with `Error: Connect error not_found: Error`. Cursor's Run RPC now rejects bare capability ids for every family, so `resolveCursorSelectionDescriptor` now resolves an explicit level to the catalog-guaranteed legacy suffix variant id (`kimi-k3-high`, `claude-fable-5-thinking-low`) whenever an alias exists, keeping bare base id + ordered parameters only as the fallback for alias-less levels. After this PR, every explicit level on every family completes instead of erroring.

Fixes #1008.

## Changes

- **Selection descriptor** (`packages/ai/src/cursor/selection-descriptor.ts`): new `suffixAliasId` resolves base + level to a legacy suffix alias — candidates try the level's wire value first, then the level token itself (`extra-high` vs `xhigh`), with `-thinking-` infixed forms for thinking Claude identities. The resolver prefers this alias for both parameters-encoded and variant-id-encoded levels; `legacySuffixId` is subsumed. Bare base + `buildParameters(...)` output remains the fallback when no alias exists.
- **Wire contract tests** (`packages/ai/test/cursor-reasoning-params.test.ts`, `packages/ai/test/cursor-run-request.test.ts`): family assertions updated from bare-id+parameters to suffix ids, plus new coverage for the level-token candidate (`gpt-5.3-codex-xhigh`) and the no-alias parameters fallback (`claude-opus-5` non-thinking xhigh).
- **Docs** (`packages/ai/CHANGELOG.md` [Unreleased] Fixed, `packages/ai/src/changes.md` tracker entry).

## QA & Evidence

All artifacts under `local-ignore/qa-evidence/20260820-cursor-bare-id-notfound/` (gitignored; sanitized — no tokens).

- **What was tested:** Live characterization against api2.cursor.sh (pre-fix, main dist): bare `kimi-k3`+`[{reasoning:high}]` and bare `claude-fable-5`+`[{thinking,context,effort}]` vs the suffix ids `kimi-k3-high` / `claude-fable-5-thinking-low`.
  **Observed result:** both bare-id requests → `Connect error not_found`; both suffix ids → completed turns (`stop=stop`, "OK").
  **Artifact:** `probe-results.json`, `probe-stdout.log`.
  **Why sufficient:** proves the server-side contract change that motivates the fix, on the real wire, for both an "unproven" family (kimi) and a previously live-proven family (claude).
- **What was tested:** RED→GREEN unit/wire proof. Updated tests run against unchanged code, then against the fix.
  **Observed result:** RED 9 failed (old bare-id encoding) → GREEN 36/36 across all five cursor suites (`cursor-reasoning-params`, `cursor-run-request` fake-h2 wire capture, capabilities, grouping, window-consistency).
  **Artifact:** `red-unit.log`, `green-unit.log`.
  **Why sufficient:** the run-request suite captures the actual protobuf `RequestedModel` on a local HTTP/2 server, so the asserted ids are the bytes on the wire.
- **What was tested:** Post-fix live proof with the worktree build: `kimi-k3` explicit `high` (the reported bug) and `claude-fable-5` explicit `low`.
  **Observed result:** wire ids `kimi-k3-high` / `claude-fable-5-thinking-low`, zero parameters, both turns completed with "OK".
  **Artifact:** `probe-fixed-results.json`, `probe-fixed-stdout.log`.
  **Why sufficient:** end-to-end reproduction of the user-reported failure, now passing, through the real provider surface.
- **What was tested:** `npm run check` (biome, tsc, lock gates) at root; full `packages/ai` suite; senpi-qa Channel 4 CLI smoke.
  **Observed result:** check exit 0; 2185 passed / 0 failed (25 files skipped as designed); cli-smoke 8/8, real auth untouched.
  **Artifact:** `cli-smoke.log`.
  **Why sufficient:** repo quality gates for a `packages/ai` runtime change.

## Risks & Residuals

- **Cursor restores bare-id acceptance later:** harmless — suffix ids are permanent catalog entries; the parameters lane is preserved as fallback code.
- **Claude 1M context (`context=1m` parameter) no longer rides explicit-level requests:** moot — the server rejects any request carrying it (bare id); `maxMode` stays orthogonal on the protobuf field and is unaffected. Accepted.
- **Alias-less level combos:** audit shows every reachable family/level resolves to an alias; the only gap (`claude-opus-5` non-thinking `xhigh`) is UI-unreachable via `thinkingLevelMap` and keeps the previous fallback behavior. Accepted.
- **changes.md gate:** `packages/ai/src/cursor/` is fork-only (absent from upstream pin `59a71b23`), tracker entry added anyway per fork convention.

## Related Issues

Fixes #1008

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve explicit Cursor thinking levels to catalog suffix variant ids to prevent Connect not_found errors. Previously we sent bare capability ids with parameters; now we prefer suffix variant ids (for example, kimi-k3-high, claude-fable-5-thinking-low) and only fall back to base id + parameters when no alias exists.

- Core change in `packages/ai/src/cursor/selection-descriptor.ts`: new `suffixAliasId` tries the level’s wire value then token (handles Claude thinking infixes) and is used before any parameter encoding; old suffix resolver removed; fallback to base id + parameters retained. `off` maps to `-none`; `maxMode` is unchanged; no-selection still uses the representative variant id.
- Tests updated in `packages/ai/test/*` to assert suffix ids and zero parameters, including xhigh token and no-alias fallback; `packages/coding-agent/test/cursor-cli-oauth/reasoning-model-string.test.ts` now expects CLI spawn models to emit suffix variant ids.
- Docs updated in `packages/ai/CHANGELOG.md` and `packages/ai/src/changes.md`.
- No migration required. Fixes #1008.

<sup>Written for commit 9db9806f652df3084be3b938b1a5b22439dba7cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

