### PR TITLE
perf(coding-agent): enable Node module compile cache for CLI startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -22,6 +22,13 @@
   and package-update notifications, the risky-main-model and high-reasoning warnings, the rules banner,
   the prompt URL widget card, and the earendil announcement. Visible text is unchanged.
 
+- Startup is faster after the first run: the CLI now enables Node's on-disk module compile cache
+  (`enableCompileCache()`) in both `cli.ts` and `cli-main.ts` and publishes the resolved cache directory
+  through `NODE_COMPILE_CACHE` so the spawned `cli-main` child process reuses it instead of re-compiling
+  the full engine module graph on every launch. An existing `NODE_COMPILE_CACHE` value is never overridden,
+  `NODE_DISABLE_COMPILE_CACHE=1` keeps the cache off, and runtimes without the API (the compiled binary)
+  degrade to plain compilation.
+
 ### Fixed
 
 ### Removed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -33,6 +33,49 @@
 - `packages/coding-agent/src/core/compaction/compaction.ts`
 - `packages/coding-agent/src/core/agent-session.ts` `_resolveThresholdContextTokens`
 
+## Node module compile cache for CLI startup (2026-08-20)
+
+### What changed
+
+- `packages/coding-agent/src/compile-cache.ts` (new, fork-only): `enableStartupCompileCache()` enables
+  Node's on-disk V8 module compile cache and publishes the resolved BASE cache directory into
+  `process.env.NODE_COMPILE_CACHE` so child processes inherit the same cache. Node's programmatic
+  `enableCompileCache()` does not export that variable itself, and the value published must be the base
+  directory (not `getCompileCacheDir()`, which already contains Node's versioned segment — handing it
+  back double-nests the child's cache and it misses every parent entry). The API is read off the
+  `node:module` namespace rather than imported by name: a named import of a missing export is a
+  link-time `SyntaxError` no runtime guard can catch, and the bun-compiled binary runs this file.
+- `packages/coding-agent/src/cli.ts` calls it as the first statement after imports (after the existing
+  `valid-cwd.ts` first-import guard): `cli.ts` spawns `cli-main` as a child, and that child loads the
+  full engine graph, so inheritance is what makes the cache reach the process that pays the compile cost.
+- `packages/coding-agent/src/cli-main.ts` calls it first as well, so direct `cli-main` invocations (the
+  bun binary, tests) benefit when no launcher published a directory; when one did, the call keeps the
+  existing value.
+- Guards: never overrides a pre-set `NODE_COMPILE_CACHE`; `NODE_DISABLE_COMPILE_CACHE=1` stays honored
+  (the call is skipped or Node reports failure and nothing is published); any failure degrades to plain
+  compilation instead of failing startup.
+
+### Why
+
+- Cold profiling attributes roughly a quarter of CLI boot CPU to V8 compiling the ~800ms module graph;
+- with the cache warm, repeated launches skip that compilation. Measured on this fork's built dist
+  (Apple M4 Pro, node v26.7.0): `cli-main --help` user CPU -11% to -14%, net user+sys -3% (the cache
+  read IO eats part of the compile saving; wall-clock gains appear on an otherwise idle machine).
+- The first launch after enabling still compiles and writes the cache (cache population), so this is a
+  warm-start optimization only.
+
+### Why an extension could not handle it
+
+- The cache must be enabled before the engine's module graph starts loading, and `NODE_COMPILE_CACHE`
+  must be in the environment before `cli.ts` spawns the `cli-main` child — both happen in the
+  entrypoints, before the extension loader exists.
+
+### Expected merge conflict zones
+
+- LOW: the first-statement call and its import in `cli.ts` and `cli-main.ts` (upstream may reshuffle
+  entrypoint imports; the `valid-cwd.ts` first-import ordering is pinned by test and must stay first).
+  `compile-cache.ts` is fork-only with no upstream counterpart.
+
 ## Entry surface and CLI coordinator re-diverge from upstream 59a71b23 (2026-08-19)
 
 ### What changed

--- a/packages/coding-agent/src/cli-main.ts
+++ b/packages/coding-agent/src/cli-main.ts
@@ -1,10 +1,15 @@
 #!/usr/bin/env node
 import "./valid-cwd.ts";
+import { enableStartupCompileCache } from "./compile-cache.ts";
 import { APP_NAME } from "./config.ts";
 import { scrubBrandFromEnvironment } from "./core/brand.ts";
 import { configureHttpDispatcher } from "./core/http-dispatcher.ts";
 import { installEarlyInspectorVmImportRecovery } from "./inspector-policy.ts";
 import { main } from "./main.ts";
+
+// A direct `cli-main` invocation (the bun binary, `--inspect` runs, tests) has no launcher parent to
+// inherit the cache from. Enabling it here is a no-op when cli.ts already published the directory.
+enableStartupCompileCache();
 
 // Must precede the asynchronous bootstrap: with --inspect-brk, the recoverable Inspector
 // import rejection can fire before interactive mode registers its own crash handler.

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -4,9 +4,14 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { enableStartupCompileCache } from "./compile-cache.ts";
 import { APP_NAME, DISPLAY_VERSION, getPackageDir } from "./config.ts";
 import { releaseInheritedInspectorForChild } from "./inspector-policy.ts";
 import { handleBootstrapSelfUpdate } from "./self-update-bootstrap.ts";
+
+// Publishes NODE_COMPILE_CACHE so the cli-main child below inherits this process's cache directory;
+// that child loads the full engine graph, so it is where the skipped compilation actually pays off.
+enableStartupCompileCache();
 
 process.title = APP_NAME;
 process.env.PI_CODING_AGENT = "true";

--- a/packages/coding-agent/src/compile-cache.ts
+++ b/packages/coding-agent/src/compile-cache.ts
@@ -1,0 +1,32 @@
+import * as nodeModule from "node:module";
+
+// Enabling the on-disk V8 code cache trades a little startup IO for skipped compilation of the
+// CLI's large module graph. Node does not export NODE_COMPILE_CACHE into process.env when the
+// programmatic API turns the cache on, so a spawned child would otherwise resolve its own cache
+// directory and re-pay the compile cost. `cli.ts` runs the real engine as a child process, so
+// publishing the directory is what makes the cache reach the process that actually loads the graph.
+//
+// The value published must be the BASE directory reported by enableCompileCache(), not
+// getCompileCacheDir(): the latter already includes Node's <version>-<arch>-<hash>-<uid> segment,
+// and handing it back through the environment makes the child nest a second segment inside it,
+// so it would miss every entry the parent wrote.
+//
+// The API is read off the namespace rather than imported by name on purpose: a named import of an
+// export the runtime does not provide is a link-time SyntaxError, which no runtime guard can catch.
+// The bun-compiled binary (dist/pi) runs this file, so the lookup has to stay late-bound.
+export function enableStartupCompileCache(): void {
+	const enable = (nodeModule as Partial<typeof nodeModule>).enableCompileCache;
+	if (typeof enable !== "function") {
+		return;
+	}
+	// A cache directory that cannot be created (read-only or sandboxed HOME/TMPDIR) must not break
+	// startup: the cache is an optimization, so every failure degrades to plain compilation.
+	try {
+		const result = enable();
+		if (result.directory !== undefined && process.env.NODE_COMPILE_CACHE === undefined) {
+			process.env.NODE_COMPILE_CACHE = result.directory;
+		}
+	} catch {
+		// Startup must never fail because the code cache is unavailable.
+	}
+}

--- a/packages/coding-agent/test/compile-cache.test.ts
+++ b/packages/coding-agent/test/compile-cache.test.ts
@@ -1,0 +1,160 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+/**
+ * The CLI pays a V8 compile cost for its whole module graph on every launch, and `cli.ts` spawns
+ * `cli-main.js` as a child process, so the child re-pays it too. `enableStartupCompileCache()`
+ * turns on Node's on-disk code cache and — because Node does NOT export `NODE_COMPILE_CACHE`
+ * into `process.env` itself — publishes the resolved base directory so spawned children inherit
+ * the same cache instead of writing their own.
+ *
+ * These tests drive the real seam through child processes: the cache directory is an observable
+ * artifact, so they assert on it rather than on how the module calls Node.
+ */
+
+const MODULE_PATH = resolve(__dirname, "..", "src", "compile-cache.ts");
+
+// Loads the seam, then reports what a spawned child would inherit plus the effective cache dir.
+const driverSource = `import { getCompileCacheDir } from "node:module";
+const { enableStartupCompileCache } = await import(process.env.MODULE_URL);
+enableStartupCompileCache();
+// Compile something after the call: ESM static imports are hoisted, so only modules loaded
+// after enablement can populate the cache.
+await import(process.env.PAYLOAD_URL);
+console.log(JSON.stringify({
+	inherited: process.env.NODE_COMPILE_CACHE ?? null,
+	effective: getCompileCacheDir() ?? null,
+}));
+`;
+
+const payloadSource = `export const value = ${JSON.stringify("x".repeat(2048))}.length;\n`;
+
+let hostDir: string;
+
+function runDriver(env: NodeJS.ProcessEnv): { status: number | null; stdout: string; stderr: string } {
+	const driver = join(hostDir, "driver.mjs");
+	const payload = join(hostDir, "payload.mjs");
+	writeFileSync(driver, driverSource);
+	writeFileSync(payload, payloadSource);
+	const result = spawnSync(process.execPath, [driver], {
+		encoding: "utf8",
+		env: { ...process.env, MODULE_URL: MODULE_PATH, PAYLOAD_URL: payload, ...env },
+	});
+	return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+function parseReport(stdout: string): { inherited: string | null; effective: string | null } {
+	const line = stdout.trim().split("\n").at(-1) ?? "";
+	return JSON.parse(line) as { inherited: string | null; effective: string | null };
+}
+
+function cacheFileCount(dir: string): number {
+	if (!existsSync(dir)) {
+		return 0;
+	}
+	// Node nests entries under a <version>-<arch>-<hash>-<uid> subdirectory.
+	return readdirSync(dir, { recursive: true, withFileTypes: true }).filter((entry) => entry.isFile()).length;
+}
+
+beforeEach(() => {
+	hostDir = mkdtempSync(join(tmpdir(), "senpi-compile-cache-"));
+});
+
+afterEach(() => {
+	rmSync(hostDir, { recursive: true, force: true });
+});
+
+describe("startup compile cache", () => {
+	describe("#given a fresh cache directory", () => {
+		test("#when the seam runs #then it populates the cache and children inherit that exact directory", () => {
+			const cacheDir = join(hostDir, "cache");
+
+			const first = runDriver({ NODE_COMPILE_CACHE: cacheDir });
+
+			expect(first.status, first.stderr).toBe(0);
+			expect(cacheFileCount(cacheDir)).toBeGreaterThan(0);
+
+			const report = parseReport(first.stdout);
+			// A child must receive the base directory, not the versioned subdirectory: passing the
+			// latter makes Node nest a second version segment inside it and miss the parent's entries.
+			expect(report.inherited).toBe(cacheDir);
+			expect(report.effective?.startsWith(cacheDir)).toBe(true);
+		});
+
+		test("#when no cache directory is configured #then the seam still publishes an inheritable default", () => {
+			const result = runDriver({ NODE_COMPILE_CACHE: undefined });
+
+			expect(result.status, result.stderr).toBe(0);
+			const report = parseReport(result.stdout);
+			expect(report.inherited).not.toBeNull();
+			expect(report.effective?.startsWith(report.inherited ?? "\u0000")).toBe(true);
+		});
+	});
+
+	describe("#given a caller that already chose a cache directory", () => {
+		test("#when NODE_COMPILE_CACHE is preset #then the seam keeps it instead of overriding", () => {
+			const preset = join(hostDir, "preset");
+
+			const result = runDriver({ NODE_COMPILE_CACHE: preset });
+
+			expect(result.status, result.stderr).toBe(0);
+			expect(parseReport(result.stdout).inherited).toBe(preset);
+		});
+	});
+
+	describe("#given the cache is disabled", () => {
+		test("#when NODE_DISABLE_COMPILE_CACHE=1 #then the seam does not throw and writes nothing", () => {
+			const cacheDir = join(hostDir, "disabled-cache");
+
+			const result = runDriver({ NODE_DISABLE_COMPILE_CACHE: "1", NODE_COMPILE_CACHE: cacheDir });
+
+			expect(result.status, result.stderr).toBe(0);
+			expect(cacheFileCount(cacheDir)).toBe(0);
+		});
+	});
+
+	describe("#given a runtime whose compile-cache API is missing or inert (the bun-compiled binary)", () => {
+		test("#when the seam runs under a stubbed-out node:module #then it neither throws nor publishes a directory", () => {
+			const probe = join(hostDir, "probe.mjs");
+			// A loader hook replaces node:module wholesale, so the seam's own static import binding
+			// resolves to a namespace with no enableCompileCache - the shape dist/pi runs under.
+			const hooks = join(hostDir, "hooks.mjs");
+			writeFileSync(
+				hooks,
+				`export async function resolve(specifier, context, next) {
+	if (specifier === "node:module") {
+		return { url: "stub:module", shortCircuit: true };
+	}
+	return next(specifier, context);
+}
+export async function load(url, context, next) {
+	if (url === "stub:module") {
+		return { format: "module", shortCircuit: true, source: "export const syncBuiltinESMExports = () => {};" };
+	}
+	return next(url, context);
+}
+`,
+			);
+			writeFileSync(
+				probe,
+				`import { register } from "node:module";
+import { pathToFileURL } from "node:url";
+register(pathToFileURL(process.env.HOOKS_PATH));
+const { enableStartupCompileCache } = await import(process.env.MODULE_URL);
+enableStartupCompileCache();
+console.log("SURVIVED " + JSON.stringify(process.env.NODE_COMPILE_CACHE ?? null));
+`,
+			);
+			const result = spawnSync(process.execPath, [probe], {
+				encoding: "utf8",
+				env: { ...process.env, MODULE_URL: MODULE_PATH, HOOKS_PATH: hooks, NODE_COMPILE_CACHE: undefined },
+			});
+
+			expect(result.status, result.stderr).toBe(0);
+			expect(result.stdout).toContain("SURVIVED null");
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Enable Node's on-disk module compile cache (`module.enableCompileCache()`) for the CLI so the ~most expensive part of startup — V8 compilation of the full engine module graph — is paid once and reused across launches.

- New `src/compile-cache.ts`: late-bound `enableCompileCache` lookup (link-safe for the bun-compiled binary), fail-open `try/catch` (read-only/sandboxed cache dirs degrade to plain compilation), and explicit publication of the resolved **base** cache directory into `NODE_COMPILE_CACHE` — Node does not export it itself, and without it the `cli.ts → cli-main.js` child (which loads the actual engine graph) would resolve its own directory and re-pay compilation. Publishing `getCompileCacheDir()` instead would double-nest the version segment and miss every parent-written entry.
- Wired as the first executed statement in both `cli.ts` and `cli-main.ts`.
- An existing `NODE_COMPILE_CACHE` is never overridden; `NODE_DISABLE_COMPILE_CACHE=1` keeps everything off; runtimes without the API are a no-op.

Zero behavior change: the cache is a pure optimization with documented opt-out.

## Measurements

Machine: Apple M4 Pro (14c), macOS 26.4.1, Node v26.7.0. hyperfine `--warmup 3 --runs 10`, built dist in this worktree. "Pre-change equiv" = `NODE_DISABLE_COMPILE_CACHE=1` (exact pre-change behavior: the diff is env-only). Captured under loadavg ~12-14 (parallel CI lanes on the host) — wall-clock σ inflated; user-CPU is the load-invariant signal.

| Scenario | pre-change | post (warm cache) | Δ wall | Δ user CPU |
|---|---|---|---|---|
| `node dist/cli-main.js --help` | 1.100 s ± 0.043 | **1.016 s ± 0.043** | **−7.6%** | 1.129 → 0.947 s (**−16%**) |
| `node dist/cli.js --help` (full 2-proc chain) | 1.280 s ± 0.070 | 1.251 s ± 0.121 | −2.3% (noisy) | 1.288 → 1.105 s (**−14%**) |

- Quiet-machine reference (same methodology, earlier investigation on this host, load < 2): `cli-main --help` 1.077 s → 0.878 s (**−18%**) with a warm `NODE_COMPILE_CACHE`.
- Cold-cache first run (fresh dir, 3 reps): ~1.94–1.99 s vs ~1.28 s disabled — a **one-time ~0.7 s write cost** on the very first launch (and after a Node version change), amortized immediately; cache size ~29 MB (`v26.7.0-arm64-*/…`).

## Verification

- `test/compile-cache.test.ts` (new, 5 tests): drives the real seam via child processes — cache dir populated after enablement, child-inheritable env published (base dir, no double nesting), no override of a pre-set `NODE_COMPILE_CACHE`, `NODE_DISABLE_COMPILE_CACHE=1` and missing-API paths stay silent no-ops.
- `npm run check` green; entry-adjacent suites (`self-update-bootstrap`, `valid-cwd-guard`, `brand`) green.
- CHANGELOG `[Unreleased]` entry + `src/changes.md` tracker entry (upstream-owned `cli.ts`/`cli-main.ts`) included; changelog gate passes locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up CLI warm starts by enabling Node’s on-disk module compile cache. Previously each launch recompiled the engine module graph; now we enable the cache early and publish the base cache directory so the spawned `cli-main` reuses it. Behavior is unchanged; opt out with `NODE_DISABLE_COMPILE_CACHE=1`.

- New `packages/coding-agent/src/compile-cache.ts`: `enableStartupCompileCache()` late-binds `node:module.enableCompileCache()`, fails open, and sets `process.env.NODE_COMPILE_CACHE` to the returned base directory when unset (not `getCompileCacheDir()` to avoid double nesting).
- Called as the first executed statement in `packages/coding-agent/src/cli.ts` and `packages/coding-agent/src/cli-main.ts`; keeps `valid-cwd.ts` as the first import. Does not override an existing `NODE_COMPILE_CACHE`; runtimes without the API are a no-op.
- Tests in `packages/coding-agent/test/compile-cache.test.ts` cover cache population, child inheritance, env override rules, disabled cache, and missing-API behavior.
- Rollout: no migration. First run writes the cache once; subsequent runs reduce user CPU by ~10–18%.

<sup>Written for commit 408b222c101ee9386375a1cae643643832097f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

