### PR TITLE
fix(coding-agent): release a dropped connection's sessions on socket close

### DIFF
--- a/packages/coding-agent/src/modes/rpc/multi-session-host.ts
+++ b/packages/coding-agent/src/modes/rpc/multi-session-host.ts
@@ -143,6 +143,15 @@ async function runSocketHost(options: MultiSessionHostOptions, socketPath: strin
 			detachReader();
 			writer.unregisterConnection(id);
 			connections.delete(id);
+			// A socket that dies without close_session still owns its sessions' attachments
+			// and path reservations. Release them on the command chain so this runs after any
+			// in-flight command for this connection settles, otherwise the path stays pinned
+			// by a runtime whose client is gone and later resumes attach to that orphan.
+			commandChain = commandChain
+				.then(() => router.releaseConnection(id))
+				.catch((cause) => {
+					process.stderr.write(`senpi rpc connection ${id} release failed: ${errorMessage(cause)}\n`);
+				});
 		};
 		connections.set(id, { id, sink, detach, close: () => socket.destroy() });
 		socket.once("close", detach);

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -26,6 +26,8 @@ function error(id: string | undefined, command: string, code: string): RpcRespon
 /** Routes control messages and enforces a routing handle for every session command. */
 export class SessionCommandRouter {
 	private readonly bindings = new Map<string, RpcSessionBinding>();
+	/** Session handles opened by each connection, so a dropped socket releases exactly its own. */
+	private readonly sessionsByConnection = new Map<string, Set<string>>();
 	private readonly registry: RpcSessionRegistry;
 	private readonly writer: SessionEventWriter;
 	private readonly defaults: Pick<
@@ -125,6 +127,15 @@ export class SessionCommandRouter {
 			});
 			const openedSession = opened;
 			const entry = this.registry.getForCommand(openedSession.sessionId, "open_session");
