### PR TITLE
fix(codemode): stop the js kernel transform from corrupting valid cells (interior comments + last-expression capture)

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -19,6 +19,11 @@
   `globalThis["jobs"] = {;`, failing cells with `Unexpected token ';'. Expected a property name.`),
   and no longer re-evaluates comment-bearing initializers when persisting bindings — such
   declarations are kept verbatim and their bindings persisted by reference.
+- Last-expression capture no longer inserts `return` before continuation lines (`else`/`catch`/`finally`
+  clauses and leading-`.`/operator method-chain lines), and now scans template literals (including
+  nested templates in interpolations), regexes, and comments with the same literal-aware scanner as
+  the persistence transform — fixing `return else …`, `return .replace(…)`, and mid-argument
+  `return )` corruption of valid cells.
 
 ### Removed
 

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 ### Fixed
 
+- The JavaScript kernel persistence transform no longer truncates declarations whose multi-line
+  initializers contain interior `//` comments (previously emitted unparseable code such as
+  `globalThis["jobs"] = {;`, failing cells with `Unexpected token ';'. Expected a property name.`),
+  and no longer re-evaluates comment-bearing initializers when persisting bindings — such
+  declarations are kept verbatim and their bindings persisted by reference.
+
 ### Removed
 
 ## [2026.8.29] - 2026-08-29

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -32,6 +32,9 @@
 - Destructuring patterns carrying interior line comments now persist their bindings, and declarations
   with a dangling trailing comma are left untransformed so the original syntax error surfaces instead
   of being silently "repaired".
+- Rewritten destructuring assignments are emitted with a leading defensive semicolon so they can no
+  longer ASI-merge into a preceding unterminated expression statement as a bogus call
+  (`foo()\n({…} = …)` previously became `foo()({…} = …)`).
 
 ### Removed
 

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -24,6 +24,14 @@
   nested templates in interpolations), regexes, and comments with the same literal-aware scanner as
   the persistence transform — fixing `return else …`, `return .replace(…)`, and mid-argument
   `return )` corruption of valid cells.
+- Last-expression capture now follows real ASI statement semantics: a parenthesized/bracketed/template
+  line after a closed block starts a new statement (echo restored), expressions split after a trailing
+  operator or `await` stay one statement, tagged templates split across lines invoke the tag, regexes
+  directly after a control-structure condition no longer desync the scanner, and labeled final
+  statements are left uncaptured instead of emitting invalid `return label: …`.
+- Destructuring patterns carrying interior line comments now persist their bindings, and declarations
+  with a dangling trailing comma are left untransformed so the original syntax error surfaces instead
+  of being silently "repaired".
 
 ### Removed
 

--- a/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
@@ -273,7 +273,7 @@ function rewriteDeclaration(code, declarationStart, start, end, keyword) {
 		if (target === undefined) return undefined;
 		const initializer = initializerStart < 0 ? "undefined" : segment.slice(initializerStart + 1).trim();
 		assignments.push(
-			`${target.startsWith("{") || target.startsWith("[") ? `(${target} = ${initializer})` : `${target} = ${initializer}`};`,
+			`${target.startsWith("{") || target.startsWith("[") ? `;(${target} = ${initializer})` : `${target} = ${initializer}`};`,
 		);
 	}
 	if (assignments.length === 0) return undefined;

