### PR TITLE
fix(goal): render cache-warm ready time in local timezone

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Goal cache-warm notices now render the expected wake time in the user's local system timezone with a short zone label (for example `ready 2026-08-22 16:51 GMT+9 (4m 30s)`), falling back to the legacy UTC shape when local timezone formatting is unavailable ([#1074](https://github.com/code-yeongyu/senpi/pull/1074)).
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm-renderer.ts
@@ -4,6 +4,7 @@ import {
 	formatCacheTtl,
 	formatSavedUsd,
 	formatWakeDuration,
+	formatWakeTimestamp,
 	formatWarmTokenCount,
 	type GoalCacheWarmupEntryData,
 } from "./cache-warm.ts";
@@ -55,8 +56,7 @@ function whyLine(data: GoalCacheWarmupEntryData): string {
 
 function formatExpectedWake(dueAtMs: number | undefined, elapsedMs: number): string {
 	if (dueAtMs === undefined || !Number.isFinite(dueAtMs)) return `waited ${formatWakeDuration(elapsedMs)}`;
-	const timestamp = new Date(dueAtMs).toISOString().slice(0, 16).replace("T", " ");
-	return `ready ${timestamp} UTC (${formatWakeDuration(elapsedMs)})`;
+	return `ready ${formatWakeTimestamp(dueAtMs)} (${formatWakeDuration(elapsedMs)})`;
 }
 
 function expandedLine(data: GoalCacheWarmupEntryData): string {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/cache-warm.ts
@@ -127,6 +127,51 @@ export function formatWakeDuration(ms: number): string {
 	return restMinutes === 0 ? `${hours}h` : `${hours}h ${restMinutes}m`;
 }
 
+/**
+ * Wake timestamp shown in cache-warm notices. Rendered in the user's local
+ * system timezone with its short zone label (for example `GMT+9`); falls back
+ * to the legacy UTC shape when local timezone formatting is unavailable.
+ */
+export function formatWakeTimestamp(dueAtMs: number): string {
+	const date = new Date(dueAtMs);
+	const local = formatLocalWakeTimestamp(date);
+	if (local !== undefined) return local;
+	return `${date.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+}
+
+function formatLocalWakeTimestamp(date: Date): string | undefined {
+	try {
+		const parts = new Intl.DateTimeFormat("en-CA", {
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			hourCycle: "h23",
+			timeZoneName: "short",
+		}).formatToParts(date);
+		const read = (type: string): string | undefined => parts.find((part) => part.type === type)?.value;
+		const year = read("year");
+		const month = read("month");
+		const day = read("day");
+		const hour = read("hour");
+		const minute = read("minute");
+		if (
+			year === undefined ||
+			month === undefined ||
+			day === undefined ||
+			hour === undefined ||
+			minute === undefined
+		) {
+			return undefined;
+		}
+		const zone = read("timeZoneName");
+		return `${year}-${month}-${day} ${hour}:${minute}${zone === undefined ? "" : ` ${zone}`}`;
+	} catch {
+		return undefined;
+	}
+}
+
 export function formatCacheTtl(seconds: number): string {
 	if (seconds % 3600 === 0) return `${seconds / 3600}h`;
 	if (seconds % 60 === 0) return `${seconds / 60}m`;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,36 @@
 # goal Extension Changes
 
+## Cache-warm ready time renders in the local timezone (2026-08-22)
+
+### What changed
+
+- `cache-warm.ts` gains `formatWakeTimestamp(dueAtMs)`: it formats the expected
+  wake time in the user's local system timezone via `Intl.DateTimeFormat`
+  (`en-CA`, `hourCycle: "h23"`, short `timeZoneName`), producing
+  `2026-08-22 16:51 GMT+9`-style stamps, and falls back to the legacy
+  `<iso> UTC` shape when local formatting throws or returns incomplete parts.
+- `cache-warm-renderer.ts` `formatExpectedWake` now delegates to
+  `formatWakeTimestamp` instead of pinning `toISOString()` UTC output.
+
+### Why
+
+- The cache-warm notice showed `ready 2026-08-22 07:51 UTC (4m 30s)` regardless
+  of the user's timezone, forcing mental conversion on every wait. Users read
+  the line to know when the goal resumes; local time with a zone label answers
+  directly, and UTC remains the fallback for platforms without ICU timezone
+  data.
+
+### Why an extension could not handle it
+
+- The renderer and its formatting helpers live inside the builtin goal
+  extension itself; the change is the extension's own display logic, not a new
+  capability another extension could provide.
+
+### Expected merge conflict zones
+
+- None upstream: `cache-warm.ts` and `cache-warm-renderer.ts` are fork-only
+  files with no pi-mono counterpart.
+
 ## Reload re-engages active goals instead of parking them (2026-08-18, fixes #934)
 
 ### What changed

--- a/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
+++ b/packages/coding-agent/test/suite/goal-cache-warm-renderer.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GoalCacheWarmupEntryData } from "../../src/core/extensions/builtin/goal/cache-warm.ts";
 import { renderGoalCacheWarmupEntry } from "../../src/core/extensions/builtin/goal/cache-warm-renderer.ts";
 import type { CustomEntry } from "../../src/core/session-manager.ts";
@@ -28,8 +28,14 @@ describe("goal cache-warm entry renderer", () => {
 		initTheme("dark");
 	});
 
+	beforeEach(() => {
+		vi.stubEnv("TZ", "UTC");
+	});
+
 	afterEach(() => {
 		vi.useRealTimers();
+		vi.unstubAllEnvs();
+		vi.restoreAllMocks();
 	});
 
 	it("renders the scheduled wait with the cache story", () => {
@@ -68,6 +74,33 @@ describe("goal cache-warm entry renderer", () => {
 		expect(text).toContain("2 wake sources on duty");
 		expect(text).toContain("~120K tokens stayed warm");
 		expect(text).toContain("$0.324 saved");
+	});
+
+	it("renders the ready time in the local timezone", () => {
+		vi.stubEnv("TZ", "Asia/Seoul");
+		const text = renderToText({
+			phase: "scheduled",
+			goalId: "goal-local-tz",
+			delayMs: 270_000,
+			dueAtMs: Date.parse("2026-07-29T00:04:30.000Z"),
+			activeMonitorCount: 1,
+		});
+		expect(text).toContain("ready 2026-07-29 09:04 GMT+9 (4m 30s)");
+		expect(text).not.toContain("UTC");
+	});
+
+	it("falls back to UTC when local timezone formatting fails", () => {
+		vi.spyOn(Intl, "DateTimeFormat").mockImplementation(() => {
+			throw new RangeError("timezone data unavailable");
+		});
+		const text = renderToText({
+			phase: "scheduled",
+			goalId: "goal-tz-fallback",
+			delayMs: 270_000,
+			dueAtMs: Date.parse("2026-07-29T00:04:30.000Z"),
+			activeMonitorCount: 1,
+		});
+		expect(text).toContain("ready 2026-07-29 00:04 UTC (4m 30s)");
 	});
 
 	it("does not claim warmth or savings when the cache TTL may have elapsed", () => {


### PR DESCRIPTION
## Summary

The goal cache-warm notice pinned the expected wake time to UTC:

```
⚡ Cache-warm wait · iteration 2 · 3 wake sources on duty
Continuation expected ready 2026-08-22 07:51 UTC (4m 30s) - ...
```

It now renders in the user's local system timezone (Windows / macOS / Linux — whatever the runtime resolves) with a short zone label, falling back to the legacy UTC shape when local timezone formatting is unavailable:

```
Continuation expected ready 2026-08-22 16:51 GMT+9 (4m 30s) - ...
```

## Changes

- `cache-warm.ts`: new `formatWakeTimestamp(dueAtMs)` — local time via `Intl.DateTimeFormat` (`en-CA`, `hourCycle: "h23"`, short `timeZoneName`); falls back to `<iso> UTC` when `Intl` throws or returns incomplete parts.
- `cache-warm-renderer.ts`: `formatExpectedWake` delegates to it (one-line swap).
- `goal/changes.md`: canonical four-section entry.

## Evidence

- **RED→GREEN**: new test `renders the ready time in the local timezone` failed pre-fix (`expected ... to contain 'ready 2026-07-29 09:04 GMT+9 (4m 30s)'`, received the old UTC line), passes post-fix. Existing assertions are pinned to `TZ=UTC` via `vi.stubEnv` so the file is deterministic on any dev machine.
- **Fallback coverage**: `falls back to UTC when local timezone formatting fails` (Intl sabotage). Mutation proof: removing the `try/catch` makes this test fail (RangeError propagates through `notice/adapters.ts`); reverting restores green.
- **Suites**: `goal-cache-warm-renderer` + `goal-wait-progress` 18/18 green; root `npm run check` exit 0 (biome / tsc / lock gates).
- **Real surface** (bun, worktree source, `TZ=Asia/Seoul`): rendered entry shows `ready 2026-08-22 16:51 GMT+9 (4m 30s)`; forced-Intl-failure run shows `ready 2026-08-22 07:51 UTC (4m 30s)`.

## Notes

- When the system timezone is UTC the output is byte-identical to the previous format, so UTC users see no change.
- No upstream conflict surface: both touched source files are fork-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render cache-warm ready time in the user’s local timezone instead of always UTC, reducing mental conversion. Previously: “ready <iso> UTC”; now: local time with a short zone label (for example “ready 2026-08-22 16:51 GMT+9”), with a UTC fallback when local formatting is unavailable.

- Add `formatWakeTimestamp(dueAtMs)` in `cache-warm.ts` using `Intl.DateTimeFormat` (`en-CA`, 24-hour, short `timeZoneName`); fall back to `<iso> UTC` if `Intl` throws or returns incomplete parts.
- Make `formatExpectedWake` in `cache-warm-renderer.ts` delegate to `formatWakeTimestamp`.
- Pin `TZ` per test (UTC and Asia/Seoul) and cover the fallback by sabotaging `Intl`; outputs are deterministic across machines.
- Update `packages/coding-agent/CHANGELOG.md` to note the fix.
- No migration required; UTC environments remain byte-identical, and platforms without ICU timezone data keep the previous UTC output.

<sup>Written for commit 5b560ff657c71c97f84f8944ee8fb6c29944641e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

