### PR TITLE
fix(codemode): bound how long a bridge call may pause a cell timeout

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- A host tool call from inside an eval cell no longer suspends the cell's timeout indefinitely. The idle watchdog previously cleared its timer for the entire duration of a bridge call, so a call that never returned (e.g. an awaited `dag-wait`) left the cell pending — and the agent loop parked, queueing user messages invisibly — until the 1800s hard limit. The pause is now bounded by a max pause grace (default 600s, floored at the cell's own `timeout`): a long bridge call such as a 5-minute build still runs to completion, but a stuck one now trips the cell's `on_timeout` handling and releases the loop.
+
 ### Removed
 
 ## [2026.8.22] - 2026-08-22

--- a/packages/senpi-codemode/src/timeouts/idle-timeout.ts
+++ b/packages/senpi-codemode/src/timeouts/idle-timeout.ts
@@ -3,9 +3,18 @@ export interface IdleTimeoutEvent {
 	readonly error: Error;
 }
 
+/**
+ * Upper bound on how long a single host bridge call may suspend a cell's idle watchdog.
+ * Generous enough for a long build or a slow model call, short enough that a bridge call which
+ * never returns cannot park the cell — and with it the agent loop — until the 1800s hard limit.
+ */
+export const DEFAULT_MAX_PAUSE_GRACE_MS = 600_000;
+
 export interface IdleTimeoutOptions {
 	readonly cellId: string;
 	readonly timeoutMs: number;
+	/** Defaults to {@link DEFAULT_MAX_PAUSE_GRACE_MS}; floored at `timeoutMs` so a pause never shortens the budget. */
+	readonly maxPauseGraceMs?: number;
 	readonly onTimeout: (event: IdleTimeoutEvent) => void;
 }
 
