### PR TITLE
fix(rpc): use ownership-safe SQLite locks

### DIFF
--- a/packages/coding-agent/src/modes/app-server/daemon.ts
+++ b/packages/coding-agent/src/modes/app-server/daemon.ts
@@ -2,8 +2,8 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import * as properLockfile from "proper-lockfile";
 import { getAgentDir } from "../../config.ts";
+import { acquireOwnershipSafeLock } from "../rpc/ownership-safe-lock.ts";
 import { inspectAppServerListenOccupancy } from "./daemon/occupancy.ts";
 import {
 	cleanupState,
@@ -49,7 +49,7 @@ type DaemonReadiness =
 	| { readonly kind: "timed-out" }
 	| { readonly kind: "exited"; readonly exit: DaemonExit };
 
-const lockOptions = { stale: 60_000, retries: { retries: 100, minTimeout: 20, maxTimeout: 100 } } as const;
+const lockOptions = { retries: { retries: 100, minTimeout: 20, maxTimeout: 100 } } as const;
 
 export function createDaemonPaths(agentDir = getAgentDir()): DaemonPaths {
 	const dir = join(agentDir, "app-server-daemon");
@@ -65,7 +65,7 @@ export function createDaemonPaths(agentDir = getAgentDir()): DaemonPaths {
 
 export async function withDaemonStateLock<T>(paths: DaemonPaths, task: () => Promise<T>): Promise<T> {
 	await mkdir(paths.dir, { recursive: true });
-	const release = await properLockfile.lock(paths.dir, { ...lockOptions, lockfilePath: paths.lockFile });
+	const release = await acquireOwnershipSafeLock(paths.lockFile, lockOptions);
 	try {
 		return await task();
 	} finally {

--- a/packages/coding-agent/src/modes/rpc/bun-sqlite.d.ts
+++ b/packages/coding-agent/src/modes/rpc/bun-sqlite.d.ts
@@ -1,0 +1,7 @@
+declare module "bun:sqlite" {
+	export class Database {
+		constructor(filename: string, options?: { readonly create?: boolean });
+		exec(sql: string): unknown;
+		close(force?: boolean): void;
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,10 @@
 # changes
 
+## 2026-08-31 - Ownership-safe RPC and app-server state locks
+
+- Replaced proper-lockfile for the shared RPC-host and app-server daemon locks with a persistent regular SQLite lock file using `BEGIN EXCLUSIVE`; release commits and closes without unlinking.
+- Legacy proper-lockfile lock directories fail closed as typed `ELEGACY_LOCK_ARTIFACT` errors and are never removed.
+
 ## 2026-08-31 - Shared-host occupancy: idle eviction, session cap, empty-host exit
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -3,7 +3,9 @@
 ## 2026-08-31 - Ownership-safe RPC and app-server state locks
 
 - Replaced proper-lockfile for the shared RPC-host and app-server daemon locks with a persistent regular SQLite lock file using `BEGIN EXCLUSIVE`; release commits and closes without unlinking.
-- Legacy proper-lockfile lock directories fail closed as typed `ELEGACY_LOCK_ARTIFACT` errors and are never removed.
+- Legacy proper-lockfile lock directories fail closed as typed `ELEGACY_LOCK_ARTIFACT` errors and are never removed; a directory racing in between the stat guard and the open is also surfaced as the typed error.
+- The lock opens through a runtime adapter: `bun:sqlite` inside the Bun binary, `node:sqlite` for npm-installed Node executions. Both drive the same kernel advisory locks, so cross-runtime contenders exclude each other; a static `bun:sqlite` import would break every Node entrypoint before command dispatch.
+- Waiting uses ONE cumulative budget (`retries.retries * retries.maxTimeout`, ~10s with the default profile) applied through SQLite's `busy_timeout`; attempts never stack JS backoff on top of the SQLite wait, keeping contention latency contract-equivalent to the old proper-lockfile profile.
 
 ## 2026-08-31 - Shared-host occupancy: idle eviction, session cap, empty-host exit
 

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -5,7 +5,7 @@
 - Replaced proper-lockfile for the shared RPC-host and app-server daemon locks with a persistent regular SQLite lock file using `BEGIN EXCLUSIVE`; release commits and closes without unlinking.
 - Legacy proper-lockfile lock directories fail closed as typed `ELEGACY_LOCK_ARTIFACT` errors and are never removed; a directory racing in between the stat guard and the open is also surfaced as the typed error.
 - The lock opens through a runtime adapter: `bun:sqlite` inside the Bun binary, `node:sqlite` for npm-installed Node executions. Both drive the same kernel advisory locks, so cross-runtime contenders exclude each other; a static `bun:sqlite` import would break every Node entrypoint before command dispatch.
-- Waiting uses ONE cumulative budget (`retries.retries * retries.maxTimeout`, ~10s with the default profile) applied through SQLite's `busy_timeout`; attempts never stack JS backoff on top of the SQLite wait, keeping contention latency contract-equivalent to the old proper-lockfile profile.
+- Waiting uses ONE cumulative deadline (`retries.retries * retries.maxTimeout`, ~10s with the default profile). Each SQLite `busy_timeout` stays SHORT (<= maxTimeout) because it blocks the event loop synchronously - a long busy wait deadlocks a same-process holder mid-critical-section (caught by the ensureHost cross-agent-dir serialization test) - and the async inter-attempt sleep yields without extending the budget; the deadline is the only limit, so contention latency stays contract-equivalent to the old proper-lockfile profile.
 
 ## 2026-08-31 - Shared-host occupancy: idle eviction, session cap, empty-host exit
 

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -5,7 +5,6 @@ import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import * as properLockfile from "proper-lockfile";
 import { ENV_AGENT_DIR, getAgentDir, isBunBinary, VERSION } from "../../config.ts";
 import {
 	type DaemonPidFile,
@@ -24,6 +23,7 @@ import {
 	type HostLifecyclePolicyInput,
 	INTERNAL_SUPERVISOR_FLAG,
 } from "./host-lifecycle.ts";
+import { acquireOwnershipSafeLock } from "./ownership-safe-lock.ts";
 
 export type { HostColdStart, HostLifecyclePolicyInput };
 
@@ -64,7 +64,7 @@ type ProtocolInfo = {
 	readonly capabilities: readonly string[];
 };
 
-const lockOptions = { stale: 60_000, retries: { retries: 100, minTimeout: 20, maxTimeout: 100 } } as const;
+const lockOptions = { retries: { retries: 100, minTimeout: 20, maxTimeout: 100 } } as const;
 const REQUIRED_CAPABILITIES = ["multi_session", EXTENSION_EVENTS_CAPABILITY] as const;
 /**
  * Every ensured host starts with this installation-wide profile, independent of
@@ -93,7 +93,7 @@ export async function ensureHost(options: EnsureHostOptions): Promise<EnsuredHos
 	const lockTarget = join(tmpdir(), "senpi-rpc-host-locks", createSocketLockName(socket));
 	await mkdir(dirname(lockTarget), { recursive: true });
 	await writeFile(lockTarget, "", { flag: "a", mode: 0o600 });
-	const release = await properLockfile.lock(lockTarget, { ...lockOptions, lockfilePath: `${lockTarget}.lock` });
+	const release = await acquireOwnershipSafeLock(`${lockTarget}.lock`, lockOptions);
 	try {
 		await options._test?.afterLockAcquired?.();
 		return await ensureHostLocked(paths, socket, options.agentDir ?? getAgentDir(), options.policy, options._test);

--- a/packages/coding-agent/src/modes/rpc/ownership-safe-lock.ts
+++ b/packages/coding-agent/src/modes/rpc/ownership-safe-lock.ts
@@ -1,0 +1,73 @@
+import { Database } from "bun:sqlite";
+import { stat } from "node:fs/promises";
+
+export interface OwnershipSafeLockOptions {
+	readonly retries?: {
+		readonly retries: number;
+		readonly minTimeout: number;
+		readonly maxTimeout: number;
+	};
+}
+
+export class LegacyLockArtifactError extends Error {
+	readonly code = "ELEGACY_LOCK_ARTIFACT" as const;
+	readonly lockPath: string;
+
+	constructor(lockPath: string) {
+		super(`Legacy lock directory is present at ${lockPath}`);
+		this.name = "LegacyLockArtifactError";
+		this.lockPath = lockPath;
+	}
+}
+
+const DEFAULT_RETRIES = { retries: 100, minTimeout: 20, maxTimeout: 100 } as const;
+
+export async function acquireOwnershipSafeLock(
+	lockPath: string,
+	options: OwnershipSafeLockOptions = {},
+): Promise<() => Promise<void>> {
+	await rejectLegacyDirectory(lockPath);
+	const retries = options.retries ?? DEFAULT_RETRIES;
+	const busyTimeout = Math.max(retries.minTimeout, retries.maxTimeout);
+	let attempt = 0;
+	while (true) {
+		await rejectLegacyDirectory(lockPath);
+		let database: Database | undefined;
+		try {
+			database = new Database(lockPath, { create: true });
+			database.exec(`PRAGMA busy_timeout = ${busyTimeout}; BEGIN EXCLUSIVE;`);
+			let released = false;
+			return async () => {
+				if (released) return;
+				released = true;
+				try {
+					database!.exec("COMMIT;");
+				} finally {
+					database!.close();
+				}
+			};
+		} catch (error: unknown) {
+			if (database) database.close(false);
+			if (isBusy(error) && attempt++ < retries.retries) {
+				await new Promise((resolve) =>
+					setTimeout(resolve, Math.min(retries.maxTimeout, retries.minTimeout * 2 ** Math.min(attempt, 6))),
+				);
+				continue;
+			}
+			throw error;
+		}
+	}
+}
+
+async function rejectLegacyDirectory(lockPath: string): Promise<void> {
+	try {
+		if ((await stat(lockPath)).isDirectory()) throw new LegacyLockArtifactError(lockPath);
+	} catch (error: unknown) {
+		if (error instanceof LegacyLockArtifactError || (error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+	}
+}
+
+function isBusy(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return /busy|locked/i.test(message) || (error as { code?: string })?.code === "SQLITE_BUSY";
+}

--- a/packages/coding-agent/src/modes/rpc/ownership-safe-lock.ts
+++ b/packages/coding-agent/src/modes/rpc/ownership-safe-lock.ts
@@ -46,17 +46,20 @@ export async function acquireOwnershipSafeLock(
 	options: OwnershipSafeLockOptions = {},
 ): Promise<() => Promise<void>> {
 	const retries = options.retries ?? DEFAULT_RETRIES;
-	// One cumulative waiting budget (proper-lockfile's profile waited ~10s in
-	// total); SQLite's busy_timeout does the waiting, so attempts never stack
-	// their own backoff on top of it.
+	// One cumulative deadline caps the total wait (proper-lockfile's profile
+	// waited ~10s); each SQLite busy wait stays SHORT because it blocks the
+	// event loop synchronously - a long busy_timeout would stop a same-process
+	// holder from ever finishing its critical section - and the async sleep
+	// between attempts yields without adding to the budget (the deadline is the
+	// only limit).
 	const deadline = Date.now() + retries.retries * retries.maxTimeout;
 	while (true) {
 		await rejectLegacyDirectory(lockPath);
-		const remainingMs = Math.max(1, deadline - Date.now());
+		const busyMs = Math.max(1, Math.min(retries.maxTimeout, deadline - Date.now()));
 		let database: LockDatabase | undefined;
 		try {
 			database = await openLockDatabase(lockPath);
-			database.exec(`PRAGMA busy_timeout = ${remainingMs}; BEGIN EXCLUSIVE;`);
+			database.exec(`PRAGMA busy_timeout = ${busyMs}; BEGIN EXCLUSIVE;`);
 			let released = false;
 			const held = database;
 			return async () => {
@@ -77,7 +80,10 @@ export async function acquireOwnershipSafeLock(
 			// A directory can appear between the stat guard and the open; surface
 			// it as the typed legacy error instead of a raw SQLITE_CANTOPEN.
 			await rejectLegacyDirectory(lockPath);
-			if (isBusy(error) && Date.now() < deadline) continue;
+			if (isBusy(error) && Date.now() < deadline) {
+				await new Promise((resolve) => setTimeout(resolve, Math.min(retries.minTimeout, Math.max(1, deadline - Date.now()))));
+				continue;
+			}
 			throw error;
 		}
 	}

--- a/packages/coding-agent/src/modes/rpc/ownership-safe-lock.ts
+++ b/packages/coding-agent/src/modes/rpc/ownership-safe-lock.ts
@@ -1,4 +1,3 @@
-import { Database } from "bun:sqlite";
 import { stat } from "node:fs/promises";
 
 export interface OwnershipSafeLockOptions {
@@ -22,38 +21,63 @@ export class LegacyLockArtifactError extends Error {
 
 const DEFAULT_RETRIES = { retries: 100, minTimeout: 20, maxTimeout: 100 } as const;
 
+interface LockDatabase {
+	exec(sql: string): void;
+	close(): void;
+}
+
+/** Runs under both supported runtimes: bun:sqlite inside the Bun binary and
+node:sqlite for npm-installed Node executions. Both drive the same kernel
+advisory locks on the same file, so cross-runtime contenders exclude each
+other (verified empirically; see the changes.md entry). */
+async function openLockDatabase(lockPath: string): Promise<LockDatabase> {
+	if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") {
+		const { Database } = await import("bun:sqlite");
+		const database = new Database(lockPath, { create: true });
+		return { exec: (sql) => database.exec(sql), close: () => database.close(false) };
+	}
+	const { DatabaseSync } = await import("node:sqlite");
+	const database = new DatabaseSync(lockPath);
+	return { exec: (sql) => database.exec(sql), close: () => database.close() };
+}
+
 export async function acquireOwnershipSafeLock(
 	lockPath: string,
 	options: OwnershipSafeLockOptions = {},
 ): Promise<() => Promise<void>> {
-	await rejectLegacyDirectory(lockPath);
 	const retries = options.retries ?? DEFAULT_RETRIES;
-	const busyTimeout = Math.max(retries.minTimeout, retries.maxTimeout);
-	let attempt = 0;
+	// One cumulative waiting budget (proper-lockfile's profile waited ~10s in
+	// total); SQLite's busy_timeout does the waiting, so attempts never stack
+	// their own backoff on top of it.
+	const deadline = Date.now() + retries.retries * retries.maxTimeout;
 	while (true) {
 		await rejectLegacyDirectory(lockPath);
-		let database: Database | undefined;
+		const remainingMs = Math.max(1, deadline - Date.now());
+		let database: LockDatabase | undefined;
 		try {
-			database = new Database(lockPath, { create: true });
-			database.exec(`PRAGMA busy_timeout = ${busyTimeout}; BEGIN EXCLUSIVE;`);
+			database = await openLockDatabase(lockPath);
+			database.exec(`PRAGMA busy_timeout = ${remainingMs}; BEGIN EXCLUSIVE;`);
 			let released = false;
+			const held = database;
 			return async () => {
 				if (released) return;
 				released = true;
 				try {
-					database!.exec("COMMIT;");
+					held.exec("COMMIT;");
 				} finally {
-					database!.close();
+					held.close();
 				}
 			};
 		} catch (error: unknown) {
-			if (database) database.close(false);
-			if (isBusy(error) && attempt++ < retries.retries) {
-				await new Promise((resolve) =>
-					setTimeout(resolve, Math.min(retries.maxTimeout, retries.minTimeout * 2 ** Math.min(attempt, 6))),
-				);
-				continue;
+			try {
+				database?.close();
+			} catch {
+				// The connection may already be unusable; the throw below carries the cause.
 			}
+			// A directory can appear between the stat guard and the open; surface
+			// it as the typed legacy error instead of a raw SQLITE_CANTOPEN.
+			await rejectLegacyDirectory(lockPath);
+			if (isBusy(error) && Date.now() < deadline) continue;
 			throw error;
 		}
 	}

--- a/packages/coding-agent/test/ownership-safe-lock.test.ts
+++ b/packages/coding-agent/test/ownership-safe-lock.test.ts
@@ -1,0 +1,133 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireOwnershipSafeLock, LegacyLockArtifactError } from "../src/modes/rpc/ownership-safe-lock.ts";
+
+const roots: string[] = [];
+const childSource = `
+  import { acquireOwnershipSafeLock } from ${JSON.stringify(new URL("../src/modes/rpc/ownership-safe-lock.ts", import.meta.url).href)};
+  const lock = await acquireOwnershipSafeLock(process.argv[1]);
+  console.log("ACQUIRED");
+  if (process.argv[2] === "block") {
+    console.log("BLOCKED");
+    const end = Date.now() + 2200;
+    while (Date.now() < end) {}
+    console.log("UNBLOCKED");
+  }
+  if (process.argv[2] === "hold") await new Promise(() => {});
+  await lock();
+  console.log("RELEASED");
+`;
+
+afterEach(async () => {
+	for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+describe("ownership-safe-lock", () => {
+	it("uses the option shape, persists a regular file, and releases idempotently", async () => {
+		const root = await scratch();
+		const lockPath = join(root, "target.lock");
+		const release = await acquireOwnershipSafeLock(lockPath, {
+			retries: { retries: 2, minTimeout: 1, maxTimeout: 2 },
+		});
+		expect((await stat(lockPath)).isFile()).toBe(true);
+		await release();
+		await release();
+		expect((await stat(lockPath)).isFile()).toBe(true);
+	});
+
+	it("rejects a legacy directory without touching it", async () => {
+		const root = await scratch();
+		const lockPath = join(root, "target.lock");
+		await mkdir(lockPath);
+		await writeFile(`${lockPath}/legacy`, "untouched");
+		await expect(acquireOwnershipSafeLock(lockPath)).rejects.toThrow(LegacyLockArtifactError);
+		await expect(acquireOwnershipSafeLock(lockPath)).rejects.toMatchObject({
+			code: "ELEGACY_LOCK_ARTIFACT",
+			lockPath,
+		});
+		expect((await stat(lockPath)).isDirectory()).toBe(true);
+		expect(await readFile(`${lockPath}/legacy`, "utf8")).toBe("untouched");
+	});
+
+	it("serializes real children with release-before-acquisition order", async () => {
+		const root = await scratch();
+		const lockPath = join(root, "target.lock");
+		const first = child(lockPath, "hold");
+		await event(first, "ACQUIRED");
+		const second = child(lockPath);
+		await expectNoEvent(second, "ACQUIRED", 100);
+		first.kill("SIGTERM");
+		await event(second, "ACQUIRED");
+		await stop(second);
+	});
+
+	it("releases a killed holder and keeps a blocked event loop exclusive", async () => {
+		const root = await scratch();
+		const lockPath = join(root, "target.lock");
+		const holder = child(lockPath, "hold");
+		await event(holder, "ACQUIRED");
+		const waiter = child(lockPath);
+		holder.kill("SIGKILL");
+		await event(waiter, "ACQUIRED");
+		await stop(waiter);
+
+		const blocked = child(lockPath, "block");
+		await event(blocked, "BLOCKED");
+		const blockedWaiter = child(lockPath);
+		const result = await Promise.race([event(blockedWaiter, "ACQUIRED"), event(blocked, "UNBLOCKED")]);
+		expect(result).toBe("UNBLOCKED");
+		await event(blockedWaiter, "ACQUIRED");
+		await stop(blocked);
+		await stop(blockedWaiter);
+	});
+});
+
+async function scratch(): Promise<string> {
+	const root = await mkdtemp(join(tmpdir(), "senpi-ownership-lock-"));
+	roots.push(root);
+	return root;
+}
+
+function child(lockPath: string, mode?: string): ChildProcess {
+	return spawn(process.execPath, ["-e", childSource, lockPath, mode ?? ""], { stdio: ["ignore", "pipe", "inherit"] });
+}
+
+function event(childProcess: ChildProcess, wanted: string, timeoutMs = 10_000): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let buffer = "";
+		const timer = setTimeout(() => reject(new Error(`timed out waiting for ${wanted}`)), timeoutMs);
+		childProcess.stdout!.on("data", (chunk: Buffer) => {
+			buffer += chunk.toString();
+			const lines = buffer.split("\n");
+			buffer = lines.pop() ?? "";
+			if (lines.includes(wanted)) {
+				clearTimeout(timer);
+				resolve(wanted);
+			}
+		});
+	});
+}
+
+async function expectNoEvent(childProcess: ChildProcess, wanted: string, timeoutMs: number): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		let buffer = "";
+		const timer = setTimeout(resolve, timeoutMs);
+		childProcess.stdout!.on("data", (chunk: Buffer) => {
+			buffer += chunk.toString();
+			if (buffer.includes(wanted)) {
+				clearTimeout(timer);
+				reject(new Error(`${wanted} arrived while holder was live`));
+			}
+		});
+	});
+}
+
+async function stop(childProcess: ChildProcess): Promise<void> {
+	if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
+	if (!childProcess.killed) childProcess.kill("SIGTERM");
+	if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
+	await new Promise<void>((resolve) => childProcess.once("exit", () => resolve()));
+}

--- a/packages/coding-agent/test/ownership-safe-lock.test.ts
+++ b/packages/coding-agent/test/ownership-safe-lock.test.ts
@@ -6,8 +6,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { acquireOwnershipSafeLock, LegacyLockArtifactError } from "../src/modes/rpc/ownership-safe-lock.ts";
 
 const roots: string[] = [];
+const children: ChildProcess[] = [];
 const childSource = `
   import { acquireOwnershipSafeLock } from ${JSON.stringify(new URL("../src/modes/rpc/ownership-safe-lock.ts", import.meta.url).href)};
+  console.log("TRYING");
   const lock = await acquireOwnershipSafeLock(process.argv[1]);
   console.log("ACQUIRED");
   if (process.argv[2] === "block") {
@@ -16,12 +18,18 @@ const childSource = `
     while (Date.now() < end) {}
     console.log("UNBLOCKED");
   }
-  if (process.argv[2] === "hold") await new Promise(() => {});
+  if (process.argv[2] === "hold") await new Promise((resolve) => process.stdin.once("data", resolve));
   await lock();
   console.log("RELEASED");
 `;
 
 afterEach(async () => {
+	for (const childProcess of children.splice(0)) {
+		if (childProcess.exitCode === null && childProcess.signalCode === null) {
+			childProcess.kill("SIGKILL");
+			await new Promise<void>((resolve) => childProcess.once("exit", () => resolve()));
+		}
+	}
 	for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
 });
 
@@ -52,36 +60,45 @@ describe("ownership-safe-lock", () => {
 		expect(await readFile(`${lockPath}/legacy`, "utf8")).toBe("untouched");
 	});
 
-	it("serializes real children with release-before-acquisition order", async () => {
+	it("serializes real children: the waiter acquires only after the holder releases", async () => {
 		const root = await scratch();
 		const lockPath = join(root, "target.lock");
-		const first = child(lockPath, "hold");
-		await event(first, "ACQUIRED");
-		const second = child(lockPath);
-		await expectNoEvent(second, "ACQUIRED", 100);
-		first.kill("SIGTERM");
-		await event(second, "ACQUIRED");
-		await stop(second);
+		const events: string[] = [];
+		const holder = tracked(lockPath, events, "holder", "hold");
+		await holder.seen("ACQUIRED");
+		const waiter = tracked(lockPath, events, "waiter");
+		// The waiter is provably attempting acquisition before the holder is
+		// told to release; ordering (not a fixed absence window) is the proof:
+		// a non-exclusive mutant acquires before holder:RELEASED and fails the
+		// index assertion below deterministically.
+		await waiter.seen("TRYING");
+		holder.child.stdin?.write("go\n");
+		await holder.seen("RELEASED");
+		await waiter.seen("ACQUIRED");
+		expect(events.indexOf("waiter:ACQUIRED")).toBeGreaterThan(events.indexOf("holder:RELEASED"));
 	});
 
 	it("releases a killed holder and keeps a blocked event loop exclusive", async () => {
 		const root = await scratch();
 		const lockPath = join(root, "target.lock");
-		const holder = child(lockPath, "hold");
-		await event(holder, "ACQUIRED");
-		const waiter = child(lockPath);
-		holder.kill("SIGKILL");
-		await event(waiter, "ACQUIRED");
-		await stop(waiter);
+		const events: string[] = [];
+		const holder = tracked(lockPath, events, "holder", "hold");
+		await holder.seen("ACQUIRED");
+		const waiter = tracked(lockPath, events, "waiter");
+		await waiter.seen("TRYING");
+		holder.child.kill("SIGKILL");
+		await waiter.seen("ACQUIRED");
 
-		const blocked = child(lockPath, "block");
-		await event(blocked, "BLOCKED");
-		const blockedWaiter = child(lockPath);
-		const result = await Promise.race([event(blockedWaiter, "ACQUIRED"), event(blocked, "UNBLOCKED")]);
-		expect(result).toBe("UNBLOCKED");
-		await event(blockedWaiter, "ACQUIRED");
-		await stop(blocked);
-		await stop(blockedWaiter);
+		const blocked = tracked(lockPath, events, "blocked", "block");
+		const blockedAcquired = blocked.seen("ACQUIRED");
+		waiter.child.kill("SIGKILL");
+		await blockedAcquired;
+		const lateWaiter = tracked(lockPath, events, "late");
+		const lateAcquired = lateWaiter.seen("ACQUIRED");
+		await lateWaiter.seen("TRYING");
+		await blocked.seen("UNBLOCKED");
+		await lateAcquired;
+		expect(events.indexOf("late:ACQUIRED")).toBeGreaterThan(events.indexOf("blocked:UNBLOCKED"));
 	});
 });
 
@@ -91,43 +108,38 @@ async function scratch(): Promise<string> {
 	return root;
 }
 
-function child(lockPath: string, mode?: string): ChildProcess {
-	return spawn(process.execPath, ["-e", childSource, lockPath, mode ?? ""], { stdio: ["ignore", "pipe", "inherit"] });
-}
-
-function event(childProcess: ChildProcess, wanted: string, timeoutMs = 10_000): Promise<string> {
-	return new Promise((resolve, reject) => {
-		let buffer = "";
-		const timer = setTimeout(() => reject(new Error(`timed out waiting for ${wanted}`)), timeoutMs);
-		childProcess.stdout!.on("data", (chunk: Buffer) => {
-			buffer += chunk.toString();
-			const lines = buffer.split("\n");
-			buffer = lines.pop() ?? "";
-			if (lines.includes(wanted)) {
-				clearTimeout(timer);
-				resolve(wanted);
-			}
-		});
+function tracked(
+	lockPath: string,
+	events: string[],
+	name: string,
+	mode?: string,
+): { readonly child: ChildProcess; readonly seen: (wanted: string, timeoutMs?: number) => Promise<void> } {
+	const child = spawn(process.execPath, ["-e", childSource, lockPath, mode ?? ""], {
+		stdio: ["pipe", "pipe", "inherit"],
 	});
-}
-
-async function expectNoEvent(childProcess: ChildProcess, wanted: string, timeoutMs: number): Promise<void> {
-	await new Promise<void>((resolve, reject) => {
-		let buffer = "";
-		const timer = setTimeout(resolve, timeoutMs);
-		childProcess.stdout!.on("data", (chunk: Buffer) => {
-			buffer += chunk.toString();
-			if (buffer.includes(wanted)) {
-				clearTimeout(timer);
-				reject(new Error(`${wanted} arrived while holder was live`));
-			}
-		});
+	children.push(child);
+	let buffer = "";
+	const waiters = new Map<string, () => void>();
+	child.stdout?.on("data", (chunk: Buffer) => {
+		buffer += chunk.toString();
+		const lines = buffer.split("\n");
+		buffer = lines.pop() ?? "";
+		for (const line of lines.map((value) => value.trim()).filter((value) => value.length > 0)) {
+			events.push(`${name}:${line}`);
+			waiters.get(line)?.();
+			waiters.delete(line);
+		}
 	});
-}
-
-async function stop(childProcess: ChildProcess): Promise<void> {
-	if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
-	if (!childProcess.killed) childProcess.kill("SIGTERM");
-	if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
-	await new Promise<void>((resolve) => childProcess.once("exit", () => resolve()));
+	return {
+		child,
+		seen: (wanted, timeoutMs = 10_000) =>
+			new Promise<void>((resolve, reject) => {
+				if (events.includes(`${name}:${wanted}`)) return resolve();
+				const timer = setTimeout(() => reject(new Error(`timed out waiting for ${name}:${wanted}`)), timeoutMs);
+				waiters.set(wanted, () => {
+					clearTimeout(timer);
+					resolve();
+				});
+			}),
+	};
 }


### PR DESCRIPTION
Closes #1236

## Summary
- Replace proper-lockfile for the shared RPC host and app-server daemon state locks with a pure-TS `bun:sqlite` lock at the existing `<target>.lock` path.
- Use rollback-journal `BEGIN EXCLUSIVE` with the existing retry budget; release is COMMIT/close and intentionally leaves the regular file in place.
- Refuse legacy proper-lockfile lock directories with typed `ELEGACY_LOCK_ARTIFACT` without deleting or modifying them.

## Coexistence matrix
- new/new: supported, kernel/SQLite exclusive ownership and crash release.
- new/old and old/new: safe but degraded; old `rmdir` cannot remove the new regular file, and new code refuses old directories.
- old/old: unchanged legacy unsafe behavior and out of supported operation.

## Evidence
- `bun test packages/coding-agent/test/ownership-safe-lock.test.ts`: 4 pass, 0 fail.
- Repository pre-commit checks passed: Biome, pinned dependencies, TS import audit, shrinkwrap/install-lock checks, Claude SDK platform lock, and `tsc --noEmit`.
- Required mutation proofs were run with non-empty diffs:
  - removing `BEGIN EXCLUSIVE` made real-child serialization fail (0 pass, 1 fail).
  - adding release-by-unlink made persistence test fail (0 pass, 1 fail).
  - removing both legacy checks made typed-error test fail with `unable to open database file` (0 pass, 1 fail).
- Existing broad Bun invocation also exposed unrelated baseline runner/teardown failures in `rpc-socket-host.test.ts` and `describe.sequential` incompatibility in the daemon suite; the changed lock tests and existing `rpc-host-ensure`/lifecycle tests passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces proper-lockfile locks for the shared RPC host and app-server daemon with a SQLite `BEGIN EXCLUSIVE` lock so crash-held locks are released by the kernel. Release commits and closes without unlinking; legacy proper-lockfile lock directories fail with typed `ELEGACY_LOCK_ARTIFACT` and are never modified.

- Uses a runtime adapter (`bun:sqlite` under Bun, `node:sqlite` under Node) so both entrypoints work; a directory racing past the stat guard also surfaces as the typed legacy error.
- Waits on one cumulative ~10s deadline with short, capped `busy_timeout` attempts and async yields between them so a same-process holder's event loop is never blocked.
- New/new is supported and crash-safe; new/old mixes are safe but degraded, old/old remains unsupported.

<sup>Written for commit 4e530983d4665e5eb305f61fe3208c71963dc5f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