+			// A client that dies without close_session (terminal closed, SIGKILL, dropped
+			// SSH) still holds this handle's attachment and its path reservation. Remember
+			// which connection owns it so releaseConnection() can close exactly that.
+			const owner = this.writer.currentConnection();
+			if (owner !== undefined) {
+				const owned = this.sessionsByConnection.get(owner) ?? new Set<string>();
+				owned.add(openedSession.sessionId);
+				this.sessionsByConnection.set(owner, owned);
+			}
 			this.bindings.set(
 				openedSession.sessionId,
 				await this.createBinding(
@@ -160,6 +171,32 @@ export class SessionCommandRouter {
 		}
 	}
 
+	/**
+	 * Releases every session a dropped connection still owned. Each handle goes through
+	 * the same refcounted close as an explicit close_session, so a session another
+	 * connection is still attached to keeps running and only the last owner tears it down.
+	 */
+	async releaseConnection(connectionId: string): Promise<void> {
+		const owned = this.sessionsByConnection.get(connectionId);
+		this.sessionsByConnection.delete(connectionId);
+		if (owned === undefined) return;
+		for (const sessionId of owned) {
+			let entry: RpcSessionEntry | undefined;
+			try {
+				entry = this.registry.beginClose(sessionId);
+			} catch {
+				// Already closed or claimed by another lifecycle path; nothing to release.
+				continue;
+			}
+			try {
+				await this.bindings.get(sessionId)?.dispose();
+			} finally {
+				this.bindings.delete(sessionId);
+				if (entry.state === "closing") await this.registry.closeMarked(sessionId);
+			}
+		}
+	}
+
 	private async close(command: Extract<RpcCommand, { type: "close_session" }>): Promise<RpcResponse | undefined> {
 		try {
 			// This must be the first operation: binding.dispose() awaits teardown and
@@ -169,6 +206,7 @@ export class SessionCommandRouter {
 				await this.bindings.get(command.sessionId)?.dispose();
 			} finally {
 				this.bindings.delete(command.sessionId);
+				for (const owned of this.sessionsByConnection.values()) owned.delete(command.sessionId);
 				// Other attachments may still own the live session; only the last
 				// close finalizes the runtime teardown.
 				if (entry.state === "closing") await this.registry.closeMarked(command.sessionId);

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -130,6 +130,11 @@ export class SessionEventWriter {
 		return this.connectionContext.run(id, task);
 	}
 
+	/** Connection id of the command currently being dispatched, when one owns it. */
+	currentConnection(): string | undefined {
+		return this.connectionContext.getStore();
+	}
+
 	/** Queue a session record. Lifecycle/events are broadcast; responses/UI are targeted. */
 	enqueue(sessionId: string, value: object): boolean {
 		if (this.sealedSessions.has(sessionId)) return false;

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -357,6 +357,96 @@ describe("RPC Unix-socket multi-connection host", () => {
 			await fake.close();
 		}
 	});
+	it("releases a dropped connection's session so the same path reopens fresh", async () => {
+		const qa = scratch("drop-release");
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const child = spawnRpc(
+			["--mode", "rpc", "--listen", `unix://${qa.socketPath}`, "--provider", MOCK_PROVIDER, "--model", MOCK_MODEL],
+			qa,
+		);
+		await waitForStderr(child, `senpi rpc listening on unix://${qa.socketPath}`);
+		const sessionPath = join(qa.sessionDir, "dropped.jsonl");
+		const first = await connectPeer(qa.socketPath);
+		try {
+			const opened = await first.peer.request({ id: "open-1", type: "open_session", cwd: qa.cwd, sessionPath });
+			expect(opened).toMatchObject({ success: true });
+			expect((opened.data as RecordValue | undefined)?.attached ?? false).toBe(false);
+
+			// Ungraceful drop: the terminal closed / the client was SIGKILLed, so no
+			// close_session ever arrives. The host must still release what this
+			// connection held, otherwise the path stays reserved by a runtime whose
+			// client is gone and every later resume of it is wrong.
+			first.peer.close();
+			first.socket.destroy();
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		} finally {
+			first.socket.destroy();
+		}
+
+		const second = await connectPeer(qa.socketPath);
+		try {
+			const reopened = await second.peer.request({ id: "open-2", type: "open_session", cwd: qa.cwd, sessionPath });
+			expect(reopened).toMatchObject({ success: true });
+			// A fresh open, NOT an attach to the orphaned runtime.
+			expect((reopened.data as RecordValue | undefined)?.attached ?? false).toBe(false);
+			await expect(
+				second.peer.request({ id: "close-2", type: "close_session", sessionId: openedSessionId(reopened) }),
+			).resolves.toMatchObject({ success: true });
+		} finally {
+			second.peer.close();
+			second.socket.destroy();
+			await fake.close();
+			await stopChild(child);
+		}
+	});
+
+	it("keeps a co-attached session alive when one of its connections drops", async () => {
+		const qa = scratch("drop-survivor");
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const child = spawnRpc(
+			["--mode", "rpc", "--listen", `unix://${qa.socketPath}`, "--provider", MOCK_PROVIDER, "--model", MOCK_MODEL],
+			qa,
+		);
+		await waitForStderr(child, `senpi rpc listening on unix://${qa.socketPath}`);
+		const sessionPath = join(qa.sessionDir, "shared.jsonl");
+		const holder = await connectPeer(qa.socketPath);
+		const dropper = await connectPeer(qa.socketPath);
+		try {
+			const held = await holder.peer.request({ id: "open-hold", type: "open_session", cwd: qa.cwd, sessionPath });
+			expect(held).toMatchObject({ success: true });
+			const heldId = openedSessionId(held);
+
+			const attached = await dropper.peer.request({
+				id: "open-attach",
+				type: "open_session",
+				cwd: qa.cwd,
+				sessionPath,
+			});
+			expect(attached).toMatchObject({ success: true });
+			expect((attached.data as RecordValue | undefined)?.attached).toBe(true);
+
+			// Only the second attachment dies. The runtime is refcounted, so the
+			// holder must keep serving commands on its own handle.
+			dropper.peer.close();
+			dropper.socket.destroy();
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			await expect(
+				holder.peer.request({ id: "probe-hold", type: "get_protocol_info", sessionId: heldId }),
+			).resolves.toMatchObject({ success: true });
+			await expect(
+				holder.peer.request({ id: "close-hold", type: "close_session", sessionId: heldId }),
+			).resolves.toMatchObject({ success: true });
+		} finally {
+			holder.peer.close();
+			holder.socket.destroy();
+			dropper.socket.destroy();
+			await fake.close();
+			await stopChild(child);
+		}
+	});
 });
 
 async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {


### PR DESCRIPTION
## Problem

A client that dies without `close_session` — terminal closed, `SIGKILL`, dropped SSH — left its session entry in `state: "open"` holding its path reservation and attachments. `detach()` on socket close only removed the reader and the connection record; nothing released the handles that connection owned, so the refcounted teardown never reached zero.

- On **2026.8.27** (no attach path) the orphaned reservation then **blocked every resume of that path** with `session_path_in_use` — the "resume도 안됨" regression that pushed users back to beta.22.
- On **2026.8.28** resume attaches, but to a runtime whose client is gone, and the leak still accumulates.

Root cause, all in the shipped tag:
- `multi-session-host.ts` `runSocketHost`: `socket.once("close", detach)` where `detach()` does only `detachReader()` + `writer.unregisterConnection(id)` + `connections.delete(id)`.
- `session-command-router.ts`: `bindings` is host-global with no connection key; `router.dispose()` runs only at whole-host shutdown.
- The client releases only on the graceful path (`interactive-host-runtime.ts` `dispose()` → `closeSession()`).

## Fix

The host now tags each opened handle with the connection that opened it and, on socket close, replays the **same refcounted close** for exactly those handles — on that connection's command chain, so the release runs after any in-flight command for that connection settles.

- `session-event-writer.ts`: `currentConnection()` exposes the `AsyncLocalStorage` connection id already populated by `withConnection` around every dispatch.
- `session-command-router.ts`: a `sessionsByConnection` map records handle→owner at `open()`; `releaseConnection(id)` replays `beginClose` → `binding.dispose()` → `closeMarked`-if-last per owned handle; graceful `close()` drops its ownership record so a later disconnect never double-closes.
- `multi-session-host.ts`: `detach()` enqueues `router.releaseConnection(id)` on the connection's `commandChain`.

No new lifecycle logic is invented — the release reuses the existing `beginClose`/`closeMarked` refcount semantics exactly, so a session another connection is still attached to keeps running and only the last owner's drop tears the runtime down.

## QA

Regression coverage in `test/rpc-socket-host.test.ts` drives the **real socket host over a unix socket** (reusing the existing `JsonlPeer`/`spawnRpc`/`connectPeer` harness):

| Test | Behavior | RED → GREEN |
|---|---|---|
| `releases a dropped connection's session so the same path reopens fresh` | ungraceful `socket.destroy()` with no `close_session`, then reopen same path | RED: `attached` was `true` (attached to orphan) → GREEN: fresh open, `attached` false |
| `keeps a co-attached session alive when one of its connections drops` | two connections attached, one drops | GREEN (characterization held): survivor keeps serving on its handle, runtime not disposed |

- `npm --prefix packages/coding-agent test -- test/rpc-socket-host.test.ts` → **6 passed**
- `test/rpc-open-session-resume.test.ts` + `test/rpc-session-registry.test.ts` → **25 passed** (graceful close semantics + reservation release unchanged)
- `npm run check` → exit 0

## Notes

- The `opening`/`closing` transitional-state rejection (a resume racing startup/teardown) is intentionally unchanged — that is a separate, narrower concern from the leak fixed here.
- This is the root cause behind the beta.23 resume regression; it ships as part of the next engine release.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a leak where a client disconnecting without `close_session` left its session open, pinning the session path and attachments so later resumes attached to an orphaned runtime. The host now tracks which connection owns each session handle and releases them on socket close, replaying the same refcounted teardown used by graceful closes. A session with another connection still attached stays alive; only the last owner's drop tears it down.

**Bug Fixes**
- Records handle ownership at `open_session` and releases them on socket close via the connection's command chain.
- Removes ownership on graceful `close_session` so a later disconnect never double-closes.
- Adds regression tests covering ungraceful drop + reopen and co-attached survivor behavior.

<sup>Written for commit 7ace9b6461af6c163027cdd3981881700bada16f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

