### PR TITLE
fix(coding-agent): retarget OpenAI automatic defaults

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Changed
 
+- Automatic startup selection for the built-in OpenAI and Codex providers now defaults to GPT-5.6 Sol instead of GPT-5.5. Explicitly saved GPT-5.5 selections remain supported.
+
 ### Removed
 
 ## [2026.8.22] - 2026-08-22

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,24 +1,5 @@
 # Local fork changes
 
-## Retarget OpenAI automatic defaults to GPT-5.6 Sol (2026-08-22)
-
-### What changed
-
-- `packages/coding-agent/src/core/model-resolver.ts`: retargeted the `openai` and `openai-codex` provider defaults from `gpt-5.5` to `gpt-5.6-sol` while retaining GPT-5.5 in catalogs and explicit settings resolution.
-
-### Why
-
-- Automatic startup recommendation should follow the current recommended GPT-5.6 Sol model; saved GPT-5.5 selections remain explicitly selectable.
-
-### Why an extension could not handle it
-
-- `defaultModelPerProvider` is consumed by core initial-model resolution before extension recommendations are applied.
-
-### Expected merge conflict zones
-
-- LOW: the OpenAI provider entries in `packages/coding-agent/src/core/model-resolver.ts`.
-
-
 ## Coding-agent dependency refresh and generated install-lock update (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,24 @@
 # Local fork changes
 
+## Retarget OpenAI automatic defaults to GPT-5.6 Sol (2026-08-22)
+
+### What changed
+
+- `packages/coding-agent/src/core/model-resolver.ts`: retargeted the `openai` and `openai-codex` provider defaults from `gpt-5.5` to `gpt-5.6-sol` while retaining GPT-5.5 in catalogs and explicit settings resolution.
+
+### Why
+
+- Automatic startup recommendation should follow the current recommended GPT-5.6 Sol model; saved GPT-5.5 selections remain explicitly selectable.
+
+### Why an extension could not handle it
+
+- `defaultModelPerProvider` is consumed by core initial-model resolution before extension recommendations are applied.
+
+### Expected merge conflict zones
+
+- LOW: the OpenAI provider entries in `packages/coding-agent/src/core/model-resolver.ts`.
+
+
 ## Coding-agent dependency refresh and generated install-lock update (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-22 - Retarget OpenAI automatic defaults to GPT-5.6 Sol
+
+### What changed
+
+- `packages/coding-agent/src/core/model-resolver.ts`: retargeted the `openai` and `openai-codex` provider defaults from `gpt-5.5` to `gpt-5.6-sol` while retaining GPT-5.5 in catalogs and explicit settings resolution.
+
+### Why
+
+- Automatic startup recommendation should follow the current recommended GPT-5.6 Sol model; saved GPT-5.5 selections remain explicitly selectable.
+
+### Why an extension could not handle it
+
+- `defaultModelPerProvider` is consumed by core initial-model resolution before extension recommendations are applied.
+
+### Expected merge conflict zones
+
+- LOW: the OpenAI provider entries in `packages/coding-agent/src/core/model-resolver.ts`.
+
 ## 2026-08-22 - emit agent_idle after settlement-deferred turns resolve
 
 ### What changed

--- a/packages/coding-agent/src/core/model-resolver.ts
+++ b/packages/coding-agent/src/core/model-resolver.ts
@@ -39,9 +39,9 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	"amazon-bedrock": "us.anthropic.claude-opus-4-6-v1",
 	"ant-ling": "Ring-2.6-1T",
 	anthropic: "claude-opus-4-8",
-	openai: "gpt-5.5",
+	openai: "gpt-5.6-sol",
 	"azure-openai-responses": "gpt-5.4",
