### PR TITLE
fix: bound cursor conversation caches and per-stream buffers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ### Fixed
 
+- Cursor conversation caches no longer grow for process lifetime: entries are dropped when their session's resources are cleaned up, the pre-rotation key is deleted when a poisoned conversation rotates to a fresh wire id, rotation records are count-bounded, and defensive byte/count bounds cap the state and blob stores for sessions that never dispose.
+
+- The Anthropic unsigned-thinking replay fallback capability is forgotten when its session's resources are cleaned up, so long-lived multi-session hosts stop collecting one entry per (session, model) that ever hit the invalid-signature retry.
+
+- The OpenAI Responses session websocket idle expiry re-arms itself when it fires while a socket is busy, and drops a busy entry whose socket already died, so a lost release can no longer pin a cached websocket forever.
+
 ### Removed
 
 ## [2026.8.30-3] - 2026-08-30

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Cursor conversation caches no longer grow for process lifetime: entries are dropped when their session's resources are cleaned up, the pre-rotation key is deleted when a poisoned conversation rotates to a fresh wire id, rotation records are count-bounded, and defensive byte/count bounds cap the state and blob stores for sessions that never dispose.
 
+- Cursor conversation cache eviction can no longer break a live request: blobs the in-flight request references are pinned for the duration of its stream (the byte cap evicts only unpinned blobs and reads promote recency, so the server's mid-turn `getBlobArgs` always resolves), the conversation count cap is enforced per owning session instead of across the process (one session's churn can no longer forget another session's conversation) and never evicts a conversation with a request in flight, and a new process-global blob ceiling (`PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES`, default 1 GiB) bounds all cached conversations together, shedding cold conversations first.
+
 - The Anthropic unsigned-thinking replay fallback capability is forgotten when its session's resources are cleaned up, so long-lived multi-session hosts stop collecting one entry per (session, model) that ever hit the invalid-signature retry.
 
 - The OpenAI Responses session websocket idle expiry re-arms itself when it fires while a socket is busy, and drops a busy entry whose socket already died, so a lost release can no longer pin a cached websocket forever.

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -9,6 +9,7 @@ import type {
 	RefusalStopDetails,
 } from "@anthropic-ai/sdk/resources/messages.js";
 import { calculateCost } from "../models.ts";
+import { registerSessionResourceCleanup } from "../session-resources.ts";
 import type {
 	AnthropicRefusalFallback,
 	Api,
@@ -281,6 +282,20 @@ type UnsignedThinkingReplay = "text" | "empty-signature";
 // A provider can reject its own empty signatures. Learn that capability for one
 // conversation without changing the shared model definition used by other sessions.
 const unsignedThinkingTextReplayFallbacks = new Set<string>();
+
+registerSessionResourceCleanup((sessionId?: string) => {
+	// One small entry per (session, base URL, model) that ever hit the fallback;
+	// drop the session's entries at teardown so long-lived hosts do not collect
+	// them for every session that ever ran.
+	if (sessionId === undefined) {
+		unsignedThinkingTextReplayFallbacks.clear();
+		return;
+	}
+	const prefix = `${sessionId}\u0000`;
+	for (const key of unsignedThinkingTextReplayFallbacks) {
+		if (key.startsWith(prefix)) unsignedThinkingTextReplayFallbacks.delete(key);
+	}
+});
 
 function unsignedThinkingFallbackKey(
 	model: Model<"anthropic-messages">,

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -22,6 +22,7 @@ import { create, fromBinary, fromJson, type JsonValue as PbJsonValue, toBinary, 
 import { ValueSchema } from "@bufbuild/protobuf/wkt";
 import { CURSOR_COMPOSER_PROMPT, isCursorComposerModel } from "../cursor/composer-prompt.ts";
 import { calculateCost } from "../models.ts";
+import { registerSessionResourceCleanup } from "../session-resources.ts";
 import type {
 	Api,
 	AssistantMessage,
@@ -320,7 +321,158 @@ const NOT_IMPLEMENTED_SUFFIX = "not implemented by this client";
 const NOT_IMPLEMENTED = "Not implemented by this client";
 /** Bare gRPC `resource_exhausted` end-streams (also inside a Connect error message). */
 const conversationStateCache = new Map<string, ConversationStateStructure>();
-const conversationBlobStores = new Map<string, Map<string, Uint8Array>>();
+const conversationBlobStores = new Map<string, ConversationBlobStore>();
+/** Cache key -> the senpi session that owns it, so session teardown can evict. */
+const conversationCacheKeySessions = new Map<string, string>();
+
+/**
+ * Defensive ceiling on how many conversations stay cached (#1024). Sessions
+ * that never dispose (raw SDK use without `sessionId`) would otherwise pin one
+ * full-history entry each for process lifetime. Eviction is FIFO by first use.
+ */
+const DEFAULT_CONVERSATION_CACHE_LIMIT = 64;
+/**
+ * Defensive ceiling on the bytes one conversation's blob store may retain.
+ * Blobs are content-addressed and every live turn's history is re-stored each
+ * request, so evicting from the cold end only drops blobs no longer referenced
+ * by the rebuilt conversation state (a server `getBlobArgs` for an evicted id
+ * degrades to the same empty reply as any missing blob).
+ */
+const DEFAULT_CONVERSATION_BLOB_LIMIT_BYTES = 256 * 1024 * 1024;
+
+function readPositiveIntEnv(raw: string | undefined, fallback: number): number {
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function conversationCacheLimit(): number {
+	return readPositiveIntEnv(process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT, DEFAULT_CONVERSATION_CACHE_LIMIT);
+}
+
+function conversationBlobLimitBytes(): number {
+	return readPositiveIntEnv(
+		process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES,
+		DEFAULT_CONVERSATION_BLOB_LIMIT_BYTES,
+	);
+}
+
+/**
+ * A conversation's blob store with byte accounting and recency-ordered
+ * eviction. `set` re-inserts existing keys so iteration order tracks "last
+ * stored" - every turn re-stores the blobs its rebuilt state still references,
+ * so the cold end of the map is exactly the dead weight (pre-compaction turns,
+ * superseded server pushes).
+ */
+class ConversationBlobStore extends Map<string, Uint8Array> {
+	private blobBytes = 0;
+
+	override set(key: string, value: Uint8Array): this {
+		const previous = super.get(key);
+		if (previous !== undefined) {
+			this.blobBytes -= previous.byteLength;
+			super.delete(key);
+		}
+		this.blobBytes += value.byteLength;
+		super.set(key, value);
+		this.trimToBudget();
+		return this;
+	}
+
+	override delete(key: string): boolean {
+		const existing = super.get(key);
+		if (existing === undefined) return super.delete(key);
+		this.blobBytes -= existing.byteLength;
+		return super.delete(key);
+	}
+
+	override clear(): void {
+		this.blobBytes = 0;
+		super.clear();
+	}
+
+	get totalBytes(): number {
+		return this.blobBytes;
+	}
+
+	private trimToBudget(): void {
+		const limit = conversationBlobLimitBytes();
+		if (this.blobBytes <= limit) return;
+		for (const [key, value] of this) {
+			if (this.blobBytes <= limit) break;
+			this.blobBytes -= value.byteLength;
+			super.delete(key);
+		}
+	}
+}
+
+function registerConversationCacheKey(sessionId: string | undefined, conversationId: string): void {
+	if (!sessionId) return;
+	conversationCacheKeySessions.set(conversationId, sessionId);
+}
+
+function forgetConversationCacheKey(conversationId: string): void {
+	conversationStateCache.delete(conversationId);
+	conversationBlobStores.delete(conversationId);
+	conversationCacheKeySessions.delete(conversationId);
+}
+
+function enforceConversationCacheLimit(newestKey: string): void {
+	const limit = conversationCacheLimit();
+	for (const key of conversationBlobStores.keys()) {
+		if (conversationBlobStores.size <= limit) return;
+		if (key === newestKey) continue;
+		forgetConversationCacheKey(key);
+	}
+}
+
+function getOrCreateConversationBlobStore(conversationId: string): ConversationBlobStore {
+	const existing = conversationBlobStores.get(conversationId);
+	if (existing) return existing;
+	const store = new ConversationBlobStore();
+	conversationBlobStores.set(conversationId, store);
+	enforceConversationCacheLimit(conversationId);
+	return store;
+}
+
+/**
+ * Drops every cache entry owned by `sessionId`. With no session id this is a
+ * global teardown and clears everything (mirrors the codex WS cleanup).
+ */
+function releaseConversationCacheForSession(sessionId?: string): void {
+	if (sessionId === undefined) {
+		conversationStateCache.clear();
+		conversationBlobStores.clear();
+		conversationCacheKeySessions.clear();
+		return;
+	}
+	for (const [key, owner] of conversationCacheKeySessions) {
+		if (owner !== sessionId) continue;
+		conversationStateCache.delete(key);
+		conversationBlobStores.delete(key);
+		conversationCacheKeySessions.delete(key);
+	}
+}
+
+registerSessionResourceCleanup((sessionId?: string) => {
+	releaseConversationCacheForSession(sessionId);
+});
+
+/** Size telemetry for the conversation caches (#1024 verification seam). */
+export function getCursorConversationCacheStats(): {
+	conversations: number;
+	states: number;
+	blobBytes: number;
+	keys: string[];
+} {
+	let blobBytes = 0;
+	for (const store of conversationBlobStores.values()) blobBytes += store.totalBytes;
+	return {
+		conversations: conversationBlobStores.size,
+		states: conversationStateCache.size,
+		blobBytes,
+		keys: [...conversationBlobStores.keys()],
+	};
+}
 /**
  * Base conversation id → rotated wire id. Cursor's backend can pin a
  * per-conversation rejection (bare `resource_exhausted`, zero tokens) to one
@@ -522,8 +674,8 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 
 				baseConversationId = options?.conversationId ?? options?.sessionId ?? randomUUID();
 				conversationId = rotationStore().getWireId(baseConversationId);
-				const blobStore = conversationBlobStores.get(conversationId) ?? new Map<string, Uint8Array>();
-				conversationBlobStores.set(conversationId, blobStore);
+				registerConversationCacheKey(options?.sessionId, conversationId);
+				const blobStore = getOrCreateConversationBlobStore(conversationId);
 				const cachedState = conversationStateCache.get(conversationId);
 				const { requestBytes, conversationState, requestedModel, modelDetails } = await buildGrpcRequest(
 					model,
@@ -905,6 +1057,12 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 							if (cached) conversationStateCache.set(decision.wireId, cached);
 							const blobs = conversationBlobStores.get(conversationId);
 							if (blobs) conversationBlobStores.set(decision.wireId, blobs);
+							registerConversationCacheKey(options?.sessionId, decision.wireId);
+							enforceConversationCacheLimit(decision.wireId);
+							// The rotated key fully replaces the old one: later attempts
+							// resolve through rotationStore().getWireId, so keeping the
+							// pre-rotation entries is a pure leak (#1024).
+							if (decision.wireId !== conversationId) forgetConversationCacheKey(conversationId);
 							retryAttempt = true;
 						} else {
 							message = CURSOR_CONVERSATION_POISONED_MESSAGE;

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -326,19 +326,33 @@ const conversationBlobStores = new Map<string, ConversationBlobStore>();
 const conversationCacheKeySessions = new Map<string, string>();
 
 /**
- * Defensive ceiling on how many conversations stay cached (#1024). Sessions
- * that never dispose (raw SDK use without `sessionId`) would otherwise pin one
- * full-history entry each for process lifetime. Eviction is FIFO by first use.
+ * Defensive ceiling on how many conversations stay cached (#1024), enforced
+ * PER OWNING SESSION: the maps are process-global, so a global cap would let
+ * one session's churn forget another session's live conversation key (its
+ * retry/resume then re-enters with empty state and silently loses history).
+ * Eviction is FIFO by first use within the overflowing session, never touching
+ * another session's keys nor a conversation with a request in flight.
  */
 const DEFAULT_CONVERSATION_CACHE_LIMIT = 64;
 /**
  * Defensive ceiling on the bytes one conversation's blob store may retain.
  * Blobs are content-addressed and every live turn's history is re-stored each
  * request, so evicting from the cold end only drops blobs no longer referenced
- * by the rebuilt conversation state (a server `getBlobArgs` for an evicted id
- * degrades to the same empty reply as any missing blob).
+ * by the rebuilt conversation state. Blobs the in-flight request references are
+ * pinned for the duration of the stream, because the server resolves them by id
+ * mid-turn and an evicted id would come back as an empty blob (silent context
+ * loss or a failed request).
  */
 const DEFAULT_CONVERSATION_BLOB_LIMIT_BYTES = 256 * 1024 * 1024;
+/**
+ * Ceiling on the blob bytes ALL cached conversations may retain in one process.
+ * The per-conversation cap alone multiplies out to (count cap x byte cap) per
+ * session, so this is the number that actually bounds the process. Trimming is
+ * cold-conversation-first and never touches a live conversation or a pinned
+ * blob, so it can only drop history that a later turn re-stores from
+ * `context.messages` anyway.
+ */
+const DEFAULT_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES = 1024 * 1024 * 1024;
 
 function readPositiveIntEnv(raw: string | undefined, fallback: number): number {
 	const parsed = Number(raw);
@@ -356,15 +370,33 @@ function conversationBlobLimitBytes(): number {
 	);
 }
 
+function conversationTotalBlobLimitBytes(): number {
+	return readPositiveIntEnv(
+		process.env.PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES,
+		DEFAULT_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES,
+	);
+}
+
 /**
- * A conversation's blob store with byte accounting and recency-ordered
- * eviction. `set` re-inserts existing keys so iteration order tracks "last
- * stored" - every turn re-stores the blobs its rebuilt state still references,
- * so the cold end of the map is exactly the dead weight (pre-compaction turns,
- * superseded server pushes).
+ * A conversation's blob store with byte accounting, true LRU ordering and
+ * pinning for the request currently being built or streamed.
+ *
+ * Both `set` and `get` re-insert the key, so iteration order is least-recently
+ * used first: the cold end is the dead weight (pre-compaction turns, superseded
+ * server pushes) while everything this turn touched sits at the hot end.
+ *
+ * While a request holds pins (`beginRequestPins` .. `releaseRequestPins`),
+ * every blob it stores or the server reads back is pinned and exempt from cap
+ * eviction. If the pinned set alone exceeds the budget the store stays
+ * temporarily over budget and logs once, rather than answering the server's
+ * `getBlobArgs` with an empty blob mid-turn; releasing the pins trims it back.
  */
 class ConversationBlobStore extends Map<string, Uint8Array> {
 	private blobBytes = 0;
+	private readonly pinnedKeys = new Set<string>();
+	/** Nesting depth of in-flight requests pinning into this store. */
+	private pinHolders = 0;
+	private warnedOverBudget = false;
 
 	override set(key: string, value: Uint8Array): this {
 		const previous = super.get(key);
@@ -374,12 +406,25 @@ class ConversationBlobStore extends Map<string, Uint8Array> {
 		}
 		this.blobBytes += value.byteLength;
 		super.set(key, value);
+		if (this.pinHolders > 0) this.pinnedKeys.add(key);
 		this.trimToBudget();
 		return this;
 	}
 
+	override get(key: string): Uint8Array | undefined {
+		const value = super.get(key);
+		if (value === undefined) return undefined;
+		// Recency promotion: a blob the server just asked for is live context, so
+		// it must not sit at the eviction end of the map.
+		super.delete(key);
+		super.set(key, value);
+		if (this.pinHolders > 0) this.pinnedKeys.add(key);
+		return value;
+	}
+
 	override delete(key: string): boolean {
 		const existing = super.get(key);
+		this.pinnedKeys.delete(key);
 		if (existing === undefined) return super.delete(key);
 		this.blobBytes -= existing.byteLength;
 		return super.delete(key);
@@ -387,6 +432,7 @@ class ConversationBlobStore extends Map<string, Uint8Array> {
 
 	override clear(): void {
 		this.blobBytes = 0;
+		this.pinnedKeys.clear();
 		super.clear();
 	}
 
@@ -394,14 +440,57 @@ class ConversationBlobStore extends Map<string, Uint8Array> {
 		return this.blobBytes;
 	}
 
+	get pinnedCount(): number {
+		return this.pinnedKeys.size;
+	}
+
+	/** Starts pinning everything the request touches; balanced by `releaseRequestPins`. */
+	beginRequestPins(): void {
+		this.pinHolders += 1;
+	}
+
+	/**
+	 * Evicts unpinned blobs, least recently used first, until at most `keepBytes`
+	 * remain in this store. Returns the bytes actually released.
+	 */
+	shedUnpinnedBytes(keepBytes: number): number {
+		let released = 0;
+		for (const [key, value] of this) {
+			if (this.blobBytes <= keepBytes) break;
+			if (this.pinnedKeys.has(key)) continue;
+			this.blobBytes -= value.byteLength;
+			released += value.byteLength;
+			super.delete(key);
+		}
+		return released;
+	}
+
+	/** Drops this request's pins once its stream settled, then re-applies the cap. */
+	releaseRequestPins(): void {
+		if (this.pinHolders === 0) return;
+		this.pinHolders -= 1;
+		if (this.pinHolders > 0) return;
+		this.pinnedKeys.clear();
+		this.warnedOverBudget = false;
+		this.trimToBudget();
+	}
+
 	private trimToBudget(): void {
 		const limit = conversationBlobLimitBytes();
 		if (this.blobBytes <= limit) return;
 		for (const [key, value] of this) {
 			if (this.blobBytes <= limit) break;
+			if (this.pinnedKeys.has(key)) continue;
 			this.blobBytes -= value.byteLength;
 			super.delete(key);
 		}
+		if (this.blobBytes <= limit || this.warnedOverBudget) return;
+		this.warnedOverBudget = true;
+		// Breaking the live request is worse than holding its working set: report
+		// the overshoot and keep every pinned blob resolvable until the turn ends.
+		console.warn(
+			`[cursor-agent] conversation blob store over budget: ${this.blobBytes} bytes pinned by the in-flight request exceed the ${limit} byte cap (${this.pinnedKeys.size} pinned blobs); the cap applies again when the stream settles`,
+		);
 	}
 }
 
@@ -416,21 +505,80 @@ function forgetConversationCacheKey(conversationId: string): void {
 	conversationCacheKeySessions.delete(conversationId);
 }
 
-function enforceConversationCacheLimit(newestKey: string): void {
+/**
+ * Conversation keys with a request in flight. A live conversation is never a
+ * cap-eviction candidate: its state and blobs are what the running stream (and
+ * its retry/resume attempt) reads back.
+ */
+const liveConversationKeys = new Map<string, number>();
+
+function retainLiveConversation(conversationId: string): void {
+	liveConversationKeys.set(conversationId, (liveConversationKeys.get(conversationId) ?? 0) + 1);
+}
+
+function releaseLiveConversation(conversationId: string): void {
+	const holders = liveConversationKeys.get(conversationId);
+	if (holders === undefined) return;
+	if (holders <= 1) liveConversationKeys.delete(conversationId);
+	else liveConversationKeys.set(conversationId, holders - 1);
+}
+
+/**
+ * Trims the overflowing session's own conversations, oldest first. Keys owned by
+ * other sessions are untouchable (the maps are process-global but the budget is
+ * per session), and neither the newest key nor any conversation with a request
+ * in flight is evictable. Keys with no owning session (raw SDK use without
+ * `sessionId`) share one bucket keyed by `undefined`.
+ */
+function enforceConversationCacheLimit(newestKey: string, sessionId?: string): void {
 	const limit = conversationCacheLimit();
-	for (const key of conversationBlobStores.keys()) {
-		if (conversationBlobStores.size <= limit) return;
+	const owner = sessionId ?? conversationCacheKeySessions.get(newestKey);
+	const ownedKeys = [...conversationBlobStores.keys()].filter(
+		(key) => conversationCacheKeySessions.get(key) === owner,
+	);
+	let owned = ownedKeys.length;
+	for (const key of ownedKeys) {
+		if (owned <= limit) return;
 		if (key === newestKey) continue;
+		if (liveConversationKeys.has(key)) continue;
 		forgetConversationCacheKey(key);
+		owned -= 1;
 	}
 }
 
-function getOrCreateConversationBlobStore(conversationId: string): ConversationBlobStore {
+/**
+ * Applies the process-global blob ceiling across every cached conversation.
+ * Cold conversations are shed first (least recently used key order); a live
+ * conversation is only shed after every cold one, and pinned blobs are never
+ * dropped, so an in-flight request keeps every id the server can ask for.
+ */
+function enforceConversationTotalBlobLimit(): void {
+	const limit = conversationTotalBlobLimitBytes();
+	let total = 0;
+	for (const store of conversationBlobStores.values()) total += store.totalBytes;
+	if (total <= limit) return;
+	const cold: [string, ConversationBlobStore][] = [];
+	const live: [string, ConversationBlobStore][] = [];
+	for (const entry of conversationBlobStores) {
+		(liveConversationKeys.has(entry[0]) ? live : cold).push(entry);
+	}
+	for (const [key, store] of [...cold, ...live]) {
+		if (total <= limit) break;
+		total -= store.shedUnpinnedBytes(Math.max(0, store.totalBytes - (total - limit)));
+		if (store.size === 0 && !liveConversationKeys.has(key)) forgetConversationCacheKey(key);
+	}
+	if (total <= limit) return;
+	console.warn(
+		`[cursor-agent] cursor conversation blobs total ${total} bytes over the ${limit} byte process ceiling; the remainder is pinned by in-flight requests and is released when their streams settle`,
+	);
+}
+
+function getOrCreateConversationBlobStore(conversationId: string, sessionId?: string): ConversationBlobStore {
 	const existing = conversationBlobStores.get(conversationId);
 	if (existing) return existing;
 	const store = new ConversationBlobStore();
 	conversationBlobStores.set(conversationId, store);
-	enforceConversationCacheLimit(conversationId);
+	enforceConversationCacheLimit(conversationId, sessionId);
 	return store;
 }
 
@@ -443,6 +591,9 @@ function releaseConversationCacheForSession(sessionId?: string): void {
 		conversationStateCache.clear();
 		conversationBlobStores.clear();
 		conversationCacheKeySessions.clear();
+		// An explicit global teardown owns the bookkeeping too; a stale live hold
+		// would otherwise make a future same-named key permanently unevictable.
+		liveConversationKeys.clear();
 		return;
 	}
 	for (const [key, owner] of conversationCacheKeySessions) {
@@ -666,6 +817,9 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				rejectH2 = reject;
 			});
 			let attemptSawCheckpoint = false;
+			// This attempt's live hold and blob pins, released when it settles.
+			let attemptLiveKey: string | undefined;
+			let attemptPinnedStore: ConversationBlobStore | undefined;
 			try {
 				const apiKey = options?.apiKey;
 				if (!apiKey) {
@@ -675,7 +829,14 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				baseConversationId = options?.conversationId ?? options?.sessionId ?? randomUUID();
 				conversationId = rotationStore().getWireId(baseConversationId);
 				registerConversationCacheKey(options?.sessionId, conversationId);
-				const blobStore = getOrCreateConversationBlobStore(conversationId);
+				// Claim the conversation before the cap can see it: the count cap never
+				// evicts a live key, and every blob this attempt touches stays pinned
+				// until the stream settles.
+				attemptLiveKey = conversationId;
+				retainLiveConversation(conversationId);
+				const blobStore = getOrCreateConversationBlobStore(conversationId, options?.sessionId);
+				attemptPinnedStore = blobStore;
+				blobStore.beginRequestPins();
 				const cachedState = conversationStateCache.get(conversationId);
 				const { requestBytes, conversationState, requestedModel, modelDetails } = await buildGrpcRequest(
 					model,
@@ -693,6 +854,9 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 				pinnedRequestedModel ??= requestedModel;
 				pinnedModelDetails ??= modelDetails;
 				conversationStateCache.set(conversationId, conversationState);
+				// This request's working set is pinned now, so the process ceiling can
+				// reclaim from cold conversations without touching what it needs.
+				enforceConversationTotalBlobLimit();
 				const requestContextTools = buildMcpToolDefinitions(context.tools);
 
 				const baseUrl = model.baseUrl || CURSOR_API_URL;
@@ -1058,7 +1222,7 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 							const blobs = conversationBlobStores.get(conversationId);
 							if (blobs) conversationBlobStores.set(decision.wireId, blobs);
 							registerConversationCacheKey(options?.sessionId, decision.wireId);
-							enforceConversationCacheLimit(decision.wireId);
+							enforceConversationCacheLimit(decision.wireId, options?.sessionId);
 							// The rotated key fully replaces the old one: later attempts
 							// resolve through rotationStore().getWireId, so keeping the
 							// pre-rotation entries is a pure leak (#1024).
@@ -1076,6 +1240,9 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 					stream.end();
 				}
 			} finally {
+				attemptPinnedStore?.releaseRequestPins();
+				if (attemptLiveKey !== undefined) releaseLiveConversation(attemptLiveKey);
+				if (attemptPinnedStore) enforceConversationTotalBlobLimit();
 				if (heartbeatTimer) {
 					clearInterval(heartbeatTimer);
 					heartbeatTimer = null;

--- a/packages/ai/src/api/cursor-conversation-rotation.ts
+++ b/packages/ai/src/api/cursor-conversation-rotation.ts
@@ -3,6 +3,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 export const MAX_CURSOR_CONVERSATION_ROTATIONS = 3;
+export const MAX_CURSOR_CONVERSATION_ROTATION_RECORDS = 512;
 export const CURSOR_CONVERSATION_POISONED_MESSAGE =
 	"Cursor conversation is poisoned for this session; use another provider";
 
@@ -39,6 +40,8 @@ export type ConversationRotationStore = {
 	shouldSurfaceBeforeRotating(baseId: string): boolean;
 	markSurfaced(baseId: string, currentWireId: string): void;
 	recordZeroTokenPoison(baseId: string, currentWireId: string): PoisonDecision;
+	/** Number of retained records (bounded; diagnostics for #1024). */
+	recordCount(): number;
 };
 
 export function isZeroTokenResourceExhausted(errorMessage: string, sawTokenDelta: boolean): boolean {
@@ -48,11 +51,28 @@ export function isZeroTokenResourceExhausted(errorMessage: string, sawTokenDelta
 export function createConversationRotationStore(options: {
 	readonly persistPath: string;
 	readonly randomId?: () => string;
+	readonly maxRecords?: number;
 }): ConversationRotationStore {
 	const randomId = options.randomId ?? randomUUID;
+	const maxRecords =
+		options.maxRecords ??
+		readRotationRecordLimit(process.env.PI_CURSOR_ROTATION_RECORD_LIMIT) ??
+		MAX_CURSOR_CONVERSATION_ROTATION_RECORDS;
 	const records = loadRecords(options.persistPath);
 
+	// #1024: records accumulate one per base conversation id for process
+	// lifetime (and each persist rewrites the whole file). Object key order is
+	// insertion order for these uuid-shaped ids, so the oldest records drop
+	// first. Poison memory survives process restarts via the persisted file;
+	// trimming only forgets the oldest ids, which re-derive cheaply (at most a
+	// surfaced 0-token RE per id).
+	const trimRecords = (): void => {
+		const keys = Object.keys(records);
+		for (let i = 0; i < keys.length - maxRecords; i++) delete records[keys[i]];
+	};
+
 	const persist = (): void => {
+		trimRecords();
 		mkdirSync(dirname(options.persistPath), { recursive: true });
 		writeFileSync(options.persistPath, `${JSON.stringify(records, null, 2)}\n`);
 	};
@@ -91,6 +111,9 @@ export function createConversationRotationStore(options: {
 			records[baseId] = existing;
 			persist();
 		},
+		recordCount(): number {
+			return Object.keys(records).length;
+		},
 		recordZeroTokenPoison(baseId: string, currentWireId: string): PoisonDecision {
 			const existing = records[baseId] ?? {
 				wireId: currentWireId,
@@ -122,6 +145,11 @@ export function resolveConversationRotationPersistPath(env: NodeJS.ProcessEnv = 
 	const agentDir =
 		env.SENPI_CODING_AGENT_DIR ?? env.CODING_AGENT_DIR ?? `${(env.HOME ?? ".").replace(/\/$/, "")}/.senpi/agent`;
 	return `${agentDir.replace(/\/$/, "")}/cursor-conversation-ids.json`;
+}
+
+function readRotationRecordLimit(raw: string | undefined): number | undefined {
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined;
 }
 
 function loadRecords(persistPath: string): Record<string, MutableRecord> {

--- a/packages/ai/src/api/openai-responses.ts
+++ b/packages/ai/src/api/openai-responses.ts
@@ -47,7 +47,7 @@ interface WebSocketLike {
 	removeEventListener(type: WebSocketEventType, listener: WebSocketListener): void;
 }
 
-interface CachedWebSocketConnection {
+export interface CachedWebSocketConnection {
 	socket: WebSocketLike;
 	busy: boolean;
 	idleTimer?: ReturnType<typeof setTimeout>;
@@ -529,17 +529,37 @@ function closeWebSocketSilently(socket: WebSocketLike, code = 1000, reason = "do
 	} catch {}
 }
 
-function scheduleSessionWebSocketExpiry(sessionId: string, entry: CachedWebSocketConnection): void {
+/**
+ * Arms the idle-expiry for a cached session socket. A fire while the entry is
+ * busy must not strand the entry: the holder may never run the release path
+ * that schedules a fresh timer, and a cached-but-forgotten entry would pin its
+ * socket for process lifetime. A live busy socket is re-checked on the next
+ * tick; a dead one is dropped immediately because nothing can release it.
+ */
+export function scheduleSessionWebSocketExpiry(sessionId: string, entry: CachedWebSocketConnection): void {
 	if (entry.idleTimer) {
 		clearTimeout(entry.idleTimer);
 	}
 	entry.idleTimer = setTimeout(() => {
-		if (entry.busy) return;
+		if (entry.busy) {
+			if (!isWebSocketReusable(entry.socket)) {
+				closeWebSocketSilently(entry.socket, 1000, "idle_timeout_dead");
+				websocketSessionCache.delete(sessionId);
+				return;
+			}
+			scheduleSessionWebSocketExpiry(sessionId, entry);
+			return;
+		}
 		closeWebSocketSilently(entry.socket, 1000, "idle_timeout");
 		websocketSessionCache.delete(sessionId);
 	}, SESSION_WEBSOCKET_CACHE_TTL_MS);
 	const unref = (entry.idleTimer as { unref?: () => void }).unref;
 	if (unref) unref.call(entry.idleTimer);
+}
+
+/** Number of sessions holding a cached websocket (diagnostics). */
+export function getOpenAIResponsesWebSocketCacheSize(): number {
+	return websocketSessionCache.size;
 }
 
 async function connectWebSocket(url: string, headers: Headers, signal?: AbortSignal): Promise<WebSocketLike> {

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,26 @@
+## Cursor conversation cache eviction cannot break a live request (2026-08-31)
+
+### What changed
+
+- `api/cursor-agent.ts`: `ConversationBlobStore` is now a true LRU (reads promote recency, not only writes) and pins every blob the in-flight request stores or the server reads back, for the lifetime of that request's stream. The byte cap evicts unpinned blobs only; if the pinned working set alone exceeds the cap the store stays temporarily over budget and logs once, and trims back when the stream settles.
+- `api/cursor-agent.ts`: the conversation count cap is enforced per owning session (the `conversationId -> sessionId` map added in this pass) instead of over the process-global maps, and never evicts a conversation with a request in flight.
+- `api/cursor-agent.ts`: a process-global blob ceiling (`PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES`, default 1 GiB) bounds every cached conversation together, shedding cold conversations before live ones and never dropping a pinned blob.
+
+### Why
+
+- Cursor resolves history blobs by id mid-turn (`getBlobArgs`); the client answers a miss with an unset `blobData`. Immediate byte-cap eviction could drop a blob the request being built or streamed still references, so a long history silently lost context or failed the turn.
+- The count cap iterated the process-global maps, so session B's 65th conversation could forget session A's live conversation key; A's retry/resume then re-entered through the same global map and fell back to fresh empty state.
+- Per-conversation caps multiply (count cap x byte cap per session), so the only number that actually bounds the process is a shared ceiling.
+
+### Why an extension could not handle it
+
+- The conversation state cache, blob stores and their eviction are module-local to the Cursor adapter; no extension seam can observe a blob id the wire protocol resolves mid-stream.
+
+### Expected merge conflict zones
+
+- MEDIUM: `ConversationBlobStore` and the cache-limit helpers in `api/cursor-agent.ts`.
+- LOW: the per-attempt live/pin retain-release pair in the `stream` retry loop.
+
 ## Session-scoped provider state hygiene (2026-08-31)
 
 ### What changed

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,23 @@
+## Session-scoped provider state hygiene (2026-08-31)
+
+### What changed
+
+- `api/anthropic-messages.ts`: the learned unsigned-thinking text-replay fallback set is cleared for a session when its session resources are cleaned up (registered on the shared session-resource cleanup seam).
+- `api/openai-responses.ts`: the session-websocket idle expiry re-arms itself when it fires while the socket is busy, and drops a busy entry whose socket already died, so a lost release can no longer pin a cached websocket forever.
+
+### Why
+
+- Both collections previously lived for process lifetime once touched: long-lived multi-session hosts accumulated one fallback key per (session, base URL, model) that ever hit the invalid-signature retry, and a cached websocket whose release path never ran stayed pinned forever. Part of the #1024 memory-hygiene pass.
+
+### Why an extension could not handle it
+
+- The fallback set and the websocket session cache are module-local state inside the provider adapters; no extension seam can reach or dispose them.
+
+### Expected merge conflict zones
+
+- LOW: the fallback set declaration and its cleanup registration in `api/anthropic-messages.ts`.
+- LOW: the `scheduleSessionWebSocketExpiry` timer body in `api/openai-responses.ts`.
+
 ## Stop replaying the Anthropic server-side fallback marker (2026-08-30)
 
 ### What changed

--- a/packages/ai/test/anthropic-unsigned-thinking-replay.test.ts
+++ b/packages/ai/test/anthropic-unsigned-thinking-replay.test.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import type { AddressInfo } from "node:net";
 import { describe, expect, it } from "vitest";
 import { stream as streamAnthropic } from "../src/api/anthropic-messages.ts";
+import { cleanupSessionResources } from "../src/session-resources.ts";
 import type { AssistantMessage, Context, Model } from "../src/types.ts";
 
 interface RequestBody {
@@ -192,5 +193,47 @@ describe("Anthropic unsigned thinking replay fallback", () => {
 		}
 
 		expect(requestCount).toBe(1);
+	});
+
+	it("forgets the learned fallback when the session's resources are cleaned up", async () => {
+		const requests: RequestBody[] = [];
+		const server = createServer(async (request, response) => {
+			requests.push(await readBody(request));
+			if (requests.length === 1) {
+				writeInvalidSignature(response);
+			} else {
+				writeEmptySse(response);
+			}
+		});
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as AddressInfo;
+		const model = createModel(`http://127.0.0.1:${address.port}`);
+
+		try {
+			// First run learns the text-replay fallback (request 1 rejected, retry replayed as text).
+			await run(model, "session-cleanup");
+			// Second run consults the learned fallback and sends text up front.
+			await run(model, "session-cleanup");
+			expect(requests[2].messages?.[1]?.content[0]).toEqual({
+				type: "text",
+				text: "unsigned replayed thought",
+			});
+
+			cleanupSessionResources("session-cleanup");
+
+			// After teardown the capability is forgotten: the next request carries the
+			// empty signature again instead of the cached text replay.
+			await run(model, "session-cleanup");
+		} finally {
+			await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+			cleanupSessionResources("session-cleanup");
+		}
+
+		expect(requests).toHaveLength(4);
+		expect(requests[3].messages?.[1]?.content[0]).toEqual({
+			type: "thinking",
+			thinking: "unsigned replayed thought",
+			signature: "",
+		});
 	});
 });

--- a/packages/ai/test/cursor-conversation-blob-pinning.test.ts
+++ b/packages/ai/test/cursor-conversation-blob-pinning.test.ts
@@ -78,6 +78,28 @@ function createFrameReader(onFrame: (payload: Buffer) => void): (chunk: Buffer) 
 	};
 }
 
+const EVICTION_ENV_KEYS = [
+	"PI_CURSOR_CONVERSATION_CACHE_LIMIT",
+	"PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES",
+	"PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES",
+] as const;
+
+function captureEvictionEnv(): Record<string, string | undefined> {
+	const captured: Record<string, string | undefined> = {};
+	for (const key of EVICTION_ENV_KEYS) {
+		captured[key] = process.env[key];
+		delete process.env[key];
+	}
+	return captured;
+}
+
+function restoreEvictionEnv(captured: Record<string, string | undefined>): void {
+	for (const [key, value] of Object.entries(captured)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
 /** Awaits a predicate driven by other in-flight work, bounded by the test timeout. */
 async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
@@ -89,6 +111,16 @@ async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<vo
 
 let server: http2.Http2Server | undefined;
 let sessions: http2.ServerHttp2Session[] = [];
+
+async function closeServer(): Promise<void> {
+	if (!server) return;
+	const closing = server;
+	server = undefined;
+	for (const session of sessions.splice(0)) {
+		session.destroy();
+	}
+	await new Promise<void>((resolve) => closing.close(() => resolve()));
+}
 
 async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): Promise<string> {
 	server = http2.createServer();
@@ -166,28 +198,14 @@ describe("cursor-agent blob pinning for the in-flight request (#1024)", () => {
 
 	beforeEach(() => {
 		process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-pin-")), "ids.json");
-		originalEnv = {
-			PI_CURSOR_CONVERSATION_CACHE_LIMIT: process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT,
-			PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES: process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES,
-		};
-		delete process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT;
-		delete process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES;
+		originalEnv = captureEvictionEnv();
 		cleanupSessionResources();
 	});
 
 	afterEach(async () => {
-		for (const [key, value] of Object.entries(originalEnv)) {
-			if (value === undefined) delete process.env[key];
-			else process.env[key] = value;
-		}
+		restoreEvictionEnv(originalEnv);
 		cleanupSessionResources();
-		if (!server) return;
-		const closing = server;
-		server = undefined;
-		for (const session of sessions.splice(0)) {
-			session.destroy();
-		}
-		await new Promise<void>((resolve) => closing.close(() => resolve()));
+		await closeServer();
 	});
 
 	it("resolves every blob the in-flight request references even past the byte budget", async () => {
@@ -247,6 +265,27 @@ describe("cursor-agent blob pinning for the in-flight request (#1024)", () => {
 		// are released and the cold end is trimmed back to the cap.
 		expect(getCursorConversationCacheStats().blobBytes).toBeLessThanOrEqual(4096);
 	});
+
+	it("holds every cached conversation under the process-global blob ceiling", async () => {
+		// Per-conversation cap generous, process ceiling tight: the ceiling is what
+		// bounds the process once many settled conversations are cached.
+		process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES = String(4 * 1024 * 1024);
+		process.env.PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES = String(64 * 1024);
+		const baseUrl = await startServer((stream) => {
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+
+		for (const conversationId of ["ceiling-1", "ceiling-2", "ceiling-3", "ceiling-4"]) {
+			await runStream(baseUrl, {
+				sessionId: "sess-ceiling",
+				conversationId,
+				messages: buildLongHistory(4, 8_000),
+			});
+		}
+
+		expect(getCursorConversationCacheStats().blobBytes).toBeLessThanOrEqual(64 * 1024);
+	});
 });
 
 describe("cursor-agent per-session conversation cache cap (#1024)", () => {
@@ -254,28 +293,14 @@ describe("cursor-agent per-session conversation cache cap (#1024)", () => {
 
 	beforeEach(() => {
 		process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-pin-")), "ids.json");
-		originalEnv = {
-			PI_CURSOR_CONVERSATION_CACHE_LIMIT: process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT,
-			PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES: process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES,
-		};
-		delete process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT;
-		delete process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES;
+		originalEnv = captureEvictionEnv();
 		cleanupSessionResources();
 	});
 
 	afterEach(async () => {
-		for (const [key, value] of Object.entries(originalEnv)) {
-			if (value === undefined) delete process.env[key];
-			else process.env[key] = value;
-		}
+		restoreEvictionEnv(originalEnv);
 		cleanupSessionResources();
-		if (!server) return;
-		const closing = server;
-		server = undefined;
-		for (const session of sessions.splice(0)) {
-			session.destroy();
-		}
-		await new Promise<void>((resolve) => closing.close(() => resolve()));
+		await closeServer();
 	});
 
 	it("never evicts another session's conversations when one session overflows", async () => {

--- a/packages/ai/test/cursor-conversation-blob-pinning.test.ts
+++ b/packages/ai/test/cursor-conversation-blob-pinning.test.ts
@@ -1,0 +1,332 @@
+import { mkdtempSync } from "node:fs";
+import * as http2 from "node:http2";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	AgentClientMessageSchema,
+	AgentServerMessageSchema,
+	GetBlobArgsSchema,
+	KvServerMessageSchema,
+} from "../src/api/cursor-agent/gen/agent_pb.ts";
+import {
+	frameConnectMessage,
+	getCursorConversationCacheStats,
+	stream as streamCursorAgent,
+} from "../src/api/cursor-agent.ts";
+import { cleanupSessionResources } from "../src/session-resources.ts";
+import type { Message, Model } from "../src/types.ts";
+
+const neverAbortedSignal = new AbortController().signal;
+
+function buildModel(baseUrl: string): Model<"cursor-agent"> {
+	return {
+		id: "claude-4.6-opus-high",
+		name: "Opus 4.6",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	};
+}
+
+function turnEndedFrame(): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: { case: "interactionUpdate", value: { message: { case: "turnEnded", value: {} } } },
+			}),
+		),
+	);
+}
+
+function getBlobArgsFrame(id: number, blobId: Uint8Array): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: {
+					case: "kvServerMessage",
+					value: create(KvServerMessageSchema, {
+						id,
+						message: { case: "getBlobArgs", value: create(GetBlobArgsSchema, { blobId }) },
+					}),
+				},
+			}),
+		),
+	);
+}
+
+/** Reassembles Connect frames from an HTTP/2 stream's chunks. */
+function createFrameReader(onFrame: (payload: Buffer) => void): (chunk: Buffer) => void {
+	let buffer = Buffer.alloc(0);
+	return (chunk: Buffer) => {
+		buffer = Buffer.concat([buffer, chunk]);
+		while (buffer.length >= 5) {
+			const length = buffer.readUInt32BE(1);
+			if (buffer.length < 5 + length) return;
+			onFrame(buffer.subarray(5, 5 + length));
+			buffer = buffer.subarray(5 + length);
+		}
+	};
+}
+
+/** Awaits a predicate driven by other in-flight work, bounded by the test timeout. */
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() > deadline) throw new Error("waitFor timed out");
+		await new Promise((resolve) => setImmediate(resolve));
+	}
+}
+
+let server: http2.Http2Server | undefined;
+let sessions: http2.ServerHttp2Session[] = [];
+
+async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): Promise<string> {
+	server = http2.createServer();
+	sessions = [];
+	server.on("session", (session) => {
+		sessions.push(session);
+	});
+	server.on("stream", (stream: http2.ServerHttp2Stream) => {
+		stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+		handler(stream);
+	});
+	await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+	const address = server.address() as AddressInfo;
+	return `http://127.0.0.1:${address.port}`;
+}
+
+async function runStream(
+	baseUrl: string,
+	options: { sessionId: string; conversationId?: string; messages?: Message[] },
+): Promise<void> {
+	const result = streamCursorAgent(
+		buildModel(baseUrl),
+		{ messages: options.messages ?? [{ role: "user", content: "hello", timestamp: 0 }] },
+		{
+			apiKey: "test-token",
+			sessionId: options.sessionId,
+			conversationId: options.conversationId,
+			signal: neverAbortedSignal,
+		},
+	);
+	for await (const _event of result) {
+		// drain
+	}
+	await result.result();
+}
+
+/** History big enough that its blobs alone blow past a small byte budget. */
+function buildLongHistory(turns: number, filler: number): Message[] {
+	const messages: Message[] = [];
+	for (let turn = 0; turn < turns; turn++) {
+		messages.push({ role: "user", content: `ask ${turn} ${"q".repeat(filler)}`, timestamp: turn });
+		messages.push({
+			role: "assistant",
+			content: [{ type: "text", text: `answer ${turn} ${"a".repeat(filler)}` }],
+			timestamp: turn,
+			api: "cursor-agent",
+			provider: "cursor",
+			model: "claude-4.6-opus-high",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+		});
+	}
+	messages.push({ role: "user", content: "final question", timestamp: turns });
+	return messages;
+}
+
+/** Every blob id the request's conversation state references. */
+function collectRequestBlobIds(frame: Buffer): Uint8Array[] {
+	const clientMessage = fromBinary(AgentClientMessageSchema, frame);
+	if (clientMessage.message.case !== "runRequest") return [];
+	const state = clientMessage.message.value.conversationState;
+	if (!state) return [];
+	return [...state.rootPromptMessagesJson, ...state.turns];
+}
+
+describe("cursor-agent blob pinning for the in-flight request (#1024)", () => {
+	let originalEnv: Record<string, string | undefined>;
+
+	beforeEach(() => {
+		process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-pin-")), "ids.json");
+		originalEnv = {
+			PI_CURSOR_CONVERSATION_CACHE_LIMIT: process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT,
+			PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES: process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES,
+		};
+		delete process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT;
+		delete process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES;
+		cleanupSessionResources();
+	});
+
+	afterEach(async () => {
+		for (const [key, value] of Object.entries(originalEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		cleanupSessionResources();
+		if (!server) return;
+		const closing = server;
+		server = undefined;
+		for (const session of sessions.splice(0)) {
+			session.destroy();
+		}
+		await new Promise<void>((resolve) => closing.close(() => resolve()));
+	});
+
+	it("resolves every blob the in-flight request references even past the byte budget", async () => {
+		// The pinned history alone exceeds the cap, so a cap that evicts live
+		// references would answer at least one getBlobArgs with an empty blob.
+		process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES = "4096";
+		const misses: string[] = [];
+		let requested = 0;
+		const baseUrl = await startServer((stream) => {
+			let asked = false;
+			const answers = new Map<number, Uint8Array>();
+			const readFrame = createFrameReader((payload) => {
+				const clientMessage = fromBinary(AgentClientMessageSchema, payload);
+				if (clientMessage.message.case === "kvClientMessage") {
+					const kv = clientMessage.message.value;
+					if (kv.message.case === "getBlobResult") {
+						const data = kv.message.value.blobData;
+						if (!data || data.byteLength === 0) misses.push(String(kv.id));
+						answers.set(kv.id, data ?? new Uint8Array());
+						if (answers.size === requested) {
+							stream.write(turnEndedFrame());
+							stream.end();
+						}
+					}
+					return;
+				}
+				if (asked) return;
+				asked = true;
+				const blobIds = collectRequestBlobIds(payload);
+				requested = blobIds.length;
+				expect(requested).toBeGreaterThan(4);
+				blobIds.forEach((blobId, index) => {
+					stream.write(getBlobArgsFrame(index + 1, blobId));
+				});
+			});
+			stream.on("data", readFrame);
+		});
+
+		await runStream(baseUrl, {
+			sessionId: "sess-pinned",
+			messages: buildLongHistory(8, 2_000),
+		});
+
+		expect(misses).toEqual([]);
+	});
+
+	it("drops the pins once the stream settles so the byte cap applies again", async () => {
+		process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES = "4096";
+		const baseUrl = await startServer((stream) => {
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+
+		await runStream(baseUrl, { sessionId: "sess-unpin", messages: buildLongHistory(8, 2_000) });
+
+		// Over budget only while the request is in flight: once it settles the pins
+		// are released and the cold end is trimmed back to the cap.
+		expect(getCursorConversationCacheStats().blobBytes).toBeLessThanOrEqual(4096);
+	});
+});
+
+describe("cursor-agent per-session conversation cache cap (#1024)", () => {
+	let originalEnv: Record<string, string | undefined>;
+
+	beforeEach(() => {
+		process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-pin-")), "ids.json");
+		originalEnv = {
+			PI_CURSOR_CONVERSATION_CACHE_LIMIT: process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT,
+			PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES: process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES,
+		};
+		delete process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT;
+		delete process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES;
+		cleanupSessionResources();
+	});
+
+	afterEach(async () => {
+		for (const [key, value] of Object.entries(originalEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		cleanupSessionResources();
+		if (!server) return;
+		const closing = server;
+		server = undefined;
+		for (const session of sessions.splice(0)) {
+			session.destroy();
+		}
+		await new Promise<void>((resolve) => closing.close(() => resolve()));
+	});
+
+	it("never evicts another session's conversations when one session overflows", async () => {
+		process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT = "2";
+		const baseUrl = await startServer((stream) => {
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+
+		await runStream(baseUrl, { sessionId: "sess-a", conversationId: "a-1" });
+		await runStream(baseUrl, { sessionId: "sess-a", conversationId: "a-2" });
+		for (const conversationId of ["b-1", "b-2", "b-3", "b-4"]) {
+			await runStream(baseUrl, { sessionId: "sess-b", conversationId });
+		}
+
+		const keys = getCursorConversationCacheStats().keys;
+		expect(keys).toContain("a-1");
+		expect(keys).toContain("a-2");
+		expect(keys.filter((key) => key.startsWith("b-")).length).toBe(2);
+	});
+
+	it("never evicts a session's own live conversation when that session overflows", async () => {
+		process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT = "2";
+		let releaseLive: (() => void) | undefined;
+		const baseUrl = await startServer((stream) => {
+			const readFrame = createFrameReader((payload) => {
+				const clientMessage = fromBinary(AgentClientMessageSchema, payload);
+				if (clientMessage.message.case !== "runRequest") return;
+				const conversationId = clientMessage.message.value.conversationId;
+				if (conversationId !== "live-1") {
+					stream.write(turnEndedFrame());
+					stream.end();
+					return;
+				}
+				releaseLive = () => {
+					stream.write(turnEndedFrame());
+					stream.end();
+				};
+			});
+			stream.on("data", readFrame);
+		});
+
+		const live = runStream(baseUrl, { sessionId: "sess-live", conversationId: "live-1" });
+		// Wait for the live request to register its conversation before overflowing.
+		await waitFor(() => getCursorConversationCacheStats().keys.includes("live-1"));
+		for (const conversationId of ["fill-1", "fill-2", "fill-3"]) {
+			await runStream(baseUrl, { sessionId: "sess-live", conversationId });
+		}
+		expect(getCursorConversationCacheStats().keys).toContain("live-1");
+		await waitFor(() => releaseLive !== undefined);
+		releaseLive?.();
+		await live;
+	});
+});

--- a/packages/ai/test/cursor-conversation-cache-eviction.test.ts
+++ b/packages/ai/test/cursor-conversation-cache-eviction.test.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync } from "node:fs";
+import * as http2 from "node:http2";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { create, toBinary } from "@bufbuild/protobuf";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { AgentServerMessageSchema } from "../src/api/cursor-agent/gen/agent_pb.ts";
+import {
+	frameConnectMessage,
+	getCursorConversationCacheStats,
+	stream as streamCursorAgent,
+} from "../src/api/cursor-agent.ts";
+import { cleanupSessionResources } from "../src/session-resources.ts";
+import type { Model } from "../src/types.ts";
+
+process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-cache-")), "ids.json");
+
+const neverAbortedSignal = new AbortController().signal;
+const CONNECT_END_STREAM_FLAG = 0b00000010;
+
+function buildModel(baseUrl: string): Model<"cursor-agent"> {
+	return {
+		id: "claude-4.6-opus-high",
+		name: "Opus 4.6",
+		api: "cursor-agent",
+		provider: "cursor",
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 64_000,
+	};
+}
+
+function turnEndedFrame(): Buffer {
+	return frameConnectMessage(
+		toBinary(
+			AgentServerMessageSchema,
+			create(AgentServerMessageSchema, {
+				message: { case: "interactionUpdate", value: { message: { case: "turnEnded", value: {} } } },
+			}),
+		),
+	);
+}
+
+function endStreamErrorFrame(code: string, message: string): Buffer {
+	return frameConnectMessage(
+		new TextEncoder().encode(JSON.stringify({ error: { code, message } })),
+		CONNECT_END_STREAM_FLAG,
+	);
+}
+
+let server: http2.Http2Server | undefined;
+let sessions: http2.ServerHttp2Session[] = [];
+
+async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): Promise<string> {
+	server = http2.createServer();
+	sessions = [];
+	// Each stream() call leaves an idle h2 session behind; server.close() waits
+	// for every session to end, so track and destroy them at teardown.
+	server.on("session", (session) => {
+		sessions.push(session);
+	});
+	server.on("stream", (stream: http2.ServerHttp2Stream) => {
+		stream.respond({ ":status": 200, "content-type": "application/connect+proto" });
+		handler(stream);
+	});
+	await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve));
+	const address = server.address() as AddressInfo;
+	return `http://127.0.0.1:${address.port}`;
+}
+
+async function runStream(baseUrl: string, sessionId: string, userContent = "hello") {
+	const result = streamCursorAgent(
+		buildModel(baseUrl),
+		{ messages: [{ role: "user", content: userContent, timestamp: 0 }] },
+		{ apiKey: "test-token", sessionId, signal: neverAbortedSignal },
+	);
+	for await (const _event of result) {
+		// drain
+	}
+	return await result.result();
+}
+
+describe("cursor-agent conversation cache eviction (#1024)", () => {
+	let originalEnv: Record<string, string | undefined>;
+
+	beforeEach(() => {
+		// Rotation state is persisted per base conversation id, so each test gets
+		// its own store; the module-level conversation caches are shared, so a
+		// no-id cleanup (global teardown) resets them between tests.
+		process.env.CURSOR_CONVERSATION_ID_STORE = join(mkdtempSync(join(tmpdir(), "cursor-cache-")), "ids.json");
+		originalEnv = {
+			PI_CURSOR_CONVERSATION_CACHE_LIMIT: process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT,
+			PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES: process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES,
+		};
+		delete process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT;
+		delete process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES;
+		cleanupSessionResources();
+	});
+
+	afterEach(async () => {
+		for (const [key, value] of Object.entries(originalEnv)) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+		cleanupSessionResources();
+		if (!server) return;
+		const closing = server;
+		server = undefined;
+		for (const session of sessions.splice(0)) {
+			session.destroy();
+		}
+		await new Promise<void>((resolve) => closing.close(() => resolve()));
+	});
+
+	it("drops only the cleaned-up session's conversation state and blobs", async () => {
+		const baseUrl = await startServer((stream) => {
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+		await runStream(baseUrl, "sess-cleanup-a");
+		await runStream(baseUrl, "sess-cleanup-b");
+		expect(getCursorConversationCacheStats().keys).toEqual(
+			expect.arrayContaining(["sess-cleanup-a", "sess-cleanup-b"]),
+		);
+		expect(getCursorConversationCacheStats().states).toBe(2);
+
+		cleanupSessionResources("sess-cleanup-a");
+
+		const stats = getCursorConversationCacheStats();
+		expect(stats.keys).toEqual(["sess-cleanup-b"]);
+		expect(stats.conversations).toBe(1);
+		expect(stats.states).toBe(1);
+		expect(stats.blobBytes).toBeGreaterThan(0);
+	});
+
+	it("deletes the pre-rotation key when a poisoned conversation rotates", async () => {
+		let runs = 0;
+		const baseUrl = await startServer((stream) => {
+			runs += 1;
+			if (runs <= 2) {
+				stream.write(endStreamErrorFrame("resource_exhausted", "Error"));
+				stream.end();
+				return;
+			}
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+		// Run 1: first 0-token RE surfaces without rotating (session compacts).
+		const first = await runStream(baseUrl, "sess-rotate-cache");
+		expect(first.stopReason).toBe("error");
+		// Run 2: the surfaced-again RE rotates in-call and the retry succeeds.
+		const second = await runStream(baseUrl, "sess-rotate-cache");
+		expect(second.stopReason).not.toBe("error");
+		expect(runs).toBe(3);
+
+		const stats = getCursorConversationCacheStats();
+		expect(stats.conversations).toBe(1);
+		expect(stats.states).toBe(1);
+		expect(stats.keys).not.toContain("sess-rotate-cache");
+	});
+
+	it("caps the number of cached conversations, evicting the oldest first", async () => {
+		process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT = "3";
+		const baseUrl = await startServer((stream) => {
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+		for (const sessionId of ["cap-1", "cap-2", "cap-3", "cap-4", "cap-5"]) {
+			await runStream(baseUrl, sessionId);
+		}
+
+		const stats = getCursorConversationCacheStats();
+		expect(stats.conversations).toBe(3);
+		expect(stats.states).toBe(3);
+		expect(stats.keys).not.toContain("cap-1");
+		expect(stats.keys).not.toContain("cap-2");
+		expect(stats.keys).toEqual(["cap-3", "cap-4", "cap-5"]);
+	});
+
+	it("caps the bytes one conversation's blob store retains", async () => {
+		process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES = "4096";
+		const baseUrl = await startServer((stream) => {
+			stream.write(turnEndedFrame());
+			stream.end();
+		});
+		await runStream(baseUrl, "sess-blob-cap", `big payload ${"x".repeat(200_000)}`);
+
+		const stats = getCursorConversationCacheStats();
+		expect(stats.keys).toEqual(["sess-blob-cap"]);
+		expect(stats.blobBytes).toBeLessThanOrEqual(4096);
+	});
+});

--- a/packages/ai/test/cursor-conversation-cache-eviction.test.ts
+++ b/packages/ai/test/cursor-conversation-cache-eviction.test.ts
@@ -72,11 +72,11 @@ async function startServer(handler: (stream: http2.ServerHttp2Stream) => void): 
 	return `http://127.0.0.1:${address.port}`;
 }
 
-async function runStream(baseUrl: string, sessionId: string, userContent = "hello") {
+async function runStream(baseUrl: string, sessionId: string, userContent = "hello", conversationId?: string) {
 	const result = streamCursorAgent(
 		buildModel(baseUrl),
 		{ messages: [{ role: "user", content: userContent, timestamp: 0 }] },
-		{ apiKey: "test-token", sessionId, signal: neverAbortedSignal },
+		{ apiKey: "test-token", sessionId, conversationId, signal: neverAbortedSignal },
 	);
 	for await (const _event of result) {
 		// drain
@@ -95,9 +95,11 @@ describe("cursor-agent conversation cache eviction (#1024)", () => {
 		originalEnv = {
 			PI_CURSOR_CONVERSATION_CACHE_LIMIT: process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT,
 			PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES: process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES,
+			PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES: process.env.PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES,
 		};
 		delete process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT;
 		delete process.env.PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES;
+		delete process.env.PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES;
 		cleanupSessionResources();
 	});
 
@@ -163,14 +165,17 @@ describe("cursor-agent conversation cache eviction (#1024)", () => {
 		expect(stats.keys).not.toContain("sess-rotate-cache");
 	});
 
-	it("caps the number of cached conversations, evicting the oldest first", async () => {
+	it("caps the number of conversations one session caches, evicting the oldest first", async () => {
+		// The cap is per owning session: one session's churn must never forget
+		// another session's conversation, so the overflow is driven from a single
+		// session cycling conversation ids.
 		process.env.PI_CURSOR_CONVERSATION_CACHE_LIMIT = "3";
 		const baseUrl = await startServer((stream) => {
 			stream.write(turnEndedFrame());
 			stream.end();
 		});
-		for (const sessionId of ["cap-1", "cap-2", "cap-3", "cap-4", "cap-5"]) {
-			await runStream(baseUrl, sessionId);
+		for (const conversationId of ["cap-1", "cap-2", "cap-3", "cap-4", "cap-5"]) {
+			await runStream(baseUrl, "sess-cap", "hello", conversationId);
 		}
 
 		const stats = getCursorConversationCacheStats();

--- a/packages/ai/test/cursor-conversation-rotation.test.ts
+++ b/packages/ai/test/cursor-conversation-rotation.test.ts
@@ -76,4 +76,22 @@ describe("cursor conversation rotation", () => {
 			}),
 		).toBe("/tmp/store.json");
 	});
+
+	it("bounds the number of retained records, dropping the oldest first (#1024)", () => {
+		const persistPath = storePath();
+		const store = createConversationRotationStore({
+			persistPath,
+			randomId: () => `wire-${Math.random()}`,
+			maxRecords: 3,
+		});
+		for (const baseId of ["rec-1", "rec-2", "rec-3", "rec-4", "rec-5"]) {
+			store.markSurfaced(baseId, baseId);
+		}
+		expect(store.recordCount()).toBe(3);
+		expect(store.shouldSurfaceBeforeRotating("rec-1")).toBe(true);
+		expect(store.shouldSurfaceBeforeRotating("rec-2")).toBe(true);
+		// The oldest records were trimmed from memory and from the persisted file.
+		const persisted = JSON.parse(readFileSync(persistPath, "utf8")) as Record<string, unknown>;
+		expect(Object.keys(persisted).sort()).toEqual(["rec-3", "rec-4", "rec-5"]);
+	});
 });

--- a/packages/ai/test/openai-responses-websocket-expiry.test.ts
+++ b/packages/ai/test/openai-responses-websocket-expiry.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type CachedWebSocketConnection, scheduleSessionWebSocketExpiry } from "../src/api/openai-responses.ts";
+
+const SESSION_WEBSOCKET_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type WebSocketEventType = "open" | "message" | "error" | "close";
+type WebSocketListener = (event: unknown) => void;
+
+class FakeWebSocket {
+	readyState: number;
+	closes: Array<{ code?: number; reason?: string }> = [];
+
+	constructor(readyState = 1) {
+		this.readyState = readyState;
+	}
+
+	close(code?: number, reason?: string): void {
+		this.readyState = 3;
+		this.closes.push({ code, reason });
+	}
+
+	send(): void {}
+
+	addEventListener(_type: WebSocketEventType, _listener: WebSocketListener): void {}
+
+	removeEventListener(_type: WebSocketEventType, _listener: WebSocketListener): void {}
+}
+
+describe("OpenAI Responses session websocket idle expiry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("re-arms the expiry when it fires while the socket is busy, then evicts once idle", () => {
+		const socket = new FakeWebSocket(1);
+		const entry: CachedWebSocketConnection = { socket, busy: true };
+		scheduleSessionWebSocketExpiry("sess-busy-rearm", entry);
+
+		// TTL fires mid-request: the entry must survive (in-flight) but the
+		// expiry must keep checking instead of dying with the fired timer.
+		vi.advanceTimersByTime(SESSION_WEBSOCKET_CACHE_TTL_MS + 1);
+		expect(socket.closes).toHaveLength(0);
+
+		entry.busy = false;
+		vi.advanceTimersByTime(SESSION_WEBSOCKET_CACHE_TTL_MS + 1);
+		expect(socket.closes).toEqual([{ code: 1000, reason: "idle_timeout" }]);
+	});
+
+	it("evicts a busy entry whose socket died, so a lost release cannot pin it", () => {
+		const socket = new FakeWebSocket(3);
+		const entry: CachedWebSocketConnection = { socket, busy: true };
+		scheduleSessionWebSocketExpiry("sess-busy-dead", entry);
+
+		vi.advanceTimersByTime(SESSION_WEBSOCKET_CACHE_TTL_MS + 1);
+		expect(socket.closes).toEqual([{ code: 1000, reason: "idle_timeout_dead" }]);
+	});
+
+	it("closes and drops an idle entry at the TTL", () => {
+		const socket = new FakeWebSocket(1);
+		const entry: CachedWebSocketConnection = { socket, busy: false };
+		scheduleSessionWebSocketExpiry("sess-idle", entry);
+
+		vi.advanceTimersByTime(SESSION_WEBSOCKET_CACHE_TTL_MS + 1);
+		expect(socket.closes).toEqual([{ code: 1000, reason: "idle_timeout" }]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 - The shared multi-session RPC host now reclaims occupancy on its own: sessions idle beyond a configurable window are evicted through the normal close path (never one with an active turn or running session-owned bash), `open_session` beyond a configurable concurrent cap fails with `too_many_sessions` (path attach stays exempt), and a host with zero open sessions for a configurable window exits cleanly instead of residing forever. Defaults: 30-minute idle eviction, 8 concurrent sessions, 15-minute empty-host exit, overridable via `SENPI_RPC_SESSION_IDLE_EVICTION_MS`, `SENPI_RPC_MAX_SESSIONS`, and `SENPI_RPC_HOST_EMPTY_EXIT_MS` ([#1226](https://github.com/code-yeongyu/senpi/pull/1226)).
 
+- TTSR stream buffers keep only a tail window sized above the longest rule pattern instead of the whole turn's stream, and are cleared when a message completes, so long agent turns no longer retain (and re-concatenate) their full streamed text.
+
+- The claude-sdk-oauth session registry derives entry generations from a monotonic counter instead of a per-session-id map, so close/reopen cycles keep stale async work gated while dropping the unbounded id-keyed bookkeeping.
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry.ts
@@ -148,7 +148,15 @@ function evictable(entry: ClaudeSdkOauthSessionEntry): boolean {
 
 export class ClaudeSdkOauthSessionRegistry {
 	private readonly entries = new Map<string, ClaudeSdkOauthSessionEntry>();
-	private readonly generations = new Map<string, number>();
+	/**
+	 * Monotonic per-registry generation counter. Numbers are never reused for
+	 * a session id, so stale async work gated on `isCurrentGeneration` cannot be
+	 * mistaken for current after a close/reopen cycle. A per-id map of last-used
+	 * numbers would grow once per distinct session id for process lifetime;
+	 * this counter provides the same (stronger, process-wide) uniqueness with no
+	 * residue at all.
+	 */
+	private generationCounter = 0;
 	private readonly reaper = new SessionReapScheduler({
 		now: () => activeSessionRegistryBoundary.now(),
 		scheduleTimer: (callback, delayMs) => activeSessionRegistryBoundary.scheduleReap(callback, delayMs),
@@ -182,7 +190,7 @@ export class ClaudeSdkOauthSessionRegistry {
 		this.evictExpired();
 		this.ensureCapacity();
 		const now = activeSessionRegistryBoundary.now();
-		const generation = (this.generations.get(input.senpiSessionId) ?? 0) + 1;
+		const generation = ++this.generationCounter;
 		const sdkSessionId = input.resume?.sdkSessionId ?? createSessionUuid(now);
 		const inputController = new StreamingInputController();
 		const lineageOptions = input.resume
@@ -229,7 +237,6 @@ export class ClaudeSdkOauthSessionRegistry {
 				return true;
 			},
 		});
-		this.generations.set(input.senpiSessionId, generation);
 		this.entries.set(input.senpiSessionId, entry);
 		return entry;
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/index.ts
@@ -218,6 +218,10 @@ export default function ttsrExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("message_end", (event) => {
+		// A completed message ends its stream: nothing it buffered can match a
+		// later message's deltas, so drop the tail windows now instead of holding
+		// them until the next turn_start reset.
+		manager?.resetBuffers();
 		if (genState.userCancelled) return undefined;
 		if (event.message.role !== "assistant") return undefined;
 		const turnText = collectAssistantText(event.message);

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/manager.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/manager.ts
@@ -25,6 +25,17 @@ interface InjectionRecord {
 }
 
 const PICOMATCH_OPTIONS = { dot: true };
+/**
+ * Floor for the per-stream tail window. Long enough that even untracked
+ * short patterns survive window slides with margin to spare.
+ */
+const MIN_STREAM_BUFFER_TAIL_CHARS = 1024;
+/**
+ * A regex can match text longer than its source (quantifiers like `\d{20}`),
+ * so the tail window scales past the longest pattern text rather than
+ * equaling it.
+ */
+const STREAM_BUFFER_TAIL_SAFETY_FACTOR = 4;
 
 export class TtsrManager {
 	readonly #settings: TtsrSettings;
@@ -32,6 +43,7 @@ export class TtsrManager {
 	readonly #rules = new Map<string, TtsrEntry>();
 	readonly #injectionRecords = new Map<string, InjectionRecord>();
 	readonly #buffers = new Map<string, string>();
+	#maxConditionLength = 0;
 	#messageCount = 0;
 	#canMatchText = false;
 	#canMatchThinking = false;
@@ -146,6 +158,7 @@ export class TtsrManager {
 				continue;
 			}
 			conditions.push(compiled);
+			if (pattern.length > this.#maxConditionLength) this.#maxConditionLength = pattern.length;
 		}
 		if (conditions.length === 0) {
 			console.warn("TTSR rule has no valid condition, skipping rule", { ruleName: rule.name });
@@ -191,9 +204,23 @@ export class TtsrManager {
 			return [];
 		}
 		const bufferKey = `${context.source}:${context.streamKey}`;
-		const nextBuffer = `${this.#buffers.get(bufferKey) ?? ""}${delta}`;
+		let nextBuffer = `${this.#buffers.get(bufferKey) ?? ""}${delta}`;
+		// Keep only a tail window: rules match against recent output, and an
+		// unbounded buffer would retain the whole turn's stream (and pay O(n^2)
+		// concat garbage per delta) until the next turn reset.
+		const cap = this.#streamBufferCapChars();
+		if (nextBuffer.length > cap) nextBuffer = nextBuffer.slice(-cap);
 		this.#buffers.set(bufferKey, nextBuffer);
 		return this.#matchBuffer(nextBuffer, context);
+	}
+
+	#streamBufferCapChars(): number {
+		return Math.max(MIN_STREAM_BUFFER_TAIL_CHARS, this.#maxConditionLength * STREAM_BUFFER_TAIL_SAFETY_FACTOR);
+	}
+
+	/** Buffered chars per stream key (diagnostics; buffer-bound verification). */
+	getStreamBufferLengths(): Map<string, number> {
+		return new Map(Array.from(this.#buffers, ([key, buffer]) => [key, buffer.length]));
 	}
 
 	#matchBuffer(buffer: string, context: TtsrMatchContext): TtsrRule[] {

--- a/packages/coding-agent/test/claude-sdk-oauth-session-registry.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-session-registry.test.ts
@@ -256,6 +256,28 @@ describe("Claude SDK OAuth session registry", () => {
 		expect(closed).toEqual([expired.sdkSessionId]);
 	});
 
+	it("never reuses a generation number across repeated close/reopen cycles", () => {
+		let now = 1_000;
+		overrideSessionRegistryBoundary({ now: () => now, queryFactory: () => fakeQuery() });
+		const registry = new ClaudeSdkOauthSessionRegistry();
+		const generations: number[] = [];
+		for (let cycle = 0; cycle < 3; cycle++) {
+			const entry = registry.getOrCreate(input("cycle"));
+			generations.push(entry.generation);
+			transitionSessionState(entry, "IDLE_SYNCED");
+			now += SESSION_REGISTRY_IDLE_TTL_MS;
+			registry.closeSession("cycle", "test_cycle");
+		}
+		expect(generations[0]).toBeLessThan(generations[1]);
+		expect(generations[1]).toBeLessThan(generations[2]);
+		const reopened = registry.getOrCreate(input("cycle"));
+		expect(reopened.generation).toBeGreaterThan(generations[2]);
+		expect(registry.isCurrentGeneration("cycle", reopened.generation)).toBe(true);
+		for (const generation of generations) {
+			expect(registry.isCurrentGeneration("cycle", generation)).toBe(false);
+		}
+	});
+
 	it("cold-seeds a resident entry idle at the TTL on the admission decision path", () => {
 		let now = 1_000;
 		overrideSessionRegistryBoundary({ now: () => now, queryFactory: () => fakeQuery() });

--- a/packages/coding-agent/test/ttsr/manager.test.ts
+++ b/packages/coding-agent/test/ttsr/manager.test.ts
@@ -134,6 +134,41 @@ describe("stream buffers", () => {
 		manager.resetBuffers();
 		expect(manager.checkDelta("dle", ctx())).toEqual([]);
 	});
+
+	it("caps each stream buffer to a tail window above the longest rule pattern", () => {
+		const manager = makeManager();
+		manager.addRule(makeRule("capped", { condition: ["needle-[0-9a-f]{8}"] }));
+		const cap = Math.max(1024, "needle-[0-9a-f]{8}".length * 4);
+		for (let i = 0; i < 100; i++) {
+			manager.checkDelta("x".repeat(200), ctx());
+		}
+		const lengths = manager.getStreamBufferLengths();
+		expect(lengths.get("text:main")).toBeDefined();
+		for (const length of lengths.values()) {
+			expect(length).toBeLessThanOrEqual(cap);
+		}
+	});
+
+	it("still matches a pattern whose match lands at the tail of the window", () => {
+		const manager = makeManager();
+		manager.addRule(makeRule("tail", { condition: ["needle-[0-9a-f]{8}"] }));
+		for (let i = 0; i < 100; i++) {
+			manager.checkDelta("x".repeat(200), ctx());
+		}
+		expect(manager.checkDelta("needle-1234", ctx())).toEqual([]);
+		expect(names(manager.checkDelta("abcd", ctx()))).toEqual(["tail"]);
+	});
+
+	it("clears the tail windows when a message completes", () => {
+		const manager = makeManager();
+		manager.addRule(makeRule("cleared"));
+		manager.checkDelta("nee", ctx());
+		manager.resetBuffers();
+		expect(manager.checkDelta("dle", ctx())).toEqual([]);
+		expect(manager.getStreamBufferLengths().size).toBe(1);
+		manager.resetBuffers();
+		expect(manager.getStreamBufferLengths().size).toBe(0);
+	});
 });
 
 describe("scope and glob gating", () => {


### PR DESCRIPTION
Fixes #1024

## What

Three memory-hygiene fixes in one pass (2.1 / 2.3 / 2.4 of the memory-audit fix shortlist):

**1. Cursor per-conversation caches (#1024)** — `packages/ai/src/api/cursor-agent.ts`, `cursor-conversation-rotation.ts`
- The module-lifetime `conversationStateCache` / `conversationBlobStores` are now session-scoped: cache keys are tracked against `options.sessionId` (threaded by the SDK for every coding-agent stream) and a `registerSessionResourceCleanup` handler drops that session's entries on `cleanupSessionResources(sessionId)` — the same seam codex already uses.
- Wire-id rotation now deletes the pre-rotation key after migrating state/blobs to the new id (the old key is never read again; keeping it was pure leak).
- Defensive bounds: count cap on cached conversations (`PI_CURSOR_CONVERSATION_CACHE_LIMIT`, default 64), an LRU byte cap per conversation blob store (`PI_CURSOR_CONVERSATION_BLOB_LIMIT_BYTES`, default 256 MiB) and a process-global blob ceiling across all stores (`PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES`, default 1 GiB).
- **Eviction can never break a live request** (review follow-up):
  - *Blob pinning + true LRU.* Cursor resolves history blob ids mid-turn over the KV channel (`getBlobArgs`), and a miss is answered with an unset `blobData` — silent context loss or a failed turn. Every blob the in-flight request stores (`buildGrpcRequest`) or the server reads back is now pinned for the lifetime of that request's stream, and the byte cap evicts unpinned blobs only. `.get()` promotes recency, so a blob the server just asked for is no longer sitting at the eviction end. If the pinned working set alone exceeds the cap, the store stays temporarily over budget and logs a warning once, rather than breaking the request; the pins drop and the cap re-applies when the stream settles (including between retry attempts).
  - *Per-session count cap.* The count cap now runs against the keys owned by the requesting session (via the existing `conversationId -> sessionId` map) instead of the process-global maps, so session B's 65th conversation can no longer forget session A's live conversation key (A's retry/resume would have re-entered through the same global map and fallen back to fresh empty state). Within a session, a conversation with a request in flight is never an eviction candidate; keys with no owning session (raw SDK use without `sessionId`) share one bucket.
- Rotation records (the third map named in #1024) are count-bounded (`PI_CURSOR_ROTATION_RECORD_LIMIT`, default 512, trimmed from memory and the persisted file, oldest first).
- `getCursorConversationCacheStats()` exposes sizes for verification/diagnostics.

**2. TTSR stream buffers** — `ttsr/manager.ts`, `ttsr/index.ts`
- `checkDelta` buffers now keep a tail window sized at `max(1024, 4 × longest rule pattern)` instead of the whole turn's stream (which also removes the O(n²) concat churn), and buffers clear on `message_end` instead of waiting for the next `turn_start`.

**3. Small hygiene**
- `anthropic-messages.ts`: the unsigned-thinking text-replay fallback Set is cleared for the session on `cleanupSessionResources`.
- `openai-responses.ts`: the session-websocket idle expiry re-arms when it fires while the socket is busy, and evicts a busy entry whose socket already died, so a lost release can no longer pin a cached websocket for process lifetime.
- `claude-sdk-oauth/session-registry.ts`: the per-id `generations` map (set-only, never deleted) is replaced by a monotonic counter — same never-reuse guarantee for stale-async gating, zero residue.

## Tests (TDD; remote runner, never local)

RED first (commit `5e3e731bd`, tests only): ai 4 files / 9 tests failed; coding-agent 1 file / 2 tests failed. The anthropic cleanup case is a behavioral RED (the Set survives `cleanupSessionResources` today); the new-seam cases fail on the missing exports by construction.

GREEN after the fixes:
- `packages/ai` (7 files, 55 tests): `cursor-conversation-cache-eviction`, `cursor-conversation-rotation`, `cursor-conversation-rotation-stream`, `anthropic-unsigned-thinking-replay`, `openai-responses-websocket-expiry`, `openai-responses-websocket`, `cursor-agent`.
- `packages/coding-agent` (6 files, 77 tests): `ttsr/manager`, `claude-sdk-oauth-session-registry`, `ttsr-extension`, all three `goal-ttsr-*-race`.

New coverage pins: session-scoped eviction leaves only the surviving session's entries; rotation deletes the old key; count cap evicts oldest-first; blob byte cap holds under a 200 KB payload; rotation records trim from memory and disk; busy-then-idle TTL re-arm; dead-socket eviction while busy; tail-window match survival; generation never reused across close/reopen.

Second RED/GREEN cycle for the two eviction blockers (`cursor-conversation-blob-pinning.test.ts`, tests-only commit `2bc7ca085`):
- RED (3 failed / 1 passed): live-reference eviction answered 23 of the request's `getBlobArgs` with an empty blob (`expected [ '5', '6', '8', ... ] to equal []`); `expected [ 'b-3', 'b-4' ] to include 'a-1'` (session B's overflow evicted session A); `expected [ 'fill-2', 'fill-3' ] to include 'live-1'` (a session's own overflow evicted its in-flight conversation).
- GREEN after `c85e3062d`: `packages/ai` cursor scope 21 files / 145 tests passed, and the whole `packages/ai` suite 257 files / 2486 tests passed (25 files / 870 tests skipped as usual).
- New pins: every referenced blob resolves during a stream whose history exceeds the byte cap; pins release when the stream settles so the cap applies again; the process-global ceiling holds across four cached conversations; the count cap now evicts oldest-first *within one session*.

## Residual

- **Process-global ceiling decision (reviewer's 64 × 256 MiB ≈ 16 GiB point): added, not documented away.** Making the count cap per session removes the cross-session eviction bug but multiplies the theoretical ceiling by the session count, so a per-conversation cap alone cannot bound the process. `enforceConversationTotalBlobLimit()` now caps the blob bytes of *all* cached conversations at `PI_CURSOR_CONVERSATION_TOTAL_BLOB_LIMIT_BYTES` (default 1 GiB), applied after each request build and after each stream settles. It sheds cold conversations before live ones, never drops a pinned blob, and forgets a conversation whose store empties; if the remainder is entirely pinned by in-flight requests it warns instead of breaking them. Cursor re-stores the history it needs from `context.messages` on the next turn, so a shed cold conversation costs re-serialization, not context.
- Bounds are still ceilings, not elimination; in the coding-agent the session-cleanup path is the real reclaim for disposed sessions.
- `openai-codex-responses.ts` has the same busy-early-return expiry shape; it is out of this PR's scope and untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1024 by bounding cursor conversation caches and per-stream buffers so long-lived sessions no longer leak memory.

- Cursor conversation state, blob stores, and rotation records get count caps; blob stores also get byte caps enforced per owning session with a process-global ceiling, in-flight requests pin their blobs and live conversations so eviction never breaks a stream, and rotations delete the pre-rotation key.
- Anthropic unsigned-thinking replay fallbacks clear on session cleanup, and OpenAI session websockets re-arm idle expiry when busy and drop dead sockets.
- TTSR stream buffers keep only a tail window (at least 1024 chars or 4× the longest rule pattern) and clear on `message_end`.
- The `claude-sdk-oauth` session registry uses a monotonic generation counter instead of an unbounded per-id map.

<sup>Written for commit 5a117f922247a59c2f1ca39a801c9c8962303d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

