### PR TITLE
feat(tui): render JSON tool results as a styled key-value fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
   close failures, waiting for the stream's terminal `close` event and failing only the tool call
   instead of returning an incomplete path or terminating the interactive session through
   `uncaughtException`.
+- Tool results without a custom renderer (MCP-wrapped tools and third-party extensions in particular) that return a JSON payload now render as a bounded key-value view in the TUI instead of a raw JSON dump; prose and malformed-JSON outputs keep the previous rendering byte for byte.
 - JavaScript-first `eval` guidance now makes the fastest composition path explicit: the first cells use the persistent JavaScript kernel, independent lookups fan out with `Promise.all`, and a later cell can continue in an idle Python kernel when JavaScript is occupied by detached work. This documents the runtime's actual multi-kernel execution model instead of teaching a serial Python-only workflow.
 - JavaScript kernel persistence transforms now rewrite only top-level declarations and remain literal-safe, so strings and nested function bodies are not accidentally modified when state is carried from one cell to the next.
 - Detached-eval busy diagnostics now identify the occupied cell and list each idle enabled kernel that can continue the step, turning a same-language contention failure into an actionable runtime choice.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -2713,3 +2713,23 @@ The tip line was teaching a small slice of the product while most of the surface
 ### Expected merge conflict zones
 
 - NONE: the upstream-only Radius session-share artifact remains excluded from the fork tree.
