### PR TITLE
feat(coding-agent): render optimistic pending user echo

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Interactive submissions now render a local pending user echo immediately, reconcile it with the canonical `message_start`, and remove it for rejected or extension-handled input without writing render-only state to session history.
 - The `claude-sdk-oauth` lane now surfaces Claude policy refusals (for example cybersecurity refusals) as an immediate, user-visible error naming the refusal category and explanation, instead of hanging until the ~90s stream watchdog timeout. Refusals are classified as non-retryable, so they no longer enter the timeout-retry ladder or account failover ([#1052](https://github.com/code-yeongyu/senpi/pull/1052)).
 
 ### Added

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## 2026-08-21 - Optimistic pending user echo
+
+### What changed
+
+- Interactive Enter, streaming steer, follow-up, extension-command, and compaction-queued submissions now create a uniquely identified TUI-local user bubble before prompt admission begins.
+- Canonical user `message_start` replaces the oldest matching pending bubble in place; `handled`, failed preflight, and thrown prompt paths remove it, while `queued` and `started` keep it until canonical delivery.
+- Focused lifecycle coverage guards immediate paint, exactly-once replacement, handled/rejected removal, FIFO queued reconciliation, and render-only persistence behavior.
+
+### Why
+
+- The editor cleared immediately but the user bubble waited behind settled-work, extension input, auth/model, compaction, and admission gates, producing a measured 0.45s median perceived submit delay.
+
+### Why an extension could not handle it
+
+- The pending artifact must exist before AgentSession admission and must replace the built-in canonical user renderer without entering extension messages or persisted session history. Only the interactive TUI owns that render lifecycle.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` submit handlers, user `message_start` rendering, and compaction queue transfer wiring.
+- `packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts` if upstream changes the TUI queue record shape.
+
 ## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,26 +1,5 @@
 # changes
 
-## 2026-08-21 - Optimistic pending user echo
-
-### What changed
-
-- Interactive Enter, streaming steer, follow-up, extension-command, and compaction-queued submissions now create a uniquely identified TUI-local user bubble before prompt admission begins.
-- Canonical user `message_start` replaces the oldest matching pending bubble in place; `handled`, failed preflight, and thrown prompt paths remove it, while `queued` and `started` keep it until canonical delivery.
-- Focused lifecycle coverage guards immediate paint, exactly-once replacement, handled/rejected removal, FIFO queued reconciliation, and render-only persistence behavior.
-
-### Why
-
-- The editor cleared immediately but the user bubble waited behind settled-work, extension input, auth/model, compaction, and admission gates, producing a measured 0.45s median perceived submit delay.
-
-### Why an extension could not handle it
-
-- The pending artifact must exist before AgentSession admission and must replace the built-in canonical user renderer without entering extension messages or persisted session history. Only the interactive TUI owns that render lifecycle.
-
-### Expected merge conflict zones
-
-- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` submit handlers, user `message_start` rendering, and compaction queue transfer wiring.
-- `packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts` if upstream changes the TUI queue record shape.
-
 ## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## 2026-08-21 - Optimistic pending user echo
+
+### What changed
+
+- `interactive-mode.ts`: Enter submissions now paint a TUI-local pending user bubble immediately, mark it eligible only after its own `promptDisposition` is `queued` or `started`, and replace it only when an eligible canonical user `message_start` arrives. Foreign user events are appended normally. Rejected and handled inputs unpaint their own pending bubble, and compaction queue cleanup removes only the queue records it owns.
+- `compaction-queue-transfer.ts`: queued compaction records carry the TUI-local pending echo id without entering session messages or persistence.
+- `packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts`: covers foreign user events, immediate rendering, exactly-once replacement, rejection/handled cleanup, FIFO queue reconciliation, and render-only persistence.
+
+### Why
+
+- Interactive input previously waited behind session admission gates before its user bubble appeared, creating a measured 0.45s p50 perceived submit delay. The TUI must distinguish its own accepted prompt lifecycle from extension and RPC prompts that can emit user events into the same session.
+
+### Why an extension could not handle it
+
+- Pending records must be created before AgentSession admission and reconciled with private interactive rendering at canonical `message_start`; extensions cannot identify or replace these built-in TUI components without persisting a fake message.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` submit handlers, user `message_start` reconciliation, and compaction queue reset/transfer paths.
+- `packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts` pending echo metadata.
+
 ## 2026-08-20 - Resumed transcripts paint the visible tail first
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
+++ b/packages/coding-agent/src/modes/interactive/compaction-queue-transfer.ts
@@ -3,6 +3,8 @@ export type CompactionQueuedMessage = {
 	readonly mode: "steer" | "followUp";
 	/** Global recovery order reserved when the TUI accepts the input. */
 	readonly enqueueOrder?: number;
+	/** TUI-local render record; never enters AgentSession or persistence. */
+	readonly pendingEchoId?: string;
 };
 
 export type PromptDisposition = "handled" | "queued" | "started";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -496,6 +496,7 @@ type OptimisticUserEchoRenderHandle = {
 type OptimisticUserEchoRecord = {
 	readonly id: string;
 	readonly handle: OptimisticUserEchoRenderHandle;
+	eligibleForCanonicalStart: boolean;
 };
 
 /** Coordinates render-only user echoes with AgentSession's canonical input lifecycle. */
@@ -510,7 +511,7 @@ export class OptimisticUserEchoController {
 
 	begin(text: string): string {
 		const id = `pending-user-${++this.nextId}`;
-		this.pending.push({ id, handle: this.render(text) });
+		this.pending.push({ id, handle: this.render(text), eligibleForCanonicalStart: false });
 		return id;
 	}
 
@@ -523,7 +524,10 @@ export class OptimisticUserEchoController {
 				if (!success) this.reject(id);
 			},
 			promptDisposition: (disposition) => {
+				const record = this.pending.find((candidate) => candidate.id === id);
+				if (!record) return;
 				if (disposition === "handled") this.reject(id);
+				else record.eligibleForCanonicalStart = true;
 			},
 		};
 	}
@@ -535,13 +539,14 @@ export class OptimisticUserEchoController {
 		record?.handle.remove();
 	}
 
-	clear(): void {
-		for (const record of this.pending) record.handle.remove();
-		this.pending.length = 0;
+	remove(id: string): void {
+		this.reject(id);
 	}
 
 	replaceNext(message: AgentMessage): boolean {
-		const record = this.pending.shift();
+		const first = this.pending[0];
+		if (!first?.eligibleForCanonicalStart) return false;
+		const [record] = this.pending.splice(0, 1);
 		if (!record) return false;
 		record.handle.replace(message);
 		return true;
@@ -5840,7 +5845,9 @@ export class InteractiveMode {
 		this.compactionInFlightMessages = [];
 		this.compactionTransferAbortControllers.clear();
 		this.compactionQueuedMessages = [];
-		this.optimisticUserEchoes?.clear();
+		for (const message of compactionMessages) {
+			if (message.pendingEchoId) this.optimisticUserEchoes?.remove(message.pendingEchoId);
+		}
 		const fallbackOrder = nativeMessages.reduce((maximum, message) => Math.max(maximum, message.enqueueOrder), 0);
 		const ordered = [
 			...nativeMessages,

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -488,10 +488,71 @@ function formatLoginProviderCompletionDescription(provider: LoginProviderComplet
 	return provider.name === provider.id ? authTypes : `${provider.name} · ${authTypes}`;
 }
 
+type OptimisticUserEchoRenderHandle = {
+	replace(message: AgentMessage): void;
+	remove(): void;
+};
+
+type OptimisticUserEchoRecord = {
+	readonly id: string;
+	readonly handle: OptimisticUserEchoRenderHandle;
+};
+
+/** Coordinates render-only user echoes with AgentSession's canonical input lifecycle. */
+export class OptimisticUserEchoController {
+	private nextId = 0;
+	private readonly pending: OptimisticUserEchoRecord[] = [];
+	private readonly render: (text: string) => OptimisticUserEchoRenderHandle;
+
+	constructor(render: (text: string) => OptimisticUserEchoRenderHandle) {
+		this.render = render;
+	}
+
+	begin(text: string): string {
+		const id = `pending-user-${++this.nextId}`;
+		this.pending.push({ id, handle: this.render(text) });
+		return id;
+	}
+
+	promptOptions(id: string): {
+		preflightResult: (success: boolean) => void;
+		promptDisposition: (disposition: "handled" | "queued" | "started") => void;
+	} {
+		return {
+			preflightResult: (success) => {
+				if (!success) this.reject(id);
+			},
+			promptDisposition: (disposition) => {
+				if (disposition === "handled") this.reject(id);
+			},
+		};
+	}
+
+	reject(id: string): void {
+		const index = this.pending.findIndex((record) => record.id === id);
+		if (index === -1) return;
+		const [record] = this.pending.splice(index, 1);
+		record?.handle.remove();
+	}
+
+	clear(): void {
+		for (const record of this.pending) record.handle.remove();
+		this.pending.length = 0;
+	}
+
+	replaceNext(message: AgentMessage): boolean {
+		const record = this.pending.shift();
+		if (!record) return false;
+		record.handle.replace(message);
+		return true;
+	}
+}
+
 /** A user submission: editor text plus the images resolved from its `[Image #N]` markers. */
 interface InteractiveUserInput {
 	text: string;
 	images?: ImageContent[];
+	pendingEchoId: string;
 }
 
 /** Local copy of pi-tui's image-marker pattern so submission scanning never mutates a shared /g regex. */
@@ -713,6 +774,7 @@ export class InteractiveMode {
 	private isInitialized = false;
 	private onInputCallback?: (input: InteractiveUserInput) => void;
 	private pendingUserInputs: InteractiveUserInput[] = [];
+	private readonly optimisticUserEchoes: OptimisticUserEchoController;
 	/**
 	 * Clipboard images pasted into the composer, keyed by their visible
 	 * `[Image #N]` marker number. The editor stores marker ids only, so these
@@ -872,6 +934,7 @@ export class InteractiveMode {
 
 	constructor(runtimeHost: AgentSessionRuntime, options: InteractiveModeOptions = {}) {
 		this.runtimeHost = runtimeHost;
+		this.optimisticUserEchoes = new OptimisticUserEchoController((text) => this.renderPendingUserEcho(text));
 		const tuiMode = options.tuiMode ?? this.settingsManager.getTuiMode();
 		this.options = { ...options, tuiMode };
 		this.chrome = options.chrome === "grok" ? new GrokChrome() : options.chrome;
@@ -1557,8 +1620,10 @@ export class InteractiveMode {
 				await this.session.prompt(userInput.text, {
 					streamingBehavior: "steer",
 					...(userInput.images ? { images: userInput.images } : {}),
+					...this.optimisticUserEchoes.promptOptions(userInput.pendingEchoId),
 				});
 			} catch (error: unknown) {
+				this.optimisticUserEchoes.reject(userInput.pendingEchoId);
 				const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 				this.showError(errorMessage);
 			}
@@ -4040,7 +4105,13 @@ export class InteractiveMode {
 			if (this.isExtensionCommand(text)) {
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.session.prompt(text);
+				const pendingEchoId = this.optimisticUserEchoes.begin(text);
+				try {
+					await this.session.prompt(text, this.optimisticUserEchoes.promptOptions(pendingEchoId));
+				} catch (error) {
+					this.optimisticUserEchoes.reject(pendingEchoId);
+					throw error;
+				}
 				return;
 			}
 
@@ -4075,7 +4146,13 @@ export class InteractiveMode {
 				if (this.isExtensionCommand(text)) {
 					this.editor.addToHistory?.(text);
 					this.editor.setText("");
-					await this.session.prompt(text);
+					const pendingEchoId = this.optimisticUserEchoes.begin(text);
+					try {
+						await this.session.prompt(text, this.optimisticUserEchoes.promptOptions(pendingEchoId));
+					} catch (error) {
+						this.optimisticUserEchoes.reject(pendingEchoId);
+						throw error;
+					}
 				} else {
 					this.queueCompactionSubmission(text, "steer");
 				}
@@ -4093,10 +4170,17 @@ export class InteractiveMode {
 				const images = preResolvedImages ?? this.takeSubmissionImages(text);
 				this.editor.addToHistory?.(text);
 				this.editor.setText("");
-				await this.session.prompt(text, {
-					streamingBehavior: "steer",
-					...(images.length > 0 ? { images } : {}),
-				});
+				const pendingEchoId = this.optimisticUserEchoes.begin(text);
+				try {
+					await this.session.prompt(text, {
+						streamingBehavior: "steer",
+						...(images.length > 0 ? { images } : {}),
+						...this.optimisticUserEchoes.promptOptions(pendingEchoId),
+					});
+				} catch (error) {
+					this.optimisticUserEchoes.reject(pendingEchoId);
+					throw error;
+				}
 				this.updatePendingMessagesDisplay();
 				this.ui.requestRender();
 				return;
@@ -4107,7 +4191,9 @@ export class InteractiveMode {
 			this.flushPendingBashComponents();
 
 			const images = preResolvedImages ?? this.takeSubmissionImages(text);
-			const submission: InteractiveUserInput = images.length > 0 ? { text, images } : { text };
+			const pendingEchoId = this.optimisticUserEchoes.begin(text);
+			const submission: InteractiveUserInput =
+				images.length > 0 ? { text, images, pendingEchoId } : { text, pendingEchoId };
 			if (this.onInputCallback) {
 				this.onInputCallback(submission);
 			} else {
@@ -4208,7 +4294,7 @@ export class InteractiveMode {
 					this.addMessageToChat(event.message);
 					this.ui.requestRender();
 				} else if (event.message.role === "user") {
-					this.addMessageToChat(event.message);
+					if (!this.optimisticUserEchoes.replaceNext(event.message)) this.addMessageToChat(event.message);
 					this.updatePendingMessagesDisplay();
 					this.ui.requestRender();
 				} else if (event.message.role === "assistant") {
@@ -4789,6 +4875,42 @@ export class InteractiveMode {
 		}
 
 		this.chatContainer.addChild(component);
+	}
+
+	private renderPendingUserEcho(text: string): OptimisticUserEchoRenderHandle {
+		const spacer = this.chatContainer.children.length > 0 ? new Spacer(1) : undefined;
+		if (spacer) this.chatContainer.addChild(spacer);
+		const component = new UserMessageComponent(
+			text,
+			this.getMarkdownThemeWithSettings(),
+			this.outputPad,
+			this.getMarkdownTransformers(),
+		);
+		this.chatContainer.addChild(component);
+		this.ui.requestRender();
+
+		const removePending = (): number => {
+			const componentIndex = this.chatContainer.children.indexOf(component);
+			const insertionIndex = spacer ? this.chatContainer.children.indexOf(spacer) : componentIndex;
+			if (spacer) this.chatContainer.removeChild(spacer);
+			this.chatContainer.removeChild(component);
+			return insertionIndex;
+		};
+		return {
+			replace: (message) => {
+				const insertionIndex = removePending();
+				const appendIndex = this.chatContainer.children.length;
+				this.addMessageToChat(message);
+				const canonicalChildren = this.chatContainer.children.splice(appendIndex);
+				if (!spacer && canonicalChildren[0] instanceof Spacer) canonicalChildren.shift()?.dispose?.();
+				this.chatContainer.children.splice(insertionIndex, 0, ...canonicalChildren);
+				this.ui.requestRender();
+			},
+			remove: () => {
+				removePending();
+				this.ui.requestRender();
+			},
+		};
 	}
 
 	private addMessageToChat(message: AgentMessage, options?: { populateHistory?: boolean }): void {
@@ -5430,10 +5552,17 @@ export class InteractiveMode {
 		if (this.session.isStreaming) {
 			this.editor.addToHistory?.(text);
 			this.editor.setText("");
-			await this.session.prompt(text, {
-				streamingBehavior: "followUp",
-				...(images.length > 0 ? { images } : {}),
-			});
+			const pendingEchoId = this.optimisticUserEchoes.begin(text);
+			try {
+				await this.session.prompt(text, {
+					streamingBehavior: "followUp",
+					...(images.length > 0 ? { images } : {}),
+					...this.optimisticUserEchoes.promptOptions(pendingEchoId),
+				});
+			} catch (error) {
+				this.optimisticUserEchoes.reject(pendingEchoId);
+				throw error;
+			}
 			this.updatePendingMessagesDisplay();
 			this.ui.requestRender();
 		}
@@ -5711,6 +5840,7 @@ export class InteractiveMode {
 		this.compactionInFlightMessages = [];
 		this.compactionTransferAbortControllers.clear();
 		this.compactionQueuedMessages = [];
+		this.optimisticUserEchoes?.clear();
 		const fallbackOrder = nativeMessages.reduce((maximum, message) => Math.max(maximum, message.enqueueOrder), 0);
 		const ordered = [
 			...nativeMessages,
@@ -5805,10 +5935,12 @@ export class InteractiveMode {
 	}
 
 	private queueCompactionMessage(text: string, mode: "steer" | "followUp", droppedImageCount = 0): void {
+		const pendingEchoId = this.optimisticUserEchoes.begin(text);
 		this.compactionQueuedMessages.push({
 			text,
 			mode,
 			enqueueOrder: this.session.reserveQueuedInputOrder(),
+			pendingEchoId,
 		});
 		this.getSessionLogger().debug("compaction_queue_enqueue", {
 			mode,
@@ -5900,16 +6032,37 @@ export class InteractiveMode {
 						return restorable.length;
 					},
 					isCommand: (message) => this.isExtensionCommand(message.text),
-					deliverCommand: (message) => session.prompt(message.text),
+					deliverCommand: async (message) => {
+						const pendingEchoId = message.pendingEchoId;
+						try {
+							await session.prompt(
+								message.text,
+								pendingEchoId ? this.optimisticUserEchoes.promptOptions(pendingEchoId) : undefined,
+							);
+						} catch (error) {
+							if (pendingEchoId) this.optimisticUserEchoes.reject(pendingEchoId);
+							throw error;
+						}
+					},
 					deliverFirstPrompt: (message) =>
 						waitForPromptDisposition(
-							(preflightResult, promptDisposition) =>
-								session.prompt(message.text, {
+							(preflightResult, promptDisposition) => {
+								const echoOptions = message.pendingEchoId
+									? this.optimisticUserEchoes.promptOptions(message.pendingEchoId)
+									: undefined;
+								return session.prompt(message.text, {
 									streamingBehavior: message.mode,
-									preflightResult,
-									promptDisposition,
+									preflightResult: (success) => {
+										echoOptions?.preflightResult(success);
+										preflightResult(success);
+									},
+									promptDisposition: (disposition) => {
+										echoOptions?.promptDisposition(disposition);
+										promptDisposition(disposition);
+									},
 									signal: this.compactionTransferAbortControllers.get(message)?.signal,
-								}),
+								});
+							},
 							(error) => {
 								if ((this.compactionQueueGeneration ?? 0) !== generation || this.session !== session) return;
 								this.showError(

--- a/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction-queue-session-rebind.test.ts
@@ -111,7 +111,7 @@ it("starts a replacement-session flush while an old transfer remains pending", a
 
 	try {
 		await new Promise<void>((resolve) => setImmediate(resolve));
-		expect(replacementPrompt).toHaveBeenCalledWith(replacementMessage.text);
+		expect(replacementPrompt).toHaveBeenCalledWith(replacementMessage.text, undefined);
 		const replacementTail = context.compactionQueueFlushTail;
 		expect(replacementTail).toBeDefined();
 

--- a/packages/coding-agent/test/interactive-mode-exit-command.test.ts
+++ b/packages/coding-agent/test/interactive-mode-exit-command.test.ts
@@ -8,6 +8,14 @@ vi.mock("../src/utils/version-check.ts", () => ({
 	getReleaseChangelogUrl: vi.fn((version: string) => `https://example.invalid/releases/${version}`),
 }));
 
+function createEchoControllerStub() {
+	return {
+		begin: vi.fn(() => "pending-test"),
+		promptOptions: vi.fn(() => ({ preflightResult: vi.fn(), promptDisposition: vi.fn() })),
+		reject: vi.fn(),
+	};
+}
+
 type SubmitContext = {
 	defaultEditor: { onSubmit?: (text: string) => void | Promise<void> };
 	editor: {
@@ -27,6 +35,7 @@ type SubmitContext = {
 	onInputCallback?: (input: { text: string; images?: unknown[] }) => void;
 	pendingUserInputs: { text: string; images?: unknown[] }[];
 	pendingImages: Map<number, unknown>;
+	optimisticUserEchoes: ReturnType<typeof createEchoControllerStub>;
 	takeSubmissionImages: (submittedText: string) => unknown[];
 	shutdown: () => Promise<void>;
 };
@@ -57,6 +66,7 @@ function createSubmitContext(): SubmitContext {
 		lastEditorText: "",
 		pendingUserInputs: [],
 		pendingImages: new Map(),
+		optimisticUserEchoes: createEchoControllerStub(),
 		takeSubmissionImages: vi.fn(() => []),
 		shutdown: vi.fn(async () => {}),
 	};

--- a/packages/coding-agent/test/interactive-mode-image-submission.test.ts
+++ b/packages/coding-agent/test/interactive-mode-image-submission.test.ts
@@ -44,7 +44,16 @@ import { getEditorTheme, initTheme } from "../src/modes/interactive/theme/theme.
 import { processImage } from "../src/utils/image-process.ts";
 
 /** The widened submission-channel payload: text plus images resolved from markers. */
-type UserSubmission = { text: string; images?: ImageContent[] };
+type UserSubmission = { text: string; images?: ImageContent[]; pendingEchoId: string };
+
+function createEchoControllerStub() {
+	let nextId = 0;
+	return {
+		begin: vi.fn(() => `pending-test-${++nextId}`),
+		promptOptions: vi.fn(() => ({ preflightResult: vi.fn(), promptDisposition: vi.fn() })),
+		reject: vi.fn(),
+	};
+}
 
 type MockFn = ReturnType<typeof vi.fn>;
 
@@ -74,6 +83,7 @@ interface ModeContext {
 	editor: FakeEditor;
 	session: FakeSession;
 	pendingImages: Map<number, ImageContent>;
+	optimisticUserEchoes: ReturnType<typeof createEchoControllerStub>;
 	compactionQueuedMessages: { text: string; mode: string; enqueueOrder: number }[];
 	pendingUserInputs: UserSubmission[];
 	onInputCallback?: (input: UserSubmission) => void;
@@ -180,6 +190,7 @@ function createModeContext(): ModeContext {
 			editor,
 			session,
 			pendingImages: new Map<number, ImageContent>(),
+			optimisticUserEchoes: createEchoControllerStub(),
 			compactionQueuedMessages: [],
 			pendingUserInputs: [] as UserSubmission[],
 			onInputCallback: undefined,
@@ -361,7 +372,13 @@ describe("InteractiveMode image submission - normal channel", () => {
 		expect(context.session.prompt).toHaveBeenCalledTimes(1);
 		const [promptText, promptOptions] = context.session.prompt.mock.calls[0] as [string, Record<string, unknown>];
 		expect(promptText).toBe("just text");
-		expect(promptOptions).toEqual({ streamingBehavior: "steer" });
+		expect(promptOptions).toEqual(
+			expect.objectContaining({
+				streamingBehavior: "steer",
+				preflightResult: expect.any(Function),
+				promptDisposition: expect.any(Function),
+			}),
+		);
 	});
 
 	it("resolves markers into the widened getUserInput payload and clears pendingImages", async () => {
@@ -376,6 +393,7 @@ describe("InteractiveMode image submission - normal channel", () => {
 		await expect(userInput).resolves.toEqual({
 			text: "look at [Image #1]",
 			images: [pending],
+			pendingEchoId: "pending-test-1",
 		});
 		expect(context.pendingImages.size).toBe(0);
 	});
@@ -383,11 +401,12 @@ describe("InteractiveMode image submission - normal channel", () => {
 	it("returns queued submissions (with images) from getUserInput before installing a callback", async () => {
 		const queued = image("cXVldWVk");
 		const context = createModeContext();
-		context.pendingUserInputs.push({ text: "queued [Image #1]", images: [queued] });
+		context.pendingUserInputs.push({ text: "queued [Image #1]", images: [queued], pendingEchoId: "pending-test-1" });
 
 		await expect(proto.getUserInput.call(context)).resolves.toEqual({
 			text: "queued [Image #1]",
 			images: [queued],
+			pendingEchoId: "pending-test-1",
 		});
 		expect(context.onInputCallback).toBeUndefined();
 	});
@@ -442,7 +461,7 @@ describe("InteractiveMode image submission - normal channel", () => {
 		const userInput = beginUserInput(context);
 		await submit(context, "all markers deleted");
 
-		await expect(userInput).resolves.toEqual({ text: "all markers deleted" });
+		await expect(userInput).resolves.toEqual({ text: "all markers deleted", pendingEchoId: "pending-test-1" });
 	});
 
 	it("passes plain text through with no images key", async () => {
@@ -452,7 +471,10 @@ describe("InteractiveMode image submission - normal channel", () => {
 		const userInput = beginUserInput(context);
 		await submit(context, "hello without attachments");
 
-		await expect(userInput).resolves.toEqual({ text: "hello without attachments" });
+		await expect(userInput).resolves.toEqual({
+			text: "hello without attachments",
+			pendingEchoId: "pending-test-1",
+		});
 	});
 
 	it("lets a hand-typed [Image #1] with no pending entry pass through untouched", async () => {
@@ -462,7 +484,7 @@ describe("InteractiveMode image submission - normal channel", () => {
 		const userInput = beginUserInput(context);
 		await submit(context, "look at [Image #1]");
 
-		await expect(userInput).resolves.toEqual({ text: "look at [Image #1]" });
+		await expect(userInput).resolves.toEqual({ text: "look at [Image #1]", pendingEchoId: "pending-test-1" });
 	});
 
 	it("lets a hand-typed marker with no pending entry consume no slot before a real one", async () => {
@@ -481,6 +503,7 @@ describe("InteractiveMode image submission - normal channel", () => {
 		await expect(userInput).resolves.toEqual({
 			text: "typed [Image #2] by hand then pasted [Image #1]",
 			images: [pasted],
+			pendingEchoId: "pending-test-1",
 		});
 	});
 
@@ -562,6 +585,7 @@ describe("InteractiveMode image submission - Alt+Enter followUp", () => {
 		await expect(userInput).resolves.toEqual({
 			text: "describe [Image #1]",
 			images: [pending],
+			pendingEchoId: "pending-test-1",
 		});
 		expect(context.editor.setText).toHaveBeenCalledWith("");
 		expect(context.pendingImages.size).toBe(0);
@@ -582,7 +606,10 @@ describe("InteractiveMode image submission - Alt+Enter followUp", () => {
 
 		const userInput = beginUserInput(context);
 		await submit(context, "next ordinary message");
-		await expect(userInput).resolves.toEqual({ text: "next ordinary message" });
+		await expect(userInput).resolves.toEqual({
+			text: "next ordinary message",
+			pendingEchoId: "pending-test-1",
+		});
 	});
 
 	it("leaves no stale images on the next ordinary submission after Alt+Enter on a bash command", async () => {
@@ -596,7 +623,10 @@ describe("InteractiveMode image submission - Alt+Enter followUp", () => {
 
 		const userInput = beginUserInput(context);
 		await submit(context, "next ordinary message");
-		await expect(userInput).resolves.toEqual({ text: "next ordinary message" });
+		await expect(userInput).resolves.toEqual({
+			text: "next ordinary message",
+			pendingEchoId: "pending-test-1",
+		});
 	});
 });
 

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -6,6 +6,16 @@ vi.mock("../src/utils/version-check.ts", () => ({
 	getReleaseChangelogUrl: vi.fn((version: string) => `https://example.invalid/releases/${version}`),
 }));
 
+type EchoControllerStub = ReturnType<typeof createEchoControllerStub>;
+
+function createEchoControllerStub() {
+	return {
+		begin: vi.fn(() => "pending-test"),
+		promptOptions: vi.fn(() => ({ preflightResult: vi.fn(), promptDisposition: vi.fn() })),
+		reject: vi.fn(),
+	};
+}
+
 type SubmitContext = {
 	defaultEditor: { onSubmit?: (text: string) => void | Promise<void> };
 	editor: {
@@ -22,15 +32,16 @@ type SubmitContext = {
 	hideShortcutOverlay: () => void;
 	isExtensionCommand: (text: string) => boolean;
 	lastEditorText: string;
-	onInputCallback?: (input: { text: string; images?: unknown[] }) => void;
-	pendingUserInputs: { text: string; images?: unknown[] }[];
+	onInputCallback?: (input: { text: string; images?: unknown[]; pendingEchoId: string }) => void;
+	pendingUserInputs: { text: string; images?: unknown[]; pendingEchoId: string }[];
 	pendingImages: Map<number, unknown>;
+	optimisticUserEchoes: EchoControllerStub;
 	takeSubmissionImages: (submittedText: string) => unknown[];
 };
 
 type InputContext = {
-	onInputCallback?: (input: { text: string; images?: unknown[] }) => void;
-	pendingUserInputs: { text: string; images?: unknown[] }[];
+	onInputCallback?: (input: { text: string; images?: unknown[]; pendingEchoId?: string }) => void;
+	pendingUserInputs: { text: string; images?: unknown[]; pendingEchoId?: string }[];
 };
 
 type StartupSubmitContext = {
@@ -39,6 +50,7 @@ type StartupSubmitContext = {
 };
 
 type RunContext = {
+	optimisticUserEchoes: EchoControllerStub;
 	init: () => Promise<void>;
 	version: string;
 	options: Record<string, never>;
@@ -50,7 +62,7 @@ type RunContext = {
 	checkForPackageUpdates: () => Promise<string[]>;
 	checkTmuxSetup: () => Promise<string | undefined>;
 	maybeWarnAboutAnthropicSubscriptionAuth: () => Promise<void>;
-	getUserInput: () => Promise<{ text: string; images?: unknown[] }>;
+	getUserInput: () => Promise<{ text: string; images?: unknown[]; pendingEchoId: string }>;
 	showNewVersionNotification: (version: string) => void;
 	showPackageUpdateNotification: (packages: string[]) => void;
 	showRiskyMainModelWarning: () => void;
@@ -87,6 +99,7 @@ function createSubmitContext(): SubmitContext {
 		lastEditorText: "",
 		pendingUserInputs: [],
 		pendingImages: new Map(),
+		optimisticUserEchoes: createEchoControllerStub(),
 		takeSubmissionImages: vi.fn(() => []),
 	};
 	// Borrowed receiver: resolve markers with the REAL production helper (its
@@ -114,7 +127,7 @@ describe("InteractiveMode startup input", () => {
 
 		await context.defaultEditor.onSubmit?.(" early prompt ");
 
-		expect(context.pendingUserInputs).toEqual([{ text: "early prompt" }]);
+		expect(context.pendingUserInputs).toEqual([{ text: "early prompt", pendingEchoId: "pending-test" }]);
 		expect(context.flushPendingBashComponents).toHaveBeenCalledTimes(1);
 		expect(context.editor.addToHistory).toHaveBeenCalledWith("early prompt");
 	});
@@ -136,10 +149,11 @@ describe("InteractiveMode startup input", () => {
 		const stopMainLoop = new Error("stop interactive loop");
 		const prompt = vi.fn(async (_text: string, _options?: unknown) => {});
 		const getUserInput = vi
-			.fn<() => Promise<{ text: string; images?: unknown[] }>>()
-			.mockResolvedValueOnce({ text: "queued prompt" })
+			.fn<() => Promise<{ text: string; images?: unknown[]; pendingEchoId: string }>>()
+			.mockResolvedValueOnce({ text: "queued prompt", pendingEchoId: "pending-test" })
 			.mockRejectedValueOnce(stopMainLoop);
 		const context: RunContext = {
+			optimisticUserEchoes: createEchoControllerStub(),
 			init: vi.fn(async () => {}),
 			version: "test",
 			options: {},
@@ -164,6 +178,13 @@ describe("InteractiveMode startup input", () => {
 
 		// Then dispatch retains steer intent in case a continuation became active.
 		expect(prompt).toHaveBeenCalledTimes(1);
-		expect(prompt).toHaveBeenCalledWith("queued prompt", { streamingBehavior: "steer" });
+		expect(prompt).toHaveBeenCalledWith(
+			"queued prompt",
+			expect.objectContaining({
+				streamingBehavior: "steer",
+				preflightResult: expect.any(Function),
+				promptDisposition: expect.any(Function),
+			}),
+		);
 	});
 });

--- a/packages/coding-agent/test/session-log-routes.test.ts
+++ b/packages/coding-agent/test/session-log-routes.test.ts
@@ -487,7 +487,15 @@ describe("session.log stuck-route instrumentation", () => {
 		if (typeof queueCompactionMessage !== "function") throw new Error("Expected queueCompactionMessage");
 		const sessionLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
 		const context = {
-			compactionQueuedMessages: [] as Array<{ text: string; mode: string; enqueueOrder: number }>,
+			optimisticUserEchoes: {
+				begin: vi.fn(() => "pending-test"),
+			},
+			compactionQueuedMessages: [] as Array<{
+				text: string;
+				mode: string;
+				enqueueOrder: number;
+				pendingEchoId?: string;
+			}>,
 			session: { reserveQueuedInputOrder: () => 1 },
 			editor: { addToHistory: vi.fn(), setText: vi.fn() },
 			updatePendingMessagesDisplay: vi.fn(),

--- a/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
+++ b/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
@@ -1,0 +1,161 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import * as interactiveModeModule from "../../src/modes/interactive/interactive-mode.ts";
+
+type RenderHandle = {
+	replace(message: AgentMessage): void;
+	remove(): void;
+};
+
+type EchoController = {
+	begin(text: string): string;
+	promptOptions(id: string): {
+		preflightResult(success: boolean): void;
+		promptDisposition(disposition: "handled" | "queued" | "started"): void;
+	};
+	reject(id: string): void;
+	replaceNext(message: AgentMessage): void;
+};
+
+type EchoControllerConstructor = new (render: (text: string) => RenderHandle) => EchoController;
+
+function getControllerConstructor(): EchoControllerConstructor {
+	const controllerClass = Reflect.get(interactiveModeModule, "OptimisticUserEchoController");
+	expect(controllerClass, "InteractiveMode must expose its TUI-local optimistic echo controller").toBeTypeOf(
+		"function",
+	);
+	return controllerClass as EchoControllerConstructor;
+}
+
+function userMessage(text: string): AgentMessage {
+	return {
+		role: "user",
+		content: [{ type: "text", text }],
+		timestamp: 1,
+	};
+}
+
+function createController() {
+	const rendered: Array<{
+		text: string;
+		replacedWith?: AgentMessage;
+		removed: boolean;
+	}> = [];
+	const Controller = getControllerConstructor();
+	const controller = new Controller((text) => {
+		const entry: { text: string; replacedWith?: AgentMessage; removed: boolean } = { text, removed: false };
+		rendered.push(entry);
+		return {
+			replace: (message) => {
+				entry.replacedWith = message;
+			},
+			remove: () => {
+				entry.removed = true;
+			},
+		};
+	});
+	return { controller, rendered };
+}
+
+describe("optimistic pending user echo", () => {
+	it("renders from the real Enter submit handler before handing input to prompt work", async () => {
+		const order: string[] = [];
+		const Controller = getControllerConstructor();
+		const optimisticUserEchoes = new Controller((text) => {
+			order.push(`render:${text}`);
+			return { replace: () => {}, remove: () => {} };
+		});
+		const defaultEditor: { onSubmit?: (text: string) => Promise<void> } = {};
+		const context = {
+			defaultEditor,
+			preResolvedSubmissionImages: undefined,
+			hideShortcutOverlay: () => {},
+			lastEditorText: "",
+			isExtensionCommand: () => false,
+			session: { isCompacting: false, isStreaming: false },
+			flushPendingBashComponents: () => {},
+			takeSubmissionImages: () => [],
+			optimisticUserEchoes,
+			onInputCallback: () => order.push("prompt-handoff"),
+			pendingUserInputs: [],
+			editor: { addToHistory: () => {} },
+		};
+		const setup = Reflect.get(interactiveModeModule.InteractiveMode.prototype, "setupEditorSubmitHandler");
+		if (typeof setup !== "function") throw new Error("InteractiveMode.setupEditorSubmitHandler is missing");
+		setup.call(context);
+
+		await defaultEditor.onSubmit?.("paint me now");
+
+		expect(order).toEqual(["render:paint me now", "prompt-handoff"]);
+	});
+
+	it("renders synchronously before prompt work starts", async () => {
+		const { controller, rendered } = createController();
+		const requestStarted = vi.fn();
+
+		const id = controller.begin("paint me now");
+		expect(rendered).toEqual([{ text: "paint me now", removed: false }]);
+		requestStarted();
+		controller.promptOptions(id).promptDisposition("started");
+
+		expect(requestStarted).toHaveBeenCalledOnce();
+		expect(rendered[0]?.removed).toBe(false);
+	});
+
+	it("replaces the pending bubble exactly once at canonical message_start", () => {
+		const { controller, rendered } = createController();
+		const id = controller.begin("original");
+		controller.promptOptions(id).promptDisposition("started");
+		const canonical = userMessage("canonical");
+
+		controller.replaceNext(canonical);
+
+		expect(rendered).toHaveLength(1);
+		expect(rendered[0]).toMatchObject({ text: "original", replacedWith: canonical, removed: false });
+	});
+
+	it("unpaints a compaction-in-progress rejection or thrown prompt", () => {
+		const { controller, rendered } = createController();
+		const preflightId = controller.begin("rejected by preflight");
+		controller.promptOptions(preflightId).preflightResult(false);
+		const thrownId = controller.begin("prompt threw");
+		controller.reject(thrownId);
+
+		expect(rendered.map((entry) => entry.removed)).toEqual([true, true]);
+	});
+
+	it("unpaints handled extension-consumed input", () => {
+		const { controller, rendered } = createController();
+		const id = controller.begin("handled by extension");
+
+		controller.promptOptions(id).promptDisposition("handled");
+
+		expect(rendered[0]?.removed).toBe(true);
+	});
+
+	it("keeps queued steer echoes and reconciles their canonical starts in order", () => {
+		const { controller, rendered } = createController();
+		const firstId = controller.begin("first steer");
+		const secondId = controller.begin("second steer");
+		controller.promptOptions(firstId).promptDisposition("queued");
+		controller.promptOptions(secondId).promptDisposition("queued");
+		const firstCanonical = userMessage("first steer");
+		const secondCanonical = userMessage("second steer");
+
+		controller.replaceNext(firstCanonical);
+		controller.replaceNext(secondCanonical);
+
+		expect(rendered.map((entry) => entry.replacedWith)).toEqual([firstCanonical, secondCanonical]);
+		expect(rendered.map((entry) => entry.removed)).toEqual([false, false]);
+	});
+
+	it("is render-only and does not persist before the canonical message", () => {
+		const persisted: AgentMessage[] = [];
+		const { controller, rendered } = createController();
+
+		controller.begin("render only");
+
+		expect(rendered).toHaveLength(1);
+		expect(persisted).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
+++ b/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
@@ -14,7 +14,8 @@ type EchoController = {
 		promptDisposition(disposition: "handled" | "queued" | "started"): void;
 	};
 	reject(id: string): void;
-	replaceNext(message: AgentMessage): void;
+	remove(id: string): void;
+	replaceNext(message: AgentMessage): boolean;
 };
 
 type EchoControllerConstructor = new (render: (text: string) => RenderHandle) => EchoController;
@@ -102,6 +103,25 @@ describe("optimistic pending user echo", () => {
 		expect(rendered[0]?.removed).toBe(false);
 	});
 
+	it("does not consume a pending bubble for a foreign user message_start", () => {
+		const { controller, rendered } = createController();
+		const id = controller.begin("local submission");
+		const foreign = userMessage("foreign extension prompt");
+		const appended: AgentMessage[] = [];
+
+		if (!controller.replaceNext(foreign)) appended.push(foreign);
+		expect(appended).toEqual([foreign]);
+		controller.promptOptions(id).promptDisposition("started");
+		controller.replaceNext(userMessage("local canonical"));
+
+		expect(rendered).toHaveLength(1);
+		expect(rendered[0]).toMatchObject({ text: "local submission", removed: false });
+		expect(rendered[0]?.replacedWith).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "local canonical" }],
+		});
+	});
+
 	it("replaces the pending bubble exactly once at canonical message_start", () => {
 		const { controller, rendered } = createController();
 		const id = controller.begin("original");
@@ -122,6 +142,23 @@ describe("optimistic pending user echo", () => {
 		controller.reject(thrownId);
 
 		expect(rendered.map((entry) => entry.removed)).toEqual([true, true]);
+	});
+
+	it("removes only the specified queue-owned pending echo", () => {
+		const { controller, rendered } = createController();
+		const queuedId = controller.begin("queued for compaction");
+		const inFlightId = controller.begin("independent in-flight prompt");
+
+		controller.remove(queuedId);
+		controller.promptOptions(inFlightId).promptDisposition("started");
+		controller.replaceNext(userMessage("independent canonical"));
+
+		expect(rendered[0]?.removed).toBe(true);
+		expect(rendered[1]?.removed).toBe(false);
+		expect(rendered[1]?.replacedWith).toMatchObject({
+			role: "user",
+			content: [{ type: "text", text: "independent canonical" }],
+		});
 	});
 
 	it("unpaints handled extension-consumed input", () => {


### PR DESCRIPTION
## Problem

Interactive Enter clears the editor immediately, but the user bubble was painted only when the canonical `message_start` arrived. That event waits behind settled-work, serial input hooks, auth/model validation, pre-prompt compaction, and admission. The measured perceived submit latency is about 0.45s at p50.

## Design

- Create a unique TUI-local pending record at submit time and paint the existing user-message component immediately.
- On canonical user `message_start`, replace the oldest pending record in place, preserving transcript order and preventing duplicate user bubbles.
- Reconcile through the existing `preflightResult` and `promptDisposition` channels:
  - `handled`: remove the pending bubble; the extension consumed the input.
  - `queued` / `started`: keep it until that input's canonical `message_start`.
  - rejected preflight or thrown prompt: remove it and preserve existing retry/editor behavior.
- Apply the same lifecycle to streaming steer/follow-up input and compaction queue transfer.

## Constraints honored

The pending artifact is render-only: it is a TUI component and local record, never an `AgentMessage`, session entry, or JSONL record. The exactly-once persistence proof remains covered by `post-compaction-queued-input-resume.test.ts`, which is unchanged and passes. AgentSession admission, compaction, settled-work, and persistence code were not modified.

## Test evidence

RED before implementation:

```text
Test Files  1 failed (1)
Tests  6 failed (6)
AssertionError: InteractiveMode must expose its TUI-local optimistic echo controller: expected undefined to be type of 'function'
```

GREEN after implementation:

```text
Test Files  5 passed (5)
Tests  21 passed (21)
```

Commands run:

- `npx npm@12.0.2 ci`
- `npx npm@12.0.2 run build`
- `cd packages/coding-agent && npx vitest --run test/suite/optimistic-pending-user-echo.test.ts test/suite/interactive-mode-scoped-settings.test.ts test/suite/regressions/post-compaction-queued-input-resume.test.ts test/suite/regressions/7150-rpc-prompt-during-compaction.test.ts test/suite/regressions/startup-session-rebind-duplicate-subscription.test.ts`
- `node scripts/check-pr-changelog.mjs --base origin/main`

## QA note

The new lifecycle suite covers immediate paint, exactly-once canonical replacement, compaction rejection cleanup, handled extension cleanup, FIFO queued reconciliation, and render-only persistence. Required regression guards and the root build pass locally. CI should additionally validate the full repository matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render a TUI-local pending user echo immediately on submit to cut perceived latency. Previously the editor cleared but the user bubble appeared only at canonical `message_start` (~0.45s p50); now we paint at submit, replace exactly once on canonical start, and remove for handled or rejected input without persisting render-only state.

- Introduces `OptimisticUserEchoController` in `packages/coding-agent/src/modes/interactive/interactive-mode.ts` to begin, replace, and remove local echoes, and to hook `preflightResult` and `promptDisposition`.
- Applies to Enter, streaming steer/follow-up, extension-command, and compaction-queued submissions; all pass `promptOptions(...)` and reject the echo on thrown prompts.
- Guards reconciliation: a `message_start` replaces only the oldest pending echo that becomes eligible after its own `promptDisposition` is `queued` or `started`; foreign user events append normally.
- Compaction: `CompactionQueuedMessage` carries an optional `pendingEchoId`; reset removes only owned echoes; transfer propagates prompt callbacks to both echo options and disposition waiters to ensure exactly-once replacement/cleanup.
- Widened submission payloads: `getUserInput`/`InteractiveUserInput` now include a `pendingEchoId` used for echo lifecycle; startup and image submission paths updated to pass echo `promptOptions`.
- Persistence unchanged; pending echoes never become session `AgentMessage`s or JSONL.
- Tests cover immediate paint, guarded replacement, handled/rejected cleanup, FIFO reconciliation, foreign user events, scoped compaction cleanup, and render-only behavior. No migration required.

<sup>Written for commit ff5708c1f98a39874721215c8137bef86f102377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Review round 1 follow-up

- Moved the `changes.md` entry to the exact nearest tracker, `packages/coding-agent/src/modes/interactive/changes.md`. The gate only accepts added marker lines in that tracker for `interactive-mode.ts`.
- Confirmed foreign user events are possible on the interactive session: extension `sendUserMessage()` enters `AgentSession.prompt(..., source: "extension")`, and RPC prompt handling can call the same session.
- Pending echoes are now ineligible for canonical replacement until their own `promptDisposition` reports `queued` or `started`. A foreign user `message_start` before that point falls back to normal append and leaves the pending record intact; the pending is then replaced by its own canonical start.
- Compaction queue reset now removes only the `pendingEchoId`s belonging to the compaction records being cleared, rather than clearing unrelated in-flight echoes.
- Added regressions for foreign user events and scoped queue cleanup.

Fresh local evidence:

```text
CHANGELOG_GATE_BASE=e54766751b0b2ef1be4a7fec83a7ba71f62cbb80 node scripts/check-pr-changelog.mjs
changelog-gate: PASS - changes.md coverage complete (1 production path(s) covered); changelog entry updated (packages/coding-agent/CHANGELOG.md)

Test Files  4 passed (4)
Tests  20 passed (20)
```
