### PR TITLE
fix: route Cursor quota resource_exhausted to provider fallback instead of overflow compaction

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Cursor `resource_exhausted` errors with token usage below half the model context window are now classified as usage-pool exhaustion instead of context overflow, while zero-token errors and legacy no-window detection remain unchanged.
+
 ### Removed
 
 ## [2026.8.24] - 2026-08-24

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,21 @@
+## 2026-08-25 - Distinguish Cursor usage-pool exhaustion from context overflow
+
+### What changed
+
+- `packages/ai/src/utils/overflow.ts`: token-bearing Cursor `resource_exhausted` errors are context overflow only at or above half the supplied context window; added `isCursorQuotaResourceExhausted` for below-half usage-pool failures while preserving zero-token and no-window behavior.
+
+### Why
+
+- Cursor uses the same bare `resource_exhausted` status for quota exhaustion and context overflow. Proximity to the model window is the verified discriminator.
+
+### Why an extension could not handle it
+
+- Overflow classification is a provider-neutral AI utility below extension-visible session behavior.
+
+### Expected merge conflict zones
+
+- LOW: Cursor `resource_exhausted` handling in `packages/ai/src/utils/overflow.ts`.
+
 ## 2026-08-25 - Harden bounded retry jitter and provider abort metadata
 
 ### What changed

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -155,7 +155,12 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 		const usage = message.usage;
 		const hasTokenEvidence =
 			(usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite) > 0;
-		if (!isNonOverflow && hasTokenEvidence && RESOURCE_EXHAUSTED_PATTERN.test(message.errorMessage)) {
+		if (
+			!isNonOverflow &&
+			hasTokenEvidence &&
+			RESOURCE_EXHAUSTED_PATTERN.test(message.errorMessage) &&
+			(contextWindow === undefined || contextWindow <= 0 || cursorZeroTokenCount(message) >= contextWindow * 0.5)
+		) {
 			return true;
 		}
 	}
@@ -219,6 +224,29 @@ export function isCursorPayloadResourceExhausted(
 		return false;
 	}
 	return !(cursorZeroTokenCount(message) > 0);
