### PR TITLE
test(coding-agent): make fs.watch-dependent tests deterministic

### DIFF
--- a/packages/coding-agent/test/config-reload-watch-engine.test.ts
+++ b/packages/coding-agent/test/config-reload-watch-engine.test.ts
@@ -473,7 +473,7 @@ describe("config reload watch engine", () => {
 				return await Promise.race([
 					change,
 					new Promise<never>((_resolve, reject) => {
-						timeout = setTimeout(() => reject(new Error(`fs.watch ${label} was not delivered`)), 10_000);
+						timeout = setTimeout(() => reject(new Error(`fs.watch ${label} was not delivered`)), 30_000);
 					}),
 				]);
 			} finally {
@@ -495,9 +495,20 @@ describe("config reload watch engine", () => {
 		} finally {
 			clearInterval(armReadiness);
 		}
-		writeFileSync(settingsPath, "after");
-		const result = await awaitChange(settingsChanged, "settings.json change");
-
-		expect(result.changedPaths).toEqual([settingsPath]);
+		// Re-arm the assertion write too: under heavy host load FSEvents can starve a
+		// single one-shot write past any fixed deadline, and rewriting identical bytes
+		// would be hash-deduped by the engine - so every re-arm writes fresh content.
+		let settingsRevision = 0;
+		const armSettingsChange = setInterval(() => {
+			settingsRevision += 1;
+			writeFileSync(settingsPath, `after-${settingsRevision}`);
+		}, 250);
+		try {
+			writeFileSync(settingsPath, "after");
+			const result = await awaitChange(settingsChanged, "settings.json change");
+			expect(result.changedPaths).toEqual([settingsPath]);
+		} finally {
+			clearInterval(armSettingsChange);
+		}
 	});
 });

--- a/packages/coding-agent/test/cursor-cli-oauth/shutdown.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/shutdown.test.ts
@@ -1,4 +1,14 @@
-import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, watch, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	copyFileSync,
+	existsSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	watch,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,19 +62,45 @@ function liveContext(): ExtensionContext {
 	return { isIdle: () => true } as unknown as ExtensionContext;
 }
 
