### PR TITLE
feat(codemode): tick running eval elapsed time live in the TUI

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- Running eval cell headers now tick their elapsed time in real time (`eval py running · 13s`) instead of freezing between kernel update events; the renderer derives elapsed time from a render-time clock while a cell is pending/running/detached and repaints once per second, while settled cells keep their exact final duration. `EvalCellResult` gains an additive `startedAt` so RPC consumers can compute the same live value.
+
 ### Fixed
 
 ### Removed

--- a/packages/senpi-codemode/scripts/qa-live-elapsed.ts
+++ b/packages/senpi-codemode/scripts/qa-live-elapsed.ts
@@ -1,0 +1,90 @@
+/**
+ * QA driver: proves a RUNNING eval cell's header elapsed time advances between renders
+ * of the SAME component, and that the repaint ticker stops once the cell settles.
+ */
+import { renderEvalResult } from "../src/tool/render.ts";
+import type { EvalCellResult, EvalToolDetails } from "../src/tool/types.ts";
+
+const STARTED_AT = Date.now();
+
+function details(cell: Partial<EvalCellResult>): EvalToolDetails {
+	return {
+		language: "py",
+		durationMs: 0,
+		toolCalls: [],
+		truncated: false,
+		cells: [
+			{
+				index: 0,
+				summary: "crunch the dataset",
+				code: "run()",
+				language: "py",
+				output: "",
+				status: "running",
+				startedAt: STARTED_AT,
+				...cell,
+			},
+		],
+	};
+}
+
+type RenderContext = Parameters<typeof renderEvalResult>[3];
+
+function context(now: number, invalidate: () => void, lastComponent?: ReturnType<typeof renderEvalResult>) {
+	return {
+		args: { language: "py", code: "run()", summary: "crunch the dataset" },
+		toolCallId: "qa-live-elapsed",
+		invalidate,
+		lastComponent,
+		state: {},
+		cwd: "/tmp",
+		executionStarted: true,
+		argsComplete: true,
+		isPartial: true,
+		expanded: false,
+		showImages: false,
+		imageProtocol: null,
+		isError: false,
+		now,
+	} as unknown as RenderContext;
+}
+
+function header(lines: readonly string[]): string {
+	return (lines[0] ?? "").replace(/\u001b\[[0-9;]*m/gu, "");
+}
+
+let repaints = 0;
+const invalidate = (): void => {
+	repaints += 1;
+};
+
+const running = details({});
+const first = renderEvalResult({ content: [], details: running }, { expanded: false, isPartial: true }, undefined, context(STARTED_AT + 1_500, invalidate));
+console.log(`render @ +1500ms : ${header(first.render(80))}`);
+
+const second = renderEvalResult(
+	{ content: [], details: running },
+	{ expanded: false, isPartial: true },
+	undefined,
+	context(STARTED_AT + 2_600, invalidate, first),
+);
+console.log(`render @ +2600ms : ${header(second.render(80))}`);
+
+const sameComponent = first === second;
+console.log(`same component reused: ${sameComponent}`);
+
+await new Promise((resolve) => setTimeout(resolve, 2_200));
+console.log(`repaints requested while running: ${repaints} (expect >= 2)`);
+
+const settled = details({ status: "complete", durationMs: 2_600 });
+const done = renderEvalResult(
+	{ content: [], details: settled },
+	{ expanded: false, isPartial: false },
+	undefined,
+	context(STARTED_AT + 900_000, invalidate, second),
+);
+console.log(`render terminal    : ${header(done.render(80))}`);
+
+const afterTerminal = repaints;
+await new Promise((resolve) => setTimeout(resolve, 2_200));
+console.log(`repaints after terminal render: ${repaints - afterTerminal} (expect 0 - ticker cleared)`);

--- a/packages/senpi-codemode/src/tool/cell-runtime.ts
+++ b/packages/senpi-codemode/src/tool/cell-runtime.ts
@@ -145,6 +145,7 @@ export class CellResultBuilder {
 					output: this.#state.output,
 					status: this.#state.status,
 					durationMs: this.#state.durationMs,
+					startedAt: this.#state.startedAt,
 					...(statusEvents === undefined ? {} : { statusEvents }),
 					...(output?.hasMarkdown ? { hasMarkdown: true } : {}),
 				},

--- a/packages/senpi-codemode/src/tool/render.ts
+++ b/packages/senpi-codemode/src/tool/render.ts
@@ -70,12 +70,36 @@ const TOOL_CALL_PREVIEW_COUNT = 5;
 const TOOL_CALL_COLLAPSED_VISUAL_LINES = 4;
 const TOOL_CALL_COLLAPSED_ERROR_CODE_POINTS = 512;
 const TOOL_ERROR_OMISSION_MARKER = "[tool error omitted]";
+const LIVE_ELAPSED_TICK_MS = 1_000;
 
 class PlainTextComponent implements EvalRenderComponent {
 	#blocks: readonly RenderBlock[] = [];
+	#ticker: ReturnType<typeof setInterval> | undefined;
 
 	setBlocks(blocks: readonly RenderBlock[]): void {
 		this.#blocks = blocks;
+	}
+
+	/**
+	 * The host only animates tool rows for streaming args, `task`, and results carrying
+	 * `details.progress`; an eval row matches none of them, so nothing repaints it between
+	 * update events. While a cell is non-terminal this drives the repaint itself so the
+	 * header's elapsed time advances, and it emits no tool updates or RPC traffic.
+	 */
+	syncLiveTicker(isLive: boolean, invalidate: () => void): void {
+		if (!isLive) {
+			this.stopLiveTicker();
+			return;
+		}
+		if (this.#ticker !== undefined) return;
+		this.#ticker = setInterval(invalidate, LIVE_ELAPSED_TICK_MS);
+		this.#ticker.unref?.();
+	}
+
+	stopLiveTicker(): void {
+		if (this.#ticker === undefined) return;
+		clearInterval(this.#ticker);
+		this.#ticker = undefined;
 	}
 
 	render(width: number): string[] {
@@ -108,6 +132,16 @@ function componentFor(context: RenderContext | ResultRenderContext): PlainTextCo
 	const existing = context.lastComponent;
 	if (existing instanceof PlainTextComponent) return existing;
 	return new PlainTextComponent();
+}
+
+/** Render-time clock; tests inject a fixed value so elapsed output never depends on wall time. */
+function renderNow(context: RenderContext | ResultRenderContext): number {
+	const injected: unknown = Reflect.get(context, "now");
+	return typeof injected === "number" && Number.isFinite(injected) ? injected : Date.now();
+}
+
+function hasLiveCell(details: EvalToolDetails | undefined): boolean {
+	return (details?.cells ?? []).some((cell) => isLiveCellStatus(cell.status) && cell.startedAt !== undefined);
 }
 
 function style(theme: Theme | undefined, color: ThemeColor, text: string): string {
@@ -188,6 +222,8 @@ type RenderEnvironment = {
 	readonly spinnerFrame: number | undefined;
 	readonly width: number;
 	readonly meta: TruncationMeta | undefined;
+	/** Render-time clock, injected so elapsed time is deterministic under test. */
+	readonly now: number;
 };
 type CellBadges = {
 	readonly reset: boolean;
@@ -232,6 +268,10 @@ function spinner(frame: number | undefined): string {
 	return SPINNER_FRAMES.at((frame ?? 0) % SPINNER_FRAMES.length) ?? SPINNER_FRAMES[0];
 }
 
+function isLiveCellStatus(status: CellStatus): boolean {
+	return status === "pending" || status === "running" || status === "detached";
+}
+
 function cellPresentation(status: CellStatus, spinnerFrame: number | undefined): StatusPresentation {
 	switch (status) {
 		case "pending":
@@ -260,13 +300,21 @@ function renderPrefixed(text: string, environment: RenderEnvironment, prefixStyl
 	);
 }
 
+// A running cell only receives updates on output/status events, so a stored duration
+// freezes between them. Non-terminal cells therefore derive elapsed time from the
+// render-time clock; terminal cells keep their settled duration verbatim.
+function cellElapsedMs(cell: EvalCellResult, environment: RenderEnvironment): number | undefined {
+	if (!isLiveCellStatus(cell.status) || cell.startedAt === undefined) return cell.durationMs;
+	return Math.max(0, environment.now - cell.startedAt);
+}
+
 function cellHeader(cell: EvalCellResult, environment: RenderEnvironment, badges: CellBadges): string {
 	const presentation = cellPresentation(cell.status, environment.spinnerFrame);
 	const runtimeBadge = cell.runtime === undefined ? "" : ` (${formatRuntimeBadge(cell.language, cell.runtime)})`;
 	let header = `eval ${cell.language}${runtimeBadge} ${presentation.label} ${presentation.icon}`;
 	const throughputBadge = badges.throughput === undefined ? undefined : formatThroughputBadge(badges.throughput);
 	if (throughputBadge !== undefined) header += ` · ${throughputBadge}`;
-	const elapsedMs = badges.throughput?.wallDurationMs ?? cell.durationMs;
+	const elapsedMs = badges.throughput?.wallDurationMs ?? cellElapsedMs(cell, environment);
 	if (elapsedMs !== undefined) header += ` · ${formatDuration(elapsedMs)}`;
 	if (badges.reset) header += " · reset";
 	if (badges.timeout !== undefined) header += ` · timeout ${badges.timeout}s`;
@@ -847,6 +895,7 @@ export function renderEvalCall(
 					spinnerFrame: context.spinnerFrame,
 					width,
 					meta: undefined,
+					now: renderNow(context),
 				};
 				const cell: EvalCellResult = {
 					index: 0,
@@ -877,6 +926,7 @@ export function renderEvalResult(
 	const details = result.details;
 	const expanded = options.expanded || context.expanded;
 	const imageProtocol = context.imageProtocol ?? null;
+	component.syncLiveTicker(hasLiveCell(details), context.invalidate);
 	if (details?.cells !== undefined && details.cells.length > 0) {
 		const blocks: RenderBlock[] = [
 			{
@@ -889,6 +939,7 @@ export function renderEvalResult(
 							spinnerFrame: context.spinnerFrame,
 							width,
 							meta: details.meta,
+							now: renderNow(context),
 						},
 						args: context.args,
 						showImageFallback: context.showImages && imageProtocol === null,
@@ -940,6 +991,7 @@ export function renderEvalResult(
 						spinnerFrame: context.spinnerFrame,
 						width,
 						meta: details?.meta,
+						now: renderNow(context),
 					};
 					return [
 						...renderStatusEvents(nonAgentEvents, environment),
@@ -961,6 +1013,7 @@ export function renderEvalResult(
 						spinnerFrame: context.spinnerFrame,
 						width,
 						meta: details?.meta,
+						now: renderNow(context),
 					}),
 			},
 		);

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -165,6 +165,8 @@ export type EvalCellResult = {
 	readonly status: "pending" | "running" | "detached" | "complete" | "error" | "cancelled";
 	readonly exitCode?: number;
 	readonly durationMs?: number;
+	/** Epoch ms when the cell started; lets renderers tick elapsed time between update events. */
+	readonly startedAt?: number;
 	readonly statusEvents?: readonly EvalStatusEvent[];
 	readonly hasMarkdown?: boolean;
 };

--- a/packages/senpi-codemode/test/eval-cell-started-at.test.ts
+++ b/packages/senpi-codemode/test/eval-cell-started-at.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { CellResultBuilder, type CellState } from "../src/tool/cell-runtime.ts";
+
+const STARTED_AT = 1_700_000_000_000;
+
+function makeState(): CellState {
+	return {
+		input: { language: "py", code: "1", summary: "startedAt propagation" },
+		startedAt: STARTED_AT,
+		signal: new AbortController().signal,
+		onUpdate: undefined,
+		toolCalls: [],
+		toolCallMetrics: [],
+		pendingBridgeCalls: [],
+		statusEvents: [],
+		active: true,
+		output: "",
+		phase: undefined,
+		error: undefined,
+		durationMs: 0,
+		status: "pending",
+	};
+}
+
+function makeBuilder(state: CellState): CellResultBuilder {
+	return new CellResultBuilder({ state, headBytes: 4096, maxColumns: 120, model: undefined });
+}
+
+describe("cell result startedAt propagation", () => {
+	it("stamps the live cell payload with the cell start time so renderers can tick", () => {
+		const builder = makeBuilder(makeState());
+
+		const live = builder.liveResult();
+
+		expect(live.details.cells?.[0]?.startedAt).toBe(STARTED_AT);
+	});
+
+	it("keeps startedAt on the settled cell payload for RPC consumers", async () => {
+		const builder = makeBuilder(makeState());
+
+		const result = await builder.finalize({ type: "result", cellId: "cell-1", ok: true, durationMs: 5 });
+
+		expect(result.details.cells?.[0]?.startedAt).toBe(STARTED_AT);
+		expect(result.details.cells?.[0]?.durationMs).toBe(5);
+	});
+});

--- a/packages/senpi-codemode/test/eval-render-elapsed.test.ts
+++ b/packages/senpi-codemode/test/eval-render-elapsed.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderEvalResult } from "../src/tool/render.ts";
+import type { EvalCellResult, EvalToolDetails } from "../src/tool/types.ts";
+import { evalResult, renderLines, resultContext, stripAnsi } from "./eval-render-fixtures.ts";
+
+const STARTED_AT = 1_700_000_000_000;
+
+function detailsWithCell(cell: Partial<EvalCellResult>): EvalToolDetails {
+	return {
+		language: "py",
+		durationMs: 0,
+		toolCalls: [],
+		truncated: false,
+		cells: [
+			{
+				index: 0,
+				code: "print(1)",
+				language: "py",
+				output: "",
+				status: "running",
+				...cell,
+			},
+		],
+	};
+}
+
+function headerFor(details: EvalToolDetails, now?: number): string {
+	const rendered = renderLines(
+		renderEvalResult(
+			evalResult(details, "running"),
+			{ expanded: false, isPartial: true },
+			undefined,
+			resultContext(now === undefined ? {} : { now }),
+		),
+	);
+	return stripAnsi(rendered[0] ?? "");
+}
+
+describe("eval renderer live elapsed time", () => {
+	it("derives a running cell's elapsed time from the injected clock, not the last update event", () => {
+		const details = detailsWithCell({ status: "running", startedAt: STARTED_AT, durationMs: 0 });
+
+		expect(headerFor(details, STARTED_AT + 13_000)).toContain("13s");
+	});
+
+	it("advances the displayed elapsed time as the injected clock advances", () => {
+		const details = detailsWithCell({ status: "running", startedAt: STARTED_AT, durationMs: 0 });
+
+		const early = headerFor(details, STARTED_AT + 4_000);
+		const later = headerFor(details, STARTED_AT + 47_000);
+
+		expect(early).toContain("4s");
+		expect(later).toContain("47s");
+		expect(early).not.toBe(later);
+	});
+
+	it.each(["pending", "detached"] as const)("ticks live for the non-terminal %s status", (status) => {
+		const details = detailsWithCell({ status, startedAt: STARTED_AT, durationMs: 0 });
+
+		expect(headerFor(details, STARTED_AT + 8_000)).toContain("8s");
+	});
+
+	it.each(["complete", "error", "cancelled"] as const)(
+		"keeps the settled durationMs for the terminal %s status",
+		(status) => {
+			const details = detailsWithCell({ status, startedAt: STARTED_AT, durationMs: 2_000 });
+
+			const header = headerFor(details, STARTED_AT + 900_000);
+
+			expect(header).toContain("2s");
+			expect(header).not.toContain("15m");
+		},
+	);
+
+	it("renders byte-identically to the no-clock baseline when the cell has no startedAt", () => {
+		const details = detailsWithCell({ status: "running", durationMs: 4_500 });
+
+		expect(headerFor(details, STARTED_AT + 600_000)).toBe(headerFor(details));
+	});
+});
+
+describe("eval renderer live elapsed repaint", () => {
+	it("schedules repaints about once per second while the cell is non-terminal", () => {
+		vi.useFakeTimers();
+		try {
+			const invalidate = vi.fn();
+			const details = detailsWithCell({ status: "running", startedAt: STARTED_AT, durationMs: 0 });
+
+			const component = renderEvalResult(
+				evalResult(details, "running"),
+				{ expanded: false, isPartial: true },
+				undefined,
+				resultContext({ invalidate, now: STARTED_AT }),
+			);
+			component.render(80);
+
+			expect(invalidate).not.toHaveBeenCalled();
+			vi.advanceTimersByTime(1_000);
+			expect(invalidate).toHaveBeenCalledTimes(1);
+			vi.advanceTimersByTime(2_000);
+			expect(invalidate).toHaveBeenCalledTimes(3);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("stops repainting once the cell reaches a terminal status", () => {
+		vi.useFakeTimers();
+		try {
+			const invalidate = vi.fn();
+			const running = detailsWithCell({ status: "running", startedAt: STARTED_AT, durationMs: 0 });
+			const component = renderEvalResult(
+				evalResult(running, "running"),
+				{ expanded: false, isPartial: true },
+				undefined,
+				resultContext({ invalidate, now: STARTED_AT }),
+			);
+			component.render(80);
+			vi.advanceTimersByTime(1_000);
+			const beforeTerminal = invalidate.mock.calls.length;
+
+			const done = detailsWithCell({ status: "complete", startedAt: STARTED_AT, durationMs: 1_500 });
+			const settled = renderEvalResult(
+				evalResult(done, "done"),
+				{ expanded: false, isPartial: false },
+				undefined,
+				resultContext({ invalidate, now: STARTED_AT + 1_500, lastComponent: component }),
+			);
+			settled.render(80);
+			vi.advanceTimersByTime(10_000);
+
+			expect(invalidate).toHaveBeenCalledTimes(beforeTerminal);
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/packages/senpi-codemode/test/eval-render-fixtures.ts
+++ b/packages/senpi-codemode/test/eval-render-fixtures.ts
@@ -16,6 +16,9 @@ export interface RenderContextOptions {
 	readonly spinnerFrame?: number;
 	readonly hasResult?: boolean;
 	readonly args?: EvalToolInput;
+	/** Fixed render-time clock in epoch ms; keeps elapsed-time assertions off wall time. */
+	readonly now?: number;
+	readonly invalidate?: () => void;
 }
 
 function isEvalComponent(input: EvalComponent | RenderContextOptions): input is EvalComponent {
@@ -38,7 +41,8 @@ export function callContext(input?: EvalComponent | RenderContextOptions): CallC
 	return {
 		args: options.args ?? { language: "js", code: "", summary: "render fixture" },
 		toolCallId: "eval-render-call",
-		invalidate: () => {},
+		invalidate: options.invalidate ?? (() => {}),
+		...(options.now === undefined ? {} : { now: options.now }),
 		lastComponent: options.lastComponent,
 		state: {},
 		cwd: "/tmp",
@@ -61,7 +65,8 @@ export function resultContext(input?: EvalComponent | RenderContextOptions, show
 	return {
 		args: options.args ?? { language: "js", code: "", summary: "render fixture" },
 		toolCallId: "eval-render-result",
-		invalidate: () => {},
+		invalidate: options.invalidate ?? (() => {}),
+		...(options.now === undefined ? {} : { now: options.now }),
 		lastComponent: options.lastComponent,
 		state: {},
 		cwd: "/tmp",


### PR DESCRIPTION
## Summary

A running `eval` cell rendered its header as `eval py running · 4.5s`, but that number came from `EvalCellResult.durationMs` / `details.wallDurationMs`, both computed at the **last update event**. `CellResultBuilder` only emits updates on output/status/tool-call events, so between events the time was frozen while the spinner kept animating — a cell blocked on a slow network call looked stuck at whatever value it had when it last printed.

The elapsed time now advances in real time at second granularity while a cell is pending/running/detached. Terminal cells (complete/error/cancelled) keep today's final `durationMs` exactly.

## Changes

- **`src/tool/types.ts`** — `EvalCellResult` gains an optional, additive `readonly startedAt?: number` (epoch ms). Cells without it render byte-identically to before.
- **`src/tool/cell-runtime.ts`** — `CellResultBuilder` emits `startedAt` on its cell payload, sourced from the `startedAt` already on `CellState`. RPC consumers receive it too, so remote UIs can compute the same live value.
- **`src/tool/render.ts`** — `RenderEnvironment` gains an injectable `now`. For non-terminal statuses with a `startedAt`, elapsed time is computed at render time and formatted through the existing `formatDuration`; terminal statuses are untouched.

### Repaint cadence: a timer was required

Investigated rather than assumed. `updateSpinnerAnimation()` in `packages/coding-agent/src/modes/interactive/components/tool-execution.ts` starts the host repaint interval for only three cases: streaming args (`edit`/`write`/`apply_patch`), a partial `task`, and a result carrying `details.progress.startedAt` (per `readToolProgress`). **An eval row matches none of them** — eval details have no `progress` field — and `ToolExecutionComponent.render()` is memoized on a render signature that is stable while `spinnerFrame` stays `undefined`. So repaints happen only on data updates, and render-time computation alone would still look frozen.

The renderer therefore owns the liveness itself: `PlainTextComponent` starts a 1s `setInterval` calling `context.invalidate()` while a cell is live, and clears it on the terminal render. The interval is `unref()`'d, is one timer per eval row, and the package invariant that every cell settles exactly once guarantees the clearing render arrives. **Zero per-second `onUpdate`/RPC emissions** — liveness is entirely renderer-local, exactly as specified.

## QA & Evidence

Transcripts (gitignored, `local-ignore/qa-evidence/20260822-eval-live-elapsed/`):

- `red-transcript.txt` — RED first: 7 failing contracts, e.g. `expected '╭─ eval py running ⠋ · <1s' to contain '13s'` and `expected undefined to be 1700000000000`.
- `green-transcript.txt` — full package suite: **90 files / 608 tests passed**, 0 failed.
- `check-transcript.txt` — `npm run check` at repo root, exit 0.
- `qa-render-pair.txt` — real-surface render-pair proof, same component rendered twice with an advancing clock:

```
render @ +1500ms : ╭─ eval py running ⠋ · 1s
render @ +2600ms : ╭─ eval py running ⠋ · 2s
same component reused: true
repaints requested while running: 2 (expect >= 2)
render terminal    : ╭─ eval py done ✓ · 2s
repaints after terminal render: 0 (expect 0 - ticker cleared)
```

New hermetic contracts in `test/eval-render-elapsed.test.ts` and `test/eval-cell-started-at.test.ts`: live value from an injected clock, a *different* clock yielding a different value, live ticking for pending/detached, terminal statuses pinned to `durationMs`, a byte-identical characterization pin for cells without `startedAt`, builder propagation, and timer-leak coverage (repaints stop and `vi.getTimerCount()` is 0 after the terminal render). They use fixed epoch constants and `vi.useFakeTimers()` — no wall-clock reads, no sleeps, no host state, so the Windows shards are unaffected.

## Risks

- **Low.** The type change is additive and optional; the no-`startedAt` path is pinned by a characterization test, and the existing runtime-badge headers on `main` are preserved (their tests still pass).
- The only new runtime resource is one `unref()`'d 1s interval per live eval row, cleared on the terminal render and proven to stop in QA. Worst case, if a cell were somehow abandoned before settling, an `unref()`'d timer cannot hold the process open.
- `renderNow()` reads `now` reflectively because the injected clock is not part of the host's shared `ToolRenderContext`; it falls back to `Date.now()` whenever absent or non-finite, which is the production path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Running eval cell headers now tick elapsed time live in the TUI instead of freezing between kernel updates. Previously the header used the last `durationMs`; now non-terminal cells compute elapsed at render time from a start timestamp while terminal cells keep their final `durationMs`.

- Adds optional `startedAt` to `EvalCellResult`; `CellResultBuilder` emits it so renderers and RPC UIs can derive live elapsed time.
- Injects a render-time clock (`now`) into the renderer; falls back to `Date.now()` when absent; tests inject a fixed value.
- The renderer owns an unref()’d 1s interval that calls `invalidate()` while a live eval cell exists; it clears on terminal render and emits no tool updates or RPC traffic.
- No migration required. Cells without `startedAt` render identically; RPC consumers may use `startedAt` to match the live ticking behavior.

<sup>Written for commit 82129952b40172b90c84d61031b7274c36f0ea42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

