### PR TITLE
fix(ai): bound Cursor turn completion

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Cursor agent turns now finish promptly when `turnEnded` arrives even if the server leaves HTTP/2 open, while silent pre-completion streams fail after a heartbeat-aware health bound instead of freezing until the generic five-minute idle timeout.
+
 ### Removed
 
 ## [2026.8.21] - 2026-08-21

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -246,6 +246,12 @@ export type {
 export const CURSOR_API_URL = "https://api2.cursor.sh";
 export const CURSOR_CLIENT_VERSION = "cli-2026.07.23-e383d2b";
 const EXEC_HEARTBEAT_INTERVAL_MS = 3000;
+/** Maximum inbound silence before a Cursor turn without turnEnded is failed. */
+export const CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS = 30_000;
+/** Maximum heartbeat/checkpoint-only silence before a Cursor turn is failed. */
+export const CURSOR_STREAM_HEALTH_HEARTBEAT_ONLY_THRESHOLD_MS = CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS * 3;
+/** Maximum time allowed to drain exec handlers after turnEnded. */
+export const CURSOR_TURN_END_DRAIN_TIMEOUT_MS = 5000;
 
 /**
  * HTTP/1 connection-specific headers that HTTP/2 forbids. Node's
@@ -443,8 +449,10 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 		let h2Client: http2.ClientHttp2Session | null = null;
 		let h2Request: http2.ClientHttp2Stream | null = null;
 		let heartbeatTimer: NodeJS.Timeout | null = null;
+		let streamHealthTimer: NodeJS.Timeout | null = null;
 		let h2Settled = false;
 		let sawTurnEnded = false;
+		let turnEndDrainTimedOut = false;
 		let endStreamError: Error | null = null;
 		// Reachable from the catch: a stream that dies mid-turn must still close
 		// and pair the blocks it left open.
@@ -454,6 +462,10 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 		const settleH2 = (error?: unknown): void => {
 			if (h2Settled) return;
 			h2Settled = true;
+			if (streamHealthTimer) {
+				clearTimeout(streamHealthTimer);
+				streamHealthTimer = null;
+			}
 			if (error !== undefined) {
 				rejectH2(error);
 				return;
@@ -481,6 +493,7 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 			attempt += 1;
 			h2Settled = false;
 			sawTurnEnded = false;
+			turnEndDrainTimedOut = false;
 			endStreamError = null;
 			openBlockState = undefined;
 			const h2Completion = new Promise<void>((resolve, reject) => {
@@ -569,6 +582,60 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				const onConversationCheckpoint = (checkpoint: ConversationStateStructure) => {
 					conversationStateCache.set(conversationId!, checkpoint);
 				};
+				const healthFailThresholdMs =
+					options?.streamHealthFailThresholdMs ?? CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS;
+				const heartbeatOnlyThresholdMs =
+					options?.streamHealthHeartbeatOnlyThresholdMs ?? CURSOR_STREAM_HEALTH_HEARTBEAT_ONLY_THRESHOLD_MS;
+				let lastInboundFrameAt = Date.now();
+				let lastMeaningfulFrameAt = lastInboundFrameAt;
+				let turnEndCompletionStarted = false;
+				const armStreamHealthTimer = (): void => {
+					if (streamHealthTimer) clearTimeout(streamHealthTimer);
+					if (sawTurnEnded || h2Settled) return;
+					const now = Date.now();
+					const deadline = Math.min(
+						lastInboundFrameAt + healthFailThresholdMs,
+						lastMeaningfulFrameAt + heartbeatOnlyThresholdMs,
+					);
+					streamHealthTimer = setTimeout(
+						() => {
+							streamHealthTimer = null;
+							if (sawTurnEnded || h2Settled) return;
+							const stalledFor = Date.now() - lastInboundFrameAt;
+							const meaningfulStalledFor = Date.now() - lastMeaningfulFrameAt;
+							if (stalledFor < healthFailThresholdMs && meaningfulStalledFor < heartbeatOnlyThresholdMs) {
+								armStreamHealthTimer();
+								return;
+							}
+							settleH2(new Error("Cursor stream ended before turnEnded: inbound stream stalled"));
+							h2Request?.close();
+						},
+						Math.max(0, deadline - now),
+					);
+				};
+				const completeAfterTurnEnded = async (): Promise<void> => {
+					const drainTimeoutMs = options?.turnEndDrainTimeoutMs ?? CURSOR_TURN_END_DRAIN_TIMEOUT_MS;
+					let timeout: NodeJS.Timeout | undefined;
+					const drained = await Promise.race([
+						drainInFlightDispatches().then(() => true),
+						new Promise<false>((resolve) => {
+							timeout = setTimeout(() => resolve(false), drainTimeoutMs);
+						}),
+					]);
+					if (timeout) clearTimeout(timeout);
+					if (h2Settled) return;
+					if (!drained) {
+						turnEndDrainTimedOut = true;
+						settleH2(
+							new Error(`Cursor exec dispatches did not settle within ${drainTimeoutMs}ms after turnEnded`),
+						);
+						h2Request?.close();
+						return;
+					}
+					h2Request?.close();
+					settleH2();
+				};
+				armStreamHealthTimer();
 
 				h2Request.on("data", (chunk: Buffer) => {
 					// Steady state drains fully per chunk; alias the fresh h2 chunk
@@ -594,9 +661,17 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 
 						try {
 							const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
-							const isTurnEnded =
-								serverMessage.message.case === "interactionUpdate" &&
-								serverMessage.message.value.message?.case === "turnEnded";
+							const interactionUpdateCase =
+								serverMessage.message.case === "interactionUpdate"
+									? serverMessage.message.value.message?.case
+									: undefined;
+							const isTurnEnded = interactionUpdateCase === "turnEnded";
+							const isLivenessOnly =
+								interactionUpdateCase === "heartbeat" ||
+								serverMessage.message.case === "conversationCheckpointUpdate";
+							lastInboundFrameAt = Date.now();
+							if (!isLivenessOnly) lastMeaningfulFrameAt = lastInboundFrameAt;
+							armStreamHealthTimer();
 							// Dispatch is fire-and-forget so the socket keeps draining
 							// while a handler runs, but the promise is tracked: `done`
 							// must not be pushed while an exec handler is still resolving,
@@ -620,10 +695,13 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 							inFlightDispatches.add(dispatch);
 							void dispatch.finally(() => inFlightDispatches.delete(dispatch));
 
-							// Application completion is not protocol success; wait for a
-							// clean HTTP/2 end.
-							if (isTurnEnded) {
+							// turnEnded is the definitive application completion signal. Drain
+							// every dispatch it follows, then close our side of the stream so a
+							// server that keeps HTTP/2 open cannot hold the turn hostage.
+							if (isTurnEnded && !turnEndCompletionStarted) {
 								sawTurnEnded = true;
+								turnEndCompletionStarted = true;
+								void completeAfterTurnEnded().catch((error) => settleH2(error));
 							}
 						} catch (e) {
 							log("error", "parseServerMessage", { error: String(e) });
@@ -690,8 +768,9 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				// Same reason as the success path: a handler still running would land
 				// its real result after the turn finalized and be discarded — even
 				// though the tool may already have run side effects. On abort the
-				// drain returns immediately.
-				await drainInFlightDispatches();
+				// drain returns immediately. A post-turn drain timeout is already the
+				// bound: do not wait forever a second time in the error path.
+				if (!turnEndDrainTimedOut) await drainInFlightDispatches();
 				// A stream that dies mid-turn leaves blocks open. Closing them here
 				// settles their live cards and pairs the server-owned calls that
 				// nothing else answers — an unpaired call is stripped from every

--- a/packages/ai/src/api/cursor-agent/types.ts
+++ b/packages/ai/src/api/cursor-agent/types.ts
@@ -159,4 +159,9 @@ export interface CursorAgentOptions extends StreamOptions {
 	 * variant request shape.
 	 */
 	thinkingSelection?: ThinkingSelection;
+	/** Override stream health bounds for deterministic provider integration tests. */
+	streamHealthFailThresholdMs?: number;
+	streamHealthHeartbeatOnlyThresholdMs?: number;
+	/** Override the post-turn exec drain bound for deterministic tests. */
+	turnEndDrainTimeoutMs?: number;
 }

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Treat Cursor `turnEnded` as definitive completion after a bounded exec-dispatch drain, and fail silent pre-completion streams with heartbeat-aware 30s/90s health thresholds.
 - Skip ANTML invoke recovery when `model.api === "cursor-agent"` so native Cursor tool starts are not rejected as invalid event order.
 - Keep usable Cursor task tool arguments when the complete frame parses as empty.
 - Remint a Cursor conversation wire id after the 3-rotation skip instead of blocking the whole session.
