### PR TITLE
style(coding-agent): fix biome format drift from #1230

### DIFF
--- a/packages/coding-agent/src/utils/changes.md
+++ b/packages/coding-agent/src/utils/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## Fix biome import-order format drift from #1230 (2026-08-31)
+
+### What changed
+
+- `packages/coding-agent/src/utils/fs-watch.ts` import specifiers reordered by `biome check --write` (type-only `FSWatcher` after `realpathSync`). Formatting only; zero behavior change.
+
+### Why
+
+- #1230 merged with biome format drift on this file, so every subsequent contributor's pre-commit `--write` pass re-fixed it and smuggled the hunk into unrelated commits. Same class as #1231.
+
+### Why an extension could not handle it
+
+- Not applicable: repository formatting hygiene, no runtime surface.
+
+### Expected merge conflict zones
+
+- LOW: `fs-watch.ts` import block only.
+
 ## Canonicalize Windows fs.watch paths before watching (2026-08-31)
 
 ### What changed

--- a/packages/coding-agent/src/utils/fs-watch.ts
+++ b/packages/coding-agent/src/utils/fs-watch.ts
@@ -1,4 +1,4 @@
-import { realpathSync, type FSWatcher, type WatchListener, type WatchOptions, watch } from "node:fs";
+import { type FSWatcher, realpathSync, type WatchListener, type WatchOptions, watch } from "node:fs";
 
 export const FS_WATCH_RETRY_DELAY_MS = 5000;
 

--- a/packages/coding-agent/test/suite/regressions/issue-1229-win-fswatch-noncanonical-abort.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-1229-win-fswatch-noncanonical-abort.test.ts
@@ -108,6 +108,8 @@ writeFileSync(join(directory, "regression-write-1229.txt"), "change");
 			});
 		});
 
-		expect(exit.code, `Child exited with code ${exit.code} (signal ${exit.signal}). stderr: ${stderr.trim()}`).toBe(0);
+		expect(exit.code, `Child exited with code ${exit.code} (signal ${exit.signal}). stderr: ${stderr.trim()}`).toBe(
+			0,
+		);
 	});
 });


### PR DESCRIPTION
Import-order biome drift on origin/main introduced by #1230 (pre-commit --write fixes surfaced while committing #1234; verified via `git show origin/main:<file> | bunx biome check --stdin-file-path`). Same class as #1231. Label: no-changelog (formatting only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Biome format drift in `packages/coding-agent` introduced by #1230 so the tree stays consistent with the formatter.

- Applies import-order and line-wrapping fixes and records the drift in `changes.md`.
- No behavior changes.

<sup>Written for commit e4ac5c0fd6df93c07c4e19945553e7f68970f360. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

