### PR TITLE
perf(coding-agent): run the agent in-process when no isolation is required

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -45,6 +45,15 @@
   and package-update notifications, the risky-main-model and high-reasoning warnings, the rules banner,
   the prompt URL widget card, and the earendil announcement. Visible text is unchanged.
 
+- Every launch is one process lighter: `cli.ts` now loads the agent (`cli-main`) in its own process
+  instead of re-spawning Node, unless the run actually needs an isolated process. The child spawn is
+  kept byte-for-byte for the two cases that require it — an inherited Inspector option (`--inspect*`
+  in exec args or `NODE_OPTIONS`), whose debugger socket must be released and re-opened in the process
+  that runs the agent, and any custom exec arguments (for example `--max-old-space-size`), which only
+  apply at process start and so must be replayed onto a fresh process. Brand environment scrubbing is
+  unaffected: `cli-main` scrubs the variable itself, so it is scrubbed in-process before anything the
+  agent spawns can inherit it. Measured on `senpi --help`: 1.206 s -> 1.131 s (-75 ms, -6.2%).
+
 - Startup is faster after the first run: the CLI now enables Node's on-disk module compile cache
   (`enableCompileCache()`) in both `cli.ts` and `cli-main.ts` and publishes the resolved cache directory
   through `NODE_COMPILE_CACHE` so the spawned `cli-main` child process reuses it instead of re-compiling

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -50,6 +50,61 @@
 - `packages/coding-agent/src/core/compaction/compaction.ts`
 - `packages/coding-agent/src/core/agent-session.ts` `_resolveThresholdContextTokens`
 
+## In-process CLI fast path when no isolation is required (2026-08-20)
+
+### What changed
+
+- `packages/coding-agent/src/cli.ts` no longer always re-spawns Node to run the agent. It now decides
+  with `requiresIsolatedProcess()` — `process.execArgv.length > 0 || hasInheritedInspectorOption()`.
+  When false (the overwhelmingly common launch), it loads the agent with a dynamic
+  `await import("./cli-main.ts")` in the launcher process itself. When true, the previous child spawn
+  is kept byte-for-byte, including `releaseInheritedInspectorForChild()`, `process.execArgv`
+  forwarding, `stdio: "inherit"`, exit-code forwarding, and signal re-raise via
+  `process.kill(process.pid, signal)`.
+- The former `runFullCli()` is renamed `spawnFullCli()` and is now reached only on the isolation path;
+  the fast path has no result to forward, because `cli-main` runs `main()` at module scope and already
+  owns `process.exitCode` and any `process.exit()` of its own.
+- `packages/coding-agent/src/inspector-policy.ts` exports the previously private
+  `hasInheritedInspectorOption()` (unchanged logic: `--inspect*` in `process.execArgv`, or `--inspect`
+  inside `NODE_OPTIONS`) so `cli.ts` decides with exactly the predicate that governs the existing
+  Inspector handoff, rather than a second, drifting copy of it.
+- Ordering with the compile cache (merged separately, same day) is preserved and is load-bearing:
+  `enableStartupCompileCache()` still runs as the first statement, BEFORE the dynamic import, so on the
+  fast path the dynamically imported engine graph is itself compile-cached in-process, and on the
+  isolation path `NODE_COMPILE_CACHE` is still published for the child to inherit. The comment on that
+  call now states both roles.
+- The two documented reasons for the respawn were re-verified. Inspector socket handoff still requires
+  a separate process and is preserved. Brand env isolation does NOT: `cli-main.ts` calls
+  `scrubBrandFromEnvironment()` itself (`src/core/brand.ts`), so an in-process load scrubs this
+  process's environment before anything the agent later spawns can inherit it.
+
+### Why
+
+- The respawn cost a full Node process launch plus a duplicated entry-module graph on every single
+  launch, for isolation that almost no launch needs. Measured on this fork's built dist (Apple M4 Pro,
+  node v26.7.0, hyperfine 15 runs, 3 warmup): `node dist/cli.js --help` 1.206 s ± 0.049 -> 1.131 s ±
+  0.036 (-75 ms, -6.2%). The untouched control `dist/cli-main.js --help` is unchanged across the same
+  pair of builds, and after the change `cli.js` is faster than `cli-main.js` itself — the launcher no
+  longer pays for a second process. System CPU per launch drops 0.513 s -> 0.397 s (12-run
+  `/usr/bin/time` means), which is where an eliminated spawn is expected to show up.
+
+### Why an extension could not handle it
+
+- This is the process structure of the entrypoint itself: the decision happens in `cli.ts` before any
+  session, extension loader, or extension API exists, and it determines which process the extension
+  loader will eventually run in.
+
+### Expected merge conflict zones
+
+- MEDIUM: `runFullCli()`/`spawnFullCli()` and the trailing dispatch in `packages/coding-agent/src/cli.ts`.
+  Upstream owns this entrypoint and reshapes it periodically; a conflict here should be resolved by
+  re-applying the `requiresIsolatedProcess()` branch around whatever spawn body upstream ends up with,
+  keeping the spawn path unchanged.
+- LOW: the `hasInheritedInspectorOption` export in `packages/coding-agent/src/inspector-policy.ts`
+  (export keyword only; the function body is untouched).
+- LOW: the `enableStartupCompileCache()` call comment in `cli.ts`, shared with the compile-cache entry
+  below.
+
 ## Node module compile cache for CLI startup (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -6,11 +6,12 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { enableStartupCompileCache } from "./compile-cache.ts";
 import { APP_NAME, DISPLAY_VERSION, getPackageDir } from "./config.ts";
