### PR TITLE
docs(agents): refresh knowledge base for 2026-08-24 HEAD

### DIFF
--- a/.agents/skills/senpi-qa/AGENTS.md
+++ b/.agents/skills/senpi-qa/AGENTS.md
@@ -1,0 +1,60 @@
+# .agents/skills/senpi-qa
+
+Manual QA harness for the senpi coding agent, driven from source in isolated sandboxes. `SKILL.md` is the operating manual (channels, golden rules, evidence contract); root `AGENTS.md` owns when QA is mandatory. This file maps the ~107-script codebase behind them.
+
+## STRUCTURE
+
+```text
+SKILL.md                                 Channel manual; start here to run QA
+scripts/*.mjs (32)                       Top-level drivers (rpc-drive, tui-smoke,
+                                         mock-loop, cli-smoke, pty-drive) + focused QA
+scripts/lib/ (42)                        Shared harness; common.mjs is the foundation
+scripts/lib/*.test.mjs (4)               node:test units for lib helpers
+scripts/scenarios/ (30 + helpers)        One-off runners; -qa checks, -repro bugs
+scripts/scenarios/cursor-exec-lifecycle/ HTTP/2 + protobuf Cursor wire helpers
+scripts/scenarios/cursor-oauth-catalog-refresh/setup.ts  Only TypeScript here; runs via tsx
+scripts/probes/cursor-cli/ (3)           Cursor CLI canaries/probes
+references/                              rpc-protocol, tui-driving, mock-loop,
+                                         credential-injection, env-vars
+evals/evals.json                         Structured eval cases
+package.json + package-lock.json         Private dep island (node-pty only); stays out
+                                         of the root lockfile and coding-agent shrinkwrap
+```
+
+## WHERE TO LOOK
+
+| Task | Path |
+|---|---|
+| Run a channel / self-test suite | `SKILL.md` scripts index |
+| Sandbox, CLI spawn, auth guard, evidence | `scripts/lib/common.mjs` |
+| Provider presets, mock `models.json`, MCP fixtures | `scripts/lib/mock-loop-support.mjs` |
+| Fake model server (three wire formats) | `scripts/lib/fake-model-server.mjs` |
+| RPC clients for QA | `scripts/lib/rpc-client.mjs`, `rpc-qa-client.mjs`, `target-rpc-client.mjs` |
+| New regression scenario | `scripts/scenarios/<name>-qa.mjs` + `--evidence <slug>` |
+| Cursor CLI behavior | `scripts/probes/cursor-cli/`, `scripts/scenarios/cursor-*` |
+| Env/credential rules | `references/env-vars.md`, `references/credential-injection.md` |
+
+## CONVENTIONS
+
+- ESM `.mjs` with explicit `node:` imports; relative imports carry extensions.
+- Every executable ships `--self-test`/`--self-check`; a script is both tool and regression check.
+- Isolation via `lib/common.mjs`: `makeSandbox`, `scrubSandboxEnv`, `PI_OFFLINE=1`, `PI_TELEMETRY=0`, `guardRealAuth`.
+- Drive the CLI from source through `tsxEntry()`; never assume built `dist`.
+- Suffix taxonomy: `-qa` check, `-repro` bug reproduction, `-spike`/`-probe` gated exploration.
+- Evidence to `local-ignore/qa-evidence/<YYYYMMDD>-<slug>/` via `--evidence`/`evidenceDir()`.
+- Lib units use `node:test` + `node:assert/strict`, not Vitest.
+
+## ANTI-PATTERNS
+
+- Never read or write the real `~/.senpi`; snapshot `auth.json` sha256 and assert unchanged.
+- Never inherit or log provider env/auth headers: scrub before spawn, `sanitizeRequests` before evidence.
+- No `src/` edits from this skill — it verifies and reports; fixes are follow-up changes.
+- No unbounded sleeps as synchronization; bounded observable waits and watchdogs only.
+- Live external paths are opt-in gates (`SENPI_CURSOR_CLI_LIVE=1`, `SENPI_LIVE_CLAUDE_SDK_OAUTH=1`), never defaults.
+- Never treat generated Cursor protobuf TypeScript as hand-authored wire logic.
+
+## VALIDATION
+
+- Setup once: `node scripts/devenv-setup.mjs`; harness check: `node .agents/skills/senpi-qa/scripts/lib/common.mjs --self-check`.
+- Lib units: `node --test .agents/skills/senpi-qa/scripts/lib/` (runs the four `*.test.mjs`).
+- A new script is not done until its own `--self-test` passes with evidence captured.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,50 @@
+# .github/
+
+CI, release, and issue automation for the senpi fork, plus the committed agent guidance
+the merge/release workflows execute. Score 12: 25 files, distinct automation domain —
+prescriptive rules here are load-bearing for agents running in Actions.
+
+## STRUCTURE
+
+```text
+workflows/     13 workflows (CI, build-binaries, native-prebuilds, publish-npm,
+               publish-model-catalog, changelog-gate, releasability, npm-audit,
+               perf-trend, issue-analysis, issue-triage-labels, remove-inprogress-on-close)
+agent/         Merge/release agent drivers, /cl command, committed skills
+ISSUE_TEMPLATE/ bug.yml, contribution.yml, package-report.yml
+upstream.json  Accepted upstream baseline recorded by merges (read by scripts)
+```
+
+## WHERE TO LOOK
+
+| Task | Path |
+|---|---|
+| CI parity for local checks | `workflows/ci.yml` (Node 24, `npm ci --ignore-scripts`, fan-in job named exactly `Check and test`) |
+| npm publish path | `workflows/publish-npm.yml` (the ONLY publisher; triggered after release tag) |
+| Binary/native builds | `workflows/build-binaries.yml`, `workflows/native-prebuilds.yml` |
+| PR changelog gate | `workflows/changelog-gate.yml` (drives `scripts/check-pr-changelog.mjs`) |
+| Merge agent procedure | `agent/README.md`, `agent/merge-driver.md`, `agent/skills/merge-upstream/` |
+| Release audit agent | `agent/release-driver.md`, `agent/skills/release-publish/` |
+| Changelog audit command | `agent/commands/cl.md` |
+
+## CONVENTIONS
+
+- GitHub Actions are pinned by full commit SHA (e.g. `actions/checkout@df4cb1c0...`); never reference floating tags.
+- Workflows install with `npm ci --ignore-scripts` and run root `npm run check`/`npm test`.
+- The release driver emits a final stdout status line: `RELEASE_DECISION: RELEASE | SKIP | FAILED`.
+  The merge agent emits `MERGE_RESULT: CLEAN_PR_READY | NO_RELEASE_NEEDED | CONFLICTS | QA_FAILED | AGENT_FAILED`.
+- Release runs only after the upstream PR is merge-committed into `main`, a fresh `/cl`
+  audit passes on that tip, and `scripts/upstream-release-worthy.mjs` finds `## [Unreleased]`
+  package changelog entries.
+
+## ANTI-PATTERNS
+
+- NEVER rebase, force-push, or rewrite history; never bypass hooks (`--no-verify`).
+- NEVER publish npm packages from the binary workflow — npm publishing belongs to `publish-npm.yml` only.
+- NEVER edit already-released changelog sections; released sections are immutable.
+- NEVER rerun a release after a tag exists; verify npm versions after a PUT 404 before
+  retrying or declaring failure.
+- Credentials stay local to the runner; never copy them into reports, PRs, or committed files.
+
+---
+Generated: 2026-08-24 | Commit `baf15a54d`

--- a/.omo/init-deep.json
+++ b/.omo/init-deep.json
@@ -1,0 +1,1 @@
+{"commitSha":"baf15a54d4aac39e4c25012b54ff0a537eb890ab","fileCount":5287,"loc":734565,"timestamp":1787568830091,"mode":"committed"}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,8 @@
 # Senpi Repository Guide
 
-Generated: 2026-08-22
-Commit: `a5eed4453`
-Branch: `main`
-
-Metadata above records the source state used for this generation pass.
+Generated: 2026-08-24
+Commit: `baf15a54d`
+Branch: `initdeep-refresh-20260824`
 
 Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve upstream mergeability, and read the nearest `AGENTS.md` plus every applicable `changes.md` before editing.
 
@@ -14,13 +12,13 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 
 **WHEN A PATCH MUST BE MADE TO THIS REPOSITORY AND THE USER HAS EXPLICITLY INSTRUCTED THE MODIFICATION, THE FOLLOWING SEQUENCE IS ABSOLUTE AND BINDING. EXECUTE EVERY STEP, IN THIS EXACT ORDER. SKIPPING, REORDERING, OR ABBREVIATING ANY STEP IS A DEFECT:**
 
-1. **EXPLORE** — SURVEY THE CODEBASE FIRST. READ EVERY FILE, SYMBOL, AND TEST THE CHANGE TOUCHES BEFORE WRITING A SINGLE LINE.
-2. **MAKE A PLAN** — WRITE A DECISION-COMPLETE PLAN BEFORE ANY IMPLEMENTATION. NO CODE BEFORE THE PLAN EXISTS.
-3. **ADD TODOS IN ULTRA-DETAIL** — MIRROR EVERY ATOMIC STEP OF THE PLAN INTO THE TODO LIST. NO STEP IS TOO SMALL TO TRACK.
-4. **MAKE A NEW WORKTREE** — NEVER IMPLEMENT IN THE SHARED WORKTREE. ALL IMPLEMENTATION HAPPENS IN A DEDICATED GIT WORKTREE.
-5. **MAKE A PR AND WORK UNTIL IT GETS MERGED** — SHIP THROUGH A REVIEWER-READABLE PR AND DRIVE IT RELENTLESSLY UNTIL IT IS MERGED. AN UNMERGED PR IS UNFINISHED WORK.
-6. **SET A GOAL AND RUN THE ULW LOOP** — REGISTER A BINDING GOAL AND EXECUTE UNDER THE ULW LOOP UNTIL EVERY SUCCESS CRITERION PASSES WITH CAPTURED EVIDENCE.
-7. **MANAGE TODOS OBSESSIVELY** — UPDATE THE TODO LIST ON EVERY STATE TRANSITION, THE INSTANT IT HAPPENS. A STALE TODO LIST IS A DEFECT.
+1. **EXPLORE** — READ EVERY FILE, SYMBOL, AND TEST THE CHANGE TOUCHES BEFORE WRITING A SINGLE LINE.
+2. **MAKE A PLAN** — A DECISION-COMPLETE PLAN EXISTS BEFORE ANY CODE.
+3. **ADD TODOS IN ULTRA-DETAIL** — MIRROR EVERY ATOMIC PLAN STEP INTO THE TODO LIST.
+4. **MAKE A NEW WORKTREE** — NEVER IMPLEMENT IN THE SHARED WORKTREE.
+5. **MAKE A PR AND WORK UNTIL IT GETS MERGED** — AN UNMERGED PR IS UNFINISHED WORK.
+6. **SET A GOAL AND RUN THE ULW LOOP** — EVERY SUCCESS CRITERION PASSES WITH CAPTURED EVIDENCE.
+7. **MANAGE TODOS OBSESSIVELY** — UPDATE ON EVERY STATE TRANSITION. A STALE TODO LIST IS A DEFECT.
 
 **DELIVERY STOP INVARIANT:** UNDER PROTOCOL 1, “PR OPENED” IS NEVER A VALID STOP CONDITION, GOAL SUCCESS CRITERION, OR FINAL TODO. DELIVERY ENDS ONLY WHEN GITHUB REPORTS `MERGED` AND THE TASK WORKTREE IS REMOVED. WHILE GATES ARE PENDING, KEEP MERGE/CLEANUP TODOS OPEN, MONITOR TO COMPLETION, THEN MERGE-COMMIT AND CLEAN UP BEFORE THE FINAL RESPONSE.
 
@@ -40,17 +38,18 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 | `packages/agent/` | Browser-safe agent loop plus optional Node harness |
 | `packages/coding-agent/` | `senpi` CLI, sessions, extensions, RPC, interactive mode |
 | `packages/tui/` | Differential terminal renderer and editor primitives |
-| `packages/server/` | Composable, transport-neutral protocol server |
+| `packages/protocol/`, `packages/server/`, `packages/client/` | Framed-CBOR wire protocol plus its server and client for remote sessions |
 | `packages/telemetry/` | Vendor-neutral telemetry contracts and typed schema utilities |
-| `packages/protocol/` | Transport-neutral CBOR protocol for remote pi sessions |
-| `packages/client/` | Transport-neutral client for remote pi sessions (framed CBOR) |
 | `packages/session-backends/` | Session backend adapters; `sqlite-node/` Node sqlite session store |
-| `packages/evals/` | Behavioral, model-backed eval suites over real `AgentSession` |
-| `packages/pty/` | TypeScript PTY loader, sessions, registry, pipe fallback |
-| `packages/senpi-codemode/` | Source-only persistent-kernel `eval` extension |
+| `packages/evals/` | Model-backed eval suites over real `AgentSession`; spends tokens by design |
+| `packages/pty/` | TypeScript PTY loader, sessions, registry, vendored prebuilds, pipe fallback |
+| `packages/senpi-codemode/` | Source-only persistent-kernel `eval` extension (js/py/rb/jl kernels) |
 | `crates/senpi-pty/` | Rust/N-API native PTY implementation and ABI owner |
 | `scripts/` | Build, validation, release, lock and environment tooling |
-| `.agents/skills/senpi-qa/` | Required real-CLI QA harness and evidence contract |
+| `bench/` | Benchmark baselines and improvement ledger (data only; run via `scripts/run-pr530-benchmarks.mjs`) |
+| `.github/` | CI/release/issue automation plus committed merge and release agent drivers |
+| `.agents/skills/senpi-qa/` | Required real-CLI QA harness; private dependency island outside the workspace |
+| `local-ignore/` | QA evidence archive; gitignored except deliberately tracked historical receipts |
 
 ## WHERE TO LOOK
 
@@ -58,98 +57,94 @@ Senpi is an extension-first coding-agent monorepo. Keep changes scoped, preserve
 |---|---|
 | Add a feature to the CLI | `packages/coding-agent/src/core/extensions/builtin/` |
 | Change provider/API behavior | `packages/ai/src/api/` then `packages/ai/src/providers/` |
-| Change Cursor agent transport or exec bridging | `packages/ai/src/api/cursor-agent/` and `packages/coding-agent/src/core/cursor-exec-bridge.ts` |
-| Change agent-loop semantics | `packages/agent/src/agent-loop.ts` |
-| Change interactive rendering | `packages/coding-agent/src/modes/interactive/` and `packages/tui/src/tui.ts` |
-| Change app-server/RPC | `packages/coding-agent/src/modes/app-server/` or `packages/coding-agent/src/modes/rpc/` |
-| Add or change coding-agent tests | `packages/coding-agent/test/` |
-| Add or change extension examples | `packages/coding-agent/examples/` |
+| Change Cursor transport or exec bridging | `packages/ai/src/api/cursor-agent/`, `packages/coding-agent/src/core/cursor-exec-bridge.ts` |
+| Change agent-loop semantics or the harness | `packages/agent/src/agent-loop.ts`, `packages/agent/src/harness/` |
+| Change interactive rendering | `packages/coding-agent/src/modes/interactive/` and `packages/tui/src/` |
+| Change app-server/RPC | `packages/coding-agent/src/modes/app-server/` or `.../modes/rpc/` |
+| Add or change coding-agent tests or examples | `packages/coding-agent/test/`, `packages/coding-agent/examples/` |
 | Change PTY behavior | `packages/pty/` and, for native behavior, `crates/senpi-pty/` |
-| Add provider setup docs | `packages/ai/README.md` and `packages/coding-agent/docs/providers.md` |
-| Change model/provider runtime | `packages/ai/src/models.ts`, `packages/ai/src/auth/`, `packages/ai/src/providers/` |
-| Change eval prompt/rendering | `packages/senpi-codemode/src/prompt/` and `packages/senpi-codemode/src/tool/` |
-| Audit changelogs | `.github/agent/commands/cl.md` |
-| Prepare a release | `scripts/release.mjs` and `scripts/release-packages.mjs` |
-| Regenerate model catalog data | `packages/ai/src/providers/data/` via root `npm run hydrate:model-data` / `check:model-data` |
+| Change model/provider runtime or docs | `packages/ai/src/{models.ts,auth,providers}`, `packages/coding-agent/docs/providers.md` |
+| Change compaction | mechanics in `packages/coding-agent/src/core/compaction/`; policy in `.../extensions/builtin/compaction/` |
+| Change wire protocol or remote sessions | `packages/protocol/`, then consumers `packages/server/` and `packages/client/` |
+| Change eval prompt/rendering | `packages/senpi-codemode/src/{prompt,tool,kernels}/` |
+| Audit changelogs or prepare a release | `.github/agent/commands/cl.md`, `scripts/release.mjs`, `scripts/release-packages.mjs` |
 
 ## CODE MAP
 
-```text
-Models/auth runtime -> packages/ai/src/models.ts + src/auth/ -> providers -> api
-                                         |
-Agent state -> packages/agent/src/agent-loop.ts
-                                         |
-CLI/session -> packages/coding-agent/src/core -> interactive | print | RPC
-                                         |
-Terminal UI -> packages/tui
-Persistent terminals -> packages/pty -> crates/senpi-pty
-```
+Runtime flow: `ai` (models/auth -> providers -> api) feeds `agent/src/agent-loop.ts`, driven by `coding-agent/src/core` into interactive | print | RPC | app-server; `tui` renders, `pty` -> `crates/senpi-pty` runs terminals, `protocol` (framed CBOR) links `server` and `client`.
+
+| Symbol / file | Role | Notes |
+|---|---|---|
+| `coding-agent/src/core/agent-session.ts` | Session runtime core | 8k LOC; highest-risk file in the repo |
+| `coding-agent/src/modes/interactive/interactive-mode.ts` | Interactive loop | 8.5k LOC; components under `interactive/components/` |
+| `agent/src/agent-loop.ts` | Browser-safe agent loop | Reached via `coding-agent/src/core/sdk.ts` |
+| `coding-agent/src/core/extensions/builtin/index.ts` | `builtinExtensions` order | 39 entries, `mcp` last; the only authority on numbering |
+| `ai/src/api/cursor-agent/gen/agent_pb.ts` | Generated protobuf-es | 19.6k LOC; regenerate, never hand-edit |
+| `tui/src/index.ts` | Renderer barrel | Consumer coupling point for coding-agent and senpi-codemode |
 
 ## COMMANDS
 
-- Install or refresh dependencies: `npm install --ignore-scripts`.
-- Refresh lockfiles after an approved dependency change: `npm run refresh-lock` (lockfile + registry metadata + shrinkwrap + install-lock regeneration).
-- Full static validation after code changes: `npm run check`; it does not run tests. It includes biome, pinned-deps/ts-imports/shrinkwrap/install-lock checks, `check:claude-sdk-platform-lock`, `tsc --noEmit`, and the browser-smoke probe.
-- Full workspace tests when broad validation is justified: `npm test`.
-- Narrow tests run from the package root using that package's test command.
+- Install dependencies: `npm install --ignore-scripts`. After an approved dependency change, `npm run refresh-lock` (lockfile + registry metadata + shrinkwrap + install-lock).
+- Full static validation after code changes: `npm run check` (biome, pinned-deps/ts-imports/shrinkwrap/install-lock checks, `check:claude-sdk-platform-lock`, `tsc --noEmit`, browser-smoke). It runs no tests; CI runs the same commands, so keep them in sync. Broad validation: `npm test`.
+- Narrow tests run from the package root using that package's test command. Runners differ: Vitest for `ai`, `coding-agent`, `senpi-codemode`, `server`, `session-backends`, `telemetry`; `node --test --import tsx` for `tui`; `node --test` for `scripts/` (`npm run test:scripts`) and `.agents/skills/senpi-qa/scripts/lib/`.
+- App-server transport QA is its own channel: `npm run qa:app-server` (`packages/coding-agent/scripts/qa-app-server/`), not part of `npm test`. Model catalog data: `npm run hydrate:model-data`, verified by `check:model-data`, from the repository root.
 - Never run `npm run dev` in this repository.
 
 ## CONVENTIONS
 
-- Read files in full before broad edits. Prefer existing patterns and public extension APIs over new core behavior.
+- Read files in full before broad edits; prefer existing patterns and public extension APIs over new core behavior.
 - TypeScript under `packages/*/src`, `packages/*/test`, and `packages/coding-agent/examples` must use erasable syntax. Avoid `any` and verify external types in `node_modules`.
 - Imports are top-level by default. Inline or dynamic imports are forbidden except existing documented lazy/browser-safe boundaries such as `packages/ai/src/api/*.lazy.ts` and credential probes.
-- Do not hardcode TUI keys. Add defaults to `packages/tui/src/keybindings.ts` or `packages/coding-agent/src/core/keybindings.ts`.
-- Do not hand-edit `packages/ai/src/models.generated.ts`; update `packages/ai/scripts/generate-models.ts` and regenerate.
-- Ask before removing intentional functionality. Backward compatibility is opt-in, not automatic.
-- Changing fork-specific source behavior means reading the nearest `changes.md` first and updating it in the same verified increment, not in a follow-up.
-- Merges resolve tracker files to `ours`, so a stale entry misleads the next upstream sync.
-- Changelog edits are release/audit work only. Follow `.github/agent/commands/cl.md` and never edit released sections.
-- PRs must satisfy the changelog gate (`.github/workflows/changelog-gate.yml`) for both CHANGELOG.md and changes.md — see CHANGES.MD TRACKER POLICY.
+- Do not hardcode TUI keys; add defaults to `packages/tui/src/keybindings.ts` or `packages/coding-agent/src/core/keybindings.ts`.
+- Never hand-edit generated sources: `packages/ai/src/{models,image-models}.generated.ts` and `src/providers/data/*.json` (regenerate via `packages/ai/scripts/generate-models.ts`), `packages/ai/src/api/cursor-agent/gen/agent_pb.ts` (`buf generate` + `scripts/transform-cursor-agent-proto.mjs`), `crates/senpi-pty/index.{js,d.ts}` (napi-rs), `packages/coding-agent/install-lock/*`, and `packages/coding-agent/src/modes/app-server/protocol/generated/`. Builtin extension registration order is authoritative only in `builtin/index.ts` — never quote a registration number from prose.
+- Ask before removing intentional functionality; backward compatibility is opt-in, not automatic.
+- Changing fork-specific source behavior means reading the nearest `changes.md` first and updating it in the same verified increment, not in a follow-up. Merges resolve tracker files to `ours`, so a stale entry misleads the next upstream sync.
+- Changelog edits are release/audit work only: follow `.github/agent/commands/cl.md`, never edit released sections, and satisfy the changelog gate (`.github/workflows/changelog-gate.yml`) for both CHANGELOG.md and changes.md — see below.
 
 ## CHANGES.MD TRACKER POLICY
 
-- Upstream ownership is pinned by `.github/upstream.json` (`badlogic/pi-mono` tag + sha). A production path present in that pinned tree is upstream-owned; a path absent from it (and not an upstream rename destination) is fork-only and exempt from coverage.
-- Production scope is every changed path except: `changes.md` trackers and `.github/upstream.json` themselves; lockfiles (`package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `Cargo.lock`, `*.lock`, `*.lock.json`); non-production metadata (`.gitignore`, `LICENSE`, `test.sh`); test, fixture, example, and doc trees (`__tests__`, `tests`, `fixtures`, `examples`, `docs`) plus `*.test.*`/`*.spec.*` files; `.md`/`.mdx` docs; and generated catalog-style sources matching `*.generated.ts` / `*.generated.mts` / `*.generated.cts` / `*.generated.js` (including `packages/ai/src/models.generated.ts` and `packages/ai/src/image-models.generated.ts`).
-- Every upstream-owned production path must be covered in its exact nearest ancestor `changes.md` — never a farther tracker — by an entry that mentions that exact repo-relative path and carries all four canonical headings: `What changed`, `Why`, `Why an extension could not handle it`, `Expected merge conflict zones`.
-- Tracker coverage is independent of the release changelog: the `no-changelog` label waives only the CHANGELOG.md entry, never changes.md, and complete coverage never substitutes for a required CHANGELOG.md entry.
+- Upstream ownership is pinned by `.github/upstream.json` (`badlogic/pi-mono` tag + sha): a production path in that pinned tree is upstream-owned; a path absent from it (and not a rename destination) is fork-only and exempt.
+- Production scope is every changed path except: `changes.md` trackers and `.github/upstream.json`; lockfiles (`package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `Cargo.lock`, `*.lock`, `*.lock.json`); non-production metadata (`.gitignore`, `LICENSE`, `test.sh`); test/fixture/example/doc trees (`__tests__`, `tests`, `fixtures`, `examples`, `docs`) plus `*.test.*`/`*.spec.*`; `.md`/`.mdx`; and `*.generated.{ts,mts,cts,js}` sources.
+- Every upstream-owned production path must be covered in its exact nearest ancestor `changes.md` — never a farther tracker — by an entry naming that exact repo-relative path under all four canonical headings: `What changed`, `Why`, `Why an extension could not handle it`, `Expected merge conflict zones`.
+- Tracker coverage is independent of the release changelog: `no-changelog` waives only the CHANGELOG.md entry, never changes.md, and coverage never substitutes for a required CHANGELOG.md entry.
 - A pin-sync PR — one that edits `.github/upstream.json` — exempts upstream-owned paths that exactly match the new pinned tree, but paths still divergent from the new pin are integration repairs and must gain coverage from tracker entries in the same PR.
 - Enforcement: `scripts/check-pr-changelog.mjs` gates every PR through `.github/workflows/changelog-gate.yml` (counting only tracker entries the PR itself touches), and `scripts/audit-changes-md.mjs` audits the whole tree against the pin (`--format json|markdown`).
 
 ## QUALITY GATES
 
-- Any runtime change under `packages/{ai,agent,coding-agent,tui,pty,senpi-codemode}` (the changelog-gate release-managed set, plus `crates/senpi-pty`) requires scoped tests, `npm run check`, and real CLI QA through `.agents/skills/senpi-qa/`.
-- Save QA receipts under `local-ignore/qa-evidence/<YYYYMMDD>-<slug>/`. No evidence means no commit or push.
-- Evidence, logs, comments, and PR bodies must not contain tokens, credentials, auth headers, cookies, or raw environment dumps.
-- Default/unit tests must not spend tokens or require real credentials. Coding-agent tests use the faux provider and `packages/coding-agent/test/suite/harness.ts`; AI live integration tests require explicit opt-in gating.
-- Tests added or changed must be run directly until green. Issue regressions belong in `packages/coding-agent/test/suite/regressions/`.
-- Documentation-only changes use focused document validators and `git diff --check`; they do not require runtime QA.
+- Any runtime change under `packages/{ai,agent,coding-agent,tui,pty,senpi-codemode}` (the release-managed set) plus `crates/senpi-pty` requires scoped tests, `npm run check`, and real CLI QA through `.agents/skills/senpi-qa/`.
+- Save QA receipts under `local-ignore/qa-evidence/<YYYYMMDD>-<slug>/`; no evidence means no commit or push. Evidence, logs, comments, and PR bodies must never contain tokens, credentials, auth headers, cookies, or raw environment dumps.
+- Default/unit tests must not spend tokens or require real credentials; coding-agent tests use the faux provider and `packages/coding-agent/test/suite/harness.ts` (the legacy `test/test-harness.ts` must not be extended).
+- Tests added or changed run directly until green. New coding-agent lifecycle tests go in `test/suite/`; issue regressions in `test/suite/regressions/<issue>-<slug>.test.ts`; the flat `test/*.test.ts` root cluster is legacy placement and must not grow.
+- Test quarantine is a safety boundary: `test/setup.ts` forces `SENPI_CODING_AGENT_DIR` into a temp dir and always wins over an inherited value. Never reintroduce an `if (!process.env.SENPI_CODING_AGENT_DIR)` short-circuit — that once deleted a real user agent dir.
+- Live/credentialed surfaces are opt-in only: `packages/ai/test/live-api-gates.ts` (`PI_ENABLE_*`), `packages/coding-agent/test/integration/` (`PI_RUN_INTEGRATION=1`), `packages/evals` (`npm run eval -- --provider X --model Y`). `packages/evals/.eval/` artifacts hold prompts and responses — treat as sensitive.
+- Async tests subscribe before triggering, with bounded deadlines or fake timers; fixed sleeps survive only at genuine OS boundaries and must not be copied from legacy tests.
+- Documentation-only changes use focused validators and `git diff --check`, not runtime QA — but `packages/coding-agent/docs/` ships in the tarball and is test-asserted, so doc edits there can fail CI.
 
 ## DEPENDENCIES AND INFRA
 
-- Treat dependency and lockfile diffs as code. Pin direct external dependencies exactly and use `--ignore-scripts` for install/lock refreshes.
-- The lockfile hook allows workspace-metadata-only refreshes; other lockfile changes require explicit `PI_ALLOW_LOCKFILE_CHANGE=1` approval.
+- Treat dependency and lockfile diffs as code: pin direct external dependencies exactly, use `--ignore-scripts` for install/lock refreshes. The pre-commit hook allows workspace-metadata-only refreshes; other lockfile changes require explicit `PI_ALLOW_LOCKFILE_CHANGE=1` approval.
 - Keep shared environment surfaces synchronized: dependency, Node, provider/env, QA-channel, build-command, and forwarded-port changes must update `scripts/devenv-setup.mjs`, `.devcontainer/devcontainer.json`, and related references together, keeping root `package.json` workspaces and `pnpm-workspace.yaml` aligned with any workspace-package move or rename.
-- Regenerate `packages/coding-agent/publish-deps.lock.json` with `node scripts/generate-coding-agent-shrinkwrap.mjs`; never replace it with `npm-shrinkwrap.json`.
-- External registry entries in root, publish, and installer locks must preserve both npm tarball `resolved` URLs
-  and `integrity` hashes; incomplete merge results are invalid even when dependency topology still resolves.
-- `@earendil-works/pi-telemetry` is a runtime dependency and must stay in Senpi's owned CalVer alias, publish,
-  and bundle sets. `@earendil-works/pi-storage-sqlite-node` remains private and independently versioned because
-  it is not reachable from the shipped coding-agent runtime.
+- Regenerate `packages/coding-agent/publish-deps.lock.json` with `node scripts/generate-coding-agent-shrinkwrap.mjs`; never replace it with `npm-shrinkwrap.json`. Regenerate `packages/coding-agent/install-lock/` with `npm run install-lock:coding-agent`.
+- External registry entries in root, publish, and installer locks must preserve both npm tarball `resolved` URLs and `integrity` hashes; incomplete merge results are invalid even when dependency topology still resolves.
+- `@earendil-works/pi-telemetry` is a runtime dependency and must stay in Senpi's owned CalVer alias, publish, and bundle sets. `@earendil-works/pi-storage-sqlite-node` remains private and independently versioned because it is not reachable from the shipped coding-agent runtime.
 - Dependencies with lifecycle scripts require package/version review and an explicit justified generator allowlist entry; never add one silently to pass the gate.
 
 ## GIT AND DELIVERY
 
