### PR TITLE
fix(codemode): contribute bun-1-4 skill only on a bun >= 1.4 eval kernel

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Added
 
-- The codemode extension now bundles the `bun-1-4` skill and contributes it via `resources_discover` when
-  bun >= 1.4 is detected (PATH probe with `process.versions.bun` fallback).
+- The codemode extension now bundles the `bun-1-4` skill and contributes it via `resources_discover` only
+  when the js eval kernel itself runs bun >= 1.4 (`process.versions.bun`); node-kernel sessions never
+  receive the skill, regardless of any bun binary on PATH.
 
 ### Changed
 

--- a/packages/senpi-codemode/src/extension/skill-contribution.ts
+++ b/packages/senpi-codemode/src/extension/skill-contribution.ts
@@ -1,13 +1,6 @@
-import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
-
-const execFileAsync = promisify(execFile);
-
-/** How long `bun --version` may run before the PATH probe gives up. */
-const PATH_BUN_PROBE_TIMEOUT_MS = 1500;
 
 const BUN_SKILL_BASE_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -15,10 +8,10 @@ let loggedMissingBunSkill = false;
 
 export const BUN_SKILL_MIN_VERSION = "1.4.0";
 
-export interface BunSkillProbe {
-	probePathBunVersion(): Promise<string | undefined>;
-	runtimeBunVersion(): string | undefined;
-}
+/** Reads the js eval kernel's bun version; undefined on a node kernel. */
+export type BunKernelVersionSource = () => string | undefined;
+
+const kernelBunVersion: BunKernelVersionSource = () => process.versions.bun;
 
 /**
  * True when the version is at least `BUN_SKILL_MIN_VERSION`: parses the leading
@@ -45,39 +38,19 @@ export function bundledBunSkillPath(baseDir: string = BUN_SKILL_BASE_DIR): strin
 	return undefined;
 }
 
-async function probePathBunVersion(): Promise<string | undefined> {
-	try {
-		const { stdout } = await execFileAsync("bun", ["--version"], { timeout: PATH_BUN_PROBE_TIMEOUT_MS });
-		return stdout.trim();
-	} catch {
-		return undefined;
-	}
-}
-
-const defaultBunSkillProbe: BunSkillProbe = {
-	probePathBunVersion,
-	runtimeBunVersion: () => process.versions.bun,
-};
-
 /**
  * Builds the `resources_discover` handler that contributes the bundled bun-1-4 skill
- * when bun >= 1.4 is detected (PATH probe first, `process.versions.bun` as fallback).
- * The gate decision is cached in a single shared promise, so the PATH probe
- * subprocess runs at most once per handler.
+ * only when the in-process js eval kernel itself runs bun >= 1.4 (`process.versions.bun`).
+ * A node kernel never receives the skill, regardless of any bun binary on PATH.
  */
 export function createBunSkillDiscoverHandler(
-	probe: BunSkillProbe = defaultBunSkillProbe,
+	getKernelBunVersion: BunKernelVersionSource = kernelBunVersion,
 	baseDir?: string,
-): () => Promise<{ skillPaths: string[] } | undefined> {
-	let decision: Promise<{ skillPaths: string[] } | undefined> | undefined;
-	return async () => {
-		decision ??= (async () => {
-			const version = (await probe.probePathBunVersion()) ?? probe.runtimeBunVersion();
-			if (!bunVersionSupportsSkill(version)) return undefined;
-			const skillPath = bundledBunSkillPath(baseDir);
-			return skillPath === undefined ? undefined : { skillPaths: [skillPath] };
-		})();
-		return decision;
+): () => { skillPaths: string[] } | undefined {
+	return () => {
+		if (!bunVersionSupportsSkill(getKernelBunVersion())) return undefined;
+		const skillPath = bundledBunSkillPath(baseDir);
+		return skillPath === undefined ? undefined : { skillPaths: [skillPath] };
 	};
 }
 
@@ -91,8 +64,8 @@ export function registerBunSkillContribution(
 			) => Promise<{ skillPaths?: string[] } | undefined> | { skillPaths?: string[] } | undefined,
 		): void;
 	},
-	probe?: BunSkillProbe,
+	getKernelBunVersion?: BunKernelVersionSource,
 	baseDir?: string,
 ): void {
-	pi.on("resources_discover", createBunSkillDiscoverHandler(probe, baseDir));
+	pi.on("resources_discover", createBunSkillDiscoverHandler(getKernelBunVersion, baseDir));
 }

--- a/packages/senpi-codemode/src/skill/bun-1-4/SKILL.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/SKILL.md
@@ -5,7 +5,7 @@ description: "MUST USE whenever writing or running JavaScript/TypeScript with Bu
 
 # Bun 1.4 — Use the Builtins First
 
