### PR TITLE
perf(coding-agent): accelerate resume discovery and rendering

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-args.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-args.mjs
@@ -1,0 +1,155 @@
+import { createWriteStream, existsSync, mkdirSync, realpathSync } from "node:fs";
+import { once } from "node:events";
+import { isAbsolute, join, posix, relative } from "node:path";
+import { finished } from "node:stream/promises";
+import { evidenceDir } from "./common.mjs";
+
+export const COLS = 120;
+export const ROWS = 34;
+export const TUI_ARGS = ["--no-context-files", "--no-skills", "--no-extensions", "--approve", "--tui-mode", "fullscreen"];
+export const FIRST_MARKER = "ResumeQaFirstMarkerA1B2C3D4";
+export const FINAL_MARKER = "ResumeQaFinalMarkerE5F6G7H8";
+export const SESSION_ID = "resume-qa-selected";
+export const BOOT_TIMEOUT_MS = 60_000;
+export const SELECTOR_TIMEOUT_MS = 30_000;
+export const HYDRATE_TIMEOUT_MS = 180_000;
+export const TEARDOWN_TIMEOUT_MS = 8_000;
+/** Documented safe maximum for `--messages`. The 5000-message load must remain valid. */
+export const MAX_MESSAGES = 5000;
+export const COMMAND = "node .agents/skills/senpi-qa/scripts/tui-resume.mjs --messages 5000 --select latest --evidence resume-performance";
+
+export function parseMessageBound(raw) {
+	const messages = Number(raw);
+	if (!Number.isInteger(messages) || messages <= 0) throw new Error("--messages must be a positive integer");
+	if (messages > MAX_MESSAGES) throw new Error(`--messages exceeds safe maximum of ${MAX_MESSAGES}`);
+	return messages;
+}
+
+export const EVIDENCE_PREFIX = "local-ignore/qa-evidence/";
+export const EXACT_EVIDENCE_PATH = "local-ignore/qa-evidence/20260820-resume-performance/tui-resume";
+
+function isSafeSegment(segment) {
+	return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(segment);
+}
+
+export function normalizeEvidencePath(raw) {
+	if (typeof raw !== "string" || raw.length === 0) throw new Error("--evidence requires a value");
+	if (raw.includes("\0") || raw.includes("\\")) throw new Error("--evidence path is not allowed");
+	if (isAbsolute(raw) || raw.startsWith("/")) throw new Error("--evidence path must not be absolute");
+	const segments = raw.split("/");
+	if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+		throw new Error("--evidence path must not contain . or ..");
+	}
+	const normalized = posix.normalize(raw);
+	if (!normalized.startsWith(EVIDENCE_PREFIX) || normalized.length <= EVIDENCE_PREFIX.length) {
+		throw new Error("--evidence path must stay under local-ignore/qa-evidence/");
+	}
+	for (const segment of normalized.slice(EVIDENCE_PREFIX.length).split("/")) {
+		if (!isSafeSegment(segment)) throw new Error("--evidence path segment is not allowed");
+	}
+	return normalized;
+}
+
+export function parseEvidence(raw) {
+	if (typeof raw !== "string" || raw.length === 0) throw new Error("--evidence requires a value");
+	if (isSafeSegment(raw)) return raw;
+	return normalizeEvidencePath(raw);
+}
+
+function assertInsideEvidenceRoot(realRoot, target) {
+	const rel = relative(realRoot, target);
+	if (rel.startsWith("..") || isAbsolute(rel)) {
+		throw new Error("--evidence path must not escape local-ignore/qa-evidence/");
+	}
+}
+
+export function resolveResumeEvidence(root, evidence) {
+	const parsed = parseEvidence(evidence);
+	if (isSafeSegment(parsed)) return evidenceDir(parsed);
+	const remainder = parsed.slice(EVIDENCE_PREFIX.length);
+	const evidenceRoot = join(root, "local-ignore", "qa-evidence");
+	mkdirSync(evidenceRoot, { recursive: true });
+	const realRoot = realpathSync(evidenceRoot);
+	let current = realRoot;
+	for (const segment of remainder.split("/")) {
+		const next = join(current, segment);
+		if (!existsSync(next)) mkdirSync(next, { recursive: true });
+		current = realpathSync(next);
+		assertInsideEvidenceRoot(realRoot, current);
+	}
+	return current;
+}
+
+export function usage() {
+	process.stdout.write(
+		`usage: node tui-resume.mjs --messages N --select latest --evidence SLUG\n--messages N is a positive integer up to ${MAX_MESSAGES}\n`,
+	);
+}
+
+export function parseArgs(argv) {
+	const options = {};
+	for (let i = 0; i < argv.length; i += 1) {
+		const flag = argv[i];
+		const value = argv[i + 1];
+		if (!value || value.startsWith("--")) {
+			if (flag !== "--messages" && flag !== "--select" && flag !== "--evidence") {
+				throw new Error(`Unknown option: ${flag}`);
+			}
+			throw new Error(`${flag} requires a value`);
+		}
+		i += 1;
+		switch (flag) {
+			case "--messages":
+				options.messages = parseMessageBound(value);
+				break;
+			case "--select":
+				if (value !== "latest") throw new Error('--select only supports "latest"');
+				options.select = value;
+				break;
+			case "--evidence":
+				options.evidence = parseEvidence(value);
+				break;
+			default:
+				throw new Error(`Unknown option: ${flag}`);
+		}
+	}
+	if (!options.messages || !options.select || !options.evidence) {
+		throw new Error("required: --messages N --select latest --evidence SLUG");
+	}
+	return options;
+}
+
+export async function writeSession(path, { sessionId, cwd, messageCount }) {
+	const activityBase = Date.now() + 86_400_000;
+	const stream = createWriteStream(path);
+	const write = async (line) => {
+		if (!stream.write(line)) await once(stream, "drain");
+	};
+	await write(
+		`${JSON.stringify({
+			type: "session",
+			version: 3,
+			id: sessionId,
+			timestamp: new Date(activityBase).toISOString(),
+			cwd,
+		})}\n`,
+	);
+	let parentId = null;
+	for (let index = 1; index <= messageCount; index += 1) {
+		const id = `msg-${index}`;
+		const text = index === 1 ? FIRST_MARKER : index === messageCount ? FINAL_MARKER : `resume-load-probe-${index}`;
+		const timestamp = activityBase + index;
+		await write(
+			`${JSON.stringify({
+				type: "message",
+				id,
+				parentId,
+				timestamp: new Date(timestamp).toISOString(),
+				message: { role: "user", content: [{ type: "text", text }], timestamp },
+			})}\n`,
+		);
+		parentId = id;
+	}
+	stream.end();
+	await finished(stream);
+}

--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-args.test.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-args.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MAX_MESSAGES, parseArgs, parseEvidence, parseMessageBound } from "./tui-resume-args.mjs";
+
+const required = ["--select", "latest", "--evidence", "slug"];
+const EXACT_EVIDENCE = "local-ignore/qa-evidence/20260820-resume-performance/tui-resume";
+
+test("documented --messages bound is at least 5000", () => {
+	assert.ok(MAX_MESSAGES >= 5000);
+});
+
+test("parseMessageBound accepts the 5000-message load", () => {
+	assert.equal(parseMessageBound("5000"), 5000);
+});
+
+test("parseMessageBound rejects counts above the documented safe maximum", () => {
+	assert.throws(() => parseMessageBound(String(MAX_MESSAGES + 1)), /safe maximum/);
+});
+
+test("parseArgs accepts 5000 messages with required flags", () => {
+	const options = parseArgs(["--messages", "5000", ...required]);
+	assert.equal(options.messages, 5000);
+	assert.equal(options.select, "latest");
+	assert.equal(options.evidence, "slug");
+});
+
+test("parseArgs rejects --messages above the documented safe maximum", () => {
+	assert.throws(
+		() => parseArgs(["--messages", String(MAX_MESSAGES + 1), ...required]),
+		/safe maximum/,
+	);
+});
+
+test("parseArgs rejects unknown flags", () => {
+	assert.throws(
+		() => parseArgs(["--messages", "1", ...required, "--nope", "1"]),
+		/Unknown option: --nope/,
+	);
+});
+
+test("parseEvidence accepts a safe slug", () => {
+	assert.equal(parseEvidence("resume-performance"), "resume-performance");
+});
+
+test("parseEvidence accepts the exact repo-relative evidence path", () => {
+	assert.equal(parseEvidence(EXACT_EVIDENCE), EXACT_EVIDENCE);
+});
+
+test("parseArgs accepts the exact repo-relative evidence path", () => {
+	const options = parseArgs(["--messages", "1", "--select", "latest", "--evidence", EXACT_EVIDENCE]);
+	assert.equal(options.evidence, EXACT_EVIDENCE);
+});
+
+test("parseArgs rejects evidence path traversal", () => {
+	assert.throws(
+		() => parseArgs(["--messages", "1", "--select", "latest", "--evidence", "local-ignore/qa-evidence/../.senpi"]),
+		/evidence/,
+	);
+});
+
+test("parseEvidence rejects traversal, absolute paths, and escapes", () => {
+	const bad = [
+		"../escape",
+		"nested/path",
+		"local-ignore/qa-evidence/../.senpi",
+		"local-ignore/qa-evidence/foo/../../etc",
+		"/tmp/evil",
+		"local-ignore/qa-evidence/../../packages",
+		`${EXACT_EVIDENCE}/../../secret`,
+	];
+	for (const value of bad) {
+		assert.throws(() => parseEvidence(value), /evidence/);
+	}
+});

