### PR TITLE
fix(coding-agent): accept video input modality in user models.json

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- User `models.json` files may now declare the `video` input modality for custom provider models, matching the runtime model type and the builtin Kimi Coding catalog; previously a video entry failed schema validation, which rejected the entire models.json and unregistered every user-defined provider ([#1087](https://github.com/code-yeongyu/senpi/pull/1087)).
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,25 @@
 # Local fork changes
 
+## models.json schema accepts the video input modality (2026-08-23)
+
+### What changed
+
+- `packages/coding-agent/src/core/model-config-schema.ts`: the `input` unions of `ModelDefinitionSchema` and `ModelOverrideSchema` now accept `video` in addition to `text` and `image`.
+- `packages/coding-agent/test/suite/regressions/0002-models-json-video-input.test.ts`: failing-first regression covering `models[]` acceptance, `modelOverrides` acceptance, and continued `audio` rejection (`audio` exists nowhere in the runtime type).
+- `packages/coding-agent/CHANGELOG.md`: [Unreleased] entry referencing PR #1087.
+
+### Why
+
+- The fork types `Model.input` as `("text" | "image" | "video")[]` (`packages/ai/src/model.ts`) and ships builtin `kimi-coding` k3 declaring `["text","image","video"]`, but the user-facing models.json schema was never extended when video support landed. Any user provider declaring video failed validation, and `ModelConfig.loadSync` rejects the entire file on any schema error — unregistering every user-defined provider and surfacing only a misleading fallback-chain "roles are unsupported" warning downstream. Upstream pi-mono is consistently `text|image` in both the type and the schema, so this gap is fork-introduced; this change closes it on the schema side only. The all-or-nothing rejection semantics and the fallback-warning wording are deliberately untouched (separate design concerns).
+
+### Why an extension could not handle it
+
+- The schema is the load-time gate for every user provider; extensions run after `ModelConfig` has already accepted or rejected the file.
+
+### Expected merge conflict zones
+
+- LOW: two single-line unions in `model-config-schema.ts`; upstream has not touched this schema since the fork split it from `model-config.ts`.
+
 ## Coding-agent dependency refresh and generated install-lock update (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/model-config-schema.ts
+++ b/packages/coding-agent/src/core/model-config-schema.ts
@@ -163,7 +163,7 @@ const ModelDefinitionSchema = Type.Object({
 	baseUrl: Type.Optional(Type.String({ minLength: 1 })),
 	reasoning: Type.Optional(Type.Boolean()),
 	thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
-	input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+	input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image"), Type.Literal("video")]))),
 	cost: Type.Optional(ModelCostSchema),
 	contextWindow: Type.Optional(Type.Number()),
 	maxTokens: Type.Optional(Type.Number()),
@@ -180,7 +180,7 @@ const ModelOverrideSchema = Type.Object({
 	reasoning: Type.Optional(Type.Boolean()),
 	thinkingLevelMap: Type.Optional(ThinkingLevelMapSchema),
 	thinkingLevelMapMode: Type.Optional(Type.Union([Type.Literal("merge"), Type.Literal("replace")])),
-	input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image")]))),
+	input: Type.Optional(Type.Array(Type.Union([Type.Literal("text"), Type.Literal("image"), Type.Literal("video")]))),
 	cost: Type.Optional(
 		Type.Object({
 			input: Type.Optional(Type.Number()),

--- a/packages/coding-agent/test/suite/regressions/0002-models-json-video-input.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0002-models-json-video-input.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ModelConfig } from "../../../src/core/model-config.ts";
+
+const VIDEO_INPUT = ["text", "image", "video"] as const;
+
+function writeModelsJson(dir: string, payload: unknown): string {
+	const path = join(dir, "models.json");
+	writeFileSync(path, `${JSON.stringify(payload)}\n`, "utf-8");
+	return path;
+}
+
+describe("models.json video input modality", () => {
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+	});
+
+	function tempDir(): string {
+		const dir = mkdtempSync(join(tmpdir(), "models-json-video-input-"));
+		dirs.push(dir);
+		return dir;
+	}
+
+	it("accepts video in a models[] entry", () => {
+		const path = writeModelsJson(tempDir(), {
+			providers: {
+				"test-video": {
+					baseUrl: "https://example.test/v1",
+					api: "openai-completions",
+					models: [{ id: "video-model", input: [...VIDEO_INPUT] }],
+				},
+			},
+		});
+
+		const config = ModelConfig.loadSync(path);
+		expect(config.getError()).toBeUndefined();
+		expect(config.getProviderIds()).toContain("test-video");
+		const provider = config.getProvider("test-video");
+		expect(provider).toBeDefined();
+		expect(provider?.models?.[0]?.id).toBe("video-model");
+		expect(provider?.models?.[0]?.input).toEqual(["text", "image", "video"]);
+	});
+
+	it("accepts video in a modelOverrides entry", () => {
+		const path = writeModelsJson(tempDir(), {
+			providers: {
+				"test-video": {
+					baseUrl: "https://example.test/v1",
+					api: "openai-completions",
+					modelOverrides: {
+						"video-model": { input: [...VIDEO_INPUT] },
+					},
+				},
+			},
+		});
+
+		const config = ModelConfig.loadSync(path);
+		expect(config.getError()).toBeUndefined();
+		expect(config.getProviderIds()).toContain("test-video");
+		const provider = config.getProvider("test-video");
+		expect(provider).toBeDefined();
+		expect(provider?.modelOverrides?.["video-model"]?.input).toEqual(["text", "image", "video"]);
+	});
+
+	it("rejects audio as an input modality", () => {
+		const path = writeModelsJson(tempDir(), {
+			providers: {
+				"test-video": {
+					baseUrl: "https://example.test/v1",
+					api: "openai-completions",
+					models: [{ id: "audio-model", input: ["text", "audio"] }],
+				},
+			},
+		});
+
+		const config = ModelConfig.loadSync(path);
+		expect(config.getError()).toContain("Invalid models.json schema");
+	});
+});


### PR DESCRIPTION
## Summary

User `models.json` files could not declare the `video` input modality: the config schema (`model-config-schema.ts`) only allowed `text` and `image`, while the runtime `Model` type (`packages/ai/src/model.ts`) and the builtin `kimi-coding` catalog already support `video`. Any models.json declaring video (for example an OpenRouter Gemini/Qwen entry) failed schema validation, which made `ModelConfig.loadSync` reject the entire file — silently unregistering every user-defined provider and surfacing only a misleading `Fallback chain key "..." must use a provider/model selector; roles are unsupported` warning downstream. After this PR, video-declaring models.json loads cleanly and such fallback chains resolve.

## Changes

- **Schema fix** (`packages/coding-agent/src/core/model-config-schema.ts`): add `Type.Literal("video")` to the `input` unions of both `ModelDefinitionSchema` and `ModelOverrideSchema`, matching the runtime type. `audio` remains rejected — it exists nowhere in the runtime type.
- **Regression test** (`packages/coding-agent/test/suite/regressions/0002-models-json-video-input.test.ts`): three cases — video accepted in a `models[]` entry, video accepted in a `modelOverrides` entry, `audio` still rejected with a schema error.
- **Changelog records**: `packages/coding-agent/CHANGELOG.md` [Unreleased] entry and `packages/coding-agent/changes.md` fork-divergence note (including the upstream comparison: upstream pi-mono is consistently `text|image` in type and schema; the fork added video to the type/catalog but not the user schema).

## QA & Evidence

- **What was tested:** failing-first regression run of the new test before the schema edit (`npx vitest run test/suite/regressions/0002-models-json-video-input.test.ts`).
- **Observed result:** RED — 2 failed / 1 passed; failures are `getError()` = `Invalid models.json schema` at the video-acceptance assertions (the right failure reason).
- **Artifact:** `.omo/ulw-loop/video-schema-concurrency-20260823/evidence/g002-c001-red-vitest.txt`
- **Why sufficient:** proves the test fails on the unpatched schema for the contract reason, not a harness error.

- **What was tested:** same command after adding the two literals, test file byte-identical (sha256 verified).
- **Observed result:** GREEN — 3 passed (3), re-run independently by the orchestrator with the same result.
- **Artifact:** `.omo/ulw-loop/video-schema-concurrency-20260823/evidence/g001-c001-green-vitest.txt`

- **What was tested:** adjacent suites `config-reload-extension` + `model-config-controls`, and the full root `npm run check` (biome, pinned deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, tsc --noEmit, browser smoke).
- **Observed result:** 69 passed (69); root check exit 0.
- **Artifact:** `.omo/ulw-loop/video-schema-concurrency-20260823/evidence/g001-c003-scoped-and-root-check.txt`

- **What was tested:** real-surface TUI boot smoke — the pre-fix dist (old build) and the post-fix worktree build were each booted under tmux with a temp agent dir whose models.json declares `input: ["text","image","video"]` and whose settings.json carries a bare-family fallback-chain key.
- **Observed result:** pre-fix boot shows `Error: models.json error: Invalid models.json schema` and `Warning: Fallback chain key "video-model" must use a provider/model selector; roles are unsupported` (exact reproduction of the original production symptom); post-fix boot shows neither.
- **Artifacts:** `.omo/ulw-loop/video-schema-concurrency-20260823/evidence/g001-c002-tui-smoke-RED-old-dist.txt` (symptom present), `.omo/ulw-loop/video-schema-concurrency-20260823/evidence/g001-c002-tui-smoke.txt` (symptom gone). All tmux sessions and temp dirs torn down (receipts in the transcripts).

## Risks & Residuals

- **Widened acceptance is the point:** the schema now accepts `video`, which the runtime type already supported — no new runtime behavior beyond accepting what the type allows.
- **Out of scope (deliberate):** the all-or-nothing rejection semantics of `ModelConfig.loadSync` (one invalid entry rejects the whole file) and the fallback-warning wording when models.json fails to load. Both are separate design concerns noted for follow-up.
- **No migration needed:** previously-rejected files now load; nothing that loaded before changes behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts the `video` input modality in user `models.json` so video-capable models load correctly. Previously, declaring `video` failed schema validation and dropped all user-defined providers; now configs validate and fallback chains resolve without spurious warnings.

- Schema: add `video` to `input` unions in `ModelDefinitionSchema` and `ModelOverrideSchema` (`packages/coding-agent/src/core/model-config-schema.ts`). `audio` remains invalid.
- Tests: add regression `packages/coding-agent/test/suite/regressions/0002-models-json-video-input.test.ts` covering acceptance in `models[]` and `modelOverrides`, and rejection of `audio`.
- Docs: update `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/changes.md` to note the behavior change.
- No migration required.

<sup>Written for commit a84af4366a850483ea6f652c47c3181b8a29215c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

