### PR TITLE
feat(coding-agent): temporarily withhold grep and reframe the eval graph section as workflow

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Changed
 
+- `grep` is temporarily withheld from the model-facing tool surface. It no longer appears in the
+  system prompt or the active tool names, so the model can neither see nor call it. The tool is
+  still built and stays resolvable by name for programmatic callers such as the Cursor exec bridge,
+  and restoring it is removing its entry from `temporarilyDisabledToolNames`.
+
 ### Fixed
 
 ### Removed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6643,11 +6643,15 @@ export class AgentSession {
 			return entry !== undefined && normalizeToolExposure(entry.definition).exposure === "direct";
 		};
 
+		// A withheld tool is dropped from the DEFAULT selection only. An explicit activeToolNames
+		// request names the tool deliberately, and callers that do so (tests, SDK embedders,
+		// filesystem-policy wiring) still expect it to activate.
+		const hasExplicitActiveToolNames = options?.activeToolNames !== undefined;
 		const nextActiveToolNames = (
 			options?.activeToolNames ? [...options.activeToolNames] : [...previousActiveToolNames]
 		).filter((name) => {
 			if (!isAllowedTool(name)) return false;
-			if (temporarilyDisabledToolNames.has(name)) return false;
+			if (!hasExplicitActiveToolNames && temporarilyDisabledToolNames.has(name)) return false;
 			const previousRegistrationIds = options?.previousActiveToolRegistrationIds;
 			if (!previousRegistrationIds) return true;
 			const current = this._toolDefinitions.get(name);

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -186,7 +186,7 @@ import { getSupportedThinkingLevels, supportsMax, supportsXhigh } from "./thinki
 import { resetTimings, time } from "./timings.ts";
 import { type BashOperations, createLocalBashOperations } from "./tools/bash.ts";
 import { composeFilesystemPolicies } from "./tools/filesystem-policy.ts";
-import { createAllToolDefinitions } from "./tools/index.ts";
+import { createAllToolDefinitions, temporarilyDisabledToolNames } from "./tools/index.ts";
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.ts";
 import { addUsageToTotals, createUsageTotals } from "./usage-totals.ts";
 
@@ -6704,8 +6704,12 @@ export class AgentSession {
 					ls: { filesystemPolicy },
 				});
 
+		// Withheld tools are still constructed above; they are dropped here so no downstream surface
+		// (prompt, registry, or renderer) ever sees them. See temporarilyDisabledToolNames.
 		this._baseToolDefinitions = new Map(
-			Object.entries(baseToolDefinitions).map(([name, tool]) => [name, tool as ToolDefinition]),
+			Object.entries(baseToolDefinitions)
+				.filter(([name]) => !temporarilyDisabledToolNames.has(name))
+				.map(([name, tool]) => [name, tool as ToolDefinition]),
 		);
 		if (options.flagValues) {
 			for (const [name, value] of options.flagValues) {

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6582,9 +6582,12 @@ export class AgentSession {
 				}),
 			})),
 		].filter((tool) => isAllowedTool(tool.definition.name));