--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-evidence.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-evidence.mjs
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { stripAnsi } from "./common.mjs";
+import { COLS, COMMAND, FINAL_MARKER, FIRST_MARKER, ROWS, SESSION_ID, TUI_ARGS } from "./tui-resume-args.mjs";
+
+function chromeExecutable() {
+	const candidates = [
+		process.env.CHROME_PATH,
+		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		"/Applications/Chromium.app/Contents/MacOS/Chromium",
+		"/usr/bin/google-chrome",
+		"/usr/bin/chromium",
+		"/usr/bin/chromium-browser",
+	].filter((candidate) => typeof candidate === "string");
+	return candidates.find((candidate) => existsSync(candidate));
+}
+
+function renderPngFromHtml(htmlPath, pngPath) {
+	const chrome = chromeExecutable();
+	if (!chrome) throw new Error("Chrome not found for headless screenshot");
+	const result = spawnSync(
+		chrome,
+		[
+			"--headless=new",
+			"--disable-gpu",
+			"--hide-scrollbars",
+			"--no-first-run",
+			"--no-default-browser-check",
+			"--window-size=1400,900",
+			`--screenshot=${pngPath}`,
+			pathToFileURL(htmlPath).href,
+		],
+		{ encoding: "utf8" },
+	);
+	if (result.status !== 0 || !existsSync(pngPath) || statSync(pngPath).size === 0) {
+		throw new Error(`Chrome screenshot failed: ${result.stderr || result.stdout || `status=${result.status}`}`);
+	}
+}
+
+function runXterm(root, args) {
+	const result = spawnSync(process.execPath, [join(root, "scripts", "qa", "xterm-render.mjs"), ...args], {
+		cwd: root,
+		encoding: "utf8",
+	});
+	if (result.status !== 0) {
+		throw new Error(`xterm-render ${args[0]} failed: ${result.stderr || result.stdout || `status=${result.status}`}`);
+	}
+	return result;
+}
+
+export function isPng(path) {
+	if (!existsSync(path) || statSync(path).size === 0) return false;
+	const bytes = readFileSync(path);
+	return bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47;
+}
+
+export function writeResumeArtifacts(evidence, { raw, actions, timing, runError, options, sessionPath }) {
+	const plain = stripAnsi(raw);
+	const ansPath = join(evidence, "terminal.ans");
+	const txtPath = join(evidence, "terminal.txt");
+	const gridPath = join(evidence, "terminal.grid.json");
+	const htmlPath = join(evidence, "terminal.html");
+	const pngPath = join(evidence, "terminal.png");
+	const specPath = join(evidence, "assertions.json");
+	writeFileSync(ansPath, raw);
+	writeFileSync(txtPath, plain);
+	writeFileSync(join(evidence, "action-log.json"), `${JSON.stringify(actions, null, 2)}\n`);
+	writeFileSync(join(evidence, "timing.json"), `${JSON.stringify(timing ?? { error: String(runError) }, null, 2)}\n`);
+	writeFileSync(
+		join(evidence, "metadata.json"),
+		`${JSON.stringify(
+			{
+				command: COMMAND,
+				messages: options.messages,
+				select: options.select,
+				evidence: options.evidence,
+				cols: COLS,
+				rows: ROWS,
+				sessionId: SESSION_ID,
+				sessionPath,
+				firstMarker: FIRST_MARKER,
+				finalMarker: FINAL_MARKER,
+				tuiArgs: TUI_ARGS,
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	return { ansPath, txtPath, gridPath, htmlPath, pngPath, specPath };
+}
+
+export function captureGridEvidence(root, paths) {
+	runXterm(root, [
+		"render",
+		paths.ansPath,
+		"--cols",
+		String(COLS),
+		"--rows",
+		String(ROWS),
+		"--out-json",
+		paths.gridPath,
+		"--out-html",
+		paths.htmlPath,
+		"--title",
+		"Senpi /resume TUI",
+	]);
+	writeFileSync(
+		paths.specPath,
+		`${JSON.stringify({ assertions: [{ id: "final-marker", kind: "text-present", text: FINAL_MARKER }] }, null, 2)}\n`,
+	);
+	const asserted = runXterm(root, ["assert", paths.gridPath, "--spec", paths.specPath]);
+	const gridAssert = JSON.parse(asserted.stdout);
+	renderPngFromHtml(paths.htmlPath, paths.pngPath);
+	return gridAssert;
+}

--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-pty.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-pty.mjs
@@ -1,0 +1,148 @@
+import { chmodSync, existsSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { cliEntry, stripAnsi, tsxEntry } from "./common.mjs";
+import {
+	BOOT_TIMEOUT_MS,
+	COLS,
+	FINAL_MARKER,
+	FIRST_MARKER,
+	HYDRATE_TIMEOUT_MS,
+	ROWS,
+	SELECTOR_TIMEOUT_MS,
+	TUI_ARGS,
+} from "./tui-resume-args.mjs";
+
+const require = createRequire(import.meta.url);
+
+function ensureNodePtySpawnHelperExecutable() {
+	if (process.platform === "win32") return;
+	const packagePath = require.resolve("node-pty/package.json");
+	const helper = join(dirname(packagePath), "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper");
+	if (!existsSync(helper)) return;
+	const mode = statSync(helper).mode & 0o777;
+	if ((mode & 0o111) === 0) chmodSync(helper, mode | 0o755);
+}
+
+async function loadNodePty() {
+	ensureNodePtySpawnHelperExecutable();
+	const mod = await import("node-pty");
+	return mod.default ?? mod;
+}
+
+function attachStream(term) {
+	const stream = {
+		raw: "",
+		exit: null,
+		listeners: new Set(),
+		exitPromise: null,
+		resolveExit: null,
+	};
+	stream.exitPromise = new Promise((resolve) => {
+		stream.resolveExit = resolve;
+	});
+	term.onData((chunk) => {
+		stream.raw += chunk;
+		for (const listener of [...stream.listeners]) listener();
+	});
+	term.onExit((event) => {
+		stream.exit = event;
+		stream.resolveExit(event);
+		for (const listener of [...stream.listeners]) listener();
+	});
+	return stream;
+}
+
+function waitUntil(stream, predicate, { timeoutMs, label }) {
+	if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) throw new Error(`${label}: timeout must be a positive integer`);
+	return new Promise((resolve, reject) => {
+		let settled = false;
+		let unsubscribe = () => {};
+		const finish = (fn, value) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			unsubscribe();
+			fn(value);
+		};
+		const inspect = () => {
+			if (predicate(stream.raw)) {
+				finish(resolve, { rawLength: stream.raw.length });
+				return;
+			}
+			if (stream.exit) {
+				finish(reject, new Error(`${label}: PTY exited before predicate matched`));
+			}
+		};
+		const timer = setTimeout(() => finish(reject, new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+		unsubscribe = () => stream.listeners.delete(inspect);
+		stream.listeners.add(inspect);
+		inspect();
+	});
+}
+
+function waitForText(stream, needle, options) {
+	return waitUntil(stream, (raw) => stripAnsi(raw).includes(needle), options);
+}
+
+function recordAction(actions, type, detail) {
+	actions.push({ t: new Date().toISOString(), type, ...detail });
+}
+
+export async function spawnResumeTui({ root, cwd, env }) {
+	const pty = await loadNodePty();
+	const term = pty.spawn(
+		process.execPath,
+		[tsxEntry(root), "--tsconfig", join(root, "tsconfig.json"), cliEntry(root), ...TUI_ARGS],
+		{ name: "xterm-256color", cols: COLS, rows: ROWS, cwd, env },
+	);
+	return { term, stream: attachStream(term) };
+}
+
+export async function driveResume(term, stream, { messages, actions }) {
+	await waitForText(stream, "senpi v", { timeoutMs: BOOT_TIMEOUT_MS, label: "TUI boot" });
+	recordAction(actions, "boot", { sentinel: "senpi v" });
+
+	const selectorWait = waitUntil(
+		stream,
+		(raw) => {
+			const text = stripAnsi(raw);
+			return text.includes("Resume Session") && text.includes(FIRST_MARKER);
+		},
+		{ timeoutMs: SELECTOR_TIMEOUT_MS, label: "/resume selector with latest session" },
+	);
+	term.write("/resume\r");
+	recordAction(actions, "input", { text: "/resume", key: "Enter" });
+	await selectorWait;
+	recordAction(actions, "wait", { sentinel: "Resume Session", marker: FIRST_MARKER });
+
+	const submitOffset = stream.raw.length;
+	const submitStarted = performance.now();
+	const finalWait = waitUntil(
+		stream,
+		(raw) => stripAnsi(raw.slice(submitOffset)).includes(FINAL_MARKER),
+		{ timeoutMs: HYDRATE_TIMEOUT_MS, label: "first final marker after submit" },
+	);
+	term.write("\r");
+	recordAction(actions, "input", { text: "", key: "Enter", select: "latest" });
+	await finalWait;
+	const commandSubmitToFirstFinalMarkerMs = performance.now() - submitStarted;
+	await waitUntil(
+		stream,
+		(raw) => {
+			const text = stripAnsi(raw);
+			return text.includes(FIRST_MARKER) && text.includes(FINAL_MARKER);
+		},
+		{ timeoutMs: HYDRATE_TIMEOUT_MS, label: "first and final markers in raw stream" },
+	);
+	const plain = stripAnsi(stream.raw);
+	const timing = {
+		commandSubmitToFirstFinalMarkerMs,
+		firstMarkerIndex: plain.indexOf(FIRST_MARKER),
+		finalMarkerIndex: plain.indexOf(FINAL_MARKER),
+		submitOffset,
+		messages,
+	};
+	recordAction(actions, "timing", timing);
+	return timing;
+}

--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-pty.test.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-pty.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyPostExitCleanup, sendSigkillTree, teardownPty, waitForPtyExit } from "./tui-resume-teardown.mjs";
+
+function fakeTerm(pid = 4242) {
+	const calls = [];
+	return {
+		pid,
+		calls,
+		write(data) {
+			calls.push(["write", data]);
+		},
+		kill(signal) {
+			calls.push(["kill", signal]);
+		},
+	};
+}
+
+function pendingStream() {
+	let resolveExit;
+	const stream = {
+		exit: null,
+		exitPromise: new Promise((resolve) => {
+			resolveExit = resolve;
+		}),
+		resolve(event) {
+			stream.exit = event;
+			resolveExit(event);
+		},
+	};
+	return stream;
+}
+
+test("waitForPtyExit unschedules the timer when the PTY already exited", async () => {
+	let cleared = false;
+	const result = await waitForPtyExit(Promise.resolve({ exitCode: 0, signal: null }), 9999, {
+		schedule: () => 1,
+		unschedule: () => {
+			cleared = true;
+		},
+	});
+	assert.deepEqual(result, { event: { exitCode: 0, signal: null } });
+	assert.equal(cleared, true);
+});
+
+test("sendSigkillTree sends process-group SIGKILL on POSIX", () => {
+	const term = fakeTerm(4242);
+	const kills = [];
+	sendSigkillTree({
+		pid: 4242,
+		term,
+		platform: "darwin",
+		killProcess(pid, signal) {
+			kills.push([pid, signal]);
+		},
+	});
+	assert.deepEqual(kills, [[-4242, "SIGKILL"]]);
+	assert.deepEqual(term.calls, [["kill", "SIGKILL"]]);
+});
+
+test("teardownPty escalates to process-group SIGKILL after graceful timeout", async () => {
+	const term = fakeTerm(4242);
+	const stream = pendingStream();
+	const kills = [];
+	let waits = 0;
+	const receipt = await teardownPty(term, stream, {
+		platform: "darwin",
+		killProcess(pid, signal) {
+			kills.push([pid, signal]);
+			stream.resolve({ exitCode: null, signal: 9 });
+		},
+		async waitExit() {
+			waits += 1;
+			if (waits === 1) return { timeout: true };
+			return { event: stream.exit };
+		},
+	});
+	assert.equal(receipt.escalated, true);
+	assert.equal(receipt.ptyExited, true);
+	assert.deepEqual(kills, [[-4242, "SIGKILL"]]);
+	assert.equal(
+		term.calls.some((call) => call[0] === "kill" && call[1] === "SIGKILL"),
+		true,
+	);
+});
+
+test("teardownPty throws when exit cannot be confirmed", async () => {
+	const term = fakeTerm(7);
+	const stream = pendingStream();
+	await assert.rejects(
+		() =>
+			teardownPty(term, stream, {
+				platform: "darwin",
+				killProcess() {},
+				async waitExit() {
+					return { timeout: true };
+				},
+			}),
+		/exit not confirmed/,
+	);
+});
+
+test("applyPostExitCleanup does not remove the sandbox when PTY is still alive", () => {
+	let removed = false;
+	const receipt = applyPostExitCleanup(
+		{ ptyExited: false },
+		{
+			removeSandbox() {
+				removed = true;
+			},
+			sandboxExists() {
+				return true;
+			},
+			assertAuth() {
+				return true;
+			},
+		},
+	);
+	assert.equal(removed, false);
+	assert.equal(receipt.sandboxRemoved, false);
+	assert.equal(receipt.cleanupSequence.includes("sandboxRemoved"), false);
+});
+
+test("applyPostExitCleanup records ptyExited before sandboxRemoved and authUnchanged", () => {
+	const receipt = applyPostExitCleanup(
+		{ ptyExited: true },
+		{
+			removeSandbox() {},
+			sandboxExists() {
+				return false;
+			},
+			assertAuth() {
+				return true;
+			},
+		},
+	);
+	assert.deepEqual(receipt.cleanupSequence, ["ptyExited", "sandboxRemoved", "authUnchanged"]);
+	assert.ok(receipt.cleanupSequence.indexOf("ptyExited") < receipt.cleanupSequence.indexOf("sandboxRemoved"));
+	assert.ok(receipt.cleanupSequence.indexOf("ptyExited") < receipt.cleanupSequence.indexOf("authUnchanged"));
+});

--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-signal.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-signal.mjs
@@ -1,0 +1,66 @@
+export function createResumeCleanupController({
+	processLike = process,
+	exit = (code) => processLike.exit(code),
+	teardown,
+	postExitCleanup,
+	prePtyCleanup = () => null,
+}) {
+	let pty;
+	let cleanupPromise;
+	let installed = false;
+	let signalHandled = false;
+	let signalCompletion = Promise.resolve();
+
+	async function cleanup() {
+		if (!cleanupPromise) {
+			cleanupPromise = (async () => {
+				if (!pty) return prePtyCleanup();
+				let receipt;
+				try {
+					receipt = await teardown(pty.term, pty.stream);
+				} catch (error) {
+					receipt = error.receipt ?? { ptyExited: false };
+					receipt.teardownError = error instanceof Error ? error.message : String(error);
+				}
+				return postExitCleanup(receipt);
+			})();
+		}
+		return cleanupPromise;
+	}
+
+	function handleSignal(signal) {
+		if (signalHandled) return signalCompletion;
+		signalHandled = true;
+		signalCompletion = cleanup().then(() => exit(signal === "SIGTERM" ? 143 : 130));
+		return signalCompletion;
+	}
+
+	function unregister() {
+		if (!installed || typeof processLike.off !== "function") return;
+		processLike.off("SIGINT", onSigint);
+		processLike.off("SIGTERM", onSigterm);
+		installed = false;
+	}
+
+	const onSigint = () => void handleSignal("SIGINT");
+	const onSigterm = () => void handleSignal("SIGTERM");
+
+	function installStable() {
+		if (installed) return;
+		installed = true;
+		processLike.on("SIGINT", onSigint);
+		processLike.on("SIGTERM", onSigterm);
+	}
+
+	return {
+		registerPty(term, stream) {
+			pty = { term, stream };
+		},
+		install: installStable,
+		unregister,
+		cleanup,
+		get signalCompletion() {
+			return signalCompletion;
+		},
+	};
+}

--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-signal.test.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-signal.test.mjs
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import { createResumeCleanupController } from "./tui-resume-signal.mjs";
+
+function fixture({ teardownResult = { ptyExited: true } } = {}) {
+	const events = [];
+	const processLike = new EventEmitter();
+	const controller = createResumeCleanupController({
+		processLike,
+		exit(code) {
+			events.push(["exit", code]);
+		},
+		async teardown() {
+			events.push(["teardown"]);
+			if (teardownResult instanceof Error) throw teardownResult;
+			return teardownResult;
+		},
+		postExitCleanup(receipt) {
+			events.push(["cleanup", receipt.ptyExited]);
+			if (receipt.ptyExited) receipt.sandboxRemoved = true;
+			return receipt;
+		},
+		prePtyCleanup() {
+			events.push(["pre-pty-cleanup"]);
+			return { ptyExited: false, sandboxRemoved: true };
+		},
+	});
+	return { controller, events, processLike };
+}
+
+test("SIGTERM awaits confirmed PTY exit before sandbox cleanup and process exit", async () => {
+	const { controller, events, processLike } = fixture();
+	controller.registerPty({}, {});
+	controller.install();
+	processLike.emit("SIGTERM");
+	await controller.signalCompletion;
+	assert.deepEqual(events, [["teardown"], ["cleanup", true], ["exit", 143]]);
+});
+
+test("signal cleanup refuses sandbox removal when PTY exit is unconfirmed", async () => {
+	const error = new Error("not confirmed");
+	error.receipt = { ptyExited: false };
+	const { controller, events, processLike } = fixture({ teardownResult: error });
+	controller.registerPty({}, {});
+	controller.install();
+	processLike.emit("SIGINT");
+	await controller.signalCompletion;
+	assert.deepEqual(events, [["teardown"], ["cleanup", false], ["exit", 130]]);
+});
+
+test("normal and signal cleanup share one idempotent teardown", async () => {
+	const { controller, events } = fixture();
+	controller.registerPty({}, {});
+	await Promise.all([controller.cleanup(), controller.cleanup()]);
+	assert.deepEqual(events, [["teardown"], ["cleanup", true]]);
+});
+
+test("signal before PTY spawn cleans the sandbox without claiming PTY exit", async () => {
+	const { controller, events, processLike } = fixture();
+	controller.install();
+	processLike.emit("SIGINT");
+	const receipt = await controller.signalCompletion;
+	assert.deepEqual(events, [["pre-pty-cleanup"], ["exit", 130]]);
+	assert.equal(receipt, undefined);
+});

--- a/.agents/skills/senpi-qa/scripts/lib/tui-resume-teardown.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/tui-resume-teardown.mjs
@@ -1,0 +1,115 @@
+import { TEARDOWN_TIMEOUT_MS } from "./tui-resume-args.mjs";
+
+export function waitForPtyExit(exitPromise, timeoutMs, timers = {}) {
+	const schedule = timers.schedule ?? setTimeout;
+	const unschedule = timers.unschedule ?? clearTimeout;
+	return new Promise((resolve) => {
+		const timer = schedule(() => resolve({ timeout: true }), timeoutMs);
+		exitPromise.then(
+			(event) => {
+				unschedule(timer);
+				resolve({ event });
+			},
+			(error) => {
+				unschedule(timer);
+				resolve({ error });
+			},
+		);
+	});
+}
+
+export function sendSigkillTree({ pid, term, platform, killProcess = process.kill.bind(process) }) {
+	const result = { groupKillAttempted: false, sigkillAttempted: true };
+	if (platform !== "win32" && Number.isInteger(pid) && pid > 0) {
+		result.groupKillAttempted = true;
+		try {
+			killProcess(-pid, "SIGKILL");
+		} catch (error) {
+			result.groupKillError = error instanceof Error ? error.message : String(error);
+		}
+	} else if (platform === "win32" && Number.isInteger(pid) && pid > 0) {
+		try {
+			killProcess(pid, "SIGKILL");
+		} catch (error) {
+			result.pidKillError = error instanceof Error ? error.message : String(error);
+		}
+	}
+	try {
+		if (platform === "win32") term.kill();
+		else term.kill("SIGKILL");
+	} catch (error) {
+		result.termKillError = error instanceof Error ? error.message : String(error);
+	}
+	return result;
+}
+
+function applyExitEvent(receipt, event) {
+	receipt.ptyExited = true;
+	receipt.exitCode = event.exitCode ?? null;
+	receipt.signal = event.signal ?? null;
+}
+
+export async function teardownPty(term, stream, hooks = {}) {
+	const waitExit = hooks.waitExit ?? ((timeoutMs) => waitForPtyExit(stream.exitPromise, timeoutMs));
+	const killProcess = hooks.killProcess ?? process.kill.bind(process);
+	const platform = hooks.platform ?? process.platform;
+	const timeoutMs = hooks.timeoutMs ?? TEARDOWN_TIMEOUT_MS;
+	const receipt = {
+		pid: term.pid ?? null,
+		killAttempted: false,
+		alreadyExited: !!stream.exit,
+		ptyExited: false,
+		exitCode: null,
+		signal: null,
+		escalated: false,
+	};
+	if (stream.exit) {
+		applyExitEvent(receipt, stream.exit);
+		return receipt;
+	}
+	receipt.killAttempted = true;
+	try {
+		term.write("\x03\x03");
+		term.kill();
+	} catch (error) {
+		receipt.killError = error instanceof Error ? error.message : String(error);
+	}
+	let outcome = await waitExit(timeoutMs);
+	if (outcome.event) {
+		applyExitEvent(receipt, outcome.event);
+		return receipt;
+	}
+	receipt.timeout = true;
+	receipt.escalated = true;
+	Object.assign(receipt, sendSigkillTree({ pid: receipt.pid, term, platform, killProcess }));
+	outcome = await waitExit(timeoutMs);
+	if (outcome.event) {
+		applyExitEvent(receipt, outcome.event);
+		return receipt;
+	}
+	const error = new Error(`PTY exit not confirmed after SIGKILL (pid=${receipt.pid})`);
+	error.receipt = receipt;
+	throw error;
+}
+
+export function applyPostExitCleanup(receipt, hooks) {
+	receipt.cleanupSequence = [];
+	if (receipt.ptyExited) {
+		receipt.cleanupSequence.push("ptyExited");
+		hooks.removeSandbox();
+		receipt.sandboxRemoved = !hooks.sandboxExists();
+		if (receipt.sandboxRemoved) receipt.cleanupSequence.push("sandboxRemoved");
+	} else {
+		receipt.sandboxRemoved = false;
+	}
+	try {
+		receipt.authUnchanged = hooks.assertAuth();
+		if (receipt.ptyExited && receipt.authUnchanged) receipt.cleanupSequence.push("authUnchanged");
+	} catch (error) {
+		receipt.authUnchanged = false;
+		receipt.authError = error instanceof Error ? error.message : String(error);
+	}
+	receipt.summary =
+		receipt.ptyExited && receipt.sandboxRemoved ? "PTY exited and sandbox removed" : "cleanup incomplete";
+	return receipt;
+}

--- a/.agents/skills/senpi-qa/scripts/tui-resume.mjs
+++ b/.agents/skills/senpi-qa/scripts/tui-resume.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Isolated real-PTY /resume scenario.
+ *
+ * Usage:
+ *   node .agents/skills/senpi-qa/scripts/tui-resume.mjs --messages 5000 --select latest --evidence resume-performance
+ */
+import { existsSync, realpathSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	guardRealAuth,
+	makeSandbox,
+	repoRoot,
+} from "./lib/common.mjs";
+import { hermeticEnv } from "./lib/mock-loop-support.mjs";
+import { parseArgs, resolveResumeEvidence, SESSION_ID, usage, writeSession } from "./lib/tui-resume-args.mjs";
+import { driveResume, spawnResumeTui } from "./lib/tui-resume-pty.mjs";
+import { applyPostExitCleanup, teardownPty } from "./lib/tui-resume-teardown.mjs";
+import { createResumeCleanupController } from "./lib/tui-resume-signal.mjs";
+import { captureGridEvidence, isPng, writeResumeArtifacts } from "./lib/tui-resume-evidence.mjs";
+
+async function main() {
+	const argv = process.argv.slice(2);
+	if (argv.length === 0) {
+		usage();
+		process.exit(2);
+	}
+	const options = parseArgs(argv);
+	const root = repoRoot();
+	const evidence = resolveResumeEvidence(root, options.evidence);
+	const guard = guardRealAuth();
+	const box = makeSandbox("tui-resume");
+	let term;
+	let stream;
+	let ptyReceipt;
+	const cleanupController = createResumeCleanupController({
+		teardown: teardownPty,
+		postExitCleanup: (receipt) =>
+			applyPostExitCleanup(receipt, {
+				removeSandbox: () => box.cleanup(),
+				sandboxExists: () => existsSync(box.dir),
+				assertAuth: () => guard.assertUnchanged(),
+			}),
+		prePtyCleanup: () => {
+			box.cleanup();
+			guard.assertUnchanged();
+			return { ptyExited: false, sandboxRemoved: !existsSync(box.dir), authUnchanged: true };
+		},
+		exit: (code) => process.exit(code),
+	});
+	cleanupController.install();
+	const actions = [];
+	const cwd = realpathSync(box.cwd);
+	const sessionPath = join(box.sessionDir, `2027-01-15T00-00-01-000Z_${SESSION_ID}.jsonl`);
+	await writeSession(sessionPath, { sessionId: SESSION_ID, cwd, messageCount: options.messages });
+
+	const env = hermeticEnv({
+		...box.env,
+		PI_SKIP_VERSION_CHECK: "1",
+		TERM: "xterm-256color",
+		COLORTERM: "truecolor",
+	});
+	({ term, stream } = await spawnResumeTui({ root, cwd, env }));
+	cleanupController.registerPty(term, stream);
+	let timing;
+	let runError;
+	try {
+		timing = await driveResume(term, stream, { messages: options.messages, actions });
+	} catch (error) {
+		runError = error;
+	} finally {
+		ptyReceipt = await cleanupController.cleanup();
+		if (ptyReceipt.teardownError) runError ??= new Error(ptyReceipt.teardownError);
+		cleanupController.unregister();
+	}
+
+	const paths = writeResumeArtifacts(evidence, {
+		raw: stream.raw,
+		actions,
+		timing,
+		runError,
+		options,
+		sessionPath,
+	});
+
+	let gridAssert = { pass: false };
+	try {
+		gridAssert = captureGridEvidence(root, paths);
+	} catch (error) {
+		runError ??= error;
+	}
+
+	writeFileSync(join(evidence, "cleanup.json"), `${JSON.stringify(ptyReceipt, null, 2)}\n`);
+	process.stdout.write(`CLEANUP_RECEIPT ${JSON.stringify(ptyReceipt)}\n`);
+	process.stderr.write(`evidence: ${evidence}\n`);
+	if (timing) process.stdout.write(`TIMING ${JSON.stringify(timing)}\n`);
+
+	const gridPass = gridAssert.failed === 0 && gridAssert.total > 0;
+	process.stdout.write(`[${gridPass ? "PASS" : "FAIL"}] final grid contains final marker\n`);
+	if (runError) {
+		process.stderr.write(`${runError instanceof Error ? runError.stack : String(runError)}\n`);
+		process.exit(1);
+	}
+	if (!gridPass) process.exit(1);
+	const seq = ptyReceipt.cleanupSequence ?? [];
+	const ptyAt = seq.indexOf("ptyExited");
+	if (
+		!ptyReceipt.ptyExited ||
+		!ptyReceipt.sandboxRemoved ||
+		!ptyReceipt.authUnchanged ||
+		ptyAt < 0 ||
+		ptyAt >= seq.indexOf("sandboxRemoved") ||
+		ptyAt >= seq.indexOf("authUnchanged")
+	) {
+		process.stderr.write(`cleanup failed: ${JSON.stringify(ptyReceipt)}\n`);
+		process.exit(1);
+	}
+	if (!isPng(paths.pngPath)) {
+		process.stderr.write("terminal.png is not a valid PNG\n");
+		process.exit(1);
+	}
+	process.stdout.write(`[PASS] screenshot: ${paths.pngPath}\n`);
+	process.stdout.write(`[PASS] cleanup: ${ptyReceipt.summary}\n`);
+}
+
+main().catch((error) => {
+	process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+	process.exit(1);
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- `/resume` now reuses exact, byte-bounded streaming session summaries for unchanged files and paints the visible transcript tail before progressively warming older messages, avoiding repeat parse/render stalls without weakening picker metadata or full-text search.
 - Late Cursor `tool_execution_end` events now create a TUI tool card when none is pending, so a result is not rendered without a card (#1011).
 - Session title generation now uses the session model's summarization auth instead of remapped compaction auth, so an explicit compaction model no longer produces `unauthenticated` Cursor title calls (#980).
 - Cursor 0-token `resource_exhausted` retries the same model after remint/compact instead of falling back to another provider, and too-small overflow compact now drops to the last user turn.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## 2026-08-20 - Resume picker caches exact streaming summaries
+
+### What changed
+
+- `packages/coding-agent/src/core/session-manager.ts`: session listing now delegates picker-row discovery instead of parsing every JSONL record itself.
+- `packages/coding-agent/src/core/session-summary.ts`: streams each cold JSONL file once and preserves the exact prior row contract: first user text, latest name, maximum activity timestamp, parsed message count, parent/cwd, and full search text.
+- `packages/coding-agent/src/core/session-summary-cache.ts`: reuses summaries while canonical path, size, and mtime match.
+- `packages/coding-agent/src/core/session-summary-lru.ts`: caps retained summaries at 4,096 entries and 64 MiB of UTF-8 transcript text, evicting least-recently-used rows and refusing oversized entries without changing their returned result.
+- `packages/coding-agent/src/core/session-discovery.ts`: builds and sorts picker rows from the exact cached summaries with the existing bounded-concurrency loader.
+
+### Why
+
+- `/resume` previously reparsed every message in every unchanged session each time the selector opened. The cost scaled with aggregate session bytes and made repeated selector use visibly slower as histories grew.
+- Cold discovery still performs one exact streaming fold so picker metadata and full-text search do not regress. Reopening `/resume` validates one stat per file and reuses unchanged summaries; byte and entry budgets bound process-lifetime retention.
+
+### Why an extension could not handle it
+
+- Session directory enumeration and `SessionInfo` construction happen inside the core `SessionManager.list()` / `listAll()` path before extensions receive a session or selector hook.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/core/session-manager.ts` imports and the `list()` / `listAll()` delegation around session discovery.
+- LOW: the new `session-discovery.ts`, `session-summary*.ts`, and `session-record.ts` modules are fork-owned extraction points.
+
 ## 2026-08-20 - Session title uses session-model auth
 
 ### What changed

--- a/packages/coding-agent/src/core/session-discovery.ts
+++ b/packages/coding-agent/src/core/session-discovery.ts
@@ -1,0 +1,118 @@
+import { existsSync } from "fs";
+import { readdir } from "fs/promises";
+import { join } from "path";
+import type { SessionHeader, SessionInfo } from "./session-manager.ts";
+import { readCachedSessionSummary } from "./session-summary-cache.ts";
+
+export type SessionListProgress = (loaded: number, total: number) => void;
+
+const MAX_CONCURRENT_SESSION_INFO_LOADS = 10;
+
+function resolveModified(activityTime: number | undefined, header: SessionHeader, mtime: Date): Date {
+	if (typeof activityTime === "number" && activityTime > 0) return new Date(activityTime);
+	const headerTime = typeof header.timestamp === "string" ? Date.parse(header.timestamp) : Number.NaN;
+	return Number.isNaN(headerTime) ? mtime : new Date(headerTime);
+}
+
+/**
+ * Build one picker row from a session file's exact summary.
+ *
+ * The summary is derived from every record in the file, so a row's name, first
+ * message, message count, and activity time are exact regardless of where those
+ * records sit. Repeat listings of an unchanged file are served from the
+ * stat-keyed summary cache and deserialize nothing.
+ */
+export async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
+	const cached = await readCachedSessionSummary(filePath);
+	if (!cached) return null;
+
+	const { summary, mtime } = cached;
+	const header = summary.header;
+
+	return {
+		path: filePath,
+		id: header.id,
+		cwd: typeof header.cwd === "string" ? header.cwd : "",
+		name: summary.name,
+		parentSessionPath: header.parentSession,
+		created: new Date(header.timestamp),
+		modified: resolveModified(summary.lastActivityTime, header, mtime),
+		messageCount: summary.messageCount,
+		firstMessage: summary.firstUserMessage || "(no messages)",
+		allMessagesText: summary.allMessagesText,
+	};
+}
+
+async function buildSessionInfosWithConcurrency(
+	files: readonly string[],
+	onLoaded: () => void,
+): Promise<(SessionInfo | null)[]> {
+	const results: (SessionInfo | null)[] = new Array(files.length).fill(null);
+	const inFlight = new Set<Promise<void>>();
+	let nextIndex = 0;
+
+	const startNext = (): void => {
+		const index = nextIndex++;
+		const file = files[index];
+		if (!file) return;
+
+		let task: Promise<void>;
+		task = buildSessionInfo(file)
+			.then((info) => {
+				results[index] = info;
+			})
+			.catch(() => {
+				results[index] = null;
+			})
+			.finally(() => {
+				inFlight.delete(task);
+				onLoaded();
+			});
+		inFlight.add(task);
+	};
+
+	while (nextIndex < files.length || inFlight.size > 0) {
+		while (nextIndex < files.length && inFlight.size < MAX_CONCURRENT_SESSION_INFO_LOADS) {
+			startNext();
+		}
+		if (inFlight.size > 0) {
+			await Promise.race(inFlight);
+		}
+	}
+
+	return results;
+}
+
+/** Build picker rows for an explicit file list, dropping files that are not sessions. */
+export async function listSessionInfos(files: readonly string[], onLoaded: () => void): Promise<SessionInfo[]> {
+	const results = await buildSessionInfosWithConcurrency(files, onLoaded);
+	const sessions: SessionInfo[] = [];
+	for (const info of results) {
+		if (info) sessions.push(info);
+	}
+	return sessions;
+}
+
+/** Build picker rows for every `.jsonl` file in one session directory. */
+export async function listSessionsFromDir(
+	dir: string,
+	onProgress?: SessionListProgress,
+	progressOffset = 0,
+	progressTotal?: number,
+): Promise<SessionInfo[]> {
+	if (!existsSync(dir)) return [];
+
+	try {
+		const dirEntries = await readdir(dir);
+		const files = dirEntries.filter((name) => name.endsWith(".jsonl")).map((name) => join(dir, name));
+		const total = progressTotal ?? files.length;
+		let loaded = 0;
+		return await listSessionInfos(files, () => {
+			loaded++;
+			onProgress?.(progressOffset + loaded, total);
+		});
+	} catch {
+		// A directory that cannot be read contributes no picker rows.
+		return [];
+	}
+}

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -4,7 +4,6 @@ import { randomBytes, randomUUID } from "crypto";
 import {
 	appendFileSync,
 	closeSync,
-	createReadStream,
 	existsSync,
 	mkdirSync,
 	openSync,
@@ -13,13 +12,15 @@ import {
 	statSync,
 	writeFileSync,
 } from "fs";
-import { readdir, stat } from "fs/promises";
+import { readdir } from "fs/promises";
 import { join, resolve } from "path";
-import { createInterface } from "readline";
 import { StringDecoder } from "string_decoder";
 import { APP_NAME, getAgentDir as getDefaultAgentDir, getSessionsDir } from "../config.ts";
 import { normalizePath, resolvePath } from "../utils/paths.ts";
+import { listSessionInfos, listSessionsFromDir, type SessionListProgress } from "./session-discovery.ts";
 import { type ResidentStoreStats, ResidentStringStore } from "./session-resident-store.ts";
+
+export type { SessionListProgress } from "./session-discovery.ts";
 
 // Fork change: inlined UUIDv7 (upstream uses the `uuid` npm package). Keeps this
 // package self-contained so consumers don't need a transitive `uuid` install.
@@ -759,192 +760,6 @@ export function findMostRecentSession(sessionDir: string, cwd?: string): string 
 		// Directory access and stat races make recent-session discovery unavailable.
 		return null;
 	}
-}
-
-function isMessageWithContent(message: AgentMessage): message is Message {
-	return typeof (message as Message).role === "string" && "content" in message;
-}
-
-function extractTextContent(message: Message): string {
-	const content = message.content;
-	if (typeof content === "string") {
-		return content;
-	}
-	return content
-		.filter((block): block is TextContent => block.type === "text")
-		.map((block) => block.text)
-		.join(" ");
-}
-
-function getMessageActivityTime(entry: SessionMessageEntry): number | undefined {
-	const message = entry.message;
-	if (!isMessageWithContent(message)) return undefined;
-	if (message.role !== "user" && message.role !== "assistant") return undefined;
-
-	const msgTimestamp = (message as { timestamp?: number }).timestamp;
-	if (typeof msgTimestamp === "number") {
-		return msgTimestamp;
-	}
-
-	const t = new Date(entry.timestamp).getTime();
-	return Number.isNaN(t) ? undefined : t;
-}
-
-async function buildSessionInfo(filePath: string): Promise<SessionInfo | null> {
-	try {
-		const stats = await stat(filePath);
-		let header: SessionHeader | null = null;
-		let messageCount = 0;
-		let firstMessage = "";
-		const allMessages: string[] = [];
-		let name: string | undefined;
-		let lastActivityTime: number | undefined;
-
-		const rl = createInterface({
-			input: createReadStream(filePath, { encoding: "utf8" }),
-			crlfDelay: Infinity,
-		});
-
-		for await (const line of rl) {
-			const entry = parseSessionEntryLine(line);
-			if (!entry) continue;
-
-			if (!header) {
-				if (entry.type !== "session") return null;
-				header = entry;
-				continue;
-			}
-
-			// Extract session name (use latest, including explicit clears)
-			if (entry.type === "session_info") {
-				name = entry.name?.trim() || undefined;
-			}
-
-			if (entry.type !== "message") continue;
-			messageCount++;
-
-			const activityTime = getMessageActivityTime(entry);
-			if (typeof activityTime === "number") {
-				lastActivityTime = Math.max(lastActivityTime ?? 0, activityTime);
-			}
-
-			const message = entry.message;
-			if (!isMessageWithContent(message)) continue;
-			if (message.role !== "user" && message.role !== "assistant") continue;
-
-			const textContent = extractTextContent(message);
-			if (!textContent) continue;
-
-			allMessages.push(textContent);
-			if (!firstMessage && message.role === "user") {
-				firstMessage = textContent;
-			}
-		}
-
-		if (!header) return null;
-
-		const cwd = typeof header.cwd === "string" ? header.cwd : "";
-		const parentSessionPath = header.parentSession;
-		const headerTime = typeof header.timestamp === "string" ? new Date(header.timestamp).getTime() : NaN;
-		const modified =
-			typeof lastActivityTime === "number" && lastActivityTime > 0
-				? new Date(lastActivityTime)
-				: !Number.isNaN(headerTime)
-					? new Date(headerTime)
-					: stats.mtime;
-
-		return {
-			path: filePath,
-			id: header.id,
-			cwd,
-			name,
-			parentSessionPath,
-			created: new Date(header.timestamp),
-			modified,
-			messageCount,
-			firstMessage: firstMessage || "(no messages)",
-			allMessagesText: allMessages.join(" "),
-		};
-	} catch {
-		return null;
-	}
-}
-
-export type SessionListProgress = (loaded: number, total: number) => void;
-
-const MAX_CONCURRENT_SESSION_INFO_LOADS = 10;
-
-async function buildSessionInfosWithConcurrency(
-	files: string[],
-	onLoaded: () => void,
-): Promise<(SessionInfo | null)[]> {
-	const results: (SessionInfo | null)[] = new Array(files.length).fill(null);
-	const inFlight = new Set<Promise<void>>();
-	let nextIndex = 0;
-
-	const startNext = (): void => {
-		const index = nextIndex++;
-		const file = files[index];
-		if (!file) return;
-
-		let task: Promise<void>;
-		task = buildSessionInfo(file)
-			.then((info) => {
-				results[index] = info;
-			})
-			.catch(() => {
-				results[index] = null;
-			})
-			.finally(() => {
-				inFlight.delete(task);
-				onLoaded();
-			});
-		inFlight.add(task);
-	};
-
-	while (nextIndex < files.length || inFlight.size > 0) {
-		while (nextIndex < files.length && inFlight.size < MAX_CONCURRENT_SESSION_INFO_LOADS) {
-			startNext();
-		}
-		if (inFlight.size > 0) {
-			await Promise.race(inFlight);
-		}
-	}
-
-	return results;
-}
-
-async function listSessionsFromDir(
-	dir: string,
-	onProgress?: SessionListProgress,
-	progressOffset = 0,
-	progressTotal?: number,
-): Promise<SessionInfo[]> {
-	const sessions: SessionInfo[] = [];
-	if (!existsSync(dir)) {
-		return sessions;
-	}
-
-	try {
-		const dirEntries = await readdir(dir);
-		const files = dirEntries.filter((f) => f.endsWith(".jsonl")).map((f) => join(dir, f));
-		const total = progressTotal ?? files.length;
-
-		let loaded = 0;
-		const results = await buildSessionInfosWithConcurrency(files, () => {
-			loaded++;
-			onProgress?.(progressOffset + loaded, total);
-		});
-		for (const info of results) {
-			if (info) {
-				sessions.push(info);
-			}
-		}
-	} catch {
-		// Return empty list on error
-	}
-
-	return sessions;
 }
 
 /**
@@ -1989,19 +1804,10 @@ export class SessionManager {
 
 			// Process all files with progress tracking
 			let loaded = 0;
-			const sessions: SessionInfo[] = [];
-			const allFiles = dirFiles.flat();
-
-			const results = await buildSessionInfosWithConcurrency(allFiles, () => {
+			const sessions = await listSessionInfos(dirFiles.flat(), () => {
 				loaded++;
 				progress?.(loaded, totalFiles);
 			});
-
-			for (const info of results) {
-				if (info) {
-					sessions.push(info);
-				}
-			}
 
 			sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime());
 			return sessions;

--- a/packages/coding-agent/src/core/session-record.ts
+++ b/packages/coding-agent/src/core/session-record.ts
@@ -1,0 +1,55 @@
+import type { Message, TextContent } from "@earendil-works/pi-ai";
+import type { FileEntry } from "./session-manager.ts";
+
+/** A user/assistant message's visible text and activity time. */
+export type VisibleMessage = {
+	readonly text: string;
+	readonly role: "user" | "assistant";
+	readonly time: number | undefined;
+};
+
+/** Deserialize one JSONL line. Malformed lines are skipped, matching full-file session loading. */
+export function parseEntryLine(line: string): FileEntry | null {
+	if (!line.trim()) return null;
+	try {
+		return JSON.parse(line) as FileEntry;
+	} catch {
+		return null;
+	}
+}
+
+function isMessageWithContent(message: unknown): message is Message {
+	return (
+		typeof message === "object" &&
+		message !== null &&
+		typeof (message as { role?: unknown }).role === "string" &&
+		"content" in message
+	);
+}
+
+function extractTextContent(message: Message): string {
+	const content = message.content;
+	if (typeof content === "string") return content;
+	return content
+		.filter((block): block is TextContent => block.type === "text")
+		.map((block) => block.text)
+		.join(" ");
+}
+
+/** The record's visible message, or null when it is not a user/assistant message. */
+export function visibleMessage(entry: FileEntry): VisibleMessage | null {
+	if (entry.type !== "message") return null;
+	const message = entry.message;
+	if (!isMessageWithContent(message)) return null;
+	if (message.role !== "user" && message.role !== "assistant") return null;
+	const messageTime = (message as { timestamp?: number }).timestamp;
+	const entryTime = Date.parse(entry.timestamp);
+	const time = typeof messageTime === "number" ? messageTime : Number.isNaN(entryTime) ? undefined : entryTime;
+	return { text: extractTextContent(message), role: message.role, time };
+}
+
+/** The record's display name, or null when the record is not a session_info entry. */
+export function sessionInfoName(entry: FileEntry): string | undefined | null {
+	if (entry.type !== "session_info") return null;
+	return entry.name?.trim() || undefined;
+}

