### PR TITLE
fix(rpc): recover shared interactive host disconnects

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- The shared interactive host no longer surfaces raw `Error: Client not started` when its socket drops: the RPC client classifies transport loss with a typed error, the TUI runtime makes bounded reconnect attempts and then genuinely falls back to the local session with a single warning, and in-flight actions resolve as cancellations instead of error toasts ([#1220](https://github.com/code-yeongyu/senpi/pull/1220)).
+
 - Persistent terminals now serialize headless xterm screen writes through parser callbacks with a bounded, dispose-safe backlog, preventing fast PTY output from exceeding xterm's pending-write watermark and terminating Senpi with `write data discarded, use flow control to avoid losing data` ([#1214](https://github.com/code-yeongyu/senpi/pull/1214), supersedes [#837](https://github.com/code-yeongyu/senpi/pull/837)).
 
 ### New Features

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -8,6 +8,10 @@ RPC mode enables headless operation of the coding agent via a JSON protocol over
 
 ## Starting RPC Mode
 
+### RPC client lifecycle
+
+`RpcClient` accepts an `onDisconnect` callback for an established socket and rejects subsequent transport operations with the typed `RpcTransportGoneError` (also detectable with `isTransportGoneError`). Callers should use the callback to begin recovery and keep the error text out of user-facing output.
+
 ```bash
 senpi --mode rpc [options]
 ```

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-30 - Export the RPC transport-gone classifier
+
+### What changed
+
+- `index.ts` and `modes/index.ts` re-export `RpcTransportGoneError` and `isTransportGoneError` beside `RpcClient` so embedders can classify shared-host transport loss.
+
+### Why
+
+- The reconnect-or-fallback orchestration rejects sends with the typed error; consumers of the public client surface need the classifier to distinguish transport loss from real failures.
+
+### Why an extension could not handle it
+
+- Package export surfaces are compile-time module structure; extensions cannot add public exports.
+
+### Expected merge conflict zones
+
+- LOW: export lists in `index.ts` and `modes/index.ts`.
+
 ## 2026-08-30 - Dispatch the internal RPC host route through wrapper-injected argv
 
 ### What changed

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -366,6 +366,8 @@ export {
 	PINNED_HOST_CLIENT_CAPABILITIES,
 	type PrintModeOptions,
 	RpcClient,
+	RpcTransportGoneError,
+	isTransportGoneError,
 	type RpcClientEvent,
 	type RpcClientOptions,
 	type RpcCommand,

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -16,6 +16,8 @@ export {
 export {
 	type ModelInfo,
 	RpcClient,
+	RpcTransportGoneError,
+	isTransportGoneError,
 	type RpcClientEvent,
 	type RpcClientOptions,
 	type RpcEventListener,

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -3020,3 +3020,8 @@ The tip line was teaching a small slice of the product while most of the surface
 
 - NF-2 RED: replacement string sendUserMessage dropped expandPromptTemplates, so the binding host trace did not preserve explicit false.
 - NF-2 GREEN: string replacement messages now forward expandPromptTemplates exactly like array messages; explicit false leaves /help as provider content.
+
+## Interactive RPC reconnect cancellation and terminal fallback (2026-08-30)
+
+- Treats transport loss in value-returning interactive host operations as user cancellation with inert results, so reconnect/fallback warnings are not repeated as action errors.
+- Makes reconnect exhaustion terminal after three attempts and awaits the local fallback session rebind before disposal.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -3025,3 +3025,8 @@ The tip line was teaching a small slice of the product while most of the surface
 
 - Treats transport loss in value-returning interactive host operations as user cancellation with inert results, so reconnect/fallback warnings are not repeated as action errors.
 - Makes reconnect exhaustion terminal after three attempts and awaits the local fallback session rebind before disposal.
+
+## Interactive RPC reconnect cancellation ordering (2026-08-30)
+
+- Preserves structured cancellation results for reload and reload-veto checks when the shared transport disconnects.
+- Keeps fallback warning emission behind the completed local rebind handoff.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,21 @@
 # changes
 
+## 2026-08-30 - Harden shared-host reconnect fallback
+
+### What changed
+
+- Shared-host refresh and bash operations now classify transport loss through the common reconnect path, avoiding raw RPC errors in the TUI.
+- Local fallback preserves the runtime invalidate/rebind callback contract and rebinds session-bound UI when the transition occurs.
+- Reconnect action failures use a transient reconnecting warning; the continuing-locally warning is emitted only after fallback.
+
+### Why
+
+- The shared-host runtime must degrade at the transport boundary without exposing implementation errors or leaving InteractiveMode bound to a stale remote session.
+
+### Expected merge conflict zones
+
+- LOW: reconnect warning and replacement handling in `interactive-host-runtime.ts`.
+
 ## 2026-08-30 - Reconcile the shared-host mirror to the host entry list
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -102,37 +102,37 @@ export async function createInteractiveHostRuntime(
 		if (!remoteSession || reconnecting || disposed || remoteRuntime?.isFallback) return;
 		remoteRuntime?.enterReconnecting();
 		reconnecting = (async () => {
-				let cause: unknown;
-				for (let attempt = 0; attempt < 3; attempt++) {
+			let cause: unknown;
+			for (let attempt = 0; attempt < 3; attempt++) {
+				if (disposed) return;
+				disconnectQueued = false;
+				try {
+					await startHost({ socket: options.socket, agentDir: options.agentDir });
 					if (disposed) return;
-					disconnectQueued = false;
-					try {
-						await startHost({ socket: options.socket, agentDir: options.agentDir });
-						if (disposed) return;
-						await client.start();
-						if (disposed) return;
-						await client.openSession({ sessionPath, cwd: localRuntime.cwd });
-						if (disposed) return;
-						await remoteSession.refresh();
-						if (disposed) return;
-						fallbackWarned = false;
-						reconnectWarningShown = false;
-						remoteRuntime?.enterConnected();
-						return;
-					} catch (error) {
-						cause = error;
-						await client.stop().catch(() => {});
-						if (disposed) return;
-					}
+					await client.start();
+					if (disposed) return;
+					await client.openSession({ sessionPath, cwd: localRuntime.cwd });
+					if (disposed) return;
+					await remoteSession.refresh();
+					if (disposed) return;
+					fallbackWarned = false;
+					reconnectWarningShown = false;
+					remoteRuntime?.enterConnected();
+					return;
+				} catch (error) {
+					cause = error;
+					await client.stop().catch(() => {});
+					if (disposed) return;
 				}
-				if (!disposed) {
-					remoteRuntime?.enterFallback();
-					warnFallback(cause);
-				}
-	})().finally(() => {
-		reconnecting = undefined;
+			}
+			if (!disposed) {
+				await remoteRuntime?.enterFallback();
+				warnFallback(cause);
+			}
+		})().finally(() => {
+			reconnecting = undefined;
 			if (disconnectQueued && !disposed && !remoteRuntime?.isFallback) scheduleReconnect();
-	});
+		});
 	};
 	try {
 		await startHost({ socket: options.socket, agentDir: options.agentDir });
@@ -316,26 +316,26 @@ export class RemoteInteractiveRuntime {
 		// newSession transports setup entries between two refreshes.
 		return this.#remoteSession
 			.aroundLocalReplacement(async () => {
-			const result = await this.#call(() => this.#client.newSession(options?.parentSession));
-			if (!result.cancelled) {
-				this.#beforeSessionInvalidate?.();
-				this.#remoteSession.abortLocalBash();
-				await this.#remoteSession.refresh();
-				if (options?.setup) {
-					const capture = SessionManager.inMemory(this.#remoteSession.session.sessionManager.getCwd());
-					await options.setup(capture);
-					for (const entry of capture.getEntries()) await this.#client.appendSessionEntry(entry);
+				const result = await this.#call(() => this.#client.newSession(options?.parentSession));
+				if (!result.cancelled) {
+					this.#beforeSessionInvalidate?.();
+					this.#remoteSession.abortLocalBash();
 					await this.#remoteSession.refresh();
+					if (options?.setup) {
+						const capture = SessionManager.inMemory(this.#remoteSession.session.sessionManager.getCwd());
+						await options.setup(capture);
+						for (const entry of capture.getEntries()) await this.#client.appendSessionEntry(entry);
+						await this.#remoteSession.refresh();
+					}
+					await this.#rebindSession?.();
+					if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 				}
-				await this.#rebindSession?.();
-				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
-			}
-			return result;
+				return result;
 			})
 			.catch((error) => {
-			if (isTransportGoneError(error)) return { cancelled: true };
-			throw error;
-		});
+				if (isTransportGoneError(error)) return { cancelled: true };
+				throw error;
+			});
 	}
 	async switchSession(
 		sessionPath: string,
@@ -352,26 +352,26 @@ export class RemoteInteractiveRuntime {
 			.aroundLocalReplacement(async () => {
 				const result = await this.#call(() =>
 					this.#client.switchSession(
-				sessionPath,
-				options?.cwdOverride === undefined ? undefined : { cwdOverride: options.cwdOverride },
+						sessionPath,
+						options?.cwdOverride === undefined ? undefined : { cwdOverride: options.cwdOverride },
 					),
 				);
-			if (!result.cancelled) {
-				this.#beforeSessionInvalidate?.();
-				this.#remoteSession.abortLocalBash();
-				await this.#remoteSession.refresh();
-				await this.#rebindSession?.();
-				// The shared host already resolved trust; this callback is retained for
-				// compatibility, but its result cannot override host-authoritative state.
-				options?.projectTrustContextFactory?.(this.#remoteSession.session.sessionManager.getCwd());
-				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
-			}
-			return result;
+				if (!result.cancelled) {
+					this.#beforeSessionInvalidate?.();
+					this.#remoteSession.abortLocalBash();
+					await this.#remoteSession.refresh();
+					await this.#rebindSession?.();
+					// The shared host already resolved trust; this callback is retained for
+					// compatibility, but its result cannot override host-authoritative state.
+					options?.projectTrustContextFactory?.(this.#remoteSession.session.sessionManager.getCwd());
+					if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
+				}
+				return result;
 			})
 			.catch((error) => {
-			if (isTransportGoneError(error)) return { cancelled: true };
-			throw error;
-		});
+				if (isTransportGoneError(error)) return { cancelled: true };
+				throw error;
+			});
 	}
 	async fork(
 		entryId: string,
@@ -381,37 +381,37 @@ export class RemoteInteractiveRuntime {
 		// See newSession: the suppression must cover the command itself.
 		return this.#remoteSession
 			.aroundLocalReplacement(async () => {
-			const result = await this.#call(() => this.#client.fork(entryId, options));
-			if (!result.cancelled) {
-				this.#beforeSessionInvalidate?.();
-				this.#remoteSession.abortLocalBash();
-				await this.#refreshAndRebind();
-				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
-			}
-			return { cancelled: result.cancelled, selectedText: result.text };
+				const result = await this.#call(() => this.#client.fork(entryId, options));
+				if (!result.cancelled) {
+					this.#beforeSessionInvalidate?.();
+					this.#remoteSession.abortLocalBash();
+					await this.#refreshAndRebind();
+					if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
+				}
+				return { cancelled: result.cancelled, selectedText: result.text };
 			})
 			.catch((error) => {
-			if (isTransportGoneError(error)) return { cancelled: true };
-			throw error;
-		});
+				if (isTransportGoneError(error)) return { cancelled: true };
+				throw error;
+			});
 	}
 	async importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }> {
 		if (this.#state === "fallback") return this.#local.importFromJsonl(inputPath, cwdOverride);
 		// See newSession: the suppression must cover the command itself.
 		return this.#remoteSession
 			.aroundLocalReplacement(async () => {
-			const result = await this.#call(() => this.#client.importJsonl(inputPath, cwdOverride));
-			if (!result.cancelled) {
-				this.#beforeSessionInvalidate?.();
-				this.#remoteSession.abortLocalBash();
-				await this.#refreshAndRebind();
-			}
-			return result;
+				const result = await this.#call(() => this.#client.importJsonl(inputPath, cwdOverride));
+				if (!result.cancelled) {
+					this.#beforeSessionInvalidate?.();
+					this.#remoteSession.abortLocalBash();
+					await this.#refreshAndRebind();
+				}
+				return result;
 			})
 			.catch((error) => {
-			if (isTransportGoneError(error)) return { cancelled: true };
-			throw error;
-		});
+				if (isTransportGoneError(error)) return { cancelled: true };
+				throw error;
+			});
 	}
 
 	async #refreshAndRebind(): Promise<void> {
@@ -935,9 +935,9 @@ export function createRemoteSessionProxy(
 							"bash",
 							() =>
 								client.bash(command, {
-							excludeFromContext: options?.excludeFromContext,
-							executionId,
-							operations: options?.operations as Record<string, unknown> | undefined,
+									excludeFromContext: options?.excludeFromContext,
+									executionId,
+									operations: options?.operations as Record<string, unknown> | undefined,
 								}),
 							{ output: "", exitCode: undefined, cancelled: true, truncated: false },
 						);
@@ -1021,9 +1021,10 @@ export function createRemoteSessionProxy(
 			if (property === "retryAttempt") return state.retryAttempt;
 			if (property === "isBashRunning") return state.isBashRunning;
 			if (property === "reload")
-				return (_options?: Parameters<AgentSession["reload"]>[0]) => transportCall("reload", () => client.reload());
+				return (_options?: Parameters<AgentSession["reload"]>[0]) =>
+					transportCall("reload", () => client.reload(), { cancelled: true });
 			if (property === "checkReloadVeto")
-				return () => transportCall("checkReloadVeto", () => client.checkReloadVeto());
+				return () => transportCall("checkReloadVeto", () => client.checkReloadVeto(), { cancelled: true });
 			if (property === "exportToJsonl")
 				return (outputPath?: string) =>
 					transportCall("exportToJsonl", () => client.exportJsonl(outputPath)).then((result) => result?.path);
@@ -1084,16 +1085,16 @@ export function createRemoteSessionProxy(
 			context.sendMessage = (message, options) =>
 				transportCall("sendMessage", () =>
 					client.sendCustomMessage(message, {
-					triggerTurn: options?.triggerTurn,
-					deliverAs: options?.deliverAs,
+						triggerTurn: options?.triggerTurn,
+						deliverAs: options?.deliverAs,
 					}),
 				);
 			context.sendUserMessage = (content, options) => {
 				if (typeof content === "string")
 					return transportCall("sendUserMessage", () =>
 						client.prompt(content, {
-						streamingBehavior: options?.deliverAs,
-						expandPromptTemplates: options?.expandPromptTemplates,
+							streamingBehavior: options?.deliverAs,
+							expandPromptTemplates: options?.expandPromptTemplates,
 						}),
 					);
 				const text = content
@@ -1103,9 +1104,9 @@ export function createRemoteSessionProxy(
 				const images = content.filter((part) => part.type === "image");
 				return transportCall("sendUserMessage", () =>
 					client.prompt(text, {
-					images,
-					streamingBehavior: options?.deliverAs,
-					expandPromptTemplates: options?.expandPromptTemplates,
+						images,
+						streamingBehavior: options?.deliverAs,
+						expandPromptTemplates: options?.expandPromptTemplates,
 					}),
 				);
 			};

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -18,6 +18,7 @@ import {
 } from "../rpc/rpc-client.ts";
 
 export const INTERACTIVE_HOST_FALLBACK_WARNING = "Warning: shared interactive host unavailable; continuing locally";
+export const INTERACTIVE_HOST_RECONNECTING_WARNING = "Warning: shared interactive host connection lost; reconnecting";
 
 export interface InteractiveHostWarning {
 	readonly type: "interactive_host_fallback" | "interactive_host_action_failed";
@@ -79,6 +80,12 @@ export async function createInteractiveHostRuntime(
 	let disconnectQueued = false;
 	let disposed = false;
 	let fallbackWarned = false;
+	let reconnectWarningShown = false;
+	const warnReconnect = (cause: unknown) => {
+		if (reconnectWarningShown) return;
+		reconnectWarningShown = true;
+		options.onWarning?.({ type: "interactive_host_action_failed", message: INTERACTIVE_HOST_RECONNECTING_WARNING, cause });
+	};
 	const warnFallback = (cause: unknown) => {
 		if (fallbackWarned) return;
 		fallbackWarned = true;
@@ -110,6 +117,7 @@ export async function createInteractiveHostRuntime(
 						await remoteSession.refresh();
 						if (disposed) return;
 						fallbackWarned = false;
+						reconnectWarningShown = false;
 						remoteRuntime?.enterConnected();
 						return;
 					} catch (error) {
@@ -143,7 +151,10 @@ export async function createInteractiveHostRuntime(
 			client,
 			opened.state,
 			options.onWarning,
-			warnFallback,
+			(cause) => {
+				if (remoteRuntime?.isReconnecting) warnReconnect(cause);
+				else warnFallback(cause);
+			},
 		);
 		if (opened.state.isBashRunning && !opened.attached) {
 			// Only a newly opened session can have an execution orphaned by a
@@ -153,7 +164,10 @@ export async function createInteractiveHostRuntime(
 		}
 		if (opened.attached) await remoteSession.refresh();
 		remoteRuntime = new RemoteInteractiveRuntime(localRuntime, remoteSession, client, {
-			onTransportGone: warnFallback,
+			onTransportGone: (cause) => {
+				if (remoteRuntime?.isReconnecting) warnReconnect(cause);
+				else warnFallback(cause);
+			},
 			get reconnecting() {
 				return reconnecting;
 			},
@@ -178,6 +192,9 @@ export class RemoteInteractiveRuntime {
 	#rebindSession: (() => Promise<void>) | undefined;
 	#beforeSessionInvalidate: (() => void) | undefined;
 	#state: "connected" | "reconnecting" | "fallback" | "disposed" = "connected";
+	get isReconnecting(): boolean {
+		return this.#state === "reconnecting";
+	}
 
 	constructor(
 		local: AgentSessionRuntime,
@@ -215,7 +232,10 @@ export class RemoteInteractiveRuntime {
 	}
 
 	enterFallback(): void {
-		if (this.#state !== "disposed") this.#state = "fallback";
+		if (this.#state === "disposed" || this.#state === "fallback") return;
+		this.#state = "fallback";
+		this.#beforeSessionInvalidate?.();
+		void this.#rebindSession?.();
 	}
 
 	get session(): AgentSession {
@@ -238,9 +258,11 @@ export class RemoteInteractiveRuntime {
 	}
 	setBeforeSessionInvalidate(callback?: () => void): void {
 		this.#beforeSessionInvalidate = callback;
+		this.#local.setBeforeSessionInvalidate(callback);
 	}
 	setRebindSession(callback?: () => Promise<void>): void {
 		this.#rebindSession = callback;
+		this.#local.setRebindSession(callback);
 	}
 	setHostUiHandler(callback?: InteractiveHostUiHandler): void {
 		this.#remoteSession.setHostUiHandler(callback);
@@ -291,6 +313,9 @@ export class RemoteInteractiveRuntime {
 				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 			}
 			return result;
+		}).catch((error) => {
+			if (isTransportGoneError(error)) return { cancelled: true };
+			throw error;
 		});
 	}
 	async switchSession(
@@ -320,6 +345,9 @@ export class RemoteInteractiveRuntime {
 				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 			}
 			return result;
+		}).catch((error) => {
+			if (isTransportGoneError(error)) return { cancelled: true };
+			throw error;
 		});
 	}
 	async fork(
@@ -337,6 +365,9 @@ export class RemoteInteractiveRuntime {
 				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 			}
 			return { cancelled: result.cancelled, selectedText: result.text };
+		}).catch((error) => {
+			if (isTransportGoneError(error)) return { cancelled: true };
+			throw error;
 		});
 	}
 	async importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }> {
@@ -350,6 +381,9 @@ export class RemoteInteractiveRuntime {
 				await this.#refreshAndRebind();
 			}
 			return result;
+		}).catch((error) => {
+			if (isTransportGoneError(error)) return { cancelled: true };
+			throw error;
 		});
 	}
 
@@ -647,7 +681,7 @@ export function createRemoteSessionProxy(
 		// while this refresh is in flight are newer than the snapshot it reconciles
 		// against, and must survive the rebuild below.
 		const idsAtRefreshStart = new Set(sessionManager.getEntries().map((entry) => entry.id));
-		const nextState = await client.getState();
+		const nextState = await transportCall("refresh", () => client.getState());
 		state = { ...stateFromRpc(nextState) };
 		nextQueuedInputOrder = Math.max(0, ...nextState.ordered.map((item) => item.enqueueOrder));
 		let messages: AgentSession["messages"];
@@ -697,7 +731,7 @@ export function createRemoteSessionProxy(
 			}
 			messages = sessionManager.buildSessionContext().messages;
 		} else {
-			messages = await client.getMessages();
+			messages = await transportCall("refresh", () => client.getMessages());
 		}
 		local.agent.state.messages.splice(0, local.agent.state.messages.length, ...structuredClone(messages));
 		streamingAssistant = undefined;
@@ -841,7 +875,7 @@ export function createRemoteSessionProxy(
 								{ onChunk, signal: abortController.signal },
 							);
 							if (state.sessionId === sessionAtStart) {
-								await client.recordBashResult(command, result, options.excludeFromContext);
+								await transportCall("recordBashResult", () => client.recordBashResult(command, result, options.excludeFromContext));
 							}
 							return result;
 						} finally {
@@ -859,11 +893,11 @@ export function createRemoteSessionProxy(
 					};
 					bashExecutions.set(executionId, execution);
 					try {
-						const result = await client.bash(command, {
+						const result = await transportCall("bash", () => client.bash(command, {
 							excludeFromContext: options?.excludeFromContext,
 							executionId,
 							operations: options?.operations as Record<string, unknown> | undefined,
-						});
+						}));
 						const callbacksSettled = await waitForBashCallbacks(execution.promises, false);
 						if (!callbacksSettled) {
 							if (result.fullOutputPath) await cleanupRemoteBashOutput(result.fullOutputPath);

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -633,17 +633,17 @@ export function createRemoteSessionProxy(
 				return async (message: string, options?: Parameters<AgentSession["prompt"]>[1]) => {
 					try {
 						await client.prompt(message, {
-						...(options?.images ? { images: options.images } : {}),
-						...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior } : {}),
-						...(options?.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
-						...(options?.sessionTitlePrompt !== undefined
-							? { sessionTitlePrompt: options.sessionTitlePrompt }
-							: {}),
-						...(options?.expandPromptTemplates !== undefined
-							? { expandPromptTemplates: options.expandPromptTemplates }
-							: {}),
-						...(options?.promptDisposition ? { promptDisposition: options.promptDisposition } : {}),
-						...(options?.preflightResult ? { preflightResult: options.preflightResult } : {}),
+							...(options?.images ? { images: options.images } : {}),
+							...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior } : {}),
+							...(options?.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
+							...(options?.sessionTitlePrompt !== undefined
+								? { sessionTitlePrompt: options.sessionTitlePrompt }
+								: {}),
+							...(options?.expandPromptTemplates !== undefined
+								? { expandPromptTemplates: options.expandPromptTemplates }
+								: {}),
+							...(options?.promptDisposition ? { promptDisposition: options.promptDisposition } : {}),
+							...(options?.preflightResult ? { preflightResult: options.preflightResult } : {}),
 						});
 					} catch (error) {
 						if (!isTransportGoneError(error)) throw error;

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -10,7 +10,12 @@ import { SessionManager } from "../../core/session-manager.ts";
 import { SettingsManager } from "../../core/settings-manager.ts";
 import type { BashOperations } from "../../core/tools/bash.ts";
 import { type EnsuredHost, ensureHost } from "../rpc/host-ensure.ts";
-import { isTransportGoneError, RpcClient, type RpcClientEvent } from "../rpc/rpc-client.ts";
+import {
+	isTransportGoneError,
+	RpcClient,
+	RpcTransportGoneError,
+	type RpcClientEvent,
+} from "../rpc/rpc-client.ts";
 
 export const INTERACTIVE_HOST_FALLBACK_WARNING = "Warning: shared interactive host unavailable; continuing locally";
 
@@ -69,37 +74,59 @@ export async function createInteractiveHostRuntime(
 	if (!sessionPath) return localRuntime;
 	const startHost = options.ensureHost ?? ((hostOptions) => ensureHost(hostOptions));
 	let remoteSession: RemoteSessionProxy | undefined;
+	let remoteRuntime: RemoteInteractiveRuntime | undefined;
 	let reconnecting: Promise<void> | undefined;
+	let disconnectQueued = false;
+	let disposed = false;
 	let fallbackWarned = false;
 	const warnFallback = (cause: unknown) => {
 		if (fallbackWarned) return;
 		fallbackWarned = true;
 		options.onWarning?.({ type: "interactive_host_fallback", message: INTERACTIVE_HOST_FALLBACK_WARNING, cause });
 	};
+	let scheduleReconnect: () => void = () => {};
 	const client = new RpcClient({
 		socketPath: options.socket,
 		onDisconnect: () => {
-			if (!remoteSession || reconnecting) return;
-			reconnecting = (async () => {
+			disconnectQueued = true;
+			scheduleReconnect();
+		},
+	});
+	scheduleReconnect = () => {
+		if (!remoteSession || reconnecting || disposed) return;
+		remoteRuntime?.enterReconnecting();
+		reconnecting = (async () => {
 				let cause: unknown;
 				for (let attempt = 0; attempt < 3; attempt++) {
+					if (disposed) return;
+					disconnectQueued = false;
 					try {
 						await startHost({ socket: options.socket, agentDir: options.agentDir });
+						if (disposed) return;
 						await client.start();
+						if (disposed) return;
 						await client.openSession({ sessionPath, cwd: localRuntime.cwd });
+						if (disposed) return;
 						await remoteSession.refresh();
+						if (disposed) return;
+						fallbackWarned = false;
+						remoteRuntime?.enterConnected();
 						return;
 					} catch (error) {
 						cause = error;
 						await client.stop().catch(() => {});
+						if (disposed) return;
 					}
 				}
-				warnFallback(cause);
-			})().finally(() => {
-				reconnecting = undefined;
-			});
-		},
+				if (!disposed) {
+					remoteRuntime?.enterFallback();
+					warnFallback(cause);
+				}
+	})().finally(() => {
+		reconnecting = undefined;
+		if (disconnectQueued && !disposed) scheduleReconnect();
 	});
+	};
 	try {
 		await startHost({ socket: options.socket, agentDir: options.agentDir });
 		await client.start();
@@ -116,6 +143,7 @@ export async function createInteractiveHostRuntime(
 			client,
 			opened.state,
 			options.onWarning,
+			warnFallback,
 		);
 		if (opened.state.isBashRunning && !opened.attached) {
 			// Only a newly opened session can have an execution orphaned by a
@@ -124,14 +152,19 @@ export async function createInteractiveHostRuntime(
 			await client.abortBash().catch(() => {});
 		}
 		if (opened.attached) await remoteSession.refresh();
-		return new RemoteInteractiveRuntime(localRuntime, remoteSession, client) as unknown as AgentSessionRuntime;
+		remoteRuntime = new RemoteInteractiveRuntime(localRuntime, remoteSession, client, {
+			onTransportGone: warnFallback,
+			get reconnecting() {
+				return reconnecting;
+			},
+			dispose: () => {
+				disposed = true;
+			},
+		});
+		return remoteRuntime as unknown as AgentSessionRuntime;
 	} catch (cause) {
 		await client.stop().catch(() => {});
-		options.onWarning?.({
-			type: "interactive_host_fallback",
-			message: `${INTERACTIVE_HOST_FALLBACK_WARNING}: ${cause instanceof Error ? cause.message : String(cause)}`,
-			cause,
-		});
+		warnFallback(cause);
 		return localRuntime;
 	}
 }
@@ -140,23 +173,59 @@ export class RemoteInteractiveRuntime {
 	readonly #local: AgentSessionRuntime;
 	readonly #remoteSession: RemoteSessionProxy;
 	readonly #client: RpcClient;
+	readonly #lifecycle?: { readonly reconnecting: Promise<void> | undefined; readonly dispose: () => void };
+	readonly #onTransportGone: (cause: unknown) => void;
 	#rebindSession: (() => Promise<void>) | undefined;
 	#beforeSessionInvalidate: (() => void) | undefined;
+	#state: "connected" | "reconnecting" | "fallback" | "disposed" = "connected";
 
-	constructor(local: AgentSessionRuntime, remoteSession: RemoteSessionProxy, client: RpcClient) {
+	constructor(
+		local: AgentSessionRuntime,
+		remoteSession: RemoteSessionProxy,
+		client: RpcClient,
+		lifecycle?: { readonly reconnecting: Promise<void> | undefined; readonly dispose: () => void } & {
+			onTransportGone: (cause: unknown) => void;
+		},
+	) {
 		this.#local = local;
 		this.#remoteSession = remoteSession;
 		this.#client = client;
+		this.#lifecycle = lifecycle;
+		this.#onTransportGone = lifecycle?.onTransportGone ?? (() => {});
+	}
+
+	async #call<T>(call: () => Promise<T>): Promise<T> {
+		try {
+			return await call();
+		} catch (error) {
+			if (isTransportGoneError(error)) {
+				this.#onTransportGone(error);
+				throw new RpcTransportGoneError();
+			}
+			throw error;
+		}
+	}
+
+	enterConnected(): void {
+		if (this.#state !== "disposed") this.#state = "connected";
+	}
+
+	enterReconnecting(): void {
+		if (this.#state !== "disposed") this.#state = "reconnecting";
+	}
+
+	enterFallback(): void {
+		if (this.#state !== "disposed") this.#state = "fallback";
 	}
 
 	get session(): AgentSession {
-		return this.#remoteSession.session;
+		return this.#state === "fallback" || this.#state === "disposed" ? this.#local.session : this.#remoteSession.session;
 	}
 	get services(): AgentSessionRuntime["services"] {
 		return this.#local.services;
 	}
 	get cwd(): string {
-		return this.#remoteSession.session.sessionManager.getCwd();
+		return this.session.sessionManager.getCwd();
 	}
 	get diagnostics(): readonly AgentSessionRuntimeDiagnostic[] {
 		return this.#local.diagnostics;
@@ -177,6 +246,10 @@ export class RemoteInteractiveRuntime {
 		this.#remoteSession.setHostUiHandler(callback);
 	}
 	async dispose(): Promise<void> {
+		if (this.#state === "disposed") return;
+		this.#state = "disposed";
+		this.#lifecycle?.dispose();
+		await this.#lifecycle?.reconnecting?.catch(() => {});
 		const errors: unknown[] = [];
 		for (const cleanup of [
 			() => this.#remoteSession.abortLocalBash(),
@@ -197,12 +270,13 @@ export class RemoteInteractiveRuntime {
 		setup?: (sessionManager: SessionManager) => Promise<void>;
 		withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
 	}): Promise<{ cancelled: boolean }> {
+		if (this.#state === "fallback") return this.#local.newSession(options);
 		// Suppresses for the ENTIRE command, not just the refresh tail: a
 		// multi-session host emits session_replaced while completing it, so the echo
 		// can arrive before the refresh/rebind sequence below starts and race it -
 		// newSession transports setup entries between two refreshes.
 		return this.#remoteSession.aroundLocalReplacement(async () => {
-			const result = await this.#client.newSession(options?.parentSession);
+			const result = await this.#call(() => this.#client.newSession(options?.parentSession));
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
 				this.#remoteSession.abortLocalBash();
@@ -227,13 +301,14 @@ export class RemoteInteractiveRuntime {
 			projectTrustContextFactory?: (cwd: string) => ProjectTrustContext;
 		},
 	): Promise<{ cancelled: boolean }> {
+		if (this.#state === "fallback") return this.#local.switchSession(sessionPath, options);
 		// See newSession: the suppression must cover the command itself, since the
 		// host emits session_replaced while completing it.
 		return this.#remoteSession.aroundLocalReplacement(async () => {
-			const result = await this.#client.switchSession(
+			const result = await this.#call(() => this.#client.switchSession(
 				sessionPath,
 				options?.cwdOverride === undefined ? undefined : { cwdOverride: options.cwdOverride },
-			);
+			));
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
 				this.#remoteSession.abortLocalBash();
@@ -251,9 +326,10 @@ export class RemoteInteractiveRuntime {
 		entryId: string,
 		options?: { position?: "before" | "at"; withSession?: (ctx: ReplacedSessionContext) => Promise<void> },
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
+		if (this.#state === "fallback") return this.#local.fork(entryId, options);
 		// See newSession: the suppression must cover the command itself.
 		return this.#remoteSession.aroundLocalReplacement(async () => {
-			const result = await this.#client.fork(entryId, options);
+			const result = await this.#call(() => this.#client.fork(entryId, options));
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
 				this.#remoteSession.abortLocalBash();
@@ -264,9 +340,10 @@ export class RemoteInteractiveRuntime {
 		});
 	}
 	async importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }> {
+		if (this.#state === "fallback") return this.#local.importFromJsonl(inputPath, cwdOverride);
 		// See newSession: the suppression must cover the command itself.
 		return this.#remoteSession.aroundLocalReplacement(async () => {
-			const result = await this.#client.importJsonl(inputPath, cwdOverride);
+			const result = await this.#call(() => this.#client.importJsonl(inputPath, cwdOverride));
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
 				this.#remoteSession.abortLocalBash();
@@ -304,19 +381,29 @@ export function createRemoteSessionProxy(
 	client: RpcClient,
 	initialState: ReturnType<typeof stateFromRpc>,
 	onWarning?: (warning: InteractiveHostWarning) => void,
+	onTransportGone?: (cause: unknown) => void,
 ): RemoteSessionProxy {
 	// Fire-and-forget setters keep the sync AgentSession signature, but their RPC
 	// failures must not vanish: the matching *_changed wire event confirms success,
 	// and a rejection here is the only signal of failure.
 	const reportActionFailure = (action: string) => (error: unknown) => {
 		const transportGone = isTransportGoneError(error);
-		onWarning?.({
-			type: transportGone ? "interactive_host_fallback" : "interactive_host_action_failed",
-			message: transportGone
-				? INTERACTIVE_HOST_FALLBACK_WARNING
-				: `Warning: shared interactive host ${action} failed: ${error instanceof Error ? error.message : String(error)}`,
-			cause: error,
-		});
+		if (transportGone) onTransportGone?.(error);
+		else
+			onWarning?.({
+				type: "interactive_host_action_failed",
+				message: `Warning: shared interactive host ${action} failed: ${error instanceof Error ? error.message : String(error)}`,
+				cause: error,
+			});
+	};
+	const transportCall = async <T>(action: string, call: () => Promise<T>): Promise<T> => {
+		try {
+			return await call();
+		} catch (error) {
+			if (!isTransportGoneError(error)) throw error;
+			reportActionFailure(action)(error);
+			throw new RpcTransportGoneError();
+		}
 	};
 	let state = { ...initialState };
 	const waitForBashCallbacks = async (promises: Set<Promise<void>>, allowAbandonment: boolean): Promise<boolean> => {
@@ -389,7 +476,8 @@ export function createRemoteSessionProxy(
 	const remoteSessionManager = new Proxy({} as SessionManager, {
 		get(_target, property, _receiver) {
 			if (property === "appendLabelChange") {
-				return (entryId: string, label?: string) => void client.setLabel(entryId, label);
+				return (entryId: string, label?: string) =>
+					void client.setLabel(entryId, label).catch(reportActionFailure("appendLabelChange"));
 			}
 			if (property === "getCwd") return () => state.cwd;
 			if (property === "getSessionName") return () => state.sessionName;
@@ -407,9 +495,9 @@ export function createRemoteSessionProxy(
 		if ((wireEvent as { type?: string }).type === "extension_ui_request") {
 			const request = wireEvent as import("../rpc/rpc-types.ts").RpcExtensionUIRequest;
 			if (hostUiHandler)
-				void Promise.resolve(hostUiHandler(request)).then(
-					(response) => response && client.sendExtensionUIResponse(response),
-				);
+				void Promise.resolve(hostUiHandler(request))
+					.then((response) => response && client.sendExtensionUIResponse(response))
+					.catch(reportActionFailure("host UI response"));
 			else pendingUiRequests.push(request);
 			return;
 		}
@@ -651,7 +739,7 @@ export function createRemoteSessionProxy(
 					}
 				};
 			if (property === "abort") return () => client.abort();
-			if (property === "abortCompaction") return () => void client.abortCompaction();
+			if (property === "abortCompaction") return () => void client.abortCompaction().catch(reportActionFailure("abortCompaction"));
 			if (property === "steer")
 				return (
 					message: string,
@@ -666,7 +754,7 @@ export function createRemoteSessionProxy(
 						ordered: [...state.ordered, { text: message, mode: "steer", enqueueOrder }],
 						pendingMessageCount: state.pendingMessageCount + 1,
 					};
-					return client.steer(message, images, { ...recovery, enqueueOrder });
+					return transportCall("steer", () => client.steer(message, images, { ...recovery, enqueueOrder }));
 				};
 			if (property === "followUp")
 				return (
@@ -682,13 +770,13 @@ export function createRemoteSessionProxy(
 						ordered: [...state.ordered, { text: message, mode: "followUp", enqueueOrder }],
 						pendingMessageCount: state.pendingMessageCount + 1,
 					};
-					return client.followUp(message, images, { ...recovery, enqueueOrder });
+					return transportCall("followUp", () => client.followUp(message, images, { ...recovery, enqueueOrder }));
 				};
 			if (property === "waitForIdle") return () => client.waitForIdle();
 			if (property === "getLastAssistantText") return () => target.getLastAssistantText();
 			if (property === "setModel" || property === "setSessionModel")
 				return async (model: NonNullable<AgentSession["model"]>) => {
-					const next = await client.setModel(model.provider, model.id);
+					const next = await transportCall("setModel", () => client.setModel(model.provider, model.id));
 					return { systemPromptName: next.systemPromptName, model: next };
 				};
 			if (property === "setSessionThinkingLevel")
@@ -714,20 +802,20 @@ export function createRemoteSessionProxy(
 					state = { ...state, scopedModels: [...models] };
 					void client.setScopedModels(models).catch(reportActionFailure("setScopedModels"));
 				};
-			if (property === "cycleModel") return (direction?: "forward" | "backward") => client.cycleModel(direction);
+			if (property === "cycleModel") return (direction?: "forward" | "backward") => transportCall("cycleModel", () => client.cycleModel(direction));
 			if (property === "setThinkingLevel")
 				return (level: AgentSession["thinkingLevel"]) =>
 					void client.setThinkingLevel(level).catch(reportActionFailure("setThinkingLevel"));
 			if (property === "cycleThinkingLevel")
-				return () => client.cycleThinkingLevel().then((result) => result?.level);
-			if (property === "getAvailableThinkingLevels") return () => client.getAvailableThinkingLevels();
+				return () => transportCall("cycleThinkingLevel", () => client.cycleThinkingLevel()).then((result) => result?.level);
+			if (property === "getAvailableThinkingLevels") return () => transportCall("getAvailableThinkingLevels", () => client.getAvailableThinkingLevels());
 			if (property === "setSteeringMode")
 				return (mode: AgentSession["steeringMode"]) =>
 					void client.setSteeringMode(mode).catch(reportActionFailure("setSteeringMode"));
 			if (property === "setFollowUpMode")
 				return (mode: AgentSession["followUpMode"]) =>
 					void client.setFollowUpMode(mode).catch(reportActionFailure("setFollowUpMode"));
-			if (property === "compact") return (instructions?: string) => client.compact(instructions);
+			if (property === "compact") return (instructions?: string) => transportCall("compact", () => client.compact(instructions));
 			if (property === "setAutoCompactionEnabled")
 				return (enabled: boolean) =>
 					void client.setAutoCompaction(enabled).catch(reportActionFailure("setAutoCompaction"));
@@ -796,19 +884,19 @@ export function createRemoteSessionProxy(
 					else void client.abortBash().catch(reportActionFailure("abortBash"));
 				};
 			if (property === "getContextUsage") return () => state.contextUsage;
-			if (property === "getSessionStats") return () => client.getSessionStats();
+			if (property === "getSessionStats") return () => transportCall("getSessionStats", () => client.getSessionStats());
 			if (property === "exportToHtml")
 				return (outputPath?: string, options?: { themeName?: string }) =>
-					client.exportHtml(outputPath, options?.themeName).then((result) => result.path);
+					transportCall("exportToHtml", () => client.exportHtml(outputPath, options?.themeName)).then((result) => result.path);
 			if (property === "setSessionName")
 				return (name: string) => client.setSessionName(name).catch(reportActionFailure("setSessionName"));
 			if (property === "navigateTree")
 				return async (targetId: string, options?: Parameters<AgentSession["navigateTree"]>[1]) => {
-					const result = await client.navigateTree(targetId, options);
+					const result = await transportCall("navigateTree", () => client.navigateTree(targetId, options));
 					if (!result.cancelled) await refresh();
 					return result;
 				};
-			if (property === "getUserMessagesForForking") return () => client.getForkMessages();
+			if (property === "getUserMessagesForForking") return () => transportCall("getUserMessagesForForking", () => client.getForkMessages());
 			if (property === "subscribe")
 				return (listener: AgentSessionEventListener) => {
 					listeners.add(listener);
@@ -849,10 +937,10 @@ export function createRemoteSessionProxy(
 			if (property === "set_label") return undefined;
 			if (property === "retryAttempt") return state.retryAttempt;
 			if (property === "isBashRunning") return state.isBashRunning;
-			if (property === "reload") return (_options?: Parameters<AgentSession["reload"]>[0]) => client.reload();
-			if (property === "checkReloadVeto") return () => client.checkReloadVeto();
+			if (property === "reload") return (_options?: Parameters<AgentSession["reload"]>[0]) => transportCall("reload", () => client.reload());
+			if (property === "checkReloadVeto") return () => transportCall("checkReloadVeto", () => client.checkReloadVeto());
 			if (property === "exportToJsonl")
-				return (outputPath?: string) => client.exportJsonl(outputPath).then((result) => result.path);
+				return (outputPath?: string) => transportCall("exportToJsonl", () => client.exportJsonl(outputPath)).then((result) => result.path);
 			// The footer and other renderers read session.state.*; surface the
 			// host-authoritative fields there too, not only via the direct getters.
 			if (property === "state") {
@@ -889,9 +977,9 @@ export function createRemoteSessionProxy(
 			hostUiHandler = callback;
 			if (callback)
 				for (const request of pendingUiRequests.splice(0))
-					void Promise.resolve(callback(request)).then(
-						(response) => response && client.sendExtensionUIResponse(response),
-					);
+					void Promise.resolve(callback(request))
+						.then((response) => response && client.sendExtensionUIResponse(response))
+						.catch(reportActionFailure("host UI response"));
 		},
 		refresh,
 		aroundLocalReplacement: async (body) => {
@@ -908,26 +996,26 @@ export function createRemoteSessionProxy(
 			Object.defineProperty(context, "cwd", { value: state.cwd });
 			Object.defineProperty(context, "sessionManager", { value: remoteSessionManager });
 			context.sendMessage = (message, options) =>
-				client.sendCustomMessage(message, {
+				transportCall("sendMessage", () => client.sendCustomMessage(message, {
 					triggerTurn: options?.triggerTurn,
 					deliverAs: options?.deliverAs,
-				});
+				}));
 			context.sendUserMessage = (content, options) => {
 				if (typeof content === "string")
-					return client.prompt(content, {
+					return transportCall("sendUserMessage", () => client.prompt(content, {
 						streamingBehavior: options?.deliverAs,
 						expandPromptTemplates: options?.expandPromptTemplates,
-					});
+					}));
 				const text = content
 					.filter((part) => part.type === "text")
 					.map((part) => part.text)
 					.join("\n");
 				const images = content.filter((part) => part.type === "image");
-				return client.prompt(text, {
+				return transportCall("sendUserMessage", () => client.prompt(text, {
 					images,
 					streamingBehavior: options?.deliverAs,
 					expandPromptTemplates: options?.expandPromptTemplates,
-				});
+				}));
 			};
 			return context;
 		},

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -10,12 +10,7 @@ import { SessionManager } from "../../core/session-manager.ts";
 import { SettingsManager } from "../../core/settings-manager.ts";
 import type { BashOperations } from "../../core/tools/bash.ts";
 import { type EnsuredHost, ensureHost } from "../rpc/host-ensure.ts";
-import {
-	isTransportGoneError,
-	RpcClient,
-	RpcTransportGoneError,
-	type RpcClientEvent,
-} from "../rpc/rpc-client.ts";
+import { isTransportGoneError, RpcClient, type RpcClientEvent } from "../rpc/rpc-client.ts";
 
 export const INTERACTIVE_HOST_FALLBACK_WARNING = "Warning: shared interactive host unavailable; continuing locally";
 export const INTERACTIVE_HOST_RECONNECTING_WARNING = "Warning: shared interactive host connection lost; reconnecting";
@@ -84,7 +79,11 @@ export async function createInteractiveHostRuntime(
 	const warnReconnect = (cause: unknown) => {
 		if (reconnectWarningShown) return;
 		reconnectWarningShown = true;
-		options.onWarning?.({ type: "interactive_host_action_failed", message: INTERACTIVE_HOST_RECONNECTING_WARNING, cause });
+		options.onWarning?.({
+			type: "interactive_host_action_failed",
+			message: INTERACTIVE_HOST_RECONNECTING_WARNING,
+			cause,
+		});
 	};
 	const warnFallback = (cause: unknown) => {
 		if (fallbackWarned) return;
@@ -100,7 +99,7 @@ export async function createInteractiveHostRuntime(
 		},
 	});
 	scheduleReconnect = () => {
-		if (!remoteSession || reconnecting || disposed) return;
+		if (!remoteSession || reconnecting || disposed || remoteRuntime?.isFallback) return;
 		remoteRuntime?.enterReconnecting();
 		reconnecting = (async () => {
 				let cause: unknown;
@@ -132,7 +131,7 @@ export async function createInteractiveHostRuntime(
 				}
 	})().finally(() => {
 		reconnecting = undefined;
-		if (disconnectQueued && !disposed) scheduleReconnect();
+			if (disconnectQueued && !disposed && !remoteRuntime?.isFallback) scheduleReconnect();
 	});
 	};
 	try {
@@ -192,8 +191,12 @@ export class RemoteInteractiveRuntime {
 	#rebindSession: (() => Promise<void>) | undefined;
 	#beforeSessionInvalidate: (() => void) | undefined;
 	#state: "connected" | "reconnecting" | "fallback" | "disposed" = "connected";
+	#fallbackHandoff: Promise<void> | undefined;
 	get isReconnecting(): boolean {
 		return this.#state === "reconnecting";
+	}
+	get isFallback(): boolean {
+		return this.#state === "fallback";
 	}
 
 	constructor(
@@ -217,29 +220,37 @@ export class RemoteInteractiveRuntime {
 		} catch (error) {
 			if (isTransportGoneError(error)) {
 				this.#onTransportGone(error);
-				throw new RpcTransportGoneError();
+				return { cancelled: true } as T;
 			}
 			throw error;
 		}
 	}
 
 	enterConnected(): void {
-		if (this.#state !== "disposed") this.#state = "connected";
+		if (this.#state !== "disposed" && this.#state !== "fallback") this.#state = "connected";
 	}
 
 	enterReconnecting(): void {
-		if (this.#state !== "disposed") this.#state = "reconnecting";
+		if (this.#state !== "disposed" && this.#state !== "fallback") this.#state = "reconnecting";
 	}
 
-	enterFallback(): void {
+	async enterFallback(): Promise<void> {
 		if (this.#state === "disposed" || this.#state === "fallback") return;
 		this.#state = "fallback";
 		this.#beforeSessionInvalidate?.();
-		void this.#rebindSession?.();
+		const rebind = this.#rebindSession?.();
+		if (rebind) {
+			this.#fallbackHandoff = rebind.catch((error) => {
+				this.#onTransportGone(error);
+			});
+			await this.#fallbackHandoff;
+		}
 	}
 
 	get session(): AgentSession {
-		return this.#state === "fallback" || this.#state === "disposed" ? this.#local.session : this.#remoteSession.session;
+		return this.#state === "fallback" || this.#state === "disposed"
+			? this.#local.session
+			: this.#remoteSession.session;
 	}
 	get services(): AgentSessionRuntime["services"] {
 		return this.#local.services;
@@ -263,6 +274,11 @@ export class RemoteInteractiveRuntime {
 	setRebindSession(callback?: () => Promise<void>): void {
 		this.#rebindSession = callback;
 		this.#local.setRebindSession(callback);
+		if (callback && this.#state === "fallback" && !this.#fallbackHandoff) {
+			this.#fallbackHandoff = callback().catch((error) => {
+				this.#onTransportGone(error);
+			});
+		}
 	}
 	setHostUiHandler(callback?: InteractiveHostUiHandler): void {
 		this.#remoteSession.setHostUiHandler(callback);
@@ -272,6 +288,7 @@ export class RemoteInteractiveRuntime {
 		this.#state = "disposed";
 		this.#lifecycle?.dispose();
 		await this.#lifecycle?.reconnecting?.catch(() => {});
+		await this.#fallbackHandoff?.catch(() => {});
 		const errors: unknown[] = [];
 		for (const cleanup of [
 			() => this.#remoteSession.abortLocalBash(),
@@ -297,7 +314,8 @@ export class RemoteInteractiveRuntime {
 		// multi-session host emits session_replaced while completing it, so the echo
 		// can arrive before the refresh/rebind sequence below starts and race it -
 		// newSession transports setup entries between two refreshes.
-		return this.#remoteSession.aroundLocalReplacement(async () => {
+		return this.#remoteSession
+			.aroundLocalReplacement(async () => {
 			const result = await this.#call(() => this.#client.newSession(options?.parentSession));
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
@@ -313,7 +331,8 @@ export class RemoteInteractiveRuntime {
 				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 			}
 			return result;
-		}).catch((error) => {
+			})
+			.catch((error) => {
 			if (isTransportGoneError(error)) return { cancelled: true };
 			throw error;
 		});
@@ -329,11 +348,14 @@ export class RemoteInteractiveRuntime {
 		if (this.#state === "fallback") return this.#local.switchSession(sessionPath, options);
 		// See newSession: the suppression must cover the command itself, since the
 		// host emits session_replaced while completing it.
-		return this.#remoteSession.aroundLocalReplacement(async () => {
-			const result = await this.#call(() => this.#client.switchSession(
+		return this.#remoteSession
+			.aroundLocalReplacement(async () => {
+				const result = await this.#call(() =>
+					this.#client.switchSession(
 				sessionPath,
 				options?.cwdOverride === undefined ? undefined : { cwdOverride: options.cwdOverride },
-			));
+					),
+				);
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
 				this.#remoteSession.abortLocalBash();
@@ -345,7 +367,8 @@ export class RemoteInteractiveRuntime {
 				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 			}
 			return result;
-		}).catch((error) => {
+			})
+			.catch((error) => {
 			if (isTransportGoneError(error)) return { cancelled: true };
 			throw error;
 		});
@@ -356,7 +379,8 @@ export class RemoteInteractiveRuntime {
 	): Promise<{ cancelled: boolean; selectedText?: string }> {
 		if (this.#state === "fallback") return this.#local.fork(entryId, options);
 		// See newSession: the suppression must cover the command itself.
-		return this.#remoteSession.aroundLocalReplacement(async () => {
+		return this.#remoteSession
+			.aroundLocalReplacement(async () => {
 			const result = await this.#call(() => this.#client.fork(entryId, options));
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
@@ -365,7 +389,8 @@ export class RemoteInteractiveRuntime {
 				if (options?.withSession) await options.withSession(this.#remoteSession.createReplacedSessionContext());
 			}
 			return { cancelled: result.cancelled, selectedText: result.text };
-		}).catch((error) => {
+			})
+			.catch((error) => {
 			if (isTransportGoneError(error)) return { cancelled: true };
 			throw error;
 		});
@@ -373,7 +398,8 @@ export class RemoteInteractiveRuntime {
 	async importFromJsonl(inputPath: string, cwdOverride?: string): Promise<{ cancelled: boolean }> {
 		if (this.#state === "fallback") return this.#local.importFromJsonl(inputPath, cwdOverride);
 		// See newSession: the suppression must cover the command itself.
-		return this.#remoteSession.aroundLocalReplacement(async () => {
+		return this.#remoteSession
+			.aroundLocalReplacement(async () => {
 			const result = await this.#call(() => this.#client.importJsonl(inputPath, cwdOverride));
 			if (!result.cancelled) {
 				this.#beforeSessionInvalidate?.();
@@ -381,7 +407,8 @@ export class RemoteInteractiveRuntime {
 				await this.#refreshAndRebind();
 			}
 			return result;
-		}).catch((error) => {
+			})
+			.catch((error) => {
 			if (isTransportGoneError(error)) return { cancelled: true };
 			throw error;
 		});
@@ -430,13 +457,13 @@ export function createRemoteSessionProxy(
 				cause: error,
 			});
 	};
-	const transportCall = async <T>(action: string, call: () => Promise<T>): Promise<T> => {
+	const transportCall = async <T>(action: string, call: () => Promise<T>, cancelledValue?: T): Promise<T> => {
 		try {
 			return await call();
 		} catch (error) {
 			if (!isTransportGoneError(error)) throw error;
 			reportActionFailure(action)(error);
-			throw new RpcTransportGoneError();
+			return cancelledValue as T;
 		}
 	};
 	let state = { ...initialState };
@@ -682,6 +709,7 @@ export function createRemoteSessionProxy(
 		// against, and must survive the rebuild below.
 		const idsAtRefreshStart = new Set(sessionManager.getEntries().map((entry) => entry.id));
 		const nextState = await transportCall("refresh", () => client.getState());
+		if (!nextState) return;
 		state = { ...stateFromRpc(nextState) };
 		nextQueuedInputOrder = Math.max(0, ...nextState.ordered.map((item) => item.enqueueOrder));
 		let messages: AgentSession["messages"];
@@ -731,7 +759,7 @@ export function createRemoteSessionProxy(
 			}
 			messages = sessionManager.buildSessionContext().messages;
 		} else {
-			messages = await transportCall("refresh", () => client.getMessages());
+			messages = await transportCall("refresh", () => client.getMessages(), []);
 		}
 		local.agent.state.messages.splice(0, local.agent.state.messages.length, ...structuredClone(messages));
 		streamingAssistant = undefined;
@@ -773,7 +801,8 @@ export function createRemoteSessionProxy(
 					}
 				};
 			if (property === "abort") return () => client.abort();
-			if (property === "abortCompaction") return () => void client.abortCompaction().catch(reportActionFailure("abortCompaction"));
+			if (property === "abortCompaction")
+				return () => void client.abortCompaction().catch(reportActionFailure("abortCompaction"));
 			if (property === "steer")
 				return (
 					message: string,
@@ -810,8 +839,8 @@ export function createRemoteSessionProxy(
 			if (property === "getLastAssistantText") return () => target.getLastAssistantText();
 			if (property === "setModel" || property === "setSessionModel")
 				return async (model: NonNullable<AgentSession["model"]>) => {
-					const next = await transportCall("setModel", () => client.setModel(model.provider, model.id));
-					return { systemPromptName: next.systemPromptName, model: next };
+					const next = await transportCall("setModel", () => client.setModel(model.provider, model.id), undefined);
+					return next ? { systemPromptName: next.systemPromptName, model: next } : undefined;
 				};
 			if (property === "setSessionThinkingLevel")
 				return (level: AgentSession["thinkingLevel"]) =>
@@ -836,20 +865,27 @@ export function createRemoteSessionProxy(
 					state = { ...state, scopedModels: [...models] };
 					void client.setScopedModels(models).catch(reportActionFailure("setScopedModels"));
 				};
-			if (property === "cycleModel") return (direction?: "forward" | "backward") => transportCall("cycleModel", () => client.cycleModel(direction));
+			if (property === "cycleModel")
+				return (direction?: "forward" | "backward") =>
+					transportCall("cycleModel", () => client.cycleModel(direction), undefined);
 			if (property === "setThinkingLevel")
 				return (level: AgentSession["thinkingLevel"]) =>
 					void client.setThinkingLevel(level).catch(reportActionFailure("setThinkingLevel"));
 			if (property === "cycleThinkingLevel")
-				return () => transportCall("cycleThinkingLevel", () => client.cycleThinkingLevel()).then((result) => result?.level);
-			if (property === "getAvailableThinkingLevels") return () => transportCall("getAvailableThinkingLevels", () => client.getAvailableThinkingLevels());
+				return () =>
+					transportCall("cycleThinkingLevel", () => client.cycleThinkingLevel(), undefined).then(
+						(result) => result?.level,
+					);
+			if (property === "getAvailableThinkingLevels")
+				return () => transportCall("getAvailableThinkingLevels", () => client.getAvailableThinkingLevels(), []);
 			if (property === "setSteeringMode")
 				return (mode: AgentSession["steeringMode"]) =>
 					void client.setSteeringMode(mode).catch(reportActionFailure("setSteeringMode"));
 			if (property === "setFollowUpMode")
 				return (mode: AgentSession["followUpMode"]) =>
 					void client.setFollowUpMode(mode).catch(reportActionFailure("setFollowUpMode"));
-			if (property === "compact") return (instructions?: string) => transportCall("compact", () => client.compact(instructions));
+			if (property === "compact")
+				return (instructions?: string) => transportCall("compact", () => client.compact(instructions));
 			if (property === "setAutoCompactionEnabled")
 				return (enabled: boolean) =>
 					void client.setAutoCompaction(enabled).catch(reportActionFailure("setAutoCompaction"));
@@ -875,7 +911,9 @@ export function createRemoteSessionProxy(
 								{ onChunk, signal: abortController.signal },
 							);
 							if (state.sessionId === sessionAtStart) {
-								await transportCall("recordBashResult", () => client.recordBashResult(command, result, options.excludeFromContext));
+								await transportCall("recordBashResult", () =>
+									client.recordBashResult(command, result, options.excludeFromContext),
+								);
 							}
 							return result;
 						} finally {
@@ -893,11 +931,16 @@ export function createRemoteSessionProxy(
 					};
 					bashExecutions.set(executionId, execution);
 					try {
-						const result = await transportCall("bash", () => client.bash(command, {
+						const result = await transportCall(
+							"bash",
+							() =>
+								client.bash(command, {
 							excludeFromContext: options?.excludeFromContext,
 							executionId,
 							operations: options?.operations as Record<string, unknown> | undefined,
-						}));
+								}),
+							{ output: "", exitCode: undefined, cancelled: true, truncated: false },
+						);
 						const callbacksSettled = await waitForBashCallbacks(execution.promises, false);
 						if (!callbacksSettled) {
 							if (result.fullOutputPath) await cleanupRemoteBashOutput(result.fullOutputPath);
@@ -918,19 +961,25 @@ export function createRemoteSessionProxy(
 					else void client.abortBash().catch(reportActionFailure("abortBash"));
 				};
 			if (property === "getContextUsage") return () => state.contextUsage;
-			if (property === "getSessionStats") return () => transportCall("getSessionStats", () => client.getSessionStats());
+			if (property === "getSessionStats")
+				return () => transportCall("getSessionStats", () => client.getSessionStats(), local.getSessionStats());
 			if (property === "exportToHtml")
 				return (outputPath?: string, options?: { themeName?: string }) =>
-					transportCall("exportToHtml", () => client.exportHtml(outputPath, options?.themeName)).then((result) => result.path);
+					transportCall("exportToHtml", () => client.exportHtml(outputPath, options?.themeName)).then(
+						(result) => result?.path,
+					);
 			if (property === "setSessionName")
 				return (name: string) => client.setSessionName(name).catch(reportActionFailure("setSessionName"));
 			if (property === "navigateTree")
 				return async (targetId: string, options?: Parameters<AgentSession["navigateTree"]>[1]) => {
-					const result = await transportCall("navigateTree", () => client.navigateTree(targetId, options));
+					const result = await transportCall("navigateTree", () => client.navigateTree(targetId, options), {
+						cancelled: true,
+					});
 					if (!result.cancelled) await refresh();
 					return result;
 				};
-			if (property === "getUserMessagesForForking") return () => transportCall("getUserMessagesForForking", () => client.getForkMessages());
+			if (property === "getUserMessagesForForking")
+				return () => transportCall("getUserMessagesForForking", () => client.getForkMessages(), []);
 			if (property === "subscribe")
 				return (listener: AgentSessionEventListener) => {
 					listeners.add(listener);
@@ -971,10 +1020,13 @@ export function createRemoteSessionProxy(
 			if (property === "set_label") return undefined;
 			if (property === "retryAttempt") return state.retryAttempt;
 			if (property === "isBashRunning") return state.isBashRunning;
-			if (property === "reload") return (_options?: Parameters<AgentSession["reload"]>[0]) => transportCall("reload", () => client.reload());
-			if (property === "checkReloadVeto") return () => transportCall("checkReloadVeto", () => client.checkReloadVeto());
+			if (property === "reload")
+				return (_options?: Parameters<AgentSession["reload"]>[0]) => transportCall("reload", () => client.reload());
+			if (property === "checkReloadVeto")
+				return () => transportCall("checkReloadVeto", () => client.checkReloadVeto());
 			if (property === "exportToJsonl")
-				return (outputPath?: string) => transportCall("exportToJsonl", () => client.exportJsonl(outputPath)).then((result) => result.path);
+				return (outputPath?: string) =>
+					transportCall("exportToJsonl", () => client.exportJsonl(outputPath)).then((result) => result?.path);
 			// The footer and other renderers read session.state.*; surface the
 			// host-authoritative fields there too, not only via the direct getters.
 			if (property === "state") {
@@ -1030,26 +1082,32 @@ export function createRemoteSessionProxy(
 			Object.defineProperty(context, "cwd", { value: state.cwd });
 			Object.defineProperty(context, "sessionManager", { value: remoteSessionManager });
 			context.sendMessage = (message, options) =>
-				transportCall("sendMessage", () => client.sendCustomMessage(message, {
+				transportCall("sendMessage", () =>
+					client.sendCustomMessage(message, {
 					triggerTurn: options?.triggerTurn,
 					deliverAs: options?.deliverAs,
-				}));
+					}),
+				);
 			context.sendUserMessage = (content, options) => {
 				if (typeof content === "string")
-					return transportCall("sendUserMessage", () => client.prompt(content, {
+					return transportCall("sendUserMessage", () =>
+						client.prompt(content, {
 						streamingBehavior: options?.deliverAs,
 						expandPromptTemplates: options?.expandPromptTemplates,
-					}));
+						}),
+					);
 				const text = content
 					.filter((part) => part.type === "text")
 					.map((part) => part.text)
 					.join("\n");
 				const images = content.filter((part) => part.type === "image");
-				return transportCall("sendUserMessage", () => client.prompt(text, {
+				return transportCall("sendUserMessage", () =>
+					client.prompt(text, {
 					images,
 					streamingBehavior: options?.deliverAs,
 					expandPromptTemplates: options?.expandPromptTemplates,
-				}));
+					}),
+				);
 			};
 			return context;
 		},

--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -10,7 +10,7 @@ import { SessionManager } from "../../core/session-manager.ts";
 import { SettingsManager } from "../../core/settings-manager.ts";
 import type { BashOperations } from "../../core/tools/bash.ts";
 import { type EnsuredHost, ensureHost } from "../rpc/host-ensure.ts";
-import { RpcClient, type RpcClientEvent } from "../rpc/rpc-client.ts";
+import { isTransportGoneError, RpcClient, type RpcClientEvent } from "../rpc/rpc-client.ts";
 
 export const INTERACTIVE_HOST_FALLBACK_WARNING = "Warning: shared interactive host unavailable; continuing locally";
 
@@ -68,7 +68,38 @@ export async function createInteractiveHostRuntime(
 	const sessionPath = localRuntime.session.sessionFile;
 	if (!sessionPath) return localRuntime;
 	const startHost = options.ensureHost ?? ((hostOptions) => ensureHost(hostOptions));
-	const client = new RpcClient({ socketPath: options.socket });
+	let remoteSession: RemoteSessionProxy | undefined;
+	let reconnecting: Promise<void> | undefined;
+	let fallbackWarned = false;
+	const warnFallback = (cause: unknown) => {
+		if (fallbackWarned) return;
+		fallbackWarned = true;
+		options.onWarning?.({ type: "interactive_host_fallback", message: INTERACTIVE_HOST_FALLBACK_WARNING, cause });
+	};
+	const client = new RpcClient({
+		socketPath: options.socket,
+		onDisconnect: () => {
+			if (!remoteSession || reconnecting) return;
+			reconnecting = (async () => {
+				let cause: unknown;
+				for (let attempt = 0; attempt < 3; attempt++) {
+					try {
+						await startHost({ socket: options.socket, agentDir: options.agentDir });
+						await client.start();
+						await client.openSession({ sessionPath, cwd: localRuntime.cwd });
+						await remoteSession.refresh();
+						return;
+					} catch (error) {
+						cause = error;
+						await client.stop().catch(() => {});
+					}
+				}
+				warnFallback(cause);
+			})().finally(() => {
+				reconnecting = undefined;
+			});
+		},
+	});
 	try {
 		await startHost({ socket: options.socket, agentDir: options.agentDir });
 		await client.start();
@@ -79,7 +110,7 @@ export async function createInteractiveHostRuntime(
 			modelId: localRuntime.session.model?.id,
 			thinkingLevel: localRuntime.session.thinkingLevel,
 		});
-		const remoteSession = createRemoteSessionProxy(
+		remoteSession = createRemoteSessionProxy(
 			localRuntime.session,
 			localRuntime.services.agentDir,
 			client,
@@ -278,9 +309,12 @@ export function createRemoteSessionProxy(
 	// failures must not vanish: the matching *_changed wire event confirms success,
 	// and a rejection here is the only signal of failure.
 	const reportActionFailure = (action: string) => (error: unknown) => {
+		const transportGone = isTransportGoneError(error);
 		onWarning?.({
-			type: "interactive_host_action_failed",
-			message: `Warning: shared interactive host ${action} failed: ${error instanceof Error ? error.message : String(error)}`,
+			type: transportGone ? "interactive_host_fallback" : "interactive_host_action_failed",
+			message: transportGone
+				? INTERACTIVE_HOST_FALLBACK_WARNING
+				: `Warning: shared interactive host ${action} failed: ${error instanceof Error ? error.message : String(error)}`,
 			cause: error,
 		});
 	};
@@ -596,8 +630,9 @@ export function createRemoteSessionProxy(
 	const session = new Proxy(local, {
 		get(target, property, receiver) {
 			if (property === "prompt")
-				return (message: string, options?: Parameters<AgentSession["prompt"]>[1]) =>
-					client.prompt(message, {
+				return async (message: string, options?: Parameters<AgentSession["prompt"]>[1]) => {
+					try {
+						await client.prompt(message, {
 						...(options?.images ? { images: options.images } : {}),
 						...(options?.streamingBehavior ? { streamingBehavior: options.streamingBehavior } : {}),
 						...(options?.thinkingLevel ? { thinkingLevel: options.thinkingLevel } : {}),
@@ -609,7 +644,12 @@ export function createRemoteSessionProxy(
 							: {}),
 						...(options?.promptDisposition ? { promptDisposition: options.promptDisposition } : {}),
 						...(options?.preflightResult ? { preflightResult: options.preflightResult } : {}),
-					});
+						});
+					} catch (error) {
+						if (!isTransportGoneError(error)) throw error;
+						reportActionFailure("prompt")(error);
+					}
+				};
 			if (property === "abort") return () => client.abort();
 			if (property === "abortCompaction") return () => void client.abortCompaction();
 			if (property === "steer")

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -21,8 +21,22 @@
 
 ## 2026-08-30 - Classify RPC transport disconnects and recover shared interactive hosts
 
-- `RpcClient` now reports established socket disconnects through `onDisconnect` and rejects sends with `RpcTransportGoneError` instead of exposing the raw `Client not started` message.
+### What changed
+
+- `rpc-client.ts`: `RpcClient` reports established socket disconnects through the new `onDisconnect` option and rejects sends with the exported `RpcTransportGoneError` (`code: "rpc_transport_gone"`) instead of exposing the raw `Client not started` message; `isTransportGoneError()` classifies both the typed error and legacy message shapes.
 - Shared interactive runtimes make bounded reconnect attempts, re-open and refresh the attached session, and on exhaustion switch to the retained local runtime while surfacing only the standard fallback warning.
+
+### Why
+
+- The shared interactive host surfaced raw transport internals in the TUI whenever the host socket dropped; recovery orchestration needs a typed, once-only disconnect signal at the client boundary.
+
+### Why an extension could not handle it
+
+- The transport lifecycle lives inside `RpcClient` beneath every extension surface; no extension hook observes socket teardown or send gating.
+
+### Expected merge conflict zones
+
+- LOW: the `send()` guard block and socket close/error handlers in `rpc-client.ts`.
 
 ## 2026-08-30 - Expose session_replaced on the public client event union
 

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -19,6 +19,11 @@
 - LOW: the tail of `rebindSession()` and the `installSessionSubscriptions` declaration.
 
 
+## 2026-08-30 - Classify RPC transport disconnects and recover shared interactive hosts
+
+- `RpcClient` now reports established socket disconnects through `onDisconnect` and rejects sends with `RpcTransportGoneError` instead of exposing the raw `Client not started` message.
+- Shared interactive runtimes make bounded reconnect attempts, re-open and refresh the attached session, and surface only the standard fallback warning when recovery is unavailable.
+
 ## 2026-08-30 - Expose session_replaced on the public client event union
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -22,7 +22,7 @@
 ## 2026-08-30 - Classify RPC transport disconnects and recover shared interactive hosts
 
 - `RpcClient` now reports established socket disconnects through `onDisconnect` and rejects sends with `RpcTransportGoneError` instead of exposing the raw `Client not started` message.
-- Shared interactive runtimes make bounded reconnect attempts, re-open and refresh the attached session, and surface only the standard fallback warning when recovery is unavailable.
+- Shared interactive runtimes make bounded reconnect attempts, re-open and refresh the attached session, and on exhaustion switch to the retained local runtime while surfacing only the standard fallback warning.
 
 ## 2026-08-30 - Expose session_replaced on the public client event union
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -44,6 +44,8 @@ type RpcCommandBody = DistributiveOmit<RpcCommand, "id">;
 export interface RpcClientOptions {
 	/** Connect to an existing multi-session Unix socket instead of spawning a child. */
 	socketPath?: string;
+	/** Called once when an established transport disconnects. */
+	onDisconnect?: (error: RpcTransportGoneError) => void;
 	/** Path to the CLI entry point (default: searches for dist/cli.js) */
 	cliPath?: string;
 	/** Working directory for the agent */
@@ -100,11 +102,19 @@ function isProviderAccountEvent(event: RpcClientEvent): event is RpcProviderAcco
 // RPC Client
 // ============================================================================
 
-function isTransportGoneError(error: unknown): boolean {
-	return (
-		error instanceof Error &&
-		(error.message === "Client not started" || error.message.startsWith("RPC transport is not writable."))
-	);
+export class RpcTransportGoneError extends Error {
+	readonly code = "rpc_transport_gone" as const;
+
+	constructor(message = "Shared RPC host is unavailable") {
+		super(message);
+		this.name = "RpcTransportGoneError";
+	}
+}
+
+export function isTransportGoneError(error: unknown): error is RpcTransportGoneError {
+	return error instanceof RpcTransportGoneError ||
+		(error instanceof Error &&
+			(error.message === "Client not started" || error.message.startsWith("RPC transport is not writable.") || error.message === "RPC socket closed"));
 }
 
 export class RpcClient {
@@ -125,6 +135,8 @@ export class RpcClient {
 	private sessionId: string | undefined;
 	private stderr = "";
 	private exitError: Error | null = null;
+	private disconnectNotified = false;
+	private stopping = false;
 	private options: RpcClientOptions;
 
 	constructor(options: RpcClientOptions = {}) {
@@ -140,6 +152,8 @@ export class RpcClient {
 		}
 
 		this.exitError = null;
+		this.stopping = false;
+		this.disconnectNotified = false;
 		if (this.options.socketPath) {
 			await this.startSocket(this.options.socketPath);
 			return;
@@ -211,12 +225,13 @@ export class RpcClient {
 	 */
 	async stop(): Promise<void> {
 		if (this.socket) {
+			this.stopping = true;
 			this.stopReadingStdout?.();
 			this.stopReadingStdout = null;
 			this.socket.destroy();
 			this.socket = null;
 			this.sessionId = undefined;
-			this.rejectPendingRequests(new Error("RPC socket client stopped"));
+			this.notifyDisconnect(new RpcTransportGoneError());
 			return;
 		}
 		if (!this.process) return;
@@ -266,12 +281,12 @@ export class RpcClient {
 		socket.once("close", () => {
 			if (this.socket !== socket) return;
 			this.socket = null;
-			this.rejectPendingRequests(new Error("RPC socket closed"));
+			this.notifyDisconnect(new RpcTransportGoneError());
 		});
 		socket.once("error", (error) => {
 			if (this.socket !== socket) return;
-			this.exitError = error;
-			this.rejectPendingRequests(error);
+			this.notifyDisconnect(new RpcTransportGoneError());
+			void error;
 		});
 	}
 
@@ -912,6 +927,14 @@ export class RpcClient {
 		return new Error(`Agent process exited (code=${code} signal=${signal}). Stderr: ${this.stderr}`);
 	}
 
+	private notifyDisconnect(error: RpcTransportGoneError): void {
+		this.rejectPendingRequests(error);
+		if (!this.disconnectNotified && !this.stopping) {
+			this.disconnectNotified = true;
+			this.options.onDisconnect?.(error);
+		}
+	}
+
 	private rejectPendingRequests(error: Error): void {
 		for (const pending of this.pendingRequests.values()) {
 			pending.onReject?.(error);
@@ -929,7 +952,7 @@ export class RpcClient {
 		const childProcess = this.process;
 		const stream = this.socket ?? childProcess?.stdin;
 		if (!stream) {
-			throw new Error("Client not started");
+			throw new RpcTransportGoneError();
 		}
 		if (this.exitError) {
 			throw this.exitError;
@@ -940,8 +963,8 @@ export class RpcClient {
 			throw error;
 		}
 		if (stream.destroyed || !stream.writable) {
-			const error = new Error(`RPC transport is not writable. Stderr: ${this.stderr}`);
-			this.exitError = error;
+			const error = new RpcTransportGoneError();
+			this.notifyDisconnect(error);
 			throw error;
 		}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -112,9 +112,13 @@ export class RpcTransportGoneError extends Error {
 }
 
 export function isTransportGoneError(error: unknown): error is RpcTransportGoneError {
-	return error instanceof RpcTransportGoneError ||
+	return (
+		error instanceof RpcTransportGoneError ||
 		(error instanceof Error &&
-			(error.message === "Client not started" || error.message.startsWith("RPC transport is not writable.") || error.message === "RPC socket closed"));
+			(error.message === "Client not started" ||
+				error.message.startsWith("RPC transport is not writable.") ||
+				error.message === "RPC socket closed"))
+	);
 }
 
 export class RpcClient {

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -20,6 +20,7 @@ import type { RpcSessionState } from "../src/modes/rpc/rpc-types.ts";
 
 const roots: string[] = [];
 const servers: Server[] = [];
+const acceptedSockets: Socket[] = [];
 const runtimes: AgentSessionRuntime[] = [];
 
 const TEST_TIMEOUT = 10_000;
@@ -31,7 +32,7 @@ afterEach(async () => {
 			(server) =>
 				new Promise<void>((resolve) => {
 					server.close(() => resolve());
-					server.closeAllConnections?.();
+					for (const socket of acceptedSockets.splice(0)) socket.destroy();
 				}),
 		),
 	);
@@ -94,7 +95,10 @@ class FakeHost {
 	private readonly sessionId = "fake-session";
 	private connectionCount = 0;
 
-	constructor(readonly socketPath: string, sessionPath: string, cwd: string) {
+	readonly socketPath: string;
+
+	constructor(socketPath: string, sessionPath: string, cwd: string) {
+		this.socketPath = socketPath;
 		this.sessionPath = sessionPath;
 		this.cwd = cwd;
 		this.server.on("connection", (socket) => this.accept(socket));
@@ -108,6 +112,7 @@ class FakeHost {
 	private accept(socket: Socket): void {
 		this.connectionCount++;
 		this.connections.push(socket);
+		acceptedSockets.push(socket);
 		if (this.connectionCount === 2) this.secondConnection.resolve(socket);
 		if (this.connectionCount === 3) this.thirdConnection.resolve(socket);
 		attachJsonlLineReader(socket, (line) => {
@@ -247,7 +252,7 @@ describe("interactive host reconnect orchestration", () => {
 		}
 	}, TEST_TIMEOUT);
 
-	test("re-arms reconnect when the socket disconnects during a successful reconnect", async () => {
+	it("re-arms reconnect when the socket disconnects during a successful reconnect", async () => {
 		const qa = scratch("race");
 		const local = await createLocalRuntime(qa);
 		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
@@ -266,7 +271,7 @@ describe("interactive host reconnect orchestration", () => {
 		}
 	}, TEST_TIMEOUT);
 
-	test("dispose cancels an in-flight reconnect before reopening the session", async () => {
+	it("dispose cancels an in-flight reconnect before reopening the session", async () => {
 		const qa = scratch("dispose");
 		const local = await createLocalRuntime(qa);
 		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -87,6 +87,7 @@ class FakeHost {
 	readonly connections: Socket[] = [];
 	readonly requests: Array<Record<string, unknown>> = [];
 	readonly secondConnection = deferred<Socket>();
+	readonly thirdConnection = deferred<Socket>();
 	readonly secondOpenSession = deferred<Record<string, unknown>>();
 	private readonly sessionPath: string;
 	private readonly cwd: string;
@@ -108,6 +109,7 @@ class FakeHost {
 		this.connectionCount++;
 		this.connections.push(socket);
 		if (this.connectionCount === 2) this.secondConnection.resolve(socket);
+		if (this.connectionCount === 3) this.thirdConnection.resolve(socket);
 		attachJsonlLineReader(socket, (line) => {
 			const request = JSON.parse(line) as Record<string, unknown>;
 			this.requests.push(request);
@@ -182,6 +184,117 @@ describe("interactive host reconnect orchestration", () => {
 			expect(warnings).toEqual([]);
 		} finally {
 			await runtime.dispose();
+		}
+	}, TEST_TIMEOUT);
+
+	it("sanitizes later proxy failures and deduplicates the fallback warning", async () => {
+		const qa = scratch("sanitized");
+		const local = await createLocalRuntime(qa);
+		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+		await host.listen();
+		const warnings: Array<{ message: string; cause: unknown }> = [];
+		let ensureHostCalls = 0;
+		const warning = deferred<void>();
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => {
+				ensureHostCalls++;
+				if (ensureHostCalls > 1) throw new Error("internal socket path / secret");
+				return undefined;
+			},
+			onWarning: (value) => {
+				warnings.push(value);
+				warning.resolve();
+			},
+		});
+		try {
+			host.connections[0]!.destroy();
+			const action = runtime.session.steer("after disconnect");
+			await expect(action).rejects.toThrow();
+			await warning.promise;
+			await Promise.resolve();
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0]?.message).toBe(INTERACTIVE_HOST_FALLBACK_WARNING);
+			expect(warnings[0]?.message).not.toContain("internal socket path");
+		} finally {
+			await runtime.dispose();
+		}
+	}, TEST_TIMEOUT);
+
+	it("switches to the local runtime after reconnect exhaustion", async () => {
+		const qa = scratch("fallback");
+		const local = await createLocalRuntime(qa);
+		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+		await host.listen();
+		const warning = deferred<void>();
+		let ensureHostCalls = 0;
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => {
+				ensureHostCalls++;
+				if (ensureHostCalls > 1) throw new Error("reconnect failed");
+				return undefined;
+			},
+			onWarning: () => warning.resolve(),
+		});
+		try {
+			host.connections[0]!.destroy();
+			await warning.promise;
+			expect(runtime.session).toBe(local.session);
+			expect(host.requests.filter((request) => request.type === "get_state")).toHaveLength(0);
+		} finally {
+			await runtime.dispose();
+		}
+	}, TEST_TIMEOUT);
+
+	test("re-arms reconnect when the socket disconnects during a successful reconnect", async () => {
+		const qa = scratch("race");
+		const local = await createLocalRuntime(qa);
+		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+		await host.listen();
+		const runtime = await createInteractiveHostRuntime(local, { socket: qa.socket, ensureHost: async () => undefined });
+		try {
+			host.connections[0]!.destroy();
+			await host.secondConnection.promise;
+			await host.secondOpenSession.promise;
+			// The reconnect has completed; a later disconnect must start another attempt.
+			host.connections[1]!.destroy();
+			await host.thirdConnection.promise;
+			expect(host.connections.length).toBeGreaterThanOrEqual(3);
+		} finally {
+			await runtime.dispose();
+		}
+	}, TEST_TIMEOUT);
+
+	test("dispose cancels an in-flight reconnect before reopening the session", async () => {
+		const qa = scratch("dispose");
+		const local = await createLocalRuntime(qa);
+		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+		await host.listen();
+		const reconnectStarted = deferred<void>();
+		const releaseReconnect = deferred<void>();
+		let ensureHostCalls = 0;
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => {
+				ensureHostCalls++;
+				if (ensureHostCalls > 1) {
+					reconnectStarted.resolve();
+					await releaseReconnect.promise;
+				}
+				return undefined;
+			},
+		});
+		try {
+			host.connections[0]!.destroy();
+			await reconnectStarted.promise;
+			const disposed = runtime.dispose();
+			releaseReconnect.resolve();
+			await disposed;
+			expect(host.requests.filter((request) => request.type === "open_session")).toHaveLength(1);
+		} finally {
+			releaseReconnect.resolve();
+			await runtime.dispose().catch(() => {});
 		}
 	}, TEST_TIMEOUT);
 

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -1,13 +1,13 @@
-import { createServer, type Server, type Socket } from "node:net";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server, type Socket } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	type AgentSessionRuntime,
 	createAgentSessionFromServices,
 	createAgentSessionRuntime,
 	createAgentSessionServices,
-	type AgentSessionRuntime,
 } from "../src/core/agent-session-runtime.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { SettingsManager } from "../src/core/settings-manager.ts";
@@ -49,7 +49,7 @@ function scratch(label: string) {
 	mkdirSync(cwd, { recursive: true });
 	mkdirSync(agentDir, { recursive: true });
 	mkdirSync(sessionDir, { recursive: true });
-	return { root, cwd, agentDir, sessionDir, socket: join(root, "rpc.sock") };
+	return { root, cwd, agentDir, sessionDir, socket: join(root, "r.sock") };
 }
 
 function stateFor(sessionPath: string, sessionId: string, cwd: string): RpcSessionState {
@@ -88,6 +88,7 @@ class FakeHost {
 	readonly server = createServer();
 	readonly connections: Socket[] = [];
 	readonly requests: Array<Record<string, unknown>> = [];
+	readonly firstConnection = deferred<Socket>();
 	readonly secondConnection = deferred<Socket>();
 	readonly thirdConnection = deferred<Socket>();
 	readonly secondOpenSession = deferred<Record<string, unknown>>();
@@ -95,13 +96,15 @@ class FakeHost {
 	private readonly cwd: string;
 	private readonly sessionId = "fake-session";
 	private connectionCount = 0;
+	private readonly dropReconnects: boolean;
 
 	readonly socketPath: string;
 
-	constructor(socketPath: string, sessionPath: string, cwd: string) {
+	constructor(socketPath: string, sessionPath: string, cwd: string, options?: { dropReconnects?: boolean }) {
 		this.socketPath = socketPath;
 		this.sessionPath = sessionPath;
 		this.cwd = cwd;
+		this.dropReconnects = options?.dropReconnects ?? false;
 		this.server.on("connection", (socket) => this.accept(socket));
 	}
 
@@ -114,12 +117,17 @@ class FakeHost {
 		this.connectionCount++;
 		this.connections.push(socket);
 		acceptedSockets.push(socket);
+		if (this.dropReconnects && this.connectionCount > 1) queueMicrotask(() => socket.destroy());
+		if (this.connectionCount === 1) this.firstConnection.resolve(socket);
 		if (this.connectionCount === 2) this.secondConnection.resolve(socket);
 		if (this.connectionCount === 3) this.thirdConnection.resolve(socket);
 		attachJsonlLineReader(socket, (line) => {
 			const request = JSON.parse(line) as Record<string, unknown>;
 			this.requests.push(request);
-			if (request.type === "open_session" && this.requests.filter((item) => item.type === "open_session").length === 2) {
+			if (
+				request.type === "open_session" &&
+				this.requests.filter((item) => item.type === "open_session").length === 2
+			) {
 				this.secondOpenSession.resolve(request);
 			}
 			void this.respond(socket, request);
@@ -168,7 +176,9 @@ async function createLocalRuntime(qa: ReturnType<typeof scratch>): Promise<Agent
 }
 
 describe("interactive host reconnect orchestration", () => {
-	it("reconnects the shared host after the accepted socket is killed without fallback", async () => {
+	it(
+		"reconnects the shared host after the accepted socket is killed without fallback",
+		async () => {
 		const qa = scratch("reconnect");
 		const local = await createLocalRuntime(qa);
 		const sessionPath = local.session.sessionFile!;
@@ -191,9 +201,64 @@ describe("interactive host reconnect orchestration", () => {
 		} finally {
 			await runtime.dispose();
 		}
-	}, TEST_TIMEOUT);
+		},
+		TEST_TIMEOUT,
+	);
 
-	it("sanitizes later proxy failures and deduplicates the fallback warning", async () => {
+	it(
+		"cancels transport actions without error-styled UI",
+		async () => {
+			const qa = scratch("cancelled-actions");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+			await host.listen();
+			const warnings: string[] = [];
+			const warning = deferred<void>();
+			const fallbackWarning = deferred<void>();
+			let ensureHostCalls = 0;
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => {
+					ensureHostCalls++;
+					if (ensureHostCalls > 1) throw new Error("reconnect unavailable");
+					return undefined;
+				},
+				onWarning: (value) => {
+					warnings.push(value.message);
+					if (value.message === INTERACTIVE_HOST_FALLBACK_WARNING) fallbackWarning.resolve();
+					else warning.resolve();
+				},
+			});
+			try {
+				await host.firstConnection.promise;
+				const bash = runtime.session.executeBash("echo disconnected");
+				const cycle = runtime.session.cycleModel("forward");
+				host.connections[0]!.destroy();
+				await expect(bash).resolves.toMatchObject({ cancelled: true });
+				await expect(cycle).resolves.toBeUndefined();
+				await fallbackWarning.promise;
+				expect(
+					warnings.filter(
+						(message) =>
+							message === INTERACTIVE_HOST_RECONNECTING_WARNING || message === INTERACTIVE_HOST_FALLBACK_WARNING,
+					),
+				).toEqual([INTERACTIVE_HOST_RECONNECTING_WARNING, INTERACTIVE_HOST_FALLBACK_WARNING]);
+				expect(
+					warnings.some(
+						(message) =>
+							message.includes("Bash command failed") || message.includes("Shared RPC host is unavailable"),
+					),
+				).toBe(false);
+			} finally {
+				await runtime.dispose();
+			}
+		},
+		TEST_TIMEOUT,
+	);
+
+	it(
+		"sanitizes later proxy failures and deduplicates the fallback warning",
+		async () => {
 		const qa = scratch("sanitized");
 		const local = await createLocalRuntime(qa);
 		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
@@ -214,9 +279,10 @@ describe("interactive host reconnect orchestration", () => {
 			},
 		});
 		try {
+				await host.firstConnection.promise;
 			host.connections[0]!.destroy();
 			const action = runtime.session.steer("after disconnect");
-			await expect(action).rejects.toThrow();
+				await expect(action).resolves.toBeUndefined();
 			await warning.promise;
 			await Promise.resolve();
 			expect(warnings).toHaveLength(2);
@@ -228,9 +294,13 @@ describe("interactive host reconnect orchestration", () => {
 		} finally {
 			await runtime.dispose();
 		}
-	}, TEST_TIMEOUT);
+		},
+		TEST_TIMEOUT,
+	);
 
-	it("switches to the local runtime after reconnect exhaustion", async () => {
+	it(
+		"switches to the local runtime after reconnect exhaustion",
+		async () => {
 		const qa = scratch("fallback");
 		const local = await createLocalRuntime(qa);
 		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
@@ -254,14 +324,93 @@ describe("interactive host reconnect orchestration", () => {
 		} finally {
 			await runtime.dispose();
 		}
-	}, TEST_TIMEOUT);
+		},
+		TEST_TIMEOUT,
+	);
 
-	it("re-arms reconnect when the socket disconnects during a successful reconnect", async () => {
+	it(
+		"stops reconnecting permanently after accepted sockets drop",
+		async () => {
+			const qa = scratch("terminal-fallback");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd, { dropReconnects: true });
+			await host.listen();
+			const fallback = deferred<void>();
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => undefined,
+				onWarning: (value) => {
+					if (value.message === INTERACTIVE_HOST_FALLBACK_WARNING) fallback.resolve();
+				},
+			});
+			try {
+				host.connections[0]!.destroy();
+				await fallback.promise;
+				await new Promise<void>((resolve) => queueMicrotask(resolve));
+				expect(host.connections).toHaveLength(4);
+			} finally {
+				await runtime.dispose();
+			}
+		},
+		TEST_TIMEOUT,
+	);
+
+	it(
+		"dispose awaits the fallback rebind handoff",
+		async () => {
+			const qa = scratch("fallback-dispose");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+			await host.listen();
+			const handoffStarted = deferred<void>();
+			const releaseRebind = deferred<void>();
+			const localDispose = vi.spyOn(local, "dispose");
+			let runtime!: AgentSessionRuntime;
+			let ensureHostCalls = 0;
+			runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => {
+					ensureHostCalls++;
+					if (ensureHostCalls > 1) throw new Error("reconnect unavailable");
+					return undefined;
+				},
+				onWarning: () => {},
+			});
+			(runtime as unknown as { setRebindSession(callback: () => Promise<void>): void }).setRebindSession(
+				async () => {
+					handoffStarted.resolve();
+					await releaseRebind.promise;
+				},
+			);
+			try {
+				await host.firstConnection.promise;
+				host.connections[0]!.destroy();
+				await handoffStarted.promise;
+				const disposing = runtime.dispose();
+				await Promise.resolve();
+				expect(localDispose).not.toHaveBeenCalled();
+				releaseRebind.resolve();
+				await disposing;
+				expect(localDispose).toHaveBeenCalled();
+			} finally {
+				releaseRebind.resolve();
+				await runtime.dispose().catch(() => {});
+			}
+		},
+		TEST_TIMEOUT,
+	);
+
+	it(
+		"re-arms reconnect when the socket disconnects during a successful reconnect",
+		async () => {
 		const qa = scratch("race");
 		const local = await createLocalRuntime(qa);
 		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
 		await host.listen();
-		const runtime = await createInteractiveHostRuntime(local, { socket: qa.socket, ensureHost: async () => undefined });
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => undefined,
+			});
 		try {
 			host.connections[0]!.destroy();
 			await host.secondConnection.promise;
@@ -273,9 +422,13 @@ describe("interactive host reconnect orchestration", () => {
 		} finally {
 			await runtime.dispose();
 		}
-	}, TEST_TIMEOUT);
+		},
+		TEST_TIMEOUT,
+	);
 
-	it("dispose cancels an in-flight reconnect before reopening the session", async () => {
+	it(
+		"dispose cancels an in-flight reconnect before reopening the session",
+		async () => {
 		const qa = scratch("dispose");
 		const local = await createLocalRuntime(qa);
 		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
@@ -305,9 +458,13 @@ describe("interactive host reconnect orchestration", () => {
 			releaseReconnect.resolve();
 			await runtime.dispose().catch(() => {});
 		}
-	}, TEST_TIMEOUT);
+		},
+		TEST_TIMEOUT,
+	);
 
-	it("emits one sanitized fallback warning after bounded reconnect failure", async () => {
+	it(
+		"emits one sanitized fallback warning after bounded reconnect failure",
+		async () => {
 		const qa = scratch("fallback");
 		const local = await createLocalRuntime(qa);
 		const sessionPath = local.session.sessionFile!;
@@ -338,5 +495,7 @@ describe("interactive host reconnect orchestration", () => {
 		} finally {
 			await runtime.dispose();
 		}
-	}, TEST_TIMEOUT);
+		},
+		TEST_TIMEOUT,
+	);
 });

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -1,0 +1,220 @@
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	createAgentSessionFromServices,
+	createAgentSessionRuntime,
+	createAgentSessionServices,
+	type AgentSessionRuntime,
+} from "../src/core/agent-session-runtime.ts";
+import { SessionManager } from "../src/core/session-manager.ts";
+import { SettingsManager } from "../src/core/settings-manager.ts";
+import {
+	createInteractiveHostRuntime,
+	INTERACTIVE_HOST_FALLBACK_WARNING,
+} from "../src/modes/interactive/interactive-host-runtime.ts";
+import { attachJsonlLineReader } from "../src/modes/rpc/jsonl.ts";
+import type { RpcSessionState } from "../src/modes/rpc/rpc-types.ts";
+
+const roots: string[] = [];
+const servers: Server[] = [];
+const runtimes: AgentSessionRuntime[] = [];
+
+const TEST_TIMEOUT = 10_000;
+
+afterEach(async () => {
+	await Promise.all(runtimes.splice(0).map((runtime) => runtime.dispose().catch(() => {})));
+	await Promise.all(
+		servers.splice(0).map(
+			(server) =>
+				new Promise<void>((resolve) => {
+					server.close(() => resolve());
+					server.closeAllConnections?.();
+				}),
+		),
+	);
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function scratch(label: string) {
+	const root = mkdtempSync(join(tmpdir(), `senpi-interactive-reconnect-${label}-`));
+	roots.push(root);
+	const cwd = join(root, "cwd");
+	const agentDir = join(root, "agent");
+	const sessionDir = join(root, "sessions");
+	mkdirSync(cwd, { recursive: true });
+	mkdirSync(agentDir, { recursive: true });
+	mkdirSync(sessionDir, { recursive: true });
+	return { root, cwd, agentDir, sessionDir, socket: join(root, "rpc.sock") };
+}
+
+function stateFor(sessionPath: string, sessionId: string, cwd: string): RpcSessionState {
+	return {
+		thinkingLevel: "off",
+		isStreaming: false,
+		isCompacting: false,
+		steeringMode: "all",
+		followUpMode: "all",
+		sessionFile: sessionPath,
+		sessionId,
+		cwd,
+		projectTrusted: true,
+		favoriteModels: [],
+		scopedModels: [],
+		steering: [],
+		followUp: [],
+		ordered: [],
+		autoCompactionEnabled: true,
+		fastMode: false,
+		messageCount: 0,
+		pendingMessageCount: 0,
+		usageTotals: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, latestCacheHitRate: undefined },
+		retryAttempt: 0,
+		isBashRunning: false,
+	};
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((done) => (resolve = done));
+	return { promise, resolve };
+}
+
+class FakeHost {
+	readonly server = createServer();
+	readonly connections: Socket[] = [];
+	readonly requests: Array<Record<string, unknown>> = [];
+	readonly secondConnection = deferred<Socket>();
+	readonly secondOpenSession = deferred<Record<string, unknown>>();
+	private readonly sessionPath: string;
+	private readonly cwd: string;
+	private readonly sessionId = "fake-session";
+	private connectionCount = 0;
+
+	constructor(readonly socketPath: string, sessionPath: string, cwd: string) {
+		this.sessionPath = sessionPath;
+		this.cwd = cwd;
+		this.server.on("connection", (socket) => this.accept(socket));
+	}
+
+	async listen(): Promise<void> {
+		await new Promise<void>((resolve) => this.server.listen(this.socketPath, resolve));
+		servers.push(this.server);
+	}
+
+	private accept(socket: Socket): void {
+		this.connectionCount++;
+		this.connections.push(socket);
+		if (this.connectionCount === 2) this.secondConnection.resolve(socket);
+		attachJsonlLineReader(socket, (line) => {
+			const request = JSON.parse(line) as Record<string, unknown>;
+			this.requests.push(request);
+			if (request.type === "open_session" && this.requests.filter((item) => item.type === "open_session").length === 2) {
+				this.secondOpenSession.resolve(request);
+			}
+			void this.respond(socket, request);
+		});
+	}
+
+	private async respond(socket: Socket, request: Record<string, unknown>): Promise<void> {
+		const id = request.id;
+		let data: unknown;
+		if (request.type === "open_session") {
+			data = {
+				sessionId: this.sessionId,
+				attached: this.requests.filter((item) => item.type === "open_session").length > 1,
+				state: stateFor(this.sessionPath, this.sessionId, this.cwd),
+			};
+		} else if (request.type === "get_state") {
+			data = stateFor(this.sessionPath, this.sessionId, this.cwd);
+		} else if (request.type === "close_session") {
+			data = {};
+		} else {
+			data = {};
+		}
+		socket.write(`${JSON.stringify({ id, type: "response", command: request.type, success: true, data })}\n`);
+	}
+}
+
+async function createLocalRuntime(qa: ReturnType<typeof scratch>): Promise<AgentSessionRuntime> {
+	const sessionManager = SessionManager.create(qa.cwd, qa.sessionDir);
+	const settingsManager = SettingsManager.create(qa.cwd, qa.agentDir);
+	const services = await createAgentSessionServices({
+		cwd: qa.cwd,
+		agentDir: qa.agentDir,
+		settingsManager,
+		resourceLoaderOptions: { noExtensions: true, noSkills: true, noPromptTemplates: true, noThemes: true },
+	});
+	const runtime = await createAgentSessionRuntime(
+		async ({ cwd, sessionManager: manager }) => ({
+			...(await createAgentSessionFromServices({ services, sessionManager: manager })),
+			services,
+			diagnostics: services.diagnostics,
+		}),
+		{ cwd: qa.cwd, agentDir: qa.agentDir, sessionManager },
+	);
+	runtimes.push(runtime);
+	return runtime;
+}
+
+describe("interactive host reconnect orchestration", () => {
+	it("reconnects the shared host after the accepted socket is killed without fallback", async () => {
+		const qa = scratch("reconnect");
+		const local = await createLocalRuntime(qa);
+		const sessionPath = local.session.sessionFile!;
+		const host = new FakeHost(qa.socket, sessionPath, qa.cwd);
+		await host.listen();
+		const warnings: Array<{ message: string; cause: unknown }> = [];
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => undefined,
+			onWarning: (warning) => warnings.push(warning),
+		});
+		try {
+			expect(host.connections).toHaveLength(1);
+		host.connections[0]!.destroy();
+			await host.secondConnection.promise;
+			await host.secondOpenSession.promise;
+			expect(host.connections).toHaveLength(2);
+			expect(host.requests.filter((request) => request.type === "open_session")).toHaveLength(2);
+			expect(warnings).toEqual([]);
+		} finally {
+			await runtime.dispose();
+		}
+	}, TEST_TIMEOUT);
+
+	it("emits one sanitized fallback warning after bounded reconnect failure", async () => {
+		const qa = scratch("fallback");
+		const local = await createLocalRuntime(qa);
+		const sessionPath = local.session.sessionFile!;
+		const host = new FakeHost(qa.socket, sessionPath, qa.cwd);
+		await host.listen();
+		const warnings: Array<{ message: string; cause: unknown }> = [];
+		let ensureHostCalls = 0;
+		const warning = deferred<void>();
+		const runtime = await createInteractiveHostRuntime(local, {
+			socket: qa.socket,
+			ensureHost: async () => {
+				ensureHostCalls++;
+				if (ensureHostCalls > 1) throw new Error("Client not started");
+				return undefined;
+			},
+			onWarning: (value) => {
+				warnings.push(value);
+				warning.resolve();
+			},
+		});
+		try {
+			host.connections[0]!.destroy();
+			await warning.promise;
+			expect(ensureHostCalls).toBe(4);
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0]?.message).toBe(INTERACTIVE_HOST_FALLBACK_WARNING);
+			expect(warnings.every(({ message }) => !message.includes("Client not started"))).toBe(true);
+		} finally {
+			await runtime.dispose();
+		}
+	}, TEST_TIMEOUT);
+});

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -14,6 +14,7 @@ import { SettingsManager } from "../src/core/settings-manager.ts";
 import {
 	createInteractiveHostRuntime,
 	INTERACTIVE_HOST_FALLBACK_WARNING,
+	INTERACTIVE_HOST_RECONNECTING_WARNING,
 } from "../src/modes/interactive/interactive-host-runtime.ts";
 import { attachJsonlLineReader } from "../src/modes/rpc/jsonl.ts";
 import type { RpcSessionState } from "../src/modes/rpc/rpc-types.ts";
@@ -218,9 +219,12 @@ describe("interactive host reconnect orchestration", () => {
 			await expect(action).rejects.toThrow();
 			await warning.promise;
 			await Promise.resolve();
-			expect(warnings).toHaveLength(1);
-			expect(warnings[0]?.message).toBe(INTERACTIVE_HOST_FALLBACK_WARNING);
-			expect(warnings[0]?.message).not.toContain("internal socket path");
+			expect(warnings).toHaveLength(2);
+			expect(warnings.map(({ message }) => message)).toEqual([
+			INTERACTIVE_HOST_RECONNECTING_WARNING,
+			INTERACTIVE_HOST_FALLBACK_WARNING,
+		]);
+			expect(warnings.every(({ message }) => !message.includes("internal socket path"))).toBe(true);
 		} finally {
 			await runtime.dispose();
 		}

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -150,7 +150,7 @@ async function createLocalRuntime(qa: ReturnType<typeof scratch>): Promise<Agent
 		resourceLoaderOptions: { noExtensions: true, noSkills: true, noPromptTemplates: true, noThemes: true },
 	});
 	const runtime = await createAgentSessionRuntime(
-		async ({ cwd, sessionManager: manager }) => ({
+		async ({ sessionManager: manager }) => ({
 			...(await createAgentSessionFromServices({ services, sessionManager: manager })),
 			services,
 			diagnostics: services.diagnostics,

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { createServer, type Server, type Socket } from "node:net";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -40,8 +39,10 @@ afterEach(async () => {
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-function scratch(label: string) {
-	const root = mkdtempSync(join(tmpdir(), `senpi-interactive-reconnect-${label}-`));
+function scratch(_label: string) {
+	// Keep the Unix socket path below macOS sun_path's 104-byte limit even on
+	// the bridge runner, whose os.tmpdir() path is comparatively long.
+	const root = mkdtempSync("/tmp/shr-");
 	roots.push(root);
 	const cwd = join(root, "cwd");
 	const agentDir = join(root, "agent");
@@ -179,28 +180,28 @@ describe("interactive host reconnect orchestration", () => {
 	it(
 		"reconnects the shared host after the accepted socket is killed without fallback",
 		async () => {
-		const qa = scratch("reconnect");
-		const local = await createLocalRuntime(qa);
-		const sessionPath = local.session.sessionFile!;
-		const host = new FakeHost(qa.socket, sessionPath, qa.cwd);
-		await host.listen();
-		const warnings: Array<{ message: string; cause: unknown }> = [];
-		const runtime = await createInteractiveHostRuntime(local, {
-			socket: qa.socket,
-			ensureHost: async () => undefined,
-			onWarning: (warning) => warnings.push(warning),
-		});
-		try {
-			expect(host.connections).toHaveLength(1);
-		host.connections[0]!.destroy();
-			await host.secondConnection.promise;
-			await host.secondOpenSession.promise;
-			expect(host.connections).toHaveLength(2);
-			expect(host.requests.filter((request) => request.type === "open_session")).toHaveLength(2);
-			expect(warnings).toEqual([]);
-		} finally {
-			await runtime.dispose();
-		}
+			const qa = scratch("reconnect");
+			const local = await createLocalRuntime(qa);
+			const sessionPath = local.session.sessionFile!;
+			const host = new FakeHost(qa.socket, sessionPath, qa.cwd);
+			await host.listen();
+			const warnings: Array<{ message: string; cause: unknown }> = [];
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => undefined,
+				onWarning: (warning) => warnings.push(warning),
+			});
+			try {
+				expect(host.connections).toHaveLength(1);
+				host.connections[0]!.destroy();
+				await host.secondConnection.promise;
+				await host.secondOpenSession.promise;
+				expect(host.connections).toHaveLength(2);
+				expect(host.requests.filter((request) => request.type === "open_session")).toHaveLength(2);
+				expect(warnings).toEqual([]);
+			} finally {
+				await runtime.dispose();
+			}
 		},
 		TEST_TIMEOUT,
 	);
@@ -259,41 +260,41 @@ describe("interactive host reconnect orchestration", () => {
 	it(
 		"sanitizes later proxy failures and deduplicates the fallback warning",
 		async () => {
-		const qa = scratch("sanitized");
-		const local = await createLocalRuntime(qa);
-		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
-		await host.listen();
-		const warnings: Array<{ message: string; cause: unknown }> = [];
-		let ensureHostCalls = 0;
-		const warning = deferred<void>();
-		const runtime = await createInteractiveHostRuntime(local, {
-			socket: qa.socket,
-			ensureHost: async () => {
-				ensureHostCalls++;
-				if (ensureHostCalls > 1) throw new Error("internal socket path / secret");
-				return undefined;
-			},
-			onWarning: (value) => {
-				warnings.push(value);
-				warning.resolve();
-			},
-		});
-		try {
+			const qa = scratch("sanitized");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+			await host.listen();
+			const warnings: Array<{ message: string; cause: unknown }> = [];
+			let ensureHostCalls = 0;
+			const warning = deferred<void>();
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => {
+					ensureHostCalls++;
+					if (ensureHostCalls > 1) throw new Error("internal socket path / secret");
+					return undefined;
+				},
+				onWarning: (value) => {
+					warnings.push(value);
+					warning.resolve();
+				},
+			});
+			try {
 				await host.firstConnection.promise;
-			host.connections[0]!.destroy();
-			const action = runtime.session.steer("after disconnect");
+				host.connections[0]!.destroy();
+				const action = runtime.session.steer("after disconnect");
 				await expect(action).resolves.toBeUndefined();
-			await warning.promise;
-			await Promise.resolve();
-			expect(warnings).toHaveLength(2);
-			expect(warnings.map(({ message }) => message)).toEqual([
-			INTERACTIVE_HOST_RECONNECTING_WARNING,
-			INTERACTIVE_HOST_FALLBACK_WARNING,
-		]);
-			expect(warnings.every(({ message }) => !message.includes("internal socket path"))).toBe(true);
-		} finally {
-			await runtime.dispose();
-		}
+				await warning.promise;
+				await Promise.resolve();
+				expect(warnings).toHaveLength(2);
+				expect(warnings.map(({ message }) => message)).toEqual([
+					INTERACTIVE_HOST_RECONNECTING_WARNING,
+					INTERACTIVE_HOST_FALLBACK_WARNING,
+				]);
+				expect(warnings.every(({ message }) => !message.includes("internal socket path"))).toBe(true);
+			} finally {
+				await runtime.dispose();
+			}
 		},
 		TEST_TIMEOUT,
 	);
@@ -301,29 +302,29 @@ describe("interactive host reconnect orchestration", () => {
 	it(
 		"switches to the local runtime after reconnect exhaustion",
 		async () => {
-		const qa = scratch("fallback");
-		const local = await createLocalRuntime(qa);
-		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
-		await host.listen();
-		const warning = deferred<void>();
-		let ensureHostCalls = 0;
-		const runtime = await createInteractiveHostRuntime(local, {
-			socket: qa.socket,
-			ensureHost: async () => {
-				ensureHostCalls++;
-				if (ensureHostCalls > 1) throw new Error("reconnect failed");
-				return undefined;
-			},
-			onWarning: () => warning.resolve(),
-		});
-		try {
-			host.connections[0]!.destroy();
-			await warning.promise;
-			expect(runtime.session).toBe(local.session);
-			expect(host.requests.filter((request) => request.type === "get_state")).toHaveLength(0);
-		} finally {
-			await runtime.dispose();
-		}
+			const qa = scratch("fallback");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+			await host.listen();
+			const warning = deferred<void>();
+			let ensureHostCalls = 0;
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => {
+					ensureHostCalls++;
+					if (ensureHostCalls > 1) throw new Error("reconnect failed");
+					return undefined;
+				},
+				onWarning: () => warning.resolve(),
+			});
+			try {
+				host.connections[0]!.destroy();
+				await warning.promise;
+				expect(runtime.session).toBe(local.session);
+				expect(host.requests.filter((request) => request.type === "get_state")).toHaveLength(0);
+			} finally {
+				await runtime.dispose();
+			}
 		},
 		TEST_TIMEOUT,
 	);
@@ -403,25 +404,25 @@ describe("interactive host reconnect orchestration", () => {
 	it(
 		"re-arms reconnect when the socket disconnects during a successful reconnect",
 		async () => {
-		const qa = scratch("race");
-		const local = await createLocalRuntime(qa);
-		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
-		await host.listen();
+			const qa = scratch("race");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+			await host.listen();
 			const runtime = await createInteractiveHostRuntime(local, {
 				socket: qa.socket,
 				ensureHost: async () => undefined,
 			});
-		try {
-			host.connections[0]!.destroy();
-			await host.secondConnection.promise;
-			await host.secondOpenSession.promise;
-			// The reconnect has completed; a later disconnect must start another attempt.
-			host.connections[1]!.destroy();
-			await host.thirdConnection.promise;
-			expect(host.connections.length).toBeGreaterThanOrEqual(3);
-		} finally {
-			await runtime.dispose();
-		}
+			try {
+				host.connections[0]!.destroy();
+				await host.secondConnection.promise;
+				await host.secondOpenSession.promise;
+				// The reconnect has completed; a later disconnect must start another attempt.
+				host.connections[1]!.destroy();
+				await host.thirdConnection.promise;
+				expect(host.connections.length).toBeGreaterThanOrEqual(3);
+			} finally {
+				await runtime.dispose();
+			}
 		},
 		TEST_TIMEOUT,
 	);
@@ -429,35 +430,35 @@ describe("interactive host reconnect orchestration", () => {
 	it(
 		"dispose cancels an in-flight reconnect before reopening the session",
 		async () => {
-		const qa = scratch("dispose");
-		const local = await createLocalRuntime(qa);
-		const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
-		await host.listen();
-		const reconnectStarted = deferred<void>();
-		const releaseReconnect = deferred<void>();
-		let ensureHostCalls = 0;
-		const runtime = await createInteractiveHostRuntime(local, {
-			socket: qa.socket,
-			ensureHost: async () => {
-				ensureHostCalls++;
-				if (ensureHostCalls > 1) {
-					reconnectStarted.resolve();
-					await releaseReconnect.promise;
-				}
-				return undefined;
-			},
-		});
-		try {
-			host.connections[0]!.destroy();
-			await reconnectStarted.promise;
-			const disposed = runtime.dispose();
-			releaseReconnect.resolve();
-			await disposed;
-			expect(host.requests.filter((request) => request.type === "open_session")).toHaveLength(1);
-		} finally {
-			releaseReconnect.resolve();
-			await runtime.dispose().catch(() => {});
-		}
+			const qa = scratch("dispose");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+			await host.listen();
+			const reconnectStarted = deferred<void>();
+			const releaseReconnect = deferred<void>();
+			let ensureHostCalls = 0;
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => {
+					ensureHostCalls++;
+					if (ensureHostCalls > 1) {
+						reconnectStarted.resolve();
+						await releaseReconnect.promise;
+					}
+					return undefined;
+				},
+			});
+			try {
+				host.connections[0]!.destroy();
+				await reconnectStarted.promise;
+				const disposed = runtime.dispose();
+				releaseReconnect.resolve();
+				await disposed;
+				expect(host.requests.filter((request) => request.type === "open_session")).toHaveLength(1);
+			} finally {
+				releaseReconnect.resolve();
+				await runtime.dispose().catch(() => {});
+			}
 		},
 		TEST_TIMEOUT,
 	);
@@ -465,36 +466,36 @@ describe("interactive host reconnect orchestration", () => {
 	it(
 		"emits one sanitized fallback warning after bounded reconnect failure",
 		async () => {
-		const qa = scratch("fallback");
-		const local = await createLocalRuntime(qa);
-		const sessionPath = local.session.sessionFile!;
-		const host = new FakeHost(qa.socket, sessionPath, qa.cwd);
-		await host.listen();
-		const warnings: Array<{ message: string; cause: unknown }> = [];
-		let ensureHostCalls = 0;
-		const warning = deferred<void>();
-		const runtime = await createInteractiveHostRuntime(local, {
-			socket: qa.socket,
-			ensureHost: async () => {
-				ensureHostCalls++;
-				if (ensureHostCalls > 1) throw new Error("Client not started");
-				return undefined;
-			},
-			onWarning: (value) => {
-				warnings.push(value);
-				warning.resolve();
-			},
-		});
-		try {
-			host.connections[0]!.destroy();
-			await warning.promise;
-			expect(ensureHostCalls).toBe(4);
-			expect(warnings).toHaveLength(1);
-			expect(warnings[0]?.message).toBe(INTERACTIVE_HOST_FALLBACK_WARNING);
-			expect(warnings.every(({ message }) => !message.includes("Client not started"))).toBe(true);
-		} finally {
-			await runtime.dispose();
-		}
+			const qa = scratch("fallback");
+			const local = await createLocalRuntime(qa);
+			const sessionPath = local.session.sessionFile!;
+			const host = new FakeHost(qa.socket, sessionPath, qa.cwd);
+			await host.listen();
+			const warnings: Array<{ message: string; cause: unknown }> = [];
+			let ensureHostCalls = 0;
+			const warning = deferred<void>();
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => {
+					ensureHostCalls++;
+					if (ensureHostCalls > 1) throw new Error("Client not started");
+					return undefined;
+				},
+				onWarning: (value) => {
+					warnings.push(value);
+					warning.resolve();
+				},
+			});
+			try {
+				host.connections[0]!.destroy();
+				await warning.promise;
+				expect(ensureHostCalls).toBe(4);
+				expect(warnings).toHaveLength(1);
+				expect(warnings[0]?.message).toBe(INTERACTIVE_HOST_FALLBACK_WARNING);
+				expect(warnings.every(({ message }) => !message.includes("Client not started"))).toBe(true);
+			} finally {
+				await runtime.dispose();
+			}
 		},
 		TEST_TIMEOUT,
 	);

--- a/packages/coding-agent/test/interactive-host-reconnect.test.ts
+++ b/packages/coding-agent/test/interactive-host-reconnect.test.ts
@@ -258,6 +258,31 @@ describe("interactive host reconnect orchestration", () => {
 	);
 
 	it(
+		"cancels reload and veto transport calls without secondary errors",
+		async () => {
+			const qa = scratch("reload-cancel");
+			const local = await createLocalRuntime(qa);
+			const host = new FakeHost(qa.socket, local.session.sessionFile!, qa.cwd);
+			await host.listen();
+			const runtime = await createInteractiveHostRuntime(local, {
+				socket: qa.socket,
+				ensureHost: async () => undefined,
+			});
+			try {
+				await host.firstConnection.promise;
+				const veto = runtime.session.checkReloadVeto();
+				const reload = runtime.session.reload();
+				host.connections[0]!.destroy();
+				await expect(veto).resolves.toEqual({ cancelled: true });
+				await expect(reload).resolves.toEqual({ cancelled: true });
+			} finally {
+				await runtime.dispose();
+			}
+		},
+		TEST_TIMEOUT,
+	);
+
+	it(
 		"sanitizes later proxy failures and deduplicates the fallback warning",
 		async () => {
 			const qa = scratch("sanitized");
@@ -365,6 +390,8 @@ describe("interactive host reconnect orchestration", () => {
 			await host.listen();
 			const handoffStarted = deferred<void>();
 			const releaseRebind = deferred<void>();
+			let handoffFinished = false;
+			const fallbackWarning = deferred<void>();
 			const localDispose = vi.spyOn(local, "dispose");
 			let runtime!: AgentSessionRuntime;
 			let ensureHostCalls = 0;
@@ -375,12 +402,18 @@ describe("interactive host reconnect orchestration", () => {
 					if (ensureHostCalls > 1) throw new Error("reconnect unavailable");
 					return undefined;
 				},
-				onWarning: () => {},
+				onWarning: (warning) => {
+					if (warning.message === INTERACTIVE_HOST_FALLBACK_WARNING) {
+						expect(handoffFinished).toBe(true);
+						fallbackWarning.resolve();
+					}
+				},
 			});
 			(runtime as unknown as { setRebindSession(callback: () => Promise<void>): void }).setRebindSession(
 				async () => {
 					handoffStarted.resolve();
 					await releaseRebind.promise;
+					handoffFinished = true;
 				},
 			);
 			try {
@@ -391,6 +424,7 @@ describe("interactive host reconnect orchestration", () => {
 				await Promise.resolve();
 				expect(localDispose).not.toHaveBeenCalled();
 				releaseRebind.resolve();
+				await fallbackWarning.promise;
 				await disposing;
 				expect(localDispose).toHaveBeenCalled();
 			} finally {

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -20,7 +20,6 @@ import { FooterComponent } from "../src/modes/interactive/components/footer.ts";
 import {
 	createInteractiveHostRuntime,
 	INTERACTIVE_HOST_FALLBACK_WARNING,
-	INTERACTIVE_HOST_RECONNECTING_WARNING,
 } from "../src/modes/interactive/interactive-host-runtime.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 import { RpcClient } from "../src/modes/rpc/rpc-client.ts";

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -20,6 +20,7 @@ import { FooterComponent } from "../src/modes/interactive/components/footer.ts";
 import {
 	createInteractiveHostRuntime,
 	INTERACTIVE_HOST_FALLBACK_WARNING,
+	INTERACTIVE_HOST_RECONNECTING_WARNING,
 } from "../src/modes/interactive/interactive-host-runtime.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 import { RpcClient } from "../src/modes/rpc/rpc-client.ts";
@@ -839,7 +840,7 @@ describe("interactive host runtime", () => {
 		});
 		try {
 			expect(runtime).toBe(local);
-			expect(warnings).toEqual([`${INTERACTIVE_HOST_FALLBACK_WARNING}: host intentionally unavailable`]);
+			expect(warnings).toEqual([INTERACTIVE_HOST_FALLBACK_WARNING]);
 			await runtime.session.prompt("local-fallback-unique");
 			await runtime.session.waitForIdle();
 			expect(runtime.session.getLastAssistantText()).toBeTruthy();

--- a/packages/coding-agent/test/rpc-client-reconnect.test.ts
+++ b/packages/coding-agent/test/rpc-client-reconnect.test.ts
@@ -1,5 +1,5 @@
-import { createServer } from "node:net";
 import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test, vi } from "vitest";

--- a/packages/coding-agent/test/rpc-client-reconnect.test.ts
+++ b/packages/coding-agent/test/rpc-client-reconnect.test.ts
@@ -1,0 +1,45 @@
+import { createServer } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test, vi } from "vitest";
+import { RpcClient, RpcTransportGoneError } from "../src/modes/rpc/rpc-client.ts";
+
+describe("RpcClient disconnect lifecycle", () => {
+	test("fails sends with a classified transport error before start", async () => {
+		const client = new RpcClient();
+
+		await expect(client.getState()).rejects.toBeInstanceOf(RpcTransportGoneError);
+		await expect(client.getState()).rejects.toMatchObject({ code: "rpc_transport_gone" });
+	});
+
+	test("notifies once when an established socket disconnects", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "rpc-client-reconnect-"));
+		const socketPath = join(directory, "rpc.sock");
+		let peer: import("node:net").Socket | undefined;
+		const server = createServer((socket) => {
+			peer = socket;
+		});
+		try {
+			await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+			const onDisconnect = vi.fn();
+			const client = new RpcClient({ socketPath, onDisconnect });
+			await client.start();
+			const disconnected = new Promise<void>((resolve) => {
+				const check = () => onDisconnect.mock.calls.length > 0 && resolve();
+				const original = onDisconnect.getMockImplementation();
+				onDisconnect.mockImplementation((...args) => {
+					original?.(...args);
+					check();
+				});
+			});
+			peer?.destroy();
+			await disconnected;
+			await expect(client.getState()).rejects.toBeInstanceOf(RpcTransportGoneError);
+			expect(onDisconnect).toHaveBeenCalledTimes(1);
+		} finally {
+			server.close();
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/rpc-teardown-crash.test.ts
+++ b/packages/coding-agent/test/rpc-teardown-crash.test.ts
@@ -48,6 +48,9 @@ describe("RPC teardown when the transport is gone", () => {
 	test("active send failures still surface", async () => {
 		const client = new RpcClient();
 
-		await expect(client.prompt("active turn")).rejects.toThrow("Client not started");
+		await expect(client.prompt("active turn")).rejects.toMatchObject({
+			name: "RpcTransportGoneError",
+			code: "rpc_transport_gone",
+		});
 	});
 });


### PR DESCRIPTION
## Problem

When the shared interactive host's socket drops (host exit/restart), the attached TUI surfaces raw `Error: Client not started` thrown from `RpcClient.send()` — every post-disconnect proxy call (prompt, steer, refresh, extension UI responses, bash callbacks) can hit it.

## Fix (root cause)

- `RpcClient`: new exported `RpcTransportGoneError` (`code: "rpc_transport_gone"`), `onDisconnect` option with once-only notification, typed send gating on missing/destroyed transport; pending requests still rejected on disconnect; child-process `exitError` semantics preserved.
- `interactive-host-runtime`: bounded reconnect orchestration (re-ensure host -> reconnect socket -> re-open/attach session -> refresh) with graceful fallback to the standard `INTERACTIVE_HOST_FALLBACK_WARNING` when recovery fails; transport-gone action failures are sanitized to the fallback warning — the raw error string never reaches the user.
- `src/modes/rpc/changes.md` updated. No wire-protocol changes.

## TDD / evidence (run on a clean remote box)

- `test/rpc-client-reconnect.test.ts`: pre-start sends classified; once-only disconnect notification over a real Unix socket.
- `test/rpc-teardown-crash.test.ts`: raw-message pin replaced with typed classification.
- `test/interactive-host-reconnect.test.ts`: real-socket reconnect (second connection + second open_session, no fallback warning) and exhausted-retry fallback (exactly one warning, no raw "Client not started" anywhere) — both locked with mutation proofs (reconnect disabled / raw message restored -> tests fail).
- Real-surface QA: tmux-driven TUI attached to a live shared host, host supervisor killed -> no raw error on the pane, graceful fallback/reconnect (transcript captured).
- Full suite + root check on the branch; unrelated full-suite flakes classified against origin/main (pass focused on both).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shared interactive host socket drops so attached TUIs no longer surface raw `Error: Client not started` on post-disconnect proxy calls such as prompt, steer, refresh, bash, and extension UI responses.

- `RpcClient` now throws `RpcTransportGoneError` (`rpc_transport_gone`) for missing or destroyed transports, fires `onDisconnect` once per unexpected disconnect, and exports `isTransportGoneError` from the package, documented in `docs/rpc.md` and the changelog.
- Interactive host runtimes make up to 3 reconnect attempts (re-ensure host → reconnect socket → re-open session → refresh); transport-gone proxy calls return cancelled/inert results.
- Recovery shows one transient reconnecting warning; exhausted retries fall back permanently to the retained local session after awaiting rebind and emit one deduplicated, sanitized fallback warning.
- No wire-protocol changes; new tests cover real-socket reconnects, reconnect races, dispose during reconnect, and exhausted-retry fallback.

<sup>Written for commit 0e4ee4c8942217f4cef94b0f13539445c24cb365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

