### PR TITLE
fix(codemode): spill detached-eval notices with absolute paths

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Detached eval cell overflow notices now point at the absolute spill file path (`…/local/detached-eval-<id>.log`) instead of a `local://detached-eval-<id>.log` URI. `local://` is resolved only by the in-cell kernel helpers, not by the agent `read` tool, so following the old notice failed with `ENOENT …/local:/detached-eval-<id>.log`. This restores the documented contract that spill notices carry plain absolute paths.
+
 ### Removed
 
 ## [2026.8.23] - 2026-08-23

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,26 @@
 # senpi-codemode fork changes
 
+## Detached-eval spill notices carry absolute paths (2026-08-23)
+
+### What changed
+
+- `packages/senpi-codemode/src/tool/detached-cell-notification.ts` now writes the plain absolute spill path into the oversized-output notice (`Buffered output overflowed; full output: <absolute path>`) instead of a `local://…` URI. The `localUri` helper and the unused `artifactsDir` parameter on `buildDetachedCellNotification` are gone; `DetachedNotificationQueue` no longer stores `artifactsDir`.
+- `test/eval-detach.test.ts` locks the contract: the notice must contain `join(artifactsDir, "local", "detached-eval-<id>.log")` and must not contain `local://`.
+
+### Why
+
+- `local://` is a kernel-helper scheme resolved from the session artifact root inside eval cells (`read()`/`write()` prelude helpers). The agent-facing `read` tool resolves plain paths only, so a model that followed the notice's `local://detached-eval-<id>.log` got `ENOENT: <cwd>/local:/detached-eval-<id>.log`. This reproduces the documented invariant: spill notices contain plain absolute paths, not a custom URI scheme.
+
+### Why an extension could not handle it
+
+- The spill notice text is composed inside this package's notification builder; no downstream hook can rewrite the notice before it is queued to the notifier.
+
+### Expected merge conflict zones
+
+- LOW in `src/tool/detached-cell-notification.ts` around the spill-notice composition and the removed helper.
+- LOW in `src/tool/detached-notification-queue.ts` around the constructor and flush mapping.
+- LOW in `test/eval-detach.test.ts` around the crash-spill assertions.
+
 ## Detached-cell notices deliver as internal custom messages (2026-08-23)
 
 ### What changed

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -93,7 +93,7 @@ export class EvalDetachedCellManager {
 		this.#artifactsDir = options.artifactsDir;
 		this.#onStatusChange = options.onStatusChange;
 		this.#onWakeSourceState = options.onWakeSourceState;
-		this.#notificationQueue = new DetachedNotificationQueue(options.notifier, options.artifactsDir);
+		this.#notificationQueue = new DetachedNotificationQueue(options.notifier);
 		this.#now = options.now ?? Date.now;
 		this.#hardLimitSeconds = options.hardLimitSeconds ?? DEFAULT_HARD_LIMIT_SECONDS;
 	}

