### PR TITLE
feat(coding-agent): opt-in Bun terminal backend behind SENPI_BUN_TERMINAL

### DIFF
--- a/packages/pty/CHANGELOG.md
+++ b/packages/pty/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Added an opt-in Bun `Bun.spawn` terminal backend for persistent PTY sessions when `SENPI_BUN_TERMINAL` is truthy; the existing native and pipe-fallback paths remain the defaults.

--- a/packages/pty/src/index.ts
+++ b/packages/pty/src/index.ts
@@ -47,6 +47,8 @@ export {
 } from "./session.ts";
 export {
 	type BunRuntime,
+	type BunRuntimeVersions,
+	type BunTerminal,
 	createBunTerminalSession,
 	ENV_BUN_TERMINAL,
 	isBunTerminalEnabled,

--- a/packages/pty/src/index.ts
+++ b/packages/pty/src/index.ts
@@ -45,6 +45,12 @@ export {
 	type TerminalSessionOperationResult,
 	type TerminalSessionOptions,
 } from "./session.ts";
+export {
+	type BunRuntime,
+	createBunTerminalSession,
+	ENV_BUN_TERMINAL,
+	isBunTerminalEnabled,
+} from "./session-bun.ts";
 
 export type PtySessionOptions = TerminalSessionOptions;
 

--- a/packages/pty/src/session-bun.ts
+++ b/packages/pty/src/session-bun.ts
@@ -1,0 +1,115 @@
+import { Buffer } from "node:buffer";
+import process from "node:process";
+import type {
+	TerminalSessionDataHandler,
+	TerminalSessionHandle,
+	TerminalSessionNativeOptions,
+	TerminalSessionOperationResult,
+	TerminalSessionSignal,
+} from "./session-types.ts";
+
+interface BunTerminal {
+	readonly write: (data: string | Uint8Array) => void;
+	readonly resize: (cols: number, rows: number) => void;
+}
+
+interface BunSubprocess {
+	readonly terminal: BunTerminal;
+	readonly exited: Promise<number>;
+	kill: (signal?: TerminalSessionSignal) => void;
+}
+
+interface BunSpawnOptions {
+	readonly cwd?: string;
+	readonly env?: Readonly<Record<string, string>>;
+	readonly terminal: {
+		readonly cols: number;
+		readonly rows: number;
+		readonly data: (terminal: BunTerminal, data: Uint8Array) => void;
+	};
+}
+
+export interface BunRuntime {
+	readonly spawn: (command: readonly string[], options: BunSpawnOptions) => BunSubprocess;
+}
+
+const BUN_TERMINAL_NOTE = "Used Bun.spawn terminal backend.";
+
+export const ENV_BUN_TERMINAL = "SENPI_BUN_TERMINAL";
+
+export function isBunTerminalEnabled(
+	env: Readonly<Record<string, string | undefined>> = process.env,
+	versions: NodeJS.ProcessVersions & { readonly bun?: unknown } = process.versions,
+): boolean {
+	if (typeof versions.bun !== "string") return false;
+	const value = env[ENV_BUN_TERMINAL];
+	if (value === undefined) return false;
+	const normalized = value.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export function createBunTerminalSession(
+	options: TerminalSessionNativeOptions,
+	onData: TerminalSessionDataHandler,
+	runtime: BunRuntime = getBunRuntime(),
+): TerminalSessionHandle {
+	if (options.timeoutMs !== undefined && (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)) {
+		throw new Error("Invalid timeoutMs: must be a finite positive number");
+	}
+	const child = runtime.spawn([options.command, ...options.args], {
+		cwd: options.cwd,
+		env: options.env ? mergeEnvironment(options.env) : undefined,
+		terminal: {
+			cols: options.cols,
+			rows: options.rows,
+			data: (_terminal, data) => onData(Buffer.from(data)),
+		},
+	});
+	let timedOut = false;
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+	const exitPromise = child.exited.then((exitCode) => {
+		if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+		return { exitCode, signal: null, timedOut };
+	});
+
+	if (options.timeoutMs !== undefined) {
+		timeoutHandle = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGTERM");
+		}, options.timeoutMs);
+	}
+
+	return {
+		write(data) {
+			child.terminal.write(data);
+			return { ok: true, note: BUN_TERMINAL_NOTE } satisfies TerminalSessionOperationResult;
+		},
+		resize(cols, rows) {
+			child.terminal.resize(cols, rows);
+			return { ok: true, note: `Resized Bun terminal session to ${cols}x${rows}.` };
+		},
+		kill(signal = "SIGTERM") {
+			child.kill(signal);
+			return { ok: true, note: `Sent ${signal} to Bun terminal session.` };
+		},
+		waitExit: async () => await exitPromise,
+	};
+}
+
+function mergeEnvironment(env: Readonly<Record<string, string | undefined>>): Record<string, string> {
+	const merged: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (value !== undefined) merged[key] = value;
+	}
+	for (const [key, value] of Object.entries(env)) {
+		if (value === undefined) delete merged[key];
+		else merged[key] = value;
+	}
+	return merged;
+}
+
+function getBunRuntime(): BunRuntime {
+	const runtime = (globalThis as { readonly Bun?: BunRuntime }).Bun;
+	if (!runtime) throw new Error("Bun terminal backend is only available in Bun runtimes");
+	return runtime;
+}

