### PR TITLE
fix(codemode): deliver detached-cell notices as internal custom messages

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Detached eval cell completion notices no longer enter the user-input steering queue. They were delivered via `sendUserMessage`, so hosts projecting that queue (e.g. the OmO desktop composer) rendered the raw `<system-reminder>Detached eval cell …</system-reminder>` notice under the STEERING heading as if the user had typed and queued it. Notices now deliver via `sendMessage` with `customType: "senpi-codemode:notification"` and `display: false` — model-visible, never painted as user input — matching the terminal and monitor notification contract.
+
 ### Removed
 
 ## [2026.8.22-2] - 2026-08-22

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,27 @@
 # senpi-codemode fork changes
 
+## Detached-cell notices deliver as internal custom messages (2026-08-23)
+
+### What changed
+
+- `packages/senpi-codemode/src/extension/eval-notifier.ts` now delivers detached-cell completion notices through `sendMessage` with the new `EVAL_NOTIFICATION_CUSTOM_TYPE` (`senpi-codemode:notification`) and `display: false`, instead of `sendUserMessage`. Wake/next-turn mode still selects `steer` vs `followUp`, and delivery stays once-per-cell per session generation.
+- `CodemodeExtensionAPI` requires `sendMessage` in place of `sendUserMessage`; the host binding forwards to `pi.sendMessage`.
+
+### Why
+
+- `sendUserMessage` enqueues into the same steering queue that holds real user input, and that queue carries no provenance. A host projecting it (the OmO desktop composer) rendered the raw `<system-reminder>Detached eval cell ... cancelled.` notice under its STEERING heading as if the user had typed and queued it.
+- The sibling injectors already solved this: terminal (`senpi-terminal:notification`), monitor (`senpi-monitor:notification`), and loop-guard notices all use `sendMessage` with a `customType`, documented as "deliver a model-visible notification without rendering synthetic user input". The eval notifier was the sole caller still using the user-input door, so this aligns it with the existing contract rather than adding a new mechanism.
+
+### Why an extension could not handle it
+
+- The notifier is owned by this package and constructed during its extension factory wiring; the delivery door it calls is chosen inside `senpiCodemode`, so no downstream extension can redirect it.
+
+### Expected merge conflict zones
+
+- LOW in `src/extension/eval-notifier.ts` around the deps interface and the notify body.
+- LOW in `src/index.ts` around the `CodemodeExtensionAPI` surface and the notifier construction.
+- LOW in the codemode test fakes that implement the host API surface.
+
 ## Subprocess readiness gates cell execution (2026-08-21)
 
 ### What changed

--- a/packages/senpi-codemode/src/extension/eval-notifier.ts
+++ b/packages/senpi-codemode/src/extension/eval-notifier.ts
@@ -3,10 +3,17 @@ import type { EvalDetachedCellNotification, EvalDetachedCellNotifier } from "../
 
 const NON_INTERACTIVE_MODES = new Set(["print", "json"]);
 
+/** Provenance marker for agent-internal detached-cell notices. */
+export const EVAL_NOTIFICATION_CUSTOM_TYPE = "senpi-codemode:notification";
+
 export type EvalNotifyMode = "wake" | "next-turn" | "off";
 
 export interface EvalNotifierDeps {
-	readonly sendUserMessage: (content: string, options?: { deliverAs?: "steer" | "followUp" }) => void;
+	/** Deliver a model-visible notification without rendering synthetic user input. */
+	readonly sendMessage: (
+		message: { customType: string; content: string; display: boolean },
+		options: { triggerTurn: boolean; deliverAs: "steer" | "followUp" },
+	) => void;
 	readonly getContext: () => ExtensionContext | undefined;
 	readonly getMode: () => EvalNotifyMode;
 }
@@ -33,8 +40,13 @@ export class EvalNotifier implements EvalDetachedCellNotifier {
 		const pending = cells.filter((cell) => !this.#notified.has(cell.cellId));
 		if (pending.length === 0) return;
 		for (const cell of pending) this.#notified.add(cell.cellId);
-		this.#deps.sendUserMessage(pending.map((cell) => cell.content).join("\n\n"), {
-			deliverAs: mode === "wake" ? "steer" : "followUp",
-		});
+		this.#deps.sendMessage(
+			{
+				customType: EVAL_NOTIFICATION_CUSTOM_TYPE,
+				content: pending.map((cell) => cell.content).join("\n\n"),
+				display: false,
+			},
+			{ triggerTurn: true, deliverAs: mode === "wake" ? "steer" : "followUp" },
+		);
 	}
 }

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -44,7 +44,10 @@ export interface CodemodeExtensionAPI {
 	executeTool: AgentExecuteTool;
 	getActiveTools(): string[];
 	getAllTools(): readonly EvalSchemaToolInfo[];
-	sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
+	sendMessage(
+		message: { customType: string; content: string; display: boolean },
+		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
+	): void;
 	/** Optional host event bus; a host without one turns extension event emission into a harmless no-op. */
 	events?: { emit(name: string, data: unknown): void };
 	/** Optional host RPC surface for forwarding extension-owned events to connected clients. */
@@ -69,7 +72,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	let activeContext: ExtensionContext | undefined;
 	let activeCells: EvalDetachedCellManager | undefined;
 	const notifier = new EvalNotifier({
-		sendUserMessage: (content, notifyOptions) => pi.sendUserMessage(content, notifyOptions),
+		sendMessage: (message, notifyOptions) => pi.sendMessage(message, notifyOptions),
 		getContext: () => activeContext,
 		getMode: () => "wake",
 	});

--- a/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-execution-event-wiring.test.ts
@@ -50,7 +50,7 @@ class WiringPi {
 			details: {},
 		};
 	}
