### PR TITLE
feat(coding-agent): re-exec under bun for bun-installed CLIs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Added
 
+- A CLI installed with `bun install -g` now runs on the Bun runtime automatically: the entry point detects that its own script lives in Bun's global install tree and re-execs itself through the installed `bun` binary instead of staying on the Node runtime its shebang picked. Set `SENPI_RUNTIME=node` to force Node or `SENPI_RUNTIME=bun` to request Bun for any install; debugger sessions (`--inspect`) and runs that are already on Bun keep their current runtime, and a missing `bun` binary silently keeps the CLI on Node.
+
 ### Changed
 
 ### Removed

--- a/packages/coding-agent/dist/cli.js
+++ b/packages/coding-agent/dist/cli.js
@@ -1,13 +1,56 @@
 #!/usr/bin/env node
 import "./valid-cwd.js";
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { processBunRuntimeOptions, resolveBunReexec } from "./bun-runtime.js";
 import { enableStartupCompileCache } from "./compile-cache.js";
 import { APP_NAME, DISPLAY_VERSION, getPackageDir } from "./config.js";
 import { hasInheritedInspectorOption, releaseInheritedInspectorForChild } from "./inspector-policy.js";
 import { handleBootstrapSelfUpdate } from "./self-update-bootstrap.js";
+/**
+ * Hand a Bun-installed CLI to Bun before anything else runs.
+ *
+ * `bun install -g` links this script into `~/.bun/bin`, but the shebang still starts it on Node,
+ * so a user who chose Bun silently gets the Node runtime. Re-exec through the Bun binary when the
+ * script really lives in Bun's global tree (or `SENPI_RUNTIME=bun` asks for it). This runs before
+ * `enableStartupCompileCache()` on purpose: a re-exec must not pay for Node's compile-cache setup.
+ * Node `execArgv` is deliberately dropped — those flags belong to the Node process, not to Bun.
+ */
+function reexecUnderBunIfNeeded() {
+    const options = processBunRuntimeOptions(existsSync, realpathSync);
+    let scriptRealPath = process.argv[1] ?? fileURLToPath(import.meta.url);
+    try {
+        // `~/.bun/bin/<name>` is a symlink into the global tree, so the link target is what has
+        // to be classified and re-executed. A path that cannot be resolved is simply used as-is;
+        // runtime selection must never be the reason startup fails.
+        scriptRealPath = realpathSync(scriptRealPath);
+    }
+    catch { }
+    const decision = resolveBunReexec({
+        scriptRealPath,
+        versions: process.versions,
+        hasInheritedInspectorOption: hasInheritedInspectorOption(),
+        options,
+    });
+    if (decision.action === "stay") {
+        return false;
+    }
+    const result = spawnSync(decision.bunPath, [scriptRealPath, ...process.argv.slice(2)], {
+        stdio: "inherit",
+        windowsHide: true,
+    });
+    if (result.signal) {
+        process.kill(process.pid, result.signal);
+        return true;
+    }
+    process.exitCode = result.status ?? 1;
+    return true;
+}
+if (reexecUnderBunIfNeeded()) {
+    process.exit();
+}
 // Must run before cli-main is loaded, by either path: it caches the engine graph this process
 // imports on the fast path below, and it publishes NODE_COMPILE_CACHE so a spawned cli-main child
 // inherits this process's cache directory instead of resolving and re-filling its own.

