### PR TITLE
fix(interactive): keep the working dock painted across queued turn boundaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- The interactive TUI now keeps the working dock painted across adjacent and locally buffered turns, clears it when prompt admission fails, and reserves the dock's measured height during clear-on-shrink rendering to prevent vertical jitter.
+- The interactive TUI now keeps the working dock painted across adjacent and locally buffered turns, and clears it on the new core `agent_idle` event - emitted only after settlement-deferred turns (TTSR, loop-guard, goal recovery) resolve without starting a run - so the editor/footer no longer bounce at queued-turn boundaries. A buffered prompt consumed with `action: "handled"` (for example a `UserPromptSubmit` hook block) also clears the retained dock, prompt admission failure clears it, and clear-on-shrink reserves the dock's measured height, together eliminating the vertical jitter.
 
 - Goal cache-warm notices now render the expected wake time in the user's local system timezone with a short zone label (for example `ready 2026-08-22 16:51 GMT+9 (4m 30s)`), falling back to the legacy UTC shape when local timezone formatting is unavailable ([#1074](https://github.com/code-yeongyu/senpi/pull/1074)).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- The interactive TUI now keeps the working dock painted across adjacent and locally buffered turns, clears it when prompt admission fails, and reserves the dock's measured height during clear-on-shrink rendering to prevent vertical jitter.
+
 - Goal cache-warm notices now render the expected wake time in the user's local system timezone with a short zone label (for example `ready 2026-08-22 16:51 GMT+9 (4m 30s)`), falling back to the legacy UTC shape when local timezone formatting is unavailable ([#1074](https://github.com/code-yeongyu/senpi/pull/1074)).
 
 ### Added

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -5,7 +5,7 @@
 ### What changed
 
 - `packages/coding-agent/src/core/agent-settled-delivery.ts`: added `DeferredTurnClaim` / `DeferredTurnDisposition` (`started` / `delegated` / `finished-without-start`) and `deferTriggerTurn`, so a settlement-deferred `sendMessage(..., { triggerTurn: true })` declares whether it actually started a run. Claims resolve at the `_promptAgent` admission boundary.
-- `packages/coding-agent/src/core/agent-session.ts`: after the deferred-action loop in `_emitAgentSettled`, an out-of-band check waits for all deferred turn dispositions, skips emission when any turn `started`, waits for delegated session work to drain, verifies the settlement epoch is still current, and emits `{ type: "agent_idle" }` only when no agent run or session work is active. `agent_settled` ordering is unchanged for existing subscribers.
+- `packages/coding-agent/src/core/agent-session.ts`: after the deferred-action loop in `_emitAgentSettled`, an out-of-band check waits for all deferred turn dispositions, skips emission when any turn `started`, waits for delegated session work to drain, verifies the settlement epoch is still current, and emits `{ type: "agent_idle" }` only when no agent run or session work is active. Both settlement-deferred turn APIs register a claim: `sendMessage(..., { triggerTurn: true })` via `deferTriggerTurn`, and `sendUserMessage` (which always triggers a turn) via a claim resolved from its prompt disposition. `agent_settled` ordering is unchanged for existing subscribers.
 
 ### Why
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## 2026-08-22 - emit agent_idle after settlement-deferred turns resolve
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-settled-delivery.ts`: added `DeferredTurnClaim` / `DeferredTurnDisposition` (`started` / `delegated` / `finished-without-start`) and `deferTriggerTurn`, so a settlement-deferred `sendMessage(..., { triggerTurn: true })` declares whether it actually started a run. Claims resolve at the `_promptAgent` admission boundary.
+- `packages/coding-agent/src/core/agent-session.ts`: after the deferred-action loop in `_emitAgentSettled`, an out-of-band check waits for all deferred turn dispositions, skips emission when any turn `started`, waits for delegated session work to drain, verifies the settlement epoch is still current, and emits `{ type: "agent_idle" }` only when no agent run or session work is active. `agent_settled` ordering is unchanged for existing subscribers.
+
+### Why
+
+- The TUI cleared its working-status dock on the public `agent_settled`, but settlement-deferred continuations (TTSR, loop-guard, goal recovery) start a turn *after* that event, so the dock was removed and immediately remounted - the same vertical bounce the jitter fix exists to eliminate. `_isAgentRunActive` alone cannot decide this at the deferred-action loop because a deferred `sendCustomMessage` can be suspended at compaction/provider admission before reaching `_promptAgent`. `agent_idle` is the single race-free boundary for final cleanup.
+
+### Why an extension could not handle it
+
+- Settlement-deferred turn admission and the settlement epoch are private `AgentSession` / `AgentSettledDelivery` state.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/agent-session.ts` `_emitAgentSettled`, `_promptAgent`, and the `AgentEvent` union.
+- `packages/coding-agent/src/core/agent-settled-delivery.ts`.
+
 ## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3931,6 +3931,7 @@ export class AgentSession {
 			deliverAs?: "steer" | "followUp";
 			expandPromptTemplates?: boolean;
 		},
+		deferredTurnClaim?: DeferredTurnClaim,
 	): Promise<void> {
 		const bindingPromptReadiness = this._extensionBindingPromptReadiness;
 		let resolveBindingPromptReadiness: (() => void) | undefined;
@@ -3974,6 +3975,8 @@ export class AgentSession {
 				source: "extension",
 				promptDisposition: (nextDisposition) => {
 					disposition = nextDisposition;
+					if (nextDisposition === "started") deferredTurnClaim?.resolve("started");
+					else if (nextDisposition === "queued") deferredTurnClaim?.resolve("delegated");
 					resolveBindingPromptReadiness?.();
 				},
 				onSessionWorkReady: waitForExistingSessionWork
@@ -3995,6 +3998,9 @@ export class AgentSession {
 			}
 			throw error;
 		} finally {
+			// A path that neither started nor delegated a turn (handled, rejected,
+			// admission failure, cancellation) resolves as finished-without-start.
+			deferredTurnClaim?.resolve("finished-without-start");
 			resolveBindingPromptReadiness?.();
 			finishSessionWork?.();
 		}
@@ -6188,13 +6194,23 @@ export class AgentSession {
 					send();
 				},
 				sendUserMessage: (content, options) => {
-					this.sendUserMessage(content, options).catch((err) => {
+					const reportError = (err: unknown) => {
 						runner.emitError({
 							extensionPath: RUNTIME_EXTENSION_PATH,
 							event: "send_user_message",
 							error: err instanceof Error ? err.message : String(err),
 						});
-					});
+					};
+					// sendUserMessage always triggers a turn; register a settlement-deferred
+					// turn claim so agent_idle is not emitted before its deferred agent_start.
+					if (
+						this._agentSettledDelivery.deferTriggerTurn((claim) => {
+							this.sendUserMessage(content, options, claim).catch(reportError);
+						})
+					) {
+						return;
+					}
+					this.sendUserMessage(content, options).catch(reportError);
 				},
 				appendEntry: (customType, data) => {
 					const entryId = this.sessionManager.appendCustomEntry(customType, data);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3941,24 +3941,32 @@ export class AgentSession {
 			});
 			bindingPromptReadiness.add(readiness);
 		}
-		// Normalize content to text string + optional images
+		// Normalize content to text string + optional images. A throw here (null or a
+		// content array whose iterator/part getter throws) happens before the guarded
+		// try below, so resolve the deferred-turn claim first to keep agent_idle reachable.
 		let text: string;
 		let images: ImageContent[] | undefined;
 
