### PR TITLE
feat(coding-agent): retry the primary model after compaction releases a refusal pin

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### New Features
 
+- Refusal-caused model fallbacks now release their pin when a senpi-owned compaction successfully rewrites the context and eagerly re-attempt the original model once per compaction, while billing-caused pins never release and `fallbackRevertPolicy: "never"` still suppresses the restore ([#1232](https://github.com/code-yeongyu/senpi/pull/1232)).
+
 ### Breaking Changes
 
 ### Added

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4619,6 +4619,17 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * A senpi-owned compaction just rewrote the conversation context: release any
+	 * refusal-caused fallback pin (the "same context refuses again" assumption no
+	 * longer holds) and, while no run is active, eagerly re-attempt the original
+	 * model through the existing revert gate. Billing-caused pins never release.
+	 */
+	private async _onCompactionContextChanged(): Promise<void> {
+		const released = this._retryFallback.notifyCompactionApplied();
+		if (released && !this.isStreaming) await this._maybeRestoreFallbackPrimary();
+	}
+
 	private async _switchActiveModel(
 		model: Model<Api>,
 		opts: {
@@ -5674,6 +5685,11 @@ export class AgentSession {
 				fromExtension,
 				willRetry: request.willRetry,
 			});
+
+			// Shared success seam: every senpi-owned compaction apply (manual /compact,
+			// extension applyCompaction, pre-prompt and auto compaction) funnels through
+			// here after the compaction entry is appended and the success event emitted.
+			await this._onCompactionContextChanged();
 
 			return {
 				accepted: true,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -6289,6 +6289,22 @@ export class AgentSession {
 		try {
 			if (this.agent.state.isStreaming) return "taken-over";
 
+			// Pre-admission restore point. A senpi-owned compaction that succeeds
+			// while a run is still active releases its refusal pin through
+			// _onCompactionContextChanged() but cannot restore there: model-select
+			// work must stay ordered behind the session-work barrier while the run
+			// owns it. Every post-compaction continuation admission - auto/overflow
+			// compaction recovery, _resumeQueuedMessagesAfterCompaction(), the
+			// agent_end queued continuation and the retry continuation - is scheduled
+			// through _scheduleContinuationAfterCurrentEvent() and funnels here, so
+			// this is the single choke point every such request passes before
+			// reaching the provider. Restoring here (a no-op when nothing is pending)
+			// keeps the guarantee that the very next request after a compaction runs
+			// on the primary, and precedes the admission revalidation below so that
+			// check samples the restored model's context window - the same ordering
+			// the retry-continuation restore uses.
+			await this._maybeRestoreFallbackPrimary();
+
 			await this._revalidateScheduledContinuationAdmission();
 			if (this.agent.state.isStreaming) return "taken-over";
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -20,6 +20,27 @@
 
 - LOW: the new `session-activity.ts` module, the activity getters and `_bindExtensionCore` subscription in `agent-session.ts`, and the `onBusEvent` helper in `extensions/runner.ts`.
 
+## 2026-08-31 - Release refusal fallback pins on compaction
+
+### What changed
+
+- `packages/coding-agent/src/core/retry-fallback/controller.ts` records pin provenance and exposes `notifyCompactionApplied` to release refusal-caused pin contributions.
+- `packages/coding-agent/src/core/agent-session.ts` calls `_onCompactionContextChanged` at the `_executeCompaction` success seam and eagerly restores the original model; billing pins and `fallbackRevertPolicy "never"` are unaffected, and there is no new settings key.
+
+### Why
+
+- Refusal pins encode "same context refuses again"; compaction rewrites the context, so one fresh primary attempt per successful apply is correct. This is always-on by user decision, with no config key.
+
+### Why an extension could not handle it
+
+- The pin state and restore gate live inside core retry-fallback controller state and the agent-session compaction apply seam. Extensions observe compaction events but cannot mutate `ActiveFallbackState` or re-enter the internal restore gate.
+
+### Expected merge conflict zones
+
+- The prepend zone at the top of `packages/coding-agent/src/core/changes.md`.
+- The `tryFallback` state-write hunk in `retry-fallback/controller.ts`.
+- The `_executeCompaction` success tail in `agent-session.ts` (near other compaction-lifecycle work).
+
 ## 2026-08-31 - Shared session host is OFF by default (opt-in)
 
 - Interactive sessions no longer join the shared RPC host implicitly. `main.ts` now gates

--- a/packages/coding-agent/src/core/retry-fallback/AGENTS.md
+++ b/packages/coding-agent/src/core/retry-fallback/AGENTS.md
@@ -6,7 +6,7 @@ Model fallback chains and hint-aware 429 retry policy for `agent-session.ts`. Pu
 
 | File | Role |
 |---|---|
-| `controller.ts` | `RetryFallbackController`: turn-scoped tried-selector set, `ActiveFallbackState`, `tryFallback` / `maybeRestorePrimary(revertPolicy)` / `clearForManualModelChange`, content-keyed memo of canonicalized chains |
+| `controller.ts` | `RetryFallbackController`: turn-scoped tried-selector set, `ActiveFallbackState`, `tryFallback` / `maybeRestorePrimary(revertPolicy)` / `notifyCompactionApplied` / `clearForManualModelChange`, content-keyed memo of canonicalized chains |
 | `chains.ts` | Selector parse/format, chain-key resolution, `canonicalizeFallbackChains` (bare-selector expansion + registry eligibility) |
 | `expansion.ts` | Bare-selector family expansion; OpenRouter denylist; OAuth-first auth tiers; `PROVIDER_PRECEDENCE` tie-break |
 | `hint-policy.ts` | Pure 429 hint tiers (`no-hint-fast-fallback` / `tier1-in-turn` / `tier2-fallback-probe-back` / `tier3-fallback-only`) + probe schedule math |
@@ -32,7 +32,7 @@ Model fallback chains and hint-aware 429 retry policy for `agent-session.ts`. Pu
 
 - Everything time- or randomness-dependent is injected (`now`, `random`, `setTimeout`/`clearTimeout`) — tests drive it deterministically with fake timers; never read `Date.now()` directly here.
 - Cooldowns are runtime-only and deliberately never persisted to settings or session files.
-- Billing-class errors pin the fallback candidate as the session model; `transient`/`refusal`/`hard-error` fallbacks revert per `fallbackRevertPolicy` (`cooldown-expiry` | `never`).
+- Billing-class errors pin the fallback candidate as the session model and NEVER release; refusal pins release when a senpi-owned compaction successfully applies (context changed => one fresh primary attempt); `transient`/`hard-error` fallbacks revert per `fallbackRevertPolicy` (`cooldown-expiry` | `never`).
 - `canonicalizeFallbackChains` is memoized on chains content — provider-error handling calls it several times per error.
 - `fallback.log` scrubs by construction: blocked keys (`headers`, `env`, `authorization`, …), allowlisted data keys only, bearer/api-key text patterns truncated.
 - Consumers: `agent-session.ts` (controller wiring), `settings-manager.ts` (resolution), `builtin/model-fallback/` (validate + canonicalize for `/model-fallback`), `builtin/cursor-cli-oauth/settings.ts` (`isFallbackEligible` probe).

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -19,6 +19,10 @@ export interface ActiveFallbackState {
 	originalSelector: string;
 	originalThinkingLevel?: ThinkingLevel;
 	lastAppliedThinkingLevel?: ThinkingLevel;
+	/** Pin provenance: refusal contributions release on compaction, billing never. */
+	pinnedByRefusal: boolean;
+	pinnedByBilling: boolean;
+	/** Derived OR of the two provenance flags - the only field consumers read. */
 	pinned: boolean;
 }
 
@@ -158,6 +162,30 @@ export class RetryFallbackController {
 		if (this.state) this.state.lastAppliedThinkingLevel = undefined;
 	}
 
+	/**
+	 * A senpi-owned compaction successfully rewrote the conversation context, the
+	 * one safe moment to re-attempt a refusal-pinned fallback's original model:
+	 * the refusal assumption ("the same context refuses again") no longer holds.
+	 * Refusal contributions clear; billing contributions never release - retrying
+	 * the same account never recovers it. Returns true only when the overall pin
+	 * transitioned true -> false, i.e. the caller may now restore the primary via
+	 * the existing maybeRestorePrimary gate.
+	 */
+	notifyCompactionApplied(): boolean {
+		const state = this.state;
+		if (!state) return false;
+		state.pinnedByRefusal = false;
+		const wasPinned = state.pinned;
+		state.pinned = state.pinnedByBilling;
+		if (!wasPinned || state.pinned) return false;
+		this.deps.logger.info("refusal_pin_released", {
+			chainKey: state.chainKey,
+			originalSelector: state.originalSelector,
+			trigger: "compaction",
+		});
+		return true;
+	}
+
 	/** A user-driven model change abandons the fallback window entirely. */
 	clearForManualModelChange(model: Model<Api>): void {
 		if (this.state) {
@@ -184,12 +212,17 @@ export class RetryFallbackController {
 		await this.deps.switchModel(candidate.model, thinking, "fallback");
 		const from = formatSelector(current.model);
 		const to = formatSelector(candidate.model);
+		const prior = this.state;
+		const pinnedByRefusal = prior?.pinnedByRefusal === true || reason === "refusal";
+		const pinnedByBilling = prior?.pinnedByBilling === true || reason === "billing";
 		this.state = {
 			chainKey: candidate.chainKey,
-			originalSelector: this.state?.originalSelector ?? from,
-			originalThinkingLevel: this.state?.originalThinkingLevel ?? current.thinkingLevel,
+			originalSelector: prior?.originalSelector ?? from,
+			originalThinkingLevel: prior?.originalThinkingLevel ?? current.thinkingLevel,
 			lastAppliedThinkingLevel: thinking,
-			pinned: this.state?.pinned === true || reason === "refusal" || reason === "billing",
+			pinnedByRefusal,
+			pinnedByBilling,
+			pinned: pinnedByRefusal || pinnedByBilling,
 		};
 		this.deps.logger.info("fallback_applied", { from, to, chainKey: candidate.chainKey, reason });
 		this.deps.emit({ type: "retry_fallback_applied", from, to, chainKey: candidate.chainKey, reason });

--- a/packages/coding-agent/src/core/retry-fallback/log.ts
+++ b/packages/coding-agent/src/core/retry-fallback/log.ts
@@ -6,7 +6,7 @@ const MAX_STRING_LENGTH = 200;
 const BLOCKED_KEY =
 	/^(?:__proto__|constructor|prototype|headers?|env(?:ironment)?|authorization|credential(?:s)?|password|secret|token|api_?key|client_?secret)$/i;
 const ALLOWED_DATA_KEY =
-	/^(?:selector|candidate|currentSelector|originalSelector|from|to|model|chainKey|reason|skipReason|classification|thinkingLevel|durationMs|retryAfterMs|error|errorMessage|warning)$/;
+	/^(?:selector|candidate|currentSelector|originalSelector|from|to|model|chainKey|reason|skipReason|classification|thinkingLevel|durationMs|retryAfterMs|error|errorMessage|warning|trigger)$/;
 const SENSITIVE_TEXT =
 	/((?:authorization\s*[:=]\s*(?:bearer|basic)\s+)|(?:bearer\s+)|(?:[?&](?:api[_-]?key|token|secret|password|auth(?:orization)?)=))[^\s&,"'}\]]+/gi;
 

--- a/packages/coding-agent/test/manual-qa/refusal-unpin-compaction-qa.mjs
+++ b/packages/coding-agent/test/manual-qa/refusal-unpin-compaction-qa.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { createHarness } from "../suite/harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+const primaryModelId = "faux-1";
+const fallbackModelId = "faux-2";
+
+function refusal(text) {
+	return fauxAssistantMessage(text, {
+		stopReason: "error",
+		errorMessage: "misleading_success_output",
+		stopDetails: { type: "refusal" },
+	});
+}
+
+function fail(message) {
+	throw new Error(`QA mismatch: ${message}`);
+}
+
+const harness = await createHarness({
+	models: [{ id: "faux-1", contextWindow: 128_000 }, { id: "faux-2", contextWindow: 128_000 }],
+	fallbackNow: () => 0,
+	settings: {
+		retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+	},
+});
+
+try {
+	harness.setResponses([refusal("primary refusal"), fauxAssistantMessage("fallback answer")]);
+	await harness.session.prompt("hello");
+	if (harness.session.model?.id !== fallbackModelId) fail(`expected fallback model, got ${harness.session.model?.id}`);
+	const active = harness.session._retryFallback?.activeState;
+	if (!active?.pinned || !active.pinnedByRefusal) fail("refusal fallback was not pinned");
+
+	const firstEntry = harness.sessionManager.getEntries()[0];
+	if (!firstEntry) fail("session has no entry for compaction");
+	const result = await harness.session.applyCompaction(
+		{ summary: "fresh summary", firstKeptEntryId: firstEntry.id, tokensBefore: 42, details: { source: "manual-qa" } },
+		{ reason: "extension", expectedRevision: harness.session.getMessageRevision() },
+	);
+	if (result.applied !== true) fail(`compaction did not apply: ${result.reason}`);
+	if (harness.session.model?.id !== primaryModelId) fail(`primary was not restored before next prompt: ${harness.session.model?.id}`);
+
+	const logPath = join(harness.tempDir, "agent", "logs", "fallback.log");
+	const log = readFileSync(logPath, "utf8");
+	const released = log.indexOf('"event":"refusal_pin_released"');
+	const reverted = log.indexOf('"event":"fallback_reverted"');
+	if (released < 0) fail("fallback.log lacks refusal_pin_released");
+	if (reverted < 0) fail("fallback.log lacks fallback_reverted");
+	if (released > reverted) fail("release event occurs after revert event");
+
+	console.log("primary -> fallback (refusal, pinned) -> compaction -> primary");
+	console.log(JSON.stringify({
+		modelCalls: harness.faux.getCallLog().map((call) => call.modelId),
+		compaction: result,
+		logEvents: ["refusal_pin_released", "fallback_reverted"],
+	}, null, 2));
+} finally {
+	harness.cleanup();
+}

--- a/packages/coding-agent/test/suite/agent-session-compaction-refusal-restore.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction-refusal-restore.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CompactionResult } from "../../src/core/compaction/index.ts";
 import { createHarness, type Harness } from "./harness.ts";
@@ -278,5 +279,71 @@ describe("agent-session compaction refusal unpin + eager restore", () => {
 		]);
 		expect(harness.eventsOfType("retry_fallback_reverted")).toMatchObject([{ from: fallback, to: primary }]);
 		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: true, pinnedByBilling: false });
+	});
+
+	it("(6) restores the primary before the queued continuation admitted after a mid-run compaction", async () => {
+		// A tool result large enough to push the post-tool context over the
+		// threshold of a 40k-token window, so compaction runs while the agent run
+		// is still active (isStreaming) and its queued continuation follows.
+		const largeToolResult = "tool output ".repeat(20_000);
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 40_000 },
+				{ id: "faux-2", contextWindow: 40_000 },
+			],
+			fallbackNow: () => 0,
+			settings: {
+				compaction: { enabled: true, keepRecentTokens: 1, reserveTokens: 1_000 },
+				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+			extensionFactories: [
+				(pi) => {
+					pi.registerTool({
+						name: "large_result",
+						label: "Large Result",
+						description: "Return text that pushes the session over the compaction threshold",
+						parameters: Type.Object({}),
+						execute: async () => ({ content: [{ type: "text", text: largeToolResult }], details: {} }),
+					});
+					pi.on("session_before_compact", async (event) => ({
+						compaction: {
+							summary: "mid-run compaction summary",
+							firstKeptEntryId: event.preparation.firstKeptEntryId,
+							tokensBefore: event.preparation.tokensBefore,
+							details: {},
+						},
+					}));
+				},
+			],
+		});
+		harnesses.push(harness);
+
+		const modelAtContinuation: string[] = [];
+		const revertsBeforeContinuation: number[] = [];
+		harness.setResponses([
+			refusal("primary refusal"),
+			fauxAssistantMessage(fauxToolCall("large_result", {}), { stopReason: "toolUse" }),
+			() => {
+				modelAtContinuation.push(harness.session.model?.id ?? "");
+				revertsBeforeContinuation.push(harness.eventsOfType("retry_fallback_reverted").length);
+				return fauxAssistantMessage("continuation answer");
+			},
+			fauxAssistantMessage("unexpected extra call"),
+		]);
+
+		await harness.session.prompt("run the large result tool");
+		await harness.session.waitForIdle();
+
+		// A senpi-owned compaction did succeed while the run was active.
+		expect(harness.eventsOfType("compaction_end").filter((event) => event.accepted === true)).toHaveLength(1);
+
+		// The next provider request after that compaction must run on the primary,
+		// with exactly one revert emitted before it.
+		expect(revertsBeforeContinuation).toEqual([1]);
+		expect(modelAtContinuation).toEqual(["faux-1"]);
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2", "faux-1"]);
+		expect(harness.eventsOfType("retry_fallback_reverted")).toMatchObject([{ from: fallback, to: primary }]);
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(fallbackState(harness)).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/suite/agent-session-compaction-refusal-restore.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-compaction-refusal-restore.test.ts
@@ -1,0 +1,282 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CompactionResult } from "../../src/core/compaction/index.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+
+function refusal(text: string): ReturnType<typeof fauxAssistantMessage> {
+	return fauxAssistantMessage(text, {
+		stopReason: "error",
+		errorMessage: "misleading_success_output",
+		stopDetails: { type: "refusal" },
+	});
+}
+
+// Verbatim provider error captured from a real session (2026-07-28, anthropic-api
+// claude-fable-5): the billing class whose pins compaction must never release.
+const creditBalanceError =
+	'400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_011CdUDPLwbT8EDXCxMJBvQy"}';
+
+const billingError = () => fauxAssistantMessage("", { stopReason: "error", errorMessage: creditBalanceError });
+
+interface FallbackStateView {
+	pinned: boolean;
+	pinnedByRefusal: boolean;
+	pinnedByBilling: boolean;
+}
+
+interface ControllerApi {
+	activeState: Readonly<FallbackStateView> | undefined;
+	notifyCompactionApplied(): boolean;
+}
+
+interface SessionRestoreSeam {
+	_maybeRestoreFallbackPrimary(): Promise<void>;
+}
+
+function controller(harness: Harness): ControllerApi {
+	return (harness.session as unknown as { _retryFallback: ControllerApi })._retryFallback;
+}
+
+function fallbackState(harness: Harness): FallbackStateView | undefined {
+	return controller(harness).activeState;
+}
+
+function restoreSeam(harness: Harness): SessionRestoreSeam {
+	return harness.session as unknown as SessionRestoreSeam;
+}
+
+function refusalReleaseLines(harness: Harness): string[] {
+	try {
+		return readFileSync(join(harness.tempDir, "agent", "logs", "fallback.log"), "utf8")
+			.split("\n")
+			.filter(Boolean)
+			.filter((line) => line.includes('"event":"refusal_pin_released"'));
+	} catch {
+		return [];
+	}
+}
+
+function createPrecomputedCompaction(harness: Harness, summary: string): CompactionResult {
+	const firstEntry = harness.sessionManager.getEntries()[0];
+	if (!firstEntry) {
+		throw new Error("Expected at least one session entry");
+	}
+
+	return {
+		summary,
+		firstKeptEntryId: firstEntry.id,
+		tokensBefore: 42,
+		details: { source: "test" },
+	};
+}
+
+function compactionEntries(harness: Harness): number {
+	return harness.sessionManager.getEntries().filter((entry) => entry.type === "compaction").length;
+}
+
+describe("agent-session compaction refusal unpin + eager restore", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("(1) restores the refusal-pinned primary eagerly after a successful compaction apply", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 128_000 },
+				{ id: "faux-2", contextWindow: 128_000 },
+			],
+			fallbackNow: () => 0,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: true, pinnedByBilling: false });
+
+		const expectedRevision = harness.session.getMessageRevision();
+		const result = await harness.session.applyCompaction(createPrecomputedCompaction(harness, "fresh summary"), {
+			reason: "extension",
+			expectedRevision,
+		});
+		expect(result).toEqual({ applied: true, reason: "ok" });
+		expect(compactionEntries(harness)).toBe(1);
+
+		// The restore is eager: the primary is selected before the next request is
+		// built (no extra provider call happened for the switch itself).
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(fallbackState(harness)).toBeUndefined();
+
+		const reverted = harness.eventsOfType("retry_fallback_reverted");
+		expect(reverted).toMatchObject([{ from: fallback, to: primary }]);
+		const types = harness.events.map((event) => event.type);
+		expect(types.indexOf("retry_fallback_reverted")).toBeGreaterThan(types.lastIndexOf("compaction_end"));
+
+		// The turn-boundary / retry-continuation restore seam is a no-op after the
+		// eager restore: state is cleared, so no second switchModel can occur.
+		const callsBeforeSecondRestore = harness.faux.getCallLog().length;
+		await restoreSeam(harness)._maybeRestoreFallbackPrimary();
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(harness.faux.getCallLog().length).toBe(callsBeforeSecondRestore);
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(1);
+	});
+
+	it("(2) keeps the refusal pin when the compaction apply fails or is rejected", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 128_000 },
+				{ id: "faux-2", contextWindow: 128_000 },
+			],
+			fallbackNow: () => 0,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.session.model?.id).toBe("faux-2");
+		const expectedRevision = harness.session.getMessageRevision();
+
+		// Stale revision: rejected before any context rewrite.
+		const oversized = createPrecomputedCompaction(harness, "overflow".repeat(1_000_000));
+		const stale = await harness.session.applyCompaction(oversized, {
+			reason: "extension",
+			expectedRevision: expectedRevision + 1,
+		});
+		expect(stale).toEqual({ applied: false, reason: "stale" });
+
+		// Would-overflow: the execution seam itself rejects with an errorMessage.
+		const rejected = await harness.session.applyCompaction(oversized, {
+			reason: "extension",
+			expectedRevision,
+		});
+		expect(rejected).toEqual({ applied: false, reason: "rejected" });
+		const failureEnds = harness.eventsOfType("compaction_end").filter((event) => event.errorMessage !== undefined);
+		expect(failureEnds.length).toBeGreaterThanOrEqual(1);
+		expect(compactionEntries(harness)).toBe(0);
+
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: true, pinnedByBilling: false });
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+		expect(refusalReleaseLines(harness)).toHaveLength(0);
+	});
+
+	it("(3) holds a billing fallback across a successful compaction apply", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 128_000 },
+				{ id: "faux-2", contextWindow: 128_000 },
+			],
+			fallbackNow: () => 0,
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([billingError(), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.eventsOfType("retry_fallback_applied").map((event) => event.reason)).toEqual(["billing"]);
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		const result = await harness.session.applyCompaction(createPrecomputedCompaction(harness, "billing stays"), {
+			reason: "extension",
+			expectedRevision: harness.session.getMessageRevision(),
+		});
+		expect(result).toEqual({ applied: true, reason: "ok" });
+		expect(compactionEntries(harness)).toBe(1);
+
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: false, pinnedByBilling: true });
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+		expect(refusalReleaseLines(harness)).toHaveLength(0);
+	});
+
+	it('(4) unpins under revertPolicy "never" but never restores', async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 128_000 },
+				{ id: "faux-2", contextWindow: 128_000 },
+			],
+			fallbackNow: () => 0,
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+					fallbackRevertPolicy: "never",
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		const result = await harness.session.applyCompaction(createPrecomputedCompaction(harness, "never summary"), {
+			reason: "extension",
+			expectedRevision: harness.session.getMessageRevision(),
+		});
+		expect(result).toEqual({ applied: true, reason: "ok" });
+
+		// The unpin ran through the seam, but the policy holds the fallback model.
+		expect(fallbackState(harness)).toMatchObject({ pinned: false, pinnedByRefusal: false, pinnedByBilling: false });
+		expect(refusalReleaseLines(harness)).toHaveLength(1);
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+
+		harness.setResponses([fauxAssistantMessage("fallback again")]);
+		await harness.session.prompt("second");
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.faux.getCallLog()[2]?.modelId).toBe("faux-2");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+	});
+
+	it("(5) re-pins when the restored primary refuses again (one attempt per compaction)", async () => {
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", contextWindow: 128_000 },
+				{ id: "faux-2", contextWindow: 128_000 },
+			],
+			fallbackNow: () => 0,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			refusal("primary refusal"),
+			fauxAssistantMessage("fallback answer"),
+			refusal("primary refusal again"),
+			fauxAssistantMessage("fallback answer again"),
+		]);
+
+		await harness.session.prompt("hello");
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: true });
+
+		const result = await harness.session.applyCompaction(createPrecomputedCompaction(harness, "bound summary"), {
+			reason: "extension",
+			expectedRevision: harness.session.getMessageRevision(),
+		});
+		expect(result).toEqual({ applied: true, reason: "ok" });
+		expect(harness.session.model?.id).toBe("faux-1");
+
+		await harness.session.prompt("second");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2", "faux-1", "faux-2"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "refusal" },
+			{ from: primary, to: fallback, reason: "refusal" },
+		]);
+		expect(harness.eventsOfType("retry_fallback_reverted")).toMatchObject([{ from: fallback, to: primary }]);
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: true, pinnedByBilling: false });
+	});
+});