--- a/packages/coding-agent/src/bun-runtime.ts
+++ b/packages/coding-agent/src/bun-runtime.ts
@@ -1,0 +1,205 @@
+/**
+ * Runtime selection for a CLI that was installed with `bun install -g`.
+ *
+ * `bun install -g` writes `~/.bun/bin/senpi` as a symlink into
+ * `<BUN_ROOT>/install/global/node_modules/...`, but the launcher still starts the script with
+ * whatever interpreter resolves the shebang — Node. A user who chose Bun then silently runs on
+ * Node, losing Bun's startup time and its runtime APIs. This module decides, from injected
+ * facts only, whether the process should hand itself to Bun.
+ *
+ * Everything here is pure and injectable so the decision can be tested without touching the
+ * host PATH or the real `~/.bun` tree; `cli.ts` owns the single impure call site.
+ */
+import { homedir as osHomedir } from "node:os";
+import { posix, win32 } from "node:path";
+
+/** Value accepted by the runtime pin environment variable. */
+export type RuntimeName = "node" | "bun";
+
+/** Environment variable that pins the runtime explicitly, bypassing detection. */
+export const RUNTIME_ENV_VAR = "SENPI_RUNTIME";
+
+/** Injected view of the world. Defaults read the real process, tests inject fakes. */
+export interface BunRuntimeOptions {
+	readonly env: NodeJS.ProcessEnv;
+	readonly homedir: string;
+	readonly platform: NodeJS.Platform;
+	readonly exists: (path: string) => boolean;
+	readonly realpath: (path: string) => string;
+}
+
+/** Why the process stayed on its current runtime. Surfaced for tests and diagnostics. */
+export type StayReason = "already-bun" | "runtime-pinned-node" | "inspector" | "bun-not-found" | "not-bun-install";
+
+export type BunReexecDecision =
+	| { readonly action: "stay"; readonly reason: StayReason }
+	| { readonly action: "reexec"; readonly bunPath: string };
+
+export interface BunReexecInput {
+	/** Real path (symlinks resolved) of the script this process was started with. */
+	readonly scriptRealPath: string;
+	/** `process.versions`; a `bun` entry means this process already IS Bun. */
+	readonly versions: Readonly<Record<string, string | undefined>>;
+	/** Whether this process inherited a `--inspect*` option. */
+	readonly hasInheritedInspectorOption: boolean;
+	readonly options: BunRuntimeOptions;
+}
+
+/** Path separators differ per platform; compare on a single normalized form. */
+function normalize(path: string): string {
+	return path.replaceAll("\\", "/");
+}
+
+/**
+ * Path semantics of the TARGET platform, not of the host running the code. Joining and PATH
+ * splitting must follow the injected platform so the decision is reproducible from a Windows
+ * fixture on a POSIX machine and vice versa.
+ */
+function paths(options: BunRuntimeOptions): typeof posix {
+	return options.platform === "win32" ? win32 : posix;
+}
+
+/**
+ * Root of the Bun installation: `BUN_INSTALL` when set, otherwise `~/.bun`. This is the same
+ * resolution order Bun itself uses to place `bin/` and `install/global/`.
+ */
+function bunRoot(options: BunRuntimeOptions): string {
+	const configured = options.env.BUN_INSTALL;
+	if (configured !== undefined && configured.trim() !== "") {
+		return configured;
+	}
+	return paths(options).join(options.homedir, ".bun");
+}
+
+/**
+ * Resolve a directory through the injected `realpath`, falling back to the input. The bun root
+ * can be a symlinked or aliased path (`/tmp` -> `/private/tmp` on macOS, a symlinked `$HOME`),
+ * and the script path is compared in its resolved form, so both sides must be resolvable.
+ * `realpath` throws on a path that does not exist, which simply means "no match here".
+ */
+function resolveOrSelf(path: string, options: BunRuntimeOptions): string {
+	try {
+		return options.realpath(path);
+	} catch {
+		return path;
+	}
+}
+
+/**
+ * Report whether the executed script lives inside Bun's global install tree.
+ *
+ * The caller must pass an already-resolved real path: `~/.bun/bin/<name>` is a symlink, and the
+ * link itself is not under `install/global/`, so an unresolved path never matches. The tree root
+ * is compared both as configured and as resolved, so a symlinked install root still matches.
+ */
+export function isUnderBunGlobalTree(scriptRealPath: string, options: BunRuntimeOptions): boolean {
+	const globalRoot = paths(options).join(bunRoot(options), "install", "global");
+	const script = normalize(scriptRealPath);
+	for (const candidate of new Set([globalRoot, resolveOrSelf(globalRoot, options)])) {
+		if (script.startsWith(`${normalize(candidate)}/`)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/** Executable name for the platform, e.g. `bun` or `bun.exe`. */
+function bunExecutableName(options: BunRuntimeOptions): string {
+	return options.platform === "win32" ? "bun.exe" : "bun";
+}
+
+/** Candidate file names to probe in a PATH directory, honoring `PATHEXT` on Windows. */
+function pathCandidateNames(options: BunRuntimeOptions): string[] {
+	if (options.platform !== "win32") {
+		return ["bun"];
+	}
+	const pathExt = options.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD";
+	const extensions = pathExt
+		.split(";")
+		.map((extension) => extension.trim())
+		.filter((extension) => extension.length > 0);
+	return extensions.length > 0 ? extensions.map((extension) => `bun${extension}`) : ["bun.exe"];
+}
+
+/**
+ * Locate a Bun binary: the configured install root first, then the default `~/.bun` root, then
+ * a PATH scan. Returns `undefined` when Bun is not installed — a missing Bun is never an error,
+ * the process simply stays on Node.
+ */
+export function findBunBinary(options: BunRuntimeOptions): string | undefined {
+	const path = paths(options);
+	const executable = bunExecutableName(options);
+	const rootCandidates = [
+		path.join(bunRoot(options), "bin", executable),
+		path.join(options.homedir, ".bun", "bin", executable),
+	];
+	for (const candidate of rootCandidates) {
+		if (options.exists(candidate)) {
+			return candidate;
+		}
+	}
+
+	const pathValue = options.env.PATH ?? options.env.Path;
+	if (pathValue === undefined || pathValue === "") {
+		return undefined;
+	}
+	const names = pathCandidateNames(options);
+	for (const directory of pathValue.split(path.delimiter)) {
+		if (directory === "") continue;
+		for (const name of names) {
+			const candidate = path.join(directory, name);
+			if (options.exists(candidate)) {
+				return candidate;
+			}
+		}
+	}
+	return undefined;
+}
+
+function readRuntimePin(options: BunRuntimeOptions): RuntimeName | undefined {
+	const value = options.env[RUNTIME_ENV_VAR];
+	if (value === "node" || value === "bun") {
+		return value;
+	}
+	return undefined;
+}
+
+/**
+ * Decide whether this process should re-exec itself under Bun. First match wins:
+ *
+ * 1. already running Bun — never re-exec, that would loop forever;
+ * 2. `SENPI_RUNTIME=node` — an explicit opt-out always wins;
+ * 3. an inherited Inspector option — a debugger session owns a Node socket, keep it;
+ * 4. `SENPI_RUNTIME=bun` with Bun installed — explicit opt-in;
+ * 5. the script lives in Bun's global install tree with Bun installed — the install implies it;
+ * 6. otherwise stay.
+ */
+export function resolveBunReexec(input: BunReexecInput): BunReexecDecision {
+	if (input.versions.bun !== undefined) {
+		return { action: "stay", reason: "already-bun" };
+	}
+	const pinned = readRuntimePin(input.options);
+	if (pinned === "node") {
+		return { action: "stay", reason: "runtime-pinned-node" };
+	}
+	if (input.hasInheritedInspectorOption) {
+		return { action: "stay", reason: "inspector" };
+	}
+	const wantsBun = pinned === "bun" || isUnderBunGlobalTree(input.scriptRealPath, input.options);
+	if (!wantsBun) {
+		return { action: "stay", reason: "not-bun-install" };
+	}
+	const bunPath = findBunBinary(input.options);
+	if (bunPath === undefined) {
+		return { action: "stay", reason: "bun-not-found" };
+	}
+	return { action: "reexec", bunPath };
+}
+
+/** Build the default, process-backed options for the real CLI entry point. */
+export function processBunRuntimeOptions(
+	exists: (path: string) => boolean,
+	realpath: (path: string) => string,
+): BunRuntimeOptions {
+	return { env: process.env, homedir: osHomedir(), platform: process.platform, exists, realpath };
+}

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-22 - Bun-installed CLIs re-exec onto the Bun runtime
+
+### What changed
+
+- `packages/coding-agent/src/cli.ts` now runs a runtime check as its first statement, before `enableStartupCompileCache()`: it realpaths `process.argv[1]`, asks the fork-only `packages/coding-agent/src/bun-runtime.ts` decision function whether this process should run under Bun, and on a positive decision `spawnSync`s the installed `bun` binary with the same script and arguments, propagates the child's signal or exit status, and exits without loading the rest of the entry flow.
+
+### Why
+
+- `bun install -g` links the CLI into `~/.bun/bin`, but the shebang still selects Node, so users who installed with Bun silently ran on the Node runtime. The check has to precede compile-cache setup so a re-exec never pays for Node-only startup work, and it honors `SENPI_RUNTIME=node`/`bun`, keeps debugger runs on Node, and never re-execs when `process.versions.bun` is already set.
+
+### Why an extension could not handle it
+
+- Runtime selection happens before any extension, session, or engine module is loaded; by the time an extension could run, the process is already committed to its interpreter.
+
+### Expected merge conflict zones
+
+- LOW: the import block and the first statements of `packages/coding-agent/src/cli.ts`, immediately above the existing `enableStartupCompileCache()` call.
+
 ## 2026-08-20 - Cursor 0-token RE stays on the same model and shrinks
 
 ### What changed

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -20,10 +20,16 @@ import { handleBootstrapSelfUpdate } from "./self-update-bootstrap.ts";
  * Node `execArgv` is deliberately dropped — those flags belong to the Node process, not to Bun.
  */
 function reexecUnderBunIfNeeded(): boolean {
-	const scriptPath = process.argv[1] ?? fileURLToPath(import.meta.url);
 	const options = processBunRuntimeOptions(existsSync, realpathSync);
+	let scriptRealPath = process.argv[1] ?? fileURLToPath(import.meta.url);
+	try {
+		// `~/.bun/bin/<name>` is a symlink into the global tree, so the link target is what has
+		// to be classified and re-executed. A path that cannot be resolved is simply used as-is;
+		// runtime selection must never be the reason startup fails.
+		scriptRealPath = realpathSync(scriptRealPath);
+	} catch {}
 	const decision = resolveBunReexec({
-		scriptRealPath: options.realpath(scriptPath),
+		scriptRealPath,
 		versions: process.versions,
 		hasInheritedInspectorOption: hasInheritedInspectorOption(),
 		options,
@@ -31,7 +37,7 @@ function reexecUnderBunIfNeeded(): boolean {
 	if (decision.action === "stay") {
 		return false;
 	}
-	const result = spawnSync(decision.bunPath, [options.realpath(scriptPath), ...process.argv.slice(2)], {
+	const result = spawnSync(decision.bunPath, [scriptRealPath, ...process.argv.slice(2)], {
 		stdio: "inherit",
 		windowsHide: true,
 	});

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -1,13 +1,51 @@
 #!/usr/bin/env node
 import "./valid-cwd.ts";
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { processBunRuntimeOptions, resolveBunReexec } from "./bun-runtime.ts";
 import { enableStartupCompileCache } from "./compile-cache.ts";
 import { APP_NAME, DISPLAY_VERSION, getPackageDir } from "./config.ts";
 import { hasInheritedInspectorOption, releaseInheritedInspectorForChild } from "./inspector-policy.ts";
 import { handleBootstrapSelfUpdate } from "./self-update-bootstrap.ts";
+
+/**
+ * Hand a Bun-installed CLI to Bun before anything else runs.
+ *
+ * `bun install -g` links this script into `~/.bun/bin`, but the shebang still starts it on Node,
+ * so a user who chose Bun silently gets the Node runtime. Re-exec through the Bun binary when the
+ * script really lives in Bun's global tree (or `SENPI_RUNTIME=bun` asks for it). This runs before
+ * `enableStartupCompileCache()` on purpose: a re-exec must not pay for Node's compile-cache setup.
+ * Node `execArgv` is deliberately dropped — those flags belong to the Node process, not to Bun.
+ */
+function reexecUnderBunIfNeeded(): boolean {
+	const scriptPath = process.argv[1] ?? fileURLToPath(import.meta.url);
+	const options = processBunRuntimeOptions(existsSync, realpathSync);
+	const decision = resolveBunReexec({
+		scriptRealPath: options.realpath(scriptPath),
+		versions: process.versions,
+		hasInheritedInspectorOption: hasInheritedInspectorOption(),
+		options,
+	});
+	if (decision.action === "stay") {
+		return false;
+	}
+	const result = spawnSync(decision.bunPath, [options.realpath(scriptPath), ...process.argv.slice(2)], {
+		stdio: "inherit",
+		windowsHide: true,
+	});
+	if (result.signal) {
+		process.kill(process.pid, result.signal);
+		return true;
+	}
+	process.exitCode = result.status ?? 1;
+	return true;
+}
+
+if (reexecUnderBunIfNeeded()) {
+	process.exit();
+}
 
 // Must run before cli-main is loaded, by either path: it caches the engine graph this process
 // imports on the fast path below, and it publishes NODE_COMPILE_CACHE so a spawned cli-main child

--- a/packages/coding-agent/test/bun-runtime.test.ts
+++ b/packages/coding-agent/test/bun-runtime.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import { type BunRuntimeOptions, findBunBinary, isUnderBunGlobalTree, resolveBunReexec } from "../src/bun-runtime.ts";
+
+/**
+ * Every case below injects its whole world (env, homedir, platform, filesystem probes).
+ * Nothing here may read the host PATH, the host HOME, or the real `~/.bun` install: CI
+ * runners ship real interpreters and a real bun, so a single host read is a latent failure.
+ */
+function options(overrides: Partial<BunRuntimeOptions> & { readonly files?: readonly string[] }): BunRuntimeOptions {
+	const files = new Set(overrides.files ?? []);
+	return {
+		env: overrides.env ?? {},
+		homedir: overrides.homedir ?? "/home/tester",
+		platform: overrides.platform ?? "linux",
+		exists: overrides.exists ?? ((path: string) => files.has(path)),
+		realpath: overrides.realpath ?? ((path: string) => path),
+	};
+}
+
+describe("isUnderBunGlobalTree", () => {
+	it("accepts a script inside the default bun global tree", () => {
+		const opts = options({ homedir: "/home/tester" });
+		const script = "/home/tester/.bun/install/global/node_modules/@code-yeongyu/senpi/dist/cli.js";
+		expect(isUnderBunGlobalTree(script, opts)).toBe(true);
+	});
+
+	it("prefers BUN_INSTALL over the home directory", () => {
+		const opts = options({ env: { BUN_INSTALL: "/opt/bun" }, homedir: "/home/tester" });
+		expect(isUnderBunGlobalTree("/opt/bun/install/global/node_modules/pkg/dist/cli.js", opts)).toBe(true);
+		expect(isUnderBunGlobalTree("/home/tester/.bun/install/global/node_modules/pkg/dist/cli.js", opts)).toBe(false);
+	});
+
+	it("rejects an npm global install", () => {
+		const opts = options({ homedir: "/home/tester" });
+		expect(isUnderBunGlobalTree("/usr/local/lib/node_modules/@code-yeongyu/senpi/dist/cli.js", opts)).toBe(false);
+	});
+
+	it("matches win32 paths written with backslashes", () => {
+		const opts = options({ platform: "win32", homedir: "C:\\Users\\tester" });
+		const script = "C:\\Users\\tester\\.bun\\install\\global\\node_modules\\@code-yeongyu\\senpi\\dist\\cli.js";
+		expect(isUnderBunGlobalTree(script, opts)).toBe(true);
+	});
+
+	it("matches a script under a symlinked install root", () => {
+		// macOS resolves `/tmp` to `/private/tmp`, so a script realpath never shares a literal
+		// prefix with a `BUN_INSTALL=/tmp/...` root until the root is resolved too.
+		const opts = options({
+			env: { BUN_INSTALL: "/tmp/bunroot" },
+			realpath: (path: string) => path.replace(/^\/tmp\//, "/private/tmp/"),
+		});
+		expect(isUnderBunGlobalTree("/private/tmp/bunroot/install/global/node_modules/pkg/dist/cli.js", opts)).toBe(true);
+	});
+
+	it("still matches when the install root cannot be resolved", () => {
+		const opts = options({
+			env: { BUN_INSTALL: "/opt/bun" },
+			realpath: () => {
+				throw new Error("ENOENT");
+			},
+		});
+		expect(isUnderBunGlobalTree("/opt/bun/install/global/node_modules/pkg/dist/cli.js", opts)).toBe(true);
+	});
+
+	it("does not treat a sibling directory as the global tree", () => {
+		const opts = options({ homedir: "/home/tester" });
+		expect(isUnderBunGlobalTree("/home/tester/.bun/install/globalish/pkg/cli.js", opts)).toBe(false);
+	});
+});
+
+describe("findBunBinary", () => {
+	it("prefers the BUN_INSTALL bin directory", () => {
+		const opts = options({
+			env: { BUN_INSTALL: "/opt/bun", PATH: "/usr/bin" },
+			files: ["/opt/bun/bin/bun", "/home/tester/.bun/bin/bun", "/usr/bin/bun"],
+		});
+		expect(findBunBinary(opts)).toBe("/opt/bun/bin/bun");
+	});
+
+	it("falls back to the home bun bin directory", () => {
+		const opts = options({
+			env: { PATH: "/usr/bin" },
+			files: ["/home/tester/.bun/bin/bun", "/usr/bin/bun"],
+		});
+		expect(findBunBinary(opts)).toBe("/home/tester/.bun/bin/bun");
+	});
+
+	it("falls back to a PATH scan", () => {
+		const opts = options({
+			env: { PATH: "/empty:/usr/local/bin" },
+			files: ["/usr/local/bin/bun"],
+		});
+		expect(findBunBinary(opts)).toBe("/usr/local/bin/bun");
+	});
+
+	it("returns undefined when bun is nowhere", () => {
+		expect(findBunBinary(options({ env: { PATH: "/usr/bin" } }))).toBeUndefined();
+	});
+
+	it("discovers bun.exe through PATHEXT on win32", () => {
+		const opts = options({
+			platform: "win32",
+			homedir: "C:\\Users\\tester",
+			env: { PATH: "C:\\tools", PATHEXT: ".COM;.EXE;.BAT" },
+			files: ["C:\\tools\\bun.EXE"],
+		});
+		expect(findBunBinary(opts)).toBe("C:\\tools\\bun.EXE");
+	});
+
+	it("prefers the win32 BUN_INSTALL bin bun.exe", () => {
+		const opts = options({
+			platform: "win32",
+			homedir: "C:\\Users\\tester",
+			env: { BUN_INSTALL: "C:\\bun", PATH: "C:\\tools", PATHEXT: ".EXE" },
+			files: ["C:\\bun\\bin\\bun.exe", "C:\\tools\\bun.exe"],
+		});
+		expect(findBunBinary(opts)).toBe("C:\\bun\\bin\\bun.exe");
+	});
+});
+
+describe("resolveBunReexec", () => {
+	const bunTreeScript = "/opt/bun/install/global/node_modules/@code-yeongyu/senpi/dist/cli.js";
+
+	it("stays when already running under bun", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: bunTreeScript,
+			versions: { bun: "1.2.3" },
+			hasInheritedInspectorOption: false,
+			options: options({ env: { BUN_INSTALL: "/opt/bun" }, files: ["/opt/bun/bin/bun"] }),
+		});
+		expect(result).toEqual({ action: "stay", reason: "already-bun" });
+	});
+
+	it("stays when SENPI_RUNTIME pins node, even inside the bun tree", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: bunTreeScript,
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({
+				env: { BUN_INSTALL: "/opt/bun", SENPI_RUNTIME: "node" },
+				files: ["/opt/bun/bin/bun"],
+			}),
+		});
+		expect(result).toEqual({ action: "stay", reason: "runtime-pinned-node" });
+	});
+
+	it("stays under an inherited inspector option so debugger sessions keep node", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: bunTreeScript,
+			versions: {},
+			hasInheritedInspectorOption: true,
+			options: options({
+				env: { BUN_INSTALL: "/opt/bun", SENPI_RUNTIME: "bun" },
+				files: ["/opt/bun/bin/bun"],
+			}),
+		});
+		expect(result).toEqual({ action: "stay", reason: "inspector" });
+	});
+
+	it("re-execs when SENPI_RUNTIME requests bun and bun exists outside the tree", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: "/usr/local/lib/node_modules/@code-yeongyu/senpi/dist/cli.js",
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({ env: { BUN_INSTALL: "/opt/bun", SENPI_RUNTIME: "bun" }, files: ["/opt/bun/bin/bun"] }),
+		});
+		expect(result).toEqual({ action: "reexec", bunPath: "/opt/bun/bin/bun" });
+	});
+
+	it("stays when SENPI_RUNTIME requests bun but no bun binary exists", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: "/usr/local/lib/node_modules/@code-yeongyu/senpi/dist/cli.js",
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({ env: { BUN_INSTALL: "/opt/bun", SENPI_RUNTIME: "bun", PATH: "/usr/bin" } }),
+		});
+		expect(result).toEqual({ action: "stay", reason: "bun-not-found" });
+	});
+
+	it("re-execs a bun-tree script whose install root is reached through a symlink", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: "/private/tmp/bunroot/install/global/node_modules/@code-yeongyu/senpi/dist/cli.js",
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({
+				env: { BUN_INSTALL: "/tmp/bunroot" },
+				files: ["/tmp/bunroot/bin/bun"],
+				realpath: (path: string) => path.replace(/^\/tmp\//, "/private/tmp/"),
+			}),
+		});
+		expect(result).toEqual({ action: "reexec", bunPath: "/tmp/bunroot/bin/bun" });
+	});
+
+	it("re-execs a script that lives in the bun global tree", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: bunTreeScript,
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({ env: { BUN_INSTALL: "/opt/bun" }, files: ["/opt/bun/bin/bun"] }),
+		});
+		expect(result).toEqual({ action: "reexec", bunPath: "/opt/bun/bin/bun" });
+	});
+
+	it("re-execs the realpath of a ~/.bun/bin symlink resolved by the caller", () => {
+		// `~/.bun/bin/senpi` is a symlink into the global tree; the caller passes the
+		// already-realpathed target, which is what must be classified.
+		const result = resolveBunReexec({
+			scriptRealPath: "/home/tester/.bun/install/global/node_modules/@code-yeongyu/senpi/dist/cli.js",
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({ homedir: "/home/tester", files: ["/home/tester/.bun/bin/bun"] }),
+		});
+		expect(result).toEqual({ action: "reexec", bunPath: "/home/tester/.bun/bin/bun" });
+	});
+
+	it("stays inside the bun tree when no bun binary is installed", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: bunTreeScript,
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({ env: { BUN_INSTALL: "/opt/bun", PATH: "/usr/bin" } }),
+		});
+		expect(result).toEqual({ action: "stay", reason: "bun-not-found" });
+	});
+
+	it("stays for a plain node install outside the bun tree", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: "/usr/local/lib/node_modules/@code-yeongyu/senpi/dist/cli.js",
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({ env: { BUN_INSTALL: "/opt/bun" }, files: ["/opt/bun/bin/bun"] }),
+		});
+		expect(result).toEqual({ action: "stay", reason: "not-bun-install" });
+	});
+
+	it("ignores an unknown SENPI_RUNTIME value and falls through to tree detection", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: bunTreeScript,
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({ env: { BUN_INSTALL: "/opt/bun", SENPI_RUNTIME: "deno" }, files: ["/opt/bun/bin/bun"] }),
+		});
+		expect(result).toEqual({ action: "reexec", bunPath: "/opt/bun/bin/bun" });
+	});
+
+	it("re-execs a win32 bun-tree script with a bun.exe discovered through PATHEXT", () => {
+		const result = resolveBunReexec({
+			scriptRealPath: "C:\\Users\\tester\\.bun\\install\\global\\node_modules\\@code-yeongyu\\senpi\\dist\\cli.js",
+			versions: {},
+			hasInheritedInspectorOption: false,
+			options: options({
+				platform: "win32",
+				homedir: "C:\\Users\\tester",
+				env: { PATH: "C:\\tools", PATHEXT: ".EXE" },
+				files: ["C:\\Users\\tester\\.bun\\bin\\bun.exe"],
+			}),
+		});
+		expect(result).toEqual({ action: "reexec", bunPath: "C:\\Users\\tester\\.bun\\bin\\bun.exe" });
+	});
+});


