### PR TITLE
perf(coding-agent): defer the Claude Agent SDK and jsdom out of the startup import graph

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -42,6 +42,11 @@
   background block, bold tone title, dim body): loaded-resource conflict diagnostics, the update-available
   and package-update notifications, the risky-main-model and high-reasoning warnings, the rules banner,
   the prompt URL widget card, and the earendil announcement. Visible text is unchanged.
+- The CLI no longer parses and evaluates the 1.2 MB Claude Agent SDK bundle or the jsdom/Readability/turndown
+  HTML stack while starting up. Both now load on first use behind the repository's documented lazy-boundary
+  pattern — the SDK when a claude-sdk-oauth stream actually opens, the HTML converters when webfetch actually
+  converts an HTML response — which removes 680 modules from the startup import graph (14,203 → 13,523).
+  Behavior is unchanged; only the moment the two dependencies are loaded moved.
 
 - Startup is faster after the first run: the CLI now enables Node's on-disk module compile cache
   (`enableCompileCache()`) in both `cli.ts` and `cli-main.ts` and publishes the resolved cache directory

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -52,6 +52,43 @@ A stream-start-timeout abort closes the SDK session with the turn's user message
 - `session-observability.ts` `ContinuityReason` union tail and `SANITIZED_REASONS` set (mechanically
   duplicated literals; both must gain the member).
 
+## 2026-08-20 - SDK bundle loads on first stream instead of at CLI startup
+
+### What changed
+
+- New `sdk-boundary.lazy.ts` owns the single deferred `import("@anthropic-ai/claude-agent-sdk")`, caching the
+  module and sharing one in-flight promise across concurrent callers. `sdk-boundary.ts` keeps its synchronous
+  `getSdkBoundary()` surface and re-exports `loadClaudeAgentSdk`; its default members read the loaded module
+  (`getSessionMessages` is async and self-loads, `query` / `createSdkMcpServer` are synchronous SDK functions
+  and therefore require the preload). Its exported types are now derived from the loader's module type instead
+  of from value imports.
+- The three async entry points that reach a synchronous SDK member now await the loader first:
+  `stream.ts` (`streamClaudeSdkOauth`, before `getSdkBoundary().query` and the resident-session lane),
+  `session-reattach.ts` (`reattachSession`, before `getOrCreateSession` builds a query), and `custom-tools.ts`
+  (`buildCustomToolServers`, now async, before `createSdkMcpServer`). A future call site that skips the preload
+  fails with a named error at that call rather than silently restoring the startup import.
+- The tiny `@anthropic-ai/claude-agent-sdk/extract` entrypoint used by `executable.ts` is unaffected and stays
+  a static import; only the 1.2 MB `sdk.mjs` bundle moved.
+
+### Why
+
+- Importing `dist/main.js` is roughly 70% of CLI boot wall time, and the SDK bundle was parsed and evaluated on
+  every start even though only the claude-sdk-oauth streaming lane ever calls into it. Deferring it removes that
+  cost from every run that never opens a Claude SDK stream, with no behavior change for runs that do.
+
+### Why an extension could not handle it
+
+- The static import lives in this builtin provider's own SDK boundary module. An extension cannot remove an
+  import edge from a module the core already loads, and re-registering the provider id would fork the auth lane,
+  session registry, and failover wiring that live here.
+
+### Expected merge conflict zones
+
+- MEDIUM in `sdk-boundary.ts`: the import block and the `defaultSdkBoundary` literal, which upstream also touches
+  when adding SDK members. A new member must be added to `sdk-boundary.lazy.ts`'s module projection as well.
+- LOW in `stream.ts` and `session-reattach.ts` at the first statement of the async body (the added `await`).
+- LOW in `custom-tools.ts` at the `buildCustomToolServers` signature, now async.
+
 ## 2026-08-19 - Kill-switched lane leaves implicit fallback expansion
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/custom-tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/custom-tools.ts
@@ -1,6 +1,6 @@
 import type { Tool } from "@earendil-works/pi-ai";
 import { jsonSchemaToZodShape } from "./custom-tools-schema.ts";
