### PR TITLE
fix(coding-agent): keep goal continuations append-only and floor hinted 429 retries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,14 @@
 - Settings hot-reload no longer cascades across sessions that share an agent directory when another session saves a routine preference such as `defaultModel` during a reload. The replacement watcher now compares reload-window changes with the request-time settings snapshot, so routine-only writes remain suppressed while substantive configuration edits still reload.
 - Settings hot-reload now clears the reload handoff unconditionally after `requestReload()` settles, preventing a stale plaintext settings snapshot from surviving when the reload successor omits the config-reload builtin.
 - Compaction no longer treats implausible Cursor billed usage as context size: when the local transcript estimate is at least 50k and billed usage is more than 8× that estimate, the threshold uses the estimate so a multi-million dashboard-cumulative cacheRead cannot force a useless compact (#983).
+- Goal continuations are no longer stripped down to the newest one on every provider request. Rewriting
+  already-sent history invalidated the provider's conversation cache prefix, so a long-running team-mode
+  session paid a full uncached re-read every turn and drove itself into 429 storms. Continuation history is
+  now append-only and bounded by normal compaction instead of per-request deletion.
+- Same-model 429 retries now floor every wait with the exponential schedule (`baseDelayMs * 2^(attempt-1)`).
+  A provider that answers each rate-limit with the same tiny `retry-after` hint can no longer pin the retry
+  cadence at a few milliseconds; longer provider hints still take precedence.
+
 ### Added
 
 - The notice-box primitives are now part of the public API: `buildNoticeBox`, `noticeMessageRenderer`,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6853,6 +6853,9 @@ export class AgentSession {
 			// because a stall carries no rate-limit markers or retry-after hint.
 			const stallError = isProviderStreamStallError(message);
 			// 429-class detection: retryable AND message carries rate-limit markers.
+			// Every same-model wait derived below is floored by the exponential schedule
+			// inside the pure hint policy, so repeated tiny retry-after hints cannot pin
+			// the cadence at a few milliseconds. Do not recompute that floor here.
 			const is429Class =
 				!stallError &&
 				/rate.?limit|(?:^429(?=\s+\{)|(?:\bHTTP\/1\.[01]\s+|\bHTTP\s+|\bstatus(?:\s+code)?\s+|\berror\s+|\bcode\s+)429\b)|too many requests|resource.?exhausted/i.test(
@@ -7043,6 +7046,8 @@ export class AgentSession {
 		// reach this point with a fallback already applied (hard-error, refusal) set
 		// switchedFallback first and force providerDelayMs undefined, so no branch may
 		// be reordered to fall through here expecting an implicit switch.
+		// 429-tier delays already carry the exponential floor from nextInTurnDelayMs /
+		// degradeWithoutFallback; the non-tier branch keeps its own exponential fallback.
 		const nonTierProviderDelayMs = providerDelayMs === 0 ? undefined : providerDelayMs;
 		const delayMs = switchedFallback
 			? 0

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,58 @@
 # changes
 
+## 2026-08-20 - Append-only goal continuations and exponentially floored 429 waits
+
+### What changed
+
+- `packages/coding-agent/src/core/messages.ts`: removed `keepLatestGoalContinuationMessage()`.
+  `filterContextExcludedMessages()` is now an explicit identity pass and `convertToLlm()` maps the full
+  input array, so every accepted `goal-continuation` custom message stays in provider-visible chronological
+  history. `GOAL_CONTINUATION_MESSAGE_TYPE` and `isContextExcludedCustomMessage() === false` are unchanged;
+  no dedupe by content, goal id, wake source, or streak was added. Session JSONL format and
+  `queueHiddenGoalPrompt()` are untouched.
+- `packages/coding-agent/src/core/retry-fallback/hint-policy.ts`: `nextInTurnDelayMs()` computes
+  `exponentialFloorMs = baseDelayMs * 2 ** (attempt - 1)` and applies it to all three same-model branches
+  (half-used deadline remainder, first hinted idle probe, and the done/hint-override path). The floored
+  delay — not the raw hint — feeds `cumulativeHintedWaitMs`, so cap demotion accounts for time actually
+  slept. `degradeWithoutFallback()` tier 2 raises its cap-clamped wait to the same floor. The probe state
+  machine, tier boundaries, budgets, and the tier-3 terminal verdict are unchanged.
+- `packages/coding-agent/src/core/agent-session.ts`: comments only near 429 detection and retry scheduling,
+  recording that the exponential floor lives in the pure policy and must not be recomputed at the call site.
+  No control-flow change.
+
+### Why
+
+- Anthropic-style prompt caching keys on an exact message-array prefix. Dropping a previously sent
+  continuation made request N stop being a prefix of request N+1, so every token ahead of the deletion point
+  missed cache and was re-read at full price. In team mode, where continuations arrive every turn, that
+  produced sustained cache-miss traffic and 429 storms (#1005). Keeping continuations append-only is the
+  smallest change that restores prefix immutability; context growth is a deliberate trade bounded by normal
+  compaction.
+- The 429 handler previously let a provider hint fully replace the exponential schedule. A provider that
+  repeats a 5 ms `retry-after` on every rate-limit pinned the same-model retry cadence at 5 ms, so the
+  session hammered a model that was already refusing it. Flooring each wait guarantees monotonic pressure
+  relief while still honouring hints longer than the floor.
+
+### Why an extension could not handle it
+
+- `filterContextExcludedMessages()` / `convertToLlm()` run inside the core transport and compaction paths
+  (`agent-session.ts`, `compaction/compaction.ts`); an extension's `transformContext` hook fires before this
+  core-owned filter, so it cannot prevent a core deletion of already-sent turns.
+- The 429 wait is computed by the pure retry policy inside the session's own retry loop. Extensions observe
+  `auto_retry_start` after the delay has been decided and cannot rewrite `delayMs` or the probe state.
+
+### Expected merge conflict zones
+
+- MEDIUM: `messages.ts` top-of-file exclusion helpers and the `convertToLlm()` entry line — any concurrent
+  change that reintroduces context filtering there will collide.
+- MEDIUM: `retry-fallback/hint-policy.ts` `nextInTurnDelayMs()` branch bodies and the
+  `degradeWithoutFallback()` tier-2 return.
+- LOW: `agent-session.ts` 429 detection and retry-delay comments (comment-only lines).
+- LOW: `test/suite/goal-continuation-context-exclusion.test.ts`,
+  `test/suite/retry-fallback-hint-policy.test.ts`, and
+  `test/suite/regressions/issue-447-goal-continuation.test.ts`, whose assertions moved from
+  keep-latest-only to append-only.
+
 ## 2026-08-20 - Ignore implausible Cursor billed usage in compaction threshold
 
 ### What changed

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -28,35 +28,22 @@ export const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
 /**
  * Per-type exclusion must remain false: compaction and branch summarization
  * inspect entries independently, where excluding this type would hide the live
- * goal-continuation message. Whole-context filtering below removes only stale
- * goal-continuation entries while retaining the last triggering message.
+ * goal-continuation message.
  */
 export function isContextExcludedCustomMessage(_customType: string): boolean {
 	return false;
 }
 
-function keepLatestGoalContinuationMessage(messages: AgentMessage[]): AgentMessage[] {
-	let lastGoalContinuationIndex = -1;
-
-	for (let index = 0; index < messages.length; index++) {
-		const message = messages[index];
-		if (message.role === "custom" && message.customType === GOAL_CONTINUATION_MESSAGE_TYPE) {
-			lastGoalContinuationIndex = index;
-		}
-	}
-
-	if (lastGoalContinuationIndex === -1) return messages;
-
-	return messages.filter(
-		(message, index) =>
-			index === lastGoalContinuationIndex ||
-			message.role !== "custom" ||
-			message.customType !== GOAL_CONTINUATION_MESSAGE_TYPE,
-	);
-}
-
+/**
+ * Whole-context filtering is deliberately a no-op. Goal continuations are
+ * append-only: dropping an already-sent continuation would rewrite a
+ * provider-visible turn, so request N would stop being a prefix of request N+1
+ * and every cached token ahead of the edit would be invalidated (full re-read,
+ * cost spike, 429 storms in team mode). Continuation history is bounded by
+ * normal compaction instead of by per-request deletion.
+ */
 export function filterContextExcludedMessages(messages: AgentMessage[]): AgentMessage[] {
-	return keepLatestGoalContinuationMessage(messages);
+	return messages;
 }
 
 /**
@@ -186,7 +173,9 @@ export function createCustomMessage(
 export function convertToLlm(messages: AgentMessage[]): Message[] {
 	const withContextProvenance = <T extends Message>(source: AgentMessage, target: T): T =>
 		copyContextProvenance(source, target);
-	return keepLatestGoalContinuationMessage(messages)
+	// Continuations are append-only here too: the transport array must extend the
+	// previous request verbatim to keep the provider's cache prefix valid.
+	return messages
 		.map((m): Message | undefined => {
 			switch (m.role) {
 				case "bashExecution":

--- a/packages/coding-agent/src/core/retry-fallback/hint-policy.ts
+++ b/packages/coding-agent/src/core/retry-fallback/hint-policy.ts
@@ -43,13 +43,19 @@ export function nextInTurnDelayMs(
 	hintedWaitCapMs: number,
 	nowMs: number,
 ): InTurnResult {
+	// Every same-model 429 wait is floored by the exponential schedule so repeated
+	// short provider hints cannot pin the retry cadence at a few milliseconds and
+	// hammer an already rate-limited model. Longer hints still win.
+	const exponentialFloorMs = baseDelayMs * 2 ** (state.attempt - 1);
+
 	// Phase: half-used -> consecutive 429 with deadline sleep
 	if (state.probePhase === "half-used") {
 		const deadlineMs = hintMs !== undefined ? nowMs + hintMs : (state.hintDeadlineMs ?? nowMs);
 		const remaining = Math.max(0, deadlineMs - nowMs);
-		const newCumulative = state.cumulativeHintedWaitMs + remaining;
+		const delayMs = Math.max(remaining, exponentialFloorMs);
+		const newCumulative = state.cumulativeHintedWaitMs + delayMs;
 		return {
-			delayMs: remaining,
+			delayMs,
 			probePhase: "done",
 			hintDeadlineMs: deadlineMs,
 			cumulativeHintedWaitMs: newCumulative,
@@ -59,7 +65,7 @@ export function nextInTurnDelayMs(
 
 	// Phase: idle -> first hinted 429, probe at hint/2
 	if (state.probePhase === "idle" && hintMs !== undefined) {
-		const delay = Math.ceil(hintMs / 2);
+		const delay = Math.max(Math.ceil(hintMs / 2), exponentialFloorMs);
 		const deadlineMs = nowMs + hintMs;
 		const newCumulative = state.cumulativeHintedWaitMs + delay;
 		return {
@@ -71,8 +77,9 @@ export function nextInTurnDelayMs(
 		};
 	}
 
-	// Phase: done (or idle without hint = non-429 / no-hint fallback) -> exponential or hint override
-	const delay = hintMs ?? baseDelayMs * 2 ** (state.attempt - 1);
+	// Phase: done (or idle without hint = non-429 / no-hint fallback) -> exponential,
+	// raised further only by a hint longer than the floor
+	const delay = Math.max(hintMs ?? 0, exponentialFloorMs);
 	return {
 		delayMs: delay,
 		probePhase: "done",
@@ -87,8 +94,9 @@ export type DegradedRateLimitAction = { kind: "in-turn"; delayMs: number } | { k
 /**
  * Policy for a 429-class failure when no fallback candidate is usable: no-hint
  * (and tier1) failures retry in-turn on the exponential schedule, tier2 hints
- * retry in-turn with the wait clamped to the in-turn cap, and only tier3
- * (probe-back-max or longer) hinted waits stay terminal.
+ * retry in-turn with the wait clamped to the in-turn cap but floored by the same
+ * exponential schedule, and only tier3 (probe-back-max or longer) hinted waits
+ * stay terminal.
  */
 export function degradeWithoutFallback(
 	tier: HintTier,
@@ -99,7 +107,11 @@ export function degradeWithoutFallback(
 ): DegradedRateLimitAction {
 	if (tier === "tier3-fallback-only") return { kind: "fail", hintMs: hintMs ?? 0 };
 	if (tier === "tier2-fallback-probe-back") {
-		return { kind: "in-turn", delayMs: Math.min(hintMs ?? hintedWaitCapMs, hintedWaitCapMs) };
+		// Cap-clamped, but never below the exponential floor for this attempt.
+		return {
+			kind: "in-turn",
+			delayMs: Math.max(Math.min(hintMs ?? hintedWaitCapMs, hintedWaitCapMs), baseDelayMs * 2 ** (attempt - 1)),
+		};
 	}
 	return { kind: "in-turn", delayMs: baseDelayMs * 2 ** (attempt - 1) };
 }

--- a/packages/coding-agent/test/suite/goal-continuation-context-exclusion.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-context-exclusion.test.ts
@@ -5,7 +5,6 @@ import { prepareBranchEntries } from "../../src/core/compaction/branch-summariza
 import {
 	DEFAULT_COMPACTION_SETTINGS,
 	estimateContextTokens,
-	estimateTokens,
 	prepareCompaction,
 } from "../../src/core/compaction/compaction.ts";
 import {
@@ -51,7 +50,27 @@ function continuationContents(messages: AgentMessage[]): string[] {
 	);
 }
 
-describe("goal-continuation context exclusion", () => {
+function fixtureAssistantMessage(text: string, timestamp: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "fixture-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp,
+	};
+}
+
+describe("goal-continuation context retention", () => {
 	test.each([
 		{ name: "zero", messages: [] as AgentMessage[], expected: [] as string[] },
 		{
@@ -62,37 +81,64 @@ describe("goal-continuation context exclusion", () => {
 		{
 			name: "many",
 			messages: [
-				goalContinuation("stale continuation one", 1),
-				goalContinuation("stale continuation two", 2),
-				goalContinuation("live continuation", 3),
+				goalContinuation("continuation one", 1),
+				goalContinuation("continuation two", 2),
+				goalContinuation("continuation three", 3),
 			] as AgentMessage[],
-			expected: ["live continuation"],
+			expected: ["continuation one", "continuation two", "continuation three"],
 		},
-	])("keeps only the last continuation when the array has $name", ({ messages, expected }) => {
+	])("retains every continuation when the array has $name", ({ messages, expected }) => {
 		expect(continuationContents(filterContextExcludedMessages(messages))).toEqual(expected);
 		expect(convertToLlm(messages).map(llmText)).toEqual(expected);
+	});
+
+	test("keeps an interleaved continuation history append-only and in order", () => {
+		// The cache prefix of request N must survive verbatim into request N+1, so an
+		// earlier continuation may never be dropped once the provider has seen it.
+		const messages: AgentMessage[] = [
+			{ role: "user", content: "user-0", timestamp: 1 },
+			goalContinuation("continuation-1", 2),
+			fixtureAssistantMessage("assistant-1", 3),
+			goalContinuation("continuation-2", 4),
+		];
+
+		const filtered = filterContextExcludedMessages(messages);
+
+		expect(filtered).toEqual(messages);
+		expect(convertToLlm(messages).map(llmText)).toEqual([
+			"user-0",
+			"continuation-1",
+			"assistant-1",
+			"continuation-2",
+		]);
 	});
 
 	test("keeps non-goal messages and their ordering unchanged", () => {
 		const messages: AgentMessage[] = [
 			{ role: "user", content: "before", timestamp: 1 },
-			goalContinuation("stale continuation", 2),
+			goalContinuation("earlier continuation", 2),
 			customMessage("non-goal custom", 3),
-			goalContinuation("live continuation", 4),
+			goalContinuation("latest continuation", 4),
 			{ role: "user", content: "after", timestamp: 5 },
 		];
 
 		const filtered = filterContextExcludedMessages(messages);
 
-		expect(filtered).toEqual([messages[0], messages[2], messages[3], messages[4]]);
-		expect(convertToLlm(messages).map(llmText)).toEqual(["before", "non-goal custom", "live continuation", "after"]);
+		expect(filtered).toEqual(messages);
+		expect(convertToLlm(messages).map(llmText)).toEqual([
+			"before",
+			"earlier continuation",
+			"non-goal custom",
+			"latest continuation",
+			"after",
+		]);
 	});
 
 	test("is idempotent across filtering and conversion", () => {
 		const messages: AgentMessage[] = [
-			goalContinuation("stale continuation", 1),
+			goalContinuation("earlier continuation", 1),
 			customMessage("non-goal custom", 2),
-			goalContinuation("live continuation", 3),
+			goalContinuation("latest continuation", 3),
 		];
 
 		const filtered = filterContextExcludedMessages(messages);
@@ -104,27 +150,8 @@ describe("goal-continuation context exclusion", () => {
 
 describe("goal-continuation call-site consistency (300-message fixture)", () => {
 	const FIXTURE_CONTINUATIONS = 300;
+	const FIRST_CONTINUATION = "goal continuation 0";
 	const LIVE_CONTINUATION = `goal continuation ${FIXTURE_CONTINUATIONS - 1}`;
-
-	function fixtureAssistantMessage(text: string, timestamp: number): AssistantMessage {
-		return {
-			role: "assistant",
-			content: [{ type: "text", text }],
-			api: "anthropic-messages",
-			provider: "anthropic",
-			model: "fixture-model",
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			timestamp,
-		};
-	}
 
 	function buildMassFixture(): AgentMessage[] {
 		const messages: AgentMessage[] = [];
@@ -171,19 +198,20 @@ describe("goal-continuation call-site consistency (300-message fixture)", () => 
 		return entries;
 	}
 
-	test("convertToLlm emits exactly one continuation-derived user message from 300", () => {
+	test("convertToLlm emits all 300 continuation-derived user messages in order", () => {
 		const fixture = buildMassFixture();
 
 		const converted = convertToLlm(fixture);
 
-		expect(converted).toHaveLength(fixture.length - (FIXTURE_CONTINUATIONS - 1));
+		expect(converted).toHaveLength(fixture.length);
 		const continuationDerived = converted.filter((message) => llmText(message).startsWith("goal continuation"));
-		expect(continuationDerived).toHaveLength(1);
-		expect(continuationDerived[0].role).toBe("user");
-		expect(llmText(continuationDerived[0])).toBe(LIVE_CONTINUATION);
+		expect(continuationDerived).toHaveLength(FIXTURE_CONTINUATIONS);
+		expect(continuationDerived.every((message) => message.role === "user")).toBe(true);
+		expect(llmText(continuationDerived[0])).toBe(FIRST_CONTINUATION);
+		expect(llmText(continuationDerived[FIXTURE_CONTINUATIONS - 1])).toBe(LIVE_CONTINUATION);
 	});
 
-	test("estimateContextTokens over the filtered fixture drops the same 299 continuations", () => {
+	test("filterContextExcludedMessages does not undercount the transport conversion", () => {
 		const fixture = buildMassFixture();
 		const continuations = fixture.filter(
 			(message) => message.role === "custom" && message.customType === GOAL_CONTINUATION_MESSAGE_TYPE,
@@ -192,18 +220,16 @@ describe("goal-continuation call-site consistency (300-message fixture)", () => 
 
 		const filtered = filterContextExcludedMessages(fixture);
 
-		expect(filtered).toHaveLength(fixture.length - (FIXTURE_CONTINUATIONS - 1));
-		expect(continuationContents(filtered)).toEqual([LIVE_CONTINUATION]);
+		expect(filtered).toHaveLength(fixture.length);
+		expect(continuationContents(filtered)).toEqual(continuationContents(fixture));
 
-		const unfilteredTokens = estimateContextTokens(fixture).tokens;
-		const filteredTokens = estimateContextTokens(filtered).tokens;
-		const staleTokens = continuations.slice(0, -1).reduce((sum, message) => sum + estimateTokens(message), 0);
-
-		expect(filteredTokens).toBeLessThan(unfilteredTokens);
-		expect(unfilteredTokens - filteredTokens).toBe(staleTokens);
+		// Token accounting must match what the provider actually receives; any
+		// context-side drop would understate the request the transport builds.
+		expect(estimateContextTokens(filtered).tokens).toBe(estimateContextTokens(fixture).tokens);
+		expect(convertToLlm(filtered)).toHaveLength(convertToLlm(fixture).length);
 	});
 
-	test("prepareCompaction applies the same filter to the flooded fixture without error", () => {
+	test("prepareCompaction still succeeds on the flooded fixture and counts every continuation", () => {
 		const entries = buildMassFixtureEntries();
 		const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 100 };
 
@@ -211,10 +237,9 @@ describe("goal-continuation call-site consistency (300-message fixture)", () => 
 
 		expect(preparation).toBeDefined();
 		const contextMessages = buildSessionContext(entries).messages;
-		const expectedFilteredTokens = estimateContextTokens(filterContextExcludedMessages(contextMessages)).tokens;
 		const unfilteredTokens = estimateContextTokens(contextMessages).tokens;
-		expect(preparation!.tokensBefore).toBe(expectedFilteredTokens);
-		expect(preparation!.tokensBefore).toBeLessThan(unfilteredTokens);
+		expect(estimateContextTokens(filterContextExcludedMessages(contextMessages)).tokens).toBe(unfilteredTokens);
+		expect(preparation!.tokensBefore).toBe(unfilteredTokens);
 	});
 
 	test("branch summarization still sees every goal-continuation entry", () => {
@@ -229,7 +254,7 @@ describe("goal-continuation call-site consistency (300-message fixture)", () => 
 		);
 		expect(visibleContinuations).toHaveLength(FIXTURE_CONTINUATIONS);
 		const visibleContents = visibleContinuations.map((message) => message.content);
-		expect(visibleContents).toContain("goal continuation 0");
+		expect(visibleContents).toContain(FIRST_CONTINUATION);
 		expect(visibleContents).toContain(LIVE_CONTINUATION);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/1005-429-floor.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1005-429-floor.test.ts
@@ -1,0 +1,44 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+/**
+ * Regression for #1005: a provider that answers every 429 with the same tiny
+ * retry-after hint used to pin the same-model wait at that hint forever, so the
+ * session hammered a rate-limited model (429 storm). Every same-model 429 wait
+ * is now floored by the exponential schedule baseDelayMs * 2^(attempt-1);
+ * longer provider hints still win.
+ */
+describe("issue #1005: repeated short 429 hints escalate on the exponential floor", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	it("escalates delays as 10/20/40 despite a constant 5ms retry-after hint", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 10 } },
+		});
+		harnesses.push(harness);
+
+		const rateLimited = () =>
+			fauxAssistantMessage("", {
+				stopReason: "error" as const,
+				errorMessage: "rate_limit_exceeded: retry-after-ms: 5",
+			});
+
+		harness.setResponses([rateLimited(), rateLimited(), rateLimited(), fauxAssistantMessage("recovered")]);
+
+		await harness.session.prompt("test");
+
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([10, 20, 40]);
+		expect(harness.faux.state.callCount).toBe(4);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([true]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(0);
+		expect(harness.eventsOfType("retry_fallback_exhausted")).toHaveLength(0);
+		expect(harness.session.isRetrying).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/1005-continuation-cache-stability.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1005-continuation-cache-stability.test.ts
@@ -1,0 +1,103 @@
+import type { Message } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, getMessageText, type Harness } from "../harness.ts";
+
+/**
+ * Regression for #1005: team-mode goal continuations used to be filtered down to
+ * the newest one on every provider request, which rewrote already-sent history
+ * and invalidated the provider's conversation cache prefix (cache miss per turn,
+ * full re-read, 429 storms). Continuations must now be append-only: the message
+ * array of request N stays a verbatim prefix of request N+1.
+ */
+describe("issue #1005: goal continuations keep the provider cache prefix stable", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	function payloadMessages(harness: Harness, callIndex: number): Message[] {
+		const call = harness.faux.getCallLog()[callIndex];
+		expect(call).toBeDefined();
+		return call.context.messages;
+	}
+
+	it("keeps payload N a verbatim prefix of payload N+1 across continuations", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage("assistant-1"),
+			fauxAssistantMessage("assistant-2"),
+			fauxAssistantMessage("assistant-3"),
+		]);
+
+		// Establish a prefix: user turn + assistant reply.
+		await harness.session.prompt("user-0");
+
+		// First continuation triggers its own turn (team-mode wake).
+		await harness.session.sendCustomMessage(
+			{ customType: "goal-continuation", content: "continuation-1", display: false, details: undefined },
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
+		const payloadA = payloadMessages(harness, 1);
+
+		// A hidden non-goal custom message lands in between, then a second continuation.
+		await harness.session.sendCustomMessage(
+			{ customType: "goal-notification", content: "hidden-note", display: false, details: undefined },
+			{ triggerTurn: false },
+		);
+		await harness.session.sendCustomMessage(
+			{ customType: "goal-continuation", content: "continuation-2", display: false, details: undefined },
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
+		const payloadB = payloadMessages(harness, 2);
+
+		// payload A must survive verbatim as the head of payload B.
+		expect(payloadB.length).toBeGreaterThan(payloadA.length);
+		expect(payloadB.slice(0, payloadA.length)).toEqual(payloadA);
+
+		// Everything appended after the shared prefix is new user-side context, and
+		// the newest continuation is the final turn the provider sees.
+		const appended = payloadB.slice(payloadA.length);
+		expect(appended.every((message) => message.role === "user" || message.role === "assistant")).toBe(true);
+		expect(appended.map(getMessageText)).toContain("continuation-2");
+		expect(getMessageText(payloadB[payloadB.length - 1])).toBe("continuation-2");
+
+		// The earlier continuation is still present in the shared prefix.
+		expect(payloadA.map(getMessageText)).toContain("continuation-1");
+		expect(payloadB.map(getMessageText)).toContain("continuation-1");
+	});
+
+	it("appends exactly one final user turn per continuation", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+
+		harness.setResponses([
+			fauxAssistantMessage("assistant-1"),
+			fauxAssistantMessage("assistant-2"),
+			fauxAssistantMessage("assistant-3"),
+		]);
+
+		await harness.session.prompt("user-0");
+		await harness.session.sendCustomMessage(
+			{ customType: "goal-continuation", content: "continuation-1", display: false, details: undefined },
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
+		const payloadA = payloadMessages(harness, 1);
+
+		await harness.session.sendCustomMessage(
+			{ customType: "goal-continuation", content: "continuation-2", display: false, details: undefined },
+			{ triggerTurn: true, deliverAs: "followUp" },
+		);
+		const payloadB = payloadMessages(harness, 2);
+
+		expect(payloadB.slice(0, payloadA.length)).toEqual(payloadA);
+		// prior assistant reply + the new continuation user turn
+		const appended = payloadB.slice(payloadA.length);
+		expect(appended.filter((message) => message.role === "user").map(getMessageText)).toEqual(["continuation-2"]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-447-goal-continuation.test.ts
@@ -119,7 +119,12 @@ describe("issue #447: goal continuation guardrails", () => {
 		expect(notices).not.toContainEqual(expect.stringContaining("continuation cap reached"));
 	});
 
-	it("does not send consumed goal-continuation prompts in the next faux-provider request", async () => {
+	it("sends historical goal-continuation prompts to the provider in stable chronological order", async () => {
+		// #447 bounds how many *new* continuations the goal extension queues (covered by
+		// the queueing tests above). Once a continuation has been sent, it stays in
+		// provider-visible history: deleting it per request would rewrite the cached
+		// prefix and force a full re-read every turn (#1005). Growth is bounded by
+		// normal compaction, not by per-request deletion.
 		const harness = await createHarness();
 		harnesses.push(harness);
 		harness.sessionManager.appendMessage({ role: "user", content: "begin the goal", timestamp: 1 });
@@ -140,8 +145,12 @@ describe("issue #447: goal continuation guardrails", () => {
 		const continuationPrompts = request.context.messages.filter(
 			(message) => message.role === "user" && getMessageText(message).startsWith("consumed continuation"),
 		);
-		expect(continuationPrompts).toHaveLength(1);
-		expect(getMessageText(continuationPrompts[0]!)).toBe("consumed continuation 299");
+		expect(continuationPrompts).toHaveLength(300);
+		expect(getMessageText(continuationPrompts[0]!)).toBe("consumed continuation 0");
+		expect(getMessageText(continuationPrompts[299]!)).toBe("consumed continuation 299");
+		// the freshly typed prompt is still the final turn the provider sees
+		const lastMessage = request.context.messages[request.context.messages.length - 1];
+		expect(getMessageText(lastMessage)).toBe("make the next provider request");
 	});
 
 	it("allows one truncation recovery, then blocks rather than looping on length stops", async () => {

--- a/packages/coding-agent/test/suite/retry-fallback-hint-policy.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hint-policy.test.ts
@@ -116,7 +116,9 @@ describe("nextInTurnDelayMs", () => {
 		expect(result.hintDeadlineMs).toBe(7_001);
 	});
 
-	it("first hinted 429 with explicit zero: immediate, half-used", () => {
+	it("first hinted 429 with explicit zero: still waits the exponential floor, half-used", () => {
+		// A retry-now hint may not bypass same-model backoff pressure (#1005): the
+		// floor keeps repeated short hints from hammering an already rate-limited model.
 		const result = nextInTurnDelayMs(
 			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 0 },
 			0,
@@ -124,15 +126,44 @@ describe("nextInTurnDelayMs", () => {
 			CAP,
 			5_000,
 		);
-		expect(result.delayMs).toBe(0);
+		expect(result.delayMs).toBe(BASE); // floor 2000 * 2^0
 		expect(result.probePhase).toBe("half-used");
 		expect(result.hintDeadlineMs).toBe(5_000);
+		expect(result.cumulativeHintedWaitMs).toBe(BASE);
 		expect(result.demoteToProbeBack).toBe(false);
+	});
+
+	it("first hinted 429 with a short hint: exponential floor wins over half-hint", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 0 },
+			3_000,
+			BASE,
+			CAP,
+			0,
+		);
+		// ceil(3000/2) = 1500 < floor 2000 -> floored to 2000
+		expect(result.delayMs).toBe(2_000);
+		expect(result.probePhase).toBe("half-used");
+		expect(result.hintDeadlineMs).toBe(3_000);
+		// cumulative tracks the delay actually slept, not the un-floored half-hint
+		expect(result.cumulativeHintedWaitMs).toBe(2_000);
+	});
+
+	it("long provider hints still beat the exponential floor", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 3, cumulativeHintedWaitMs: 0 },
+			30_000,
+			BASE,
+			CAP,
+			0,
+		);
+		// hint 30000 > floor 2000 * 2^2 = 8000
+		expect(result.delayMs).toBe(30_000);
 	});
 
 	// --- consecutive 429 after half-used (deadline sleep) ---
 
-	it("consecutive unhinted 429 after half: sleep remaining to prior deadline, then done", () => {
+	it("consecutive unhinted 429 after half: elapsed deadline still waits the exponential floor", () => {
 		const result = nextInTurnDelayMs(
 			{ probePhase: "half-used", hintDeadlineMs: 61_000, attempt: 2, cumulativeHintedWaitMs: 60_000 },
 			undefined,
@@ -140,10 +171,11 @@ describe("nextInTurnDelayMs", () => {
 			CAP,
 			61_000,
 		);
-		// no new hint -> keep deadline 61000; remaining = max(0, 61000 - 61000) = 0
-		expect(result.delayMs).toBe(0);
+		// no new hint -> keep deadline 61000; remaining = 0, floored to 2000 * 2^1 = 4000
+		expect(result.delayMs).toBe(4_000);
 		expect(result.probePhase).toBe("done");
 		expect(result.hintDeadlineMs).toBe(61_000);
+		expect(result.cumulativeHintedWaitMs).toBe(64_000);
 		expect(result.demoteToProbeBack).toBe(false);
 	});
 
@@ -229,7 +261,7 @@ describe("nextInTurnDelayMs", () => {
 
 	// --- explicit zero after half ---
 
-	it("explicit zero after half: immediate, done", () => {
+	it("explicit zero after half: exponential floor applies, done", () => {
 		const result = nextInTurnDelayMs(
 			{ probePhase: "half-used", hintDeadlineMs: 100_000, attempt: 2, cumulativeHintedWaitMs: 50_000 },
 			0,
@@ -237,10 +269,11 @@ describe("nextInTurnDelayMs", () => {
 			CAP,
 			60_000,
 		);
-		// new deadline = 60000 + 0 = 60000; remaining = max(0, 60000 - 60000) = 0
-		expect(result.delayMs).toBe(0);
+		// new deadline = 60000 + 0 = 60000; remaining = 0, floored to 2000 * 2^1 = 4000
+		expect(result.delayMs).toBe(4_000);
 		expect(result.probePhase).toBe("done");
 		expect(result.hintDeadlineMs).toBe(60_000);
+		expect(result.cumulativeHintedWaitMs).toBe(54_000);
 		expect(result.demoteToProbeBack).toBe(false);
 	});
 
@@ -280,7 +313,7 @@ describe("nextInTurnDelayMs", () => {
 
 	// --- after done: exponential with hint override ---
 
-	it("after done with fresh hint: hint overrides exponential", () => {
+	it("after done with a short fresh hint: exponential floor overrides the hint", () => {
 		const result = nextInTurnDelayMs(
 			{ probePhase: "done", attempt: 3, cumulativeHintedWaitMs: 120_000 },
 			5_000,
@@ -288,7 +321,8 @@ describe("nextInTurnDelayMs", () => {
 			CAP,
 			200_000,
 		);
-		expect(result.delayMs).toBe(5_000);
+		// hint 5000 < floor 2000 * 2^2 = 8000
+		expect(result.delayMs).toBe(8_000);
 		expect(result.probePhase).toBe("done");
 		expect(result.demoteToProbeBack).toBe(false);
 	});
@@ -437,6 +471,77 @@ describe("nextInTurnDelayMs", () => {
 });
 
 // ---------------------------------------------------------------------------
+// nextInTurnDelayMs — exponential floor on same-model 429 waits (#1005)
+// ---------------------------------------------------------------------------
+
+describe("nextInTurnDelayMs exponential floor (#1005)", () => {
+	it("grows the same-model wait monotonically under repeated short hints", () => {
+		// attempt 1: 3s hint -> half-probe 1500 floored to 2000
+		const first = nextInTurnDelayMs(
+			{ probePhase: "idle", attempt: 1, cumulativeHintedWaitMs: 0 },
+			3_000,
+			BASE,
+			CAP,
+			0,
+		);
+		expect(first.delayMs).toBe(2_000);
+		expect(first.cumulativeHintedWaitMs).toBe(2_000);
+
+		// attempt 2: deadline already elapsed -> floored to at least 4000
+		const second = nextInTurnDelayMs(
+			{
+				probePhase: first.probePhase,
+				hintDeadlineMs: first.hintDeadlineMs,
+				attempt: 2,
+				cumulativeHintedWaitMs: first.cumulativeHintedWaitMs,
+			},
+			undefined,
+			BASE,
+			CAP,
+			10_000,
+		);
+		expect(second.delayMs).toBeGreaterThanOrEqual(4_000);
+		expect(second.cumulativeHintedWaitMs).toBe(first.cumulativeHintedWaitMs + second.delayMs);
+
+		// attempt 3: another short 5s hint cannot undo the accumulated pressure
+		const third = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 3, cumulativeHintedWaitMs: second.cumulativeHintedWaitMs },
+			5_000,
+			BASE,
+			CAP,
+			20_000,
+		);
+		expect(third.delayMs).toBe(8_000);
+		expect(third.delayMs).toBeGreaterThan(second.delayMs);
+	});
+
+	it("leaves a long provider delay untouched when the floor is smaller", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "done", attempt: 3, cumulativeHintedWaitMs: 0 },
+			30_000,
+			BASE,
+			CAP,
+			0,
+		);
+		expect(result.delayMs).toBe(30_000); // floor 8000 loses
+	});
+
+	it("demotion accounting uses the floored delay, not the raw hint", () => {
+		const result = nextInTurnDelayMs(
+			{ probePhase: "half-used", hintDeadlineMs: 10_000, attempt: 8, cumulativeHintedWaitMs: 40_000 },
+			undefined,
+			BASE,
+			100_000,
+			10_000,
+		);
+		// remaining = 0, floored to 2000 * 2^7 = 256000; cumulative 296000 > 100000 cap
+		expect(result.delayMs).toBe(256_000);
+		expect(result.cumulativeHintedWaitMs).toBe(296_000);
+		expect(result.demoteToProbeBack).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // degradeWithoutFallback
 // ---------------------------------------------------------------------------
 
@@ -456,6 +561,14 @@ describe("degradeWithoutFallback", () => {
 		expect(degradeWithoutFallback("tier2-fallback-probe-back", CAP + 60_000, 1, BASE, CAP)).toEqual({
 			kind: "in-turn",
 			delayMs: CAP,
+		});
+	});
+
+	it("floors tier2 hinted waits with the exponential schedule", () => {
+		// A tiny cap could otherwise let a degraded tier2 retry hammer the model (#1005).
+		expect(degradeWithoutFallback("tier2-fallback-probe-back", 5_000, 4, BASE, 5_000)).toEqual({
+			kind: "in-turn",
+			delayMs: BASE * 8, // 16_000 floor beats the 5_000 clamp
 		});
 	});
 


### PR DESCRIPTION
Fixes #1005.

## Summary

Long-running team-mode sessions rewrote their own conversation history on every provider request and then hammered rate-limited models. Two independent defects, one shared symptom (429 storms):

1. **Continuation churn.** `keepLatestGoalContinuationMessage()` in `core/messages.ts` filtered the message array down to the *newest* `goal-continuation` on every request, deleting continuations the provider had already seen. Continuations are now **append-only**: `filterContextExcludedMessages()` is an explicit identity pass and `convertToLlm()` maps the full input array. History growth is bounded by normal compaction instead of per-request deletion.
2. **429 hint pinning.** `core/retry-fallback/hint-policy.ts` let a provider `retry-after` hint fully replace the exponential backoff schedule. Every same-model 429 wait is now floored with `baseDelayMs * 2 ** (attempt - 1)` across all three probe branches, and `degradeWithoutFallback()` tier 2 raises its cap-clamped wait to the same floor. Longer provider hints still win; the probe state machine, tier boundaries, budgets, and the tier-3 terminal verdict are unchanged.

`core/agent-session.ts` changes are comment-only — no control-flow change. The exponential floor lives entirely in the pure policy and is not recomputed at the call site.

## Why

Anthropic-style prompt caching keys on an **exact message-array prefix**. A cached request is reused only for as long as the new request's message array matches the previous one verbatim from position 0.

Deleting a previously-sent continuation broke exactly that invariant: request N stopped being a prefix of request N+1, so every token *ahead of the deletion point* — i.e. essentially the whole conversation — missed cache and was re-read at full uncached price. In team mode, where a continuation is appended every turn, this ran on every single request: sustained full-context re-reads, a cost/latency spike proportional to session length, and enough request pressure to trigger 429 storms.

The second defect turned those 429s into a hot loop. When a provider answers each rate-limit with the same small `retry-after` hint (e.g. 5 ms), the old policy took the hint verbatim, so the same-model retry cadence stayed pinned at 5 ms no matter how many consecutive 429s came back — the session hammered a model that was actively refusing it. Flooring each wait with the exponential schedule guarantees monotonic pressure relief while still honouring any hint longer than the floor.

Keeping continuations append-only is the smallest change that restores prefix immutability. Context growth is the deliberate trade, and it is bounded by the compaction path that already exists.

## QA & Evidence

### RED (tests written first, run against unchanged production code)

```
 Test Files  4 failed (4)
      Tests  17 failed | 41 passed (58)
```

Every failure is a real assertion mismatch for the predicted reason — no import or syntax errors:

```
 FAIL  test/suite/goal-continuation-context-exclusion.test.ts > retains every continuation when the array has 'many'
AssertionError: expected [ 'continuation three' ] to deeply equal [ 'continuation one', …(2) ]
 FAIL  test/suite/goal-continuation-context-exclusion.test.ts > keeps an interleaved continuation history append-only and in order
AssertionError: expected [ { role: 'user', …(2) }, …(2) ] to deeply equal [ { role: 'user', …(2) }, …(3) ]
 FAIL  test/suite/goal-continuation-context-exclusion.test.ts > convertToLlm emits all 300 continuation-derived user messages in order
AssertionError: expected [ { role: 'user', …(2) }, …(600) ] to have a length of 900 but got 601
 FAIL  test/suite/goal-continuation-context-exclusion.test.ts > prepareCompaction still succeeds on the flooded fixture and counts every continuation
AssertionError: expected 2606 to be 4300 // Object.is equality
 FAIL  test/suite/retry-fallback-hint-policy.test.ts > first hinted 429 with a short hint: exponential floor wins over half-hint
AssertionError: expected 1500 to be 2000 // Object.is equality
 FAIL  test/suite/retry-fallback-hint-policy.test.ts > after done with a short fresh hint: exponential floor overrides the hint
AssertionError: expected 5000 to be 8000 // Object.is equality
 FAIL  test/suite/retry-fallback-hint-policy.test.ts > demotion accounting uses the floored delay, not the raw hint
AssertionError: expected +0 to be 256000 // Object.is equality
 FAIL  test/suite/regressions/1005-429-floor.test.ts > escalates delays as 10/20/40 despite a constant 5ms retry-after hint
AssertionError: expected [ 3, 5, 5 ] to deeply equal [ 10, 20, 40 ]
 FAIL  test/suite/regressions/1005-continuation-cache-stability.test.ts > keeps payload N a verbatim prefix of payload N+1 across continuations
AssertionError: expected [ { role: 'user', …(2) }, …(2) ] to deeply equal [ { role: 'user', …(2) }, …(2) ]
```

### GREEN (same targets, after the fix)

```
 Test Files  5 passed (5)
      Tests  64 passed (64)
```

Full package suite: `npm test -- test/suite` → **442 files, 3055 passed | 1 skipped**.

### Payload-prefix QA assertion

`test/suite/regressions/1005-continuation-cache-stability.test.ts` proves cache stability on the **real transport surface**, not on a unit-level helper. It drives `AgentSession.sendCustomMessage({ customType: "goal-continuation", display: false }, { triggerTurn: true, deliverAs: "followUp" })` twice through the faux provider — with an intervening hidden non-goal custom message — and reads the actual per-call provider payloads from `harness.faux.getCallLog()[i].context.messages`.

The assertion is a strict deep-equal prefix check: `payloadB.slice(0, payloadA.length)` must equal `payloadA` verbatim. That is precisely the invariant prompt caching depends on. It further asserts that everything appended past the shared prefix is new user/assistant context, that the newest continuation is the final turn the provider sees, and that exactly one new user turn is appended per continuation — so the fix cannot regress into "append everything twice" while still passing the prefix check. On unpatched code `payloadB` omits `continuation-1` entirely and the prefix check fails.

`test/suite/regressions/1005-429-floor.test.ts` exercises the retry loop end-to-end through the faux harness (`baseDelayMs: 10`, three retryable 429s each hinting `retry-after-ms: 5`, then success) and asserts `auto_retry_start.delayMs === [10, 20, 40]` with 4 provider calls, one `auto_retry_end`, and no fallback event. Unpatched, it produces `[3, 5, 5]`.

### Rewritten existing tests

`test/suite/regressions/issue-447-goal-continuation.test.ts` had one case pinning the old deletion behaviour ("does not send consumed goal-continuation prompts in the next faux-provider request"). It was **rewritten, not deleted**: it now asserts all 300 historical continuations reach the provider in stable chronological order and that the freshly typed prompt is still the final turn. #447's actual contract — bounding how many *new* continuations the goal extension queues, and suppressing auto-continuation on a flooded resume — is untouched and still covered by the other five cases in that file, which all pass.

The keep-latest assertions in `goal-continuation-context-exclusion.test.ts` and the un-floored delay expectations in `retry-fallback-hint-policy.test.ts` were likewise rewritten to assert the new contract, each retaining a real behavioural claim (ordering, idempotency, token-accounting parity with the transport, cumulative-wait accounting, demotion thresholds).

No tests were skipped or removed to reach green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps `goal-continuation` history append-only and floors same-model 429 retry waits to the exponential backoff. This restores provider cache-prefix stability and prevents retry storms when providers repeat short retry-after hints (fixes #1005).

Previously, only the newest `goal-continuation` was kept per request, rewriting provider-visible history and breaking the exact-prefix cache invariant; the context filter is now a no-op and the transport maps the full array, with growth bounded by existing compaction. The retry policy no longer lets a hint replace the schedule: every same-model wait is at least `baseDelayMs * 2 ** (attempt - 1)` in `nextInTurnDelayMs` and tier-2 `degradeWithoutFallback`; longer hints still win, and demotion accounting uses the floored delay. `agent-session` changes are comments only.

**Review and rollout**
- Review `src/core/messages.ts` (filter removal and `convertToLlm` append-only) and `src/core/retry-fallback/hint-policy.ts` (floor applied in all branches). No control-flow change in `src/core/agent-session.ts`.
- No migration or API changes; extensions and session JSONL are unchanged. Expect slightly larger histories; normal compaction bounds size.
- New regression tests cover cache-prefix stability and exponential floors; probe state machine, tier boundaries, and budgets are unchanged.

<sup>Written for commit 1ed732a8b7f68c2c6213e66b68fc2c38e35a0dd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

