### PR TITLE
test(pty): make native wait cleanup cancellation deterministic

### DIFF
--- a/packages/pty/test/fixtures/native-wait-threadpool-starvation.mjs
+++ b/packages/pty/test/fixtures/native-wait-threadpool-starvation.mjs
@@ -79,14 +79,16 @@ try {
 } finally {
 	for (const session of sessions) {
 		try {
-			session.kill("SIGKILL");
+			// Mark cancellation before signalling so a fast exit cannot beat the
+			// waiter's cancellation flag observation.
+			session.kill();
 		} catch {
 			// The child may have exited while another session was being stopped.
 		}
 		try {
-			session.kill();
+			session.kill("SIGKILL");
 		} catch {
-			// Mark cancellation even if the explicit SIGKILL already won the race.
+			// The cancellation-marking kill already stopped the process.
 		}
 	}
 	const exits = await deadline(Promise.all(waits), 5_000, "PTY_CLEANUP_TIMEOUT");


### PR DESCRIPTION
## Summary
- mark native PTY sessions cancelled before cleanup signalling in the threadpool starvation fixture
- avoid a fast SIGKILL exit racing the cancellation flag observation

## Root cause
The fixture sent `SIGKILL` through `kill(signal)` first. That API intentionally sends only the requested signal and does not set the cancellation flag; the follow-up no-argument `kill()` could lose a race with `waitExit()` on macOS, producing a normal exit even though the fixture was cleaning up a cancelled session. The flow-control changes altered scheduling enough to expose this existing fixture race deterministically.

## Verification
- focused native wait test: 2 consecutive passes
- full `@earendil-works/pi-pty` suite: 9 files, 71 tests passed
- `cargo test -p senpi-pty`: 13 tests passed
- package TypeScript build passed
- prebuild freshness check was run and reports the existing vendored darwin-arm64 binary differs from a local rebuild; no native artifact was changed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the native PTY test fixture so cancellation is marked before the cleanup signal.

The fixture previously sent `SIGKILL` first, which didn't set the cancellation flag, so a fast exit could lose the race with `waitExit()` on macOS. It now marks cancellation with `kill()` before sending `kill("SIGKILL")`, making cleanup deterministic.

<sup>Written for commit f3afea921e3cad514264b55447b345c76732fb8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

