### PR TITLE
fix(tui,coding-agent): survive stdin EIO when the controlling terminal detaches

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixed
 
 - A goal continuation whose backstop timer fired after the session was replaced or reloaded no longer crashes the session with "This extension ctx is stale after session replacement or reload". The timer callback (and its own error handler) now treats a retired context as "no UI" instead of letting the stale-context error escape as an uncaught exception; unrelated delivery failures are still reported.
-
+- An uncaught dead-terminal error (e.g. a stdin read EIO after the controlling terminal detached) no longer prints the `exiting due to uncaughtException` banner and exits 1: `uncaughtCrash` routes it to the silent `emergencyTerminalExit()`, matching terminal write errors. `isDeadTerminalError` now also accepts Bun's raw `errno: 5`/`-5` shape.
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-26 - Route dead-terminal uncaught crashes to the silent emergency exit
+
+### What changed
+
+- `uncaughtCrash` in `interactive-mode.ts` classifies dead-terminal errors and routes them to `emergencyTerminalExit()` (silent 129) instead of printing the `exiting due to uncaughtException` banner and exiting 1. `isDeadTerminalError` now also accepts Bun's raw `errno: 5`/`-5` shape alongside string codes.
+
+### Why
+
+- A stdin read EIO from a detached terminal reached the last-resort handler while `isShuttingDown` was false and printed a crash banner to a terminal that was already gone; the dead-terminal path already existed for write errors and now covers uncaught throws too.
+
+### Why this lives in the fork
+
+- The signal/shutdown choreography (`emergencyTerminalExit`, drain ordering) is fork-owned.
+
+### Expected merge conflict zones
+
+- LOW: `uncaughtCrash` and `isDeadTerminalError` in `interactive-mode.ts` during upstream syncs.
+
 ## 2026-08-25 - Do not adopt unwired upstream settings submenu
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -313,6 +313,8 @@ function isCompactionCostNotice(item: RenderSessionItem): item is CompactionCost
 }
 
 const DEAD_TERMINAL_ERROR_CODES = new Set(["EIO", "EPIPE", "ENOTCONN"]);
+// Bun's macOS tty shim can report a dead terminal as raw positive errno 5 without a string code.
+const EIO_ERRNO = 5;
 const DEFAULT_RETRY_STATUS_REFRESH_INTERVAL_MS = 80;
 const LARGE_SESSION_RETRY_STATUS_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_WORKING_STATUS_REFRESH_INTERVAL_MS = 600;
@@ -385,11 +387,20 @@ function formatWorkingStatusShimmerText(text: string, intensity: number): string
 }
 
 function isDeadTerminalError(error: unknown): boolean {
-	if (!error || typeof error !== "object" || !("code" in error)) {
+	if (!error || typeof error !== "object") {
 		return false;
 	}
-	const code = (error as NodeJS.ErrnoException).code;
-	return code !== undefined && DEAD_TERMINAL_ERROR_CODES.has(code);
+	if ("code" in error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code !== undefined && DEAD_TERMINAL_ERROR_CODES.has(code)) {
+			return true;
+		}
+	}
+	if ("errno" in error) {
+		const errno = (error as NodeJS.ErrnoException).errno;
+		return errno === EIO_ERRNO || errno === -EIO_ERRNO;
+	}
+	return false;
 }
 
 const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