--- a/packages/coding-agent/src/core/session-summary-cache.ts
+++ b/packages/coding-agent/src/core/session-summary-cache.ts
@@ -1,0 +1,93 @@
+import { stat } from "fs/promises";
+import { resolve } from "path";
+import { readSessionSummary, type SessionSummary } from "./session-summary.ts";
+import { type FileStamp, SessionSummaryLru } from "./session-summary-lru.ts";
+
+/**
+ * Upper bound on cached session files, evicted least-recently-used rather than
+ * grown with the sessions directory.
+ */
+export const SESSION_SUMMARY_CACHE_LIMIT = 4096;
+
+/**
+ * Upper bound on retained transcript text across the whole cache.
+ *
+ * A cached summary's footprint is its `allMessagesText`, which grows with the
+ * session, so the entry ceiling alone bounds nothing: 4096 large sessions would
+ * pin gigabytes for the life of the process. 64 MiB is deliberately conservative
+ * — it holds a normal user's entire sessions directory (a heavy 2 MB session
+ * file yields well under 2 MB of visible text, so hundreds of them fit) while
+ * capping the worst case at a fraction of a Node heap. Exceeding it evicts the
+ * least recently listed sessions, which then cost one streaming re-read.
+ */
+export const SESSION_SUMMARY_CACHE_MAX_TEXT_BYTES = 64 * 1024 * 1024;
+
+export type CachedSessionSummary = {
+	readonly summary: SessionSummary;
+	readonly mtime: Date;
+};
+
+/** Process-local summary cache, bounded by entry count and retained text bytes. */
+const cache = new SessionSummaryLru({
+	maxEntries: SESSION_SUMMARY_CACHE_LIMIT,
+	maxTextBytes: SESSION_SUMMARY_CACHE_MAX_TEXT_BYTES,
+});
+
+function stampsMatch(left: FileStamp, right: FileStamp): boolean {
+	return left.size === right.size && left.mtimeMs === right.mtimeMs;
+}
+
+/**
+ * Exact summary of one session file, reusing the cached summary when the file's
+ * size and mtime are unchanged since it was read.
+ *
+ * A cache hit deserializes nothing: the whole point is that listing an unchanged
+ * sessions directory costs one `stat` per file. A file that cannot be stat'ed or
+ * read drops its cache entry, so a truncated or replaced file is never served
+ * from stale bytes. A summary too large for the cache's byte budget is returned
+ * to the caller without being retained.
+ */
+export async function readCachedSessionSummary(filePath: string): Promise<CachedSessionSummary | null> {
+	const key = resolve(filePath);
+
+	let stamp: FileStamp;
+	let mtime: Date;
+	try {
+		const stats = await stat(filePath);
+		stamp = { size: stats.size, mtimeMs: stats.mtimeMs };
+		mtime = stats.mtime;
+	} catch (error) {
+		if (!(error instanceof Error)) throw error;
+		cache.drop(key);
+		return null;
+	}
+
+	const cached = cache.get(key);
+	if (cached && stampsMatch(cached.stamp, stamp)) {
+		return { summary: cached.summary, mtime: cached.mtime };
+	}
+
+	const summary = await readSessionSummary(filePath);
+	if (!summary) {
+		cache.drop(key);
+		return null;
+	}
+
+	cache.retain(key, { stamp, summary, mtime });
+	return { summary, mtime };
+}
+
+/** Drop every cached summary. Test-only seam for cold-read assertions. */
+export function clearSessionSummaryCache(): void {
+	cache.clear();
+}
+
+/** Number of cached summaries. Test-only seam for eviction assertions. */
+export function sessionSummaryCacheSize(): number {
+	return cache.size;
+}
+
+/** Retained transcript bytes across the cache. Test-only seam for budget assertions. */
+export function sessionSummaryCacheTextBytes(): number {
+	return cache.textBytes;
+}

