### PR TITLE
feat(terminal): emit monitor snapshots through pi.rpc.emit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Terminal monitor snapshots now also publish on the RPC `extension_event` path as `terminal_monitor_state` (`activeCount` plus per-watch `id`/`description`/`paused`/`startedAtMs`). Clients receive them only when they advertise `extension_events`; the in-process `pi.events` channel is unchanged.
+
 - `--auto-title-sessions` opts non-interactive launches into engine-side session auto-titling, so `--mode rpc` hosts (including `--multi-session`) generate session titles and publish them through the existing `session_info_changed` event. Resumed sessions that already have context messages are still never retitled.
 
 ### Changed

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -1250,6 +1250,30 @@ Emitted when an extension calls `pi.rpc.emit(name, data)` and the client adverti
 the specific event name before applying it. In multi-session mode the record also includes the
 routing `sessionId`; delivery preserves the owning session and per-session event order.
 
+The terminal builtin emits `terminal_monitor_state` on this path whenever the active monitor set
+changes. `data` is `{ activeCount, monitors }`, where each monitor entry has `id`, `description`,
+`paused`, and `startedAtMs`. The matching in-process `pi.events` channel is unchanged and is not
+forwarded. Clients receive the wire record only when they advertise the `extension_events`
+capability:
+
+```json
+{
+  "type": "extension_event",
+  "name": "terminal_monitor_state",
+  "data": {
+    "activeCount": 1,
+    "monitors": [
+      {
+        "id": "bash_1",
+        "description": "watch checks",
+        "paused": false,
+        "startedAtMs": 1710000000000
+      }
+    ]
+  }
+}
+```
+
 ### agent_start
 
 Emitted when the agent begins processing a prompt.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,28 @@
 # terminal builtin extension — fork surface
 
