### PR TITLE
fix(ai): stop replaying the Anthropic server-side fallback marker

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Stop replaying the Anthropic server-side fallback marker into request params; the stored marker remains audit metadata and keeps pruning the declined attempt, so same-model replays no longer 400 with "Input tag 'fallback'".
+
 ### Removed
 
 ## [2026.8.30] - 2026-08-30

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -437,12 +437,13 @@ const REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES: ReadonlySet<string> = new Set(
 	"text_editor_code_execution_tool_result",
 	"tool_search_tool_result",
 	"container_upload",
-	// Server-side fallback beta (server-side-fallback-2026-06-01) emits a
-	// `fallback` marker mid-response. The marker itself is replayed as a kept
-	// audit block. Blocks emitted *before* the final marker are the declined
-	// attempt and are pruned in convertMessages (see lastAnthropicFallbackBoundary
-	// and collectDiscardedFallbackToolCallIds); the marker onward replays verbatim.
-	"fallback",
+	// The server-side fallback marker (`fallback`, server-side-fallback-2026-06-01
+	// beta) is deliberately absent: the Messages API rejects it as an *input* tag
+	// ("Input tag 'fallback' found using 'type' does not match any of the expected
+	// tags"), so replaying it 400s every subsequent same-model request. The stored
+	// marker is audit metadata and still drives declined-attempt pruning in
+	// convertMessages (see lastAnthropicFallbackBoundary and
+	// collectDiscardedFallbackToolCallIds); blocks after it replay verbatim.
 ]);
 
 function isReplayableAnthropicProviderNativeBlock(raw: unknown): raw is ContentBlockParam {
@@ -2313,7 +2314,8 @@ function convertMessages(
 			const blocks: ContentBlockParam[] = [];
 			const isSameModel = isSameAnthropicModel(msg, model);
 			// Blocks before the final fallback marker are the declined attempt; the
-			// marker onward is the serving model's output and replays verbatim.
+			// blocks after it are the serving model's output and replay verbatim. The
+			// marker itself never replays: the API rejects `fallback` as an input tag.
 			const fallbackBoundary = isSameModel ? lastAnthropicFallbackBoundary(msg.content) : -1;
 			const preBoundaryPairedServerToolUseIds =
 				fallbackBoundary >= 0

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,24 @@
+## Stop replaying the Anthropic server-side fallback marker (2026-08-30)
+
+### What changed
+
+- `packages/ai/src/api/anthropic-messages.ts`: `REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES` no longer contains `fallback`. The stored marker (`providerNative` subtype `fallback`) remains session audit metadata and still drives declined-attempt pruning (`lastAnthropicFallbackBoundary`, `collectDiscardedFallbackToolCallIds`), but it is never serialized into request params.
+- `packages/ai/test/anthropic-provider-native-replay.test.ts`: new regression test `never replays the fallback marker itself into request content`; the three existing fallback replay expectations updated to the marker-absent contract.
+
+### Why
+
+- Production 400 loop (omo session 01a050f8, 2026-08-30): after a client retry-fallback switched the session to the model that had served a server-side fallback (`claude-opus-4-8`), `isSameAnthropicModel` became true and the raw `{type:"fallback"}` marker replayed verbatim as `messages.253.content.0`. The Messages API rejected every subsequent request with `Input tag 'fallback' found using 'type' does not match any of the expected tags`, wedging the session permanently.
+- Live wire probes (2026-08-30, ccapi): a marker-bearing assistant input 400s with exactly that error on routes without the `server-side-fallback` beta and is merely tolerated on beta routes, while the marker-stripped shape is accepted on both. Replaying the marker buys nothing and breaks every cross-route/model-switch replay, so the marker is stored-only now.
+
+### Why an extension could not handle it
+
+- The replay set is provider serialization internals in `convertMessages`; no extension hook exists between stored assistant content and the Anthropic payload.
+
+### Expected merge conflict zones
+
+- LOW: the `REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES` literal and its comment block.
+- LOW: expectation arrays in `anthropic-provider-native-replay.test.ts`.
+
 ## Measure Cursor history at the wire representation (2026-08-29)
 
 ### What changed

--- a/packages/ai/test/anthropic-provider-native-replay.test.ts
+++ b/packages/ai/test/anthropic-provider-native-replay.test.ts
@@ -154,12 +154,12 @@ describe("Anthropic provider-native replay", () => {
 		]);
 	});
 
