### PR TITLE
fix(codemode): prevent eval QA from deleting live session state

### DIFF
--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,38 @@
 # senpi-codemode fork changes
 
+## Eval QA owns its temporary agent directory (2026-08-30)
+
+### What changed
+
+- `packages/senpi-codemode/scripts/qa-e2e-eval.ts` now always creates its own
+  temporary agent directory instead of reusing an inherited
+  `SENPI_CODING_AGENT_DIR`.
+- `test/qa-e2e-eval-sandbox.test.ts` runs the real QA driver with an external
+  sentinel agent directory and proves the directory remains unchanged after
+  the driver exits.
+
+### Why
+
+- A QA command launched from an active Senpi or branded Omo session inherits
+  the live runtime's agent directory. The driver previously treated that path
+  as QA-owned scratch space, wrote test settings into it, and recursively
+  removed it during cleanup.
+- In the observed incident, deleting the live sessions directory made the
+  running UI appear to open a new session. The surviving processes recreated
+  headerless JSONL fragments, so the resume picker no longer found the recent
+  sessions.
+
+### Why an extension could not handle it
+
+- The destructive path selection and cleanup happen in the standalone QA
+  driver before extension behavior can impose a filesystem boundary. The
+  driver itself must create and own the paths it removes.
+
+### Expected merge conflict zones
+
+- LOW in `scripts/qa-e2e-eval.ts` around sandbox setup and cleanup.
+- LOW in the new focused QA sandbox regression test.
+
 ## Compiled eval kernels resolve runtime assets from the sidecar (2026-08-27)
 
 ### What changed

--- a/packages/senpi-codemode/scripts/qa-e2e-eval.ts
+++ b/packages/senpi-codemode/scripts/qa-e2e-eval.ts
@@ -17,8 +17,9 @@ class QaScenarioError extends Error {
 }
 
 async function main(): Promise<void> {
-	const suppliedAgentDir = process.env.SENPI_CODING_AGENT_DIR;
-	const agentDir = suppliedAgentDir ?? (await mkdtemp(join(tmpdir(), "senpi-codemode-agent-")));
+	// A live Senpi or branded launcher exports its real agent directory to child commands.
+	// Cleanup below must own every path it removes, so inherited runtime state is never scratch space.
+	const agentDir = await mkdtemp(join(tmpdir(), "senpi-codemode-agent-"));
 	const settingsJson = settingsJsonFromArgs();
 	const cwd = await mkdtemp(join(tmpdir(), "senpi-codemode-e2e-"));
 	await mkdir(agentDir, { recursive: true });

--- a/packages/senpi-codemode/test/qa-e2e-eval-sandbox.test.ts
+++ b/packages/senpi-codemode/test/qa-e2e-eval-sandbox.test.ts
@@ -1,0 +1,43 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const qaDriver = fileURLToPath(new URL("../scripts/qa-e2e-eval.ts", import.meta.url));
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const tempDir of tempDirs.splice(0)) {
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});
+
+describe("qa-e2e-eval sandbox", () => {
+	it("leaves an inherited Senpi agent directory untouched", () => {
+		const tempRoot = mkdtempSync(join(tmpdir(), "senpi-codemode-qa-isolation-"));
+		tempDirs.push(tempRoot);
+		const inheritedAgentDir = join(tempRoot, "inherited-agent");
+		const sentinelPath = join(inheritedAgentDir, "sentinel.txt");
+		mkdirSync(inheritedAgentDir);
+		writeFileSync(sentinelPath, "must survive\n");
+
+		const result = spawnSync(process.execPath, ["--import", "tsx", qaDriver], {
+			cwd: repoRoot,
+			encoding: "utf8",
+			env: {
+				...process.env,
+				PI_OFFLINE: "1",
+				SENPI_CODING_AGENT_DIR: inheritedAgentDir,
+			},
+			timeout: 30_000,
+		});
+
+		expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+		expect(existsSync(sentinelPath)).toBe(true);
+		expect(readFileSync(sentinelPath, "utf8")).toBe("must survive\n");
+		expect(readdirSync(inheritedAgentDir)).toEqual(["sentinel.txt"]);
+	});
+});


### PR DESCRIPTION
## Summary

**Severity: Critical — destructive loss of live session state.**

