### PR TITLE
fix(pty): flow-controlled, dispose-safe xterm screen writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Persistent terminals now serialize headless xterm screen writes through parser callbacks with a bounded, dispose-safe backlog, preventing fast PTY output from exceeding xterm's pending-write watermark and terminating Senpi with `write data discarded, use flow control to avoid losing data` ([#1214](https://github.com/code-yeongyu/senpi/pull/1214), supersedes [#837](https://github.com/code-yeongyu/senpi/pull/837)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
@@ -74,7 +74,10 @@ export class TerminalRuntimeSession {
 	private ingest(chunk: Uint8Array): string {
 		const text = this.decoder.decode(chunk, { stream: true });
 		if (text.length === 0) return text;
-		void this.screen.feed(text);
+		// The screen is a best-effort projection; a rejected feed must never
+		// become an unhandled rejection that kills the host process (#837).
+		// `buffer` below remains the source of truth for reads.
+		this.screen.feed(text).catch(() => {});
 		this.buffer += text;
 		if (this.buffer.length > MAX_SESSION_OUTPUT_CHARS) {
 			const overflow = this.buffer.length - MAX_SESSION_OUTPUT_CHARS;
@@ -109,7 +112,7 @@ export class TerminalRuntimeSession {
 	}
 
 	resizeScreen(cols: number, rows: number): void {
-		void this.screen.resize(cols, rows);
+		this.screen.resize(cols, rows).catch(() => {});
 	}
 
 	dispose(): void {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/runtime-session.ts
@@ -74,10 +74,7 @@ export class TerminalRuntimeSession {
 	private ingest(chunk: Uint8Array): string {
 		const text = this.decoder.decode(chunk, { stream: true });
 		if (text.length === 0) return text;
-		// The screen is a best-effort projection; a rejected feed must never
-		// become an unhandled rejection that kills the host process (#837).
-		// `buffer` below remains the source of truth for reads.
-		this.screen.feed(text).catch(() => {});
+		this.ownScreenWrite(this.screen.feed(text));
 		this.buffer += text;
 		if (this.buffer.length > MAX_SESSION_OUTPUT_CHARS) {
 			const overflow = this.buffer.length - MAX_SESSION_OUTPUT_CHARS;
@@ -112,7 +109,24 @@ export class TerminalRuntimeSession {
 	}
 
 	resizeScreen(cols: number, rows: number): void {
-		this.screen.resize(cols, rows).catch(() => {});
+		this.ownScreenWrite(this.screen.resize(cols, rows));
+	}
+
+	/**
+	 * The screen is a best-effort projection; a rejected feed/resize must never
+	 * become an unhandled rejection that kills the host process (#837), and
+	 * `buffer` remains the source of truth for reads. The screen hands every
+	 * caller coalesced into one queued operation the same memoized promise, so
+	 * attach the rejection handler once per distinct promise - re-attaching per
+	 * PTY chunk would grow promise reactions without bound while a replay is
+	 * stalled behind a slow parser.
+	 */
+	private lastScreenWrite: Promise<void> | null = null;
+
+	private ownScreenWrite(written: Promise<void>): void {
+		if (written === this.lastScreenWrite) return;
+		this.lastScreenWrite = written;
+		written.catch(() => {});
 	}
 
 	dispose(): void {

--- a/packages/coding-agent/test/pty-runtime-screen-errors.test.ts
+++ b/packages/coding-agent/test/pty-runtime-screen-errors.test.ts
@@ -6,6 +6,7 @@ interface RejectionRecord {
 
 const pty = vi.hoisted(() => {
 	const records: RejectionRecord[] = [];
+	const state = { sharedMode: false, sharedAttachCount: 0, feedCalls: 0 };
 
 	// A thenable standing in for a rejected feed/resize promise. It records
 	// whether the caller ever attaches a rejection handler; with none, the
@@ -14,13 +15,14 @@ const pty = vi.hoisted(() => {
 	const observedRejection = (record: RejectionRecord): Promise<void> => {
 		const failure = new Error("write data discarded, use flow control to avoid losing data");
 		const thenable = {
-			// biome-ignore lint/suspicious/noThenProperty: intentionally thenable so the test observes whether the call site attaches a rejection handler
+			// biome-ignore lint/suspicious/noThenProperty: intentional thenable observing handler attachment
 			then(
 				_onFulfilled?: ((value: undefined) => unknown) | null,
 				onRejected?: ((reason: unknown) => unknown) | null,
 			): Promise<void> {
 				if (typeof onRejected === "function") {
 					record.handled = true;
+					state.sharedAttachCount += 1;
 					onRejected(failure);
 				}
 				return Promise.resolve();
@@ -35,6 +37,9 @@ const pty = vi.hoisted(() => {
 		};
 		return thenable as unknown as Promise<void>;
 	};
+
+	const sharedRecord: RejectionRecord = { handled: false };
+	const sharedRejection = observedRejection(sharedRecord);
 
 	class TerminalSession {
 		backend: string | null = null;
@@ -69,12 +74,15 @@ const pty = vi.hoisted(() => {
 
 	class TerminalScreen {
 		feed(): Promise<void> {
+			state.feedCalls += 1;
+			if (state.sharedMode) return sharedRejection;
 			const record: RejectionRecord = { handled: false };
 			records.push(record);
 			return observedRejection(record);
 		}
 
 		resize(): Promise<void> {
+			if (state.sharedMode) return sharedRejection;
 			const record: RejectionRecord = { handled: false };
 			records.push(record);
 			return observedRejection(record);
@@ -83,25 +91,46 @@ const pty = vi.hoisted(() => {
 		dispose(): void {}
 	}
 
-	return { TerminalScreen, TerminalSession, records, sessions: [] as TerminalSession[] };
+	return { TerminalScreen, TerminalSession, records, sessions: [] as TerminalSession[], state };
 });
 
 vi.mock("@earendil-works/pi-pty", () => pty);
 
 import { TerminalRuntimeSession } from "../src/core/extensions/builtin/terminal/runtime-session.ts";
 
+function latestSession(): InstanceType<typeof pty.TerminalSession> {
+	const session = pty.sessions.at(-1);
+	if (!session) throw new Error("Terminal session was not created");
+	return session;
+}
+
 describe("PTY runtime screen error ownership", () => {
 	it("owns screen feed/resize rejections instead of leaking them unhandled", () => {
+		pty.state.sharedMode = false;
 		const runtime = new TerminalRuntimeSession("screen-error-fixture", {});
-		const session = pty.sessions.at(-1);
-		if (!session) throw new Error("Terminal session was not created");
 
-		session.emit("flood");
+		latestSession().emit("flood");
 		runtime.resizeScreen(120, 40);
 
 		expect(pty.records).toHaveLength(2);
 		expect(pty.records.every((record) => record.handled)).toBe(true);
 		expect(runtime.fullOutput()).toBe("flood");
 		runtime.dispose();
+	});
+
+	it("attaches one rejection handler per distinct coalesced screen promise", () => {
+		pty.state.sharedMode = true;
+		pty.state.sharedAttachCount = 0;
+		const feedCallsBefore = pty.state.feedCalls;
+		const runtime = new TerminalRuntimeSession("screen-coalesce-fixture", {});
+
+		latestSession().emit("one");
+		latestSession().emit("two");
+		latestSession().emit("three");
+
+		expect(pty.state.feedCalls - feedCallsBefore).toBe(3);
+		expect(pty.state.sharedAttachCount).toBe(1);
+		runtime.dispose();
+		pty.state.sharedMode = false;
 	});
 });

--- a/packages/coding-agent/test/pty-runtime-screen-errors.test.ts
+++ b/packages/coding-agent/test/pty-runtime-screen-errors.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+interface RejectionRecord {
+	handled: boolean;
+}
+
+const pty = vi.hoisted(() => {
+	const records: RejectionRecord[] = [];
+
+	// A thenable standing in for a rejected feed/resize promise. It records
+	// whether the caller ever attaches a rejection handler; with none, the
+	// real promise would become an unhandled rejection and kill the host
+	// process (the omo-ai Windows crash behind #837 / #1214).
+	const observedRejection = (record: RejectionRecord): Promise<void> => {
+		const failure = new Error("write data discarded, use flow control to avoid losing data");
+		const thenable = {
+			// biome-ignore lint/suspicious/noThenProperty: intentionally thenable so the test observes whether the call site attaches a rejection handler
+			then(
+				_onFulfilled?: ((value: undefined) => unknown) | null,
+				onRejected?: ((reason: unknown) => unknown) | null,
+			): Promise<void> {
+				if (typeof onRejected === "function") {
+					record.handled = true;
+					onRejected(failure);
+				}
+				return Promise.resolve();
+			},
+			catch(onRejected?: ((reason: unknown) => unknown) | null): Promise<void> {
+				return thenable.then(undefined, onRejected);
+			},
+			finally(onFinally?: (() => void) | null): Promise<void> {
+				onFinally?.();
+				return Promise.resolve();
+			},
+		};
+		return thenable as unknown as Promise<void>;
+	};
+
+	class TerminalSession {
+		backend: string | null = null;
+		exited = false;
+		exitResult = null;
+		private readonly dataListeners = new Set<(chunk: Uint8Array) => void>();
+
+		constructor() {
+			pty.sessions.push(this);
+		}
+
+		onData(listener: (chunk: Uint8Array) => void): () => void {
+			this.dataListeners.add(listener);
+			return () => this.dataListeners.delete(listener);
+		}
+
+		onExit(): () => void {
+			return () => {};
+		}
+
+		start(): this {
+			return this;
+		}
+
+		kill(): void {}
+
+		emit(text: string): void {
+			const chunk = new TextEncoder().encode(text);
+			for (const listener of this.dataListeners) listener(chunk);
+		}
+	}
+
+	class TerminalScreen {
+		feed(): Promise<void> {
+			const record: RejectionRecord = { handled: false };
+			records.push(record);
+			return observedRejection(record);
+		}
+
+		resize(): Promise<void> {
+			const record: RejectionRecord = { handled: false };
+			records.push(record);
+			return observedRejection(record);
+		}
+
+		dispose(): void {}
+	}
+
+	return { TerminalScreen, TerminalSession, records, sessions: [] as TerminalSession[] };
+});
+
+vi.mock("@earendil-works/pi-pty", () => pty);
+
+import { TerminalRuntimeSession } from "../src/core/extensions/builtin/terminal/runtime-session.ts";
+
+describe("PTY runtime screen error ownership", () => {
+	it("owns screen feed/resize rejections instead of leaking them unhandled", () => {
+		const runtime = new TerminalRuntimeSession("screen-error-fixture", {});
+		const session = pty.sessions.at(-1);
+		if (!session) throw new Error("Terminal session was not created");
+
+		session.emit("flood");
+		runtime.resizeScreen(120, 40);
+
+		expect(pty.records).toHaveLength(2);
+		expect(pty.records.every((record) => record.handled)).toBe(true);
+		expect(runtime.fullOutput()).toBe("flood");
+		runtime.dispose();
+	});
+});

--- a/packages/pty/src/screen-operations.ts
+++ b/packages/pty/src/screen-operations.ts
@@ -11,7 +11,7 @@ export interface WriteOperation {
 
 export interface ReplayOperation {
 	readonly kind: "replay";
-	historyMark: number;
+	payload: string;
 	settled: Promise<void> | null;
 	readonly settlers: OperationSettler[];
 }
@@ -20,7 +20,7 @@ export interface ResizeOperation {
 	readonly kind: "resize";
 	cols: number;
 	rows: number;
-	historyMark: number;
+	replay: string;
 	settled: Promise<void> | null;
 	readonly settlers: OperationSettler[];
 }

--- a/packages/pty/src/screen-operations.ts
+++ b/packages/pty/src/screen-operations.ts
@@ -1,0 +1,49 @@
+export interface OperationSettler {
+	readonly resolve: () => void;
+	readonly reject: (error: Error) => void;
+}
+
+export interface WriteOperation {
+	readonly kind: "write";
+	readonly payload: string;
+	readonly settlers: OperationSettler[];
+}
+
+export interface ReplayOperation {
+	readonly kind: "replay";
+	payload: string;
+	readonly settlers: OperationSettler[];
+}
+
+export interface ResizeOperation {
+	readonly kind: "resize";
+	readonly cols: number;
+	readonly rows: number;
+	readonly replay: string;
+	readonly settlers: OperationSettler[];
+}
+
+export type ScreenOperation = WriteOperation | ReplayOperation | ResizeOperation;
+
+/**
+ * Ceiling for characters queued but not yet parsed by xterm. Beyond it the
+ * queued writes collapse into one bounded history replay, so a flooding PTY
+ * can neither overrun xterm's 50M-char pending-write watermark (which rejects
+ * with "write data discarded, use flow control to avoid losing data") nor
+ * grow the queue's memory without limit.
+ */
+export const MAX_PENDING_WRITE_CHARS = 1_048_576;
+
+export function settleOperation(settlers: OperationSettler[], error: Error | null): void {
+	const owners = settlers.splice(0, settlers.length);
+	for (const settler of owners) {
+		if (error === null) settler.resolve();
+		else settler.reject(error);
+	}
+}
+
+export function trackSettler(settlers: OperationSettler[]): Promise<void> {
+	return new Promise<void>((resolve, reject) => {
+		settlers.push({ resolve, reject });
+	});
+}

--- a/packages/pty/src/screen-operations.ts
+++ b/packages/pty/src/screen-operations.ts
@@ -6,6 +6,7 @@ export interface OperationSettler {
 export interface WriteOperation {
 	readonly kind: "write";
 	readonly payload: string;
+	settled: Promise<void> | null;
 	readonly settlers: OperationSettler[];
 }
 
@@ -51,11 +52,11 @@ export function trackSettler(settlers: OperationSettler[]): Promise<void> {
 }
 
 /**
- * Every caller coalesced into the same replay or merged resize shares ONE
- * promise and ONE settler, so a flood or resize storm cannot grow an
+ * Every caller attached to the same queued operation shares ONE promise and
+ * ONE settler, so a flood, resize storm, or flush storm cannot grow an
  * operation's settler memory with the number of callers.
  */
-export function sharedSettler(operation: ReplayOperation | ResizeOperation): Promise<void> {
+export function sharedSettler(operation: ScreenOperation): Promise<void> {
 	if (operation.settled === null) {
 		operation.settled = trackSettler(operation.settlers);
 	}

--- a/packages/pty/src/screen-operations.ts
+++ b/packages/pty/src/screen-operations.ts
@@ -11,15 +11,13 @@ export interface WriteOperation {
 
 export interface ReplayOperation {
 	readonly kind: "replay";
-	payload: string;
 	readonly settlers: OperationSettler[];
 }
 
 export interface ResizeOperation {
 	readonly kind: "resize";
-	readonly cols: number;
-	readonly rows: number;
-	readonly replay: string;
+	cols: number;
+	rows: number;
 	readonly settlers: OperationSettler[];
 }
 

--- a/packages/pty/src/screen-operations.ts
+++ b/packages/pty/src/screen-operations.ts
@@ -11,6 +11,8 @@ export interface WriteOperation {
 
 export interface ReplayOperation {
 	readonly kind: "replay";
+	historyMark: number;
+	settled: Promise<void> | null;
 	readonly settlers: OperationSettler[];
 }
 
@@ -18,6 +20,8 @@ export interface ResizeOperation {
 	readonly kind: "resize";
 	cols: number;
 	rows: number;
+	historyMark: number;
+	settled: Promise<void> | null;
 	readonly settlers: OperationSettler[];
 }
 
@@ -44,4 +48,16 @@ export function trackSettler(settlers: OperationSettler[]): Promise<void> {
 	return new Promise<void>((resolve, reject) => {
 		settlers.push({ resolve, reject });
 	});
+}
+
+/**
+ * Every caller coalesced into the same replay or merged resize shares ONE
+ * promise and ONE settler, so a flood or resize storm cannot grow an
+ * operation's settler memory with the number of callers.
+ */
+export function sharedSettler(operation: ReplayOperation | ResizeOperation): Promise<void> {
+	if (operation.settled === null) {
+		operation.settled = trackSettler(operation.settlers);
+	}
+	return operation.settled;
 }

--- a/packages/pty/src/screen-text.ts
+++ b/packages/pty/src/screen-text.ts
@@ -1,0 +1,52 @@
+import type { Terminal as XtermTerminalType } from "@xterm/headless";
+
+const DEFAULT_SCROLLBACK = 1000;
+const MIN_SIZE = 1;
+const MAX_SIZE = 10000;
+const MIN_REPLAY_HISTORY_LENGTH = 4096;
+const MAX_REPLAY_HISTORY_LENGTH = 1_000_000;
+
+export function readLine(buffer: XtermTerminalType["buffer"]["active"], lineIndex: number): string {
+	return buffer.getLine(lineIndex)?.translateToString(true) ?? "";
+}
+
+export function normalizeDimension(value: number | undefined, fallback: number): number {
+	if (value === undefined || !Number.isFinite(value)) return fallback;
+	return Math.min(MAX_SIZE, Math.max(MIN_SIZE, Math.trunc(value)));
+}
+
+export function normalizeScrollback(value: number | undefined): number {
+	if (value === undefined || !Number.isFinite(value)) return DEFAULT_SCROLLBACK;
+	return Math.max(0, Math.trunc(value));
+}
+
+export function normalizeReplayHistoryLength(cols: number, rows: number, scrollback: number): number {
+	const visibleCells = Math.max(MIN_SIZE, cols) * Math.max(MIN_SIZE, rows + scrollback + 1);
+	return Math.min(MAX_REPLAY_HISTORY_LENGTH, Math.max(MIN_REPLAY_HISTORY_LENGTH, visibleCells * 4));
+}
+
+export function decodeInput(value: string | Uint8Array): string {
+	if (typeof value === "string") return value;
+	return new TextDecoder("utf-8", { fatal: false }).decode(value);
+}
+
+export function sanitizeString(value: string): string {
+	let output = "";
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code >= 0xd800 && code <= 0xdbff) {
+			const next = value.charCodeAt(index + 1);
+			if (next >= 0xdc00 && next <= 0xdfff) {
+				output += value[index] + value[index + 1];
+				index += 1;
+			} else {
+				output += "\uFFFD";
+			}
+		} else if (code >= 0xdc00 && code <= 0xdfff) {
+			output += "\uFFFD";
+		} else {
+			output += value[index];
+		}
+	}
+	return output;
+}

--- a/packages/pty/src/screen.ts
+++ b/packages/pty/src/screen.ts
@@ -1,5 +1,20 @@
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import xterm from "@xterm/headless";
+import {
+	MAX_PENDING_WRITE_CHARS,
+	type OperationSettler,
+	type ScreenOperation,
+	settleOperation,
+	trackSettler,
+} from "./screen-operations.ts";
+import {
+	decodeInput,
+	normalizeDimension,
+	normalizeReplayHistoryLength,
+	normalizeScrollback,
+	readLine,
+	sanitizeString,
+} from "./screen-text.ts";
 
 export interface TerminalScreenOptions {
 	readonly cols?: number;
@@ -21,17 +36,29 @@ export interface TerminalScreenSnapshot {
 const XtermTerminal = xterm.Terminal;
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
-const DEFAULT_SCROLLBACK = 1000;
-const MIN_SIZE = 1;
-const MAX_SIZE = 10000;
-const MIN_REPLAY_HISTORY_LENGTH = 4096;
-const MAX_REPLAY_HISTORY_LENGTH = 1_000_000;
 
+/**
+ * Headless xterm screen model with serialized, flow-controlled writes.
+ *
+ * Every terminal mutation (feed, resize, backlog replay) runs through one
+ * FIFO queue that awaits xterm's parse callback before issuing the next
+ * write, so xterm's pending-write watermark can never be exceeded. When the
+ * queued backlog outgrows {@link MAX_PENDING_WRITE_CHARS}, the queued writes
+ * collapse into a single bounded history replay that reconstructs the same
+ * screen state. After {@link TerminalScreen.dispose}, queued and future
+ * operations settle as resolved no-ops; a terminal is never created after
+ * disposal.
+ */
 export class TerminalScreen {
 	private terminal: XtermTerminalType;
 	private readonly history: string[] = [];
 	private historyLength = 0;
-	private writeQueue: Promise<void> = Promise.resolve();
+	private readonly operations: ScreenOperation[] = [];
+	private pendingWriteChars = 0;
+	private draining = false;
+	private disposed = false;
+	private notifyDisposed: () => void = () => undefined;
+	private readonly whenDisposed: Promise<void>;
 	private readonly maxReplayHistoryLength: number;
 	private readonly scrollback: number;
 
@@ -40,29 +67,40 @@ export class TerminalScreen {
 		const rows = normalizeDimension(options.rows, DEFAULT_ROWS);
 		this.scrollback = normalizeScrollback(options.scrollback);
 		this.maxReplayHistoryLength = normalizeReplayHistoryLength(cols, rows, this.scrollback);
+		this.whenDisposed = new Promise((resolve) => {
+			this.notifyDisposed = resolve;
+		});
 		this.terminal = this.createTerminal(cols, rows);
 	}
 
 	feed(data: string | Uint8Array): Promise<void> {
+		if (this.disposed) return Promise.resolve();
 		const payload = decodeInput(data);
 		const sanitizedPayload = sanitizeString(payload);
 		if (sanitizedPayload.length > 0) this.appendHistory(sanitizedPayload);
-		return this.enqueueWrite(payload);
+		if (this.pendingWriteChars + payload.length > MAX_PENDING_WRITE_CHARS) {
+			return this.coalesceBacklogIntoReplay();
+		}
+		this.pendingWriteChars += payload.length;
+		return this.enqueue({ kind: "write", payload, settlers: [] });
 	}
 
 	resize(cols: number, rows: number): Promise<void> {
+		if (this.disposed) return Promise.resolve();
 		const nextCols = normalizeDimension(cols, this.terminal.cols);
 		const nextRows = normalizeDimension(rows, this.terminal.rows);
-		const replay = this.history.join("");
-		return this.enqueue(async () => {
-			this.terminal.dispose();
-			this.terminal = this.createTerminal(nextCols, nextRows);
-			await this.write(replay);
+		return this.enqueue({
+			kind: "resize",
+			cols: nextCols,
+			rows: nextRows,
+			replay: this.history.join(""),
+			settlers: [],
 		});
 	}
 
 	flush(): Promise<void> {
-		return this.enqueueWrite("");
+		if (this.disposed) return Promise.resolve();
+		return this.enqueue({ kind: "write", payload: "", settlers: [] });
 	}
 
 	snapshot(): TerminalScreenSnapshot {
@@ -92,6 +130,14 @@ export class TerminalScreen {
 	}
 
 	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.notifyDisposed();
+		const pending = this.operations.splice(0, this.operations.length);
+		this.pendingWriteChars = 0;
+		for (const operation of pending) {
+			settleOperation(operation.settlers, null);
+		}
 		this.terminal.dispose();
 	}
 
@@ -106,17 +152,81 @@ export class TerminalScreen {
 		});
 	}
 
-	private enqueueWrite(payload: string): Promise<void> {
-		return this.enqueue(() => this.write(payload));
+	private enqueue(operation: ScreenOperation): Promise<void> {
+		this.operations.push(operation);
+		const settled = trackSettler(operation.settlers);
+		void this.drain();
+		return settled;
 	}
 
-	private enqueue(operation: () => Promise<void>): Promise<void> {
-		const result = this.writeQueue.then(operation);
-		this.writeQueue = result.then(
-			() => undefined,
-			() => undefined,
-		);
-		return result;
+	/**
+	 * Collapse every queued write into one replay of the bounded history.
+	 * Dropped feeds settle with the replay's outcome: their payloads already
+	 * live in `history`, so the replayed screen state includes them. Queued
+	 * resizes are kept; the replay lands at the queue tail so it repaints
+	 * after the final dimensions apply.
+	 */
+	private coalesceBacklogIntoReplay(): Promise<void> {
+		const orphanedSettlers: OperationSettler[] = [];
+		for (let index = this.operations.length - 1; index >= 0; index -= 1) {
+			const operation = this.operations[index];
+			if (operation === undefined || operation.kind !== "write") continue;
+			orphanedSettlers.push(...operation.settlers);
+			operation.settlers.length = 0;
+			this.operations.splice(index, 1);
+		}
+		this.pendingWriteChars = 0;
+		const tail = this.operations[this.operations.length - 1];
+		const replayPayload = this.history.join("");
+		if (tail !== undefined && tail.kind === "replay") {
+			tail.payload = replayPayload;
+			tail.settlers.push(...orphanedSettlers);
+			return trackSettler(tail.settlers);
+		}
+		return this.enqueue({ kind: "replay", payload: replayPayload, settlers: orphanedSettlers });
+	}
+
+	private async drain(): Promise<void> {
+		if (this.draining) return;
+		this.draining = true;
+		try {
+			while (!this.disposed) {
+				const operation = this.operations.shift();
+				if (operation === undefined) return;
+				if (operation.kind === "write") this.pendingWriteChars -= operation.payload.length;
+				try {
+					await this.run(operation);
+					settleOperation(operation.settlers, null);
+				} catch (error) {
+					settleOperation(operation.settlers, error instanceof Error ? error : new Error(String(error)));
+				}
+			}
+		} finally {
+			this.draining = false;
+		}
+	}
+
+	private async run(operation: ScreenOperation): Promise<void> {
+		if (this.disposed) return;
+		switch (operation.kind) {
+			case "write":
+				await this.raceDisposal(this.write(operation.payload));
+				return;
+			case "replay":
+				this.terminal.reset();
+				await this.raceDisposal(this.write(operation.payload));
+				return;
+			case "resize":
+				this.terminal.dispose();
+				this.terminal = this.createTerminal(operation.cols, operation.rows);
+				await this.raceDisposal(this.write(operation.replay));
+				return;
+		}
+	}
+
+	/** A disposed terminal may never invoke its parse callback; do not hang. */
+	private raceDisposal(written: Promise<void>): Promise<void> {
+		return Promise.race([written, this.whenDisposed]);
 	}
 
 	private write(payload: string): Promise<void> {
@@ -154,49 +264,4 @@ export class TerminalScreen {
 		this.history[0] = trimmed;
 		this.historyLength = trimmed.length;
 	}
-}
-
-function readLine(buffer: XtermTerminalType["buffer"]["active"], lineIndex: number): string {
-	return buffer.getLine(lineIndex)?.translateToString(true) ?? "";
-}
-
-function normalizeDimension(value: number | undefined, fallback: number): number {
-	if (value === undefined || !Number.isFinite(value)) return fallback;
-	return Math.min(MAX_SIZE, Math.max(MIN_SIZE, Math.trunc(value)));
-}
-
-function normalizeScrollback(value: number | undefined): number {
-	if (value === undefined || !Number.isFinite(value)) return DEFAULT_SCROLLBACK;
-	return Math.max(0, Math.trunc(value));
-}
-
-function normalizeReplayHistoryLength(cols: number, rows: number, scrollback: number): number {
-	const visibleCells = Math.max(MIN_SIZE, cols) * Math.max(MIN_SIZE, rows + scrollback + 1);
-	return Math.min(MAX_REPLAY_HISTORY_LENGTH, Math.max(MIN_REPLAY_HISTORY_LENGTH, visibleCells * 4));
-}
-
-function decodeInput(value: string | Uint8Array): string {
-	if (typeof value === "string") return value;
-	return new TextDecoder("utf-8", { fatal: false }).decode(value);
-}
-
-function sanitizeString(value: string): string {
-	let output = "";
-	for (let index = 0; index < value.length; index += 1) {
-		const code = value.charCodeAt(index);
-		if (code >= 0xd800 && code <= 0xdbff) {
-			const next = value.charCodeAt(index + 1);
-			if (next >= 0xdc00 && next <= 0xdfff) {
-				output += value[index] + value[index + 1];
-				index += 1;
-			} else {
-				output += "\uFFFD";
-			}
-		} else if (code >= 0xdc00 && code <= 0xdfff) {
-			output += "\uFFFD";
-		} else {
-			output += value[index];
-		}
-	}
-	return output;
 }

--- a/packages/pty/src/screen.ts
+++ b/packages/pty/src/screen.ts
@@ -1,12 +1,6 @@
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import xterm from "@xterm/headless";
-import {
-	MAX_PENDING_WRITE_CHARS,
-	type OperationSettler,
-	type ScreenOperation,
-	settleOperation,
-	trackSettler,
-} from "./screen-operations.ts";
+import { MAX_PENDING_WRITE_CHARS, type ScreenOperation, settleOperation, trackSettler } from "./screen-operations.ts";
 import {
 	decodeInput,
 	normalizeDimension,
@@ -89,13 +83,13 @@ export class TerminalScreen {
 		if (this.disposed) return Promise.resolve();
 		const nextCols = normalizeDimension(cols, this.terminal.cols);
 		const nextRows = normalizeDimension(rows, this.terminal.rows);
-		return this.enqueue({
-			kind: "resize",
-			cols: nextCols,
-			rows: nextRows,
-			replay: this.history.join(""),
-			settlers: [],
-		});
+		const tail = this.operations[this.operations.length - 1];
+		if (tail !== undefined && tail.kind === "resize") {
+			tail.cols = nextCols;
+			tail.rows = nextRows;
+			return trackSettler(tail.settlers);
+		}
+		return this.enqueue({ kind: "resize", cols: nextCols, rows: nextRows, settlers: [] });
 	}
 
 	flush(): Promise<void> {
@@ -160,30 +154,18 @@ export class TerminalScreen {
 	}
 
 	/**
-	 * Collapse every queued write into one replay of the bounded history.
-	 * Dropped feeds settle with the replay's outcome: their payloads already
-	 * live in `history`, so the replayed screen state includes them. Queued
-	 * resizes are kept; the replay lands at the queue tail so it repaints
-	 * after the final dimensions apply.
+	 * Route an over-cap feed to the queue's replay operation instead of
+	 * enqueueing another write. The feed's payload already lives in `history`,
+	 * and a replay renders `history` at run time, so settling with the replay's
+	 * outcome loses nothing. Settlers attach one at a time; no unbounded spread
+	 * or snapshot string is ever built here.
 	 */
 	private coalesceBacklogIntoReplay(): Promise<void> {
-		const orphanedSettlers: OperationSettler[] = [];
-		for (let index = this.operations.length - 1; index >= 0; index -= 1) {
-			const operation = this.operations[index];
-			if (operation === undefined || operation.kind !== "write") continue;
-			orphanedSettlers.push(...operation.settlers);
-			operation.settlers.length = 0;
-			this.operations.splice(index, 1);
-		}
-		this.pendingWriteChars = 0;
 		const tail = this.operations[this.operations.length - 1];
-		const replayPayload = this.history.join("");
 		if (tail !== undefined && tail.kind === "replay") {
-			tail.payload = replayPayload;
-			tail.settlers.push(...orphanedSettlers);
 			return trackSettler(tail.settlers);
 		}
-		return this.enqueue({ kind: "replay", payload: replayPayload, settlers: orphanedSettlers });
+		return this.enqueue({ kind: "replay", settlers: [] });
 	}
 
 	private async drain(): Promise<void> {
@@ -213,14 +195,34 @@ export class TerminalScreen {
 				await this.raceDisposal(this.write(operation.payload));
 				return;
 			case "replay":
+				this.absorbQueuedWrites(operation);
 				this.terminal.reset();
-				await this.raceDisposal(this.write(operation.payload));
+				await this.raceDisposal(this.write(this.history.join("")));
 				return;
 			case "resize":
+				this.absorbQueuedWrites(operation);
 				this.terminal.dispose();
 				this.terminal = this.createTerminal(operation.cols, operation.rows);
-				await this.raceDisposal(this.write(operation.replay));
+				await this.raceDisposal(this.write(this.history.join("")));
 				return;
+		}
+	}
+
+	/**
+	 * A replay or resize renders the full bounded `history` at run time, which
+	 * already contains every queued write's payload; running those writes
+	 * afterwards would duplicate their content on the fresh screen. Absorb
+	 * them instead: remove the queued writes and settle them with this
+	 * operation's outcome.
+	 */
+	private absorbQueuedWrites(into: ScreenOperation): void {
+		for (let index = this.operations.length - 1; index >= 0; index -= 1) {
+			const operation = this.operations[index];
+			if (operation === undefined || operation.kind !== "write") continue;
+			this.pendingWriteChars -= operation.payload.length;
+			for (const settler of operation.settlers) into.settlers.push(settler);
+			operation.settlers.length = 0;
+			this.operations.splice(index, 1);
 		}
 	}
 

--- a/packages/pty/src/screen.ts
+++ b/packages/pty/src/screen.ts
@@ -1,6 +1,14 @@
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import xterm from "@xterm/headless";
-import { MAX_PENDING_WRITE_CHARS, type ScreenOperation, settleOperation, trackSettler } from "./screen-operations.ts";
+import {
+	MAX_PENDING_WRITE_CHARS,
+	type ReplayOperation,
+	type ResizeOperation,
+	type ScreenOperation,
+	settleOperation,
+	sharedSettler,
+	trackSettler,
+} from "./screen-operations.ts";
 import {
 	decodeInput,
 	normalizeDimension,
@@ -48,6 +56,7 @@ export class TerminalScreen {
 	private readonly history: string[] = [];
 	private historyLength = 0;
 	private readonly operations: ScreenOperation[] = [];
+	private historyHeadChunks = 0;
 	private pendingWriteChars = 0;
 	private draining = false;
 	private disposed = false;
@@ -76,7 +85,8 @@ export class TerminalScreen {
 			return this.coalesceBacklogIntoReplay();
 		}
 		this.pendingWriteChars += payload.length;
-		return this.enqueue({ kind: "write", payload, settlers: [] });
+		const operation: ScreenOperation = { kind: "write", payload, settlers: [] };
+		return this.enqueue(operation, trackSettler(operation.settlers));
 	}
 
 	resize(cols: number, rows: number): Promise<void> {
@@ -87,14 +97,24 @@ export class TerminalScreen {
 		if (tail !== undefined && tail.kind === "resize") {
 			tail.cols = nextCols;
 			tail.rows = nextRows;
-			return trackSettler(tail.settlers);
+			tail.historyMark = this.historyEnd();
+			return sharedSettler(tail);
 		}
-		return this.enqueue({ kind: "resize", cols: nextCols, rows: nextRows, settlers: [] });
+		const operation: ResizeOperation = {
+			kind: "resize",
+			cols: nextCols,
+			rows: nextRows,
+			historyMark: this.historyEnd(),
+			settled: null,
+			settlers: [],
+		};
+		return this.enqueue(operation, sharedSettler(operation));
 	}
 
 	flush(): Promise<void> {
 		if (this.disposed) return Promise.resolve();
-		return this.enqueue({ kind: "write", payload: "", settlers: [] });
+		const operation: ScreenOperation = { kind: "write", payload: "", settlers: [] };
+		return this.enqueue(operation, trackSettler(operation.settlers));
 	}
 
 	snapshot(): TerminalScreenSnapshot {
@@ -146,26 +166,32 @@ export class TerminalScreen {
 		});
 	}
 
-	private enqueue(operation: ScreenOperation): Promise<void> {
+	private enqueue(operation: ScreenOperation, settled: Promise<void>): Promise<void> {
 		this.operations.push(operation);
-		const settled = trackSettler(operation.settlers);
 		void this.drain();
 		return settled;
 	}
 
 	/**
-	 * Route an over-cap feed to the queue's replay operation instead of
-	 * enqueueing another write. The feed's payload already lives in `history`,
-	 * and a replay renders `history` at run time, so settling with the replay's
-	 * outcome loses nothing. Settlers attach one at a time; no unbounded spread
-	 * or snapshot string is ever built here.
+	 * Route an over-cap feed to the queue's tail replay instead of enqueueing
+	 * another write. The feed's payload already lives in `history` and the
+	 * replay renders history up to its mark, so advancing the mark and sharing
+	 * the replay's promise loses nothing while keeping the queue, its settler
+	 * memory, and the replay payload all O(1) per queued operation.
 	 */
 	private coalesceBacklogIntoReplay(): Promise<void> {
 		const tail = this.operations[this.operations.length - 1];
 		if (tail !== undefined && tail.kind === "replay") {
-			return trackSettler(tail.settlers);
+			tail.historyMark = this.historyEnd();
+			return sharedSettler(tail);
 		}
-		return this.enqueue({ kind: "replay", settlers: [] });
+		const operation: ReplayOperation = {
+			kind: "replay",
+			historyMark: this.historyEnd(),
+			settled: null,
+			settlers: [],
+		};
+		return this.enqueue(operation, sharedSettler(operation));
 	}
 
 	private async drain(): Promise<void> {
@@ -195,35 +221,30 @@ export class TerminalScreen {
 				await this.raceDisposal(this.write(operation.payload));
 				return;
 			case "replay":
-				this.absorbQueuedWrites(operation);
 				this.terminal.reset();
-				await this.raceDisposal(this.write(this.history.join("")));
+				await this.raceDisposal(this.write(this.renderHistory(operation.historyMark)));
 				return;
 			case "resize":
-				this.absorbQueuedWrites(operation);
 				this.terminal.dispose();
 				this.terminal = this.createTerminal(operation.cols, operation.rows);
-				await this.raceDisposal(this.write(this.history.join("")));
+				await this.raceDisposal(this.write(this.renderHistory(operation.historyMark)));
 				return;
 		}
 	}
 
 	/**
-	 * A replay or resize renders the full bounded `history` at run time, which
-	 * already contains every queued write's payload; running those writes
-	 * afterwards would duplicate their content on the fresh screen. Absorb
-	 * them instead: remove the queued writes and settle them with this
-	 * operation's outcome.
+	 * Render only the history recorded up to the operation's mark. Feeds made
+	 * after the mark keep their own queued writes and land after this barrier,
+	 * preserving FIFO order; feeds before it drained ahead of the barrier and
+	 * are reproduced exactly by the replayed prefix.
 	 */
-	private absorbQueuedWrites(into: ScreenOperation): void {
-		for (let index = this.operations.length - 1; index >= 0; index -= 1) {
-			const operation = this.operations[index];
-			if (operation === undefined || operation.kind !== "write") continue;
-			this.pendingWriteChars -= operation.payload.length;
-			for (const settler of operation.settlers) into.settlers.push(settler);
-			operation.settlers.length = 0;
-			this.operations.splice(index, 1);
-		}
+	private renderHistory(historyMark: number): string {
+		const end = Math.max(0, historyMark - this.historyHeadChunks);
+		return this.history.slice(0, end).join("");
+	}
+
+	private historyEnd(): number {
+		return this.historyHeadChunks + this.history.length;
 	}
 
 	/** A disposed terminal may never invoke its parse callback; do not hang. */
@@ -256,6 +277,7 @@ export class TerminalScreen {
 		while (this.historyLength > this.maxReplayHistoryLength && this.history.length > 1) {
 			const removed = this.history.shift();
 			if (removed === undefined) return;
+			this.historyHeadChunks += 1;
 			this.historyLength -= removed.length;
 		}
 

--- a/packages/pty/src/screen.ts
+++ b/packages/pty/src/screen.ts
@@ -9,6 +9,7 @@ import {
 	sharedSettler,
 	trackSettler,
 } from "./screen-operations.ts";
+
 import {
 	decodeInput,
 	normalizeDimension,
@@ -56,8 +57,7 @@ export class TerminalScreen {
 	private readonly history: string[] = [];
 	private historyLength = 0;
 	private readonly operations: ScreenOperation[] = [];
-	private historyHeadChunks = 0;
-	private pendingWriteChars = 0;
+	private pendingChars = 0;
 	private draining = false;
 	private disposed = false;
 	private notifyDisposed: () => void = () => undefined;
@@ -81,10 +81,10 @@ export class TerminalScreen {
 		const payload = decodeInput(data);
 		const sanitizedPayload = sanitizeString(payload);
 		if (sanitizedPayload.length > 0) this.appendHistory(sanitizedPayload);
-		if (this.pendingWriteChars + payload.length > MAX_PENDING_WRITE_CHARS) {
-			return this.coalesceBacklogIntoReplay();
+		if (this.pendingChars + payload.length > MAX_PENDING_WRITE_CHARS) {
+			return this.coalesceFeedIntoReplay(payload);
 		}
-		this.pendingWriteChars += payload.length;
+		this.pendingChars += payload.length;
 		const operation: ScreenOperation = { kind: "write", payload, settlers: [] };
 		return this.enqueue(operation, trackSettler(operation.settlers));
 	}
@@ -93,21 +93,27 @@ export class TerminalScreen {
 		if (this.disposed) return Promise.resolve();
 		const nextCols = normalizeDimension(cols, this.terminal.cols);
 		const nextRows = normalizeDimension(rows, this.terminal.rows);
+		const snapshot = this.history.join("");
 		const tail = this.operations[this.operations.length - 1];
 		if (tail !== undefined && tail.kind === "resize") {
 			tail.cols = nextCols;
 			tail.rows = nextRows;
-			tail.historyMark = this.historyEnd();
+			this.pendingChars += snapshot.length - tail.replay.length;
+			tail.replay = snapshot;
 			return sharedSettler(tail);
+		}
+		if (this.pendingChars + snapshot.length > MAX_PENDING_WRITE_CHARS) {
+			return this.coalesceQueueIntoResize(nextCols, nextRows, snapshot);
 		}
 		const operation: ResizeOperation = {
 			kind: "resize",
 			cols: nextCols,
 			rows: nextRows,
-			historyMark: this.historyEnd(),
+			replay: snapshot,
 			settled: null,
 			settlers: [],
 		};
+		this.pendingChars += snapshot.length;
 		return this.enqueue(operation, sharedSettler(operation));
 	}
 
@@ -148,7 +154,7 @@ export class TerminalScreen {
 		this.disposed = true;
 		this.notifyDisposed();
 		const pending = this.operations.splice(0, this.operations.length);
-		this.pendingWriteChars = 0;
+		this.pendingChars = 0;
 		for (const operation of pending) {
 			settleOperation(operation.settlers, null);
 		}
@@ -174,24 +180,55 @@ export class TerminalScreen {
 
 	/**
 	 * Route an over-cap feed to the queue's tail replay instead of enqueueing
-	 * another write. The feed's payload already lives in `history` and the
-	 * replay renders history up to its mark, so advancing the mark and sharing
-	 * the replay's promise loses nothing while keeping the queue, its settler
-	 * memory, and the replay payload all O(1) per queued operation.
+	 * another write. Replay payloads are owned snapshot strings (immune to
+	 * history trimming) bounded to the replay budget, and every coalesced feed
+	 * shares the tail's memoized promise, so a flood cannot grow the queue,
+	 * its payload memory, or its settler memory past the configured bounds.
 	 */
-	private coalesceBacklogIntoReplay(): Promise<void> {
+	private coalesceFeedIntoReplay(payload: string): Promise<void> {
 		const tail = this.operations[this.operations.length - 1];
 		if (tail !== undefined && tail.kind === "replay") {
-			tail.historyMark = this.historyEnd();
+			const previousLength = tail.payload.length;
+			tail.payload = this.boundReplayPayload(tail.payload + payload);
+			this.pendingChars += tail.payload.length - previousLength;
 			return sharedSettler(tail);
 		}
 		const operation: ReplayOperation = {
 			kind: "replay",
-			historyMark: this.historyEnd(),
+			payload: this.history.join(""),
 			settled: null,
 			settlers: [],
 		};
+		this.pendingChars += operation.payload.length;
 		return this.enqueue(operation, sharedSettler(operation));
+	}
+
+	/**
+	 * A resize whose snapshot would push the queued payload past the cap
+	 * collapses the whole queue into one resize at the latest dimensions:
+	 * every dropped operation's payload is already covered by the bounded
+	 * history snapshot, and their settlers settle with this operation.
+	 */
+	private coalesceQueueIntoResize(cols: number, rows: number, snapshot: string): Promise<void> {
+		const operation: ResizeOperation = {
+			kind: "resize",
+			cols,
+			rows,
+			replay: snapshot,
+			settled: null,
+			settlers: [],
+		};
+		for (const queued of this.operations.splice(0, this.operations.length)) {
+			for (const settler of queued.settlers) operation.settlers.push(settler);
+			queued.settlers.length = 0;
+		}
+		this.pendingChars = snapshot.length;
+		return this.enqueue(operation, sharedSettler(operation));
+	}
+
+	private boundReplayPayload(payload: string): string {
+		if (payload.length <= this.maxReplayHistoryLength) return payload;
+		return sanitizeString(payload.slice(-this.maxReplayHistoryLength));
 	}
 
 	private async drain(): Promise<void> {
@@ -201,7 +238,7 @@ export class TerminalScreen {
 			while (!this.disposed) {
 				const operation = this.operations.shift();
 				if (operation === undefined) return;
-				if (operation.kind === "write") this.pendingWriteChars -= operation.payload.length;
+				this.pendingChars -= operation.kind === "resize" ? operation.replay.length : operation.payload.length;
 				try {
 					await this.run(operation);
 					settleOperation(operation.settlers, null);
@@ -222,29 +259,14 @@ export class TerminalScreen {
 				return;
 			case "replay":
 				this.terminal.reset();
-				await this.raceDisposal(this.write(this.renderHistory(operation.historyMark)));
+				await this.raceDisposal(this.write(operation.payload));
 				return;
 			case "resize":
 				this.terminal.dispose();
 				this.terminal = this.createTerminal(operation.cols, operation.rows);
-				await this.raceDisposal(this.write(this.renderHistory(operation.historyMark)));
+				await this.raceDisposal(this.write(operation.replay));
 				return;
 		}
-	}
-
-	/**
-	 * Render only the history recorded up to the operation's mark. Feeds made
-	 * after the mark keep their own queued writes and land after this barrier,
-	 * preserving FIFO order; feeds before it drained ahead of the barrier and
-	 * are reproduced exactly by the replayed prefix.
-	 */
-	private renderHistory(historyMark: number): string {
-		const end = Math.max(0, historyMark - this.historyHeadChunks);
-		return this.history.slice(0, end).join("");
-	}
-
-	private historyEnd(): number {
-		return this.historyHeadChunks + this.history.length;
 	}
 
 	/** A disposed terminal may never invoke its parse callback; do not hang. */
@@ -277,7 +299,6 @@ export class TerminalScreen {
 		while (this.historyLength > this.maxReplayHistoryLength && this.history.length > 1) {
 			const removed = this.history.shift();
 			if (removed === undefined) return;
-			this.historyHeadChunks += 1;
 			this.historyLength -= removed.length;
 		}
 

--- a/packages/pty/src/screen.ts
+++ b/packages/pty/src/screen.ts
@@ -31,6 +31,7 @@ export class TerminalScreen {
 	private terminal: XtermTerminalType;
 	private readonly history: string[] = [];
 	private historyLength = 0;
+	private writeQueue: Promise<void> = Promise.resolve();
 	private readonly maxReplayHistoryLength: number;
 	private readonly scrollback: number;
 
@@ -46,19 +47,22 @@ export class TerminalScreen {
 		const payload = decodeInput(data);
 		const sanitizedPayload = sanitizeString(payload);
 		if (sanitizedPayload.length > 0) this.appendHistory(sanitizedPayload);
-		return this.write(payload);
+		return this.enqueueWrite(payload);
 	}
 
 	resize(cols: number, rows: number): Promise<void> {
 		const nextCols = normalizeDimension(cols, this.terminal.cols);
 		const nextRows = normalizeDimension(rows, this.terminal.rows);
-		this.terminal.dispose();
-		this.terminal = this.createTerminal(nextCols, nextRows);
-		return this.write(this.history.join(""));
+		const replay = this.history.join("");
+		return this.enqueue(async () => {
+			this.terminal.dispose();
+			this.terminal = this.createTerminal(nextCols, nextRows);
+			await this.write(replay);
+		});
 	}
 
 	flush(): Promise<void> {
-		return this.write("");
+		return this.enqueueWrite("");
 	}
 
 	snapshot(): TerminalScreenSnapshot {
@@ -100,6 +104,19 @@ export class TerminalScreen {
 			allowProposedApi: true,
 			logLevel: "off",
 		});
+	}
+
+	private enqueueWrite(payload: string): Promise<void> {
+		return this.enqueue(() => this.write(payload));
+	}
+
+	private enqueue(operation: () => Promise<void>): Promise<void> {
+		const result = this.writeQueue.then(operation);
+		this.writeQueue = result.then(
+			() => undefined,
+			() => undefined,
+		);
+		return result;
 	}
 
 	private write(payload: string): Promise<void> {

--- a/packages/pty/src/screen.ts
+++ b/packages/pty/src/screen.ts
@@ -7,7 +7,6 @@ import {
 	type ScreenOperation,
 	settleOperation,
 	sharedSettler,
-	trackSettler,
 } from "./screen-operations.ts";
 
 import {
@@ -85,8 +84,8 @@ export class TerminalScreen {
 			return this.coalesceFeedIntoReplay(payload);
 		}
 		this.pendingChars += payload.length;
-		const operation: ScreenOperation = { kind: "write", payload, settlers: [] };
-		return this.enqueue(operation, trackSettler(operation.settlers));
+		const operation: ScreenOperation = { kind: "write", payload, settled: null, settlers: [] };
+		return this.enqueue(operation, sharedSettler(operation));
 	}
 
 	resize(cols: number, rows: number): Promise<void> {
@@ -117,10 +116,18 @@ export class TerminalScreen {
 		return this.enqueue(operation, sharedSettler(operation));
 	}
 
+	/**
+	 * Resolves once everything fed before this call has been parsed. Attaches
+	 * to the queue tail instead of enqueueing a marker so a flush can never
+	 * split a tail replay (which would let over-cap feeds mint unbounded new
+	 * replay operations); only an empty queue enqueues a zero-length write.
+	 */
 	flush(): Promise<void> {
 		if (this.disposed) return Promise.resolve();
-		const operation: ScreenOperation = { kind: "write", payload: "", settlers: [] };
-		return this.enqueue(operation, trackSettler(operation.settlers));
+		const tail = this.operations[this.operations.length - 1];
+		if (tail !== undefined) return sharedSettler(tail);
+		const operation: ScreenOperation = { kind: "write", payload: "", settled: null, settlers: [] };
+		return this.enqueue(operation, sharedSettler(operation));
 	}
 
 	snapshot(): TerminalScreenSnapshot {

--- a/packages/pty/test/screen.test.ts
+++ b/packages/pty/test/screen.test.ts
@@ -388,6 +388,35 @@ describe("TerminalScreen", () => {
 		}
 	});
 
+	it("keeps one bounded replay when flushes interleave an over-cap flood", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		xterm.Terminal.prototype.write = function heldWrite(): void {};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 4, scrollback: 10 });
+			const chunk = "y".repeat(65_536);
+			const outcomes: Promise<void>[] = [];
+			for (let index = 0; index < 17; index += 1) {
+				outcomes.push(screen.feed(chunk));
+			}
+			const firstCoalesced = screen.feed(chunk);
+			outcomes.push(firstCoalesced);
+
+			for (let index = 0; index < 30; index += 1) {
+				outcomes.push(screen.flush());
+				const coalesced = screen.feed(chunk);
+				outcomes.push(coalesced);
+				expect(coalesced).toBe(firstCoalesced);
+			}
+
+			screen.dispose();
+			const results = await Promise.allSettled(outcomes);
+			expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
+
 	it("keeps a queued resize replay intact when later floods trim history", async () => {
 		const originalWrite = xterm.Terminal.prototype.write;
 		const heldWrite: { release: (() => void) | null } = { release: null };

--- a/packages/pty/test/screen.test.ts
+++ b/packages/pty/test/screen.test.ts
@@ -388,6 +388,38 @@ describe("TerminalScreen", () => {
 		}
 	});
 
+	it("keeps a queued resize replay intact when later floods trim history", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		const heldWrite: { release: (() => void) | null } = { release: null };
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			if (heldWrite.release === null) {
+				heldWrite.release = () => originalWrite.call(this, data, callback);
+				return;
+			}
+			originalWrite.call(this, data, callback);
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 10, rows: 4, scrollback: 10 });
+			const held = screen.feed("A");
+			const resized = screen.resize(5, 4);
+			const flood = screen.feed("\u001b7".repeat(100_000));
+			heldWrite.release?.();
+
+			await Promise.all([held, resized, flood]);
+			expect(screen.snapshot().cols).toBe(5);
+			expect(screen.snapshot().visibleGrid[0]).toBe("A");
+			screen.dispose();
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	}, 30_000);
+
 	it("delivers write rejections to the owning caller and keeps the queue usable", async () => {
 		const originalWrite = xterm.Terminal.prototype.write;
 

--- a/packages/pty/test/screen.test.ts
+++ b/packages/pty/test/screen.test.ts
@@ -246,6 +246,66 @@ describe("TerminalScreen", () => {
 		}
 	}, 30_000);
 
+	it("coalesces an over-cap flood without unbounded settler spreads", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		xterm.Terminal.prototype.write = function heldWrite(): void {};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 4, scrollback: 10 });
+			const chunk = "zzzz";
+			const roundSize = 262_145;
+			const outcomes: Promise<void>[] = [];
+			for (let round = 0; round < 2; round += 1) {
+				for (let index = 0; index < roundSize; index += 1) {
+					outcomes.push(screen.feed(chunk));
+				}
+			}
+			screen.dispose();
+
+			const results = await Promise.allSettled(outcomes);
+			expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	}, 60_000);
+
+	it("merges queued resizes instead of storing a replay snapshot per resize", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		let capturing = false;
+		let capturedWrites = 0;
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			if (capturing) capturedWrites += 1;
+			originalWrite.call(this, data, callback);
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 40, rows: 4, scrollback: 10 });
+			await screen.feed("seed");
+			capturing = true;
+
+			const outcomes: Promise<void>[] = [];
+			for (let index = 0; index < 100; index += 1) {
+				outcomes.push(screen.resize(10 + (index % 5), 4));
+			}
+			await Promise.all(outcomes);
+
+			const snapshot = screen.snapshot();
+			expect(snapshot.cols).toBe(10 + (99 % 5));
+			expect(snapshot.visibleGrid[0]).toBe("seed");
+			// 100 queued resizes must collapse into at most two replay renders:
+			// the in-flight head resize plus one merged tail resize.
+			expect(capturedWrites).toBeLessThanOrEqual(2);
+			screen.dispose();
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
+
 	it("delivers write rejections to the owning caller and keeps the queue usable", async () => {
 		const originalWrite = xterm.Terminal.prototype.write;
 

--- a/packages/pty/test/screen.test.ts
+++ b/packages/pty/test/screen.test.ts
@@ -92,6 +92,45 @@ describe("TerminalScreen", () => {
 		}
 	});
 
+	it("serializes concurrent feeds through xterm write callbacks", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		let writePending = false;
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			if (writePending) {
+				throw new Error("write data discarded, use flow control to avoid losing data");
+			}
+			writePending = true;
+			originalWrite.call(this, data, () => {
+				writePending = false;
+				callback?.();
+			});
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 2, scrollback: 10 });
+			await Promise.all([screen.feed("first"), screen.feed(" second"), screen.feed(" third")]);
+
+			expect(screen.snapshot().visibleGrid[0]).toBe("first second third");
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
+
+	it("orders resize replay between concurrent feeds", async () => {
+		const screen = new TerminalScreen({ cols: 6, rows: 4, scrollback: 10 });
+
+		await Promise.all([screen.feed("abcdef"), screen.resize(3, 4), screen.feed("ghi")]);
+
+		const snapshot = screen.snapshot();
+		expect(snapshot.cols).toBe(3);
+		expect(snapshot.visibleGrid).toEqual(["abc", "def", "ghi", ""]);
+	});
+
 	it("bounds resize replay history in long sessions", async () => {
 		const originalWrite = xterm.Terminal.prototype.write;
 		const replayLengths: number[] = [];

--- a/packages/pty/test/screen.test.ts
+++ b/packages/pty/test/screen.test.ts
@@ -306,6 +306,88 @@ describe("TerminalScreen", () => {
 		}
 	});
 
+	it("shares one promise across all feeds coalesced into the same replay", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		xterm.Terminal.prototype.write = function heldWrite(): void {};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 4, scrollback: 10 });
+			const chunk = "y".repeat(65_536);
+			const promises = Array.from({ length: 20 }, () => screen.feed(chunk));
+
+			const coalesced = promises.slice(17);
+			for (const promise of coalesced) {
+				expect(promise).toBe(coalesced[0]);
+			}
+			expect(promises[0]).not.toBe(coalesced[0]);
+
+			screen.dispose();
+			await expect(Promise.all(promises)).resolves.toBeDefined();
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
+
+	it("shares one promise across resizes merged into the same queued resize", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		xterm.Terminal.prototype.write = function heldWrite(): void {};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 4, scrollback: 10 });
+			const first = screen.resize(10, 4);
+			const queued = screen.resize(11, 4);
+			const mergedA = screen.resize(12, 4);
+			const mergedB = screen.resize(13, 4);
+
+			expect(mergedA).toBe(queued);
+			expect(mergedB).toBe(queued);
+			expect(first).not.toBe(queued);
+
+			screen.dispose();
+			await expect(Promise.all([first, queued, mergedA, mergedB])).resolves.toBeDefined();
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
+
+	it("keeps feeds after a queued resize behind that barrier", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		const sequence: Array<[string, number]> = [];
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			const payload = typeof data === "string" ? data : new TextDecoder().decode(data);
+			sequence.push([payload, this.cols]);
+			originalWrite.call(this, data, callback);
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 10, rows: 4, scrollback: 10 });
+			await Promise.all([
+				screen.feed("A"),
+				screen.resize(3, 4),
+				screen.feed("X"),
+				screen.resize(5, 4),
+				screen.feed("B"),
+			]);
+
+			expect(sequence).toEqual([
+				["A", 10],
+				["A", 3],
+				["X", 3],
+				["AX", 5],
+				["B", 5],
+			]);
+			expect(screen.snapshot().visibleGrid[0]).toBe("AXB");
+			screen.dispose();
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
+
 	it("delivers write rejections to the owning caller and keeps the queue usable", async () => {
 		const originalWrite = xterm.Terminal.prototype.write;
 

--- a/packages/pty/test/screen.test.ts
+++ b/packages/pty/test/screen.test.ts
@@ -168,4 +168,106 @@ describe("TerminalScreen", () => {
 		// but exceed it on the slower Windows CI runner; give this long-session
 		// case explicit headroom rather than weakening the scrollback coverage.
 	}, 30000);
+
+	it("survives an unawaited feed flood beyond xterm's pending-write watermark", async () => {
+		const screen = new TerminalScreen({ cols: 80, rows: 24, scrollback: 100 });
+		const chunk = `${"x".repeat(4095)}\n`;
+
+		const results = await Promise.allSettled(Array.from({ length: 13_000 }, () => screen.feed(chunk)));
+
+		const rejected = results.filter((result) => result.status === "rejected");
+		expect(rejected).toEqual([]);
+
+		await screen.flush();
+		expect(screen.snapshot().visibleGrid.some((line) => line.includes("x"))).toBe(true);
+		screen.dispose();
+	}, 60_000);
+
+	it("settles queued operations on dispose without recreating a terminal", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		const originalDispose = xterm.Terminal.prototype.dispose;
+		let disposeCalls = 0;
+		let writesAfterDispose = 0;
+		let screenDisposed = false;
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			if (screenDisposed) writesAfterDispose += 1;
+			originalWrite.call(this, data, callback);
+		};
+		xterm.Terminal.prototype.dispose = function patchedDispose(this: XtermTerminalType): void {
+			disposeCalls += 1;
+			originalDispose.call(this);
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 4, scrollback: 10 });
+			const outcomes = [screen.feed("before"), screen.resize(40, 5), screen.feed(" after")];
+			screenDisposed = true;
+			screen.dispose();
+
+			await expect(Promise.all(outcomes)).resolves.toEqual([undefined, undefined, undefined]);
+			expect(writesAfterDispose).toBe(0);
+			expect(disposeCalls).toBe(1);
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+			xterm.Terminal.prototype.dispose = originalDispose;
+		}
+	});
+
+	it("bounds the queued write backlog by coalescing into a bounded replay", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+		let writtenChars = 0;
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			writtenChars += typeof data === "string" ? data.length : data.byteLength;
+			originalWrite.call(this, data, callback);
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 4, scrollback: 10 });
+			const chunk = "y".repeat(65_536);
+			const results = await Promise.allSettled(Array.from({ length: 96 }, () => screen.feed(chunk)));
+
+			expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+			// 6 MiB submitted; the parsed volume must stay near the 1 MiB pending
+			// cap plus the bounded replay, nowhere near the full submission.
+			expect(writtenChars).toBeLessThan(3 * 1_048_576);
+			screen.dispose();
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	}, 30_000);
+
+	it("delivers write rejections to the owning caller and keeps the queue usable", async () => {
+		const originalWrite = xterm.Terminal.prototype.write;
+
+		xterm.Terminal.prototype.write = function patchedWrite(
+			this: XtermTerminalType,
+			data: string | Uint8Array,
+			callback?: () => void,
+		): void {
+			const payload = typeof data === "string" ? data : new TextDecoder().decode(data);
+			if (payload.includes("poison")) throw new Error("synthetic xterm write failure");
+			originalWrite.call(this, data, callback);
+		};
+
+		try {
+			const screen = new TerminalScreen({ cols: 20, rows: 2, scrollback: 10 });
+			await screen.feed("ok");
+			await expect(screen.feed("poison")).rejects.toThrow("synthetic xterm write failure");
+			await expect(screen.feed(" fine")).resolves.toBeUndefined();
+			expect(screen.snapshot().visibleGrid[0]).toBe("ok fine");
+			screen.dispose();
+		} finally {
+			xterm.Terminal.prototype.write = originalWrite;
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Persistent-terminal screen writes now run through one FIFO operation queue with real flow control, fixing the Windows omo-ai crash:

```
Error: write data discarded, use flow control to avoid losing data
    at TerminalScreen.write (@earendil-works/pi-pty/dist/screen.js)
    at TerminalRuntimeSession.ingest (.../terminal/runtime-session.js)
```

`TerminalRuntimeSession.ingest` intentionally fires `screen.feed()` without awaiting, so fast PTY output (Windows pipe-fallback floods especially) could enqueue past xterm's 50M-char pending-write watermark; xterm then threw, the discarded promise became an unhandled rejection, and the process exited.

Supersedes #837 (its serialization commit is cherry-picked here with authorship preserved, thanks @stevenahhh) and additionally fixes the four blockers from the 2026-08-17 ULW audit (`local-ignore/qa-evidence/20260817-fix-pr-audit/pr-837/DOSSIER.md`):

- **Serialization**: every mutation (feed/resize/replay) awaits xterm's parse callback before the next write ships (#837, cherry-picked).
- **Bounded backlog** (audit blocker 2): beyond 1 MiB of queued-unparsed characters, queued writes collapse into a single bounded history replay (`terminal.reset()` + replay of the already-bounded history), so memory and parse latency stay bounded under sustained floods instead of growing an unbounded promise queue.
- **Queue-aware disposal** (audit blocker 1): `dispose()` settles all queued operations as resolved no-ops and a terminal is never created after disposal — the queued-resize resurrection race from the audit is gone. In-flight writes race against disposal so callers never hang on a disposed terminal's parse callback.
- **Rejection ownership** (audit blocker 3): operation rejections belong to the owning caller's promise; the queue never poisons and never leaks unhandled rejections. `TerminalRuntimeSession` explicitly owns the fire-and-forget `feed`/`resize` rejections at the call sites that crashed omo-ai.
- **Rebase** (audit blocker 4): built on current `main`; only the CHANGELOG had conflicted.

`screen.ts` was over the 250-LOC ceiling after the fix, so text/dimension normalization moved to `screen-text.ts` and queue operation types/settling to `screen-operations.ts` (no behavior change).

## Verification

- RED (pre-fix `main` screen.ts): the new flood regression rejects with the exact xterm discard error; dispose/backlog tests fail on the unbounded queue.
- RED (pre-fix runtime-session): the new ownership test captures the unhandled rejection that killed omo-ai.
- GREEN: full `packages/pty` suite + both runtime tests + root `npm run check`, executed remotely on mengmotaMac; evidence in the session ledger.
- Regression: existing serialization/resize-ordering/replay-bounding tests unchanged and green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows crash where fast PTY output exceeded xterm's pending-write watermark, discarding data and killing Senpi. Terminal screen writes now run through a flow-controlled FIFO queue that is disposal-safe and rejection-safe.

**Changes**
- Feed, resize, and replay operations await xterm's parse callback before the next write.
- Queued writes beyond 1 MiB collapse into a single bounded history replay; coalesced callers share one promise and one settler, and flushes attach to the queue tail instead of enqueueing markers that could split a replay.
- Replays render owned snapshots immune to history trimming; feeds after a queued resize land behind that barrier, and queued resizes merge into the latest dimensions.
- Disposal settles queued operations and in-flight writes as resolved no-ops; no terminal is created after disposal.
- Operation rejections go to the owning caller's promise; `TerminalRuntimeSession` attaches one rejection handler per distinct coalesced promise.

<sup>Written for commit f05b37ef364cddfb175be8cf44df416b57cc9c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

