### PR TITLE
fix(config-reload): allow safe filtered ancestor targets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Idle warm compaction now applies as soon as its summary finishes generating while the session is idle, so the `[compaction]` block renders during the idle gap and the next message stacks below it instead of the prompt waiting behind a compaction that was generated minutes earlier; stale or racy applies keep the previous warm-hold behavior.
 - The canonical user message no longer renders above the `[compaction]` block when a compaction applies during prompt admission: the pending-echo reconciliation now appends it after the rebuilt transcript, matching the session's canonical order.
 - An uncaught dead-terminal error (e.g. a stdin read EIO after the controlling terminal detached) no longer prints the `exiting due to uncaughtException` banner and exits 1: `uncaughtCrash` routes it to the silent `emergencyTerminalExit()`, matching terminal write errors. `isDeadTerminalError` now also accepts Bun's raw `errno: 5`/`-5` shape.
+- config-reload no longer rejects a directory watch target that covers the agent directory when every filter glob is root-anchored and none of the anchored paths intersects a protected path (`auth.json`, `sessions/`, `logs/`) in either direction. With the default `~/.omo/agent` layout this lets the omo extension's `~/.omo` user-config watch register instead of failing with "Configuration watch target is restricted" (code-yeongyu/oh-my-openagent#7064). Unfiltered targets, unanchored filters, and filters resolving into or onto a protected path stay rejected.
 ### Added
 
 ### Changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -149,6 +149,24 @@
 
 - LOW: `index.ts` `registrationHasRestrictedTarget` and the new `isSafeFilteredAgentDirTarget`; LOW in `config-reload-extension.test.ts`.
 
+## Accept filtered ancestor config-watch targets safely (2026-08-26)
+
+### What changed
+
+- Generalized the protected-path registration guard so directory targets covering the agent directory are accepted when every filter glob is root-anchored and each resolved path stays outside protected paths in both directions. Targets inside protected paths, unfiltered targets, unanchored filters, and filters naming protected paths remain rejected.
+
+### Why
+
+- Issue code-yeongyu/oh-my-openagent#7064: the default `~/.omo/agent` layout made the omo extension's user-config watch target at `~/.omo` rejected, even though its anchored `/omo.jsonc` and `/omo.json` filters are confined to safe files.
+
+### Why an extension could not handle it
+
+- The protected-target guard runs inside this builtin during registration intake, before an external extension's filtered watch can be stored or watched.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` protected-target filtering and `config-reload-extension.test.ts` restricted-registration coverage.
+
 ## Off-main-thread recursive watchers on macOS and non-blocking teardown (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -890,25 +890,26 @@ function registrationFingerprint(registration: ConfigWatchRegistration): string 
 	});
 }
 