@@ -42,6 +43,24 @@
 - `packages/ai/src/utils/overflow.ts` after `getOverflowPatterns()`.
 
 # AI Source Changes
+
+## 2026-08-21 - Cursor turn completion and stream health bounds
+
+### What changed
+
+- `packages/ai/src/api/cursor-agent.ts`: treats a decoded `turnEnded` frame as definitive application completion, drains tracked exec dispatches for at most `CURSOR_TURN_END_DRAIN_TIMEOUT_MS` (5000ms), then closes the client HTTP/2 stream instead of waiting for the server. Before `turnEnded`, `CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS` (30000ms) bounds complete inbound silence and `CURSOR_STREAM_HEALTH_HEARTBEAT_ONLY_THRESHOLD_MS` (90000ms) bounds streams carrying only heartbeats or conversation checkpoints.
+
+### Why
+
+- Cursor can leave the HTTP/2 response open after all assistant content, exec results, usage, and `turnEnded` have arrived. The adapter previously waited exclusively for transport end, leaving the user-facing turn frozen until the generic 300000ms agent idle timeout. A server that stalls before `turnEnded` had the same five-minute escape path despite the official Cursor CLI bounding transport silence much sooner.
+
+### Why an extension could not handle it
+
+- Frame decoding, HTTP/2 stream ownership, exec-dispatch tracking, and the conversation-rotation retry loop all live inside the Cursor provider adapter below extension-visible events. Only this transport layer can distinguish heartbeat/checkpoint liveness from meaningful frames and close the active request after the authoritative completion signal.
+
+### Expected merge conflict zones
+
+- HIGH: `packages/ai/src/api/cursor-agent.ts` `stream()` HTTP/2 lifecycle, frame decode loop, and final exec drain; upstream and fork Cursor protocol changes commonly touch the same block.
 
 ## 2026-08-20 - Cursor conversation rotation composes with compact-before-rotate
 