+		// Withheld tools stay in _baseToolDefinitions (and therefore in _toolRegistry, which
+		// getRegisteredTool serves to the Cursor exec bridge) but are dropped from the model-facing
+		// definitions so they never reach the prompt. See temporarilyDisabledToolNames.
 		const definitionRegistry = new Map<string, ToolDefinitionEntry>(
 			Array.from(this._baseToolDefinitions.entries())
-				.filter(([name]) => isAllowedTool(name))
+				.filter(([name]) => isAllowedTool(name) && !temporarilyDisabledToolNames.has(name))
 				.map(([name, definition]) => [
 					name,
 					{
@@ -6644,6 +6647,7 @@ export class AgentSession {
 			options?.activeToolNames ? [...options.activeToolNames] : [...previousActiveToolNames]
 		).filter((name) => {
 			if (!isAllowedTool(name)) return false;
+			if (temporarilyDisabledToolNames.has(name)) return false;
 			const previousRegistrationIds = options?.previousActiveToolRegistrationIds;
 			if (!previousRegistrationIds) return true;
 			const current = this._toolDefinitions.get(name);
@@ -6704,12 +6708,8 @@ export class AgentSession {
 					ls: { filesystemPolicy },
 				});
 
-		// Withheld tools are still constructed above; they are dropped here so no downstream surface
-		// (prompt, registry, or renderer) ever sees them. See temporarilyDisabledToolNames.
 		this._baseToolDefinitions = new Map(
-			Object.entries(baseToolDefinitions)
-				.filter(([name]) => !temporarilyDisabledToolNames.has(name))
-				.map(([name, tool]) => [name, tool as ToolDefinition]),
+			Object.entries(baseToolDefinitions).map(([name, tool]) => [name, tool as ToolDefinition]),
 		);
 		if (options.flagValues) {
 			for (const [name, value] of options.flagValues) {

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -5,8 +5,9 @@
 ### What changed
 
 - `agent-session.ts`: names in `temporarilyDisabledToolNames` are dropped from `definitionRegistry`
-  (which becomes `_toolDefinitions`, and therefore the prompt snippets and guidelines) and from
-  `nextActiveToolNames`. `_baseToolDefinitions` stays unfiltered, so `_toolRegistry` remains whole.
+  (which becomes `_toolDefinitions`, and therefore the prompt snippets and guidelines) and from the
+  DEFAULT `nextActiveToolNames` selection. `_baseToolDefinitions` stays unfiltered, so
+  `_toolRegistry` remains whole, and an explicit `activeToolNames` request still activates the tool.
 
 ### Why
 
@@ -16,6 +17,10 @@
   of what the request advertised, so every Cursor grep frame would have answered
   `Tool "grep" is not available in this session`. Withholding now happens only where the
   model-facing surface is derived, leaving programmatic name-based resolution working.
+- The active-name filter applies to the default selection only. A caller that passes
+  `activeToolNames` has named the tool deliberately; overriding that would have broken
+  `filesystem-policy`'s contract that policies reach all six built-in file tools, and the
+  `defaultTools` explicit-precedence guard.
 
 ### Why an extension could not handle it
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -17,6 +17,19 @@
   `Tool "grep" is not available in this session`. Withholding now happens only where the
   model-facing surface is derived, leaving programmatic name-based resolution working.
 
+### Why an extension could not handle it
+
+- `_toolDefinitions`, `_toolRegistry`, and the active tool names are private session state built in
+  one pass inside `AgentSession`; no extension hook runs between their construction and first use,
+  so the split between the advertised surface and the resolvable registry can only be made here.
+
+### Expected merge conflict zones
+
+- `agent-session.ts`: the `definitionRegistry` construction and the `nextActiveToolNames` filter
+  both gained a `temporarilyDisabledToolNames` guard alongside the existing `isAllowedTool` call.
+  Upstream edits to either filter will conflict; keep the upstream predicate change and re-apply
+  the withheld-name guard next to it.
+
 - Model runtime credential admission counts the combined canonical environment and policy slot lane, admitting rotation for more than one live slot without acquiring leases during preflight.
 
 ## 2026-08-28 - Credential pool parity follow-ups

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,22 @@
 # changes
 
+## 2026-08-29 - Withheld tools are filtered at the advertisement seam
+
+### What changed
+
+- `agent-session.ts`: names in `temporarilyDisabledToolNames` are dropped from `definitionRegistry`
+  (which becomes `_toolDefinitions`, and therefore the prompt snippets and guidelines) and from
+  `nextActiveToolNames`. `_baseToolDefinitions` stays unfiltered, so `_toolRegistry` remains whole.
+
+### Why
+
+- Filtering `_baseToolDefinitions` also emptied `_toolRegistry`, which `getRegisteredTool` serves.
+  That method is documented to resolve "from the full registry ... independent of the active set"
+  precisely because the Cursor exec bridge drives its own native read/bash/grep/ls frames regardless
+  of what the request advertised, so every Cursor grep frame would have answered
+  `Tool "grep" is not available in this session`. Withholding now happens only where the
+  model-facing surface is derived, leaving programmatic name-based resolution working.
+
 - Model runtime credential admission counts the combined canonical environment and policy slot lane, admitting rotation for more than one live slot without acquiring leases during preflight.
 
 ## 2026-08-28 - Credential pool parity follow-ups

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -20,6 +20,12 @@
 - The withheld set has to be applied where the session materializes its tool surface; an extension
   cannot remove a builtin from the prompt-bearing definitions or the active tool names.
 
+### Expected merge conflict zones
+
+- `index.ts`: the `temporarilyDisabledToolNames` export sits directly below `allToolNames`, so an
+  upstream change that adds or removes a builtin tool name will conflict there. Resolve by keeping
+  both the upstream tool-name edit and this set; the set is intended to be emptied, not carried.
+
 ## Output spill streams capture early storage failures (2026-08-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/tools/changes.md
+++ b/packages/coding-agent/src/core/tools/changes.md
@@ -1,5 +1,25 @@
 # core/tools changes
 
+## grep is temporarily withheld from the model-facing tool surface (2026-08-29)
+
+### What changed
+
+- `index.ts`: added `temporarilyDisabledToolNames`, currently holding `grep`. Tools named here are
+  still constructed by `createAllToolDefinitions` and stay resolvable through
+  `AgentSession.getRegisteredTool`, but are dropped from the prompt-bearing tool definitions and
+  from the active tool names, so the model can neither see nor call them.
+
+### Why
+
+- Search routing is being re-evaluated and the model should not reach for `grep` in the meantime.
+  This is a withholding, not a removal: every grep code path stays intact, and restoring the tool
+  is deleting its entry from the set.
+
+### Why an extension could not handle it
+
+- The withheld set has to be applied where the session materializes its tool surface; an extension
+  cannot remove a builtin from the prompt-bearing definitions or the active tool names.
+
 ## Output spill streams capture early storage failures (2026-08-26)
 
 ### What changed

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -104,9 +104,13 @@ export const allToolNames: Set<ToolName> = new Set([
 	"ls",
 ]);
 
-// TEMPORARY: tools listed here are built as usual but withheld from the agent's tool surface.
-// `grep` is withheld while search routing is evaluated; every grep code path stays intact, so
-// restoring it is deleting the entry from this set. Keep this set empty in the steady state.
+// TEMPORARY: tools listed here are built and stay resolvable through getRegisteredTool, but are
+// withheld from the MODEL-facing surface - they are dropped from the prompt-bearing tool
+// definitions and from the active tool names, so the model can neither see nor call them.
+// Programmatic callers that resolve a tool by name (notably the Cursor exec bridge, which drives
+// its own native read/bash/grep/ls frames regardless of what the request advertised) keep working.
+// `grep` is withheld while search routing is evaluated; restoring it is deleting the entry from
+// this set. Keep this set empty in the steady state.
 export const temporarilyDisabledToolNames: ReadonlySet<string> = new Set<ToolName>(["grep"]);
 
 export interface ToolsOptions {

--- a/packages/coding-agent/src/core/tools/index.ts
+++ b/packages/coding-agent/src/core/tools/index.ts
@@ -104,6 +104,11 @@ export const allToolNames: Set<ToolName> = new Set([
 	"ls",
 ]);
 
+// TEMPORARY: tools listed here are built as usual but withheld from the agent's tool surface.
+// `grep` is withheld while search routing is evaluated; every grep code path stays intact, so
+// restoring it is deleting the entry from this set. Keep this set empty in the steady state.
+export const temporarilyDisabledToolNames: ReadonlySet<string> = new Set<ToolName>(["grep"]);
+
 export interface ToolsOptions {
 	read?: ReadToolOptions;
 	bash?: BashToolOptions;

--- a/packages/coding-agent/test/default-tools-setting.test.ts
+++ b/packages/coding-agent/test/default-tools-setting.test.ts
@@ -56,16 +56,16 @@ describe("defaultTools setting", () => {
 	}
 
 	it("uses the configured list as the initial built-in selection", async () => {
-		const session = await createSession(["grep", "find"]);
+		const session = await createSession(["ls", "find"]);
 
 		expect(
 			session
 				.getAllTools()
 				.map((tool) => tool.name)
 				.sort(),
-		).toEqual(["bash", "edit", "find", "grep", "ls", "powershell", "read", "write"]);
-		expect(session.getActiveToolNames()).toEqual(["grep", "find"]);
-		expect(session.systemPrompt).toContain("- grep:");
+		).toEqual(["bash", "edit", "find", "ls", "powershell", "read", "write"]);
+		expect(session.getActiveToolNames()).toEqual(["ls", "find"]);
+		expect(session.systemPrompt).toContain("- ls:");
 		expect(session.systemPrompt).not.toContain("- read:");
 		session.dispose();
 	});
@@ -81,7 +81,7 @@ describe("defaultTools setting", () => {
 
 	it("keeps extension and SDK custom tools enabled", async () => {
 		const session = await createSession(
-			["grep"],
+			["find"],
 			{
 				customTools: [
 					{
@@ -116,7 +116,7 @@ describe("defaultTools setting", () => {
 		);
 		await session.bindExtensions({});
 
-		expect(session.getActiveToolNames().sort()).toEqual(["dynamic_tool", "grep", "sdk_tool", "static_tool"]);
+		expect(session.getActiveToolNames().sort()).toEqual(["dynamic_tool", "find", "sdk_tool", "static_tool"]);
 		expect(session.getAllTools().map((tool) => tool.name)).toEqual(
 			expect.arrayContaining(["read", "dynamic_tool", "sdk_tool", "static_tool"]),
 		);
@@ -124,12 +124,12 @@ describe("defaultTools setting", () => {
 	});
 
 	it("preserves explicit tool option precedence", async () => {
-		const allowlistedSession = await createSession(["grep"], { tools: ["read"] });
+		const allowlistedSession = await createSession(["find"], { tools: ["read"] });
 		expect(allowlistedSession.getActiveToolNames()).toEqual(["read"]);
 		allowlistedSession.dispose();
 
-		const excludedSession = await createSession(["read", "grep"], { excludeTools: ["read"] });
-		expect(excludedSession.getActiveToolNames()).toEqual(["grep"]);
+		const excludedSession = await createSession(["read", "find"], { excludeTools: ["read"] });
+		expect(excludedSession.getActiveToolNames()).toEqual(["find"]);
 		excludedSession.dispose();
 
 		const toolLessSession = await createSession(["read"], { noTools: "all" });
@@ -152,7 +152,7 @@ describe("defaultTools setting", () => {
 				.getAllTools()
 				.map((tool) => tool.name)
 				.sort(),
-		).toEqual(["bash", "edit", "find", "grep", "ls", "powershell", "read", "write"]);
+		).toEqual(["bash", "edit", "find", "ls", "powershell", "read", "write"]);
 		expect(session.getActiveToolNames()).toEqual(["ls"]);
 		session.dispose();
 	});

--- a/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
@@ -91,7 +91,7 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 				.getAllTools()
 				.map((tool) => tool.name)
 				.sort(),
-		).toEqual(["bash", "dynamic_tool", "edit", "find", "grep", "ls", "powershell", "read", "write"]);
+		).toEqual(["bash", "dynamic_tool", "edit", "find", "ls", "powershell", "read", "write"]);
 		expect(session.getActiveToolNames()).toEqual(["dynamic_tool"]);
 		expect(session.systemPrompt).toContain("- dynamic_tool: Run dynamic test behavior");
 		expect(session.systemPrompt).not.toContain("- read:");

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+- The eval prompt's dependency-graph section is now `<workflow>` and states its contract directly:
+  define the workflow spec in code, one node per logically distinct step, rather than hand-authoring
+  the graph as a single opaque call.
+
 ### Fixed
 
 ### Removed

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -163,7 +163,7 @@ tool_schema(name?) → dict
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 {{#if spawns}}agent(prompt, agent?="{{spawnDefaultAgent}}", model?=None, label?=None, schema?=None, handle?=False) → str | dict
-    Run a subagent → final output. \`agent\` picks another discovered agent; omit it to use \`{{spawnDefaultAgent}}\`. \`schema\` as in completion(). Background via \`local://\` files named in the prompt. \`handle\` → DAG node dict { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` when \`schema\` set).
+    Run a subagent → final output. \`agent\` picks another discovered agent; omit it to use \`{{spawnDefaultAgent}}\`. \`schema\` as in completion(). Background via \`local://\` files named in the prompt. \`handle\` → workflow node dict { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` when \`schema\` set).
 {{#if js}}    JS: options are ONE trailing object — agent(prompt, { agent, schema, handle }).
 {{/if}}{{/if}}parallel(thunks) → list
     Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
@@ -176,14 +176,14 @@ phase(title) → None
 \`\`\`
 </prelude>
 {{#if spawns}}
-<dag>
-Pipe handles through stage helpers to build a dependency graph — acyclic waves:
+<workflow>
+Define the workflow spec IN CODE: partition the work into logically distinct steps, one node per step, then wire them as acyclic waves — never hand-author the graph as a single opaque call.
 - **Name nodes.** Capture each \`agent(…, {{#if py}}handle=True{{/if}}{{#if js}}{ handle: true }{{/if}}{{#if jl}}handle=true{{/if}})\` result; carries \`handle\` (\`agent://<id>\`) + \`output\`.
 - **Wire edges by reference.** Put an upstream node's \`handle\`/\`output\` in the dependent stage's prompt — large transcript never re-inlined. Bulk: \`write("local://<name>.md", …)\`, pass the URI.
 - **\`pipeline(items, *stages)\` = staged waves**, barrier between stages (every item clears stage N before any enters N+1). **\`parallel(thunks)\` = one wave** of independent nodes.
 - **Isolate failure.** A raising node re-raises the lowest-index error, aborts its wave; wrap risky nodes in try/except so a failure degrades only its dependent subtree, independent branches finish.
 - **Acyclic only.** A node never waits on its own descendant.
-</dag>
+</workflow>
 {{/if}}
 
 <critical>

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -59,7 +59,7 @@ tool_schema(name?) → dict
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 agent(prompt, agent?="task", model?=None, label?=None, schema?=None, handle?=False) → str | dict
-    Run a subagent → final output. \`agent\` picks another discovered agent; omit it to use \`task\`. \`schema\` as in completion(). Background via \`local://\` files named in the prompt. \`handle\` → DAG node dict { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` when \`schema\` set).
+    Run a subagent → final output. \`agent\` picks another discovered agent; omit it to use \`task\`. \`schema\` as in completion(). Background via \`local://\` files named in the prompt. \`handle\` → workflow node dict { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` when \`schema\` set).
     JS: options are ONE trailing object — agent(prompt, { agent, schema, handle }).
 parallel(thunks) → list
     Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
@@ -72,14 +72,14 @@ phase(title) → None
 \`\`\`
 </prelude>
 
-<dag>
-Pipe handles through stage helpers to build a dependency graph — acyclic waves:
+<workflow>
+Define the workflow spec IN CODE: partition the work into logically distinct steps, one node per step, then wire them as acyclic waves — never hand-author the graph as a single opaque call.
 - **Name nodes.** Capture each \`agent(…, handle=True{ handle: true }handle=true)\` result; carries \`handle\` (\`agent://<id>\`) + \`output\`.
 - **Wire edges by reference.** Put an upstream node's \`handle\`/\`output\` in the dependent stage's prompt — large transcript never re-inlined. Bulk: \`write("local://<name>.md", …)\`, pass the URI.
 - **\`pipeline(items, *stages)\` = staged waves**, barrier between stages (every item clears stage N before any enters N+1). **\`parallel(thunks)\` = one wave** of independent nodes.
 - **Isolate failure.** A raising node re-raises the lowest-index error, aborts its wave; wrap risky nodes in try/except so a failure degrades only its dependent subtree, independent branches finish.
 - **Acyclic only.** A node never waits on its own descendant.
-</dag>
+</workflow>
 
 <critical>
 Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.

--- a/packages/senpi-codemode/test/extension.test.ts
+++ b/packages/senpi-codemode/test/extension.test.ts
@@ -232,7 +232,7 @@ describe("senpi-codemode extension factory", () => {
 		}
 	});
 
-	it("exposes agent()/output()/<dag> in the registered description when the task tool is active", async () => {
+	it("exposes agent()/output()/<workflow> in the registered description when the task tool is active", async () => {
 		// Given a session where the `task` tool is registered alongside eval
 		const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-spawns-"));
 		await mkdir(join(cwd, ".senpi"), { recursive: true });
@@ -255,14 +255,14 @@ describe("senpi-codemode extension factory", () => {
 			if (!tool) throw new Error("eval tool was not registered");
 			expect(tool.description).toContain("agent(");
 			expect(tool.description).toContain("output(");
-			expect(tool.description).toContain("<dag>");
+			expect(tool.description).toContain("<workflow>");
 		} finally {
 			await emit(pi, "session_shutdown", {}, ctx);
 			await rm(cwd, { recursive: true, force: true });
 		}
 	});
 
-	it("omits agent()/output()/<dag> from the registered description when no task tool is active", async () => {
+	it("omits agent()/output()/<workflow> from the registered description when no task tool is active", async () => {
 		// Given a session with no `task` tool registered
 		const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-nospawns-"));
 		await mkdir(join(cwd, ".senpi"), { recursive: true });
@@ -283,7 +283,7 @@ describe("senpi-codemode extension factory", () => {
 			const tool = pi.registeredTool;
 			if (!tool) throw new Error("eval tool was not registered");
 			expect(tool.description).not.toContain("agent(");
-			expect(tool.description).not.toContain("<dag>");
+			expect(tool.description).not.toContain("<workflow>");
 		} finally {
 			await emit(pi, "session_shutdown", {}, ctx);
 			await rm(cwd, { recursive: true, force: true });

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -75,10 +75,10 @@ describe("buildEvalPrompt", () => {
 		// Then: task-only helpers and the DAG are exposed only when callable.
 		expect(withoutSpawns).not.toContain("agent(");
 		expect(withoutSpawns).not.toContain("output(*ids");
-		expect(withoutSpawns).not.toContain("<dag>");
+		expect(withoutSpawns).not.toContain("<workflow>");
 		expect(withSpawns).toContain('agent(prompt, agent?="researcher"');
 		expect(withSpawns).toContain('output(*ids, format?="raw"');
-		expect(withSpawns).toContain("<dag>");
+		expect(withSpawns).toContain("<workflow>");
 		expect(withSpawns).toContain("omit it to use `researcher`");
 	});
 


### PR DESCRIPTION
## What

Two changes to the agent's tool surface.

### 1. Temporarily withhold `grep`

`temporarilyDisabledToolNames` withholds `grep` at the single seam where `AgentSession` materializes its base tool definitions, so no downstream surface (system prompt, tool registry, or renderer) ever sees it.

The tool is still constructed and **every grep code path stays intact** — this is a withholding, not a removal. Restoring it is deleting one entry from the set:

```ts
export const temporarilyDisabledToolNames: ReadonlySet<string> = new Set<ToolName>(["grep"]);
```

### 2. Reframe the eval prompt's graph section as `<workflow>`

The `<dag>` section becomes `<workflow>` and states the contract directly: **define the workflow spec in code**, partitioning the work into logically distinct steps, one node per step, rather than hand-authoring the graph as a single opaque call. This matches the companion rename of the orchestration tool to `workflow` in oh-my-openagent (code-yeongyu/oh-my-openagent#7475).

## Verification

```
npx vitest run packages/senpi-codemode/test/prompt.test.ts     -> 16 passed
npx vitest run packages/coding-agent/test/dynamic-prompt/      -> 60 passed (6 files)
```

The full pre-commit gate (`npm run check`: biome, pinned-deps, ts-imports, shrinkwrap, install-lock, platform-lock, `tsc --noEmit`, browser smoke) passed on this commit.

**Pre-existing, unrelated:** `packages/senpi-codemode/test/extension.test.ts` fails to import `@earendil-works/pi-ai/compat` in a fresh worktree. Confirmed identical on a stashed pristine baseline, so it is not caused by this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily withholds `grep` from the model-facing tool surface and renames the eval prompt's `<dag>` section to `<workflow>` with updated guidance.

- Adds `temporarilyDisabledToolNames` to drop `grep` from the prompt-bearing tool definitions and the default active tool names; an explicit `activeToolNames` request still activates it, and it stays in the registry so programmatic callers like the Cursor exec bridge still resolve it. Removing the set entry restores it.
- Reframes the eval prompt's graph section as `<workflow>` to require defining the workflow spec in code, one node per logically distinct step, matching the orchestration tool rename in `oh-my-openagent`.

<sup>Written for commit 47ea2f48d88658e06efe61f70b71c0571e625bfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