-function isProtectedAgentPath(candidate: string, agentDir: string): boolean {
-	const authPath = resolve(agentDir, "auth.json");
-	const sessionsPath = resolve(agentDir, "sessions");
-	const logsPath = resolve(agentDir, "logs");
-	return isWithin(candidate, authPath) || isWithin(candidate, sessionsPath) || isWithin(candidate, logsPath);
-}
-
-// A watch rooted exactly at the agent directory is safe when every filter is
-// root-anchored (a leading `/` matches only an immediate child of the watch root,
-// never a nested path) and none of those anchored names resolves into a protected
-// path. Unfiltered targets, unanchored filters, and any protected filter stay
-// fail-closed.
-function isSafeFilteredAgentDirTarget(target: ConfigWatchTarget, resolvedPath: string, agentDir: string): boolean {
-	if (target.kind !== "dir" || resolvedPath !== resolve(agentDir)) return false;
+// A directory target that covers a protected path is safe when every filter is
+// root-anchored (a leading `/` matches only a path relative to the watch root,
+// never a suffix at any depth) and none of those anchored paths intersects a
+// protected path in either direction. Unfiltered targets, unanchored filters,
+// and any protected filter stay fail-closed.
+function isSafeFilteredProtectedTarget(
+	target: ConfigWatchTarget,
+	resolvedPath: string,
+	protectedPaths: readonly string[],
+): boolean {
+	if (target.kind !== "dir") return false;
+	if (protectedPaths.some((protectedPath) => isWithin(resolvedPath, protectedPath))) return false;
 	const filterGlobs = target.filterGlobs;
 	if (!filterGlobs || filterGlobs.length === 0) return false;
 	return filterGlobs.every((glob) => {
 		if (!glob.startsWith("/")) return false;
-		return !isProtectedAgentPath(resolve(resolvedPath, glob.slice(1)), agentDir);
+		const filteredPath = resolve(resolvedPath, glob.slice(1));
+		return protectedPaths.every(
+			(protectedPath) => !isWithin(filteredPath, protectedPath) && !isWithin(protectedPath, filteredPath),
+		);
 	});
 }
 
@@ -917,18 +918,11 @@ function registrationHasRestrictedTarget(
 	cwd: string,
 	agentDir: string,
 ): boolean {
-	const authPath = resolve(agentDir, "auth.json");
-	const sessionsPath = resolve(agentDir, "sessions");
-	const logsPath = resolve(agentDir, "logs");
+	const protectedPaths = [resolve(agentDir, "auth.json"), resolve(agentDir, "sessions"), resolve(agentDir, "logs")];
 	return registration.targets.some((target) => {
 		const path = resolvePath(target.path, cwd, { trim: true });
-		if (isSafeFilteredAgentDirTarget(target, path, agentDir)) return false;
-		return (
-			isWithin(path, authPath) ||
-			isWithin(authPath, path) ||
-			isWithin(path, sessionsPath) ||
-			isWithin(path, logsPath)
-		);
+		if (isSafeFilteredProtectedTarget(target, path, protectedPaths)) return false;
+		return protectedPaths.some((protectedPath) => isWithin(path, protectedPath) || isWithin(protectedPath, path));
 	});
 }
 

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { EventBus } from "../../src/core/event-bus.ts";
@@ -717,6 +717,89 @@ describe("config reload builtin extension", () => {
 		});
 		expect(watches.subscribeCalls).not.toContain(restrictedDir);
 		expect(watches.activeListenerCount(restrictedDir)).toBe(0);
+	});
+
+	it("accepts a filtered ancestor watch whose anchored filters stay outside protected paths", async () => {
+		const fixture = await createFixture();
+		const ancestorDir = resolve(fixture.agentDir, "..");
+		const rejected: unknown[] = [];
+		fixture.events.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo-ancestor",
+			displayName: "Ancestor .omo config",
+			targets: [{ path: ancestorDir, kind: "dir" as const, filterGlobs: ["/omo.jsonc", "/omo.json"] }],
+		});
+
+		expect(rejected).toHaveLength(0);
+		expect(fixture.watches.activeListenerCount(ancestorDir)).toBe(1);
+	});
+
+	it("rejects an ancestor watch with an unanchored filter", async () => {
+		const fixture = await createFixture();
+		const ancestorDir = join(fixture.agentDir, "..");
+		const rejected: unknown[] = [];
+		fixture.events.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo-ancestor-unanchored",
+			displayName: "Ancestor .omo config",
+			targets: [{ path: ancestorDir, kind: "dir" as const, filterGlobs: ["omo.jsonc"] }],
+		});
+
+		expect(rejected).toHaveLength(1);
+		expect(fixture.watches.activeListenerCount(ancestorDir)).toBe(0);
+	});
+
+	it("rejects an ancestor watch whose anchored filter enters a protected path", async () => {
+		const fixture = await createFixture();
+		const ancestorDir = join(fixture.agentDir, "..");
+		const rejected: unknown[] = [];
+		fixture.events.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo-ancestor-auth",
+			displayName: "Ancestor .omo config",
+			targets: [
+				{
+					path: ancestorDir,
+					kind: "dir" as const,
+					filterGlobs: [`/${basename(fixture.agentDir)}/auth.json`],
+				},
+			],
+		});
+
+		expect(rejected).toHaveLength(1);
+	});
+
+	it("rejects an ancestor watch whose anchored filter names a protected directory", async () => {
+		const fixture = await createFixture();
+		const ancestorDir = join(fixture.agentDir, "..");
+		const rejected: unknown[] = [];
+		fixture.events.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo-ancestor-agent",
+			displayName: "Ancestor .omo config",
+			targets: [{ path: ancestorDir, kind: "dir" as const, filterGlobs: [`/${basename(fixture.agentDir)}`] }],
+		});
+
+		expect(rejected).toHaveLength(1);
+	});
+
+	it("rejects a target inside a protected path even with anchored filters", async () => {
+		const fixture = await createFixture();
+		const restrictedDir = join(fixture.agentDir, "sessions", "foo");
+		const rejected: unknown[] = [];
+		fixture.events.on(CONFIG_WATCH_REJECTED, (payload) => rejected.push(payload));
+
+		fixture.events.emit(CONFIG_WATCH_REGISTER, {
+			id: "omo-inside-sessions",
+			displayName: "Nested .omo config",
+			targets: [{ path: restrictedDir, kind: "dir" as const, filterGlobs: ["/omo.json"] }],
+		});
+
+		expect(rejected).toHaveLength(1);
 	});
 
 	it("accepts an agent-dir watch whose filters are all root-anchored and non-protected", async () => {


### PR DESCRIPTION
# Accept safely filtered ancestor config-watch targets

## Problem

`registrationHasRestrictedTarget` rejects any watch target that lexically covers a protected agent path (`auth.json`, `sessions/`, `logs/`), with a safe-filter exception only for a target rooted **exactly at the agent directory**.

On a default omo install the agent directory is `~/.omo/agent`, nested inside the user-config directory `~/.omo`. The omo extension's user-config target (`~/.omo` with `filterGlobs: ["/omo.jsonc", "/omo.json"]`) is therefore rejected even though a root-anchored glob is an exact relative-path match (`matchesConfigWatchFilter`) that can only ever surface `~/.omo/omo.jsonc` / `~/.omo/omo.json` — never anything under `~/.omo/agent/`.

Downstream this is code-yeongyu/oh-my-openagent#7064: every session logs `config-watch user config discovery requires reload`, user-scope config is never hot-reloaded, and with `cwd == $HOME` the omo extension registers zero targets.

## Change

`isSafeFilteredAgentDirTarget` is generalized to `isSafeFilteredProtectedTarget`: a `dir` target that covers a protected path is accepted when

- the target path itself is not inside a protected path, and
- `filterGlobs` is non-empty, every glob is root-anchored (leading `/`), and
- every resolved glob path intersects no protected path **in either direction** (neither inside a protected path nor containing one).

Unfiltered targets, unanchored filters, and protected-resolving filters stay fail-closed rejected. The both-directions check also closes a latent hole in the old agent-dir exception, which only tested the glob path being *inside* a protected path (e.g. an anchored `/` glob resolving onto the agent dir itself was previously accepted).

## Test

`test/suite/config-reload-extension.test.ts` adds five cases: the ancestor target with anchored `/omo.jsonc` + `/omo.json` globs is accepted (fails on the previous implementation), and rejection is pinned for an unanchored filter, an anchored filter entering `auth.json`, an anchored filter naming the agent directory, and a target nested inside `sessions/`.

Run the focused suite from `packages/coding-agent`:

```
npx vitest --run test/config-reload-*.test.ts test/suite/config-reload-extension.test.ts
```

5 files, 100 tests green. `config-reload/changes.md` carries the canonical changelog entry.