--- a/packages/coding-agent/src/core/session-summary-lru.ts
+++ b/packages/coding-agent/src/core/session-summary-lru.ts
@@ -1,0 +1,103 @@
+import type { SessionSummary } from "./session-summary.ts";
+
+/** Identity of the exact bytes a cached summary was derived from. */
+export type FileStamp = {
+	readonly size: number;
+	readonly mtimeMs: number;
+};
+
+/** One cached session summary plus the file identity it was derived from. */
+export type SummaryEntry = {
+	readonly stamp: FileStamp;
+	readonly summary: SessionSummary;
+	/** The file's mtime at read time, used for the row's fallback modified date. */
+	readonly mtime: Date;
+};
+
+/** Both ceilings a retained set of summaries has to stay under. */
+export type SummaryCacheBudget = {
+	readonly maxEntries: number;
+	readonly maxTextBytes: number;
+};
+
+type RetainedEntry = {
+	readonly entry: SummaryEntry;
+	readonly textBytes: number;
+};
+
+/**
+ * Least-recently-used store of session summaries bounded by BOTH entry count and
+ * retained transcript bytes.
+ *
+ * An entry ceiling alone does not bound memory: a summary's footprint is
+ * dominated by `allMessagesText`, which grows with the transcript, so the same
+ * 4096 entries can hold kilobytes or gigabytes depending on whose sessions they
+ * are. `Map` preserves insertion order, so re-inserting on every hit makes the
+ * first key the least recently used one.
+ */
+export class SessionSummaryLru {
+	private readonly entries = new Map<string, RetainedEntry>();
+	private readonly budget: SummaryCacheBudget;
+	private retainedTextBytes = 0;
+
+	constructor(budget: SummaryCacheBudget) {
+		this.budget = budget;
+	}
+
+	get size(): number {
+		return this.entries.size;
+	}
+
+	/** Retained transcript bytes across every cached summary. */
+	get textBytes(): number {
+		return this.retainedTextBytes;
+	}
+
+	/** The cached entry for this key, promoted to most-recently-used. */
+	get(key: string): SummaryEntry | undefined {
+		const retained = this.entries.get(key);
+		if (!retained) return undefined;
+		this.entries.delete(key);
+		this.entries.set(key, retained);
+		return retained.entry;
+	}
+
+	drop(key: string): void {
+		const retained = this.entries.get(key);
+		if (!retained) return;
+		this.entries.delete(key);
+		this.retainedTextBytes -= retained.textBytes;
+	}
+
+	/**
+	 * Retain one summary, evicting least-recently-used entries until both ceilings
+	 * hold.
+	 *
+	 * A summary whose own transcript exceeds the byte budget is never retained:
+	 * caching it could only be paid for by evicting every other entry, and it
+	 * would still have to be evicted on the next insert. The caller keeps the
+	 * summary it asked for either way. Any previous entry under this key is
+	 * dropped first, so an oversized re-read can never leave stale bytes behind.
+	 */
+	retain(key: string, entry: SummaryEntry): void {
+		this.drop(key);
+		const textBytes = Buffer.byteLength(entry.summary.allMessagesText, "utf8");
+		if (textBytes > this.budget.maxTextBytes) return;
+		this.entries.set(key, { entry, textBytes });
+		this.retainedTextBytes += textBytes;
+		this.evictUntilWithinBudget();
+	}
+
+	clear(): void {
+		this.entries.clear();
+		this.retainedTextBytes = 0;
+	}
+
+	private evictUntilWithinBudget(): void {
+		while (this.entries.size > this.budget.maxEntries || this.retainedTextBytes > this.budget.maxTextBytes) {
+			const oldest = this.entries.keys().next();
+			if (oldest.done) break;
+			this.drop(oldest.value);
+		}
+	}
+}

--- a/packages/coding-agent/src/core/session-summary.ts
+++ b/packages/coding-agent/src/core/session-summary.ts
@@ -1,0 +1,119 @@
+import { createReadStream } from "fs";
+import { createInterface } from "readline";
+import type { SessionHeader } from "./session-manager.ts";
+import { parseEntryLine, sessionInfoName, visibleMessage } from "./session-record.ts";
+
+/**
+ * Everything a picker row needs from one session file, derived from every record
+ * in the file. Exact by construction: no window, no marker heuristic, so a first
+ * user message, a rename, or an out-of-order activity timestamp is found no
+ * matter how deep in the transcript it sits.
+ */
+export type SessionSummary = {
+	readonly header: SessionHeader;
+	/** Latest `session_info` name anywhere in the file, including explicit clears. */
+	readonly name: string | undefined;
+	/** First visible user message text anywhere in the file. */
+	readonly firstUserMessage: string;
+	/** Count of records that parsed as `type: "message"`. */
+	readonly messageCount: number;
+	/** Max user/assistant activity time seen, regardless of record order. */
+	readonly lastActivityTime: number | undefined;
+	/** Full user/assistant transcript text in file order. */
+	readonly allMessagesText: string;
+};
+
+type SummaryAccumulator = {
+	header: SessionHeader | null;
+	name: string | undefined;
+	firstUserMessage: string;
+	messageCount: number;
+	lastActivityTime: number | undefined;
+	readonly texts: string[];
+};
+
+function newAccumulator(): SummaryAccumulator {
+	return {
+		header: null,
+		name: undefined,
+		firstUserMessage: "",
+		messageCount: 0,
+		lastActivityTime: undefined,
+		texts: [],
+	};
+}
+
+/**
+ * Fold one JSONL line into the accumulator.
+ *
+ * Returns false when the file's first parsable record is not a session header,
+ * which means the file is not a session and the caller stops reading.
+ */
+function accumulateLine(accumulator: SummaryAccumulator, line: string): boolean {
+	const entry = parseEntryLine(line);
+	if (!entry) return true;
+
+	if (!accumulator.header) {
+		if (entry.type !== "session" || typeof entry.id !== "string") return false;
+		accumulator.header = entry;
+		return true;
+	}
+
+	const infoName = sessionInfoName(entry);
+	if (infoName !== null) {
+		accumulator.name = infoName;
+		return true;
+	}
+
+	if (entry.type !== "message") return true;
+	accumulator.messageCount++;
+
+	const visible = visibleMessage(entry);
+	if (!visible) return true;
+	if (typeof visible.time === "number") {
+		accumulator.lastActivityTime = Math.max(accumulator.lastActivityTime ?? 0, visible.time);
+	}
+	if (!visible.text) return true;
+	accumulator.texts.push(visible.text);
+	if (!accumulator.firstUserMessage && visible.role === "user") {
+		accumulator.firstUserMessage = visible.text;
+	}
+	return true;
+}
+
+/**
+ * Stream one session file line by line and fold it into an exact summary.
+ *
+ * Memory stays bounded by readline's buffer plus the transcript text the summary
+ * contract requires; no full-file string is ever materialized. A file whose
+ * first record is not a session header, or that cannot be read, yields null.
+ */
+export async function readSessionSummary(filePath: string): Promise<SessionSummary | null> {
+	const accumulator = newAccumulator();
+	const stream = createReadStream(filePath, { encoding: "utf8" });
+	const lines = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
+
+	try {
+		for await (const line of lines) {
+			if (!accumulateLine(accumulator, line)) return null;
+		}
+	} catch (error) {
+		if (error instanceof Error) return null;
+		throw error;
+	} finally {
+		lines.close();
+		stream.destroy();
+	}
+
+	const header = accumulator.header;
+	if (!header) return null;
+
+	return {
+		header,
+		name: accumulator.name,
+		firstUserMessage: accumulator.firstUserMessage,
+		messageCount: accumulator.messageCount,
+		lastActivityTime: accumulator.lastActivityTime,
+		allMessagesText: accumulator.texts.join(" "),
+	};
+}

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## 2026-08-20 - Resumed transcripts paint the visible tail first
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: the chat transcript now uses `ProgressiveTranscriptContainer`.
+- `packages/coding-agent/src/modes/interactive/components/progressive-transcript-container.ts`: the first frame renders a bounded tail of real message/tool components, then warms earlier components in bounded macrotask chunks and requests one exact full-history repaint.
+
+### Why
+
+- Resuming a large session eagerly Markdown-rendered every persisted component before the first useful frame. Thousands of off-screen messages could block the TUI for hundreds of milliseconds even though the user initially sees only the transcript tail.
+- Progressive hydration preserves the exact full output and component styling while moving off-screen cache warming out of the input-critical path.
+
+### Why an extension could not handle it
+
+- Initial transcript component construction, chat-container ownership, clearing, disposal, and renderer invalidation are private `InteractiveMode` lifecycle state; extensions cannot replace the built-in transcript container.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/modes/interactive/interactive-mode.ts` chat-container import and constructor.
+- LOW: the new progressive transcript container is a fork-owned component.
+
 ## 2026-08-20 - Late tool_execution_end still draws a TUI card
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/progressive-transcript-container.ts
+++ b/packages/coding-agent/src/modes/interactive/components/progressive-transcript-container.ts
@@ -1,0 +1,185 @@
+import { Container } from "@earendil-works/pi-tui";
+
+/**
+ * Tunables for progressive transcript hydration.
+ *
+ * `tailBudget` is the number of trailing children painted on the first frame:
+ * enough to fill the visible viewport, never the whole persisted history.
+ * `warmChunkSize` bounds how many earlier children are rendered per macrotask
+ * so hydration never blocks input handling.
+ */
+export type ProgressiveTranscriptOptions = {
+	readonly tailBudget: number;
+	readonly warmChunkSize: number;
+	readonly requestRender: () => void;
+};
+
+/** Trailing children painted on the first frame; roughly two tall viewports of messages. */
+export const DEFAULT_TAIL_BUDGET = 60 as const;
+
+/** Earlier children warmed per macrotask during background hydration. */
+export const DEFAULT_WARM_CHUNK_SIZE = 100 as const;
+
+/** Watermark sentinel: no frame has been painted yet, so nothing is proven renderable. */
+const PENDING_FIRST_PAINT = -1 as const;
+
+/**
+ * A transcript container that paints a bounded, fully-styled tail on its first
+ * frame and warms the earlier history in bounded `setImmediate` chunks.
+ *
+ * Resuming a long session used to Markdown-render every persisted message
+ * before the first paint, so `/resume` blocked for hundreds of milliseconds on
+ * work the user could not see. Children are still the real message and tool
+ * components and are still rendered by their own `render(width)`, so the
+ * visible tail is pixel-identical to the eager path; only the render *order*
+ * changes. Once hydration completes the container behaves exactly like its
+ * `Container` base, which keeps scrolling, history, and full-transcript output
+ * unchanged.
+ */
+export class ProgressiveTranscriptContainer extends Container {
+	private readonly tailBudget: number;
+	private readonly warmChunkSize: number;
+	private readonly requestRender: () => void;
+
+	/**
+	 * Index of the first child proven renderable, or `PENDING_FIRST_PAINT` before
+	 * any frame has been painted. Walks down to 0 as hydration warms the history.
+	 * A distinct sentinel is required because 0 legitimately means "fully
+	 * hydrated", which is also the state of a freshly cleared transcript.
+	 */
+	private hydratedFrom: number = PENDING_FIRST_PAINT;
+	private hydrationScheduled = false;
+	private hydrationGeneration = 0;
+	/**
+	 * Deliberately NOT named `disposed`: `Container` keeps a private `disposed`
+	 * own-property guard, and a same-named subclass field lands in the same slot,
+	 * so setting it before `super.dispose()` would make the base early-return and
+	 * silently skip disposing every child.
+	 */
+	private hydrationHalted = false;
+
+	/** Width of the last painted frame, reused to warm the head at the real render width. */
+	private lastRenderWidth: number | undefined;
+
+	constructor(options: ProgressiveTranscriptOptions) {
+		super();
+		this.tailBudget = options.tailBudget;
+		this.warmChunkSize = options.warmChunkSize;
+		this.requestRender = options.requestRender;
+	}
+
+	/** True when every child has been rendered at least once and no work is pending. */
+	get isFullyHydrated(): boolean {
+		return this.hydratedFrom === 0 && !this.hydrationScheduled;
+	}
+
+	override render(width: number): string[] {
+		this.lastRenderWidth = width;
+		const total = this.children.length;
+		if (this.hydratedFrom === 0 || total === 0) {
+			this.hydratedFrom = 0;
+			return super.render(width);
+		}
+
+		const firstVisible = Math.max(0, total - this.tailBudget);
+		if (firstVisible === 0) {
+			// Whole transcript fits the visible budget: nothing is worth deferring.
+			this.hydratedFrom = 0;
+			return super.render(width);
+		}
+
+		// Never move the watermark forward: a child warmed by an earlier chunk must
+		// stay warm even when later frames only need the tail.
+		this.hydratedFrom =
+			this.hydratedFrom === PENDING_FIRST_PAINT ? firstVisible : Math.min(this.hydratedFrom, firstVisible);
+		this.scheduleHydration();
+		return this.renderRange(this.hydratedFrom, total, width);
+	}
+
+	// `addChild` is inherited: a live message appended before hydration finishes
+	// sits past the watermark, so it paints on the very next frame.
+
+	override clear(): void {
+		this.cancelHydration();
+		this.hydratedFrom = PENDING_FIRST_PAINT;
+		super.clear();
+	}
+
+	override detachAll(): void {
+		this.cancelHydration();
+		this.hydratedFrom = PENDING_FIRST_PAINT;
+		super.detachAll();
+	}
+
+	override dispose(): void {
+		this.hydrationHalted = true;
+		this.cancelHydration();
+		super.dispose();
+	}
+
+	// `invalidate` is inherited: `Container.invalidate` already walks every child,
+	// so a theme switch reaches the un-warmed head and it cannot warm with a stale palette.
+
+	private renderRange(from: number, to: number, width: number): string[] {
+		const lines: string[] = [];
+		for (let index = from; index < to; index++) {
+			const child = this.children[index];
+			if (child === undefined) continue;
+			let childLines: string[];
+			try {
+				childLines = child.render(width);
+			} catch {
+				const componentName = child.constructor.name || "AnonymousComponent";
+				childLines = [`[render error: ${componentName}]`];
+			}
+			for (const line of childLines) {
+				lines.push(line);
+			}
+		}
+		return lines;
+	}
+
+	private scheduleHydration(): void {
+		if (this.hydrationScheduled || this.hydrationHalted) return;
+		this.hydrationScheduled = true;
+		const generation = this.hydrationGeneration;
+		setImmediate(() => {
+			this.hydrationScheduled = false;
+			this.warmNextChunk(generation);
+		});
+	}
+
+	/**
+	 * Warm one bounded chunk of the deferred head. Each child is actually rendered
+	 * here so its own line cache is populated off the critical path; the eventual
+	 * full-history frame then pays for cache hits instead of one burst of Markdown
+	 * work. Without this the deferred cost would merely be moved, not spread.
+	 */
+	private warmNextChunk(generation: number): void {
+		if (this.hydrationHalted || generation !== this.hydrationGeneration) return;
+		if (this.hydratedFrom === 0) return;
+
+		const chunkEnd = this.hydratedFrom;
+		const chunkStart = Math.max(0, chunkEnd - this.warmChunkSize);
+		const width = this.lastRenderWidth;
+		if (width !== undefined) {
+			// Discard the lines: this pass exists only to fill each child's cache.
+			this.renderRange(chunkStart, chunkEnd, width);
+		}
+		this.hydratedFrom = chunkStart;
+
+		if (chunkStart === 0) {
+			// The whole transcript is renderable now; ask the TUI to repaint it.
+			this.requestRender();
+			return;
+		}
+		this.scheduleHydration();
+	}
+
+	private cancelHydration(): void {
+		// Bumping the generation makes any already-queued macrotask a no-op, so a
+		// clear + rebuild cannot warm components that no longer belong to the tree.
+		this.hydrationGeneration += 1;
+		this.hydrationScheduled = false;
+	}
+}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -168,6 +168,11 @@ import {
 	formatAuthSelectorProviderType,
 	OAuthSelectorComponent,
 } from "./components/oauth-selector.ts";
+import {
+	DEFAULT_TAIL_BUDGET,
+	DEFAULT_WARM_CHUNK_SIZE,
+	ProgressiveTranscriptContainer,
+} from "./components/progressive-transcript-container.ts";
 import { ScopedModelsSelectorComponent } from "./components/scoped-models-selector.ts";
 import { SessionSelectorComponent } from "./components/session-selector.ts";
 import { SettingsSelectorComponent } from "./components/settings-selector.ts";
@@ -905,7 +910,14 @@ export class InteractiveMode {
 		this.ui.setClearOnShrink(this.settingsManager.getClearOnShrink());
 		this.headerContainer = new Container();
 		this.loadedResourcesContainer = new Container();
-		this.chatContainer = new Container();
+		// Resuming a long session paints a bounded, fully-styled tail first and warms
+		// the earlier history in background chunks, so /resume is not blocked on
+		// Markdown-rendering every persisted message before the first frame.
+		this.chatContainer = new ProgressiveTranscriptContainer({
+			tailBudget: DEFAULT_TAIL_BUDGET,
+			warmChunkSize: DEFAULT_WARM_CHUNK_SIZE,
+			requestRender: () => this.ui.requestRender(),
+		});
 		this.documentContainer = new Container();
 		this.documentContainer.addChild(this.headerContainer);
 		this.documentContainer.addChild(this.loadedResourcesContainer);

--- a/packages/coding-agent/test/benchmarks/resume-flow-args.ts
+++ b/packages/coding-agent/test/benchmarks/resume-flow-args.ts
@@ -1,0 +1,55 @@
+import { resolve } from "node:path";
+import { readIterations } from "../../../tui/bench/_meta.ts";
+
+export type ResumeBenchArgs = {
+	readonly messages: number;
+	readonly iterations: number;
+	readonly jsonPath: string | undefined;
+};
+
+function parsePositiveInt(raw: string | undefined, flag: string): number {
+	const parsed = raw === undefined ? Number.NaN : Number(raw);
+	if (!Number.isFinite(parsed) || parsed < 1) {
+		throw new Error(`Invalid ${flag}: ${raw ?? "(missing)"}`);
+	}
+	return Math.floor(parsed);
+}
+
+export function parseResumeBenchArgs(argv: readonly string[]): ResumeBenchArgs {
+	let messages = 5000;
+	let jsonPath: string | undefined;
+
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		if (arg === "--help" || arg === "-h") {
+			throw new Error(
+				"Usage: node packages/coding-agent/test/benchmarks/resume-flow.bench.mjs --messages <n> --iterations <n> [--json <path>]",
+			);
+		}
+		if (arg === "--iterations") {
+			index++;
+			continue;
+		}
+		if (arg === "--messages") {
+			messages = parsePositiveInt(argv[index + 1], "--messages");
+			index++;
+			continue;
+		}
+		if (arg === "--json") {
+			const rawPath = argv[index + 1];
+			if (!rawPath) {
+				throw new Error("Missing value for --json");
+			}
+			jsonPath = resolve(process.cwd(), rawPath);
+			index++;
+			continue;
+		}
+		throw new Error(`Unknown argument: ${arg}`);
+	}
+
+	return {
+		messages,
+		iterations: readIterations(15),
+		jsonPath,
+	};
+}

--- a/packages/coding-agent/test/benchmarks/resume-flow-fixture.ts
+++ b/packages/coding-agent/test/benchmarks/resume-flow-fixture.ts
@@ -1,0 +1,163 @@
+import { once } from "node:events";
+import { createWriteStream, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { finished } from "node:stream/promises";
+
+export const SELECTED_SESSION_ID = "resume-bench-selected";
+export const DECOY_SESSION_COUNT = 8;
+export const DECOY_MESSAGE_COUNT = 12;
+export const SESSION_TIMESTAMP_BASE = 1_800_000_000_000;
+
+export type ResumeBenchFixture = {
+	readonly rootDir: string;
+	readonly cwd: string;
+	readonly sessionDir: string;
+	readonly selectedPath: string;
+	readonly selectedId: string;
+	readonly fixtureBytes: number;
+	readonly decoySessionCount: number;
+};
+
+type SessionFileSpec = {
+	readonly path: string;
+	readonly sessionId: string;
+	readonly cwd: string;
+	readonly messageCount: number;
+};
+
+function usage() {
+	return {
+		input: 10,
+		output: 5,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 15,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function userText(index: number, sessionId: string): string {
+	return `user ${sessionId} turn ${index} resume-load-probe`;
+}
+
+function assistantText(index: number, sessionId: string): string {
+	return [
+		`### Result ${index}`,
+		"",
+		`assistant ${sessionId} turn ${index} with **bold** and a list:`,
+		"",
+		`- item ${index}`,
+		`- item ${index + 1}`,
+		"",
+		"```ts",
+		`const value = ${index};`,
+		"console.log(value);",
+		"```",
+	].join("\n");
+}
+
+function entryId(index: number): string {
+	return `e${String(index).padStart(6, "0")}`;
+}
+
+function sessionEntryLine(spec: SessionFileSpec, index: number, parentId: string | null): string {
+	const id = entryId(index);
+	const timestamp = new Date(SESSION_TIMESTAMP_BASE + index).toISOString();
+	if (index % 2 === 0) {
+		return `${JSON.stringify({
+			type: "message",
+			id,
+			parentId,
+			timestamp,
+			message: {
+				role: "user",
+				content: [{ type: "text", text: userText(index, spec.sessionId) }],
+				timestamp: SESSION_TIMESTAMP_BASE + index,
+			},
+		})}\n`;
+	}
+	return `${JSON.stringify({
+		type: "message",
+		id,
+		parentId,
+		timestamp,
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: assistantText(index, spec.sessionId) }],
+			api: "openai-responses",
+			provider: "openai",
+			model: "test-model",
+			usage: usage(),
+			stopReason: "stop",
+			timestamp: SESSION_TIMESTAMP_BASE + index,
+		},
+	})}\n`;
+}
+
+async function writeLine(stream: ReturnType<typeof createWriteStream>, line: string): Promise<void> {
+	if (!stream.write(line)) {
+		await once(stream, "drain");
+	}
+}
+
+async function writeSessionJsonl(spec: SessionFileSpec): Promise<void> {
+	const stream = createWriteStream(spec.path);
+	const header = {
+		type: "session",
+		version: 3,
+		id: spec.sessionId,
+		timestamp: new Date(SESSION_TIMESTAMP_BASE).toISOString(),
+		cwd: spec.cwd,
+	};
+	await writeLine(stream, `${JSON.stringify(header)}\n`);
+	let parentId: string | null = null;
+	for (let index = 0; index < spec.messageCount; index++) {
+		await writeLine(stream, sessionEntryLine(spec, index, parentId));
+		parentId = entryId(index);
+	}
+	stream.end();
+	await finished(stream);
+}
+
+export async function createResumeBenchFixture(messageCount: number): Promise<ResumeBenchFixture> {
+	const rootDir = mkdtempSync(join(tmpdir(), "senpi-resume-bench-"));
+	const cwd = join(rootDir, "project");
+	const sessionDir = join(rootDir, "sessions");
+	mkdirSync(cwd, { recursive: true });
+	mkdirSync(sessionDir, { recursive: true });
+	const resolvedCwd = realpathSync(cwd);
+
+	for (let decoy = 0; decoy < DECOY_SESSION_COUNT; decoy++) {
+		const sessionId = `resume-bench-decoy-${String(decoy).padStart(2, "0")}`;
+		await writeSessionJsonl({
+			path: join(sessionDir, `2026-01-01T00-00-00-${String(decoy).padStart(3, "0")}Z_${sessionId}.jsonl`),
+			sessionId,
+			cwd: resolvedCwd,
+			messageCount: DECOY_MESSAGE_COUNT,
+		});
+	}
+
+	const selectedPath = join(sessionDir, `2026-01-01T00-00-01-000Z_${SELECTED_SESSION_ID}.jsonl`);
+	await writeSessionJsonl({
+		path: selectedPath,
+		sessionId: SELECTED_SESSION_ID,
+		cwd: resolvedCwd,
+		messageCount,
+	});
+	const fixtureBytes = statSync(selectedPath).size;
+
+	return {
+		rootDir,
+		cwd: resolvedCwd,
+		sessionDir,
+		selectedPath,
+		selectedId: SELECTED_SESSION_ID,
+		fixtureBytes,
+		decoySessionCount: DECOY_SESSION_COUNT,
+	};
+}
+
+export function removeResumeBenchFixture(fixture: ResumeBenchFixture): void {
+	rmSync(fixture.rootDir, { recursive: true, force: true });
+}

