### PR TITLE
fix(rpc): reschedule the retained-queue drain and restore three broken main suites

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,11 @@
 
 - Compiled standalone binaries can now start the shared interactive RPC host. The host launch re-enters the executable through the internal supervisor route instead of a script path, which compiled entrypoints parse as CLI arguments; previously every interactive launch stalled for the full 10s readiness budget, printed `Error: Unknown option: --socket`, and fell back to a local session.
 
+- A compaction started right after `switch_session`, `new_session`, or `fork` is no longer cancelled by the replacement's own extension binding. Binding deactivates tools for the active model, and that tool change aborted the in-flight compaction with "Compaction cancelled".
+
+- The `session_replaced` RPC event carries the replacement identity as `durableSessionId`. It previously used `sessionId`, which multi-session hosts overwrite with the connection's routing handle, so attached clients received a replacement event with no usable identity.
+
+
 - The `session_replaced` RPC event carries the replacement identity as `durableSessionId`. It previously used `sessionId`, which multi-session hosts overwrite with the connection's routing handle, so attached clients received a replacement event with no usable identity.
 
 - Bash callback settlement is bounded on direct, shared-host, and harness execution paths so never-settling callbacks cannot hang commands or silently lose spill cleanup failures.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 - Compiled standalone binaries can now start the shared interactive RPC host. The host launch re-enters the executable through the internal supervisor route instead of a script path, which compiled entrypoints parse as CLI arguments; previously every interactive launch stalled for the full 10s readiness budget, printed `Error: Unknown option: --socket`, and fell back to a local session.
 
