### PR TITLE
feat(tui): include skills in @ autocomplete

### DIFF
--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -6,6 +6,7 @@ import { getDollarInvocationContext, getDollarInvocationSuggestions } from "./do
 import { getSlashCommandSuggestions } from "./slash-command-autocomplete.ts";
 
 const PATH_DELIMITERS = new Set([" ", "\t", '"', "'", "="]);
+const SKILL_COMMAND_PREFIX = "skill:";
 
 function toDisplayPath(value: string): string {
 	return value.replace(/\\/g, "/");
@@ -294,10 +295,12 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const atPrefix = this.extractAtPrefix(textBeforeCursor);
 		if (atPrefix) {
 			const { rawPrefix, isQuotedPrefix } = parsePathPrefix(atPrefix);
-			const suggestions = await this.getFuzzyFileSuggestions(rawPrefix, {
+			const skillSuggestions = isQuotedPrefix ? [] : this.getAtSkillSuggestions(rawPrefix);
+			const fileSuggestions = await this.getFuzzyFileSuggestions(rawPrefix, {
 				isQuotedPrefix,
 				signal: options.signal,
 			});
+			const suggestions = [...skillSuggestions, ...fileSuggestions];
 			if (suggestions.length === 0) return null;
 
 			return {
@@ -506,6 +509,22 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				});
 			})
 		);
+	}
+
+	private getAtSkillSuggestions(query: string): AutocompleteItem[] {
+		const skillCommands = this.commands.filter((command) => {
+			const name = "name" in command ? command.name : command.value;
+			return name.startsWith(SKILL_COMMAND_PREFIX);
+		});
+		const skillQuery = query.toLowerCase().startsWith(SKILL_COMMAND_PREFIX)
+			? query
+			: `${SKILL_COMMAND_PREFIX}${query}`;
+
+		return getSlashCommandSuggestions(skillCommands, skillQuery).map((item) => ({
+			...item,
+			value: `/${item.value}`,
+			label: item.label.slice(SKILL_COMMAND_PREFIX.length),
+		}));
 	}
 
 	// Extract @ prefix for fuzzy file suggestions

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,39 @@
 # TUI delta rendering fork changes
 
+## @ autocomplete includes executable skill commands (2026-08-26)
+
+### What changed
+
+- `packages/tui/src/autocomplete.ts`: `CombinedAutocompleteProvider` now derives `skill:*`
+  entries from its existing command inventory when an unquoted `@` token is active, ranks them
+  through the existing slash-command matcher, and prepends them to file suggestions. Skill
+  selections carry `/skill:<name>` as their completion value, so the existing `@` application path
+  inserts an executable leading skill command while file and quoted-path completion stay unchanged.
+- `packages/tui/src/components/editor.ts`: `@` best-match selection now compares the trigger-stripped
+  query with visible item labels as well as comparing raw values. Executable skill values can
+  therefore stay selected and visible even though they begin with `/skill:` instead of `@`.
+
+### Why
+
+- Interactive mode already loads user skills and supplies them as `skill:*` commands, but the `@`
+  branch returned after file lookup and never surfaced that inventory. Users therefore saw files
+  only even though the same skills were available through `/skill:` and `$skill:`.
+
+### Why an extension could not handle it
+
+- `@` token extraction, candidate merging, completion replacement, and highlighted-item selection
+  are private TUI control flow. Extensions can wrap the provider but cannot amend the built-in
+  provider's file-only early return or editor best-match logic for every editor.
+
+### Expected merge conflict zones
+
+- LOW: `packages/tui/src/autocomplete.ts` around the `@` branch in `getSuggestions()` and the
+  adjacent private skill-candidate mapper. Preserve upstream file-search and quoted-path behavior
+  while retaining the fork's executable skill entries.
+- LOW: `packages/tui/src/components/editor.ts` around `getBestAutocompleteMatchIndex()`. Preserve
+  exact/prefix value priority for every existing autocomplete surface before the additional
+  trigger-stripped `@` label comparison.
+
 ## TUI runtime re-diverges from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -2342,22 +2342,25 @@ export class Editor implements Component, Focusable {
 	 *
 	 * Match priority:
 	 * 1. Exact match (prefix === item.value) -> always selected
-	 * 2. Prefix match -> first item whose value starts with prefix
+	 * 2. Prefix match -> first item whose value or @-query label starts with prefix
 	 * 3. No match -> -1 (keep default highlight)
-	 *
-	 * Matching is case-sensitive and checks item.value only.
 	 */
 	private getBestAutocompleteMatchIndex(items: Array<{ value: string; label: string }>, prefix: string): number {
 		if (!prefix) return -1;
 
 		let firstPrefixIndex = -1;
+		const atLabelPrefix = prefix.startsWith("@") ? prefix.slice(1) : null;
 
 		for (let i = 0; i < items.length; i++) {
-			const value = items[i]!.value;
+			const item = items[i]!;
+			const value = item.value;
 			if (value === prefix) {
 				return i; // Exact match always wins
 			}
-			if (firstPrefixIndex === -1 && value.startsWith(prefix)) {
+			if (
+				firstPrefixIndex === -1 &&
+				(value.startsWith(prefix) || (atLabelPrefix !== null && item.label.startsWith(atLabelPrefix)))
+			) {
 				firstPrefixIndex = i;
 			}
 		}

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -114,6 +114,52 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 	});
 
