### PR TITLE
perf(config-reload): keep hot reload off the FSEvents teardown path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Retry waits no longer animate decorative spinner frames at the default 80 ms cadence for sessions with at least 1,000 persisted entries, while the one-second countdown and small-session animation remain intact.
+- Hot reload no longer stalls on filesystem watcher teardown: recursive config watchers now run in a worker thread on macOS as well as Linux, and the watch engine tears down its subscriptions off the reload critical path (measured 1.5-62s of `session_shutdown` stall eliminated). MCP server reconnect during a hot reload no longer blocks the reload either (startup behavior unchanged).
 - Settings hot-reload no longer cascades across sessions that share an agent directory when another session saves a routine preference such as `defaultModel` during a reload. The replacement watcher now compares reload-window changes with the request-time settings snapshot, so routine-only writes remain suppressed while substantive configuration edits still reload.
 - Settings hot-reload now clears the reload handoff unconditionally after `requestReload()` settles, preventing a stale plaintext settings snapshot from surviving when the reload successor omits the config-reload builtin.
 - Compaction no longer treats implausible Cursor billed usage as context size: when the local transcript estimate is at least 50k and billed usage is more than 8× that estimate, the threshold uses the estimate so a multi-million dashboard-cumulative cacheRead cannot force a useless compact (#983).

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -108,3 +108,24 @@
 ### Expected merge conflict zones
 
 - LOW: `index.ts` `registrationHasRestrictedTarget` and the new `isSafeFilteredAgentDirTarget`; LOW in `config-reload-extension.test.ts`.
+
+## Off-main-thread recursive watchers on macOS and non-blocking teardown (2026-08-20)
+
+### What changed
+
+- `watch-event-source.ts` routes recursive watches through the existing worker thread on `darwin` as well as `linux` (`WORKER_OFFLOADED_RECURSIVE_PLATFORMS`); creation and teardown of recursive `fs.watch` handles no longer run on the interactive main thread on macOS. Non-recursive watches are unchanged.
+- `ConfigReloadWatchEngine.close()` now returns `Promise<void>`: it flips the `#closed` dispatch guard and clears the debounce timer synchronously, then drains the unsubscribe loop on a 0ms clock tick. `closeWatchers()` in `index.ts` fires that teardown without awaiting it, logging failures via the existing `watcher_error` logger shape.
+
+### Why
+
+- Hot reload awaits this extension's `session_shutdown` handler. On macOS each recursive `FSWatcher.close()` is an FSEvents stream teardown that blocks the calling thread — measured 5.2-13.9s per watcher on a loaded M4 Pro (44.8-62.8s for 8 watchers; ~150-200ms each idle), making `/reload` and config-watch reloads stall for seconds to a minute. The engine is inert the moment `#closed` flips, so nothing on the reload path needs teardown completion.
+
+### Why an extension could not handle it
+
+- The watch engine, its event source, and the `session_shutdown` ordering are all internal to this builtin; no external extension can change how the host awaits the shutdown handler or where `fs.watch` handles are created.
+
+### Expected merge conflict zones
+
+- MEDIUM: `watch-engine.ts` `close()` signature (`void` -> `Promise<void>`) and any upstream callers that await or type it.
+- LOW: `watch-event-source.ts` platform gate; `index.ts` `closeWatchers`.
+- LOW: `config-reload-extension.test.ts` (macOS offload block appended; two teardown-timing assertions restated as behavior assertions) and the new `config-reload-lazy-teardown.test.ts`.

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -181,8 +181,12 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 	const vetoDeferral = new ReloadVetoDeferral();
 	let changeChain: Promise<void> = Promise.resolve();
 
+	// The engine goes inert the moment close() is called; its unsubscribe loop can
+	// take seconds per watcher, and session_shutdown is awaited by the reload flow.
 	const closeWatchers = (): void => {
-		engine?.close();
+		engine?.close().catch((error: unknown) => {
+			logger.error("watcher_error", { path: "watcher teardown", message: errorMessage(error) });
+		});
 		engine = undefined;
 		activeTargets = [];
 	};

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-engine.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-engine.ts
@@ -112,22 +112,35 @@ export class ConfigReloadWatchEngine {
 		}
 	}
 
