### PR TITLE
feat(codemode): show kernel runtime identity in eval headers, details, and host line

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Eval headers now display the kernel runtime identity, e.g. `eval py (3.14.7, ~/.venv/bin/python3)` and `eval js (node 26.7.0, /opt/…/bin/node)`; the same `runtime` info rides `EvalToolDetails` and its `cells` so RPC consumers receive it, interpreter detection resolves absolute executable paths from PATH, and the eval prompt host line names the JS runtime (`node`/`bun` with version).
+
 ### Changed
 
 ### Fixed

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -30,6 +30,11 @@ task-tool names are known.
 - TUI and HTML-export rendering for syntax-highlighted cells, status rows,
   task progress, structured display values, truncation warnings, and image
   fallbacks.
+- Runtime identity badges in eval headers — `eval py (3.14.7, ~/.venv/bin/python3)`,
+  `eval js (node 26.7.0, /opt/…/bin/node)` — with the same `runtime` info on
+  `EvalToolDetails` and its `cells` for RPC consumers; interpreter detection
+  resolves absolute executable paths, and the eval prompt host line names the
+  JS runtime (`node`/`bun`).
 - JavaScript import rewriting for supported local modules and package imports
   in the persistent Node.js worker.
 - GPT models receive a terse `eval` prompt dialect that prioritizes composing

--- a/packages/senpi-codemode/src/extension/runtime-factory.ts
+++ b/packages/senpi-codemode/src/extension/runtime-factory.ts
@@ -14,7 +14,8 @@ import {
 	type InterpreterAvailability,
 } from "../interpreters/detect.ts";
 import { resolveSessionArtifactsDir } from "../output/streaming-output.ts";
-import type { EnabledEvalLanguages, EvalLanguage } from "../tool/types.ts";
+import type { EnabledEvalLanguages, EvalLanguage, EvalRuntimes } from "../tool/types.ts";
+import { jsRuntimeInfo, runtimesFromAvailability } from "./runtime-info.ts";
 import {
 	type CodemodeSessionManager,
 	type CreateCodemodeSessionManagerOptions,
@@ -39,6 +40,7 @@ export type SessionRuntime = {
 	readonly parallelPoolWidth: number;
 	readonly manager: CodemodeSessionManager;
 	readonly enabledLanguages: EnabledEvalLanguages;
+	readonly runtimes: EvalRuntimes;
 	readonly settings: ResolvedCodemodeSettings;
 	readonly artifactsDir: string;
 	readonly executeTool: AgentExecuteTool;
@@ -82,6 +84,7 @@ export async function createRuntime(
 		parallelPoolWidth,
 		manager,
 		enabledLanguages,
+		runtimes: runtimesFromAvailability(availability, jsRuntimeInfo()),
 		settings,
 		artifactsDir: artifacts.dir,
 		executeTool,

--- a/packages/senpi-codemode/src/extension/runtime-info.ts
+++ b/packages/senpi-codemode/src/extension/runtime-info.ts
@@ -1,0 +1,41 @@
+import type { InterpreterAvailability } from "../interpreters/detect.ts";
+import type { EvalLanguage, EvalRuntimeInfo, EvalRuntimes } from "../tool/types.ts";
+
+export interface JsRuntimeVersions {
+	readonly node: string;
+	readonly bun?: string | undefined;
+}
+
+/** Identity of the in-process JS kernel host: bun when its marker exists, node otherwise. */
+export function jsRuntimeInfo(
+	versions: JsRuntimeVersions = process.versions,
+	execPath: string = process.execPath,
+): EvalRuntimeInfo {
+	const bun = versions.bun;
+	if (bun !== undefined && bun.length > 0) return { name: "bun", version: bun, path: execPath };
+	return { name: "node", version: versions.node, path: execPath };
+}
+
+/** Short host-line segment, e.g. "node 26.7.0" or "bun 1.4.0". */
+export function jsRuntimeLabel(versions: JsRuntimeVersions = process.versions): string {
+	const info = jsRuntimeInfo(versions, "");
+	return `${info.name} ${info.version}`;
+}
+
+const subprocessRuntimeNames = { py: "python", rb: "ruby", jl: "julia" } as const;
+const subprocessLanguages = ["py", "rb", "jl"] as const;
+
+/** Maps detected interpreters to display runtimes, preferring resolved absolute paths. */
+export function runtimesFromAvailability(availability: InterpreterAvailability, js: EvalRuntimeInfo): EvalRuntimes {
+	const runtimes: Partial<Record<EvalLanguage, EvalRuntimeInfo>> = { js };
+	for (const language of subprocessLanguages) {
+		const detected = availability[language].detected;
+		if (!detected.ok) continue;
+		runtimes[language] = {
+			name: subprocessRuntimeNames[language],
+			version: detected.version,
+			path: detected.resolvedPath ?? detected.path,
+		};
+	}
+	return runtimes;
+}

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -13,6 +13,7 @@ import {
 	enabledLanguagesFrom,
 	type SessionRuntime,
 } from "./extension/runtime-factory.ts";
+import { jsRuntimeInfo, jsRuntimeLabel } from "./extension/runtime-info.ts";
 import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "./extension/session-manager.ts";
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
 import { WAKE_SOURCE_STATE_EVENT, type WakeSourceState } from "./extension/wake-source-state.ts";
@@ -119,6 +120,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 				spawns: runtime.spawns,
 				spawnDefaultAgent: runtime.settings.taskTools.task,
 				hostLine: hostLine(),
+				runtimes: runtime.runtimes,
 				...(modelId === undefined ? {} : { modelId }),
 			}),
 		);
