### PR TITLE
feat(coding-agent): add --auto-title-sessions for RPC hosts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- `--auto-title-sessions` opts non-interactive launches into engine-side session auto-titling, so `--mode rpc` hosts (including `--multi-session`) generate session titles and publish them through the existing `session_info_changed` event. Resumed sessions that already have context messages are still never retitled.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -57,6 +57,19 @@ every open session, each tagged with its routing `sessionId`. Correlated respons
 only to the connection that issued the command. This lets a non-owner observe a foreign turn without requiring a
 separate subscription protocol.
 
+### Session auto-titling
+
+Auto-generated session titles are on by default only for interactive launches. RPC hosts opt in with
+`--auto-title-sessions`:
+
+```bash
+senpi --mode rpc --multi-session --auto-title-sessions
+```
+
+With the flag, every session the host opens (classic or multi-session) generates a title from its first user prompt and
+publishes it to clients through the existing `session_info_changed` event; no new command or event is involved. Sessions
+resumed with existing context messages are never retitled, with or without the flag.
+
 Startup: `senpi --mode rpc --multi-session` → NO default session is constructed (no default `AgentSessionRuntime`, no default extension/watcher load). Classic `senpi --mode rpc` is byte-identical to today. Mode is fixed at process start; there is no runtime transition.
 
 ### Interactive sessions and shared-host opt-out

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Honor --auto-title-sessions outside interactive mode (2026-08-28)
+
+### What changed
+
+- `packages/coding-agent/src/main.ts` resolves session auto-titling through the exported `resolveAutoTitleSessions(appMode, parsed, hasContextMessages)` helper: interactive launches keep titling by default, any app mode opts in with `--auto-title-sessions`, and sessions resumed with context messages are still never retitled. Because the shared `createRuntime` closure is also what the multi-session RPC host calls through `RpcSessionRegistry.openSession`, both the classic and multi-session RPC paths honor the flag without extra plumbing.
+
+### Why
+
+- RPC clients (the desktop app spawns `--mode rpc --multi-session`) never received generated session titles even though `setSessionName()` already emits `session_info_changed` and the RPC connection handler already forwards it.
+
+### Why an extension could not handle it
+
+- The auto-title decision is made while the entrypoint constructs the first `AgentSession`, before extensions load.
+
+### Expected merge conflict zones
+
+- LOW: the `autoTitleSessions` argument in the `createAgentSessionFromServices` call and the helper beside `toProjectTrustMode`.
+
 ## Credential accounts in auth check --json (2026-08-27)
 
 ### What changed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -57,6 +57,8 @@ export interface Args {
 	grokNeo?: boolean;
 	/** Serve independently routed plain-RPC sessions over one host. */
 	multiSession?: boolean;
+	/** Opt non-interactive app modes (notably RPC) into engine-side session auto-titling. */
+	autoTitleSessions?: boolean;
 	/** Multi-session RPC listener: stdio://, unix://, unix:///path, or a socket path. */
 	listen?: string;
 	messages: string[];
