### PR TITLE
fix(interactive): release the model selector before the auth round trip

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Contended auth-storage lock retries now sleep via `Atomics.wait` instead of busy-waiting, matching the settings-lock fix (#1056). The auth store kept the original spin loop, so under multi-session OAuth-refresh contention a synchronous auth write could burn a CPU core on the main thread.
+- Selecting a model now releases the selector and repaints immediately instead of after the provider auth check resolves. The overlay is disposed on Enter, so waiting for that round trip (a network call for subscription-OAuth providers such as Cursor) left the TUI showing a frozen frame on the previous model.
 
 ### Added
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-21 - Model selection releases the selector before the auth round trip
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `selectModelFromUi` now calls `done?.()` and `ui.requestRender()` *before* awaiting `session.setModel(model)`, instead of only after it resolves. The error path no longer double-releases.
+
+### Why
+
+- `ModelSelectorComponent.handleSelect` disposes the overlay synchronously on Enter, but the selector was only released after `setModel` resolved. `AgentSession._setModel` awaits `modelRuntime.checkAuth(provider)` as its first step, which for subscription-OAuth providers (Cursor) is a network round trip. Between Enter and that resolution the TUI held a torn-down-but-unreleased overlay with no repaint, so the screen appeared frozen on the old model while the switch was in flight.
+
+### Why an extension could not handle it
+
+- Selector lifecycle and overlay release are interactive-mode internals with no extension seam.
+
+### Expected merge conflict zones
+
+- `interactive-mode.ts` around `selectModelFromUi` (line ~6460).
+
+
 ## 2026-08-21 - Optimistic pending user echo
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6458,11 +6458,15 @@ export class InteractiveMode {
 	}
 
 	private async selectModelFromUi(model: Model<any>, done?: () => void): Promise<void> {
+		// The selector overlay is already disposed on Enter, so releasing it only
+		// after setModel resolves leaves a stale frozen frame for the whole provider
+		// auth round trip. Release and repaint first, then apply the switch.
+		done?.();
+		this.ui.requestRender();
 		try {
 			const systemPromptChange = await this.session.setModel(model);
 			this.footer.invalidate();
 			this.updateEditorBorderColor();
-			done?.();
 			const systemPromptStr = systemPromptChange?.systemPromptName
 				? ` (optimized system prompt applied: ${systemPromptChange.systemPromptName})`
 				: "";
@@ -6471,7 +6475,6 @@ export class InteractiveMode {
 			void this.maybeWarnAboutAnthropicSubscriptionAuth(model);
 			this.checkDaxnutsEasterEgg(model);
 		} catch (error) {
-			done?.();
 			this.showError(error instanceof Error ? error.message : String(error));
 		}
 	}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6462,7 +6462,7 @@ export class InteractiveMode {
 		// after setModel resolves leaves a stale frozen frame for the whole provider
 		// auth round trip. Release and repaint first, then apply the switch.
 		done?.();
-		this.ui.requestRender();
+		this.ui?.requestRender();
 		try {
 			const systemPromptChange = await this.session.setModel(model);
 			this.footer.invalidate();

--- a/packages/coding-agent/test/suite/regressions/model-select-feedback-before-auth.test.ts
+++ b/packages/coding-agent/test/suite/regressions/model-select-feedback-before-auth.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+
+describe("InteractiveMode.selectModelFromUi feedback ordering", () => {
+	test("#given a slow provider auth check #when a model is selected #then the selector is released before setModel resolves", async () => {
+		const order: string[] = [];
+		let releaseSetModel: (() => void) | undefined;
+		const setModelGate = new Promise<void>((resolve) => {
+			releaseSetModel = resolve;
+		});
+
+		const fakeThis: any = {
+			session: {
+				setModel: vi.fn(async () => {
+					order.push("setModel:start");
+					await setModelGate;
+					order.push("setModel:end");
+					return undefined;
+				}),
+			},
+			footer: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn((message: string) => order.push(`status:${message}`)),
+			showError: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(async () => {}),
+			checkDaxnutsEasterEgg: vi.fn(),
+			ui: { requestRender: vi.fn() },
+		};
+
+		const done = () => order.push("selector:released");
+		const model = { id: "beta-1", provider: "faux" };
+
+		const pending = (InteractiveMode as any).prototype.selectModelFromUi.call(fakeThis, model, done);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		// The overlay is torn down on Enter, so the selector must be released while
+		// setModel is still pending; otherwise the TUI shows a stale frozen frame
+		// for the entire provider auth round trip.
+		expect(order).toContain("selector:released");
+		expect(order).not.toContain("setModel:end");
+		expect(order.indexOf("selector:released")).toBeLessThan(order.indexOf("setModel:start"));
+
+		releaseSetModel?.();
+		await pending;
+		expect(order.indexOf("selector:released")).toBeLessThan(order.indexOf("setModel:end"));
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the "model change freezes the TUI" report. Stacked on #1060 (shares the CHANGELOG hunk); base will retarget to `main` once #1060 merges.

## Root cause

`ModelSelectorComponent.handleSelect` disposes the overlay **synchronously** on Enter:

```ts
private handleSelect(model: Model<any>): void {
    this.dispose();
    this.settingsManager.setDefaultModelAndProvider(model.provider, model.id);
    this.onSelectCallback(model);
}
```

But `selectModelFromUi` only called `done?.()` — which releases the selector and lets the UI repaint — **after** `await this.session.setModel(model)` resolved. And `AgentSession._setModel`'s very first step is `await this._modelRuntime.checkAuth(model.provider)`, which for subscription-OAuth providers (Cursor) is a network round trip.

So between Enter and that resolution the TUI held a torn-down-but-unreleased overlay with no repaint: the selector stayed painted, the highlight stayed on the chosen model, and the footer still showed the **previous** model. Exactly the reported symptom.

Measured on the affected host: the Cursor endpoint answers in ~0.56s and the auth/settings locks were healthy — so this is a *feedback-ordering* defect, not a slow backend.

## Fix

Release the selector and request a repaint **before** awaiting the switch; drop the now-redundant `done?.()` from the error path.

## Verification

- New `test/suite/regressions/model-select-feedback-before-auth.test.ts` drives the real `InteractiveMode.prototype.selectModelFromUi` against a gated `setModel`.
  - **RED** on unfixed code: `order` is only `['setModel:start']` — the selector is never released while the switch is in flight.
  - **GREEN** after the fix, and **mutation-proved**: reverting only `interactive-mode.ts` puts it back to RED, restoring returns GREEN. The assertion cannot pass without the fix.
- Interactive + model suites: 28 files / 184 tests green (no fallout from the reordering).
- `npm run check` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases the model selector and repaints immediately on selection to keep the TUI responsive during model switches. Previously the selector released only after the provider auth check; now we release and repaint first, and the repaint is guarded for ui-less callers.

- Call `done?.()` and `this.ui?.requestRender()` before awaiting `session.setModel(model)`; remove the redundant `done` in the error path.
- Add a regression test asserting the selector releases before `setModel` resolves.
- No API or extension changes; no migration. To verify, switch to a model whose provider performs an auth check and confirm the overlay clears immediately.

<sup>Written for commit d119440d91fc20c533eed33ee19abfa4c450b63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