Prevent `packages/senpi-codemode/scripts/qa-e2e-eval.ts` from treating an inherited `SENPI_CODING_AGENT_DIR` as disposable QA scratch space.

The driver now creates its own temporary agent directory for every invocation and removes only paths it owns. A process-level regression test runs the real QA driver with an external sentinel agent directory and proves that directory remains unchanged.

## User impact and observed failure

The issue was discovered after a long-running Omo session suddenly appeared to reset into a new session. Opening `/resume` then showed none of the recent sessions.

This initially looked like a resume-picker or session-directory resolution problem. Filesystem and process inspection instead showed that the live agent state had been deleted:

- Omo launches child commands with `SENPI_CODING_AGENT_DIR=~/.omo/agent` so nested Senpi processes share the same runtime state.
- The incident timestamp matched an invocation of `npm exec tsx packages/senpi-codemode/scripts/qa-e2e-eval.ts`.
- `~/.omo/agent/sessions` and the affected session-file inodes were recreated immediately after that QA process exited.
- The recreated JSONL files retained their old names but began with mid-session `message` or `custom` records instead of the required `type: "session"` header.
- Session discovery correctly rejected those headerless fragments, which made `/resume` appear empty.

The same deletion also removed settings and RPC pid/socket metadata. That triggered config-reload churn and allowed a second RPC host to start while the original host was still alive. Those were downstream effects of the agent-directory deletion, not the primary fault.

## Root cause

The QA driver previously selected its sandbox like this:

```ts
const suppliedAgentDir = process.env.SENPI_CODING_AGENT_DIR;
const agentDir = suppliedAgentDir ?? (await mkdtemp(...));
```

Its unconditional cleanup later ran:

```ts
await rm(agentDir, { recursive: true, force: true });
```

When the driver was launched from an active Senpi or branded Omo session, `agentDir` therefore pointed at the user's live `~/.omo/agent`. The driver wrote QA settings into that directory and recursively deleted the entire directory in `finally`.

This was deterministic whenever the QA driver inherited a writable production agent directory. The driver could still exit successfully, so the destructive side effect was easy to miss until the next session or resume operation.

## Changes

### Make sandbox ownership explicit

- Always create the QA `agentDir` with `mkdtemp()`.
- Ignore inherited runtime state for scratch-directory selection.
- Keep cleanup limited to directories created by the current QA invocation.

### Add a process-boundary regression

- Create a caller-owned agent directory containing a sentinel file.
- Spawn the real `qa-e2e-eval.ts` driver with that path in `SENPI_CODING_AGENT_DIR`.
- Require the eval QA scenario itself to succeed.
- Assert that the external directory still contains exactly the unchanged sentinel after the child exits.

## QA and evidence

### Failing-first reproduction

- **What was tested:** the new process-level regression against the old driver.
- **Observed result:** the driver exited successfully, but the assertion failed because the inherited sentinel file had been deleted.
- **Why sufficient:** this reproduces the destructive behavior at the exact environment/process boundary involved in the incident.

### Focused regression

- **Command:** focused Vitest run for `test/qa-e2e-eval-sandbox.test.ts`.
- **Observed result:** 1 test passed after the fix.
- **Why sufficient:** proves both successful driver execution and preservation of caller-owned state.

### Real QA driver

- **Observed result:** `LANGS: py,js`, output truncation passed, spill artifact existed, disabled Ruby was rejected, and the external agent directory retained one unchanged sentinel with a matching digest.
- **Why sufficient:** proves isolation without weakening the QA scenario's existing behavioral coverage.

### Package and repository gates

- `packages/senpi-codemode`: 93 test files passed, 1 skipped; 640 tests passed, 6 skipped.
- Senpi QA harness self-check: 10/10 passed, including sandbox cleanup and unchanged real auth.
- `npm run check`: passed.

Sanitized local receipts are stored under:

```text
local-ignore/qa-evidence/20260830-codemode-qa-agent-dir-isolation/
```

No credentials, auth headers, raw environment dumps, or conversation/session contents were captured.

## Risks and residuals

- The change is limited to a standalone QA driver's sandbox selection and its regression coverage; eval runtime behavior is unchanged.
- This removes the undocumented ability to reuse `SENPI_CODING_AGENT_DIR` as the QA scratch directory. A driver that recursively cleans up state must own that state, so per-invocation isolation is the safer contract.
- This prevents recurrence but cannot restore session data deleted by earlier runs.