+## Monitor snapshots cross the RPC wire (2026-08-28)
+
+### What changed
+
+- `extension.ts`: the monitor-state sink now builds one payload and publishes it
+  on both `pi.events` (`terminal_monitor_state`, consumed in-process by goal)
+  and `pi.rpc.emit` so JSONL RPC clients receive `{ type: "extension_event",
+  name: "terminal_monitor_state", data }` when they advertise `extension_events`.
+
+### Why
+
+- Ordinary `pi.events` channels are never forwarded over RPC. Desktop and other
+  RPC hosts could not observe live monitor snapshots without this second emit.
+
+### Why an extension could not handle it
+
+- The authoritative monitor registry is private to the terminal builtin; only
+  this sink sees the snapshot.
+
+### Expected merge conflict zones
+
+- LOW: `extension.ts` `onMonitorState` sink next to the existing `pi.events.emit`.
+
 ## Align terminal bash environment guidance (2026-08-13)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -56,7 +56,7 @@ function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalE
 		onMonitorEvent: (event) => state.monitorNotifier?.notifyEvent(event),
 		onMonitorState: (snapshot) => {
 			state.statusTicker.sync(snapshot);
-			pi.events?.emit(TERMINAL_MONITOR_STATE_EVENT, {
+			const payload = {
 				activeCount: snapshot.length,
 				monitors: snapshot.map((entry) => ({
 					id: entry.id,
@@ -64,7 +64,9 @@ function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalE
 					paused: entry.paused,
 					startedAtMs: entry.startedAtMs,
 				})),
-			});
+			};
+			pi.events?.emit(TERMINAL_MONITOR_STATE_EVENT, payload);
+			pi.rpc?.emit(TERMINAL_MONITOR_STATE_EVENT, payload);
 			pi.events?.emit(WAKE_SOURCE_STATE_EVENT, {
 				source: "terminal-monitors",
 				activeCount: snapshot.length,

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## Terminal monitor snapshots ride `extension_event` (2026-08-28)
+
+### What changed
+
+- The terminal builtin now calls `pi.rpc.emit("terminal_monitor_state", payload)`
+  alongside the existing in-process event. Connection-handler forwarding is
+  unchanged: clients that advertised `extension_events` receive
+  `{ type: "extension_event", name: "terminal_monitor_state", data }`.
+
+### Why
+
+- Ordinary `pi.events` channels stay extension-local. Monitor liveness was
+  therefore invisible to RPC clients even though the snapshot existed in-process.
+
+### Why an extension could not handle it
+
+- The emit lives in the terminal builtin; the RPC host already forwards every
+  `pi.rpc.emit`. No connection-handler or schema change is required.
+
+### Expected merge conflict zones
+
+- LOW: `docs/rpc.md` `extension_event` section (payload example).
+
 ## Prompt disposition rides the wire and sessions attach by path (2026-08-28)
 
 ### What changed

--- a/packages/coding-agent/test/suite/app-server-extension-events.test.ts
+++ b/packages/coding-agent/test/suite/app-server-extension-events.test.ts
@@ -95,4 +95,52 @@ describe("app-server extension RPC events", () => {
 		expect(secondFrames.filter((frame) => "method" in frame && frame.method === "extension_event")).toEqual([]);
 		runtime.dispose();
 	});
+
+	it("forwards terminal_monitor_state to the owning thread subscriber", async () => {
+		const fixture = createFixture();
+		vi.stubEnv("SENPI_CODING_AGENT_DIR", fixture.agentDir);
+		vi.stubEnv("SENPI_CODING_AGENT_SESSION_DIR", join(fixture.root, "sessions"));
+		vi.stubEnv("PI_OFFLINE", "1");
+		const runtime = createAppServerRuntime(() => undefined);
+		const frames: RpcEnvelope[] = [];
+		runtime.core.addConnection({
+			id: "owner",
+			transportKind: "stdio",
+			send: (message) => {
+				frames.push(message);
+			},
+			close: () => undefined,
+		});
+		await request(runtime, "owner", 1, "initialize", {
+			clientInfo: { name: "owner", version: "1.0.0" },
+			capabilities: {},
+		});
+		await request(runtime, "owner", 2, "thread/start", { cwd: fixture.root });
+
+		const monitorStateEvents = frames.filter(
+			(frame) =>
+				"method" in frame &&
+				frame.method === "extension_event" &&
+				"params" in frame &&
+				frame.params !== null &&
+				typeof frame.params === "object" &&
+				"name" in frame.params &&
+				frame.params.name === "terminal_monitor_state",
+		);
+		expect(monitorStateEvents).toContainEqual(
+			expect.objectContaining({
+				method: "extension_event",
+				params: {
+					type: "extension_event",
+					name: "terminal_monitor_state",
+					data: {
+						activeCount: expect.any(Number),
+						monitors: expect.any(Array),
+					},
+					threadId: expect.any(String),
+				},
+			}),
+		);
+		runtime.dispose();
+	});
 });

--- a/packages/coding-agent/test/suite/app-server-extension-events.test.ts
+++ b/packages/coding-agent/test/suite/app-server-extension-events.test.ts
@@ -69,8 +69,19 @@ describe("app-server extension RPC events", () => {
 		// When: only the first client starts and subscribes to a thread.
 		await request(runtime, "first", 2, "thread/start", { cwd: fixture.root });
 
-		// Then: exactly one extension record reaches that owner and no unrelated client.
-		expect(firstFrames.filter((frame) => "method" in frame && frame.method === "extension_event")).toEqual([
+		// Then: the fixture session-start event reaches that owner and no unrelated client.
+		// Builtins may also emit on this path (e.g. empty terminal_monitor_state on bind).
+		const fixtureEvents = firstFrames.filter(
+			(frame) =>
+				"method" in frame &&
+				frame.method === "extension_event" &&
+				"params" in frame &&
+				frame.params !== null &&
+				typeof frame.params === "object" &&
+				"name" in frame.params &&
+				frame.params.name === "fixture.ready",
+		);
+		expect(fixtureEvents).toEqual([
 			expect.objectContaining({
 				method: "extension_event",
 				params: {

--- a/packages/coding-agent/test/suite/terminal-monitor-state-event.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-state-event.test.ts
@@ -75,4 +75,47 @@ describe("terminal monitor liveness event", () => {
 		}
 		expect(states.at(-1)).toEqual({ activeCount: 0, monitors: [] });
 	});
+
+	it("emits terminal_monitor_state over pi.rpc.emit when a monitor starts", async () => {
+		const rpcEvents: Array<{ name: string; data: unknown }> = [];
+		const harness = await createHarness({
+			extensionFactories: [registerTerminalExtension],
+		});
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		const unsubscribe = harness.getExtensionRunner().onRpcEvent((event) => {
+			rpcEvents.push(event);
+		});
+
+		try {
+			const started = await harness.session.executeTool("monitor", {
+				description: "rpc liveness test",
+				command: "sleep 30",
+				persistent: true,
+			});
+			const bashId = /bash_\d+/.exec(resultText(started))?.[0];
+			if (!bashId) throw new Error("Monitor did not return a bash id");
+
+			try {
+				expect(rpcEvents).toContainEqual({
+					name: "terminal_monitor_state",
+					data: {
+						activeCount: 1,
+						monitors: [
+							{
+								id: bashId,
+								description: "rpc liveness test",
+								paused: false,
+								startedAtMs: expect.any(Number),
+							},
+						],
+					},
+				});
+			} finally {
+				await harness.session.executeTool("kill_bash", { bash_id: bashId });
+			}
+		} finally {
+			unsubscribe();
+		}
+	});
 });


### PR DESCRIPTION
## What changed

The terminal builtin already published live monitor snapshots on the in-process `pi.events` channel `terminal_monitor_state` (`activeCount` plus per-watch `id` / `description` / `paused` / `startedAtMs`). That payload now also goes out through `pi.rpc.emit` on the same name, so JSONL RPC clients receive it inside the existing generic envelope:

```json
{ "type": "extension_event", "name": "terminal_monitor_state", "data": { "activeCount": 1, "monitors": [...] } }
```

The snapshot is factored into one local value so both sinks send byte-identical data. The in-process emit is kept: the goal builtin still consumes `pi.events`. No `AgentSessionEvent` / `RpcClientEvent` / schema change — this is an extension-owned event on the generic `extension_event` path. `connection-handler.ts` already forwards every `pi.rpc.emit`.

## Why the in-process event was insufficient

Ordinary `pi.events` channels are never forwarded over RPC or app-server (`docs/app-server.md`). Desktop and other RPC hosts therefore could not observe live monitors even though the snapshot already existed in-process. `pi.rpc.emit` is the sanctioned server-to-client extension-RPC path.

Clients receive this record **only when they advertise the `extension_events` capability**. Unflagged clients remain byte-identical.

## QA

```
# changelog / changes.md gate
node scripts/check-pr-changelog.mjs --base origin/main
# PASS - changes.md coverage complete (0 production path(s) covered); changelog entry updated (packages/coding-agent/CHANGELOG.md)

# repo check
npm run check
# biome: Checked 3368 files in 3s. No fixes applied.
# pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, tsc --noEmit, browser-smoke: exit 0

# new test, test-first
npm --prefix packages/coding-agent test -- test/suite/terminal-monitor-state-event.test.ts
# RED before the production edit:
#   FAIL  emits terminal_monitor_state over pi.rpc.emit when a monitor starts
#   AssertionError: expected [] to deep equally contain { Object (name, data) }
# GREEN after:
#   Test Files  1 passed (1)
#   Tests       2 passed (2)

# terminal + goal suites (goal is the in-process consumer)
npx vitest --run test/suite/terminal-*.test.ts test/suite/goal-*.test.ts
# (explicit file list, 40 files)
# Test Files  40 passed (40)
# Tests       406 passed (406)

# client-wire coverage (app-server)
# Temporarily commented out pi.rpc.emit(TERMINAL_MONITOR_STATE_EVENT, payload)
npm --prefix packages/coding-agent test -- test/suite/app-server-extension-events.test.ts
# RED:
#   FAIL  forwards terminal_monitor_state to the owning thread subscriber
#   AssertionError: expected [] to deep equally contain ObjectContaining{…}
#   Tests  1 failed | 1 passed (2)
# Restored the emit:
#   Test Files  1 passed (1)
#   Tests       2 passed (2)
```

No real provider was used; tests run on the faux-provider harness.

## Risks

CI shard `Test (coding-agent 3/3)` is red on a pre-existing flake, not this change:
`test/rpc-host-lifecycle.test.ts > does not exit while a turn is active ... exits after the turn settles`
(`RPC socket host pid ... did not exit within 20000ms`). That file does not mention terminal, monitor, or `rpc.emit`. The same assertion fails on `main` (run 33152599123). All other CI jobs on this PR are green, including coding-agent shards 1/3 and 2/3, static checks, and the changelog gate. This PR does not modify that test or host-lifecycle production code.
