### PR TITLE
perf(coding-agent): make settings reads lock-free via atomic rename publish

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Changed
 
+- Settings reads no longer acquire the settings lock: writes publish atomically via a same-directory temp file plus rename, so read-only settings loads skip lock acquisition entirely and can never observe a torn write. Concurrent writers still serialize on the lock and re-merge against the winner's content.
+
 - Refreshed dependency pins, including `@anthropic-ai/claude-agent-sdk` 0.3.238, `jsdom` 30, `undici` 8.10.0, `marked` 18.0.10, `highlight.js` 11.12.0, `grok-mermaid` 0.2.3, `minimatch` 10.2.6, `ws` 8.21.3, and `typebox` 1.3.16, and removed the unused `@mistralai/mistralai` and `@types/ms` entries.
 
 - The `monitor` tool's description, schema text, prompt guidance, and terminal docs now state the verified contract (PTY output with stderr merged, event-only filtering, dedup and pause semantics) and include worked recipes plus an anti-pattern reference.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-21 - Settings reads are lock-free; writes publish atomically via temp+rename
+
+### What changed
+
+- `packages/coding-agent/src/core/settings-manager.ts`: `FileSettingsStorage.withLock` no longer acquires the settings lock for read-only callbacks. The initial read happens without the lock; only a callback that returns content acquires the lock, re-reads under it, re-runs the callback when a concurrent winner changed the file, and publishes by writing a same-directory `*.tmp` file then `renameSync`-ing it over the settings path. `recordSelfWrite` fires before the rename so the config-reload watcher's self-write suppression still sees the hash first. A failed publish removes the temp file and rethrows.
+
+### Why
+
+- Follow-up to the settings-lock CPU-spin fix (#1056). Locked reads were the remaining lock-pressure source: every `SettingsManager` load acquired the lock even when nothing was written, so cache misses and multi-session startups still convoyed on `settings.json.lock`. Atomic rename publish makes torn reads impossible, which is the precondition for dropping the read lock entirely.
+
+### Why an extension could not handle it
+
+- `FileSettingsStorage` is the core settings persistence path with no extension seam.
+
+### Expected merge conflict zones
+
+- `settings-manager.ts` around `withLock` (line ~555) and the `fs` import list (line ~5).
+
+
 ## 2026-08-21 - Settings-lock retry sleeps instead of spinning; retry-fallback canonicalization memoized
 
 ### What changed

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -2,7 +2,7 @@ import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { Transport } from "@earendil-works/pi-ai";
 import type { TuiMode as RendererTuiMode, ScrollViewScrollbar } from "@earendil-works/pi-tui";
 import { createHash, randomUUID } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import lockfile from "proper-lockfile";
@@ -556,36 +556,40 @@ export class FileSettingsStorage implements SettingsStorage {
 		const path = scope === "global" ? this.globalSettingsPath : this.projectSettingsPath;
 		const dir = dirname(path);
 
-		let release: (() => void) | undefined;
+		// Read without the lock: writers publish atomically via temp+rename below, so
+		// a reader can never observe partial content. Read-only callers therefore skip
+		// lock acquisition entirely (no lock churn, no lock-dir filesystem events).
+		const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+		let next = fn(current);
+		if (next === undefined) {
+			return;
+		}
+		// Only create directory when we actually need to write
+		if (!existsSync(dir)) {
+			mkdirSync(dir, { recursive: true });
+		}
+		const release = this.acquireLockSyncWithRetry(path);
 		try {
-			// Only create directory and lock if file exists or we need to write
-			let current: string | undefined;
-			if (existsSync(path)) {
-				release = this.acquireLockSyncWithRetry(path);
-				current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+			const underLock = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+			if (underLock !== current) {
+				// Lost a write race: re-merge against the winner's content under the lock.
+				next = fn(underLock);
 			}
-			let next = fn(current);
 			if (next !== undefined) {
-				// Only create directory when we actually need to write
-				if (!existsSync(dir)) {
-					mkdirSync(dir, { recursive: true });
-				}
-				if (!release) {
-					release = this.acquireLockSyncWithRetry(path);
-					if (existsSync(path)) {
-						// Lost the first-write race: re-merge against the winner's content under the lock.
-						next = fn(readFileSync(path, "utf-8"));
-					}
-				}
-				if (next !== undefined) {
-					writeFileSync(path, next, "utf-8");
+				// Publish atomically: write a same-directory temp file, then rename over
+				// the settings path so lock-free readers never see a torn write.
+				const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+				try {
+					writeFileSync(tempPath, next, "utf-8");
 					recordSelfWrite(path, next);
+					renameSync(tempPath, path);
+				} catch (error) {
+					rmSync(tempPath, { force: true });
+					throw error;
 				}
 			}
 		} finally {
-			if (release) {
-				release();
-			}
+			release();
 		}
 	}
 }

--- a/packages/coding-agent/test/lockfile-policy.test.ts
+++ b/packages/coding-agent/test/lockfile-policy.test.ts
@@ -38,7 +38,9 @@ describe("file storage lock policy", () => {
 			const authBackend = new FileAuthStorageBackend(authPath);
 			authBackend.withLock((current) => ({ result: current }));
 			await authBackend.withLockAsync(async (current) => ({ result: current }));
-			new FileSettingsStorage(directory, agentDir).withLock("global", () => undefined);
+			// Reads are lock-free since the atomic temp+rename publish, so the settings
+			// lock policy is observable only through a write-returning callback.
+			new FileSettingsStorage(directory, agentDir).withLock("global", () => "{}");
 
 			// #then
 			expect(syncOptions).toHaveLength(2);

--- a/packages/coding-agent/test/settings-lock-cpu-spin.test.ts
+++ b/packages/coding-agent/test/settings-lock-cpu-spin.test.ts
@@ -50,9 +50,11 @@ describe("FileSettingsStorage lock-retry CPU spin", () => {
 		const storage = new FileSettingsStorage(cwd, join(root, "agent"), root);
 		const cpuBefore = process.cpuUsage();
 		const wallBefore = Date.now();
+		// Reads are lock-free since the atomic temp+rename publish; only a WRITE
+		// acquires the settings lock, so contention is exercised through one.
 		storage.withLock("global", (current) => {
 			expect(current).toBeDefined();
-			return undefined;
+			return JSON.stringify({ x: 2 });
 		});
 		const cpuAfter = process.cpuUsage();
 		const wallMs = Date.now() - wallBefore;

--- a/packages/coding-agent/test/settings-lock-free-reads.test.ts
+++ b/packages/coding-agent/test/settings-lock-free-reads.test.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileSettingsStorage, getSettingsPath, wasSelfWrite } from "../src/core/settings-manager.ts";
+
+const lockState = vi.hoisted(() => ({
+	acquisitions: 0,
+	onNextAcquire: undefined as (() => void) | undefined,
+}));
+
+vi.mock("proper-lockfile", async (importOriginal) => {
+	const actual = await importOriginal<{ default: typeof import("proper-lockfile") }>();
+	const base = actual.default;
+	return {
+		default: {
+			...base,
+			lockSync: (path: string, options?: Parameters<typeof base.lockSync>[1]) => {
+				lockState.acquisitions += 1;
+				const hook = lockState.onNextAcquire;
+				lockState.onNextAcquire = undefined;
+				hook?.();
+				return base.lockSync(path, options);
+			},
+		},
+	};
+});
+
+const fsCalls = vi.hoisted(() => ({
+	writes: [] as string[],
+	renames: [] as { from: string; to: string }[],
+}));
+
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>();
+	return {
+		...actual,
+		writeFileSync: ((...args: Parameters<typeof actual.writeFileSync>) => {
+			if (typeof args[0] === "string") fsCalls.writes.push(args[0]);
+			return actual.writeFileSync(...args);
+		}) as typeof actual.writeFileSync,
+		renameSync: ((from: Parameters<typeof actual.renameSync>[0], to: Parameters<typeof actual.renameSync>[1]) => {
+			fsCalls.renames.push({ from: String(from), to: String(to) });
+			return actual.renameSync(from, to);
+		}) as typeof actual.renameSync,
+	};
+});
+
+describe("FileSettingsStorage lock-free reads with atomic rename publish", () => {
+	let root: string;
+	let agentDir: string;
+	let cwd: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "senpi-lockfree-"));
+		agentDir = join(root, "agent");
+		cwd = join(root, "work");
+		settingsPath = getSettingsPath(cwd, agentDir, "global", root);
+		lockState.acquisitions = 0;
+		lockState.onNextAcquire = undefined;
+		fsCalls.writes.length = 0;
+		fsCalls.renames.length = 0;
+	});
+
+	afterEach(() => {
+		lockState.onNextAcquire = undefined;
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("#given an existing settings file #when the callback only reads #then no lock is acquired", () => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }), "utf-8");
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+		let observed: string | undefined;
+
+		storage.withLock("global", (current) => {
+			observed = current;
+			return undefined;
+		});
+
+		expect(observed).toBe(JSON.stringify({ theme: "dark" }));
+		expect(lockState.acquisitions).toBe(0);
+	});
+
+	it("#given a write #then content is published only through temp-file rename, never a direct write to the settings path", () => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }), "utf-8");
+		fsCalls.writes.length = 0;
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+
+		storage.withLock("global", () => JSON.stringify({ theme: "light" }));
+
+		expect(fsCalls.writes).not.toContain(settingsPath);
+		expect(fsCalls.renames.some((r) => r.to === settingsPath && r.from !== settingsPath)).toBe(true);
+		expect(JSON.parse(readFileSync(settingsPath, "utf-8"))).toEqual({ theme: "light" });
+		expect(lockState.acquisitions).toBe(1);
+	});
+
+	it("#given an existing file changed by a concurrent winner before the write lock #then the merge re-runs against the winner's content", () => {
+		mkdirSync(agentDir, { recursive: true });
+		writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }), "utf-8");
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+		lockState.onNextAcquire = () => {
+			writeFileSync(settingsPath, JSON.stringify({ theme: "winner" }), "utf-8");
+		};
+
+		storage.withLock("global", (current) => {
+			const settings: Record<string, unknown> = current ? (JSON.parse(current) as Record<string, unknown>) : {};
+			settings.defaultModel = "merged-model";
+			return JSON.stringify(settings);
+		});
+
+		const written = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+		expect(written.defaultModel).toBe("merged-model");
+		expect(written.theme).toBe("winner");
+	});
+
+	it("#given a rename-published write #then the content is recorded as a self-write and no temp file is left behind", () => {
+		const storage = new FileSettingsStorage(cwd, agentDir, root);
+		const content = JSON.stringify({ created: true });
+
+		storage.withLock("global", () => content);
+
+		const hash = createHash("sha256").update(content).digest("hex");
+		expect(wasSelfWrite(settingsPath, hash)).toBe(true);
+		expect(existsSync(settingsPath)).toBe(true);
+		const leftovers = readFileSync(settingsPath, "utf-8");
+		expect(JSON.parse(leftovers)).toEqual({ created: true });
+		expect(readdirSync(agentDir).filter((name) => name.includes(".tmp"))).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to #1056 (settings-lock CPU-spin TUI freeze). This lands the deferred item from that PR's follow-up list: **lock-free settings reads via atomic temp+rename writes**.

Locked reads were the remaining lock-pressure source after #1056: every `SettingsManager` load acquired `settings.json.lock` even when nothing was written, so cache misses and multi-session startups still convoyed on the lock.

## Changes

- `FileSettingsStorage.withLock` (settings-manager.ts):
  - Read-only callbacks (callback returns `undefined`) no longer acquire the lock at all.
  - Writers publish atomically: content is written to a same-directory `<path>.<pid>.<uuid>.tmp` file, then `renameSync`-ed over the settings path — lock-free readers can never observe a torn write.
  - Writers still serialize on the lock: after acquisition the file is re-read, and if a concurrent winner changed it since the unlocked read, the callback re-runs against the winner's content (same merge semantics the no-file race already had).
  - `recordSelfWrite` fires before the rename so config-reload self-write suppression sees the hash before any watcher event; a failed publish removes the temp file and rethrows.

## Semantics preserved

- Synchronous API unchanged; `SettingsStorage` interface unchanged; `InMemorySettingsStorage` untouched.
- 20ms/10-attempt lock retry policy (with #1056's `Atomics.wait` sleep) unchanged for writers.
- Temp files (`settings.json.*.tmp`) and the lock dir are both dropped by the config-reload allowList filter (`relativePath === allowed || startsWith(allowed + sep)`), so no new watcher feedback.

## Verification

- New `test/settings-lock-free-reads.test.ts` (RED-first): read-only never locks; publish happens only via temp+rename (never a direct write to the settings path); concurrent-winner re-merge under the write lock; self-write recording + no temp leftovers.
- `test/settings-lock-cpu-spin.test.ts` updated: lock contention is now exercised through a write (reads no longer lock).
- Scoped suites: settings + config-reload = 31 files / 296 tests green.
- `npm run check` green (biome + tsc + pinned-deps + shrinkwrap + install-lock + claude-sdk-platform-lock).
- senpi-qa: CLI smoke 8/8, mock loop `--with-tool` 4/4 (real CLI turn from source, isolated sandbox, real auth untouched). Evidence: `local-ignore/qa-evidence/20260821-settings-lock-free-reads/`.

## Out of scope

- `fallbackEligible` refusal semantics (intentionally preserved, see #978 / #1056).
- senpi-qa harness gap: `mock-loop.mjs --with-tool` ignores `--evidence` (only `--run`/scenario paths forward it) — noted for a separate fix.

## changes.md

- `packages/coding-agent/src/core/changes.md` (settings-manager.ts entry)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make settings reads lock-free; writes publish atomically via same-directory temp file + rename. Previously all reads acquired `settings.json.lock`; now only writers lock, eliminating read convoys while preserving serialized writes and preventing torn reads.

- Read-only callbacks in `FileSettingsStorage.withLock` (callback returns `undefined`) skip the lock; initial read is unlocked.
- Writers: acquire the lock, re-read, re-run the callback if the file changed, write `<path>.<pid>.<uuid>.tmp`, call `recordSelfWrite`, then `renameSync` to the final path; remove the temp file on failure.
- No API or lock retry changes; watcher allowlist already ignores `*.tmp`.
- Tests: added `settings-lock-free-reads.test.ts`; updated lock policy and CPU-spin tests to exercise contention via a write (reads no longer lock).

<sup>Written for commit 98f97881e154f4e407aff2355f4bf671ac4de72c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

