### PR TITLE
fix(coding-agent): restore shared-host session resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### Fixed
 
+- Shared-host `/resume` now completes for sessions with blocked or paused Goals and refreshes the interactive proxy's
+  session identity, manager, history, and token context instead of timing out or returning to the empty bootstrap
+  composer with a stale `0/1M` footer.
+
 - Imagegen missing-skill diagnostics now go to stderr, keeping RPC NDJSON stdout clean when a compiled binary lacks the optional skill asset.
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/changes.md
@@ -1,5 +1,31 @@
 # goal Extension Changes
 
+## 2026-08-28 - RPC session resume does not deadlock on stopped-goal prompts
+
+### What changed
+
+- `index.ts` leaves paused or blocked Goals stopped during RPC `switch_session` rebinding instead of awaiting the
+  interactive restart prompt inside the in-flight RPC request. It emits an informational notification telling the
+  user to resume explicitly after the session finishes loading.
+- TUI resume behavior is unchanged: interactive sessions still offer `Resume goal` and `Leave stopped`.
+- Coverage in `test/suite/goal-extension.test.ts` pins that RPC resume does not call `ctx.ui.select`, reactivate the
+  Goal, or queue a continuation.
+
+### Why
+
+- The RPC client waits for the `switch_session` response before it can service the Goal extension's nested
+  `ctx.ui.select` request. The host awaited that selection before returning the switch response, so both sides waited
+  until the client timed out and exited without rendering the hidden error.
+
+### Why an extension couldn't do it
+
+- The stopped-goal restart prompt and its persisted status transition are private to the builtin Goal extension. An
+  external extension cannot bypass or reorder that handler during RPC session rebinding.
+
+### Expected merge conflict zones
+
+- LOW in `index.ts` around `maybePromptResumeStoppedGoal` and its mode-specific UI policy.
+
 ## 2026-08-27 - TUI widget rendering for goal tool results
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/index.ts
@@ -283,6 +283,16 @@ export default function goalExtension(pi: ExtensionAPI): void {
 		if (!isResumeOfStoppedGoal(ctx, sessionStartReason, goal)) {
 			return false;
 		}
+		// RPC switch_session cannot service a nested interactive UI request until the
+		// switch response completes. Keep the goal stopped and let the user resume it
+		// explicitly after the new session finishes binding.
+		if (ctx.mode === "rpc") {
+			ctx.ui.notify(
+				`Goal remains ${goal.status} after session resume. Resume it explicitly after the session finishes loading.`,
+				"info",
+			);
+			return true;
+		}
 
 		const choice = await ctx.ui.select(`Resume ${goal.status} goal?\nGoal: ${goal.objective}`, [
 			RESUME_GOAL_CHOICE,

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## Shared-host session replacement refreshes the interactive proxy (2026-08-28)
+
+### What changed
+
+- `interactive-host-runtime.ts` refreshes the shared host's state and messages after a successful `switch_session`,
+  then updates the interactive proxy's session manager, identity, cwd, and message history before rebinding the TUI.
+- `test/interactive-host-runtime.test.ts` switches to a second persisted session carrying a blocked Goal and pins
+  that the RPC request completes while the proxy exposes the target session file, ID, manager, and historical user
+  message.
+
+### Why
+
+- The shared RPC host changed its authoritative session, but the interactive proxy remained permanently bound to the
+  local bootstrap session. `/resume` therefore reported success while the TUI returned to an empty composer with the
+  old `0/1M` footer and no target history.
+
+### Why an extension could not handle it
+
+- The proxy owns transport state and the `AgentSessionRuntime` seam before extension events reach the TUI. Extensions
+  cannot replace the proxy's session identity, manager, or message mirror after an RPC session replacement.
+
+### Expected merge conflict zones
+
+- LOW in `interactive-host-runtime.ts` around remote session replacement and proxy property routing.
+
 ## Footer shows the active credential account (2026-08-27)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -1,6 +1,7 @@
 import type { AgentSession, AgentSessionEvent, AgentSessionEventListener } from "../../core/agent-session.ts";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.ts";
 import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.ts";
+import { SessionManager } from "../../core/session-manager.ts";
 import { type EnsuredHost, ensureHost } from "../rpc/host-ensure.ts";
 import { RpcClient, type RpcClientEvent } from "../rpc/rpc-client.ts";
 
@@ -58,25 +59,25 @@ export async function createInteractiveHostRuntime(
 
 class RemoteInteractiveRuntime {
 	readonly #local: AgentSessionRuntime;
-	readonly #session: AgentSession;
+	readonly #remoteSession: RemoteSessionProxy;
 	readonly #client: RpcClient;
 	#rebindSession: (() => Promise<void>) | undefined;
 	#beforeSessionInvalidate: (() => void) | undefined;
 
-	constructor(local: AgentSessionRuntime, session: AgentSession, client: RpcClient) {
+	constructor(local: AgentSessionRuntime, remoteSession: RemoteSessionProxy, client: RpcClient) {
 		this.#local = local;
-		this.#session = session;
+		this.#remoteSession = remoteSession;
 		this.#client = client;
 	}
 
 	get session(): AgentSession {
-		return this.#session;
+		return this.#remoteSession.session;
 	}
 	get services(): AgentSessionRuntime["services"] {
 		return this.#local.services;
 	}
 	get cwd(): string {
-		return this.#local.cwd;
+		return this.#remoteSession.session.sessionManager.getCwd();
 	}
 	get diagnostics(): readonly AgentSessionRuntimeDiagnostic[] {
 		return this.#local.diagnostics;
@@ -107,7 +108,7 @@ class RemoteInteractiveRuntime {
 	async switchSession(sessionPath: string): Promise<{ cancelled: boolean }> {
 		this.#beforeSessionInvalidate?.();
 		const result = await this.#client.switchSession(sessionPath);
-		if (!result.cancelled) await this.#rebindSession?.();
+		if (!result.cancelled) await this.#refreshAndRebind();
 		return result;
 	}
 	async fork(entryId: string): Promise<{ cancelled: boolean; selectedText?: string }> {
@@ -119,14 +120,25 @@ class RemoteInteractiveRuntime {
 	async importFromJsonl(): Promise<{ cancelled: boolean }> {
 		throw new Error("Session import is not available while connected to the shared host");
 	}
+
+	async #refreshAndRebind(): Promise<void> {
+		await this.#remoteSession.refresh();
+		await this.#rebindSession?.();
+	}
+}
+
+interface RemoteSessionProxy {
+	readonly session: AgentSession;
+	refresh(): Promise<void>;
 }
 
 function createRemoteSessionProxy(
 	local: AgentSession,
 	client: RpcClient,
 	initialState: ReturnType<typeof stateFromRpc>,
-): AgentSession {
+): RemoteSessionProxy {
 	let state = initialState;
+	let sessionManager = local.sessionManager;
 	let streamingAssistant: Extract<AgentSession["messages"][number], { role: "assistant" }> | undefined;
 	const listeners = new Set<AgentSessionEventListener>();
 	client.onEvent((wireEvent) => {
@@ -199,13 +211,29 @@ function createRemoteSessionProxy(
 			if (property === "isStreaming") return state.isStreaming;
 			if (property === "sessionFile") return state.sessionFile;
 			if (property === "sessionId") return state.sessionId;
+			if (property === "sessionManager") return sessionManager;
 			if (property === "messages") return target.messages;
 			if (property === "model") return state.model ?? target.model;
 			if (property === "thinkingLevel") return state.thinkingLevel;
 			return Reflect.get(target, property, receiver);
 		},
 	});
-	return session;
+	return {
+		session,
+		async refresh() {
+			const nextState = await client.getState();
+			state = stateFromRpc(nextState);
+			let messages: AgentSession["messages"];
+			if (nextState.sessionFile) {
+				sessionManager = SessionManager.open(nextState.sessionFile);
+				messages = sessionManager.buildSessionContext().messages;
+			} else {
+				messages = await client.getMessages();
+			}
+			local.agent.state.messages.splice(0, local.agent.state.messages.length, ...structuredClone(messages));
+			streamingAssistant = undefined;
+		},
+	};
 }
 
 function hydrateMessageUpdate(

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -2,6 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	type AgentSessionRuntime,
@@ -9,6 +10,7 @@ import {
 	createAgentSessionRuntime,
 	createAgentSessionServices,
 } from "../src/core/agent-session-runtime.ts";
+import { createGoal, updateGoal } from "../src/core/extensions/builtin/goal/store.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
 import {
@@ -201,6 +203,59 @@ describe("interactive host runtime", () => {
 			await runtime.session.prompt("local-fallback-unique");
 			await runtime.session.waitForIdle();
 			expect(runtime.session.getLastAssistantText()).toBeTruthy();
+		} finally {
+			await runtime.dispose();
+			await fake.close();
+		}
+	});
+
+	it("resumes stopped-goal history through the shared host and refreshes the local proxy", async () => {
+		const qa = scratch("switch-session");
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const host = spawnHost(qa);
+		await waitForHost(host, qa.socket);
+		const localSessionManager = SessionManager.create(qa.cwd, qa.sessionDir);
+		const local = await createAgentSessionRuntimeFixture({
+			cwd: qa.cwd,
+			agentDir: qa.agentDir,
+			sessionManager: localSessionManager,
+			settingsManager: SettingsManager.create(qa.cwd, qa.agentDir),
+		});
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => undefined,
+		});
+		const targetManager = SessionManager.create(qa.cwd, qa.sessionDir);
+		const targetPath = targetManager.getSessionFile();
+		if (!targetPath) throw new Error("Expected persisted target session path");
+		targetManager.appendMessage({ role: "user", content: "target-history", timestamp: 1 });
+		targetManager.appendMessage(fauxAssistantMessage("target-response"));
+		const goalRef = {
+			baseDir: join(targetManager.getSessionDir(), "extensions", "goal"),
+			threadId: targetManager.getSessionId(),
+		};
+		await createGoal(goalRef, "Keep the target goal stopped");
+		await updateGoal(goalRef, { status: "blocked", reason: "user interrupted the turn" });
+		expect(targetManager.buildSessionContext().messages).toContainEqual({
+			role: "user",
+			content: "target-history",
+			timestamp: 1,
+		});
+		const initialSessionId = runtime.session.sessionId;
+
+		try {
+			await runtime.switchSession(targetPath);
+
+			expect(runtime.session.sessionFile).toBe(targetPath);
+			expect(runtime.session.sessionId).not.toBe(initialSessionId);
+			expect(runtime.session.sessionManager.getSessionFile()).toBe(targetPath);
+			expect(runtime.session.sessionManager.buildSessionContext().messages).toContainEqual({
+				role: "user",
+				content: "target-history",
+				timestamp: 1,
+			});
+			expect(runtime.session.messages).toContainEqual({ role: "user", content: "target-history", timestamp: 1 });
 		} finally {
 			await runtime.dispose();
 			await fake.close();

--- a/packages/coding-agent/test/suite/goal-extension.test.ts
+++ b/packages/coding-agent/test/suite/goal-extension.test.ts
@@ -786,6 +786,23 @@ describe("goal extension resume-on-restart prompt (codex parity)", () => {
 		expect(sent).toHaveLength(0);
 	});
 
+	it("does not block an RPC session switch on the stopped-goal resume prompt", async () => {
+		const { tools, handlers, sent } = createGoalHarness();
+		const prompts: string[] = [];
+		const selectingCtx = await makeSelectingCtx(prompts, (options) => options[0], "thread-blocked-rpc-resume");
+		const ctx = { ...selectingCtx, mode: "rpc" } as ExtensionContext;
+		await tools.get("create_goal")?.execute("c1", { objective: "Finish the migration" }, undefined, undefined, ctx);
+		await tools
+			.get("update_goal")
+			?.execute("u1", { status: "blocked", reason: "provider error" }, undefined, undefined, ctx);
+
+		await runHandlers(handlers, "session_start", { type: "session_start", reason: "resume" }, ctx);
+
+		expect(prompts).toHaveLength(0);
+		expect((await readGoal(storeRefFor(ctx)))?.status).toBe("blocked");
+		expect(sent).toHaveLength(0);
+	});
+
 	it("never prompts for a completed goal on resume", async () => {
 		const { tools, handlers } = createGoalHarness();
 		const prompts: string[] = [];


### PR DESCRIPTION
## Summary

- avoid awaiting the stopped-goal restart dialog inside an in-flight RPC `switch_session`; RPC resumes keep the goal stopped and notify the user to resume explicitly after loading
- refresh the interactive shared-host proxy state, session manager, cwd, and historical messages before rebinding the TUI after a successful session switch

## Reproduction

1. Start an interactive session with the default shared host.
2. Run `/resume` and select a persisted session containing a blocked goal and history.
3. The host either deadlocks on the nested goal prompt until the client times out, or reports success while the TUI remains on the bootstrap session with an empty composer and `0/1M` footer.

The added integration test drives a real shared RPC host, switches to a persisted stopped-goal session, and verifies the target path, identity, manager, and history are visible through the interactive proxy.

## Verification

- `npm run check`
- `npm test` (all workspaces; coding-agent 8,966 passed / 37 skipped)
- focused Goal + interactive-host tests: 50 passed
- senpi-qa RPC: 4/4
- senpi-qa TUI smoke: 5/5
- senpi-qa mock loop: 48/48

No provider credentials or paid model calls were used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shared-host session resume so `/resume` into a session with a blocked goal no longer deadlocks or leaves the TUI bound to the old session.

**Bug Fixes**

- RPC session switches no longer await the stopped-goal restart prompt inside the in-flight request; the goal stays stopped and the user is notified to resume explicitly after loading.
- The interactive proxy now refreshes the remote session state and message history before rebinding the TUI, so the target session file, ID, manager, cwd, and messages are shown instead of the stale bootstrap session.
- Interactive TUI resume behavior is unchanged; it still offers `Resume goal` and `Leave stopped`.

<sup>Written for commit 46fdb95b63779e4f7875860ee56acb4ead197e62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

