### PR TITLE
fix(claude-sdk-oauth): classify successful error results

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Fixed
 
+- Claude SDK OAuth now treats terminal `is_error` results as failures even when
+  the SDK reports `subtype: "success"`, preserving fallback for rate-limit and
+  session-limit responses ([#1169](https://github.com/code-yeongyu/senpi/issues/1169)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/auth-lane.ts
@@ -17,7 +17,7 @@ import { selectAccount } from "./affinity.ts";
 import { type AuthenticatedAttemptInput, createAttemptMessages, type RetainableAttempt } from "./auth-attempt.ts";
 import { hasRequestOauthToken, mergeRequestAuthEnvironment, stripManagedAuthEnvironment } from "./auth-environment.ts";
 import { writeConfigDirCredential } from "./config-dir-credentials.ts";
-import { classifySdkError } from "./errors.ts";
+import { classifySdkError, sdkResultFailure } from "./errors.ts";
 import { runFailover } from "./failover.ts";
 import { refusalError } from "./refusal.ts";
 import type { Options, SDKMessage, SdkQuery } from "./sdk-boundary.ts";
@@ -158,19 +158,7 @@ function sdkFailure(message: SDKMessage): unknown | undefined {
 	const refusal = refusalError(message);
 	if (refusal) return refusal;
 	if (message.type === "assistant" && message.error) return message.error;
-	if (message.type === "result" && message.subtype !== "success") {
-		const errors = "errors" in message && Array.isArray(message.errors) ? (message.errors as unknown[]) : [];
-		if (errors.length > 0) return new Error(String(errors[0]));
-		// `subtype` alone is too coarse to classify: a subscription limit and an
-		// ordinary tool failure both arrive as "error_during_execution". The SDK
-		// carries the real cause in `terminal_reason` (e.g. "blocking_limit"), so
-		// append it — otherwise classifySdkError() scores every result error as
-		// non-retryable "other", the exhausted account is never blocked, and a
-		// multi-account pool never rotates past it.
-		const reason =
-			"terminal_reason" in message && typeof message.terminal_reason === "string" ? message.terminal_reason : "";
-		return new Error(reason ? `Claude Code ${message.subtype}: ${reason}` : `Claude Code ${message.subtype}`);
-	}
+	if (message.type === "result") return sdkResultFailure(message);
 	return undefined;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,33 @@
 # claude-sdk-oauth
 
+## 2026-08-31 - Treat SDK `is_error` results as terminal failures (issue #1169)
+
+### What changed
+
+- `errors.ts` centralizes Claude SDK result failure detection. A `result` with `is_error: true` now fails even when its
+  subtype is `success`, preserving API status and terminal-reason metadata for the existing failover classifier.
+- `auth-lane.ts`, `stream.ts`, `session-registry-pump.ts`, and `session-turn-attempt.ts` use that boundary so ambient,
+  managed, non-resident, and resident turns cannot report an errored result as successful or synchronize it as a
+  resident-session success.
+
+### Why
+
+Claude emits subscription/session-limit failures as `subtype: "success"` plus `is_error: true`, often with HTTP 429
+and `blocking_limit` metadata. Treating subtype as the sole success signal displayed the error text as a completed
+assistant response and could retain a failed resident turn as synchronized.
+
+### Why an extension could not handle it
+
+The SDK result crosses this builtin provider's private auth, non-resident stream, and resident query-pump boundaries.
+An external extension receives only the already-classified provider stream and cannot correct failover or continuity
+state.
+
+### Expected merge conflict zones
+
+- LOW in `errors.ts`, `auth-lane.ts`, and `stream.ts` around SDK terminal-result handling.
+- MEDIUM in `session-registry-pump.ts` and `session-turn-attempt.ts` around resident turn settlement and success
+  detection.
+
 ## 2026-08-21 - Cache provider settings loads by mtime+size to cut lock convoy
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/errors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/errors.ts
@@ -1,4 +1,5 @@
 import type { SDKAssistantMessageError } from "@anthropic-ai/claude-agent-sdk";
+import type { SDKMessage } from "./sdk-boundary.ts";
 
 export type SdkErrorKind = "rate_limit" | "overloaded" | "auth_error" | "billing" | "org_not_allowed" | "other";
 
@@ -23,6 +24,20 @@ function record(value: unknown): Record<string, unknown> | undefined {
 	return value !== null && typeof value === "object" && !Array.isArray(value)
 		? (value as Record<string, unknown>)
 		: undefined;
+}
+
+export function sdkResultFailure(message: Extract<SDKMessage, { type: "result" }>): Error | undefined {
+	if (message.subtype === "success" && !("is_error" in message && message.is_error === true)) return undefined;
+	const errors = "errors" in message && Array.isArray(message.errors) ? message.errors : [];
+	const status =
+		"api_error_status" in message && typeof message.api_error_status === "number"
+			? `HTTP ${message.api_error_status}`
+			: undefined;
+	const terminalReason =
+		"terminal_reason" in message && typeof message.terminal_reason === "string" ? message.terminal_reason : undefined;
+	const details = [status, terminalReason].filter((detail): detail is string => detail !== undefined);
+	const summary = errors.length > 0 ? String(errors[0]) : `Claude Code ${message.subtype}`;
+	return new Error(details.length > 0 ? `${summary}: ${details.join(", ")}` : summary);
 }
 
 function errorText(error: unknown): string {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
@@ -1,3 +1,4 @@
+import { sdkResultFailure } from "./errors.ts";
 import { refusalError } from "./refusal.ts";
 import type { SDKMessage, SDKUserMessage } from "./sdk-boundary.ts";
 import { evaluateAbortOutcome } from "./session-reattach.ts";
@@ -134,8 +135,14 @@ function handleMessage(
 		failTurn(registry, entry, refusal);
 		return true;
 	}
-	if (message.type === "result") finishTurn(registry, entry, turn, message);
-	else deliver(entry, turn, message);
+	if (message.type === "result") {
+		const failure = sdkResultFailure(message);
+		if (failure) {
+			failTurn(registry, entry, failure);
+			return true;
+		}
+		finishTurn(registry, entry, turn, message);
+	} else deliver(entry, turn, message);
 	return false;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-turn-attempt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-turn-attempt.ts
@@ -1,4 +1,5 @@
 import { BoundedAsyncQueue, SESSION_STREAM_QUEUE_CAPACITY } from "./bounded-queue.ts";
+import { sdkResultFailure } from "./errors.ts";
 import type { SDKMessage, SDKUserMessage } from "./sdk-boundary.ts";
 import { bindingFromEntry, rememberBinding } from "./session-reattach.ts";
 import {
@@ -13,7 +14,9 @@ import { recordSyncedStream, sentHashPrefixDigest } from "./session-sync.ts";
 type StagedContinuityDecision = { emit(): void };
 
 function successfulTurn(messages: readonly SDKMessage[]): boolean {
-	return messages.some((message) => message.type === "result" && message.subtype === "success");
+	return messages.some(
+		(message) => message.type === "result" && message.subtype === "success" && !sdkResultFailure(message),
+	);
 }
 
 function recordAssistantUuid(entry: ClaudeSdkOauthSessionEntry, sentCount: number, message: SDKMessage): void {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
@@ -10,6 +10,7 @@ import {
 import { getSessionClaudeAccountPin } from "./account-command.ts";
 import { queryWithAuthLane } from "./auth-lane.ts";
 import { buildCustomToolServers } from "./custom-tools.ts";
+import { sdkResultFailure } from "./errors.ts";
 import { defaultExecutableDeps, resolveClaudeCodeExecutable } from "./executable.ts";
 import { buildClaudeSdkOauthQueryOptions } from "./options.ts";
 import { buildPromptBlocks, buildPromptStream } from "./prompt-bridge.ts";
@@ -185,6 +186,8 @@ export function streamClaudeSdkOauth(
 						},
 					];
 				} else if (message.type === "result" && message.subtype === "success") {
+					const failure = sdkResultFailure(message);
+					if (failure) throw failure;
 					// Both fields are optional on the wire, so only adopt them when present.
 					// A terminal result must never downgrade a toolUse turn that the stream
 					// already established, or the agent loop would stop instead of running

--- a/packages/coding-agent/test/claude-sdk-oauth-failover.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-failover.test.ts
@@ -7,8 +7,9 @@ import {
 	emptyCredential,
 } from "../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
 import { rendezvousOrder, selectAccount } from "../src/core/extensions/builtin/claude-sdk-oauth/affinity.ts";
-import { classifySdkError } from "../src/core/extensions/builtin/claude-sdk-oauth/errors.ts";
+import { classifySdkError, sdkResultFailure } from "../src/core/extensions/builtin/claude-sdk-oauth/errors.ts";
 import { ClassifiedSdkError, runFailover } from "../src/core/extensions/builtin/claude-sdk-oauth/failover.ts";
+import type { SDKMessage } from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
 
 type AttemptEvent =
 	| { type: "text_delta"; delta: string }
@@ -83,6 +84,41 @@ describe("Claude SDK OAuth failover", () => {
 			kind: "other",
 			retryable: false,
 		});
+	});
+
+	it("rotates after a successful-subtype SDK result carries a rate-limit error", async () => {
+		const store = await storeWithAccounts();
+		const result = {
+			type: "result",
+			subtype: "success",
+			is_error: true,
+			api_error_status: 429,
+			terminal_reason: "blocking_limit",
+			result: "session limit reached",
+		} as Extract<SDKMessage, { type: "result" }>;
+		const failure = sdkResultFailure(result);
+		expect(failure?.message).toContain("HTTP 429");
+		expect(failure?.message).toContain("blocking_limit");
+
+		const attempts: string[] = [];
+		const events = await collect(
+			runFailover({
+				accounts: accountPool,
+				selectFn: (pool) => selectAccount(pool, { sessionId: "success-error", now }),
+				runAttempt: async function* (slot) {
+					attempts.push(slot.name);
+					if (attempts.length === 1) throw failure;
+					yield { type: "done", value: slot.name };
+				},
+				classify: classifySdkError,
+				store,
+				providerId: "claude-sdk-oauth",
+				now: () => now,
+			}),
+		);
+
+		expect(attempts).toHaveLength(2);
+		expect(events).toEqual([{ type: "done", value: attempts[1] }]);
 	});
 
 	it("still treats unrelated errors as non-retryable", () => {

--- a/packages/coding-agent/test/suite/regressions/1169-claude-sdk-oauth-result-error.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1169-claude-sdk-oauth-result-error.test.ts
@@ -1,0 +1,87 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	overrideSdkBoundary,
+	resetSdkBoundary,
+	type SDKMessage,
+	type SdkQuery,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import { streamClaudeSdkOauth } from "../../../src/core/extensions/builtin/claude-sdk-oauth/stream.ts";
+
+const model: Model<Api> = {
+	id: "claude-test",
+	name: "Claude test",
+	api: "claude-sdk-oauth",
+	provider: "claude-sdk-oauth",
+	baseUrl: "claude-sdk-oauth",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+function sdkMessage(value: unknown): SDKMessage {
+	return value as SDKMessage;
+}
+
+function queryWithResult(result: SDKMessage): SdkQuery {
+	return () => ({
+		async *[Symbol.asyncIterator](): AsyncGenerator<SDKMessage> {
+			yield result;
+		},
+		async interrupt() {},
+		close() {},
+	});
+}
+
+afterEach(resetSdkBoundary);
+
+describe("issue #1169: Claude SDK success results with is_error", () => {
+	it("keeps an ordinary non-error success result successful", async () => {
+		// Given: the SDK's ordinary terminal success result.
+		overrideSdkBoundary({
+			query: queryWithResult(
+				sdkMessage({
+					type: "result",
+					subtype: "success",
+					is_error: false,
+					api_error_status: null,
+					terminal_reason: "completed",
+					result: "ordinary answer",
+				}),
+			),
+		});
+
+		// When: the authoritative Claude SDK stream boundary consumes it.
+		const result = await streamClaudeSdkOauth(model, { messages: [] }).result();
+
+		// Then: its text remains a successful assistant response.
+		expect(result).toMatchObject({
+			stopReason: "stop",
+			content: [{ type: "text", text: "ordinary answer" }],
+		});
+	});
+
+	it("reports a 429 session-limit success result with is_error as an error", async () => {
+		// Given: the SDK's documented API-error shape despite subtype success.
+		overrideSdkBoundary({
+			query: queryWithResult(
+				sdkMessage({
+					type: "result",
+					subtype: "success",
+					is_error: true,
+					api_error_status: 429,
+					terminal_reason: "blocking_limit",
+					result: "session limit reached",
+				}),
+			),
+		});
+
+		// When: the authoritative Claude SDK stream boundary consumes it.
+		const result = await streamClaudeSdkOauth(model, { messages: [] }).result();
+
+		// Then: it must not be emitted as a completed assistant response.
+		expect(result.stopReason).toBe("error");
+	});
+});


### PR DESCRIPTION
## Problem
Claude SDK terminal results may report `subtype: success` while `is_error: true`; ambient streams then surface a successful assistant response and managed OAuth fallback is bypassed.

## Root cause
The result boundary classified success only by subtype and did not share one failure classifier across ambient, managed, and resident paths.

## Invariant
Any SDK result with `is_error: true` must be terminal failure regardless of subtype. Ordinary success must remain successful, and rate-limit metadata must remain available to account failover.

## Changes
- Centralized SDK result failure classification with HTTP status and terminal-reason details.
- Applied it to ambient streaming, managed OAuth failover, and resident session settlement.
- Preserved resident retry checkpoints without synchronizing failed turns.

## RED -> GREEN
RED: the injected `success` + `is_error: true` regression was emitted with `stopReason: stop`.
GREEN: the regression and affected OAuth suites pass; 83 tests passed in the final focused wave.

## Real-surface verification
The real SDK stream boundary is exercised through the repository SDK boundary override with a documented terminal-result payload; no credentials or network calls are used.

## Regression coverage
Added `test/suite/regressions/1169-claude-sdk-oauth-result-error.test.ts` and exact managed failover coverage for HTTP 429 plus `blocking_limit`.

## Risks / residuals
Provider-specific terminal prose remains classified by the existing failover policy. Full repository build typecheck is host-limited because this machine runs Node 22 while the repository requires Node 24 and exposes unrelated workspace export-resolution failures.

## Non-goals
No changes to provider credentials, SDK versioning, retry budgets, or ordinary successful-result rendering.

Fixes #1169