-	close(): void {
+	/**
+	 * Marks the engine inert synchronously, then drains the unsubscribe loop off
+	 * the caller's stack. A single `fs.watch` unsubscribe can block for seconds on
+	 * a loaded machine, and a reload awaits this call; every dispatch path already
+	 * checks `#closed`, so the still-attached subscriptions are silent while the
+	 * returned promise settles. Await it only to observe teardown completion.
+	 */
+	close(): Promise<void> {
 		if (this.#closed) {
-			return;
+			return Promise.resolve();
 		}
 		this.#closed = true;
 		if (this.#timer) {
 			this.#clock.clearTimeout(this.#timer);
 			this.#timer = undefined;
 		}
-		for (const unsubscribe of this.#unsubscribes.splice(0)) {
-			try {
-				unsubscribe();
-			} catch (error) {
-				this.#reportError(error, "watch subscription");
-			}
-		}
+		const unsubscribes = this.#unsubscribes.splice(0);
+		return new Promise<void>((settle) => {
+			this.#clock.setTimeout(() => {
+				for (const unsubscribe of unsubscribes) {
+					try {
+						unsubscribe();
+					} catch (error) {
+						this.#reportError(error, "watch subscription");
+					}
+				}
+				settle();
+			}, 0);
+		});
 	}
 
 	getBaselineSnapshot(): ReadonlyMap<string, string> {

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
@@ -84,7 +84,13 @@ function isRecursiveWatchMessage(message: unknown): message is RecursiveWatchMes
 	);
 }
 
