### PR TITLE
fix(coding-agent): preserve interactive session confirmation

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,27 @@
 # changes
 
+## 2026-08-20 - Preserve interactive cross-project session confirmations
+
+### What changed
+
+- `packages/coding-agent/src/main.ts`: prevent the readline `close` fallback from overriding an answer already received by `promptConfirm()`.
+- `packages/coding-agent/test/suite/regressions/interactive-session-confirmation.test.ts`: cover `y`, `yes`, `n`, empty input, and EOF.
+
+### Why
+
+- Calling `rl.close()` from the question callback emits `close` before the callback's result can settle the promise, so `y` and `yes` were incorrectly treated as `false`.
+
+### Why an extension could not handle it
+
+- Cross-project session confirmation runs in the core CLI session-resolution path before an extension can take over.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/main.ts` `promptConfirm`, `createSessionManager`
+- `packages/coding-agent/test/suite/regressions/interactive-session-confirmation.test.ts`
+
+##
+
 ## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -20,8 +20,6 @@
 - `packages/coding-agent/src/main.ts` `promptConfirm`, `createSessionManager`
 - `packages/coding-agent/test/suite/regressions/interactive-session-confirmation.test.ts`
 
-##
-
 ## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
 
 ### What changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -333,17 +333,23 @@ async function resolveSessionPath(sessionArg: string, cwd: string, sessionDir?: 
  * Resolves false on stdin EOF (Ctrl+D, closed pipe): without the close handler a
  * readline question never settles once the input stream ends, hanging the process.
  */
-async function promptConfirm(message: string): Promise<boolean> {
+export async function promptConfirm(message: string): Promise<boolean> {
 	return new Promise((resolve) => {
 		const rl = createInterface({
 			input: process.stdin,
 			output: process.stdout,
 		});
+		let settled = false;
+		const settle = (result: boolean): void => {
+			if (settled) return;
+			settled = true;
+			resolve(result);
+		};
 		rl.question(`${message} [y/N] `, (answer) => {
+			settle(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
 			rl.close();
-			resolve(answer.toLowerCase() === "y" || answer.toLowerCase() === "yes");
 		});
-		rl.on("close", () => resolve(false));
+		rl.once("close", () => settle(false));
 	});
 }
 

--- a/packages/coding-agent/test/suite/regressions/interactive-session-confirmation.test.ts
+++ b/packages/coding-agent/test/suite/regressions/interactive-session-confirmation.test.ts
@@ -1,0 +1,35 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, test } from "vitest";
+import { promptConfirm } from "../../../src/main.ts";
+
+const originalStdin = process.stdin;
+const originalStdout = process.stdout;
+
+async function confirmWithInput(input: string | undefined): Promise<boolean> {
+	const stdin = new PassThrough();
+	const stdout = new PassThrough();
+	Object.defineProperty(process, "stdin", { configurable: true, value: stdin });
+	Object.defineProperty(process, "stdout", { configurable: true, value: stdout });
+
+	const result = promptConfirm("Continue?");
+	if (input === undefined) stdin.end();
+	else stdin.end(`${input}\n`);
+	return result;
+}
+
+afterEach(() => {
+	Object.defineProperty(process, "stdin", { configurable: true, value: originalStdin });
+	Object.defineProperty(process, "stdout", { configurable: true, value: originalStdout });
+});
+
+describe("interactive session confirmation", () => {
+	test.each([
+		["y", true],
+		["yes", true],
+		["n", false],
+		["", false],
+		[undefined, false],
+	] as const)("returns %s => %s", async (input, expected) => {
+		await expect(confirmWithInput(input)).resolves.toBe(expected);
+	});
+});


### PR DESCRIPTION
## Summary

- Prevent the readline `close` fallback from overriding an answer already received by `promptConfirm()`.
- Preserve `y`/`yes` approval and `n`/empty/EOF rejection.
- Add deterministic regression coverage and the required coding-agent change tracker entry.

## Reproduction

When resuming a session from another project with `--session`, answering `y` or `yes` incorrectly aborted the operation:

```text
Fork this session into current directory? [y/N] y
Aborted.
```

## Root cause

`rl.close()` was called inside the readline question callback before resolving the answer. The emitted `close` event resolved the promise with `false` before the `y`/`yes` result could take effect.

The fix uses a settled guard so the EOF fallback remains active without overriding an answer that has already been received.

## Testing

- `npm run build`
- `npm --prefix packages/coding-agent test -- test/suite/regressions/interactive-session-confirmation.test.ts` — 5 passed
- `npm --prefix packages/coding-agent test -- test/suite/regressions/756-session-cross-project-resume.test.ts` — 2 passed
- `npm run check`
- `node .agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` — 8/8 passed
- Manual interactive terminal QA: entering `y` returned a forked session manager with the target session created in the destination project.

## Related

This is related to [#756](https://github.com/code-yeongyu/senpi/pull/756), but is distinct: #756 covers non-interactive stdin handling, while this PR fixes the interactive readline confirmation race.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves interactive confirmation during cross-project session resolution. Previously, y/yes approvals were overridden by a readline close event and aborted; now y/yes approves, while n/empty/EOF rejects.

- Guard the readline close fallback so it rejects only when no answer was received; settle once in `promptConfirm`.
- Export `promptConfirm` and add regression tests for y, yes, n, empty input, and EOF; update the `changes.md` tracker entry.

<sup>Written for commit 1ffd42634fc5eeda6766d438163430eb3b9ddc74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