--- a/packages/coding-agent/test/benchmarks/resume-flow-harness.ts
+++ b/packages/coding-agent/test/benchmarks/resume-flow-harness.ts
@@ -1,0 +1,188 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { forceGc, metadata, percentile } from "../../../tui/bench/_meta.ts";
+import { SessionManager, sessionEntryToContextMessages } from "../../src/core/session-manager.ts";
+import { initTheme } from "../../src/modes/interactive/theme/theme.ts";
+import { parseResumeBenchArgs } from "./resume-flow-args.ts";
+import { createResumeBenchFixture, type ResumeBenchFixture, removeResumeBenchFixture } from "./resume-flow-fixture.ts";
+import { digestRestoredTexts, renderTranscript, TRANSCRIPT_WIDTH } from "./resume-flow-render.ts";
+
+type StageStats = {
+	readonly samples: readonly number[];
+	readonly medianMs: number;
+	readonly p95Ms: number;
+};
+
+type IterationMeasurement = {
+	readonly discoveryMs: number;
+	readonly openMs: number;
+	readonly contextMs: number;
+	readonly renderMs: number;
+	readonly endToEndMs: number;
+	readonly eventLoopGapMs: number;
+	readonly entryCount: number;
+	readonly messageCount: number;
+	readonly digest: string;
+};
+
+function stageStats(samples: readonly number[]): StageStats {
+	return {
+		samples,
+		medianMs: percentile(samples, 50),
+		p95Ms: percentile(samples, 95),
+	};
+}
+
+async function measureSyncWithEventLoopGap<T>(
+	work: () => T,
+): Promise<{ readonly value: T; readonly elapsedMs: number; readonly maxGapMs: number }> {
+	let maxGap = 0;
+	let last = performance.now();
+	let active = true;
+	const tick = (): void => {
+		const now = performance.now();
+		const gap = now - last;
+		last = now;
+		if (gap > maxGap) {
+			maxGap = gap;
+		}
+		if (active) {
+			setImmediate(tick);
+		}
+	};
+	await new Promise<void>((resolve) => {
+		setImmediate(() => {
+			tick();
+			resolve();
+		});
+	});
+	const start = performance.now();
+	const value = work();
+	const elapsedMs = performance.now() - start;
+	active = false;
+	await new Promise<void>((resolve) => {
+		setImmediate(resolve);
+	});
+	return { value, elapsedMs, maxGapMs: maxGap };
+}
+
+async function measureIteration(fixture: ResumeBenchFixture): Promise<IterationMeasurement> {
+	const endToEndStart = performance.now();
+
+	const discoveryStart = performance.now();
+	const listed = await SessionManager.list(fixture.cwd, fixture.sessionDir);
+	const selected = listed.find((session) => session.id === fixture.selectedId);
+	if (!selected) {
+		throw new Error(`Selected session ${fixture.selectedId} missing from listing`);
+	}
+	if (listed.length < fixture.decoySessionCount + 1) {
+		throw new Error(`Expected at least ${fixture.decoySessionCount + 1} listed sessions, got ${listed.length}`);
+	}
+	const discoveryMs = performance.now() - discoveryStart;
+
+	const opened = await measureSyncWithEventLoopGap(() => SessionManager.open(selected.path, fixture.sessionDir));
+	const session = opened.value;
+
+	const contextStart = performance.now();
+	const entries = session.buildContextEntries();
+	const messages = entries.flatMap(sessionEntryToContextMessages);
+	const contextMs = performance.now() - contextStart;
+
+	const renderStart = performance.now();
+	const renderLines = renderTranscript(messages);
+	const renderMs = performance.now() - renderStart;
+	if (renderLines === 0) {
+		throw new Error("Expected transcript output");
+	}
+
+	return {
+		discoveryMs,
+		openMs: opened.elapsedMs,
+		contextMs,
+		renderMs,
+		endToEndMs: performance.now() - endToEndStart,
+		eventLoopGapMs: opened.maxGapMs,
+		entryCount: session.getEntries().length,
+		messageCount: messages.length,
+		digest: digestRestoredTexts(messages),
+	};
+}
+
+export async function runResumeFlowBench(argv: readonly string[]): Promise<void> {
+	const args = parseResumeBenchArgs(argv);
+	const fixture = await createResumeBenchFixture(args.messages);
+	try {
+		process.env.HOME = fixture.rootDir;
+		process.env.USERPROFILE = fixture.rootDir;
+		process.env.PI_OFFLINE = "1";
+		process.env.PI_SKIP_VERSION_CHECK = "1";
+		initTheme("dark");
+
+		await measureIteration(fixture);
+		forceGc();
+
+		const discoverySamples: number[] = [];
+		const openSamples: number[] = [];
+		const contextSamples: number[] = [];
+		const renderSamples: number[] = [];
+		const endToEndSamples: number[] = [];
+		const eventLoopGapSamples: number[] = [];
+		let digestSha256 = "";
+		let restoredEntryCount = 0;
+		let restoredMessageCount = 0;
+		let eventLoopMaxGapMs = 0;
+
+		for (let iteration = 0; iteration < args.iterations; iteration++) {
+			const measured = await measureIteration(fixture);
+			discoverySamples.push(measured.discoveryMs);
+			openSamples.push(measured.openMs);
+			contextSamples.push(measured.contextMs);
+			renderSamples.push(measured.renderMs);
+			endToEndSamples.push(measured.endToEndMs);
+			eventLoopGapSamples.push(measured.eventLoopGapMs);
+			eventLoopMaxGapMs = Math.max(eventLoopMaxGapMs, measured.eventLoopGapMs);
+			if (iteration === 0) {
+				digestSha256 = measured.digest;
+				restoredEntryCount = measured.entryCount;
+				restoredMessageCount = measured.messageCount;
+			} else if (measured.digest !== digestSha256) {
+				throw new Error("Restored digest changed across iterations");
+			}
+		}
+
+		forceGc();
+		const report = {
+			suite: "resume-flow",
+			package: "@code-yeongyu/senpi",
+			messages: args.messages,
+			iterations: args.iterations,
+			fixtureBytes: fixture.fixtureBytes,
+			fixtureRoot: fixture.rootDir,
+			decoySessionCount: fixture.decoySessionCount,
+			transcriptWidth: TRANSCRIPT_WIDTH,
+			restoredEntryCount,
+			restoredMessageCount,
+			digestSha256,
+			eventLoopMaxGapMs,
+			eventLoopGapSamples,
+			endToEndSamples,
+			endToEndMedianMs: percentile(endToEndSamples, 50),
+			endToEndP95Ms: percentile(endToEndSamples, 95),
+			stages: {
+				sessionDiscoveryListing: stageStats(discoverySamples),
+				sessionOpenParseRestore: stageStats(openSamples),
+				buildContextEntries: stageStats(contextSamples),
+				transcriptFirstRender: stageStats(renderSamples),
+			},
+			metadata: metadata(),
+		};
+		const encoded = JSON.stringify(report);
+		if (args.jsonPath) {
+			mkdirSync(dirname(args.jsonPath), { recursive: true });
+			writeFileSync(args.jsonPath, `${encoded}\n`);
+		}
+		console.log(encoded);
+	} finally {
+		removeResumeBenchFixture(fixture);
+	}
+}