@@ -5505,6 +5516,13 @@ export class InteractiveMode {
 	private uncaughtCrash(error: Error, origin: "uncaughtException" | "unhandledRejection"): void {
 		if (this.isShuttingDown) {
 			process.exit(1);
+		}
+		if (isDeadTerminalError(error)) {
+			// The terminal died under the session (e.g. an stdin read EIO after
+			// the controlling terminal vanished or this pgrp lost the tty
+			// foreground). Same handling as terminal write errors: exit silently
+			// instead of printing a crash banner to a terminal that is gone.
+			this.emergencyTerminalExit();
 		}
 		if (isRecoverableInspectorVmImportError(error, origin)) {
 			this.showWarning(INSPECTOR_VM_IMPORT_WARNING);

--- a/packages/coding-agent/test/suite/regressions/terminal-detach-uncaught-crash.test.ts
+++ b/packages/coding-agent/test/suite/regressions/terminal-detach-uncaught-crash.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../../../src/modes/interactive/interactive-mode.ts";
+
+type UncaughtExceptionOrigin = "uncaughtException" | "unhandledRejection";
+
+class ProcessExitError extends Error {
+	readonly code: string | number | null | undefined;
+
+	constructor(code: string | number | null | undefined) {
+		super(`process.exit(${String(code)})`);
+		this.code = code;
+	}
+}
+
+type UncaughtCrashThis = {
+	isShuttingDown: boolean;
+	showWarning: (message: string) => void;
+	ui: { stop: () => void };
+	unregisterSignalHandlers: () => void;
+	emergencyTerminalExit: () => never;
+};
+
+type InteractiveModePrototypeWithUncaughtCrash = {
+	uncaughtCrash(this: UncaughtCrashThis, error: Error, origin: UncaughtExceptionOrigin): void;
+};
+
+const interactiveModePrototype = InteractiveMode.prototype as unknown as InteractiveModePrototypeWithUncaughtCrash;
+
+function callUncaughtCrash(context: UncaughtCrashThis, error: Error, origin: UncaughtExceptionOrigin): void {
+	interactiveModePrototype.uncaughtCrash.call(context, error, origin);
+}
+
+function createCrashContext(): UncaughtCrashThis {
+	return {
+		isShuttingDown: false,
+		showWarning: vi.fn(),
+		ui: { stop: vi.fn() },
+		unregisterSignalHandlers: vi.fn(),
+		emergencyTerminalExit: vi.fn(() => {
+			throw new ProcessExitError(129);
+		}) as unknown as () => never,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("uncaughtCrash dead-terminal classification", () => {
+	test("routes a stdin read EIO to the silent emergency exit instead of the crash banner", () => {
+		// Given a running session whose controlling terminal vanished under it.
+		const context = createCrashContext();
+		const eio = Object.assign(new Error("EIO: i/o error, read"), { code: "EIO", errno: -5, syscall: "read" });
+		const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new ProcessExitError(code);
+		});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// When the unlistened stdin error reaches the last-resort handler.
+		expect(() => callUncaughtCrash(context, eio, "uncaughtException")).toThrow(ProcessExitError);
+
+		// Then the dead-terminal path wins: silent 129, no banner, no fatal exit(1).
+		expect(context.emergencyTerminalExit).toHaveBeenCalledTimes(1);
+		expect(exit).not.toHaveBeenCalled();
+		expect(context.ui.stop).not.toHaveBeenCalled();
+		const bannerCalls = consoleError.mock.calls.filter((args) =>
+			args.some((arg) => typeof arg === "string" && arg.includes("exiting due to uncaughtException")),
+		);
+		expect(bannerCalls).toHaveLength(0);
+	});
+
+	test("routes Bun's numeric-errno dead-terminal shape to the emergency exit", () => {
+		// Given the same detach reported as a bare numeric errno (Bun macOS shape).
+		const context = createCrashContext();
+		const eio = Object.assign(new Error("read failed with errno: 5"), { errno: 5 });
+		vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new ProcessExitError(code);
+		});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// When / Then
+		expect(() => callUncaughtCrash(context, eio, "uncaughtException")).toThrow(ProcessExitError);
+		expect(context.emergencyTerminalExit).toHaveBeenCalledTimes(1);
+	});
+
+	test("keeps ordinary crashes on the fatal banner path", () => {
+		// Given a crash that has nothing to do with a dead terminal.
+		const context = createCrashContext();
+		const failure = Object.assign(new Error("unexpected extension failure"), { code: "EINVAL" });
+		const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new ProcessExitError(code);
+		});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// When
+		expect(() => callUncaughtCrash(context, failure, "uncaughtException")).toThrow(ProcessExitError);
+
+		// Then the existing contract is untouched: banner, terminal restore, exit(1).
+		expect(exit).toHaveBeenCalledWith(1);
+		expect(context.emergencyTerminalExit).not.toHaveBeenCalled();
+		expect(context.ui.stop).toHaveBeenCalledTimes(1);
+		const bannerCalls = consoleError.mock.calls.filter((args) =>
+			args.some((arg) => typeof arg === "string" && arg.includes("exiting due to uncaughtException")),
+		);
+		expect(bannerCalls.length).toBeGreaterThan(0);
+	});
+
+	test("stays silent when the dead-terminal error arrives mid-shutdown", () => {
+		// Given shutdown already latched (its own EIO handling owns the terminal).
+		const context = createCrashContext();
+		context.isShuttingDown = true;
+		const eio = Object.assign(new Error("EIO: i/o error, read"), { code: "EIO" });
+		const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new ProcessExitError(code);
+		});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		// When
+		expect(() => callUncaughtCrash(context, eio, "uncaughtException")).toThrow(ProcessExitError);
+
+		// Then the established silent exit(1) is preserved, no double teardown.
+		expect(exit).toHaveBeenCalledWith(1);
+		expect(context.emergencyTerminalExit).not.toHaveBeenCalled();
+		expect(consoleError).not.toHaveBeenCalled();
+	});
+});

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Fixed terminal shutdown still crashing with `setRawMode failed with errno: 5` under Bun, whose tty shim throws
   the errno only inside the message text with no `code` or `errno` property. Dead-terminal detection now also
   reads that message form for `EIO` and `EPIPE` while unrelated raw-mode failures keep propagating.
