### PR TITLE
fix(codemode): gate subprocess runs on readiness

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Ruby and Julia eval cells now wait for the subprocess `ready` signal before execution timeouts begin, so interpreter startup under load cannot time out a state-setting cell and silently restart the kernel before the next cell runs.
+
 ### Removed
 
 ## [2026.8.21-3] - 2026-08-21

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,25 @@
 # senpi-codemode fork changes
 
+## Subprocess readiness gates cell execution (2026-08-21)
+
+### What changed
+
+- `packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts` now keeps Ruby and Julia cells queued until the active subprocess emits `ready`; only then does it write the `run` frame and arm that cell's timeout.
+- An `init-failed` frame now fails queued work immediately as a kernel startup error instead of leaving it to an unrelated cell timeout.
+
+### Why
+
+- The shared kernel previously sent `init` and immediately started the first cell's timeout without observing readiness. Under load, interpreter and prelude startup could consume the entire cell budget, time out the state-setting cell, restart into a clean process, and make the following state-read cell fail nondeterministically.
+
+### Why an extension could not handle it
+
+- Subprocess generation ownership, protocol readiness, run queue dispatch, and timeout arming are private to the shared kernel implementation; an extension cannot safely order those lifecycle transitions from outside the package.
+
+### Expected merge conflict zones
+
+- LOW in `packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts` around process startup and protocol-message dispatch.
+- LOW in the Ruby subprocess lifecycle tests that now emit the protocol readiness event explicitly.
+
 ## Eval completion throughput badge (2026-08-17)
 
 ### What changed