### PR DESCRIPTION
## Summary

A CLI installed with `bun install -g` was running on Node. `bun install -g` links the entry script into `~/.bun/bin`, but the shebang still selects Node, so a user who deliberately chose Bun silently got the Node runtime. The entry point now detects that its own script lives in Bun's global install tree and re-execs itself through the installed `bun` binary.

Explicit control stays with the user: `SENPI_RUNTIME=node` forces Node, `SENPI_RUNTIME=bun` requests Bun for any install. Detection never breaks a working setup — a process already on Bun never re-execs, an inherited `--inspect` option keeps the debugger session on Node, and a missing `bun` binary silently stays on Node.

## Changes

- **`packages/coding-agent/src/bun-runtime.ts`** (new, fork-only): pure helpers with a fully injected view of the world (`env`, `homedir`, `platform`, `exists`, `realpath`).
  - `isUnderBunGlobalTree(scriptRealPath, options)` — compares the script's real path against `<BUN_ROOT>/install/global/`, where `BUN_ROOT` is `BUN_INSTALL` or `~/.bun`. Paths are normalized to `/` so Windows matches, and the tree root is compared both as configured and as resolved, so a symlinked install root (`/tmp` → `/private/tmp` on macOS) still matches. Path joining/splitting follows the *injected* platform, not the host's.
  - `findBunBinary(options)` — `BUN_INSTALL/bin/bun` → `~/.bun/bin/bun` → PATH scan, honoring `PATHEXT` and `bun.exe` on win32. Returns `undefined` when Bun is absent; that is never an error.
  - `resolveBunReexec(input)` — one first-match-wins decision returning `{action:"stay",reason}` or `{action:"reexec",bunPath}`: already-bun → stay; `SENPI_RUNTIME=node` → stay; inherited inspector → stay; `SENPI_RUNTIME=bun` + bun found → re-exec; script in the bun tree + bun found → re-exec; otherwise stay.