@@ -152,6 +154,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			executionTracker: manager,
 			renderers,
 			hostLine: hostLine(),
+			runtimes: { js: jsRuntimeInfo() },
 		}),
 	);
 	pi.registerRemovedToolHint(
@@ -206,7 +209,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 
 function hostLine(): string {
 	const cpu = os.cpus()[0]?.model?.trim();
-	return [`${os.platform()} ${os.arch()}`, cpu, `${os.availableParallelism()} cores`]
+	return [`${os.platform()} ${os.arch()}`, cpu, `${os.availableParallelism()} cores`, jsRuntimeLabel()]
 		.filter((part): part is string => !!part)
 		.join(" \u00b7 ");
 }

--- a/packages/senpi-codemode/src/interpreters/detect.ts
+++ b/packages/senpi-codemode/src/interpreters/detect.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { platform as currentPlatform } from "node:os";
 import { promisify } from "node:util";
 import type { CodemodeSettings } from "../config/settings.ts";
+import { resolveCommandPath as defaultResolveCommandPath, type ResolveCommandPath } from "./resolve-command.ts";
 
 const execFileAsync = promisify(execFile);
 const probeTimeoutMs = 3_000;
@@ -10,8 +11,11 @@ export type CodemodeLanguage = "py" | "js" | "rb" | "jl";
 
 export interface InterpreterDetected {
 	readonly ok: true;
+	/** The probe command line that answered, e.g. "python3" or "py -3". */
 	readonly path: string;
 	readonly version: string;
+	/** Absolute executable path resolved from PATH, when resolution succeeded. */
+	readonly resolvedPath?: string;
 }
 
 export interface InterpreterUnavailable {
@@ -34,6 +38,7 @@ export interface CreateInterpreterDetectorOptions {
 	readonly platform?: NodeJS.Platform;
 	readonly execFile?: ExecFileProbe;
 	readonly nodeVersion?: string;
+	readonly resolveCommandPath?: ResolveCommandPath;
 }
 
 export interface InterpreterDetector {
@@ -55,6 +60,7 @@ export function createInterpreterDetector(options: CreateInterpreterDetectorOpti
 	const probe = options.execFile ?? defaultExecFileProbe;
 	const hostPlatform = options.platform ?? currentPlatform();
 	const nodeVersion = options.nodeVersion ?? process.versions.node;
+	const resolveCommand = options.resolveCommandPath ?? defaultResolveCommandPath;
 	const cache = new Map<CodemodeLanguage, Promise<InterpreterDetection>>();
 
 	return {
@@ -64,7 +70,7 @@ export function createInterpreterDetector(options: CreateInterpreterDetectorOpti
 				return cached;
 			}
 
-			const pending = detectUncached(language, hostPlatform, probe, nodeVersion);
+			const pending = detectUncached(language, hostPlatform, probe, nodeVersion, resolveCommand);
 			cache.set(language, pending);
 			return pending;
 		},
@@ -99,13 +105,14 @@ async function detectUncached(
 	hostPlatform: NodeJS.Platform,
 	probe: ExecFileProbe,
 	nodeVersion: string,
+	resolveCommand: ResolveCommandPath,
 ): Promise<InterpreterDetection> {
 	if (language === "js") {
 		return { ok: true, path: "node", version: nodeVersion };
 	}
 
 	for (const candidate of candidatesFor(language, hostPlatform)) {
-		const result = await probeCandidate(candidate, probe);
+		const result = await probeCandidate(candidate, probe, resolveCommand);
 		if (result.ok) {
 			return result;
 		}
@@ -114,12 +121,18 @@ async function detectUncached(
 	return unavailable;
 }
 
-async function probeCandidate(candidate: string, probe: ExecFileProbe): Promise<InterpreterDetection> {
+async function probeCandidate(
+	candidate: string,
+	probe: ExecFileProbe,
+	resolveCommand: ResolveCommandPath,
+): Promise<InterpreterDetection> {
 	const invocation = candidateInvocation(candidate);
 	try {
 		const result = await probe(invocation.command, [...invocation.args, "--version"], { timeoutMs: probeTimeoutMs });
 		const version = parseVersion(`${result.stdout}\n${result.stderr}`);
-		return version === null ? unavailable : { ok: true, path: candidate, version };
+		if (version === null) return unavailable;
+		const resolvedPath = resolveCommand(invocation.command);
+		return { ok: true, path: candidate, version, ...(resolvedPath === undefined ? {} : { resolvedPath }) };
 	} catch {
 		return unavailable;
 	}

--- a/packages/senpi-codemode/src/interpreters/resolve-command.ts
+++ b/packages/senpi-codemode/src/interpreters/resolve-command.ts
@@ -1,0 +1,68 @@
+import { accessSync, constants, statSync } from "node:fs";
+import { delimiter, isAbsolute, resolve as resolvePath } from "node:path";
+
+export interface ResolveCommandPathOptions {
+	readonly env?: NodeJS.ProcessEnv;
+	readonly platform?: NodeJS.Platform;
+	readonly cwd?: string;
+}
+
+export type ResolveCommandPath = (command: string, options?: ResolveCommandPathOptions) => string | undefined;
+
+const defaultWindowsPathExt = ".COM;.EXE;.BAT;.CMD";
+
+/**
+ * Resolves a bare command name to the absolute executable path a spawn would
+ * use, by scanning PATH without spawning a process. Returns undefined when the
+ * command cannot be resolved; callers treat that as "no display path known".
+ */
+export function resolveCommandPath(command: string, options: ResolveCommandPathOptions = {}): string | undefined {
+	if (command.length === 0) return undefined;
+	const env = options.env ?? process.env;
+	const platform = options.platform ?? process.platform;
+	const isWindows = platform === "win32";
+	if (command.includes("/") || (isWindows && command.includes("\\"))) {
+		const absolute = isAbsolute(command) ? command : resolvePath(options.cwd ?? process.cwd(), command);
+		return firstExecutable(candidatesFor(absolute, isWindows, env), isWindows);
+	}
+	const pathValue = env.PATH ?? env.Path ?? "";
+	if (pathValue.length === 0) return undefined;
+	for (const directory of pathValue.split(delimiter)) {
+		if (directory.length === 0) continue;
+		const base = `${directory}${directory.endsWith("/") || directory.endsWith("\\") ? "" : pathSeparatorFor(directory, isWindows)}${command}`;
+		const found = firstExecutable(candidatesFor(base, isWindows, env), isWindows);
+		if (found !== undefined) return found;
+	}
+	return undefined;
+}
+
+function pathSeparatorFor(directory: string, isWindows: boolean): string {
+	if (isWindows && directory.includes("\\") && !directory.includes("/")) return "\\";
+	return "/";
+}
+
+function candidatesFor(base: string, isWindows: boolean, env: NodeJS.ProcessEnv): readonly string[] {
+	if (!isWindows) return [base];
+	const extensions = (env.PATHEXT ?? defaultWindowsPathExt)
+		.split(";")
+		.map((extension) => extension.trim())
+		.filter((extension) => extension.startsWith("."));
+	const candidates = [base];
+	for (const extension of extensions) {
+		candidates.push(`${base}${extension.toLowerCase()}`, `${base}${extension}`);
+	}
+	return candidates;
+}
+
+function firstExecutable(candidates: readonly string[], isWindows: boolean): string | undefined {
+	for (const candidate of candidates) {
+		try {
+			if (!statSync(candidate).isFile()) continue;
+			if (!isWindows) accessSync(candidate, constants.X_OK);
+			return candidate;
+		} catch {
+			// Missing or non-executable candidate: keep scanning the remaining ones.
+		}
+	}
+	return undefined;
+}

--- a/packages/senpi-codemode/src/tool/cell-runtime.ts
+++ b/packages/senpi-codemode/src/tool/cell-runtime.ts
@@ -2,7 +2,7 @@ import type { AgentToolResult, AgentToolUpdateCallback, ExtensionContext } from 
 import type { KernelToHostMessage } from "../bridge/protocol.ts";
 import type { EvalToolCallMetric } from "./call-capture.ts";
 import { type EvalImageResizer, EvalOutputCollector, type EvalOutputResult } from "./image.ts";
-import type { EvalStatusEvent, EvalToolDetails, EvalToolInput } from "./types.ts";
+import type { EvalRuntimeInfo, EvalStatusEvent, EvalToolDetails, EvalToolInput } from "./types.ts";
 
 type KernelResult = Extract<KernelToHostMessage, { type: "result" }>;
 type DisplayMessage = Extract<KernelToHostMessage, { type: "display" }>;
@@ -10,6 +10,7 @@ type ToolCall = EvalToolDetails["toolCalls"] extends readonly (infer Item)[] ? I
 
 export interface CellState {
 	readonly input: EvalToolInput;
+	readonly runtime?: EvalRuntimeInfo;
 	readonly startedAt: number;
 	readonly signal: AbortSignal;
 	readonly onUpdate: AgentToolUpdateCallback<EvalToolDetails> | undefined;
@@ -125,6 +126,7 @@ export class CellResultBuilder {
 		return {
 			language: this.#state.input.language,
 			languages: [this.#state.input.language],
+			...(this.#state.runtime === undefined ? {} : { runtime: this.#state.runtime }),
 			...(this.#state.input.summary === undefined ? {} : { summary: this.#state.input.summary }),
 			durationMs: this.#state.durationMs,
 			wallDurationMs: Math.max(0, Date.now() - this.#state.startedAt),
@@ -139,6 +141,7 @@ export class CellResultBuilder {
 					...(this.#state.input.summary === undefined ? {} : { summary: this.#state.input.summary }),
 					code: this.#state.input.code,
 					language: this.#state.input.language,
+					...(this.#state.runtime === undefined ? {} : { runtime: this.#state.runtime }),
 					output: this.#state.output,
 					status: this.#state.status,
 					durationMs: this.#state.durationMs,

--- a/packages/senpi-codemode/src/tool/eval-tool-options.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool-options.ts
@@ -11,6 +11,7 @@ import type {
 	EnabledEvalLanguages,
 	EvalInputSchema,
 	EvalKernelManager,
+	EvalRuntimes,
 	EvalToolDetails,
 	EvalToolInput,
 	ExecuteTool,
@@ -38,6 +39,8 @@ export interface CreateEvalToolOptions {
 	readonly spawnDefaultAgent?: string;
 	readonly modelId?: string;
 	readonly hostLine?: string;
+	/** Display identity of each language's runtime, shown in headers and details. */
+	readonly runtimes?: EvalRuntimes;
 }
 
 export interface EvalCellInvocation {

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -98,8 +98,10 @@ async function runEvalCell(
 	const bridgeAbortController = new AbortController();
 	const cellSignal = AbortSignal.any([invocation.signal, bridgeAbortController.signal]);
 	const bridgeContext: ExtensionContext = { ...invocation.ctx, signal: cellSignal };
+	const runtime = options.runtimes?.[invocation.input.language];
 	const state: CellState = {
 		input: invocation.input,
+		...(runtime === undefined ? {} : { runtime }),
 		startedAt: Date.now(),
 		signal: cellSignal,
 		onUpdate: invocation.onUpdate,

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -19,6 +19,7 @@ import {
 	JSON_TREE_SCALAR_LEN_EXPANDED,
 	renderJsonTreeLines,
 } from "./json-tree.ts";
+import { formatRuntimeBadge } from "./runtime-label.ts";
 import { codePointPrefix, formatDuration, renderToolCallWidget } from "./tool-widgets.ts";
 import type {
 	EvalCellResult,
@@ -261,7 +262,8 @@ function renderPrefixed(text: string, environment: RenderEnvironment, prefixStyl
 
 function cellHeader(cell: EvalCellResult, environment: RenderEnvironment, badges: CellBadges): string {
 	const presentation = cellPresentation(cell.status, environment.spinnerFrame);
-	let header = `eval ${cell.language} ${presentation.label} ${presentation.icon}`;
+	const runtimeBadge = cell.runtime === undefined ? "" : ` (${formatRuntimeBadge(cell.language, cell.runtime)})`;
+	let header = `eval ${cell.language}${runtimeBadge} ${presentation.label} ${presentation.icon}`;
 	const throughputBadge = badges.throughput === undefined ? undefined : formatThroughputBadge(badges.throughput);
 	if (throughputBadge !== undefined) header += ` · ${throughputBadge}`;
 	const elapsedMs = badges.throughput?.wallDurationMs ?? cell.durationMs;
@@ -780,7 +782,9 @@ function resultHeader(
 			color = "error";
 			break;
 	}
-	return style(theme, color, `eval ${details?.language ?? "?"} ${status}`);
+	const runtimeBadge =
+		details?.runtime === undefined ? "" : ` (${formatRuntimeBadge(details.language, details.runtime)})`;
+	return style(theme, color, `eval ${details?.language ?? "?"}${runtimeBadge} ${status}`);
 }
 
 function resultMetadata(

--- a/packages/senpi-codemode/src/tool/runtime-label.ts
+++ b/packages/senpi-codemode/src/tool/runtime-label.ts
@@ -1,0 +1,49 @@
+import { homedir } from "node:os";
+import type { EvalLanguage, EvalRuntimeInfo } from "./types.ts";
+
+const MAX_BADGE_PATH_CODE_POINTS = 40;
+const ELLIPSIS = "\u2026";
+
+/**
+ * One-line runtime badge for eval headers, e.g. "3.14.7, ~/.venv/bin/python3"
+ * or "node 26.7.0, /opt/…/bin/node". The js language always carries the
+ * runtime name because node and bun are otherwise indistinguishable.
+ */
+export function formatRuntimeBadge(language: EvalLanguage, runtime: EvalRuntimeInfo, home: string = homedir()): string {
+	const label = language === "js" ? `${runtime.name} ${runtime.version}` : runtime.version;
+	if (runtime.path === undefined || runtime.path.length === 0) return label;
+	return `${label}, ${minifyPath(runtime.path, home)}`;
+}
+
+/** Home-contracts and middle-truncates a path so header badges stay short. */
+export function minifyPath(path: string, home: string = homedir()): string {
+	const contracted = contractHome(path, home);
+	if (codePointLength(contracted) <= MAX_BADGE_PATH_CODE_POINTS) return contracted;
+	const separator = contracted.includes("/") ? "/" : "\\";
+	const segments = contracted.split(separator).filter((segment) => segment.length > 0);
+	const head = contracted.startsWith(separator) ? `${separator}${segments[0] ?? ""}` : (segments[0] ?? "");
+	const tail: string[] = [];
+	for (let index = segments.length - 1; index >= 1; index -= 1) {
+		const attempt = joinTruncated(head, [segments[index] ?? "", ...tail], separator);
+		if (codePointLength(attempt) > MAX_BADGE_PATH_CODE_POINTS) break;
+		tail.unshift(segments[index] ?? "");
+	}
+	if (tail.length > 0) return joinTruncated(head, tail, separator);
+	const suffix = [...contracted].slice(-(MAX_BADGE_PATH_CODE_POINTS - 1)).join("");
+	return `${ELLIPSIS}${suffix}`;
+}
+
+function joinTruncated(head: string, tail: readonly string[], separator: string): string {
+	return `${head}${separator}${ELLIPSIS}${separator}${tail.join(separator)}`;
+}
+
+function contractHome(path: string, home: string): string {
+	if (home.length === 0) return path;
+	if (path === home) return "~";
+	if (path.startsWith(`${home}/`) || path.startsWith(`${home}\\`)) return `~${path.slice(home.length)}`;
+	return path;
+}
+
+function codePointLength(text: string): number {
+	return [...text].length;
+}

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -140,6 +140,15 @@ export interface EvalToolCallSummary {
 
 export type EvalStatusEvent = { readonly op: string } & Readonly<Record<string, unknown>>;
 
+/** Identity of the runtime executing a kernel: interpreter or JS host. */
+export interface EvalRuntimeInfo {
+	readonly name: string;
+	readonly version: string;
+	readonly path?: string;
+}
+
+export type EvalRuntimes = Readonly<Partial<Record<EvalLanguage, EvalRuntimeInfo>>>;
+
 export type EvalDisplayOutput =
 	| { readonly type: "json"; readonly data: unknown }
 	| { readonly type: "image"; readonly data: string; readonly mimeType: string }
@@ -152,6 +161,7 @@ export type EvalCellResult = {
 	readonly code: string;
 	readonly language: EvalLanguage;
 	readonly output: string;
+	readonly runtime?: EvalRuntimeInfo;
 	readonly status: "pending" | "running" | "detached" | "complete" | "error" | "cancelled";
 	readonly exitCode?: number;
 	readonly durationMs?: number;
@@ -162,6 +172,7 @@ export type EvalCellResult = {
 export interface EvalToolDetails {
 	readonly language: EvalLanguage;
 	readonly languages?: readonly EvalLanguage[];
+	readonly runtime?: EvalRuntimeInfo;
 	readonly summary?: string;
 	readonly durationMs: number;
 	/** True wall-clock elapsed time since the cell started; `durationMs` stays kernel-reported. */

--- a/packages/senpi-codemode/test/eval-cell-runtime-details.test.ts
+++ b/packages/senpi-codemode/test/eval-cell-runtime-details.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { CellResultBuilder, type CellState } from "../src/tool/cell-runtime.ts";
+import type { EvalRuntimeInfo } from "../src/tool/types.ts";
+
+function makeState(runtime?: EvalRuntimeInfo): CellState {
+	return {
+		input: { language: "py", code: "1", summary: "runtime propagation" },
+		startedAt: Date.now(),
+		signal: new AbortController().signal,
+		onUpdate: undefined,
+		toolCalls: [],
+		toolCallMetrics: [],
+		pendingBridgeCalls: [],
+		statusEvents: [],
+		active: true,
+		output: "",
+		phase: undefined,
+		error: undefined,
+		durationMs: 0,
+		status: "pending",
+		...(runtime === undefined ? {} : { runtime }),
+	};
+}
+
+function makeBuilder(state: CellState): CellResultBuilder {
+	return new CellResultBuilder({ state, headBytes: 4096, maxColumns: 120, model: undefined });
+}
+
+describe("cell result runtime propagation", () => {
+	it("carries the kernel runtime into details and the RPC cell payload", async () => {
+		const runtime: EvalRuntimeInfo = { name: "python", version: "3.14.7", path: "/opt/homebrew/bin/python3" };
+		const builder = makeBuilder(makeState(runtime));
+
+		const result = await builder.finalize({ type: "result", cellId: "cell-1", ok: true, durationMs: 5 });
+
+		expect(result.details.runtime).toEqual(runtime);
+		expect(result.details.cells?.[0]?.runtime).toEqual(runtime);
+	});
+
+	it("omits runtime from details when the kernel identity is unknown", async () => {
+		const builder = makeBuilder(makeState());
+
+		const result = await builder.finalize({ type: "result", cellId: "cell-2", ok: true, durationMs: 5 });
+
+		expect(result.details.runtime).toBeUndefined();
+		expect(result.details.cells?.[0]).not.toHaveProperty("runtime");
+	});
+});

--- a/packages/senpi-codemode/test/eval-render-runtime.test.ts
+++ b/packages/senpi-codemode/test/eval-render-runtime.test.ts
@@ -1,0 +1,73 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { renderEvalResult } from "../src/tool/render.ts";
+import type { EvalToolDetails } from "../src/tool/types.ts";
+import { evalResult, renderLines, resultContext } from "./eval-render-fixtures.ts";
+
+function detailsWithCell(runtime: EvalToolDetails["runtime"]): EvalToolDetails {
+	return {
+		language: "py",
+		durationMs: 0,
+		toolCalls: [],
+		truncated: false,
+		...(runtime === undefined ? {} : { runtime }),
+		cells: [
+			{
+				index: 0,
+				code: "print(1)",
+				language: "py",
+				output: "",
+				status: "complete",
+				...(runtime === undefined ? {} : { runtime }),
+			},
+		],
+	};
+}
+
+describe("eval renderer runtime badge", () => {
+	it("shows version and home-contracted interpreter path in the cell header", () => {
+		const pythonPath = join(homedir(), ".venv", "bin", "python3");
+		const result = evalResult(detailsWithCell({ name: "python", version: "3.14.7", path: pythonPath }), "done");
+
+		const rendered = renderLines(
+			renderEvalResult(result, { expanded: false, isPartial: false }, undefined, resultContext(undefined, false)),
+		);
+
+		expect(rendered[0]).toBe("\u256d\u2500 eval py (3.14.7, ~/.venv/bin/python3) done \u2713");
+	});
+
+	it("labels the js runtime with its name so node and bun are distinguishable", () => {
+		const details: EvalToolDetails = {
+			language: "js",
+			durationMs: 0,
+			toolCalls: [],
+			truncated: false,
+			runtime: { name: "node", version: "26.7.0" },
+		};
+
+		const rendered = renderLines(
+			renderEvalResult(
+				evalResult(details, "complete"),
+				{ expanded: false, isPartial: false },
+				undefined,
+				resultContext(undefined, false),
+			),
+		);
+
+		expect(rendered[0]).toBe("eval js (node 26.7.0) done");
+	});
+
+	it("renders headers without any badge when runtime is unknown", () => {
+		const rendered = renderLines(
+			renderEvalResult(
+				evalResult(detailsWithCell(undefined), "done"),
+				{ expanded: false, isPartial: false },
+				undefined,
+				resultContext(undefined, false),
+			),
+		);
+
+		expect(rendered[0]).toBe("\u256d\u2500 eval py done \u2713");
+	});
+});

--- a/packages/senpi-codemode/test/interpreter-resolved-path.test.ts
+++ b/packages/senpi-codemode/test/interpreter-resolved-path.test.ts
@@ -1,0 +1,101 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import type { ExecFileProbe } from "../src/interpreters/detect.ts";
+import { createInterpreterDetector } from "../src/interpreters/detect.ts";
+import { resolveCommandPath } from "../src/interpreters/resolve-command.ts";
+
+function stubProbe(outputs: ReadonlyMap<string, string>): ExecFileProbe {
+	return async (command, args) => {
+		const value = outputs.get([command, ...args].join(" "));
+		if (typeof value !== "string") throw new Error("missing command");
+		return { stdout: value, stderr: "" };
+	};
+}
+
+describe("interpreter detection resolved path", () => {
+	it("attaches the resolved absolute executable path to detections", async () => {
+		const detector = createInterpreterDetector({
+			platform: "linux",
+			execFile: stubProbe(new Map([["python3 --version", "Python 3.14.7"]])),
+			resolveCommandPath: (command) => (command === "python3" ? "/opt/homebrew/bin/python3" : undefined),
+		});
+
+		await expect(detector.detect("py")).resolves.toEqual({
+			ok: true,
+			path: "python3",
+			version: "3.14.7",
+			resolvedPath: "/opt/homebrew/bin/python3",
+		});
+	});
+
+	it("omits resolvedPath when the command cannot be resolved", async () => {
+		const detector = createInterpreterDetector({
+			platform: "linux",
+			execFile: stubProbe(new Map([["ruby --version", "ruby 3.3.6"]])),
+			resolveCommandPath: () => undefined,
+		});
+
+		await expect(detector.detect("rb")).resolves.toEqual({ ok: true, path: "ruby", version: "3.3.6" });
+	});
+
+	it("resolves multi-word candidates through the bare command", async () => {
+		const seen: string[] = [];
+		const detector = createInterpreterDetector({
+			platform: "win32",
+			execFile: stubProbe(
+				new Map([
+					["python --version", ""],
+					["py -3 --version", "Python 3.12.4"],
+				]),
+			),
+			resolveCommandPath: (command) => {
+				seen.push(command);
+				return command === "py" ? "C:\\Windows\\py.exe" : undefined;
+			},
+		});
+
+		await expect(detector.detect("py")).resolves.toEqual({
+			ok: true,
+			path: "py -3",
+			version: "3.12.4",
+			resolvedPath: "C:\\Windows\\py.exe",
+		});
+		expect(seen).toContain("py");
+	});
+});
+
+describe("resolveCommandPath", () => {
+	const dir = mkdtempSync(join(tmpdir(), "senpi-resolve-"));
+	afterAll(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("finds an executable on PATH and returns its absolute path", () => {
+		const target = join(dir, "fake-interpreter");
+		writeFileSync(target, "#!/bin/sh\n");
+		chmodSync(target, 0o755);
+		expect(resolveCommandPath("fake-interpreter", { env: { PATH: dir }, platform: "darwin" })).toBe(target);
+	});
+
+	it("returns undefined for a missing command", () => {
+		expect(resolveCommandPath("definitely-missing-tool", { env: { PATH: dir }, platform: "darwin" })).toBeUndefined();
+	});
+
+	it("skips non-executable files on posix", () => {
+		const target = join(dir, "not-executable");
+		writeFileSync(target, "");
+		chmodSync(target, 0o644);
+		expect(resolveCommandPath("not-executable", { env: { PATH: dir }, platform: "darwin" })).toBeUndefined();
+	});
+
+	it("matches Windows PATHEXT candidates", () => {
+		const winDir = join(dir, "win");
+		mkdirSync(winDir);
+		writeFileSync(join(winDir, "tool.exe"), "");
+		expect(resolveCommandPath("tool", { env: { PATH: winDir, PATHEXT: ".COM;.EXE" }, platform: "win32" })).toBe(
+			join(winDir, "tool.exe"),
+		);
+	});
+});

--- a/packages/senpi-codemode/test/interpreter.test.ts
+++ b/packages/senpi-codemode/test/interpreter.test.ts
@@ -70,6 +70,7 @@ describe("interpreter detection", () => {
 				probes += 1;
 				return { stdout: "Python 3.11.9", stderr: "" };
 			},
+			resolveCommandPath: () => undefined,
 		});
 
 		await expect(detector.detect("py")).resolves.toEqual({ ok: true, path: "python3", version: "3.11.9" });
@@ -88,6 +89,7 @@ describe("interpreter detection", () => {
 				]),
 			),
 			nodeVersion: "24.1.0",
+			resolveCommandPath: () => undefined,
 		});
 
 		const availability = await getInterpreterAvailability(

--- a/packages/senpi-codemode/test/interpreter.test.ts
+++ b/packages/senpi-codemode/test/interpreter.test.ts
@@ -22,6 +22,7 @@ describe("interpreter detection", () => {
 	it("falls through per-platform candidates and rejects empty Store-alias output", async () => {
 		const detector = createInterpreterDetector({
 			platform: "win32",
+			resolveCommandPath: () => undefined,
 			execFile: stubProbe(
 				new Map([
 					["python --version", ""],
@@ -36,6 +37,7 @@ describe("interpreter detection", () => {
 	it("returns unavailable for missing and timed-out interpreters without throwing", async () => {
 		const detector = createInterpreterDetector({
 			platform: "linux",
+			resolveCommandPath: () => undefined,
 			execFile: stubProbe(
 				new Map([
 					["ruby --version", new Error("ENOENT")],
@@ -56,6 +58,7 @@ describe("interpreter detection", () => {
 		// the skip-if-absent jl tests hid it.
 		const detector = createInterpreterDetector({
 			platform: "linux",
+			resolveCommandPath: () => undefined,
 			execFile: stubProbe(new Map([["julia --version", "julia version 1.12.6"]])),
 		});
 

--- a/packages/senpi-codemode/test/runtime-info.test.ts
+++ b/packages/senpi-codemode/test/runtime-info.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { jsRuntimeInfo, jsRuntimeLabel, runtimesFromAvailability } from "../src/extension/runtime-info.ts";
+import type { InterpreterAvailability, LanguageAvailability } from "../src/interpreters/detect.ts";
+
+const unavailable: LanguageAvailability = { enabled: false, detected: { ok: false } };
+
+function availability(overrides: Partial<InterpreterAvailability>): InterpreterAvailability {
+	return {
+		py: unavailable,
+		js: { enabled: true, detected: { ok: true, path: "node", version: "26.7.0" } },
+		rb: unavailable,
+		jl: unavailable,
+		...overrides,
+	};
+}
+
+describe("jsRuntimeInfo", () => {
+	it("reports bun with the bun version when running under bun", () => {
+		expect(jsRuntimeInfo({ node: "26.7.0", bun: "1.4.0" }, "/opt/bun/bin/bun")).toEqual({
+			name: "bun",
+			version: "1.4.0",
+			path: "/opt/bun/bin/bun",
+		});
+	});
+
+	it("reports node when no bun marker exists", () => {
+		expect(jsRuntimeInfo({ node: "26.7.0" }, "/usr/local/bin/node")).toEqual({
+			name: "node",
+			version: "26.7.0",
+			path: "/usr/local/bin/node",
+		});
+	});
+});
+
+describe("jsRuntimeLabel", () => {
+	it("labels bun runtimes", () => {
+		expect(jsRuntimeLabel({ node: "26.7.0", bun: "1.4.0" })).toBe("bun 1.4.0");
+	});
+
+	it("labels node runtimes", () => {
+		expect(jsRuntimeLabel({ node: "26.7.0" })).toBe("node 26.7.0");
+	});
+});
+
+describe("runtimesFromAvailability", () => {
+	it("maps detected interpreters preferring the resolved absolute path", () => {
+		const js = { name: "node", version: "26.7.0", path: "/usr/local/bin/node" };
+		const runtimes = runtimesFromAvailability(
+			availability({
+				py: {
+					enabled: true,
+					detected: {
+						ok: true,
+						path: "python3",
+						version: "3.14.7",
+						resolvedPath: "/opt/homebrew/bin/python3",
+					},
+				},
+			}),
+			js,
+		);
+		expect(runtimes.py).toEqual({ name: "python", version: "3.14.7", path: "/opt/homebrew/bin/python3" });
+		expect(runtimes.js).toEqual(js);
+	});
+
+	it("falls back to the probe command when no absolute path resolved and skips unavailable languages", () => {
+		const js = { name: "node", version: "26.7.0", path: "/usr/local/bin/node" };
+		const runtimes = runtimesFromAvailability(
+			availability({ rb: { enabled: true, detected: { ok: true, path: "ruby", version: "3.3.6" } } }),
+			js,
+		);
+		expect(runtimes.rb).toEqual({ name: "ruby", version: "3.3.6", path: "ruby" });
+		expect(runtimes.py).toBeUndefined();
+		expect(runtimes.jl).toBeUndefined();
+	});
+});

--- a/packages/senpi-codemode/test/runtime-label.test.ts
+++ b/packages/senpi-codemode/test/runtime-label.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { formatRuntimeBadge, minifyPath } from "../src/tool/runtime-label.ts";
+
+describe("formatRuntimeBadge", () => {
+	it("shows version and home-contracted path for subprocess kernels", () => {
+		expect(
+			formatRuntimeBadge(
+				"py",
+				{ name: "python", version: "3.14.7", path: "/Users/dev/.venv/bin/python3" },
+				"/Users/dev",
+			),
+		).toBe("3.14.7, ~/.venv/bin/python3");
+	});
+
+	it("prefixes the runtime name for js so bun and node are distinguishable", () => {
+		expect(
+			formatRuntimeBadge("js", { name: "bun", version: "1.4.0", path: "/usr/local/bin/bun" }, "/Users/dev"),
+		).toBe("bun 1.4.0, /usr/local/bin/bun");
+	});
+
+	it("falls back to a version-only badge when no path is known", () => {
+		expect(formatRuntimeBadge("py", { name: "python", version: "3.12.4" }, "/Users/dev")).toBe("3.12.4");
+	});
+});
+
+describe("minifyPath", () => {
+	it("keeps short absolute paths untouched", () => {
+		expect(minifyPath("/usr/bin/ruby", "/Users/dev")).toBe("/usr/bin/ruby");
+	});
+
+	it("contracts the home directory to ~", () => {
+		expect(minifyPath("/Users/dev/bin/julia", "/Users/dev")).toBe("~/bin/julia");
+	});
+
+	it("middle-truncates long paths keeping the head and trailing segments", () => {
+		const minified = minifyPath("/opt/homebrew/Cellar/node-runtime/26.7.0_1/libexec/bin/node", "/Users/dev");
+		expect(minified.startsWith("/opt/")).toBe(true);
+		expect(minified).toContain("\u2026");
+		expect(minified.endsWith("/bin/node")).toBe(true);
+		expect([...minified].length).toBeLessThanOrEqual(40);
+	});
+
+	it("hard-truncates a single oversized segment", () => {
+		const longSegment = "x".repeat(80);
+		const minified = minifyPath(`/tmp/${longSegment}`, "/Users/dev");
+		expect([...minified].length).toBeLessThanOrEqual(40);
+		expect(minified).toContain("\u2026");
+	});
+});


### PR DESCRIPTION
## Summary

The eval tool now surfaces which runtime actually executes each kernel. TUI cell and result headers append the runtime identity right after the language token — `eval py (3.14.7, /opt/homebrew/bin/python3)`, `eval js (node 26.7.0, /opt/…/Cellar/node/26.7.0/bin/node)` — and the same `runtime` info rides `EvalToolDetails` and every cell so RPC consumers receive it. The eval prompt host line now names the JS runtime (`node`/`bun` with version), so the model knows which JS API surface is available.

## Changes

- **Interpreter detection** (`src/interpreters/`): detection additionally resolves the bare probe command (`python3`, `py -3`, `ruby`, `julia`) to its absolute executable via a spawn-free PATH scan (`resolve-command.ts`, PATHEXT-aware on Windows) and attaches it as `InterpreterDetected.resolvedPath`. Existing detector tests inject an undefined resolver to stay hermetic.
- **Runtime identity plumbing** (`src/extension/runtime-info.ts`, `runtime-factory.ts`, `src/tool/{types,eval-tool,eval-tool-options,cell-runtime}.ts`, `src/index.ts`): session runtimes (python/ruby/julia from detection; node or bun from `process.versions` — plain property reads, no Bun-only APIs) flow through `CreateEvalToolOptions.runtimes` into `CellState` and land on `EvalToolDetails.runtime` plus each cell. The host line gains a runtime segment.
- **Rendering** (`src/tool/{runtime-label,render}.ts`): headers show `(version, path)` badges with home contraction and 40-code-point middle truncation. Headers without runtime info render byte-identical to before, so existing snapshots and fixtures are untouched.

## QA & Evidence

All evidence under `local-ignore/qa-evidence/20260822-eval-runtime-badge/` (gitignored, sanitized).

- **What was tested:** new vitest contracts captured failing before implementation (13 assertion failures), then green — `vitest-red.txt`, `vitest-green.txt` (25/25).
- **Full package suite:** `npm test` in `packages/senpi-codemode` — `vitest-full.txt` (596 passed / 6 skipped / 0 failed). Two pre-existing interpreter tests were made hermetic (resolver stub) after the new default resolver attached real paths on the QA machine.
- **Static gates:** `npm run check` at repo root — exit 0 (biome, tsc, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk platform lock, browser smoke).
- **Real-surface QA:** a driver registering the real extension through `createAgentSession` + `bindExtensions`, executing real py/js cells, and rendering through `renderEvalResult` — `qa-runtime-badge-output.txt`:
  - `PROMPT_HOST_LINE: Host: darwin arm64 · Apple M4 Pro · 14 cores · node 26.7.0 — …`
  - `TUI_HEADER[py]: ╭─ eval py (3.14.7, /opt/homebrew/bin/python3) done ✓ · <1s`
  - `TUI_HEADER[js]: ╭─ eval js (node 26.7.0, /opt/…/Cellar/node/26.7.0/bin/node) done ✓ · <1s`
  - `RPC_CELL_RUNTIME[py]: {"name":"python","version":"3.14.7","path":"/opt/homebrew/bin/python3"}`
- **Why sufficient:** the driver exercises the exact production path (extension registration → session_start detection → eval-tool → details → renderer) rather than fixtures, and the no-runtime rendering contract pins backward compatibility.

## Risks & Residuals

- Rendering regression risk is pinned by the byte-identical no-badge contract; existing render tests and snapshots pass unchanged.
- PATH resolution adds sync fs probes once per session per language (cached detector), no extra process spawns — negligible.
- `packages/senpi-codemode` is fork-only (absent from the upstream pin), so no `changes.md` tracker entry is required; the release CHANGELOG `[Unreleased]` entry is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the kernel runtime identity in eval headers, result headers, and the prompt host line, and propagates it over RPC. Previously headers and details had no runtime; now headers show a “(version, path)” badge, details expose runtime, and the host line names the JS runtime (node/bun) with version.

- Detection resolves interpreter commands to absolute executables via a spawn-free PATH scan and records `resolvedPath`.
- Runtimes flow from interpreter availability and the JS host into `CreateEvalToolOptions.runtimes` → `CellState` → `EvalToolDetails.runtime` and each cell; `packages/senpi-codemode` wires this by default.
- Rendering adds a concise badge: JS shows `name version`; paths are home-contracted and middle-truncated to 40 code points; when runtime is unknown, headers render identically to before.
- RPC: `details.runtime` and `details.cells[].runtime` are available to consumers.
- Migration: If you build eval tools outside `senpiCodemode`, pass `runtimes` to enable badges and RPC runtime fields.
- Tests: all probe-stubbed interpreter tests now stub PATH resolution to avoid picking real `resolvedPath` on CI.

<sup>Written for commit 912f99865909d1d74b3ac18b854b5cc21ecb4960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

