### PR TITLE
test(coding-agent): pin production-wired cursor exec bridge ownership

### DIFF
--- a/packages/coding-agent/test/suite/regressions/1003-cursor-exec-bridge-production-wiring.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1003-cursor-exec-bridge-production-wiring.test.ts
@@ -1,0 +1,182 @@
+import { Agent, type AgentEvent, type AgentTool } from "@earendil-works/pi-agent-core";
+import {
+	type AssistantMessage,
+	type AssistantMessageEvent,
+	EventStream,
+	type ToolResultMessage,
+} from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import {
+	type CursorExecBridgeSession,
+	createSessionCursorExecBridge,
+} from "../../../src/core/cursor-exec-bridge-session.ts";
+
+/**
+ * Production wiring of the Cursor exec bridge, end to end.
+ *
+ * Every other bridge test constructs `createSessionCursorExecBridge` by hand
+ * and hands it a signal the test chose. That leaves the actual production
+ * seam untested: `sdk.ts` registers the bridge as a *factory*
+ * (`cursorExecHandlers: (runSignal) => createSessionCursorExecBridge(...)`)
+ * and the agent loop is what decides which signal that factory receives
+ * (`agent-loop.ts`, issue #1002: the owning RUN signal, not the per-request
+ * idle-timeout controller). A bridge bound to the wrong signal fails the
+ * `getAbortSignal` ownership check and refuses every live exec frame with
+ * "Tool execution has no active run" — the #1003 field regression, invisible
+ * to hand-wired tests because they inject a matching signal.
+ *
+ * This test reproduces that wiring exactly: a real `Agent`, the real factory,
+ * and a stream function that dispatches exec frames onto whatever handlers
+ * the loop actually built.
+ */
+
+class MockAssistantStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+	constructor() {
+		super(
+			(event) => event.type === "done" || event.type === "error",
+			(event) => {
+				if (event.type === "done") return event.message;
+				if (event.type === "error") return event.error;
+				throw new Error("Unexpected event type");
+			},
+		);
+	}
+}
+
+function createAssistantMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "cursor-agent",
+		provider: "cursor",
+		model: "mock-cursor",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createDeferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+function isToolResult(value: unknown): value is ToolResultMessage {
+	return typeof value === "object" && value !== null && "role" in value && value.role === "toolResult";
+}
+
+function stubReadTool(execute: () => void): AgentTool {
+	return {
+		name: "read",
+		label: "read",
+		description: "stub read",
+		parameters: Type.Object({ path: Type.String() }),
+		execute: async () => {
+			execute();
+			return { content: [{ type: "text", text: "read ok" }], details: undefined };
+		},
+	} as unknown as AgentTool;
+}
+
+/** Handlers the loop built for one provider request, as the Cursor API would receive them. */
+type ExecHandlers = { read?: (args: unknown) => Promise<unknown> };
+
+type ToolLifecycleEvent = Extract<AgentEvent, { type: "tool_execution_start" | "tool_execution_end" }>;
+
+describe("cursor exec bridge production wiring (issue #1003)", () => {
+	it("executes a live frame on the run that owns it and refuses it once a replacement run is active", async () => {
+		const execute = vi.fn();
+		const tool = stubReadTool(execute);
+		const session: CursorExecBridgeSession = {
+			getRegisteredTool: (name) => (name === "read" ? tool : undefined),
+			preflightToolCall: async () => undefined,
+			emitExecBridgeToolResult: async () => undefined,
+		};
+		const sessionRef = { current: session };
+
+		const streams: MockAssistantStream[] = [];
+		const handlers: ExecHandlers[] = [];
+		const runAOpened = createDeferred();
+		const runBOpened = createDeferred();
+
+		// Production wiring: sdk.ts passes the bridge as a per-run factory and the
+		// agent loop resolves it with the signal of the run opening the stream.
+		const agent: Agent = new Agent({
+			cursorExecHandlers: (runSignal: AbortSignal) =>
+				createSessionCursorExecBridge(sessionRef, () => agent, runSignal),
+			streamFn: (_model, _context, options) => {
+				const stream = new MockAssistantStream();
+				streams.push(stream);
+				handlers.push((options as { execHandlers?: ExecHandlers }).execHandlers ?? {});
+				(streams.length === 1 ? runAOpened : runBOpened).resolve();
+				return stream;
+			},
+		});
+
+		const lifecycleEvents: ToolLifecycleEvent[] = [];
+		agent.subscribe((event) => {
+			if (event.type === "tool_execution_start" || event.type === "tool_execution_end") {
+				lifecycleEvents.push(event);
+			}
+		});
+
+		// given run A is streaming and the loop has handed its stream a bridge
+		const runA = agent.prompt("run A");
+		await runAOpened.promise;
+		const runASignal = agent.signal;
+		expect(runASignal).toBeDefined();
+		const bridgeA = handlers[0];
+		expect(bridgeA.read).toBeDefined();
+
+		// when run A's stream dispatches an exec frame while run A is still live
+		const liveResult = await bridgeA.read?.({ path: "a.ts", toolCallId: "live-run-a-frame" });
+
+		// then the tool runs and the frame answers with its output, and the
+		// bridge's lifecycle events land on the owning run (issue #992 also
+		// routes a tool_result through the session, stubbed here)
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(isToolResult(liveResult)).toBe(true);
+		expect(isToolResult(liveResult) && liveResult.isError).toBe(false);
+		expect(isToolResult(liveResult) && liveResult.content).toEqual([{ type: "text", text: "read ok" }]);
+		expect(lifecycleEvents.map((event) => event.type)).toEqual(["tool_execution_start", "tool_execution_end"]);
+		expect(lifecycleEvents.every((event) => event.toolCallId === "live-run-a-frame")).toBe(true);
+
+		// and when run A ends and the fallback lane starts run B
+		streams[0].push({ type: "done", reason: "stop", message: createAssistantMessage("run A done") });
+		await runA;
+
+		const runB = agent.prompt("run B");
+		await runBOpened.promise;
+		expect(agent.signal).toBeDefined();
+		expect(agent.signal).not.toBe(runASignal);
+		lifecycleEvents.length = 0;
+		execute.mockClear();
+
+		// then a straggler frame buffered on run A's stream is refused rather than
+		// executed against, or leaked into, run B. Post-preflight ownership
+		// rechecks (issue #1002) surface as an error tool_execution_end, so assert
+		// on the tool and the transcript, not merely on event silence.
+		const lateResult = await bridgeA.read?.({ path: "a.ts", toolCallId: "late-run-a-frame" });
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(isToolResult(lateResult) && lateResult.isError).toBe(true);
+		expect(isToolResult(lateResult) && lateResult.content).toEqual([
+			{ type: "text", text: "Tool execution has no active run" },
+		]);
+		expect(lifecycleEvents.filter((event) => event.type === "tool_execution_end" && !event.isError)).toEqual([]);
+
+		streams[1].push({ type: "done", reason: "stop", message: createAssistantMessage("run B done") });
+		await runB;
+	});
+});


