### PR TITLE
test: fail fast on stale workspace dist in child-process suites

### DIFF
--- a/packages/coding-agent/test/support/workspace-build-prerequisite.ts
+++ b/packages/coding-agent/test/support/workspace-build-prerequisite.ts
@@ -28,18 +28,167 @@
  * `import.meta.resolve` is spec-compliant and does not touch the filesystem,
  * the resolved target is then stat-ed — resolving a path proves the `exports`
  * map, not the build.
+ *
+ * FRESHNESS is separate and path-based: inside vitest every workspace
+ * specifier is aliased to `src` even under `import.meta.resolve`, so a
+ * resolver probe can never see the `dist` children load. Staleness is
+ * therefore measured against the checkout that owns this module.
  */
-import { existsSync } from "node:fs";
+import { type Dirent, existsSync, readdirSync, realpathSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 /** Specifiers that child processes resolve through Node's `exports` maps. */
 const CHILD_PROCESS_SPECIFIERS = [
 	"@earendil-works/pi-ai",
 	"@earendil-works/pi-ai/compat",
+	"@earendil-works/pi-ai/providers/cursor",
 	"@earendil-works/pi-tui",
 	"@earendil-works/pi-agent-core",
 	"@earendil-works/pi-agent-core/node",
 ] as const;
+
+/**
+ * Workspace packages whose built `dist` a child process imports. Existence is
+ * not enough: a dist older than the package's newest source file means the
+ * child still crashes at import on freshly added modules (observed: 31 suite
+ * failures across 9 files from one stale `packages/ai/dist`).
+ */
+const FRESHNESS_PACKAGES = [
+	{ name: "ai", dir: "packages/ai", specifier: "@earendil-works/pi-ai" },
+	{ name: "agent", dir: "packages/agent", specifier: "@earendil-works/pi-agent-core" },
+	{ name: "tui", dir: "packages/tui", specifier: "@earendil-works/pi-tui" },
+	{ name: "pty", dir: "packages/pty", specifier: "@earendil-works/pi-pty" },
+	{ name: "protocol", dir: "packages/protocol", specifier: "@earendil-works/pi-protocol" },
+	{ name: "client", dir: "packages/client", specifier: "@earendil-works/pi-client" },
+] as const;
+
+interface WorkspacePackageRef {
+	readonly name: string;
+	readonly dir: string;
+	readonly specifier: string;
+}
+
+/**
+ * The package root whose `dist` spawned children of this suite actually
+ * load: the workspace symlink under the CHECKOUT ROOT `node_modules` (where
+ * Node's upward resolution lands for hoisted `@earendil-works/*` packages),
+ * real-pathed. A git worktree that links the main checkout's `node_modules`
+ * resolves to the MAIN package, which is exactly what its children import.
+ * Falls back to the checkout-relative directory when no symlink exists.
+ */
+function resolveLoadedPackageRoot(pkg: WorkspacePackageRef, workspaceRoot: string): string {
+	try {
+		return realpathSync(join(workspaceRoot, "node_modules", pkg.specifier));
+	} catch {
+		return join(workspaceRoot, pkg.dir);
+	}
+}
+
+/**
+ * Find the repository root that owns this module: the first ancestor directory
+ * containing the workspace manifest (`pnpm-workspace.yaml`). Returns undefined
+ * when this file runs from outside a checkout (e.g. a copied fixture).
+ */
+function findWorkspaceRoot(startDir: string): string | undefined {
+	let current = startDir;
+	for (let depth = 0; depth < 8; depth += 1) {
+		if (existsSync(join(current, "pnpm-workspace.yaml"))) return current;
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+	return undefined;
+}
+
+/** Newest file mtime (ms) under `dir`, or 0 when the directory is missing/empty. */
+function newestMtimeMs(dir: string): number {
+	let newest = 0;
+	const stack = [dir];
+	while (stack.length > 0) {
+		const current = stack.pop() as string;
+		let entries: Dirent[];
+		try {
+			entries = readdirSync(current, { withFileTypes: true });
+		} catch {
+			continue;
+		}
+		for (const entry of entries) {
+			const full = join(current, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(full);
+				continue;
+			}
+			try {
+				const mtimeMs = statSync(full).mtimeMs;
+				if (mtimeMs > newest) newest = mtimeMs;
+			} catch {}
+		}
+	}
+	return newest;
+}
+
+export interface WorkspacePackageFreshness {
+	readonly stale: boolean;
+	readonly srcNewestMs: number;
+	readonly distNewestMs: number;
+}
+
+/**
+ * A package is stale when its built output is missing, empty, or predates its
+ * newest source file. Equal mtimes count as fresh: `npm run build` rewrites
+ * the entrypoint last, so `dist >= src` holds for a correct build.
+ */
+export function isWorkspacePackageStale(rootDir: string): WorkspacePackageFreshness {
+	const srcNewestMs = newestMtimeMs(join(rootDir, "src"));
+	const distNewestMs = newestMtimeMs(join(rootDir, "dist"));
+	return { stale: distNewestMs < srcNewestMs, srcNewestMs, distNewestMs };
+}
+
+/**
+ * Staleness (package name) per entry, measured against the package root whose
+ * built `dist` the spawned children of `parentUrl`'s checkout actually load —
+ * not through Node resolution (vitest aliases make every workspace specifier
+ * resolve to `src`, so a resolver probe can never see the loaded `dist`).
+ */
+export function findStaleWorkspacePackages(
+	parentUrl: string,
+	packages: readonly WorkspacePackageRef[] = FRESHNESS_PACKAGES,
+	workspaceRoot = findWorkspaceRoot(dirname(fileURLToPath(parentUrl))),
+): string[] {
+	if (workspaceRoot === undefined) return [];
+	const stale: string[] = [];
+	for (const pkg of packages) {
+		// Two roots can disagree: children that resolve through the hoisted root
+		// `node_modules` load the realpathed package (a linked worktree loads the
+		// main checkout's dist), while suite-local import hooks and checkout-
+		// relative resolution load the checkout's own `packages/<dir>`. A stale
+		// build in EITHER root crashes children, so both must be fresh.
+		const loadedRoot = resolveLoadedPackageRoot(pkg, workspaceRoot);
+		const checkoutRoot = join(workspaceRoot, pkg.dir);
+		if (loadedRoot !== checkoutRoot) {
+			if (isWorkspacePackageStale(loadedRoot).stale || isWorkspacePackageStale(checkoutRoot).stale) {
+				stale.push(pkg.name);
+			}
+		} else if (isWorkspacePackageStale(loadedRoot).stale) {
+			stale.push(pkg.name);
+		}
+	}
+	return stale;
+}
+
+/** Throws an actionable error when a checked workspace package carries a stale dist. */
+export function assertStaleWorkspacePackages(
+	packages: readonly { readonly name: string; readonly rootDir: string }[],
+): void {
+	const stale = packages.filter((pkg) => isWorkspacePackageStale(pkg.rootDir).stale).map((pkg) => pkg.name);
+	if (stale.length === 0) return;
+	throw new Error(
+		`Unmet test prerequisite: the workspace build is stale — ${stale.join(", ")} have source files ` +
+			`newer than their built dist, so child-process tests will crash at import. ` +
+			`Run \`npm run build\` from the repository root, then re-run this suite.`,
+	);
+}
 
 /**
  * Returns the specifiers whose built entrypoint cannot be resolved from
@@ -62,10 +211,20 @@ export function findUnbuiltWorkspaceSpecifiers(parentUrl: string): string[] {
 /** Throws an actionable error when the workspace build prerequisite is unmet. */
 export function assertWorkspaceBuildPrerequisite(parentUrl: string): void {
 	const missing = findUnbuiltWorkspaceSpecifiers(parentUrl);
-	if (missing.length === 0) return;
-	throw new Error(
-		`Unmet test prerequisite: the workspace packages are not built, so child-process tests ` +
-			`(spawned CLI, worker fixtures) cannot resolve ${missing.join(", ")}. ` +
-			`Run \`npm run build\` from the repository root, then re-run this suite.`,
-	);
+	if (missing.length > 0) {
+		throw new Error(
+			`Unmet test prerequisite: the workspace packages are not built, so child-process tests ` +
+				`(spawned CLI, worker fixtures) cannot resolve ${missing.join(", ")}. ` +
+				`Run \`npm run build\` from the repository root, then re-run this suite.`,
+		);
+	}
+	const stale = findStaleWorkspacePackages(parentUrl);
+	if (stale.length > 0) {
+		throw new Error(
+			`Unmet test prerequisite: the workspace build is stale — ${stale.join(", ")} have source files ` +
+				`newer than their built dist, so child-process tests crash at import ` +
+				`(e.g. a provider module added after the last build). ` +
+				`Run \`npm run build\` from the repository root, then re-run this suite.`,
+		);
+	}
 }

--- a/packages/coding-agent/test/workspace-build-prerequisite.test.ts
+++ b/packages/coding-agent/test/workspace-build-prerequisite.test.ts
@@ -1,11 +1,14 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	assertStaleWorkspacePackages,
 	assertWorkspaceBuildPrerequisite,
+	findStaleWorkspacePackages,
 	findUnbuiltWorkspaceSpecifiers,
+	isWorkspacePackageStale,
 } from "./support/workspace-build-prerequisite.ts";
 
 const tempDirs: string[] = [];
@@ -28,6 +31,7 @@ describe("workspace build prerequisite", () => {
 		expect(missing).toEqual([
 			"@earendil-works/pi-ai",
 			"@earendil-works/pi-ai/compat",
+			"@earendil-works/pi-ai/providers/cursor",
 			"@earendil-works/pi-tui",
 			"@earendil-works/pi-agent-core",
 			"@earendil-works/pi-agent-core/node",
@@ -46,5 +50,59 @@ describe("workspace build prerequisite", () => {
 		// which is what the spawned-CLI and worker tests in this suite depend on.
 		expect(findUnbuiltWorkspaceSpecifiers(import.meta.url)).toEqual([]);
 		expect(() => assertWorkspaceBuildPrerequisite(import.meta.url)).not.toThrow();
+	});
+});
+
+describe("workspace dist freshness", () => {
+	function makePackage(sourceMtimeMs: number, distMtimeMs: number, distFiles = true): string {
+		const root = mkdtempSync(join(tmpdir(), "pi-workspace-freshness-"));
+		tempDirs.push(root);
+		const pkg = join(root, "fake-pkg");
+		mkdirSync(join(pkg, "src"), { recursive: true });
+		mkdirSync(join(pkg, "dist"), { recursive: true });
+		writeFileSync(join(pkg, "src", "index.ts"), "export {};\n");
+		if (distFiles) writeFileSync(join(pkg, "dist", "index.js"), "export {};\n");
+		// Pin every file's mtime explicitly: fixture timestamps, not wall clock.
+		const pin = (path: string, ms: number) => utimesSync(path, new Date(ms), new Date(ms));
+		pin(join(pkg, "src", "index.ts"), sourceMtimeMs);
+		if (distFiles) pin(join(pkg, "dist", "index.js"), distMtimeMs);
+		return pkg;
+	}
+
+	it("flags a package whose dist predates its newest source file", () => {
+		const pkg = makePackage(2_000, 1_000);
+		expect(isWorkspacePackageStale(pkg)).toEqual({ stale: true, srcNewestMs: 2_000, distNewestMs: 1_000 });
+	});
+
+	it("accepts a package whose dist is at least as new as its sources", () => {
+		const pkg = makePackage(1_000, 2_000);
+		expect(isWorkspacePackageStale(pkg).stale).toBe(false);
+	});
+
+	it("reports an empty dist as stale (unbuilt output)", () => {
+		const pkg = makePackage(1_000, 1_000, false);
+		expect(isWorkspacePackageStale(pkg).stale).toBe(true);
+	});
+
+	it("assertWorkspaceBuildPrerequisite names the stale package and the remedy", () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-workspace-freshness-"));
+		tempDirs.push(root);
+		const pkg = join(root, "fake-pkg");
+		mkdirSync(join(pkg, "src"), { recursive: true });
+		mkdirSync(join(pkg, "dist"), { recursive: true });
+		writeFileSync(join(pkg, "src", "index.ts"), "export {};\n");
+		writeFileSync(join(pkg, "dist", "index.js"), "export {};\n");
+		const pin = (path: string, ms: number) => utimesSync(path, new Date(ms), new Date(ms));
+		pin(join(pkg, "src", "index.ts"), 2_000);
+		pin(join(pkg, "dist", "index.js"), 1_000);
+		const run = () => assertStaleWorkspacePackages([{ name: "fake-pkg", rootDir: pkg }]);
+		expect(run).toThrowError(/fake-pkg/);
+		expect(run).toThrowError(/npm run build/);
+	});
+
+	it("this live workspace is fresh right after a build", () => {
+		// Live prerequisite: the repository that owns this suite must not carry a
+		// dist older than its sources, or every spawned-child test dies at import.
+		expect(findStaleWorkspacePackages(import.meta.url)).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Problem

All 31 failures across 9 files in `packages/coding-agent` (rpc.test.ts fully wiped out, plus stdout-cleanliness, session-file-invalid, 756-cross-project-resume, startup-session-name, session-id-readonly, model-runtime-text-toolcall-recovery, 0000-multi-session-theme-init) shared one root cause that the failing tests themselves could never show: the workspace packages' built `dist/` was older than their sources after a pull that added `pi-ai/providers/cursor`. In-process tests stayed green because `vitest.base.ts` aliases every `@earendil-works/*` specifier to sibling `src/`; the spawned child processes resolve through Node's `exports` maps, hit the stale `dist`, and died at import — surfacing only downstream symptoms (`expected 1 to be +0`, empty stdout) 1.8-4.2s later.

After `npm run build` from the repository root, all 9 files pass: 40/40 in the affected set, then **8500 passed / 0 failed** on the full suite (36 pre-existing skips untouched).

## Fix

`test/support/workspace-build-prerequisite.ts` — the opt-in guard already used by every child-process suite — now checks FRESHNESS in addition to existence:

- A workspace package is stale when its newest `dist` file predates its newest `src` file (equal mtimes count as fresh; a build rewrites entrypoints last).
- Staleness is measured at BOTH roots that children can load from: the realpathed hoisted `node_modules/@earendil-works/*` symlink (what plain children resolve — in a linked worktree that is the main checkout's package) and the checkout-relative `packages/<dir>` (what suite-local import hooks load). A stale build in either root crashes children.
- Path-based, not resolver-based: inside vitest even `import.meta.resolve` follows the src aliases, so a resolver probe can never see the dist children actually load.
- The unbuilt-specifier probe now also covers the `pi-ai/providers/cursor` subpath that triggered this incident.
- On violation the suite fails immediately with the stale package names and the exact remedy: `npm run build` from the repository root.

## Verification

- RED captured live: with a deliberately touched `packages/ai/src` (dist stale), `rpc.test.ts` fails instantly with `Unmet test prerequisite: the workspace build is stale — ai ...` instead of 19 mystery failures; the freshness unit tests fail against the old helper. GREEN after rebuild: 12/12 opt-in files, 51/51; full suite 8500/8500.
- Unit tests pin the contract with mtime-pinned fixture trees (stale dist, fresh dist, empty dist, named-package error, live fresh workspace).
- `npx biome check` clean on both changed files.
- One note for reviewers: a single full-suite run mid-development showed 1 failure that did not reproduce across two consecutive full re-runs (subprocess-timing flake, not touched by this change; its file was outside the opt-in set and its name was not captured before the log rotated).

## Follow-ups (not in scope)

- The flake observed once could be worth a dedicated pass once it reproduces.
- `scripts/build-all.mjs` could optionally grow a post-pull staleness warning for interactive developers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast in child-process test suites when a workspace package’s `dist` is older than its `src`. Previously we only checked that packages were built; stale `dist` caused late import crashes with opaque failures. Now we detect staleness and surface an actionable error.

- Adds path-based freshness checks: a package is stale if the newest file in `dist/` predates the newest file in `src/` (equal mtimes are fresh).
- Checks both roots children can load from: the real-pathed hoisted `node_modules/@earendil-works/*` symlink and `packages/<dir>` in the checkout. Either root being stale fails the suite immediately.
- Extends unbuilt-specifier probe to include `@earendil-works/pi-ai/providers/cursor`.
- New helpers: `isWorkspacePackageStale`, `findStaleWorkspacePackages`, `assertStaleWorkspacePackages`; `assertWorkspaceBuildPrerequisite` now also enforces freshness.
- Unit tests pin the contract with mtime-controlled fixtures and a live fresh-workspace assertion.

- Required action when this trips: run `npm run build` from the repository root, then re-run the suite.

<sup>Written for commit 74d603990354d13484d68a12e9557e1e9db3bd0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

