### PR TITLE
fix(ai): strip sep-less kimi xtml channel markers from visible text

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Kimi XTML channel markers no longer reach user-visible assistant text when a leaked marker arrives without its trailing `<|sep|>` (seen live as a text block ending in the literal `<|close|>think` newline). One shared channel-marker grammar now backs both the stream recovery parser and message-level thinking recovery, which also strips markers from `text` blocks while keeping code-span literals intact ([#1092](https://github.com/code-yeongyu/senpi/pull/1092)).
+
 ### Removed
 
 ## [2026.8.22-2] - 2026-08-22

--- a/packages/ai/src/tool-call-middleware/changes.md
+++ b/packages/ai/src/tool-call-middleware/changes.md
@@ -1,6 +1,35 @@
 # Tool Call Middleware Changes
 
-# Tool Call Middleware Changes
+## 2026-08-23 - Kimi XTML sep-less channel marker leak
+
+### What changed and why
+
+- Kimi models leak XTML channel markers into visible text when tool calling
+  fails mid-think: session 01a02505 (message 84281a4b, `kimi-k3-ultrafast-unlocked`)
+  ended a user-visible text block with the literal `<|close|>think\n` because the
+  marker arrives without its trailing `<|sep|>`. Both defenses missed it: the
+  stream recovery parser only recognized `<|sep|>`-terminated markers (the
+  fallback re-emitted the marker bytes as 2-char text slices), and
+  `recoverKimiXtmlThinking()` never scanned `text` blocks at all.
+- `markers.ts` now owns a single shared `XTML_CHANNEL_MARKER_PATTERN` consumed by
+  BOTH the stream parser and the message-level recovery, so the two paths cannot
+  drift again: a marker is `<|open|>`/`<|close|>` + optional channel name
+  (`call`/`argument` reserved for structural opens) + optional `<|sep|>`,
+  terminated by `<|sep|>`, a non-word character, or end of stream; a bare
+  `<|sep|>` is also a marker. `matchXtmlChannelMarker()` anchors it for the
+  streaming state machine.
+- `recovery-stream.ts` holds a buffer that could still grow into a longer marker
+  (name run, partial `<|sep|>`) instead of emitting bytes, defers to structural
+  `<|open|>call `/`<|open|>argument ` opens before generic matching, runs behind
+  a recovery code mask so fenced/inline code keeps marker-shaped literals, and
+  strips held complete markers at `finish()` rather than flushing them.
+- `thinking-recovery.ts` additionally strips markers from `text` blocks (same
+  code-mask treatment). Text-block stripping is silent: the
+  `kimi_xtml_thinking_recovery` diagnostic still fires only for thinking-channel
+  recovery, keeping the runtime-boundary diagnostics contract stable.
+- A word run after a marker is absorbed into the channel name
+  (`<|close|>thinkafter` strips whole), which is the only self-consistent reading
+  of the protocol; incomplete junk like `<|clo` still flushes as plain text.
 
 ## 2026-08-18 - Wire-alias tool-name resolution in invoke recovery
 

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/markers.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/markers.ts
@@ -6,6 +6,28 @@ export const XTML_ARGUMENT_OPEN = "<|open|>argument ";
 export const XTML_ARGUMENT_CLOSE = "<|close|>argument<|sep|>";
 export const XTML_SEP = "<|sep|>";
 
+export const XTML_OPEN_PREFIX = "<|open|>";
+export const XTML_CLOSE_PREFIX = "<|close|>";
+
+const CHANNEL_NAME = "[a-zA-Z_][a-zA-Z0-9_]*";
+const STRUCTURAL_CHANNEL_NAME = "(?:call|argument)\\b";
+const SEPLESS_CHANNEL_NAME = `(?!${STRUCTURAL_CHANNEL_NAME})${CHANNEL_NAME}`;
+
+export const XTML_CHANNEL_MARKER_PATTERN = new RegExp(
+	[
+		`<\\|(?:open|close)\\|>(?:${CHANNEL_NAME})?<\\|sep\\|>`,
+		`<\\|(?:open|close)\\|>(?:${SEPLESS_CHANNEL_NAME})?(?=$|[^a-zA-Z0-9_])`,
+		`<\\|sep\\|>`,
+	].join("|"),
+	"g",
+);
+
+const ANCHORED_CHANNEL_MARKER_PATTERN = new RegExp(`^(?:${XTML_CHANNEL_MARKER_PATTERN.source})`);
+
+export function matchXtmlChannelMarker(text: string): string | undefined {
+	return ANCHORED_CHANNEL_MARKER_PATTERN.exec(text)?.[0];
+}
+
 const ATTRIBUTE_PATTERN = /([\w-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s<]+))/g;
 
 export function parseXtmlAttributes(header: string): Record<string, string> {

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts
@@ -1,13 +1,17 @@
 import type { Tool } from "../../../types.ts";
+import { createRecoveryCodeMask } from "../../recovery-code-mask.ts";
 import type { ParserOptions, StreamParserEvent } from "../../types.ts";
 import type { RecoveryStreamParser } from "../anthropic-xml/recovery-stream.ts";
 import {
 	getPartialXtmlSuffix,
+	matchXtmlChannelMarker,
 	parseXtmlAttributes,
 	XTML_ARGUMENT_CLOSE,
 	XTML_ARGUMENT_OPEN,
 	XTML_CALL_CLOSE,
 	XTML_CALL_OPEN,
+	XTML_CLOSE_PREFIX,
+	XTML_OPEN_PREFIX,
 	XTML_SEP,
 	XTML_TOOLS_CLOSE,
 	XTML_TOOLS_OPEN,
@@ -23,24 +27,32 @@ type ParserMode =
 	| "argument-value"
 	| "discard-call";
 
-const CHANNEL_MARKER_PATTERN = /^<\|(?:open|close)\|>(?:[a-zA-Z_][a-zA-Z0-9_]*)?<\|sep\|>/;
-const OPEN_PREFIX = "<|open|>";
-const CLOSE_PREFIX = "<|close|>";
+const MARKER_PREFIXES = [XTML_OPEN_PREFIX, XTML_CLOSE_PREFIX, XTML_SEP] as const;
 
-function couldBeMarkerPrefix(tail: string): boolean {
-	if (OPEN_PREFIX.startsWith(tail) || CLOSE_PREFIX.startsWith(tail)) return true;
-	for (const prefix of [OPEN_PREFIX, CLOSE_PREFIX]) {
-		if (!tail.startsWith(prefix)) continue;
-		const rest = tail.slice(prefix.length);
-		const angleIndex = rest.indexOf("<");
-		if (angleIndex === -1) return /^[a-zA-Z0-9_]*$/.test(rest);
-		if (!/^(?:[a-zA-Z_][a-zA-Z0-9_]*)?$/.test(rest.slice(0, angleIndex))) return false;
-		return XTML_SEP.startsWith(rest.slice(angleIndex));
-	}
-	return false;
+function findMarkerStart(text: string): number | undefined {
+	return MARKER_PREFIXES.map((prefix) => text.indexOf(prefix))
+		.filter((index) => index !== -1)
+		.sort((a, b) => a - b)[0];
+}
+
+function couldExtendMarker(buffer: string, marker: string): boolean {
+	if (marker.endsWith(XTML_SEP)) return false;
+	const rest = buffer.slice(marker.length);
+	return rest.length === 0 || XTML_SEP.startsWith(rest);
+}
+
+const STRUCTURAL_MARKER_OPENS = [XTML_CALL_OPEN, XTML_ARGUMENT_OPEN] as const;
+
+function startsCompleteStructuralMarker(buffer: string): boolean {
+	return STRUCTURAL_MARKER_OPENS.some((open) => buffer.startsWith(open));
+}
+
+function startsPartialStructuralMarker(buffer: string): boolean {
+	return STRUCTURAL_MARKER_OPENS.some((open) => buffer.length < open.length && open.startsWith(buffer));
 }
 
 export function createXtmlRecoveryStreamParser(tools: readonly Tool[], options?: ParserOptions): RecoveryStreamParser {
+	const mask = createRecoveryCodeMask();
 	let buffer = "";
 	let mode: ParserMode = "text";
 	let callIndex = -1;
@@ -82,11 +94,9 @@ export function createXtmlRecoveryStreamParser(tools: readonly Tool[], options?:
 	}
 
 	function processText(events: StreamParserEvent[]): boolean {
-		const openIndex = buffer.indexOf(OPEN_PREFIX);
-		const closeIndex = buffer.indexOf(CLOSE_PREFIX);
-		const markerIndex = [openIndex, closeIndex].filter((index) => index !== -1).sort((a, b) => a - b)[0];
+		const markerIndex = findMarkerStart(buffer);
 		if (markerIndex === undefined) {
-			const partial = getPartialXtmlSuffix(buffer, [OPEN_PREFIX, CLOSE_PREFIX]);
+			const partial = getPartialXtmlSuffix(buffer, MARKER_PREFIXES);
 			const flushable = partial ? buffer.slice(0, -partial.length) : buffer;
 			if (flushable) events.push({ type: "text", text: flushable });
 			buffer = partial;
@@ -97,14 +107,18 @@ export function createXtmlRecoveryStreamParser(tools: readonly Tool[], options?:
 			buffer = buffer.slice(markerIndex);
 			return true;
 		}
-		const markerMatch = CHANNEL_MARKER_PATTERN.exec(buffer);
-		if (markerMatch) {
-			const marker = markerMatch[0];
+		if (startsCompleteStructuralMarker(buffer)) {
+			mode = "tools";
+			return true;
+		}
+		if (startsPartialStructuralMarker(buffer)) return false;
+		const marker = matchXtmlChannelMarker(buffer);
+		if (marker) {
+			if (couldExtendMarker(buffer, marker)) return false;
 			buffer = buffer.slice(marker.length);
 			if (marker === XTML_TOOLS_OPEN) mode = "tools";
 			return true;
 		}
-		if (couldBeMarkerPrefix(buffer)) return false;
 		events.push({ type: "text", text: buffer.slice(0, 2) });
 		buffer = buffer.slice(2);
 		return true;
@@ -189,12 +203,27 @@ export function createXtmlRecoveryStreamParser(tools: readonly Tool[], options?:
 		}
 	}
 
+	function consume(segments: readonly { readonly text: string; readonly scan: boolean }[]): StreamParserEvent[] {
+		const events: StreamParserEvent[] = [];
+		for (const segment of segments) {
+			if (segment.scan) {
+				buffer += segment.text;
+				process(events);
+				continue;
+			}
+			if (mode === "text" && buffer) {
+				events.push({ type: "text", text: buffer });
+				buffer = "";
+			}
+			if (mode === "text") events.push({ type: "text", text: segment.text });
+			else buffer += segment.text;
+		}
+		return events;
+	}
+
 	return {
 		feed(textDelta: string): StreamParserEvent[] {
-			buffer += textDelta;
-			const events: StreamParserEvent[] = [];
-			process(events);
-			return events;
+			return consume(mask.feed(textDelta));
 		},
 		interrupt(): StreamParserEvent[] {
 			const events: StreamParserEvent[] = [];
@@ -205,9 +234,16 @@ export function createXtmlRecoveryStreamParser(tools: readonly Tool[], options?:
 			return events;
 		},
 		finish(): StreamParserEvent[] {
-			const events: StreamParserEvent[] = [];
+			const events: StreamParserEvent[] = consume(mask.finish());
 			if (mode === "text") {
-				if (buffer) events.push({ type: "text", text: buffer });
+				let rest = buffer;
+				for (;;) {
+					const marker = matchXtmlChannelMarker(rest);
+					if (!marker) break;
+					rest = rest.slice(marker.length);
+				}
+				if (XTML_SEP.startsWith(rest) && rest.length > 0) rest = "";
+				if (rest) events.push({ type: "text", text: rest });
 			} else if (callStarted) {
 				endCall(events, true);
 			}

--- a/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts
+++ b/packages/ai/src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, ThinkingContent } from "../../../types.ts";
 import { createRecoveryCodeMask } from "../../recovery-code-mask.ts";
+import { XTML_CHANNEL_MARKER_PATTERN } from "./markers.ts";
 
 type OutputChannel = "thinking" | "response";
 
@@ -10,7 +11,7 @@ type RecoveredThinking = {
 	readonly recoveredResponse: boolean;
 };
 
-const CHANNEL_MARKER_PATTERN = /<\|(open|close)\|>([a-zA-Z_][a-zA-Z0-9_]*)?<\|sep\|>|<\|(?:open|close|sep)\|>/g;
+const NAMED_MARKER_PATTERN = /^<\|(open|close)\|>([a-zA-Z_][a-zA-Z0-9_]*)?/;
 
 function recoverThinkingContent(input: string): RecoveredThinking {
 	const mask = createRecoveryCodeMask();
@@ -27,12 +28,13 @@ function recoverThinkingContent(input: string): RecoveredThinking {
 
 	const scan = (text: string): void => {
 		let offset = 0;
-		for (const match of text.matchAll(CHANNEL_MARKER_PATTERN)) {
+		for (const match of text.matchAll(XTML_CHANNEL_MARKER_PATTERN)) {
 			const index = match.index;
 			if (index === undefined) continue;
 			append(text.slice(offset, index));
-			const action = match[1];
-			const name = match[2];
+			const named = NAMED_MARKER_PATTERN.exec(match[0]);
+			const action = named?.[1];
+			const name = named?.[2];
 			changed = true;
 			if (action === "open" && name === "response") {
 				channel = "response";
@@ -59,18 +61,44 @@ function recoveredThinkingBlock(block: ThinkingContent, thinking: string): Think
 	return { ...block, thinking };
 }
 
+function strippedVisibleText(input: string): { readonly text: string; readonly changed: boolean } {
+	const mask = createRecoveryCodeMask();
+	let text = "";
+	let changed = false;
+
+	for (const segment of [...mask.feed(input), ...mask.finish()]) {
+		if (!segment.scan) {
+			text += segment.text;
+			continue;
+		}
+		const stripped = segment.text.replace(XTML_CHANNEL_MARKER_PATTERN, "");
+		if (stripped !== segment.text) changed = true;
+		text += stripped;
+	}
+
+	return { text, changed };
+}
+
 export function recoverKimiXtmlThinking(message: AssistantMessage): AssistantMessage {
 	let changed = false;
+	let thinkingChanged = false;
 	let recoveredResponse = false;
 	const content: AssistantMessage["content"] = [];
 
 	for (const block of message.content) {
+		if (block.type === "text") {
+			const stripped = strippedVisibleText(block.text);
+			changed = changed || stripped.changed;
+			content.push(stripped.changed ? { ...block, text: stripped.text } : block);
+			continue;
+		}
 		if (block.type !== "thinking") {
 			content.push(block);
 			continue;
 		}
 		const recovered = recoverThinkingContent(block.thinking);
 		changed = changed || recovered.changed;
+		thinkingChanged = thinkingChanged || recovered.changed;
 		recoveredResponse = recoveredResponse || recovered.recoveredResponse;
 		content.push(recoveredThinkingBlock(block, recovered.thinking));
 		if (recovered.response.length > 0) content.push({ type: "text", text: recovered.response });
@@ -80,13 +108,15 @@ export function recoverKimiXtmlThinking(message: AssistantMessage): AssistantMes
 	return {
 		...message,
 		content,
-		diagnostics: [
-			...(message.diagnostics ?? []),
-			{
-				type: "kimi_xtml_thinking_recovery",
-				timestamp: Date.now(),
-				details: { recoveredResponse },
-			},
-		],
+		diagnostics: thinkingChanged
+			? [
+					...(message.diagnostics ?? []),
+					{
+						type: "kimi_xtml_thinking_recovery",
+						timestamp: Date.now(),
+						details: { recoveredResponse },
+					},
+				]
+			: message.diagnostics,
 	};
 }

--- a/packages/ai/test/tool-call-middleware/kimi-xtml-marker-leak.test.ts
+++ b/packages/ai/test/tool-call-middleware/kimi-xtml-marker-leak.test.ts
@@ -1,0 +1,207 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { createXtmlRecoveryStreamParser } from "../../src/tool-call-middleware/protocols/kimi-xtml/recovery-stream.ts";
+import { recoverKimiXtmlThinking } from "../../src/tool-call-middleware/protocols/kimi-xtml/thinking-recovery.ts";
+import type { StreamParserEvent } from "../../src/tool-call-middleware/types.ts";
+import type { AssistantMessage, Tool } from "../../src/types.ts";
+
+const todoTool: Tool = {
+	name: "todo",
+	description: "Track work items",
+	parameters: Type.Object({ op: Type.String() }),
+};
+
+function textOf(events: readonly StreamParserEvent[]): string {
+	return events
+		.filter((event) => event.type === "text")
+		.map((event) => (event.type === "text" ? event.text : ""))
+		.join("");
+}
+
+function streamText(chunks: readonly string[]): string {
+	const parser = createXtmlRecoveryStreamParser([todoTool]);
+	const events: StreamParserEvent[] = [];
+	for (const chunk of chunks) events.push(...parser.feed(chunk));
+	events.push(...parser.finish());
+	return textOf(events);
+}
+
+function messageWithText(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		api: "openai-completions",
+		provider: "apitopia",
+		model: "kimi-k3-ultrafast-unlocked",
+		content: [{ type: "text", text }],
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: 1,
+	};
+}
+
+function visibleText(message: AssistantMessage): string {
+	return message.content
+		.filter((item) => item.type === "text")
+		.map((item) => (item.type === "text" ? item.text : ""))
+		.join("");
+}
+
+type MarkerShape = { readonly name: string; readonly marker: string; readonly trailing: string };
+
+const MARKER_SHAPES: readonly MarkerShape[] = [
+	{ name: "named close terminated by <|sep|>", marker: "<|close|>think", trailing: "<|sep|>" },
+	{ name: "named close terminated by newline", marker: "<|close|>think", trailing: "\n" },
+	{ name: "named close terminated by end of stream", marker: "<|close|>think", trailing: "\n" },
+	{ name: "named open terminated by newline", marker: "<|open|>think", trailing: "\n" },
+	{ name: "named close terminated by a space", marker: "<|close|>think", trailing: " " },
+	{ name: "unnamed close", marker: "<|close|>", trailing: "<|sep|>" },
+	{ name: "unnamed open", marker: "<|open|>", trailing: "<|sep|>" },
+	{ name: "bare separator", marker: "<|sep|>", trailing: "" },
+	{ name: "named response close terminated by newline", marker: "<|close|>response", trailing: "\n" },
+];
+
+const PRODUCTION_LEAK_TAIL = "Time to report, not act further.<|close|>think\n";
+
+describe("kimi xtml channel markers never reach visible text", () => {
+	it.each(MARKER_SHAPES)("strips a $name from the streamed text channel", ({ marker, trailing }: MarkerShape) => {
+		// given
+		const chunk = `before ${marker}${trailing}after`;
+
+		// when
+		const text = streamText([chunk]);
+
+		// then
+		expect(text).not.toContain("<|");
+		expect(text).toContain("before ");
+		expect(text).toContain("after");
+	});
+
+	it.each(MARKER_SHAPES)("strips a $name split across every chunk boundary", ({ marker, trailing }: MarkerShape) => {
+		// given
+		const payload = `${marker}${trailing}`;
+
+		// when
+		const outputs = Array.from({ length: payload.length - 1 }, (_unused, index) =>
+			streamText([`before${payload.slice(0, index + 1)}`, `${payload.slice(index + 1)}after`]),
+		);
+
+		// then
+		for (const output of outputs) expect(output).not.toContain("<|");
+	});
+
+	it.each(MARKER_SHAPES)("strips a $name from a visible text block", ({ marker, trailing }: MarkerShape) => {
+		// given
+		const message = messageWithText(`before ${marker}${trailing}after`);
+
+		// when
+		const recovered = recoverKimiXtmlThinking(message);
+
+		// then
+		expect(visibleText(recovered)).not.toContain("<|");
+		expect(visibleText(recovered)).toContain("before ");
+		expect(visibleText(recovered)).toContain("after");
+	});
+
+	it("strips the verbatim production leak from the streamed text channel", () => {
+		// when
+		const text = streamText([PRODUCTION_LEAK_TAIL]);
+
+		// then
+		expect(text).toBe("Time to report, not act further.\n");
+	});
+
+	it("strips the verbatim production leak from a visible text block", () => {
+		// given
+		const message = messageWithText(PRODUCTION_LEAK_TAIL);
+
+		// when
+		const recovered = recoverKimiXtmlThinking(message);
+
+		// then
+		expect(visibleText(recovered)).toBe("Time to report, not act further.\n");
+	});
+
+	it("keeps marker-shaped prose inside fenced code intact", () => {
+		// given
+		const literal = "Docs:\n```text\n<|close|>think\n<|open|>response\n```\ndone";
+
+		// when
+		const streamed = streamText([literal]);
+		const recovered = recoverKimiXtmlThinking(messageWithText(literal));
+
+		// then
+		expect(streamed).toBe(literal);
+		expect(visibleText(recovered)).toBe(literal);
+	});
+
+	it("keeps text that merely looks like a marker intact", () => {
+		// given
+		const prose = "compare a <| b and pipes |> here";
+
+		// when
+		const streamed = streamText([prose]);
+		const recovered = recoverKimiXtmlThinking(messageWithText(prose));
+
+		// then
+		expect(streamed).toBe(prose);
+		expect(visibleText(recovered)).toBe(prose);
+	});
+
+	it("strips a marker that ends the stream with no terminator", () => {
+		// given / when
+		const streamed = streamText(["before <|close|>think"]);
+		const recovered = visibleText(recoverKimiXtmlThinking(messageWithText("before <|close|>think")));
+
+		// then
+		expect(streamed).toBe("before ");
+		expect(recovered).toBe("before ");
+	});
+
+	it("absorbs a word run after a marker into the channel name", () => {
+		// given
+		const ambiguous = "before <|close|>thinkafter";
+
+		// when
+		const text = streamText([ambiguous]);
+
+		// then
+		expect(text).toBe("before ");
+	});
+
+	it("flushes an incomplete marker prefix that never completes before end of stream", () => {
+		// when
+		const text = streamText(["tail end <|clo"]);
+
+		// then
+		expect(text).toBe("tail end <|clo");
+	});
+
+	it("still recovers a well-formed tools block into tool call events", () => {
+		// given
+		const block = [
+			"<|open|>tools<|sep|>",
+			'<|open|>call tool="todo" index="1"<|sep|>',
+			'<|open|>argument key="op" type="string"<|sep|>view<|close|>argument<|sep|>',
+			"<|close|>call<|sep|>",
+			"<|close|>tools<|sep|>",
+		].join("");
+		const parser = createXtmlRecoveryStreamParser([todoTool]);
+
+		// when
+		const events = [...parser.feed(`One moment. ${block} Done.`), ...parser.finish()];
+
+		// then
+		expect(events.find((event) => event.type === "toolcall_end")).toMatchObject({
+			name: "todo",
+			arguments: { op: "view" },
+		});
+		expect(textOf(events)).toBe("One moment.  Done.");
+	});
+});


### PR DESCRIPTION
## Summary

Kimi models can end a user-visible assistant text block with a raw XTML channel marker when the marker arrives without its trailing `<|sep|>` (production incident: session 01a02505, message 84281a4b, `kimi-k3-ultrafast-unlocked` — visible text ended with the literal `<|close|>think\n`).

Both existing defenses missed it:
- the stream recovery parser only recognized `<|sep|>`-terminated markers and re-emitted everything else as 2-char text slices;
- `recoverKimiXtmlThinking()` had a regex that could match bare markers but only ever scanned `thinking` blocks, never `text` blocks.

## What changed

- `markers.ts` now owns a single shared `XTML_CHANNEL_MARKER_PATTERN` consumed by **both** the stream parser and message-level recovery, so the two paths cannot drift apart again. Marker grammar: `<|open|>`/`<|close|>` + optional channel name (`call`/`argument` reserved for structural opens) + optional `<|sep|>`, terminated by `<|sep|>`, any non-word character, or end of stream; bare `<|sep|>` is also a marker.
- `recovery-stream.ts`: holds a buffer that could still grow into a longer marker (name run, partial `<|sep|>`) instead of emitting bytes; defers to structural `<|open|>call `/`<|open|>argument ` opens before generic matching; runs behind a recovery code mask so marker-shaped literals inside fenced/inline code survive verbatim; `finish()` strips held complete markers instead of flushing them.
- `thinking-recovery.ts`: additionally strips markers from `text` blocks with the same code-mask treatment. Text-block stripping is silent — the `kimi_xtml_thinking_recovery` diagnostic still fires only for thinking-channel recovery, keeping the runtime-boundary diagnostics contract unchanged.
- New matrix test `kimi-xtml-marker-leak.test.ts` (35 cases): 9-shape marker matrix on both paths, every-chunk-boundary splits, verbatim production tail, EOF termination, fenced-code and lookalike-prose preservation, and a well-formed tools block still recovering into an executable tool call.

## Verification

- New matrix: 35/35 (was RED 27 failed / 6 passed at the base commit before any src change).
- `packages/ai` tool-call-middleware suite: 533/533 across 42 files.
- `packages/coding-agent` kimi-xtml runtime boundary: 2/2.
- `tsc --noEmit` clean; LSP diagnostics 0 errors; biome clean.
- Real-surface replay: extracted message 84281a4b verbatim from the session JSONL and fed it char-by-char through both paths — marker stripped, all other bytes identical.

## Notes

- A word run after a marker is absorbed into the channel name (`<|close|>thinkafter` strips whole) — the only self-consistent reading of the protocol; incomplete junk like `<|clo` still flushes as plain text.
- Changes.md fork-tracker entry added.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Kimi XTML channel markers without `<|sep|>` from appearing in visible assistant text. Before: the stream parser only stripped `<|sep|>`-terminated markers and message recovery skipped `text` blocks, so `<|close|>think` could leak. Now: a shared marker grammar strips markers in both streaming and message recovery while preserving code spans and tool-call behavior.

- Centralizes `XTML_CHANNEL_MARKER_PATTERN` and `matchXtmlChannelMarker()` in `markers.ts`; both the stream parser and message recovery use it.
- Stream parser: buffers potential sep-less markers, prioritizes structural `<|open|>call`/`argument`, masks fenced/inline code, and drops held markers in `finish()`.
- Message recovery: strips markers from `text` blocks with the same code-mask; emits `kimi_xtml_thinking_recovery` only when thinking is recovered.
- Tests: adds `kimi-xtml-marker-leak.test.ts` (35 cases) covering sep-less markers, chunk splits, EOF, code literals, and valid tool-call handling.
- Docs: adds a `packages/ai` changelog entry noting the fix.

No migration required.

<sup>Written for commit 94e64827a3c84a29f8863f6ba1ef769a83a7ec58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

