### PR TITLE
feat(goal): render goal tool results as TUI widgets

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Goal tool results (`create_goal`, `update_goal`, `get_goal`) now render as a TUI widget — status-colored header with compact token and elapsed usage, objective preview (full objective plus created/updated timestamps when expanded), and the blocked reason — instead of dumping the raw JSON payload into the transcript. The model-facing JSON result text is unchanged.
 - Native todo lists with an explicit empty `todos: []` payload now clear persisted todo state and remove the `todo-sidebar`, while absent payloads remain ignored and lists with pending work remain visible.
 - Bash output spill files now capture early `EDQUOT`/`ENOSPC` stream errors and late filesystem
   close failures, waiting for the stream's terminal `close` event and failing only the tool call

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,23 @@
 # goal Extension Changes
 
+## 2026-08-27 - TUI widget rendering for goal tool results
+
+### What changed
+
+- `renderers.ts` (new): `renderGoalToolCall` / `renderGoalToolResult` render the goal tools as
+  a widget instead of the raw `JSON.stringify({goal:...})` dump — status-colored header
+  (glyph + status + compact tokens + elapsed), objective preview (collapsed: first two
+  non-empty lines, 120-col shorten, `… +N more lines`) or the full objective plus
+  `created/updated` ISO timestamps (expanded), a `⚠ <blockedReason>` line, and the
+  objective-truncation notice. Falls back to parsing the legacy JSON text when `details`
+  are absent (old sessions), and to the raw text when nothing parses.
+- `format.ts`: adds `GoalToolRenderDetails` + `goalToolRenderDetails()` so tool results
+  carry the snapshot in `details` for the renderer.
+- `tool-registration.ts`: `create_goal` / `update_goal` / `get_goal` register
+  `renderCall`/`renderResult` and attach the render details. The model-facing JSON text
+  result is unchanged.
+- Tests: `test/goal-renderers.test.ts`.
+
 ## 2026-08-27 - unattended continuation backstop (#1139)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/format.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/format.ts
@@ -52,6 +52,18 @@ export function formatGoalForTool(goal: Goal | null): string {
 	return lines.join("\n");
 }
 
+export type GoalToolRenderDetails = {
+	goal: GoalToolSnapshot | null;
+	notice?: string;
+};
+
+export function goalToolRenderDetails(goal: Goal | null, notice?: string): GoalToolRenderDetails {
+	return {
+		goal: goal === null ? null : goalToolSnapshot(goal),
+		...(notice === undefined ? {} : { notice }),
+	};
+}
+
 export function goalToolResponse(goal: Goal | null): GoalToolResponse {
 	return { goal: goal === null ? null : goalToolSnapshot(goal) };
 }

