### PR TITLE
fix(codemode): pass localRoots and artifactsDir to the JS eval kernel

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- `js` eval cells now accept `local://` paths in `read()` and `write()` like every other kernel. The session manager computed the session local root only after its `language === "js"` early return, so the JavaScript kernel was constructed without `localRoots` or `artifactsDir` and every `local://` helper call failed with `Protocol paths are not supported by write()`, even though the JavaScript prelude documents `local://` as the session local root. `py`/`rb`/`jl` behavior is unchanged.
+
 ### Removed
 
 ## [2026.8.21] - 2026-08-21

--- a/packages/senpi-codemode/src/extension/session-manager.ts
+++ b/packages/senpi-codemode/src/extension/session-manager.ts
@@ -196,19 +196,24 @@ class DefaultCodemodeSessionManager implements CodemodeSessionManager {
 		if (!bridge) throw new Error("codemode bridge server is not running");
 		const configuredPoolWidth = this.#options.settings.parallelPoolWidth;
 		const parallelPoolWidth = Number.isFinite(configuredPoolWidth) ? Math.max(1, Math.trunc(configuredPoolWidth)) : 1;
+		// localRoots must be computed BEFORE the js branch: the JS kernel resolves local://
+		// from its worker init connection exactly like the subprocess kernels resolve it from
+		// theirs. Computing it after the early return left js cells with no local root at all.
+		const localRoots =
+			this.#options.localRoots ??
+			(this.#options.artifactsDir ? { local: join(this.#options.artifactsDir, "local") } : undefined);
 		if (language === "js") {
 			return new JavaScriptKernel({
 				sessionId: this.#options.sessionId,
 				cwd: this.#options.cwd,
 				parallelPoolWidth,
 				onMessage,
+				...(localRoots ? { localRoots: { ...localRoots } } : {}),
+				...(this.#options.artifactsDir ? { artifactsDir: this.#options.artifactsDir } : {}),
 			});
 		}
 		const detected = this.#options.availability[language].detected;
 		if (!detected.ok) throw new Error(`No ${language} interpreter is available`);
-		const localRoots =
-			this.#options.localRoots ??
-			(this.#options.artifactsDir ? { local: join(this.#options.artifactsDir, "local") } : undefined);
 		const connection = {
 			port: bridge.port,
 			token: bridge.token,

--- a/packages/senpi-codemode/test/session-manager-js-local-roots.test.ts
+++ b/packages/senpi-codemode/test/session-manager-js-local-roots.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { defaultCodemodeSettings } from "../src/config/settings.ts";
+import { type CodemodeSessionManager, createCodemodeSessionManager } from "../src/extension/session-manager.ts";
+import type { InterpreterAvailability } from "../src/interpreters/detect.ts";
+import { localBridgeConnection } from "../src/kernels/js/local-module-loader.ts";
+
+// Regression: session-manager computed localRoots/artifactsDir only AFTER the
+// `language === "js"` early return, so py/rb/jl kernels received them on their
+// connection and the JS kernel received neither. js cells then rejected every
+// local:// path with "Protocol paths are not supported by write()", even though
+// the JS prelude documents local:// as the session local root.
+const availability: InterpreterAvailability = {
+	js: { enabled: true, detected: { ok: true, path: "node", version: "v20" } },
+	py: { enabled: false, detected: { ok: false } },
+	rb: { enabled: false, detected: { ok: false } },
+	jl: { enabled: false, detected: { ok: false } },
+};
+
+describe("codemode session manager JS local roots", () => {
+	let manager: CodemodeSessionManager | undefined;
+	let dir = "";
+
+	afterEach(async () => {
+		await manager?.dispose();
+		manager = undefined;
+		if (dir) rmSync(dir, { recursive: true, force: true });
+		dir = "";
+	});
+
+	it("Given artifactsDir when a js cell writes a local:// path then it resolves under <artifactsDir>/local", async () => {
+		// Given: a session manager configured exactly like the extension runtime,
+		// with an artifacts directory but no explicit localRoots.
+		dir = mkdtempSync(join(tmpdir(), "codemode-js-local-"));
+		const artifactsDir = join(dir, "artifacts");
+		manager = await createCodemodeSessionManager({
+			sessionId: "s",
+			cwd: dir,
+			settings: defaultCodemodeSettings,
+			availability,
+			artifactsDir,
+			executeTool: async () => ({ content: [{ type: "text", text: "" }], details: {} }),
+			complete: async () => {
+				throw new Error("completion is not exercised in this test");
+			},
+		});
+
+		// When
+		const kernel = await manager.getKernel("js", () => {});
+		const result = await kernel.run({
+			cellId: "c1",
+			code: 'return await write("local://f.txt", "x")',
+			timeoutMs: 10_000,
+		});
+
+		// Then
+		if (!result.ok) throw new Error(`js local:// write failed: ${result.error.message}`);
+		expect(result.valueRepr).toBe(JSON.stringify(join(artifactsDir, "local", "f.txt")));
+		expect(await readFile(join(artifactsDir, "local", "f.txt"), "utf8")).toBe("x");
+	});
+
+	it("Given explicit localRoots when a js cell reads a local:// path then it resolves under that root", async () => {
+		// Given: an explicit local root that must win over the artifacts fallback.
+		dir = mkdtempSync(join(tmpdir(), "codemode-js-local-explicit-"));
+		const localRoot = join(dir, "explicit-root");
+		manager = await createCodemodeSessionManager({
+			sessionId: "s",
+			cwd: dir,
+			settings: defaultCodemodeSettings,
+			availability,
+			localRoots: { local: localRoot },
+			artifactsDir: join(dir, "artifacts"),
+			executeTool: async () => ({ content: [{ type: "text", text: "" }], details: {} }),
+			complete: async () => {
+				throw new Error("completion is not exercised in this test");
+			},
+		});
+
+		// When
+		const kernel = await manager.getKernel("js", () => {});
+		const result = await kernel.run({
+			cellId: "c1",
+			code: 'await write("local://notes.md", "hi"); return await read("local://notes.md")',
+			timeoutMs: 10_000,
+		});
+
+		// Then
+		if (!result.ok) throw new Error(`js local:// round trip failed: ${result.error.message}`);
+		expect(result.valueRepr).toBe(JSON.stringify("hi"));
+		expect(await readFile(join(localRoot, "notes.md"), "utf8")).toBe("hi");
+	});
+});
+
+describe("localBridgeConnection", () => {
+	it("Given localRoots and artifactsDir when the worker init connection is built then both are carried", () => {
+		// Given / When
+		const connection = localBridgeConnection({
+			cwd: "/tmp/cwd",
+			localRoots: { local: "/tmp/roots/local" },
+			artifactsDir: "/tmp/artifacts",
+		});
+
+		// Then
+		expect(connection).toMatchObject({
+			localRoots: { local: "/tmp/roots/local" },
+			artifactsDir: "/tmp/artifacts",
+		});
+	});
+});


### PR DESCRIPTION
## Root cause

`packages/senpi-codemode/src/extension/session-manager.ts#createKernel` computed the session
local root **after** its `language === "js"` early return:

```ts
if (language === "js") {
  return new JavaScriptKernel({ sessionId, cwd, parallelPoolWidth, onMessage });  // <- no roots
}
const detected = ...;
const localRoots = this.#options.localRoots ?? (artifactsDir ? { local: join(artifactsDir, "local") } : undefined);
const connection = { port, token, parallelPoolWidth, ...localRoots, ...artifactsDir };  // py/rb/jl only
```

So py/rb/jl kernels received `connection.localRoots` + `connection.artifactsDir` and the JS kernel
received **neither**. Everything downstream was already wired and waiting:

- `src/kernels/js/worker-core.js` reads `message.connection.localRoots` / `.artifactsDir` into `JsWorkerRuntime`
- `src/kernels/js/worker-runtime.js` consumes `options.localRoots` with an `artifactsDir -> join(artifactsDir, "local")` fallback
- `src/kernels/js/worker-runtime.js#resolvePath` throws `Protocol paths are not supported by <op>()` when no root reaches it
- `localBridgeConnection` (`src/kernels/js/local-module-loader.ts`) already spreads both when the options carry them

`src/kernels/js/prelude.ts` documents the promise that was being broken:
`read(path, options?): read UTF-8 text; plain paths use cwd and local:// uses the session local root.`

## Fix

Hoist the `localRoots` computation above the js branch and forward `localRoots` + `artifactsDir`
into `JavaScriptKernelOptions`. The py/rb/jl `connection` object is byte-for-byte unchanged; it now
reads the hoisted binding instead of computing its own.

## py/js parity proof (real `CodemodeSessionManager`, same session, same `artifactsDir`)

Before:

```
AVAILABILITY js=true py=true
[py] OK resolved=/tmp/codemode-qa-parity-0tGSaw/artifacts/local/py.txt content=from-py
[js] FAILED: Protocol paths are not supported by write(): local://js.txt
```

After:

```
AVAILABILITY js=true py=true
[py] OK resolved=/tmp/codemode-qa-parity-bxxIgt/artifacts/local/py.txt content=from-py
[js] OK resolved=/tmp/codemode-qa-parity-bxxIgt/artifacts/local/js.txt content=from-js
```

## RED (test added first, before the production edit)

```
 RUN  v4.1.11 packages/senpi-codemode

xx·

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/session-manager-js-local-roots.test.ts > codemode session manager JS local roots > Given artifactsDir when a js cell writes a local:// path then it resolves under <artifactsDir>/local
Error: js local:// write failed: Protocol paths are not supported by write(): local://f.txt

 FAIL  test/session-manager-js-local-roots.test.ts > codemode session manager JS local roots > Given explicit localRoots when a js cell reads a local:// path then it resolves under that root
Error: js local:// round trip failed: Protocol paths are not supported by write(): local://notes.md

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

The third case (`localBridgeConnection` carries both when the options carry them) passes in RED by
design: it pins the already-correct downstream seam so the fix cannot regress it.

## GREEN

```
 RUN  v4.1.11 packages/senpi-codemode

···

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full package suite:

```
 Test Files  83 passed | 1 skipped (84)
      Tests  569 passed | 6 skipped (575)
```

## Verification

- `npm test` from `packages/senpi-codemode` — 83 files / 569 tests pass
- `npm run check` from the repo root — exit 0 (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, `tsc --noEmit`, browser smoke)
- `npx tsx scripts/qa-js-cell.ts` — direct-kernel QA path unaffected
- Real-surface parity driver above, run before and after the production edit
- `packages/senpi-codemode/CHANGELOG.md` `[Unreleased] > Fixed` entry added

Zero behavior change for py/rb/jl.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
JS eval cells now resolve local:// paths by receiving `localRoots` and `artifactsDir` from the session manager. Previously, JS rejected local:// paths with “Protocol paths are not supported by write()”; now it resolves to the session local root (explicit `localRoots` or `<artifactsDir>/local`), matching py/rb/jl.

- Hoists `localRoots` computation above the JS branch in `packages/senpi-codemode/src/extension/session-manager.ts`, and forwards `localRoots` and `artifactsDir` into the JS kernel options. py/rb/jl connection remains unchanged.
- Adds `packages/senpi-codemode/test/session-manager-js-local-roots.test.ts` covering artifacts fallback, explicit root precedence, and `localBridgeConnection` carrying both.
- Updates `packages/senpi-codemode/CHANGELOG.md`. No migration required; py/rb/jl behavior unchanged.

<sup>Written for commit 9fc8fbe957981e99889cba73d896cab253bf5c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