@@ -238,6 +240,8 @@ export function parseArgs(args: string[], options: { grokNeoEnabled?: boolean } 
 			result.grokNeo = true;
 		} else if (arg === "--multi-session") {
 			result.multiSession = true;
+		} else if (arg === "--auto-title-sessions") {
+			result.autoTitleSessions = true;
 		} else if (arg === "--listen" && result.mode === "rpc") {
 			const value = args[i + 1];
 			if (value === undefined || value.startsWith("--")) {
@@ -353,6 +357,7 @@ ${chalk.bold("Options:")}
   --offline                      Disable startup network operations (same as PI_OFFLINE=1)
 ${grokNeoOptionsText}  --multi-session               Serve multiple routed RPC sessions
   --listen <address>            RPC listener: stdio://, unix://, unix:///path, or a socket path
+  --auto-title-sessions         Auto-generate session titles outside interactive mode
   --help, -h                     Show this help
   --version, -v                  Show version number
 

--- a/packages/coding-agent/src/cli/changes.md
+++ b/packages/coding-agent/src/cli/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Opt-in session auto-titling flag (2026-08-28)
+
+### What changed
+
+- `packages/coding-agent/src/cli/args.ts` adds `--auto-title-sessions` (`Args.autoTitleSessions`) and a help row for it, so non-interactive launches can request engine-side session titles.
+
+### Why
+
+- RPC hosts (the desktop app spawns `--mode rpc --multi-session`) had no way to enable session auto-titling, which was hardcoded to interactive mode only.
+
+### Why an extension could not handle it
+
+- Flag parsing happens in the entrypoint before extension flags are registered, and the value is consumed while the first session is constructed.
+
+### Expected merge conflict zones
+
+- LOW: the `Args` fields, the parse branch beside `--multi-session`, and the help rows in `args.ts`.
+
 ## CLI argument surface re-diverges from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -176,6 +176,16 @@ function toProjectTrustMode(appMode: AppMode): AppMode {
 	return appMode === "app-server" ? "print" : appMode;
 }
 
+/**
+ * Interactive launches auto-title by default; every other app mode (RPC with or
+ * without `--multi-session`, print, json, app-server) opts in with
+ * `--auto-title-sessions`. Sessions resumed with existing context messages are
+ * never retitled, whatever the mode or flag.
+ */
+export function resolveAutoTitleSessions(appMode: AppMode, parsed: Args, hasContextMessages: boolean): boolean {
+	return (appMode === "interactive" || parsed.autoTitleSessions === true) && !hasContextMessages;
+}
+
 function isPlainRuntimeMetadataCommand(parsed: Args): boolean {
 	return (
 		!parsed.print &&
@@ -1049,7 +1059,7 @@ export async function main(args: string[], options?: MainOptions) {
 			excludeTools: sessionOptions.excludeTools,
 			noTools: sessionOptions.noTools,
 			customTools: sessionOptions.customTools,
-			autoTitleSessions: appMode === "interactive" && !sessionManager.hasContextMessages(),
+			autoTitleSessions: resolveAutoTitleSessions(appMode, parsed, sessionManager.hasContextMessages()),
 		});
 		const cliThinkingOverride = runtimeParsed.thinking !== undefined || cliThinkingFromModel;
 		if (created.session.model && cliThinkingOverride) {

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -467,6 +467,27 @@ describe("parseArgs", () => {
 		});
 	});
 
+	describe("--auto-title-sessions flag", () => {
+		test("parses --auto-title-sessions", () => {
+			const result = parseArgs(["--auto-title-sessions"]);
+			expect(result.autoTitleSessions).toBe(true);
+			expect(result.unknownFlags.has("auto-title-sessions")).toBe(false);
+		});
+
+		test("is undefined when the flag is absent", () => {
+			const result = parseArgs(["--mode", "rpc", "--multi-session"]);
+			expect(result.autoTitleSessions).toBeUndefined();
+			expect(result.multiSession).toBe(true);
+		});
+
+		test("combines with rpc multi-session flags", () => {
+			const result = parseArgs(["--mode", "rpc", "--multi-session", "--auto-title-sessions"]);
+			expect(result.mode).toBe("rpc");
+			expect(result.multiSession).toBe(true);
+			expect(result.autoTitleSessions).toBe(true);
+		});
+	});
+
 	describe("messages and file args", () => {
 		test("parses plain text messages", () => {
 			const result = parseArgs(["hello", "world"]);

--- a/packages/coding-agent/test/auto-title-sessions-flag.test.ts
+++ b/packages/coding-agent/test/auto-title-sessions-flag.test.ts
@@ -1,0 +1,83 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
+import { afterEach, describe, expect, test } from "vitest";
+import { parseArgs } from "../src/cli/args.ts";
+import { resolveAutoTitleSessions } from "../src/main.ts";
+import { waitForSessionName } from "./agent-session-auto-title-helpers.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+/**
+ * `--auto-title-sessions` opts non-interactive app modes (notably `--mode rpc`,
+ * with or without `--multi-session`) into engine-side session auto-titling.
+ * Interactive launches keep auto-titling on by default, and a resumed session
+ * that already carries context messages must never be retitled.
+ */
+describe("resolveAutoTitleSessions", () => {
+	test("keeps auto-titling on for interactive launches without the flag", () => {
+		const parsed = parseArgs([]);
+		expect(resolveAutoTitleSessions("interactive", parsed, false)).toBe(true);
+	});
+
+	test("leaves non-interactive modes off without the flag", () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session"]);
+		expect(resolveAutoTitleSessions("rpc", parsed, false)).toBe(false);
+	});
+
+	test.each(["rpc", "print", "json", "app-server"] as const)("honors the flag in %s mode", (appMode) => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session", "--auto-title-sessions"]);
+		expect(resolveAutoTitleSessions(appMode, parsed, false)).toBe(true);
+	});
+
+	test("still suppresses auto-titling when the session has context messages", () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session", "--auto-title-sessions"]);
+		expect(resolveAutoTitleSessions("rpc", parsed, true)).toBe(false);
+	});
+
+	test("suppresses auto-titling for interactive resumes with context messages", () => {
+		const parsed = parseArgs([]);
+		expect(resolveAutoTitleSessions("interactive", parsed, true)).toBe(false);
+	});
+});
+
+describe("rpc sessions launched with --auto-title-sessions", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) {
+			harnesses.pop()?.cleanup();
+		}
+	});
+
+	test("titles a fresh rpc session", async () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session", "--auto-title-sessions"]);
+		const harness = await createHarness({
+			persistSession: true,
+			autoTitleSessions: resolveAutoTitleSessions("rpc", parsed, false),
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("turn complete"),
+			fauxAssistantMessage("<title>RPC Titled Session</title>"),
+		]);
+
+		const sessionName = waitForSessionName(harness);
+		await harness.session.prompt("fix the OAuth login button on mobile");
+
+		await expect(sessionName).resolves.toBe("RPC Titled Session");
+	});
+
+	test("leaves a resumed rpc session with context messages untitled", async () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session", "--auto-title-sessions"]);
+		const harness = await createHarness({
+			persistSession: true,
+			autoTitleSessions: resolveAutoTitleSessions("rpc", parsed, true),
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("turn complete")]);
+
+		await harness.session.prompt("fix the OAuth login button on mobile");
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.faux.getCallLog()).toHaveLength(1);
+		expect(harness.sessionManager.getSessionName()).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