-
+- A vanished or re-backgrounded controlling terminal no longer kills the agent process: the next stdin read fails with EIO, and `process.stdin` had no `"error"` listener, so the EventEmitter rethrew it as an uncaught exception. `ProcessTerminal` now arms a stdin error guard from `start()` until a 250ms grace window after `stop()`, swallowing EIO (Node's `code: "EIO"` and Bun's raw `errno: 5`/`-5`) while every other stdin error keeps its default EventEmitter propagation.
 ### Removed
 
 ## [2026.8.26] - 2026-08-26

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -35,6 +35,24 @@
   body.
 - LOW: `packages/tui/test/terminal.test.ts` around the `ProcessTerminal stop` suite.
 
+## 2026-08-26 - Guard stdin EIO when the controlling terminal detaches
+
+### What changed
+
+- `packages/tui/src/terminal.ts` arms a `process.stdin` "error" guard from `ProcessTerminal.start()` until a 250ms grace window after `stop()`: a vanished or re-backgrounded controlling terminal fails the next stdin read with EIO, and without a listener the EventEmitter rethrew it as an uncaught exception that killed the agent process. The classifier owns EIO only — Node's `code: "EIO"` and Bun's raw `errno: 5`/`-5` shapes — and every other stdin error keeps its default EventEmitter propagation. EIO is swallowed without pausing the stream, so a pgrp that regains the tty foreground keeps accepting input.
+
+### Why
+
+- When omo's launcher chain dies (e.g. external SIGTERM), the orphaned engine's pending stdin read on the now-background tty fails with EIO and crashed the process through `uncaughtException` ("exiting due to uncaughtException: EIO read"). The same hazard was fixed upstream-style in gajae #3758; this port adapts it to the fork's `ProcessTerminal` and adds the numeric-errno shape from the shutdown-time classifier.
+
+### Why this lives in the fork
+
+- The crash topology (launcher chain + orphaned engine) and the Bun runtime shim are fork-owned; the fork's terminal lifecycle differs from upstream's.
+
+### Expected merge conflict zones
+
+- `ProcessTerminal.start()`/`stop()` in `packages/tui/src/terminal.ts` during upstream syncs.
+
 ## TUI runtime re-diverges from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -80,6 +80,52 @@ function isDeadTerminalError(error: unknown): boolean {
 	return DEAD_TERMINAL_ERRNOS.has(Number.parseInt(messageErrno[1]!, 10));
 }
 
