### PR TITLE
fix(codemode): name idle kernels in detached-eval busy errors

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Detached-eval same-language busy errors now name each idle enabled kernel and tell the agent to continue the step there (`continue this step in an idle kernel: js`), instead of only pointing at peek and the output tail. A busy Python kernel no longer reads as "eval is unavailable", which previously sent agents to `bash`+`python3` while JavaScript (or another idle kernel) was free. Single-language sessions and fully-busy sessions omit the idle-kernel claim.
+
 ### Removed
 
 ## [2026.8.26-2] - 2026-08-26

--- a/packages/senpi-codemode/src/tool/detached-eval-result.ts
+++ b/packages/senpi-codemode/src/tool/detached-eval-result.ts
@@ -5,7 +5,7 @@ import type {
 	EvalDetachedCellState,
 } from "./detached-cell-manager.ts";
 import { interruptionStateNote } from "./interrupt-note.ts";
-import type { EvalCellResult, EvalControlInput, EvalToolDetails, EvalToolInput } from "./types.ts";
+import type { EvalCellResult, EvalControlInput, EvalLanguage, EvalToolDetails, EvalToolInput } from "./types.ts";
 
 export async function executeEvalControl(
 	cellManager: EvalDetachedCellManager,
@@ -101,10 +101,16 @@ export function resultForDetachedState(
 	};
 }
 
-export function detachedKernelBusyError(snapshot: EvalDetachedCellSnapshot): Error {
+export function detachedKernelBusyError(
+	snapshot: EvalDetachedCellSnapshot,
+	idleLanguages: readonly EvalLanguage[] = [],
+): Error {
 	const tail = snapshot.outputTail.length === 0 ? "(no output yet)" : snapshot.outputTail;
+	const peek = `eval({ action: "peek", cell_id: "${snapshot.cellId}" })`;
+	const idleHint =
+		idleLanguages.length === 0 ? "" : ` or continue this step in an idle kernel: ${idleLanguages.join(", ")}`;
 	return new Error(
-		`The ${snapshot.language} eval kernel is busy running detached cell ${snapshot.cellId}. Do not re-run it; use eval({ action: "peek", cell_id: "${snapshot.cellId}" }). Current output tail:\n${tail}`,
+		`The ${snapshot.language} eval kernel is busy running detached cell ${snapshot.cellId} - peek with ${peek}${idleHint}. Do not re-run the busy cell. Current output tail:\n${tail}`,
 	);
 }
 

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -67,7 +67,12 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 					`Unsupported eval language "${request.language}". Enabled languages: ${languages.join(", ")}`,
 				);
 			const busy = cellManager.busyFor(request.language);
-			if (busy !== undefined) throw detachedKernelBusyError(busy);
+			if (busy !== undefined) {
+				const idleLanguages = languages.filter(
+					(language) => language !== request.language && cellManager.busyFor(language) === undefined,
+				);
+				throw detachedKernelBusyError(busy, idleLanguages);
+			}
 			options.executionTracker?.assertEvalExecutionAllowed();
 			const lifecycleController = new AbortController();
 			const combinedSignal = signal

--- a/packages/senpi-codemode/test/eval-detach.test.ts
+++ b/packages/senpi-codemode/test/eval-detach.test.ts
@@ -7,9 +7,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	EvalDetachedCellManager,
 	type EvalDetachedCellNotification,
+	type EvalDetachedCellSnapshot,
 	type EvalDetachedCellStatusEntry,
 } from "../src/tool/detached-cell-manager.ts";
+import { detachedKernelBusyError } from "../src/tool/detached-eval-result.ts";
 import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { EnabledEvalLanguages, EvalLanguage } from "../src/tool/types.ts";
 import { errorResult, FakeKernel, FakeManager, fakeExtensionContext, result } from "./eval/fakes.ts";
 
 type TextContent = Extract<AgentToolResult<unknown>["content"][number], { type: "text" }>;
@@ -458,6 +461,187 @@ describe("eval detached cell status emissions", () => {
 			[{ cellId: "untitled-cell", language: "js", summary: "untitled detached", startedAtMs: expect.any(Number) }],
 		]);
 		await manager.stop("untitled-cell");
