### PR TITLE
feat(agent): optional postMutate seam inside the harness file-mutation queue

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Harness tool contexts accept an optional `postMutate` hook. It runs inside the file mutation queue immediately after `write` or `edit` commits its bytes, so a formatter or normalizer can adjust the file as an atomic part of the same mutation. `edit` recomputes its diff and unified patch against the post-hook file contents whenever the hook may have touched the file, and a rejecting hook is reported as an appended warning note rather than discarding the landed write. Tool behavior is unchanged when no hook is supplied.
+
 ### Changed
 
 ### Fixed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -14,7 +14,8 @@
 - `packages/agent/src/harness/tools/edit.ts` invokes the hook in the same position and re-reads the
   file whenever the hook may have touched it (`changed: true`, or the hook rejected after a partial
   rewrite) so the returned diff, unified patch, and first-changed-line describe the bytes actually
-  on disk.
+  on disk. A hook that leaves the file unreadable is reported as a note on the successful edit
+  rather than as an edit failure, because the edit itself already landed.
 - `packages/agent/src/harness/tools/index.ts` exports the new post-mutate types.
 
 ### Why

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,42 @@
 # Changes
 
+## 2026-08-27 - Optional postMutate seam inside the file mutation queue
+
+### What changed
+
+- `packages/agent/src/harness/tools/tool-context.ts` adds an optional `postMutate` hook to
+  `ExecutionToolContext` plus the `PostMutateContext`, `PostMutateResult`, and `PostMutateHook`
+  contracts describing it.
+- `packages/agent/src/harness/tools/post-mutate.ts` (fork-only) runs the hook and degrades a
+  rejecting hook into an appended warning note, so a landed write is never discarded.
+- `packages/agent/src/harness/tools/write.ts` invokes the hook inside the `withFileMutationQueue`
+  callback right after `env.writeFile` succeeds and appends the returned note to the success text.
+- `packages/agent/src/harness/tools/edit.ts` invokes the hook in the same position and re-reads the
+  file whenever the hook may have touched it (`changed: true`, or the hook rejected after a partial
+  rewrite) so the returned diff, unified patch, and first-changed-line describe the bytes actually
+  on disk.
+- `packages/agent/src/harness/tools/index.ts` exports the new post-mutate types.
+
+### Why
+
+Fork tooling (formatters, codegen, normalizers) must observe and adjust a file as an atomic part of
+the mutation that produced it. A `tool_result` extension hook runs outside the mutation queue, so a
+concurrent same-path mutation can interleave and the edit tool's diff metadata can describe bytes
+that are no longer on disk. Placing the seam inside the queue slot makes the post-write step
+unobservable to other mutations and lets edit report the committed content.
+
+### Why an extension could not handle it
+
+`withFileMutationQueue` is internal to the harness tool implementations; no extension hook executes
+inside a queue slot, and the edit tool computes its diff metadata before any extension sees the
+result.
+
+### Expected merge conflict zones
+
+- LOW: the `execute` bodies of `write.ts` and `edit.ts` (post-`writeFile` lines), the
+  `ExecutionToolContext` declaration in `tool-context.ts`, and the `tool-context.ts` export block in
+  `index.ts`.
+
 ## Agent loop config surface re-diverges from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/packages/agent/src/harness/tools/AGENTS.md
