### PR TITLE
fix(todotools): apply empty native todo lists (#1146)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Native todo lists with an explicit empty `todos: []` payload now clear persisted todo state and remove the `todo-sidebar`, while absent payloads remain ignored and lists with pending work remain visible.
 - Bash output spill files now capture early `EDQUOT`/`ENOSPC` stream errors and late filesystem
   close failures, waiting for the stream's terminal `close` event and failing only the tool call
   instead of returning an incomplete path or terminating the interactive session through

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/changes.md
@@ -6,6 +6,27 @@ Cursor resolves `todo` on the server and never runs local `execute()`, so the wi
 
 Conflict zone: `todotools/index.ts` `message_end`.
 
+## 2026-08-27 - Apply explicit empty native todo lists
+
+### What changed
+
+- The native todo mirror now distinguishes an absent `todos` payload from an explicitly empty array.
+- Empty native lists are persisted and synced, allowing the `todo-sidebar` widget to be removed.
+- Fully terminal native lists remain hidden while lists with pending work remain visible.
+
+### Why
+
+The `message_end` mirror previously skipped every empty result, so a native `todos: []` call could not clear stale persisted state or remove the widget.
+
+### Source
+
+- Fork-local fix for issue #1146.
+- Regression coverage is in `test/suite/regressions/991-cursor-native-todo-mirror.test.ts`.
+
+### Expected merge conflict zones
+
+- LOW: `todotools/index.ts` and `native-todo-mirror.ts` around native todo mirroring.
+
 ## 2026-07-31 - Animate same-phase completions in the todo sidebar
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/index.ts
@@ -57,7 +57,7 @@ export default function todotoolsExtension(pi: ExtensionAPI): void {
 				continue;
 			}
 			const phases = phasesFromCursorTodos(block.arguments?.todos);
-			if (phases.length === 0) {
+			if (phases === undefined) {
 				continue;
 			}
 			setCurrentPhases(phases);

--- a/packages/coding-agent/src/core/extensions/builtin/todotools/native-todo-mirror.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/todotools/native-todo-mirror.ts
@@ -3,9 +3,9 @@ import type { TodoPhase, TodoStatus } from "./todo-types.ts";
 const STATUSES = new Set<TodoStatus>(["pending", "in_progress", "completed", "abandoned"]);
 const DEFAULT_PHASE_NAME = "Tasks";
 
-export function phasesFromCursorTodos(todos: unknown): TodoPhase[] {
+export function phasesFromCursorTodos(todos: unknown): TodoPhase[] | undefined {
 	if (!Array.isArray(todos)) {
-		return [];
+		return undefined;
 	}
 	const tasks = [];
 	for (const item of todos) {

--- a/packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts
+++ b/packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts
@@ -1,7 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { phasesFromCursorTodos } from "../../../src/core/extensions/builtin/todotools/native-todo-mirror.ts";
+import { getTodoWidgetLines } from "../../../src/core/extensions/builtin/todotools/todo-widget.ts";
 
 describe("phasesFromCursorTodos", () => {
+	it("distinguishes an absent native todo payload from an explicitly empty list", () => {
+		expect(phasesFromCursorTodos(undefined)).toBeUndefined();
+		expect(phasesFromCursorTodos([])).toEqual([]);
+	});
+
+	it("removes the widget for an empty or fully terminal native list while keeping pending work visible", () => {
+		expect(getTodoWidgetLines(phasesFromCursorTodos([]) ?? [])).toBeUndefined();
+		expect(
+			getTodoWidgetLines(
+				phasesFromCursorTodos([
+					{ content: "build", status: "completed" },
+					{ content: "drop", status: "abandoned" },
+				]) ?? [],
+			),
+		).toBeUndefined();
+		expect(
+			getTodoWidgetLines(phasesFromCursorTodos([{ content: "build", status: "pending" }]) ?? []),
+		).toBeDefined();
+	});
+
 	it("turns native Cursor todos into one Tasks phase", () => {
 		expect(
 			phasesFromCursorTodos([


### PR DESCRIPTION
## Root cause

The native todo mirror returned `[]` both when no native `todos` payload was present and when the payload was explicitly `todos: []`. The `message_end` handler treated any empty result as "no update" and skipped persistence/widget synchronization, leaving stale todo state and the sidebar visible.

The fix makes `phasesFromCursorTodos` return `undefined` only for an absent/non-array payload. An explicit empty array still returns `[]`, so it is persisted and passed to widget sync. The existing widget model already hides empty and fully terminal (`completed`/`abandoned`) lists; pending work remains visible.

## RED proof (before fix)

Command:

```text
npx vitest run packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts
```

Output:

```text
❯ packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts (2 tests | 1 failed) 4ms
× distinguishes an absent native todo payload from an explicitly empty list 3ms
AssertionError: expected [] to be undefined
- Expected: undefined
+ Received: []
Test Files  1 failed (1)
Tests  1 failed | 1 passed (2)
```

This fails on the intended pre-fix behavior: an absent payload was indistinguishable from an explicit empty list.

## GREEN proof

Command:

```text
npx vitest run packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts
```

Output:

```text
Test Files  1 passed (1)
Tests  3 passed (3)
```

Targeted todo scope:

```text
npm --prefix packages/coding-agent test -- test/suite/regressions/991-cursor-native-todo-mirror.test.ts test/suite/todo-widget.test.ts test/suite/todo-extension.test.ts
```

Output:

```text
Test Files  3 passed (3)
Tests  37 passed (37)
```

## Verification commands

- `npx vitest run packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts`
- `npm --prefix packages/coding-agent test -- test/suite/regressions/991-cursor-native-todo-mirror.test.ts test/suite/todo-widget.test.ts test/suite/todo-extension.test.ts`
- `npm run build:npm`
- `npm run check:ts-imports`
- `git diff --check`
- LSP diagnostics on changed TypeScript files: no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the todo sidebar not clearing when a native Cursor call explicitly sends an empty `todos` array. The mirror now returns `undefined` only for a missing payload, so empty lists are persisted and passed to widget sync, which already hides empty or fully completed lists. This lets the widget be removed when appropriate. Added regression tests verifying the distinction and widget behavior, and documented the fix in the changelog.

<sup>Written for commit 266ea9008205ce1311b20da9e31c92ce56666c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