--- a/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
@@ -258,7 +258,7 @@ function rewriteDeclaration(code, declarationStart, start, end, keyword) {
 	const preserveDeclaration = source.includes("//") || source.includes("/*");
 	for (const [segmentStart, segmentEnd] of splitDeclarators(code, start, end)) {
 		const segment = code.slice(segmentStart, segmentEnd);
-		if (!segment.trim()) continue;
+		if (!segment.trim()) return undefined;
 		const initializerStart = findTopLevelEquals(segment);
 		if (initializerStart < 0 && keyword === "const") return undefined;
 		const pattern = trimPattern(initializerStart < 0 ? segment : segment.slice(0, initializerStart));
@@ -410,6 +410,7 @@ function splitDeclarators(code, start, end) {
 		if (!/\s/u.test(char)) canStartRegex = isExpressionOperator(char) || char === "(" || char === "[" || char === "{";
 	}
 	if (segmentStart < end && code.slice(segmentStart, end).trim() !== ";") ranges.push([segmentStart, end - (code[end - 1] === ";" ? 1 : 0)]);
+	else if (ranges.length > 0 && code.slice(segmentStart, end).trim() !== ";") ranges.push([end, end]);
 	return ranges;
 }
 
@@ -505,8 +506,7 @@ function applyTextEdits(code, edits) {
 
 function trimPattern(source) {
 	let start = 0;
-	let end = source.length;
-	while (start < end) {
+	while (start < source.length) {
 		if (/\s/u.test(source[start])) {
 			start += 1;
 			continue;
@@ -521,12 +521,30 @@ function trimPattern(source) {
 		}
 		break;
 	}
-	while (true) {
-		while (end > start && /\s/u.test(source[end - 1])) end -= 1;
-		if (end < start + 2 || source.slice(end - 2, end) !== "*/") break;
-		const commentStart = source.lastIndexOf("/*", end - 2);
-		if (commentStart < start) break;
-		end = commentStart;
+	let end = start;
+	for (let index = start; index < source.length; index += 1) {
+		const char = source[index];
+		const next = source[index + 1];
+		if (/\s/u.test(char)) continue;
+		if (char === "/" && next === "/") {
+			index = skipLineComment(source, index) - 1;
+			continue;
+		}
+		if (char === "/" && next === "*") {
+			index = skipBlockComment(source, index) - 1;
+			continue;
+		}
+		if (char === "'" || char === '"') {
+			index = skipQuotedLiteral(source, index) - 1;
+			end = index + 1;
+			continue;
+		}
+		if (char === "`") {
+			index = skipTemplateLiteral(source, index) - 1;
+			end = index + 1;
+			continue;
+		}
+		end = index + 1;
 	}
 	return source.slice(start, end);
 }
@@ -694,11 +712,19 @@ function captureLastExpression(code) {
 	return `${head}return ${tail.replace(/;+$/u, "")};`;
 }
 
+const LABEL_PREFIX_RE = /^[\p{ID_Start}$_][\p{ID_Continue}\u200c\u200d$]*\s*:/u;
+
 function isStatementOnly(source) {
-	return /^(?:const|let|var|if|for|while|switch|try|catch|finally|class|function|import|export|throw|return|do|break|continue|debugger)\b/u.test(
-		source,
-	);
+	if (
+		/^(?:const|let|var|if|for|while|switch|try|catch|finally|class|function|import|export|throw|return|do|break|continue|debugger)\b/u.test(
+			source,
+		)
+	)
+		return true;
+	return LABEL_PREFIX_RE.test(source);
 }
+
+const CONTROL_PAREN_KEYWORDS = new Set(["catch", "for", "if", "switch", "while", "with"]);
 
 function findLastTopLevelStatementStart(code) {
 	let start = 0;
@@ -706,6 +732,9 @@ function findLastTopLevelStatementStart(code) {
 	let square = 0;
 	let curly = 0;
 	let canStartRegex = true;
+	let lastSignificant = "";
+	let pendingControlParen = false;
+	const controlParens = [];
 	for (let index = 0; index < code.length; index += 1) {
 		const char = code[index];
 		const next = code[index + 1];
@@ -717,50 +746,87 @@ function findLastTopLevelStatementStart(code) {
 			index = skipBlockComment(code, index) - 1;
 			continue;
 		}
-		if (char === "'" || char === '"') {
-			index = skipQuotedLiteral(code, index) - 1;
+		if (char === "'" || char === '"' || char === "`") {
+			index = (char === "`" ? skipTemplateLiteral(code, index) : skipQuotedLiteral(code, index)) - 1;
 			canStartRegex = false;
-			continue;
-		}
-		if (char === "`") {
-			index = skipTemplateLiteral(code, index) - 1;
-			canStartRegex = false;
+			lastSignificant = char;
+			pendingControlParen = false;
 			continue;
 		}
 		if (char === "/" && canStartRegex) {
 			index = skipRegexLiteral(code, index) - 1;
 			canStartRegex = false;
+			lastSignificant = char;
+			pendingControlParen = false;
 			continue;
 		}
 		if (isIdentifierStart(char)) {
 			const end = readIdentifier(code, index);
-			canStartRegex = REGEX_PREFIX_KEYWORDS.has(code.slice(index, end));
+			const token = code.slice(index, end);
+			canStartRegex = REGEX_PREFIX_KEYWORDS.has(token);
+			pendingControlParen = CONTROL_PAREN_KEYWORDS.has(token);
+			lastSignificant = code[end - 1];
 			index = end - 1;
 			continue;
 		}
 		if (isDecimalDigit(char)) {
 			index = skipNumberLiteral(code, index) - 1;
 			canStartRegex = false;
+			lastSignificant = char;
+			pendingControlParen = false;
 			continue;
 		}
-		if (char === "(") round += 1;
-		else if (char === ")") round = Math.max(0, round - 1);
-		else if (char === "[") square += 1;
-		else if (char === "]") square = Math.max(0, square - 1);
-		else if (char === "{") curly += 1;
-		else if (char === "}") curly = Math.max(0, curly - 1);
-		else if (char === ";" && round === 0 && square === 0 && curly === 0) {
+		if (char === "(") {
+			round += 1;
+			controlParens.push(pendingControlParen);
+			pendingControlParen = false;
+			canStartRegex = true;
+			lastSignificant = char;
+			continue;
+		}
+		if (char === ")") {
+			round = Math.max(0, round - 1);
+			canStartRegex = controlParens.pop() === true;
+			lastSignificant = char;
+			continue;
+		}
+		if (char === "[" || char === "{") {
+			if (char === "[") square += 1;
+			else curly += 1;
+			canStartRegex = true;
+			lastSignificant = char;
+			pendingControlParen = false;
+			continue;
+		}
+		if (char === "]" || char === "}") {
+			if (char === "]") square = Math.max(0, square - 1);
+			else curly = Math.max(0, curly - 1);
+			canStartRegex = false;
+			lastSignificant = char;
+			pendingControlParen = false;
+			continue;
+		}
+		if (char === ";" && round === 0 && square === 0 && curly === 0) {
 			const nextIndex = nextSignificantIndex(code, index + 1);
 			if (nextIndex < code.length && !isContinuationKeyword(code, nextIndex)) start = nextIndex;
 			canStartRegex = true;
+			lastSignificant = char;
+			pendingControlParen = false;
 			continue;
-		} else if (isLineTerminator(char) && round === 0 && square === 0 && curly === 0) {
-			const nextIndex = nextSignificantIndex(code, index + 1);
-			if (nextIndex < code.length && !isStatementContinuation(code, nextIndex)) start = nextIndex;
+		}
+		if (isLineTerminator(char) && round === 0 && square === 0 && curly === 0) {
+			if (!canStartRegex) {
+				const nextIndex = nextSignificantIndex(code, index + 1);
+				if (nextIndex < code.length && !isStatementContinuation(code, nextIndex, lastSignificant)) start = nextIndex;
+			}
 			canStartRegex = true;
 			continue;
 		}
-		if (!/\s/u.test(char)) canStartRegex = isExpressionOperator(char) || char === "(" || char === "[" || char === "{" || char === ",";
+		if (!/\s/u.test(char)) {
+			canStartRegex = isExpressionOperator(char) || char === ",";
+			lastSignificant = char;
+			pendingControlParen = false;
+		}
 	}
 	return start;
 }
@@ -772,8 +838,10 @@ function isContinuationKeyword(code, index) {
 	return STATEMENT_CONTINUATION_KEYWORDS.has(code.slice(index, readIdentifier(code, index)));
 }
 
-function isStatementContinuation(code, index) {
+function isStatementContinuation(code, index, previousChar) {
 	const char = code[index];
+	if (char === "(" || char === "[" || char === "`") return previousChar !== "}" && previousChar !== "";
+	if (char === "!" || char === "~") return false;
 	if (char !== undefined && isDeclarationContinuation(char)) return true;
 	return isContinuationKeyword(code, index);
 }

--- a/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
@@ -705,55 +705,75 @@ function findLastTopLevelStatementStart(code) {
 	let round = 0;
 	let square = 0;
 	let curly = 0;
-	let quote = "";
-	let escaped = false;
-	let lineComment = false;
-	let blockComment = false;
+	let canStartRegex = true;
 	for (let index = 0; index < code.length; index += 1) {
 		const char = code[index];
 		const next = code[index + 1];
-		if (lineComment) {
-			if (char === "\n") lineComment = false;
-			continue;
-		}
-		if (blockComment) {
-			if (char === "*" && next === "/") {
-				blockComment = false;
-				index += 1;
-			}
-			continue;
-		}
-		if (quote) {
-			if (escaped) {
-				escaped = false;
-			} else if (char === "\\") {
-				escaped = true;
-			} else if (char === quote) {
-				quote = "";
-			}
-			continue;
-		}
 		if (char === "/" && next === "/") {
-			lineComment = true;
-			index += 1;
+			index = skipLineComment(code, index) - 1;
 			continue;
 		}
 		if (char === "/" && next === "*") {
-			blockComment = true;
-			index += 1;
+			index = skipBlockComment(code, index) - 1;
 			continue;
 		}
-		if (char === "'" || char === '"' || char === "`") {
-			quote = char;
+		if (char === "'" || char === '"') {
+			index = skipQuotedLiteral(code, index) - 1;
+			canStartRegex = false;
+			continue;
+		}
+		if (char === "`") {
+			index = skipTemplateLiteral(code, index) - 1;
+			canStartRegex = false;
+			continue;
+		}
+		if (char === "/" && canStartRegex) {
+			index = skipRegexLiteral(code, index) - 1;
+			canStartRegex = false;
+			continue;
+		}
+		if (isIdentifierStart(char)) {
+			const end = readIdentifier(code, index);
+			canStartRegex = REGEX_PREFIX_KEYWORDS.has(code.slice(index, end));
+			index = end - 1;
+			continue;
+		}
+		if (isDecimalDigit(char)) {
+			index = skipNumberLiteral(code, index) - 1;
+			canStartRegex = false;
 			continue;
 		}
 		if (char === "(") round += 1;
-		else if (char === ")") round -= 1;
+		else if (char === ")") round = Math.max(0, round - 1);
 		else if (char === "[") square += 1;
-		else if (char === "]") square -= 1;
+		else if (char === "]") square = Math.max(0, square - 1);
 		else if (char === "{") curly += 1;
-		else if (char === "}") curly -= 1;
-		else if ((char === ";" || char === "\n") && round === 0 && square === 0 && curly === 0) start = index + 1;
+		else if (char === "}") curly = Math.max(0, curly - 1);
+		else if (char === ";" && round === 0 && square === 0 && curly === 0) {
+			const nextIndex = nextSignificantIndex(code, index + 1);
+			if (nextIndex < code.length && !isContinuationKeyword(code, nextIndex)) start = nextIndex;
+			canStartRegex = true;
+			continue;
+		} else if (isLineTerminator(char) && round === 0 && square === 0 && curly === 0) {
+			const nextIndex = nextSignificantIndex(code, index + 1);
+			if (nextIndex < code.length && !isStatementContinuation(code, nextIndex)) start = nextIndex;
+			canStartRegex = true;
+			continue;
+		}
+		if (!/\s/u.test(char)) canStartRegex = isExpressionOperator(char) || char === "(" || char === "[" || char === "{" || char === ",";
 	}
 	return start;
+}
+
+const STATEMENT_CONTINUATION_KEYWORDS = new Set(["catch", "else", "finally"]);
+
+function isContinuationKeyword(code, index) {
+	if (!isIdentifierStart(code[index])) return false;
+	return STATEMENT_CONTINUATION_KEYWORDS.has(code.slice(index, readIdentifier(code, index)));
+}
+
+function isStatementContinuation(code, index) {
+	const char = code[index];
+	if (char !== undefined && isDeclarationContinuation(char)) return true;
+	return isContinuationKeyword(code, index);
 }

--- a/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-indirect-eval.js
@@ -265,13 +265,15 @@ function rewriteDeclaration(code, declarationStart, start, end, keyword) {
 		const bindings = [];
 		collectPatternNames(pattern, bindings);
 		if (bindings.length === 0) return undefined;
+		if (preserveDeclaration) {
+			for (const name of bindings) assignments.push(`globalThis[${JSON.stringify(name)}] = ${name};`);
+			continue;
+		}
 		const target = rewriteBindingPattern(pattern);
 		if (target === undefined) return undefined;
 		const initializer = initializerStart < 0 ? "undefined" : segment.slice(initializerStart + 1).trim();
-		const [assignmentInitializer, comment] = splitTrailingLineComment(initializer);
-		const assignmentComment = preserveDeclaration ? "" : comment;
 		assignments.push(
-			`${target.startsWith("{") || target.startsWith("[") ? `(${target} = ${assignmentInitializer})` : `${target} = ${assignmentInitializer}`};${assignmentComment}`,
+			`${target.startsWith("{") || target.startsWith("[") ? `(${target} = ${initializer})` : `${target} = ${initializer}`};`,
 		);
 	}
 	if (assignments.length === 0) return undefined;
@@ -499,47 +501,6 @@ function applyTextEdits(code, edits) {
 		output = output.slice(0, edit.start) + edit.text + output.slice(edit.end);
 	}
 	return output;
-}
-
-function splitTrailingLineComment(source) {
-	let canStartRegex = true;
-	for (let index = 0; index < source.length; index += 1) {
-		const char = source[index];
-		const next = source[index + 1];
-		if (char === "/" && next === "/") return [source.slice(0, index).trimEnd(), source.slice(index)];
-		if (char === "/" && next === "*") {
-			index = skipBlockComment(source, index) - 1;
-			continue;
-		}
-		if (char === "'" || char === '"') {
-			index = skipQuotedLiteral(source, index) - 1;
-			canStartRegex = false;
-			continue;
-		}
-		if (char === "`") {
-			index = skipTemplateLiteral(source, index) - 1;
-			canStartRegex = false;
-			continue;
-		}
-		if (char === "/" && canStartRegex) {
-			index = skipRegexLiteral(source, index) - 1;
-			canStartRegex = false;
-			continue;
-		}
-		if (isIdentifierStart(char)) {
-			const end = readIdentifier(source, index);
-			canStartRegex = REGEX_PREFIX_KEYWORDS.has(source.slice(index, end));
-			index = end - 1;
-			continue;
-		}
-		if (isDecimalDigit(char)) {
-			index = skipNumberLiteral(source, index) - 1;
-			canStartRegex = false;
-			continue;
-		}
-		if (!/\s/u.test(char)) canStartRegex = isExpressionOperator(char) || char === "(" || char === "[" || char === "{";
-	}
-	return [source, ""];
 }
 
 function trimPattern(source) {

--- a/packages/senpi-codemode/test/kernel-js-last-expression.test.ts
+++ b/packages/senpi-codemode/test/kernel-js-last-expression.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { parseJavaScriptResult, runJavaScriptCell, withJavaScriptKernel } from "./eval/js-kernel-harness.ts";
+
+describe("JavaScript kernel last-expression capture", () => {
+	it("captures a parenthesized expression statement after a completed block", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, "if (true) {}\n(42)");
+
+			expect(parseJavaScriptResult(run.result)).toBe(42);
+		});
+	});
+
+	it("echoes final declarations identically with and without trailing comments", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const uncommented = await runJavaScriptCell(kernel, "const captureFinalPlain = 9");
+			const commented = await runJavaScriptCell(kernel, "const captureFinalCommented = 7 // note");
+
+			expect(parseJavaScriptResult(uncommented.result)).toBe(9);
+			expect(parseJavaScriptResult(commented.result)).toBe(7);
+		});
+	});
+
+	it("keeps a division continuation split across lines as one statement", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, "const captureDivBase = 8;\ncaptureDivBase /\n2");
+
+			expect(parseJavaScriptResult(run.result)).toBe(4);
+		});
+	});
+
+	it("keeps an await operand on the next line as one statement", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, "await\nPromise.resolve(42)");
+
+			expect(parseJavaScriptResult(run.result)).toBe(42);
+		});
+	});
+
+	it("invokes tagged templates split across lines", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, "const captureTag = () => 123;\ncaptureTag\n`raw`");
+
+			expect(parseJavaScriptResult(run.result)).toBe(123);
+		});
+	});
+
+	it("captures the last expression after a regex following a control condition", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, 'if (true) /[(]/.test("(")\n42');
+
+			expect(parseJavaScriptResult(run.result)).toBe(42);
+		});
+	});
+
+	it("runs labeled final statements without capturing them", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, "captureLabel: { break captureLabel; }");
+
+			expect(run.result.ok).toBe(true);
+		});
+	});
+});

