### PR TITLE
fix(goal): block unattended continuation runs with a persisted backstop

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Added
 
+- Active goals now stop auto-continuing after 150 automatic continuations without accepted direct user input ([#1139](https://github.com/code-yeongyu/senpi/issues/1139)): a persisted unattended budget survives assistant-text changes and tool use, the goal blocks mechanically (`unattended continuation limit reached`), and any user message resumes it with the budget restored. Monitor-delayed deliveries (armed wake sources) do not consume the budget.
+
 ### Changed
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,46 @@
 # goal Extension Changes
 
+## 2026-08-27 - unattended continuation backstop (#1139)
+
+### What changed
+
+- `types.ts` adds the persisted `Goal.unattendedContinuations` counter;
+  `persistence.ts` sanitizes it like the other continuation state.
+- `store.ts` increments it on every counted `recordContinuationDelivered`
+  (new `countUnattended` option, default on), zeroes it on any status
+  transition alongside `consecutiveContinuations`, and
+  `resetContinuationStreak(ref, { unattended: true })` clears it on accepted
+  direct user input (`direct-input-lifecycle.ts`, both branches).
+- `continuation.ts` adds `GOAL_UNATTENDED_CONTINUATION_LIMIT = 150` and a new
+  `"unattended"` deny reason: any counted path
+  (immediate/userGrace/sessionStart/systemRecovery/providerRecovery) is denied
+  once the budget is exhausted; `monitorDelayed` is exempt because armed-wake
+  waiting is by-design and rate-limited by the cache-aware timer.
+- `continuation-recovery.ts` / `lifecycle-helpers.ts` map the deny to a new
+  mechanical block reason `unattended continuation limit reached`, so the
+  existing "Send any message to resume" recovery applies.
+  `goal_continuation_guard_tripped` now also carries `unattendedContinuations`.
+
+### Why
+
+- #539/#567 progress semantics reset the persisted streak on any tool use or
+  changed narration, so a stalled agent that varies its status text
+  self-authorizes continuations forever (observed: 289 continuations without
+  direct input, 122 consecutive zero-tool turns, 45.7M tokens). The limit sits
+  above the #447 distinct-progress pin (50) and an 8-hour monitor-backstop
+  cadence (~120 deliveries at 240s), below the observed incident run.
+
+### Why an extension could not handle it
+
+- Delivery accounting, the persisted goal store, and continuation admission are
+  private state inside the builtin Goal extension; no external hook can veto an
+  admission or observe per-delivery accounting.
+
+### Expected merge conflict zones
+
+- LOW in `continuation.ts` (constants + verdict union), `store.ts`
+  (continuation mutators), and `lifecycle-helpers.ts` (guard mapping).
+
 ## 2026-08-26 - continuation timer survives a retired extension context
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation-recovery.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation-recovery.ts
@@ -1,6 +1,7 @@
 export const CONTINUATION_CAP_BLOCKED_REASON = "continuation cap reached";
 export const REPETITION_BLOCKED_REASON = "repeated assistant output";
 export const LENGTH_EXHAUSTED_BLOCKED_REASON = "output truncation repeated";
+export const UNATTENDED_CONTINUATION_BLOCKED_REASON = "unattended continuation limit reached";
 export const PROVIDER_ERROR_BLOCKED_REASON = "provider error ended the turn (retries exhausted)";
 
 // Mechanical blocks are stops the runtime imposed on itself, not decisions the
@@ -12,6 +13,7 @@ const MECHANICAL_CONTINUATION_BLOCKS: readonly string[] = [
 	CONTINUATION_CAP_BLOCKED_REASON,
 	REPETITION_BLOCKED_REASON,
 	LENGTH_EXHAUSTED_BLOCKED_REASON,
+	UNATTENDED_CONTINUATION_BLOCKED_REASON,
 	PROVIDER_ERROR_BLOCKED_REASON,
 ];
 

--- a/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/continuation.ts
@@ -8,6 +8,13 @@ export const GOAL_CONTINUATION_CAP = 8;
 export const GOAL_STALL_TOOLLESS_THRESHOLD = 3;
 export const GOAL_REPETITION_HASH_STREAK = 3;
 export const GOAL_LENGTH_RECOVERY_LIMIT = 1;
+/**
+ * Hard budget of automatic continuations without accepted direct user input (#1139).
+ * Progress and tool use never refill it: only direct input does. Stays above the
+ * #447 distinct-progress pin (50) and an 8-hour monitor-backstop cadence
+ * (~120 deliveries at 240s), below the observed 289-continuation incident run.
+ */
+export const GOAL_UNATTENDED_CONTINUATION_LIMIT = 150;
 export const GOAL_USER_GRACE_DELAY_MS = 10_000;
 
 export type GoalContinuationPath =
@@ -37,7 +44,7 @@ export type GoalContinuationVerdict =
 	| { kind: "continue"; prompt: "full" | "minimal"; stallNotice: boolean }
 	| {
 			kind: "deny";
-			reason: "not-eligible" | "single-flight" | "cap" | "stale" | "repetition" | "length-exhausted";
+			reason: "not-eligible" | "single-flight" | "cap" | "stale" | "repetition" | "length-exhausted" | "unattended";
 	  };
 
 export function shouldQueueGoalContinuationWhenIdle(
@@ -94,6 +101,7 @@ export function evaluateGoalContinuation(input: GoalContinuationInput): GoalCont
 	if (input.continuationPending) return { kind: "deny", reason: "single-flight" };
 	if (hasRepeatedNormalizedOutputHash(input.recentNormalizedOutputHashes))
 		return { kind: "deny", reason: "repetition" };
+	if (isUnattendedBudgetExhausted(input)) return { kind: "deny", reason: "unattended" };
 	if (input.consecutiveContinuations >= GOAL_CONTINUATION_CAP) {
 		return { kind: "deny", reason: "cap" };
 	}
@@ -166,6 +174,12 @@ function isEligibleForGoalContinuation(input: GoalContinuationInput): boolean {
 		return input.lastStopReason !== undefined && isContinuableStopReason(input.lastStopReason);
 	}
 	return input.isIdle;
+}
+
+/** Monitor-delayed deliveries are exempt: armed-wake waiting is by-design and rate-limited by the cache-aware timer. */
+function isUnattendedBudgetExhausted(input: GoalContinuationInput): boolean {
+	if (input.path === "monitorDelayed") return false;
+	return (input.goal?.unattendedContinuations ?? 0) >= GOAL_UNATTENDED_CONTINUATION_LIMIT;
 }
 
 function hasRepeatedNormalizedOutputHash(hashes: readonly string[]): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/goal/direct-input-lifecycle.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/direct-input-lifecycle.ts
@@ -63,7 +63,7 @@ export class GoalDirectInputLifecycle {
 		if (currentGoal?.id !== candidate.goalId) return;
 
 		if (currentGoal.status === "blocked" && isMechanicalContinuationBlock(currentGoal.blockedReason)) {
-			await resetContinuationStreak(ref);
+			await resetContinuationStreak(ref, { unattended: true });
 			const reactivated = await updateGoal(ref, { status: "active" }, "user");
 			this.#dependencies.beginAgentGoalAccounting(reactivated);
 			this.#dependencies.refreshGoalUi(ctx, reactivated);
@@ -71,7 +71,7 @@ export class GoalDirectInputLifecycle {
 		}
 
 		if (currentGoal.status !== "active") return;
-		const reset = await resetContinuationStreak(ref);
+		const reset = await resetContinuationStreak(ref, { unattended: true });
 		if (reset !== null) this.#dependencies.refreshGoalUi(ctx, reset);
 		if (this.#suppressedLoadResumeArmed) {
 			this.#suppressedLoadResumeArmed = false;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/lifecycle-helpers.ts
@@ -15,6 +15,7 @@ import {
 	continuationCapRecoveryHint,
 	LENGTH_EXHAUSTED_BLOCKED_REASON,
 	REPETITION_BLOCKED_REASON,
+	UNATTENDED_CONTINUATION_BLOCKED_REASON,
 } from "./continuation-recovery.ts";
 import { buildContinuationPrompt } from "./prompt.ts";
 import { recordContinuationDelivered, updateGoal } from "./store.ts";
@@ -79,6 +80,7 @@ export async function admitAndQueueGoalContinuation(
 		goalStoreRef(ctx.sessionManager, ctx.cwd),
 		options.input.currentSignature,
 		goal.id,
+		{ countUnattended: options.input.path !== "monitorDelayed" },
 	);
 	if (recordedGoal === null) return null;
 	options.markContinuationPending();
@@ -171,6 +173,7 @@ async function handleDeniedContinuation(
 		goalId: goal.id,
 		reason,
 		count: input.consecutiveContinuations,
+		unattendedContinuations: goal.unattendedContinuations ?? 0,
 	});
 	return blocked;
 }
@@ -181,6 +184,8 @@ function blockedReasonForContinuationGuard(
 	switch (reason) {
 		case "cap":
 			return CONTINUATION_CAP_BLOCKED_REASON;
+		case "unattended":
+			return UNATTENDED_CONTINUATION_BLOCKED_REASON;
 		case "repetition":
 			return REPETITION_BLOCKED_REASON;
 		case "length-exhausted":

--- a/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/monitor-continuation.ts
@@ -148,7 +148,8 @@ export class MonitorAwareGoalContinuation {
 					return goal;
 				case "cap":
 				case "repetition":
-				case "length-exhausted": {
+				case "length-exhausted":
+				case "unattended": {
 					const admission = await this.#admitAndQueue(options.ctx, goal, "immediate", options.messages);
 					return admission.goal;
 				}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/persistence.ts
@@ -315,6 +315,7 @@ function hasValidBlockedFields(value: Record<string, unknown>, status: GoalStatu
 function sanitizeContinuationState(goal: Goal): Goal {
 	const next: Goal = { ...goal };
 	if (!isNonNegativeSafeInteger(next.consecutiveContinuations)) delete next.consecutiveContinuations;
+	if (!isNonNegativeSafeInteger(next.unattendedContinuations)) delete next.unattendedContinuations;
 	if (typeof next.lastContinuationSignature !== "string") delete next.lastContinuationSignature;
 	return next;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
@@ -71,6 +71,7 @@ export async function createGoal(ref: GoalStoreRef, objective: string, tokenBudg
 			tokensUsed: 0,
 			timeUsedSeconds: 0,
 			consecutiveContinuations: 0,
+			unattendedContinuations: 0,
 			createdAt: now,
 			updatedAt: now,
 			lastStartedAt: now,
@@ -112,6 +113,7 @@ export async function updateGoal(
 				tokensUsed: 0,
 				timeUsedSeconds: 0,
 				consecutiveContinuations: 0,
+				unattendedContinuations: 0,
 				createdAt: now,
 				updatedAt: now,
 				...(tokenBudget === undefined ? {} : { tokenBudget }),
@@ -132,6 +134,7 @@ export async function updateGoal(
 		);
 		if (next.status !== current.status) {
 			next.consecutiveContinuations = 0;
+			next.unattendedContinuations = 0;
 			delete next.lastContinuationSignature;
 		}
 		if (tokenBudget === undefined) delete next.tokenBudget;
@@ -189,6 +192,7 @@ export async function recordContinuationDelivered(
 	ref: GoalStoreRef,
 	signature: string,
 	expectedGoalId?: string,
+	options: { countUnattended?: boolean } = {},
 ): Promise<Goal | null> {
 	return enqueueGoalMutation(ref, async () => {
 		const goal = await readGoalFile(ref);
@@ -196,6 +200,7 @@ export async function recordContinuationDelivered(
 		const next: Goal = {
 			...goal,
 			consecutiveContinuations: (goal.consecutiveContinuations ?? 0) + 1,
+			unattendedContinuations: (goal.unattendedContinuations ?? 0) + (options.countUnattended === false ? 0 : 1),
 			lastContinuationSignature: signature,
 		};
 		await writeGoalFile(ref, next);
@@ -203,11 +208,15 @@ export async function recordContinuationDelivered(
 	});
 }
 
-export async function resetContinuationStreak(ref: GoalStoreRef): Promise<Goal | null> {
+export async function resetContinuationStreak(
+	ref: GoalStoreRef,
+	options: { unattended?: boolean } = {},
+): Promise<Goal | null> {
 	return enqueueGoalMutation(ref, async () => {
 		const goal = await readGoalFile(ref);
 		if (!goal) return goal;
 		const next: Goal = { ...goal, consecutiveContinuations: 0 };
+		if (options.unattended === true) next.unattendedContinuations = 0;
 		delete next.lastContinuationSignature;
 		await writeGoalFile(ref, next);
 		return next;

--- a/packages/coding-agent/src/core/extensions/builtin/goal/types.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/types.ts
@@ -21,6 +21,7 @@ export type Goal = {
 	tokensUsed: number;
 	timeUsedSeconds: number;
 	consecutiveContinuations?: number;
+	unattendedContinuations?: number;
 	lastContinuationSignature?: string;
 	createdAt: number;
 	updatedAt: number;

--- a/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
+++ b/packages/coding-agent/test/suite/goal-continuation-verdict.test.ts
@@ -6,6 +6,7 @@ import {
 	GOAL_LENGTH_RECOVERY_LIMIT,
 	GOAL_REPETITION_HASH_STREAK,
 	GOAL_STALL_TOOLLESS_THRESHOLD,
+	GOAL_UNATTENDED_CONTINUATION_LIMIT,
 	GOAL_USER_GRACE_DELAY_MS,
 	hashAssistantText,
 	normalizeAssistantText,
@@ -90,6 +91,32 @@ describe("goal continuation verdict", () => {
 		],
 	] as const)("denies with %s", (reason, input) => {
 		expect(evaluateGoalContinuation(input)).toEqual({ kind: "deny", reason });
+	});
+
+	it("denies with unattended at the limit on every counted path and admits below it", () => {
+		const atLimit = makeGoal({ unattendedContinuations: GOAL_UNATTENDED_CONTINUATION_LIMIT });
+		for (const path of ["immediate", "userGrace", "sessionStart", "systemRecovery", "providerRecovery"] as const) {
+			expect(evaluateGoalContinuation(makeInput({ goal: atLimit, path }))).toEqual({
+				kind: "deny",
+				reason: "unattended",
+			});
+		}
+		expect(
+			evaluateGoalContinuation(
+				makeInput({ goal: makeGoal({ unattendedContinuations: GOAL_UNATTENDED_CONTINUATION_LIMIT - 1 }) }),
+			),
+		).toMatchObject({ kind: "continue" });
+	});
+
+	it("exempts the monitor-delayed path from the unattended limit", () => {
+		expect(
+			evaluateGoalContinuation(
+				makeInput({
+					goal: makeGoal({ unattendedContinuations: GOAL_UNATTENDED_CONTINUATION_LIMIT }),
+					path: "monitorDelayed",
+				}),
+			),
+		).toMatchObject({ kind: "continue" });
 	});
 
 	it("admits below the continuation cap and denies at the boundary", () => {
@@ -210,6 +237,7 @@ describe("goal continuation verdict", () => {
 		expect(GOAL_STALL_TOOLLESS_THRESHOLD).toBe(3);
 		expect(GOAL_REPETITION_HASH_STREAK).toBe(3);
 		expect(GOAL_LENGTH_RECOVERY_LIMIT).toBe(1);
+		expect(GOAL_UNATTENDED_CONTINUATION_LIMIT).toBe(150);
 		expect(GOAL_USER_GRACE_DELAY_MS).toBe(10_000);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/issue-1139-goal-unattended-backstop.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-1139-goal-unattended-backstop.test.ts
@@ -1,0 +1,176 @@
+import { join } from "node:path";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readGoal, updateGoal } from "../../../src/core/extensions/builtin/goal/store.ts";
+import type { ExtensionContext } from "../../../src/core/extensions/types.ts";
+import {
+	cleanAssistantStop,
+	cleanupGoalMonitorTempDirs,
+	createGoalHarness,
+	makeGoalContext,
+	runGoalHandlers,
+	waitForSentCount,
+} from "../goal-monitor-test-harness.ts";
+
+const GOAL_CONTINUATION_MESSAGE_TYPE = "goal-continuation";
+
+// The unattended budget is a policy pin, mirroring how issue-447 pins its 50-turn
+// bound. It must stay above the #447 distinct-progress pin (50) and above an
+// 8-hour monitor-backstop cadence (~120 deliveries at 240s).
+const UNATTENDED_LIMIT = 150;
+const UNATTENDED_BLOCKED_REASON = "unattended continuation limit reached";
+
+afterEach(async () => {
+	vi.useRealTimers();
+	await cleanupGoalMonitorTempDirs();
+});
+
+function goalStoreRef(ctx: ExtensionContext) {
+	return {
+		baseDir: join(ctx.sessionManager.getSessionDir(), "extensions", "goal"),
+		threadId: ctx.sessionManager.getSessionId(),
+	};
+}
+
+function cleanAssistantStopWithText(text: string): AgentMessage {
+	const message = cleanAssistantStop();
+	if (message.role !== "assistant") throw new Error("Expected an assistant message");
+	return { ...message, content: [{ type: "text", text }] };
+}
+
+async function createActiveGoal(
+	harness: ReturnType<typeof createGoalHarness>,
+	ctx: ExtensionContext,
+	objective: string,
+): Promise<void> {
+	const createGoal = harness.tools.get("create_goal");
+	if (createGoal === undefined) throw new Error("Goal tool was not registered");
+	await createGoal.execute("issue-1139-create", { objective }, undefined, undefined, ctx);
+}
+
+async function runContinuationTurn(
+	harness: ReturnType<typeof createGoalHarness>,
+	ctx: ExtensionContext,
+	message: AgentMessage,
+): Promise<void> {
+	await runGoalHandlers(harness.handlers, "agent_start", { type: "agent_start" }, ctx);
+	await runGoalHandlers(harness.handlers, "agent_end", { type: "agent_end", messages: [message] }, ctx);
+}
+
+async function runAcceptedDirectInput(
+	harness: ReturnType<typeof createGoalHarness>,
+	ctx: ExtensionContext,
+	inputId: string,
+): Promise<void> {
+	await runGoalHandlers(
+		harness.handlers,
+		"input",
+		{ type: "input", inputId, text: "continue", source: "interactive" },
+		ctx,
+	);
+	await runGoalHandlers(
+		harness.handlers,
+		"input_disposition",
+		{ type: "input_disposition", inputId, disposition: "started" },
+		ctx,
+	);
+}
+
+describe("issue #1139: unattended continuation backstop", () => {
+	it("blocks an active goal after the unattended limit despite varied toolless narration", {
+		timeout: 60_000,
+	}, async () => {
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-1139-unattended-limit");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await createActiveGoal(harness, ctx, "Reproduce the #1139 varied-narration stall");
+
+		// Every turn varies its narration, so the #539/#567 progress semantics reset
+		// the consecutive streak each time and the cap can never accumulate.
+		for (let turn = 1; turn <= UNATTENDED_LIMIT + 1; turn++) {
+			const promptsBeforeTurn = harness.sent.length;
+			await runContinuationTurn(harness, ctx, cleanAssistantStopWithText(`varied status narration ${turn}`));
+			expect(harness.sent.length - promptsBeforeTurn).toBeLessThanOrEqual(1);
+		}
+
+		expect(harness.sent).toHaveLength(UNATTENDED_LIMIT);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "blocked",
+			blockedReason: UNATTENDED_BLOCKED_REASON,
+		});
+		expect(notices).toContainEqual(
+			`Goal continuation blocked: ${UNATTENDED_BLOCKED_REASON}. Send any message to resume.`,
+		);
+		expect(harness.events.emitted).toContainEqual(
+			expect.objectContaining({
+				channel: "goal_continuation_guard_tripped",
+				data: expect.objectContaining({ reason: "unattended" }),
+			}),
+		);
+	});
+
+	it("counts unattended deliveries and resets the budget on accepted direct input", async () => {
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-1139-direct-input-reset");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await createActiveGoal(harness, ctx, "Reset the unattended budget on direct input");
+
+		await runContinuationTurn(harness, ctx, cleanAssistantStopWithText("varied narration one"));
+		await runContinuationTurn(harness, ctx, cleanAssistantStopWithText("varied narration two"));
+		expect(harness.sent).toHaveLength(2);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "active",
+			unattendedContinuations: 2,
+		});
+
+		await runAcceptedDirectInput(harness, ctx, "issue-1139-reset");
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "active",
+			unattendedContinuations: 0,
+		});
+	});
+
+	it("reactivates a backstop-blocked goal on accepted direct input with the budget restored", async () => {
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-1139-reactivation");
+		await createActiveGoal(harness, ctx, "Resume after the unattended backstop");
+		await updateGoal(goalStoreRef(ctx), { status: "blocked", reason: UNATTENDED_BLOCKED_REASON }, "model");
+
+		await runAcceptedDirectInput(harness, ctx, "issue-1139-reactivate");
+
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({
+			status: "active",
+			unattendedContinuations: 0,
+		});
+	});
+
+	it("does not count monitor-delayed deliveries toward the unattended budget", async () => {
+		vi.useFakeTimers();
+		const notices: string[] = [];
+		const harness = createGoalHarness();
+		const ctx = await makeGoalContext(notices, "issue-1139-monitor-exempt");
+		await runGoalHandlers(harness.handlers, "session_start", { type: "session_start", reason: "reload" }, ctx);
+		await createActiveGoal(harness, ctx, "Keep watching the monitor");
+
+		// An immediate delivery consumes one unit of the unattended budget.
+		const immediateDeliveryRecorded = waitForSentCount(harness, 1);
+		await runContinuationTurn(harness, ctx, cleanAssistantStopWithText("immediate continuation"));
+		await immediateDeliveryRecorded;
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ unattendedContinuations: 1 });
+
+		// A monitor-delayed delivery (armed wake source, cache-aware timer) does not.
+		harness.events.emit("terminal_monitor_state", { activeCount: 1 });
+		await harness.events.flush();
+		await runContinuationTurn(harness, ctx, cleanAssistantStopWithText("waiting on the monitor"));
+		const delayedDeliveryRecorded = waitForSentCount(harness, 2);
+		await vi.advanceTimersByTimeAsync(240_000);
+		await delayedDeliveryRecorded;
+
+		expect(harness.sent).toHaveLength(2);
+		expect(harness.sent[1]?.message.customType).toBe(GOAL_CONTINUATION_MESSAGE_TYPE);
+		expect(await readGoal(goalStoreRef(ctx))).toMatchObject({ unattendedContinuations: 1 });
+	});
+});


### PR DESCRIPTION
## What

Fixes #1139: adds the unattended-continuation backstop to the built-in Goal extension.

A stalled agent could keep an active Goal alive indefinitely by varying its status text: changed narration counts as progress under the #539/#567 semantics, any tool use resets the persisted streak, so `consecutiveContinuations` loops `1 -> 0 -> 1` and the cap never accumulates (observed: 289 continuations without direct user input, 122 consecutive zero-tool turns, 45.7M accounted tokens).

## Policy decisions (the three questions in #1139)

1. **Back off, hold, or block?** Mechanically **block** through the existing mechanical-block channel: new blocked reason `unattended continuation limit reached`, the standard "Send any message to resume." recovery hint, and reactivation on the next accepted direct input. Consistent with cap/repetition/length-exhausted.
2. **What resets the budget?** **Accepted direct user input only** (both `GoalDirectInputLifecycle` branches), plus goal status transitions and goal creation/replacement. Not assistant-text changes, not tool use, not wake events - progress-shaped resets are exactly what the incident evaded (same lesson as the loop-guard polling-evasion incident). Status-transition resets are evasion-safe because the model cannot set `active` (`MODEL_SETTABLE_GOAL_STATUS_VALUES`).
3. **K = 150** (`GOAL_UNATTENDED_CONTINUATION_LIMIT`): above the #447 distinct-progress pin (50) and above an 8-hour monitor-backstop cadence (~120 deliveries at 240s), below the observed 289-continuation incident block.

**Counted paths:** `immediate`, `userGrace`, `sessionStart`, `systemRecovery`, `providerRecovery`. **Exempt:** `monitorDelayed` - armed-wake waiting is by-design and rate-limited by the cache-aware timer (>=240s), and #1139 scoped wake-source accounting out; legitimate long monitor waits therefore never trip the backstop while the self-authorizing immediate loop does.

## How

- `Goal.unattendedContinuations` persisted counter (`types.ts`), sanitized on read like the other continuation state (`persistence.ts`).
- `recordContinuationDelivered` increments it on counted deliveries (`countUnattended` option); `resetContinuationStreak(ref, { unattended: true })` clears it on accepted direct input; status transitions zero it alongside `consecutiveContinuations` (`store.ts`, `direct-input-lifecycle.ts`).
- New `"unattended"` deny reason in `evaluateGoalContinuation`, mapped to the new mechanical block (`continuation.ts`, `continuation-recovery.ts`, `lifecycle-helpers.ts`, `monitor-continuation.ts`).
- `goal_continuation_guard_tripped` now also carries `unattendedContinuations`.

## Verification (TDD, RED -> GREEN)

- New `test/suite/regressions/issue-1139-goal-unattended-backstop.test.ts` (4 tests) captured RED on unmodified `main` (151 deliveries, goal stayed active) and GREEN after the fix (exactly 150 deliveries, then mechanical block + notice + guard event).
- New verdict unit tests: deny at the limit on every counted path, admit at limit-1, `monitorDelayed` exempt, constant pinned at 150.
- Existing pins hold unchanged: `vitest --run goal` = **42 files / 367 tests green**, including `issue-447-goal-continuation` (50 distinct-progress turns stay active), `issue-566-goal-repetition-tool-reset`, `goal-monitor-continuation`.
- Root `npm run check` green (biome, pinned deps, ts-imports, shrinkwrap, install locks, `tsc --noEmit`).
- senpi-qa Channel 3 mock loop (real CLI, fake model server) evidence under `local-ignore/qa-evidence/`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1139: gives the Goal extension a persisted unattended-continuation budget so a stalled agent can't keep a goal alive indefinitely by varying its status text. Previously, changed narration counted as progress and reset the continuation streak, which allowed an observed 289 auto-continuations without direct input.

**Behavior**
- Every automatic continuation without accepted direct input consumes one unit; only accepted direct input or a goal status transition restores the budget, so tool use and narration changes refill nothing.
- At 150 the goal blocks mechanically with `unattended continuation limit reached` and any user message resumes it with the budget restored.
- Monitor-delayed deliveries stay exempt because armed-wake waiting is by-design and rate-limited by the cache-aware timer.

<sup>Written for commit 38b1e820fc12354b60c872378d01fc153b4b7822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

