### PR TITLE
fix(interactive): render queued prompts as waiting state, not sent

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Agentic turns no longer shake the transcript up and down: assistant text painted between tool cards keeps its position instead of teleporting above the cards whenever the next tool call arrives. The streaming message component now owns only the content through the first tool call, and each text segment after it renders in a persistent component at its chronological position (#1064).
 
+- Prompts submitted while the agent is streaming (steer/follow-up) render as the queued waiting state (`Steering:`/`Follow-up:` pending display) again instead of appearing as already-sent user messages; the optimistic submit echo now applies only to prompts that actually start immediately. Messages queued during compaction likewise no longer paint a sent-looking bubble.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -19,6 +19,26 @@
 - HIGH: `syncTrailingAssistantText`, the `message_start`/`message_update` reveal-target wiring, and the `agent_end` cleanup in `packages/coding-agent/src/modes/interactive/interactive-mode.ts`; any upstream refactor of the streaming render path collides here.
 - LOW: the removed `split-trailing-assistant-text.ts` (fork-added file, now deleted; upstream never carried it).
 
+## 2026-08-21 - Queued input renders as waiting state, not as a sent message
+
+### What changed
+
+- `interactive-mode.ts`: `OptimisticUserEchoController.promptOptions` now keeps an optimistic pending user bubble only when its prompt's `promptDisposition` is `started`. `queued` (steer/follow-up while streaming) and `handled` dispositions unpaint the bubble, so waiting input renders exclusively through `updatePendingMessagesDisplay` (dim `Steering:`/`Follow-up:` lines + dequeue hint) until canonical delivery, matching upstream pi semantics where user messages appear only at `message_start`.
+- `interactive-mode.ts`: `queueCompactionMessage` no longer begins an optimistic echo. Compaction-queued input has no prompt lifecycle until transfer, so its echo could never be resolved by a disposition (the `deliverQueued` transfer path never fires one), leaving a phantom sent-looking message forever.
+
+### Why
+
+- The optimistic echo feature (2026-08-21 below) made prompts submitted while the agent was streaming look already sent at their submission position; the queued/waiting state disappeared and message ordering diverged from actual delivery order. Reported against omo-ai 5.0.0-0.beta.14 (senpi v2026.8.21/-2).
+
+### Why an extension could not handle it
+
+- Same seam as the original feature: pending-echo records and their reconciliation are interactive-mode internals.
+
+### Expected merge conflict zones
+
+- `interactive-mode.ts` `OptimisticUserEchoController.promptOptions` and `queueCompactionMessage`.
+
+
 ## 2026-08-21 - Model selection releases the selector before the auth round trip
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -536,8 +536,12 @@ export class OptimisticUserEchoController {
 			promptDisposition: (disposition) => {
 				const record = this.pending.find((candidate) => candidate.id === id);
 				if (!record) return;
-				if (disposition === "handled") this.reject(id);
-				else record.eligibleForCanonicalStart = true;
+				// Only a prompt that actually STARTED keeps its optimistic echo; queued
+				// (steer/follow-up) input must render as the pending-queue waiting state,
+				// matching upstream pi where user messages appear only at canonical
+				// message_start and queued text lives in the pending display.
+				if (disposition === "started") record.eligibleForCanonicalStart = true;
+				else this.reject(id);
 			},
 		};
 	}
