### PR TITLE
fix(compaction): preserve post-compaction continuations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Fixed
 
+- A manual `/compact` that has nothing left to summarize is now rejected before it aborts the active post-compaction continuation, so an in-flight turn survives instead of terminally ending with "Nothing to compact".
+- Long-lived sessions no longer stop compacting after ten successful compactions: the absolute session cap became telemetry only, while the failure circuit breaker still halts repeated failed or ineffective attempts.
+- Compaction todo snapshots now capture only the latest todo phases from the active branch instead of recursively retaining the full `senpi.todo-state` history, which grew to megabytes and refilled the context right after a compaction; legacy raw-entry snapshots are normalized before restore.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4816,6 +4816,41 @@ export class AgentSession {
 	 * @param customInstructions Optional instructions for the compaction summary
 	 */
 	async compact(customInstructions?: string): Promise<CompactionResult> {
+		const model = this.model;
+		if (!model) throw new Error(formatNoModelSelectedMessage());
+		const pathEntries = this.sessionManager.getBranch();
+		const settings = cursorOverflowCompactionSettings(
+			this.settingsManager.getCompactionSettings(),
+			model.provider,
+			"manual",
+		);
+		if (!prepareCompaction(pathEntries, settings)) {
+			const requestId = randomUUID();
+			const lastEntry = pathEntries[pathEntries.length - 1];
+			const error = new Error(
+				lastEntry?.type === "compaction" ? "Already compacted" : "Nothing to compact (session too small)",
+			);
+			const errorMessage = `Compaction failed: ${error.message}`;
+			this._emit({ type: "compaction_start", reason: "manual", requestId });
+			this._emit({
+				type: "compaction_end",
+				reason: "manual",
+				result: undefined,
+				aborted: false,
+				willRetry: false,
+				requestId,
+				errorMessage,
+			});
+			await this._emitSessionCompactFailed({
+				reason: "manual",
+				errorMessage,
+				aborted: false,
+				willRetry: false,
+				fromExtension: false,
+			});
+			throw error;
+		}
+
 		const admission = this._claimPendingCompactionAdmission();
 		const controller = admission.controller;
 		const requestId = randomUUID();

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,31 @@
 # changes
 
+## 2026-08-26 - Reject no-progress manual compaction before active abort
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `AgentSession.compact()` now runs the existing
+  `prepareCompaction()` check before claiming manual admission or aborting an active agent run.
+- A no-progress request still emits balanced manual `compaction_start` / failed `compaction_end`
+  events and the existing `session_compact_failed` hook, but it leaves the active continuation alive.
+
+### Why
+
+- A manual compaction request can arrive after automatic tool-result compaction has committed but
+  while that same turn's next provider call is streaming. The old order aborted the provider
+  continuation first and only then discovered that the pre-abort branch had nothing left to
+  summarize, terminally ending otherwise healthy goal work.
+
+### Why an extension could not handle it
+
+- Manual compaction admission, active-agent abort ownership, and the pre-abort branch snapshot are
+  private `AgentSession` lifecycle state. An extension observes compaction hooks only after the core
+  has already admitted the operation.
+
+### Expected merge conflict zones
+
+- HIGH: `packages/coding-agent/src/core/agent-session.ts` around the public `compact()` entry point.
+
 ## 2026-08-23 - Provider-declared retry policy profiles (session wiring)
 
 ### What changed
@@ -128,7 +154,6 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 ### Expected merge conflict zones
 
 - LOW: `packages/coding-agent/src/core/agent-session.ts` retry scheduling and `packages/coding-agent/src/core/extensions/types.ts` event contract.
-
 ## 2026-08-24 - expose abort provenance to interactive rendering
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,35 @@
 # Builtin compaction extension changes
 
+## Bound todo snapshots and keep successful compaction admission open (2026-08-25)
+
+### What changed
+
+- `todo-bridge.ts` now snapshots only the latest todo phases from the active branch instead of
+  persisting every historical `senpi.todo-state` session envelope. Restore checks use the same
+  branch-local current state, and legacy snapshots containing raw custom entries are normalized
+  to their latest todo payload before any restore message is emitted.
+- `per-turn-cap.ts` retains successful-compaction counters as telemetry but no longer rejects a
+  long-lived session after ten accepted compactions. The independent circuit breaker remains
+  responsible for repeated failed or ineffective attempts.
+
+### Why
+
+- Repeated snapshots recursively retained the full todo-state history, growing from kilobytes to
+  megabytes and immediately refilling context after compaction.
+- The absolute success cap then permanently rejected threshold, overflow, manual, and pre-prompt
+  compaction routes after ten effective compactions, leaving no in-session recovery path.
+
+### Why an extension could not handle it
+
+- Snapshot capture/restore and admission accounting are private policy inside this builtin.
+  External extensions cannot replace the persisted metadata payload or override this builtin's
+  pre-compaction rejection decision.
+
+### Expected merge conflict zones
+
+- LOW: `todo-bridge.ts` around snapshot parsing, current-state capture, and restore suppression.
+- LOW: `per-turn-cap.ts` around the former absolute-cap exports and admission predicate.
+
 ## Skip Cursor compaction while the session is not idle (2026-08-19)
 
 Blocking and generated apply refuse `cursor` / `cursor-cli-oauth` when `!ctx.isIdle()`. Mid-run Cursor compact poisons `conversationId`. Idle `agent_end` / `pre_prompt` still compact.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/per-turn-cap.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/per-turn-cap.ts
@@ -1,7 +1,5 @@
 import type { CompactionExtensionState } from "./state.ts";
 
-export const hardCap = 10;
-
 export function incrementAccepted(state: CompactionExtensionState): CompactionExtensionState {
 	return {
 		...state,
@@ -17,17 +15,11 @@ export function incrementIneffective(state: CompactionExtensionState): Compactio
 	};
 }
 
-export function isOverHardCap(state: CompactionExtensionState): boolean {
-	return state.acceptedAbsolute >= hardCap;
-}
-
 /**
- * Admission is bounded only by the absolute session cap. The former per-turn
- * soft cap (3 accepted + ineffective attempts) rejected required compactions
- * mid-turn, which fatally ended turns that legitimately needed more than three
- * compactions. Runaway protection remains: `hardCap` bounds accepted
- * compactions per session and the circuit breaker halts repeated failures.
+ * Successful compactions never consume an admission budget. The absolute
+ * counter remains telemetry for long-lived sessions, while the circuit breaker
+ * independently halts repeated failed or ineffective attempts.
  */
-export function shouldRejectByCap(state: CompactionExtensionState): { cancel: boolean } {
-	return { cancel: isOverHardCap(state) };
+export function shouldRejectByCap(_state: CompactionExtensionState): { cancel: false } {
+	return { cancel: false };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/todo-bridge.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/todo-bridge.ts
@@ -1,6 +1,6 @@
 import type { CustomEntry, SessionEntry } from "../../../session-manager.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
-import type { TodoPhase } from "../todotools/state.ts";
+import { getLatestPhasesFromBranchEntries, type TodoPhase } from "../todotools/state.ts";
 
 const TODO_SNAPSHOT_CUSTOM_TYPE = "compaction.todo-snapshot";
 const TODO_SNAPSHOT_SCHEMA = "senpi.compaction.todo-snapshot.v1";
@@ -17,7 +17,7 @@ export type TodoSnapshotItems = TodoEntry[] | TodoPhase[];
 
 export interface TodoSnapshotPayload {
 	schema: typeof TODO_SNAPSHOT_SCHEMA;
-	todos: TodoSnapshotItems | SessionEntry[];
+	todos: TodoSnapshotItems;
 	capturedAt: number;
 }
 
@@ -81,39 +81,70 @@ function readTodosFromEntry(entry: CustomEntry): TodoEntry[] {
 	return [];
 }
 
+function isCustomEntryEnvelope(value: unknown): value is CustomEntry {
+	return (
+		isRecord(value) &&
+		value.type === "custom" &&
+		typeof value.id === "string" &&
+		(value.parentId === null || typeof value.parentId === "string") &&
+		typeof value.timestamp === "string" &&
+		typeof value.customType === "string"
+	);
+}
+
+function normalizeLegacySnapshotEntries(entries: CustomEntry[]): TodoSnapshotItems {
+	for (let index = entries.length - 1; index >= 0; index -= 1) {
+		const entry = entries[index];
+		if (!isLegacyTodoListEntry(entry) && !isCustomTodoEntry(entry)) continue;
+		if (entry.customType === TODO_STATE_ENTRY_TYPE) {
+			return getLatestPhasesFromBranchEntries(entries.slice(0, index + 1));
+		}
+		return readTodosFromEntry(entry);
+	}
+	return [];
+}
+
+function normalizeSnapshotItems(value: unknown): TodoSnapshotItems | null {
+	if (!Array.isArray(value)) return null;
+	if (value.every(isTodoPhase)) return value;
+	if (value.every(isCustomEntryEnvelope)) return normalizeLegacySnapshotEntries(value);
+	if (value.every(isTodoEntry)) return value;
+	return null;
+}
+
+function getCurrentTodoPhases(ctx: ExtensionContext): TodoPhase[] {
+	return getLatestPhasesFromBranchEntries(ctx.sessionManager.getBranch());
+}
+
 function findLatestTodoSnapshot(ctx: ExtensionContext): TodoSnapshotPayload | null {
-	const entries = ctx.sessionManager.getEntries();
+	const entries = ctx.sessionManager.getBranch();
 	for (let index = entries.length - 1; index >= 0; index -= 1) {
 		const entry = entries[index];
 		if (entry.type !== "custom" || entry.customType !== TODO_SNAPSHOT_CUSTOM_TYPE) continue;
 		const data = entry.data;
-		if (isRecord(data) && data.schema === TODO_SNAPSHOT_SCHEMA && Array.isArray(data.todos)) {
-			return data as unknown as TodoSnapshotPayload;
-		}
+		if (!isRecord(data) || data.schema !== TODO_SNAPSHOT_SCHEMA) continue;
+		const todos = normalizeSnapshotItems(data.todos);
+		if (!todos) continue;
+		return {
+			schema: TODO_SNAPSHOT_SCHEMA,
+			todos,
+			capturedAt: typeof data.capturedAt === "number" ? data.capturedAt : 0,
+		};
 	}
 	return null;
 }
 
-export function findTodoEntries(ctx: ExtensionContext): SessionEntry[];
-export function findTodoEntries(entries: SessionEntry[], options?: { branchId?: string }): TodoEntry[];
-export function findTodoEntries(
-	ctxOrEntries: ExtensionContext | SessionEntry[],
-	options?: { branchId?: string },
-): SessionEntry[] | TodoEntry[] {
-	if (Array.isArray(ctxOrEntries)) {
-		return ctxOrEntries
-			.filter((entry) => isLegacyTodoListEntry(entry) || isCustomTodoEntry(entry))
-			.filter((entry) => options?.branchId === undefined || entry.parentId === options.branchId)
-			.flatMap(readTodosFromEntry);
-	}
-
-	return ctxOrEntries.sessionManager.getEntries().filter(isCustomTodoEntry);
+export function findTodoEntries(entries: SessionEntry[], options?: { branchId?: string }): TodoEntry[] {
+	return entries
+		.filter((entry) => isLegacyTodoListEntry(entry) || isCustomTodoEntry(entry))
+		.filter((entry) => options?.branchId === undefined || entry.parentId === options.branchId)
+		.flatMap(readTodosFromEntry);
 }
 
 export function createTodoSnapshot(ctx: ExtensionContext): TodoSnapshotPayload {
 	return {
 		schema: TODO_SNAPSHOT_SCHEMA,
-		todos: findTodoEntries(ctx),
+		todos: getCurrentTodoPhases(ctx),
 		capturedAt: Date.now(),
 	};
 }
@@ -162,7 +193,7 @@ export function restoreTodosIfMissing(
 
 	const pi = piOrSnapshot as SendMessageTarget;
 	const ctx = ctxOrCurrentTodos as ExtensionContext;
-	if (findTodoEntries(ctx).length > 0) return;
+	if (getCurrentTodoPhases(ctx).length > 0) return;
 
 	const snapshot = findLatestTodoSnapshot(ctx);
 	if (!snapshot || snapshot.todos.length === 0) return;

--- a/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
+++ b/packages/coding-agent/test/compaction/blocking-compaction-route-guards.test.ts
@@ -2,7 +2,6 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FAILURE_TRIP_THRESHOLD } from "../../src/core/extensions/builtin/compaction/circuit-breaker.ts";
 import compactionExtension from "../../src/core/extensions/builtin/compaction/index.ts";
-import { hardCap } from "../../src/core/extensions/builtin/compaction/per-turn-cap.ts";
 import { MAX_SUMMARIZATION_ATTEMPT_RETRIES } from "../../src/core/extensions/builtin/compaction/summarization-retry.ts";
 import type { ExtensionHandler } from "../../src/core/extensions/index.ts";
 import {
@@ -15,6 +14,7 @@ import {
 const SUMMARIZATION_ATTEMPTS = 1 + MAX_SUMMARIZATION_ATTEMPT_RETRIES;
 
 const FORMER_SOFT_CAP = 3;
+const FORMER_ABSOLUTE_CAP = 10;
 
 const registrations: Array<{ unregister: () => void }> = [];
 
@@ -83,7 +83,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 		expect(harness.registration.state.callCount).toBe(FAILURE_TRIP_THRESHOLD * SUMMARIZATION_ATTEMPTS);
 	});
 
-	it("bounds successful hard-limit blocking compactions by the absolute session cap", async () => {
+	it("keeps successful hard-limit blocking compactions open past the former session cap", async () => {
 		const handlers = captureHandlers();
 		const beforeAgentStart = handlers.get("before_agent_start");
 		const sessionCompact = handlers.get("session_compact");
@@ -91,7 +91,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 		expect(sessionCompact).toBeDefined();
 		const harness = createBlockingContext({ usageTokens: 9_950 });
 		registrations.push(harness.registration);
-		const attempts = hardCap + 2;
+		const attempts = FORMER_ABSOLUTE_CAP + 2;
 		harness.registration.setResponses(
 			Array.from({ length: attempts }, () => fauxAssistantMessage("## Goal\ncompact summary")),
 		);
@@ -105,7 +105,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 			}
 		}
 
-		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(hardCap);
+		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBe(attempts);
 	});
 
 	it("admits a compaction past the former soft cap within the same provider turn", async () => {
@@ -166,7 +166,7 @@ describe("blocking compaction route guards (issue #527)", () => {
 		}
 		await turnEnd?.({ type: "turn_end" } as never, harness.ctx);
 
-		// The next provider turn must still admit below the absolute cap.
+		// The next provider turn must remain open regardless of successful history.
 		await beforeAgentStart?.(createBeforeAgentStartEvent() as never, harness.ctx);
 		expect((harness.ctx.applyCompaction as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(appliedAtCap);
 	});

--- a/packages/coding-agent/test/compaction/per-turn-cap.test.ts
+++ b/packages/coding-agent/test/compaction/per-turn-cap.test.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import { registerFauxProvider } from "@earendil-works/pi-ai";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
-	hardCap,
 	incrementAccepted,
 	incrementIneffective,
 	shouldRejectByCap,
@@ -16,7 +15,8 @@ import {
 import { migrateSessionEntries, parseSessionEntries, type SessionEntry } from "../../src/core/session-manager.ts";
 
 const FORMER_SOFT_CAP = 3;
-const EXPECTED_HARD_CAP = 10;
+const FORMER_ABSOLUTE_CAP = 10;
+const LONG_LIVED_SESSION_ACCEPTED = 10_000;
 
 function acceptN(state: CompactionExtensionState, n: number): CompactionExtensionState {
 	let next = state;
@@ -59,7 +59,7 @@ beforeAll(() => {
 	perTurnFixtureEntries = entries.filter((entry): entry is SessionEntry => entry.type !== "session");
 });
 
-describe("compaction absolute cap", () => {
+describe("compaction admission accounting", () => {
 	describe("Given the former per-turn soft cap of 3 accepted compactions this turn", () => {
 		describe("When a 4th required compaction is checked in the same turn", () => {
 			it("Then it is admitted instead of fatally ending the turn", () => {
@@ -89,7 +89,7 @@ describe("compaction absolute cap", () => {
 		});
 	});
 
-	describe("Given accepted compactions below the absolute cap", () => {
+	describe("Given successful compactions before a turn reset", () => {
 		describe("When the turn ends and resetTurnCounter is applied", () => {
 			it("Then admission is open before and after the reset", () => {
 				const registration = registerFauxProvider();
@@ -107,20 +107,27 @@ describe("compaction absolute cap", () => {
 		});
 	});
 
-	describe("Given accepted compactions reach the absolute cap across provider turns", () => {
-		it("Then every further compaction is rejected, even after a turn reset", () => {
-			expect(hardCap).toBe(EXPECTED_HARD_CAP);
-
+	describe("Given accepted compactions exceed the former absolute cap across provider turns", () => {
+		it("Then successful compactions remain admitted in a long-lived session", () => {
 			let state = createInitialState();
-			for (let accepted = 0; accepted < EXPECTED_HARD_CAP; accepted++) {
+			for (let accepted = 0; accepted < FORMER_ABSOLUTE_CAP; accepted++) {
 				state = incrementAccepted(state);
 				state = resetTurnCounter(state, `turn-${accepted}`);
 			}
 
 			expect(state.acceptedThisTurn).toBe(0);
-			expect(state.acceptedAbsolute).toBe(EXPECTED_HARD_CAP);
-			expect(shouldRejectByCap(state)).toEqual({ cancel: true });
-			expect(shouldRejectByCap(resetTurnCounter(state, "turn-final"))).toEqual({ cancel: true });
+			expect(state.acceptedAbsolute).toBe(FORMER_ABSOLUTE_CAP);
+			expect(shouldRejectByCap(state)).toEqual({ cancel: false });
+
+			for (let accepted = FORMER_ABSOLUTE_CAP; accepted < LONG_LIVED_SESSION_ACCEPTED; accepted++) {
+				state = incrementAccepted(state);
+				state = resetTurnCounter(state, `turn-${accepted}`);
+			}
+
+			expect(state.acceptedThisTurn).toBe(0);
+			expect(state.acceptedAbsolute).toBe(LONG_LIVED_SESSION_ACCEPTED);
+			expect(shouldRejectByCap(state)).toEqual({ cancel: false });
+			expect(shouldRejectByCap(resetTurnCounter(state, "turn-final"))).toEqual({ cancel: false });
 		});
 	});
 

--- a/packages/coding-agent/test/compaction/todo-bridge-current-state.test.ts
+++ b/packages/coding-agent/test/compaction/todo-bridge-current-state.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+	createTodoSnapshot,
+	restoreTodosIfMissing,
+	type TodoSnapshotPayload,
+} from "../../src/core/extensions/builtin/compaction/todo-bridge.ts";
+import type { TodoPhase } from "../../src/core/extensions/builtin/todotools/state.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/index.ts";
+import type { CustomEntry, SessionEntry } from "../../src/core/session-manager.ts";
+
+const TODO_SNAPSHOT_CUSTOM_TYPE = "compaction.todo-snapshot";
+const TODO_SNAPSHOT_SCHEMA = "senpi.compaction.todo-snapshot.v1";
+
+interface RestoreMessage {
+	customType: string;
+	content: string;
+	display: boolean;
+	details?: TodoSnapshotPayload;
+}
+
+function createStateEntry(index: number, phases: TodoPhase[]): CustomEntry {
+	return {
+		type: "custom",
+		id: `todo-state-${index}`,
+		parentId: index === 0 ? null : `todo-state-${index - 1}`,
+		timestamp: new Date(Date.UTC(2026, 7, 25, 0, index)).toISOString(),
+		customType: "senpi.todo-state",
+		data: { schema: "v2", phases },
+	};
+}
+
+function createSnapshotEntry(todos: unknown[]): CustomEntry {
+	return {
+		type: "custom",
+		id: "todo-snapshot",
+		parentId: null,
+		timestamp: "2026-08-25T02:00:00.000Z",
+		customType: TODO_SNAPSHOT_CUSTOM_TYPE,
+		data: {
+			schema: TODO_SNAPSHOT_SCHEMA,
+			todos,
+			capturedAt: Date.UTC(2026, 7, 25, 2),
+		},
+	};
+}
+
+function createContext(entries: SessionEntry[], branchEntries: SessionEntry[]): ExtensionContext {
+	return {
+		sessionManager: {
+			getEntries: () => entries,
+			getBranch: () => branchEntries,
+		} as ExtensionContext["sessionManager"],
+	} as ExtensionContext;
+}
+
+function createRestoreApi(messages: RestoreMessage[]): ExtensionAPI {
+	return {
+		sendMessage(message: RestoreMessage) {
+			messages.push(message);
+		},
+	} as ExtensionAPI;
+}
+
+function containsHistoryEnvelope(value: unknown): boolean {
+	if (Array.isArray(value)) return value.some(containsHistoryEnvelope);
+	if (typeof value !== "object" || value === null) return false;
+	const record = value as Record<string, unknown>;
+	return "customType" in record || Object.values(record).some(containsHistoryEnvelope);
+}
+
+describe("compaction todo bridge current-state snapshots", () => {
+	const latestPhases: TodoPhase[] = [
+		{
+			name: "Repair",
+			tasks: [{ content: "Ship bounded snapshot", status: "in_progress" }],
+		},
+	];
+	const historicalEntries = Array.from({ length: 80 }, (_, index) =>
+		createStateEntry(
+			index,
+			index === 79
+				? latestPhases
+				: [
+						{
+							name: `History ${index}`,
+							tasks: [{ content: `Superseded task ${index}`, status: "completed" }],
+						},
+					],
+		),
+	);
+
+	describe("Given eighty historical todo-state entries on the active branch", () => {
+		it("Then createTodoSnapshot captures only the latest current phases", () => {
+			const ctx = createContext(historicalEntries, historicalEntries);
+
+			const snapshot = createTodoSnapshot(ctx);
+
+			expect(snapshot.todos).toEqual(latestPhases);
+			expect(containsHistoryEnvelope(snapshot.todos)).toBe(false);
+			expect(JSON.stringify(snapshot.todos).length).toBe(JSON.stringify(latestPhases).length);
+		});
+	});
+
+	describe("Given stale todo history outside an active branch with no current todos", () => {
+		it("Then stale entries do not suppress restoration from a bounded snapshot", () => {
+			const snapshotEntry = createSnapshotEntry(latestPhases);
+			const messages: RestoreMessage[] = [];
+			const ctx = createContext([...historicalEntries, snapshotEntry], [snapshotEntry]);
+
+			restoreTodosIfMissing(createRestoreApi(messages), ctx);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]?.details?.todos).toEqual(latestPhases);
+			expect(containsHistoryEnvelope(messages[0]?.details?.todos)).toBe(false);
+		});
+	});
+
+	describe("Given a legacy snapshot containing raw historical session entries", () => {
+		it("Then restore normalizes it to the latest phases before reinjection", () => {
+			const legacySnapshotEntry = createSnapshotEntry(historicalEntries);
+			const messages: RestoreMessage[] = [];
+			const ctx = createContext([legacySnapshotEntry], [legacySnapshotEntry]);
+
+			restoreTodosIfMissing(createRestoreApi(messages), ctx);
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]?.details?.todos).toEqual(latestPhases);
+			expect(containsHistoryEnvelope(messages[0]?.details?.todos)).toBe(false);
+			expect(messages[0]?.content).not.toContain("senpi.todo-state");
+		});
+	});
+});

--- a/packages/coding-agent/test/compile-cache.test.ts
+++ b/packages/coding-agent/test/compile-cache.test.ts
@@ -85,7 +85,7 @@ describe("startup compile cache", () => {
 		});
 
 		test("#when no cache directory is configured #then the seam still publishes an inheritable default", () => {
-			const result = runDriver({ NODE_COMPILE_CACHE: undefined });
+			const result = runDriver({ NODE_COMPILE_CACHE: undefined, TMPDIR: hostDir });
 
 			expect(result.status, result.stderr).toBe(0);
 			const report = parseReport(result.stdout);

--- a/packages/coding-agent/test/suite/manual-compaction-liveness.test.ts
+++ b/packages/coding-agent/test/suite/manual-compaction-liveness.test.ts
@@ -1,0 +1,144 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "../../src/core/extensions/index.ts";
+import { createHarness, getAssistantTexts, type Harness } from "./harness.ts";
+
+type Deferred = {
+	readonly promise: Promise<void>;
+	readonly resolve: () => void;
+};
+
+function createDeferred(): Deferred {
+	let resolve: (() => void) | undefined;
+	const promise = new Promise<void>((next) => {
+		resolve = next;
+	});
+	if (!resolve) throw new Error("Deferred resolver was not initialized");
+	return { promise, resolve };
+}
+
+async function waitForSignal(signal: Promise<void>, label: string): Promise<void> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			signal,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(() => reject(new Error(`Timed out waiting for ${label}`)), 1_000);
+			}),
+		]);
+	} finally {
+		if (timeout !== undefined) clearTimeout(timeout);
+	}
+}
+
+function createUsage(totalTokens: number) {
+	return {
+		input: totalTokens,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createLargeResultExtension(toolResult: string, summary: string) {
+	return (pi: ExtensionAPI): void => {
+		pi.registerTool({
+			name: "large_result",
+			label: "Large Result",
+			description: "Return text that requires next-turn compaction",
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: "text", text: toolResult }],
+				details: {},
+			}),
+		});
+		pi.on("session_before_compact", (event) => ({
+			compaction: {
+				summary,
+				firstKeptEntryId: event.preparation.firstKeptEntryId,
+				tokensBefore: event.preparation.tokensBefore,
+				details: {},
+			},
+		}));
+	};
+}
+
+describe("manual compaction liveness", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("keeps a post-compaction continuation alive when redundant manual compaction has no work", async () => {
+		const continuationUpdate = createDeferred();
+		const contextWindow = 5_000;
+		const reserveTokens = 1_000;
+		const harness = await createHarness({
+			models: [{ id: "faux-1", contextWindow }],
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens },
+			},
+			extensionFactories: [createLargeResultExtension("tool output ".repeat(300), "post-tool compaction summary")],
+		});
+		harnesses.push(harness);
+
+		const model = harness.getModel();
+		const seedTimestamp = Date.now() - 2_000;
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "prior context ".repeat(220) }],
+			timestamp: seedTimestamp,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("prior response", { timestamp: seedTimestamp + 1_000 }),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: createUsage(700),
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+		let autoCompactionAccepted = false;
+		harness.session.subscribe((event) => {
+			if (event.type === "compaction_end" && event.reason === "threshold" && event.accepted === true) {
+				autoCompactionAccepted = true;
+			}
+			if (autoCompactionAccepted && event.type === "message_update" && event.message.role === "assistant") {
+				continuationUpdate.resolve();
+			}
+		});
+		harness.setResponses([
+			fauxAssistantMessage(fauxToolCall("large_result", {}), { stopReason: "toolUse" }),
+			fauxAssistantMessage("continuation survived redundant compaction ".repeat(4_000)),
+		]);
+
+		const activePrompt = harness.session.prompt("run the large result tool");
+		await waitForSignal(continuationUpdate.promise, "the post-compaction continuation");
+		expect(harness.session.isStreaming).toBe(true);
+
+		const manualOutcome = harness.session.compact().then(
+			() => "completed" as const,
+			() => "rejected" as const,
+		);
+		await Promise.all([activePrompt, manualOutcome]);
+
+		const agentEnds = harness.eventsOfType("agent_end");
+		const finalMessages = agentEnds[agentEnds.length - 1]?.messages ?? [];
+		expect(
+			finalMessages[finalMessages.length - 1],
+			"a redundant manual compaction must not abort the active continuation",
+		).toMatchObject({ role: "assistant", stopReason: "stop" });
+		expect(harness.eventsOfType("compaction_start").map((event) => event.reason)).toEqual(["threshold", "manual"]);
+		expect(harness.eventsOfType("compaction_end")[1]).toMatchObject({
+			reason: "manual",
+			result: undefined,
+			aborted: false,
+		});
+		const assistantTexts = getAssistantTexts(harness);
+		expect(assistantTexts[assistantTexts.length - 1]).toContain("continuation survived redundant compaction");
+	});
+});


### PR DESCRIPTION
## Summary
- reject no-progress manual compaction before it aborts an active post-compaction continuation
- keep current todo snapshots bounded and remove the absolute successful-compaction cap while retaining failure protection
- lock the liveness path with deterministic regression coverage and make the default compile-cache test hermetic

## Verification
- `80` focused compaction/continuation tests passed on current `main`
- full coding-agent suite: `8,701` passed, `36` skipped, `0` failed
- current-main monorepo build passed
- root TypeScript and browser smoke checks passed
- Biome checked `3,265` files with no errors or fixes

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)