--- a/packages/senpi-codemode/test/kernel-js-persistence.test.ts
+++ b/packages/senpi-codemode/test/kernel-js-persistence.test.ts
@@ -292,6 +292,26 @@ footer\`)`,
 		});
 	});
 
+	it("persists bindings whose pattern carries an interior line comment", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			await runJavaScriptCell(
+				kernel,
+				"const { persistenceCommentedBinding // note\n} = { persistenceCommentedBinding: 7 };",
+			);
+			const run = await runJavaScriptCell(kernel, "return persistenceCommentedBinding");
+
+			expect(parseJavaScriptResult(run.result)).toBe(7);
+		});
+	});
+
+	it("rejects declarations with a dangling trailing comma", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(kernel, "const persistenceDangling = 1,");
+
+			expect(run.result.ok).toBe(false);
+		});
+	});
+
 	it("captures the last expression after nested template literals in interpolations", async () => {
 		await withJavaScriptKernel(async (kernel) => {
 			const run = await runJavaScriptCell(

--- a/packages/senpi-codemode/test/kernel-js-persistence.test.ts
+++ b/packages/senpi-codemode/test/kernel-js-persistence.test.ts
@@ -186,4 +186,76 @@ footer\`)`,
 			expect(parseJavaScriptResult(run.result)).toBe(2);
 		});
 	});
+
+	it("persists object-literal declarations containing interior line comments", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const first = await runJavaScriptCell(
+				kernel,
+				`const persistenceCommentedObject = {
+		  // interior comment
+		  value: 41,
+		}
+		return persistenceCommentedObject.value`,
+			);
+			const second = await runJavaScriptCell(kernel, "return persistenceCommentedObject.value + 1");
+
+			expect(parseJavaScriptResult(first.result)).toBe(41);
+			expect(parseJavaScriptResult(second.result)).toBe(42);
+		});
+	});
+
+	it("persists arrow-function declarations containing interior comments", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const first = await runJavaScriptCell(
+				kernel,
+				`const persistenceCommentedArrow = () => {
+		  // helper note
+		  return 20
+		}
+		return persistenceCommentedArrow() + 1`,
+			);
+			const second = await runJavaScriptCell(kernel, "return persistenceCommentedArrow() + 2");
+
+			expect(parseJavaScriptResult(first.result)).toBe(21);
+			expect(parseJavaScriptResult(second.result)).toBe(22);
+		});
+	});
+
+	it("evaluates initializers with trailing comments exactly once", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			await runJavaScriptCell(kernel, "var persistenceEvalCount = 0");
+			const declared = await runJavaScriptCell(
+				kernel,
+				"const persistenceCountedValue = (persistenceEvalCount += 1) // trailing note\nreturn persistenceCountedValue",
+			);
+			const counted = await runJavaScriptCell(kernel, "return persistenceEvalCount");
+
+			expect(parseJavaScriptResult(declared.result)).toBe(1);
+			expect(parseJavaScriptResult(counted.result)).toBe(1);
+		});
+	});
+
+	it("persists destructured bindings declared with trailing comments", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			await runJavaScriptCell(
+				kernel,
+				"const { persistenceCommentedA, renamed: persistenceCommentedB } = { persistenceCommentedA: 1, renamed: 2 } // note",
+			);
+			const run = await runJavaScriptCell(kernel, "return [persistenceCommentedA, persistenceCommentedB]");
+
+			expect(parseJavaScriptResult(run.result)).toEqual([1, 2]);
+		});
+	});
+
+	it("persists multi-declarator declarations containing block comments", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			await runJavaScriptCell(
+				kernel,
+				"const persistenceMultiFirst = 1, persistenceMultiSecond = { /* block */ value: 2 }",
+			);
+			const run = await runJavaScriptCell(kernel, "return [persistenceMultiFirst, persistenceMultiSecond.value]");
+
+			expect(parseJavaScriptResult(run.result)).toEqual([1, 2]);
+		});
+	});
 });