+}
+
+/**
+ * Detects Cursor's verified usage-pool exhaustion signature: a token-bearing
+ * `resource_exhausted` error while the conversation is well below the model
+ * context window.
+ */
+export function isCursorQuotaResourceExhausted(
+	message: {
+		stopReason?: string;
+		errorMessage?: string;
+		usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; totalTokens?: number };
+	},
+	contextWindow: number,
+): boolean {
+	const tokens = cursorZeroTokenCount(message);
+	return (
+		message.stopReason === "error" &&
+		RESOURCE_EXHAUSTED_PATTERN.test(message.errorMessage || "") &&
+		contextWindow > 0 &&
+		tokens > 0 &&
+		tokens < contextWindow * 0.5
+	);
 }
 
 export function isCursorZeroTokenResourceExhausted(message: {

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AssistantMessage } from "../src/types.ts";
-import { isContextOverflow, isRecoverableLength } from "../src/utils/overflow.ts";
+import { isContextOverflow, isCursorQuotaResourceExhausted, isRecoverableLength } from "../src/utils/overflow.ts";
 
 function createErrorMessage(errorMessage: string): AssistantMessage {
 	return {
@@ -94,18 +94,43 @@ describe("isContextOverflow", () => {
 		expect(isContextOverflow(rfcStyle, 200000)).toBe(true);
 	});
 
-	it("treats token-bearing resource_exhausted errors as context overflow", () => {
+	it("does not treat tiny token-bearing resource_exhausted usage as context overflow", () => {
 		const message = createErrorMessage("Connect error resource_exhausted");
 		message.usage.output = 12;
 		message.usage.totalTokens = 12;
-		expect(isContextOverflow(message, 200_000)).toBe(true);
+		expect(isContextOverflow(message, 200_000)).toBe(false);
 	});
 
-	it("treats token-bearing gRPC trailer resource_exhausted errors as context overflow", () => {
+	it("treats token-bearing resource_exhausted usage near the context window as overflow", () => {
 		const message = createErrorMessage("gRPC error 8: resource_exhausted");
-		message.usage.output = 3;
-		message.usage.totalTokens = 3;
-		expect(isContextOverflow(message, 200_000)).toBe(true);
+		message.usage.totalTokens = 600_000;
+		expect(isContextOverflow(message, 1_048_576)).toBe(true);
+	});
+
+	it("preserves legacy token-bearing resource_exhausted overflow detection without a context window", () => {
+		const message = createErrorMessage("Connect error resource_exhausted");
+		message.usage.totalTokens = 12;
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
+	it("identifies Cursor usage-pool exhaustion below half the context window", () => {
+		const message = createErrorMessage("Connect error resource_exhausted: Error");
+		message.usage.totalTokens = 178_626;
+		expect(isContextOverflow(message, 1_048_576)).toBe(false);
+		expect(isCursorQuotaResourceExhausted(message, 1_048_576)).toBe(true);
+	});
+
+	it("does not identify Cursor context overflow as usage-pool exhaustion", () => {
+		const message = createErrorMessage("Connect error resource_exhausted: Error");
+		message.usage.totalTokens = 600_000;
+		expect(isCursorQuotaResourceExhausted(message, 1_048_576)).toBe(false);
+	});
+
+	it("does not identify zero-token or non-resource-exhausted errors as usage-pool exhaustion", () => {
+		const zeroToken = createErrorMessage("Connect error resource_exhausted: Error");
+		const nonResourceExhausted = createErrorMessage("Connect error unavailable");
+		expect(isCursorQuotaResourceExhausted(zeroToken, 1_048_576)).toBe(false);
+		expect(isCursorQuotaResourceExhausted(nonResourceExhausted, 1_048_576)).toBe(false);
 	});
 
 	it("keeps zero-token resource_exhausted errors out of overflow detection", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Cursor token-bearing `resource_exhausted` failures now fall back to the next provider model without incorrectly triggering compaction, and terminal quota failures explain the likely usage-pool cause.
 - Logging in while a provider already holds more than one credential no longer replaces every stored credential with the new one. `AuthStorage` writes (including the RPC `login_api_key` path), `Models.login`, and OAuth token refresh now preserve sibling slots and the pinned slot; a flat single-credential entry keeps its exact previous shape until a second credential actually exists.
 - Provider stream stalls can no longer be turned into terminal watchdog aborts after the first retry: the configured retry budget is now spent, the final error preserves the real watchdog/provider cause, and unhinted transient retry delays include bounded jitter while provider hints and 429 floors remain intact.
 - Loop-guard blocks for terminal/task polling now direct the agent to stop

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -56,6 +56,7 @@ import {
 	isClassifierRefusal,
 	isContextOverflow,
 	isCursorPayloadResourceExhausted,
+	isCursorQuotaResourceExhausted,
 	isCursorZeroTokenResourceExhausted,
 	isProviderStreamStallError,
 	isProviderTimeoutError,
@@ -1755,7 +1756,8 @@ export class AgentSession {
 			!lastAssistant ||
 			(!this._isRetryableError(lastAssistant) &&
 				!this._isHardErrorFallbackEligible(lastAssistant) &&
-				!isCursorZeroTokenResourceExhausted(lastAssistant))
+				!isCursorZeroTokenResourceExhausted(lastAssistant) &&
+				!isCursorQuotaResourceExhausted(lastAssistant, this.model?.contextWindow ?? 0))
 		) {
 			return;
 		}
@@ -1957,6 +1959,9 @@ export class AgentSession {
 		if (isCursorZeroTokenResourceExhausted(lastAssistant)) {
 			return true;
 		}
+		if (isCursorQuotaResourceExhausted(lastAssistant, this.model?.contextWindow ?? 0)) {
+			return this._retryFallback.canTryFallback();
+		}
 		if (!retryableError && this._isHardErrorFallbackEligible(lastAssistant)) {
 			return true;
 		}
@@ -2126,10 +2131,11 @@ export class AgentSession {
 			const retryableError = this._isRetryableError(msg);
 			const hardErrorFallbackEligible = this._isHardErrorFallbackEligible(msg);
 			const cursorZeroTokenRe = isCursorZeroTokenResourceExhausted(msg);
+			const cursorQuotaRe = isCursorQuotaResourceExhausted(msg, this.model?.contextWindow ?? 0);
 			const retryCanAdmitProvider =
 				!userAbortSuppressedQueuedContinuation &&
 				this.settingsManager.getRetrySettings().enabled &&
-				(retryableError || hardErrorFallbackEligible || cursorZeroTokenRe);
+				(retryableError || hardErrorFallbackEligible || cursorZeroTokenRe || cursorQuotaRe);
 			let compactedBeforeRetry = false;
 			if (
 				retryCanAdmitProvider &&
@@ -2147,6 +2153,11 @@ export class AgentSession {
 			if (!retryContinuationBlocked && !userAbortSuppressedQueuedContinuation) {
 				if (cursorZeroTokenRe) {
 					retryOutcome = await this._handleRetryableError(msg, { sameModelRemint: true });
+				} else if (cursorQuotaRe) {
+					// Mid-turn Cursor errors may retain unpaired tool calls. Remove the
+					// failed assistant before provider fallback so replay stays valid.
+					this._retireFailedRetryAssistant(msg);
+					retryOutcome = await this._handleRetryableError(msg, { hardErrorFallback: true });
 				} else if (retryableError) {
 					retryOutcome = await this._handleRetryableError(msg);
 				} else if (hardErrorFallbackEligible) {
@@ -2170,6 +2181,9 @@ export class AgentSession {
 				retryOutcome === "not-handled" &&
 				(msg.stopReason === "error" || msg.stopReason === "aborted");
 
+			if (retryOutcome === "not-handled" && cursorQuotaRe && msg.errorMessage) {
+				msg.errorMessage = `${msg.errorMessage} (likely provider usage/quota exhaustion: conversation is well below the model context window)`;
+			}
 			if (retryOutcome === "not-handled" && this._retryAttempt > 0 && msg.errorMessage) {
 				const attempt = this._retryAttempt;
 				this._retryAttempt = 0;

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -19,6 +19,24 @@
 
 - LOW: the new methods sit immediately after `remove()` in `packages/coding-agent/src/core/auth-storage.ts`; `credential-slots.ts` is a new file with no upstream counterpart.
 
+## 2026-08-25 - Fall back on Cursor usage-pool exhaustion
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: admits token-bearing Cursor `resource_exhausted` failures as a dedicated fallback class, retires failed assistants before fallback, and annotates terminal no-fallback errors with the likely usage-pool cause.
+
+### Why
+
+- Cursor quota exhaustion was misclassified as overflow and entered compaction loops; mid-turn tool calls also require explicit retry admission outside the generic hard-error gate.
+
+### Why an extension could not handle it
+
+- Retry admission, assistant retirement, and provider fallback are private AgentSession lifecycle boundaries.
+
+### Expected merge conflict zones
+
+- HIGH: Cursor retry admission and fallback dispatch in `packages/coding-agent/src/core/agent-session.ts`.
+
 ## 2026-08-25 - Harden watchdog abort accounting and retry jitter
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/cursor-quota-re-fallback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/cursor-quota-re-fallback.test.ts
@@ -1,0 +1,75 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CompactionReason } from "../../../src/core/extensions/types.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const PRIMARY = "cursor/composer";
+const FALLBACK = "cursor/k3";
+
+function quotaError(): ReturnType<typeof fauxAssistantMessage> {
+	const message = fauxAssistantMessage(fauxToolCall("partial_tool", {}), {
+		stopReason: "error",
+		errorMessage: "Connect error resource_exhausted: Error",
+	});
+	message.usage = {
+		...message.usage,
+		input: 178_626,
+		totalTokens: 178_626,
+	};
+	return message;
+}
+
+describe("Cursor token-bearing resource_exhausted quota fallback", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("falls back without compaction and continues the turn", async () => {
+		const compactReasons: CompactionReason[] = [];
+		const harness = await createHarness({
+			provider: "cursor",
+			models: [
+				{ id: "composer", contextWindow: 1_048_576, maxTokens: 16_384 },
+				{ id: "k3", contextWindow: 1_048_576, maxTokens: 16_384 },
+			],
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 16_384 },
+				retry: {
+					enabled: true,
+					maxRetries: 3,
+					baseDelayMs: 1,
+					fallbackChains: { [PRIMARY]: [FALLBACK] },
+				},
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.on("session_before_compact", (event) => {
+						compactReasons.push(event.reason);
+						return {
+							compaction: {
+								summary: "unexpected compaction",
+								firstKeptEntryId: event.preparation.firstKeptEntryId,
+								tokensBefore: event.preparation.tokensBefore,
+								details: {},
+							},
+						};
+					});
+				},
+			],
+		});
+		harnesses.push(harness);
+		harness.setResponses([quotaError(), fauxAssistantMessage("continued on fallback")]);
+
+		await harness.session.prompt("continue");
+
+		expect(compactReasons).toEqual([]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toHaveLength(1);
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["composer", "k3"]);
+		expect(harness.eventsOfType("message_end").at(-1)?.message).toMatchObject({
+			role: "assistant",
+			stopReason: "stop",
+		});
+	});
+});


### PR DESCRIPTION
## Problem

Cursor's api2 backend surfaces BOTH usage-pool/quota exhaustion AND context overflow as the same bare gRPC `resource_exhausted` error. `isContextOverflow` classified ANY token-bearing `resource_exhausted` as context overflow, so a quota rejection arriving mid-turn (accumulated usage > 0) was misrouted into the overflow-compaction loop: compact -> retry -> `resource_exhausted` again -> conversation-rotation burn -> wedged session walking the fallback chain with a misleading error.

Live incident (2026-08-25): `cursor/kimi-k3-low` killed at 178,626 accumulated tokens on a 1,048,576-token-window model with `Connect error resource_exhausted: Error` while the account's Cursor "Other Models" pool was exhausted (isolation probes: every third-party model returned instant zero-token RE while Cursor-pool models answered normally). Overflow at 17% of the window is implausible; proximity to the window is the honest discriminator.

## Fix

- `packages/ai/src/utils/overflow.ts`: the token-bearing `resource_exhausted` branch of `isContextOverflow` now classifies overflow only when accumulated tokens >= 0.5 * contextWindow (callers that pass no window keep the legacy behavior). New export `isCursorQuotaResourceExhausted` names the below-half-window token-bearing RE signature.
- `packages/coding-agent/src/core/agent-session.ts`: that quota class is admitted into the retry path as a hard-error provider fallback, dispatched strictly AFTER the zero-token RE branch so the #1009/#1015 compact-before-rotate policy is untouched. The failed assistant is retired first so unpaired mid-turn tool calls are not replayed. Terminal no-fallback quota errors are annotated with the likely usage-pool cause instead of the bare RE text.

## Behavior matrix

| Signal | Before | After |
|---|---|---|
| zero-token RE, large transcript | overflow-compact, then rotate (#1009) | unchanged |
| token-bearing RE >= 50% of window | overflow-compact | unchanged (overflow-compact) |
| token-bearing RE < 50% of window | overflow-compact loop -> wedge | provider fallback, honest error |

## Tests

- `packages/ai/test/overflow.test.ts`: contract updated + new cases (tiny-usage RE vs 1M window -> not overflow; >= 50% -> overflow; no-window legacy; `isCursorQuotaResourceExhausted` partition incl. exact-boundary pair). RED captured on unmodified code.
- New `packages/coding-agent/test/suite/regressions/cursor-quota-re-fallback.test.ts`: token-bearing below-window RE falls back to the next chain model WITHOUT compaction (RED on unmodified code: `expected [ 'overflow' ] to deeply equal []`).
- Discriminator pair proven: #1009 (zero-token -> compaction, no fallback) and the new test (token-bearing -> fallback, no compaction) both green.
- Full `packages/ai` suite green (237 files), all `packages/coding-agent` regressions green (163 files), `tsc --noEmit` + `npm run build` green, `scripts/check-pr-changelog.mjs` PASS. Pre-existing biome errors on main (`biome.json` schema drift + 2 stale-format test files) are untouched by this branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Cursor token-bearing resource_exhausted errors to provider fallback when usage is well below the model context window, instead of entering overflow compaction loops. This keeps zero-token and near-window overflows on the compaction path and prevents wedged sessions.

**Bug Fixes**
- Classifies token-bearing errors as overflow only at or above 50% of the context window; below-half is treated as quota exhaustion.
- Admits quota exhaustion to hard-error provider fallback, retires the failed assistant first, and skips compaction.
- Annotates terminal no-fallback cases with a likely usage/quota exhaustion cause.
- Preserves legacy behavior: zero-token errors still compact; callers without a context window keep prior detection.

<sup>Written for commit fcf5f18778bb3c643ad0c306b5c99e60d8f84e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

