### PR TITLE
fix: recover failing CI checks

### DIFF
--- a/.github/changes.md
+++ b/.github/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Gate the inherited model-catalog publisher behind fork opt-in (2026-08-20)
+
+### What changed
+
+- `.github/workflows/publish-model-catalog.yml` now schedules the `publish` job only when the repository variable `PI_MODEL_CATALOG_PUBLISH` is exactly `true`, in addition to its existing event and manual-publish conditions.
+
+### Why
+
+- This fork inherited upstream's R2 endpoint and bucket without either required `PI_ARTIFACTS_R2_*` secret. Every upload attempt therefore exported empty AWS credentials and failed with `Unable to locate credentials`, while generation and validation stayed green.
+- Keeping publishing opt-in makes the fork's default workflow honest: catalog generation still runs and is validated, but the unavailable upstream infrastructure no longer creates recurring default-branch failures. A maintainer can restore uploads after configuring a fork-owned R2 target, both secrets, and the opt-in variable.
+
+### Why an extension could not handle it
+
+- GitHub evaluates the job graph, repository variables, and environment secrets before any Senpi runtime or extension is available.
+
+### Expected merge conflict zones
+
+- MEDIUM: the `publish` job condition in `.github/workflows/publish-model-catalog.yml`, because upstream may continue changing its publication events or credential contract. Preserve the fork opt-in unless the fork owns a working publication target.
+
 ## Changelog-gate labels and base SHA move to env (2026-08-17)
 
 ### What changed

--- a/.github/workflows/publish-model-catalog.yml
+++ b/.github/workflows/publish-model-catalog.yml
@@ -71,7 +71,7 @@ jobs:
           retention-days: 14
 
   publish:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ vars.PI_MODEL_CATALOG_PUBLISH == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.publish)) }}
     needs: generate
     runs-on: ubuntu-latest
     environment: pi-model-upload

--- a/packages/coding-agent/src/valid-cwd.ts
+++ b/packages/coding-agent/src/valid-cwd.ts
@@ -4,10 +4,14 @@ import { homedir } from "node:os";
 // process: Node boots with the stale handle and only throws `uv_cwd` when something evaluates
 // process.cwd(). The bundled agent SDK does that during module evaluation, before any user code
 // can recover, so the guard must run before every other import - keep it dependency-free.