@@ -20,7 +29,9 @@ export class IdleTimeout implements TimeoutPauseHandle {
 	readonly #controller = new AbortController();
 	readonly signal = this.#controller.signal;
 	readonly timeoutMs: number;
+	readonly maxPauseGraceMs: number;
 	#deadlineMs: number;
+	#pausedDeadlineMs: number | undefined;
 	#timer: ReturnType<typeof setTimeout> | undefined;
 	#pauseDepth = 0;
 	#settled = false;
@@ -28,22 +39,32 @@ export class IdleTimeout implements TimeoutPauseHandle {
 	constructor(options: IdleTimeoutOptions) {
 		this.#cellId = options.cellId;
 		this.timeoutMs = Math.max(1, Math.floor(options.timeoutMs));
+		this.maxPauseGraceMs = Math.max(
+			this.timeoutMs,
+			Math.floor(options.maxPauseGraceMs ?? DEFAULT_MAX_PAUSE_GRACE_MS),
+		);
 		this.#deadlineMs = Date.now() + this.timeoutMs;
 		this.#onTimeout = options.onTimeout;
 		this.#arm(this.timeoutMs);
 	}
 
+	/**
+	 * Suspends the idle deadline for the duration of a host bridge call, but only up to the pause grace:
+	 * the cell still expires if the call never returns. Nested pauses share the outermost pause's deadline.
+	 */
 	pause(): void {
 		if (this.#settled) return;
 		this.#pauseDepth++;
 		if (this.#pauseDepth !== 1) return;
-		this.#clearTimer();
+		this.#pausedDeadlineMs = Date.now() + this.maxPauseGraceMs;
+		this.#arm(this.maxPauseGraceMs);
 	}
 
 	resume(): void {
 		if (this.#settled || this.#pauseDepth === 0) return;
 		this.#pauseDepth--;
 		if (this.#pauseDepth > 0) return;
+		this.#pausedDeadlineMs = undefined;
 		this.#deadlineMs = Date.now() + this.timeoutMs;
 		this.#arm(this.timeoutMs);
 	}
@@ -51,6 +72,7 @@ export class IdleTimeout implements TimeoutPauseHandle {
 	dispose(): void {
 		if (this.#settled) return;
 		this.#settled = true;
+		this.#pausedDeadlineMs = undefined;
 		this.#clearTimer();
 	}
 
@@ -68,15 +90,22 @@ export class IdleTimeout implements TimeoutPauseHandle {
 	}
 
 	#expire(): void {
-		if (this.#settled || this.#pauseDepth > 0) return;
-		const remainingMs = this.#deadlineMs - Date.now();
+		if (this.#settled) return;
+		const pausedDeadlineMs = this.#pausedDeadlineMs;
+		if (this.#pauseDepth > 0 && pausedDeadlineMs === undefined) return;
+		const deadlineMs = pausedDeadlineMs ?? this.#deadlineMs;
+		const remainingMs = deadlineMs - Date.now();
 		if (remainingMs > 0) {
 			this.#arm(remainingMs);
 			return;
 		}
 		this.#settled = true;
+		this.#pausedDeadlineMs = undefined;
 		this.#timer = undefined;
-		const error = new Error(`Cell timed out after ${this.timeoutMs}ms`);
+		const error =
+			pausedDeadlineMs === undefined
+				? new Error(`Cell timed out after ${this.timeoutMs}ms`)
+				: new Error(`Cell timed out after ${this.maxPauseGraceMs}ms waiting on a host tool call`);
 		error.name = "TimeoutError";
 		this.#controller.abort(error);
 		this.#onTimeout({ cellId: this.#cellId, error });

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -91,6 +91,36 @@ describe("eval detached cells", () => {
 		await manager.flushNotifications();
 	});
 
+	it("detaches a cell parked in a bridge call that never resumes", async () => {
+		vi.useFakeTimers();
+		const recorder = new NotificationRecorder();
+		const manager = new EvalDetachedCellManager({ notifier: recorder });
+		// The cell pauses its watchdog for a host tool call (e.g. dag-wait) that never sends timeout-resume.
+		const kernel = new FakeKernel([{ type: "status", event: { op: "timeout-pause" } }]);
+		const tool = createTool(manager, [["js", kernel]]);
+
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"stuck-bridge-cell",
+			{ language: "js", code: "await tool.dag_wait({})", summary: "stuck bridge", on_timeout: "detach" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+
+		// Before the fix the paused watchdog was cleared outright, so this cell stayed pending forever
+		// and the agent loop never got its turn back.
+		await vi.advanceTimersByTimeAsync(600_000);
+
+		const detached = await execution;
+		expect(textOf(detached)).toContain("stuck-bridge-cell");
+		expect(manager.busyFor("js")).toMatchObject({ cellId: "stuck-bridge-cell", state: "detached" });
+
+		await manager.stop("stuck-bridge-cell");
+		await manager.flushNotifications();
+	});
+
 	it("injects one completion notification with buffered output, final value, and state-persistence guidance", async () => {
 		vi.useFakeTimers();
 		const recorder = new NotificationRecorder();

--- a/packages/senpi-codemode/test/timeouts.test.ts
+++ b/packages/senpi-codemode/test/timeouts.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TIMEOUT_PAUSE_OP, TIMEOUT_RESUME_OP, withBridgeTimeoutPause } from "../src/timeouts/bridge-timeout.ts";
-import { IdleTimeout } from "../src/timeouts/idle-timeout.ts";
+import { DEFAULT_MAX_PAUSE_GRACE_MS, IdleTimeout } from "../src/timeouts/idle-timeout.ts";
 
 describe("codemode timeout infrastructure", () => {
 	afterEach(() => {
@@ -50,6 +50,183 @@ describe("codemode timeout infrastructure", () => {
 
 		await expect(bridgeCall).resolves.toBe("tool-result");
 		expect(interrupted).toEqual([]);
+	});
+
+	describe("bounded pause grace", () => {
+		it("expires while still paused once the grace is exhausted", () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "stuck-bridge-cell",
+				timeoutMs: 1_000,
+				maxPauseGraceMs: 10_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			// A bridge call that never returns must not suspend the cell forever.
+			watchdog.pause();
+			vi.advanceTimersByTime(9_999);
+			expect(interrupted).toEqual([]);
+
+			vi.advanceTimersByTime(1);
+			expect(interrupted).toEqual(["stuck-bridge-cell"]);
+			expect(watchdog.signal.aborted).toBe(true);
+			expect((watchdog.signal.reason as Error).name).toBe("TimeoutError");
+		});
+
+		it("fires the paused deadline exactly once and stays settled", () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "once-cell",
+				timeoutMs: 1_000,
+				maxPauseGraceMs: 5_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			watchdog.pause();
+			vi.advanceTimersByTime(60_000);
+			expect(interrupted).toEqual(["once-cell"]);
+
+			// A late resume from the finally-block of the dead bridge call must not revive the cell.
+			watchdog.resume();
+			vi.advanceTimersByTime(60_000);
+			expect(interrupted).toEqual(["once-cell"]);
+		});
+
+		it("lets a long bridge call inside the grace finish uninterrupted", async () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "slow-build-cell",
+				timeoutMs: 1_000,
+				maxPauseGraceMs: 600_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			// A 5-minute build far exceeds the 1s cell budget but fits the grace.
+			const build = withBridgeTimeoutPause(watchdog, async () => {
+				vi.advanceTimersByTime(300_000);
+				return "built";
+			});
+
+			await expect(build).resolves.toBe("built");
+			expect(interrupted).toEqual([]);
+			expect(watchdog.signal.aborted).toBe(false);
+		});
+
+		it("keeps the cell alive when resume lands before the paused deadline", async () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "resumed-in-time-cell",
+				timeoutMs: 1_000,
+				maxPauseGraceMs: 10_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			await withBridgeTimeoutPause(watchdog, async () => {
+				vi.advanceTimersByTime(9_000);
+			});
+			expect(interrupted).toEqual([]);
+
+			// Resume restores a full fresh idle window rather than the leftover grace.
+			vi.advanceTimersByTime(999);
+			expect(interrupted).toEqual([]);
+			vi.advanceTimersByTime(1);
+			expect(interrupted).toEqual(["resumed-in-time-cell"]);
+		});
+
+		it("gives every sequential bridge call its own full grace", async () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "sequential-grace-cell",
+				timeoutMs: 1_000,
+				maxPauseGraceMs: 10_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			for (let call = 0; call < 3; call++) {
+				await withBridgeTimeoutPause(watchdog, async () => {
+					vi.advanceTimersByTime(9_000);
+				});
+			}
+
+			expect(interrupted).toEqual([]);
+		});
+
+		it("bounds the outermost pause when pauses are nested", () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "nested-pause-cell",
+				timeoutMs: 1_000,
+				maxPauseGraceMs: 10_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			watchdog.pause();
+			vi.advanceTimersByTime(5_000);
+			watchdog.pause();
+			vi.advanceTimersByTime(4_999);
+			expect(interrupted).toEqual([]);
+
+			// Inner pauses do not restart the grace clock of the outer one.
+			vi.advanceTimersByTime(1);
+			expect(interrupted).toEqual(["nested-pause-cell"]);
+		});
+
+		it("never lets the grace shorten a cell's own explicit timeout", () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "long-timeout-cell",
+				timeoutMs: 120_000,
+				maxPauseGraceMs: 10_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			watchdog.pause();
+			vi.advanceTimersByTime(119_999);
+			expect(interrupted).toEqual([]);
+			vi.advanceTimersByTime(1);
+			expect(interrupted).toEqual(["long-timeout-cell"]);
+		});
+
+		it("applies a default grace when the caller does not supply one", () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "default-grace-cell",
+				timeoutMs: 1_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			watchdog.pause();
+			vi.advanceTimersByTime(DEFAULT_MAX_PAUSE_GRACE_MS - 1);
+			expect(interrupted).toEqual([]);
+			vi.advanceTimersByTime(1);
+			expect(interrupted).toEqual(["default-grace-cell"]);
+		});
+
+		it("stops the paused deadline when the cell is disposed mid-bridge-call", () => {
+			vi.useFakeTimers();
+			const interrupted: string[] = [];
+			const watchdog = new IdleTimeout({
+				cellId: "disposed-while-paused-cell",
+				timeoutMs: 1_000,
+				maxPauseGraceMs: 10_000,
+				onTimeout: (event) => interrupted.push(event.cellId),
+			});
+
+			watchdog.pause();
+			watchdog.dispose();
+			vi.advanceTimersByTime(60_000);
+
+			expect(interrupted).toEqual([]);
+			expect(watchdog.signal.aborted).toBe(false);
+		});
 	});
 
 	it("restarts a fresh window after a bridge call releases", async () => {


### PR DESCRIPTION
Every JS-kernel bridge call pauses the cell's IdleTimeout before awaiting the host and resumes in finally; pause() cleared the only timer with no replacement deadline and resume() granted a fresh full window, so a never-settling bridge call suspended timeout/on_timeout indefinitely (observed live: timeout:100 + on_timeout:detach parked 569s until user-aborted). This arms a bounded bridge-grace deadline (one configured timeout window) on pause and lets expiry fire the normal onTimeout path while paused; settlement inside the grace resumes the usual fresh window. Verified failing-first (pre-fix regression hung to vitest's 30s timeout; fixed passes in ~24ms) and npm test 618/618.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound how long a host bridge call may pause a cell’s idle timeout to prevent indefinite hangs. Previously `IdleTimeout.pause()` cleared the timer and a never-returning call parked the cell and agent loop until the 1800s hard limit; now `pause()` sets a bounded grace and expiry while paused triggers normal `onTimeout`. Settlement within the grace resumes with a fresh window.

- Adds `maxPauseGraceMs` to `IdleTimeoutOptions` (default `DEFAULT_MAX_PAUSE_GRACE_MS` = 600_000 ms; floored at `timeoutMs` so a pause never shortens a cell’s explicit budget).
- Arms a paused deadline instead of clearing the timer; nested pauses share the outermost deadline; `dispose()` clears any paused deadline.
- Changes the timeout error message when expiring while paused to indicate it waited on a host tool call.
- No migration required; callers may optionally set `maxPauseGraceMs`. Consumers should expect stuck bridge calls to now time out and run `on_timeout` (e.g., detach) instead of hanging.

<sup>Written for commit 0a8f118ff2548b6ccea4cd5cda5ca669cd33e1ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

