### PR TITLE
feat(ai): credential pool engine — HRW selection, failure taxonomy, slot failover, slot-scoped resolution

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- Credential pool engine under `@earendil-works/pi-ai/auth/pool/*`: HRW slot selection with an injected hasher (`select`), a three-way in-lane failure taxonomy (`classify`), and a slot failover runner (`failover`) that rotates accounts only before committed output and marks post-output failures with the turn-retry suppression prefix.
+- `AuthResolutionOverrides.slotName` resolves provider auth against one named credential slot, refreshing exactly that slot under the store lock while siblings and the flat downgrade projection stay untouched.
+
 ### Changed
 
 ### Fixed

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,5 +1,23 @@
 # changes.md — ai
 
+## Credential pool export wildcard (2026-08-27)
+
+### What changed
+
+- `packages/ai/package.json`: the `./auth/pool/slots` export entry became the wildcard `./auth/pool/*` so the new `select`, `classify`, and `failover` pool modules resolve through the package export map alongside `slots`.
+
+### Why
+
+- The credential pool engine ships as separate browser-safe modules; consumers (including `packages/coding-agent`) import them by subpath.
+
+### Why an extension could not handle it
+
+- Package export maps are packaging surface owned by the package itself.
+
+### Expected merge conflict zones
+
+- LOW: one wildcard line in the `exports` map.
+
 ## @anthropic-ai/sdk peer alignment (2026-08-26)
 
 ### What changed

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -31,9 +31,9 @@
 			"types": "./dist/oauth.d.ts",
 			"import": "./dist/oauth.js"
 		},
