### PR TITLE
fix(rpc): restore main CI after audit2 merge

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -36,6 +36,9 @@
 
 - The `session_replaced` RPC event carries the replacement identity as `durableSessionId`. It previously used `sessionId`, which multi-session hosts overwrite with the connection's routing handle, so attached clients received a replacement event with no usable identity.
 
+- The RPC `session_replaced` event is now part of the typed `RpcClientEvent` union, so clients can discriminate it and read `durableSessionId` without casting.
+
+- An interactive session sharing a host no longer keeps rendering the previous session after another attached client switches, forks, or replaces the shared session; the proxy rebinds its session manager, settings, and transcript when the host announces the replacement.
 
 - The `session_replaced` RPC event carries the replacement identity as `durableSessionId`. It previously used `sessionId`, which multi-session hosts overwrite with the connection's routing handle, so attached clients received a replacement event with no usable identity.
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,26 +1,25 @@
 # changes
 
-## 2026-08-30 - Scope host UI dispatch to the shared-host lane
-## 2026-08-30 - Restore the external-owner compaction delegation episode
+## 2026-08-30 - Rebind the shared-host proxy on session_replaced
 
 ### What changed
 
-- `interactive-mode.ts`: restores the `externalOwnerCompactionNoticeShown` guard, the `rejectionCause === "external-owner"` branch in `compaction_end`, and every episode reset (successful compaction, session rebind, reload, retry fallback, `cycleModel`, `selectModelFromUi`, the `model_changed` wire event, and full transcript rerenders). Settings-only `rebuildChatFromMessages` rebuilds deliberately preserve the episode.
+- `interactive-host-runtime.ts`: the remote session proxy handles the `session_replaced` wire event by refreshing its binding. Refreshes are serialized, so a replacement-driven refresh cannot interleave with a caller-driven one and commit a snapshot mixing two sessions. Replacements this runtime drives itself are wrapped in `aroundLocalReplacement`, which suppresses the echo a multi-session host broadcasts back to the issuing connection; the scope covers the whole command, because the host emits while completing it. `createRemoteSessionProxy` is exported for direct coverage.
 
 ### Why
 
-- A stray commit on this branch carried an RPC subject but held a reverse-diff of `interactive-mode.ts` that deleted the feature outright. Without it, a session whose compaction is owned by an external owner (the Claude Agent SDK) renders a red error on every auto-compaction attempt instead of one muted informational notice, and the footer never marks the saturated context meter as handled natively. The external-owner branch is checked before `aborted` because production rejections are emitted via `_rejectCompaction(..., true, reason)` and carry `aborted: true`.
+- A replacement can be driven by any other attached client, or by an extension that no client asked, and the command response carries only `{ cancelled }`. Without handling the event the proxy kept serving the previous session's `sessionManager`, `settingsManager`, and mirrored message list while the host had already moved on. Without the suppression the echo raced the runtime's own ordered refresh/rebind, which transports setup entries between two refreshes. The event is deliberately not forwarded to `AgentSession` listeners: it is connection-level, not part of the agent event stream.
 
 ### Why an extension could not handle it
 
-- The notice, its once-per-episode guard, and the footer delegation marker are interactive-mode chat rendering state that no extension surface owns.
+- The proxy owns the shared-host binding beneath every extension surface; no extension hook observes the connection's replacement notice.
 
 ### Expected merge conflict zones
 
-- LOW: the `compaction_end` and `model_changed` cases in `handleEvent`, and the episode resets at each model-switch and rerender call site.
+- LOW: the wire-event switch in the proxy's `client.onEvent` handler, the replacement methods, and the `refresh` definition.
 
 
-## 2026-08-30 - Keep shared-host disposal working when the remote session is incomplete
+## 2026-08-30 - Scope host UI dispatch to the shared-host lane
 
 ### What changed
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,6 +1,26 @@
 # changes
 
 ## 2026-08-30 - Scope host UI dispatch to the shared-host lane
