### PR TITLE
fix(cursor): match official CLI stream recovery for stalls and heartbeats

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Cursor streams no longer fail while the server keeps sending heartbeats or checkpoints: the provider now matches the official Cursor CLI's stream recovery, refreshing its 30s health deadline on every inbound frame and silently retrying pre-`turnEnded` stalls or transport deaths with bounded backoff, resuming from the latest conversation checkpoint with the originally pinned model. Long-running local tools and long `xhigh` thinking turns previously died with `Cursor stream ended before turnEnded: inbound stream stalled` and immediately rotated the fallback chain.
+
 ### Removed
 
 ## [2026.8.21-3] - 2026-08-21

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -159,6 +159,7 @@ import {
 	McpToolNotFoundSchema,
 	McpToolResultContentItemSchema,
 	McpToolResultSchema,
+	type ModelDetails,
 	ModelDetailsSchema,
 	ReadErrorSchema,
 	ReadMcpResourceExecResultSchema,
@@ -171,6 +172,7 @@ import {
 	RequestContextResultSchema,
 	RequestContextSchema,
 	RequestContextSuccessSchema,
+	type RequestedModel,
 	ResumeActionSchema,
 	SelectedContextSchema,
 	SelectedImageSchema,
@@ -215,6 +217,12 @@ import {
 	piTimeout,
 } from "./cursor-agent/pi-args.ts";
 import { buildRequestedModel } from "./cursor-agent/reasoning-params.ts";
+import {
+	CursorRetryableStreamError,
+	cursorStreamRetryDelayMs,
+	shouldRetryCursorStream,
+	waitForCursorStreamRetry,
+} from "./cursor-agent/stream-retry.ts";
 import type {
 	CursorAgentOptions,
 	CursorExecHandlerResult,
@@ -248,7 +256,7 @@ export const CURSOR_CLIENT_VERSION = "cli-2026.07.23-e383d2b";
 const EXEC_HEARTBEAT_INTERVAL_MS = 3000;
 /** Maximum inbound silence before a Cursor turn without turnEnded is failed. */
 export const CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS = 30_000;
-/** Maximum heartbeat/checkpoint-only silence before a Cursor turn is failed. */
+/** @deprecated Heartbeats and checkpoints count as inbound liveness without a separate deadline. */
 export const CURSOR_STREAM_HEALTH_HEARTBEAT_ONLY_THRESHOLD_MS = CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS * 3;
 /** Maximum time allowed to drain exec handlers after turnEnded. */
 export const CURSOR_TURN_END_DRAIN_TIMEOUT_MS = 5000;
@@ -486,10 +494,14 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 		let baseConversationId: string | undefined;
 		let conversationId: string | undefined;
 		let usageState: UsageState | undefined;
-		let retryPoisonedConversation = false;
+		let retryAttempt = false;
 		let attempt = 0;
+		let streamRetries = 0;
+		let forceResumeAction = false;
+		let pinnedRequestedModel: RequestedModel | undefined;
+		let pinnedModelDetails: ModelDetails | undefined;
 		do {
-			retryPoisonedConversation = false;
+			retryAttempt = false;
 			attempt += 1;
 			h2Settled = false;
 			sawTurnEnded = false;
@@ -500,6 +512,7 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				resolveH2 = resolve;
 				rejectH2 = reject;
 			});
+			let attemptSawCheckpoint = false;
 			try {
 				const apiKey = options?.apiKey;
 				if (!apiKey) {
@@ -511,11 +524,21 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
 				conversationBlobStores.set(conversationId, blobStore);
 				const cachedState = conversationStateCache.get(conversationId);
-				const { requestBytes, conversationState } = await buildGrpcRequest(model, context, options, {
-					conversationId,
-					blobStore,
-					conversationState: cachedState,
-				});
+				const { requestBytes, conversationState, requestedModel, modelDetails } = await buildGrpcRequest(
+					model,
+					context,
+					options,
+					{
+						conversationId,
+						blobStore,
+						conversationState: cachedState,
+						forceResumeAction,
+						pinnedRequestedModel,
+						pinnedModelDetails,
+					},
+				);
+				pinnedRequestedModel ??= requestedModel;
+				pinnedModelDetails ??= modelDetails;
 				conversationStateCache.set(conversationId, conversationState);
 				const requestContextTools = buildMcpToolDefinitions(context.tools);
 
@@ -538,10 +561,33 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 					"x-request-id": randomUUID(),
 				};
 
-				h2Client = http2.connect(baseUrl);
-				h2Client.on("error", (error) => settleH2(mapH2TransportError(error, baseUrl)));
-
-				h2Request = h2Client.request(requestHeaders);
+				const attemptH2Client = http2.connect(baseUrl);
+				h2Client = attemptH2Client;
+				attemptH2Client.on("error", (error) => {
+					if (h2Client !== attemptH2Client) return;
+					const mapped = mapH2TransportError(error, baseUrl);
+					settleH2(
+						sawTurnEnded
+							? mapped
+							: new CursorRetryableStreamError(
+									mapped instanceof Error ? mapped.message : String(mapped),
+									"transport",
+									{ cause: mapped },
+								),
+					);
+				});
+				attemptH2Client.on("goaway", () => {
+					if (h2Client === attemptH2Client && !h2Settled && !sawTurnEnded) {
+						settleH2(new CursorRetryableStreamError("Cursor HTTP/2 session received GOAWAY", "transport"));
+						h2Request?.close();
+					}
+				});
+				attemptH2Client.on("close", () => {
+					if (h2Client === attemptH2Client && !h2Settled && !sawTurnEnded && !endStreamError) {
+						settleH2(new CursorRetryableStreamError("Cursor HTTP/2 session closed", "transport"));
+					}
+				});
+				h2Request = attemptH2Client.request(requestHeaders);
 
 				if (attempt === 1) {
 					stream.push({ type: "start", partial: output });
@@ -580,34 +626,33 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				openBlockState = state;
 
 				const onConversationCheckpoint = (checkpoint: ConversationStateStructure) => {
+					attemptSawCheckpoint = true;
 					conversationStateCache.set(conversationId!, checkpoint);
 				};
 				const healthFailThresholdMs =
 					options?.streamHealthFailThresholdMs ?? CURSOR_STREAM_HEALTH_FAIL_THRESHOLD_MS;
-				const heartbeatOnlyThresholdMs =
-					options?.streamHealthHeartbeatOnlyThresholdMs ?? CURSOR_STREAM_HEALTH_HEARTBEAT_ONLY_THRESHOLD_MS;
 				let lastInboundFrameAt = Date.now();
-				let lastMeaningfulFrameAt = lastInboundFrameAt;
 				let turnEndCompletionStarted = false;
 				const armStreamHealthTimer = (): void => {
 					if (streamHealthTimer) clearTimeout(streamHealthTimer);
 					if (sawTurnEnded || h2Settled) return;
 					const now = Date.now();
-					const deadline = Math.min(
-						lastInboundFrameAt + healthFailThresholdMs,
-						lastMeaningfulFrameAt + heartbeatOnlyThresholdMs,
-					);
+					const deadline = lastInboundFrameAt + healthFailThresholdMs;
 					streamHealthTimer = setTimeout(
 						() => {
 							streamHealthTimer = null;
 							if (sawTurnEnded || h2Settled) return;
 							const stalledFor = Date.now() - lastInboundFrameAt;
-							const meaningfulStalledFor = Date.now() - lastMeaningfulFrameAt;
-							if (stalledFor < healthFailThresholdMs && meaningfulStalledFor < heartbeatOnlyThresholdMs) {
+							if (stalledFor < healthFailThresholdMs) {
 								armStreamHealthTimer();
 								return;
 							}
-							settleH2(new Error("Cursor stream ended before turnEnded: inbound stream stalled"));
+							settleH2(
+								new CursorRetryableStreamError(
+									"Cursor stream ended before turnEnded: inbound stream stalled",
+									"stall",
+								),
+							);
 							h2Request?.close();
 						},
 						Math.max(0, deadline - now),
@@ -666,11 +711,7 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 									? serverMessage.message.value.message?.case
 									: undefined;
 							const isTurnEnded = interactionUpdateCase === "turnEnded";
-							const isLivenessOnly =
-								interactionUpdateCase === "heartbeat" ||
-								serverMessage.message.case === "conversationCheckpointUpdate";
 							lastInboundFrameAt = Date.now();
-							if (!isLivenessOnly) lastMeaningfulFrameAt = lastInboundFrameAt;
 							armStreamHealthTimer();
 							// Dispatch is fire-and-forget so the socket keeps draining
 							// while a handler runs, but the promise is tracked: `done`
@@ -729,11 +770,24 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				});
 
 				h2Request.on("end", () => {
+					if (!sawTurnEnded && !endStreamError) {
+						settleH2(new CursorRetryableStreamError("Cursor stream ended before turnEnded", "clean-end"));
+						return;
+					}
 					settleH2();
 				});
 
 				h2Request.on("error", (error) => {
-					settleH2(mapH2TransportError(error, baseUrl));
+					const mapped = mapH2TransportError(error, baseUrl);
+					settleH2(
+						sawTurnEnded
+							? mapped
+							: new CursorRetryableStreamError(
+									mapped instanceof Error ? mapped.message : String(mapped),
+									"transport",
+									{ cause: mapped },
+								),
+					);
 				});
 
 				if (options?.signal) {
@@ -771,6 +825,39 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				// drain returns immediately. A post-turn drain timeout is already the
 				// bound: do not wait forever a second time in the error path.
 				if (!turnEndDrainTimedOut) await drainInFlightDispatches();
+				const shouldRetryStream = shouldRetryCursorStream({
+					error,
+					retries: streamRetries,
+					maxRetries: options?.streamStallMaxRetries ?? 10,
+					sawTurnEnded,
+					aborted: options?.signal?.aborted === true,
+				});
+				if (shouldRetryStream) {
+					if (openBlockState) {
+						// Resume responses continue from the server checkpoint. Close any
+						// locally open cards before resetting per-attempt bookkeeping; no
+						// speculative replay deduplication is attempted.
+						endCurrentTextBlock(output, stream, openBlockState);
+						endCurrentThinkingBlock(output, stream, openBlockState);
+						flushOpenToolCalls(output, stream, openBlockState);
+					}
+					forceResumeAction ||= attemptSawCheckpoint;
+					const retryDelayMs = cursorStreamRetryDelayMs({
+						attempt: streamRetries,
+						fixedDelayMs: options?.streamStallRetryDelayMs,
+					});
+					streamRetries += 1;
+					retryAttempt = true;
+					await waitForCursorStreamRetry(retryDelayMs, options?.signal);
+					if (options?.signal?.aborted) {
+						retryAttempt = false;
+						output.stopReason = "aborted";
+						output.errorMessage = "Request was aborted";
+						stream.push({ type: "error", reason: output.stopReason, error: output });
+						stream.end();
+					}
+					continue;
+				}
 				// A stream that dies mid-turn leaves blocks open. Closing them here
 				// settles their live cards and pairs the server-owned calls that
 				// nothing else answers — an unpaired call is stripped from every
@@ -817,13 +904,13 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 							if (cached) conversationStateCache.set(decision.wireId, cached);
 							const blobs = conversationBlobStores.get(conversationId);
 							if (blobs) conversationBlobStores.set(decision.wireId, blobs);
-							retryPoisonedConversation = true;
+							retryAttempt = true;
 						} else {
 							message = CURSOR_CONVERSATION_POISONED_MESSAGE;
 						}
 					}
 				}
-				if (!retryPoisonedConversation) {
+				if (!retryAttempt) {
 					output.stopReason = options?.signal?.aborted ? "aborted" : "error";
 					output.errorMessage = message;
 					stream.push({ type: "error", reason: output.stopReason, error: output });
@@ -839,7 +926,7 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				h2Request = null;
 				h2Client = null;
 			}
-		} while (retryPoisonedConversation);
+		} while (retryAttempt);
 	})();
 
 	return stream;
