### PR TITLE
feat(coding-agent): credential pool persistence, taxonomy, failover runner, and in-request rotation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Credential pool engine under `@earendil-works/pi-ai/auth/pool/*`: HRW slot selection with an injected hasher (`select`), a three-way in-lane failure taxonomy (`classify`), and a slot failover runner (`failover`) that rotates accounts only before committed output and marks post-output failures with the turn-retry suppression prefix.
 - `AuthResolutionOverrides.slotName` resolves provider auth against one named credential slot, refreshing exactly that slot under the store lock while siblings and the flat downgrade projection stay untouched.
+- `getApiKeyEnvVars` is exported so consumers can generalize over the canonical provider-id to API-key env-var mapping instead of re-deriving it.
 
 ### Changed
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,21 @@
+## 2026-08-27 - Export the canonical provider API-key env-var mapping
+
+### What changed
+
+- `packages/ai/src/env-api-keys.ts`: `getApiKeyEnvVars` is now exported (previously module-private and reachable only through `findEnvKeys`/`getEnvApiKey`).
+
+### Why
+
+- Numbered environment credential slots (`OPENAI_API_KEY_2`, ...) must generalize over the same provider-id-to-env-var mapping the resolver already uses. Re-deriving that table in `packages/coding-agent` would let the two drift, and a drifted table silently discovers the wrong variable for a provider.
+
+### Why an extension could not handle it
+
+- The mapping is data owned by this module and reachable only from inside it; an extension can neither read it nor keep a copy in step with upstream catalog changes.
+
+### Expected merge conflict zones
+
+- LOW: one `export` keyword on an existing function declaration.
+
 ## 2026-08-27 - Credential pool engine: HRW selection, failure taxonomy, slot failover, slot-scoped resolution
 
 ### What changed

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -65,7 +65,12 @@ function hasVertexAdcCredentials(env?: ProviderEnv): boolean {
 	return cachedVertexAdcCredentialsExists;
 }
 