### PR DESCRIPTION
## What

Adds one regression test, `packages/coding-agent/test/suite/regressions/1003-cursor-exec-bridge-production-wiring.test.ts`. No production code changes.

It ports the production-wiring case from closed PR #1004, adapted to the identity semantics that actually merged in #1002 and #992.

## Why

Every existing exec-bridge test hand-builds `createSessionCursorExecBridge` and injects a signal the test chose. That skips the seam that actually broke in the field: `sdk.ts` registers the bridge as a *per-run factory*, and `agent-loop.ts` decides which signal that factory receives. #1002 fixed the loop to pass the owning **run** signal instead of the per-request idle-timeout controller — but nothing pins that decision, so it can silently regress again while the whole suite stays green.

This test drives the real path: a real `Agent`, the real factory as `sdk.ts` wires it, `agent.prompt()`, and a `streamFn` that dispatches exec frames onto whatever handlers the loop actually built.

Assertions, per merged semantics:

- a live frame **executes** while its run is active, and its `tool_execution_start` / `tool_execution_end` lifecycle lands on the owning run (#1002 binds the bridge to the run signal, so `Agent.emitExternalEvent` accepts these rather than dropping them);
- a straggler frame from that same bridge is **refused** with `Tool execution has no active run` once a replacement run is active, executing no tool and contributing no successful lifecycle event.

Deviations from #1004, deliberate:

- #1004's "falls back to the agent run signal when no request signal is supplied" case is **dropped** — #1002 made unbound adapters fail closed, so that behavior no longer exists.
- #1004's `requestA.abort()` edit to `cursor-exec-bridge-run-ownership.test.ts` is **not** ported; that file is untouched here.
- The post-preflight ownership recheck (#1002) surfaces refusal as an *error* `tool_execution_end`, so the refusal assertion filters on non-error events instead of demanding total event silence. #992's `emitToolResult` hook is accounted for via the session stub.

## Mutation proof

Temporarily reverted the #1002 one-liner in `packages/agent/src/agent-loop.ts` (`config.cursorExecHandlers(signal ?? requestAbortController.signal)` → `config.cursorExecHandlers(requestAbortController.signal)`), then restored it.

RED with the mutation applied:

```
 FAIL  test/suite/regressions/1003-cursor-exec-bridge-production-wiring.test.ts > cursor exec bridge production wiring (issue #1003) > executes a live frame on the run that owns it and refuses it once a replacement run is active
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ test/suite/regressions/1003-cursor-exec-bridge-production-wiring.test.ts:148:19
    146|   // bridge's lifecycle events land on the owning run (issue #992 also
    147|   // routes a tool_result through the session, stubbed here)
    148|   expect(execute).toHaveBeenCalledTimes(1);
       |                   ^
    149|   expect(isToolResult(liveResult)).toBe(true);
    150|   expect(isToolResult(liveResult) && liveResult.isError).toBe(false);

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

GREEN with `main`'s code restored:

```
 RUN  v4.1.10 /…/packages/coding-agent

·

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  759ms
```

The failure is the exact field symptom of #1003: the tool never runs.

## Verification

- `vitest run` over the new file plus `cursor-exec-bridge.test.ts`, `cursor-exec-bridge-run-ownership.test.ts`, `cursor-exec-bridge-preflight.test.ts` — 18 passed.
- `tsc --noEmit` clean; `biome check` clean; full pre-commit check suite passed.
- `CHANGELOG_GATE_BASE=$(git merge-base origin/main HEAD) node scripts/check-pr-changelog.mjs` → `PASS - … no runtime source changes detected`. Test-only, so no changelog or `changes.md` entry is required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins production wiring of the Cursor exec bridge by adding a regression test that verifies run-signal ownership. Existing tests hand-wired `createSessionCursorExecBridge` with arbitrary signals, masking the field bug where the loop passed the request idle-timeout signal; this test drives the real path and guards against that regression.

- Exercises a real `Agent` via `agent.prompt()`, uses `cursorExecHandlers: (runSignal) => createSessionCursorExecBridge(...)` as in `sdk.ts`, and captures the handlers the loop built.
- Asserts: a live frame executes and emits `tool_execution_start`/`tool_execution_end` on its owning run; a straggler after a replacement run is refused with "Tool execution has no active run" and does not execute.
- Mutation check: reverting the `agent-loop.ts` fix makes the test fail; with `main` it passes. No runtime code changes.

<sup>Written for commit 741962812d651caccee002d58a36c4c0443b32ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