@@ -4089,11 +4176,16 @@ async function buildGrpcRequest(
 		conversationId: string;
 		blobStore: Map<string, Uint8Array>;
 		conversationState?: ConversationStateStructure;
+		forceResumeAction?: boolean;
+		pinnedRequestedModel?: RequestedModel;
+		pinnedModelDetails?: ModelDetails;
 	},
 ): Promise<{
 	requestBytes: Uint8Array;
 	blobStore: Map<string, Uint8Array>;
 	conversationState: ConversationStateStructure;
+	requestedModel: RequestedModel;
+	modelDetails: ModelDetails;
 }> {
 	const blobStore = state.blobStore;
 
@@ -4119,7 +4211,7 @@ async function buildGrpcRequest(
 
 	const action = create(ConversationActionSchema, {
 		action:
-			userContent && (userText.trim().length > 0 || hasUserImages)
+			!state.forceResumeAction && userContent && (userText.trim().length > 0 || hasUserImages)
 				? {
 						case: "userMessageAction",
 						value: create(UserMessageActionSchema, {
@@ -4180,15 +4272,17 @@ async function buildGrpcRequest(
 		turns,
 	});
 
-	const requestedModel = buildRequestedModel(model, options?.thinkingSelection);
+	const requestedModel = state.pinnedRequestedModel ?? buildRequestedModel(model, options?.thinkingSelection);
 	const wireModelId = requestedModel.modelId;
 	const cursorMaxMode = model.compat?.cursorMaxMode === true;
-	const modelDetails = create(ModelDetailsSchema, {
-		modelId: wireModelId,
-		displayModelId: model.id,
-		displayName: model.name,
-		...(cursorMaxMode ? { maxMode: true } : undefined),
-	});
+	const modelDetails =
+		state.pinnedModelDetails ??
+		create(ModelDetailsSchema, {
+			modelId: wireModelId,
+			displayModelId: model.id,
+			displayName: model.name,
+			...(cursorMaxMode ? { maxMode: true } : undefined),
+		});
 
 	const runRequest = create(AgentRunRequestSchema, {
 		conversationState,
@@ -4215,7 +4309,7 @@ async function buildGrpcRequest(
 		tools: context.tools?.length ?? 0,
 	});
 
-	return { requestBytes, blobStore, conversationState };
+	return { requestBytes, blobStore, conversationState, requestedModel, modelDetails };
 }
 
 function hasImages(content: (TextContent | ImageContent)[]): boolean {

--- a/packages/ai/src/api/cursor-agent/stream-retry.ts
+++ b/packages/ai/src/api/cursor-agent/stream-retry.ts
@@ -1,0 +1,58 @@
+export type CursorStreamRetryCause = "stall" | "transport" | "clean-end";
+
+export class CursorRetryableStreamError extends Error {
+	readonly retryCause: CursorStreamRetryCause;
+
+	constructor(message: string, retryCause: CursorStreamRetryCause, options?: ErrorOptions) {
+		super(message, options);
+		this.name = "CursorRetryableStreamError";
+		this.retryCause = retryCause;
+	}
+}
+
+export function isCursorRetryableStreamError(error: unknown): error is CursorRetryableStreamError {
+	return error instanceof CursorRetryableStreamError;
+}
+
+export function cursorStreamRetryDelayMs(options: {
+	attempt: number;
+	baseDelayMs?: number;
+	fixedDelayMs?: number;
+	random?: () => number;
+}): number {
+	if (options.fixedDelayMs !== undefined) return Math.max(0, options.fixedDelayMs);
+	const baseDelayMs = options.baseDelayMs ?? 1000;
+	const backoffMs = Math.min(baseDelayMs * 2 ** options.attempt, 60_000);
+	const jitter = Math.floor(backoffMs * 0.2 * (options.random ?? Math.random)());
+	return backoffMs + jitter;
+}
+
+export function shouldRetryCursorStream(options: {
+	error: unknown;
+	retries: number;
+	maxRetries: number;
+	sawTurnEnded: boolean;
+	aborted: boolean;
+}): boolean {
+	return (
+		!options.sawTurnEnded &&
+		!options.aborted &&
+		options.retries < options.maxRetries &&
+		isCursorRetryableStreamError(options.error)
+	);
+}
+
+export async function waitForCursorStreamRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+	if (delayMs <= 0 || signal?.aborted) return;
+	await new Promise<void>((resolve) => {
+		const timer = setTimeout(resolve, delayMs);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timer);
+				resolve();
+			},
+			{ once: true },
+		);
+	});
+}

--- a/packages/ai/src/api/cursor-agent/types.ts
+++ b/packages/ai/src/api/cursor-agent/types.ts
@@ -161,7 +161,12 @@ export interface CursorAgentOptions extends StreamOptions {
 	thinkingSelection?: ThinkingSelection;
 	/** Override stream health bounds for deterministic provider integration tests. */
 	streamHealthFailThresholdMs?: number;
+	/** @deprecated Accepted for compatibility; heartbeat/checkpoint frames are always liveness. */
 	streamHealthHeartbeatOnlyThresholdMs?: number;
+	/** Maximum pre-completion stall/transport retries (default 10). */
+	streamStallMaxRetries?: number;
+	/** Fixed retry delay for tests; production uses exponential backoff plus jitter. */
+	streamStallRetryDelayMs?: number;
 	/** Override the post-turn exec drain bound for deterministic tests. */
 	turnEndDrainTimeoutMs?: number;
 }

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-- Treat Cursor `turnEnded` as definitive completion after a bounded exec-dispatch drain, and fail silent pre-completion streams with heartbeat-aware 30s/90s health thresholds.
+- Match the official Cursor CLI's stream recovery: every inbound frame, including heartbeats and checkpoints, refreshes the 30s health timer; pre-`turnEnded` stalls and transport deaths retry with bounded backoff, and checkpointed attempts resume with the original pinned model request.
+- Treat Cursor `turnEnded` as definitive completion after a bounded exec-dispatch drain.
 - Skip ANTML invoke recovery when `model.api === "cursor-agent"` so native Cursor tool starts are not rejected as invalid event order.
 - Keep usable Cursor task tool arguments when the complete frame parses as empty.
 - Remint a Cursor conversation wire id after the 3-rotation skip instead of blocking the whole session.
@@ -43,6 +44,26 @@
 - `packages/ai/src/utils/overflow.ts` after `getOverflowPatterns()`.
 
 # AI Source Changes
+
+## 2026-08-22 - Cursor heartbeat liveness and checkpoint resume retries
+
+### What changed
+
+- `packages/ai/src/api/cursor-agent.ts`: uses one 30s deadline since the last inbound frame of any kind, waits for local exec dispatches before retrying pre-completion stalls or transport termination, and rebuilds checkpointed attempts as `resumeAction` requests without re-resolving the selected model.
+- `packages/ai/src/api/cursor-agent/stream-retry.ts` (new): contains the retry classification, 10-retry default policy, and official-style exponential backoff capped at 60s plus 0-20% jitter. Deterministic delay and budget options support transport harness tests.
+
+### Why
+
+- Cursor heartbeats and conversation checkpoints prove the server stream is alive, especially while a local exec handler is running. Killing heartbeat-only streams after 90s interrupted valid long-running tools. The official CLI instead retries a stream only after 30s with no inbound frame at all, resuming from the latest checkpoint when available.
+
+### Why an extension could not handle it
+
+- HTTP/2 termination, checkpoint caching, request action selection, and exec-dispatch draining all happen inside the native provider below extension-visible events.
+
+### Expected merge conflict zones
+
+- HIGH: `packages/ai/src/api/cursor-agent.ts` `stream()` HTTP/2 lifecycle and retry loop.
+- LOW: `packages/ai/src/api/cursor-agent/types.ts` test-tuning options.
 
 ## 2026-08-21 - Cursor turn completion and stream health bounds
 

--- a/packages/ai/test/cursor-agent-exec-lifecycle-harness.ts
+++ b/packages/ai/test/cursor-agent-exec-lifecycle-harness.ts
@@ -7,6 +7,7 @@ import type { AssistantMessage, Message, Model, ToolResultMessage } from "../src
 
 export type ExecMode = "success" | "rejection" | "pending" | "unknown" | "shellStream" | "dispatchFailure";
 export type TurnTerminationMode = "turnEndedOpen" | "silentMidTurn";
+export type StreamHealthMode = "heartbeatOnly" | "checkpointResume" | "retryExhaustion";
 type ClientFrame = ReturnType<typeof fromBinary<typeof AgentClientMessageSchema>>;
 
 const EXEC_IDS: Record<ExecMode, number> = {
@@ -18,7 +19,7 @@ const EXEC_IDS: Record<ExecMode, number> = {
 	dispatchFailure: 12,
 };
 
-class ClientFrameReader {
+export class ClientFrameReader {
 	#buffer: Buffer = Buffer.alloc(0);
 	readonly messages: ClientFrame[] = [];
 	#waiters = new Set<() => void>();
@@ -80,6 +81,24 @@ function turnEndedFrame(): Buffer {
 	});
 }
 
+function heartbeatFrame(): Buffer {
+	return serverFrame({
+		message: { case: "interactionUpdate", value: { message: { case: "heartbeat", value: {} } } },
+	});
+}
+
+function textDeltaFrame(text: string): Buffer {
+	return serverFrame({
+		message: { case: "interactionUpdate", value: { message: { case: "textDelta", value: { text } } } },
+	});
+}
+
+function checkpointFrame(): Buffer {
+	return serverFrame({
+		message: { case: "conversationCheckpointUpdate", value: {} },
+	});
+}
+
 function toolResult(toolCallId: string, text: string): ToolResultMessage {
 	return {
 		role: "toolResult",
@@ -97,6 +116,76 @@ async function observeServerTask(task: Promise<void>): Promise<unknown> {
 		return undefined;
 	} catch (error) {
 		return error instanceof Error ? error : new Error(String(error));
+	}
+}
+
+export async function runStreamHealthScenario(mode: StreamHealthMode): Promise<{
+	readonly attempts: number;
+	readonly actions: readonly ("userMessageAction" | "resumeAction" | undefined)[];
+	readonly message: AssistantMessage;
+}> {
+	const server = http2.createServer();
+	const sessions = new Set<http2.ServerHttp2Session>();
+	const actions: ("userMessageAction" | "resumeAction" | undefined)[] = [];
+	let attempts = 0;
+	server.on("session", (session) => {
+		sessions.add(session);
+		session.once("close", () => sessions.delete(session));
+	});
+	server.on("stream", (httpStream: http2.ServerHttp2Stream) => {
+		attempts += 1;
+		const attempt = attempts;
+		const reader = new ClientFrameReader();
+		httpStream.on("data", (chunk: Buffer) => reader.feed(chunk));
+		httpStream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+		void (async () => {
+			const runRequest = await reader.waitFor(() =>
+				reader.messages.find((item) => item.message.case === "runRequest"),
+			);
+			if (runRequest.message.case !== "runRequest") throw new Error("Expected runRequest");
+			const actionCase = runRequest.message.value.action?.action.case;
+			actions.push(actionCase === "userMessageAction" || actionCase === "resumeAction" ? actionCase : undefined);
+			if (mode === "heartbeatOnly") {
+				for (let index = 0; index < 5; index += 1) {
+					httpStream.write(heartbeatFrame());
+					await new Promise<void>((resolve) => setTimeout(resolve, 20));
+				}
+				httpStream.write(textDeltaFrame("alive"));
+				httpStream.write(turnEndedFrame());
+				return;
+			}
+			if (mode === "checkpointResume" && attempt === 1) {
+				httpStream.write(checkpointFrame());
+				return;
+			}
+			if (mode === "checkpointResume") {
+				httpStream.write(turnEndedFrame());
+			}
+		})().catch(() => httpStream.destroy());
+	});
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address();
+	if (!address || typeof address === "string") throw new Error("Expected TCP server address");
+	try {
+		const cursorStream = streamCursorAgent(
+			buildModel(`http://127.0.0.1:${address.port}`),
+			{ messages: [{ role: "user", content: "hello", timestamp: 0 }] satisfies Message[] },
+			{
+				apiKey: "test-token",
+				streamHealthFailThresholdMs: 50,
+				streamHealthHeartbeatOnlyThresholdMs: 50,
+				streamStallMaxRetries: mode === "retryExhaustion" ? 1 : 10,
+				streamStallRetryDelayMs: 1,
+				turnEndDrainTimeoutMs: 50,
+			} satisfies CursorAgentOptions,
+		);
+		for await (const _event of cursorStream) {
+			// Drain the public stream while the fake server drives retry behavior.
+		}
+		return { attempts, actions, message: await cursorStream.result() };
+	} finally {
+		for (const session of sessions) session.destroy();
+		await new Promise<void>((resolve) => server.close(() => resolve()));
 	}
 }
 
@@ -123,6 +212,7 @@ export async function runTurnTerminationScenario(mode: TurnTerminationMode): Pro
 				apiKey: "test-token",
 				streamHealthFailThresholdMs: 50,
 				streamHealthHeartbeatOnlyThresholdMs: 150,
+				streamStallMaxRetries: 0,
 				turnEndDrainTimeoutMs: 50,
 			} satisfies CursorAgentOptions,
 		);

--- a/packages/ai/test/cursor-agent-exec-lifecycle.cases.ts
+++ b/packages/ai/test/cursor-agent-exec-lifecycle.cases.ts
@@ -3,6 +3,7 @@ import { armExecHeartbeat } from "../src/api/cursor-agent/exec-lifecycle.ts";
 import {
 	findControlFrames,
 	runExecLifecycleScenario,
+	runStreamHealthScenario,
 	runTurnTerminationScenario,
 } from "./cursor-agent-exec-lifecycle-harness.ts";
 
@@ -45,6 +46,29 @@ export function registerCursorExecLifecycleTests(): void {
 			} finally {
 				vi.useRealTimers();
 			}
+		});
+	});
+
+	describe("cursor-agent stream health and resume", () => {
+		it("keeps heartbeat-only streams alive past the meaningful-frame window", async () => {
+			const { attempts, message } = await runStreamHealthScenario("heartbeatOnly");
+			expect(attempts).toBe(1);
+			expect(message.stopReason).toBe("stop");
+			expect(message.content).toEqual([expect.objectContaining({ type: "text", text: "alive" })]);
+		});
+
+		it("resumes from a checkpoint after a silent mid-turn stall", async () => {
+			const { actions, attempts, message } = await runStreamHealthScenario("checkpointResume");
+			expect(attempts).toBe(2);
+			expect(actions).toEqual(["userMessageAction", "resumeAction"]);
+			expect(message.stopReason).toBe("stop");
+		});
+
+		it("surfaces the last stall after the retry budget is exhausted", async () => {
+			const { attempts, message } = await runStreamHealthScenario("retryExhaustion");
+			expect(attempts).toBe(2);
+			expect(message.stopReason).toBe("error");
+			expect(message.errorMessage).toContain("inbound stream stalled");
 		});
 	});
 