- **`packages/coding-agent/src/cli.ts`**: runs the check as the first statement, ahead of `enableStartupCompileCache()`, so a re-exec pays for none of Node's compile-cache setup. It realpaths `process.argv[1]` (the `~/.bun/bin/<name>` symlink target is what must be classified), reuses the existing `hasInheritedInspectorOption()`, and on a re-exec decision runs `spawnSync(bun, [script, ...argv.slice(2)], { stdio: "inherit", windowsHide: true })`, propagates the child's signal or exit status, and exits without loading the rest of the entry flow. Node `execArgv` is deliberately dropped: those flags belong to the Node process, not to Bun. A script path that cannot be resolved is used as-is — runtime selection must never be the reason startup fails.
- **`packages/coding-agent/test/bun-runtime.test.ts`** (new): 25 hermetic contracts over the decision table, tree detection, symlinked and unresolvable install roots, PATH/PATHEXT discovery, and win32 backslash paths. Every input is injected; nothing reads the host PATH, host `HOME`, or the real `~/.bun`, so the Windows CI shards evaluate the same fixtures as the POSIX ones.
- **`packages/coding-agent/dist/cli.js`**: the committed bin-target stub recompiled from the source change, matching prior cli.ts fixes.
- Release `CHANGELOG.md` `[Unreleased] / Added` entry and a `packages/coding-agent/src/changes.md` tracker entry covering the upstream-owned `src/cli.ts` edit.

