### PR TITLE
test(senpi-qa): scrub inherited brand/session env from QA sandboxes

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/common.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/common.mjs
@@ -69,6 +69,48 @@ export function realAuthPath() {
 const sandboxes = new Set();
 
 /**
+ * Inherited variables that must never cross into a QA sandbox. A branded parent
+ * session (the omo launcher) exports SENPI_BRAND plus <envPrefix>_* overrides
+ * such as OMO_CODING_AGENT_DIR; the CLI resolves settings brand-prefix-first
+ * (brandEnvNames in src/core/brand.ts), so those overrides silently outrank the
+ * SENPI_* pins below and the "isolated" CLI reads the REAL agent dir.
+ * SENPI_RUNTIME is a bun-runtime opt-in that would lie to a node-spawned CLI,
+ * PI_PROMPT_CACHE_SAFE_WAIT_SECONDS steers cache timing, and PI_SESSION_FILE /
+ * PI_SESSION_ID point at the parent session's live transcript.
+ */
+const SCRUBBED_SESSION_ENV = [
+	"SENPI_BRAND",
+	"SENPI_RUNTIME",
+	"PI_PROMPT_CACHE_SAFE_WAIT_SECONDS",
+	"PI_SESSION_FILE",
+	"PI_SESSION_ID",
+];
+
+/** envPrefix of the inherited brand profile, if any (mirrors parseBrandProfile's fallback). */
+function brandEnvPrefix(raw) {
+	try {
+		const profile = JSON.parse(raw);
+		const prefix = profile?.envPrefix ?? profile?.name;
+		return typeof prefix === "string" && prefix.trim() ? prefix.trim().toUpperCase() : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Remove inherited brand/session steering vars from a spawned-CLI env; returns the scrubbed names. */
+export function scrubSandboxEnv(env) {
+	const scrubbed = [];
+	const prefix = brandEnvPrefix(env.SENPI_BRAND);
+	for (const name of Object.keys(env)) {
+		if (SCRUBBED_SESSION_ENV.includes(name) || (prefix !== undefined && name.startsWith(`${prefix}_`))) {
+			delete env[name];
+			scrubbed.push(name);
+		}
+	}
+	return scrubbed;
+}
+
+/**
  * Create an isolated agent/session sandbox so QA never touches the real ~/.senpi.
  * Returns { dir, agentDir, sessionDir, cwd, env, cleanup }.
  * `env` is meant to be merged into spawn options (it already includes offline flags).
@@ -80,8 +122,9 @@ export function makeSandbox(label = "senpi-qa") {
 	const cwd = join(dir, "work");
 	for (const d of [agentDir, sessionDir, cwd]) mkdirSync(d, { recursive: true });
 
-	const env = {
-		...process.env,
+	const env = { ...process.env };
+	scrubSandboxEnv(env);
+	Object.assign(env, {
 		[ENV_AGENT_DIR]: agentDir,
 		[ENV_SESSION_DIR]: sessionDir,
 		// Keep QA hermetic and quiet: no startup network, no telemetry.
@@ -95,7 +138,7 @@ export function makeSandbox(label = "senpi-qa") {
 		// Never let an interactive pager/editor hang a captured run.
 		PAGER: "cat",
 		GIT_PAGER: "cat",
-	};
+	});
 
 	const box = {
 		dir,
@@ -351,6 +394,35 @@ async function selfCheck() {
 			box.env.SENPI_OMO_LOCAL_UPDATE === "0",
 		box.dir,
 	);
+
+	// A branded parent session (the omo launcher) exports SENPI_BRAND plus
+	// <envPrefix>_* overrides and session-steering vars; none may cross into a sandbox.
+	const leakedFixture = {
+		SENPI_BRAND: JSON.stringify({ name: "OmO", configDir: ".omo", envPrefix: "OMO", userAgent: "omo" }),
+		OMO_CODING_AGENT_DIR: "/tmp/qa-real-agent",
+		OMO_NATIVE: "1",
+		SENPI_RUNTIME: "bun",
+		PI_PROMPT_CACHE_SAFE_WAIT_SECONDS: "270",
+		PI_SESSION_FILE: "/tmp/qa-real-session.jsonl",
+		PI_SESSION_ID: "qa-real-session",
+	};
+	const savedFixture = new Map();
+	for (const [key, value] of Object.entries(leakedFixture)) {
+		savedFixture.set(key, process.env[key]);
+		process.env[key] = value;
+	}
+	const leakedBox = makeSandbox("self-check-leak");
+	for (const [key, value] of savedFixture) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	checks.ok(
+		"sandbox scrubs inherited brand/session env",
+		Object.keys(leakedFixture).every((key) => leakedBox.env[key] === undefined) &&
+			leakedBox.env[ENV_AGENT_DIR] === leakedBox.agentDir,
+		`scrubbed=${Object.keys(leakedFixture).filter((key) => leakedBox.env[key] === undefined).length}/${Object.keys(leakedFixture).length}`,
+	);
+	leakedBox.cleanup();
 
 	const guard = guardRealAuth();
 	checks.ok("real auth snapshot taken", true, guard.before ? `sha256=${guard.before.slice(0, 12)}…` : "absent");


### PR DESCRIPTION
## Summary

`senpi-qa` sandboxes were not hermetic when a channel ran from inside a branded (omo) agent session: the inherited `SENPI_BRAND` plus `<envPrefix>_*` overrides (e.g. `OMO_CODING_AGENT_DIR`) crossed into the spawned CLI, whose brand-prefix-first `envValue` resolution (`src/core/brand.ts`) let them outrank the harness's `SENPI_CODING_AGENT_DIR` pin. The "isolated" CLI then resolved the **real** agent dir — `mock-loop.mjs --self-test` failed 21/48 (`Unknown provider "mock"`, and the anthropic lane egressed to the real API with the dummy key), reproduced identically on main and in a worktree.

## Root cause

`makeSandbox()` spread `...process.env` and pinned only the `SENPI_*` dir vars. With `SENPI_BRAND` present, the spawned CLI parses the brand at startup and reads `OMO_CODING_AGENT_DIR` **before** `SENPI_CODING_AGENT_DIR` (`brandEnvNames`: brand prefix, then `SENPI`, then `PI`), so the sandbox pin lost every time a branded parent session ran QA.

## Fix

`common.mjs` `makeSandbox()` now scrubs the inherited brand/session steering set from the spawned-CLI env before applying the sandbox pins:

- `SENPI_BRAND` (the brand profile itself) plus every var under the parsed brand `envPrefix` (`OMO_*`) — with the brand gone the CLI is unbranded and the `SENPI_*` pins win;
- `SENPI_RUNTIME` (a bun-runtime opt-in that would lie to a node-spawned CLI), `PI_PROMPT_CACHE_SAFE_WAIT_SECONDS` (parent session cache-timing steering), `PI_SESSION_FILE` / `PI_SESSION_ID` (pointers at the parent session's live transcript).

The harness process env is untouched, so the real-auth guard keeps watching the caller's real agent dir. Channels that layer their own vars onto `box.env` (e.g. `SENPI_ENABLE_NEO`) are unaffected, and `pty-drive` spawns no CLI.

## Evidence

- RED (unfixed, this worktree): new `common.mjs --self-check` fixture assertion fails (`9/10` — the sandbox env inherits all 7 planted brand/session vars); `SENPI_BRAND` + `OMO_CODING_AGENT_DIR` + `OMO_NATIVE` + `SENPI_RUNTIME` + `PI_PROMPT_CACHE_SAFE_WAIT_SECONDS` exported → `mock-loop.mjs --self-test` **21/48**.
- GREEN: identical commands after the fix — self-check **10/10**, mock-loop **48/48** with the full brand env exported.
- Regression: the skill's full channel suite (common, fake-model-server, rpc-drive, mock-loop, tui-smoke, cli-smoke) run twice — once with the omo-session env exported, once plain — both fully green; evidence under `local-ignore/qa-evidence/20260824-qa-env-scrub/`.
- Changelog gate: `.agents/` is outside `RUNTIME_SOURCE_PATTERN` (`^packages/*/src/`) and not upstream-owned, so the release check passes as "no runtime source changes" and changes.md coverage is exempt — no changelog artifacts by design.

## Test plan

- `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`
- `SENPI_BRAND='{"name":"OmO","configDir":".omo","envPrefix":"OMO","userAgent":"omo"}' OMO_CODING_AGENT_DIR="$HOME/.omo/agent" node .agents/skills/senpi-qa/scripts/mock-loop.mjs --self-test`
- `for s in lib/common.mjs:--self-check lib/fake-model-server.mjs:--self-test rpc-drive.mjs:--self-test mock-loop.mjs:--self-test tui-smoke.mjs:--self-test cli-smoke.mjs:--self-test; do node ".agents/skills/senpi-qa/scripts/${s%%:*}" "${s##*:}" || echo "FAILED: $s"; done`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scrubs inherited brand/session environment variables from `senpi-qa` sandboxes to restore isolation. Previously, brand-prefixed vars from a branded parent session outranked `SENPI_*` pins, so the CLI read the real agent dir and could egress.

- `makeSandbox()` now calls `scrubSandboxEnv()` to delete `SENPI_BRAND`, brand `envPrefix` vars (e.g., `OMO_*`), `SENPI_RUNTIME`, `PI_PROMPT_CACHE_SAFE_WAIT_SECONDS`, `PI_SESSION_FILE`, and `PI_SESSION_ID` before pinning `SENPI_*` dirs.
- Adds a self-check that plants the leak set and asserts a clean sandbox; `mock-loop` and channel suites pass under both branded and plain sessions.
- The harness process env stays intact; channels that add vars to `box.env` continue to work; no runtime-source changes.

<sup>Written for commit 007772424ff13590be87257a2d0b4910b3b63907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

