### PR TITLE
fix: stop TUI render stalls from dead periodic repaint drivers

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1119,3 +1119,15 @@ codex-aligned tool naming, and budget-driven behavior removed. An optional
 - LOW in `types.ts` around the `SessionEvent` union and `on()` overloads (additive).
 - LOW in `agent-session.ts` around `abort()` and the `AgentSessionEvent` union (additive).
 - LOW in `goal/index.ts` around the session_start handler and the new session_abort handler.
+
+## 2026-08-20 — tickers retire on stale extension contexts
+
+`GoalWaitTicker`/`GoalElapsedTicker` previously relied on `index.ts` render
+callbacks that swallowed the stale-ctx error thrown after session
+replacement/reload, so a ticker holding a retired ctx kept ticking forever
+while rendering nothing — the footer elapsed/countdown froze and the TUI lost
+its only periodic repaint source in idle sessions. Both tickers now detect the
+stale-ctx error (`stale-context.ts`) inside `tick()` and retire (clear the
+interval, drop the ctx); `GoalWaitTicker.stop()` tolerates a stale ctx on its
+final clear render. A later `sync()` with a live ctx re-arms them. Covered by
+`test/suite/goal-ticker-stale-context.test.ts`.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/elapsed-ticker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/elapsed-ticker.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "../../types.ts";
 import { formatGoalElapsedSeconds } from "./format.ts";
+import { isStaleExtensionContextError } from "./stale-context.ts";
 import type { Goal } from "./types.ts";
 
 /** Footer live-elapsed refresh cadence while a goal is actively pursued. */
@@ -82,6 +83,18 @@ export class GoalElapsedTicker {
 		const elapsedLabel = formatGoalElapsedSeconds(liveElapsedSeconds);
 		if (elapsedLabel === this.lastRenderedElapsedLabel) return;
 		this.lastRenderedElapsedLabel = elapsedLabel;
-		this.render(this.ctx, this.goal, liveElapsedSeconds);
+		try {
+			this.render(this.ctx, this.goal, liveElapsedSeconds);
+		} catch (error) {
+			// A retired ctx (session replacement/reload) throws on every render from
+			// now on; retire instead of spinning dead forever. This stop() renders
+			// nothing, so it is safe against the same stale ctx. The next sync() with
+			// a live ctx re-arms the ticker.
+			if (isStaleExtensionContextError(error)) {
+				this.stop();
+				return;
+			}
+			throw error;
+		}
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -24,10 +24,10 @@ import { TurnUsageTracker } from "./turn-usage.ts";
 import type { Goal, GoalAccountingMode, GoalStoreRef } from "./types.ts";
 import { updateGoalUi } from "./ui.ts";
 import { GOAL_WAIT_STATUS_KEY, GoalWaitTicker } from "./wait-ticker.ts";
+import { isStaleExtensionContextError } from "./stale-context.ts";
 
 const RESUME_GOAL_CHOICE = "Resume goal";
 const LEAVE_GOAL_STOPPED_CHOICE = "Leave stopped";
-const STALE_EXTENSION_CONTEXT_ERROR_PREFIX = "This extension ctx is stale after session replacement or reload.";
 
 type AgentGoalAccounting = {
 	goalId: string;
@@ -43,15 +43,11 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	let continuationPending = false;
 	let activeContext: ExtensionContext | undefined;
 	const turnUsage = new TurnUsageTracker();
+	// No stale-ctx swallow here: GoalWaitTicker retires itself on a stale render
+	// (a ticker that keeps ticking against a retired ctx freezes the footer
+	// countdown forever); non-stale render errors still propagate.
 	const goalWaitTicker = new GoalWaitTicker({
-		render: (renderCtx, status) => {
-			try {
-				renderCtx.ui.setStatus(GOAL_WAIT_STATUS_KEY, status);
-			} catch (error) {
-				if (error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX)) return;
-				throw error;
-			}
-		},
+		render: (renderCtx, status) => renderCtx.ui.setStatus(GOAL_WAIT_STATUS_KEY, status),
 	});
 	const monitorContinuation = new MonitorAwareGoalContinuation(
 		pi,
@@ -70,14 +66,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 	});
 
 	const goalTicker = new GoalElapsedTicker({
-		render: (renderCtx, renderGoal, live) => {
-			try {
-				updateGoalUi(renderCtx, renderGoal, live);
-			} catch (error) {
-				if (error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX)) return;
-				throw error;
-			}
-		},
+		render: (renderCtx, renderGoal, live) => updateGoalUi(renderCtx, renderGoal, live),
 	});
 
 	pi.registerEntryRenderer(GOAL_CACHE_WARMUP_ENTRY_TYPE, renderGoalCacheWarmupEntry);