--- a/packages/pty/src/session-bun.ts
+++ b/packages/pty/src/session-bun.ts
@@ -8,7 +8,7 @@ import type {
 	TerminalSessionSignal,
 } from "./session-types.ts";
 
-interface BunTerminal {
+export interface BunTerminal {
 	readonly write: (data: string | Uint8Array) => void;
 	readonly resize: (cols: number, rows: number) => void;
 }
@@ -29,6 +29,10 @@ interface BunSpawnOptions {
 	};
 }
 
+export interface BunRuntimeVersions {
+	readonly bun?: unknown;
+}
+
 export interface BunRuntime {
 	readonly spawn: (command: readonly string[], options: BunSpawnOptions) => BunSubprocess;
 }
@@ -39,7 +43,7 @@ export const ENV_BUN_TERMINAL = "SENPI_BUN_TERMINAL";
 
 export function isBunTerminalEnabled(
 	env: Readonly<Record<string, string | undefined>> = process.env,
-	versions: NodeJS.ProcessVersions & { readonly bun?: unknown } = process.versions,
+	versions: BunRuntimeVersions = process.versions as BunRuntimeVersions,
 ): boolean {
 	if (typeof versions.bun !== "string") return false;
 	const value = env[ENV_BUN_TERMINAL];

--- a/packages/pty/src/session-types.ts
+++ b/packages/pty/src/session-types.ts
@@ -1,7 +1,7 @@
 import type { Buffer } from "node:buffer";
 import type { NativePtyLoadResult } from "./native-loader.ts";
 
-export type TerminalSessionBackend = "native" | "pipe-fallback";
+export type TerminalSessionBackend = "native" | "pipe-fallback" | "bun";
 export type TerminalSessionDataHandler = (chunk: Buffer) => void;
 export type TerminalSessionSignal = NodeJS.Signals;
 
@@ -75,4 +75,6 @@ export interface TerminalSessionDependencies {
 	readonly nativeLoadResult?: NativePtyLoadResult;
 	readonly createNativeSession?: CreateNativeTerminalSession;
 	readonly env?: Readonly<Record<string, string | undefined>>;
+	readonly runtimeVersions?: NodeJS.ProcessVersions & { readonly bun?: unknown };
+	readonly bunRuntime?: import("./session-bun.ts").BunRuntime;
 }

--- a/packages/pty/src/session-types.ts
+++ b/packages/pty/src/session-types.ts
@@ -75,6 +75,6 @@ export interface TerminalSessionDependencies {
 	readonly nativeLoadResult?: NativePtyLoadResult;
 	readonly createNativeSession?: CreateNativeTerminalSession;
 	readonly env?: Readonly<Record<string, string | undefined>>;
-	readonly runtimeVersions?: NodeJS.ProcessVersions & { readonly bun?: unknown };
+	readonly runtimeVersions?: import("./session-bun.ts").BunRuntimeVersions;
 	readonly bunRuntime?: import("./session-bun.ts").BunRuntime;
 }

--- a/packages/pty/src/session.ts
+++ b/packages/pty/src/session.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import process from "node:process";
 import { loadNativePty, type NativePtyLoadResult, type NativePtyUnavailableDiagnostic } from "./native-loader.ts";
 import { PipeFallbackSession, shouldUsePipeFallback } from "./pipe-fallback.ts";
+import { createBunTerminalSession, isBunTerminalEnabled } from "./session-bun.ts";
 import {
 	exitedOperation,
 	normalizeOperationResult,
@@ -43,6 +44,8 @@ export class TerminalSession {
 	private readonly nativeLoadResult: NativePtyLoadResult;
 	private readonly createNativeSessionDependency?: CreateNativeTerminalSession;
 	private readonly env: Readonly<Record<string, string | undefined>>;
+	private readonly runtimeVersions: NodeJS.ProcessVersions & { readonly bun?: unknown };
+	private readonly bunRuntime: import("./session-bun.ts").BunRuntime | undefined;
 	private readonly rawTailLimit: number;
 	private readonly dataHandlers = new Set<TerminalSessionDataHandler>();
 	private readonly exitHandlers = new Set<() => void>();
@@ -64,6 +67,8 @@ export class TerminalSession {
 		this.nativeLoadResult = dependencies.nativeLoadResult ?? loadNativePty();
 		this.createNativeSessionDependency = dependencies.createNativeSession;
 		this.env = dependencies.env ?? process.env;
+		this.runtimeVersions = dependencies.runtimeVersions ?? process.versions;
+		this.bunRuntime = dependencies.bunRuntime;
 		this.rawTailLimit = normalizeRawTailBytes(options.rawTailBytes);
 	}
 
@@ -117,16 +122,25 @@ export class TerminalSession {
 		if (this.settledExit !== null) throw new Error("Cannot restart exited terminal session");
 		if (this.backendHandle !== null) throw new Error("Terminal session has already been started");
 
-		const nativeFactory = this.createNativeSessionDependency ?? getNativeSessionFactory(this.nativeLoadResult);
-		if (nativeFactory && !shouldUsePipeFallback(this.nativeLoadResult, this.env)) {
-			this.backendValue = "native";
-			this.backendHandle = nativeFactory(toNativeOptions(this.options), (chunk) => this.emitData(chunk));
+		if (isBunTerminalEnabled(this.env, this.runtimeVersions)) {
+			this.backendValue = "bun";
+			this.backendHandle = createBunTerminalSession(
+				toNativeOptions(this.options),
+				(chunk) => this.emitData(chunk),
+				this.bunRuntime,
+			);
 		} else {
-			this.backendValue = "pipe-fallback";
-			const fallback = new PipeFallbackSession(toPipeFallbackOptions(this.options));
-			this.backendHandle = fallback;
-			this.unsubscribeBackendData = fallback.onData((chunk) => this.emitData(chunk));
-			fallback.start();
+			const nativeFactory = this.createNativeSessionDependency ?? getNativeSessionFactory(this.nativeLoadResult);
+			if (nativeFactory && !shouldUsePipeFallback(this.nativeLoadResult, this.env)) {
+				this.backendValue = "native";
+				this.backendHandle = nativeFactory(toNativeOptions(this.options), (chunk) => this.emitData(chunk));
+			} else {
+				this.backendValue = "pipe-fallback";
+				const fallback = new PipeFallbackSession(toPipeFallbackOptions(this.options));
+				this.backendHandle = fallback;
+				this.unsubscribeBackendData = fallback.onData((chunk) => this.emitData(chunk));
+				fallback.start();
+			}
 		}
 
 		const backendHandle = this.backendHandle;

--- a/packages/pty/src/session.ts
+++ b/packages/pty/src/session.ts
@@ -44,7 +44,7 @@ export class TerminalSession {
 	private readonly nativeLoadResult: NativePtyLoadResult;
 	private readonly createNativeSessionDependency?: CreateNativeTerminalSession;
 	private readonly env: Readonly<Record<string, string | undefined>>;
-	private readonly runtimeVersions: NodeJS.ProcessVersions & { readonly bun?: unknown };
+	private readonly runtimeVersions: import("./session-bun.ts").BunRuntimeVersions;
 	private readonly bunRuntime: import("./session-bun.ts").BunRuntime | undefined;
 	private readonly rawTailLimit: number;
 	private readonly dataHandlers = new Set<TerminalSessionDataHandler>();
@@ -67,7 +67,7 @@ export class TerminalSession {
 		this.nativeLoadResult = dependencies.nativeLoadResult ?? loadNativePty();
 		this.createNativeSessionDependency = dependencies.createNativeSession;
 		this.env = dependencies.env ?? process.env;
-		this.runtimeVersions = dependencies.runtimeVersions ?? process.versions;
+		this.runtimeVersions = dependencies.runtimeVersions ?? (process.versions as import("./session-bun.ts").BunRuntimeVersions);
 		this.bunRuntime = dependencies.bunRuntime;
 		this.rawTailLimit = normalizeRawTailBytes(options.rawTailBytes);
 	}

--- a/packages/pty/src/session.ts
+++ b/packages/pty/src/session.ts
@@ -67,7 +67,8 @@ export class TerminalSession {
 		this.nativeLoadResult = dependencies.nativeLoadResult ?? loadNativePty();
 		this.createNativeSessionDependency = dependencies.createNativeSession;
 		this.env = dependencies.env ?? process.env;
-		this.runtimeVersions = dependencies.runtimeVersions ?? (process.versions as import("./session-bun.ts").BunRuntimeVersions);
+		this.runtimeVersions =
+			dependencies.runtimeVersions ?? (process.versions as import("./session-bun.ts").BunRuntimeVersions);
 		this.bunRuntime = dependencies.bunRuntime;
 		this.rawTailLimit = normalizeRawTailBytes(options.rawTailBytes);
 	}

--- a/packages/pty/test/bun-terminal.test.ts
+++ b/packages/pty/test/bun-terminal.test.ts
@@ -86,7 +86,7 @@ describe("Bun terminal session adapter", () => {
 			(data) => chunks.push(new TextDecoder().decode(data)),
 			fake.runtime,
 		);
-		fake.dataHandler()?.({}, new TextEncoder().encode("hello"));
+		fake.dataHandler()?.(undefined as never, new TextEncoder().encode("hello"));
 		session.write("echo hi");
 		session.resize(120, 40);
 		session.kill("SIGTERM");

--- a/packages/pty/test/bun-terminal.test.ts
+++ b/packages/pty/test/bun-terminal.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { TerminalSession } from "../src/session.ts";
+import { type BunRuntime, createBunTerminalSession, isBunTerminalEnabled } from "../src/session-bun.ts";
+
+const bunVersions = { bun: "1.4.0" };
+const nodeVersions = {};
+
+function fakeRuntime() {
+	let dataHandler: ((terminal: unknown, data: Uint8Array) => void) | undefined;
+	let resolveExit: ((code: number) => void) | undefined;
+	const writes: string[] = [];
+	const resizes: string[] = [];
+	const kills: string[] = [];
+	const runtime: BunRuntime = {
+		spawn(_command, options) {
+			dataHandler = options.terminal.data;
+			return {
+				terminal: {
+					write(data) {
+						writes.push(typeof data === "string" ? data : new TextDecoder().decode(data));
+					},
+					resize(cols, rows) {
+						resizes.push(`${cols}x${rows}`);
+					},
+				},
+				exited: new Promise((resolve) => {
+					resolveExit = resolve;
+				}),
+				kill(signal) {
+					kills.push(signal ?? "SIGTERM");
+					resolveExit?.(143);
+				},
+			};
+		},
+	};
+	return { runtime, dataHandler: () => dataHandler, resolveExit: () => resolveExit, writes, resizes, kills };
+}
+
+describe("Bun terminal gate", () => {
+	it.each([
+		["node off", nodeVersions, {}, false],
+		["node on", nodeVersions, { SENPI_BUN_TERMINAL: "1" }, false],
+		["bun off", bunVersions, {}, false],
+		["bun on", bunVersions, { SENPI_BUN_TERMINAL: "true" }, true],
+	])("%s", (_name, versions, env, expected) => {
+		expect(isBunTerminalEnabled(env, versions)).toBe(expected);
+	});
+
+	it("accepts the documented truthy values and rejects other values", () => {
+		for (const value of ["1", "true", "yes", "on", " TRUE "]) {
+			expect(isBunTerminalEnabled({ SENPI_BUN_TERMINAL: value }, bunVersions)).toBe(true);
+		}
+		for (const value of ["", "0", "false", "no", "off"]) {
+			expect(isBunTerminalEnabled({ SENPI_BUN_TERMINAL: value }, bunVersions)).toBe(false);
+		}
+	});
+});
+
+describe("Bun terminal session adapter", () => {
+	it("selects Bun only for a Bun runtime with the opt-in flag", async () => {
+		const fake = fakeRuntime();
+		const session = new TerminalSession(
+			{ command: "bash" },
+			{
+				env: { SENPI_BUN_TERMINAL: "1" },
+				runtimeVersions: { ...process.versions, bun: "1.4.0" },
+				bunRuntime: fake.runtime,
+			},
+		);
+		session.start();
+		fake.resolveExit()?.(0);
+		await session.waitExit();
+		expect(session.backend).toBe("bun");
+	});
+
+	it("forwards data, writes, resize, kill, and exit", async () => {
+		const fake = fakeRuntime();
+		const chunks: string[] = [];
+		const session = createBunTerminalSession(
+			{ command: "bash", args: ["-i"], cols: 80, rows: 24 },
+			(data) => chunks.push(new TextDecoder().decode(data)),
+			fake.runtime,
+		);
+		fake.dataHandler()?.({}, new TextEncoder().encode("hello"));
+		session.write("echo hi");
+		session.resize(120, 40);
+		session.kill("SIGTERM");
+		const exit = await session.waitExit?.();
+
+		expect(chunks).toEqual(["hello"]);
+		expect(fake.writes).toEqual(["echo hi"]);
+		expect(fake.resizes).toEqual(["120x40"]);
+		expect(fake.kills).toEqual(["SIGTERM"]);
+		expect(exit).toEqual({ exitCode: 143, signal: null, timedOut: false });
+	});
+});

--- a/packages/pty/test/bun-terminal.test.ts
+++ b/packages/pty/test/bun-terminal.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest";
 import { TerminalSession } from "../src/session.ts";
-import { type BunRuntime, createBunTerminalSession, isBunTerminalEnabled } from "../src/session-bun.ts";
+import {
+	type BunRuntime,
+	type BunTerminal,
+	createBunTerminalSession,
+	isBunTerminalEnabled,
+} from "../src/session-bun.ts";
 
 const bunVersions = { bun: "1.4.0" };
 const nodeVersions = {};
 
 function fakeRuntime() {
-	let dataHandler: ((terminal: unknown, data: Uint8Array) => void) | undefined;
+	let dataHandler: ((terminal: BunTerminal, data: Uint8Array) => void) | undefined;
 	let resolveExit: ((code: number) => void) | undefined;
 	const writes: string[] = [];
 	const resizes: string[] = [];


### PR DESCRIPTION
## Summary
Add an opt-in Bun native PTY backend for persistent terminal sessions. The backend is selected only when running under Bun and `SENPI_BUN_TERMINAL` is set to a documented truthy value; all default Node and Bun behavior remains on the existing native/pipe-fallback selector.

## Changes
### PTY session backend
- Added a Bun `Bun.spawn([...], { terminal })` adapter implementing the existing session handle contract: data delivery, write, resize, kill, timeout, and exit waiting.
- Added the `bun` backend state and exported gate/runtime test seams.
- Kept native loading and pipe fallback paths unchanged when the gate is false.

### Tests
- Added the runtime/flag matrix tests (Node/Bun x off/on), truthy-value parsing tests, backend selection test, and adapter lifecycle contract test.

## QA & Evidence
- `npm run build`: passed. Log: `/tmp/ulw-pr-run/lane-f/repo-build.log`
- `npm test`: 1063 passing test files/suites outside two unrelated pre-existing coding-agent failures; `packages/pty` passed 9 files / 58 tests. Log: `/tmp/ulw-pr-run/lane-f/repo-test.log`
- `npm run test:scripts`: 180/180 passed. Log: `/tmp/ulw-pr-run/lane-f/repo-test-scripts.log`
- `npm run check:ts-imports`: passed. Log: `/tmp/ulw-pr-run/lane-f/repo-check-ts-imports.log`
- `npm test --workspace=@earendil-works/pi-pty`: 9 files / 58 tests passed.
- Real Bun PTY smoke with `SENPI_BUN_TERMINAL=1`: backend reported `bun`, bash output was captured, resize returned success, kill returned success, and exit propagated as cancelled. Transcript: `/tmp/ulw-pr-run/lane-f/bun-flag-on-transcript.json`
- Real Bun smoke with the flag unset: backend reported `native`, proving the default path remains active. Transcript: `/tmp/ulw-pr-run/lane-f/bun-flag-off-transcript.json`
- Runtime/flag matrix: `/tmp/ulw-pr-run/lane-f/matrix.txt`

The two unrelated full-suite failures were `test/stdout-cleanliness.test.ts` (existing project config migration chatter) and `test/suite/app-server-daemon.test.ts` (existing Bun/WebSocket daemon error); neither touches the changed PTY package.

## Risks & Residuals
- Bun PTY support is strictly opt-in and has no CI lane, so Bun TUI behavior remains a residual risk covered by the real PTY smoke and adapter tests.
- Bun reports exit codes through `BunSubprocess.exited`; the shared session layer adds cancellation semantics for explicit kills.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Bun PTY backend in `packages/pty` for persistent terminal sessions. Previously we selected only `native` or `pipe-fallback`; now we select `bun` only when running under Bun with `SENPI_BUN_TERMINAL` set, keeping defaults unchanged.

- Adds gate in `session.ts` and Bun adapter in `session-bun.ts`.
- Public API exports: `BunRuntime`, `BunRuntimeVersions`, `BunTerminal`, `createBunTerminalSession`, `ENV_BUN_TERMINAL`, `isBunTerminalEnabled`.
- `TerminalSessionBackend` now includes `bun`; `TerminalSessionDependencies` accepts `runtimeVersions` and `bunRuntime`.
- Enable by setting `SENPI_BUN_TERMINAL` to 1/true/yes/on in a Bun runtime; no migration.
- Adds tests for gate selection and adapter lifecycle; updates `packages/pty/CHANGELOG.md`.

Bug Fixes
- Corrects the Bun terminal test callback type.

<sup>Written for commit 0514e1bb2e9a20aae833d065bc03aabcf98a9390. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

