### PR TITLE
fix(interactive): render external-owner compaction delegation once as muted state

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 ### Fixed
 
+- On the `claude-sdk-oauth` lane, the "Compaction rejected: the Claude Agent SDK owns compaction for
+  this session" notice now renders at most once per delegation episode as a muted informational line
+  instead of repainting a red error line every turn, and the footer context meter shows an `(SDK)`
+  marker while the SDK owns compaction. Manual `/compact` feedback is unchanged.
+
 ### Removed
 
 ## [2026.8.29] - 2026-08-29

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -2,9 +2,39 @@
 
 ## 2026-08-29 - Render external-owner compaction delegation once, as state (#1174 UX half)
 
-- Auto compaction rejections with `rejectionCause: "external-owner"` now render a single muted informational line ("The Claude Agent SDK manages and compacts this session's context natively.") at most once per delegation episode, instead of repainting a red error line on every rejected attempt. Manual `/compact` rejections keep their explicit error feedback.
-- A delegation episode is tracked entirely in the interactive layer from observed `compaction_end` events: it starts on an external-owner rejection and the one-time notice re-arms on a successful compaction, a model switch, or a session rebind. The logic does not depend on repeat rejection events arriving (the core attempt-suppression half of #1174 lands separately).
-- The footer context meter appends an ` (SDK)` marker while a delegation episode is active (`FooterComponent.setCompactionDelegated`, optional on `InteractiveFooter`), so a saturated meter reads as "compacted natively by the SDK" rather than a stall. The marker rides the existing tail segment and respects the footer width ladder.
+### What changed
+
+- `interactive-mode.ts`: auto compaction rejections with `rejectionCause: "external-owner"` now render a
+  single muted informational line ("The Claude Agent SDK manages and compacts this session's context
+  natively.") at most once per delegation episode, instead of repainting a red error line on every
+  rejected attempt. Manual `/compact` rejections keep their explicit error feedback. The episode is
+  tracked entirely in the interactive layer from observed `compaction_end` events: it starts on an
+  external-owner rejection and the one-time notice re-arms on a successful compaction, a model switch,
+  or a session rebind; the logic does not depend on repeat rejection events arriving (the core
+  attempt-suppression half of #1174 lands separately).
+- `components/footer.ts`: the context meter appends an ` (SDK)` marker while a delegation episode is
+  active, so a saturated meter reads as "compacted natively by the SDK" rather than a stall. The marker
+  rides the existing tail segment and respects the footer width ladder.
+- `grok/chrome.ts`: `InteractiveFooter` gains the optional `setCompactionDelegated` seam that feeds the
+  marker.
+
+### Why
+
+- Issue #1174: once the local context estimate crossed the compaction threshold on the claude-sdk-oauth
+  lane, every turn repainted the same red error line (twice per tool-call turn), presenting a designed
+  stand-down as a recurring failure, and the saturated context meter looked like a stall instead of
+  SDK-owned state.
+
+### Why an extension could not handle it
+
+- The `compaction_end` rendering branch, the chat container, and the footer meter segments are private
+  `InteractiveMode`/footer render state; extensions observe compaction events but cannot restyle or
+  dedupe the built-in error rendering.
+
+### Expected merge conflict zones
+
+- LOW: the `compaction_end` error branch in `interactive-mode.ts`; the context segment composition in
+  `components/footer.ts`; the footer seam in `grok/chrome.ts`.
 
 ## 2026-08-28 - Hydrate setup-only proxy mirrors from host state
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,11 @@
 # changes
 
+## 2026-08-29 - Render external-owner compaction delegation once, as state (#1174 UX half)
+
+- Auto compaction rejections with `rejectionCause: "external-owner"` now render a single muted informational line ("The Claude Agent SDK manages and compacts this session's context natively.") at most once per delegation episode, instead of repainting a red error line on every rejected attempt. Manual `/compact` rejections keep their explicit error feedback.
+- A delegation episode is tracked entirely in the interactive layer from observed `compaction_end` events: it starts on an external-owner rejection and the one-time notice re-arms on a successful compaction, a model switch, or a session rebind. The logic does not depend on repeat rejection events arriving (the core attempt-suppression half of #1174 lands separately).
+- The footer context meter appends an ` (SDK)` marker while a delegation episode is active (`FooterComponent.setCompactionDelegated`, optional on `InteractiveFooter`), so a saturated meter reads as "compacted natively by the SDK" rather than a stall. The marker rides the existing tail segment and respects the footer width ladder.
+
 ## 2026-08-28 - Hydrate setup-only proxy mirrors from host state
 
 - Proxy refresh now hydrates the explicit session path with authoritative host entries when deferred persistence has not created the file yet, so setup entries are visible immediately in replacement contexts.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -11,9 +11,14 @@
   tracked entirely in the interactive layer from observed `compaction_end` events: it starts on an
   external-owner rejection and the one-time notice re-arms on a successful compaction, a model switch
   (selector, keyboard/favorite `cycleModel`, or retry provider failover via `retry_fallback_applied`),
-  a session rebind, or any full transcript rerender (`renderInitialMessages`/`rebuildChatFromMessages`,
-  covering branch/tree navigation, reload, and settings-driven rebuilds); the logic does not depend on
-  repeat rejection events arriving (the core attempt-suppression half of #1174 lands separately). The
+  a session rebind, a session reload, tree/branch navigation rerenders
+  (`renderInitialMessages`), a `model_changed` event (including shared-host/other-client
+  switches), or retry provider failover via `retry_fallback_applied`; cosmetic transcript
+  rebuilds (hide-thinking, cache-notice visibility, output padding via
+  `rebuildChatFromMessages`) deliberately preserve the episode, because post-#1188 core
+  emits no repeat rejection event to restore cleared state. The logic does not depend on
+  repeat rejection events arriving (the core attempt-suppression half of #1174 landed in
+  #1188). The
   external-owner branch is checked before the `aborted` branch because production rejections are
   emitted via `_rejectCompaction(..., true, reason)` and carry `aborted: true`.
 - `components/footer.ts`: the context meter appends an ` (SDK)` marker while a delegation episode is

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -9,12 +9,19 @@
   natively.") at most once per delegation episode, instead of repainting a red error line on every
   rejected attempt. Manual `/compact` rejections keep their explicit error feedback. The episode is
   tracked entirely in the interactive layer from observed `compaction_end` events: it starts on an
-  external-owner rejection and the one-time notice re-arms on a successful compaction, a model switch,
-  or a session rebind; the logic does not depend on repeat rejection events arriving (the core
-  attempt-suppression half of #1174 lands separately).
+  external-owner rejection and the one-time notice re-arms on a successful compaction, a model switch
+  (selector, keyboard/favorite `cycleModel`, or retry provider failover via `retry_fallback_applied`),
+  a session rebind, or any full transcript rerender (`renderInitialMessages`/`rebuildChatFromMessages`,
+  covering branch/tree navigation, reload, and settings-driven rebuilds); the logic does not depend on
+  repeat rejection events arriving (the core attempt-suppression half of #1174 lands separately). The
+  external-owner branch is checked before the `aborted` branch because production rejections are
+  emitted via `_rejectCompaction(..., true, reason)` and carry `aborted: true`.
 - `components/footer.ts`: the context meter appends an ` (SDK)` marker while a delegation episode is
   active, so a saturated meter reads as "compacted natively by the SDK" rather than a stall. The marker
-  rides the existing tail segment and respects the footer width ladder.
+  rides the existing tail segment and respects the footer width ladder; when head elision would leave a
+  chopped fragment (e.g. "…SDK)"), the layout is re-planned without the marker so it renders complete or
+  not at all. The marker stays muted even when the >90% meter is error-tinted — delegation is expected
+  state, not alarm.
 - `grok/chrome.ts`: `InteractiveFooter` gains the optional `setCompactionDelegated` seam that feeds the
   marker.
 

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -99,6 +99,7 @@ export class FooterComponent implements Component {
 	private session: InteractiveSession;
 	private footerData: ReadonlyFooterDataProvider;
 	private autoCompactEnabled = true;
+	private compactionDelegated = false;
 
 	constructor(session: InteractiveSession, footerData: ReadonlyFooterDataProvider) {
 		this.session = session;
@@ -111,6 +112,15 @@ export class FooterComponent implements Component {
 
 	setAutoCompactEnabled(enabled: boolean): void {
 		this.autoCompactEnabled = enabled;
+	}
+
+	/**
+	 * Marks the context meter while an external owner (the Claude Agent SDK)
+	 * manages compaction natively, so a saturated meter reads as delegated
+	 * rather than stalled.
+	 */
+	setCompactionDelegated(delegated: boolean): void {
+		this.compactionDelegated = delegated;
 	}
 
 	/**
@@ -186,10 +196,11 @@ export class FooterComponent implements Component {
 		}
 
 		const autoIndicator = this.autoCompactEnabled ? " (auto)" : "";
+		const delegationIndicator = this.compactionDelegated ? " (SDK)" : "";
 		const ctxDisplay =
 			contextPercent === "?"
-				? `${contextTokens}/${formatTokens(contextWindow)} (?)${autoIndicator}`
-				: `${contextTokens}/${formatTokens(contextWindow)} (${contextPercent}%)${autoIndicator}`;
+				? `${contextTokens}/${formatTokens(contextWindow)} (?)${autoIndicator}${delegationIndicator}`
+				: `${contextTokens}/${formatTokens(contextWindow)} (${contextPercent}%)${autoIndicator}${delegationIndicator}`;
 		const ctxColored =
 			contextPercentValue > 90
 				? theme.fg("error", ctxDisplay)

--- a/packages/coding-agent/src/modes/interactive/components/footer.ts
+++ b/packages/coding-agent/src/modes/interactive/components/footer.ts
@@ -197,17 +197,23 @@ export class FooterComponent implements Component {
 
 		const autoIndicator = this.autoCompactEnabled ? " (auto)" : "";
 		const delegationIndicator = this.compactionDelegated ? " (SDK)" : "";
-		const ctxDisplay =
+		const ctxBase =
 			contextPercent === "?"
-				? `${contextTokens}/${formatTokens(contextWindow)} (?)${autoIndicator}${delegationIndicator}`
-				: `${contextTokens}/${formatTokens(contextWindow)} (${contextPercent}%)${autoIndicator}${delegationIndicator}`;
-		const ctxColored =
+				? `${contextTokens}/${formatTokens(contextWindow)} (?)${autoIndicator}`
+				: `${contextTokens}/${formatTokens(contextWindow)} (${contextPercent}%)${autoIndicator}`;
+		const colorCtx = (text: string): string =>
 			contextPercentValue > 90
-				? theme.fg("error", ctxDisplay)
+				? theme.fg("error", text)
 				: contextPercentValue > 70
-					? theme.fg("warning", ctxDisplay)
-					: theme.fg("muted", ctxDisplay);
-		const tail: FooterSegment = { plain: ctxDisplay, colored: ctxColored };
+					? theme.fg("warning", text)
+					: theme.fg("muted", text);
+		// The delegation marker stays muted even when the saturated meter is
+		// error/warning tinted: SDK-owned compaction is expected state, not alarm.
+		const makeTail = (withMarker: boolean): FooterSegment => ({
+			plain: withMarker ? `${ctxBase}${delegationIndicator}` : ctxBase,
+			colored: withMarker ? `${colorCtx(ctxBase)}${theme.fg("muted", delegationIndicator)}` : colorCtx(ctxBase),
+		});
+		let tail: FooterSegment = makeTail(delegationIndicator !== "");
 
 		// Model label pinned to the right edge; the provider prefix stays only when
 		// the full line fits.
@@ -239,17 +245,30 @@ export class FooterComponent implements Component {
 			: undefined;
 
 		const marker: FooterSegment = { plain: "…", colored: theme.fg("dim", "…") };
-		const plan = planFooterLayout({
-			width,
-			anchor,
-			pwdIndex,
-			middle,
-			tail,
-			right: { minimal, full },
-			separator,
-			minPadding: 2,
-			ellipsisMarker: marker,
-		});
+		const planWithTail = (tailSegment: FooterSegment) =>
+			planFooterLayout({
+				width,
+				anchor,
+				pwdIndex,
+				middle,
+				tail: tailSegment,
+				right: { minimal, full },
+				separator,
+				minPadding: 2,
+				ellipsisMarker: marker,
+			});
+		let plan = planWithTail(tail);
+		// Head elision keeps the string tail, so at narrow widths it can leave a
+		// chopped marker fragment like "…SDK)". Render the complete marker or drop
+		// it entirely — never a fragment.
+		if (
+			delegationIndicator !== "" &&
+			plan.kind === "left-elided" &&
+			!plan.leftPlain.includes(delegationIndicator.trimStart())
+		) {
+			tail = makeTail(false);
+			plan = planWithTail(tail);
+		}
 
 		const joinSegments = (segments: readonly FooterSegment[]): { colored: string; width: number } => ({
 			colored: segments.map((segment) => segment.colored).join(sepColored),

--- a/packages/coding-agent/src/modes/interactive/grok/chrome.ts
+++ b/packages/coding-agent/src/modes/interactive/grok/chrome.ts
@@ -16,6 +16,8 @@ import { GrokWelcomeCard } from "./welcome-card.ts";
 export interface InteractiveFooter extends Component {
 	setSession(session: InteractiveSession): void;
 	setAutoCompactEnabled(enabled: boolean): void;
+	/** Optional: mark the context meter while an external owner compacts natively. */
+	setCompactionDelegated?(delegated: boolean): void;
 	invalidate(): void;
 	dispose(): void;
 }

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4623,7 +4623,28 @@ export class InteractiveMode {
 				InteractiveMode.restoreCompactionEscapeOverride(this);
 				this.clearStatusIndicator("compaction");
 				this.autoCompactionProgressText = "";
-				if (event.aborted) {
+				// Checked before `aborted`: production external-owner rejections are
+				// emitted via `_rejectCompaction(..., true, reason)` and carry
+				// `aborted: true`, so this branch must win for auto reasons or the
+				// delegation state renders as a per-turn red error.
+				if (event.rejectionCause === "external-owner" && event.reason !== "manual") {
+					// Auto compaction is delegated to an external owner (Claude Agent SDK).
+					// This is expected state, not an error: surface it at most once per
+					// delegation episode as a muted informational line and mark the footer
+					// so the saturated context meter reads as "handled natively".
+					if (!this.externalOwnerCompactionNoticeShown) {
+						this.externalOwnerCompactionNoticeShown = true;
+						this.chatContainer.addChild(new Spacer(1));
+						this.chatContainer.addChild(
+							new Text(
+								theme.fg("muted", "The Claude Agent SDK manages and compacts this session's context natively."),
+								1,
+								0,
+							),
+						);
+					}
+					this.footer?.setCompactionDelegated?.(true);
+				} else if (event.aborted) {
 					// Prefer the extension-provided reason over the generic "cancelled"
 					// label so per-turn-cap / circuit-breaker / provider-error cancels are
 					// no longer indistinguishable from a user-triggered abort.
@@ -4683,23 +4704,6 @@ export class InteractiveMode {
 					// A real compaction landed: the delegation episode (if any) is over.
 					this.externalOwnerCompactionNoticeShown = false;
 					this.footer?.setCompactionDelegated?.(false);
-				} else if (event.rejectionCause === "external-owner" && event.reason !== "manual") {
-					// Auto compaction is delegated to an external owner (Claude Agent SDK).
-					// This is expected state, not an error: surface it at most once per
-					// delegation episode as a muted informational line and mark the footer
-					// so the saturated context meter reads as "handled natively".
-					if (!this.externalOwnerCompactionNoticeShown) {
-						this.externalOwnerCompactionNoticeShown = true;
-						this.chatContainer.addChild(new Spacer(1));
-						this.chatContainer.addChild(
-							new Text(
-								theme.fg("muted", "The Claude Agent SDK manages and compacts this session's context natively."),
-								1,
-								0,
-							),
-						);
-					}
-					this.footer?.setCompactionDelegated?.(true);
 				} else if (event.errorMessage) {
 					const errorMessage = sanitizeTerminalLabel(event.errorMessage);
 					if (event.reason === "manual") {
@@ -4781,6 +4785,10 @@ export class InteractiveMode {
 					why: `Retry switched models (${event.reason}); the turn continues on ${event.to}.`,
 				});
 				this.setExtensionStatus(FALLBACK_STATUS_KEY, `fallback: ${event.to}`);
+				// Provider/model failover ends any external-owner delegation episode:
+				// the fallback model does not inherit SDK-owned compaction state.
+				this.externalOwnerCompactionNoticeShown = false;
+				this.footer?.setCompactionDelegated?.(false);
 				break;
 			}
 
@@ -5419,6 +5427,11 @@ export class InteractiveMode {
 	}
 
 	renderInitialMessages(): void {
+		// Any full transcript rerender ends the external-owner delegation episode:
+		// the rendered notice is gone, so the guard must re-arm and the footer
+		// marker must not persist as stale state.
+		this.externalOwnerCompactionNoticeShown = false;
+		this.footer?.setCompactionDelegated?.(false);
 		const entries = this.sessionManager.buildContextEntries();
 		this.renderSessionEntries(entries, {
 			updateFooter: true,
@@ -5498,6 +5511,10 @@ export class InteractiveMode {
 	}
 
 	private rebuildChatFromMessages(): void {
+		// Transcript rebuild wipes the rendered notice; re-arm the delegation
+		// episode so the next external-owner rejection surfaces it again.
+		this.externalOwnerCompactionNoticeShown = false;
+		this.footer?.setCompactionDelegated?.(false);
 		try {
 			this.sessionManager?.reloadFromDisk?.();
 		} catch {
@@ -5854,6 +5871,9 @@ export class InteractiveMode {
 				this.showStatus(msg);
 			} else {
 				this.footer.invalidate();
+				// A model switch ends any external-owner delegation episode.
+				this.externalOwnerCompactionNoticeShown = false;
+				this.footer?.setCompactionDelegated?.(false);
 				this.updateEditorBorderColor();
 				const thinkingStr =
 					result.model.reasoning && result.thinkingLevel !== "off" ? ` (thinking: ${result.thinkingLevel})` : "";

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -920,6 +920,12 @@ export class InteractiveMode {
 	// Auto-compaction state
 	private autoCompactionEscapeHandler?: () => void;
 	private compactionEscapeOverrideActive = false;
+	/**
+	 * One-time notice guard for the external-owner compaction delegation episode
+	 * (e.g. the Claude Agent SDK owning compaction). Armed while true; re-armed by
+	 * a successful compaction, a model switch, or a session rebind.
+	 */
+	private externalOwnerCompactionNoticeShown = false;
 	private autoCompactionProgressText = "";
 
 	// Auto-retry state
@@ -2597,6 +2603,9 @@ export class InteractiveMode {
 
 	private async rebindCurrentSession(options: { renderBeforeBind?: boolean } = {}): Promise<void> {
 		InteractiveMode.restoreCompactionEscapeOverride(this);
+		// A session switch/reset ends any external-owner delegation episode.
+		this.externalOwnerCompactionNoticeShown = false;
+		this.footer.setCompactionDelegated?.(false);
 		const session = this.session;
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
@@ -4671,6 +4680,26 @@ export class InteractiveMode {
 						this.addMessageToChat(summaryMessage);
 					}
 					this.footer.invalidate();
+					// A real compaction landed: the delegation episode (if any) is over.
+					this.externalOwnerCompactionNoticeShown = false;
+					this.footer.setCompactionDelegated?.(false);
+				} else if (event.rejectionCause === "external-owner" && event.reason !== "manual") {
+					// Auto compaction is delegated to an external owner (Claude Agent SDK).
+					// This is expected state, not an error: surface it at most once per
+					// delegation episode as a muted informational line and mark the footer
+					// so the saturated context meter reads as "handled natively".
+					if (!this.externalOwnerCompactionNoticeShown) {
+						this.externalOwnerCompactionNoticeShown = true;
+						this.chatContainer.addChild(new Spacer(1));
+						this.chatContainer.addChild(
+							new Text(
+								theme.fg("muted", "The Claude Agent SDK manages and compacts this session's context natively."),
+								1,
+								0,
+							),
+						);
+					}
+					this.footer.setCompactionDelegated?.(true);
 				} else if (event.errorMessage) {
 					const errorMessage = sanitizeTerminalLabel(event.errorMessage);
 					if (event.reason === "manual") {
@@ -6664,6 +6693,9 @@ export class InteractiveMode {
 		try {
 			const systemPromptChange = await this.session.setModel(model);
 			this.footer.invalidate();
+			// A model switch ends any external-owner delegation episode.
+			this.externalOwnerCompactionNoticeShown = false;
+			this.footer.setCompactionDelegated?.(false);
 			this.updateEditorBorderColor();
 			const systemPromptStr = systemPromptChange?.systemPromptName
 				? ` (optimized system prompt applied: ${systemPromptChange.systemPromptName})`

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2605,7 +2605,7 @@ export class InteractiveMode {
 		InteractiveMode.restoreCompactionEscapeOverride(this);
 		// A session switch/reset ends any external-owner delegation episode.
 		this.externalOwnerCompactionNoticeShown = false;
-		this.footer.setCompactionDelegated?.(false);
+		this.footer?.setCompactionDelegated?.(false);
 		const session = this.session;
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
@@ -4682,7 +4682,7 @@ export class InteractiveMode {
 					this.footer.invalidate();
 					// A real compaction landed: the delegation episode (if any) is over.
 					this.externalOwnerCompactionNoticeShown = false;
-					this.footer.setCompactionDelegated?.(false);
+					this.footer?.setCompactionDelegated?.(false);
 				} else if (event.rejectionCause === "external-owner" && event.reason !== "manual") {
 					// Auto compaction is delegated to an external owner (Claude Agent SDK).
 					// This is expected state, not an error: surface it at most once per
@@ -4699,7 +4699,7 @@ export class InteractiveMode {
 							),
 						);
 					}
-					this.footer.setCompactionDelegated?.(true);
+					this.footer?.setCompactionDelegated?.(true);
 				} else if (event.errorMessage) {
 					const errorMessage = sanitizeTerminalLabel(event.errorMessage);
 					if (event.reason === "manual") {
@@ -6695,7 +6695,7 @@ export class InteractiveMode {
 			this.footer.invalidate();
 			// A model switch ends any external-owner delegation episode.
 			this.externalOwnerCompactionNoticeShown = false;
-			this.footer.setCompactionDelegated?.(false);
+			this.footer?.setCompactionDelegated?.(false);
 			this.updateEditorBorderColor();
 			const systemPromptStr = systemPromptChange?.systemPromptName
 				? ` (optimized system prompt applied: ${systemPromptChange.systemPromptName})`

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -4773,6 +4773,15 @@ export class InteractiveMode {
 				break;
 			}
 
+			case "model_changed":
+				// Shared-host/other-client model switches arrive as model_changed wire
+				// events; the new model must not inherit the previous model's
+				// SDK-delegation episode (post-#1188 core emits no repeat rejection to
+				// self-heal a stale marker).
+				this.externalOwnerCompactionNoticeShown = false;
+				this.footer?.setCompactionDelegated?.(false);
+				break;
+
 			case "retry_fallback_applied": {
 				if (this.pendingZeroDelayRetryIndicator) {
 					this.pendingZeroDelayRetryIndicator.fallbackApplied = true;
@@ -5511,10 +5520,6 @@ export class InteractiveMode {
 	}
 
 	private rebuildChatFromMessages(): void {
-		// Transcript rebuild wipes the rendered notice; re-arm the delegation
-		// episode so the next external-owner rejection surfaces it again.
-		this.externalOwnerCompactionNoticeShown = false;
-		this.footer?.setCompactionDelegated?.(false);
 		try {
 			this.sessionManager?.reloadFromDisk?.();
 		} catch {
@@ -7953,6 +7958,12 @@ export class InteractiveMode {
 			this.resetExtensionUI();
 			this.hideThinkingBlock = this.settingsManager.getHideThinkingBlock();
 			this.outputPad = this.settingsManager.getOutputPad();
+			// Reload replaces the session runner: a genuine ownership boundary, so the
+			// external-owner delegation episode ends here (settings-only rebuilds below
+			// go through rebuildChatFromMessages and must NOT reset it — post-#1188 core
+			// emits no repeat rejection event to restore cleared state).
+			this.externalOwnerCompactionNoticeShown = false;
+			this.footer?.setCompactionDelegated?.(false);
 			this.rebuildChatFromMessages();
 			time("chatRebuild", "reload");
 			chatRestoredBeforeSessionStart = true;

--- a/packages/coding-agent/test/footer-sdk-delegation.test.ts
+++ b/packages/coding-agent/test/footer-sdk-delegation.test.ts
@@ -1,0 +1,41 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, it } from "vitest";
+import { FooterComponent } from "../src/modes/interactive/components/footer.ts";
+import { initTheme } from "../src/modes/interactive/theme/theme.ts";
+import { stripAnsi } from "../src/utils/ansi.ts";
+import { createFooterData, createFooterSession as createFooterSessionFixture } from "./helpers/footer-test-fixtures.ts";
+
+function createFooterSession(sessionName: string) {
+	const session = createFooterSessionFixture({ sessionName });
+	Object.assign(session, { modelRuntime: { isUsingSubscription: () => false } });
+	return session;
+}
+
+describe("FooterComponent SDK delegation marker", () => {
+	beforeAll(() => {
+		initTheme(undefined, false);
+	});
+
+	it("shows the (SDK) marker while a delegation episode is active and drops it after", () => {
+		const footer = new FooterComponent(createFooterSession("s"), createFooterData(1));
+
+		expect(stripAnsi(footer.render(120).join("\n"))).not.toContain("(SDK)");
+
+		footer.setCompactionDelegated(true);
+		expect(stripAnsi(footer.render(120).join("\n"))).toContain("(SDK)");
+
+		footer.setCompactionDelegated(false);
+		expect(stripAnsi(footer.render(120).join("\n"))).not.toContain("(SDK)");
+	});
+
+	it("stays within the width budget with the marker present", () => {
+		const footer = new FooterComponent(createFooterSession("中文".repeat(30)), createFooterData(2));
+		footer.setCompactionDelegated(true);
+
+		for (const width of [40, 60, 93]) {
+			for (const line of footer.render(width)) {
+				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+		}
+	});
+});

--- a/packages/coding-agent/test/footer-sdk-delegation.test.ts
+++ b/packages/coding-agent/test/footer-sdk-delegation.test.ts
@@ -5,8 +5,8 @@ import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 import { stripAnsi } from "../src/utils/ansi.ts";
 import { createFooterData, createFooterSession as createFooterSessionFixture } from "./helpers/footer-test-fixtures.ts";
 
-function createFooterSession(sessionName: string) {
-	const session = createFooterSessionFixture({ sessionName });
+function createFooterSession(sessionName: string, options: { reasoning?: boolean; thinkingLevel?: string } = {}) {
+	const session = createFooterSessionFixture({ sessionName, ...options });
 	Object.assign(session, { modelRuntime: { isUsingSubscription: () => false } });
 	return session;
 }
@@ -35,6 +35,33 @@ describe("FooterComponent SDK delegation marker", () => {
 		for (const width of [40, 60, 93]) {
 			for (const line of footer.render(width)) {
 				expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+			}
+		}
+	});
+
+	it("renders the complete (SDK) marker or omits it entirely at every width", () => {
+		// Head elision must never leave fragments like "…SDK)" behind.
+		const markerFragments = ["SDK)", "DK)", "K)"];
+		// The reasoning label ("test-model:high") widens the pinned right side so the
+		// left-elision budget lands inside the marker at narrow widths (reviewer repro).
+		const sessions = [
+			createFooterSession("s", { reasoning: true, thinkingLevel: "high" }),
+			createFooterSession("中文".repeat(30), { reasoning: true, thinkingLevel: "high" }),
+			createFooterSession("中文".repeat(30)),
+		];
+		for (const session of sessions) {
+			const footer = new FooterComponent(session, createFooterData(2));
+			footer.setCompactionDelegated(true);
+			for (let width = 20; width <= 100; width++) {
+				for (const line of footer.render(width)) {
+					expect(visibleWidth(line)).toBeLessThanOrEqual(width);
+					const plain = stripAnsi(line);
+					if (plain.includes("(SDK)")) continue;
+					expect(plain).not.toContain("SDK");
+					for (const fragment of markerFragments) {
+						expect(plain).not.toContain(fragment);
+					}
+				}
 			}
 		}
 	});

--- a/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
+++ b/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
@@ -58,10 +58,13 @@ const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
 	event: Record<string, unknown>,
 ) => Promise<void>;
 
-function externalOwnerEvent(reason = "threshold") {
+// Real production shape: core `_rejectCompaction(..., true, reason)` emits the
+// external-owner rejection with `aborted: true` (agent-session.ts _rejectCompaction).
+function externalOwnerEvent(reason = "pre_prompt") {
 	return {
 		type: "compaction_end",
 		reason,
+		aborted: true,
 		accepted: false,
 		rejectionCause: "external-owner",
 		errorMessage: EXTERNAL_OWNER_MESSAGE,
@@ -82,7 +85,7 @@ describe("external-owner compaction rejection rendering", () => {
 		initTheme("dark");
 	});
 
-	test("two auto external-owner rejections render exactly one muted notice and no error line", async () => {
+	test("two real-shape (aborted) auto external-owner rejections render exactly one muted notice and no error line", async () => {
 		const fakeThis = makeFakeThis();
 
 		await handleEvent.call(fakeThis, externalOwnerEvent());
@@ -155,6 +158,71 @@ describe("external-owner compaction rejection rendering", () => {
 
 		await handleEvent.call(fakeThis, externalOwnerEvent());
 		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(2);
+	});
+
+	test("cycleModel re-arms the one-time notice and clears the footer marker", async () => {
+		const fakeThis = Object.assign(makeFakeThis(), {
+			session: {
+				abortCompaction: vi.fn(),
+				cycleModel: vi.fn().mockResolvedValue({
+					model: { id: "next-model", name: "Next Model", reasoning: false },
+					thinkingLevel: "off",
+				}),
+				favoriteModels: [],
+			},
+			updateEditorBorderColor: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn().mockResolvedValue(undefined),
+		});
+		const cycleModel = Reflect.get(InteractiveMode.prototype, "cycleModel") as (
+			this: typeof fakeThis,
+			direction: "forward" | "backward",
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		await cycleModel.call(fakeThis, "forward");
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(false);
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(2);
+	});
+
+	test("retry_fallback_applied re-arms the one-time notice and clears the footer marker", async () => {
+		const fakeThis = Object.assign(makeFakeThis(), {
+			showNoticeBox: vi.fn(),
+			setExtensionStatus: vi.fn(),
+		});
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		await handleEvent.call(fakeThis, {
+			type: "retry_fallback_applied",
+			from: "model-a",
+			to: "model-b",
+			reason: "provider-error",
+		});
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(false);
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(2);
+	});
+
+	test("transcript rebuilds re-arm the notice so the next rejection renders it again", async () => {
+		const fakeThis = makeFakeThis();
+		const rebuildChatFromMessages = Reflect.get(InteractiveMode.prototype, "rebuildChatFromMessages") as (
+			this: FakeThis,
+		) => void;
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(1);
+
+		// Branch navigation / reload / settings rebuilds clear the chat and rerender.
+		rebuildChatFromMessages.call(fakeThis);
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(false);
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(0);
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(1);
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(true);
 	});
 
 	test("rebindCurrentSession tolerates harness contexts without a footer", async () => {

--- a/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
+++ b/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
@@ -13,6 +13,7 @@ function makeFakeThis() {
 	const chatContainer = new Container();
 	return {
 		isInitialized: true,
+		externalOwnerCompactionNoticeShown: false,
 		footer: { invalidate: vi.fn(), setCompactionDelegated: vi.fn() },
 		autoCompactionEscapeHandler: undefined as (() => void) | undefined,
 		autoCompactionLoader: undefined as { stop(): void } | undefined,
@@ -33,7 +34,10 @@ function makeFakeThis() {
 					tokensBefore: 1,
 				},
 			]),
+			reloadFromDisk: vi.fn(),
+			countCompactions: vi.fn().mockReturnValue(0),
 		},
+		renderProjectTrustWarningIfNeeded: vi.fn(),
 		rebuildChatFromMessages: vi.fn(),
 		renderSessionEntries: vi.fn(),
 		addMessageToChat: vi.fn(),
@@ -206,23 +210,65 @@ describe("external-owner compaction rejection rendering", () => {
 		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(2);
 	});
 
-	test("transcript rebuilds re-arm the notice so the next rejection renders it again", async () => {
+	test("settings-only transcript rebuilds preserve the active delegation episode", async () => {
+		// Post-#1188 core never re-emits the rejection while delegated, so a cosmetic
+		// rebuild (hide-thinking, cache-notice, output padding) must not lose the
+		// guard or the footer marker.
 		const fakeThis = makeFakeThis();
 		const rebuildChatFromMessages = Reflect.get(InteractiveMode.prototype, "rebuildChatFromMessages") as (
 			this: FakeThis,
 		) => void;
 
 		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(fakeThis.externalOwnerCompactionNoticeShown).toBe(true);
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(true);
+
+		rebuildChatFromMessages.call(fakeThis);
+
+		// Episode state survives the rebuild; the rendered notice was cleared with
+		// the chat, but the marker stays authoritative and the guard still suppresses
+		// any (hypothetical) repeat notice.
+		expect(fakeThis.externalOwnerCompactionNoticeShown).toBe(true);
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(true);
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(0);
+	});
+
+	test("tree navigation rerenders reset the delegation episode", async () => {
+		const fakeThis = makeFakeThis();
+		const renderInitialMessages = Reflect.get(InteractiveMode.prototype, "renderInitialMessages") as (
+			this: FakeThis,
+		) => void;
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
 		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(1);
 
-		// Branch navigation / reload / settings rebuilds clear the chat and rerender.
-		rebuildChatFromMessages.call(fakeThis);
+		// Branch/tree navigation clears the chat and rerenders via renderInitialMessages.
+		fakeThis.chatContainer.clear();
+		renderInitialMessages.call(fakeThis);
 		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(false);
 		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(0);
 
 		await handleEvent.call(fakeThis, externalOwnerEvent());
 		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(1);
 		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(true);
+	});
+
+	test("a model_changed event resets the delegation episode", async () => {
+		const fakeThis = makeFakeThis();
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(fakeThis.externalOwnerCompactionNoticeShown).toBe(true);
+
+		await handleEvent.call(fakeThis, {
+			type: "model_changed",
+			model: { id: "other-model", provider: "other", reasoning: false },
+			thinkingLevel: "off",
+			source: "selector",
+		});
+
+		expect(fakeThis.externalOwnerCompactionNoticeShown).toBe(false);
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(false);
 	});
 
 	test("rebindCurrentSession tolerates harness contexts without a footer", async () => {

--- a/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
+++ b/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
@@ -156,4 +156,26 @@ describe("external-owner compaction rejection rendering", () => {
 		await handleEvent.call(fakeThis, externalOwnerEvent());
 		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(2);
 	});
+
+	test("rebindCurrentSession tolerates harness contexts without a footer", async () => {
+		// Mirrors the minimal RebindContext used by
+		// test/suite/regressions/5943-session-start-notify.test.ts: no footer, no
+		// chrome. The delegation reset must not dereference the absent receiver.
+		const context = {
+			applyRuntimeSettings: vi.fn(),
+			renderCurrentSessionState: vi.fn(),
+			bindCurrentSessionExtensions: vi.fn().mockResolvedValue(undefined),
+			subscribeToAgent: vi.fn(),
+			updateAvailableProviderCount: vi.fn().mockResolvedValue(undefined),
+			updateEditorBorderColor: vi.fn(),
+			updateTerminalTitle: vi.fn(),
+		};
+		const rebindCurrentSession = Reflect.get(InteractiveMode.prototype, "rebindCurrentSession") as (
+			this: typeof context,
+			options?: { renderBeforeBind?: boolean },
+		) => Promise<void>;
+
+		await expect(rebindCurrentSession.call(context)).resolves.toBeUndefined();
+		expect(context.bindCurrentSessionExtensions).toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
+++ b/packages/coding-agent/test/interactive-mode-external-owner-notice.test.ts
@@ -1,0 +1,159 @@
+import { Container } from "@earendil-works/pi-tui";
+import { beforeAll, describe, expect, test, vi } from "vitest";
+import { InteractiveMode } from "../src/modes/interactive/interactive-mode.ts";
+import { initTheme, theme } from "../src/modes/interactive/theme/theme.ts";
+
+function stripAnsi(value: string): string {
+	return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+const EXTERNAL_OWNER_MESSAGE = "Compaction rejected: the Claude Agent SDK owns compaction for this session";
+
+function makeFakeThis() {
+	const chatContainer = new Container();
+	return {
+		isInitialized: true,
+		footer: { invalidate: vi.fn(), setCompactionDelegated: vi.fn() },
+		autoCompactionEscapeHandler: undefined as (() => void) | undefined,
+		autoCompactionLoader: undefined as { stop(): void } | undefined,
+		autoCompactionProgressText: "",
+		defaultEditor: {} as { onEscape?: () => void },
+		session: { abortCompaction: vi.fn() },
+		statusContainer: { clear: vi.fn() },
+		chatContainer,
+		sessionManager: {
+			buildContextEntries: vi.fn().mockReturnValue([
+				{
+					type: "compaction",
+					id: "latest",
+					parentId: null,
+					timestamp: "2025-01-01T00:00:00Z",
+					summary: "summary",
+					firstKeptEntryId: "kept",
+					tokensBefore: 1,
+				},
+			]),
+		},
+		rebuildChatFromMessages: vi.fn(),
+		renderSessionEntries: vi.fn(),
+		addMessageToChat: vi.fn(),
+		addCompactionCostNotice: vi.fn(),
+		showError: vi.fn(),
+		showWarning: vi.fn(),
+		showStatus: vi.fn(),
+		clearStatusIndicator: vi.fn(),
+		compactionQueuedMessages: [] as Array<{ text: string; mode: "steer" | "followUp" }>,
+		getSessionLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+		flushCompactionQueue: vi.fn().mockResolvedValue(undefined),
+		restoreQueuedMessagesToEditor: vi.fn().mockReturnValue(0),
+		settingsManager: { getShowTerminalProgress: () => false },
+		ui: { requestRender: vi.fn(), terminal: { setProgress: vi.fn() } },
+	};
+}
+
+type FakeThis = ReturnType<typeof makeFakeThis>;
+
+const handleEvent = Reflect.get(InteractiveMode.prototype, "handleEvent") as (
+	this: FakeThis,
+	event: Record<string, unknown>,
+) => Promise<void>;
+
+function externalOwnerEvent(reason = "threshold") {
+	return {
+		type: "compaction_end",
+		reason,
+		accepted: false,
+		rejectionCause: "external-owner",
+		errorMessage: EXTERNAL_OWNER_MESSAGE,
+		willRetry: false,
+	};
+}
+
+function renderChat(fakeThis: FakeThis): string {
+	return fakeThis.chatContainer.render(120).join("\n");
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+	return haystack.split(needle).length - 1;
+}
+
+describe("external-owner compaction rejection rendering", () => {
+	beforeAll(() => {
+		initTheme("dark");
+	});
+
+	test("two auto external-owner rejections render exactly one muted notice and no error line", async () => {
+		const fakeThis = makeFakeThis();
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+
+		const raw = renderChat(fakeThis);
+		const plain = stripAnsi(raw);
+		expect(plain).not.toContain(EXTERNAL_OWNER_MESSAGE);
+		expect(countOccurrences(plain, "Claude Agent SDK")).toBe(1);
+		// Muted informational styling, not error styling.
+		const noticeLine = plain
+			.split("\n")
+			.find((line) => line.includes("Claude Agent SDK"))
+			?.trim();
+		expect(noticeLine).toBeTruthy();
+		expect(raw).toContain(theme.fg("muted", noticeLine as string));
+		expect(raw).not.toContain(theme.fg("error", noticeLine as string));
+		expect(fakeThis.showError).not.toHaveBeenCalled();
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenCalledWith(true);
+	});
+
+	test("manual external-owner rejection keeps explicit error feedback", async () => {
+		const fakeThis = makeFakeThis();
+
+		await handleEvent.call(fakeThis, externalOwnerEvent("manual"));
+
+		expect(fakeThis.showError).toHaveBeenCalledWith(EXTERNAL_OWNER_MESSAGE);
+		expect(stripAnsi(renderChat(fakeThis))).not.toContain("Claude Agent SDK");
+	});
+
+	test("a successful compaction re-arms the one-time notice", async () => {
+		const fakeThis = makeFakeThis();
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(1);
+
+		await handleEvent.call(fakeThis, {
+			type: "compaction_end",
+			reason: "threshold",
+			accepted: true,
+			result: { summary: "compacted", tokensBefore: 100 },
+			willRetry: false,
+		});
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(false);
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(1);
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(true);
+	});
+
+	test("a model switch re-arms the one-time notice", async () => {
+		const fakeThis = Object.assign(makeFakeThis(), {
+			session: {
+				abortCompaction: vi.fn(),
+				setModel: vi.fn().mockResolvedValue(undefined),
+			},
+			updateEditorBorderColor: vi.fn(),
+			showRiskyMainModelWarning: vi.fn(),
+			maybeWarnAboutAnthropicSubscriptionAuth: vi.fn().mockResolvedValue(undefined),
+			checkDaxnutsEasterEgg: vi.fn(),
+		});
+		const selectModelFromUi = Reflect.get(InteractiveMode.prototype, "selectModelFromUi") as (
+			this: typeof fakeThis,
+			model: { id: string },
+		) => Promise<void>;
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		await selectModelFromUi.call(fakeThis, { id: "some-model" });
+		expect(fakeThis.footer.setCompactionDelegated).toHaveBeenLastCalledWith(false);
+
+		await handleEvent.call(fakeThis, externalOwnerEvent());
+		expect(countOccurrences(stripAnsi(renderChat(fakeThis)), "Claude Agent SDK")).toBe(2);
+	});
+});


### PR DESCRIPTION
## What

UX half of #1174. On the claude-sdk-oauth lane, every auto compaction attempt is rejected with `rejectionCause: "external-owner"`, and the interactive TUI repainted the same red error line on every occurrence once the local context estimate crossed the threshold.

- `interactive-mode.ts`: external-owner auto rejections now render a single muted informational line — "The Claude Agent SDK manages and compacts this session's context natively." — at most once per delegation episode. Manual `/compact` rejections keep their existing explicit error feedback.
- Delegation-episode tracking lives entirely in the interactive layer, derived from observed `compaction_end` events: an external-owner rejection starts an episode; a successful compaction, model switch, or session rebind ends it and re-arms the notice. The logic does not depend on repeat rejection events arriving, so it stays correct once the core attempt-suppression half of #1174 lands separately.
- `footer.ts`: the context meter gains an ` (SDK)` marker while an episode is active (`setCompactionDelegated`, optional on `InteractiveFooter`), so a meter sitting at 1M/1M reads as "SDK will compact natively", not a stall. The marker rides the existing tail segment and respects the footer width ladder.

## Why

An expected, permanent delegation state was surfaced as a recurring error (twice per tool-call turn), and the saturated context meter gave no hint that compaction is owned by the Claude Agent SDK. Maintainer-agreed fix: render it once, as state, not per turn.

## Verification

Failing-first: new tests captured RED before the change —

```
 Test Files  2 failed (2)
      Tests  5 failed | 1 passed (6)
```

GREEN after:

```
 Test Files  2 passed (2)
      Tests  6 passed (6)
```

Existing interactive compaction + footer suites stay green:

```
 Test Files  7 passed (7)
      Tests  46 passed (46)
```

`npx tsc --noEmit` clean; `npx biome check` clean on touched files; full pre-commit gate (biome, pinned-deps, shrinkwrap, tsc) passed on both commits.

Covers: two external-owner auto rejections => exactly one muted line and zero error-styled lines; manual rejection keeps explicit feedback; successful compaction and model switch re-arm the notice; footer shows/drops the `(SDK)` marker and stays within width budgets (40/60/93 cols, CJK session names).

Refs #1174 (UX half; core attempt-suppression lands separately).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders external-owner compaction rejections once as a muted informational line instead of repainting the same red error every turn, and marks the footer context meter with `(SDK)` while the Claude Agent SDK owns compaction.

Manual `/compact` rejections keep their explicit error feedback. A delegation episode starts on an external-owner rejection and re-arms only at genuine boundaries: successful compaction, model switch (selector, `cycleModel`, retry failover, or `model_changed`), session rebind/reload, or tree navigation rerender. Cosmetic transcript rebuilds preserve the episode because post-#1188 core emits no repeat rejection to restore cleared state. The external-owner branch wins over the `aborted` branch since production rejections carry `aborted: true`, and reset call sites tolerate contexts without an `InteractiveFooter`. The `(SDK)` marker stays muted even on an error-tinted meter and renders complete or not at all.

<sup>Written for commit 148ccb8bee1f5a44f96385bce6fed0088ef2f209. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