--- a/packages/senpi-codemode/test/kernel-js-persistence.test.ts
+++ b/packages/senpi-codemode/test/kernel-js-persistence.test.ts
@@ -304,6 +304,22 @@ footer\`)`,
 		});
 	});
 
+	it("emits destructuring assignments that cannot merge with the previous expression statement", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(
+				kernel,
+				[
+					"var persistenceAsiPrev = [0]",
+					"persistenceAsiPrev.pop()",
+					"const { length: persistenceAsiLen } = []",
+					"persistenceAsiLen",
+				].join("\n"),
+			);
+
+			expect(parseJavaScriptResult(run.result)).toBe(0);
+		});
+	});
+
 	it("rejects declarations with a dangling trailing comma", async () => {
 		await withJavaScriptKernel(async (kernel) => {
 			const run = await runJavaScriptCell(kernel, "const persistenceDangling = 1,");

--- a/packages/senpi-codemode/test/kernel-js-persistence.test.ts
+++ b/packages/senpi-codemode/test/kernel-js-persistence.test.ts
@@ -258,4 +258,54 @@ footer\`)`,
 			expect(parseJavaScriptResult(run.result)).toEqual([1, 2]);
 		});
 	});
+
+	it("runs cells whose final statement is an else clause on its own line", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const first = await runJavaScriptCell(
+				kernel,
+				[
+					"var persistenceBranchValue = 0",
+					"if (persistenceBranchValue) { persistenceBranchValue = 1 }",
+					"else persistenceBranchValue = 2",
+				].join("\n"),
+			);
+			const run = await runJavaScriptCell(kernel, "return persistenceBranchValue");
+
+			expect(first.result.ok).toBe(true);
+			expect(parseJavaScriptResult(run.result)).toBe(2);
+		});
+	});
+
+	it("keeps continuation-line method chains inside the captured last statement", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(
+				kernel,
+				[
+					'var persistenceChained = "a-b"',
+					'persistenceChained = persistenceChained.replace("a", "x")',
+					'.replace(/b|\\(/g, "y")',
+					"persistenceChained",
+				].join("\n"),
+			);
+
+			expect(parseJavaScriptResult(run.result)).toBe("x-y");
+		});
+	});
+
+	it("captures the last expression after nested template literals in interpolations", async () => {
+		await withJavaScriptKernel(async (kernel) => {
+			const run = await runJavaScriptCell(
+				kernel,
+				[
+					"var persistenceQuoted = `$" + '{"x".replace("x", `)`)}`',
+					'var persistenceJoined = ["a", persistenceQuoted].join(',
+					'\t"-",',
+					")",
+					"persistenceJoined",
+				].join("\n"),
+			);
+
+			expect(parseJavaScriptResult(run.result)).toBe("a-)");
+		});
+	});
 });