-/** Production event source. Linux recursive setup runs off the interactive main thread. */
+/**
+ * Platforms whose recursive fs.watch handles are expensive to create and tear down on the
+ * interactive main thread: inotify tree walks on Linux, FSEvents stream teardown on macOS.
+ */
+const WORKER_OFFLOADED_RECURSIVE_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["linux", "darwin"]);
+
+/** Production event source. Recursive setup and teardown run off the interactive main thread. */
 export function createFsWatchEventSource(
 	onError: (error: unknown, path: string) => void = () => {},
 	options: FsWatchEventSourceOptions = {},
@@ -114,7 +120,7 @@ export function createFsWatchEventSource(
 	};
 
 	return (path, listener, watchOptions) => {
-		if ((options.platform ?? process.platform) === "linux" && watchOptions?.recursive) {
+		if (WORKER_OFFLOADED_RECURSIVE_PLATFORMS.has(options.platform ?? process.platform) && watchOptions?.recursive) {
 			const id = nextSubscriptionId++;
 			const worker = ensureRecursiveWorker();
 			recursiveSubscriptions.set(id, { path, listener });

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/changes.md
@@ -540,3 +540,21 @@ loader's auto-activation of newly registered tools.
   `@modelcontextprotocol/sdk` dependency.
 - NONE for `extensions/types.ts` (untouched); `builtin/mcp/` itself does not
   exist upstream.
+
+## Non-blocking reconnect on hot reload (2026-08-20)
+
+### What changed
+
+- The `session_start` handler still starts `attach()` immediately, but when `event.reason === "reload"` it no longer awaits it; errors keep flowing through `wrapAsync` -> the extension error sink. `startup`/omitted reasons await exactly as before.
+
+### Why
+
+- Hot reload awaits every `session_start` handler; MCP reconnect measured ~260ms per reload on the critical path. Attach is single-flight (`attachPromise` + `McpService` attach queue) and `before_agent_start` already awaits `attachPromise`, so tools are still connected before any agent turn needs them.
+
+### Why an extension could not handle it
+
+- The handler lives in this builtin; only it can decide not to await its own reconnect.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` `session_start` registration block; new `test/suite/mcp-reload-deferral.test.ts`.

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/index.ts
@@ -120,10 +120,22 @@ export function createMcpExtension(service: McpService, sessionOwned = true): Ex
 			})();
 			return attachPromise;
 		};
-		pi.on(
-			"session_start",
-			wrapAsync("mcp.session_start", (event, ctx) => attach(event, ctx), sink),
+		const onSessionStart = wrapAsync(
+			"mcp.session_start",
+			(event: SessionStartEvent, ctx: ExtensionContext) => attach(event, ctx),
+			sink,
 		);
+		pi.on("session_start", (event, ctx) => {
+			const work = onSessionStart(event, ctx);
+			// Reload's runner.emit("session_start") is on the hot-reload critical path
+			// (~260ms when this awaits reconnect). Attach is already single-flight via
+			// attachPromise + service.#attachQueue; before_agent_start awaits it.
+			if (event.reason === "reload") {
+				void work;
+				return;
+			}
+			return work;
+		});
 		pi.on("before_agent_start", async (event, ctx) => {
 			try {
 				// Elicitation (todo 41): point mid-call forms at this session's UI.

--- a/packages/coding-agent/test/config-reload-watch-engine.test.ts
+++ b/packages/coding-agent/test/config-reload-watch-engine.test.ts
@@ -327,10 +327,12 @@ describe("config reload watch engine", () => {
 		mocks.fsWatch.mockClear();
 		createEngine({
 			targets: [{ id: "settings", kind: "dir-recursive", path: tempDir, allowList: ["settings.json"] }],
-			// Pin the direct fs.watch backend: on Linux the production source routes
-			// recursive watches through a worker thread (issue #477), which is covered
-			// by test/suite/regressions/477-recursive-watch-main-thread-stall.test.ts.
-			subscribe: createFsWatchEventSource(undefined, { platform: "darwin" }),
+			// Pin the direct fs.watch backend: on Linux (issue #477) and macOS
+			// (FSEvents teardown stalls) the production source routes recursive
+			// watches through a worker thread, covered by
+			// test/suite/regressions/477-recursive-watch-main-thread-stall.test.ts and
+			// the macOS offload block in test/suite/config-reload-extension.test.ts.
+			subscribe: createFsWatchEventSource(undefined, { platform: "win32" }),
 			onRealChange: (change) => {
 				if (change.changedPaths.includes(settingsPath)) resolveSettingsChange?.(change);
 			},

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -17,7 +18,10 @@ import {
 	CONFIG_WATCH_REJECTED,
 	CONFIG_WATCH_RELOADED,
 } from "../../src/core/extensions/builtin/config-reload/protocol.ts";
-import type { WatchEventListener } from "../../src/core/extensions/builtin/config-reload/watch-engine.ts";
+import {
+	createFsWatchEventSource,
+	type WatchEventListener,
+} from "../../src/core/extensions/builtin/config-reload/watch-engine.ts";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
 import type {
 	ExtensionAPI,
@@ -625,7 +629,8 @@ describe("config reload builtin extension", () => {
 			{ type: "session_shutdown", reason: "reload" } satisfies SessionShutdownEvent,
 			firstContext,
 		);
-		expect(watches.activeListenerCount(agentDir)).toBe(0);
+		// Teardown is deferred, so the shutdown watcher may still be attached; the
+		// contract is that the closed extension no longer registers new watchers.
 		bus.emit(CONFIG_WATCH_REGISTER, {
 			id: "old-listener",
 			displayName: "Old listener",
@@ -1147,8 +1152,14 @@ describe("config reload builtin extension", () => {
 			displayName: "Second",
 			targets: [{ path: secondDir, kind: "dir" }],
 		});
-		expect(fixture.watches.activeListenerCount(firstDir)).toBe(0);
 		expect(fixture.watches.activeListenerCount(secondDir)).toBe(1);
+
+		// The replaced registration's watcher detaches on a deferred teardown, so it
+		// may still be attached here; what matters is that it is inert. A change under
+		// the old directory must not reload, and the new one must reload exactly once.
+		writeFileSync(firstPath, "stale");
+		await settleChange(fixture, firstDir, "config.json");
+		expect(fixture.reload).not.toHaveBeenCalled();
 
 		writeFileSync(secondPath, "two");
 		await settleChange(fixture, secondDir, "config.json");
@@ -1513,5 +1524,64 @@ describe("config reload builtin extension", () => {
 		await Promise.resolve();
 
 		expect(reload).toHaveBeenCalledTimes(1);
+	});
+});
+
+class DarwinWorkerProbe extends EventEmitter {
+	readonly postMessage = vi.fn();
+	readonly terminate = vi.fn(async () => 0);
+}
+
+describe("macOS recursive watch offload", () => {
+	it("routes darwin recursive watches through the worker and terminates it when the last one unsubscribes", () => {
+		// Given: a darwin event source with an injected fake recursive worker
+		const worker = new DarwinWorkerProbe();
+		const createRecursiveWorker = vi.fn(() => worker);
+		const onError = vi.fn();
+		const listener = vi.fn<WatchEventListener>();
+		const source = createFsWatchEventSource(onError, { platform: "darwin", createRecursiveWorker });
+
+		// When: two recursive watches are registered and one emits an event
+		const unsubscribeFirst = source("/Users/dev/large-workspace", listener, { recursive: true });
+		const unsubscribeSecond = source("/Users/dev/another-config-root", vi.fn(), { recursive: true });
+		worker.emit("message", { kind: "event", id: 1, eventType: "change", filename: ".omo/omo.json" });
+
+		// Then: setup went to the worker, events route back, and teardown waits for the last subscription
+		expect(createRecursiveWorker).toHaveBeenCalledTimes(1);
+		expect(worker.postMessage).toHaveBeenCalledWith({
+			kind: "watch",
+			id: 1,
+			path: "/Users/dev/large-workspace",
+		});
+		expect(worker.postMessage).toHaveBeenCalledWith({
+			kind: "watch",
+			id: 2,
+			path: "/Users/dev/another-config-root",
+		});
+		expect(listener).toHaveBeenCalledWith("change", ".omo/omo.json");
+		expect(onError).not.toHaveBeenCalled();
+
+		unsubscribeFirst();
+		expect(worker.postMessage).toHaveBeenCalledWith({ kind: "unwatch", id: 1 });
+		expect(worker.terminate).not.toHaveBeenCalled();
+
+		unsubscribeSecond();
+		expect(worker.terminate).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps darwin non-recursive watches on the main thread", () => {
+		// Given: a darwin event source whose worker factory must stay unused
+		const createRecursiveWorker = vi.fn(() => new DarwinWorkerProbe());
+		const agentDir = mkdtempSync(join(tmpdir(), "senpi-darwin-nonrecursive-"));
+		agentDirs.push(agentDir);
+		const source = createFsWatchEventSource(vi.fn(), { platform: "darwin", createRecursiveWorker });
+
+		// When: a non-recursive watch is registered
+		const unsubscribe = source(agentDir, vi.fn(), { recursive: false });
+
+		// Then: no worker is spawned
+		expect(createRecursiveWorker).not.toHaveBeenCalled();
+
+		unsubscribe();
 	});
 });

--- a/packages/coding-agent/test/suite/config-reload-lazy-teardown.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-lazy-teardown.test.ts
@@ -1,0 +1,228 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEventBus } from "../../src/core/event-bus.ts";
+import configReloadExtension from "../../src/core/extensions/builtin/config-reload/index.ts";
+import type { ConfigReloadLogger } from "../../src/core/extensions/builtin/config-reload/log.ts";
+import {
+	ConfigReloadWatchEngine,
+	type WatchEventListener,
+} from "../../src/core/extensions/builtin/config-reload/watch-engine.ts";
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+	ExtensionUIContext,
+	SessionShutdownEvent,
+	SessionStartEvent,
+} from "../../src/core/extensions/types.ts";
+
+type RecordedHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>;
+
+type ManualExtension = {
+	readonly api: ExtensionAPI;
+	readonly handlers: Map<string, RecordedHandler[]>;
+};
+
+/**
+ * A subscribe seam whose unsubscribes are slow: each one records the teardown
+ * marker observed at the moment it runs, so a test can prove close() returned
+ * before the loop drained.
+ */
+type SlowTeardownProbe = {
+	readonly subscribe: (
+		path: string,
+		listener: WatchEventListener,
+		options?: { readonly recursive: boolean },
+	) => () => void;
+	/** Marker value each unsubscribe saw when it ran. */
+	readonly unsubscribeMarkers: string[];
+	marker: string;
+	emit(path: string, filename: string | null): void;
+	activeListenerCount(path: string): number;
+};
+
+function createSlowTeardownProbe(): SlowTeardownProbe {
+	const listeners = new Map<string, Set<WatchEventListener>>();
+	const probe: SlowTeardownProbe = {
+		marker: "before-close",
+		unsubscribeMarkers: [],
+		subscribe: (path, listener) => {
+			const set = listeners.get(path) ?? new Set<WatchEventListener>();
+			set.add(listener);
+			listeners.set(path, set);
+			return () => {
+				probe.unsubscribeMarkers.push(probe.marker);
+				set.delete(listener);
+			};
+		},
+		emit: (path, filename) => {
+			for (const listener of [...(listeners.get(path) ?? [])]) listener("change", filename);
+		},
+		activeListenerCount: (path) => listeners.get(path)?.size ?? 0,
+	};
+	return probe;
+}
+
+function createManualExtension(): ManualExtension {
+	const handlers = new Map<string, RecordedHandler[]>();
+	const api = {
+		events: createEventBus(),
+		on: (event: string, handler: RecordedHandler) => {
+			const registered = handlers.get(event) ?? [];
+			registered.push(handler);
+			handlers.set(event, registered);
+		},
+	} as unknown as ExtensionAPI;
+	return { api, handlers };
+}
+
+async function invoke(
+	handlers: ReadonlyMap<string, readonly RecordedHandler[]>,
+	eventName: string,
+	event: unknown,
+	ctx: ExtensionContext,
+): Promise<void> {
+	const handler = handlers.get(eventName)?.at(-1);
+	if (!handler) throw new Error(`Missing ${eventName} handler`);
+	await handler(event, ctx);
+}
+
+function fakeContext(cwd: string): ExtensionContext {
+	return {
+		cwd,
+		mode: "tui",
+		ui: { notify: () => {} } as unknown as ExtensionUIContext,
+		isIdle: () => true,
+		hasPendingMessages: () => false,
+		isProjectTrusted: () => true,
+		isCompacting: () => false,
+	} as unknown as ExtensionContext;
+}
+
+function silentLogger(): ConfigReloadLogger {
+	return {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	} as unknown as ConfigReloadLogger;
+}
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+	const directory = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(directory);
+	return directory;
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	for (const directory of tempDirs.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("config reload watcher teardown is non-blocking", () => {
+	it("returns from close() before the unsubscribe loop runs", async () => {
+		// Given: an engine watching several directories through a probe that
+		// records the teardown marker each unsubscribe observes.
+		const rootDir = createTempDir("senpi-config-reload-lazy-engine-");
+		const watchedDirs = ["one", "two", "three"].map((name) => {
+			const directory = join(rootDir, name);
+			mkdirSync(directory);
+			writeFileSync(join(directory, "config.json"), '{"a":1}\n', "utf-8");
+			return directory;
+		});
+		const probe = createSlowTeardownProbe();
+		const onRealChange = vi.fn();
+		const engine = new ConfigReloadWatchEngine({
+			targets: watchedDirs.map((path, index) => ({ id: `target-${index}`, kind: "dir" as const, path })),
+			subscribe: probe.subscribe,
+			onRealChange,
+		});
+		expect(watchedDirs.every((path) => probe.activeListenerCount(path) === 1)).toBe(true);
+
+		// When: the engine is closed and the caller immediately marks that
+		// control returned to it.
+		const teardown = engine.close();
+		probe.marker = "after-close-returned";
+
+		// Then: no unsubscribe ran before close() returned, and every one of them
+		// ran afterwards.
+		expect(probe.unsubscribeMarkers).toEqual([]);
+		await teardown;
+		expect(probe.unsubscribeMarkers).toEqual([
+			"after-close-returned",
+			"after-close-returned",
+			"after-close-returned",
+		]);
+		expect(watchedDirs.every((path) => probe.activeListenerCount(path) === 0)).toBe(true);
+	});
+
+	it("drops events delivered after close() while teardown is still pending", async () => {
+		// Given: a closed engine whose subscriptions are still live because the
+		// deferred unsubscribe loop has not drained yet.
+		vi.useFakeTimers();
+		const rootDir = createTempDir("senpi-config-reload-lazy-drop-");
+		const watchedDir = join(rootDir, "watched");
+		mkdirSync(watchedDir);
+		const configPath = join(watchedDir, "config.json");
+		writeFileSync(configPath, '{"a":1}\n', "utf-8");
+		const probe = createSlowTeardownProbe();
+		const onRealChange = vi.fn();
+		const engine = new ConfigReloadWatchEngine({
+			targets: [{ id: "target", kind: "dir", path: watchedDir }],
+			subscribe: probe.subscribe,
+			onRealChange,
+			debounceMs: 200,
+		});
+
+		// When: a real content change is delivered to the still-attached listener
+		// after close() returned.
+		const teardown = engine.close();
+		expect(probe.activeListenerCount(watchedDir)).toBe(1);
+		writeFileSync(configPath, '{"a":2}\n', "utf-8");
+		probe.emit(watchedDir, "config.json");
+		await vi.advanceTimersByTimeAsync(200);
+
+		// Then: the closed engine reported nothing, and teardown still completes.
+		expect(onRealChange).not.toHaveBeenCalled();
+		await teardown;
+		expect(probe.activeListenerCount(watchedDir)).toBe(0);
+	});
+
+	it("returns from session_shutdown without waiting for the unsubscribe loop", async () => {
+		// Given: a started extension whose watcher unsubscribes record the
+		// teardown marker they observe.
+		const agentDir = createTempDir("senpi-config-reload-lazy-shutdown-");
+		writeFileSync(join(agentDir, "settings.json"), '{"theme":"dark"}\n', "utf-8");
+		const probe = createSlowTeardownProbe();
+		const extension = createManualExtension();
+		configReloadExtension(extension.api, {
+			agentDir,
+			subscribe: probe.subscribe,
+			logger: silentLogger(),
+		});
+		const context = fakeContext(agentDir);
+		await invoke(
+			extension.handlers,
+			"session_start",
+			{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+			context,
+		);
+		expect(probe.activeListenerCount(agentDir)).toBeGreaterThan(0);
+
+		// When: the session shuts down for a reload.
+		await invoke(
+			extension.handlers,
+			"session_shutdown",
+			{ type: "session_shutdown", reason: "reload" } satisfies SessionShutdownEvent,
+			context,
+		);
+		probe.marker = "after-shutdown-returned";
+
+		// Then: the shutdown handler resolved before any unsubscribe ran.
+		expect(probe.unsubscribeMarkers).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/suite/mcp-reload-deferral.test.ts
+++ b/packages/coding-agent/test/suite/mcp-reload-deferral.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createEventBus } from "../../src/core/event-bus.ts";
+import { createMcpExtension } from "../../src/core/extensions/builtin/mcp/index.ts";
+import { McpService, resetMcpServiceForTests } from "../../src/core/extensions/builtin/mcp/service.ts";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../../src/core/extensions/loader.ts";
+import type { Extension, SessionStartEvent } from "../../src/core/extensions/types.ts";
+
+type Deferred = {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+};
+
+class SlowAttachMcpService extends McpService {
+	connectCompleted = false;
+	readonly #connectStarted: Deferred;
+	readonly #connectGate: Deferred;
+
+	constructor(connectStarted: Deferred, connectGate: Deferred) {
+		super();
+		this.#connectStarted = connectStarted;
+		this.#connectGate = connectGate;
+	}
+
+	override async attachSession(): Promise<void> {
+		this.#connectStarted.resolve();
+		await this.#connectGate.promise;
+		this.connectCompleted = true;
+	}
+}
+
+const services: McpService[] = [];
+
+afterEach(async () => {
+	await Promise.all(services.splice(0).map((service) => service.dispose("quit")));
+	resetMcpServiceForTests();
+});
+
+describe("mcp session_start reload deferral", () => {
+	it("resolves session_start before reconnect completes when reason is reload", async () => {
+		const { extension, service, connectStarted, connectGate } = await loadSlowAttachExtension();
+
+		// Given: attachSession is blocked at the connect seam.
+		let sessionStartResolved = false;
+		const sessionStart = emitSessionStart(extension, "reload").then(() => {
+			sessionStartResolved = true;
+		});
+
+		// When: session_start is emitted with reason reload.
+		await connectStarted.promise;
+		await drainMicrotasks();
+
+		// Then: the handler settles while reconnect is still in flight.
+		expect(sessionStartResolved).toBe(true);
+		expect(service.connectCompleted).toBe(false);
+
+		connectGate.resolve();
+		await sessionStart;
+		expect(service.connectCompleted).toBe(true);
+	});
+
+	it("awaits reconnect during session_start when reason is startup", async () => {
+		const { extension, service, connectStarted, connectGate } = await loadSlowAttachExtension();
+
+		// Given: attachSession is blocked at the connect seam.
+		let sessionStartResolved = false;
+		const sessionStart = emitSessionStart(extension, "startup").then(() => {
+			sessionStartResolved = true;
+		});
+
+		// When: session_start is emitted with reason startup.
+		await connectStarted.promise;
+		await drainMicrotasks();
+
+		// Then: the handler stays pending until reconnect completes.
+		expect(sessionStartResolved).toBe(false);
+		expect(service.connectCompleted).toBe(false);
+
+		connectGate.resolve();
+		await sessionStart;
+		expect(service.connectCompleted).toBe(true);
+	});
+
+	it("awaits reconnect during session_start when reason is omitted", async () => {
+		const { extension, service, connectStarted, connectGate } = await loadSlowAttachExtension();
+
+		let sessionStartResolved = false;
+		const sessionStart = emitSessionStart(extension, undefined).then(() => {
+			sessionStartResolved = true;
+		});
+		await connectStarted.promise;
+		await drainMicrotasks();
+
+		expect(sessionStartResolved).toBe(false);
+		expect(service.connectCompleted).toBe(false);
+
+		connectGate.resolve();
+		await sessionStart;
+		expect(service.connectCompleted).toBe(true);
+	});
+});
+
+async function loadSlowAttachExtension(): Promise<{
+	readonly extension: Extension;
+	readonly service: SlowAttachMcpService;
+	readonly connectStarted: Deferred;
+	readonly connectGate: Deferred;
+}> {
+	const connectStarted = createDeferred();
+	const connectGate = createDeferred();
+	const service = new SlowAttachMcpService(connectStarted, connectGate);
+	services.push(service);
+	const extension = await loadExtensionFromFactory(
+		createMcpExtension(service, true),
+		process.cwd(),
+		createEventBus(),
+		createExtensionRuntime(),
+		"<builtin:mcp>",
+	);
+	return { extension, service, connectStarted, connectGate };
+}
+
+function emitSessionStart(extension: Extension, reason: SessionStartEvent["reason"] | undefined): Promise<void> {
+	const event =
+		reason === undefined
+			? ({ type: "session_start" } as SessionStartEvent)
+			: { type: "session_start" as const, reason };
+	return emit(extension, event);
+}
+
+async function emit(extension: Extension, event: SessionStartEvent): Promise<void> {
+	for (const handler of extension.handlers.get("session_start") ?? []) {
+		await handler(event, { cwd: process.cwd(), isProjectTrusted: () => true });
+	}
+}
+
+function createDeferred(): Deferred {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((complete) => {
+		resolve = complete;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+async function drainMicrotasks(): Promise<void> {
+	for (let i = 0; i < 8; i++) await Promise.resolve();
+}


### PR DESCRIPTION
# perf(config-reload): keep hot reload off the FSEvents teardown path

## Problem

Hot reload (`/reload` or a config-watch trigger) stalls for seconds — up to a minute on a loaded machine. Profiled on macOS (M4 Pro, node 26.7) with `PI_TIMING=1` on a real TUI pty session:

| run | shutdown | settings | models | resources | runtime | chatRebuild | lifecycle | total |
|---|---|---|---|---|---|---|---|---|
| idle machine | 1515ms | 1 | 13 | 86 | 2 | 0 | 39 | **1656ms** |
| loaded #1 | 2023ms | 1 | 17 | 141 | 2 | 0 | 16889 | **19073ms** |
| loaded #2 | 26553ms | 1 | 11 | 41 | 2 | 0 | 23184 | **49817ms** |
| loaded #3 | 48199ms | 1 | 15 | 93 | 2 | 0 | 14532 | **62842ms** |

## Root cause (instrumented per-handler / per-watcher)

`session_shutdown` → config-reload `closeWatchers()` → `WatchEngine.close()` closes every `fs.watch` stream **synchronously on the main thread**. On macOS each recursive `FSWatcher.close()` is an FSEvents stream teardown that blocks the calling thread — measured 5182/4614/6057/8955/13903/8077/5921/70 ms for the 8 watchers (44.8-62.8s total under load; ~150-200ms each idle). All other shutdown-handler steps measured 0ms. Slow closes happen even for near-empty temp dirs, so it is stream teardown latency (fseventsd rendezvous), not tree size.

Secondary lifecycle costs per reload: mcp `session_start` reconnect ~260ms; user-level extensions (out of repo scope).

## Fix

1. **watch-event-source.ts** — route recursive watches through the existing worker-thread path (previously Linux-only) on darwin too: create AND close happen off the interactive thread; teardown becomes a `postMessage`/`terminate()`.
2. **watch-engine.ts / index.ts** — `WatchEngine.close()` flips the `#closed` dispatch guard synchronously but runs unsubscribe teardown off the reload critical path; `closeWatchers()` no longer blocks `session_shutdown` on watcher teardown.
3. **mcp/index.ts** — `session_start` with `reason === "reload"` no longer blocks the reload on server reconnect (startup behavior unchanged). <!-- drop if lane verdict = unsafe -->

## After (same procedure)

| run | shutdown | settings | models | resources | runtime | chatRebuild | lifecycle | total |
|---|---|---|---|---|---|---|---|---|
| after-fix #1 | 2ms | 2 | 980 | 90 | 3 | 0 | 62 | **1139ms** |
| after-fix #2 | 1ms | 1 | 6608 | 48 | 2 | 0 | 61 | **6721ms** |
| after-fix #3 | 1ms | 0 | 4282 | 46 | 2 | 0 | 48 | **4379ms** |

`shutdown` (the fixed phase): **1515-48199ms → 1-2ms**. The `models` phase variance (0.98-6.6s) is a pre-existing, untouched path (model availability scan / auth command spawns; see Out of scope).

## Verification

- RED→GREEN test evidence per change (see test files; failing-first outputs captured in the work log).
- `npx vitest --run test/suite/config-reload-extension.test.ts` — TBD
- root `npm run check` — TBD
- Real-surface QA: TUI pty `/reload` with `PI_TIMING=1` before/after tables above.

## Out of scope (documented findings)

- Model-runtime tail risks measured cheap here but with pathological worst cases (`!command` auth key `spawnSync` 10s×3 retries; availability scan skip guards) — future work.
- User-level extension costs in `~/.omo/agent` (herdr session_start network report) — not senpi code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates hot-reload stalls by moving recursive `fs.watch` work off the main thread and deferring teardown; also stops blocking reload on MCP reconnect. Previously, reload waited for synchronous macOS FSEvents teardown and MCP attach; now teardown runs after the engine goes inert and reload does not await attach, cutting shutdown from 1.5–62s to 1–2ms.

- Routes recursive watchers through a worker on macOS and Linux; non-recursive watches are unchanged. The watch engine flips its closed guard immediately and drains unsubscribes on the next tick; `/reload` no longer waits for watcher teardown.
- Changes `ConfigReloadWatchEngine.close()` to return `Promise<void>`; it is safe to ignore or await to observe teardown completion. The `session_shutdown` handler no longer awaits teardown; errors are logged.
- In `mcp`, `session_start` with `reason: "reload"` starts reconnect but no longer awaits it; `startup`/omitted reasons still await. `before_agent_start` continues to await the single-flight attach to ensure tools are ready.

<sup>Written for commit a6b934c48f471d44dd5117064c8a9ecdfb21b4ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