-	sendUserMessage(): void {}
+	sendMessage(): void {}
 	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
 		for (const entry of this.handlers.filter((handler) => handler.event === event)) await entry.handler(payload, ctx);
 	}

--- a/packages/senpi-codemode/test/eval-notifier.test.ts
+++ b/packages/senpi-codemode/test/eval-notifier.test.ts
@@ -1,18 +1,50 @@
 import type { Api, Model } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { EvalNotifier } from "../src/extension/eval-notifier.ts";
+import { EVAL_NOTIFICATION_CUSTOM_TYPE, EvalNotifier } from "../src/extension/eval-notifier.ts";
 import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
 import { FakeKernel, fakeExtensionContext } from "./eval/fakes.ts";
+
+interface RecordedMessage {
+	readonly customType: string;
+	readonly content: string;
+	readonly display: boolean;
+	readonly deliverAs?: string;
+	readonly triggerTurn?: boolean;
+}
 
 afterEach(() => {
 	vi.useRealTimers();
 });
 
 describe("EvalNotifier", () => {
+	it("delivers detached-cell notices as non-displayed custom messages, never as synthetic user input", () => {
+		const delivered: RecordedMessage[] = [];
+		const notifier = new EvalNotifier({
+			sendMessage: (message, options) => delivered.push({ ...message, ...options }),
+			getContext: () => ({ ...fakeExtensionContext(), mode: "tui", model: fakeModel() }),
+			getMode: () => "wake",
+		});
+
+		notifier.notify([
+			{
+				cellId: "leaky-cell",
+				content: "<system-reminder>Detached eval cell leaky-cell (js) cancelled.</system-reminder>",
+			},
+		]);
+
+		expect(delivered).toHaveLength(1);
+		// The composer renders the user-input steering queue. An agent-internal
+		// notice must carry provenance and stay undisplayed so it cannot be
+		// painted as the user's own queued message.
+		expect(delivered[0]?.customType).toBe(EVAL_NOTIFICATION_CUSTOM_TYPE);
+		expect(delivered[0]?.display).toBe(false);
+		expect(delivered[0]?.content).toContain("leaky-cell");
+	});
+
 	it("scopes once-per-cell delivery to one session generation", () => {
 		const messages: string[] = [];
 		const notifier = new EvalNotifier({
-			sendUserMessage: (content) => messages.push(content),
+			sendMessage: (message) => messages.push(message.content),
 			getContext: () => ({ ...fakeExtensionContext(), mode: "tui", model: fakeModel() }),
 			getMode: () => "wake",
 		});
@@ -27,10 +59,9 @@ describe("EvalNotifier", () => {
 
 	it("wakes the main agent when a detached cell is killed by the hard limit", async () => {
 		vi.useFakeTimers();
-		const delivered: Array<{ content: string; deliverAs?: string }> = [];
+		const delivered: RecordedMessage[] = [];
 		const notifier = new EvalNotifier({
-			sendUserMessage: (content, options) =>
-				delivered.push({ content, ...(options?.deliverAs === undefined ? {} : { deliverAs: options.deliverAs }) }),
+			sendMessage: (message, options) => delivered.push({ ...message, ...options }),
 			getContext: () => ({ ...fakeExtensionContext(), mode: "tui", model: fakeModel() }),
 			getMode: () => "wake",
 		});
@@ -47,6 +78,7 @@ describe("EvalNotifier", () => {
 
 		expect(delivered).toHaveLength(1);
 		expect(delivered[0]?.deliverAs).toBe("steer");
+		expect(delivered[0]?.display).toBe(false);
 		expect(delivered[0]?.content).toContain("killed-cell");
 		expect(delivered[0]?.content).toContain("2s hard limit");
 	});

--- a/packages/senpi-codemode/test/eval-status-wiring.test.ts
+++ b/packages/senpi-codemode/test/eval-status-wiring.test.ts
@@ -37,8 +37,8 @@ class WiringPi {
 	async executeTool(): Promise<never> {
 		throw new Error("nested tool execution was not expected");
 	}
-	sendUserMessage(content: string): void {
-		this.messages.push(content);
+	sendMessage(message: { customType: string; content: string; display: boolean }): void {
+		this.messages.push(message.content);
 	}
 	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
 		for (const entry of this.handlers.filter((handler) => handler.event === event)) await entry.handler(payload, ctx);

--- a/packages/senpi-codemode/test/eval-wake-source.test.ts
+++ b/packages/senpi-codemode/test/eval-wake-source.test.ts
@@ -154,8 +154,8 @@ class WiringPi {
 	async executeTool(): Promise<never> {
 		throw new Error("nested tool execution was not expected");
 	}
-	sendUserMessage(content: string): void {
-		this.messages.push(content);
+	sendMessage(message: { customType: string; content: string; display: boolean }): void {
+		this.messages.push(message.content);
 	}
 	async emit(event: string, payload: unknown, ctx: ExtensionContext): Promise<void> {
 		for (const entry of this.handlers.filter((handler) => handler.event === event)) await entry.handler(payload, ctx);

--- a/packages/senpi-codemode/test/extension.test.ts
+++ b/packages/senpi-codemode/test/extension.test.ts
@@ -47,10 +47,13 @@ class FakePi {
 	async executeTool(): Promise<never> {
 		throw new Error("nested tool execution was not expected");
 	}
-	sendUserMessage(content: string, options?: { readonly deliverAs?: "steer" | "followUp" }): void {
-		this.messages.push(content);
-		this.deliveries.push({ content, deliverAs: options?.deliverAs });
-		this.#nextMessage.resolve(content);
+	sendMessage(
+		message: { customType: string; content: string; display: boolean },
+		options?: { readonly deliverAs?: "steer" | "followUp" },
+	): void {
+		this.messages.push(message.content);
+		this.deliveries.push({ content: message.content, deliverAs: options?.deliverAs });
+		this.#nextMessage.resolve(message.content);
 	}
 	nextMessage(): Promise<string> {
 		return this.#nextMessage.promise;


### PR DESCRIPTION
## Summary

Detached eval cell completion notices (`<system-reminder>Detached eval cell ... cancelled.</system-reminder>`) were delivered via `sendUserMessage`, which enqueues into the same steering queue that holds real user input — and that queue carries no provenance. A host projecting the queue (the OmO desktop composer) rendered the raw notice under its STEERING heading as if the user had typed and queued it themselves.

This aligns the eval notifier with the contract its siblings already implement: terminal (`senpi-terminal:notification`), monitor (`senpi-monitor:notification`), and loop-guard notices all deliver via `sendMessage` with a `customType` and `display: false` — "deliver a model-visible notification without rendering synthetic user input".

## Changes

- `packages/senpi-codemode/src/extension/eval-notifier.ts`: `EvalNotifierDeps.sendMessage` replaces `sendUserMessage`. Delivery uses the new `EVAL_NOTIFICATION_CUSTOM_TYPE` (`senpi-codemode:notification`), `display: false`, `triggerTurn: true`. Wake/next-turn still selects `steer` vs `followUp`; delivery stays once-per-cell per session generation.
- `packages/senpi-codemode/src/index.ts`: `CodemodeExtensionAPI.sendMessage` replaces `sendUserMessage`; the host binding forwards to `pi.sendMessage`.
- Test fakes implement the new host surface.

## Evidence

- Failing-first: the new `eval-notifier.test.ts` case asserted provenance + `display: false` before the fix and failed with `sendUserMessage is not a function` / missing `EVAL_NOTIFICATION_CUSTOM_TYPE` (red run captured).
- Green: `packages/senpi-codemode` suite 90 files, 619 passed / 6 skipped / 0 failed.
- Root `npm run check` exit 0 (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, platform-lock, `tsc --noEmit`, browser-smoke).
- `scripts/qa-detached-peek.ts` driver passes end to end (detached py cell, peek, clean kernel/bridge teardown).

## Notes

- The steering-queue leak only manifests in hosts that project `queue_update` steering entries; the fix is on the senpi side at the injection point, not a UI-side filter.
- Changes.md entry added per package convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents detached eval-cell notices from rendering as user input by delivering them as internal messages. Previously we used `sendUserMessage` into the steering queue; now we call `sendMessage` with `customType: "senpi-codemode:notification"`, `display: false`, and `triggerTurn: true`. Wake mode still selects `steer` vs `followUp`, and delivery remains once per cell per session. `CodemodeExtensionAPI` now exposes `sendMessage` and removes `sendUserMessage`.

- Migration
  - Hosts implementing `CodemodeExtensionAPI` must implement `sendMessage(message, { triggerTurn, deliverAs })` and remove or shim `sendUserMessage`.
  - No UI changes required; notices are undisplayed internal messages even if the host projects the steering queue.

<sup>Written for commit 19c8d5b0ef973cf248b85237866dfc86b93672d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

