### PR TITLE
fix(coding-agent): stop repeated delegated compaction attempts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 ### Fixed
 
+- On the `claude-sdk-oauth` lane, automatic compaction no longer re-attempts and re-logs a rejection
+  every turn after the Claude Agent SDK owns compaction: the first `external-owner` rejection makes the
+  delegation sticky until compaction is accepted, the model or provider changes, or the session
+  navigates to another branch. Manual `/compact` behavior is unchanged.
+
 ### Removed
 
 ## [2026.8.29] - 2026-08-29

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6251,6 +6251,7 @@ export class AgentSession {
 	}
 
 	private _refreshCurrentModelFromRegistry(): void {
+		this._delegatedCompactionKey = undefined;
 		const currentModel = this.model;
 		if (!currentModel) {
 			return;
@@ -6702,6 +6703,7 @@ export class AgentSession {
 		includeAllExtensionTools?: boolean;
 		previousActiveToolRegistrationIds?: ReadonlyMap<string, string>;
 	}): void {
+		this._delegatedCompactionKey = undefined;
 		const autoResizeImages = this.settingsManager.getImageAutoResize();
 		const shellCommandPrefix = this.settingsManager.getShellCommandPrefix();
 		const shellPath = this.settingsManager.getShellPath();
@@ -6783,6 +6785,7 @@ export class AgentSession {
 		});
 		time("shutdown", "reload");
 		await this.settingsManager.reload();
+		this._delegatedCompactionKey = undefined;
 		this.syncQueueModesFromSettings();
 		resetApiProviders();
 		time("settings", "reload");

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -890,6 +890,7 @@ export class AgentSession {
 	// response must not retrigger threshold compaction from stale provider usage.
 	private _skipNextPostRetryCompactionCheck = false;
 	private _blockedPostCompactionAssistant: { assistant: AssistantMessage; revision: number } | undefined;
+	private _delegatedCompactionKey: { provider: string; id: string } | undefined;
 	private _skipNextPostCompactionAssistantCheck = false;
 	private _scheduledContinuationRecompacted = false;
 	private readonly _assistantsPendingAtCompaction = new WeakSet<AssistantMessage>();
@@ -1574,6 +1575,7 @@ export class AgentSession {
 	private _invalidateCompactionForModelSelection(): void {
 		this.abortCompaction();
 		this.abortBranchSummary();
+		this._delegatedCompactionKey = undefined;
 		this._incrementMessageRevision();
 	}
 
@@ -4278,7 +4280,12 @@ export class AgentSession {
 		},
 	): Promise<SystemPromptChangeEvent | undefined> {
 		const previousModel = this.model;
-		if (opts.invalidateCompaction && this._modelSelectionChangesContext(previousModel, model)) {
+		if (
+			opts.invalidateCompaction &&
+			(this._modelSelectionChangesContext(previousModel, model) ||
+				previousModel?.provider !== model.provider ||
+				previousModel?.id !== model.id)
+		) {
 			this._invalidateCompactionForModelSelection();
 		}
 		const thinking = this._getThinkingForModelSwitch(model, opts.ephemeralThinkingLevel);
@@ -4364,7 +4371,10 @@ export class AgentSession {
 			nextIndex = direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
 		}
 		const next = favoriteModels[nextIndex];
-		const invalidatesCompaction = this._modelSelectionChangesContext(currentModel, next.model);
+		const invalidatesCompaction =
+			this._modelSelectionChangesContext(currentModel, next.model) ||
+			currentModel?.provider !== next.model.provider ||
+			currentModel?.id !== next.model.id;
 		if (invalidatesCompaction) {
 			this._invalidateCompactionForModelSelection();
 		}
@@ -5264,6 +5274,7 @@ export class AgentSession {
 			) {
 				throw new CompactionCancelledError();
 			}
+			this._delegatedCompactionKey = undefined;
 			if (request.owner === "compaction" && this._compactionAbortController === request.controller) {
 				this._compactionAbortController = undefined;
 			}
@@ -5379,6 +5390,9 @@ export class AgentSession {
 		// also emitted with accepted:false so the compaction extension's circuit-breaker
 		// bookkeeping stops being dead code; other builtin session_compact handlers guard
 		// on event.accepted.
+		if (rejectionCause === "external-owner" && this.model) {
+			this._delegatedCompactionKey = { provider: this.model.provider, id: this.model.id };
+		}
 		const trimmedExtensionReason = extensionReason?.trim();
 		const detailedMessage = trimmedExtensionReason
 			? `Compaction rejected: ${trimmedExtensionReason}`
@@ -5770,14 +5784,12 @@ export class AgentSession {
 	}
 
 	private _isCompactionDelegated(): boolean {
-		const state = this._compactionLifecycle.state;
 		const model = this.model;
 		return (
-			state.status === "failed" &&
-			state.rejectionCause === "external-owner" &&
-			state.model !== undefined &&
+			this._delegatedCompactionKey !== undefined &&
 			model !== undefined &&
-			state.model.provider === model.provider
+			this._delegatedCompactionKey.provider === model.provider &&
+			this._delegatedCompactionKey.id === model.id
 		);
 	}
 
@@ -5788,6 +5800,7 @@ export class AgentSession {
 		willRetry = false,
 		allowSummaryOnly = false,
 	): Promise<boolean> {
+		if (this._isCompactionDelegated()) return false;
 		const controller = new AbortController();
 		const requestId = randomUUID();
 		this._claimCompactionController(controller, "compaction");
@@ -5977,6 +5990,7 @@ export class AgentSession {
 	 * @returns Whether the post-run loop should call `agent.continue()`
 	 */
 	private async _runAutoCompaction(reason: "overflow" | "threshold", willRetry: boolean): Promise<boolean> {
+		if (this._isCompactionDelegated()) return false;
 		const finishCompactionWork = this._sessionWorkBarrier.begin();
 		const agentMessagesAtStart = this.agent.state.messages.slice();
 		const autoCompactionController = new AbortController();
@@ -7882,6 +7896,7 @@ export class AgentSession {
 
 			// Update agent state (preserving exact messages still awaiting persistence)
 			this._restoreAgentMessagesFromSession();
+			this._delegatedCompactionKey = undefined;
 			this._incrementMessageRevision();
 
 			// Emit session_tree event

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-29 - Make externally owned compaction delegation sticky
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: remember the provider and model id after an automatic compaction is rejected by an external owner, suppressing repeated automatic attempts until that key changes or compaction is accepted. Manual compaction remains admitted.
+- Added `test/suite/regressions/1174-sticky-delegated-compaction.test.ts` covering repeated turns, manual compaction, and model changes.
+
+### Why
+
+- A provider-owned compaction lane previously caused the core to emit a new automatic compaction attempt on every turn, repeatedly producing rejection events and repainting the same error.
+
+### Why an extension could not handle it
+
+- Automatic compaction admission and lifecycle state are private `AgentSession` control flow that runs before extension hooks are emitted.
+
+### Expected merge conflict zones
+
+- `agent-session.ts`: compaction state, automatic admission methods, rejection handling, model selection invalidation, and tree navigation.
+
 ## 2026-08-29 - Withheld tools are filtered at the advertisement seam
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -4,7 +4,7 @@
 
 ### What changed
 
-- `packages/coding-agent/src/core/agent-session.ts`: remember the provider and model id after an automatic compaction is rejected by an external owner, suppressing repeated automatic attempts until that key changes or compaction is accepted. Manual compaction remains admitted.
+- `packages/coding-agent/src/core/agent-session.ts`: remember the provider and model id after an automatic compaction is rejected by an external owner, suppressing repeated automatic attempts until that key changes, compaction is accepted, or runtime ownership is reconfigured by reload/registry refresh. Manual compaction remains admitted.
 - Added `test/suite/regressions/1174-sticky-delegated-compaction.test.ts` covering repeated turns, manual compaction, and model changes.
 
 ### Why

--- a/packages/coding-agent/test/suite/regressions/1174-sticky-delegated-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1174-sticky-delegated-compaction.test.ts
@@ -1,0 +1,84 @@
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
+import type { InlineExtension } from "../../../src/index.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+	for (const harness of harnesses.splice(0)) {
+		harness.cleanup();
+	}
+});
+
+function externallyOwnedCompaction(attempts: string[]): InlineExtension {
+	return ((pi: ExtensionAPI) => {
+		pi.on("session_before_compact", (event) => {
+			attempts.push(event.reason);
+			return {
+				cancel: true,
+				rejectionCause: "external-owner",
+				reason: "provider lane owns compaction",
+			};
+		});
+	}) as InlineExtension;
+}
+
+async function createOverThresholdHarness(attempts: string[]): Promise<Harness> {
+	const harness = await createHarness({
+		models: [
+			{ id: "faux-large", contextWindow: 20_000, maxTokens: 4_096 },
+			{ id: "faux-large-next", contextWindow: 20_000, maxTokens: 4_096 },
+		],
+		settings: { compaction: { reserveTokens: 1_000 } },
+		extensionFactories: [externallyOwnedCompaction(attempts)],
+	});
+	harnesses.push(harness);
+	const timestamp = Date.now() - 1_000;
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "work through the todo list" }],
+		timestamp: timestamp - 1,
+	});
+	harness.sessionManager.appendMessage({
+		...fauxAssistantMessage("progress note ".concat("x".repeat(80_000)), { timestamp }),
+		usage: {
+			input: 19_500,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 19_500,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	});
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+	return harness;
+}
+
+describe("issue #1174: delegated compaction stays sticky per model", () => {
+	it("stops auto attempts, preserves manual attempts, and re-arms after a model change", async () => {
+		const attempts: string[] = [];
+		const harness = await createOverThresholdHarness(attempts);
+		harness.setResponses([
+			fauxAssistantMessage("first turn continued"),
+			fauxAssistantMessage("second turn continued"),
+			fauxAssistantMessage("model-switched turn continued"),
+		]);
+
+		await harness.session.prompt("first turn");
+		expect(attempts).toEqual(["pre_prompt"]);
+
+		await harness.session.prompt("second turn");
+		expect(attempts).toEqual(["pre_prompt"]);
+
+		await expect(harness.session.compact()).rejects.toThrow("active provider owns compaction");
+		expect(attempts).toEqual(["pre_prompt", "manual"]);
+
+		const nextModel = harness.getModel("faux-large-next");
+		if (!nextModel) throw new Error("Expected second faux model");
+		await harness.session.setSessionModel(nextModel);
+		await harness.session.prompt("turn after model change");
+		expect(attempts).toEqual(["pre_prompt", "manual", "overflow"]);
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/1174-sticky-delegated-compaction.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1174-sticky-delegated-compaction.test.ts
@@ -2,6 +2,7 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ExtensionAPI } from "../../../src/core/extensions/index.ts";
 import type { InlineExtension } from "../../../src/index.ts";
+import { createTestExtensionsResult, createTestResourceLoader } from "../../utilities.ts";
 import { createHarness, type Harness } from "../harness.ts";
 
 const harnesses: Harness[] = [];
@@ -56,6 +57,45 @@ async function createOverThresholdHarness(attempts: string[]): Promise<Harness> 
 	return harness;
 }
 
+async function createOverThresholdHarnessWithResourceLoader(
+	resourceLoader: ReturnType<typeof createTestResourceLoader>,
+): Promise<Harness> {
+	const harness = await createHarness({
+		models: [
+			{ id: "faux-large", contextWindow: 20_000, maxTokens: 4_096 },
+			{ id: "faux-large-next", contextWindow: 20_000, maxTokens: 4_096 },
+		],
+		settings: { compaction: { reserveTokens: 1_000 } },
+		resourceLoader,
+	});
+	harnesses.push(harness);
+	const timestamp = Date.now() - 1_000;
+	harness.sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "work through the todo list" }],
+		timestamp: timestamp - 1,
+	});
+	harness.sessionManager.appendMessage({
+		...fauxAssistantMessage("progress note ".concat("x".repeat(80_000)), { timestamp }),
+		usage: {
+			input: 19_500,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 19_500,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+	});
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+	return harness;
+}
+
+function privateSessionMethod(session: Harness["session"], name: string): (...args: unknown[]) => unknown {
+	const method: unknown = Reflect.get(session, name);
+	if (typeof method !== "function") throw new Error(`Expected AgentSession.${name}`);
+	return method.bind(session);
+}
+
 describe("issue #1174: delegated compaction stays sticky per model", () => {
 	it("stops auto attempts, preserves manual attempts, and re-arms after a model change", async () => {
 		const attempts: string[] = [];
@@ -71,6 +111,7 @@ describe("issue #1174: delegated compaction stays sticky per model", () => {
 
 		await harness.session.prompt("second turn");
 		expect(attempts).toEqual(["pre_prompt"]);
+		expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === false)).toHaveLength(1);
 
 		await expect(harness.session.compact()).rejects.toThrow("active provider owns compaction");
 		expect(attempts).toEqual(["pre_prompt", "manual"]);
@@ -80,5 +121,32 @@ describe("issue #1174: delegated compaction stays sticky per model", () => {
 		await harness.session.setSessionModel(nextModel);
 		await harness.session.prompt("turn after model change");
 		expect(attempts).toEqual(["pre_prompt", "manual", "overflow"]);
+	});
+
+	it("re-arms automatic compaction after reload removes the external owner", async () => {
+		const attempts: string[] = [];
+		const owner = externallyOwnedCompaction(attempts);
+		const extensionResult = await createTestExtensionsResult([owner]);
+		let activeExtensions = extensionResult;
+		const resourceLoader = createTestResourceLoader({ extensionsResult: activeExtensions });
+		const harness = await createOverThresholdHarnessWithResourceLoader(resourceLoader);
+
+		await privateSessionMethod(harness.session, "_runPrePromptCompaction")(
+			harness.session.agent.state.messages.findLast((message) => message.role === "assistant"),
+			false,
+			"pre_prompt",
+		);
+		expect(attempts).toEqual(["pre_prompt"]);
+
+		activeExtensions = await createTestExtensionsResult([]);
+		(resourceLoader as { getExtensions: () => typeof activeExtensions }).getExtensions = () => activeExtensions;
+		await harness.session.reload();
+		expect(harness.session.hasExtensionHandlers("session_before_compact")).toBe(false);
+		const startsBeforeRetry = harness.eventsOfType("compaction_start").length;
+		const runAutoCompaction = privateSessionMethod(harness.session, "_runAutoCompaction");
+		await runAutoCompaction("threshold", false);
+
+		expect(attempts).toEqual(["pre_prompt"]);
+		expect(harness.eventsOfType("compaction_start")).toHaveLength(startsBeforeRetry + 1);
 	});
 });


### PR DESCRIPTION
## What

Make externally owned compaction delegation sticky per provider and model id. Once an automatic compaction is rejected by an external owner, subsequent automatic admission attempts are suppressed without emitting compaction lifecycle events. Manual `/compact` remains admitted, model changes re-arm automatic attempts, and reload/registry refresh re-arm automatic attempts when ownership can change.

## Why

Fixes the attempt-spam root of #1174: the core repeatedly attempted compaction every turn on provider-owned lanes, producing repeated rejection events. The TUI rendering half of the issue lands separately.

## Verification

- RED (base commit): the original regression failed with `expected [ 'pre_prompt' ]` but received `[ 'pre_prompt', 'overflow' ]`, proving a duplicate automatic attempt.
- RED (review blocker): after one external-owner rejection, removing the owner and calling `reload()` still left `compaction_start` at length `1` instead of `2` because the sticky key remained set.
- GREEN: the strengthened sticky regression and reload-owner-removal regression pass.
- GREEN: `test/compaction` passed 63 files / 443 tests; cooldown admission, Claude SDK alignment, and sticky regression passed 3 files / 17 tests.
- Pre-commit full check passed: Biome, pinned dependency/import/lock checks, Claude SDK platform lock, `tsc --noEmit`, and browser smoke.
