### PR TITLE
fix(goal): contain stale-ctx reads in the continuation timer path

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- A goal continuation whose backstop timer fired after the session was replaced or reloaded no longer crashes the session with "This extension ctx is stale after session replacement or reload". The timer callback (and its own error handler) now treats a retired context as "no UI" instead of letting the stale-context error escape as an uncaught exception; unrelated delivery failures are still reported.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,40 @@
 # goal Extension Changes
 
+## 2026-08-26 - continuation timer survives a retired extension context
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts`
+  routes every `hasUI` read through a new private `#ctxHasUI(ctx)` helper that
+  treats the stale-ctx error (`stale-context.ts`) as "no UI" and rethrows
+  anything else. The three affected reads are `#armTimer`'s pre-arm wait-ticker
+  sync, the `setTimeout` callback's own `catch` handler, and the toolless stall
+  notice in `#buildContinuationContent`. The timer callback additionally drops a
+  rejection that is itself a stale-ctx error, since that is the expected outcome
+  after a session replacement. Covered by
+  `test/suite/goal-ticker-stale-context.test.ts`.
+
+### Why
+
+- `ctx.hasUI` is an `assertActive()`-guarded getter, so a context retired by
+  session replacement or reload THROWS rather than returning false. The existing
+  `this.#ctx?.hasUI` optional chaining only guarded the `undefined` that
+  `dispose()` leaves behind, not the stale object left when a session is replaced
+  without disposing this monitor. Because the read happened inside a bare
+  `setTimeout` callback, the throw escaped as an uncaughtException and killed the
+  session (reported in the wild from `runner.js` `assertActive` via `hasUI`).
+
+### Why an extension could not handle it
+
+- The armed continuation timer, the retained `#ctx`, and the continuation
+  admission path are all private state inside the builtin Goal extension; no
+  external hook observes or wraps that callback.
+
+### Expected merge conflict zones
+
+- LOW in `monitor-continuation.ts` around `#armTimer` and
+  `#buildContinuationContent` where the `hasUI` reads are now helper calls.
+
 ## 2026-08-24 - provider retry exhaustion uses guarded recovery
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -40,6 +40,7 @@ import type {
 	SystemAbortOptions,
 } from "./monitor-continuation-types.ts";
 import { buildContinuationPrompt, buildGoalStallNotice, buildTruncationRecoveryPrompt } from "./prompt.ts";
+import { isStaleExtensionContextError } from "./stale-context.ts";
 import { resetContinuationStreak } from "./store.ts";
 import { goalStoreRef } from "./store-ref.ts";
 import { collectAssistantUsage } from "./turn-usage.ts";
@@ -364,10 +365,27 @@ export class MonitorAwareGoalContinuation {
 		this.#armTimer(kind, delayMs, delayMs);
 	}
 
+	/**
+	 * `hasUI` is an `assertActive()`-guarded getter, so a ctx retired by session
+	 * replacement or reload THROWS instead of reporting false. Optional chaining
+	 * only guards an undefined ctx (what `dispose()` leaves behind), never a stale
+	 * object left by a replacement that never disposed this monitor. Callers reach
+	 * this from timer and event callbacks where a throw is fatal, so a retired ctx
+	 * reports "no UI" and any other failure keeps its current behavior.
+	 */
+	#ctxHasUI(ctx: ExtensionContext | undefined = this.#ctx): boolean {
+		try {
+			return ctx?.hasUI === true;
+		} catch (error) {
+			if (isStaleExtensionContextError(error)) return false;
+			throw error;
+		}
+	}
+
 	#armTimer(kind: DelayedContinuationKind, delayMs: number, totalMs: number, drainFire = false): void {
 		this.#scheduledDueAtMs = Date.now() + delayMs;
 		const ctx = this.#ctx;
-		if (ctx?.hasUI) {
+		if (ctx !== undefined && this.#ctxHasUI(ctx)) {
 			this.#waitTicker?.sync(ctx, {
 				kind,
 				remainingMs: delayMs,
@@ -377,10 +395,13 @@ export class MonitorAwareGoalContinuation {
 		}
 		this.#timer = setTimeout(() => {
 			void this.#continueIfEligible(kind, drainFire).catch((error: unknown) => {
-				if (this.#ctx?.hasUI) {
-					const message = error instanceof Error ? error.message : String(error);
-					this.#ctx.ui.notify(`Goal continuation delivery failed: ${message}`, "error");
-				}
+				// Runs from a bare setTimeout: anything thrown here escapes as an
+				// uncaughtException and kills the session. A retired ctx cannot be
+				// notified, and its own staleness is the expected cause of this
+				// rejection after a session replacement, so drop it quietly.
+				if (isStaleExtensionContextError(error) || !this.#ctxHasUI()) return;
+				const message = error instanceof Error ? error.message : String(error);
+				this.#ctx?.ui.notify(`Goal continuation delivery failed: ${message}`, "error");
 			});
 		}, delayMs);
 	}
