### PR TITLE
fix(tui): preserve ConPTY scrollback on redraw (#1145)

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed Windows Terminal/ConPTY resize redraws erasing terminal scrollback with `ESC[3J` ([#1145](https://github.com/code-yeongyu/senpi/issues/1145)).
+
 ### Removed
 
 ## [2026.8.26-2] - 2026-08-26

--- a/packages/tui/src/changes.md
+++ b/packages/tui/src/changes.md
@@ -1,5 +1,24 @@
 # TUI delta rendering fork changes
 
+## 2026-08-27 - Preserve Windows Terminal scrollback during resize redraws
+
+### What changed
+
+- `packages/tui/src/tui.ts`: Windows full redraws continue to clear and repaint the visible screen, but no longer emit `ESC[3J`, which deletes the user's terminal scrollback buffer on ConPTY. Non-Windows non-multiplexer redraws retain their existing scrollback-clearing behavior.
+
+### Why
+
+- Windows Terminal's ConPTY resize and focus transitions can trigger a full redraw outside a multiplexer. Clearing scrollback is destructive and makes prior session output unrecoverable when the user returns to the terminal window.
+
+### Why this lives in the fork
+
+- The platform-specific redraw guard belongs in the TUI renderer's `fullRender()` path, where screen clearing and scrollback deletion are emitted together.
+
+### Expected merge conflict zones
+
+- LOW: `packages/tui/src/tui.ts` around `TuiBase.doRender()` and the `fullRender()` scrollback-clear guard.
+- LOW: `packages/tui/test/mux-scrollback.test.ts` around resize scrollback emission assertions.
+
 ## Dead-terminal detection reads Bun's errno-in-message shape (2026-08-26)
 
 ### What changed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2032,7 +2032,7 @@ export abstract class TuiBase extends Container {
 			if (clear) {
 				buffer += this.deleteKittyImages(this.previousKittyImageIds);
 				buffer += "\x1b[2J\x1b[H";
-				if (clearScrollback && !preserveMuxScrollback) {
+				if (clearScrollback && !preserveMuxScrollback && process.platform !== "win32") {
 					buffer += "\x1b[3J";
 				}
 			} else {

--- a/packages/tui/test/mux-scrollback.test.ts
+++ b/packages/tui/test/mux-scrollback.test.ts
@@ -20,6 +20,56 @@ import {
 } from "./mux-scrollback-harness.ts";
 
 describe("TUI multiplexer scrollback preservation", () => {
+	it("does not clear scrollback when a non-multiplexer Windows terminal is resized", async () => {
+		const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+		assert.ok(platformDescriptor);
+		Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+		try {
+			const terminal = new LoggingVirtualTerminal(40, 6);
+			const tui = new TUI(terminal, nonMuxOptions());
+			const component = new StaticComponent();
+			component.lines = ["alpha", "beta", "gamma"];
+			tui.addChild(component);
+
+			tui.start();
+			await terminal.waitForRender();
+			terminal.clearWrites();
+
+			terminal.resize(50, 6);
+			await terminal.waitForRender();
+
+			const writes = terminal.getWrites();
+			assert.ok(writes.includes(SCREEN_CLEAR + HOME), "width change should clear and home the visible screen");
+			assert.strictEqual(
+				countOccurrences(writes, SCROLLBACK_CLEAR),
+				0,
+				"Windows resize must not clear terminal scrollback",
+			);
+			assertFrameBalanced(writes);
+			tui.stop();
+		} finally {
+			Object.defineProperty(process, "platform", platformDescriptor);
+		}
+	});
+
+	it("keeps clearing scrollback for non-Windows non-multiplexer resizes", async () => {
+		const terminal = new LoggingVirtualTerminal(40, 6);
+		const tui = new TUI(terminal, nonMuxOptions());
+		const component = new StaticComponent();
+		component.lines = ["alpha", "beta", "gamma"];
+		tui.addChild(component);
+
+		tui.start();
+		await terminal.waitForRender();
+		terminal.clearWrites();
+
+		terminal.resize(50, 6);
+		await terminal.waitForRender();
+
+		assert.strictEqual(countOccurrences(terminal.getWrites(), SCROLLBACK_CLEAR), 1);
+		tui.stop();
+	});
+
 	it("emits a screen clear without clearing scrollback when width changes inside a multiplexer", async () => {
 		const terminal = new LoggingVirtualTerminal(40, 6);
 		const tui = new TUI(terminal, muxOptions());


### PR DESCRIPTION
## Root cause
The resize-driven `fullRender(true)` path used its default `clearScrollback = true`. On bare Windows Terminal/ConPTY, where mux scrollback preservation is false, this appended `ESC[3J` after `ESC[2J ESC[H`, deleting the user scrollback buffer.

The guard now suppresses `ESC[3J` on Windows while retaining the existing screen clear/home behavior. Non-Windows non-multiplexer full redraws retain their prior behavior.

## RED output
Before the production edit, the focused test failed against the unguarded path:
```text
✖ does not clear scrollback when a non-multiplexer terminal is resized
AssertionError [ERR_ASSERTION]: resize must not clear terminal scrollback
1 !== 0
```
This captured one emitted `ESC[3J` (`countOccurrences = 1`) from the ConPTY/darwin-non-tmux seam.

## GREEN output
```text
✔ does not clear scrollback when a non-multiplexer Windows terminal is resized
✔ keeps clearing scrollback for non-Windows non-multiplexer resizes
✔ emits a screen clear without clearing scrollback when width changes inside a multiplexer
✔ repaints height changes inside a multiplexer without screen or scrollback clears

11 tests
pass 11
fail 0
```

Complete `packages/tui` test run: all tests passed.

## Verification commands
```sh
cd packages/tui
npm test -- --test-name-pattern="does not clear scrollback when a non-multiplexer terminal is resized"
npm test
npm run build
cd ../..
npx biome check packages/tui/src/tui.ts packages/tui/test/mux-scrollback.test.ts
git diff --check
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scrollback being cleared on Windows terminals when the TUI redraws after a resize. The resize-driven full redraw emitted `ESC[3J` on Windows (ConPTY), deleting the user's scrollback buffer; that escape sequence is now suppressed on Windows while keeping the existing screen clear and home behavior. Non-Windows and multiplexer redraws are unchanged.

<sup>Written for commit 0a2a99ac971898e6016a2fac7b64e48ed1ee266f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

