### PR TITLE
fix(coding-agent): stop polling after loop-guard blocks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Fixed
 
+- Loop-guard blocks for terminal/task polling now direct the agent to stop
+  repeating the target and use a monitor, supported completion notification, or
+  re-plan instead of changing arguments to evade escalation.
 - The interactive TUI resume hint now uses the brand executable name (`APP_COMMAND`) instead of the display name, so a brand whose binary is `omo` no longer prints `OmO --session <id>`.
 - TTSR now watches streamed tool-call arguments and interrupts collapse floods inside tool inputs, preventing corrupted argument generations from reaching persisted session history.
 

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/changes.md
@@ -1,5 +1,18 @@
 # loop-guard changes
 
+## loop-guard: give polling blocks a terminal recovery action (2026-08-25)
+
+- Block reasons for `bash_output` and `task_output` now tell the agent to stop
+  polling, arm a monitor or rely on a supported completion notification when
+  waiting is appropriate, and otherwise re-plan.
+- Other blocked tools keep generic reuse, stop, re-plan, or alternate-tool
+  guidance without implying that a monitor exists.
+- Why: the previous generic instruction to change an argument deliberately
+  allowed same-target polling to evade identical-loop escalation.
+- Tests cover the polling and non-polling recovery branches.
+- Expected merge conflict zones: LOW in `notice.ts` and this tracker entry;
+  NONE in public extension APIs.
+
 ## loop-guard: block ignored identical loops and interrupt persistent hard stops (2026-08-17)
 
 - Exact identical loops now hard-escalate after two admitted reminders. The

--- a/packages/coding-agent/src/core/extensions/builtin/loop-guard/notice.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop-guard/notice.ts
@@ -11,10 +11,15 @@ export interface LoopGuardEscalationDetails {
 	readonly blockedCallCount: number;
 }
 
+const POLLING_TOOL_NAMES = new Set(["bash_output", "task_output"]);
+
 export function buildLoopGuardBlockReason(toolName: string, blockedCallCount: number): string {
+	const recovery = POLLING_TOOL_NAMES.has(toolName)
+		? "Stop polling this target. If you need to wait for a change, arm a monitor or rely on a completion notification when this mode supports it; otherwise re-plan or choose a different tool."
+		: "Reuse the existing result, stop repeating this call, and re-plan from the current goal or choose a different tool.";
 	return [
 		`Loop guard blocked repeated call ${blockedCallCount} to \`${toolName}\` with arguments that already triggered two identical-call warnings.`,
-		"Reuse the existing result, change an argument deliberately, or choose a different tool.",
+		recovery,
 	].join(" ");
 }
 

--- a/packages/coding-agent/test/suite/loop-guard-extension.test.ts
+++ b/packages/coding-agent/test/suite/loop-guard-extension.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { LoopGuardDetection } from "../../src/core/extensions/builtin/loop-guard/detectors.ts";
 import loopGuardExtension from "../../src/core/extensions/builtin/loop-guard/index.ts";
-import { LOOP_GUARD_NOTICE_CUSTOM_TYPE } from "../../src/core/extensions/builtin/loop-guard/notice.ts";
+import {
+	buildLoopGuardBlockReason,
+	LOOP_GUARD_NOTICE_CUSTOM_TYPE,
+} from "../../src/core/extensions/builtin/loop-guard/notice.ts";
 import { renderLoopGuardNotice } from "../../src/core/extensions/builtin/loop-guard/renderer.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
@@ -56,6 +59,23 @@ function userInput(fire: LoopGuardHarness["fire"], source: "interactive" | "rpc"
 }
 
 describe("loop-guard extension", () => {
+	it("gives polling tools a terminal recovery action instead of argument mutation", () => {
+		const reason = buildLoopGuardBlockReason("bash_output", 1);
+		const normalized = reason.toLowerCase();
+
+		expect(normalized).toContain("arm a monitor");
+		expect(normalized).toContain("stop polling");
+		expect(normalized).not.toContain("change an argument");
+	});
+
+	it("keeps non-polling recovery actionable without requiring a monitor", () => {
+		const reason = buildLoopGuardBlockReason("read", 1);
+		const normalized = reason.toLowerCase();
+
+		expect(normalized).toContain("re-plan");
+		expect(normalized).not.toContain("monitor");
+	});
+
 	it("registers the notice renderer under the notice custom type", () => {
 		const harness = createLoopGuardHarness();
 		expect(harness.renderers.get(LOOP_GUARD_NOTICE_CUSTOM_TYPE)).toBe(renderLoopGuardNotice);


### PR DESCRIPTION
## Summary
Blocked polling calls now direct the agent to stop repeating the target and use a monitor, a supported completion notification, or re-plan instead of changing arguments to evade identical-loop escalation. Non-polling tools retain generic recovery guidance.

## Changes
- Added exact polling-tool classification for `bash_output` and `task_output`.
- Replaced the misleading argument-mutation recovery instruction with conditional stop-and-recovery guidance.
- Added focused branch tests, loop-guard tracker notes, and the required package CHANGELOG entry.

## QA & Evidence
- RED: focused `loop-guard-extension.test.ts` failed on the old recovery wording (2 new assertions failed; existing 10 tests passed).
- GREEN: focused suite passed 12/12.
- Regression: all 7 loop-guard suites passed, 57/57 tests.
- Final affected suites passed 25/25.
- `npm run check`: exit 0; unrelated Biome rewrites on two pre-existing main-branch tests were reverted.
- `npm run build`: exit 0.
- Real Bun driver and extension integration QA passed for `bash_output`, `task_output`, and `read`.
- Evidence: `local-ignore/qa-evidence/20260825-loop-guard-polling-recovery/README.md`.

## Risks & Residuals
- The polling classification intentionally follows existing loop-guard tool-name literals and is limited to the two polling tools in scope.
- Full-suite app-server port-bind flakes are pre-existing and unrelated; focused loop-guard and build/check gates are green.

## Related Issues
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loop-guard blocks on `bash_output` and `task_output` now tell the agent to stop polling and either arm a monitor/use a completion notification or re-plan. Previously we suggested changing an argument, which let identical polling loops evade escalation.

**Bug Fixes**
- Non-polling tools keep actionable reuse/stop/re-plan guidance without implying monitors.
- Tests cover both polling and non-polling recovery paths; no public API changes.

<sup>Written for commit 40be3951deb5a5fe753a8f2990e13d554870a861. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

