### PR TITLE
test(rpc): make interactive-host entry parity rules-hermetic

### DIFF
--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,9 @@
 # Local fork changes
 
+## 2026-08-30 - Make interactive-host entry-parity tests rules-hermetic
+
+- The spawned RPC host in `test/interactive-host-runtime.test.ts` now sets `PI_RULES_DISABLED=1`, so the rules extension's asynchronous `pi-rules.scan` custom entry can no longer race the host-vs-local entry parity assertions (flaky `transports setup mutations to the authoritative host before rebind` on CI shard 1/3).
+
 ## 2026-08-29 - GLM-5.3 default and prompt preset
 
 - Use GLM-5.3 as the Z.AI global and China default, with the matching built-in prompt preset from current main.

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -3,6 +3,7 @@
 ## 2026-08-30 - Make interactive-host entry-parity tests rules-hermetic
 
 - The spawned RPC host in `test/interactive-host-runtime.test.ts` now sets `PI_RULES_DISABLED=1`, so the rules extension's asynchronous `pi-rules.scan` custom entry can no longer race the host-vs-local entry parity assertions (flaky `transports setup mutations to the authoritative host before rebind` on CI shard 1/3).
+- The tree-navigation regression now asserts navigation through its real contract: `SessionManager.branch()` is a memory-only leaf-pointer move, so the test proves the host applied it by checking that the next host append (`session_info`) lands as a root entry. The old persisted-leaf-changed assertion only ever passed when the rules extension's async scan entry happened to append after the branch, which was the flake.
 
 ## 2026-08-29 - GLM-5.3 default and prompt preset
 

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -87,6 +87,10 @@ function spawnHost(
 				...hermeticProviderEnv(),
 				PI_OFFLINE: "1",
 				PI_TELEMETRY: "0",
+				// The rules extension appends an async `pi-rules.scan` entry on the
+				// host after session start, racing entry-parity assertions between
+				// the host and the local mirror. No test here exercises rules.
+				PI_RULES_DISABLED: "1",
 				SENPI_RUNTIME: "node",
 				SENPI_CODING_AGENT_DIR: qa.agentDir,
 				SENPI_CODING_AGENT_SESSION_DIR: qa.sessionDir,

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -1160,15 +1160,29 @@ describe("interactive host runtime", () => {
 			ensureHost: async () => undefined,
 		});
 		try {
-			const before = runtime.session.sessionManager.getLeafId();
-			await runtime.session.navigateTree(userId, { summarize: false });
-			const persistedHostSession = SessionManager.open(runtime.session.sessionFile!);
-			expect(before).not.toBe(persistedHostSession.getLeafId());
-			expect(persistedHostSession.getLeafId()).toBe(runtime.session.sessionManager.getLeafId());
+			const result = await runtime.session.navigateTree(userId, { summarize: false });
+			expect(result.cancelled).toBe(false);
+			expect(result.editorText).toBe("nav-user");
 			expect(runtime.session.messages).toContainEqual({
 				role: "user",
 				content: "nav-user",
 				timestamp: 1,
+			});
+			// SessionManager.branch() moves the leaf pointer in memory only, so the
+			// host's applied navigation is proven by where the NEXT host append
+			// parents: navigating to the root user message moved the leaf to null,
+			// so the session_info below must land as a root entry. The previous
+			// persisted-leaf assertion only ever held when the rules extension's
+			// async `pi-rules.scan` append raced in ahead of it.
+			await runtime.session.setSessionName("post-nav");
+			const sessionFile = runtime.session.sessionFile!;
+			await vi.waitFor(() => {
+				const persisted = SessionManager.open(sessionFile);
+				const info = persisted
+					.getEntries()
+					.find((entry) => entry.type === "session_info" && entry.name === "post-nav");
+				expect(info).toBeDefined();
+				expect(info?.parentId).toBeNull();
 			});
 		} finally {
 			await runtime.dispose();


### PR DESCRIPTION
## Summary

Disable the rules extension (\`PI_RULES_DISABLED=1\`) in the spawned RPC host of \`interactive-host-runtime.test.ts\`.

## Root cause

The rules builtin appends an asynchronous \`pi-rules.scan\` custom entry on the host right after session start. The entry-parity assertion in \`transports setup mutations to the authoritative host before rebind\` compares the local mirror's entries with the host's at one instant, so the scan entry lands on one side but not the other depending on timing: CI shard 1/3 failed with \`expected [ Array(4) ] to deeply equal [ Array(5) ]\`, where the extra entry was exactly \`pi-rules.scan\` (runs 33309893200, 33311735408 on #1214). No test in this file exercises rules, so the host fixture disables the extension via its documented env gate, matching the file's existing hermetic env (PI_OFFLINE/PI_TELEMETRY).

## Verification

- Test-only change; the flake reproduced twice on PR #1214's CI with the identical missing-entry diff.
- Full test file green post-change (see PR checks).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky RPC entry-parity test by making the spawned host rules-hermetic and proving routed navigation through the next host append.

- Sets `PI_RULES_DISABLED=1` in the test host env so the rules extension's async `pi-rules.scan` entry can't race the host-vs-local entry parity assertions.
- The navigation regression now asserts the host applied the branch by checking that the next host append lands as a root entry, since `SessionManager.branch()` only moves the in-memory leaf pointer.
- Documents both changes in `packages/coding-agent/changes.md`.

<sup>Written for commit 45b8653e326a1b1478aa0ad616429490a026c646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

