### PR TITLE
test(ai): track the Fire Pass router family rename in fireworks catalog

### DIFF
--- a/packages/ai/test/fireworks-models.test.ts
+++ b/packages/ai/test/fireworks-models.test.ts
@@ -37,14 +37,14 @@ describe("Fireworks models", () => {
 		});
 	});
 
-	it("registers the Fire Pass turbo router model", () => {
+	it("registers the Fire Pass fast router model", () => {
 		const model = getModels("fireworks").find(
-			(candidate) => candidate.id.startsWith("accounts/fireworks/routers/") && candidate.id.endsWith("-turbo"),
+			(candidate) => candidate.id === "accounts/fireworks/routers/kimi-k3-fast",
 		);
 
 		expect(model).toBeDefined();
-		expect(model?.api).toBe("anthropic-messages");
-		expect(model?.baseUrl).toBe("https://api.fireworks.ai/inference");
+		expect(model?.api).toBe("openai-completions");
+		expect(model?.baseUrl).toBe("https://api.fireworks.ai/inference/v1");
 		expect(model?.input).toEqual(["text", "image"]);
 	});
 


### PR DESCRIPTION
## Summary

The 2026.8.28 release gate failed on `test/fireworks-models.test.ts:45`: after the release script regenerates the model catalog from live models.dev, the entire `-turbo` Fire Pass router family is gone upstream — only `-fast` routers remain (`openai-completions`, `https://api.fireworks.ai/inference/v1`). The test's turbo assertion was stale against upstream catalog drift.

This pins the Fire Pass router test to the current family via the deterministic `accounts/fireworks/routers/kimi-k3-fast` entry, which exists in both the committed and the regenerated catalogs.

## Test plan

- Reproduced locally: `npm --prefix packages/ai run generate-models` then the test fails with the same `expected undefined to be defined` as the release log; after the fix, `npx vitest run test/fireworks-models.test.ts` passes 15/15 against the regenerated catalog.
- Full `packages/ai` suite: 2440 passed; the only other failure (`cursor-agent` heartbeat) passes in isolation on both base and branch — parallel-load flake, unrelated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Fireworks model catalog test so it tracks the current Fire Pass router family, unblocking the 2026.8.28 release gate.

- The test asserted a `-turbo` router that models.dev removed; the live catalog now only registers `-fast` routers.
- Pins the assertion to the deterministic `kimi-k3-fast` entry and updates the expected API and base URL.

<sup>Written for commit be403c182d47069f6830ddf7290f463e69c908ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

