### PR TITLE
fix(codemode): resolve compiled eval runtime assets

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- JavaScript and Python eval kernels resolve worker and prelude assets from the executable sidecar in Bun-compiled distributions instead of passing unusable `$bunfs` paths to `Worker` and `python3`.
+
 ### Removed
 
 ## [2026.8.27] - 2026-08-27

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,20 @@
 # senpi-codemode fork changes
 
+## Compiled eval kernels resolve runtime assets from the sidecar (2026-08-27)
+
+### What changed
+
+- JavaScript worker entries and the Python prelude now resolve through the compiled-runtime sidecar, matching the existing Ruby and Julia kernel behavior.
+- Added coverage for all three assets in the compiled runner path tests.
+
+### Why
+
+- Bun-compiled eval kernels received `$bunfs` paths that are not usable by `Worker` or an external `python3` process. The staged sidecar provides real filesystem paths next to the compiled executable.
+
+### Expected merge conflict zones
+
+- LOW in the JavaScript and Python kernel asset resolution paths and compiled runner path tests.
+
 ## Session teardown failures stay out of lifecycle handler rejections (2026-08-25)
 
 ### What changed

--- a/packages/senpi-codemode/src/kernels/js/context-manager.ts
+++ b/packages/senpi-codemode/src/kernels/js/context-manager.ts
@@ -1,5 +1,8 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
 import type { KernelInterruptHandle } from "../../tool/types.ts";
