### PR TITLE
fix(tui): keep the streaming head single-written while smooth reveal paces

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Assistant text painted during smooth streaming no longer vanishes and bursts back: `syncTrailingAssistantText` now yields the streaming head to the reveal controller while it paces (smooth streaming on, no toolCall in the head), so the paced prefix and the full head can no longer overwrite each other mid-stream ([#1102](https://github.com/code-yeongyu/senpi/pull/1102)).
 - The goal continuation wait countdown no longer renders over the Working indicator during externally started turns; the `goal-wait` footer segment now hides while a turn runs and restores itself when the session parks again, leaving the cache-warm schedule and iteration accounting untouched ([#1100](https://github.com/code-yeongyu/senpi/pull/1100)).
 - Webfetch now safely discards redirect response bodies under Bun 1.4.0's bare `undici`, which may omit `body.dump()`, by falling back to argument-free stream destruction instead of re-emitting cleanup failures as uncaught stream errors ([#1089](https://github.com/code-yeongyu/senpi/issues/1089)).
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,4 +1,25 @@
 # changes
+## 2026-08-24 — streaming head stays single-written while smooth reveal paces (fixes dual-write flicker)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `syncTrailingAssistantText` no longer overwrites the streaming head component while `streamingReveal.isPacingHead(head)` is true (smooth streaming on, no toolCall block in the head, component bound). The full-head write still lands when smooth streaming is off, when the head carries a toolCall (the reveal dumps full immediately there), and after the reveal stops at `message_end`. Trailing-segment logic is unchanged.
+- `packages/coding-agent/src/modes/interactive/streaming-reveal.ts`: new `isPacingHead(message)` — the single ownership query for the pacing condition.
+- `packages/coding-agent/test/tui-streaming-head-single-writer.test.ts`: regression test asserting the streaming component's painted text never shrinks before `message_end` with smooth streaming on (mutation-verified).
+
+### Why
+
+- Every assistant `message_update` wrote the head twice: `streamingReveal.setTarget(head)` painted the paced prefix, then `syncTrailingAssistantText` overwrote the component with the full head, and the next reveal tick repainted the shorter prefix. Painted text visibly vanished and burst back (lengths oscillated `[0, 116, 0, 168, ...]` in the regression capture), and the full/prefix height churn tripped the above-viewport scrollback replay, producing the vertical jumping reported after the 2026.8.22 line shipped.
+
+### Why an extension could not handle it
+
+- The streaming component, reveal pacing state, and per-update write ordering are private `InteractiveMode`/`StreamingRevealController` render state; extensions observe session events only.
+
+### Expected merge conflict zones
+
+- HIGH: `syncTrailingAssistantText` and the `message_update` handler in `packages/coding-agent/src/modes/interactive/interactive-mode.ts` (same hunk as the #1064 segment work).
+- LOW: `packages/coding-agent/src/modes/interactive/streaming-reveal.ts` around the new `isPacingHead` query.
+
 ## 2026-08-22 - working dock stays painted across queued turn boundaries
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5056,7 +5056,15 @@ export class InteractiveMode {
 
 	private syncTrailingAssistantText(message: AssistantMessage): void {
 		if (!this.streamingComponent) return;
-		this.streamingComponent.updateContent(assistantStreamingHeadMessage(message), true);
+		const head = assistantStreamingHeadMessage(message);
+		// Single writer: while smooth streaming paces the head (no toolCall block),
+		// streamingReveal owns the streaming component. Overwriting the full head
+		// here makes the next reveal tick repaint a shorter prefix (dual-write
+		// flicker). Once the reveal has stopped (message_end), it no longer paces
+		// and the final full paint below still lands.
+		if (!this.streamingReveal?.isPacingHead(head)) {
+			this.streamingComponent.updateContent(head, true);
+		}
 		const content = message.content;
 		const firstToolIndex = content.findIndex((block) => block.type === "toolCall");
 		if (firstToolIndex === -1) {

--- a/packages/coding-agent/src/modes/interactive/streaming-reveal.ts
+++ b/packages/coding-agent/src/modes/interactive/streaming-reveal.ts
@@ -87,6 +87,18 @@ export class StreamingRevealController {
 		this.#applyTarget();
 	}
 
+	/**
+	 * True while this controller is the pacing writer for the given head message:
+	 * smooth streaming is on, the head carries no toolCall block (those dump in
+	 * full), and a component is still bound (before stop()). While true, callers
+	 * must not overwrite the component's content, or the next reveal tick
+	 * repaints a shorter prefix after their full write (dual-write flicker).
+	 */
+	isPacingHead(message: AssistantMessage): boolean {
+		if (!this.#target || !this.#component) return false;
+		return this.#getSmoothStreaming() && !message.content.some((block) => block.type === "toolCall");
+	}
+
 	stop(): void {
 		this.#stopTimer();
 		this.#target = undefined;

--- a/packages/coding-agent/test/tui-streaming-head-single-writer.test.ts
+++ b/packages/coding-agent/test/tui-streaming-head-single-writer.test.ts
@@ -1,0 +1,132 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { Container } from "@earendil-works/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
+import type { AssistantMessageComponent } from "../src/modes/interactive/components/assistant-message.ts";
+import { ContinuityNoticeTracker } from "../src/modes/interactive/components/continuity-notice.ts";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { StreamingRevealController } from "../src/modes/interactive/streaming-reveal.ts";
+import { getMarkdownTheme } from "../src/modes/interactive/theme/theme.ts";
+import { createHarness, getMessageText, type Harness } from "./suite/harness.ts";
+
+const handleEvent = (InteractiveMode.prototype as unknown as { handleEvent(event: AgentSessionEvent): Promise<void> })
+	.handleEvent;
+
+type StreamingSurface = {
+	isInitialized: boolean;
+	hideThinkingBlock: boolean;
+	hiddenThinkingLabel: string;
+	outputPad: number;
+	toolOutputExpanded: boolean;
+	chatContainer: Container;
+	assistantTextSegments: Map<number, AssistantMessageComponent>;
+	pendingTools: Map<string, never>;
+	streamingComponent: AssistantMessageComponent | undefined;
+	streamingMessage: AssistantMessage | undefined;
+	runtimeHost: { session: Harness["session"] };
+	continuityNotices: ContinuityNoticeTracker;
+	toolArgsReveal: { flush: () => boolean; flushAll: () => void };
+	getMarkdownThemeWithSettings: () => ReturnType<typeof getMarkdownTheme>;
+	getMarkdownTransformers: () => [];
+	footer: { invalidate: () => void };
+	ui: { requestRender: () => void };
+	streamingReveal: StreamingRevealController;
+};
+
+/**
+ * Minimal surface for the real handleEvent message_start/message_update/
+ * message_end (assistant) path: real AssistantMessageComponent, real chat
+ * container, and the REAL StreamingRevealController wired to the harness
+ * settings manager, so smooth-streaming pacing runs exactly as in production.
+ * The surface inherits InteractiveMode.prototype so private helpers
+ * (syncTrailingAssistantText et al.) run for real against this state.
+ */
+function createStreamingSurface(harness: Harness): StreamingSurface {
+	const surface = Object.create(InteractiveMode.prototype) as StreamingSurface;
+	return Object.assign(surface, {
+		isInitialized: true,
+		hideThinkingBlock: false,
+		hiddenThinkingLabel: "Thinking...",
+		outputPad: 1,
+		toolOutputExpanded: false,
+		chatContainer: new Container(),
+		assistantTextSegments: new Map(),
+		pendingTools: new Map(),
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		runtimeHost: { session: harness.session },
+		continuityNotices: new ContinuityNoticeTracker(),
+		toolArgsReveal: { flush: () => false, flushAll: () => {} },
+		getMarkdownThemeWithSettings: () => getMarkdownTheme(),
+		getMarkdownTransformers: () => [],
+		footer: { invalidate: vi.fn() },
+		ui: { requestRender: vi.fn() },
+		streamingReveal: new StreamingRevealController({
+			getSmoothStreaming: () => harness.settingsManager.getSmoothStreaming(),
+			getSmoothStreamingFps: () => harness.settingsManager.getSmoothStreamingFps(),
+			getHideThinkingBlock: () => false,
+			requestRender: () => {},
+		}),
+	});
+}
+
+type Paint = { event: string; text: string };
+
+describe("streaming head single-writer (smooth streaming)", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("never shrinks the streaming component's painted text while the reveal paces the head", async () => {
+		const harness = await createHarness({ settings: { smoothStreaming: true } });
+		harnesses.push(harness);
+		const surface = createStreamingSurface(harness);
+
+		// Record EVERY paint pushed into the streaming component (from both the
+		// reveal controller and syncTrailingAssistantText) between message_start
+		// and message_end. The dual-write regression paints full-head then a
+		// paced prefix, so the sequence shrinks.
+		const paints: Paint[] = [];
+		let currentEvent = "before-stream";
+		const unsubscribe = harness.session.subscribe((event) => {
+			if (event.type !== "message_start" && event.type !== "message_update" && event.type !== "message_end") {
+				return;
+			}
+			if (event.message.role !== "assistant") return;
+			currentEvent = event.type;
+			const handled = handleEvent.call(surface, event);
+			if (event.type === "message_start" && surface.streamingComponent) {
+				const component = surface.streamingComponent;
+				const original = component.updateContent.bind(component);
+				component.updateContent = (message: AssistantMessage, isStreaming?: boolean) => {
+					paints.push({ event: currentEvent, text: getMessageText(message) });
+					return original(message, isStreaming);
+				};
+			}
+			return handled;
+		});
+
+		const streamedText = Array.from({ length: 30 }, (_, index) => `token-${index}`).join(" ");
+		harness.setResponses([fauxAssistantMessage(streamedText)]);
+		await harness.session.prompt("stream");
+		await harness.session.waitForIdle();
+		unsubscribe();
+
+		const updates = harness.events.filter(
+			(event) => event.type === "message_update" && event.message.role === "assistant",
+		);
+		expect(updates.length).toBeGreaterThanOrEqual(2);
+
+		const lengths = paints.map((paint) => paint.text.length);
+		const firstShrink = lengths.findIndex((length, index) => index > 0 && length < (lengths[index - 1] ?? 0));
+		expect(
+			firstShrink,
+			`streaming head paints must never shrink (single writer); got lengths [${lengths.join(", ")}] for events [${paints.map((paint) => paint.event).join(", ")}]`,
+		).toBe(-1);
+
+		// message_end must still flush the complete head once the reveal stops.
+		expect(paints[paints.length - 1]?.text).toBe(streamedText);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the streaming-render regression where, with smooth streaming on, already-painted assistant text vanished and burst back while the screen jumped vertically. Root cause: a dual write on the streaming head component. Every assistant `message_update` first called `streamingReveal.setTarget(head)` (which paints a paced prefix in smooth mode) and then `syncTrailingAssistantText()`, which overwrote the same component with the complete head; the next reveal tick repainted the shorter prefix. The full/prefix oscillation changed wrapped heights and, once the block sat above the viewport, tripped the whole-history scrollback replay — the visible jump-and-burst. After this PR the reveal controller is the single writer while it paces the head, so painted text never shrinks mid-stream.

## Changes

- **Single-writer gate** (`packages/coding-agent/src/modes/interactive/interactive-mode.ts`): `syncTrailingAssistantText` skips the full-head overwrite only while `streamingReveal.isPacingHead(head)` is true — smooth streaming on, no toolCall block in the head, component still bound. When smooth streaming is off, when a toolCall is present (the reveal dumps full immediately there), and at `message_end` (reveal stopped), the full write still lands exactly as before. The trailing-segment logic is untouched.
- **Pacing ownership query** (`packages/coding-agent/src/modes/interactive/streaming-reveal.ts`): new `isPacingHead(message)` — the one place that knows the pacing condition, so callers can't diverge from it.
- **Regression test** (`packages/coding-agent/test/tui-streaming-head-single-writer.test.ts`): drives a real `AgentSession` + `handleEvent` with smooth streaming on and asserts the streaming component's painted text never shrinks before `message_end`. Captured failing pre-fix (lengths oscillated `[0, 116, 0, 168, 0, 232, ...]` — full head, then an empty paced prefix), passing post-fix; a mutation check (restoring the unconditional overwrite) fails it again.

## QA & Evidence

All artifacts under `local-ignore/qa-evidence/20260824-streaming-dual-write/` (not committed; available on request — key RESULT.md verdicts quoted below).

- **What was tested:** RED→GREEN regression test (real session harness, smooth streaming on).
  **Observed result:** pre-fix failure with the dual-write signature (painted length drops to 0 between full writes); post-fix pass; mutation re-fails.
  **Artifact:** `red.txt`, `green.txt`, `mutation.txt`.
  **Why sufficient:** proves the exact mechanism (shrink-then-regrow) is gone at the component level, and that the test pins the behavior (non-tautological).
- **What was tested:** five manual QA lanes driving the real TUI (`packages/coding-agent/src/cli.ts`, mock provider) in a real PTY, frames rendered via `@xterm/headless` / `scripts/qa/xterm-render.mjs` (never `tmux capture-pane`). Detectors: VANISH = a standalone 3-digit marker visible in frame N, absent in N+1, present again later; JUMP = a marker's row oscillating across consecutive frames without scroll.
  **Observed result:** every lane **VANISH=0, JUMP=0** —
  `qa-smooth-on` (fresh session, smooth ON, 402 frames, 501/501 markers), `qa-smooth-off` (control, settings-verified off, 372 frames), `qa-resume` (160-child session + `/resume` + hydration during the live stream, 423 frames, resume markers intact), `qa-tool-heavy` (4 text segments interleaved with 3 tool cards, no segment reinsert), `qa-kimi` (`kimi-k3-ultrafast` stream, 186 frames).
  **Artifact:** `qa-*/RESULT.md` + `frames/` + `analysis.json` per lane.
  **Why sufficient:** reproduces the user-reported symptom scenario end-to-end on the fixed build across the risky variants (smooth on/off, hydration, tool segments, kimi transport) and shows the symptom is gone.
- **What was tested:** scoped suites + `npm run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, platform-lock, `tsc --noEmit`, browser smoke); full suite in VERIFICATION.md.
  **Observed result:** 13 files / 108 tests pass; check chain green.
  **Artifact:** `scoped-tests.txt`, `npm-run-check.txt`, `VERIFICATION.md`.
  **Why sufficient:** no regressions in adjacent TUI behavior; repo quality gates pass locally before CI.

## Risks & Residuals

- **Residual: progressive hydration and post-tool segment indexing** were rated lower-confidence contributors in the root-cause analysis. The `qa-resume` and `qa-tool-heavy` lanes both show VANISH=0/JUMP=0 on the fixed build, so no further change is made here; if a variant still reproduces in the wild it should get its own focused PR.
- **Risk: a caller overwrites the head while the reveal paces.** Mitigated by construction: `isPacingHead` lives on the controller, and the regression test fails if the dual write is reintroduced (mutation-verified).
- **Risk: smooth streaming toggled mid-stream.** Accepted: on the next `message_update` the reveal either starts pacing (gate engages) or dumps full and stops (gate disengages); both writers then agree on the same content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes smooth-streaming flicker where assistant text vanished and reappeared with vertical jumps. Previously each update dual-wrote the streaming head (paced prefix plus full overwrite); now the reveal controller is the single writer while pacing, so painted text never shrinks mid-stream.

- In `packages/coding-agent/src/modes/interactive/interactive-mode.ts`, `syncTrailingAssistantText` writes the full head only when `!streamingReveal.isPacingHead(head)`. Behavior is unchanged when smooth streaming is off, a `toolCall` is present, or at `message_end`; trailing-segment logic is unchanged.
- Adds `isPacingHead(message)` in `packages/coding-agent/src/modes/interactive/streaming-reveal.ts` to centralize pacing ownership.
- Adds `packages/coding-agent/test/tui-streaming-head-single-writer.test.ts` to assert the streaming head’s painted text never shrinks during pacing and ends with a full flush.
- Updates `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/src/modes/interactive/changes.md` to document the fix and the single-writer gate.

<sup>Written for commit 817e379a2be292c8d29a97fab7beb42952dd7c71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

