### PR TITLE
fix(retry-fallback): give chainless models a wildcard escape lane

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- A model with no fallback chain of its own no longer wedges the session on a terminal error. `resolveChainKey` now falls through exact -> base -> a shipped `"*"` wildcard lane, so an upstream that hard-fails (e.g. repeated provider 500s) can still rotate to a healthy model instead of ending the turn permanently. The wildcard is a last resort only: a model's own chain wins, an in-flight fallback episode keeps walking its own chain, and an explicit `[]` tombstone on the model's key still switches fallback off (`hasExplicitFallbackOptOut`). Disable the lane itself with `"*": []`.
+
 ### Removed
 
 ## [2026.8.28] - 2026-08-28

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,41 @@
 # changes
 
+## 2026-08-28 - Wildcard fallback lane for chainless models
+
+### What changed
+
+- `packages/coding-agent/src/core/retry-fallback/chains.ts`: added the `WILDCARD_CHAIN_KEY` (`"*"`),
+  taught `canonicalizeFallbackChains` to expand and tombstone it (both existing loops skip it because
+  it is not a model selector), gave `resolveChainKey` an opt-in `allowWildcard` fallthrough, and added
+  `hasExplicitFallbackOptOut` so a `[]` tombstone on the current model's exact/base/bare-family key
+  suppresses the lane.
+- `packages/coding-agent/src/core/retry-fallback/settings.ts`: `DEFAULT_FALLBACK_CHAINS` ships a `"*"`
+  lane mirroring the Fable default rungs.
+- `packages/coding-agent/src/core/retry-fallback/controller.ts`: `nextCandidate` resolves in the order
+  own chain -> active episode's `chainKey` -> wildcard (gated on the opt-out check).
+
+### Why
+
+- Desktop thread 487d7c29 (2026-08-28) burned nine consecutive turns on upstream 500s from
+  `apitopia/kimi-k3-unlocked` with zero fallback attempts and wedged terminal `error`; a manual model
+  switch recovered it instantly. `DEFAULT_FALLBACK_CHAINS` only keyed `claude-fable-5`, so the
+  manually selected model resolved no chain and `canTryFallback()` was permanently false.
+- Ordering is load-bearing: an unconditional wildcard fallthrough hijacked sessions already walking a
+  configured chain (their last rung usually has no key either), which the engine suite caught as a
+  7 -> 5 call-count regression.
+- The opt-out gate exists because canonicalization deletes tombstoned keys, which would otherwise let
+  the shipped wildcard silently resurrect fallback for a user who explicitly disabled it.
+
+### Why an extension could not handle it
+
+- Chain resolution and candidate selection are private `RetryFallbackController` state; extensions see
+  fallback events only after the core has already decided not to rotate.
+
+### Expected merge conflict zones
+
+- LOW: the `resolveChainKey` tail and the `canonicalizeFallbackChains` return block in `chains.ts`.
+- LOW: the `chainKey` resolution expression in `controller.ts`.
+
 ## 2026-08-27 - Default retry policy phase-2 close-out (docs)
 
 ### What changed

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -127,6 +127,46 @@ export function baseSelector(selector: Pick<FallbackSelector, "provider" | "id">
  * Provider-qualified keys and entries keep exact semantics, and an explicit key
  * always overrides the expansion it collides with.
  */
+/**
+ * Chain key matched when no exact or base key resolves for the current model.
+ * Exists so a model without its own configured chain still has an escape lane:
+ * without it, a hard-failing upstream wedges the session terminal even though
+ * healthy fallback targets exist (desktop thread 487d7c29, 2026-08-28: nine
+ * consecutive upstream 500s, zero fallback attempts, terminal error).
+ * Users disable it with the `"*": []` tombstone.
+ */
+export const WILDCARD_CHAIN_KEY = "*";
+
+/**
+ * Whether the user explicitly switched fallback OFF for this model with the
+ * documented `[]` tombstone (exact key, base key, or a bare family key that
+ * covers it). The shipped wildcard lane must never resurrect fallback against
+ * that instruction, so the wildcard gate consults this first.
+ *
+ * Bare-family matching is deliberately conservative: an ambiguous match
+ * suppresses the wildcard rather than overriding an explicit opt-out, because a
+ * surprising extra fallback hop is worse than a missing convenience lane.
+ */
+export function hasExplicitFallbackOptOut(
+	chains: FallbackChains,
+	currentModel: Model<Api>,
+	currentThinking: ThinkingLevel | undefined,
+): boolean {
+	const base = formatSelector(currentModel).toLowerCase();
+	const exact = currentThinking ? `${base}:${currentThinking}`.toLowerCase() : base;
+	const modelId = currentModel.id.toLowerCase();
+	for (const [key, entries] of Object.entries(chains)) {
+		if (!Array.isArray(entries) || !isChainTombstone(entries)) continue;
+		if (key === WILDCARD_CHAIN_KEY) continue;
+		const normalizedKey = key.trim().toLowerCase();
+		const keyBase = normalizedBase(normalizedKey);
+		if (keyBase === base || normalizedKey === exact) return true;
+		// Bare family key (no provider prefix): treat an id match as covering.
+		if (!normalizedKey.includes("/") && (keyBase === modelId || modelId.startsWith(`${keyBase}-`))) return true;
+	}
+	return false;
+}
+
 export function canonicalizeFallbackChains(chains: FallbackChains, lookup: FallbackModelLookup): FallbackChains {
 	const models = availableModels(lookup);
 	const tiers = authTiers(lookup);
@@ -186,6 +226,17 @@ export function canonicalizeFallbackChains(chains: FallbackChains, lookup: Fallb
 		if (tombstones.has(normalizedBase(key))) delete canonical[key];
 	}
 
+	// The wildcard key is not a model selector, so both loops above skip it.
+	// Its entries expand exactly like any other chain; a `[]` tombstone removes
+	// the lane entirely. Self-selection of the failing model is prevented at
+	// candidate time (nextCandidate's "self" skip), not here, because the
+	// wildcard has no key selector to filter against.
+	const wildcardEntries = chains[WILDCARD_CHAIN_KEY];
+	if (Array.isArray(wildcardEntries) && !isChainTombstone(wildcardEntries)) {
+		const canonicalEntries = expandEntries(wildcardEntries, WILDCARD_CHAIN_KEY);
+		if (canonicalEntries.length > 0) canonical[WILDCARD_CHAIN_KEY] = canonicalEntries;
+	}
+
 	return canonical;
 }
 
@@ -193,11 +244,18 @@ export function resolveChainKey(
 	currentModel: Model<Api>,
 	currentThinking: ThinkingLevel | undefined,
 	chains: FallbackChains,
+	options?: { allowWildcard?: boolean },
 ): string | undefined {
 	const base = formatSelector(currentModel);
 	const exact = currentThinking ? `${base}:${currentThinking}` : base;
 	if (Object.hasOwn(chains, exact)) return exact;
-	return Object.hasOwn(chains, base) ? base : undefined;
+	if (Object.hasOwn(chains, base)) return base;
+	// The wildcard is opt-in per call site: it is a last resort for a model with
+	// no chain of its own, and it must never hijack a session already walking a
+	// configured chain (the last rung of that chain usually has no key either).
+	// nextCandidate consults the active episode's chainKey before asking for it.
+	if (!options?.allowWildcard) return undefined;
+	return Object.hasOwn(chains, WILDCARD_CHAIN_KEY) ? WILDCARD_CHAIN_KEY : undefined;
 }
 
 function formatParsedSelector(selector: FallbackSelector): string {

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -5,6 +5,7 @@ import {
 	candidatesAfter,
 	canonicalizeFallbackChains,
 	type FallbackChains,
+	hasExplicitFallbackOptOut,
 	type FallbackSelector,
 	formatSelector,
 	parseFallbackSelector,
@@ -202,7 +203,15 @@ export class RetryFallbackController {
 		const current = this.deps.getCurrentSelector();
 		if (!settings.modelFallback || !current) return undefined;
 		const chains = this.canonicalChains();
-		const chainKey = resolveChainKey(current.model, current.thinkingLevel, chains) ?? this.state?.chainKey;
+		// Order matters: a model's own chain wins, then the active episode keeps
+		// owning its walk (its last rung usually has no key of its own), and only
+		// a session with neither falls back to the wildcard lane.
+		const chainKey =
+			resolveChainKey(current.model, current.thinkingLevel, chains) ??
+			this.state?.chainKey ??
+			(hasExplicitFallbackOptOut(settings.chains, current.model, current.thinkingLevel)
+				? undefined
+				: resolveChainKey(current.model, current.thinkingLevel, chains, { allowWildcard: true }));
 		const entries = chainKey ? chains[chainKey] : undefined;
 		if (!chainKey || !entries) {
 			if (reserve) this.deps.logger.debug("no_chain", { selector: formatSelector(current.model) });

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -39,6 +39,15 @@ export const DEFAULT_FALLBACK_CHAINS: FallbackChains = {
 	// vendor-prefixed id `kimi-k3` (e.g. OpenCode Go), which the conservative `k3`
 	// family matcher intentionally cannot capture (issue #793).
 	"claude-fable-5": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
+	// Last-resort lane for models with no chain of their own. resolveChainKey
+	// falls through exact -> base -> "*", so any current model whose upstream
+	// hard-fails can still escape instead of wedging the session terminal
+	// (desktop thread 487d7c29, 2026-08-28: nine consecutive upstream 500s on a
+	// chainless model, zero fallback attempts). Same lane order as the Fable
+	// default: cheap family escape first, then the Opus tiers. The candidate
+	// walk skips the failing model itself ("self"), tried selectors, cooldowns,
+	// and unauthenticated providers. Disable with the `"*": []` tombstone.
+	"*": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 };
 
 function cloneDefaultFallbackChains(): Record<string, readonly string[]> {

--- a/packages/coding-agent/test/agent-session-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-retry.test.ts
@@ -107,7 +107,13 @@ describe("AgentSession retry", () => {
 		const settingsManager = SettingsManager.create(tempDir, tempDir);
 		const authStorage = AuthStorage.create(join(tempDir, "auth.json"));
 		const modelRegistry = await createAuthenticatedModelRegistry(authStorage, tempDir);
-		settingsManager.applyOverrides({ retry: { enabled: true, maxRetries, baseDelayMs: 1 } });
+		// Tombstone the shipped `"*"` lane: these cases measure the retry budget
+		// itself, and a fallback hop would restart that budget on the next rung
+		// (the per-rung budget is existing, deliberate behaviour - see
+		// retry-fallback-engine "spends a fresh retry budget on every rung").
+		settingsManager.applyOverrides({
+			retry: { enabled: true, maxRetries, baseDelayMs: 1, fallbackChains: { "*": [] } },
+		});
 
 		session = new AgentSession({
 			agent,

--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -31,6 +31,9 @@ afterEach(() => {
 describe("SettingsManager retry fallback settings", () => {
 	const defaultChains = {
 		"claude-fable-5": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
+		// Last-resort lane so a model without its own chain still has an escape
+		// route instead of wedging the session terminal.
+		"*": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 	};
 
 	it("defaults abortServerSideFallback to true and round-trips an explicit false", () => {
@@ -79,9 +82,11 @@ describe("SettingsManager retry fallback settings", () => {
 		await manager.flush();
 
 		const reloaded = SettingsManager.create(projectDir, agentDir);
+		// Overriding one key layers over the shipped defaults; the wildcard lane
+		// survives so other models keep their escape route.
 		expect(reloaded.getRetryFallbackSettings()).toEqual({
 			modelFallback: false,
-			chains: { "claude-fable-5": ["ccapi/kimi-k3:max"] },
+			chains: { "claude-fable-5": ["ccapi/kimi-k3:max"], "*": defaultChains["*"] },
 			revertPolicy: "never",
 		});
 

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -260,9 +260,11 @@ describe("model fallback builtin command", () => {
 			expected: "anthropic/claude-fable-5 -> anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
 		},
 		{
+			// Fable's own chain drops out with the model, but the shipped wildcard
+			// lane remains so a chainless model still has an escape route.
 			name: "Fable 5 is unavailable",
 			models: [opus5, opus48],
-			expected: "No fallback chains configured.",
+			expected: "* -> anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
 		},
 	])("shows the availability-filtered default chain when $name", async ({ models, expected }) => {
 		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -5,6 +5,7 @@ import {
 	candidatesAfter,
 	canonicalizeFallbackChains,
 	formatSelector,
+	hasExplicitFallbackOptOut,
 	parseFallbackSelector,
 	resolveChainKey,
 } from "../../src/core/retry-fallback/chains.ts";
@@ -95,6 +96,76 @@ describe("fallback chain selectors", () => {
 				models,
 			),
 		).toEqual({ "openai/gpt-5.4:high": ["anthropic/claude-sonnet-4-5:max"] });
+	});
+
+	it("resolves the wildcard key when no exact or base chain matches", () => {
+		// A model without its own chain must still have an escape lane: thread
+		// 487d7c29 wedged terminal on nine consecutive upstream 500s because
+		// resolveChainKey returned undefined for the manually selected model.
+		const model = getModel("openai", "gpt-5.4");
+		const chains = { "*": ["anthropic/claude-sonnet-4-5:high"] };
+		expect(resolveChainKey(model, "high", chains, { allowWildcard: true })).toBe("*");
+		expect(resolveChainKey(model, undefined, chains, { allowWildcard: true })).toBe("*");
+	});
+
+	it("treats a tombstoned chain as an explicit opt-out from the wildcard", () => {
+		// The `[]` tombstone is the documented way to switch fallback off. The
+		// shipped wildcard lane must not resurrect it against that instruction.
+		const model = getModel("anthropic", "claude-fable-5");
+		expect(hasExplicitFallbackOptOut({ "claude-fable-5": [] }, model, "max")).toBe(true);
+		expect(hasExplicitFallbackOptOut({ "anthropic/claude-fable-5": [] }, model, undefined)).toBe(true);
+		expect(hasExplicitFallbackOptOut({ "openai/gpt-5.4": [] }, model, "max")).toBe(false);
+		// A tombstoned wildcard is not itself a per-model opt-out.
+		expect(hasExplicitFallbackOptOut({ "*": [] }, model, "max")).toBe(false);
+	});
+
+	it("withholds the wildcard unless the caller opts in", () => {
+		// An active fallback episode must keep walking its own chain; the wildcard
+		// is only offered to a session that resolved no chain at all.
+		const model = getModel("openai", "gpt-5.4");
+		expect(resolveChainKey(model, "high", { "*": ["anthropic/claude-sonnet-4-5"] })).toBeUndefined();
+	});
+
+	it("prefers exact and base keys over the wildcard", () => {
+		const model = getModel("openai", "gpt-5.4");
+		expect(
+			resolveChainKey(
+				model,
+				"high",
+				{
+					"openai/gpt-5.4:high": ["anthropic/claude-sonnet-4-5"],
+					"*": ["anthropic/claude-sonnet-4-5"],
+				},
+				{ allowWildcard: true },
+			),
+		).toBe("openai/gpt-5.4:high");
+		expect(
+			resolveChainKey(
+				model,
+				"max",
+				{
+					"openai/gpt-5.4": ["anthropic/claude-sonnet-4-5"],
+					"*": ["anthropic/claude-sonnet-4-5"],
+				},
+				{ allowWildcard: true },
+			),
+		).toBe("openai/gpt-5.4");
+	});
+
+	it("preserves the wildcard chain through canonicalization", () => {
+		expect(canonicalizeFallbackChains({ "*": ["ANTHROPIC/claude-sonnet-4-5:MAX"] }, models)).toEqual({
+			"*": ["anthropic/claude-sonnet-4-5:max"],
+		});
+	});
+
+	it("drops a tombstoned wildcard chain", () => {
+		expect(canonicalizeFallbackChains({ "*": [] }, models)).toEqual({});
+	});
+
+	it("ships a default wildcard lane that user config can tombstone", () => {
+		expect(DEFAULT_FALLBACK_CHAINS["*"]?.length ?? 0).toBeGreaterThan(0);
+		const resolved = resolveRetryFallbackSettings({ fallbackChains: { "*": [] } });
+		expect(resolved.chains["*"]).toEqual([]);
 	});
 
 	it("prefers an exact thinking key, then the base key", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -51,6 +51,8 @@ describe("bare model-id family expansion", () => {
 	it("ships a provider-agnostic default chain with bare model ids", () => {
 		expect(DEFAULT_FALLBACK_CHAINS).toEqual({
 			[FABLE]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
+			// Last-resort lane for models with no chain of their own.
+			"*": ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 		});
 	});
 
@@ -66,7 +68,7 @@ describe("bare model-id family expansion", () => {
 	it("expands a bare key into one canonical key per serving provider", () => {
 		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
 
-		expect(Object.keys(chains).sort()).toEqual([`anthropic/${FABLE}`, `claude-sdk-oauth/${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual(["*", `anthropic/${FABLE}`, `claude-sdk-oauth/${FABLE}`]);
 	});
 
 	it("ranks OAuth-credential providers ahead of API-key providers for bare candidates", () => {
@@ -117,7 +119,7 @@ describe("bare model-id family expansion", () => {
 		];
 		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
 
-		expect(Object.keys(chains)).toEqual([`amazon-bedrock/global.anthropic.${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual(["*", `amazon-bedrock/global.anthropic.${FABLE}`]);
 		expect(chains[`amazon-bedrock/global.anthropic.${FABLE}`]).toEqual([
 			`amazon-bedrock/global.anthropic.${OPUS5}:xhigh`,
 		]);
@@ -132,7 +134,7 @@ describe("bare model-id family expansion", () => {
 		];
 		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
 
-		expect(Object.keys(chains)).toEqual([`anthropic/${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual(["*", `anthropic/${FABLE}`]);
 		expect(chains[`anthropic/${FABLE}`]).toEqual([`anthropic/${OPUS5}:xhigh`]);
 	});
 
@@ -165,14 +167,17 @@ describe("bare-key opt-out tombstones", () => {
 	it("removes the shipped default when the user empties the bare key", () => {
 		const resolved = resolveRetryFallbackSettings({ fallbackChains: { [FABLE]: [] } });
 
-		expect(canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic))).toEqual({});
+		// The per-model chain is gone; the wildcard lane survives as its own key.
+		// hasExplicitFallbackOptOut keeps that lane from resurrecting fallback for
+		// the tombstoned model itself (see retry-fallback-chains.test.ts).
+		expect(Object.keys(canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic)))).toEqual(["*"]);
 	});
 
 	it("removes only one provider variant when the user empties a canonical key", () => {
 		const resolved = resolveRetryFallbackSettings({ fallbackChains: { [`anthropic/${FABLE}`]: [] } });
 		const chains = canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic));
 
-		expect(Object.keys(chains)).toEqual([`claude-sdk-oauth/${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual(["*", `claude-sdk-oauth/${FABLE}`]);
 	});
 
 	it("lets an explicit canonical chain override the expanded default for that provider only", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hardening.test.ts
@@ -96,9 +96,11 @@ describe("retry fallback hardening", () => {
 	});
 
 	it("logs the no-chain decision for an unconfigured model", async () => {
+		// The shipped `"*"` lane means every model now resolves a chain, so the
+		// no_chain decision is only reachable once that lane is tombstoned too.
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
-			settings: { retry: { enabled: true, baseDelayMs: 1, maxRetries: 0 } },
+			settings: { retry: { enabled: true, baseDelayMs: 1, maxRetries: 0, fallbackChains: { "*": [] } } },
 		});
 		harnesses.push(harness);
 		harness.setResponses([overloaded(), fauxAssistantMessage("recovered")]);

--- a/packages/coding-agent/test/suite/retry-fallback-long-delay.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-long-delay.test.ts
@@ -65,9 +65,11 @@ describe("retry fallback for over-threshold provider delays", () => {
 	});
 
 	it("settles the turn unchanged when no chain is configured", async () => {
+		// Tombstone the shipped wildcard lane so this case keeps exercising the
+		// delay-cap guard for a genuinely chainless model.
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }],
-			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1 } },
+			settings: { retry: { enabled: true, maxRetries: 3, baseDelayMs: 1, fallbackChains: { "*": [] } } },
 		});
 		harnesses.push(harness);
 		harness.setResponses([errorTurn(overThreshold), fauxAssistantMessage("never reached")]);


### PR DESCRIPTION
## Problem

A model with no fallback chain of its own wedges the session on a terminal `error`. `DEFAULT_FALLBACK_CHAINS` only keys `claude-fable-5`, so `resolveChainKey` returns undefined for any other model, `canTryFallback()` is permanently false, and repeated upstream hard failures have nowhere to go.

Observed on desktop thread `487d7c29` (2026-08-28): nine consecutive turns failed on `apitopia/kimi-k3-unlocked` upstream 500s over ~70s with **zero** fallback attempts, session wedged terminal. Every `_isHardErrorFallbackEligible` exclusion passed (failed messages were `stopReason=error`, `content=[]`), so eligibility hinged entirely on `canTryFallback()`. A manual switch to the healthy sibling model recovered the thread immediately.

## Fix

`resolveChainKey` falls through **exact → base → `"*"`**, and `DEFAULT_FALLBACK_CHAINS` ships that lane with the Fable rungs.

Two guards keep it a last resort, not a hijack:

1. **`nextCandidate` order: own chain → active episode's `chainKey` → wildcard.** An unconditional fallthrough stole sessions already walking a configured chain, because that chain's last rung usually has no key of its own. The engine suite caught this as a 7 → 5 call-count regression, which is why the wildcard is opt-in per call site (`allowWildcard`).
2. **`hasExplicitFallbackOptOut` honours `[]` tombstones.** Canonicalization deletes tombstoned keys, so without this the shipped lane would silently resurrect fallback for a user who explicitly disabled it. Bare-family matching is deliberately conservative: ambiguity suppresses the lane rather than overriding an explicit opt-out.

Disable the lane itself with `"*": []`.

## Evidence

- RED captured by stashing only the two src files: the wildcard resolution, canonicalization survival, and shipped-lane assertions fail without the fix.
- **70/70 green** across `retry-fallback-{chains,engine,expansion,settings,hardening,long-delay}` + `model-fallback-command`.
- `npx tsc --noEmit` exit 0.
- Six `retry-fallback-expansion` expectations and three no-chain tests updated: they pinned "a chainless model gets no fallback", which is exactly the contract this PR overturns. Each update says why inline; the two no-chain behavioural tests now tombstone `"*"` so they keep testing what they were written to test.

## Not mine

`app-server-daemon.test.ts` ("starts, reports status, attaches idempotently") fails identically on a stashed baseline without my changes — pre-existing, untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives models with no fallback chain of their own a wildcard escape lane: a hard-failing upstream previously wedged the session on a terminal error because `resolveChainKey` returned undefined. The resolver now falls through exact → base → a shipped `"*"` lane, so such models can still rotate to a healthy candidate.

**Guards**
- `nextCandidate` resolves own chain → active episode's `chainKey` → wildcard, so the lane never hijacks a session already walking a configured chain.
- `hasExplicitFallbackOptOut` suppresses the lane when the model's key is tombstoned with `[]`; ambiguous bare-family matches suppress it rather than override an explicit opt-out.
- Disable the lane itself with `"*": []`.

**Tests**
- Tests pinned to the old contract now tombstone `"*"` or expect the shipped lane; budget cases tombstone it because each rung spends a fresh retry budget, which is existing deliberate behavior.
- `app-server-daemon.test.ts` fails identically on a stashed baseline; pre-existing.

<sup>Written for commit 125bfb55d2ed0c6730f4098003bb380c879899ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