--- a/packages/ai/test/cursor-agent.test.ts
+++ b/packages/ai/test/cursor-agent.test.ts
@@ -358,7 +358,7 @@ describe("cursor-agent wire protocol", () => {
 			stream.end();
 		});
 
-		const { message } = await collectStream(baseUrl, { apiKey: "test-token" });
+		const { message } = await collectStream(baseUrl, { apiKey: "test-token", streamStallMaxRetries: 0 });
 		expect(message.stopReason).toBe("error");
 		expect(message.errorMessage).toContain("ended before turnEnded");
 		// Partial content is preserved on the error message.

--- a/packages/ai/test/cursor-stream-retry.test.ts
+++ b/packages/ai/test/cursor-stream-retry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+	CursorRetryableStreamError,
+	cursorStreamRetryDelayMs,
+	isCursorRetryableStreamError,
+	shouldRetryCursorStream,
+} from "../src/api/cursor-agent/stream-retry.ts";
+
+describe("cursor stream retry policy", () => {
+	it("exponentially backs off and clamps before jitter", () => {
+		expect(cursorStreamRetryDelayMs({ attempt: 0, random: () => 0 })).toBe(1000);
+		expect(cursorStreamRetryDelayMs({ attempt: 6, random: () => 0 })).toBe(60_000);
+		expect(cursorStreamRetryDelayMs({ attempt: 20, random: () => 1 })).toBe(72_000);
+	});
+
+	it("keeps jitter within 0-20 percent and allows a fixed test delay", () => {
+		expect(cursorStreamRetryDelayMs({ attempt: 2, random: () => 0 })).toBe(4000);
+		expect(cursorStreamRetryDelayMs({ attempt: 2, random: () => 1 })).toBe(4800);
+		expect(cursorStreamRetryDelayMs({ attempt: 20, fixedDelayMs: 3, random: () => 1 })).toBe(3);
+	});
+
+	it("retries only classified pre-turn transport failures within budget", () => {
+		const error = new CursorRetryableStreamError("stalled", "stall");
+		expect(isCursorRetryableStreamError(error)).toBe(true);
+		expect(shouldRetryCursorStream({ error, retries: 0, maxRetries: 1, sawTurnEnded: false, aborted: false })).toBe(
+			true,
+		);
+		expect(shouldRetryCursorStream({ error, retries: 1, maxRetries: 1, sawTurnEnded: false, aborted: false })).toBe(
+			false,
+		);
+		expect(shouldRetryCursorStream({ error, retries: 0, maxRetries: 1, sawTurnEnded: true, aborted: false })).toBe(
+			false,
+		);
+		expect(
+			shouldRetryCursorStream({
+				error: new Error("grpc"),
+				retries: 0,
+				maxRetries: 1,
+				sawTurnEnded: false,
+				aborted: false,
+			}),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

User report: with `claude-fable-5-thinking` xhigh as the main model on the native Cursor lane, turns error out when the model works for a long time, and the subsequent model rotation produces further errors.

Reproduced live against `api2.cursor.sh` (default thresholds, `claude-fable-5-thinking-xhigh`): a local MCP tool taking 150s kills the turn mid-tool with `Cursor stream ended before turnEnded: inbound stream stalled` (`/tmp/fable-stall-repro-2.jsonl`).

## Root cause (verified against the official CLI bundle 2026.08.11-e8db854)

senpi's stream-health logic diverges from the official cursor-agent CLI:

| Aspect | Official CLI | senpi (before) |
| --- | --- | --- |
| Heartbeat-only stream | Lives indefinitely: every inbound frame, heartbeats included, resets the single 30s deadline (`reset("inbound_message","heartbeat")` @4436447 defaults `meaningful=true` @4406411; the 90s heartbeat-only path is unreachable dead code, guard @4410465) | Killed after 90s of heartbeat/checkpoint-only frames (`cursor-agent.ts` dual deadline) |
| 30s inbound silence | Aborts the attempt, then silently retries: new stream + `resumeAction` + latest server checkpoint, model pinned from attempt 0 (@4424917, @4419421), backoff `min(1000*2^n, 60000)` + 0-20% jitter (@4420210), 10 transport retries | Terminal error, zero retries |
| Downstream | Absorbed inside the client | The stall string is not retry-classified (`utils/retry.ts`), so the session layer instantly hard-error-falls-back, rotating models against the same wedged conversation - cascading errors |

Any local exec tool running past 90s (builds, test suites) was a deterministic failure; any transient 30s+ network hiccup during a long xhigh turn surfaced as an error the official CLI would have hidden.

## Fix

- Single 30s health deadline refreshed by every inbound frame; `streamHealthHeartbeatOnlyThresholdMs` stays accepted but inert (deprecated).
- New `cursor-agent/stream-retry.ts`: retry classification (`stall` / `transport` / `clean-end`), 10-retry default budget, official-style backoff + jitter, abort-aware wait; `streamStallMaxRetries` / `streamStallRetryDelayMs` options make it deterministic in tests.
- On a retryable death: drain in-flight exec dispatches, close open blocks, rebuild the request - `resumeAction` when a checkpoint arrived this turn, otherwise the original action - with `requestedModel`/`modelDetails` pinned from attempt 0 and a fresh `x-request-id`.
- Never retry after `turnEnded`, on abort, or past the budget; the final error surfaces unchanged so fallback still engages when genuinely needed.

## Failing-first proof

RED (pre-fix, captured on reverted src with the new tests):
```
Tests  3 failed | 30 skipped (33)
  x keeps heartbeat-only streams alive past the meaningful-frame window   expected 'error' to be 'stop'
  x resumes from a checkpoint after a silent mid-turn stall               expected 1 to be 2
  x surfaces the last stall after the retry budget is exhausted           expected 1 to be 2
```
GREEN (post-fix): the same file passes (33 tests), full `packages/ai` suite `233 passed | 25 skipped (2205 tests)`.

## QA evidence

- Live RED: `/tmp/fable-stall-repro-2.jsonl` - 150s tool, turn killed mid-tool with the reported error.
- Live GREEN (this branch's dist, identical scenario): tool runs 150s, turn completes `stop`, no error (`/tmp/fable-stall-green-1.jsonl`).
- Healthy-stream sanity: 216s xhigh thinking turn streams fine before and after (`/tmp/fable-stall-repro-1.jsonl`).
- Adjacent suites: `packages/agent` cursor exec loop/recovery 9/9; `packages/coding-agent` cursor-cli-oauth + exec-bridge 271/271; root `npm run check` clean (biome, tsc, pinned-deps, shrinkwrap, install-lock, browser smoke).

Out of scope, tracked separately: unanswered `interactionQuery` frames (#1026) and rotation double-exec risk (#1027); with this fix their symptom no longer masquerades as an instant turn kill.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match the official Cursor CLI’s stream recovery to stop premature turn failures and model rotation. Previously we failed after 90s of heartbeat-only frames or 30s of silence with no retries; now every inbound frame refreshes a single 30s liveness timer, and pre-turnEnded stalls/transport deaths retry up to 10 times with backoff, resuming from checkpoints while pinning the original model.

- Introduces `packages/ai/src/api/cursor-agent/stream-retry.ts` with retry classification (`stall`/`transport`/`clean-end`), exponential backoff capped at 60s with 0–20% jitter, and options `streamStallMaxRetries`/`streamStallRetryDelayMs` for deterministic tests.
- Replaces dual health timers with one 30s deadline refreshed by any inbound frame; `streamHealthHeartbeatOnlyThresholdMs` is accepted but inert (deprecated).
- On retryable deaths: drains in-flight exec dispatches, rebuilds the request (`resumeAction` when checkpointed), pins the initial `requestedModel`/`modelDetails`, and issues a fresh `x-request-id`; never retries after `turnEnded`, on abort, or past budget; final errors surface unchanged.
- Maps HTTP/2 GOAWAY/close/errors to retryable transport causes; adds harness and unit tests in `packages/ai` verifying heartbeat-only survival, checkpoint resume, and retry exhaustion; updates `changes.md` and `CHANGELOG.md`. No migration required; tests can set the new retry options for determinism.

<sup>Written for commit b6ca554b66c5f8f739dc84e7deffc72b84a06219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