--- a/packages/ai/test/cursor-agent-exec-lifecycle-harness.ts
+++ b/packages/ai/test/cursor-agent-exec-lifecycle-harness.ts
@@ -6,6 +6,7 @@ import { frameConnectMessage, stream as streamCursorAgent } from "../src/api/cur
 import type { AssistantMessage, Message, Model, ToolResultMessage } from "../src/types.ts";
 
 export type ExecMode = "success" | "rejection" | "pending" | "unknown" | "shellStream" | "dispatchFailure";
+export type TurnTerminationMode = "turnEndedOpen" | "silentMidTurn";
 type ClientFrame = ReturnType<typeof fromBinary<typeof AgentClientMessageSchema>>;
 
 const EXEC_IDS: Record<ExecMode, number> = {
@@ -96,6 +97,42 @@ async function observeServerTask(task: Promise<void>): Promise<unknown> {
 		return undefined;
 	} catch (error) {
 		return error instanceof Error ? error : new Error(String(error));
+	}
+}
+
+export async function runTurnTerminationScenario(mode: TurnTerminationMode): Promise<AssistantMessage> {
+	const server = http2.createServer();
+	const sessions = new Set<http2.ServerHttp2Session>();
+	server.on("session", (session) => {
+		sessions.add(session);
+		session.once("close", () => sessions.delete(session));
+	});
+	server.on("stream", (stream: http2.ServerHttp2Stream) => {
+		stream.on("data", () => undefined);
+		stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+		if (mode === "turnEndedOpen") stream.write(turnEndedFrame());
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+	try {
+		const stream = streamCursorAgent(
+			buildModel(`http://127.0.0.1:${address.port}`),
+			{ messages: [{ role: "user", content: "hello", timestamp: 0 }] satisfies Message[] },
+			{
+				apiKey: "test-token",
+				streamHealthFailThresholdMs: 50,
+				streamHealthHeartbeatOnlyThresholdMs: 150,
+				turnEndDrainTimeoutMs: 50,
+			} satisfies CursorAgentOptions,
+		);
+		for await (const _event of stream) {
+			// Drain the public stream while the fake server deliberately stays open.
+		}
+		return await stream.result();
+	} finally {
+		for (const session of sessions) session.destroy();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
 	}
 }
 

--- a/packages/ai/test/cursor-agent-exec-lifecycle.cases.ts
+++ b/packages/ai/test/cursor-agent-exec-lifecycle.cases.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { armExecHeartbeat } from "../src/api/cursor-agent/exec-lifecycle.ts";
-import { findControlFrames, runExecLifecycleScenario } from "./cursor-agent-exec-lifecycle-harness.ts";
+import {
+	findControlFrames,
+	runExecLifecycleScenario,
+	runTurnTerminationScenario,
+} from "./cursor-agent-exec-lifecycle-harness.ts";
 
 export function registerCursorExecLifecycleTests(): void {
 	describe("cursor-agent exec heartbeat scheduler", () => {
@@ -41,6 +45,19 @@ export function registerCursorExecLifecycleTests(): void {
 			} finally {
 				vi.useRealTimers();
 			}
+		});
+	});
+
+	describe("cursor-agent turn termination", () => {
+		it("completes after turnEnded while the server keeps the stream open", async () => {
+			const message = await runTurnTerminationScenario("turnEndedOpen");
+			expect(message.stopReason).toBe("stop");
+		});
+
+		it("fails a silent mid-turn stream instead of hanging", async () => {
+			const message = await runTurnTerminationScenario("silentMidTurn");
+			expect(message.stopReason).toBe("error");
+			expect(message.errorMessage).toContain("inbound stream stalled");
 		});
 	});
 


### PR DESCRIPTION
## Root cause

The native Cursor adapter treated `interactionUpdate/turnEnded` as bookkeeping only and waited for the server to end the HTTP/2 response before completing the assistant stream. Cursor can leave that response open after all content, usage, and exec results are complete, so the turn remained in `Working` until the generic 300000ms agent idle timeout. A stream that stalled before `turnEnded` had no provider-local watchdog either.

## Fix

- Treat decoded `turnEnded` as the definitive application completion signal.
- Preserve usage capture, then wait for all tracked exec dispatches to settle (bounded by `CURSOR_TURN_END_DRAIN_TIMEOUT_MS = 5000`) before closing the client HTTP/2 request and settling through the existing clean `sawTurnEnded` path.
- Add a heartbeat-aware stream health watchdog before `turnEnded`:
  - `CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS = 30000` for no inbound frames.
  - `CURSOR_STREAM_HEALTH_HEARTBEAT_ONLY_THRESHOLD_MS = 90000` when heartbeats/checkpoints provide liveness without meaningful activity.
- Stall failures retain the retryable transport shape: `Cursor stream ended before turnEnded: inbound stream stalled`.
- Preserve conversation rotation retries, abort behavior, 5s run heartbeats, usage accounting, and exec draining.

## Failing-first evidence (RED)

Command:

```text
npm test --workspace packages/ai -- test/cursor-agent.test.ts
```

Before production changes:

```text
FAIL cursor-agent wire protocol > completes after turnEnded even when the server keeps the stream open
AssertionError: expected Error: turn completion timed out to not be an instance of Error

FAIL cursor-agent wire protocol > fails a silent stream without turnEnded at the stream health threshold
AssertionError: expected Error: stall detection timed out to not be an instance of Error

Test Files  1 failed (1)
Tests       2 failed | 28 passed (30)
```

Full receipt: `local-ignore/qa-evidence/20260821-cursor-turnend-completion/red.txt` (local, gitignored).

## GREEN evidence

```text
npm test --workspace packages/ai -- test/cursor-agent.test.ts
Test Files  1 passed (1)
Tests       30 passed (30)

npm test --workspace packages/ai
Test Files  232 passed | 25 skipped (257)
Tests       2199 passed | 866 skipped (3065)
```

The first broad run found one unrelated unbuilt-workspace resolution error for `@earendil-works/pi-tui`; after `npm run build --workspace packages/tui`, the single rerun passed as shown above.

## Validation / QA

- `npm run check` passed. Biome emitted only the existing schema-version informational notice (`2.5.5` config vs `2.5.9` CLI).
- `node scripts/check-pr-changelog.mjs --base origin/main` passed.
- Senpi QA common harness: 9/9 passed.
- Real source CLI mock loop: 48/48 passed.
- Native Cursor real-surface harness (`cursor-exec-lifecycle-qa.mjs`): 24/24 passed, including exec result draining, heartbeat ordering, one Run stream, final `stop`, isolated fake bearer, and unchanged real auth.
- Live api2 Cursor QA was not used; the deterministic HTTP/2 wire harness exercises the changed native transport without spending tokens or exposing credentials.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds Cursor agent turn completion and stream health to prevent five-minute hangs. Before: the adapter waited for HTTP/2 to end. After: it completes on decoded `turnEnded` (after a short exec drain) and fails silent streams early with a retryable transport error.

- Treat `turnEnded` as completion: drain in-flight exec dispatches for up to 5000ms (`CURSOR_TURN_END_DRAIN_TIMEOUT_MS`), then close the client HTTP/2 stream. Preserves usage capture and exec ordering.
- Add a heartbeat-aware watchdog: fail after 30000ms with no inbound frames, or after 90000ms of heartbeats/checkpoints only. Error text: "Cursor stream ended before turnEnded: inbound stream stalled".
- Expose test-only overrides in `CursorAgentOptions`: `streamHealthFailThresholdMs`, `streamHealthHeartbeatOnlyThresholdMs`, `turnEndDrainTimeoutMs`.
- Review focus: `packages/ai/src/api/cursor-agent.ts` stream lifecycle (timers cleared on settle, post-turn drain, error path drain guard), `types.ts` option additions, and the new termination tests in `packages/ai/test`.
- Rollout: no migration. Defaults are conservative. Monitor logs for unexpected stall failures on flaky networks.

<sup>Written for commit d8f06915fa46f57eff763fb07acca7b802b7d4db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