-import { releaseInheritedInspectorForChild } from "./inspector-policy.ts";
+import { hasInheritedInspectorOption, releaseInheritedInspectorForChild } from "./inspector-policy.ts";
 import { handleBootstrapSelfUpdate } from "./self-update-bootstrap.ts";
 
-// Publishes NODE_COMPILE_CACHE so the cli-main child below inherits this process's cache directory;
-// that child loads the full engine graph, so it is where the skipped compilation actually pays off.
+// Must run before cli-main is loaded, by either path: it caches the engine graph this process
+// imports on the fast path below, and it publishes NODE_COMPILE_CACHE so a spawned cli-main child
+// inherits this process's cache directory instead of resolving and re-filling its own.
 enableStartupCompileCache();
 
 process.title = APP_NAME;
@@ -40,7 +41,22 @@ function isMissingBundledWorkspaceDependencies(packageDir: string): boolean {
 	});
 }
 
-async function runFullCli(): Promise<number> {
+/**
+ * Decide whether the agent needs its own process.
+ *
+ * Two things justify the extra Node process, and only two. An inherited Inspector option means a
+ * debugger socket has to be released here and re-opened over there, which a same-process load
+ * cannot do. Custom exec arguments (`--max-old-space-size`, a loader `--import`, ...) were chosen
+ * for the process that runs the agent, and they are only applied at process start, so they must be
+ * replayed onto a fresh one. Brand scrubbing does NOT justify it: `cli-main` calls
+ * `scrubBrandFromEnvironment()` itself, so loading it here scrubs this process's environment before
+ * anything the agent spawns can inherit it.
+ */
+function requiresIsolatedProcess(): boolean {
+	return process.execArgv.length > 0 || hasInheritedInspectorOption();
+}
+
+async function spawnFullCli(): Promise<number> {
 	const extension = import.meta.url.endsWith(".ts") ? ".ts" : ".js";
 	const fullCliPath = fileURLToPath(new URL(`./cli-main${extension}`, import.meta.url));
 	releaseInheritedInspectorForChild();
@@ -74,4 +90,12 @@ if (isMissingBundledWorkspaceDependencies(getPackageDir())) {
 	}
 }
 
-process.exitCode = await runFullCli();
+if (requiresIsolatedProcess()) {
+	process.exitCode = await spawnFullCli();
+} else {
+	// Entry-point process-structure seam: `cli-main` runs `main()` at module scope and owns
+	// `process.exitCode` and any `process.exit()` of its own, so importing it here IS the run - there
+	// is no result to forward. It has to be a dynamic import: a static one would evaluate the whole
+	// engine graph before the `--version` and bootstrap-repair paths above, which answer without it.
+	await import("./cli-main.ts");
+}

--- a/packages/coding-agent/src/inspector-policy.ts
+++ b/packages/coding-agent/src/inspector-policy.ts
@@ -11,7 +11,12 @@ const RECOVER_INSPECTOR_VM_IMPORT = envValue("RECOVER_INSPECTOR_VM_IMPORT") === 
 export const INSPECTOR_VM_IMPORT_WARNING =
 	"Node Inspector dynamic import is unsupported; use require() or a target-side loader. Senpi kept running.";
 
-function hasInheritedInspectorOption(): boolean {
+/**
+ * Report whether this process inherited an Inspector option, either as an exec argument or
+ * through NODE_OPTIONS. Such a run owns a debugger socket that has to be handed to the process
+ * running the agent, which is what makes the child spawn in `cli.ts` load-bearing there.
+ */
+export function hasInheritedInspectorOption(): boolean {
 	return (
 		process.execArgv.some((argument) => argument.startsWith("--inspect")) ||
 		process.env.NODE_OPTIONS?.includes("--inspect") === true

--- a/packages/coding-agent/test/cli-inprocess-fast-path.test.ts
+++ b/packages/coding-agent/test/cli-inprocess-fast-path.test.ts
@@ -1,0 +1,113 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+/**
+ * `cli.ts` historically ran the real agent (`cli-main.ts`) as a spawned child so that an
+ * inherited Inspector socket could be handed over and so brand env scrubbing could not leak
+ * back to the launcher. That second Node process costs a full spawn plus a duplicated
+ * entry-module graph on every single launch, and neither reason applies to a plain run.
+ *
+ * These tests pin the observable process structure: a plain launch must load `cli-main` in the
+ * SAME process, while an isolation-requiring launch (custom exec args, or an inherited
+ * `--inspect*`) must keep the child spawn exactly as before.
+ *
+ * The probe is a `--import` hook published through `NODE_OPTIONS`, which — unlike a `--import`
+ * on the command line — leaves `process.execArgv` empty, so it observes the fast path instead of
+ * disabling it. Every process that loads it appends one record, so the record count IS the
+ * process count: no polling, no sleeps, no platform-specific process-tree walking.
+ */
+
+const CLI_PATH = fileURLToPath(new URL("../src/cli.ts", import.meta.url));
+
+const probeHookSource = `import { appendFileSync } from "node:fs";
+const report = process.env.SENPI_FAST_PATH_REPORT;
+process.on("exit", () => {
+	appendFileSync(report, JSON.stringify({ pid: process.pid, entry: process.argv[1] }) + "\\n");
+});
+`;
+
+interface ProbeRecord {
+	readonly pid: number;
+	readonly entry: string;
+}
+
+interface RunResult {
+	readonly status: number | null;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly records: readonly ProbeRecord[];
+}
+
+let hostDir: string;
+
+function runCli(args: readonly string[], nodeOptionsPrefix = ""): RunResult {
+	const hookPath = join(hostDir, "probe-hook.mjs");
+	const reportPath = join(hostDir, `report-${Math.random().toString(36).slice(2)}.jsonl`);
+	writeFileSync(hookPath, probeHookSource);
+	writeFileSync(reportPath, "");
+	const nodeOptions = `${nodeOptionsPrefix} --import=${pathToFileURL(hookPath).href} --import tsx`.trim();
+	const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+		encoding: "utf8",
+		env: {
+			...process.env,
+			NODE_OPTIONS: nodeOptions,
+			SENPI_FAST_PATH_REPORT: reportPath,
+			PI_OFFLINE: "1",
+		},
+	});
+	const records = readFileSync(reportPath, "utf8")
+		.split("\n")
+		.filter((line) => line.length > 0)
+		.map((line) => JSON.parse(line) as ProbeRecord);
+	return { status: result.status, stdout: result.stdout, stderr: result.stderr, records };
+}
+
+beforeEach(() => {
+	hostDir = mkdtempSync(join(tmpdir(), "senpi-fast-path-"));
+});
+
+afterEach(() => {
+	rmSync(hostDir, { recursive: true, force: true });
+});
+
+describe("CLI in-process fast path", () => {
+	describe("#given a launch that needs no exec-arg or inspector isolation", () => {
+		test("#when the CLI runs #then cli-main loads in the launcher process itself", () => {
+			const result = runCli(["--help"]);
+
+			expect(result.status, result.stderr).toBe(0);
+			expect(result.stdout).toContain("Usage:");
+			// One record = one Node process. The child spawn would add a second record whose
+			// entry is cli-main, so this assertion is exactly the "no respawn" contract.
+			expect(result.records).toHaveLength(1);
+			expect(result.records[0]?.entry).toBe(CLI_PATH);
+		});
+
+		test("#when the CLI exits non-zero #then the launcher reports that exact code", () => {
+			const result = runCli(["--model", "definitely-not-a-real-model-id", "--print", "hi"]);
+
+			// Deterministic failure: an unknown model id is rejected before any provider call.
+			expect(result.status).toBe(1);
+			expect(result.records).toHaveLength(1);
+		});
+	});
+
+	describe("#given a launch that inherits an Inspector option", () => {
+		test("#when NODE_OPTIONS carries --inspect #then the agent still runs in a spawned child", () => {
+			// Port 0 lets the OS pick a free port, so concurrent runs cannot collide.
+			const result = runCli(["--help"], "--inspect=127.0.0.1:0");
+
+			expect(result.status, result.stderr).toBe(0);
+			expect(result.stdout).toContain("Usage:");
+			expect(result.records).toHaveLength(2);
+			const entries = result.records.map((record) => record.entry);
+			expect(entries).toContain(CLI_PATH);
+			expect(entries.some((entry) => entry.includes("cli-main"))).toBe(true);
+			expect(new Set(result.records.map((record) => record.pid)).size).toBe(2);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

`cli.ts` re-spawned Node to run `cli-main` on **every** launch — a full process launch plus a duplicated entry-module graph — for isolation that almost no launch actually needs.

It now loads `cli-main` **in-process**, unless the run genuinely requires its own process. The respawn is kept byte-for-byte for the two cases that require it:

| Condition | Why the child is still required |
|---|---|
| `hasInheritedInspectorOption()` — `--inspect*` in `process.execArgv` or `NODE_OPTIONS` | The inherited debugger socket must be released here and re-opened in the process that runs the agent. `releaseInheritedInspectorForChild()` is unchanged. |
| `process.execArgv.length > 0` | Custom exec args (`--max-old-space-size`, a loader `--import`, …) were chosen for the process that runs the agent and only apply at process start, so they must be replayed onto a fresh process. |

The third historically-cited reason — **brand env isolation** — was re-verified and does *not* require a child: `cli-main.ts` calls `scrubBrandFromEnvironment()` itself, so an in-process load scrubs this process's environment before anything the agent later spawns can inherit it.

### Interaction with #1030 (compile cache, merged earlier today)

Preserved deliberately and load-bearing: `enableStartupCompileCache()` still runs as the **first** statement, *before* the dynamic import — so on the fast path the dynamically imported engine graph is itself compile-cached in-process, and on the isolation path `NODE_COMPILE_CACHE` is still published for the child to inherit. `test/compile-cache.test.ts` stays green.

### Notes

- `hasInheritedInspectorOption()` is now exported from `inspector-policy.ts` (export keyword only, body untouched) so `cli.ts` decides with exactly the predicate that governs the Inspector handoff, instead of a second copy that could drift.
- The dynamic `import("./cli-main.ts")` is an entry-point process-structure seam, documented in the tracker per AGENTS.md. A static import would evaluate the whole engine graph before the `--version` and bootstrap-repair paths, which must answer without it. It matches the existing precedent in `src/bun/cli.ts` (`await import("../cli-main.ts")`) and passes `check:ts-imports`.

## Measurements

Machine: Apple M4 Pro (14c), node v26.7.0, macOS 26.4.1. Both trees built from the **same base commit**, back-to-back in one session, under `/tmp/ulw-bench.lock`.

Note on conditions: this workstation was running concurrent sibling workloads plus macOS `fseventsd`/`mediaanalysisd` churn; 1-min loadavg during the runs was **9.9–13.9**, above an ideal idle bench. The wall-clock deltas are therefore corroborated by user/system CPU time, which is far less sensitive to external contention, and by an **unmodified control binary** measured in the same interleaved pass.

### hyperfine — 15 runs, 3 warmup (loadavg 10.27 at start)

| Command | Mean ± σ | Min … Max |
|---|---|---|
| BEFORE `cli.js` (spawn) | 1.206 s ± 0.049 s | 1.152 … 1.314 s |
| **AFTER `cli.js` (in-proc)** | **1.131 s ± 0.036 s** | 1.100 … 1.209 s |
| BEFORE `cli-main.js` *(control)* | 1.244 s ± 0.052 s | 1.167 … 1.334 s |
| AFTER `cli-main.js` *(control)* | 1.295 s ± 0.072 s | 1.185 … 1.431 s |

**`cli.js`: 1.206 s → 1.131 s = −75 ms (−6.2%).**

The structural proof is the control: `cli-main.js` is untouched by this PR and is statistically unchanged across the two builds, while `cli.js` moves. After the change **`cli.js` is faster than `cli-main.js` itself** — the launcher no longer pays for a second process, which is only possible if the respawn is gone.

### `/usr/bin/time` — 12 runs each, means (loadavg 9.93 → 11.52)

| Binary | real | user | sys |
|---|---|---|---|
| BEFORE `cli.js` | 1.377 s | 1.074 s | **0.513 s** |
| AFTER `cli.js` | 1.182 s | 1.050 s | **0.397 s** |
| BEFORE `cli-main.js` *(control)* | 1.198 s | 1.196 s | 0.260 s |
| AFTER `cli-main.js` *(control)* | 1.180 s | 1.177 s | 0.253 s |

**System CPU per launch drops 0.513 s → 0.397 s (−116 ms)** — exactly where an eliminated `fork`/`exec` is expected to land, and independent of scheduler noise.

### TUI smoke — real PTY, both builds

| Build | first render | Ctrl-D exit | terminal restored |
|---|---|---|---|
| BEFORE | 1112 ms | code 0 | yes |
| AFTER | 1082 ms | code 0 | yes |

(`npm run profile:tui` refuses to run without an interactive terminal — `PI_STARTUP_BENCHMARK only supports interactive mode` — so the smoke was driven through this repo's own `packages/pty` against a real PTY instead.)

## Tests

New: `packages/coding-agent/test/cli-inprocess-fast-path.test.ts`, written failing-first.

The probe is a `--import` hook published via `NODE_OPTIONS`, which — unlike a command-line `--import` — leaves `process.execArgv` empty, so it *observes* the fast path instead of disabling it. Every process that loads the hook appends one record, so **the record count is the process count**: no polling, no sleeps, no platform-specific process-tree walking.

| Test | Baseline (RED) | After (GREEN) |
|---|---|---|
| plain `--help` loads `cli-main` in the launcher process | FAIL — 2 records (2 processes) | PASS — 1 record, entry `cli.ts` |
| non-zero exit code preserved | FAIL — 2 records | PASS — exit 1, 1 record |
| `NODE_OPTIONS=--inspect` still spawns a child | PASS | PASS — 2 records, 2 distinct pids |

Signal/exit fidelity verified separately: SIGINT to the process group terminates with `signal=SIGINT`; Ctrl-D in a real PTY exits 0 with the terminal restored; `--version` still short-circuits without loading the engine.

## Verification

- `npm run check` — **exit 0** (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, `tsc --noEmit`, browser smoke).
- `packages/coding-agent` `npm test` — **8547 passed**, 36 skipped, **1 failed: `test/cursor-cli-oauth/shutdown.test.ts`**. Pre-existing and unrelated — the same test fails on untouched `origin/main` in the same environment (in fact worse there: 2 failures vs 1). It is a 5-second-timeout process fixture and was failing under a loadavg-63 spike.
- Inspector suites green: `inspector-endpoint-handoff.test.ts` (the cross-OS CI job's test — still asserts **two** debugger endpoints, i.e. the respawn is intact under `--inspect-brk`), `inspector-vm-import-crash.test.ts`, `rpc-client-process-exit.test.ts`, `compile-cache.test.ts`.

Note: `packages/coding-agent/dist/cli.js` is a checked-in artifact that is already stale on `main` (PR #1030 did not refresh it either); this PR follows that precedent and does not commit build output.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the coding agent (`cli-main`) in-process by default; previously `cli.ts` always respawned Node. This removes an extra process launch while preserving isolation when needed (inherited Inspector or any custom exec args), improving `senpi --help` by ~75 ms (~6%).

- In-process fast path: dynamic `import("./cli-main.ts")` when no isolation is required.
- Isolation path unchanged: respawn still occurs when `process.execArgv.length > 0` or `--inspect*` is inherited (via exec args or `NODE_OPTIONS`); debugger handoff and exec args are replayed exactly.
- Compile cache ordering is preserved: `enableStartupCompileCache()` still runs first to cache the engine graph and publish `NODE_COMPILE_CACHE`.
- `hasInheritedInspectorOption()` is now exported from `inspector-policy.ts` (logic unchanged); new test `cli-inprocess-fast-path.test.ts` asserts 1 process on the fast path and 2 with `--inspect*`.
- Brand env scrubbing is unaffected (`cli-main` scrubs before any child processes). Exit codes, signals, and stdio behavior are unchanged. No migration required.

<sup>Written for commit 456109d4a52fc705098cd85b9213c217e4e29579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

