### PR TITLE
fix(tui): handle numeric EIO during shutdown

### DIFF
--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -287,7 +287,7 @@ Landed 2026-08-16 (commit 03f46f57e, shipped in PR #892).
 
 ### What changed
 
-- `ProcessTerminal.stop()` still restores the raw-mode state captured by `start()`, but now treats `EIO`, `EPIPE`,
+- `packages/tui/src/terminal.ts`: `ProcessTerminal.stop()` still restores the raw-mode state captured by `start()`, but now treats `EIO`, `EPIPE`,
   and `ENOTCONN` from the teardown-time `setRawMode()` call as a dead terminal instead of crashing the exiting CLI.
 - The EIO classifier accepts both Node's string `code: "EIO"` shape and Bun's macOS numeric `errno: 5` shape.
 - Unexpected raw-mode restoration errors still propagate so shutdown does not hide unrelated defects.

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -289,7 +289,10 @@ Landed 2026-08-16 (commit 03f46f57e, shipped in PR #892).
 
 - `packages/tui/src/terminal.ts`: `ProcessTerminal.stop()` still restores the raw-mode state captured by `start()`, but now treats `EIO`, `EPIPE`,
   and `ENOTCONN` from the teardown-time `setRawMode()` call as a dead terminal instead of crashing the exiting CLI.
-- The EIO classifier accepts both Node's string `code: "EIO"` shape and Bun's macOS numeric `errno: 5` shape.
+- The EIO classifier accepts both Node's string `code: "EIO"` shape and Bun's macOS raw positive `errno: 5`
+  shape, using numeric errno only when no string code is available.
+- The separate coding-agent classifier handles asynchronous stdout/stderr stream `error` events; this numeric fallback
+  stays scoped to the synchronous stdin `setRawMode()` ioctl that produced the observed Bun error shape.
 - Unexpected raw-mode restoration errors still propagate so shutdown does not hide unrelated defects.
 - `test/terminal.test.ts` covers successful restoration, the dead-terminal `EIO` regression, and unexpected-error
   propagation.

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -289,6 +289,7 @@ Landed 2026-08-16 (commit 03f46f57e, shipped in PR #892).
 
 - `ProcessTerminal.stop()` still restores the raw-mode state captured by `start()`, but now treats `EIO`, `EPIPE`,
   and `ENOTCONN` from the teardown-time `setRawMode()` call as a dead terminal instead of crashing the exiting CLI.
+- The EIO classifier accepts both Node's string `code: "EIO"` shape and Bun's macOS numeric `errno: 5` shape.
 - Unexpected raw-mode restoration errors still propagate so shutdown does not hide unrelated defects.
 - `test/terminal.test.ts` covers successful restoration, the dead-terminal `EIO` regression, and unexpected-error
   propagation.

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -14,6 +14,7 @@ const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0\x07";
 const NATIVE_SHIFT_ENTER_SEQUENCE = "\x1b[13;2u";
 const DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS = 7;
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
+const EIO_ERRNO = 5;
 const KEYBOARD_PROTOCOL_RESPONSE_FRAGMENT_TIMEOUT_MS = 150;
 const KITTY_KEYBOARD_PROTOCOL_QUERY = `\x1b[>${DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS}u\x1b[?u\x1b[c`;
 
@@ -64,9 +65,8 @@ export function keyboardEnhancementEnabled(): boolean {
 function isDeadTerminalError(error: unknown): boolean {
 	return (
 		error instanceof Error &&
-		"code" in error &&
-		typeof error.code === "string" &&
-		DEAD_TERMINAL_ERROR_CODES.has(error.code)
+		(("code" in error && typeof error.code === "string" && DEAD_TERMINAL_ERROR_CODES.has(error.code)) ||
+			("errno" in error && error.errno === EIO_ERRNO))
 	);
 }
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -14,6 +14,7 @@ const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0\x07";
 const NATIVE_SHIFT_ENTER_SEQUENCE = "\x1b[13;2u";
 const DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS = 7;
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
+// Bun's macOS tty shim can report synchronous ioctl EIO as raw positive errno 5 without a string code.
 const EIO_ERRNO = 5;
 const KEYBOARD_PROTOCOL_RESPONSE_FRAGMENT_TIMEOUT_MS = 150;
 const KITTY_KEYBOARD_PROTOCOL_QUERY = `\x1b[>${DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS}u\x1b[?u\x1b[c`;
@@ -63,11 +64,9 @@ export function keyboardEnhancementEnabled(): boolean {
 }
 
 function isDeadTerminalError(error: unknown): boolean {
-	return (
-		error instanceof Error &&
-		(("code" in error && typeof error.code === "string" && DEAD_TERMINAL_ERROR_CODES.has(error.code)) ||
-			("errno" in error && error.errno === EIO_ERRNO))
-	);
+	if (!(error instanceof Error)) return false;
+	if ("code" in error && typeof error.code === "string") return DEAD_TERMINAL_ERROR_CODES.has(error.code);
+	return "errno" in error && error.errno === EIO_ERRNO;
 }
 
 /**

--- a/packages/tui/test/terminal.test.ts
+++ b/packages/tui/test/terminal.test.ts
@@ -404,6 +404,21 @@ describe("ProcessTerminal stop", () => {
 		}
 	});
 
+	it("does not throw when Node reports the dead terminal by error code", () => {
+		// Given
+		const eio = Object.assign(new Error("setRawMode failed"), { code: "EIO" });
+		const harness = setupTerminalStopHarness(false, () => {
+			throw eio;
+		});
+
+		try {
+			// When / Then
+			assert.doesNotThrow(() => harness.terminal.stop());
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("rethrows unexpected raw-mode restoration failures", () => {
 		// Given
 		const invalidArgument = Object.assign(new Error("unexpected setRawMode failure"), { code: "EINVAL" });

--- a/packages/tui/test/terminal.test.ts
+++ b/packages/tui/test/terminal.test.ts
@@ -391,7 +391,7 @@ describe("ProcessTerminal stop", () => {
 
 	it("does not throw when raw-mode restoration fails during stop", () => {
 		// Given
-		const eio = Object.assign(new Error("setRawMode failed"), { code: "EIO" });
+		const eio = Object.assign(new Error("setRawMode failed with errno: 5"), { errno: 5 });
 		const harness = setupTerminalStopHarness(false, () => {
 			throw eio;
 		});


### PR DESCRIPTION
## Summary

- recognize Bun/macOS raw-mode failures that expose `errno: 5` without a string `code`
- keep the existing dead-terminal whitelist and continue rethrowing unexpected shutdown errors
- update the focused regression to match the error shape observed in the real crash

## Root cause

`ProcessTerminal.stop()` already ignored dead-terminal errors when `error.code` was
`EIO`, `EPIPE`, or `ENOTCONN`. During the reported shutdown, Bun threw
`setRawMode failed with errno: 5` without a string `code`, so the classifier
returned false and normal interactive shutdown surfaced an uncaught stack.

## RED -> GREEN

Focused command:

```sh
cd packages/tui
node --test --import tsx \
  --import ./test/setup-multiplexer-env.mjs \
  --test-reporter=spec \
  --test-name-pattern='ProcessTerminal stop' \
  test/terminal.test.ts
```

- RED before production change: 2 passed / 1 failed, exit 1; the numeric
  `{ errno: 5 }` fixture escaped with `setRawMode failed with errno: 5`
- GREEN after production change: 3 passed / 0 failed, exit 0
- the adjacent `EINVAL` test still proves unexpected restoration errors propagate

## Validation

- `packages/tui/test/terminal.test.ts`: 30/30 passed
- `cd packages/tui && npm test`: passed
- `npm run check`: passed
- `npm run build --workspace @earendil-works/pi-tui`: passed
- changed-file LSP diagnostics: clean
- Senpi CLI smoke: 8/8 passed (`--help`, version, offline models, bad input, auth integrity)
- live PTY + xterm.js + Chrome EIO proof:
  `RENDERED -> INJECTED=errno5 -> STOP_RETURNED -> CLEANUP=cooked -> EXIT=0`
- normal Senpi TUI proof: rendered, accepted input, cleared, exited with code 0
- two independent visual QA passes: PASS, no blocking findings
- five-lane review-work: code-quality blocker fixed by restoring a separate
  Node `code: "EIO"` regression, giving string `code` precedence over numeric
  errno, and documenting the separate async stdout/stderr classifier scope

The local full workspace test run progressed through script, agent, AI, and client
suites, then the coding-agent suite left an app-server child listening on
`127.0.0.1:18990` and never emitted its final summary. The orphan was terminated
and the port was verified free. GitHub CI is the authoritative full-suite gate.

## Scope

The change is intentionally limited to the existing terminal error classifier,
its focused test, and the nearest fork `changes.md` tracker.
