### PR TITLE
fix(coding-agent): route imagegen missing-skill notice to stderr

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Imagegen missing-skill diagnostics now go to stderr, keeping RPC NDJSON stdout clean when a compiled binary lacks the optional skill asset.
+
 ### Removed
 
 ## [2026.8.27] - 2026-08-27

--- a/packages/coding-agent/src/core/extensions/builtin/imagegen/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/imagegen/changes.md
@@ -1,5 +1,25 @@
 # imagegen builtin — changes
 
+## RPC-safe missing-skill diagnostics (2026-08-27)
+
+### What changed
+
+- Missing bundled-skill diagnostics now route to stderr instead of stdout.
+- Added regression coverage proving the notice is emitted once without writing to stdout.
+
+### Why
+
+- Bun-compiled RPC binaries can legitimately lack the optional skill file at the module URL. Writing that diagnostic to stdout corrupts the NDJSON RPC wire.
+
+### Why an extension could not handle it
+
+- The diagnostic is emitted inside the builtin extension's resource-discovery path before any downstream extension can redirect the stream.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` missing-skill branch and `test/imagegen-skill-gating.test.ts` diagnostic assertions.
+
+
 ## 2026-08-13 - Materialize nullable headers only at image requests
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/imagegen/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/imagegen/index.ts
@@ -26,7 +26,7 @@ function bundledSkillPath(baseDir: string): string | undefined {
 	if (existsSync(skillPath)) return skillPath;
 	if (!loggedMissingSkill) {
 		loggedMissingSkill = true;
-		console.debug(`[imagegen] bundled skill not found at ${skillPath}; skipping contribution`);
+		console.error(`[imagegen] bundled skill not found at ${skillPath}; skipping contribution`);
 	}
 	return undefined;
 }

--- a/packages/coding-agent/test/imagegen-skill-gating.test.ts
+++ b/packages/coding-agent/test/imagegen-skill-gating.test.ts
@@ -106,12 +106,14 @@ describe("imagegen skill contribution", () => {
 		const errors: string[] = [];
 		runner.onError((error) => errors.push(error.error));
 		const debug = vi.spyOn(console, "debug").mockImplementation(() => {});
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
 
 		const resources = await runner.emitResourcesDiscover(cwd, "reload");
 		await runner.emitResourcesDiscover(cwd, "reload");
 
 		expect(resources.skillPaths).toEqual([]);
 		expect(errors).toEqual([]);
-		expect(debug).toHaveBeenCalledTimes(1);
+		expect(debug).not.toHaveBeenCalled();
+		expect(error).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
Routes the missing bundled imagegen skill diagnostic to stderr so compiled RPC NDJSON stdout remains clean. Adds a regression assertion and changelog/change record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the missing bundled imagegen skill diagnostic from stdout to stderr so compiled RPC NDJSON stdout stays clean. Adds regression coverage and a changelog entry.

<sup>Written for commit 07ac85e01deea6e828f3aaee623b1473d974cec9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

