### PR TITLE
feat(coding-agent): export notice primitives and unify divergent notice cards

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,7 +8,16 @@
 
 ### Added
 
+- The notice-box primitives are now part of the public API: `buildNoticeBox`, `noticeMessageRenderer`,
+  `noticeEntryRenderer`, and the `NoticeSpec`/`NoticeLine`/`NoticeTone` types are exported from the package
+  entry so extensions can render transcript notices in the shared visual family instead of re-implementing it.
+
 ### Changed
+
+- Every remaining divergent transcript card now renders through the shared notice box (`customMessageBg`
+  background block, bold tone title, dim body): loaded-resource conflict diagnostics, the update-available
+  and package-update notifications, the risky-main-model and high-reasoning warnings, the rules banner,
+  the prompt URL widget card, and the earendil announcement. Visible text is unchanged.
 
 ### Fixed
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Public notice renderer primitives (2026-08-20)
+
+### What changed
+
+- `packages/coding-agent/src/index.ts` now exports `buildNoticeBox`, `noticeMessageRenderer`, `noticeEntryRenderer`, and the `NoticeSpec`, `NoticeLine`, and `NoticeTone` types.
+
+### Why
+
+- Extensions and package consumers need the same notice-card contract as built-in transcript surfaces instead of recreating its background, title, and detail styling.
+
+### Why an extension could not handle it
+
+- The package entry point owns the supported public API; an extension cannot export additional symbols from it.
+
+### Expected merge conflict zones
+
+- LOW: the notice export block in `packages/coding-agent/src/index.ts`.
+
 ## Entry surface and CLI coordinator re-diverge from upstream 59a71b23 (2026-08-19)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Shared notice styling for built-in cards (2026-08-20)
+
+### What changed
+
+- The prompt URL widget and the multi-line pi-rules banner now render through `buildNoticeBox`, retaining their existing titles, paths, diagnostics, and URL details while using the shared notice background and bold tone title.
+- The compact pi-rules footer remains a one-line status surface and is unchanged.
+
+### Why
+
+- These built-in multi-line cards were visually divergent from every transcript notice renderer and did not carry the `customMessageBg` notice background.
+
+### Why an extension could not handle it
+
+- The built-in widget and rules banner own their component rendering before another extension can restyle the returned component.
+
+### Expected merge conflict zones
+
+- LOW: `extensions/builtin/prompt-url-widget.ts` widget construction and `extensions/builtin/rules/ui/rules-banner.ts` multi-line rendering.
+
 ## Provider-declared fallback-expansion eligibility gate (2026-08-19)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-url-widget.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-url-widget.ts
@@ -1,5 +1,4 @@
-import { Container, Text } from "@earendil-works/pi-tui";
-import { DynamicBorder } from "../../../modes/interactive/components/dynamic-border.ts";
+import { buildNoticeBox } from "../notice/index.ts";
 import type { ExtensionAPI, ExtensionContext } from "../types.ts";
 
 const PR_PROMPT_PATTERN = /^\s*You are given one or more GitHub PR URLs:\s*(\S+)/im;
