### PR TITLE
feat(codemode): teach js-first eval examples with batched fan-out

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Eval tool description examples are now a JS-first mixed set: set up once in JavaScript, fan out batched `Promise.all` session-tool calls in the next cell, then hop to Python when the JS kernel is busy with a detached cell. The detach paragraph now states in the same sentence that another language can continue.
+
 ### Fixed
 
 - Detached-eval same-language busy errors now name each idle enabled kernel and tell the agent to continue the step there (`continue this step in an idle kernel: js`), instead of only pointing at peek and the output tail. A busy Python kernel no longer reads as "eval is unavailable", which previously sent agents to `bash`+`python3` while JavaScript (or another idle kernel) was free. Single-language sessions and fully-busy sessions omit the idle-kernel claim.

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -70,21 +70,21 @@ type EvalPromptExample = {
 const REUSE_CHAIN_EXAMPLES = [
 	{
 		caption: "First call — set up once",
-		language: "py",
+		language: "js",
 		summary: "Count all TypeScript source files under src/ excluding tests",
-		code: "from pathlib import Path\nfrom collections import Counter\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\nprint(len(files))",
+		code: "import { readdir } from 'node:fs/promises'\nimport { extname } from 'node:path'\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\nprint(files.length)",
 	},
 	{
-		caption: "Second call — reuse `files`, batch-read in one cell",
-		language: "py",
-		summary: "Find which files reference legacyClient so we know what to migrate",
-		code: "hits = Counter()\nfor p in files:\n    hits[p.name] = read(p).count('legacyClient')\ndisplay({k: v for k, v in hits.items() if v})",
+		caption: "Second call — reuse `files`, fan out session tools in parallel",
+		language: "js",
+		summary: "Grep legacyClient per directory in one cell",
+		code: "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\ndisplay(hits.map(h => h.matches?.length ?? 0))",
 	},
 	{
-		caption: "Third call — reuse results, fan out session tools in parallel",
+		caption: "JS kernel is busy with a detached cell — continue in py",
 		language: "py",
-		summary: "Confirm exact callsite lines in each directory to plan the refactor",
-		code: "dirs = ['src/core', 'src/tools']\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))",
+		summary: "Aggregate legacyClient hits while JS is busy",
+		code: "from pathlib import Path\nprint(sum('legacyClient' in read(p) for p in Path('src').rglob('*.ts')))",
 	},
 ] as const satisfies readonly EvalPromptExample[];
 
@@ -129,7 +129,7 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 {{#if py}}Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".{{/if}}
 {{#if js}}JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.{{/if}}

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -25,7 +25,7 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
@@ -89,27 +89,27 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 ### First call — set up once
 \`\`\`json
 {
-  "language": "py",
+  "language": "js",
   "summary": "Count all TypeScript source files under src/ excluding tests",
-  "code": "from pathlib import Path\\nfrom collections import Counter\\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\\nprint(len(files))"
+  "code": "import { readdir } from 'node:fs/promises'\\nimport { extname } from 'node:path'\\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\\nprint(files.length)"
 }
 \`\`\`
 
-### Second call — reuse \`files\`, batch-read in one cell
+### Second call — reuse \`files\`, fan out session tools in parallel
 \`\`\`json
 {
-  "language": "py",
-  "summary": "Find which files reference legacyClient so we know what to migrate",
-  "code": "hits = Counter()\\nfor p in files:\\n    hits[p.name] = read(p).count('legacyClient')\\ndisplay({k: v for k, v in hits.items() if v})"
+  "language": "js",
+  "summary": "Grep legacyClient per directory in one cell",
+  "code": "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\\ndisplay(hits.map(h => h.matches?.length ?? 0))"
 }
 \`\`\`
 
-### Third call — reuse results, fan out session tools in parallel
+### JS kernel is busy with a detached cell — continue in py
 \`\`\`json
 {
   "language": "py",
-  "summary": "Confirm exact callsite lines in each directory to plan the refactor",
-  "code": "dirs = ['src/core', 'src/tools']\\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))"
+  "summary": "Aggregate legacyClient hits while JS is busy",
+  "code": "from pathlib import Path\\nprint(sum('legacyClient' in read(p) for p in Path('src').rglob('*.ts')))"
 }
 \`\`\`
 </examples>",
@@ -146,7 +146,7 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
@@ -188,7 +188,27 @@ phase(title) → None
 
 <critical>
 Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
-</critical>",
+</critical>
+
+<examples>
+### First call — set up once
+\`\`\`json
+{
+  "language": "js",
+  "summary": "Count all TypeScript source files under src/ excluding tests",
+  "code": "import { readdir } from 'node:fs/promises'\\nimport { extname } from 'node:path'\\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\\nprint(files.length)"
+}
+\`\`\`
+
+### Second call — reuse \`files\`, fan out session tools in parallel
+\`\`\`json
+{
+  "language": "js",
+  "summary": "Grep legacyClient per directory in one cell",
+  "code": "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\\ndisplay(hits.map(h => h.matches?.length ?? 0))"
+}
+\`\`\`
+</examples>",
   "promptGuidelines": [
     "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
     "Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
@@ -222,7 +242,7 @@ Fields:
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
-A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
@@ -271,27 +291,27 @@ Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into th
 ### First call — set up once
 \`\`\`json
 {
-  "language": "py",
+  "language": "js",
   "summary": "Count all TypeScript source files under src/ excluding tests",
-  "code": "from pathlib import Path\\nfrom collections import Counter\\nfiles = [p for p in Path('src').rglob('*.ts') if 'test' not in p.parts]\\nprint(len(files))"
+  "code": "import { readdir } from 'node:fs/promises'\\nimport { extname } from 'node:path'\\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\\nprint(files.length)"
 }
 \`\`\`
 
-### Second call — reuse \`files\`, batch-read in one cell
+### Second call — reuse \`files\`, fan out session tools in parallel
 \`\`\`json
 {
-  "language": "py",
-  "summary": "Find which files reference legacyClient so we know what to migrate",
-  "code": "hits = Counter()\\nfor p in files:\\n    hits[p.name] = read(p).count('legacyClient')\\ndisplay({k: v for k, v in hits.items() if v})"
+  "language": "js",
+  "summary": "Grep legacyClient per directory in one cell",
+  "code": "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\\ndisplay(hits.map(h => h.matches?.length ?? 0))"
 }
 \`\`\`
 
-### Third call — reuse results, fan out session tools in parallel
+### JS kernel is busy with a detached cell — continue in py
 \`\`\`json
 {
   "language": "py",
-  "summary": "Confirm exact callsite lines in each directory to plan the refactor",
-  "code": "dirs = ['src/core', 'src/tools']\\ndisplay(parallel([lambda d=d: tool.grep({'pattern': 'legacyClient', 'path': d}) for d in dirs]))"
+  "summary": "Aggregate legacyClient hits while JS is busy",
+  "code": "from pathlib import Path\\nprint(sum('legacyClient' in read(p) for p in Path('src').rglob('*.ts')))"
 }
 \`\`\`
 </examples>",

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -89,12 +89,12 @@ describe("buildEvalPrompt", () => {
 		const node = buildEvalPrompt({ py: false, js: true, rb: false, jl: false }, { spawns: false }).description;
 
 		// When: their embedded reuse-chain examples are rendered.
-		// Then: only Python kernels carry examples, and those teach batch + tool bridging.
-		expect(python).toContain("Count all TypeScript source files under src/ excluding tests");
-		expect(python).toContain("tool.grep");
-		expect(python).toContain("parallel([");
+		// Then: JS kernels carry the batched fan-out examples, Python kernels carry the kernel-hop example, and other languages have none.
+		expect(node).toContain("Count all TypeScript source files under src/ excluding tests");
+		expect(node).toContain("tool.grep");
+		expect(node).toContain("Promise.all");
+		expect(python).toContain("JS kernel is busy with a detached cell — continue in py");
 		expect(ruby).not.toContain("<examples>");
-		expect(node).not.toContain("<examples>");
 	});
 
 	it("documents core helpers with Node wording and no excluded surface", () => {


### PR DESCRIPTION
## Summary

Eval tool description examples were three Python cells. They now teach a JS-first mixed chain without adding sections, rules, or ALWAYS/NEVER lines, and without touching dialect machinery:

1. **JS set-up once** — import node builtins, collect `.ts` sources excluding tests, print the count.
2. **JS batched fan-out (load-bearing)** — reuse `files`, then `await Promise.all(dirs.map(d => tool.grep({ pattern, path: d })))` and display the distilled result in one cell.
3. **Python kernel-hop** — caption states the JS kernel is busy with a detached cell, so the step continues in py with a small equivalent aggregation.

The existing detach paragraph was reworded by moving the clause only: "another language can continue" now sits in the same sentence as the busy/detached-cell statement. No new sentences.

## Example-block size (must be ≤ 110%)

| Measure | Before | After | Ratio | 110% cap |
|---|---:|---:|---:|---:|
| `REUSE_CHAIN_EXAMPLES` source array | 1019 | 1085 | 106.5% | 1120 |
| Rendered `<examples>` block | 975 | 1041 | 106.8% | 1072 |
| Concatenated field values | 737 | 804 | 109.1% | 810 |

Prompt-surgery grep: eval-prompt.ts diff adds no section headers and no ALWAYS/NEVER lines. NEVER count stays 5.

## Snapshot diff summary

`test/__snapshots__/prompt.test.ts.snap` (3 variants: all-with-spawns, js-without-spawns, js-py-without-spawns) changes **only**:

- The reworded detach sentence in every variant.
- The three example objects (js / js / py). js-without-spawns newly *includes* the two JS examples (previously empty because every example was `py`).

No dialect-block, helper, or guideline drift.

## RED proof (before snapshot update)

Command:

```text
cd packages/senpi-codemode && npm test
```

Output:

```text
FAIL  test/prompt.test.ts > buildEvalPrompt > renders the js without spawns prompt
FAIL  test/prompt.test.ts > buildEvalPrompt > renders the js-py without spawns prompt
FAIL  test/prompt.test.ts > buildEvalPrompt > renders the all with spawns prompt
Error: Snapshot `buildEvalPrompt > renders the js without spawns prompt 1` mismatched
- A detached cell keeps its language kernel busy while it finishes. Do not re-run a detached cell: the same-language busy error names its cell id and output tail; another language can continue.
+ A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail.
Snapshots  3 failed
```

## GREEN proof

Command:

```text
cd packages/senpi-codemode && npm test
```

Output:

```text
Test Files  92 passed | 1 skipped (93)
Tests  636 passed | 6 skipped (642)
```

## Verification

- `cd packages/senpi-codemode && npm test` — 636 passed, 6 skipped
- `npx biome check` on changed TypeScript files — clean
- `git diff --check` — clean
- Prompt surgery: zero new sections, zero ALWAYS/NEVER additions, dialect machinery untouched

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the eval tool description examples from three Python cells to a JS-first mixed chain: set up once in JavaScript, fan out batched `Promise.all` session-tool calls in one cell, then drop to Python when the JS kernel is busy with a detached cell. The detach paragraph now states that another language can continue in the same sentence. No new sections, rules, or ALWAYS/NEVER lines were added, and dialect machinery is untouched.

<sup>Written for commit 3979bbe56fda4e86e5cfe8ee1e35b84dbf3b7ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

