### PR TITLE
fix(coding-agent): contain bash spill stream errors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Fixed
 
+- Bash output spill files now capture early `EDQUOT`/`ENOSPC` stream errors and fail only the tool
+  call instead of terminating the interactive session through `uncaughtException`.
+
 ### Added
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,8 +6,10 @@
 
 ### Fixed
 
-- Bash output spill files now capture early `EDQUOT`/`ENOSPC` stream errors and fail only the tool
-  call instead of terminating the interactive session through `uncaughtException`.
+- Bash output spill files now capture early `EDQUOT`/`ENOSPC` stream errors and late filesystem
+  close failures, waiting for the stream's terminal `close` event and failing only the tool call
+  instead of returning an incomplete path or terminating the interactive session through
+  `uncaughtException`.
 
 ### Added
 

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -61,6 +61,7 @@ export async function executeBashWithOperations(
 	let tempFilePath: string | undefined;
 	let tempFileStream: WriteStream | undefined;
 	let tempFileError: Error | undefined;
+	let tempFileErrorListener: ((error: Error) => void) | undefined;
 	let totalBytes = 0;
 
 	const compactOutputChunks = () => {
@@ -80,9 +81,10 @@ export async function executeBashWithOperations(
 		const id = randomBytes(8).toString("hex");
 		tempFilePath = join(tmpdir(), `pi-bash-${id}.log`);
 		tempFileStream = createWriteStream(tempFilePath);
-		tempFileStream.on("error", (error) => {
+		tempFileErrorListener = (error) => {
 			tempFileError ??= error;
-		});
+		};
+		tempFileStream.on("error", tempFileErrorListener);
 		for (let i = outputChunkStart; i < outputChunks.length; i++) {
 			const chunk = outputChunks[i];
 			if (chunk !== undefined) {
@@ -98,21 +100,33 @@ export async function executeBashWithOperations(
 			return;
 		}
 		if (tempFileError) {
+			if (tempFileErrorListener) stream.off("error", tempFileErrorListener);
 			stream.destroy();
 			throw tempFileError;
 		}
 
 		await new Promise<void>((resolve, reject) => {
-			const onError = (error: Error) => {
-				stream.off("finish", onFinish);
-				reject(error);
-			};
-			const onFinish = () => {
+			let settled = false;
+			const cleanup = () => {
 				stream.off("error", onError);
-				resolve();
+				if (tempFileErrorListener) stream.off("error", tempFileErrorListener);
+				stream.off("close", onClose);
 			};
-			stream.once("error", onError);
-			stream.once("finish", onFinish);
+			const settle = (error?: Error) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				if (error) reject(error);
+				else resolve();
+			};
+			const onError = (error: Error) => {
+				tempFileError ??= error;
+			};
+			const onClose = () => {
+				settle(tempFileError);
+			};
+			stream.on("error", onError);
+			stream.once("close", onClose);
 			stream.end();
 		});
 	};

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -159,6 +159,25 @@ export async function executeBashWithOperations(
 		}
 	};
 
+	const prepareFinalOutput = async () => {
+		try {
+			finishDecoder();
+			const fullOutput = outputText();
+			const truncationResult = truncateTail(fullOutput);
+			if (truncationResult.truncated) {
+				ensureTempFile();
+			}
+			return { fullOutput, truncationResult };
+		} catch (error) {
+			try {
+				await closeTempFileStream();
+			} catch (closeError) {
+				throw new AggregateError([error, closeError], "Bash output finalization and spill cleanup failed");
+			}
+			throw error;
+		}
+	};
+
 	let result: Awaited<ReturnType<BashOperations["exec"]>>;
 	try {
 		result = await operations.exec(command, cwd, {
@@ -168,12 +187,7 @@ export async function executeBashWithOperations(
 	} catch (err) {
 		// Check if it was an abort
 		if (options?.signal?.aborted) {
-			finishDecoder();
-			const fullOutput = outputText();
-			const truncationResult = truncateTail(fullOutput);
-			if (truncationResult.truncated) {
-				ensureTempFile();
-			}
+			const { fullOutput, truncationResult } = await prepareFinalOutput();
 			await closeTempFileStream();
 			return {
 				output: truncationResult.truncated ? truncationResult.content : fullOutput,
@@ -189,12 +203,7 @@ export async function executeBashWithOperations(
 		throw err;
 	}
 
-	finishDecoder();
-	const fullOutput = outputText();
-	const truncationResult = truncateTail(fullOutput);
-	if (truncationResult.truncated) {
-		ensureTempFile();
-	}
+	const { fullOutput, truncationResult } = await prepareFinalOutput();
 	await closeTempFileStream();
 	const cancelled = options?.signal?.aborted ?? false;
 

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -159,28 +159,12 @@ export async function executeBashWithOperations(
 		}
 	};
 
+	let result: Awaited<ReturnType<BashOperations["exec"]>>;
 	try {
-		const result = await operations.exec(command, cwd, {
+		result = await operations.exec(command, cwd, {
 			onData,
 			signal: options?.signal,
 		});
-
-		finishDecoder();
-		const fullOutput = outputText();
-		const truncationResult = truncateTail(fullOutput);
-		if (truncationResult.truncated) {
-			ensureTempFile();
-		}
-		await closeTempFileStream();
-		const cancelled = options?.signal?.aborted ?? false;
-
-		return {
-			output: truncationResult.truncated ? truncationResult.content : fullOutput,
-			exitCode: cancelled ? undefined : (result.exitCode ?? undefined),
-			cancelled,
-			truncated: truncationResult.truncated,
-			fullOutputPath: tempFilePath,
-		};
 	} catch (err) {
 		// Check if it was an abort
 		if (options?.signal?.aborted) {
@@ -204,4 +188,21 @@ export async function executeBashWithOperations(
 
 		throw err;
 	}
+
+	finishDecoder();
+	const fullOutput = outputText();
+	const truncationResult = truncateTail(fullOutput);
+	if (truncationResult.truncated) {
+		ensureTempFile();
+	}
+	await closeTempFileStream();
+	const cancelled = options?.signal?.aborted ?? false;
+
+	return {
+		output: truncationResult.truncated ? truncationResult.content : fullOutput,
+		exitCode: cancelled ? undefined : (result.exitCode ?? undefined),
+		cancelled,
+		truncated: truncationResult.truncated,
+		fullOutputPath: tempFilePath,
+	};
 }

--- a/packages/coding-agent/src/core/bash-executor.ts
+++ b/packages/coding-agent/src/core/bash-executor.ts
@@ -60,6 +60,7 @@ export async function executeBashWithOperations(
 
 	let tempFilePath: string | undefined;
 	let tempFileStream: WriteStream | undefined;
+	let tempFileError: Error | undefined;
 	let totalBytes = 0;
 
 	const compactOutputChunks = () => {
@@ -79,6 +80,9 @@ export async function executeBashWithOperations(
 		const id = randomBytes(8).toString("hex");
 		tempFilePath = join(tmpdir(), `pi-bash-${id}.log`);
 		tempFileStream = createWriteStream(tempFilePath);
+		tempFileStream.on("error", (error) => {
+			tempFileError ??= error;
+		});
 		for (let i = outputChunkStart; i < outputChunks.length; i++) {
 			const chunk = outputChunks[i];
 			if (chunk !== undefined) {
@@ -92,6 +96,10 @@ export async function executeBashWithOperations(
 		tempFileStream = undefined;
 		if (!stream) {
 			return;
+		}
+		if (tempFileError) {
+			stream.destroy();
+			throw tempFileError;
 		}
 
 		await new Promise<void>((resolve, reject) => {

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -9,6 +9,8 @@
   through the existing close boundary even when the stream failed before command settlement.
 - Successful command finalization now runs outside the command-execution catch, so an already-set
   abort signal cannot reinterpret a spill close failure as a successful cancelled result.
+- Decoder flushing and output preparation now close the spill stream before propagating a callback
+  or formatting failure; if cleanup also fails, both errors are preserved in an `AggregateError`.
 
 ### Why
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## 2026-08-26 - Capture bash spill-file errors before the first write
+
+### What changed
+
+- `packages/coding-agent/src/core/bash-executor.ts`: attaches an `error` listener as soon as the
+  full-output `WriteStream` is created, records the first failure, and rejects the bash execution
+  through the existing close boundary even when the stream failed before command settlement.
+
+### Why
+
+- A full `/tmp` or exhausted user quota can make the spill stream emit `ENOSPC` or `EDQUOT` while
+  command output is still arriving. The only previous listener was installed after execution
+  finished, so the early `error` event escaped to the process-level `uncaughtException` handler and
+  terminated the interactive session instead of failing only the bash tool call.
+
+### Why an extension could not handle it
+
+- The stream is created and written inside the core bash executor before extension result hooks
+  receive control.
+
+### Expected merge conflict zones
+
+- LOW: the temp-file stream creation and close lifecycle in `bash-executor.ts`.
+
 ## 2026-08-26 - Continue provider fallback after failed required compaction
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -6,7 +6,10 @@
 
 - `packages/coding-agent/src/core/bash-executor.ts`: attaches an `error` listener as soon as the
   full-output `WriteStream` is created, records the first failure, and rejects the bash execution
-  through the existing close boundary even when the stream failed before command settlement.
+  through the terminal `close` boundary even when a late filesystem close failure follows `finish`.
+- The close helper waits for `close`, preserves the first storage failure, and removes its error and
+  close listeners after settlement so a stream cannot resolve successfully before final storage state
+  is known or retain listeners after cleanup.
 - Successful command finalization now runs outside the command-execution catch, so an already-set
   abort signal cannot reinterpret a spill close failure as a successful cancelled result.
 - Decoder flushing and output preparation now close the spill stream before propagating a callback
@@ -15,9 +18,9 @@
 ### Why
 
 - A full `/tmp` or exhausted user quota can make the spill stream emit `ENOSPC` or `EDQUOT` while
-  command output is still arriving. The only previous listener was installed after execution
-  finished, so the early `error` event escaped to the process-level `uncaughtException` handler and
-  terminated the interactive session instead of failing only the bash tool call.
+  command output is still arriving, or during the final filesystem close after `finish`. The close
+  path must therefore wait for `close`, rather than treating `finish` as durable completion; the first
+  storage failure is reported instead of returning a successful result with an incomplete path.
 
 ### Why an extension could not handle it
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -7,6 +7,8 @@
 - `packages/coding-agent/src/core/bash-executor.ts`: attaches an `error` listener as soon as the
   full-output `WriteStream` is created, records the first failure, and rejects the bash execution
   through the existing close boundary even when the stream failed before command settlement.
+- Successful command finalization now runs outside the command-execution catch, so an already-set
+  abort signal cannot reinterpret a spill close failure as a successful cancelled result.
 
 ### Why
 

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -5,14 +5,17 @@
 ### What changed
 
 - `output-accumulator.ts`: attaches an `error` listener when its full-output `WriteStream` is
-  created, records the first failure, and rejects `closeTempFile()` even when the failure happened
-  before close began.
+  created, records the first failure, and rejects `closeTempFile()` through the terminal `close`
+  boundary, including when a filesystem close failure follows `finish`.
+- `closeTempFile()` preserves the first storage failure and removes its error and close listeners
+  after settlement, preventing a premature success or post-completion listener leak.
 
 ### Why
 
 - Bash output can cross the in-memory limit while `/tmp` is quota-exhausted. The stream previously
   had no listener until `closeTempFile()`, so an early `EDQUOT`/`ENOSPC` event reached
-  `uncaughtException` and killed the TUI. The normal tool promise now owns that failure.
+  `uncaughtException` and killed the TUI. A late filesystem close failure could also arrive after
+  `finish`; waiting for `close` ensures the normal tool promise owns either failure.
 
 ### Why an extension could not handle it
 

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -1,5 +1,27 @@
 # core/tools changes
 
+## Output spill streams capture early storage failures (2026-08-26)
+
+### What changed
+
+- `output-accumulator.ts`: attaches an `error` listener when its full-output `WriteStream` is
+  created, records the first failure, and rejects `closeTempFile()` even when the failure happened
+  before close began.
+
+### Why
+
+- Bash output can cross the in-memory limit while `/tmp` is quota-exhausted. The stream previously
+  had no listener until `closeTempFile()`, so an early `EDQUOT`/`ENOSPC` event reached
+  `uncaughtException` and killed the TUI. The normal tool promise now owns that failure.
+
+### Why an extension could not handle it
+
+- The built-in shell tool writes the spill stream before extension result hooks run.
+
+### Expected merge conflict zones
+
+- LOW: `output-accumulator.ts` stream creation and close lifecycle.
+
 ## Tooling layer re-diverges from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/packages/coding-agent/src/core/tools/output-accumulator.ts
+++ b/packages/coding-agent/src/core/tools/output-accumulator.ts
@@ -51,6 +51,7 @@ export class OutputAccumulator {
 
 	private tempFilePath: string | undefined;
 	private tempFileStream: WriteStream | undefined;
+	private tempFileError: Error | undefined;
 
 	constructor(options: OutputAccumulatorOptions = {}) {
 		this.maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
@@ -143,6 +144,10 @@ export class OutputAccumulator {
 		if (!stream) {
 			return;
 		}
+		if (this.tempFileError) {
+			stream.destroy();
+			throw this.tempFileError;
+		}
 
 		await new Promise<void>((resolve, reject) => {
 			const onError = (error: Error) => {
@@ -211,6 +216,9 @@ export class OutputAccumulator {
 		}
 		this.tempFilePath = defaultTempFilePath(this.tempFilePrefix);
 		this.tempFileStream = createWriteStream(this.tempFilePath);
+		this.tempFileStream.on("error", (error) => {
+			this.tempFileError ??= error;
+		});
 		for (const chunk of this.rawChunks) {
 			this.tempFileStream.write(chunk);
 		}

--- a/packages/coding-agent/src/core/tools/output-accumulator.ts
+++ b/packages/coding-agent/src/core/tools/output-accumulator.ts
@@ -52,6 +52,7 @@ export class OutputAccumulator {
 	private tempFilePath: string | undefined;
 	private tempFileStream: WriteStream | undefined;
 	private tempFileError: Error | undefined;
+	private tempFileErrorListener: ((error: Error) => void) | undefined;
 
 	constructor(options: OutputAccumulatorOptions = {}) {
 		this.maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
@@ -145,21 +146,33 @@ export class OutputAccumulator {
 			return;
 		}
 		if (this.tempFileError) {
+			if (this.tempFileErrorListener) stream.off("error", this.tempFileErrorListener);
 			stream.destroy();
 			throw this.tempFileError;
 		}
 
 		await new Promise<void>((resolve, reject) => {
-			const onError = (error: Error) => {
-				stream.off("finish", onFinish);
-				reject(error);
-			};
-			const onFinish = () => {
+			let settled = false;
+			const cleanup = () => {
 				stream.off("error", onError);
-				resolve();
+				if (this.tempFileErrorListener) stream.off("error", this.tempFileErrorListener);
+				stream.off("close", onClose);
 			};
-			stream.once("error", onError);
-			stream.once("finish", onFinish);
+			const settle = (error?: Error) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				if (error) reject(error);
+				else resolve();
+			};
+			const onError = (error: Error) => {
+				this.tempFileError ??= error;
+			};
+			const onClose = () => {
+				settle(this.tempFileError);
+			};
+			stream.on("error", onError);
+			stream.once("close", onClose);
 			stream.end();
 		});
 	}
@@ -216,9 +229,10 @@ export class OutputAccumulator {
 		}
 		this.tempFilePath = defaultTempFilePath(this.tempFilePrefix);
 		this.tempFileStream = createWriteStream(this.tempFilePath);
-		this.tempFileStream.on("error", (error) => {
+		this.tempFileErrorListener = (error) => {
 			this.tempFileError ??= error;
-		});
+		};
+		this.tempFileStream.on("error", this.tempFileErrorListener);
 		for (const chunk of this.rawChunks) {
 			this.tempFileStream.write(chunk);
 		}

--- a/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
+++ b/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const spillState = vi.hoisted(() => {
-	const createdStreams: Array<{ readonly destroyed: boolean }> = [];
+	const createdStreams: Array<{
+		readonly destroyed: boolean;
+		listenerCount(eventName: string | symbol): number;
+	}> = [];
 	let emitQuotaError = true;
+	let emitLateQuotaError = false;
 	const pendingEmissions: Array<() => void> = [];
 	const unhandledErrors: Error[] = [];
 	const quotaError = Object.assign(new Error("unknown error, write"), {
@@ -17,6 +21,12 @@ const spillState = vi.hoisted(() => {
 		},
 		set emitQuotaError(value: boolean) {
 			emitQuotaError = value;
+		},
+		get emitLateQuotaError() {
+			return emitLateQuotaError;
+		},
+		set emitLateQuotaError(value: boolean) {
+			emitLateQuotaError = value;
 		},
 		pendingEmissions,
 		quotaError,
@@ -46,6 +56,17 @@ vi.mock("node:fs", async (importOriginal) => {
 					});
 				},
 			});
+			if (spillState.emitLateQuotaError) {
+				const emit = stream.emit.bind(stream);
+				stream.emit = ((event: string | symbol, ...args: any[]) => {
+					const result = emit(event, ...args);
+					if (event === "finish") {
+						emit("error", spillState.quotaError);
+						emit("close");
+					}
+					return result;
+				}) as typeof stream.emit;
+			}
 			spillState.createdStreams.push(stream);
 			return stream;
 		},
@@ -65,6 +86,7 @@ describe("bash spill storage errors", () => {
 	beforeEach(() => {
 		spillState.createdStreams.length = 0;
 		spillState.emitQuotaError = true;
+		spillState.emitLateQuotaError = false;
 		spillState.pendingEmissions.length = 0;
 		spillState.unhandledErrors.length = 0;
 	});
@@ -127,6 +149,23 @@ describe("bash spill storage errors", () => {
 		expect(spillState.createdStreams[0]?.destroyed).toBe(true);
 	});
 
+	it("rejects a late quota failure after finish in bash executor", async () => {
+		spillState.emitQuotaError = false;
+		spillState.emitLateQuotaError = true;
+		const operations: BashOperations = {
+			exec: async (_command, _cwd, { onData }) => {
+				onData(Buffer.alloc(DEFAULT_MAX_BYTES + 1, "x"));
+				return { exitCode: 0 };
+			},
+		};
+
+		await expect(executeBashWithOperations("late bash spill failure", process.cwd(), operations)).rejects.toBe(
+			spillState.quotaError,
+		);
+		expect(spillState.createdStreams[0]?.listenerCount("error")).toBe(0);
+		expect(spillState.createdStreams[0]?.listenerCount("close")).toBe(0);
+	});
+
 	it("routes a quota failure through OutputAccumulator.closeTempFile", async () => {
 		const errorEmitted = nextSpillErrorEmission();
 		const output = new OutputAccumulator({ maxBytes: 1 });
@@ -136,5 +175,18 @@ describe("bash spill storage errors", () => {
 
 		await expect(output.closeTempFile()).rejects.toBe(spillState.quotaError);
 		expect(spillState.unhandledErrors).toEqual([]);
+	});
+
+	it("rejects a late quota failure after finish in OutputAccumulator", async () => {
+		spillState.emitQuotaError = false;
+		spillState.emitLateQuotaError = true;
+		const output = new OutputAccumulator({ maxBytes: 1 });
+
+		output.append(Buffer.from("too large"));
+
+		await expect(output.closeTempFile()).rejects.toBe(spillState.quotaError);
+		const stream = spillState.createdStreams[0];
+		expect(stream?.listenerCount("error")).toBe(0);
+		expect(stream?.listenerCount("close")).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
+++ b/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const spillState = vi.hoisted(() => {
+	const createdStreams: Array<{ readonly destroyed: boolean }> = [];
+	let emitQuotaError = true;
 	const pendingEmissions: Array<() => void> = [];
 	const unhandledErrors: Error[] = [];
 	const quotaError = Object.assign(new Error("unknown error, write"), {
@@ -8,7 +10,18 @@ const spillState = vi.hoisted(() => {
 		errno: -122,
 		syscall: "write",
 	});
-	return { pendingEmissions, quotaError, unhandledErrors };
+	return {
+		createdStreams,
+		get emitQuotaError() {
+			return emitQuotaError;
+		},
+		set emitQuotaError(value: boolean) {
+			emitQuotaError = value;
+		},
+		pendingEmissions,
+		quotaError,
+		unhandledErrors,
+	};
 });
 
 vi.mock("node:fs", async (importOriginal) => {
@@ -21,7 +34,7 @@ vi.mock("node:fs", async (importOriginal) => {
 			const stream = new Writable({
 				write(_chunk, _encoding, callback) {
 					callback();
-					if (emitted) return;
+					if (emitted || !spillState.emitQuotaError) return;
 					emitted = true;
 					queueMicrotask(() => {
 						for (const resolve of spillState.pendingEmissions.splice(0)) resolve();
@@ -33,6 +46,7 @@ vi.mock("node:fs", async (importOriginal) => {
 					});
 				},
 			});
+			spillState.createdStreams.push(stream);
 			return stream;
 		},
 	};
@@ -49,6 +63,8 @@ function nextSpillErrorEmission(): Promise<void> {
 
 describe("bash spill storage errors", () => {
 	beforeEach(() => {
+		spillState.createdStreams.length = 0;
+		spillState.emitQuotaError = true;
 		spillState.pendingEmissions.length = 0;
 		spillState.unhandledErrors.length = 0;
 	});
@@ -87,6 +103,28 @@ describe("bash spill storage errors", () => {
 
 		await expect(execution).rejects.toBe(spillState.quotaError);
 		expect(spillState.unhandledErrors).toEqual([]);
+	});
+
+	it("closes the spill stream when decoder flush delivery throws", async () => {
+		spillState.emitQuotaError = false;
+		const callbackError = new Error("consumer failed on decoder flush");
+		const operations: BashOperations = {
+			exec: async (_command, _cwd, { onData }) => {
+				onData(Buffer.alloc(DEFAULT_MAX_BYTES + 1, "x"));
+				onData(Buffer.from([0xe2]));
+				return { exitCode: 0 };
+			},
+		};
+
+		const execution = executeBashWithOperations("partial utf8 output", process.cwd(), operations, {
+			onChunk: (chunk) => {
+				if (chunk === "\ufffd") throw callbackError;
+			},
+		});
+
+		await expect(execution).rejects.toBe(callbackError);
+		expect(spillState.createdStreams).toHaveLength(1);
+		expect(spillState.createdStreams[0]?.destroyed).toBe(true);
 	});
 
 	it("routes a quota failure through OutputAccumulator.closeTempFile", async () => {

--- a/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
+++ b/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
@@ -69,6 +69,26 @@ describe("bash spill storage errors", () => {
 		expect(spillState.unhandledErrors).toEqual([]);
 	});
 
+	it("preserves a quota failure when cancellation races with command settlement", async () => {
+		const errorEmitted = nextSpillErrorEmission();
+		const controller = new AbortController();
+		const operations: BashOperations = {
+			exec: async (_command, _cwd, { onData }) => {
+				onData(Buffer.alloc(DEFAULT_MAX_BYTES + 1, "x"));
+				await errorEmitted;
+				controller.abort();
+				return { exitCode: 0 };
+			},
+		};
+
+		const execution = executeBashWithOperations("cancelled large output", process.cwd(), operations, {
+			signal: controller.signal,
+		});
+
+		await expect(execution).rejects.toBe(spillState.quotaError);
+		expect(spillState.unhandledErrors).toEqual([]);
+	});
+
 	it("routes a quota failure through OutputAccumulator.closeTempFile", async () => {
 		const errorEmitted = nextSpillErrorEmission();
 		const output = new OutputAccumulator({ maxBytes: 1 });

--- a/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
+++ b/packages/coding-agent/test/suite/regressions/bash-spill-storage-error.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spillState = vi.hoisted(() => {
+	const pendingEmissions: Array<() => void> = [];
+	const unhandledErrors: Error[] = [];
+	const quotaError = Object.assign(new Error("unknown error, write"), {
+		code: "EDQUOT",
+		errno: -122,
+		syscall: "write",
+	});
+	return { pendingEmissions, quotaError, unhandledErrors };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs")>();
+	const { Writable } = await import("node:stream");
+	return {
+		...actual,
+		createWriteStream: () => {
+			let emitted = false;
+			const stream = new Writable({
+				write(_chunk, _encoding, callback) {
+					callback();
+					if (emitted) return;
+					emitted = true;
+					queueMicrotask(() => {
+						for (const resolve of spillState.pendingEmissions.splice(0)) resolve();
+						if (stream.listenerCount("error") === 0) {
+							spillState.unhandledErrors.push(spillState.quotaError);
+							return;
+						}
+						stream.emit("error", spillState.quotaError);
+					});
+				},
+			});
+			return stream;
+		},
+	};
+});
+
+import { executeBashWithOperations } from "../../../src/core/bash-executor.ts";
+import type { BashOperations } from "../../../src/core/tools/bash.ts";
+import { OutputAccumulator } from "../../../src/core/tools/output-accumulator.ts";
+import { DEFAULT_MAX_BYTES } from "../../../src/core/tools/truncate.ts";
+
+function nextSpillErrorEmission(): Promise<void> {
+	return new Promise((resolve) => spillState.pendingEmissions.push(resolve));
+}
+
+describe("bash spill storage errors", () => {
+	beforeEach(() => {
+		spillState.pendingEmissions.length = 0;
+		spillState.unhandledErrors.length = 0;
+	});
+
+	it("routes a quota failure through executeBashWithOperations instead of an unhandled stream error", async () => {
+		const errorEmitted = nextSpillErrorEmission();
+		const operations: BashOperations = {
+			exec: async (_command, _cwd, { onData }) => {
+				onData(Buffer.alloc(DEFAULT_MAX_BYTES + 1, "x"));
+				await errorEmitted;
+				return { exitCode: 0 };
+			},
+		};
+
+		const execution = executeBashWithOperations("large output", process.cwd(), operations);
+
+		await expect(execution).rejects.toBe(spillState.quotaError);
+		expect(spillState.unhandledErrors).toEqual([]);
+	});
+
+	it("routes a quota failure through OutputAccumulator.closeTempFile", async () => {
+		const errorEmitted = nextSpillErrorEmission();
+		const output = new OutputAccumulator({ maxBytes: 1 });
+
+		output.append(Buffer.from("too large"));
+		await errorEmitted;
+
+		await expect(output.closeTempFile()).rejects.toBe(spillState.quotaError);
+		expect(spillState.unhandledErrors).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- attach spill-file `error` listeners before the first write in both bash output paths
- preserve the first storage failure and reject it through the existing awaited close boundary
- add deterministic EDQUOT regressions for `executeBashWithOperations` and `OutputAccumulator`

## Root cause

When large bash output crossed the in-memory limit, Senpi opened a `/tmp` `WriteStream` and started writing before installing its only `error` listener. An early `EDQUOT`/`ENOSPC` event therefore reached the process-level `uncaughtException` handler and terminated the interactive session.

## Verification

- RED before fix: 2/2 new regression cases resolved instead of rejecting, proving the early stream error was unowned
- GREEN after fix: focused bash/tool suites, 78 passed and 2 platform-skipped
- `npm run check`
- `npm run build`
- `env -u KIMI_API_KEY CI=1 npm test` (full hermetic workspace suite)
- LSP diagnostics clean on both implementations and the regression test
- real built spill driver: `SPILL_FAILURE=ENOTDIR:open`, then `PROCESS_SURVIVED=1`
- isolated Senpi CLI smoke: 8/8 passed
- isolated zero-token mock bash loop: 4/4 passed, real auth unchanged

The first non-hermetic full-suite attempt activated legacy live Kimi E2E tests from ambient `KIMI_API_KEY` and received account-level 403 usage-limit responses. Re-running with that opt-in credential removed completed cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bash output spill files so an early `EDQUOT`/`ENOSPC` stream error fails only the tool call instead of terminating the interactive session through `uncaughtException`.

**Bug Fixes**
- Attaches spill-file `error` listeners before the first write in both bash output paths.
- Waits for the stream's terminal `close` event so late filesystem failures after `finish` (and cancellation racing command settlement) still reject through the awaited close boundary.
- Closes the spill stream before propagating decoder-flush or output-preparation errors, aggregating cleanup failures.
- Adds deterministic `EDQUOT` regressions for `executeBashWithOperations` and `OutputAccumulator`.

<sup>Written for commit 7b47dbabd4be35add4db4b1ce328595167e074a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