-- Multiple agents share this worktree. Stage only files changed in the current session with explicit `git add <path>` commands.
-- Do not commit speculatively; commit only when the user asks or a delegated workflow already ends in commit/push.
-- Never use `git reset --hard`, `git checkout .`, `git clean -fd`, `git stash`, `git add -A`, `git add .`, `git commit --no-verify`, or force-push.
-- Review incoming PRs without switching this shared worktree; when the user requests a PR review, follow PROTOCOL 2 above (dedicated worktree, removed after the review).
-- Commit format: `{feat,fix,docs}[(scope)]: concise message`; include `fixes #N` or `closes #N` when applicable.
-- Normal work ships through a feature branch and reviewer-readable PR with evidence. Merge PRs with a merge commit, never squash or rebase merge.
+- Multiple agents share this worktree. Stage only files changed in the current session with explicit `git add <path>`; do not commit speculatively — commit only when the user asks or a delegated workflow already ends in commit/push.
+- Never use `git reset --hard`, `git checkout .`, `git clean -fd`, `git stash`, `git add -A`, `git add .`, `git commit --no-verify`, or force-push. Review incoming PRs per PROTOCOL 2, never by switching this shared worktree.
+- Commit format `{feat,fix,docs}[(scope)]: concise message` with `fixes #N` / `closes #N` when applicable. Normal work ships through a feature branch and reviewer-readable PR with evidence; merge with a merge commit, never squash or rebase merge.
 - Resolve rebase conflicts only in files owned by the current session; otherwise abort and ask.
 
 ## RELEASE NOTES
 
-- Releases use CalVer and lockstep-version the packages listed in `scripts/release-packages.mjs`.
-- Release only from clean `main` after changelog audit and local release smoke tests. `scripts/release.mjs` owns versioning, generated artifacts, checks, commits, tag, and push.
-- Never rerun the release script after its tag is pushed; failed publishing is retried from the existing tag workflow.
+- Releases use CalVer and lockstep-version the packages in `scripts/release-packages.mjs`; the pipeline runs `.github/agent/` drivers -> `scripts/release.mjs` -> `publish-npm.yml` -> `build-binaries.yml` / `native-prebuilds.yml`.
+- Release only from clean `main` after changelog audit and release smoke tests; `scripts/release.mjs` owns versioning, generated artifacts, checks, commits, tag, and push.
+- Never rerun the release script after its tag is pushed; failed publishing is retried from the existing tag workflow. Publishing is fork-scoped: `scripts/publish.mjs` rewrites private `@earendil-works/pi-*` packages into public `@code-yeongyu/senpi-*` manifests, and upstream names never appear on npm.
+
+## NOTES
+
+- Deep guidance lives in ~60 nested `AGENTS.md` files holding the file-level maps this root omits; read the nearest one before editing. `packages/coding-agent` is by far the largest package (~105k LOC with tests).
+- `packages/ai` tests alias `@earendil-works/pi-telemetry` to telemetry source, so telemetry breakage fails AI tests. Node floors differ: packages require >=22.19.0, root and CI use Node 24.
+- `packages/tui` uses tabs in source and its own `node --test` runner — do not apply coding-agent test habits there. `packages/coding-agent/bin/senpi` is only a symlink to built output; launcher logic lives in `src/cli.ts` / `src/bun-runtime.ts`.

--- a/crates/senpi-pty/AGENTS.md
+++ b/crates/senpi-pty/AGENTS.md
@@ -17,9 +17,10 @@ index.js, index.d.ts     Node package loader/types
 
 ## ABI CONTRACT
 
-- `NATIVE_PTY_ABI_VERSION = "1"` in the TypeScript loader and the exported `__senpiPtyAbi1` marker must agree.
+- `NATIVE_PTY_ABI_VERSION = "1"` in the TypeScript loader (`packages/pty/src/native-loader.ts`) and the exported `__senpiPtyAbi1` marker must agree; the Rust constant lives in `src/lib.rs`.
 - ABI versioning is intentionally separate from CalVer. Change it only for an incompatible native contract and update both crate and loader tests.
-- Keep the six targets declared in `package.json` aligned when changing exports or build paths. Checked-in/runtime prebuild coverage may be partial; missing native bindings intentionally use the TypeScript pipe fallback.
+- `index.js` and `index.d.ts` are NAPI-RS-generated loader output; never hand-edit them. Regenerate with `npm run build --workspace=@earendil-works/senpi-pty-native` (`napi build --platform`).
+- Keep the six targets declared in `package.json` aligned when changing exports or build paths. A checked-in `senpi_pty.darwin-arm64.node` prebuild covers the local darwin-arm64 fast path only; other targets come from prebuilt packaging, and missing native bindings intentionally use the TypeScript pipe fallback.
 
 ## LIFECYCLE INVARIANTS
 

--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -14,14 +14,18 @@ src/types.ts                 App messages, events, state, conversion boundary
 src/proxy.ts                 Remote stream proxy
 src/index.ts                 Browser-safe public exports
 src/node.ts                  Node harness public exports
-src/harness/                 Compaction, sessions, skills, prompts, env adapters
-src/harness/tools/           Built-in tools: bash, edit, edit-diff, write, read,
-                             image, file-mutation-queue, path-utils, tool-context, index
+src/search/                  Scanning session search over readable storage
+src/harness/                 AgentHarness: lanes, sessions (own AGENTS.md),
+                             tools (own AGENTS.md), compaction, skills, prompt
+                             templates, env adapters
+src/harness/reducer.ts       Record-log validation and lane state reduction
+src/harness/telemetry.ts     Schema-first AI/harness telemetry spans
 src/harness/messages.ts      Harness message helpers
 src/harness/prompt-templates.ts  Prompt template expansion
 src/harness/system-prompt.ts System prompt assembly
 src/harness/skills.ts        Skill discovery and loading
 src/changes.md               Fork-specific behavior record
+scripts/generate-telemetry-docs.ts  Regenerates docs/telemetry-schema.md
 ```
 
 ## WHERE TO LOOK
@@ -33,8 +37,9 @@ src/changes.md               Fork-specific behavior record
 | Public message/event contract | `src/types.ts` |
 | Harness orchestration | `src/harness/agent-harness.ts` |
 | Node process and filesystem behavior | `src/harness/env/nodejs.ts` |
-| Session persistence | `src/harness/session/` (`repository.ts`, `jsonl-store.ts`, `memory-store.ts`, `array-session-reader.ts`, `fork.ts`, `keyed-operation-queue.ts`, `search-backend.ts`) |
-| Built-in tool behavior | `src/harness/tools/` |
+| Session persistence | `src/harness/session/` (`session.ts`, `state.ts`, `context.ts`, `types.ts`, `jsonl/`, `memory.ts`; own AGENTS.md) |
+| Session search | `src/search/scanning.ts`, contracts in `src/search/index.ts`; see `docs/search.md` |
+| Built-in tool behavior | `src/harness/tools/` (own AGENTS.md) |
 | SQLite session storage | `packages/session-backends/sqlite-node` (`@earendil-works/pi-storage-sqlite-node`) |
 | Compaction | `src/harness/compaction/` |
 
@@ -58,13 +63,14 @@ src/changes.md               Fork-specific behavior record
 
 - Run `npm test` from this package for agent-loop coverage.
 - Run `npm run test:harness` for harness/session/env changes.
+- Telemetry schema changes: `npm run generate-telemetry-docs` to rewrite `docs/telemetry-schema.md`, then `npm run check:telemetry-docs`; the generated file must never be edited by hand.
 - Runtime changes also require root `npm run check` and the root QA evidence gate.
-- Keep `README.md`, `docs/agent-harness.md`, `docs/harness.md`, `docs/harness-v2.md`, and `src/changes.md` aligned with public or fork-specific changes.
+- Keep `README.md`, `docs/harness.md`, `docs/search.md`, and `src/changes.md` aligned with public or fork-specific changes.
 
 ## NOTES
 
-- Session backend refactor: old `jsonl-repo`/`memory-repo`/`repo-utils` are gone. Storage is store-based (`jsonl-store.ts`, `memory-store.ts`, SQLite via `packages/session-backends/sqlite-node`) behind `repository.ts`.
+- Session storage: `SessionStorage` implementations (`jsonl/` `JsonlSessionStorage`/`JsonlSessionRepo`, `memory.ts` `InMemorySessionStorage`/`InMemorySessionRepo`) behind `Session` tree semantics in `session.ts`; SQLite backend in `packages/session-backends/sqlite-node`. New backends must pass `createSessionBackendConformance`, published as the `@earendil-works/pi-agent-core/session/testing` subpath.
 - Cursor exec bridging: `execHandlers`/`onToolResult` are installed only when `config.cursorExecHandlers` is set. Assistant `toolCall` blocks stamped `kCursorExecResolved` (`packages/ai/src/utils/block-symbols.ts`) were executed server-side and are never re-run locally; their buffered `toolResult`s are appended right after the assistant message, including on error/abort paths. Local exec work re-arms the idle watchdog via `AssistantMessageEventStream.trackLocalWork`.
 
 ---
-Generated: 2026-08-17 | Commit `abae968e8`
+Generated: 2026-08-24 | Commit `baf15a54d`

--- a/packages/agent/src/harness/AGENTS.md
+++ b/packages/agent/src/harness/AGENTS.md
@@ -1,0 +1,35 @@
+# src/harness
+
+Optional Node-side harness over the core agent loop: durable sessions, lane state machine, compaction, skills/prompt templates, built-in tools, and schema-first telemetry. Public entry `AgentHarness` (`agent-harness.ts`), exported via `src/node.ts`.
+
+Earned its own file: 41 files / ~10k LOC, distinct domain from the browser-safe core (score 12: file count, export surface, 23+ `AgentHarness` references in coding-agent).
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Run/compaction/navigation/queue lifecycle | `agent-harness.ts` (`AgentHarness`, `AgentLane`) |
+| Record-log validation, lane state reduction | `reducer.ts` (`validateRecordLog`, `reduceLaneState`, `RecordLogCorruption`) |
+| Telemetry span schemas | `telemetry.ts` (`AI_TELEMETRY_SCHEMA`, `HARNESS_TELEMETRY_SCHEMA`, `startAiSpan`/`startHarnessSpan`) |
+| Node process/filesystem environment | `env/nodejs.ts` (`NodeExecutionEnv`, Windows process-tree teardown) |
+| Compaction and branch summaries | `compaction/` (`compaction.ts`, `branch-summarization.ts`) |
+| Session persistence | `session/` (own AGENTS.md) |
+| Built-in tools | `tools/` (own AGENTS.md) |
+| Skills, prompt templates, system prompt | `skills.ts`, `prompt-templates.ts`, `system-prompt.ts` |
+| Result/error vocabulary | `result.ts`, `types.ts` (`Result`, `TaggedError`, `matchError`) |
+| Output truncation, shell capture | `utils/truncate.ts`, `utils/shell-output.ts` |
+
+## CONVENTIONS
+
+- `docs/harness.md` is the normative implementation spec (entries + registers + usage ledger, transactional writes, op-state recovery). When code and spec contradict, stop for review; do not improvise a new durable contract.
+- Operational failures are tagged errors inside `Result` values, never untyped exceptions.
+- Telemetry is schema-first: edit the const schemas in `telemetry.ts`, then regenerate `docs/telemetry-schema.md` (`npm run generate-telemetry-docs`; `npm run check:telemetry-docs` verifies CI-exact output).
+- Harness tools are `AgentTool & { replay?: "never" | "safe" }` (`HarnessTool`); only tools marked replay-safe re-run after recovery.
+- Harness tests run under `vitest.harness.config.ts` (`test/harness/**`; coverage limited to `src/harness/**` plus `src/agent.ts` and `src/agent-loop.ts`).
+
+## ANTI-PATTERNS
+
+- Weakening `never`-typed fields that keep invalid entry/record/operation unions unrepresentable.
+- Defining telemetry spans or attributes outside the schemas in `telemetry.ts`.
+- Treating non-zero command exits as thrown execution failures; they are values in the execution result (spawn/timeout/abort are the distinct error cases).
+- Truncation that returns partial lines; `utils/truncate.ts` must never split a line (documented bash-tail edge case aside).

--- a/packages/agent/src/harness/session/AGENTS.md
+++ b/packages/agent/src/harness/session/AGENTS.md
@@ -1,0 +1,32 @@
+# src/harness/session
+
+Durable session storage: append-only entries (message, model/thinking/tools changes, compaction, branch-summary, custom), lane operation records, and the `Session` tree that projects them. Ships JSONL and in-memory backends; the SQLite backend lives in `packages/session-backends/sqlite-node`.
+
+Earned its own file: distinct domain from harness orchestration (score 11: `index.ts` boundary, wide type surface, `SessionRepo`/`SessionError`/`Entry` consumed across sqlite-node).
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Durable contract: `Entry`/`LaneRecord` unions, `SessionRepo`, error codes | `types.ts` |
+| Tree semantics: branching, queries, stats, `assertJsonSerializable` | `session.ts` |
+| Mutation log feeding state reduction | `state.ts` (`SessionState`) |
+| JSONL backend: codec, atomic storage, repo, torn-tail repair | `jsonl/` (`codec.ts`, `storage.ts`, `repo.ts`, `errors.ts`) |
+| In-memory backend | `memory.ts` (`InMemorySessionStorage`, `InMemorySessionRepo`) |
+| Session context projection to model messages | `context.ts` |
+| Backend conformance suite | `testing/conformance.ts` (`createSessionBackendConformance`, published as `@earendil-works/pi-agent-core/session/testing`) |
+
+## CONVENTIONS
+
+- IDs come from an injectable `IdGenerator`, defaulting to `uuidv7` from pi-ai.
+- Entries, records, and usage rows are append-only with strictly increasing sequence numbers; `SessionState` is the derived projection, never the source of truth.
+- JSONL publication stages a complete sibling `.tmp` file and atomically renames it over the destination; callers must serialize publications per destination (shared deterministic temp path). Torn tails are repaired from the valid prefix on load.
+- Query misuse throws `SessionError` (`invalid_query`, `invalid_payload`); `session.ts` validates limits and cursors up front.
+- New backends must pass `createSessionBackendConformance`; memory, JSONL, and SQLite all run the same cases.
+
+## ANTI-PATTERNS
+
+- Mutating entries, records, or usage rows in place instead of appending.
+- Weakening `never`-typed union members in `types.ts`.
+- Claiming writer leases from scanning code; use read-only helpers (`scanningEntries` in `src/search/`) or already-open storage.
+- Swallowing decode failures; malformed JSONL surfaces as `JsonlDecodeError` with the item index.

--- a/packages/agent/src/harness/tools/AGENTS.md
+++ b/packages/agent/src/harness/tools/AGENTS.md
@@ -1,0 +1,32 @@
+# src/harness/tools
+
+Built-in tool library (bash, edit, edit-diff, write, read, image) for the harness, re-exported by coding-agent as `create*Tool` and `create*ToolDefinition`. All factories are generic over `ExecutionToolContext`.
+
+Earned its own file: distinct domain plus external centrality (score 11: `index.ts` barrel, 57 tool-factory references in coding-agent).
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Shell execution, capture, timeout/abort | `bash.ts` (`createBashTool`, `BashToolDetails`, `BashExecution`) |
+| Edit application and diff algorithms | `edit.ts`, `edit-diff.ts` |
+| File write/read | `write.ts`, `read.ts` |
+| Serialized filesystem mutations | `file-mutation-queue.ts` (`withFileMutationQueue`) |
+| Path resolution helpers | `path-utils.ts` |
+| Tool context contract | `tool-context.ts` (`ExecutionToolContext`) |
+| Image attachment encoding | `image.ts` |
+| Public surface | `index.ts` (factories + types) |
+
+## CONVENTIONS
+
+- All filesystem mutation goes through `withFileMutationQueue(env, path, fn)`; tools never write via env APIs directly.
+- Paths resolve through `path-utils.ts` helpers against the context root.
+- Tools throw on failure so the agent reports the error; failure text is never returned as successful result content.
+- Replay semantics are declared where consumed as `HarnessTool` (`replay?: "never" | "safe"`, defined in `agent-harness.ts`), not inferred from the tool.
+- A new tool ships as a factory plus exported input/details types in `index.ts`.
+
+## ANTI-PATTERNS
+
+- Bypassing the mutation queue for writes.
+- Returning failure text as tool result content instead of throwing.
+- Adding a tool without its matching exported types in `index.ts`.

--- a/packages/ai/AGENTS.md
+++ b/packages/ai/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/ai
 
-Generated: 2026-08-22. Commit `a5eed4453`.
+Generated: 2026-08-24. Commit `baf15a54d`.
 
-`@earendil-works/pi-ai` is the provider-neutral streaming, model, auth, tool-call, and image API used across the monorepo. Its root surface must remain browser-safe.
+`@earendil-works/pi-ai` is the provider-neutral streaming, model, auth, tool-call, and image API used across the monorepo. Its root surface must remain browser-safe. ESM, Node `>=24`, built with `tsc -p tsconfig.build.json` (`src/**/*.ts` -> `dist`).
 
 ## STRUCTURE
 
@@ -41,7 +41,8 @@ src/tool-call-middleware/       Text-encoded tool protocols
 src/utils/                      ~33 files; key: retry.ts, provider-retry.ts, retry-hint.ts, prompt-cache-ttl.ts, stop-details.ts, tool-call-id.ts, tool-schema-compat.ts
 scripts/generate-models.ts      Model catalog source of truth
 scripts/generate-image-models.ts Image catalog source of truth
-test/                           Faux-first and opt-in live tests
+test/                           Faux-first + opt-in live tests, ~53k LOC flat (own AGENTS.md; ditto test/tool-call-middleware/)
+bench/                          event-stream + model-registry micro-benchmarks
 ```
 
 ## MODEL DATA GENERATION
@@ -56,7 +57,8 @@ test/                           Faux-first and opt-in live tests
 - Provider factories and model catalogs live in `src/providers/`; wire protocol implementations live in `src/api/`.
 - `src/api/lazy.ts` exposes `lazyApi()`. API-specific `*.lazy.ts` wrappers are the documented dynamic-import boundary.
 - `src/providers/register-builtins.ts` registers compatibility behavior and currently imports only `src/compat.ts`; do not restore the old provider-loader architecture there.
-- Public provider and API wildcard subpaths are declared in `package.json`. Keep root exports browser-safe.
+- Public subpaths in `package.json`: `.`, `./compat`, `./oauth`, wildcard `./providers/*`, `./api/*`, `./utils/*`, plus `./node/provider-scope`, `./bedrock-provider` (root shim re-exporting `dist/`), `./bun-oauth`. Keep root exports browser-safe.
+- `sideEffects` is non-empty by design: `dist/compat.js`, `dist/images.js`, `dist/providers/images/register-builtins.js` register on import.
 - Message transforms return new structures; never mutate shared input messages.
 
 ## WHERE TO LOOK
@@ -90,3 +92,4 @@ test/                           Faux-first and opt-in live tests
 - Run `npm run check:browser-smoke` from the root for import/export boundary changes.
 - Runtime changes require root `npm run check` and real CLI QA evidence.
 - Read `src/changes.md` and the nearest child `AGENTS.md` before editing provider or middleware internals.
+- Live suites are opt-in through `test/live-api-gates.ts` (`PI_ENABLE_LIVE_API_TESTS` or a per-provider `PI_ENABLE_*` flag); see `test/AGENTS.md` before adding network coverage.

