### PR TITLE
fix(goal): hide the continuation wait countdown while a turn runs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- The goal continuation wait countdown no longer renders over the Working indicator during externally started turns; the `goal-wait` footer segment now hides while a turn runs and restores itself when the session parks again, leaving the cache-warm schedule and iteration accounting untouched ([#1100](https://github.com/code-yeongyu/senpi/pull/1100)).
 - Webfetch now safely discards redirect response bodies under Bun 1.4.0's bare `undici`, which may omit `body.dump()`, by falling back to argument-free stream destruction instead of re-emitting cleanup failures as uncaught stream errors ([#1089](https://github.com/code-yeongyu/senpi/issues/1089)).
 
 ### Added

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,41 @@
 # goal Extension Changes
 
+## Wait countdown hides while a turn runs (2026-08-24)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts`
+  `GoalWaitTicker.tick` now renders `undefined` (clearing the `goal-wait`
+  footer segment) whenever `ctx.isIdle()` is false, and re-renders the
+  countdown on the next idle tick. The armed continuation timer, its
+  cache-TTL deadline, and the cache-warm iteration accounting are untouched;
+  only the render follows session idleness.
+
+### Why
+
+- A turn started by a channel the goal continuation did not deliver (a
+  monitor event, a task completion notification, a scheduled wakeup) left the
+  parked wait countdown rendering over the Working indicator for the whole
+  turn — observed live: `▰▰▰▱… goal continues in 2m 55s · 1 bash on duty`
+  beside `Working (1m 10s)`. The label was doubly false: the goal was being
+  pursued, not waited on, and the timer would no-op on `!ctx.isIdle()` when
+  it fired.
+- Cancelling the timer on foreign turn starts was rejected: the monitor wait
+  schedule is cache-TTL-driven, so re-arming at the next agent_end resets
+  the wake clock and corrupts cache-warm iteration accounting (proven by
+  `goal-cache-warmup.test.ts`).
+
+### Why an extension could not handle it
+
+- The ticker and its render seam live inside the builtin goal extension
+  itself; the idleness contract of its footer segment is the extension's own
+  display logic, not a capability another extension can provide.
+
+### Expected merge conflict zones
+
+- None upstream: `wait-ticker.ts` is a fork-only file with no pi-mono
+  counterpart.
+
 ## Cache-warm ready time renders in the local timezone (2026-08-22)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/wait-ticker.ts
@@ -102,15 +102,20 @@ export class GoalWaitTicker {
 
 	private tick(): void {
 		if (this.ctx === undefined || this.kind === undefined) return;
-		const status = formatGoalWaitLabel({
-			kind: this.kind,
-			remainingMs: Math.max(0, this.dueAtMs - this.now()),
-			totalMs: this.totalMs,
-			channelCounts: this.channelCounts,
-		});
-		if (status === this.lastRenderedStatus) return;
-		this.lastRenderedStatus = status;
 		try {
+			// The countdown is a parked-state display: while a turn runs the goal is
+			// pursued, not waited on, so the segment clears. The armed timer (and its
+			// cache-TTL deadline) is untouched, so the next idle tick re-renders it.
+			const status = this.ctx.isIdle()
+				? formatGoalWaitLabel({
+						kind: this.kind,
+						remainingMs: Math.max(0, this.dueAtMs - this.now()),
+						totalMs: this.totalMs,
+						channelCounts: this.channelCounts,
+					})
+				: undefined;
+			if (status === this.lastRenderedStatus) return;
+			this.lastRenderedStatus = status;
 			this.render(this.ctx, status);
 		} catch (error) {
 			if (isStaleExtensionContextError(error)) {

--- a/packages/coding-agent/test/suite/goal-ticker-stale-context.test.ts
+++ b/packages/coding-agent/test/suite/goal-ticker-stale-context.test.ts
@@ -9,7 +9,7 @@ import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/t
 const STALE_CTX_MESSAGE =
 	"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().";
 
-const fakeCtx = { ui: { setStatus: () => {} } } as unknown as ExtensionContext;
+const fakeCtx = { isIdle: () => true, ui: { setStatus: () => {} } } as unknown as ExtensionContext;
 
 function activeGoal(): Goal {
 	return {

--- a/packages/coding-agent/test/suite/goal-wait-turn-start.test.ts
+++ b/packages/coding-agent/test/suite/goal-wait-turn-start.test.ts
@@ -13,6 +13,7 @@ import {
 	type GoalStatusUpdate,
 	makeGoalContext,
 	runGoalHandlers,
+	waitForSentCount,
 } from "./goal-monitor-test-harness.ts";
 
 function activeGoal(id: string): Goal {
@@ -96,7 +97,9 @@ describe("goal wait countdown versus externally started turns", () => {
 		expect(waitUpdates(status).at(-1)?.text).toContain("goal continues in");
 		expect(timerStates(harness).filter((state) => state.armed)).toHaveLength(1);
 
+		const delivered = waitForSentCount(harness, 1);
 		await vi.advanceTimersByTimeAsync(300_000);
+		await delivered;
 		expect(harness.sent).toHaveLength(1);
 	});
 });

--- a/packages/coding-agent/test/suite/goal-wait-turn-start.test.ts
+++ b/packages/coding-agent/test/suite/goal-wait-turn-start.test.ts
@@ -1,0 +1,102 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GOAL_CONTINUATION_TIMER_STATE_EVENT } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
+import { writeGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
+import { WAKE_SOURCE_STATE_EVENT } from "../../src/core/extensions/builtin/monitor-state-event.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+import {
+	cleanAssistantStop,
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	createGoalStatusHarness,
+	type GoalStatusUpdate,
+	makeGoalContext,
+	runGoalHandlers,
+} from "./goal-monitor-test-harness.ts";
+
+function activeGoal(id: string): Goal {
+	return {
+		id,
+		threadId: `${id}-thread`,
+		objective: "Keep moving",
+		status: "active",
+		tokensUsed: 0,
+		timeUsedSeconds: 0,
+		createdAt: 0,
+		updatedAt: 0,
+	};
+}
+
+async function persistGoal(ctx: ExtensionContext, goal: Goal): Promise<void> {
+	await writeGoal(
+		{
+			baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+			threadId: ctx.sessionManager.getSessionId(),
+		},
+		goal,
+	);
+}
+
+function waitUpdates(status: ReturnType<typeof createGoalStatusHarness>): GoalStatusUpdate[] {
+	return status.updates.filter((update) => update.key === "goal-wait");
+}
+
+function timerStates(harness: ReturnType<typeof createGoalHarness>): Array<{ armed: boolean; kind?: string }> {
+	return harness.events.emitted
+		.filter((event) => event.channel === GOAL_CONTINUATION_TIMER_STATE_EVENT)
+		.map((event) => event.data as { armed: boolean; kind?: string });
+}
+
+describe("goal wait countdown versus externally started turns", () => {
+	afterEach(async () => {
+		vi.useRealTimers();
+		await cleanupGoalMonitorTempDirs();
+	});
+
+	it("hides the countdown while a turn runs and restores it when the session parks again", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const status = createGoalStatusHarness();
+		const ctx = await makeGoalContext(notices, "thread-foreign-turn", { pendingMessages: false, status });
+		let turnActive = false;
+		ctx.isIdle = () => !turnActive;
+		const harness = createGoalHarness();
+		const goal = activeGoal("goal-foreign-turn");
+		await persistGoal(ctx, goal);
+
+		harness.events.emit(WAKE_SOURCE_STATE_EVENT, { source: "terminal-background-sessions", activeCount: 1 });
+		await harness.events.flush();
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStop()] },
+			ctx,
+		);
+
+		expect(waitUpdates(status).at(-1)?.text).toContain("goal continues in");
+		expect(timerStates(harness).at(-1)).toMatchObject({ armed: true, kind: "monitor" });
+
+		turnActive = true;
+		await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(waitUpdates(status).at(-1)?.text).toBeUndefined();
+		expect(timerStates(harness).at(-1)).toMatchObject({ armed: true, kind: "monitor" });
+
+		turnActive = false;
+		await runGoalHandlers(
+			harness.handlers,
+			"agent_end",
+			{ type: "agent_end", messages: [cleanAssistantStop()] },
+			ctx,
+		);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(waitUpdates(status).at(-1)?.text).toContain("goal continues in");
+		expect(timerStates(harness).filter((state) => state.armed)).toHaveLength(1);
+
+		await vi.advanceTimersByTimeAsync(300_000);
+		expect(harness.sent).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary

The TUI footer kept rendering the goal continuation wait countdown (`▰▰▰▰… goal continues in 2m 55s · 1 bash on duty`) **over the Working indicator** when a turn was started by a channel the goal continuation did not deliver (a monitor event, a task completion notification, a scheduled wakeup). Observed live and confirmed stale against the session logs: the session was actively working while the footer claimed it was parked-waiting.

## Root cause

`GoalWaitTicker` rendered the countdown unconditionally on every 1s tick while a continuation timer was armed. Nothing in the render path consulted session idleness, so an externally woken turn left the parked-state countdown on screen for the whole turn — and the countdown was doubly false, since the timer no-ops on `!ctx.isIdle()` when it fires.

Production corroboration (session `01a031e3-…`, `~/.omo/agent/sessions/--Users-yeongyu-sionicai--/2026-08-24T03-49-34-218Z_….jsonl`): agent_end armed the cache-warm wait at 14:13:36 (due 05:18:06); a momus task-completion woke the turn at 14:14:14; the countdown rendered over `Working` until 14:18:03.

## Why not cancel the timer on foreign turn starts

That was the first attempt and it is wrong: the monitor wait schedule is driven by the provider prompt-cache TTL (`resolveGoalMonitorContinuationDelayMs`), not idleness. Cancelling makes the next agent_end re-arm with a fresh delay and an incremented cache-warm iteration — proven to corrupt warm accounting by `goal-cache-warmup.test.ts` ("resets the warm iteration after an accepted user prompt" fails under that approach, 5/5 green without it). The **schedule** must survive foreign turns; only the **render** was wrong.

## Fix

`wait-ticker.ts` — `GoalWaitTicker.tick` now renders `undefined` (clearing the `goal-wait` segment) whenever `ctx.isIdle()` is false, and re-renders the countdown on the next idle tick. The armed timer, its cache-TTL deadline, and cache-warm iteration accounting are untouched. One file, four effective lines; self-healing in both directions with no lifecycle coupling.

## Evidence

- RED (unfixed): new `test/suite/goal-wait-turn-start.test.ts` fails with `expected '▱▱▱▱… goal continues in 3m 59s · 1 bash on duty' to be undefined` — the exact production string shape.
- GREEN: same test passes — countdown hides on turn start, the timer stays armed (`{armed: true, kind: "monitor"}`), the countdown self-restores on re-park, and the armed wait still delivers at its deadline.
- Regression: full goal scope — 34 files / 318 tests, all pass (includes `goal-cache-warmup` 5/5 and the stale-context ticker tests; the shared `fakeCtx` stub gained `isIdle: () => true` to match the real `ExtensionContext` surface, assertions unchanged).
- `npm run check`: exit 0.
- senpi-qa: `common.mjs --self-check` 9/9; `mock-loop.mjs --self-test` 48/48; `tui-smoke.mjs --self-test` — evidence under `local-ignore/qa-evidence/20260824-goal-wait-foreign-turn/`.

## Pre-existing note (not this PR's scope)

`mock-loop.mjs --self-test` fails 21/48 when launched from inside an omo agent session, on main as well: the harness spreads `...process.env` but never scrubs `SENPI_BRAND`, so the brand-aware CLI resolves its config via the OMO brand (`~/.omo/agent`) and the isolated sandbox `models.json` (the `mock` provider) is never loaded. Reproduced identically on the main checkout; the scrubbed-env run (`env -u SENPI_BRAND -u SENPI_CODING_AGENT_DIR -u SENPI_CODING_AGENT_SESSION_DIR …`) passes 48/48. Worth a follow-up harness fix.

## Test plan

- `cd packages/coding-agent && CI=1 npx vitest --run test/suite/goal-wait-turn-start.test.ts`
- `CI=1 npx vitest --run test/suite/goal test/suite/regressions/goal test/suite/loop-guard-goal-isolation`
- `npm run check`
- `env -u SENPI_BRAND -u SENPI_CODING_AGENT_DIR -u SENPI_CODING_AGENT_SESSION_DIR node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the goal continuation wait countdown while a turn runs so the footer no longer shows a parked-state label over the Working indicator. Previously the countdown rendered whenever the timer was armed; now it clears during active turns and resumes on idle, with the timer schedule and cache-warm iteration unchanged.

- In `goal/wait-ticker.ts`, `GoalWaitTicker.tick` renders `undefined` when `!ctx.isIdle()`, and restores the countdown on the next idle tick. Timer arming, due time, and iteration accounting are untouched.
- Adds `test/suite/goal-wait-turn-start.test.ts`; verifies hide-on-turn, restore-on-park, and deadline delivery. The test now awaits the continuation delivery signal to avoid races.
- Updates `goal-ticker-stale-context.test.ts` to include `isIdle()` on the `fakeCtx`.
- No config or migration changes; UI-only behavior fix.

<sup>Written for commit 9a288e5cf696c7dc5903f094037577d8fe054ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

