### PR TITLE
fix(coding-agent): canonicalize Windows fs.watch paths to stop /resume native aborts (#1229)

### DIFF
--- a/.github/changes.md
+++ b/.github/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Windows fs.watch regression joins the terminal cross-OS CI job (2026-08-31)
+
+### What changed
+
+- `.github/workflows/ci.yml` appends `test/suite/regressions/issue-1229-win-fswatch-noncanonical-abort.test.ts` to the `terminal-cross-os` job's Vitest invocation so the win32-only regression actually executes on the windows-latest runner.
+
+### Why
+
+- The main coding-agent test shards run on ubuntu only, where the win32-gated regression for the `/resume` fs.watch abort ([#1229](https://github.com/code-yeongyu/senpi/issues/1229)) always skips; the 3-OS terminal job is the only lane with a real Windows runner.
+
+### Why an extension could not handle it
+
+- CI workflow wiring is repository build plumbing; no runtime extension hook can add a test to a GitHub Actions job.
+
+### Expected merge conflict zones
+
+- The `Terminal extension + shell resolution tests` step's file list in `.github/workflows/ci.yml`.
+
 ## Release workflow re-diverges from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Terminal extension + shell resolution tests
         shell: bash
-        run: npx vitest run test/suite/terminal-extension.test.ts test/suite/terminal-settings-notify.test.ts test/suite/shell-config-kind.test.ts
+        run: npx vitest run test/suite/terminal-extension.test.ts test/suite/terminal-settings-notify.test.ts test/suite/shell-config-kind.test.ts test/suite/regressions/issue-1229-win-fswatch-noncanonical-abort.test.ts
         working-directory: packages/coding-agent
 
   inspector-handoff:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Windows session resume no longer aborts the process when `fs.watch()` receives an event for a watch path containing a non-canonical component; existing paths are canonicalized before watching ([#1229](https://github.com/code-yeongyu/senpi/issues/1229)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,23 +1,5 @@
 # changes
 
-## 2026-08-31 - Canonicalize Windows fs.watch paths before watching
-
-### What changed
-
-- `packages/coding-agent/src/utils/fs-watch.ts` resolves existing watch paths with `realpathSync.native()` on Windows before calling `fs.watch()`, while preserving the raw path when resolution fails.
-
-### Why
-
-- libuv can abort the process on Windows when a watch path contains a non-canonical component such as an 8.3 short name or junction and an event arrives with its canonical long path ([#1229](https://github.com/code-yeongyu/senpi/issues/1229)).
-
-### Why an extension could not handle it
-
-- The abort occurs inside libuv's native Windows fs-event implementation before JavaScript can receive an error event, and all repository watchers share this wrapper.
-
-### Expected merge conflict zones
-
-- LOW: `packages/coding-agent/src/utils/fs-watch.ts` watcher setup.
-
 ## 2026-08-30 - Export the RPC transport-gone classifier
 
 ### What changed

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-08-31 - Canonicalize Windows fs.watch paths before watching
+
+### What changed
+
+- `packages/coding-agent/src/utils/fs-watch.ts` resolves existing watch paths with `realpathSync.native()` on Windows before calling `fs.watch()`, while preserving the raw path when resolution fails.
+
+### Why
+
+- libuv can abort the process on Windows when a watch path contains a non-canonical component such as an 8.3 short name or junction and an event arrives with its canonical long path ([#1229](https://github.com/code-yeongyu/senpi/issues/1229)).
+
+### Why an extension could not handle it
+
+- The abort occurs inside libuv's native Windows fs-event implementation before JavaScript can receive an error event, and all repository watchers share this wrapper.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/utils/fs-watch.ts` watcher setup.
+
 ## 2026-08-30 - Export the RPC transport-gone classifier
 
 ### What changed

--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Canonicalize Windows fs.watch paths before watching (2026-08-31)
+
+### What changed
+
+- `packages/coding-agent/src/utils/fs-watch.ts` resolves existing watch paths with `realpathSync.native()` on Windows before calling `fs.watch()`, keeping the raw path when resolution fails (missing paths still surface through the existing `onError` flow).
+
+### Why
+
+- libuv's Windows fs-event implementation `abort()`s the whole process (`Assertion failed: !_wcsnicmp(filename, dir, dirlen), src\win\fs-event.c:72`) when a watched directory path carries a non-canonical component (8.3 short name, junction) and an incoming event's long-path conversion no longer prefix-matches the stored watch path. Entering a session from the `/resume` selector re-creates the runtime while such watchers are armed, killing the app ([#1229](https://github.com/code-yeongyu/senpi/issues/1229)).
+
+### Why an extension could not handle it
+
+- The abort happens inside libuv native code before any JavaScript `error` event fires, and every repository watcher (footer git watchers, theme watcher, config-reload) routes through this shared wrapper.
+
+### Expected merge conflict zones
+
+- LOW: the `watchWithErrorHandler` body in `packages/coding-agent/src/utils/fs-watch.ts`.
+
 ## Utils re-diverge from upstream dcd4619 (2026-08-25)
 
 ### What changed

--- a/packages/coding-agent/src/utils/fs-watch.ts
+++ b/packages/coding-agent/src/utils/fs-watch.ts
@@ -1,4 +1,4 @@
-import { type FSWatcher, type WatchListener, type WatchOptions, watch } from "node:fs";
+import { realpathSync, type FSWatcher, type WatchListener, type WatchOptions, watch } from "node:fs";
 
 export const FS_WATCH_RETRY_DELAY_MS = 5000;
 
@@ -21,7 +21,15 @@ export function watchWithErrorHandler(
 	options?: WatchOptions,
 ): FSWatcher | null {
 	try {
-		const watcher = watch(path, { ...options, encoding: "utf8" }, listener);
+		let watchPath = path;
+		if (process.platform === "win32") {
+			try {
+				watchPath = realpathSync.native(path);
+			} catch {
+				// Keep the raw path when it does not exist yet.
+			}
+		}
+		const watcher = watch(watchPath, { ...options, encoding: "utf8" }, listener);
 		watcher.on("error", onError);
 		return watcher;
 	} catch {

--- a/packages/coding-agent/test/suite/regressions/issue-1229-win-fswatch-noncanonical-abort.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-1229-win-fswatch-noncanonical-abort.test.ts
@@ -1,0 +1,113 @@
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const CHILD_TIMEOUT_MS = 20_000;
+const tempDirs: string[] = [];
+
+function shortPath(path: string): string | undefined {
+	try {
+		const result = execFileSync("cmd.exe", ["/d", "/s", "/c", `for %I in ("${path}") do @echo %~sI`], {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+		return result && result !== path ? result : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function nonCanonicalTempDir(): string | undefined {
+	const rawTempDir = tmpdir();
+	if (rawTempDir !== realpathSync.native(rawTempDir)) {
+		const directory = mkdtempSync(join(rawTempDir, "senpi-1229-long-directory-"));
+		tempDirs.push(directory);
+		return directory;
+	}
+
+	const longDirectory = mkdtempSync(join(rawTempDir, "senpi-1229-long-directory-name-"));
+	tempDirs.push(longDirectory);
+	const alias = shortPath(longDirectory);
+	if (!alias) {
+		rmSync(longDirectory, { recursive: true, force: true });
+		tempDirs.pop();
+	}
+	return alias;
+}
+
+afterEach(() => {
+	for (const directory of tempDirs.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe.skipIf(process.platform !== "win32")("issue #1229 non-canonical fs.watch path", () => {
+	it("does not abort the process when a watched file changes", async (ctx) => {
+		const directory = nonCanonicalTempDir();
+		if (!directory) {
+			ctx.skip("The Windows volume does not expose an 8.3 short alias");
+			return;
+		}
+
+		const wrapperPath = resolve(__dirname, "../../../src/utils/fs-watch.ts");
+		const scriptPath = join(directory, "watch-child.ts");
+		const script = `
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { watchWithErrorHandler } from ${JSON.stringify(pathToFileURL(wrapperPath).href)};
+
+// Watch the DIRECTORY through its non-canonical (8.3 short-name) path. On
+// unfixed code libuv aborts the whole process (fs-event.c uv__relative_path
+// assertion) as soon as a directory entry event arrives; file watches never
+// enter that code path, so this must stay a directory watch.
+const directory = ${JSON.stringify(directory)};
+let completed = false;
+const timeout = setTimeout(() => process.exit(2), 10000);
+const watcher = watchWithErrorHandler(
+  directory,
+  () => {
+    if (completed) return;
+    completed = true;
+    clearTimeout(timeout);
+    watcher?.close();
+    process.exit(0);
+  },
+  () => {
+    clearTimeout(timeout);
+    process.exit(3);
+  },
+);
+if (!watcher) {
+  clearTimeout(timeout);
+  process.exit(4);
+}
+writeFileSync(join(directory, "regression-write-1229.txt"), "change");
+`;
+		writeFileSync(scriptPath, script);
+		const child = spawn(process.execPath, ["--import", "tsx", scriptPath], {
+			cwd: resolve(__dirname, "../../../../.."),
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stderr = "";
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+
+		const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolveExit, reject) => {
+			const timeout = setTimeout(() => {
+				child.kill();
+				reject(new Error(`Child timed out after ${CHILD_TIMEOUT_MS}ms`));
+			}, CHILD_TIMEOUT_MS);
+			child.once("error", reject);
+			child.once("close", (code, signal) => {
+				clearTimeout(timeout);
+				resolveExit({ code, signal });
+			});
+		});
+
+		expect(exit.code, `Child exited with code ${exit.code} (signal ${exit.signal}). stderr: ${stderr.trim()}`).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #1229: on Windows, entering a session from the `/resume` selector could abort the whole process with a native libuv assertion:

```
Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72
```

libuv's Windows fs-event implementation `abort()`s the process when a watched directory path contains a non-canonical component (8.3 short name such as `C:\Users\RUNNER~1\...` from a short-form `%TEMP%`/profile env, a junction, or a OneDrive-style redirect) and a directory entry event arrives whose long-form conversion no longer prefix-matches the stored watch path. This bypasses `watcher.on("error")` entirely — it is a native process abort, not an error event. A `/resume` session switch re-creates the runtime while watchers are armed, which is why it surfaced there.

The fix canonicalizes the watch path with `realpathSync.native()` (win32 only, raw-path fallback when resolution fails) inside `watchWithErrorHandler`, the single wrapper every repository watcher routes through (footer git watchers, theme watcher, config-reload).

## Evidence (real Windows surface: GH Actions windows-latest + ConPTY)

Scratch branch `debug/win-resume-repro` drives the real CLI under `@lydell/node-pty`, plants a session fixture, types `/resume`, and selects the session:

- RED e2e + RED test — run [33363719860](https://github.com/code-yeongyu/senpi/actions/runs/33363719860): probe `crashed exit=-1073740791` with the fs-event.c assertion; new regression test failed with `Child exited with code 3221226505`.
- Minimal mechanism matrix — run [33363407169](https://github.com/code-yeongyu/senpi/actions/runs/33363407169): `fs.watch(<short-name dir>)` + one plain file write aborts; every canonical-path case is clean; ubuntu control clean.
- GREEN — run [33364283468](https://github.com/code-yeongyu/senpi/actions/runs/33364283468): regression test passes on windows and the e2e probe reports `REPRO-VERDICT: resumed` on both windows and ubuntu.

Adjacent surfaces (session-cwd, session selector rename/delete, agent-session-runtime switchSession, footer git watchers, config-reload watch engine/scope, theme controller): 66/67 targeted tests green at this branch head; the single `footer-data-provider-watch-fallback` polling failure was proven flaky, not causal (bisect matrix 6/6 green including fix-as-is twice and main twice on the same machine).

## Changes

- `packages/coding-agent/src/utils/fs-watch.ts`: canonicalize watch paths on win32 before `fs.watch`.
- `packages/coding-agent/test/suite/regressions/issue-1229-win-fswatch-noncanonical-abort.test.ts`: win32 regression driving the real wrapper in a spawned child (in-process abort would kill the vitest worker); skips on non-Windows and on volumes without an 8.3 alias.
- `.github/workflows/ci.yml`: the regression runs in the 3-OS `terminal-cross-os` job — the ubuntu-only test shards would never execute a win32-gated test.
- `packages/coding-agent/src/changes.md` + `CHANGELOG.md`: tracker entry and fix bullet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1229: on Windows, resuming a session from the `/resume` selector could abort the whole process with a libuv assertion when a watched path contained a non-canonical component (8.3 short name, junction, or OneDrive redirect). Watch paths are now canonicalized before watching, with a raw-path fallback when resolution fails.

**Bug Fixes**
- Canonicalizes watch paths on win32 in `watchWithErrorHandler`, the shared wrapper for all repository watchers.
- Adds a Windows-only regression test that drives the real wrapper in a spawned child process, since an in-process abort would kill the vitest worker.
- Runs the regression test in the 3-OS `terminal-cross-os` CI job so it actually executes on Windows.

<sup>Written for commit af3a22936a8cd50e474aec10901b70a89245fbfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

