### PR TITLE
fix(coding-agent): advance model fallback after failed required compaction and report hard-error chain exhaustion

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Cursor quota and eligible hard-error fallback now advances after required pre-retry compaction is rejected instead of stalling the turn; ordinary transient retry compaction blocking is unchanged.
+- Hard-error fallback exhaustion now emits `retry_fallback_exhausted` when the configured chain has no usable candidate.
 - A goal continuation whose backstop timer fired after the session was replaced or reloaded no longer crashes the session with "This extension ctx is stale after session replacement or reload". The timer callback (and its own error handler) now treats a retired context as "no UI" instead of letting the stale-context error escape as an uncaught exception; unrelated delivery failures are still reported.
 - Idle warm compaction now applies as soon as its summary finishes generating while the session is idle, so the `[compaction]` block renders during the idle gap and the next message stacks below it instead of the prompt waiting behind a compaction that was generated minutes earlier; stale or racy applies keep the previous warm-hold behavior.
 - The canonical user message no longer renders above the `[compaction]` block when a compaction applies during prompt admission: the pending-echo reconciliation now appends it after the rebuilt transcript, matching the session's canonical order.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Cursor quota and eligible hard-error fallback now advances after required pre-retry compaction is rejected instead of stalling the turn; ordinary transient retry compaction blocking is unchanged.
 - A goal continuation whose backstop timer fired after the session was replaced or reloaded no longer crashes the session with "This extension ctx is stale after session replacement or reload". The timer callback (and its own error handler) now treats a retired context as "no UI" instead of letting the stale-context error escape as an uncaught exception; unrelated delivery failures are still reported.
 - Idle warm compaction now applies as soon as its summary finishes generating while the session is idle, so the `[compaction]` block renders during the idle gap and the next message stacks below it instead of the prompt waiting behind a compaction that was generated minutes earlier; stale or racy applies keep the previous warm-hold behavior.
 - The canonical user message no longer renders above the `[compaction]` block when a compaction applies during prompt admission: the pending-echo reconciliation now appends it after the rebuilt transcript, matching the session's canonical order.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2157,7 +2157,11 @@ export class AgentSession {
 			) {
 				this._retireFailedRetryAssistant(msg);
 				compactedBeforeRetry = await this._runPrePromptCompaction(msg, true, requiredAutoCompaction, true);
-				retryContinuationBlocked = !compactedBeforeRetry && !this._isCompactionDelegated();
+				retryContinuationBlocked =
+					!compactedBeforeRetry &&
+					!this._isCompactionDelegated() &&
+					!cursorQuotaRe &&
+					!hardErrorFallbackEligible;
 			}
 
 			let retryOutcome: "continued" | "blocked" | "not-handled" | "cancelled" = "not-handled";
