### PR TITLE
fix(coding-agent): reject local:// URIs in the read tool with actionable guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- The read tool now rejects `local://` URIs with actionable guidance instead of resolving them as relative paths and failing with a confusing `ENOENT <cwd>/local:/...`; the error names the eval kernel `read()` helper and the plain-absolute-path alternative, so agents following detached-eval spill notices recover in one step ([#1103](https://github.com/code-yeongyu/senpi/pull/1103)).
 - Assistant text painted during smooth streaming no longer vanishes and bursts back: `syncTrailingAssistantText` now yields the streaming head to the reveal controller while it paces (smooth streaming on, no toolCall in the head), so the paced prefix and the full head can no longer overwrite each other mid-stream ([#1102](https://github.com/code-yeongyu/senpi/pull/1102)).
 - The goal continuation wait countdown no longer renders over the Working indicator during externally started turns; the `goal-wait` footer segment now hides while a turn runs and restores itself when the session parks again, leaving the cache-warm schedule and iteration accounting untouched ([#1100](https://github.com/code-yeongyu/senpi/pull/1100)).
 - Webfetch now safely discards redirect response bodies under Bun 1.4.0's bare `undici`, which may omit `body.dump()`, by falling back to argument-free stream destruction instead of re-emitting cleanup failures as uncaught stream errors ([#1089](https://github.com/code-yeongyu/senpi/issues/1089)).

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-24 - reject local:// URIs in the read tool with actionable guidance
+
+### What changed
+
+- `packages/coding-agent/src/core/tools/read.ts`: the execute path now guards the `local://` URI scheme (`/^local:\/\//i`) before any path resolution and throws guidance naming the eval kernel `read()`/`write()` helpers and the plain-absolute-path alternative, instead of resolving the URI as a relative path and failing with `ENOENT <cwd>/local:/...`. Single-slash `local:/x` stays an ordinary relative path because a colon is legal in macOS filenames.
+
+### Why
+
+- A 2026-08-24 session replayed a detached-eval spill notice pointing at `local://detached-eval-eval_5.log` through the read tool; the scheme collapsed to a relative path and the tool returned a bare ENOENT with no recovery hint. Deployed bundles still emit `local://` spill URIs and the eval prompt documents the scheme for kernel helpers, so the read tool is a repeatable trap; the error itself now teaches the two working paths.
+
+### Why an extension could not handle it
+
+- The guard must run inside the built-in read tool's own execute path before `resolveReadPathAsync`; extension filesystem-policy hooks only see already-canonicalized paths, so the raw scheme string never reaches them.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/tools/read.ts` execute prologue and the module constants block.
+
 ## 2026-08-22 - Retarget OpenAI automatic defaults to GPT-5.6 Sol
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,23 +1,5 @@
 # changes
 
-## 2026-08-24 - reject local:// URIs in the read tool with actionable guidance
-
-### What changed
-
-- `packages/coding-agent/src/core/tools/read.ts`: the execute path now guards the `local://` URI scheme (`/^local:\/\//i`) before any path resolution and throws guidance naming the eval kernel `read()`/`write()` helpers and the plain-absolute-path alternative, instead of resolving the URI as a relative path and failing with `ENOENT <cwd>/local:/...`. Single-slash `local:/x` stays an ordinary relative path because a colon is legal in macOS filenames.
-
-### Why
-
-- A 2026-08-24 session replayed a detached-eval spill notice pointing at `local://detached-eval-eval_5.log` through the read tool; the scheme collapsed to a relative path and the tool returned a bare ENOENT with no recovery hint. Deployed bundles still emit `local://` spill URIs and the eval prompt documents the scheme for kernel helpers, so the read tool is a repeatable trap; the error itself now teaches the two working paths.
-
-### Why an extension could not handle it
-
-- The guard must run inside the built-in read tool's own execute path before `resolveReadPathAsync`; extension filesystem-policy hooks only see already-canonicalized paths, so the raw scheme string never reaches them.
-
-### Expected merge conflict zones
-
-- `packages/coding-agent/src/core/tools/read.ts` execute prologue and the module constants block.
-
 ## 2026-08-22 - Retarget OpenAI automatic defaults to GPT-5.6 Sol
 
 ### What changed

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -1,5 +1,31 @@
 # core/tools changes
 
+## Read tool rejects local:// URIs with actionable guidance (2026-08-24)
+
+### What changed
+
+- `packages/coding-agent/src/core/tools/read.ts`: the execute path now guards the `local://` URI scheme
+  (`/^local:\/\//i`) before any path resolution and throws guidance naming the eval kernel `read()`/`write()`
+  helpers and the plain-absolute-path alternative, instead of resolving the URI as a relative path and failing
+  with `ENOENT <cwd>/local:/...`. Single-slash `local:/x` stays an ordinary relative path because a colon is legal
+  in macOS filenames.
+
+### Why
+
+- A 2026-08-24 session replayed a detached-eval spill notice pointing at `local://detached-eval-eval_5.log`
+  through the read tool; the scheme collapsed to a relative path and the tool returned a bare ENOENT with no
+  recovery hint. Deployed bundles still emit `local://` spill URIs and the eval prompt documents the scheme for
+  kernel helpers, so the read tool is a repeatable trap; the error itself now teaches the two working paths.
+
+### Why an extension could not handle it
+
+- The guard must run inside the built-in read tool's own execute path before `resolveReadPathAsync`; extension
+  filesystem-policy hooks only see already-canonicalized paths, so the raw scheme string never reaches them.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/tools/read.ts` execute prologue and the module constants block.
+
 ## Edit tool keeps filesystem policy and themed diff rendering after the 59a71b23 pin (2026-08-19)
 
 ### What changed

--- a/packages/coding-agent/src/core/tools/read.ts
+++ b/packages/coding-agent/src/core/tools/read.ts
@@ -42,6 +42,9 @@ interface CompactReadClassification {
 }
 
 const COMPACT_RESOURCE_FILE_NAMES = new Set(["AGENTS.override.md", "AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"]);
+const LOCAL_URI_SCHEME = /^local:\/\//i;
+const LOCAL_URI_GUIDANCE =
+	"local:// URIs resolve only inside eval cells via the kernel read()/write() helpers; the read tool takes filesystem paths. Re-read this with the eval read() helper, or retry with the plain absolute file path.";
 
 /**
  * Pluggable operations for the read tool.
@@ -231,6 +234,9 @@ export function createReadToolDefinition(
 			_onUpdate?,
 			ctx?,
 		) {
+			if (LOCAL_URI_SCHEME.test(path)) {
+				throw new Error(LOCAL_URI_GUIDANCE);
+			}
 			return new Promise<{ content: (TextContent | ImageContent)[]; details: ReadToolDetails | undefined }>(
 				(resolve, reject) => {
 					if (signal?.aborted) {

--- a/packages/coding-agent/test/read-tool-local-uri.test.ts
+++ b/packages/coding-agent/test/read-tool-local-uri.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createReadTool } from "../src/index.ts";
+
+const GUIDANCE_PHRASE = "URIs resolve only inside eval cells";
+
+const readTool = createReadTool(process.cwd());
+
+async function rejectedMessage(path: string): Promise<string> {
+	try {
+		await readTool.execute("read-tool-local-uri", { path });
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+	throw new Error(`expected read to reject for path: ${path}`);
+}
+
+function expectLocalUriGuidance(message: string): void {
+	expect(message).toContain("local://");
+	expect(message).toMatch(/eval/i);
+	expect(message).not.toContain("ENOENT");
+}
+
+function expectClassicNotFound(message: string): void {
+	expect(message).toMatch(/ENOENT|not found/i);
+	expect(message).not.toContain(GUIDANCE_PHRASE);
+}
+
+describe("read tool local:// URI guard", () => {
+	it('rejects path "local://detached-eval-eval_5.log" with guidance and no ENOENT', async () => {
+		expectLocalUriGuidance(await rejectedMessage("local://detached-eval-eval_5.log"));
+	});
+
+	it('rejects path "local://" with the same guidance error', async () => {
+		expectLocalUriGuidance(await rejectedMessage("local://"));
+	});
+
+	it('rejects uppercase scheme "LOCAL://x.log" with the same guidance error', async () => {
+		expectLocalUriGuidance(await rejectedMessage("LOCAL://x.log"));
+	});
+
+	it("returns a classic not-found error for a missing filesystem path", async () => {
+		expectClassicNotFound(await rejectedMessage("definitely-missing-file-12345.txt"));
+	});
+
+	it("treats a single-slash local:/ path as an ordinary relative path", async () => {
+		expectClassicNotFound(await rejectedMessage("local:/single-slash.txt"));
+	});
+});


### PR DESCRIPTION
## Problem

2026-08-24 incident: read tool called with `local://detached-eval-eval_5.log` (spilled detached-eval URI) failed with `ENOENT <cwd>/local:/...` because the tool resolves the scheme as a relative path; the deployed omo-ai beta.18 bundle still emits `local://` spill notices (the absolute-path notice fix `04c2b7a99` is merged but undeployed), and the eval prompt documents `local://` for kernel helpers, so agents keep hitting this.

## Fix

Scheme-exact `/^local:\/\//i` guard at the top of the coding-agent read tool execute path raising actionable guidance (use the eval kernel `read()` helper or the plain absolute path). Single-slash `local:/` stays an ordinary path (colon is legal in macOS filenames).

## Evidence

RED->GREEN vitest `packages/coding-agent/test/read-tool-local-uri.test.ts` (5 cases incl. negative controls), CLI QA captures, full package suite, root `npm run check`; artifacts under `/Users/yeongyu/sisyphuslabs/.omo/evidence/20260824-read-tool-local-uri`.

## Follow-ups

Mirror the guard in `packages/agent/src/harness/tools/read.ts` (upstream-fork copy); bump the senpi dependency in omo-ai so the fix ships.

## Test plan

The exact commands run are documented in the evidence artifacts and commit verification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects local:// URIs in the coding-agent read tool and returns actionable guidance to use eval kernel helpers or an absolute path. This replaces resolving these URIs as filesystem paths that failed with ENOENT.

- Behavior: Paths matching /^local:\/\//i now throw guidance naming the eval kernel read()/write() helpers and the absolute-path alternative; the error omits ENOENT; uppercase schemes are rejected; single-slash local:/ is unaffected.
- Tests: Added `packages/coding-agent/test/read-tool-local-uri.test.ts` covering guarded URIs, case-insensitivity, classic not-found, and the single-slash local:/ case.
- Docs: Added `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/src/core/tools/changes.md` entries describing the guard.
- Migration: Do not pass local:// to the read tool. In eval cells, call the kernel read() helper; otherwise provide a plain absolute path.

<sup>Written for commit c9f6096f15930a2b76e1ac4960707ac701242d9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