+## 2026-08-30 - Restore the external-owner compaction delegation episode
+
+### What changed
+
+- `interactive-mode.ts`: restores the `externalOwnerCompactionNoticeShown` guard, the `rejectionCause === "external-owner"` branch in `compaction_end`, and every episode reset (successful compaction, session rebind, reload, retry fallback, `cycleModel`, `selectModelFromUi`, the `model_changed` wire event, and full transcript rerenders). Settings-only `rebuildChatFromMessages` rebuilds deliberately preserve the episode.
+
+### Why
+
+- A stray commit on this branch carried an RPC subject but held a reverse-diff of `interactive-mode.ts` that deleted the feature outright. Without it, a session whose compaction is owned by an external owner (the Claude Agent SDK) renders a red error on every auto-compaction attempt instead of one muted informational notice, and the footer never marks the saturated context meter as handled natively. The external-owner branch is checked before `aborted` because production rejections are emitted via `_rejectCompaction(..., true, reason)` and carry `aborted: true`.
+
+### Why an extension could not handle it
+
+- The notice, its once-per-episode guard, and the footer delegation marker are interactive-mode chat rendering state that no extension surface owns.
+
+### Expected merge conflict zones
+
+- LOW: the `compaction_end` and `model_changed` cases in `handleEvent`, and the episode resets at each model-switch and rerender call site.
+
+
+## 2026-08-30 - Keep shared-host disposal working when the remote session is incomplete
 
 ### What changed
 

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -166,21 +166,27 @@ export class RemoteInteractiveRuntime {
 		setup?: (sessionManager: SessionManager) => Promise<void>;
 		withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
 	}): Promise<{ cancelled: boolean }> {
-		const result = await this.#client.newSession(options?.parentSession);
-		if (!result.cancelled) {
-			this.#beforeSessionInvalidate?.();
-			this.#remoteSession.abortLocalBash();
-			await this.#remoteSession.refresh();
-			if (options?.setup) {
-				const capture = SessionManager.inMemory(this.#remoteSession.session.sessionManager.getCwd());
-				await options.setup(capture);
-				for (const entry of capture.getEntries()) await this.#client.appendSessionEntry(entry);
+		// Suppresses for the ENTIRE command, not just the refresh tail: a
+		// multi-session host emits session_replaced while completing it, so the echo
+		// can arrive before the refresh/rebind sequence below starts and race it -
+		// newSession transports setup entries between two refreshes.
+		return this.#remoteSession.aroundLocalReplacement(async () => {
+			const result = await this.#client.newSession(options?.parentSession);
+			if (!result.cancelled) {
+				this.#beforeSessionInvalidate?.();
+				this.#remoteSession.abortLocalBash();
 				await this.#remoteSession.refresh();
+				if (options?.setup) {
+					const capture = SessionManager.inMemory(this.#remoteSession.session.sessionManager.getCwd());
+					await options.setup(capture);
+					for (const entry of capture.getEntries()) await this.#client.appendSessionEntry(entry);
+					await this.#remoteSession.refresh();
+				}
+				await this.#rebindSession?.();
+				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 			}
-			await this.#rebindSession?.();
-			if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
-		}
-		return result;
+			return result;
+		});
 	}
 	async switchSession(
 		sessionPath: string,
@@ -190,43 +196,53 @@ export class RemoteInteractiveRuntime {
 			projectTrustContextFactory?: (cwd: string) => ProjectTrustContext;
 		},
 	): Promise<{ cancelled: boolean }> {
-		const result = await this.#client.switchSession(
-			sessionPath,
-			options?.cwdOverride === undefined ? undefined : { cwdOverride: options.cwdOverride },
-		);
-		if (!result.cancelled) {
-			this.#beforeSessionInvalidate?.();
-			this.#remoteSession.abortLocalBash();
-			await this.#remoteSession.refresh();
-			await this.#rebindSession?.();
-			// The shared host already resolved trust; this callback is retained for
-			// compatibility, but its result cannot override host-authoritative state.
-			options?.projectTrustContextFactory?.(this.#remoteSession.session.sessionManager.getCwd());
-			if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
-		}
-		return result;
+		// See newSession: the suppression must cover the command itself, since the
+		// host emits session_replaced while completing it.
+		return this.#remoteSession.aroundLocalReplacement(async () => {
+			const result = await this.#client.switchSession(
+				sessionPath,
+				options?.cwdOverride === undefined ? undefined : { cwdOverride: options.cwdOverride },
+			);
+			if (!result.cancelled) {
+				this.#beforeSessionInvalidate?.();
+				this.#remoteSession.abortLocalBash();
+				await this.#remoteSession.refresh();
+				await this.#rebindSession?.();
+				// The shared host already resolved trust; this callback is retained for
+				// compatibility, but its result cannot override host-authoritative state.
+				options?.projectTrustContextFactory?.(this.#remoteSession.session.sessionManager.getCwd());
+				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
+			}
+			return result;
+		});
 	}
 	async fork(
 		entryId: string,
 		options?: { position?: "before" | "at"; withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
-		const result = await this.#client.fork(entryId, options);
-		if (!result.cancelled) {
-			this.#beforeSessionInvalidate?.();
-			this.#remoteSession.abortLocalBash();
-			await this.#refreshAndRebind();
-			if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
-		}
-		return { cancelled: result.cancelled, selectedText: result.text };
+		// See newSession: the suppression must cover the command itself.
+		return this.#remoteSession.aroundLocalReplacement(async () => {
+			const result = await this.#client.fork(entryId, options);
+			if (!result.cancelled) {
+				this.#beforeSessionInvalidate?.();
+				this.#remoteSession.abortLocalBash();
+				await this.#refreshAndRebind();
+				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
+			}
+			return { cancelled: result.cancelled, selectedText: result.text };
+		});
 	}
 	async importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }> {
-		const result = await this.#client.importJsonl(inputPath, cwdOverride);
-		if (!result.cancelled) {
-			this.#beforeSessionInvalidate?.();
-			this.#remoteSession.abortLocalBash();
-			await this.#refreshAndRebind();
-		}
-		return result;
+		// See newSession: the suppression must cover the command itself.
+		return this.#remoteSession.aroundLocalReplacement(async () => {
+			const result = await this.#client.importJsonl(inputPath, cwdOverride);
+			if (!result.cancelled) {
+				this.#beforeSessionInvalidate?.();
+				this.#remoteSession.abortLocalBash();
+				await this.#refreshAndRebind();
+			}
+			return result;
+		});
 	}
 
 	async #refreshAndRebind(): Promise<void> {
@@ -239,11 +255,19 @@ interface RemoteSessionProxy {
 	readonly session: AgentSession;
 	setHostUiHandler(callback?: InteractiveHostUiHandler): void;
 	refresh(): Promise<void>;
+	/**
+	 * Run a replacement this runtime is driving itself, suppressing the refresh
+	 * that the host's broadcast `session_replaced` would otherwise trigger. The
+	 * caller owns the refresh/rebind ordering for its own replacements, so the
+	 * scope must cover the command itself, not just its refresh tail.
+	 */
+	aroundLocalReplacement<T>(body: () => Promise<T>): Promise<T>;
 	abortLocalBash(): void;
 	createReplacedSessionContext(): ReplacedSessionContext;
 }
 