+++ b/packages/agent/src/harness/tools/AGENTS.md
@@ -13,7 +13,8 @@ Earned its own file: distinct domain plus external centrality (score 11: `index.
 | File write/read | `write.ts`, `read.ts` |
 | Serialized filesystem mutations | `file-mutation-queue.ts` (`withFileMutationQueue`) |
 | Path resolution helpers | `path-utils.ts` |
-| Tool context contract | `tool-context.ts` (`ExecutionToolContext`) |
+| Tool context contract | `tool-context.ts` (`ExecutionToolContext`, `PostMutateHook`) |
+| Post-write hook execution | `post-mutate.ts` (`runPostMutate`, `appendPostMutateNote`) |
 | Image attachment encoding | `image.ts` |
 | Public surface | `index.ts` (factories + types) |
 
@@ -21,7 +22,8 @@ Earned its own file: distinct domain plus external centrality (score 11: `index.
 
 - All filesystem mutation goes through `withFileMutationQueue(env, path, fn)`; tools never write via env APIs directly.
 - Paths resolve through `path-utils.ts` helpers against the context root.
-- Tools throw on failure so the agent reports the error; failure text is never returned as successful result content.
+- Tools throw on failure so the agent reports the error; failure text is never returned as successful result content. The one deliberate exception is `postMutate`: the write it follows has already landed, so a rejecting hook becomes an appended warning note instead of discarding a committed mutation.
+- The optional `context.postMutate` hook runs inside the same `withFileMutationQueue` slot as the write it follows; `edit` recomputes its diff metadata from disk whenever the hook may have touched the file (reported `changed`, or rejected after a partial rewrite).
 - Replay semantics are declared where consumed as `HarnessTool` (`replay?: "never" | "safe"`, defined in `agent-harness.ts`), not inferred from the tool.
 - A new tool ships as a factory plus exported input/details types in `index.ts`.
 

--- a/packages/agent/src/harness/tools/edit.ts
+++ b/packages/agent/src/harness/tools/edit.ts
@@ -130,16 +130,20 @@ export function createEditTool<TContext extends ExecutionToolContext = Execution
 				if (signal?.aborted) throw new Error("Operation aborted");
 
 				let committedContent = newContent;
+				let rereadNote: string | undefined;
 				if (outcome.fileMayHaveChanged) {
 					const postMutateRead = await env.readTextFile(absolutePath, signal);
-					if (!postMutateRead.ok) throw editAccessError(path, postMutateRead.error);
-					committedContent = normalizeToLF(stripBom(postMutateRead.value).text);
+					// The edit itself already landed, so an unreadable file is the hook's doing, not a
+					// failed edit. Report it as a note rather than an error that misattributes the failure.
+					if (postMutateRead.ok) committedContent = normalizeToLF(stripBom(postMutateRead.value).text);
+					else
+						rereadNote = `postMutate left the file unreadable: ${postMutateRead.error.code}. Reported diff describes the edit before the hook ran.`;
 				}
 
 				const diffResult = generateDiffString(baseContent, committedContent);
 				const text = appendPostMutateNote(
-					`Successfully replaced ${edits.length} block(s) in ${path}.`,
-					outcome.note,
+					appendPostMutateNote(`Successfully replaced ${edits.length} block(s) in ${path}.`, outcome.note),
+					rereadNote,
 				);
 				return {
 					content: [{ type: "text", text }],

--- a/packages/agent/src/harness/tools/edit.ts
+++ b/packages/agent/src/harness/tools/edit.ts
@@ -12,6 +12,7 @@ import {
 } from "./edit-diff.ts";
 import { withFileMutationQueue } from "./file-mutation-queue.ts";
 import { resolveToolPath } from "./path-utils.ts";
+import { appendPostMutateNote, runPostMutate } from "./post-mutate.ts";
 import type { ExecutionToolContext } from "./tool-context.ts";
 
 const replaceEditSchema = Type.Object(
@@ -99,7 +100,7 @@ export function createEditTool<TContext extends ExecutionToolContext = Execution
 			"Edit a single file using exact text replacement. Every edits[].oldText must match a unique, non-overlapping region of the original file. If two changes affect the same block or nearby lines, merge them into one edit instead of emitting overlapping edits. Do not include large unchanged regions just to connect distant changes.",
 		parameters: editSchema,
 		prepareArguments: prepareEditArguments,
-		async execute(_toolCallId, input, signal, _onUpdate, { env }) {
+		async execute(_toolCallId, input, signal, _onUpdate, { env, postMutate }) {
 			const { path, edits } = validateEditInput(input);
 			const absolutePath = await resolveToolPath(env, path, signal);
 			return withFileMutationQueue(env, absolutePath, async () => {
@@ -125,12 +126,26 @@ export function createEditTool<TContext extends ExecutionToolContext = Execution
 				if (!writeResult.ok) throw editAccessError(path, writeResult.error);
 				if (signal?.aborted) throw new Error("Operation aborted");
 
-				const diffResult = generateDiffString(baseContent, newContent);
+				const outcome = await runPostMutate(postMutate, { tool: "edit", path: absolutePath, signal });
+				if (signal?.aborted) throw new Error("Operation aborted");
+
+				let committedContent = newContent;
+				if (outcome.fileMayHaveChanged) {
+					const postMutateRead = await env.readTextFile(absolutePath, signal);
+					if (!postMutateRead.ok) throw editAccessError(path, postMutateRead.error);
+					committedContent = normalizeToLF(stripBom(postMutateRead.value).text);
+				}
+
+				const diffResult = generateDiffString(baseContent, committedContent);
+				const text = appendPostMutateNote(
+					`Successfully replaced ${edits.length} block(s) in ${path}.`,
+					outcome.note,
+				);
 				return {
-					content: [{ type: "text", text: `Successfully replaced ${edits.length} block(s) in ${path}.` }],
+					content: [{ type: "text", text }],
 					details: {
 						diff: diffResult.diff,
-						patch: generateUnifiedPatch(path, baseContent, newContent),
+						patch: generateUnifiedPatch(path, baseContent, committedContent),
 						firstChangedLine: diffResult.firstChangedLine,
 					},
 				};

--- a/packages/agent/src/harness/tools/edit.ts
+++ b/packages/agent/src/harness/tools/edit.ts
@@ -142,7 +142,8 @@ export function createEditTool<TContext extends ExecutionToolContext = Execution
 
 				const diffResult = generateDiffString(baseContent, committedContent);
 				const text = appendPostMutateNote(
-					appendPostMutateNote(`Successfully replaced ${edits.length} block(s) in ${path}.`, outcome.note),
+					`Successfully replaced ${edits.length} block(s) in ${path}.`,
+					outcome.note,
 					rereadNote,
 				);
 				return {

--- a/packages/agent/src/harness/tools/index.ts
+++ b/packages/agent/src/harness/tools/index.ts
@@ -19,5 +19,10 @@ export {
 	type ReadToolInput,
 	type ReadToolOptions,
 } from "./read.ts";
-export type { ExecutionToolContext } from "./tool-context.ts";
+export type {
+	ExecutionToolContext,
+	PostMutateContext,
+	PostMutateHook,
+	PostMutateResult,
+} from "./tool-context.ts";
 export { createWriteTool, type WriteToolInput } from "./write.ts";

--- a/packages/agent/src/harness/tools/post-mutate.ts
+++ b/packages/agent/src/harness/tools/post-mutate.ts
@@ -1,0 +1,43 @@
+import type { PostMutateContext, PostMutateHook, PostMutateResult } from "./tool-context.ts";
+
+/** Result of running a `postMutate` hook, with hook failures degraded to a warning note. */
+export interface PostMutateOutcome {
+	/**
+	 * Whether the file may differ from the bytes the tool itself wrote. True when the hook reported
+	 * a change, and also when the hook rejected — a hook that fails midway can leave the file
+	 * partially rewritten, so callers must re-read rather than trust their own bytes.
+	 */
+	fileMayHaveChanged: boolean;
+	note?: string;
+}
+
+const NO_CHANGE: PostMutateOutcome = { fileMayHaveChanged: false };
+
+/**
+ * Run a `postMutate` hook after a write has already landed on disk.
+ *
+ * The write is committed by the time the hook runs, so a rejecting hook must not fail the tool
+ * call and lose that result. Hook failures are reported as an appended warning note instead.
+ */
+export async function runPostMutate(
+	hook: PostMutateHook | undefined,
+	input: PostMutateContext,
+): Promise<PostMutateOutcome> {
+	if (!hook) return NO_CHANGE;
+	let result: PostMutateResult;
+	try {
+		result = await hook(input);
+	} catch (error) {
+		return { fileMayHaveChanged: true, note: `postMutate hook failed: ${errorMessage(error)}` };
+	}
+	return { fileMayHaveChanged: result.changed, note: result.note };
+}
+
+/** Append a `postMutate` note to tool result text. */
+export function appendPostMutateNote(text: string, note: string | undefined): string {
+	return note ? `${text}\n${note}` : text;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/packages/agent/src/harness/tools/post-mutate.ts
+++ b/packages/agent/src/harness/tools/post-mutate.ts
@@ -33,9 +33,9 @@ export async function runPostMutate(
 	return { fileMayHaveChanged: result.changed, note: result.note };
 }
 
-/** Append a `postMutate` note to tool result text. */
-export function appendPostMutateNote(text: string, note: string | undefined): string {
-	return note ? `${text}\n${note}` : text;
+/** Append any `postMutate` notes to tool result text, one per line, skipping absent ones. */
+export function appendPostMutateNote(text: string, ...notes: Array<string | undefined>): string {
+	return [text, ...notes.filter((note) => note !== undefined)].join("\n");
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/agent/src/harness/tools/tool-context.ts
+++ b/packages/agent/src/harness/tools/tool-context.ts
@@ -1,6 +1,33 @@
 import type { ExecutionEnv } from "../types.ts";
 
+/** Mutation that triggered a `postMutate` hook run. */
+export interface PostMutateContext {
+	/** Tool that performed the mutation. */
+	tool: "write" | "edit";
+	/** Absolute path of the file that was just written. */
+	path: string;
+	/** Abort signal of the originating tool call, when the caller supplied one. */
+	signal?: AbortSignal;
+}
+
+/** Outcome reported by a `postMutate` hook. */
+export interface PostMutateResult {
+	/** Whether the hook itself rewrote the file after the tool's own write landed. */
+	changed: boolean;
+	/** Single-line note appended to the tool result text. */
+	note?: string;
+}
+
+/** Hook invoked inside the file mutation queue, immediately after a tool write succeeds. */
+export type PostMutateHook = (input: PostMutateContext) => Promise<PostMutateResult>;
+
 /** Filesystem and shell context required by the built-in execution tools. */
 export interface ExecutionToolContext {
 	env: ExecutionEnv;
+	/**
+	 * Optional post-write hook (formatting, codegen, normalization). It runs inside the same
+	 * mutation-queue slot as the write it follows, so the file cannot be mutated in between.
+	 * A rejecting hook never discards the landed write; the tool appends a warning note instead.
+	 */
+	postMutate?: PostMutateHook;
 }

--- a/packages/agent/src/harness/tools/write.ts
+++ b/packages/agent/src/harness/tools/write.ts
@@ -3,6 +3,7 @@ import type { AgentHarnessTool } from "../types.ts";
 import { getOrThrow } from "../types.ts";
 import { withFileMutationQueue } from "./file-mutation-queue.ts";
 import { resolveToolPath } from "./path-utils.ts";
+import { appendPostMutateNote, runPostMutate } from "./post-mutate.ts";
 import type { ExecutionToolContext } from "./tool-context.ts";
 
 const writeSchema = Type.Object({
@@ -23,14 +24,17 @@ export function createWriteTool<TContext extends ExecutionToolContext = Executio
 		description:
 			"Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
 		parameters: writeSchema,
-		async execute(_toolCallId, { path, content }, signal, _onUpdate, { env }) {
+		async execute(_toolCallId, { path, content }, signal, _onUpdate, { env, postMutate }) {
 			const absolutePath = await resolveToolPath(env, path, signal);
 			return withFileMutationQueue(env, absolutePath, async () => {
 				if (signal?.aborted) throw new Error("Operation aborted");
 				getOrThrow(await env.writeFile(absolutePath, content, signal));
 				if (signal?.aborted) throw new Error("Operation aborted");
+				const outcome = await runPostMutate(postMutate, { tool: "write", path: absolutePath, signal });
+				if (signal?.aborted) throw new Error("Operation aborted");
+				const text = appendPostMutateNote(`Successfully wrote ${content.length} bytes to ${path}`, outcome.note);
 				return {
-					content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` }],
+					content: [{ type: "text", text }],
 					details: undefined,
 				};
 			});

--- a/packages/agent/test/harness/tools-post-mutate.test.ts
+++ b/packages/agent/test/harness/tools-post-mutate.test.ts
@@ -1,4 +1,5 @@
 import { rmSync } from "node:fs";
+import { symlink } from "node:fs/promises";
 import { applyPatch } from "diff";
 import { describe, expect, it } from "vitest";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
@@ -66,6 +67,30 @@ describe("AgentHarness tools postMutate", () => {
 		);
 
 		expect(observed).toBe("written-bytes");
+	});
+
+	it("hands the hook the path the tool wrote, not the canonical target, when editing through a symlink", async () => {
+		const env = createEnv();
+		getOrThrow(await env.writeFile("target.txt", "alpha\nbeta\n"));
+		await symlink("target.txt", `${env.cwd}/link.txt`);
+		const seen: string[] = [];
+
+		await createEditTool().execute(
+			"edit-post-mutate-symlink",
+			{ path: "link.txt", edits: [{ oldText: "alpha", newText: "ALPHA" }] },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async (input) => {
+					seen.push(input.path);
+					return { changed: false };
+				},
+			},
+		);
+
+		expect(seen).toEqual([getOrThrow(await env.absolutePath("link.txt"))]);
+		expect(getOrThrow(await env.readTextFile("target.txt"))).toBe("ALPHA\nbeta\n");
 	});
 
 	it("recomputes edit diff metadata against the post-mutate file contents", async () => {

--- a/packages/agent/test/harness/tools-post-mutate.test.ts
+++ b/packages/agent/test/harness/tools-post-mutate.test.ts
@@ -1,0 +1,292 @@
+import { applyPatch } from "diff";
+import { describe, expect, it } from "vitest";
+import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
+import { createEditTool } from "../../src/harness/tools/edit.ts";
+import type { PostMutateContext, PostMutateResult } from "../../src/harness/tools/tool-context.ts";
+import { createWriteTool } from "../../src/harness/tools/write.ts";
+import { getOrThrow } from "../../src/harness/types.ts";
+import { createTempDir } from "./session-test-utils.ts";
+
+function textOutput(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.flatMap((part) => (part.type === "text" ? [part.text ?? ""] : [])).join("\n");
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = () => {};
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function createEnv(): NodeExecutionEnv {
+	return new NodeExecutionEnv({ cwd: createTempDir() });
+}
+
+describe("AgentHarness tools postMutate", () => {
+	it("calls postMutate with the resolved absolute path and appends its note to write output", async () => {
+		const env = createEnv();
+		const calls: PostMutateContext[] = [];
+		const result = await createWriteTool().execute(
+			"write-post-mutate",
+			{ path: "nested/file.txt", content: "hello" },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async (input) => {
+					calls.push(input);
+					return { changed: false, note: "formatted with biome" };
+				},
+			},
+		);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.path).toBe(getOrThrow(await env.absolutePath("nested/file.txt")));
+		expect(calls[0]?.tool).toBe("write");
+		expect(textOutput(result)).toBe("Successfully wrote 5 bytes to nested/file.txt\nformatted with biome");
+	});
+
+	it("observes the freshly written bytes from inside postMutate", async () => {
+		const env = createEnv();
+		let observed: string | undefined;
+		await createWriteTool().execute(
+			"write-post-mutate-read",
+			{ path: "file.txt", content: "written-bytes" },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async (input) => {
+					observed = getOrThrow(await env.readTextFile(input.path));
+					return { changed: false };
+				},
+			},
+		);
+
+		expect(observed).toBe("written-bytes");
+	});
+
+	it("recomputes edit diff metadata against the post-mutate file contents", async () => {
+		const env = createEnv();
+		const original = "alpha\nbeta\ngamma\n";
+		getOrThrow(await env.writeFile("edit.txt", original));
+
+		const result = await createEditTool().execute(
+			"edit-post-mutate",
+			{ path: "edit.txt", edits: [{ oldText: "alpha", newText: "ALPHA" }] },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async (input) => {
+					const current = getOrThrow(await env.readTextFile(input.path));
+					getOrThrow(await env.writeFile(input.path, current.replace("gamma", "GAMMA")));
+					return { changed: true, note: "auto-formatted edit.txt" };
+				},
+			},
+		);
+
+		const onDisk = getOrThrow(await env.readTextFile("edit.txt"));
+		expect(onDisk).toBe("ALPHA\nbeta\nGAMMA\n");
+		expect(result.details?.diff).toContain("GAMMA");
+		expect(applyPatch(original, result.details?.patch ?? "")).toBe(onDisk);
+		expect(textOutput(result)).toBe("Successfully replaced 1 block(s) in edit.txt.\nauto-formatted edit.txt");
+	});
+
+	it("keeps edit diff metadata unchanged when postMutate reports no change", async () => {
+		const env = createEnv();
+		const original = "alpha\nbeta\n";
+		getOrThrow(await env.writeFile("edit.txt", original));
+
+		const result = await createEditTool().execute(
+			"edit-post-mutate-unchanged",
+			{ path: "edit.txt", edits: [{ oldText: "alpha", newText: "ALPHA" }] },
+			undefined,
+			undefined,
+			{ env, postMutate: async () => ({ changed: false }) },
+		);
+
+		expect(applyPatch(original, result.details?.patch ?? "")).toBe("ALPHA\nbeta\n");
+		expect(textOutput(result)).toBe("Successfully replaced 1 block(s) in edit.txt.");
+	});
+
+	it("runs postMutate inside the mutation queue so same-path mutations stay serialized", async () => {
+		const env = createEnv();
+		const events: string[] = [];
+		const firstHookEntered = deferred();
+		const releaseFirstHook = deferred();
+		const tool = createWriteTool();
+		const context = {
+			env,
+			postMutate: async (input: PostMutateContext): Promise<PostMutateResult> => {
+				const content = getOrThrow(await env.readTextFile(input.path));
+				events.push(`hook-start:${content}`);
+				if (content === "first") {
+					firstHookEntered.resolve();
+					await releaseFirstHook.promise;
+				}
+				events.push(`hook-end:${content}`);
+				return { changed: false };
+			},
+		};
+
+		const first = tool.execute("write-a", { path: "file.txt", content: "first" }, undefined, undefined, context);
+		await firstHookEntered.promise;
+		const second = tool.execute("write-b", { path: "file.txt", content: "second" }, undefined, undefined, context);
+		releaseFirstHook.resolve();
+		await Promise.all([first, second]);
+
+		expect(events).toEqual(["hook-start:first", "hook-end:first", "hook-start:second", "hook-end:second"]);
+		expect(getOrThrow(await env.readTextFile("file.txt"))).toBe("second");
+	});
+
+	it("surfaces a throwing postMutate as a warning note without losing the landed write", async () => {
+		const env = createEnv();
+		const result = await createWriteTool().execute(
+			"write-post-mutate-throws",
+			{ path: "file.txt", content: "payload" },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async () => {
+					throw new Error("formatter exploded");
+				},
+			},
+		);
+
+		expect(getOrThrow(await env.readTextFile("file.txt"))).toBe("payload");
+		expect(textOutput(result)).toBe(
+			"Successfully wrote 7 bytes to file.txt\npostMutate hook failed: formatter exploded",
+		);
+	});
+
+	it("surfaces a throwing postMutate as a warning note without losing the landed edit", async () => {
+		const env = createEnv();
+		getOrThrow(await env.writeFile("edit.txt", "alpha\nbeta\n"));
+
+		const result = await createEditTool().execute(
+			"edit-post-mutate-throws",
+			{ path: "edit.txt", edits: [{ oldText: "alpha", newText: "ALPHA" }] },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async () => {
+					throw new Error("formatter exploded");
+				},
+			},
+		);
+
+		expect(getOrThrow(await env.readTextFile("edit.txt"))).toBe("ALPHA\nbeta\n");
+		expect(textOutput(result)).toBe(
+			"Successfully replaced 1 block(s) in edit.txt.\npostMutate hook failed: formatter exploded",
+		);
+		expect(result.details?.diff).toContain("ALPHA");
+	});
+
+	it("reports the on-disk bytes when postMutate rewrites the file and then throws", async () => {
+		const env = createEnv();
+		const original = "alpha\nbeta\ngamma\n";
+		getOrThrow(await env.writeFile("edit.txt", original));
+
+		const result = await createEditTool().execute(
+			"edit-post-mutate-partial",
+			{ path: "edit.txt", edits: [{ oldText: "alpha", newText: "ALPHA" }] },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async (input) => {
+					const current = getOrThrow(await env.readTextFile(input.path));
+					getOrThrow(await env.writeFile(input.path, current.replace("gamma", "GAMMA")));
+					throw new Error("formatter exploded after writing");
+				},
+			},
+		);
+
+		const onDisk = getOrThrow(await env.readTextFile("edit.txt"));
+		expect(onDisk).toBe("ALPHA\nbeta\nGAMMA\n");
+		expect(applyPatch(original, result.details?.patch ?? "")).toBe(onDisk);
+		expect(textOutput(result)).toBe(
+			"Successfully replaced 1 block(s) in edit.txt.\npostMutate hook failed: formatter exploded after writing",
+		);
+	});
+
+	it("forwards the abort signal to postMutate and aborts the write when the hook observes it", async () => {
+		const env = createEnv();
+		const controller = new AbortController();
+		let receivedSignal: AbortSignal | undefined;
+
+		const pending = createWriteTool().execute(
+			"write-post-mutate-abort",
+			{ path: "file.txt", content: "payload" },
+			controller.signal,
+			undefined,
+			{
+				env,
+				postMutate: async (input) => {
+					receivedSignal = input.signal;
+					controller.abort();
+					return { changed: false };
+				},
+			},
+		);
+
+		await expect(pending).rejects.toThrow("Operation aborted");
+		expect(receivedSignal).toBe(controller.signal);
+		expect(getOrThrow(await env.readTextFile("file.txt"))).toBe("payload");
+	});
+
+	it("skips postMutate entirely when the signal is already aborted before the hook runs", async () => {
+		const env = createEnv();
+		const controller = new AbortController();
+		let hookCalls = 0;
+
+		const pending = createEditTool().execute(
+			"edit-post-mutate-pre-abort",
+			{ path: "missing.txt", edits: [{ oldText: "a", newText: "b" }] },
+			controller.signal,
+			undefined,
+			{
+				env,
+				postMutate: async () => {
+					hookCalls += 1;
+					return { changed: false };
+				},
+			},
+		);
+		controller.abort();
+
+		await expect(pending).rejects.toThrow();
+		expect(hookCalls).toBe(0);
+	});
+
+	it("produces byte-identical results to the pre-seam behavior when postMutate is absent", async () => {
+		const env = createEnv();
+		const writeResult = await createWriteTool().execute(
+			"write-no-hook",
+			{ path: "file.txt", content: "hello" },
+			undefined,
+			undefined,
+			{ env },
+		);
+		getOrThrow(await env.writeFile("edit.txt", "alpha\nbeta\n"));
+		const editResult = await createEditTool().execute(
+			"edit-no-hook",
+			{ path: "edit.txt", edits: [{ oldText: "alpha", newText: "ALPHA" }] },
+			undefined,
+			undefined,
+			{ env },
+		);
+
+		expect(writeResult).toEqual({
+			content: [{ type: "text", text: "Successfully wrote 5 bytes to file.txt" }],
+			details: undefined,
+		});
+		expect(textOutput(editResult)).toBe("Successfully replaced 1 block(s) in edit.txt.");
+		expect(editResult.details?.firstChangedLine).toBe(1);
+		expect(applyPatch("alpha\nbeta\n", editResult.details?.patch ?? "")).toBe("ALPHA\nbeta\n");
+	});
+});

--- a/packages/agent/test/harness/tools-post-mutate.test.ts
+++ b/packages/agent/test/harness/tools-post-mutate.test.ts
@@ -1,3 +1,4 @@
+import { rmSync } from "node:fs";
 import { applyPatch } from "diff";
 import { describe, expect, it } from "vitest";
 import { NodeExecutionEnv } from "../../src/harness/env/nodejs.ts";
@@ -212,6 +213,30 @@ describe("AgentHarness tools postMutate", () => {
 		expect(textOutput(result)).toBe(
 			"Successfully replaced 1 block(s) in edit.txt.\npostMutate hook failed: formatter exploded after writing",
 		);
+	});
+
+	it("keeps the landed edit result when the post-mutate re-read fails", async () => {
+		const env = createEnv();
+		getOrThrow(await env.writeFile("edit.txt", "alpha\nbeta\n"));
+
+		const result = await createEditTool().execute(
+			"edit-post-mutate-reread-fails",
+			{ path: "edit.txt", edits: [{ oldText: "alpha", newText: "ALPHA" }] },
+			undefined,
+			undefined,
+			{
+				env,
+				postMutate: async (input) => {
+					rmSync(input.path);
+					return { changed: true, note: "replaced the file with nothing" };
+				},
+			},
+		);
+
+		expect(textOutput(result)).toBe(
+			"Successfully replaced 1 block(s) in edit.txt.\nreplaced the file with nothing\npostMutate left the file unreadable: not_found. Reported diff describes the edit before the hook ran.",
+		);
+		expect(result.details?.diff).toContain("ALPHA");
 	});
 
 	it("forwards the abort signal to postMutate and aborts the write when the hook observes it", async () => {


### PR DESCRIPTION
## Summary

The harness `write` and `edit` tools commit bytes to disk and return immediately; nothing can observe or adjust the file as part of that same mutation. This PR adds an optional `postMutate` hook to `ExecutionToolContext` that runs **inside** the `withFileMutationQueue` slot, right after `env.writeFile` succeeds — so a formatter, codegen step, or normalizer can touch the file before any other mutation to that path is allowed to start.

The observable difference: with a hook injected, `write` appends the hook's note to its success text, and `edit` recomputes its diff and unified patch from the file *as it now exists on disk* rather than from the bytes `edit` itself wrote. With no hook injected — which is every caller today, including `packages/coding-agent/src/server/create-harness.ts` — behavior is byte-identical to before.

This is the seam only. No formatter is implemented and nothing is wired into it yet.

## Changes

**Contract (`tool-context.ts`, `post-mutate.ts`, `index.ts`)**
- `ExecutionToolContext` gains optional `postMutate?: (input: PostMutateContext) => Promise<PostMutateResult>`, where the input carries the originating tool (`"write" | "edit"`), the **resolved absolute path**, and the tool call's abort signal.
- `PostMutateResult` is `{ changed: boolean; note?: string }`. All three types plus `PostMutateHook` are exported from the tools barrel, which `src/index.ts` re-exports with `export *`.
- New `post-mutate.ts` holds `runPostMutate` (the failure-degradation policy) and `appendPostMutateNote`, so `write` and `edit` cannot drift apart on hook semantics.

**Tool wiring (`write.ts`, `edit.ts`)**
- Both call the hook inside the queue callback immediately after the write lands, with an abort check on either side.
- `write` appends the note to `Successfully wrote N bytes to <path>`.
- `edit` re-reads the file through the same BOM-strip / LF-normalize pipeline it already uses, then computes `diff`, `patch`, and `firstChangedLine` from that content.

**Error policy — the one deliberate exception to "tools throw on failure"**

`tools/AGENTS.md` says tools throw on failure. `postMutate` is exempt, and the reason is ordering: by the time the hook runs, `env.writeFile` has already succeeded and the file is on disk. Throwing would report failure for a mutation that in fact landed, and the agent would then act on a false picture of the filesystem. So a rejecting hook becomes an appended warning note (`postMutate hook failed: <message>`) on an otherwise successful result. The exception is documented in `tools/AGENTS.md` next to the convention it breaks.

Two consequences worth calling out, both found while reviewing this PR's own diff:

1. A hook that rewrites the file and *then* throws would otherwise leave `edit` reporting a stale diff — exactly the failure this seam exists to prevent. So `runPostMutate` reports `fileMayHaveChanged: true` on rejection as well as on `changed: true`, and `edit` re-reads in both cases. The diff always describes disk.
2. If the hook leaves the file unreadable (deletes it, say), the re-read fails. Throwing there produced `Could not edit file: <path>. Error code: not_found` — which blames the edit for damage the hook did, and tells the agent a mutation that in fact landed never happened. That is now a note on the successful result instead: `postMutate left the file unreadable: <code>. Reported diff describes the edit before the hook ran.`

**Docs**
- `packages/agent/src/changes.md` gains an entry naming every upstream-owned path touched, under all four canonical headings.
- `packages/agent/CHANGELOG.md` `[Unreleased] / Added`.
- `docs/harness.md` is untouched: it specifies the durable session / record-log contract and does not document the tool-context surface, so there is nothing there to extend.

## QA & Evidence

Evidence lives under `local-ignore/qa-evidence/20260827-harness-post-mutate-seam/` (gitignored, per repo policy).

**RED first**
- **What was tested:** the new harness suite against unmodified source, before any implementation existed.
- **Observed result:** 7 failed / 3 passed — the passing ones were the deliberate characterization tests (absent hook, queue serialization) that must be green both before and after. `tsc` additionally reported `has no exported member 'PostMutateContext'` and `'postMutate' does not exist in type 'ExecutionToolContext'`.
- **Artifact:** `01-red-tools-post-mutate.log`
- **Why sufficient:** proves the new tests fail for the intended reason rather than passing vacuously.

**Manual QA — real CLI, no hook injected (the regression risk)**
- **What was tested:** the real senpi CLI driven through the senpi-qa mock-loop channel (isolated sandbox, `PI_OFFLINE=1`, localhost fake model, zero tokens), scripted to issue an actual `write` tool call followed by an actual `edit` tool call and then finish the turn.
- **Observed result:** 7/7 checks passed. The file landed on disk as `alpha\nBETA\ngamma\n`; the tool results fed back to the model were exactly `Successfully wrote 17 bytes to seam-target.txt` and `Successfully replaced 1 block(s) in seam-target.txt.` — no trailing note, no extra whitespace. Real auth file sha256 verified unchanged.
- **Artifact:** `05-cli-write-edit-run.log`, `05-cli-write-edit-tool-results.json`, `05-cli-write-edit-stdout.txt`, driver `drive-write-edit.mjs`
- **Why sufficient:** covers the "zero behavior change when postMutate is absent" requirement at the user-visible surface, not just in unit tests. `create-harness.ts` supplies no hook, so this is the path every real user takes today.

**Manual QA — real formatter through the seam (the feature)**
- **What was tested:** the real harness tools against a real temp filesystem with the repo's own **biome binary** wired in as the hook (`biome format --write`), in a sandbox carrying its own `biome.json`. Three scenarios: a write of unformatted source, an edit that introduces sloppy spacing, and a hook that genuinely fails (spawning a nonexistent binary).
- **Observed result:** 7/7 checks passed.
  - write: `export const x   =    1` on disk became `export const x = 1;`, and the result text carried `(QA) auto-formatted sample.ts with biome`.
  - edit: the tool wrote `export const y   =    22`, biome rewrote it to `export const y = 22;`, and the returned diff was `-2 export const y = 2;` / `+2 export const y = 22;` — the **formatted** text, not what edit wrote. The returned unified patch applied to the pre-edit content reproduces the post-format on-disk bytes exactly.
  - hook failure: `kept.txt` still contained `must survive`, and the result was `Successfully wrote 12 bytes to kept.txt` followed by `postMutate hook failed: spawn ... ENOENT`.
- **Artifact:** `06-post-mutate-hook-run.log`, `06-post-mutate-hook-real-biome.json`, driver `drive-post-mutate-hook.mjs`
- **Why sufficient:** proves the two claims that matter with a real external process rather than a stub — that edit's diff reflects disk after third-party rewriting, and that a real hook failure cannot destroy a landed write. The coding-agent has no injection point for `postMutate` yet (follow-up work), so this is the highest-fidelity surface the hook can currently be driven on.

**Automated**
- `cd packages/agent && npm run test:harness` → 379 passed, 1 skipped (380), exit 0. Artifact: `02-green-test-harness.log`
- `cd packages/agent && npm test` → 531 passed, 1 skipped (532), exit 0. Artifact: `03-green-npm-test.log`
- `npm run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, `tsc --noEmit`, browser-smoke) → exit 0. Artifact: `04-npm-run-check.log`
- No pre-existing test was modified; the 13 new tests are additive in a new file.

## Risks & Residuals

| Risk | Evidence | Conclusion |
|---|---|---|
| Existing callers see changed behavior | Real-CLI run asserts byte-exact pre-seam result strings; characterization test asserts the full `write` result object and that edit's patch still reproduces the pre-seam content | Mitigated |
| `edit` returns a diff that no longer matches disk | Real-biome QA: the returned patch applies to produce the exact post-format on-disk bytes; a rewrite-then-throw unit test covers the partial-failure case | Mitigated |
| A failing hook loses a committed write | Real ENOENT hook QA plus unit coverage on both tools; the write survives and the failure degrades to a note | Mitigated by design, documented above |
| A hook that destroys the file makes `edit` misreport the mutation as never having happened | Test drives a hook that deletes the file mid-flight; the successful result is retained and the re-read failure becomes an explicit note naming the cause | Mitigated |
| Hook interleaves with a concurrent same-path mutation | The hook runs inside the queue callback; a test drives two concurrent same-path writes and asserts strict hook-start/hook-end ordering via a recording hook with event handoff — no sleeps, no timing luck | Mitigated |
| Hook receives a path that differs from what the tool wrote (symlinks) | Test edits through a symlink and asserts the hook is handed the resolved symlink path the tool wrote, not the canonical target | Mitigated |
| Hook ignores abort | The signal is passed through in `PostMutateContext` and re-checked after the hook returns; tests cover both forwarding and the already-aborted path where the hook must not run at all | Mitigated |
| A long-running hook stalls a queue slot | Not addressed here — timeouts and concurrency caps belong to the hook implementation, which this PR deliberately does not ship | Accepted, out of scope |

No formatter, no LSP work, and no `packages/coding-agent` wiring are included; injecting a hook at `create-harness.ts` is follow-up work.