@@ -501,7 +522,7 @@ export class MonitorAwareGoalContinuation {
 			consecutiveContinuations: this.#toollessContinuationStreak,
 			toolless: true,
 		});
-		if (ctx.hasUI) {
+		if (this.#ctxHasUI(ctx)) {
 			const context =
 				liveSources.length > 0 ? `while ${liveSources.join(", ")} channels stayed active` : "without tool use";
 			ctx.ui.notify(

--- a/packages/coding-agent/test/suite/goal-ticker-stale-context.test.ts
+++ b/packages/coding-agent/test/suite/goal-ticker-stale-context.test.ts
@@ -3,6 +3,7 @@ import { GoalElapsedTicker } from "../../src/core/extensions/builtin/goal/elapse
 import { MonitorAwareGoalContinuation } from "../../src/core/extensions/builtin/goal/monitor-continuation.ts";
 import type { Goal } from "../../src/core/extensions/builtin/goal/types.ts";
 import { GoalWaitTicker } from "../../src/core/extensions/builtin/goal/wait-ticker.ts";
+import { WAKE_SOURCE_STATE_EVENT } from "../../src/core/extensions/builtin/monitor-state-event.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 
 /** The runtime contract thrown by a retired extension context (agent-session). */
@@ -10,6 +11,43 @@ const STALE_CTX_MESSAGE =
 	"This extension ctx is stale after session replacement or reload. Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(), or ctx.reload().";
 
 const fakeCtx = { isIdle: () => true, ui: { setStatus: () => {} } } as unknown as ExtensionContext;
+
+/**
+ * A ctx retired by session replacement: every runner-guarded member rethrows the
+ * stale contract error, exactly as the real `assertActive()` getters do. `hasUI`
+ * is a getter (not a method) because that is the accessor shape that crashed in
+ * production from the goal continuation timer callback.
+ */
+function retiredCtx(onNotify: () => void, options: { readonly staleFrom?: number } = {}): ExtensionContext {
+	const stale = () => {
+		throw new Error(STALE_CTX_MESSAGE);
+	};
+	// `staleFrom` lets a ctx stay live long enough to arm the timer and go stale
+	// only once the callback runs — the real session-replacement ordering.
+	let hasUIReads = 0;
+	return {
+		get hasUI(): boolean {
+			hasUIReads += 1;
+			if (hasUIReads <= (options.staleFrom ?? 0)) return true;
+			return stale();
+		},
+		get ui(): unknown {
+			return {
+				notify: () => {
+					onNotify();
+				},
+				setStatus: () => {},
+			};
+		},
+		isIdle: () => {
+			if (hasUIReads < (options.staleFrom ?? 0)) return true;
+			return stale();
+		},
+		hasPendingMessages: stale,
+		getPromptCacheSafeWaitSeconds: () => undefined,
+		getPromptCacheGoalBackstopMaxSeconds: () => 3570,
+	} as unknown as ExtensionContext;
+}
 
 function activeGoal(): Goal {
 	return {
@@ -68,6 +106,120 @@ describe("goal tickers vs retired extension contexts", () => {
 			const rendersAfterRetire = renders;
 			vi.advanceTimersByTime(5_000);
 			expect(renders).toBe(rendersAfterRetire);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	// Regression: the armed continuation timer fires from a bare setTimeout, so a
+	// stale-ctx throw inside the callback (including inside its own catch handler,
+	// which read `this.#ctx?.hasUI` — optional chaining guards undefined, never a
+	// retired object) escaped as an uncaughtException and killed the session.
+	it.each([
+		// Stale before the timer is even armed: `#armTimer` reads `ctx?.hasUI`
+		// synchronously, so the throw escapes into whichever event handler re-armed it.
+		{ label: "while arming the timer", staleFrom: 0 },
+		// Stale only once the callback runs: the reported production crash, where the
+		// throw escapes a bare setTimeout as an uncaughtException.
+		{ label: "when the armed timer fires", staleFrom: 1 },
+	])("MonitorAwareGoalContinuation contains a stale ctx $label", async ({ staleFrom }) => {
+		vi.useFakeTimers();
+		// The crash escaped a bare setTimeout, so it surfaces as an unhandled
+		// rejection rather than a thrown assertion. Capture it explicitly.
+		const escaped: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			escaped.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			let notifies = 0;
+			const ctx = retiredCtx(
+				() => {
+					notifies += 1;
+				},
+				{ staleFrom },
+			);
+			const listeners = new Map<string, Array<(data: unknown) => void>>();
+			const pi = {
+				events: {
+					on: (channel: string, handler: (data: unknown) => void) => {
+						const handlers = listeners.get(channel) ?? [];
+						handlers.push(handler);
+						listeners.set(channel, handlers);
+						return () => {};
+					},
+					emit: () => {},
+				},
+			} as unknown as ExtensionAPI;
+			const monitor = new MonitorAwareGoalContinuation(pi);
+
+			// A live wake source keeps the monitor backstop armable.
+			for (const handler of listeners.get(WAKE_SOURCE_STATE_EVENT) ?? []) {
+				handler({ source: "terminal-monitors", activeCount: 1 });
+			}
+			monitor.start(ctx);
+			monitor.rearmMonitorBackstop(activeGoal());
+
+			// The session was replaced without dispose(), so the retained ctx is stale
+			// when the backstop finally fires. Nothing may escape the timer callback.
+			expect(() => vi.advanceTimersByTime(3_600_000)).not.toThrow();
+			await vi.runAllTimersAsync();
+			// Let any rejection the callback failed to contain reach the process handler.
+			vi.useRealTimers();
+			await new Promise((resolve) => setImmediate(resolve));
+
+			expect(escaped).toEqual([]);
+			// A dead ctx cannot show UI, so no notify may be attempted against it.
+			expect(notifies).toBe(0);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+			vi.useRealTimers();
+		}
+	});
+
+	// The stale-ctx containment above must not become a blanket catch: a LIVE ctx
+	// still has to surface a genuine delivery failure to the user.
+	it("MonitorAwareGoalContinuation still reports a delivery failure on a live ctx", async () => {
+		vi.useFakeTimers();
+		try {
+			const notices: string[] = [];
+			const ctx = {
+				hasUI: true,
+				ui: {
+					notify: (message: string) => notices.push(message),
+					setStatus: () => {},
+				},
+				// A live ctx that fails for an unrelated reason must not be silenced.
+				isIdle: () => {
+					throw new Error("disk exploded");
+				},
+				hasPendingMessages: () => false,
+				getPromptCacheSafeWaitSeconds: () => undefined,
+				getPromptCacheGoalBackstopMaxSeconds: () => 3570,
+			} as unknown as ExtensionContext;
+			const listeners = new Map<string, Array<(data: unknown) => void>>();
+			const pi = {
+				events: {
+					on: (channel: string, handler: (data: unknown) => void) => {
+						const handlers = listeners.get(channel) ?? [];
+						handlers.push(handler);
+						listeners.set(channel, handlers);
+						return () => {};
+					},
+					emit: () => {},
+				},
+			} as unknown as ExtensionAPI;
+			const monitor = new MonitorAwareGoalContinuation(pi);
+			for (const handler of listeners.get(WAKE_SOURCE_STATE_EVENT) ?? []) {
+				handler({ source: "terminal-monitors", activeCount: 1 });
+			}
+			monitor.start(ctx);
+			monitor.rearmMonitorBackstop(activeGoal());
+
+			vi.advanceTimersByTime(3_600_000);
+			await vi.runAllTimersAsync();
+
+			expect(notices).toEqual(["Goal continuation delivery failed: disk exploded"]);
 		} finally {
 			vi.useRealTimers();
 		}


### PR DESCRIPTION
## Summary
A goal-continuation timer callback touched a **stale** extension ctx and threw, killing the session (real user report):

```
error: This extension ctx is stale after session replacement or reload. ...
  at assertActive (core/extensions/runner.js:513:23)
  at hasUI (core/extensions/runner.js:711:24)
  at <anonymous> (builtin/goal/monitor-continuation.js:316:26)
```

`ctx.hasUI` is an `assertActive()`-guarded getter, so a ctx retired by session replacement **throws** instead of returning false. The existing `this.#ctx?.hasUI` optional chaining only guarded the `undefined` that `dispose()` leaves behind - never the stale *object* left when a session is replaced without disposing the monitor. Because this ran inside a bare `setTimeout` callback's own catch handler, the throw escaped as an uncaughtException.

## Scope was wider than reported
The audit found **three** hazardous reads, not one:
- `:380` - the fatal one from the user report (timer catch handler)
- `:370` - `#armTimer`, reachable synchronously from wake-source event handlers, throws even earlier
- `:504` - only stayed contained because `:380` swallowed it

Uses the repo's existing `stale-context.ts` seam (already used by both goal tickers) rather than inventing a predicate. There is no `isActive` on `ExtensionContext` - it exists only on the runner and is not reachable from a captured ctx - so error-shape detection is the idiomatic seam here.

## Verification
- **RED**: 2 failed / 3 passed, reproducing the exact production signature including the unhandled rejection at `monitor-continuation.ts:380:14`.
- **GREEN**: 6 passed / 0 failed.
- **`npm run check` exit 0** (`tsc --noEmit`, biome, all lock checks).
- **CI-shape suite, all 3 shards exit 0**: 3042 + 3106 + 2643 = **8791 passed, 37 skipped, 0 failed** (1093 files).
- Adjacent goal suites: 50/50 passed.
- **Mutation-tested**: removing the containment reintroduces the failure, and replacing it with a blanket `return` also fails - so the test is load-bearing and the fix provably contains *only* stale-ctx conditions. Added a test pinning that a **live** ctx still surfaces unrelated delivery failures, since no existing test covered that branch.