### PR TITLE
style(coding-agent): fix biome format drift from recent merges

### DIFF
--- a/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
@@ -155,7 +155,7 @@ export async function createInteractiveHostRuntime(
 			client,
 			opened.state,
 			options.onWarning,
-(cause) => {
+			(cause) => {
 				if (remoteRuntime?.isReconnecting) warnReconnect(cause);
 				else warnFallback(cause);
 			},
@@ -460,7 +460,7 @@ export function createRemoteSessionProxy(
 	client: RpcClient,
 	initialState: ReturnType<typeof stateFromRpc>,
 	onWarning?: (warning: InteractiveHostWarning) => void,
-onTransportGone?: (cause: unknown) => void,
+	onTransportGone?: (cause: unknown) => void,
 	startupEvents: readonly import("../rpc/rpc-client.ts").RpcClientEvent[] = [],
 ): RemoteSessionProxy {
 	// Fire-and-forget setters keep the sync AgentSession signature, but their RPC

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -71,10 +71,7 @@ const REQUIRED_CAPABILITIES = ["multi_session", EXTENSION_EVENTS_CAPABILITY] as 
  * the first caller. In particular, extension_events must remain available when
  * a terminal client starts the shared host before the desktop connects.
  */
-export const PINNED_HOST_CLIENT_CAPABILITIES = [
-	EXTENSION_EVENTS_CAPABILITY,
-	CUSTOM_UNSUPPORTED_CAPABILITY,
-] as const;
+export const PINNED_HOST_CLIENT_CAPABILITIES = [EXTENSION_EVENTS_CAPABILITY, CUSTOM_UNSUPPORTED_CAPABILITY] as const;
 
 export function createHostDaemonPaths(agentDir = getAgentDir()): HostDaemonPaths {
 	const dir = join(agentDir, "rpc-host-daemon");

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -159,7 +159,8 @@ export class SessionEventWriter {
 		sessions.add(sessionId);
 		this.connectionSessions.set(id, sessions);
 		if (this.connectionCapabilities.get(id)?.has("rendered_components"))
-			for (const record of this.sessionSnapshots.get(sessionId) ?? []) if (record.rendered) this.connections.get(id)!.actor.enqueue(record.line);
+			for (const record of this.sessionSnapshots.get(sessionId) ?? [])
+				if (record.rendered) this.connections.get(id)!.actor.enqueue(record.line);
 	}
 
 	detachConnectionFromSession(id: string, sessionId: string): void {
@@ -174,7 +175,8 @@ export class SessionEventWriter {
 		this.registeredCapabilityConnections.add(id);
 		if (!wasCapable && capabilities.includes("rendered_components"))
 			for (const sessionId of this.connectionSessions.get(id) ?? [])
-				for (const record of this.sessionSnapshots.get(sessionId) ?? []) if (record.rendered) registered.actor.enqueue(record.line);
+				for (const record of this.sessionSnapshots.get(sessionId) ?? [])
+					if (record.rendered) registered.actor.enqueue(record.line);
 	}
 
 	clearConnectionCapabilities(id: string): void {
@@ -226,9 +228,10 @@ export class SessionEventWriter {
 		const targets = isTargeted
 			? [targetId]
 			: record[RENDERED_COMPONENT_RECORD] && this.connections.size > 0
-				? [...this.connections.keys()].filter((id) =>
-						this.connectionCapabilities.get(id)?.has("rendered_components") &&
-						this.connectionSessions.get(id)?.has(sessionId),
+				? [...this.connections.keys()].filter(
+						(id) =>
+							this.connectionCapabilities.get(id)?.has("rendered_components") &&
+							this.connectionSessions.get(id)?.has(sessionId),
 					)
 				: this.connections.size > 0
 					? [...this.connections.keys()]

--- a/packages/coding-agent/test/interactive-host-runtime.test.ts
+++ b/packages/coding-agent/test/interactive-host-runtime.test.ts
@@ -20,8 +20,8 @@ import { FooterComponent } from "../src/modes/interactive/components/footer.ts";
 import {
 	createInteractiveHostRuntime,
 	createRemoteSessionProxy,
-	RemoteInteractiveRuntime,
 	INTERACTIVE_HOST_FALLBACK_WARNING,
+	RemoteInteractiveRuntime,
 } from "../src/modes/interactive/interactive-host-runtime.ts";
 import { initTheme } from "../src/modes/interactive/theme/theme.ts";
 import { RpcClient } from "../src/modes/rpc/rpc-client.ts";
@@ -160,11 +160,7 @@ async function waitForHost(child: ChildProcessWithoutNullStreams, socket: string
 describe("interactive host runtime", () => {
 	it("re-registers rendered capability and last width after reconnect", async () => {
 		const setClientInfo = vi.fn(async () => {});
-		const runtime = new RemoteInteractiveRuntime(
-			{} as AgentSessionRuntime,
-			{} as never,
-			{ setClientInfo } as never,
-		);
+		const runtime = new RemoteInteractiveRuntime({} as AgentSessionRuntime, {} as never, { setClientInfo } as never);
 		runtime.setClientInfo(117);
 		await Promise.resolve();
 		await runtime.reRegisterClientInfo();

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -367,7 +367,12 @@ describe("RPC Unix-socket multi-connection host", () => {
 					Array.isArray(value.widgetLines),
 			);
 			await expect(
-				peer.peer.request({ id: "client-info", type: "set_client_info", width: 80, capabilities: ["rendered_components"] }),
+				peer.peer.request({
+					id: "client-info",
+					type: "set_client_info",
+					width: 80,
+					capabilities: ["rendered_components"],
+				}),
 			).resolves.toMatchObject({ type: "response", command: "set_client_info", success: true });
 			const opened = await peer.peer.request({ id: "open", type: "open_session", cwd: qa.cwd });
 			const sessionId = openedSessionId(opened);
@@ -499,7 +504,18 @@ describe("RPC Unix-socket multi-connection host", () => {
 			`export default function (pi) { pi.on("session_start", (_event, ctx) => ctx.ui.setWidget("factory", () => ({ render: (width) => [String(width)] }))); }`,
 		);
 		const child = spawnRpc(
-			["--mode", "rpc", "--listen", `unix://${qa.socketPath}`, "--provider", MOCK_PROVIDER, "--model", MOCK_MODEL, "--extension", join(qa.agentDir, "extensions", "widget-factory.ts")],
+			[
+				"--mode",
+				"rpc",
+				"--listen",
+				`unix://${qa.socketPath}`,
+				"--provider",
+				MOCK_PROVIDER,
+				"--model",
+				MOCK_MODEL,
+				"--extension",
+				join(qa.agentDir, "extensions", "widget-factory.ts"),
+			],
 			qa,
 			"rendered_components",
 		);
@@ -508,13 +524,26 @@ describe("RPC Unix-socket multi-connection host", () => {
 		try {
 			const first = await peer.peer.request({ id: "open-a", type: "open_session", cwd: qa.cwd });
 			const sessionA = openedSessionId(first);
-			await peer.peer.request({ id: "info-a", type: "set_client_info", sessionId: sessionA, width: 80, capabilities: ["rendered_components"] });
+			await peer.peer.request({
+				id: "info-a",
+				type: "set_client_info",
+				sessionId: sessionA,
+				width: 80,
+				capabilities: ["rendered_components"],
+			});
 			await peer.peer.request({ id: "open-b", type: "open_session", cwd: qa.cwd });
 			const factoryAfterSecondOpen = peer.peer.waitFor(
-				(value) => value.type === "extension_ui_request" && value.widgetKey === "factory" && JSON.stringify(value.widgetLines) === JSON.stringify(["81"]),
+				(value) =>
+					value.type === "extension_ui_request" &&
+					value.widgetKey === "factory" &&
+					JSON.stringify(value.widgetLines) === JSON.stringify(["81"]),
 			);
 			await peer.peer.request({ id: "info-a-again", type: "set_client_info", sessionId: sessionA, width: 81 });
-			expect(await factoryAfterSecondOpen).toMatchObject({ sessionId: sessionA, widgetKey: "factory", widgetLines: ["81"] });
+			expect(await factoryAfterSecondOpen).toMatchObject({
+				sessionId: sessionA,
+				widgetKey: "factory",
+				widgetLines: ["81"],
+			});
 		} finally {
 			peer.peer.close();
 			peer.socket.destroy();


### PR DESCRIPTION
This is a pure formatting-only change generated by `npx biome check --write .`.

- No semantic changes.
- Unblocks the releasability Biome gate, which currently fails on main.
- Focused tests were run; their failures reproduce identically on untouched origin/main and are pre-existing.
- `npx tsc --noEmit` passes.

Touched files:
- packages/coding-agent/src/modes/interactive/interactive-host-runtime.ts
- packages/coding-agent/src/modes/rpc/host-ensure.ts
- packages/coding-agent/src/modes/rpc/session-event-writer.ts
- packages/coding-agent/test/interactive-host-runtime.test.ts
- packages/coding-agent/test/rpc-socket-host.test.ts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reformats `coding-agent` files with Biome so the releasability check passes on main. This is a formatting-only change with no behavior impact.

- `npx tsc --noEmit` passes.
- The focused test failures reproduce identically on `origin/main` and are pre-existing.

<sup>Written for commit 082d71bffa883be02cc22863ea1cad470118d843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

