### PR TITLE
fix(coding-agent): repair shared interactive host session regressions (beta.23 hotfix)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ### Fixed
 
+- Shared interactive host sessions no longer print `Thinking level: [object Promise]` on Shift+Tab: the TUI awaits the four session reads the shared-host proxy answers over RPC (`cycleThinkingLevel`, `getAvailableThinkingLevels`, `getSessionStats`, `getUserMessagesForForking`), the thinking-level status and footer render from the `thinking_level_changed` event so every attached client converges, and `/settings` thinking options, `/fork`, and `/session` work again.
+- User messages no longer render twice in shared-host sessions: the RPC prompt success response now carries `data.disposition` (`started`/`queued`/`handled`), delivered through client response hooks that run synchronously inside frame dispatch, so optimistic user echoes resolve exactly like the local path; `streamingBehavior` and `thinkingLevel` are forwarded again, so mid-stream submissions queue instead of failing.
+- Resuming a session that a live shared host already holds no longer fails with `session_path_in_use`: `open_session` on a fully-open path now attaches to the existing session (same handle, `attached: true`), and the runtime is torn down only when the last attachment closes.
+- Fire-and-forget session setters proxied to the shared host (thinking level, steering/follow-up mode, auto-compaction, session name, bash abort) now surface RPC failures through a typed warning instead of vanishing silently.
+
 - Imagegen missing-skill diagnostics now go to stderr, keeping RPC NDJSON stdout clean when a compiled binary lacks the optional skill asset.
 
 ### Removed

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -100,7 +100,7 @@ hosts) sees neither variable and is unaffected. A host whose supervisor is alive
 | Command | Params | Success data | Notes |
 | --- | --- | --- | --- |
 | `get_protocol_info` | - | `{ protocolVersion: 1, serverVersion: string, capabilities: string[], mode: "classic"\|"multi" }` | Answered in BOTH modes; side-effect-free; the capability probe. Multi-session hosts include `multi_session` plus the negotiated launch capabilities. |
-| `open_session` | `sessionPath?`, `cwd?`, `provider?`, `modelId?`, `thinkingLevel?`, `permissionPreset?` (all optional; paths MUST be absolute) | `{ sessionId, state: RpcSessionState }` | `sessionPath` = today's `--session` semantics (open-if-exists else create persisting there, `session-manager.ts:926-940`); `provider`/`modelId` applied only on create (resume restores the session's model — mirrors `SenpiSessionRuntime.ts:198-200`); params form the immutable launch profile (D8). |
+| `open_session` | `sessionPath?`, `cwd?`, `provider?`, `modelId?`, `thinkingLevel?`, `permissionPreset?` (all optional; paths MUST be absolute) | `{ sessionId, state: RpcSessionState, attached?: true }` | `sessionPath` = today's `--session` semantics (open-if-exists else create persisting there, `session-manager.ts:926-940`); `provider`/`modelId` applied only on create (resume restores the session's model — mirrors `SenpiSessionRuntime.ts:198-200`); params form the immutable launch profile (D8). When the path is already held by a fully-open session, the open ATTACHES to it: same routing handle, `attached: true`, one more attachment counted; the runtime is torn down only when the last attachment closes. |
 | `close_session` | `sessionId` | `{}` | Aborts active work, awaits agent idle + settled persistence, flushes queued events, detaches subscriptions; its response is the LAST record tagged with that handle — no events after (test-pinned). |
 | `list_sessions` | - | `{ sessions: [{ sessionId, durableSessionId, sessionPath, cwd, name, status }] }` | Includes `opening`/`closing` entries with their status. |
 | every existing command | + `sessionId` (REQUIRED in multi mode) | unchanged | Routed to that session. |
@@ -115,7 +115,7 @@ In the response `error` field, machine-matchable:
 
 - `unknown_session`
 - `session_closing`
-- `session_path_in_use`
+- `session_path_in_use` (path held by a session still `opening` or already `closing`; a fully-open session is attached instead)
 - `missing_session_id` (session-scoped command without `sessionId` in multi mode)
 - `multi_session_disabled` (`open_session` in classic mode)
 - `invalid_path` (relative `sessionPath`/`cwd`)
@@ -131,7 +131,7 @@ Strict FIFO per session; one total stdout order; cross-session order unspecified
 
 ### Duplicate/idempotency
 
-Duplicate `open_session` while a path reservation is held → `session_path_in_use`. `close_session` on unknown/already-closed → `unknown_session` error. Request `id`s are client-owned; the server echoes them without dedup.
+Duplicate `open_session` while a path reservation is held by a fully-open session → ATTACH (`attached: true`, same handle); while held by an `opening`/`closing` entry → `session_path_in_use`. `close_session` releases one attachment; the runtime is disposed only when the last attachment closes. `close_session` on unknown/already-closed → `unknown_session` error. Request `id`s are client-owned; the server echoes them without dedup.
 
 ## Protocol Overview
 
@@ -197,8 +197,10 @@ sending/queueing. Bare inline dollar text remains literal.
 
 Response:
 ```json
-{"id": "req-1", "type": "response", "command": "prompt", "success": true}
+{"id": "req-1", "type": "response", "command": "prompt", "success": true, "data": { "disposition": "started" }}
 ```
+
+The prompt success response carries `data.disposition` (`"started"` | `"queued"` | `"handled"`), captured from the host session's own disposition callback so proxied clients can resolve optimistic-echo contracts exactly like the local path. Older hosts omit `data`; clients must then degrade to canonical-only rendering (treat the echo as rejected). The response is emitted before the user `message_start` event on the same connection, and disposition callbacks registered through the client run synchronously inside response-frame dispatch — never through the resolved promise's microtask.
 
 `success: true` means the prompt was accepted, queued, or handled immediately. `success: false` means the prompt was rejected before acceptance. Failures after acceptance are reported through the normal event and message stream, not as a second `response` for the same request id.
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## Shared-host sessions await async session reads and render thinking level from the event (2026-08-28)
+
+### What changed
+
+- `interactive-host-runtime.ts`: new `InteractiveSession` type — the TUI-facing session contract that widens `cycleThinkingLevel`, `getAvailableThinkingLevels`, `getSessionStats`, and `getUserMessagesForForking` to `T | Promise<T>` so the shared-host proxy is honestly typed. The proxy's `prompt` now forwards `streamingBehavior`, `thinkingLevel`, and the optimistic-echo `promptDisposition`/`preflightResult` callbacks across the wire, and fire-and-forget setters report RPC failures through a new `interactive_host_action_failed` warning instead of swallowing them.
+- `interactive-mode.ts`: the Shift+Tab handler awaits the cycle and only renders the unsupported-model branch; the level status/footer render from the `thinking_level_changed` event (single path for local, remote, and other attached clients). `/settings` thinking levels, `/fork` message list, and `/session` stats await their reads. No more `Thinking level: [object Promise]`.
+- `components/footer.ts`, `grok/chrome.ts`, `grok/footer.ts`: session parameters accept `InteractiveSession`.
+
+### Why
+
+- Since the shared RPC host became the default for interactive sessions, the proxy answered these four reads with Promises while the TUI consumed them synchronously: Shift+Tab printed `[object Promise]`, the settings selector lost low/med/high options, and `/fork` + `/session` broke. Event-driven level rendering also fixes multi-client convergence (desktop + terminal on one host session).
+
+### Why an extension could not handle it
+
+- The session contract and key-dispatch handlers are core interactive wiring; extensions cannot retype or resequence them.
+
+### Expected merge conflict zones
+
+- MEDIUM: `interactive-mode.ts` handler/event-case edits and the session getter type.
+- LOW: proxy setter overrides in `interactive-host-runtime.ts`.
+
 ## Footer shows the active credential account (2026-08-27)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -4,7 +4,7 @@ import type { Credential } from "@earendil-works/pi-ai";
 import { rendezvousOrder } from "@earendil-works/pi-ai/auth/pool/select";
 import { listSlots } from "@earendil-works/pi-ai/auth/pool/slots";
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import type { AgentSession } from "../../../core/agent-session.ts";
+import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
 import { theme } from "../theme/theme.ts";
 import { type FooterSegment, planFooterLayout } from "./footer-layout.ts";