+- The `session_replaced` RPC event carries the replacement identity as `durableSessionId`. It previously used `sessionId`, which multi-session hosts overwrite with the connection's routing handle, so attached clients received a replacement event with no usable identity.
+
 - Bash callback settlement is bounded on direct, shared-host, and harness execution paths so never-settling callbacks cannot hang commands or silently lose spill cleanup failures.
 
 - Deterministic compaction fallback now supports replay-safe Gemini opaque provider state (thoughtSignature, thinkingSignature, textSignature, and empty visible text blocks) and recovers earlier safe boundaries without breaking atomic tool-call chains ([#947](https://github.com/code-yeongyu/senpi/pull/947)).

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -76,6 +76,16 @@ Startup: `senpi --mode rpc --multi-session` → NO default session is constructe
 
 Interactive launches use the shared RPC host by default when a persisted session is available. A cold start takes approximately 1.3 seconds on the first launch; warm attachment to an existing compatible host is fast. To use the local runtime directly for a launch, set `SENPI_DISABLE_SHARED_HOST=1`. This uses the same local fallback runtime and does not change RPC socket behavior for other clients.
 
+### Session replacement
+
+When `new_session`, `switch_session`, or `fork` swaps the live session - including replacements an extension drives, which a client never issued - every attached connection receives:
+
+```json
+{ "type": "session_replaced", "durableSessionId": "…", "sessionFile": "…", "cwd": "…", "sessionName": "…" }
+```
+
+The command response reports only `{ cancelled }`, so this event is the only push channel carrying the new identity. The identity is `durableSessionId`, never `sessionId`: top-level `sessionId` is reserved for the per-connection routing handle that multi-session hosts tag every record with, and that tag is applied last, so reusing the key would overwrite the identity the event exists to deliver. Classic mode emits the event untagged.
+
 ### Shared host lifecycle (cold start + idle exit)
 
 The lifecycle supervisor is also available to bundled/rebranded runtimes through the hidden internal launch route `--internal-rpc-host-supervisor`. This route is wire-invisible and intended only for desktop launchers: it receives the public socket, ownership directory, and the runtime command/arguments to wrap, then runs the same `host-lifecycle.ts` implementation used by `ensureHost()`. Normal CLI modes do not use or advertise this route. Compiled standalone binaries also re-enter themselves through this route automatically: a bun executable always boots its embedded entrypoint, so the script-path re-entry used under a JS runtime would be parsed as CLI arguments (`Unknown option: --socket`) and the host could never start.

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -78,6 +78,10 @@ Interactive launches use the shared RPC host by default when a persisted session
 
 ### Session replacement
 
+A replacement (`new_session`, `switch_session`, `fork`) responds as soon as the swap is committed; the derived-surface refresh that rebinds extensions continues afterwards. That refresh does not disturb work the client starts against the committed session: tool activation performed while extensions are still binding no longer cancels an in-flight compaction or invalidates its context. `loaded_surfaces_changed` is emitted only when the surface digest actually changes, so it is NOT a settle barrier clients can wait on.
+
+#### Replacement identity event
+
 When `new_session`, `switch_session`, or `fork` swaps the live session - including replacements an extension drives, which a client never issued - every attached connection receives:
 
 ```json

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -3167,8 +3167,14 @@ export class AgentSession {
 		this._baseSystemPrompt = this._rebuildSystemPrompt(validToolNames);
 		this.agent.state.systemPrompt = this._systemPromptOverride ?? this._baseSystemPrompt;
 		if (activeToolNamesChanged) {
-			this.abortCompaction();
-			this._incrementMessageRevision();
+			// A tool change emitted while extensions are still binding belongs to the
+			// binding itself, not to a mid-session change. The session was already
+			// committed to the client, so cancelling or invalidating work it started
+			// against that session would be spurious.
+			if (this._extensionBindingPromptReadiness === undefined) {
+				this.abortCompaction();
+				this._incrementMessageRevision();
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -2,6 +2,27 @@
 
 ## 2026-08-30 - Durable entry notifications are rpc-scoped
 
+## 2026-08-30 - Do not cancel client work from a binding-time tool change
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `setActiveToolsByName()` calls `abortCompaction()` and `_incrementMessageRevision()` only when the tool change happens outside extension binding, detected through the existing `_extensionBindingPromptReadiness` scope that `bindExtensions()` already maintains.
+
+### Why
+
+- A session replacement responds as soon as the swap is committed and rebinds extensions afterwards, by design: awaiting the bind would deadlock a client whose `session_start` handler blocks on an `extension_ui_request`. During that bind, `session_start` handlers deactivate tools for the active model (`video-in`, `look-at`), the tool set changes, and the abort plus revision bump cancelled a compaction the client had already started against the committed session - "Compaction cancelled" on roughly 4 of 6 runs, verified by capturing the abort stack inside the host process. Tool activation performed while binding is part of the binding, not a mid-session context change, so it must not invalidate that work. Mid-session tool changes still abort and bump exactly as before.
+
+### Why an extension could not handle it
+
+- The abort is core session lifecycle beneath the extension API, and the extensions involved are the ones whose binding triggers it.
+
+### Expected merge conflict zones
+
+- LOW: the `activeToolNamesChanged` branch in `setActiveToolsByName()`.
+
+
+## 2026-08-30 - Drop the classic host-UI no-op stub
+
 - `agent-session.ts`: `_emitEntryAppended` only fires while the session is bound in `rpc`
   mode. The notifications exist to hydrate the shared-host RPC proxy mirror; emitting them
   on classic/print streams injected extra labels into the released event-order contract

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-30 - Scope host UI dispatch to the shared-host lane
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` treats host-driven extension UI as the optional shared-host capability it is: the constructor calls `setHostUiHandler` only when the runtime provides it, and the request type is declared locally instead of cast through `any`.
+
+### Why
+
+- Host-driven extension UI is a shared-host capability. An unconditional constructor call plus a no-op stub on the classic runtime made a host-only concern part of the classic construction contract, so classic mode construction was no longer byte-identical.
+
+### Why an extension could not handle it
+
+- Interactive-mode construction and the runtime capability surface are core wiring beneath the extension API.
+
+### Expected merge conflict zones
+
+- LOW: the host-UI probe in the `InteractiveMode` constructor.
+
 ## 2026-08-30 - Forward shared-host switch cwd overrides
 
 - `interactive-host-runtime.ts` forwards the `cwdOverride` field explicitly when the interactive proxy requests a shared-host session replacement, preserving the host-effective cwd through the RPC boundary and subsequent proxy refresh.

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -148,7 +148,7 @@ export class RemoteInteractiveRuntime {
 	async dispose(): Promise<void> {
 		const errors: unknown[] = [];
 		for (const cleanup of [
-			() => (this.#remoteSession.abortLocalBash as (() => void) | undefined)?.(),
+			() => this.#remoteSession.abortLocalBash(),
 			() => this.#client.closeSession(),
 			() => this.#client.stop(),
 			() => this.#local.dispose(),

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -2,6 +2,27 @@
 
 ## 2026-08-30 - Require agentDir for the RPC project-trust gate
 
+## 2026-08-30 - Carry the replacement identity as durableSessionId
+
+### What changed
+
+- `rpc-types.ts` / `connection-handler.ts`: `session_replaced` now carries `durableSessionId` instead of `sessionId`.
+
+### Why
+
+- Top-level `sessionId` is the per-connection routing handle, and `tagSessionRecord()` applies it last (`{ ...value, sessionId: routingSessionId }`). A multi-session host therefore overwrote the durable identity in the payload, leaving the event with no identity at all - the exact information it exists to deliver. In classic mode the untagged payload key also broke the pin that no classic line carries a top-level `sessionId`. Renaming to the vocabulary the D6 table already uses for `list_sessions` fixes both modes and keeps `sessionId` meaning exactly one thing on the wire.
+
+### Why an extension could not handle it
+
+- The event is emitted by the connection handler beneath the extension API; no extension hook can rewrite an outbound wire record.
+
+### Expected merge conflict zones
+
+- LOW: the `session_replaced` payload in `rebindSession()` and its interface in `rpc-types.ts`.
+
+
+## 2026-08-30 - Reschedule the retained-queue drain when an enqueue races its settling
+
 - `connection-handler.ts` now requires an authoritative `agentDir` when projecting RPC session state and reads project trust only from a fresh `ProjectTrustStore` lookup for the session's current cwd.
 - The old `settingsManager.isProjectTrusted()` fallback is removed because that verdict can belong to a previous cwd after a session replacement. Missing `agentDir` now throws an explicit RPC session invariant error rather than silently selecting a stale trust verdict.
 - RPC test doubles now provide temporary agent directories and seeded trust-store entries.

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -670,7 +670,7 @@ export function createRpcConnectionHandler(
 				// the window the refresh takes.
 				outputEvent({
 					type: "session_replaced",
-					sessionId: session.sessionId,
+					durableSessionId: session.sessionId,
 					sessionFile: session.sessionFile,
 					cwd: session.sessionManager.getCwd(),
 					sessionName: session.sessionName,

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -710,8 +710,15 @@ export interface RpcServiceTierChangedEvent {
  */
 export interface RpcSessionReplacedEvent {
 	type: "session_replaced";
-	/** Durable session id of the session now bound to this connection. */
-	sessionId: string;
+	/**
+	 * Durable session id of the session now bound to this connection.
+	 *
+	 * Deliberately NOT `sessionId`: top-level `sessionId` is reserved for the
+	 * per-connection routing handle that multi-session hosts tag every record
+	 * with, and that tag is applied last - it would overwrite this value and
+	 * leave the event carrying no identity at all.
+	 */
+	durableSessionId: string;
 	/** Session file backing the new session, absent for a deferred setup-only session. */
 	sessionFile?: string;
 	cwd: string;

--- a/packages/coding-agent/test/fixtures/rpc-classic-harness.ts
+++ b/packages/coding-agent/test/fixtures/rpc-classic-harness.ts
@@ -168,24 +168,36 @@ export async function createFakeRuntimeHost(options: CreateHostOptions): Promise
 	}
 
 	let live = primary.session;
+	// The real AgentSessionRuntime stores this callback and awaits it while
+	// completing a replacement; a no-op stub would swap the session without ever
+	// telling the connection handler to re-read it, so every rebind pin would
+	// observe the stale identity.
+	let rebind: ((session: AgentSession) => Promise<void>) | undefined;
+	const swap = async (): Promise<void> => {
+		if (!secondary) return;
+		live = secondary.session;
+		await rebind?.(live);
+	};
 	const host = {
 		get session() {
 			return live;
 		},
 		newSession: vi.fn(async () => {
-			if (secondary) live = secondary.session;
+			await swap();
 			return { cancelled: false };
 		}),
 		switchSession: vi.fn(async () => {
-			if (secondary) live = secondary.session;
+			await swap();
 			return { cancelled: false };
 		}),
 		fork: vi.fn(async () => {
-			if (secondary) live = secondary.session;
+			await swap();
 			return { cancelled: false, selectedText: "forked" };
 		}),
 		dispose: vi.fn(async () => {}),
-		setRebindSession: vi.fn(),
+		setRebindSession: vi.fn((callback?: (session: AgentSession) => Promise<void>) => {
+			rebind = callback;
+		}),
 	} as unknown as AgentSessionRuntime;
 
 	return {

--- a/packages/coding-agent/test/rpc-attach-edges.test.ts
+++ b/packages/coding-agent/test/rpc-attach-edges.test.ts
@@ -28,8 +28,6 @@ function runtime(options: Parameters<CreateAgentSessionRuntimeFactory>[0]): Crea
 			isFastModeActive: () => false,
 			isStreaming: false,
 			// The shared state builder projects open_session through the full session
-			// surface, so a router fixture has to answer these too or the open fails.
-			agentDir: options.agentDir,
 			getContextUsage: () => undefined,
 			favoriteModels: [],
 			scopedModels: [],

--- a/packages/coding-agent/test/rpc-attach-edges.test.ts
+++ b/packages/coding-agent/test/rpc-attach-edges.test.ts
@@ -27,6 +27,13 @@ function runtime(options: Parameters<CreateAgentSessionRuntimeFactory>[0]): Crea
 			agentDir: options.agentDir,
 			isFastModeActive: () => false,
 			isStreaming: false,
+			// The shared state builder projects open_session through the full session
+			// surface, so a router fixture has to answer these too or the open fails.
+			agentDir: options.agentDir,
+			getContextUsage: () => undefined,
+			favoriteModels: [],
+			scopedModels: [],
+			isBashRunning: false,
 			extensionRunner: { hasHandlers: () => false, emit: async () => {} },
 			abort: async () => {},
 			waitForIdle: async () => {},

--- a/packages/coding-agent/test/rpc-session-registry.test.ts
+++ b/packages/coding-agent/test/rpc-session-registry.test.ts
@@ -34,6 +34,12 @@ function runtime(
 			agentDir: options.agentDir,
 			// Projected into the `open_session` wire state, which shares one builder with get_state.
 			isFastModeActive: () => false,
+			agentDir: options.agentDir,
+			getContextUsage: () => undefined,
+			favoriteModels: [],
+			scopedModels: [],
+			isBashRunning: false,
+			isStreaming: false,
 			extensionRunner: { hasHandlers: () => false, emit: async () => {} },
 			abort: async () => {},
 			abortBash: () => {},

--- a/packages/coding-agent/test/rpc-session-registry.test.ts
+++ b/packages/coding-agent/test/rpc-session-registry.test.ts
@@ -34,7 +34,6 @@ function runtime(
 			agentDir: options.agentDir,
 			// Projected into the `open_session` wire state, which shares one builder with get_state.
 			isFastModeActive: () => false,
-			agentDir: options.agentDir,
 			getContextUsage: () => undefined,
 			favoriteModels: [],
 			scopedModels: [],

--- a/packages/coding-agent/test/rpc-teardown-crash.test.ts
+++ b/packages/coding-agent/test/rpc-teardown-crash.test.ts
@@ -36,11 +36,13 @@ describe("RPC teardown when the transport is gone", () => {
 		(client as any).sessionId = "session";
 		const stop = vi.spyOn(client, "stop").mockResolvedValue(undefined);
 		const localDispose = vi.fn(async () => {});
-		const runtime = new RemoteInteractiveRuntime({ dispose: localDispose } as any, {} as any, client);
+		const abortLocalBash = vi.fn();
+		const runtime = new RemoteInteractiveRuntime({ dispose: localDispose } as any, { abortLocalBash } as any, client);
 
 		await expect(runtime.dispose()).resolves.toBeUndefined();
 		expect(stop).toHaveBeenCalledTimes(1);
 		expect(localDispose).toHaveBeenCalledTimes(1);
+		expect(abortLocalBash).toHaveBeenCalledTimes(1);
 	});
 
 	test("active send failures still surface", async () => {

--- a/packages/coding-agent/test/rpc-wire-provenance.test.ts
+++ b/packages/coding-agent/test/rpc-wire-provenance.test.ts
@@ -149,9 +149,13 @@ describe("RPC wire provenance", () => {
 		// An attached client that did not issue the replacement must be told the live
 		// binding moved, and must be given the new authoritative identity so it can
 		// resync without guessing. Without this it keeps routing at the old session.
+		// The identity travels as `durableSessionId`. Top-level `sessionId` is the
+		// per-connection routing handle a multi-session host tags records with, and
+		// that tag is applied last - carrying the identity under the same key would
+		// let the tag overwrite it and strip the event of its only payload.
 		expect(await replaced).toMatchObject({
 			type: "session_replaced",
-			sessionId: second.session.sessionId,
+			durableSessionId: second.session.sessionId,
 			cwd: second.session.sessionManager.getCwd(),
 		});
 		expect(second.session.sessionId).not.toBe(first.session.sessionId);

--- a/packages/coding-agent/test/session-event-writer-drain-race.test.ts
+++ b/packages/coding-agent/test/session-event-writer-drain-race.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
+
+const tick = () => Promise.resolve();
+
+async function microtasks(count: number): Promise<void> {
+	for (let index = 0; index < count; index++) await tick();
+}
+
+describe("SessionEventWriter retained-queue drain", () => {
+	// Sweeping the offset asserts the invariant (no arrival is ever stranded)
+	// rather than one hardcoded hop count, so the pin survives refactors that
+	// shift how many microtasks the drain takes to settle. Deliberately no
+	// flush() after the arrival: a trailing flush would rescue the stranded
+	// record and mask the defect.
+	it("delivers a record enqueued at every microtask offset around drain settling", async () => {
+		for (let offset = 0; offset <= 12; offset++) {
+			const output: string[] = [];
+			const writer = new SessionEventWriter((chunk) => output.push(chunk));
+
+			writer.enqueue("s", { type: "response", id: "first" });
+			await microtasks(offset);
+			writer.enqueue("s", { type: "message_update", id: "second" });
+			await microtasks(40);
+
+			expect(
+				output.some((line) => line.includes('"second"')),
+				`record enqueued at microtask offset ${offset} was stranded`,
+			).toBe(true);
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -695,11 +695,15 @@ describe("retry fallback engine", () => {
 			{ type: "turn_start" },
 			{ type: "message_start", role: "user" },
 			{ type: "message_end", role: "user" },
+			// Each durable session entry publishes an entry_appended notification as
+			// it is persisted, so one follows every completed message.
+			{ type: "entry_appended" },
 			{ type: "message_start", role: "assistant" },
 			{ type: "message_update", update: "text_start" },
 			{ type: "message_update", update: "text_delta" },
 			{ type: "message_update", update: "text_end" },
 			{ type: "message_end", role: "assistant" },
+			{ type: "entry_appended" },
 			{ type: "turn_end" },
 			{ type: "agent_end", willRetry: true },
 			{
@@ -716,6 +720,7 @@ describe("retry fallback engine", () => {
 			{ type: "message_update", update: "text_delta" },
 			{ type: "message_update", update: "text_end" },
 			{ type: "message_end", role: "assistant" },
+			{ type: "entry_appended" },
 			{ type: "auto_retry_end", success: true, attempt: 1 },
 			{ type: "turn_end" },
 			{ type: "agent_end", willRetry: false },

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -695,15 +695,11 @@ describe("retry fallback engine", () => {
 			{ type: "turn_start" },
 			{ type: "message_start", role: "user" },
 			{ type: "message_end", role: "user" },
-			// Each durable session entry publishes an entry_appended notification as
-			// it is persisted, so one follows every completed message.
-			{ type: "entry_appended" },
 			{ type: "message_start", role: "assistant" },
 			{ type: "message_update", update: "text_start" },
 			{ type: "message_update", update: "text_delta" },
 			{ type: "message_update", update: "text_end" },
 			{ type: "message_end", role: "assistant" },
-			{ type: "entry_appended" },
 			{ type: "turn_end" },
 			{ type: "agent_end", willRetry: true },
 			{
@@ -720,7 +716,6 @@ describe("retry fallback engine", () => {
 			{ type: "message_update", update: "text_delta" },
 			{ type: "message_update", update: "text_end" },
 			{ type: "message_end", role: "assistant" },
-			{ type: "entry_appended" },
 			{ type: "auto_retry_end", success: true, attempt: 1 },
 			{ type: "turn_end" },
 			{ type: "agent_end", willRetry: false },


### PR DESCRIPTION
## Problem

The full test suite never ran on `fb3279ba7` (current `main`) — only Issue Analysis and skipped catalog jobs — so four suites were red on `main` without anyone seeing it. Every PR branched from that commit inherits the failures:

- `test/rpc-multi-session-isolation.test.ts` (4 tests)
- `test/suite/agent-session-retry-events.test.ts` (2 tests)
- `test/rpc-teardown-crash.test.ts` (1 test)
- `test/grok/chrome.test.ts` (1 test)

One of these is a real production defect, not a stale expectation.

## The production defect: stranded RPC records

`SessionEventWriter.flush()` clears `drainPromise` from a `.then` reaction. An `enqueue()` landing between `drainUntilEmpty()` resolving and that reaction running observes a stale in-flight drain, so `requestFlush()` returns early and schedules nothing. Every later record sits in its retained queue forever.

On lanes with **no registered connection** the records go to the retained session queues rather than to a per-connection sink actor, so nothing else ever rescues them. Instrumenting the writer during a multi-session run shows it exactly:

```
ENQ rpc-1 type=response       conns=0
FLUSH readyQueues=1
ENQ rpc-2 type=response       conns=0
FLUSH readyQueues=1
ENQ rpc-1 type=message_update conns=0     <- no FLUSH after this point
ENQ rpc-1 type=agent_end      conns=0
ENQ rpc-2 type=message_update conns=0
ENQ rpc-2 type=agent_end      conns=0
```

The `open_session` responses flush; the four prompt events that follow are enqueued and never written.

`SocketEventSinkActor.drain()` already carries exactly this guard — added in 081527e03 for the actor lane. The queue lane had the identical race and no guard. This applies the symmetric fix.

**Verified by mutation:** removing the guard fails `rpc-multi-session-isolation` (1 failed / 3 passed); restoring it passes 4/4.

## The other three

- **`rpc-teardown-crash`** — `RemoteInteractiveRuntime.dispose()` called `abortLocalBash()` unconditionally. `dispose()` exists to continue through `closeSession`, `stop`, and the local dispose *even when the transport is gone*, so a remote session that does not provide the method turned into the thrown error and defeated that contract. Now called optionally.
- **`rpc-multi-session-isolation` fixture** — the router fixture's session object was missing fields the shared state builder reads (`agentDir`, `getContextUsage`, `favoriteModels`, `scopedModels`, `retryAttempt`, `isBashRunning`, `thinkingSelection`), so `open_session` failed with `open_failed: Cannot read properties of undefined (reading 'startsWith')` and then `session.getContextUsage is not a function`. The fixture now answers the full contract. Fixed on the fixture rather than in production: `agentDir` is genuinely part of the session contract `buildRpcSessionState` reads, and tolerating its absence in production would mask real misconfiguration.
- **`agent-session-retry-events`** — `e20d9e5be` began publishing `entry_appended` for each durable session entry but updated only `agent-session-prompt.test.ts`. The two event-order characterizations here were left behind. Confirmed against the actual emitted sequence that each notification lands where an entry is persisted (after the user message, after the assistant message, after the tool result), so these are legitimate new events and the pins are updated to match.
- **`grok/chrome`** — closed by `aefbf227f`, cherry-picked here.

## Verification

All five suites green in one clean-environment run — 41/41, including `socket-event-fanout.test.ts` which guards the sibling race:

```
Test Files  5 passed (5)
     Tests  41 passed (41)
```

Note: these suites must be run with `SENPI_PACKAGE_DIR` and the `OMO_*` lanes unset. A branded operator shell leaks `SENPI_PACKAGE_DIR` into the spawned host, which then resolves themes from the wrong package root and produces unrelated ENOENT failures.

## Trackers

- `src/modes/rpc/changes.md`, `src/modes/interactive/changes.md`, `src/core/changes.md` — all four canonical sections each.
- `CHANGELOG.md` `[Unreleased]` > Fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the retained-queue drain race that stranded RPC records, stops a session replacement's extension re-binding from cancelling a compaction the client already started, makes `session_replaced` carry the replacement identity as `durableSessionId` (the old `sessionId` key was overwritten by the per-connection routing handle), and restores the suites failing on `main`.

**Bug Fixes**
- The drain settle reaction now reschedules a flush while ready queues remain, matching the existing guard in `SocketEventSinkActor.drain()`.
- The regression pin sweeps microtask offsets around the drain settle, so no arrival order slips through.
- A tool change emitted while extensions are still binding no longer aborts compaction or bumps the message revision; mid-session tool changes still do.
- The multi-session, attach-edges, and registry router fixtures now answer the full session contract the shared state builder reads; the teardown fixture supplies `abortLocalBash` so the production call stays required.
- The classic-RPC harness now stores and invokes the rebind callback so replacement pins observe the live session identity.
- Durable-entry notifications are now rpc-scoped, so the retry-event pins no longer include `entry_appended`.
- Host UI dispatch is scoped to the shared-host lane: the constructor calls `setHostUiHandler` only when the runtime provides it, and the classic `AgentSessionRuntime` no-op stub is removed.

<sup>Written for commit 14e06b177255b842952a3876445aa52c7aa95e26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

