### PR TITLE
fix(coding-agent): explain disk-capacity crashes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Interactive crashes caused by a full filesystem (`ENOSPC`) or exhausted disk quota (`EDQUOT`) now explain what failed and tell the user to free filesystem space or quota before retrying, while preserving the original error and exit behavior ([#1184](https://github.com/code-yeongyu/senpi/pull/1184) by [@minpeter](https://github.com/minpeter)).
+
 - A client socket that drops while its session's turn is still streaming no longer aborts the run mid-turn: the dropped connection's refcounted release is deferred until the turn settles (`agent_settled`/`agent_idle`), then the path reservation frees as before. This also fixes the RPC socket host never idle-exiting after such a drop (the sealed session leaked the lifecycle observer's busy counter, so the supervisor saw a permanently active turn).
 
 - A model with no fallback chain of its own no longer wedges the session on a terminal error. `resolveChainKey` now falls through exact -> base -> a shipped `"*"` wildcard lane, so an upstream that hard-fails (e.g. repeated provider 500s) can still rotate to a healthy model instead of ending the turn permanently. The wildcard is a last resort only: a model's own chain wins, an in-flight fallback episode keeps walking its own chain, and an explicit `[]` tombstone on the model's key still switches fallback off (`hasExplicitFallbackOptOut`). Disable the lane itself with `"*": []`.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,32 @@
 # changes
 
+## Explain disk-capacity failures during uncaught interactive shutdown (2026-08-29)
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: after restoring a live
+  terminal and recording the redacted crash log, `uncaughtCrash` now identifies `EDQUOT` and
+  `ENOSPC` errors and prints a stable disk-quota or disk-full remedy before the existing fatal
+  banner and original error.
+
+### Why
+
+- A filesystem spill write can still reach the last-resort crash path. The generic banner preserved
+  the original error but did not tell the operator that local storage or quota was exhausted or
+  that freeing filesystem capacity before retrying is the recovery action.
+
+### Why an extension could not handle it
+
+- `uncaughtCrash` is the process-level listener installed by interactive mode and exits
+  synchronously after terminal restoration. An extension cannot insert guidance between that
+  restoration and `process.exit(1)`, and its own listener would run after the prepended core
+  listener has already exited.
+
+### Expected merge conflict zones
+
+- LOW: the final live-terminal output sequence in `InteractiveMode.uncaughtCrash` and the adjacent
+  error-code classifier.
+
 ## Shared-host sessions await async session reads and render thinking level from the event (2026-08-28)
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -404,6 +404,20 @@ function isDeadTerminalError(error: unknown): boolean {
 	return false;
 }
 
+function storageWriteCrashMessage(error: unknown): string | undefined {
+	if (!error || typeof error !== "object" || !("code" in error)) {
+		return undefined;
+	}
+	const code = (error as NodeJS.ErrnoException).code;
+	if (code === "EDQUOT") {
+		return "Disk quota exceeded (EDQUOT). Free space or quota on the filesystem, then retry.";
+	}
+	if (code === "ENOSPC") {
+		return "Disk full (ENOSPC). Free space on the filesystem, then retry.";
+	}
+	return undefined;
+}
+
 const ANTHROPIC_SUBSCRIPTION_AUTH_WARNING =
 	"Anthropic subscription auth is active. Third-party harness usage draws from extra usage and is billed per token, not your Claude plan limits. Manage extra usage at https://claude.ai/settings/usage. Disable this warning in /settings.";
 
@@ -5561,6 +5575,10 @@ export class InteractiveMode {
 			appendUncaughtCrashLog(origin, error);
 		} catch {}
 		restoreInteractiveStderr();
+		const storageMessage = storageWriteCrashMessage(error);
+		if (storageMessage !== undefined) {
+			console.error(storageMessage);
+		}
 		console.error(`${APP_NAME} exiting due to uncaughtException:`);
 		console.error(error);
 		process.exit(1);

--- a/packages/coding-agent/test/suite/regressions/uncaught-crash-debug-log.test.ts
+++ b/packages/coding-agent/test/suite/regressions/uncaught-crash-debug-log.test.ts
@@ -86,6 +86,20 @@ function createDeadTerminalError(shape: "errno-string" | "errno-number"): Error 
 		: Object.assign(new Error("read failed with errno: 5"), { errno: 5 });
 }
 
+function createStorageWriteError(code: "EDQUOT" | "ENOSPC"): Error & {
+	code: "EDQUOT" | "ENOSPC";
+	errno: -122 | -28;
+	syscall: "write";
+} {
+	const error = Object.assign(new Error(`${code}: unknown error, write`), {
+		code,
+		errno: code === "EDQUOT" ? (-122 as const) : (-28 as const),
+		syscall: "write" as const,
+	});
+	error.stack = `${error.message}\nAuthorization: Bearer crash-secret-value`;
+	return error;
+}
+
 /** Drives the dead-terminal route and asserts it still ends in the silent `process.exit(129)`. */
 function crashAndExpectEmergencyExit(context: UncaughtCrashThis, error: Error): { bannerCalls: number } {
 	const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
@@ -152,6 +166,63 @@ afterEach(() => {
 });
 
 describe("uncaught crash debug log", () => {
+	test("explains an EDQUOT write crash while preserving cleanup, logging, and exit semantics", () => {
+		useTempAgentDir("edquot");
+		const context = createCrashContext();
+		const error = createStorageWriteError("EDQUOT");
+		const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new ProcessExitError(code);
+		});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		expect(() => interactiveModePrototype.uncaughtCrash.call(context, error, "uncaughtException")).toThrow(
+			ProcessExitError,
+		);
+
+		const stderr = consoleError.mock.calls.flat().map(String).join("\n");
+		expect(stderr).toContain("Disk quota exceeded (EDQUOT)");
+		expect(stderr).toContain("Free space or quota on the filesystem, then retry.");
+		expect(stderr).toContain("EDQUOT: unknown error, write");
+		expect(stderr).not.toContain("model quota");
+		expect(stderr).not.toContain("provider quota");
+		expect(exit).toHaveBeenCalledWith(1);
+		expect(exit).not.toHaveBeenCalledWith(129);
+		expect(context.ui.stop).toHaveBeenCalledTimes(1);
+		expect(context.unregisterSignalHandlers).toHaveBeenCalledTimes(1);
+		expect(context.isShuttingDown).toBe(true);
+		expect(error.code).toBe("EDQUOT");
+
+		const debugLogPath = getDebugLogPath();
+		const log = readFileSync(debugLogPath, "utf8");
+		expect(log).toContain("uncaught crash (uncaughtException)");
+		expect(log).toContain("EDQUOT: unknown error, write");
+		expect(log).toContain("Authorization: Bearer [REDACTED]");
+		expect(log).not.toContain("crash-secret-value");
+		expect(log).not.toContain("hidden stdout while TUI active");
+		expect((statSync(debugLogPath).mode & 0o777).toString(8)).toBe("600");
+		expect(restoreObservations).toEqual([{ debugLogExisted: true }]);
+	});
+
+	test("distinguishes an ENOSPC write crash from a quota failure", () => {
+		useTempAgentDir("enospc");
+		const context = createCrashContext();
+		const exit = vi.spyOn(process, "exit").mockImplementation((code) => {
+			throw new ProcessExitError(code);
+		});
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		expect(() =>
+			interactiveModePrototype.uncaughtCrash.call(context, createStorageWriteError("ENOSPC"), "uncaughtException"),
+		).toThrow(ProcessExitError);
+
+		const stderr = consoleError.mock.calls.flat().map(String).join("\n");
+		expect(stderr).toContain("Disk full (ENOSPC)");
+		expect(stderr).toContain("Free space on the filesystem, then retry.");
+		expect(stderr).not.toContain("Disk quota exceeded");
+		expect(exit).toHaveBeenCalledWith(1);
+		expect(context.ui.stop).toHaveBeenCalledTimes(1);
+	});
+
 	test("records origin and error in the brand debug log before restoring stderr", () => {
 		useTempAgentDir("write");
 		const error = new Error("extension exploded after boot");


### PR DESCRIPTION
## Summary

- identify `EDQUOT` and `ENOSPC` in the interactive uncaught-crash path
- print a stable filesystem recovery action after terminal restoration and before the existing fatal banner
- preserve the original error, redacted mode-0600 crash log, live-terminal exit 1, and silent dead-terminal EIO exit 129

## Verification

- RED: focused regression ran with 2 expected failures because disk guidance was absent; 7 existing cases passed
- GREEN: `uncaught-crash-debug-log.test.ts` — 9/9 passed
- adjacent regressions — 5 files, 25/25 passed
- `npm run check` — passed
- `npm run build` — passed
- `git diff --check` — passed
- real PTY -> xterm.js -> Chrome: actionable EDQUOT message visible, original error visible, exit status 1, `icanon` restored, cursor restored, bracketed paste disabled, auth unchanged
- dual independent visual review — PASS / HIGH confidence from both reviewers, no blockers

Evidence is retained locally under `local-ignore/qa-evidence/20260828-disk-quota-crash/` and is intentionally not committed.

## Scope

Only the interactive crash handler, its nearest `changes.md`, and the existing uncaught-crash regression suite are changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the interactive uncaught-crash handler so disk-capacity crashes (`EDQUOT`/`ENOSPC`) now print a recovery action before the generic fatal banner, which previously only showed the original error without explaining the disk issue.

**Bug Fixes**
- Adds a classifier that prints a disk-quota or disk-full remedy after terminal restoration and crash-log recording.
- Preserves existing semantics: redacted mode-0600 crash log, live-terminal exit 1, and silent dead-terminal exit 129.
- Records the fix in the package changelog and interactive-mode changes doc.

<sup>Written for commit 112539fbab1408ddfee98811db4b10aa0fb2354e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

