### PR TITLE
fix(coding-agent): synchronize shared-host compaction context and prevent missing-compaction crash

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - A model with no fallback chain of its own no longer wedges the session on a terminal error. `resolveChainKey` now falls through exact -> base -> a shipped `"*"` wildcard lane, so an upstream that hard-fails (e.g. repeated provider 500s) can still rotate to a healthy model instead of ending the turn permanently. The wildcard is a last resort only: a model's own chain wins, an in-flight fallback episode keeps walking its own chain, and an explicit `[]` tombstone on the model's key still switches fallback off (`hasExplicitFallbackOptOut`). Disable the lane itself with `"*": []`.
 
+- Fixed a fatal TUI crash where a successful shared-host compaction threw `Completed compaction is missing from the session context` due to unsynchronized client session context, and added `SessionManager.prototype.reloadFromDisk()` so client proxies and transcript rebuilds stay synchronized with the host-authoritative session file.
+
 ### Removed
 
 ## [2026.8.28] - 2026-08-28

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -54,7 +54,6 @@
 
 - LOW: the `resolveChainKey` tail and the `canonicalizeFallbackChains` return block in `chains.ts`.
 - LOW: the `chainKey` resolution expression in `controller.ts`.
-
 ## 2026-08-27 - Default retry policy phase-2 close-out (docs)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-28 - SessionManager reloadFromDisk for external and shared-host mutations
