### PR TITLE
fix(ai): detect Kiro byte-limit rejections as context overflow

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixed
 
-- Classify Kiro (Amazon Q) byte-limit rejections as context overflow so the agent shrinks its input and retries instead of failing the session on repeated identical HTTP 400s.
+- Classify kiro-lb gateway byte/token payload-cap and enhanced upstream context-limit rejections as context overflow so the agent shrinks its input and retries instead of failing the session on HTTP 400s.
 
 ### Removed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Classify Kiro (Amazon Q) byte-limit rejections as context overflow so the agent shrinks its input and retries instead of failing the session on repeated identical HTTP 400s.
+
 ### Removed
 
 ## [2026.8.26] - 2026-08-26

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -58,7 +58,7 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 - Import blocks and option-mapping functions of every listed `packages/ai/src/api/*.ts` file, and the
   export list of `packages/ai/src/index.ts` — upstream touches these on nearly every provider change.
 
-## 2026-08-26 - Detect Kiro byte-limit rejections as context overflow
+## 2026-08-26 - Detect Kiro payload-limit/context-limit rejections as context overflow
 
 ### What changed
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -58,6 +58,24 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 - Import blocks and option-mapping functions of every listed `packages/ai/src/api/*.ts` file, and the
   export list of `packages/ai/src/index.ts` — upstream touches these on nearly every provider change.
 
+## 2026-08-26 - Detect Kiro byte-limit rejections as context overflow
+
+### What changed
+
+- `packages/ai/src/utils/overflow.ts`: Kiro (Amazon Q) byte-cap rejections (`Request payload is <n> bytes, over the <n> byte limit`) classify as context overflow, joining `request_too_large` and the gateway HTTP 413 family; the provider inventory comment gains the matching line.
+
+### Why
+
+- Kiro caps on raw request bytes and states the two sizes instead of saying "too large", so no existing pattern matched and the HTTP 400 was terminal: nothing shrank the input, the retry re-serialized to the same size, and the session died on repeated identical 400s. Observed against a `kiro-lb` gateway on `claude-opus-5` where the last accepted request billed 276,627 input tokens against a 666,667-token window, so token-threshold compaction could never fire before the ~1.09 MB byte cap.
+
+### Why an extension could not handle it
+
+- Overflow classification is a provider-neutral AI utility below extension-visible session behavior; retry policy reads the verdict before any extension sees the error.
+
+### Expected merge conflict zones
+
+- LOW: the tail of `OVERFLOW_PATTERNS` and the provider inventory comment in `packages/ai/src/utils/overflow.ts`.
+
 ## 2026-08-25 - Distinguish Cursor usage-pool exhaustion from context overflow
 
 ### What changed

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -62,11 +62,11 @@ The divergence lives in core wiring, package identity, or build plumbing that ex
 
 ### What changed
 
-- `packages/ai/src/utils/overflow.ts`: Kiro (Amazon Q) byte-cap rejections (`Request payload is <n> bytes, over the <n> byte limit`) classify as context overflow, joining `request_too_large` and the gateway HTTP 413 family; the provider inventory comment gains the matching line.
+- `packages/ai/src/utils/overflow.ts`: kiro-lb local byte/token payload-guard rejections (`Request payload is <n> bytes/tokens, over the <n> byte/token limit Kiro accepts.`) and kiro-lb's enhanced upstream context-limit response classify as context overflow.
 
 ### Why
 
-- Kiro caps on raw request bytes and states the two sizes instead of saying "too large", so no existing pattern matched and the HTTP 400 was terminal: nothing shrank the input, the retry re-serialized to the same size, and the session died on repeated identical 400s. Observed against a `kiro-lb` gateway on `claude-opus-5` where the last accepted request billed 276,627 input tokens against a 666,667-token window, so token-threshold compaction could never fire before the ~1.09 MB byte cap.
+- The local `KIRO_MAX_PAYLOAD_BYTES` guard is a gateway limit distinct from Kiro's upstream `CONTENT_LENGTH_EXCEEDS_THRESHOLD` token rejection. Both are client-visible HTTP 400 overflow paths, with route-specific wrappers (Anthropic `invalid_request_error`, OpenAI `detail`, and upstream `kiro_api_error`), so matching the emitted message lets input-shrinking recovery handle each instead of terminating the session.
 
 ### Why an extension could not handle it
 

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -27,6 +27,7 @@ import type { AssistantMessage } from "../types.ts";
  * - DS4: "Prompt has X tokens, but the configured context size is Y tokens"
  * - Cerebras: "400/413 status code (no body)"
  * - Gateways: "413 Request body too large" / "Request Entity Too Large" / "Payload Too Large" (byte-size overflow)
