### PR TITLE
fix(interactive): throttle large-session retry indicators

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Retry waits no longer animate decorative spinner frames at the default 80 ms cadence for sessions with at least 1,000 persisted entries, while the one-second countdown and small-session animation remain intact.
 - Settings hot-reload no longer cascades across sessions that share an agent directory when another session saves a routine preference such as `defaultModel` during a reload. The replacement watcher now compares reload-window changes with the request-time settings snapshot, so routine-only writes remain suppressed while substantive configuration edits still reload.
 - Settings hot-reload now clears the reload handoff unconditionally after `requestReload()` settles, preventing a stale plaintext settings snapshot from surviving when the reload successor omits the config-reload builtin.
 - Compaction no longer treats implausible Cursor billed usage as context size: when the local transcript estimate is at least 50k and billed usage is more than 8× that estimate, the threshold uses the estimate so a multi-million dashboard-cumulative cacheRead cannot force a useless compact (#983).

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## Large-session retry indicator cadence (2026-08-20)
+
+### What changed
+
+- Retry status indicators now reuse the existing large-session cadence policy instead of advancing their decorative spinner every 80 ms.
+- Sessions below the 1,000-entry boundary retain the existing animated retry indicator, while large sessions keep the independent one-second retry countdown visible.
+
+### Why
+
+- Every retry spinner frame requests a whole-TUI render. During provider rate-limit waits, large persisted sessions could spend an entire JavaScript core repeatedly rebuilding the transcript even though the network retry itself was sleeping.
+
+### Why an extension could not handle it
+
+- Retry lifecycle events, persisted session entry counts, status-indicator construction, and TUI render scheduling are owned by the built-in interactive runtime.
+
+### Expected merge conflict zones
+
+- LOW: `interactive-mode.ts` around `showRetryStatusIndicator()`.
+- LOW: `components/status-indicator.ts` around the retry indicator constructor.
+- LOW: `interactive-tui.test.ts` around retry status cadence coverage.
+
 ## Canonical interactive notice cards (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
+++ b/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
@@ -53,15 +53,23 @@ export class WorkingStatusIndicator extends StatusIndicator {
 export class RetryStatusIndicator extends StatusIndicator {
 	private countdown: CountdownTimer | undefined;
 
-	constructor(ui: TUI, attempt: number, maxAttempts: number, delayMs: number) {
+	constructor(ui: TUI, attempt: number, maxAttempts: number, delayMs: number, indicator?: LoaderIndicatorOptions) {
 		const retryMessage = (seconds: number) =>
 			`Retrying (${attempt}/${maxAttempts}) in ${seconds}s... (${keyText("app.interrupt")} to cancel)`;
+		const retryIndicator =
+			indicator === undefined
+				? undefined
+				: {
+						...indicator,
+						indicatorFormatter: indicator.indicatorFormatter ?? ((spinner) => theme.fg("warning", spinner)),
+					};
 		super(
 			"retry",
 			ui,
 			(spinner) => theme.fg("warning", spinner),
 			(text) => theme.fg("muted", text),
 			retryMessage(Math.ceil(delayMs / 1000)),
+			retryIndicator,
 		);
 		this.countdown = new CountdownTimer(
 			delayMs,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -307,6 +307,8 @@ function isCompactionCostNotice(item: RenderSessionItem): item is CompactionCost
 }
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
+const DEFAULT_RETRY_STATUS_REFRESH_INTERVAL_MS = 80;
+const LARGE_SESSION_RETRY_STATUS_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_WORKING_STATUS_REFRESH_INTERVAL_MS = 600;
 const DEFAULT_WORKING_STATUS_MESSAGE_ANIMATION_INTERVAL_MS = 32;
 const LARGE_SESSION_WORKING_STATUS_REFRESH_INTERVAL_MS = 60_000;
@@ -4624,10 +4626,7 @@ export class InteractiveMode {
 
 			case "summarization_retry_scheduled": {
 				this.showError(event.errorMessage);
-				this.showStatusIndicator(
-					new RetryStatusIndicator(this.ui, event.attempt, event.maxAttempts, event.delayMs),
-				);
-				this.ui.requestRender();
+				this.showSummarizationRetryStatusIndicator(event);
 				break;
 			}
 
@@ -4674,7 +4673,26 @@ export class InteractiveMode {
 	}
 
 	private showRetryStatusIndicator(event: Extract<AgentSessionEvent, { type: "auto_retry_start" }>): void {
-		this.showStatusIndicator(new RetryStatusIndicator(this.ui, event.attempt, event.maxAttempts, event.delayMs));
+		this.showRetryStatusIndicatorWithCadence(event);
+	}
+
+	private showSummarizationRetryStatusIndicator(
+		event: Extract<AgentSessionEvent, { type: "summarization_retry_scheduled" }>,
+	): void {
+		this.showRetryStatusIndicatorWithCadence(event);
+	}
+
+	private showRetryStatusIndicatorWithCadence(event: { attempt: number; maxAttempts: number; delayMs: number }): void {
+		const refreshIntervalMs = largeSessionWorkingStatusInterval(
+			this.sessionManager.getEntries().length,
+			DEFAULT_RETRY_STATUS_REFRESH_INTERVAL_MS,
+			LARGE_SESSION_RETRY_STATUS_REFRESH_INTERVAL_MS,
+		);
+		const indicator =
+			refreshIntervalMs === DEFAULT_RETRY_STATUS_REFRESH_INTERVAL_MS ? undefined : { intervalMs: refreshIntervalMs };
+		this.showStatusIndicator(
+			new RetryStatusIndicator(this.ui, event.attempt, event.maxAttempts, event.delayMs, indicator),
+		);
 		this.ui.requestRender();
 	}
 

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -388,3 +388,137 @@ describe("clear-on-shrink status spacing", () => {
 		}
 	});
 });
+
+type RetryStatusEvent = {
+	attempt: number;
+	maxAttempts: number;
+	delayMs: number;
+};
+
+type RetryStatusContext = {
+	ui: TUI;
+	statusContainer: Container;
+	activeStatusIndicator: (Component & { dispose(): void }) | undefined;
+	runtimeHost: {
+		session: {
+			sessionManager: { getEntries(): readonly unknown[] };
+		};
+	};
+};
+
+type RetryInteractiveModePrototype = {
+	showRetryStatusIndicator(this: RetryStatusContext, event: RetryStatusEvent & { type: "auto_retry_start" }): void;
+	showSummarizationRetryStatusIndicator(
+		this: RetryStatusContext,
+		event: RetryStatusEvent & { type: "summarization_retry_scheduled" },
+	): void;
+};
+
+const retryInteractiveModePrototype = InteractiveMode.prototype as unknown as RetryInteractiveModePrototype;
+
+function createRetryStatusContext(sessionEntryCount: number): RetryStatusContext {
+	const ui = createInteractiveTui({
+		tuiMode: "regular",
+		showHardwareCursor: false,
+		logDirectory: "/tmp",
+		terminal: new RecordingTerminal(80, 24),
+	});
+	return Object.assign(Object.create(InteractiveMode.prototype), {
+		ui,
+		statusContainer: new Container(),
+		activeStatusIndicator: undefined,
+		runtimeHost: {
+			session: {
+				sessionManager: {
+					getEntries: () => Array.from({ length: sessionEntryCount }, () => ({})),
+				},
+			},
+		},
+	}) as RetryStatusContext;
+}
+
+function renderRetryStatus(context: RetryStatusContext): string {
+	const component = context.statusContainer.children[0];
+	if (!component) throw new Error("retry status indicator was not mounted");
+	return component.render(80).join("\n");
+}
+
+describe("retry indicator cadence", () => {
+	it("throttles retry indicator animation for large sessions", () => {
+		initTheme("dark");
+		vi.useFakeTimers();
+		const context = createRetryStatusContext(1_000);
+
+		try {
+			retryInteractiveModePrototype.showRetryStatusIndicator.call(context, {
+				type: "auto_retry_start",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 5_000,
+			});
+			const initialFrame = renderRetryStatus(context);
+
+			vi.advanceTimersByTime(999);
+			expect(renderRetryStatus(context)).toBe(initialFrame);
+
+			vi.advanceTimersByTime(1);
+			expect(renderRetryStatus(context)).not.toBe(initialFrame);
+		} finally {
+			context.activeStatusIndicator?.dispose();
+			context.ui.stop();
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps retry indicator animation for small sessions", () => {
+		initTheme("dark");
+		vi.useFakeTimers();
+		const context = createRetryStatusContext(999);
+
+		try {
+			retryInteractiveModePrototype.showRetryStatusIndicator.call(context, {
+				type: "auto_retry_start",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 5_000,
+			});
+			const initialFrame = renderRetryStatus(context);
+
+			vi.advanceTimersByTime(80);
+			expect(renderRetryStatus(context)).not.toBe(initialFrame);
+		} finally {
+			context.activeStatusIndicator?.dispose();
+			context.ui.stop();
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
+	});
+
+	it("throttles summarization retry animation for large sessions", () => {
+		initTheme("dark");
+		vi.useFakeTimers();
+		const context = createRetryStatusContext(1_000);
+
+		try {
+			retryInteractiveModePrototype.showSummarizationRetryStatusIndicator.call(context, {
+				type: "summarization_retry_scheduled",
+				attempt: 1,
+				maxAttempts: 3,
+				delayMs: 5_000,
+			});
+			const initialFrame = renderRetryStatus(context);
+
+			vi.advanceTimersByTime(999);
+			expect(renderRetryStatus(context)).toBe(initialFrame);
+
+			vi.advanceTimersByTime(1);
+			expect(renderRetryStatus(context)).not.toBe(initialFrame);
+		} finally {
+			context.activeStatusIndicator?.dispose();
+			context.ui.stop();
+			vi.clearAllTimers();
+			vi.useRealTimers();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- throttle decorative retry spinner animation for sessions with at least 1,000 persisted entries
- preserve the one-second retry countdown and the existing small-session 80 ms animation
- apply the same cadence policy to automatic retries and summarization retries
- preserve warning-color formatting when the retry indicator uses custom Loader options

## Why

During provider retry waits, the default 80 ms spinner requested whole-TUI renders even though the network retry itself was sleeping. On large persisted sessions, repeatedly rebuilding the transcript could consume an entire JavaScript core.

## Validation

- focused Vitest: 2 files, 16 tests passed
- `npm run check`: passed
- `npm run build`: passed across all workspace phases
- `npm test`: passed across the full workspace
- browser-rendered xterm.js QA: warning spinner, muted retry copy, visible countdown and cancel hint
- raw PTY QA: 8 render requests over 3.2 seconds, 4 synchronized frame starts / 4 ends, balanced
- independent QA reproduction: 7 render requests over 3.2 seconds and 16/16 focused tests

## Evidence

QA receipts are stored locally under:

`local-ignore/qa-evidence/20260820-large-session-retry-indicator-cadence/`

## Review

Five parallel review lanes covered goal compliance, code quality, security/reliability, hands-on QA, and repository/Git context. Review findings were addressed before this PR: rebased onto current `main`, covered summarization retries, and added the required changelog entry.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttles the retry status indicator for large persisted sessions to avoid full-TUI renders during retry sleeps. Previously the spinner advanced every 80 ms for all sessions; now large sessions reuse the large‑session cadence while keeping the one‑second countdown and small‑session animation.

- Applies to both automatic retries and summarization retries.
- Threshold: ≥1,000 entries. Small sessions refresh at 80 ms; large sessions refresh at 60 s while the countdown still ticks each second.
- Preserves warning-color formatting even when `Loader` options are provided; `RetryStatusIndicator` now accepts optional indicator options, with a default formatter applied if none is set.
- Coverage added for cadence on small vs large sessions and summarization retries.

<sup>Written for commit a4875bb1c282eafa15e6f1197c51af3efd0520f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