-function createRemoteSessionProxy(
+/** Exported for direct coverage of the wire-event handling below. */
+export function createRemoteSessionProxy(
 	local: AgentSession,
 	agentDir: string,
 	client: RpcClient,
@@ -342,6 +366,8 @@ function createRemoteSessionProxy(
 	});
 	let streamingAssistant: Extract<AgentSession["messages"][number], { role: "assistant" }> | undefined;
 	let mirroredCurrentAssistantUsage = false;
+	/** Non-zero while this runtime is driving its own replacement sequence. */
+	let localReplacementDepth = 0;
 	const listeners = new Set<AgentSessionEventListener>();
 	client.onEvent((wireEvent) => {
 		if ((wireEvent as { type?: string }).type === "extension_ui_request") {
@@ -351,6 +377,24 @@ function createRemoteSessionProxy(
 					(response) => response && client.sendExtensionUIResponse(response),
 				);
 			else pendingUiRequests.push(request);
+			return;
+		}
+		if (wireEvent.type === "session_replaced") {
+			// The host swapped the live session behind this connection - another
+			// attached client issued the replacement, or an extension drove one that no
+			// client issued. Nothing else re-reads the binding, so without this the
+			// proxy keeps serving the previous session's manager, settings and message
+			// mirror while the host has already moved on. The command response carries
+			// only `{ cancelled }`, so this event is the only signal available here.
+			//
+			// A multi-session host broadcasts the event to every connection including
+			// the one that issued the replacement, and this runtime's own replacement
+			// methods already run an ordered refresh/rebind - newSession additionally
+			// transports setup entries between two refreshes. Refreshing again from
+			// here would race that sequence, so self-driven replacements are skipped.
+			if (localReplacementDepth === 0) {
+				void refresh().catch(reportActionFailure("session refresh after replacement"));
+			}
 			return;
 		}
 		if (wireEvent.type === "agent_settled") state = { ...state, isStreaming: false, retryAttempt: 0 };
@@ -476,7 +520,7 @@ function createRemoteSessionProxy(
 		const event = hydrateMessageUpdate(wireEvent, streamingAssistant);
 		for (const listener of listeners) listener(event);
 	});
-	const refresh = async (): Promise<void> => {
+	const performRefresh = async (): Promise<void> => {
 		const nextState = await client.getState();
 		state = { ...stateFromRpc(nextState) };
 		nextQueuedInputOrder = Math.max(0, ...nextState.ordered.map((item) => item.enqueueOrder));
@@ -504,6 +548,19 @@ function createRemoteSessionProxy(
 		}
 		local.agent.state.messages.splice(0, local.agent.state.messages.length, ...structuredClone(messages));
 		streamingAssistant = undefined;
+	};
+	// Refreshes must not interleave: each one reassigns sessionManager,
+	// settingsManager and the mirrored message list, so two in flight can commit a
+	// mixed snapshot of two different sessions. A replacement-driven refresh races
+	// exactly that way against a caller-driven one, so run them in order.
+	let refreshChain: Promise<void> = Promise.resolve();
+	const refresh = (): Promise<void> => {
+		const next = refreshChain.then(performRefresh, performRefresh);
+		refreshChain = next.then(
+			() => {},
+			() => {},
+		);
+		return next;
 	};
 	const session = new Proxy(local, {
 		get(target, property, receiver) {
@@ -766,6 +823,14 @@ function createRemoteSessionProxy(
 					);
 		},
 		refresh,
+		aroundLocalReplacement: async (body) => {
+			localReplacementDepth++;
+			try {
+				return await body();
+			} finally {
+				localReplacementDepth--;
+			}
+		},
 		abortLocalBash: () => localBashAbortController?.abort(),
 		createReplacedSessionContext: () => {
 			const context = local.createReplacedSessionContext();

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,25 @@
 # changes
 
+## 2026-08-30 - Expose session_replaced on the public client event union
+
+### What changed
+
+- `rpc-client.ts`: `RpcSessionReplacedEvent` joins the public `RpcClientEvent` union, so a typed client can discriminate `event.type === "session_replaced"` and read `durableSessionId` without casting. The runtime already forwarded the event through the unchecked `data as RpcClientEvent` cast in `handleFrame`, so it reached listeners untyped.
+- `rpc-client.ts`: `collectEvents()` excludes it alongside the other non-session events it already filtered. It returns `JsonAgentSessionEvent[]`, and a replacement notice is connection-level rather than part of the agent's event stream.
+
+### Why
+
+- The command response for a replacement carries only `{ cancelled }`, and a replacement can be driven by another attached client or by an extension, so this event is the only channel delivering the new identity. A client that cannot narrow to it cannot resync.
+
+### Why an extension could not handle it
+
+- The client event union is protocol surface beneath every extension hook.
+
+### Expected merge conflict zones
+
+- LOW: the `RpcClientEvent` union members and the `collectEvents()` filter.
+
+
 ## 2026-08-30 - Require agentDir for the RPC project-trust gate
 
 ## 2026-08-30 - Carry the replacement identity as durableSessionId
@@ -74,63 +94,6 @@
 ### Expected merge conflict zones
 
 - LOW: `defaultHostLaunch` in `host-ensure.ts`, the child spawn in `runHostSupervisor`, and the internal-route dispatch block in `main.ts`.
-
-## 2026-08-30 - Carry the session replacement identity under durableSessionId
-
-### What changed
-
-- `rpc-types.ts` / `connection-handler.ts`: `RpcSessionReplacedEvent` renames its identity field from `sessionId` to `durableSessionId`. Multi-session hosts tag every outbound record through `tagSessionRecord()`, which spreads `sessionId: routingSessionId` last, so the event's own identity was overwritten by the per-connection routing handle before it reached the wire.
-
-### Why
-
-- The command response for a replacement reports only `{ cancelled }`, so `session_replaced` is the only push channel carrying the new identity. An attached client that did not issue the replacement was told its binding moved but received the routing handle it already knew, leaving it no way to resync without guessing.
-
-### Why an extension could not handle it
-
-- The routing tag is applied by the connection handler beneath every extension hook; no extension can observe or reorder it.
-
-### Expected merge conflict zones
-
-- LOW: the `session_replaced` payload in `rebindSession()` and its wire type.
-
-
-## 2026-08-30 - Settle a deferred rebind before compacting
-
-### What changed
-
-- `connection-handler.ts`: the deferred rebind refresh started by `setRebindSession` is now retained in `pendingRebindRefresh`, and the `compact` command awaits it before calling `session.compact()`.
-
-### Why
-
-- A replacement acknowledges its command before extensions finish binding, by design: extensions may wait for session work the replacement still owns, so the derived-surface refresh runs out of band. Nothing tracked that detached promise, so it escaped the registry's lifecycle mutex. Extensions bind their tool activation during that window (`video-in` and `look-at` sync their tool against the new model's capabilities), and an active-tool change advances the context revision and aborts core compaction by design. A client issuing `compact` right after `switch_session` returned therefore raced the rebind and failed with "Compaction cancelled".
-
-### Why an extension could not handle it
-
-- The ordering between a command response and the out-of-band rebind is connection-handler scheduling; no extension hook observes the deferred refresh.
-
-### Expected merge conflict zones
-
-- LOW: the deferred branch of `rebindSession()` and the `compact` command case.
-
-
-## 2026-08-30 - Reschedule the retained-queue drain when an enqueue races its settling
-
-### What changed
-
-- `session-event-writer.ts`: `flush()` clears `drainPromise` from a `.then` reaction, so an `enqueue()` landing between `drainUntilEmpty()` resolving and that reaction observed a stale in-flight drain. `requestFlush()` then returned early and scheduled nothing, stranding every subsequent record in its retained queue. The settle reaction now reschedules a flush while ready queues remain.
-
-### Why
-
-- On lanes with no registered connection the records go to the retained session queues rather than to a per-connection sink actor, so nothing else ever rescued them: `open_session` responses flushed, and the prompt events that followed were enqueued and never written. `SocketEventSinkActor.drain()` already carried the same guard; the queue lane did not.
-
-### Why an extension could not handle it
-
-- The drain scheduler is internal writer machinery beneath the RPC transport; no extension hook observes or drives it.
-
-### Expected merge conflict zones
-
-- LOW: the drain settle reaction in `flush()`.
-
 
 ## 2026-08-30 - Reschedule the sink actor drain when an enqueue races its settling
 

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -75,6 +75,63 @@
 
 - LOW: `defaultHostLaunch` in `host-ensure.ts`, the child spawn in `runHostSupervisor`, and the internal-route dispatch block in `main.ts`.
 
+## 2026-08-30 - Carry the session replacement identity under durableSessionId
+
+### What changed
+
+- `rpc-types.ts` / `connection-handler.ts`: `RpcSessionReplacedEvent` renames its identity field from `sessionId` to `durableSessionId`. Multi-session hosts tag every outbound record through `tagSessionRecord()`, which spreads `sessionId: routingSessionId` last, so the event's own identity was overwritten by the per-connection routing handle before it reached the wire.
+
+### Why
+
+- The command response for a replacement reports only `{ cancelled }`, so `session_replaced` is the only push channel carrying the new identity. An attached client that did not issue the replacement was told its binding moved but received the routing handle it already knew, leaving it no way to resync without guessing.
+
+### Why an extension could not handle it
+
+- The routing tag is applied by the connection handler beneath every extension hook; no extension can observe or reorder it.
+
+### Expected merge conflict zones
+
+- LOW: the `session_replaced` payload in `rebindSession()` and its wire type.
+
+
+## 2026-08-30 - Settle a deferred rebind before compacting
+
+### What changed
+
+- `connection-handler.ts`: the deferred rebind refresh started by `setRebindSession` is now retained in `pendingRebindRefresh`, and the `compact` command awaits it before calling `session.compact()`.
+
+### Why
+
+- A replacement acknowledges its command before extensions finish binding, by design: extensions may wait for session work the replacement still owns, so the derived-surface refresh runs out of band. Nothing tracked that detached promise, so it escaped the registry's lifecycle mutex. Extensions bind their tool activation during that window (`video-in` and `look-at` sync their tool against the new model's capabilities), and an active-tool change advances the context revision and aborts core compaction by design. A client issuing `compact` right after `switch_session` returned therefore raced the rebind and failed with "Compaction cancelled".
+
+### Why an extension could not handle it
+
+- The ordering between a command response and the out-of-band rebind is connection-handler scheduling; no extension hook observes the deferred refresh.
+
+### Expected merge conflict zones
+
+- LOW: the deferred branch of `rebindSession()` and the `compact` command case.
+
+
+## 2026-08-30 - Reschedule the retained-queue drain when an enqueue races its settling
+
+### What changed
+
+- `session-event-writer.ts`: `flush()` clears `drainPromise` from a `.then` reaction, so an `enqueue()` landing between `drainUntilEmpty()` resolving and that reaction observed a stale in-flight drain. `requestFlush()` then returned early and scheduled nothing, stranding every subsequent record in its retained queue. The settle reaction now reschedules a flush while ready queues remain.
+
+### Why
+
+- On lanes with no registered connection the records go to the retained session queues rather than to a per-connection sink actor, so nothing else ever rescued them: `open_session` responses flushed, and the prompt events that followed were enqueued and never written. `SocketEventSinkActor.drain()` already carried the same guard; the queue lane did not.
+
+### Why an extension could not handle it
+
+- The drain scheduler is internal writer machinery beneath the RPC transport; no extension hook observes or drives it.
+
+### Expected merge conflict zones
+
+- LOW: the drain settle reaction in `flush()`.
+
+
 ## 2026-08-30 - Reschedule the sink actor drain when an enqueue races its settling
 
 - `socket-event-fanout.ts`: `SocketEventSinkActor.drain()` clears `draining` in a `.finally()` reaction. An `enqueue()` landing between the drain loop's exit and that reaction received the stale settled promise and started no new drain, leaving the record queued until the next unrelated enqueue rescued it — observed as targeted `open_session` responses reaching the client seconds late or not at all (`W-route` logged, `socket.write` never called). The `.finally()` now reschedules `drain()` when the queue is non-empty, so a racing record flushes immediately. Deterministic reproduction: `test/socket-event-fanout.test.ts`.

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -26,6 +26,7 @@ import type {
 	RpcProviderAccount,
 	RpcResponse,
 	RpcSessionModelEntry,
+	RpcSessionReplacedEvent,
 	RpcSessionState,
 	RpcSlashCommand,
 } from "./rpc-types.ts";
@@ -81,6 +82,12 @@ export type RpcClientEvent =
 	| RpcProviderAccountEvent
 	| RpcExtensionEvent
 	| RpcExtensionUIRequest
+	// The host swapped the live session behind this connection. Part of the public
+	// union so a typed client can discriminate on the type and read the new
+	// `durableSessionId` without casting: the command response carries only
+	// `{ cancelled }`, and a replacement may be driven by another client or an
+	// extension, so this is the only channel delivering the new identity.
+	| RpcSessionReplacedEvent
 	| { type: "bash_start" }
 	| { type: "bash_end" };
 export type RpcEventListener = (event: RpcClientEvent) => void;
@@ -846,7 +853,9 @@ export class RpcClient {
 					event.type === "extension_event" ||
 					event.type === "bash_start" ||
 					event.type === "bash_end" ||
-					event.type === "extension_ui_request"
+					event.type === "extension_ui_request" ||
+					// Connection-level, not part of the agent's event stream.
+					event.type === "session_replaced"
 				)
 					return;
 				events.push(event);

--- a/packages/coding-agent/test/interactive-host-session-replaced.test.ts
+++ b/packages/coding-agent/test/interactive-host-session-replaced.test.ts
@@ -1,0 +1,220 @@
+/**
+ * The shared-host proxy must re-read its binding when the host swaps the live
+ * session underneath it.
+ *
+ * A replacement can be driven by any other attached client, or by an extension
+ * that no client asked. The command response for one carries only
+ * `{ cancelled }`, so `session_replaced` is the only signal this connection
+ * gets. Without handling it the proxy keeps serving the previous session's
+ * manager, settings and message mirror while the host has already moved on.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { createRemoteSessionProxy } from "../src/modes/interactive/interactive-host-runtime.ts";
+import type { RpcClient } from "../src/modes/rpc/rpc-client.ts";
+
+const roots: string[] = [];
+
+afterEach(() => {
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function scratch(): { cwd: string; agentDir: string; sessionDir: string } {
+	const root = mkdtempSync(join(tmpdir(), "senpi-replaced-"));
+	roots.push(root);
+	const cwd = join(root, "cwd");
+	const agentDir = join(root, "agent");
+	const sessionDir = join(root, "sessions");
+	for (const dir of [cwd, agentDir, sessionDir]) mkdirSync(dir, { recursive: true });
+	return { cwd, agentDir, sessionDir };
+}
+
+function stateFor(manager: SessionManager, cwd: string) {
+	return {
+		thinkingLevel: "off" as const,
+		isStreaming: false,
+		isCompacting: false,
+		pendingMessageCount: 0,
+		usageTotals: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+		} as unknown as ReturnType<SessionManager["getUsageTotals"]>,
+		retryAttempt: 0,
+		isBashRunning: false,
+		sessionFile: manager.getSessionFile(),
+		sessionId: manager.getSessionId(),
+		sessionName: undefined,
+		cwd,
+		// The host ships the durable entries alongside the state; refresh() backfills
+		// them into a freshly opened manager whose file has not been flushed yet.
+		entries: manager.getEntries(),
+		projectTrusted: true,
+		fastMode: false,
+		steeringMode: "enabled" as AgentSession["steeringMode"],
+		followUpMode: "all" as AgentSession["followUpMode"],
+		autoCompactionEnabled: false,
+		favoriteModels: [],
+		scopedModels: [],
+		steering: [],
+		followUp: [],
+		ordered: [],
+	};
+}
+
+describe("shared-host proxy session replacement", () => {
+	it("refreshes its binding when the host reports a replacement", async () => {
+		const qa = scratch();
+		const first = SessionManager.create(qa.cwd, qa.sessionDir);
+		first.appendMessage({ role: "user", content: "first-session", timestamp: 1 });
+		const second = SessionManager.create(qa.cwd, qa.sessionDir);
+		second.appendMessage({ role: "user", content: "second-session", timestamp: 2 });
+		expect(second.getSessionFile()).not.toBe(first.getSessionFile());
+
+		let listener: ((event: Record<string, unknown>) => void) | undefined;
+		let liveState = stateFor(first, qa.cwd);
+		let getStateCalls = 0;
+		const client = {
+			onEvent(next: (event: Record<string, unknown>) => void) {
+				listener = next;
+				return () => {};
+			},
+			async getState() {
+				getStateCalls++;
+				return liveState;
+			},
+			async getMessages() {
+				return [];
+			},
+		} as unknown as RpcClient;
+
+		const mirrored: AgentSession["messages"] = [];
+		const local = {
+			sessionManager: first,
+			agent: { state: { messages: mirrored } },
+		} as unknown as AgentSession;
+
+		const proxy = createRemoteSessionProxy(local, qa.agentDir, client, stateFor(first, qa.cwd));
+		expect(proxy.session.sessionManager.getSessionFile()).toBe(first.getSessionFile());
+
+		// The host has moved to the second session and announces it. This connection
+		// never issued the replacement.
+		liveState = stateFor(second, qa.cwd);
+		listener?.({
+			type: "session_replaced",
+			durableSessionId: second.getSessionId(),
+			sessionFile: second.getSessionFile(),
+			cwd: qa.cwd,
+		});
+
+		// Refreshes are serialized, so awaiting an explicit one settles the
+		// replacement-driven refresh first. No microtask counting, no sleeps.
+		await proxy.refresh();
+
+		// Two refreshes ran: the one the event triggered, then this explicit one.
+		// Without the event handler only the explicit refresh happens, so this is the
+		// assertion that distinguishes handling the event from ignoring it.
+		expect(getStateCalls).toBe(2);
+		// ...and the binding actually moved: manager, and the mirrored transcript.
+		expect(proxy.session.sessionManager.getSessionFile()).toBe(second.getSessionFile());
+		expect(mirrored.map((message) => (message.role === "user" ? message.content : undefined))).toEqual([
+			"second-session",
+		]);
+	});
+
+	it("ignores the replacement echo for a replacement this runtime is driving", async () => {
+		// A multi-session host broadcasts session_replaced to every connection,
+		// including the one that issued the replacement. That connection's own
+		// newSession/switchSession/fork already run an ordered refresh/rebind -
+		// newSession transports setup entries between two refreshes - so a refresh
+		// fired from the echo would race that sequence and read host state before
+		// the setup entries land.
+		const qa = scratch();
+		const only = SessionManager.create(qa.cwd, qa.sessionDir);
+		only.appendMessage({ role: "user", content: "only-session", timestamp: 1 });
+
+		let listener: ((event: Record<string, unknown>) => void) | undefined;
+		let getStateCalls = 0;
+		const client = {
+			onEvent(next: (event: Record<string, unknown>) => void) {
+				listener = next;
+				return () => {};
+			},
+			async getState() {
+				getStateCalls++;
+				return stateFor(only, qa.cwd);
+			},
+			async getMessages() {
+				return [];
+			},
+		} as unknown as RpcClient;
+
+		const local = {
+			sessionManager: only,
+			agent: { state: { messages: [] as AgentSession["messages"] } },
+		} as unknown as AgentSession;
+
+		const proxy = createRemoteSessionProxy(local, qa.agentDir, client, stateFor(only, qa.cwd));
+
+		let echoedInside = false;
+		await proxy.aroundLocalReplacement(async () => {
+			// The host's echo lands while the runtime owns the sequence.
+			listener?.({
+				type: "session_replaced",
+				durableSessionId: only.getSessionId(),
+				sessionFile: only.getSessionFile(),
+				cwd: qa.cwd,
+			});
+			echoedInside = true;
+			// The caller owns refresh ordering for its own replacement.
+			await proxy.refresh();
+		});
+
+		expect(echoedInside).toBe(true);
+		// Exactly the caller's own refresh; the echo added none.
+		expect(getStateCalls).toBe(1);
+	});
+
+	it("keeps serving the bound session when no replacement is announced", async () => {
+		const qa = scratch();
+		const only = SessionManager.create(qa.cwd, qa.sessionDir);
+		only.appendMessage({ role: "user", content: "only-session", timestamp: 1 });
+
+		let listener: ((event: Record<string, unknown>) => void) | undefined;
+		let getStateCalls = 0;
+		const client = {
+			onEvent(next: (event: Record<string, unknown>) => void) {
+				listener = next;
+				return () => {};
+			},
+			async getState() {
+				getStateCalls++;
+				return stateFor(only, qa.cwd);
+			},
+			async getMessages() {
+				return [];
+			},
+		} as unknown as RpcClient;
+
+		const local = {
+			sessionManager: only,
+			agent: { state: { messages: [] as AgentSession["messages"] } },
+		} as unknown as AgentSession;
+
+		const proxy = createRemoteSessionProxy(local, qa.agentDir, client, stateFor(only, qa.cwd));
+
+		// An unrelated event must not trigger a rebind.
+		listener?.({ type: "agent_settled" });
+		await proxy.refresh();
+
+		expect(getStateCalls).toBe(1);
+		expect(proxy.session.sessionManager.getSessionFile()).toBe(only.getSessionFile());
+	});
+});

--- a/packages/coding-agent/test/rpc-session-replaced-contract.test.ts
+++ b/packages/coding-agent/test/rpc-session-replaced-contract.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Client-side contract for the session replacement event.
+ *
+ * `session_replaced` is the only push channel carrying the identity of a session
+ * that was swapped behind an attached connection, so a typed client has to be
+ * able to discriminate it off `RpcClientEvent` and read `durableSessionId`
+ * without casting. These pins are as much a typecheck as a runtime assertion:
+ * the discrimination below does not compile while the event is missing from the
+ * union.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { RpcClientEvent } from "../src/modes/rpc/rpc-client.ts";
+import type { RpcSessionReplacedEvent } from "../src/modes/rpc/rpc-types.ts";
+
+describe("session_replaced client contract", () => {
+	it("is a member of the RpcClientEvent union", () => {
+		const replaced: RpcSessionReplacedEvent = {
+			type: "session_replaced",
+			durableSessionId: "01a05196-f9b3-7367-adb6-9b3136ef1582",
+			sessionFile: "/tmp/session.jsonl",
+			cwd: "/tmp",
+			sessionName: "replacement",
+		};
+
+		// Fails to compile when the event is absent from the union, which is the
+		// state this pin exists to prevent.
+		const event: RpcClientEvent = replaced;
+
+		expect(event.type).toBe("session_replaced");
+	});
+
+	it("narrows to the replacement identity on the type discriminant", () => {
+		const events: RpcClientEvent[] = [
+			{ type: "bash_start" },
+			{
+				type: "session_replaced",
+				durableSessionId: "durable-1",
+				cwd: "/workspace",
+			},
+		];
+
+		const identities: string[] = [];
+		for (const event of events) {
+			// No cast: `durableSessionId` has to be reachable through the discriminant
+			// alone, otherwise a typed client cannot resync after a replacement it did
+			// not issue.
+			if (event.type === "session_replaced") identities.push(event.durableSessionId);
+		}
+
+		expect(identities).toEqual(["durable-1"]);
+	});
+});

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { createConnection, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Readable } from "node:stream";
+import { PassThrough, type Readable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseArgs } from "../src/cli/args.ts";
 import { attachJsonlLineReader } from "../src/modes/rpc/jsonl.ts";
@@ -54,7 +54,7 @@ class JsonlPeer {
 	waitFor(predicate: (value: RecordValue) => boolean, timeoutMs = 15_000): Promise<RecordValue> {
 		const existing = this.messages.find(predicate);
 		if (existing) return Promise.resolve(existing);
-		return new Promise((resolve, reject) => {
+		const pending = new Promise<RecordValue>((resolve, reject) => {
 			const waiter = {
 				predicate,
 				resolve,
@@ -66,6 +66,15 @@ class JsonlPeer {
 			};
 			this.waiters.add(waiter);
 		});
+		// Callers arm a waiter BEFORE the command that triggers it and await it only
+		// after that command returns, so anything rejecting in between - the timeout
+		// or close() during teardown - rejects a promise with no handler attached
+		// yet. Node then reports an unhandled rejection blamed on whichever test
+		// happened to be running when the timer fired. Marking the promise handled at
+		// creation closes that window for good; the rejection still propagates to the
+		// eventual awaiter, so failures are surfaced rather than swallowed.
+		pending.catch(() => {});
+		return pending;
 	}
 
 	close(): void {
@@ -223,6 +232,71 @@ function normalizeResponse(value: RecordValue): RecordValue {
 	}
 	return clone;
 }
+
+/**
+ * Observe whether Node reports an unhandled rejection while `body` runs.
+ *
+ * Subscribes before triggering, then waits for either the rejection event or a
+ * bounded deadline, so the check never depends on a fixed sleep landing after
+ * the microtask checkpoint.
+ */
+async function unhandledRejectionDuring(body: () => void, settleMs = 250): Promise<unknown> {
+	let onUnhandled!: (reason: unknown) => void;
+	const observed = new Promise<unknown>((resolve) => {
+		onUnhandled = (reason: unknown) => resolve(reason);
+		process.on("unhandledRejection", onUnhandled);
+		setTimeout(() => resolve(undefined), settleMs);
+	});
+	try {
+		body();
+		return await observed;
+	} finally {
+		process.off("unhandledRejection", onUnhandled);
+	}
+}
+
+describe("JSONL peer waiter lifecycle", () => {
+	// Every waiter in this suite is armed BEFORE the command that triggers it and
+	// awaited only after that command returns. Whatever rejects in that window -
+	// the timeout, or close() during teardown - rejects a promise nobody is
+	// holding yet. A longer timeout only narrows the window; the rejection must be
+	// handled from the moment the waiter exists.
+	it("does not surface an unhandled rejection when an armed waiter times out before it is awaited", async () => {
+		const peer = new JsonlPeer(new PassThrough(), () => {});
+		let pending!: Promise<RecordValue>;
+
+		const reason = await unhandledRejectionDuring(() => {
+			pending = peer.waitFor(() => false, 1);
+		});
+
+		expect(reason).toBeUndefined();
+		// The rejection still reaches the eventual awaiter; it is handled, not swallowed.
+		await expect(pending).rejects.toThrow(/Timed out waiting for RPC record/);
+	});
+
+	it("does not surface an unhandled rejection when close() settles an armed waiter", async () => {
+		const peer = new JsonlPeer(new PassThrough(), () => {});
+		let pending!: Promise<RecordValue>;
+
+		const reason = await unhandledRejectionDuring(() => {
+			pending = peer.waitFor(() => false, 60_000);
+			peer.close();
+		});
+
+		expect(reason).toBeUndefined();
+		await expect(pending).rejects.toThrow(/RPC peer closed/);
+	});
+
+	it("still resolves a waiter armed before the matching record arrives", async () => {
+		const stream = new PassThrough();
+		const peer = new JsonlPeer(stream, () => {});
+
+		const pending = peer.waitFor((value) => value.type === "late", 15_000);
+		stream.write(`${JSON.stringify({ type: "late", ok: true })}\n`);
+
+		expect(await pending).toMatchObject({ type: "late", ok: true });
+	});
+});
 
 describe("RPC Unix-socket multi-connection host", () => {
 	it("signals unsupported factory widgets while preserving array widgets", async () => {

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -257,16 +257,19 @@ describe("RPC Unix-socket multi-connection host", () => {
 		await waitForStderr(child, `senpi rpc listening on unix://${qa.socketPath}`);
 		const peer = await connectPeer(qa.socketPath);
 		try {
+			// Armed before open_session so neither request can be missed, but left on
+			// the default timeout: both only arrive after the session spawns and loads
+			// its extensions, which outruns a 1s budget on a loaded CI shard. A short
+			// deadline here rejected both waiters and surfaced as two unhandled
+			// rejections attributed to whichever test ran next.
 			const arrayWidget = peer.peer.waitFor(
 				(value) =>
 					value.type === "extension_ui_request" &&
 					value.method === "setWidget" &&
 					value.widgetKey === "array-widget",
-				1_000,
 			);
 			const unsupported = peer.peer.waitFor(
 				(value) => value.type === "extension_ui_request" && value.method === "custom_unsupported",
-				1_000,
 			);
 			const opened = await peer.peer.request({ id: "open", type: "open_session", cwd: qa.cwd });
 			const sessionId = openedSessionId(opened);

--- a/packages/coding-agent/test/rpc-wire-provenance.test.ts
+++ b/packages/coding-agent/test/rpc-wire-provenance.test.ts
@@ -140,7 +140,7 @@ describe("RPC wire provenance", () => {
 		const second = await newHarness();
 		const collected = makeSink();
 		const host = makeRuntimeHost(first.session);
-		const handler = createRpcConnectionHandler(host.runtimeHost, collected.sink);
+		const handler = createRpcConnectionHandler(host.runtimeHost, collected.sink, { sessionId: "rpc-attached" });
 		await handler.ready;
 
 		const replaced = collected.waitFor((record) => record.type === "session_replaced");

--- a/packages/coding-agent/test/rpc-wire-provenance.test.ts
+++ b/packages/coding-agent/test/rpc-wire-provenance.test.ts
@@ -140,7 +140,7 @@ describe("RPC wire provenance", () => {
 		const second = await newHarness();
 		const collected = makeSink();
 		const host = makeRuntimeHost(first.session);
-		const handler = createRpcConnectionHandler(host.runtimeHost, collected.sink, { sessionId: "rpc-attached" });
+		const handler = createRpcConnectionHandler(host.runtimeHost, collected.sink);
 		await handler.ready;
 
 		const replaced = collected.waitFor((record) => record.type === "session_replaced");
@@ -159,6 +159,32 @@ describe("RPC wire provenance", () => {
 			cwd: second.session.sessionManager.getCwd(),
 		});
 		expect(second.session.sessionId).not.toBe(first.session.sessionId);
+
+		await handler.dispose();
+	});
+
+	it("keeps the replacement identity intact on a routed multi-session connection", async () => {
+		const first = await newHarness();
+		const second = await newHarness();
+		const collected = makeSink();
+		const host = makeRuntimeHost(first.session);
+		// The lane the key separation exists for: only a routed connection tags every
+		// record with its per-connection handle, and tagSessionRecord() applies that
+		// tag last. Carrying the identity under `sessionId` would be overwritten here
+		// and nowhere else, so the classic case above cannot catch a regression.
+		const handler = createRpcConnectionHandler(host.runtimeHost, collected.sink, { sessionId: "rpc-attached" });
+		await handler.ready;
+
+		const replaced = collected.waitFor((record) => record.type === "session_replaced");
+		await host.replaceWith(second.session);
+
+		expect(await replaced).toMatchObject({
+			type: "session_replaced",
+			durableSessionId: second.session.sessionId,
+			// The routing handle still rides alongside, untouched by the identity.
+			sessionId: "rpc-attached",
+		});
+		expect(second.session.sessionId).not.toBe("rpc-attached");
 
 		await handler.dispose();
 	});


### PR DESCRIPTION
Fix the main-branch CI regression introduced by fb3279ba7.

- preserve classic RPC session rebinding without emitting shared-host routing events
- keep RPC session-state/output compatibility with lightweight runtimes
- reschedule queued event flushes after backpressure drains
- tolerate missing local bash cleanup and scope host UI dispatch to shared-host runtimes

Validation: targeted regression suite passes twice; full workspace build passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the main-branch CI regressions from the audit2 merge so classic RPC session rebinding works again, the shared interactive host stops serving stale sessions, and no session events get stranded.

- Renames the `session_replaced` identity field to `durableSessionId` so the per-connection `sessionId` routing tag can't overwrite it, and adds the event to the typed `RpcClientEvent` union.
- Refreshes the interactive shared-host proxy's binding on `session_replaced`, serializing refreshes and suppressing the echo of this runtime's own replacements, so it no longer serves the previous session's manager, settings, and transcript after another client or an extension replaces the session.
- Builds RPC session state with safe fallbacks for lightweight runtimes, makes `compact` await the deferred rebind, and restores the external-owner compaction notice.
- Reschedules the retained-queue drain when an enqueue races its settling, tolerates a missing `abortLocalBash` cleanup, scopes host UI dispatch to the shared-host lane, and hardens test peers by making waiters lifecycle-safe and dropping the widget pin's racing 1s timeout.

<sup>Written for commit 7b1af9a2d1c4b2401fb3e007b7f32c67805054c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