-Bun 1.4 (2026) ships builtins that replace most utility npm packages. **Before adding a dependency or writing a workaround, check the capability map below — if Bun ships it, use the builtin.** This skill is loaded because this session has the `eval` tool and bun >= 1.4 was detected; on other machines or pinned projects, confirm with `bun --version` ([v1.3.x]/[v1.4.0] tags in the references give exact minimums). Release post: <https://bun.com/blog/bun-v1.4>
+Bun 1.4 (2026) ships builtins that replace most utility npm packages. **Before adding a dependency or writing a workaround, check the capability map below — if Bun ships it, use the builtin.** This skill is loaded because this session's `eval` js kernel runs Bun >= 1.4; on other machines or pinned projects, confirm with `bun --version` ([v1.3.x]/[v1.4.0] tags in the references give exact minimums). Release post: <https://bun.com/blog/bun-v1.4>
 
 ## Capability map — what you can do now
 
@@ -37,45 +37,8 @@ Free wins (no code change): 2x lower CPU, 13-48% less server memory, 2-2.5x fast
 
 ## Operating rules
 
-1. **Eval-first.** Drive Bun work through the `eval` tool. The eval prelude's host line names the js kernel runtime: on a `bun` kernel, `Bun.*` globals are available directly in js cells — use them in-kernel. On a `node` kernel, `Bun.*` does not exist inside cells: spawn Bun from the cell (`node:child_process` → `bun -e '<code>'` / `bun script.ts`) or use the bash tool.
+1. **Eval-first.** The `eval` js kernel runs on Bun (that is why this skill is present): call `Bun.*` APIs directly inside js cells. Reach for `bash` or a spawned `bun <file>` / `bun -e` only for CLI surfaces (`bun test`, `bun build`, `bun pm`) or work that needs a separate process.
 2. **Builtin-first.** The Replaces column above is a ban list for new dependencies, in production code, test helpers, and one-off scripts alike.
 3. **Read the matching reference before using an unfamiliar API** — signatures and caveats (e.g. `Bun.markdown` HTML is unsanitized, HTTP/3 is experimental) live there, not here.