--- a/packages/senpi-codemode/src/tool/detached-cell-notification.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-notification.ts
@@ -12,7 +12,6 @@ export function detachedNotificationSpillPath(artifactsDir: string | undefined, 
 export async function buildDetachedCellNotification(
 	snapshot: EvalDetachedCellSnapshot,
 	spillPath: string | undefined,
-	artifactsDir: string | undefined,
 ): Promise<EvalDetachedCellNotification> {
 	const body = notificationBody(snapshot);
 	const overflow = Buffer.byteLength(body, "utf8") > NOTIFICATION_TAIL_BYTES;
@@ -21,7 +20,9 @@ export async function buildDetachedCellNotification(
 		try {
 			await mkdir(dirname(spillPath), { recursive: true });
 			await writeFile(spillPath, body, "utf8");
-			spillNotice = `\nBuffered output overflowed; full output: ${localUri(spillPath, artifactsDir)}`;
+			// The agent read tool resolves plain paths only, so the notice must carry
+			// the absolute spill path, never the kernel-helper local:// scheme.
+			spillNotice = `\nBuffered output overflowed; full output: ${spillPath}`;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			spillNotice = `\nBuffered output overflow could not be spilled: ${message}`;
@@ -82,12 +83,6 @@ function stateNoteOf(cell: EvalDetachedCellSnapshot): string {
 
 function safeCellId(cellId: string): string {
 	return cellId.replace(/[^a-zA-Z0-9_-]/gu, "_");
-}
-
-function localUri(path: string, artifactsDir: string | undefined): string {
-	if (artifactsDir === undefined) return `local://${path}`;
-	const root = join(artifactsDir, "local");
-	return path.startsWith(`${root}/`) ? `local://${path.slice(root.length + 1)}` : `local://${path}`;
 }
 
 function truncateTailUtf8(text: string, maxBytes: number): string {

--- a/packages/senpi-codemode/src/tool/detached-notification-queue.ts
+++ b/packages/senpi-codemode/src/tool/detached-notification-queue.ts
@@ -7,14 +7,12 @@ export interface PendingDetachedNotification {
 }
 
 export class DetachedNotificationQueue {
-	readonly #artifactsDir: string | undefined;
 	readonly #notifier: EvalDetachedCellNotifier | undefined;
 	#pending: PendingDetachedNotification[] = [];
 	#flush: Promise<void> | undefined;
 
-	constructor(notifier: EvalDetachedCellNotifier | undefined, artifactsDir: string | undefined) {
+	constructor(notifier: EvalDetachedCellNotifier | undefined) {
 		this.#notifier = notifier;
-		this.#artifactsDir = artifactsDir;
 	}
 
 	enqueue(notification: PendingDetachedNotification): void {
@@ -32,9 +30,7 @@ export class DetachedNotificationQueue {
 		const flush = Promise.resolve().then(async () => {
 			const pending = this.#pending.splice(0);
 			const notifications = await Promise.all(
-				pending.map(
-					async (item) => await buildDetachedCellNotification(item.snapshot(), item.spillPath, this.#artifactsDir),
-				),
+				pending.map(async (item) => await buildDetachedCellNotification(item.snapshot(), item.spillPath)),
 			);
 			this.#notifier?.notify(notifications);
 		});

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -310,7 +310,7 @@ describe("eval detached cells", () => {
 		expect(manager.busyFor("js")).toBeUndefined();
 	});
 
-	it("reports detached kernel crashes with the buffered tail and spills oversized notifications to local://", async () => {
+	it("reports detached kernel crashes with the buffered tail and spills oversized notifications to an absolute path", async () => {
 		vi.useFakeTimers();
 		const artifactsDir = await mkdtemp(join(tmpdir(), "senpi-codemode-detach-"));
 		directories.push(artifactsDir);
@@ -328,8 +328,12 @@ describe("eval detached cells", () => {
 
 		expect(recorder.notices).toHaveLength(1);
 		expect(recorder.notices[0]?.content).toContain("kernel crashed");
-		expect(recorder.notices[0]?.content).toContain("local://detached-eval-crashed-detached.log");
-		expect(existsSync(join(artifactsDir, "local", "detached-eval-crashed-detached.log"))).toBe(true);
+		// Spill notices must carry the absolute spill path — the agent read tool cannot
+		// resolve the local:// scheme (it is a kernel-helper-only scheme).
+		const spillPath = join(artifactsDir, "local", "detached-eval-crashed-detached.log");
+		expect(recorder.notices[0]?.content).toContain(spillPath);
+		expect(recorder.notices[0]?.content).not.toContain("local://");
+		expect(existsSync(spillPath)).toBe(true);
 	});
 });
 


### PR DESCRIPTION
## Summary

Detached eval cells that produce more than 512 bytes of notification output spill the full body to a log file and tell the model where to find it. That notice used to carry a `local://detached-eval-<id>.log` URI, but `local://` is a kernel-helper scheme resolved from the session artifact root inside eval cells — the agent `read` tool resolves plain paths only. Following the notice failed with `ENOENT: <cwd>/local:/detached-eval-<id>.log`. The notice now carries the plain absolute spill path, restoring the documented package invariant ("spill notices contain plain absolute paths, not a custom URI scheme").

## Changes

- **Spill notice composition** (`packages/senpi-codemode/src/tool/detached-cell-notification.ts`): emit `spillPath` directly; remove the `localUri` helper and the `artifactsDir` parameter it existed for.
- **Queue plumbing** (`packages/senpi-codemode/src/tool/detached-notification-queue.ts`, `detached-cell-manager.ts`): drop the now-unused `artifactsDir` from the queue constructor and pass-through.
- **Regression lock** (`packages/senpi-codemode/test/eval-detach.test.ts`): the crash-spill test asserts the notice contains `join(artifactsDir, "local", "detached-eval-<id>.log")` and does not contain `local://`.
- **Changelog** (`packages/senpi-codemode/changes.md`): fork-change record in the established format.

## QA & Evidence

- **What was tested:** the exact user-facing failure — an oversized detached-cell notice whose "full output" reference is then read back.
  - RED: modified test run against unfixed code failed with the notice containing `local://detached-eval-crashed-detached.log` instead of the absolute path.
  - GREEN: `vitest run test/eval-detach.test.ts` → 12/12 passed.
- **Real-surface check:** drove `buildDetachedCellNotification` from the fixed sources with a >512-byte body; notice carried the absolute spill path, no `local://`; the agent `read` tool then consumed that exact path successfully (full body returned, no ENOENT).
- **Regression:** `npm test` in `packages/senpi-codemode` → 619 passed / 6 skipped (exit 0); root `npm run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, tsc, browser-smoke) → exit 0.
- **Artifacts:** RED/GREEN vitest transcripts and the QA driver log captured during the run (temp files, sanitized; nothing secret-bearing).

## Risks & Residuals

- The `artifactsDir` parameter removal is an internal signature change within one package; all callers updated in the same PR and root typecheck covers the package — risk assessed as low.
- `local://` remains fully supported inside eval cells (kernel helpers); only the model-facing notice text changed.

## Related Issues

None filed; reproduced live during an agent session (`read local://detached-eval-*.log` → ENOENT).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Spill notices from detached evals now include the absolute spill file path instead of a `local://…` URI. Previously, following the notice with the agent `read` tool failed with ENOENT; the absolute path fixes this and keeps in-cell `local://` behavior unchanged.

- In `packages/senpi-codemode`, emit `spillPath` directly; remove the `localUri` helper and `artifactsDir` plumbing from `buildDetachedCellNotification` and `DetachedNotificationQueue`; update the call site in `EvalDetachedCellManager`.
- Tests assert the notice contains `join(artifactsDir, "local", "detached-eval-<id>.log")` and does not contain `local://`.

- Migration
  - If you construct `DetachedNotificationQueue`, drop the `artifactsDir` constructor argument.
  - If you call `buildDetachedCellNotification` directly, remove the `artifactsDir` parameter.

<sup>Written for commit 168e28d4593a1a886a46ee7f673dd617ee08f444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

