### PR TITLE
fix(config-reload): watch only in-scope directories instead of whole subtrees

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,5 +1,45 @@
 # config-reload Extension Changes
 
+## Watch only in-scope directories instead of whole subtrees (2026-08-20)
+
+### What changed
+
+- `watch-engine.ts` no longer hands a `dir-recursive` target root to
+  `fs.watch({ recursive: true })`. The scan already computes the in-scope
+  directory set (skipping `node_modules`, `.git`, symlinks, dot-directories that
+  are not explicitly allow-listed, and anything the target `filter` rejects), so
+  the engine now records those directories as `scannedDirectories` and opens one
+  non-recursive subscription per directory.
+- `#onEvent` takes the watched directory and re-anchors the reported filename to
+  the target root, because a per-directory watcher names children relative to
+  itself.
+- `#attach` / `#detachMissing` reconcile subscriptions after every full and
+  partial rescan, so directories created after startup gain a watcher and
+  directories that leave scope release theirs.
+
+### Why
+
+- `fs.watch({ recursive: true })` registers the entire subtree with the OS
+  watcher (FSEvents on macOS). The target `filter` only discards events after
+  delivery, so a `~/.omo/extensions` or skills directory containing
+  `node_modules` still paid for a full-subtree registration in every session.
+  Measured on this machine: `fseventsd` at 123% CPU and 3-4.3GB RSS with load
+  above 200, and the only available mitigation was disabling `configReload`
+  entirely. Watching the scanned set gives identical change coverage because the
+  scan and the subscriptions now derive from the same scope rules.
+
+### Why an extension could not handle it
+
+- The watch engine and its event source are internal to this builtin; no
+  external extension can change how config watch targets reach `fs.watch`.
+
+### Expected merge conflict zones
+
+- MEDIUM: `watch-engine.ts` constructor subscription loop, `#onEvent` signature,
+  `#evaluateState`, and the `ScanResult` / `TargetState` shapes.
+- LOW: `config-reload-watch-engine.test.ts` event-source probe, which now keeps
+  one listener per watched directory instead of a single listener.
+
 ## Clear orphaned handoff unconditionally after reload (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-engine.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-engine.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { lstatSync, readdirSync, readFileSync, type Stats } from "node:fs";
-import { basename, isAbsolute, join, normalize, resolve, sep } from "node:path";
+import { basename, isAbsolute, join, normalize, relative, resolve, sep } from "node:path";
 
 export { createFsWatchEventSource } from "./watch-event-source.ts";
 
@@ -46,6 +46,14 @@ type TargetState = {
 	readonly target: ResolvedWatchTarget;
 	readonly hashes: Map<string, string>;
 	readonly allowedDirectories: Set<string>;
+	/**
+	 * Directories the scan actually descended into, which are exactly the
+	 * directories worth handing to the OS. Recursive targets subscribe per entry
+	 * here instead of registering their whole subtree.
+	 */
+	readonly watchedDirectories: Map<string, () => void>;
+	/** Directories currently in scope, refreshed by every scan. */
+	scannedDirectories: Set<string>;
 };
 
 type ResolvedWatchTarget = Omit<WatchTarget, "path"> & { readonly path: string };
@@ -53,6 +61,8 @@ type ResolvedWatchTarget = Omit<WatchTarget, "path"> & { readonly path: string }
 type ScanResult = {
 	readonly hashes: Map<string, string>;
 	readonly allowedDirectories: Set<string>;
+	/** Directories visited by the scan, i.e. the in-scope directory set. */
+	readonly scannedDirectories: Set<string>;
 };
 
 const DEFAULT_DEBOUNCE_MS = 200;