## QA & Evidence

Real-surface QA against the built `dist/cli.js`, using a temp dir with a fake logging `bun` shim (an `sh` script that appends its argv to a log and exits 0). The real `~/.bun` was never read or written.

Transcript: `local-ignore/qa-evidence/20260822-cli-bun-auto-runtime/qa-final-transcript.txt`

| Case | Setup | Result |
|---|---|---|
| a | `SENPI_RUNTIME=bun`, script outside the tree | re-exec; shim logged `.../dist/cli.js --version` |
| b | `SENPI_RUNTIME=node` | `2026.8.22` printed on Node; shim never invoked |
| c | no pin, script outside the tree | version on Node; shim never invoked |
| d | no pin, script inside a fake `BUN_INSTALL` global tree | auto re-exec; shim logged the resolved script path + argv |
| e | inside the tree, `SENPI_RUNTIME=node` | opt-out kept Node; shim never invoked |
| f | inside the tree, `node --inspect=0` | debugger kept Node; shim never invoked |

Case (d) caught a real defect during QA: the tree root was compared unresolved while the script path was realpathed, so macOS's `/tmp` → `/private/tmp` aliasing defeated auto-detection. Fixed, and pinned by two added hermetic tests.

Other evidence in the same directory:
- `red-bun-runtime.txt` — failing run captured before the implementation existed.
- `green-bun-runtime.txt` — bun-runtime plus the neighbouring CLI entry suites, 39 passed.
- `package-suite.txt` — full `@code-yeongyu/senpi` suite, 1058 files / 8659 tests passed.
- `root-check.txt` — root `npm run check`, exit 0.