+const STDIN_ERROR_HANDLER_GRACE_MS = 250;
+const stdinErrorSubscribers = new Set<(err: Error) => void>();
+
+export function __stdinErrorSubscriberCountForTests(): number {
+	return stdinErrorSubscribers.size;
+}
+export function __stdinErrorDispatcherInstalledForTests(): boolean {
+	return process.stdin.listeners("error").includes(dispatchStdinError);
+}
+
+/**
+ * A vanished or re-backgrounded controlling terminal fails the next stdin
+ * read with EIO; that is the only stdin error this module owns. Node reports
+ * it as code "EIO" (errno -5), Bun's macOS tty shim as a bare positive
+ * errno 5 — both shapes classify. Any other stdin failure (EBADF, EPIPE, an
+ * unexpected platform error) keeps its default EventEmitter propagation so it
+ * stays observable instead of being downgraded to a silently ignored error.
+ */
+function isTerminalDetachStdinError(err: Error): boolean {
+	if ((err as NodeJS.ErrnoException).code === "EIO") return true;
+	const errno = (err as NodeJS.ErrnoException).errno;
+	return errno === EIO_ERRNO || errno === -EIO_ERRNO;
+}
+
+const dispatchStdinError = (err: Error): void => {
+	if (!isTerminalDetachStdinError(err)) {
+		// Our listener must not be the reason a non-EIO error stops propagating.
+		// When no other "error" listener exists, EventEmitter would have thrown;
+		// rethrowing from inside emit() reproduces that exact contract.
+		const hasOtherListener = process.stdin.listeners("error").some((listener) => listener !== dispatchStdinError);
+		if (!hasOtherListener) throw err;
+		return;
+	}
+	for (const subscriber of stdinErrorSubscribers) subscriber(err);
+};
+
+function subscribeToStdinErrors(subscriber: (err: Error) => void): void {
+	if (stdinErrorSubscribers.size === 0) process.stdin.on("error", dispatchStdinError);
+	stdinErrorSubscribers.add(subscriber);
+}
+
+function unsubscribeFromStdinErrors(subscriber: (err: Error) => void): void {
+	stdinErrorSubscribers.delete(subscriber);
+	if (stdinErrorSubscribers.size === 0) process.stdin.removeListener("error", dispatchStdinError);
+}
+
 /**
  * Minimal terminal interface for TUI
  */