+ * - Kiro (Amazon Q) gateways: "Request payload is 1095225 bytes, over the 1085435 byte limit Kiro accepts" (HTTP 400 byte-size overflow, no "too large" wording)
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - z.ai: Does NOT error, accepts overflow silently - handled via usage.input > contextWindow
  * - Xiaomi MiMo: Truncates input to fill contextWindow exactly, then returns finish_reason "length"
@@ -62,6 +63,7 @@ const OVERFLOW_PATTERNS = [
 	/token limit exceeded/i, // Generic fallback
 	/^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
 	/(?:request[ _])?(?:body|entity|payload)[_ ]too[_ ]large/i, // Gateway HTTP 413 byte-size rejections ("Request body too large", "Request Entity Too Large", "body_too_large", "Payload Too Large"). Substring-anchored by design (JSON bodies lack an adjacent status code); a non-context size rejection (e.g. an oversized image) can over-match, which costs one bounded shrink-retry, never a wedge.
+	/payload is [\d,]+ bytes, over the [\d,]+ byte limit/i, // Kiro (Amazon Q) byte-size cap, surfaced as HTTP 400 invalid_request_error. Reports the two sizes instead of saying "too large", so the gateway 413 pattern above cannot match it. Same class as request_too_large: shrink the input and retry.
 ];
 
 /**

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -64,8 +64,8 @@ const OVERFLOW_PATTERNS = [
 	/token limit exceeded/i, // Generic fallback
 	/^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
 	/(?:request[ _])?(?:body|entity|payload)[_ ]too[_ ]large/i, // Gateway HTTP 413 byte-size rejections ("Request body too large", "Request Entity Too Large", "body_too_large", "Payload Too Large"). Substring-anchored by design (JSON bodies lack an adjacent status code); a non-context size rejection (e.g. an oversized image) can over-match, which costs one bounded shrink-retry, never a wedge.
-	/Request payload is \d+ (?:bytes, over the \d+ byte|tokens, over the \d+ token) limit Kiro accepts\./i, // kiro-lb local byte/token payload guard (HTTP 400; Anthropic uses invalid_request_error, OpenAI uses detail).
-	/Model context limit reached\. Conversation size exceeds model capacity\./i, // kiro-lb enhancement of Kiro CONTENT_LENGTH_EXCEEDS_THRESHOLD
+	/Request payload is \d+ (?:bytes, over the \d+ byte|tokens, over the \d+ token) limit Kiro accepts\./, // kiro-lb local byte/token payload guard (HTTP 400; Anthropic uses invalid_request_error, OpenAI uses detail).
+	/Model context limit reached\. Conversation size exceeds model capacity\./, // kiro-lb enhancement of Kiro CONTENT_LENGTH_EXCEEDS_THRESHOLD
 ];
 
 /**

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -27,7 +27,8 @@ import type { AssistantMessage } from "../types.ts";
  * - DS4: "Prompt has X tokens, but the configured context size is Y tokens"
  * - Cerebras: "400/413 status code (no body)"
  * - Gateways: "413 Request body too large" / "Request Entity Too Large" / "Payload Too Large" (byte-size overflow)
- * - Kiro (Amazon Q) gateways: "Request payload is 1095225 bytes, over the 1085435 byte limit Kiro accepts" (HTTP 400 byte-size overflow, no "too large" wording)
+ * - kiro-lb gateways: "Request payload is 1095225 bytes, over the 1085435 byte limit Kiro accepts." / "Request payload is N tokens, over the M token limit Kiro accepts." (HTTP 400 local payload guard)
+ * - Kiro upstream via kiro-lb: "Model context limit reached. Conversation size exceeds model capacity." (CONTENT_LENGTH_EXCEEDS_THRESHOLD token overflow)
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - z.ai: Does NOT error, accepts overflow silently - handled via usage.input > contextWindow
  * - Xiaomi MiMo: Truncates input to fill contextWindow exactly, then returns finish_reason "length"
@@ -63,7 +64,8 @@ const OVERFLOW_PATTERNS = [
 	/token limit exceeded/i, // Generic fallback
 	/^4(?:00|13)\s*(?:status code)?\s*\(no body\)/i, // Cerebras: 400/413 with no body
 	/(?:request[ _])?(?:body|entity|payload)[_ ]too[_ ]large/i, // Gateway HTTP 413 byte-size rejections ("Request body too large", "Request Entity Too Large", "body_too_large", "Payload Too Large"). Substring-anchored by design (JSON bodies lack an adjacent status code); a non-context size rejection (e.g. an oversized image) can over-match, which costs one bounded shrink-retry, never a wedge.
-	/payload is [\d,]+ bytes, over the [\d,]+ byte limit/i, // Kiro (Amazon Q) byte-size cap, surfaced as HTTP 400 invalid_request_error. Reports the two sizes instead of saying "too large", so the gateway 413 pattern above cannot match it. Same class as request_too_large: shrink the input and retry.
+	/Request payload is \d+ (?:bytes, over the \d+ byte|tokens, over the \d+ token) limit Kiro accepts\./i, // kiro-lb local byte/token payload guard (HTTP 400; Anthropic uses invalid_request_error, OpenAI uses detail).
+	/Model context limit reached\. Conversation size exceeds model capacity\./i, // kiro-lb enhancement of Kiro CONTENT_LENGTH_EXCEEDS_THRESHOLD
 ];
 
 /**

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -94,6 +94,26 @@ describe("isContextOverflow", () => {
 		expect(isContextOverflow(rfcStyle, 200000)).toBe(true);
 	});
 
+	it("detects Kiro byte-limit rejections as byte-size overflow", () => {
+		// Real rejection captured 2026-08-25/26 from a kiro-lb gateway fronting Kiro
+		// (Amazon Q). The cap is on raw request bytes, so a session well inside its
+		// token window still gets refused: the last accepted request billed 276,627
+		// input tokens against a 666,667-token window. Kiro reports the two sizes
+		// instead of saying "too large", so the gateway 413 pattern cannot match it
+		// and the failure surfaced as a terminal error that retried identically
+		// until the session died.
+		const kiroStyle = createErrorMessage(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"Request payload is 1095225 bytes, over the 1085435 byte limit Kiro accepts. Shorten the conversation or send fewer tools. Set AUTO_TRIM_PAYLOAD=true to drop the oldest history instead (this silently loses earlier context)."}}',
+		);
+		expect(isContextOverflow(kiroStyle, 666667)).toBe(true);
+
+		// Comma-grouped sizes must match too; the wording is stable, the formatting is not.
+		const groupedStyle = createErrorMessage(
+			"Request payload is 1,095,225 bytes, over the 1,085,435 byte limit Kiro accepts.",
+		);
+		expect(isContextOverflow(groupedStyle, 666667)).toBe(true);
+	});
+
 	it("does not treat tiny token-bearing resource_exhausted usage as context overflow", () => {
 		const message = createErrorMessage("Connect error resource_exhausted");
 		message.usage.output = 12;

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -94,24 +94,41 @@ describe("isContextOverflow", () => {
 		expect(isContextOverflow(rfcStyle, 200000)).toBe(true);
 	});
 
-	it("detects Kiro byte-limit rejections as byte-size overflow", () => {
-		// Real rejection captured 2026-08-25/26 from a kiro-lb gateway fronting Kiro
-		// (Amazon Q). The cap is on raw request bytes, so a session well inside its
-		// token window still gets refused: the last accepted request billed 276,627
-		// input tokens against a 666,667-token window. Kiro reports the two sizes
-		// instead of saying "too large", so the gateway 413 pattern cannot match it
-		// and the failure surfaced as a terminal error that retried identically
-		// until the session died.
-		const kiroStyle = createErrorMessage(
-			'400 {"type":"error","error":{"type":"invalid_request_error","message":"Request payload is 1095225 bytes, over the 1085435 byte limit Kiro accepts. Shorten the conversation or send fewer tools. Set AUTO_TRIM_PAYLOAD=true to drop the oldest history instead (this silently loses earlier context)."}}',
+	it("detects kiro-lb local payload guards across both route wrappers and units", () => {
+		const anthropicBytes = createErrorMessage(
+			'400 {"type":"error","error":{"type":"invalid_request_error","message":"Request payload is 1095225 bytes, over the 1085435 byte limit Kiro accepts. Shorten the conversation or send fewer tools."}}',
 		);
-		expect(isContextOverflow(kiroStyle, 666667)).toBe(true);
+		const openAiTokens = createErrorMessage(
+			'400 {"detail":"Request payload is 800001 tokens, over the 800000 token limit Kiro accepts."}',
+		);
+		expect(isContextOverflow(anthropicBytes, 666667)).toBe(true);
+		expect(isContextOverflow(openAiTokens, 666667)).toBe(true);
+	});
 
-		// Comma-grouped sizes must match too; the wording is stable, the formatting is not.
-		const groupedStyle = createErrorMessage(
-			"Request payload is 1,095,225 bytes, over the 1,085,435 byte limit Kiro accepts.",
+	it("detects Kiro upstream context overflow enhanced by kiro-lb", () => {
+		const upstream = createErrorMessage(
+			'400 {"error":{"type":"kiro_api_error","message":"Model context limit reached. Conversation size exceeds model capacity."}}',
 		);
-		expect(isContextOverflow(groupedStyle, 666667)).toBe(true);
+		expect(isContextOverflow(upstream, 666667)).toBe(true);
+	});
+
+	it("rejects malformed or unrelated Kiro-like payload-size prose", () => {
+		expect(
+			isContextOverflow(
+				createErrorMessage("Request payload is 1,,225 bytes, over the 1,085 byte limit Kiro accepts."),
+			),
+		).toBe(false);
+		expect(
+			isContextOverflow(
+				createErrorMessage("Request payload is 1,225 bytes, over the 1,085 byte limit Kiro accepts."),
+			),
+		).toBe(false);
+		expect(
+			isContextOverflow(
+				createErrorMessage("Payload 1095225 bytes exceeds the 1085435 byte limit; AUTO_TRIM_PAYLOAD is disabled"),
+			),
+		).toBe(false);
+		expect(isContextOverflow(createErrorMessage("Another provider reports payload size exceeded."))).toBe(false);
 	});
 
 	it("does not treat tiny token-bearing resource_exhausted usage as context overflow", () => {


### PR DESCRIPTION
# Detect kiro-lb payload-limit rejections as context overflow

## Problem

kiro-lb has a legacy local payload guard that can reject HTTP 400 requests with:

```
Request payload is 1095225 bytes, over the 1085435 byte limit Kiro accepts.
```

It can also emit the same form with `tokens` rather than `bytes`. These local guard
messages are distinct from Kiro's upstream `CONTENT_LENGTH_EXCEEDS_THRESHOLD` response,
which kiro-lb enhances to:

```
Model context limit reached. Conversation size exceeds model capacity.
```

The overflow classifier did not match these client-visible messages, so input shrinking
could not recover the request.

## Change

`OVERFLOW_PATTERNS` now matches the exact ungrouped integer forms emitted by kiro-lb for
both local byte and token guards, including the terminal period and `Kiro accepts` suffix,
and the enhanced upstream context-limit message. The pattern is wrapper-neutral because
the message appears in route-specific shapes: Anthropic uses nested `invalid_request_error`,
OpenAI uses FastAPI `detail`, and the upstream error uses `kiro_api_error`.

## Test

`packages/ai/test/overflow.test.ts` covers both units, Anthropic and OpenAI wrappers, the
enhanced upstream response, malformed comma grouping, unrelated prose, and the log-only
`Payload N bytes exceeds ... AUTO_TRIM_PAYLOAD is disabled` message.

Run the focused test from the repository root with:

```
npm --prefix packages/ai test -- test/overflow.test.ts
```

The command passes from the repository root and reports all 28 focused tests passing.
