### PR TITLE
fix(coding-agent): embed the imagegen skill for compiled binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Bun-compiled binaries now embed the imagegen bundled skill so resource discovery remains available after compilation.
+
 - `/account <provider> [list | pin <name> | unpin | remove <name>]` manages any provider's credential accounts, the TUI footer shows the active account as `(provider@account)` whenever a provider pools more than one credential, `auth check --json` reports a non-secret `accounts` array, and the account RPC/app-server surfaces (`get_provider_accounts`, `account_pin`, `account_remove`, `account/providerAccounts/*`) now work for every provider instead of only the Claude lane.
 
 ### Changed

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,24 @@
 # Local fork changes
 
+## Bun-compiled runtime assets (2026-08-27)
+
+### What changed
+
+- Bun-compiled coding-agent binaries now embed the imagegen bundled skill through the builtin's file-asset import; Node distributions continue to use the copied `dist` asset.
+
+### Why
+
+- Copying the skill into `dist` does not add it to Bun's compile graph, so compiled binaries lost the skill while emitting a missing-skill diagnostic.
+
+### Why an extension could not handle it
+
+- The compiled asset graph and builtin resource path are established by the package build and extension implementation before an extension can provide resources.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/extensions/builtin/imagegen/index.ts` and its asset declaration.
+
+
 ## @anthropic-ai/sdk peer alignment (2026-08-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/imagegen/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/imagegen/changes.md
@@ -1,5 +1,24 @@
 # imagegen builtin — changes
 
+## Bun-compiled skill asset (2026-08-27)
+
+### What changed
+
+- Bun-compiled binaries now resolve the bundled skill through a file-asset import, while Node continues using the copied adjacent skill file.
+
+### Why
+
+- The skill is copied into `dist` for Node execution but was not embedded in the Bun compile graph, leaving compiled binaries without imagegen guidance.
+
+### Why an extension could not handle it
+
+- The skill path is resolved inside the builtin's resource-discovery handler, so no downstream extension can restore an asset absent from the compiled module graph.
+
+### Expected merge conflict zones
+
+- LOW: `index.ts` asset resolution branch.
+
+
 ## RPC-safe missing-skill diagnostics (2026-08-27)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/imagegen/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/imagegen/index.ts
@@ -7,6 +7,10 @@ import { imageGenRegistryOverride } from "./state.ts";
 import { generateImageTool } from "./tool.ts";
 
 const IMAGEGEN_BASE_DIR = dirname(fileURLToPath(import.meta.url));
+// Bun compile extracts imported file assets to a real path; Node dist keeps using the copied skill.
+const embeddedSkillPath = process.versions.bun
+	? import("./skill/SKILL.md", { with: { type: "file" } }).then((module) => module.default as string)
+	: Promise.resolve(undefined);
 let loggedMissingSkill = false;
 
 export const IMAGE_GEN_SECTION = `
@@ -21,9 +25,11 @@ async function isImageGenActive(ctx: ExtensionContext): Promise<boolean> {
 	return auth.kind !== "none";
 }
 
-function bundledSkillPath(baseDir: string): string | undefined {
+async function bundledSkillPath(baseDir: string): Promise<string | undefined> {
 	const skillPath = join(baseDir, "skill", "SKILL.md");
 	if (existsSync(skillPath)) return skillPath;
+	const embeddedPath = await embeddedSkillPath;
+	if (baseDir === IMAGEGEN_BASE_DIR && embeddedPath !== undefined && existsSync(embeddedPath)) return embeddedPath;
 	if (!loggedMissingSkill) {
 		loggedMissingSkill = true;
 		console.error(`[imagegen] bundled skill not found at ${skillPath}; skipping contribution`);
@@ -36,7 +42,7 @@ export function registerImageGenExtension(pi: ExtensionAPI, baseDir = IMAGEGEN_B
 
 	pi.on("resources_discover", async (_event, ctx) => {
 		if (!(await isImageGenActive(ctx))) return undefined;
-		const skillPath = bundledSkillPath(baseDir);
+		const skillPath = await bundledSkillPath(baseDir);
 		return skillPath === undefined ? undefined : { skillPaths: [skillPath] };
 	});
 

--- a/packages/coding-agent/src/runtime-assets.d.ts
+++ b/packages/coding-agent/src/runtime-assets.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+	const path: string;
+	export default path;
+}


### PR DESCRIPTION
Embeds the imagegen bundled skill via a Bun file-asset import so Bun-compiled binaries stop losing it (previously: skill silently skipped with a missing-skill diagnostic). Node distributions keep using the copied dist asset — the Node path stays untouched.

## Scope note (rebased)
This PR originally also embedded the codemode kernel assets. That half is superseded by #1164 (sidecar resolution, merged) plus the omo-desktop-runtime build's codemode sidecar staging, so the codemode changes were dropped in the rebase; the earlier CI failure (17 py-kernel lifecycle tests) was caused by the async hop the embedding introduced before spawn and is gone with it.

## Verification
- `packages/senpi-codemode` py-kernel suites (the 17 formerly failing): 31/31 pass — codemode tree is byte-identical to main.
- imagegen tests (tool, auth-chain, skill-gating, arbitration regression): 63/63 pass.
- Node smoke: dynamic import of `imagegen/index.ts` OK under tsx.
- Pre-commit full gate (biome, tsc --noEmit, lock checks) green.
