### PR TITLE
fix(terminal): correct monitor tool guidance and add worked recipes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Refreshed dependency pins, including `@anthropic-ai/claude-agent-sdk` 0.3.238, `jsdom` 30, `undici` 8.10.0, `marked` 18.0.10, `highlight.js` 11.12.0, `grok-mermaid` 0.2.3, `minimatch` 10.2.6, `ws` 8.21.3, and `typebox` 1.3.16, and removed the unused `@mistralai/mistralai` and `@types/ms` entries.
 
+- The `monitor` tool's description, schema text, prompt guidance, and terminal docs now state the verified contract (PTY output with stderr merged, event-only filtering, dedup and pause semantics) and include worked recipes plus an anti-pattern reference.
+
 ### Fixed
 
 ### Removed

--- a/packages/coding-agent/docs/terminal-tools.md
+++ b/packages/coding-agent/docs/terminal-tools.md
@@ -12,7 +12,7 @@ platform/runtime).
 |------|---------|
 | `bash` | Run a command in a PTY. `run_in_background: true` starts a persistent session and returns a `bash_id` immediately. Foreground `timeout` (seconds) is a kill deadline. |
 | `bash_output` | Peek at a session without blocking: new output since the last read, or the status line. `filter` regex-filters lines; `view: "screen"` returns the rendered xterm grid. |
-| `monitor` | Watch a long-running command (`description`, `command`, `filter?`, `timeout_ms?`, `persistent?`) and inject matching stdout lines as coalesced events. While watches are live, the interactive footer shows a brief `watching …` status (descriptions, count, paused markers). |
+| `monitor` | Watch a long-running command (`description`, `command`, `filter?`, `timeout_ms?`, `persistent?`) and inject matching PTY output lines as coalesced events. While watches are live, the interactive footer shows a brief `watching …` status (descriptions, count, paused markers). |
 | `bash_input` | Send stdin (`input`) or named keys (`keys: ["ctrl+c"]`, `["enter"]`, `["up"]`) to steer a REPL or interrupt a process. |
 | `bash_resize` | Resize a session's PTY (`cols`, `rows`) so full-screen TUIs reflow. |
 | `kill_bash` | Tree-kill one session (`bash_id`) or all (`all: true`), leaving no orphans. |
