### PR TITLE
fix(rpc): fail fast and report honestly when host cannot become ready

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Fixed shared RPC socket host startup to fail fast when the spawned host exits before answering `get_protocol_info`, instead of silently consuming the full 10-second readiness budget, and made readiness diagnostics honest: an early exit reports the child's exit code, an incompatible host reports its advertised server version and capabilities against the expected values, and a host that never answered keeps the existing timeout message.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -51,7 +51,25 @@
   `replacementIssuedHere` for the duration of that rebind only.
 - Routed/shared-host behavior is unchanged: those connections still receive the broadcast.
 
+## 2026-08-30 - Fail fast and report honest spawned-host readiness diagnostics
 
+### What changed
+
+- `host-ensure.ts` observes the spawned host's exit event during readiness polling and aborts immediately when the child exits before answering `get_protocol_info`.
+- Readiness retains the last valid protocol answer so incompatible hosts report their advertised server version and capabilities alongside the expected values, while never-answered hosts retain the existing timeout message.
+- Added coverage for early child exit and answered-but-incompatible protocol information.
+
+### Why
+
+- A host that exits before binding can never become ready, but previously consumed the full 10-second readiness budget. An incompatible answer was also incorrectly reported as a host that never answered, obscuring version and capability mismatches.
+
+### Why an extension could not handle it
+
+- Spawn lifecycle observation and readiness diagnostics happen inside the core shared-host startup path before any extension can run.
+
+### Expected merge conflict zones
+
+- LOW: `host-ensure.ts` readiness polling and its focused test coverage.
 
 ## 2026-08-30 - Launch the shared RPC socket host correctly from compiled binaries
 

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -148,9 +148,12 @@ async function startHost(
 	);
 	const stderr = await open(paths.stderrLog, "w", 0o600);
 	let pidFile: DaemonPidFile | undefined;
