### PR TITLE
test(coding-agent): guard senpi-default against kimi semantics; record phase-2 retry docs

### DIFF
--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,25 @@
+## 2026-08-27 - Default retry policy phase-2 close-out (docs)
+
+### What changed
+
+- `packages/ai/src/utils/retry-profile/profiles.ts`: the senpi-default turn stage ships an 8s `perAttemptCapMs` and +0..25% additive jitter on locally computed exponential backoffs (provider-derived `Retry-After` hints stay exact). `classifyErrorMessage` remains tri-state (non-retryable / retryable / unknown) with non-retryable outranking retryable.
+- The default same-model turn retry budget stays at 3 retries. This is an intentional non-change: the budget was reviewed during phase-2 close and kept at its existing value for all providers that don't declare their own profile.
+- No new kimi-code observability or telemetry surface was adopted. The `provider_retry_failure` diagnostic added in phase 1 is the only retry-specific emission, and no additional counters, traces, or structured events were introduced.
+- Regression coverage: `packages/coding-agent/test/suite/regressions/retry-default-no-kimi-leak.test.ts` guards senpi-default against kimi semantics leaking in (no-hint 429 first-failure fallback, 1258000ms hint tier routing, billing 429 pinned fallback, abort during backoff single `auto_retry_end`).
+- Tracked in `packages/ai/src/changes.md` and `packages/coding-agent/src/core/changes.md`.
+
+### Why
+
+- Phase-2 close needs an explicit record that the 3-retry budget and the absence of new telemetry were deliberate decisions, not oversights. The profile defaults recap documents the shipped values in one place for reviewers who don't read `profiles.ts`.
+
+### Why an extension could not handle it
+
+- The profile constants and classifier live inside this package's retry-profile tree, below any extension-visible hook.
+
+### Expected merge conflict zones
+
+- NONE: doc-only section append; no code files touched.
+
 ## 2026-08-27 - Storage docs describe pooled entries
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,43 @@
 # changes
 