@@ -5984,12 +5988,12 @@ export class InteractiveMode {
 	}
 
 	private queueCompactionMessage(text: string, mode: "steer" | "followUp", droppedImageCount = 0): void {
-		const pendingEchoId = this.optimisticUserEchoes.begin(text);
+		// No optimistic echo here: compaction-queued input is waiting state and must
+		// render only in the pending-messages display until it is actually delivered.
 		this.compactionQueuedMessages.push({
 			text,
 			mode,
 			enqueueOrder: this.session.reserveQueuedInputOrder(),
-			pendingEchoId,
 		});
 		this.getSessionLogger().debug("compaction_queue_enqueue", {
 			mode,

--- a/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
+++ b/packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts
@@ -170,20 +170,60 @@ describe("optimistic pending user echo", () => {
 		expect(rendered[0]?.removed).toBe(true);
 	});
 
-	it("keeps queued steer echoes and reconciles their canonical starts in order", () => {
+	it("unpaints queued steer echoes so waiting input renders only as the pending queue", () => {
 		const { controller, rendered } = createController();
 		const firstId = controller.begin("first steer");
 		const secondId = controller.begin("second steer");
 		controller.promptOptions(firstId).promptDisposition("queued");
 		controller.promptOptions(secondId).promptDisposition("queued");
+
+		expect(rendered.map((entry) => entry.removed)).toEqual([true, true]);
+
+		const appended: AgentMessage[] = [];
 		const firstCanonical = userMessage("first steer");
-		const secondCanonical = userMessage("second steer");
+		if (!controller.replaceNext(firstCanonical)) appended.push(firstCanonical);
+		expect(appended).toEqual([firstCanonical]);
+		expect(rendered.map((entry) => entry.replacedWith)).toEqual([undefined, undefined]);
+	});
 
-		controller.replaceNext(firstCanonical);
-		controller.replaceNext(secondCanonical);
+	it("keeps a started echo intact while a later queued echo is unpainted", () => {
+		const { controller, rendered } = createController();
+		const startedId = controller.begin("started prompt");
+		controller.promptOptions(startedId).promptDisposition("started");
+		const queuedId = controller.begin("queued steer");
+		controller.promptOptions(queuedId).promptDisposition("queued");
 
-		expect(rendered.map((entry) => entry.replacedWith)).toEqual([firstCanonical, secondCanonical]);
-		expect(rendered.map((entry) => entry.removed)).toEqual([false, false]);
+		expect(rendered[0]?.removed).toBe(false);
+		expect(rendered[1]?.removed).toBe(true);
+
+		const canonical = userMessage("started prompt");
+		expect(controller.replaceNext(canonical)).toBe(true);
+		expect(rendered[0]?.replacedWith).toEqual(canonical);
+	});
+
+	it("queues compaction input without painting a sent-looking echo", () => {
+		const beginCalls: string[] = [];
+		const compactionQueuedMessages: unknown[] = [];
+		const context = {
+			optimisticUserEchoes: {
+				begin: (text: string) => {
+					beginCalls.push(text);
+					return "pending-user-stub";
+				},
+			},
+			compactionQueuedMessages,
+			session: { reserveQueuedInputOrder: () => 1 },
+			getSessionLogger: () => ({ debug: () => {} }),
+			editor: { addToHistory: () => {}, setText: () => {} },
+			updatePendingMessagesDisplay: () => {},
+			showStatus: () => {},
+		};
+		const queue = Reflect.get(interactiveModeModule.InteractiveMode.prototype, "queueCompactionMessage");
+		if (typeof queue !== "function") throw new Error("InteractiveMode.queueCompactionMessage is missing");
+		queue.call(context, "queued during compaction", "steer");
+
+		expect(beginCalls).toEqual([]);
+		expect(compactionQueuedMessages).toHaveLength(1);
 	});
 
 	it("is render-only and does not persist before the canonical message", () => {


### PR DESCRIPTION
## Problem

Since the optimistic pending user echo shipped (v2026.8.21, in omo-ai beta.14), a prompt submitted while the agent is streaming (steer/follow-up → disposition `queued`) kept its optimistic echo, so waiting input rendered as an already-sent user message at its submission position. The queued waiting state (`Steering:`/`Follow-up:` pending display) effectively disappeared, and rendered ordering diverged from actual delivery order.

Two more defects of the same class:
- `queueCompactionMessage` began an echo with no prompt lifecycle to resolve it; the `deliverQueued` transfer path never fires a disposition, leaving a phantom "sent" bubble forever.
- `replaceNext` repositioned the canonical message at the echo's submission index instead of its delivery position.

## Fix

Match upstream pi semantics (upstream renders user messages only at canonical `message_start`; queued text lives exclusively in the pending display):
- Keep the optimistic echo only for prompts whose disposition is `started` (the fast-submit path the feature was built for).
- `queued`/`handled` unpaint the echo; the pending-messages display owns the waiting state.
- Compaction-queued messages begin no echo at all.

## QA

- `test/suite/optimistic-pending-user-echo.test.ts`: RED→GREEN, 11/11 (queued unpaint, started-echo preservation, FIFO with mixed dispositions, compaction no-echo).
- Adjacent suites: 64 files / 469 tests green; root `npm run check` green.
- Live TUI QA: mid-stream submit renders `Steering:` waiting line; post-completion delivery renders canonical bubble (tmux-driven frame capture).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queued prompts render as the waiting state again instead of sent bubbles, restoring the pending display and delivery order. Only prompts with disposition "started" keep the optimistic user echo; "queued"/"handled" unpaint it, and compaction-queued prompts create no echo.

- **Review notes**
  - Touches `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `OptimisticUserEchoController.promptOptions` keeps the echo only on "started"; `queueCompactionMessage` no longer begins an echo.
  - Tests updated in `packages/coding-agent/test/suite/optimistic-pending-user-echo.test.ts` for queued unpaint, started-echo preservation, and compaction no-echo.
  - No API or data changes; no migration.

<sup>Written for commit 510682cea880e640c1417dc6d7b54d6966fa97dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