@@ -401,7 +390,7 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		try {
 			refreshGoalUi(ctx, goal);
 		} catch (error) {
-			if (error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX)) {
+			if (isStaleExtensionContextError(error)) {
 				return;
 			}
 			throw error;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/stale-context.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/stale-context.ts
@@ -1,0 +1,11 @@
+/**
+ * Detection for the error a retired extension context throws when used after
+ * session replacement or reload (thrown by the extension runner; see
+ * agent-session). Long-lived goal tickers retain a ctx across ticks, so they
+ * must recognize this error and retire instead of spinning dead forever.
+ */
+export const STALE_EXTENSION_CONTEXT_ERROR_PREFIX = "This extension ctx is stale after session replacement or reload.";
+
+export function isStaleExtensionContextError(error: unknown): error is Error {
+	return error instanceof Error && error.message.startsWith(STALE_EXTENSION_CONTEXT_ERROR_PREFIX);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
@@ -1,5 +1,6 @@
 import type { ExtensionContext } from "../../types.ts";
 import type { ResumptionChannelCounts } from "./monitor-continuation-types.ts";
+import { isStaleExtensionContextError } from "./stale-context.ts";
 import { formatGoalWaitLabel, type GoalWaitKind, type GoalWaitLabelInput } from "./wait-progress.ts";
 
 /** Footer countdown refresh cadence while a Goal continuation is delayed. */
@@ -72,7 +73,31 @@ export class GoalWaitTicker {
 		this.ctx = undefined;
 		this.kind = undefined;
 		this.lastRenderedStatus = undefined;
-		if (ctx !== undefined) this.render(ctx, undefined);
+		if (ctx !== undefined) {
+			try {
+				this.render(ctx, undefined);
+			} catch (error) {
+				// A stale ctx cannot clear its own footer status; dropping it is enough.
+				if (!isStaleExtensionContextError(error)) throw error;
+			}
+		}
+	}
+
+	/**
+	 * Drop the interval and retained ctx without a final render. Used when a tick
+	 * discovers the ctx was retired by a session replacement or reload: every
+	 * render against it throws from now on, and a ticker that keeps ticking dead
+	 * renders freezes the footer forever without crashing. The next sync() with a
+	 * live ctx re-arms everything.
+	 */
+	private retire(): void {
+		if (this.intervalId !== undefined) {
+			clearInterval(this.intervalId);
+			this.intervalId = undefined;
+		}
+		this.ctx = undefined;
+		this.kind = undefined;
+		this.lastRenderedStatus = undefined;
 	}
 
 	private tick(): void {
@@ -85,6 +110,14 @@ export class GoalWaitTicker {
 		});
 		if (status === this.lastRenderedStatus) return;
 		this.lastRenderedStatus = status;
-		this.render(this.ctx, status);
+		try {
+			this.render(this.ctx, status);
+		} catch (error) {
+			if (isStaleExtensionContextError(error)) {
+				this.retire();
+				return;
+			}
+			throw error;
+		}
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -2296,3 +2296,17 @@ The tip line was teaching a small slice of the product while most of the surface
 
 - MEDIUM: the paste handler, submit path, and editor wiring in `packages/coding-agent/src/modes/interactive/interactive-mode.ts`.
 - LOW: `packages/coding-agent/src/modes/interactive/editor-paste-transfer.ts` (small transfer helper, additive return value).
+
+## 2026-08-20 — render-stall fixes: mode-switch detach + reload-scoped extension UI reset
+
+- `switchTuiMode()` now moves components to the new renderer with
+  `detachAll()` instead of `clear()`. Clearing disposed the live components
+  (tool spinners, reveals, extension widgets) and remounted the dead
+  instances, killing every interval they owned: the TUI froze until an input
+  event forced a frame. Regression: `test/interactive-tui.test.ts`
+  ("switchTuiMode component lifecycle").
+- `handleReloadCommand()` resets extension UI inside reload()'s
+  `beforeSessionStart` callback instead of up front, so a vetoed or failed
+  reload no longer destroys live extension footers/widgets/tickers.
+  Regression: `test/interactive-tui.test.ts` ("handleReloadCommand extension
+  UI lifecycle").

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7425,8 +7425,6 @@ export class InteractiveMode {
 			return;
 		}
 
-		this.resetExtensionUI();
-
 		const reloadBox = new Container();
 		const borderColor = (s: string) => theme.fg("border", s);
 		reloadBox.addChild(new DynamicBorder(borderColor));
@@ -7461,6 +7459,13 @@ export class InteractiveMode {
 			if (chatRestoredBeforeSessionStart) {
 				return;
 			}
+			// Reset extension UI only once the reload is actually proceeding (this
+			// callback runs after reload()'s internal veto re-check, right before the
+			// new runner's session_start re-registers extension UI). Resetting before
+			// reload() destroyed live extension footers/widgets/tickers on a vetoed
+			// or failed reload with nothing left to restore them, so the TUI stopped
+			// self-repainting until an input event forced a frame.
+			this.resetExtensionUI();
 			this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
 			this.outputPad = this.settingsManager.getOutputPad();
 			this.rebuildChatFromMessages();

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1169,7 +1169,11 @@ export class InteractiveMode {
 
 		previousUi.stop({ preserveScreen: true });
 		previousUi.setFocus(null);
-		previousUi.clear();
+		// Detach, not clear: the same live components (spinners, reveals, extension
+		// widgets) are remounted on nextUi below. clear() would dispose them,
+		// killing every interval they own while they keep rendering static frames
+		// forever — the TUI then never self-repaints until an input event forces one.
+		previousUi.detachAll();
 		if (TuiLayouts.isViewportTUI(previousUi)) previousUi.setLayoutRoot(undefined);
 
 		const nextUi = createInteractiveTui({

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -128,6 +128,61 @@ describe("createInteractiveTui", () => {
 	});
 });
 
+describe("switchTuiMode component lifecycle", () => {
+	it("remounts live components without disposing them", async () => {
+		const terminal = new RecordingTerminal(40, 8);
+		const renderer = createInteractiveTui({
+			tuiMode: "regular",
+			showHardwareCursor: false,
+			logDirectory: "/tmp",
+			terminal,
+		});
+		let stableUi: TUI;
+		const dispose = vi.fn();
+		const component: Component & { focused: boolean } = {
+			focused: false,
+			render: () => ["content"],
+			invalidate: () => {},
+			dispose,
+		};
+		renderer.addChild(component);
+		renderer.setFocus(component);
+
+		type SwitchContext = {
+			renderer: ReturnType<typeof createInteractiveTui>;
+			ui: TUI;
+			fullscreenLayoutRoot: Component;
+			options: { tuiMode?: TuiMode };
+			themeController: { rebindTui: () => void };
+			extensionTerminalInputSubscriptions: Set<never>;
+		};
+		const context = Object.assign(Object.create(InteractiveMode.prototype), {
+			renderer,
+			ui: undefined as unknown as TUI,
+			fullscreenLayoutRoot: component,
+			options: { tuiMode: "regular" as TuiMode },
+			themeController: { rebindTui: () => {} },
+			extensionTerminalInputSubscriptions: new Set<never>(),
+		}) as SwitchContext;
+		stableUi = createInteractiveTuiReference(() => context.renderer);
+		context.ui = stableUi;
+		const { switchTuiMode } = InteractiveMode.prototype as unknown as {
+			switchTuiMode(this: SwitchContext, mode: TuiMode, restoreProgress?: boolean): boolean;
+		};
+
+		renderer.start();
+		await terminal.waitForRender();
+		expect(switchTuiMode.call(context, "fullscreen", false)).toBe(true);
+		await terminal.waitForRender();
+
+		// Components moved to the new renderer must stay alive: disposing them on
+		// switch kills their intervals (spinners, reveals) while they keep
+		// rendering static frames forever.
+		expect(dispose).not.toHaveBeenCalled();
+		expect(context.renderer.children).toEqual([component]);
+	});
+});
+
 describe("InteractiveMode right-click paste", () => {
 	it("feeds clipboard text to the focused component as a bracketed paste", async () => {
 		clipboardMocks.readClipboardText.mockResolvedValue("clipboard text");

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -8,6 +8,7 @@ import {
 	createInteractiveTuiReference,
 	InteractiveMode,
 } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 
 const clipboardMocks = vi.hoisted(() => ({
 	copyToClipboard: vi.fn<(text: string) => Promise<void>>(),
@@ -180,6 +181,79 @@ describe("switchTuiMode component lifecycle", () => {
 		// rendering static frames forever.
 		expect(dispose).not.toHaveBeenCalled();
 		expect(context.renderer.children).toEqual([component]);
+	});
+});
+
+describe("handleReloadCommand extension UI lifecycle", () => {
+	function makeContext(session: unknown) {
+		const resetExtensionUI = vi.fn();
+		const editor = new Container();
+		const editorContainer = new Container();
+		editorContainer.addChild(editor);
+		const ui = createInteractiveTui({
+			tuiMode: "regular",
+			showHardwareCursor: false,
+			logDirectory: "/tmp",
+			terminal: new VirtualTerminal(80, 24),
+		});
+		ui.start();
+		const context = Object.assign(Object.create(InteractiveMode.prototype), {
+			runtimeHost: { session },
+			editor,
+			editorContainer,
+			ui,
+			resetExtensionUI,
+			rebuildChatFromMessages: vi.fn(),
+			showWarning: vi.fn(),
+			showError: vi.fn(),
+			showStatus: vi.fn(),
+			hideThinkingBlock: false,
+			outputPad: 0,
+		}) as unknown as InteractiveMode;
+		return { context, resetExtensionUI, ui };
+	}
+	const proto = InteractiveMode.prototype as unknown as {
+		handleReloadCommand(this: InteractiveMode): Promise<void>;
+	};
+
+	it("leaves extension UI untouched when the reload is vetoed", async () => {
+		// resetExtensionUI() disposes every extension footer/header/widget. Running
+		// it before reload() re-checks the extension veto destroys live extension UI
+		// (goal tickers, task widgets, hook statuses) with nothing left to restore
+		// it: the TUI stops self-repainting until an input event forces a frame.
+		initTheme("dark");
+		const session = {
+			isCompacting: false,
+			settingsManager: { getHideThinkingBlock: () => false, getOutputPad: () => 0 },
+			checkReloadVeto: async () => ({ cancelled: false }),
+			reload: async () => ({ cancelled: true, reason: "subagents running" }),
+		};
+		const { context, resetExtensionUI, ui } = makeContext(session);
+
+		await proto.handleReloadCommand.call(context);
+
+		expect(resetExtensionUI).not.toHaveBeenCalled();
+		ui.stop();
+	});
+
+	it("resets extension UI exactly when a proceeding reload rebuilds the session", async () => {
+		initTheme("dark");
+		const sentinel = new Error("boom after commit point");
+		const session = {
+			isCompacting: false,
+			settingsManager: { getHideThinkingBlock: () => false, getOutputPad: () => 0 },
+			checkReloadVeto: async () => ({ cancelled: false }),
+			reload: async (options?: { beforeSessionStart?: () => void | Promise<void> }) => {
+				await options?.beforeSessionStart?.();
+				throw sentinel;
+			},
+		};
+		const { context, resetExtensionUI, ui } = makeContext(session);
+
+		await proto.handleReloadCommand.call(context);
+
+		expect(resetExtensionUI).toHaveBeenCalledOnce();
+		ui.stop();
 	});
 });
 

--- a/packages/coding-agent/test/suite/goal-ticker-stale-context.test.ts
+++ b/packages/coding-agent/test/suite/goal-ticker-stale-context.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { GoalElapsedTicker } from "../../src/core/extensions/builtin/goal/elapsed-ticker.ts";
+import { MonitorAwareGoalContinuation } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+import { GoalWaitTicker } from "../../src/core/extensions/builtin/goal/wait-ticker.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+
+/** The runtime contract thrown by a retired extension context (agent-session). */
+const STALE_CTX_MESSAGE =
+	"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().";
+
+const fakeCtx = { ui: { setStatus: () => {} } } as unknown as ExtensionContext;
+
+function activeGoal(): Goal {
+	return {
+		id: "goal-1",
+		threadId: "goal-1-thread",
+		objective: "Keep moving",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+describe("goal tickers vs retired extension contexts", () => {
+	it("MonitorAwareGoalContinuation.dispose() stops the wait ticker interval", () => {
+		vi.useFakeTimers();
+		try {
+			const ticker = new GoalWaitTicker({ render: () => {} });
+			const pi = { events: { on: () => () => {} } } as unknown as ExtensionAPI;
+			const monitor = new MonitorAwareGoalContinuation(
+				pi,
+				() => false,
+				() => {},
+				ticker,
+			);
+			ticker.sync(fakeCtx, { kind: "monitor", remainingMs: 60_000, totalMs: 60_000, channelCounts: {} });
+			expect(ticker.running).toBe(true);
+
+			monitor.dispose();
+
+			expect(ticker.running).toBe(false);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("GoalWaitTicker retires itself when a tick hits a stale extension context", () => {
+		vi.useFakeTimers();
+		try {
+			let renders = 0;
+			const ticker = new GoalWaitTicker({
+				render: () => {
+					renders += 1;
+					if (renders > 1) throw new Error(STALE_CTX_MESSAGE);
+				},
+			});
+			ticker.sync(fakeCtx, { kind: "monitor", remainingMs: 60_000, totalMs: 60_000, channelCounts: {} });
+			expect(ticker.running).toBe(true);
+
+			// The session is replaced; the retained ctx goes stale and the next tick throws.
+			expect(() => vi.advanceTimersByTime(1_000)).not.toThrow();
+
+			expect(ticker.running).toBe(false);
+			// A dead ticker must not keep attempting renders on later ticks.
+			const rendersAfterRetire = renders;
+			vi.advanceTimersByTime(5_000);
+			expect(renders).toBe(rendersAfterRetire);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("GoalElapsedTicker retires itself when a tick hits a stale extension context", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(0);
+		try {
+			let renders = 0;
+			const ticker = new GoalElapsedTicker({
+				render: () => {
+					renders += 1;
+					if (renders > 1) throw new Error(STALE_CTX_MESSAGE);
+				},
+			});
+			ticker.sync(fakeCtx, activeGoal(), Date.now());
+			expect(ticker.running).toBe(true);
+
+			expect(() => vi.advanceTimersByTime(1_000)).not.toThrow();
+
+			expect(ticker.running).toBe(false);
+			const rendersAfterRetire = renders;
+			vi.advanceTimersByTime(5_000);
+			expect(renders).toBe(rendersAfterRetire);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});


### PR DESCRIPTION
## Problem

Live sessions intermittently freeze their TUI for minutes: the footer clock, goal elapsed/countdown, child status lines, and spinners all stop advancing while background children keep working, and any input event (esc, ctrl+l) instantly paints one fully current frame. Diagnosed live on a fleet session (omo 5.0.0-0.beta12 / senpi 2026.8.19): during a freeze the process sits at ~5% CPU parked in cvwait — the renderer is not wedged, it has simply lost every periodic `requestRender` source. pi-tui is render-on-invalidate with no standing frame loop, so when the last periodic driver dies the screen stays frozen until input forces a repaint.

## Root causes fixed

1. **Goal tickers spin dead against retired extension contexts** (`builtin/goal`).
   `GoalWaitTicker` / `GoalElapsedTicker` retain the ctx captured at `sync()`. After a session replacement or reload that ctx throws the stale-ctx error on every use — and the render callbacks in `goal/index.ts` swallowed it. Result: the interval keeps firing every second, renders nothing, forever. The footer countdown freezes at its last painted value and the session loses its 1s repaint heartbeat. The tickers now detect the stale-ctx error inside `tick()` (shared predicate in `goal/stale-context.ts`) and retire themselves; a later `sync()` with a live ctx re-arms them.

2. **`switchTuiMode()` disposes components and remounts the corpses** (`interactive-mode.ts`).
   The renderer swap moved children with `previousUi.clear()`, which *disposes* every child — clearing tool spinner intervals, reveal animations, and extension widget timers — then remounted those same disposed instances on the new renderer. They still render static frames on demand but never animate again. Now uses `detachAll()` so live components carry their intervals across the swap.

3. **`handleReloadCommand()` destroys extension UI before the reload can still be vetoed** (`interactive-mode.ts`).
   `resetExtensionUI()` ran up front; when `session.reload()` then returned `cancelled` (extension veto, e.g. running subagents) or threw, every extension footer/header/widget/hook status was already gone with nothing to restore it. The reset now lives in reload()'s `beforeSessionStart` callback, which runs only after the internal veto re-check and right before the new runner's `session_start` re-registers extension UI.

## Tests (all failing-first)

- `test/suite/goal-ticker-stale-context.test.ts` — both tickers retire on a stale-ctx tick and stop attempting renders; `MonitorAwareGoalContinuation.dispose()` stops the wait ticker (characterization).
- `test/interactive-tui.test.ts` — "switchTuiMode component lifecycle": a mounted component survives the mode switch undisposed; "handleReloadCommand extension UI lifecycle": a vetoed reload leaves extension UI untouched, a proceeding reload resets it exactly once via `beforeSessionStart`.

## Verification

- `packages/coding-agent`: full `vitest --run` green locally.
- `packages/tui`: full `npm test` (node --test) green locally, including `tui-render.test.ts` per `src/modes/interactive/AGENTS.md`.
- Typecheck: no new errors introduced (repo baseline on main currently carries pre-existing `tsc` errors in `src/server/create-harness.ts`, untouched here).

## Follow-ups (out of scope, filed as observations)

- Extension runner can emit events (`before_agent_start`, input disposition) with a stale per-extension ctx on resumed sessions — the error spam seen alongside the freezes (`prompt-url-widget`, plugin extensions). Needs a runner-level ctx refresh audit.
- `renderCurrentSessionState()` restart predicates leave quiet, already-running task children static after session resume until their next event.
- pi-tui `requestRender` can strand `renderRequested=true` when called between `stop()` and the consumer tick; harmless today (`start()` clears flags) but worth defensive hardening.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops intermittent TUI freezes by preserving periodic repaint sources. Previously, goal tickers kept ticking against stale extension contexts and mode switches/reloads killed live component intervals; the screen froze until input forced a frame. Now tickers retire on stale contexts, components survive mode switches, and reload resets extension UI only when the reload proceeds.

- Goal tickers: detect the stale extension context error and retire themselves; remove error-swallowing wrappers; `GoalWaitTicker.stop()` tolerates a stale ctx; shared predicate in `core/extensions/builtin/goal/stale-context.ts`.
- Mode switch: `switchTuiMode()` uses `detachAll()` instead of `clear()` so components keep their timers (spinners, reveals, widgets) when remounted.
- Reload: `resetExtensionUI()` runs inside `reload()`’s `beforeSessionStart`, not up front, so vetoed or failed reloads leave extension UI intact.
- Tests: `goal-ticker-stale-context.test.ts` and additions in `interactive-tui.test.ts` pin ticker retirement, component lifecycle on mode switch, and reload UI behavior.

<sup>Written for commit 1f1452eb0a63fd1858cfd4a5b924c907e1af28b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