+		await manager.flushNotifications();
+	});
+});
+
+describe("detachedKernelBusyError", () => {
+	const snapshot = {
+		cellId: "cell-9",
+		language: "py",
+		state: "detached",
+		outputTail: "still going",
+		result: { content: [], details: { language: "py", durationMs: 0, toolCalls: [], truncated: false } },
+		stateRetained: undefined,
+	} as const satisfies EvalDetachedCellSnapshot;
+
+	it("names each idle kernel and keeps busy language, cell id, peek, do-not-re-run, and output tail", () => {
+		const message = detachedKernelBusyError(snapshot, ["js", "rb"]).message;
+		expect(message).toBe(
+			'The py eval kernel is busy running detached cell cell-9 - peek with eval({ action: "peek", cell_id: "cell-9" }) or continue this step in an idle kernel: js, rb. Do not re-run the busy cell. Current output tail:\nstill going',
+		);
+	});
+
+	it("omits any idle-kernel claim when no other language is free", () => {
+		const message = detachedKernelBusyError(snapshot, []).message;
+		expect(message).not.toMatch(/idle kernel/iu);
+		expect(message).toContain("The py eval kernel is busy running detached cell cell-9");
+		expect(message).toContain('eval({ action: "peek", cell_id: "cell-9" })');
+		expect(message).toMatch(/Do not re-run/u);
+		expect(message).toContain("still going");
+	});
+});
+
+describe("eval detached kernel busy error idle-kernel hint", () => {
+	function createBusyTool(
+		manager: EvalDetachedCellManager,
+		entries: Array<readonly [string, FakeKernel]>,
+		enabledLanguages: EnabledEvalLanguages,
+	) {
+		return createEvalTool({
+			enabledLanguages,
+			kernelManager: new FakeManager(entries),
+			cellTimeoutSeconds: 1,
+			executeTool: vi.fn(),
+			cellManager: manager,
+		});
+	}
+
+	async function detachLanguage(
+		tool: ReturnType<typeof createBusyTool>,
+		kernel: FakeKernel,
+		cellId: string,
+		language: EvalLanguage,
+	): Promise<void> {
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			cellId,
+			{ language, code: "await forever", summary: `detach ${language}`, on_timeout: "detach" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		await vi.advanceTimersByTimeAsync(1_000);
+		await execution;
+	}
+
+	async function busyMessage(
+		tool: ReturnType<typeof createBusyTool>,
+		cellId: string,
+		language: EvalLanguage,
+	): Promise<string> {
+		const rejection = await tool
+			.execute(
+				cellId,
+				{ language, code: "sideEffect()", summary: `blocked ${language}` },
+				undefined,
+				undefined,
+				interactiveContext(),
+			)
+			.then(
+				() => undefined,
+				(error: unknown) => error,
+			);
+		expect(rejection).toBeInstanceOf(Error);
+		return (rejection as Error).message;
+	}
+
+	function idleSection(message: string): string | undefined {
+		const match = /idle kernel:\s*([^.]*)/u.exec(message);
+		return match?.[1]?.trim();
+	}
+
+	it("names each idle enabled kernel when only one language is busy", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const py = new FakeKernel([{ type: "text", stream: "stdout", data: "py still computing\n" }]);
+		const tool = createBusyTool(
+			manager,
+			[
+				["py", py],
+				["js", new FakeKernel([])],
+				["rb", new FakeKernel([])],
+			],
+			{ js: true, py: true, rb: true, jl: false },
+		);
+
+		await detachLanguage(tool, py, "busy-py", "py");
+		const message = await busyMessage(tool, "blocked-py", "py");
+
+		expect(message).toContain("The py eval kernel is busy running detached cell busy-py");
+		expect(message).toContain('eval({ action: "peek", cell_id: "busy-py" })');
+		expect(message).toMatch(/Do not re-run/u);
+		expect(message).toContain("py still computing");
+		const idle = idleSection(message);
+		expect(idle).toBeDefined();
+		expect(idle).toContain("js");
+		expect(idle).toContain("rb");
+		expect(idle).not.toContain("py");
+		expect(message).toMatch(/continue this step in an idle kernel/u);
+
+		await manager.stop("busy-py");
+		await manager.flushNotifications();
+	});
+
+	it("omits any idle-kernel claim when only one language is enabled", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const js = new FakeKernel([{ type: "text", stream: "stdout", data: "js still computing\n" }]);
+		const tool = createBusyTool(manager, [["js", js]], { js: true, py: false, rb: false, jl: false });
+
+		await detachLanguage(tool, js, "busy-js", "js");
+		const message = await busyMessage(tool, "blocked-js", "js");
+
+		expect(message).toContain("The js eval kernel is busy running detached cell busy-js");
+		expect(message).toContain('eval({ action: "peek", cell_id: "busy-js" })');
+		expect(message).toMatch(/Do not re-run/u);
+		expect(message).toContain("js still computing");
+		expect(message).not.toMatch(/idle kernel/iu);
+
+		await manager.stop("busy-js");
+		await manager.flushNotifications();
+	});
+
+	it("names only remaining idle kernels when several languages are busy, and omits the claim when none are idle", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const js = new FakeKernel([{ type: "text", stream: "stdout", data: "js still computing\n" }]);
+		const py = new FakeKernel([{ type: "text", stream: "stdout", data: "py still computing\n" }]);
+		const rb = new FakeKernel([{ type: "text", stream: "stdout", data: "rb still computing\n" }]);
+		const tool = createBusyTool(
+			manager,
+			[
+				["js", js],
+				["py", py],
+				["rb", rb],
+			],
+			{ js: true, py: true, rb: true, jl: false },
+		);
+
+		await detachLanguage(tool, js, "busy-js", "js");
+		await detachLanguage(tool, py, "busy-py", "py");
+
+		const jsWhileRbIdle = await busyMessage(tool, "blocked-js", "js");
+		expect(jsWhileRbIdle).toContain("The js eval kernel is busy running detached cell busy-js");
+		expect(jsWhileRbIdle).toContain('eval({ action: "peek", cell_id: "busy-js" })');
+		expect(jsWhileRbIdle).toMatch(/Do not re-run/u);
+		expect(jsWhileRbIdle).toContain("js still computing");
+		expect(idleSection(jsWhileRbIdle)).toBe("rb");
+
+		const pyWhileRbIdle = await busyMessage(tool, "blocked-py", "py");
+		expect(idleSection(pyWhileRbIdle)).toBe("rb");
+		expect(pyWhileRbIdle).toContain("py still computing");
+
+		await detachLanguage(tool, rb, "busy-rb", "rb");
+		const jsWhenNoneIdle = await busyMessage(tool, "blocked-js-again", "js");
+		expect(jsWhenNoneIdle).not.toMatch(/idle kernel/iu);
+		expect(jsWhenNoneIdle).toContain("The js eval kernel is busy running detached cell busy-js");
+		expect(jsWhenNoneIdle).toContain("js still computing");
+
+		await manager.stop("busy-js");
+		await manager.stop("busy-py");
+		await manager.stop("busy-rb");
 		await manager.flushNotifications();
 	});
 });