-	it("keeps the served attempt and the fallback marker, dropping the discarded thinking before it", async () => {
+	it("keeps the served attempt, dropping the discarded thinking and the fallback marker", async () => {
 		// Server-side fallback (server-side-fallback-2026-06-01 beta) emits a
 		// `fallback` content block mid-response. Blocks *before* the marker belong
-		// to the declined attempt; per the replay contract they must be omitted
-		// (the marker onward is the serving model's output and replays verbatim).
-		// The marker itself is kept as an audit block.
+		// to the declined attempt and must be omitted; blocks after it are the
+		// serving model's output and replay verbatim. The marker itself is
+		// stored-only audit metadata: the API rejects `fallback` as an input tag.
 		const model = getModel("anthropic", "claude-fable-5");
 		const fallbackBlock = {
 			type: "fallback",
@@ -192,7 +192,6 @@ describe("Anthropic provider-native replay", () => {
 
 		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
 		expect(assistantPayload?.content).toEqual([
-			fallbackBlock,
 			{ type: "thinking", thinking: "after fallback", signature: "sig_2" },
 			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
 		]);
@@ -247,7 +246,6 @@ describe("Anthropic provider-native replay", () => {
 
 		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
 		expect(assistantPayload?.content).toEqual([
-			fallbackBlock,
 			{ type: "thinking", thinking: "served", signature: "sig_post" },
 			{ type: "tool_use", id: "toolu_post", name: "read", input: { path: "README.md" } },
 		]);
@@ -328,7 +326,6 @@ describe("Anthropic provider-native replay", () => {
 					},
 				],
 			},
-			fallbackBlock,
 			{ type: "thinking", thinking: "served", signature: "sig_post" },
 			{ type: "tool_use", id: "toolu_post", name: "read", input: { path: "README.md" } },
 		]);
@@ -352,6 +349,49 @@ describe("Anthropic provider-native replay", () => {
 
 		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
 		expect(assistantPayload?.content).toEqual([{ type: "text", text: "kept" }]);
+	});
+
+	it("never replays the fallback marker itself into request content", async () => {
+		// Production 400 (omo session 01a050f8, "messages.253.content.0: Input tag
+		// 'fallback' found using 'type' does not match any of the expected tags"):
+		// the Messages API rejects `fallback` as an *input* content tag even on a
+		// same-model request. The marker is response metadata — it stays stored to
+		// mark the declined-attempt boundary but must never serialize into params.
+		const model = getModel("anthropic", "claude-fable-5");
+		const fallbackBlock = {
+			type: "fallback",
+			from: { model: "claude-fable-5" },
+			to: { model: "claude-opus-4-8" },
+			trigger: { type: "refusal", category: "reasoning_extraction" },
+		};
+		const assistant = assistantMessage(
+			[
+				{ type: "providerNative", subtype: "fallback", raw: fallbackBlock },
+				{ type: "text", text: "served" },
+				{ type: "toolCall", id: "toolu_post", name: "read", arguments: { path: "README.md" } },
+			],
+			{ stopReason: "toolUse", model: "claude-fable-5" },
+		);
+
+		const payload = await capturePayload(model, [
+			{ role: "user", content: "hello", timestamp: 1 },
+			assistant,
+			{
+				role: "toolResult",
+				toolCallId: "toolu_post",
+				toolName: "read",
+				content: [{ type: "text", text: "out" }],
+				isError: false,
+				timestamp: 2,
+			},
+		]);
+
+		const assistantPayload = payload.messages?.find((message) => message.role === "assistant");
+		expect(assistantPayload?.content).toEqual([
+			{ type: "text", text: "served" },
+			{ type: "tool_use", id: "toolu_post", name: "read", input: { path: "README.md" } },
+		]);
+		expect(JSON.stringify(payload)).not.toContain('"type":"fallback"');
 	});
 
 	it("drops fallback blocks from a different model's assistant message", async () => {


### PR DESCRIPTION
## Problem

Production omo session `01a050f8` (2026-08-30) got permanently wedged: every request failed with

```
messages.253.content.0: Input tag 'fallback' found using 'type' does not match any of the expected tags: ...
```

**Root cause chain:**
1. A `claude-opus-5` turn was served by `claude-opus-4-8` via Anthropic server-side fallback; the marker block `{type:"fallback", from, to, trigger}` was stored (`providerNative` subtype `fallback`, `message.model = claude-opus-4-8`).
2. While the session stayed on opus-5, `isSameAnthropicModel` was false, so the marker never replayed.
3. A ToS-refusal triggered client retry-fallback to `claude-opus-4-8` — now the requested model matched the stored `message.model`, `"fallback"` was in `REPLAYABLE_ANTHROPIC_PROVIDER_NATIVE_TYPES` (added in 84aa87c0a), and the raw marker replayed verbatim as `messages.253.content.0` → 400 on every subsequent request, forever.

## Fix

Remove `"fallback"` from the replayable set. The marker stays stored as audit metadata and still drives declined-attempt pruning (`lastAnthropicFallbackBoundary`, `collectDiscardedFallbackToolCallIds`); it is just never serialized into request params.

## Evidence (all test/build runs on mengmotaMac via bunshin, /tmp/fallback-fix-20260830)

- **RED**: new test `never replays the fallback marker itself into request content` failed pre-fix with the marker leading received content (1 failed | 15 passed).
- **GREEN**: focused file 16/16; full packages/ai suite **254 files / 2472 tests passed, 0 failed**; `tsc` build OK after root build; biome clean on both touched files. (Fresh-worktree `pi-tui`/`pi-telemetry` resolution failures reproduced on clean main pre-build — environment, attributed.)
- **Live wire probes (ccapi gateway)**:
  - BEFORE shape (marker included, verbatim block from the failing session): `claude-sonnet-4-5` → **400** with the exact production error; `claude-fable-5` (server-side-fallback beta route) → 200, proving the old "replay contract" only ever held on beta routes and breaks on any cross-route/model-switch replay.
  - AFTER shape (marker stripped): `claude-opus-4-8` → **200** ("ok"), `claude-fable-5` → **200**. Accepted everywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops replaying the Anthropic server-side fallback marker so sessions no longer get permanently wedged with 400 errors. The marker is still stored as audit metadata and drives declined-attempt pruning, but it is never serialized into request params anymore; the API rejects it as an input tag. Added a regression test for the marker-absent contract and a changelog entry.

<sup>Written for commit 063d776df0ec3f6481b4cd992ce45c6ffbb0bfb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

