### PR TITLE
fix(coding-agent): harden provider retry watchdogs

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -677,6 +677,10 @@ type AssistantEventReader = {
 	dispose(): void;
 };
 
+function abortError(reason: unknown): Error {
+	return reason instanceof Error ? reason : new Error("Request was aborted");
+}
+
 function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
 	return typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : undefined;
 }
@@ -711,7 +715,7 @@ function createAssistantEventReader(
 		next: async () => {
 			if (signal?.aborted) {
 				void iterator.return?.();
-				return Promise.reject(new Error("Request was aborted"));
+				return Promise.reject(abortError(signal.reason));
 			}
 			// The start bound applies only until the provider proves the request is
 			// alive with its first event; afterwards the idle bound governs as before.
@@ -727,6 +731,7 @@ function createAssistantEventReader(
 				abortPromise,
 				onIdleTimeout,
 				stream,
+				signal,
 			);
 			if (!result.done) sawFirstEvent = true;
 			return result;
@@ -742,6 +747,7 @@ async function readNextAssistantEvent(
 	abortPromise: Promise<typeof ABORTED> | undefined,
 	onIdleTimeout?: (error: Error) => void,
 	stream?: Pick<AssistantMessageEventStream, "hasPendingLocalWork">,
+	signal?: AbortSignal,
 ): Promise<IteratorResult<AssistantMessageEvent>> {
 	if (idleTimeoutMs === undefined && abortPromise === undefined) {
 		return iterator.next();
@@ -785,7 +791,7 @@ async function readNextAssistantEvent(
 			(result) => {
 				if (result === ABORTED) {
 					void iterator.return?.();
-					settle(() => reject(new Error("Request was aborted")));
+					settle(() => reject(abortError(signal?.reason)));
 					return;
 				}
 				settle(() => resolve(result));

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -13,6 +13,7 @@ import {
 	runAgentLoop,
 	runAgentLoopContinue,
 } from "./agent-loop.ts";
+import { ProviderRetryWatchdogAbortError } from "./assistant-terminal-state.ts";
 import { getDefaultStreamFn } from "./stream-fn.ts";
 import type {
 	AfterToolCallContext,
@@ -186,16 +187,6 @@ class PendingMessageQueue {
 	clear(): void {
 		this.messages = [];
 		this.clearGeneration++;
-	}
-}
-
-export class ProviderRetryWatchdogAbortError extends Error {
-	readonly providerCause: string;
-
-	constructor(providerCause: string) {
-		super(providerCause);
-		this.providerCause = providerCause;
-		this.name = "ProviderRetryWatchdogAbortError";
 	}
 }
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -189,6 +189,16 @@ class PendingMessageQueue {
 	}
 }
 
+export class ProviderRetryWatchdogAbortError extends Error {
+	readonly providerCause: string;
+
+	constructor(providerCause: string) {
+		super(providerCause);
+		this.providerCause = providerCause;
+		this.name = "ProviderRetryWatchdogAbortError";
+	}
+}
+
 type ActiveRun = {
 	promise: Promise<void>;
 	resolve: () => void;
@@ -374,8 +384,8 @@ export class Agent {
 	}
 
 	/** Abort the current run, if one is active. */
-	abort(): void {
-		this.activeRun?.abortController.abort();
+	abort(reason?: unknown): void {
+		this.activeRun?.abortController.abort(reason);
 	}
 
 	/**
@@ -722,6 +732,7 @@ export class Agent {
 			usage: EMPTY_USAGE,
 			stopReason: aborted ? "aborted" : "error",
 			errorMessage: error instanceof Error ? error.message : String(error),
+			...(error instanceof ProviderRetryWatchdogAbortError ? { abortSource: "provider" as const } : {}),
 			timestamp: Date.now(),
 		} satisfies AgentMessage;
 		await this.processEvents({ type: "message_start", message: failureMessage });

--- a/packages/agent/src/assistant-terminal-state.ts
+++ b/packages/agent/src/assistant-terminal-state.ts
@@ -19,6 +19,16 @@ const EMPTY_USAGE = {
 
 type TerminalAssistantMessageEvent = Extract<AssistantMessageEvent, { type: "done" | "error" }>;
 
+export class ProviderRetryWatchdogAbortError extends Error {
+	readonly providerCause: string;
+
+	constructor(providerCause: string) {
+		super(providerCause);
+		this.providerCause = providerCause;
+		this.name = "ProviderRetryWatchdogAbortError";
+	}
+}
+
 export function promoteStopWithPendingToolCalls(message: AssistantMessage): AssistantMessage {
 	if (message.stopReason !== "stop") return message;
 	if (!message.content.some((block) => block.type === "toolCall")) return message;
@@ -57,6 +67,7 @@ export function createTerminalFailureAssistantMessage(
 	const errorMessage = error instanceof Error ? error.message : String(error);
 	return {
 		role: "assistant",
+
 		content: partialMessage?.content ?? [{ type: "text", text: "" }],
 		api: partialMessage?.api ?? model.api,
 		provider: partialMessage?.provider ?? model.provider,
@@ -67,6 +78,7 @@ export function createTerminalFailureAssistantMessage(
 		usage: partialMessage?.usage ?? EMPTY_USAGE,
 		stopReason: reason,
 		errorMessage: errorMessage || (reason === "aborted" ? "Request was aborted" : "Error"),
+		...(error instanceof ProviderRetryWatchdogAbortError ? { abortSource: "provider" as const } : {}),
 		timestamp: partialMessage?.timestamp ?? Date.now(),
 	};
 }

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -7,6 +7,7 @@
 - `packages/agent/src/agent.ts` accepts an abort reason and emits a provider-owned assistant abort for retry-watchdog cancellation.
 - `packages/agent/src/agent-loop.ts` preserves an explicit abort Error instead of replacing it with generic `Request was aborted` text.
 - `packages/agent/src/assistant-terminal-state.ts` stamps provider provenance where terminal stream failures are constructed.
+- `packages/agent/src/index.ts` exports the typed watchdog abort reason for session hosts.
 
 ### Why
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,24 @@
 # Changes
 
+## 2026-08-25 - Preserve provider retry watchdog abort provenance
+
+### What changed
+
+- `packages/agent/src/agent.ts` accepts an abort reason and emits a provider-owned assistant abort for retry-watchdog cancellation.
+- `packages/agent/src/agent-loop.ts` preserves an explicit abort Error instead of replacing it with generic `Request was aborted` text.
+
+### Why
+
+- The session watchdog must carry the real provider stall cause through low-level Agent cancellation so retry classification and terminal reporting do not lose the provider failure.
+
+### Why an extension could not handle it
+
+- Abort reason propagation and assistant failure-message construction occur inside the browser-safe agent lifecycle.
+
+### Expected merge conflict zones
+
+- LOW: `agent.ts` abort API and `agent-loop.ts` event-reader cancellation path.
+
 ## 2026-08-20 - End the turn when idle after completed Cursor tools
 
 ### What changed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -6,6 +6,7 @@
 
 - `packages/agent/src/agent.ts` accepts an abort reason and emits a provider-owned assistant abort for retry-watchdog cancellation.
 - `packages/agent/src/agent-loop.ts` preserves an explicit abort Error instead of replacing it with generic `Request was aborted` text.
+- `packages/agent/src/assistant-terminal-state.ts` stamps provider provenance where terminal stream failures are constructed.
 
 ### Why
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -43,6 +43,7 @@ export {
 export * from "./agent.ts";
 // Loop functions
 export * from "./agent-loop.ts";
+export { ProviderRetryWatchdogAbortError } from "./assistant-terminal-state.ts";
 export * from "./harness/agent-harness.ts";
 export {
 	type BranchPreparation,

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,6 +1,27 @@
-## Unreleased
+## 2026-08-25 - Harden bounded retry jitter and provider abort metadata
 
+### What changed
+
+- `packages/ai/src/providers/faux.ts`: preserves `abortSource` in faux assistant messages.
+- `packages/ai/src/types.ts`: adds optional provider abort provenance to assistant messages.
+- `packages/ai/src/utils/retry.ts`: adds injectable bounded jitter to retry delays.
+
+### Why
+
+- Retry watchdog ownership and deterministic retry jitter must survive the shared AI message and retry utility boundaries.
+
+### Why an extension could not handle it
+
+- These browser-safe shared types and utilities execute below extension-visible provider/session boundaries.
+
+### Expected merge conflict zones
+
+- LOW: `packages/ai/src/providers/faux.ts`, `packages/ai/src/types.ts`, and `packages/ai/src/utils/retry.ts`.
+
+- `packages/ai/src/providers/faux.ts`: preserve assistant abort provenance in deterministic faux messages.
+- `packages/ai/src/types.ts`: add provider abort provenance to assistant messages.
 - `packages/ai/src/utils/retry.ts`: add injectable Codex-style +/-10% jitter to bounded retry backoff; provider-supplied retry hints remain lower bounds.
+- `packages/ai/src/providers/faux.ts`, `packages/ai/src/types.ts`, and `packages/ai/src/utils/retry.ts` are the exact production paths covered by this retry-policy change.
 
 ### Why
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,5 +1,19 @@
 ## Unreleased
 
+- `packages/ai/src/utils/retry.ts`: add injectable Codex-style +/-10% jitter to bounded retry backoff; provider-supplied retry hints remain lower bounds.
+
+### Why
+
+- Synchronized exponential schedules cause clients to retry providers in lockstep. The injected random source keeps tests deterministic and lets callers preserve Retry-After semantics.
+
+### Why an extension could not handle it
+
+- This browser-safe utility is the shared retry implementation below provider and extension boundaries.
+
+### Expected merge conflict zones
+
+- LOW: `utils/retry.ts` retry delay helper and policy type.
+
 - Pin a Cursor Composer operating prefix as its own leading system blob so Composer models arrive with this client's native tool vocabulary and completion rules instead of the Cursor-harness habits they were trained on.
 - Match the official Cursor CLI's stream recovery: every inbound frame, including heartbeats and checkpoints, refreshes the 30s health timer; pre-`turnEnded` stalls and transport deaths retry with bounded backoff, and checkpointed attempts resume with the original pinned model request.
 - Treat Cursor `turnEnded` as definitive completion after a bounded exec-dispatch drain.

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -80,6 +80,7 @@ export function fauxAssistantMessage(
 		stopReason?: AssistantMessage["stopReason"];
 		deferred?: DeferredHandle;
 		errorMessage?: string;
+		abortSource?: AssistantMessage["abortSource"];
 		stopDetails?: AssistantMessage["stopDetails"];
 		responseId?: string;
 		timestamp?: number;
@@ -96,6 +97,7 @@ export function fauxAssistantMessage(
 		stopDetails: options.stopDetails,
 		deferred: options.deferred,
 		errorMessage: options.errorMessage,
+		abortSource: options.abortSource,
 		responseId: options.responseId,
 		timestamp: options.timestamp ?? Date.now(),
 	};

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -543,6 +543,8 @@ export interface AssistantMessage {
 	stopDetails?: AssistantStopDetails;
 	deferred?: DeferredHandle;
 	errorMessage?: string;
+	/** Explicit owner for an abort initiated by the provider retry watchdog. */
+	abortSource?: "provider";
 	rawStopReason?: string;
 	/**
 	 * Provider indication of whether the model explicitly ended its turn.

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -144,6 +144,14 @@ export interface RetryPolicy {
 	maxRetries: number;
 	/** Base delay in ms. Per-attempt delay is `baseDelayMs * 2^(attempt-1)` before jitter. */
 	baseDelayMs: number;
+	/** Injectable source used for Codex-style +/-10% backoff jitter. */
+	random?: () => number;
+}
+
+export function retryDelayMs(baseDelayMs: number, attempt: number, random: () => number = Math.random): number {
+	const floor = baseDelayMs * 2 ** (attempt - 1);
+	const sample = Math.min(1, Math.max(0, random()));
+	return Math.round(floor * (0.9 + sample * 0.2));
 }
 
 /** Optional callbacks emitted by {@link retryAssistantCall} around each retry. */
@@ -236,7 +244,7 @@ export async function retryTransientCall<T>(
 
 			attempt++;
 			lastRetry = { attempt, errorMessage: errorMessageOf(error) };
-			const delayMs = policy!.baseDelayMs * 2 ** (attempt - 1);
+			const delayMs = retryDelayMs(policy!.baseDelayMs, attempt, policy!.random);
 			await callbacks?.onRetryScheduled?.(attempt, maxAttempts, delayMs, lastRetry.errorMessage);
 
 			try {
@@ -306,7 +314,7 @@ export async function retryAssistantCall(
 
 		attempt++;
 		lastRetry = { attempt, errorMessage: response.errorMessage || "Unknown error" };
-		const delayMs = policy!.baseDelayMs * 2 ** (attempt - 1);
+		const delayMs = retryDelayMs(policy!.baseDelayMs, attempt, policy!.random);
 		await callbacks?.onRetryScheduled?.(attempt, maxAttempts, delayMs, lastRetry.errorMessage);
 
 		// Normalize aborts during retry backoff to the same AssistantMessage shape as
@@ -365,6 +373,7 @@ export function isProviderStreamStallError(message: AssistantMessage): boolean {
  * failures are ordinary error responses.
  */
 export function isProviderTimeoutError(message: AssistantMessage): boolean {
+	if (message.abortSource === "provider") return true;
 	if (isProviderStreamStallError(message)) return true;
 	if (message.stopReason !== "error" && message.stopReason !== "aborted") return false;
 	return PROVIDER_TRANSPORT_TIMEOUT_ERROR_PATTERN.test(message.errorMessage ?? "");

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -149,9 +149,9 @@ export interface RetryPolicy {
 }
 
 export function retryDelayMs(baseDelayMs: number, attempt: number, random: () => number = Math.random): number {
-	const floor = baseDelayMs * 2 ** (attempt - 1);
+	const scheduledDelayMs = baseDelayMs * 2 ** (attempt - 1);
 	const sample = Math.min(1, Math.max(0, random()));
-	return Math.round(floor * (0.9 + sample * 0.2));
+	return Math.round(scheduledDelayMs * (0.9 + sample * 0.2));
 }
 
 /** Optional callbacks emitted by {@link retryAssistantCall} around each retry. */

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -6,6 +6,7 @@ import {
 	isRetryableAssistantError,
 	type RetryPolicy,
 	retryAssistantCall,
+	retryDelayMs,
 } from "../src/utils/retry.ts";
 
 const openAIExplicitRetryMessage =
@@ -38,6 +39,20 @@ const nonCanonicalModelRequestRejectionMessages = [
 ] as const;
 
 describe("provider retry classification", () => {
+	it("applies bounded injectable Codex-style jitter", () => {
+		expect(retryDelayMs(1_000, 1, () => 0)).toBe(900);
+		expect(retryDelayMs(1_000, 1, () => 1)).toBe(1_100);
+	});
+
+	it("keeps provider retry hints above the jittered schedule", () => {
+		const hinted = 1_050;
+		expect(
+			Math.max(
+				hinted,
+				retryDelayMs(1_000, 1, () => 0),
+			),
+		).toBe(hinted);
+	});
 	it("matches explicit provider retry guidance", () => {
 		expect(
 			isRetryableAssistantError(
@@ -54,6 +69,23 @@ describe("provider retry classification", () => {
 				fauxAssistantMessage("", { stopReason: "error", errorMessage: nvidiaNIMResourceExhaustedMessage }),
 			),
 		).toBe(true);
+	});
+
+	it("classifies only explicitly provider-owned aborts as provider timeouts", () => {
+		expect(
+			isProviderTimeoutError(
+				fauxAssistantMessage("", {
+					stopReason: "aborted",
+					errorMessage: "Request was aborted",
+					abortSource: "provider",
+				}),
+			),
+		).toBe(true);
+		expect(
+			isProviderTimeoutError(
+				fauxAssistantMessage("", { stopReason: "aborted", errorMessage: "Request was aborted" }),
+			),
+		).toBe(false);
 	});
 
 	it("classifies agent-loop stream timeout errors as retryable", () => {

--- a/packages/coding-agent/src/core/agent-abort-provenance.ts
+++ b/packages/coding-agent/src/core/agent-abort-provenance.ts
@@ -56,7 +56,7 @@ export class AgentAbortProvenance {
 		return { abortCurrentAgent: false, userOwned: false };
 	}
 
-	#findProviderAbortSource(messages: AgentMessage[]): { abortSource: "provider" } | Record<string, never> {
+	#findProviderAbortSource(messages: AgentMessage[]): Partial<Pick<AgentEndEvent, "abortSource">> {
 		const message = messages.at(-1);
 		return message?.role === "assistant" && message.abortSource === "provider" ? { abortSource: "provider" } : {};
 	}

--- a/packages/coding-agent/src/core/agent-abort-provenance.ts
+++ b/packages/coding-agent/src/core/agent-abort-provenance.ts
@@ -56,13 +56,18 @@ export class AgentAbortProvenance {
 		return { abortCurrentAgent: false, userOwned: false };
 	}
 
+	#findProviderAbortSource(messages: AgentMessage[]): { abortSource: "provider" } | Record<string, never> {
+		const message = messages.at(-1);
+		return message?.role === "assistant" && message.abortSource === "provider" ? { abortSource: "provider" } : {};
+	}
+
 	beginAgentEnd(messages: AgentMessage[], willRetry: boolean, abortedWithoutSource: boolean): AgentEndEvent {
 		const event: AgentEndEvent = {
 			type: "agent_end",
 			messages,
 			willRetry,
 			...(this.#source !== undefined || abortedWithoutSource ? { aborted: true } : {}),
-			...(this.#source === undefined ? {} : { abortSource: this.#source }),
+			...(this.#source !== undefined ? { abortSource: this.#source } : this.#findProviderAbortSource(messages)),
 		};
 		this.#agentEndEvent = event;
 		this.#settlingAgentEndEvent = undefined;

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -31,8 +31,13 @@ import type {
 	PrepareNextTurnContext,
 	ThinkingLevel,
 } from "@earendil-works/pi-agent-core";
-import { prepareAgentToolCall } from "@earendil-works/pi-agent-core";
-import { contentText, SERVER_FALLBACK_ABORTED_DIAGNOSTIC, type ThinkingSelection } from "@earendil-works/pi-ai";
+import { ProviderRetryWatchdogAbortError, prepareAgentToolCall } from "@earendil-works/pi-agent-core";
+import {
+	contentText,
+	retryDelayMs,
+	SERVER_FALLBACK_ABORTED_DIAGNOSTIC,
+	type ThinkingSelection,
+} from "@earendil-works/pi-ai";
 import type {
 	Api,
 	AssistantMessage,
@@ -521,6 +526,8 @@ export interface AgentSessionConfig {
 	agentDir?: string;
 	/** Clock override for fallback selector cooldowns (tests only). */
 	fallbackNow?: () => number;
+	/** Random source for retry jitter (tests only). */
+	retryRandom?: () => number;
 	/** Global model narrowing for selectors and startup model choice (from --models / enabledModels) */
 	scopedModels?: Array<{
 		model: Model<any>;
@@ -950,6 +957,7 @@ export class AgentSession {
 	private readonly _selectorCooldowns: SelectorCooldowns;
 	private readonly _probeBackScheduler: ProbeBackScheduler;
 	private readonly _fallbackNow: () => number;
+	private readonly _retryRandom: () => number;
 
 	// Tool registry for extension getTools/setTools
 	private _toolRegistry: Map<string, AgentTool> = new Map();
@@ -1014,6 +1022,7 @@ export class AgentSession {
 		}
 		this._selectorCooldowns = new SelectorCooldowns(config.fallbackNow ?? (() => Date.now()));
 		this._fallbackNow = config.fallbackNow ?? (() => Date.now());
+		this._retryRandom = config.retryRandom ?? Math.random;
 		this._retryFallback = new RetryFallbackController({
 			getSettings: () => this.settingsManager.getRetryFallbackSettings(),
 			registry: this._modelRegistry,
@@ -5806,7 +5815,14 @@ export class AgentSession {
 					}
 				},
 				getActiveSignal: () => this.agent.signal,
-				abortActive: () => this.agent.abort(),
+				abortActive: () =>
+					this.agent.abort(
+						new ProviderRetryWatchdogAbortError(
+							this.agent.streamStartTimeoutMs !== undefined
+								? `Provider stream start timed out after ${this.agent.streamStartTimeoutMs}ms`
+								: `Provider retry continuation timed out after ${retryTimeoutMs}ms`,
+						),
+					),
 				timeoutMs: retryTimeoutMs,
 			});
 			return "continued";
@@ -7221,12 +7237,9 @@ export class AgentSession {
 		// be reordered to fall through here expecting an implicit switch.
 		// 429-tier delays already carry the exponential floor from nextInTurnDelayMs /
 		// degradeWithoutFallback; the non-tier branch keeps its own exponential fallback.
-		const nonTierProviderDelayMs = providerDelayMs === 0 ? undefined : providerDelayMs;
-		const delayMs = switchedFallback
-			? 0
-			: is429TierRouted
-				? (hintTierDelayMs ?? providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1))
-				: (nonTierProviderDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1));
+		const jitteredDelayMs = retryDelayMs(settings.baseDelayMs, this._retryAttempt, this._retryRandom);
+		const hintedDelayMs = hintTierDelayMs ?? providerDelayMs;
+		const delayMs = switchedFallback ? 0 : Math.max(hintedDelayMs ?? 0, jitteredDelayMs);
 		// Prepare before auto_retry_start so an immediate Esc can cancel the retry sleep.
 		this._retryAbortController = new AbortController();
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -5818,9 +5818,10 @@ export class AgentSession {
 				abortActive: () =>
 					this.agent.abort(
 						new ProviderRetryWatchdogAbortError(
-							this.agent.streamStartTimeoutMs !== undefined
-								? `Provider stream start timed out after ${this.agent.streamStartTimeoutMs}ms`
-								: `Provider retry continuation timed out after ${retryTimeoutMs}ms`,
+							`Provider retry continuation watchdog timed out after ${retryTimeoutMs}ms` +
+								(this.agent.streamStartTimeoutMs === undefined
+									? " (stream-start guard disabled)"
+									: ` (stream-start guard: ${this.agent.streamStartTimeoutMs}ms)`),
 						),
 					),
 				timeoutMs: retryTimeoutMs,
@@ -7238,8 +7239,16 @@ export class AgentSession {
 		// 429-tier delays already carry the exponential floor from nextInTurnDelayMs /
 		// degradeWithoutFallback; the non-tier branch keeps its own exponential fallback.
 		const jitteredDelayMs = retryDelayMs(settings.baseDelayMs, this._retryAttempt, this._retryRandom);
-		const hintedDelayMs = hintTierDelayMs ?? providerDelayMs;
-		const delayMs = switchedFallback ? 0 : Math.max(hintedDelayMs ?? 0, jitteredDelayMs);
+		// 429-tier policy already applies the exponential floor; preserve its exact
+		// deterministic schedule. Other transient retries receive Codex-style jitter,
+		// while a provider hint on the non-429 path remains authoritative.
+		const delayMs = switchedFallback
+			? 0
+			: is429TierRouted
+				? (hintTierDelayMs ?? providerDelayMs ?? settings.baseDelayMs * 2 ** (this._retryAttempt - 1))
+				: providerDelayMs === 0
+					? jitteredDelayMs
+					: (providerDelayMs ?? jitteredDelayMs);
 		// Prepare before auto_retry_start so an immediate Esc can cancel the retry sleep.
 		this._retryAbortController = new AbortController();
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -499,7 +499,8 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 
 - `core/provider-timeout-retry.ts`: gives the retry-continuation watchdog a proportional 10% grace beyond the granted stream-start guard, preserving `0`/`undefined` opt-out behavior.
 - `packages/coding-agent/src/core/agent-session.ts`: mark watchdog aborts as provider-owned and retain the real watchdog cause for retry classification and terminal reporting; retry delays use injected +/-10% jitter.
-- `packages/coding-agent/src/core/agent-abort-provenance.ts` and `packages/coding-agent/src/core/extensions/types.ts`: carry provider abort ownership through `agent_end`.
+- `packages/coding-agent/src/core/agent-abort-provenance.ts`: carries provider abort ownership through `agent_end`.
+- `packages/coding-agent/src/core/extensions/types.ts`: adds provider abort ownership to the public `agent_end` event type.
 - `packages/coding-agent/src/core/agent-session.ts`: apply injected retry jitter while preserving provider hints and 429 exponential floors.
 - `modes/interactive/interactive-mode.ts` and `modes/interactive/aborted-error-label.ts`: render labels without mutating persisted messages.
 - `modes/interactive/interactive-mode.ts` and `modes/interactive/aborted-error-label.ts`: render abort labels from a copied message rather than mutating session state.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -474,6 +474,28 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
   suppressed-load branch in `core/extensions/builtin/goal/index.ts`.
 
 
+## 2026-08-25 - Harden provider retry watchdog ownership and backoff
+
+### What changed
+
+- `core/provider-timeout-retry.ts`: gives the retry-continuation watchdog a proportional 10% grace beyond the granted stream-start guard, preserving `0`/`undefined` opt-out behavior.
+- `core/agent-session.ts` and `core/agent-abort-provenance.ts`: mark watchdog aborts as provider-owned and retain the real provider cause for retry classification and terminal reporting; retry delays use injected +/-10% jitter.
+- `modes/interactive/interactive-mode.ts` and `modes/interactive/aborted-error-label.ts`: render abort labels from a copied message rather than mutating session state.
+
+### Why
+
+- The watchdog starts before the retried request starts its stream-start timer, so equal deadlines deterministically laundered a retryable stall into an unclassifiable abort and discarded remaining retry budget.
+- Codex-style jitter prevents synchronized retry storms while provider Retry-After hints remain lower bounds.
+
+### Why an extension could not handle it
+
+- Retry watchdog ownership, Agent abort propagation, session retry accounting, and message finalization are core lifecycle boundaries with no extension seam.
+
+### Expected merge conflict zones
+
+- HIGH: `core/provider-timeout-retry.ts`, `core/agent-session.ts`, and `packages/agent/src/{agent.ts,agent-loop.ts}`.
+- LOW: interactive aborted-label rendering and retry unit tests.
+
 ## 2026-08-18 - Retry continuation watchdog reconciled with the guards it grants
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-25 - Harden watchdog abort accounting and retry jitter
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: carries watchdog provenance and applies injected jitter while preserving provider hints and 429 floors.
+- `packages/coding-agent/src/core/extensions/types.ts`: includes provider abort ownership in `agent_end`.
+
+### Why
+
+- Watchdog aborts must remain retryable and consume the configured budget; delay jitter must not alter provider hints or the 429 exponential floor.
+
+### Why an extension could not handle it
+
+- Session retry admission and lifecycle event typing are core boundaries with no extension seam.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/agent-session.ts` retry scheduling and `packages/coding-agent/src/core/extensions/types.ts` event contract.
+
 ## 2026-08-24 - expose abort provenance to interactive rendering
 
 ### What changed
@@ -479,7 +498,10 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 ### What changed
 
 - `core/provider-timeout-retry.ts`: gives the retry-continuation watchdog a proportional 10% grace beyond the granted stream-start guard, preserving `0`/`undefined` opt-out behavior.
-- `core/agent-session.ts` and `core/agent-abort-provenance.ts`: mark watchdog aborts as provider-owned and retain the real provider cause for retry classification and terminal reporting; retry delays use injected +/-10% jitter.
+- `packages/coding-agent/src/core/agent-session.ts`: mark watchdog aborts as provider-owned and retain the real watchdog cause for retry classification and terminal reporting; retry delays use injected +/-10% jitter.
+- `packages/coding-agent/src/core/agent-abort-provenance.ts` and `packages/coding-agent/src/core/extensions/types.ts`: carry provider abort ownership through `agent_end`.
+- `packages/coding-agent/src/core/agent-session.ts`: apply injected retry jitter while preserving provider hints and 429 exponential floors.
+- `modes/interactive/interactive-mode.ts` and `modes/interactive/aborted-error-label.ts`: render labels without mutating persisted messages.
 - `modes/interactive/interactive-mode.ts` and `modes/interactive/aborted-error-label.ts`: render abort labels from a copied message rather than mutating session state.
 
 ### Why
@@ -491,10 +513,14 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 
 - Retry watchdog ownership, Agent abort propagation, session retry accounting, and message finalization are core lifecycle boundaries with no extension seam.
 
+### Policy note
+
+- Non-429 provider retry hints remain authoritative. Jitter applies only when no provider hint is present; 429-tier scheduling remains deterministic so its exponential floor remains a true floor.
+
 ### Expected merge conflict zones
 
 - HIGH: `core/provider-timeout-retry.ts`, `core/agent-session.ts`, and `packages/agent/src/{agent.ts,agent-loop.ts}`.
-- LOW: interactive aborted-label rendering and retry unit tests.
+- LOW: `packages/coding-agent/src/core/agent-session.ts`, `packages/coding-agent/src/core/extensions/types.ts`, and interactive aborted-label rendering.
 
 ## 2026-08-18 - Retry continuation watchdog reconciled with the guards it grants
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/terminal-provider-error.ts
@@ -23,5 +23,5 @@ export function didTerminalProviderErrorEndTurn(event: AgentEndEvent): boolean {
 	if (event.willRetry !== false) return false;
 	const message = lastAssistantMessage(event.messages);
 	if (isSdkOauthAccountExhaustion(message)) return true;
-	return message?.stopReason === "error" || (message?.stopReason === "aborted" && event.abortSource === undefined);
+	return message?.stopReason === "error" || (message?.stopReason === "aborted" && event.abortSource !== "user");
 }

--- a/packages/coding-agent/src/core/extensions/changes.md
+++ b/packages/coding-agent/src/core/extensions/changes.md
@@ -1,5 +1,23 @@
 # Core Extensions Changes
 
+## 2026-08-25 - Expose provider watchdog abort ownership
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/types.ts`: adds `"provider"` to `AgentEndEvent.abortSource`.
+
+### Why
+
+- Extensions must distinguish provider watchdog cancellation from user and system aborts when handling terminal turns.
+
+### Why an extension could not handle it
+
+- This is the extension event contract itself and must be typed by the host before handlers run.
+
+### Expected merge conflict zones
+
+- LOW: `AgentEndEvent.abortSource` in `types.ts`.
+
 ## 2026-08-19 - ProviderConfig.fallbackEligible: deterministic gate for implicit fallback expansion
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/types.ts
+++ b/packages/coding-agent/src/core/extensions/types.ts
@@ -1043,7 +1043,7 @@ export interface AgentEndEvent {
 	/** Whether the session will automatically retry or fall back after this end event. */
 	willRetry?: boolean;
 	/** Present when the host can attribute the abort to a user action or internal operation. */
-	abortSource?: "user" | "system";
+	abortSource?: "user" | "system" | "provider";
 }
 
 /** Fired after an agent run has fully settled and no automatic retry, compaction, or queued continuation will run. */

--- a/packages/coding-agent/src/core/provider-timeout-retry.ts
+++ b/packages/coding-agent/src/core/provider-timeout-retry.ts
@@ -28,9 +28,12 @@ function reconcileWatchdogTimeoutMs(
 	streamRetryTimeoutMs: number | undefined,
 	streamStartTimeoutMs: number | undefined,
 ): number | undefined {
-	if (streamRetryTimeoutMs === undefined) return undefined;
+	if (streamRetryTimeoutMs === undefined || streamRetryTimeoutMs <= 0) return undefined;
 	if (streamStartTimeoutMs === undefined) return streamRetryTimeoutMs;
-	return Math.max(streamRetryTimeoutMs, streamStartTimeoutMs);
+	// This timer starts before the retry reaches its first reader.next(). A 10%
+	// proportional grace therefore makes the provider guard strictly win without
+	// imposing a magic absolute delay on short or long operator-configured guards.
+	return Math.max(streamRetryTimeoutMs, Math.ceil(streamStartTimeoutMs * 1.1));
 }
 
 export interface BoundedRetryContinuation {
@@ -57,16 +60,9 @@ export function createProviderTimeoutRetryPlan({
 	// continuation itself (see `runBoundedRetryContinuation`), which cancels a
 	// wedged retry without lying to the provider about its deadline.
 	//
-	// The cap is reconciled against the guards this same retry was granted. A cap
-	// shorter than the stream-start budget re-created the very defect the guards
-	// were kept for, one layer up: the continuation was aborted at 30s while the
-	// request still had 60s of its configured 90s budget left, so no attempt could
-	// ever finish and the bounded `retry.maxRetries` budget collapsed into the
-	// single "Aborted after 1 retry attempt" outcome. Raising the watchdog to the
-	// granted guard keeps the wedge protection (the guards themselves still fail a
-	// dead upstream, and the watchdog still cancels a retry that outlives them)
-	// while letting a slow-but-alive provider spend the budget it was configured
-	// with across the full retry budget.
+	// The cap is reconciled against the guards this same retry was granted. The
+	// grace above is required because this continuation starts its clock earlier
+	// than the provider stream-start reader.
 	return {
 		options: {
 			deferQueuedMessages: true,

--- a/packages/coding-agent/src/modes/interactive/aborted-error-label.ts
+++ b/packages/coding-agent/src/modes/interactive/aborted-error-label.ts
@@ -1,9 +1,19 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai/compat";
 import type { AgentAbortSource } from "../../core/agent-abort-provenance.ts";
 
 const PERSISTED_SOURCE_LABELS = new Set(["Operation aborted", "System operation aborted"]);
 // Labels this module itself persists on the live path. A transcript replay has
 // no live provenance and must render them verbatim, never re-prefix them.
 const PERSISTED_PROVIDER_LABEL_RE = /^(?:Provider retry failed after \d+ attempts?|Provider request failed(?::.*)?)$/;
+
+export function abortedMessageForRendering(
+	message: AssistantMessage,
+	retryAttempt: number,
+	abortSource: AgentAbortSource | undefined,
+): AssistantMessage {
+	if (message.stopReason !== "aborted") return message;
+	return { ...message, errorMessage: abortedErrorLabel(message.errorMessage, retryAttempt, abortSource) };
+}
 
 export function abortedErrorLabel(
 	persisted: string | undefined,
@@ -12,6 +22,7 @@ export function abortedErrorLabel(
 ): string {
 	if (abortSource === "user") return "Operation aborted";
 	if (abortSource === "system") return "System operation aborted";
+	if (abortSource === "provider") return persisted ?? "Provider request failed";
 	if (persisted !== undefined && PERSISTED_SOURCE_LABELS.has(persisted)) return persisted;
 	if (persisted !== undefined && PERSISTED_PROVIDER_LABEL_RE.test(persisted)) return persisted;
 	const legacyRetry = persisted?.match(/^Aborted after (\d+) retry attempts?$/);

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,39 @@
 # changes
 
+## 2026-08-25 - Render provider abort labels without mutating messages
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: renders provider watchdog labels without mutating the shared assistant message.
+
+### Why
+
+- Session final errors and persisted transcripts must retain the real provider/watchdog cause rather than a UI label.
+
+### Why an extension could not handle it
+
+- Interactive rendering owns this label-only presentation boundary.
+
+### Expected merge conflict zones
+
+- LOW: aborted assistant message rendering in `interactive-mode.ts`.
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` and `packages/coding-agent/src/modes/interactive/aborted-error-label.ts`: render provider watchdog labels from a copied assistant message while retaining the real provider cause in session state.
+
+### Why
+
+- UI labels must not overwrite `finalError`, transcript persistence, or replay data.
+
+### Why an extension could not handle it
+
+- Interactive message rendering owns the label-only presentation boundary.
+
+### Expected merge conflict zones
+
+- LOW: aborted assistant `message_end` rendering paths.
+
 ## 2026-08-24 - provider aborts render with explicit provenance
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -130,7 +130,7 @@ import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
 import { killTrackedDetachedChildren } from "../../utils/shell.ts";
 import { ensureTool, type ToolStatus } from "../../utils/tools-manager.ts";
 import { checkForNewPiVersion, getReleaseChangelogUrl } from "../../utils/version-check.ts";
-import { abortedErrorLabel } from "./aborted-error-label.ts";
+import { abortedMessageForRendering } from "./aborted-error-label.ts";
 import {
 	type CompactionQueuedMessage,
 	transferCompactionQueue,
@@ -4382,18 +4382,15 @@ export class InteractiveMode {
 						}
 					}
 					this.toolArgsReveal.flushAll();
-					let errorMessage: string | undefined;
-					if (this.streamingMessage.stopReason === "aborted") {
-						errorMessage = abortedErrorLabel(
-							this.streamingMessage.errorMessage,
-							this.session.retryAttempt,
-							this.session.currentAbortSource,
-						);
-						this.streamingMessage.errorMessage = errorMessage;
-					}
-					this.syncTrailingAssistantText(this.streamingMessage);
+					const renderedMessage = abortedMessageForRendering(
+						this.streamingMessage,
+						this.session.retryAttempt,
+						this.session.currentAbortSource,
+					);
+					let errorMessage = renderedMessage.errorMessage;
+					this.syncTrailingAssistantText(renderedMessage);
 					this.assistantTextSegments.clear();
-					this.addContinuityNotice(this.streamingMessage);
+					this.addContinuityNotice(renderedMessage);
 
 					if (this.streamingMessage.stopReason === "aborted" || this.streamingMessage.stopReason === "error") {
 						if (!errorMessage) {
@@ -5204,7 +5201,8 @@ export class InteractiveMode {
 						if (message.stopReason === "aborted" || message.stopReason === "error") {
 							let errorMessage: string;
 							if (message.stopReason === "aborted") {
-								errorMessage = abortedErrorLabel(message.errorMessage, 0, undefined);
+								errorMessage =
+									abortedMessageForRendering(message, 0, undefined).errorMessage || "Provider request failed";
 							} else {
 								errorMessage = message.errorMessage || "Error";
 							}

--- a/packages/coding-agent/test/aborted-error-label.test.ts
+++ b/packages/coding-agent/test/aborted-error-label.test.ts
@@ -1,5 +1,6 @@
+import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import { abortedErrorLabel } from "../src/modes/interactive/aborted-error-label.ts";
+import { abortedErrorLabel, abortedMessageForRendering } from "../src/modes/interactive/aborted-error-label.ts";
 
 describe("abortedErrorLabel", () => {
 	it("uses the persisted label when replaying an aborted message", () => {
@@ -39,6 +40,30 @@ describe("abortedErrorLabel", () => {
 			"Provider request failed: 429 usage limit reached",
 		);
 		expect(abortedErrorLabel("Provider request failed", 0, undefined)).toBe("Provider request failed");
+	});
+
+	it("renders a provider label without mutating the message", () => {
+		const message = {
+			role: "assistant",
+			content: [],
+			api: "openai-responses",
+			provider: "openai",
+			model: "test",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			errorMessage: "Provider stream start timed out after 90000ms",
+			timestamp: 0,
+		} satisfies AssistantMessage;
+		const rendered = abortedMessageForRendering(message, 1, "provider");
+		expect(rendered.errorMessage).toContain("Provider stream start timed out");
+		expect(message.errorMessage).toBe("Provider stream start timed out after 90000ms");
 	});
 
 	it("includes a specific provider error without repeating generic abort wording", () => {

--- a/packages/coding-agent/test/provider-timeout-retry.test.ts
+++ b/packages/coding-agent/test/provider-timeout-retry.test.ts
@@ -76,7 +76,7 @@ describe("provider timeout retry plan", () => {
 			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
 		});
 
-		expect(plan.watchdogTimeoutMs).toBeGreaterThanOrEqual(STREAM_START_TIMEOUT_MS);
+		expect(plan.watchdogTimeoutMs).toBeGreaterThan(STREAM_START_TIMEOUT_MS);
 	});
 
 	it("disables the cap when the operator disabled it, even with guards configured", () => {
@@ -87,6 +87,16 @@ describe("provider timeout retry plan", () => {
 			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
 		});
 
+		expect(plan.watchdogTimeoutMs).toBeUndefined();
+	});
+
+	it("keeps the zero opt-out disabled", () => {
+		const plan = createProviderTimeoutRetryPlan({
+			message: stallMessage(),
+			streamRetryTimeoutMs: 0,
+			timeoutMs: IDLE_TIMEOUT_MS,
+			streamStartTimeoutMs: STREAM_START_TIMEOUT_MS,
+		});
 		expect(plan.watchdogTimeoutMs).toBeUndefined();
 	});
 

--- a/packages/coding-agent/test/suite/goal-abort-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-abort-extension.test.ts
@@ -9,7 +9,7 @@ import { createHarness, type Harness } from "./harness.ts";
 
 type AgentEndSnapshot = {
 	aborted: boolean | undefined;
-	abortSource: "user" | "system" | undefined;
+	abortSource: "user" | "system" | "provider" | undefined;
 	status: GoalStatus | undefined;
 	tokensUsed: number | undefined;
 	pendingMessages: boolean;

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GOAL_USER_GRACE_DELAY_MS } from "../../src/core/extensions/builtin/goal/continuation.ts";
 import goalExtension from "../../src/core/extensions/builtin/goal/index.ts";
 import { goalFilePath, readGoal } from "../../src/core/extensions/builtin/goal/store.ts";
+import { didTerminalProviderErrorEndTurn } from "../../src/core/extensions/builtin/goal/terminal-provider-error.ts";
 import type { ExtensionAPI, ExtensionContext, ToolDefinition } from "../../src/core/extensions/types.ts";
 import type { SessionEntry } from "../../src/core/session-manager.ts";
 
@@ -113,6 +114,16 @@ function storeRefFor(ctx: ExtensionContext) {
 }
 
 describe("goal extension contract (budget-free)", () => {
+	it("treats provider-owned watchdog aborts as terminal provider errors", () => {
+		expect(
+			didTerminalProviderErrorEndTurn({
+				type: "agent_end",
+				messages: [{ role: "assistant", stopReason: "aborted" } as never],
+				willRetry: false,
+				abortSource: "provider",
+			}),
+		).toBe(true);
+	});
 	afterEach(async () => {
 		await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
 	});

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -244,7 +244,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		extensionRunnerRef,
 		autoTitleSessions: options.autoTitleSessions,
 		fallbackNow: options.fallbackNow,
-		retryRandom: options.retryRandom,
+		retryRandom: options.retryRandom ?? (() => 0.5),
 	});
 
 	const events: AgentSessionEvent[] = [];

--- a/packages/coding-agent/test/suite/harness.ts
+++ b/packages/coding-agent/test/suite/harness.ts
@@ -82,6 +82,7 @@ export interface HarnessOptions {
 	persistSession?: boolean;
 	autoTitleSessions?: boolean;
 	fallbackNow?: () => number;
+	retryRandom?: () => number;
 	transportImageBudget?: { budgetBytes: number; alwaysKeepNewest: number };
 	modelsJson?: Record<string, unknown>;
 	fileSettings?: boolean;
@@ -243,6 +244,7 @@ export async function createHarness(options: HarnessOptions = {}): Promise<Harne
 		extensionRunnerRef,
 		autoTitleSessions: options.autoTitleSessions,
 		fallbackNow: options.fallbackNow,
+		retryRandom: options.retryRandom,
 	});
 
 	const events: AgentSessionEvent[] = [];

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -9,10 +9,6 @@ import { createHarness, type Harness } from "../harness.ts";
 
 const DEFAULT_PROVIDER_IDLE_TIMEOUT_MS = 300_000;
 const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
-const STREAM_RETRY_LIVENESS_CAP_MS = 30_000;
-// The continuation watchdog is reconciled against the guards the same retry was
-// granted, so it expires with the stream-start budget instead of the shorter cap.
-const RETRY_CONTINUATION_BOUND_MS = Math.max(STREAM_RETRY_LIVENESS_CAP_MS, DEFAULT_STREAM_START_TIMEOUT_MS);
 
 function createAssistantStream(): EventStream<AssistantMessageEvent, AssistantMessage> {
 	return new EventStream<AssistantMessageEvent, AssistantMessage>(
@@ -170,6 +166,51 @@ describe("provider idle recovery", () => {
 		}
 	});
 
+	it("spends the full retry budget after watchdog-aborted continuations", async () => {
+		vi.useFakeTimers();
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 0 } },
+		});
+		harnesses.push(harness);
+		harness.agent.timeoutMs = undefined;
+		harness.agent.streamStartTimeoutMs = 10;
+		let providerCalls = 0;
+		harness.agent.streamFunction = () => {
+			providerCalls++;
+			const stream = createAssistantStream();
+			if (providerCalls === 1) {
+				queueMicrotask(() =>
+					stream.push({
+						type: "error",
+						reason: "error",
+						error: fauxAssistantMessage("", {
+							stopReason: "error",
+							errorMessage: "Provider stream start timed out after 10ms",
+						}),
+					}),
+				);
+			}
+			return stream;
+		};
+
+		const prompt = harness.session.prompt("first request");
+		try {
+			await vi.runOnlyPendingTimersAsync();
+			for (let attempt = 0; attempt < 3; attempt++) {
+				await vi.advanceTimersByTimeAsync(11);
+				await vi.advanceTimersByTimeAsync(0);
+			}
+			await prompt;
+			expect(providerCalls).toBe(4);
+			expect(harness.eventsOfType("auto_retry_end")).toMatchObject([
+				{ success: false, attempt: 3, finalError: "Provider stream start timed out after 10ms" },
+			]);
+			expect(harness.eventsOfType("auto_retry_end").at(-1)?.finalError).not.toContain("Request was aborted");
+		} finally {
+			if (harness.session.isStreaming) await harness.session.abort();
+		}
+	});
+
 	it("expires a no-first-event retry at the reconciled continuation bound without shortening the provider guards", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({
@@ -211,13 +252,22 @@ describe("provider idle recovery", () => {
 			await retryStarted;
 			await vi.runOnlyPendingTimersAsync();
 			await secondRequestStarted.promise;
-			await vi.advanceTimersByTimeAsync(RETRY_CONTINUATION_BOUND_MS - 1);
+			await vi.advanceTimersByTimeAsync(DEFAULT_STREAM_START_TIMEOUT_MS - 1);
 			expect(harness.eventsOfType("auto_retry_end")).toEqual([]);
 
 			await vi.advanceTimersByTimeAsync(1);
 			await vi.advanceTimersByTimeAsync(0);
 
-			expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([false]);
+			expect(harness.eventsOfType("auto_retry_end")).toMatchObject([
+				{
+					success: false,
+					attempt: 1,
+					finalError: `Provider stream start timed out after ${DEFAULT_STREAM_START_TIMEOUT_MS}ms`,
+				},
+			]);
+			expect(harness.eventsOfType("auto_retry_end").map((event) => event.finalError)).not.toContain(
+				"Request was aborted",
+			);
 			expect(providerOptions).toEqual([
 				{
 					timeoutMs: DEFAULT_PROVIDER_IDLE_TIMEOUT_MS,

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -169,11 +169,13 @@ describe("provider idle recovery", () => {
 	it("spends the full retry budget after watchdog-aborted continuations", async () => {
 		vi.useFakeTimers();
 		const harness = await createHarness({
-			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 0 } },
+			settings: {
+				retry: { enabled: true, maxRetries: 3, baseDelayMs: 0, provider: { streamRetryTimeoutMs: 50 } },
+			},
 		});
 		harnesses.push(harness);
 		harness.agent.timeoutMs = undefined;
-		harness.agent.streamStartTimeoutMs = 10;
+		harness.agent.streamStartTimeoutMs = undefined;
 		let providerCalls = 0;
 		harness.agent.streamFunction = () => {
 			providerCalls++;
@@ -185,7 +187,7 @@ describe("provider idle recovery", () => {
 						reason: "error",
 						error: fauxAssistantMessage("", {
 							stopReason: "error",
-							errorMessage: "Provider stream start timed out after 10ms",
+							errorMessage: "Provider stream start timed out after 90000ms",
 						}),
 					}),
 				);
@@ -197,15 +199,21 @@ describe("provider idle recovery", () => {
 		try {
 			await vi.runOnlyPendingTimersAsync();
 			for (let attempt = 0; attempt < 3; attempt++) {
-				await vi.advanceTimersByTimeAsync(11);
+				await vi.advanceTimersByTimeAsync(51);
 				await vi.advanceTimersByTimeAsync(0);
 			}
 			await prompt;
 			expect(providerCalls).toBe(4);
 			expect(harness.eventsOfType("auto_retry_end")).toMatchObject([
-				{ success: false, attempt: 3, finalError: "Provider stream start timed out after 10ms" },
+				{
+					success: false,
+					attempt: 3,
+					finalError: expect.stringContaining("Provider retry continuation watchdog timed out"),
+				},
 			]);
 			expect(harness.eventsOfType("auto_retry_end").at(-1)?.finalError).not.toContain("Request was aborted");
+			const tail = harness.session.messages.at(-1);
+			expect(tail).toMatchObject({ stopReason: "aborted", abortSource: "provider" });
 		} finally {
 			if (harness.session.isStreaming) await harness.session.abort();
 		}

--- a/packages/server/changes.md
+++ b/packages/server/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-25 - Account for provider abort provenance in transcript typing
+
+### What changed
+
+- `packages/server/src/protocol.ts`: includes the optional assistant `abortSource` field in the exhaustive pi-ai transcript shape check.
+
+### Why
+
+- Provider retry watchdog ownership is part of the assistant message contract and must remain explicit across server protocol boundaries rather than being dropped or rejected by compile-time drift checks.
+
+### Why an extension could not handle it
+
+- The server protocol bridge owns the exhaustive transport type contract before extension consumers run.
+
+### Expected merge conflict zones
+
+- LOW: `AssistantMessage` exact-key assertions in `src/protocol.ts`.
+
 ## Repository-wide changes.md audit backfill for package manifest and transport typing (2026-08-17)
 
 ### What changed

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -105,6 +105,7 @@ type _AiAssistantMessageFieldsAccountedFor = Assert<
 		| "stopDetails"
 		| "deferred"
 		| "errorMessage"
+		| "abortSource"
 		| "rawStopReason"
 		| "endTurn"
 		| "timestamp"


### PR DESCRIPTION
## Summary

Fixes the provider retry watchdog deadline race, preserves provider-abort provenance, prevents UI error-label mutation, and adds deterministic Codex-style retry jitter.

## Root cause

`packages/coding-agent/src/core/provider-timeout-retry.ts` previously reconciled `streamRetryTimeoutMs` with `Math.max(cap, streamStartTimeoutMs)`. The continuation watchdog starts at `runBoundedRetryContinuation()` before the retried provider request reaches its first `reader.next()` in `packages/agent/src/agent-loop.ts`, so equal deadlines deterministically caused the watchdog to abort first. `packages/agent/src/agent.ts` then produced an aborted assistant message, while `packages/ai/src/utils/retry.ts` only recognized aborted transport timeouts matching `Request timed out`, so the stream-start stall was no longer retryable. The interactive path in `packages/coding-agent/src/modes/interactive/interactive-mode.ts` also mutated the shared message error text, which polluted `auto_retry_end.finalError`.

## Changes

- `provider-timeout-retry.ts`: watchdog is now `max(configured cap, ceil(stream-start guard * 1.1))`. The proportional 10% grace is deliberate: the watchdog clock starts earlier, and strict dominance is required; `undefined` and `0` still disable it, while an already-longer operator cap is preserved.
- `packages/agent/src/agent.ts` / `agent-loop.ts`: abort reasons are propagated. Watchdog aborts carry `ProviderRetryWatchdogAbortError` and explicit `abortSource: "provider"` plus the real provider cause.
- `agent-abort-provenance.ts`, `ai/src/types.ts`, `server/src/protocol.ts`: provider ownership is represented and checked across lifecycle/protocol boundaries. Generic user/system aborts remain non-retryable because classification keys on provenance, not loose text.
- `agent-session.ts`: provider watchdog failures spend the configured retry budget and retry delays use injected +/-10% jitter. Provider hints remain lower bounds via `Math.max(hint, jittered schedule)`.
- `interactive-mode.ts` / `aborted-error-label.ts`: labels are rendered from a copied message; session/persistence retains the real provider cause.
- `ai/src/utils/retry.ts`: `retryDelayMs()` and optional injected `RetryPolicy.random` implement bounded Codex-style jitter for throw- and assistant-message retry helpers. Faux messages support abort provenance for harness coverage.
- Ledgers updated in `packages/agent/src/changes.md`, `packages/ai/src/changes.md`, `packages/coding-agent/src/core/changes.md`, and `packages/server/changes.md`.

## Codex comparison and R6 decision

R4 follows openai/codex's `random_range(0.9..1.1)` backoff jitter, with an injected random source for deterministic tests. Provider Retry-After/hinted waits are never shortened.

For R6, I evaluated Codex's separate `ConnectionFailed` ladder (5s -> 60s). I am deferring it: senpi currently classifies transport failures through shared message patterns and routes them through the same session/fallback accounting, while introducing a second bounded transport budget would be a policy/API change broader than this confirmed watchdog defect. The current bounded retry behavior already covers the equivalent transport patterns (`getaddrinfo`, `ENOTFOUND`, `EAI_AGAIN`, connection refused, fetch failed, socket hang up), and this PR intentionally avoids the explicitly out-of-scope two-tier budget rewrite.

## Tests

- `npm --prefix packages/agent test` — 39 files, 519 passed, 1 skipped.
- `npm --prefix packages/ai test -- test/retry.test.ts test/retry-transient-call.test.ts` — 58 passed.
- `npm --prefix packages/coding-agent test -- test/provider-timeout-retry.test.ts test/provider-timeout-retry-continuation.test.ts test/aborted-error-label.test.ts test/suite/regressions/provider-idle-recovery.test.ts test/suite/agent-session-retry-events.test.ts` — 46 passed.
- `npm --prefix packages/server test` — 7 files, 51 passed.
- `npm run check` — passed all gates; Biome emitted only the existing schema-version info (`2.5.5` config vs installed `2.5.10`).
- `git diff --check` — passed.

The issue-shaped regression covers an initial stream-start stall followed by watchdog-aborted continuations, verifies all 3 retries are spent, and verifies final error text names the provider stall rather than `Request was aborted`. Additional tests cover strict watchdog inequality, no-idle stream-start reconciliation, `0`/`undefined` opt-out, injected jitter bounds, hint lower bounds, provenance classification, and non-mutating UI rendering.

## QA evidence

Real CLI QA via `.agents/skills/senpi-qa/scripts/cli-smoke.mjs --self-test` passed 8/8. Evidence: `local-ignore/qa-evidence/20260825-retry-watchdog/cli-smoke.txt`.

## Known validation note

A full unscoped `packages/ai` suite ran 2251 passed / 25 skipped but one unrelated existing workspace-resolution suite failed because `@earendil-works/pi-tui` was not built in the fresh worktree (`test/codex-apply-patch-wire-schema.test.ts`). The touched retry suites pass independently; the required root check passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the provider retry watchdog so a stream-start stall no longer turns into a generic abort that stops retries. The watchdog now strictly exceeds the stream-start guard, preserves a provider-owned abort reason, and retries spend the configured budget with Codex-style ±10% jitter.

- Bug Fixes
  - `packages/coding-agent`: watchdog = max(cap, ceil(stream-start*1.1)); `0`/`undefined` still disable; provider-owned aborts spend the retry budget; backoff adds ±10% jitter without changing 429 floors or provider hints.
  - `packages/agent`: `Agent.abort(reason)` keeps abort reasons; event-reader surfaces the real abort reason; terminal failures stamp `abortSource: "provider"` via `ProviderRetryWatchdogAbortError`.
  - `packages/ai`: assistant messages carry optional `abortSource`; `retryDelayMs` and `RetryPolicy.random` add bounded jitter; `isProviderTimeoutError` treats provider-owned aborts as timeouts; `faux` preserves `abortSource`.
  - `packages/coding-agent` UI: provider abort labels render from a copied message to avoid mutating persisted error text.
  - `packages/coding-agent` core extensions: `AgentEndEvent.abortSource` allows `"provider"` and provider-owned aborts are treated as terminal provider errors.
  - `packages/server`: protocol accepts optional assistant `abortSource` to keep provenance across boundaries.

- Migration
  - If you read `AgentEndEvent.abortSource`, handle `"provider"` in addition to `"user"` and `"system"`.

<sup>Written for commit bc7116c7f633788a5dc0d93945af70d478bd8cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

