### PR TITLE
fix(test): quarantine every brand agent-dir env var in the vitest suite

### DIFF
--- a/packages/coding-agent/test/setup-quarantine.test.ts
+++ b/packages/coding-agent/test/setup-quarantine.test.ts
@@ -1,6 +1,6 @@
 import { tmpdir } from "node:os";
 import { describe, expect, test } from "vitest";
-import { getAgentDir } from "../src/config.ts";
+import { getAgentDir, getPackageDir } from "../src/config.ts";
 import { resetBrandProfileForTests } from "../src/core/brand.ts";
 import { resolveQuarantineAgentDir, scrubAmbientAgentDirEnv } from "./support/quarantine.ts";
 
@@ -8,6 +8,9 @@ const AMBIENT_AGENT_DIR_KEYS = [
 	"OMO_CODING_AGENT_DIR",
 	"SENPI_CODING_AGENT_DIR",
 	"PI_CODING_AGENT_DIR",
+	"OMO_PACKAGE_DIR",
+	"SENPI_PACKAGE_DIR",
+	"PI_PACKAGE_DIR",
 	"SENPI_BRAND",
 ] as const;
 
@@ -18,6 +21,9 @@ function saveAndPoisonEnv(realDir: string): Record<string, string | undefined> {
 	}
 	process.env.OMO_CODING_AGENT_DIR = realDir;
 	process.env.SENPI_CODING_AGENT_DIR = realDir;
+	process.env.OMO_PACKAGE_DIR = "/installed/omo";
+	process.env.SENPI_PACKAGE_DIR = "/installed/senpi";
+	process.env.PI_PACKAGE_DIR = "/installed/pi";
 	process.env.SENPI_BRAND = JSON.stringify({ name: "omo", configDir: ".omo", envPrefix: "OMO" });
 	resetBrandProfileForTests();
 	return saved;
