### PR TITLE
perf(coding-agent): slim the rpc child boot graph

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- RPC child startup now lazy-loads the interactive TUI mode graph at mode dispatch, avoiding parsing interactive-only components for headless sessions while preserving the interactive path.
+
 ### Removed
 
 ## [2026.8.24] - 2026-08-24

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-25 - Lazy-load the interactive mode at the CLI mode seam
+
+### What changed
+
+- `packages/coding-agent/src/main.ts`: RPC and print mode imports remain eager, while `InteractiveMode` is loaded dynamically only after the final mode is known to be interactive.
+
+### Why
+
+- RPC children are headless and never construct the interactive TUI. Keeping the interactive mode import in the shared static mode barrel made the full component tree parse during RPC startup. The dynamic boundary removes that interactive-only work from the RPC boot path while preserving the same interactive import immediately before its first use.
+
+### Why an extension could not handle it
+
+- Mode selection and entry-module loading happen before extensions are loaded; only the CLI coordinator can keep an unused mode graph out of the RPC child entry.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/main.ts` mode imports and the final interactive dispatch branch.
+
 ## 2026-08-22 - emit agent_idle after settlement-deferred turns resolve
 
 ### What changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -76,9 +76,10 @@ import { hasTrustRequiringProjectResources, ProjectTrustStore } from "./core/tru
 import { builtInExtensions } from "./extensions/index.ts";
 import { getFromSourceRealConfigWarning } from "./from-source-config-guard.ts";
 import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
-import { InteractiveMode, runPrintMode, runRpcMode } from "./modes/index.ts";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.ts";
+import { runPrintMode } from "./modes/print-mode.ts";
 import { runMultiSessionHost } from "./modes/rpc/multi-session-host.ts";
+import { runRpcMode } from "./modes/rpc/rpc-mode.ts";
 import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
 import { isLocalPath, normalizePath, resolvePath } from "./utils/paths.ts";
 import { cleanupWindowsSelfUpdateQuarantine } from "./utils/windows-self-update.ts";
@@ -1132,6 +1133,9 @@ export async function main(args: string[], options?: MainOptions) {
 		printTimings();
 		await runRpcMode(runtime);
 	} else if (appMode === "interactive") {
+		// Keep the TUI graph out of headless RPC children. This is intentionally at the
+		// mode seam: interactive startup still loads the same module before first use.
+		const { InteractiveMode } = await import("./modes/interactive/interactive-mode.ts");
 		const interactiveMode = new InteractiveMode(runtime, {
 			migratedProviders,
 			modelFallbackMessage,


### PR DESCRIPTION
## Summary
Keep the headless RPC child from eagerly parsing the interactive TUI mode graph.

## Changes
- `main.ts` imports print and RPC modes directly instead of through the mode barrel.
- `InteractiveMode` is dynamically imported only after mode dispatch selects interactive mode.
- Added the required fork change tracker entry.

The cut is intentionally conservative: theme/render helpers remain eager because built-in tools and RPC extension UI can reach them at runtime.

## QA & Evidence
- `npm run build` passed.
- `npm run test:scripts` passed (180 tests).
- `npm run check:ts-imports` passed.
- `npm test` passed for all workspaces except two pre-existing coding-agent failures: stdout-cleanliness migration chatter and Bun websocket daemon noise; 1065/1067 coding-agent files passed.
- Focused RPC tests passed: 26 tests.
- `npm run check` passed through lock checks; Biome reported the repository schema is 2.5.5 while installed CLI is 2.5.10, and did not produce a tracked diff.
- Metafile/timing evidence: `/tmp/ulw-pr-run/lane-e/metafile-timing-summary.txt`
- RPC transcript: `/tmp/ulw-pr-run/lane-e/rpc-transcript.txt`
- Built split metafile: `/tmp/ulw-pr-run/lane-e/after/split/rpc-metafile.md`

Boot timing (5-run median, Node import of built rpc-entry): origin/main 1.30s; branch 1.26s. Bun split build emits the interactive-mode graph as a separate dynamic chunk; RPC entry stub is 1.29 KB.

## Risks & Residuals
- The shared engine graph still includes RPC-reachable theme/render modules. Removing those would alter builtin extension/tool behavior, so they remain eager by design.
- Interactive behavior is unchanged: the same `InteractiveMode` module is loaded immediately before construction on the interactive path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads the interactive TUI to slim the RPC child boot graph. Previously RPC eagerly imported `InteractiveMode` via the mode barrel; now the CLI loads it only when app mode is interactive, keeping TUI code out of headless runs.

- Review notes
  - In `packages/coding-agent/src/main.ts`, replace the barrel import with direct `runPrintMode` and `runRpcMode` imports and dynamically import `InteractiveMode` in the interactive branch.
  - Behavior: RPC no longer parses the interactive graph; interactive loads the same module just-in-time; theme/render helpers remain eager by design.
  - Docs: updated `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/src/changes.md` to record the lazy-load change.
  - No migration or config changes; extensions are unaffected because mode selection happens before extensions load.

<sup>Written for commit aee101ff5a714e9350648b4bc400a204fc193c76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