-4. **Upgrading a project to 1.4 or debugging behavior that changed?** Read [breaking-changes](references/breaking-changes.md) first — YAML/TOML strictness, `.xml`/`.css` import semantics, `Bun.---
-name: bun-1-4
-description: "MUST USE whenever writing or running JavaScript/TypeScript with Bun — including JS through the eval tool, bun -e one-liners, scratch scripts, servers, CLIs, tests, bundling, or package management. Bun 1.4 replaced 15+ npm deps with builtins: consult BEFORE npm-installing sharp, puppeteer/playwright (scraping), marked, node-cron, node-pty, concurrently, serve-static, tar, json5, fast-xml-parser, string-width — Bun ships it. Triggers: bun, Bun.serve, bun test, bun build, bun install, bun run, JS 스크립트, 번들링, 이미지 리사이즈, 헤드리스 브라우저, 크론, PTY, eval js."
----
-
-# Bun 1.4 — Use the Builtins First
-
-Bun 1.4 (2026) ships builtins that replace most utility npm packages. **Before adding a dependency or writing a workaround, check the capability map below — if Bun ships it, use the builtin.** This skill is loaded because this session has the `eval` tool and bun >= 1.4 was detected; on other machines or pinned projects, confirm with `bun --version` ([v1.3.x]/[v1.4.0] tags in the references give exact minimums). Release post: <https://bun.com/blog/bun-v1.4>
-
-## Capability map — what you can do now
-
-| You want to... | Use | Replaces | Ref = `references/<name>.md` |
-|---|---|---|---|
-| Resize/convert/rotate images | `Bun.file(p).image().resize().webp().write()` | sharp | runtime-apis |
-| Headless browser: navigate, click, screenshot, evaluate, CDP | `new Bun.WebView()` | puppeteer, playwright (scraping) | runtime-apis |
-| Markdown → HTML / React / ANSI | `Bun.markdown.html() / .react() / .render()` | marked, react-markdown | runtime-apis |
-| Schedule cron jobs | `Bun.cron()` | node-cron | runtime-apis |
-| Drive a PTY (bash, vim, TUIs) from JS | `Bun.spawn([...], { terminal })` | node-pty | runtime-apis |
-| Run package scripts concurrently, glob-matched | `bun run --parallel "build:*"` | concurrently, npm-run-all | runtime-apis |
-| Parse JSON5 / JSONL / JSONC / XML / TOML; tarballs | `Bun.JSON5/.JSONL/.JSONC/.XML/.TOML`, `Bun.Archive` | json5, ndjson, jsonc-parser, fast-xml-parser, @iarna/toml, tar | runtime-apis |
-| ANSI-aware terminal text: width, slice, wrap | `Bun.stringWidth()`, `Bun.sliceAnsi()`, `Bun.wrapAnsi()` | string-width, slice-ansi, wrap-ansi | runtime-apis |
-| Call C libraries 3x faster, plain strings back | `bun:ffi` (`buffer_length`, `cstring`) | — | runtime-apis |
-| Serve a static dir (ETag/Range/304 handled) | `Bun.serve({ routes: { "/x/*": { dir } } })` | express.static, serve-static, sirv | http-networking |
-| HTTP/3 server; `fetch` protocol/compress/proxy | `http3: true`, `fetch(url, { protocol, compress, proxy })` | — | http-networking |
-| Tests across CPU workers / CI shards / changed files / flaky retry | `bun test --parallel --shard=1/3 --changed=main --retry` | jest/vitest infra | test |
-| Kill "passes alone, fails in suite" bugs | `bun test --isolate` | vitest default behavior | test |
-| React Compiler auto-memoization | `bun build --react-compiler` | babel-plugin-react-compiler | build |
-| Embed assets/dirs into a single-file executable | `bun build --compile --asset ./public` | pkg hacks | build |
-| Compile-time feature flags, in-memory bundling, metafile | `bun:bundle feature()`, `files:{}`, `metafile: true` | esbuild define/plugins | build |
-| Diff package versions, fix vulns, dedupe/prune, license audit | `bun pm diff`, `bun audit fix`, `bun dedupe`, `bun prune`, `bun pm licenses` | npm-diff, npm audit fix | install |
-| 7x faster CI installs (global virtual store) | `linker = "isolated"` in bunfig.toml | pnpm store | install |
-| Profile CPU/heap/bundle as grep-able Markdown | `bun --cpu-prof-md`, `--heap-prof-md`, `bun build --metafile-md` | Chrome DevTools round-trip | dev-tooling |
-| Native REPL; render Markdown in terminal | `bun repl`, `bun ./README.md` | node repl, glow | runtime-apis |
-| Run Playwright, vitest, Next.js 16, OpenTelemetry, dd-trace | they now just work | Node.js | node-compat-platforms |
-
-Free wins (no code change): 2x lower CPU, 13-48% less server memory, 2-2.5x faster startup — full numbers in [performance](references/performance.md).
-
- globbing, fetch header combining, and WebSocket close timing all changed.
+4. **Upgrading a project to 1.4 or debugging behavior that changed?** Read [breaking-changes](references/breaking-changes.md) first — YAML/TOML strictness, `.xml`/`.css` import semantics, `Bun.$` globbing, fetch header combining, and WebSocket close timing all changed.
 5. **TLS errors after upgrade are usually intentional** — 1.4 tightened certificate verification across `fetch`, `tls.connect`, `Bun.connect`, `RedisClient`. See [security](references/security.md) before loosening anything.

--- a/packages/senpi-codemode/test/bun-skill-contribution.test.ts
+++ b/packages/senpi-codemode/test/bun-skill-contribution.test.ts
@@ -90,4 +90,11 @@ describe("bun-1-4 skill assets", () => {
 		const references = readdirSync(bunSkillRefs).filter((name) => name.endsWith(".md"));
 		expect(references).toHaveLength(10);
 	});
+
+	it("ships a single document: one frontmatter block and one H1", () => {
+		const text = readFileSync(bunSkillMd, "utf8");
+		expect(text.match(/^---$/gm)).toHaveLength(2);
+		expect(text.match(/^# Bun 1\.4/gm)).toHaveLength(1);
+		expect(text.match(/^## Operating rules$/gm)).toHaveLength(1);
+	});
 });

--- a/packages/senpi-codemode/test/bun-skill-contribution.test.ts
+++ b/packages/senpi-codemode/test/bun-skill-contribution.test.ts
@@ -2,7 +2,6 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-	type BunSkillProbe,
 	bundledBunSkillPath,
 	bunVersionSupportsSkill,
 	createBunSkillDiscoverHandler,
@@ -11,13 +10,6 @@ import {
 
 const bunSkillMd = join(import.meta.dirname, "..", "src", "skill", "bun-1-4", "SKILL.md");
 const bunSkillRefs = join(import.meta.dirname, "..", "src", "skill", "bun-1-4", "references");
-
-function probe(pathVersion: string | undefined, runtimeVersion?: string): BunSkillProbe {
-	return {
-		probePathBunVersion: async () => pathVersion,
-		runtimeBunVersion: () => runtimeVersion,
-	};
-}
 
 describe("bunVersionSupportsSkill", () => {
 	it.each([
@@ -42,43 +34,29 @@ describe("bundledBunSkillPath", () => {
 });
 
 describe("createBunSkillDiscoverHandler", () => {
-	it("contributes the bundled skill when path bun is 1.4.2", async () => {
-		const handler = createBunSkillDiscoverHandler(probe("1.4.2"));
-		await expect(handler()).resolves.toEqual({ skillPaths: [bunSkillMd] });
+	it("contributes the bundled skill when the eval kernel runs bun 1.4.2", async () => {
+		const handler = createBunSkillDiscoverHandler(() => "1.4.2");
+		await expect(Promise.resolve(handler())).resolves.toEqual({ skillPaths: [bunSkillMd] });
 	});
 
-	it("contributes nothing when path bun is 1.3.0", async () => {
-		const handler = createBunSkillDiscoverHandler(probe("1.3.0"));
-		await expect(handler()).resolves.toBeUndefined();
+	it("contributes nothing when the eval kernel runs bun 1.3.0", async () => {
+		const handler = createBunSkillDiscoverHandler(() => "1.3.0");
+		await expect(Promise.resolve(handler())).resolves.toBeUndefined();
 	});
 
-	it("falls back to runtime bun 1.4.0 when the path probe is missing", async () => {
-		const handler = createBunSkillDiscoverHandler(probe(undefined, "1.4.0"));
-		await expect(handler()).resolves.toEqual({ skillPaths: [bunSkillMd] });
+	it("contributes nothing on a node kernel, regardless of any bun binary on PATH", async () => {
+		const handler = createBunSkillDiscoverHandler(() => undefined);
+		await expect(Promise.resolve(handler())).resolves.toBeUndefined();
 	});
 
-	it("contributes nothing when both path and runtime bun are missing", async () => {
-		const handler = createBunSkillDiscoverHandler(probe(undefined));
-		await expect(handler()).resolves.toBeUndefined();
-	});
-
-	it("probes path bun version only once for the same handler", async () => {
-		let counter = 0;
-		const handler = createBunSkillDiscoverHandler({
-			probePathBunVersion: async () => {
-				counter += 1;
-				return "1.4.2";
-			},
-			runtimeBunVersion: () => undefined,
-		});
-		await handler();
-		await handler();
-		expect(counter).toBe(1);
+	it("contributes nothing when the kernel version is unparseable", async () => {
+		const handler = createBunSkillDiscoverHandler(() => "not-a-version");
+		await expect(Promise.resolve(handler())).resolves.toBeUndefined();
 	});
 });
 
 describe("registerBunSkillContribution", () => {
-	it("registers one resources_discover handler that contributes the gated-in skill", async () => {
+	it("registers one resources_discover handler that contributes on a bun >= 1.4 kernel", async () => {
 		const registrations: Array<{
 			event: "resources_discover";
 			handler: (
@@ -98,7 +76,7 @@ describe("registerBunSkillContribution", () => {
 			},
 		};
 
-		registerBunSkillContribution(pi, probe("1.4.2"));
+		registerBunSkillContribution(pi, () => "1.4.5");
 
 		expect(registrations).toHaveLength(1);
 		expect(registrations[0]?.event).toBe("resources_discover");


### PR DESCRIPTION
## Summary

Corrects the bun-1-4 builtin skill gate shipped in #1222, per review: the skill must be contributed **only when the js eval kernel itself runs Bun >= 1.4**. A node-kernel session never receives the skill — an external `bun` binary on PATH no longer rescues it.

- `skill-contribution.ts`: PATH `bun --version` probe deleted; the gate reads the in-process kernel runtime (`process.versions.bun`) through an injectable `BunKernelVersionSource`. The handler is now synchronous.
- `SKILL.md`: intro + rule 1 rewritten for the kernel-only reality — the kernel IS Bun, so `Bun.*` is called directly in js cells; `bash`/spawned `bun` stays only for CLI surfaces.
- **Repairs shipped asset corruption**: the merged SKILL.md carried a full duplicated document (frontmatter + capability map injected mid-token in rule 4) caused by an unescaped `$\`` in a `String.replace` replacement during asset generation. The asset test now pins single-document shape (one frontmatter block, one H1, one Operating rules section).
- CHANGELOG entry reworded to the kernel gate.

## Verification

- RED at the tests-only commit on mengmotaMac: 5 gate tests fail against the shipped PATH-probe impl (node-kernel case decisive), 0 import errors
- GREEN: full senpi-codemode suite at the impl commit on mengmotaMac (evidence in run logs)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the `bun-1-4` skill to sessions whose js eval kernel runs Bun >= 1.4, so node-kernel sessions no longer receive it via a `bun` binary on PATH.

**Bug Fixes**
- Removes the PATH probe and makes the `resources_discover` handler synchronous.
- Rewrites `SKILL.md` to call `Bun.*` directly in js cells; bash or spawned `bun` remains for CLI surfaces.
- Repairs a duplicated document in the shipped `SKILL.md` caused by an unescaped `$`` in asset generation and pins single-document shape in the asset test.

<sup>Written for commit 56cba26c5cafa856d1467f2f02349087603fd931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

