### PR TITLE
fix(claude-sdk-oauth): terminate policy refusals

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- The `claude-sdk-oauth` lane now surfaces Claude policy refusals (for example cybersecurity refusals) as an immediate, user-visible error naming the refusal category and explanation, instead of hanging until the ~90s stream watchdog timeout. Refusals are classified as non-retryable, so they no longer enter the timeout-retry ladder or account failover ([#1052](https://github.com/code-yeongyu/senpi/pull/1052)).
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
@@ -19,6 +19,7 @@ import { hasRequestOauthToken, mergeRequestAuthEnvironment, stripManagedAuthEnvi
 import { writeConfigDirCredential } from "./config-dir-credentials.ts";
 import { classifySdkError } from "./errors.ts";
 import { runFailover } from "./failover.ts";
+import { refusalError } from "./refusal.ts";
 import type { Options, SDKMessage, SdkQuery } from "./sdk-boundary.ts";
 import type { ClaudeSdkOauthProviderSettings, ClaudeSdkOauthTokenInjection } from "./settings.ts";
 
@@ -154,6 +155,8 @@ async function prepareSlot(
 }
 
 function sdkFailure(message: SDKMessage): unknown | undefined {
+	const refusal = refusalError(message);
+	if (refusal) return refusal;
 	if (message.type === "assistant" && message.error) return message.error;
 	if (message.type === "result" && message.subtype !== "success") {
 		const errors = "errors" in message && Array.isArray(message.errors) ? (message.errors as unknown[]) : [];

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,36 @@
 # claude-sdk-oauth
 
+## 2026-08-20 - Terminate policy refusals without waiting for the stream watchdog
+
+### What changed
+
+- `refusal.ts` recognizes the pinned SDK's terminal `system/model_refusal_no_fallback` message and its documented
+  older assistant `message.stop_reason: "refusal"` shape, preserving the policy category and display explanation in a
+  typed terminal error. The fallback-retry notice remains non-terminal.
+- `auth-lane.ts` classifies that error as non-retryable before account failover, `stream.ts` terminates non-resident
+  streams immediately, and `session-registry-pump.ts` settles and closes a resident turn without reading another SDK
+  message.
+- `test/claude-sdk-oauth-refusal.test.ts` covers structured ambient and resident refusals plus the legacy assistant
+  frame, with iterators that fail if consumption proceeds past the refusal.
+
+### Why
+
+Claude policy and cybersecurity refusals can end without an SDK `result` message. The resident pump treated the
+refusal notice as an ordinary message and kept waiting for a result, so the provider watchdog fired about 90 seconds
+later and the timeout retry ladder re-sent the paid conversation. Refusal is a terminal model decision, not a
+stream-start transport failure or an account failover condition.
+
+### Why an extension could not handle it
+
+The dropped signal sits inside this builtin provider's private SDK message consumer and resident query pump. No
+external extension hook can settle the active resident turn or prevent its timeout retry after the SDK message has
+been consumed here.
+
+### Expected merge conflict zones
+
+- LOW in `auth-lane.ts` at `sdkFailure`, `stream.ts` at the SDK message loop, and `session-registry-pump.ts` at active
+  turn message handling.
+
 ## 2026-08-20 - Same-turn timeout retries fork at the pre-turn boundary (issue #723)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/refusal.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/refusal.ts
@@ -1,0 +1,38 @@
+import type { SDKMessage } from "./sdk-boundary.ts";
+
+export class ClaudeSdkRefusalError extends Error {
+	readonly name = "ClaudeSdkRefusalError";
+	readonly category: string | undefined;
+
+	constructor(content: string, category?: string) {
+		super(`Claude refused this request${category ? ` (${category})` : ""}: ${content}`);
+		this.category = category;
+	}
+}
+
+function refusalDetails(message: SDKMessage): { content: string; category?: string } | undefined {
+	if (message.type === "system" && message.subtype === "model_refusal_no_fallback") {
+		return {
+			content: message.api_refusal_explanation ?? message.content,
+			...(message.api_refusal_category ? { category: message.api_refusal_category } : {}),
+		};
+	}
+	if (message.type !== "assistant") return undefined;
+	const assistantMessage = message.message as {
+		stop_reason?: string | null;
+		stop_details?: { category?: string | null; explanation?: string | null } | null;
+	};
+	if (assistantMessage.stop_reason !== "refusal") return undefined;
+	const content = assistantMessage.stop_details?.explanation ?? "The request was blocked by policy.";
+	const category = assistantMessage.stop_details?.category ?? undefined;
+	return { content, ...(category ? { category } : {}) };
+}
+
+export function refusalError(message: SDKMessage): ClaudeSdkRefusalError | undefined {
+	const details = refusalDetails(message);
+	return details ? new ClaudeSdkRefusalError(details.content, details.category) : undefined;
+}
+
+export function isClaudeSdkRefusal(error: unknown): error is ClaudeSdkRefusalError {
+	return error instanceof ClaudeSdkRefusalError;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
@@ -1,3 +1,4 @@
+import { refusalError } from "./refusal.ts";
 import type { SDKMessage, SDKUserMessage } from "./sdk-boundary.ts";
 import { evaluateAbortOutcome } from "./session-reattach.ts";
 import {
@@ -109,7 +110,7 @@ function handleMessage(
 	registry: ClaudeSdkOauthSessionRegistry,
 	entry: ClaudeSdkOauthSessionEntry,
 	message: SDKMessage,
-): void {
+): boolean {
 	// A forked query mints a NEW session id (forkSession: true + resume): the
 	// init message carries it, and it must be persisted BEFORE any turn-state
 	// guard — otherwise subsequent reattach targets the original session and
@@ -118,18 +119,24 @@ function handleMessage(
 		if (message.session_id !== entry.sdkSessionId) entry.sdkSessionId = message.session_id;
 	}
 	const turn = currentTurn(entry);
-	if (!turn || !registry.isCurrentGeneration(entry.senpiSessionId, turn.generation)) return;
+	if (!turn || !registry.isCurrentGeneration(entry.senpiSessionId, turn.generation)) return false;
 	if (!turn.claimed) {
 		if (isReplayFor(message, turn.uuid)) claimTurn(entry, turn);
 		else if (message.type === "stream_event") bufferBeforeReplay(registry, entry, turn, message);
 		else if (message.type === "result") {
 			throw new SessionTurnAttributionError("Claude SDK OAuth result arrived before replay claim");
 		}
-		return;
+		return false;
 	}
-	if (message.type === "user" && "isReplay" in message && message.isReplay === true) return;
+	if (message.type === "user" && "isReplay" in message && message.isReplay === true) return false;
+	const refusal = refusalError(message);
+	if (refusal) {
+		failTurn(registry, entry, refusal);
+		return true;
+	}
 	if (message.type === "result") finishTurn(registry, entry, turn, message);
 	else deliver(entry, turn, message);
+	return false;
 }
 
 async function runPump(registry: ClaudeSdkOauthSessionRegistry, entry: ClaudeSdkOauthSessionEntry): Promise<void> {
@@ -141,7 +148,7 @@ async function runPump(registry: ClaudeSdkOauthSessionRegistry, entry: ClaudeSdk
 				failTurn(registry, entry, new Error("Claude SDK OAuth query ended before the active turn completed"));
 				return;
 			}
-			handleMessage(registry, entry, value);
+			if (handleMessage(registry, entry, value)) return;
 		}
 	} catch (error) {
 		failTurn(registry, entry, error instanceof Error ? error : new Error(String(error)));

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
@@ -14,6 +14,7 @@ import { defaultExecutableDeps, resolveClaudeCodeExecutable } from "./executable
 import { buildClaudeSdkOauthQueryOptions } from "./options.ts";
 import { buildPromptBlocks, buildPromptStream } from "./prompt-bridge.ts";
 import { dedupeUltraworkBlocks } from "./prompt-directive-dedupe.ts";
+import { refusalError } from "./refusal.ts";
 import { getSdkBoundary, loadClaudeAgentSdk, type SdkQueryHandle } from "./sdk-boundary.ts";
 import { type ContinuityObservation, emitContinuityObservation } from "./session-observability.ts";
 import { residentSessionMessages } from "./session-stream.ts";
@@ -151,6 +152,8 @@ export function streamClaudeSdkOauth(
 					});
 
 			for await (const message of messages) {
+				const refusal = refusalError(message);
+				if (refusal) throw refusal;
 				if (!started) {
 					stream.push({ type: "start", partial: output });
 					started = true;
@@ -212,6 +215,8 @@ export function streamClaudeSdkOauth(
 				});
 			}
 		} catch (error) {
+			// no-excuse-ok: catch
+			// Provider boundary converts every thrown SDK value into the stream error contract.
 			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 			output.errorMessage = withAuthGuidance(error, errorMessage(error));
 			stream.push({ type: "error", reason: output.stopReason, error: output });

--- a/packages/coding-agent/test/claude-sdk-oauth-refusal.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-refusal.test.ts
@@ -1,0 +1,154 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	overrideSdkBoundary,
+	resetSdkBoundary,
+	type SDKMessage,
+	type SdkQuery,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import {
+	closeSession,
+	overrideSessionRegistryBoundary,
+	resetSessionRegistryBoundary,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-registry.ts";
+import { streamClaudeSdkOauth } from "../src/core/extensions/builtin/claude-sdk-oauth/stream.ts";
+
+const model: Model<Api> = {
+	id: "claude-test",
+	name: "Claude test",
+	api: "claude-sdk-oauth",
+	provider: "claude-sdk-oauth",
+	baseUrl: "claude-sdk-oauth",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const sessionId = "resident-policy-refusal";
+
+function sdkMessage(value: unknown): SDKMessage {
+	return value as SDKMessage;
+}
+
+afterEach(() => {
+	closeSession(sessionId, "test_cleanup");
+	resetSessionRegistryBoundary();
+	resetSdkBoundary();
+});
+
+describe("Claude SDK OAuth refusals", () => {
+	it("surfaces an ambient cybersecurity refusal before reading another SDK message", async () => {
+		// Given: the non-resident ambient query emits the SDK's terminal refusal shape.
+		overrideSdkBoundary({
+			query: () => ({
+				async *[Symbol.asyncIterator]() {
+					yield sdkMessage({
+						type: "system",
+						subtype: "model_refusal_no_fallback",
+						original_model: model.id,
+						request_id: "request-refusal",
+						api_refusal_category: "cyber",
+						api_refusal_explanation: "The request was blocked by policy.",
+						content: "Claude refused this request.",
+						uuid: "refusal-message",
+						session_id: "ambient-policy-refusal",
+					});
+					throw new Error("consumer read past terminal refusal");
+				},
+				async interrupt() {},
+				close() {},
+			}),
+		});
+
+		// When: the ambient lane consumes the refusal.
+		const result = await streamClaudeSdkOauth(model, { messages: [] }).result();
+
+		// Then: refusal itself terminates the stream; no watchdog is needed.
+		expect(result).toMatchObject({
+			stopReason: "error",
+			errorMessage: "Claude refused this request (cyber): The request was blocked by policy.",
+		});
+	});
+
+	it("surfaces the legacy assistant refusal frame", async () => {
+		// Given: older CLIs expose refusal only on the assistant API message.
+		overrideSdkBoundary({
+			query: () => ({
+				async *[Symbol.asyncIterator]() {
+					yield sdkMessage({
+						type: "assistant",
+						message: {
+							id: "assistant-refusal",
+							type: "message",
+							role: "assistant",
+							content: [],
+							stop_reason: "refusal",
+							stop_details: { category: "cyber", explanation: "The request was blocked by policy." },
+						},
+						parent_tool_use_id: null,
+						uuid: "assistant-refusal",
+						session_id: "legacy-policy-refusal",
+					});
+					throw new Error("consumer read past terminal refusal");
+				},
+				async interrupt() {},
+				close() {},
+			}),
+		});
+
+		// When: the lane consumes the assistant refusal frame.
+		const result = await streamClaudeSdkOauth(model, { messages: [] }).result();
+
+		// Then: the legacy shape produces the same terminal refusal outcome.
+		expect(result).toMatchObject({
+			stopReason: "error",
+			errorMessage: "Claude refused this request (cyber): The request was blocked by policy.",
+		});
+	});
+
+	it("surfaces a resident cybersecurity refusal before reading another SDK message", async () => {
+		// Given: SDK 0.3.220's structured no-fallback refusal follows the replay claim.
+		const query: SdkQuery = ({ prompt }) => {
+			if (typeof prompt === "string") throw new Error("Expected resident streaming input");
+			return {
+				async *[Symbol.asyncIterator]() {
+					const submitted = await prompt[Symbol.asyncIterator]().next();
+					if (submitted.done) throw new Error("Expected submitted turn");
+					yield sdkMessage({ ...submitted.value, isReplay: true });
+					yield sdkMessage({
+						type: "system",
+						subtype: "model_refusal_no_fallback",
+						original_model: model.id,
+						request_id: "request-refusal",
+						api_refusal_category: "cyber",
+						api_refusal_explanation: "The request was blocked by policy.",
+						refused_user_message_uuid: submitted.value.uuid,
+						content: "Claude refused this request.",
+						uuid: "refusal-message",
+						session_id: sessionId,
+					});
+					throw new Error("consumer read past terminal refusal");
+				},
+				async interrupt() {},
+				close() {},
+			};
+		};
+		overrideSdkBoundary({ query });
+		overrideSessionRegistryBoundary({ queryFactory: query });
+
+		// When: the resident lane consumes the refusal.
+		const result = await streamClaudeSdkOauth(
+			model,
+			{ messages: [{ role: "user", content: "security-sensitive request", timestamp: 1 }] },
+			{ sessionId, streamKind: "main" },
+		).result();
+
+		// Then: refusal itself terminates the stream; the pump never asks for another message.
+		expect(result).toMatchObject({
+			stopReason: "error",
+			errorMessage: "Claude refused this request (cyber): The request was blocked by policy.",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the Claude SDK OAuth lane hanging until the provider stream watchdog after Claude rejects a request on policy grounds.

Discord report from shrimpwtf (2026-08-20):

> "found out what it is. cybersecurity refusal is not handled for in oauth sdk so it times out."

## Root cause

The pinned `@anthropic-ai/claude-agent-sdk@0.3.220` emits a terminal `system` message with subtype `model_refusal_no_fallback` when `stop_reason: "refusal"` has no fallback retry. Its type also documents the older assistant-frame counterpart where `message.stop_reason === "refusal"`.

The non-resident stream loop ignored both shapes. More importantly, the resident session pump delivered `model_refusal_no_fallback` as an ordinary message and continued awaiting a `result` that does not arrive. The provider watchdog then converted the stalled turn into a timeout, allowing the timeout retry ladder to resend the conversation.

## Fix

- Recognize the structured no-fallback refusal and documented legacy assistant refusal frame in one typed boundary.
- Surface a clear terminal error such as `Claude refused this request (cyber): ...`.
- Stop resident query consumption immediately after the refusal and close the failed session generation.
- Classify refusal as non-retryable, so it is neither account failover nor a retryable stream-start failure.
- Leave `model_refusal_fallback` non-terminal because that shape means the SDK is actively retrying on its configured fallback model.

## Test evidence

- RED: the resident regression reached the sentinel failure `consumer read past terminal refusal` instead of settling on the refusal.
- GREEN targeted: `npm --prefix packages/coding-agent exec vitest -- --run test/claude-sdk-oauth-refusal.test.ts` — 3/3 passed.
- Lane suite: all 62 claude-sdk-oauth test files passed when run in isolated Vitest invocations (453 passed, 3 skipped total).
- Type/static gate: `npm run check` passed, including `tsc --noEmit`, lock checks, and browser smoke.
- Real CLI QA: `mock-loop.mjs --self-test` — 48/48 passed; receipt at `local-ignore/qa-evidence/20260820-claude-sdk-oauth-refusal/mock-loop.txt` (gitignored).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Terminates `claude-sdk-oauth` policy refusals immediately and returns a clear terminal error. Previously, refusals hung until the stream watchdog timed out and the retry ladder resent the conversation.

- Recognizes SDK `system/model_refusal_no_fallback` and legacy assistant `stop_reason: "refusal"` in one boundary and throws `ClaudeSdkRefusalError` with preserved category/explanation.
- Stops consuming messages on refusal in both non-resident (`streamClaudeSdkOauth`) and resident session pumps, and closes the active generation.
- Classifies refusal as non-retryable: no account failover and no stream-start retry. Keeps `model_refusal_fallback` non-terminal because the SDK already retries on its fallback.
- Touches: `auth-lane.ts` (classify early), `session-registry-pump.ts` (fail turn and stop), `stream.ts` (terminate immediately), new `refusal.ts`; tests cover ambient, resident, and legacy shapes. Updates `changes.md` and `CHANGELOG.md`.

<sup>Written for commit 356001ea71853617194608d4eee3ea33b094b8ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

