### PR TITLE
fix: recover remaining CI gaps

### DIFF
--- a/.github/changes.md
+++ b/.github/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## Gate the inherited model-catalog publisher behind fork opt-in (2026-08-20)
+
+### What changed
+
+- `.github/workflows/publish-model-catalog.yml` now schedules the `publish` job only when the repository variable `PI_MODEL_CATALOG_PUBLISH` is exactly `true`, in addition to its existing event and manual-publish conditions.
+
+### Why
+
+- This fork inherited upstream's R2 endpoint and bucket without either required `PI_ARTIFACTS_R2_*` secret. Every upload attempt therefore exported empty AWS credentials and failed with `Unable to locate credentials`, while generation and validation stayed green.
+- Keeping publishing opt-in makes the fork's default workflow honest: catalog generation still runs and is validated, but the unavailable upstream infrastructure no longer creates recurring default-branch failures. A maintainer can restore uploads after configuring a fork-owned R2 target, both secrets, and the opt-in variable.
+
+### Why an extension could not handle it
+
+- GitHub evaluates the job graph, repository variables, and environment secrets before any Senpi runtime or extension is available.
+
+### Expected merge conflict zones
+
+- MEDIUM: the `publish` job condition in `.github/workflows/publish-model-catalog.yml`, because upstream may continue changing its publication events or credential contract. Preserve the fork opt-in unless the fork owns a working publication target.
+
 ## Changelog-gate labels and base SHA move to env (2026-08-17)
 
 ### What changed

--- a/.github/workflows/publish-model-catalog.yml
+++ b/.github/workflows/publish-model-catalog.yml
@@ -71,7 +71,7 @@ jobs:
           retention-days: 14
 
   publish:
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+    if: ${{ vars.PI_MODEL_CATALOG_PUBLISH == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_run' || (github.event_name == 'workflow_dispatch' && inputs.publish)) }}
     needs: generate
     runs-on: ubuntu-latest
     environment: pi-model-upload

--- a/packages/coding-agent/src/valid-cwd.ts
+++ b/packages/coding-agent/src/valid-cwd.ts
@@ -4,10 +4,14 @@ import { homedir } from "node:os";
 // process: Node boots with the stale handle and only throws `uv_cwd` when something evaluates
 // process.cwd(). The bundled agent SDK does that during module evaluation, before any user code
 // can recover, so the guard must run before every other import - keep it dependency-free.
-try {
-	process.cwd();
-} catch {
-	const fallback = homedir();
-	process.chdir(fallback);
-	console.error(`the current working directory no longer exists; continuing from ${fallback}`);
+export function recoverValidCwd(): void {
+	try {
+		process.cwd();
+	} catch {
+		const fallback = homedir();
+		process.chdir(fallback);
+		console.error(`the current working directory no longer exists; continuing from ${fallback}`);
+	}
 }
+
+recoverValidCwd();

--- a/packages/coding-agent/test/valid-cwd-guard.test.ts
+++ b/packages/coding-agent/test/valid-cwd-guard.test.ts
@@ -11,19 +11,28 @@ import { describe, expect, test } from "vitest";
  * recover. These tests reproduce that exact shape in a child process and pin the recovery guard.
  */
 
+// Both modules are linked while the cwd is still valid: on macOS the ESM loader
+// itself wedges when a dynamic import starts after the cwd was unlinked, which
+// would hang the child instead of exercising the guard. Awaiting the imports is
+// the completion event - no polling, no sleeps - and the deletion plus the
+// guard/probe calls then run synchronously in the deleted-cwd state.
 const driverSource = `import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+const guard = process.env.WITH_GUARD === "1" ? await import(process.env.GUARD_URL) : undefined;
+const probe = await import(process.env.PROBE_URL);
 const dir = mkdtempSync(join(tmpdir(), "senpi-cwd-guard-"));
 process.chdir(dir);
 rmSync(dir, { recursive: true, force: true });
-if (process.env.WITH_GUARD === "1") await import(process.env.GUARD_URL);
-await import(process.env.PROBE_URL);
+guard?.recoverValidCwd();
+probe.resolveCwdLikeBundledSdk();
 console.log("CWD_OK=" + process.cwd());
 `;
 
-const probeSource = `// Mimics the bundled agent SDK: resolves the cwd during module evaluation.
-process.cwd();
+const probeSource = `// Mimics the bundled agent SDK: resolves the cwd the moment it runs.
+export function resolveCwdLikeBundledSdk() {
+	process.cwd();
+}
 `;
 
 function runChild(withGuard: boolean) {
@@ -35,6 +44,9 @@ function runChild(withGuard: boolean) {
 		writeFileSync(probe, probeSource);
 		return spawnSync(process.execPath, [driver], {
 			encoding: "utf8",
+			// Deadlock backstop only; the driver's awaited imports are the real
+			// synchronization, so a healthy child never approaches this bound.
+			timeout: 30_000,
 			env: {
 				...process.env,
 				WITH_GUARD: withGuard ? "1" : "0",


### PR DESCRIPTION
Rebased onto current `main` (`20cd958c0`) and reduced to the fixes `main` still lacks.

While this work was in flight, `main` landed an equivalent guard for the cursor-CLI shutdown pid-file race, so that commit is dropped here. Verified against `main` that neither fix below is present.

## What this adds

**`ci(model-catalog)` publish opt-in** — the publish job inherits R2 credentials this repository does not define, so every scheduled run failed at the upload step while generation and checking were healthy. Requires `vars.PI_MODEL_CATALOG_PUBLISH` alongside the existing event conditions; generation and the catalog check stay unconditional.

**`fix(coding-agent)` deleted-cwd guard** — exports `recoverValidCwd()` while keeping the module-level invocation, so a caller can trigger recovery after the working directory is already gone. On macOS the ESM loader wedges when a dynamic import *starts* after the cwd is unlinked, which hung the child and blocked Vitest's own timeout through an unbounded `spawnSync`. The guard test now links both modules while the directory is still valid, invokes the preloaded functions afterwards, and carries a bounded deadlock backstop.

## Verification

- `npx vitest --run test/valid-cwd-guard.test.ts test/cursor-cli-oauth/shutdown.test.ts` — 11 passed / 0 failed.
- `actionlint` — clean on the changed workflow.

Supersedes #1047.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops failing scheduled model-catalog publishes in forks and lets `coding-agent` recover after the working directory is deleted. Previously, publishing always ran and failed without R2 creds and the cwd guard only ran at module load; now publishing runs only when explicitly opted in and `recoverValidCwd()` can be called to restore a valid cwd.

- CI: model-catalog publish opt-in
  - The `publish` job in `.github/workflows/publish-model-catalog.yml` now requires `vars.PI_MODEL_CATALOG_PUBLISH == 'true'`; generation and validation remain unconditional.
  - To re-enable publishing in a fork, set `PI_MODEL_CATALOG_PUBLISH` to `true` and provide `PI_ARTIFACTS_R2_*` secrets.

- coding-agent: deleted-cwd guard
  - Exports `recoverValidCwd()` while retaining the module-level invocation; callers can restore a valid cwd after it was unlinked (falls back to `homedir()` and logs).
  - Test preloads modules to avoid macOS ESM loader wedges and adds a 30s child-process timeout as a backstop.

<sup>Written for commit dc2a4faaa65da6a287dc6cc06bcfbd31b65af78d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