--- a/packages/coding-agent/src/core/extensions/builtin/goal/renderers.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/renderers.ts
@@ -1,0 +1,162 @@
+import { Text } from "@earendil-works/pi-tui";
+import type { Theme, ThemeColor } from "../../../../modes/interactive/theme/theme.ts";
+import type { ToolRenderResultOptions } from "../../types.ts";
+import { formatGoalElapsedSeconds, formatTokensCompact, type GoalToolRenderDetails } from "./format.ts";
+import { GOAL_STATUS_VALUES, type GoalStatus, type GoalToolSnapshot, isRecord } from "./types.ts";
+
+const OBJECTIVE_PREVIEW_WIDTH = 120;
+const COLLAPSED_OBJECTIVE_LINES = 2;
+const CALL_OBJECTIVE_BUDGET = 80;
+const CALL_REASON_BUDGET = 60;
+
+interface ResultLike {
+	content: ReadonlyArray<{ type: string; text?: string }>;
+	details?: unknown;
+}
+
+export function renderGoalToolCall(toolName: string, args: unknown, theme: Theme): Text {
+	const title = theme.fg("toolTitle", theme.bold(toolName));
+	const params = isRecord(args) ? args : {};
+	if (toolName === "create_goal" && typeof params.objective === "string") {
+		const preview = objectiveCallPreview(params.objective);
+		return new Text(preview === "" ? title : `${title} ${theme.fg("muted", preview)}`, 0, 0);
+	}
+	if (toolName === "update_goal" && typeof params.status === "string") {
+		const statusColor: ThemeColor = params.status === "complete" ? "success" : "error";
+		let line = `${title} ${theme.fg("muted", "→")} ${theme.fg(statusColor, params.status)}`;
+		if (typeof params.reason === "string" && params.reason.trim().length > 0) {
+			line += ` ${theme.fg("muted", `— ${shorten(params.reason.trim(), CALL_REASON_BUDGET)}`)}`;
+		}
+		return new Text(line, 0, 0);
+	}
+	return new Text(title, 0, 0);
+}
+
+export function renderGoalToolResult(result: ResultLike, options: ToolRenderResultOptions, theme: Theme): Text {
+	const text = result.content.find((block) => block.type === "text")?.text ?? "";
+	const details = resolveRenderDetails(result.details, text);
+	if (details === undefined) return new Text(theme.fg("toolOutput", text), 0, 0);
+	if (details.goal === null) {
+		const lines = [theme.fg("dim", "No active goal is set.")];
+		appendNotice(lines, details.notice, theme);
+		return new Text(lines.join("\n"), 0, 0);
+	}
+	const lines = goalWidgetLines(details.goal, options.expanded, theme);
+	appendNotice(lines, details.notice, theme);
+	return new Text(lines.join("\n"), 0, 0);
+}
+
+function goalWidgetLines(goal: GoalToolSnapshot, expanded: boolean, theme: Theme): string[] {
+	const status = theme.fg(statusColor(goal.status), theme.bold(`${statusGlyph(goal.status)} ${goal.status}`));
+	const usage = ` • ${formatTokensCompact(goal.tokensUsed)} tokens • ${formatGoalElapsedSeconds(goal.timeUsedSeconds)}`;
+	const lines = [`${status}${theme.fg("muted", usage)}`];
+
+	const objectiveLines = goal.objective
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+	if (expanded) {
+		for (const line of objectiveLines) lines.push(theme.fg("toolOutput", `  ${line}`));
+	} else {
+		for (const line of objectiveLines.slice(0, COLLAPSED_OBJECTIVE_LINES)) {
+			lines.push(theme.fg("toolOutput", `  ${shorten(line, OBJECTIVE_PREVIEW_WIDTH)}`));
+		}
+		const hidden = objectiveLines.length - COLLAPSED_OBJECTIVE_LINES;
+		if (hidden > 0) lines.push(theme.fg("dim", `  … +${hidden} more lines`));
+	}
+
+	if (goal.blockedReason !== undefined && goal.blockedReason.length > 0) {
+		lines.push(theme.fg("warning", `  ⚠ ${goal.blockedReason}`));
+	}
+	if (expanded) {
+		const created = isoTimestamp(goal.createdAt);
+		const updated = isoTimestamp(goal.updatedAt);
+		lines.push(theme.fg("dim", `  created ${created} • updated ${updated}`));
+	}
+	return lines;
+}
+
+function appendNotice(lines: string[], notice: string | undefined, theme: Theme): void {
+	if (notice !== undefined && notice.length > 0) lines.push(theme.fg("dim", `  ${notice}`));
+}
+
+function resolveRenderDetails(details: unknown, text: string): GoalToolRenderDetails | undefined {
+	const direct = parseRenderDetails(details);
+	if (direct !== undefined) return direct;
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("{")) return undefined;
+	try {
+		return parseRenderDetails(JSON.parse(trimmed));
+	} catch {
+		return undefined;
+	}
+}
+
+function parseRenderDetails(value: unknown): GoalToolRenderDetails | undefined {
+	if (!isRecord(value) || !("goal" in value)) return undefined;
+	const goal = value.goal;
+	const notice = typeof value.notice === "string" ? value.notice : undefined;
+	if (goal === null) return { goal: null, ...(notice === undefined ? {} : { notice }) };
+	if (!isGoalSnapshotLike(goal)) return undefined;
+	return { goal, ...(notice === undefined ? {} : { notice }) };
+}
+
+function isGoalSnapshotLike(value: unknown): value is GoalToolSnapshot {
+	return (
+		isRecord(value) &&
+		typeof value.objective === "string" &&
+		typeof value.status === "string" &&
+		(GOAL_STATUS_VALUES as readonly string[]).includes(value.status) &&
+		typeof value.tokensUsed === "number" &&
+		typeof value.timeUsedSeconds === "number" &&
+		typeof value.createdAt === "number" &&
+		typeof value.updatedAt === "number"
+	);
+}
+
+function statusGlyph(status: GoalStatus): string {
+	switch (status) {
+		case "active":
+			return "●";
+		case "paused":
+			return "◌";
+		case "blocked":
+			return "■";
+		case "complete":
+			return "✓";
+	}
+}
+
+function statusColor(status: GoalStatus): ThemeColor {
+	switch (status) {
+		case "active":
+			return "accent";
+		case "paused":
+			return "muted";
+		case "blocked":
+			return "error";
+		case "complete":
+			return "success";
+	}
+}
+
+function objectiveCallPreview(objective: string): string {
+	const lines = objective
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+	const first = lines[0] ?? "";
+	if (first === "") return "";
+	const truncated = shorten(first, CALL_OBJECTIVE_BUDGET);
+	if (lines.length > 1 && truncated === first) return `${first}…`;
+	return truncated;
+}
+
+function isoTimestamp(epochSeconds: number): string {
+	return new Date(epochSeconds * 1000).toISOString();
+}
+
+function shorten(value: string, max: number): string {
+	if (value.length <= max) return value;
+	return `${value.slice(0, max - 1)}…`;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/tool-registration.ts
@@ -1,13 +1,14 @@
 import { Type } from "typebox";
 import type { AgentToolResult, ExtensionAPI, ExtensionContext } from "../../types.ts";
-import { formatGoalToolResponse } from "./format.ts";
+import { formatGoalToolResponse, type GoalToolRenderDetails, goalToolRenderDetails } from "./format.ts";
+import { renderGoalToolCall, renderGoalToolResult } from "./renderers.ts";
 import { createGoal, objectiveFullTextFileName, readGoal, updateGoal } from "./store.ts";
 import { openTodoCompletionError, openTodoTaskContents } from "./todo-gate.ts";
 import type { Goal, GoalAccountingMode, GoalStoreRef } from "./types.ts";
 import { MODEL_SETTABLE_GOAL_STATUS_VALUES } from "./types.ts";
 import { objectiveTruncationNotice, validateObjective } from "./validation.ts";
 
-type GoalToolResult = AgentToolResult<Record<string, never>>;
+type GoalToolResult = AgentToolResult<GoalToolRenderDetails>;
 
 export type GoalToolRegistrationDeps = {
 	readonly goalStoreRef: (ctx: ExtensionContext) => GoalStoreRef;
@@ -45,13 +46,13 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 			const goal = await createGoal(ref, params.objective);
 			deps.beginAgentGoalAccounting(goal);
 			deps.refreshGoalUi(ctx, goal);
-			return toolText(
-				formatGoalToolResponse(
-					goal,
-					validatedObjective.truncated ? objectiveTruncationNotice(objectiveFullTextFileName(ref)) : undefined,
-				),
-			);
+			const notice = validatedObjective.truncated
+				? objectiveTruncationNotice(objectiveFullTextFileName(ref))
+				: undefined;
+			return toolText(formatGoalToolResponse(goal, notice), goalToolRenderDetails(goal, notice));
 		},
+		renderCall: (args, theme) => renderGoalToolCall("create_goal", args, theme),
+		renderResult: (result, options, theme) => renderGoalToolResult(result, options, theme),
 	});
 
 	pi.registerTool({
@@ -94,8 +95,10 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 			if (goal.status === "blocked") deps.markGoalBlockedThisTurn(goal);
 			else deps.markGoalCompletedThisTurn(goal);
 			deps.refreshGoalUi(ctx, goal);
-			return toolText(formatGoalToolResponse(goal));
+			return toolText(formatGoalToolResponse(goal), goalToolRenderDetails(goal));
 		},
+		renderCall: (args, theme) => renderGoalToolCall("update_goal", args, theme),
+		renderResult: (result, options, theme) => renderGoalToolResult(result, options, theme),
 	});
 
 	pi.registerTool({
@@ -106,11 +109,13 @@ export function registerGoalTools(pi: ExtensionAPI, deps: GoalToolRegistrationDe
 		async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
 			const goal = await deps.accountCurrentAgentTurn(ctx, "active");
 			deps.refreshGoalUi(ctx, goal);
-			return toolText(formatGoalToolResponse(goal));
+			return toolText(formatGoalToolResponse(goal), goalToolRenderDetails(goal));
 		},
+		renderCall: (args, theme) => renderGoalToolCall("get_goal", args, theme),
+		renderResult: (result, options, theme) => renderGoalToolResult(result, options, theme),
 	});
 }
 