@@ -92,22 +102,67 @@ export class ConfigReloadWatchEngine {
 				target: resolvedTarget,
 				hashes: scan.hashes,
 				allowedDirectories: scan.allowedDirectories,
+				watchedDirectories: new Map<string, () => void>(),
+				scannedDirectories: scan.scannedDirectories,
 			};
 		});
 
 		for (const state of this.#states) {
+			this.#attach(state, state.scannedDirectories);
+		}
+	}
+
+	/**
+	 * Subscribes to exactly the in-scope directories.
+	 *
+	 * A `dir-recursive` target used to hand its root to `fs.watch({recursive:true})`,
+	 * which registers the entire subtree with the OS watcher (FSEvents on macOS).
+	 * The target `filter` only discards events after delivery, so an extensions or
+	 * skills directory containing `node_modules` still cost a full-subtree
+	 * registration per session. The scan already knows which directories are in
+	 * scope — it skips `node_modules`, `.git`, symlinks, and filtered paths — so
+	 * watching that set directly gives identical coverage at a fraction of the
+	 * OS-level cost.
+	 */
+	#attach(state: TargetState, directories: ReadonlySet<string>): void {
+		const recursive = state.target.kind === "dir-recursive";
+		// The root is always watched so that creations directly beneath it are seen.
+		const wanted = recursive ? new Set([state.target.path, ...directories]) : new Set([state.target.path]);
+		for (const directory of wanted) {
+			if (state.watchedDirectories.has(directory)) {
+				continue;
+			}
 			try {
-				this.#unsubscribes.push(
-					this.#subscribe(
-						state.target.path,
-						(eventType, filename) => {
-							this.#onEvent(state, eventType, filename);
-						},
-						{ recursive: state.target.kind === "dir-recursive" },
-					),
+				const unsubscribe = this.#subscribe(
+					directory,
+					(eventType, filename) => {
+						this.#onEvent(state, eventType, filename, directory);
+					},
+					{ recursive: false },
 				);
+				state.watchedDirectories.set(directory, unsubscribe);
+				this.#unsubscribes.push(unsubscribe);
 			} catch (error) {
-				this.#reportError(error, state.target.path);
+				this.#reportError(error, directory);
+			}
+		}
+	}
+
+	/** Drops subscriptions for directories that left scope (deleted or filtered out). */
+	#detachMissing(state: TargetState, live: ReadonlySet<string>): void {
+		for (const [directory, unsubscribe] of [...state.watchedDirectories]) {
+			if (directory === state.target.path || live.has(directory)) {
+				continue;
+			}
+			state.watchedDirectories.delete(directory);
+			const index = this.#unsubscribes.indexOf(unsubscribe);
+			if (index >= 0) {
+				this.#unsubscribes.splice(index, 1);
+			}
+			try {
+				unsubscribe();
+			} catch (error) {
+				this.#reportError(error, directory);
 			}
 		}
 	}
@@ -153,7 +208,7 @@ export class ConfigReloadWatchEngine {
 		return snapshot;
 	}
 
-	#onEvent(state: TargetState, _eventType: string, filename: string | null): void {
+	#onEvent(state: TargetState, _eventType: string, filename: string | null, watchedDirectory?: string): void {
 		if (this.#closed) {
 			return;
 		}
@@ -161,7 +216,13 @@ export class ConfigReloadWatchEngine {
 			this.#pending.set(state, null);
 		} else if (this.#pending.get(state) !== null) {
 			const affected = this.#pending.get(state) ?? new Set<string>();
-			const relPath = normalizeRelativePath(filename);
+			// Per-directory subscriptions report names relative to their own directory,
+			// so re-anchor them to the target root before matching.
+			const relPath = normalizeRelativePath(
+				watchedDirectory && watchedDirectory !== state.target.path
+					? join(relative(state.target.path, watchedDirectory), filename)
+					: filename,
+			);
 			if (relPath && this.#matches(state.target, relPath)) {
 				affected.add(relPath);
 				this.#pending.set(state, affected);
@@ -217,6 +278,9 @@ export class ConfigReloadWatchEngine {
 			for (const path of next.allowedDirectories) {
 				state.allowedDirectories.add(path);
 			}
+			state.scannedDirectories = next.scannedDirectories;
+			this.#detachMissing(state, state.scannedDirectories);
+			this.#attach(state, state.scannedDirectories);
 			this.#compare(previousHashes, previousDirectories, state.hashes, state.allowedDirectories, changes);
 			return;
 		}
@@ -232,17 +296,29 @@ export class ConfigReloadWatchEngine {
 				state.allowedDirectories.delete(path);
 			}
 		}
+		for (const path of [...state.scannedDirectories]) {
+			if (prefixes.some((prefix) => isWithin(path, prefix))) {
+				state.scannedDirectories.delete(path);
+			}
+		}
 		for (const [path, hash] of next.hashes) {
 			state.hashes.set(path, hash);
 		}
 		for (const path of next.allowedDirectories) {
 			state.allowedDirectories.add(path);
 		}
+		for (const path of next.scannedDirectories) {
+			state.scannedDirectories.add(path);
+		}
+		// A partial rescan can both create and remove directories in scope, so the
+		// subscription set is reconciled in both directions here too.
+		this.#detachMissing(state, state.scannedDirectories);
+		this.#attach(state, state.scannedDirectories);
 		this.#compare(previousHashes, previousDirectories, state.hashes, state.allowedDirectories, changes);
 	}
 
 	#scanAffected(target: ResolvedWatchTarget, affected: Set<string>, state: TargetState): ScanResult {