+
+## 2026-08-27 - render JSON tool results as a styled key-value fallback
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/components/tool-execution-fallback.ts`: `createToolResultFallback()` now inspects the rendered text output before styling it. When the trimmed text starts with `{` or `[`, parses as JSON, and yields a non-null object or array, the fallback renders a bounded `key: value` view (keys in `muted`, string values in `toolOutput`, numbers/booleans in `accent`, `null` in `dim`) with 2-space indentation per nesting level. Anything else — prose, logs, malformed JSON — keeps the previous `theme.fg("toolOutput", output)` path byte for byte.
+- The view is bounded so a large payload cannot flood the transcript: max nesting depth 3 (deeper containers collapse to a truncated compact `JSON.stringify`), max 24 rendered rows followed by a single dim `… N more` line, and string values truncated to 100 characters with a trailing ellipsis. The function still returns the same `Text` component type as before.
+- `packages/coding-agent/test/tool-execution-fallback-json.test.ts`: new regression suite covering nested objects, prose passthrough, malformed-JSON passthrough, row/string bounds, and top-level primitive arrays.
+
+### Why
+
+- Tools without a `renderResult` hook — MCP-wrapped tools and third-party extensions in particular — commonly return their payload as a JSON string. The fallback dumped that raw string into the transcript, so a single call could paste an unreadable one-line blob across the viewport. A bounded key-value view keeps the same information scannable without asking every tool author to ship a renderer.
+
+### Why an extension could not handle it
+
+- This is the renderer of last resort inside `ToolExecutionComponent` for tools that have no renderer. An extension can only supply `renderResult` for its own tools; it has no hook covering results produced by other extensions or by MCP-bridged tools, which is exactly the population that hits this path.
+
+### Expected merge conflict zones
+
+- LOW: `createToolResultFallback()` in `packages/coding-agent/src/modes/interactive/components/tool-execution-fallback.ts` (additive helpers plus a two-line branch in one small function).

--- a/packages/coding-agent/src/modes/interactive/components/tool-execution-fallback.ts
+++ b/packages/coding-agent/src/modes/interactive/components/tool-execution-fallback.ts
@@ -6,6 +6,9 @@ import type { ToolExecutionResult } from "./tool-execution-types.ts";
 
 const FALLBACK_STRING_MAX_LENGTH = 160;
 const FALLBACK_JSON_MAX_LENGTH = 2000;
+const JSON_VIEW_MAX_DEPTH = 3;
+const JSON_VIEW_MAX_ROWS = 24;
+const JSON_VIEW_MAX_VALUE_LENGTH = 100;
 
 function sanitizeFallbackString(value: string, maxLength = FALLBACK_STRING_MAX_LENGTH): string {
 	const sanitized = stripAnsi(value)
@@ -22,6 +25,83 @@ function sanitizeFallbackJsonValue(_key: string, value: unknown): unknown {
 	return typeof value === "string" ? sanitizeFallbackString(value) : value;
 }
 
+type JsonRecord = Record<string, unknown>;
+
+function parseRenderableJson(text: string): JsonRecord | unknown[] | undefined {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(trimmed);
+		if (typeof parsed !== "object" || parsed === null) return undefined;
+		return parsed as JsonRecord | unknown[];
+	} catch {
+		return undefined;
+	}
+}
+
+function truncateJsonViewValue(value: string): string {
+	return value.length > JSON_VIEW_MAX_VALUE_LENGTH ? `${value.slice(0, JSON_VIEW_MAX_VALUE_LENGTH)}\u2026` : value;
+}
+
+function styleJsonPrimitive(value: unknown): string {
+	if (typeof value === "string") return theme.fg("toolOutput", truncateJsonViewValue(value));
+	if (typeof value === "number" || typeof value === "boolean") return theme.fg("accent", String(value));
+	if (value === null) return theme.fg("dim", "null");
+	return theme.fg("toolOutput", truncateJsonViewValue(String(value)));
+}
+
+function styleJsonCompact(value: unknown): string {
+	return theme.fg("toolOutput", truncateJsonViewValue(JSON.stringify(value) ?? String(value)));
+}
+
+function isJsonContainer(value: unknown): value is JsonRecord | unknown[] {
+	return typeof value === "object" && value !== null;
+}
+
+/**
+ * Flattens a parsed JSON value into bounded `key: value` rows. Returns the rendered rows plus the
+ * number of entries that were dropped so the caller can append a single truncation line.
+ */
+function collectJsonViewRows(value: JsonRecord | unknown[]): { rows: string[]; omitted: number } {
+	const rows: string[] = [];
+	let omitted = 0;
+
+	const walk = (node: JsonRecord | unknown[], depth: number): void => {
+		const entries: Array<[string, unknown]> = Array.isArray(node)
+			? node.map((item, index) => [String(index), item])
+			: Object.entries(node);
+		const indent = "  ".repeat(depth);
+
+		for (const [key, entryValue] of entries) {
+			if (rows.length >= JSON_VIEW_MAX_ROWS) {
+				omitted += 1;
+				continue;
+			}
+			const label = `${indent}${theme.fg("muted", `${key}:`)}`;
+			if (isJsonContainer(entryValue)) {
+				if (depth + 1 >= JSON_VIEW_MAX_DEPTH) {
+					rows.push(`${label} ${styleJsonCompact(entryValue)}`);
+					continue;
+				}
+				rows.push(label);
+				walk(entryValue, depth + 1);
+				continue;
+			}
+			rows.push(`${label} ${styleJsonPrimitive(entryValue)}`);
+		}
+	};
+
+	walk(value, 0);
+	return { rows, omitted };
+}
+
+function renderJsonView(value: JsonRecord | unknown[]): string {
+	const { rows, omitted } = collectJsonViewRows(value);
+	if (rows.length === 0) return theme.fg("dim", "(empty)");
+	if (omitted > 0) rows.push(theme.fg("dim", `\u2026 ${omitted} more`));
+	return rows.join("\n");
+}
+
 export function createToolCallFallback(toolName: string): Component {
 	return new Text(theme.fg("toolTitle", theme.bold(toolName)), 0, 0);
 }
@@ -31,7 +111,10 @@ export function createToolResultFallback(
 	showImages: boolean,
 ): Component | undefined {
 	const output = getRenderedTextOutput(result, showImages);
-	return output ? new Text(theme.fg("toolOutput", output), 0, 0) : undefined;
+	if (!output) return undefined;
+	const parsed = parseRenderableJson(output);
+	if (parsed) return new Text(renderJsonView(parsed), 0, 0);
+	return new Text(theme.fg("toolOutput", output), 0, 0);
 }
 
 export function formatToolExecutionFallback(

--- a/packages/coding-agent/test/tool-execution-fallback-json.test.ts
+++ b/packages/coding-agent/test/tool-execution-fallback-json.test.ts
@@ -1,0 +1,88 @@
+import { Text } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test } from "vitest";
+
+import { createToolResultFallback } from "../src/modes/interactive/components/tool-execution-fallback.ts";
+import type { ToolExecutionResult } from "../src/modes/interactive/components/tool-execution-types.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+
+function textResult(text: string): ToolExecutionResult {
+	return { content: [{ type: "text", text }], details: {}, isError: false };
+}
+
+function renderFallback(text: string, width = 200): string {
+	const component = createToolResultFallback(textResult(text), false);
+	if (!component) throw new Error("expected a fallback component");
+	return component.render(width).join("\n");
+}
+
+function renderPlain(text: string, width = 200): string {
+	return stripAnsi(renderFallback(text, width))
+		.split("\n")
+		.map((line) => line.trimEnd())
+		.join("\n")
+		.trimEnd();
+}
+
+/** Byte-exact rendering of the pre-existing fallback code path. */
+function renderLegacyRaw(text: string, width = 200): string {
+	return new Text(theme.fg("toolOutput", text), 0, 0).render(width).join("\n");
+}
+
+describe("createToolResultFallback JSON view", () => {
+	beforeAll(() => initTheme("dark"));
+
+	test("renders a nested JSON object as a bounded key-value view", () => {
+		const payload = { goal: { status: "blocked", tokensUsed: 1838, nested: { a: 1 } } };
+		const singleLine = JSON.stringify(payload);
+		const pretty = JSON.stringify(payload, null, 2);
+
+		const plain = renderPlain(singleLine);
+
+		expect(plain).not.toContain(singleLine);
+		expect(plain).not.toContain(pretty);
+		expect(plain.split("\n")).toEqual(["goal:", "  status: blocked", "  tokensUsed: 1838", "  nested:", "    a: 1"]);
+	});
+
+	test("keeps plain prose byte-identical to the raw tool output styling", () => {
+		const text = "hello world\nline2";
+		expect(renderFallback(text)).toBe(renderLegacyRaw(text));
+		expect(renderPlain(text)).toBe(text);
+	});
+
+	test("keeps malformed JSON byte-identical to the raw tool output styling", () => {
+		const text = "{oops";
+		expect(renderFallback(text)).toBe(renderLegacyRaw(text));
+		expect(renderPlain(text)).toBe(text);
+	});
+
+	test("bounds row count and long string values", () => {
+		const wide: Record<string, string> = {};
+		for (let index = 0; index < 60; index += 1) {
+			wide[`key${index}`] = `value${index}`;
+		}
+		const plain = renderPlain(JSON.stringify(wide));
+		const lines = plain.split("\n");
+
+		expect(lines.length).toBeLessThanOrEqual(25);
+		const truncationLine = lines[lines.length - 1];
+		expect(truncationLine).toMatch(/^… \d+ more$/);
+		expect(truncationLine).toBe(`… ${60 - (lines.length - 1)} more`);
+
+		const long = "x".repeat(250);
+		const longPlain = renderPlain(JSON.stringify({ long }), 400);
+		expect(longPlain).toBe(`long: ${"x".repeat(100)}…`);
+	});
+
+	test("renders a top-level array of primitives as a bounded list", () => {
+		const values = Array.from({ length: 40 }, (_, index) => `item${index}`);
+		const raw = JSON.stringify(values);
+		const plain = renderPlain(raw);
+		const lines = plain.split("\n");
+
+		expect(plain).not.toContain(raw);
+		expect(plain).toContain("item0");
+		expect(lines.length).toBeLessThanOrEqual(25);
+		expect(lines[lines.length - 1]).toMatch(/^… \d+ more$/);
+	});
+});


### PR DESCRIPTION
## Problem

Tool results are rendered by `createToolResultFallback` whenever a tool ships no `renderResult` hook. That fallback wrapped the raw text in `theme.fg("toolOutput", output)` and stopped there. MCP-wrapped tools and third-party extensions commonly return their payload as a JSON string, so a single call could paste an unreadable one-line `{"goal":{"status":"blocked",...}}` blob across the transcript.

## Approach

`createToolResultFallback` now inspects the rendered text before styling it:

- Detection is deliberately narrow: the trimmed text must start with `{` or `[`, `JSON.parse` must succeed, and the result must be a non-null object or array. Everything else — prose, logs, malformed JSON such as `{oops` — takes the pre-existing code path byte for byte.
- When it matches, the payload renders as a `key: value` view with 2-space indentation per nesting level: keys in `muted`, string values in `toolOutput`, numbers/booleans in `accent`, `null` in `dim`.
- The function still returns the same `Text` component as before; nothing about the surrounding `ToolExecutionComponent` wiring changes.

## Bounds

A tool result is untrusted input, so the view can never flood the viewport:

- **Depth:** max 3 levels. A container deeper than that collapses to a compact `JSON.stringify`, itself truncated.
- **Rows:** max 24 rendered rows, then a single dim `… N more` line counting the dropped entries.
- **Strings:** values longer than 100 characters are truncated with a trailing `…`.

## Test evidence

New suite `packages/coding-agent/test/tool-execution-fallback-json.test.ts` (written red-first, 5 tests):

- nested object renders as the expected `goal: / status: blocked / …` line list and contains neither the single-line nor the pretty-printed raw JSON;
- prose (`"hello world\nline2"`) renders byte-identically to the previous `theme.fg("toolOutput", …)` output;
- malformed JSON (`"{oops"`) likewise unchanged;
- a 60-key object renders at most 24 value rows plus an exact `… 36 more` line, and a 250-char string value truncates to 100 chars + `…`;
- a 40-element primitive array renders as a bounded per-index list, not a raw dump.

Verification run locally: the new file goes 3 failed / 2 passed before the implementation and 5 passed after; neighbouring suites `tool-execution-component`, `tool-execution-invalid-renderer`, and `webfetch-renderers` pass unchanged (52 tests); the repo pre-commit gate (biome + pinned-dep/lock checks + `tsc --noEmit`) is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tool results that arrive as JSON now render as a bounded key-value view instead of an unreadable one-line blob in the transcript.

- JSON detection is narrow: only trimmed text starting with `{` or `[` that parses into a non-null object or array; prose, logs, and malformed JSON keep the previous byte-for-byte `toolOutput` styling.
- The view caps nesting at depth 3, renders at most 24 rows (with a `… N more` line), and truncates string values at 100 characters, so large payloads cannot flood the viewport.
- Adds a regression suite (`tool-execution-fallback-json.test.ts`) covering nested objects, prose and malformed-JSON passthrough, and row/string bounds, and documents the change in the changelog.

<sup>Written for commit 3ac94ed8e2a6e2d3e2b92c285d9f4a69f36291cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

