### PR TITLE
fix(rpc): launch the shared socket host from compiled binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 ### Fixed
 
+- Compiled standalone binaries can now start the shared interactive RPC host. The host launch re-enters the executable through the internal supervisor route instead of a script path, which compiled entrypoints parse as CLI arguments; previously every interactive launch stalled for the full 10s readiness budget, printed `Error: Unknown option: --socket`, and fell back to a local session.
+
 - Bash callback settlement is bounded on direct, shared-host, and harness execution paths so never-settling callbacks cannot hang commands or silently lose spill cleanup failures.
 
 - Deterministic compaction fallback now supports replay-safe Gemini opaque provider state (thoughtSignature, thinkingSignature, textSignature, and empty visible text blocks) and recovers earlier safe boundaries without breaking atomic tool-call chains ([#947](https://github.com/code-yeongyu/senpi/pull/947)).

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -78,7 +78,7 @@ Interactive launches use the shared RPC host by default when a persisted session
 
 ### Shared host lifecycle (cold start + idle exit)
 
-The lifecycle supervisor is also available to bundled/rebranded runtimes through the hidden internal launch route `--internal-rpc-host-supervisor`. This route is wire-invisible and intended only for desktop launchers: it receives the public socket, ownership directory, and the runtime command/arguments to wrap, then runs the same `host-lifecycle.ts` implementation used by `ensureHost()`. Normal CLI modes do not use or advertise this route.
+The lifecycle supervisor is also available to bundled/rebranded runtimes through the hidden internal launch route `--internal-rpc-host-supervisor`. This route is wire-invisible and intended only for desktop launchers: it receives the public socket, ownership directory, and the runtime command/arguments to wrap, then runs the same `host-lifecycle.ts` implementation used by `ensureHost()`. Normal CLI modes do not use or advertise this route. Compiled standalone binaries also re-enter themselves through this route automatically: a bun executable always boots its embedded entrypoint, so the script-path re-entry used under a JS runtime would be parsed as CLI arguments (`Unknown option: --socket`) and the host could never start.
 
 Hosts started through `ensureHost()` are wrapped by a lifecycle supervisor that owns the public socket and spawns the
 real RPC host on a private internal hop. The policy lives in `<agentDir>/rpc-host-daemon/settings.json`:

--- a/packages/coding-agent/scripts/qa-rpc-socket/compiled-host.mjs
+++ b/packages/coding-agent/scripts/qa-rpc-socket/compiled-host.mjs
@@ -47,6 +47,7 @@ async function main() {
 	let fake;
 	let tui;
 	let output = "";
+	let supervisorStopped = false;
 	try {
 		if (!binaryPath || !existsSync(binaryPath)) {
 			throw new Error(`--binary must name an existing compiled binary (got: ${binaryPath ?? "<missing>"})`);
@@ -93,6 +94,7 @@ async function main() {
 		stopTui(tui);
 		tui = undefined;
 		await stopSupervisor(paths, socketPath);
+		supervisorStopped = true;
 		transcript.push("assert supervisor-sigterm=clean pidfile-socket-removed");
 		transcript.push("PASS compiled-host");
 	} catch (error) {
@@ -106,6 +108,13 @@ async function main() {
 		process.exitCode = 1;
 	} finally {
 		if (tui) stopTui(tui);
+		// The supervisor is detached and outlives this process, so every exit path -
+		// including a failed run - must reap it or the QA leaks a live host and a
+		// bound socket into the developer's machine.
+		if (!supervisorStopped && scratch) {
+			const reaped = await reapSupervisor(createHostDaemonPaths(scratch.agentDir));
+			transcript.push(`cleanup-supervisor=${reaped}`);
+		}
 		await fake?.stop().catch(() => undefined);
 		await cleanupAllAndWait();
 		transcript.push("cleanup=tui,supervisor,sockets,scratch-removed");
@@ -211,6 +220,32 @@ async function stopSupervisor(paths, socketPath) {
 		await delay(100);
 	}
 	throw new Error(`supervisor ${pid} did not clean up within 10s (socket=${existsSync(socketPath)} pidfile=${existsSync(paths.pidFile)})`);
+}
+
+/**
+ * Best-effort teardown for a supervisor left behind by a failed run. Escalates
+ * to SIGKILL so a wedged supervisor cannot survive the QA process.
+ */
+async function reapSupervisor(paths) {
+	let pid;
+	try {
+		pid = JSON.parse(readFileSync(paths.pidFile, "utf8")).pid;
+	} catch {
+		return "none";
+	}
+	for (const signal of ["SIGTERM", "SIGKILL"]) {
+		try {
+			process.kill(pid, signal);
+		} catch {
+			return `already-gone(${pid})`;
+		}
+		const deadline = Date.now() + 5_000;
+		while (Date.now() <= deadline) {
+			if (!alive(pid)) return `${signal}(${pid})`;
+			await delay(100);
+		}
+	}
+	return `survived(${pid})`;
 }
 
 function alive(pid) {

--- a/packages/coding-agent/scripts/qa-rpc-socket/compiled-host.mjs
+++ b/packages/coding-agent/scripts/qa-rpc-socket/compiled-host.mjs
@@ -86,7 +86,7 @@ async function main() {
 			}
 		}
 		transcript.push(`assert get_protocol_info serverVersion=${info.serverVersion} capabilities=${info.capabilities.join(",")}`);
-		if (output.includes(FALLBACK_NEEDLE)) {
+		if (plainText(output).includes(FALLBACK_NEEDLE)) {
 			throw new Error(`compiled TUI fell back to a local session:\n${supervisorStderr(paths)}`);
 		}
 		transcript.push("assert fallback-warning=absent");
@@ -100,7 +100,7 @@ async function main() {
 	} catch (error) {
 		if (scratch) {
 			const paths = createHostDaemonPaths(scratch.agentDir);
-			transcript.push(`observed fallback-warning=${output.includes(FALLBACK_NEEDLE) ? "present" : "absent"}`);
+			transcript.push(`observed fallback-warning=${plainText(output).includes(FALLBACK_NEEDLE) ? "present" : "absent"}`);
 			transcript.push(`supervisor-stderr: ${supervisorStderr(paths)}`);
 		}
 		transcript.push(`pty-tail: ${plainText(output).slice(-800) || "<empty>"}`);
@@ -128,7 +128,7 @@ async function main() {
 async function waitForSharedHost(socketPath, readOutput) {
 	const deadline = Date.now() + READY_BUDGET_MS;
 	while (Date.now() <= deadline) {
-		if (readOutput().includes(FALLBACK_NEEDLE)) {
+		if (plainText(readOutput()).includes(FALLBACK_NEEDLE)) {
 			throw new Error("compiled TUI printed the shared-host fallback warning before the host became ready");
 		}
 		const info = await probeProtocolInfo(socketPath);

--- a/packages/coding-agent/scripts/qa-rpc-socket/compiled-host.mjs
+++ b/packages/coding-agent/scripts/qa-rpc-socket/compiled-host.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Real-binary QA for the shared interactive host under a bun-compiled
+ * standalone executable (`npm run build:binary` -> dist/pi).
+ *
+ * A compiled binary cannot re-enter itself through a script path: bun
+ * standalone executables always boot their embedded entrypoint, so a
+ * `host-lifecycle.ts --socket <path>` argv is parsed as CLI arguments and the
+ * spawned host dies with "Unknown option: --socket" before it ever answers
+ * `get_protocol_info`. This driver proves the full compiled chain end to end:
+ *
+ *   compiled TUI (pty) -> ensureHost() -> `--internal-rpc-host-supervisor`
+ *     -> supervisor -> compiled `--mode rpc --multi-session --listen` host
+ *
+ * PASS: the public socket answers get_protocol_info with the running VERSION
+ * and the required capabilities while the compiled TUI is attached, and the
+ * pty transcript never shows the shared-host fallback warning.
+ * FAIL: the fallback warning appears (the supervisor stderr log is captured
+ * into the transcript for diagnosis) or the socket never answers.
+ *
+ * Usage: compiled-host.mjs --binary <path-to-compiled-binary> [--out <file>]
+ */
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { createConnection } from "node:net";
+import { join, resolve } from "node:path";
+import { createHostDaemonPaths } from "../../src/modes/rpc/host-ensure.ts";
+import {
+	cleanupAllAndWait,
+	installCleanupHooks,
+	makeScratch,
+	startFakeModelServer,
+	writeMockModelsJson,
+} from "../qa-app-server/lib/env.mjs";
+import { trackChild } from "../qa-app-server/lib/cleanup.mjs";
+
+const FALLBACK_NEEDLE = "shared interactive host unavailable";
+const READY_BUDGET_MS = 30_000;
+
+const transcript = [];
+const binaryPath = flag("--binary") === undefined ? undefined : resolve(flag("--binary"));
+const outPath = flag("--out");
+installCleanupHooks();
+
+async function main() {
+	let scratch;
+	let fake;
+	let tui;
+	let output = "";
+	try {
+		if (!binaryPath || !existsSync(binaryPath)) {
+			throw new Error(`--binary must name an existing compiled binary (got: ${binaryPath ?? "<missing>"})`);
+		}
+		scratch = makeScratch("cbin");
+		fake = await startFakeModelServer([{ text: "compiled-host-qa" }]);
+		writeMockModelsJson(scratch.agentDir, fake);
+		const socketPath = join(scratch.dir, "rpc.sock");
+		const paths = createHostDaemonPaths(scratch.agentDir);
+
+		// `expect` allocates a real pty so the compiled binary resolves the
+		// interactive app mode exactly as a terminal launch does (stdin and
+		// stdout are both TTYs inside the spawned session).
+		tui = spawn("expect", ["-c", "set timeout -1; spawn -noecho $env(COMPILED_HOST_QA_BINARY); expect eof"], {
+			cwd: scratch.cwd,
+			env: {
+				...scrubBrandEnv(scratch.env),
+				COMPILED_HOST_QA_BINARY: binaryPath,
+				SENPI_RPC_SOCKET: socketPath,
+				TERM: "xterm-256color",
+			},
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		trackChild(tui);
+		tui.stdout.on("data", (chunk) => (output += chunk.toString("utf8")));
+		tui.stderr.on("data", (chunk) => (output += chunk.toString("utf8")));
+		transcript.push(`spawn compiled-tui pid=${tui.pid} binary=${binaryPath}`);
+
+		const info = await waitForSharedHost(socketPath, () => output);
+		if (typeof info.serverVersion !== "string" || info.serverVersion.length === 0) {
+			throw new Error(`shared host served no version: ${JSON.stringify(info)}`);
+		}
+		for (const capability of ["multi_session", "extension_events"]) {
+			if (!info.capabilities.includes(capability)) {
+				throw new Error(`shared host is missing capability ${capability}: ${JSON.stringify(info)}`);
+			}
+		}
+		transcript.push(`assert get_protocol_info serverVersion=${info.serverVersion} capabilities=${info.capabilities.join(",")}`);
+		if (output.includes(FALLBACK_NEEDLE)) {
+			throw new Error(`compiled TUI fell back to a local session:\n${supervisorStderr(paths)}`);
+		}
+		transcript.push("assert fallback-warning=absent");
+
+		stopTui(tui);
+		tui = undefined;
+		await stopSupervisor(paths, socketPath);
+		transcript.push("assert supervisor-sigterm=clean pidfile-socket-removed");
+		transcript.push("PASS compiled-host");
+	} catch (error) {
+		if (scratch) {
+			const paths = createHostDaemonPaths(scratch.agentDir);
+			transcript.push(`observed fallback-warning=${output.includes(FALLBACK_NEEDLE) ? "present" : "absent"}`);
+			transcript.push(`supervisor-stderr: ${supervisorStderr(paths)}`);
+		}
+		transcript.push(`pty-tail: ${plainText(output).slice(-800) || "<empty>"}`);
+		transcript.push(`FAIL compiled-host: ${error instanceof Error ? error.stack : String(error)}`);
+		process.exitCode = 1;
+	} finally {
+		if (tui) stopTui(tui);
+		await fake?.stop().catch(() => undefined);
+		await cleanupAllAndWait();
+		transcript.push("cleanup=tui,supervisor,sockets,scratch-removed");
+		if (outPath) writeFileSync(outPath, `${transcript.join("\n")}\n`);
+		process.stdout.write(`${transcript.join("\n")}\n`);
+		process.exit(process.exitCode ?? 0);
+	}
+}
+
+/** Polls the public socket until the shared host answers; fails fast when the TUI prints the fallback warning. */
+async function waitForSharedHost(socketPath, readOutput) {
+	const deadline = Date.now() + READY_BUDGET_MS;
+	while (Date.now() <= deadline) {
+		if (readOutput().includes(FALLBACK_NEEDLE)) {
+			throw new Error("compiled TUI printed the shared-host fallback warning before the host became ready");
+		}
+		const info = await probeProtocolInfo(socketPath);
+		if (info) return info;
+		await delay(200);
+	}
+	throw new Error(`shared host socket never answered get_protocol_info within ${READY_BUDGET_MS}ms`);
+}
+
+function probeProtocolInfo(socketPath) {
+	return new Promise((resolve) => {
+		const socket = createConnection(socketPath);
+		let buffer = "";
+		let settled = false;
+		const finish = (value) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			socket.destroy();
+			resolve(value);
+		};
+		const timer = setTimeout(() => finish(undefined), 500);
+		socket.once("connect", () => socket.write('{"id":"compiled-host-qa","type":"get_protocol_info"}\n'));
+		socket.on("data", (chunk) => {
+			buffer += chunk.toString("utf8");
+			const newline = buffer.indexOf("\n");
+			if (newline === -1) return;
+			try {
+				const parsed = JSON.parse(buffer.slice(0, newline));
+				finish(parsed?.success === true ? parsed.data : undefined);
+			} catch {
+				finish(undefined);
+			}
+		});
+		socket.once("error", () => finish(undefined));
+		socket.once("close", () => finish(undefined));
+	});
+}
+
+/**
+ * The compiled binary under test must resolve its own brand, package root, and
+ * runtime; identity inherited from a branded operator shell (omo and friends)
+ * would silently redirect resource and version lookups away from the binary.
+ */
+function scrubBrandEnv(env) {
+	const scrubbed = { ...env };
+	for (const key of Object.keys(scrubbed)) {
+		if (key.startsWith("OMO_")) delete scrubbed[key];
+	}
+	delete scrubbed.SENPI_PACKAGE_DIR;
+	delete scrubbed.SENPI_RUNTIME;
+	return scrubbed;
+}
+
+function plainText(raw) {
+	return raw
+		.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "")
+		.replace(/\x1b\][^\x07]*(\x07|\x1b\\)/g, "")
+		.replace(/\r/g, "");
+}
+
+function supervisorStderr(paths) {
+	try {
+		return readFileSync(paths.stderrLog, "utf8").trim() || "<empty>";
+	} catch {
+		return "<missing>";
+	}
+}
+
+function stopTui(child) {
+	try {
+		child.kill("SIGTERM");
+	} catch {}
+}
+
+async function stopSupervisor(paths, socketPath) {
+	let pid;
+	try {
+		pid = JSON.parse(readFileSync(paths.pidFile, "utf8")).pid;
+	} catch {
+		throw new Error("supervisor pidfile missing after successful attach");
+	}
+	try {
+		process.kill(pid, "SIGTERM");
+	} catch {}
+	const deadline = Date.now() + 10_000;
+	while (Date.now() <= deadline) {
+		if (!alive(pid) && !existsSync(socketPath) && !existsSync(paths.pidFile)) return;
+		await delay(100);
+	}
+	throw new Error(`supervisor ${pid} did not clean up within 10s (socket=${existsSync(socketPath)} pidfile=${existsSync(paths.pidFile)})`);
+}
+
+function alive(pid) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function flag(name) {
+	const index = process.argv.indexOf(name);
+	return index === -1 ? undefined : process.argv[index + 1];
+}
+
+await main();

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-30 - Dispatch the internal RPC host route through wrapper-injected argv
+
+### What changed
+
+- `packages/coding-agent/src/main.ts` matches the hidden `--internal-rpc-host-supervisor` route through `findInternalSupervisorArgs()` instead of a strict `args[0]` comparison, and still fails closed with `exit(2)` when the payload does not parse.
+
+### Why
+
+- A rebranded wrapper re-dispatches this binary through its own entry and prepends `--extension <dir>` for every non-early command, which pushed the sentinel off `args[0]`. The internal route then never fired and the spawned helper died on `--socket`, so compiled wrapper builds could never start the shared host.
+
+### Why an extension could not handle it
+
+- The dispatch happens in the CLI entry before argument parsing and before any extension host exists, so no extension hook can observe or rewrite it.
+
+### Expected merge conflict zones
+
+- LOW: the internal-route dispatch block near the top of `main()`.
+
+
 ## Measure Cursor tool-result history at the wire representation (2026-08-29)
 
 ### What changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -81,7 +81,7 @@ import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
 import { createInteractiveHostRuntime } from "./modes/interactive/interactive-host-runtime.ts";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.ts";
 import { runPrintMode } from "./modes/print-mode.ts";
-import { parseSupervisorArgs, runHostSupervisor } from "./modes/rpc/host-lifecycle.ts";
+import { findInternalSupervisorArgs, parseSupervisorArgs, runHostSupervisor } from "./modes/rpc/host-lifecycle.ts";
 import { runMultiSessionHost } from "./modes/rpc/multi-session-host.ts";
 import { runRpcMode } from "./modes/rpc/rpc-mode.ts";
 import { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
@@ -694,10 +694,15 @@ export async function main(args: string[], options?: MainOptions) {
 	}
 
 	// Internal launch surface used by bundled/rebranded runtimes. It is deliberately
-	// not accepted by parseArgs, so existing CLI modes remain unchanged.
-	if (args[0] === "--internal-rpc-host-supervisor") {
-		const launch = parseSupervisorArgs(args.slice(1));
+	// not accepted by parseArgs, so existing CLI modes remain unchanged. A rebranded
+	// wrapper may prepend its own `--extension <dir>` before forwarding argv, so the
+	// route is matched through the bounded scan rather than at argv[0] alone.
+	const supervisorArgs = findInternalSupervisorArgs(args);
+	if (supervisorArgs) {
+		const launch = parseSupervisorArgs(supervisorArgs);
 		if (!launch) {
+			// Fail closed: an internal protocol fault must never fall through to the
+			// public parser and surface as a confusing "Unknown option" error.
 			console.error("invalid internal RPC host supervisor arguments");
 			process.exit(2);
 		}

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -31,6 +31,27 @@
 - Routed/shared-host behavior is unchanged: those connections still receive the broadcast.
 
 
+
+## 2026-08-30 - Launch the shared RPC socket host correctly from compiled binaries
+
+### What changed
+
+- `host-ensure.ts`: `defaultHostLaunch()` (now exported for tests) re-enters a compiled standalone binary through the hidden `--internal-rpc-host-supervisor` route instead of a `host-lifecycle` script path. A bun executable always boots its embedded entrypoint, so the script path was parsed as CLI arguments and the spawned supervisor died with `Unknown option: --socket`; every interactive launch then burned the full 10s readiness budget before printing the shared-host fallback warning.
+- `host-lifecycle.ts`: the supervisor's default host spawn moved into the exported `resolveHostChildLaunch()`. In compiled binaries it drops `resolveCliMainPath()` and passes `--mode rpc --multi-session --listen` directly to the executable; explicit `--child-command` launches (desktop) are unchanged.
+- QA: `scripts/qa-rpc-socket/compiled-host.mjs` drives the real `build:binary` output through a pty and asserts the shared host answers `get_protocol_info` without the fallback warning, tearing the supervisor down afterwards.
+
+### Why
+
+- No compiled distribution (release binaries, bundled/rebranded runtimes) could ever start the shared interactive host: the script-path re-entry only works when `process.execPath` is a JS runtime. Both spawn levels (ensure -> supervisor, supervisor -> host) had the same defect.
+
+### Why an extension could not handle it
+
+- The spawn shapes are core host-lifecycle wiring inside `ensureHost()` and the supervisor; no extension hook runs before the shared host is ensured, so an extension cannot intercept or rewrite the default launch.
+
+### Expected merge conflict zones
+
+- LOW: `defaultHostLaunch` in `host-ensure.ts` and the child spawn in `runHostSupervisor`.
+
 ## 2026-08-30 - Reschedule the sink actor drain when an enqueue races its settling
 
 - `socket-event-fanout.ts`: `SocketEventSinkActor.drain()` clears `draining` in a `.finally()` reaction. An `enqueue()` landing between the drain loop's exit and that reaction received the stale settled promise and started no new drain, leaving the record queued until the next unrelated enqueue rescued it — observed as targeted `open_session` responses reaching the client seconds late or not at all (`W-route` logged, `socket.write` never called). The `.finally()` now reschedules `drain()` when the queue is non-empty, so a racing record flushes immediately. Deterministic reproduction: `test/socket-event-fanout.test.ts`.

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -38,7 +38,9 @@
 
 - `host-ensure.ts`: `defaultHostLaunch()` (now exported for tests) re-enters a compiled standalone binary through the hidden `--internal-rpc-host-supervisor` route instead of a `host-lifecycle` script path. A bun executable always boots its embedded entrypoint, so the script path was parsed as CLI arguments and the spawned supervisor died with `Unknown option: --socket`; every interactive launch then burned the full 10s readiness budget before printing the shared-host fallback warning.
 - `host-lifecycle.ts`: the supervisor's default host spawn moved into the exported `resolveHostChildLaunch()`. In compiled binaries it drops `resolveCliMainPath()` and passes `--mode rpc --multi-session --listen` directly to the executable; explicit `--child-command` launches (desktop) are unchanged.
-- QA: `scripts/qa-rpc-socket/compiled-host.mjs` drives the real `build:binary` output through a pty and asserts the shared host answers `get_protocol_info` without the fallback warning, tearing the supervisor down afterwards.
+- `host-lifecycle.ts`: the internal launch route is now matched by the exported `findInternalSupervisorArgs()` bounded scan instead of a strict `args[0]` test in `main.ts`. A rebranded wrapper may prepend engine-global flags before re-dispatching (`packages/omo-native` injects `--extension <dir>` for every non-early command), which pushed the sentinel off `args[0]` so the route never fired and the helper died on `--socket` anyway. The scan accepts the sentinel at `args[0]` or preceded only by allowlisted `--extension <value>` pairs; a positional operand, `--`, an unknown flag, or a dangling prefix all disqualify it, so a user-supplied value equal to the sentinel can never reach the supervisor. The skipped prefix is not forwarded, because the wrapper re-injects its own on every re-entry.
+- `main.ts`: dispatches through that scan and still fails closed (`exit(2)`) on a malformed payload rather than falling through to the public parser.
+- QA: `scripts/qa-rpc-socket/compiled-host.mjs` drives the real `build:binary` output through a pty and asserts the shared host answers `get_protocol_info` without the fallback warning, reaping the detached supervisor on every exit path (SIGTERM then SIGKILL) so a failed run cannot leak a live host and a bound socket.
 
 ### Why
 
@@ -50,7 +52,7 @@
 
 ### Expected merge conflict zones
 
-- LOW: `defaultHostLaunch` in `host-ensure.ts` and the child spawn in `runHostSupervisor`.
+- LOW: `defaultHostLaunch` in `host-ensure.ts`, the child spawn in `runHostSupervisor`, and the internal-route dispatch block in `main.ts`.
 
 ## 2026-08-30 - Reschedule the sink actor drain when an enqueue races its settling
 

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -18,7 +18,12 @@ import {
 	EXTENSION_EVENTS_CAPABILITY,
 	RPC_CLIENT_CAPABILITIES_ENV,
 } from "./custom-capability.ts";
-import { DEFAULT_HOST_IDLE_EXIT_MS, type HostColdStart, type HostLifecyclePolicyInput } from "./host-lifecycle.ts";
+import {
+	DEFAULT_HOST_IDLE_EXIT_MS,
+	type HostColdStart,
+	type HostLifecyclePolicyInput,
+	INTERNAL_SUPERVISOR_FLAG,
+} from "./host-lifecycle.ts";
 
 export type { HostColdStart, HostLifecyclePolicyInput };
 
@@ -321,7 +326,7 @@ export function defaultHostLaunch(
 	if (compiled) {
 		return {
 			command: process.execPath,
-			args: ["--internal-rpc-host-supervisor", "--socket", socket, ...hostArgs],
+			args: [INTERNAL_SUPERVISOR_FLAG, "--socket", socket, ...hostArgs],
 		};
 	}
 	return {

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as properLockfile from "proper-lockfile";
-import { ENV_AGENT_DIR, getAgentDir, VERSION } from "../../config.ts";
+import { ENV_AGENT_DIR, getAgentDir, isBunBinary, VERSION } from "../../config.ts";
 import {
 	type DaemonPidFile,
 	parseDaemonPidFile,
@@ -301,14 +301,29 @@ function normalizeSocketPath(value: string): string {
  * Default launch: the host-lifecycle supervisor owns the public socket and the
  * idle-exit policy; it spawns the committed RPC socket host itself. Any extra
  * hostArgs are forwarded verbatim to the host CLI (e.g. provider pinning).
+ *
+ * A compiled standalone binary cannot re-enter itself through a script path:
+ * bun executables always boot their embedded entrypoint and parse the whole
+ * argv as CLI arguments, so `host-lifecycle.ts --socket <path>` dies with
+ * "Unknown option: --socket" before the host ever answers get_protocol_info.
+ * Compiled binaries therefore re-enter through the hidden
+ * `--internal-rpc-host-supervisor` route that main() dispatches before
+ * argument parsing. Exported for tests.
  */
-function defaultHostLaunch(
+export function defaultHostLaunch(
 	socket: string,
 	hostArgs: readonly string[],
+	compiled: boolean = isBunBinary,
 ): {
 	command: string;
 	args: string[];
 } {
+	if (compiled) {
+		return {
+			command: process.execPath,
+			args: ["--internal-rpc-host-supervisor", "--socket", socket, ...hostArgs],
+		};
+	}
 	return {
 		command: process.execPath,
 		args: [...process.execArgv, resolveHostLifecycleEntryPath(), "--socket", socket, ...hostArgs],

--- a/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
+++ b/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
@@ -45,7 +45,7 @@ import { createConnection, createServer, type Server, type Socket } from "node:n
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { getAgentDir } from "../../config.ts";
+import { getAgentDir, isBunBinary } from "../../config.ts";
 import { createHostDaemonPaths } from "./host-ensure.ts";
 import {
 	HOST_CLEANUP_PATHS_ENV,
@@ -215,6 +215,39 @@ export function resolveCliMainPath(): string {
 	return resolve(dirname(modulePath), "..", "..", `cli-main${extension}`);
 }
 
+/**
+ * Resolves the host child spawn. Explicit child commands (desktop launchers)
+ * are forwarded untouched. The default re-enters the committed CLI entry
+ * through the runtime, except in compiled standalone binaries, which always
+ * boot their embedded entrypoint and would parse a script path as CLI
+ * arguments - there the executable itself is the CLI, so the mode flags are
+ * passed directly. Exported for tests.
+ */
+export function resolveHostChildLaunch(
+	launch: SupervisorLaunch,
+	internalSocket: string,
+	compiled: boolean = isBunBinary,
+): { command: string; args: string[] } {
+	if (launch.childCommand) {
+		return {
+			command: launch.childCommand,
+			args: [...(launch.childArgs ?? []), "--listen", `unix://${internalSocket}`],
+		};
+	}
+	return {
+		command: process.execPath,
+		args: [
+			...(compiled ? [] : [...process.execArgv, resolveCliMainPath()]),
+			"--mode",
+			"rpc",
+			"--multi-session",
+			"--listen",
+			`unix://${internalSocket}`,
+			...launch.hostArgs,
+		],
+	};
+}
+
 export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void> {
 	const paths = createHostDaemonPaths(launch.agentDir ?? getAgentDir());
 	const policy = resolveHostPolicy(await readSettingsFile(paths.settingsFile), process.env);
@@ -228,34 +261,20 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 	let shuttingDown = false;
 	let shutdownPromise: Promise<never> | undefined;
 
-	const child = spawn(
-		launch.childCommand ?? process.execPath,
-		launch.childCommand
-			? [...(launch.childArgs ?? []), "--listen", `unix://${internalSocket}`]
-			: [
-					...process.execArgv,
-					resolveCliMainPath(),
-					"--mode",
-					"rpc",
-					"--multi-session",
-					"--listen",
-					`unix://${internalSocket}`,
-					...launch.hostArgs,
-				],
-		{
-			env: {
-				...process.env,
-				...(launch.agentDir ? { SENPI_CODING_AGENT_DIR: launch.agentDir } : {}),
-				[HOST_WATCH_FD_ENV]: String(CHILD_WATCH_FD),
-				[HOST_WATCH_PPID_ENV]: String(process.pid),
-				[HOST_SCRATCH_DIR_ENV]: internal.dir,
-				[HOST_CLEANUP_PATHS_ENV]: [publicSocket, paths.pidFile, paths.settingsFile].join("\n"),
-			},
-			// Slot 3 is the lifetime pipe: "pipe" gives the child a read end it can
-			// wait on and keeps the write end owned by this process alone.
-			stdio: ["ignore", "ignore", "inherit", "pipe"],
+	const childLaunch = resolveHostChildLaunch(launch, internalSocket);
+	const child = spawn(childLaunch.command, childLaunch.args, {
+		env: {
+			...process.env,
+			...(launch.agentDir ? { SENPI_CODING_AGENT_DIR: launch.agentDir } : {}),
+			[HOST_WATCH_FD_ENV]: String(CHILD_WATCH_FD),
+			[HOST_WATCH_PPID_ENV]: String(process.pid),
+			[HOST_SCRATCH_DIR_ENV]: internal.dir,
+			[HOST_CLEANUP_PATHS_ENV]: [publicSocket, paths.pidFile, paths.settingsFile].join("\n"),
 		},
-	);
+		// Slot 3 is the lifetime pipe: "pipe" gives the child a read end it can
+		// wait on and keeps the write end owned by this process alone.
+		stdio: ["ignore", "ignore", "inherit", "pipe"],
+	});
 	// Nothing is ever written; the pipe exists purely so its EOF is a reliable
 	// death notification. Errors on it must not crash the supervisor.
 	child.stdio[CHILD_WATCH_FD]?.on("error", () => {});

--- a/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
+++ b/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
@@ -173,6 +173,41 @@ export interface SupervisorLaunch {
 	readonly agentDir?: string;
 }
 
+/** Hidden internal launch route: wire-invisible, never advertised by the public CLI surface. */
+export const INTERNAL_SUPERVISOR_FLAG = "--internal-rpc-host-supervisor";
+
+/**
+ * Engine-global flags a rebranded wrapper may legitimately prepend when it
+ * re-dispatches this binary. `packages/omo-native` injects `--extension <dir>`
+ * for every non-early command, which pushed the sentinel off argv[0].
+ */
+const INJECTABLE_PREFIX_FLAGS = new Set(["--extension"]);
+
+/**
+ * Returns the internal supervisor payload when argv selects that route.
+ *
+ * The route dispatches when the sentinel is argv[0] OR is preceded only by
+ * known injectable prefix flags and their values - the one perturbation
+ * wrappers legitimately perform. Everything else disqualifies it: a positional
+ * operand, `--`, or an unknown flag before the sentinel all return undefined,
+ * so a user-supplied value that happens to equal the sentinel can never reach
+ * the supervisor.
+ *
+ * The skipped prefix is deliberately NOT forwarded to the host: a wrapper
+ * re-injects its own prefix on every re-entry, so the host child receives it
+ * from the wrapper rather than twice from here.
+ */
+export function findInternalSupervisorArgs(argv: readonly string[]): readonly string[] | undefined {
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		if (arg === INTERNAL_SUPERVISOR_FLAG) return argv.slice(index + 1);
+		// A prefix flag only counts when its value is actually present.
+		if (!INJECTABLE_PREFIX_FLAGS.has(arg) || index + 1 >= argv.length) return undefined;
+		index++;
+	}
+	return undefined;
+}
+
 /** `--socket <path>` selects the public socket; every other argument is forwarded to the host CLI. */
 export function parseSupervisorArgs(argv: readonly string[]): SupervisorLaunch | undefined {
 	const hostArgs: string[] = [];

--- a/packages/coding-agent/test/rpc-host-ensure.test.ts
+++ b/packages/coding-agent/test/rpc-host-ensure.test.ts
@@ -10,7 +10,7 @@ import {
 	readProcessStartTime,
 	waitForStartTime,
 } from "../src/modes/app-server/daemon/process.ts";
-import { createHostDaemonPaths, ensureHost } from "../src/modes/rpc/host-ensure.ts";
+import { createHostDaemonPaths, defaultHostLaunch, ensureHost } from "../src/modes/rpc/host-ensure.ts";
 
 const roots: string[] = [];
 const children: ChildProcess[] = [];
@@ -141,6 +141,23 @@ describe("ensureHost", () => {
 		await expect(access(paths.pidFile)).rejects.toMatchObject({ code: "ENOENT" });
 		await expect(access(qa.socket)).rejects.toMatchObject({ code: "ENOENT" });
 	}, 10_000);
+});
+
+describe("defaultHostLaunch", () => {
+	it("re-enters through the internal supervisor route in compiled binaries", () => {
+		expect(defaultHostLaunch("/tmp/qa.sock", ["--provider", "mock"], true)).toEqual({
+			command: process.execPath,
+			args: ["--internal-rpc-host-supervisor", "--socket", "/tmp/qa.sock", "--provider", "mock"],
+		});
+	});
+
+	it("re-enters through the host-lifecycle script outside compiled binaries", () => {
+		const launch = defaultHostLaunch("/tmp/qa.sock", ["--provider", "mock"], false);
+		expect(launch.command).toBe(process.execPath);
+		const args = launch.args.slice(process.execArgv.length);
+		expect(args[0]).toMatch(/host-lifecycle\.(ts|js)$/);
+		expect(args.slice(1)).toEqual(["--socket", "/tmp/qa.sock", "--provider", "mock"]);
+	});
 });
 
 type Qa = { root: string; agentDir: string; socket: string };

--- a/packages/coding-agent/test/rpc-host-lifecycle.test.ts
+++ b/packages/coding-agent/test/rpc-host-lifecycle.test.ts
@@ -21,9 +21,11 @@ import { processMatchesPidFile, readProcessStartTime } from "../src/modes/app-se
 import { createHostDaemonPaths, ensureHost, type HostLifecyclePolicyInput } from "../src/modes/rpc/host-ensure.ts";
 import {
 	DEFAULT_HOST_IDLE_EXIT_MS,
+	findInternalSupervisorArgs,
 	HOST_COLD_START_ENV,
 	HOST_IDLE_EXIT_MS_ENV,
 	IdleExitDecider,
+	INTERNAL_SUPERVISOR_FLAG,
 	resolveHostChildLaunch,
 	resolveHostPolicy,
 } from "../src/modes/rpc/host-lifecycle.ts";
@@ -339,6 +341,51 @@ describe("host watchdog configuration", () => {
 		expect(await reason).toContain("closed");
 		expect(existsSync(scratchDir)).toBe(false);
 	}, 15_000);
+});
+
+describe("findInternalSupervisorArgs", () => {
+	it("dispatches when the sentinel leads argv", () => {
+		expect(findInternalSupervisorArgs([INTERNAL_SUPERVISOR_FLAG, "--socket", "/tmp/qa.sock"])).toEqual([
+			"--socket",
+			"/tmp/qa.sock",
+		]);
+	});
+
+	it("dispatches through a rebranded wrapper's injected --extension prefix", () => {
+		// packages/omo-native prepends this pair to every non-early command, which
+		// is exactly the argv shape that used to miss the route entirely.
+		expect(
+			findInternalSupervisorArgs([
+				"--extension",
+				"/opt/branded/plugin",
+				INTERNAL_SUPERVISOR_FLAG,
+				"--socket",
+				"/tmp/qa.sock",
+			]),
+		).toEqual(["--socket", "/tmp/qa.sock"]);
+	});
+
+	it("refuses a sentinel that follows a positional operand", () => {
+		expect(
+			findInternalSupervisorArgs(["explain this", INTERNAL_SUPERVISOR_FLAG, "--socket", "/tmp/x"]),
+		).toBeUndefined();
+	});
+
+	it("refuses a sentinel escaped behind --", () => {
+		expect(findInternalSupervisorArgs(["--", INTERNAL_SUPERVISOR_FLAG, "--socket", "/tmp/x"])).toBeUndefined();
+	});
+
+	it("refuses a sentinel behind an unknown flag", () => {
+		expect(findInternalSupervisorArgs(["--print", INTERNAL_SUPERVISOR_FLAG])).toBeUndefined();
+	});
+
+	it("refuses a dangling prefix flag with no value", () => {
+		expect(findInternalSupervisorArgs(["--extension"])).toBeUndefined();
+	});
+
+	it("returns undefined when the sentinel is absent", () => {
+		expect(findInternalSupervisorArgs(["--mode", "rpc"])).toBeUndefined();
+	});
 });
 
 describe("resolveHostChildLaunch", () => {

--- a/packages/coding-agent/test/rpc-host-lifecycle.test.ts
+++ b/packages/coding-agent/test/rpc-host-lifecycle.test.ts
@@ -24,6 +24,7 @@ import {
 	HOST_COLD_START_ENV,
 	HOST_IDLE_EXIT_MS_ENV,
 	IdleExitDecider,
+	resolveHostChildLaunch,
 	resolveHostPolicy,
 } from "../src/modes/rpc/host-lifecycle.ts";
 import {
@@ -338,6 +339,41 @@ describe("host watchdog configuration", () => {
 		expect(await reason).toContain("closed");
 		expect(existsSync(scratchDir)).toBe(false);
 	}, 15_000);
+});
+
+describe("resolveHostChildLaunch", () => {
+	const baseLaunch = { socket: "/tmp/qa-public.sock", hostArgs: ["--provider", "mock"] } as const;
+
+	it("forwards explicit child commands untouched", () => {
+		const launch = { ...baseLaunch, childCommand: "/opt/branded/omo", childArgs: ["--mode", "rpc"] };
+		expect(resolveHostChildLaunch(launch, "/tmp/internal.sock", true)).toEqual({
+			command: "/opt/branded/omo",
+			args: ["--mode", "rpc", "--listen", "unix:///tmp/internal.sock"],
+		});
+	});
+
+	it("passes the mode flags directly to the executable in compiled binaries", () => {
+		expect(resolveHostChildLaunch(baseLaunch, "/tmp/internal.sock", true)).toEqual({
+			command: process.execPath,
+			args: ["--mode", "rpc", "--multi-session", "--listen", "unix:///tmp/internal.sock", "--provider", "mock"],
+		});
+	});
+
+	it("re-enters the committed CLI entry outside compiled binaries", () => {
+		const launch = resolveHostChildLaunch(baseLaunch, "/tmp/internal.sock", false);
+		expect(launch.command).toBe(process.execPath);
+		const args = launch.args.slice(process.execArgv.length);
+		expect(args[0]).toMatch(/cli-main\.(ts|js)$/);
+		expect(args.slice(1)).toEqual([
+			"--mode",
+			"rpc",
+			"--multi-session",
+			"--listen",
+			"unix:///tmp/internal.sock",
+			"--provider",
+			"mock",
+		]);
+	});
 });
 
 function scratch(label: string): Scratch {


### PR DESCRIPTION
## Problem

Every compiled standalone distribution (release `pi` binaries, bundled/rebranded runtimes such as omo) fails to start the shared interactive RPC host. Each interactive launch stalls for the full 10s readiness budget and then falls back to a local session:

```
Warning: shared interactive host unavailable; continuing locally: spawned RPC socket host did not answer get_protocol_info within 10000ms
Error: Unknown option: --socket
```

## Root cause

Both host spawn levels re-enter `process.execPath` with a **script path**:

- `host-ensure.ts` `defaultHostLaunch()`: `[...execArgv, <host-lifecycle entry>, --socket, ...]`
- `host-lifecycle.ts` `runHostSupervisor()` default child: `[...execArgv, <cli-main entry>, --mode, rpc, ...]`

That shape only works when `process.execPath` is a JS runtime (`bun`/`node`). A bun-compiled executable always boots its embedded entrypoint and parses the whole argv as CLI arguments, so the supervisor child dies instantly with `Unknown option: --socket` (`cli/args.ts`) and `ensureHost()` polls a socket that will never answer.

## Fix

Gated on the existing `isBunBinary` detection (`config.ts`):

- Level 1 (`defaultHostLaunch`, exported for tests): compiled binaries re-enter through the existing hidden `--internal-rpc-host-supervisor` route that `main()` dispatches before argument parsing.
- Level 2 (new exported `resolveHostChildLaunch`): the supervisor's default host spawn drops the script path and passes `--mode rpc --multi-session --listen unix://<internal>` directly to the executable. Explicit `--child-command` launches (desktop lane) are unchanged.

Non-compiled launches keep the exact previous shapes.

## QA evidence (real compiled binary, both captured with `scripts/qa-rpc-socket/compiled-host.mjs`)

The new QA driver builds on the packaged QA harness: it runs the real `npm run build:binary` output (`dist/pi`) in a pty with an isolated agent dir, an isolated `SENPI_RPC_SOCKET`, and mock models, then probes the public socket.

- RED (pre-fix tree): driver fails — fallback warning present, supervisor stderr `Error: Unknown option: --socket`.
- GREEN (this branch): driver passes — `get_protocol_info` answers with the running version and `multi_session,extension_events`; no fallback warning; supervisor SIGTERM teardown leaves no pidfile/socket.

## Tests

- `test/rpc-host-ensure.test.ts`: `defaultHostLaunch` pins for the compiled (sentinel route) and non-compiled (host-lifecycle script) shapes.
- `test/rpc-host-lifecycle.test.ts`: `resolveHostChildLaunch` pins for the childCommand override, compiled direct-mode args, and non-compiled cli-main re-entry.
- Existing rpc host suites (`rpc-host-ensure`, `rpc-host-lifecycle`, `interactive-host-runtime`, `rpc-classic-compat`, `rpc-multi-session`) green in one run.

Note: `rpc-host-lifecycle.test.ts` e2e scenarios fail identically on the unmodified base tree when the invoking shell carries a branded `SENPI_PACKAGE_DIR` (host resolves themes from the wrong package root). That leak is pre-existing and environment-specific; runs with a clean environment are green before and after this change.

## Trackers

- `src/modes/rpc/changes.md` entry with all four canonical sections.
- `packages/coding-agent/CHANGELOG.md` `[Unreleased]` > Fixed entry.
- `docs/rpc.md` documents the compiled-binary re-entry through the internal route.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shared RPC host startup from compiled standalone binaries and rebranded wrappers. A bun-compiled executable boots its embedded entrypoint, so the script-path re-entry used by JS runtimes was parsed as CLI arguments: the supervisor died with `Error: Unknown option: --socket` and every interactive launch stalled the full 10s readiness budget before falling back to a local session.

**Bug Fixes**
- Compiled binaries now re-enter through the hidden `--internal-rpc-host-supervisor` route; non-compiled launches keep their previous shape.
- The supervisor's default host spawn passes `--mode rpc --multi-session --listen` directly to the compiled executable; explicit `--child-command` launches are unchanged.
- The route is now matched by a bounded scan that tolerates the `--extension <dir>` prefix injected by rebranded wrappers, so they no longer miss it and die on `--socket`; user-supplied values equal to the sentinel still never reach the supervisor.
- Added `scripts/qa-rpc-socket/compiled-host.mjs`, which drives the real `build:binary` output, asserts the host answers `get_protocol_info` without the fallback warning, and reaps the detached supervisor on every exit path.
- Recorded the route change in `src/changes.md` so the changelog gate reports coverage for `main.ts`.

<sup>Written for commit c9db48c0d684a7b65619e3d22b91f495ccd9e4e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