-async function waitForPidFile(pidFile: string): Promise<number> {
+/**
+ * Wait for the fixture's atomically-renamed pid file. Call BEFORE spawning
+ * the process tree that writes it. Presence on disk - checked on a short
+ * bounded poll - is the signal of record: fs.watch is only a best-effort
+ * wake-up here because macOS event delivery inside a vitest worker has been
+ * observed to drop every event for a freshly created temp directory (the
+ * file sat on disk while the old event-only wait burned its whole deadline).
+ */
+function waitForPidFile(pidFile: string): Promise<number> {
 	return new Promise<number>((resolvePid, rejectPid) => {
 		const watcher = watch(dirname(pidFile));
-		const deadline = setTimeout(() => {
-			watcher.close();
-			rejectPid(new Error("fixture did not report its grandchild"));
-		}, 5_000);
-		watcher.on("change", (_eventType, filename) => {
-			if (filename !== "grandchild.pid") return;
+		let settled = false;
+		const finish = (outcome: () => void) => {
+			if (settled) return;
+			settled = true;
 			clearTimeout(deadline);
+			clearInterval(poll);
 			watcher.close();
-			resolvePid(Number(readFileSync(pidFile, "utf8").trim()));
-		});
+			outcome();
+		};
+		const tryRead = () => {
+			if (settled || !existsSync(pidFile)) return;
+			const contents = readFileSync(pidFile, "utf8").trim();
+			if (contents === "") return;
+			finish(() => resolvePid(Number(contents)));
+		};
+		const poll = setInterval(tryRead, 50);
+		const deadline = setTimeout(() => {
+			finish(() =>
+				rejectPid(
+					new Error(
+						`fixture did not report its grandchild (directory: [${readdirSync(dirname(pidFile)).join(", ")}])`,
+					),
+				),
+			);
+		}, 10_000);
+		watcher.on("change", tryRead);
+		watcher.on("error", tryRead);
+		tryRead();
 	});
 }
 
@@ -103,6 +139,7 @@ describe("cursor CLI shutdown safety", () => {
 		expect(handlers.has("session_extensions_removed")).toBe(true);
 
 		process.env.SENPI_CURSOR_CLI_OAUTH_EXECUTABLE = fixture.executable;
+		const pendingGrandchildPid = waitForPidFile(fixture.pidFile);
 		const handle = spawnCursorCliTracked(
 			{
 				prompt: "grandchild scenario",
@@ -112,7 +149,7 @@ describe("cursor CLI shutdown safety", () => {
 			},
 			registry,
 		);
-		const grandchildPid = await waitForPidFile(fixture.pidFile);
+		const grandchildPid = await pendingGrandchildPid;
 		expect(registry.livePids()).toContain(handle.pid);
 
 		await shutdown({ type: "session_shutdown", reason: "reload" }, liveContext());
@@ -137,6 +174,7 @@ describe("cursor CLI shutdown safety", () => {
 		if (!shutdown) throw new Error("session_shutdown handler was not registered");
 
 		process.env.SENPI_CURSOR_CLI_OAUTH_EXECUTABLE = fixture.executable;
+		const pendingGrandchildPid = waitForPidFile(fixture.pidFile);
 		const handle = spawnCursorCliTracked(
 			{
 				prompt: "grandchild scenario",
@@ -146,7 +184,7 @@ describe("cursor CLI shutdown safety", () => {
 			},
 			registry,
 		);
-		const grandchildPid = await waitForPidFile(fixture.pidFile);
+		const grandchildPid = await pendingGrandchildPid;
 
 		await shutdown({ type: "session_shutdown", reason: "quit" }, liveContext());
 		await handle.completed;


### PR DESCRIPTION
## Summary

Makes the two fs.watch-dependent flaky tests deterministic — the only red in the post-merge-train verification of `a33020fd0`:

- `test/cursor-cli-oauth/shutdown.test.ts` (both grandchild tests): failed most runs, even isolated, with `fixture did not report its grandchild`.
- `test/config-reload-watch-engine.test.ts` ("uses the production fs.watch adapter for recursive directory events"): failed under full-suite CPU load with `fs.watch readiness event was not delivered`.

## Root cause

**shutdown.test.ts** — the old `waitForPidFile` relied exclusively on an fs.watch event, armed *after* the process tree was spawned, filtered to an exact filename. Instrumenting the deadline error proved the decisive fact: at rejection time `grandchild.pid` was already sitting in the directory — on macOS inside a vitest worker, fs.watch delivered **zero events** for the freshly created temp directory (the identical chain run standalone delivers the pid file in under a second with events working). An event-only wait therefore burns its whole deadline while the awaited state is already true.

Fix: presence on disk is now the signal of record — a bounded 50 ms existence poll (10 s deadline) with the watcher retained only as a best-effort wake-up; the wait is armed before the spawn and re-checks on any event type/filename (macOS may deliver null filenames). The fixture already publishes atomically via rename, so a non-empty read is complete.

**config-reload-watch-engine.test.ts** — the readiness probe already re-armed every 250 ms, but both waits used a 10 s bound that FSEvents can starve past under full-machine load, and the final `settings.json` change wait was one-shot: rewriting identical bytes would be hash-deduped by the engine, so a single dropped event was unrecoverable.

Fix: bounds raised to 30 s, and the settings-change phase re-arms every 250 ms with content-varying writes (`after-N`) cleared in `finally`; the `changedPaths` assertion is unchanged (allowlist keeps it `[settings.json]` whichever write lands).

## QA & Evidence

- RED (unchanged code): shutdown failed on loop run 1 — `2 failed | 5 passed`, both `fixture did not report its grandchild`. config-reload failed on stress run 6 under an 8-core busy-loop — `1 failed | 15 passed`, `fs.watch readiness event was not delivered`.
- GREEN: shutdown `7 passed (7)` in 1.49 s (previously 20 s+ burning deadlines — the poll resolves ~50 ms after the pid file lands).
- Determinism proof: **30/30 consecutive** shutdown runs green; **20/20 consecutive** config-reload runs green while the same 8-core busy-loop load ran. Zero failures.
- Full `packages/coding-agent` suite green on this branch (summary in CI).
- Test-only change: no production sources touched.

Assisted by an AI agent (omo/senpi); every line and claim reviewed and verified.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops flaky `fs.watch`-dependent tests by switching from event-only waits to on-disk presence checks and by re-arming file writes under load. This makes `packages/coding-agent` tests deterministic on macOS and under CPU contention.

- shutdown: In `test/cursor-cli-oauth/shutdown.test.ts`, replace the event-only `waitForPidFile` with a 50 ms existence poll (10 s deadline) plus a best-effort `fs.watch` wake-up. Arm the wait before spawning, accept any event/filename, and resolve only on a non-empty read. On timeout, include the directory listing for diagnostics.
- config reload: In `test/config-reload-watch-engine.test.ts`, raise watch timeouts from 10 s to 30 s. Re-arm the `settings.json` change every 250 ms with content-varying writes (`after-N`) and clear the interval in `finally`. The assertion still expects only `settings.json` in `changedPaths`.

<sup>Written for commit d801a67f15ad22f2bccc5dfd550387ae68607b49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