--- a/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
@@ -1,10 +1,14 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import modelFallbackExtension from "../../src/core/extensions/builtin/model-fallback/index.ts";
+import { renderFallbackState } from "../../src/core/extensions/builtin/model-fallback/ui.ts";
 import { createHarness, type Harness } from "./harness.ts";
 
 const primary = "faux/faux-1";
 const fallback = "faux/faux-2";
+
+const billingError =
+	'400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."}}';
 
 function getFallbackCommand(harness: Harness) {
 	const command = harness.getExtensionRunner().getCommand("fallback");
@@ -79,6 +83,57 @@ describe("model fallback host wiring", () => {
 			if (previous === undefined) delete process.env.SENPI_NO_FALLBACK;
 			else process.env.SENPI_NO_FALLBACK = previous;
 		}
+	});
+
+	it("exposes refusal pin state and badge semantics through the live menu accessor", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "refusal", stopDetails: { type: "refusal" } }),
+			fauxAssistantMessage("recovered"),
+		]);
+		await harness.session.prompt("create a refusal fallback");
+		const context = harness.getExtensionRunner().createCommandContext();
+		expect(context.sessionSettings.getFallbackStatus()?.pinned).toBe(true);
+		expect(renderFallbackState(context, harness.settingsManager.getRetryFallbackSettings())).toContain("(pinned)");
+
+		expect(
+			(
+				harness.session as unknown as { _retryFallback: { notifyCompactionApplied(): boolean } }
+			)._retryFallback.notifyCompactionApplied(),
+		).toBe(true);
+		expect(context.sessionSettings.getFallbackStatus()?.pinned).toBe(false);
+		expect(renderFallbackState(context, harness.settingsManager.getRetryFallbackSettings())).not.toContain(
+			"(pinned)",
+		);
+	});
+
+	it("keeps billing pins in the live status and badge after compaction", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: billingError }),
+			fauxAssistantMessage("recovered"),
+		]);
+		await harness.session.prompt("create a billing fallback");
+		const context = harness.getExtensionRunner().createCommandContext();
+		expect(context.sessionSettings.getFallbackStatus()?.pinned).toBe(true);
+		expect(renderFallbackState(context, harness.settingsManager.getRetryFallbackSettings())).toContain("(pinned)");
+		expect(
+			(
+				harness.session as unknown as { _retryFallback: { notifyCompactionApplied(): boolean } }
+			)._retryFallback.notifyCompactionApplied(),
+		).toBe(false);
+		expect(context.sessionSettings.getFallbackStatus()?.pinned).toBe(true);
+		expect(renderFallbackState(context, harness.settingsManager.getRetryFallbackSettings())).toContain("(pinned)");
 	});
 
 	it("exposes active retry state through the live menu accessor", async () => {

--- a/packages/coding-agent/test/suite/retry-fallback-compaction-unpin.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-compaction-unpin.test.ts
@@ -1,0 +1,249 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHarness, type Harness } from "./harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+const nextFallback = "faux/faux-3";
+
+function refusal(text: string): ReturnType<typeof fauxAssistantMessage> {
+	return fauxAssistantMessage(text, {
+		stopReason: "error",
+		errorMessage: "misleading_success_output",
+		stopDetails: { type: "refusal" },
+	});
+}
+
+// Verbatim provider error captured from a real session (2026-07-28, anthropic-api
+// claude-fable-5): the billing class whose pins compaction must never release.
+const creditBalanceError =
+	'400 {"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits."},"request_id":"req_011CdUDPLwbT8EDXCxMJBvQy"}';
+
+const billingError = () => fauxAssistantMessage("", { stopReason: "error", errorMessage: creditBalanceError });
+const transientError = () => fauxAssistantMessage("", { stopReason: "error", errorMessage: "overloaded_error" });
+
+interface FallbackStateView {
+	pinned: boolean;
+	pinnedByRefusal: boolean;
+	pinnedByBilling: boolean;
+}
+
+interface ControllerApi {
+	activeState: Readonly<FallbackStateView> | undefined;
+	notifyCompactionApplied(): boolean;
+}
+
+function controller(harness: Harness): ControllerApi {
+	return (harness.session as unknown as { _retryFallback: ControllerApi })._retryFallback;
+}
+
+function fallbackState(harness: Harness): FallbackStateView | undefined {
+	return controller(harness).activeState;
+}
+
+function fallbackLogLines(harness: Harness): string[] {
+	try {
+		return readFileSync(join(harness.tempDir, "agent", "logs", "fallback.log"), "utf8")
+			.split("\n")
+			.filter(Boolean);
+	} catch {
+		return [];
+	}
+}
+
+function refusalReleaseLines(harness: Harness): string[] {
+	return fallbackLogLines(harness).filter((line) => line.includes('"event":"refusal_pin_released"'));
+}
+
+describe("retry fallback compaction unpin", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("(1) releases a refusal pin on compaction and lets the existing cooldown-expiry restore fire", async () => {
+		const now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: true, pinnedByBilling: false });
+
+		expect(controller(harness).notifyCompactionApplied()).toBe(true);
+		expect(fallbackState(harness)).toMatchObject({ pinned: false, pinnedByRefusal: false, pinnedByBilling: false });
+
+		// The unpin alone must make the existing turn-boundary gate restore the primary.
+		harness.setResponses([fauxAssistantMessage("primary answer")]);
+		await harness.session.prompt("post-compaction");
+
+		const reverted = harness.eventsOfType("retry_fallback_reverted");
+		expect(reverted).toHaveLength(1);
+		expect(reverted[0]).toMatchObject({ from: fallback, to: primary });
+		expect(harness.session.model?.id).toBe("faux-1");
+		expect(harness.faux.getCallLog().at(-1)?.modelId).toBe("faux-1");
+		expect(fallbackState(harness)).toBeUndefined();
+		expect(refusalReleaseLines(harness)).toHaveLength(1);
+		const releaseLine = refusalReleaseLines(harness)[0];
+		expect(releaseLine).toContain(`"chainKey":"${primary}"`);
+		expect(releaseLine).toContain(`"originalSelector":"${primary}"`);
+		expect(releaseLine).toContain('"trigger":"compaction"');
+	});
+
+	it("(2) never releases a billing pin and keeps refusing the restore", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([billingError(), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.eventsOfType("retry_fallback_applied").map((event) => event.reason)).toEqual(["billing"]);
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: false, pinnedByBilling: true });
+
+		expect(controller(harness).notifyCompactionApplied()).toBe(false);
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByBilling: true });
+		expect(refusalReleaseLines(harness)).toHaveLength(0);
+
+		// Far past the 30-minute billing cooldown: the billing contribution must hold.
+		now += 31 * 60_000;
+		harness.setResponses([fauxAssistantMessage("still fallback")]);
+		await harness.session.prompt("second");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-2");
+	});
+
+	it("(3) holds the pin when billing compounds an earlier refusal", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }, { id: "faux-3" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback, nextFallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), billingError(), fauxAssistantMessage("next answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.eventsOfType("retry_fallback_applied").map((event) => event.reason)).toEqual([
+			"refusal",
+			"billing",
+		]);
+		expect(harness.session.model?.id).toBe("faux-3");
+		expect(fallbackState(harness)).toMatchObject({
+			pinned: true,
+			pinnedByRefusal: true,
+			pinnedByBilling: true,
+		});
+
+		// The refusal contribution clears but the billing contribution keeps the pin.
+		expect(controller(harness).notifyCompactionApplied()).toBe(false);
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByBilling: true });
+		expect(refusalReleaseLines(harness)).toHaveLength(0);
+
+		now += 31 * 60_000;
+		harness.setResponses([fauxAssistantMessage("still next")]);
+		await harness.session.prompt("second");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-3");
+	});
+
+	it('(4) unpins under revertPolicy "never" but still refuses the restore', async () => {
+		const now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+					fallbackRevertPolicy: "never",
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([refusal("primary refusal"), fauxAssistantMessage("fallback answer")]);
+
+		await harness.session.prompt("hello");
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		expect(controller(harness).notifyCompactionApplied()).toBe(true);
+		expect(fallbackState(harness)).toMatchObject({ pinned: false, pinnedByRefusal: false });
+
+		harness.setResponses([fauxAssistantMessage("fallback again")]);
+		await harness.session.prompt("second");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toEqual([]);
+		expect(harness.session.model?.id).toBe("faux-2");
+		expect(harness.faux.getCallLog()[2]?.modelId).toBe("faux-2");
+	});
+
+	it("(5) is a no-op without active fallback state and writes no release log", async () => {
+		let now = 0;
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => now,
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		// A transient fallback that reverts leaves no active state but does leave a
+		// populated fallback.log, so the "no release log" check is meaningful.
+		harness.setResponses([transientError(), fauxAssistantMessage("fallback answer")]);
+		await harness.session.prompt("hello");
+		expect(harness.session.model?.id).toBe("faux-2");
+
+		now += 10 * 60_000; // past the 45s(+jitter) transient cooldown
+		harness.setResponses([fauxAssistantMessage("primary back")]);
+		await harness.session.prompt("second");
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(1);
+		expect(fallbackState(harness)).toBeUndefined();
+
+		expect(controller(harness).notifyCompactionApplied()).toBe(false);
+		expect(refusalReleaseLines(harness)).toHaveLength(0);
+	});
+
+	it("(6) re-pins when the restored primary refuses again", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			fallbackNow: () => 0,
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			refusal("primary refusal"),
+			fauxAssistantMessage("fallback answer"),
+			refusal("primary refusal again"),
+			fauxAssistantMessage("fallback answer again"),
+		]);
+
+		await harness.session.prompt("hello");
+		expect(controller(harness).notifyCompactionApplied()).toBe(true);
+
+		// The restore puts the primary back, its second refusal re-enters the
+		// existing refusal path: one fresh primary attempt per compaction, no ping-pong.
+		await harness.session.prompt("second");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2", "faux-1", "faux-2"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, reason: "refusal" },
+			{ from: primary, to: fallback, reason: "refusal" },
+		]);
+		expect(harness.eventsOfType("retry_fallback_reverted")).toHaveLength(1);
+		expect(fallbackState(harness)).toMatchObject({ pinned: true, pinnedByRefusal: true, pinnedByBilling: false });
+	});
+});