--- a/packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts
+++ b/packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts
@@ -26,6 +26,7 @@ export class SubprocessKernel {
 	private readonly onMessage?: (message: KernelToHostMessage) => void;
 	private readonly runs = new SubprocessRunQueue();
 	private process: SubprocessProcess | null = null;
+	private processReady = false;
 	private retirementPromise: Promise<void> | null = null;
 	private retirementProcess: SubprocessProcess | null = null;
 	private retirementFailure: Error | null = null;
@@ -109,7 +110,7 @@ export class SubprocessKernel {
 
 	private pumpRuns(): void {
 		const process = this.process;
-		if (this.closed || this.runs.active || !process || process.isRetiring) return;
+		if (this.closed || this.runs.active || !process || process.isRetiring || !this.processReady) return;
 		const run = this.runs.startNext(performance.now());
 		if (!run) return;
 		const timeoutMs = run.input.timeoutMs;
@@ -142,6 +143,7 @@ export class SubprocessKernel {
 			},
 		});
 		this.process = process;
+		this.processReady = false;
 		try {
 			process.send(
 				encodeBridgeFrame({ type: "init", sessionId: this.options.sessionId, connection: this.options.connection }),
@@ -165,6 +167,17 @@ export class SubprocessKernel {
 
 	private handleMessage(process: SubprocessProcess, message: KernelToHostMessage): void {
 		if (!this.accepts(process)) return;
+		if (message.type === "ready") {
+			this.processReady = true;
+			this.runs.handleMessage(message, this.onMessage);
+			this.pumpRuns();
+			return;
+		}
+		if (message.type === "init-failed") {
+			this.runs.handleMessage(message, this.onMessage);
+			this.failClosed(new KernelStartupError(message.error.message));
+			return;
+		}
 		if (this.runs.handleMessage(message, this.onMessage)) this.pumpRuns();
 	}
 
@@ -176,6 +189,7 @@ export class SubprocessKernel {
 			return;
 		}
 		this.process = null;
+		this.processReady = false;
 		this.failClosed(new KernelExitedError(signal ?? code ?? "unknown"));
 	}
 

--- a/packages/senpi-codemode/test/kernels/rb/subprocess-kernel-interrupt.test.ts
+++ b/packages/senpi-codemode/test/kernels/rb/subprocess-kernel-interrupt.test.ts
@@ -91,11 +91,20 @@ describe("SubprocessKernel interrupt", () => {
 });
 
 function createKernel(spawn: () => InterruptibleFakeProcess): SubprocessKernel {
-	return new SubprocessKernel({
+	let initial: InterruptibleFakeProcess | undefined;
+	const readySpawn = (): InterruptibleFakeProcess => {
+		const child = spawn();
+		if (!initial) initial = child;
+		else queueMicrotask(() => child.emitMessage({ type: "ready" }));
+		return child;
+	};
+	const kernel = new SubprocessKernel({
 		command: "ruby",
 		args: ["runner.rb"],
-		spawn,
+		spawn: readySpawn,
 		sessionId: "subprocess-interrupt",
 		connection: { port: 39_001, token: "mock-token" },
 	});
+	initial?.emitMessage({ type: "ready" });
+	return kernel;
 }

--- a/packages/senpi-codemode/test/kernels/rb/subprocess-kernel.test.ts
+++ b/packages/senpi-codemode/test/kernels/rb/subprocess-kernel.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { KernelToHostMessage } from "../../../src/bridge/protocol.ts";
 import { decodeBridgeFrame } from "../../../src/bridge/protocol.ts";
 import type { SubprocessSpawn } from "../../../src/kernels/shared/subprocess-kernel.ts";
@@ -34,6 +34,10 @@ class FakeProc extends EventEmitter {
 		this.stdout.write(`${JSON.stringify(message)}\n`);
 	}
 }
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe("SubprocessKernel", () => {
 	it("sends bridge init over stdin without leaking port or token into argv", async () => {
@@ -87,6 +91,57 @@ describe("SubprocessKernel", () => {
 		});
 	});
 
+	it("waits for the exact ready signal before starting a cell timeout", async () => {
+		vi.useFakeTimers();
+		const fake = new FakeProc();
+		const kernel = new SubprocessKernel({
+			command: "ruby",
+			args: ["runner.rb"],
+			spawn: () => fake,
+			sessionId: "session-1",
+			connection: { port: 39_001, token: "secret-token" },
+		});
+		const run = kernel.run({ cellId: "after-ready", code: "42", timeoutMs: 10 });
+		const settlements: KernelToHostMessage[] = [];
+		void run.then((result) => settlements.push(result));
+
+		await vi.advanceTimersByTimeAsync(100);
+		expect(fake.stdin.writes).toHaveLength(1);
+		expect(settlements).toEqual([]);
+
+		fake.emitMessage({ type: "ready" });
+		await vi.advanceTimersByTimeAsync(0);
+		expect(decodeBridgeFrame(fake.stdin.writes[1] ?? "")).toMatchObject({
+			ok: true,
+			message: { type: "run", cellId: "after-ready", code: "42", timeoutMs: 10 },
+		});
+		fake.emitMessage({ type: "result", cellId: "after-ready", ok: true, valueRepr: "42", durationMs: 1 });
+
+		await expect(run).resolves.toMatchObject({ ok: true, valueRepr: "42" });
+		await kernel.close();
+	});
+
+	it("fails queued work immediately when initialization fails", async () => {
+		const fake = new FakeProc();
+		const kernel = new SubprocessKernel({
+			command: "ruby",
+			args: ["runner.rb"],
+			spawn: () => fake,
+			sessionId: "session-1",
+			connection: { port: 39_001, token: "secret-token" },
+		});
+		const run = kernel.run({ cellId: "never-started", code: "42", timeoutMs: 1_000 });
+
+		fake.emitMessage({ type: "init-failed", error: { message: "prelude failed" } });
+
+		await expect(run).resolves.toMatchObject({
+			ok: false,
+			error: { message: "Kernel startup failed: prelude failed" },
+			durationMs: 0,
+		});
+		await kernel.close();
+	});
+
 	it("runs cells and round-trips tool replies", async () => {
 		const fake = new FakeProc();
 		const messages: KernelToHostMessage[] = [];
@@ -135,12 +190,22 @@ describe("SubprocessKernel", () => {
 });
 
 function createKernel(spawn: SubprocessSpawn, onMessage?: (message: KernelToHostMessage) => void): SubprocessKernel {
-	return new SubprocessKernel({
+	let initial: FakeProc | undefined;
+	const readySpawn: SubprocessSpawn = (command, args, options) => {
+		const child = spawn(command, args, options);
+		if (!(child instanceof FakeProc)) throw new Error("expected FakeProc");
+		if (!initial) initial = child;
+		else queueMicrotask(() => child.emitMessage({ type: "ready" }));
+		return child;
+	};
+	const kernel = new SubprocessKernel({
 		command: "ruby",
 		args: ["runner.rb"],
-		spawn,
+		spawn: readySpawn,
 		sessionId: "session-1",
 		connection: { port: 39_001, token: "secret-token" },
 		onMessage,
 	});
+	initial?.emitMessage({ type: "ready" });
+	return kernel;
 }

--- a/packages/senpi-codemode/test/kernels/rb/subprocess-lifecycle-races.test.ts
+++ b/packages/senpi-codemode/test/kernels/rb/subprocess-lifecycle-races.test.ts
@@ -235,13 +235,23 @@ describe("SubprocessKernel settlement races", () => {
 });
 
 function createKernel(spawn: SubprocessSpawn): SubprocessKernel {
-	return new SubprocessKernel({
+	let initial: RaceSubprocess | undefined;
+	const readySpawn: SubprocessSpawn = (command, args, options) => {
+		const child = spawn(command, args, options);
+		if (!(child instanceof RaceSubprocess)) throw new Error("expected RaceSubprocess");
+		if (!initial) initial = child;
+		else queueMicrotask(() => child.emitMessage({ type: "ready" }));
+		return child;
+	};
+	const kernel = new SubprocessKernel({
 		command: "ruby",
 		args: ["runner.rb"],
-		spawn,
+		spawn: readySpawn,
 		sessionId: "session-1",
 		connection: { port: 39_001, token: "secret-token" },
 	});
+	initial?.emitMessage({ type: "ready" });
+	return kernel;
 }
 
 function spawnFrom(children: RaceSubprocess[]): SubprocessSpawn {

--- a/packages/senpi-codemode/test/kernels/rb/subprocess-lifecycle.test.ts
+++ b/packages/senpi-codemode/test/kernels/rb/subprocess-lifecycle.test.ts
@@ -180,7 +180,9 @@ describe("SubprocessKernel lifecycle", () => {
 		const secondChild = new FakeSubprocess();
 		const children = [firstChild, secondChild];
 		const observed: KernelToHostMessage[] = [];
-		const kernel = createKernel(spawnFrom(children), (message) => observed.push(message));
+		const kernel = createKernel(spawnFrom(children), (message) => {
+			if (message.type !== "ready") observed.push(message);
+		});
 		const firstRun = kernel.run({ cellId: "first", code: "block", timeoutMs: 1_000 });
 		const laterRun = kernel.run({ cellId: "later", code: "next", timeoutMs: 1_000 });
 
@@ -243,14 +245,24 @@ describe("SubprocessKernel lifecycle", () => {
 });
 
 function createKernel(spawn: SubprocessSpawn, onMessage?: (message: KernelToHostMessage) => void): SubprocessKernel {
-	return new SubprocessKernel({
+	let initial: FakeSubprocess | undefined;
+	const readySpawn: SubprocessSpawn = (command, args, options) => {
+		const child = spawn(command, args, options);
+		if (!(child instanceof FakeSubprocess)) throw new Error("expected FakeSubprocess");
+		if (!initial) initial = child;
+		else queueMicrotask(() => child.emitMessage({ type: "ready" }));
+		return child;
+	};
+	const kernel = new SubprocessKernel({
 		command: "ruby",
 		args: ["runner.rb"],
-		spawn,
+		spawn: readySpawn,
 		sessionId: "session-1",
 		connection: { port: 39_001, token: "secret-token" },
 		onMessage,
 	});
+	initial?.emitMessage({ type: "ready" });
+	return kernel;
 }
 
 function spawnFrom(children: FakeSubprocess[]): SubprocessSpawn {

--- a/packages/senpi-codemode/test/rb-kernel.test.ts
+++ b/packages/senpi-codemode/test/rb-kernel.test.ts
@@ -83,7 +83,9 @@ describe("RubyKernel", () => {
 					connection: { port: server.port, token: server.token },
 				});
 				try {
-					await kernel.run({ cellId: "set", code: "$answer = 41", timeoutMs: 3_000 });
+					await expect(
+						kernel.run({ cellId: "set", code: "$answer = 41", timeoutMs: 3_000 }),
+					).resolves.toMatchObject({ ok: true });
 					const persisted = await kernel.run({ cellId: "get", code: "$answer + 1", timeoutMs: 3_000 });
 					expect(persisted).toMatchObject({ ok: true, valueRepr: "42" });
 					await kernel.reset();


### PR DESCRIPTION
## Root cause

`SubprocessKernel` wrote the first `run` frame and armed its cell timeout immediately after writing `init`, while the Ruby/Julia runners' `ready` and `init-failed` protocol messages were only forwarded and never affected dispatch.

Under load, Ruby interpreter/prelude startup could consume the state-setting cell's entire 3-second budget. That cell then timed out and retired its process. The test did not assert the `set` result, so the next `get` cell ran on the replacement process without `$answer` and returned `ok:false`. This matches Actions run 32500850319: the identical commit passed on rerun after the one-off `get` failure.

A controlled fake-process regression reproduced the ordering deterministically: with `ready` withheld, the old implementation wrote `run`, fired the 10 ms cell watchdog, and spawned a replacement.

## Fix

- Keep subprocess cells queued until the active process emits the exact `ready` signal.
- Arm each cell timeout only when its `run` frame is actually dispatched.
- Convert `init-failed` into an immediate `KernelStartupError` for queued work.
- Make lifecycle fakes emit readiness explicitly and assert the live Ruby state-setting cell succeeds before reading persisted state.

No sleeps, timeout bumps, retries, or weakened assertions are used.

## Verification

- Ruby test file: **30/30 consecutive passes** (8 tests per run, zero failures)
- `npm --prefix packages/senpi-codemode test`: **83 passed / 1 skipped files; 571 passed / 6 skipped tests**
- `npm run check`: passed
- `npm run build`: passed
- `qa-rb-cell.ts`: emitted `ready`, persisted state, and returned `valueRepr: "42"`
- Local changelog gate against merge-base: passed
- LSP diagnostics on every changed TypeScript file: clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate subprocess cell dispatch on explicit readiness to eliminate Ruby/Julia startup races that timed out the first cell and silently restarted the kernel. Old: armed timeouts immediately after `init`; new: queue cells until `ready`, start each timeout on actual `run` dispatch; `init-failed` now fails queued work with a startup error.

- Subprocess kernel: add a `processReady` gate, block `pumpRuns` until `ready`, handle `ready`/`init-failed` explicitly, and reset readiness on exit in `packages/senpi-codemode/src/kernels/shared/subprocess-kernel.ts`.
- Tests: update Ruby subprocess fakes to emit `ready`, assert the state-setting cell succeeds, and add cases for readiness gating and `init-failed`.
- Behavior notes: timeouts now measure execution, not interpreter startup; Ruby and Julia only. Protocol implementers must continue to send `ready`/`init-failed`. No sleeps, retries, or timeout bumps.

<sup>Written for commit 4a1e57de16b962b3fc537dcbce7dd5bd1fae2d24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

