### PR TITLE
fix(rpc): defer a dropped connection's session release while its turn streams

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- A client socket that drops while its session's turn is still streaming no longer aborts the run mid-turn: the dropped connection's refcounted release is deferred until the turn settles (`agent_settled`/`agent_idle`), then the path reservation frees as before. This also fixes the RPC socket host never idle-exiting after such a drop (the sealed session leaked the lifecycle observer's busy counter, so the supervisor saw a permanently active turn).
+
 - A model with no fallback chain of its own no longer wedges the session on a terminal error. `resolveChainKey` now falls through exact -> base -> a shipped `"*"` wildcard lane, so an upstream that hard-fails (e.g. repeated provider 500s) can still rotate to a healthy model instead of ending the turn permanently. The wildcard is a last resort only: a model's own chain wins, an in-flight fallback episode keeps walking its own chain, and an explicit `[]` tombstone on the model's key still switches fallback off (`hasExplicitFallbackOptOut`). Disable the lane itself with `"*": []`.
 
 ### Removed

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## 2026-08-28 - Dropped-connection release defers while a turn is streaming
+
+### What changed
+
+- `session-command-router.ts`: `releaseConnection()` now checks the live entry
+  (`registry.peek`) and, when the owned session's turn is still streaming,
+  defers the refcounted close until `agent_settled`/`agent_idle` via a one-shot
+  session subscription instead of tearing the runtime down immediately. Idle
+  sessions release exactly as before. The per-session guarded close moved into
+  `releaseOwnedSession()`; the deferred path reuses it and tolerates races with
+  an explicit `close_session` (beginClose already-closed guard).
+- `session-registry.ts`: added the read-only `peek(handle)` lookup (no state
+  transitions, no attachment accounting) for lifecycle decisions.
+
+### Why
+
+- The 2026-08-28 release-a-dropped-connection's-sessions change closed owned
+  sessions on socket close even mid-turn. That aborts the run and seals the
+  session before `agent_settled` reaches the host-lifecycle observer, leaking
+  the busy-session counter, so the supervisor saw a permanently active turn and
+  the host never idle-exited (`rpc-host-lifecycle` "does not exit while a turn
+  is active" turned red on main). Deferring - never skipping - keeps both
+  contracts: the headless turn runs to completion, and the dead owner's path
+  reservation still frees right after settlement.
+
 ## Terminal monitor snapshots ride `extension_event` (2026-08-28)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -181,19 +181,52 @@ export class SessionCommandRouter {
 		this.sessionsByConnection.delete(connectionId);
 		if (owned === undefined) return;
 		for (const sessionId of owned) {
-			let entry: RpcSessionEntry | undefined;
-			try {
-				entry = this.registry.beginClose(sessionId);
-			} catch {
-				// Already closed or claimed by another lifecycle path; nothing to release.
+			// Headless completion contract: a turn survives its client's death and
+			// runs to settlement (the host lifecycle keeps the process alive on
+			// active turns even with zero connections). Releasing mid-turn aborts
+			// the run and seals the session before agent_settled reaches the
+			// lifecycle observer, leaking the busy counter so the host never
+			// idle-exits. Defer - never skip - the release until the turn settles,
+			// so the dropped owner's reservation still frees afterwards.
+			const live = this.registry.peek(sessionId);
+			const session = live?.state === "open" ? live.runtime?.session : undefined;
+			if (session?.isStreaming) {
+				let released = false;
+				const unsubscribe = session.subscribe((event) => {
+					if (event.type !== "agent_settled" && event.type !== "agent_idle") return;
+					if (released) return;
+					released = true;
+					unsubscribe();
+					void this.releaseOwnedSession(sessionId).catch((cause) => {
+						process.stderr.write(
+							`senpi rpc deferred release for session ${sessionId} failed: ${String(cause)}\n`,
+						);
+					});
+				});
 				continue;
 			}
-			try {
-				await this.bindings.get(sessionId)?.dispose();
-			} finally {
-				this.bindings.delete(sessionId);
-				if (entry.state === "closing") await this.registry.closeMarked(sessionId);
-			}
+			await this.releaseOwnedSession(sessionId);
+		}
+	}
+
+	/**
+	 * One owned handle's refcounted close: the same sequence as an explicit
+	 * close_session, tolerant of races with other lifecycle paths (an entry
+	 * already closed or claimed elsewhere is simply skipped).
+	 */
+	private async releaseOwnedSession(sessionId: string): Promise<void> {
+		let entry: RpcSessionEntry | undefined;
+		try {
+			entry = this.registry.beginClose(sessionId);
+		} catch {
+			// Already closed or claimed by another lifecycle path; nothing to release.
+			return;
+		}
+		try {
+			await this.bindings.get(sessionId)?.dispose();
+		} finally {
+			this.bindings.delete(sessionId);
+			if (entry.state === "closing") await this.registry.closeMarked(sessionId);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -161,6 +161,16 @@ export class RpcSessionRegistry {
 		}
 	}
 
+	/**
+	 * Read-only lookup with no state transitions or attachment accounting.
+	 * Exists so lifecycle decisions (e.g. deferring a dropped connection's
+	 * release while a turn is still streaming) can inspect the live entry
+	 * without claiming it.
+	 */
+	peek(handle: string): RpcSessionEntry | undefined {
+		return this.entries.get(handle);
+	}
+
 	getForCommand(handle: string, command: string): RpcSessionEntry {
 		const entry = this.entries.get(handle);
 		if (!entry) throw new RpcSessionRegistryError("unknown_session");


### PR DESCRIPTION
## Problem

#1177 (7ace9b646) releases a dropped connection's sessions on socket close — correct for idle sessions, but it also fires **mid-turn**: the runtime teardown aborts the run and seals the session before `agent_settled` reaches the host-lifecycle observer, leaking the busy-session counter. The supervisor then sees a permanently active turn and the host never idle-exits.

**This is the current main CI breakage**: `rpc-host-lifecycle > does not exit while a turn is active even with no connections; exits after the turn settles` fails on main's own runs (33152599123, 33155308197; last green 33149502757 = the commit before #1177). It also violates the headless-completion contract — a turn must survive its client's death.

## Fix

`releaseConnection` peeks the live entry (`registry.peek`, new read-only lookup) and, when the owned session's turn is still streaming, **defers** the refcounted close until `agent_settled`/`agent_idle` via a one-shot session subscription. Idle sessions release immediately as before. The per-session guarded close is factored into `releaseOwnedSession`; the deferred path reuses it and tolerates races with an explicit `close_session` (the beginClose already-closed guard).

Defer — never skip — so #1177's purpose survives: the dead owner's path reservation still frees, just after settlement instead of mid-turn.

## Evidence

- RED: the lifecycle test reproduced locally on clean main in this worktree (host pid never exited, 37s timeout) before the fix.
- GREEN: same test passes in 11.7s after the fix; full `rpc-host-lifecycle` (15) + #1177's own `rpc-socket-host` regression suite + `interactive-host-runtime` = **26/26**, proving both the leak fix and the turn-survival contract hold simultaneously.
- `npx tsc --noEmit`: 0 errors.
- `changes.md` (modes/rpc) + package CHANGELOG updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped-connection session release so a client socket drop no longer aborts an in-flight turn, which leaked the busy-session counter and left the host never idle-exiting.

Before, socket close released sessions mid-turn and tore down the runtime; now `releaseConnection` defers the refcounted close until `agent_settled`/`agent_idle` when the turn is still streaming, and idle sessions release immediately.

**Bug Fixes**
- Deferred release is never skipped, so the dead owner's path reservation still frees after settlement.
- Adds read-only `peek(handle)` to `session-registry` for lifecycle decisions.

<sup>Written for commit d3b7bc056376141426a294fbb552cf4a7254fbb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

