### PR TITLE
fix(webfetch): drain fallback response bodies

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -129,6 +129,8 @@
 
 ### Fixed
 
+- Webfetch's Bun-compatible response cleanup now drains bodies without `dump()` before destruction and guards discard-time stream errors from escaping as uncaught process errors, adapting the lifecycle hardening proposed by `@Indosaram` in [`pi-webfetch` #7](https://github.com/code-yeongyu/pi-webfetch/pull/7).
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
@@ -33,7 +33,7 @@ Vendored from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-we
 
 ### What changed
 
-- The no-`dump()` fallback now drains the response body through async iteration, bounded by `MAX_RESPONSE_SIZE_BYTES`, before quiet destruction.
+- The no-`dump()` fallback now drains the response body through abort-aware async iteration, bounded by `MAX_RESPONSE_SIZE_BYTES`, before quiet destruction.
 - Cleanup attaches an error listener before destruction so a stream error emitted during best-effort discard cannot escape as an unhandled process error.
 
 ### Why

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
@@ -40,6 +40,10 @@ Vendored from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-we
 
 - The upstream [`pi-webfetch` PR #7](https://github.com/code-yeongyu/pi-webfetch/pull/7) identified the remaining lifecycle edge: destroying immediately can leave a readable body undrained, and a failing stream can emit an unhandled error while it is being destroyed. This adaptation preserves the bounded `dump()` path while adopting the safer drain-and-guard behavior for Bun-compatible bodies.
 
+### Why an extension could not handle it
+
+- Redirect and oversized-response disposal happen inside the vendored fetcher's private request loop before the registered webfetch tool receives a response, so downstream extension hooks cannot replace this cleanup.
+
 ### Expected merge conflict zones
 
 - LOW in `packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts` at the import and cleanup call sites, and in the new `response-body.ts` cleanup module.

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
@@ -29,6 +29,21 @@ Vendored from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-we
 
 - LOW in `packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts` at the `ResponseBodyStream` contract and `discardBody`; re-vendoring may restore a required `dump()` method and error-bearing `destroy(error)` fallback, so retain the runtime feature detection and argument-free destroy behavior.
 
+## 2026-08-23 - Discard fallback drains and guards stream errors
+
+### What changed
+
+- The no-`dump()` fallback now drains the response body through async iteration, bounded by `MAX_RESPONSE_SIZE_BYTES`, before quiet destruction.
+- Cleanup attaches an error listener before destruction so a stream error emitted during best-effort discard cannot escape as an unhandled process error.
+
+### Why
+
+- The upstream [`pi-webfetch` PR #7](https://github.com/code-yeongyu/pi-webfetch/pull/7) identified the remaining lifecycle edge: destroying immediately can leave a readable body undrained, and a failing stream can emit an unhandled error while it is being destroyed. This adaptation preserves the bounded `dump()` path while adopting the safer drain-and-guard behavior for Bun-compatible bodies.
+
+### Expected merge conflict zones
+
+- LOW in `packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts` at the import and cleanup call sites, and in the new `response-body.ts` cleanup module.
+
 ## 2026-08-20 - HTML converters load on first conversion instead of at CLI startup
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
@@ -7,6 +7,7 @@ import {
 	WebfetchResponseTooLargeError,
 	WebfetchTimeoutError,
 } from "./errors.ts";
+import { discardBody, type ResponseBodyStream, toUint8Array } from "./response-body.ts";
 
 export const MAX_RESPONSE_SIZE_BYTES = 5 * 1024 * 1024;
 export const DEFAULT_TIMEOUT_SECONDS = 30;
@@ -44,11 +45,6 @@ interface HttpResponse {
 	readonly statusText: string;
 	readonly headers: IncomingHttpHeaders;
 	readonly body: ResponseBodyStream;
-}
-
-interface ResponseBodyStream extends AsyncIterable<unknown> {
-	destroy(error?: Error): void;
-	dump?(options?: { limit: number; signal?: AbortSignal }): Promise<void>;
 }
 
 export async function fetchUrl(options: FetchOptions): Promise<FetchResult> {
@@ -174,7 +170,7 @@ async function requestUrl(options: RequestUrlOptions): Promise<HttpResponse> {
 			};
 		}
 
-		await discardBody(response.body);
+		await discardBody(response.body, MAX_RESPONSE_SIZE_BYTES);
 		currentUrl = new URL(location, currentUrl).toString();
 	}
 
@@ -202,7 +198,7 @@ async function readHttpResponse(
 async function rejectOversizedContentLength(response: HttpResponse): Promise<void> {
 	const contentLength = getHeader(response.headers, "content-length");
 	if (contentLength && Number.parseInt(contentLength, 10) > MAX_RESPONSE_SIZE_BYTES) {
-		await discardBody(response.body);
+		await discardBody(response.body, MAX_RESPONSE_SIZE_BYTES);
 		throw new WebfetchResponseTooLargeError("Response too large (exceeds 5MB limit)");
 	}
 }
@@ -211,19 +207,6 @@ function getHeader(headers: IncomingHttpHeaders, name: string): string {
 	const value = headers[name.toLowerCase()];
 	if (Array.isArray(value)) return value.join(", ");
 	return value ?? "";
-}
-
-async function discardBody(body: ResponseBodyStream): Promise<void> {
-	if (!body.dump) {
-		body.destroy();
-		return;
-	}
-
-	try {
-		await body.dump({ limit: 1024 });
-	} catch {
-		body.destroy();
-	}
 }
 
 async function readResponseBody(
@@ -271,12 +254,6 @@ function parseContentLength(response: HttpResponse): number | undefined {
 	if (contentLength === "") return undefined;
 	const parsed = Number.parseInt(contentLength, 10);
 	return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
-}
-
-function toUint8Array(chunk: unknown): Uint8Array {
-	if (chunk instanceof Uint8Array) return chunk;
-	if (typeof chunk === "string") return new TextEncoder().encode(chunk);
-	throw new Error("Unexpected response body chunk");
 }
 
 function forwardAbort(signal: AbortSignal | undefined, controller: AbortController): () => void {

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/fetcher.ts
@@ -170,7 +170,7 @@ async function requestUrl(options: RequestUrlOptions): Promise<HttpResponse> {
 			};
 		}
 
-		await discardBody(response.body, MAX_RESPONSE_SIZE_BYTES);
+		await discardBody(response.body, MAX_RESPONSE_SIZE_BYTES, options.signal);
 		currentUrl = new URL(location, currentUrl).toString();
 	}
 
@@ -182,7 +182,7 @@ async function readHttpResponse(
 	signal: AbortSignal,
 	onProgress: FetchOptions["onProgress"],
 ): Promise<FetchResult> {
-	await rejectOversizedContentLength(response);
+	await rejectOversizedContentLength(response, signal);
 	const body = await readResponseBody(response, signal, onProgress);
 	return {
 		url: response.url,
@@ -195,10 +195,10 @@ async function readHttpResponse(
 	};
 }
 
-async function rejectOversizedContentLength(response: HttpResponse): Promise<void> {
+async function rejectOversizedContentLength(response: HttpResponse, signal: AbortSignal): Promise<void> {
 	const contentLength = getHeader(response.headers, "content-length");
 	if (contentLength && Number.parseInt(contentLength, 10) > MAX_RESPONSE_SIZE_BYTES) {
-		await discardBody(response.body, MAX_RESPONSE_SIZE_BYTES);
+		await discardBody(response.body, MAX_RESPONSE_SIZE_BYTES, signal);
 		throw new WebfetchResponseTooLargeError("Response too large (exceeds 5MB limit)");
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/response-body.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/response-body.ts
@@ -1,0 +1,34 @@
+export interface ResponseBodyStream extends AsyncIterable<unknown> {
+	on?(event: "error", listener: (error: Error) => void): unknown;
+	destroy(error?: Error): void;
+	dump?(options?: { limit: number; signal?: AbortSignal }): Promise<void>;
+}
+
+export async function discardBody(body: ResponseBodyStream, maxBytes: number): Promise<void> {
+	try {
+		if (typeof body.dump === "function") {
+			await body.dump({ limit: 1024 });
+			return;
+		}
+		await drainBody(body, maxBytes);
+	} catch {
+		// Discard failures are not actionable for the caller.
+	} finally {
+		body.on?.("error", () => {});
+		body.destroy();
+	}
+}
+
+async function drainBody(body: ResponseBodyStream, maxBytes: number): Promise<void> {
+	let drained = 0;
+	for await (const chunk of body) {
+		drained += toUint8Array(chunk).length;
+		if (drained > maxBytes) return;
+	}
+}
+
+export function toUint8Array(chunk: unknown): Uint8Array {
+	if (chunk instanceof Uint8Array) return chunk;
+	if (typeof chunk === "string") return new TextEncoder().encode(chunk);
+	throw new Error("Unexpected response body chunk");
+}

--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/response-body.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/webfetch/response-body.ts
@@ -4,26 +4,49 @@ export interface ResponseBodyStream extends AsyncIterable<unknown> {
 	dump?(options?: { limit: number; signal?: AbortSignal }): Promise<void>;
 }
 
-export async function discardBody(body: ResponseBodyStream, maxBytes: number): Promise<void> {
+export async function discardBody(body: ResponseBodyStream, maxBytes: number, signal?: AbortSignal): Promise<void> {
+	body.on?.("error", () => {});
 	try {
 		if (typeof body.dump === "function") {
-			await body.dump({ limit: 1024 });
+			await body.dump(signal ? { limit: 1024, signal } : { limit: 1024 });
 			return;
 		}
-		await drainBody(body, maxBytes);
+		await drainBody(body, maxBytes, signal);
 	} catch {
-		// Discard failures are not actionable for the caller.
+		// no-excuse-ok: catch - discard failures are not actionable for the caller.
 	} finally {
-		body.on?.("error", () => {});
 		body.destroy();
 	}
 }
 
-async function drainBody(body: ResponseBodyStream, maxBytes: number): Promise<void> {
+async function drainBody(body: ResponseBodyStream, maxBytes: number, signal?: AbortSignal): Promise<void> {
 	let drained = 0;
-	for await (const chunk of body) {
-		drained += toUint8Array(chunk).length;
+	const iterator = body[Symbol.asyncIterator]();
+	while (true) {
+		const result = await nextChunk(iterator, signal);
+		if (!result || result.done) return;
+		drained += toUint8Array(result.value).length;
 		if (drained > maxBytes) return;
+	}
+}
+
+async function nextChunk(
+	iterator: AsyncIterator<unknown>,
+	signal?: AbortSignal,
+): Promise<IteratorResult<unknown> | undefined> {
+	if (!signal) return iterator.next();
+	if (signal.aborted) return undefined;
+
+	let resolveAbort: () => void = () => {};
+	const aborted = new Promise<undefined>((resolve) => {
+		resolveAbort = () => resolve(undefined);
+	});
+	const onAbort = (): void => resolveAbort();
+	signal.addEventListener("abort", onAbort, { once: true });
+	try {
+		return await Promise.race([iterator.next(), aborted]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
 	}
 }
 

--- a/packages/coding-agent/test/suite/regressions/1089-webfetch-bun-body-discard.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1089-webfetch-bun-body-discard.test.ts
@@ -12,6 +12,7 @@ interface DumpOptions {
 }
 
 interface RedirectBody extends AsyncIterable<Uint8Array> {
+	readonly on?: (event: "error", listener: (error: Error) => void) => unknown;
 	readonly destroy: (error?: Error) => void;
 	readonly dump?: (options?: DumpOptions) => Promise<void>;
 }
@@ -45,10 +46,12 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 	it("destroys without an error when the redirect body has no dump method", async () => {
 		// Given
 		const redirectDestroy = vi.fn<(error?: Error) => void>();
+		let drained = false;
 		queueRedirectResponses({
 			destroy: redirectDestroy,
 			async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
 				yield new TextEncoder().encode("redirect body");
+				drained = true;
 			},
 		});
 
@@ -57,10 +60,11 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 
 		// Then
 		expect(result.url).toBe("https://example.test/final");
+		expect(drained).toBe(true);
 		expect(redirectDestroy).toHaveBeenCalledExactlyOnceWith();
 	});
 
-	it("uses dump without destroying when the redirect body supports dump", async () => {
+	it("uses dump and then destroys when the redirect body supports dump", async () => {
 		// Given
 		const dump = vi.fn<(options?: DumpOptions) => Promise<void>>().mockResolvedValue();
 		const destroy = vi.fn<(error?: Error) => void>();
@@ -77,16 +81,39 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 
 		// Then
 		expect(dump).toHaveBeenCalledExactlyOnceWith({ limit: 1024 });
-		expect(destroy).not.toHaveBeenCalled();
+		expect(destroy).toHaveBeenCalledExactlyOnceWith();
+	});
+
+	it("swallows a manual-drain failure before destroying the redirect body", async () => {
+		const on = vi.fn<(event: "error", listener: (error: Error) => void) => unknown>();
+		const destroy = vi.fn<(error?: Error) => void>();
+		queueRedirectResponses({
+			on,
+			destroy,
+			async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+				yield new TextEncoder().encode("partial redirect body");
+				throw new Error("stream exploded");
+			},
+		});
+
+		const result = await fetchUrl({ url: "https://example.test/start", format: "text" });
+
+		expect(result.url).toBe("https://example.test/final");
+		expect(on).toHaveBeenCalledExactlyOnceWith("error", expect.any(Function));
+		expect(destroy).toHaveBeenCalledExactlyOnceWith();
 	});
 
 	it("destroys without the dump error when redirect body dumping fails", async () => {
 		// Given
+		const cleanupOrder: string[] = [];
 		const dump = vi.fn<(options?: DumpOptions) => Promise<void>>().mockRejectedValue(new Error("dump failed"));
-		const destroy = vi.fn<(error?: Error) => void>();
+		const destroy = vi.fn<(error?: Error) => void>(() => cleanupOrder.push("destroy"));
 		queueRedirectResponses({
 			dump,
 			destroy,
+			on: vi.fn((event: "error") => {
+				cleanupOrder.push(`listen:${event}`);
+			}),
 			async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
 				yield new TextEncoder().encode("redirect body");
 			},
@@ -97,5 +124,6 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 
 		// Then
 		expect(destroy).toHaveBeenCalledExactlyOnceWith();
+		expect(cleanupOrder).toEqual(["listen:error", "destroy"]);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/1089-webfetch-bun-body-discard.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1089-webfetch-bun-body-discard.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fetchUrl } from "../../../src/core/extensions/builtin/webfetch/webfetch/fetcher.ts";
+import { discardBody } from "../../../src/core/extensions/builtin/webfetch/webfetch/response-body.ts";
 
 const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
 
@@ -45,11 +46,16 @@ function queueRedirectResponses(redirectBody: RedirectBody): void {
 describe("issue #1089 webfetch redirect body cleanup", () => {
 	it("destroys without an error when the redirect body has no dump method", async () => {
 		// Given
-		const redirectDestroy = vi.fn<(error?: Error) => void>();
+		const cleanupOrder: string[] = [];
+		const redirectDestroy = vi.fn<(error?: Error) => void>(() => cleanupOrder.push("destroy"));
 		let drained = false;
 		queueRedirectResponses({
 			destroy: redirectDestroy,
+			on: vi.fn((event: "error") => {
+				cleanupOrder.push(`listen:${event}`);
+			}),
 			async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+				cleanupOrder.push("iterate");
 				yield new TextEncoder().encode("redirect body");
 				drained = true;
 			},
@@ -62,6 +68,7 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 		expect(result.url).toBe("https://example.test/final");
 		expect(drained).toBe(true);
 		expect(redirectDestroy).toHaveBeenCalledExactlyOnceWith();
+		expect(cleanupOrder).toEqual(["listen:error", "iterate", "destroy"]);
 	});
 
 	it("uses dump and then destroys when the redirect body supports dump", async () => {
@@ -80,7 +87,7 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 		await fetchUrl({ url: "https://example.test/start", format: "text" });
 
 		// Then
-		expect(dump).toHaveBeenCalledExactlyOnceWith({ limit: 1024 });
+		expect(dump).toHaveBeenCalledExactlyOnceWith({ limit: 1024, signal: expect.any(AbortSignal) });
 		expect(destroy).toHaveBeenCalledExactlyOnceWith();
 	});
 
@@ -125,5 +132,55 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 		// Then
 		expect(destroy).toHaveBeenCalledExactlyOnceWith();
 		expect(cleanupOrder).toEqual(["listen:error", "destroy"]);
+	});
+
+	it("aborts a fallback drain whose iterator never produces a chunk", async () => {
+		let markIteratorStarted: () => void = () => {};
+		const iteratorStarted = new Promise<void>((resolve) => {
+			markIteratorStarted = resolve;
+		});
+		const destroy = vi.fn<(error?: Error) => void>();
+		const body: RedirectBody = {
+			destroy,
+			[Symbol.asyncIterator]() {
+				return {
+					next(): Promise<IteratorResult<Uint8Array>> {
+						markIteratorStarted();
+						return new Promise<IteratorResult<Uint8Array>>(() => {});
+					},
+				};
+			},
+		};
+		const controller = new AbortController();
+		let settled = false;
+		const discardPromise = discardBody(body, 1024, controller.signal).then(() => {
+			settled = true;
+		});
+
+		await iteratorStarted;
+		controller.abort(new Error("stop drain"));
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(settled).toBe(true);
+		expect(destroy).toHaveBeenCalledExactlyOnceWith();
+		await discardPromise;
+	});
+
+	it("stops fallback iteration after the response-size bound is crossed", async () => {
+		let yieldedAfterLimit = false;
+		const destroy = vi.fn<(error?: Error) => void>();
+		const body: RedirectBody = {
+			destroy,
+			async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+				yield new Uint8Array(1025);
+				yieldedAfterLimit = true;
+				yield new Uint8Array(1);
+			},
+		};
+
+		await discardBody(body, 1024);
+
+		expect(yieldedAfterLimit).toBe(false);
+		expect(destroy).toHaveBeenCalledExactlyOnceWith();
 	});
 });


### PR DESCRIPTION
## Summary

- drain redirect and oversized response bodies when the runtime's `undici` body does not expose `dump()`
- guard discard-time stream errors before quiet destruction
- preserve the bounded native Undici `dump({ limit: 1024 })` path
- extract response-body cleanup into a focused module so the vendored fetcher stays below the repository's 250 pure-LOC ceiling

## Upstream credit

This adapts the lifecycle hardening proposed by **@Indosaram** in [code-yeongyu/pi-webfetch#7](https://github.com/code-yeongyu/pi-webfetch/pull/7). The upstream PR identified that immediate destruction leaves the no-`dump()` body undrained and that discard-time stream errors need an attached listener before destruction.

## Verification

- RED: the existing Senpi fallback failed new assertions that the no-`dump()` body was drained and that an error listener was attached before destruction
- GREEN: `npm test -- test/suite/regressions/1089-webfetch-bun-body-discard.test.ts test/extensions-webfetch.test.ts` — 2 files, 6 tests passed
- `npm run check` — passed
- changed-file TypeScript diagnostics — no diagnostics
- real Bun reproduction — `200 https://httpbingo.org/get`, exit 0, no uncaught exception
- pure LOC — `fetcher.ts` 236, `response-body.ts` 30, regression test 101

Follow-up to #1091.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains Bun-compatible webfetch response bodies, guards discard-time stream errors, and makes cleanup abort-aware. Previously, bodies without `dump()` were destroyed immediately and could remain undrained or emit unhandled errors; now we attach an error listener before discard begins, drain up to the 5MB limit or until aborted, use `dump({ limit: 1024, signal })` when available, and always destroy afterward.

- Extracts cleanup into `response-body.ts` with `discardBody(body, maxBytes, signal)` and `toUint8Array`; `fetcher.ts` imports these and passes `MAX_RESPONSE_SIZE_BYTES` for redirects and oversized `content-length`.
- When `dump()` exists, call `dump({ limit: 1024, signal })` then destroy; otherwise, bounded, abort-aware async drain then destroy; drain failures are swallowed.
- Attaches an `error` listener before discard starts so stream errors during best-effort cleanup do not surface as uncaught process errors.
- Tests cover draining, aborting a stalled iterator, stopping after the size bound, listener ordering, and destroy order; no external API changes.
- Updates `webfetch/changes.md` to credit upstream `pi-webfetch` #7 and note why extension hooks cannot replace this vendored cleanup.

<sup>Written for commit 3d3d049a7784a860ac4c42a171075af05d26d1c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

