### PR TITLE
fix(compaction): raise summarization wall-clock budget to 15 minutes

### DIFF
--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -222,8 +222,10 @@
 - `stream-watchdog.ts`: `consumeStreamWithIdleTimeout()` accepts an optional `maxDurationMs` and throws the new
   `StreamDurationBudgetError` when one stream outlives it. The budget is a single absolute deadline for the whole
   stream, not a per-read timer, and it is cleared alongside the idle timer. Caller aborts still win over the budget.
-- `DEFAULT_SUMMARIZATION_MAX_DURATION_MS` = 120s, applied by `compaction.ts` `completeSummarization()` and the
-  extension's `speculative.ts` request path. `retryAssistantCall` applies it per attempt.
+- `DEFAULT_SUMMARIZATION_MAX_DURATION_MS` = 900s, applied by `compaction.ts` `completeSummarization()` and the
+  extension's `speculative.ts` request path. `retryAssistantCall` applies it per attempt. The 120s cap aborted
+  legitimate large-session summaries (observed: 257k tokens on Grok 4.6) while the stream was still live; idle
+  timeout (300s silence) still kills a hung connection.
 
 ### Why
 

--- a/packages/coding-agent/src/core/compaction/stream-watchdog.ts
+++ b/packages/coding-agent/src/core/compaction/stream-watchdog.ts
@@ -38,12 +38,13 @@ export class StreamDurationBudgetError extends Error {
 export const DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS = 300_000;
 
 /**
- * Total time one summarization attempt may hold the session. Well above healthy
- * summarizations (tens of seconds) and below the idle budget, so a live-but-slow
- * provider fails fast enough to keep the session interactive. Retries apply this
- * budget per attempt.
+ * Total time one summarization attempt may hold the session. Large sessions
+ * (200k+ tokens) on slower models take minutes, not tens of seconds; 15 minutes
+ * still bounds a live-but-slow provider so the session is not stuck forever.
+ * Silence is a different class and stays on the 300s idle timeout. Retries apply
+ * this budget per attempt.
  */
-export const DEFAULT_SUMMARIZATION_MAX_DURATION_MS = 120_000;
+export const DEFAULT_SUMMARIZATION_MAX_DURATION_MS = 900_000;
 
 export interface ConsumeStreamWithIdleTimeoutOptions<T> {
 	/** Silence budget per read; the timer resets on every event. */

--- a/packages/coding-agent/test/compaction/summarization-duration-constant.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-duration-constant.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SUMMARIZATION_MAX_DURATION_MS } from "../../src/core/compaction/stream-watchdog.ts";
+
+describe("DEFAULT_SUMMARIZATION_MAX_DURATION_MS", () => {
+	it("gives large-session summarization 15 minutes", () => {
+		expect(DEFAULT_SUMMARIZATION_MAX_DURATION_MS).toBe(900_000);
+	});
+});

--- a/packages/coding-agent/test/compaction/summarization-wall-clock-budget.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-wall-clock-budget.test.ts
@@ -125,6 +125,6 @@ describe("consumeStreamWithIdleTimeout wall-clock budget", () => {
 	});
 
 	it("exposes a default wall-clock budget below the idle timeout", () => {
-		expect(DEFAULT_SUMMARIZATION_MAX_DURATION_MS).toBe(120_000);
+		expect(DEFAULT_SUMMARIZATION_MAX_DURATION_MS).toBe(900_000);
 	});
 });


### PR DESCRIPTION
## Summary
`DEFAULT_SUMMARIZATION_MAX_DURATION_MS` was 120s. A 257k-token session summarizing on Grok 4.6 was still streaming when the cap fired, so compact was rejected and the session stayed above the threshold.

Keep a wall-clock budget, but size it for large-session summarization (900s). The 300s idle timeout still kills a silent connection.

Fixes #1068

## Test plan
- [x] `bun test test/compaction/summarization-duration-constant.test.ts`
- Existing `summarization-wall-clock-budget.test.ts` still expects the exported constant (now 900_000). Full file needs `packages/ai` installed; the new constant test does not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the summarization wall-clock budget from 120s to 15 minutes so large-session compaction can complete. Previously, we aborted still-live summaries and left sessions above the compaction threshold; now large summaries can finish while the 300s idle timeout still ends silent connections.

- `DEFAULT_SUMMARIZATION_MAX_DURATION_MS` is now `900_000` ms in `packages/coding-agent/src/core/compaction/stream-watchdog.ts` and applies per attempt via `retryAssistantCall`.
- Idle timeout remains `DEFAULT_SUMMARIZATION_IDLE_TIMEOUT_MS = 300_000` ms; silence still terminates hung streams.
- Tests: added `summarization-duration-constant.test.ts`; updated `summarization-wall-clock-budget.test.ts` to assert the new constant.

<sup>Written for commit 1fb922de08a0a6fb70eb5be9ebfd3732224c444d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