@@ -65,6 +71,10 @@ describe("test quarantine resolver", () => {
 			SENPI_CODING_AGENT_DIR: "/real",
 			PI_CODING_AGENT_DIR: "/real",
 			TAU_CODING_AGENT_DIR: "/real",
+			OMO_PACKAGE_DIR: "/installed/omo",
+			SENPI_PACKAGE_DIR: "/installed/senpi",
+			PI_PACKAGE_DIR: "/installed/pi",
+			TAU_PACKAGE_DIR: "/installed/tau",
 			SENPI_BRAND: "{}",
 			UNRELATED: "keep",
 		};
@@ -90,8 +100,10 @@ describe("test quarantine resolver", () => {
 
 			// Proof the setup module re-executed and quarantined the SENPI_ lane.
 			expect(process.env.SENPI_CODING_AGENT_DIR).toContain(tmpdir());
-			// The regression: no brand/agent-dir lane may leak the real directory through.
+			// The regression: no brand/agent-dir lane may leak the real directory through, and no
+			// package-dir lane may redirect asset resolution to an installed runtime.
 			expect(getAgentDir()).not.toBe(realDir);
+			expect(getPackageDir()).toBe(process.cwd());
 		} finally {
 			restoreEnv(saved);
 		}

--- a/packages/coding-agent/test/setup.ts
+++ b/packages/coding-agent/test/setup.ts
@@ -1,6 +1,7 @@
 /**
- * Vitest setup: quarantine SENPI_CODING_AGENT_DIR so the test suite never
- * writes session JSONLs into the user's real `~/.senpi/agent/sessions/`.
+ * Vitest setup: quarantine inherited branded agent/package directory overrides so the test suite
+ * never writes session JSONLs into the user's real `~/.senpi/agent/sessions/` or loads assets from
+ * an installed runtime instead of this checkout.
  *
  * Many tests call `SessionManager.create(tempDir)` without an explicit
  * sessionDir. That falls back to `getDefaultSessionDir(cwd)` → `getAgentDir()`,
@@ -17,8 +18,8 @@ for (const key of ["PI_RULES_DISABLED", "PI_RULES_MAX_RULE_CHARS", "PI_RULES_MAX
 const quarantineAgentDir = resolveQuarantineAgentDir(process.env);
 if (quarantineAgentDir) {
 	// Resolve BEFORE scrubbing so the SENPI_TEST_USE_REAL_AGENT_DIR=1 opt-in still reads its
-	// target; scrubbing then removes the brand marker and every other agent-dir lane, so no
-	// ambient `OMO_`/`PI_` (or future-brand) override can outrank the quarantined value below.
+	// target; scrubbing then removes the brand marker and every other branded override, so no
+	// ambient `OMO_`/`PI_` (or future-brand) value can affect config or asset resolution below.
 	scrubAmbientAgentDirEnv(process.env);
 	process.env.SENPI_CODING_AGENT_DIR = quarantineAgentDir;
 }

--- a/packages/coding-agent/test/support/quarantine.ts
+++ b/packages/coding-agent/test/support/quarantine.ts
@@ -16,23 +16,25 @@ import { join } from "node:path";
 
 /** Env var suffix every brand uses for its agent-state directory override. */
 const AGENT_DIR_ENV_SUFFIX = "_CODING_AGENT_DIR";
+const PACKAGE_DIR_ENV_SUFFIX = "_PACKAGE_DIR";
 
 /** Brand marker deciding which env lane wins in `brandEnvNames` (`OMO_` before `SENPI_`/`PI_`). */
 const BRAND_ENV_VAR = "SENPI_BRAND";
 
 /**
- * Remove every ambient agent-directory lane and the brand marker from `env`.
+ * Remove every ambient agent-directory/package-directory lane and the brand marker from `env`.
  *
  * Quarantining only `SENPI_CODING_AGENT_DIR` is not enough: the omo launcher exports
  * `OMO_CODING_AGENT_DIR` and `SENPI_BRAND` to every session, tool children inherit both, and
- * with the omo brand active `brandEnvNames` resolves the `OMO_` lane first — so `getAgentDir()`
- * returned the real `~/.omo/agent` inside the suite and `settings-tips.test.ts` wiped the live
- * settings.json on 2026-08-25. Deleting the marker plus every `*_CODING_AGENT_DIR` lane (any
- * current or future brand) makes the quarantined `SENPI_` lane the only possible answer.
+ * with the omo brand active `brandEnvNames` resolves the `OMO_` lane first. The launcher also
+ * exports `SENPI_PACKAGE_DIR`/`OMO_PACKAGE_DIR`; `config.ts` reads that override before locating
+ * package assets, so leaving it in place makes tests load files from the installed runtime.
+ * Deleting the marker plus every branded `*_CODING_AGENT_DIR` and `*_PACKAGE_DIR` lane (any
+ * current or future brand) keeps the suite rooted in its checked-out package.
  */
 export function scrubAmbientAgentDirEnv(env: NodeJS.ProcessEnv = process.env): void {
 	for (const key of Object.keys(env)) {
-		if (key.endsWith(AGENT_DIR_ENV_SUFFIX)) {
+		if (key.endsWith(AGENT_DIR_ENV_SUFFIX) || key.endsWith(PACKAGE_DIR_ENV_SUFFIX)) {
 			delete env[key];
 		}
 	}


### PR DESCRIPTION
## Problem
Vitest runs launched from an omo session inherit branded environment overrides. `SENPI_CODING_AGENT_DIR` and `OMO_CODING_AGENT_DIR` could point tests at the real agent state, while `SENPI_PACKAGE_DIR`/`OMO_PACKAGE_DIR` redirected `src/config.ts` asset resolution into the installed omo runtime. The latter caused the focused TUI regressions to load missing theme files from `/Users/yeongyu/.omo/binary-runtime/...`.

## Fix
- Scrub every current and future-brand `*_CODING_AGENT_DIR` and `*_PACKAGE_DIR` lane plus `SENPI_BRAND` in the Vitest setup boundary.
- Preserve `SENPI_TEST_USE_REAL_AGENT_DIR=1` exactly.
- Extend the quarantine regression to assert the package root remains the checkout and to cover all enumerated brand lanes (SENPI, OMO, PI, plus sibling/future prefixes).

Root cause: `packages/coding-agent/src/config.ts:400-414` reads `envValue("PACKAGE_DIR")` before package asset resolution; `packages/coding-agent/src/modes/interactive/theme/theme.ts:479` then reads the redirected theme path. Agent directory selection is at `src/config.ts:578` and is protected after all agent-dir lanes are scrubbed.

## Validation
- RED: `/tmp/hermetic-red.txt` - mandated poisoned-env focused run failed (8 tests), including redirected installed-runtime theme paths and shared temp collision.
- Mutation RED: `/tmp/hermetic-mutation-red.txt` - removing package-dir scrubbing failed the quarantine regression (2 assertions).
- GREEN: `/tmp/hermetic-green.txt` - four mandated regression files passed, 15/15, with poisoned agent/package env exported.
- Full suite: `/tmp/hermetic-full.txt` - 1114 passed, 4 skipped, 16 inherited failures.

The inherited failures are the known main-branch CI breakage in RPC multi-session/isolation, RPC teardown, interactive host/runtime, grok/chrome, app-server mode, and related event-contract suites. They are out of scope and must not be attributed to this test-infrastructure change; the suite is expected to go fully green after sibling PRs #1202/#1203 land.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vitest isolation for `packages/coding-agent` so suites run from an omo session can't inherit real agent state or redirect package asset resolution to the installed runtime instead of the checkout.

- Scrubs every `*_CODING_AGENT_DIR` and `*_PACKAGE_DIR` env var plus `SENPI_BRAND` in the test setup boundary.
- Preserves the `SENPI_TEST_USE_REAL_AGENT_DIR=1` opt-in.
- Extends the quarantine regression to assert the package root stays the checkout.
- Inherited main-branch failures (RPC, interactive host/runtime, grok/chrome) are out of scope.

<sup>Written for commit bac53c717d27f33e91c200e7cf2b9d05f07dad93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