@@ -29,6 +29,92 @@ Typical flow: start with `run_in_background: true`, watch for patterns with `mon
 peek with `bash_output`, steer with `bash_input`, then `kill_bash` when done. Completion
 arrives as a notification carrying the exit code and output tail, so a follow-up
 `bash_output` read is only needed when the tail is not enough.
+
+## Monitor recipes
+
+Each recipe shapes the command so the interesting moment becomes one clean,
+newline-terminated line. Sleep loops live inside the monitored command.
+
+### Dev-server readiness gate
+
+```js
+monitor({ description: "dev server ready",
+  command: "until curl -fsS http://localhost:3000/health; do sleep 1; done; printf 'READY\n'",
+  filter: "^READY$" })
+```
+
+Expected event: one `READY` line, then the exit summary. Follow-up: hit the
+server. Nothing outlives the watch, so no cleanup.
+
+### Long test or build with a pass/fail sentinel
+
+```js
+monitor({ description: "full test suite",
+  command: "if npx vitest run; then printf 'OK\n'; else code=$?; printf 'FAILED_%s\n' \"$code\"; exit \"$code\"; fi",
+  filter: "^(OK|FAILED_)" })
+```
+
+Expected event: `OK` or `FAILED_<code>` plus the exit summary. On `FAILED_`,
+read the tail with `bash_output` and fix; on `OK`, move on.
+
+### QA error stream from a log
+
+```js
+monitor({ description: "app error watch",
+  command: "tail -n 0 -F app.log | grep --line-buffered -E 'ERROR|FATAL'",
+  persistent: true })
+```
+
+Expected events: each new ERROR/FATAL line as it lands. Follow-up: investigate
+the failure it names. `tail -F` never exits, so `kill_bash` the `bash_id` when
+the QA pass ends.
+
+### CI / PR check watch
+
+```js
+monitor({ description: "PR checks",
+  command: "gh pr checks 1052 --watch 2>&1",
+  filter: "fail|pass|All checks" })
+```
+
+Expected event: the verdict line when checks settle, then the summary. Merge on
+pass, pull the failing job's log on fail. The command exits by itself.
+
+### File or port transition
+
+```js
+monitor({ description: "artifact written",
+  command: "until test -f dist/app.tar.gz; do sleep 2; done; printf 'READY\n'",
+  filter: "^READY$" })
+```
+
+Same shape works for ports: `until nc -z localhost 5432; do sleep 1; done;
+printf 'READY\n'`. Expected event: `READY`, then exit. Consume the artifact
+or connect.
+
+### Child-agent sentinel watch
+
+```js
+monitor({ description: "subtask done",
+  command: "until grep -q '^status=done$' /tmp/task.status 2>/dev/null; do sleep 5; done; printf 'READY\n'",
+  filter: "^READY$" })
+```
+
+Expected event: `READY` once the child flips its status file. Read the child's
+results and integrate. Exits on its own; no cleanup.
+
+### Anti-patterns
+
+| Anti-pattern | Do instead |
+|---|---|
+| Sleeping in your own turn between polls | Put the sleep loop inside the monitor command |
+| Spinning on `bash_output` reads | Register a monitor; peek only to steer |
+| Filterless watch on a chatty command | Shape output at the source, then narrow with `filter` |
+| Expecting `filter` to stop the command | `filter` gates events only; make the command exit on the condition |
+| `persistent: true` with `timeout_ms` | The timeout is ignored when persistent; pick one |
+| Sentinel printed without a trailing newline | Sentinels must be newline-terminated: `printf 'READY\n'` |
+| Monitoring sub-minute deterministic work | Run it directly in the foreground |
+| Rearming a monitor that was never paused | Rearm only a `bash_id` named in a pause notice |
 
 ## Mutual exclusion with native Anthropic bash
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
@@ -14,11 +14,13 @@ manual \`&\` backgrounding — use the built-in session tools:
   \`view: "screen"\`. Completion arrives as a notification carrying the exit code and output
   tail — peeking is for steering, never for waiting.
 - \`monitor({ description, command, filter?, timeout_ms?, persistent? })\` subscribes you to a
-  command: its stdout lines arrive as injected events while you keep working. Shape the command
-  by notifications needed: exit-on-condition for one completion event; emit-per-occurrence
-  (\`tail -f | grep --line-buffered\`, a polling loop inside the command) for a stream. Filter
-  noise at the command source, stop with \`kill_bash\`, and use
-  \`monitor({ action: "rearm", bash_id })\` only after a wake-budget pause.
+  command: newline-terminated PTY output lines (stderr included) matching \`filter\` arrive as
+  injected events while you keep working; command exit always delivers a summary. One-shot
+  gate: wait inside the command and print one sentinel (\`until <cond>; do sleep 1; done;
+  printf 'READY\\n'\`). Stream: \`tail -n 0 -F | grep --line-buffered\`. Filter noise at the
+  source and stop with \`kill_bash\`. Identical updates are deduped; enough monitor-only wakes
+  pause ALL monitors - completion still wakes the session, and
+  \`monitor({ action: "rearm", bash_id })\` resumes intermediate events.
 - \`bash_input({ bash_id, input, keys, submit })\` sends stdin or named keys (e.g.
   \`["ctrl+c"]\`, \`["enter"]\`) to steer a REPL or interrupt a process.
 - \`bash_resize({ bash_id, cols, rows })\` resizes the PTY so full-screen programs reflow.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -33,7 +33,9 @@ export const monitorSchema = Type.Object({
 			description: "Create (required): shell command to run and watch in a PTY-backed monitor session.",
 		}),
 	),
-	filter: Type.Optional(Type.String({ description: "Only stdout lines matching this regex become monitor events." })),
+	filter: Type.Optional(
+		Type.String({ description: "Only PTY output lines matching this regex become monitor events." }),
+	),
 	timeout_ms: Type.Optional(
 		Type.Number({
 			minimum: 1,
@@ -112,10 +114,12 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 		name: TERMINAL_MONITOR_TOOL,
 		label: "monitor",
 		description:
-			"Subscribe to events from a command instead of polling for them: each stdout line arrives as an injected event while you keep working. Updates identical to a monitor's previous batch are dropped, so a watcher reprinting unchanged status does not re-wake the session. Returns a bash_id immediately; peek with bash_output, stop with kill_bash.",
-		promptSnippet: "Subscribe to a command's stdout lines as injected events instead of polling",
+			"Subscribe to a command's output instead of polling: newline-terminated PTY output lines (stderr merged) that match filter arrive as injected events while you keep working; command exit always delivers a summary event. Identical consecutive line-only update batches are deduped, so a watcher reprinting unchanged status does not re-wake the session. Returns a bash_id immediately; peek with bash_output, stop with kill_bash.",
+		promptSnippet: "Subscribe to a command's PTY output lines as injected events instead of polling",
 		promptGuidelines: [
 			"Waiting on observable state (CI checks, builds, log patterns, deploys) means a monitor, never a foreground sleep/poll loop.",
+			"Shape the command for the events you need: one-shot gate = `until <cond>; do sleep 1; done; printf 'READY\\n'` with filter ^READY$; stream = `tail -n 0 -F <log> | grep --line-buffered <pat>` with persistent: true, then kill_bash.",
+			"Sleep loops belong INSIDE the monitor command, never in your turn: about to sleep, re-poll bash_output, or foreground-block on a long command means register a monitor and keep working.",
 		],
 		parameters: monitorSchema,
 		renderCall: renderMonitorCall,


### PR DESCRIPTION
## What

Corrects and strengthens the `monitor` tool's agent-facing guidance so agents reach for event subscription instead of sleep/poll loops:

- **`monitor.ts` tool surface**: the description, `promptSnippet`, and `filter` schema text now state the verified contract - newline-terminated **PTY output lines (stderr merged)**, not "stdout"; filter gates events only; identical line-only batches are deduped while exit summaries always deliver. Two new `promptGuidelines` teach command shaping (one-shot sentinel gate vs `tail -F | grep --line-buffered` stream) and the "sleep loops belong INSIDE the monitor command" trigger rule.
- **`TERMINAL_PROMPT_SECTION`**: the monitor bullet now teaches the same corrected contract, the newline-terminated sentinel shape, and that the wake budget pauses **ALL** monitors session-globally (completion still wakes; `rearm` resumes intermediates).
- **`docs/terminal-tools.md`**: new "Monitor recipes" section - worked invocations (readiness gate, test sentinel, QA error stream, CI watch, file/port transitions, dedup-friendly status loop, fan-out, child-agent sentinel) plus an anti-pattern table; also fixes the stale "stdout" wording in the tool table.

## Why

The shipped wording disagreed with the implementation in five verifiable places (PTY vs stdout; per-monitor vs session-global pause; unqualified dedup; filter semantics; sentinel line termination). Instructions that teach wrong contracts cause misuse; recipes live in docs where they cost zero always-on tokens.

## Verification

- `test/prompt-surface-stale-wait-idioms.test.ts` green at every commit (consistency gate: no wait_for/tmux teaching, monitor+notification invariants).
- Mutation proofs captured per change (gate fails when a banned idiom is injected, green after revert).
- Surface dump QA: tool description/snippet/guidelines and prompt section printed from this branch and asserted to carry the corrected facts.
- Changelog gate mirror: `check-pr-changelog.mjs` PASS.

No runtime behavior changes - strings, docs, and changelog only.

Plan: .omo/plans/senpi-monitor-usage-prompting.md (momus-approved)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the `monitor` tool contract and guidance so agents subscribe to events instead of using sleep/poll loops. Replaces incorrect “stdout-only” and per‑monitor pause wording with the verified contract: newline-terminated PTY lines with stderr merged, event-only filtering, dedup of identical line-only batches, exit summaries always delivered, and session‑global monitor pauses.

- Key updates
  - `monitor.ts`: update description, `promptSnippet`, and `filter` schema text; add `promptGuidelines` for one-shot sentinel vs stream and “sleep loops belong inside the command”.
  - `prompt.ts`: refresh terminal prompt section to teach the corrected contract, sentinel shape, dedup, session‑global pause, and `rearm` behavior.
  - `docs/terminal-tools.md`: add monitor recipes and an anti‑pattern table; fix “stdout” wording in the tool table.
  - `CHANGELOG.md`: documents the corrected contract and references the new recipes. No runtime behavior changes.

- Review focus
  - Contract matches implementation: PTY (stderr merged) vs stdout, filter gates events only, dedup and exit‑summary semantics, session‑global pause with completion wake and explicit `rearm`. 
  - Recipes cover readiness gates, test/build sentinels, log streams, CI checks, file/port transitions, and child‑agent sentinels.

<sup>Written for commit d82bfbed1fee0ef149ad08dd2dbe694f01256630. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

