### PR TITLE
fix(tui): treat Bun errno-in-message as a dead terminal during shutdown

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Fixed
 
+- Fixed terminal shutdown still crashing with `setRawMode failed with errno: 5` under Bun, whose tty shim throws
+  the errno only inside the message text with no `code` or `errno` property. Dead-terminal detection now also
+  reads that message form for `EIO` and `EPIPE` while unrelated raw-mode failures keep propagating.
+
 ### Removed
 
 ## [2026.8.26] - 2026-08-26

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,40 @@
 # TUI delta rendering fork changes
 
+## Dead-terminal detection reads Bun's errno-in-message shape (2026-08-26)
+
+### What changed
+
+- `packages/tui/src/terminal.ts`: `isDeadTerminalError()` gains a third, last-resort branch that parses a
+  trailing `errno: <n>` out of the error message. It fires only when that number is a dead-terminal errno
+  that is stable across darwin and linux — `EIO` (5) and `EPIPE` (32). `ENOTCONN` is deliberately left out of
+  the numeric set because its value differs per platform (57 on darwin, 107 on linux). The existing string
+  `code` and numeric `errno` branches are unchanged and still win first, and any error that matches none of
+  the three branches still propagates out of `ProcessTerminal.stop()`.
+- `test/terminal.test.ts` pins the real Bun shape (a bare `new Error("setRawMode failed with errno: 5")`
+  with neither `code` nor `errno`), the `errno: 32` message form, and two rethrow fences: an unrelated
+  `new Error("boom")` and a live-but-unrelated `errno: 22` message.
+
+### Why
+
+- Bun 1.4.0's tty shim throws a plain `Error` for a failed `setRawMode()` ioctl: `code` and `errno` are both
+  absent and the number survives only in the message text (verified locally:
+  `{"isError":true,"hasCode":false,"hasErrno":false,"msg":"setRawMode failed with errno: 5"}`). The previous
+  classifier recognized only the two property shapes, so on a dead SSH/PTY peer the exception escaped
+  `ProcessTerminal.stop()` into `Tui.stop()` and `stopInteractiveTui()`, aborting shutdown and hanging the
+  session with `error: setRawMode failed with errno: 5`.
+
+### Why this lives in the fork
+
+- Raw-mode ownership and teardown are private `ProcessTerminal` lifecycle responsibilities running inside the
+  shutdown path. No extension surface sits between the saved raw-mode state and the stdin ioctl, so the
+  classification has to happen where the throw occurs.
+
+### Expected merge conflict zones
+
+- LOW: `packages/tui/src/terminal.ts` around the dead-terminal errno constants and the `isDeadTerminalError()`
+  body.
+- LOW: `packages/tui/test/terminal.test.ts` around the `ProcessTerminal stop` suite.
+
 ## TUI runtime re-diverges from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -16,6 +16,14 @@ const DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS = 7;
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
 // Bun's macOS tty shim can report synchronous ioctl EIO as raw positive errno 5 without a string code.
 const EIO_ERRNO = 5;
+// Bun's tty shim can also drop both properties and leave the errno only in the message text
+// (`new Error("setRawMode failed with errno: 5")` - no `code`, no `errno`), so the numeric
+// fallback has to read the message. Restricted to errno values that are stable across darwin
+// and linux: EIO (5) and EPIPE (32). ENOTCONN is deliberately excluded because its number
+// differs per platform (57 on darwin, 107 on linux) and a wrong guess would swallow a live error.
+const EPIPE_ERRNO = 32;
+const DEAD_TERMINAL_ERRNOS = new Set([EIO_ERRNO, EPIPE_ERRNO]);
+const ERRNO_IN_MESSAGE_PATTERN = /errno:\s*(\d+)/;
 const KEYBOARD_PROTOCOL_RESPONSE_FRAGMENT_TIMEOUT_MS = 150;
 const KITTY_KEYBOARD_PROTOCOL_QUERY = `\x1b[>${DESIRED_KITTY_KEYBOARD_PROTOCOL_FLAGS}u\x1b[?u\x1b[c`;
 