--- a/packages/coding-agent/test/benchmarks/resume-flow-render.ts
+++ b/packages/coding-agent/test/benchmarks/resume-flow-render.ts
@@ -1,0 +1,77 @@
+import { createHash } from "node:crypto";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { AssistantMessage, UserMessage } from "@earendil-works/pi-ai";
+import { AssistantMessageComponent } from "../../src/modes/interactive/components/assistant-message.ts";
+import {
+	DEFAULT_TAIL_BUDGET,
+	DEFAULT_WARM_CHUNK_SIZE,
+	ProgressiveTranscriptContainer,
+} from "../../src/modes/interactive/components/progressive-transcript-container.ts";
+import { UserMessageComponent } from "../../src/modes/interactive/components/user-message.ts";
+
+export const TRANSCRIPT_WIDTH = 100;
+
+function extractTextContent(message: UserMessage | AssistantMessage): string {
+	const content = message.content;
+	if (typeof content === "string") {
+		return content;
+	}
+	const parts: string[] = [];
+	for (const block of content) {
+		if (block.type === "text") {
+			parts.push(block.text);
+		}
+	}
+	return parts.join(" ");
+}
+
+export function extractRestoredUserAssistantTexts(messages: readonly AgentMessage[]): readonly string[] {
+	const texts: string[] = [];
+	for (const message of messages) {
+		switch (message.role) {
+			case "user":
+			case "assistant": {
+				const text = extractTextContent(message);
+				if (text.length > 0) {
+					texts.push(text);
+				}
+				break;
+			}
+			default:
+				break;
+		}
+	}
+	return texts;
+}
+
+export function digestRestoredTexts(messages: readonly AgentMessage[]): string {
+	const texts = extractRestoredUserAssistantTexts(messages);
+	return createHash("sha256").update(texts.join("\n"), "utf8").digest("hex");
+}
+
+export function renderTranscript(messages: readonly AgentMessage[]): number {
+	const transcript = new ProgressiveTranscriptContainer({
+		tailBudget: DEFAULT_TAIL_BUDGET,
+		warmChunkSize: DEFAULT_WARM_CHUNK_SIZE,
+		requestRender: () => {},
+	});
+	try {
+		for (const message of messages) {
+			switch (message.role) {
+				case "user": {
+					const text = extractTextContent(message);
+					if (text.length > 0) transcript.addChild(new UserMessageComponent(text));
+					break;
+				}
+				case "assistant":
+					transcript.addChild(new AssistantMessageComponent(message));
+					break;
+				default:
+					break;
+			}
+		}
+		return transcript.render(TRANSCRIPT_WIDTH).length;
+	} finally {
+		transcript.dispose();
+	}
+}

--- a/packages/coding-agent/test/benchmarks/resume-flow.bench.mjs
+++ b/packages/coding-agent/test/benchmarks/resume-flow.bench.mjs
@@ -1,0 +1,25 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const entry = fileURLToPath(import.meta.url);
+const hasTsx = process.execArgv.some((arg) => arg === "tsx" || arg.includes("tsx"));
+
+if (!hasTsx) {
+	const result = spawnSync(process.execPath, ["--import", "tsx", entry, ...process.argv.slice(2)], {
+		stdio: "inherit",
+		env: process.env,
+	});
+	if (result.error) {
+		console.error(result.error);
+		process.exit(1);
+	}
+	process.exit(result.status === null ? 1 : result.status);
+}
+
+const { runResumeFlowBench } = await import("./resume-flow-harness.ts");
+try {
+	await runResumeFlowBench(process.argv.slice(2));
+} catch (error) {
+	console.error(error);
+	process.exitCode = 1;
+}