+## 2026-08-27 - Default retry policy phase-2 close-out (docs)
+
+### What changed
+
+- `packages/coding-agent/src/core/retry-fallback/profile-override.ts`: the `retry.providers.<providerId>` override surface accepts per-provider scheduling-knob overrides validated against `RetryStageOverride` (fields: `enabled`, `maxRetries`, `baseDelayMs`, `growthFactor`, `perAttemptCapMs`, `jitter`, `serverHintMaxDelayMs`). An entire provider entry is rejected atomically when any knob is invalid.
+- Recommended settings snippet for users who configure no fallback chain and want a larger same-model budget:
+  ```jsonc
+  {
+    // Raise the turn retry budget for a single-provider setup.
+    // maxRetries must be a non-negative safe integer.
+    "retry": {
+      "providers": {
+        "<providerId>": {
+          "turn": {
+            "maxRetries": 5
+          }
+        }
+      }
+    }
+  }
+  ```
+- The default same-model turn retry budget stays at 3 retries. This is an intentional non-change: the budget was reviewed during phase-2 close and kept at its existing value for all providers that don't declare their own profile.
+- No new kimi-code observability or telemetry surface was adopted.
+- Regression coverage: `packages/coding-agent/test/suite/regressions/retry-default-no-kimi-leak.test.ts` guards senpi-default against kimi semantics leaking in (no-hint 429 first-failure fallback, 1258000ms hint tier routing, billing 429 pinned fallback, abort during backoff single `auto_retry_end`).
+- Tracked in `packages/ai/src/changes.md` and `packages/coding-agent/src/core/changes.md`.
+
+### Why
+
+- Users running a single provider without a fallback chain benefit from a higher retry budget, but the default stays conservative (3) to avoid masking persistent failures when fallback providers are available. The snippet documents the exact override path so users don't have to read the validation source.
+
+### Why an extension could not handle it
+
+- `retry.providers` overrides are resolved inside `resolveRetryProfile` in `packages/coding-agent/src/core/settings-manager.ts`, before any extension hook. The validation and merge happen at settings load time.
+
+### Expected merge conflict zones
+
+- NONE: doc-only section append; no code files touched.
+
 ## Provider-neutral credential accounts (2026-08-27)
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/retry-default-no-kimi-leak.test.ts
+++ b/packages/coding-agent/test/suite/regressions/retry-default-no-kimi-leak.test.ts
@@ -1,0 +1,167 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "../harness.ts";
+
+// Phase-2 guardrail (plan todo 18): the shipped `senpi-default` profile runs with
+// the phase-2 turn backoff values (8s per-attempt cap, additive 25% jitter) and must
+// NOT acquire kimi-code semantics — no same-model 429 budget, no uncapped local wait,
+// no unpinned billing fallback, no retry surviving an abort. Randomness is injected
+// deterministically through the harness `retryRandom` seam so jittered local waits are
+// exact; provider-derived waits and the fallback switch stay unjittered by contract.
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+// Both retryable AND rate-limit marked, so the 429-class tier router fires.
+const noHint429 = "HTTP 429: rate_limit_exceeded - All tokens rate limited";
+// 1_258_000ms sits above hintedWaitCapMs (300_000) and below probeBackMaxMs
+// (3_600_000) => tier2: fallback now, probe the demoted model back later.
+const hint1258s = "HTTP 429: rate_limit_error (retry-after-ms: 1258000)";
+// Verbatim Anthropic Console credit exhaustion (429 carrying credits_required).
+const billing429 =
+	'429 event: error\ndata: {"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for this model.","details":{"error_code":"credits_required","model":"claude-fable-5"}},"request_id":"req_011CdW2nFxprAx6KQ9JhnAvq"}';
+const transient500 = "HTTP 500: internal_error";
+
+function errorTurn(errorMessage: string) {
+	return fauxAssistantMessage("", { stopReason: "error", errorMessage });
+}
+
+function createDefaultProfileHarness(options: {
+	now: () => number;
+	baseDelayMs?: number;
+	withChain?: boolean;
+}): Promise<Harness> {
+	return createHarness({
+		models: [{ id: "faux-1" }, { id: "faux-2" }],
+		fallbackNow: options.now,
+		// Midpoint sample: a jittered local wait is exactly floor * 1.125.
+		retryRandom: () => 0.5,
+		settings: {
+			retry: {
+				enabled: true,
+				maxRetries: 3,
+				baseDelayMs: options.baseDelayMs ?? 1,
+				...(options.withChain === false ? {} : { fallbackChains: { [primary]: [fallback] } }),
+			},
+		},
+	});
+}
+
+function primaryCallCount(harness: Harness): number {
+	return harness.faux.getCallLog().filter((call) => call.modelId === "faux-1").length;
+}
+
+describe("senpi-default retry profile does not leak kimi-code semantics", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	// (1) Mutation target: flipping fallback.rateLimited to "after-turn-budget"
+	// spends the same-model turn budget first, which this scenario forbids.
+	it("falls back on the first no-hint 429 with zero same-model retries", async () => {
+		const harness = await createDefaultProfileHarness({ now: () => 0 });
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(noHint429), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+
+		// Kimi semantics would retry faux-1 up to the turn budget before switching.
+		expect(primaryCallCount(harness)).toBe(1);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+		// The fallback switch is the exact zero-delay contract: never jittered, never capped.
+		expect(harness.eventsOfType("auto_retry_start").map((event) => event.delayMs)).toEqual([0]);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([true]);
+	});
+
+	// (2) A huge hint must never become a same-model sleep; senpi tiers out instead.
+	it("routes a 1258s hint to a tier2 fallback with probe-back, never an uncapped same-model wait", async () => {
+		let now = 0;
+		const harness = await createDefaultProfileHarness({ now: () => now });
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(hint1258s), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+
+		expect(primaryCallCount(harness)).toBe(1);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "transient" },
+		]);
+		// Only the zero-delay fallback switch: no 1_258_000ms (or any hint-derived) sleep.
+		const delays = harness.eventsOfType("auto_retry_start").map((event) => event.delayMs);
+		expect(delays).toEqual([0]);
+		expect(delays).not.toContain(1_258_000);
+		// Probe-back is armed at half the hint, bounded by the hint deadline.
+		expect(harness.eventsOfType("retry_probe_scheduled")).toMatchObject([
+			{ selector: primary, atMs: 629_000, probeIndex: 1 },
+		]);
+		// The demoted primary stays on cooldown for the full remaining hint: a
+		// 60s hop past the generic 30s rate-limit cooldown must not revert it.
+		now += 60_000;
+		await harness.session.prompt("again");
+
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-2");
+	});
+
+	// (3) Billing-class 429 pins; a cooldown expiry must not walk back into a dead model.
+	it("pins the fallback for a billing-class 429 instead of reverting on cooldown expiry", async () => {
+		let now = 0;
+		const harness = await createDefaultProfileHarness({ now: () => now });
+		harnesses.push(harness);
+		harness.setResponses([
+			errorTurn(billing429),
+			fauxAssistantMessage("fallback answer"),
+			fauxAssistantMessage("still fallback"),
+		]);
+
+		await harness.session.prompt("first");
+
+		expect(harness.eventsOfType("retry_fallback_applied").map((event) => event.reason)).toEqual(["billing"]);
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		// Past every cooldown bucket, including the 30-minute billing one.
+		now += 31 * 60_000;
+		await harness.session.prompt("second");
+
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2", "faux-2"]);
+	});
+
+	// (4) Abort during a local backoff sleep is terminal: one cancelled end, no further call.
+	it("cancels a backoff sleep on abort with exactly one 'Retry cancelled' end and no further call", async () => {
+		// No chain, non-429 transient: the retry stays on faux-1 and sleeps the
+		// locally computed jittered wait (2000 * 1.125 = 2250ms) we abort inside.
+		const harness = await createDefaultProfileHarness({ now: () => 0, baseDelayMs: 2_000, withChain: false });
+		harnesses.push(harness);
+		harness.setResponses([errorTurn(transient500), fauxAssistantMessage("must never be requested")]);
+
+		let abortPromise: Promise<void> | undefined;
+		const sawRetryStart = new Promise<{ delayMs: number }>((resolve) => {
+			const unsubscribe = harness.session.subscribe((event) => {
+				if (event.type !== "auto_retry_start") return;
+				unsubscribe();
+				abortPromise = harness.session.abort();
+				resolve({ delayMs: event.delayMs });
+			});
+		});
+
+		const promptPromise = harness.session.prompt("hello");
+		const retryStart = await sawRetryStart;
+		if (!abortPromise) throw new Error("abort was not triggered from auto_retry_start");
+		await abortPromise;
+		await promptPromise;
+
+		// Local exponential under phase-2 values: floor 2000, additive jitter at random 0.5.
+		expect(retryStart.delayMs).toBe(2_250);
+		expect(harness.eventsOfType("auto_retry_end")).toMatchObject([{ success: false, finalError: "Retry cancelled" }]);
+		// The pending success response was never consumed: no post-abort provider call.
+		expect(harness.faux.state.callCount).toBe(1);
+		expect(harness.getPendingResponseCount()).toBe(1);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.session.isRetrying).toBe(false);
+	});
+});