-		if (typeof content === "string") {
-			text = content;
-		} else {
-			const textParts: string[] = [];
-			images = [];
-			for (const part of content) {
-				if (part.type === "text") {
-					textParts.push(part.text);
-				} else {
-					images.push(part);
+		try {
+			if (typeof content === "string") {
+				text = content;
+			} else {
+				const textParts: string[] = [];
+				images = [];
+				for (const part of content) {
+					if (part.type === "text") {
+						textParts.push(part.text);
+					} else {
+						images.push(part);
+					}
 				}
+				text = textParts.join("\n");
+				if (images.length === 0) images = undefined;
 			}
-			text = textParts.join("\n");
-			if (images.length === 0) images = undefined;
+		} catch (error) {
+			deferredTurnClaim?.resolve("finished-without-start");
+			resolveBindingPromptReadiness?.();
+			throw error;
 		}
 
 		// An extension binding invokes this method fire-and-forget. When it

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -70,7 +70,11 @@ import { resolvePath } from "../utils/paths.ts";
 import { sleep } from "../utils/sleep.ts";
 import { normalizeToolResultImages } from "../utils/tool-result-images.ts";
 import { AgentAbortProvenance } from "./agent-abort-provenance.ts";
-import { AgentSettledDelivery, type DeferredAgentSettledAction } from "./agent-settled-delivery.ts";
+import {
+	AgentSettledDelivery,
+	type DeferredAgentSettledAction,
+	type DeferredTurnClaim,
+} from "./agent-settled-delivery.ts";
 import { formatNoApiKeyFoundMessage, formatNoModelSelectedMessage } from "./auth-guidance.ts";
 import { type BashResult, executeBashWithOperations } from "./bash-executor.ts";
 import { envValue } from "./brand.ts";
@@ -368,6 +372,7 @@ export type AgentSessionEvent =
 	| Exclude<AgentEvent, { type: "agent_end" }>
 	| AgentSessionAgentEndEvent
 	| { type: "agent_settled" }
+	| { type: "agent_idle" }
 	| { type: "session_abort" }
 	| { type: "continuation_error"; errorMessage: string }
 	| {
@@ -840,6 +845,7 @@ export class AgentSession {
 	private _nextInputId = 0;
 	private _idleWaitPromise: Promise<void> | undefined;
 	private _resolveIdleWait: (() => void) | undefined;
+	private _settlementEpoch = 0;
 
 	/** Tracks pending steering messages for UI display. Removed when delivered. */
 	private _steeringMessages: string[] = [];
@@ -1580,21 +1586,46 @@ export class AgentSession {
 		}
 		this._isAgentRunActive = false;
 		let deferredActions: DeferredAgentSettledAction[] = [];
+		let deferredTurnClaims: DeferredTurnClaim[] = [];
 		this._agentSettledDelivery.begin(this._userAbortGeneration);
+		const settlementEpoch = ++this._settlementEpoch;
 		try {
 			await this._extensionRunner.emit({ type: "agent_settled" });
 			this._emit({ type: "agent_settled" });
 			if (this._abortProvenance.takeLateUserJoin()) await this._emitSessionAbort();
-			deferredActions = this._agentSettledDelivery.finish(this._userAbortGeneration);
+			({ actions: deferredActions, turnClaims: deferredTurnClaims } = this._agentSettledDelivery.finish(
+				this._userAbortGeneration,
+			));
 		} finally {
 			this._agentSettledDelivery.cancel();
 			this._abortProvenance.closeAgentEndBoundary();
 			this._resolveIdleWaitIfIdle();
 		}
 		for (const action of deferredActions) action();
+		queueMicrotask(() => {
+			void this._emitAgentIdleAfterDeferredTurns(settlementEpoch, deferredTurnClaims);
+		});
 	}
 
-	private async _promptAgent(messages: AgentMessage | AgentMessage[]): Promise<void> {
+	private async _emitAgentIdleAfterDeferredTurns(
+		settlementEpoch: number,
+		deferredTurnClaims: DeferredTurnClaim[],
+	): Promise<void> {
+		const dispositions = await Promise.all(deferredTurnClaims.map((claim) => claim.disposition));
+		if (dispositions.includes("started")) return;
+		if (dispositions.includes("delegated") || this._sessionWorkBarrier.hasActiveWork) {
+			await this._waitForSettledSessionWork();
+		}
+		if (settlementEpoch !== this._settlementEpoch) return;
+		if (this._isAgentRunActive || this._sessionWorkBarrier.hasActiveWork) return;
+		this._emit({ type: "agent_idle" });
+	}
+
+	private async _promptAgent(
+		messages: AgentMessage | AgentMessage[],
+		deferredTurnClaim?: DeferredTurnClaim,
+	): Promise<void> {
+		deferredTurnClaim?.resolve("started");
 		this._isAgentRunActive = true;
 		this._requiredCompactionAdmissionError = undefined;
 		this.agent.abortServerSideFallback =
@@ -3794,6 +3825,7 @@ export class AgentSession {
 			triggerTurn?: boolean;
 			deliverAs?: "steer" | "followUp" | "nextTurn";
 		},
+		deferredTurnClaim?: DeferredTurnClaim,
 	): Promise<void> {
 		const userAbortGeneration = this._userAbortGeneration;
 		const appMessage = {
@@ -3828,6 +3860,7 @@ export class AgentSession {
 			if (options?.deliverAs === "nextTurn") {
 				this._pendingNextTurnMessages.push(appMessage);
 			} else if (this.isStreaming && options?.triggerTurn !== false) {
+				deferredTurnClaim?.resolve("delegated");
 				if (options?.deliverAs === "followUp") {
 					this.agent.followUp(appMessage);
 				} else {
@@ -3840,6 +3873,7 @@ export class AgentSession {
 						this._compactionLifecycle.state.generation === activeCompactionGeneration &&
 						this._compactionLifecycle.state.status !== "completed"))
 			) {
+				deferredTurnClaim?.resolve("delegated");
 				if (options?.deliverAs === "followUp") {
 					this.agent.followUp(appMessage);
 				} else {
@@ -3861,7 +3895,7 @@ export class AgentSession {
 					}
 					throw error;
 				}
-				await this._promptAgent(appMessage);
+				await this._promptAgent(appMessage, deferredTurnClaim);
 			} else {
 				this.agent.state.messages.push(appMessage);
 				this.sessionManager.appendCustomMessageEntry(
@@ -3875,6 +3909,7 @@ export class AgentSession {
 				this._emit({ type: "message_end", message: appMessage });
 			}
 		} finally {
+			deferredTurnClaim?.resolve("finished-without-start");
 			finishSessionWork?.();
 		}
 	}
@@ -6132,14 +6167,23 @@ export class AgentSession {
 		runner.bindCore(
 			{
 				sendMessage: (message, options) => {
-					const send = () =>
-						this.sendCustomMessage(message, options).catch((err) => {
-							runner.emitError({
-								extensionPath: RUNTIME_EXTENSION_PATH,
-								event: "send_message",
-								error: err instanceof Error ? err.message : String(err),
-							});
+					const reportError = (err: unknown) => {
+						runner.emitError({
+							extensionPath: RUNTIME_EXTENSION_PATH,
+							event: "send_message",
+							error: err instanceof Error ? err.message : String(err),
 						});
+					};
+					if (options?.triggerTurn === true) {
+						if (
+							this._agentSettledDelivery.deferTriggerTurn((claim) => {
+								this.sendCustomMessage(message, options, claim).catch(reportError);
+							})
+						) {
+							return;
+						}
+					}
+					const send = () => this.sendCustomMessage(message, options).catch(reportError);
 					if (this._agentSettledDelivery.defer(send)) return;
 					send();
 				},

--- a/packages/coding-agent/src/core/agent-settled-delivery.ts
+++ b/packages/coding-agent/src/core/agent-settled-delivery.ts
@@ -1,12 +1,39 @@
+export type DeferredTurnDisposition = "started" | "delegated" | "finished-without-start";
+
+export class DeferredTurnClaim {
+	readonly disposition: Promise<DeferredTurnDisposition>;
+	#resolve: ((disposition: DeferredTurnDisposition) => void) | undefined;
+
+	constructor() {
+		this.disposition = new Promise((resolve) => {
+			this.#resolve = resolve;
+		});
+	}
+
+	resolve(disposition: DeferredTurnDisposition): void {
+		const resolve = this.#resolve;
+		if (!resolve) return;
+		this.#resolve = undefined;
+		resolve(disposition);
+	}
+}
+
 export type DeferredAgentSettledAction = () => void;
+
+export interface DeferredAgentSettledBatch {
+	actions: DeferredAgentSettledAction[];
+	turnClaims: DeferredTurnClaim[];
+}
 
 export class AgentSettledDelivery {
 	#generation: number | undefined;
 	#actions: DeferredAgentSettledAction[] = [];
+	#turnClaims: DeferredTurnClaim[] = [];
 
 	begin(userAbortGeneration: number): void {
 		this.#generation = userAbortGeneration;
 		this.#actions = [];
+		this.#turnClaims = [];
 	}
 
 	defer(action: DeferredAgentSettledAction): boolean {
@@ -15,15 +42,29 @@ export class AgentSettledDelivery {
 		return true;
 	}
 
-	finish(userAbortGeneration: number): DeferredAgentSettledAction[] {
-		const actions = this.#generation === userAbortGeneration ? this.#actions : [];
+	deferTriggerTurn(action: (claim: DeferredTurnClaim) => void): boolean {
+		if (this.#generation === undefined) return false;
+		const claim = new DeferredTurnClaim();
+		this.#turnClaims.push(claim);
+		this.#actions.push(() => action(claim));
+		return true;
+	}
+
+	finish(userAbortGeneration: number): DeferredAgentSettledBatch {
+		const batch =
+			this.#generation === userAbortGeneration
+				? { actions: this.#actions, turnClaims: this.#turnClaims }
+				: { actions: [], turnClaims: [] };
 		this.#generation = undefined;
 		this.#actions = [];
-		return actions;
+		this.#turnClaims = [];
+		return batch;
 	}
 
 	cancel(): void {
+		for (const claim of this.#turnClaims) claim.resolve("finished-without-start");
 		this.#generation = undefined;
 		this.#actions = [];
+		this.#turnClaims = [];
 	}
 }

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## 2026-08-22 - emit agent_idle after settlement-deferred turns resolve
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-settled-delivery.ts`: added `DeferredTurnClaim` / `DeferredTurnDisposition` (`started` / `delegated` / `finished-without-start`) and `deferTriggerTurn`, so a settlement-deferred turn request declares whether it actually started a run. Claims resolve at the `_promptAgent` admission boundary.
+- `packages/coding-agent/src/core/agent-session.ts`: after the deferred-action loop in `_emitAgentSettled`, an out-of-band check waits for all deferred turn dispositions, skips emission when any turn `started`, waits for delegated session work to drain, verifies the settlement epoch is still current, and emits `{ type: "agent_idle" }` only when no agent run or session work is active. Both settlement-deferred turn APIs register a claim: `sendMessage(..., { triggerTurn: true })` via `deferTriggerTurn`, and `sendUserMessage` (which always triggers a turn) via a claim resolved from its prompt disposition; its content normalization is wrapped so a throwing iterator/getter resolves the claim instead of hanging the idle wait. `agent_settled` ordering is unchanged for existing subscribers.
+
+### Why
+
+- The TUI cleared its working-status dock on the public `agent_settled`, but settlement-deferred continuations (TTSR, loop-guard, goal recovery) start a turn *after* that event, so the dock was removed and immediately remounted - the same vertical bounce the jitter fix exists to eliminate. `_isAgentRunActive` alone cannot decide this at the deferred-action loop because a deferred `sendCustomMessage`/`sendUserMessage` can be suspended at compaction/provider admission before reaching `_promptAgent`, and a throwing content normalization could leave the claim unresolved forever. `agent_idle` is the single race-free boundary for final cleanup.
+
+### Why an extension could not handle it
+
+- Settlement-deferred turn admission, the settlement epoch, and the deferred-turn claim lifecycle are private `AgentSession` / `AgentSettledDelivery` state.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/agent-session.ts` `_emitAgentSettled`, `_promptAgent`, `sendCustomMessage`, `sendUserMessage`, and the `AgentEvent` union.
+- `packages/coding-agent/src/core/agent-settled-delivery.ts`.
+
 ## 2026-08-21 - Auth-storage lock retry sleeps instead of spinning
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -3,12 +3,12 @@
 
 ### What changed
 
-- `interactive-mode.ts`: `agent_end` keeps the working status mounted; `agent_settled` clears it only when no locally buffered input is waiting. The main input loop's prompt-admission catch clears a retained working status when a dequeued prompt fails before `agent_start`.
+- `interactive-mode.ts`: `agent_end` keeps the working status mounted; the dock clears on the new core `agent_idle` event (not `agent_settled`) only when no locally buffered input is waiting. An `agentIdle` latch is set on `agent_idle` and cleared on `agent_start`. The main input loop composes the optimistic-echo `promptDisposition` so a buffered prompt that resolves `handled` (for example a `UserPromptSubmit` hook block) clears the retained dock while idle; the prompt-admission catch still clears it when a dequeued prompt throws before `agent_start`.
 - `clearStatusIndicator` measures the outgoing status container before clearing and uses that height for the regular-mode clear-on-shrink idle placeholder, capped to the terminal height. `IdleStatus` now accepts a reserved height while retaining its two-row default.
 
 ### Why
 
-- Clearing the four-row working dock at `agent_end` and remounting it at the next `agent_start` moved the editor/footer between adjacent agentic turns. The old hardcoded two-row idle placeholder also allowed a four-row dock to shrink by two rows during clear-on-shrink rendering.
+- Clearing the four-row working dock at `agent_end` and remounting it at the next `agent_start` moved the editor/footer between adjacent agentic turns. Clearing on the public `agent_settled` was still too early: settlement-deferred continuations (TTSR, loop-guard, goal recovery) start a turn after that event, re-bouncing the dock, and a locally buffered prompt consumed with `action: "handled"` never produced another lifecycle event to clear it. `agent_idle` fires only after deferred turns resolve with no run started, giving one race-free cleanup boundary. The old hardcoded two-row idle placeholder also allowed a four-row dock to shrink by two rows during clear-on-shrink rendering.
 
 ### Why an extension could not handle it
 
@@ -16,7 +16,7 @@
 
 ### Expected merge conflict zones
 
-- `interactive-mode.ts` around the main input-loop catch, `clearStatusIndicator`, and the `agent_end`/`agent_settled` handlers.
+- `interactive-mode.ts` around the main input-loop disposition composition, `clearStatusIndicator`, and the `agent_start`/`agent_settled`/`agent_idle` handlers.
 - `components/status-indicator.ts` around `IdleStatus`.
 
 ## 2026-08-21 — assistant text segments keep their painted position between tool cards (fixes #1064)

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,4 +1,24 @@
 # changes
+## 2026-08-22 - working dock stays painted across queued turn boundaries
+
+### What changed
+
+- `interactive-mode.ts`: `agent_end` keeps the working status mounted; `agent_settled` clears it only when no locally buffered input is waiting. The main input loop's prompt-admission catch clears a retained working status when a dequeued prompt fails before `agent_start`.
+- `clearStatusIndicator` measures the outgoing status container before clearing and uses that height for the regular-mode clear-on-shrink idle placeholder, capped to the terminal height. `IdleStatus` now accepts a reserved height while retaining its two-row default.
+
+### Why
+
+- Clearing the four-row working dock at `agent_end` and remounting it at the next `agent_start` moved the editor/footer between adjacent agentic turns. The old hardcoded two-row idle placeholder also allowed a four-row dock to shrink by two rows during clear-on-shrink rendering.
+
+### Why an extension could not handle it
+
+- Agent lifecycle rendering, locally buffered prompt admission, status-container ownership, and clear-on-shrink placeholders are private `InteractiveMode` state.
+
+### Expected merge conflict zones
+
+- `interactive-mode.ts` around the main input-loop catch, `clearStatusIndicator`, and the `agent_end`/`agent_settled` handlers.
+- `components/status-indicator.ts` around `IdleStatus`.
+
 ## 2026-08-21 — assistant text segments keep their painted position between tool cards (fixes #1064)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
+++ b/packages/coding-agent/src/modes/interactive/components/status-indicator.ts
@@ -165,12 +165,22 @@ export class BranchSummaryStatusIndicator extends StatusIndicator {
 }
 
 export class IdleStatus implements Component {
+	private height: number;
+
+	constructor(height = 2) {
+		this.height = height;
+	}
+
+	setHeight(height: number): void {
+		this.height = height;
+	}
+
 	invalidate(): void {
 		// No cached state to invalidate.
 	}
 
 	render(width: number): string[] {
 		const emptyLine = " ".repeat(width);
-		return [emptyLine, emptyLine];
+		return Array.from({ length: this.height }, () => emptyLine);
 	}
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1637,19 +1637,7 @@ export class InteractiveMode {
 		while (true) {
 			const userInput = await this.getUserInput();
 			try {
-				const echoOptions = this.optimisticUserEchoes.promptOptions(userInput.pendingEchoId);
-				await this.session.prompt(userInput.text, {
-					streamingBehavior: "steer",
-					...(userInput.images ? { images: userInput.images } : {}),
-					preflightResult: echoOptions.preflightResult,
-					promptDisposition: (disposition) => {
-						echoOptions.promptDisposition(disposition);
-						if (disposition === "handled" && this.agentIdle) {
-							this.clearStatusIndicator("working");
-							this.ui.requestRender();
-						}
-					},
-				});
+				await this.session.prompt(userInput.text, this.buildMainLoopPromptOptions(userInput));
 			} catch (error: unknown) {
 				this.optimisticUserEchoes.reject(userInput.pendingEchoId);
 				this.clearStatusIndicator("working");
@@ -5369,6 +5357,32 @@ export class InteractiveMode {
 				resolve(input);
 			};
 		});
+	}
+
+	// Build the session.prompt options for a main-loop submission. The optimistic echo
+	// keeps only a prompt that actually started; a buffered prompt consumed by an input
+	// extension with action "handled" clears the retained working dock, but only once
+	// agent_idle has fired (the agentIdle latch) so a settlement-deferred continuation
+	// still in admission keeps its dock.
+	private buildMainLoopPromptOptions(userInput: InteractiveUserInput): {
+		streamingBehavior: "steer";
+		images?: InteractiveUserInput["images"];
+		preflightResult: (success: boolean) => void;
+		promptDisposition: (disposition: "handled" | "queued" | "started") => void;
+	} {
+		const echoOptions = this.optimisticUserEchoes.promptOptions(userInput.pendingEchoId);
+		return {
+			streamingBehavior: "steer",
+			...(userInput.images ? { images: userInput.images } : {}),
+			preflightResult: echoOptions.preflightResult,
+			promptDisposition: (disposition) => {
+				echoOptions.promptDisposition(disposition);
+				if (disposition === "handled" && this.agentIdle) {
+					this.clearStatusIndicator("working");
+					this.ui.requestRender();
+				}
+			},
+		};
 	}
 
 	private rebuildChatFromMessages(): void {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -793,6 +793,7 @@ export class InteractiveMode {
 	private isInitialized = false;
 	private onInputCallback?: (input: InteractiveUserInput) => void;
 	private pendingUserInputs: InteractiveUserInput[] = [];
+	private agentIdle = false;
 	private readonly optimisticUserEchoes: OptimisticUserEchoController;
 	/**
 	 * Clipboard images pasted into the composer, keyed by their visible
@@ -1636,10 +1637,18 @@ export class InteractiveMode {
 		while (true) {
 			const userInput = await this.getUserInput();
 			try {
+				const echoOptions = this.optimisticUserEchoes.promptOptions(userInput.pendingEchoId);
 				await this.session.prompt(userInput.text, {
 					streamingBehavior: "steer",
 					...(userInput.images ? { images: userInput.images } : {}),
-					...this.optimisticUserEchoes.promptOptions(userInput.pendingEchoId),
+					preflightResult: echoOptions.preflightResult,
+					promptDisposition: (disposition) => {
+						echoOptions.promptDisposition(disposition);
+						if (disposition === "handled" && this.agentIdle) {
+							this.clearStatusIndicator("working");
+							this.ui.requestRender();
+						}
+					},
 				});
 			} catch (error: unknown) {
 				this.optimisticUserEchoes.reject(userInput.pendingEchoId);
@@ -4244,6 +4253,7 @@ export class InteractiveMode {
 
 		switch (event.type) {
 			case "agent_start":
+				this.agentIdle = false;
 				this.clearPendingTools();
 				this.clearActiveToolExecutionStatus();
 				this.clearToolHookStatuses();
@@ -4502,10 +4512,15 @@ export class InteractiveMode {
 				break;
 
 			case "agent_settled":
+				await this.checkShutdownRequested();
+				break;
+
+			case "agent_idle":
+				this.agentIdle = true;
 				if (this.pendingUserInputs.length === 0) {
 					this.clearStatusIndicator("working");
 				}
-				await this.checkShutdownRequested();
+				this.ui.requestRender();
 				break;
 
 			case "continuation_error":

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5377,7 +5377,10 @@ export class InteractiveMode {
 			preflightResult: echoOptions.preflightResult,
 			promptDisposition: (disposition) => {
 				echoOptions.promptDisposition(disposition);
-				if (disposition === "handled" && this.agentIdle) {
+				// Clear the retained dock on a handled prompt only when it was the last
+				// buffered input; a still-queued follow-up remounts it on agent_start, so
+				// clearing here would bounce the editor/footer.
+				if (disposition === "handled" && this.agentIdle && this.pendingUserInputs.length === 0) {
 					this.clearStatusIndicator("working");
 					this.ui.requestRender();
 				}

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -1643,6 +1643,7 @@ export class InteractiveMode {
 				});
 			} catch (error: unknown) {
 				this.optimisticUserEchoes.reject(userInput.pendingEchoId);
+				this.clearStatusIndicator("working");
 				const errorMessage = error instanceof Error ? error.message : "Unknown error occurred";
 				this.showError(errorMessage);
 			}
@@ -2970,13 +2971,18 @@ export class InteractiveMode {
 		}
 		const hadActiveStatusIndicator = this.activeStatusIndicator !== undefined;
 		const isClearingWorking = this.activeStatusIndicator?.kind === "working";
+		const shouldReserveHeight =
+			hadActiveStatusIndicator && this.options.tuiMode === "regular" && this.ui.getClearOnShrink();
+		const renderedHeight = shouldReserveHeight ? this.statusContainer.render(this.ui.terminal.columns).length : 0;
 		this.activeStatusIndicator?.dispose();
 		this.activeStatusIndicator = undefined;
 		if (isClearingWorking) {
 			this.workingStartedAt = undefined;
 		}
 		this.statusContainer.clear();
-		if (hadActiveStatusIndicator && this.options.tuiMode === "regular" && this.ui.getClearOnShrink()) {
+		if (shouldReserveHeight) {
+			const idleHeight = Math.min(this.ui.terminal.rows, Math.max(1, renderedHeight || 2));
+			this.idleStatus.setHeight(idleHeight);
 			this.statusContainer.addChild(this.idleStatus);
 		}
 	}
@@ -4480,7 +4486,6 @@ export class InteractiveMode {
 				if (this.settingsManager.getShowTerminalProgress()) {
 					this.ui.terminal.setProgress(false);
 				}
-				this.clearStatusIndicator("working");
 				this.clearActiveToolExecutionStatus();
 				this.clearToolHookStatuses();
 				this.streamingReveal.stop();
@@ -4497,6 +4502,9 @@ export class InteractiveMode {
 				break;
 
 			case "agent_settled":
+				if (this.pendingUserInputs.length === 0) {
+					this.clearStatusIndicator("working");
+				}
 				await this.checkShutdownRequested();
 				break;
 

--- a/packages/coding-agent/test/interactive-mode-image-submission.test.ts
+++ b/packages/coding-agent/test/interactive-mode-image-submission.test.ts
@@ -93,6 +93,7 @@ interface ModeContext {
 	getSessionLogger: () => ModeContext["sessionLogger"];
 	ui: { requestRender: () => void };
 	showStatus: MockFn;
+	clearStatusIndicator: MockFn;
 	showError: (message: string) => void;
 	showWarning: (message: string) => void;
 	hideShortcutOverlay: () => void;
@@ -203,6 +204,7 @@ function createModeContext(): ModeContext {
 			getSessionLogger: () => sessionLogger,
 			ui: { requestRender: vi.fn() },
 			showStatus: vi.fn(),
+			clearStatusIndicator: vi.fn(),
 			showError: vi.fn(),
 			showWarning: vi.fn(),
 			hideShortcutOverlay: vi.fn(),

--- a/packages/coding-agent/test/interactive-mode-image-submission.test.ts
+++ b/packages/coding-agent/test/interactive-mode-image-submission.test.ts
@@ -124,6 +124,7 @@ interface ModeContext {
 	queueCompactionSubmission?: (text: string, mode: "steer" | "followUp") => void;
 	queueCompactionMessage?: (text: string, mode: "steer" | "followUp", droppedImageCount?: number) => void;
 	getUserInput?: () => Promise<UserSubmission>;
+	buildMainLoopPromptOptions?: (userInput: UserSubmission) => unknown;
 	isExtensionCommand?: (text: string) => boolean;
 	getExpandedEditorText?: () => string;
 }
@@ -144,6 +145,7 @@ type ModePrototype = {
 		droppedImageCount?: number,
 	): void;
 	takeSubmissionImages(this: ModeContext, submittedText: string): ImageContent[];
+	buildMainLoopPromptOptions(this: ModeContext, userInput: UserSubmission): unknown;
 	isExtensionCommand(this: ModeContext, text: string): boolean;
 	getExpandedEditorText(this: ModeContext): string;
 };
@@ -236,6 +238,7 @@ function createModeContext(): ModeContext {
 		"isExtensionCommand",
 		"getExpandedEditorText",
 		"getUserInput",
+		"buildMainLoopPromptOptions",
 	] as const) {
 		const real = proto[method] as unknown as ((this: ModeContext, ...args: never[]) => unknown) | undefined;
 		if (typeof real === "function") {

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -63,6 +63,14 @@ type RunContext = {
 	checkTmuxSetup: () => Promise<string | undefined>;
 	maybeWarnAboutAnthropicSubscriptionAuth: () => Promise<void>;
 	getUserInput: () => Promise<{ text: string; images?: unknown[]; pendingEchoId: string }>;
+	buildMainLoopPromptOptions: (userInput: { text: string; images?: unknown[]; pendingEchoId: string }) => {
+		streamingBehavior: "steer";
+		preflightResult: (s: boolean) => void;
+		promptDisposition: (d: string) => void;
+	};
+	clearStatusIndicator: (kind?: string) => void;
+	ui: { requestRender: () => void };
+	agentIdle: boolean;
 	showNewVersionNotification: (version: string) => void;
 	showPackageUpdateNotification: (packages: string[]) => void;
 	showRiskyMainModelWarning: () => void;
@@ -75,6 +83,10 @@ type InteractiveModePrivate = {
 	setupEditorSubmitHandler(this: SubmitContext): void;
 	getUserInput(this: InputContext): Promise<{ text: string; images?: unknown[] }>;
 	takeSubmissionImages(this: SubmitContext, submittedText: string): unknown[];
+	buildMainLoopPromptOptions(
+		this: RunContext,
+		userInput: { text: string; images?: unknown[]; pendingEchoId: string },
+	): { streamingBehavior: "steer"; preflightResult: (s: boolean) => void; promptDisposition: (d: string) => void };
 	run(this: RunContext): Promise<void>;
 };
 
@@ -166,6 +178,11 @@ describe("InteractiveMode startup input", () => {
 			checkTmuxSetup: vi.fn(async () => undefined),
 			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn(async () => {}),
 			getUserInput,
+			buildMainLoopPromptOptions: (userInput: { text: string; images?: unknown[]; pendingEchoId: string }) =>
+				interactiveModePrototype.buildMainLoopPromptOptions.call(context, userInput),
+			clearStatusIndicator: vi.fn(),
+			ui: { requestRender: vi.fn() },
+			agentIdle: false,
 			showNewVersionNotification: vi.fn(),
 			showPackageUpdateNotification: vi.fn(),
 			showRiskyMainModelWarning: vi.fn(),

--- a/packages/coding-agent/test/interactive-tui.test.ts
+++ b/packages/coding-agent/test/interactive-tui.test.ts
@@ -3,6 +3,7 @@ import { Container, isViewportTUI, Text } from "@earendil-works/pi-tui";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { VirtualTerminal } from "../../tui/test/virtual-terminal.ts";
 import type { FullscreenExitOutput, TuiMode } from "../src/core/settings-manager.ts";
+import { IdleStatus } from "../src/modes/interactive/components/status-indicator.ts";
 import {
 	createInteractiveTui,
 	createInteractiveTuiReference,
@@ -356,8 +357,8 @@ type ClearStatusContext = {
 	activeStatusIndicator: { kind: "working"; dispose: () => void } | undefined;
 	statusContainer: Container;
 	options: { tuiMode?: TuiMode };
-	ui: { getClearOnShrink: () => boolean };
-	idleStatus: Component;
+	ui: { getClearOnShrink: () => boolean; terminal: { columns: number; rows: number } };
+	idleStatus: IdleStatus;
 };
 
 type InteractiveModePrototype = {
@@ -367,24 +368,26 @@ type InteractiveModePrototype = {
 const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototype;
 
 describe("clear-on-shrink status spacing", () => {
-	it("reserves status height only on the main-screen renderer", () => {
-		for (const [tuiMode, expectedChildren] of [
-			["regular", 1],
-			["fullscreen", 0],
-		] as const) {
+	it("reserves the measured status height only on the main-screen renderer", () => {
+		for (const tuiMode of ["regular", "fullscreen"] as const) {
 			const dispose = vi.fn();
+			const statusContainer = new Container();
+			for (const line of ["one", "two", "three", "four"]) {
+				statusContainer.addChild(new Text(line, 0, 0));
+			}
+			const outgoingHeight = statusContainer.render(80).length;
 			const context: ClearStatusContext = {
 				activeStatusIndicator: { kind: "working", dispose },
-				statusContainer: new Container(),
+				statusContainer,
 				options: { tuiMode },
-				ui: { getClearOnShrink: () => true },
-				idleStatus: new Text("", 0, 0),
+				ui: { getClearOnShrink: () => true, terminal: { columns: 80, rows: 24 } },
+				idleStatus: new IdleStatus(),
 			};
 
 			interactiveModePrototype.clearStatusIndicator.call(context);
 
 			expect(dispose).toHaveBeenCalledOnce();
-			expect(context.statusContainer.children).toHaveLength(expectedChildren);
+			expect(context.statusContainer.render(80).length).toBe(tuiMode === "regular" ? outgoingHeight : 0);
 		}
 	});
 });

--- a/packages/coding-agent/test/status-indicator.test.ts
+++ b/packages/coding-agent/test/status-indicator.test.ts
@@ -16,12 +16,12 @@ describe("status indicators", () => {
 		vi.useRealTimers();
 	});
 
-	it("keeps idle status at the same height as status indicators", () => {
-		const idleStatus = new IdleStatus();
+	it("renders the configured reserved height and defaults to two rows", () => {
+		const defaultLines = new IdleStatus().render(20);
+		const measuredLines = new IdleStatus(4).render(20);
 
-		const lines = idleStatus.render(20);
-		expect(lines).toHaveLength(2);
-		expect(lines).toEqual([" ".repeat(20), " ".repeat(20)]);
+		expect(defaultLines).toEqual([" ".repeat(20), " ".repeat(20)]);
+		expect(measuredLines).toEqual(Array.from({ length: 4 }, () => " ".repeat(20)));
 	});
 
 	it("keeps the cancellation hint visible on narrow terminals before progress arrives", () => {

--- a/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-retry-events.test.ts
@@ -455,6 +455,7 @@ describe("AgentSession retry and event characterization", () => {
 			"turn_end",
 			"agent_end",
 			"agent_settled",
+			"agent_idle",
 		]);
 	});
 
@@ -501,6 +502,7 @@ describe("AgentSession retry and event characterization", () => {
 			"turn_end",
 			"agent_end",
 			"agent_settled",
+			"agent_idle",
 		]);
 	});
 
@@ -532,7 +534,8 @@ describe("AgentSession retry and event characterization", () => {
 		await harness.session.prompt("hi");
 
 		expect(harness.eventsOfType("agent_end")).toHaveLength(1);
-		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_settled");
+		await harness.session.waitForIdle();
+		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_idle");
 	});
 
 	it("delivers retry_probe_scheduled to a subscribed listener with payload intact", async () => {
@@ -652,7 +655,8 @@ describe("AgentSession retry and event characterization", () => {
 		await promptPromise;
 
 		expect(harness.eventsOfType("agent_end")).toHaveLength(1);
-		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_settled");
+		await harness.session.waitForIdle();
+		expect(harness.events[harness.events.length - 1]?.type).toBe("agent_idle");
 		const lastMessage = harness.session.messages[harness.session.messages.length - 1];
 		expect(lastMessage?.role).toBe("assistant");
 		if (lastMessage?.role === "assistant") {

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -707,6 +707,7 @@ describe("retry fallback engine", () => {
 			{ type: "turn_end" },
 			{ type: "agent_end", willRetry: false },
 			{ type: "agent_settled" },
+			{ type: "agent_idle" },
 		]);
 	});
 

--- a/packages/coding-agent/test/tui-vertical-jitter-lifecycle.test.ts
+++ b/packages/coding-agent/test/tui-vertical-jitter-lifecycle.test.ts
@@ -11,6 +11,15 @@ const handleEvent = (InteractiveMode.prototype as unknown as { handleEvent(event
 const clearStatusIndicator = (
 	InteractiveMode.prototype as unknown as { clearStatusIndicator(kind?: "working" | "retry"): void }
 ).clearStatusIndicator;
+const buildMainLoopPromptOptions = (
+	InteractiveMode.prototype as unknown as {
+		buildMainLoopPromptOptions(userInput: { text: string; pendingEchoId: string }): {
+			streamingBehavior: "steer";
+			preflightResult(success: boolean): void;
+			promptDisposition(disposition: "handled" | "queued" | "started"): void;
+		};
+	}
+).buildMainLoopPromptOptions;
 
 type Surface = {
 	activeStatusIndicator: { kind: "working"; dispose(): void } | undefined;
@@ -135,6 +144,17 @@ function deferredContinuation(pi: ExtensionAPI): void {
 	});
 }
 
+// Settlement-deferred continuation via the always-triggering sendUserMessage API,
+// which must ALSO hold off agent_idle until its turn starts (blocker B2b).
+function deferredUserContinuation(pi: ExtensionAPI): void {
+	let sent = false;
+	pi.on("agent_settled", () => {
+		if (sent) return;
+		sent = true;
+		pi.sendUserMessage("settlement user continuation", { deliverAs: "followUp" });
+	});
+}
+
 describe("real AgentSession vertical-jitter lifecycle", () => {
 	const harnesses: Harness[] = [];
 	afterEach(() => {
@@ -147,6 +167,30 @@ describe("real AgentSession vertical-jitter lifecycle", () => {
 		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("continued")]);
 		await harness.session.prompt("start");
 		await harness.session.waitForIdle();
+
+		expect(lifecycle(harness.events)).toEqual([
+			"agent_start",
+			"agent_end",
+			"agent_settled",
+			"agent_start",
+			"agent_end",
+			"agent_settled",
+			"agent_idle",
+		]);
+	});
+
+	it("C6 keeps settlement-deferred sendUserMessage ownership between settled and start", async () => {
+		const harness = await createHarness({ extensionFactories: [deferredUserContinuation] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("continued")]);
+		await harness.session.prompt("start");
+		// The deferred sendUserMessage turn holds a session-work barrier token while
+		// it awaits admission; drain that, then let the final settlement flush the
+		// queued agent_idle microtask.
+		await harness.session.waitForIdle();
+		await harness.session.waitForSettledSessionWork().catch(() => {});
+		await harness.session.waitForIdle();
+		await new Promise<void>((resolve) => setImmediate(resolve));
 
 		expect(lifecycle(harness.events)).toEqual([
 			"agent_start",
@@ -191,21 +235,17 @@ describe("real AgentSession vertical-jitter lifecycle", () => {
 		harnesses.push(harness);
 		const surface = createSurface(harness.session);
 		surface.agentIdle = true;
-		// Drive the exact disposition composition the main input loop wires in
-		// interactive-mode.ts: echo callbacks plus a dock clear on "handled" while idle.
-		const echoOptions = surface.optimisticUserEchoes.promptOptions("echo-1");
+		// Drive the REAL production composition from the main input loop
+		// (interactive-mode.ts buildMainLoopPromptOptions). Deleting the production
+		// handled-clear makes this test fail; nothing is duplicated here.
+		const options = buildMainLoopPromptOptions.call(surface, { text: "blocked", pendingEchoId: "echo-1" });
 		let disposition: string | undefined;
-		await harness.session.prompt("blocked", {
-			preflightResult: echoOptions.preflightResult,
-			promptDisposition: (value) => {
-				disposition = value;
-				echoOptions.promptDisposition(value);
-				if (value === "handled" && surface.agentIdle) {
-					surface.clearStatusIndicator("working");
-					surface.ui.requestRender();
-				}
-			},
-		});
+		const realDisposition = options.promptDisposition;
+		options.promptDisposition = (value) => {
+			disposition = value;
+			realDisposition(value);
+		};
+		await harness.session.prompt("blocked", options);
 		expect(disposition).toBe("handled");
 		expect(surface.statusContainer.render(80)).toHaveLength(0);
 	});

--- a/packages/coding-agent/test/tui-vertical-jitter-lifecycle.test.ts
+++ b/packages/coding-agent/test/tui-vertical-jitter-lifecycle.test.ts
@@ -275,4 +275,53 @@ describe("real AgentSession vertical-jitter lifecycle", () => {
 		expect(boundary.map(({ event }) => event)).toEqual(["agent_end", "agent_settled", "agent_start"]);
 		expect(new Set(boundary.map(({ height }) => height)).size).toBe(1);
 	});
+
+	it("C7 keeps the dock when a handled prompt is not the last buffered input", async () => {
+		const harness = await createHarness({
+			extensionFactories: [(pi) => pi.on("input", () => ({ action: "handled" }))],
+		});
+		harnesses.push(harness);
+		const surface = createSurface(harness.session);
+		surface.agentIdle = true;
+		// Two buffered prompts: prompt1 is shifted and handled, but prompt2 is still
+		// queued, so clearing the dock here would bounce it when prompt2 starts.
+		surface.pendingUserInputs.push({ text: "p1", pendingEchoId: "e1" }, { text: "p2", pendingEchoId: "e2" });
+		const first = surface.pendingUserInputs.shift();
+		expect(surface.pendingUserInputs).toHaveLength(1);
+		const options = buildMainLoopPromptOptions.call(surface, first!);
+		let disposition: string | undefined;
+		const realDisposition = options.promptDisposition;
+		options.promptDisposition = (value) => {
+			disposition = value;
+			realDisposition(value);
+		};
+		await harness.session.prompt("p1", options);
+		expect(disposition).toBe("handled");
+		// Dock must survive because another buffered input remains.
+		expect(surface.statusContainer.render(80).length).toBeGreaterThan(0);
+	});
+
+	it("C8 resolves the deferred claim when sendUserMessage content normalization throws", async () => {
+		const harness = await createHarness({
+			extensionFactories: [
+				(pi) => {
+					let sent = false;
+					pi.on("agent_settled", () => {
+						if (sent) return;
+						sent = true;
+						// null content throws in normalization before the guarded try.
+						pi.sendUserMessage(null as unknown as string, { deliverAs: "followUp" });
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		await harness.session.prompt("start");
+		await harness.session.waitForIdle();
+		await new Promise<void>((resolve) => setImmediate(resolve));
+		// The claim must resolve (finished-without-start), so agent_idle still fires
+		// exactly once instead of hanging the settlement's Promise.all.
+		expect(harness.events.filter((event) => event.type === "agent_idle")).toHaveLength(1);
+	});
 });

--- a/packages/coding-agent/test/tui-vertical-jitter-lifecycle.test.ts
+++ b/packages/coding-agent/test/tui-vertical-jitter-lifecycle.test.ts
@@ -1,0 +1,238 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { Container, Text } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
+import type { ExtensionAPI } from "../src/index.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+const handleEvent = (InteractiveMode.prototype as unknown as { handleEvent(event: AgentSessionEvent): Promise<void> })
+	.handleEvent;
+const clearStatusIndicator = (
+	InteractiveMode.prototype as unknown as { clearStatusIndicator(kind?: "working" | "retry"): void }
+).clearStatusIndicator;
+
+type Surface = {
+	activeStatusIndicator: { kind: "working"; dispose(): void } | undefined;
+	statusContainer: Container;
+	editorContainer: Container;
+	footerContainer: Container;
+	pendingUserInputs: Array<{ text: string; pendingEchoId: string }>;
+	agentIdle: boolean;
+	workingVisible: boolean;
+	workingMessage: string | undefined;
+	defaultWorkingMessage: string;
+	isInitialized: boolean;
+	options: { tuiMode: "regular" };
+	turnWorkingTip: { resetForNewTurn(): void };
+	chrome: { createWorkingIndicator(): { kind: "working"; dispose(): void } };
+	footer: { invalidate(): void };
+	settingsManager: { getShowTerminalProgress(): boolean };
+	ui: {
+		requestRender(): void;
+		getClearOnShrink(): boolean;
+		terminal: { setProgress(value: boolean): void; columns: number; rows: number };
+	};
+	checkShutdownRequested(): Promise<void>;
+	clearPendingTools(): void;
+	clearActiveToolExecutionStatus(): void;
+	clearToolHookStatuses(): void;
+	streamingReveal: { stop(): void };
+	toolResultReveal: { stop(): void };
+	detachAssistantTextSegments(): void;
+	streamingComponent: undefined;
+	getWorkingIndicatorOptions(): Record<string, never>;
+	showStatusIndicator(indicator: { kind: "working"; dispose(): void }): void;
+	clearStatusIndicator(kind?: "working" | "retry"): void;
+	optimisticUserEchoes: {
+		promptOptions(id: string): {
+			preflightResult(success: boolean): void;
+			promptDisposition(disposition: "handled" | "queued" | "started"): void;
+		};
+		reject(id: string): void;
+	};
+	session: Harness["session"];
+	getUserInput(): Promise<{ text: string; pendingEchoId: string }>;
+	showError(message: string): void;
+};
+
+function createSurface(session: Harness["session"]): Surface {
+	const surface = {
+		activeStatusIndicator: { kind: "working" as const, dispose: vi.fn() },
+		statusContainer: new Container(),
+		editorContainer: new Container(),
+		footerContainer: new Container(),
+		pendingUserInputs: [],
+		agentIdle: false,
+		workingVisible: true,
+		workingMessage: undefined,
+		defaultWorkingMessage: "Working",
+		isInitialized: true,
+		options: { tuiMode: "regular" as const },
+		turnWorkingTip: { resetForNewTurn: vi.fn() },
+		chrome: { createWorkingIndicator: () => ({ kind: "working" as const, dispose: vi.fn() }) },
+		footer: { invalidate: vi.fn() },
+		settingsManager: { getShowTerminalProgress: () => false },
+		ui: {
+			requestRender: vi.fn(),
+			getClearOnShrink: () => false,
+			terminal: { setProgress: vi.fn(), columns: 80, rows: 24 },
+		},
+		checkShutdownRequested: vi.fn(async () => {}),
+		clearPendingTools: vi.fn(),
+		clearActiveToolExecutionStatus: vi.fn(),
+		clearToolHookStatuses: vi.fn(),
+		streamingReveal: { stop: vi.fn() },
+		toolResultReveal: { stop: vi.fn() },
+		detachAssistantTextSegments: vi.fn(),
+		streamingComponent: undefined,
+		getWorkingIndicatorOptions: () => ({}),
+		showStatusIndicator: vi.fn(),
+		clearStatusIndicator,
+		optimisticUserEchoes: {
+			promptOptions: () => ({ preflightResult: vi.fn(), promptDisposition: vi.fn() }),
+			reject: vi.fn(),
+		},
+		session,
+		getUserInput: vi.fn(),
+		showError: vi.fn(),
+	} satisfies Surface;
+	surface.statusContainer.addChild(new Text("working\nworking\nworking\nworking", 0, 0));
+	surface.editorContainer.addChild(new Text("editor\neditor\neditor", 0, 0));
+	surface.footerContainer.addChild(new Text("footer", 0, 0));
+	surface.showStatusIndicator = vi.fn((indicator) => {
+		surface.activeStatusIndicator = indicator;
+		surface.statusContainer.clear();
+		surface.statusContainer.addChild(new Text("working\nworking\nworking\nworking", 0, 0));
+	});
+	return surface;
+}
+
+const LIFECYCLE_EVENT_TYPES = new Set(["agent_start", "agent_end", "agent_settled", "agent_idle"]);
+
+function subscribeSurface(harness: Harness, surface: Surface): () => void {
+	// Only forward the dock-lifecycle events the partial surface can handle; the
+	// real handleEvent also renders messages/tools, which the surface does not stub.
+	return harness.session.subscribe((event) => {
+		if (LIFECYCLE_EVENT_TYPES.has(event.type)) return handleEvent.call(surface, event);
+	});
+}
+
+function lifecycle(events: AgentSessionEvent[]): string[] {
+	return events
+		.map((event) => event.type)
+		.filter(
+			(type) => type === "agent_start" || type === "agent_end" || type === "agent_settled" || type === "agent_idle",
+		);
+}
+
+function deferredContinuation(pi: ExtensionAPI): void {
+	let sent = false;
+	pi.on("agent_settled", () => {
+		if (sent) return;
+		sent = true;
+		pi.sendMessage({ customType: "test-continuation", content: "continue", display: false }, { triggerTurn: true });
+	});
+}
+
+describe("real AgentSession vertical-jitter lifecycle", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("C1 keeps settlement-deferred continuation ownership between settled and start", async () => {
+		const harness = await createHarness({ extensionFactories: [deferredContinuation] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("continued")]);
+		await harness.session.prompt("start");
+		await harness.session.waitForIdle();
+
+		expect(lifecycle(harness.events)).toEqual([
+			"agent_start",
+			"agent_end",
+			"agent_settled",
+			"agent_start",
+			"agent_end",
+			"agent_settled",
+			"agent_idle",
+		]);
+	});
+
+	it("C2 emits idle after an ordinary final settlement", async () => {
+		const harness = await createHarness();
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		await harness.session.prompt("start");
+		await harness.session.waitForIdle();
+		expect(lifecycle(harness.events)).toEqual(["agent_start", "agent_end", "agent_settled", "agent_idle"]);
+	});
+
+	it("C3 emits exactly one idle when deferred continuation admission fails", async () => {
+		const harness = await createHarness({ extensionFactories: [deferredContinuation] });
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("done")]);
+		const enforce = Reflect.get(harness.session, "_enforceFinalProviderAdmission");
+		let admissions = 0;
+		Reflect.set(harness.session, "_enforceFinalProviderAdmission", async (...args: unknown[]) => {
+			admissions++;
+			if (admissions === 2) throw new Error("deferred admission rejected");
+			return enforce.apply(harness.session, args);
+		});
+		await harness.session.prompt("start");
+		await harness.session.waitForSettledSessionWork();
+		expect(harness.events.filter((event) => event.type === "agent_idle")).toHaveLength(1);
+	});
+
+	it("C4 clears retained Working when a locally buffered prompt is handled", async () => {
+		const harness = await createHarness({
+			extensionFactories: [(pi) => pi.on("input", () => ({ action: "handled" }))],
+		});
+		harnesses.push(harness);
+		const surface = createSurface(harness.session);
+		surface.agentIdle = true;
+		// Drive the exact disposition composition the main input loop wires in
+		// interactive-mode.ts: echo callbacks plus a dock clear on "handled" while idle.
+		const echoOptions = surface.optimisticUserEchoes.promptOptions("echo-1");
+		let disposition: string | undefined;
+		await harness.session.prompt("blocked", {
+			preflightResult: echoOptions.preflightResult,
+			promptDisposition: (value) => {
+				disposition = value;
+				echoOptions.promptDisposition(value);
+				if (value === "handled" && surface.agentIdle) {
+					surface.clearStatusIndicator("working");
+					surface.ui.requestRender();
+				}
+			},
+		});
+		expect(disposition).toBe("handled");
+		expect(surface.statusContainer.render(80)).toHaveLength(0);
+	});
+
+	it("C5 keeps editor/footer surface height stable through a deferred continuation", async () => {
+		const harness = await createHarness({ extensionFactories: [deferredContinuation] });
+		harnesses.push(harness);
+		const surface = createSurface(harness.session);
+		const unsubscribe = subscribeSurface(harness, surface);
+		const heights: Array<{ event: string; height: number }> = [];
+		const record = harness.session.subscribe((event) => {
+			if (event.type !== "agent_end" && event.type !== "agent_settled" && event.type !== "agent_start") return;
+			heights.push({
+				event: event.type,
+				height:
+					surface.statusContainer.render(80).length +
+					surface.editorContainer.render(80).length +
+					surface.footerContainer.render(80).length,
+			});
+		});
+		harness.setResponses([fauxAssistantMessage("first"), fauxAssistantMessage("continued")]);
+		await harness.session.prompt("start");
+		await harness.session.waitForIdle();
+		unsubscribe();
+		record();
+		const boundary = heights.slice(1, 4);
+		expect(boundary.map(({ event }) => event)).toEqual(["agent_end", "agent_settled", "agent_start"]);
+		expect(new Set(boundary.map(({ height }) => height)).size).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/tui-vertical-jitter.test.ts
+++ b/packages/coding-agent/test/tui-vertical-jitter.test.ts
@@ -97,17 +97,17 @@ describe("TUI vertical jitter lifecycle", () => {
 		expect(after).toBe(before);
 	});
 
-	it("clears working only when settled without buffered input", async () => {
+	it("clears working only when idle without buffered input", async () => {
 		fixtureStatus = fixture();
 		fixtureStatus.statusContainer.addChild(new Text("working", 0, 0));
 		fixtureStatus.pendingUserInputs.push({ text: "queued" });
 
 		await handleEvent.call(fixtureStatus, { type: "agent_end" });
-		await handleEvent.call(fixtureStatus, { type: "agent_settled" });
+		await handleEvent.call(fixtureStatus, { type: "agent_idle" });
 		expect(fixtureStatus.statusContainer.render(80).length).toBeGreaterThan(0);
 
 		fixtureStatus.pendingUserInputs.length = 0;
-		await handleEvent.call(fixtureStatus, { type: "agent_settled" });
+		await handleEvent.call(fixtureStatus, { type: "agent_idle" });
 		expect(fixtureStatus.statusContainer.render(80).length).toBe(0);
 	});
 

--- a/packages/coding-agent/test/tui-vertical-jitter.test.ts
+++ b/packages/coding-agent/test/tui-vertical-jitter.test.ts
@@ -1,0 +1,139 @@
+import { Container, Text } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { IdleStatus } from "../src/modes/interactive/components/status-indicator.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type Fixture = {
+	activeStatusIndicator: { kind: "working" | "retry"; dispose: () => void } | undefined;
+	statusContainer: Container;
+	pendingUserInputs: unknown[];
+	workingVisible: boolean;
+	workingMessage: string | undefined;
+	defaultWorkingMessage: string;
+	isInitialized: boolean;
+	options: { tuiMode: "regular" };
+	idleStatus: IdleStatus;
+	turnWorkingTip: { resetForNewTurn: () => void };
+	chrome: { createWorkingIndicator: () => { kind: "working"; dispose: () => void } };
+	footer: { invalidate: () => void };
+	settingsManager: { getShowTerminalProgress: () => boolean };
+	ui: {
+		requestRender: () => void;
+		terminal: { setProgress: (value: boolean) => void; columns: number; rows: number };
+	};
+	checkShutdownRequested: () => Promise<void>;
+	clearPendingTools: () => void;
+	clearActiveToolExecutionStatus: () => void;
+	clearToolHookStatuses: () => void;
+	streamingReveal: { stop: () => void };
+	toolResultReveal: { stop: () => void };
+	detachAssistantTextSegments: () => void;
+	streamingComponent: undefined;
+	getWorkingIndicatorOptions: () => Record<string, never>;
+	showStatusIndicator: (indicator: { kind: "working" }) => void;
+	clearStatusIndicator: (kind?: "working" | "retry") => void;
+};
+
+const handleEvent = (InteractiveMode.prototype as unknown as { handleEvent: (event: any) => Promise<void> })
+	.handleEvent;
+const clearStatusIndicator = (
+	InteractiveMode.prototype as unknown as {
+		clearStatusIndicator: (kind?: "working" | "retry") => void;
+	}
+).clearStatusIndicator;
+
+function fixture(): Fixture {
+	return {
+		activeStatusIndicator: { kind: "working", dispose: vi.fn() },
+		statusContainer: new Container(),
+		pendingUserInputs: [],
+		workingVisible: true,
+		workingMessage: undefined,
+		defaultWorkingMessage: "Working",
+		isInitialized: true,
+		options: { tuiMode: "regular" },
+		idleStatus: new IdleStatus(),
+		turnWorkingTip: { resetForNewTurn: vi.fn() },
+		chrome: { createWorkingIndicator: () => ({ kind: "working", dispose: vi.fn() }) },
+		footer: { invalidate: vi.fn() },
+		settingsManager: { getShowTerminalProgress: () => false },
+		ui: {
+			requestRender: vi.fn(),
+			getClearOnShrink: () => false,
+			terminal: { setProgress: vi.fn(), columns: 80, rows: 24 },
+		} as Fixture["ui"] & { getClearOnShrink: () => boolean },
+		checkShutdownRequested: vi.fn(async () => {}),
+		clearPendingTools: vi.fn(),
+		clearActiveToolExecutionStatus: vi.fn(),
+		clearToolHookStatuses: vi.fn(),
+		streamingReveal: { stop: vi.fn() },
+		toolResultReveal: { stop: vi.fn() },
+		detachAssistantTextSegments: vi.fn(),
+		streamingComponent: undefined,
+		getWorkingIndicatorOptions: () => ({}),
+		showStatusIndicator: vi.fn((indicator) => {
+			fixtureStatus.activeStatusIndicator = indicator;
+			fixtureStatus.statusContainer.clear();
+			fixtureStatus.statusContainer.addChild(new Text("working", 0, 0));
+		}),
+		clearStatusIndicator: clearStatusIndicator,
+	};
+}
+
+let fixtureStatus: Fixture;
+
+describe("TUI vertical jitter lifecycle", () => {
+	it("keeps the working dock painted between agent_end and the next agent_start", async () => {
+		fixtureStatus = fixture();
+		fixtureStatus.statusContainer.addChild(new Text("working", 0, 0));
+		const before = fixtureStatus.statusContainer.render(80).length;
+
+		await handleEvent.call(fixtureStatus, { type: "agent_end" });
+		const between = fixtureStatus.statusContainer.render(80).length;
+		await handleEvent.call(fixtureStatus, { type: "agent_start" });
+		const after = fixtureStatus.statusContainer.render(80).length;
+
+		expect(between).toBeGreaterThan(0);
+		expect(after).toBe(before);
+	});
+
+	it("clears working only when settled without buffered input", async () => {
+		fixtureStatus = fixture();
+		fixtureStatus.statusContainer.addChild(new Text("working", 0, 0));
+		fixtureStatus.pendingUserInputs.push({ text: "queued" });
+
+		await handleEvent.call(fixtureStatus, { type: "agent_end" });
+		await handleEvent.call(fixtureStatus, { type: "agent_settled" });
+		expect(fixtureStatus.statusContainer.render(80).length).toBeGreaterThan(0);
+
+		fixtureStatus.pendingUserInputs.length = 0;
+		await handleEvent.call(fixtureStatus, { type: "agent_settled" });
+		expect(fixtureStatus.statusContainer.render(80).length).toBe(0);
+	});
+
+	it("does not let a delayed working clear remove a newer indicator", () => {
+		fixtureStatus = fixture();
+		const retry = { kind: "retry" as const, dispose: vi.fn() };
+		fixtureStatus.activeStatusIndicator = retry;
+		fixtureStatus.statusContainer.addChild(new Text("retry", 0, 0));
+
+		clearStatusIndicator.call(fixtureStatus, "working");
+
+		expect(fixtureStatus.activeStatusIndicator).toBe(retry);
+		expect(fixtureStatus.statusContainer.render(80).length).toBeGreaterThan(0);
+	});
+
+	it("reserves the measured outgoing height for clear-on-shrink", () => {
+		fixtureStatus = fixture();
+		fixtureStatus.statusContainer.addChild(new Text("one", 0, 0));
+		fixtureStatus.statusContainer.addChild(new Text("two", 0, 0));
+		fixtureStatus.statusContainer.addChild(new Text("three", 0, 0));
+		fixtureStatus.statusContainer.addChild(new Text("four", 0, 0));
+		const outgoingHeight = fixtureStatus.statusContainer.render(80).length;
+		(fixtureStatus.ui as Fixture["ui"] & { getClearOnShrink: () => boolean }).getClearOnShrink = () => true;
+
+		clearStatusIndicator.call(fixtureStatus);
+
+		expect(fixtureStatus.statusContainer.render(80).length).toBe(outgoingHeight);
+	});
+});


### PR DESCRIPTION
## Symptom

Since ~2026-08-20 the interactive TUI visibly shook up and down during agentic turns. #1064 fixed the assistant-text teleport half; on v2026.8.22 a residual bounce remained: the whole editor/footer block jumped at every turn boundary. Real-PTY capture on pre-fix HEAD (100x30 tmux, raw stream replayed through `@xterm/headless`) showed total height / footer row going `95 -> 93 -> 97` at a queued-turn boundary, then again `104 -> 102`.

## Root cause

`agent_end` eagerly cleared the 4-row working/tip status dock (`clearStatusIndicator("working")`), and the next `agent_start` immediately remounted it - so every adjacent turn boundary removed and re-added 4 rows below the transcript, bouncing the editor/footer.

Review then surfaced two deeper holes in the naive "clear at agent_settled" fix:

- **Settlement-deferred continuations** (TTSR, loop-guard, goal recovery) call `pi.sendMessage(..., {triggerTurn:true})` / `pi.sendUserMessage(...)` from `agent_settled`, which run AFTER the public `agent_settled` emit - so clearing there still removed the dock right before a deferred `agent_start` remounted it. `_isAgentRunActive` alone cannot decide this, because a deferred send can be suspended at compaction/provider admission before reaching `_promptAgent`.
- **Locally buffered prompts** consumed by an input extension with `action: "handled"` (e.g. a `UserPromptSubmit` hook block) never produced another lifecycle event to clear the dock, leaving a stale spinner.

## Fix (intent-preserving, no feature reverts)

New core `agent_idle` event + TUI rewire:

- `agent-settled-delivery.ts`: `DeferredTurnClaim` / `DeferredTurnDisposition` (`started` / `delegated` / `finished-without-start`) and `deferTriggerTurn`. Claims resolve at the `_promptAgent` admission boundary; `DeferredTurnClaim.resolve()` is idempotent so catch/disposition/finally overlap cannot double-resolve.
- `agent-session.ts`: after the settlement deferred-action loop, an out-of-band check waits for all deferred turn dispositions, skips emission when a turn `started`, waits for delegated session work, verifies the settlement epoch is current, and emits `agent_idle` only when no run/work is active. Both deferred-turn APIs register a claim: `sendMessage(triggerTurn:true)` via `deferTriggerTurn`, and `sendUserMessage` (always triggers a turn) via a claim resolved from its prompt disposition, with content normalization wrapped so a throwing iterator/getter resolves the claim instead of hanging the idle wait. `agent_settled` ordering is unchanged for existing subscribers.
- `interactive-mode.ts`: the dock clears on `agent_idle` (not `agent_settled`), gated on no locally buffered input; an `agentIdle` latch is set on `agent_idle` and cleared on `agent_start`. The main loop's `buildMainLoopPromptOptions` clears the dock on a `handled` disposition only when idle AND no further buffered input is queued. The admission-throw catch still clears. `clearStatusIndicator` measures the outgoing dock height for the clear-on-shrink idle placeholder (capped to terminal rows, fallback 2) instead of a hardcoded 2.

## Failing-first proof + regression tests

`test/tui-vertical-jitter-lifecycle.test.ts` drives a REAL `AgentSession` (faux provider) + real `InteractiveMode.handleEvent`, no sleeps, covering 8 contracts:
- C1 settlement-deferred `sendMessage` continuation: no `agent_idle` between `agent_settled` and the deferred `agent_start`.
- C2 ordinary final settlement emits `agent_idle`.
- C3 deferred admission failure emits exactly one `agent_idle`.
- C4 handled local prompt clears the dock (drives the production `buildMainLoopPromptOptions`).
- C5 editor/footer height stable across a deferred continuation.
- C6 settlement-deferred `sendUserMessage` continuation: no early `agent_idle`.
- C7 a handled prompt that is NOT the last buffered input retains the dock.
- C8 `sendUserMessage` with throwing content normalization still resolves the claim so `agent_idle` fires.

Mutation-verified: removing the sendUserMessage claim fails C6; removing the production handled-clear fails C4; removing the queue-depth guard fails C7. Event-order characterization tests updated to expect `agent_idle` after `agent_settled`.

## Real-surface QA (fixed build)

Scripted 100x30 PTY sessions, raw stream replayed through `@xterm/headless`:
- **Queued steering turn**: 802 frames, boundary `104 -> 106 -> 108 -> 109` monotonic (pre-fix `95 -> 93 -> 97` eliminated), 0 narration teleports, 0 `ESC[2J`/`ESC[3J`. (`verify.md`)
- **Settlement continuation** (extension `sendMessage(triggerTurn:true)` from `agent_settled`): dock painted across `agent_end -> agent_settled -> deferred agent_start` (frames 74-80 monotonic, dock present every frame), only the allowed one-way collapse after final idle. (`verify-settlement.md`)

Full `packages/coding-agent` suite (8671 tests on the merged tree) + `packages/tui` + root `npm run check` + changelog gate: green. Branch merges cleanly into `origin/main` (`git merge-tree --write-tree` exit 0).

## Review

Aggressive ultrabrain review across 4 rounds; each blocker's fix verified. Round 4: **unconditional APPROVE, 0 blockers**.

## Related

Follow-up (separate mechanism, excluded from this PR): #1076 progressive-hydration watermark exposure on resume.