-	"openai-codex": "gpt-5.5",
+	"openai-codex": "gpt-5.6-sol",
 	ollama: "qwen3.5:397b",
 	// Cursor ships no models until its chat protocol is ported; "auto" matches
 	// the Cursor agent's native model auto-selection once models exist.

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -929,23 +929,17 @@ describe("default model selection", () => {
 			contextWindow: 128000,
 			maxTokens: 8192,
 		};
-		const openAiRecommended = {
-			...openAiDefault,
-			id: "gpt-5.6-sol",
-		};
 		const custom: Model<"anthropic-messages"> = {
 			...openAiDefault,
-			id: "custom-model",
-			provider: "custom",
+			id: "grok-4.5",
+			provider: "xai",
 		};
 		const runtime = {
-			getModels: () => [openAiDefault, openAiRecommended, custom],
+			getModels: () => [openAiDefault, custom],
 			getModel: (provider: string, modelId: string) =>
-				[openAiDefault, openAiRecommended, custom].find(
-					(candidate) => candidate.provider === provider && candidate.id === modelId,
-				),
+				[openAiDefault, custom].find((candidate) => candidate.provider === provider && candidate.id === modelId),
 			hasConfiguredAuth: () => true,
-			getAvailable: async () => [openAiDefault, openAiRecommended, custom],
+			getAvailable: async () => [openAiDefault, custom],
 		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
 
 		const cli = await findInitialModel({
@@ -963,8 +957,8 @@ describe("default model selection", () => {
 		const settings = await findInitialModel({
 			scopedModels: [],
 			isContinuing: false,
-			defaultProvider: "openai",
-			defaultModelId: "gpt-5.5",
+			defaultProvider: "xai",
+			defaultModelId: "grok-4.5",
 			modelRuntime: runtime,
 		});
 		const providerDefault = await findInitialModel({
@@ -974,7 +968,7 @@ describe("default model selection", () => {
 		});
 		const firstAvailableRuntime = {
 			...runtime,
-			getAvailable: async () => [custom],
+			getAvailable: async () => [openAiDefault],
 		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
 		const firstAvailable = await findInitialModel({
 			scopedModels: [],
@@ -984,9 +978,7 @@ describe("default model selection", () => {
 
 		expect(cli.provenance).toBe("cli");
 		expect(scoped.provenance).toBe("scoped");
-		expect(settings.model?.id).toBe("gpt-5.5");
 		expect(settings.provenance).toBe("settings");
-		expect(providerDefault.model?.id).toBe("gpt-5.6-sol");
 		expect(providerDefault.provenance).toBe("provider-default");
 		expect(firstAvailable.provenance).toBe("first-available");
 	});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -697,8 +697,8 @@ describe("resolveCliModel", () => {
 
 describe("default model selection", () => {
 	test("openai defaults track current models", () => {
-		expect(defaultModelPerProvider.openai).toBe("gpt-5.5");
-		expect(defaultModelPerProvider["openai-codex"]).toBe("gpt-5.5");
+		expect(defaultModelPerProvider.openai).toBe("gpt-5.6-sol");
+		expect(defaultModelPerProvider["openai-codex"]).toBe("gpt-5.6-sol");
 	});
 
 	test("zai, minimax, cerebras, and ant-ling defaults track current models", () => {
@@ -929,17 +929,23 @@ describe("default model selection", () => {
 			contextWindow: 128000,
 			maxTokens: 8192,
 		};
+		const openAiRecommended = {
+			...openAiDefault,
+			id: "gpt-5.6-sol",
+		};
 		const custom: Model<"anthropic-messages"> = {
 			...openAiDefault,
 			id: "custom-model",
 			provider: "custom",
 		};
 		const runtime = {
-			getModels: () => [openAiDefault, custom],
+			getModels: () => [openAiDefault, openAiRecommended, custom],
 			getModel: (provider: string, modelId: string) =>
-				[openAiDefault, custom].find((candidate) => candidate.provider === provider && candidate.id === modelId),
+				[openAiDefault, openAiRecommended, custom].find(
+					(candidate) => candidate.provider === provider && candidate.id === modelId,
+				),
 			hasConfiguredAuth: () => true,
-			getAvailable: async () => [openAiDefault, custom],
+			getAvailable: async () => [openAiDefault, openAiRecommended, custom],
 		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
 
 		const cli = await findInitialModel({
@@ -957,8 +963,8 @@ describe("default model selection", () => {
 		const settings = await findInitialModel({
 			scopedModels: [],
 			isContinuing: false,
-			defaultProvider: "custom",
-			defaultModelId: "custom-model",
+			defaultProvider: "openai",
+			defaultModelId: "gpt-5.5",
 			modelRuntime: runtime,
 		});
 		const providerDefault = await findInitialModel({
@@ -978,7 +984,9 @@ describe("default model selection", () => {
 
 		expect(cli.provenance).toBe("cli");
 		expect(scoped.provenance).toBe("scoped");
+		expect(settings.model?.id).toBe("gpt-5.5");
 		expect(settings.provenance).toBe("settings");
+		expect(providerDefault.model?.id).toBe("gpt-5.6-sol");
 		expect(providerDefault.provenance).toBe("provider-default");
 		expect(firstAvailable.provenance).toBe("first-available");
 	});

--- a/packages/coding-agent/test/provider-default-model-selection.test.ts
+++ b/packages/coding-agent/test/provider-default-model-selection.test.ts
@@ -1,0 +1,35 @@
+import { getModels } from "@earendil-works/pi-ai/compat";
+import { describe, expect, test } from "vitest";
+import { findInitialModel } from "../src/core/model-resolver.ts";
+
+describe("OpenAI provider defaults", () => {
+	test("prefers GPT-5.6 Sol automatically while preserving explicit GPT-5.5", async () => {
+		const openAiModels = getModels("openai");
+		const codexModels = getModels("openai-codex");
+		const availableModels = [
+			openAiModels.find((model) => model.id === "gpt-5.6-sol"),
+			codexModels.find((model) => model.id === "gpt-5.6-sol"),
+			codexModels.find((model) => model.id === "gpt-5.5"),
+		].filter((model) => model !== undefined);
+		const runtime = {
+			getAvailableSnapshot: () => availableModels,
+			getModel: (provider: string, modelId: string) =>
+				availableModels.find((model) => model.provider === provider && model.id === modelId),
+			hasConfiguredAuth: () => true,
+		} as unknown as Parameters<typeof findInitialModel>[0]["modelRuntime"];
+
+		const automatic = await findInitialModel({ scopedModels: [], isContinuing: false, modelRuntime: runtime });
+		const explicit = await findInitialModel({
+			scopedModels: [],
+			isContinuing: false,
+			defaultProvider: "openai-codex",
+			defaultModelId: "gpt-5.5",
+			modelRuntime: runtime,
+		});
+
+		expect(automatic.model?.id).toBe("gpt-5.6-sol");
+		expect(automatic.provenance).toBe("provider-default");
+		expect(explicit.model?.id).toBe("gpt-5.5");
+		expect(explicit.provenance).toBe("settings");
+	});
+});

--- a/packages/coding-agent/test/suite/interactive-mode-scoped-settings.test.ts
+++ b/packages/coding-agent/test/suite/interactive-mode-scoped-settings.test.ts
@@ -117,7 +117,7 @@ describe("InteractiveMode scoped-setting caller compatibility", () => {
 
 	it("keeps post-auth default model selection on the global-setting setter", async () => {
 		// Given: authentication completes while the session still has the unknown placeholder model.
-		const defaultModel = { provider: "openai", id: "gpt-5.5" };
+		const defaultModel = { provider: "openai", id: "gpt-5.6-sol" };
 		const setModel = vi.fn(async () => undefined);
 		const setSessionModel = vi.fn(async () => undefined);
 		const fakeThis = {


### PR DESCRIPTION
## Summary

Retarget Senpi's implicit OpenAI and Codex startup defaults from GPT-5.5 to GPT-5.6 Sol. Explicitly saved GPT-5.5 selections remain supported and continue to resolve through the settings path.

## Changes

- Update the `openai` and `openai-codex` entries in `defaultModelPerProvider` to `gpt-5.6-sol`.
- Extend the existing initial-model provenance test to prove the automatic path selects Sol while an explicit GPT-5.5 setting remains selected.
- Record the core fork divergence in the nearest `changes.md` tracker.

## QA & Evidence

- **Failing-first proof:** temporarily restored the prior GPT-5.5 defaults and ran `npm exec vitest -- --run test/model-resolver.test.ts` from `packages/coding-agent`; observed 2 intended assertion failures (`gpt-5.5` received instead of `gpt-5.6-sol`).
- **Focused GREEN:** the same command passed all 55 tests after restoring the implementation.
- **Resolver surface:** an executable source-level resolver probe returned:
  - automatic: `openai/gpt-5.6-sol`, provenance `provider-default`
  - explicit: `openai-codex/gpt-5.5`, provenance `settings`
- **Real CLI QA:** `cli-smoke.mjs --self-test` passed 8/8 and `rpc-drive.mjs --self-test` passed 4/4 in isolated sandboxes; the real auth file was unchanged.
- **Static validation:** `npm exec tsc -- --noEmit`, browser smoke, and `git diff --check` passed.

Local artifacts are under `local-ignore/qa-evidence/20260822-gpt55-provider-default/` and are intentionally not committed.

## Risks & Residuals

- GPT-5.5 is not removed from provider catalogs or explicit selection paths.
- The change affects only implicit provider-default and restore-fallback selection that consumes the same map.
- No model networking or real provider credentials were used in tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retargets the OpenAI provider default from GPT-5.5 to GPT-5.6 Sol so implicit selection follows the current recommendation. Old behavior: provider-default selected GPT-5.5; new behavior: it selects GPT-5.6 Sol; explicit GPT-5.5 settings still resolve unchanged.

**Review notes**
- Update `defaultModelPerProvider` in `packages/coding-agent/src/core/model-resolver.ts` for `openai` and `openai-codex` to `gpt-5.6-sol`.
- Add `packages/coding-agent/test/provider-default-model-selection.test.ts` to assert automatic vs. explicit selection; refresh expectations in `packages/coding-agent/test/model-resolver.test.ts`.
- Update `packages/coding-agent/test/suite/interactive-mode-scoped-settings.test.ts` to reflect the post-auth default of `openai/gpt-5.6-sol`.
- Document the change in `packages/coding-agent/src/core/changes.md` and `packages/coding-agent/CHANGELOG.md`.

**Rollout**
- No migration required; saved GPT-5.5 selections continue to work.
- Impact is limited to implicit provider-default and restore-fallback paths.

<sup>Written for commit dda31057dfd130a89231002f4a2ee2b573a7c758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