@@ -61,20 +60,18 @@ function formatAuthor(author?: GhMetadata["author"]): string | undefined {
 
 export default function promptUrlWidgetExtension(pi: ExtensionAPI) {
 	const setWidget = (ctx: ExtensionContext, match: PromptMatch, title?: string, authorText?: string) => {
-		ctx.ui.setWidget("prompt-url", (_tui, thm) => {
-			const titleText = title ? thm.fg("accent", title) : thm.fg("accent", match.url);
-			const authorLine = authorText ? thm.fg("muted", authorText) : undefined;
-			const urlLine = thm.fg("dim", match.url);
-
-			const lines = [titleText];
-			if (authorLine) lines.push(authorLine);
-			lines.push(urlLine);
-
-			const container = new Container();
-			container.addChild(new DynamicBorder((s: string) => thm.fg("muted", s)));
-			container.addChild(new Text(lines.join("\n"), 1, 0));
-			return container;
-		});
+		ctx.ui.setWidget("prompt-url", (_tui, thm) =>
+			buildNoticeBox(
+				{
+					title: title ?? match.url,
+					tone: "accent",
+					why: authorText ?? "Prompt URL detected.",
+					extra: [{ text: match.url, tone: "dim" }],
+				},
+				{ expanded: false },
+				thm,
+			),
+		);
 	};
 
 	const applySessionName = (_ctx: ExtensionContext, match: PromptMatch, title?: string) => {

--- a/packages/coding-agent/src/core/extensions/builtin/rules/ui/rules-banner.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/rules/ui/rules-banner.ts
@@ -1,7 +1,7 @@
 import { Container } from "@earendil-works/pi-tui";
 import type { Theme } from "../../../../../modes/interactive/theme/theme.ts";
+import { buildNoticeBox, type NoticeLine } from "../../../notice/index.ts";
 import type { LoadedRule, RuleDiagnostic } from "../rules/types.ts";
-import { DynamicBorder } from "./dynamic-border.ts";
 
 export interface RulesBannerProps {
 	ruleCount: number;
@@ -27,44 +27,41 @@ export class RulesBanner extends Container {
 }
 
 export function renderBannerLines(props: RulesBannerProps, theme: Theme, width: number): string[] {
-	const lines: string[] = [];
-	const border = new DynamicBorder((str) => theme.fg("border", str));
-
 	if (props.ruleCount === 0) {
-		lines.push(...border.render(width));
-		lines.push(`${theme.bold(theme.fg("accent", "[pi-rules]"))} No rules discovered`);
-		lines.push(...border.render(width));
-		return lines;
+		return buildNoticeBox(
+			{
+				title: "[pi-rules] No rules discovered",
+				tone: "accent",
+				why: "No rules were discovered.",
+			},
+			{ expanded: false },
+			theme,
+		).render(width);
 	}
 
-	lines.push(...border.render(width));
-	lines.push(
-		`${theme.bold(theme.fg("accent", "[pi-rules]"))} ${theme.fg("muted", `${props.ruleCount} active rules`)}`,
-	);
-	lines.push("");
-
-	if (props.topRules) {
-		for (const rule of props.topRules) {
-			const hasDiagnostic = props.diagnostics.some((diagnostic) => diagnostic.source === rule.relativePath);
-			const indicator = hasDiagnostic ? theme.fg("error", "⚠") : theme.fg("success", "●");
-
-			let annotation = "";
-			if (typeof rule.matchReason === "object" && rule.matchReason.kind === "glob") {
-				annotation = ` ${theme.fg("muted", rule.matchReason.pattern)}`;
-			}
-
-			lines.push(`  ${indicator} ${rule.relativePath}${annotation}`);
-		}
-	}
-
+	const extra: NoticeLine[] = (props.topRules ?? []).map((rule) => {
+		const hasDiagnostic = props.diagnostics.some((diagnostic) => diagnostic.source === rule.relativePath);
+		const annotation =
+			typeof rule.matchReason === "object" && rule.matchReason.kind === "glob" ? ` ${rule.matchReason.pattern}` : "";
+		return {
+			text: `  ${hasDiagnostic ? "⚠" : "●"} ${rule.relativePath}${annotation}`,
+			tone: hasDiagnostic ? ("error" as const) : ("success" as const),
+		};
+	});
 	if (props.diagnostics.length > 0) {
-		lines.push(`  ${theme.fg("warning", `⚠ ${props.diagnostics.length} warning(s)`)}`);
+		extra.push({ text: `  ⚠ ${props.diagnostics.length} warning(s)`, tone: "warning" });
 	}
 
-	lines.push("");
-	lines.push(...border.render(width));
-
-	return lines;
+	return buildNoticeBox(
+		{
+			title: `[pi-rules] ${props.ruleCount} active rules`,
+			tone: "accent",
+			why: `${props.ruleCount} active rules were discovered.`,
+			extra,
+		},
+		{ expanded: false },
+		theme,
+	).render(width);
 }
 
 export interface StatusLineInput {

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -174,6 +174,15 @@ export {
 	wrapRegisteredTool,
 	wrapRegisteredTools,
 } from "./core/extensions/index.ts";
+// Notice primitives
+export {
+	buildNoticeBox,
+	type NoticeLine,
+	type NoticeSpec,
+	type NoticeTone,
+	noticeEntryRenderer,
+	noticeMessageRenderer,
+} from "./core/extensions/notice/index.ts";
 // Footer data provider (git branch + extension statuses - data not otherwise available to extensions)
 export type { ReadonlyFooterDataProvider } from "./core/footer-data-provider.ts";
 export { convertToLlm } from "./core/messages.ts";

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Canonical interactive notice cards (2026-08-20)
+
+### What changed
+
+- Loaded-resource diagnostics, version and package updates, risky-model and high-reasoning warnings, debug-log completion, and the Earendil announcement text now render through `buildNoticeBox`.
+- Existing notice text, diagnostic severity, changelog hyperlink behavior, package lists, and the optional Earendil image remain intact.
+
+### Why
+
+- These multi-line notice cards used independent borders and foreground styling, so they diverged from the shared transcript notice background and title contract.
+
+### Why an extension could not handle it
+
+- These surfaces are constructed directly by `InteractiveMode` or its built-in announcement component; extensions cannot replace their internal TUI components after insertion.
+
+### Expected merge conflict zones
+
+- MEDIUM: `interactive-mode.ts` loaded-resource diagnostics and notification helpers; LOW: `components/earendil-announcement.ts` textual banner construction.
+
 ## Interactive chrome, queued-input recovery, and smooth-streaming settings after the 59a71b23 pin (2026-08-19)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/earendil-announcement.ts
+++ b/packages/coding-agent/src/modes/interactive/components/earendil-announcement.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs";
-import { Container, Image, Spacer, Text } from "@earendil-works/pi-tui";
+import { Container, Image, Spacer } from "@earendil-works/pi-tui";
 import { getBundledInteractiveAssetPath } from "../../../config.ts";
+import { buildNoticeBox } from "../../../core/extensions/notice/index.ts";
 import { theme } from "../theme/theme.ts";
-import { DynamicBorder } from "./dynamic-border.ts";
 
 const BLOG_URL = "https://mariozechner.at/posts/2026-04-08-ive-sold-out/";
 const IMAGE_FILENAME = "clankolas.png";
@@ -28,11 +28,18 @@ export class EarendilAnnouncementComponent extends Container {
 	constructor() {
 		super();
 
-		this.addChild(new DynamicBorder((text) => theme.fg("accent", text)));
-		this.addChild(new Text(theme.bold(theme.fg("accent", "pi has joined Earendil")), 1, 0));
-		this.addChild(new Spacer(1));
-		this.addChild(new Text(theme.fg("muted", "Read the blog post:"), 1, 0));
-		this.addChild(new Text(theme.fg("mdLink", BLOG_URL), 1, 0));
+		this.addChild(
+			buildNoticeBox(
+				{
+					title: "pi has joined Earendil",
+					tone: "accent",
+					why: "Read the blog post:",
+					extra: [{ text: BLOG_URL, tone: "accent" }],
+				},
+				{ expanded: false },
+				theme,
+			),
+		);
 		this.addChild(new Spacer(1));
 
 		const imageBase64 = loadImageBase64();
@@ -47,7 +54,5 @@ export class EarendilAnnouncementComponent extends Container {
 			);
 			this.addChild(new Spacer(1));
 		}
-
-		this.addChild(new DynamicBorder((text) => theme.fg("accent", text)));
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -85,7 +85,7 @@ import type {
 	ProjectTrustContext,
 	WorkingIndicatorOptions,
 } from "../../core/extensions/index.ts";
-import { buildNoticeBox, type NoticeSpec } from "../../core/extensions/notice/index.ts";
+import { buildNoticeBox, type NoticeLine, type NoticeSpec } from "../../core/extensions/notice/index.ts";
 import { FooterDataProvider, type ReadonlyFooterDataProvider } from "../../core/footer-data-provider.ts";
 import { appendHiddenTuiStdout } from "../../core/hidden-stdout-log.ts";
 import { buildHighReasoningWarning } from "../../core/high-reasoning-warning.ts";
@@ -2068,8 +2068,11 @@ export class InteractiveMode {
 		return this.formatDisplayPath(p);
 	}
 
-	private formatDiagnostics(diagnostics: readonly ResourceDiagnostic[], sourceInfos: Map<string, SourceInfo>): string {
-		const lines: string[] = [];
+	private formatDiagnostics(
+		diagnostics: readonly ResourceDiagnostic[],
+		sourceInfos: Map<string, SourceInfo>,
+	): NoticeLine[] {
+		const lines: NoticeLine[] = [];
 
 		// Group collision diagnostics by name
 		const collisions = new Map<string, ResourceDiagnostic[]>();
@@ -2089,36 +2092,33 @@ export class InteractiveMode {
 		for (const [name, collisionList] of collisions) {
 			const first = collisionList[0]?.collision;
 			if (!first) continue;
-			lines.push(theme.fg("warning", `  "${name}" collision:`));
-			lines.push(
-				theme.fg(
-					"dim",
-					`    ${theme.fg("success", "✓")} ${this.formatPathWithSource(first.winnerPath, this.findSourceInfoForPath(first.winnerPath, sourceInfos))}`,
-				),
-			);
+			lines.push({ text: `  "${name}" collision:`, tone: "warning" });
+			lines.push({
+				text: `    ✓ ${this.formatPathWithSource(first.winnerPath, this.findSourceInfoForPath(first.winnerPath, sourceInfos))}`,
+				tone: "warning",
+			});
 			for (const d of collisionList) {
 				if (d.collision) {
-					lines.push(
-						theme.fg(
-							"dim",
-							`    ${theme.fg("warning", "✗")} ${this.formatPathWithSource(d.collision.loserPath, this.findSourceInfoForPath(d.collision.loserPath, sourceInfos))} (skipped)`,
-						),
-					);
+					lines.push({
+						text: `    ✗ ${this.formatPathWithSource(d.collision.loserPath, this.findSourceInfoForPath(d.collision.loserPath, sourceInfos))} (skipped)`,
+						tone: "warning",
+					});
 				}
 			}
 		}
 
 		for (const d of otherDiagnostics) {
+			const tone = d.type === "error" ? "error" : "warning";
 			if (d.path) {
 				const formattedPath = this.formatPathWithSource(d.path, this.findSourceInfoForPath(d.path, sourceInfos));
-				lines.push(theme.fg(d.type === "error" ? "error" : "warning", `  ${formattedPath}`));
-				lines.push(theme.fg(d.type === "error" ? "error" : "warning", `    ${d.message}`));
+				lines.push({ text: `  ${formattedPath}`, tone });
+				lines.push({ text: `    ${d.message}`, tone });
 			} else {
-				lines.push(theme.fg(d.type === "error" ? "error" : "warning", `  ${d.message}`));
+				lines.push({ text: `  ${d.message}`, tone });
 			}
 		}
 
-		return lines.join("\n");
+		return lines;
 	}
 
 	private showLoadedResources(options?: {
@@ -2288,22 +2288,30 @@ export class InteractiveMode {
 		}
 
 		if (showDiagnostics) {
-			const skillDiagnostics = skillsResult.diagnostics;
-			if (skillDiagnostics.length > 0) {
-				const warningLines = this.formatDiagnostics(skillDiagnostics, sourceInfos);
+			const addDiagnosticNotice = (title: string, diagnostics: readonly ResourceDiagnostic[]): void => {
 				this.loadedResourcesContainer.addChild(
-					new Text(`${theme.fg("warning", "[Skill conflicts]")}\n${warningLines}`, 0, 0),
+					buildNoticeBox(
+						{
+							title,
+							tone: "warning",
+							why: "Conflicting or invalid loaded resources were found.",
+							extra: this.formatDiagnostics(diagnostics, sourceInfos),
+						},
+						{ expanded: this.toolOutputExpanded },
+						theme,
+					),
 				);
 				this.loadedResourcesContainer.addChild(new Spacer(1));
+			};
+
+			const skillDiagnostics = skillsResult.diagnostics;
+			if (skillDiagnostics.length > 0) {
+				addDiagnosticNotice("Skill conflicts", skillDiagnostics);
 			}
 
 			const promptDiagnostics = promptsResult.diagnostics;
 			if (promptDiagnostics.length > 0) {
-				const warningLines = this.formatDiagnostics(promptDiagnostics, sourceInfos);
-				this.loadedResourcesContainer.addChild(
-					new Text(`${theme.fg("warning", "[Prompt conflicts]")}\n${warningLines}`, 0, 0),
-				);
-				this.loadedResourcesContainer.addChild(new Spacer(1));
+				addDiagnosticNotice("Prompt conflicts", promptDiagnostics);
 			}
 
 			const extensionDiagnostics: ResourceDiagnostic[] = [];
@@ -2326,20 +2334,12 @@ export class InteractiveMode {
 			extensionDiagnostics.push(...shortcutDiagnostics);
 
 			if (extensionDiagnostics.length > 0) {
-				const warningLines = this.formatDiagnostics(extensionDiagnostics, sourceInfos);
-				this.loadedResourcesContainer.addChild(
-					new Text(`${theme.fg("warning", "[Extension issues]")}\n${warningLines}`, 0, 0),
-				);
-				this.loadedResourcesContainer.addChild(new Spacer(1));
+				addDiagnosticNotice("Extension issues", extensionDiagnostics);
 			}
 
 			const themeDiagnostics = themesResult.diagnostics;
 			if (themeDiagnostics.length > 0) {
-				const warningLines = this.formatDiagnostics(themeDiagnostics, sourceInfos);
-				this.loadedResourcesContainer.addChild(
-					new Text(`${theme.fg("warning", "[Theme conflicts]")}\n${warningLines}`, 0, 0),
-				);
-				this.loadedResourcesContainer.addChild(new Spacer(1));
+				addDiagnosticNotice("Theme conflicts", themeDiagnostics);
 			}
 		}
 	}
@@ -5537,41 +5537,21 @@ export class InteractiveMode {
 	}
 
 	showNewVersionNotification(newVersion: string): void {
-		const action = theme.fg("accent", BRAND?.update?.command ?? `${APP_NAME} update`);
-		const updateInstruction = theme.fg("muted", `New version ${newVersion} is available. Run `) + action;
+		const action = BRAND?.update?.command ?? `${APP_NAME} update`;
 		const changelogUrl = getReleaseChangelogUrl(newVersion);
-		const changelogLink = getCapabilities().hyperlinks
-			? hyperlink(theme.fg("accent", changelogUrl), changelogUrl)
-			: theme.fg("accent", changelogUrl);
-		const changelogLine = theme.fg("muted", "Changelog: ") + changelogLink;
-
-		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
-		this.chatContainer.addChild(
-			new Text(
-				`${theme.bold(theme.fg("warning", "Update Available"))}\n${updateInstruction}\n${changelogLine}`,
-				1,
-				0,
-			),
-		);
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
-		this.ui.requestRender();
+		const changelogLink = getCapabilities().hyperlinks ? hyperlink(changelogUrl, changelogUrl) : changelogUrl;
+		this.showNoticeBox({
+			title: "Update Available",
+			tone: "warning",
+			why: `New version ${newVersion} is available. Run ${action}`,
+			extra: [{ text: `Changelog: ${changelogLink}`, tone: "accent" }],
+		});
 	}
 
 	showRiskyMainModelWarning(model: Model<any> | undefined): void {
 		if (!model || !isRiskyMainModel(model)) return;
 
-		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
-		this.chatContainer.addChild(
-			new Text(
-				`${theme.bold(theme.fg("error", "Risky model warning"))}\n${theme.fg("error", RISKY_MAIN_MODEL_WARNING)}`,
-				1,
-				0,
-			),
-		);
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
-		this.ui.requestRender();
+		this.showNoticeBox({ title: "Risky model warning", tone: "error", why: RISKY_MAIN_MODEL_WARNING });
 	}
 
 	showSettingsSourceSelected(event: Extract<AgentSessionEvent, { type: "settings_source_selected" }>): void {
@@ -5583,35 +5563,24 @@ export class InteractiveMode {
 			{ id: event.modelId, provider: event.provider },
 			event.thinkingLevel,
 		);
-		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
-		this.chatContainer.addChild(
-			new Text(
-				`${theme.bold(theme.fg("error", title))}\n${body.map((line) => theme.fg("error", line)).join("\n")}`,
-				1,
-				0,
-			),
-		);
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("error", text)));
-		this.ui.requestRender();
+		this.showNoticeBox({
+			title,
+			tone: "error",
+			why: body[0] ?? "High reasoning may affect reliability or cost.",
+			extra: body.slice(1).map((text) => ({ text, tone: "error" })),
+		});
 	}
 
 	showPackageUpdateNotification(packages: string[]): void {
-		const action = theme.fg("accent", `${APP_NAME} update --extensions`);
-		const updateInstruction = theme.fg("muted", "Package updates are available. Run ") + action;
-		const packageLines = packages.map((pkg) => `- ${pkg}`).join("\n");
-
-		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
-		this.chatContainer.addChild(
-			new Text(
-				`${theme.bold(theme.fg("warning", "Package Updates Available"))}\n${updateInstruction}\n${theme.fg("muted", "Packages:")}\n${packageLines}`,
-				1,
-				0,
-			),
-		);
-		this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
-		this.ui.requestRender();
+		this.showNoticeBox({
+			title: "Package Updates Available",
+			tone: "warning",
+			why: `Package updates are available. Run ${APP_NAME} update --extensions`,
+			extra: [
+				{ text: "Packages:", tone: "dim" },
+				...packages.map((pkg) => ({ text: `- ${pkg}`, tone: "dim" as const })),
+			],
+		});
 	}
 
 	/**
@@ -8033,11 +8002,7 @@ export class InteractiveMode {
 		fs.mkdirSync(path.dirname(debugLogPath), { recursive: true });
 		fs.writeFileSync(debugLogPath, debugData);
 
-		this.chatContainer.addChild(new Spacer(1));
-		this.chatContainer.addChild(
-			new Text(`${theme.fg("accent", "✓ Debug log written")}\n${theme.fg("muted", debugLogPath)}`, 1, 1),
-		);
-		this.ui.requestRender();
+		this.showNoticeBox({ title: "✓ Debug log written", tone: "success", why: debugLogPath });
 	}
 
 	private handleArminSaysHi(): void {

--- a/packages/coding-agent/test/divergent-notice-rendering.test.ts
+++ b/packages/coding-agent/test/divergent-notice-rendering.test.ts
@@ -1,0 +1,183 @@
+import type { Model } from "@earendil-works/pi-ai";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import promptUrlWidgetExtension from "../src/core/extensions/builtin/prompt-url-widget.ts";
+import { renderBannerLines } from "../src/core/extensions/builtin/rules/ui/rules-banner.ts";
+import type { ExtensionAPI, ExtensionContext } from "../src/core/extensions/types.ts";
+import { buildNoticeBox, noticeEntryRenderer, noticeMessageRenderer } from "../src/index.ts";
+import { EarendilAnnouncementComponent } from "../src/modes/interactive/components/earendil-announcement.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme, type Theme, theme } from "../src/modes/interactive/theme/theme.ts";
+
+function renderComponent(component: Component, width = 160): string {
+	return component.render(width).join("\n");
+}
+
+function renderChildren(container: { children: Component[] }, width = 160): string {
+	return container.children.flatMap((child) => child.render(width)).join("\n");
+}
+
+const BOLD = "\x1b[1m";
+
+function expectNoticeContract(rendered: string): void {
+	expect(rendered).toContain(theme.getBgAnsi("customMessageBg"));
+	expect(rendered).toContain(BOLD);
+}
+
+function interactiveMethod(name: string): (this: unknown, ...args: unknown[]) => void {
+	const method = Reflect.get(InteractiveMode.prototype, name);
+	if (typeof method !== "function") throw new Error(`InteractiveMode.${name} is missing`);
+	return method;
+}
+
+function createInteractiveThis() {
+	const chatContainer = new (class {
+		children: Component[] = [];
+		addChild(child: Component): void {
+			this.children.push(child);
+		}
+	})();
+	const fakeThis = {
+		chatContainer,
+		toolOutputExpanded: false,
+		ui: {
+			requestRender: vi.fn(),
+			render: () => [],
+			terminal: { columns: 120, rows: 40 },
+		},
+		session: { messages: [] },
+		showNoticeBox(spec: unknown): void {
+			interactiveMethod("showNoticeBox").call(fakeThis, spec);
+		},
+	};
+	return fakeThis;
+}
+
+function riskyModel(): Model<"openai-completions"> {
+	return {
+		id: "minimax-m2",
+		name: "MiniMax M2",
+		api: "openai-completions",
+		provider: "minimax",
+		baseUrl: "http://127.0.0.1/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 16_384,
+	};
+}
+
+describe("divergent notice rendering", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("exports the shared notice renderer primitives", () => {
+		expect(buildNoticeBox).toBeTypeOf("function");
+		expect(noticeMessageRenderer).toBeTypeOf("function");
+		expect(noticeEntryRenderer).toBeTypeOf("function");
+	});
+
+	test.each([
+		["showNewVersionNotification", ["2026.8.20"]],
+		["showRiskyMainModelWarning", [riskyModel()]],
+		["showHighReasoningWarning", [{ modelId: "gpt-5.6-sol", provider: "openai", thinkingLevel: "xhigh" }]],
+		["showPackageUpdateNotification", [["example-extension@2.0.0"]]],
+	])("renders %s through the notice background", (methodName, args) => {
+		const fakeThis = createInteractiveThis();
+		interactiveMethod(methodName).call(fakeThis, ...args);
+		expectNoticeContract(renderChildren(fakeThis.chatContainer));
+	});
+
+	test("renders loaded-resource conflict diagnostics through the notice background", () => {
+		const loadedResourcesContainer = new (class {
+			children: Component[] = [];
+			clear(): void {
+				this.children = [];
+			}
+			addChild(child: Component): void {
+				this.children.push(child);
+			}
+		})();
+		const fakeThis = {
+			options: { verbose: false },
+			toolOutputExpanded: false,
+			loadedResourcesContainer,
+			settingsManager: { getQuietStartup: () => true, getDisabledBuiltinExtensions: () => [] },
+			sessionManager: { getCwd: () => "/tmp/project" },
+			session: {
+				promptTemplates: [],
+				extensionRunner: {
+					getCommandDiagnostics: () => [],
+					getShortcutDiagnostics: () => [],
+				},
+				resourceLoader: {
+					getPathMetadata: () => new Map(),
+					getAgentsFiles: () => ({ agentsFiles: [] }),
+					getSystemPromptSource: () => undefined,
+					getAppendSystemPromptSources: () => [],
+					getSkills: () => ({ skills: [], diagnostics: [{ type: "warning", message: "duplicate skill" }] }),
+					getPrompts: () => ({ prompts: [], diagnostics: [] }),
+					getExtensions: () => ({ extensions: [], errors: [], runtime: {} }),
+					getThemes: () => ({ themes: [], diagnostics: [] }),
+				},
+			},
+			formatDiagnostics: () => "duplicate skill",
+			getBuiltInCommandConflictDiagnostics: () => [],
+		};
+		interactiveMethod("showLoadedResources").call(fakeThis, {
+			force: false,
+			showDiagnosticsWhenQuiet: true,
+		});
+		expectNoticeContract(renderChildren(loadedResourcesContainer));
+	});
+
+	test("renders the rules banner through the notice background", () => {
+		const rendered = renderBannerLines(
+			{
+				ruleCount: 1,
+				diagnostics: [],
+				topRules: [{ relativePath: "AGENTS.md", matchReason: "single-file" }],
+			},
+			theme,
+			120,
+		).join("\n");
+		expectNoticeContract(rendered);
+	});
+
+	test("renders the prompt URL widget through the notice background", async () => {
+		let beforeAgentStart: ((event: { prompt: string }, ctx: ExtensionContext) => unknown) | undefined;
+		let widgetFactory: ((tui: TUI, theme: Theme) => Component) | undefined;
+		const pi = {
+			on: (event: string, handler: (event: { prompt: string }, ctx: ExtensionContext) => unknown) => {
+				if (event === "before_agent_start") beforeAgentStart = handler;
+			},
+			exec: () => new Promise(() => {}),
+			getSessionName: () => undefined,
+			setSessionName: () => {},
+		} as unknown as ExtensionAPI;
+		promptUrlWidgetExtension(pi);
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget: (_key: string, content: unknown) => {
+					if (typeof content === "function") widgetFactory = content as (tui: TUI, theme: Theme) => Component;
+				},
+			},
+		} as unknown as ExtensionContext;
+		await beforeAgentStart?.({ prompt: "Analyze GitHub issue(s): https://github.com/org/repo/issues/1" }, ctx);
+		if (!widgetFactory) throw new Error("Prompt URL widget was not registered");
+		expectNoticeContract(renderComponent(widgetFactory({} as TUI, theme)));
+	});
+
+	test("renders the Earendil announcement text through the notice background", () => {
+		expectNoticeContract(renderComponent(new EarendilAnnouncementComponent()));
+	});
+
+	test("renders debug-log completion through the notice background", () => {
+		const fakeThis = createInteractiveThis();
+		interactiveMethod("handleDebugCommand").call(fakeThis);
+		expectNoticeContract(renderChildren(fakeThis.chatContainer));
+	});
+});

--- a/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
+++ b/packages/coding-agent/test/high-reasoning-warning-tui.test.ts
@@ -15,9 +15,13 @@ describe("InteractiveMode.showHighReasoningWarning", () => {
 	});
 
 	test("renders a scary warning box naming the model+level and urging ultrabrain", () => {
-		const fakeThis: { chatContainer: Container; ui: { requestRender: () => void } } = {
+		const fakeThis = {
 			chatContainer: new Container(),
+			toolOutputExpanded: false,
 			ui: { requestRender: vi.fn() },
+			showNoticeBox(spec: unknown): void {
+				(InteractiveMode as any).prototype.showNoticeBox.call(fakeThis, spec);
+			},
 		};
 
 		const event = {
@@ -31,7 +35,7 @@ describe("InteractiveMode.showHighReasoningWarning", () => {
 			InteractiveMode as unknown as { prototype: { showHighReasoningWarning(this: unknown, event: unknown): void } }
 		).prototype.showHighReasoningWarning.call(fakeThis, event);
 
-		expect(fakeThis.chatContainer.children).toHaveLength(4);
+		expect(fakeThis.chatContainer.children).toHaveLength(2);
 		const rendered = stripAnsi(renderAll(fakeThis.chatContainer));
 		expect(rendered).toMatch(/WARNING/i);
 		expect(rendered).toContain("gpt-5.6-sol");
@@ -42,9 +46,13 @@ describe("InteractiveMode.showHighReasoningWarning", () => {
 	});
 
 	test("reflects the max level for a sol variant when max is selected", () => {
-		const fakeThis: { chatContainer: Container; ui: { requestRender: () => void } } = {
+		const fakeThis = {
 			chatContainer: new Container(),
+			toolOutputExpanded: false,
 			ui: { requestRender: vi.fn() },
+			showNoticeBox(spec: unknown): void {
+				(InteractiveMode as any).prototype.showNoticeBox.call(fakeThis, spec);
+			},
 		};
 		const event = {
 			type: "high_reasoning_warning",

--- a/packages/coding-agent/test/interactive-mode-status.test.ts
+++ b/packages/coding-agent/test/interactive-mode-status.test.ts
@@ -18,7 +18,7 @@ import { KeybindingsManager } from "../src/core/keybindings.ts";
 import type { SourceInfo } from "../src/core/source-info.ts";
 import type { AuthSelectorProvider } from "../src/modes/interactive/components/oauth-selector.ts";
 import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
-import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../src/utils/ansi.ts";
 
 function renderLastLine(container: Container, width = 120): string {
@@ -963,7 +963,7 @@ describe("InteractiveMode.showLoadedResources", () => {
 			) => (InteractiveMode as any).prototype.getCompactNonPackageExtensionLabel.call(fakeThis, p, index, allPaths),
 			getCompactExtensionLabels: (extensions: ExtensionFixture[]) =>
 				(InteractiveMode as any).prototype.getCompactExtensionLabels.call(fakeThis, extensions),
-			formatDiagnostics: () => "diagnostics",
+			formatDiagnostics: () => [{ text: "diagnostics", tone: "warning" }],
 			getBuiltInCommandConflictDiagnostics: () => [],
 		};
 
@@ -1626,7 +1626,8 @@ describe("InteractiveMode.showLoadedResources", () => {
 		});
 
 		const output = renderAll(fakeThis.loadedResourcesContainer);
-		expect(output).toContain("[Skill conflicts]");
+		expect(output).toContain("Skill conflicts");
+		expect(output).toContain(theme.getBgAnsi("customMessageBg"));
 		expect(output).not.toContain("[Skills]");
 	});
 

--- a/packages/coding-agent/test/notice-public-api.test.ts
+++ b/packages/coding-agent/test/notice-public-api.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import {
+	buildNoticeBox,
+	type NoticeLine,
+	type NoticeSpec,
+	type NoticeTone,
+	noticeEntryRenderer,
+	noticeMessageRenderer,
+} from "../src/index.ts";
+
+describe("public notice API", () => {
+	test("exports notice primitives and types from the package entry", () => {
+		expect(buildNoticeBox).toBeTypeOf("function");
+		expect(noticeMessageRenderer).toBeTypeOf("function");
+		expect(noticeEntryRenderer).toBeTypeOf("function");
+
+		const tone: NoticeTone = "warning";
+		const line: NoticeLine = { text: "detail", tone };
+		const spec: NoticeSpec = { title: "Notice", why: "Reason", extra: [line] };
+		expect(spec.extra).toEqual([line]);
+	});
+});

--- a/packages/coding-agent/test/risky-main-model-warning-tui.test.ts
+++ b/packages/coding-agent/test/risky-main-model-warning-tui.test.ts
@@ -54,7 +54,11 @@ describe("risky main-model warning", () => {
 		(selectedModel) => {
 			const fakeThis = {
 				chatContainer: new Container(),
+				toolOutputExpanded: false,
 				ui: { requestRender: vi.fn() },
+				showNoticeBox(spec: unknown): void {
+					(InteractiveMode as any).prototype.showNoticeBox.call(fakeThis, spec);
+				},
 			};
 
 			warningMethod().call(fakeThis, selectedModel);
@@ -64,7 +68,7 @@ describe("risky main-model warning", () => {
 			expect(plain).toContain(RISKY_MAIN_MODEL_WARNING);
 			expect(plain).toContain("Risky model warning");
 			expect(rendered).toContain(theme.getFgAnsi("error"));
-			expect(fakeThis.chatContainer.children).toHaveLength(4);
+			expect(fakeThis.chatContainer.children).toHaveLength(2);
 			expect(fakeThis.ui.requestRender).toHaveBeenCalledExactlyOnceWith();
 		},
 	);


### PR DESCRIPTION
## What

Unify every block-style TUI notice onto the shared notice-box visual family (`buildNoticeBox`: `customMessageBg` background block + bold tone title + dim body) and expose the notice primitives on the public package API.

- `src/index.ts` now exports `buildNoticeBox`, `noticeMessageRenderer`, `noticeEntryRenderer`, and types `NoticeSpec`, `NoticeLine`, `NoticeTone` so downstream extensions (e.g. omo-senpi) can render their transcript notices in the identical style instead of re-implementing it.
- Converted the nine divergent notice surfaces found by audit to render through `buildNoticeBox`, preserving user-visible text: loaded-resource conflict diagnostics (skill/prompt/extension/theme), update-available notification, risky-main-model warning, high-reasoning warning, package-update notification, rules banner, prompt URL widget card, and the earendil announcement card.

## Why

Transcript blocks rendered with inconsistent backgrounds/styles: fallback and cache-warm notices used the canonical `customMessageBg` notice box while other cards drew bare bordered/unstyled lines. One visual family, one primitive.

## QA

- `npx vitest run test/divergent-notice-rendering.test.ts test/notice-public-api.test.ts test/suite/notice-kit.test.ts test/risky-main-model-warning-tui.test.ts test/high-reasoning-warning-tui.test.ts test/interactive-mode-status.test.ts` -> 6 files, 70/70 passed.
- `npx tsc -p tsconfig.build.json --noEmit` -> exit 0.
- Failing-first: full-suite run exposed `showNoticeBox is not a function` / `[Skill conflicts]` expectation failures mid-conversion (RED), fixed to GREEN.
- Known pre-existing, unrelated full-suite flakes (reproduce without these changes): `test/cursor-cli-oauth/shutdown.test.ts` grandchild-PID fixture timeouts, `goal-wake-sources.test.ts` tempdir cleanup race.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports shared notice primitives and routes all block-style TUI notices through a single notice box for consistent styling. Previously, several cards used ad‑hoc borders; now all use `customMessageBg` with a bold tone title and dim body without changing copy or link behavior.

- Public API: `packages/coding-agent` exports `buildNoticeBox`, `noticeMessageRenderer`, `noticeEntryRenderer`, and types `NoticeSpec`, `NoticeLine`, `NoticeTone` so extensions can render identical transcript notices.
- Unified surfaces: loaded‑resource diagnostics (skill/prompt/extension/theme), update‑available, risky‑main‑model, high‑reasoning, package‑update, rules banner, prompt URL widget, Earendil announcement, and debug‑log completion now render through `buildNoticeBox`; removed legacy `DynamicBorder` where applicable.
- Tests/docs: added `test/divergent-notice-rendering.test.ts` and `test/notice-public-api.test.ts`; updated TUI tests to match the notice box; changelog and internal `changes.md` documents record the exports and unification.
- Migration: no required changes. Extensions may adopt the new exports to match built‑in notices.
- Review focus: `interactive-mode.ts` notice helpers, `rules-banner.ts`, and `prompt-url-widget.ts`; low–medium merge risk in those areas.

<sup>Written for commit f46936fb569381cdc1fe7c65e4f0650731fc05a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