### PR DESCRIPTION
## Problem

Sessions on current builds keep losing whole eval cells to kernel-side parse mangling. Sweeping every senpi session store found 45 genuine eval parse-failure cells; 24 of them contained VALID user code corrupted by `wrapUserCode`, in two distinct defect classes (the other 21 are author syntax errors, correctly rejected):

**Class 1 - interior-comment truncation (persistence transform).** `splitTrailingLineComment` treated the FIRST `//` anywhere in a multi-line initializer as a trailing comment, so

```js
const jobs = {
  // note
  a: 1,
}
```

was persisted as `globalThis["jobs"] = {;` -> `Unexpected token ';'. Expected a property name.` The comment-preserving path also re-evaluated the initializer, duplicating side effects (proven by a RED test observing a counter increment twice).

**Class 2 - naive last-expression scanner (`findLastTopLevelStatementStart`).** It had its own weak lexer: no regex-literal handling, no `${}` interpolation handling (a nested template desyncs its quote state), and it treated EVERY top-level newline as a statement boundary. Corruptions observed in real sessions: `return else console.log(...)`, `return .replace(/.../g, ...)` mid-cell after a regex froze its depth counters, and `return )` injected inside a call argument list after a nested-template desync.

## Fix

- Class 1: comment-bearing declarations keep their source verbatim and persist each collected binding **by reference** (`globalThis["name"] = name;`) instead of re-evaluating the initializer; `splitTrailingLineComment` is deleted (the comment-free path cannot contain line comments).
- Class 2: `findLastTopLevelStatementStart` is rewritten on the same literal-aware skip helpers used by the persistence transform (comments, quoted strings, templates incl. nested interpolations, regex literals with `canStartRegex` tracking), and boundaries now respect statement continuations: `;` boundaries skip `else`/`catch`/`finally`, newline (ASI) boundaries additionally skip continuation characters (`.`, operators, `(`, `[`), matching real JS semantics.

