### PR TITLE
feat(cursor): pin a composer operating prefix on the cursor path

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Cursor Composer models receive an operating prefix as their own leading system blob, carrying this client's native tool vocabulary and completion rules in place of the Cursor-harness habits they were trained on. Other Cursor models keep their existing request shape.
+
 ### Changed
 
 ### Fixed

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -20,6 +20,7 @@ import { createHash, randomUUID } from "node:crypto";
 import * as http2 from "node:http2";
 import { create, fromBinary, fromJson, type JsonValue as PbJsonValue, toBinary, toJson } from "@bufbuild/protobuf";
 import { ValueSchema } from "@bufbuild/protobuf/wkt";
+import { CURSOR_COMPOSER_PROMPT, isCursorComposerModel } from "../cursor/composer-prompt.ts";
 import { calculateCost } from "../models.ts";
 import type {
 	Api,
@@ -3847,13 +3848,20 @@ function findLastUserMessageIndex(messages: Message[]): number {
  * Build one Cursor system-message JSON blob per system prompt. When no system
  * prompt is provided, returns a single default greeting so we never emit an
  * empty `rootPromptMessagesJson` head.
+ *
+ * Composer models get their operating prefix as its own leading blob rather
+ * than concatenated into the host prompt, so Cursor's per-blob prompt cache
+ * keeps the prefix stable while the host prompt changes underneath it.
  */
-export function buildCursorSystemPromptJsons(systemPrompt: string | undefined): string[] {
+export function buildCursorSystemPromptJsons(systemPrompt: string | undefined, modelId?: string): string[] {
 	const trimmed = systemPrompt?.trim();
-	if (!trimmed) {
-		return [JSON.stringify({ role: "system", content: "You are a helpful assistant." })];
+	const host = trimmed
+		? [JSON.stringify({ role: "system", content: trimmed })]
+		: [JSON.stringify({ role: "system", content: "You are a helpful assistant." })];
+	if (modelId !== undefined && isCursorComposerModel(modelId)) {
+		return [JSON.stringify({ role: "system", content: CURSOR_COMPOSER_PROMPT }), ...host];
 	}
-	return [JSON.stringify({ role: "system", content: trimmed })];
+	return host;
 }
 
 /**
@@ -4189,7 +4197,7 @@ async function buildGrpcRequest(
 }> {
 	const blobStore = state.blobStore;
 
-	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt).map((json) =>
+	const systemPromptIds = buildCursorSystemPromptJsons(context.systemPrompt, model.id).map((json) =>
 		storeCursorBlob(blobStore, new TextEncoder().encode(json)),
 	);
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Pin a Cursor Composer operating prefix as its own leading system blob so Composer models arrive with this client's native tool vocabulary and completion rules instead of the Cursor-harness habits they were trained on.
 - Match the official Cursor CLI's stream recovery: every inbound frame, including heartbeats and checkpoints, refreshes the 30s health timer; pre-`turnEnded` stalls and transport deaths retry with bounded backoff, and checkpointed attempts resume with the original pinned model request.
 - Treat Cursor `turnEnded` as definitive completion after a bounded exec-dispatch drain.
 - Skip ANTML invoke recovery when `model.api === "cursor-agent"` so native Cursor tool starts are not rejected as invalid event order.

--- a/packages/ai/src/cursor/composer-prompt.ts
+++ b/packages/ai/src/cursor/composer-prompt.ts
@@ -1,0 +1,55 @@
+/**
+ * Cursor Composer operating prefix.
+ *
+ * Composer 2 and 2.5 are Cursor's continued pretraining plus large-scale
+ * agentic RL on top of Moonshot's Kimi K2.5 checkpoint, and Cursor trains them
+ * inside essentially the same agent harness it serves them from
+ * (arXiv:2603.24477; cursor.com/blog/composer-2-5). The policy is therefore
+ * shaped around Cursor's own tool surface, and Cursor reports that a model
+ * given an unfamiliar tool or edit format still works but spends more reasoning
+ * tokens and makes more mistakes.
+ *
+ * Driving Composer through this client is exactly that off-distribution case,
+ * so the prefix supplies only what the host prompt cannot know: which tools
+ * this wire surface actually exposes, and the operating rules for the habits
+ * Cursor documents as trained-in. Everything the host prompt already covers
+ * (verification depth, output style, commit policy) is deliberately absent:
+ * K2-family models follow instructions strictly enough that restating an
+ * existing rule buys nothing and dilutes the rules that are new.
+ *
+ * The wording is positive and procedural rather than a stack of prohibitions.
+ * A prohibition invites this family to spend reasoning deciding whether the
+ * current case is the prohibited one, while a named tool and a terminal
+ * condition install the behavior directly.
+ */
+export const CURSOR_COMPOSER_PROMPT = `You are running in this client, not in Cursor. Your tools on this surface are read, ls, grep, write, delete, diagnostics, and shell. Tool names from other harnesses are unavailable here.
+
+Reach for repository files through the native tools: read for file contents, ls for directory entries, grep for content and filename search, write to create or modify, delete to remove, diagnostics for a file's current errors. These carry line anchors and result metadata that shell output does not.
+
+Keep shell for terminal work: tests, builds, package scripts, git, and process control. Put only the command in the command string.
+
+Tool arguments are the schema object the tool declares. Keep explanation and markdown in your message text, where it belongs.
+
+Read a file before you edit it, and read it again after any write before relying on its contents. Copy line anchors from the most recent tool output rather than computing or adjusting them; when an anchor is rejected, re-read and use the anchors that come back.
+
+Run independent searches and reads together in one batch. Keep dependent steps in sequence, and let a step that needs the previous result wait for it.
+
+A task is finished when the requested behavior is in place and you have watched it work: the relevant test, build, or command run, and its output read. Until you have that, keep going. If something remains unproven or broken, say which part and why.
+
+When asked a question, answer it from the code and stop there. Edit when a change was requested or when a fix is confirmed.`;
+
+/**
+ * Composer ids on this provider, e.g. `composer-2.5`, `composer-2.6-thinking-max`,
+ * `composer-2.6-lite-medium-fast`. The match is name-based and version-agnostic
+ * because the trained-in harness habits belong to the family rather than to any
+ * one release, and Cursor serves ids ahead of its public docs.
+ *
+ * Cursor also resells first-party Kimi models (`kimi-k2.7-code`, `kimi-k3-*`).
+ * Those are ordinary hosted models rather than Cursor-harness-trained policies,
+ * so keying on the Composer name keeps them out.
+ */
+const COMPOSER_MODEL_ID_PATTERN = /(?:^|[/:._-])composer(?:[/:._-]|\d|$)/i;
+
+export function isCursorComposerModel(modelId: string): boolean {
+	return COMPOSER_MODEL_ID_PATTERN.test(modelId);
+}

--- a/packages/ai/test/cursor-composer-prompt.test.ts
+++ b/packages/ai/test/cursor-composer-prompt.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { buildCursorSystemPromptJsons } from "../src/api/cursor-agent.ts";
+import { CURSOR_COMPOSER_PROMPT, isCursorComposerModel } from "../src/cursor/composer-prompt.ts";
+import aliasData from "../src/cursor/cursor-variant-aliases.json" with { type: "json" };
+
+const catalogIds = Object.keys((aliasData as { aliases: Record<string, unknown> }).aliases);
+const composerIds = catalogIds.filter((id) => id.toLowerCase().includes("composer"));
+const nonComposerIds = catalogIds.filter((id) => !id.toLowerCase().includes("composer"));
+
+function contentsOf(jsons: readonly string[]): string[] {
+	return jsons.map((json) => (JSON.parse(json) as { content: string }).content);
+}
+
+describe("isCursorComposerModel", () => {
+	it("matches every composer id the live catalog capture serves", () => {
+		expect(composerIds.length).toBeGreaterThan(0);
+		expect(composerIds.filter((id) => !isCursorComposerModel(id))).toEqual([]);
+	});
+
+	it("leaves every non-composer catalog id alone", () => {
+		expect(nonComposerIds.filter((id) => isCursorComposerModel(id))).toEqual([]);
+	});
+
+	it("keeps cursor's resold first-party kimi models out of the composer family", () => {
+		for (const id of ["kimi-k2.7-code", "kimi-k3-high", "kimi-k3-low"]) {
+			expect(isCursorComposerModel(id), `${id} must not be treated as composer`).toBe(false);
+		}
+	});
+
+	it("matches provider-qualified and future composer ids", () => {
+		for (const id of ["cursor/composer-2.5", "composer-3", "composer-2.7-thinking-max"]) {
+			expect(isCursorComposerModel(id), `${id} must be treated as composer`).toBe(true);
+		}
+	});
+});
+
+describe("buildCursorSystemPromptJsons composer prefix", () => {
+	it("pins the composer prompt ahead of the host prompt for composer models", () => {
+		const contents = contentsOf(buildCursorSystemPromptJsons("Host system prompt.", "composer-2.6"));
+		expect(contents).toEqual([CURSOR_COMPOSER_PROMPT, "Host system prompt."]);
+	});
+
+	it("still emits the composer prompt when the host prompt is absent", () => {
+		const contents = contentsOf(buildCursorSystemPromptJsons(undefined, "composer-2.5-fast"));
+		expect(contents[0]).toBe(CURSOR_COMPOSER_PROMPT);
+		expect(contents).toHaveLength(2);
+	});
+
+	it("leaves non-composer models on the untouched single-blob shape", () => {
+		const contents = contentsOf(buildCursorSystemPromptJsons("Host system prompt.", "claude-4.5-sonnet"));
+		expect(contents).toEqual(["Host system prompt."]);
+	});
+
+	it("keeps the pre-existing shape when no model id is supplied", () => {
+		const contents = contentsOf(buildCursorSystemPromptJsons("Host system prompt."));
+		expect(contents).toEqual(["Host system prompt."]);
+	});
+
+	it("emits each system message as its own role-tagged blob", () => {
+		const jsons = buildCursorSystemPromptJsons("Host system prompt.", "composer-2.6-lite-medium-fast");
+		for (const json of jsons) {
+			expect((JSON.parse(json) as { role: string }).role).toBe("system");
+		}
+	});
+});


### PR DESCRIPTION
## What

Cursor Composer models now receive an operating prefix as their own leading system blob on the `cursor-agent` path. Every other model on that path keeps the exact request shape it has today.

## Why

Composer 2 and 2.5 are Cursor's continued pretraining plus large-scale agentic RL on top of Moonshot's Kimi K2.5 checkpoint ([Composer 2 technical report](https://arxiv.org/abs/2603.24477), [Composer 2.5 announcement](https://cursor.com/blog/composer-2-5)), and Cursor trains them inside essentially the same agent harness it serves them from. Cursor states plainly that a model handed an unfamiliar tool or edit format still works, but spends more reasoning tokens and makes more mistakes.

Driving Composer through this client over the agent RPC is exactly that off-distribution case, and today it arrives with no correction at all.

The prefix carries only what the host prompt cannot know. Each paragraph targets a documented failure mode:

| Prefix content | Failure mode it targets |
|---|---|
| Harness reset plus this surface's tool list | Cursor's own takeover-instruction practice on model switch; Moonshot reports unclear tool definitions cause excessive or truncated tool calls |
| Repository I/O through `read`/`ls`/`grep`/`write`/`delete`/`diagnostics` | Shell reads and shell file discovery return output carrying no line anchors |
| Shell scoped to terminal work, command string carries only the command | Reasoning prose leaking into command strings |
| Tool arguments are the schema object | Markdown and commentary inside tool arguments |
| Read before and after writing, copy anchors from the latest output | Fabricated anchor hashes and arithmetic anchor renumbering after the model's own edits |
| Parallelize independent work, sequence dependent work | Composer 2's nonlinear length penalty trains a speed prior that needs a correctness bound |
| Completion gated on observed output | Documented Composer reward hacking: it learned to emit invalid tool calls to dodge negative reward, and to avoid risky edits because unwritten code could not be punished |
| Investigate versus edit boundary | Composer 2 is evaluated for eager editing, and real-time RL once overcorrected into question-asking |

The wording is positive and procedural rather than a stack of prohibitions. For a K2-family model a prohibition invites reasoning about whether the current case is the prohibited one, while a named tool plus a terminal condition installs the behavior directly. Nothing the host prompt already covers (verification depth, output style, commit policy) is restated.

## Design notes

- The prefix is its own blob rather than concatenated into the host prompt, so Cursor's per-blob prompt cache keeps it stable while the host prompt changes underneath it.
- Matching is name-based and version-agnostic: the habits belong to the family, and Cursor serves ids ahead of its public docs. `composer-2.6` and `composer-2.6-lite-*` are already live in our catalog capture while Cursor's docs still list 2.5 as current.
- Keying on the Composer name deliberately excludes Cursor's resold first-party Kimi models (`kimi-k2.7-code`, `kimi-k3-*`). Those are ordinary hosted models, not Cursor-harness-trained policies, and they must not receive this prefix.

## Verification

All commands run in a clean worktree off `origin/main`.

- `npx vitest run test/cursor-composer-prompt.test.ts` — 9 passed, exit 0. Captured RED first: the suite failed with `Cannot find module '../src/cursor/composer-prompt.ts'`, then failed with 2 of 9 on the seam alone before the `cursor-agent.ts` change landed.
- `npx vitest run test/cursor-window-ssot.test.ts test/cursor-run-request.test.ts test/cursor-agent.test.ts test/cursor-conversation-rotation.test.ts` — 48 passed across 4 files, exit 0. Confirms the added parameter left existing Cursor request construction untouched.
- `npx tsc --noEmit` — exit 0.
- `npx biome check --error-on-warnings` on the touched paths — exit 0, 7 files.
- `node scripts/check-ts-relative-imports.mjs` — exit 0.
- Pre-commit gate ran the full suite including `check:browser-smoke` — all passed.

Real-surface decode of the actual blobs the request builder produces:

```
model=composer-2.6         blobs=2  [0] composer prefix (1538 chars)  [1] host prompt
model=composer-2.5-fast    blobs=2  [0] composer prefix (1538 chars)  [1] host prompt
model=claude-4.5-sonnet    blobs=1  [0] host prompt
model=kimi-k2.7-code       blobs=1  [0] host prompt
```

The last row is the one that matters most: Cursor's resold Kimi model stays on the untouched single-blob shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins a Composer-specific operating prefix as a separate leading system blob on the `cursor-agent` path to align Composer models with this client's tools and completion rules. Previously all models sent one system blob (host prompt); now Composer models send two (prefix + host), others remain unchanged.

- Implemented in `buildCursorSystemPromptJsons(systemPrompt, modelId)`: when `isCursorComposerModel(modelId)` is true, prepend `CURSOR_COMPOSER_PROMPT`; behavior is unchanged when `modelId` is absent.
- Matching is name-based and version-agnostic for `composer-*`; excludes resold Kimi models (`kimi-k2.7-code`, `kimi-k3-*`).
- Prefix ships as its own blob to leverage Cursor’s per-blob prompt cache.
- Request shape: Composer models now emit two system blobs in `rootPromptMessagesJson`; others remain one. Tests cover matcher accuracy, blob order, and unchanged non-Composer behavior.
- Migration: If any downstream assumes a single system blob, update it to handle multiple system messages for Composer models. No configuration changes required.

<sup>Written for commit a3380bff1f7a19ff391312c7e22e46bea75eeeda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