### PR DESCRIPTION
## Summary

A detached Python eval cell kept its kernel busy, but the same-language busy error never named idle kernels. Agents treated eval as unavailable and fell back to `bash`+`python3` instead of continuing the step in JavaScript (or another free kernel).

`detachedKernelBusyError` now takes the idle enabled-language list from the eval throw site. With at least one idle kernel it becomes one string of the form:

`The py eval kernel is busy running detached cell <id> - peek with eval({ action: "peek", cell_id: "<id>" }) or continue this step in an idle kernel: js. Do not re-run the busy cell. Current output tail: …`

Single-language sessions and fully-busy sessions omit the idle-kernel claim. Peek, do-not-re-run, busy language, cell id, and output tail stay in the message.

## RED proof (before change)

Command:

```text
cd packages/senpi-codemode && npx tsx ../../node_modules/vitest/dist/cli.js --run test/eval-detach.test.ts
```

Output:

```text
FAIL  test/eval-detach.test.ts > detachedKernelBusyError > names each idle kernel and keeps busy language, cell id, peek, do-not-re-run, and output tail
- The py eval kernel is busy running detached cell cell-9 - peek with eval({ action: "peek", cell_id: "cell-9" }) or continue this step in an idle kernel: js, rb. Do not re-run the busy cell. Current output tail:
+ The py eval kernel is busy running detached cell cell-9. Do not re-run it; use eval({ action: "peek", cell_id: "cell-9" }). Current output tail:

FAIL  test/eval-detach.test.ts > eval detached kernel busy error idle-kernel hint > names each idle enabled kernel when only one language is busy
AssertionError: expected undefined to be defined

FAIL  test/eval-detach.test.ts > eval detached kernel busy error idle-kernel hint > names only remaining idle kernels when several languages are busy, and omits the claim when none are idle
AssertionError: expected undefined to be 'rb'

Test Files  1 failed (1)
Tests  3 failed | 14 passed (17)
```

## GREEN proof

Command:

```text
cd packages/senpi-codemode && npm test
```

Output:

```text
Test Files  91 passed | 1 skipped (92)
Tests  627 passed | 6 skipped (633)
```

## Verification

- `cd packages/senpi-codemode && npm test` — 627 passed, 6 skipped
- Pre-commit `npm run check` (biome, pinned deps, ts imports, shrinkwrap, tsc) passed
- Prompt copy (`src/prompt/*`) and kernels (`src/kernels/*`) left for other lanes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detached-eval same-language busy errors now name each idle enabled kernel and tell the agent to continue the step there (`continue this step in an idle kernel: js`), instead of only pointing to peek and the output tail. This stops agents from falling back to `bash`+`python3` when another eval language is idle. Single-language sessions and fully-busy sessions omit the idle-kernel claim.

<sup>Written for commit cab35fe9fb22f6e714a09ee83dfcf59d6d41c370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