-function toolText(text: string): GoalToolResult {
-	return { content: [{ type: "text" as const, text }], details: {} };
+function toolText(text: string, details: GoalToolRenderDetails): GoalToolResult {
+	return { content: [{ type: "text" as const, text }], details };
 }

--- a/packages/coding-agent/test/goal-renderers.test.ts
+++ b/packages/coding-agent/test/goal-renderers.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import type { GoalToolRenderDetails } from "../src/core/extensions/builtin/goal/format.ts";
+import { renderGoalToolCall, renderGoalToolResult } from "../src/core/extensions/builtin/goal/renderers.ts";
+import type { GoalToolSnapshot } from "../src/core/extensions/builtin/goal/types.ts";
+import type { Theme, ThemeColor } from "../src/modes/interactive/theme/theme.ts";
+
+const passthroughTheme = {
+	bold: (value: string) => value,
+	fg: (_key: ThemeColor, value: string) => value,
+} as unknown as Theme;
+
+function snapshot(overrides: Partial<GoalToolSnapshot> = {}): GoalToolSnapshot {
+	return {
+		threadId: "01a04104-22d5-7f13-be4e-ada49243a283",
+		objective: "Finish X re-login for q_yeon_gyu_kim",
+		status: "active",
+		tokensUsed: 512,
+		timeUsedSeconds: 45,
+		createdAt: 1787814204,
+		updatedAt: 1787814296,
+		...overrides,
+	};
+}
+
+function renderResultLines(
+	details: GoalToolRenderDetails | undefined,
+	options: { expanded?: boolean; text?: string } = {},
+): string[] {
+	const text = options.text ?? "{}";
+	const component = renderGoalToolResult(
+		{ content: [{ type: "text", text }], details },
+		{ expanded: options.expanded ?? false, isPartial: false },
+		passthroughTheme,
+	);
+	const lines = component.render(200).map((line) => line.trimEnd());
+	while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+	return lines;
+}
+
+function renderCallLine(toolName: string, args: unknown): string {
+	return renderGoalToolCall(toolName, args, passthroughTheme).render(200).join("\n").trimEnd();
+}
+
+describe("goal tool result renderer", () => {
+	it("renders a blocked goal as a status header, objective preview, and blocked reason", () => {
+		const lines = renderResultLines({
+			goal: snapshot({
+				status: "blocked",
+				tokensUsed: 1838,
+				timeUsedSeconds: 92,
+				blockedReason: "user interrupted the turn",
+				blockedAt: 1787814296,
+			}),
+		});
+		expect(lines).toEqual([
+			"■ blocked • 1.8K tokens • 1m",
+			"  Finish X re-login for q_yeon_gyu_kim",
+			"  ⚠ user interrupted the turn",
+		]);
+		expect(lines.join("\n")).not.toContain('"goal"');
+	});
+
+	it("renders an active goal happy path", () => {
+		const lines = renderResultLines({ goal: snapshot() });
+		expect(lines).toEqual(["● active • 512 tokens • 45s", "  Finish X re-login for q_yeon_gyu_kim"]);
+	});
+
+	it("renders a complete goal with a check glyph", () => {
+		const lines = renderResultLines({
+			goal: snapshot({ status: "complete", tokensUsed: 2_340_000, timeUsedSeconds: 11_100 }),
+		});
+		expect(lines[0]).toBe("✓ complete • 2.3M tokens • 3h 5m");
+	});
+
+	it("renders the no-goal state", () => {
+		expect(renderResultLines({ goal: null })).toEqual(["No active goal is set."]);
+	});
+
+	it("collapses a multi-line objective to two lines with a more-lines marker", () => {
+		const objective = ["line one", "line two", "line three", "line four", "line five"].join("\n");
+		const lines = renderResultLines({ goal: snapshot({ objective, tokensUsed: 0, timeUsedSeconds: 0 }) });
+		expect(lines).toEqual(["● active • 0 tokens • 0s", "  line one", "  line two", "  … +3 more lines"]);
+	});
+
+	it("expands to the full objective plus timestamps", () => {
+		const objective = ["line one", "line two", "line three"].join("\n");
+		const lines = renderResultLines(
+			{ goal: snapshot({ objective, tokensUsed: 0, timeUsedSeconds: 0 }) },
+			{ expanded: true },
+		);
+		expect(lines).toEqual([
+			"● active • 0 tokens • 0s",
+			"  line one",
+			"  line two",
+			"  line three",
+			"  created 2026-08-27T07:03:24.000Z • updated 2026-08-27T07:04:56.000Z",
+		]);
+	});
+
+	it("truncates an over-wide objective line in the collapsed view", () => {
+		const objective = "x".repeat(150);
+		const lines = renderResultLines({ goal: snapshot({ objective }) });
+		expect(lines[1].endsWith("…")).toBe(true);
+		expect(lines[1].length).toBeLessThanOrEqual(123);
+		const expanded = renderResultLines({ goal: snapshot({ objective }) }, { expanded: true });
+		expect(expanded[1]).toBe(`  ${objective}`);
+	});
+
+	it("appends the objective truncation notice when present", () => {
+		const lines = renderResultLines({ goal: snapshot(), notice: "objective truncated; full text saved" });
+		expect(lines[lines.length - 1]).toBe("  objective truncated; full text saved");
+	});
+
+	it("falls back to parsing the JSON text when details are missing", () => {
+		const text = JSON.stringify({ goal: snapshot({ status: "blocked", blockedReason: "stuck" }) });
+		const lines = renderResultLines(undefined, { text });
+		expect(lines[0]).toBe("■ blocked • 512 tokens • 45s");
+		expect(lines).toContain("  ⚠ stuck");
+	});
+
+	it("renders raw text unchanged when neither details nor parseable JSON exist", () => {
+		const lines = renderResultLines(undefined, { text: "plain failure message" });
+		expect(lines).toEqual(["plain failure message"]);
+	});
+});
+
+describe("goal tool call renderer", () => {
+	it("labels get_goal plainly", () => {
+		expect(renderCallLine("get_goal", {})).toBe("get_goal");
+	});
+
+	it("previews the objective for create_goal", () => {
+		expect(renderCallLine("create_goal", { objective: "Do the thing" })).toBe("create_goal Do the thing");
+	});
+
+	it("truncates multi-line create_goal objectives to the first line", () => {
+		expect(renderCallLine("create_goal", { objective: "Do the thing\nand more" })).toBe("create_goal Do the thing…");
+	});
+
+	it("shows the target status and reason for update_goal", () => {
+		expect(renderCallLine("update_goal", { status: "blocked", reason: "stuck" })).toBe(
+			"update_goal → blocked — stuck",
+		);
+		expect(renderCallLine("update_goal", { status: "complete" })).toBe("update_goal → complete");
+	});
+});


### PR DESCRIPTION
## Problem

The goal tools (`create_goal`, `update_goal`, `get_goal`) register no `renderCall`/`renderResult` hooks, so the interactive TUI falls back to dumping the model-facing result text — a raw `JSON.stringify({ goal: ... }, null, 2)` blob — straight into the transcript:

```
get_goal
{
  "goal": {
    "threadId": "01a04104-22d5-7f13-be4e-ada49243a283",
    "objective": "Finish X re-login for ...",
    "status": "blocked",
    ...
  }
}
```

## Approach

- `builtin/goal/renderers.ts` (new): `renderGoalToolCall` / `renderGoalToolResult`.
  - Result widget: status-colored header (`● active` / `■ blocked` / `✓ complete` / `◌ paused` + compact tokens + elapsed via the existing `format.ts` helpers), objective preview (collapsed: first two non-empty lines, 120-col shorten, `… +N more lines`), full objective plus `created/updated` ISO timestamps when expanded, `⚠ <blockedReason>` line, objective-truncation notice, and `No active goal is set.` for the null goal.
  - Call line: `create_goal <first objective line>`, `update_goal → <status> — <reason>`, plain `get_goal`.
- `format.ts`: `GoalToolRenderDetails` + `goalToolRenderDetails()` so results carry the snapshot in `details`.
- `tool-registration.ts`: the three tools register the renderers and attach details. The model-facing JSON text is byte-identical to before.
- Back-compat: when `details` are absent (older session entries), the renderer parses the legacy JSON text; when nothing parses, it renders the raw text exactly as today.

## Evidence

- TDD: `test/goal-renderers.test.ts` written first — captured RED (12 failed, assertions showing the raw `{"goal":` dump), then GREEN (14/14). Goal suites (`goal-extension`, `goal-store`, `goal-modules`) 136 passed; `tsc --noEmit` clean.
- Real-surface QA (senpi-qa style, hermetic): fake model server scripted `create_goal` → `get_goal` → sentinel; real TUI driven via tmux in an isolated sandbox. Captured screen shows the widget and the transcript contains no raw goal JSON:

```
 create_goal Ship the goal widget QA proof
 ● active • 0 tokens • 0s
   Ship the goal widget QA proof

 get_goal
 ● active • 2 tokens • 0s
   Ship the goal widget QA proof
```

Sandbox torn down; real `auth.json` untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders `create_goal`, `update_goal`, and `get_goal` tool results in the TUI as a formatted widget instead of dumping the raw JSON payload into the transcript. The model-facing JSON result text is byte-identical, so this is purely a display change.

**Details**
- The widget shows a status-colored header with compact token count and elapsed time, a trimmed objective preview, the blocked reason, and full objective plus timestamps when expanded.
- Tool call lines now preview the objective for `create_goal` and the target status and reason for `update_goal`.
- Results from older sessions without render details fall back to parsing the legacy JSON text, or render the raw text unchanged when nothing parses.

<sup>Written for commit e36dba3ede9163b1947d4f4bcc03d279de1cb41d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