@@ -7094,14 +7098,6 @@ export class AgentSession {
 			}
 			switchedFallback = await this._retryFallback.tryFallback("refusal", {});
 			if (!switchedFallback) {
-				const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
-				if (exhaustedChainKey) {
-					this._emit({
-						type: "retry_fallback_exhausted",
-						chainKey: exhaustedChainKey,
-						lastError: errorMessage,
-					});
-				}
 				if (this._retryAttempt > 0) {
 					this._emit({
 						type: "auto_retry_end",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7074,6 +7074,14 @@ export class AgentSession {
 				errorMessage,
 			});
 			if (!switchedFallback) {
+				const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+				if (exhaustedChainKey) {
+					this._emit({
+						type: "retry_fallback_exhausted",
+						chainKey: exhaustedChainKey,
+						lastError: errorMessage,
+					});
+				}
 				this._resolveRetry();
 				return "not-handled";
 			}
@@ -7098,6 +7106,14 @@ export class AgentSession {
 			}
 			switchedFallback = await this._retryFallback.tryFallback("refusal", {});
 			if (!switchedFallback) {
+				const exhaustedChainKey = this._retryFallback.exhaustedChainKey;
+				if (exhaustedChainKey) {
+					this._emit({
+						type: "retry_fallback_exhausted",
+						chainKey: exhaustedChainKey,
+						lastError: errorMessage,
+					});
+				}
 				if (this._retryAttempt > 0) {
 					this._emit({
 						type: "auto_retry_end",

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2158,10 +2158,7 @@ export class AgentSession {
 				this._retireFailedRetryAssistant(msg);
 				compactedBeforeRetry = await this._runPrePromptCompaction(msg, true, requiredAutoCompaction, true);
 				retryContinuationBlocked =
-					!compactedBeforeRetry &&
-					!this._isCompactionDelegated() &&
-					!cursorQuotaRe &&
-					!hardErrorFallbackEligible;
+					!compactedBeforeRetry && !this._isCompactionDelegated() && !cursorQuotaRe && !hardErrorFallbackEligible;
 			}
 
 			let retryOutcome: "continued" | "blocked" | "not-handled" | "cancelled" = "not-handled";

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,11 @@
 # changes
 
+## 2026-08-26 - Continue provider fallback after failed required compaction
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: Cursor quota and eligible hard-error failures now advance the provider fallback chain when required pre-retry compaction is rejected, while ordinary transient retries remain compaction-blocked.
+
 ## 2026-08-26 - Reject no-progress manual compaction before active abort
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -5,6 +5,7 @@
 ### What changed
 
 - `packages/coding-agent/src/core/agent-session.ts`: Cursor quota and eligible hard-error failures now advance the provider fallback chain when required pre-retry compaction is rejected, while ordinary transient retries remain compaction-blocked.
+- `packages/coding-agent/src/core/agent-session.ts`: Hard-error fallback exhaustion now emits `retry_fallback_exhausted` when the fallback chain is spent.
 
 ## 2026-08-26 - Reject no-progress manual compaction before active abort
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -4,8 +4,33 @@
 
 ### What changed
 
-- `packages/coding-agent/src/core/agent-session.ts`: Cursor quota and eligible hard-error failures now advance the provider fallback chain when required pre-retry compaction is rejected, while ordinary transient retries remain compaction-blocked.
-- `packages/coding-agent/src/core/agent-session.ts`: Hard-error fallback exhaustion now emits `retry_fallback_exhausted` when the fallback chain is spent.
+- `packages/coding-agent/src/core/agent-session.ts`: Cursor token-bearing quota `resource_exhausted`
+  and eligible hard-error failures now advance the provider fallback chain when required pre-retry
+  compaction is rejected (`retryContinuationBlocked` no longer covers those two classes). Ordinary
+  transient retries remain compaction-blocked, and zero-token Cursor `resource_exhausted` keeps its
+  compact-before-rotate contract.
+- `packages/coding-agent/src/core/agent-session.ts`: the hard-error fallback not-switched path now
+  emits `retry_fallback_exhausted` when the configured chain has no usable candidate, mirroring the
+  refusal path.
+
+### Why
+
+- Cursor usage-pool exhaustion surfaces as `resource_exhausted` that also demands required
+  compaction; the compaction generator runs on the same dead lane and always fails, so the old
+  blocking wedged the turn ("Compaction rejected: compaction generator failed" then "Retry failed
+  after 1 attempts") and the fallback chain never advanced to the next provider.
+- The silent not-switched path gave the TUI no signal about why no fallback hop happened.
+
+### Why an extension could not handle it
+
+- `retryContinuationBlocked`, required-compaction admission, and fallback dispatch ordering are
+  private `AgentSession` agent_end lifecycle state; extensions observe compaction and fallback
+  events only after the core has already made the dispatch decision.
+
+### Expected merge conflict zones
+
+- MEDIUM: `packages/coding-agent/src/core/agent-session.ts` agent_end retry/compaction dispatch
+  block and the `_handleRetryableError` hard-error branch.
 
 ## 2026-08-26 - Reject no-progress manual compaction before active abort
 

--- a/packages/coding-agent/test/suite/regressions/cursor-quota-re-fallback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/cursor-quota-re-fallback.test.ts
@@ -1,6 +1,6 @@
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
-import compactionExtension from "../../../src/core/extensions/builtin/compaction/index.ts";
 import { afterEach, describe, expect, it } from "vitest";
+import compactionExtension from "../../../src/core/extensions/builtin/compaction/index.ts";
 import type { CompactionReason } from "../../../src/core/extensions/types.ts";
 import { createHarness, type Harness } from "../harness.ts";
 
@@ -39,11 +39,11 @@ describe("Cursor token-bearing resource_exhausted quota fallback", () => {
 				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [PRIMARY]: [FALLBACK] } },
 			},
 			extensionFactories: [
-			compactionExtension,
-			(pi) => {
-				pi.on("session_before_compact", () => ({ cancel: true }));
-			},
-		],
+				compactionExtension,
+				(pi) => {
+					pi.on("session_before_compact", () => ({ cancel: true }));
+				},
+			],
 		});
 		harnesses.push(harness);
 		const originalStream = harness.agent.streamFunction;

--- a/packages/coding-agent/test/suite/regressions/cursor-quota-re-fallback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/cursor-quota-re-fallback.test.ts
@@ -1,4 +1,5 @@
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import compactionExtension from "../../../src/core/extensions/builtin/compaction/index.ts";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CompactionReason } from "../../../src/core/extensions/types.ts";
 import { createHarness, type Harness } from "../harness.ts";
@@ -6,15 +7,15 @@ import { createHarness, type Harness } from "../harness.ts";
 const PRIMARY = "cursor/composer";
 const FALLBACK = "cursor/k3";
 
-function quotaError(): ReturnType<typeof fauxAssistantMessage> {
+function quotaError(input = 178_626): ReturnType<typeof fauxAssistantMessage> {
 	const message = fauxAssistantMessage(fauxToolCall("partial_tool", {}), {
 		stopReason: "error",
 		errorMessage: "Connect error resource_exhausted: Error",
 	});
 	message.usage = {
 		...message.usage,
-		input: 178_626,
-		totalTokens: 178_626,
+		input,
+		totalTokens: input,
 	};
 	return message;
 }
@@ -24,6 +25,54 @@ describe("Cursor token-bearing resource_exhausted quota fallback", () => {
 
 	afterEach(() => {
 		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("falls back after required compaction fails and continues on the next model", async () => {
+		const harness = await createHarness({
+			provider: "cursor",
+			models: [
+				{ id: "composer", contextWindow: 200_000, maxTokens: 16_384 },
+				{ id: "k3", contextWindow: 200_000, maxTokens: 16_384 },
+			],
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 16_384 },
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [PRIMARY]: [FALLBACK] } },
+			},
+			extensionFactories: [
+			compactionExtension,
+			(pi) => {
+				pi.on("session_before_compact", () => ({ cancel: true }));
+			},
+		],
+		});
+		harnesses.push(harness);
+		const originalStream = harness.agent.streamFunction;
+		let firstProviderCall = true;
+		harness.agent.streamFunction = async (...args) => {
+			if (firstProviderCall) {
+				firstProviderCall = false;
+				harness.sessionManager.appendMessage({
+					role: "user",
+					content: [{ type: "text", text: "large prior context ".repeat(45_000) }],
+					timestamp: Date.now() - 2_000,
+				});
+				harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+			}
+			return originalStream(...args);
+		};
+		harness.setResponses([
+			quotaError(50_000),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "compaction generator failed" }),
+			fauxAssistantMessage("continued after compaction failure"),
+		]);
+
+		await harness.session.prompt("continue");
+
+		expect(harness.eventsOfType("compaction_end")).toMatchObject([
+			{ accepted: false, rejectionCause: "cancelled-by-extension", willRetry: false },
+		]);
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["composer", "k3"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([{ to: FALLBACK, reason: "hard-error" }]);
 	});
 
 	it("falls back without compaction and continues the turn", async () => {

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -93,7 +93,10 @@ describe("retry fallback hard errors", () => {
 		harnesses.push(harness);
 		const internals = harness.session as unknown as {
 			_retryFallback: { exhaustedChainKey: string; tryFallback: () => Promise<boolean> };
-			_handleRetryableError: (message: ReturnType<typeof fauxAssistantMessage>, options: { hardErrorFallback: boolean }) => Promise<string>;
+			_handleRetryableError: (
+				message: ReturnType<typeof fauxAssistantMessage>,
+				options: { hardErrorFallback: boolean },
+			) => Promise<string>;
 		};
 		Object.defineProperty(internals._retryFallback, "exhaustedChainKey", { value: primary, configurable: true });
 		internals._retryFallback.tryFallback = async () => false;

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -86,6 +86,26 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("auto_retry_end").filter((event) => event.success)).toEqual([]);
 	});
 
+	it("emits fallback exhaustion when a hard-error chain has no next candidate", async () => {
+		const harness = await createHarness({
+			settings: { retry: { enabled: true, baseDelayMs: 1 } },
+		});
+		harnesses.push(harness);
+		const internals = harness.session as unknown as {
+			_retryFallback: { exhaustedChainKey: string; tryFallback: () => Promise<boolean> };
+			_handleRetryableError: (message: ReturnType<typeof fauxAssistantMessage>, options: { hardErrorFallback: boolean }) => Promise<string>;
+		};
+		Object.defineProperty(internals._retryFallback, "exhaustedChainKey", { value: primary, configurable: true });
+		internals._retryFallback.tryFallback = async () => false;
+
+		await internals._handleRetryableError(
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: insufficientQuota }),
+			{ hardErrorFallback: true },
+		);
+
+		expect(harness.eventsOfType("retry_fallback_exhausted")).toMatchObject([{ chainKey: primary }]);
+	});
+
 	it("settles an insufficient-quota error without a configured fallback", async () => {
 		const harness = await createHarness({ settings: { retry: { enabled: true, baseDelayMs: 1 } } });
 		harnesses.push(harness);


### PR DESCRIPTION
## Summary

When a provider lane dies with `resource_exhausted` (the live trigger: Cursor's usage-pool exhaustion), the session could get permanently wedged instead of advancing the model-fallback chain: the error demands compaction-before-retry, the compaction generator runs on the same dead lane and fails, and the failed compaction then blocked the entire fallback dispatch. The turn died with `Compaction rejected: compaction generator failed: Connect error resource_exhausted` + `Retry failed after 1 attempts`, and the chain never hopped. Separately, when a hard-error fallback found no usable candidate, the session returned silently without emitting `retry_fallback_exhausted`, so the TUI never explained why no hop happened.

This PR makes a failed required pre-retry compaction fall through to provider-fallback dispatch for fallback-eligible errors (Cursor token-bearing quota RE and eligible hard errors), and emits `retry_fallback_exhausted` on the hard-error not-switched path.

## Changes

- **Fallback after failed required compaction** (`agent-session.ts` `_processAgentEvent`): `retryContinuationBlocked` no longer blocks the dispatch block when the failing error is `cursorQuotaRe` or `hardErrorFallbackEligible`. Ordinary transient retryable errors keep the existing compaction-blocking behavior, and zero-token Cursor RE keeps its #1009/#1015 compact-before-rotate contract (compaction still gets first refusal; same-model remint stays the first remedy).
- **Hard-error chain exhaustion event** (`agent-session.ts` `_handleRetryableError`): the `hardErrorFallback` not-switched path now emits `retry_fallback_exhausted` (guarded by `exhaustedChainKey`), mirroring the refusal path.
- Changelog entries in `packages/coding-agent/CHANGELOG.md` ([Unreleased]) and `packages/coding-agent/src/core/changes.md`.

## QA & Evidence

- **What was tested:** New regression test `falls back after required compaction fails and continues on the next model` (`test/suite/regressions/cursor-quota-re-fallback.test.ts`) — quota RE + extension-cancelled compaction must still hop `composer -> k3`.
  - **Observed:** RED at base (call log `["composer"]`, no hop), GREEN after fix (`["composer","k3"]` + `retry_fallback_applied` reason `hard-error`).
- **What was tested:** New test `emits fallback exhaustion when a hard-error chain has no next candidate` (`test/suite/retry-fallback-hard-error.test.ts`).
  - **Observed:** RED at base (no `retry_fallback_exhausted` event), GREEN after fix.
- **Manual QA on the real CLI surface:** headless `pi-test.sh -p` against two local mock OpenAI-compatible providers — a dead primary lane (streams ~900 tokens of usage then mid-stream `resource_exhausted`, including for the compaction summarization request) and a healthy fallback lane, with `fallbackChains: {"mock-primary/wedge-model": ["mock-fallback/rescue-model"]}`.
  - **Before (base 6a7c6ed3a, deterministic 3/3):** `compaction_end accepted:false ("compaction generator failed: ... resource_exhausted")`, zero retry/fallback events, 0 requests to the healthy lane; terminal error carries the quota-RE fingerprint suffix. A control run with compaction disabled hops fine — isolating the wedge to the compact-before-retry interaction.
  - **After (this branch):** same scenario produces `retry_fallback_applied {to: mock-fallback/rescue-model, reason: hard-error}` -> `retry_fallback_succeeded` -> turn completes with `stopReason: stop` and exactly 1 healthy-lane completion request.
- **Suites:** `vitest run` (repo runner) on `retry-fallback-*.test.ts` + the touched regression files: all pass, including the #1009 zero-token compact-before-rotate pair. `bun run build` exit 0.

## Risks & Residuals

- Behavior change is scoped to two error classes that previously dead-ended: quota-RE and eligible hard errors after a failed required compaction. Transient-retry compaction blocking and zero-token RE semantics are regression-tested unchanged (`1009-cursor-payload-re-compaction.test.ts`, existing quota/zero-token suites).
- The compaction generator itself still has no fallback lane (out of scope here); with this fix its failure no longer wedges the turn.