-		"./auth/pool/slots": {
-			"types": "./dist/auth/pool/slots.d.ts",
-			"import": "./dist/auth/pool/slots.js"
+		"./auth/pool/*": {
+			"types": "./dist/auth/pool/*.d.ts",
+			"import": "./dist/auth/pool/*.js"
 		},
 		"./bedrock-provider": {
 			"types": "./dist/bedrock-provider.d.ts",

--- a/packages/ai/src/auth/pool/classify.ts
+++ b/packages/ai/src/auth/pool/classify.ts
@@ -1,0 +1,77 @@
+export type PoolFailureAction = "rotate" | "retry" | "fail";
+
+export type PoolBlockReason = "auth_error" | "rate_limit";
+
+export type PoolFailureClassification = {
+	action: PoolFailureAction;
+	blockReason?: PoolBlockReason;
+	retryAfterMs?: number;
+};
+
+const MAX_NESTING_DEPTH = 3;
+
+function fieldOf(value: unknown, key: string): unknown {
+	if (typeof value !== "object" || value === null) return undefined;
+	const entry = Object.entries(value).find(([candidate]) => candidate === key);
+	return entry?.[1];
+}
+
+function statusOf(error: unknown, depth = 0): number | undefined {
+	if (depth >= MAX_NESTING_DEPTH) return undefined;
+	for (const key of ["status", "statusCode"]) {
+		const value = fieldOf(error, key);
+		if (typeof value === "number") return value;
+	}
+	const nested = fieldOf(error, "error");
+	return nested === undefined ? undefined : statusOf(nested, depth + 1);
+}
+
+function messageOf(error: unknown, depth = 0): string {
+	if (typeof error === "string") return error;
+	if (error instanceof Error) return error.message;
+	if (depth >= MAX_NESTING_DEPTH) return String(error);
+	const message = fieldOf(error, "message");
+	if (typeof message === "string") return message;
+	const nested = fieldOf(error, "error");
+	return nested === undefined ? String(error) : messageOf(nested, depth + 1);
+}
+
+function retryAfterMsOf(error: unknown, text: string): number | undefined {
+	const explicit = fieldOf(error, "retryAfterMs");
+	if (typeof explicit === "number" && Number.isFinite(explicit) && explicit > 0) return Math.ceil(explicit);
+	const milliseconds = text.match(/\bretry[-_ ]?after[-_ ]?ms\s*[:=]\s*(\d+(?:\.\d+)?)/i);
+	if (milliseconds?.[1] !== undefined) return Math.ceil(Number(milliseconds[1]));
+	const seconds = text.match(/\bretry[-_ ]?after\s*[:=]\s*(\d+(?:\.\d+)?)/i);
+	return seconds?.[1] === undefined ? undefined : Math.ceil(Number(seconds[1]) * 1_000);
+}
+
+const RATE_LIMIT_TEXT = /rate.?limit|resource_exhausted|quota|too many requests|overloaded/i;
+const AUTH_TEXT = /invalid.?api.?key|unauthorized|authentication|forbidden|token (?:is )?expired|revoked/i;
+const TRANSIENT_TEXT =
+	/econnreset|econnrefused|etimedout|socket hang up|fetch failed|network error|internal server error|service unavailable|bad gateway|gateway timeout/i;
+
+function rotateOnRateLimit(error: unknown, text: string): PoolFailureClassification {
+	const retryAfterMs = retryAfterMsOf(error, text);
+	return retryAfterMs === undefined
+		? { action: "rotate", blockReason: "rate_limit" }
+		: { action: "rotate", blockReason: "rate_limit", retryAfterMs };
+}
+
+/**
+ * Three-way in-lane failure taxonomy. Rotation is reserved for failures another
+ * account can plausibly absorb (rate/capacity and per-account auth); transient
+ * transport failures stay on the same slot for the outer retry policy, and
+ * everything unrecognized default-denies to `fail` so the model fallback chain
+ * above this engine keeps owning unknown errors.
+ */
+export function classifyPoolFailure(error: unknown): PoolFailureClassification {
+	const text = messageOf(error);
+	const status = statusOf(error);
+	if (status === 429 || status === 529) return rotateOnRateLimit(error, text);
+	if (status === 401 || status === 403) return { action: "rotate", blockReason: "auth_error" };
+	if (status !== undefined && status >= 500 && status < 600) return { action: "retry" };
+	if (RATE_LIMIT_TEXT.test(text)) return rotateOnRateLimit(error, text);
+	if (AUTH_TEXT.test(text)) return { action: "rotate", blockReason: "auth_error" };
+	if (TRANSIENT_TEXT.test(text)) return { action: "retry" };
+	return { action: "fail" };
+}

--- a/packages/ai/src/auth/pool/failover.ts
+++ b/packages/ai/src/auth/pool/failover.ts
@@ -1,0 +1,121 @@
+import { classifyPoolFailure, type PoolFailureClassification } from "./classify.ts";
+import type { SelectableSlot } from "./select.ts";
+
+/** Must stay byte-identical to the claude-sdk-oauth marker AgentSession already honors. */
+export const TURN_RETRY_SUPPRESSION_PREFIX = "senpi:no-turn-retry:";
+export const DEFAULT_SLOT_BLOCK_MS = 60_000;
+export const MAX_SLOT_BLOCK_MS = 48 * 60 * 60 * 1_000;
+
+export type PoolFailoverEvent<TSlot extends SelectableSlot> = {
+	slot: TSlot;
+	nextSlot?: TSlot;
+	classification: PoolFailureClassification;
+	attempt: number;
+	committedOutput: boolean;
+};
+
+export type PoolFailoverOptions<TEvent, TSlot extends SelectableSlot> = {
+	slots: readonly TSlot[];
+	select: (slots: readonly TSlot[]) => TSlot;
+	runAttempt: (slot: TSlot) => AsyncIterable<TEvent> | Promise<AsyncIterable<TEvent>>;
+	classify?: (error: unknown) => PoolFailureClassification;
+	/**
+	 * Rotation is transparent only before committed output. Absent, every yielded
+	 * event counts as committed (default-DENY), so silent mid-stream rotation
+	 * requires an explicit opt-in from a caller that knows which events are
+	 * bookkeeping rather than user-visible output.
+	 */
+	isCommittedOutput?: (event: TEvent) => boolean;
+	persistBlock?: (slot: TSlot) => void | Promise<void>;
+	onRotate?: (event: PoolFailoverEvent<TSlot>) => void | Promise<void>;
+	now?: () => number;
+	baseBlockMs?: number;
+};
+
+export class PoolFailoverError extends Error {
+	readonly classification: PoolFailureClassification;
+	readonly original: unknown;
+	readonly suppressTurnRetry: boolean;
+
+	constructor(classification: PoolFailureClassification, original: unknown, suppressTurnRetry: boolean) {
+		const detail = original instanceof Error ? original.message : String(original);
+		super(`${suppressTurnRetry ? TURN_RETRY_SUPPRESSION_PREFIX : ""}${detail}`);
+		this.name = "PoolFailoverError";
+		this.classification = classification;
+		this.original = original;
+		this.suppressTurnRetry = suppressTurnRetry;
+	}
+}
+
+function blockedSlot<TSlot extends SelectableSlot>(
+	slot: TSlot,
+	classification: PoolFailureClassification,
+	now: number,
+	attempt: number,
+	baseBlockMs: number,
+): TSlot {
+	if (classification.blockReason === "auth_error") {
+		// An auth block has no expiry: only a re-login rewrites the slot.
+		const next = { ...slot, blockReason: "auth_error" };
+		delete next.blockedUntil;
+		return next;
+	}
+	const fallback = Math.min(MAX_SLOT_BLOCK_MS, baseBlockMs * 2 ** attempt);
+	const duration = Math.min(MAX_SLOT_BLOCK_MS, classification.retryAfterMs ?? fallback);
+	return { ...slot, blockedUntil: now + duration, blockReason: "rate_limit" };
+}
+
+/**
+ * Runs at most one attempt per slot. A rotation is transparent only while no
+ * committed output has reached the caller; afterwards the classified error is
+ * thrown with the turn-retry suppression marker so the session layer never
+ * replays a partially delivered turn. Non-rotate classes throw immediately and
+ * compose with the retry/model-fallback machinery above this engine.
+ */
+export async function* runSlotFailover<TEvent, TSlot extends SelectableSlot>(
+	options: PoolFailoverOptions<TEvent, TSlot>,
+): AsyncGenerator<TEvent> {
+	const now = options.now ?? Date.now;
+	const classify = options.classify ?? classifyPoolFailure;
+	const committed = options.isCommittedOutput ?? (() => true);
+	const baseBlockMs = options.baseBlockMs ?? DEFAULT_SLOT_BLOCK_MS;
+	let slots = [...options.slots];
+	let lastError: PoolFailoverError | undefined;
+
+	for (let attempt = 0; attempt < options.slots.length; attempt++) {
+		const slot = options.select(slots);
+		let committedOutput = false;
+		try {
+			const attemptStream = await options.runAttempt(slot);
+			for await (const event of attemptStream) {
+				committedOutput ||= committed(event);
+				yield event;
+			}
+			return;
+		} catch (error) {
+			const classification = classify(error);
+			const failure = new PoolFailoverError(classification, error, committedOutput);
+			lastError = failure;
+			if (classification.action !== "rotate") throw failure;
+
+			const blocked = blockedSlot(slot, classification, now(), attempt, baseBlockMs);
+			slots = slots.map((candidate) => (candidate.name === blocked.name ? blocked : candidate));
+			await options.persistBlock?.(blocked);
+			const rotation: PoolFailoverEvent<TSlot> = {
+				slot: blocked,
+				classification,
+				attempt: attempt + 1,
+				committedOutput,
+			};
+			try {
+				if (!committedOutput && attempt + 1 < slots.length) {
+					rotation.nextSlot = options.select(slots);
+				}
+			} finally {
+				await options.onRotate?.(rotation);
+			}
+			if (committedOutput) throw failure;
+		}
+	}
+	throw lastError ?? new Error("Credential pool failover exhausted without an attempt");
+}

--- a/packages/ai/src/auth/pool/select.ts
+++ b/packages/ai/src/auth/pool/select.ts
@@ -1,0 +1,95 @@
+export type SlotHasher = (input: string) => bigint;
+
+export type SelectableSlot = {
+	name: string;
+	blockedUntil?: number;
+	blockReason?: string;
+};
+
+export const DEFAULT_POOL_AFFINITY_KEY = "credential-pool-default";
+
+export class AllSlotsBlockedError extends Error {
+	readonly soonestUnblockAt: number | undefined;
+
+	constructor(soonestUnblockAt: number | undefined) {
+		super(
+			soonestUnblockAt === undefined
+				? "All credential slots are blocked until re-login."
+				: `All credential slots are blocked until ${new Date(soonestUnblockAt).toISOString()}.`,
+		);
+		this.name = "AllSlotsBlockedError";
+		this.soonestUnblockAt = soonestUnblockAt;
+	}
+}
+
+export type SlotSelectionOptions = {
+	/** Injected so this module stays browser-safe; callers pick the hash (sha256 for oracle parity). */
+	hasher: SlotHasher;
+	affinityKey?: string;
+	sessionId?: string;
+	pinnedSlot?: string;
+	now?: number;
+};
+
+export function getPoolAffinityKey(options: Pick<SlotSelectionOptions, "affinityKey" | "sessionId">): string {
+	return options.affinityKey ?? options.sessionId ?? DEFAULT_POOL_AFFINITY_KEY;
+}
+
+/**
+ * HRW ordering hashes `key\0slot.name` exactly like the claude-sdk-oauth
+ * affinity oracle, so a sha256 hasher reproduces its winner sequence and no
+ * live session remaps when a pool migrates onto this engine.
+ */
+export function rendezvousOrder<T extends SelectableSlot>(key: string, slots: readonly T[], hasher: SlotHasher): T[] {
+	return [...slots]
+		.map((slot) => ({ slot, score: hasher(`${key}\0${slot.name}`) }))
+		.sort((left, right) => (right.score > left.score ? 1 : right.score < left.score ? -1 : 0))
+		.map(({ slot }) => slot);
+}
+
+function isBlocked(slot: SelectableSlot, now: number): boolean {
+	return slot.blockReason === "auth_error" || (slot.blockedUntil !== undefined && slot.blockedUntil > now);
+}
+
+/** Elapsed rate/capacity blocks clear; auth blocks persist until a login rewrites the slot. */
+export function clearExpiredSlotBlocks(slots: readonly SelectableSlot[], now = Date.now()): SelectableSlot[] {
+	return slots.map((slot) => {
+		if (slot.blockReason !== "auth_error" && slot.blockedUntil !== undefined && slot.blockedUntil <= now) {
+			const { blockedUntil: _blockedUntil, blockReason: _blockReason, ...available } = slot;
+			return available;
+		}
+		return slot;
+	});
+}
+
+function selectUnblocked<T extends SelectableSlot>(
+	slots: readonly T[],
+	options: SlotSelectionOptions,
+	now: number,
+): T | undefined {
+	const pinned = options.pinnedSlot === undefined ? undefined : slots.find((slot) => slot.name === options.pinnedSlot);
+	if (pinned && !isBlocked(pinned, now)) return pinned;
+	return rendezvousOrder(getPoolAffinityKey(options), slots, options.hasher).find((slot) => !isBlocked(slot, now));
+}
+
+function soonestUnblockAt(slots: readonly SelectableSlot[], now: number): number | undefined {
+	const candidates = slots
+		.map((slot) => slot.blockedUntil)
+		.filter((value): value is number => value !== undefined && value > now);
+	return candidates.length === 0 ? undefined : Math.min(...candidates);
+}
+
+/** Selects a pinned or HRW-ranked slot with no pool-global selection state. */
+export function selectSlot<T extends SelectableSlot>(slots: readonly T[], options: SlotSelectionOptions): T {
+	const now = options.now ?? Date.now();
+	const selected = selectUnblocked(slots, options, now);
+	if (selected) return selected;
+
+	// A stale persisted rate-limit entry must not dead-end the pool: retry once
+	// against the cleared view, then map the winner back to the caller's slot.
+	const cleared = clearExpiredSlotBlocks(slots, now);
+	const retried = selectUnblocked(cleared, { ...options, now }, now);
+	const original = retried === undefined ? undefined : slots.find((slot) => slot.name === retried.name);
+	if (original) return original;
+	throw new AllSlotsBlockedError(soonestUnblockAt(slots, now));
+}

--- a/packages/ai/src/auth/pool/slots.ts
+++ b/packages/ai/src/auth/pool/slots.ts
@@ -101,6 +101,23 @@ export function pinSlot(credential: PooledCredential, name: string): PooledCrede
 	return { ...credential, pinned: name };
 }
 
+/**
+ * Projects one named slot onto the flat credential shape for request-scoped
+ * resolution; pool bookkeeping fields are stripped so provider handlers see a
+ * plain credential and never write pool state back through the projection.
+ */
+export function projectSlot(credential: PooledCredential | undefined, name: string): Credential | undefined {
+	if (!credential) return undefined;
+	const slot = findSlot(credential, name);
+	if (!slot) return undefined;
+	const { accounts: _accounts, pinned: _pinned, ...flat } = credential;
+	if (flat.type === "oauth") {
+		if (slot.access === undefined || slot.refresh === undefined || slot.expires === undefined) return undefined;
+		return { ...flat, access: slot.access, refresh: slot.refresh, expires: slot.expires };
+	}
+	return { ...flat, key: slot.key };
+}
+
 function slotFromFlatCredentialNamed(credential: Credential, name: string): CredentialSlot {
 	if (credential.type === "oauth") {
 		return {
@@ -141,6 +158,22 @@ export function appendLoginSlot(current: PooledCredential | undefined, flat: Cre
  * flat fields, while every sibling and the pin survive byte-identical. A flat
  * current entry keeps today's whole-write shape.
  */
+/**
+ * Merges a rotated OAuth credential into the NAMED slot. The flat top-level
+ * projection rotates only when it mirrored that slot's previous material, so
+ * refreshing a secondary slot never disturbs what an older binary reads.
+ */
+export function mergeRefreshedSlot(current: PooledCredential, name: string, refreshed: Credential): Credential {
+	if (refreshed.type !== "oauth" || current.type !== "oauth") return current;
+	if (!Array.isArray(current.accounts) || current.accounts.length === 0) return mergeRefreshed(current, refreshed);
+	const target = current.accounts.find((slot) => slot.name === name);
+	if (!target) return current;
+	const rotated = { access: refreshed.access, refresh: refreshed.refresh, expires: refreshed.expires };
+	const accounts = current.accounts.map((slot) => (slot === target ? { ...slot, ...rotated } : slot));
+	const mirrorsFlat = target.access === current.access || target.refresh === current.refresh;
+	return mirrorsFlat ? { ...current, ...rotated, accounts } : { ...current, accounts };
+}
+
 export function mergeRefreshed(current: PooledCredential, refreshed: Credential): Credential {
 	if (!Array.isArray(current.accounts) || current.accounts.length === 0) {
 		return refreshed;

--- a/packages/ai/src/auth/resolve.ts
+++ b/packages/ai/src/auth/resolve.ts
@@ -1,7 +1,7 @@
 import type { ProviderEnv } from "../types.ts";
 import { operationSignal, raceWithAbortSignal } from "../utils/abort.ts";
 import { formatThrownValue } from "../utils/diagnostics.ts";
-import { mergeRefreshed } from "./pool/slots.ts";
+import { mergeRefreshed, mergeRefreshedSlot, projectSlot } from "./pool/slots.ts";
 import type {
 	ApiKeyAuth,
 	ApiKeyCredential,
@@ -21,6 +21,12 @@ export interface AuthResolutionOverrides {
 	env?: ProviderEnv;
 	/** Require this much remaining OAuth-token validity; defaults to five minutes. */
 	minOAuthValidityMs?: number;
+	/**
+	 * Resolve against one named slot of a pooled credential. A missing entry or
+	 * slot resolves to undefined rather than falling back to another account or
+	 * ambient env, so a slot-scoped request can never silently switch identities.
+	 */
+	slotName?: string;
 	signal?: AbortSignal;
 }
 
@@ -87,6 +93,29 @@ async function resolveProviderAuthWithSignal(
 	}
 
 	const stored = await readCredential(credentials, provider.id, signal);
+	const slotName = overrides?.slotName;
+	if (slotName !== undefined) {
+		const projected = stored === undefined ? undefined : projectSlot(stored, slotName);
+		if (!projected) return undefined;
+		if (projected.type === "oauth" && provider.auth.oauth) {
+			return resolveStoredOAuth(
+				credentials,
+				provider.id,
+				provider.auth.oauth,
+				projected,
+				requestAuthContext,
+				overrides?.env,
+				signal,
+				overrides?.minOAuthValidityMs,
+				slotName,
+			);
+		}
+		if (projected.type === "api_key" && provider.auth.apiKey) {
+			const credential = overrides?.env ? { ...projected, env: { ...projected.env, ...overrides.env } } : projected;
+			return resolveApiKey(requestAuthContext, provider.auth.apiKey, provider.id, credential, signal);
+		}
+		return undefined;
+	}
 	if (stored) {
 		if (stored.type === "oauth" && provider.auth.oauth) {
 			return resolveStoredOAuth(
@@ -142,6 +171,11 @@ const DEFAULT_OAUTH_REFRESH_TIMEOUT_MS = 15_000;
  * minutes remaining lock, re-check expiry under the lock, refresh once
  * globally, and persist the rotated credential before release.
  */
+function projectOAuthSlot(credential: OAuthCredential, name: string): OAuthCredential | undefined {
+	const projected = projectSlot(credential, name);
+	return projected?.type === "oauth" ? projected : undefined;
+}
+
 async function resolveStoredOAuth(
 	credentials: CredentialStore,
 	providerId: string,
@@ -151,6 +185,7 @@ async function resolveStoredOAuth(
 	requestEnv: ProviderEnv | undefined,
 	signal: AbortSignal,
 	minOAuthValidityMs?: number,
+	slotName?: string,
 ): Promise<AuthResult | undefined> {
 	const minimumValidityMs = Math.max(DEFAULT_OAUTH_MINIMUM_VALIDITY_MS, minOAuthValidityMs ?? 0);
 	const expiresSoon = (credential: OAuthCredential) => Date.now() + minimumValidityMs >= credential.expires;
@@ -164,14 +199,18 @@ async function resolveStoredOAuth(
 				providerId,
 				async (current) => {
 					if (current?.type !== "oauth") return undefined; // logged out meanwhile
-					if (!expiresSoon(current)) return undefined; // another process/request refreshed
+					const view = slotName === undefined ? current : projectOAuthSlot(current, slotName);
+					if (!view) return undefined; // slot removed meanwhile
+					if (!expiresSoon(view)) return undefined; // another process/request refreshed
 					try {
 						const refreshSignal = AbortSignal.any([
 							signal,
 							AbortSignal.timeout(DEFAULT_OAUTH_REFRESH_TIMEOUT_MS),
 						]);
-						const refreshed = await oauth.refresh(current, refreshSignal);
-						return mergeRefreshed(current, refreshed);
+						const refreshed = await oauth.refresh(view, refreshSignal);
+						return slotName === undefined
+							? mergeRefreshed(current, refreshed)
+							: mergeRefreshedSlot(current, slotName, refreshed);
 					} catch (error) {
 						throw new ModelsError("oauth", `OAuth refresh failed for ${providerId}`, { cause: error });
 					}
@@ -183,7 +222,9 @@ async function resolveStoredOAuth(
 			throw new ModelsError("auth", `Credential store modify failed for ${providerId}`, { cause: error });
 		}
 		if (post?.type !== "oauth") return undefined; // logged out meanwhile
-		credential = post;
+		const postView = slotName === undefined ? post : projectOAuthSlot(post, slotName);
+		if (!postView) return undefined; // slot removed meanwhile
+		credential = postView;
 		// The normal five-minute window triggers a refresh but does not impose a
 		// provider contract. Explicit callers (such as bearer-token export) do
 		// require the requested minimum after the refresh.

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,25 @@
+## 2026-08-27 - Credential pool engine: HRW selection, failure taxonomy, slot failover, slot-scoped resolution
+
+### What changed
+
+- `packages/ai/src/auth/pool/select.ts` (new): browser-safe HRW slot selection over an injected `SlotHasher` - `rendezvousOrder` hashes `key\0slot.name` exactly like the claude-sdk-oauth affinity oracle, `selectSlot` honors a pinned slot, skips blocked slots (auth blocks persist, elapsed rate blocks clear), and throws `AllSlotsBlockedError` with the soonest unblock time.
+- `packages/ai/src/auth/pool/classify.ts` (new): three-way in-lane failure taxonomy (`rotate`/`retry`/`fail`) with `retryAfterMs` extraction; unknown errors default-deny to `fail` so the model fallback chain keeps owning them.
+- `packages/ai/src/auth/pool/failover.ts` (new): `runSlotFailover` runs at most one attempt per slot, blocks failed slots (exponential rate-limit windows capped at 48h, expiry-free auth blocks), and reuses the `senpi:no-turn-retry:` suppression marker; `isCommittedOutput` is default-DENY, so absent an explicit bookkeeping filter any yielded event makes rotation non-transparent.
+- `packages/ai/src/auth/pool/slots.ts`: added `projectSlot` (named-slot flat projection with pool fields stripped) and `mergeRefreshedSlot` (named-slot refresh merge that rotates the flat downgrade projection only when it mirrored that slot).
+- `packages/ai/src/auth/resolve.ts`: `AuthResolutionOverrides.slotName` resolves one named slot of a pooled credential; a missing entry or slot resolves to undefined instead of falling back to another account or ambient env, and the locked OAuth refresh path refreshes exactly the named slot via `mergeRefreshedSlot`.
+
+### Why
+
+- Generic multi-credential rotation needs a provider-neutral engine: session-affine slot choice that provably never remaps existing claude-sdk-oauth sessions (golden-oracle test), failover that can rotate accounts mid-lane without replaying committed output, and an auth resolution path that can address a specific slot without disturbing siblings or the flat projection older binaries read.
+
+### Why an extension could not handle it
+
+- Slot-scoped resolution must run inside `resolveProviderAuth`'s locked OAuth refresh path, which is the cross-provider choke point in `packages/ai`; extensions cannot enter that lock or the credential-store modify transaction.
+
+### Expected merge conflict zones
+
+- LOW: `resolve.ts` stored-credential branch and the refresh modify callback; new pool files have no upstream counterpart.
+
 ## 2026-08-25 - Preserve same-model redacted thinking during message transforms
 
 ### What changed

--- a/packages/ai/test/credential-pool-classify.test.ts
+++ b/packages/ai/test/credential-pool-classify.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { classifyPoolFailure } from "../src/auth/pool/classify.ts";
+
+describe("credential pool failure classification", () => {
+	test.each([
+		[{ status: 429, message: "Too Many Requests" }, "rotate", "rate_limit"],
+		[new Error("rate limit exceeded, retry-after: 12"), "rotate", "rate_limit"],
+		[new Error("RESOURCE_EXHAUSTED: quota exceeded"), "rotate", "rate_limit"],
+		[{ status: 529, message: "overloaded" }, "rotate", "rate_limit"],
+		[new Error("Anthropic API error: overloaded_error"), "rotate", "rate_limit"],
+		[{ status: 401, message: "Unauthorized" }, "rotate", "auth_error"],
+		[{ status: 403, message: "Forbidden" }, "rotate", "auth_error"],
+		[new Error("invalid api key provided"), "rotate", "auth_error"],
+		[new Error("OAuth token expired or revoked"), "rotate", "auth_error"],
+	] as const)("%o classifies as %s/%s", (error, action, blockReason) => {
+		const classification = classifyPoolFailure(error);
+		expect(classification.action).toBe(action);
+		expect(classification.blockReason).toBe(blockReason);
+	});
+
+	test.each([
+		[{ status: 500, message: "Internal Server Error" }],
+		[{ status: 503, message: "Service Unavailable" }],
+		[new Error("fetch failed: ECONNRESET")],
+		[new Error("socket hang up")],
+	] as const)("%o classifies as retry with no block reason", (error) => {
+		const classification = classifyPoolFailure(error);
+		expect(classification.action).toBe("retry");
+		expect(classification.blockReason).toBeUndefined();
+	});
+
+	test("unknown failures default-deny to fail", () => {
+		const classification = classifyPoolFailure(new Error("model produced invalid tool arguments"));
+		expect(classification.action).toBe("fail");
+		expect(classification.blockReason).toBeUndefined();
+	});
+
+	test("retry-after hints surface in milliseconds", () => {
+		expect(classifyPoolFailure({ status: 429, message: "slow down", retryAfterMs: 2_500 }).retryAfterMs).toBe(2_500);
+		expect(classifyPoolFailure(new Error("429 rate limited, retry-after: 3")).retryAfterMs).toBe(3_000);
+		expect(classifyPoolFailure(new Error("429 rate limited, retry-after-ms: 450")).retryAfterMs).toBe(450);
+	});
+
+	test("nested provider error shapes are inspected", () => {
+		const classification = classifyPoolFailure({ error: { status: 429, message: "rate limited" } });
+		expect(classification.action).toBe("rotate");
+		expect(classification.blockReason).toBe("rate_limit");
+	});
+});

--- a/packages/ai/test/credential-pool-failover.test.ts
+++ b/packages/ai/test/credential-pool-failover.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "vitest";
+import {
+	PoolFailoverError,
+	type PoolFailoverEvent,
+	runSlotFailover,
+	TURN_RETRY_SUPPRESSION_PREFIX,
+} from "../src/auth/pool/failover.ts";
+import type { SelectableSlot } from "../src/auth/pool/select.ts";
+
+type Event = { type: string; text?: string };
+
+const NOW = 1_756_000_000_000;
+
+function firstUnblocked(slots: readonly SelectableSlot[]): SelectableSlot {
+	const found = slots.find((slot) => slot.blockedUntil === undefined && slot.blockReason === undefined);
+	if (!found) throw new Error("no unblocked slot");
+	return found;
+}
+
+async function* events(...items: Event[]): AsyncGenerator<Event> {
+	for (const item of items) yield item;
+}
+
+async function* failWith(error: unknown, ...items: Event[]): AsyncGenerator<Event> {
+	for (const item of items) yield item;
+	throw error;
+}
+
+async function collect(stream: AsyncGenerator<Event>): Promise<Event[]> {
+	const seen: Event[] = [];
+	for await (const event of stream) seen.push(event);
+	return seen;
+}
+
+describe("credential pool slot failover", () => {
+	test("a pre-output 429 rotates to the next slot and blocks the failed one", async () => {
+		const persisted: SelectableSlot[] = [];
+		const rotations: PoolFailoverEvent<SelectableSlot>[] = [];
+		const attempts: string[] = [];
+		const stream = runSlotFailover<Event, SelectableSlot>({
+			slots: [{ name: "alpha" }, { name: "beta" }],
+			select: firstUnblocked,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return slot.name === "alpha"
+					? failWith({ status: 429, message: "rate limited" })
+					: events({ type: "text_delta", text: "ok" });
+			},
+			persistBlock: (slot) => {
+				persisted.push(slot);
+			},
+			onRotate: (event) => {
+				rotations.push(event);
+			},
+			now: () => NOW,
+		});
+		const seen = await collect(stream);
+		expect(attempts).toEqual(["alpha", "beta"]);
+		expect(seen).toEqual([{ type: "text_delta", text: "ok" }]);
+		expect(persisted).toHaveLength(1);
+		expect(persisted[0]).toMatchObject({ name: "alpha", blockReason: "rate_limit" });
+		expect(persisted[0]?.blockedUntil).toBeGreaterThan(NOW);
+		expect(rotations[0]?.nextSlot?.name).toBe("beta");
+	});
+
+	test("default-DENY: any yielded event commits the turn and suppresses rotation", async () => {
+		const attempts: string[] = [];
+		const stream = runSlotFailover<Event, SelectableSlot>({
+			slots: [{ name: "alpha" }, { name: "beta" }],
+			select: firstUnblocked,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return failWith({ status: 429, message: "rate limited" }, { type: "unknown_frame" });
+			},
+			now: () => NOW,
+		});
+		const seen: Event[] = [];
+		let caught: unknown;
+		try {
+			for await (const event of stream) seen.push(event);
+		} catch (error) {
+			caught = error;
+		}
+		expect(attempts).toEqual(["alpha"]);
+		expect(seen).toEqual([{ type: "unknown_frame" }]);
+		expect(caught).toBeInstanceOf(PoolFailoverError);
+		expect((caught as PoolFailoverError).suppressTurnRetry).toBe(true);
+		expect((caught as PoolFailoverError).message.startsWith(TURN_RETRY_SUPPRESSION_PREFIX)).toBe(true);
+	});
+
+	test("an explicit isCommittedOutput keeps rotation transparent for bookkeeping events", async () => {
+		const attempts: string[] = [];
+		const stream = runSlotFailover<Event, SelectableSlot>({
+			slots: [{ name: "alpha" }, { name: "beta" }],
+			select: firstUnblocked,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return slot.name === "alpha"
+					? failWith({ status: 429, message: "rate limited" }, { type: "bookkeeping" })
+					: events({ type: "text_delta", text: "ok" });
+			},
+			isCommittedOutput: (event) => event.type === "text_delta",
+			now: () => NOW,
+		});
+		const seen = await collect(stream);
+		expect(attempts).toEqual(["alpha", "beta"]);
+		expect(seen).toEqual([{ type: "bookkeeping" }, { type: "text_delta", text: "ok" }]);
+	});
+
+	test("an auth failure blocks the slot without an expiry", async () => {
+		const persisted: SelectableSlot[] = [];
+		const stream = runSlotFailover<Event, SelectableSlot>({
+			slots: [{ name: "alpha" }, { name: "beta" }],
+			select: firstUnblocked,
+			runAttempt: (slot) =>
+				slot.name === "alpha"
+					? failWith({ status: 401, message: "unauthorized" })
+					: events({ type: "text_delta", text: "ok" }),
+			persistBlock: (slot) => {
+				persisted.push(slot);
+			},
+			now: () => NOW,
+		});
+		await collect(stream);
+		expect(persisted[0]).toMatchObject({ name: "alpha", blockReason: "auth_error" });
+		expect(persisted[0]?.blockedUntil).toBeUndefined();
+	});
+
+	test("a fail-class error throws immediately without trying siblings", async () => {
+		const attempts: string[] = [];
+		const stream = runSlotFailover<Event, SelectableSlot>({
+			slots: [{ name: "alpha" }, { name: "beta" }],
+			select: firstUnblocked,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return failWith(new Error("model produced invalid tool arguments"));
+			},
+			now: () => NOW,
+		});
+		await expect(collect(stream)).rejects.toBeInstanceOf(PoolFailoverError);
+		expect(attempts).toEqual(["alpha"]);
+	});
+
+	test("a retry-class error throws for the outer retry policy without rotation", async () => {
+		const attempts: string[] = [];
+		const stream = runSlotFailover<Event, SelectableSlot>({
+			slots: [{ name: "alpha" }, { name: "beta" }],
+			select: firstUnblocked,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return failWith({ status: 503, message: "service unavailable" });
+			},
+			now: () => NOW,
+		});
+		let caught: unknown;
+		try {
+			await collect(stream);
+		} catch (error) {
+			caught = error;
+		}
+		expect(attempts).toEqual(["alpha"]);
+		expect(caught).toBeInstanceOf(PoolFailoverError);
+		expect((caught as PoolFailoverError).classification.action).toBe("retry");
+		expect((caught as PoolFailoverError).suppressTurnRetry).toBe(false);
+	});
+
+	test("exhausting every slot rethrows the last rotate-class failure", async () => {
+		const stream = runSlotFailover<Event, SelectableSlot>({
+			slots: [{ name: "alpha" }, { name: "beta" }],
+			select: firstUnblocked,
+			runAttempt: () => failWith({ status: 429, message: "rate limited" }),
+			now: () => NOW,
+		});
+		let caught: unknown;
+		try {
+			await collect(stream);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(PoolFailoverError);
+		expect((caught as PoolFailoverError).classification.action).toBe("rotate");
+	});
+});

--- a/packages/ai/test/credential-pool-resolve-slot.test.ts
+++ b/packages/ai/test/credential-pool-resolve-slot.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "vitest";
+import { InMemoryCredentialStore } from "../src/auth/credential-store.ts";
+import { envApiKeyAuth } from "../src/auth/helpers.ts";
+import { listSlots, type PooledCredential } from "../src/auth/pool/slots.ts";
+import { resolveProviderAuth } from "../src/auth/resolve.ts";
+import type { OAuthCredential } from "../src/auth/types.ts";
+import { createProvider, type Provider } from "../src/models.ts";
+
+const authContext = { env: async () => undefined, fileExists: async () => false };
+
+function pooledApiKeyEntry(): PooledCredential {
+	return {
+		type: "api_key",
+		key: "primary-key",
+		accounts: [
+			{ name: "default", key: "primary-key", source: "login" },
+			{ name: "work", key: "work-key", source: "login" },
+		],
+	};
+}
+
+const apiKeyProvider: Provider = createProvider({
+	id: "slottest",
+	name: "Slot Test",
+	baseUrl: "https://slottest.example/v1",
+	auth: { apiKey: envApiKeyAuth("Slot Test API key", ["SLOTTEST_API_KEY"]) },
+	models: [],
+	api: "openai-responses" as never,
+});
+
+const FUTURE = 4_102_444_800_000;
+
+function pooledOAuthEntry(): PooledCredential {
+	return {
+		type: "oauth",
+		access: "default-access",
+		refresh: "r-default",
+		expires: FUTURE,
+		accounts: [
+			{ name: "default", access: "default-access", refresh: "r-default", expires: FUTURE, source: "login" },
+			{ name: "alt", access: "alt-access", refresh: "r-alt", expires: 1, source: "login" },
+		],
+	};
+}
+
+function oauthProvider(refreshed: (credential: OAuthCredential) => OAuthCredential): Provider {
+	return createProvider({
+		id: "slotoauth",
+		name: "Slot OAuth",
+		baseUrl: "https://slotoauth.example",
+		auth: {
+			apiKey: envApiKeyAuth("Slot OAuth API key", ["SLOTOAUTH_API_KEY"]),
+			oauth: {
+				name: "Slot OAuth",
+				login: async () => ({ type: "oauth", access: "a", refresh: "r", expires: FUTURE }),
+				refresh: async (credential: OAuthCredential) => refreshed(credential),
+				toAuth: async (credential) => ({ apiKey: credential.access }),
+			},
+		},
+		models: [],
+		api: "openai-responses" as never,
+	});
+}
+
+describe("slot-scoped auth resolution", () => {
+	test("slotName resolves the named api_key slot instead of the flat projection", async () => {
+		const store = new InMemoryCredentialStore();
+		await store.modify("slottest", async () => pooledApiKeyEntry());
+
+		const resolved = await resolveProviderAuth(apiKeyProvider, store, authContext, { slotName: "work" });
+
+		expect(resolved?.auth.apiKey).toBe("work-key");
+	});
+
+	test("an unknown slotName resolves to undefined instead of another account", async () => {
+		const store = new InMemoryCredentialStore();
+		await store.modify("slottest", async () => pooledApiKeyEntry());
+
+		const resolved = await resolveProviderAuth(apiKeyProvider, store, authContext, { slotName: "missing" });
+
+		expect(resolved).toBeUndefined();
+	});
+
+	test("slotName refreshes only the named oauth slot and leaves siblings byte-identical", async () => {
+		const store = new InMemoryCredentialStore();
+		await store.modify("slotoauth", async () => pooledOAuthEntry());
+		const refreshedFrom: string[] = [];
+		const provider = oauthProvider((credential) => {
+			refreshedFrom.push(credential.refresh);
+			return {
+				type: "oauth",
+				access: `refreshed-${credential.refresh}`,
+				refresh: `${credential.refresh}-next`,
+				expires: FUTURE,
+			};
+		});
+
+		const resolved = await resolveProviderAuth(provider, store, authContext, { slotName: "alt" });
+
+		expect(refreshedFrom).toEqual(["r-alt"]);
+		expect(resolved?.auth.apiKey).toBe("refreshed-r-alt");
+		const stored = (await store.read("slotoauth")) as PooledCredential;
+		expect(listSlots(stored).find((slot) => slot.name === "alt")).toMatchObject({
+			access: "refreshed-r-alt",
+			refresh: "r-alt-next",
+			expires: FUTURE,
+		});
+		expect(listSlots(stored).find((slot) => slot.name === "default")).toMatchObject({
+			access: "default-access",
+			refresh: "r-default",
+			expires: FUTURE,
+		});
+		expect(stored).toMatchObject({ access: "default-access", refresh: "r-default", expires: FUTURE });
+	});
+
+	test("refreshing the flat-mirrored slot by name also rotates the downgrade projection", async () => {
+		const store = new InMemoryCredentialStore();
+		await store.modify("slotoauth", async () => {
+			const entry = pooledOAuthEntry();
+			const accounts = entry.accounts?.map((slot) => (slot.name === "default" ? { ...slot, expires: 1 } : slot));
+			return { ...entry, expires: 1, accounts };
+		});
+		const provider = oauthProvider((credential) => ({
+			type: "oauth",
+			access: `refreshed-${credential.refresh}`,
+			refresh: `${credential.refresh}-next`,
+			expires: FUTURE,
+		}));
+
+		const resolved = await resolveProviderAuth(provider, store, authContext, { slotName: "default" });
+
+		expect(resolved?.auth.apiKey).toBe("refreshed-r-default");
+		const stored = (await store.read("slotoauth")) as PooledCredential;
+		expect(stored).toMatchObject({ access: "refreshed-r-default", refresh: "r-default-next", expires: FUTURE });
+		expect(listSlots(stored).find((slot) => slot.name === "alt")).toMatchObject({
+			access: "alt-access",
+			refresh: "r-alt",
+			expires: 1,
+		});
+	});
+});

--- a/packages/ai/test/credential-pool-select.test.ts
+++ b/packages/ai/test/credential-pool-select.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "vitest";
+import {
+	AllSlotsBlockedError,
+	clearExpiredSlotBlocks,
+	DEFAULT_POOL_AFFINITY_KEY,
+	getPoolAffinityKey,
+	rendezvousOrder,
+	type SelectableSlot,
+	type SlotHasher,
+	selectSlot,
+} from "../src/auth/pool/select.ts";
+
+/** Deterministic FNV-1a 64-bit hasher; select.ts itself must not hash. */
+const fnv1a64: SlotHasher = (input) => {
+	let hash = 0xcbf29ce484222325n;
+	for (let index = 0; index < input.length; index++) {
+		hash ^= BigInt(input.charCodeAt(index));
+		hash = (hash * 0x100000001b3n) & 0xffffffffffffffffn;
+	}
+	return hash;
+};
+
+const NOW = 1_756_000_000_000;
+
+function slots(...names: string[]): SelectableSlot[] {
+	return names.map((name) => ({ name }));
+}
+
+describe("credential pool affinity key", () => {
+	test("explicit affinityKey wins, sessionId is the fallback, then the default", () => {
+		expect(getPoolAffinityKey({ affinityKey: "k", sessionId: "s" })).toBe("k");
+		expect(getPoolAffinityKey({ sessionId: "s" })).toBe("s");
+		expect(getPoolAffinityKey({})).toBe(DEFAULT_POOL_AFFINITY_KEY);
+	});
+});
+
+describe("credential pool HRW ordering", () => {
+	test("ordering is deterministic for a fixed key and slot set", () => {
+		const pool = slots("alpha", "beta", "gamma", "delta");
+		const first = rendezvousOrder("session-1", pool, fnv1a64).map((slot) => slot.name);
+		const second = rendezvousOrder("session-1", pool, fnv1a64).map((slot) => slot.name);
+		expect(first).toEqual(second);
+		expect([...first].sort()).toEqual(["alpha", "beta", "delta", "gamma"]);
+	});
+
+	test("different keys can rendezvous with different winners", () => {
+		const pool = slots("alpha", "beta", "gamma", "delta", "epsilon");
+		const winners = new Set(
+			Array.from({ length: 64 }, (_, index) => rendezvousOrder(`key-${index}`, pool, fnv1a64)[0]?.name),
+		);
+		expect(winners.size).toBeGreaterThan(1);
+	});
+
+	test("removing a non-winning slot keeps the winner stable", () => {
+		const pool = slots("alpha", "beta", "gamma", "delta");
+		const winner = rendezvousOrder("stable-key", pool, fnv1a64)[0];
+		if (!winner) throw new Error("expected a winner");
+		const reduced = pool.filter((slot) => slot.name !== "delta" || winner.name === "delta");
+		expect(rendezvousOrder("stable-key", reduced, fnv1a64)[0]?.name).toBe(winner.name);
+	});
+});
+
+describe("credential pool slot selection", () => {
+	test("an unblocked pinned slot wins over HRW order", () => {
+		const pool = slots("alpha", "beta", "gamma");
+		const selected = selectSlot(pool, { hasher: fnv1a64, affinityKey: "k", pinnedSlot: "gamma", now: NOW });
+		expect(selected.name).toBe("gamma");
+	});
+
+	test("a blocked pinned slot falls back to the HRW winner", () => {
+		const pool: SelectableSlot[] = [
+			{ name: "alpha" },
+			{ name: "beta" },
+			{ name: "gamma", blockedUntil: NOW + 60_000, blockReason: "rate_limit" },
+		];
+		const selected = selectSlot(pool, { hasher: fnv1a64, affinityKey: "k", pinnedSlot: "gamma", now: NOW });
+		expect(selected.name).not.toBe("gamma");
+		const hrw = rendezvousOrder("k", pool, fnv1a64).filter((slot) => slot.name !== "gamma");
+		expect(selected.name).toBe(hrw[0]?.name);
+	});
+
+	test("a blocked HRW winner is skipped for the next unblocked slot", () => {
+		const pool = slots("alpha", "beta", "gamma");
+		const order = rendezvousOrder("k2", pool, fnv1a64);
+		const winner = order[0];
+		if (!winner) throw new Error("expected a winner");
+		const blocked = pool.map((slot) =>
+			slot.name === winner.name ? { ...slot, blockedUntil: NOW + 60_000, blockReason: "rate_limit" } : slot,
+		);
+		const selected = selectSlot(blocked, { hasher: fnv1a64, affinityKey: "k2", now: NOW });
+		expect(selected.name).toBe(order[1]?.name);
+	});
+
+	test("an elapsed rate-limit block clears, an auth block does not", () => {
+		const pool: SelectableSlot[] = [
+			{ name: "alpha", blockedUntil: NOW - 1, blockReason: "rate_limit" },
+			{ name: "beta", blockReason: "auth_error" },
+		];
+		const cleared = clearExpiredSlotBlocks(pool, NOW);
+		expect(cleared[0]).toEqual({ name: "alpha" });
+		expect(cleared[1]).toEqual({ name: "beta", blockReason: "auth_error" });
+	});
+
+	test("selection recovers from a stale persisted block via the cleared view", () => {
+		const pool: SelectableSlot[] = [
+			{ name: "alpha", blockedUntil: NOW - 5_000, blockReason: "rate_limit" },
+			{ name: "beta", blockReason: "auth_error" },
+		];
+		const selected = selectSlot(pool, { hasher: fnv1a64, affinityKey: "k", now: NOW });
+		expect(selected.name).toBe("alpha");
+	});
+
+	test("a fully blocked pool throws with the soonest unblock time", () => {
+		const pool: SelectableSlot[] = [
+			{ name: "alpha", blockedUntil: NOW + 120_000, blockReason: "rate_limit" },
+			{ name: "beta", blockedUntil: NOW + 60_000, blockReason: "rate_limit" },
+		];
+		try {
+			selectSlot(pool, { hasher: fnv1a64, affinityKey: "k", now: NOW });
+			throw new Error("expected AllSlotsBlockedError");
+		} catch (error) {
+			expect(error).toBeInstanceOf(AllSlotsBlockedError);
+			expect((error as AllSlotsBlockedError).soonestUnblockAt).toBe(NOW + 60_000);
+		}
+	});
+});

--- a/packages/coding-agent/test/credential-pool-affinity-oracle.test.ts
+++ b/packages/coding-agent/test/credential-pool-affinity-oracle.test.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+import { TURN_RETRY_SUPPRESSION_PREFIX as POOL_PREFIX } from "@earendil-works/pi-ai/auth/pool/failover";
+import {
+	rendezvousOrder as poolRendezvousOrder,
+	type SlotHasher,
+	selectSlot,
+} from "@earendil-works/pi-ai/auth/pool/select";
+import { describe, expect, test } from "vitest";
+import type { AccountSlot } from "../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
+import {
+	rendezvousOrder as sdkRendezvousOrder,
+	selectAccount,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/affinity.ts";
+import { TURN_RETRY_SUPPRESSION_PREFIX as SDK_PREFIX } from "../src/core/extensions/builtin/claude-sdk-oauth/failover.ts";
+
+/** The exact hash the claude-sdk-oauth oracle uses, injected into the pool engine. */
+const sha256Hasher: SlotHasher = (input) => createHash("sha256").update(input).digest().readBigUInt64BE(0);
+
+function account(name: string, extra?: Partial<AccountSlot>): AccountSlot {
+	return {
+		name,
+		access: `${name}-access`,
+		refresh: `${name}-refresh`,
+		expires: 4_102_444_800_000,
+		source: "login",
+		...extra,
+	};
+}
+
+const SLOT_NAME_SETS = [
+	["default", "work"],
+	["alpha", "beta", "gamma"],
+	["a1", "b2", "c3", "d4", "e5"],
+] as const;
+
+describe("credential pool HRW matches the claude-sdk-oauth affinity oracle", () => {
+	test("full rendezvous order is identical for every key and slot set", () => {
+		for (const names of SLOT_NAME_SETS) {
+			const accounts = names.map((name) => account(name));
+			const slots = names.map((name) => ({ name }));
+			for (let index = 0; index < 50; index++) {
+				const key = `golden-session-${index}`;
+				const oracle = sdkRendezvousOrder(key, accounts).map((entry) => entry.name);
+				const pool = poolRendezvousOrder(key, slots, sha256Hasher).map((entry) => entry.name);
+				expect(pool).toEqual(oracle);
+			}
+		}
+	});
+
+	test("winner selection matches the oracle when the leading slot is blocked", () => {
+		const now = 1_756_000_000_000;
+		for (let index = 0; index < 25; index++) {
+			const key = `blocked-session-${index}`;
+			const names = ["alpha", "beta", "gamma"];
+			const oracleOrder = sdkRendezvousOrder(
+				key,
+				names.map((name) => account(name)),
+			);
+			const winner = oracleOrder[0];
+			if (!winner) throw new Error("expected an oracle winner");
+			const blockedAccounts = names.map((name) =>
+				name === winner.name
+					? account(name, { blockedUntil: now + 60_000, blockReason: "rate_limit" })
+					: account(name),
+			);
+			const blockedSlots = blockedAccounts.map(({ name, blockedUntil, blockReason }) => ({
+				name,
+				...(blockedUntil === undefined ? {} : { blockedUntil }),
+				...(blockReason === undefined ? {} : { blockReason }),
+			}));
+			const oracle = selectAccount(blockedAccounts, { affinityKey: key, now });
+			const pool = selectSlot(blockedSlots, { hasher: sha256Hasher, affinityKey: key, now });
+			expect(pool.name).toBe(oracle.name);
+		}
+	});
+
+	test("the pool failover reuses the exact turn-retry suppression marker", () => {
+		expect(POOL_PREFIX).toBe(SDK_PREFIX);
+		expect(POOL_PREFIX).toBe("senpi:no-turn-retry:");
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts
+++ b/packages/coding-agent/test/suite/regressions/991-cursor-native-todo-mirror.test.ts
@@ -18,9 +18,7 @@ describe("phasesFromCursorTodos", () => {
 				]) ?? [],
 			),
 		).toBeUndefined();
-		expect(
-			getTodoWidgetLines(phasesFromCursorTodos([{ content: "build", status: "pending" }]) ?? []),
-		).toBeDefined();
+		expect(getTodoWidgetLines(phasesFromCursorTodos([{ content: "build", status: "pending" }]) ?? [])).toBeDefined();
 	});
 
 	it("turns native Cursor todos into one Tasks phase", () => {


### PR DESCRIPTION
## What

Wave 2 of generic multi-credential support (follows #1093, foundation): the browser-safe credential pool **engine** in `packages/ai/src/auth/pool/`, plus slot-scoped auth resolution.

- **`auth/pool/select.ts`** — HRW (rendezvous) slot selection over an **injected hasher** (no `node:crypto` in the module, browser-safe). The hash input is `` `${key}\0${slot.name}` `` — byte-identical to the claude-sdk-oauth affinity oracle, so a sha256 hasher reproduces its winner sequence and **no live session remaps**. Pinned slots win when unblocked; auth blocks persist until re-login while elapsed rate blocks clear; a fully blocked pool throws `AllSlotsBlockedError` with the soonest unblock time.
- **`auth/pool/classify.ts`** — three-way in-lane failure taxonomy: `rotate` (429/529/rate-limit/quota + 401/403/auth), `retry` (transient 5xx/network, stays on the same slot for the outer retry policy), `fail` (**default-deny**: unknown errors stay owned by the model fallback chain above this engine). Extracts `retryAfterMs` hints.
- **`auth/pool/failover.ts`** — `runSlotFailover` runs at most one attempt per slot, blocks failed slots (exponential rate-limit windows capped at 48h; expiry-free auth blocks), and reuses the existing `senpi:no-turn-retry:` suppression marker. `isCommittedOutput` is **default-DENY**: absent an explicit bookkeeping filter, any yielded event makes rotation non-transparent and post-output failures carry the suppression prefix so a partially delivered turn is never replayed.
- **`auth/resolve.ts`** — `AuthResolutionOverrides.slotName` resolves provider auth against one named slot of a pooled credential. A missing entry or slot resolves to `undefined` rather than falling back to another account or ambient env. The locked OAuth refresh path refreshes exactly the named slot (`mergeRefreshedSlot`); the flat downgrade projection rotates only when it mirrored that slot, so siblings and what an older binary reads stay untouched.
- **`auth/pool/slots.ts`** — `projectSlot` (named-slot flat projection, pool fields stripped) and `mergeRefreshedSlot` supporting the above.
- `packages/ai/package.json` — the `./auth/pool/slots` export became the `./auth/pool/*` wildcard.

## Data safety

- Read-only projection: resolving a slot never writes pool state back.
- Slot-scoped refresh mutates only the named slot inside the existing `credentials.modify` lock; siblings and the pin survive byte-identical (asserted in tests).
- The flat top-level credential (older-binary downgrade projection) rotates only when the refreshed slot is the one it mirrored.

## Tests (RED captured first, then GREEN)

- `packages/ai/test/credential-pool-select.test.ts` — HRW determinism, pinned/blocked/expired-block semantics, `AllSlotsBlockedError`.
- `packages/ai/test/credential-pool-classify.test.ts` — taxonomy table + retry-after extraction + nested error shapes.
- `packages/ai/test/credential-pool-failover.test.ts` — pre-output rotation, default-DENY committed output, explicit bookkeeping opt-in, auth blocks, fail/retry pass-through, exhaustion.
- `packages/ai/test/credential-pool-resolve-slot.test.ts` — slotName projection (api_key + oauth), sibling byte-identity, flat-mirror rotation.
- `packages/coding-agent/test/credential-pool-affinity-oracle.test.ts` — **golden oracle**: full rendezvous order and blocked-winner selection identical to `claude-sdk-oauth/affinity.ts` under a sha256 hasher across 50 keys x 3 slot sets; `senpi:no-turn-retry:` marker parity. A mutation probe (hash separator `\0` -> `#`) flips this suite RED, proving the oracle bites.

## Verification

- `npm --prefix packages/ai test` focused pool + regression suites: 51/51 and 56/56 green.
- Oracle suite: 3/3 green (and RED under the mutation probe, then reverted).
- Root `npm run check` exit 0; `npm run check:browser-smoke` exit 0.
- QA evidence: `local-ignore/qa-evidence/20260827-credential-pool-engine/` (RED/GREEN vitest captures, mutation probe, gate outputs).

The `style(coding-agent)` commit is one pre-existing formatting drift the pinned biome pre-commit gate force-fixes on every commit in this branch; isolated into its own commit for reviewability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the credential pool engine under `packages/ai/src/auth/pool/` and slot-scoped auth resolution via `AuthResolutionOverrides.slotName`.

**Behavior**
- HRW slot selection uses an injected hasher with the exact `key\0slot` input as the claude-sdk-oauth oracle, so existing sessions don’t remap.
- Failure classification defaults to `fail` for unknown errors; only rate/auth failures rotate, transient 5xx retry on the same slot.
- `runSlotFailover` rotates at most once per slot and only before committed output; post-output failures carry the `senpi:no-turn-retry:` marker.
- Resolving a slot never writes pool state; refresh mutates only the named slot, leaving siblings and the flat downgrade projection untouched.
- Pool exports widened to `./auth/pool/*`.

<sup>Written for commit c9a0d6cad227d79abab9eeb98267486ec8e49d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

