### PR TITLE
feat(codemode): ship bun-1-4 builtin skill gated on eval + bun >= 1.4

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Added
 
+- The codemode extension now bundles the `bun-1-4` skill and contributes it via `resources_discover` when
+  bun >= 1.4 is detected (PATH probe with `process.versions.bun` fallback).
+
 ### Changed
 
 ### Fixed

--- a/packages/senpi-codemode/src/extension/skill-contribution.ts
+++ b/packages/senpi-codemode/src/extension/skill-contribution.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/senpi-codemode/src/extension/skill-contribution.ts
+++ b/packages/senpi-codemode/src/extension/skill-contribution.ts
@@ -1,3 +1,18 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const execFileAsync = promisify(execFile);
+
+/** How long `bun --version` may run before the PATH probe gives up. */
+const PATH_BUN_PROBE_TIMEOUT_MS = 1500;
+
+const BUN_SKILL_BASE_DIR = dirname(fileURLToPath(import.meta.url));
+
+let loggedMissingBunSkill = false;
+
 export const BUN_SKILL_MIN_VERSION = "1.4.0";
 
 export interface BunSkillProbe {
@@ -5,23 +20,65 @@ export interface BunSkillProbe {
 	runtimeBunVersion(): string | undefined;
 }
 
+/**
+ * True when the version is at least `BUN_SKILL_MIN_VERSION`: parses the leading
+ * `<major>.<minor>` integers of the string and gates on major > 1 || (major === 1 && minor >= 4).
+ * Unparseable or missing versions never enable the skill.
+ */
 export function bunVersionSupportsSkill(version: string | undefined): boolean {
-	void version;
-	return false;
+	if (version === undefined) return false;
+	const match = /^(\d+)\.(\d+)/.exec(version);
+	if (match === null) return false;
+	const major = Number.parseInt(match[1]!, 10);
+	const minor = Number.parseInt(match[2]!, 10);
+	return major > 1 || (major === 1 && minor >= 4);
 }
 
-export function bundledBunSkillPath(baseDir?: string): string | undefined {
-	void baseDir;
+/** Absolute path of the bundled bun-1-4 SKILL.md, or undefined (logged once) when it is not shipped. */
+export function bundledBunSkillPath(baseDir: string = BUN_SKILL_BASE_DIR): string | undefined {
+	const candidate = join(baseDir, "..", "skill", "bun-1-4", "SKILL.md");
+	if (existsSync(candidate)) return candidate;
+	if (!loggedMissingBunSkill) {
+		loggedMissingBunSkill = true;
+		console.debug(`[senpi-codemode] bundled bun-1-4 skill not found at ${candidate}; skipping contribution`);
+	}
 	return undefined;
 }
 
+async function probePathBunVersion(): Promise<string | undefined> {
+	try {
+		const { stdout } = await execFileAsync("bun", ["--version"], { timeout: PATH_BUN_PROBE_TIMEOUT_MS });
+		return stdout.trim();
+	} catch {
+		return undefined;
+	}
+}
+
+const defaultBunSkillProbe: BunSkillProbe = {
+	probePathBunVersion,
+	runtimeBunVersion: () => process.versions.bun,
+};
+
+/**
+ * Builds the `resources_discover` handler that contributes the bundled bun-1-4 skill
+ * when bun >= 1.4 is detected (PATH probe first, `process.versions.bun` as fallback).
+ * The gate decision is cached in a single shared promise, so the PATH probe
+ * subprocess runs at most once per handler.
+ */
 export function createBunSkillDiscoverHandler(
-	probe?: BunSkillProbe,
+	probe: BunSkillProbe = defaultBunSkillProbe,
 	baseDir?: string,
 ): () => Promise<{ skillPaths: string[] } | undefined> {
-	void probe;
-	void baseDir;
-	return async () => undefined;
+	let decision: Promise<{ skillPaths: string[] } | undefined> | undefined;
+	return async () => {
+		decision ??= (async () => {
+			const version = (await probe.probePathBunVersion()) ?? probe.runtimeBunVersion();
+			if (!bunVersionSupportsSkill(version)) return undefined;
+			const skillPath = bundledBunSkillPath(baseDir);
+			return skillPath === undefined ? undefined : { skillPaths: [skillPath] };
+		})();
+		return decision;
+	};
 }
 
 export function registerBunSkillContribution(
@@ -37,7 +94,5 @@ export function registerBunSkillContribution(
 	probe?: BunSkillProbe,
 	baseDir?: string,
 ): void {
-	void probe;
-	void baseDir;
-	pi.on("resources_discover", async () => undefined);
+	pi.on("resources_discover", createBunSkillDiscoverHandler(probe, baseDir));
 }

--- a/packages/senpi-codemode/src/extension/skill-contribution.ts
+++ b/packages/senpi-codemode/src/extension/skill-contribution.ts
@@ -1,0 +1,43 @@
+export const BUN_SKILL_MIN_VERSION = "1.4.0";
+
+export interface BunSkillProbe {
+	probePathBunVersion(): Promise<string | undefined>;
+	runtimeBunVersion(): string | undefined;
+}
+
+export function bunVersionSupportsSkill(version: string | undefined): boolean {
+	void version;
+	return false;
+}
+
+export function bundledBunSkillPath(baseDir?: string): string | undefined {
+	void baseDir;
+	return undefined;
+}
+
+export function createBunSkillDiscoverHandler(
+	probe?: BunSkillProbe,
+	baseDir?: string,
+): () => Promise<{ skillPaths: string[] } | undefined> {
+	void probe;
+	void baseDir;
+	return async () => undefined;
+}
+
+export function registerBunSkillContribution(
+	pi: {
+		on(
+			event: "resources_discover",
+			handler: (
+				event: unknown,
+				ctx: unknown,
+			) => Promise<{ skillPaths?: string[] } | undefined> | { skillPaths?: string[] } | undefined,
+		): void;
+	},
+	probe?: BunSkillProbe,
+	baseDir?: string,
+): void {
+	void probe;
+	void baseDir;
+	pi.on("resources_discover", async () => undefined);
+}

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -41,13 +41,12 @@ type CodemodeEvent = SessionLifecycleEvent | "model_select";
 export interface CodemodeExtensionAPI {
 	registerTool(tool: ReturnType<typeof createEvalTool>): void;
 	registerRemovedToolHint(name: string, hint: string): void;
-	on(event: CodemodeEvent, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void;
 	on(
-		event: "resources_discover",
+		event: CodemodeEvent | "resources_discover",
 		handler: (
 			event: unknown,
 			ctx: ExtensionContext,
-		) => Promise<{ skillPaths?: string[] } | undefined> | { skillPaths?: string[] } | undefined,
+		) => Promise<{ skillPaths?: string[] } | undefined | void> | { skillPaths?: string[] } | undefined | void,
 	): void;
 	executeTool: AgentExecuteTool;
 	getActiveTools(): string[];

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -41,13 +41,7 @@ type CodemodeEvent = SessionLifecycleEvent | "model_select";
 export interface CodemodeExtensionAPI {
 	registerTool(tool: ReturnType<typeof createEvalTool>): void;
 	registerRemovedToolHint(name: string, hint: string): void;
-	on(
-		event: CodemodeEvent | "resources_discover",
-		handler: (
-			event: unknown,
-			ctx: ExtensionContext,
-		) => Promise<{ skillPaths?: string[] } | undefined | void> | { skillPaths?: string[] } | undefined | void,
-	): void;
+	on(event: CodemodeEvent | "resources_discover", handler: (event: unknown, ctx: ExtensionContext) => unknown): void;
 	executeTool: AgentExecuteTool;
 	getActiveTools(): string[];
 	getAllTools(): readonly EvalSchemaToolInfo[];

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { jsRuntimeInfo, jsRuntimeLabel } from "./extension/runtime-info.ts";
 import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "./extension/session-manager.ts";
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
+import { registerBunSkillContribution } from "./extension/skill-contribution.ts";
 import { WAKE_SOURCE_STATE_EVENT, type WakeSourceState } from "./extension/wake-source-state.ts";
 import { EvalDetachedCellManager, type EvalDetachedCellStatusEntry } from "./tool/detached-cell-manager.ts";
 import {
@@ -41,6 +42,13 @@ export interface CodemodeExtensionAPI {
 	registerTool(tool: ReturnType<typeof createEvalTool>): void;
 	registerRemovedToolHint(name: string, hint: string): void;
 	on(event: CodemodeEvent, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void): void;
+	on(
+		event: "resources_discover",
+		handler: (
+			event: unknown,
+			ctx: ExtensionContext,
+		) => Promise<{ skillPaths?: string[] } | undefined> | { skillPaths?: string[] } | undefined,
+	): void;
 	executeTool: AgentExecuteTool;
 	getActiveTools(): string[];
 	getAllTools(): readonly EvalSchemaToolInfo[];
@@ -168,6 +176,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 		"wait",
 		'wait was removed; detached eval cells notify when complete. Use eval({ action: "peek"|"stop", cell_id }) to inspect or stop one.',
 	);
+	registerBunSkillContribution(pi);
 
 	pi.on("session_start", async (event, ctx) => {
 		const previousCells = activeCells;

--- a/packages/senpi-codemode/src/skill/bun-1-4/SKILL.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: bun-1-4
+description: "MUST USE whenever writing or running JavaScript/TypeScript with Bun — including JS through the eval tool, bun -e one-liners, scratch scripts, servers, CLIs, tests, bundling, or package management. Bun 1.4 replaced 15+ npm deps with builtins: consult BEFORE npm-installing sharp, puppeteer/playwright (scraping), marked, node-cron, node-pty, concurrently, serve-static, tar, json5, fast-xml-parser, string-width — Bun ships it. Triggers: bun, Bun.serve, bun test, bun build, bun install, bun run, JS 스크립트, 번들링, 이미지 리사이즈, 헤드리스 브라우저, 크론, PTY, eval js."
+---
+
+# Bun 1.4 — Use the Builtins First
+
+Bun 1.4 (2026) ships builtins that replace most utility npm packages. **Before adding a dependency or writing a workaround, check the capability map below — if Bun ships it, use the builtin.** This skill is loaded because this session has the `eval` tool and bun >= 1.4 was detected; on other machines or pinned projects, confirm with `bun --version` ([v1.3.x]/[v1.4.0] tags in the references give exact minimums). Release post: <https://bun.com/blog/bun-v1.4>
+
+## Capability map — what you can do now
+
+| You want to... | Use | Replaces | Ref = `references/<name>.md` |
+|---|---|---|---|
+| Resize/convert/rotate images | `Bun.file(p).image().resize().webp().write()` | sharp | runtime-apis |
+| Headless browser: navigate, click, screenshot, evaluate, CDP | `new Bun.WebView()` | puppeteer, playwright (scraping) | runtime-apis |
+| Markdown → HTML / React / ANSI | `Bun.markdown.html() / .react() / .render()` | marked, react-markdown | runtime-apis |
+| Schedule cron jobs | `Bun.cron()` | node-cron | runtime-apis |
+| Drive a PTY (bash, vim, TUIs) from JS | `Bun.spawn([...], { terminal })` | node-pty | runtime-apis |
+| Run package scripts concurrently, glob-matched | `bun run --parallel "build:*"` | concurrently, npm-run-all | runtime-apis |
+| Parse JSON5 / JSONL / JSONC / XML / TOML; tarballs | `Bun.JSON5/.JSONL/.JSONC/.XML/.TOML`, `Bun.Archive` | json5, ndjson, jsonc-parser, fast-xml-parser, @iarna/toml, tar | runtime-apis |
+| ANSI-aware terminal text: width, slice, wrap | `Bun.stringWidth()`, `Bun.sliceAnsi()`, `Bun.wrapAnsi()` | string-width, slice-ansi, wrap-ansi | runtime-apis |
+| Call C libraries 3x faster, plain strings back | `bun:ffi` (`buffer_length`, `cstring`) | — | runtime-apis |
+| Serve a static dir (ETag/Range/304 handled) | `Bun.serve({ routes: { "/x/*": { dir } } })` | express.static, serve-static, sirv | http-networking |
+| HTTP/3 server; `fetch` protocol/compress/proxy | `http3: true`, `fetch(url, { protocol, compress, proxy })` | — | http-networking |
+| Tests across CPU workers / CI shards / changed files / flaky retry | `bun test --parallel --shard=1/3 --changed=main --retry` | jest/vitest infra | test |
+| Kill "passes alone, fails in suite" bugs | `bun test --isolate` | vitest default behavior | test |
+| React Compiler auto-memoization | `bun build --react-compiler` | babel-plugin-react-compiler | build |
+| Embed assets/dirs into a single-file executable | `bun build --compile --asset ./public` | pkg hacks | build |
+| Compile-time feature flags, in-memory bundling, metafile | `bun:bundle feature()`, `files:{}`, `metafile: true` | esbuild define/plugins | build |
+| Diff package versions, fix vulns, dedupe/prune, license audit | `bun pm diff`, `bun audit fix`, `bun dedupe`, `bun prune`, `bun pm licenses` | npm-diff, npm audit fix | install |
+| 7x faster CI installs (global virtual store) | `linker = "isolated"` in bunfig.toml | pnpm store | install |
+| Profile CPU/heap/bundle as grep-able Markdown | `bun --cpu-prof-md`, `--heap-prof-md`, `bun build --metafile-md` | Chrome DevTools round-trip | dev-tooling |
+| Native REPL; render Markdown in terminal | `bun repl`, `bun ./README.md` | node repl, glow | runtime-apis |
+| Run Playwright, vitest, Next.js 16, OpenTelemetry, dd-trace | they now just work | Node.js | node-compat-platforms |
+
+Free wins (no code change): 2x lower CPU, 13-48% less server memory, 2-2.5x faster startup — full numbers in [performance](references/performance.md).
+
+## Operating rules
+
+1. **Eval-first.** Drive Bun work through the `eval` tool. The eval prelude's host line names the js kernel runtime: on a `bun` kernel, `Bun.*` globals are available directly in js cells — use them in-kernel. On a `node` kernel, `Bun.*` does not exist inside cells: spawn Bun from the cell (`node:child_process` → `bun -e '<code>'` / `bun script.ts`) or use the bash tool.
+2. **Builtin-first.** The Replaces column above is a ban list for new dependencies, in production code, test helpers, and one-off scripts alike.
+3. **Read the matching reference before using an unfamiliar API** — signatures and caveats (e.g. `Bun.markdown` HTML is unsanitized, HTTP/3 is experimental) live there, not here.
+4. **Upgrading a project to 1.4 or debugging behavior that changed?** Read [breaking-changes](references/breaking-changes.md) first — YAML/TOML strictness, `.xml`/`.css` import semantics, `Bun.---
+name: bun-1-4
+description: "MUST USE whenever writing or running JavaScript/TypeScript with Bun — including JS through the eval tool, bun -e one-liners, scratch scripts, servers, CLIs, tests, bundling, or package management. Bun 1.4 replaced 15+ npm deps with builtins: consult BEFORE npm-installing sharp, puppeteer/playwright (scraping), marked, node-cron, node-pty, concurrently, serve-static, tar, json5, fast-xml-parser, string-width — Bun ships it. Triggers: bun, Bun.serve, bun test, bun build, bun install, bun run, JS 스크립트, 번들링, 이미지 리사이즈, 헤드리스 브라우저, 크론, PTY, eval js."
+---
+
+# Bun 1.4 — Use the Builtins First
+
+Bun 1.4 (2026) ships builtins that replace most utility npm packages. **Before adding a dependency or writing a workaround, check the capability map below — if Bun ships it, use the builtin.** This skill is loaded because this session has the `eval` tool and bun >= 1.4 was detected; on other machines or pinned projects, confirm with `bun --version` ([v1.3.x]/[v1.4.0] tags in the references give exact minimums). Release post: <https://bun.com/blog/bun-v1.4>
+
+## Capability map — what you can do now
+
+| You want to... | Use | Replaces | Ref = `references/<name>.md` |
+|---|---|---|---|
+| Resize/convert/rotate images | `Bun.file(p).image().resize().webp().write()` | sharp | runtime-apis |
+| Headless browser: navigate, click, screenshot, evaluate, CDP | `new Bun.WebView()` | puppeteer, playwright (scraping) | runtime-apis |
+| Markdown → HTML / React / ANSI | `Bun.markdown.html() / .react() / .render()` | marked, react-markdown | runtime-apis |
+| Schedule cron jobs | `Bun.cron()` | node-cron | runtime-apis |
+| Drive a PTY (bash, vim, TUIs) from JS | `Bun.spawn([...], { terminal })` | node-pty | runtime-apis |
+| Run package scripts concurrently, glob-matched | `bun run --parallel "build:*"` | concurrently, npm-run-all | runtime-apis |
+| Parse JSON5 / JSONL / JSONC / XML / TOML; tarballs | `Bun.JSON5/.JSONL/.JSONC/.XML/.TOML`, `Bun.Archive` | json5, ndjson, jsonc-parser, fast-xml-parser, @iarna/toml, tar | runtime-apis |
+| ANSI-aware terminal text: width, slice, wrap | `Bun.stringWidth()`, `Bun.sliceAnsi()`, `Bun.wrapAnsi()` | string-width, slice-ansi, wrap-ansi | runtime-apis |
+| Call C libraries 3x faster, plain strings back | `bun:ffi` (`buffer_length`, `cstring`) | — | runtime-apis |
+| Serve a static dir (ETag/Range/304 handled) | `Bun.serve({ routes: { "/x/*": { dir } } })` | express.static, serve-static, sirv | http-networking |
+| HTTP/3 server; `fetch` protocol/compress/proxy | `http3: true`, `fetch(url, { protocol, compress, proxy })` | — | http-networking |
+| Tests across CPU workers / CI shards / changed files / flaky retry | `bun test --parallel --shard=1/3 --changed=main --retry` | jest/vitest infra | test |
+| Kill "passes alone, fails in suite" bugs | `bun test --isolate` | vitest default behavior | test |
+| React Compiler auto-memoization | `bun build --react-compiler` | babel-plugin-react-compiler | build |
+| Embed assets/dirs into a single-file executable | `bun build --compile --asset ./public` | pkg hacks | build |
+| Compile-time feature flags, in-memory bundling, metafile | `bun:bundle feature()`, `files:{}`, `metafile: true` | esbuild define/plugins | build |
+| Diff package versions, fix vulns, dedupe/prune, license audit | `bun pm diff`, `bun audit fix`, `bun dedupe`, `bun prune`, `bun pm licenses` | npm-diff, npm audit fix | install |
+| 7x faster CI installs (global virtual store) | `linker = "isolated"` in bunfig.toml | pnpm store | install |
+| Profile CPU/heap/bundle as grep-able Markdown | `bun --cpu-prof-md`, `--heap-prof-md`, `bun build --metafile-md` | Chrome DevTools round-trip | dev-tooling |
+| Native REPL; render Markdown in terminal | `bun repl`, `bun ./README.md` | node repl, glow | runtime-apis |
+| Run Playwright, vitest, Next.js 16, OpenTelemetry, dd-trace | they now just work | Node.js | node-compat-platforms |
+
+Free wins (no code change): 2x lower CPU, 13-48% less server memory, 2-2.5x faster startup — full numbers in [performance](references/performance.md).
+
+ globbing, fetch header combining, and WebSocket close timing all changed.
+5. **TLS errors after upgrade are usually intentional** — 1.4 tightened certificate verification across `fetch`, `tls.connect`, `Bun.connect`, `RedisClient`. See [security](references/security.md) before loosening anything.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/breaking-changes.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/breaking-changes.md
@@ -1,0 +1,75 @@
+# Upgrading to Bun 1.4 — Behavior Changes
+
+Blog: [#upgrading-to-1-4](https://bun.com/blog/bun-v1.4#upgrading-to-1-4). Most code is unaffected. Scan the Top 5, then the table for whatever subsystem you touched.
+
+## Top 5 most likely to bite
+
+1. **Node.js 26**: `NODE_MODULE_VERSION` is 147 (native addons need a 147 build); `res.writeHeader()` removed → use `res.writeHead()`; paused-mode `readable.read()` returns ONE chunk → loop until `null`.
+2. **New monorepos default to the isolated linker** (`configVersion: 1`). Existing lockfiles keep hoisted. Opt out: `linker = "hoisted"` in bunfig.toml.
+3. **Bun invoked as `node`** (`bun --bun`, `bunx --bun`, node symlink) no longer loads `.env` files. Pass `--env-file` to keep them.
+4. **`Bun.YAML` is YAML 1.2**: `yes`/`no`/`on`/`off` are strings. GitHub Actions `on:` parses as `"on"`.
+5. **`Bun.TOML` / `bunfig.toml` are strict**: unquoted strings, missing newlines, ints past `MAX_SAFE_INTEGER` → `SyntaxError` at startup. Quote your values.
+
+## Module resolution / loaders
+
+| Change | Migration |
+|---|---|
+| `.xml` imports return the parsed document (was: file path) | `--loader .xml:file` to keep the path |
+| `.css` imports at runtime export `{}` (was: absolute path) | — |
+| `import "."` / `".."` resolve as directories (index/main), matching Node | name the sibling file explicitly |
+| `"jsx": "react-jsx"` emits `jsx` (was: `jsxDEV` unless production) | use `"react-jsxdev"` for the dev runtime |
+| `useDefineForClassFields: false` now honored like tsc | remove the option to keep old output |
+
+## Bun APIs
+
+| Change | Migration |
+|---|---|
+| `Bun.$` globs only patterns written in the template — `${...}` interpolated globs are literal | write the pattern in the template: `` $`echo **/*` `` |
+| `Bun.cron.parse()` / in-process `Bun.cron()` use LOCAL time (was UTC) | pass `{ tz: "UTC" }` |
+| `Bun.Socket#setKeepAlive(true, delay)`: `delay` is milliseconds now | pass ms, not seconds |
+| `Bun.mmap({ offset })`: view starts at `offset` exactly (was page-rounded) | remove `offset % pageSize` compensation |
+| `bun:ffi`: `cstring` values are plain strings; `CString` has no `.ptr` | keep the original pointer to free |
+| `Bun.serve({ inspector })` removed | `bun --inspect` |
+| `server.publish()`/`ws.publish()` return `0` (dropped) / `-1` (backpressure) | treat 0/-1 specially |
+| `server.stop()` waits for in-flight requests, closes idle connections | `stop(true)` to force |
+| `Bun.sql`: MySQL `DATETIME`/`TIMESTAMP` decoded as UTC; MariaDB 10.5+ JSON columns parsed to objects | remove offset corrections and `JSON.parse()` calls |
+| `Bun.randomUUIDv7()`, `Bun.udpSocket()`, `Bun.password`, `Bun.spawn` timeout/killSignal/argv0 | invalid inputs now throw instead of silently clamping |
+
+## fetch / WebSocket / HTTP
+
+| Change | Migration |
+|---|---|
+| Duplicate headers combined with `, ` per Fetch spec (was: last wins) | parse combined values |
+| `clone()` throws after body read (`Body is disturbed or locked`) | clone BEFORE reading |
+| Network errors are `TypeError` (`.code` still set); failed body read sets `bodyUsed` | retry with a NEW fetch() |
+| `redirect: "error"` rejects only on 301/302/303/307/308 (304 resolves now) | — |
+| global `WebSocket` no longer accepts `agent` (ws module's does) | import from "ws" |
+| `WebSocket#close()` queues the close event — `readyState` is CLOSING when it returns | await the `close` event |
+| `close()`/`ping()`/`pong()` validate codes/reason/payload sizes | shorten/fix values |
+| Handshake fails (1002) when requested subprotocol isn't negotiated | fix server echo or drop `protocols` |
+
+## node: modules
+
+| Change | Migration |
+|---|---|
+| `fs.rmdir` rejects `{ recursive: true }` | `fs.rm(path, { recursive: true, force: true })` |
+| `dns.lookup()` uses the system resolver (getaddrinfo) on Linux — split-DNS/VPN names now resolve | `Bun.dns.lookup(name, { backend: "c-ares" })` for old behavior |
+| fs/dns/pbkdf2 callback exceptions are `uncaughtException` (was unhandledRejection) | move the handler |
+| `dgram`: second `bind()` and post-`close()` calls throw synchronously | try/catch |
+| `tls.createServer({ requestCert: true })` rejects unverified client certs by default | `rejectUnauthorized: false` to admit them |
+| `X509Certificate` serial/modulus are UPPERCASE hex | normalize case when pinning |
+| `child_process.spawn()` ignores `options.encoding` (always Buffers) | `child.stdout.setEncoding()` |
+| `process.title` defaults to `argv[0]`; warnings print as `(node:PID) [CODE] ...` | — |
+
+## bun test
+
+- `jest.resetAllMocks()` drops implementations (matches Jest) — use `clearAllMocks()` for history-only.
+- `toContain()` uses `===` (not `Object.is`); `toEqual()` compares Temporal by value.
+
+## Misc
+
+- x64 builds are baseline-only (no more separate haswell build; `-baseline` URLs still work).
+- `Temporal` defined by default (`BUN_JSC_useTemporal=0` to disable).
+- `bun.lock` is `lockfileVersion: 2`; nested/version-scoped overrides produce v3 (older Bun can't read v3).
+- `bun feedback` removed; `Bun.password.hash()` argon2 requires `memoryCost >= 8`.
+- Full exhaustive list: [Other behavior changes](https://bun.com/blog/bun-v1.4#other-behavior-changes) and the [Changelog](https://bun.com/blog/bun-v1.4#changelog).

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/build.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/build.md
@@ -1,0 +1,114 @@
+# bun build / Bun.build() in 1.4
+
+## Built-in React Compiler [v1.4.0]
+
+Blog: [#built-in-react-compiler](https://bun.com/blog/bun-v1.4#built-in-react-compiler)
+
+```ts
+await Bun.build({ entrypoints: ["./src/index.tsx"], outdir: "./dist", reactCompiler: true });
+// or: bun build --react-compiler
+```
+
+React's auto-memoization compiler runs inside Bun's parser — no Babel/SWC round-trip. On ~860 components: +71ms build cost, ~20x faster than the Babel plugin (9.15s); full `--compile` build 3.6x faster.
+
+## Barrel import optimization [v1.3.10]
+
+Blog: [#barrel-import-optimization](https://bun.com/blog/bun-v1.4#barrel-import-optimization)
+
+```ts
+await Bun.build({ entrypoints: ["./src/index.tsx"], optimizeImports: ["antd", "@mui/material"] });
+```
+
+`import { Button } from "antd"` skips the hundreds of files behind names you didn't import. Automatic for packages with `"sideEffects": false`; opt others in with `optimizeImports`.
+
+## Compile-time feature flags: bun:bundle [v1.3.5]
+
+Blog: [#compile-time-feature-flags-with-bun-bundle](https://bun.com/blog/bun-v1.4#compile-time-feature-flags-with-bun-bundle)
+
+```ts
+import { feature } from "bun:bundle";
+if (feature("SUPER_SECRET")) { console.log("enabled"); }
+// bun build --feature=SUPER_SECRET index.ts   (also works in bun run and bun test)
+// Bun.build({ features: ["SUPER_SECRET"] })
+```
+
+Becomes `true`/`false` at build time; dead branch removed.
+
+## In-memory files [v1.3.6]
+
+Blog: [#in-memory-files-in-bun-build](https://bun.com/blog/bun-v1.4#in-memory-files-in-bun-build)
+
+```ts
+await Bun.build({
+  entrypoints: ["/app/index.ts"],
+  files: {
+    "/app/index.ts": `import { greet } from "./greet.ts"; console.log(greet("World"));`,
+    "/app/greet.ts": `export function greet(n: string) { return "Hello, " + n; }`,
+  },
+});
+```
+
+Strings, Blobs, or TypedArrays; virtual paths override disk. Ideal for codegen and stubbing modules in tests.
+
+## Single-file HTML [v1.3.10]
+
+Blog: [#single-file-html-with-compile-target-browser](https://bun.com/blog/bun-v1.4#single-file-html-with-compile-target-browser)
+
+```bash
+bun build ./index.html --compile --target=browser --outdir=dist
+# → dist/index.html — every script/stylesheet/asset inlined, opens from file://
+```
+
+## --asset: embed files/dirs into executables [v1.4.0]
+
+Blog: [#asset](https://bun.com/blog/bun-v1.4#asset)
+
+```bash
+bun build ./build/index.js --compile \
+    --asset ./build/client --asset ./build/prerendered \
+    --outfile server
+./server   # every route + static asset served from the binary
+```
+
+Keeps original filenames; `path.join(import.meta.dir, ...)` works. `node:fs` treats `/$bunfs/` as a real tree (`existsSync`, `readdirSync` recursive/withFileTypes, ...), so static-file servers run unmodified inside the binary.
+
+## Bytecode for ES modules [v1.3.9]
+
+Blog: [#bytecode-compilation-for-es-modules](https://bun.com/blog/bun-v1.4#bytecode-compilation-for-es-modules)
+
+`--bytecode --format=esm` (requires `--compile`) enables top-level await, `import.meta`, dynamic imports, and code splitting in bytecode-compiled binaries (previously CJS-only).
+
+## metafile: true and --metafile-md [v1.3.6 / v1.3.8]
+
+Blog: [#metafile-true](https://bun.com/blog/bun-v1.4#metafile-true), [#metafile-md](https://bun.com/blog/bun-v1.4#metafile-md)
+
+```ts
+const result = await Bun.build({ entrypoints: ["./index.js"], metafile: true });
+result.metafile.inputs; result.metafile.outputs; // esbuild metafile format — works with esbuild.github.io/analyze
+```
+
+```bash
+bun build entry.js --metafile-md=analysis.md --outdir=dist   # Markdown bundle report: largest modules,
+                                                             # per-entry breakdowns, dependency chains — grep it or hand to an LLM
+```
+
+## Standard TC39 decorators [v1.3.10]
+
+Blog: [#standard-tc39-decorators](https://bun.com/blog/bun-v1.4#standard-tc39-decorators)
+
+```ts
+function logged(value, { kind, name }) {
+  if (kind === "method") return function (...args) { console.log(`calling ${name}`); return value.call(this, ...args); };
+}
+class C { @logged greet() {} }
+```
+
+Active when `experimentalDecorators` is off in tsconfig. Classes, methods, fields, accessors, private members; passes esbuild's decorator test suite.
+
+## Code splitting: 14x faster on huge graphs [v1.4.0]
+
+Reachability walk is now BFS O(V+E); a 20,000-module DAG links in 320ms (was 4.65s). Tree-shaking/TLA/CSS-order passes use explicit stacks, so linear chains of thousands of modules link without stack growth.
+
+## Compile gotcha (v1.3.4 change)
+
+`bun build --compile` binaries no longer auto-load `tsconfig.json` / `package.json` from the runtime cwd. Opt back in with `--compile-autoload-tsconfig` / `--compile-autoload-package-json`. `.env` and `bunfig.toml` still auto-load.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/dev-tooling.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/dev-tooling.md
@@ -1,0 +1,34 @@
+# Bun 1.4 Dev Tooling & Observability
+
+Blog: [#dev-tooling](https://bun.com/blog/bun-v1.4#dev-tooling), [#observability](https://bun.com/blog/bun-v1.4#observability)
+
+## Markdown profilers — built for terminals and LLMs
+
+```bash
+bun --cpu-prof-md ./app.ts     # CPU profile as Markdown: hot functions by self time,
+                               # call tree, who-calls-whom. grep it, paste into a bug or an LLM.
+bun --heap-prof-md ./app.ts    # heap profile as Markdown: total size, types by retained size,
+                               # largest objects, retention chains. Includes grep recipes in the header.
+bun build ./src/index.ts --outdir ./dist --metafile-md=./dist/meta.md   # bundle-size analysis as Markdown
+```
+
+- `bun --cpu-prof` / `--heap-prof` still write `.cpuprofile` / V8-compatible `.heapsnapshot` for Chrome DevTools / VS Code.
+- `BUN_CPU_PROFILE=1` turns on the CPU profiler for a process you cannot pass flags to (e.g. a framework-spawned worker).
+- **Agent workflow: when a Bun process is slow or leaking, run the `-md` variants and read the report directly — no DevTools round-trip.**
+
+## Async stack traces [v1.4.0]
+
+Errors from async native APIs (`fs.promises`, `Bun.file()`, S3, DNS, crypto, `fetch`) point at the `await` in your code, not native frames.
+
+## Process lifetime & env flags
+
+```bash
+bun --no-orphans app.ts    # exit when parent dies; SIGKILL every descendant on exit (Linux/macOS/Windows)
+bun --no-env-file app.ts   # skip automatic .env loading (or env = false in bunfig.toml) — use in prod/CI
+```
+
+## APM / tracing works now
+
+- **`node:inspector`**: a `Session` can start/stop CPU profiles while the app runs (`Profiler.start`/`Profiler.stop`).
+- **Datadog**: `dd-trace` traces requests; `@datadog/pprof` profiles continuously (required V8 C++ APIs implemented).
+- **OpenTelemetry**: `@opentelemetry/instrumentation-http` and `-fs` export spans; `shimmer` and `require-in-the-middle` can patch bundled code.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/http-networking.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/http-networking.md
@@ -1,0 +1,113 @@
+# Bun 1.4 HTTP & Networking
+
+## Serve files & folders (replaces express.static, serve-static, sirv) [v1.4.0]
+
+Docs: <https://bun.com/docs/runtime/http/routing> · Blog: [#serve-files-folders](https://bun.com/blog/bun-v1.4#serve-files-folders)
+
+```ts
+Bun.serve({
+  routes: {
+    "/static/*": { dir: "./public" },
+  },
+});
+```
+
+- Files stream with `sendfile`; `Content-Type`, `ETag`, `Last-Modified`, `304`, and `Range` handled automatically; `index.html` served for directories.
+- Path traversal is blocked: paths normalized, and on Linux files open with `openat2` + `O_RESOLVE_BENEATH` so symlinks can't escape the directory.
+
+## Range and conditional requests [v1.3.13, improved v1.4.0]
+
+Blog: [#range-and-conditional-requests](https://bun.com/blog/bun-v1.4#range-and-conditional-requests)
+
+```ts
+Bun.serve({
+  routes: { "/video.mp4": new Response(Bun.file("./video.mp4")) },
+});
+// curl -H 'Range: bytes=0-1023' → 206 Partial Content
+// curl -H 'If-None-Match: "..."' → 304 Not Modified
+```
+
+Static routes and `Bun.file()` bodies handle `Range` (206), `If-None-Match`/`If-Modified-Since` (304), `If-Match`/`If-Unmodified-Since` (412). Video seeking and resumable downloads work out of the box.
+
+## HTTP/3 in Bun.serve() — EXPERIMENTAL [v1.3.14, improved v1.4.0]
+
+Docs: <https://bun.com/docs/runtime/http/server> · Blog: [#http-3-in-bun-serve-experimental](https://bun.com/blog/bun-v1.4#http-3-in-bun-serve-experimental)
+
+```ts
+Bun.serve({
+  port: 443,
+  tls: { /* cert, key */ },
+  http3: true,      // also listen on UDP/443
+  // h1: false,     // optional: HTTP/3 only
+  fetch(req) { return new Response("hi"); },
+});
+```
+
+- HTTP/1.1 keeps working over TCP; `Alt-Svc` header advertises H3 so browsers upgrade themselves. 2.7x faster than HTTPS/1.1 on static routes.
+- **Do not ship `http3: true` to production yet**: 0-RTT resumption disabled, `server.upgrade()` returns `false` over H3, `unix:` sockets skip the H3 listener.
+
+## HTTP/2 & HTTP/3 in fetch() — EXPERIMENTAL [v1.3.14, improved v1.4.0]
+
+Blog: [#http-2-http-3-in-fetch-experimental](https://bun.com/blog/bun-v1.4#http-2-http-3-in-fetch-experimental)
+
+```ts
+const [a, b] = await Promise.all([
+  fetch(url1, { protocol: "http2" }),  // concurrent same-origin requests share one connection
+  fetch(url2, { protocol: "http2" }),
+]);
+const res = await fetch(url3, { protocol: "http3" });
+```
+
+- Redirects, decompression, streaming behave as over HTTP/1.1.
+- Global opt-in: `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT=1` or `--experimental-http3-fetch` (Bun remembers per-origin H3 support).
+
+## fetch() request compression [v1.4.0]
+
+Blog: [#fetch-request-compression](https://bun.com/blog/bun-v1.4#fetch-request-compression)
+
+```ts
+await fetch(url, {
+  method: "POST",
+  body: largeJsonString,
+  compress: "gzip", // or true, "deflate", "br", "zstd", { encoding, level }
+});
+```
+
+Buffered bodies (string, ArrayBuffer, TypedArray, Blob) are compressed and `Content-Encoding`/`Content-Length` set automatically; streaming bodies pass through unchanged.
+
+## fetch() proxy headers [v1.3.4]
+
+Blog: [#fetch-proxy-headers](https://bun.com/blog/bun-v1.4#fetch-proxy-headers)
+
+```ts
+await fetch(url, {
+  proxy: {
+    url: "http://proxy.example.com:8080",
+    headers: { "Proxy-Authorization": "Bearer token" },
+  },
+});
+```
+
+## TLS session resumption + connection reuse [v1.3.10-v1.4.0]
+
+Blog: [#tls-session-resumption](https://bun.com/blog/bun-v1.4#tls-session-resumption), [#connection-reuse](https://bun.com/blog/bun-v1.4#connection-reuse)
+
+- Second cold connection to an origin resumes at 1 RTT (32-entry per-origin LRU of BoringSSL client sessions).
+- `fetch()` reuses connections through HTTPS proxies and for requests with custom TLS options (client cert, custom CA). No code change needed.
+
+## HTML routes: sourcemaps off in production [v1.4.0]
+
+Blog: [#html-routes-sourcemaps-disabled-in-production](https://bun.com/blog/bun-v1.4#html-routes-sourcemaps-disabled-in-production)
+
+Production `Bun.serve` no longer serves sourcemaps for HTML routes (dev mode still does). Override in `bunfig.toml`:
+
+```toml
+[serve.static]
+sourcemap = "linked"
+```
+
+## Server lifecycle changes worth knowing (v1.4)
+
+- `server.stop()` now closes idle keep-alive connections immediately, waits for in-flight responses, and resolves when the last connection closes. `server.stop(true)` force-closes stalled ones.
+- `server.publish()` / `ws.publish()` return `0` (dropped/no subscribers) or `-1` (backpressure) instead of always the byte count.
+- Per-method route objects (`{ GET }`) answer `HEAD` with the GET handler automatically.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/install.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/install.md
@@ -1,0 +1,93 @@
+# bun install & package management in 1.4
+
+## Global virtual store: up to 7x faster installs [v1.3.14]
+
+Blog: [#global-virtual-store-up-to-7x-faster-installs](https://bun.com/blog/bun-v1.4#global-virtual-store-up-to-7x-faster-installs)
+
+```toml
+# bunfig.toml
+[install]
+linker = "isolated"
+```
+
+With the isolated linker, packages extract once into Bun's global cache and are symlinked into `node_modules/.bun/` (one `symlink()` per package instead of one `clonefileat()`). Warm-cache CI installs of 1,400 packages: 7x faster. Opt-in for existing projects; **new monorepos default to isolated** (see below).
+
+## New subcommands [v1.4.0]
+
+Blog anchors: [#bun-pm-diff](https://bun.com/blog/bun-v1.4#bun-pm-diff), [#bun-audit-fix](https://bun.com/blog/bun-v1.4#bun-audit-fix), [#bun-dedupe](https://bun.com/blog/bun-v1.4#bun-dedupe), [#bun-prune](https://bun.com/blog/bun-v1.4#bun-prune), [#bun-pm-licenses](https://bun.com/blog/bun-v1.4#bun-pm-licenses)
+
+```bash
+bun pm diff react                    # lockfile version → latest; un-minifies before diffing;
+bun pm diff react@18.2.0 19.0.0      # summary flags new install scripts + new child_process/fs/net/vm imports
+bun pm diff ./vendored-pkg pkg@2.1.0
+
+bun audit fix                        # upgrade vulnerable packages to safe versions; --latest allows majors; --dry-run
+bun dedupe                           # collapse duplicate versions in bun.lock; --check fails CI on dupes
+bun prune --production               # delete node_modules entries not in bun.lock; --production drops devDeps
+bun pm licenses --prod --json        # dependency license inventory
+```
+
+Docker pattern: build with devDeps, ship without:
+
+```dockerfile
+RUN bun install --frozen-lockfile
+COPY . .
+RUN bun run build
+RUN bun prune --production
+```
+
+## bun update: transitive + patterns [v1.4.0]
+
+Blog: [#bun-update-updates-transitive-dependencies](https://bun.com/blog/bun-v1.4#bun-update-updates-transitive-dependencies)
+
+```bash
+bun update                    # now updates deps-of-deps too
+bun update zod                # updates zod everywhere it appears
+bun update '@types/*' --latest
+```
+
+`bun update <name>` errors (exit 1) if nothing depends on it (no longer silently adds).
+
+## Monorepo: --filter and --catalog [v1.4.0]
+
+Blog: [#bun-add-filter](https://bun.com/blog/bun-v1.4#bun-add-filter), [#bun-add-catalog](https://bun.com/blog/bun-v1.4#bun-add-catalog)
+
+```bash
+bun add zod --filter api          # add to one workspace from the repo root
+bun run --filter 'web...' build   # web + its dependencies; '...web' = its dependents
+bun add react --catalog           # add to root catalog, write "catalog:" in the workspace
+```
+
+Plain `bun add x` in a workspace whose default catalog lists `x` writes `catalog:` automatically.
+
+## Nested overrides [v1.4.0]
+
+Blog: [#nested-overrides](https://bun.com/blog/bun-v1.4#nested-overrides)
+
+```json
+{
+  "overrides": {
+    "express": { "qs": "6.13.0" },
+    "lodash@<4.17.21": "4.17.21"
+  }
+}
+```
+
+npm nested form, yarn `a/b`, pnpm `a>b` all work; overrides can be version-scoped. Lockfiles using these become `lockfileVersion: 3` (older Bun can't read them).
+
+## Supply-chain hardening
+
+- **Lockfile integrity** [v1.3.10]: `bun.lock` records SHA-512 for GitHub and tarball deps, like npm packages.
+- **`trustedDependencies` auto-trust is npm-registry-only** [v1.3.5]: a `git:`/`github:`/`file:` package named `esbuild` gets NO trust from the default list — list it yourself. Names match exactly (not by hash).
+- **`nativeDependencies`** [v1.3.2]: for packages shipping prebuilt binaries as per-platform optionalDependencies, Bun links the right binary directly instead of running postinstall. **`ignoreScripts`** skips a package's lifecycle scripts even if trusted.
+
+```json
+{ "nativeDependencies": ["esbuild"], "ignoreScripts": ["sharp"] }
+```
+
+## Defaults changed in 1.4 (see also breaking-changes.md)
+
+- New monorepos default to `linker: "isolated"` (`configVersion: 1` in bun.lock). Existing lockfiles keep hoisted. Pin `linker = "hoisted"` to opt out.
+- `bun.lock` is `lockfileVersion: 2`: out-of-registry tarballs need integrity hashes; git entries validated against path traversal. Run `bun install` to migrate.
+- A project's `bunfig.toml` now overrides `.npmrc` for the same key.
+- `bun init` writes `typescript ^7`; non-TTY `bun init` behaves as `-y`.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/node-compat-platforms.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/node-compat-platforms.md
@@ -1,0 +1,36 @@
+# Node.js Compatibility & Platforms (Bun 1.4)
+
+Blog: [#node-js-compatibility](https://bun.com/blog/bun-v1.4#node-js-compatibility), [#platforms](https://bun.com/blog/bun-v1.4#platforms) · Live tracker: <https://bun.com/node-test-suite>
+
+Bun 1.4 reports **Node.js 26** (`process.versions.modules` = 147). 3,743 Node test-suite files pass (+1,517 since 1.3). `node:http`, `node:fs`, `node:cluster`, `node:timers`, `node:zlib`, `node:vm`, `node:stream` pass 97% of Node's own tests; `node:quic` 99%; `node:events`, `node:trace_events`, `node:sqlite` 100%.
+
+## Big frameworks/tools that now run on Bun
+
+- **Playwright** [v1.4.0]: `connectOverCDP()`, `playwright test` with config, `--ui`, Chromium on Windows.
+- **Next.js 16** [v1.3.2]: `bun --bun next build` works on 16.3 with Turbopack + React Compiler.
+- **vitest** [v1.4.0]: runs under Bun including `--coverage`, threads and forks pools.
+- **OpenTelemetry** [v1.4.0]: http/fs instrumentation export spans; shimmer + require-in-the-middle patch bundled code.
+- **dd-trace** [v1.4.0]: traces + `@datadog/pprof` continuous profiling (V8 C++ APIs implemented).
+
+## Newly working packages
+
+Nuxt (`nuxt dev` HMR + DevTools), testcontainers/dockerode (`container.exec()`), https-proxy-agent / socks-proxy-agent, crawlee (proxy-chain), @grpc/grpc-js + ConnectRPC (behind Envoy/ALB), amqplib (RabbitMQ), @aws-sdk/client-s3 streaming uploads, TypeORM (tsconfig decorator settings), nock, Fastify `inject()` / light-my-request, happy-dom, piscina.
+
+## New Node.js APIs in Bun
+
+- `worker_threads`: `resourceLimits`, `stdout`, `stderr`, `eval` options.
+- ws: `'upgrade'` and `'unexpected-response'` events.
+- `socket.upgradeTLS({ isServer: true })`: server-side STARTTLS.
+- `node:cluster` shares listening sockets between workers.
+- `node:repl`, `node:trace_events`, `node:domain`: implemented.
+
+## Platforms
+
+| Platform | Status |
+|---|---|
+| FreeBSD x86_64/aarch64 [v1.3.14] | Official native builds; full runtime on stock FreeBSD 14.3+ (native port, not Linux compat layer) |
+| Windows ARM64 [v1.3.7] | Native builds (Surface, Snapdragon X, Ampere) |
+| Android aarch64/x64 [v1.4.0] | Experimental builds with every release |
+| Linux glibc 2.17 [v1.3.13] | Minimum dropped from 2.26 — RHEL/CentOS 7, Amazon Linux 1 work; kernel minimum 3.10 (`memfd_create` fallback) |
+| Windows | Sub-15ms timers (no 15.6ms tick rounding); runs in AppContainer; read-only directories OK |
+| TypeScript 7 | `bun init` templates + `@types/bun` are TS7-ready; `bun init` writes `typescript ^7` |

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/performance.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/performance.md
@@ -1,0 +1,33 @@
+# Bun 1.4 Performance
+
+Blog: [#production](https://bun.com/blog/bun-v1.4#production), [#faster](https://bun.com/blog/bun-v1.4#faster)
+
+All of this is free — no code changes. Use these numbers when justifying a Bun 1.4 upgrade.
+
+## Production footprint
+
+- **Allocator unified**: JavaScriptCore now uses mimalloc (extended with partial page clearing, an idle-time scavenger thread, lazy zeroing).
+- **CPU**: Claude Code production CPU dropped 2x (p99 24%→10%, p50 5.8%→2.5%); hello-world idle CPU 5x lower.
+- **Memory under load** (1M requests): fastify −48% (120MB), Express −46% (92MB), node:http −40% (81MB), Elysia −40%, Next.js −28%, Bun.serve −20% (36MB). Next.js App Router SSR that grew unbounded in 1.3 settles at 238MB (Node: 410MB).
+- **Startup**: Windows 15.5ms (2.5x faster, was 39ms; Node 40ms); Linux 5.1ms (2x faster; Node 27.2ms) with peak memory 14.6MB vs Node 44.5MB.
+- **Binary size**: Linux/Windows ~17% smaller (77MB Linux x64).
+
+## Runtime speedups (WebKit pin bumped 39 times = ~8 months of JSC work)
+
+| What | Improvement |
+|---|---|
+| `new URL()` | up to 4.6x faster (75ns vs Node 232ns); `url.href` 5ns |
+| RegExp (JSC-vs-V8 gap fixed) | `marked.parse()` 138x faster (912ms→6ms on 80KB); `isbot` 200x faster |
+| `node:zlib` → zlib-ng | decompression ~20% faster across the board; peak memory 25-35MB lower; runtime CPU dispatch |
+| `Buffer.from(str, "hex")` | 8x faster (SIMD); `"base64url"` 46x faster |
+| Source map decoding | 3.1x faster (SIMD); 24x faster than Node on a 9.5MB map |
+| Promises (JSC rewrite) | 1.5-2.4x faster; `await` resolved 84ns; 1M pending promises: 251MB peak (was 668MB), settle 12.5ms (was 39ms) |
+
+## Streams, bodies, backpressure
+
+The Production section of the blog also covers stream/body handling and backpressure improvements in `Bun.serve` — notably `server.publish()`/`ws.publish()` now report drops (`0`) and backpressure (`-1`) honestly; see [http-networking](http-networking.md).
+
+## Windows-specific
+
+- Timers no longer round to the 15.6ms system tick: `setTimeout(fn, 1)` fires in ~1.4ms.
+- Startup 2.5x faster; runs inside an AppContainer sandbox; works on read-only directories/shares.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/runtime-apis.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/runtime-apis.md
@@ -1,0 +1,156 @@
+# Bun 1.4 Runtime Builtins
+
+Every API here ships inside the Bun binary: no install step, no native build, no lockfile entry. Version tags mark the minimum Bun version.
+
+## Bun.Image — image processing (replaces sharp) [v1.3.14]
+
+Docs: <https://bun.com/docs/runtime/image> · Blog: [#bun-image](https://bun.com/blog/bun-v1.4#bun-image)
+
+```ts
+await Bun.file("photo.jpg")
+  .image()
+  .resize(1024, 1024, { fit: "inside" })
+  .rotate(90)
+  .webp({ quality: 85 })
+  .write("thumb.webp");
+
+// Stream straight into a Response
+return new Response(new Bun.Image(upload).resize(200).jpeg());
+```
+
+- Decode/resize/rotate/encode JPEG, PNG, WebP, GIF, BMP everywhere; HEIC, AVIF, TIFF on macOS and Windows.
+- API mirrors sharp; 1.19-1.38x faster than sharp; ICC profiles (Display P3) survive transcoding.
+
+## Bun.WebView — headless browser (replaces puppeteer for scraping/screenshots) [v1.3.12, improved v1.4.0]
+
+Docs: <https://bun.com/docs/runtime/webview> · Blog: [#bun-webview](https://bun.com/blog/bun-v1.4#bun-webview)
+
+```ts
+await using view = new Bun.WebView({ width: 800, height: 600 });
+await view.navigate("https://bun.sh");
+await view.click("a[href='/docs']");
+const title = await view.evaluate("document.title");
+await Bun.write("page.png", await view.screenshot());
+```
+
+- macOS: system WebKit, nothing to install. macOS/Linux/Windows: can drive installed Chrome/Chromium/Edge.
+- Clicks/scrolls are trusted user input (`event.isTrusted === true`).
+- Extends `EventTarget`; screenshots are `Blob`s; `.cdp(method, params?)` escape hatch for raw Chrome DevTools Protocol.
+
+## Bun.markdown — Markdown parser (replaces marked) [v1.3.8, improved v1.4.0]
+
+Docs: <https://bun.com/docs/runtime/markdown> · Blog: [#bun-markdown](https://bun.com/blog/bun-v1.4#bun-markdown)
+
+```ts
+const html = Bun.markdown.html("# Hello **world**");   // HTML string
+const el = Bun.markdown.react(readme);                  // React elements; swap components per tag
+const ansi = Bun.markdown.render("# Hi\n\n**bold**", {  // callback per element (terminal output etc.)
+  heading: (children) => `\x1b[1;4m${children}\x1b[0m\n`,
+  paragraph: (children) => children + "\n",
+  strong: (children) => `\x1b[1m${children}\x1b[22m`,
+});
+```
+
+- GFM tables, strikethrough, task lists, autolinks. `.md` is a bundler loader. Linear time on adversarial input.
+- **HTML output is NOT sanitized** — raw HTML, event handlers, `javascript:` hrefs pass through. Sanitize before serving user content.
+- Bonus: `bun ./README.md` renders Markdown to the terminal (replaces glow).
+
+## Bun.cron() — scheduled jobs (replaces node-cron) [v1.3.11, improved v1.4.0]
+
+Docs: <https://bun.com/docs/runtime/cron> · Blog: [#bun-cron](https://bun.com/blog/bun-v1.4#bun-cron)
+
+```ts
+// OS-level job: crontab (Linux), launchd (macOS), Task Scheduler (Windows)
+await Bun.cron("./worker.ts", "30 2 * * MON", "weekly-report");
+// worker.ts exports: export default { async scheduled(controller) { ... } }  // Cloudflare Workers shape
+
+// In-process job on the event loop, no system cron
+using job = Bun.cron("*/5 * * * *", async () => { await cleanupTempFiles(); });
+job.unref(); job.stop();  // or let `using` dispose
+
+Bun.cron.parse("*/15 * * * *"); // → next matching Date
+```
+
+- 5-field syntax incl. named days and `@daily`. Jobs never overlap.
+- **v1.4 change:** `parse()` and in-process schedules use LOCAL time (was UTC). Pass `{ tz: "UTC" }` to keep UTC.
+
+## Bun.Terminal — native PTY (replaces node-pty) [v1.3.5, improved v1.4.0]
+
+Docs: <https://bun.com/docs/runtime/child-process#terminal-pty-support> · Blog: [#bun-terminal](https://bun.com/blog/bun-v1.4#bun-terminal)
+
+```ts
+const proc = Bun.spawn(["bash"], {
+  terminal: {
+    cols: 80, rows: 24,
+    data(term, data) { process.stdout.write(data); },
+  },
+});
+proc.terminal.write("echo Hello from PTY!\n");
+```
+
+- Drive bash/vim/htop with colored output; resize; works on Linux, macOS, Windows.
+- `write()` returns full input length (whole input buffered); `drain` fires on POSIX.
+
+## bun run --parallel — concurrent scripts (replaces concurrently, npm-run-all) [v1.3.9, improved v1.4.0]
+
+Blog: [#bun-run-parallel](https://bun.com/blog/bun-v1.4#bun-run-parallel)
+
+```bash
+bun run --parallel build test                        # named scripts concurrently
+bun run --parallel "build:*"                         # glob-matched
+bun run --parallel --filter '*' build                # every workspace package
+bun run --parallel --no-exit-on-error --filter '*' test   # keep going past failures
+```
+
+- Output lines prefixed with script name (`package:script` under `--filter`); pre/post hooks stay ordered; `--sequential` for one-at-a-time with same prefixing.
+
+## bun:ffi — 3x faster, engine-native [v1.4.0]
+
+Docs: <https://bun.com/docs/runtime/ffi> · Blog: [#3x-faster-bun-ffi](https://bun.com/blog/bun-v1.4#3x-faster-bun-ffi)
+
+```ts
+import { dlopen } from "bun:ffi";
+const { symbols } = dlopen("libhash.so", {
+  hash: { args: ["buffer", "buffer_length"], returns: "cstring" },
+});
+const digest = symbols.hash(data, data); // typeof digest === "string"
+```
+
+- FFI is built into JavaScriptCore (TinyCC removed): no-op call 0.70ns (3x), `CString` 3.8x faster. Hot call sites JIT into direct C calls.
+- New `buffer_length` arg type passes a TypedArray's length with its pointer.
+- **Breaking:** `cstring` returns are plain strings (`NULL` → `null`); `new CString(ptr)` has no `.ptr` anymore — keep the original pointer to free it. See [breaking-changes](breaking-changes.md).
+
+## Data format parsers
+
+Blog: [#also-built-in](https://bun.com/blog/bun-v1.4#also-built-in)
+
+| API | Replaces | Notes |
+|---|---|---|
+| `Bun.JSON5.parse()/stringify()` | json5 | `.json5` files importable directly |
+| `Bun.JSONL.parse()` / streaming `parseChunk()` | ndjson | newline-delimited JSON |
+| `Bun.JSONC.parse()` | jsonc-parser | comments + trailing commas (the tsconfig parser); throws `SyntaxError` on invalid input |
+| `Bun.XML.parse()/stringify()` | fast-xml-parser, xml2js | SIMD; `.xml` files importable (v1.4: import returns parsed doc, not path) |
+| `Bun.TOML.parse()/stringify()` | @iarna/toml | TOML v1.1.0, 708/708 toml-test; v1.4 is strict — unquoted strings throw `SyntaxError` |
+| `Bun.YAML.parse()` | — | YAML 1.2: `yes/no/on/off` are strings, not booleans |
+| `Bun.Archive` | tar | create/extract tarballs off the main thread — docs <https://bun.com/docs/runtime/archive> |
+
+## Terminal text utilities (replaces string-width, slice-ansi, cli-truncate, wrap-ansi)
+
+Docs: <https://bun.com/docs/runtime/utils>
+
+```ts
+Bun.stringWidth("한글 text");     // terminal columns, ANSI + grapheme aware
+Bun.sliceAnsi(str, 0, 20);        // slice by columns, preserving ANSI codes
+Bun.wrapAnsi(str, 80);            // wrap by columns
+```
+
+## Everything else new in the runtime
+
+- **`URLPattern`**: the Web API, 408 WPT passing. Replaces path-to-regexp.
+- **`CompressionStream` / `DecompressionStream`**: gzip, deflate, deflate-raw + brotli and zstd.
+- **`Response.textStream()`**: `ReadableStream<string>` of the body decoded as UTF-8.
+- **`process.on("memoryPressure")`**: OS low-memory notification on macOS/Linux/Windows.
+- **ML-DSA and ML-KEM**: NIST post-quantum signatures/KEM in `crypto.subtle` and `node:crypto`.
+- **`Bun.spawn({ cgroup })`**: place a child in a cgroup before it starts (Linux). Docs: <https://bun.com/docs/runtime/child-process#resource-limits-with-cgroups-linux>
+- **`bun repl`** [native]: highlighting, history, tab completion, `-e`/`-p`. Docs: <https://bun.com/docs/runtime/repl>
+- **`Temporal`** is defined by default (JSC implementation). `BUN_JSC_useTemporal=0` disables.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/security.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/security.md
@@ -1,0 +1,52 @@
+# Bun 1.4 Security Tightening
+
+Blog: [#security](https://bun.com/blog/bun-v1.4#security)
+
+1.4 tightened TLS/parsing defaults. **A connection that worked on 1.3 can now fail with a verification error — that is usually the fix working, not a bug.** Diagnose before loosening.
+
+## checkServerIdentity runs BEFORE fetch() sends [v1.4.0]
+
+```ts
+await fetch("https://api.example.com/upload", {
+  method: "POST",
+  body: secretPayload,
+  tls: {
+    checkServerIdentity(hostname, cert) {
+      if (cert.fingerprint256 !== PINNED) return new Error("pin mismatch");
+    },
+  },
+});
+// nothing is sent until the callback returns undefined; re-runs on each redirect hop
+```
+
+If you pin a cert and the URL redirects through another host, the callback sees that cert too — accept every hop or use `redirect: "manual"`.
+
+## tls.connect defaults servername to host [v1.3.13]
+
+`tls.connect({ host, port })` without `servername` uses `host` for SNI + identity check (matches Node). Connecting by IP or `localhost` to a cert issued for another name now fails with `ERR_TLS_CERT_ALTNAME_INVALID` — including through drivers like `pg`/`ioredis`. Fix: pass the cert's name as `servername`, or `checkServerIdentity: () => undefined` if trusting by CA alone.
+
+```ts
+tls.connect({ host: "10.0.0.12", port: 5432, ca, servername: "db.internal" });
+```
+
+## Bun.connect / Bun.listen enforce rejectUnauthorized [v1.4.0]
+
+`Bun.connect({ tls })`, `socket.upgradeTLS()`, and `Bun.listen()` with `requestCert: true` default to `rejectUnauthorized: true`. A self-signed dev server with no `ca` does NOT throw — the `handshake` handler runs with `socket.authorized === false`, writes return `-1`, and the socket closes without data. Pass the CA in `tls`, or `rejectUnauthorized: false` (`NODE_TLS_REJECT_UNAUTHORIZED=0` honored).
+
+## RedisClient verifies TLS hostname [v1.3.14]
+
+`rediss://` checks the server cert against the URL host; first command rejects with `ERR_TLS_CERT_ALTNAME_INVALID` on mismatch. Connect by the certificate's name, or pass `tls: { rejectUnauthorized: false }`.
+
+## HTTP request parsing hardening in Bun.serve [v1.3.4]
+
+More malformed `Content-Length` / `Transfer-Encoding` / chunked bodies get `400` + connection close, without calling your `fetch` handler or logging. Browsers/curl/proxies never send these; if a hand-written client starts seeing 400s, fix its framing headers.
+
+## Tarball extraction hardening [v1.3.6]
+
+`github:`/URL dependencies and `bun create` templates skip tar entries that would land outside the package directory. A post-upgrade `Cannot find module` for such a package usually means the repo has a symlink pointing outside the package — replace it with a real file or relative link.
+
+## Also
+
+- Registry credentials stay scoped to their configured host: never sent cross-origin, never downgraded to `http://`, never printed in errors/verbose output.
+- `tls.createServer({ requestCert: true })` now rejects unverified client certs by default; only a literal `rejectUnauthorized: false` disables verification (`null` no longer counts).
+- Full list: [Security hardening](https://bun.com/blog/bun-v1.4#security-hardening) in the changelog; advisories at <https://github.com/oven-sh/bun/security/advisories>.

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/test.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/test.md
@@ -1,0 +1,103 @@
+# bun test in 1.4
+
+Composable CI recipe:
+
+```bash
+bun test --changed=main                                   # only what your branch touches
+bun test --parallel --timings=timings.json --update-timings
+bun test --parallel --shard=1/3 --timings=timings.json    # in CI, per machine
+```
+
+## --parallel: worker processes [v1.3.13, improved v1.4.0]
+
+Blog: [#bun-test-parallel](https://bun.com/blog/bun-v1.4#bun-test-parallel)
+
+```bash
+bun test --parallel          # N = CPU count
+bun test --parallel=4
+```
+
+- Files go to whichever worker frees up next. Coverage and JUnit output merged across workers; `--bail` stops every worker.
+- `--parallel` implies `--isolate`; `--no-isolate` opts out.
+- Workers expose 1-indexed `JEST_WORKER_ID` / `BUN_TEST_WORKER_ID`, so Jest setups keying DBs/ports off worker id work unchanged.
+- Preload scripts with top-level `await` complete before any worker runs tests.
+
+## --isolate: fresh global per file [v1.3.13, hardened v1.4.0]
+
+Blog: [#bun-test-isolate](https://bun.com/blog/bun-v1.4#bun-test-isolate)
+
+```bash
+bun test --isolate
+```
+
+Between files, Bun creates a new `globalThis`, clears ESM/CJS module registries, closes leaked servers/sockets/watchers/subprocesses, cancels timers, restores fake timers, and re-runs `--preload`. Transpiled source/bytecode stay cached process-wide, so only top-level code re-runs. This is how Jest/Vitest behave by default — use it to kill "passes alone, fails in the full suite" bugs. v1.4 fixed the 1.3.13 stability issues (fake-timer leaks, module-scope subprocess leaks, `process.chdir` bleed, N-API across files, debugger breakpoints).
+
+## --shard: split across CI machines [v1.3.13]
+
+Blog: [#bun-test-shard](https://bun.com/blog/bun-v1.4#bun-test-shard)
+
+```bash
+bun test --shard=1/3   # deterministic, round-robin, 1-based (matches Jest/Vitest/Playwright)
+```
+
+Works with `--changed` and `--randomize`; an empty shard exits 0.
+
+## --timings: balance by wall time [v1.4.0]
+
+Blog: [#bun-test-timings](https://bun.com/blog/bun-v1.4#bun-test-timings)
+
+```bash
+bun test --timings=timings.json --update-timings   # record per-file durations
+bun test --shard=1/3 --timings=timings.json        # shards cut by equal time, not file count
+bun test --parallel --timings=timings.json         # workers start slowest file first (LPT scheduling)
+```
+
+The timings file is written slowest-first, so it doubles as a slow-test report. Files sharing imports stay together (warm module cache).
+
+## --changed: only affected tests [v1.3.13]
+
+Blog: [#bun-test-changed](https://bun.com/blog/bun-v1.4#bun-test-changed)
+
+```bash
+bun test --changed             # uncommitted (unstaged + staged + untracked)
+bun test --changed=main        # diff against branch/commit/tag
+bun test --changed --watch     # re-filters on every restart
+```
+
+Bun scans test imports, asks git what changed, walks the import graph backwards. tsconfig `paths` aliases (`@/*`) work. Vitest-compatible flag.
+
+## --retry and repeats [v1.3.3]
+
+Blog: [#bun-test-retry](https://bun.com/blog/bun-v1.4#bun-test-retry)
+
+```ts
+test("flaky network call", async () => { await fetch("https://example.com"); }, { retry: 5 });
+test("stress", () => { if (Math.random() < 0.1) throw new Error("uh oh!"); }, { repeats: 20 });
+```
+
+`bun test --retry <N>` sets a suite-wide default. NOTE: prefer fixing the flake; retry is a containment tool.
+
+## jest.useFakeTimers() [v1.3.4, improved v1.4.0]
+
+Blog: [#jest-usefaketimers](https://bun.com/blog/bun-v1.4#jest-usefaketimers)
+
+```ts
+import { jest, test, expect } from "bun:test";
+test("debounce", () => {
+  jest.useFakeTimers();
+  let called = 0;
+  setTimeout(() => called++, 1000);
+  jest.advanceTimersByTime(1000);
+  expect(called).toBe(1);
+  jest.useRealTimers();
+});
+```
+
+- Controls `setTimeout`, `setInterval`, `Date`. `jest.setSystemTime()` works with `advanceTimersByTime()`.
+- `@testing-library/react`'s `waitFor` detects fake timers and advances instead of sleeping. `Bun.cron` schedules can be driven by the fake clock.
+
+## Behavior changes in 1.4 (test-related)
+
+- `jest.resetAllMocks()` now drops implementations too (matches Jest); use `clearAllMocks()` for history-only.
+- `expect().toContain()` compares with `===` not `Object.is` (`[NaN]` no longer contains `NaN`).
+- `toEqual()` compares `Temporal` objects by value.

--- a/packages/senpi-codemode/test/bun-skill-contribution.test.ts
+++ b/packages/senpi-codemode/test/bun-skill-contribution.test.ts
@@ -1,0 +1,115 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	type BunSkillProbe,
+	bundledBunSkillPath,
+	bunVersionSupportsSkill,
+	createBunSkillDiscoverHandler,
+	registerBunSkillContribution,
+} from "../src/extension/skill-contribution.ts";
+
+const bunSkillMd = join(import.meta.dirname, "..", "src", "skill", "bun-1-4", "SKILL.md");
+const bunSkillRefs = join(import.meta.dirname, "..", "src", "skill", "bun-1-4", "references");
+
+function probe(pathVersion: string | undefined, runtimeVersion?: string): BunSkillProbe {
+	return {
+		probePathBunVersion: async () => pathVersion,
+		runtimeBunVersion: () => runtimeVersion,
+	};
+}
+
+describe("bunVersionSupportsSkill", () => {
+	it.each([
+		{ version: "1.4.0", expected: true },
+		{ version: "1.4.1", expected: true },
+		{ version: "2.0.0", expected: true },
+		{ version: "1.3.9", expected: false },
+		{ version: "0.9.0", expected: false },
+		{ version: undefined, expected: false },
+		{ version: "garbage", expected: false },
+	])("maps $version to $expected", ({ version, expected }) => {
+		expect(bunVersionSupportsSkill(version)).toBe(expected);
+	});
+});
+
+describe("bundledBunSkillPath", () => {
+	it("returns the absolute bun-1-4 SKILL.md path that exists on disk", () => {
+		const result = bundledBunSkillPath();
+		expect(result).toBe(bunSkillMd);
+		expect(result !== undefined && existsSync(result)).toBe(true);
+	});
+});
+
+describe("createBunSkillDiscoverHandler", () => {
+	it("contributes the bundled skill when path bun is 1.4.2", async () => {
+		const handler = createBunSkillDiscoverHandler(probe("1.4.2"));
+		await expect(handler()).resolves.toEqual({ skillPaths: [bunSkillMd] });
+	});
+
+	it("contributes nothing when path bun is 1.3.0", async () => {
+		const handler = createBunSkillDiscoverHandler(probe("1.3.0"));
+		await expect(handler()).resolves.toBeUndefined();
+	});
+
+	it("falls back to runtime bun 1.4.0 when the path probe is missing", async () => {
+		const handler = createBunSkillDiscoverHandler(probe(undefined, "1.4.0"));
+		await expect(handler()).resolves.toEqual({ skillPaths: [bunSkillMd] });
+	});
+
+	it("contributes nothing when both path and runtime bun are missing", async () => {
+		const handler = createBunSkillDiscoverHandler(probe(undefined));
+		await expect(handler()).resolves.toBeUndefined();
+	});
+
+	it("probes path bun version only once for the same handler", async () => {
+		let counter = 0;
+		const handler = createBunSkillDiscoverHandler({
+			probePathBunVersion: async () => {
+				counter += 1;
+				return "1.4.2";
+			},
+			runtimeBunVersion: () => undefined,
+		});
+		await handler();
+		await handler();
+		expect(counter).toBe(1);
+	});
+});
+
+describe("registerBunSkillContribution", () => {
+	it("registers one resources_discover handler that contributes the gated-in skill", async () => {
+		const registrations: Array<{
+			event: "resources_discover";
+			handler: (
+				event: unknown,
+				ctx: unknown,
+			) => Promise<{ skillPaths?: string[] } | undefined> | { skillPaths?: string[] } | undefined;
+		}> = [];
+		const pi = {
+			on(
+				event: "resources_discover",
+				handler: (
+					event: unknown,
+					ctx: unknown,
+				) => Promise<{ skillPaths?: string[] } | undefined> | { skillPaths?: string[] } | undefined,
+			): void {
+				registrations.push({ event, handler });
+			},
+		};
+
+		registerBunSkillContribution(pi, probe("1.4.2"));
+
+		expect(registrations).toHaveLength(1);
+		expect(registrations[0]?.event).toBe("resources_discover");
+		await expect(Promise.resolve(registrations[0]?.handler({}, {}))).resolves.toEqual({ skillPaths: [bunSkillMd] });
+	});
+});
+
+describe("bun-1-4 skill assets", () => {
+	it("pins SKILL.md frontmatter name and exactly 10 reference markdown files", () => {
+		expect(readFileSync(bunSkillMd, "utf8")).toContain("name: bun-1-4");
+		const references = readdirSync(bunSkillRefs).filter((name) => name.endsWith(".md"));
+		expect(references).toHaveLength(10);
+	});
+});

--- a/packages/senpi-codemode/test/factory.test.ts
+++ b/packages/senpi-codemode/test/factory.test.ts
@@ -19,6 +19,7 @@ describe("senpi-codemode extension factory", () => {
 		expect(() => senpiCodemode(pi)).not.toThrow();
 		expect(registeredTools).toEqual(["eval"]);
 		expect(events).toEqual([
+			"resources_discover",
 			"session_start",
 			"session_shutdown",
 			"session_before_switch",


### PR DESCRIPTION
## Summary

Ships the `bun-1-4` skill as a **builtin of the codemode extension**, contributed through `resources_discover` only when the session can actually use it:

- **Gate**: PATH `bun --version` probe (1.5s timeout) with `process.versions.bun` fallback; the skill is contributed iff the detected version is >= 1.4. The gate decision is cached per handler, so the probe subprocess runs at most once.
- **Placement**: because the contribution lives inside `senpi-codemode`, the skill only exists when the eval extension itself is loaded — disabling codemode removes the skill with zero extra wiring (mirrors the `imagegen` bundled-skill precedent in coding-agent).
- **Skill content**: eval-first operating rules (bun kernel -> use `Bun.*` directly in js cells; node kernel -> spawn `bun -e` from a cell), token-optimized capability map, 10 reference files shipped verbatim under `src/skill/bun-1-4/references/`.
- **Collision-safe**: `loadSkills` is first-wins, so a user-level `~/.agents/skills/bun-1-4` copy keeps overriding the builtin.

## Changes

- `src/extension/skill-contribution.ts` — version gate, bundled path resolution, cached discover handler, registration helper
- `src/index.ts` — `CodemodeExtensionAPI` gains a `resources_discover` overload; factory registers the contribution
- `src/skill/bun-1-4/` — SKILL.md + 10 references (ships via the package's `files: ["src"]`)
- `test/bun-skill-contribution.test.ts` — 15 gating/asset contracts (version table, PATH/runtime fallback, probe caching, registration, asset pins)
- `test/factory.test.ts` — event-registration pin extended with `resources_discover`

## Verification

- RED captured at the tests-only commit (8 assertion failures against the stub, 0 import errors), GREEN at impl: 15/15 targeted + full senpi-codemode suite on a fleet machine (mengmotaMac), evidence in run logs
- Integration matrix on the real default probe: PRESENT (skillPaths -> existing SKILL.md) with bun 1.4.0 on PATH; ABSENT under node with bun stripped from PATH

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships the `bun-1-4` skill as a builtin of the codemode extension, contributed via `resources_discover` only when bun >= 1.4 is detected (PATH probe with runtime fallback). Previously the skill only existed as a user-level contribution; now it's bundled and appears automatically whenever the eval extension is loaded.

- The version gate decision is cached per handler, so the bun probe subprocess runs at most once.
- The skill is eval-first: use `Bun.*` directly in js cells on a bun kernel, or spawn `bun -e` from a node kernel.
- Ships 10 reference files under `src/skill/bun-1-4/references/`.
- User-level `~/.agents/skills/bun-1-4` still overrides the builtin because `loadSkills` is first-wins.

<sup>Written for commit df3194a763caf3838a9a7d6465d32ffac54ea60c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

