### PR TITLE
fix(coding-agent): eliminate settings-lock CPU-spin TUI freeze under error storms

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Interactive submissions now render a local pending user echo immediately, reconcile it with the canonical `message_start`, and remove it for rejected or extension-handled input without writing render-only state to session history.
 - The `claude-sdk-oauth` lane now surfaces Claude policy refusals (for example cybersecurity refusals) as an immediate, user-visible error naming the refusal category and explanation, instead of hanging until the ~90s stream watchdog timeout. Refusals are classified as non-retryable, so they no longer enter the timeout-retry ladder or account failover ([#1052](https://github.com/code-yeongyu/senpi/pull/1052)).
+- Contended settings-lock retries now sleep via `Atomics.wait` instead of busy-waiting, retry-fallback canonicalization is memoized per error burst, and `cursor-cli-oauth`/`claude-sdk-oauth` settings loads are cached by mtime+size. Together these eliminate the settings-lock CPU-spin that froze the TUI at ~100% CPU under provider-error storms ([#1056](https://github.com/code-yeongyu/senpi/pull/1056)).
 
 ### Added
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## 2026-08-21 - Settings-lock retry sleeps instead of spinning; retry-fallback canonicalization memoized
+
+### What changed
+
+- `settings-manager.ts`: `acquireLockSyncWithRetry` replaces the `while (Date.now() - start < delayMs)` busy-wait with `Atomics.wait` on a `SharedArrayBuffer`. The wait stays synchronous (callers and the 20ms/10-attempt policy unchanged) but the thread actually sleeps, so contended retries no longer burn a CPU core per waiter.
+- `retry-fallback/controller.ts`: `RetryFallbackController` memoizes `canonicalizeFallbackChains` by the serialized chains content. `canTryFallback`/`nextCandidate`/`hasConfiguredChain` reuse the canonical result for an unchanged config; a chains edit invalidates immediately; `clear()` drops the memo.
+
+### Why
+
+- Provider-error handling calls `canTryFallback` 4-6 times per error, each re-canonicalizing chains whose oauth-lane eligibility probes create fresh `SettingsManager` instances and locked disk reads. With ~12 sessions sharing one settings.json the lock convoy made every waiter busy-spin on the main thread, starving the TUI render loop and freezing the screen at ~100% CPU under 429/5xx storms. V8 profile of a frozen omo process showed 65% in `acquireLockSyncWithRetry` and 18% in `parseSettingsJson`.
+
+### Why an extension could not handle it
+
+- The settings file lock and the retry-fallback controller are core storage and session-admission paths with no extension seam.
+
+### Expected merge conflict zones
+
+- `settings-manager.ts` around `acquireLockSyncWithRetry` (line ~527). `retry-fallback/controller.ts` around `nextCandidate`/`hasConfiguredChain` and the new `canonicalChains` private method.
+
+
 ## 2026-08-20 - Resume picker caches exact streaming summaries
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,24 @@
 # claude-sdk-oauth
 
+## 2026-08-21 - Cache provider settings loads by mtime+size to cut lock convoy
+
+### What changed
+
+- `settings.ts`: `loadClaudeSdkOauthProviderSettingsFromDisk` caches the `SettingsManager` instance keyed on (cwd, mtimeMs:size of the global and project settings.json). A cache hit skips `SettingsManager.create` and its two locked disk reads; environment overrides are re-parsed on every call so live env changes take effect immediately.
+
+### Why
+
+- `fallbackEligible()` calls this loader on every retry-fallback candidate probe. A fresh `SettingsManager` per call took the cross-process settings lock twice; under error storms this multiplied into hundreds of locked disk reads per session per error, driving the lock-retry busy-wait (fixed in core) that froze the TUI.
+
+### Why an extension could not handle it
+
+- This IS the extension side: the cache is local to the provider settings loader.
+
+### Expected merge conflict zones
+
+- `settings.ts` around `loadClaudeSdkOauthProviderSettingsFromDisk`.
+
+
 ## 2026-08-20 - Terminate policy refusals without waiting for the stream watchdog
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/settings.ts
@@ -1,5 +1,6 @@
+import { statSync } from "node:fs";
 import { getAgentDir } from "../../../../config.ts";
-import { type Settings, SettingsManager } from "../../../settings-manager.ts";
+import { getSettingsPath, type Settings, SettingsManager } from "../../../settings-manager.ts";
 import type { SettingSource } from "./sdk-boundary.ts";
 
 export type ClaudeSdkOauthSystemPromptMode = "preset-append" | "full" | "override";
@@ -165,7 +166,32 @@ export function loadClaudeSdkOauthProviderSettings(
 	return settings;
 }
 
+function settingsFingerprint(path: string): string {
+	try {
+		const stat = statSync(path);
+		return `${stat.mtimeMs}:${stat.size}`;
+	} catch {
+		return "missing";
+	}
+}
+
+let cachedClaudeSdkOauthManager: { cwd: string; key: string; manager: SettingsManager } | undefined;
+
 /** Load settings from Senpi's configured global and project settings.json paths. */
 export function loadClaudeSdkOauthProviderSettingsFromDisk(cwd: string): ClaudeSdkOauthProviderSettings {
-	return loadClaudeSdkOauthProviderSettings(SettingsManager.create(cwd, getAgentDir()));
+	// fallbackEligible() calls this per candidate probe; cache the manager by
+	// (cwd, settings mtime+size) and re-apply env live to avoid locked disk reads.
+	const agentDir = getAgentDir();
+	const key = `${cwd}|${settingsFingerprint(getSettingsPath(cwd, agentDir, "global"))}|${settingsFingerprint(
+		getSettingsPath(cwd, agentDir, "project"),
+	)}`;
+	let settingsManager =
+		cachedClaudeSdkOauthManager?.cwd === cwd && cachedClaudeSdkOauthManager.key === key
+			? cachedClaudeSdkOauthManager.manager
+			: undefined;
+	if (!settingsManager) {
+		settingsManager = SettingsManager.create(cwd, agentDir);
+		cachedClaudeSdkOauthManager = { cwd, key, manager: settingsManager };
+	}
+	return loadClaudeSdkOauthProviderSettings(settingsManager);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/changes.md
@@ -1,5 +1,24 @@
 # cursor-cli-oauth extension changes
 
+## 2026-08-21 - Cache provider settings loads by mtime+size to cut lock convoy
+
+### What changed
+
+- `settings.ts`: `loadCursorCliOauthProviderSettingsFromDisk` caches the `SettingsManager` instance keyed on (cwd, mtimeMs:size of the global and project settings.json). A cache hit skips `SettingsManager.create` and its two locked disk reads; environment overrides are re-parsed on every call so live env changes take effect immediately.
+
+### Why
+
+- `fallbackEligible()` calls this loader on every retry-fallback candidate probe. A fresh `SettingsManager` per call took the cross-process settings lock twice and read+parsed both files; under error storms this multiplied into hundreds of locked disk reads per session per error, driving the lock-retry busy-wait (fixed in core) that froze the TUI.
+
+### Why an extension could not handle it
+
+- This IS the extension side: the cache is local to the provider settings loader.
+
+### Expected merge conflict zones
+
+- `settings.ts` around `loadCursorCliOauthProviderSettingsFromDisk`.
+
+
 ## 2026-08-19 - Guaranteed-refusal lane leaves implicit fallback expansion
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/settings.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/cursor-cli-oauth/settings.ts
@@ -1,5 +1,12 @@
+import { statSync } from "node:fs";
 import { getAgentDir } from "../../../../config.ts";
-import { FileSettingsStorage, parseSettingsJson, type Settings, SettingsManager } from "../../../settings-manager.ts";
+import {
+	FileSettingsStorage,
+	getSettingsPath,
+	parseSettingsJson,
+	type Settings,
+	SettingsManager,
+} from "../../../settings-manager.ts";
 
 export type CursorCliOauthExecutionMode = "agent" | "plan";
 export type CursorCliOauthResumeMode = "auto" | "off";
@@ -213,9 +220,34 @@ export function createCursorCliOauthSandboxModeValidator(
 	};
 }
 
+function settingsFingerprint(path: string): string {
+	try {
+		const stat = statSync(path);
+		return `${stat.mtimeMs}:${stat.size}`;
+	} catch {
+		return "missing";
+	}
+}
+
+let cachedCursorCliOauthManager: { cwd: string; key: string; manager: SettingsManager } | undefined;
+
 /** Load global and project settings afresh, with env values taking final precedence. */
 export function loadCursorCliOauthProviderSettingsFromDisk(cwd: string): CursorCliOauthProviderSettings {
-	const settingsManager = SettingsManager.create(cwd, getAgentDir());
+	// fallbackEligible() calls this per candidate probe during retry-fallback; a fresh
+	// SettingsManager per call drove locked disk reads hundreds of times per provider
+	// error. Cache the manager by (cwd, settings mtime+size) and re-apply env live.
+	const agentDir = getAgentDir();
+	const key = `${cwd}|${settingsFingerprint(getSettingsPath(cwd, agentDir, "global"))}|${settingsFingerprint(
+		getSettingsPath(cwd, agentDir, "project"),
+	)}`;
+	let settingsManager =
+		cachedCursorCliOauthManager?.cwd === cwd && cachedCursorCliOauthManager.key === key
+			? cachedCursorCliOauthManager.manager
+			: undefined;
+	if (!settingsManager) {
+		settingsManager = SettingsManager.create(cwd, agentDir);
+		cachedCursorCliOauthManager = { cwd, key, manager: settingsManager };
+	}
 	const global = settingsManager.getGlobalSettings() as SettingsWithCursorCliOauthProvider;
 	const project = settingsManager.getProjectSettings() as SettingsWithCursorCliOauthProvider;
 	return resolveSettings(

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -4,6 +4,7 @@ import {
 	baseSelector,
 	candidatesAfter,
 	canonicalizeFallbackChains,
+	type FallbackChains,
 	type FallbackSelector,
 	formatSelector,
 	parseFallbackSelector,
@@ -60,6 +61,14 @@ export class RetryFallbackController {
 	private readonly triedSelectors = new Set<string>();
 	private state: ActiveFallbackState | undefined;
 	private lastExhaustedChainKey: string | undefined;
+	// Content-keyed memo of canonicalizeFallbackChains. Provider-error handling calls
+	// canTryFallback/nextCandidate several times per error; without this each call
+	// re-expands bare selectors and re-probes registry eligibility over the full
+	// model set. Keying on the serialized chains content means an unchanged config
+	// reuses the canonical result, while a chains edit invalidates immediately.
+	// Registry mutations without a chains change are not tracked here; they are rare
+	// and in practice coincide with a settings reload that replaces the chains object.
+	private canonicalCache: { key: string; chains: FallbackChains } | undefined;
 
 	constructor(deps: RetryFallbackControllerDeps) {
 		this.deps = deps;
@@ -80,7 +89,17 @@ export class RetryFallbackController {
 
 	clear(): void {
 		this.state = undefined;
+		this.canonicalCache = undefined;
 		this.resetTurn();
+	}
+
+	private canonicalChains(): FallbackChains {
+		const chains = this.deps.getSettings().chains;
+		const key = JSON.stringify(chains);
+		if (this.canonicalCache?.key === key) return this.canonicalCache.chains;
+		const canonical = canonicalizeFallbackChains(chains, this.deps.registry);
+		this.canonicalCache = { key, chains: canonical };
+		return canonical;
 	}
 
 	canTryFallback(): boolean {
@@ -96,7 +115,7 @@ export class RetryFallbackController {
 	hasConfiguredChain(): boolean {
 		const current = this.deps.getCurrentSelector();
 		if (!current) return false;
-		const chains = canonicalizeFallbackChains(this.deps.getSettings().chains, this.deps.registry);
+		const chains = this.canonicalChains();
 		return resolveChainKey(current.model, current.thinkingLevel, chains) !== undefined;
 	}
 
@@ -182,7 +201,7 @@ export class RetryFallbackController {
 		const settings = this.deps.getSettings();
 		const current = this.deps.getCurrentSelector();
 		if (!settings.modelFallback || !current) return undefined;
-		const chains = canonicalizeFallbackChains(settings.chains, this.deps.registry);
+		const chains = this.canonicalChains();
 		const chainKey = resolveChainKey(current.model, current.thinkingLevel, chains) ?? this.state?.chainKey;
 		const entries = chainKey ? chains[chainKey] : undefined;
 		if (!chainKey || !entries) {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -541,10 +541,11 @@ export class FileSettingsStorage implements SettingsStorage {
 					throw error;
 				}
 				lastError = error;
-				const start = Date.now();
-				while (Date.now() - start < delayMs) {
-					// Sleep synchronously to avoid changing callers to async.
-				}
+				// Atomics.wait sleeps the thread without spinning, so contended lock retries
+				// no longer burn a CPU core per waiter (root cause of the TUI freeze under
+				// provider-error storms). Stays synchronous to keep callers unchanged.
+				const sleeper = new Int32Array(new SharedArrayBuffer(4));
+				Atomics.wait(sleeper, 0, 0, delayMs);
 			}
 		}
 

--- a/packages/coding-agent/test/cursor-cli-oauth/settings-cache.test.ts
+++ b/packages/coding-agent/test/cursor-cli-oauth/settings-cache.test.ts
@@ -1,0 +1,72 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadCursorCliOauthProviderSettingsFromDisk } from "../../src/core/extensions/builtin/cursor-cli-oauth/settings.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+
+const temporaryDirectories: string[] = [];
+const originalAgentDir = process.env.SENPI_CODING_AGENT_DIR;
+
+function temporaryDirectory(): string {
+	const directory = mkdtempSync(join(tmpdir(), "senpi-cursor-oauth-cache-"));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+afterEach(() => {
+	if (originalAgentDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+	else process.env.SENPI_CODING_AGENT_DIR = originalAgentDir;
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("Cursor CLI OAuth provider settings cache", () => {
+	let cwd: string;
+	let agentDir: string;
+	let settingsPath: string;
+	let createSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		agentDir = temporaryDirectory();
+		cwd = temporaryDirectory();
+		process.env.SENPI_CODING_AGENT_DIR = agentDir;
+		mkdirSync(agentDir, { recursive: true });
+		settingsPath = join(agentDir, "settings.json");
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({ cursorCliOauthProvider: { enabled: true, pinnedAccount: "first" } }),
+		);
+		createSpy = vi.spyOn(SettingsManager, "create");
+	});
+
+	afterEach(() => {
+		createSpy.mockRestore();
+	});
+
+	it("#given an unchanged settings file #when the loader is called repeatedly #then SettingsManager.create runs once, not per call", () => {
+		const N = 5;
+		for (let i = 0; i < N; i++) loadCursorCliOauthProviderSettingsFromDisk(cwd);
+
+		expect(createSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+		// The loader caches by (cwd, mtime, size); unchanged files must not create
+		// a fresh SettingsManager + locked disk reads on every call. Current code
+		// has no cache => N creates.
+		expect(createSpy.mock.calls.length).toBeLessThan(N);
+	});
+
+	it("#given a rewritten settings file #when the loader runs again #then the cache invalidates and create runs", () => {
+		loadCursorCliOauthProviderSettingsFromDisk(cwd);
+		const before = createSpy.mock.calls.length;
+
+		writeFileSync(
+			settingsPath,
+			JSON.stringify({ cursorCliOauthProvider: { enabled: false, pinnedAccount: "second" } }),
+		);
+		const result = loadCursorCliOauthProviderSettingsFromDisk(cwd);
+
+		expect(createSpy.mock.calls.length).toBeGreaterThan(before);
+		expect(result.pinnedAccount).toBe("second");
+	});
+});

--- a/packages/coding-agent/test/retry-fallback-controller-memo.test.ts
+++ b/packages/coding-agent/test/retry-fallback-controller-memo.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
-import type { Api, Model } from "@earendil-works/pi-ai";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { describe, expect, it, vi } from "vitest";
 import { RetryFallbackController } from "../src/core/retry-fallback/controller.ts";
 
 function makeModel(provider: string, id: string): Model<Api> {
@@ -18,7 +18,11 @@ interface Deps {
 		isUsingOAuth?: (model: Model<Api>) => boolean;
 		isFallbackEligible?: (model: Model<Api>) => boolean;
 	};
-	cooldowns: { isSuppressed: (selector: string) => boolean; note: (selector: string, failure: object) => void; clear: (selector: string) => void };
+	cooldowns: {
+		isSuppressed: (selector: string) => boolean;
+		note: (selector: string, failure: object) => void;
+		clear: (selector: string) => void;
+	};
 	logger: { info: (event: string, meta: object) => void; debug: (event: string, meta: object) => void };
 	switchModel: (model: Model<Api>, thinking: ThinkingLevel, reason: "fallback" | "fallback-revert") => Promise<void>;
 	emit: (event: object) => void;
@@ -26,12 +30,20 @@ interface Deps {
 	isAuthAvailable: (provider: string) => boolean;
 }
 
-function makeController(overrides: Partial<Deps> = {}): { controller: RetryFallbackController; eligibleSpy: ReturnType<typeof vi.fn> } {
+function makeController(overrides: Partial<Deps> = {}): {
+	controller: RetryFallbackController;
+	eligibleSpy: ReturnType<typeof vi.fn>;
+} {
 	const eligibleSpy = vi.fn(() => true);
 	const deps: Deps = {
 		getSettings: () => ({ modelFallback: true, chains: { "claude-fable-5": ["kimi-k3:max"] } }),
 		registry: {
-			find: (provider, id) => (provider === "anthropic" && id === "claude-fable-5" ? CLAUDE : provider === "kimi-coding" && id === "kimi-k3" ? KIMI : undefined),
+			find: (provider, id) =>
+				provider === "anthropic" && id === "claude-fable-5"
+					? CLAUDE
+					: provider === "kimi-coding" && id === "kimi-k3"
+						? KIMI
+						: undefined,
 			getAll: () => [CLAUDE, KIMI],
 			isUsingOAuth: () => false,
 			isFallbackEligible: eligibleSpy,

--- a/packages/coding-agent/test/retry-fallback-controller-memo.test.ts
+++ b/packages/coding-agent/test/retry-fallback-controller-memo.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import { RetryFallbackController } from "../src/core/retry-fallback/controller.ts";
+
+function makeModel(provider: string, id: string): Model<Api> {
+	return { provider, id } as unknown as Model<Api>;
+}
+
+const CLAUDE = makeModel("anthropic", "claude-fable-5");
+const KIMI = makeModel("kimi-coding", "kimi-k3");
+
+interface Deps {
+	getSettings: () => { modelFallback: boolean; chains: Readonly<Record<string, readonly string[]>> };
+	registry: {
+		find: (provider: string, id: string) => Model<Api> | undefined;
+		getAll: () => Model<Api>[];
+		isUsingOAuth?: (model: Model<Api>) => boolean;
+		isFallbackEligible?: (model: Model<Api>) => boolean;
+	};
+	cooldowns: { isSuppressed: (selector: string) => boolean; note: (selector: string, failure: object) => void; clear: (selector: string) => void };
+	logger: { info: (event: string, meta: object) => void; debug: (event: string, meta: object) => void };
+	switchModel: (model: Model<Api>, thinking: ThinkingLevel, reason: "fallback" | "fallback-revert") => Promise<void>;
+	emit: (event: object) => void;
+	getCurrentSelector: () => { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined;
+	isAuthAvailable: (provider: string) => boolean;
+}
+
+function makeController(overrides: Partial<Deps> = {}): { controller: RetryFallbackController; eligibleSpy: ReturnType<typeof vi.fn> } {
+	const eligibleSpy = vi.fn(() => true);
+	const deps: Deps = {
+		getSettings: () => ({ modelFallback: true, chains: { "claude-fable-5": ["kimi-k3:max"] } }),
+		registry: {
+			find: (provider, id) => (provider === "anthropic" && id === "claude-fable-5" ? CLAUDE : provider === "kimi-coding" && id === "kimi-k3" ? KIMI : undefined),
+			getAll: () => [CLAUDE, KIMI],
+			isUsingOAuth: () => false,
+			isFallbackEligible: eligibleSpy,
+		},
+		cooldowns: { isSuppressed: () => false, note: () => {}, clear: () => {} },
+		logger: { info: () => {}, debug: () => {} },
+		switchModel: vi.fn(async () => {}),
+		emit: () => {},
+		getCurrentSelector: () => ({ model: CLAUDE, thinkingLevel: undefined }),
+		isAuthAvailable: () => true,
+		...overrides,
+	};
+	return { controller: new RetryFallbackController(deps as never), eligibleSpy };
+}
+
+describe("RetryFallbackController canonicalization memoization", () => {
+	it("#given unchanged settings and registry #when canTryFallback is called repeatedly #then isFallbackEligible is probed once, not per call", () => {
+		const { controller, eligibleSpy } = makeController();
+		const N = 5;
+		for (let i = 0; i < N; i++) controller.canTryFallback();
+
+		expect(eligibleSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+		// Memoized canonicalization probes the registry once, not N times.
+		// Current (un-memoized) code re-canonicalizes every call => >= N probes.
+		expect(eligibleSpy.mock.calls.length).toBeLessThan(N);
+	});
+
+	it("#given a changed chains setting #when canTryFallback runs again #then canonicalization is refreshed", () => {
+		let chains: Readonly<Record<string, readonly string[]>> = { "claude-fable-5": ["kimi-k3:max"] };
+		const { controller, eligibleSpy } = makeController({ getSettings: () => ({ modelFallback: true, chains }) });
+		controller.canTryFallback();
+		const before = eligibleSpy.mock.calls.length;
+
+		chains = { "claude-fable-5": ["kimi-k3:max", "claude-opus-5:xhigh"] };
+		controller.canTryFallback();
+
+		expect(eligibleSpy.mock.calls.length).toBeGreaterThan(before);
+	});
+});

--- a/packages/coding-agent/test/settings-lock-cpu-spin.test.ts
+++ b/packages/coding-agent/test/settings-lock-cpu-spin.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileSettingsStorage, getSettingsPath } from "../src/core/settings-manager.ts";
+
+const lockState = vi.hoisted(() => ({
+	attempts: 0,
+	// Throw ELOCKED for attempts 1..9, succeed on the 10th => 9x ~20ms waits.
+	succeedOnAttempt: 10,
+}));
+
+vi.mock("proper-lockfile", async (importOriginal) => {
+	const actual = await importOriginal<{ default: typeof import("proper-lockfile") }>();
+	const base = actual.default;
+	return {
+		default: {
+			...base,
+			lockSync: (_path: string, _opts?: Parameters<typeof base.lockSync>[1]) => {
+				lockState.attempts += 1;
+				if (lockState.attempts < lockState.succeedOnAttempt) {
+					throw Object.assign(new Error("LOCKED"), { code: "ELOCKED" });
+				}
+				return () => {};
+			},
+		},
+	};
+});
+
+describe("FileSettingsStorage lock-retry CPU spin", () => {
+	let root: string;
+	let cwd: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "senpi-cpuspin-"));
+		const agentDir = join(root, "agent");
+		cwd = join(root, "work");
+		settingsPath = getSettingsPath(cwd, agentDir, "global", root);
+		mkdirSync(join(root, "agent"), { recursive: true });
+		writeFileSync(settingsPath, JSON.stringify({ x: 1 }), "utf-8");
+		lockState.attempts = 0;
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("#given a contended lock #when withLock waits through 9 retries #then user CPU stays a small fraction of wall time (no busy-wait spin)", () => {
+		const storage = new FileSettingsStorage(cwd, join(root, "agent"), root);
+		const cpuBefore = process.cpuUsage();
+		const wallBefore = Date.now();
+		storage.withLock("global", (current) => {
+			expect(current).toBeDefined();
+			return undefined;
+		});
+		const cpuAfter = process.cpuUsage();
+		const wallMs = Date.now() - wallBefore;
+		const userMs = (cpuAfter.user - cpuBefore.user) / 1000;
+
+		// 9 retries x 20ms = ~180ms wall. The wait MUST happen (proves the retry
+		// path ran) but CPU must NOT burn near wall-clock (a busy-wait spin does).
+		// A real sleep keeps user CPU near zero; a spin makes it ~= wall time.
+		expect(wallMs).toBeGreaterThan(100);
+		expect(userMs).toBeLessThan(80);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the settings-lock CPU-spin that froze the senpi/omo TUI at ~100% CPU under provider-error storms. Root cause: the retry-fallback hot path performed per-call locked disk reads with a synchronous busy-wait, and provider-error storms (429/5xx) drove it hundreds of times per session per error.

## Root cause (V8 profile of a frozen omo process)
- 65% `acquireLockSyncWithRetry` — `while (Date.now() - start < 20) {}` busy-wait
- 18% `parseSettingsJson` — fresh `SettingsManager.create` per `fallbackEligible()` probe
- Per provider error: 4-6 `canTryFallback` × 6 canonicalization passes × N model eligibility probes × 2 locked reads = hundreds of lock+parse ops on the main thread

## Changes (3 fixes, semantics preserved)
1. **F1 — spin removal** (`settings-manager.ts`): replace `while(Date.now())` busy-wait with `Atomics.wait` on a `SharedArrayBuffer`. Stays synchronous (callers unchanged, 20ms/10-attempt policy preserved) but the thread sleeps.
2. **F2 — canonicalization memo** (`retry-fallback/controller.ts`): cache `canonicalizeFallbackChains` by serialized chains content. Unchanged config reuses the result; a chains edit invalidates immediately.
3. **F3 — oauth-lane settings cache** (`cursor-cli-oauth/settings.ts`, `claude-sdk-oauth/settings.ts`): cache the `SettingsManager` instance by (cwd, mtimeMs:size). A cache hit skips `create` + locked disk reads; env overrides re-parse live; a settings edit invalidates.

## Failing-first proofs (RED→GREEN)
- **F1**: `test/settings-lock-cpu-spin.test.ts` — contended lock (9×ELOCKED). RED: user CPU 179.9ms ≈ 180ms wall (spin). GREEN: user CPU near 0 (sleep).
- **F2**: `test/retry-fallback-controller-memo.test.ts` — 5 `canTryFallback` calls. RED: 20 `isFallbackEligible` probes (4/call). GREEN: probes collapse; chains edit refreshes.
- **F3**: `test/cursor-cli-oauth/settings-cache.test.ts` — 5 loader calls. RED: 5 `SettingsManager.create`. GREEN: 1 create; rewrite invalidates.

## Verification
- Scoped suites: 8 files / 144 tests green (settings-manager, settings-storage-lock, settings-manager-retry-fallback, settings-manager-bug, settings-lock-cpu-spin, retry-fallback-controller-memo, cursor-cli-oauth/settings-cache, cursor-cli-oauth/settings). Claude-SDK-OAuth cluster: 51 files / 417 tests green.
- `npm run check` green (biome + tsc + pinned-deps + shrinkwrap + install-lock + claude-sdk-platform-lock).
- senpi-qa CLI smoke: 8/8 passed (`--help`, `--version`, `--list-models`, unknown-option exit 1, real auth untouched).
- `audit-changes-md`: 0 uncovered paths for touched files.

## Out of scope (follow-ups)
- Lock-free reads via atomic temp+rename writes (larger blast radius).
- config-reload watcher FSEvents feedback (lock dir inside watched agent dir) — amplifier, not root cause.
- No removal of `fallbackEligible` refusal semantics (PR #978).

## changes.md
- `core/changes.md` (settings-manager.ts, controller.ts)
- `cursor-cli-oauth/changes.md`
- `claude-sdk-oauth/changes.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the settings-lock busy-wait that froze the `senpi/omo` TUI during provider-error storms. Old behavior: lock retries spun on the main thread; new behavior: retries sleep synchronously with `Atomics.wait`, with reduced lock pressure via memoization and cached settings loads.

- Core lock retries: in `settings-manager.ts`, replace the `while`-spin with `Atomics.wait`. Synchronous calls and the 20ms/10-attempt policy are unchanged; CPU spin under contention is removed.
- Retry-fallback canonicalization: in `retry-fallback/controller.ts`, memoize `canonicalizeFallbackChains` by serialized chains content. Unchanged chains reuse results; a chains edit or `clear()` invalidates.
- OAuth provider settings loads: in `cursor-cli-oauth/settings.ts` and `claude-sdk-oauth/settings.ts`, cache the `SettingsManager` by `(cwd, mtimeMs:size)` for global/project settings. Cache hits skip locked reads; env overrides re-parse on every call; file edits invalidate automatically.
- Verification: add tests for low CPU during lock contention, reduced eligibility probes with memoization, and fewer manager creations with the per-file cache; update `CHANGELOG.md` and extension `changes.md`.

<sup>Written for commit 5a1c276a61f0e148f20624fefd91e06602c38658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

