### PR TITLE
fix(coding-agent): sleep contended auth-lock retries instead of busy-waiting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Contended auth-storage lock retries now sleep via `Atomics.wait` instead of busy-waiting, matching the settings-lock fix (#1056). The auth store kept the original spin loop, so under multi-session OAuth-refresh contention a synchronous auth write could burn a CPU core on the main thread.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -109,10 +109,11 @@ export class FileAuthStorageBackend implements AuthStorageBackend {
 					throw error;
 				}
 				lastError = error;
-				const start = Date.now();
-				while (Date.now() - start < delayMs) {
-					// Sleep synchronously to avoid changing callers to async.
-				}
+				// Atomics.wait sleeps the thread without spinning, so contended lock retries
+				// no longer burn a CPU core per waiter (same root cause as the settings-lock
+				// TUI freeze fixed in #1056). Stays synchronous to keep callers unchanged.
+				const sleeper = new Int32Array(new SharedArrayBuffer(4));
+				Atomics.wait(sleeper, 0, 0, delayMs);
 			}
 		}
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-21 - Auth-storage lock retry sleeps instead of spinning
+
+### What changed
+
+- `packages/coding-agent/src/core/auth-storage.ts`: `FileAuthStorageBackend.acquireLockSyncWithRetry` replaces the `while (Date.now() - start < delayMs) {}` busy-wait with `Atomics.wait` on a `SharedArrayBuffer`. The wait stays synchronous (callers and the 20ms/10-attempt policy unchanged) but the thread actually sleeps.
+
+### Why
+
+- This is the same defect PR #1056 removed from `settings-manager.ts`, but `auth-storage.ts` was left out of both #1056 and #1057. The sync `withLock` paths (`reload()`, `set()`, `remove()`) reach it, so under multi-session OAuth-refresh contention (auth.json rewritten by other sessions, forcing `reload()` through a contended lock) a synchronous auth write could spin up to 10×20ms of pure CPU on the main thread.
+
+### Why an extension could not handle it
+
+- `FileAuthStorageBackend` is the core credential persistence path with no extension seam.
+
+### Expected merge conflict zones
+
+- `auth-storage.ts` around `acquireLockSyncWithRetry` (line ~95).
+
+
 ## 2026-08-21 - Settings reads are lock-free; writes publish atomically via temp+rename
 
 ### What changed

--- a/packages/coding-agent/test/auth-lock-cpu-spin.test.ts
+++ b/packages/coding-agent/test/auth-lock-cpu-spin.test.ts
@@ -1,0 +1,59 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileAuthStorageBackend } from "../src/core/auth-storage.ts";
+
+const lockState = vi.hoisted(() => ({
+	attempts: 0,
+	succeedOnAttempt: 10,
+}));
+
+vi.mock("proper-lockfile", async (importOriginal) => {
+	const actual = await importOriginal<{ default: typeof import("proper-lockfile") }>();
+	const base = actual.default;
+	return {
+		default: {
+			...base,
+			lockSync: (_path: string, _opts?: Parameters<typeof base.lockSync>[1]) => {
+				lockState.attempts += 1;
+				if (lockState.attempts < lockState.succeedOnAttempt) {
+					throw Object.assign(new Error("LOCKED"), { code: "ELOCKED" });
+				}
+				return () => {};
+			},
+		},
+	};
+});
+
+describe("FileAuthStorageBackend lock-retry CPU spin", () => {
+	let root: string;
+	let authPath: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "senpi-authspin-"));
+		authPath = join(root, "auth.json");
+		mkdirSync(root, { recursive: true });
+		writeFileSync(authPath, "{}", "utf-8");
+		lockState.attempts = 0;
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("#given a contended auth lock #when a sync write waits through 9 retries #then user CPU stays a small fraction of wall time (no busy-wait spin)", () => {
+		const backend = new FileAuthStorageBackend(authPath);
+		const cpuBefore = process.cpuUsage();
+		const wallBefore = Date.now();
+		backend.withLock((current) => ({ result: undefined, next: current ?? "{}" }));
+		const cpuAfter = process.cpuUsage();
+		const wallMs = Date.now() - wallBefore;
+		const userMs = (cpuAfter.user - cpuBefore.user) / 1000;
+
+		// 9 retries x 20ms = ~180ms wall must elapse (retry path ran), but a real
+		// sleep keeps user CPU near zero while a busy-wait spin makes it ~= wall.
+		expect(wallMs).toBeGreaterThan(100);
+		expect(userMs).toBeLessThan(80);
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to #1056 (settings-lock CPU-spin). The auth store kept the **identical busy-wait loop** that #1056 removed from `settings-manager.ts` — `auth-storage.ts` was left out of both #1056 and #1057.

## The defect

`FileAuthStorageBackend.acquireLockSyncWithRetry` (`auth-storage.ts:113`):

```ts
const start = Date.now();
while (Date.now() - start < delayMs) {
    // Sleep synchronously to avoid changing callers to async.
}
```

Reached via the synchronous `withLock` paths — `reload()` (fired from the constructor when auth.json's revision changes, i.e. whenever another session refreshes an OAuth token), `set()`, `remove()`. Under multi-session OAuth-refresh contention, a synchronous auth write spins up to 10×20ms of pure CPU on the main thread.

## The fix

Mirrors #1056 exactly: replace the spin with `Atomics.wait` on a `SharedArrayBuffer`. The wait stays synchronous (callers and the 20ms/10-attempt policy unchanged) but the thread actually sleeps.

## Verification

- New `test/auth-lock-cpu-spin.test.ts` (RED-first): contended auth lock through 9 ELOCKED retries — **RED**: user CPU 178ms ≈ wall time (spin burning a core); **GREEN** after the fix (thread sleeps).
- Scoped suites green: `auth-storage`, `lockfile-policy`, `settings-lock-cpu-spin`, `settings-lock-free-reads`, `settings-storage-lock`, `auth-read-lock-degrade` + the new file = 7 files / 38 tests.
- `npm run check` green. senpi-qa: CLI smoke 8/8, mock loop `--with-tool` 4/4. Evidence: `local-ignore/qa-evidence/20260821-auth-lock-spin/`.
- Note: `test/mcp/oauth-race.test.ts` fails to *collect* in a fresh worktree because it is a child-process suite needing built workspace `dist/` (the #1029 prerequisite) — unrelated to this change.

## changes.md

- `packages/coding-agent/src/core/changes.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop busy-waiting in contended auth lock retries; sleep with `Atomics.wait` instead. Previously `FileAuthStorageBackend.acquireLockSyncWithRetry` spun up to 10×20ms on the main thread; now it sleeps synchronously, cutting CPU burn during multi-session OAuth refreshes with no API or policy changes.

- Replaces the spin loop in `packages/coding-agent/src/core/auth-storage.ts` with `Atomics.wait` on a `SharedArrayBuffer` inside `acquireLockSyncWithRetry`.
- Keeps the synchronous call pattern and retry policy (20 ms delay, up to 10 attempts); no migration required.
- Adds `packages/coding-agent/test/auth-lock-cpu-spin.test.ts` to verify reduced user CPU under lock contention (mocks `proper-lockfile`).

<sup>Written for commit 495c4cfeb2e6f9ac72e677772bac2bcdf8d2aa2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

