### PR TITLE
test(webfetch): port pi-webfetch PR #8 parity coverage

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/webfetch/changes.md
@@ -77,6 +77,27 @@ Vendored from [`code-yeongyu/pi-webfetch`](https://github.com/code-yeongyu/pi-we
   boundary must be re-applied together with the `HeadersInit` patch noted below.
 - `webfetch/content.ts` itself is untouched, so a re-vendor of that file cannot conflict.
 
+## 2026-08-26 - Port pi-webfetch PR #8 regression coverage
+
+### What changed
+
+- Added the one-redirect end-to-end regression, including final markdown content and the exact visited path sequence.
+- Strengthened explicit-article extraction coverage with a module-level Readability parse counter so the test fails if fallback parsing runs.
+- Added discard-body coverage for a body already destroyed before cleanup; existing senpi coverage already exercises dump success/failure, no-dump draining, drain errors, aborts, and the response-size bound.
+
+### Why
+
+- The merged upstream PR #8 added redirect and mutation-sensitive explicit-article regressions plus dump feature-detection coverage. Senpi already contains the corresponding cleanup implementation and stronger drain lifecycle coverage, but lacked these specific regression assertions.
+- Senpi retains `on?.("error")` rather than upstream's `once("error")`: the vendored response-body contract allows bodies without an error-listener API, and the optional registration guards both Bun-compatible bare bodies and Undici bodies without changing cleanup semantics. No defect was found requiring a semantic change.
+
+### Why an extension could not handle it
+
+- Redirect body disposal occurs inside the vendored fetcher's private request loop, before the webfetch extension receives a response. The explicit article and response-body test coverage targets vendored builtin modules directly.
+
+### Expected merge conflict zones
+
+- LOW in the webfetch suite tests and `changes.md`; production webfetch implementation is unchanged.
+
 ## Conflict zones
 
 Re-vendoring overwrites these files; this is a MANUAL_PACKAGES entry in `scripts/sync-builtin-extensions.mjs` (metadata only, no auto file-sync). Re-apply the `HeadersInit` patch and Tistory article/noise selector behavior after re-running the transform, then re-check `npm run check`. A jsdom upgrade can also change the worker lookup patched by `scripts/prepare-bun-compile-assets.mjs`; keep its fixture and the explicit worker entrypoints in `scripts/build-binaries.sh` and `packages/coding-agent/package.json` aligned.

--- a/packages/coding-agent/test/suite/regressions/1089-webfetch-bun-body-discard.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1089-webfetch-bun-body-discard.test.ts
@@ -71,6 +71,31 @@ describe("issue #1089 webfetch redirect body cleanup", () => {
 		expect(cleanupOrder).toEqual(["listen:error", "iterate", "destroy"]);
 	});
 
+	it("handles an already-destroyed body without escaping its cleanup error", async () => {
+		// Given
+		const destroy = vi.fn<(error?: Error) => void>();
+		destroy();
+		const body: RedirectBody = {
+			destroy,
+			on: vi.fn(),
+			dump: vi.fn().mockRejectedValue(new Error("body already destroyed")),
+			[Symbol.asyncIterator](): AsyncIterator<Uint8Array> {
+				return {
+					next: async () => {
+						throw new Error("iteration should not be needed");
+					},
+				};
+			},
+		};
+
+		// When
+		await expect(discardBody(body, 1024)).resolves.toBeUndefined();
+
+		// Then
+		expect(destroy).toHaveBeenCalledTimes(2);
+		expect(destroy).toHaveBeenLastCalledWith();
+	});
+
 	it("uses dump and then destroys when the redirect body supports dump", async () => {
 		// Given
 		const dump = vi.fn<(options?: DumpOptions) => Promise<void>>().mockResolvedValue();

--- a/packages/coding-agent/test/suite/webfetch-explicit-article.test.ts
+++ b/packages/coding-agent/test/suite/webfetch-explicit-article.test.ts
@@ -1,15 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-const readability = vi.hoisted(() => ({
-	parse: vi.fn(() => {
-		throw new Error("Readability should not run for explicit article matches");
-	}),
-}));
+let readabilityParseCalls = 0;
 
 vi.mock("@mozilla/readability", () => ({
 	Readability: class {
 		parse(): unknown {
-			return readability.parse();
+			readabilityParseCalls += 1;
+			return null;
 		}
 	},
 }));
@@ -29,10 +26,6 @@ function explicitArticleHtml(): string {
 }
 
 describe("webfetch explicit article extraction", () => {
-	beforeEach(() => {
-		readability.parse.mockClear();
-	});
-
 	it("#given an explicit article container #when converting markdown #then skips Readability fallback parsing", () => {
 		// given / when
 		const markdown = htmlToMarkdown(explicitArticleHtml(), "https://example.test/post");
@@ -40,6 +33,6 @@ describe("webfetch explicit article extraction", () => {
 		// then
 		expect(markdown).toContain("# Explicit Article");
 		expect(markdown).toContain("Explicit article body");
-		expect(readability.parse).not.toHaveBeenCalled();
+		expect(readabilityParseCalls).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/suite/webfetch-reader-mode.test.ts
+++ b/packages/coding-agent/test/suite/webfetch-reader-mode.test.ts
@@ -176,6 +176,34 @@ describe("webfetch reader-mode cleanup", () => {
 		expect(headerValue(challengeHeaders, "sec-ch-ua-platform")).toBe('"Windows"');
 	});
 
+	it("#given one redirect #when fetching #then returns the final response body", async () => {
+		// given
+		const visitedPaths: string[] = [];
+		const server = await createFixtureServer((request, response) => {
+			visitedPaths.push(request.url ?? "");
+			if (request.url === "/start") {
+				response.writeHead(302, {
+					location: "/final",
+					"content-type": "text/plain; charset=utf-8",
+				});
+				response.end("redirecting");
+				return;
+			}
+
+			response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+			response.end("<html><body><h1>Redirect Complete</h1><p>Final page.</p></body></html>");
+		});
+
+		// when
+		const result = await executeWebfetch({ url: `${server.baseUrl}/start`, format: "markdown" });
+		const text = textContent(result);
+
+		// then
+		expect(text).toContain("# Redirect Complete");
+		expect(text).toContain("Final page.");
+		expect(visitedPaths).toEqual(["/start", "/final"]);
+	});
+
 	it("#given too many redirects #when fetching #then returns the final redirect response body", async () => {
 		// given
 		const server = await createFixtureServer((_request, response) => {


### PR DESCRIPTION
## Summary

Port the missing regression coverage from merged `code-yeongyu/pi-webfetch#8` into senpi's manually vendored builtin webfetch.

No production webfetch behavior was changed: senpi already contains the upstream cleanup implementation plus stronger bounded, abort-aware fallback draining. This PR adds only the missing/weak test deltas and the required ledger entry.

## Parity audit

| pi-webfetch#8 delta | Result | Evidence / rationale |
| --- | --- | --- |
| New one-redirect regression asserting final markdown and `visitedPaths === ["/start", "/final"]` | **ported** | Added to `packages/coding-agent/test/suite/webfetch-reader-mode.test.ts`. |
| Strengthened explicit-article regression with a module-level Readability parse counter | **ported** | Updated `packages/coding-agent/test/suite/webfetch-explicit-article.test.ts`; the old thrown-error mock was swallowed by senpi's production fallback and therefore was mutation-weak. |
| New `src/webfetch/fetcher.test.ts` dump feature-detection coverage (no-dump, dump rejection, already-destroyed body) | **ported** | Senpi already covered no-dump draining, dump success, dump rejection, drain errors, abort, and the response-size bound in `1089-webfetch-bun-body-discard.test.ts`; added the missing already-destroyed-body cleanup case there. The existing tests are adapted to senpi's `discardBody(body, maxBytes, signal)` boundary. |
| `once("error")` instead of senpi's `on?.("error")` | **declined-with-reason** | No real defect found. Senpi's optional `on` contract intentionally supports Bun-compatible bare bodies that may expose async iteration and `destroy()` without an error-listener method. The current listener is installed before discard/drain and preserves quiet teardown for bodies that support it; changing to mandatory `once` would narrow compatibility without adding tested behavior. |

## Mutation evidence

Each ported/strengthened assertion was proven capable of failing via a temporary local mutation, then reverted before the green run:

- Redirect regression: mutated redirect URL resolution to retain the start URL; RED failed on the expected final URL, then GREEN passed after restore.
- Explicit article regression: disabled the explicit-article early return; RED observed `readabilityParseCalls === 1` instead of `0`, then GREEN passed after restore.
- Discard-body coverage: bypassed fallback draining; RED failed the drain assertion and the abort-aware drain test timed out, then GREEN passed after restore.

## Verification

- Targeted Vitest: **3 files passed, 14 tests passed**
- `node scripts/audit-changes-md.mjs`: **247 audited, 247 covered, 0 uncovered; exit 0**
- `npm run check`: **passed** (Biome, pinned deps, import checks, shrinkwrap/install locks, Claude SDK platform lock, TypeScript, browser smoke)
- `git diff --check`: passed

The PR intentionally does not modify `external-versions.json`, run builtin sync, or touch unrelated executor/output files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the missing regression coverage from upstream `code-yeongyu/pi-webfetch` PR #8 into the vendored webfetch. No production webfetch code changed; this PR only adds test coverage and a changelog entry.

**Test changes**

- Adds a one-redirect regression asserting final markdown and the exact visited path sequence.
- Strengthens the explicit-article test with a module-level Readability parse counter because the old thrown-error mock was swallowed by the production fallback.
- Adds discard-body coverage for an already-destroyed body; dump, drain, and abort cases were already covered.
- Declined upstream's mandatory `once("error")` listener because the vendored body contract intentionally supports bodies without an error-listener API.

<sup>Written for commit 4c0e4cb2f0b44d5be8e54c7c619ec6ff6597d9f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