-try {
-	process.cwd();
-} catch {
-	const fallback = homedir();
-	process.chdir(fallback);
-	console.error(`the current working directory no longer exists; continuing from ${fallback}`);
+export function recoverValidCwd(): void {
+	try {
+		process.cwd();
+	} catch {
+		const fallback = homedir();
+		process.chdir(fallback);
+		console.error(`the current working directory no longer exists; continuing from ${fallback}`);
+	}
 }
+
+recoverValidCwd();

--- a/packages/coding-agent/test/cursor-cli-oauth/shutdown.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/shutdown.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, copyFileSync, mkdtempSync, readFileSync, rmSync, watch, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdtempSync, readFileSync, rmSync, watch, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -52,19 +52,33 @@ function liveContext(): ExtensionContext {
 	return { isIdle: () => true } as unknown as ExtensionContext;
 }
 
+/**
+ * The fixture publishes the pid file with rename(2) before its first stdout
+ * event, so the file can already exist by the time a watcher is installed -
+ * `fs.watch` then never fires and the wait wedges. Check the published state
+ * first, and let the watcher cover only the not-yet-published case.
+ */
 async function waitForPidFile(pidFile: string): Promise<number> {
+	const readPid = (): number => Number(readFileSync(pidFile, "utf8").trim());
+	if (existsSync(pidFile)) return readPid();
+
 	return new Promise<number>((resolvePid, rejectPid) => {
 		const watcher = watch(dirname(pidFile));
 		const deadline = setTimeout(() => {
 			watcher.close();
 			rejectPid(new Error("fixture did not report its grandchild"));
 		}, 5_000);
-		watcher.on("change", (_eventType, filename) => {
-			if (filename !== "grandchild.pid") return;
+		const settle = () => {
+			if (!existsSync(pidFile)) return;
 			clearTimeout(deadline);
 			watcher.close();
-			resolvePid(Number(readFileSync(pidFile, "utf8").trim()));
-		});
+			resolvePid(readPid());
+		};
+		// rename(2) surfaces as "rename" on macOS and "change" on Linux; both
+		// route through the same published-state check.
+		watcher.on("change", settle);
+		// The event can also land between the existsSync above and this listener.
+		settle();
 	});
 }
 

--- a/packages/coding-agent/test/valid-cwd-guard.test.ts
+++ b/packages/coding-agent/test/valid-cwd-guard.test.ts
@@ -11,19 +11,28 @@ import { describe, expect, test } from "vitest";
  * recover. These tests reproduce that exact shape in a child process and pin the recovery guard.
  */
 
+// Both modules are linked while the cwd is still valid: on macOS the ESM loader
+// itself wedges when a dynamic import starts after the cwd was unlinked, which
+// would hang the child instead of exercising the guard. Awaiting the imports is
+// the completion event - no polling, no sleeps - and the deletion plus the
+// guard/probe calls then run synchronously in the deleted-cwd state.
 const driverSource = `import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const guard = process.env.WITH_GUARD === "1" ? await import(process.env.GUARD_URL) : undefined;
+const probe = await import(process.env.PROBE_URL);
 const dir = mkdtempSync(join(tmpdir(), "senpi-cwd-guard-"));
 process.chdir(dir);
 rmSync(dir, { recursive: true, force: true });
-if (process.env.WITH_GUARD === "1") await import(process.env.GUARD_URL);
-await import(process.env.PROBE_URL);
+guard?.recoverValidCwd();
+probe.resolveCwdLikeBundledSdk();
 console.log("CWD_OK=" + process.cwd());
 `;
 
-const probeSource = `// Mimics the bundled agent SDK: resolves the cwd during module evaluation.
-process.cwd();
+const probeSource = `// Mimics the bundled agent SDK: resolves the cwd the moment it runs.
+export function resolveCwdLikeBundledSdk() {
+	process.cwd();
+}
 `;
 
 function runChild(withGuard: boolean) {
@@ -35,6 +44,9 @@ function runChild(withGuard: boolean) {
 		writeFileSync(probe, probeSource);
 		return spawnSync(process.execPath, [driver], {
 			encoding: "utf8",
+			// Deadlock backstop only; the driver's awaited imports are the real
+			// synchronization, so a healthy child never approaches this bound.
+			timeout: 30_000,
 			env: {
 				...process.env,
 				WITH_GUARD: withGuard ? "1" : "0",


### PR DESCRIPTION
## What was failing

- **Publish Model Catalog.** The publish job inherits R2 credentials this repository does not define, so every scheduled run failed at upload while generation and checking were healthy. Now gated on `vars.PI_MODEL_CATALOG_PUBLISH`; generation and the catalog check stay unconditional.
- **`valid-cwd-guard`.** On macOS the ESM loader wedges when a dynamic import *starts* after the cwd is unlinked, so the child hung and the unbounded `spawnSync` blocked Vitest's own timeout. `recoverValidCwd()` is now exported and the test links both modules while the directory is still valid.
- **`cursor-cli-oauth/shutdown`.** The fixture publishes its pid file with `rename(2)` before its first stdout event, so `fs.watch` never fires when the file already exists by the time the watcher is installed.

## Verification

- `npx vitest --run test/valid-cwd-guard.test.ts test/cursor-cli-oauth/shutdown.test.ts` — 11/11.
- Full `npm test` at repo root — exit 0.
- `actionlint` clean on all workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers failing CI by gating model-catalog publishing and fixing two test hangs on macOS. Previously, the publish job always ran and failed with missing R2 credentials; now it runs only when `vars.PI_MODEL_CATALOG_PUBLISH` is `true`, while generation and validation stay unconditional.

- Publishing: Set `vars.PI_MODEL_CATALOG_PUBLISH='true'` and configure `PI_ARTIFACTS_R2_*` secrets to re-enable uploads; otherwise only generate and validate the catalog.
- Valid CWD guard: Export `recoverValidCwd()` (still invoked at module load) so callers can recover after the cwd is deleted; tests preload modules to avoid macOS ESM loader wedging and add a 30s timeout backstop.
- PID watcher: Read the pid file if it already exists and handle both “change” and “rename” events to avoid missing the publish event.

<sup>Written for commit 76bcae75e86c7b13f63cf008d08e7b455876da8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