-		const result: ScanResult = { hashes: new Map(), allowedDirectories: new Set() };
+		const result: ScanResult = { hashes: new Map(), allowedDirectories: new Set(), scannedDirectories: new Set() };
 		for (const relPath of affected) {
 			const absolutePath = join(target.path, relPath);
 			this.#scanPath(target, absolutePath, relPath, result, state);
@@ -251,7 +327,7 @@ export class ConfigReloadWatchEngine {
 	}
 
 	#scan(target: ResolvedWatchTarget): ScanResult {
-		const result: ScanResult = { hashes: new Map(), allowedDirectories: new Set() };
+		const result: ScanResult = { hashes: new Map(), allowedDirectories: new Set(), scannedDirectories: new Set() };
 		this.#scanPath(target, target.path, "", result);
 		return result;
 	}
@@ -301,6 +377,8 @@ export class ConfigReloadWatchEngine {
 		if (dotDirectory && !explicitlyAllowedDirectory) {
 			return;
 		}
+		// Recorded before descending: this is the set the OS watcher subscribes to.
+		result.scannedDirectories.add(absolutePath);
 		try {
 			for (const child of readdirSync(absolutePath, { withFileTypes: true })) {
 				if (child.isSymbolicLink() || child.name === "node_modules" || child.name === ".git") {

--- a/packages/coding-agent/test/config-reload-watch-engine.test.ts
+++ b/packages/coding-agent/test/config-reload-watch-engine.test.ts
@@ -28,20 +28,35 @@ vi.mock("node:fs", async (importOriginal) => {
 });
 
 type EventSourceProbe = {
-	readonly subscribe: (_path: string, listener: WatchEventListener) => () => void;
+	readonly subscribe: (path: string, listener: WatchEventListener) => () => void;
+	/** Emits on the root watcher, mirroring how a real parent directory reports its children. */
 	readonly emit: (filename: string | null) => void;
+	/** Emits on the watcher for a specific directory, with a name relative to it. */
+	readonly emitFrom: (directory: string, filename: string | null) => void;
+	readonly watchedPaths: () => string[];
 };
 
+/**
+ * Keeps one listener per watched directory. The engine subscribes per in-scope
+ * directory rather than handing a whole subtree to the OS, so a single-listener
+ * probe would silently drop every watcher but the last.
+ */
 function eventSource(): EventSourceProbe {
-	let listener: WatchEventListener | undefined;
+	const listeners = new Map<string, WatchEventListener>();
+	let rootPath: string | undefined;
 	return {
-		subscribe: (_path, callback) => {
-			listener = callback;
+		subscribe: (path, callback) => {
+			rootPath ??= path;
+			listeners.set(path, callback);
 			return () => {
-				listener = undefined;
+				listeners.delete(path);
 			};
 		},
-		emit: (filename) => listener?.("change", filename),
+		emit: (filename) => {
+			if (rootPath !== undefined) listeners.get(rootPath)?.("change", filename);
+		},
+		emitFrom: (directory, filename) => listeners.get(directory)?.("change", filename),
+		watchedPaths: () => [...listeners.keys()],
 	};
 }
 
@@ -227,6 +242,115 @@ describe("config reload watch engine", () => {
 		expect(snapshot).toEqual(new Map([[settingsPath, sha256("settings")]]));
 		(snapshot as Map<string, string>).set(settingsPath, "changed");
 		expect(engine.getBaselineSnapshot()).toEqual(new Map([[settingsPath, sha256("settings")]]));
+	});
+
+	it("subscribes only to in-scope directories, never a whole subtree", () => {
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-watch-"));
+		// A realistic extensions tree: one loadable package plus dependency and VCS
+		// noise that must never reach the OS watcher.
+		mkdirSync(join(tempDir, "my-ext"), { recursive: true });
+		writeFileSync(join(tempDir, "my-ext", "index.ts"), "export default {}");
+		mkdirSync(join(tempDir, "my-ext", "node_modules", "dep", "dist"), { recursive: true });
+		writeFileSync(join(tempDir, "my-ext", "node_modules", "dep", "dist", "index.js"), "noise");
+		mkdirSync(join(tempDir, ".git", "objects"), { recursive: true });
+
+		const source = eventSource();
+		createEngine({
+			targets: [{ id: "extensions", kind: "dir-recursive", path: tempDir }],
+			subscribe: source.subscribe,
+			onRealChange: vi.fn(),
+		});
+
+		const watched = source.watchedPaths();
+		expect(watched).toContain(tempDir);
+		expect(watched).toContain(join(tempDir, "my-ext"));
+		// The regression this locks: `fs.watch({recursive:true})` on the root would
+		// register every one of these with the OS, and the target filter only
+		// discards their events after delivery.
+		expect(watched.filter((path) => path.includes("node_modules"))).toEqual([]);
+		expect(watched.filter((path) => path.includes(".git"))).toEqual([]);
+	});
+
+	it("requests no recursive OS watch for a recursive target", () => {
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-watch-"));
+		mkdirSync(join(tempDir, "nested", "deeper"), { recursive: true });
+		const recursiveRequests: (boolean | undefined)[] = [];
+		createEngine({
+			targets: [{ id: "root", kind: "dir-recursive", path: tempDir }],
+			subscribe: (_path, _listener, options) => {
+				recursiveRequests.push(options?.recursive);
+				return () => {};
+			},
+			onRealChange: vi.fn(),
+		});
+
+		expect(recursiveRequests.length).toBeGreaterThan(1);
+		expect(recursiveRequests.some(Boolean)).toBe(false);
+	});
+
+	it("detects a change in a nested directory through its own watcher", () => {
+		vi.useFakeTimers();
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-watch-"));
+		const nested = join(tempDir, "pkg", "deep");
+		mkdirSync(nested, { recursive: true });
+		const nestedFile = join(nested, "skill.md");
+		writeFileSync(nestedFile, "before");
+		const source = eventSource();
+		const onRealChange = vi.fn();
+		createEngine({
+			targets: [{ id: "skills", kind: "dir-recursive", path: tempDir }],
+			subscribe: source.subscribe,
+			onRealChange,
+		});
+
+		writeFileSync(nestedFile, "after");
+		// A per-directory watcher reports names relative to its own directory; the
+		// engine must re-anchor that to the target root before matching.
+		source.emitFrom(nested, "skill.md");
+		vi.advanceTimersByTime(200);
+
+		expect(onRealChange.mock.calls).toEqual([[{ changedPaths: [nestedFile], created: [], deleted: [] }]]);
+	});
+
+	it("attaches a watcher to a directory created after startup", () => {
+		vi.useFakeTimers();
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-watch-"));
+		const source = eventSource();
+		createEngine({
+			targets: [{ id: "skills", kind: "dir-recursive", path: tempDir }],
+			subscribe: source.subscribe,
+			onRealChange: vi.fn(),
+		});
+		const added = join(tempDir, "added");
+		expect(source.watchedPaths()).not.toContain(added);
+
+		mkdirSync(added);
+		writeFileSync(join(added, "skill.md"), "content");
+		source.emit("added");
+		vi.advanceTimersByTime(200);
+
+		expect(source.watchedPaths()).toContain(added);
+	});
+
+	it("releases the watcher for a directory that leaves scope", () => {
+		vi.useFakeTimers();
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-config-reload-watch-"));
+		const removable = join(tempDir, "removable");
+		mkdirSync(removable);
+		writeFileSync(join(removable, "skill.md"), "content");
+		const source = eventSource();
+		createEngine({
+			targets: [{ id: "skills", kind: "dir-recursive", path: tempDir }],
+			subscribe: source.subscribe,
+			onRealChange: vi.fn(),
+		});
+		expect(source.watchedPaths()).toContain(removable);
+
+		rmSync(removable, { recursive: true });
+		source.emit("removable");
+		vi.advanceTimersByTime(200);
+
+		expect(source.watchedPaths()).not.toContain(removable);
 	});
 
 	it("reports only explicit dot-directory creation and deletion", () => {


### PR DESCRIPTION
## Problem

Every `dir-recursive` config watch target (extensions dirs, skills dirs) was handed to `fs.watch({ recursive: true })`, which registers the **entire subtree** with the OS watcher (FSEvents on macOS). The target `filter` only discards events *after* delivery, so an extensions directory containing `node_modules` still paid for a full-subtree registration in every session.

Measured on a loaded M4 Pro: `fseventsd` at 123% CPU and 3–4.3GB RSS, load average above 200 — the only mitigation was disabling `configReload` entirely.

Reproduced with a standalone probe: `fs.watch({recursive:true})` on an extensions dir delivers `node_modules` change events at OS level; per-directory non-recursive watches do not.

## Fix

The engine's scan already computes the in-scope directory set (skipping `node_modules`, `.git`, symlinks, non-allow-listed dot-directories, and filtered paths). Record that set and open **one non-recursive subscription per in-scope directory** instead:

- `ScanResult.scannedDirectories` tracks visited directories; `#attach`/`#detachMissing` reconcile subscriptions after every full and partial rescan (new directories gain a watcher, directories leaving scope release theirs).
- `#onEvent` re-anchors per-directory filenames to the target root before matching.
- The watch engine never requests `recursive: true` from the OS anymore, on any platform.

## Verification

- New regression tests in `config-reload-watch-engine.test.ts` (16/16): no recursive OS requests, no node_modules/.git watches, nested change detection through per-directory watchers, attach-on-create, detach-on-scope-exit. The single-listener test probe was fixed to keep one listener per watched directory (it previously dropped all but the last watcher).
- Full config-reload/watch suites: 41 + 65 tests green (engine, scope, protocol, shim, footer fallback, 2791 fswatch-error-crash, lazy-teardown, config-reload-extension, 477 recursive-watch-main-thread-stall, rpc-multi-session-isolation).
- Baseline comparison for unrelated full-suite failures (6999 models-json-hot-reload et al.): fails identically on origin/main — pre-existing, not this change.
- Real-FS QA probe (`local-ignore/qa-evidence/20260820-watch-scope/`): 0 recursive OS requests, 0 node_modules/.git watches, real nested change detected, node_modules writes silent — ALL PASS.
- `npm run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, tsc, browser-smoke): green via pre-commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Watches only in-scope directories for config reload instead of registering whole subtrees. This replaces recursive OS watches with per-directory non-recursive subscriptions, eliminating `node_modules`/`.git` overhead and fixing high CPU/RSS without losing change coverage.

- Old vs new: previously used `fs.watch({ recursive: true })` on the target root; now records directories found by the scan and subscribes to each non-recursively; never requests recursive on any platform.
- Event handling: re-anchors per-directory filenames to the target root before matching.
- Rescans: adds `#attach` and `#detachMissing` to reconcile subscriptions after full and partial rescans (attach on create, detach on scope exit).
- State shapes: `ScanResult` now includes `scannedDirectories`; `TargetState` adds `watchedDirectories` and `scannedDirectories`; `#onEvent` accepts the watched directory.
- Tests: extends `config-reload-watch-engine.test.ts` to assert no recursive OS requests, no `node_modules`/`.git` watches, nested change detection, and attach/detach behavior.
- Migration: no external API changes; extensions require no action.

<sup>Written for commit b089521dc63b66362e4498fd85a7cdc031199727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

