### PR TITLE
ci(release): provision ripgrep and fd on the release runner

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -61,6 +61,13 @@ jobs:
       - name: Install dependencies
         run: npm install --ignore-scripts --no-audit --no-fund
 
+      # coding-agent tool tests resolve rg/fd via system binaries first and only
+      # download from GitHub releases as a fallback. Unauthenticated downloads
+      # are rate-limited on shared runner egress IPs, which flakes the release
+      # gate; provisioning the binaries here keeps the fallback unused.
+      - name: Provision ripgrep and fd
+        run: sudo apt-get update && sudo apt-get install -y ripgrep fd-find
+
       - name: Build all workspaces (so husky pre-commit type check resolves)
         run: npm run build
 


### PR DESCRIPTION
## Summary

The 2026.8.28 release run (and its first rerun) failed in the coding-agent test suite with `ripgrep (rg) is not available and could not be downloaded` / `fd is not available and could not be downloaded`. The tool resolver checks system binaries first and only downloads from GitHub releases as a fallback; the fallback is unauthenticated, so it is rate-limited on shared GitHub-runner egress IPs and flakes under load.

This adds an apt provisioning step (`ripgrep`, `fd-find`) to `publish-npm.yml` ahead of the release step, keeping the download fallback unused and the release gate deterministic. `fdfind` satisfies the resolver's `systemBinaryNames`.

## Test plan

- The workflow change is exercised by the next release dispatch; CI on this PR validates the YAML and the rest of the gates.
- Local: the same tests pass with system rg/fd present (verified in the beta.23 hotfix QA).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provisions `ripgrep` and `fd` on the release runner so coding-agent tests stop flaking when the unauthenticated GitHub download fallback gets rate-limited.

Previously the tool resolver fell back to downloading from GitHub releases when system binaries were missing, which failed twice on the 2026.8.28 release gate. The new apt step installs both tools ahead of the release step, keeping the fallback unused and the gate deterministic.

<sup>Written for commit f898cce7a7440852b637859d8a58e2edb1f07c18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