--- a/packages/ai/scripts/AGENTS.md
+++ b/packages/ai/scripts/AGENTS.md
@@ -1,0 +1,50 @@
+# packages/ai/scripts
+
+Generated: 2026-08-24. Commit `baf15a54d`.
+
+Networked generators that produce the committed model catalogs (`src/providers/data/*.json`, `src/models.generated.ts`, `src/image-models.generated.ts`) plus their validators. Scored 7 but kept: this is the only place the generation contract (flags, staging/rename, manifest hashing) is written down, and the parent file states only the outcome.
+
+## FILE MAP
+
+```text
+generate-models.ts             3.4k LOC orchestrator; all four model scripts are flag variants of it
+generate-models-opengateway.ts fetchOpenGatewayModels + OpenGatewayReasoningRecorder (enrichment source)
+models-dev-reasoning-options.ts getEffortThinkingLevelMap — models.dev effort -> thinkingLevelMap
+model-data.ts                  Shared manifest/schema layer: MODEL_DATA_SCHEMA_VERSION=3,
+                               createModelDataManifest, validateGeneratedModelData, assertExactModelIds
+check-model-data.ts            Thin CLI over validateGeneratedModelData
+generate-image-models.ts       Image catalog (OpenRouter `/models?output_modalities=image`)
+generate-test-image.ts         Writes test/data/red-circle.png; requires the `canvas` native dep
+transform-cursor-agent-proto.mjs Rewrites protoc-gen-es enums to const objects for erasableSyntaxOnly
+```
+
+## FLAG CONTRACT (`generate-models.ts`)
+
+| Invocation | Flags | Effect |
+|---|---|---|
+| `npm run generate-models` | `--strict` | Full: `data/` JSON + `models.generated.ts` |
+| `npm run hydrate-model-data` | `--strict --data-only` | `data/` JSON only; rejects any JSON-catalog flag |
+| `npm run generate-model-catalog` | `--strict --json-only --json-output <dir>` | Publishable catalog to `.artifacts/model-catalog`; `--json-only` requires `--json-output` |
+| `npm run check:model-data` | — | Validates manifest hashes; fails with "run `npm run hydrate:model-data` from the repository root" |
+
+`--strict` turns per-provider fetch failures into a thrown error instead of a skip. Without it a network hiccup silently ships a shrunken catalog — always keep it on for committed regeneration.
+
+## CONVENTIONS
+
+- `data/` writes are staged, not in-place: a `.model-generation-*` temp dir under `src/providers/`, then rename-swap with the previous dir kept for rollback. Never write `data/` file-by-file.
+- Every provider fetch skips records with `status === "deprecated"` (five separate call sites) — deprecated upstream models must not enter the catalog.
+- `model-data.ts` is the single schema authority: the manifest carries a sha256 per file plus a `structureHash`, so a hand-edit of any JSON fails `check:model-data`.
+- Scripts run under `tsx` (see package scripts), use explicit `.ts` import suffixes, and import repo types from `../src/types.ts` — they are type-checked against runtime contracts, not standalone.
+- These are the only files in the package that legitimately use bare `fs`/`path` imports rather than `node:`-prefixed ones; leave the style alone unless converting the whole file.
+
+## ANTI-PATTERNS
+
+- Hand-editing `src/providers/data/*.json`, `src/models.generated.ts`, or `src/image-models.generated.ts` instead of rerunning the generator — the manifest will catch it, but only at `check:model-data` time.
+- Running generation without `--strict` and committing the diff.
+- Adding a provider fetcher that does not honor the deprecated-status skip or the staging/rename path.
+- Editing `src/api/cursor-agent/gen/agent_pb.ts` by hand: regenerate via `buf generate` on `proto/cursor/agent.proto`, then `node scripts/transform-cursor-agent-proto.mjs <in> <out>` (the exact `buf` invocation is in that file's header comment).
+
+## VALIDATION
+
+- After any regeneration: `npm run check:model-data`, then inspect the `data/` diff for unintended model removals.
+- Root-level entry points are `npm run generate:models`, `npm run hydrate:model-data`, `npm run check:model-data`; the `packages/ai` scripts are what they delegate to.

--- a/packages/ai/src/AGENTS.md
+++ b/packages/ai/src/AGENTS.md
@@ -1,0 +1,39 @@
+# packages/ai/src
+
+Generated: 2026-08-24. Commit `baf15a54d`.
+
+Entry-surface discipline and the API-provider scope model. Directory structure is mapped in the parent `packages/ai/AGENTS.md`; children own the deep guidance (`api/`, `auth/`, `providers/`, `tool-call-middleware/`, `utils/`).
+
+## ENTRY SURFACES
+
+| Entry | Loads | Use for |
+|---|---|---|
+| `index.ts` | Side-effect-free core only: types, option types, lazy API factories, cursor arg helpers, provenance, wire-identity. No catalogs, no provider factories, no registry, no OAuth, no compat (its header comment is the contract) | Browser-safe imports |
+| `compat.ts` | `index` + legacy dispatch + builtin API registration + env keys + image surface + legacy aliases | Legacy/global API, registration side effects |
+| `stream.ts` | Re-exports `complete`, `completeSimple`, `stream`, `streamSimple` from compat | One-line stream imports |
+| `images.ts` | Image generation; resolves `model.api` through `getImagesApiProvider`, triggers image registration via side-effect import | Image generation |
+| `cli.ts` | Node CLI (`#!/usr/bin/env node`) | Auth flows from the shell |
+| `oauth.ts` / `bun-oauth.ts` | OAuth re-exports / Bun registration | OAuth surfaces |
+| `node/provider-scope.ts` | Node-only subpath (`@earendil-works/pi-ai/node/*`); NOT root-reachable | Installing a provider scope |
+
+## PROVIDER SCOPE (api-registry.ts)
+
+- `ProviderScope` has `active|closed` state plus a per-scope overlay `Map`. In an active scope, lookup = `session overlay → immutable builtin set` — **NEVER the mutable legacy global** (recorded invariant in `changes.md`).
+- A closed scope throws on any lookup/mutation; no silent fallback.
+- Builtin entries register once and retain immutable identity for active scopes; `getBuiltinProvider*` must keep working while a scope holds unrelated overlay entries.
+- The images registry (`images-api-registry.ts`) is scoped identically.
+- `providerScopeStrictMode` makes scope-less lookup throw instead of using the global registry.
+
+## CONVENTIONS
+
+- `KnownApi`/`Provider` ids are open string unions (`KnownApi | (string & {})`), not enums; `legacy-api-aliases.ts` carries the old ids — extend it when renaming an api.
+- `model-catalog.ts` `flattenModelCatalog` turns grouped JSON into the flat typed catalog every `*.models.ts` reuses; `models.generated.ts` / `image-models.generated.ts` are generated (never hand-edit — see `../scripts/AGENTS.md`).
+- `xml` is retained only as a deprecated alias of `morph-xml` in tool-call format strings.
+- `changes.md` (2.7k lines) is the design history for registry, catalog, OAuth, and Cursor invariants — read the relevant dated section before touching any of those.
+
+## ANTI-PATTERNS
+
+- Adding generated catalogs, provider factories, OAuth, or compat side effects to `index.ts`.
+- Falling back from an active scope overlay to the mutable legacy provider set.
+- Letting external image providers extend the generated `IMAGE_MODELS` catalog or builtin list instead of the images registry.
+- Bypassing provider-managed request fields via `StreamOptions.extraBody` — builders reserve and protect those keys.

--- a/packages/ai/src/api/AGENTS.md
+++ b/packages/ai/src/api/AGENTS.md
@@ -1,8 +1,8 @@
 # packages/ai/src/api
 
-Generated: 2026-08-17. Commit `abae968e8`.
+Generated: 2026-08-24. Commit `baf15a54d`.
 
-Provider wire protocol implementations and stream adapters. Each provider ships as a concrete module plus a `.lazy.ts` wrapper that uses `lazyApi()` from `lazy.ts`.
+Provider wire protocol implementations and stream adapters. Each provider ships as a concrete module plus a `.lazy.ts` wrapper that uses `lazyApi()` from `lazy.ts`. 44 files at this level, ~19.5k LOC; the three largest (`cursor-agent.ts` 4.5k, `openai-completions.ts` 1.8k, `openai-codex-responses.ts` 1.7k) hold the streaming state machines.
 
 ## MODULE PAIRS
 
@@ -20,10 +20,11 @@ Provider wire protocol implementations and stream adapters. Each provider ships 
 | `mistral-conversations.ts` | `mistral-conversations.lazy.ts` |
 | `pi-messages.ts` | `pi-messages.lazy.ts` |
 | `openrouter-images.ts` | `openrouter-images.lazy.ts` |
+| `openai-images.ts` | `openai-images.lazy.ts` |
 
-Utility modules with no lazy wrapper: `cloudflare.ts`, `github-copilot-headers.ts`, `openai-prompt-cache.ts`, `anthropic-tool-pairs.ts` (browser-safe Anthropic tool_use/tool_result pair sanitizer; final pre-submit pass), `openai-client-auth.ts` (shared client-auth resolution from credential headers), `constrained-sampling.ts` (JSON-schema-driven constrained sampling helpers).
+Utility modules with no lazy wrapper: `cloudflare.ts`, `cloudflare-gateway-binding.ts` (`createGatewayBindingFetch` — routes gateway HTTPS URLs to the Workers AI binding; pre-authenticated in-account via a sentinel header that must be stripped before send), `github-copilot-headers.ts`, `openai-prompt-cache.ts`, `warm-prompt-cache.ts` (`warmPromptCache` pre-flight), `anthropic-tool-pairs.ts` (browser-safe Anthropic tool_use/tool_result pair sanitizer; final pre-submit pass), `openai-client-auth.ts` (shared client-auth resolution from credential headers), `constrained-sampling.ts` (JSON-schema-driven constrained sampling helpers), `cursor-conversation-rotation.ts` (Node-only; rotates a poisoned Cursor conversation up to `MAX_CURSOR_CONVERSATION_ROTATIONS`), `cursor-task-args.ts` (usable-task-arg predicates).
 
-`cursor-agent/` subdir: `types.ts` (exec-handler contracts), `pi-args.ts` (arg translators shared with `cursor-exec-bridge.ts` in coding-agent — display blocks and executed args must stay identical), `exec-modern.ts` (wire result builders for modern exec frames), `deterministic-id.ts` (stable UUID-shape ids), and `gen/agent_pb.ts` (generated protobuf-es schema; regenerate with `buf generate` from `packages/ai/proto/cursor/agent.proto`, then `node scripts/transform-cursor-agent-proto.mjs <in> <out>`; never hand-edit). `cursor-agent.ts` is Node-only: it is reached exclusively through `cursor-agent.lazy.ts`, and the Bun binary overrides it statically via `packages/ai/src/cursor-agent-provider.ts` plus `packages/coding-agent/src/bun/register-cursor-agent.ts` (imported before any Cursor provider use).
+`cursor-agent/` subdir: `types.ts` (exec-handler contracts), `pi-args.ts` (arg translators shared with `cursor-exec-bridge.ts` in coding-agent — display blocks and executed args must stay identical), `exec-modern.ts` (wire result builders for modern exec frames), `exec-lifecycle.ts` (one exec-scoped heartbeat armed at a time; next timer starts only after the current write callback succeeds), `stream-retry.ts` (`CursorRetryableStreamError` with `stall` | `transport` | `clean-end` causes), `reasoning-params.ts` (renders the resolved `src/cursor/` selection descriptor into protobuf `RequestedModel` fields), `deterministic-id.ts` (stable UUID-shape ids), and `gen/agent_pb.ts` (19.6k LOC generated protobuf-es schema; regenerate with `buf generate` from `packages/ai/proto/cursor/agent.proto`, then `node scripts/transform-cursor-agent-proto.mjs <in> <out>`; never hand-edit, and never reuse a field number that would decode into unknown fields). `cursor-agent.ts` is Node-only: it is reached exclusively through `cursor-agent.lazy.ts`, and the Bun binary overrides it statically via `packages/ai/src/cursor-agent-provider.ts` plus `packages/coding-agent/src/bun/register-cursor-agent.ts` (imported before any Cursor provider use).
 
 `openai-codex-responses/` subdir: `fallback-state.ts` (WebSocket fallback state + cooldown), `reasoning.ts` (Codex reasoning summary normalizer).
 
@@ -41,7 +42,8 @@ Utility modules with no lazy wrapper: `cloudflare.ts`, `github-copilot-headers.t
   `image_generation_call` items are structurally reconciled here (not from the installed SDK type): partial-image
   events are ignored, terminal output can backfill a missing done frame, and final base64 is aggregate-capped before
   provider-native content leaves the parser.
-- `google-shared.ts`: shared logic for both `google-generative-ai.ts` and `google-vertex.ts`.
+- `google-shared.ts`: shared logic for both `google-generative-ai.ts` and `google-vertex.ts` — message/tool conversion, thinking-level resolution and clamping, thought-signature retention, stop-reason mapping, `retryGoogleRequest`.
+- `openai-completions.ts` usage accounting: do not subtract cache writes from cached tokens for spec-compliant providers. Cache read and cache write stay separate counters.
 
 ## PROVIDERSTREAMS CONTRACT
 
@@ -55,5 +57,6 @@ All files in this directory are wildcarded in `package.json` under the `./api/*`
 
 - No ordinary dynamic imports in concrete modules; all dynamic loading goes through `.lazy.ts` wrappers.
 - Don't duplicate shared conversion logic in a single adapter; put it in `simple-options.ts`, `transform-messages.ts`, `openai-responses-shared.ts`, or `google-shared.ts`.
-- Don't hand-edit `src/models.generated.ts`; regenerate with `scripts/generate-models.ts`.
+- Don't hand-edit `src/models.generated.ts`; regenerate with `scripts/generate-models.ts` (see `scripts/AGENTS.md`).
 - Don't add top-level Node built-in imports to any module consumed in browser builds.
+- Don't sanitize by sending: unsupported native tools, thinking modes, and Cursor schema keys are stripped before the request, and reserved headers (`authorization`/`host` for Bedrock; `content-length`/`host`/the gateway auth sentinel for Cloudflare) are removed rather than forwarded.

--- a/packages/ai/src/auth/AGENTS.md
+++ b/packages/ai/src/auth/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/ai/src/auth
 
-Generated: 2026-08-17. Commit `abae968e8`.
+Generated: 2026-08-24. Commit `baf15a54d`.
 
 Credential storage, auth contexts, provider auth resolution, and bundled OAuth flows. Everything here must stay browser-safe; Node access goes through injected/lazy boundaries only.
 
@@ -39,6 +39,8 @@ xai.ts               xAI flow
 - One credential per provider id in the store. Persistent stores are injected by the app, never assumed.
 - OAuth flows register through `registerBundledOAuthFlowLoaders`; don't import flow modules eagerly from browser-reachable code.
 - Auth resolution order in `helpers.ts` (stored credential, then env) is load-bearing; don't reorder.
+- `oauth/openai-codex.ts` and `oauth/radius.ts` carry `// NEVER convert to top-level imports - breaks browser/Vite builds` on their dynamic imports. Keep both the imports and the comments.
+- `resolveProviderAuth` / `resolveProviderAuthWithSignal` in `resolve.ts` is the cross-provider choke point (credential, env, OAuth refresh, error paths); it raises `ModelsError` with a `ModelsErrorCode`, not bare `Error`.
 
 ## WHERE TO LOOK
 
@@ -48,3 +50,4 @@ xai.ts               xAI flow
 | Header semantics | `headers.ts` |
 | Credential persistence | `credential-store.ts` + app-side injected store |
 | Env-vs-credential precedence | `helpers.ts`, `resolve.ts` |
+| Codex auth token helpers shared with `../api/` | `../utils/openai-codex-auth.ts` |

--- a/packages/ai/src/providers/AGENTS.md
+++ b/packages/ai/src/providers/AGENTS.md
@@ -1,20 +1,24 @@
 # packages/ai/src/providers
 
-Generated: 2026-08-07. Commit `4f26b8282`.
+Generated: 2026-08-24. Commit `baf15a54d`.
 
-This directory owns provider factories, catalogs, provider metadata, and the faux test provider. API wire implementations, option translation, and message transforms live in sibling `../api/`.
+This directory owns provider factories, catalogs, provider metadata, and the faux test provider. API wire implementations, option translation, and message transforms live in sibling `../api/`. 41 provider factories, 41 matching `*.models.ts` catalogs, 41 `data/` JSONs — the three counts move together or generation is broken.
 
 ## FILE MAP
 
 ```text
-register-builtins.ts     Compatibility registration through src/compat.ts
-all.ts                   Builtin provider/model aggregation
+register-builtins.ts     One line: `import "../compat.ts"` — that is the whole contract
+all.ts                   Builtin provider/model aggregation: builtinProviders, builtinModels,
+                         builtinImagesProviders, builtinImagesModels, getBuiltinProvider(s)/Model(s);
+                         also re-exports the data/.manifest.json generation timestamp
 faux.ts                  Deterministic public test provider
 *-models.ts              Provider model/catalog helpers where present
-images/                  Image-provider metadata and factories
+images/register-builtins.ts  Image API registration; holds its own lazy module promises per images
+                         provider and returns a lazy-load-error AssistantImages instead of throwing
 radius.ts                Dynamic Radius provider with persisted model refresh
 radius-config.ts         Radius gateway/model catalog loading
-data/                    38 provider JSONs + .manifest.json — committed generated artifacts
+data/                    41 provider JSONs + .manifest.json (schemaVersion 3, sha256 per file +
+                         structureHash) — committed generated artifacts, never hand-edited
 data-json.d.ts           Typed import shim for data/ JSON
 ollama.ts                Dynamic provider, no .models.ts; runtime catalog via /api/tags
 cloudflare-auth.ts       Cloudflare auth split out of the two Cloudflare providers
@@ -44,7 +48,8 @@ Newer providers on disk (each `<name>.ts` + `<name>.models.ts`): ant-ling, kimi-
 - Every API stream must preserve tool calls, thinking blocks, usage accounting, stop reasons, setup errors, and abort semantics.
 - Default tests run with zero credentials. Use the faux provider for deterministic event sequences.
 - Keep image providers structurally separate under `images/`.
-- `data/` is committed generated source; never hand-edit. Regenerate with `npm run hydrate-model-data`, validate with `npm run check:model-data`.
+- `data/` is committed generated source; never hand-edit. Regenerate with `npm run hydrate-model-data`, validate with `npm run check:model-data` (contract in `packages/ai/scripts/AGENTS.md`).
+- Every `*.models.ts` opens with "Do not edit manually - run `npm run generate-models` to update" and flattens its JSON through `../model-catalog.ts`.
 
 ## ANTI-PATTERNS
 

--- a/packages/ai/src/tool-call-middleware/AGENTS.md
+++ b/packages/ai/src/tool-call-middleware/AGENTS.md
@@ -2,7 +2,9 @@
 
 Text-format tool-call protocols for providers that don't support native function calling. Wraps `openai-completions` streams and parses `<tool_call>` / XML / delimiter formats back into pi's canonical `toolCall` events. Fork-modified — see `changes.md`.
 
-Generated: 2026-08-07. Commit `4f26b8282`.
+Generated: 2026-08-24. Commit `baf15a54d`.
+
+Size: 21 files here + 9 under `protocols/` (~5.4k LOC). Complexity sits in `morph-xml.ts` (1.2k), `json-mix.ts` (854), `gemma4.ts` (809).
 
 ## FILES
 
@@ -60,6 +62,8 @@ tool-call-middleware/
 - **Strict parsing**: reject malformed XML/JSON instead of coercing into invalid strings (precedent: `morph-xml` array<object> handling).
 - **Delegate to `json-mix.ts`** for any new JSON-inside-delimiters protocol — minimizes drift across Hermes-family parsers.
 - **`xml-tool-tag-scanner.ts`** is the canonical streaming boundary detector; reuse it for any XML-tag-based protocol.
+- **Non-mutating context transform**: `context-transformer.ts` strips `tools`, injects the protocol prompt, serializes assistant tool calls, and rewrites tool results as user text — it returns new structures.
+- **Recovery replays sanitized calls only**: raw truncated markup never re-enters context; incomplete calls come back as canonical calls paired with error results.
 
 ## ANTI-PATTERNS
 

--- a/packages/ai/src/utils/AGENTS.md
+++ b/packages/ai/src/utils/AGENTS.md
@@ -1,0 +1,54 @@
+# packages/ai/src/utils
+
+Generated: 2026-08-24. Commit `baf15a54d`.
+
+Cross-provider behavior choke points: retry classification, prompt-cache compatibility, overflow detection, tool-schema normalization, stream primitives. 33 files, ~3.5k LOC, no barrel — import each module by explicit path. Scored 12 (33 files, >300 import sites across `src/` and `packages/coding-agent`); it earns its own file because a change here silently reshapes every provider.
+
+## FILE MAP
+
+```text
+retry.ts                 Assistant/transient retry policy; NON_RETRYABLE_PROVIDER_ERROR_PATTERN is the allowlist-by-exclusion of permanent failures
+provider-retry.ts        HTTP-status/header-driven provider backoff (Retry-After parsing)
+retry-hint.ts            Retry-after marker encode/decode carried through error messages
+prompt-cache-ttl.ts      Per-provider cache TTL + capability matrix (getAnthropicCompat, getOpenAICompletionsCompat)
+overflow.ts              Context-overflow / recoverable-length error patterns per provider
+tool-schema-compat.ts    JSON-schema normalization for OpenAI-compat and Moonshot
+tool-pair-repair.ts      Orphaned tool_result repair
+tool-call-id.ts          Tool-call id shaping
+tool-choice-fallback.ts  Tool-choice degradation when a provider rejects the requested mode
+deferred-tools.ts        splitDeferredTools
+event-stream.ts          EventStream<T,R> — the async-iteration primitive behind every provider stream
+json-parse.ts            repairJson / parseJsonWithRepair / parseStreamingJson
+provider-env.ts          getProviderEnvValue — the only sanctioned ProviderEnv read
+node-http-proxy.ts       Proxy URL resolution from env (no Node imports; pure URL logic)
+openai-codex-auth.ts     Codex auth helpers shared by api/ and auth/
+error-body.ts, stop-details.ts, estimate.ts, diagnostics.ts, validation.ts,
+sanitize-unicode.ts, visible-text.ts, text.ts, block-symbols.ts, headers.ts,
+hash.ts, uuid.ts, abort.ts, abort-signals.ts, pi-user-agent.ts,
+server-fallback-receipt.ts, typebox-helpers.ts, unavailable-tool-text.ts
+```
+
+## CONVENTIONS
+
+- Browser-safe by default. `node-http-proxy.ts` resolves proxies from `ProviderEnv` values only; it does not import `node:*`. Anything needing Node goes through an injected boundary in `../auth/` instead.
+- Provider quirks are encoded as explicit named patterns/constants with a comment naming the provider and the observed error text (see `retry.ts`, `overflow.ts`). Do not add a bare regex without the wire evidence that motivated it.
+- Compatibility detection is layered: provider id / base URL / model id heuristic first, then explicit per-model `compat` overrides win.
+- `tool-schema-compat.ts` deliberately strips JSON-schema `deprecated` annotations during normalization — providers reject the keyword.
+- Retry classification is exclusion-based: everything is retryable unless it matches a permanent-failure pattern (quota, credits, malformed request shape). Adding a pattern makes failures terminal for every provider.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| A transient failure is being treated as permanent (or vice versa) | `retry.ts` classification patterns |
+| Provider returns 429 with a Retry-After we ignore | `provider-retry.ts`, `retry-hint.ts` |
+| Cache TTL / cache-write accounting wrong for a model | `prompt-cache-ttl.ts` |
+| "Context length exceeded" not detected for a new provider | `overflow.ts` |
+| Provider rejects a tool schema | `tool-schema-compat.ts` |
+| Stream backpressure / iteration semantics | `event-stream.ts` (also the `bench/event-stream.ts` fixture) |
+
+## ANTI-PATTERNS
+
+- Adding a top-level `node:*` import here — these modules are reachable from the browser-safe package root.
+- Duplicating a provider quirk in an adapter under `../api/` when it belongs in the shared matrix here.
+- Widening a retry pattern to "fix" one provider without checking the other providers that share the classifier.

--- a/packages/ai/test/AGENTS.md
+++ b/packages/ai/test/AGENTS.md
@@ -1,0 +1,56 @@
+# packages/ai/test
+
+Generated: 2026-08-24. Commit `baf15a54d`.
+
+Flat Vitest suite for the whole `pi-ai` package: 228 top-level `.ts` files, ~53k LOC, plus `tool-call-middleware/` (own AGENTS.md), `fixtures/` (catalog JSON), `data/red-circle.png`. Earns its own file on size and on gating/harness conventions that exist nowhere in `src/`.
+
+## LAYOUT
+
+No mirroring of `src/` structure. Filenames encode provider + behavior: `anthropic-*`, `bedrock-*`, `openai-completions-*`, `openai-codex-*`, `azure-openai-*`, `mistral-*`, `cursor-agent*`. Cross-cutting suites are named by concern: `stream`, `models-runtime`, `retry`, `retry-hint`, `total-tokens`, `context-overflow`, `cache-retention`, `empty`, `unicode-surrogate`, `cross-provider-handoff`.
+
+## SHARED HELPERS (non-`.test.ts` modules)
+
+| File | Exports |
+|---|---|
+| `live-api-gates.ts` | `isLiveApiTestEnabled`, `isOAuthLiveApiTestEnabled`, `isOllamaLiveTestAvailable`, `getLiveEnvApiKey` + the `PI_ENABLE_*` flag constants |
+| `oauth.ts` | `resolveApiKey(provider)` — reads/refreshes `~/.pi/agent/auth.json`; writes refreshed tokens back |
+| `azure-utils.ts` | `hasAzureOpenAICredentials`, `resolveAzureDeploymentName` |
+| `bedrock-utils.ts` / `cloudflare-utils.ts` | `hasBedrockCredentials`, `hasCloudflareWorkersAICredentials`, `hasCloudflareAiGatewayCredentials` |
+| `cursor-agent-exec-lifecycle-harness.ts` + `.cases.ts` | HTTP/2 + protobuf frame harness; `registerCursorExecLifecycleTests()` |
+| `model-switch-replay-fixtures.ts` | `HISTORY`, `APPLY_PATCH_TOOL`, `makePatchHistory`, `makeModel` — shared by both model-switch replay tests |
+| `scratch.ts`, `codex-websocket-cached-probe.ts` | Manual probes, NOT Vitest entries; run via `node test/<file>.ts` |
+
+## LIVE-TEST GATING
+
+- Every network-touching case is opt-in. `PI_ENABLE_LIVE_API_TESTS=1` enables all; per-provider flags (`PI_ENABLE_LOCAL_LLM`, `PI_ENABLE_OPENROUTER_LIVE`, `PI_ENABLE_BASETEN_LIVE`, `PI_ENABLE_QWEN_TOKEN_PLAN_LIVE`, `PI_ENABLE_ANTHROPIC_OAUTH_LIVE`, `PI_ENABLE_GITHUB_COPILOT_LIVE`, `PI_ENABLE_OPENAI_CODEX_LIVE`) enable one.
+- Gate through `live-api-gates.ts` (15 suites do), not raw `process.env` reads. Ollama availability is probed by `which ollama`, never assumed.
+- Credential-only presence checks belong in the `*-utils.ts` helpers so setup is not duplicated per suite.
+
+## CONVENTIONS
+
+- Relative imports into source carry the explicit `.ts` extension (`from "../src/compat.ts"`), matching the package's NodeNext build.
+- Offline default: fake `fetch`, local Node HTTP/HTTP2 servers, or `src/providers/faux.ts` (12 suites). Assertions target serialized wire payloads, headers, event order, stop reasons, and usage — not implementation names.
+- `vitest.config.ts` sets `globals: true`, node env, 30s `testTimeout`, dot reporter, `silent: "passed-only"`, and aliases `@earendil-works/pi-telemetry` to `../telemetry/src/index.ts`. Suites still import `describe`/`it`/`expect` explicitly.
+- Env mutation and temp credential stores are isolated per suite via `beforeEach`/`afterEach`; faux-provider registrations keep their unregister handle and are cleaned up.
+- Large fixtures live in `fixtures/*.json` (dated catalog snapshots) — characterization tests, refresh them deliberately.
+
+## ANTI-PATTERNS
+
+- Never make a live provider call part of default success. Ungated network access breaks CI and every offline dev loop.
+- Never assert on timing/sleep in stream or protocol tests — await the captured event or frame predicate. OAuth expiry tests use fake timers.
+- Never let secret values reach assertions; credential tests assert metadata shape only.
+- Do not mutate caller-owned tool/schema objects in normalization tests; the suite asserts source objects survive untouched.
+- Do not leak faux-provider or model registrations across tests; superseded providers must not publish late.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/ai test                          # vitest --run, whole package
+npm --prefix packages/ai test -- test/stream.test.ts   # one file
+npm --prefix packages/ai test -- test/anthropic-       # provider group by prefix
+PI_ENABLE_LIVE_API_TESTS=1 npm --prefix packages/ai test   # opt into live suites
+```
+
+## HOTSPOTS
+
+`openai-codex-stream.test.ts` (2850), `openai-completions-tool-choice.test.ts` (1969), `stream.test.ts` (1802, multi-provider matrix + local Ollama process), `models-runtime.test.ts` (1193, provider/auth/refresh/cancel runtime), `total-tokens.test.ts` (912), `unicode-surrogate.test.ts` (866), `empty.test.ts` (861), `anthropic-provider-native-replay.test.ts` (832). Touch shared conventions here first.

--- a/packages/ai/test/tool-call-middleware/AGENTS.md
+++ b/packages/ai/test/tool-call-middleware/AGENTS.md
@@ -1,0 +1,46 @@
+# packages/ai/test/tool-call-middleware
+
+Generated: 2026-08-24. Commit `baf15a54d`.
+
+58 files / ~12.5k LOC covering `src/tool-call-middleware`: text-tool protocol parsers, the stream wrapper, and the leaked-invoke recovery state machine. Distinct domain — the only suite in this package built on registration-module fixtures rather than self-contained `.test.ts` files.
+
+## FIXTURE / CASE SPLIT
+
+16 non-`.test.ts` modules. A thin `*.test.ts` aggregator calls `register*Cases(...)` from `.ts` case modules; the cases import shared fixtures. Look for the behavior in the case module, not the test file.
+
+| Module | Role |
+|---|---|
+| `invoke-recovery-stream-fixtures.ts` | `TextStreamHarness`, `NativeStreamHarness`, `collectEvents`, `collectIterator`, `nextEvent`, `textFrom`, `createAssistantMessage`, `cloneToolCall` |
+| `invoke-recovery-scenario-fixtures.ts` | `bashTool`, `ambiguousTools`, `invoke`, `namespacedInvoke`, `terminal`, `toolEvents`, `nativeCall`, `runChunks` |
+| `invoke-recovery-*-cases.ts` | `registerInvokeRecovery{ContentExclusion,ContentOrder,Native,NativeLifecycle,SnapshotCancel,TerminalEdge,Termination}Cases` |
+| `stream-wrapper-fixtures.ts` | `weatherTool`, `createScriptedProtocol`, `create{TextOnly,Hermes,ErroredMorphXml,Thinking,Scripted}InnerStream` |
+| `stream-wrapper-*-cases.ts` | `registerStreamWrapper{Basic,Error,Finalization,StopReason,TransportError}Cases`, `registerLegacyProjectionDifferentialCase` |
+| `truncation-fixtures.ts` | `FIXTURE_TOOLS`, `TRUNCATION_FIXTURES` — one truncation matrix reused by Hermes, Anthropic XML, Morph XML, Gemma4, YAML XML |
+
+## CONVENTIONS
+
+- Per-protocol coverage is split by concern, not bundled: `<proto>-format`, `-parser`, `-stream`, edge/resource, recovery, then `e2e.test.ts` against the faux provider.
+- Stream tests feed input at exhaustive and randomized chunk boundaries and assert the full event sequence, terminal flush, metadata identity, and content indices — never just the final text.
+- Recovery tests drive synthetic `AssistantMessageEventStream` harnesses for both native and text event paths; source ordering and content index preservation are part of the contract.
+- Tool schemas use `typebox` `Type`; one export-purity check runs `spawnSync(process.execPath, ["--input-type=module", "--eval", ...])` to prove imports are side-effect free.
+- Adding a protocol means adding `<name>*.test.ts` here (step 5 of ADD A PROTOCOL in `src/tool-call-middleware/AGENTS.md`).
+
+## ANTI-PATTERNS
+
+- Never let protocol markup leak into visible text: XTML channel/close markers, function-call wrappers, and prompt-like markup inside parameter values must stay literal unless recognized.
+- Recovery fails closed. Unknown/ambiguous tool names, missing closes, schema-coercion failures, fenced code examples, thinking/redacted/provider-native content, invalid content indices, ID collisions, aborts, and transport errors must never become executable calls.
+- Terminal lifecycle is exactly-once — no duplicated text finalization, cancellation, upstream cleanup, or native start/delta/end transitions.
+- Scan work and retained buffers must stay bounded/linear; nested candidate-close handling and UTF-16 split boundaries are asserted. Do not introduce unbounded rescans.
+- `xml` is a deprecated alias for `morph-xml`; keep the compatibility test, write new coverage against the canonical name.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/ai test -- test/tool-call-middleware
+npm --prefix packages/ai test -- test/tool-call-middleware/stream-integration.test.ts
+npm --prefix packages/ai test -- test/tool-call-middleware/truncation-e2e.test.ts
+```
+
+## HOTSPOTS
+
+`e2e.test.ts` (719), `morph-xml-parser.test.ts` (709), `yaml-xml-parser.test.ts` (627), `hermes-parser.test.ts` (477), `context-transformer.test.ts` (475), `stream-integration.test.ts` (454). Highest blast radius on edit: `invoke-recovery-stream-fixtures.ts`, `stream-wrapper-fixtures.ts`, `truncation-fixtures.ts` — each feeds many suites.

--- a/packages/client/AGENTS.md
+++ b/packages/client/AGENTS.md
@@ -1,0 +1,55 @@
+# packages/client
+
+Transport-neutral client for remote pi sessions: `PiClient` exchanges framed CBOR through an injected `ByteTransportFactory`. Sole runtime dependency is `@earendil-works/pi-protocol`; the core stays runtime-neutral (no Node imports).
+
+## STRUCTURE
+
+```text
+src/client.ts          PiClient: connection, requests, leases, cleanup reconciliation
+src/connection.ts      Transport lifecycle, frame codec, connect/reconnect
+src/state.ts           Authoritative snapshots, event and listener fan-out
+src/session-handle.ts  SessionLease / PiSessionHandle semantics
+src/transport.ts       ByteTransport / ByteTransportFactory contracts
+src/errors.ts          PiServerError and client error taxonomy
+src/unix.ts            Node Unix-domain transport (separate ./unix subpath)
+src/index.ts           Public barrel
+test/                  Vitest suites plus support harness
+```
+
+## WHERE TO LOOK
+
+| Task | Path |
+|---|---|
+| Connection lifecycle, reconnect | `src/connection.ts` |
+| Session leases, attach/detach, reconciliation | `src/client.ts` |
+| Lease modes and invalidation | `src/session-handle.ts` |
+| Snapshot vs event state | `src/state.ts` |
+| New transports | implement `ByteTransportFactory` per `src/transport.ts` |
+| Unix-domain sockets | `src/unix.ts` via `@earendil-works/pi-client/unix` |
+
+## CONVENTIONS
+
+- Node-only code lives in `src/unix.ts`, exported only through the separate `./unix` subpath; the `src/index.ts` barrel must stay runtime-neutral.
+- `package.json` exports map is `.`, `./unix`, `./package.json`; `sideEffects: false`. Extend the map rather than adding side-effectful entry points.
+- Build and tests resolve `@earendil-works/pi-protocol` via `paths`/vitest alias (`../protocol/dist` for build, `../protocol/src` for tests); keep both in sync when files move.
+- Imports carry explicit `.ts` extensions per root `tsconfig.base.json`.
+- Engines: Node >=22.19.0 (repo root requires >=24). Published as CalVer `@earendil-works/pi-client`.
+
+## ANTI-PATTERNS
+
+- No auto-reconnect: `PiClient` requires explicit `reconnect()` after disconnection; do not add hidden retry loops.
+- Never apply optimistic state mutation from progress events; server snapshots and successful response snapshots are authoritative.
+- Do not construct `SessionLease` directly; leases exist only via `acquireSession()`, `createSession()`, or `attachSession()`.
+- Do not add Node/builtin imports outside `src/unix.ts`.
+- Keep `maxFrameLength` bounded and matching the server; transports must preserve send order and bound queued bytes.
+- Disconnection or server removal invalidates every lease for the affected attachment; disposing an invalidated lease is a no-op — preserve that behavior.
+
+## COMMANDS
+
+From the package root, or with `--workspace=@earendil-works/pi-client` from the repo root:
+
+```bash
+npm run build        # tsc -p tsconfig.build.json
+npm test             # vitest --run
+npm run typecheck    # tsc -p tsconfig.test.json
+```

--- a/packages/coding-agent/AGENTS.md
+++ b/packages/coding-agent/AGENTS.md
@@ -6,6 +6,7 @@
 
 ```text
 src/cli.ts, cli-main.ts, main.ts   Bootstrap, args, mode dispatch
+src/bun-runtime.ts              Bun-vs-Node runtime selection for bun-installed CLI (`SENPI_RUNTIME` pin)
 src/bun/cli.ts, src/bun/register-cursor-agent.ts   Bun-binary entry; static cursor-agent module install
 src/package-manager-cli.ts         install/update/config subcommands (incl. `senpi update --models`)
 src/core/agent-session.ts          Session lifecycle and runtime

--- a/packages/coding-agent/docs/AGENTS.md
+++ b/packages/coding-agent/docs/AGENTS.md
@@ -6,7 +6,7 @@ Public documentation for `@code-yeongyu/senpi`. Shipped inside the npm package: 
 ## Navigation manifest
 
 `docs.json` has two top-level keys: `navigation` (ordered section and page list) and `redirects`.
-Page paths are relative to this directory.
+Sections are `{ "title", "items": [{ "title", "path" }] }`; page paths are relative to this directory.
 
 - Every new `.md` file needs an entry in `docs.json` under `navigation`.
 - Renamed or moved pages need a `redirects` entry to avoid broken links.
@@ -29,6 +29,8 @@ These pages must track their implementation counterparts. Treat them as specs, n
 | `app-server.md` | `packages/coding-agent/src/modes/app-server/` |
 | `json.md` | JSONL wire format and record shapes |
 | `session-format.md` | Session file structure and field types |
+| `extensions.md` | Public extension API in `src/core/extensions/`; largest page — API tables must match `types.ts` |
+| `release-guide.md` | Release tooling; canonical check/build/test/lock command sequences |
 
 Preserve LF line endings and exact field names in these pages. Field spellings and JSONL record
 structures are asserted by tests; prose-only rewording can still break them.

--- a/packages/coding-agent/examples/AGENTS.md
+++ b/packages/coding-agent/examples/AGENTS.md
@@ -5,16 +5,28 @@ Runnable examples for the public Senpi SDK and extension API. Examples are docum
 ## STRUCTURE
 
 ```text
-extensions/        Tools, commands, UI, providers, hooks, resources
-extensions/*/      Multi-file examples and nested private workspaces
-sdk/               Programmatic SDK usage
-rpc-extension-ui.ts RPC-compatible extension UI example
-extensions/kimi-deferred-tools.ts  Deferred tool discovery/activation example
+extensions/          Single-file extension catalog (70+ files) + multi-file dirs
+extensions/*/        Multi-file examples; several are private nested workspaces
+sdk/                 Numbered SDK programs (01-minimal.ts ... 13-session-runtime.ts)
+rpc-extension-ui.ts  RPC-mode extension UI as standalone JSONL child process
 ```
+
+## WHERE TO LOOK
+
+| Task | First choice |
+|---|---|
+| Tool/flag/command/shortcut registration | `extensions/tools.ts`, `commands.ts`, `dynamic-tools.ts` |
+| Custom provider, OAuth, streaming | `extensions/custom-provider-anthropic/` |
+| UI widgets, overlays, editors | `extensions/overlay-*.ts`, `modal-editor.ts`, `widget-placement.ts` |
+| Session-entry persistence | `extensions/todo.ts`, `bookmark.ts`, `handoff.ts` |
+| Safety guards | `extensions/permission-gate.ts`, `protected-paths.ts`, `sandbox/` |
+| Full SDK composition | `sdk/12-full-control.ts`, `sdk/13-session-runtime.ts` |
+
+Largest examples carry real complexity, not toy scope: `extensions/overlay-qa-tests.ts` (~1.5k LOC), `extensions/subagent/index.ts` (~1k), `extensions/tic-tac-toe.ts` (~1k), `extensions/custom-provider-anthropic/index.ts` (~600). See `extensions/AGENTS.md` for the catalog map.
 
 ## CONVENTIONS
 
-- Import public package surfaces such as `@code-yeongyu/senpi` and `@earendil-works/pi-ai`; do not reach into `packages/coding-agent/src/core/` internals.
+- Import public package surfaces — `@code-yeongyu/senpi` (newer alias), `@earendil-works/pi-coding-agent` (lower level), `@earendil-works/pi-ai`/`pi-tui` — never `packages/coding-agent/src/core/` internals.
 - Keep examples small enough to teach one pattern, while preserving real error, cleanup, cancellation, and persistence behavior where relevant.
 - Extension factories have no top-level runtime side effects. Register work through the public `pi.*` API and lifecycle events.
 - New interactive examples should use configurable keybindings and themed TUI helpers. Existing demos may keep fixed controls when the control scheme is part of the example. Direct terminal writes belong only in examples explicitly teaching a terminal protocol; ordinary SDK examples may use normal stdout.
@@ -23,6 +35,9 @@ extensions/kimi-deferred-tools.ts  Deferred tool discovery/activation example
 - Deferred-tool examples preserve the Kimi flow: expose search first, activate via `pi.setActiveTools()`, and register lifecycle work in `session_start`.
 - Stateful examples persist reconstructable state in session entries or tool-result details so fork/resume behavior remains valid.
 - Nested example packages are private workspaces with exact-pinned dependencies. Treat their manifests and lock impact as production dependency changes.
+- Kebab-case filenames and slash-command names; camelCase named exports; one example per file default-exporting its extension factory.
+- UI examples guard on `ctx.hasUI` and clean up timers/child processes on `session_shutdown`; stateful atomic tools (games, questionnaires) set `executionMode: "sequential"`.
+- Tool schemas use TypeBox; handlers follow the `(toolCallId, params, signal, onUpdate, ctx)` shape.
 
 ## DOCUMENTATION CONTRACT
 

--- a/packages/coding-agent/examples/extensions/AGENTS.md
+++ b/packages/coding-agent/examples/extensions/AGENTS.md
@@ -1,0 +1,50 @@
+# packages/coding-agent/examples/extensions
+
+Flat catalog of executable extension examples plus multi-file extension packages. Own file because it is the densest `pi.*` registration surface in the repo (score 14: 110+ files, 10 subdirs, heavy symbol/export density). Load any single file with `senpi -e <path>.ts`; per-example docs live in `README.md`.
+
+## STRUCTURE
+
+```text
+*.ts                        Single-file examples, one pattern each (kebab-case)
+subagent/                   Subagent tool: single/parallel/chain dispatch (~1k LOC)
+custom-provider-anthropic/  OAuth + Anthropic-compatible streaming provider
+custom-provider-gitlab-duo/ Provider against GitLab Duo
+gondolin/                   Route built-in tools + `!` commands into a Gondolin micro-VM
+sandbox/                    OS-level sandboxing via @anthropic-ai/sandbox-runtime
+plan-mode/                  Read-only planning mode (generated instructions)
+openai-codex-usage/         Codex usage tracking
+dynamic-resources/          Dynamic resource examples
+with-deps/                  Extension with its own private dependency manifest
+doom-overlay/               WASM Doom rendered as live overlay; doom/build/ is generated
+```
+
+## WHERE TO LOOK
+
+| Task | First choice |
+|---|---|
+| Register tool/command/flag/shortcut/renderer | `tools.ts`, `commands.ts`, `dynamic-tools.ts`, `custom-header.ts` |
+| Built-in tool override or rendering | `minimal-mode.ts`, `built-in-tool-renderer.ts` |
+| Overlays, focus, geometry | `overlay-test.ts`, `overlay-qa-tests.ts`, `widget-placement.ts` |
+| Provider auth/payload | `custom-provider-anthropic/`, `provider-payload.ts` |
+| Persistent state via session entries | `todo.ts`, `tic-tac-toe.ts`, `bookmark.ts`, `handoff.ts` |
+| Prompt/preset/config files | `preset.ts`, `prompt-customizer.ts`, `system-prompt-header.ts` |
+| Games / keyboard input | `snake.ts`, `space-invaders.ts`, `tic-tac-toe.ts` |
+| Deferred-tool activation (Kimi flow) | `kimi-deferred-tools.ts` |
+| RPC/UI child process | `../rpc-extension-ui.ts`, `rpc-demo.ts` |
+
+## CONVENTIONS
+
+- Event seams used across examples: `session_start`/`session_shutdown`, `turn_*`, `agent_*`, `before_agent_start`, `tool_call`/`tool_result`, `input`, `user_bash`, `model_select`.
+- Presets read `~/.senpi/agent/presets.json` then `<cwd>/.senpi/presets.json`; project file wins. `provider-payload.ts` writes under `CONFIG_DIR_NAME`.
+- `overlay-qa-tests.ts` is a runtime QA extension (many overlay commands, timers, spawned streaming processes), not a conventional test target.
+
+## ANTI-PATTERNS
+
+- Custom tools MUST truncate output (`truncated-tool.ts` demonstrates ripgrep wrapping with 50KB/2000-line caps).
+- Games never expose the user's cursor and never split a tool-call sequence across responses.
+- Never leave timers or child processes alive past `session_shutdown`.
+- Shell/process-delegating examples (`ssh.ts`, `interactive-shell.ts`, `inline-bash.ts`, `auto-commit-on-exit.ts`, `git-merge-and-resolve.ts`) cross trust boundaries; adopt deliberately, never as boilerplate.
+
+---
+
+Parent: `examples/AGENTS.md` (import rules, factory discipline, validation).

--- a/packages/coding-agent/scripts/AGENTS.md
+++ b/packages/coding-agent/scripts/AGENTS.md
@@ -1,0 +1,41 @@
+# packages/coding-agent/scripts
+
+Developer tooling for the coding-agent package: vendoring upstream extension packages, app-server protocol codegen, reload benchmarking, legacy session migration. The app-server QA harness lives in `qa-app-server/` (own AGENTS.md). Own file because this is a distinct tooling domain (score 13) with a shared vendoring seam into `src/core/extensions/builtin/`.
+
+## STRUCTURE
+
+```text
+sync-builtin-extensions.mjs      Vendor pi-extensions packages into src/core/extensions/builtin
+vendor-transform.mjs             Shared import-rewrite transform used by vendoring
+generate-app-server-protocol.sh  Regenerate src/modes/app-server/protocol/generated from codex
+bench-reload.mjs                 DefaultResourceLoader.reload() benchmark vs synthetic extensions
+migrate-sessions.sh              Legacy one-off: ~/.pi/agent/*.jsonl -> session dirs (v0.30.0 bug)
+qa-app-server/                   App-server QA harness; see its AGENTS.md
+```
+
+## WHERE TO LOOK
+
+| Task | First choice |
+|---|---|
+| Update a vendored builtin | `sync-builtin-extensions.mjs` + `vendor-transform.mjs` |
+| Update app-server protocol types | `generate-app-server-protocol.sh` |
+| Diagnose reload slowness | `bench-reload.mjs` (`--ext-count/--runs/--procs/--out`) |
+| Run transport QA | `qa-app-server/run-all.mjs` |
+
+## CONVENTIONS
+
+- Vendoring source root defaults to sibling `../pi-extensions`; override with `SENPI_BUILTIN_EXTENSIONS_SOURCE`.
+- `DIR_SYNCS` lists packages whose senpi adaptation is fully captured by the mechanical transform (auto re-copy); `MANUAL_PACKAGES` lists diverged copies — upstream version recorded in `external-versions.json` only, behavior ported by hand.
+- `vendor-transform.mjs` owns the rewrite rules (drop published `.js` suffixes, `@mariozechner`/`@earendil-works` scope mapping, depth-relative core imports, Theme exception). Only transforms expressible there belong in `DIR_SYNCS`.
+- `bench-reload.mjs` always uses an isolated temporary agent dir and probes via `node --import tsx` (same jiti path as `test/resource-loader.test.ts`); never touches real `~/.senpi`.
+- Protocol codegen needs `codex` on PATH or `--from-checkout <dir>` pointing at a codex checkout; it writes `protocol/generated/` and `PROTOCOL_VERSION.txt`.
+
+## ANTI-PATTERNS
+
+- Re-copying a `MANUAL_PACKAGES` builtin — it clobbers hand-maintained divergence.
+- Hand-editing `protocol/generated/` or vendored builtin trees instead of going through the sync script + transform.
+- Running `bench-reload.mjs` against the real agent directory.
+
+---
+
+Parent: `packages/coding-agent/AGENTS.md`.

--- a/packages/coding-agent/scripts/qa-app-server/AGENTS.md
+++ b/packages/coding-agent/scripts/qa-app-server/AGENTS.md
@@ -1,0 +1,32 @@
+# scripts/qa-app-server
+
+Real-surface QA harness for app-server. `npm run qa:app-server` runs `run-all.mjs`, which executes handshake, multiclient, approval-roundtrip, real-client, and real-client-sweep probes against the locally built CLI. `differential/` is the source-oracle parity harness referenced by `src/modes/app-server/AGENTS.md`. 27 standalone `.mjs` files, ~3.5k LOC. Score 15 — own driver/oracle/compare stack, no other directory owns this surface.
+
+## STRUCTURE
+
+```text
+run-all.mjs               orchestrator — the npm script entry
+handshake.mjs, multiclient.mjs, approval-roundtrip.mjs,
+real-client.mjs, real-client-sweep.mjs   packaged probes
+lib/                      shared spawn/env/rpc/cleanup helpers
+                          (run-node.mjs, env.mjs, fake-model.mjs, rpc.mjs,
+                          cleanup.mjs + two vitest-runnable *.test.mjs)
+differential/             source-vs-oracle parity harness: driver.mjs (RawWebSocketDriver),
+                          run.mjs, build-oracle.mjs, compare.mjs, normalize.mjs, diff.mjs,
+                          cell.mjs, readiness.mjs, transcript-validation.mjs, allowlist.json
+```
+
+## CONVENTIONS
+
+- All probes spawn the repo-local CLI with explicit env overrides from `lib/env.mjs`: temp `SENPI_CODING_AGENT_DIR`, `PI_OFFLINE=1`, ports drawn from the fixed `qaPortRange` (18990-18999). Never hardcode other ports.
+- Temp state via `mkdtempSync`; `lib/cleanup.mjs` tracks and reaps spawned process groups (`cleanupAllAndWait`) — probe exit must not leak children.
+- Differential scenarios run through `differential/driver.mjs` / `run.mjs`, never as individual node invocations; scenario bodies live in `test/qa/app-server/differential/`.
+- `build-oracle.mjs` cargo-builds `codex-app-server` from a local codex-rs checkout (`ORACLE_MANIFEST` pins the path); without that checkout only the senpi side runs.
+- `allowlist.json` (`rules: []`) gates accepted parity gaps; the allowlist may never hide audience, frame-order, or array-order differences.
+- `lib/*.test.mjs` run under the package Vitest config (node:test-style asserts inside `test()`), skipped on win32 where process-group semantics differ.
+
+## ANTI-PATTERNS
+
+- Running a differential scenario file directly instead of through the driver.
+- Adding an allowlist rule to absorb a real ordering/audience divergence — that is a wire defect.
+- Spawning with fully inherited env — the explicit overrides in `lib/env.mjs` are load-bearing for hermetic QA.

--- a/packages/coding-agent/src/core/AGENTS.md
+++ b/packages/coding-agent/src/core/AGENTS.md
@@ -1,0 +1,59 @@
+# packages/coding-agent/src/core
+
+Session runtime, model/provider stack, session persistence, settings, resources. 72 flat `.ts` files (~28.8k LOC) plus six subtrees with their own AGENTS.md (`tools/`, `extensions/`, `dynamic-prompt/`, `compaction/`, `export-html/`, `retry-fallback/`). Reach for the extension API before adding anything here.
+
+## HOTSPOTS (flat files >500 LOC)
+
+| File | LOC | Owns |
+|---|---|---|
+| `agent-session.ts` | 8007 | `AgentSession`: prompt/steer/follow-up, tool registry, compaction admission/recovery, retry/fallback, abort provenance, navigation, extension binding |
+| `package-manager.ts` | 2760 | `DefaultPackageManager`: install/update/remove, source parsing, git/npm, resource precedence |
+| `settings-manager.ts` | 2022 | Layered global/project settings, JSONC, locking, queued writes, migrations |
+| `session-manager.ts` | 1818 | Append-only JSONL entry stream, version-3 migrations, branching, labels, bounded header scans |
+| `resource-loader.ts` | 1609 | `DefaultResourceLoader`: extension/hook/prompt/skill/theme discovery, precedence, generated shims |
+| `model-resolver.ts` | 1054 | Scope parsing, minimatch narrowing, Cursor legacy aliases, ambiguity diagnostics, CLI/initial/session selection |
+| `model-runtime.ts` | 931 | `ModelRuntime`: provider catalog composition, auth, refresh, availability snapshots, streaming |
+| `auth-storage.ts` | 724 | `AuthStorage` + file/read-only/in-memory backends; lock-backed JSON, 0600 credentials |
+
+`ModelRegistry` (`model-registry.ts`) is a synchronous compatibility facade over `ModelRuntime` — not a second implementation.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Session lifecycle / turn execution | `agent-session.ts` |
+| New/switch/fork/import session | `agent-session-runtime.ts` (`createAgentSessionRuntime`) |
+| Wire services into a session | `agent-session-services.ts` |
+| Model selection / scope resolution | `model-resolver.ts` |
+| Provider auth composition | `provider-composer.ts`, `provider-api-key-auth.ts`, `provider-header-auth.ts` |
+| Credential storage | `auth-storage.ts` |
+| Session persistence / branching | `session-manager.ts` |
+| Settings read/write | `settings-manager.ts` |
+| Bash execution (local or injected remote ops) | `bash-executor.ts` |
+| Skill discovery + prompt formatting | `skills.ts` |
+| Keybinding config + migration | `keybindings.ts` |
+| Transport message conversion / image elision | `messages.ts` |
+
+## CONVENTIONS
+
+- **Layering is explicit**: services → runtime/session lifecycle → `AgentSession`. Dependency injection through option interfaces and factories, never global construction.
+- **Session state is event-driven**: typed discriminated event unions, abort signals, queues, barriers, deferred settlement. No polling.
+- **Provider/auth availability is capability-derived** — enumerate compatibility providers and inspect credentials/env; never hard-code availability from UI names.
+- **Persistence is lock-backed**: `proper-lockfile` for credentials and file model stores, revision checks, atomic/coalesced reloads. Settings writes are queued with self-write tracking.
+- **Branding propagates via `SENPI_BRAND`** then is scrubbed from spawned tool environments (`brand.ts`) so child engines never inherit it.
+- Bash output is sanitized (ANSI/binary), bounded, and spilled to a temp file when truncated. Preserve abort-signal and chunk callbacks.
+- Node imports use `node:` in newer files; `auth-storage.ts` retains bare `fs`/`path`. Mixed by history, not by accident.
+
+## ANTI-PATTERNS
+
+- Implementing an extension-capable feature here instead of `extensions/builtin/`.
+- Mutating credentials through `ReadOnlyAuthStorage` (mutators throw by design) or bypassing lock/revision handling in the file backend.
+- Assuming a session operation owns terminal state during compaction/retry/abort — ownership, deferred queues, epochs, and provenance exist to prevent duplicate transitions.
+- Relying on `provider-composer.ts`'s `@deprecated` field for authentication; it is retained only for extension-source compatibility.
+- Dropping legacy Cursor model aliases or model compatibility flags when touching resolution paths.
+
+## NOTES
+
+- `core/changes.md` (3.5k lines) is the fork ledger for this directory — read the relevant dated section before touching a hotspot.
+- `output-guard.ts` holds process-global mutable stdio state with retry/backpressure timing; treat it as a process-wide singleton, not a helper.
+- `session-summary-lru.ts` / `session-summary-cache.ts` enforce byte budgets; summary regeneration is not free.

--- a/packages/coding-agent/src/core/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/compaction/AGENTS.md
@@ -1,0 +1,48 @@
+# packages/coding-agent/src/core/compaction
+
+Core compaction **mechanics** — token estimation, cut-point selection, summary generation, branch summarization, stream watchdogs. Distinct from `extensions/builtin/compaction/`, which owns compaction **policy** (speculative, circuit breaker, restoration, remote route). Core is what the extension calls; the extension is what decides when.
+
+## FILES
+
+```
+compaction/
+├── index.ts                  # Selective barrel: branch-summarization, compaction, utils ONLY
+├── compaction.ts             # 1367 LOC — token estimation, threshold decisions, cut-point selection,
+│                             # generateSummary, prepareCompaction, compact orchestration
+├── branch-summarization.ts   # Branch collection/preparation/generation for forked sessions
+├── utils.ts                  # Conversation serialization + file-operation tracking
+├── lifecycle.ts              # Compaction lifecycle state/coordinator (imported directly, not via barrel)
+├── stream-watchdog.ts        # Idle + duration watchdogs over provider summary streams
+└── warm-anchor.ts            # Warm-anchor validation for speculative results
+```
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Change token estimation or cut-point math | `compaction.ts` |
+| Change the summarization system prompt | `compaction.ts` (`SUMMARIZATION_SYSTEM_PROMPT`) |
+| Change default thresholds | `compaction.ts` (`DEFAULT_COMPACTION_SETTINGS`) |
+| Fork/branch summary behavior | `branch-summarization.ts` |
+| Detect a stalled summary stream | `stream-watchdog.ts` |
+| Serialize conversation for a summary request | `utils.ts` |
+
+## CONVENTIONS
+
+- **The barrel is deliberately selective** (three files). `lifecycle.ts`, `stream-watchdog.ts`, and `warm-anchor.ts` are imported by path from `agent-session.ts` and tests — do not widen `index.ts` into a blanket subtree export.
+- **Never cut at a tool result.** Cut-point selection must land on a message boundary that leaves no orphaned tool_use/tool_result pair; `extensions/builtin/tool-pair-guard/` and `compaction/repair-tool-pairs.ts` exist because violations are expensive.
+- A defined preparation must never carry empty summarizable content — return undefined instead.
+- Adaptive threshold and effective keep-recent-cap updates move together; splitting them desynchronizes admission.
+- Provider streams must be returned/consumed under both idle and duration watchdogs; an unwatched stream can hang a turn indefinitely.
+- Policy changes ship with policy tests in lock-step (`test/compaction*.test.ts`, `test/fixtures/compaction/`).
+
+## ANTI-PATTERNS
+
+- Adding policy (when to compact, retry, circuit-break) here instead of in the builtin extension — this directory answers "how", not "whether".
+- Pinning summarization prose in tests. The prompt contains deliberate "Do NOT" directives that are machine-consumed prompt contracts; assert parsed structure, not sentences.
+- Regenerating summaries without checking `warm-anchor.ts` staleness — a stale warm result applied after context moved silently drops turns.
+
+## NOTES
+
+- `compaction.ts` is the highest-behavioral-risk file in `core/`; changes here reach every provider path.
+- Overflow detection lives outside this directory: `core/agent-session.ts` calls `isContextOverflow` from `packages/ai/src/utils/overflow.ts`, then drives blocking compaction through the extension.

--- a/packages/coding-agent/src/core/export-html/AGENTS.md
+++ b/packages/coding-agent/src/core/export-html/AGENTS.md
@@ -1,0 +1,35 @@
+# packages/coding-agent/src/core/export-html
+
+Self-contained HTML session export (`/export`): renders a session JSONL file plus its system prompt and tool metadata into one styled HTML document. Isolated from the agent loop — `agent-session.ts` calls in through `exportSessionToHtml` only.
+
+## FILES
+
+| File | Role |
+|---|---|
+| `index.ts` | `exportSessionToHtml(sm, state?, options?)` (live-session export) and `exportFromFile(inputPath, …)` (standalone CLI export of arbitrary `.jsonl`); default output `<app>-session-<basename>.html` |
+| `ansi-to-html.ts` | Terminal ANSI → HTML conversion for tool output |
+| `tool-renderer.ts` | Support for the `ToolHtmlRenderer` seam — custom tool calls/results collapsed into HTML fragments |
+| `template.html` / `template.css` / `template.js` | Exported page shell: self-contained viewer with collapsible tool calls and syntax highlighting |
+| `vendor/highlight.min.js`, `vendor/marked.min.js` | Vendored highlight.js + marked, shipped as-is |
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Change export output/wiring | `index.ts` |
+| Change terminal-output rendering fidelity | `ansi-to-html.ts` |
+| Change how extension tools appear | `tool-renderer.ts` + the `ToolHtmlRenderer` implementation in `agent-session.ts` |
+| Change viewer styling/behavior | `template.*` (assets, not TS) |
+
+## CONVENTIONS
+
+- Custom tool rendering goes through the `ToolHtmlRenderer` seam: `agent-session.ts` pre-renders extension tools (`renderCall` / `renderResult`) so export never imports tool code.
+- Theme colors resolve through `modes/interactive/theme` (`getThemeExportColors`); the template directory resolves through `config.ts` `getExportTemplateDir`.
+- Output naming uses `APP_NAME` branding (`senpi-session-…`); `outputPath` supports `~` expansion and path normalization.
+- In-memory sessions cannot export — the guard requires an existing session file; preserve it.
+
+## ANTI-PATTERNS
+
+- Hand-editing `vendor/*.min.js` — vendored assets ship byte-for-byte; upgrade by re-vendoring.
+- Interpolating entry content into the template without escaping — escaping is owned here, not by callers.
+- Adding a markdown/syntax-highlight dependency — marked and highlight.js are vendored on purpose (offline, zero install).

--- a/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/AGENTS.md
@@ -46,28 +46,22 @@
 | 38 | `tool-search` | `tool-search/` | Shared tool catalog + `tool_search` exposure tool; loads before MCP, which feeds its tools into the same catalog |
 | 39 | `mcp` | `mcp/` | Built-in MCP client: `mcpServers` config, stdio/http transports, `/mcp` commands, tool exposure policy — kept last so its provider-payload tap observes all co-resident builtin mutations; see `mcp/changes.md` |
 
-Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by resource-loader.ts) and 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`).
-
-Shared non-factory modules in this directory:
-
-- `rule-activation/` — `appendRuleActivation` + renderer/types; consumed by `rules/` and `ttsr/`.
-- `monitor-state-event.ts` — `TerminalMonitorStateEvent` + guard; consumed by `goal/` and `terminal/`.
+Plus bundled extension **codemode** (`@code-yeongyu/senpi-codemode`, resolved by resource-loader.ts) and 4 **global default extensions** (resolved fast-path): `diff`, `files`, `prompt-url-widget`, `tps` (in `globalDefaultExtensionFactories`). Shared non-factory modules: `rule-activation/` (appendRuleActivation + renderer, consumed by `rules/` and `ttsr/`) and `monitor-state-event.ts` (consumed by `goal/` and `terminal/`).
 
 ## ADDING A NEW BUILTIN EXTENSION
 
 1. Create `builtin/<name>/index.ts` exporting `default function(pi: ExtensionAPI) { … }`. Single-file extensions go in `builtin/<name>.ts`.
 2. Add to `builtin/index.ts` import block + `builtinExtensions` array — pick registration order with intent.
 3. Add a regression test under `test/suite/<name>-extension.test.ts` using `test/suite/harness.ts`.
-4. If you modify upstream files (rare for new extensions), add a section to `<extension-dir>/changes.md`.
-5. Reach for `ExtensionContext` getters (the `ctx` parameter of event handlers); do NOT cross into `core/` directly.
+4. Reach for `ExtensionContext` getters (the `ctx` parameter of event handlers); do NOT cross into `core/` directly. If you modify upstream files (rare), add a section to `<extension-dir>/changes.md`.
 
 ## CONVENTIONS
 
 - **Subdirectory extensions** ship multi-file: `index.ts` + supporting `.ts` (`registry.ts`, `types.ts`, `parsers.ts`, etc.).
 - **Single-file extensions** are kept flat (`diff.ts`, `files.ts`, `redraws.ts`, `service-tier.ts`, `tps.ts`, `prompt-url-widget.ts`).
-- **`prompt-preset/`** has per-model files (`gpt-5.6.ts`, `claude-opus-4-8.ts`, …) and a shared `file-operations.ts` tuning block. New model = new preset file + entry in `presets.ts`. Models covered: gpt-5.x (incl. `gpt-5.3-codex`), claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, glm-5.3, deepseek-v4-{flash,flash-0731,pro}, grok-4.{5,6}, kimi-k2-{6,7}, kimi-k3.
+- **`prompt-preset/`** has per-model files plus a shared `file-operations.ts` tuning block; new model = new preset file + entry in `presets.ts`. See `prompt-preset/AGENTS.md` for the covered list.
 - **`permission-system/` is a full port** of opencode's permission flow.
-- **`compaction/`** is policy-rich (`policy.ts`, `speculative.ts`, `restoration-tracker.ts`, `circuit-breaker.ts`, `degradation-monitor.ts`, `per-turn-cap.ts`, `tool-truncation.ts`, `checkpoint-state.ts`, `context-reduction.ts`, `openai-remote.ts`, `repair-tool-pairs.ts`, `state.ts`, `todo-bridge.ts`, `prompts.ts`). Touch only with policy tests in lock-step.
+- **`compaction/`** is policy-rich — see `compaction/AGENTS.md` for the sub-policy map; touch only with policy tests in lock-step.
 - **External versions**: `external-versions.json` pins versions of sibling `../pi-extensions` packages used as vendored builtins; refresh with `packages/coding-agent/scripts/sync-builtin-extensions.mjs`.
 
 ## ANTI-PATTERNS
@@ -75,16 +69,12 @@ Shared non-factory modules in this directory:
 - Reordering `builtinExtensions` for cosmetic reasons — registration order is load-bearing for tools and permission hooks.
 - Expecting context inside the factory body — `ExtensionContext` only arrives as the `ctx` parameter of event handlers. Do side effects inside `pi.on("session_start", …)`.
 - Importing from `core/` directly — extensions must use the public `pi.*` API.
-- Adding a new builtin without a regression test in `test/suite/<name>-extension.test.ts`.
 - Splitting an existing single-file extension into a folder "for symmetry" — only split when there's actual code to split.
 
 ## NOTES
 
-- `permission-system/storage.ts` writes JSONL approval logs; don't change the line shape without a migration.
-- `compaction/restoration-tracker.ts` powers the post-compact context restoration feature — see `compaction/changes.md`.
-- `goal/elapsed-ticker.ts` drives the live 'Pursuing goal...' footer refresh on a one-second cadence.
 - MCP search exposure tool is `tool_search`, owned by the registered `tool-search` builtin (`builtin/tool-search/tool.ts`). Do not reintroduce `mcp_search` references anywhere.
-- Prompt presets routinely append the shared `file-operations.ts` tuning block. Mirror this when adding GPT-5.x presets — see `prompt-preset/changes.md` 2026-05-07.
+- Sub-directory detail lives in per-extension `AGENTS.md` files (compaction, mcp, goal, loop, terminal, permission-system, prompt-preset, gpt-apply-patch, claude-sdk-oauth, cursor-cli-oauth).
 
 ---
 Generated: 2026-08-22 | Commit: `a5eed4453`

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
@@ -46,7 +46,7 @@ Generated: 2026-08-07 | Commit: `4f26b8282`
 
 ## TESTS
 
-Flat cluster at `test/claude-sdk-oauth-*.test.ts` (35 files at this commit): accounts, affinity, auth-lane, binding, continuity decisions, failover, custom-tools schema, guidance, login, model switch, observability, and more. Keep edited test files below the 250-pure-LOC ceiling (see 2026-07-31 rename entry).
+Flat cluster at `test/claude-sdk-oauth-*.test.ts` (51 files): accounts, affinity, auth-lane, binding, continuity decisions, failover, custom-tools schema, guidance, login, model switch, observability, and more. Keep edited test files below the 250-pure-LOC ceiling (see 2026-07-31 rename entry).
 
 ## MERGE RISK
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/compaction
 
-Builtin extension #23 (last). Owns senpi's compaction pipeline: speculative compaction running in parallel with the next turn, blocking compaction at the hard context limit, proactive compaction near the soft limit, degradation monitoring, circuit breaker, absolute session cap, todo bridging, checkpoint state, restoration tracker, and tool-result truncation. Policy-rich; touch with policy tests in lock-step. See `changes.md` for the restoration tracker rationale.
+Builtin extension #20. Owns senpi's compaction *policy* (mechanics live in `core/compaction/`): speculative compaction running in parallel with the next turn, blocking compaction at the hard context limit, proactive compaction near the soft limit, degradation monitoring, circuit breaker, absolute session cap, todo bridging, checkpoint state, restoration tracker, and tool-result truncation. Policy-rich; touch with policy tests in lock-step. See `changes.md` for the restoration tracker rationale.
 
 ## FILES
 
@@ -28,6 +28,10 @@ compaction/
 ├── todo-bridge.ts            # Carries todos through compaction so the summary preserves them
 ├── restoration-tracker.ts    # Post-compact: re-injects skill + file context (fork-introduced)
 ├── prompts.ts                # Compaction summarization prompt + system message
+├── lane-policy.ts            # SDK-native lane detection; `external-owner` structured ownership
+├── deterministic-fallback.ts # Classification + construction when summarization fails outright
+├── summarization-retry.ts, transient-failure.ts, retained-message-safety.ts  # Retry/safety predicates
+├── openai-remote-{convert,model,schema,timeout,responses-v2}.ts  # Remote-route support modules
 └── changes.md                # Fork tracker (restoration tracker, extension hook wiring)
 ```
 
@@ -65,6 +69,9 @@ compaction/
 - Changing the `prompts.ts` summarization template without regenerating the relevant goldens.
 - Bypassing `tool-truncation.ts` for "small" tool results — the policy uses a global token budget; even small additions matter.
 - Mutating `restoration-tracker.ts` queue from a non-compaction hook.
+- Treating provider-owned SDK-native compaction as ordinary extension cancellation — `lane-policy.ts` must preserve `external-owner` ownership.
+- Letting an aborted compaction surface: aborts stand down silently (no circuit-breaker failure, no raw abort error, no `{cancel: true}` rejected-compact event).
+- Leaving idle warm-up continuations unfenced against retired extension generations — stale context access becomes an uncaught crash.
 
 ## NOTES
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/AGENTS.md
@@ -1,132 +1,77 @@
 # builtin/goal
 
-Builtin extension #16. Persistent per-thread **goal** tracking, ported from the
-standalone `pi-goal` extension with **zero dependency on it** and **budget-driven
-behavior fully removed**. Registers the codex-aligned `create_goal` /
-`update_goal` / `get_goal` tools plus a `/goal` command, persists a single goal
-per thread to a JSON file, and re-engages the agent toward an active goal via
-hidden continuation prompts.
+Builtin extension #30. Persistent per-thread **goal** tracking, ported from standalone
+`pi-goal` with **zero dependency on it** and **budget-driven behavior fully removed**.
+Registers codex-aligned `create_goal` / `update_goal` / `get_goal` plus `/goal`, persists one
+goal per thread, re-engages the agent via hidden continuation prompts. 34 `.ts` files, flat;
+`changes.md` is the fork tracker.
 
-## FILES
+## FILES (by cluster)
 
-```
-goal/
-├── index.ts          # Extension entry — tools + /goal command + session/agent lifecycle + usage accounting
-├── agent-end-continuation.ts # Agent-end routing into Goal continuation ownership
-├── store.ts          # File persistence: read/write/create/update/clear/accountGoalUsage
-├── types.ts          # Goal (+ inert tokenBudget compatibility metadata), GoalStatus, GoalFile, refs, snapshots
-├── validation.ts     # validateObjective (trim + max length)
-├── continuation.ts   # shouldQueueGoalContinuation* gating predicates
-├── monitor-continuation-types.ts # Monitor scheduler lifecycle contracts
-├── last-assistant-message.ts # Shared last-assistant lookup for terminal classification
-├── prompt.ts         # buildContinuationPrompt (untrusted-objective + completion audit)
-├── format.ts         # Tool/UI formatting + goalToolResponse snapshot
-├── command.ts        # parseGoalCommand (show|pause|resume|clear|setObjective)
-├── ui.ts             # ctx.ui.setStatus footer segment for the active goal
-├── cache-warm.ts     # Cache-warm metrics/formatting + goal-cache-warmup entry contract
-├── cache-warm-renderer.ts # Scheduled/resumed TUI renderer for goal-cache-warmup entries
-├── elapsed-ticker.ts # GoalElapsedTicker + goalLiveElapsedSeconds (live footer refresh)
-├── wait-progress.ts  # Pure continuation-wait progress bar + label formatting
-├── wait-ticker.ts    # GoalWaitTicker (live footer countdown lifecycle)
-├── terminal-provider-error.ts # Terminal provider-failure classification
-├── errors.ts         # Goal{AlreadyExists,NotFound}/store error classes
-└── changes.md        # Fork tracker (port + budget behavior removal + wire compatibility)
-```
+- **Entry/registration**: `index.ts` (441 LOC; lifecycle, accounting, UI),
+  `tool-registration.ts`, `command-registration.ts`, `command.ts`.
+- **Domain/persistence**: `types.ts` (Goal, statuses, inert `tokenBudget`), `store.ts`
+  (serialized mutations), `persistence.ts` (atomic writes, legacy migration),
+  `validation.ts`, `errors.ts`.
+- **Continuation**: `monitor-continuation.ts` (603 LOC — timers, wake sources, direct-input
+  holds, cache-warm scheduling, admission, recovery, disposal) plus `continuation.ts`,
+  `lifecycle-helpers.ts`, `direct-input-lifecycle.ts`, `agent-end-continuation.ts`,
+  `continuation-recovery.ts`, `reload-reengagement.ts`.
+- **Prompt/format**: `prompt.ts` (untrusted-objective + completion audit), `format.ts`,
+  `todo-gate.ts`, `last-assistant-message.ts`, `terminal-provider-error.ts`.
+- **UI/tickers**: `ui.ts` (footer segment), `elapsed-ticker.ts`, `wait-ticker.ts`,
+  `wait-progress.ts`, `cache-warm.ts`, `cache-warm-renderer.ts`.
 
 ## NO BUDGET-DRIVEN BEHAVIOR
 
-This is the deliberate divergence from `pi-goal` / codex `ext/goal`. `Goal` may
-persist an optional `tokenBudget` only as inert app-server wire-compatibility
-metadata. The builtin tools do not create or interpret it. There is no
-`budgetLimited`/`usageLimited` status, budget-limit continuation, or
-budget-driven status transition. `tokensUsed` and `timeUsedSeconds` remain
-display-only usage metrics. Status is `active | paused | blocked | complete`; `blocked` carries `blockedReason`/`blockedAt` and suppresses continuations.
+The deliberate divergence from `pi-goal` / codex `ext/goal`. `Goal` may persist an optional
+`tokenBudget` **only** as inert app-server wire-compatibility metadata; the tools neither
+create nor interpret it. No `budgetLimited`/`usageLimited` status, no budget-limit continuation,
+no budget-driven transition. `tokensUsed`/`timeUsedSeconds` are display-only. Status is
+`active | paused | blocked | complete`; `blocked` carries `blockedReason`/`blockedAt` and
+suppresses continuations.
 
 ## CONTINUATION POLICY
 
-Continuation admission is guarded by a persisted consecutive-continuation cap of 8,
-a stale-signature check on immediate re-entry, and a single-flight latch so only one
-hidden continuation can be queued at a time. The stall notice is goal-wide: from the
-3rd consecutive toolless continuation turn it prefixes the prompt with `<goal_stall_check>`
-and switches between monitor-flavored bullets while monitors are active and generic
-recovery bullets otherwise. Accepted direct input disarms a pending continuation,
-and a clean accepted user turn arms a visible 10-second grace countdown before the Goal
-resumes; mechanically blocked Goals are reactivated on accepted input, including admitted
-steering. A `length` stop gets exactly one minimal truncation recovery before the goal
-blocks on repetition. Terminal provider errors block the goal only when
-`AgentEndEvent.willRetry` is false and the abort is not explicitly system-owned; those
-blocks count as mechanical, so a new user message resumes the goal and the blocked notice
-says so. A terminal system error instead preserves the active Goal: it schedules the live
-monitor wait when one exists, or queues a guarded hidden `systemRecovery` continuation
-after `agent_settled` when no monitor or retry can resume the run. Staging recovery until
-settlement makes an error-compatible idle turn while preserving late user cancellation;
-canceling the staged delivery also releases the single-flight latch so `/goal resume`
-can start fresh recovery.
-Intentional blocks — a user interrupt or a model-declared `update_goal` block — stay
-non-recoverable. Resumed sessions with 8+
-trailing historical continuation entries suppress session-start auto-resume.
-`tokenBudget` remains inert compatibility metadata only; this policy is budget-free by
-design.
+Admission guards: consecutive-continuation cap of 8 (persisted), stale-signature check on
+immediate re-entry, single-flight latch. From the 3rd consecutive toolless turn the prompt
+gains a `<goal_stall_check>` prefix — monitor-flavored bullets while monitors are active,
+generic recovery bullets otherwise. Accepted direct input disarms a pending continuation; a
+clean accepted user turn arms a visible 10-second grace countdown before the Goal resumes.
+Mechanically blocked Goals reactivate on accepted input, including admitted steering. A
+`length` stop gets exactly one truncation recovery, then blocks.
 
-## RESTART RESUME PROMPT
-
-On `session_start` with reason `resume`, an idle TUI session with no pending
-messages prompts before doing anything else when the stored goal is stopped but
-unfinished — `paused` or `blocked`. `isResumeOfStoppedGoal` (lifecycle-helpers.ts)
-owns that admission and `maybePromptResumeStoppedGoal` (index.ts) renders it;
-the title names the actual status (`Resume blocked goal?`). Accepting flips the
-goal to `active` as a `"user"` mutation and queues a continuation; declining
-leaves the status untouched. `active` and `complete` goals never prompt; a completed
-goal is revived only by an explicit `/goal resume`. This mirrors codex
-`maybe_prompt_resume_paused_goal_after_resume`, minus its
-`UsageLimited` arm, which senpi has no counterpart for.
-
-## PERSISTENCE
-
-`store.ts` writes `GoalFile{version:1, goal}` to
-`<sessionDir>/extensions/goal/<threadId>.json`, falling back to
-`getAgentDir()/extensions/goal/no-session/<sha256(cwd)[:24]>/` when the session
-has no file (in-memory / print mode). One goal per thread.
-
-## ERRORS
-
-Tool error results are signaled by **throwing** from `execute()` — senpi's
-`AgentToolResult` has no `isError` field and the agent loop only marks a result
-as an error when the tool throws (`agent-loop.ts` `executePreparedToolCall`).
-Do not return an `isError` property; it is ignored.
-
-## WHERE TO LOOK
-
-| Task | File |
-|------|------|
-| Change a tool schema or description | `index.ts` `registerTool` |
-| Adjust status transitions / persistence | `store.ts` |
-| Tune the continuation prompt | `prompt.ts` |
-| Change the footer status text | `ui.ts` |
-| Change the live footer elapsed ticker | `elapsed-ticker.ts` (+ `refreshGoalUi` in `index.ts`) |
-| Change the continuation-wait countdown | `wait-progress.ts`, `wait-ticker.ts`, and `monitor-continuation.ts` |
-| `/goal` argument parsing | `command.ts` |
+Terminal provider errors block only when `AgentEndEvent.willRetry` is false and the abort is
+not system-owned; those blocks are mechanical, so a new user message resumes. A terminal
+*system* error preserves the active Goal: schedule the live monitor wait, or queue a guarded
+hidden `systemRecovery` continuation after `agent_settled` (staging preserves late user
+cancellation; canceling releases the single-flight latch for `/goal resume`). Intentional
+blocks — user interrupt or a model-declared `update_goal` block — stay non-recoverable.
+Resuming with 8+ trailing continuation entries suppresses session-start auto-resume. On
+`session_start` reason `resume`, an idle TUI session with a stopped-but-unfinished goal
+(`paused`/`blocked`) prompts first (`isResumeOfStoppedGoal`); accepting flips to `active` as
+a `"user"` mutation. `active`/`complete` never prompt.
 
 ## CONVENTIONS
 
-- **Single goal per thread.** `create_goal` fails while an UNFINISHED goal exists;
-  over a `complete` goal it replaces, archiving the old goal to
-  `<threadId>.history.jsonl`. `update_goal` marks `complete` or `blocked` (blocked
-  requires a `reason`). `/goal <objective>` replaces with a UI confirm.
-- **Continuation is opt-in by state**: hidden prompts are queued only while a goal
-  is `active`, idle, and there are no pending messages.
-- **Usage accounting is display-only**: `accountGoalUsage` increments
-  `tokensUsed`/`timeUsedSeconds`; it never changes status.
-- **Live footer is ticker-driven**: `refreshGoalUi` (index.ts) drives
-  `GoalElapsedTicker` to refresh `Pursuing goal (…)` once per second while a goal
-  is `active` and its accounting window is open. `GoalWaitTicker` independently
-  refreshes the transient continuation countdown while a monitor or user-grace
-  timer is armed. Both tickers only run with a TUI context and stop on their owning
-  lifecycle cleanup.
-
-## NOTES
-
-- Tests: `test/suite/goal-store.test.ts`, `goal-modules.test.ts`,
-  `goal-extension.test.ts`, `goal-elapsed-ticker.test.ts`, `goal-wait-progress.test.ts` (faux/mocked `pi`, temp-file store, no real APIs).
-- Registered last in `builtin/index.ts` `builtinExtensions`; inert until a goal
-  is created.
+- **Single goal per thread.** `create_goal` fails while an UNFINISHED goal exists; over a
+  `complete` goal it replaces, archiving to `<threadId>.history.jsonl`. `update_goal` marks
+  `complete` or `blocked` (blocked requires a `reason`). `/goal <objective>` replaces with a
+  UI confirm.
+- **Tool errors are THROWN, never returned.** `AgentToolResult` has no `isError` field; the
+  agent loop marks an error only when `execute()` throws (`agent-loop.ts`
+  `executePreparedToolCall`). A returned `isError` property is silently ignored.
+- **Persistence**: `GoalFile{version:1, goal}` at `<sessionDir>/extensions/goal/<threadId>.json`,
+  falling back to `getAgentDir()/extensions/goal/no-session/<sha256(cwd)[:24]>/` when the
+  session has no file. Writes are atomic, mutations serialize per goal path via promise tails,
+  and legacy `pi-goal` stores/status spellings migrate on read. Objectives trim and cap at
+  4,000 code points with a truncation marker plus full-text sidecar.
+- **Continuation is opt-in by state**: hidden prompts queue only while the goal is `active`,
+  the agent is idle, and no messages are pending.
+- **Live footer is ticker-driven**: `refreshGoalUi` drives `GoalElapsedTicker` once per second
+  while a goal is `active` with an open accounting window; `GoalWaitTicker` independently
+  refreshes the continuation countdown while a monitor or user-grace timer is armed. Both
+  require a TUI context and stop on their owning lifecycle cleanup.
+- Inert until a goal exists; `loop` (#31) and later builtins register after it. Tests:
+  `test/suite/goal-{store,modules,extension,elapsed-ticker,wait-progress}.test.ts`
+  (faux/mocked `pi`, temp-file store, no real APIs).

--- a/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/gpt-apply-patch/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/gpt-apply-patch
 
-Builtin extension #2. For `gpt-*` models on Responses-family APIs, swaps `write` / `edit` for a freeform Codex-style `apply_patch` tool with a Lark-style grammar; for `gpt-*` models on `openai-completions`, exposes `apply_patch` as a plain JSON function tool instead. Applies multi-file patches (add / update / delete / move). Keeps standard edit tools for all other models and APIs. Largest single builtin (18 files).
+Builtin extension #4. For `gpt-*` models on Responses-family APIs, swaps `write` / `edit` for a freeform Codex-style `apply_patch` tool with a Lark-style grammar; for `gpt-*` models on `openai-completions`, exposes `apply_patch` as a plain JSON function tool instead. Applies multi-file patches (add / update / delete / move). Keeps standard edit tools for all other models and APIs. Largest single builtin (18 files).
 
 ## FILES
 

--- a/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
@@ -1,98 +1,80 @@
 # builtin/loop
 
-Fork-only builtin extension porting Claude Code's `/loop`: recurring (fixed-interval)
-and self-paced (dynamic) scheduled prompts inside one session. A loop re-delivers a
-prompt or a loop-file sentinel on a cadence; dynamic loops pick their own next delay
-through the `schedule_wakeup` tool. Everything ships in this directory plus one
-registration line in `builtin/index.ts`.
+Fork-only builtin extension porting Claude Code's `/loop`: recurring (fixed-interval) and
+self-paced (dynamic) scheduled prompts inside one session. A loop re-delivers a prompt or a
+loop-file sentinel on a cadence; dynamic loops pick their own next delay through the
+`schedule_wakeup` tool.
 
 ## FILES
 
-```
-loop/
-├── index.ts        # Extension entry: real timers, store wiring, tick dispatch, lifecycle
-├── command.ts      # /loop command registration: routes parsed invocations to the scheduler
-├── types.ts        # Single type home: LoopState, CronEntry, lifecycle, payloads, sentinels
-├── store.ts        # Atomic versioned per-session sidecar (temp file + rename, fail closed)
-├── parse.ts        # Pure /loop argument grammar (subcommands, interval forms, prompt)
-├── cron-planner.ts # normalizeInterval / describeCron / computeNextFireAt (pure)
-├── loopfile.ts     # Loop-file resolution + content fingerprint (injected fs)
-├── tick-prompt.ts  # buildTickMessage: sentinel expansion, full-vs-reminder decision (pure)
-├── tools.ts        # schedule_wakeup: the only model-callable surface (flat TypeBox schema)
-├── scheduler.ts    # Pure state machine: arm/fire/settle/pause/resume/stop/suspend/restore
-└── status.ts       # Footer presenter: formatLoopStatus + 1s LoopStatusTicker
-```
+- **Impure**: `index.ts` (extension entry: timers, store wiring, tick dispatch, lifecycle),
+  `store.ts` (atomic versioned sidecar, fail closed), `command.ts` (/loop → scheduler),
+  `tools.ts` (`schedule_wakeup`, flat TypeBox schema).
+- **Pure**: `scheduler.ts` (state machine: arm/fire/settle/pause/resume/stop/suspend/restore),
+  `parse.ts` (/loop argument grammar), `cron-planner.ts` (normalizeInterval/describeCron/
+  computeNextFireAt), `tick-prompt.ts` (sentinel expansion, full-vs-reminder), `status.ts`
+  (formatLoopStatus + 1s LoopStatusTicker), `loopfile.ts` (loop-file resolution, injected fs).
+- `types.ts` — single type home (LoopState, CronEntry, lifecycle, payloads, sentinels); other
+  modules re-export rather than redeclare.
 
 ## PURITY SEAM
 
-`scheduler.ts`, `parse.ts`, `cron-planner.ts`, `tick-prompt.ts`, and `status.ts`
-(formatting) are pure. The scheduler never calls `Date.now` or `setTimeout`: a
-`LoopClock` supplies `now` and a `LoopTimerPort` owns the single armed timeout per loop,
-both injected by `index.ts`. `loopfile.ts` takes an injected `fs`/`path`/`cwd` bundle.
-Only `index.ts` and `store.ts` touch the real world (timers, disk, extension events,
-message dispatch). Every scheduling invariant is therefore testable with a fake clock and
-zero real waiting. `types.ts` is the canonical type home; other modules re-export from it
-rather than redeclaring.
+`scheduler.ts`, `parse.ts`, `cron-planner.ts`, `tick-prompt.ts`, and `status.ts` are pure.
+The scheduler never calls `Date.now` or `setTimeout`: `LoopClock` supplies `now` and a
+`LoopTimerPort` owns the single armed timeout per loop, both injected by `index.ts`;
+`loopfile.ts` takes an injected `fs`/`path`/`cwd` bundle. Only `index.ts` and `store.ts`
+touch the real world, so every scheduling invariant is testable with a fake clock and
+zero real waiting.
 
 ## PERSISTENCE
 
-`store.ts` mirrors the goal store's discipline: one sidecar file per session, strict
-`version: 1` validation, atomic write via temp file + rename, and a promise tail
-serializing every mutation so command, timer, tool, and lifecycle writes cannot
-interleave. It FAILS CLOSED: unparseable or wrong-version state returns a typed error,
-arms nothing, and never silently resets. Session custom entries are deliberately not the
-authoritative store (a globally scanned "latest" entry can come from an abandoned
-branch); the `loop-tick` entry exists only for attribution and noop folding.
+`store.ts`: one sidecar file per session, strict `version: 1` validation, atomic write
+via temp file + rename, and a promise tail serializing every mutation so command, timer,
+tool, and lifecycle writes cannot interleave. It FAILS CLOSED: unparseable or wrong-version
+state returns a typed error, arms nothing, never silently resets. Session custom entries
+are deliberately NOT the authoritative store; the `loop-tick` entry exists only for
+attribution and noop folding.
 
 ## SCHEDULING INVARIANTS
 
-- Coalescing: at most ONE queued or running tick per loop. A fire that lands while one
-  is in flight sets `coalescedFirePending` instead of enqueuing a second delivery, so a
-  sleeping laptop or a long turn never produces a tick storm. `nextFireAt` is always
-  recomputed from `now`, never from the stale due time, so missed occurrences collapse
-  into exactly one catch-up tick.
-- 5-loop cap: at most `MAX_ACTIVE_LOOPS` (5) active loops per session; a further
-  creation returns a typed rejection and leaves existing loops armed.
-- Max-ticks valve: each loop carries a dispatched-tick budget (`DEFAULT_MAX_TICKS`,
-  2000); exhausting it ends the loop with `tick_budget_exhausted` so a forgotten fast
-  loop cannot spend without bound.
-- Expiry: loops live at most 7 days from `createdAt`, checked at arm, fire, re-entry,
-  and restore; a new wakeup never extends it.
-- Keepalive: a two-strike device on dynamic loops only. When an attributed dynamic
-  iteration ends without calling `schedule_wakeup`, the first omission burns one
-  keepalive credit and arms a fallback wakeup (`SENPI_LOOP_KEEPALIVE_SECONDS`, default
-  1200s, clamped 60-3600); the second consecutive omission ends the loop with
-  `keepalive_exhausted`. Keepalive never applies after an ordinary user turn, and a user
-  abort PAUSES the loop rather than ending it or counting as an omission.
-- Provider/turn errors are never terminal for a loop.
+- **Coalescing**: at most ONE queued or running tick per loop; a fire landing while one is
+  in flight sets `coalescedFirePending` rather than enqueuing a second delivery, and
+  `nextFireAt` recomputes from `now`, collapsing missed occurrences into one catch-up tick.
+- **5-loop cap + max-ticks valve**: `MAX_ACTIVE_LOOPS` (5) active loops per session (further
+  creation returns a typed rejection, existing loops stay armed); each loop carries a
+  `DEFAULT_MAX_TICKS` (2000) dispatched-tick budget, exhaustion ending it with
+  `tick_budget_exhausted` so a forgotten fast loop cannot spend without bound.
+- **Expiry**: at most 7 days from `createdAt`, checked at arm, fire, re-entry, and restore;
+  a new wakeup never extends it.
+- **Keepalive** (dynamic loops only): two-strike. The first iteration ending without
+  `schedule_wakeup` burns one credit and arms a fallback wakeup (`SENPI_LOOP_KEEPALIVE_SECONDS`,
+  default 1200s, clamped 60-3600); the second consecutive omission ends the loop with
+  `keepalive_exhausted`. Never applies after an ordinary user turn; a user abort PAUSES the
+  loop. Provider/turn errors are never terminal for a loop.
 
 ## TICK DELIVERY
 
-A tick never steers. When the session is idle, `index.ts` dispatches through
-`sendUserMessage` with `expandPromptTemplates: true` so a slash payload reaches the real
-command path; a busy session receives the tick as a follow-up. Sentinel payloads (the
-four `<<...>>` loop/loop-file forms) follow a cache-friendly full-vs-reminder rule: the
-long instruction block is delivered once as an anchor, and later ticks send a short
-reminder pointing back at that anchored delivery, keeping the cached message prefix
-stable. A changed loop-file fingerprint (content hash from `loopfile.ts`) re-anchors
-with a fresh full delivery. Verbatim `prompt` payloads are always sent as-is.
+A tick never steers. When idle, `index.ts` dispatches through `sendUserMessage` with
+`expandPromptTemplates: true` so a slash payload reaches the real command path; a busy
+session receives the tick as a follow-up. Sentinel payloads (the four `<<...>>`
+loop/loop-file forms) deliver the long instruction block once as an anchor, later ticks send
+a short reminder pointing back at it, keeping the cached message prefix stable; a changed
+loop-file fingerprint re-anchors. Verbatim `prompt` payloads are always sent as-is.
 
 ## LIFECYCLE
 
-Shutdown SUSPENDS, it never terminates: every senpi shutdown reason
-(`quit|reload|new|resume|fork`) leaves the session resumable, so `onShutdown` cancels
-timers, disposes the status ticker, and persists the snapshot without a terminal reason.
-There is deliberately no `session_closed` end reason in `LoopEndReason`; the terminal
-reasons are exactly `stopped | keepalive_exhausted | expired | tick_budget_exhausted |
-error`. `restore` re-arms suspended loops on the next session start, re-checking expiry.
-A store failure is not swallowed: affected loops end with `error` and the user is told,
-because a schedule that cannot be persisted must not keep running.
+Shutdown SUSPENDS, it never terminates: every senpi shutdown reason (`quit|reload|new|
+resume|fork`) leaves the session resumable, so `onShutdown` cancels timers, disposes the
+status ticker, and persists the snapshot without a terminal reason. Terminal reasons are
+exactly `stopped | keepalive_exhausted | expired | tick_budget_exhausted | error` (there is
+deliberately no `session_closed`). `restore` re-arms suspended loops on the next session
+start, re-checking expiry. A store failure ends affected loops with `error` and tells the
+user — a schedule that cannot be persisted must not keep running.
 
 ## MODEL SURFACE
 
-`schedule_wakeup` (`tools.ts`) is the only model-callable surface. Its TypeBox schema is
-a flat object with no root union (several provider conversions rebuild schemas from
-top-level `properties`, so a root `anyOf` would arrive empty; same reasoning as
-`terminal/tools/monitor.ts`), and `delaySeconds` carries no schema bounds because the
-executor clamps out-of-range integers (60-3600s) instead of rejecting them. All effects
-go through an injected scheduler port; the tool mutates no state directly.
+`schedule_wakeup` (`tools.ts`) is the only model-callable surface. Its TypeBox schema is a
+flat object with no root union (several provider conversions rebuild schemas from top-level
+`properties`; a root `anyOf` would arrive empty — same reasoning as `terminal/tools/monitor.ts`).
+`delaySeconds` carries no schema bounds; the executor clamps out-of-range integers (60-3600s)
+instead of rejecting them. All effects go through an injected scheduler port.

--- a/packages/coding-agent/src/core/extensions/builtin/mcp/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/mcp/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/coding-agent/src/core/extensions/builtin/mcp
 
-Fork-native builtin MCP client. Registration #23 in `builtin/index.ts` — kept last so its provider-payload tap observes all co-resident builtin mutations. Entry: `index.ts` exports `default function mcpExtension(pi: ExtensionAPI): void`. `changes.md` is the active fork ledger; every divergence from upstream MCP SDK behavior goes there.
+Fork-native builtin MCP client. Registration #39 in `builtin/index.ts` — kept last so its provider-payload tap observes all co-resident builtin mutations. Entry: `index.ts` exports `default function mcpExtension(pi: ExtensionAPI): void`. `changes.md` is the active fork ledger; every divergence from upstream MCP SDK behavior goes there.
 
 ## SUBTREES
 

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/permission-system
 
-Builtin extension #1. Full port of opencode's permission flow. Loads preset/rule policy from CLI (`--permission-preset`, `--permission tool=action`), settings (`permissionPreset`, `permission`), and per-session approvals. Defaults to the `full-access` preset, persists "always allow" decisions, blocks denied calls with a structured error, and supports parser-aware patterns (bash command prefixes, file path globs for read/write/edit/apply_patch). **JSONL storage shape is a contract — migration required to change it.**
+Builtin extension #3. Full port of opencode's permission flow. Loads preset/rule policy from CLI (`--permission-preset`, `--permission tool=action`), settings (`permissionPreset`, `permission`), and per-session approvals. Defaults to the `full-access` preset, persists "always allow" decisions, blocks denied calls with a structured error, and supports parser-aware patterns (bash command prefixes, file path globs for read/write/edit/apply_patch). **JSONL storage shape is a contract — migration required to change it.**
 
 ## FILES
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -1,6 +1,6 @@
 # builtin/prompt-preset
 
-Builtin extension #3. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, glm-5.3, deepseek-v4-{flash,flash-0731,pro}, kimi-k2-{6,7}, kimi-k3) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
+Builtin extension #7. On `before_agent_start` and `model_select`, picks a system prompt preset by **model family** (gpt-5.x through gpt-5.6, claude-fable-5, claude-opus-5, claude-opus-4-{5,6,7,8}, glm-5.2, glm-5.3, deepseek-v4-{flash,flash-0731,pro}, kimi-k2-{6,7}, kimi-k3) and falls back to the senpi dynamic prompt when nothing matches. Renders the active preset name in the startup header. After 2026-04-30, presets are thin wrappers around `buildDynamicSystemPrompt()` carrying only model-specific tuning.
 
 ## FILES
 
@@ -19,18 +19,13 @@ prompt-preset/
 ├── gpt-5.6.ts           # GPT-5.6 series preset (sol/terra/luna) — dieted full-core rewrite via `corePrompt`; Hephaestus-parity autonomous deep worker (implement-don't-propose, Manual QA Gate, binding stop contract: declared per-turn stop condition + Stop Goal) under GPT-5.6 simplify-first doctrine; also owns `GPT56_EXECUTION_RULES` — typed execution-discipline rule data (eval-first code-cell routing, maximum parallel batching, over-call bias, in-kernel reduction, stay-direct exceptions, subagent fan-out, finest-grain todos, test-first, atomic commits, LSP symbol routing) rendered one directive per point of use
 ├── claude-fable-5.ts    # Claude Fable 5 preset — dieted full-core rewrite via `corePrompt` (Fable 5 prompting guide; binding stop contract)
 ├── claude-opus-5.ts     # Claude Opus 5 preset — dieted full-core rewrite via `corePrompt` (Opus 5 prompting-guide behaviors; binding stop contract)
-├── claude-opus-4-5.ts   # Claude Opus 4.5 preset
-├── claude-opus-4-6.ts   # Claude Opus 4.6 preset
-├── claude-opus-4-7.ts   # Claude Opus 4.7 preset
-├── claude-opus-4-8.ts   # Claude Opus 4.8 preset
-├── glm-5-2.ts           # GLM 5.2 preset
-├── glm-5-3.ts           # GLM 5.3 preset
+├── claude-opus-4-{5,6,7,8}.ts  # Per-snapshot Opus 4.x presets (claude-opus-4-5.ts … 4-8.ts)
+├── glm-5-{2,3}.ts       # GLM 5.2 / 5.3 presets (glm-5-2.ts, glm-5-3.ts)
 ├── deepseek-v4.ts       # Shared DeepSeek V4 rule data (`DEEPSEEK_V4_RULES`) + tuning builders (directive authority, todo discipline, missing-info, settled-reading, reasoning-aim)
 ├── deepseek-v4-flash.ts # DeepSeek V4 Flash preset (thin tuningSection over the shared core)
 ├── deepseek-v4-flash-0731.ts # DeepSeek V4 Flash 0731 snapshot preset — dated snapshot resolves before the generic flash alias
 ├── deepseek-v4-pro.ts   # DeepSeek V4 Pro preset (deep-reasoner calibration)
-├── kimi-k2-6.ts         # Kimi K2.6 preset
-├── kimi-k2-7.ts         # Kimi K2.7 preset
+├── kimi-k2-{6,7}.ts     # Kimi K2.6 / K2.7 presets (kimi-k2-6.ts, kimi-k2-7.ts)
 ├── kimi-k3.ts           # Kimi K3 preset — full-core rewrite via `corePrompt` (K3 tuning merged into a leaner Kimi-shaped core; K2-family loop discipline + Opus 4.8/Fable 5 distillation traits) + binding stop contract (declared stop condition in the routing line)
 └── changes.md           # Fork tracker (model-family rename 2026-04-30, file-operations 2026-05-07)
 ```

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/AGENTS.md
@@ -1,0 +1,57 @@
+# builtin/terminal
+
+Builtin extension #18. Replaces one-shot bash with a **PTY-backed persistent session** model: `bash` plus companion tools `bash_output`, `bash_input`, `bash_resize`, `kill_bash`, and `monitor`. Registered after `bash-timeout` (so the resolved default timeout reaches PTY bash) and after `anthropic-bash` (so a native Anthropic bash tool makes terminal step aside).
+
+## FILES
+
+```
+terminal/
+├── index.ts             # Barrel: extension + settings + tool-name constants + shared key/regex helpers
+├── extension.ts         # Registration entry — registers all six tools, wires lifecycle + reload bundles
+├── manager.ts           # TerminalManager: session map ownership
+├── runtime-session.ts   # TerminalRuntimeSession: one live PTY
+├── session-bundle.ts    # TerminalSessionBundle: reload parking/claiming across extension generations
+├── monitor-registry.ts  # MonitorRegistry: registered watches over session output
+├── monitor-notify.ts    # Event → notification delivery (283 LOC, largest non-tool file)
+├── monitor-status*.ts   # Footer status text + 1s unref'd ticker
+├── notify.ts            # TerminalNotifier
+├── output-format.ts     # Output shaping/sanitization
+├── settings.ts          # loadTerminalSettings / resolveTerminalSettings
+├── shared.ts            # Defaults: 120x40, 10000 scrollback, 32 sessions, 1,000,000 output chars
+├── prompt.ts            # Tool prompt guidance
+└── tools/               # bash.ts (420 LOC), bash-output/input/resize, kill-bash, monitor,
+                         # spawn, render, context, foreground-detach/window, sleep-wait
+```
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Change PTY spawn/exec behavior | `tools/bash.ts`, `tools/spawn.ts` |
+| Change auto-detach window (~60s foreground) | `tools/foreground-detach.ts`, `tools/foreground-window.ts` |
+| Add/change a monitor condition | `tools/monitor.ts` + `monitor-registry.ts` |
+| Change how monitor wakes the session | `monitor-notify.ts` |
+| Change footer terminal status | `monitor-status.ts`, `monitor-status-ticker.ts` |
+| Change defaults (size, scrollback, caps) | `shared.ts` |
+| Survive an extension reload | `session-bundle.ts` |
+
+## CONVENTIONS
+
+- **Monitor is the wait mechanism.** Observable state changes are delivered as events that wake the session; `bash_output` is for peeking, not waiting.
+- **Companion tools stay active together** with `bash` and are synchronized with extension lifecycle and session-reload bundles — a companion tool without a live PTY is a bug.
+- Tool output is capped at 2,000 lines / 50 KiB and sanitized before it reaches the model; monitor status refreshes on a 1-second unref'd interval.
+- TypeBox schemas are **flat root objects, never root unions** (`tools/monitor.ts` is the reference) — several provider conversions rebuild schemas from top-level `properties` and a root `anyOf` arrives empty.
+- Environment overrides are injected for tests rather than mutating `process.env`.
+- Cross-extension seam: `monitor-state-event.ts` (parent dir) carries `TerminalMonitorStateEvent`, consumed by `goal/`.
+
+## ANTI-PATTERNS
+
+- Using `tmux` for long-running/interactive work through terminal `bash` — the PTY session is the mechanism.
+- Polling with `sleep`, foreground wait loops, or repeated `bash_output` while waiting on observable state.
+- Letting a companion tool dangle without a live PTY `bash`, or letting an output observer interfere with session ingest.
+- Assuming the injected `timeout` kills a background session — it never does; use `kill_bash`.
+
+## NOTES
+
+- `changes.md` records `wait_for`, `block`, and `timeout` as **deprecated ghost schema parameters**: still accepted for compatibility, but not the current control model. Do not build new behavior on them.
+- The default bash timeout itself is owned by `builtin/bash-timeout/`, not here; terminal consumes the resolved value.

--- a/packages/coding-agent/src/core/retry-fallback/AGENTS.md
+++ b/packages/coding-agent/src/core/retry-fallback/AGENTS.md
@@ -1,0 +1,51 @@
+# packages/coding-agent/src/core/retry-fallback
+
+Model fallback chains and hint-aware 429 retry policy for `agent-session.ts`. Pure/injectable modules only — every clock, timer, and registry probe is injected; `core/agent-session.ts` owns the single impure wiring. No local `changes.md`: fork changes track in `src/changes.md` / `core/changes.md`.
+
+## FILES
+
+| File | Role |
+|---|---|
+| `controller.ts` | `RetryFallbackController`: turn-scoped tried-selector set, `ActiveFallbackState`, `tryFallback` / `maybeRestorePrimary(revertPolicy)` / `clearForManualModelChange`, content-keyed memo of canonicalized chains |
+| `chains.ts` | Selector parse/format, chain-key resolution, `canonicalizeFallbackChains` (bare-selector expansion + registry eligibility) |
+| `expansion.ts` | Bare-selector family expansion; OpenRouter denylist; OAuth-first auth tiers; `PROVIDER_PRECEDENCE` tie-break |
+| `hint-policy.ts` | Pure 429 hint tiers (`no-hint-fast-fallback` / `tier1-in-turn` / `tier2-fallback-probe-back` / `tier3-fallback-only`) + probe schedule math |
+| `probe-scheduler.ts` | ONE armed probe plan per session, max two probes (half-hint, then deadline), injected `setTimeout`/`clearTimeout` |
+| `cooldown.ts` | `SelectorCooldowns`: runtime-only selector suppression, injected `now`/`random`, honors `retryAfterMs` |
+| `billing.ts` | Billing-class failure detection — billing fallbacks are PINNED (never revert on cooldown expiry) |
+| `settings.ts` | `RetrySettings` shape (chains, `fallbackRevertPolicy`, provider retry timeouts) resolved via `settings-manager.ts` |
+| `validate.ts` | Chain validation with per-selector warnings (unknown models, unsupported thinking levels) |
+| `log.ts` | `fallback.log` writer: 5 MiB cap, key allow/blocklists, secret scrubbing |
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Change when fallback fires or reverts | `controller.ts` |
+| Change selector syntax / chain canonicalization | `chains.ts` |
+| Change which providers a bare selector expands to | `expansion.ts` |
+| Tune 429 wait/probe behavior | `hint-policy.ts`, `probe-scheduler.ts` |
+| Add a non-recoverable failure class | `billing.ts` pattern |
+| Change resolved settings shape | `settings.ts` + `core/settings-manager.ts` |
+
+## CONVENTIONS
+
+- Everything time- or randomness-dependent is injected (`now`, `random`, `setTimeout`/`clearTimeout`) — tests drive it deterministically with fake timers; never read `Date.now()` directly here.
+- Cooldowns are runtime-only and deliberately never persisted to settings or session files.
+- Billing-class errors pin the fallback candidate as the session model; `transient`/`refusal`/`hard-error` fallbacks revert per `fallbackRevertPolicy` (`cooldown-expiry` | `never`).
+- `canonicalizeFallbackChains` is memoized on chains content — provider-error handling calls it several times per error.
+- `fallback.log` scrubs by construction: blocked keys (`headers`, `env`, `authorization`, …), allowlisted data keys only, bearer/api-key text patterns truncated.
+- Consumers: `agent-session.ts` (controller wiring), `settings-manager.ts` (resolution), `builtin/model-fallback/` (validate + canonicalize for `/model-fallback`), `builtin/cursor-cli-oauth/settings.ts` (`isFallbackEligible` probe).
+
+## ANTI-PATTERNS
+
+- Expanding a bare selector onto OpenRouter — it re-publishes other vendors' catalogs under namespaced ids; only an explicit `openrouter/...` selector may route there.
+- Persisting cooldown or tried-selector state across sessions.
+- Two in-flight probes, or arming a second plan without superseding — `probe-scheduler.ts` owns exactly one plan per session.
+- Writing raw provider errors/headers to `fallback.log` — always go through `log.ts` scrubbing.
+- Treating a billing error as transient — retrying the same account never recovers it.
+
+## NOTES
+
+- Tests: `test/suite/retry-fallback-*.test.ts` (20 files) — engine, chains, expansion eligibility, cooldown, hint tiers, probe scheduler, billing swap, revert, validate, log.
+- `streamRetryTimeoutMs` reconciles to `max(cap, streamStartTimeoutMs)` so a granted stream-start budget is never cut short; `0` disables.

--- a/packages/coding-agent/src/modes/interactive/components/AGENTS.md
+++ b/packages/coding-agent/src/modes/interactive/components/AGENTS.md
@@ -1,0 +1,45 @@
+# packages/coding-agent/src/modes/interactive/components
+
+Rendering units for the TUI: message renderers, selectors/dialogs, tool surfaces, layout helpers. 56 flat `.ts` files (~11.6k LOC), no subdirectories. `interactive-mode.ts` (parent dir) drives them; these files never own lifecycle.
+
+## HOTSPOTS
+
+| File | LOC | Owns |
+|---|---|---|
+| `tree-selector.ts` | 1434 | `TreeList` + `TreeSelectorComponent`: tree flattening, gutters, active-path, folding, filtering, horizontal viewport, copy/text extraction, label editing |
+| `session-selector.ts` | 1031 | Session tree build/flatten, search/sort/name filtering, loading progress, delete/rename flows |
+| `config-selector.ts` | 942 | Config browse/edit surface |
+| `settings-selector.ts` | 917 | Settings browse/mutate surface |
+| `model-selector.ts` | 459 | Model picker; favorites/search split into helper modules |
+
+Cross-cutting fan-in: `DynamicBorder`, `theme`, and `keybinding-hints` are imported by nearly every selector/renderer — a change there reaches most dialogs. Tool rendering is split across `tool-execution.ts` plus renderer/types/images/fallback/boundary modules and is a second coupled cluster.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Assistant streaming render | `assistant-message.ts` (+ `createAssistantRenderDescriptors`) |
+| Tool call/result render | `tool-execution.ts`, `tool-execution-renderer.ts`, `tool-execution-images.ts`, fallback/boundary modules |
+| Footer/status segments | `footer.ts` (format + layout planning) |
+| Diff rendering in messages | `diff.ts` (`renderDiff`, intra-line helpers) |
+| Markdown/mermaid transforms | `createMarkdownTransform`, `createMermaidMarkdownTransformer` |
+| Border chrome | `dynamic-border.ts` |
+| Key label text | `keybinding-hints.ts` (`keyText`, `keyDisplayText`, `keyHint`) |
+| Public component surface for extensions | `index.ts` (barrel, 33 re-exports) |
+
+## CONVENTIONS
+
+- Components extend `@earendil-works/pi-tui` primitives (`Container`, `Box`, `Loader`, `Editor`, `Component`, `Focusable`) and compose explicit rows/strings styled through `theme`.
+- Selectors are callback-driven: `onSelect`/`onCancel` plus mutation/error callbacks, mutable component state, explicit `invalidate()`/`render()`, and configurable `getKeybindings()`.
+- Layout is width-aware everywhere: `visibleWidth`, `truncateToWidth`, visual-line truncation, footer planning, bounded render signatures, explicit viewport/anchor math.
+- `ProgressiveTranscriptContainer` hydrates only visible/tail content incrementally; input handling must never block during hydration and the progressive watermark never moves backward.
+- Border color is always passed explicitly — jiti creates a separate module cache, so an implicit default resolves to the wrong theme instance.
+- The barrel re-exports only the public UI classes; many helpers stay direct-file APIs by design.
+
+## ANTI-PATTERNS
+
+- Recomputing complete message trees per streaming delta — memoization in the assistant/tool renderers is load-bearing.
+- Writing to stdout directly, or emitting arbitrary ANSI. Only established terminal-protocol markers (OSC 133 zones in `assistant-message.ts`) are allowed.
+- Inline key literals instead of `../../core/keybindings.ts` routing.
+- Adding a render path without width, theme, and cancellation states.
+- Hiding the tree gutter/current leaf, or dropping required footer model/context segments during truncation.

--- a/packages/coding-agent/test/AGENTS.md
+++ b/packages/coding-agent/test/AGENTS.md
@@ -5,18 +5,18 @@ Vitest coverage for the Senpi CLI, sessions, extensions, modes, transports, and 
 ## STRUCTURE
 
 ```text
-suite/             Preferred AgentSession/AgentSessionRuntime harness tests
-suite/regressions/ Issue-specific regressions
-mcp/               MCP transports, fixtures, security, lifecycle
-permission/        Permission-system behavior
-compaction/        Compaction mechanics and policy
+suite/             Preferred AgentSession/AgentSessionRuntime harness tests (own AGENTS.md)
+suite/regressions/ Issue-specific regressions (own AGENTS.md)
+mcp/               MCP transports, fixtures, security, lifecycle (own AGENTS.md)
+permission/        Permission-system behavior (own AGENTS.md)
+compaction/        Compaction mechanics and policy (own AGENTS.md)
 session-manager/   Persistence, branching, context construction
 dynamic-prompt/    Dynamic system-prompt + workstation fact coverage
 tool-pair-guard/   Provider payload tool-pair sanitization tests
 client/            RPC/app-server client coverage
 server/            App-server/server surface coverage
 extensions/        Extension loading and API behavior
-cursor-cli-oauth/  Cursor CLI OAuth provider-lane coverage (accounts, spawn, stream, failover)
+cursor-cli-oauth/  Cursor CLI OAuth provider-lane coverage (own AGENTS.md)
 tool-search/       Shared tool-catalog / `tool_search` exposure coverage
 grok/              Grok provider coverage
 ttsr/              Stream-rule (ttsr) extension coverage
@@ -25,7 +25,7 @@ helpers/           Shared subprocess/QA/fixture helpers
 benchmarks/        Perf-oriented probes (not part of the default correctness gate)
 examples/          Coverage for the shipped `examples/` extensions
 manual-qa/         Explicit manual QA scripts (not part of default suite)
-qa/app-server/     Real app-server surface drivers
+qa/app-server/     Real app-server surface drivers (own AGENTS.md)
 integration/       Explicitly gated real-provider tests
 fixtures/, goldens/ Shared deterministic inputs and snapshots
 model-runtime*.test.ts / models-store.test.ts / remote-catalog-provider.test.ts / runtime-credentials.test.ts
@@ -34,6 +34,11 @@ claude-sdk-oauth-*.test.ts
                    Flat cluster (51 files) at test/ root covering the Claude SDK
                    OAuth provider extension
 ```
+
+The flat `test/*.test.ts` root cluster (~350 files) is legacy/feature-focused placement.
+New lifecycle and extension coverage belongs in `suite/`, not at this root.
+Legacy root helpers: `test-harness.ts` (superseded), `utilities.ts`, `model-runtime-test-utils.ts`,
+`test-network-env.ts`, `test-theme-colors.ts`. `setup.ts` is the quarantine entry (see below).
 
 ## TEST RULES
 
@@ -66,7 +71,8 @@ claude-sdk-oauth-*.test.ts
 
 - Run every added or changed test file directly until green.
 - Run the narrow owning directory or package suite when shared harnesses, fixtures, or lifecycle behavior change.
+- Package runner is Vitest: `npm --prefix packages/coding-agent test -- --run <path>`.
 - Root `npm run check` is static validation and does not replace tests.
 
 ---
-Generated: 2026-08-22 | Commit: `a5eed4453`
+Generated: 2026-08-24 | Commit: `baf15a54d`

--- a/packages/coding-agent/test/compaction/AGENTS.md
+++ b/packages/coding-agent/test/compaction/AGENTS.md
@@ -1,0 +1,42 @@
+# test/compaction
+
+Compaction mechanics and policy: blocking, speculative, idle/warm, pruning, routing, retry/degradation, tool-pair repair, and OpenAI remote compaction. 57 files / ~13,100 LOC, ~612 test call sites. Score 15 — distinct policy domain with numeric constants pinned as contracts.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Extension wiring / handlers | `*-characterization.test.ts`, tests importing `src/core/extensions/builtin/compaction/index.ts` |
+| Speculative warm-start | `speculative-compaction.test.ts` (848 LOC), `speculative-budget-handoff.test.ts`, `stale-context-idle-warmup.test.ts`, `stale-warm-blocking-repro.test.ts` |
+| OpenAI remote route | `openai-remote-compaction.test.ts` (1,160 LOC), `openai-remote-abort-standdown.test.ts`, shared fixtures in `openai-remote-test-models.ts` |
+| Checkpoint provenance | `canonical-routes.test.ts` (1,017 LOC) |
+| Deterministic degradation | `required-compaction-deterministic-fallback.test.ts`, `summarization-body-too-large.test.ts` |
+| Thresholds / budgets | `adaptive-threshold.test.ts`, `context-reduction.test.ts`, `hard-limit-emergency.test.ts`, `idle-compaction.test.ts` |
+| Tool-call pairing | `tool-pair-repair.test.ts`, `todo-preservation.test.ts` |
+| Restoration bookkeeping | `restoration-tracker.test.ts` |
+
+`openai-remote-test-models.ts` is the only shared module: it exports `OPENAI_NATIVE_LEGACY_MODEL` (Responses/WebSocket, `supportsRemoteCompactionV2`) and `OPENAI_CANONICAL_LEGACY_MODEL` (canonical endpoint/base URL derivation).
+
+## CONVENTIONS
+
+- File names encode route, failure mode, boundary, or incident (`blocking-*`, `stale-*`, `summarization-*`, `openai-remote-*`, `*-characterization`) — deliberately not one-file-per-source-module.
+- Session-manager entries are constructed explicitly (`type`, `id`, `parentId`, `timestamp`, payload), often as complete OpenAI-native branches, to verify replay and provenance.
+- Compaction is exercised through extension harnesses and event callbacks (`beforeAgentStart`, `sessionBeforeCompact`, `agentEnd`, context hooks), not by calling pure functions alone. Provider request/header/context hooks are installed to validate the final pipeline plus redaction.
+- Assertions inspect machine values: route/transport, payload input, persisted details, revisions, reasons, emitted events. Numeric policy constants (37.5% speculative threshold, adaptive ratios, context windows, retry bounds, hard caps) are literal contracts — changing a constant means changing these tests deliberately.
+- Remote OpenAI coverage distinguishes the direct compact endpoint from the Responses WebSocket route and validates provenance against endpoint, stable headers, auth tenant, hook-filtered prefixes, and model identity.
+
+## ANTI-PATTERNS
+
+- Raw provider items must never be treated as context-boundary provenance.
+- Cancellation must never be reported as a credential error.
+- Stale-generation continuations must not start another warm-up or throw; stale/warm paths must not end feedback without an applied entry.
+- Oversized summarization responses (HTTP 413 / "Request body too large") are the same recovery class as token-window overflow: shrink and retry, then degrade deterministically. An unclassified failure causing a long stall is the bug.
+- A failed speculative warm start must reuse the existing job/watchdog failure path — never discard it and issue a second full-budget blocking request.
+- Never apply a speculative summary after a superseding revision/generation or a rewritten boundary; never replay checkpoints after endpoint/auth/context-hook provenance changes; never persist raw credentials; never drop tool-call/result pairs.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/coding-agent test -- --run test/compaction/<file>.test.ts
+npm --prefix packages/coding-agent test -- --run test/compaction
+```

--- a/packages/coding-agent/test/cursor-cli-oauth/AGENTS.md
+++ b/packages/coding-agent/test/cursor-cli-oauth/AGENTS.md
@@ -1,0 +1,51 @@
+# test/cursor-cli-oauth
+
+Provider-lane coverage for the Cursor CLI OAuth extension: accounts, settings, executable resolution, spawn args, stream parsing, session routing, failover, guardrails, shutdown. 27 tests / ~7,000 LOC + committed CLI captures. Score 12 — distinct provider domain with a replay-fixture contract nothing else in `test/` uses.
+
+## STRUCTURE
+
+```text
+*.test.ts                       one file per production module in
+                                src/core/extensions/builtin/cursor-cli-oauth/
+fixtures/captures/*.jsonl       recorded cursor-agent wire output, replayed across
+                                adversarial chunk boundaries
+fixtures/cursor-agent-models.txt   model-listing capture
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Account slots, pinning, failover | `account-command.test.ts` (463 LOC), `accounts.test.ts`, `affinity.test.ts` |
+| Stream event mapping | `stream.test.ts` (627 LOC) — usage isolation, tool rendering, failover, guardrails |
+| Resume / fresh-chat / recap | `session-router.test.ts` (423 LOC) |
+| Token/context ownership | `context-ownership.test.ts` (450 LOC) |
+| Executable probe + bootstrap | `executable.test.ts`, `native-bootstrap.test.ts` |
+| Login and ambient opt-in | `oauth-login.test.ts`, `ambient-optin.test.ts`, `nonthrowing-checks.test.ts` |
+| Process lifecycle | `transport.test.ts`, `shutdown.test.ts`, `fixture-process.test.ts` |
+
+Highest production fan-in: `accounts.ts` (11 test files), `settings.ts` (8), `index.ts` (5), `executable.ts` (5), `oauth-login.ts` (4).
+
+## CONVENTIONS
+
+- Dependency injection with small local harnesses plus `vi.fn()` — no broad module mocks. Local helper names recur: `makeStore`, `fixtureExecutable`, `accountAwareFixture`, `runTurn`, `createHarness`, `scriptedRunner`, `makeRouter`, `textDeltas`.
+- Transport/stream/shutdown tests spawn **real child processes** from generated temporary executable scripts standing in for `cursor-agent`.
+- JSONL captures are committed and treated as the Cursor CLI wire format; parser tests replay them split at adversarial chunk boundaries.
+- Contract tests pin exact values: defaults, sentinel/provider IDs, argument shapes, warning counts, recap size ceilings, and machine-distinguishable error kinds.
+- Security assertions are explicit and load-bearing: token material must not appear in output or logs, credential files use restrictive permissions, native credential sources stay isolated unless explicitly requested.
+
+## ANTI-PATTERNS
+
+- Never leak token material into output, logs, or errors.
+- Never read or write the native Cursor credential entry on managed-account paths.
+- Never spawn when the lane is disabled, no account is bound, or force acknowledgement is missing.
+- Malformed/unknown stream frames and zero-output "success" are failures, not empty successes.
+- Fresh-chat retry is bounded; transcript text must not persist beyond the recap window; CLI-reported usage must never land in assistant usage fields.
+- `shutdown.test.ts` / `transport.test.ts` use interval-and-timeout PID death observation — that is process-lifecycle synchronization at a real OS boundary, not a pattern to copy into ordinary async tests.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/coding-agent test -- --run test/cursor-cli-oauth/<file>.test.ts
+CI=1 npm --prefix packages/coding-agent test -- --run test/cursor-cli-oauth
+```

--- a/packages/coding-agent/test/mcp/AGENTS.md
+++ b/packages/coding-agent/test/mcp/AGENTS.md
@@ -1,0 +1,51 @@
+# test/mcp
+
+MCP transport, lifecycle, OAuth, exposure, and configuration coverage plus the fixture servers/workers that back it. 48 top-level files + `fixtures/` (15 modules, 2 schema JSON). Score 16 — the only test subtree that ships its own runnable MCP servers and fault-injection harness.
+
+## STRUCTURE
+
+```text
+*.test.ts              config, transport/connection, lifecycle (startup-race, reconnect,
+                       idle, expiry), oauth-{headless,callback,provider,race,token-store},
+                       exposure-tierb / tool-search activation, resources/prompts/
+                       elicitation, logging/security, recovery
+fixtures/              runnable servers + shared attach/lifecycle helpers
+fixtures/schema/       nasty-input.schema.json + nasty-input.typebox.golden.json
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Attach a capturing extension to the MCP service | `fixtures/register-call.ts` — `attach`, `mcpExtensionFor`, `capturingPi`, `awaitMcpToolRegistration`, `awaitMcpPromptRegistration`, `withoutMcpUtilityTools` |
+| Roots/config/process lifecycle | `fixtures/service-lifecycle.ts` — `makeRoot`, `setConfig`, `stdioServer`, `waitForCondition`, `assertAlive`, `cleanupRoots` |
+| Spin up a fixture MCP server | `fixtures/sdk-server.ts` (`createFixtureServer`), `fixtures/stdio-server.ts`, `fixtures/http-server.ts` |
+| Fault injection flags | `fixtures/options.ts` — `parseFixtureOptions`, `maybeWedge`, `delaySlowStart` |
+| OAuth IDP | `fixtures/oauth-idp.ts`, `fixtures/oauth-idp-core.ts` (`pkceS256`, `parseIdpOptions`), `fixtures/spawn-idp.ts` |
+| Cross-process workers | `fixtures/token-store-worker.ts`, `fixtures/oauth-race-worker.ts` |
+| Provider-native search mocks | `fixtures/native-search-mocks.ts` (`buildAnthropicSse`, `buildOpenAiResponseEvents`) |
+
+## CONVENTIONS
+
+- Every test creates an isolated temporary root/config and resets the singleton MCP service between cases (`getMcpService` / `resetMcpServiceForTests`). Skipping the reset leaks connections into the next file.
+- Fixture servers expose capabilities deliberately (tools, resources, prompts, logging, list-changed, subscriptions) and take argv flags for crashes, wedges, delays, expiry, counters, bearer tokens, huge output/schema, and list changes. Add new failure modes as flags in `fixtures/options.ts`, not as new servers.
+- Async waits go through named helpers (`waitForCondition`, `awaitMcpToolRegistration`, service/session attach helpers) — never inline timers.
+- The harness does **not** emit `session_start` automatically; attach and await the lifecycle signal before asserting.
+- Test names/comments carry numbered TODO tracks (todo 27, 29-42); coverage is split one file per concern.
+- JSON schema fixtures live beside their golden typebox output; regenerate both together.
+
+## ANTI-PATTERNS
+
+- Never log raw OAuth tokens — fingerprints only.
+- Never combine Anthropic `defer_loading` with `cache_control`.
+- Proxy exposure must never be auto-selected; the `tool_search` tool must not re-enter requests; unknown/unregistered tools are never eligible.
+- Do not contact OAuth discovery when headers are configured.
+- `fixtures/native-search-mocks.ts` fabricates API responses and never touches a real API — preserve that isolation.
+- `never` casts at mocked SDK/extension boundaries are a harness accommodation here; do not copy them into production code.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/coding-agent test -- --run test/mcp/<file>.test.ts
+CI=1 npm --prefix packages/coding-agent test -- --run test/mcp   # subprocess-heavy: one fork
+```

--- a/packages/coding-agent/test/permission/AGENTS.md
+++ b/packages/coding-agent/test/permission/AGENTS.md
@@ -1,0 +1,40 @@
+# test/permission
+
+Permission-system coverage: parsers, evaluation, presets, config merge/expand, service lifecycle, persistence, CLI, and non-interactive handling. 15 files / ~6,000 LOC. Score 11 — distinct domain, dense end-to-end scenarios that no parent file can summarize.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Full pipeline scenarios | `integration.test.ts` (1,513 LOC, 15 numbered scenarios + evaluate/expand/merge/parser/non-interactive cases) |
+| Cross-mode UI vs no-UI cascade | `multi-mode.test.ts` (841 LOC) |
+| Request lifecycle + events | `service.test.ts` (515 LOC) — `ask`/`reply`/`list`/`getApproved`, event emission, defensive copies, insertion order |
+| Arity/pattern matching | `arity.test.ts` (566 LOC) |
+| Rule parsing | `parsers.test.ts` — `createBuiltinParserRegistry` |
+| Config shape | `config.test.ts` — `fromConfig`, `merge`, `expand`, `disabled` |
+| Presets | `presets.test.ts` — `rulesForPreset` |
+| Persistence | `storage.test.ts`, `settings.test.ts` — JSONL load/save |
+| Headless behavior | `non-interactive.test.ts` — `handleNoUI` |
+| CLI surface | `cli.test.ts` |
+| External path handling | `external-path.test.ts` |
+
+## CONVENTIONS
+
+- Permission behavior is expressed as **ordered** rules `{permission, pattern, action}` plus a separate `always` pattern list. Tests assert precedence, wildcard/glob matching, session scoping, and JSONL persistence — order is the contract, not a detail.
+- Services are constructed with injected fakes (`createLocalEventEmitter`, fake models/contexts) and isolated `mkdtemp` roots cleaned in `afterEach`; no ambient global state.
+- Both `describe`+`it` and `describe`+`test` appear; hooks and `vi` are imported per file rather than relying on globals.
+- Shared session/auth/resource fixtures come from the parent `../utilities.ts` (`createTestSession`, `createTestResourceLoader`, `createTestExtensionsResult`, `loadAuthStorage`).
+
+## ANTI-PATTERNS
+
+- The fixture action string `"always"` and settings values `revertPolicy: "never"` / `defaultProjectTrust: "never"` are product data — do not read them as coding directives.
+- Do not assert permission outcomes by timing; the pipeline is synchronous evaluation plus event-driven reply, so subscribe before asking and await the reply.
+- Do not bypass the parser registry when adding a rule form; new syntax is registered, then evaluated, then persisted, and all three layers have tests.
+- Do not weaken defensive-copy or insertion-order guarantees in `service.test.ts` to accommodate an implementation change.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/coding-agent test -- --run test/permission/<file>.test.ts
+npm --prefix packages/coding-agent test -- --run test/permission
+```

--- a/packages/coding-agent/test/qa/app-server/AGENTS.md
+++ b/packages/coding-agent/test/qa/app-server/AGENTS.md
@@ -1,0 +1,49 @@
+# test/qa/app-server
+
+Real-surface app-server QA drivers. 47 files + `differential/`. Score 14 — distinct domain: these are **standalone executable scenarios**, not Vitest suites, and they are excluded from the default correctness gate.
+
+## STRUCTURE
+
+```text
+task<N>-<behavior>.ts      standalone scenario programs, exit via process.exit
+task8-thread-search-support.test.ts   the one Vitest wrapper in this tree
+differential/*.mjs         Node ESM scenarios driven by scripts/qa-app-server/differential/
+differential/expected-gaps.json, capability-manifest.json   pinned expectations
+```
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Stdio client + server spawn | `task8-thread-search-support.ts` — `StdioClient`, `spawnServer`, `initialize`, `writeSession`, `WireRecord` |
+| Fuzzy QA client / port handling | `task23-fuzzy-client.ts` — `FuzzyQaClient`, `findQaPort`, `startSourceServer`, `waitForReady`, `assertPortReusable` |
+| Diff/notify client | `task24-diff-client.ts` (`Task24Client`), `task24-diff-model.ts`, `task24-diff-notify.ts` |
+| Compaction QA | `task11-compact.ts`, `task11-compact-support.ts`, `task11-zero-subscriber.ts` |
+| Differential scenario helpers | `differential/scenario.mjs` — `runAgainstEndpoints`, `startThread`, `startTurn`, `waitForNotification`, `requestResult`, `assertErrorCode`, `ScenarioError` |
+| Wire projections | `differential/projection.mjs` — `projectLifecycle`, `projectTurnLifecycle`, `projectSearch`, `projectApprovals`, `projectCompaction`, `resequence` |
+| Largest scenarios | `task9-unarchive.ts` (430 LOC), `task12b-remote-control.ts` (415) |
+
+## CONVENTIONS
+
+- Scenario files are named `task<N>-<behavior>.ts` with colocated `*-support.ts` / `*-client.ts` modules; they are run directly, not discovered by Vitest.
+- Child app-servers launch through the repo-local `node_modules/tsx/dist/cli.mjs` with explicit env overrides: `PI_OFFLINE`, `PI_TELEMETRY`, `SENPI_CODING_AGENT_DIR`, `SENPI_CODING_AGENT_SESSION_DIR`, `SENPI_TASK8_EXPERIMENTAL`.
+- Wire traffic is asserted as JSON-RPC/NDJSON over stdio, Unix socket, and WebSocket. Helpers expose typed wire records and client classes rather than generic fixtures.
+- Temp state is always `mkdtemp` under `tmpdir()`; persisted session/model fixtures are written into it.
+- Localhost port allocation and readiness are encapsulated (`findQaPort`, `canBind`, `waitForReady`, `assertPortReusable`) — do not hardcode ports in a new task.
+
+## ANTI-PATTERNS
+
+- `differential/projection.mjs`: the projection **never reorders frames or collapses duplicate notifications**. Any normalization that changes wire ordering or dedupes notifications is a defect, not a cleanup.
+- `blocked` is readable via `thread/goal/get` and agent-settable only via `update_goal`; `thread/goal/set` deliberately rejects `blocked`, `usageLimited`, and `budgetLimited`. They are not interchangeable statuses.
+- Two-tier broadcast (task8): a forbidden broadcast must error **and** must not deliver the notification to the other client.
+- Process-group cleanup is an invariant in `StdioClient.close` and the source-server helpers — killing only the direct child, or resolving before the group is gone, leaks servers into later tasks.
+
+## COMMANDS
+
+```bash
+npx tsx packages/coding-agent/test/qa/app-server/task<N>-<behavior>.ts
+npm --prefix packages/coding-agent test -- --run test/qa/app-server/task8-thread-search-support.test.ts
+npm run qa:app-server        # packaged handshake / multiclient / approval / real-client probes
+```
+
+Differential scenarios run through the repository's differential harness (`scripts/qa-app-server/differential/driver.mjs`), never as individual node invocations.

--- a/packages/coding-agent/test/suite/AGENTS.md
+++ b/packages/coding-agent/test/suite/AGENTS.md
@@ -1,0 +1,50 @@
+# test/suite
+
+Preferred harness-based coverage for `AgentSession` / `AgentSessionRuntime`, builtin extensions, app-server, goals, loops, and compaction lifecycle. 312 flat files + `regressions/` (own file). Score 20 — largest, highest-fan-in test surface in the package.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Shared session/agent fixture | `harness.ts` (`createHarness`, `Harness`, `HarnessOptions`, `getUserTexts`, `getAssistantTexts`, `getMessageText`) |
+| App-server transports/threads | `app-server-mode-harness.ts`, `app-server-mode-socket.ts`, `app-server-thread-handlers-harness.ts`, `app-server-thread-search-support.ts`, `app-server-fuzzy-test-support.ts` |
+| Goal subsystem | `goal-*.test.ts`, `goal-monitor-test-harness.ts` (`TestEventBus`, `waitForGoalStatus`) |
+| Loop scheduler/tools | `loop-*.test.ts`, `loop-guard-test-harness.ts` |
+| Hooks lifecycle/safety/trust | `hooks-*.test.ts`, `hooks-command-harness.ts` |
+| History/help UI fixtures | `history-search-fixtures.ts` (`testTheme`, `writeSessionFile`) |
+| Prompt presets / model rules | `prompt-presets-*.test.ts`, `recommended-models-harness.ts` |
+| TTSR activation asserts | `ttsr-activation-assertions.ts` (`expectTtsrActivation`) |
+| Terminal monitor notifications | `terminal-monitor-notify-harness.ts` |
+| Issue regressions | `regressions/` — see its own AGENTS.md |
+
+Local `README.md` carries the same harness/faux-provider rules; keep both in sync.
+
+## CONVENTIONS
+
+- Broad lifecycle and characterization tests go here flat; issue regressions go to `regressions/`. Nothing else nests.
+- Support modules are `*-harness.ts` / `*-support.ts` / `*-fixtures.ts` siblings (never `.test.ts`) and export their helpers directly rather than hiding behind one fixture API.
+- Harnesses inject clocks, timers, IDs, model registries, extension APIs, and faux providers. Time-dependent tests use `vi.useFakeTimers` / `advanceTimersByTimeAsync` or deferred promises — never elapsed real time.
+- App-server tests assert wire-level JSON-RPC envelopes over real WebSocket/UDS/stdio transports plus fake connections; protocol/parity tests pin generated manifests, hashes, and stable/experimental method lists.
+- State machines are asserted via typed terminal reasons, phases, delivery IDs, persisted state, event ordering, and exact call counts — `exactly once` / `at most one` are the load-bearing invariants for recovery ticks, coalesced due work, wakeups, and fallback transitions.
+- Config-reload timing tests use dynamic `import()` after env setup because timing config is read at module evaluation. This is the documented exception to the repo's top-level-import rule.
+
+## ANTI-PATTERNS
+
+- Never extend `test/test-harness.ts` (legacy) when `harness.ts` has the capability.
+- Never introduce sleeps, polling, or real-clock assertions here; the suite's whole value is deterministic scheduling.
+- Do not reuse a captured `pi` / command context after `newSession`, `fork`, `switchSession`, or `reload` — `goal-ticker-stale-context.test.ts` and `stale-extension-context-*` exist because that broke in production.
+- Goal schemas and guidance stay budget-free; legacy budget metadata is migrated away, never resurrected.
+- `app-server-thread-compact.test.ts` pins that completion emits the shared context-compaction item and **never** the deprecated notification.
+- Do not verify protocol behavior by filename or shape guessing; compare against the generated manifests.
+
+## HOTSPOTS
+
+`agent-session-compaction.test.ts` (2,214 LOC), `config-reload-extension.test.ts` (1,587), `goal-extension.test.ts` (1,081), `goal-store.test.ts` (956), `goal-monitor-continuation.test.ts` (952), `loop-scheduler.test.ts` (930), `gpt-apply-patch-extension.test.ts` (858), `loop-extension.test.ts` (789), `agent-session-queue.test.ts` (778), `retry-fallback-engine.test.ts` (743). `harness.ts` is the convergence point — changes there ripple across ~250 files.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/coding-agent test -- --run test/suite/<file>.test.ts
+npm --prefix packages/coding-agent test -- --run test/suite   # whole suite dir
+CI=1 npm --prefix packages/coding-agent test -- --run test/suite/app-server-mode-ws.test.ts
+```

--- a/packages/coding-agent/test/suite/regressions/AGENTS.md
+++ b/packages/coding-agent/test/suite/regressions/AGENTS.md
@@ -1,0 +1,41 @@
+# test/suite/regressions
+
+One-concern-per-file regression tests, 162 files / ~22,790 LOC. Score 16 — distinct naming contract and the densest compaction/queue-ownership coverage in the repo.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|------|----------|
+| Compaction admission/rejection | `pre-prompt-compaction-no-continue.test.ts` (915 LOC), `compaction-synchronous-admission.test.ts`, `compaction-rejection-feedback.test.ts` |
+| Post-compaction queue ownership | `post-compaction-queue-ownership.test.ts`, `post-compaction-queued-input-resume.test.ts`, `post-compaction-tool-continuation-deadlock.test.ts`, `post-compaction-recovery-{bounds,guards}.test.ts` |
+| Stale generation/revision races | `compaction-generation-stale-revision.test.ts`, `stale-extension-context-after-session-replacement.test.ts`, `stale-goal-direct-input.test.ts` |
+| Goal continuation caps | `goal-continuation-*.test.ts`, `issue-447-goal-continuation.test.ts`, `issue-566-goal-repetition-tool-reset.test.ts` |
+| Provider retry/timeout | `provider-idle-{recovery,steering}.test.ts`, `provider-retry-recompaction.test.ts`, `provider-timeout-classification.test.ts` |
+| Codex remote compaction | `issue-296-openai-codex-remote-compaction{,-boundaries}.test.ts` |
+| Image generation arbitration | `imagegen-arbitration.test.ts` (740 LOC, 24-row truth table) |
+| Model config/selector | `model-config-controls.test.ts`, `model-selector-favorites-search.test.ts`, `per-model-thinking-memory.test.ts` |
+| Process/inspector/Windows | `inspector-*.test.ts`, `issue-812-windows-taskkill-enoent.test.ts`, `issue-823-mcp-pgrep-pattern.test.ts` |
+
+## CONVENTIONS
+
+- Name by behavior, not source module: `issue-<number>-<slug>.test.ts` for tracked issues, `todo-<n>-<slug>.test.ts` for todo tracks, plain behavior slugs otherwise. Do not infer coverage from the filename — several issue-numbered files test broad session/compaction behavior.
+- 85 of 162 files import `../harness.ts`; the rest drive real `AgentSession` / `InteractiveMode` paths directly. Extensions are injected via `extensionFactories` and `pi.on(...)` hooks.
+- Compaction regressions deliberately configure tiny context windows / reserve tokens to force the boundary under test. Model IDs, provider IDs, canonical paths, and MCP prefixes are exact-value assertions.
+- Async coordination is deferred promises + captured event arrays + explicit release points; assertions inspect event order, queue ownership, payloads, usage, and persisted state.
+- Windows path tests construct absolute `System32`/`Sysnative` candidates while running on POSIX; that is intentional, not dead code.
+
+## ANTI-PATTERNS
+
+- Never signal PID 1; never queue more than one pending continuation; never replay stale continuations.
+- Do not continue after a rejected required compaction, and do not mutate the session while enforcing the transport image budget.
+- Provider timeout policy must not match incidental extension/error text; unsupported providers must not enter Codex remote compaction; untrusted remote base URLs must never receive Codex OAuth compaction.
+- Non-native / proxied image generation must never be reported as official native capability.
+- Extension command dispatch must not wait behind barriers (`extension-command-immediate-dispatch.test.ts`).
+- Do not convert a regression into a broad characterization test — that belongs one level up in `suite/`.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/coding-agent test -- --run test/suite/regressions/<name>.test.ts
+npm --prefix packages/coding-agent test -- --run test/suite/regressions
+```

--- a/packages/coding-agent/test/ttsr/AGENTS.md
+++ b/packages/coding-agent/test/ttsr/AGENTS.md
@@ -1,0 +1,38 @@
+# test/ttsr
+
+Coverage for the ttsr stream-rule extension (`src/core/extensions/builtin/ttsr/` — own `changes.md`): collapse and control-token-leak detectors, coordinator generation/abort races, rule parsing, repetitive-turns lane, remediation, persistence, and `/ttsr` settings. 18 files, ~3.4k LOC. Score 11 — distinct detector-grammar/evidence domain.
+
+## WHERE TO LOOK
+
+| Task | Location |
+|---|---|
+| Control-leak grammar accept/reject | `detector-control-leak-grammar.test.ts` + `control-leak-helpers.ts` (`ctrl`, `sgml`, `bracket`, `runSplitMatrix`, `expectLeakMatchEverywhere`) |
+| Control-leak evidence / negatives | `detector-control-leak-evidence.test.ts`, `detector-control-leak-negatives.test.ts` |
+| Collapse detection | `detector-collapse.test.ts` + `collapse-test-inputs.ts` |
+| Coordinator races / abort semantics | `coordinator.test.ts`, `coordinator-races.test.ts` (`claimAbort`, `createGenerationState`, `markUserCancelled`, `resolveDetection`) |
+| Rule parsing / builtin rules | `rule-parser.test.ts` |
+| Repetitive-turns lane | `repetitive-turns.test.ts` |
+| Retry integration / wiring | `integration-retry.test.ts`, `extension-wiring.test.ts` |
+| Persistence / discovery / settings | `persistence.test.ts`, `discovery.test.ts`, `settings-command.test.ts` |
+| Stream helpers | `stream-utils.test.ts` |
+
+## CONVENTIONS
+
+- Detector/grammar tests import production pure modules directly (`detectors/*`, `prompts.ts`, remediation builders) — no session harness needed for detector behavior.
+- Split-matrix discipline: inputs replay split at multiple chunk boundaries (`runSplitMatrix`) so streaming partials behave like complete text.
+- Grammar assertions pin structural facts — token ids, occurrence counts, offsets, contexts — never detector prose.
+- Integration/wiring/persistence tests use `suite/harness.ts` faux-provider sessions.
+- Negative coverage is first-class: `detector-control-leak-negatives.test.ts` and the `PLAIN_PROSE_PREFIX` guard keep ordinary prose from firing detectors.
+
+## ANTI-PATTERNS
+
+- Loosening a grammar rule to pass a model regression — add the failing token to the negatives suite instead.
+- Asserting on remediation message text; assert remediation payloads and classifications.
+- Driving detectors through full sessions when a pure import reaches the behavior.
+
+## COMMANDS
+
+```bash
+npm --prefix packages/coding-agent test -- --run test/ttsr/<file>.test.ts
+npm --prefix packages/coding-agent test -- --run test/ttsr
+```

--- a/packages/evals/AGENTS.md
+++ b/packages/evals/AGENTS.md
@@ -1,0 +1,48 @@
+# packages/evals
+
+`@code-yeongyu/senpi-evals` — behavioral, model-backed eval suites over a real
+`AgentSession`, adapted to `vitest-evals`. Earned by distinct domain: the only
+token-spending eval surface in the repo.
+
+## WHERE TO LOOK
+
+| Task | Path |
+| --- | --- |
+| Pi harness adapter | `src/pi-harness.ts` (`createPiCodingAgentHarness`) |
+| Eval suites | `src/smoke.eval.ts`, `src/extensions.eval.ts` |
+| Comparative tables, reporting | `src/vitest-evals/harness-table.ts`, `summary.ts`, `reporter.ts` |
+| Artifact recording | `src/vitest-evals/artifacts.ts` |
+| Runner | `scripts/run-evals.mjs` |
+| Unit tests (no tokens) | `test/` via `npm test` |
+
+## CONVENTIONS
+
+- One harness bound to each `describeEval(...)` suite; harness names stay
+  stable and unique within an eval set (grouping combines repetition with
+  `input.id` or a SHA-256 of canonical JSON input).
+- Runs accept one prompt or prompt/reload step sequences; `output` transforms
+  response + session into JSON-safe domain results; assert behavior on
+  `result.output` and traces on `result.session`.
+- Comparative suites use `evalHarnessTable(...)` + `describe.for(...)` with
+  deterministic or model-backed judges and `judgeThreshold: null` — low scores
+  are observations, not failures. Hard assertions only for suite invariants;
+  `expect.soft` is not a scoring mechanism.
+- The harness snapshots native session JSONL before deleting its temp
+  workspace; an eval-only `afterEach` registers it against the test task.
+- Evals run against workspace source via vitest alias config, not built
+  artifacts.
+- Each invocation writes an ignored `.eval/<timestamp>_<uuid>/` dir: `runs.jsonl`
+  indexing harness runs plus `sessions/` JSONL attachments. Artifacts may
+  contain prompts, responses, source, and tool output — treat as sensitive.
+
+## COMMANDS
+
+```bash
+npm run eval -- --provider openai --model gpt-5.6-sol   # provider+model together, or none
+PI_PROVIDER=openai PI_MODEL=gpt-5.6-sol npm run eval    # env equivalent
+npm run eval -- src/extensions.eval.ts                  # forwards file filters to Vitest
+npm run eval -- -t "<pattern>"                          # forwards -t filters
+npm test                                                # unit tests, config vitest.test.config.ts
+```
+
+`PI_EVAL_ARTIFACT_DIR` overrides the artifact directory.

--- a/packages/protocol/AGENTS.md
+++ b/packages/protocol/AGENTS.md
@@ -1,0 +1,39 @@
+# packages/protocol
+
+`@earendil-works/pi-protocol` — transport-neutral CBOR wire protocol for remote pi sessions: TypeBox schemas, message codec, byte-stream framing. Consumed by `packages/server` and `packages/client`. Node `>=22.19.0`; only dependency is `typebox`.
+
+## STRUCTURE
+
+```text
+src/index.ts        Root barrel; the package's only export
+src/schemas.ts      All TypeBox wire schemas + derived types; PROTOCOL_VERSION
+src/codec.ts        Validate/encode/parse messages; incremental decoders
+src/framing.ts      4-byte big-endian length prefix; FrameDecoder/FrameError
+src/cbor/           CBOR encoder/decoder/options with resource limits
+test/               protocol.test.ts, framing.test.ts, cbor/cbor.test.ts (Vitest)
+```
+
+## INVARIANTS
+
+- Transport-neutral: bytes in, bytes out. No socket/stream code here; callers own the transport. Incremental decoders must tolerate arbitrary fragmentation and coalescing.
+- Wire format: u32 big-endian frame length + one definite-length CBOR item. First client message is always `hello` carrying `PROTOCOL_VERSION`.
+- Every message parse goes through `codec.ts` TypeBox validation (strict objects, `additionalProperties: false`); never trust raw `decodeCbor` output as a message.
+- Resource limits are load-bearing and configurable: frame <=16 MiB (`DEFAULT_MAX_FRAME_LENGTH`), CBOR <=16 MiB bytes / 1M containers / depth 64 (cap 512). Keep them enforced.
+- `JsonValue` recursion uses `Type.Cyclic`; explicit `undefined` optional properties are omitted on wire.
+- Progress events are transient UI hints; never reduce them into authoritative session/server state.
+
+## WHERE TO LOOK
+
+| Task | Path |
+|---|---|
+| Add/change a message or field | `src/schemas.ts` (+ `test/protocol.test.ts`) |
+| Validation or encode/parse rules | `src/codec.ts` |
+| Frame layout, decoder limits | `src/framing.ts` |
+| CBOR internals / limits | `src/cbor/` |
+| Wire contract prose | `README.md` |
+
+## VALIDATION
+
+- `npm test` (Vitest `--run`) from this package; `npm run build` to typecheck against the build config.
+- Root `npm run check` after changes.
+- Schema/codec changes ripple to `packages/server` and `packages/client`; run their tests too.

--- a/packages/pty/AGENTS.md
+++ b/packages/pty/AGENTS.md
@@ -5,6 +5,7 @@
 ## STRUCTURE
 
 ```text
+src/index.ts                     Public barrel; ".", "./screen", "./registry", "./native" exports
 src/loader.ts, native-loader.ts  Native prebuild discovery and ABI checks
 src/session.ts                   Public session lifecycle
 src/session-native.ts            Native backend adapter
@@ -12,13 +13,16 @@ src/pipe-fallback.ts             child_process fallback when native is absent
 src/session-exit.ts              Exit settlement helpers
 src/registry*.ts                 Session registry and detached ownership
 src/screen.ts                    Headless terminal screen state
+src/quarantine.ts                macOS quarantine detection for prebuilds
 native/prebuilds/                Shipped platform binaries
 native/check-prebuild-fresh.mjs  Prebuild freshness gate
+test/fixtures/*.mjs              Native-addon child processes for callback/worker races
 ```
 
 ## INVARIANTS
 
 - The native ABI constant is intentionally independent of package CalVer. Keep it aligned with `crates/senpi-pty` exports.
+- macOS quarantine is probed via `xattr -p` before loading a prebuild. Detection must never clear the attribute; an unreadable attribute is non-rejecting.
 - Unsupported or missing native bindings select the pipe fallback with a diagnostic; fallback behavior must never be presented as a real PTY.
 - Exit notification settles exactly once across native exit, child exit, startup failure, kill, and disposal races.
 - `kill()` is idempotent and detached-child cleanup owns the full process tree.
@@ -29,6 +33,7 @@ native/check-prebuild-fresh.mjs  Prebuild freshness gate
 
 | Task | Path |
 |---|---|
+| Public API / subpath exports | `src/index.ts` |
 | Native loading/ABI | `src/loader.ts`, `src/native-loader.ts` |
 | Session lifecycle | `src/session.ts`, `src/session-exit.ts` |
 | Fallback process behavior | `src/pipe-fallback.ts` |

--- a/packages/senpi-codemode/AGENTS.md
+++ b/packages/senpi-codemode/AGENTS.md
@@ -2,6 +2,7 @@
 
 `@code-yeongyu/senpi-codemode` is a source-only Senpi extension that registers
 the persistent-kernel `eval` tool for JavaScript, Python, Ruby, and Julia.
+Deeper guides: `src/tool/AGENTS.md`, `src/kernels/AGENTS.md`, `test/AGENTS.md`.
 
 ## STRUCTURE
 
@@ -12,10 +13,7 @@ src/interpreters/                Interpreter availability detection (detect.ts)
 src/config/                      Settings schema, defaults, env overrides
 src/extension/                   Session generations and kernel ownership
 src/tool/                        Eval schema, cell execution, status events, rendering
-src/kernels/js/                  Worker-backed persistent JavaScript kernel
-src/kernels/py/                  Python process and transport
-src/kernels/rb/, kernels/jl/     Optional subprocess kernels
-src/kernels/shared/              Shared subprocess lifecycle and queues
+src/kernels/                     Persistent kernels: js (worker), py/rb/jl (subprocess), shared lifecycle
 src/bridge/                      Loopback bearer-auth protocol and server
 src/bridges/                     Host adapters for agent(), output(), structured schemas
 src/output/                      OutputSink, truncation metadata, artifact-path handling
@@ -27,34 +25,24 @@ test/                            Vitest contracts and the omp parity ledger
 
 ## INVARIANTS
 
-- `eval` is registered at extension load and re-registered at `session_start`
-  after settings, interpreter availability, and active task-tool names resolve.
-- Eval prompt dialect is selected from the active model id; GPT models receive a
+- `eval` registers at extension load and re-registers at `session_start` after settings, interpreter availability, and task-tool names resolve.
+- Eval prompt dialect comes from the active model id; GPT models receive the
   terse composition-forward dialect that documents detached-cell completion.
-  Host/workstation context is explicit; renderer/status semantics are structured.
-- Session generations fence old kernels and callbacks. A retired generation
-  must not emit into a newer session.
-- Kernels persist state per language, while per-cell callbacks are rebound for
-  each execution.
-- Eval runs require a `summary` written in the user's conversational language.
-  Detached cells are labeled with that summary; the old `title` field is dropped.
-- Every cell settles exactly once across success, error, timeout, abort, bridge
-  failure, and kernel crash.
+- Session generations fence old kernels and callbacks; a retired generation
+  never emits into a newer session.
+- Kernels persist state per language; per-cell callbacks rebind per execution.
+- Evals require a `summary` in the user's conversational language; detached cells carry it and the old `title` field stays dropped.
+- Every cell settles exactly once: success, error, timeout, abort, bridge failure, kernel crash.
 - Timeout and abort cleanup retires child work before ownership is released.
-- The host bridge binds loopback only, requires a per-session bearer token,
-  limits request bodies, and aborts work on disconnect.
-- `agent()` and `output()` use configured active tool names through
-  `pi.executeTool`. Do not import an orchestration workspace package here.
-- `local://` resolves under the extension-owned session artifact root. Spill
-  notices contain plain absolute paths, not a custom URI scheme.
+- The bridge binds loopback only, requires a per-session bearer token, limits
+  request bodies, and aborts work on disconnect.
+- `agent()` and `output()` use configured active tool names via `pi.executeTool`; never import an orchestration workspace package here.
+- `local://` resolves under the extension-owned session artifact root; spill notices use plain absolute paths.
 - Status events stay structured from kernel protocol through `EvalToolDetails`
-  and render output. Preserve agent-progress coalescing semantics.
-- Nested tool-call rendering is bounded and rendering-only: no session messages,
-  no extension events, and no toggle.
-- Optional interpreters are capability gaps, not installation failures;
-  JavaScript remains available on supported Node versions.
-- This package targets Node 24 or newer. Do not introduce Bun-only APIs,
-  `@oh-my-opencode` imports, or a `budget` helper.
+  to render output; preserve agent-progress coalescing.
+- Nested tool-call rendering is bounded and rendering-only: no session messages, no extension events, no toggle.
+- Optional interpreters are capability gaps, not installation failures; JavaScript remains available on supported Node versions.
+- Target Node 24+. No Bun-only APIs, `@oh-my-opencode` imports, or `budget`.
 
 ## WHERE TO LOOK
 
@@ -62,38 +50,31 @@ test/                            Vitest contracts and the omp parity ledger
 | --- | --- |
 | Register or narrow eval | `src/index.ts`, `src/tool/eval-tool.ts` |
 | Prompt behavior | `src/prompt/eval-prompt.ts` |
-| Call/result rendering | `src/tool/render.ts` |
-| Cell settlement and output | `src/tool/cell-handler.ts`, `src/output/` |
-| Detached cells | `src/tool/detached-cell-manager.ts`, `detached-cell-notification.ts`, `detached-cell-snapshot.ts`, `detached-cell-state.ts`, `detached-eval-result.ts`, `detached-notification-queue.ts`, `cell-runtime.ts` |
+| Cell execution, settlement, rendering | `src/tool/` (see `src/tool/AGENTS.md`) |
 | Interpreter detection | `src/interpreters/detect.ts` |
 | Session and kernel ownership | `src/extension/session-manager.ts`, `src/index.ts` |
 | Bridge auth and protocol | `src/bridge/` |
 | Agent/output task composition | `src/bridges/` |
-| JavaScript lifecycle and imports | `src/kernels/js/` |
-| Subprocess lifecycle | `src/kernels/shared/` and each language directory |
+| Kernel runtimes, subprocess lifecycle | `src/kernels/` (see `src/kernels/AGENTS.md`) |
+| Output sink and artifacts | `src/output/`, `src/tool/cell-handler.ts` |
 | Status and TUI/HTML rendering | `src/tool/status-events.ts`, `src/tool/render.ts` |
+| Tests and port coverage | `test/`, `test/PARITY.md` (see `test/AGENTS.md`) |
 | Real-surface QA | `scripts/qa-*.ts` |
-| Port coverage mapping | `test/PARITY.md` |
 
 ## QUALITY GATES
 
 - Add or update a focused Vitest contract before changing runtime behavior; run
   it red, then green.
 - Run `npm test` from this package and `npm run check` from the repository root
-  before committing code or packaging changes.
-- Run the relevant `scripts/qa-*.ts` driver when changing a kernel, bridge,
-  extension lifecycle, output sink, or renderer. Capture evidence without
-  tokens, headers, cookies, or raw environment dumps.
-- Keep TypeScript erasable and strict: no `any`, assertions, non-null
-  assertions, ignored diagnostics, or dynamic imports outside documented
-  boundaries.
-- Keep renderer imports out of `src/output/`; output collection is a runtime
-  layer and must not create a renderer dependency cycle.
-- Direct dependencies are exact-pinned. Refresh locks with
-  `npm install --ignore-scripts`; use `PI_ALLOW_LOCKFILE_CHANGE=1` only when the
-  lockfile policy permits the intentional change.
-- Documentation must describe the current tool contract. Update README settings
+  before committing.
+- Run the relevant `scripts/qa-*.ts` driver for kernel, bridge, extension,
+  output, or renderer changes; capture evidence without secrets.
+- TypeScript stays erasable and strict: no `any`, assertions, non-null
+  assertions, ignored diagnostics, or undocumented dynamic imports.
+- Renderer imports stay out of `src/output/` — no renderer dependency cycle.
+- Direct dependencies stay exact-pinned; lock refreshes follow root lockfile policy.
+- Documentation must describe the current tool contract; update README settings
   and helper tables with every user-visible surface change.
 
 ---
-Generated: 2026-08-07 | Commit `4f26b8282`
+Generated: 2026-08-24 | Commit `baf15a54d`

--- a/packages/senpi-codemode/src/kernels/AGENTS.md
+++ b/packages/senpi-codemode/src/kernels/AGENTS.md
@@ -1,0 +1,40 @@
+# src/kernels
+
+Persistent kernels for four runtimes plus shared subprocess lifecycle. Earned
+by score 13 — distinct multi-runtime domain (31 files, TS hosts plus embedded
+runner/prelude assets).
+
+## WHERE TO LOOK
+
+| Task | Path |
+| --- | --- |
+| JavaScript host API | `js/context-manager.ts` (`JavaScriptKernel`), `js/worker-host.ts` |
+| JS worker runtime, entries | `js/worker-runtime.js`, `js/worker-entry.js`, `js/inline-worker-entry.js`, `js/inline-worker.ts`, `js/worker-core.js` (+ `worker-core.d.ts`) |
+| JS import rewriting, queueing | `js/rewrite-imports.ts`, `js/run-queue.ts`, `js/prelude.ts`, `js/local-module-loader.ts` |
+| Python kernel | `py/kernel.ts`, `py/transport.ts`, `py/process.ts`, `py/prelude.py` |
+| Ruby kernel | `rb/kernel.ts` + `rb/prelude.rb`, `rb/runner.rb` |
+| Julia kernel | `jl/kernel.ts` + `jl/prelude.jl`, `jl/runner.jl` |
+| Shared subprocess layer | `shared/subprocess-kernel.ts`, `subprocess-{contract,process,queue,run}.ts`, `runtime-asset.ts` |
+
+## CONVENTIONS
+
+- Each language dir pairs a typed TS host/controller with an embedded runner or
+  prelude asset; `shared/runtime-asset.ts` ships them.
+- Transport messages are discriminated by string `type` (`ready`, `result`,
+  `tool-call`, `closed`, `init-failed`, ...) exchanged as framed bridge
+  messages, one JSON line per frame.
+- JS persistent cell bindings are rewritten onto `globalThis`; imports are
+  AST-parsed (Babel) and rewritten to bridge-compatible dynamic imports.
+- JS runs on worker threads with an inline-worker fallback; py/rb/jl run as
+  framed subprocesses through `shared/`.
+- Subprocess retirement/restart, worker recovery, timeout, and interrupt
+  semantics live here, never in the tool layer.
+
+## ANTI-PATTERNS
+
+- Never treat arbitrary objects as bridge messages without discriminant
+  validation.
+- Never rewrite imports by filename/regex — `rewrite-imports.ts` applies
+  source-position edits from the parsed program.
+- An optional interpreter being absent (py/rb/jl not installed) is a capability
+  gap, not an installation failure or error path.

--- a/packages/senpi-codemode/src/tool/AGENTS.md
+++ b/packages/senpi-codemode/src/tool/AGENTS.md
@@ -1,0 +1,40 @@
+# src/tool
+
+Eval tool core: input schema, cell execution lifecycle, detached-cell state
+machine, status events, and all call/result rendering. Earned by score 12 —
+highest reference density in the package (`createEvalTool` and `EvalToolDetails`
+anchor most suites).
+
+## WHERE TO LOOK
+
+| Task | Path |
+| --- | --- |
+| Tool registration, options | `eval-tool.ts`, `eval-tool-options.ts`, `eval-request.ts` |
+| Wire contract, TypeBox schemas | `types.ts` (`createEvalInputSchema`, `fullEvalInputSchema`) |
+| Cell execution, settlement | `cell-handler.ts`, `cell-execution.ts`, `cell-runtime.ts` |
+| Detached cells | `detached-cell-manager.ts` + `detached-cell-{state,snapshot,notification}.ts`, `detached-notification-queue.ts`, `detached-eval-result.ts` |
+| Call/result rendering | `render.ts`, `runtime-label.ts`, `json-tree.ts`, `image.ts`, `tool-widgets.ts` |
+| Status events, execution events | `status-events.ts`, `eval-execution-event.ts` |
+| Interrupt, capture | `interrupt-note.ts`, `call-capture.ts` |
+
+## CONVENTIONS
+
+- Wire/schema fields are snake_case (`cell_id`, `on_timeout`); internal TS
+  fields are camelCase. Schemas and shared eval types live only in `types.ts`.
+- Rendering is bounded by explicit line/code-point budgets with an injectable
+  render clock; nothing here depends on wall-clock luck.
+- Detached execution is a first-class state machine — snapshot, notification
+  queue, spill-file notice, result conversion — never folded into ordinary
+  cell execution.
+- Unicode tree glyphs and status icons are intentional UI conventions.
+
+## ANTI-PATTERNS
+
+- Never add unbounded output: previews, JSON tree depth/lines/scalar length,
+  widget lines, and collapsed errors all cap.
+- Never bypass the kernel bridge message contract with ad-hoc return values;
+  kernels import `KernelInterruptHandle` from `types.ts`, so discriminants and
+  lifecycle state are cross-runtime contracts — change them only with all four
+  runtimes and the detached path in mind.
+- `render.ts` (1,030 LOC) is the package's largest file and the highest-risk
+  hotspot for regressions; changes there need render contracts first.

--- a/packages/senpi-codemode/test/AGENTS.md
+++ b/packages/senpi-codemode/test/AGENTS.md
@@ -1,0 +1,47 @@
+# test
+
+Vitest contracts for the codemode package plus the port-coverage parity ledger.
+Earned by score 15 — contract layer and fixture hub (95 code files, ~12k LOC).
+
+## WHERE TO LOOK
+
+| Task | Path |
+| --- | --- |
+| Shared fakes, fixtures | `eval/fakes.ts` (`FakeKernel`, `FakeManager`), `eval-render-fixtures.ts` |
+| Render contracts | `eval-render*.test.ts` family, `json-tree.test.ts`, `tool-widgets.test.ts` |
+| Kernel contracts | `js-kernel*.test.ts`, `py-kernel*.test.ts`, `rb-kernel.test.ts`, `kernels/rb/`, `jl-kernel.test.ts` |
+| Detach, interrupt, timeouts | `eval-detach*.test.ts`, `eval-tool-interrupt.test.ts`, `timeouts.test.ts`, `eval-hard-limit.test.ts` |
+| Bridge protocol, servers | `bridge-protocol.test.ts`, `bridge-server*.test.ts`, `agent-bridge.test.ts`, `schema-bridge.test.ts` |
+| Extension/session lifecycle | `extension.test.ts`, `session-manager*.test.ts`, `factory.test.ts` |
+| Output sink | `output/` |
+| Prompt snapshots | `prompt.test.ts`, `__snapshots__/` |
+| Port coverage mapping | `PARITY.md` |
+
+## CONVENTIONS
+
+- Import `describe`/`it`/`expect`/`vi` explicitly; no ambient globals.
+- Source imports are direct relative `.ts` paths; test-only fixtures live in
+  `test/eval/` and `eval-render-fixtures.ts`.
+- Async behavior is asserted via promise resolution/rejection and fake timers
+  (`vi.useFakeTimers`, `advanceTimersByTime`); `setTimeout` appears only in
+  intentional crash/deadline fixtures; `vi.waitFor` stays event/state based.
+- Titles are behavior-oriented, often Given/When; parity suites compare
+  JS/Python/Julia/runtime output and error behavior.
+- `SIZE_OK` allowance marks the intentionally large parity suite.
+
+## ANTI-PATTERNS
+
+- Reserved schema/agent/output tools must never execute or surface as ordinary
+  agent tools; `tool_schema()` must not execute tools.
+- Late bridge resumes must not revive detached/dead cells; no second interrupt
+  after hard-limit settlement; detached cells are never re-run or replayed as
+  synthetic user input.
+- Legacy stored `title` without `summary` must not crash or emit a label line.
+- Errors omit success previews; status histories and live previews stay bounded.
+
+## COMMANDS
+
+```bash
+npm test                                                              # whole suite, from package root
+npx tsx ../../node_modules/vitest/dist/cli.js --run test/eval-render.test.ts  # one file
+```

--- a/packages/server/AGENTS.md
+++ b/packages/server/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/server
 
-Commit: `4f26b8282` (2026-08-07)
+Commit: `baf15a54d` (2026-08-24)
 
 `@code-yeongyu/senpi-server` is an experimental private package. It is a composable, transport-neutral protocol server built on `@earendil-works/pi-protocol`. The old daemon/IPC/Radius stack under `src/legacy/` and the `server` CLI bin were removed upstream in v0.84.1; applications supply their own `PiServerService`. Node `>=22.19.0`.
 
@@ -15,9 +15,9 @@ src/connection.ts        ByteConnection, handler, ConnectionState stages
 src/sessions.ts          LiveSessionManager: session runtimes + subscriber fanout
 src/snapshots.ts         ServerSnapshotPublisher: revisioned server-snapshot broadcast
 src/errors.ts            PiServerError
-src/types.ts             PiServerOptions, PiSessionBackend, PiSessionRuntime
+src/types.ts             PiServerOptions, PiServerService, PiSessionRuntime
 src/transports/unix/     createUnixListener, createUnixServer preset
-src/testing/             TestSessionBackend, ProtocolTestClient, createTestServer
+src/testing/             TestServerService, TestSessionRuntime, ProtocolTestClient, createTestServer
 ```
 
 Package exports: `.` (core), `./testing`, `./unix`.
@@ -25,7 +25,9 @@ Package exports: `.` (core), `./testing`, `./unix`.
 ## INVARIANTS
 
 - Transports are byte-level only. `ByteConnection` gives an ordered byte sink; all framing, hello handshake, and protocol-version checks belong to `PiServer` in `src/server.ts`.
-- Handshake is bounded (5s default timeout) and auth compares token hashes with `timingSafeEqual`; never short-circuit with string equality.
+- Handshake is bounded (5s default timeout) and validates the protocol version.
+  Authentication is transport/application-specific; `PiServer` performs no token auth
+  (upstream #7551) — never add string-compare token checks to the core.
 - Connection stages progress `awaitingHello -> handshaking -> ready -> closing -> closed`; dispatch only after `ready`.
 - `LiveSessionManager` owns runtime lifecycle: unsubscribe on dispose, settle in-flight operations on disconnect, guard double-dispose via the `disposing` promise.
 - Snapshot broadcasts serialize through `broadcastQueue` and carry a monotonic revision; do not publish out of order.
@@ -40,7 +42,7 @@ Package exports: `.` (core), `./testing`, `./unix`.
 | Session runtime lifecycle | `src/sessions.ts`, `src/types.ts` |
 | Server snapshot fanout | `src/snapshots.ts` |
 | Add a transport | `src/listener.ts`, `src/connection.ts`, `src/transports/unix/` as template |
-| Unix socket specifics (stale sockets) | `src/transports/unix/listener.ts`, `test/unix.test.ts`, `test/fixtures/stale-socket-server.mjs` |
+| Unix socket specifics (stale sockets) | `src/transports/unix/listener.ts`, `test/unix.test.ts`, `test/unix-connection.test.ts`, `test/fixtures/stale-socket-server.mjs` |
 | Test harness/backend fakes | `src/testing/` |
 | Protocol conformance | `test/conformance.test.ts`, `test/protocol.test.ts` |
 
@@ -49,3 +51,6 @@ Package exports: `.` (core), `./testing`, `./unix`.
 - `npm test` (Vitest) from this package; root `npm run check` after code changes.
 - Add lifecycle tests for handshake timeout, disconnect mid-operation, duplicate close, and stale-socket takeover.
 - Inspect logs and fixtures for secret safety before committing.
+
+---
+Updated: 2026-08-24 | Commit `baf15a54d` (was `4f26b8282`)

--- a/packages/session-backends/sqlite-node/AGENTS.md
+++ b/packages/session-backends/sqlite-node/AGENTS.md
@@ -1,0 +1,52 @@
+# packages/session-backends/sqlite-node
+
+`@earendil-works/pi-storage-sqlite-node` (private). Node `node:sqlite` backend for
+`@earendil-works/pi-agent-core` sessions; vendored from upstream pi. Node `>=22.19.0`.
+Score 16: 50 files, 6 subdirs, dense typed SQL layer with its own migration pipeline.
+
+## STRUCTURE
+
+```text
+src/index.ts              wrapNodeSqliteDatabase / createNodeSqliteFactory + re-exports sqlite/
+src/sqlite/repo.ts        SqliteSessionRepository — repository/storage orchestration (953 LOC hotspot)
+src/sqlite/sql.ts         Tagged-template `sql` helper
+src/sqlite/migrations.ts  Migration runner; SQL files in src/sqlite/migrations/
+src/sqlite/storage/       Per-table modules: sessions, entries, records, lanes, facts,
+                          branch-entries, branch-tips, branch-cache, session-sequences,
+                          session-stats, writer-leases
+src/sqlite/search-backend.ts   FTS/search over stored entries
+scripts/prepare-dist.mjs  `copy-sqlite-migrations` build step
+test/                     11 Vitest files (repository, adapter, branch-query, writer-leases...) + test-utils
+```
+
+Package exports only `.` (dist/index.js). Migrations are plain `.sql` files copied into
+`dist/` by the build script — never inline SQL changes without adding a migration.
+
+## WHERE TO LOOK
+
+| Task | Path |
+|---|---|
+| New stored field / table | `src/sqlite/storage/` + new `NNN_*.sql` migration |
+| Session lifecycle, decoding, writer leases | `src/sqlite/repo.ts` |
+| Branch resolution / caching | `src/sqlite/branch-cache.ts`, `storage/branch-*.ts` |
+| Search | `src/sqlite/search-backend.ts`, `test/search.test.ts` |
+| node:sqlite adapter quirks | `src/index.ts` |
+
+## CONVENTIONS
+
+- ESM with `.ts`-suffixed relative imports; `tsc -p tsconfig.build.json` build.
+- `npm run build` runs `prepare-dist.mjs copy-sqlite-migrations` after `tsc`.
+- Tests are Vitest (`npm test` -> `vitest --run`), not the Node test runner.
+- Storage functions are named `read/insert/delete/create*` per table module.
+
+## ANTI-PATTERNS
+
+- Transaction callbacks must be synchronous and must not return a promise —
+  `NodeSqliteDatabase.transaction` throws `TypeError` on async results (`BEGIN IMMEDIATE`).
+- Rollback errors are intentionally ignored so the original transaction error is rethrown;
+  don't add rollback error propagation.
+- Writer leases guard serialized writes; don't bypass `repo.ts` orchestration by calling
+  storage modules directly from outside the package.
+
+---
+Generated: 2026-08-24 | Commit `baf15a54d`

--- a/packages/telemetry/AGENTS.md
+++ b/packages/telemetry/AGENTS.md
@@ -1,0 +1,57 @@
+# packages/telemetry
+
+`@earendil-works/pi-telemetry` (private). Vendor-neutral telemetry contracts and typed
+schema utilities: explicit context/span types, a NOOP context, an in-memory reference
+adapter, and compile-time schema inference. No exporter, backend, or global state.
+Score 11: distinct domain — dense type-level API with strict lifecycle invariants.
+
+## STRUCTURE
+
+```text
+src/index.ts        TelemetryContext/Span types, schema definitions, defineTelemetrySchema,
+                    createTypedSpanStarter; re-exports noop + memory
+src/noop.ts         NOOP_TELEMETRY_CONTEXT
+src/memory.ts       InMemoryTelemetryContext, RecordedTelemetrySpan/Event
+src/testing/        createTelemetryAdapterConformance — adapter conformance suite (subpath ./testing)
+test/               telemetry + conformance Vitest files
+```
+
+## INVARIANTS
+
+- Contexts propagate explicitly through function arguments. NO ambient current-span, no
+  `AsyncLocalStorage`, no global registry, no backend dependency.
+- Span lifecycle is callback-owned: the callback runs synchronously exactly once; the
+  returned promise controls settlement; recording methods are synchronous and passive;
+  calls after settlement are inert.
+- Schemas are compile-time only: `defineTelemetrySchema` values drive type inference and
+  duplicate-name rejection; there is no runtime schema validation.
+- Attributes are primitive scalars or readonly arrays; `undefined` is ignored; later values
+  overwrite earlier ones; end attributes are always optional enrichment; exact mapped
+  types reject undeclared keys.
+- The in-memory adapter returns detached snapshots in span-start order with deterministic
+  numeric IDs and no timestamps; storage is process-local and intentionally unbounded.
+
+## WHERE TO LOOK
+
+| Task | Path |
+|---|---|
+| Add/extend a schema | `src/index.ts` (schema + inference types), patterns in `test/telemetry.test.ts` |
+| Write an adapter (OTel, Sentry, logs) | implement `TelemetryContext`, then run `src/testing/conformance.ts` suite against it |
+| Assert spans in tests | `InMemoryTelemetryContext` snapshots |
+
+## ANTI-PATTERNS
+
+- Don't persist telemetry contexts/spans in records, messages, snapshots, or deferred
+  handles; keep prompts, completions, tool payloads, file contents, credentials, and
+  free-form error details OUT of attributes unless the schema explicitly allows them.
+- Don't turn recording failures into application failures — implementations swallow
+  unreadable payloads and fall back without changing callback behavior.
+- Don't add runtime validation or ambient span state; both are deliberate exclusions.
+
+## COMMANDS
+
+- `npm test` (vitest --run), `npm run build` (`tsgo -p tsconfig.build.json`), `npm run clean`.
+- Repository-wide `npm run check` from root after changes.
+
+---
+Generated: 2026-08-24 | Commit `baf15a54d`

--- a/packages/tui/AGENTS.md
+++ b/packages/tui/AGENTS.md
@@ -1,6 +1,6 @@
 # packages/tui
 
-Commit: `abae968e8` (2026-08-17)
+Commit: `baf15a54d` (2026-08-24)
 
 `@earendil-works/pi-tui` is the standalone terminal renderer/editor library used by Senpi interactive mode. Rendering uses synchronized, differential frames and must preserve terminal ownership boundaries.
 
@@ -20,22 +20,19 @@ src/components/v-stack.ts   VStack; h-stack.ts HStack; spacer.ts Spacer
 src/components/scroll-view.ts  ScrollView with scrollbar options
 src/keybindings.ts          Configurable default bindings
 src/keys.ts                 Key parsing and matching
+src/utils.ts                Width, wrapping, ANSI segmentation, output normalization
 src/stdin-buffer.ts         Paste/input framing
 src/terminal-image.ts       Kitty/iTerm image paths
 src/dollar-invocation-autocomplete.ts  $-invocation suggestions for the editor
 src/changes.md              Fork render behavior
 test/*.test.ts              Node test-runner coverage
-bench/frame-cost.ts         Frame cost benchmark (see test/frame-cost-harness.test.ts)
+bench/                      frame-cost, editor-layout, markdown-render benchmarks
+native/                     Optional Darwin/Win32 modifier binaries (prebuilt, lazy-loaded)
 ```
-
-Root `tui-plan.md` is the design doc for the alternate-screen layout system (landed 2026-07-31).
-
-Public exports include `VStack`, `HStack`, `ScrollView`, `Spacer`, `TuiAltScreen`, `TuiMainScreen`, `Container`, `CURSOR_MARKER`, `isViewportTUI`, and `ViewportTUI` (see `src/index.ts`).
 
 ## RENDERING CONTRACT
 
-- Balanced synchronized-output and autowrap frame guards are mandatory on every render path.
-- Stable-width streaming updates must remain differential and must not introduce clear-screen operations.
+- Balanced synchronized-output/autowrap frame guards on every render path; stable-width streaming updates stay differential with no clear-screen operations.
 - Resize, recovery, scrollback replay, multiplexer, and image branches may legitimately repaint or clear when their contracts require it.
 - `start()` and `stop()` reset queued render state so stale scheduled frames cannot leak across lifecycles.
 - `ProcessTerminal` owns external stdout while running; components must not write around it.
@@ -47,17 +44,14 @@ Public exports include `VStack`, `HStack`, `ScrollView`, `Spacer`, `TuiAltScreen
 
 | Task | File |
 |---|---|
-| Flicker, cursor, viewport | `src/tui.ts` |
+| Flicker, cursor, viewport (`isViewportTUI`, `VIEWPORT_TUI`) | `src/tui.ts` |
 | Alt-screen rendering, scroll wheel/keys routing | `src/tui-alt-screen.ts` |
 | Layout rects, clipping, scrollbar geometry | `src/layout.ts`, `src/layout-node.ts` |
 | Stack sizing, scrollable regions | `src/components/stack.ts`, `src/components/scroll-view.ts` |
-| Viewport contract checks | `src/tui.ts` (`isViewportTUI`, `VIEWPORT_TUI`) |
-| Terminal lifecycle/title | `src/terminal.ts` |
-| Child process terminal | `src/terminal.ts` (`ProcessTerminal`) |
+| Terminal lifecycle/title, child process terminal | `src/terminal.ts` (`ProcessTerminal`) |
 | Key parsing/defaults | `src/keys.ts`, `src/keybindings.ts` |
 | Paste handling | `src/stdin-buffer.ts` |
-| Width/wrapping | `src/utils.ts` |
-| Terminal-output normalization/tab width | `src/utils.ts` (`normalizeTerminalOutput`, `visibleWidth`) and `src/tui.ts` |
+| Width/wrapping, output normalization, tab width | `src/utils.ts` (`normalizeTerminalOutput`, `visibleWidth`) |
 | Images | `src/terminal-image.ts` |
 | $-invocation autocomplete | `src/dollar-invocation-autocomplete.ts`, `src/autocomplete.ts` (`CombinedAutocompleteProvider`) |
 
@@ -82,3 +76,4 @@ Public exports include `VStack`, `HStack`, `ScrollView`, `Spacer`, `TuiAltScreen
 - Rendering changes must include focused headless-terminal assertions and preserve flicker budgets.
 - Runtime changes require root `npm run check`, `senpi-qa` TUI smoke evidence, and visual terminal QA.
 - Read `src/changes.md` before altering renderer or loader behavior.
+- Native modifier binaries: `npm run build:native:darwin`; `npm run build:native:win32` (toolchain via `PI_TUI_WIN32_TOOLCHAIN=msvc|mingw`).

--- a/packages/tui/src/AGENTS.md
+++ b/packages/tui/src/AGENTS.md
@@ -1,0 +1,39 @@
+# packages/tui/src
+
+Score: 34 (33 files, barrel at `index.ts`, highest reference centrality in the package).
+
+Rendering engine, input/terminal protocol modules, and the fork-delta ledger. The package-level rendering contract and ownership rules live in `../AGENTS.md`; this file covers module-level operations.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Render scheduling, diffing, viewport remap, scrollback replay, Kitty-image invalidation | `tui.ts` (`TuiBase.doRender()` and frame-guard paths) |
+| Key protocol parsing/matching (Kitty keyboard, legacy sequences, modifyOtherKeys) | `keys.ts` |
+| Namespaced default bindings | `keybindings.ts` |
+| Stdin framing, bracketed paste | `stdin-buffer.ts` |
+| Kitty/iTerm2/tmux image paths | `terminal-image.ts`, `tmux-image-capability.ts`, `tmux-image-probe.ts` |
+| Autocomplete provider contracts, `$`/`/` mixing | `autocomplete.ts` (`CombinedAutocompleteProvider`) |
+| Image/paste marker registries, canonicalization | `image-markers.ts`, `paste-markers.ts` |
+| Editor primitives shared with the component `Editor` | `kill-ring.ts`, `undo-stack.ts`, `word-navigation.ts` |
+| Public API surface | `index.ts` — barrel; the coupling point for `coding-agent` and `senpi-codemode` |
+| Fork render-behavior history | `changes.md` |
+
+Public exports include `VStack`, `HStack`, `ScrollView`, `Spacer`, `TuiAltScreen`, `TuiMainScreen`, `Container`, `CURSOR_MARKER`, `isViewportTUI`, and `ViewportTUI`.
+
+Design doc for the alternate-screen layout system (landed 2026-07-31): root `tui-plan.md`.
+
+## CONVENTIONS
+
+- Keybinding IDs are namespaced (`tui.editor.*`, `tui.input.*`, `tui.select.*`, `tui.altScreen.*`) and centrally managed via `KeybindingsManager`; components consume them, never define them.
+- Markers (paste, image) are atomic, registry-backed, and canonicalized/renumbered on every mutation; they transfer through the paired optional state APIs.
+- Terminal protocols are modeled explicitly: Kitty keyboard, legacy sequences, modifyOtherKeys level detection, tmux focus/passthrough, OSC color queries (`terminal-capabilities.ts`, `native-modifiers.ts`, `tmux-focus.ts`).
+- Native capabilities load lazily and degrade to `undefined`; never a hard dependency.
+- All width/wrap/segment math goes through `utils.ts` primitives (`visibleWidth`, `wrapTextWithAnsi`, `sliceByColumn`, `extractSegments`) — never hand-rolled string slicing.
+- `utils.ts` uses a bounded/rotating width cache and a pooled ANSI style tracker; `__widthCacheStats()` exposes cache diagnostics for tests.
+
+## ANTI-PATTERNS
+
+- Empty autocomplete text must not trigger file suggestions; only forced Tab completion does (`autocomplete.ts`).
+- Render containment must not implicitly steal or clear focus ownership (`tui.ts`).
+- A pending visibility change that has not rendered yet must not erase content (`tui.ts`).

--- a/packages/tui/src/components/AGENTS.md
+++ b/packages/tui/src/components/AGENTS.md
@@ -1,0 +1,32 @@
+# packages/tui/src/components
+
+Score: 21 (18 files, >10 exports, high external reference centrality from `coding-agent` and `senpi-codemode`).
+
+Terminal component library: text, markdown, editor, selectors, stacks, images, loaders. Rendering contract and terminal-ownership rules live in `../../AGENTS.md`; width primitives in `../utils.ts`.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Multiline editor: markers, history, undo, autocomplete, wrapping | `editor.ts` — dominant hotspot (~2.6k LOC) |
+| Markdown rendering, highlighting, tables, LaTeX | `markdown.ts`, `latex.ts` |
+| Single-line input | `input.ts` |
+| Select/settings lists | `select-list.ts`, `settings-list.ts` |
+| Scrollable regions | `scroll-view.ts` |
+| Size allocation shared by both stack directions | `stack.ts` (`allocateStackSizes`) |
+| Layout wrappers | `v-stack.ts`, `h-stack.ts`, `spacer.ts` |
+| Images, boxes, loaders | `image.ts`, `box.ts`, `loader.ts`, `cancellable-loader.ts` |
+| Alt-screen flash overlay | `alt-screen-flash.ts` |
+
+## CONVENTIONS
+
+- Components implement `Component.render(width)`-style text rendering; grapheme/CJK/emoji-aware width comes from `../utils.ts` (`Intl.Segmenter` + East Asian width), not local arithmetic.
+- Stack sizing uses basis/grow/shrink/min/max plus `visible` flags; `VStack` and `HStack` share `stack.ts` allocation.
+- `ScrollView` owns scrolling and takes exactly one immutable child; invalid axis or child mutation throws (`scroll-view.ts`).
+- High-frequency components memoize aggressively: `Editor` and `Markdown` hold substantial render/highlight caches — preserve them.
+
+## ANTI-PATTERNS
+
+- Mutating or removing a `ScrollView` child after construction.
+- Width math bypassing `../utils.ts`.
+- Unbounded caches; the `utils.ts` width cache is bounded/rotating — follow that pattern.

--- a/packages/tui/test/AGENTS.md
+++ b/packages/tui/test/AGENTS.md
@@ -1,0 +1,30 @@
+# packages/tui/test
+
+Score: 23 (77 files; `VirtualTerminal` imported by 65 of them).
+
+`node:test` suite asserting rendered escape sequences against a simulated terminal. Test command and multiplexer setup are in `../../AGENTS.md`.
+
+## WHERE TO LOOK
+
+| Task | File |
+|---|---|
+| Terminal simulation helper | `virtual-terminal.ts` — `VirtualTerminal`: `write`/`resize`/`flush`/`getViewport`/`getScrollBuffer`/`waitForRender` |
+| Shared themes | `test-themes.ts` — `defaultSelectListTheme`, `defaultMarkdownTheme`, `defaultEditorTheme` |
+| Editor behavior | `editor.test.ts` (~4.4k LOC, 219 cases: autocomplete, history, Unicode, wrapping, markers, sticky columns) |
+| Core render/diff, alt-screen, overlays | `tui-render.test.ts`, `tui-alt-screen.test.ts`, `overlay-non-capturing.test.ts` |
+| Forbidden-regression guards | `external-stdout-guard.test.ts`, `cursor-write-hygiene.test.ts` |
+| Perf harness | `perf-trend-local.test.ts`, `render-churn-bench.ts` (inspector profiles), `frame-cost-harness.test.ts` (validates the bench JSON) |
+| Multiplexer environment | `setup-multiplexer-env.mjs` (imported globally by the test script) |
+
+## CONVENTIONS
+
+- Assert exact ANSI/OSC/APC bytes and viewport/scroll-buffer state via `VirtualTerminal` — never DOM or snapshot abstractions.
+- Naming is behavior-oriented: `regression-*`, `*-characterization`, `*-contract`, `*-repro`.
+- Filesystem autocomplete tests build isolated tmpdir trees and mock `fd` discovery; quoted paths, symlinks, hidden files, and `./` prefixes are explicit seams.
+- Non-`*.test.ts` files are runnable utilities outside the runner glob: `chat-simple.ts`, `image-test.ts`, `key-tester.ts`, `mux-scrollback-harness.ts`, `viewport-overwrite-repro.ts`, `render-churn-bench.ts`.
+- `stdin-buffer.test.ts` deliberately supports both `node:test` and Vitest APIs through a compat wrapper.
+
+## ANTI-PATTERNS
+
+- New tests synchronize on render/event signals (`waitForRender`, flush) — never fixed `setTimeout` sleeps. Legacy sleeps in `loader.test.ts`, `layout.test.ts`, `editor.test.ts`, `chat-simple.ts` must not be extended.
+- Do not relax byte-exact terminal assertions; characterization contracts pin cursor/clear/SGR/OSC sequences.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -4,101 +4,76 @@ Build, validation, release, publish, lockfile, and environment tooling for the s
 
 ## Script anatomy
 
-All `.mjs` files carry `#!/usr/bin/env node` and run as ES modules.
-Shell wrappers `devenv-setup.sh` and `devenv-setup.ps1` locate Node and delegate to `devenv-setup.mjs`; they own no logic of their own.
-Colocated `*.test.mjs` files run via root `npm run test:scripts` (`node --test scripts/*.test.mjs`).
-Root `package.json` runs `preinstall: node scripts/create-bin-stubs.mjs`.
-`scripts/qa/` holds QA render drivers and fixtures.
-
-## Naming convention
+All `.mjs` files carry `#!/usr/bin/env node` and run as ES modules; `devenv-setup.sh`/
+`.ps1` locate Node and delegate to `devenv-setup.mjs` (they own no logic). Colocated
+`*.test.mjs` run via root `npm run test:scripts`; root `preinstall` runs
+`create-bin-stubs.mjs`. `scripts/qa/` render assertions go through `xterm-render.mjs`'s
+cell grid. Prefixes encode role:
 
 | Prefix | Role |
 |--------|------|
-| `build-*` | Compile and bundle steps |
-| `check-*` | Validation and gate scripts |
-| `create-*` | Stub/wrapper creation (`create-bin-stubs.mjs`, `create-root-senpi-wrapper.mjs`) |
-| `generate-*` | Artifact generation (shrinkwrap, install-lock) |
-| `prepare-*` | Publish staging |
-| `release-*` | Sub-tasks composed by `release.mjs` |
-| `publish-*` | npm publish workflows |
-| `sync-*` | Version synchronization |
+| `build-*` / `create-*` / `check-*` / `audit-*` / `generate-*` / `hydrate-*` | Build, stubs, gates, lock generation |
+| `prepare-*` / `materialize-*` / `sync-*` / `copy-*` | Staging, runtime materialization, sync, sidecars |
+| `release-*` / `publish-*` | Release orchestration and npm publish |
 
 ## Key entry points
 
 - `build-all.mjs`: PM-agnostic build orchestrator. Detects npm/Bun/pnpm via `npm_execpath`
-  and `npm_config_user_agent`; strips pnpm-only `npm_config_*` env keys before spawning
-  children. `BUILD_PHASES` is an exported constant; tests consume it directly.
+  and `npm_config_user_agent`; strips pnpm-only `npm_config_*` env keys before spawning.
+- `release.mjs`: CalVer release composing `calver.mjs` and
+  `release-{packages,artifacts,changelog,git,test-gate}.mjs`. Preflight: on `main`, clean tree
+  (dry-run warns), valid CalVer; `--dry-run` previews every command and file write.
+- `publish.mjs`: publishes seven fork-owned packages (`senpi-ai`, `senpi-agent-core`, `senpi-tui`,
+  `senpi-pty`, `senpi-telemetry`, `senpi-codemode`, `senpi`); sources stay `private`, copied to
+  temporary public manifests under the fork scope (`@code-yeongyu/senpi-server` stays excluded).
+  Provenance requires GitHub Actions (`publish-command.mjs` throws outside it);
+  `local-release.mjs` smoke-tests a release to a temp dir without pushing tags.
+  `build-binaries.sh` mirrors `.github/workflows/build-binaries.yml` locally;
+  `prepare-bun-compile-assets.mjs` + `smoke-standalone-binary.mjs` cover standalone binaries.
+- Lock plumbing: `generate-coding-agent-{shrinkwrap,install-lock}.mjs`,
+  `generate-claude-agent-sdk-platform-lock.mjs`, `hydrate-lock-registry-metadata.mjs`,
+  `materialize-publish-runtime.mjs`, `npm-pack-json.mjs`, helpers in `install-lock-*.mjs`;
+  root `npm run refresh-lock` chains them.
+- Gates/catalog: `check-pr-changelog.mjs`, `check-upstream-release.mjs`, `check-pinned-deps.mjs`,
+  `check-ts-relative-imports.mjs`, `check-browser-smoke.mjs`, `diff-model-catalog.mjs`,
+  `publish-model-catalog.mjs`, `generate-thinking-capabilities.mjs` — `npm run check` chains them.
 
-- `release.mjs`: CalVer release. Composes `calver.mjs`, `release-packages.mjs`,
-  `release-artifacts.mjs`, `release-changelog.mjs`. Pre-flight checks run in sequence:
-  must be on `main`, working tree must be clean (dry-run only warns), computed version
-  must be a valid CalVer string. Accepts `--dry-run` to preview all commands and file
-  writes without modifying anything.
+## changes.md tracker
 
-- `local-release.mjs`: Smoke-test release to a temp directory. Doesn't push tags.
-
-- `publish.mjs`: Publishes seven fork-owned packages in release order:
-  `@code-yeongyu/senpi-ai`, `@code-yeongyu/senpi-agent-core`,
-  `@code-yeongyu/senpi-tui`, `@code-yeongyu/senpi-pty`,
-  `@code-yeongyu/senpi-telemetry`, `@code-yeongyu/senpi-codemode`, and
-  `@code-yeongyu/senpi`. Every source package remains `private`; the publisher
-  copies each to a temporary public manifest under the fork scope.
-  `@code-yeongyu/senpi-server` remains private and explicitly excluded.
-
-- `build-binaries.sh`: Mirrors `.github/workflows/build-binaries.yml` for local
-  cross-platform binary builds.
-
-- `devenv-setup.mjs`: Universal, idempotent dev-environment setup. Both shell wrappers
-  delegate here after locating Node.
-
-- Release/publish helpers: `prepare-senpi-publish-manifest.mjs`, `publish-command.mjs`,
-  `publish-manifest.mjs`, `release-notes.mjs`, `release-test-gate.mjs`,
-  `local-release-runner.mjs`.
-
-- Standalone binaries: `prepare-bun-compile-assets.mjs`, `smoke-standalone-binary.mjs`.
-
-- Gates and upstream: `check-pr-changelog.mjs`, `check-upstream-release.mjs`.
-
-- Model catalog: `diff-model-catalog.mjs`, `publish-model-catalog.mjs`,
-  `generate-thinking-capabilities.mjs`.
+`scripts/changes.md` is the hand-written change tracker feeding CHANGELOG gates.
+`changes-md-policy.mjs` owns policy: canonical sections, path classification, coverage audit,
+and the added-line restrictor — a PR only gets credit for tracker bullets its diff added.
+`changes-md-git.mjs` owns git/filesystem collection (skips symlinked trackers, rejects option-like
+`--base` revisions). `audit-changes-md.mjs` audits coverage; `check-pr-changelog.mjs` gates PRs
+via `CHANGELOG_GATE_LABELS` / `CHANGELOG_GATE_BASE` env vars, never shell interpolation; entries
+parse `## YYYY-MM-DD` and `## Title (YYYY-MM-DD)` dialects.
 
 ## prepare-senpi-bundled-workspaces.mjs
 
-Manages workspace packages embedded in the published `@code-yeongyu/senpi` tarball.
-
-- `sourceOnly: false`: workspace ships `dist/index.js`; a build is required before staging.
-- `sourceOnly: true`: workspace ships `src/` directly without a build step.
-  `@code-yeongyu/senpi-codemode` is the only current source-only entry.
-- Validates every `requiredFiles` entry exists before staging; aborts with a clear list on failure.
-- `@earendil-works/pi-pty` also requires `native/index.js` and a platform prebuild file.
-
-The publish tarball is fully self-contained: `copyPublishDependencies` stages the ENTIRE
-runtime closure from `publish-deps.lock.json` (all registry deps + transitives, not just the
-workspace closure) into `packages/coding-agent/node_modules`, and `stagePublishManifest`
-rewrites the publish manifest so `bundleDependencies` lists every platform-portable staged
-package while the original `dependencies` keys stay intact. Their staged specs point
-through npm aliases to the matching fork-owned `@code-yeongyu/senpi-*` package: npm still
-packs the original import paths, while Bun resolves only the fork-owned alias rather than
-fetching unavailable upstream lockstep versions. The previous partial bundle let arborist
-abort reify mid-flight and drop arbitrary registry deps (ERR_MODULE_NOT_FOUND).
-Staging dirties `packages/coding-agent/package.json`; restore it with `git checkout --`
-after packing/publishing.
-
-`bundleDependencies` deliberately excludes packages that declare `os`/`cpu`/`libc`
-(`isPlatformConstrainedPackage`). npm resolves those fields against the installing machine, but
-the bundle is one artifact shipped to every platform and npm republishes the bundled set as
-required `dependencies` in the registry manifest — so bundling the publish runner's own natives
-(linux-x64, per `publish-npm.yml`) made `npm install @code-yeongyu/senpi` fail with
-EBADPLATFORM everywhere else. They remain optional registry deps, resolved per install target.
+Embeds workspace packages in the published `@code-yeongyu/senpi` tarball. `sourceOnly: false`
+ships `dist/index.js` (build before staging); `sourceOnly: true` ships `src/` (only
+`senpi-codemode`). Every `requiredFiles` entry is validated; `@earendil-works/pi-pty` also
+requires `native/index.js` and a platform prebuild. The tarball is fully self-contained: `copyPublishDependencies` stages the ENTIRE runtime
+closure from `publish-deps.lock.json` into `packages/coding-agent/node_modules`, and
+`stagePublishManifest` rewrites `bundleDependencies` to every platform-portable staged
+package while original `dependencies` keys stay intact, pointing through npm aliases to
+fork-owned `@code-yeongyu/senpi-*` packages (npm packs original import paths; Bun resolves
+the alias; the old partial bundle made arborist abort reify with ERR_MODULE_NOT_FOUND).
+Staging dirties `packages/coding-agent/package.json`; restore with `git checkout --` after it.
 
 ## Anti-patterns
 
 - Don't hardcode `npm` as the child process manager. Use the detected PM from `build-all.mjs`.
-- Never hand-edit `publish-deps.lock.json` or `coding-agent-install-lock.json`.
-  Regenerate with `generate-coding-agent-shrinkwrap.mjs` / `generate-coding-agent-install-lock.mjs`.
-- Never invoke `node scripts/publish.mjs` without a prior build. The script checks for
-  `dist/` existence but not for stale output.
-- Never commit `.env` files or print credentials in build log output.
+- Never hand-edit `publish-deps.lock.json` or `coding-agent-install-lock.json`; regenerate
+  with the `generate-*` scripts.
+- Never run `node scripts/publish.mjs` without a prior build; it checks `dist/` exists, not
+  freshness. Never commit `.env` files or print credentials in build logs.
+- Lock generators refuse unreviewed install scripts; the allowlist is keyed by exact
+  `name@version` — bump the allowlist entry together with the dependency.
+- Never bundle packages declaring `os`/`cpu`/`libc` into `bundleDependencies`
+  (`isPlatformConstrainedPackage`): npm republishes the bundled set as required deps, so one
+  cross-platform artifact fails installs with EBADPLATFORM elsewhere; keep them optional
+  registry deps resolved per install target.
 
 ---
-Generated: 2026-08-07 | Commit `4f26b8282`
+Generated: 2026-08-24 | Commit `baf15a54d`


### PR DESCRIPTION
## What
Update-mode init-deep refresh of the hierarchical AGENTS.md knowledge base (2026-08-24, base baf15a54d).

- 60+ AGENTS.md files updated/created (coding-agent src/core + extensions/builtin coverage, packages/ai, tui, protocol, pty)
- `.omo/init-deep.json` snapshot refreshed (committed mode)
- Docs-only change: no runtime code touched

## How
88 chunk scans -> 13 writers -> root -> verification. On-disk verification: all digest-declared locations resolve, no new line-gate breaches, no duplication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the monorepo’s `AGENTS.md` knowledge base to the current source state. Documentation-only; no runtime behavior changes.

- Notable additions: per-tree guides for `packages/agent/src/harness` (with `session` and `tools`), `packages/ai/src` entry surfaces and `utils`, `packages/protocol`, `packages/client`, `packages/telemetry`, and `packages/session-backends/sqlite-node`. Clarifies compaction mechanics (`core/compaction`) vs policy (`extensions/builtin/compaction`), documents `retry-fallback`, adds the PTY-backed `terminal` builtin, and expands TUI component coverage. Updates `@earendil-works/pi-ai` entry-surface contracts (ESM, Node >=24, lazy APIs) and model-generation scripts; refreshes `@earendil-works/pi-pty` ABI guidance; broadens coding-agent examples/scripts; and adds test-suite maps for tool-call middleware, compaction, MCP, permission, ttsr, and TUI.
- Review focus: verify counts/indices and registration order match code (builtin extension numbers, provider/catalog triplets, tool factories); confirm ABI/version and browser-safe constraints (`pi-pty` ABI, Node version floors, `@earendil-works/pi-ai` entry surfaces); ensure barrel/lazy loader contracts and import paths are accurate; and check cross-links that must remain stable (session JSONL shapes, SQLite repo types, TUI render rules). `.omo/init-deep.json` snapshot is updated; no migrations or release steps required.

<sup>Written for commit 0549249cf41eb71a87d8f6af6ed4a75cb342e319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