@@ -96,16 +96,16 @@ function colorRightSide(text: string): string {
  * Computes token/context stats from session, gets git branch and extension statuses from provider.
  */
 export class FooterComponent implements Component {
-	private session: AgentSession;
+	private session: InteractiveSession;
 	private footerData: ReadonlyFooterDataProvider;
 	private autoCompactEnabled = true;
 
-	constructor(session: AgentSession, footerData: ReadonlyFooterDataProvider) {
+	constructor(session: InteractiveSession, footerData: ReadonlyFooterDataProvider) {
 		this.session = session;
 		this.footerData = footerData;
 	}
 
-	setSession(session: AgentSession): void {
+	setSession(session: InteractiveSession): void {
 		this.session = session;
 	}
 

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -4,8 +4,8 @@ import type { Credential } from "@earendil-works/pi-ai";
 import { rendezvousOrder } from "@earendil-works/pi-ai/auth/pool/select";
 import { listSlots } from "@earendil-works/pi-ai/auth/pool/slots";
 import { type Component, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
+import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import { theme } from "../theme/theme.ts";
 import { type FooterSegment, planFooterLayout } from "./footer-layout.ts";
 

--- a/packages/coding-agent/src/modes/interactive/grok/chrome.ts
+++ b/packages/coding-agent/src/modes/interactive/grok/chrome.ts
@@ -1,5 +1,5 @@
 import type { Component, EditorOptions, EditorTheme, TUI } from "@earendil-works/pi-tui";
-import type { AgentSession } from "../../../core/agent-session.ts";
+import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import type { WorkingIndicatorOptions } from "../../../core/extensions/index.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
 import type { KeybindingsManager } from "../../../core/keybindings.ts";
@@ -14,7 +14,7 @@ import { GROK_GLYPHS } from "./palette.ts";
 import { GrokWelcomeCard } from "./welcome-card.ts";
 
 export interface InteractiveFooter extends Component {
-	setSession(session: AgentSession): void;
+	setSession(session: InteractiveSession): void;
 	setAutoCompactEnabled(enabled: boolean): void;
 	invalidate(): void;
 	dispose(): void;
@@ -33,7 +33,7 @@ export interface InteractiveChrome {
 	readonly toolPresentation: ToolExecutionPresentation;
 	createBaseEditor(context: { ui: TUI; keybindings: KeybindingsManager; editorOptions: EditorOptions }): CustomEditor;
 	getEditorTheme(): EditorTheme;
-	createFooter(session: AgentSession, footerData: ReadonlyFooterDataProvider): InteractiveFooter;
+	createFooter(session: InteractiveSession, footerData: ReadonlyFooterDataProvider): InteractiveFooter;
 	createWelcomeContent(appName: string, version: string): Component;
 	createWorkingIndicator(ui: TUI, message: string, indicator?: WorkingIndicatorOptions): WorkingStatusIndicator;
 	getEditorBorderColor(context: EditorBorderContext): (text: string) => string;
@@ -133,7 +133,7 @@ export class GrokChrome implements InteractiveChrome {
 		};
 	}
 
-	createFooter(session: AgentSession, footerData: ReadonlyFooterDataProvider): InteractiveFooter {
+	createFooter(session: InteractiveSession, footerData: ReadonlyFooterDataProvider): InteractiveFooter {
 		return new GrokFooter(session, footerData);
 	}
 

--- a/packages/coding-agent/src/modes/interactive/grok/chrome.ts
+++ b/packages/coding-agent/src/modes/interactive/grok/chrome.ts
@@ -1,11 +1,11 @@
 import type { Component, EditorOptions, EditorTheme, TUI } from "@earendil-works/pi-tui";
-import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import type { WorkingIndicatorOptions } from "../../../core/extensions/index.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
 import type { KeybindingsManager } from "../../../core/keybindings.ts";
 import { CustomEditor } from "../components/custom-editor.ts";
 import { WorkingStatusIndicator } from "../components/status-indicator.ts";
 import type { ToolExecutionPresentation } from "../components/tool-execution.ts";
+import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import { theme } from "../theme/theme.ts";
 import { getGrokChromeTokens } from "./chrome-tokens.ts";
 import { GrokFooter } from "./footer.ts";

--- a/packages/coding-agent/src/modes/interactive/grok/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/grok/footer.ts
@@ -1,6 +1,6 @@
 import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
-import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
+import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import { getGrokChromeTokens } from "./chrome-tokens.ts";
 
 /** Compact status footer for grok chrome. */

--- a/packages/coding-agent/src/modes/interactive/grok/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/grok/footer.ts
@@ -1,17 +1,17 @@
 import { type Component, truncateToWidth } from "@earendil-works/pi-tui";
-import type { AgentSession } from "../../../core/agent-session.ts";
+import type { InteractiveSession } from "../interactive-host-runtime.ts";
 import type { ReadonlyFooterDataProvider } from "../../../core/footer-data-provider.ts";
 import { getGrokChromeTokens } from "./chrome-tokens.ts";
 
 /** Compact status footer for grok chrome. */
 export class GrokFooter implements Component {
-	private session: AgentSession;
+	private session: InteractiveSession;
 
-	constructor(session: AgentSession, _footerData: ReadonlyFooterDataProvider) {
+	constructor(session: InteractiveSession, _footerData: ReadonlyFooterDataProvider) {
 		this.session = session;
 	}
 
-	setSession(session: AgentSession): void {
+	setSession(session: InteractiveSession): void {
 		this.session = session;
 	}
 

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -237,6 +237,17 @@ function createRemoteSessionProxy(
 					};
 				};
 			if (property === "isStreaming") return state.isStreaming;
+			// The footer and other renderers read session.state.*; surface the
+			// host-authoritative fields there too, not only via the direct getters.
+			if (property === "state") {
+				const localState = target.state;
+				return {
+					...localState,
+					model: state.model ?? localState.model,
+					thinkingLevel: state.thinkingLevel,
+					isStreaming: state.isStreaming,
+				};
+			}
 			if (property === "sessionFile") return state.sessionFile;
 			if (property === "sessionId") return state.sessionId;
 			if (property === "messages") return target.messages;

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -26,8 +26,12 @@ export type InteractiveSession = Omit<
 > & {
 	cycleThinkingLevel(): ThinkingLevel | undefined | Promise<ThinkingLevel | undefined>;
 	getAvailableThinkingLevels(): ThinkingLevel[] | Promise<ThinkingLevel[]>;
-	getSessionStats(): ReturnType<AgentSession["getSessionStats"]> | Promise<ReturnType<AgentSession["getSessionStats"]>>;
-	getUserMessagesForForking(): ReturnType<AgentSession["getUserMessagesForForking"]> | Promise<ReturnType<AgentSession["getUserMessagesForForking"]>>;
+	getSessionStats():
+		| ReturnType<AgentSession["getSessionStats"]>
+		| Promise<ReturnType<AgentSession["getSessionStats"]>>;
+	getUserMessagesForForking():
+		| ReturnType<AgentSession["getUserMessagesForForking"]>
+		| Promise<ReturnType<AgentSession["getUserMessagesForForking"]>>;
 };
 
 export interface InteractiveHostRuntimeOptions {

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -1,3 +1,4 @@
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { AgentSession, AgentSessionEvent, AgentSessionEventListener } from "../../core/agent-session.ts";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.ts";
 import type { AgentSessionRuntimeDiagnostic } from "../../core/agent-session-services.ts";
@@ -7,10 +8,27 @@ import { RpcClient, type RpcClientEvent } from "../rpc/rpc-client.ts";
 export const INTERACTIVE_HOST_FALLBACK_WARNING = "Warning: shared interactive host unavailable; continuing locally";
 
 export interface InteractiveHostWarning {
-	readonly type: "interactive_host_fallback";
+	readonly type: "interactive_host_fallback" | "interactive_host_action_failed";
 	readonly message: string;
 	readonly cause: unknown;
 }
+
+/**
+ * The session contract InteractiveMode actually runs against. The local
+ * AgentSession answers these reads synchronously; the shared-host proxy answers
+ * them over RPC. Declaring the union here keeps the proxy honest (no more
+ * `as unknown as` lie at the boundary) and lets the compiler find every TUI
+ * call site that must await.
+ */
+export type InteractiveSession = Omit<
+	AgentSession,
+	"cycleThinkingLevel" | "getAvailableThinkingLevels" | "getSessionStats" | "getUserMessagesForForking"
+> & {
+	cycleThinkingLevel(): ThinkingLevel | undefined | Promise<ThinkingLevel | undefined>;
+	getAvailableThinkingLevels(): ThinkingLevel[] | Promise<ThinkingLevel[]>;
+	getSessionStats(): ReturnType<AgentSession["getSessionStats"]> | Promise<ReturnType<AgentSession["getSessionStats"]>>;
+	getUserMessagesForForking(): ReturnType<AgentSession["getUserMessagesForForking"]> | Promise<ReturnType<AgentSession["getUserMessagesForForking"]>>;
+};
 
 export interface InteractiveHostRuntimeOptions {
 	readonly socket: string;
@@ -43,7 +61,7 @@ export async function createInteractiveHostRuntime(
 			modelId: localRuntime.session.model?.id,
 			thinkingLevel: localRuntime.session.thinkingLevel,
 		});
-		const remoteSession = createRemoteSessionProxy(localRuntime.session, client, opened.state);
+		const remoteSession = createRemoteSessionProxy(localRuntime.session, client, opened.state, options.onWarning);
 		return new RemoteInteractiveRuntime(localRuntime, remoteSession, client) as unknown as AgentSessionRuntime;
 	} catch (cause) {
 		await client.stop().catch(() => {});
@@ -125,7 +143,18 @@ function createRemoteSessionProxy(
 	local: AgentSession,
 	client: RpcClient,
 	initialState: ReturnType<typeof stateFromRpc>,
+	onWarning?: (warning: InteractiveHostWarning) => void,
 ): AgentSession {
+	// Fire-and-forget setters keep the sync AgentSession signature, but their RPC
+	// failures must not vanish: the matching *_changed wire event confirms success,
+	// and a rejection here is the only signal of failure.
+	const reportActionFailure = (action: string) => (error: unknown) => {
+		onWarning?.({
+			type: "interactive_host_action_failed",
+			message: `Warning: shared interactive host ${action} failed: ${error instanceof Error ? error.message : String(error)}`,
+			cause: error,
+		});
+	};
 	let state = initialState;
 	let streamingAssistant: Extract<AgentSession["messages"][number], { role: "assistant" }> | undefined;
 	const listeners = new Set<AgentSessionEventListener>();
@@ -154,7 +183,13 @@ function createRemoteSessionProxy(
 		get(target, property, receiver) {
 			if (property === "prompt")
 				return (message: string, options?: Parameters<AgentSession["prompt"]>[1]) =>
-					client.prompt(message, options?.images);
+					client.prompt(message, {
+						...(options?.images ? { images: options.images } : {}),
+						...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior } : {}),
+						...(options?.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
+						...(options?.promptDisposition ? { promptDisposition: options.promptDisposition } : {}),
+						...(options?.preflightResult ? { preflightResult: options.preflightResult } : {}),
+					});
 			if (property === "abort") return () => client.abort();
 			if (property === "steer")
 				return (message: string, images?: Parameters<AgentSession["steer"]>[1]) => client.steer(message, images);
@@ -169,23 +204,28 @@ function createRemoteSessionProxy(
 				};
 			if (property === "cycleModel") return () => client.cycleModel();
 			if (property === "setThinkingLevel")
-				return (level: AgentSession["thinkingLevel"]) => void client.setThinkingLevel(level);
+				return (level: AgentSession["thinkingLevel"]) =>
+					void client.setThinkingLevel(level).catch(reportActionFailure("setThinkingLevel"));
 			if (property === "cycleThinkingLevel")
 				return () => client.cycleThinkingLevel().then((result) => result?.level);
 			if (property === "getAvailableThinkingLevels") return () => client.getAvailableThinkingLevels();
 			if (property === "setSteeringMode")
-				return (mode: AgentSession["steeringMode"]) => void client.setSteeringMode(mode);
+				return (mode: AgentSession["steeringMode"]) =>
+					void client.setSteeringMode(mode).catch(reportActionFailure("setSteeringMode"));
 			if (property === "setFollowUpMode")
-				return (mode: AgentSession["followUpMode"]) => void client.setFollowUpMode(mode);
+				return (mode: AgentSession["followUpMode"]) =>
+					void client.setFollowUpMode(mode).catch(reportActionFailure("setFollowUpMode"));
 			if (property === "compact") return (instructions?: string) => client.compact(instructions);
 			if (property === "setAutoCompactionEnabled")
-				return (enabled: boolean) => void client.setAutoCompaction(enabled);
+				return (enabled: boolean) =>
+					void client.setAutoCompaction(enabled).catch(reportActionFailure("setAutoCompaction"));
 			if (property === "executeBash") return (command: string) => client.bash(command);
-			if (property === "abortBash") return () => void client.abortBash();
+			if (property === "abortBash") return () => void client.abortBash().catch(reportActionFailure("abortBash"));
 			if (property === "getSessionStats") return () => client.getSessionStats();
 			if (property === "exportToHtml")
 				return (outputPath?: string) => client.exportHtml(outputPath).then((result) => result.path);
-			if (property === "setSessionName") return (name: string) => void client.setSessionName(name);
+			if (property === "setSessionName")
+				return (name: string) => void client.setSessionName(name).catch(reportActionFailure("setSessionName"));
 			if (property === "getUserMessagesForForking") return () => client.getForkMessages();
 			if (property === "subscribe")
 				return (listener: AgentSessionEventListener) => {

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -62,9 +62,8 @@ import {
 	getShareViewerUrl,
 	VERSION,
 } from "../../config.ts";
-import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
+import { type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
-import type { InteractiveSession } from "./interactive-host-runtime.ts";
 import { isApiKeyLoginProvider } from "../../core/auth-providers.ts";
 import { envValue } from "../../core/brand.ts";
 import {
@@ -197,6 +196,7 @@ import { expandEditorSubmission, expandSubmittedText, transferEditorContent } fr
 import { formatExtensionErrorHeadline, sanitizeTuiErrorMessage } from "./extension-error-format.ts";
 import { editFileInExternalEditor, editInExternalEditor } from "./external-editor.ts";
 import { GrokChrome, type InteractiveChrome, type InteractiveFooter } from "./grok/chrome.ts";
+import type { InteractiveSession } from "./interactive-host-runtime.ts";
 import { restoreInteractiveStderr, takeOverInteractiveStderr } from "./interactive-stderr-guard.ts";
 import { applyKeybindingsFileEdit, seedKeybindingsFile } from "./keybindings-command.ts";
 import { refreshModelCatalogs } from "./model-catalog-refresh.ts";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -64,6 +64,7 @@ import {
 } from "../../config.ts";
 import { type AgentSession, type AgentSessionEvent, parseSkillBlock } from "../../core/agent-session.ts";
 import { type AgentSessionRuntime, SessionImportFileNotFoundError } from "../../core/agent-session-runtime.ts";
+import type { InteractiveSession } from "./interactive-host-runtime.ts";
 import { isApiKeyLoginProvider } from "../../core/auth-providers.ts";
 import { envValue } from "../../core/brand.ts";
 import {
@@ -956,7 +957,9 @@ export class InteractiveMode {
 	private themeController: InteractiveThemeController;
 
 	// Convenience accessors
-	private get session(): AgentSession {
+	// The session may be the local AgentSession or the shared-host RPC proxy; the
+	// four reads widened on InteractiveSession must be awaited at every call site.
+	private get session(): InteractiveSession {
 		return this.runtimeHost.session;
 	}
 	private get sessionManager() {
@@ -4326,6 +4329,7 @@ export class InteractiveMode {
 			case "thinking_level_changed":
 				this.footer.invalidate();
 				this.updateEditorBorderColor();
+				this.showStatus(`Thinking level: ${event.level}`);
 				break;
 
 			case "high_reasoning_warning":
@@ -5751,14 +5755,14 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	private cycleThinkingLevel(): void {
-		const newLevel = this.session.cycleThinkingLevel();
+	private async cycleThinkingLevel(): Promise<void> {
+		// The shared-host proxy answers this over RPC. The level itself is rendered
+		// from the thinking_level_changed event (single path for local and remote,
+		// and for changes made by OTHER attached clients); the awaited value only
+		// distinguishes "model does not support thinking".
+		const newLevel = await this.session.cycleThinkingLevel();
 		if (newLevel === undefined) {
 			this.showStatus("Current model does not support thinking");
-		} else {
-			this.footer.invalidate();
-			this.updateEditorBorderColor();
-			this.showStatus(`Thinking level: ${newLevel}`);
 		}
 	}
 
@@ -6308,7 +6312,9 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	private showSettingsSelector(): void {
+	private async showSettingsSelector(): Promise<void> {
+		// Awaited at the boundary: the shared-host proxy answers this over RPC.
+		const availableThinkingLevels = await this.session.getAvailableThinkingLevels();
 		this.showSelector((done) => {
 			let selector: SettingsSelectorComponent | undefined;
 			selector = new SettingsSelectorComponent(
@@ -6324,7 +6330,7 @@ export class InteractiveMode {
 					transport: this.settingsManager.getTransport(),
 					httpIdleTimeoutMs: this.settingsManager.getHttpIdleTimeoutMs(),
 					thinkingLevel: this.session.thinkingLevel,
-					availableThinkingLevels: this.session.getAvailableThinkingLevels(),
+					availableThinkingLevels,
 					currentTheme: this.themeController.getThemeSelection() || "dark",
 					terminalTheme: this.themeController.getTerminalTheme(),
 					availableThemes: getAvailableThemes(),
@@ -6977,8 +6983,9 @@ export class InteractiveMode {
 		});
 	}
 
-	private showUserMessageSelector(): void {
-		const userMessages = this.session.getUserMessagesForForking();
+	private async showUserMessageSelector(): Promise<void> {
+		// Awaited at the boundary: the shared-host proxy answers this over RPC.
+		const userMessages = await this.session.getUserMessagesForForking();
 
 		if (userMessages.length === 0) {
 			this.showStatus("No messages to fork from");
@@ -8133,8 +8140,9 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	private handleSessionCommand(): void {
-		const stats = this.session.getSessionStats();
+	private async handleSessionCommand(): Promise<void> {
+		// Awaited at the boundary: the shared-host proxy answers this over RPC.
+		const stats = await this.session.getSessionStats();
 		const sessionName = this.sessionManager.getSessionName();
 		const entries = this.sessionManager.getEntries();
 		const cacheWaste = computeCacheWaste(entries, this.session.modelRuntime);

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## Prompt disposition rides the wire and sessions attach by path (2026-08-28)
+
+### What changed
+
+- `connection-handler.ts`: the `prompt` success response now carries `data.disposition` (`started`/`queued`/`handled`), captured from the host session's own `promptDisposition` callback, which always fires strictly before `preflightResult(true)`.
+- `rpc-types.ts`: the prompt success response gains the additive optional `data.disposition` field; older hosts omit it and clients degrade to canonical-only rendering.
+- `rpc-client.ts`: pending requests accept `onResponse`/`onReject` hooks that run synchronously inside frame dispatch (before the next frame), so ordering-sensitive contracts never route through a resolved promise's microtask. `prompt()` takes an options object (`images`, `streamingBehavior`, `thinkingLevel`, `promptDisposition`, `preflightResult`); a success response without a disposition maps to `"handled"`, and transport rejection/timeout reports `preflightResult(false)`.
+- `session-registry.ts`: `openSession` with a path reserved by a live, fully-open session now ATTACHES (same handle, `attached: true`, attachment count incremented) instead of throwing `session_path_in_use`. Entries still opening or closing keep the exclusive reservation. `beginClose` releases one attachment and only transitions to `closing` when the last one closes.
+- `session-command-router.ts`: close paths finalize the runtime teardown only when the entry actually transitioned to `closing`; `open_session` responses include `attached: true` on attach.
+
+### Why
+
+- Interactive sessions run through the shared host by default; the proxy's dropped disposition callbacks left optimistic user echoes permanently ineligible, so every canonical user message rendered twice. The attach semantics make resume of a host-held session possible at all — previously any live attachment (desktop app, second terminal) made `open_session` throw by construction.
+
+### Why an extension could not handle it
+
+- Wire framing, response dispatch order, and the process-local session registry are core RPC contracts established before extensions load.
+
+### Expected merge conflict zones
+
+- MEDIUM: `session-registry.ts` openSession/beginClose attachment semantics.
+- LOW: `connection-handler.ts` prompt case, `rpc-client.ts` prompt options, `rpc-types.ts` additive response field.
+
 ## Provider-neutral account RPC commands (2026-08-27)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -19,7 +19,7 @@ import * as crypto from "node:crypto";
 import { basename, dirname, extname } from "node:path";
 import type { OAuthProviderId } from "@earendil-works/pi-ai/compat";
 import { VERSION } from "../../config.ts";
-import type { AgentSession } from "../../core/agent-session.ts";
+import type { AgentSession, PromptDisposition } from "../../core/agent-session.ts";
 import type { AgentSessionRuntime } from "../../core/agent-session-runtime.ts";
 import { buildLoginProviderInfos } from "../../core/auth-providers.ts";
 import {
@@ -757,17 +757,23 @@ export function createRpcConnectionHandler(
 				}
 				// Start prompt handling immediately, but emit the authoritative response only after
 				// prompt preflight succeeds. Queued and immediately handled prompts also count as success.
+				// The disposition is captured for the wire: AgentSession always fires promptDisposition
+				// strictly before preflightResult(true), so the success frame carries the final value.
 				let preflightSucceeded = false;
+				let disposition: PromptDisposition | undefined;
 				void session
 					.prompt(command.message, {
 						images: command.images,
 						streamingBehavior: command.streamingBehavior,
 						thinkingLevel: command.thinkingLevel,
 						source: "rpc",
+						promptDisposition: (nextDisposition) => {
+							disposition = nextDisposition;
+						},
 						preflightResult: (didSucceed) => {
 							if (didSucceed && !preflightSucceeded) {
 								preflightSucceeded = true;
-								output(success(id, "prompt"));
+								output(success(id, "prompt", { ...(disposition !== undefined ? { disposition } : {}) }));
 							}
 						},
 					})

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -8,7 +8,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { createConnection, type Socket } from "node:net";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent } from "@earendil-works/pi-ai";
-import type { SessionStats } from "../../core/agent-session.ts";
+import type { PromptDisposition, SessionStats } from "../../core/agent-session.ts";
 import type { BashResult } from "../../core/bash-executor.ts";
 import type { CompactionResult } from "../../core/compaction/index.ts";
 import type { ServiceTier } from "../../core/extensions/builtin/service-tier.ts";
@@ -78,8 +78,15 @@ export class RpcClient {
 	private socket: Socket | null = null;
 	private stopReadingStdout: (() => void) | null = null;
 	private eventListeners: RpcEventListener[] = [];
-	private pendingRequests: Map<string, { resolve: (response: RpcResponse) => void; reject: (error: Error) => void }> =
-		new Map();
+	private pendingRequests: Map<
+		string,
+		{
+			resolve: (response: RpcResponse) => void;
+			reject: (error: Error) => void;
+			onResponse?: (response: RpcResponse) => void;
+			onReject?: (error: Error) => void;
+		}
+	> = new Map();
 	private requestId = 0;
 	private sessionId: string | undefined;
 	private stderr = "";
@@ -265,9 +272,9 @@ export class RpcClient {
 		modelId?: string;
 		thinkingLevel?: ThinkingLevel;
 		permissionPreset?: string;
-	}): Promise<{ sessionId: string; state: RpcSessionState }> {
+	}): Promise<{ sessionId: string; state: RpcSessionState; attached?: boolean }> {
 		const response = await this.send({ type: "open_session", ...options }, false);
-		const opened = this.getData<{ sessionId: string; state: RpcSessionState }>(response);
+		const opened = this.getData<{ sessionId: string; state: RpcSessionState; attached?: boolean }>(response);
 		this.sessionId = opened.sessionId;
 		return opened;
 	}
@@ -305,9 +312,50 @@ export class RpcClient {
 	 * Send a prompt to the agent.
 	 * Returns immediately after sending; use onEvent() to receive streaming events.
 	 * Use waitForIdle() to wait for completion.
+	 *
+	 * The disposition/preflight callbacks mirror AgentSession's local prompt contract:
+	 * they fire synchronously while the response frame is dispatched — before any
+	 * queued message_start event — so optimistic-echo eligibility is settled in wire
+	 * order. A success response without a disposition (older host) maps to "handled"
+	 * so the echo degrades to canonical-only rendering instead of double-rendering.
 	 */
-	async prompt(message: string, images?: ImageContent[]): Promise<void> {
-		await this.send({ type: "prompt", message, images });
+	async prompt(
+		message: string,
+		options?: {
+			images?: ImageContent[];
+			streamingBehavior?: "steer" | "followUp";
+			thinkingLevel?: ThinkingLevel;
+			promptDisposition?: (disposition: PromptDisposition) => void;
+			preflightResult?: (success: boolean) => void;
+		},
+	): Promise<void> {
+		const response = await this.send(
+			{
+				type: "prompt",
+				message,
+				...(options?.images ? { images: options.images } : {}),
+				...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior } : {}),
+				...(options?.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
+			},
+			true,
+			{
+				onResponse: (wireResponse) => {
+					if (!wireResponse.success) {
+						options?.preflightResult?.(false);
+						return;
+					}
+					const data = (wireResponse as { data?: { disposition?: PromptDisposition } }).data;
+					options?.promptDisposition?.(data?.disposition ?? "handled");
+					options?.preflightResult?.(true);
+				},
+				onReject: () => {
+					options?.preflightResult?.(false);
+				},
+			},
+		);
+		if (!response.success) {
+			throw new Error((response as Extract<RpcResponse, { success: false }>).error);
+		}
 	}
 
 	/**
@@ -670,7 +718,7 @@ export class RpcClient {
 	 */
 	async promptAndWait(message: string, images?: ImageContent[], timeout = 60000): Promise<JsonAgentSessionEvent[]> {
 		const eventsPromise = this.collectEvents(timeout);
-		await this.prompt(message, images);
+		await this.prompt(message, images ? { images } : undefined);
 		return eventsPromise;
 	}
 
@@ -686,6 +734,10 @@ export class RpcClient {
 			if (data.type === "response" && data.id && this.pendingRequests.has(data.id)) {
 				const pending = this.pendingRequests.get(data.id)!;
 				this.pendingRequests.delete(data.id);
+				// Response hooks run synchronously inside the frame dispatch so ordering-sensitive
+				// contracts (e.g. optimistic-echo disposition) settle before the NEXT frame —
+				// never through the microtask scheduled by resolve().
+				pending.onResponse?.(data as RpcResponse);
 				pending.resolve(data as RpcResponse);
 				return;
 			}
@@ -707,12 +759,17 @@ export class RpcClient {
 
 	private rejectPendingRequests(error: Error): void {
 		for (const pending of this.pendingRequests.values()) {
+			pending.onReject?.(error);
 			pending.reject(error);
 		}
 		this.pendingRequests.clear();
 	}
 
-	private async send(command: RpcCommandBody, route = true): Promise<RpcResponse> {
+	private async send(
+		command: RpcCommandBody,
+		route = true,
+		hooks?: { onResponse?: (response: RpcResponse) => void; onReject?: (error: Error) => void },
+	): Promise<RpcResponse> {
 		const childProcess = this.process;
 		const stream = this.socket ?? childProcess?.stdin;
 		if (!stream) {
@@ -741,8 +798,11 @@ export class RpcClient {
 
 		return new Promise((resolve, reject) => {
 			const timeout = setTimeout(() => {
+				const pending = this.pendingRequests.get(id);
 				this.pendingRequests.delete(id);
-				reject(new Error(`Timeout waiting for response to ${command.type}. Stderr: ${this.stderr}`));
+				const timeoutError = new Error(`Timeout waiting for response to ${command.type}. Stderr: ${this.stderr}`);
+				pending?.onReject?.(timeoutError);
+				reject(timeoutError);
 			}, 30000);
 
 			this.pendingRequests.set(id, {
@@ -754,6 +814,8 @@ export class RpcClient {
 					clearTimeout(timeout);
 					reject(error);
 				},
+				...(hooks?.onResponse ? { onResponse: hooks.onResponse } : {}),
+				...(hooks?.onReject ? { onReject: hooks.onReject } : {}),
 			});
 
 			try {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,7 +7,7 @@
 
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
 import type { ImageContent, Model } from "@earendil-works/pi-ai";
-import type { SessionStats } from "../../core/agent-session.ts";
+import type { PromptDisposition, SessionStats } from "../../core/agent-session.ts";
 import type { BashResult } from "../../core/bash-executor.ts";
 import type { CompactionResult } from "../../core/compaction/index.ts";
 import type { ServiceTier } from "../../core/extensions/builtin/service-tier.ts";
@@ -279,7 +279,10 @@ export type RpcResponse =
 			};
 	  }
 	// Prompting (async - events follow)
-	| { id?: string; type: "response"; command: "prompt"; success: true }
+	// data.disposition reports how the host disposed the prompt (started/queued/handled)
+	// so proxied optimistic-echo contracts resolve exactly like the local path; older
+	// hosts omit it and clients must degrade to canonical-only rendering.
+	| { id?: string; type: "response"; command: "prompt"; success: true; data?: { disposition?: PromptDisposition } }
 	| { id?: string; type: "response"; command: "steer"; success: true }
 	| { id?: string; type: "response"; command: "follow_up"; success: true }
 	| { id?: string; type: "response"; command: "abort"; success: true }

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -9,7 +9,12 @@ import {
 } from "./rpc-types.ts";
 import { createRpcSessionBinding, type RpcSessionBinding } from "./session-binding.ts";
 import type { SessionEventWriter } from "./session-event-writer.ts";
-import type { OpenRpcSession, RpcSessionLaunchProfile, RpcSessionRegistry } from "./session-registry.ts";
+import type {
+	OpenRpcSession,
+	RpcSessionEntry,
+	RpcSessionLaunchProfile,
+	RpcSessionRegistry,
+} from "./session-registry.ts";
 import { RpcSessionRegistryError } from "./session-registry.ts";
 
 const controls = new Set(["get_protocol_info", "open_session", "close_session", "list_sessions"]);
@@ -86,7 +91,7 @@ export class SessionCommandRouter {
 	async dispose(): Promise<void> {
 		await Promise.all(
 			[...this.bindings.entries()].map(async ([sessionId, binding]) => {
-				let entry;
+				let entry: RpcSessionEntry | undefined;
 				try {
 					entry = this.registry.beginClose(sessionId);
 				} catch {

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -9,7 +9,7 @@ import {
 } from "./rpc-types.ts";
 import { createRpcSessionBinding, type RpcSessionBinding } from "./session-binding.ts";
 import type { SessionEventWriter } from "./session-event-writer.ts";
-import type { RpcSessionLaunchProfile, RpcSessionRegistry } from "./session-registry.ts";
+import type { OpenRpcSession, RpcSessionLaunchProfile, RpcSessionRegistry } from "./session-registry.ts";
 import { RpcSessionRegistryError } from "./session-registry.ts";
 
 const controls = new Set(["get_protocol_info", "open_session", "close_session", "list_sessions"]);
@@ -86,8 +86,9 @@ export class SessionCommandRouter {
 	async dispose(): Promise<void> {
 		await Promise.all(
 			[...this.bindings.entries()].map(async ([sessionId, binding]) => {
+				let entry;
 				try {
-					this.registry.beginClose(sessionId);
+					entry = this.registry.beginClose(sessionId);
 				} catch {
 					return;
 				}
@@ -95,7 +96,9 @@ export class SessionCommandRouter {
 					await binding.dispose();
 				} finally {
 					this.bindings.delete(sessionId);
-					await this.registry.closeMarked(sessionId);
+					// Attached sessions outlive this connection: only the last
+					// attachment's close transitions the entry to "closing".
+					if (entry.state === "closing") await this.registry.closeMarked(sessionId);
 				}
 			}),
 		);
@@ -103,7 +106,7 @@ export class SessionCommandRouter {
 	}
 
 	private async open(command: Extract<RpcCommand, { type: "open_session" }>): Promise<RpcResponse | undefined> {
-		let opened: { sessionId: string } | undefined;
+		let opened: OpenRpcSession | undefined;
 		try {
 			opened = await this.registry.openSession({
 				cwd: command.cwd ?? this.defaults.cwd,
@@ -136,6 +139,7 @@ export class SessionCommandRouter {
 				data: {
 					sessionId: opened.sessionId,
 					state: buildRpcSessionState(state),
+					...(opened.attached ? { attached: true } : {}),
 				},
 			});
 			return undefined;
@@ -155,12 +159,14 @@ export class SessionCommandRouter {
 		try {
 			// This must be the first operation: binding.dispose() awaits teardown and
 			// otherwise leaves a window where commands can enter the old handler.
-			this.registry.beginClose(command.sessionId);
+			const entry = this.registry.beginClose(command.sessionId);
 			try {
 				await this.bindings.get(command.sessionId)?.dispose();
 			} finally {
 				this.bindings.delete(command.sessionId);
-				await this.registry.closeMarked(command.sessionId);
+				// Other attachments may still own the live session; only the last
+				// close finalizes the runtime teardown.
+				if (entry.state === "closing") await this.registry.closeMarked(command.sessionId);
 			}
 			this.writer.closeSession(command.sessionId, {
 				id: command.id,

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -24,6 +24,10 @@ export interface RpcSessionEntry {
 	profile: Readonly<RpcSessionLaunchProfile>;
 	durableSessionId?: string;
 	sessionPath?: string;
+	/** Canonical reservation key for path-opened sessions; matches the reservations set. */
+	reservationKey?: string;
+	/** Live attachments (open + later attaches). The runtime is disposed only when the last one closes. */
+	attachments: number;
 	lifecycleMutex: Promise<void>;
 }
 
@@ -46,6 +50,8 @@ export interface OpenRpcSession {
 	sessionId: string;
 	durableSessionId: string;
 	sessionPath?: string;
+	/** True when this open attached to an already-open session instead of creating one. */
+	attached?: boolean;
 }
 
 function canonicalPath(path: string): string {
@@ -75,7 +81,20 @@ export class RpcSessionRegistry {
 	async openSession(profile: RpcSessionLaunchProfile): Promise<OpenRpcSession> {
 		this.validateProfile(profile);
 		const sessionPath = profile.sessionPath ? canonicalPath(profile.sessionPath) : undefined;
-		if (sessionPath && this.reservations.has(sessionPath)) throw new RpcSessionRegistryError("session_path_in_use");
+		if (sessionPath && this.reservations.has(sessionPath)) {
+			// Attach-on-open: a live session outlives individual client attachments, so a
+			// resume (or a second surface) for an already-hosted path joins the existing
+			// runtime instead of failing. Entries still opening or closing keep the
+			// exclusive reservation and reject as before.
+			const existing = [...this.entries].find(
+				([, entry]) => entry.reservationKey === sessionPath && entry.state === "open",
+			);
+			if (!existing) throw new RpcSessionRegistryError("session_path_in_use");
+			const [handle, entry] = existing;
+			entry.attachments += 1;
+			if (!entry.durableSessionId) throw new RpcSessionRegistryError("session_path_in_use");
+			return { sessionId: handle, durableSessionId: entry.durableSessionId, sessionPath: entry.sessionPath, attached: true };
+		}
 		if (sessionPath) this.reservations.add(sessionPath);
 
 		// Resume vs create parity (D1 + omo SenpiSessionRuntime.ts:198-200):
@@ -94,6 +113,8 @@ export class RpcSessionRegistry {
 			scope: new ProviderScope(),
 			profile: storedProfile,
 			sessionPath,
+			reservationKey: sessionPath,
+			attachments: 1,
 			lifecycleMutex: Promise.resolve(),
 		};
 		this.entries.set(handle, entry);
@@ -148,16 +169,23 @@ export class RpcSessionRegistry {
 	/**
 	 * Starts a close synchronously. Call this before disposing any session-owned
 	 * binding so a concurrent command cannot reach a half-disposed handler.
+	 * Each call releases one attachment; the entry transitions to "closing" only
+	 * when the last attachment closes, so callers must check the returned state
+	 * and skip finalization while other attachments remain.
 	 */
 	beginClose(handle: string): RpcSessionEntry {
 		const entry = this.entries.get(handle);
 		if (entry?.state !== "open") throw new RpcSessionRegistryError("unknown_session");
+		entry.attachments -= 1;
+		if (entry.attachments > 0) return entry;
 		entry.state = "closing";
 		return entry;
 	}
 
 	async close(handle: string): Promise<void> {
-		this.beginClose(handle);
+		const entry = this.beginClose(handle);
+		// Other attachments may still own the live session; only the last close finalizes.
+		if (entry.state !== "closing") return;
 		return this.closeMarked(handle);
 	}
 

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -93,7 +93,12 @@ export class RpcSessionRegistry {
 			const [handle, entry] = existing;
 			entry.attachments += 1;
 			if (!entry.durableSessionId) throw new RpcSessionRegistryError("session_path_in_use");
-			return { sessionId: handle, durableSessionId: entry.durableSessionId, sessionPath: entry.sessionPath, attached: true };
+			return {
+				sessionId: handle,
+				durableSessionId: entry.durableSessionId,
+				sessionPath: entry.sessionPath,
+				attached: true,
+			};
 		}
 		if (sessionPath) this.reservations.add(sessionPath);
 

--- a/packages/coding-agent/test/helpers/rpc-fake-model.ts
+++ b/packages/coding-agent/test/helpers/rpc-fake-model.ts
@@ -108,6 +108,17 @@ export async function startFakeModelServer(): Promise<FakeModelServer> {
 				text,
 			});
 			if (req.url?.includes("/messages")) {
+				// Deterministic slow lane: prompts containing "hold-open-<ms>" keep the
+				// response (and therefore the session's streaming state) open for <ms>.
+				const holdOpenMs = /hold-open-(\d+)/.exec(requestText(body))?.[1];
+				if (holdOpenMs) {
+					// No abort listener: the response stays pending by design; the res.destroyed
+					// guard keeps a late fire quiet after the client gave up.
+					setTimeout(() => {
+						if (!res.destroyed) writeAnthropicSse(res, responseTextFor(body), model ?? MOCK_MODEL);
+					}, Number(holdOpenMs));
+					return;
+				}
 				writeAnthropicSse(res, responseTextFor(body), model ?? MOCK_MODEL);
 				return;
 			}

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -177,6 +177,97 @@ describe("interactive host runtime", () => {
 		}
 	});
 
+	it("delivers prompt disposition and preflight callbacks before the canonical user message_start", async () => {
+		const qa = scratch("disposition");
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const host = spawnHost(qa);
+		await waitForHost(host, qa.socket);
+		const local = await createAgentSessionRuntimeFixture({
+			cwd: qa.cwd,
+			agentDir: qa.agentDir,
+			sessionManager: SessionManager.create(qa.cwd, qa.sessionDir),
+			settingsManager: SettingsManager.create(qa.cwd, qa.agentDir),
+		});
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => undefined,
+			onWarning: vi.fn(),
+		});
+		try {
+			const order: string[] = [];
+			const promptDisposition = vi.fn((disposition: string) => {
+				order.push(`disposition:${disposition}`);
+			});
+			const preflightResult = vi.fn((success: boolean) => {
+				order.push(`preflight:${success}`);
+			});
+			const settled = new Promise<void>((resolve) => {
+				const unsubscribe = runtime.session.subscribe((event) => {
+					if (event.type === "message_start" && event.message.role === "user") order.push("event:message_start");
+					if (event.type !== "agent_settled") return;
+					unsubscribe();
+					resolve();
+				});
+			});
+			await runtime.session.prompt("disposition-probe", { promptDisposition, preflightResult });
+			await settled;
+			expect(promptDisposition).toHaveBeenCalledWith("started");
+			expect(preflightResult).toHaveBeenCalledWith(true);
+			expect(order).toEqual(["disposition:started", "preflight:true", "event:message_start"]);
+		} finally {
+			await runtime.dispose();
+			await fake.close();
+		}
+	});
+
+	it("forwards streamingBehavior so a mid-stream prompt queues instead of failing", async () => {
+		const qa = scratch("queued");
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const host = spawnHost(qa);
+		await waitForHost(host, qa.socket);
+		const local = await createAgentSessionRuntimeFixture({
+			cwd: qa.cwd,
+			agentDir: qa.agentDir,
+			sessionManager: SessionManager.create(qa.cwd, qa.sessionDir),
+			settingsManager: SettingsManager.create(qa.cwd, qa.agentDir),
+		});
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => undefined,
+			onWarning: vi.fn(),
+		});
+		try {
+			const firstSettled = new Promise<void>((resolve) => {
+				const unsubscribe = runtime.session.subscribe((event) => {
+					if (event.type !== "agent_settled") return;
+					unsubscribe();
+					resolve();
+				});
+			});
+			void runtime.session.prompt("hold-open-1500 first-turn");
+			const streamingDeadline = Date.now() + 10_000;
+			while (!runtime.session.isStreaming) {
+				if (Date.now() > streamingDeadline) throw new Error("session never entered streaming state");
+				await new Promise((resolve) => setTimeout(resolve, 25));
+			}
+			const queuedDisposition = vi.fn();
+			const queuedPreflight = vi.fn();
+			await runtime.session.prompt("queued second turn", {
+				streamingBehavior: "followUp",
+				promptDisposition: queuedDisposition,
+				preflightResult: queuedPreflight,
+			});
+			await firstSettled;
+			expect(queuedDisposition).toHaveBeenCalledWith("queued");
+			expect(queuedPreflight).toHaveBeenCalledWith(true);
+		} finally {
+			await runtime.dispose();
+			await fake.close();
+		}
+	});
+
 	it("falls back locally with a typed warning when the host remains unreachable", async () => {
 		const qa = scratch("fallback");
 		const fake = await startFakeModelServer();

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -268,6 +268,36 @@ describe("interactive host runtime", () => {
 		}
 	});
 
+	it("reflects remote thinking-level cycles in session.state for footer rendering", async () => {
+		const qa = scratch("state-sync");
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const host = spawnHost(qa);
+		await waitForHost(host, qa.socket);
+		const local = await createAgentSessionRuntimeFixture({
+			cwd: qa.cwd,
+			agentDir: qa.agentDir,
+			sessionManager: SessionManager.create(qa.cwd, qa.sessionDir),
+			settingsManager: SettingsManager.create(qa.cwd, qa.agentDir),
+		});
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => undefined,
+			onWarning: vi.fn(),
+		});
+		try {
+			const newLevel = await runtime.session.cycleThinkingLevel();
+			expect(newLevel).toBeTruthy();
+			// The footer reads session.state.thinkingLevel; the proxy must surface the
+			// host's level there too, not only through the direct thinkingLevel getter.
+			expect(runtime.session.thinkingLevel).toBe(newLevel);
+			expect(runtime.session.state.thinkingLevel).toBe(newLevel);
+		} finally {
+			await runtime.dispose();
+			await fake.close();
+		}
+	});
+
 	it("falls back locally with a typed warning when the host remains unreachable", async () => {
 		const qa = scratch("fallback");
 		const fake = await startFakeModelServer();

--- a/packages/coding-agent/test/interactive-mode-thinking-cycle.test.ts
+++ b/packages/coding-agent/test/interactive-mode-thinking-cycle.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Shift+Tab thinking-cycle under the shared interactive host.
+ *
+ * Since the shared RPC host became the default for interactive sessions,
+ * `session.cycleThinkingLevel()` may return a Promise (the remote proxy
+ * forwards the RPC), while the classic local AgentSession returns the level
+ * synchronously. The InteractiveMode handler must await either shape and must
+ * never render "[object Promise]"; the user-visible level status is driven by
+ * the `thinking_level_changed` session event so every attached client (not
+ * just the one that pressed Shift+Tab) converges on the host's level.
+ */
+
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+
+type MockFn = ReturnType<typeof vi.fn>;
+
+interface CycleContext {
+	isInitialized: boolean;
+	session: {
+		cycleThinkingLevel: () => unknown;
+		thinkingLevel?: string;
+	};
+	footer: { invalidate: MockFn };
+	ui: { requestRender: MockFn };
+	showStatus: MockFn;
+	updateEditorBorderColor: MockFn;
+}
+
+interface ModePrototype {
+	cycleThinkingLevel(this: CycleContext): unknown;
+	handleEvent(this: CycleContext, event: { type: string; level?: string }): unknown;
+}
+
+const proto = InteractiveMode.prototype as unknown as ModePrototype;
+
+function createContext(cycleResult: unknown): CycleContext {
+	return {
+		isInitialized: false,
+		session: {
+			cycleThinkingLevel: vi.fn(() => cycleResult),
+			thinkingLevel: "medium",
+		},
+		footer: { invalidate: vi.fn() },
+		ui: { requestRender: vi.fn() },
+		showStatus: vi.fn(),
+		updateEditorBorderColor: vi.fn(),
+	};
+}
+
+async function flushMicrotasks(turns = 20): Promise<void> {
+	for (let i = 0; i < turns; i += 1) await Promise.resolve();
+}
+
+describe("interactive thinking level cycle", () => {
+	it("never renders [object Promise] when the session resolves the level asynchronously", async () => {
+		const context = createContext(Promise.resolve("high"));
+		await proto.cycleThinkingLevel.call(context);
+		await flushMicrotasks();
+		const statuses = context.showStatus.mock.calls.map((call) => String(call[0]));
+		expect(statuses.every((status) => !status.includes("[object Promise]"))).toBe(true);
+	});
+
+	it("reports unsupported models when the async cycle resolves undefined", async () => {
+		const context = createContext(Promise.resolve(undefined));
+		await proto.cycleThinkingLevel.call(context);
+		await flushMicrotasks();
+		const statuses = context.showStatus.mock.calls.map((call) => String(call[0]));
+		expect(statuses).toContain("Current model does not support thinking");
+	});
+
+	it("keeps the sync local-session path free of [object Promise] and unsupported false negatives", async () => {
+		const context = createContext("xhigh");
+		await proto.cycleThinkingLevel.call(context);
+		await flushMicrotasks();
+		const statuses = context.showStatus.mock.calls.map((call) => String(call[0]));
+		expect(statuses.every((status) => !status.includes("[object Promise]"))).toBe(true);
+		expect(statuses).not.toContain("Current model does not support thinking");
+	});
+
+	it("drives the level status from thinking_level_changed so remote and local paths converge", async () => {
+		const context = createContext(Promise.resolve("high"));
+		context.isInitialized = true;
+		await proto.handleEvent.call(context, { type: "thinking_level_changed", level: "high" });
+		await flushMicrotasks();
+		const statuses = context.showStatus.mock.calls.map((call) => String(call[0]));
+		expect(statuses).toContain("Thinking level: high");
+		expect(context.footer.invalidate).toHaveBeenCalled();
+		expect(context.updateEditorBorderColor).toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/rpc-session-registry.test.ts
+++ b/packages/coding-agent/test/rpc-session-registry.test.ts
@@ -218,6 +218,47 @@ describe("RPC session registry", () => {
 		await expect(registry.close(opened.sessionId)).rejects.toMatchObject({ code: "unknown_session" });
 	});
 
+	test("attaches to an already-open session by path instead of rejecting session_path_in_use", async () => {
+		const { dir, registry } = await createRegistry();
+		const path = join(dir, "attach.jsonl");
+		const first = await registry.openSession(profile(dir, path));
+
+		const attached = await registry.openSession(profile(dir, path));
+
+		expect(attached.sessionId).toBe(first.sessionId);
+		expect(attached.durableSessionId).toBe(first.durableSessionId);
+		expect(attached.attached).toBe(true);
+		expect(registry.list()).toHaveLength(1);
+	});
+
+	test("keeps the runtime alive until the last attachment closes", async () => {
+		const { dir } = await createRegistry();
+		let disposed = false;
+		const registry = new RpcSessionRegistry({
+			agentDir: dir,
+			createRuntime: async (options) => {
+				const result = runtime(options);
+				result.session.dispose = () => {
+					disposed = true;
+				};
+				return result;
+			},
+		});
+		const path = join(dir, "attach-close.jsonl");
+		const first = await registry.openSession(profile(dir, path));
+		await registry.openSession(profile(dir, path));
+
+		await registry.close(first.sessionId);
+		expect(disposed).toBe(false);
+		expect(registry.list()).toHaveLength(1);
+		expect(registry.getForCommand(first.sessionId, "prompt").state).toBe("open");
+
+		await registry.close(first.sessionId);
+		expect(disposed).toBe(true);
+		expect(registry.list()).toHaveLength(0);
+		await expect(registry.openSession(profile(dir, path))).resolves.toMatchObject({ sessionId: expect.any(String) });
+	});
+
 	test("constructs each opened runtime inside an isolated provider scope", async () => {
 		const { dir } = await createRegistry();
 		const api = "rpc-session-scope-test";

--- a/packages/coding-agent/test/suite/interactive-mode-scoped-settings.test.ts
+++ b/packages/coding-agent/test/suite/interactive-mode-scoped-settings.test.ts
@@ -74,7 +74,7 @@ describe("InteractiveMode scoped-setting caller compatibility", () => {
 		expect(setSessionModel).not.toHaveBeenCalled();
 	});
 
-	it("keeps the settings UI thinking selector on the global-setting setter", () => {
+	it("keeps the settings UI thinking selector on the global-setting setter", async () => {
 		// Given: the settings selector is opened with both thinking-setting APIs observable.
 		const setThinkingLevel = vi.fn();
 		const setSessionThinkingLevel = vi.fn();
@@ -105,7 +105,9 @@ describe("InteractiveMode scoped-setting caller compatibility", () => {
 		}
 
 		// When: the interactive settings callback selects a new thinking level.
-		showSettingsSelector.call(fakeThis);
+		// showSettingsSelector is async: it awaits the (possibly remote) thinking-level
+		// list before building the selector.
+		await showSettingsSelector.call(fakeThis);
 		const callbacks = settingsCapture.callbacks;
 		if (callbacks === undefined) throw new Error("Settings callbacks were not captured");
 		callbacks.onThinkingLevelChange("high");


### PR DESCRIPTION
## Summary

Hotfix for the beta.23 (senpi 2026.8.27) shared interactive host regressions reported by users in the OMO Discord:

1. **Shift+Tab printed `Thinking level: [object Promise]`** and the low/med/high thinking options disappeared from `/settings`. Since the shared RPC host became the default for interactive sessions, the remote session proxy answers `cycleThinkingLevel`, `getAvailableThinkingLevels`, `getSessionStats`, and `getUserMessagesForForking` with Promises, while the TUI consumed them synchronously.
2. **User messages rendered twice.** The proxy's `prompt` override dropped the optimistic-echo `promptDisposition`/`preflightResult` callbacks (and `streamingBehavior`), so echoes never became eligible for canonical replacement and `message_start` rendered as a duplicate. Mid-stream submissions also lost steer/follow-up semantics entirely.
3. **Resume failed with `session_path_in_use` by construction.** `open_session` on a path held by a fully-open session threw, so any live attachment (desktop app, second terminal) made resume impossible; the TUI silently fell back to a divergent local runtime.

## Fixes

- **`InteractiveSession` type** (`interactive-host-runtime.ts`): widens the four reads to `T | Promise<T>` so the proxy is honestly typed; the compiler sweep found every TUI call site (Shift+Tab handler, `/settings`, `/fork`, `/session`, footers) and all now await. The thinking-level status and footer render from the `thinking_level_changed` event (single path for local, remote, and other attached clients), and the proxy overlays host-authoritative fields onto `session.state` so the footer stops rendering stale levels.
- **Wire `data.disposition`** on the prompt success response (`started`/`queued`/`handled`), captured host-side where disposition always fires before preflight. Client response hooks run **synchronously inside frame dispatch** (never through the resolved promise's microtask), so echo eligibility settles in wire order before `message_start`. Older hosts omit `data` and degrade to canonical-only rendering. `streamingBehavior`/`thinkingLevel` are forwarded again.
- **Attach-on-open** in the session registry: `open_session` on a path held by a fully-open session attaches (same handle, `attached: true`, attachment-counted) instead of throwing; the runtime tears down only when the last attachment closes. Entries still opening/closing keep the exclusive reservation.
- Proxy fire-and-forget setters now surface RPC failures via a typed `interactive_host_action_failed` warning instead of swallowing them.

## Test plan

- New `test/interactive-mode-thinking-cycle.test.ts` (4 tests): no `[object Promise]` on async or sync cycle, unsupported-model branch, event-driven level status. RED before fix (`'Thinking level: [object Promise]'`), GREEN after.
- `test/interactive-host-runtime.test.ts` (+3 integration tests against a real spawned host): disposition+preflight fire in wire order before the canonical `message_start`; mid-stream prompt with `streamingBehavior: "followUp"` queues instead of failing; remote cycle reflects in `session.state.thinkingLevel`. RED before, GREEN after.
- `test/rpc-session-registry.test.ts` (+2): attach returns the same handle with `attached: true`; runtime survives until the last attachment closes. RED before (`session_path_in_use`), GREEN after. All 8 pre-existing tests unchanged and passing.
- Full `packages/coding-agent` suite green; root `tsc --noEmit` clean; changelog gate PASS.
- Real-surface QA on the fixed build (pty-driven TUI against a live shared host): Shift+Tab renders `Thinking level: xhigh` with the footer following; one submitted message renders exactly once in the chat area; `senpi --session <id>` against a session held open by another live client attaches with no fallback warning and shows the session history.

## Notes

- The py/js eval-kernel `$bunfs` asset failure is already fixed on main by #1164 and rides this release; verified `compiled-runner-path` + `py-kernel` tests (17/17).
- Known follow-ups (not in scope): proxy reads that still fall through to the local session for rarely-changed state (`isFastModeActive`, steering/follow-up mode displays, auto-compaction flag) can lag the host until their `*_changed` events land.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three shared interactive host session regressions from the beta.23 release: Shift+Tab printed `Thinking level: [object Promise]` and `/settings` lost the thinking options, user messages rendered twice, and resuming a session another client held failed with `session_path_in_use`.

**Bug Fixes**

- The TUI-facing session contract now permits the four RPC-backed reads to return Promises; every call site awaits them, and the thinking level renders from the `thinking_level_changed` event.
- The prompt success response carries `data.disposition` and forwards `streamingBehavior` and `thinkingLevel`, with client hooks running synchronously inside frame dispatch so optimistic echoes resolve in wire order.
- `open_session` on a path held by a fully-open session attaches to it instead of throwing; the runtime is torn down only when the last attachment closes.
- Fire-and-forget proxied setters now surface RPC failures as a typed warning instead of swallowing them.

<sup>Written for commit 5e6714e6859375e31393f7bd53ebc1eb188b0a64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