+	describe("@ skill suggestions", () => {
+		const skillCommands = [
+			{ name: "skill:open-demo-alpha", description: "Synthetic demo alpha" },
+			{ name: "skill:open-demo-beta", description: "Synthetic demo beta" },
+			{ name: "skill:open-demo-gamma", description: "Synthetic demo gamma" },
+		];
+
+		it("returns loaded skills for an @ query and inserts an executable skill command", async () => {
+			const provider = new CombinedAutocompleteProvider(skillCommands, "/tmp");
+			const line = "@open-demo-al";
+			const result = await getSuggestions(provider, [line], 0, line.length);
+
+			assert.deepStrictEqual(
+				result?.items.map((item) => item.value),
+				["/skill:open-demo-alpha"],
+			);
+			assert.strictEqual(result?.prefix, line);
+
+			const completion = provider.applyCompletion([line], 0, line.length, result!.items[0]!, result!.prefix);
+			assert.deepStrictEqual(completion.lines, ["/skill:open-demo-alpha "]);
+			assert.strictEqual(completion.cursorCol, "/skill:open-demo-alpha ".length);
+		});
+
+		it("keeps skill and file candidates in the same @ list", { skip: !isFdInstalled }, async () => {
+			const baseDir = mkdtempSync(join(tmpdir(), "pi-autocomplete-skill-files-"));
+			try {
+				setupFolder(baseDir, {
+					files: {
+						"README.md": "readme",
+					},
+				});
+				const provider = new CombinedAutocompleteProvider(skillCommands, baseDir, requireFdPath());
+
+				const result = await getSuggestions(provider, ["@"], 0, 1);
+				const values = result?.items.map((item) => item.value) ?? [];
+
+				assert.ok(values.includes("/skill:open-demo-alpha"));
+				assert.ok(values.includes("/skill:open-demo-beta"));
+				assert.ok(values.includes("/skill:open-demo-gamma"));
+				assert.ok(values.includes("@README.md"));
+			} finally {
+				rmSync(baseDir, { recursive: true, force: true });
+			}
+		});
+	});
+
 	describe("fd @ file suggestions", { skip: !isFdInstalled }, () => {
 		let rootDir = "";
 		let baseDir = "";

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -2674,6 +2674,49 @@ describe("Editor component", () => {
 			assert.strictEqual(editor.getText(), "/argtest two");
 		});
 
+		it("prioritizes @ suggestions whose labels match the typed query", async () => {
+			const editor = new Editor(createTestTUI(), defaultEditorTheme);
+			let markFinalRequestStarted!: () => void;
+			const finalRequestStarted = new Promise<void>((resolve) => {
+				markFinalRequestStarted = resolve;
+			});
+			let releaseFinalResponse!: () => void;
+			const finalResponseGate = new Promise<void>((resolve) => {
+				releaseFinalResponse = resolve;
+			});
+			const mockProvider: AutocompleteProvider = {
+				getSuggestions: async (lines, _cursorLine, cursorCol) => {
+					const prefix = (lines[0] || "").slice(0, cursorCol);
+					if (!prefix.startsWith("@")) return null;
+					if (prefix === "@open") {
+						markFinalRequestStarted();
+						await finalResponseGate;
+					}
+					return {
+						items: [
+							{ value: "/skill:open-demo-alpha", label: "open-demo-alpha" },
+							{ value: "@opencode.json", label: "opencode.json" },
+						],
+						prefix,
+					};
+				},
+				applyCompletion,
+			};
+			editor.setAutocompleteProvider(mockProvider);
+
+			for (const char of "@open") {
+				editor.handleInput(char);
+			}
+
+			await finalRequestStarted;
+			releaseFinalResponse();
+			await flushAutocomplete();
+			assert.strictEqual(editor.isShowingAutocomplete(), true);
+
+			editor.handleInput("\r");
+			assert.strictEqual(editor.getText(), "/skill:open-demo-alpha");
+		});
+
 		it("highlights unique prefix match as user types (before full exact match)", async () => {
 			const editor = new Editor(createTestTUI(), defaultEditorTheme);
 


### PR DESCRIPTION
## Summary

- include loaded `skill:*` commands in unquoted `@` autocomplete alongside file candidates
- insert an executable `/skill:<name>` token when a skill candidate is selected
- rank `@` queries against visible labels while preserving file, quoted-path, slash-command, and dollar-command behavior
- use synthetic skill fixtures only

## Validation

- focused autocomplete and editor tests
- full TUI package suite
- workspace check and build
- isolated browser-rendered xterm.js scenarios kept local

This pull request is being closed because the requested behavior was a local configuration need rather than an upstream contribution.