-import { getSdkBoundary, type SdkBoundary } from "./sdk-boundary.ts";
+import { getSdkBoundary, loadClaudeAgentSdk, type SdkBoundary } from "./sdk-boundary.ts";
 import { CUSTOM_TOOLS_MCP_SERVER_NAME, TOOL_EXECUTION_DENIED_MESSAGE } from "./tools.ts";
 
 type CustomToolsMcpServer = ReturnType<SdkBoundary["createSdkMcpServer"]>;
@@ -16,8 +16,13 @@ export async function denyCustomToolExecution() {
  * Exposes senpi-only tools to Claude Code's planner. The SDK handler is deliberately
  * unusable: senpi receives the matching streamed tool call and executes it itself.
  */
-export function buildCustomToolServers(customTools: readonly Tool[]): Record<string, CustomToolsMcpServer> | undefined {
+export async function buildCustomToolServers(
+	customTools: readonly Tool[],
+): Promise<Record<string, CustomToolsMcpServer> | undefined> {
 	if (customTools.length === 0) return undefined;
+	// `createSdkMcpServer` is a synchronous SDK member behind a lazy boundary;
+	// awaiting here is what makes this call site self-sufficient.
+	await loadClaudeAgentSdk();
 	const server = getSdkBoundary().createSdkMcpServer({
 		name: CUSTOM_TOOLS_MCP_SERVER_NAME,
 		version: "1.0.0",

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.lazy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.lazy.ts
@@ -1,0 +1,61 @@
+/**
+ * Lazy boundary for the Claude Agent SDK runtime module.
+ *
+ * `@anthropic-ai/claude-agent-sdk`'s entrypoint is a ~1.2 MB single-file
+ * bundle that every CLI start parses and evaluates today, even though only the
+ * claude-sdk-oauth streaming lane ever calls into it. This module owns the one
+ * deferred import; `sdk-boundary.ts` keeps the synchronous `getSdkBoundary()`
+ * surface its callers depend on and simply refuses to hand out SDK functions
+ * before {@link loadClaudeAgentSdk} has resolved.
+ *
+ * That split is what keeps the deferral honest: the SDK's `query` and
+ * `createSdkMcpServer` are synchronous, so their call sites cannot await. Every
+ * one of them is reached from an async entry point that awaits this loader
+ * first (the `streamClaudeSdkOauth` async body, `reattachSession`,
+ * `verifyRestoredTranscript`), so the module is always resident by the time a
+ * synchronous member is read — and a future call site that forgets to preload
+ * fails loudly and locally instead of silently regressing startup.
+ *
+ * Follows the repository's documented lazy-boundary pattern
+ * (`packages/ai/src/api/*.lazy.ts`); `test/startup-import-graph.test.ts` fails
+ * if a static edge to the SDK reappears.
+ */
+import type { createSdkMcpServer, getSessionMessages, query } from "@anthropic-ai/claude-agent-sdk";
+
+export type ClaudeAgentSdkModule = {
+	query: typeof query;
+	createSdkMcpServer: typeof createSdkMcpServer;
+	getSessionMessages: typeof getSessionMessages;
+};
+
+let loaded: ClaudeAgentSdkModule | undefined;
+let loading: Promise<ClaudeAgentSdkModule> | undefined;
+
+/**
+ * Loads the SDK once and caches it. Concurrent callers share the in-flight
+ * promise; a failed load is not cached, so a later attempt can retry.
+ */
+export function loadClaudeAgentSdk(): Promise<ClaudeAgentSdkModule> {
+	if (loaded) return Promise.resolve(loaded);
+	loading ??= import("@anthropic-ai/claude-agent-sdk")
+		.then((module) => {
+			loaded = {
+				query: module.query,
+				createSdkMcpServer: module.createSdkMcpServer,
+				getSessionMessages: module.getSessionMessages,
+			};
+			return loaded;
+		})
+		.finally(() => {
+			loading = undefined;
+		});
+	return loading;
+}
+
+/**
+ * The loaded SDK, or `undefined` when nothing has awaited
+ * {@link loadClaudeAgentSdk} yet.
+ */
+export function loadedClaudeAgentSdk(): ClaudeAgentSdkModule | undefined {
+	return loaded;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts
@@ -7,9 +7,10 @@ import type {
 	SettingSource,
 	ThinkingConfig,
 } from "@anthropic-ai/claude-agent-sdk";
-import { createSdkMcpServer, getSessionMessages, query } from "@anthropic-ai/claude-agent-sdk";
 import type { Base64ImageSource, ContentBlockParam } from "@anthropic-ai/sdk/resources";
+import { loadClaudeAgentSdk, loadedClaudeAgentSdk } from "./sdk-boundary.lazy.ts";
 
+export { loadClaudeAgentSdk } from "./sdk-boundary.lazy.ts";
 export type {
 	Base64ImageSource,
 	ContentBlockParam,
@@ -22,7 +23,9 @@ export type {
 	ThinkingConfig,
 };
 
-export type SdkQueryInput = Parameters<typeof query>[0];
+type SdkModule = Awaited<ReturnType<typeof loadClaudeAgentSdk>>;
+
+export type SdkQueryInput = Parameters<SdkModule["query"]>[0];
 export type SdkQueryHandle = AsyncIterable<SDKMessage> & {
 	interrupt(): Promise<unknown>;
 	setModel?: (model?: string) => Promise<void>;
@@ -33,11 +36,36 @@ export type SdkQuery = (input: SdkQueryInput) => SdkQueryHandle;
 
 export type SdkBoundary = {
 	query: SdkQuery;
-	createSdkMcpServer: typeof createSdkMcpServer;
-	getSessionMessages: typeof getSessionMessages;
+	createSdkMcpServer: SdkModule["createSdkMcpServer"];
+	getSessionMessages: SdkModule["getSessionMessages"];
 };
 
-const defaultSdkBoundary: SdkBoundary = { query, createSdkMcpServer, getSessionMessages };
+/**
+ * Reads the deferred SDK module for a synchronous boundary member.
+ *
+ * `query` and `createSdkMcpServer` are synchronous SDK functions, so the
+ * default boundary cannot await here. Every caller reaches these through an
+ * async entry point that awaits `loadClaudeAgentSdk()` first, which makes an
+ * unloaded module a wiring defect rather than a runtime condition — and this
+ * names it at the exact call that skipped the preload.
+ */
+function requireLoadedSdk(member: keyof SdkBoundary): SdkModule {
+	const sdk = loadedClaudeAgentSdk();
+	if (!sdk) {
+		throw new Error(
+			`Claude Agent SDK was not preloaded before '${member}'. ` +
+				`Await loadClaudeAgentSdk() on the entry path before reaching the SDK boundary.`,
+		);
+	}
+	return sdk;
+}
+
+const defaultSdkBoundary: SdkBoundary = {
+	query: (input) => requireLoadedSdk("query").query(input),
+	createSdkMcpServer: (options) => requireLoadedSdk("createSdkMcpServer").createSdkMcpServer(options),
+	getSessionMessages: async (sessionId, options) =>
+		(await loadClaudeAgentSdk()).getSessionMessages(sessionId, options),
+};
 let activeSdkBoundary = defaultSdkBoundary;
 
 export function getSdkBoundary(): SdkBoundary {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-reattach.ts
@@ -1,6 +1,6 @@
 import type { ClaudeSdkOauthAuthLane } from "./options.ts";
 import type { Options, SessionMessage } from "./sdk-boundary.ts";
-import { getSdkBoundary } from "./sdk-boundary.ts";
+import { getSdkBoundary, loadClaudeAgentSdk } from "./sdk-boundary.ts";
 import { type ClaudeSdkOauthSessionEntry, closeSession, getOrCreateSession } from "./session-registry.ts";
 import { recordSyncedStream } from "./session-sync.ts";
 
@@ -142,6 +142,9 @@ async function awaitInitialization(entry: ClaudeSdkOauthSessionEntry, signal?: A
  * (sdk.d.ts:1805-1808) and would otherwise silently start an unrelated session.
  */
 export async function reattachSession(input: ReattachInput): Promise<ClaudeSdkOauthSessionEntry> {
+	// getOrCreateSession() reaches the synchronous SDK `query` through the
+	// session-registry boundary - see sdk-boundary.lazy.ts.
+	await loadClaudeAgentSdk();
 	const { binding, atUuid } = input;
 	closeSession(binding.senpiSessionId, "reattach");
 	const entry = getOrCreateSession({

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
@@ -14,7 +14,7 @@ import { defaultExecutableDeps, resolveClaudeCodeExecutable } from "./executable
 import { buildClaudeSdkOauthQueryOptions } from "./options.ts";
 import { buildPromptBlocks, buildPromptStream } from "./prompt-bridge.ts";
 import { dedupeUltraworkBlocks } from "./prompt-directive-dedupe.ts";
-import { getSdkBoundary, type SdkQueryHandle } from "./sdk-boundary.ts";
+import { getSdkBoundary, loadClaudeAgentSdk, type SdkQueryHandle } from "./sdk-boundary.ts";
 import { type ContinuityObservation, emitContinuityObservation } from "./session-observability.ts";
 import { residentSessionMessages } from "./session-stream.ts";
 import { loadClaudeSdkOauthProviderSettingsFromDisk } from "./settings.ts";
@@ -58,13 +58,16 @@ export function streamClaudeSdkOauth(
 		else options?.signal?.addEventListener("abort", onAbort, { once: true });
 
 		try {
+			// Resident before the synchronous SDK member below (getSdkBoundary().query)
+			// reads it - see sdk-boundary.lazy.ts.
+			await loadClaudeAgentSdk();
 			const resolvedTools = resolveSdkTools(context);
 			const affinityKey = options?.affinitySessionId ?? options?.sessionId;
 			const sessionKey = options?.sessionId ? toolWatch.sessionKey(options.sessionId) : undefined;
 			if (sessionKey) toolWatch.reconcileWithContext(sessionKey, context);
 			const toolWatchNote = toolWatch.buildPromptNote(sessionKey, context, resolvedTools.customToolNameToSdk);
 			const providerSettings = loadClaudeSdkOauthProviderSettingsFromDisk(process.cwd());
-			const mcpServers = buildCustomToolServers(resolvedTools.customTools);
+			const mcpServers = await buildCustomToolServers(resolvedTools.customTools);
 			const executable = resolveClaudeCodeExecutable(defaultExecutableDeps());
 			const buildOptions = (authLane: Parameters<typeof buildClaudeSdkOauthQueryOptions>[0]["authLane"]) => {
 				const queryOptions = buildClaudeSdkOauthQueryOptions({

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
@@ -11,6 +11,35 @@ Vendored from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-we
 - Tistory-style article containers are preferred over surrounding blog chrome, noisy related-post/sidebar blocks are stripped from the cloned article, and text conversion uses a DOM pass to preserve readable line breaks.
 - Standalone Bun builds rewrite jsdom 29's eager worker lookup to select the compiled worker entry only in standalone executables while retaining jsdom's normal `require.resolve()` behavior under Node, then compile that worker as an explicit entrypoint. Without both steps, the executable captures the CI checkout path and fails during startup on machines where that path does not exist. This must be handled in the host build because an extension cannot change third-party module resolution inside an already-compiled executable.
 
+## 2026-08-20 - HTML converters load on first conversion instead of at CLI startup
+
+### What changed
+
+- New `webfetch/content.lazy.ts` wraps `webfetch/content.ts` behind a single deferred import and exposes the
+  same two functions as async, so jsdom, `@mozilla/readability` and turndown load on the first HTML conversion
+  instead of at process start.
+- `webfetch/tool.ts` imports the converters from that boundary and awaits `htmlToMarkdown` / `htmlToText`. Both
+  call sites already sat inside the tool's async `execute`, so the conversion result, output shape and error
+  behavior are unchanged.
+
+### Why
+
+- jsdom is the single heaviest package in the CLI's startup import graph, and nothing in it is needed until the
+  webfetch tool actually converts an HTML response. Deferring it removes that parse/evaluate cost from every
+  run, and costs a conversion nothing beyond the one-time load that run would have paid anyway.
+
+### Why an extension could not handle it
+
+- The import edge originates in this vendored builtin's own tool module, which the core loads during extension
+  registration. An extension cannot remove an import edge from a module the core already loads.
+
+### Expected merge conflict zones
+
+- LOW in `webfetch/tool.ts` at the `content` import line and at the two conversion call sites inside `execute`;
+  re-vendoring from `code-yeongyu/pi-webfetch` restores the direct import and the non-awaited calls, so this
+  boundary must be re-applied together with the `HeadersInit` patch noted below.
+- `webfetch/content.ts` itself is untouched, so a re-vendor of that file cannot conflict.
+
 ## Conflict zones
 
 Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the `HeadersInit` patch and Tistory article/noise selector behavior after re-running the transform, then re-check `npm run check`. A jsdom upgrade can also change the worker lookup patched by `scripts/prepare-bun-compile-assets.mjs`; keep its fixture and the explicit worker entrypoints in `scripts/build-binaries.sh` and `packages/coding-agent/package.json` aligned.

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.lazy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/content.lazy.ts
@@ -1,0 +1,24 @@
+/**
+ * Lazy boundary for the HTML-to-text/markdown converters.
+ *
+ * `content.ts` pulls in jsdom (plus Readability and turndown), the single
+ * heaviest package in the CLI's startup import graph. Nothing is needed until
+ * the webfetch tool actually converts an HTML response, so the module loads on
+ * first conversion instead of at process start. Both call sites are already
+ * async, so deferring costs nothing beyond the one-time load the run would
+ * have paid anyway.
+ *
+ * Follows the repository's documented lazy-boundary pattern
+ * (`packages/ai/src/api/*.lazy.ts`); `test/startup-import-graph.test.ts` fails
+ * if a static edge to jsdom reappears.
+ */
+
+const loadContentModule = () => import("./content.ts");
+
+export async function htmlToMarkdown(html: string, url: string): Promise<string> {
+	return (await loadContentModule()).htmlToMarkdown(html, url);
+}
+
+export async function htmlToText(html: string, url: string): Promise<string> {
+	return (await loadContentModule()).htmlToText(html, url);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/tool.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/tool.ts
@@ -2,7 +2,7 @@ import { StringEnum } from "@earendil-works/pi-ai";
 import { Type } from "typebox";
 import { defineTool } from "../../../types.ts";
 
-import { htmlToMarkdown, htmlToText } from "./content.ts";
+import { htmlToMarkdown, htmlToText } from "./content.lazy.ts";
 import { clampTimeout, fetchUrl, type WebfetchFormat } from "./fetcher.ts";
 
 const WEBFETCH_FORMATS = ["markdown", "text", "html"] as const;
@@ -129,10 +129,10 @@ export const webfetch = defineTool<typeof Params, WebfetchRenderDetails>({
 		let converted = false;
 
 		if (isHtml && format === "markdown") {
-			text = htmlToMarkdown(raw, fetched.url);
+			text = await htmlToMarkdown(raw, fetched.url);
 			converted = true;
 		} else if (isHtml && format === "text") {
-			text = htmlToText(raw, fetched.url);
+			text = await htmlToText(raw, fetched.url);
 			converted = true;
 		}
 

--- a/packages/coding-agent/test/claude-sdk-oauth-tools.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-tools.test.ts
@@ -42,8 +42,8 @@ describe("Claude SDK OAuth tool integration", () => {
 		expect(resolveSdkTools({ messages: [] }).sdkTools).toEqual(BUILTIN_SDK_TOOLS);
 	});
 
-	it("builds one in-process custom-tools MCP server for active custom tools", () => {
-		const servers = buildCustomToolServers([tool("repoSearch")]);
+	it("builds one in-process custom-tools MCP server for active custom tools", async () => {
+		const servers = await buildCustomToolServers([tool("repoSearch")]);
 		expect(Object.keys(servers ?? {})).toEqual(["custom-tools"]);
 	});
 

--- a/packages/coding-agent/test/helpers/esm-import-graph-probe.ts
+++ b/packages/coding-agent/test/helpers/esm-import-graph-probe.ts
@@ -48,25 +48,39 @@ function ensureBuiltDependencyLink(repoRoot: string): () => void {
 	}
 }
 
+/**
+ * Records the static-import graph Node actually walks while importing
+ * `entryPath`, using the same loader-hook probe as
+ * `probeModelRuntimeImport`. Deferred (`await import(...)`) modules never
+ * appear, so the result is the startup graph a cold CLI process pays for.
+ */
+export function probeImportGraph(repoRoot: string, entryPath: string): ImportGraphProbeResult {
+	return runImportProbe(repoRoot, resolve(entryPath), "pi-import-graph-");
+}
+
 export function probeModelRuntimeImport(repoRoot: string, target: "source" | "built"): ImportGraphProbeResult {
-	const scratch = mkdtempSync(join(tmpdir(), "pi-model-runtime-import-"));
+	const targetPath =
+		target === "source"
+			? join(repoRoot, "packages/coding-agent/src/core/model-runtime.ts")
+			: join(repoRoot, "packages/coding-agent/dist/core/model-runtime.js");
+	return runImportProbe(repoRoot, resolve(targetPath), "pi-model-runtime-import-");
+}
+
+function runImportProbe(repoRoot: string, targetPath: string, scratchPrefix: string): ImportGraphProbeResult {
+	const scratch = mkdtempSync(join(tmpdir(), scratchPrefix));
 	const logPath = join(scratch, "graph.jsonl");
 	writeFileSync(join(scratch, "hook.mjs"), hookSource);
 	writeFileSync(join(scratch, "register.mjs"), registerSource);
 	writeFileSync(join(scratch, "driver.mjs"), driverSource);
 	const cleanupLink = ensureBuiltDependencyLink(repoRoot);
 	try {
-		const targetPath =
-			target === "source"
-				? join(repoRoot, "packages/coding-agent/src/core/model-runtime.ts")
-				: join(repoRoot, "packages/coding-agent/dist/core/model-runtime.js");
-		const args = ["--import", join(scratch, "register.mjs"), join(scratch, "driver.mjs"), resolve(targetPath)];
+		const args = ["--import", join(scratch, "register.mjs"), join(scratch, "driver.mjs"), targetPath];
 		const child = spawnSync(process.execPath, args, {
 			cwd: repoRoot,
 			env: { ...process.env, PI_IMPORT_GRAPH_LOG: logPath },
 			encoding: "utf8",
 		});
-		if (child.status !== 0) throw new Error(`Import probe failed (${target}): ${child.stderr || child.stdout}`);
+		if (child.status !== 0) throw new Error(`Import probe failed (${targetPath}): ${child.stderr || child.stdout}`);
 		const output = JSON.parse(child.stdout.trim()) as { globalsAdded: string[] };
 		const entries = readFileSync(logPath, "utf8")
 			.trim()

--- a/packages/coding-agent/test/startup-import-graph.test.ts
+++ b/packages/coding-agent/test/startup-import-graph.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Startup static-import-graph regression guard.
+ *
+ * Importing `dist/main.js` is ~70% of CLI boot wall time, and every package
+ * statically reachable from it is parsed, compiled and evaluated before the
+ * first frame renders — whether or not the run ever uses that package. The
+ * modules asserted here are used only inside call-time code paths (a webfetch
+ * tool invocation, a Claude-SDK-OAuth stream), so they belong behind the
+ * repository's documented lazy boundaries and must stay there.
+ *
+ * The probe is Node's own loader hook, not a source scan: it records what the
+ * runtime really resolves, so a deferred `await import(...)` is absent by
+ * construction while any reintroduced top-level edge — direct or transitive,
+ * through any re-export chain — reappears and fails this test.
+ */
+import { describe, expect, it } from "vitest";
+import { probeImportGraph } from "./helpers/esm-import-graph-probe.ts";
+import { assertWorkspaceBuildPrerequisite } from "./support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
+
+const repoRoot = new URL("../../..", import.meta.url).pathname;
+
+/**
+ * Packages whose cost is paid on every start today and is wasted unless the
+ * run actually reaches the owning feature. `pattern` matches the resolved URL
+ * so a transitive edge cannot slip through under a different specifier.
+ */
+const DEFERRED_STARTUP_PACKAGES = [
+	{
+		specifier: "jsdom",
+		pattern: /\/node_modules\/jsdom\//u,
+		owner: "webfetch HTML conversion (core/extensions/builtin/webfetch/webfetch/content.lazy.ts)",
+	},
+	{
+		specifier: "@anthropic-ai/claude-agent-sdk",
+		pattern: /\/node_modules\/@anthropic-ai\/claude-agent-sdk\/sdk\.mjs$/u,
+		owner: "claude-sdk-oauth streaming lane (core/extensions/builtin/claude-sdk-oauth/sdk-boundary.lazy.ts)",
+	},
+] as const;
+
+describe("CLI startup import graph", () => {
+	it("does not statically reach deferred heavy packages from dist/main.js", () => {
+		const result = probeImportGraph(repoRoot, `${repoRoot}/packages/coding-agent/dist/main.js`);
+
+		// Guards the probe itself: a graph this small means the walk failed, not
+		// that the CLI got lean, and every assertion below would pass vacuously.
+		expect(result.entries.length).toBeGreaterThan(500);
+
+		for (const { specifier, pattern, owner } of DEFERRED_STARTUP_PACKAGES) {
+			const reached = result.entries.filter((entry) => entry.specifier === specifier || pattern.test(entry.url));
+			expect(
+				reached.map((entry) => entry.url),
+				`${specifier} is statically reachable from dist/main.js; it must stay behind the lazy boundary owned by ${owner}`,
+			).toEqual([]);
+		}
+	});
+});


### PR DESCRIPTION
## What

`@anthropic-ai/claude-agent-sdk` (a 1.2 MB single-file bundle) and the webfetch HTML stack
(jsdom + `@mozilla/readability` + turndown) were parsed and evaluated on **every** CLI start,
even though only a claude-sdk-oauth stream and a webfetch HTML conversion ever use them.
Importing `dist/main.js` is roughly 70% of boot wall time, so every run that never reached
either feature still paid for both.

Both now load on first use behind the repository's documented lazy-boundary pattern
(`packages/ai/src/api/*.lazy.ts`):

- **`claude-sdk-oauth/sdk-boundary.lazy.ts`** owns the single deferred SDK import, caches the
  module and shares one in-flight promise across concurrent callers. `sdk-boundary.ts` keeps its
  synchronous `getSdkBoundary()` surface (callers are unchanged) and derives its exported types
  from the loader's module type instead of from value imports.
- **`webfetch/webfetch/content.lazy.ts`** wraps `content.ts` and exposes the two converters as
  async. Both call sites already sat inside the tool's async `execute`, so nothing else moved.

`getSessionMessages` is async and self-loads. `query` and `createSdkMcpServer` are *synchronous*
SDK functions, so the three async entry points that reach them await the loader first —
`streamClaudeSdkOauth`, `reattachSession`, and `buildCustomToolServers` (now async). A future call
site that forgets the preload fails with a named error at that exact call instead of silently
restoring the startup import.

The tiny `@anthropic-ai/claude-agent-sdk/extract` entrypoint used by `executable.ts` (6.6 KB) is
unrelated to the heavy bundle and deliberately stays a static import.

**Zero behavior change.** Only the moment the two dependencies load moved.

## Failing-first proof

`test/startup-import-graph.test.ts` probes the graph with Node's own loader hook (not a source
scan), so a deferred `await import(...)` is absent by construction while any reintroduced
top-level edge — direct or transitive, through any re-export chain — reappears and fails.

**RED** — same test, same commit, against a build of `main` without the lazy boundaries:

```
 FAIL  test/startup-import-graph.test.ts > CLI startup import graph > does not statically reach deferred heavy packages from dist/main.js
AssertionError: jsdom is statically reachable from dist/main.js; it must stay behind the lazy boundary owned by webfetch HTML conversion (core/extensions/builtin/webfetch/webfetch/content.lazy.ts): expected [ …(2) ] to deeply equal []

- Expected
+ Received

- []
+ [
+   ".../node_modules/jsdom/lib/api.js",
+   ".../node_modules/jsdom/lib/api.js",
+ ]

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

The assertion stops at the first offender, so here is the full per-package count from the same
two builds (`probeImportGraph` on `dist/main.js`):

| package | before | after |
|---|---|---|
| `jsdom` | 2 | **0** |
| `@mozilla/readability` | 2 | **0** |
| `turndown` | 2 | **0** |
| `@anthropic-ai/claude-agent-sdk` (`sdk.mjs`, 1.2 MB) | 4 | **0** |
| `@anthropic-ai/claude-agent-sdk/extract` (6.6 KB, unrelated) | — | 2 |
| **total modules in the startup graph** | **14,203** | **13,523** |

**GREEN** — with the lazy boundaries:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

## Measurements

Machine: Apple M4 Pro (14c), macOS 26.4.1, node v26.7.0. Warm FS cache. Both sides built from
this same worktree back-to-back in one session under an exclusive bench lock (`before` = this
branch with the lazy diff reverted and its two `.lazy.ts` modules removed, rebuilt and the stale
`*.lazy.js` artifacts pruned; `after` = the full diff). 1-min loadavg is recorded per pass — a
concurrent lane shares this machine, so passes are only compared against passes taken at a
comparable load, and user-CPU is reported alongside wall time because it is load-invariant.

### `hyperfine --warmup 3 --runs 10 'node packages/coding-agent/dist/cli-main.js --help'`

| pass | loadavg (1-min) | mean ± σ | min | user CPU |
|---|---|---|---|---|
| before | 11.34 | 1.241 s ± 0.045 s | 1.179 s | 1.250 s |
| after | 10.17 | 1.064 s ± 0.058 s | 0.967 s | 1.061 s |
| after (repeat) | 8.64 | 0.990 s ± 0.040 s | 0.942 s | 0.989 s |

**-177 ms mean (-14.3%)** at comparable load; **-189 ms user CPU (-15.1%)**, which does not
depend on machine load. The repeat pass at a lower load shows the same delta direction and size.

### Import-only cost of `dist/main.js` (`Date.now()` around `await import(...)`, 7 runs)

| pass | loadavg (1-min) | runs (ms) | mean |
|---|---|---|---|
| before | 11.34 | 853, 862, 886, 882, 893, 905, 881 | **880 ms** |
| after | 10.17 | 694, 722, 683, 668, 688, 718, 693 | **695 ms** |
| after (repeat) | 8.64 | 647, 641, 648, 643, 642, 645, 630 | **642 ms** |

**-185 ms (-21%)** on the module graph alone — this is the isolated cost this PR removes, and it
matches the 680-module reduction in the graph table above.

### Startup smoke (`npm run profile:rpc -- --skip-build --runs 3 --warmup 1`)

After the change, at loadavg 8.3: median 1350.9 ms, min 1342.8 ms across 3 runs. This drives a
real boot to a served `get_state` RPC response, so it exercises the full CLI startup path
(including extension registration, where both deferred modules used to be pulled in).

`npm run profile:tui` cannot run in this environment — it requires a controlling terminal and
exits with `TUI benchmark must be run from an interactive terminal` / `PI_STARTUP_BENCHMARK only
supports interactive mode`. The RPC profiler covers the same startup path headlessly.

## Verification

- `npm run build` (root) clean.
- `npm run check` green (biome, pinned-deps, ts-imports, shrinkwrap, install-lock,
  claude-sdk-platform-lock, `tsc --noEmit`, browser smoke).
- `packages/coding-agent` `npm test`: **8,503 passed**, 36 skipped, 2 failed — both in
  `test/cursor-cli-oauth/shutdown.test.ts`, which spawns a real process tree with a 5 s deadline.
  Pre-existing and unrelated: this PR touches no cursor path, and the file fails identically in
  isolation on unmodified `main`.
- Focused suites green: all 54 `claude-sdk-oauth*` / `webfetch*` / `export*` files
  (426 passed, 3 skipped), plus `startup-import-graph`, `claude-sdk-oauth-tools`, and
  `model-runtime-text-toolcall-recovery` (the sibling import-graph probe test).
- `node scripts/check-pr-changelog.mjs --base origin/main`: PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers `@anthropic-ai/claude-agent-sdk` and the webfetch HTML stack (`jsdom`, `@mozilla/readability`, `turndown`) out of the CLI’s startup import graph; they now load on first SDK stream or first HTML conversion. Previously both parsed on every start; now 680 modules are removed from startup, cutting import/boot time with no behavior change.

- Adds lazy boundaries: `claude-sdk-oauth/sdk-boundary.lazy.ts` (SDK) and `webfetch/webfetch/content.lazy.ts` (HTML converters). `sdk-boundary.ts` keeps a synchronous surface and throws a named error if synchronous SDK members are read without preloading.
- Preloads SDK in async entry points: `streamClaudeSdkOauth`, `reattachSession`, and `buildCustomToolServers` (now async). Webfetch tool imports from `content.lazy.ts` and awaits `htmlToMarkdown`/`htmlToText`.
- Startup guard: `test/startup-import-graph.test.ts` fails if `dist/main.js` statically reaches these packages; the probe helper now accepts an arbitrary entry. The small `@anthropic-ai/claude-agent-sdk/extract` import remains static.

**Required actions**
- Callers of `buildCustomToolServers` must await it.
- New call sites to `query` or `createSdkMcpServer` must `await loadClaudeAgentSdk()` first.
- Callers of the webfetch converters must await `htmlToMarkdown`/`htmlToText`.

<sup>Written for commit 2584e6446a487e4b71890f7f0f6b1324e3d166c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

