### PR TITLE
feat(coding-agent): add experimental.workflowEvalOnly to route the workflow tool through eval

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- New experimental setting `experimental.workflowEvalOnly` (default `false`). When enabled, the `workflow` (dag)
+  tool is withheld from the model-facing tool surface and runs only inside eval cells via
+  `tool.workflow({ action: "snapshot", run_id })`. Hooks and permission checks still apply to those operations.
+  The policy is inert whenever the `eval` tool is unavailable, so workflow access is never lost, and it follows the
+  flag across a reload.
+
 ### Fixed
 
 - Bash callback settlement is bounded on direct, shared-host, and harness execution paths so never-settling callbacks cannot hang commands or silently lose spill cleanup failures.

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -400,6 +400,7 @@ Windows paths in JSON must use forward slashes or escaped backslashes:
 |---------|------|---------|-------------|
 | `defaultTools` | string[] | - | Built-in tools enabled initially. When omitted, Pi uses its standard defaults |
 | `experimental.bashEvalOnly` | boolean | `false` | Route `bash` and `powershell` through eval cells only; the tools leave the model's direct tool list |
+| `experimental.workflowEvalOnly` | boolean | `false` | Route the workflow (dag) tool through eval cells only; the tool leaves the model direct tool list |
 
 `defaultTools` selects the built-in tools enabled at startup. Extension and SDK custom tools remain enabled. Available built-ins are `read`, `bash`, `powershell`, `edit`, `write`, `grep`, `find`, and `ls`:
 
