### PR TITLE
test: isolate shared /tmp state and unrestored env in the suites

### DIFF
--- a/packages/ai/test/openai-completions-empty-tools.test.ts
+++ b/packages/ai/test/openai-completions-empty-tools.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getModel, streamSimple } from "../src/compat.ts";
 
 // Empty tools arrays must NOT be serialized as `tools: []` — some OpenAI-compatible
@@ -57,6 +57,10 @@ describe("openai-completions empty tools handling", () => {
 	beforeEach(() => {
 		mockState.lastParams = undefined;
 		mockState.lastClientOptions = undefined;
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
 	});
 
 	it("omits tools field when context.tools is an empty array", async () => {
@@ -161,9 +165,9 @@ describe("openai-completions empty tools handling", () => {
 	});
 
 	it("uses conservative OpenAI-compatible fields for Cloudflare AI Gateway /compat models", async () => {
-		process.env.CLOUDFLARE_API_KEY = "cf-token";
-		process.env.CLOUDFLARE_ACCOUNT_ID = "account-id";
-		process.env.CLOUDFLARE_GATEWAY_ID = "gateway-id";
+		vi.stubEnv("CLOUDFLARE_API_KEY", "cf-token");
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id");
+		vi.stubEnv("CLOUDFLARE_GATEWAY_ID", "gateway-id");
 		const model = getModel("cloudflare-ai-gateway", "workers-ai/@cf/moonshotai/kimi-k2.6")!;
 
 		await streamSimple(
@@ -198,9 +202,9 @@ describe("openai-completions empty tools handling", () => {
 	});
 
 	it("resolves Cloudflare AI Gateway base URL through provider auth", async () => {
-		process.env.CLOUDFLARE_API_KEY = "cf-token";
-		process.env.CLOUDFLARE_ACCOUNT_ID = "account-id";
-		process.env.CLOUDFLARE_GATEWAY_ID = "gateway-id";
+		vi.stubEnv("CLOUDFLARE_API_KEY", "cf-token");
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id");
+		vi.stubEnv("CLOUDFLARE_GATEWAY_ID", "gateway-id");
 		const model = getModel("cloudflare-ai-gateway", "workers-ai/@cf/moonshotai/kimi-k2.6")!;
 
 		await streamSimple(model, {
@@ -212,9 +216,9 @@ describe("openai-completions empty tools handling", () => {
 	});
 
 	it("preserves inline upstream Authorization for Cloudflare AI Gateway BYOK requests", async () => {
-		process.env.CLOUDFLARE_API_KEY = "cf-token";
-		process.env.CLOUDFLARE_ACCOUNT_ID = "account-id";
-		process.env.CLOUDFLARE_GATEWAY_ID = "gateway-id";
+		vi.stubEnv("CLOUDFLARE_API_KEY", "cf-token");
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id");
+		vi.stubEnv("CLOUDFLARE_GATEWAY_ID", "gateway-id");
 		const model = getModel("cloudflare-ai-gateway", "gpt-5.1")!;
 
 		await streamSimple(
@@ -231,9 +235,9 @@ describe("openai-completions empty tools handling", () => {
 	});
 
 	it("sends session affinity headers for Workers AI through Cloudflare AI Gateway", async () => {
-		process.env.CLOUDFLARE_API_KEY = "cf-token";
-		process.env.CLOUDFLARE_ACCOUNT_ID = "account-id";
-		process.env.CLOUDFLARE_GATEWAY_ID = "gateway-id";
+		vi.stubEnv("CLOUDFLARE_API_KEY", "cf-token");
+		vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "account-id");
+		vi.stubEnv("CLOUDFLARE_GATEWAY_ID", "gateway-id");
 		const workersModel = getModel("cloudflare-ai-gateway", "workers-ai/@cf/moonshotai/kimi-k2.6")!;
 
 		await streamSimple(

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "./support/temp-agent-dir.ts";
 
 const { completeMock } = vi.hoisted(() => ({
 	completeMock: vi.fn(),
@@ -68,6 +69,8 @@ import {
 	type SessionMessageEntry,
 	type ThinkingLevelChangeEntry,
 } from "../src/core/session-manager.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 // ============================================================================
 // Test fixtures
@@ -267,7 +270,7 @@ function createExtensionContext(overrides: Partial<ExtensionContext>): Extension
 		mode: "print",
 		ui: {} as ExtensionContext["ui"],
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		isProjectTrusted: () => true,
 		sessionManager: Object.assign(Object.create(null), {
 			getEntries: () => [],

--- a/packages/coding-agent/test/compaction/compaction-decision-log.test.ts
+++ b/packages/coding-agent/test/compaction/compaction-decision-log.test.ts
@@ -4,6 +4,9 @@ import {
 	type CompactionLoggerEvent,
 	createCompactionLogger,
 } from "../../src/core/extensions/builtin/compaction/log.ts";
+import { createTempAgentDir } from "../support/temp-agent-dir.ts";
+
+const LOG_DIR = createTempAgentDir("senpi-compaction-decision-log-");
 
 const EVENTS = [
 	"speculative_started",
@@ -68,7 +71,7 @@ describe("compaction decision log", () => {
 		["summary_failed", { origin: "speculative", requestId: "req-14", reason: "transient", durationMs: 77 }],
 	] as const)("Given %s When logging Then it emits allowlisted fields only", (event, data) => {
 		const sink: string[] = [];
-		const logger = createCompactionLogger("/tmp/senpi-compaction-decision-log", {
+		const logger = createCompactionLogger(LOG_DIR, {
 			sink: (line) => sink.push(line),
 			mirrorToStderr: false,
 		});
@@ -109,7 +112,7 @@ describe("compaction decision log", () => {
 
 	it("Given injected sink When logging Then it preserves the allowlisted payload", () => {
 		const sink: string[] = [];
-		const logger = createCompactionLogger("/tmp/senpi-compaction-decision-log-sink", {
+		const logger = createCompactionLogger(LOG_DIR, {
 			sink: (line) => sink.push(line),
 			mirrorToStderr: false,
 		});

--- a/packages/coding-agent/test/compaction/compaction-log.test.ts
+++ b/packages/coding-agent/test/compaction/compaction-log.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { type CompactionLoggerData, createCompactionLogger } from "../../src/core/extensions/builtin/compaction/log.ts";
+import { createTempAgentDir } from "../support/temp-agent-dir.ts";
 
 describe("compaction logger", () => {
 	afterEach(() => {
@@ -9,7 +10,7 @@ describe("compaction logger", () => {
 	});
 
 	it("Given disabled mirror env When logging Then it stays silent on stderr and writes JSONL", () => {
-		const dir = "/tmp/senpi-compaction-log-disabled";
+		const dir = createTempAgentDir("senpi-compaction-log-disabled-");
 		const error = vi.spyOn(console, "error").mockImplementation(() => {});
 		const sink: string[] = [];
 		const logger = createCompactionLogger(dir, { sink: (line) => sink.push(line), mirrorToStderr: false });
@@ -33,7 +34,7 @@ describe("compaction logger", () => {
 	});
 
 	it("Given a writable log file When logging Then it rotates past the maxBytes override", () => {
-		const dir = "/tmp/senpi-compaction-log-rotate";
+		const dir = createTempAgentDir("senpi-compaction-log-rotate-");
 		const sink: string[] = [];
 		const logger = createCompactionLogger(dir, { sink: (line) => sink.push(line), maxBytes: 1 });
 
@@ -46,7 +47,7 @@ describe("compaction logger", () => {
 	});
 
 	it("Given debug env When logging Then it mirrors to stderr", () => {
-		const dir = "/tmp/senpi-compaction-log-debug";
+		const dir = createTempAgentDir("senpi-compaction-log-debug-");
 		vi.stubEnv("SENPI_COMPACTION_DEBUG", "1");
 		const error = vi.spyOn(console, "error").mockImplementation(() => {});
 		const logger = createCompactionLogger(dir);
@@ -57,7 +58,7 @@ describe("compaction logger", () => {
 	});
 
 	it("Given circular data When logging Then it never throws", () => {
-		const dir = "/tmp/senpi-compaction-log-circular";
+		const dir = createTempAgentDir("senpi-compaction-log-circular-");
 		const logger = createCompactionLogger(dir, { sink: () => {} });
 		const circular: Record<string, unknown> = { origin: "blocking" };
 		circular.reason = circular;
@@ -66,7 +67,7 @@ describe("compaction logger", () => {
 	});
 
 	it("Given disallowed fields When logging Then only allowlisted data is emitted", () => {
-		const dir = "/tmp/senpi-compaction-log-allowlist";
+		const dir = createTempAgentDir("senpi-compaction-log-allowlist-");
 		const sink: string[] = [];
 		const logger = createCompactionLogger(dir, { sink: (line) => sink.push(line) });
 
@@ -91,7 +92,7 @@ describe("compaction logger", () => {
 	});
 
 	it("Given the idle warm-up trigger When logging Then the idle_trigger event is emitted", () => {
-		const dir = "/tmp/senpi-compaction-log-idle";
+		const dir = createTempAgentDir("senpi-compaction-log-idle-");
 		const sink: string[] = [];
 		const logger = createCompactionLogger(dir, { sink: (line) => sink.push(line), mirrorToStderr: false });
 

--- a/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
+++ b/packages/coding-agent/test/compaction/hard-limit-emergency.test.ts
@@ -20,6 +20,9 @@ import type {
 } from "../../src/core/extensions/index.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "../support/temp-agent-dir.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 const registrations: Array<{ unregister: () => void }> = [];
 
@@ -96,7 +99,7 @@ function createContext(contextWindow: number, maxTokens = contextWindow, compact
 		mode: "print",
 		ui: Object.create(null) as ExtensionContext["ui"],
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		isProjectTrusted: () => true,
 		sessionManager,
 		modelRegistry: {} as ExtensionContext["modelRegistry"],
@@ -150,7 +153,7 @@ function createCompactionContext(): ExtensionContext {
 		mode: "print",
 		ui: Object.create(null) as ExtensionContext["ui"],
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		isProjectTrusted: () => true,
 		sessionManager,
 		modelRegistry,

--- a/packages/coding-agent/test/compaction/metadata-side-effects.test.ts
+++ b/packages/coding-agent/test/compaction/metadata-side-effects.test.ts
@@ -11,6 +11,9 @@ import type {
 } from "../../src/core/extensions/index.ts";
 import type { CompactionEntry, SessionEntry } from "../../src/core/session-manager.ts";
 import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "../support/temp-agent-dir.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 const CHECKPOINT_CUSTOM_TYPE = "compaction.agent-checkpoint";
 const TODO_SNAPSHOT_CUSTOM_TYPE = "compaction.todo-snapshot";
@@ -70,7 +73,7 @@ function createExtensionContext(entries: SessionEntry[]): ExtensionContext {
 			notify: vi.fn(),
 		}) as ExtensionContext["ui"],
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		isProjectTrusted: () => true,
 		sessionManager,
 		modelRegistry: {} as ExtensionContext["modelRegistry"],

--- a/packages/coding-agent/test/compaction/restoration-tracker.test.ts
+++ b/packages/coding-agent/test/compaction/restoration-tracker.test.ts
@@ -20,6 +20,9 @@ import type {
 } from "../../src/core/extensions/index.ts";
 import type { SessionEntry } from "../../src/core/session-manager.ts";
 import { createInMemoryExtensionSessionSettings } from "../helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "../support/temp-agent-dir.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 interface RestorationGateHarness {
 	toolCall: ExtensionHandler<ToolCallEvent, ToolCallEventResult>;
@@ -79,7 +82,7 @@ function createGateExtensionContext(settings: CompactionSettings): ExtensionCont
 			notify: vi.fn(),
 		}) as ExtensionContext["ui"],
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		isProjectTrusted: () => true,
 		sessionManager,
 		modelRegistry: {} as ExtensionContext["modelRegistry"],

--- a/packages/coding-agent/test/support/temp-agent-dir.ts
+++ b/packages/coding-agent/test/support/temp-agent-dir.ts
@@ -1,0 +1,27 @@
+/**
+ * Per-run agent/log directories for tests that hand a real filesystem path to a writer.
+ *
+ * `createCompactionLogger(agentDir)` is not inert: `writeLine` calls the injected `sink` and then
+ * still does `mkdirSync` + `openSync(..., "a")` on `<agentDir>/logs/compaction.log`, rotating it
+ * with `renameSync` once it passes `maxBytes`. A hardcoded `/tmp/...` argument therefore makes every
+ * test file that uses it append to — and rotate — ONE shared file: across the parallel vitest
+ * workers of a single run, and across two checkouts/worktrees running the suite at the same time.
+ * The signature of that hazard is a different test failing on each run.
+ *
+ * These helpers return a path unique per process and per call, so no two runs can collide. The
+ * directory lives under `os.tmpdir()` and is left for the OS to reap, matching
+ * `support/quarantine.ts`, which solves the same problem for `SENPI_CODING_AGENT_DIR`.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Create a fresh directory usable as an `agentDir`.
+ *
+ * `prefix` only aids humans reading `/tmp`; uniqueness comes from `mkdtemp`, so callers never need
+ * to add their own entropy.
+ */
+export function createTempAgentDir(prefix = "senpi-test-agent-"): string {
+	return mkdtempSync(join(tmpdir(), prefix));
+}

--- a/packages/coding-agent/test/trigger-compact-extension.test.ts
+++ b/packages/coding-agent/test/trigger-compact-extension.test.ts
@@ -3,6 +3,9 @@ import triggerCompactExtension from "../examples/extensions/trigger-compact.ts";
 import { DEFAULT_COMPACTION_SETTINGS } from "../src/core/compaction/index.ts";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "../src/core/extensions/index.ts";
 import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "./support/temp-agent-dir.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 function createContext(tokens: number | null, compact = vi.fn()): ExtensionContext {
 	return {
@@ -10,7 +13,7 @@ function createContext(tokens: number | null, compact = vi.fn()): ExtensionConte
 		hasUI: false,
 		ui: {} as ExtensionContext["ui"],
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		sessionManager: {} as ExtensionContext["sessionManager"],
 		modelRegistry: {} as ExtensionContext["modelRegistry"],
 		model: undefined,

--- a/packages/coding-agent/test/websearch-native-provider-routing.test.ts
+++ b/packages/coding-agent/test/websearch-native-provider-routing.test.ts
@@ -10,6 +10,9 @@ import type {
 import type { ExtensionContext } from "../src/core/extensions/types.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
 import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "./support/temp-agent-dir.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 function nativeModel(provider: string, id: string, api: Api, baseUrl: string): Model<Api> {
 	return {
@@ -32,7 +35,7 @@ function toolContext(model: Model<Api>, modelRegistry: ModelRegistry): Extension
 		mode: "print",
 		hasUI: false,
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		sessionManager: Object.create(null) as ExtensionContext["sessionManager"],
 		modelRegistry,
 		model,

--- a/packages/coding-agent/test/websearch-native-tool.test.ts
+++ b/packages/coding-agent/test/websearch-native-tool.test.ts
@@ -10,6 +10,9 @@ import type {
 import type { ExtensionContext } from "../src/core/extensions/types.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
 import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "./support/temp-agent-dir.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 function successfulSearchResponse(): Response {
 	return new Response(
@@ -41,7 +44,7 @@ function toolContext(model: Model<Api> | undefined, modelRegistry: ModelRegistry
 		mode: "print",
 		hasUI: false,
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		sessionManager: Object.create(null) as ExtensionContext["sessionManager"],
 		modelRegistry,
 		model,

--- a/packages/coding-agent/test/websearch-progress.test.ts
+++ b/packages/coding-agent/test/websearch-progress.test.ts
@@ -12,6 +12,9 @@ import type {
 import type { ExtensionContext } from "../src/core/extensions/types.ts";
 import { ModelRegistry } from "../src/core/model-registry.ts";
 import { createInMemoryExtensionSessionSettings } from "./helpers/extension-session-settings.ts";
+import { createTempAgentDir } from "./support/temp-agent-dir.ts";
+
+const AGENT_DIR = createTempAgentDir();
 
 function minimalToolContext(): ExtensionContext {
 	return {
@@ -19,7 +22,7 @@ function minimalToolContext(): ExtensionContext {
 		mode: "print",
 		hasUI: false,
 		cwd: process.cwd(),
-		agentDir: "/tmp/senpi-test-agent",
+		agentDir: AGENT_DIR,
 		sessionManager: Object.create(null) as ExtensionContext["sessionManager"],
 		modelRegistry: ModelRegistry.inMemory(AuthStorage.inMemory()),
 		model: undefined,


### PR DESCRIPTION
## Summary

Re-verified the reported test-isolation hazard classes against the tree and fixed the two that are real. Tests and one new test helper only — no production `src/` change, no `package-lock.json` change, no workflow change.

Two of the four reported classes did **not** survive verification and are deliberately left untouched. Details below, because "we fixed it" on a non-hazard is worse than not looking.

## Root cause

### 1. Shared compaction log files across parallel workers and concurrent runs

`createCompactionLogger(agentDir)` is not inert when a `sink` is injected. `writeLine` calls the sink and *then* still touches the filesystem:

```ts
// src/core/extensions/builtin/compaction/log.ts:145-158
function writeLine(filePath, line, maxBytes, sink) {
  if (sink) sink(line);
  mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
  if (needsRotate(filePath, Buffer.byteLength(text), maxBytes)) {
    renameSync(filePath, `${filePath}.1`);   // <- rotation
  }
  const fd = openSync(filePath, "a", 0o600); // <- append
```

Eight test files passed the identical literal `agentDir: "/tmp/senpi-test-agent"`, so every one of them appended to — and could rotate — the single file `/tmp/senpi-test-agent/logs/compaction.log`. That is shared across the parallel vitest workers of one run *and* across two checkouts/worktrees running the suite at the same time. `renameSync` means a second run can move the file out from under the first mid-write. The `compaction-log` and `compaction-decision-log` suites added eight more fixed directories of the same shape.

This is the classic multi-agent-workstation flake generator: harmless on a single checkout, and its signature is a different test failing on each run.

### 2. Unrestored Cloudflare env mutation

`packages/ai/test/openai-completions-empty-tools.test.ts` assigned `CLOUDFLARE_API_KEY`, `CLOUDFLARE_ACCOUNT_ID`, and `CLOUDFLARE_GATEWAY_ID` straight onto `process.env` in four tests. The file had **no `afterEach` and no restore of any kind**, so the values outlived their tests for the remainder of that worker process and clobbered the developer's real ambient Cloudflare credentials. `packages/ai` does not set `unstubEnvs`, so the stubs need an explicit teardown.

## Fix design

`packages/coding-agent/test/support/temp-agent-dir.ts` (6 pure LOC) returns an `mkdtemp` directory under `os.tmpdir()`, unique per process and per call. Every hazardous literal now routes through it. This deliberately mirrors the existing `test/support/quarantine.ts`, which already solves exactly this problem for `SENPI_CODING_AGENT_DIR` — same repo, same idea, so there is one convention rather than two.

For the env hazard: `vi.stubEnv` plus `vi.unstubAllEnvs()` in `afterEach`.

**Assertions and covered behavior are unchanged in both commits.** No test was skipped, deleted, or weakened, and no sleep was added.

## Classes that were reported but are NOT hazards

Verified rather than assumed, and left alone:

- **Fixed unix socket paths** — every path that actually binds is already `mkdtemp`-derived. The remaining `/tmp/*.sock` literals are validation fixtures that throw before any FS access: `createUnixServer` rejects in the constructor, and `server.test.ts:38` rejects at `validateUnixSocketPath` (listener.ts:66) *before* the `mkdir` on line 67. Measured a real socket path at **73 bytes**, comfortably under the 103-byte macOS `sun_path` limit.
- **`process.chdir` leakage** — all ten call sites restore via `afterEach` or `try/finally`. The apparent exception, `valid-cwd-guard.test.ts:18`, is a `chdir` inside a template string executed in a **spawned child process**; the parent cwd is never touched.
- **Literal `/tmp/` paths** — ~250 hits, and the overwhelming majority are inert string fixtures compared with `toBe` or handed to in-memory fakes. Rather than eyeball them, the FS-touching subset was determined empirically by snapshotting `/tmp` before and after a full suite run and diffing.

## RED / GREEN evidence

Evidence directory: `/tmp/bun14-fix-senpi-isolation/`

**RED** — two concurrent runs of the compaction suites shared one log file:

```
single run  -> /tmp/senpi-test-agent/logs/compaction.log  2107 bytes
2 concurrent runs -> ONE file, 4214 bytes   (both runs interleaved)
plus 8 shared fixed dirs: /tmp/senpi-compaction-log-{disabled,rotate,debug,circular,allowlist,idle}
                          /tmp/senpi-compaction-decision-log{,-sink}
```

**GREEN** — same two concurrent runs after the fix:

```
A_exit=0   Test Files 65 passed (65)   Tests 450 passed (450)
B_exit=0   Test Files 65 passed (65)   Tests 450 passed (450)

20 unique agent dirs under os.tmpdir(), each with its own compaction.log
0 fixed shared paths recreated (/tmp/senpi-test-agent, /tmp/senpi-compaction-log-* absent)
```

**The env fix is load-bearing, not decorative.** Forcing the regression — deleting one `vi.stubEnv` line — fails exactly the four Cloudflare tests and nothing else, then reverting restores green. Coverage is identical to before, not weakened:

```
exit-with-stub-removed=1   Tests 4 failed | 7 passed (11)
```

## Validation

| Command | Result |
|---|---|
| `npx vitest run test/compaction … --root packages/coding-agent` | **exit 0** — 67 files, 459 tests |
| `npx vitest run test/openai-completions-empty-tools.test.ts` (packages/ai) | **exit 0** — 11 tests |
| `npm run test:scripts` | **exit 0** — 180 tests, 47 suites |
| `npx vitest run --root packages/client` ×2 concurrent | **exit 0 / exit 0** — 36 tests each |
| `npx vitest run` (full packages/coding-agent) | exit 1 — **byte-identical failure set to the pre-change baseline** |
| `npx vitest run` (full packages/ai) | exit 1 — 244 passed, 1 pre-existing failure |
| `npx vitest run --root packages/server` ×2 concurrent | exit 1 — pre-existing, reproduced on pristine `origin/main` |
| `npx biome check` on all touched files | clean |
| `tsc --noEmit` | no errors in touched files |
| `git status --porcelain` after all runs | clean; `package-lock.json` untouched |

### About the pre-existing failures

They are **not** caused by this branch. Every one is `ERR_MODULE_NOT_FOUND` / `Failed to resolve entry for package` on `@earendil-works/pi-ai` and `@earendil-works/pi-tui` — the workspace has not been built, and `test/workspace-build-prerequisite.test.ts` fails by design to say so. Confirmed two independent ways:

1. `git stash` → `npx vitest run --root packages/server` on pristine `origin/main` reproduces the identical `3 failed | 4 passed`.
2. The full coding-agent failure set is byte-identical before and after the change: `15 failed | 1076 passed | 4 skipped` and `3 failed | 8745 passed | 37 skipped`, with `diff` of the sorted FAIL lines empty.

Fixing them means running `npm run build`, which is outside this lane's scope.