--- a/packages/coding-agent/test/session-discovery-search-text.test.ts
+++ b/packages/coding-agent/test/session-discovery-search-text.test.ts
@@ -1,0 +1,144 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type SessionInfo, SessionManager } from "../src/core/session-manager.ts";
+import { clearSessionSummaryCache } from "../src/core/session-summary-cache.ts";
+import { filterAndSortSessions } from "../src/modes/interactive/components/session-selector-search.ts";
+
+const SESSION_ID = "search-text-session" as const;
+const MIDDLE_PHRASE = "middle-only-searchable-phrase" as const;
+const HEADER_TIMESTAMP = "2026-02-01T00:00:00.000Z" as const;
+const MESSAGE_TIMESTAMP = "2026-02-01T00:00:01.000Z" as const;
+/** Enough turns that the phrase sits deep in the middle of a multi-window file. */
+const TURNS_PER_SIDE = 200 as const;
+
+function userMessageLine(index: number, content: string): string {
+	return JSON.stringify({
+		type: "message",
+		id: `msg-${index}`,
+		parentId: index === 1 ? null : `msg-${index - 1}`,
+		timestamp: MESSAGE_TIMESTAMP,
+		message: { role: "user", content, timestamp: Date.parse(MESSAGE_TIMESTAMP) },
+	});
+}
+
+/** A session whose only occurrence of MIDDLE_PHRASE sits deep in the middle of the file. */
+function writeMiddlePhraseSession(path: string, cwd: string): void {
+	const lines = [JSON.stringify({ type: "session", version: 3, id: SESSION_ID, timestamp: HEADER_TIMESTAMP, cwd })];
+	let index = 0;
+	const padding = "filler-padding-text".repeat(6);
+	for (let turn = 0; turn < TURNS_PER_SIDE; turn++) {
+		lines.push(userMessageLine(++index, `head-side-${turn} ${padding}`));
+	}
+	lines.push(userMessageLine(++index, MIDDLE_PHRASE));
+	for (let turn = 0; turn < TURNS_PER_SIDE; turn++) {
+		lines.push(userMessageLine(++index, `tail-side-${turn} ${padding}`));
+	}
+	writeFileSync(path, `${lines.join("\n")}\n`);
+}
+
+describe("session discovery search text", () => {
+	let tempDir: string;
+	let projectDir: string;
+	let sessionDir: string;
+	let phraseParseCount: number;
+
+	beforeEach(() => {
+		clearSessionSummaryCache();
+		tempDir = mkdtempSync(join(tmpdir(), "session-search-text-"));
+		projectDir = join(tempDir, "project");
+		sessionDir = join(tempDir, "sessions");
+		mkdirSync(sessionDir, { recursive: true });
+		writeMiddlePhraseSession(join(sessionDir, `${SESSION_ID}.jsonl`), projectDir);
+		phraseParseCount = 0;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		clearSessionSummaryCache();
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	/** Count JSON.parse calls that deserialize the middle record from here on. */
+	function spyOnPhraseParses(): void {
+		const originalParse = JSON.parse;
+		vi.spyOn(JSON, "parse").mockImplementation(
+			(text: string, reviver?: (this: unknown, key: string, value: unknown) => unknown): unknown => {
+				if (text.includes(MIDDLE_PHRASE)) {
+					phraseParseCount += 1;
+				}
+				return originalParse(text, reviver);
+			},
+		);
+	}
+
+	async function listRows(): Promise<SessionInfo[]> {
+		const rows = await SessionManager.list(projectDir, sessionDir);
+		expect(rows.map((row) => row.id)).toEqual([SESSION_ID]);
+		return rows;
+	}
+
+	it("does not re-parse a middle-only record when relisting an unchanged session", async () => {
+		// Given: a cold listing that has already summarized the session file.
+		await listRows();
+		spyOnPhraseParses();
+
+		// When: the same unchanged session directory is listed again.
+		await listRows();
+
+		// Then: the cached summary served the row without deserializing the middle record.
+		expect(phraseParseCount).toBe(0);
+	});
+
+	it("keeps the middle-only phrase searchable on a non-empty query", async () => {
+		// Given: listed picker rows for a session whose phrase lives mid-file.
+		const rows = await listRows();
+
+		// When: a non-empty query searches the listed rows.
+		const matched = filterAndSortSessions(rows, `"${MIDDLE_PHRASE}"`, "recent");
+
+		// Then: the row matches on text that only exists in the middle of the file.
+		expect(matched.map((row) => row.id)).toEqual([SESSION_ID]);
+	});
+
+	it("keeps the middle-only phrase searchable from a warm cached listing", async () => {
+		// Given: a warm cache and a fresh listing served from it.
+		await listRows();
+		spyOnPhraseParses();
+		const rows = await listRows();
+
+		// When: a non-empty query searches the cache-served rows.
+		const matched = filterAndSortSessions(rows, `"${MIDDLE_PHRASE}"`, "recent");
+
+		// Then: the cached transcript text still matches, with no record deserialized.
+		expect(matched.map((row) => row.id)).toEqual([SESSION_ID]);
+		expect(phraseParseCount).toBe(0);
+	});
+
+	it("re-reads the transcript after the session file changes", async () => {
+		// Given: a warm cache for the session file.
+		await listRows();
+		const appendedPhrase = "appended-after-cache-phrase";
+		const file = join(sessionDir, `${SESSION_ID}.jsonl`);
+		writeMiddlePhraseSession(file, projectDir);
+		writeFileSync(file, `${userMessageLine(9001, appendedPhrase)}\n`, { flag: "a" });
+
+		// When: the changed directory is listed again.
+		const rows = await listRows();
+
+		// Then: the new text is searchable, so the stale summary was not reused.
+		expect(filterAndSortSessions(rows, `"${appendedPhrase}"`, "recent").map((row) => row.id)).toEqual([SESSION_ID]);
+	});
+
+	it("keeps every row on an empty query", async () => {
+		// Given: listed picker rows.
+		const rows = await listRows();
+
+		// When: an empty query filters the listed rows.
+		const unfiltered = filterAndSortSessions(rows, "", "recent");
+
+		// Then: every row is kept.
+		expect(unfiltered.map((row) => row.id)).toEqual([SESSION_ID]);
+	});
+});

--- a/packages/coding-agent/test/session-summary-cache-budget.test.ts
+++ b/packages/coding-agent/test/session-summary-cache-budget.test.ts
@@ -1,0 +1,218 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SessionHeader } from "../src/core/session-manager.ts";
+import type { SessionSummary } from "../src/core/session-summary.ts";
+import {
+	clearSessionSummaryCache,
+	readCachedSessionSummary,
+	sessionSummaryCacheSize,
+	sessionSummaryCacheTextBytes,
+} from "../src/core/session-summary-cache.ts";
+import { SessionSummaryLru, type SummaryEntry } from "../src/core/session-summary-lru.ts";
+
+const HEADER_TIMESTAMP = "2026-04-01T00:00:00.000Z" as const;
+/** Small enough that a handful of synthetic summaries cross it. */
+const TINY_TEXT_BUDGET = 100 as const;
+
+function header(id: string): SessionHeader {
+	return { type: "session", version: 3, id, timestamp: HEADER_TIMESTAMP, cwd: "/tmp/project" };
+}
+
+function entryWithText(id: string, text: string): SummaryEntry {
+	const summary: SessionSummary = {
+		header: header(id),
+		name: undefined,
+		firstUserMessage: text,
+		messageCount: 1,
+		lastActivityTime: Date.parse(HEADER_TIMESTAMP),
+		allMessagesText: text,
+	};
+	return { stamp: { size: text.length, mtimeMs: 1 }, summary, mtime: new Date(HEADER_TIMESTAMP) };
+}
+
+describe("session summary cache byte budget", () => {
+	describe("SessionSummaryLru", () => {
+		it("evicts least-recently-used entries until retained bytes fit the budget", () => {
+			// Given: an LRU whose byte budget holds two 40-byte summaries but not three.
+			const lru = new SessionSummaryLru({ maxEntries: 1000, maxTextBytes: TINY_TEXT_BUDGET });
+			lru.retain("a", entryWithText("a", "a".repeat(40)));
+			lru.retain("b", entryWithText("b", "b".repeat(40)));
+
+			// When: a third summary pushes retained bytes past the budget.
+			lru.retain("c", entryWithText("c", "c".repeat(40)));
+
+			// Then: the oldest entry is gone and retained bytes are back under the ceiling.
+			expect(lru.get("a")).toBeUndefined();
+			expect(lru.get("b")?.summary.header.id).toBe("b");
+			expect(lru.get("c")?.summary.header.id).toBe("c");
+			expect(lru.size).toBe(2);
+			expect(lru.textBytes).toBe(80);
+			expect(lru.textBytes).toBeLessThanOrEqual(TINY_TEXT_BUDGET);
+		});
+
+		it("evicts by recency of use rather than of insertion", () => {
+			// Given: three retained summaries where the oldest insert was read most recently.
+			const lru = new SessionSummaryLru({ maxEntries: 1000, maxTextBytes: TINY_TEXT_BUDGET });
+			lru.retain("a", entryWithText("a", "a".repeat(40)));
+			lru.retain("b", entryWithText("b", "b".repeat(40)));
+			lru.get("a");
+
+			// When: a third summary forces an eviction.
+			lru.retain("c", entryWithText("c", "c".repeat(40)));
+
+			// Then: the entry not read since insertion is the one evicted.
+			expect(lru.get("b")).toBeUndefined();
+			expect(lru.get("a")?.summary.header.id).toBe("a");
+		});
+
+		it("counts UTF-8 bytes rather than code units", () => {
+			// Given: a budget of 100 bytes and a 60-character summary of 3-byte characters.
+			const lru = new SessionSummaryLru({ maxEntries: 1000, maxTextBytes: TINY_TEXT_BUDGET });
+			const multiByte = "한".repeat(60);
+			expect(multiByte.length).toBeLessThan(TINY_TEXT_BUDGET);
+
+			// When: that summary is retained.
+			lru.retain("wide", entryWithText("wide", multiByte));
+
+			// Then: its 180 bytes exceed the budget, so it is not retained at all.
+			expect(lru.size).toBe(0);
+			expect(lru.textBytes).toBe(0);
+		});
+
+		it("keeps existing entries when an oversized summary is refused", () => {
+			// Given: an LRU already holding a small summary.
+			const lru = new SessionSummaryLru({ maxEntries: 1000, maxTextBytes: TINY_TEXT_BUDGET });
+			lru.retain("small", entryWithText("small", "s".repeat(40)));
+
+			// When: a summary larger than the whole budget is offered.
+			lru.retain("huge", entryWithText("huge", "h".repeat(TINY_TEXT_BUDGET * 3)));
+
+			// Then: the oversized summary is refused and the small one survives untouched.
+			expect(lru.get("huge")).toBeUndefined();
+			expect(lru.get("small")?.summary.header.id).toBe("small");
+			expect(lru.size).toBe(1);
+			expect(lru.textBytes).toBe(40);
+		});
+
+		it("drops a stale entry when its oversized replacement is refused", () => {
+			// Given: a retained summary that a later read finds much larger.
+			const lru = new SessionSummaryLru({ maxEntries: 1000, maxTextBytes: TINY_TEXT_BUDGET });
+			lru.retain("grown", entryWithText("grown", "old-text"));
+
+			// When: the grown summary exceeds the budget and is refused.
+			lru.retain("grown", entryWithText("grown", "g".repeat(TINY_TEXT_BUDGET * 3)));
+
+			// Then: the stale summary is gone rather than served for the changed file.
+			expect(lru.get("grown")).toBeUndefined();
+			expect(lru.size).toBe(0);
+			expect(lru.textBytes).toBe(0);
+		});
+
+		it("still enforces the entry ceiling when bytes are plentiful", () => {
+			// Given: a two-entry ceiling and an effectively unlimited byte budget.
+			const lru = new SessionSummaryLru({ maxEntries: 2, maxTextBytes: 1024 * 1024 });
+			lru.retain("a", entryWithText("a", "a"));
+			lru.retain("b", entryWithText("b", "b"));
+
+			// When: a third summary is retained.
+			lru.retain("c", entryWithText("c", "c"));
+
+			// Then: the entry ceiling evicts the oldest even though bytes were fine.
+			expect(lru.size).toBe(2);
+			expect(lru.get("a")).toBeUndefined();
+		});
+
+		it("returns retained bytes to zero after a clear", () => {
+			// Given: an LRU holding two summaries.
+			const lru = new SessionSummaryLru({ maxEntries: 1000, maxTextBytes: TINY_TEXT_BUDGET });
+			lru.retain("a", entryWithText("a", "a".repeat(20)));
+			lru.retain("b", entryWithText("b", "b".repeat(20)));
+
+			// When: the cache is cleared.
+			lru.clear();
+
+			// Then: both the entry count and the byte tally reset.
+			expect(lru.size).toBe(0);
+			expect(lru.textBytes).toBe(0);
+		});
+	});
+
+	describe("process-local cache", () => {
+		let tempDir: string;
+
+		beforeEach(() => {
+			clearSessionSummaryCache();
+			tempDir = mkdtempSync(join(tmpdir(), "session-summary-budget-"));
+			mkdirSync(tempDir, { recursive: true });
+		});
+
+		afterEach(() => {
+			clearSessionSummaryCache();
+			rmSync(tempDir, { recursive: true, force: true });
+		});
+
+		function writeSession(id: string, text: string): string {
+			const path = join(tempDir, `${id}.jsonl`);
+			const lines = [
+				JSON.stringify({ type: "session", version: 3, id, timestamp: HEADER_TIMESTAMP, cwd: tempDir }),
+				JSON.stringify({
+					type: "message",
+					id: "msg-1",
+					parentId: null,
+					timestamp: HEADER_TIMESTAMP,
+					message: { role: "user", content: text, timestamp: Date.parse(HEADER_TIMESTAMP) },
+				}),
+			];
+			writeFileSync(path, `${lines.join("\n")}\n`);
+			return path;
+		}
+
+		it("tracks retained transcript bytes for cached session files", async () => {
+			// Given: two session files with known transcript text.
+			const first = writeSession("first", "first-transcript-text");
+			const second = writeSession("second", "second-transcript-text");
+
+			// When: both are summarized through the process-local cache.
+			await readCachedSessionSummary(first);
+			await readCachedSessionSummary(second);
+
+			// Then: the byte tally is the sum of the two transcripts.
+			expect(sessionSummaryCacheSize()).toBe(2);
+			expect(sessionSummaryCacheTextBytes()).toBe(
+				Buffer.byteLength("first-transcript-text") + Buffer.byteLength("second-transcript-text"),
+			);
+		});
+
+		it("does not double-count a repeated read of an unchanged file", async () => {
+			// Given: a session file already summarized once.
+			const path = writeSession("stable", "stable-transcript-text");
+			await readCachedSessionSummary(path);
+			const bytesAfterFirstRead = sessionSummaryCacheTextBytes();
+
+			// When: the unchanged file is summarized twice more.
+			await readCachedSessionSummary(path);
+			await readCachedSessionSummary(path);
+
+			// Then: the byte tally is unchanged, so cache hits do not leak accounting.
+			expect(sessionSummaryCacheTextBytes()).toBe(bytesAfterFirstRead);
+			expect(sessionSummaryCacheSize()).toBe(1);
+		});
+
+		it("releases retained bytes when a cached file becomes unreadable", async () => {
+			// Given: a cached summary for an existing session file.
+			const path = writeSession("vanishing", "vanishing-transcript-text");
+			await readCachedSessionSummary(path);
+			expect(sessionSummaryCacheTextBytes()).toBeGreaterThan(0);
+
+			// When: the file is removed and the summary is requested again.
+			rmSync(path);
+			await readCachedSessionSummary(path);
+
+			// Then: the entry and its bytes are both released.
+			expect(sessionSummaryCacheSize()).toBe(0);
+			expect(sessionSummaryCacheTextBytes()).toBe(0);
+		});
+	});
+});

--- a/packages/coding-agent/test/session-summary-exactness.test.ts
+++ b/packages/coding-agent/test/session-summary-exactness.test.ts
@@ -1,0 +1,205 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildSessionInfo } from "../src/core/session-discovery.ts";
+import {
+	clearSessionSummaryCache,
+	readCachedSessionSummary,
+	sessionSummaryCacheSize,
+} from "../src/core/session-summary-cache.ts";
+
+const SESSION_ID = "exactness-session" as const;
+const HEADER_TIMESTAMP = "2026-03-01T00:00:00.000Z" as const;
+/** Wide enough that a middle record sits far past any fixed-size head window. */
+const PADDING = "exactness-filler-padding".repeat(40);
+const TURNS_PER_SIDE = 400 as const;
+
+function headerLine(cwd: string, extra: Readonly<Record<string, unknown>> = {}): string {
+	return JSON.stringify({ type: "session", version: 3, id: SESSION_ID, timestamp: HEADER_TIMESTAMP, cwd, ...extra });
+}
+
+function messageLine(index: number, content: string, role: "user" | "assistant", timeMs: number): string {
+	return JSON.stringify({
+		type: "message",
+		id: `msg-${index}`,
+		parentId: index === 1 ? null : `msg-${index - 1}`,
+		timestamp: new Date(timeMs).toISOString(),
+		message: { role, content, timestamp: timeMs },
+	});
+}
+
+function filler(index: number, timeMs: number): string {
+	return messageLine(index, `filler-${index} ${PADDING}`, index % 2 === 0 ? "assistant" : "user", timeMs);
+}
+
+describe("session summary exactness", () => {
+	let tempDir: string;
+	let projectDir: string;
+	let file: string;
+
+	beforeEach(() => {
+		clearSessionSummaryCache();
+		tempDir = mkdtempSync(join(tmpdir(), "session-summary-exact-"));
+		projectDir = join(tempDir, "project");
+		mkdirSync(projectDir, { recursive: true });
+		file = join(tempDir, `${SESSION_ID}.jsonl`);
+	});
+
+	afterEach(() => {
+		clearSessionSummaryCache();
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("takes the first user message from the middle when earlier records are assistant-only", async () => {
+		// Given: a session whose first *user* message sits deep past every assistant record.
+		const base = Date.parse(HEADER_TIMESTAMP);
+		const lines = [headerLine(projectDir)];
+		let index = 0;
+		for (let turn = 0; turn < TURNS_PER_SIDE; turn++) {
+			lines.push(messageLine(++index, `assistant-only-${turn} ${PADDING}`, "assistant", base + index));
+		}
+		lines.push(messageLine(++index, "the-real-first-user-message", "user", base + index));
+		for (let turn = 0; turn < TURNS_PER_SIDE; turn++) {
+			lines.push(messageLine(++index, `tail-user-${turn} ${PADDING}`, "user", base + index));
+		}
+		writeFileSync(file, `${lines.join("\n")}\n`);
+
+		// When: the picker row is built.
+		const info = await buildSessionInfo(file);
+
+		// Then: the mid-file user message is the row's first message.
+		expect(info?.firstMessage).toBe("the-real-first-user-message");
+	});
+
+	it("takes the latest session_info name from the middle of the file", async () => {
+		// Given: renames early and mid-file, with a long transcript tail after the last one.
+		const base = Date.parse(HEADER_TIMESTAMP);
+		const lines = [
+			headerLine(projectDir),
+			JSON.stringify({ type: "session_info", id: "info-1", timestamp: HEADER_TIMESTAMP, name: "early-name" }),
+		];
+		let index = 0;
+		for (let turn = 0; turn < TURNS_PER_SIDE; turn++) {
+			lines.push(filler(++index, base + index));
+		}
+		lines.push(
+			JSON.stringify({ type: "session_info", id: "info-2", timestamp: HEADER_TIMESTAMP, name: "middle-name" }),
+		);
+		for (let turn = 0; turn < TURNS_PER_SIDE; turn++) {
+			lines.push(filler(++index, base + index));
+		}
+		writeFileSync(file, `${lines.join("\n")}\n`);
+
+		// When: the picker row is built.
+		const info = await buildSessionInfo(file);
+
+		// Then: the mid-file rename wins over the early one.
+		expect(info?.name).toBe("middle-name");
+	});
+
+	it("takes the max activity time when the newest message is not the last record", async () => {
+		// Given: the newest timestamp mid-file, followed by older records.
+		const base = Date.parse(HEADER_TIMESTAMP);
+		const newest = base + 900_000;
+		const lines = [
+			headerLine(projectDir),
+			messageLine(1, "first", "user", base + 1_000),
+			messageLine(2, "newest-mid-file", "assistant", newest),
+			messageLine(3, "older-after-newest", "user", base + 2_000),
+			messageLine(4, "older-still", "assistant", base + 3_000),
+		];
+		writeFileSync(file, `${lines.join("\n")}\n`);
+
+		// When: the picker row is built.
+		const info = await buildSessionInfo(file);
+
+		// Then: modified reflects the max activity time, not the last record's.
+		expect(info?.modified.getTime()).toBe(newest);
+	});
+
+	it("counts message records regardless of whitespace and property order", async () => {
+		// Given: message records written with reordered keys and padded whitespace.
+		const base = Date.parse(HEADER_TIMESTAMP);
+		const lines = [
+			headerLine(projectDir),
+			'  {"message":{"role":"user","content":"reordered-one","timestamp":1},"timestamp":"2026-03-01T00:00:01.000Z","id":"msg-1","parentId":null,"type":"message"}  ',
+			`{ "type" : "message" , "id" : "msg-2" , "parentId" : "msg-1" , "timestamp" : "${new Date(base + 2).toISOString()}" , "message" : { "role" : "assistant" , "content" : "spaced-two" } }`,
+			"",
+			"   ",
+			messageLine(3, "plain-three", "user", base + 3),
+		];
+		writeFileSync(file, `${lines.join("\n")}\n`);
+
+		// When: the picker row is built.
+		const info = await buildSessionInfo(file);
+
+		// Then: all three message records count, and their text is searchable.
+		expect(info?.messageCount).toBe(3);
+		expect(info?.allMessagesText).toBe("reordered-one spaced-two plain-three");
+	});
+
+	it("keeps intact records when the final JSONL record is truncated", async () => {
+		// Given: valid records followed by a truncated trailing record.
+		const base = Date.parse(HEADER_TIMESTAMP);
+		const valid = [
+			headerLine(projectDir),
+			messageLine(1, "kept-one", "user", base + 1),
+			messageLine(2, "kept-two", "assistant", base + 2),
+		];
+		const truncated = '{"type":"message","id":"msg-3","parentId":"msg-2","message":{"role":"user","content":"partial';
+		writeFileSync(file, `${valid.join("\n")}\n${truncated}\n`);
+
+		// When: the picker row is built.
+		const info = await buildSessionInfo(file);
+
+		// Then: the intact records survive and the truncated tail is dropped.
+		expect(info?.messageCount).toBe(2);
+		expect(info?.allMessagesText).toBe("kept-one kept-two");
+	});
+
+	it("rejects a file whose first record is not a session header", async () => {
+		// Given: a JSONL file that starts with a non-session record.
+		writeFileSync(file, `${JSON.stringify({ type: "event", id: "not-a-session" })}\n`);
+
+		// When: the picker row is built.
+		const info = await buildSessionInfo(file);
+
+		// Then: no row is produced and nothing is cached for it.
+		expect(info).toBeNull();
+		expect(sessionSummaryCacheSize()).toBe(0);
+	});
+
+	it("drops the cache entry when the file becomes unreadable", async () => {
+		// Given: a cached summary for an existing session file.
+		writeFileSync(
+			file,
+			`${headerLine(projectDir)}\n${messageLine(1, "only", "user", Date.parse(HEADER_TIMESTAMP))}\n`,
+		);
+		expect(await readCachedSessionSummary(file)).not.toBeNull();
+
+		// When: the file is removed and the summary is requested again.
+		rmSync(file);
+		const afterRemoval = await readCachedSessionSummary(file);
+
+		// Then: the stale entry is gone rather than served from cache.
+		expect(afterRemoval).toBeNull();
+		expect(sessionSummaryCacheSize()).toBe(0);
+	});
+
+	it("preserves the parent session path from the header", async () => {
+		// Given: a forked session header carrying a parent path.
+		const parentPath = join(tempDir, "parent.jsonl");
+		writeFileSync(
+			file,
+			`${headerLine(projectDir, { parentSession: parentPath })}\n${messageLine(1, "forked", "user", Date.parse(HEADER_TIMESTAMP))}\n`,
+		);
+
+		// When: the picker row is built.
+		const info = await buildSessionInfo(file);
+
+		// Then: the row carries the header's parent path and cwd.
+		expect(info?.parentSessionPath).toBe(parentPath);
+		expect(info?.cwd).toBe(projectDir);
+	});
+});

--- a/packages/coding-agent/test/suite/progressive-transcript-container.test.ts
+++ b/packages/coding-agent/test/suite/progressive-transcript-container.test.ts
@@ -1,0 +1,281 @@
+import type { Component } from "@earendil-works/pi-tui";
+import { Container } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { ProgressiveTranscriptContainer } from "../../src/modes/interactive/components/progressive-transcript-container.ts";
+
+const WIDTH = 100 as const;
+const TAIL_BUDGET = 40 as const;
+const WARM_CHUNK = 200 as const;
+const LARGE_TRANSCRIPT = 5000 as const;
+const OVER_BUDGET = TAIL_BUDGET + 10;
+
+/**
+ * A stand-in for a real message component that counts how many times the
+ * transcript asked it to render. Line content is unique per index so ordering
+ * regressions cannot hide behind identical output.
+ */
+class CountingComponent implements Component {
+	renderCount = 0;
+	invalidateCount = 0;
+	disposeCount = 0;
+	readonly index: number;
+
+	constructor(index: number) {
+		this.index = index;
+	}
+
+	render(width: number): string[] {
+		this.renderCount += 1;
+		return [`component-${this.index}-w${width}`, `component-${this.index}-body`];
+	}
+
+	invalidate(): void {
+		this.invalidateCount += 1;
+	}
+
+	dispose(): void {
+		this.disposeCount += 1;
+	}
+}
+
+class ThrowingComponent implements Component {
+	renderCount = 0;
+
+	render(_width: number): string[] {
+		this.renderCount += 1;
+		throw new Error("intentional render failure");
+	}
+
+	invalidate(): void {}
+
+	dispose(): void {}
+}
+
+function countingLines(index: number): readonly [string, string] {
+	return [`component-${index}-w${WIDTH}`, `component-${index}-body`];
+}
+
+function createProgressive(rerender: () => void): ProgressiveTranscriptContainer {
+	return new ProgressiveTranscriptContainer({
+		tailBudget: TAIL_BUDGET,
+		warmChunkSize: WARM_CHUNK,
+		requestRender: rerender,
+	});
+}
+
+function populate(container: Container, count: number): readonly CountingComponent[] {
+	const components: CountingComponent[] = [];
+	for (let index = 0; index < count; index++) {
+		const component = new CountingComponent(index);
+		components.push(component);
+		container.addChild(component);
+	}
+	return components;
+}
+
+/** Resolve once hydration reports completion, with a bounded macrotask budget. */
+async function awaitHydration(container: ProgressiveTranscriptContainer, maxTicks: number): Promise<void> {
+	for (let tick = 0; tick < maxTicks; tick++) {
+		if (container.isFullyHydrated) return;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	if (!container.isFullyHydrated) {
+		throw new Error(`hydration did not complete within ${maxTicks} macrotasks`);
+	}
+}
+
+describe("ProgressiveTranscriptContainer", () => {
+	it("renders only a bounded tail on the first paint of a large transcript", () => {
+		// Given: a 5,000-message transcript hydrated into the progressive container
+		const container = createProgressive(() => {});
+		const components = populate(container, LARGE_TRANSCRIPT);
+
+		// When: the TUI paints the first frame
+		const lines = container.render(WIDTH);
+
+		// Then: only the bounded visible tail was asked to render
+		const rendered = components.filter((component) => component.renderCount > 0);
+		expect(rendered).toHaveLength(TAIL_BUDGET);
+		// Then: the rendered window is the tail, in order, and nothing earlier was touched
+		const expectedTail = components.slice(LARGE_TRANSCRIPT - TAIL_BUDGET);
+		expect(rendered).toStrictEqual([...expectedTail]);
+		expect(lines).toStrictEqual(expectedTail.flatMap((component) => countingLines(component.index)));
+	});
+
+	it("eventually renders the full history exactly like an ordinary Container", async () => {
+		// Given: identical transcripts in a plain Container and the progressive one
+		const baseline = new Container();
+		populate(baseline, LARGE_TRANSCRIPT);
+		let rerenderRequests = 0;
+		const progressive = createProgressive(() => {
+			rerenderRequests += 1;
+		});
+		populate(progressive, LARGE_TRANSCRIPT);
+
+		// When: the first paint lands and hydration warms every earlier component
+		progressive.render(WIDTH);
+		await awaitHydration(progressive, LARGE_TRANSCRIPT / WARM_CHUNK + 8);
+
+		// Then: hydration asked for exactly one completion rerender and the full output matches the baseline
+		expect(rerenderRequests).toBe(1);
+		expect(progressive.render(WIDTH)).toStrictEqual(baseline.render(WIDTH));
+	});
+
+	it("warms the deferred head off the critical path so the full frame is not one burst", async () => {
+		// Given: a large transcript whose head was skipped by the first paint
+		const container = createProgressive(() => {});
+		const components = populate(container, LARGE_TRANSCRIPT);
+		container.render(WIDTH);
+		const head = components.slice(0, LARGE_TRANSCRIPT - TAIL_BUDGET);
+		expect(head.every((component) => component.renderCount === 0)).toBe(true);
+
+		// When: background hydration runs to completion
+		await awaitHydration(container, LARGE_TRANSCRIPT / WARM_CHUNK + 8);
+
+		// Then: the head was actually rendered during hydration, not merely marked ready.
+		// Without real warming the deferred Markdown cost would just move to the repaint.
+		expect(head.every((component) => component.renderCount > 0)).toBe(true);
+	});
+
+	it("renders every child immediately once the transcript fits the tail budget", () => {
+		// Given: a transcript smaller than the visible tail budget
+		const container = createProgressive(() => {});
+		const components = populate(container, TAIL_BUDGET - 1);
+
+		// When: the first frame paints
+		container.render(WIDTH);
+
+		// Then: nothing was deferred, so hydration is already complete
+		expect(components.every((component) => component.renderCount > 0)).toBe(true);
+		expect(container.isFullyHydrated).toBe(true);
+	});
+
+	it("renders appended live messages after hydration completes", async () => {
+		// Given: a hydrated large transcript
+		const container = createProgressive(() => {});
+		populate(container, LARGE_TRANSCRIPT);
+		container.render(WIDTH);
+		await awaitHydration(container, LARGE_TRANSCRIPT / WARM_CHUNK + 8);
+
+		// When: a live message arrives and the next frame paints
+		const live = new CountingComponent(LARGE_TRANSCRIPT);
+		container.addChild(live);
+		const lines = container.render(WIDTH);
+
+		// Then: the appended message is painted at the tail
+		expect(live.renderCount).toBeGreaterThan(0);
+		expect(lines.slice(-2)).toStrictEqual([...countingLines(LARGE_TRANSCRIPT)]);
+	});
+
+	it("cancels pending hydration when the transcript is cleared and rebuilt", async () => {
+		// Given: a large transcript whose first paint scheduled hydration work
+		let rerenderRequests = 0;
+		const container = createProgressive(() => {
+			rerenderRequests += 1;
+		});
+		const stale = populate(container, LARGE_TRANSCRIPT);
+		container.render(WIDTH);
+		const rerendersAtClear = rerenderRequests;
+
+		// When: the transcript is cleared and rebuilt small, then repainted
+		container.clear();
+		const rebuilt = populate(container, 3);
+		container.render(WIDTH);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		// Then: the cleared components were disposed and never warmed further
+		expect(stale.every((component) => component.disposeCount === 1)).toBe(true);
+		const staleRenderTotal = stale.reduce((total, component) => total + component.renderCount, 0);
+		expect(staleRenderTotal).toBe(TAIL_BUDGET);
+		// Then: the small rebuild paints synchronously without extra hydration passes
+		expect(rebuilt.every((component) => component.renderCount === 1)).toBe(true);
+		expect(container.isFullyHydrated).toBe(true);
+		expect(rerenderRequests).toBe(rerendersAtClear);
+	});
+
+	it("stops hydration and forwards disposal to children on dispose", async () => {
+		// Given: a large transcript mid-hydration
+		const container = createProgressive(() => {});
+		const components = populate(container, LARGE_TRANSCRIPT);
+		container.render(WIDTH);
+
+		// When: the container is disposed before hydration finishes
+		container.dispose();
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		// Then: children were disposed and no further warming happened
+		expect(components.every((component) => component.disposeCount === 1)).toBe(true);
+		const renderTotal = components.reduce((total, component) => total + component.renderCount, 0);
+		expect(renderTotal).toBe(TAIL_BUDGET);
+	});
+
+	it("contains a throwing tail child on the first frame without escaping", () => {
+		// Given: a transcript larger than the tail budget with a thrower in the visible tail
+		const container = createProgressive(() => {});
+		const throwerIndex = OVER_BUDGET - 5;
+		const thrower = new ThrowingComponent();
+		let last: CountingComponent | undefined;
+		for (let index = 0; index < OVER_BUDGET; index++) {
+			if (index === throwerIndex) {
+				container.addChild(thrower);
+				continue;
+			}
+			const component = new CountingComponent(index);
+			container.addChild(component);
+			last = component;
+		}
+
+		// When: the TUI paints the first frame
+		const lines = container.render(WIDTH);
+
+		// Then: the thrower is contained and the rest of the tail still paints
+		expect(thrower.renderCount).toBe(1);
+		expect(lines).toContain("[render error: ThrowingComponent]");
+		expect(last?.renderCount).toBe(1);
+		expect(lines.slice(-2)).toStrictEqual([...countingLines(OVER_BUDGET - 1)]);
+	});
+
+	it("contains a throwing head child during warm chunks without escaping", async () => {
+		// Given: a transcript larger than the tail budget with a thrower in the deferred head
+		let rerenderRequests = 0;
+		const container = createProgressive(() => {
+			rerenderRequests += 1;
+		});
+		const thrower = new ThrowingComponent();
+		container.addChild(thrower);
+		const headNeighbor = new CountingComponent(1);
+		container.addChild(headNeighbor);
+		for (let index = 2; index < OVER_BUDGET; index++) {
+			container.addChild(new CountingComponent(index));
+		}
+
+		// When: first paint lands and background hydration warms the head
+		const first = container.render(WIDTH);
+		expect(first).not.toContain("[render error: ThrowingComponent]");
+		expect(thrower.renderCount).toBe(0);
+		await awaitHydration(container, 8);
+
+		// Then: hydration completed through the thrower and the full frame contains it
+		expect(container.isFullyHydrated).toBe(true);
+		expect(rerenderRequests).toBe(1);
+		expect(headNeighbor.renderCount).toBeGreaterThan(0);
+		expect(thrower.renderCount).toBe(1);
+		expect(container.render(WIDTH)).toContain("[render error: ThrowingComponent]");
+		expect(thrower.renderCount).toBe(2);
+	});
+
+	it("forwards theme invalidation to every child, warmed or not", () => {
+		// Given: a large transcript whose earlier components were never warmed
+		const container = createProgressive(() => {});
+		const components = populate(container, LARGE_TRANSCRIPT);
+		container.render(WIDTH);
+
+		// When: the theme changes and invalidation propagates
+		container.invalidate();
+
+		// Then: every child was invalidated, including the un-warmed head
+		expect(components.every((component) => component.invalidateCount === 1)).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/resume-load-performance.test.ts
+++ b/packages/coding-agent/test/suite/regressions/resume-load-performance.test.ts
@@ -1,0 +1,243 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../../src/core/session-manager.ts";
+import { clearSessionSummaryCache } from "../../../src/core/session-summary-cache.ts";
+
+const HEADER_TIMESTAMP = "2026-01-15T12:00:00.000Z" as const;
+const MESSAGE_TIMESTAMP = "2026-01-15T12:00:01.000Z" as const;
+const MESSAGE_TIME_MS = Date.parse(MESSAGE_TIMESTAMP);
+const ONE_MESSAGE_CONTENT = "resume-one-message-content" as const;
+const SELECTED_SESSION_ID = "resume-selected-session" as const;
+const NON_SELECTED_SESSION_ID = "resume-non-selected-session" as const;
+const ONE_MESSAGE_SESSION_ID = "resume-one-message-session" as const;
+const SELECTED_MESSAGE_COUNT = 5000 as const;
+const SENTINEL = "RESUME_LOAD_PERF_SENTINEL_DO_NOT_PARSE" as const;
+const FILLER_BEFORE_SENTINEL = 256 as const;
+const FILLER_AFTER_SENTINEL = 16 as const;
+const TRUNCATED_FINAL_RECORD =
+	`{"type":"message","id":"truncated-final","parentId":"msg-${SELECTED_MESSAGE_COUNT}","timestamp":"${MESSAGE_TIMESTAMP}","message":{"role":"user","content":"partial` as const;
+
+type UserMessageLineInput = {
+	readonly id: string;
+	readonly parentId: string | null;
+	readonly content: string;
+};
+
+function sessionHeaderLine(id: string, cwd: string): string {
+	return JSON.stringify({
+		type: "session",
+		version: 3,
+		id,
+		timestamp: HEADER_TIMESTAMP,
+		cwd,
+	});
+}
+
+function userMessageLine(input: UserMessageLineInput): string {
+	return JSON.stringify({
+		type: "message",
+		id: input.id,
+		parentId: input.parentId,
+		timestamp: MESSAGE_TIMESTAMP,
+		message: {
+			role: "user",
+			content: input.content,
+			timestamp: MESSAGE_TIME_MS,
+		},
+	});
+}
+
+function chainedUserMessages(count: number, contentPrefix: string): string[] {
+	const lines: string[] = [];
+	for (let index = 1; index <= count; index++) {
+		lines.push(
+			userMessageLine({
+				id: `msg-${index}`,
+				parentId: index === 1 ? null : `msg-${index - 1}`,
+				content: `${contentPrefix}-${index}`,
+			}),
+		);
+	}
+	return lines;
+}
+
+function writeJsonl(path: string, lines: readonly string[]): void {
+	writeFileSync(path, `${lines.join("\n")}\n`);
+}
+
+describe("resume session discovery/load performance contract", () => {
+	let tempDir: string;
+	let projectDir: string;
+	let sessionDir: string;
+
+	beforeEach(() => {
+		clearSessionSummaryCache();
+		tempDir = mkdtempSync(join(tmpdir(), "resume-load-perf-"));
+		projectDir = join(tempDir, "project");
+		sessionDir = join(tempDir, "sessions");
+		mkdirSync(sessionDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		clearSessionSummaryCache();
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("omits empty and invalid session files from discovery", async () => {
+		// Given: empty, malformed, and non-session JSONL files in the session directory.
+		writeFileSync(join(sessionDir, "empty.jsonl"), "");
+		writeFileSync(join(sessionDir, "invalid.jsonl"), "{this is not json\n");
+		writeJsonl(join(sessionDir, "not-a-session.jsonl"), [JSON.stringify({ type: "event", id: "not-a-session" })]);
+
+		// When: SessionManager.list discovers sessions for the project.
+		const listed = await SessionManager.list(projectDir, sessionDir);
+
+		// Then: none of the unreadable files become picker rows.
+		expect(listed).toEqual([]);
+	});
+
+	it("preserves one-message ordering and content on load", () => {
+		// Given: a session whose tree is a single user message.
+		const file = join(sessionDir, `${ONE_MESSAGE_SESSION_ID}.jsonl`);
+		writeJsonl(file, [
+			sessionHeaderLine(ONE_MESSAGE_SESSION_ID, projectDir),
+			userMessageLine({
+				id: "msg-1",
+				parentId: null,
+				content: ONE_MESSAGE_CONTENT,
+			}),
+		]);
+
+		// When: SessionManager.open loads that session.
+		const session = SessionManager.open(file, sessionDir);
+
+		// Then: the loaded tree is that one message, in order, with the written content.
+		const entries = session.getEntries();
+		expect(session.getSessionId()).toBe(ONE_MESSAGE_SESSION_ID);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			type: "message",
+			id: "msg-1",
+			parentId: null,
+			timestamp: MESSAGE_TIMESTAMP,
+			message: {
+				role: "user",
+				content: ONE_MESSAGE_CONTENT,
+				timestamp: MESSAGE_TIME_MS,
+			},
+		});
+	});
+
+	it("recovers a 5000-message selected session when the final JSONL record is truncated", () => {
+		// Given: a selected session with 5000 valid messages and a truncated trailing record.
+		const file = join(sessionDir, `${SELECTED_SESSION_ID}.jsonl`);
+		writeFileSync(
+			file,
+			`${[sessionHeaderLine(SELECTED_SESSION_ID, projectDir), ...chainedUserMessages(SELECTED_MESSAGE_COUNT, "selected-message")].join("\n")}\n${TRUNCATED_FINAL_RECORD}\n`,
+		);
+
+		// When: SessionManager.open loads the selected session.
+		const session = SessionManager.open(file, sessionDir);
+
+		// Then: lenient recovery keeps the 5000 intact messages and drops the truncated tail.
+		const entries = session.getEntries();
+		expect(session.getSessionId()).toBe(SELECTED_SESSION_ID);
+		expect(entries).toHaveLength(SELECTED_MESSAGE_COUNT);
+		expect(entries[0]).toMatchObject({
+			type: "message",
+			id: "msg-1",
+			parentId: null,
+			message: { role: "user", content: "selected-message-1" },
+		});
+		expect(entries[SELECTED_MESSAGE_COUNT - 1]).toMatchObject({
+			type: "message",
+			id: `msg-${SELECTED_MESSAGE_COUNT}`,
+			parentId: `msg-${SELECTED_MESSAGE_COUNT - 1}`,
+			message: { role: "user", content: `selected-message-${SELECTED_MESSAGE_COUNT}` },
+		});
+		expect(entries.map((entry) => entry.id)).not.toContain("truncated-final");
+	});
+
+	it("does not re-parse a sentinel deep in an unchanged non-selected session on a later list()", async () => {
+		// Given: a small selected session and an unchanged non-selected session with a sentinel past the picker preview.
+		writeJsonl(join(sessionDir, `${SELECTED_SESSION_ID}.jsonl`), [
+			sessionHeaderLine(SELECTED_SESSION_ID, projectDir),
+			userMessageLine({
+				id: "msg-1",
+				parentId: null,
+				content: "selected-preview",
+			}),
+		]);
+
+		const nonSelectedLines = [
+			sessionHeaderLine(NON_SELECTED_SESSION_ID, projectDir),
+			userMessageLine({
+				id: "msg-1",
+				parentId: null,
+				content: "non-selected-preview",
+			}),
+			...chainedUserMessages(FILLER_BEFORE_SENTINEL, "filler-before").map((_, index) => {
+				const messageIndex = index + 2;
+				return userMessageLine({
+					id: `msg-${messageIndex}`,
+					parentId: `msg-${messageIndex - 1}`,
+					content: `filler-before-${index + 1}`,
+				});
+			}),
+		];
+		const sentinelIndex = FILLER_BEFORE_SENTINEL + 2;
+		nonSelectedLines.push(
+			userMessageLine({
+				id: `msg-${sentinelIndex}`,
+				parentId: `msg-${sentinelIndex - 1}`,
+				content: SENTINEL,
+			}),
+		);
+		for (let offset = 1; offset <= FILLER_AFTER_SENTINEL; offset++) {
+			const messageIndex = sentinelIndex + offset;
+			nonSelectedLines.push(
+				userMessageLine({
+					id: `msg-${messageIndex}`,
+					parentId: `msg-${messageIndex - 1}`,
+					content: `filler-after-${offset}`,
+				}),
+			);
+		}
+		writeJsonl(join(sessionDir, `${NON_SELECTED_SESSION_ID}.jsonl`), nonSelectedLines);
+
+		// Given: a first listing that has already summarized both unchanged session files.
+		await SessionManager.list(projectDir, sessionDir);
+
+		const originalParse = JSON.parse;
+		let sentinelParseCount = 0;
+		const parseSpy = vi
+			.spyOn(JSON, "parse")
+			.mockImplementation(
+				(text: string, reviver?: (this: unknown, key: string, value: unknown) => unknown): unknown => {
+					if (text.includes(SENTINEL)) {
+						sentinelParseCount += 1;
+					}
+					return originalParse(text, reviver);
+				},
+			);
+
+		try {
+			// When: SessionManager.list repopulates picker rows for the unchanged directory.
+			const listed = await SessionManager.list(projectDir, sessionDir);
+
+			// Then: both sessions are discovered, but the non-selected sentinel is not re-parsed.
+			expect(listed).toHaveLength(2);
+			expect(new Set(listed.map((session) => session.id))).toEqual(
+				new Set([SELECTED_SESSION_ID, NON_SELECTED_SESSION_ID]),
+			);
+			expect(
+				sentinelParseCount,
+				"SessionManager.list() must not re-parse a sentinel placed deep in an unchanged non-selected session; an unchanged session file must be served from the stat-keyed summary cache",
+			).toBe(0);
+		} finally {
+			parseSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

This PR removes the main `/resume` stalls across session discovery and transcript hydration. Session files are now summarized exactly with streaming I/O and a byte-bounded stat-keyed cache, while the TUI paints the visible transcript tail before warming older components.

On a deterministic 5,000-message, 15-iteration benchmark, the final merged-head end-to-end median fell from 717.33 ms to 130.05 ms (81.9% lower) with the restored entry count, message count, and transcript digest unchanged.

## Changes

- **Exact cached session discovery**
  - Streams every JSONL record without loading the full file.
  - Preserves exact first-user text, latest session name, maximum activity timestamp, parsed record count, and full search text.
  - Reuses unchanged summaries through canonical-path + size + mtime keys.
  - Bounds retention to 4,096 entries and 64 MiB of UTF-8 transcript text; oversized summaries are returned but not retained.

- **Progressive transcript hydration**
  - Renders the visible transcript tail on the first frame.
  - Warms older message/tool components in bounded macrotask chunks, then performs one full-history repaint.
  - Contains child-render failures as visible fallback lines instead of aborting hydration.

- **Regression, benchmark, and real-PTY coverage**
  - Adds exactness, malformed/truncated JSONL, stale-cache, UTF-8 byte-budget, LRU, and progressive-render tests.
  - Adds a deterministic end-to-end resume benchmark.
  - Adds an isolated 5,000-message `/resume` node-pty/xterm QA harness with safe evidence paths and signal-safe teardown.

## QA & Evidence

- **Root static validation**
  - Command: `npm run check`
  - Result: PASS; 3,225 files checked, no fixes.

- **Focused resume regressions**
  - Command: `npm --prefix packages/coding-agent test -- test/session-summary-cache-budget.test.ts test/session-summary-exactness.test.ts test/session-discovery-search-text.test.ts test/suite/regressions/resume-load-performance.test.ts test/suite/progressive-transcript-container.test.ts`
  - Result: PASS; 5 files / 37 tests.

- **PTY harness safety**
  - Command: `node --test .agents/skills/senpi-qa/scripts/lib/tui-resume-args.test.mjs .agents/skills/senpi-qa/scripts/lib/tui-resume-pty.test.mjs .agents/skills/senpi-qa/scripts/lib/tui-resume-signal.test.mjs`
  - Result: PASS; 21/21 tests, including confirmed exit-before-cleanup, unconfirmed-exit isolation, signal idempotence, and pre-PTY cleanup.

- **Real `/resume` surface**
  - Command: `node .agents/skills/senpi-qa/scripts/tui-resume.mjs --messages 5000 --select latest --evidence local-ignore/qa-evidence/20260820-resume-performance/tui-resume`
  - Result: PASS; final marker visible in the xterm grid, valid PNG generated, submit-to-final-marker 2,875.91 ms, cleanup sequence `ptyExited -> sandboxRemoved -> authUnchanged`.
  - Artifact: `local-ignore/qa-evidence/20260820-resume-performance/tui-resume/`

- **Final benchmark**
  - Command: `node packages/coding-agent/test/benchmarks/resume-flow.bench.mjs --messages 5000 --iterations 15 --json local-ignore/qa-evidence/20260820-resume-performance/final-merged-large-session.json`
  - Result: end-to-end median 717.33 -> 130.05 ms (81.9% lower); discovery 32.11 -> 4.95 ms; first transcript render 592.58 -> 45.18 ms.
  - Semantics: digest `451e6fba64dbb501f6faf09d1ae231f24e63edef36ca9f2f51c6470dae096c35`; restored entries/messages 5,000/5,000 before and after.

- **Full repository suite**
  - Built workspace entrypoints with `npm run build`, then ran `npm test` on the final PR head.

## Risks & Residuals

- Cache growth is explicitly bounded by both entry count and UTF-8 bytes.
- Cache invalidation is based on canonical path, file size, and modification time; read/stat failures drop stale entries.
- Progressive rendering preserves the same message/tool component implementations and performs an exact full-history repaint after warming.
- The QA harness refuses sandbox removal unless PTY exit is confirmed and applies the same teardown sequence for SIGINT/SIGTERM.

## Comparison

The implementation was informed by the lazy/session-loading structure in `can1357/oh-my-pi` at commit `72000acfeb902e21816252699482887f34d1a5a4`, while preserving Senpi's exact picker metadata and full-text search contracts.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `/resume` by streaming exact session summaries with a bounded cache and by progressively hydrating the transcript. Previously resume parsed entire JSONL files and rendered the whole history before the first frame; now it reuses stat-keyed summaries and paints only the visible tail first, then warms older components. Median end-to-end fell from 717.33 ms to 130.05 ms on a 5,000-message benchmark; picker metadata and full-text search remain exact.

- Review notes
  - Discovery: `session-manager` delegates to streaming summary builders that preserve first user text, latest name, message count, max activity time, cwd/parent, and full search text. Summaries are cached by canonical path + size + mtime, bounded to 4,096 entries and 64 MiB of UTF‑8 text; oversized summaries are returned but not retained, and stat/read failures drop stale entries.
  - Rendering: `ProgressiveTranscriptContainer` renders the visible tail on the first frame, warms earlier components in bounded macrotask chunks, then triggers one exact full-history repaint. Child render failures surface as fallback lines instead of aborting hydration.
  - Scope to review: `src/core/session-discovery.ts`, `src/core/session-summary*.ts`, the removals in `session-manager.ts`, and `modes/interactive/components/progressive-transcript-container.ts`. Tests cover exactness, malformed/truncated JSONL, stale-cache behavior, UTF‑8 byte budget + LRU, progressive render, and an end‑to‑end resume benchmark; a real PTY QA harness validates `/resume` at 5,000 messages.

- Rollout
  - No migrations. Behavior, picker metadata, and search semantics are unchanged. Validate `/resume` on large sessions; 5,000 messages remain supported.

<sup>Written for commit 85ab8ba2cfb3e45cd3ce4fdec25481cea1d5ab44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