Temp QA dir removed after capture; no `~/.bun` mutation at any point.

## Risks

- **Startup-path change.** The check is the first statement in the entry flow, so a defect here would affect every invocation. It is pure except for `existsSync`/`realpathSync` probes, `realpathSync` failure is swallowed, and cases (b), (c), (e), (f) confirm the untouched Node path still prints normally.
- **Unwanted re-exec.** Only a script physically under `<BUN_ROOT>/install/global/`, or an explicit `SENPI_RUNTIME=bun`, triggers it; npm/pnpm/yarn installs are unaffected (case c).
- **Behavior differences under Bun.** Users who installed with Bun now actually get Bun. `SENPI_RUNTIME=node` is the one-variable escape hatch, and the changelog documents it.
- **Dropped `execArgv`.** Node-only flags cannot be forwarded to Bun. Debugger runs are explicitly excluded from re-exec so the common case keeps working.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-execs Bun-installed CLIs under Bun instead of silently running on Node. Previously `bun install -g` linked the CLI but the shebang started Node; now the entry point detects Bun’s global install tree and re-execs through the installed `bun` binary when appropriate.

- Adds `packages/coding-agent/src/bun-runtime.ts`: pure, injectable helpers to detect the Bun global tree, honor `SENPI_RUNTIME` pins, skip debugger sessions, and discover `bun` via `BUN_INSTALL`, `~/.bun`, or PATH (with `PATHEXT` on win32). Handles symlinked roots and path normalization.
- Updates `packages/coding-agent/src/cli.ts`: runs the check first, realpaths the script, re-execs via `spawnSync(bun, [script, ...argv])`, propagates signals/status, exits early, and deliberately drops Node `execArgv`. Updates `packages/coding-agent/dist/cli.js` accordingly.
- Adds `packages/coding-agent/test/bun-runtime.test.ts`: hermetic tests across platforms, PATH/PATHEXT, symlinked roots, and decision table. Updates `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/src/changes.md`.

**Rollout and migration**
- No action required. Only Bun-global installs change behavior; other installs stay on Node.
- To force Node: set `SENPI_RUNTIME=node`. To request Bun: set `SENPI_RUNTIME=bun`.
- Debugger sessions (`--inspect*`) and processes already on Bun stay on their current runtime. If `bun` is missing, the CLI stays on Node. Node-only flags are not forwarded to Bun; pin Node if needed.

<sup>Written for commit f37f589d89cf0e869355528b4ba849b932d14167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