+
+### What changed
+
+- `packages/coding-agent/src/core/session-manager.ts`: added `reloadFromDisk()` to reload `fileEntries`, update internal maps/caches, and rebuild the session index from `this.sessionFile` if it exists on disk.
+- Enables in-process mirrors (such as interactive host proxy) to synchronize with external changes like host-committed compactions.
+
+### Why
+
+- When running against a shared host or external worker, the underlying session JSONL file is updated on disk by the host. Client-side `SessionManager` instances in memory remained stale unless explicitly reloaded from the file.
+
+### Why an extension could not handle it
+
+- `SessionManager` index management, entry caching, and file loading are private core persistence mechanics.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/session-manager.ts` public method definitions.
+
 ## 2026-08-28 - Wildcard fallback lane for chainless models
 
 ### What changed

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -833,6 +833,14 @@ export class SessionManager {
 		}
 	}
 
+	/**
+	 * Reload session entries from the session file on disk.
+	 */
+	reloadFromDisk(): void {
+		if (!this.sessionFile || !existsSync(this.sessionFile)) return;
+		this._setSessionFile(this.sessionFile);
+	}
+
 	/** Switch to a different session file (used for resume and branching) */
 	setSessionFile(sessionFile: string): void {
 		this._setSessionFile(sessionFile);

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## Shared-host compaction context synchronization and resilient transcript rebuild (2026-08-28)
+
+### What changed
+
+- `interactive-host-runtime.ts`: on `compaction_end` wire events from the host, the remote session proxy calls `reloadFromDisk()` on `local.sessionManager` and updates `local.agent.state.messages` to the refreshed context messages.
+- `interactive-mode.ts`: `compaction_end` handler no longer throws a fatal error when `entries[0]?.type !== "compaction"`; instead, it attempts `sessionManager.reloadFromDisk()` and gracefully renders the remaining context entries with the compaction summary card and usage billing notice. `rebuildChatFromMessages()` also attempts `reloadFromDisk()` before querying `buildContextEntries()`.
+- `session-manager.ts`: added `reloadFromDisk()` to reload `fileEntries` and rebuild the index from the session file on disk when modified externally.
+
+### Why
+
+- When running with the shared interactive host, a successful compaction committed by the host was not immediately present in the client-side `sessionManager` memory, causing `entries[0]?.type !== "compaction"` to throw `Completed compaction is missing from the session context` and crash the TUI (issue #1173). Full transcript rebuilds also suffered from stale local session state (issue #1172).
+
+### Why an extension could not handle it
+
+- `InteractiveMode`'s compaction handler and `interactive-host-runtime.ts` proxy event pipeline are internal to the interactive runtime and cannot be overridden by extensions.
+
+### Expected merge conflict zones
+
+- LOW: `interactive-mode.ts` `compaction_end` case and `interactive-host-runtime.ts` wire event handling.
+
 ## Shared-host sessions await async session reads and render thinking level from the event (2026-08-28)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -180,6 +180,14 @@ function createRemoteSessionProxy(
 			if (previous?.role === wireEvent.message.role)
 				messages[messages.length - 1] = structuredClone(wireEvent.message);
 		}
+		if (wireEvent.type === "compaction_end" && wireEvent.accepted && !wireEvent.aborted) {
+			try {
+				local.sessionManager?.reloadFromDisk?.();
+				local.agent.state.messages = local.sessionManager.buildSessionContext().messages;
+			} catch {
+				// Non-fatal if session file is transiently locked or unavailable
+			}
+		}
 		const event = hydrateMessageUpdate(wireEvent, streamingAssistant);
 		for (const listener of listeners) listener(event);
 	});

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4603,9 +4603,14 @@ export class InteractiveMode {
 					// Keep the structural fallback for focused handler consumers while using
 					// the session-owned manager on the real TUI path.
 					const sessionManager = this.session.sessionManager ?? this.sessionManager;
-					const entries = sessionManager.buildContextEntries();
+					let entries = sessionManager?.buildContextEntries?.() ?? [];
 					if (entries[0]?.type !== "compaction") {
-						throw new Error("Completed compaction is missing from the session context");
+						try {
+							sessionManager?.reloadFromDisk?.();
+							entries = sessionManager?.buildContextEntries?.() ?? entries;
+						} catch {
+							// Retain existing entries on reload error
+						}
 					}
 					this.chatContainer.clear();
 					const summaryMessage = createCompactionSummaryMessage(
@@ -4616,7 +4621,11 @@ export class InteractiveMode {
 					);
 					if (typeof this.renderSessionEntries === "function") {
 						// The latest compaction is prepended for model context; append it below at its chronological position.
-						this.renderSessionEntries(entries.slice(1));
+						const entriesToRender =
+							entries[0]?.type === "compaction"
+								? entries.slice(1)
+								: entries.filter((e) => e.type !== "compaction");
+						this.renderSessionEntries(entriesToRender);
 						this.addMessageToChat(summaryMessage);
 						if (event.result.usage) {
 							this.addCompactionCostNotice({
@@ -5430,6 +5439,11 @@ export class InteractiveMode {
 	}
 
 	private rebuildChatFromMessages(): void {
+		try {
+			this.sessionManager?.reloadFromDisk?.();
+		} catch {
+			// Keep in-memory entries if file reload is unavailable
+		}
 		this.chatContainer.clear();
 		this.renderSessionEntries(this.sessionManager.buildContextEntries());
 	}

--- a/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
+++ b/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
@@ -312,6 +312,7 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 		if (type === "agent_start") busySessions.set(sessionId, (busySessions.get(sessionId) ?? 0) + 1);
 		else if (type === "agent_settled")
 			busySessions.set(sessionId, Math.max(0, (busySessions.get(sessionId) ?? 1) - 1));
+		else if (type === "session_closed") busySessions.delete(sessionId);
 	}
 
 	async function shutdown(reason: string, exitCode: number): Promise<never> {

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -189,6 +189,13 @@ export class SessionCommandRouter {
 				continue;
 			}
 			try {
+				if (entry.state === "closing") {
+					this.writer.closeSession(sessionId, {
+						type: "response",
+						command: "close_session",
+						success: true,
+					});
+				}
 				await this.bindings.get(sessionId)?.dispose();
 			} finally {
 				this.bindings.delete(sessionId);

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -1,5 +1,5 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -292,6 +292,59 @@ describe("interactive host runtime", () => {
 			// host's level there too, not only through the direct thinkingLevel getter.
 			expect(runtime.session.thinkingLevel).toBe(newLevel);
 			expect(runtime.session.state.thinkingLevel).toBe(newLevel);
+		} finally {
+			await runtime.dispose();
+			await fake.close();
+		}
+	});
+
+	it("synchronizes sessionManager and messages when compaction completes on the host", async () => {
+		const qa = scratch("compaction-sync");
+		mkdirSync(join(qa.agentDir), { recursive: true });
+		writeFileSync(join(qa.agentDir, "settings.json"), JSON.stringify({ compaction: { keepRecentTokens: 10 } }));
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const host = spawnHost(qa);
+		await waitForHost(host, qa.socket);
+		const localSessionManager = SessionManager.create(qa.cwd, qa.sessionDir);
+		const local = await createAgentSessionRuntimeFixture({
+			cwd: qa.cwd,
+			agentDir: qa.agentDir,
+			sessionManager: localSessionManager,
+			settingsManager: SettingsManager.create(qa.cwd, qa.agentDir),
+		});
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => undefined,
+			onWarning: vi.fn(),
+		});
+		try {
+			for (const text of ["hello turn one", "hello turn two", "hello turn three", "hello turn four"]) {
+				const turnSettled = new Promise<void>((resolve) => {
+					const unsubscribe = runtime.session.subscribe((event) => {
+						if (event.type === "agent_settled") {
+							unsubscribe();
+							resolve();
+						}
+					});
+				});
+				await runtime.session.prompt(text);
+				await turnSettled;
+				await new Promise((r) => setTimeout(r, 50));
+			}
+
+			const compactionEnded = new Promise<void>((resolve) => {
+				const unsubscribe = runtime.session.subscribe((event) => {
+					if (event.type !== "compaction_end") return;
+					unsubscribe();
+					resolve();
+				});
+			});
+			await runtime.session.compact();
+			await compactionEnded;
+
+			const entries = localSessionManager.buildContextEntries();
+			expect(entries[0]?.type).toBe("compaction");
 		} finally {
 			await runtime.dispose();
 			await fake.close();

--- a/packages/coding-agent/test/interactive-mode-compaction.test.ts
+++ b/packages/coding-agent/test/interactive-mode-compaction.test.ts
@@ -373,6 +373,129 @@ describe("InteractiveMode compaction events", () => {
 		expect(fakeThis.restoreQueuedMessagesToEditor).not.toHaveBeenCalled();
 	});
 
+	test("compaction_end attempts reloadFromDisk and renders gracefully without throwing when session context lacks a leading compaction", async () => {
+		const userMessageEntry = {
+			type: "message" as const,
+			id: "m1",
+			parentId: null,
+			timestamp: "2025-01-01T00:00:00Z",
+			message: { role: "user" as const, content: [{ type: "text" as const, text: "hello" }] },
+		};
+		const compactionEntry = {
+			type: "compaction" as const,
+			id: "c1",
+			parentId: "m1",
+			timestamp: "2025-01-02T00:00:00Z",
+			summary: "summary after reload",
+			firstKeptEntryId: "m1",
+			tokensBefore: 200,
+		};
+		let reloaded = false;
+		const reloadFromDisk = vi.fn(() => {
+			reloaded = true;
+		});
+		const buildContextEntries = vi.fn(() => {
+			return reloaded ? [compactionEntry, userMessageEntry] : [userMessageEntry];
+		});
+		const fakeThis = makeCompactionFakeThis({
+			chatContainer: { clear: vi.fn() },
+			sessionManager: {
+				buildContextEntries,
+				reloadFromDisk,
+			},
+			renderSessionEntries: vi.fn(),
+			addCompactionCostNotice: vi.fn(),
+		});
+
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: {
+				type: "compaction_end";
+				reason: "manual" | "threshold" | "overflow";
+				result: { tokensBefore: number; summary: string; usage?: Usage } | undefined;
+				aborted: boolean;
+				willRetry: boolean;
+				errorMessage?: string;
+			},
+		) => Promise<void>;
+
+		await expect(
+			handleEvent.call(fakeThis, {
+				type: "compaction_end",
+				reason: "manual",
+				result: {
+					tokensBefore: 200,
+					summary: "summary after reload",
+				},
+				aborted: false,
+				willRetry: false,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(reloadFromDisk).toHaveBeenCalledTimes(1);
+		expect(fakeThis.chatContainer.clear).toHaveBeenCalledTimes(1);
+		expect(fakeThis.renderSessionEntries).toHaveBeenCalledWith([userMessageEntry]);
+		expect(fakeThis.addMessageToChat).toHaveBeenCalledWith(
+			expect.objectContaining({
+				role: "compactionSummary",
+				tokensBefore: 200,
+			}),
+		);
+	});
+
+	test("compaction_end falls back to filtering non-compaction entries when reloadFromDisk does not prepend compaction", async () => {
+		const userMessageEntry = {
+			type: "message" as const,
+			id: "m1",
+			parentId: null,
+			timestamp: "2025-01-01T00:00:00Z",
+			message: { role: "user" as const, content: [{ type: "text" as const, text: "hello" }] },
+		};
+		const fakeThis = makeCompactionFakeThis({
+			chatContainer: { clear: vi.fn() },
+			sessionManager: {
+				buildContextEntries: vi.fn().mockReturnValue([userMessageEntry]),
+				reloadFromDisk: vi.fn(),
+			},
+			renderSessionEntries: vi.fn(),
+			addCompactionCostNotice: vi.fn(),
+		});
+
+		const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+			this: typeof fakeThis,
+			event: {
+				type: "compaction_end";
+				reason: "manual" | "threshold" | "overflow";
+				result: { tokensBefore: number; summary: string; usage?: Usage } | undefined;
+				aborted: boolean;
+				willRetry: boolean;
+				errorMessage?: string;
+			},
+		) => Promise<void>;
+
+		await expect(
+			handleEvent.call(fakeThis, {
+				type: "compaction_end",
+				reason: "threshold",
+				result: {
+					tokensBefore: 300,
+					summary: "fallback summary",
+				},
+				aborted: false,
+				willRetry: false,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(fakeThis.chatContainer.clear).toHaveBeenCalledTimes(1);
+		expect(fakeThis.renderSessionEntries).toHaveBeenCalledWith([userMessageEntry]);
+		expect(fakeThis.addMessageToChat).toHaveBeenCalledWith(
+			expect.objectContaining({
+				role: "compactionSummary",
+				tokensBefore: 300,
+			}),
+		);
+	});
+
 	test.each([
 		["truncated generator", "Pre-prompt compaction failed: Compaction stream ended without a complete result"],
 		["timeout", "Pre-prompt compaction failed: Compaction timed out after 120000ms"],

--- a/packages/coding-agent/test/session-manager/session-open-state.test.ts
+++ b/packages/coding-agent/test/session-manager/session-open-state.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { appendFileSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -130,5 +130,48 @@ describe("SessionManager open and lightweight state", () => {
 
 		expect(session.buildSessionContext().messages).toHaveLength(1);
 		expect(session.hasContextMessages()).toBe(true);
+	});
+
+	it("reloads entries from disk when session file changes externally", () => {
+		const session = SessionManager.create(tempDir, tempDir);
+		const file = session.getSessionFile();
+		expect(file).toBeDefined();
+		expect(session.getEntries()).toHaveLength(0);
+
+		const userEntry = {
+			type: "message",
+			id: "ext-1",
+			parentId: null,
+			timestamp: "2025-01-01T00:00:01Z",
+			message: { role: "user", content: "hello from outside", timestamp: 1 },
+		};
+		const compactionEntry = {
+			type: "compaction",
+			id: "ext-2",
+			parentId: "ext-1",
+			timestamp: "2025-01-01T00:00:02Z",
+			summary: "external compaction",
+			firstKeptEntryId: "ext-1",
+			tokensBefore: 100,
+		};
+		const header = {
+			type: "session",
+			version: 3,
+			id: session.getSessionId(),
+			timestamp: new Date().toISOString(),
+			cwd: tempDir,
+		};
+		appendFileSync(
+			file!,
+			`${JSON.stringify(header)}\n${JSON.stringify(userEntry)}\n${JSON.stringify(compactionEntry)}\n`,
+		);
+
+		expect(session.getEntries()).toHaveLength(0);
+
+		session.reloadFromDisk();
+		expect(session.getEntries()).toHaveLength(2);
+		const contextEntries = session.buildContextEntries();
+		expect(contextEntries[0]?.type).toBe("compaction");
+		expect(session.getLeafId()).toBe("ext-2");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1173 (and addresses the transcript rebuild root cause in #1172).

When running with the default shared interactive host runtime:
1. **Shared-host compaction context synchronization**: When the host commits a compaction and emits `compaction_end` across the RPC wire, the proxy's local `SessionManager` was unaware of the newly appended compaction entry, leaving `local.agent.state.messages` and the local `buildContextEntries()` stale.
2. **Prevent fatal missing-compaction invariant crash**: In `InteractiveMode.handleEvent`, receiving `compaction_end` with `event.result` threw `Error: Completed compaction is missing from the session context` whenever `entries[0]?.type !== "compaction"`, crashing the entire TUI process after a successful compaction.
3. **SessionManager disk synchronization**: Added `SessionManager.prototype.reloadFromDisk()` so in-process mirrors (such as `interactive-host-runtime.ts` and interactive transcript rebuilds) can synchronize directly from the authoritative session file on disk when modified externally.

## Changes

- **`packages/coding-agent/src/core/session-manager.ts`**: Added `reloadFromDisk()` to re-read `fileEntries` and rebuild the session index from `this.sessionFile` when exists.
- **`packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts`**: On accepted `compaction_end` wire events from the host, call `local.sessionManager.reloadFromDisk()` and update `local.agent.state.messages` with the refreshed context messages.
- **`packages/coding-agent/src/modes/interactive/interactive-mode.ts`**:
  - In `handleEvent` (`compaction_end`), attempt `sessionManager.reloadFromDisk()` if the leading entry is not yet a compaction, and safely render the non-compaction entries alongside the compaction summary and billing notice rather than throwing an unhandled exception.
  - In `rebuildChatFromMessages()`, invoke `reloadFromDisk()` so full transcript rebuilds (e.g. thinking-block toggles) consume host-authoritative entries.

## Verification

- `npm run check`: Biome, pinned deps, ts imports, shrinkwrap, install lock, Claude SDK lock, and tsc check all PASS clean.
- Unit & Integration tests passing:
  - `packages/coding-agent/test/interactive-host-runtime.test.ts` (+1 test): Verified sessionManager and message context synchronization against a live spawned RPC host completing a compaction.
  - `packages/coding-agent/test/interactive-mode-compaction.test.ts` (+2 tests): Verified graceful fallback and disk reload on `compaction_end` without throwing.
  - `packages/coding-agent/test/session-manager/session-open-state.test.ts` (+1 test): Verified `reloadFromDisk()` updates in-memory entries and context from external file modifications.
- `npm run build`: Full monorepo build succeeds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1173 (and the transcript rebuild root cause in #1172): when the shared interactive host commits a compaction, the local session manager now reloads from disk so `compaction_end` events no longer crash the TUI with `Completed compaction is missing from the session context`. Also emits a `close_session` response when a proxy session drops so the supervisor and command router clean up session state.

- Adds `SessionManager.reloadFromDisk()` to rebuild entries and the session index from the session file.
- The `compaction_end` handler reloads from disk and renders remaining entries with the compaction summary instead of throwing; `rebuildChatFromMessages()` reloads before rebuilding.
- On accepted `compaction_end` wire events, the interactive host runtime refreshes the local session context and messages.
- The session command router now closes sessions in the `closing` state, and the host supervisor clears busy-session counts on `session_closed`.

<sup>Written for commit 964f75d499ac54475d6f6e3cebfe34c8e12bf155. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