+	let child: ReturnType<typeof spawn> | undefined;
+	let exitedEarly: ChildExit | undefined;
+	let childExit: Promise<ChildExit> | undefined;
 	try {
 		const launch = testOptions?.spawn ?? defaultHostLaunch(socket, testOptions?.hostArgs ?? []);
-		const child = spawn(launch.command, [...launch.args], {
+		child = spawn(launch.command, [...launch.args], {
 			detached: true,
 			env: {
 				...process.env,
@@ -160,21 +163,43 @@ async function startHost(
 			},
 			stdio: ["ignore", "ignore", stderr.fd],
 		});
+		childExit = new Promise((resolveExit) => {
+			child!.once("exit", (code, signal) => {
+				exitedEarly = { code, signal };
+				resolveExit(exitedEarly);
+			});
+		});
 		child.unref();
 		if (child.pid === undefined) throw new Error("failed to spawn RPC socket host");
-		pidFile = { pid: child.pid, processStartTime: await waitForStartTime(child.pid, 2_000) };
+		const processStartTime = await Promise.race([
+			waitForStartTime(child.pid, 2_000),
+			childExit.then(() => {
+				throw new Error("RPC socket host exited before its start time could be read");
+			}),
+		]);
+		pidFile = { pid: child.pid, processStartTime };
 		await writeFile(paths.pidFile, `${JSON.stringify(pidFile)}\n`, { mode: 0o600 });
+	} catch (error: unknown) {
+		if (!exitedEarly) throw error;
+		const diagnostic = await appendStderr(
+			paths,
+			`RPC socket host exited with code ${exitedEarly.code ?? "null"}${exitedEarly.signal ? ` (${exitedEarly.signal})` : ""} before answering get_protocol_info`,
+		);
+		await cleanupState(paths);
+		throw new Error(diagnostic);
 	} finally {
 		await stderr.close();
 	}
 	const readinessTimeoutMs = testOptions?.readinessTimeoutMs ?? 10_000;
-	const protocol = await pollProtocolInfo(socket, readinessTimeoutMs);
-	if (isCompatible(protocol)) return { pid: pidFile.pid, socket, reused: false };
+	const result = await pollProtocolInfo(socket, readinessTimeoutMs, childExit);
+	if (isCompatible(result.protocol)) return { pid: pidFile.pid, socket, reused: false };
 	await stopManagedHost(pidFile, testOptions?.stopTimeoutMs ?? 10_000);
-	const diagnostic = await appendStderr(
-		paths,
-		`spawned RPC socket host did not answer get_protocol_info within ${readinessTimeoutMs}ms`,
-	);
+	const message = result.protocol
+		? `RPC socket host answered get_protocol_info with serverVersion ${result.protocol.serverVersion} and capabilities ${JSON.stringify(result.protocol.capabilities)}, but is incompatible with serverVersion ${VERSION} and required capabilities ${JSON.stringify(REQUIRED_CAPABILITIES)}`
+		: result.exited
+			? `RPC socket host exited with code ${result.exited.code ?? "null"}${result.exited.signal ? ` (${result.exited.signal})` : ""} before answering get_protocol_info`
+			: `spawned RPC socket host did not answer get_protocol_info within ${readinessTimeoutMs}ms`;
+	const diagnostic = await appendStderr(paths, message);
 	await cleanupState(paths);
 	// The supervisor may have failed before binding, or another owner may have
 	// appeared while readiness was being checked. Never unlink an endpoint we
@@ -209,14 +234,32 @@ async function waitForGone(pidFile: DaemonPidFile, timeoutMs: number): Promise<b
 	return false;
 }
 
-async function pollProtocolInfo(socket: string, timeoutMs: number): Promise<ProtocolInfo | undefined> {
+type ChildExit = { readonly code: number | null; readonly signal: NodeJS.Signals | null };
+
+type ProtocolPollResult = { readonly protocol?: ProtocolInfo; readonly exited?: ChildExit };
+
+async function pollProtocolInfo(
+	socket: string,
+	timeoutMs: number,
+	childExit?: Promise<ChildExit>,
+): Promise<ProtocolPollResult> {
 	const deadline = Date.now() + timeoutMs;
+	let lastProtocol: ProtocolInfo | undefined;
 	while (Date.now() <= deadline) {
-		const info = await probeProtocolInfo(socket, Math.min(500, Math.max(1, deadline - Date.now())));
-		if (info) return info;
+		const probe = probeProtocolInfo(socket, Math.min(500, Math.max(1, deadline - Date.now())));
+		const info = childExit ? await Promise.race([probe, childExit]) : await probe;
+		if (isChildExit(info)) return { protocol: lastProtocol, exited: info };
+		if (info) {
+			lastProtocol = info;
+			if (isCompatible(info)) return { protocol: info };
+		}
 		await delay(50);
 	}
-	return undefined;
+	return { protocol: lastProtocol };
+}
+
+function isChildExit(value: ProtocolInfo | ChildExit | undefined): value is ChildExit {
+	return !!value && "code" in value && "signal" in value;
 }
 
 function probeProtocolInfo(socketPath: string, timeoutMs: number): Promise<ProtocolInfo | undefined> {

--- a/packages/coding-agent/test/rpc-host-ensure.test.ts
+++ b/packages/coding-agent/test/rpc-host-ensure.test.ts
@@ -141,6 +141,35 @@ describe("ensureHost", () => {
 		await expect(access(paths.pidFile)).rejects.toMatchObject({ code: "ENOENT" });
 		await expect(access(qa.socket)).rejects.toMatchObject({ code: "ENOENT" });
 	}, 10_000);
+
+	it("fails fast when the spawned host exits before readiness", async () => {
+		const qa = await scratch("early-exit");
+		const startedAt = Date.now();
+		await expect(
+			ensureFixtureHost(qa, {
+				readinessTimeoutMs: 5_000,
+				spawn: { command: "/bin/sh", args: ["-c", "exit 7"] },
+			}),
+		).rejects.toThrow(/exited.*7/);
+		expect(Date.now() - startedAt).toBeLessThan(2_500);
+	}, 10_000);
+
+	it("reports an incompatible protocol answer instead of a readiness timeout", async () => {
+		const qa = await scratch("incompatible-answer");
+		const helper = `
+			const net = require("node:net");
+			const server = net.createServer((socket) => {
+				socket.on("data", () => socket.end(JSON.stringify({ id: "ensure-host-probe", success: true, data: { serverVersion: "0.0.0-wrong", capabilities: [] } }) + "\\n"));
+			});
+			server.listen(process.argv[1]);
+		`;
+		await expect(
+			ensureFixtureHost(qa, {
+				readinessTimeoutMs: 500,
+				spawn: { command: process.execPath, args: ["-e", helper, qa.socket] },
+			}),
+		).rejects.toThrow(/incompatible|0\\.0\\.0-wrong/);
+	}, 10_000);
 });
 
 describe("defaultHostLaunch", () => {


### PR DESCRIPTION
## Problem

The spawned RPC host readiness path had two defects:

- If the child exited immediately (for example, due to bad compiled-binary argv), `ensureHost()` still polled for the full 10-second readiness budget. Today's startup profiling measured a 10.0s stall on every interactive launch.
- If the host answered `get_protocol_info` but was incompatible (wrong server version or missing required capabilities), the error incorrectly said it did not answer, hiding the useful diagnostic and contributing to a multi-day desktop debugging incident on 2026-08-29.

## Fix

- Observe the spawned detached child's `exit` event and fail readiness immediately when it exits before a compatible answer.
- Preserve the last parsed protocol answer and report advertised server version/capabilities plus expected values for incompatible hosts.
- Keep the existing never-answered timeout message and cleanup/stop semantics.
- Add focused regression tests.

This PR is stacked on #1200 and must merge after `fix/compiled-binary-host-spawn`.

## RED -> GREEN evidence

RED with the new tests against the old implementation:

```text
10 pass
2 fail
Expected: /exited.*7/
Received: "spawned RPC socket host did not answer get_protocol_info within 5000ms"
Expected: /incompatible|0\\.0\\.0-wrong/
Received: "spawned RPC socket host did not answer get_protocol_info within 500ms"
```

GREEN after the implementation:

```text
12 pass
0 fail
```

## Verification

- `bun test ./packages/coding-agent/test/rpc-host-ensure.test.ts` - 12 passed
- `bun test ./packages/coding-agent/test/rpc-host-lifecycle.test.ts` - 22 passed, 6 failed due to the pre-existing missing binary-runtime theme asset (`~/.omo/.../dist/modes/interactive/theme/dark.json`)
- `npm run build --workspace packages/coding-agent` - blocked by pre-existing unresolved sibling package artifacts (`@earendil-works/pi-ai`, `@earendil-works/pi-tui`, etc.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails RPC host readiness immediately when the spawned child exits before answering, instead of polling the full 10-second budget. When the host answers but is incompatible, reports the advertised server version and capabilities alongside expected values instead of the misleading "did not answer" timeout error.

- Adds regression tests for early child exit and answered-but-incompatible protocol info.
- Keeps the existing never-answered timeout message and the managed host stop/cleanup flow.

<sup>Written for commit eb80681e8b0eb1aa8fcd1ff705d5703f71909758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