@@ -174,6 +220,8 @@ export class ProcessTerminal implements Terminal {
 	private keyboardProtocolBufferFlushTimer?: ReturnType<typeof setTimeout>;
 	private stdinBuffer?: StdinBuffer;
 	private stdinDataHandler?: (data: string | Buffer) => void;
+	private stdinErrorHandler?: (err: Error) => void;
+	private stdinErrorHandlerCleanupTimer?: ReturnType<typeof setTimeout>;
 	private progressInterval?: ReturnType<typeof setInterval>;
 	private writeLogPath = (() => {
 		const env = process.env.PI_TUI_WRITE_LOG || "";
@@ -265,6 +313,22 @@ export class ProcessTerminal implements Terminal {
 			process.stdin.setRawMode(true);
 		}
 		process.stdin.resume();
+
+		// stdin carries the same hazard as stdout: when the controlling PTY
+		// disappears (launcher killed, tmux pane closed, SSH dropped) or this
+		// pgrp loses the tty foreground, the next read fails with EIO.
+		// `process.stdin` is an EventEmitter, so an unobserved "error" event is
+		// rethrown as an uncaught exception that kills the whole agent process.
+		if (this.stdinErrorHandlerCleanupTimer) {
+			clearTimeout(this.stdinErrorHandlerCleanupTimer);
+			this.stdinErrorHandlerCleanupTimer = undefined;
+		}
+		if (!this.stdinErrorHandler) {
+			// Swallow only: the stream stays resumable, so if this pgrp regains
+			// the tty foreground the session keeps accepting input.
+			this.stdinErrorHandler = () => {};
+			subscribeToStdinErrors(this.stdinErrorHandler);
+		}
 
 		// Enable bracketed paste mode - terminal will wrap pastes in \x1b[200~ ... \x1b[201~
 		this.rawWrite("\x1b[?2004h");
@@ -579,6 +643,23 @@ export class ProcessTerminal implements Terminal {
 		}
 
 		this.removeExternalStdoutGuard();
+
+		this.scheduleStdinErrorHandlerCleanup();
+	}
+
+	private scheduleStdinErrorHandlerCleanup(): void {
+		if (!this.stdinErrorHandler || this.stdinErrorHandlerCleanupTimer) return;
+		// Keep the guard armed briefly past stop(): a late PTY failure racing
+		// the exit path must not crash the process after the TUI tore down.
+		const handler = this.stdinErrorHandler;
+		this.stdinErrorHandlerCleanupTimer = setTimeout(() => {
+			this.stdinErrorHandlerCleanupTimer = undefined;
+			if (this.stdinErrorHandler === handler) {
+				this.stdinErrorHandler = undefined;
+				unsubscribeFromStdinErrors(handler);
+			}
+		}, STDIN_ERROR_HANDLER_GRACE_MS);
+		this.stdinErrorHandlerCleanupTimer.unref();
 	}
 
 	write(data: string): void {

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert";
 import { describe as nodeDescribe, it as nodeIt } from "node:test";
 import { describe as vitestDescribe, it as vitestIt } from "vitest";
-import { ProcessTerminal } from "../src/terminal.ts";
+import {
+	__stdinErrorDispatcherInstalledForTests,
+	__stdinErrorSubscriberCountForTests,
+	ProcessTerminal,
+} from "../src/terminal.ts";
 
 const isVitest = process.env.VITEST === "true";
 type TestCallback = () => void | Promise<void>;
@@ -76,6 +80,8 @@ describe("ProcessTerminal stdin detach", () => {
 		const started = startTerminal();
 		try {
 			// When / Then: an unlistened "error" event would rethrow from emit().
+			assert.equal(__stdinErrorDispatcherInstalledForTests(), true);
+			assert.equal(__stdinErrorSubscriberCountForTests(), 1);
 			assert.doesNotThrow(() => process.stdin.emit("error", eioStringCode()));
 		} finally {
 			started.cleanup();
@@ -124,6 +130,8 @@ describe("ProcessTerminal stdin detach", () => {
 		// When: the grace window (250ms) has fully elapsed.
 		await new Promise((resolve) => setTimeout(resolve, 400));
 		// Then: no leaked listener remains, so EIO rethrows like any unlistened error.
+		assert.equal(__stdinErrorSubscriberCountForTests(), 0);
+		assert.equal(__stdinErrorDispatcherInstalledForTests(), false);
 		assert.throws(() => process.stdin.emit("error", eioStringCode()));
 	});
 });

--- a/packages/tui/test/terminal-detach.test.ts
+++ b/packages/tui/test/terminal-detach.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert";
+import { describe as nodeDescribe, it as nodeIt } from "node:test";
+import { describe as vitestDescribe, it as vitestIt } from "vitest";
+import { ProcessTerminal } from "../src/terminal.ts";
+
+const isVitest = process.env.VITEST === "true";
+type TestCallback = () => void | Promise<void>;
+
+function describe(name: string, fn: TestCallback): void {
+	if (isVitest) {
+		vitestDescribe(name, fn);
+		return;
+	}
+	nodeDescribe(name, fn);
+}
+
+function it(name: string, fn: TestCallback): void {
+	if (isVitest) {
+		vitestIt(name, fn);
+		return;
+	}
+	nodeIt(name, fn);
+}
+
+/**
+ * A vanished controlling terminal (launcher killed, tmux pane closed, SSH
+ * dropped) fails the in-flight stdin read with EIO. Without an "error"
+ * listener, process.stdin rethrows it as an uncaught exception that kills the
+ * agent process. The stdin guard must swallow EIO (and only EIO) from the
+ * moment the terminal starts until a short grace window after stop().
+ */
+
+function eioStringCode(): Error {
+	return Object.assign(new Error("EIO: i/o error, read"), { code: "EIO", errno: -5, syscall: "read" });
+}
+
+function eioNumericErrno(): Error {
+	return Object.assign(new Error("read failed with errno: 5"), { errno: 5 });
+}
+
+function ebadf(): Error {
+	return Object.assign(new Error("EBADF: bad file descriptor, read"), { code: "EBADF" });
+}
+
+interface StartedTerminal {
+	terminal: ProcessTerminal;
+	cleanup: () => void;
+}
+
+function startTerminal(): StartedTerminal {
+	const previousKeyboardProtocol = process.env.PI_TUI_KEYBOARD_PROTOCOL;
+	process.env.PI_TUI_KEYBOARD_PROTOCOL = "0";
+	const terminal = new ProcessTerminal();
+	terminal.start(
+		() => {},
+		() => {},
+	);
+	// Keep restore sequences out of the test transcript.
+	Reflect.set(terminal, "rawStdoutWrite", (_data: string) => {});
+	return {
+		terminal,
+		cleanup(): void {
+			terminal.stop();
+			if (previousKeyboardProtocol === undefined) {
+				delete process.env.PI_TUI_KEYBOARD_PROTOCOL;
+			} else {
+				process.env.PI_TUI_KEYBOARD_PROTOCOL = previousKeyboardProtocol;
+			}
+		},
+	};
+}
+
+describe("ProcessTerminal stdin detach", () => {
+	it("swallows a stdin EIO reported with Node's string code while running", () => {
+		// Given
+		const started = startTerminal();
+		try {
+			// When / Then: an unlistened "error" event would rethrow from emit().
+			assert.doesNotThrow(() => process.stdin.emit("error", eioStringCode()));
+		} finally {
+			started.cleanup();
+		}
+	});
+
+	it("swallows a stdin EIO reported with Bun's numeric errno", () => {
+		// Given
+		const started = startTerminal();
+		try {
+			// When / Then
+			assert.doesNotThrow(() => process.stdin.emit("error", eioNumericErrno()));
+		} finally {
+			started.cleanup();
+		}
+	});
+
+	it("keeps the EventEmitter contract for non-EIO stdin errors", () => {
+		// Given
+		const started = startTerminal();
+		const failure = ebadf();
+		try {
+			// When / Then: EBADF is not a terminal detach and must keep propagating.
+			assert.throws(
+				() => process.stdin.emit("error", failure),
+				(error: unknown) => error === failure,
+			);
+		} finally {
+			started.cleanup();
+		}
+	});
+
+	it("keeps swallowing a late EIO during the stop grace window", () => {
+		// Given
+		const started = startTerminal();
+		// When: stop, then a late PTY failure arrives inside the grace window.
+		started.cleanup();
+		// Then
+		assert.doesNotThrow(() => process.stdin.emit("error", eioStringCode()));
+	});
+
+	it("removes the guard once the stop grace window expires", async () => {
+		// Given
+		const started = startTerminal();
+		started.cleanup();
+		// When: the grace window (250ms) has fully elapsed.
+		await new Promise((resolve) => setTimeout(resolve, 400));
+		// Then: no leaked listener remains, so EIO rethrows like any unlistened error.
+		assert.throws(() => process.stdin.emit("error", eioStringCode()));
+	});
+});


### PR DESCRIPTION
## Summary

When omo's launcher chain dies (e.g. an external SIGTERM), the orphaned interactive engine keeps a pending stdin read on a terminal whose foreground the shell has reclaimed. The next read fails with `EIO`, and because `process.stdin` had no `"error"` listener anywhere in senpi, the EventEmitter rethrew it as an uncaught exception: `uncaughtCrash` printed `<app> exiting due to uncaughtException: EIO: i/o error, read` and the process died with exit 1 — intermittently, whenever the EIO won the race against the engine's own SIGHUP/SIGTTIN shutdown path.

This PR fixes the crash at two layers: the TUI now guards stdin errors the way upstream's #3758 did (adapted to the fork's `ProcessTerminal`), and `uncaughtCrash` routes any dead-terminal error to the existing silent `emergencyTerminalExit()` instead of printing a crash banner to a terminal that is already gone.

## Changes

- **`packages/tui` — stdin detach guard** (`src/terminal.ts`): a `dispatchStdinError` + subscribe/unsubscribe mechanism armed by `ProcessTerminal.start()` and held for a 250ms grace window after `stop()`. The classifier owns **EIO only** — both Node's `code: "EIO"` (errno −5) and Bun's raw numeric `errno: 5` macOS shape — and swallows it without pausing the stream, so a process group that regains the tty foreground keeps accepting input. Every non-EIO stdin error keeps its exact default EventEmitter propagation (rethrown when no other listener exists).
- **`packages/coding-agent` — crash classification** (`src/modes/interactive/interactive-mode.ts`): `uncaughtCrash` now routes `isDeadTerminalError(error)` to `emergencyTerminalExit()` (silent 129), the same path terminal *write* errors already take. `isDeadTerminalError` gains the numeric-errno branch alongside string codes.
- **Tests**: `packages/tui/test/terminal-detach.test.ts` (5 cases) and `packages/coding-agent/test/suite/regressions/terminal-detach-uncaught-crash.test.ts` (4 cases), each captured failing on the unmodified tree first.
- **`changes.md` entries** in both packages per fork convention.

## QA & Evidence

- **What was tested:** unit — stdin EIO swallowed while running (string + numeric shapes), non-EIO `EBADF` keeps the EventEmitter rethrow contract, late EIO inside the stop grace window swallowed, guard removed after grace expiry. Command: `node --test --import tsx --import ./test/setup-multiplexer-env.mjs test/terminal-detach.test.ts`.
- **Observed result:** RED before (EventEmitter rethrew `EIO: i/o error, read`), GREEN after — 5/5 pass.
- **Artifact:** `terminal-detach.test.ts` (RED/GREEN transcripts captured during the run).
- **Why sufficient:** covers the guard's happy path, both error shapes, the propagation contract, and the lifecycle window.

- **What was tested:** unit — `uncaughtCrash` with a dead-terminal error routes to `emergencyTerminalExit` (no banner, no exit(1)); ordinary crashes keep the banner + exit(1); mid-shutdown EIO keeps the silent exit(1). Command: `npx vitest --run test/suite/regressions/terminal-detach-uncaught-crash.test.ts`.
- **Observed result:** RED before (`emergencyTerminalExit` never called), GREEN after — 4/4 pass.
- **Why sufficient:** pins the new classification plus the two pre-existing behaviors that must not change.

- **What was tested:** real-surface E2E — a PTY harness runs the built engine (`node packages/coding-agent/dist/cli.js`) as a pty session leader with `SIGTTIN` ignored, then steals the tty foreground and pokes input, deterministically forcing the next stdin `read()` to fail `EIO` (the exact production condition).
- **Observed result:** base tree: engine printed `exiting due to uncaughtException` + EIO and exited 1. Fixed tree: engine still alive at the end of the observation window, zero banner, zero EIO output (harness had to SIGKILL it). Same-day control against the currently installed unguarded engine (omo beta.19 / senpi 2026.8.24): still crashes with exit 1 + banner under the identical harness.
- **Why sufficient:** this is the production failure surface reproduced end-to-end, RED→GREEN on the same trigger, with a live control proving the trigger still fires.

- **Regression:** `packages/tui` full `npm test` green (exit 0); root `npm run check` green (biome, tsc --noEmit, pinned-deps/ts-imports/shrinkwrap/install-lock/claude-sdk-platform-lock, browser smoke). Pre-commit hooks re-ran the full check on both commits.

## Risks & Residuals

- **Re-foreground semantics:** the guard swallows EIO without pausing stdin, so a process group that regains the tty foreground keeps working — verified by the stream staying resumable (no pause in the subscriber).
- **Non-EIO contract:** `EBADF`/`EPIPE` on stdin still rethrow when nothing else listens — pinned by test, so the guard cannot silently swallow unrelated stream failures.
- **Out of scope (follow-ups):** the omo launcher still dies instantly under `spawnSync` without forwarding signals to the engine (the trigger side of this crash), and `uncaughtCrash` output never reaches the debug log. Both are noted for separate PRs; this PR removes the crash they cause.
- **Windows/ConPTY:** stdin error codes on ConPTY are not covered by the classifier (EIO-only, POSIX shapes) — behavior there is unchanged.

## Related Issues

- Diagnosed from a user report of intermittent `OmO exiting due to uncaughtException: EIO: i/o error, read` at quit (errno −5, syscall read); see also upstream-style guard #3758 (gajae) which senpi had never merged.
