### PR TITLE
fix(rpc): deliver session events across a deferred rebind

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 ### Fixed
 
+- Entries an extension appends while a replaced session is still binding (for example the `pi-rules` scan) now reach every attached RPC connection. The event subscription was reinstalled only after the deferred bind finished, so those durable entries were never delivered, and because the session file is not written until an assistant message exists nothing else could carry them.
+
+- The shared interactive host mirror now reconciles to the complete entry list the host reports, instead of backfilling only when empty, so it no longer stays permanently short of entries after a session replacement.
+
 - Fixed shared RPC socket host startup to fail fast when the spawned host exits before answering `get_protocol_info`, instead of silently consuming the full 10-second readiness budget, and made readiness diagnostics honest: an early exit reports the child's exit code, an incompatible host reports its advertised server version and capabilities against the expected values, and a host that never answered keeps the existing timeout message.
 
 ### New Features

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-30 - Reconcile the shared-host mirror to the host entry list
+
+### What changed
+
+- `interactive-host-runtime.ts`: `performRefresh()` reconciles the session mirror to the complete entry list the host ships in `get_state`, whenever that list is present, instead of backfilling only an empty mirror. A mismatch rebuilds the mirror from the authoritative list, keeping any entry whose `entry_appended` notification crossed the refresh - such an entry postdates the snapshot, so dropping it would strand it until an unrelated refresh happened to run.
+
+### Why
+
+- The host ships its full entry list only while the session file is still deferred (no assistant message yet, so nothing has been written to disk), which makes that list the only authoritative view of the session. `entry_appended` notifications that cross a concurrent refresh land on whichever manager object is current at that instant, so the mirror could hold an arbitrary partial set rather than a prefix of the host's list; backfill-only-when-empty then wedged it at that partial set permanently. Together with event delivery across the rebind this makes the mirror converge after a replacement.
+
+### Why an extension could not handle it
+
+- The mirror is proxy state beneath every extension surface; no extension hook observes it.
+
+### Expected merge conflict zones
+
+- LOW: the entry-list reconciliation block inside `performRefresh()`.
+
+
 ## 2026-08-30 - Rebind the shared-host proxy on session_replaced
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -521,6 +521,10 @@ export function createRemoteSessionProxy(
 		for (const listener of listeners) listener(event);
 	});
 	const performRefresh = async (): Promise<void> => {
+		// Captured before the first await: entries that arrive via `entry_appended`
+		// while this refresh is in flight are newer than the snapshot it reconciles
+		// against, and must survive the rebuild below.
+		const idsAtRefreshStart = new Set(sessionManager.getEntries().map((entry) => entry.id));
 		const nextState = await client.getState();
 		state = { ...stateFromRpc(nextState) };
 		nextQueuedInputOrder = Math.max(0, ...nextState.ordered.map((item) => item.enqueueOrder));
@@ -539,8 +543,35 @@ export function createRemoteSessionProxy(
 				// deferred creating the file for a setup-only session.
 				sessionManager = SessionManager.open(nextState.sessionFile, undefined, nextState.cwd);
 			}
-			if (nextState.entries?.length && !sessionManager.getEntries().length) {
-				for (const entry of nextState.entries) sessionManager.appendEntry(entry);
+			// The host ships its complete entry list while the session file is still
+			// deferred (no assistant message yet, so nothing has been written), which
+			// makes that list the only authoritative view of the session. Reconcile the
+			// mirror to it exactly: `entry_appended` notifications that cross a
+			// concurrent refresh land on whichever manager is current, so the mirror
+			// can hold an arbitrary partial set rather than a prefix, and a snapshot
+			// taken mid-bind can simply be short. Backfilling only an empty mirror
+			// wedged it at whatever partial set it happened to hold.
+			const authoritative = nextState.entries;
+			if (authoritative?.length) {
+				const mirror = sessionManager.getEntries();
+				const matches =
+					mirror.length === authoritative.length &&
+					mirror.every((entry, index) => entry.id === authoritative[index]?.id);
+				if (!matches) {
+					const rebuilt = SessionManager.open(nextState.sessionFile, undefined, nextState.cwd);
+					for (const entry of authoritative) rebuilt.appendEntry(entry);
+					// A notification that crossed this refresh refers to an entry the
+					// snapshot predates, so it is newer than the snapshot; dropping it
+					// would strand the entry until an unrelated refresh happened to
+					// run. Keep it, in arrival order, after the authoritative list.
+					const authoritativeIds = new Set(authoritative.map((entry) => entry.id));
+					for (const entry of mirror) {
+						if (!idsAtRefreshStart.has(entry.id) && !authoritativeIds.has(entry.id)) {
+							rebuilt.appendEntry(entry);
+						}
+					}
+					sessionManager = rebuilt;
+				}
 			}
 			messages = sessionManager.buildSessionContext().messages;
 		} else {

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-08-30 - Deliver session events across a deferred rebind
+
+### What changed
+
+- `connection-handler.ts`: `rebindSession()` installs the session event subscription on the replaced session immediately after the swap, instead of only after the deferred derived-surface refresh completes, and the post-refresh install is removed - it would have re-subscribed and replayed the settings-source selection a second time, since `AgentSession.subscribe()` replays the current selection to every new listener. `installSessionSubscriptions` became a hoisted function declaration so the eagerly-run initial bind can reach it. The deferred refresh still reports its failure as `rpc_error`.
+
+### Why
+
+- A replacement swaps the live session and rebinds extensions afterwards, and that bind is deferred by design: awaiting it would deadlock a client whose `session_start` handler blocks on an `extension_ui_request` it cannot answer while still awaiting the replacement response. But the bind still mutates the session it owns - the pi-rules builtin appends a durable `pi-rules.scan` entry from `session_start` - and those entries were never forwarded, because the subscription was torn down at rebind start and reinstalled only once the bind finished. Nothing else can carry them: the session file is not written until an assistant message exists, so a client that misses the notification can never reconstruct the session it is bound to. Observed as the shared-host mirror ending one entry short after `new_session`, roughly one run in six under load.
+
+### Why an extension could not handle it
+
+- The event subscription belongs to the connection handler, beneath every extension surface; no extension hook can observe or reinstate it.
+
+### Expected merge conflict zones
+
+- LOW: the tail of `rebindSession()` and the `installSessionSubscriptions` declaration.
+
+
 ## 2026-08-30 - Expose session_replaced on the public client event union
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -683,6 +683,17 @@ export function createRpcConnectionHandler(
 				})
 			: undefined;
 		subscribeLoadedSurfaceEvents();
+		// Subscribe to the replaced session before its bind runs, not after. The bind
+		// is deferred by design - awaiting it would deadlock a client whose
+		// session_start handler blocks on an extension_ui_request it cannot answer
+		// while still awaiting the replacement response - and it still mutates the
+		// session it owns: pi-rules appends a durable scan entry from session_start.
+		// Those entries must reach every attached connection, and nothing else can
+		// carry them, because the session file is not written until an assistant
+		// message exists, so a client that misses the notification can never
+		// reconstruct the session it is bound to. Installing here also drops the
+		// previous session's subscription immediately instead of after the bind.
+		installSessionSubscriptions();
 		const refresh = refreshLoadedSurfacesAfter(
 			() =>
 				session.bindExtensions({
@@ -731,7 +742,7 @@ export function createRpcConnectionHandler(
 				}),
 			true,
 		);
-		const installSessionSubscriptions = () => {
+		function installSessionSubscriptions(): void {
 			unsubscribe?.();
 			unsubscribeBackpressure?.();
 			unsubscribe = session.subscribe((event) => {
@@ -765,15 +776,17 @@ export function createRpcConnectionHandler(
 			unsubscribeBackpressure = session.agent.subscribe(async () => {
 				await waitForRpcBackpressure();
 			});
-		};
+		}
 		if (deferRefresh) {
-			void refresh.then(installSessionSubscriptions, (cause) => {
+			// The subscription is already installed on the replaced session above, so
+			// the deferred refresh only needs its failure reported. Re-installing here
+			// would replay the settings-source selection a second time.
+			void refresh.catch((cause) => {
 				outputEvent({ type: "rpc_error", error: String(cause) });
 			});
 			return;
 		}
 		await refresh;
-		installSessionSubscriptions();
 	};
 
 	/**

--- a/packages/coding-agent/test/rpc-rebind-event-continuity.test.ts
+++ b/packages/coding-agent/test/rpc-rebind-event-continuity.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Event continuity across a session replacement.
+ *
+ * A replacement swaps the live session and rebinds extensions afterwards. That
+ * rebind is deferred by design: awaiting it would deadlock a client whose
+ * session_start handler blocks on an extension_ui_request it cannot answer
+ * while still awaiting the replacement response. But the deferred bind still
+ * mutates the session it owns - the pi-rules builtin appends a `pi-rules.scan`
+ * entry from `session_start` - and those durable entries must reach every
+ * attached connection. A client that misses them can never reconstruct the
+ * session it is bound to: nothing else re-reads the binding, and the file is
+ * not written until an assistant message exists, so disk cannot rescue it.
+ *
+ * Pinned in-process against the real `createRpcConnectionHandler` with a real
+ * `AgentSession` from the suite harness, so the bind runs for real and the
+ * append lands inside it - no child process, no load, no timing.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.ts";
+import type { AgentSessionRuntime } from "../src/core/agent-session-runtime.ts";
+import { createRpcConnectionHandler, type RpcConnectionSink } from "../src/modes/rpc/connection-handler.ts";
+import { createHarness, type Harness } from "./suite/harness.ts";
+
+type RpcRecord = Record<string, unknown>;
+
+function makeSink(): {
+	sink: RpcConnectionSink;
+	waitFor: (p: (r: RpcRecord) => boolean, t?: number) => Promise<RpcRecord>;
+} {
+	const records: RpcRecord[] = [];
+	const waiters: Array<{ predicate: (r: RpcRecord) => boolean; resolve: (r: RpcRecord) => void }> = [];
+	let buffer = "";
+	const dispatch = (record: RpcRecord) => {
+		records.push(record);
+		for (const waiter of [...waiters]) {
+			if (!waiter.predicate(record)) continue;
+			waiters.splice(waiters.indexOf(waiter), 1);
+			waiter.resolve(record);
+		}
+	};
+	return {
+		sink: {
+			writeRaw(chunk) {
+				buffer += chunk;
+				let newline = buffer.indexOf("\n");
+				while (newline !== -1) {
+					const line = buffer.slice(0, newline);
+					buffer = buffer.slice(newline + 1);
+					if (line) {
+						try {
+							dispatch(JSON.parse(line) as RpcRecord);
+						} catch {
+							/* partial line */
+						}
+					}
+					newline = buffer.indexOf("\n");
+				}
+			},
+			waitForBackpressure: async () => {},
+		},
+		waitFor(predicate, timeoutMs = 5_000) {
+			const existing = records.find(predicate);
+			if (existing) return Promise.resolve(existing);
+			return new Promise((resolve, reject) => {
+				let waiter!: (typeof waiters)[number];
+				const timer = setTimeout(() => {
+					const index = waiters.indexOf(waiter);
+					if (index !== -1) waiters.splice(index, 1);
+					reject(new Error("Timed out waiting for the expected RPC record"));
+				}, timeoutMs);
+				waiter = {
+					predicate,
+					resolve: (record) => {
+						clearTimeout(timer);
+						resolve(record);
+					},
+				};
+				waiters.push(waiter);
+			});
+		},
+	};
+}
+
+function makeRuntimeHost(initial: AgentSession): {
+	runtimeHost: AgentSessionRuntime;
+	replaceWith: (next: AgentSession) => Promise<void>;
+} {
+	let live = initial;
+	let rebind: (() => Promise<void>) | undefined;
+	const runtimeHost = {
+		get session() {
+			return live;
+		},
+		newSession: vi.fn(async () => ({ cancelled: true })),
+		switchSession: vi.fn(async () => ({ cancelled: true })),
+		fork: vi.fn(async () => ({ cancelled: true, selectedText: "" })),
+		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn((callback?: () => Promise<void>) => {
+			rebind = callback;
+		}),
+	} as unknown as AgentSessionRuntime;
+	return {
+		runtimeHost,
+		replaceWith: async (next) => {
+			live = next;
+			await rebind?.();
+		},
+	};
+}
+
+describe("RPC rebind event continuity", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		for (const harness of harnesses.splice(0)) harness.cleanup();
+		vi.restoreAllMocks();
+	});
+
+	async function newHarness(): Promise<Harness> {
+		const harness = await createHarness({ models: [{ id: "rebind-continuity-model", reasoning: true }] });
+		harnesses.push(harness);
+		return harness;
+	}
+
+	it("delivers entries appended while extensions are still binding after a replacement", async () => {
+		const first = await newHarness();
+		const second = await newHarness();
+		const collected = makeSink();
+		const host = makeRuntimeHost(first.session);
+
+		// Reproduce exactly what the pi-rules builtin does: append a durable entry
+		// from the session_start handler, which runs inside the deferred bind. The
+		// append happens once the bind has set rpc mode, so the notification is
+		// emitted on the wire lane it belongs to.
+		const originalBind = second.session.bindExtensions.bind(second.session);
+		let resolveDuringBind!: () => void;
+		const duringBind = new Promise<void>((resolve) => {
+			resolveDuringBind = resolve;
+		});
+		second.session.bindExtensions = async (options: unknown) => {
+			const result = await originalBind(options as never);
+			resolveDuringBind();
+			second.session.appendSessionEntry({
+				type: "custom",
+				customType: "pi-rules.scan",
+				id: "during-bind-entry",
+				parentId: null,
+				timestamp: new Date().toISOString(),
+				data: { reason: "new" },
+			} as never);
+			return result;
+		};
+
+		const handler = createRpcConnectionHandler(host.runtimeHost, collected.sink, { sessionId: "rpc-attached" });
+		await handler.ready;
+
+		// The replacement is driven the way AgentSessionRuntime drives one: swap the
+		// live session, then invoke the rebind callback, which acknowledges before
+		// the deferred bind finishes.
+		await host.replaceWith(second.session);
+		// Waiting on the append itself, not on a delay, keeps this deterministic.
+		await duringBind;
+
+		// The entry the host durably recorded while binding must reach this
+		// connection. There is no later refresh to rescue it: the session file is
+		// not written until an assistant message exists, so this notification is the
+		// only channel that can ever carry it.
+		const record = await collected.waitFor((r) => r.type === "entry_appended");
+		expect(record).toMatchObject({
+			type: "entry_appended",
+			entry: expect.objectContaining({ customType: "pi-rules.scan" }),
+		});
+
+		await handler.dispose();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the load-dependent failure in `test/interactive-host-runtime.test.ts > transports setup mutations to the authoritative host before rebind` (missing setup-entry record under CI load, roughly 1 run in 6 on main).

## Root cause

Two compounding defects:

1. **No event delivery across a deferred rebind.** A replacement swaps the live session and rebinds extensions afterwards, and that bind is deferred by design (awaiting it would deadlock a client whose `session_start` handler blocks on an `extension_ui_request` it cannot answer while still awaiting the response). The bind still mutates the session it owns - the **pi-rules builtin appends a durable `pi-rules.scan` entry from `session_start`** - but the session event subscription was torn down at rebind start and reinstalled only once the bind finished, so those entries were never forwarded. Nothing else can carry them: the session file is not written until an assistant message exists, so a client that misses the notification can never reconstruct the session it is bound to.

2. **The mirror only backfilled while empty.** `entry_appended` notifications that cross a concurrent refresh land on whichever manager object is current at that instant, so the shared-host mirror could hold an arbitrary *partial* set rather than a prefix of the host's list - and backfill-only-when-empty wedged it there permanently.

Verified by dumping both entry lists under load: the missing element was always exactly the `pi-rules.scan` entry, appended 2-11ms after the setup entries.

## Fix

- `connection-handler.ts`: install the session subscription on the replaced session **immediately after the swap**, so events flow throughout the bind. `installSessionSubscriptions` becomes a hoisted function declaration because `rebindSession` also runs eagerly for the initial bind.
- `interactive-host-runtime.ts`: reconcile the mirror to the complete authoritative entry list the host ships in `get_state` whenever present, rebuilding on mismatch.

## Necessity of both halves (8 busy-loop CPU hogs per run)

| Configuration | Result |
|---|---|
| Reconciliation alone | 7 pass / 1 fail - the append can land *after* the last refresh |
| Event delivery alone | 0 pass / 10 fail - the mirror holds a non-prefix partial set |
| **Both** | **10 pass / 0 fail** |

## Test

Deterministic in-process pin (no child process, no load): a real `AgentSession` whose `bindExtensions` appends an entry once the bind has set rpc mode must surface it as `entry_appended` on the connection. **Fails before the fix** (times out waiting for the record), passes after.

## Verification

- New regression test 2x: 1/1
- `interactive-host-runtime.test.ts` full file 2x: 40/40
- Racy test under load 10x: 10/10
- RPC surface (provenance, classic-compat, multi-session-isolation, attach-edges, teardown, drain-race, session-replaced-contract, interactive-host-session-replaced, multi-session-events): 48/48
- `rpc-socket-host.test.ts`: 14/14
- `npm run check` (biome, tsc, lockfiles): exit 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a load-dependent race in `interactive-host-runtime.test.ts` where session events appended while a replaced session is still binding (like the `pi-rules.scan` entry) were never delivered to attached RPC connections, and the shared interactive host mirror stayed permanently short of entries after a session replacement.

- The connection handler subscribes to the replaced session immediately after the swap; the old post-refresh install is gone because re-installing would replay the settings-source selection.
- The mirror now reconciles to the host's authoritative entry list whenever present, keeping entries that arrived via `entry_appended` during a concurrent refresh, instead of backfilling only when empty.

<sup>Written for commit 9f3cff97d8a77f4e68a10a9474ce5a5bf52a2a84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

