### PR TITLE
test: pin branded resume command with literal expectations

### DIFF
--- a/packages/coding-agent/test/brand.test.ts
+++ b/packages/coding-agent/test/brand.test.ts
@@ -145,6 +145,7 @@ describe("config module brand integration", () => {
 		const config = await import("../src/config.ts");
 
 		expect(config.APP_NAME).toBe("senpi");
+		expect(config.APP_COMMAND).toBe("senpi");
 		expect(config.CONFIG_DIR_NAME).toBe(".senpi");
 		expect(config.CONFIG_FLAT_LAYOUT).toBe(false);
 		expect(config.DISPLAY_VERSION).toBe(config.VERSION);

--- a/packages/coding-agent/test/branded-format-resume-command.test.ts
+++ b/packages/coding-agent/test/branded-format-resume-command.test.ts
@@ -1,0 +1,29 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionManager } from "../src/core/session-manager.ts";
+
+const dirs: string[] = [];
+afterEach(() => {
+	for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+	delete process.env.SENPI_BRAND;
+	vi.resetModules();
+});
+
+describe("branded formatResumeCommand", () => {
+	it("uses the literal branded executable for default and custom session dirs", async () => {
+		process.env.SENPI_BRAND = JSON.stringify({ name: "OmO", configDir: ".omo", flatLayout: false, envPrefix: "OMO", userAgent: "omo", command: "omo" });
+		vi.resetModules();
+		const { APP_COMMAND } = await import("../src/config.ts");
+		const { formatResumeCommand } = await import("../src/modes/interactive/interactive-mode.ts");
+		Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+		const dir = mkdtempSync(join(tmpdir(), "senpi-brand-command-"));
+		dirs.push(dir);
+		const file = join(dir, "session.jsonl");
+		writeFileSync(file, "\n");
+		const manager = { isPersisted: () => true, getSessionFile: () => file, getSessionId: () => "test-session", getSessionDir: () => "/tmp/custom-omo-sessions", usesDefaultSessionDir: () => false } as unknown as SessionManager;
+		expect(APP_COMMAND).toBe("omo");
+		expect(formatResumeCommand(manager)).toBe("omo --session-dir /tmp/custom-omo-sessions --session test-session");
+	});
+});

--- a/packages/coding-agent/test/format-resume-command.test.ts
+++ b/packages/coding-agent/test/format-resume-command.test.ts
@@ -2,9 +2,8 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { APP_COMMAND } from "../src/config.ts";
-import type { SessionManager } from "../src/core/session-manager.ts";
 import { formatResumeCommand } from "../src/modes/interactive/interactive-mode.ts";
+import type { SessionManager } from "../src/core/session-manager.ts";
 
 const tempDirs: string[] = [];
 const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
@@ -55,7 +54,7 @@ describe("formatResumeCommand", () => {
 		const sessionFile = createTempFile();
 		const sessionManager = createSessionManager({ sessionFile, sessionId: "test-session" });
 
-		expect(formatResumeCommand(sessionManager)).toBe(`${APP_COMMAND} --session test-session`);
+		expect(formatResumeCommand(sessionManager)).toBe("senpi --session test-session");
 	});
 
 	it("includes unquoted safe session dirs for non-default session dirs", () => {
@@ -69,7 +68,7 @@ describe("formatResumeCommand", () => {
 		});
 
 		expect(formatResumeCommand(sessionManager)).toBe(
-			`${APP_COMMAND} --session-dir /tmp/custom-pi-sessions --session test-session`,
+			"senpi --session-dir /tmp/custom-pi-sessions --session test-session",
 		);
 	});
 
@@ -84,7 +83,7 @@ describe("formatResumeCommand", () => {
 		});
 
 		expect(formatResumeCommand(sessionManager)).toBe(
-			`${APP_COMMAND} --session-dir '/tmp/custom pi sessions' --session test-session`,
+			"senpi --session-dir '/tmp/custom pi sessions' --session test-session",
 		);
 	});
 
@@ -99,7 +98,7 @@ describe("formatResumeCommand", () => {
 		});
 
 		expect(formatResumeCommand(sessionManager)).toBe(
-			`${APP_COMMAND} --session-dir '/tmp/custom pi'\\''s sessions' --session test-session`,
+			"senpi --session-dir '/tmp/custom pi'\\''s sessions' --session test-session",
 		);
 	});
 


### PR DESCRIPTION
Addresses the review blocker from #1115 by asserting literal branded copy-paste commands for OmO/omo, including a custom session directory, and asserting the unbranded APP_COMMAND fallback as the literal senpi value. Existing resume command expectations are also hardened to literals.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins resume-command tests to literal executables so copy/paste instructions are stable. Previously tests interpolated APP_COMMAND; now unbranded tests expect “senpi” and branded tests expect “omo,” including custom session-dir handling.

- Adds a branded test that sets SENPI_BRAND and verifies “omo --session-dir /tmp/custom-omo-sessions --session test-session”.
- Hardens unbranded tests to exact “senpi …” strings, including quoting for spaces and apostrophes in session dirs.
- Asserts APP_COMMAND is “senpi” by default and “omo” when branded.

<sup>Written for commit 98c50e4e2adec5b15d21b48900faf91b0bc0c4e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