## Verification

- RED -> GREEN at the kernel harness: 6 new tests captured failing first (3 for class 1 incl. the exact production errors and the double-evaluation counter, 3 for class 2 reproducing `return else` / `return .replace` / `return )`), all green post-fix. `kernel-js-persistence.test.ts` 17/17.
- Session corpus replay: all 24 valid-code failing cells now transform to parseable output; all 21 author-error cells still correctly rejected (no false acceptance).
- `npm run check` (root): PASS (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, tsc, browser-smoke) - runs in the pre-commit hook of each commit.
- Distributed validation: full root vitest on mengmotaMac (18-core), linux codemode suite on gorky (node 24), sanitized-env codemode suite locally - results posted in PR comments.

## Note

`worker-indirect-eval.js` was already ~761 pure LOC before this PR (3x the 250 ceiling); this PR reduces it (~735) but the file remains an architectural smell - splitting the transform into scanner/persistence/capture modules is follow-up work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the JavaScript kernel transform corrupting valid cells: comment-bearing declarations were truncated into unparseable output (e.g. `globalThis["jobs"] = {;`), last-expression capture injected `return` mid-statement, and rewritten destructuring assignments could ASI-merge into a preceding expression as a bogus call. Declarations now persist by reference, and capture follows real ASI semantics.

**Bug Fixes**
- Comment-bearing declarations (including destructured patterns with interior comments) are kept verbatim and persisted by reference, so initializers no longer re-evaluate; dangling trailing commas are left untransformed so the real syntax error surfaces.
- Capture now follows real ASI semantics: it skips comments, strings, templates (including nested interpolations), and regexes, keeps continuation lines (`else`/`catch`/`finally`, leading-`.`, trailing operators, `await`) inside the captured statement, restores echo after closed blocks, and leaves labels uncaptured.
- Rewritten destructuring assignments now emit a leading defensive semicolon so they can't merge into a preceding unterminated expression statement.
- Added 18 kernel tests covering the exact production failures, including double evaluation and ASI call merging.

<sup>Written for commit d7e68287ef8fef1841d0f0a815bdd4df835da217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