-function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
+/**
+ * The canonical provider-id to API-key env-var mapping. Exported so numbered
+ * env credential slots (`OPENAI_API_KEY_2`, ...) can generalize over the same
+ * source of truth instead of duplicating it.
+ */
+export function getApiKeyEnvVars(provider: string): readonly string[] | undefined {
 	if (provider === "github-copilot") {
 		return ["COPILOT_GITHUB_TOKEN"];
 	}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Breaking Changes
 
+### Added
+
+- Any provider holding more than one credential now rotates between them inside a single request: a conversation sticks to one account through session-stable HRW affinity, a 429 or 401 on one account fails over to a healthy sibling before the model fallback chain is consulted, and cooldowns persist across restarts with absolute deadlines. Rotation is transparent only before committed output - a failure after streaming has begun is never replayed. Providers with a single credential are unaffected.
+- A second credential can be added with one environment variable (`OPENAI_API_KEY_2` and up, for any provider's primary key variable) or declared per provider in `models.json` under a validated `credentials` policy block (`rotation`, `affinity`, cooldown bounds, and named slot references). The block holds policy and references only; key material stays in `auth.json` or the environment.
+
 ### Fixed
 
 - Native todo lists with an explicit empty `todos: []` payload now clear persisted todo state and remove the `todo-sidebar`, while absent payloads remain ignored and lists with pending work remain visible.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## 2026-08-27 - Credential pool: health sidecar, policy schema, env slots, in-lane rotation
+
+### What changed
+
+- `packages/coding-agent/src/core/credential-pool/state-store.ts` (new): file-locked health sidecar at `<agent-dir>/credential-pool-state.json` (mode 0600, `FILE_STORAGE_LOCK_OPTIONS`) holding ONLY health - absolute cooldown deadlines, permanent auth/billing blocks, half-open probe leases, `lastSuccessAt`, and HMAC-derived env-slot revisions. `CredentialSlotRepository.mutateSlotState` is an atomic read-modify-write with a `stateVersion` increment; `acquireHalfOpenLease` transitions an elapsed cooldown to half-open for exactly one probing caller. An unreadable or schema-invalid document resets to fresh state rather than failing auth resolution.
+- `packages/coding-agent/src/core/credential-pool/classify.ts` (new): concrete provider-error taxonomy over `normalizeProviderError` and the existing 429 retry-hint parser. 401/invalid-key and account-scoped 403 block permanently and fail over; bare 403 fails the request; 429 fails over with a per-slot exponential cooldown floored (never overridden) by the server hint and capped at 48h; billing/quota-exhausted disables the account; 5xx/529/overload/network retry the SAME slot without blocking it; overflow, invalid model, 400, 404, malformed stream, and abort fail the request.
+- `packages/coding-agent/src/core/credential-pool/failover.ts` (new): `runCredentialFailover` re-reads slots before each distinct-credential attempt (so a newly added slot participates), runs at most one failover attempt per slot per request, settles a failed stream before starting the next, persists the block BEFORE selecting a replacement, and requires an `isCommittedOutput` predicate whose contract is default-DENY. Committed output bars rotation and the rethrow carries the existing `senpi:no-turn-retry:` marker.
+- `packages/coding-agent/src/core/credential-pool/env-slots.ts` (new): numbered env credential slots for any provider (`<VAR>`, `<VAR>_2` .. `<VAR>_16`), gap-tolerant, over the canonical `getApiKeyEnvVars` mapping.
+- `packages/coding-agent/src/core/credential-pool/rotation-stream.ts` (new): lists a provider's rotation slots with sidecar health overlaid (stored lane when a credential exists, env lane otherwise), selects by sha256 HRW over the request affinity key, and persists blocks per lane. An env slot's persisted health applies only while its HMAC revision still matches the current value.
+- `packages/coding-agent/src/core/model-runtime.ts`: `ModelRuntime.stream` engages that rotation only when the provider actually holds more than one slot and nothing pins the request to a single credential (runtime key, explicit per-request `apiKey`, or `credentials.rotation: false`); `prepareRequest` accepts a per-attempt slot override, and `ModelRuntimeAuthOverrides.slotName` plumbs slot-scoped resolution.
+- `packages/coding-agent/src/core/model-config-schema.ts`: per-provider `credentials` policy block (`additionalProperties: false`) with `rotation`/`affinity` toggles, cooldown bounds, and named slot references to env vars or command values; `CREDENTIAL_POLICY_DEFAULTS` re-exports the engine constants so schema and runtime cannot drift.
+
+### Why
+
+- Multi-credential rotation needs durable per-slot health that survives restart with absolute deadlines, a taxonomy that distinguishes credential-scoped from provider-scoped faults (blocking a healthy credential for a provider outage only destroys prompt-cache locality), and a request-level runner that exhausts a lane's slots before the model fallback chain above it is consulted. Health cannot live in `auth.json`: that file is credential material under its own lock, and mixing volatile block state into it would rewrite user credentials on every rate limit.
+
+### Why an extension could not handle it
+
+- `ModelRuntime.stream` is the one place where a request's provider auth is resolved and the provider stream is constructed; per-attempt credential selection has to happen inside it. The sidecar likewise needs `getAgentDir()` and the shared file-storage lock policy, neither of which is reachable through the extension API.
+
+### Expected merge conflict zones
+
+- MEDIUM: `model-runtime.ts` `prepareRequest`/`stream` (upstream-owned request construction; the rotation branch is additive and the single-credential path is unchanged).
+- LOW: `model-config-schema.ts` provider block (one optional property); the `credential-pool/` directory is fork-new with no upstream counterpart.
+
 ## 2026-08-26 - Capture bash spill-file errors before the first write
 
 ### What changed

--- a/packages/coding-agent/src/core/credential-pool/classify.ts
+++ b/packages/coding-agent/src/core/credential-pool/classify.ts
@@ -1,0 +1,95 @@
+import { DEFAULT_SLOT_BLOCK_MS, MAX_SLOT_BLOCK_MS } from "@earendil-works/pi-ai/auth/pool/failover";
+import { normalizeProviderError } from "@earendil-works/pi-ai/utils/error-body";
+import { getOverflowPatterns } from "@earendil-works/pi-ai/utils/overflow";
+import { extract429RetryAfterMs } from "@earendil-works/pi-ai/utils/retry-hint";
+
+export const COOLDOWN_BASE_MS = DEFAULT_SLOT_BLOCK_MS;
+export const COOLDOWN_CAP_MS = MAX_SLOT_BLOCK_MS;
+export const RETRY_SAME_MAX_ATTEMPTS = 2;
+
+export type CredentialBlock =
+	| { reason: "auth_error" }
+	| { reason: "account_disabled" }
+	| { reason: "rate_limit"; cooldownMs: number; retryAfterWasCapped: boolean };
+
+export type CredentialAction =
+	| { kind: "failover"; block: CredentialBlock }
+	| { kind: "retry_same"; maxAttempts: typeof RETRY_SAME_MAX_ATTEMPTS }
+	| { kind: "fail_request" };
+
+/**
+ * Per-slot exponential cooldown with the server hint as a FLOOR, never an
+ * override: a hint can only lengthen the wait the failure count already earned,
+ * and everything caps at 48 hours with the capping recorded.
+ */
+export function rateLimitCooldown(
+	failureCount: number,
+	serverHintMs?: number,
+): { cooldownMs: number; retryAfterWasCapped: boolean } {
+	const backoff = Math.min(COOLDOWN_CAP_MS, COOLDOWN_BASE_MS * 2 ** Math.max(0, failureCount));
+	const floored = serverHintMs === undefined ? backoff : Math.max(backoff, serverHintMs);
+	return { cooldownMs: Math.min(COOLDOWN_CAP_MS, floored), retryAfterWasCapped: floored > COOLDOWN_CAP_MS };
+}
+
+const INVALID_KEY_TEXT = /invalid[ _-]?(?:api[ _-]?)?key|authentication[_ ]?error|invalid x-api-key|unauthorized/i;
+const ACCOUNT_SCOPED_403_TEXT = /account|credential|token|api[ _-]?key|organization|subscription/i;
+const RATE_LIMIT_TEXT = /rate[ _-]?limit|too many requests|resource_exhausted/i;
+const BILLING_TEXT =
+	/billing|credits?[ _-]?(?:required|exhausted|balance)|insufficient[ _-]?(?:funds|quota|credit)|payment[ _-]?required|quota[ _-]?exhausted/i;
+const OVERLOAD_TEXT = /overloaded/i;
+const NETWORK_TEXT =
+	/econnreset|econnrefused|etimedout|enotfound|socket hang up|fetch failed|network error|request timed out/i;
+const FAIL_FAST_TEXT =
+	/context[ _-]?(?:length|window)|maximum context|invalid[ _-]?model|model[ _-]?not[ _-]?found|malformed[ _-]?stream|premature[ _-]?(?:close|stream)/i;
+const ABORT_TEXT = /\baborted?\b/i;
+
+function isAbort(error: unknown, message: string): boolean {
+	if (error instanceof Error && error.name === "AbortError") return true;
+	return ABORT_TEXT.test(message);
+}
+
+function isOverflowText(text: string): boolean {
+	return getOverflowPatterns().some((pattern) => pattern.test(text));
+}
+
+/**
+ * Maps a provider failure onto the credential-pool action space. Credential-
+ * scoped failures fail over (permanently for auth/billing, cooldown for rate
+ * limits); provider-scoped faults (5xx/overload/network) retry the SAME slot
+ * without blocking it, because blocking a healthy credential for a provider
+ * outage only destroys prompt-cache locality; everything else fails the
+ * request so the model fallback chain above keeps owning it.
+ */
+export function classifyCredentialFailure(error: unknown, context: { failureCount?: number } = {}): CredentialAction {
+	const normalized = normalizeProviderError(error);
+	const text = normalized.messageCarriesBody ? normalized.message : `${normalized.message} ${normalized.body ?? ""}`;
+	const status = normalized.status;
+	const failureCount = context.failureCount ?? 0;
+
+	if (isAbort(error, text)) return { kind: "fail_request" };
+	if (status === 401 || INVALID_KEY_TEXT.test(text)) {
+		return { kind: "failover", block: { reason: "auth_error" } };
+	}
+	if (status === 403) {
+		return ACCOUNT_SCOPED_403_TEXT.test(text)
+			? { kind: "failover", block: { reason: "auth_error" } }
+			: { kind: "fail_request" };
+	}
+	if (status === 402 || BILLING_TEXT.test(text)) {
+		return { kind: "failover", block: { reason: "account_disabled" } };
+	}
+	if (status === 429 || RATE_LIMIT_TEXT.test(text)) {
+		const hint = extract429RetryAfterMs({ status: status ?? 429, bodyText: text });
+		return { kind: "failover", block: { reason: "rate_limit", ...rateLimitCooldown(failureCount, hint) } };
+	}
+	if (isOverflowText(text) || status === 400 || status === 404 || FAIL_FAST_TEXT.test(text)) {
+		return { kind: "fail_request" };
+	}
+	if (status === 529 || OVERLOAD_TEXT.test(text) || (status !== undefined && status >= 500 && status < 600)) {
+		return { kind: "retry_same", maxAttempts: RETRY_SAME_MAX_ATTEMPTS };
+	}
+	if (status === 408 || NETWORK_TEXT.test(text)) {
+		return { kind: "retry_same", maxAttempts: RETRY_SAME_MAX_ATTEMPTS };
+	}
+	return { kind: "fail_request" };
+}

--- a/packages/coding-agent/src/core/credential-pool/env-slots.ts
+++ b/packages/coding-agent/src/core/credential-pool/env-slots.ts
@@ -1,0 +1,42 @@
+import { getApiKeyEnvVars } from "@earendil-works/pi-ai";
+
+export const MAX_ENV_SLOT_INDEX = 16;
+
+export type EnvCredentialSlot = {
+	name: string;
+	envVarName: string;
+	key: string;
+	source: "env";
+};
+
+/**
+ * Anthropic maps to bearer/OAuth token vars ahead of its API-key var; numbered
+ * slots must extend the API-key lane, so prefer the `*_API_KEY` entry when the
+ * canonical mapping lists several variables.
+ */
+export function primaryEnvVar(providerId: string): string | undefined {
+	const envVars = getApiKeyEnvVars(providerId);
+	if (!envVars || envVars.length === 0) return undefined;
+	return envVars.find((name) => name.endsWith("_API_KEY")) ?? envVars[0];
+}
+
+/**
+ * Discovers numbered env credential slots: the primary var yields slot `env`,
+ * and `<VAR>_2` .. `<VAR>_16` yield `env-2` .. `env-16`. Discovery is
+ * gap-tolerant - a configured `<VAR>_3` with no `<VAR>_2` is still found and no
+ * slot is invented for the gap. Stored credentials keep outranking every env
+ * slot because resolution consults env only when nothing is stored.
+ */
+export function discoverEnvSlots(providerId: string, env: (name: string) => string | undefined): EnvCredentialSlot[] {
+	const primary = primaryEnvVar(providerId);
+	if (!primary) return [];
+	const slots: EnvCredentialSlot[] = [];
+	const base = env(primary);
+	if (base) slots.push({ name: "env", envVarName: primary, key: base, source: "env" });
+	for (let index = 2; index <= MAX_ENV_SLOT_INDEX; index++) {
+		const envVarName = `${primary}_${index}`;
+		const value = env(envVarName);
+		if (value) slots.push({ name: `env-${index}`, envVarName, key: value, source: "env" });
+	}
+	return slots;
+}

--- a/packages/coding-agent/src/core/credential-pool/failover.ts
+++ b/packages/coding-agent/src/core/credential-pool/failover.ts
@@ -54,7 +54,8 @@ export class CredentialFailoverError extends Error {
 }
 
 function isAvailable(slot: RunSlot, now: number): boolean {
-	return slot.blockReason !== "auth_error" && (slot.blockedUntil === undefined || slot.blockedUntil <= now);
+	if (slot.blockReason === "auth_error" || slot.blockReason === "account_disabled") return false;
+	return slot.blockedUntil === undefined || slot.blockedUntil <= now;
 }
 
 function soonestRetryAt(slots: readonly RunSlot[], now: number): number | undefined {

--- a/packages/coding-agent/src/core/credential-pool/failover.ts
+++ b/packages/coding-agent/src/core/credential-pool/failover.ts
@@ -1,0 +1,146 @@
+import { TURN_RETRY_SUPPRESSION_PREFIX } from "@earendil-works/pi-ai/auth/pool/failover";
+import { type CredentialAction, type CredentialBlock, classifyCredentialFailure } from "./classify.ts";
+
+export { TURN_RETRY_SUPPRESSION_PREFIX };
+
+export type RunSlot = {
+	name: string;
+	blockedUntil?: number;
+	blockReason?: string;
+	failureCount?: number;
+};
+
+export type CredentialFailoverEvent<TSlot extends RunSlot> = {
+	slot: TSlot;
+	block: CredentialBlock;
+	attempt: number;
+	committedOutput: boolean;
+};
+
+export type RunCredentialFailoverOptions<TEvent, TSlot extends RunSlot> = {
+	/** Re-read before every distinct-credential attempt so a newly added slot participates. */
+	listSlots: () => Promise<readonly TSlot[]> | readonly TSlot[];
+	select: (slots: readonly TSlot[]) => TSlot;
+	runAttempt: (slot: TSlot) => AsyncIterable<TEvent> | Promise<AsyncIterable<TEvent>>;
+	/**
+	 * REQUIRED and default-DENY by contract: return false only for event types
+	 * explicitly known to be pre-commit bookkeeping. Any event this predicate
+	 * does not recognize must count as committed output.
+	 */
+	isCommittedOutput: (event: TEvent) => boolean;
+	classify?: (error: unknown, context: { failureCount: number }) => CredentialAction;
+	errorFromEvent?: (event: TEvent) => unknown | undefined;
+	/** Persisted BEFORE a replacement slot is selected so a crash never forgets a block. */
+	persistBlock: (slot: TSlot, block: CredentialBlock) => void | Promise<void>;
+	onRotate?: (event: CredentialFailoverEvent<TSlot>) => void | Promise<void>;
+	now?: () => number;
+};
+
+export class CredentialFailoverError extends Error {
+	readonly action: CredentialAction;
+	readonly original: unknown;
+	readonly suppressTurnRetry: boolean;
+	readonly retryAt: number | undefined;
+
+	constructor(action: CredentialAction, original: unknown, options: { suppressTurnRetry: boolean; retryAt?: number }) {
+		const detail = original instanceof Error ? original.message : String(original);
+		super(`${options.suppressTurnRetry ? TURN_RETRY_SUPPRESSION_PREFIX : ""}${detail}`, { cause: original });
+		this.name = "CredentialFailoverError";
+		this.action = action;
+		this.original = original;
+		this.suppressTurnRetry = options.suppressTurnRetry;
+		this.retryAt = options.retryAt;
+	}
+}
+
+function isAvailable(slot: RunSlot, now: number): boolean {
+	return slot.blockReason !== "auth_error" && (slot.blockedUntil === undefined || slot.blockedUntil <= now);
+}
+
+function soonestRetryAt(slots: readonly RunSlot[], now: number): number | undefined {
+	const deadlines = slots
+		.map((slot) => slot.blockedUntil)
+		.filter((value): value is number => value !== undefined && value > now);
+	return deadlines.length === 0 ? undefined : Math.min(...deadlines);
+}
+
+async function settle<TEvent>(stream: AsyncIterable<TEvent>): Promise<void> {
+	// A failed attempt must fully release its transport before a replacement
+	// starts, or two live streams can interleave provider-side effects.
+	const iterator = stream[Symbol.asyncIterator]();
+	try {
+		await iterator.return?.(undefined);
+	} catch {
+		// Settling a dead stream must never mask the original failure.
+	}
+}
+
+/**
+ * Generic in-lane credential failover. Runs at most one failover attempt per
+ * slot per request, retries provider-scoped faults on the SAME slot up to the
+ * classifier's bound without blocking it, and rotates only while no committed
+ * output has reached the caller - afterwards the failure is rethrown with the
+ * `senpi:no-turn-retry:` marker so the turn is never replayed.
+ */
+export async function* runCredentialFailover<TEvent, TSlot extends RunSlot>(
+	options: RunCredentialFailoverOptions<TEvent, TSlot>,
+): AsyncGenerator<TEvent> {
+	const now = options.now ?? Date.now;
+	const classify = options.classify ?? classifyCredentialFailure;
+	const attempted = new Set<string>();
+	const retriesBySlot = new Map<string, number>();
+	let lastError: CredentialFailoverError | undefined;
+	let lastOriginal: unknown;
+
+	while (true) {
+		const slots = await options.listSlots();
+		const candidates = slots.filter((slot) => !attempted.has(slot.name) && isAvailable(slot, now()));
+		if (candidates.length === 0) {
+			const retryAt = soonestRetryAt(slots, now());
+			throw lastError !== undefined && lastOriginal !== undefined
+				? new CredentialFailoverError(lastError.action, lastOriginal, {
+						suppressTurnRetry: lastError.suppressTurnRetry,
+						...(retryAt === undefined ? {} : { retryAt }),
+					})
+				: new CredentialFailoverError({ kind: "fail_request" }, new Error("No credential slots available"), {
+						suppressTurnRetry: false,
+						...(retryAt === undefined ? {} : { retryAt }),
+					});
+		}
+		const slot = options.select(candidates);
+		let committedOutput = false;
+		let attemptStream: AsyncIterable<TEvent> | undefined;
+		try {
+			attemptStream = await options.runAttempt(slot);
+			for await (const event of attemptStream) {
+				const failure = options.errorFromEvent?.(event);
+				if (failure !== undefined) throw failure;
+				committedOutput ||= options.isCommittedOutput(event);
+				yield event;
+			}
+			return;
+		} catch (error) {
+			if (attemptStream) await settle(attemptStream);
+			const failureCount = (slot.failureCount ?? 0) + (retriesBySlot.get(slot.name) ?? 0);
+			const action = classify(error, { failureCount });
+			lastOriginal = error;
+
+			if (action.kind === "retry_same" && !committedOutput) {
+				const used = (retriesBySlot.get(slot.name) ?? 0) + 1;
+				retriesBySlot.set(slot.name, used);
+				if (used < action.maxAttempts) continue;
+				throw new CredentialFailoverError(action, error, { suppressTurnRetry: false });
+			}
+			if (action.kind !== "failover") {
+				throw new CredentialFailoverError(action, error, { suppressTurnRetry: committedOutput });
+			}
+
+			await options.persistBlock(slot, action.block);
+			attempted.add(slot.name);
+			const failure = new CredentialFailoverError(action, error, { suppressTurnRetry: committedOutput });
+			lastError = failure;
+			await options.onRotate?.({ slot, block: action.block, attempt: attempted.size, committedOutput });
+			if (committedOutput) throw failure;
+		}
+	}
+}

--- a/packages/coding-agent/src/core/credential-pool/rotation-stream.ts
+++ b/packages/coding-agent/src/core/credential-pool/rotation-stream.ts
@@ -1,0 +1,141 @@
+import { createHash, randomUUID } from "node:crypto";
+import type { AssistantMessageEvent, Credential } from "@earendil-works/pi-ai";
+import { rendezvousOrder, type SlotHasher } from "@earendil-works/pi-ai/auth/pool/select";
+import { listSlots as listCredentialSlots } from "@earendil-works/pi-ai/auth/pool/slots";
+import { type CredentialBlock, classifyCredentialFailure } from "./classify.ts";
+import { discoverEnvSlots } from "./env-slots.ts";
+import { type RunSlot, runCredentialFailover } from "./failover.ts";
+import type { CredentialSlotRepository, CredentialSlotState } from "./state-store.ts";
+
+/** The exact hash the claude-sdk-oauth affinity oracle uses, so pools never remap. */
+export const sha256SlotHasher: SlotHasher = (input) => createHash("sha256").update(input).digest().readBigUInt64BE(0);
+
+export type RotationLane = "stored" | "env";
+
+export type RotationSlot = RunSlot & {
+	lane: RotationLane;
+	/** Env-lane key material for the attempt; never serialized or persisted. */
+	envKey?: string;
+	envVarName?: string;
+};
+
+export type RotationSources = {
+	providerId: string;
+	credential: Credential | undefined;
+	env: (name: string) => string | undefined;
+	repository: CredentialSlotRepository;
+	now?: () => number;
+};
+
+function overlayState(slot: RotationSlot, state: CredentialSlotState | undefined): RotationSlot {
+	if (!state) return slot;
+	return {
+		...slot,
+		...(state.blockedUntil === undefined ? {} : { blockedUntil: state.blockedUntil }),
+		...(state.blockReason === undefined ? {} : { blockReason: state.blockReason }),
+		...(state.failureCount === undefined ? {} : { failureCount: state.failureCount }),
+	};
+}
+
+/**
+ * Lists the provider's rotation slots with sidecar health overlaid. Stored
+ * credentials own the lane when present; env slots participate only when
+ * nothing is stored, preserving today's resolution precedence. An env slot's
+ * persisted health applies only while its HMAC revision still matches the
+ * current env value, so rotating a key in place clears its own stale block.
+ */
+export async function listRotationSlots(sources: RotationSources): Promise<RotationSlot[]> {
+	const { providerId, credential, env, repository } = sources;
+	if (credential) {
+		const state = await repository.listSlots(providerId, "stored");
+		return listCredentialSlots(credential).map((slot) =>
+			overlayState({ name: slot.name, lane: "stored" }, state[slot.name]),
+		);
+	}
+	const envSlots = discoverEnvSlots(providerId, env);
+	if (envSlots.length === 0) return [];
+	const state = await repository.listSlots(providerId, "env");
+	const slots: RotationSlot[] = [];
+	for (const slot of envSlots) {
+		const persisted = state[slot.name];
+		const revision = await repository.envCredentialRevision(slot.envVarName, slot.key);
+		const applicable = persisted?.credentialRevision === revision ? persisted : undefined;
+		slots.push(
+			overlayState({ name: slot.name, lane: "env", envKey: slot.key, envVarName: slot.envVarName }, applicable),
+		);
+	}
+	return slots;
+}
+
+function blockPatch(
+	block: CredentialBlock,
+	current: CredentialSlotState | undefined,
+	now: number,
+	credentialRevision?: string,
+): Omit<CredentialSlotState, "stateVersion"> {
+	const failureCount = (current?.failureCount ?? 0) + 1;
+	const base = {
+		failureCount,
+		...(credentialRevision === undefined ? {} : { credentialRevision }),
+		...(current?.lastSuccessAt === undefined ? {} : { lastSuccessAt: current.lastSuccessAt }),
+	};
+	if (block.reason === "rate_limit") {
+		return { ...base, blockedUntil: now + block.cooldownMs, blockReason: "rate_limit" };
+	}
+	return { ...base, blockReason: block.reason };
+}
+
+export type CredentialRotationOptions = {
+	sources: RotationSources;
+	/** Stable session key keeps a session on its slot; absent, each request distributes. */
+	affinityKey?: string;
+	hasher?: SlotHasher;
+	runAttempt: (
+		slot: RotationSlot,
+	) => AsyncIterable<AssistantMessageEvent> | Promise<AsyncIterable<AssistantMessageEvent>>;
+};
+
+function errorFromEvent(event: AssistantMessageEvent): unknown {
+	if (event.type !== "error") return undefined;
+	const message = event.error.errorMessage ?? "provider stream error";
+	return new Error(message);
+}
+
+/**
+ * In-lane credential rotation for one provider request. Selection follows the
+ * HRW order for the affinity key; only the `start` bookkeeping event counts as
+ * pre-commit, so any delta bars silent rotation (default-DENY) and failures
+ * after output carry the turn-retry suppression marker.
+ */
+export function streamWithCredentialRotation(
+	options: CredentialRotationOptions,
+): AsyncGenerator<AssistantMessageEvent> {
+	const { sources, runAttempt } = options;
+	const hasher = options.hasher ?? sha256SlotHasher;
+	const affinityKey = options.affinityKey ?? randomUUID();
+	const now = sources.now ?? Date.now;
+
+	return runCredentialFailover<AssistantMessageEvent, RotationSlot>({
+		listSlots: () => listRotationSlots(sources),
+		select: (candidates) => {
+			const ordered = rendezvousOrder(affinityKey, candidates, hasher);
+			const winner = ordered[0];
+			if (!winner) throw new Error("credential rotation selected from an empty candidate set");
+			return winner;
+		},
+		runAttempt,
+		isCommittedOutput: (event) => event.type !== "start",
+		errorFromEvent,
+		classify: classifyCredentialFailure,
+		persistBlock: async (slot, block) => {
+			const revision =
+				slot.lane === "env" && slot.envVarName !== undefined && slot.envKey !== undefined
+					? await sources.repository.envCredentialRevision(slot.envVarName, slot.envKey)
+					: undefined;
+			await sources.repository.mutateSlotState(sources.providerId, slot.lane, slot.name, (current) =>
+				blockPatch(block, current, now(), revision),
+			);
+		},
+		now,
+	});
+}

--- a/packages/coding-agent/src/core/credential-pool/state-store.ts
+++ b/packages/coding-agent/src/core/credential-pool/state-store.ts
@@ -1,0 +1,200 @@
+import { createHmac, randomBytes, randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import lockfile from "proper-lockfile";
+import { z } from "zod";
+import { getAgentDir } from "../../config.ts";
+import { FILE_STORAGE_LOCK_OPTIONS } from "../lockfile-policy.ts";
+
+export const CREDENTIAL_POOL_STATE_FILENAME = "credential-pool-state.json";
+
+const HEX_256_BIT = /^[0-9a-f]{64}$/;
+
+const leaseSchema = z.strictObject({
+	id: z.string().min(1).max(128),
+	expiresAt: z.number().int().positive(),
+});
+
+const slotStateSchema = z.strictObject({
+	stateVersion: z.number().int().nonnegative(),
+	blockedUntil: z.number().int().positive().optional(),
+	blockReason: z.enum(["auth_error", "rate_limit"]).optional(),
+	failureCount: z.number().int().nonnegative().optional(),
+	lastSuccessAt: z.number().int().positive().optional(),
+	credentialRevision: z.string().regex(HEX_256_BIT).optional(),
+	lease: leaseSchema.optional(),
+});
+
+export type CredentialSlotState = Readonly<z.infer<typeof slotStateSchema>>;
+
+const documentSchema = z.strictObject({
+	schemaVersion: z.literal(1),
+	installationKey: z.string().regex(HEX_256_BIT),
+	providers: z.record(
+		z.string(),
+		z.strictObject({
+			lanes: z.record(
+				z.string(),
+				z.strictObject({
+					slots: z.record(z.string(), slotStateSchema),
+				}),
+			),
+		}),
+	),
+});
+
+export type CredentialPoolStateDocument = z.infer<typeof documentSchema>;
+
+export function credentialPoolStatePath(agentDir: string = getAgentDir()): string {
+	return join(agentDir, CREDENTIAL_POOL_STATE_FILENAME);
+}
+
+const FILE_WRITE_OPTIONS = { encoding: "utf-8", mode: 0o600 } as const;
+
+function freshDocument(): CredentialPoolStateDocument {
+	return { schemaVersion: 1, installationKey: randomBytes(32).toString("hex"), providers: {} };
+}
+
+/**
+ * The sidecar holds only health, so an unreadable or invalid document resets to
+ * a fresh one instead of failing auth resolution; the worst outcome of a reset
+ * is a cleared cooldown, never lost credential material.
+ */
+function parseDocument(content: string): CredentialPoolStateDocument {
+	try {
+		const parsed = documentSchema.safeParse(JSON.parse(content));
+		return parsed.success ? parsed.data : freshDocument();
+	} catch {
+		return freshDocument();
+	}
+}
+
+export type SlotHealth = "ready" | "blocked" | "half_open";
+
+/** Deadlines are absolute so a restart never re-enables a cooling credential early. */
+export function slotHealth(state: CredentialSlotState | undefined, now: number): SlotHealth {
+	if (!state) return "ready";
+	if (state.blockedUntil !== undefined && state.blockedUntil > now) return "blocked";
+	if (state.blockedUntil !== undefined && state.lease !== undefined && state.lease.expiresAt > now) {
+		return "half_open";
+	}
+	return "ready";
+}
+
+/**
+ * File-locked health sidecar for credential pools. Never stores credential
+ * material: env slots are keyed by an installation-local HMAC revision so a
+ * rotated env value clears its own stale block without persisting a raw key
+ * hash anywhere.
+ */
+export class CredentialSlotRepository {
+	private readonly path: string;
+
+	constructor(path: string = credentialPoolStatePath()) {
+		this.path = path;
+	}
+
+	private ensureFile(): void {
+		if (existsSync(this.path)) return;
+		mkdirSync(dirname(this.path), { recursive: true, mode: 0o700 });
+		writeFileSync(this.path, JSON.stringify(freshDocument(), null, 2), FILE_WRITE_OPTIONS);
+	}
+
+	private async withDocument<T>(
+		fn: (document: CredentialPoolStateDocument) => { result: T; next?: CredentialPoolStateDocument },
+	): Promise<T> {
+		this.ensureFile();
+		const release = await lockfile.lock(this.path, FILE_STORAGE_LOCK_OPTIONS);
+		try {
+			const document = parseDocument(readFileSync(this.path, "utf-8"));
+			const { result, next } = fn(document);
+			if (next) writeFileSync(this.path, JSON.stringify(next, null, 2), FILE_WRITE_OPTIONS);
+			return result;
+		} finally {
+			await release();
+		}
+	}
+
+	async installationKey(): Promise<string> {
+		return this.withDocument((document) => ({ result: document.installationKey, next: document }));
+	}
+
+	/**
+	 * Derives the persistence key for an env slot's health. HMAC over the
+	 * installation key means the revision is useless outside this installation
+	 * and never equals a raw hash of the key material.
+	 */
+	async envCredentialRevision(envVarName: string, envValue: string): Promise<string> {
+		const key = await this.installationKey();
+		return createHmac("sha256", key).update(`${envVarName}\0${envValue}`).digest("hex");
+	}
+
+	async listSlots(providerId: string, laneId: string): Promise<Record<string, CredentialSlotState>> {
+		return this.withDocument((document) => ({
+			result: { ...document.providers[providerId]?.lanes[laneId]?.slots },
+		}));
+	}
+
+	/**
+	 * Atomic read-modify-write for one slot's health. `stateVersion` increments
+	 * on every write so concurrent mutators can detect lost updates; returning
+	 * undefined removes the slot state entirely.
+	 */
+	async mutateSlotState(
+		providerId: string,
+		laneId: string,
+		slotId: string,
+		fn: (current: CredentialSlotState | undefined) => Omit<CredentialSlotState, "stateVersion"> | undefined,
+	): Promise<CredentialSlotState | undefined> {
+		return this.withDocument((document) => {
+			const provider = document.providers[providerId] ?? { lanes: {} };
+			const lane = provider.lanes[laneId] ?? { slots: {} };
+			const current = lane.slots[slotId];
+			const mutated = fn(current);
+			const slots = { ...lane.slots };
+			let result: CredentialSlotState | undefined;
+			if (mutated === undefined) {
+				delete slots[slotId];
+			} else {
+				result = { ...mutated, stateVersion: (current?.stateVersion ?? 0) + 1 };
+				slots[slotId] = result;
+			}
+			const next: CredentialPoolStateDocument = {
+				...document,
+				providers: {
+					...document.providers,
+					[providerId]: { lanes: { ...provider.lanes, [laneId]: { slots } } },
+				},
+			};
+			return { result, next };
+		});
+	}
+}
+
+export type HalfOpenLease = { leaseId: string; expiresAt: number };
+
+/**
+ * Transitions an expired cooldown atomically to half_open: exactly one caller
+ * wins the probe lease; everyone else keeps treating the slot as unavailable
+ * until the lease expires or the probe settles the block.
+ */
+export async function acquireHalfOpenLease(
+	repository: CredentialSlotRepository,
+	providerId: string,
+	laneId: string,
+	slotId: string,
+	options: { now?: number; leaseTtlMs?: number } = {},
+): Promise<HalfOpenLease | undefined> {
+	const now = options.now ?? Date.now();
+	const leaseTtlMs = options.leaseTtlMs ?? 30_000;
+	let lease: HalfOpenLease | undefined;
+	await repository.mutateSlotState(providerId, laneId, slotId, (current) => {
+		if (!current) return current;
+		const expired = current.blockedUntil !== undefined && current.blockedUntil <= now;
+		const leaseLive = current.lease !== undefined && current.lease.expiresAt > now;
+		if (!expired || leaseLive || current.blockReason === "auth_error") return current;
+		lease = { leaseId: randomUUID(), expiresAt: now + leaseTtlMs };
+		return { ...current, lease: { id: lease.leaseId, expiresAt: lease.expiresAt } };
+	});
+	return lease;
+}

--- a/packages/coding-agent/src/core/credential-pool/state-store.ts
+++ b/packages/coding-agent/src/core/credential-pool/state-store.ts
@@ -18,7 +18,7 @@ const leaseSchema = z.strictObject({
 const slotStateSchema = z.strictObject({
 	stateVersion: z.number().int().nonnegative(),
 	blockedUntil: z.number().int().positive().optional(),
-	blockReason: z.enum(["auth_error", "rate_limit"]).optional(),
+	blockReason: z.enum(["auth_error", "rate_limit", "account_disabled"]).optional(),
 	failureCount: z.number().int().nonnegative().optional(),
 	lastSuccessAt: z.number().int().positive().optional(),
 	credentialRevision: z.string().regex(HEX_256_BIT).optional(),
@@ -74,6 +74,8 @@ export type SlotHealth = "ready" | "blocked" | "half_open";
 /** Deadlines are absolute so a restart never re-enables a cooling credential early. */
 export function slotHealth(state: CredentialSlotState | undefined, now: number): SlotHealth {
 	if (!state) return "ready";
+	// Auth and billing blocks have no expiry; only credential replacement clears them.
+	if (state.blockReason === "auth_error" || state.blockReason === "account_disabled") return "blocked";
 	if (state.blockedUntil !== undefined && state.blockedUntil > now) return "blocked";
 	if (state.blockedUntil !== undefined && state.lease !== undefined && state.lease.expiresAt > now) {
 		return "half_open";

--- a/packages/coding-agent/src/core/model-config-schema.ts
+++ b/packages/coding-agent/src/core/model-config-schema.ts
@@ -1,5 +1,38 @@
+import { DEFAULT_SLOT_BLOCK_MS, MAX_SLOT_BLOCK_MS } from "@earendil-works/pi-ai/auth/pool/failover";
 import { type Static, Type } from "typebox";
 import { Compile } from "typebox/compile";
+
+/** Policy defaults shared with the pool engine so schema and runtime cannot drift. */
+export const CREDENTIAL_POLICY_DEFAULTS = {
+	rotation: true,
+	affinity: true,
+	cooldownBaseMs: DEFAULT_SLOT_BLOCK_MS,
+	cooldownCapMs: MAX_SLOT_BLOCK_MS,
+} as const;
+
+const CredentialSlotRefSchema = Type.Object(
+	{
+		env: Type.Optional(Type.String({ minLength: 1 })),
+		value: Type.Optional(Type.String({ minLength: 1 })),
+	},
+	{ additionalProperties: false },
+);
+
+/**
+ * Policy only: named slots REFERENCE env vars or command values; key material
+ * itself stays in auth.json or the environment, and unknown keys (for example
+ * a literal `apiKey`) are rejected outright.
+ */
+const CredentialPolicySchema = Type.Object(
+	{
+		rotation: Type.Optional(Type.Boolean()),
+		affinity: Type.Optional(Type.Boolean()),
+		cooldownBaseMs: Type.Optional(Type.Number({ minimum: 0 })),
+		cooldownCapMs: Type.Optional(Type.Number({ minimum: 0 })),
+		slots: Type.Optional(Type.Record(Type.String({ minLength: 1 }), CredentialSlotRefSchema)),
+	},
+	{ additionalProperties: false },
+);
 
 const PercentileCutoffsSchema = Type.Object({
 	p50: Type.Optional(Type.Number()),
@@ -214,6 +247,7 @@ const ProviderConfigSchema = Type.Object({
 	blacklist: Type.Optional(Type.Array(Type.String({ minLength: 1 }))),
 	models: Type.Optional(Type.Array(ModelDefinitionSchema)),
 	modelOverrides: Type.Optional(Type.Record(Type.String(), ModelOverrideSchema)),
+	credentials: Type.Optional(CredentialPolicySchema),
 });
 
 const ModelsConfigSchema = Type.Object({
@@ -225,4 +259,5 @@ export const validateModelsConfig = Compile(ModelsConfigSchema);
 export type ModelsJsonModel = Static<typeof ModelDefinitionSchema>;
 export type ModelsJsonModelOverride = Static<typeof ModelOverrideSchema>;
 export type ModelsJsonProvider = Static<typeof ProviderConfigSchema>;
+export type ModelsJsonCredentialPolicy = Static<typeof CredentialPolicySchema>;
 export type ModelsJson = Static<typeof ModelsConfigSchema>;

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -43,6 +43,12 @@ import { APP_NAME, BRAND, getAgentDir } from "../config.ts";
 import { operationSignal, raceWithAbortSignal } from "../utils/abort.ts";
 import { AuthStorage as DefaultAuthStorage } from "./auth-storage.ts";
 import { envValue } from "./brand.ts";
+import {
+	listRotationSlots,
+	type RotationSources,
+	streamWithCredentialRotation,
+} from "./credential-pool/rotation-stream.ts";
+import { CredentialSlotRepository } from "./credential-pool/state-store.ts";
 import { ModelConfig } from "./model-config.ts";
 import { FileModelsStore, InMemoryCodingAgentModelsStore } from "./models-store.ts";
 import {
@@ -93,7 +99,17 @@ export interface ModelRuntimeAuthOverrides extends AuthOperationOptions {
 	env?: Record<string, string>;
 	/** Require this much remaining OAuth-token validity; defaults to five minutes. */
 	minOAuthValidityMs?: number;
+	/** Resolve against one named slot of a pooled credential instead of the flat projection. */
+	slotName?: string;
 }
+
+/**
+ * Stream options plus the coding-agent-only affinity key. It is declared here
+ * rather than widening the engine's `StreamOptions`: a stable key (the session
+ * id) keeps one conversation on one credential slot, and its absence simply
+ * distributes requests instead of concentrating them.
+ */
+export type CredentialRotationStreamOptions = StreamOptions & ModelsRequestTransforms & { affinityKey?: string };
 
 export type CredentialSynchronizationOperation = "login" | "logout" | "setRuntimeApiKey" | "removeRuntimeApiKey";
 
@@ -169,6 +185,7 @@ export class ModelRuntime implements Models {
 	private readonly providerAvailabilitySeq = new Map<string, number>();
 	private availabilityError: string | undefined;
 	private readonly credentialOperations = new Map<string, Promise<unknown>>();
+	private readonly credentialSlots = new CredentialSlotRepository();
 	private constructor(
 		credentials: RuntimeCredentials,
 		config: ModelConfig,
@@ -636,6 +653,7 @@ export class ModelRuntime implements Models {
 	private async prepareRequest<TOptions extends ProviderRequestOptions & ModelsRequestTransforms>(
 		model: Model<Api>,
 		options: TOptions | undefined,
+		slotAuth?: { apiKey?: string; slotName?: string },
 	): Promise<{
 		provider: Provider;
 		model: Model<Api>;
@@ -644,9 +662,10 @@ export class ModelRuntime implements Models {
 		const provider = this.models.getProvider(model.provider);
 		if (!provider) throw new ModelsError("provider", `Unknown provider: ${model.provider}`);
 		const resolution = await this.getAuth(model, {
-			apiKey: options?.apiKey,
+			apiKey: slotAuth?.apiKey ?? options?.apiKey,
 			env: options?.env,
 			signal: options?.signal,
+			...(slotAuth?.slotName === undefined ? {} : { slotName: slotAuth.slotName }),
 		});
 		if (!resolution) throw new ModelsError("auth", `Provider is not configured: ${model.provider}`);
 
@@ -678,12 +697,36 @@ export class ModelRuntime implements Models {
 			model: requestModel,
 			options: {
 				...providerOptions,
-				apiKey: providerOptions.apiKey ?? resolution.auth.apiKey,
+				apiKey: slotAuth?.apiKey ?? providerOptions.apiKey ?? resolution.auth.apiKey,
 				headers,
 				extraBody,
 				env,
 			} as Omit<TOptions, "transformHeaders"> & ProviderRequestOptions,
 		};
+	}
+
+	/**
+	 * Rotation engages only for a provider that actually holds more than one
+	 * credential slot and only when nothing pins the request to one credential
+	 * (a runtime key or an explicit per-request apiKey). Every single-credential
+	 * user therefore keeps byte-identical request behavior.
+	 */
+	private async credentialRotationSources(
+		model: Model<Api>,
+		options: CredentialRotationStreamOptions | undefined,
+	): Promise<RotationSources | undefined> {
+		if (options?.apiKey !== undefined) return undefined;
+		if (this.credentials.hasRuntimeApiKey(model.provider)) return undefined;
+		if (this.config.getProvider(model.provider)?.credentials?.rotation === false) return undefined;
+		const credential = await this.credentials.read(model.provider, { signal: options?.signal });
+		const sources: RotationSources = {
+			providerId: model.provider,
+			credential,
+			env: (name: string) => options?.env?.[name] ?? process.env[name],
+			repository: this.credentialSlots,
+		};
+		const slots = await listRotationSlots(sources);
+		return slots.length > 1 ? sources : undefined;
 	}
 
 	stream<TApi extends Api>(
@@ -692,10 +735,30 @@ export class ModelRuntime implements Models {
 		options?: ModelsApiStreamOptions<TApi>,
 	): AssistantMessageEventStream {
 		return lazyStream(model, async () => {
-			const prepared = await this.prepareRequest(
-				model,
-				options as (StreamOptions & ModelsRequestTransforms) | undefined,
-			);
+			const streamOptions = options as CredentialRotationStreamOptions | undefined;
+			const sources = await this.credentialRotationSources(model, streamOptions);
+			if (sources) {
+				return streamWithCredentialRotation({
+					sources,
+					...(streamOptions?.affinityKey === undefined ? {} : { affinityKey: streamOptions.affinityKey }),
+					runAttempt: async (slot) => {
+						const prepared = await this.prepareRequest(
+							model,
+							streamOptions,
+							slot.lane === "env"
+								? { ...(slot.envKey === undefined ? {} : { apiKey: slot.envKey }) }
+								: { slotName: slot.name },
+						);
+						const attempt = prepared.provider.stream(
+							prepared.model as Model<TApi>,
+							context,
+							withPayloadRequestMetadata(prepared.options, prepared.model) as ApiStreamOptions<TApi>,
+						);
+						return wrapStreamWithModelRecovery(attempt, model, context.tools ?? []);
+					},
+				});
+			}
+			const prepared = await this.prepareRequest(model, streamOptions);
 			const inner = prepared.provider.stream(
 				prepared.model as Model<TApi>,
 				context,

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -17,6 +17,7 @@ import {
 	type DeferredCancelOptions,
 	type DeferredFetchOptions,
 	type DeferredHandle,
+	getApiKeyEnvVars,
 	lazyStream,
 	type Model,
 	type Models,
@@ -43,12 +44,7 @@ import { APP_NAME, BRAND, getAgentDir } from "../config.ts";
 import { operationSignal, raceWithAbortSignal } from "../utils/abort.ts";
 import { AuthStorage as DefaultAuthStorage } from "./auth-storage.ts";
 import { envValue } from "./brand.ts";
-import {
-	listRotationSlots,
-	type RotationSources,
-	streamWithCredentialRotation,
-} from "./credential-pool/rotation-stream.ts";
-import { CredentialSlotRepository } from "./credential-pool/state-store.ts";
+import type { RotationSources } from "./credential-pool/rotation-stream.ts";
 import { ModelConfig } from "./model-config.ts";
 import { FileModelsStore, InMemoryCodingAgentModelsStore } from "./models-store.ts";
 import {
@@ -110,6 +106,35 @@ export interface ModelRuntimeAuthOverrides extends AuthOperationOptions {
  * distributes requests instead of concentrating them.
  */
 export type CredentialRotationStreamOptions = StreamOptions & ModelsRequestTransforms & { affinityKey?: string };
+
+/**
+ * Cheap pre-check answering "could this provider hold more than one credential
+ * at all?" without loading the credential pool. A stored entry pools only
+ * through `accounts`; env slots participate only when nothing is stored, and a
+ * lone primary variable is still a single credential.
+ */
+function mightHoldEnvCredentialPool(providerId: string, env: (name: string) => string | undefined): boolean {
+	const envVars = getApiKeyEnvVars(providerId);
+	const primary = envVars?.find((name) => name.endsWith("_API_KEY")) ?? envVars?.[0];
+	if (primary === undefined) return false;
+	let found = env(primary) ? 1 : 0;
+	for (let index = 2; index <= 16 && found < 2; index++) {
+		if (env(`${primary}_${index}`)) found++;
+	}
+	return found > 1;
+}
+
+function mightHoldCredentialPool(
+	providerId: string,
+	credential: Credential | undefined,
+	env: (name: string) => string | undefined,
+): boolean {
+	if (credential) {
+		const accounts = Object.entries(credential).find(([key]) => key === "accounts")?.[1];
+		return Array.isArray(accounts) && accounts.length > 1;
+	}
+	return mightHoldEnvCredentialPool(providerId, env);
+}
 
 export type CredentialSynchronizationOperation = "login" | "logout" | "setRuntimeApiKey" | "removeRuntimeApiKey";
 
@@ -185,7 +210,18 @@ export class ModelRuntime implements Models {
 	private readonly providerAvailabilitySeq = new Map<string, number>();
 	private availabilityError: string | undefined;
 	private readonly credentialOperations = new Map<string, Promise<unknown>>();
-	private readonly credentialSlots = new CredentialSlotRepository();
+	/**
+	 * The credential pool is loaded lazily and only for a provider that actually
+	 * has more than one slot. Importing it eagerly would pull the pool's schema
+	 * validator - and its module-level global registry - into every consumer of
+	 * ModelRuntime, which the import-graph guard forbids.
+	 */
+	private credentialPoolModules:
+		| Promise<{
+				rotation: typeof import("./credential-pool/rotation-stream.ts");
+				repository: InstanceType<typeof import("./credential-pool/state-store.ts").CredentialSlotRepository>;
+		  }>
+		| undefined;
 	private constructor(
 		credentials: RuntimeCredentials,
 		config: ModelConfig,
@@ -711,21 +747,47 @@ export class ModelRuntime implements Models {
 	 * (a runtime key or an explicit per-request apiKey). Every single-credential
 	 * user therefore keeps byte-identical request behavior.
 	 */
+	private loadCredentialPool(): NonNullable<typeof this.credentialPoolModules> {
+		this.credentialPoolModules ??= (async () => {
+			const [rotation, stateStore] = await Promise.all([
+				import("./credential-pool/rotation-stream.ts"),
+				import("./credential-pool/state-store.ts"),
+			]);
+			return { rotation, repository: new stateStore.CredentialSlotRepository() };
+		})();
+		return this.credentialPoolModules;
+	}
+
+	/**
+	 * Fully synchronous admission check. A provider that cannot possibly hold a
+	 * pool must not even reach the async rotation path: awaiting an async method
+	 * costs a microtask hop, which would reorder an ordinary request's provider
+	 * call relative to the untouched `streamSimple` path.
+	 */
+	private couldRotateCredentials(model: Model<Api>, options: CredentialRotationStreamOptions | undefined): boolean {
+		if (options?.apiKey !== undefined) return false;
+		if (this.credentials.hasRuntimeApiKey(model.provider)) return false;
+		if (this.config.getProvider(model.provider)?.credentials?.rotation === false) return false;
+		const env = (name: string) => options?.env?.[name] ?? process.env[name];
+		if (this.snapshot.storedProviders.has(model.provider)) return true;
+		return mightHoldEnvCredentialPool(model.provider, env);
+	}
+
 	private async credentialRotationSources(
 		model: Model<Api>,
 		options: CredentialRotationStreamOptions | undefined,
 	): Promise<RotationSources | undefined> {
-		if (options?.apiKey !== undefined) return undefined;
-		if (this.credentials.hasRuntimeApiKey(model.provider)) return undefined;
-		if (this.config.getProvider(model.provider)?.credentials?.rotation === false) return undefined;
+		const env = (name: string) => options?.env?.[name] ?? process.env[name];
 		const credential = await this.credentials.read(model.provider, { signal: options?.signal });
+		if (!mightHoldCredentialPool(model.provider, credential, env)) return undefined;
+		const pool = await this.loadCredentialPool();
 		const sources: RotationSources = {
 			providerId: model.provider,
 			credential,
-			env: (name: string) => options?.env?.[name] ?? process.env[name],
-			repository: this.credentialSlots,
+			env,
+			repository: pool.repository,
 		};
-		const slots = await listRotationSlots(sources);
+		const slots = await pool.rotation.listRotationSlots(sources);
 		return slots.length > 1 ? sources : undefined;
 	}
 
@@ -736,9 +798,12 @@ export class ModelRuntime implements Models {
 	): AssistantMessageEventStream {
 		return lazyStream(model, async () => {
 			const streamOptions = options as CredentialRotationStreamOptions | undefined;
-			const sources = await this.credentialRotationSources(model, streamOptions);
+			const sources = this.couldRotateCredentials(model, streamOptions)
+				? await this.credentialRotationSources(model, streamOptions)
+				: undefined;
 			if (sources) {
-				return streamWithCredentialRotation({
+				const { rotation } = await this.loadCredentialPool();
+				return rotation.streamWithCredentialRotation({
 					sources,
 					...(streamOptions?.affinityKey === undefined ? {} : { affinityKey: streamOptions.affinityKey }),
 					runAttempt: async (slot) => {

--- a/packages/coding-agent/test/auth-storage-pool.test.ts
+++ b/packages/coding-agent/test/auth-storage-pool.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PooledCredential } from "@earendil-works/pi-ai/auth/pool/slots";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { AuthStorage, ReadOnlyAuthStorage } from "../src/core/auth-storage.ts";
+
+const FUTURE = 4_102_444_800_000;
+
+let dir: string;
+let authPath: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "auth-pool-"));
+	authPath = join(dir, "auth.json");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function writeAuthFile(data: Record<string, unknown>): string {
+	const content = JSON.stringify(data, null, 2);
+	writeFileSync(authPath, content, { encoding: "utf-8", mode: 0o600 });
+	return content;
+}
+
+function pooledOAuthEntry(): PooledCredential {
+	return {
+		type: "oauth",
+		access: "flat-access",
+		refresh: "flat-refresh",
+		expires: FUTURE,
+		accounts: [
+			{ name: "default", access: "flat-access", refresh: "flat-refresh", expires: FUTURE, source: "login" },
+			{ name: "work", access: "work-access", refresh: "work-refresh", expires: FUTURE, source: "login" },
+		],
+		pinned: "work",
+	};
+}
+
+describe("auth.json accepts and preserves credential slots", () => {
+	test("a flat api_key and oauth file reads unchanged and is not rewritten", async () => {
+		const original = writeAuthFile({
+			openai: { type: "api_key", key: "sk-flat" },
+			anthropic: { type: "oauth", access: "a", refresh: "r", expires: FUTURE },
+		});
+
+		const store = AuthStorage.create(authPath);
+		expect(await store.read("openai")).toEqual({ type: "api_key", key: "sk-flat" });
+		expect(await store.read("anthropic")).toMatchObject({ type: "oauth", access: "a" });
+		expect(readFileSync(authPath, "utf-8")).toBe(original);
+	});
+
+	test("a pooled entry reads with accounts and pin preserved, without a rewrite", async () => {
+		const original = writeAuthFile({ pooled: pooledOAuthEntry() });
+
+		const store = AuthStorage.create(authPath);
+		const credential = await store.read("pooled");
+		expect(credential).toMatchObject({ type: "oauth", access: "flat-access", pinned: "work" });
+		const pooled = credential as PooledCredential;
+		expect(pooled.accounts?.map((slot) => slot.name)).toEqual(["default", "work"]);
+		expect(readFileSync(authPath, "utf-8")).toBe(original);
+	});
+
+	test("ReadOnlyAuthStorage accepts a pooled entry through its validator", async () => {
+		writeAuthFile({ pooled: pooledOAuthEntry() });
+
+		const store = new ReadOnlyAuthStorage(authPath);
+		const credential = (await store.read("pooled")) as PooledCredential;
+		expect(credential.accounts?.length).toBe(2);
+		expect(credential.pinned).toBe("work");
+	});
+
+	test("a modify that returns the current entry preserves pool bytes", async () => {
+		const original = writeAuthFile({ pooled: pooledOAuthEntry() });
+
+		const store = AuthStorage.create(authPath);
+		await store.modify("pooled", async (current) => current);
+		expect(readFileSync(authPath, "utf-8")).toBe(original);
+	});
+
+	test("a pooled write keeps auth.json at mode 0600", async () => {
+		const store = AuthStorage.create(authPath);
+		await store.modify("pooled", async () => pooledOAuthEntry());
+
+		expect(statSync(authPath).mode & 0o777).toBe(0o600);
+		const reread = (await store.read("pooled")) as PooledCredential;
+		expect(reread.accounts?.map((slot) => slot.name)).toEqual(["default", "work"]);
+	});
+
+	test("a pooled oauth entry without its flat projection is rejected by the read-only validator", async () => {
+		writeAuthFile({
+			broken: {
+				type: "oauth",
+				accounts: [{ name: "only", access: "x", refresh: "y", expires: FUTURE, source: "login" }],
+			},
+		});
+
+		const store = new ReadOnlyAuthStorage(authPath);
+		await expect(store.read("broken")).rejects.toThrow('Invalid auth.json credential for provider "broken"');
+	});
+});

--- a/packages/coding-agent/test/credential-error-taxonomy.test.ts
+++ b/packages/coding-agent/test/credential-error-taxonomy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import {
+	COOLDOWN_BASE_MS,
+	COOLDOWN_CAP_MS,
+	classifyCredentialFailure,
+	rateLimitCooldown,
+} from "../src/core/credential-pool/classify.ts";
+
+function status(code: number, message = `HTTP ${code}`): Error {
+	const error = new Error(message);
+	Object.assign(error, { status: code });
+	return error;
+}
+
+describe("credential error taxonomy", () => {
+	test.each([
+		["401", status(401, "Unauthorized"), "failover", "auth_error"],
+		["invalid api key", new Error("invalid api key provided"), "failover", "auth_error"],
+		["403 with account code", status(403, "account suspended for this credential"), "failover", "auth_error"],
+		["402 billing", status(402, "Payment Required"), "failover", "account_disabled"],
+		["credits exhausted", new Error("billing: credits exhausted for this org"), "failover", "account_disabled"],
+	] as const)("%s -> %s/%s", (_label, error, kind, reason) => {
+		const action = classifyCredentialFailure(error);
+		expect(action.kind).toBe(kind);
+		if (action.kind === "failover") expect(action.block.reason).toBe(reason);
+	});
+
+	test("bare 403 fails the request instead of blocking a credential", () => {
+		expect(classifyCredentialFailure(status(403, "Forbidden")).kind).toBe("fail_request");
+	});
+
+	test("429 fails over with an exponential cooldown", () => {
+		const action = classifyCredentialFailure(status(429, "Too Many Requests"), { failureCount: 2 });
+		expect(action.kind).toBe("failover");
+		if (action.kind !== "failover" || action.block.reason !== "rate_limit") throw new Error("expected rate_limit");
+		expect(action.block.cooldownMs).toBe(COOLDOWN_BASE_MS * 4);
+		expect(action.block.retryAfterWasCapped).toBe(false);
+	});
+
+	test.each([
+		["529", status(529, "overloaded")],
+		["500", status(500, "Internal Server Error")],
+		["503", status(503, "Service Unavailable")],
+		["network", new Error("fetch failed: ECONNRESET")],
+		["408", status(408, "Request Timeout")],
+	] as const)("%s retries the same slot and never blocks the credential", (_label, error) => {
+		const action = classifyCredentialFailure(error);
+		expect(action).toEqual({ kind: "retry_same", maxAttempts: 2 });
+	});
+
+	test.each([
+		["context overflow", new Error("prompt is too long: maximum context length exceeded")],
+		["invalid model", new Error("model_not_found: no such model")],
+		["400", status(400, "Bad Request")],
+		["404", status(404, "Not Found")],
+		["malformed stream", new Error("malformed stream frame")],
+		["abort", Object.assign(new Error("The operation was aborted"), { name: "AbortError" })],
+		["unknown", new Error("something inexplicable happened")],
+	] as const)("%s fails the request", (_label, error) => {
+		expect(classifyCredentialFailure(error).kind).toBe("fail_request");
+	});
+
+	test("the server retry hint is a floor, not an override", () => {
+		// A hint shorter than the earned backoff must not shorten the cooldown.
+		expect(rateLimitCooldown(3, 1_000).cooldownMs).toBe(COOLDOWN_BASE_MS * 8);
+		// A hint longer than the backoff lengthens it.
+		expect(rateLimitCooldown(0, 300_000).cooldownMs).toBe(300_000);
+		// Everything caps at 48h with the capping recorded.
+		const capped = rateLimitCooldown(0, COOLDOWN_CAP_MS * 2);
+		expect(capped.cooldownMs).toBe(COOLDOWN_CAP_MS);
+		expect(capped.retryAfterWasCapped).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/credential-failover-composition.test.ts
+++ b/packages/coding-agent/test/credential-failover-composition.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import {
+	CredentialFailoverError,
+	type RunSlot,
+	runCredentialFailover,
+	TURN_RETRY_SUPPRESSION_PREFIX,
+} from "../src/core/credential-pool/failover.ts";
+
+type Event = { type: string };
+
+function rateLimited(): Error {
+	return Object.assign(new Error("rate limited"), { status: 429 });
+}
+
+async function* ok(): AsyncGenerator<Event> {
+	yield { type: "text_delta" };
+}
+
+async function* fail(error: unknown): AsyncGenerator<Event> {
+	throw error;
+	// biome-ignore lint/correctness/noUnreachable: generator needs a yield type
+	yield { type: "never" };
+}
+
+/**
+ * Drives the credential runner the way the session layer composes it: the
+ * model fallback chain (tryFallback) is consulted only when the runner itself
+ * gives up, never once per slot.
+ */
+async function driveRequest(slots: RunSlot[], failing: Set<string>) {
+	let fallbackCalls = 0;
+	const attempts: string[] = [];
+	const stream = runCredentialFailover<Event, RunSlot>({
+		listSlots: () => slots,
+		select: (candidates) => {
+			const slot = candidates[0];
+			if (!slot) throw new Error("no candidate");
+			return slot;
+		},
+		runAttempt: (slot) => {
+			attempts.push(slot.name);
+			return failing.has(slot.name) ? fail(rateLimited()) : ok();
+		},
+		isCommittedOutput: (event) => event.type !== "bookkeeping",
+		persistBlock: (slot) => {
+			const index = slots.findIndex((candidate) => candidate.name === slot.name);
+			slots[index] = { ...slot, blockedUntil: Number.MAX_SAFE_INTEGER, blockReason: "rate_limit" };
+		},
+	});
+	try {
+		const seen: Event[] = [];
+		for await (const event of stream) seen.push(event);
+		return { attempts, fallbackCalls, seen, error: undefined };
+	} catch (error) {
+		// The model chain is the layer ABOVE this runner: one consultation per
+		// exhausted lane, exactly like agent-session routes terminal errors.
+		fallbackCalls += 1;
+		return { attempts, fallbackCalls, seen: [], error };
+	}
+}
+
+describe("credential rotation composes below the model fallback chain", () => {
+	test("a 429 with a healthy sibling rotates in-lane and never reaches tryFallback", async () => {
+		const result = await driveRequest([{ name: "alpha" }, { name: "beta" }], new Set(["alpha"]));
+		expect(result.attempts).toEqual(["alpha", "beta"]);
+		expect(result.seen).toEqual([{ type: "text_delta" }]);
+		expect(result.fallbackCalls).toBe(0);
+	});
+
+	test("a 429 with every slot blocked reaches the model chain exactly once", async () => {
+		const result = await driveRequest([{ name: "alpha" }, { name: "beta" }], new Set(["alpha", "beta"]));
+		expect(result.attempts).toEqual(["alpha", "beta"]);
+		expect(result.fallbackCalls).toBe(1);
+		expect(result.error).toBeInstanceOf(CredentialFailoverError);
+	});
+
+	test("the runner emits the exact marker the session layer already suppresses on", () => {
+		// agent-session.ts consumes this string on message.errorMessage; the
+		// engine constant must stay byte-identical for the Claude path to remain
+		// suppressed by the same mechanism.
+		expect(TURN_RETRY_SUPPRESSION_PREFIX).toBe("senpi:no-turn-retry:");
+	});
+});

--- a/packages/coding-agent/test/credential-failover.test.ts
+++ b/packages/coding-agent/test/credential-failover.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "vitest";
+import type { CredentialBlock } from "../src/core/credential-pool/classify.ts";
+import {
+	CredentialFailoverError,
+	type RunSlot,
+	runCredentialFailover,
+	TURN_RETRY_SUPPRESSION_PREFIX,
+} from "../src/core/credential-pool/failover.ts";
+
+type Event = { type: string };
+
+function firstAvailable(slots: readonly RunSlot[]): RunSlot {
+	const slot = slots[0];
+	if (!slot) throw new Error("no candidate slot");
+	return slot;
+}
+
+async function* events(...items: Event[]): AsyncGenerator<Event> {
+	for (const item of items) yield item;
+}
+
+async function* failWith(error: unknown, ...items: Event[]): AsyncGenerator<Event> {
+	for (const item of items) yield item;
+	throw error;
+}
+
+function rateLimited(): Error {
+	return Object.assign(new Error("rate limited"), { status: 429 });
+}
+
+/** Only bookkeeping frames are pre-commit; everything unknown counts as committed. */
+function committedUnlessBookkeeping(event: Event): boolean {
+	return event.type !== "bookkeeping";
+}
+
+async function collect(stream: AsyncGenerator<Event>): Promise<Event[]> {
+	const seen: Event[] = [];
+	for await (const event of stream) seen.push(event);
+	return seen;
+}
+
+describe("generic credential failover runner", () => {
+	test("rotation happens before the first delta and the block persists before replacement", async () => {
+		const order: string[] = [];
+		const stream = runCredentialFailover<Event, RunSlot>({
+			listSlots: () => {
+				order.push("list");
+				return [{ name: "alpha" }, { name: "beta" }];
+			},
+			select: (slots) => {
+				order.push(`select:${slots.map((slot) => slot.name).join(",")}`);
+				return firstAvailable(slots);
+			},
+			runAttempt: (slot) => {
+				order.push(`attempt:${slot.name}`);
+				return slot.name === "alpha" ? failWith(rateLimited()) : events({ type: "text_delta" });
+			},
+			isCommittedOutput: committedUnlessBookkeeping,
+			persistBlock: (slot, block) => {
+				order.push(`persist:${slot.name}:${block.reason}`);
+			},
+		});
+		const seen = await collect(stream);
+		expect(seen).toEqual([{ type: "text_delta" }]);
+		// The block lands before the replacement slot is even listed or selected.
+		expect(order).toEqual([
+			"list",
+			"select:alpha,beta",
+			"attempt:alpha",
+			"persist:alpha:rate_limit",
+			"list",
+			"select:beta",
+			"attempt:beta",
+		]);
+	});
+
+	test("an UNKNOWN event type sets the committed-output barrier: no rotation, marked error", async () => {
+		const attempts: string[] = [];
+		const persisted: string[] = [];
+		const stream = runCredentialFailover<Event, RunSlot>({
+			listSlots: () => [{ name: "alpha" }, { name: "beta" }],
+			select: firstAvailable,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return failWith(rateLimited(), { type: "mystery_frame" });
+			},
+			isCommittedOutput: committedUnlessBookkeeping,
+			persistBlock: (slot) => {
+				persisted.push(slot.name);
+			},
+		});
+		let caught: unknown;
+		try {
+			await collect(stream);
+		} catch (error) {
+			caught = error;
+		}
+		expect(attempts).toEqual(["alpha"]);
+		// The applicable block still persists even though rotation is barred.
+		expect(persisted).toEqual(["alpha"]);
+		expect(caught).toBeInstanceOf(CredentialFailoverError);
+		expect((caught as CredentialFailoverError).suppressTurnRetry).toBe(true);
+		expect((caught as CredentialFailoverError).message.startsWith(TURN_RETRY_SUPPRESSION_PREFIX)).toBe(true);
+	});
+
+	test("a newly added slot participates because slots re-read per attempt", async () => {
+		let reads = 0;
+		const attempts: string[] = [];
+		const stream = runCredentialFailover<Event, RunSlot>({
+			listSlots: () => {
+				reads += 1;
+				return reads === 1 ? [{ name: "alpha" }] : [{ name: "alpha" }, { name: "fresh" }];
+			},
+			select: firstAvailable,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return slot.name === "fresh" ? events({ type: "text_delta" }) : failWith(rateLimited());
+			},
+			isCommittedOutput: committedUnlessBookkeeping,
+			persistBlock: () => {},
+		});
+		await collect(stream);
+		expect(attempts).toEqual(["alpha", "fresh"]);
+	});
+
+	test("retry_same reruns the same slot at most twice without blocking it", async () => {
+		const attempts: string[] = [];
+		const persisted: string[] = [];
+		const stream = runCredentialFailover<Event, RunSlot>({
+			listSlots: () => [{ name: "alpha" }, { name: "beta" }],
+			select: firstAvailable,
+			runAttempt: (slot) => {
+				attempts.push(slot.name);
+				return failWith(Object.assign(new Error("overloaded"), { status: 529 }));
+			},
+			isCommittedOutput: committedUnlessBookkeeping,
+			persistBlock: (slot) => {
+				persisted.push(slot.name);
+			},
+		});
+		let caught: unknown;
+		try {
+			await collect(stream);
+		} catch (error) {
+			caught = error;
+		}
+		expect(attempts).toEqual(["alpha", "alpha"]);
+		expect(persisted).toEqual([]);
+		expect((caught as CredentialFailoverError).action.kind).toBe("retry_same");
+		expect((caught as CredentialFailoverError).suppressTurnRetry).toBe(false);
+	});
+
+	test("pool exhaustion carries retryAt and the original error as cause", async () => {
+		const NOW = 1_756_000_000_000;
+		let blocked: { name: string; blockedUntil: number } | undefined;
+		const original = rateLimited();
+		const stream = runCredentialFailover<Event, RunSlot>({
+			listSlots: () =>
+				blocked
+					? [{ name: "alpha", blockedUntil: blocked.blockedUntil, blockReason: "rate_limit" }]
+					: [{ name: "alpha" }],
+			select: firstAvailable,
+			runAttempt: () => failWith(original),
+			isCommittedOutput: committedUnlessBookkeeping,
+			persistBlock: (slot, block) => {
+				const cooldownMs = block.reason === "rate_limit" ? block.cooldownMs : 0;
+				blocked = { name: slot.name, blockedUntil: NOW + cooldownMs };
+			},
+			now: () => NOW,
+		});
+		let caught: unknown;
+		try {
+			await collect(stream);
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(CredentialFailoverError);
+		const failure = caught as CredentialFailoverError;
+		expect(failure.retryAt).toBe(NOW + 60_000);
+		expect(failure.cause).toBe(original);
+	});
+});

--- a/packages/coding-agent/test/credential-failover.test.ts
+++ b/packages/coding-agent/test/credential-failover.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "vitest";
-import type { CredentialBlock } from "../src/core/credential-pool/classify.ts";
 import {
 	CredentialFailoverError,
 	type RunSlot,

--- a/packages/coding-agent/test/credential-pool-state-store.test.ts
+++ b/packages/coding-agent/test/credential-pool-state-store.test.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	acquireHalfOpenLease,
+	CredentialSlotRepository,
+	credentialPoolStatePath,
+	slotHealth,
+} from "../src/core/credential-pool/state-store.ts";
+
+const NOW = 1_756_000_000_000;
+
+let dir: string;
+let path: string;
+let repository: CredentialSlotRepository;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "cred-pool-state-"));
+	path = join(dir, "credential-pool-state.json");
+	repository = new CredentialSlotRepository(path);
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("credential pool state sidecar", () => {
+	test("default path lives in the agent dir", () => {
+		expect(credentialPoolStatePath("/tmp/agent")).toBe("/tmp/agent/credential-pool-state.json");
+	});
+
+	test("a cooldown written before a restart still suppresses the slot after re-reading", async () => {
+		await repository.mutateSlotState("openai", "api", "work", () => ({
+			blockedUntil: NOW + 120_000,
+			blockReason: "rate_limit",
+			failureCount: 1,
+		}));
+
+		const restarted = new CredentialSlotRepository(path);
+		const slots = await restarted.listSlots("openai", "api");
+		expect(slots.work).toMatchObject({ blockedUntil: NOW + 120_000, blockReason: "rate_limit" });
+		expect(slotHealth(slots.work, NOW)).toBe("blocked");
+	});
+
+	test("stateVersion increments on every mutation and deletion removes the slot", async () => {
+		const first = await repository.mutateSlotState("openai", "api", "work", () => ({ failureCount: 1 }));
+		const second = await repository.mutateSlotState("openai", "api", "work", (current) => ({
+			...current,
+			failureCount: 2,
+		}));
+		expect(first?.stateVersion).toBe(1);
+		expect(second?.stateVersion).toBe(2);
+
+		await repository.mutateSlotState("openai", "api", "work", () => undefined);
+		expect(await repository.listSlots("openai", "api")).toEqual({});
+	});
+
+	test("an expired cooldown becomes half_open via exactly one lease, not blocked or ready", async () => {
+		await repository.mutateSlotState("openai", "api", "work", () => ({
+			blockedUntil: NOW - 1_000,
+			blockReason: "rate_limit",
+		}));
+
+		const lease = await acquireHalfOpenLease(repository, "openai", "api", "work", { now: NOW });
+		expect(lease?.leaseId).toBeTruthy();
+		const slots = await repository.listSlots("openai", "api");
+		expect(slotHealth(slots.work, NOW)).toBe("half_open");
+
+		const second = await acquireHalfOpenLease(repository, "openai", "api", "work", { now: NOW });
+		expect(second).toBeUndefined();
+	});
+
+	test("an auth block never leases a probe; only re-login clears it", async () => {
+		await repository.mutateSlotState("openai", "api", "work", () => ({
+			blockedUntil: NOW - 1_000,
+			blockReason: "auth_error",
+		}));
+
+		const lease = await acquireHalfOpenLease(repository, "openai", "api", "work", { now: NOW });
+		expect(lease).toBeUndefined();
+	});
+
+	test("the installation key is stable and env revisions rotate with the value", async () => {
+		const key1 = await repository.installationKey();
+		const key2 = await new CredentialSlotRepository(path).installationKey();
+		expect(key1).toBe(key2);
+		expect(key1).toMatch(/^[0-9a-f]{64}$/);
+
+		const revisionA = await repository.envCredentialRevision("OPENAI_API_KEY", "value-a");
+		const revisionASame = await repository.envCredentialRevision("OPENAI_API_KEY", "value-a");
+		const revisionB = await repository.envCredentialRevision("OPENAI_API_KEY", "value-b");
+		expect(revisionA).toBe(revisionASame);
+		expect(revisionA).not.toBe(revisionB);
+		expect(readFileSync(path, "utf-8")).not.toContain("value-a");
+	});
+
+	test("the sidecar file is created at mode 0600 and an invalid document self-heals", async () => {
+		await repository.mutateSlotState("openai", "api", "work", () => ({ failureCount: 1 }));
+		expect(statSync(path).mode & 0o777).toBe(0o600);
+
+		const { writeFileSync } = await import("node:fs");
+		writeFileSync(path, "not json at all", { encoding: "utf-8", mode: 0o600 });
+		const healed = new CredentialSlotRepository(path);
+		expect(await healed.listSlots("openai", "api")).toEqual({});
+		const state = await healed.mutateSlotState("openai", "api", "work", () => ({ failureCount: 1 }));
+		expect(state?.stateVersion).toBe(1);
+	});
+});

--- a/packages/coding-agent/test/env-credential-slots.test.ts
+++ b/packages/coding-agent/test/env-credential-slots.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import { InMemoryCredentialStore } from "../../ai/src/auth/credential-store.ts";
+import { envApiKeyAuth } from "../../ai/src/auth/helpers.ts";
+import { resolveProviderAuth } from "../../ai/src/auth/resolve.ts";
+import { discoverEnvSlots, primaryEnvVar } from "../src/core/credential-pool/env-slots.ts";
+
+function envFrom(values: Record<string, string>): (name: string) => string | undefined {
+	return (name) => values[name];
+}
+
+describe("numbered env credential slots", () => {
+	test("OPENAI_API_KEY plus OPENAI_API_KEY_2 yield a two-slot pool", () => {
+		const slots = discoverEnvSlots("openai", envFrom({ OPENAI_API_KEY: "sk-one", OPENAI_API_KEY_2: "sk-two" }));
+		expect(slots).toEqual([
+			{ name: "env", envVarName: "OPENAI_API_KEY", key: "sk-one", source: "env" },
+			{ name: "env-2", envVarName: "OPENAI_API_KEY_2", key: "sk-two", source: "env" },
+		]);
+	});
+
+	test("a numbering gap is tolerated without inventing slots", () => {
+		const slots = discoverEnvSlots("openai", envFrom({ OPENAI_API_KEY_3: "sk-three" }));
+		expect(slots).toEqual([{ name: "env-3", envVarName: "OPENAI_API_KEY_3", key: "sk-three", source: "env" }]);
+	});
+
+	test("anthropic numbered slots extend the API-key var, not the token vars", () => {
+		expect(primaryEnvVar("anthropic")).toBe("ANTHROPIC_API_KEY");
+	});
+
+	test("an unmapped provider yields no env slots", () => {
+		expect(discoverEnvSlots("no-such-provider", envFrom({ NO_SUCH_PROVIDER_API_KEY: "x" }))).toEqual([]);
+	});
+
+	test("a stored credential still outranks every env slot at resolution", async () => {
+		const store = new InMemoryCredentialStore();
+		await store.modify("envtest", async () => ({ type: "api_key", key: "stored-key" }));
+		const provider = {
+			id: "envtest",
+			auth: { apiKey: envApiKeyAuth("Env Test API key", ["ENVTEST_API_KEY"]) },
+		};
+		const authContext = {
+			env: async (name: string) => ({ ENVTEST_API_KEY: "env-key", ENVTEST_API_KEY_2: "env-key-2" })[name],
+			fileExists: async () => false,
+		};
+
+		const resolved = await resolveProviderAuth(provider, store, authContext);
+
+		expect(resolved?.auth.apiKey).toBe("stored-key");
+	});
+});

--- a/packages/coding-agent/test/model-config-credentials-schema.test.ts
+++ b/packages/coding-agent/test/model-config-credentials-schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest";
+import { CREDENTIAL_POLICY_DEFAULTS, validateModelsConfig } from "../src/core/model-config-schema.ts";
+
+function config(credentials: unknown): unknown {
+	return { providers: { openai: { credentials } } };
+}
+
+describe("models.json credentials policy schema", () => {
+	test("defaults mirror the pool engine constants", () => {
+		expect(CREDENTIAL_POLICY_DEFAULTS).toEqual({
+			rotation: true,
+			affinity: true,
+			cooldownBaseMs: 60_000,
+			cooldownCapMs: 172_800_000,
+		});
+	});
+
+	test("a full valid policy block is accepted", () => {
+		const valid = config({
+			rotation: true,
+			affinity: false,
+			cooldownBaseMs: 30_000,
+			cooldownCapMs: 3_600_000,
+			slots: { work: { env: "OPENAI_API_KEY_2" }, personal: { value: "!op read op://vault/key" } },
+		});
+		expect(validateModelsConfig.Check(valid)).toBe(true);
+	});
+
+	test("a provider without a credentials block stays valid", () => {
+		expect(validateModelsConfig.Check({ providers: { openai: {} } })).toBe(true);
+	});
+
+	test("a negative cooldown is rejected", () => {
+		expect(validateModelsConfig.Check(config({ cooldownBaseMs: -1 }))).toBe(false);
+	});
+
+	test("an unknown key inside the policy block is rejected", () => {
+		expect(validateModelsConfig.Check(config({ rotate: true }))).toBe(false);
+	});
+
+	test("a literal apiKey inside the policy block is rejected", () => {
+		expect(validateModelsConfig.Check(config({ apiKey: "sk-secret" }))).toBe(false);
+	});
+
+	test("a slot reference with an unknown key is rejected", () => {
+		expect(validateModelsConfig.Check(config({ slots: { work: { apiKey: "sk-secret" } } }))).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
+++ b/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
@@ -1,0 +1,179 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AssistantMessage, AssistantMessageEvent } from "@earendil-works/pi-ai";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import type { PooledCredential } from "@earendil-works/pi-ai/auth/pool/slots";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	listRotationSlots,
+	sha256SlotHasher,
+	streamWithCredentialRotation,
+} from "../src/core/credential-pool/rotation-stream.ts";
+import { CredentialSlotRepository } from "../src/core/credential-pool/state-store.ts";
+
+const NOW = 1_756_000_000_000;
+
+let dir: string;
+let repository: CredentialSlotRepository;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "rotation-stream-"));
+	repository = new CredentialSlotRepository(join(dir, "credential-pool-state.json"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function pooled(): PooledCredential {
+	return {
+		type: "api_key",
+		key: "key-default",
+		accounts: [
+			{ name: "default", key: "key-default", source: "login" },
+			{ name: "work", key: "key-work", source: "login" },
+		],
+	};
+}
+
+function partialMessage(errorMessage?: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "openai-completions",
+		provider: "test",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: errorMessage === undefined ? "stop" : "error",
+		...(errorMessage === undefined ? {} : { errorMessage }),
+		timestamp: Date.now(),
+	};
+}
+
+function startEvent(): AssistantMessageEvent {
+	return { type: "start", partial: partialMessage() };
+}
+
+function textEvent(text: string): AssistantMessageEvent {
+	return { type: "text_delta", contentIndex: 0, delta: text, partial: partialMessage() };
+}
+
+function errorEvent(message: string): AssistantMessageEvent {
+	return { type: "error", reason: "error", error: partialMessage(message) };
+}
+
+async function* stream(...items: AssistantMessageEvent[]): AsyncGenerator<AssistantMessageEvent> {
+	for (const item of items) yield item;
+}
+
+async function collect(source: AsyncGenerator<AssistantMessageEvent>): Promise<AssistantMessageEvent[]> {
+	const seen: AssistantMessageEvent[] = [];
+	for await (const event of source) seen.push(event);
+	return seen;
+}
+
+describe("credential rotation over a pooled provider", () => {
+	test("lists both stored slots with sidecar health overlaid", async () => {
+		await repository.mutateSlotState("test", "stored", "work", () => ({
+			blockedUntil: NOW + 60_000,
+			blockReason: "rate_limit",
+		}));
+
+		const slots = await listRotationSlots({
+			providerId: "test",
+			credential: pooled(),
+			env: () => undefined,
+			repository,
+		});
+
+		expect(slots.map((slot) => slot.name)).toEqual(["default", "work"]);
+		expect(slots[1]).toMatchObject({ lane: "stored", blockedUntil: NOW + 60_000, blockReason: "rate_limit" });
+	});
+
+	test("a 429 before any delta rotates to the sibling slot and persists the cooldown", async () => {
+		const attempted: string[] = [];
+		const events = await collect(
+			streamWithCredentialRotation({
+				sources: { providerId: "test", credential: pooled(), env: () => undefined, repository, now: () => NOW },
+				affinityKey: "session-1",
+				hasher: sha256SlotHasher,
+				runAttempt: (slot) => {
+					attempted.push(slot.name);
+					return attempted.length === 1
+						? stream(startEvent(), errorEvent("429 rate limited"))
+						: stream(startEvent(), textEvent("hello"));
+				},
+			}),
+		);
+
+		expect(attempted).toHaveLength(2);
+		expect(attempted[0]).not.toBe(attempted[1]);
+		expect(events.some((event) => event.type === "text_delta")).toBe(true);
+		const persisted = await repository.listSlots("test", "stored");
+		const blocked = persisted[attempted[0] ?? ""];
+		expect(blocked).toMatchObject({ blockReason: "rate_limit" });
+		expect(blocked?.blockedUntil).toBe(NOW + 60_000);
+	});
+
+	test("the same affinity key sticks to the same slot with no config present", async () => {
+		const chosen: string[] = [];
+		for (let index = 0; index < 3; index++) {
+			await collect(
+				streamWithCredentialRotation({
+					sources: { providerId: "test", credential: pooled(), env: () => undefined, repository },
+					affinityKey: "stable-session",
+					runAttempt: (slot) => {
+						chosen.push(slot.name);
+						return stream(startEvent(), textEvent("ok"));
+					},
+				}),
+			);
+		}
+		expect(new Set(chosen).size).toBe(1);
+	});
+
+	test("a failure after a delta never rotates and carries the suppression marker", async () => {
+		const attempted: string[] = [];
+		let caught: unknown;
+		try {
+			await collect(
+				streamWithCredentialRotation({
+					sources: { providerId: "test", credential: pooled(), env: () => undefined, repository },
+					affinityKey: "session-2",
+					runAttempt: (slot) => {
+						attempted.push(slot.name);
+						return stream(startEvent(), textEvent("partial"), errorEvent("429 rate limited"));
+					},
+				}),
+			);
+		} catch (error) {
+			caught = error;
+		}
+		expect(attempted).toHaveLength(1);
+		expect((caught as Error).message.startsWith("senpi:no-turn-retry:")).toBe(true);
+	});
+
+	test("env slots form a pool and a rotated env value clears its own stale block", async () => {
+		const env = (name: string) => ({ OPENAI_API_KEY: "sk-one", OPENAI_API_KEY_2: "sk-two" })[name];
+		const staleRevision = await repository.envCredentialRevision("OPENAI_API_KEY", "sk-old");
+		await repository.mutateSlotState("openai", "env", "env", () => ({
+			blockedUntil: NOW + 600_000,
+			blockReason: "rate_limit",
+			credentialRevision: staleRevision,
+		}));
+
+		const slots = await listRotationSlots({ providerId: "openai", credential: undefined, env, repository });
+
+		expect(slots.map((slot) => slot.name)).toEqual(["env", "env-2"]);
+		// The persisted block belonged to the previous value of OPENAI_API_KEY.
+		expect(slots[0]?.blockedUntil).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
+++ b/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
@@ -2,7 +2,6 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantMessage, AssistantMessageEvent } from "@earendil-works/pi-ai";
-import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
 import type { PooledCredential } from "@earendil-works/pi-ai/auth/pool/slots";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {


### PR DESCRIPTION
## What

Wave 3 of generic multi-credential support (follows #1093 foundation and #1154 engine): credential-pool persistence, the concrete failure taxonomy, the request-level failover runner, declarative policy, numbered env slots, and the **live wiring** that makes rotation actually happen inside a provider request.

- **`core/credential-pool/state-store.ts`** — file-locked health sidecar at `<agent-dir>/credential-pool-state.json` (mode 0600, shared `FILE_STORAGE_LOCK_OPTIONS`). Holds **only health**: absolute cooldown deadlines, permanent auth/billing blocks, half-open probe leases, `lastSuccessAt`, and HMAC-derived env-slot revisions. `mutateSlotState` is an atomic read-modify-write with a `stateVersion` increment; `acquireHalfOpenLease` hands an elapsed cooldown to exactly one probing caller. An unreadable or schema-invalid document resets to fresh state rather than failing auth resolution.
- **`core/credential-pool/classify.ts`** — concrete taxonomy over the existing `normalizeProviderError` + 429 retry-hint parser. 401/invalid-key and account-scoped 403 block permanently and fail over; bare 403 fails the request; 429 fails over with a per-slot exponential cooldown **floored** (never overridden) by the server hint and capped at 48h; billing disables the account; 5xx/529/overload/network **retry the same slot without blocking it**; overflow/invalid-model/400/404/malformed-stream/abort fail the request.
- **`core/credential-pool/failover.ts`** — `runCredentialFailover` re-reads slots before each distinct-credential attempt (a newly added slot participates), runs at most one failover attempt per slot per request, settles a failed stream before starting the next, persists the block **before** selecting a replacement, and requires an `isCommittedOutput` predicate whose contract is **default-DENY**.
- **`core/credential-pool/env-slots.ts`** — numbered env credential slots for any provider (`<VAR>`, `<VAR>_2` .. `<VAR>_16`), gap-tolerant, over the canonical `getApiKeyEnvVars` mapping (newly exported from `pi-ai`).
- **`core/credential-pool/rotation-stream.ts` + `core/model-runtime.ts`** — `ModelRuntime.stream` engages rotation **only** when the provider actually holds more than one slot and nothing pins the request to one credential (runtime key, explicit per-request `apiKey`, or `credentials.rotation: false`). Slot choice is sha256 HRW over the request affinity key; each attempt resolves its own slot through `prepareRequest`; blocks persist per lane.
- **`core/model-config-schema.ts`** — per-provider `credentials` policy block (`additionalProperties: false`) with `rotation`/`affinity` toggles, cooldown bounds, and named slot references. `CREDENTIAL_POLICY_DEFAULTS` re-exports the engine constants so schema and runtime cannot drift.

## Data safety

- Single-credential providers take the unchanged code path — rotation is gated on `slots.length > 1`.
- Health **never** enters `auth.json`; the sidecar is a separate file and stores no credential material (asserted by a repo gate: `rg "credential\.access|credential\.refresh|\.apiKey" state-store.ts` exits 1).
- Env-slot health is keyed by an installation-local HMAC revision, so rotating a key in place clears its own stale block and no raw key hash is ever persisted.
- Rotation is transparent only before committed output; afterwards the rethrow carries the existing `senpi:no-turn-retry:` marker, so a partially streamed turn is never replayed.
- The policy block holds policy and references only; literal key material inside it is rejected by validation.

## Tests

102 assertions across 12 files, including the Wave 1/2 regressions (`auth-storage`, slot writes, pool concurrency, the claude-sdk-oauth affinity oracle):

- `auth-storage-pool.test.ts` — flat and pooled `auth.json` read unchanged (byte-identical), pooled write keeps mode 0600, a pooled entry missing its flat projection is rejected.
- `credential-pool-state-store.test.ts` — cooldown survives a restart, `stateVersion` increments, exactly one half-open lease, auth blocks never lease, stable installation key with rotating env revisions, self-healing invalid document.
- `credential-error-taxonomy.test.ts` — one case per taxonomy row; 529 is `retry_same` and leaves slot health untouched; the hint is a floor with 48h capping recorded.
- `credential-failover.test.ts` — rotation before the first delta with block-persisted-before-replacement asserted by call order; an **unknown** event type sets the committed-output barrier; a newly added slot participates; `retry_same` never blocks; exhaustion carries `retryAt` and the original `cause`.
- `credential-failover-composition.test.ts` — a 429 with a healthy sibling rotates in-lane and never reaches the model chain; all-blocked reaches it exactly once.
- `model-runtime-credential-rotation.test.ts` — end-to-end over a pooled provider: sidecar health overlay, 429 pre-delta rotation with the cooldown persisted, same affinity key sticks to one slot with no config present, post-delta failure never rotates and carries the marker, and a rotated env value clears its own stale block.

A mutation probe (removing the post-commit rotation bar) flips the barrier test RED, proving it bites; reverted.

## Verification

- Root `npm run check` exit 0 (biome `--error-on-warnings`, typecheck, browser smoke, all locks).
- `node scripts/audit-changes-md.mjs` — 247/247 production paths covered.
- QA evidence: `local-ignore/qa-evidence/20260827-credential-pool-surfaces/`.

Follow-up (not in this PR): the `/account` command and selector, footer / `auth check --json` / RPC account surfaces, and the docs + auth-invariant update.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-credential rotation to the coding agent: when a provider holds more than one credential, a failing slot fails over to a healthy sibling inside the same request, before the model fallback chain is consulted. Per-slot health persists in a sidecar across restarts, and single-credential providers keep the existing request path unchanged.

**New Features**
- A file-locked health sidecar at `<agent-dir>/credential-pool-state.json` (mode 0600) stores absolute cooldown deadlines, permanent auth/billing blocks, half-open probe leases, and `lastSuccessAt`; unreadable or schema-invalid documents reset to fresh state.
- Provider failures map to actions: 401 and account-scoped 403 block the slot permanently and fail over, 429 blocks with an exponential cooldown capped at 48h (the server hint is a floor, never an override), and 5xx/529/network errors retry the same slot without blocking it.
- `ModelRuntime.stream` engages rotation only when the provider genuinely holds multiple slots and nothing pins the request to one credential (runtime key, explicit `apiKey`, or `credentials.rotation: false`); the rotation path is loaded lazily so providers without a pool keep byte-identical request behavior, and slot choice follows sha256 HRW over the affinity key so a session stays on one account.
- Numbered env slots (`OPENAI_API_KEY_2` … `_16`) add a second credential for any provider, gap-tolerantly, over the `getApiKeyEnvVars` mapping now exported from `@earendil-works/pi-ai`; a per-provider `credentials` policy block in `models.json` sets rotation/affinity toggles, cooldown bounds, and named slot references, and rejects literal key material.
- A failure after the first streamed delta never re-rotates and rethrows with the `senpi:no-turn-retry:` marker, so a partially streamed turn is never replayed.
- 102 assertions across 12 test files cover the store, taxonomy, failover runner, and end-to-end rotation behavior.

**Safety**
- Health never enters `auth.json`, and the sidecar holds no credential material; env-slot blocks are keyed by an installation-local HMAC revision so rotating a key in place clears its own stale block.
- Blocks persist before a replacement is selected, slots are re-read before each attempt so a newly added credential joins immediately, and committed-output detection is deny-by-default (only the `start` event is pre-commit).

Outside this PR: the `/account` selector, footer and `auth check --json` surfaces, and the docs update.

<sup>Written for commit 3a1963737da9d94628cb57194a3b892d407511c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