### PR DESCRIPTION
## What

Close-out of the provider-retry-profiles plan (`.omo/plans/provider-retry-profiles.md`, todos 17-18) left open after #1121 merged:

- **Guardrail regression suite** — new `packages/coding-agent/test/suite/regressions/retry-default-no-kimi-leak.test.ts` (4 tests, 167 lines) pinning that the shipped `senpi-default` profile, under phase-2 values (8s turn cap, +0..25% additive jitter), never acquires kimi-code semantics:
  1. no-hint 429 with a chain → fallback on the FIRST failure, zero same-model retries, exact `[0]` switch delay
  2. 1,258,000ms retry-after hint → tier-2 fallback + probe-back at 629,000ms; never an uncapped same-model wait; no revert after a 60s clock hop
  3. billing-class 429 (`credits_required`) → fallback PINNED; no revert past the 30-minute cooldown; exact call log `[faux-1, faux-2, faux-2]`
  4. abort during backoff sleep → exactly one `auto_retry_end` "Retry cancelled", no further provider call; also pins the phase-2 jittered wait (2000 × 1.125 = 2250ms at injected `retryRandom` 0.5)
- **Tracker docs** — dated phase-2 close-out sections in `packages/ai/src/changes.md` and `packages/coding-agent/src/core/changes.md`: the intentional NON-change of the 3-retry default budget, the recommended `retry.providers.<id>.turn.maxRetries: 5` override snippet for no-fallback-chain setups (field-validated against `RetryStageOverride` in `profile-override.ts`), and the explicit note that no new kimi-code observability was adopted.

## Why

Phase 2 of #1121 changed shipped default values on purpose; these guardrails make any future leak of kimi semantics into `senpi-default` (immediate-fallback policy, hint tiering, billing pinning, abort finality) fail loudly, and the trackers record the deliberate decisions reviewers would otherwise have to reverse-engineer.

## QA

- Mutation proof (RED): flipping `SENPI_DEFAULT_RETRY_PROFILE.fallback.rateLimited` to `"after-turn-budget"` makes scenario 1 fail with `expected 2 to be 1` (same-model retry instead of immediate fallback) — mutation reverted, never committed.
- GREEN: `npx vitest --run test/suite/regressions/retry-default-no-kimi-leak.test.ts` → 4/4 pass.
- Adjacent suites re-run: `retry-profile-default-parity`, `retry-fallback-hint-tiers`, `retry-fallback-billing-swap`.
- `node scripts/check-pr-changelog.mjs --base <merge-base>` → PASS; root `npm run check` (biome, tsc, locks, browser smoke) green in pre-commit on both commits.

Plan: `.omo/plans/provider-retry-profiles.md` (todos 17-18; todos 1-16 shipped in #1121)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression suite that pins the shipped `senpi-default` retry profile to phase-2 semantics and records the phase-2 close-out decisions in the changelogs. No shipped behavior changes.

**Guardrail scenarios**
- Covers no-hint 429s, a 1,258,000ms retry-after hint, billing-class 429s, and abort during backoff sleep.
- Asserts call logs, switch delays, probe-back timings, and the jittered local wait (2000 × 1.125 = 2250ms) through the injected `retryRandom` seam.

**Recorded decisions**
- Documents the intentionally unchanged 3-retry default budget and the absence of new kimi-code telemetry.
- Snippets the validated `retry.providers.<id>.turn.maxRetries: 5` override for single-provider setups without a fallback chain.

<sup>Written for commit c47fc88359d559ab85d1db29011b4d4283a68992. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