@@ -66,7 +74,10 @@ export function keyboardEnhancementEnabled(): boolean {
 function isDeadTerminalError(error: unknown): boolean {
 	if (!(error instanceof Error)) return false;
 	if ("code" in error && typeof error.code === "string") return DEAD_TERMINAL_ERROR_CODES.has(error.code);
-	return "errno" in error && error.errno === EIO_ERRNO;
+	if ("errno" in error && error.errno === EIO_ERRNO) return true;
+	const messageErrno = ERRNO_IN_MESSAGE_PATTERN.exec(error.message);
+	if (!messageErrno) return false;
+	return DEAD_TERMINAL_ERRNOS.has(Number.parseInt(messageErrno[1]!, 10));
 }
 
 /**

--- a/packages/tui/test/terminal.test.ts
+++ b/packages/tui/test/terminal.test.ts
@@ -404,6 +404,72 @@ describe("ProcessTerminal stop", () => {
 		}
 	});
 
+	it("does not throw when Bun reports the dead terminal only in the message", () => {
+		// Given
+		const bunShimEio = new Error("setRawMode failed with errno: 5");
+		const harness = setupTerminalStopHarness(false, () => {
+			throw bunShimEio;
+		});
+
+		try {
+			// When / Then
+			assert.doesNotThrow(() => harness.terminal.stop());
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("does not throw when the message carries the EPIPE errno", () => {
+		// Given
+		const bunShimEpipe = new Error("setRawMode failed with errno: 32");
+		const harness = setupTerminalStopHarness(false, () => {
+			throw bunShimEpipe;
+		});
+
+		try {
+			// When / Then
+			assert.doesNotThrow(() => harness.terminal.stop());
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("rethrows raw-mode failures whose message carries no dead-terminal errno", () => {
+		// Given
+		const unrelated = new Error("boom");
+		const harness = setupTerminalStopHarness(false, () => {
+			throw unrelated;
+		});
+
+		try {
+			// When / Then
+			assert.throws(
+				() => harness.terminal.stop(),
+				(error: unknown) => error === unrelated,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("rethrows raw-mode failures carrying a non-dead errno in the message", () => {
+		// Given
+		const unrelated = new Error("setRawMode failed with errno: 22");
+		const harness = setupTerminalStopHarness(false, () => {
+			throw unrelated;
+		});
+
+		try {
+			// When / Then
+			assert.throws(
+				() => harness.terminal.stop(),
+				(error: unknown) => error === unrelated,
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
 	it("does not throw when Node reports the dead terminal by error code", () => {
 		// Given
 		const eio = Object.assign(new Error("setRawMode failed"), { code: "EIO" });


### PR DESCRIPTION
## Summary
TUI shutdown could throw `error: setRawMode failed with errno: 5` and hang the session (real user report: `stop()` -> `tui.stop()` -> `stopInteractiveTui` -> `shutdown`).

`isDeadTerminalError` only recognized a dead terminal from a string `code` (EIO/EPIPE/ENOTCONN) or a numeric `errno` property. Bun's tty shim throws a **bare `Error` with neither property** - the errno lives only in the message. Verified empirically against the real shim on Bun 1.4.0:

```
{"isError":true,"hasCode":false,"hasErrno":false,"msg":"setRawMode failed with errno: 9"}
```

(errno 9 = EBADF from a forced bogus fd; a dead SSH/PTY peer yields errno 5 = EIO through the identical path.)

The pre-existing fixture bolted a synthetic `errno` property onto the right message, which is exactly why this shipped green.

## Fix
A third, last-resort branch parsing `/errno:\s*(\d+)/` from the message, accepted **only** for EIO (5) and EPIPE (32). ENOTCONN is deliberately excluded from the numeric set: it is 57 on darwin but 107 on linux, and a wrong constant would swallow a genuinely live error on the other platform - the string-`code` branch already covers it where Node supplies one. The existing `code` and `errno` branches are untouched and still evaluated first.

## Verification
- RED: new bare-error test failed with `Got unwanted exception. Actual message: "setRawMode failed with errno: 5"` (32 pass / 1 fail).
- GREEN: `packages/tui` suite **1074 passed / 0 failed**; `npm run test --workspace packages/tui` exit 0.
- Real-Bun end-to-end: an actual `tty.ReadStream` shim throw driven through `ProcessTerminal.stop()` -> `stop() survived the real Bun shim throw`.
- `npm run check` exit 0 (biome 3315 files, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, `tsc --noEmit`, browser-smoke).
- Anti-swallow fences: `new Error("boom")` rethrows, and `errno: 22` (EINVAL) rethrows - both would fail under a catch-all widening.