### PR TITLE
docs(agents): correct the SENPI_BRAND scrub claim for Bun runtimes

### DIFF
--- a/packages/coding-agent/src/core/AGENTS.md
+++ b/packages/coding-agent/src/core/AGENTS.md
@@ -40,7 +40,7 @@ Session runtime, model/provider stack, session persistence, settings, resources.
 - **Session state is event-driven**: typed discriminated event unions, abort signals, queues, barriers, deferred settlement. No polling.
 - **Provider/auth availability is capability-derived** — enumerate compatibility providers and inspect credentials/env; never hard-code availability from UI names.
 - **Persistence is lock-backed**: `proper-lockfile` for credentials and file model stores, revision checks, atomic/coalesced reloads. Settings writes are queued with self-write tracking.
-- **Branding propagates via `SENPI_BRAND`** then is scrubbed from spawned tool environments (`brand.ts`) so child engines never inherit it.
+- **Branding propagates via `SENPI_BRAND`**; `scrubBrandFromEnvironment()` (`brand.ts`) clears only the JS-level `process.env` view. Under Bun, `delete process.env.X` does not unsetenv for spawned children (verified 2026-08-25: a `Bun.spawn` child still sees the original value after the delete), so tool children inherit the full launcher env — `SENPI_BRAND`, `OMO_CODING_AGENT_DIR`, and `SENPI_CODING_AGENT_DIR` included. Never rely on the scrub to keep brand or agent-dir state out of subprocesses; pass an explicit sanitized `env` at spawn where that matters (the vitest quarantine in `test/setup.ts` is the model).
 - Bash output is sanitized (ANSI/binary), bounded, and spilled to a temp file when truncated. Preserve abort-signal and chunk callbacks.
 - Node imports use `node:` in newer files; `auth-storage.ts` retains bare `fs`/`path`. Mixed by history, not by accident.
 


### PR DESCRIPTION
## Summary

The `src/core/AGENTS.md` CONVENTIONS bullet claimed `scrubBrandFromEnvironment()` removes `SENPI_BRAND` from spawned tool environments "so child engines never inherit it". That guarantee does not hold under Bun: `delete process.env.X` clears only the JS-level view, and spawned children still receive the original kernel environment. This PR corrects the doc to the measured behavior and points at the safe pattern.

## Evidence

Measured 2026-08-25 on mengmotaHost (senpi 2026.8.24 under Bun):

```js
process.env.SENPI_BRAND = "secret-brand";
delete process.env.SENPI_BRAND;
// JS view: undefined
// Bun.spawn(["sh", "-c", "echo $SENPI_BRAND"]) → still prints the full brand JSON
```

Live confirmation: the session's own bash-tool env carries `SENPI_BRAND`, `OMO_CODING_AGENT_DIR`, and `SENPI_CODING_AGENT_DIR` despite the engine running the scrub at boot (`cli-main.ts:20`). This inheritance is exactly what let the 2026-08-25 release-gate vitest run bypass the `SENPI_`-only test quarantine (fixed in #1110).

## Changes

- `packages/coding-agent/src/core/AGENTS.md`: one CONVENTIONS bullet rewritten to the measured behavior; adds the safe pattern (explicit sanitized `env` at spawn, as `test/setup.ts` now does).

Docs-only; no runtime code touched (Changelog gate: no runtime source changes).

## Out of scope (follow-ups)

- The same incorrect guarantee appears in code comments at `src/cli.ts` ("Brand scrubbing does NOT justify it ... scrubs this process's environment before anything the agent spawns can inherit it") and `src/core/brand.ts` (`scrubBrandFromEnvironment` docstring). Left untouched here because `.ts` edits trigger the CHANGELOG/changes.md gates; they belong with the eventual production fix (a real unsetenv or explicit sanitized spawn env).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects `AGENTS.md` to state that `scrubBrandFromEnvironment()` only clears the JS `process.env` view under Bun and does not remove `SENPI_BRAND` (or related vars) from spawned children. This matters because tool processes still inherit the launcher environment unless you pass a sanitized `env`.

- Required: When spawning tools under Bun, pass an explicit sanitized `env`; do not rely on the scrub to hide `SENPI_BRAND`, `OMO_CODING_AGENT_DIR`, or `SENPI_CODING_AGENT_DIR`.
- Docs-only change in `packages/coding-agent/src/core/AGENTS.md`; no runtime behavior changed.

<sup>Written for commit be6e9f83ef02b5cf131c8d70f45f4f8bac3c6ea0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