+import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import { createInlineWorker, type WorkerLike } from "./inline-worker.ts";
 import {
 	assertJavaScriptKernelOpen,
@@ -15,6 +18,15 @@ import { bridgeError, spawnNodeWorker, WorkerStartupCancelledError, waitForReady
 
 export { JavaScriptKernelClosedError, type JavaScriptKernelMode, type JavaScriptRunInput } from "./kernel-contract.ts";
 export type { JavaScriptKernelOptions } from "./local-module-loader.ts";
+
+export interface JavaScriptWorkerEntryUrlOptions extends CodemodeRuntimeAssetEnvironment {
+	readonly localPath?: string;
+}
+
+export function resolveJsWorkerEntryUrl(options: JavaScriptWorkerEntryUrlOptions = {}): URL {
+	const localPath = options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "worker-entry.js");
+	return pathToFileURL(resolveCodemodeRuntimeAsset(localPath, join("kernels", "js", "worker-entry.js"), options));
+}
 
 export class JavaScriptKernel {
 	readonly #options: JavaScriptKernelOptions;
@@ -161,7 +173,7 @@ export class JavaScriptKernel {
 
 	#spawnWorker(): WorkerLike {
 		try {
-			const url = this.#options.workerEntryUrl ?? new URL("./worker-entry.js", import.meta.url);
+			const url = this.#options.workerEntryUrl ?? resolveJsWorkerEntryUrl();
 			return spawnNodeWorker(url, this.#options.cwd, this.#options.parallelPoolWidth);
 		} catch (error) {
 			if (!(error instanceof Error)) throw error;

--- a/packages/senpi-codemode/src/kernels/js/inline-worker.ts
+++ b/packages/senpi-codemode/src/kernels/js/inline-worker.ts
@@ -1,6 +1,20 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
+import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import type { JavaScriptKernelMode } from "./kernel-contract.ts";
 import { spawnNodeWorker } from "./worker-host.ts";
+
+export interface JavaScriptInlineWorkerEntryUrlOptions extends CodemodeRuntimeAssetEnvironment {
+	readonly localPath?: string;
+}
+
+export function resolveInlineWorkerEntryUrl(options: JavaScriptInlineWorkerEntryUrlOptions = {}): URL {
+	const localPath = options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "inline-worker-entry.js");
+	return pathToFileURL(
+		resolveCodemodeRuntimeAsset(localPath, join("kernels", "js", "inline-worker-entry.js"), options),
+	);
+}
 
 export interface WorkerLike {
 	readonly mode: JavaScriptKernelMode;
@@ -11,5 +25,5 @@ export interface WorkerLike {
 }
 
 export function createInlineWorker(cwd: string, parallelPoolWidth: number): WorkerLike {
-	return spawnNodeWorker(new URL("./inline-worker-entry.js", import.meta.url), cwd, parallelPoolWidth, "inline");
+	return spawnNodeWorker(resolveInlineWorkerEntryUrl(), cwd, parallelPoolWidth, "inline");
 }

--- a/packages/senpi-codemode/src/kernels/py/transport.ts
+++ b/packages/senpi-codemode/src/kernels/py/transport.ts
@@ -8,6 +8,7 @@ import {
 	isKernelToHostMessage,
 	type KernelToHostMessage,
 } from "../../bridge/protocol.ts";
+import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
 import {
 	defaultSpawn,
 	hardKill,
@@ -47,6 +48,18 @@ export interface PythonTransportOptions {
 
 const hardKillWaitMs = 500;
 
+export interface PythonPreludePathOptions extends CodemodeRuntimeAssetEnvironment {
+	readonly localPath?: string;
+}
+
+export function resolvePythonPreludePath(options: PythonPreludePathOptions = {}): string {
+	return resolveCodemodeRuntimeAsset(
+		options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "prelude.py"),
+		join("kernels", "py", "prelude.py"),
+		options,
+	);
+}
+
 export class PythonKernelTransport {
 	readonly #options: PythonTransportOptions;
 	readonly #child: KernelChild;
@@ -64,7 +77,7 @@ export class PythonKernelTransport {
 	}
 
 	static async start(options: PythonTransportOptions): Promise<PythonKernelTransport> {
-		const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "prelude.py");
+		const scriptPath = resolvePythonPreludePath();
 		const invocation = splitCommand(options.interpreterPath);
 		const spawnOptions: KernelSpawnOptions = {
 			command: invocation.command,

--- a/packages/senpi-codemode/test/compiled-runner-path.test.ts
+++ b/packages/senpi-codemode/test/compiled-runner-path.test.ts
@@ -3,6 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { resolveJuliaRunnerPath } from "../src/kernels/jl/kernel.ts";
+import { resolveJsWorkerEntryUrl } from "../src/kernels/js/context-manager.ts";
+import { resolveInlineWorkerEntryUrl } from "../src/kernels/js/inline-worker.ts";
+import { resolvePythonPreludePath } from "../src/kernels/py/transport.ts";
 import { resolveRubyRunnerPath } from "../src/kernels/rb/kernel.ts";
 
 let tempDir: string | undefined;
@@ -53,6 +56,42 @@ describe("compiled codemode runner paths", () => {
 				executablePath: fixture.executablePath,
 				localPath: fixture.localPath,
 			}),
+		).toBe(fixture.sidecarPath);
+	});
+
+	it("resolves the Python prelude from the executable sidecar", () => {
+		const fixture = setupRunner(join("kernels", "py", "prelude.py"));
+
+		expect(
+			resolvePythonPreludePath({
+				bunVersion: "1.3.14",
+				executablePath: fixture.executablePath,
+				localPath: fixture.localPath,
+			}),
+		).toBe(fixture.sidecarPath);
+	});
+
+	it("resolves the JavaScript worker entry from the executable sidecar", () => {
+		const fixture = setupRunner(join("kernels", "js", "worker-entry.js"));
+
+		expect(
+			resolveJsWorkerEntryUrl({
+				bunVersion: "1.3.14",
+				executablePath: fixture.executablePath,
+				localPath: fixture.localPath,
+			}).pathname,
+		).toBe(fixture.sidecarPath);
+	});
+
+	it("resolves the inline JavaScript worker entry from the executable sidecar", () => {
+		const fixture = setupRunner(join("kernels", "js", "inline-worker-entry.js"));
+
+		expect(
+			resolveInlineWorkerEntryUrl({
+				bunVersion: "1.3.14",
+				executablePath: fixture.executablePath,
+				localPath: fixture.localPath,
+			}).pathname,
 		).toBe(fixture.sidecarPath);
 	});
 


### PR DESCRIPTION
## Summary

Bun-compiled distributions passed unusable `$bunfs` asset paths to JavaScript `Worker` and the external `python3` process, leaving JS and Python eval kernels dead. Ruby and Julia already resolved these assets through the executable sidecar.

This change adds sidecar-aware resolvers for:

- Python `kernels/py/prelude.py`
- JavaScript `kernels/js/worker-entry.js`
- JavaScript `kernels/js/inline-worker-entry.js`

The JS call sites preserve the explicit `workerEntryUrl` override and the existing worker-to-inline fallback. Resolved filesystem paths are converted back to `file:` URLs for worker construction.

Distribution packaging and sidecar staging in `omo-desktop-app` are handled in a separate PR.

## Verification

- TDD RED captured: focused test file failed 3 tests with missing resolver functions; existing Ruby/Julia cases passed (3 passed, 3 failed).
- Focused GREEN: `test/compiled-runner-path.test.ts` - 6/6 tests passed.
- Changed-file LSP diagnostics: clean.
- Biome on changed source/test files: clean.
- `npm run check:ts-imports`: passed.
- `node scripts/check-pr-changelog.mjs --base "$(git merge-base HEAD origin/main)"`: passed.
- Root `npm run check`: formatter and repository consistency gates passed; final repository typecheck is blocked by pre-existing workspace package/declaration errors after a clean install.
- Full `npm test` for `senpi-codemode`: 297 tests passed, but 50 suites fail at import time because local workspace packages (including `@earendil-works/pi-telemetry`) are not built/resolvable in this clean worktree.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JS and Python eval kernels in Bun-compiled distributions by resolving runtime assets from the executable sidecar instead of unusable `$bunfs` paths, matching existing Ruby and Julia behavior.

**Bug Fixes**
- Adds sidecar-aware resolvers for the Python prelude and both JavaScript worker entry files, with tests covering each.
- Preserves the explicit `workerEntryUrl` override and the worker-to-inline fallback in JavaScript call sites.
- Distribution packaging and sidecar staging in `omo-desktop-app` are handled in a separate PR.

<sup>Written for commit db66d56a9630a45a46529a1c0039c52c48940f26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