@@ -434,6 +435,22 @@ const { output } = await tool.bash({ command: "ls -la" });
 ```
 
 Hooks and permission checks apply unchanged to shell commands run this way. If the model hallucinates a direct `bash` or `powershell` call anyway, the call returns a hint redirecting it to an eval cell. When the `eval` tool is unavailable (codemode not loaded), the policy auto-disables and both tools stay on the direct tool list, so shell access is never lost.
+
+With `experimental.workflowEvalOnly` enabled, the `workflow` (dag) tool disappears from the model's direct tool list and runs only inside eval cells:
+
+```json
+{
+  "experimental": {
+    "workflowEvalOnly": true
+  }
+}
+```
+
+```js
+const snapshot = await tool.workflow({ action: "snapshot", run_id });
+```
+
+Hooks and permission checks apply unchanged to workflow operations run this way. When the `eval` tool is unavailable (codemode not loaded), the policy auto-disables and the workflow tool stays on the direct tool list, so workflow access is never lost.
 
 ### Sessions
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -203,7 +203,16 @@ import { createToolDefinitionFromAgentTool } from "./tools/tool-definition-wrapp
 import { addUsageToTotals, createUsageTotals } from "./usage-totals.ts";
 
 /** Built-in shell tools routed exclusively through eval when experimental.bashEvalOnly is enabled. */
-const EVAL_ONLY_POLICY_TOOL_NAMES: readonly string[] = ["bash", "powershell"];
+const EVAL_ONLY_SHELL_TOOL_NAMES: readonly string[] = ["bash", "powershell"];
+/** Workflow tool routed exclusively through eval when experimental.workflowEvalOnly is enabled. */
+const EVAL_ONLY_WORKFLOW_TOOL_NAMES: readonly string[] = ["workflow"];
+
+/** Sample eval-cell call for an eval-only tool, using the argument name that tool actually takes. */
+function evalHelperCall(name: string): string {
+	if (EVAL_ONLY_SHELL_TOOL_NAMES.includes(name)) return `tool.${name}({ command: "..." })`;
+	if (EVAL_ONLY_WORKFLOW_TOOL_NAMES.includes(name)) return `tool.${name}({ action: "..." })`;
+	return `tool.${name}({ ... })`;
+}
 const TURN_RETRY_SUPPRESSION_PREFIX = "senpi:no-turn-retry:";
 const DEFERRED_RETRY_QUEUE_OWNERS = new WeakSet<object>();
 
@@ -3037,7 +3046,11 @@ export class AgentSession {
 	 */
 	private _resolveEvalOnlyToolNames(): ReadonlySet<string> | undefined {
 		if (this._evalOnlyToolNamesOverride !== undefined) return this._evalOnlyToolNamesOverride;
-		return this.settingsManager.getExperimentalBashEvalOnly() ? new Set(EVAL_ONLY_POLICY_TOOL_NAMES) : undefined;
+		const names = [
+			...(this.settingsManager.getExperimentalBashEvalOnly() ? EVAL_ONLY_SHELL_TOOL_NAMES : []),
+			...(this.settingsManager.getExperimentalWorkflowEvalOnly() ? EVAL_ONLY_WORKFLOW_TOOL_NAMES : []),
+		];
+		return names.length > 0 ? new Set(names) : undefined;
 	}
 
 	/** Publish per-tool eval-only redirect hints so a direct call names its own eval helper. */
@@ -3045,7 +3058,7 @@ export class AgentSession {
 		if (!this._isEvalOnlyPolicyArmed()) return;
 		for (const name of this._evalOnlyToolNames ?? []) {
 			this.agent.removedToolHints[name] =
-				`Run ${name} inside an eval cell via tool.${name}({ command: "..." }); hooks and permissions still apply.`;
+				`Run ${name} inside an eval cell via ${evalHelperCall(name)}; hooks and permissions still apply.`;
 		}
 	}
 
@@ -3294,10 +3307,20 @@ export class AgentSession {
 		const prompt =
 			loaderAppendSystemPrompt.length > 0 ? `${basePrompt}\n\n${loaderAppendSystemPrompt.join("\n\n")}` : basePrompt;
 		if (!this._isEvalOnlyPolicyArmed()) return prompt;
-		const helpers = [...(this._evalOnlyToolNames ?? [])]
-			.map((name) => `tool.${name}({ command: "..." })`)
-			.join(" or ");
-		return `${prompt}\n\nShell commands run ONLY inside eval cells via ${helpers}; hooks and permissions still apply.`;
+		const armed = this._evalOnlyToolNames ?? new Set<string>();
+		const sentences: string[] = [];
+		const shellHelpers = EVAL_ONLY_SHELL_TOOL_NAMES.filter((name) => armed.has(name)).map(evalHelperCall);
+		if (shellHelpers.length > 0) {
+			sentences.push(
+				`Shell commands run ONLY inside eval cells via ${shellHelpers.join(" or ")}; hooks and permissions still apply.`,
+			);
+		}
+		if (armed.has("workflow")) {
+			sentences.push(
+				`The workflow tool runs ONLY inside eval cells via ${evalHelperCall("workflow")}; hooks and permissions still apply.`,
+			);
+		}
+		return sentences.length > 0 ? `${prompt}\n\n${sentences.join("\n\n")}` : prompt;
 	}
 
 	/**

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1095,6 +1095,8 @@ export class AgentSession {
 	private readonly _evalOnlyToolNamesOverride?: ReadonlySet<string>;
 	/** Policy tools withheld from the model, retained so disarming can restore direct access. */
 	private readonly _withheldEvalOnlyToolNames = new Set<string>();
+	/** Eval-only hint names this session published, so a disarm can withdraw exactly those. */
+	private readonly _publishedEvalOnlyHintNames = new Set<string>();
 	/** Active-tool selection as requested by callers, before eval-only filtering. */
 	private _requestedActiveToolNames?: string[];
 	private _allowedToolNames?: Set<string>;
@@ -3053,12 +3055,25 @@ export class AgentSession {
 		return names.length > 0 ? new Set(names) : undefined;
 	}
 
-	/** Publish per-tool eval-only redirect hints so a direct call names its own eval helper. */
+	/**
+	 * Publish per-tool eval-only redirect hints so a direct call names its own eval helper.
+	 *
+	 * Hints published here are tracked so a disarm - or a shrinking armed set, e.g. bash+workflow
+	 * down to workflow only - withdraws the stale ones. Only tracked names are ever deleted, so
+	 * hints owned by other publishers survive.
+	 */
 	private _publishEvalOnlyToolHints(): void {
-		if (!this._isEvalOnlyPolicyArmed()) return;
-		for (const name of this._evalOnlyToolNames ?? []) {
+		const armed = this._isEvalOnlyPolicyArmed() ? (this._evalOnlyToolNames ?? new Set<string>()) : undefined;
+		for (const name of this._publishedEvalOnlyHintNames) {
+			if (armed?.has(name)) continue;
+			delete this.agent.removedToolHints[name];
+		}
+		this._publishedEvalOnlyHintNames.clear();
+		if (!armed) return;
+		for (const name of armed) {
 			this.agent.removedToolHints[name] =
 				`Run ${name} inside an eval cell via ${evalHelperCall(name)}; hooks and permissions still apply.`;
+			this._publishedEvalOnlyHintNames.add(name);
 		}
 	}
 
@@ -3318,6 +3333,15 @@ export class AgentSession {
 		if (armed.has("workflow")) {
 			sentences.push(
 				`The workflow tool runs ONLY inside eval cells via ${evalHelperCall("workflow")}; hooks and permissions still apply.`,
+			);
+		}
+		// SDK embedders can arm names outside the built-in groups; they still need eval guidance.
+		const otherHelpers = [...armed]
+			.filter((name) => !EVAL_ONLY_SHELL_TOOL_NAMES.includes(name) && name !== "workflow")
+			.map(evalHelperCall);
+		if (otherHelpers.length > 0) {
+			sentences.push(
+				`These tools run ONLY inside eval cells via ${otherHelpers.join(" or ")}; hooks and permissions still apply.`,
 			);
 		}
 		return sentences.length > 0 ? `${prompt}\n\n${sentences.join("\n\n")}` : prompt;

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-30 - Experimental workflow eval-only policy
+
+### What changed
+
+- `packages/coding-agent/src/core/settings-manager.ts`: adds the `experimental.workflowEvalOnly` setting and its getter.
+- `packages/coding-agent/src/core/agent-session.ts`: resolves the policy from settings in the constructor and on reload, hides the `workflow` tool while the registered `eval` tool is present, executes it through the registry without activation, publishes an eval-cell hint, adds system-prompt guidance, and retains the withheld tool so disarming restores direct access.
+
+### Why
+
+- Codemode can keep invoking the workflow (dag) tool from eval cells while preventing it from being advertised as a direct model tool. The policy is inert when codemode's `eval` tool is unavailable, so workflow access is never lost.
+
+### Why an extension could not handle it
+
+- Active tool visibility, lazy activation, the wrapped registry, and the agent-loop removed-tool hint map are coordinated inside `AgentSession`; an extension cannot atomically enforce these boundaries.
+
+### Expected merge conflict zones
+
+- `agent-session.ts`: active-tool selection, tool registry refresh, reload, and system-prompt assembly.
 ## 2026-08-29 - Bound Cursor serialized tool-result admissions
 
 ### What changed

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -178,6 +178,7 @@ export type PackageSource =
 
 export interface ExperimentalSettings {
 	bashEvalOnly?: boolean;
+	workflowEvalOnly?: boolean;
 }
 
 export interface Settings {
@@ -2035,6 +2036,10 @@ export class SettingsManager {
 
 	getExperimentalBashEvalOnly(): boolean {
 		return this.settings.experimental?.bashEvalOnly === true;
+	}
+
+	getExperimentalWorkflowEvalOnly(): boolean {
+		return this.settings.experimental?.workflowEvalOnly === true;
 	}
 
 	setEnabledModels(patterns: string[] | undefined): void {

--- a/packages/coding-agent/test/manual-qa/workflow-eval-only-qa.ts
+++ b/packages/coding-agent/test/manual-qa/workflow-eval-only-qa.ts
@@ -1,0 +1,205 @@
+/**
+ * Real-surface QA driver for experimental.workflowEvalOnly.
+ *
+ * Drives the shipped SDK entrypoint (createAgentSession) against a scratch
+ * project directory whose .senpi/settings.json carries the flag, using the
+ * faux provider so no credentials or network model calls are involved.
+ *
+ * Usage: npx tsx test/manual-qa/workflow-eval-only-qa.ts <scratchDir> <mode:armed|control> <outDir>
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { CONFIG_DIR_NAME } from "../../src/config.ts";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { DefaultResourceLoader } from "../../src/core/resource-loader.ts";
+import { createAgentSession, type ExtensionFactory } from "../../src/core/sdk.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+import { SettingsManager } from "../../src/core/settings-manager.ts";
+import { createInMemoryModelRegistry } from "../model-runtime-test-utils.ts";
+
+const [scratchDir, mode, outDir] = process.argv.slice(2);
+if (!scratchDir || !mode || !outDir) {
+	throw new Error("usage: workflow-eval-only-qa.ts <scratchDir> <armed|control> <outDir>");
+}
+
+const lines: string[] = [];
+function log(line: string): void {
+	lines.push(line);
+	process.stdout.write(`${line}\n`);
+}
+
+const toolCallReceipts: Array<{ toolName: string; input: unknown }> = [];
+
+async function main(): Promise<void> {
+	const agentDir = join(scratchDir, "agent-dir");
+	mkdirSync(agentDir, { recursive: true });
+	const projectSettingsPath = join(scratchDir, CONFIG_DIR_NAME, "settings.json");
+	mkdirSync(join(scratchDir, CONFIG_DIR_NAME), { recursive: true });
+	// The project settings file is the real surface the flag ships on.
+	writeFileSync(
+		projectSettingsPath,
+		`${JSON.stringify({ experimental: { workflowEvalOnly: mode === "armed" } }, null, 2)}\n`,
+	);
+
+	const faux = registerFauxProvider({});
+	const model = faux.getModel();
+	faux.setResponses([]);
+
+	// Faux credentials only: no real provider key and no network model call.
+	const authStorage = AuthStorage.inMemory();
+	await authStorage.modify(model.provider, async () => ({ type: "api_key", key: "faux-key" }));
+	const modelRegistry = await createInMemoryModelRegistry(authStorage);
+	modelRegistry.registerProvider(model.provider, {
+		baseUrl: model.baseUrl,
+		apiKey: "faux-key",
+		api: faux.api,
+		models: faux.models.map((registeredModel) => ({
+			id: registeredModel.id,
+			name: registeredModel.name,
+			api: registeredModel.api,
+			reasoning: registeredModel.reasoning,
+			input: registeredModel.input,
+			cost: registeredModel.cost,
+			contextWindow: registeredModel.contextWindow,
+			maxTokens: registeredModel.maxTokens,
+			baseUrl: registeredModel.baseUrl,
+		})),
+	});
+
+	// The eval tool stands in for codemode's registration: the policy is only
+	// armed while a tool named "eval" is present in the registry. The workflow
+	// tool stands in for the external extension that registers it at runtime.
+	const extensionFactory: ExtensionFactory = (pi) => {
+		pi.registerTool({
+			name: "eval",
+			label: "Eval",
+			description: "Evaluate code in a persistent kernel",
+			parameters: Type.Object({ code: Type.String() }),
+			execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+		});
+		pi.registerTool({
+			name: "workflow",
+			label: "Workflow",
+			description: "Run a workflow action",
+			parameters: Type.Object({ action: Type.String() }),
+			execute: async (_toolCallId, params) => ({
+				content: [{ type: "text", text: `workflow-ran:${params.action}` }],
+				details: {},
+			}),
+		});
+		pi.on("tool_call", (event) => {
+			toolCallReceipts.push({ toolName: event.toolName, input: event.input });
+		});
+	};
+
+	const settingsManager = SettingsManager.create(scratchDir, agentDir);
+	const resourceLoader = new DefaultResourceLoader({
+		cwd: scratchDir,
+		agentDir,
+		settingsManager,
+		extensionFactories: [extensionFactory],
+		noSkills: true,
+		noPromptTemplates: true,
+		noThemes: true,
+		noContextFiles: true,
+	});
+	await resourceLoader.reload();
+
+	const { session } = await createAgentSession({
+		cwd: scratchDir,
+		agentDir,
+		model,
+		settingsManager,
+		resourceLoader,
+		authStorage,
+		modelRegistry,
+		sessionManager: SessionManager.inMemory(scratchDir),
+	});
+
+	try {
+		log(`# workflow-eval-only QA (${mode})`);
+		log(`scratch: ${scratchDir}`);
+		log(`project settings file: ${projectSettingsPath}`);
+		log(`getExperimentalWorkflowEvalOnly(): ${settingsManager.getExperimentalWorkflowEvalOnly()}`);
+		log(`getExperimentalBashEvalOnly(): ${settingsManager.getExperimentalBashEvalOnly()}`);
+		log("");
+
+		// (i) active tool list
+		const activeTools = session.getActiveToolNames();
+		log("## (i) active tool names");
+		log(JSON.stringify(activeTools));
+		log(`workflow present: ${activeTools.includes("workflow")}`);
+		log(`bash present: ${activeTools.includes("bash")}`);
+		log(`eval present: ${activeTools.includes("eval")}`);
+		log(`all registered tools include workflow: ${session.getAllTools().some((tool) => tool.name === "workflow")}`);
+		log("");
+
+		// (ii) system prompt sentinel
+		const prompt = session.systemPrompt;
+		const sentinel = "tool.workflow(";
+		const sentinelIndex = prompt.indexOf(sentinel);
+		log('## (ii) system prompt sentinel "tool.workflow("');
+		log(`contains sentinel: ${sentinelIndex >= 0}`);
+		log(`contains shell sentinel "tool.bash(": ${prompt.includes("tool.bash(")}`);
+		if (sentinelIndex >= 0) {
+			log(
+				`sentinel line: ${prompt
+					.slice(Math.max(0, sentinelIndex - 200), sentinelIndex + 120)
+					.split("\n")
+					.pop()}`,
+			);
+		}
+		log("");
+
+		// (iii) executeTool workflow through the full pipeline
+		log('## (iii) executeTool("workflow", { action: "qa-ok" })');
+		try {
+			const result = await session.executeTool("workflow", { action: "qa-ok" });
+			const text = result.content
+				.filter((part): part is { type: "text"; text: string } => part.type === "text")
+				.map((part) => part.text)
+				.join("\n");
+			log(`output contains "qa-ok": ${text.includes("qa-ok")}`);
+			log(`output: ${JSON.stringify(text.slice(0, 400))}`);
+		} catch (error) {
+			log(`executeTool threw: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		log(`tool_call receipts: ${JSON.stringify(toolCallReceipts)}`);
+		log(`active tools after execute: ${JSON.stringify(session.getActiveToolNames())}`);
+		log(`workflow reactivated: ${session.getActiveToolNames().includes("workflow")}`);
+		log("");
+
+		// (iv) redirect hint for a direct/unknown workflow call from the model
+		log("## (iv) redirect hint for a direct model workflow call");
+		const hints = (session as unknown as { agent: { removedToolHints: Record<string, string> } }).agent
+			.removedToolHints;
+		log(`removedToolHints.workflow: ${JSON.stringify(hints.workflow)}`);
+		log(`removedToolHints.bash: ${JSON.stringify(hints.bash)}`);
+		faux.setResponses([
+			fauxAssistantMessage(fauxToolCall("workflow", { action: "direct-call" }), { stopReason: "toolUse" }),
+			fauxAssistantMessage("done"),
+		]);
+		await session.prompt("run workflow directly");
+		const toolResult = session.messages.find((message) => message.role === "toolResult");
+		const resultText =
+			toolResult && "content" in toolResult
+				? JSON.stringify((toolResult.content as Array<{ text?: string }>)[0]?.text ?? "")
+				: "<no toolResult>";
+		log(`model-issued workflow toolResult: ${resultText}`);
+		log("");
+
+		writeFileSync(join(outDir, `tool-call-receipts-${mode}.json`), `${JSON.stringify(toolCallReceipts, null, 2)}\n`);
+		writeFileSync(join(outDir, `system-prompt-${mode}.txt`), prompt);
+		log(`receipts file: ${join(outDir, `tool-call-receipts-${mode}.json`)}`);
+		log(`system prompt file: ${join(outDir, `system-prompt-${mode}.txt`)}`);
+	} finally {
+		session.dispose();
+		faux.unregister();
+	}
+}
+
+await main();
+writeFileSync(join(outDir, `${mode}.log`), `${lines.join("\n")}\n`);

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -1198,6 +1198,61 @@ describe("SettingsManager", () => {
 			expect(manager.drainErrors()).toEqual([]);
 		});
 	});
+
+	describe("experimental.workflowEvalOnly", () => {
+		it("returns false when experimental is unset", () => {
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalWorkflowEvalOnly()).toBe(false);
+		});
+
+		it("returns true when global experimental.workflowEvalOnly is true", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { workflowEvalOnly: true } }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalWorkflowEvalOnly()).toBe(true);
+		});
+
+		it("lets project override global true to false via deep merge", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { workflowEvalOnly: true } }));
+			writeFileSync(
+				join(projectDir, CONFIG_DIR_NAME, "settings.json"),
+				JSON.stringify({ experimental: { workflowEvalOnly: false } }),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalWorkflowEvalOnly()).toBe(false);
+		});
+
+		it("lets project override global false to true via deep merge", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { workflowEvalOnly: false } }));
+			writeFileSync(
+				join(projectDir, CONFIG_DIR_NAME, "settings.json"),
+				JSON.stringify({ experimental: { workflowEvalOnly: true } }),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalWorkflowEvalOnly()).toBe(true);
+		});
+
+		it("stays independent of experimental.bashEvalOnly", () => {
+			writeFileSync(
+				join(agentDir, "settings.json"),
+				JSON.stringify({ experimental: { bashEvalOnly: true, workflowEvalOnly: false } }),
+			);
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalBashEvalOnly()).toBe(true);
+			expect(manager.getExperimentalWorkflowEvalOnly()).toBe(false);
+		});
+
+		it("returns false for a malformed string value without throwing on load", () => {
+			writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ experimental: { workflowEvalOnly: "yes" } }));
+
+			const manager = SettingsManager.create(projectDir, agentDir);
+			expect(manager.getExperimentalWorkflowEvalOnly()).toBe(false);
+			expect(manager.drainErrors()).toEqual([]);
+		});
+	});
 });
 
 describe("routine settings keys", () => {

--- a/packages/coding-agent/test/suite/workflow-eval-only.test.ts
+++ b/packages/coding-agent/test/suite/workflow-eval-only.test.ts
@@ -1,0 +1,209 @@
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai/compat";
+import { Type } from "typebox";
+import { describe, expect, it, vi } from "vitest";
+import type { ExtensionFactory } from "../../src/core/sdk.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+vi.mock("@code-yeongyu/senpi", async () => await import("../../src/index.ts"));
+
+const WORKFLOW_HINT = 'tool.workflow({ action: "..." })';
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content
+		.filter((part): part is { type: "text"; text: string } => part.type === "text")
+		.map((part) => part.text)
+		.join("\n");
+}
+
+function armedNames(harness: Harness): string[] {
+	const session = harness.session as unknown as { _evalOnlyToolNames?: ReadonlySet<string> };
+	return [...(session._evalOnlyToolNames ?? [])];
+}
+
+interface WorkflowHarnessOptions {
+	withEval?: boolean;
+	settings?: Record<string, unknown>;
+}
+
+async function createWorkflowHarness(options: WorkflowHarnessOptions = {}): Promise<{
+	harness: Harness;
+	observed: string[];
+}> {
+	const observed: string[] = [];
+	const extensionFactory: ExtensionFactory = (pi) => {
+		if (options.withEval !== false) {
+			pi.registerTool({
+				name: "eval",
+				label: "Eval",
+				description: "Evaluate code",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+			});
+		}
+		// Stands in for the external extension that registers the real workflow tool.
+		pi.registerTool({
+			name: "workflow",
+			label: "Workflow",
+			description: "Run a workflow action",
+			parameters: Type.Object({ action: Type.String() }),
+			execute: async (_toolCallId, params) => ({
+				content: [{ type: "text", text: `workflow-ran:${params.action}` }],
+				details: {},
+			}),
+		});
+		pi.on("tool_call", (event) => {
+			if (event.toolName === "workflow") observed.push(event.toolName);
+		});
+	};
+	const harness = await createHarness({
+		extensionFactories: [extensionFactory],
+		...(options.settings ? { settings: options.settings } : {}),
+	});
+	return { harness, observed };
+}
+
+describe("experimental workflow eval-only policy", () => {
+	it("hides workflow and explains tool.workflow( when the flag arms the session", async () => {
+		// Given: a session whose settings enable experimental.workflowEvalOnly with eval registered
+		const { harness } = await createWorkflowHarness({ settings: { experimental: { workflowEvalOnly: true } } });
+		try {
+			// When: the caller requests workflow among its active tools
+			harness.session.setActiveToolsByName(["read", "workflow", "edit", "write"]);
+
+			// Then: workflow is withheld and the prompt names its eval helper
+			expect(harness.session.getActiveToolNames()).not.toContain("workflow");
+			expect(harness.session.systemPrompt).toContain("tool.workflow({ action:");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("executes hidden workflow through hooks without reactivating it", async () => {
+		// Given: an armed session with workflow left out of the active set
+		const { harness, observed } = await createWorkflowHarness({
+			settings: { experimental: { workflowEvalOnly: true } },
+		});
+		try {
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+
+			// When: the eval bridge executes workflow directly
+			const result = await harness.session.executeTool(
+				"workflow",
+				{ action: "deploy" },
+				{ activateInactiveTool: true },
+			);
+
+			// Then: it runs through the registry, emits a tool_call, and stays inactive
+			expect(textOf(result)).toContain("workflow-ran:deploy");
+			expect(observed).toEqual(["workflow"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("workflow");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("publishes the workflow removed-tool hint for direct model calls", async () => {
+		// Given: an armed session with workflow withheld
+		const { harness } = await createWorkflowHarness({ settings: { experimental: { workflowEvalOnly: true } } });
+		try {
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			expect(harness.agent.removedToolHints.workflow).toContain(WORKFLOW_HINT);
+			harness.setResponses([
+				fauxAssistantMessage(fauxToolCall("workflow", { action: "deploy" }), { stopReason: "toolUse" }),
+				fauxAssistantMessage("done"),
+			]);
+
+			// When: the model calls workflow directly anyway
+			await harness.session.prompt("run workflow");
+
+			// Then: the tool result redirects it to the eval helper
+			const toolResult = harness.session.messages.find((message) => message.role === "toolResult");
+			expect(toolResult && "content" in toolResult ? toolResult.content[0] : undefined).toMatchObject({
+				text: expect.stringContaining(WORKFLOW_HINT),
+			});
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("leaves the policy inert when eval is not registered", async () => {
+		// Given: the flag is on but no eval tool exists to route through
+		const { harness } = await createWorkflowHarness({
+			withEval: false,
+			settings: { experimental: { workflowEvalOnly: true } },
+		});
+		try {
+			// When: workflow is requested as an active tool
+			harness.session.setActiveToolsByName(["read", "workflow", "edit", "write"]);
+
+			// Then: workflow stays directly available
+			expect(harness.session.getActiveToolNames()).toContain("workflow");
+			expect(textOf(await harness.session.executeTool("workflow", { action: "deploy" }))).toContain(
+				"workflow-ran:deploy",
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps flag-off behavior unchanged", async () => {
+		// Given: a session with no experimental flags
+		const { harness } = await createWorkflowHarness();
+		try {
+			const before = harness.session.systemPrompt;
+
+			// When: workflow is requested as an active tool
+			harness.session.setActiveToolsByName(["read", "workflow", "edit", "write"]);
+
+			// Then: nothing is withheld and no eval guidance is appended
+			expect(harness.session.getActiveToolNames()).toEqual(["read", "workflow", "edit", "write"]);
+			expect(harness.session.systemPrompt).not.toContain("tool.workflow(");
+			expect(before).not.toContain("tool.workflow(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("arms only workflow when bashEvalOnly stays off", async () => {
+		// Given: only the workflow flag is enabled
+		const { harness } = await createWorkflowHarness({ settings: { experimental: { workflowEvalOnly: true } } });
+		try {
+			// When: shell tools and workflow are all requested
+			harness.session.setActiveToolsByName(["read", "bash", "powershell", "workflow", "edit"]);
+
+			// Then: shell tools stay directly available and no shell sentence is appended
+			expect(armedNames(harness)).toEqual(["workflow"]);
+			expect(harness.session.getActiveToolNames()).toContain("bash");
+			expect(harness.session.getActiveToolNames()).toContain("powershell");
+			expect(harness.session.getActiveToolNames()).not.toContain("workflow");
+			expect(harness.session.systemPrompt).not.toContain("tool.bash(");
+			expect(harness.session.systemPrompt).toContain("tool.workflow(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("arms the union of both groups when both experimental flags are on", async () => {
+		// Given: both experimental eval-only flags are enabled
+		const { harness } = await createWorkflowHarness({
+			settings: { experimental: { bashEvalOnly: true, workflowEvalOnly: true } },
+		});
+		try {
+			// When: shell tools and workflow are all requested
+			harness.session.setActiveToolsByName(["read", "bash", "powershell", "workflow", "edit"]);
+
+			// Then: every group member is withheld and each hint names its own helper
+			expect(new Set(armedNames(harness))).toEqual(new Set(["bash", "powershell", "workflow"]));
+			const active = harness.session.getActiveToolNames();
+			expect(active).toEqual(["read", "edit"]);
+			expect(harness.agent.removedToolHints.bash).toContain('tool.bash({ command: "..." })');
+			expect(harness.agent.removedToolHints.powershell).toContain('tool.powershell({ command: "..." })');
+			expect(harness.agent.removedToolHints.workflow).toContain(WORKFLOW_HINT);
+			expect(harness.session.systemPrompt).toContain("tool.bash(");
+			expect(harness.session.systemPrompt).toContain("tool.powershell(");
+			expect(harness.session.systemPrompt).toContain("tool.workflow(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/workflow-eval-only.test.ts
+++ b/packages/coding-agent/test/suite/workflow-eval-only.test.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai/compat";
 import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
@@ -18,6 +20,12 @@ function textOf(result: { content: Array<{ type: string; text?: string }> }): st
 function armedNames(harness: Harness): string[] {
 	const session = harness.session as unknown as { _evalOnlyToolNames?: ReadonlySet<string> };
 	return [...(session._evalOnlyToolNames ?? [])];
+}
+
+/** Arm the policy directly, standing in for an SDK embedder's evalOnlyToolNames override. */
+function arm(harness: Harness, names: string[]): void {
+	const session = harness.session as unknown as { _evalOnlyToolNames: ReadonlySet<string> };
+	session._evalOnlyToolNames = new Set(names);
 }
 
 interface WorkflowHarnessOptions {
@@ -202,6 +210,218 @@ describe("experimental workflow eval-only policy", () => {
 			expect(harness.session.systemPrompt).toContain("tool.bash(");
 			expect(harness.session.systemPrompt).toContain("tool.powershell(");
 			expect(harness.session.systemPrompt).toContain("tool.workflow(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("explains eval-only names an SDK override armed outside the built-in groups", async () => {
+		// Given: an embedder arms a custom tool name that is neither a shell tool nor workflow
+		const { harness } = await createWorkflowHarness();
+		try {
+			arm(harness, ["custom"]);
+
+			// When: the active tool set is rebuilt under that policy
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+
+			// Then: the prompt still names the generic eval helper for that tool
+			expect(harness.session.systemPrompt).toContain(
+				"These tools run ONLY inside eval cells via tool.custom({ ... }); hooks and permissions still apply.",
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps the shell and workflow sentences when a custom override name is armed alongside them", async () => {
+		// Given: an override arming a shell tool, workflow, and a custom name at once
+		const { harness } = await createWorkflowHarness();
+		try {
+			arm(harness, ["bash", "workflow", "custom"]);
+
+			// When: the active tool set is rebuilt under that policy
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+
+			// Then: all three sentences are present, with the built-in wording unchanged
+			const prompt = harness.session.systemPrompt;
+			expect(prompt).toContain(
+				'Shell commands run ONLY inside eval cells via tool.bash({ command: "..." }); hooks and permissions still apply.',
+			);
+			expect(prompt).toContain(
+				'The workflow tool runs ONLY inside eval cells via tool.workflow({ action: "..." }); hooks and permissions still apply.',
+			);
+			expect(prompt).toContain(
+				"These tools run ONLY inside eval cells via tool.custom({ ... }); hooks and permissions still apply.",
+			);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("drops hints for names that leave the armed set when the policy shrinks", async () => {
+		// Given: a session armed for both shell tools and workflow
+		const { harness } = await createWorkflowHarness();
+		try {
+			arm(harness, ["bash", "powershell", "workflow"]);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			expect(harness.agent.removedToolHints.workflow).toContain(WORKFLOW_HINT);
+			expect(harness.agent.removedToolHints.bash).toBeDefined();
+
+			// When: the armed set shrinks to workflow only
+			arm(harness, ["workflow"]);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+
+			// Then: the shell hints are withdrawn while workflow keeps its hint
+			expect(harness.agent.removedToolHints.bash).toBeUndefined();
+			expect(harness.agent.removedToolHints.powershell).toBeUndefined();
+			expect(harness.agent.removedToolHints.workflow).toContain(WORKFLOW_HINT);
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("leaves hints published by other owners untouched when the policy disarms", async () => {
+		// Given: an armed session plus an unrelated hint published by someone else
+		const { harness } = await createWorkflowHarness();
+		try {
+			arm(harness, ["workflow"]);
+			harness.session.setActiveToolsByName(["read", "edit", "write"]);
+			harness.agent.removedToolHints.somethingElse = "owned by another publisher";
+
+			// When: the policy disarms
+			(harness.session as unknown as { _evalOnlyToolNames?: ReadonlySet<string> })._evalOnlyToolNames = undefined;
+			harness.session.setActiveToolsByName(["read", "workflow", "edit", "write"]);
+
+			// Then: only the policy's own hint is removed
+			expect(harness.agent.removedToolHints.workflow).toBeUndefined();
+			expect(harness.agent.removedToolHints.somethingElse).toBe("owned by another publisher");
+		} finally {
+			harness.cleanup();
+		}
+	});
+});
+
+describe("experimental workflow eval-only policy across reload", () => {
+	async function createReloadHarness(options: {
+		flagOn?: boolean;
+		settings?: Record<string, unknown>;
+	}): Promise<Harness> {
+		const extensionFactory: ExtensionFactory = (pi) => {
+			pi.registerTool({
+				name: "eval",
+				label: "Eval",
+				description: "Evaluate code",
+				parameters: Type.Object({}),
+				execute: async () => ({ content: [{ type: "text", text: "eval" }], details: {} }),
+			});
+			pi.registerTool({
+				name: "workflow",
+				label: "Workflow",
+				description: "Run a workflow action",
+				parameters: Type.Object({ action: Type.String() }),
+				execute: async (_toolCallId, params) => ({
+					content: [{ type: "text", text: `workflow-ran:${params.action}` }],
+					details: {},
+				}),
+			});
+		};
+		const settings = options.settings ?? (options.flagOn ? { experimental: { workflowEvalOnly: true } } : undefined);
+		return await createHarness({
+			fileSettings: true,
+			...(settings ? { settings } : {}),
+			initialActiveToolNames: ["read", "bash", "powershell", "workflow", "edit"],
+			extensionFactories: [extensionFactory],
+		});
+	}
+
+	function writeSettings(harness: Harness, contents: Record<string, unknown>): void {
+		writeFileSync(join(harness.tempDir, "agent", "settings.json"), JSON.stringify(contents));
+	}
+
+	it("arms the policy when the workflow flag is turned on and the session reloads", async () => {
+		// Given: a session started with the flag off, so workflow is directly available
+		const harness = await createReloadHarness({ flagOn: false });
+		try {
+			expect(harness.session.getActiveToolNames()).toContain("workflow");
+
+			// When: the flag is turned on and the session reloads
+			writeSettings(harness, { experimental: { workflowEvalOnly: true } });
+			await harness.session.reload();
+
+			// Then: workflow is withheld and the eval guidance is appended
+			expect(armedNames(harness)).toEqual(["workflow"]);
+			expect(harness.session.getActiveToolNames()).not.toContain("workflow");
+			expect(harness.agent.removedToolHints.workflow).toContain(WORKFLOW_HINT);
+			expect(harness.session.systemPrompt).toContain("tool.workflow(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("disarms and clears the workflow hint when the flag is turned off and the session reloads", async () => {
+		// Given: an armed session that has already published the workflow hint
+		const harness = await createReloadHarness({ flagOn: true });
+		try {
+			expect(harness.session.getActiveToolNames()).not.toContain("workflow");
+			expect(harness.agent.removedToolHints.workflow).toContain(WORKFLOW_HINT);
+
+			// When: the flag is removed and the session reloads
+			writeSettings(harness, {});
+			await harness.session.reload();
+
+			// Then: workflow comes back and its stale redirect hint is withdrawn
+			expect(harness.session.getActiveToolNames()).toContain("workflow");
+			expect(harness.agent.removedToolHints.workflow).toBeUndefined();
+			expect(harness.session.systemPrompt).not.toContain("tool.workflow(");
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("keeps shell tools armed when only the workflow flag is turned off across a reload", async () => {
+		// Given: a session armed for the union of both groups
+		const harness = await createReloadHarness({
+			settings: { experimental: { bashEvalOnly: true, workflowEvalOnly: true } },
+		});
+		try {
+			expect(new Set(armedNames(harness))).toEqual(new Set(["bash", "powershell", "workflow"]));
+			expect(harness.agent.removedToolHints.workflow).toContain(WORKFLOW_HINT);
+
+			// When: only the workflow flag is turned off and the session reloads
+			writeSettings(harness, { experimental: { bashEvalOnly: true } });
+			await harness.session.reload();
+
+			// Then: shell tools stay withheld while workflow returns without a stale hint
+			expect(new Set(armedNames(harness))).toEqual(new Set(["bash", "powershell"]));
+			const active = harness.session.getActiveToolNames();
+			expect(active).toContain("workflow");
+			expect(active).not.toContain("bash");
+			expect(harness.agent.removedToolHints.workflow).toBeUndefined();
+			expect(harness.agent.removedToolHints.bash).toBeDefined();
+		} finally {
+			harness.cleanup();
+		}
+	});
+
+	it("retains the withheld workflow tool across a reload so a later disarm restores it", async () => {
+		// Given: an armed session whose workflow request is already filtered out
+		const harness = await createReloadHarness({ flagOn: true });
+		try {
+			expect(harness.session.getActiveToolNames()).not.toContain("workflow");
+
+			// When: the session reloads while still armed
+			await harness.session.reload();
+
+			// Then: workflow stays hidden but the unfiltered request still carries it
+			expect(harness.session.getActiveToolNames()).not.toContain("workflow");
+			const retained = (harness.session as unknown as { _requestedActiveToolNames?: string[] })
+				._requestedActiveToolNames;
+			expect(retained).toContain("workflow");
+
+			// And: a later disarm restores it
+			writeSettings(harness, {});
+			await harness.session.reload();
+			expect(harness.session.getActiveToolNames()).toContain("workflow");
 		} finally {
 			harness.cleanup();
 		}


### PR DESCRIPTION
## What
Adds `experimental.workflowEvalOnly`: when enabled and the `eval` tool is registered, the `workflow` (dag) tool leaves the model-visible tool list and runs only inside eval cells via `tool.workflow({ action: ... })`, mirroring the `experimental.bashEvalOnly` mechanism from #1192.

## How
- `settings-manager.ts`: `ExperimentalSettings.workflowEvalOnly` + `getExperimentalWorkflowEvalOnly()`.
- `agent-session.ts`: splits the eval-only policy const into a shell group (`bash`/`powershell`) and a workflow group (`workflow`); `_resolveEvalOnlyToolNames()` unions the groups whose flag is on; per-tool helper shapes (`{ command }` for shell, `{ action }` for workflow) drive the removed-tool hints and the system-prompt note, which now emits one sentence per armed group.
- Safety valve unchanged: without a registered `eval` tool the policy stays inert, so the tool is never lost.
- Flag off => byte-identical tool list and system prompt (regression-tested).

## Tests / QA
- New `test/suite/workflow-eval-only.test.ts` (hide+sentinel, registry execution with tool_call hook receipt, redirect hint, inert-without-eval, flag-off unchanged, settings-driven arming, both-flags union). RED captured before implementation (5 behavioral failures), GREEN after.
- `test/settings-manager.test.ts`: getter/merge coverage for the new flag.
- New `test/manual-qa/workflow-eval-only-qa.ts` armed|control driver; armed run hides workflow, executes it through the registry without reactivation, and returns the redirect hint on a direct model call; control run is an unchanged baseline.
- `npx vitest run test/suite/workflow-eval-only.test.ts test/suite/bash-eval-only.test.ts test/settings-manager.test.ts`: 126/126 pass. Root `npm run check`: exit 0.
- Pre-existing and unrelated: `test/suite/hooks-tool-events.test.ts` fails 5 tests identically on the clean base (5b3e0463c).

## Docs
`docs/settings.md` table row + example, `src/core/changes.md` dated entry, `CHANGELOG.md` entry — mirroring #1192's doc shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `experimental.workflowEvalOnly` to route the `workflow` (dag) tool exclusively through eval cells when enabled and the `eval` tool is registered, mirroring `experimental.bashEvalOnly`. Default is off, so existing behavior is unchanged.

**Notes**
- The policy stays inert when the `eval` tool is unavailable, so workflow access is never lost.
- The setting is independent of `experimental.bashEvalOnly`; both flags can be armed simultaneously.
- The flag re-resolves on reload, and stale hints are withdrawn when the armed set shrinks or disarms, leaving hints owned by other publishers untouched.
- Prompt guidance emits one sentence per armed group with per-tool helpers: `{ action }` for workflow, `{ command }` for shell, `{ ... }` for custom override names.

<sup>Written for commit 1160cb3615153fa597eee1b374d3501a8561a776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

