### PR TITLE
feat(coding-agent): add experimental.bashEvalOnly to route shell tools through eval

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Added
 
+- New experimental setting `experimental.bashEvalOnly` (default `false`). When enabled, the `bash` and
+  `powershell` tools are withheld from the model-facing tool surface and run only inside eval cells via
+  `tool.bash({ command: "..." })`, with system-prompt guidance and a redirect hint if the model calls them
+  directly. Hooks and permission checks still apply to those commands. The policy is inert whenever the
+  `eval` tool is unavailable, so shell access is never lost, and it follows the flag across a reload.
+
 ### Changed
 
 - `grep` is temporarily withheld from the model-facing tool surface. It no longer appears in the

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -399,6 +399,7 @@ Windows paths in JSON must use forward slashes or escaped backslashes:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `defaultTools` | string[] | - | Built-in tools enabled initially. When omitted, Pi uses its standard defaults |
+| `experimental.bashEvalOnly` | boolean | `false` | Route `bash` and `powershell` through eval cells only; the tools leave the model's direct tool list |
 
 `defaultTools` selects the built-in tools enabled at startup. Extension and SDK custom tools remain enabled. Available built-ins are `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`:
 
@@ -417,6 +418,22 @@ On Windows, select `powershell` instead of `bash`, or include both:
 ```
 
 An empty array starts with no built-in tools while preserving extension and SDK custom tools. `--tools` replaces this behavior with a strict allowlist for all tools, `--no-tools` disables all tools, and `--no-builtin-tools` disables the built-in defaults. `--exclude-tools` filters the resulting list. A project `defaultTools` array replaces the global array.
+
+With `experimental.bashEvalOnly` enabled, the `bash` and `powershell` tools disappear from the model's direct tool list and run only inside eval cells:
+
+```json
+{
+  "experimental": {
+    "bashEvalOnly": true
+  }
+}
+```
+
+```js
+const { output } = await tool.bash({ command: "ls -la" });
+```
+
+Hooks and permission checks apply unchanged to shell commands run this way. If the model hallucinates a direct `bash` or `powershell` call anyway, the call returns a hint redirecting it to an eval cell. When the `eval` tool is unavailable (codemode not loaded), the policy auto-disables and both tools stay on the direct tool list, so shell access is never lost.
 
 ### Sessions
 

--- a/packages/coding-agent/docs/windows.md
+++ b/packages/coding-agent/docs/windows.md
@@ -30,6 +30,8 @@ Or enable both while comparing behavior:
 
 The `!` and `!!` editor commands still use Bash.
 
+With `experimental.bashEvalOnly` enabled, both `bash` and `powershell` run only inside eval cells; see [Settings](settings.md#tools).
+
 ## Custom Bash Path
 
 ```json

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -552,6 +552,8 @@ export interface AgentSessionConfig {
 	initialActiveToolNames?: string[];
 	/** Configured built-in defaults; fork-native builtin extension tools outside this set are omitted. */
 	defaultToolNames?: string[];
+	/** Tool names that remain executable only through the registered eval tool. */
+	evalOnlyToolNames?: string[];
 	/** Optional allowlist of tool names. When provided, only these tool names are exposed. */
 	allowedToolNames?: string[];
 	/** Optional denylist of tool names. When provided, these tool names are not exposed. */
@@ -949,6 +951,7 @@ export class AgentSession {
 	private _extensionRunnerRef?: { current?: ExtensionRunner };
 	private _initialActiveToolNames?: string[];
 	private _defaultToolNames?: Set<string>;
+	private _evalOnlyToolNames?: ReadonlySet<string>;
 	private _allowedToolNames?: Set<string>;
 	private _excludedToolNames?: Set<string>;
 	private _baseToolsOverride?: Record<string, AgentTool>;
@@ -1061,6 +1064,7 @@ export class AgentSession {
 		this._extensionRunnerRef = config.extensionRunnerRef;
 		this._initialActiveToolNames = config.initialActiveToolNames;
 		this._defaultToolNames = config.defaultToolNames ? new Set(config.defaultToolNames) : undefined;
+		this._evalOnlyToolNames = config.evalOnlyToolNames ? new Set(config.evalOnlyToolNames) : undefined;
 		this._allowedToolNames = config.allowedToolNames ? new Set(config.allowedToolNames) : undefined;
 		this._excludedToolNames = config.excludedToolNames ? new Set(config.excludedToolNames) : undefined;
 		this._baseToolsOverride = config.baseToolsOverride;
@@ -2763,6 +2767,9 @@ export class AgentSession {
 	): Promise<AgentToolResult<TDetails>> {
 		let activeTools = this.getActiveToolNames();
 		let tool = this.agent.state.tools.find((candidate) => candidate.name === toolName);
+		if (!tool && this._isEvalOnlyPolicyArmed() && this._evalOnlyToolNames?.has(toolName)) {
+			tool = this._toolRegistry.get(toolName);
+		}
 		if (
 			!tool &&
 			options?.activateInactiveTool === true &&
@@ -2864,6 +2871,19 @@ export class AgentSession {
 		return this._lazyToolActivators.some((activate) => activate(toolName));
 	}
 
+	private _isEvalOnlyPolicyArmed(): boolean {
+		return this._evalOnlyToolNames !== undefined && this._toolRegistry.has("eval");
+	}
+
+	/** Publish per-tool eval-only redirect hints so a direct call names its own eval helper. */
+	private _publishEvalOnlyToolHints(): void {
+		if (!this._isEvalOnlyPolicyArmed()) return;
+		for (const name of this._evalOnlyToolNames ?? []) {
+			this.agent.removedToolHints[name] =
+				`Run ${name} inside an eval cell via tool.${name}({ command: "..." }); hooks and permissions still apply.`;
+		}
+	}
+
 	/**
 	 * Set active tools by name.
 	 * Only tools in the registry can be enabled. Unknown tool names are ignored.
@@ -2905,7 +2925,12 @@ export class AgentSession {
 	setActiveToolsByName(toolNames: string[]): void {
 		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];
-		for (const name of toolNames) {
+		const policyArmed = this._isEvalOnlyPolicyArmed();
+		this._publishEvalOnlyToolHints();
+		const filteredToolNames = policyArmed
+			? toolNames.filter((name) => !this._evalOnlyToolNames?.has(name))
+			: toolNames;
+		for (const name of filteredToolNames) {
 			const tool = this._toolRegistry.get(name);
 			if (tool) {
 				tools.push(tool);
@@ -3092,9 +3117,11 @@ export class AgentSession {
 			appendSystemPrompt: loaderAppendSystemPrompt.length > 0 ? loaderAppendSystemPrompt.join("\n\n") : undefined,
 		};
 		const basePrompt = loaderSystemPrompt ?? buildDynamicSystemPrompt(this._baseSystemPromptOptions);
-		return loaderAppendSystemPrompt.length > 0
-			? `${basePrompt}\n\n${loaderAppendSystemPrompt.join("\n\n")}`
-			: basePrompt;
+		const prompt =
+			loaderAppendSystemPrompt.length > 0 ? `${basePrompt}\n\n${loaderAppendSystemPrompt.join("\n\n")}` : basePrompt;
+		return this._isEvalOnlyPolicyArmed()
+			? `${prompt}\n\nBash runs ONLY inside eval cells via tool.bash({ command: "..." }); hooks and permissions still apply.`
+			: prompt;
 	}
 
 	/**
@@ -6653,6 +6680,7 @@ export class AgentSession {
 			toolRegistry.set(tool.name, tool);
 		}
 		this._toolRegistry = toolRegistry;
+		this._publishEvalOnlyToolHints();
 		const isDirectlyExposed = (name: string): boolean => {
 			const entry = this._toolDefinitions.get(name);
 			return entry !== undefined && normalizeToolExposure(entry.definition).exposure === "direct";

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -190,6 +190,8 @@ import { createAllToolDefinitions, temporarilyDisabledToolNames } from "./tools/
 import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapper.ts";
 import { addUsageToTotals, createUsageTotals } from "./usage-totals.ts";
 
+/** Built-in shell tools routed exclusively through eval when experimental.bashEvalOnly is enabled. */
+const EVAL_ONLY_POLICY_TOOL_NAMES: readonly string[] = ["bash", "powershell"];
 const TURN_RETRY_SUPPRESSION_PREFIX = "senpi:no-turn-retry:";
 const DEFERRED_RETRY_QUEUE_OWNERS = new WeakSet<object>();
 
@@ -952,6 +954,12 @@ export class AgentSession {
 	private _initialActiveToolNames?: string[];
 	private _defaultToolNames?: Set<string>;
 	private _evalOnlyToolNames?: ReadonlySet<string>;
+	/** Explicit config override; when supplied it wins over the settings-derived policy across reloads. */
+	private readonly _evalOnlyToolNamesOverride?: ReadonlySet<string>;
+	/** Policy tools withheld from the model, retained so disarming can restore direct access. */
+	private readonly _withheldEvalOnlyToolNames = new Set<string>();
+	/** Active-tool selection as requested by callers, before eval-only filtering. */
+	private _requestedActiveToolNames?: string[];
 	private _allowedToolNames?: Set<string>;
 	private _excludedToolNames?: Set<string>;
 	private _baseToolsOverride?: Record<string, AgentTool>;
@@ -1064,7 +1072,8 @@ export class AgentSession {
 		this._extensionRunnerRef = config.extensionRunnerRef;
 		this._initialActiveToolNames = config.initialActiveToolNames;
 		this._defaultToolNames = config.defaultToolNames ? new Set(config.defaultToolNames) : undefined;
-		this._evalOnlyToolNames = config.evalOnlyToolNames ? new Set(config.evalOnlyToolNames) : undefined;
+		this._evalOnlyToolNamesOverride = config.evalOnlyToolNames ? new Set(config.evalOnlyToolNames) : undefined;
+		this._evalOnlyToolNames = this._resolveEvalOnlyToolNames();
 		this._allowedToolNames = config.allowedToolNames ? new Set(config.allowedToolNames) : undefined;
 		this._excludedToolNames = config.excludedToolNames ? new Set(config.excludedToolNames) : undefined;
 		this._baseToolsOverride = config.baseToolsOverride;
@@ -2875,6 +2884,15 @@ export class AgentSession {
 		return this._evalOnlyToolNames !== undefined && this._toolRegistry.has("eval");
 	}
 
+	/**
+	 * Resolve the eval-only policy from settings so a reload picks up a flag change.
+	 * An explicitly configured set stays authoritative for SDK embedders and tests.
+	 */
+	private _resolveEvalOnlyToolNames(): ReadonlySet<string> | undefined {
+		if (this._evalOnlyToolNamesOverride !== undefined) return this._evalOnlyToolNamesOverride;
+		return this.settingsManager.getExperimentalBashEvalOnly() ? new Set(EVAL_ONLY_POLICY_TOOL_NAMES) : undefined;
+	}
+
 	/** Publish per-tool eval-only redirect hints so a direct call names its own eval helper. */
 	private _publishEvalOnlyToolHints(): void {
 		if (!this._isEvalOnlyPolicyArmed()) return;
@@ -2927,9 +2945,18 @@ export class AgentSession {
 		const validToolNames: string[] = [];
 		const policyArmed = this._isEvalOnlyPolicyArmed();
 		this._publishEvalOnlyToolHints();
-		const filteredToolNames = policyArmed
-			? toolNames.filter((name) => !this._evalOnlyToolNames?.has(name))
-			: toolNames;
+		const policyNames = this._evalOnlyToolNames;
+		let filteredToolNames = toolNames;
+		if (policyArmed && policyNames) {
+			for (const name of toolNames) {
+				if (policyNames.has(name)) this._withheldEvalOnlyToolNames.add(name);
+			}
+			filteredToolNames = toolNames.filter((name) => !policyNames.has(name));
+		} else {
+			this._withheldEvalOnlyToolNames.clear();
+		}
+		// Remember the unfiltered request so a later disarm can restore withheld shell tools.
+		this._requestedActiveToolNames = [...new Set([...toolNames, ...this._withheldEvalOnlyToolNames])];
 		for (const name of filteredToolNames) {
 			const tool = this._toolRegistry.get(name);
 			if (tool) {
@@ -3119,9 +3146,11 @@ export class AgentSession {
 		const basePrompt = loaderSystemPrompt ?? buildDynamicSystemPrompt(this._baseSystemPromptOptions);
 		const prompt =
 			loaderAppendSystemPrompt.length > 0 ? `${basePrompt}\n\n${loaderAppendSystemPrompt.join("\n\n")}` : basePrompt;
-		return this._isEvalOnlyPolicyArmed()
-			? `${prompt}\n\nBash runs ONLY inside eval cells via tool.bash({ command: "..." }); hooks and permissions still apply.`
-			: prompt;
+		if (!this._isEvalOnlyPolicyArmed()) return prompt;
+		const helpers = [...(this._evalOnlyToolNames ?? [])]
+			.map((name) => `tool.${name}({ command: "..." })`)
+			.join(" or ");
+		return `${prompt}\n\nShell commands run ONLY inside eval cells via ${helpers}; hooks and permissions still apply.`;
 	}
 
 	/**
@@ -6691,7 +6720,9 @@ export class AgentSession {
 		// filesystem-policy wiring) still expect it to activate.
 		const hasExplicitActiveToolNames = options?.activeToolNames !== undefined;
 		const nextActiveToolNames = (
-			options?.activeToolNames ? [...options.activeToolNames] : [...previousActiveToolNames]
+			options?.activeToolNames
+				? [...options.activeToolNames]
+				: [...(this._requestedActiveToolNames ?? previousActiveToolNames)]
 		).filter((name) => {
 			if (!isAllowedTool(name)) return false;
 			if (!hasExplicitActiveToolNames && temporarilyDisabledToolNames.has(name)) return false;
@@ -6803,7 +6834,9 @@ export class AgentSession {
 		const oldExtensionIdentities = oldExtensionRunner.getExtensionIdentities();
 		const previousFlagValues = oldExtensionRunner.getFlagValues();
 		const previousActiveToolRegistrationIds = new Map<string, string>();
-		for (const name of this.getActiveToolNames()) {
+		// Cover withheld eval-only tools too: the rebuild drops any seeded name missing from this
+		// map, which would strand shell tools when the policy disarms during this reload.
+		for (const name of this._requestedActiveToolNames ?? this.getActiveToolNames()) {
 			const entry = this._toolDefinitions.get(name);
 			if (entry) previousActiveToolRegistrationIds.set(name, deriveExtensionRegistrationId(entry.sourceInfo, name));
 		}
@@ -6814,6 +6847,11 @@ export class AgentSession {
 		time("shutdown", "reload");
 		await this.settingsManager.reload();
 		this._delegatedCompactionKey = undefined;
+		// Capture the unfiltered request BEFORE the rebuild reassigns it, so a policy that
+		// disarms during this reload can still restore its withheld shell tools.
+		const requestedActiveToolNamesBeforeRebuild = [...(this._requestedActiveToolNames ?? this.getActiveToolNames())];
+		// A flag change must take effect on reload, matching documented settings hot-reload behavior.
+		this._evalOnlyToolNames = this._resolveEvalOnlyToolNames();
 		this.syncQueueModesFromSettings();
 		resetApiProviders();
 		time("settings", "reload");
@@ -6843,7 +6881,7 @@ export class AgentSession {
 		time("resources", "reload");
 		try {
 			this._buildRuntime({
-				activeToolNames: this.getActiveToolNames(),
+				activeToolNames: requestedActiveToolNamesBeforeRebuild,
 				flagValues: previousFlagValues,
 				includeAllExtensionTools: true,
 				previousActiveToolRegistrationIds,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -19,6 +19,24 @@
 
 - `agent-session.ts`: compaction state, automatic admission methods, rejection handling, model selection invalidation, and tree navigation.
 
+## 2026-08-29 - Experimental bash eval-only policy
+
+### What changed
+
+- `packages/coding-agent/src/core/settings-manager.ts`: adds the `experimental.bashEvalOnly` setting and its getter.
+- `packages/coding-agent/src/core/agent-session.ts`: resolves the policy from settings in the constructor and on reload, hides the `bash` and `powershell` tools while the registered `eval` tool is present, executes them through the registry without activation, publishes per-tool eval-cell hints, adds system-prompt guidance, and retains withheld tools so disarming restores direct access.
+
+### Why
+
+- Codemode can keep invoking `bash` and `powershell` from eval cells while preventing those tools from being advertised as direct model tools. The policy is inert when codemode's `eval` tool is unavailable, so shell access is never lost.
+
+### Why an extension could not handle it
+
+- Active tool visibility, lazy activation, the wrapped registry, and the agent-loop removed-tool hint map are coordinated inside `AgentSession`; an extension cannot atomically enforce these boundaries.
+
+### Expected merge conflict zones
+
+- `agent-session.ts`: active-tool selection, tool registry refresh, reload, and system-prompt assembly.
 ## 2026-08-29 - Withheld tools are filtered at the advertisement seam
 
 ### What changed

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -367,7 +367,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
 	const excludedToolNames = options.excludeTools;
 	const excludedToolNameSet = excludedToolNames ? new Set(excludedToolNames) : undefined;
-	const evalOnlyToolNames = settingsManager.getExperimentalBashEvalOnly() ? ["bash", "powershell"] : undefined;
 	const initialActiveToolNames = (
 		options.tools ?? (options.noTools ? [] : (configuredDefaultToolNames ?? defaultActiveToolNames))
 	).filter((name) => !excludedToolNameSet?.has(name));
@@ -510,7 +509,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		modelRegistry,
 		initialActiveToolNames,
 		defaultToolNames: sessionDefaultToolNames,
-		evalOnlyToolNames,
 		allowedToolNames,
 		excludedToolNames,
 		extensionRunnerRef,

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -367,6 +367,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const allowedToolNames = options.tools ?? (options.noTools === "all" ? [] : undefined);
 	const excludedToolNames = options.excludeTools;
 	const excludedToolNameSet = excludedToolNames ? new Set(excludedToolNames) : undefined;
+	const evalOnlyToolNames = settingsManager.getExperimentalBashEvalOnly() ? ["bash", "powershell"] : undefined;
 	const initialActiveToolNames = (
 		options.tools ?? (options.noTools ? [] : (configuredDefaultToolNames ?? defaultActiveToolNames))
 	).filter((name) => !excludedToolNameSet?.has(name));
@@ -509,6 +510,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		modelRegistry,
 		initialActiveToolNames,
 		defaultToolNames: sessionDefaultToolNames,
+		evalOnlyToolNames,
 		allowedToolNames,
 		excludedToolNames,
 		extensionRunnerRef,

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -176,6 +176,10 @@ export type PackageSource =
 			hooks?: string[];
 	  };
 
+export interface ExperimentalSettings {
+	bashEvalOnly?: boolean;
+}
+
 export interface Settings {
 	lastChangelogVersion?: string;
 	defaultProvider?: string;
@@ -241,6 +245,7 @@ export interface Settings {
 	tuiMode?: TuiMode; // default: "regular"
 	fullscreenExitOutput?: FullscreenExitOutput; // default: "transcript"; no effect in regular TUI mode
 	fullscreenScrollbar?: ScrollViewScrollbar; // default: "auto"; no effect in regular TUI mode
+	experimental?: ExperimentalSettings;
 }
 
 function isMergeableObject(value: unknown): value is Record<string, unknown> {
@@ -2026,6 +2031,10 @@ export class SettingsManager {
 	getDefaultTools(): string[] | undefined {
 		const tools = this.settings.defaultTools;
 		return tools ? [...tools] : undefined;
+	}
+
+	getExperimentalBashEvalOnly(): boolean {
+		return this.settings.experimental?.bashEvalOnly === true;
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {

--- a/packages/coding-agent/test/manual-qa/bash-eval-only-qa.ts
+++ b/packages/coding-agent/test/manual-qa/bash-eval-only-qa.ts
@@ -1,0 +1,180 @@
+/**
+ * Real-surface QA driver for experimental.bashEvalOnly.
+ *
+ * Drives the shipped SDK entrypoint (createAgentSession) against a scratch
+ * project directory whose .senpi/settings.json carries the flag, using the
+ * faux provider so no credentials or network model calls are involved.
+ *
+ * Usage: npx tsx test/manual-qa/bash-eval-only-qa.ts <scratchDir> <mode:armed|control> <outDir>
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { DefaultResourceLoader } from "../../src/core/resource-loader.ts";
+import { createInMemoryModelRegistry } from "../model-runtime-test-utils.ts";
+import { createAgentSession, type ExtensionFactory } from "../../src/core/sdk.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+
+const [scratchDir, mode, outDir] = process.argv.slice(2);
+if (!scratchDir || !mode || !outDir) {
+	throw new Error("usage: bash-eval-only-qa.ts <scratchDir> <armed|control> <outDir>");
+}
+
+const lines: string[] = [];
+function log(line: string): void {
+	lines.push(line);
+	process.stdout.write(`${line}\n`);
+}
+
+const toolCallReceipts: Array<{ toolName: string; args: unknown }> = [];
+
+async function main(): Promise<void> {
+	const agentDir = join(scratchDir, "agent-dir");
+	mkdirSync(agentDir, { recursive: true });
+
+	const faux = registerFauxProvider({});
+	const model = faux.getModel();
+	faux.setResponses([]);
+
+	// Faux credentials only: no real provider key and no network model call.
+	const authStorage = AuthStorage.inMemory();
+	await authStorage.modify(model.provider, async () => ({ type: "api_key", key: "faux-key" }));
+	const modelRegistry = await createInMemoryModelRegistry(authStorage);
+	modelRegistry.registerProvider(model.provider, {
+		baseUrl: model.baseUrl,
+		apiKey: "faux-key",
+		api: faux.api,
+		models: faux.models.map((registeredModel) => ({
+			id: registeredModel.id,
+			name: registeredModel.name,
+			api: registeredModel.api,
+			reasoning: registeredModel.reasoning,
+			input: registeredModel.input,
+			cost: registeredModel.cost,
+			contextWindow: registeredModel.contextWindow,
+			maxTokens: registeredModel.maxTokens,
+			baseUrl: registeredModel.baseUrl,
+		})),
+	});
+
+	// The eval tool stands in for codemode's registration: the policy is only
+	// armed while a tool named "eval" is present in the registry.
+	const extensionFactory: ExtensionFactory = (pi) => {
+		pi.registerTool({
+			name: "eval",
+			label: "Eval",
+			description: "Evaluate code in a persistent kernel",
+			parameters: Type.Object({ code: Type.String() }),
+			execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+		});
+		pi.on("tool_call", (event) => {
+			toolCallReceipts.push({ toolName: event.toolName, args: event.args });
+		});
+	};
+
+	const settingsManager = SettingsManager.create(scratchDir, agentDir);
+	const resourceLoader = new DefaultResourceLoader({
+		cwd: scratchDir,
+		agentDir,
+		settingsManager,
+		extensionFactories: [extensionFactory],
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await resourceLoader.reload();
+
+	const { session } = await createAgentSession({
+		cwd: scratchDir,
+		agentDir,
+		model,
+		settingsManager,
+		resourceLoader,
+		authStorage,
+		modelRegistry,
+		sessionManager: SessionManager.inMemory(scratchDir),
+	});
+
+	try {
+		log(`# bash-eval-only QA (${mode})`);
+		log(`scratch: ${scratchDir}`);
+		log(`project settings file: ${join(scratchDir, ".senpi", "settings.json")}`);
+		log(`getExperimentalBashEvalOnly(): ${settingsManager.getExperimentalBashEvalOnly()}`);
+		log("");
+
+		// (i) active tool list
+		const activeTools = session.getActiveToolNames();
+		log("## (i) active tool names");
+		log(JSON.stringify(activeTools));
+		log(`bash present: ${activeTools.includes("bash")}`);
+		log(`powershell present: ${activeTools.includes("powershell")}`);
+		log(`eval present: ${activeTools.includes("eval")}`);
+		log(`all registered tools include bash: ${session.getAllTools().some((tool) => tool.name === "bash")}`);
+		log("");
+
+		// (ii) system prompt sentinel
+		const prompt = session.systemPrompt;
+		const sentinel = "tool.bash(";
+		const sentinelIndex = prompt.indexOf(sentinel);
+		log('## (ii) system prompt sentinel "tool.bash("');
+		log(`contains sentinel: ${sentinelIndex >= 0}`);
+		if (sentinelIndex >= 0) {
+			log(`sentinel line: ${prompt.slice(Math.max(0, sentinelIndex - 200), sentinelIndex + 120).split("\n").pop()}`);
+		}
+		log("");
+
+		// (iii) executeTool bash through the full pipeline
+		log('## (iii) executeTool("bash", { command: "echo qa-ok" })');
+		try {
+			const result = await session.executeTool("bash", { command: "echo qa-ok" });
+			const text = result.content
+				.filter((part): part is { type: "text"; text: string } => part.type === "text")
+				.map((part) => part.text)
+				.join("\n");
+			log(`isError: ${result.isError === true}`);
+			log(`output contains "qa-ok": ${text.includes("qa-ok")}`);
+			log(`output: ${JSON.stringify(text.slice(0, 400))}`);
+		} catch (error) {
+			log(`executeTool threw: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		log(`tool_call receipts: ${JSON.stringify(toolCallReceipts)}`);
+		log(`active tools after execute: ${JSON.stringify(session.getActiveToolNames())}`);
+		log(`bash reactivated: ${session.getActiveToolNames().includes("bash")}`);
+		log("");
+
+		// (iv) redirect hint for a direct/unknown bash call from the model
+		log("## (iv) redirect hint for a direct model bash call");
+		const hints = (session as unknown as { agent: { removedToolHints: Record<string, string> } }).agent
+			.removedToolHints;
+		log(`removedToolHints.bash: ${JSON.stringify(hints.bash)}`);
+		log(`removedToolHints.powershell: ${JSON.stringify(hints.powershell)}`);
+		faux.setResponses([
+			fauxAssistantMessage(fauxToolCall("bash", { command: "echo direct-call" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+		await session.prompt("run bash directly");
+		const toolResult = session.messages.find((message) => message.role === "toolResult");
+		const resultText =
+			toolResult && "content" in toolResult
+				? JSON.stringify((toolResult.content as Array<{ text?: string }>)[0]?.text ?? "")
+				: "<no toolResult>";
+		log(`model-issued bash toolResult: ${resultText}`);
+		log("");
+
+		writeFileSync(join(outDir, `tool-call-receipts-${mode}.json`), `${JSON.stringify(toolCallReceipts, null, 2)}\n`);
+		writeFileSync(join(outDir, `system-prompt-${mode}.txt`), prompt);
+		log(`receipts file: ${join(outDir, `tool-call-receipts-${mode}.json`)}`);
+		log(`system prompt file: ${join(outDir, `system-prompt-${mode}.txt`)}`);
+	} finally {
+		session.dispose();
+		faux.unregister();
+	}
+}
+
+await main();
+writeFileSync(join(outDir, `${mode}.log`), `${lines.join("\n")}\n`);

--- a/packages/coding-agent/test/manual-qa/bash-eval-only-qa.ts
+++ b/packages/coding-agent/test/manual-qa/bash-eval-only-qa.ts
@@ -14,10 +14,10 @@ import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earen
 import { Type } from "typebox";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { DefaultResourceLoader } from "../../src/core/resource-loader.ts";
-import { createInMemoryModelRegistry } from "../model-runtime-test-utils.ts";
 import { createAgentSession, type ExtensionFactory } from "../../src/core/sdk.ts";
 import { SessionManager } from "../../src/core/session-manager.ts";
 import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { createInMemoryModelRegistry } from "../model-runtime-test-utils.ts";
 
 const [scratchDir, mode, outDir] = process.argv.slice(2);
 if (!scratchDir || !mode || !outDir) {
@@ -30,7 +30,7 @@ function log(line: string): void {
 	process.stdout.write(`${line}\n`);
 }
 
-const toolCallReceipts: Array<{ toolName: string; args: unknown }> = [];
+const toolCallReceipts: Array<{ toolName: string; input: unknown }> = [];
 
 async function main(): Promise<void> {
 	const agentDir = join(scratchDir, "agent-dir");
@@ -72,7 +72,7 @@ async function main(): Promise<void> {
 			execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
 		});
 		pi.on("tool_call", (event) => {
-			toolCallReceipts.push({ toolName: event.toolName, args: event.args });
+			toolCallReceipts.push({ toolName: event.toolName, input: event.input });
 		});
 	};
 
@@ -124,7 +124,12 @@ async function main(): Promise<void> {
 		log('## (ii) system prompt sentinel "tool.bash("');
 		log(`contains sentinel: ${sentinelIndex >= 0}`);
 		if (sentinelIndex >= 0) {
-			log(`sentinel line: ${prompt.slice(Math.max(0, sentinelIndex - 200), sentinelIndex + 120).split("\n").pop()}`);
+			log(
+				`sentinel line: ${prompt
+					.slice(Math.max(0, sentinelIndex - 200), sentinelIndex + 120)
+					.split("\n")
+					.pop()}`,
+			);
 		}
 		log("");
 
@@ -136,7 +141,6 @@ async function main(): Promise<void> {
 				.filter((part): part is { type: "text"; text: string } => part.type === "text")
 				.map((part) => part.text)
 				.join("\n");
-			log(`isError: ${result.isError === true}`);
 			log(`output contains "qa-ok": ${text.includes("qa-ok")}`);
 			log(`output: ${JSON.stringify(text.slice(0, 400))}`);
 		} catch (error) {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1154,6 +1154,53 @@ describe("SettingsManager", () => {
 			});
 		});
 	});
+
+	describe("experimental.bashEvalOnly", () => {
+		it("returns false when experimental is unset", () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalBashEvalOnly()).toBe(false);
+		});
+
+		it("returns true when global experimental.bashEvalOnly is true", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { bashEvalOnly: true } }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalBashEvalOnly()).toBe(true);
+		});
+
+		it("lets project override global true to false via deep merge", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { bashEvalOnly: true } }));
+			writeFileSync(
+				join(projectDir, CONFIG_DIR_NAME, "settings.json"),
+				JSON.stringify({ experimental: { bashEvalOnly: false } }),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalBashEvalOnly()).toBe(false);
+		});
+
+		it("lets project override global false to true via deep merge", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { bashEvalOnly: false } }));
+			writeFileSync(
+				join(projectDir, CONFIG_DIR_NAME, "settings.json"),
+				JSON.stringify({ experimental: { bashEvalOnly: true } }),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalBashEvalOnly()).toBe(true);
+		});
+
+		it("returns false for a malformed string value without throwing on load", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ experimental: { bashEvalOnly: "yes" } }),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalBashEvalOnly()).toBe(false);
+			expect(manager.drainErrors()).toEqual([]);
+		});
+	});
 });
 
 describe("routine settings keys", () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1191,10 +1191,7 @@ describe("SettingsManager", () => {
 		});
 
 		it("returns false for a malformed string value without throwing on load", () => {
-			writeFileSync(
-				join(agentDir, "settings.json"),
-				JSON.stringify({ experimental: { bashEvalOnly: "yes" } }),
-			);
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { bashEvalOnly: "yes" } }));
 
 			const manager = SettingsManager.create(projectDir, agentDir);
 			expect(manager.getExperimentalBashEvalOnly()).toBe(false);

--- a/packages/coding-agent/test/suite/bash-eval-only.test.ts
+++ b/packages/coding-agent/test/suite/bash-eval-only.test.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { fauxAssistantMessage, fauxToolCall, getModel } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
@@ -230,6 +232,84 @@ describe("experimental bash eval-only policy", () => {
 			expect(harness.agent.removedToolHints.bash).toContain('tool.bash({ command: "..." })');
 			expect(harness.agent.removedToolHints.powershell).toContain('tool.powershell({ command: "..." })');
 			expect(harness.agent.removedToolHints.powershell).not.toContain("tool.bash(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("names every hidden tool in the system-prompt guidance", async () => {
+		const { harness } = await createEvalHarness();
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			expect(harness.session.systemPrompt).toContain("tool.bash(");
+			expect(harness.session.systemPrompt).toContain("tool.powershell(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});
+
+describe("experimental bash eval-only policy across reload", () => {
+	async function createReloadHarness(options: { flagOn: boolean; evalRegistered?: () => boolean }): Promise<Harness> {
+		const evalRegistered = options.evalRegistered ?? (() => true);
+		const extensionFactory: ExtensionFactory = (pi) => {
+			if (!evalRegistered()) return;
+			pi.registerTool({
+				name: "eval",
+				label: "Eval",
+				description: "Evaluate code",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+			});
+		};
+		return await createHarness({
+			fileSettings: true,
+			...(options.flagOn ? { settings: { experimental: { bashEvalOnly: true } } } : {}),
+			initialActiveToolNames: ["read", "bash", "edit", "write"],
+			extensionFactories: [extensionFactory],
+		});
+	}
+
+	function writeSettings(harness: Harness, contents: Record<string, unknown>): void {
+		writeFileSync(join(harness.tempDir, "agent", "settings.json"), JSON.stringify(contents));
+	}
+
+	it("arms the policy when the flag is turned on and the session reloads", async () => {
+		const harness = await createReloadHarness({ flagOn: false });
+		try {
+			expect(harness.session.getActiveToolNames()).toContain("bash");
+			writeSettings(harness, { experimental: { bashEvalOnly: true } });
+			await harness.session.reload();
+			expect(harness.session.getActiveToolNames()).not.toContain("bash");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("disarms the policy when the flag is turned off and the session reloads", async () => {
+		const harness = await createReloadHarness({ flagOn: true });
+		try {
+			expect(harness.session.getActiveToolNames()).not.toContain("bash");
+			writeSettings(harness, {});
+			await harness.session.reload();
+			expect(harness.session.getActiveToolNames()).toContain("bash");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("retains withheld shell tools across a reload so disarming can restore them", async () => {
+		const harness = await createReloadHarness({ flagOn: true });
+		try {
+			expect(harness.session.getActiveToolNames()).not.toContain("bash");
+			await harness.session.reload();
+			// Still armed, so bash stays hidden - but the unfiltered request must keep carrying it,
+			// otherwise a later disarm has nothing to restore (see the flag-off reload test above).
+			expect(harness.session.getActiveToolNames()).not.toContain("bash");
+			const retained = (harness.session as unknown as { _requestedActiveToolNames?: string[] })
+				._requestedActiveToolNames;
+			expect(retained).toContain("bash");
 		} finally {
 			harness.cleanup();
 		}

--- a/packages/coding-agent/test/suite/bash-eval-only.test.ts
+++ b/packages/coding-agent/test/suite/bash-eval-only.test.ts
@@ -1,0 +1,237 @@
+import { fauxAssistantMessage, fauxToolCall, getModel } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import { runEvalSchema } from "../../../senpi-codemode/src/bridges/schema-bridge.ts";
+import { DefaultResourceLoader } from "../../src/core/resource-loader.ts";
+import { createAgentSession, type ExtensionFactory } from "../../src/core/sdk.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import type { ExtensionAPI } from "../../src/index.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+vi.mock("@code-yeongyu/senpi", async () => await import("../../src/index.ts"));
+const { createExecuteTool } = await import("../../../senpi-codemode/src/extension/runtime-factory.ts");
+
+function arm(harness: Harness, names = ["bash", "powershell"]): void {
+	const session = harness.session as unknown as { _evalOnlyToolNames: ReadonlySet<string> };
+	session._evalOnlyToolNames = new Set(names);
+}
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter((part): part is { type: "text"; text: string } => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+async function createEvalHarness(options: { withEval?: boolean } = {}): Promise<{
+	harness: Harness;
+	observed: string[];
+}> {
+	const observed: string[] = [];
+	const extensionFactory: ExtensionFactory = (pi) => {
+		if (options.withEval !== false) {
+			pi.registerTool({
+				name: "eval",
+				label: "Eval",
+				description: "Evaluate code",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+			});
+		}
+		pi.on("tool_call", (event) => {
+			if (event.toolName === "bash") observed.push(event.toolName);
+		});
+	};
+	const harness = await createHarness({ extensionFactories: [extensionFactory] });
+	return { harness, observed };
+}
+
+describe("experimental bash eval-only policy", () => {
+	it("armed sessions hide bash and powershell and explain tool.bash(", async () => {
+		const { harness } = await createEvalHarness();
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "bash", "powershell", "edit", "write"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("bash");
+			expect(harness.session.getActiveToolNames()).not.toContain("powershell");
+			expect(harness.session.systemPrompt).toContain("tool.bash(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("executes hidden bash through hooks without reactivating it", async () => {
+		const { harness, observed } = await createEvalHarness();
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			const result = await harness.session.executeTool(
+				"bash",
+				{ command: "echo hi" },
+				{ activateInactiveTool: true },
+			);
+			expect(textOf(result)).toContain("hi");
+			expect(observed).toEqual(["bash"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("bash");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("publishes the removed-tool hint for unknown tool calls", async () => {
+		const { harness } = await createEvalHarness();
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			expect(harness.agent.removedToolHints.bash).toContain('tool.bash({ command: "..." })');
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("bash", { command: "echo hi" }), { stopReason: "toolUse" }),
+				fauxAssistantMessage("done"),
+			]);
+			await harness.session.prompt("run bash");
+			const toolResult = harness.session.messages.find((message) => message.role === "toolResult");
+			expect(toolResult && "content" in toolResult ? toolResult.content[0] : undefined).toMatchObject({
+				text: expect.stringContaining('tool.bash({ command: "..." })'),
+			});
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("leaves the policy inert when eval is not registered", async () => {
+		const { harness } = await createEvalHarness({ withEval: false });
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "bash", "edit", "write"]);
+			expect(harness.session.getActiveToolNames()).toContain("bash");
+			expect(textOf(await harness.session.executeTool("bash", { command: "echo hi" }))).toContain("hi");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps flag-off behavior unchanged", async () => {
+		const { harness } = await createEvalHarness();
+		try {
+			const before = harness.session.systemPrompt;
+			harness.session.setActiveToolsByName(["read", "bash", "edit", "write"]);
+			expect(harness.session.getActiveToolNames()).toEqual(["read", "bash", "edit", "write"]);
+			expect(harness.session.systemPrompt).not.toContain("tool.bash(");
+			expect(before).not.toContain("tool.bash(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("SDK wiring arms the policy from experimental.bashEvalOnly", async () => {
+		const settingsManager = SettingsManager.inMemory({ experimental: { bashEvalOnly: true } });
+		const resourceLoader = new DefaultResourceLoader({
+			cwd: process.cwd(),
+			agentDir: process.cwd(),
+			settingsManager,
+			extensionFactories: [
+				(pi) => {
+					pi.registerTool({
+						name: "eval",
+						label: "Eval",
+						description: "Evaluate code",
+						parameters: Type.Object({}),
+						execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+					});
+				},
+			],
+			noSkills: true,
+			noPromptTemplates: true,
+			noThemes: true,
+			noContextFiles: true,
+		});
+		await resourceLoader.reload();
+		const { session } = await createAgentSession({
+			model: getModel("anthropic", "claude-sonnet-4-5")!,
+			settingsManager,
+			resourceLoader,
+			sessionManager: SessionManager.inMemory(process.cwd()),
+		});
+		try {
+			expect(session.getActiveToolNames()).not.toContain("bash");
+			expect(session.systemPrompt).toContain("tool.bash(");
+		} finally {
+			session.dispose();
+		}
+	});
+
+	it("getAllTools-backed eval schema still lists bash while the armed policy keeps it inactive", async () => {
+		const { harness } = await createEvalHarness();
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "bash", "powershell", "edit", "write"]);
+			const active = harness.session.getActiveToolNames();
+			const allNames = harness.session.getAllTools().map((tool) => tool.name);
+			expect(active).not.toContain("bash");
+			expect(active).not.toContain("powershell");
+			expect(allNames).toContain("bash");
+			expect(allNames).toContain("powershell");
+			const listed = runEvalSchema({}, { listTools: () => harness.session.getAllTools() });
+			expect(listed).toEqual({
+				tools: expect.arrayContaining(["bash", "powershell"]),
+			});
+			expect(runEvalSchema({ name: "bash" }, { listTools: () => harness.session.getAllTools() })).toMatchObject({
+				name: "bash",
+			});
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("createExecuteTool wrapper runs bash without reactivating it", async () => {
+		const observedActivations: string[] = [];
+		let api: ExtensionAPI | undefined;
+		const extensionFactory: ExtensionFactory = (pi) => {
+			api = pi;
+			pi.registerTool({
+				name: "eval",
+				label: "Eval",
+				description: "Evaluate code",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+			});
+			pi.registerLazyToolActivator((toolName) => {
+				observedActivations.push(toolName);
+				pi.setActiveTools([...pi.getActiveTools(), toolName]);
+				return true;
+			});
+		};
+		const harness = await createHarness({ extensionFactories: [extensionFactory] });
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			if (api === undefined) throw new Error("extension API was not captured");
+			const runtime = api;
+			const executeTool = createExecuteTool({
+				executeTool: (toolName, params, options) => runtime.executeTool(toolName, params, options),
+				getActiveTools: () => runtime.getActiveTools(),
+				getAllTools: () => runtime.getAllTools(),
+			});
+			const result = await executeTool("bash", { command: "echo hi" });
+			expect(textOf(result)).toContain("hi");
+			expect(observedActivations).toEqual([]);
+			expect(harness.session.getActiveToolNames()).not.toContain("bash");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("names each hidden tool in its own removed-tool hint", async () => {
+		const { harness } = await createEvalHarness();
+		try {
+			arm(harness);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			expect(harness.agent.removedToolHints.bash).toContain('tool.bash({ command: "..." })');
+			expect(harness.agent.removedToolHints.powershell).toContain('tool.powershell({ command: "..." })');
+			expect(harness.agent.removedToolHints.powershell).not.toContain("tool.bash(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
## What

Adds an opt-in experimental setting, `experimental.bashEvalOnly` (boolean, default `false`). When enabled, the `bash` and `powershell` tools are removed from the model-visible tool list and remain reachable only from inside eval cells via `tool.bash({ command: "..." })`.

Hooks and permission checks keep firing exactly as before, because eval-lane execution still runs the full `prepareAgentToolCall` → `preflightToolCall` → `execute` pipeline.

```json
{
  "experimental": {
    "bashEvalOnly": true
  }
}
```

## Why this shape

The model can only call tools present in its tool list, so removing them from that list is the actual enforcement. Execution is then reopened on the extension-only `executeTool` surface, which the model's tool-call loop never reaches.

Three guidance surfaces keep the agent oriented from the first turn:

1. A system-prompt note stating shell commands run only inside eval cells, generated from the policy names so it names both `tool.bash(...)` and `tool.powershell(...)`.
2. A per-tool `removedToolHints` redirect if a direct call is hallucinated anyway.
3. Continued visibility in eval's `tool_schema` listing, which is sourced from `getAllTools()` and therefore still includes inactive tools.

## Design details

- **Settings ownership lives in the session.** `AgentSession` resolves the policy from `settingsManager` in both its constructor and `reload()`, so toggling the flag takes effect on reload in both directions. An explicitly supplied `AgentSessionConfig.evalOnlyToolNames` stays authoritative for SDK embedders and tests.
- **Arming rule:** the policy is armed only when the names resolve **and** the `eval` tool is registered. If codemode is unavailable the policy is fully inert, so a session never loses shell access entirely.
- **Single choke point:** filtering lives in `setActiveToolsByName`, which every activation path flows through — initial activation, `_enforceConfiguredDefaultTools`, `_refreshToolRegistry` re-activation, and tool-search lazy activation. A policy name cannot be re-activated while armed, including via `activateInactiveTool: true` (which codemode always passes).
- **Withheld tools are retained, not forgotten.** Hiding a tool records it in a withheld set and keeps it in the unfiltered request. `reload()` builds its registration-id map from that unfiltered request, because the rebuild drops any seeded name missing from that map — without this, disarming the policy would strand shell access instead of restoring it.

## Verification

TDD throughout: every behavior was captured RED before the production change, then GREEN.

Feature suite `test/suite/bash-eval-only.test.ts` — 13 passing — covers visibility, eval-lane execution with hook receipts, no re-activation, per-tool hints, flag-off regression, the safety valve, flag transitions across reload in both directions, and retention of withheld tools across reload. Test-only additions carry mutation proofs (each assertion was watched failing under a deliberate break, then restored).

Real-surface QA via `test/manual-qa/bash-eval-only-qa.ts`, driving the shipped `createAgentSession` entrypoint against a scratch project with the faux provider (no credentials, no network):

| Check | Armed | Control (flag off) |
|---|---|---|
| `bash` in active tools | absent | present |
| `bash` in `getAllTools()` | present | present |
| `tool.bash(` prompt sentinel | present | absent |
| `executeTool("bash", …)` | returns `qa-ok` | returns `qa-ok` |
| `tool_call` hook receipt | captured | captured |
| bash re-activated after execute | no | n/a |

The armed hook receipt records `{"command":"echo qa-ok","timeout":1800}`; the defaulted `timeout` confirms real schema instantiation through the full pipeline rather than a shortcut path.

**Regression check:** an adjacent sweep over `test/suite`, `settings-manager`, and `tool-search` passes 489 files / 3392 tests with zero failures. Against the full package suite, this branch's failing files are a strict subset of the same suite's failures on `origin/main`: baseline at `e93092942` had 19 failing files, this branch has 3, all present in that baseline and all bound to the fixed `QA_PORTS 18990-18999` pool held by orphaned daemons predating this branch.

Root `npm run check` exits 0.

## Scope and known limitation

Behavior is unchanged when the flag is absent or `false`, which is the default. No changes to the hooks pipeline, the permission system, or the bash/powershell tool implementations. Background terminal tools (`bash_output`, `bash_input`, `bash_resize`, `kill_bash`, `monitor`) stay directly available, and the TUI `!` bang path is untouched.

Known limitation: when a prompt preset replaces the base system prompt wholesale, the armed guidance note is not part of the final model-facing prompt. This follows from how prompt-preset replacement works rather than from this change, and direct-call protection still holds through the redirect hints. Addressing it would mean altering the prompt-preset contract, which is left out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an experimental `experimental.bashEvalOnly` setting that hides `bash` and `powershell` as direct model tools and routes them through eval cells instead. It defaults to `false`, so existing sessions are unchanged; hooks and permission checks still apply.

**Behavior**
- The policy is inert when the `eval` tool is unavailable, so shell access is never lost.
- Reloading a session picks up flag changes in both directions.
- Hallucinated direct calls get a redirect hint naming the eval-cell helper.
- A system-prompt note tells the model shell commands run only inside eval cells.
- Background terminal tools and the TUI `!` path are untouched.

**Implementation notes**
- Filtering happens in `setActiveToolsByName`, the single path all activations flow through.
- Withheld tools are retained in the unfiltered request so disarming can restore them.
- An explicit `AgentSessionConfig.evalOnlyToolNames` override stays authoritative for SDK embedders.
- Eval-lane execution still runs the full `prepareAgentToolCall` → `preflightToolCall` → `execute` pipeline.

<sup>Written for commit 21867e7eeeac230ad67758389e7c3dca1c54f251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

