### PR TITLE
test(rpc): await widget events with session open

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,9 @@
 # Local fork changes
 
+## 2026-08-30 - Make RPC widget test event waits deterministic
+
+- The Unix-socket widget regression subscribes to both UI records before issuing `open_session`, waits for the open response and both records together, and uses the shared bounded waiter timeout. This prevents slow shard startup from expiring the record waiters and avoids unhandled rejections from promises that were not yet observed.
+
 ## 2026-08-29 - GLM-5.3 default and prompt preset
 
 - Use GLM-5.3 as the Z.AI global and China default, with the matching built-in prompt preset from current main.

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -262,21 +262,24 @@ describe("RPC Unix-socket multi-connection host", () => {
 					value.type === "extension_ui_request" &&
 					value.method === "setWidget" &&
 					value.widgetKey === "array-widget",
-				1_000,
 			);
 			const unsupported = peer.peer.waitFor(
 				(value) => value.type === "extension_ui_request" && value.method === "custom_unsupported",
-				1_000,
 			);
-			const opened = await peer.peer.request({ id: "open", type: "open_session", cwd: qa.cwd });
-			const sessionId = openedSessionId(opened);
-			expect(await arrayWidget).toMatchObject({
+			const opened = peer.peer.request({ id: "open", type: "open_session", cwd: qa.cwd });
+			const [openedResponse, arrayWidgetRecord, unsupportedRecord] = await Promise.all([
+				opened,
+				arrayWidget,
+				unsupported,
+			]);
+			const sessionId = openedSessionId(openedResponse);
+			expect(arrayWidgetRecord).toMatchObject({
 				type: "extension_ui_request",
 				method: "setWidget",
 				widgetKey: "array-widget",
 				widgetLines: ["array widget"],
 			});
-			expect(await unsupported).toMatchObject({
+			expect(unsupportedRecord).toMatchObject({
 				type: "extension_ui_request",
 				method: "custom_unsupported",
 				extensionName: "widget component",


### PR DESCRIPTION
## Summary
- subscribe to both widget events before issuing open_session
- await the open response and event records together using the shared bounded timeout
- prevent unhandled waiter rejections under slow shard startup

## Root cause
The regression test armed independent 1-second timers before triggering open_session, then awaited the open response before observing either event promise. On slow Ubuntu shard startup, the event records arrived after the private timers (or a startup failure rejected both promises), producing the timeout and Vitest unhandled-rejection report. The fix uses the existing 15-second bounded waiter default, subscribes before the trigger, and observes all operations with Promise.all. It is test-only; runtime behavior is unchanged.

## Latest-base verification
- rebased from b106c1078 onto e7131bc9b (latest origin/main, including PR #1212 and PR #1200)
- latest-base gorky Node 24 focused target: 1/1 passed, 0 unhandled errors
- prior rebased b106c1078 gorky Linux focused test: 10/10 green
- prior rebased b106c1078 mengmotaMac focused test: 3/3 green
- exact shard 3/3 includes rpc-socket-host.test.ts; target passed in the shard. The shard still has unrelated pre-existing failures in sdk-session-manager.test.ts and suite/terminal-monitor.test.ts.
- PR #1212's post-#1200 target pass is consistent with #1200 changing the failure profile, but the waiter/unhandled-rejection harness defects remain independently valid and are fixed here.

Remote verification namespaces were removed after testing.