### PR DESCRIPTION
## Summary

Release refusal-caused model-fallback pins when a senpi-owned compaction successfully rewrites the context, and eagerly re-attempt the original (primary) model — bounded to one retry per compaction (a fresh refusal re-pins via the existing path).

- `retry-fallback/controller.ts`: `ActiveFallbackState` gains pin provenance (`pinnedByRefusal`/`pinnedByBilling`; public `pinned` stays the derived OR); new `notifyCompactionApplied()` releases only the refusal contribution and logs `refusal_pin_released`. Billing pins never release; `fallbackRevertPolicy: "never"` still suppresses restore.
- `agent-session.ts`: single call of `_onCompactionContextChanged()` at the shared `_executeCompaction` success seam (all manual /compact, extension applyCompaction, pre-prompt and auto applies funnel through it; every failure/reject/abort path returns before it). Restore reuses the existing `maybeRestorePrimary` gate — no new settings key, no new UI event.
- `log.ts`: `trigger` added to the scrubbing allowlist so the release payload survives.
- Docs: retry-fallback AGENTS.md convention + core/changes.md entry.

## Evidence

- TDD per todo: RED (6/6 fail on missing API; 3/5 fail on behavior) → GREEN → mutation proofs (stub kills cases; choke-point comment kills 3).
- Post-rebase re-verified at HEAD 0644fbc2c: `bun test` feature suites 17 pass / 0 fail; `bun test/manual-qa/refusal-unpin-compaction-qa.mjs` exit 0 with timeline `primary -> fallback (refusal, pinned) -> compaction -> primary` and log order `refusal_pin_released` -> `fallback_reverted`; narrow biome gate exit 0; `tsc --noEmit` exit 0.
- Full retry-fallback + compaction shard: green except 7 pre-existing `retry-fallback-probe-scheduler.test.ts` failures (`vi.waitFor` under bun test; reproduce identically on pristine main — untouched by this diff).
- F-wave review (4 independent reviewers): plan-compliance APPROVE, code-quality APPROVE (state-machine invariant, abort interplay on all owners, streaming-race atomicity), manual-QA APPROVE (incl. scrubbing check on a live fallback.log), scope-fidelity REJECT→fixed (biome)→delta re-audit APPROVE.
- Plan: .omo/plans/senpi-refusal-unpin-on-compaction.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases refusal-caused model fallback pins when a successful compaction rewrites the conversation context, so the primary model gets one fresh attempt instead of staying stuck on the fallback.

- Restores the primary before queued continuations admitted after a mid-run compaction, so the first post-compaction provider request runs on the primary.
- `RetryFallbackController` now records pin provenance (`pinnedByRefusal` / `pinnedByBilling`); only refusal pins release on compaction.
- The release happens at the shared compaction success seam, covering manual `/compact`, extension, pre-prompt, and auto compaction.
- Billing pins and `fallbackRevertPolicy: "never"` still hold the fallback; a fresh refusal re-pins through the existing path.
- No new settings key or UI event; the release event is allowed through the `fallback.log` scrubber.
- Existing fallback status and badge UI reflect the unpin through the live menu accessor.
- Adds a changelog entry documenting the new behavior.

<sup>Written for commit e184dc32296a7bee507048e83cab9e701fe9e63d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