Session auto-titling worked end to end *except* it was never enabled for RPC. `main.ts` hardcoded:

```ts
autoTitleSessions: appMode === "interactive" && !sessionManager.hasContextMessages(),
```

So a client spawning `omo --mode rpc --multi-session` (the desktop app) never received a generated session name, even though `AgentSession.setSessionName()` already emits `session_info_changed`, the event is already in the `AgentSessionEvent` union, and `modes/rpc/connection-handler.ts` already forwards it generically. The only missing piece was enabling the flag.

## Change

- `cli/args.ts`: new `--auto-title-sessions` flag (`Args.autoTitleSessions`) parsed beside `--multi-session`, plus a help row.
- `main.ts`: the decision moves into an exported pure helper:

```ts
export function resolveAutoTitleSessions(appMode: AppMode, parsed: Args, hasContextMessages: boolean): boolean {
	return (appMode === "interactive" || parsed.autoTitleSessions === true) && !hasContextMessages;
}
```

Interactive stays on by default; any other mode opts in; the `hasContextMessages()` suppression is preserved exactly, so a resumed session with context messages is still never retitled.

No new event, no new schema, no connection-handler change. Multi-session RPC reaches the same `createRuntime` closure (`runMultiSessionHost` -> `RpcSessionRegistry.openSession` -> `createAgentSessionRuntime`), so both the classic and multi-session RPC paths are covered with no new plumbing on `MultiSessionHostOptions` or `RpcSessionLaunchProfile`.

## Tests

Written first and captured failing (12 red), then green:

- `test/args.test.ts`: `--auto-title-sessions` sets `true`; absence leaves it `undefined`; combines with `--mode rpc --multi-session`.
- `test/auto-title-sessions-flag.test.ts`: `resolveAutoTitleSessions` matrix (interactive default on, non-interactive default off, flag honored in rpc/print/json/app-server, context messages suppress in every case), plus two harness-backed tests that a flag-enabled non-interactive session really titles via `session_info_changed` and that a context-bearing resume stays untitled.

## Docs / trackers

- `docs/rpc.md`: new "Session auto-titling" section under multi-session startup.
- `src/changes.md`, `src/cli/changes.md`, `CHANGELOG.md [Unreleased]`.

`node scripts/check-pr-changelog.mjs` → PASS (2 production paths covered).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--auto-title-sessions` so RPC hosts can receive generated session titles, which were previously hardcoded to interactive mode only.

- Interactive launches keep auto-titling on by default; other modes opt in via the new exported `resolveAutoTitleSessions()` helper.
- Resumed sessions with context messages are still never retitled, with or without the flag.
- Both classic and `--multi-session` RPC paths are covered through the shared `createRuntime` closure, with no new event, schema, or connection-handler changes.
- Adds parse and harness tests, plus docs in `docs/rpc.md` and changelog entries.

<sup>Written for commit e191aab8faaa9af9644efdbc133a42339602b101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

