### PR TITLE
test(compaction): pin the thrash-regression counter contract

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,20 @@
 # changes.md — builtin compaction policy
 
+## Emergency-prune counter emitted at its one true site (2026-09-01)
+
+### What changed
+
+The `emergency_prune` debug event previously fired in `index.ts` on the proactive
+speculative-start branch, so the counter recorded speculation starts, not prunes,
+and incident analysis (the 2026-08-30 session-death shape) read a corrupted value.
+That mislabeled emission is removed (the speculative start already logs
+`speculative_started` itself), and `buildCompactionContext` now emits the real
+`emergency_prune` exactly when `hardLimitEmergencyPrune` engaged - new array or
+`needsAggressiveCompaction` - through a `logEmergencyPrune` callback passed from
+the context handler. The thrash harness pins the shipped output-adjusted basis at
+the production context callsite with a band payload (image blocks, which bypass the
+text-part admission cap): the assertion fails when the callsite reverts to the full
+window.
 ## Recover compaction from a summarizer tool-call hijack (2026-08-31)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/context-pipeline.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/context-pipeline.ts
@@ -8,6 +8,7 @@ import {
 import { markOpenAiRemoteReplayBoundary } from "./openai-remote.ts";
 import { isOpenAiRemoteCompactionModel } from "./openai-remote-model.ts";
 import { admitContextToolResults, injectTokenBudgetReminder } from "./orchestration.ts";
+import { estimateTotalTokens } from "./overflow-retry.ts";
 import { repairOrphanedToolResults } from "./repair-tool-pairs.ts";
 import { type EmergencyPruneLatch, hardLimitEmergencyPrune } from "./speculative.ts";
 
@@ -24,6 +25,8 @@ export function buildCompactionContext(input: {
 	breakerFallback: boolean;
 	laneOwnsCompaction: boolean;
 	emergencyPruneLatch: EmergencyPruneLatch;
+	/** Emits the compaction log event for a real emergency prune at its one true site. */
+	logEmergencyPrune?: (fields: { route: string; tokensBefore: number; tokens: number }) => void;
 	reminder?: string;
 }) {
 	if (input.laneOwnsCompaction) {
@@ -47,6 +50,16 @@ export function buildCompactionContext(input: {
 	const emergency = input.laneOwnsCompaction
 		? { messages: sourceMessages, needsAggressiveCompaction: false }
 		: hardLimitEmergencyPrune(sourceMessages, input.promptContextWindow, input.emergencyPruneLatch);
+	// This is the ONE site that actually prunes, so the emergency_prune counter must be
+	// emitted here. Engagement shows up either as a rewritten message array or as
+	// needsAggressiveCompaction when nothing prunable remained.
+	if (!input.laneOwnsCompaction && (emergency.needsAggressiveCompaction || emergency.messages !== sourceMessages)) {
+		input.logEmergencyPrune?.({
+			route: "context-event",
+			tokensBefore: estimateTotalTokens(sourceMessages),
+			tokens: estimateTotalTokens(emergency.messages),
+		});
+	}
 	const marked = markOpenAiRemoteReplayBoundary(emergency.messages, {
 		model: input.ctx.model,
 		branchEntries: input.ctx.sessionManager.getBranch(),

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/index.ts
@@ -842,10 +842,9 @@ export default function compactionExtension(
 				leadTokens,
 			)
 		) {
-			getLogger(ctx).debug("emergency_prune", {
-				route: "context-event",
-				tokens: usageWithPendingPrompt.tokens ?? 0,
-			});
+			// The speculative start below logs "speculative_started" itself; logging
+			// "emergency_prune" here mislabeled proactive speculation as pruning and
+			// corrupted the counter the incident analysis relies on.
 			startSpeculativeCompaction(ctx, PROACTIVE_COMPACTION_INSTRUCTIONS);
 		}
 
@@ -898,6 +897,7 @@ export default function compactionExtension(
 				breakerFallback,
 				laneOwnsCompaction,
 				emergencyPruneLatch,
+				logEmergencyPrune: (fields) => getLogger(ctx).debug("emergency_prune", fields),
 			}),
 		};
 	});

--- a/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
+++ b/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
@@ -164,4 +164,59 @@ describe("production-shaped compaction thrash regression", () => {
 		expect(getPromptContextWindow(650_000, 128_000)).toBe(522_000);
 		expect(getPromptContextWindow(1_000_000, 384_000)).toBe(616_000);
 	});
+
+	it("pins the output-adjusted emergency basis at the production context callsite", async () => {
+		// Band scenario: 200K window with 100K maxTokens gives promptWindow = 100K.
+		// A context payload estimating ~120K tokens sits ABOVE the shipped engage point
+		// (0.95 * 100K = 95K) but BELOW the full-window engage point (0.95 * 200K = 190K).
+		// Shipped code (index.ts context handler passing getPromptContextWindow(...)) MUST
+		// emergency-prune here; mutating that callsite back to the full window makes this
+		// payload look safe and flips this assertion RED.
+		const contextWindow = 200_000;
+		const harness = await createHarness({
+			models: [{ id: `emergency-band-${contextWindow}`, contextWindow, maxTokens: 100_000 }],
+			settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+			extensionFactories: [(pi) => compactionExtension(pi)],
+		});
+		harnesses.push(harness);
+		const seedResponse = fauxAssistantMessage("band seed");
+		seedResponse.usage = { ...seedResponse.usage, input: 10_000, totalTokens: 10_000 };
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "band seed" }],
+			timestamp: 1,
+		});
+		harness.sessionManager.appendMessage({
+			...seedResponse,
+			api: harness.getModel().api,
+			provider: harness.getModel().provider,
+			model: harness.getModel().id,
+		});
+		harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+		expect(harness.session.getContextUsage()?.contextWindow).toBe(contextWindow);
+		// estimateTotalTokens scales with content length here, so size the payload
+		// directly in the (95K, 190K) band and make it PRUNABLE (tool results are what
+		// hardLimitEmergencyPrune can drop).
+		// Non-text image blocks bypass the text-part admission cap and estimate at
+		// ESTIMATED_IMAGE_CHARS (4800 chars -> 1200 tokens) each, so 100 images put the
+		// payload at ~120K tokens - inside the (95K, 190K) band for 200K/100K geometry.
+		const imageCount = 100;
+		const bandMessages = [
+			{
+				role: "user" as const,
+				content: [
+					{ type: "text" as const, text: "band question" },
+					...Array.from({ length: imageCount }, (_, i) => ({
+						type: "image" as const,
+						data: `data:image/png;base64,band-${i}`,
+						mimeType: "image/png",
+					})),
+				],
+				timestamp: 1,
+			},
+		];
+		await harness.getExtensionRunner().emitContext(bandMessages);
+		const events = logEvents(harness);
+		expect(count(events, "emergency_prune")).toBeGreaterThanOrEqual(1);
+	});
 });

--- a/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
+++ b/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
@@ -113,13 +113,31 @@ async function runLongSession(
 	const summary = deferred<ReturnType<typeof fauxAssistantMessage>>();
 	harness.setResponses([() => summary.promise, fauxAssistantMessage("normal response")]);
 	const runner = harness.getExtensionRunner();
+	// Idle speculation is gated on a PERSISTENT extension mode (idle.ts: tui/rpc/app-server).
+	// The suite harness leaves the runner at its "print" default, where agent_end can never
+	// reach startSpeculativeCompaction - which made any invalidation bound vacuous. Pin a
+	// real interactive mode so the speculative lifecycle actually runs.
+	runner.setUIContext(undefined, "tui");
 	if ((harness.session.getContextUsage()?.tokens ?? 0) < threshold - lead)
 		throw new Error(`usage too low: ${harness.session.getContextUsage()?.tokens}`);
 	const turn = runner.emit({ type: "agent_end", messages: [] });
 	for (let churnTurn = 0; churnTurn < 36; churnTurn++) {
 		for (let event = 0; event < 9; event++) await runner.emitContext([]);
 	}
-	expect(contextEvents).toBe(36 * 9);
+	// The churn above ran while a real speculative job was IN FLIGHT: the summary
+	// deferred is still unresolved here, so a logged start means the job was live for
+	// the whole churn. Without this, the invalidation bound is vacuous (0 <= 0 + 2
+	// passes with no speculative lifecycle at all). Asserted BEFORE the event count so
+	// a missing speculative lifecycle fails on its own cause, not on arithmetic.
+	const midChurn = logEvents(harness);
+	expect(count(midChurn, "speculative_started")).toBeGreaterThanOrEqual(1);
+	// A storm would invalidate on every one of the 324 churn context events; the shipped
+	// contract invalidates only on real lifecycle events.
+	expect(count(midChurn, "speculative_invalidated")).toBeLessThanOrEqual(count(midChurn, "speculative_started") + 2);
+	// 36x9 churn events plus exactly one context event from the in-flight speculative
+	// summary request itself - that extra event only exists because a real speculative
+	// job is running, so this count is itself part of the in-flight proof.
+	expect(contextEvents).toBe(36 * 9 + 1);
 	summary.resolve(fauxAssistantMessage("deterministic speculative summary"));
 	await turn;
 	await harness.session.prompt(`cross the threshold ${"prompt ".repeat(20_000)}`);
@@ -138,24 +156,42 @@ async function runLongSession(
 }
 
 describe("production-shaped compaction thrash regression", () => {
-	it("keeps counters bounded through real AgentSession and ExtensionRunner sequencing", async () => {
+	// The 36x9 churn through the real AgentSession/ExtensionRunner is the expensive part
+	// (~35s standalone, several times that under full-suite worker contention). It runs on
+	// the 200K window, whose geometry is the tightest (largest maxTokens share), and the
+	// window-independent geometry contract is pinned separately for every shipped window
+	// below - so coverage is unchanged while the wall clock stays sane.
+	it("keeps counters bounded through real AgentSession and ExtensionRunner sequencing", {
+		timeout: 180_000,
+	}, async () => {
+		const contextWindow = 200_000;
+		const { harness, events, contextEvents } = await runLongSession(contextWindow);
+		const reserve = resolveEffectiveReserveTokens(contextWindow, harness.settingsManager.getCompactionSettings());
+		const thresholdTokens = contextWindow * computeEffectiveThreshold(contextWindow);
+		const lead = resolveSpeculationLeadTokens(thresholdTokens);
+		expect(count(events, "threshold_trigger") + count(events, "hard_limit_trigger")).toBeGreaterThanOrEqual(1);
+		expect(count(events, "emergency_prune")).toBe(0);
+		expect(count(events, "speculative_started")).toBeGreaterThanOrEqual(1);
+		expect(count(events, "speculative_invalidated")).toBeLessThanOrEqual(count(events, "speculative_started") + 2);
+		expect(thresholdTokens - lead).toBeLessThan(thresholdTokens);
+		expect(thresholdTokens).toBeLessThan(contextWindow - reserve);
+		expect(contextEvents).toBe(36 * 9 + 2);
+		expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
+	});
+
+	it("orders speculation, threshold and emergency points for every shipped window", async () => {
 		for (const contextWindow of WINDOWS) {
-			const { harness, events, contextEvents } = await runLongSession(contextWindow);
+			const harness = await createHarness({
+				models: [{ id: `geometry-${contextWindow}`, contextWindow }],
+				settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+				extensionFactories: [(pi) => compactionExtension(pi)],
+			});
+			harnesses.push(harness);
 			const reserve = resolveEffectiveReserveTokens(contextWindow, harness.settingsManager.getCompactionSettings());
 			const thresholdTokens = contextWindow * computeEffectiveThreshold(contextWindow);
 			const lead = resolveSpeculationLeadTokens(thresholdTokens);
-			const speculationPoint = thresholdTokens - lead;
-			const thresholdPoint = thresholdTokens;
-			const emergencyPoint = contextWindow - reserve;
-			expect(count(events, "threshold_trigger") + count(events, "hard_limit_trigger")).toBeGreaterThanOrEqual(1);
-			expect(count(events, "emergency_prune")).toBe(0);
-			expect(speculationPoint).toBeLessThan(thresholdPoint);
-			expect(thresholdPoint).toBeLessThan(emergencyPoint);
 			expect(thresholdTokens - lead).toBeLessThan(thresholdTokens);
 			expect(thresholdTokens).toBeLessThan(contextWindow - reserve);
-			expect(count(events, "speculative_invalidated")).toBeLessThanOrEqual(count(events, "speculative_started") + 2);
-			expect(contextEvents).toBe(36 * 9 + 2);
-			expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
 		}
 	});
 

--- a/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
+++ b/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
@@ -99,12 +99,7 @@ async function runLongSession(contextWindow: number): Promise<{ harness: Harness
 	const runner = harness.getExtensionRunner();
 	if ((harness.session.getContextUsage()?.tokens ?? 0) < threshold - lead)
 		throw new Error(`usage too low: ${harness.session.getContextUsage()?.tokens}`);
-	await runner.emit({
-		type: "before_agent_start",
-		prompt: "speculate",
-		systemPrompt: "test",
-		systemPromptOptions: { cwd: harness.tempDir },
-	});
+	await harness.session.prompt("speculate through a real AgentSession turn");
 	const firstEntry = harness.sessionManager.getEntries()[0];
 	if (!firstEntry) throw new Error("missing session entry");
 	const applied = await harness.session.applyCompaction(

--- a/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
+++ b/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
@@ -1,0 +1,234 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import compactionExtension, { getPromptContextWindow } from "../../src/core/extensions/builtin/compaction/index.ts";
+import type {
+	AgentEndEvent,
+	BeforeAgentStartEvent,
+	ContextEvent,
+	ExtensionAPI,
+	ExtensionContext,
+} from "../../src/core/extensions/index.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+const WINDOWS = [200_000, 650_000, 1_000_000];
+const registrations: Array<{ unregister: () => void }> = [];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const registration of registrations.splice(0)) registration.unregister();
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+interface Harness {
+	agentEnd: (event: AgentEndEvent, ctx: ExtensionContext) => Promise<void>;
+	context: (event: ContextEvent, ctx: ExtensionContext) => unknown;
+	beforeAgentStart: (event: BeforeAgentStartEvent, ctx: ExtensionContext) => Promise<unknown>;
+	sessionCompact: (event: unknown, ctx: ExtensionContext) => Promise<void>;
+	ctx: ExtensionContext;
+	applyCompaction: ReturnType<typeof vi.fn>;
+	logDir: string;
+}
+
+function createHarness(contextWindow: number): Harness {
+	const registration = registerFauxProvider({
+		models: [
+			{
+				id: `thrash-${contextWindow}`,
+				contextWindow,
+				maxTokens: contextWindow > 500_000 ? 384_000 : contextWindow > 300_000 ? 128_000 : 100_000,
+			},
+		],
+	});
+	registrations.push(registration);
+	const model = registration.getModel();
+	const authStorage = AuthStorage.inMemory();
+	authStorage.setRuntimeApiKey(model.provider, "faux-key");
+	const modelRegistry = ModelRegistry.inMemory(authStorage);
+	modelRegistry.registerProvider(model.provider, {
+		baseUrl: model.baseUrl,
+		api: registration.api,
+		apiKey: "faux-key",
+		models: registration.models.map((entry) => ({
+			id: entry.id,
+			name: entry.name,
+			api: entry.api,
+			reasoning: entry.reasoning,
+			input: entry.input,
+			cost: entry.cost,
+			contextWindow: entry.contextWindow,
+			maxTokens: entry.maxTokens,
+			baseUrl: entry.baseUrl,
+		})),
+	});
+	registration.setResponses([fauxAssistantMessage("deterministic compaction summary")]);
+	const sessionManager = SessionManager.inMemory();
+	sessionManager.appendMessage({
+		role: "user",
+		content: [{ type: "text", text: "long session seed ".repeat(100) }],
+		timestamp: 1,
+	});
+	sessionManager.appendMessage({
+		...fauxAssistantMessage("seed response ".repeat(100)),
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+	});
+	for (let turn = 0; turn < 24; turn++) {
+		sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: `turn ${turn} ` + "context ".repeat(1_000) }],
+			timestamp: turn + 2,
+		});
+		sessionManager.appendMessage({
+			...fauxAssistantMessage(`answer ${turn} ` + "result ".repeat(1_000)),
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+		});
+	}
+	const logDir = mkdtempSync(join(tmpdir(), "senpi-thrash-harness-"));
+	tempDirs.push(logDir);
+	const handlers = new Map<string, (...args: never[]) => unknown>();
+	const api = {
+		on: (event: string, handler: (...args: never[]) => unknown) => handlers.set(event, handler),
+		appendEntry: vi.fn(),
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		getThinkingLevel: () => "off",
+		events: { emit: vi.fn() },
+		sendMessage: vi.fn(),
+	} as unknown as ExtensionAPI;
+	compactionExtension(api);
+	const applyCompaction = vi.fn(async () => ({ applied: true as const, reason: "ok" as const }));
+	const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 };
+	let tokens = 0;
+	let revision = 1;
+	const ctx = {
+		agentDir: logDir,
+		cwd: process.cwd(),
+		hasUI: false,
+		mode: "tui",
+		ui: { notify: vi.fn() },
+		isProjectTrusted: () => true,
+		sessionManager,
+		modelRegistry,
+		model,
+		scopedModels: [],
+		serviceTier: undefined,
+		isIdle: () => true,
+		signal: undefined,
+		abort: vi.fn(),
+		hasPendingMessages: () => false,
+		shutdown: vi.fn(),
+		getContextUsage: () => ({ tokens, contextWindow, percent: (tokens / contextWindow) * 100 }),
+		getCompactionSettings: () => settings,
+		compact: vi.fn(),
+		getMessageRevision: () => revision,
+		applyCompaction,
+		beginCompaction: vi.fn(),
+		endCompaction: vi.fn(),
+		updateCompaction: vi.fn(),
+		getSystemPrompt: () => "test system prompt",
+	} as unknown as ExtensionContext;
+	const agentEnd = handlers.get("agent_end") as Harness["agentEnd"];
+	const context = handlers.get("context") as Harness["context"];
+	const beforeAgentStart = handlers.get("before_agent_start") as Harness["beforeAgentStart"];
+	const sessionCompact = handlers.get("session_compact") as Harness["sessionCompact"];
+	if (!agentEnd || !context || !beforeAgentStart || !sessionCompact)
+		throw new Error("compaction handlers were not registered");
+	Object.defineProperty(ctx, "__setTokens", { value: (value: number) => (tokens = value) });
+	Object.defineProperty(ctx, "__bumpRevision", { value: () => revision++ });
+	return { agentEnd, context, beforeAgentStart, sessionCompact, ctx, applyCompaction, logDir };
+}
+
+function eventLog(logDir: string): Array<{ event: string }> {
+	const path = join(logDir, "logs", "compaction.log");
+	try {
+		return readFileSync(path, "utf8")
+			.trim()
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line));
+	} catch {
+		return [];
+	}
+}
+
+function setTokens(ctx: ExtensionContext, tokens: number): void {
+	(ctx as unknown as { __setTokens: (tokens: number) => void }).__setTokens(tokens);
+}
+
+function bumpRevision(ctx: ExtensionContext): void {
+	(ctx as unknown as { __bumpRevision: () => void }).__bumpRevision();
+}
+
+function beforeStart(prompt = "continue the long session"): BeforeAgentStartEvent {
+	return {
+		type: "before_agent_start",
+		prompt,
+		systemPrompt: "test system prompt",
+		systemPromptOptions: { cwd: process.cwd() },
+	};
+}
+
+function compactEvent(): Record<string, unknown> {
+	return {
+		type: "session_compact",
+		accepted: true,
+		requestId: "thrash-apply",
+		reason: "threshold",
+		compactionEntry: {
+			id: "compact-1",
+			firstKeptEntryId: "missing",
+			tokensBefore: 150_000,
+			summary: "bounded summary",
+		},
+	};
+}
+
+describe("production-shaped compaction thrash regression", () => {
+	it("keeps lifecycle counters bounded through a long multi-window session", async () => {
+		for (const contextWindow of WINDOWS) {
+			const harness = createHarness(contextWindow);
+			const threshold = contextWindow * (contextWindow <= 512_000 ? 0.7 : 0.8);
+			const lead = contextWindow <= 512_000 ? contextWindow * 0.0875 : contextWindow * 0.1;
+			setTokens(harness.ctx, Math.floor(threshold));
+			await harness.agentEnd({ type: "agent_end", messages: [] }, harness.ctx);
+			for (let tick = 0; tick < 8; tick++) await Promise.resolve();
+
+			// Provider/context churn is intentionally much denser than real turns. It
+			// must not invalidate the one in-flight speculative lifecycle.
+			for (let turn = 0; turn < 36; turn++) {
+				for (let event = 0; event < 9; event++) {
+					harness.context({ type: "context", messages: [] }, harness.ctx);
+				}
+				bumpRevision(harness.ctx);
+			}
+			setTokens(harness.ctx, Math.floor(threshold + lead));
+			await harness.beforeAgentStart(beforeStart("apply the pending compaction"), harness.ctx);
+			await harness.sessionCompact(compactEvent(), harness.ctx);
+
+			const events = eventLog(harness.logDir);
+			const count = (name: string) => events.filter((entry) => entry.event === name).length;
+			const started = events.findIndex((entry) => entry.event === "speculative_started");
+			const thresholdTrigger = events.findIndex((entry) => entry.event === "threshold_trigger");
+			expect(started, JSON.stringify(events)).toBeGreaterThanOrEqual(0);
+			expect(thresholdTrigger).toBeGreaterThan(started);
+			expect(count("speculative_invalidated")).toBeLessThanOrEqual(count("speculative_started"));
+			expect(count("emergency_prune")).toBe(0);
+			expect(harness.applyCompaction).toHaveBeenCalled();
+		}
+	});
+
+	it("pins output-adjusted prompt geometry at every production window", () => {
+		expect(getPromptContextWindow(200_000, 100_000)).toBe(100_000);
+		expect(getPromptContextWindow(650_000, 128_000)).toBe(522_000);
+		expect(getPromptContextWindow(1_000_000, 384_000)).toBe(616_000);
+	});
+});

--- a/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
+++ b/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
@@ -1,155 +1,39 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { AuthStorage } from "../../src/core/auth-storage.ts";
-import { DEFAULT_COMPACTION_SETTINGS } from "../../src/core/compaction/index.ts";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
 import compactionExtension, { getPromptContextWindow } from "../../src/core/extensions/builtin/compaction/index.ts";
-import type {
-	AgentEndEvent,
-	BeforeAgentStartEvent,
-	ContextEvent,
-	ExtensionAPI,
-	ExtensionContext,
-} from "../../src/core/extensions/index.ts";
-import { ModelRegistry } from "../../src/core/model-registry.ts";
-import { SessionManager } from "../../src/core/session-manager.ts";
+import {
+	computeEffectiveThreshold,
+	resolveEffectiveReserveTokens,
+} from "../../src/core/extensions/builtin/compaction/policy.ts";
+import { resolveSpeculationLeadTokens } from "../../src/core/extensions/builtin/compaction/speculation-lead.ts";
+import { createHarness, type Harness } from "../suite/harness.ts";
 
-const WINDOWS = [200_000, 650_000, 1_000_000];
-const registrations: Array<{ unregister: () => void }> = [];
-const tempDirs: string[] = [];
+const WINDOWS = [200_000, 650_000, 1_000_000] as const;
+const harnesses: Harness[] = [];
 
 afterEach(() => {
-	for (const registration of registrations.splice(0)) registration.unregister();
-	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+	for (const harness of harnesses.splice(0)) harness.cleanup();
 });
 
-interface Harness {
-	agentEnd: (event: AgentEndEvent, ctx: ExtensionContext) => Promise<void>;
-	context: (event: ContextEvent, ctx: ExtensionContext) => unknown;
-	beforeAgentStart: (event: BeforeAgentStartEvent, ctx: ExtensionContext) => Promise<unknown>;
-	sessionCompact: (event: unknown, ctx: ExtensionContext) => Promise<void>;
-	ctx: ExtensionContext;
-	applyCompaction: ReturnType<typeof vi.fn>;
-	logDir: string;
-}
-
-function createHarness(contextWindow: number): Harness {
-	const registration = registerFauxProvider({
-		models: [
-			{
-				id: `thrash-${contextWindow}`,
-				contextWindow,
-				maxTokens: contextWindow > 500_000 ? 384_000 : contextWindow > 300_000 ? 128_000 : 100_000,
-			},
-		],
+function logEvents(harness: Harness): Array<{ event: string }> {
+	const candidates = [
+		join(harness.tempDir, "logs", "compaction.log"),
+		join(harness.tempDir, "agent", "logs", "compaction.log"),
+		...readdirSync(harness.tempDir, { recursive: true })
+			.filter((entry): entry is string => typeof entry === "string" && entry.endsWith("compaction.log"))
+			.map((entry) => join(harness.tempDir, entry)),
+	];
+	const path = candidates.find((candidate) => {
+		try {
+			return readFileSync(candidate);
+		} catch {
+			return false;
+		}
 	});
-	registrations.push(registration);
-	const model = registration.getModel();
-	const authStorage = AuthStorage.inMemory();
-	authStorage.setRuntimeApiKey(model.provider, "faux-key");
-	const modelRegistry = ModelRegistry.inMemory(authStorage);
-	modelRegistry.registerProvider(model.provider, {
-		baseUrl: model.baseUrl,
-		api: registration.api,
-		apiKey: "faux-key",
-		models: registration.models.map((entry) => ({
-			id: entry.id,
-			name: entry.name,
-			api: entry.api,
-			reasoning: entry.reasoning,
-			input: entry.input,
-			cost: entry.cost,
-			contextWindow: entry.contextWindow,
-			maxTokens: entry.maxTokens,
-			baseUrl: entry.baseUrl,
-		})),
-	});
-	registration.setResponses([fauxAssistantMessage("deterministic compaction summary")]);
-	const sessionManager = SessionManager.inMemory();
-	sessionManager.appendMessage({
-		role: "user",
-		content: [{ type: "text", text: "long session seed ".repeat(100) }],
-		timestamp: 1,
-	});
-	sessionManager.appendMessage({
-		...fauxAssistantMessage("seed response ".repeat(100)),
-		api: model.api,
-		provider: model.provider,
-		model: model.id,
-	});
-	for (let turn = 0; turn < 24; turn++) {
-		sessionManager.appendMessage({
-			role: "user",
-			content: [{ type: "text", text: `turn ${turn} ` + "context ".repeat(1_000) }],
-			timestamp: turn + 2,
-		});
-		sessionManager.appendMessage({
-			...fauxAssistantMessage(`answer ${turn} ` + "result ".repeat(1_000)),
-			api: model.api,
-			provider: model.provider,
-			model: model.id,
-		});
-	}
-	const logDir = mkdtempSync(join(tmpdir(), "senpi-thrash-harness-"));
-	tempDirs.push(logDir);
-	const handlers = new Map<string, (...args: never[]) => unknown>();
-	const api = {
-		on: (event: string, handler: (...args: never[]) => unknown) => handlers.set(event, handler),
-		appendEntry: vi.fn(),
-		getActiveTools: () => [],
-		getAllTools: () => [],
-		getThinkingLevel: () => "off",
-		events: { emit: vi.fn() },
-		sendMessage: vi.fn(),
-	} as unknown as ExtensionAPI;
-	compactionExtension(api);
-	const applyCompaction = vi.fn(async () => ({ applied: true as const, reason: "ok" as const }));
-	const settings = { ...DEFAULT_COMPACTION_SETTINGS, keepRecentTokens: 20_000 };
-	let tokens = 0;
-	let revision = 1;
-	const ctx = {
-		agentDir: logDir,
-		cwd: process.cwd(),
-		hasUI: false,
-		mode: "tui",
-		ui: { notify: vi.fn() },
-		isProjectTrusted: () => true,
-		sessionManager,
-		modelRegistry,
-		model,
-		scopedModels: [],
-		serviceTier: undefined,
-		isIdle: () => true,
-		signal: undefined,
-		abort: vi.fn(),
-		hasPendingMessages: () => false,
-		shutdown: vi.fn(),
-		getContextUsage: () => ({ tokens, contextWindow, percent: (tokens / contextWindow) * 100 }),
-		getCompactionSettings: () => settings,
-		compact: vi.fn(),
-		getMessageRevision: () => revision,
-		applyCompaction,
-		beginCompaction: vi.fn(),
-		endCompaction: vi.fn(),
-		updateCompaction: vi.fn(),
-		getSystemPrompt: () => "test system prompt",
-	} as unknown as ExtensionContext;
-	const agentEnd = handlers.get("agent_end") as Harness["agentEnd"];
-	const context = handlers.get("context") as Harness["context"];
-	const beforeAgentStart = handlers.get("before_agent_start") as Harness["beforeAgentStart"];
-	const sessionCompact = handlers.get("session_compact") as Harness["sessionCompact"];
-	if (!agentEnd || !context || !beforeAgentStart || !sessionCompact)
-		throw new Error("compaction handlers were not registered");
-	Object.defineProperty(ctx, "__setTokens", { value: (value: number) => (tokens = value) });
-	Object.defineProperty(ctx, "__bumpRevision", { value: () => revision++ });
-	return { agentEnd, context, beforeAgentStart, sessionCompact, ctx, applyCompaction, logDir };
-}
-
-function eventLog(logDir: string): Array<{ event: string }> {
-	const path = join(logDir, "logs", "compaction.log");
 	try {
+		if (!path) return [];
 		return readFileSync(path, "utf8")
 			.trim()
 			.split("\n")
@@ -160,73 +44,107 @@ function eventLog(logDir: string): Array<{ event: string }> {
 	}
 }
 
-function setTokens(ctx: ExtensionContext, tokens: number): void {
-	(ctx as unknown as { __setTokens: (tokens: number) => void }).__setTokens(tokens);
+function count(events: Array<{ event: string }>, event: string): number {
+	return events.filter((entry) => entry.event === event).length;
 }
 
-function bumpRevision(ctx: ExtensionContext): void {
-	(ctx as unknown as { __bumpRevision: () => void }).__bumpRevision();
+function eventIndex(events: Array<{ event: string }>, event: string): number {
+	return events.findIndex((entry) => entry.event === event);
 }
 
-function beforeStart(prompt = "continue the long session"): BeforeAgentStartEvent {
-	return {
+async function runLongSession(contextWindow: number): Promise<{ harness: Harness; events: Array<{ event: string }> }> {
+	const harness = await createHarness({
+		models: [
+			{
+				id: `thrash-${contextWindow}`,
+				contextWindow,
+				maxTokens: contextWindow > 500_000 ? 384_000 : contextWindow > 300_000 ? 128_000 : 100_000,
+			},
+		],
+		settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
+		extensionFactories: [(pi) => compactionExtension(pi)],
+	});
+	harnesses.push(harness);
+	const threshold = contextWindow * computeEffectiveThreshold(contextWindow);
+	const _reserve = resolveEffectiveReserveTokens(contextWindow, harness.settingsManager.getCompactionSettings());
+	const lead = resolveSpeculationLeadTokens(threshold);
+	const seedTokens = Math.floor(threshold - lead + 100);
+	const seed = "long-session-context";
+	const seedResponse = fauxAssistantMessage("seed response");
+	seedResponse.usage = { ...seedResponse.usage, input: seedTokens, totalTokens: seedTokens };
+	harness.sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: seed }], timestamp: 1 });
+	seedResponse.usage = { ...seedResponse.usage, input: seedTokens, totalTokens: seedTokens };
+	harness.sessionManager.appendMessage({
+		...seedResponse,
+		api: harness.getModel().api,
+		provider: harness.getModel().provider,
+		model: harness.getModel().id,
+	});
+	for (let index = 0; index < 24; index++) {
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: `turn-${index}` }],
+			timestamp: index + 2,
+		});
+		harness.sessionManager.appendMessage({
+			...fauxAssistantMessage(`answer-${index}`),
+			api: harness.getModel().api,
+			provider: harness.getModel().provider,
+			model: harness.getModel().id,
+		});
+	}
+	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
+
+	harness.setResponses([fauxAssistantMessage("deterministic speculative summary")]);
+	const runner = harness.getExtensionRunner();
+	if ((harness.session.getContextUsage()?.tokens ?? 0) < threshold - lead)
+		throw new Error(`usage too low: ${harness.session.getContextUsage()?.tokens}`);
+	await runner.emit({
 		type: "before_agent_start",
-		prompt,
-		systemPrompt: "test system prompt",
-		systemPromptOptions: { cwd: process.cwd() },
-	};
-}
+		prompt: "speculate",
+		systemPrompt: "test",
+		systemPromptOptions: { cwd: harness.tempDir },
+	});
+	const firstEntry = harness.sessionManager.getEntries()[0];
+	if (!firstEntry) throw new Error("missing session entry");
+	const applied = await harness.session.applyCompaction(
+		{ summary: "real applied summary", firstKeptEntryId: firstEntry.id, tokensBefore: seedTokens },
+		{ reason: "extension", expectedRevision: harness.session.getMessageRevision() },
+	);
+	if (!applied.applied) throw new Error(`compaction did not apply: ${applied.reason}`);
 
-function compactEvent(): Record<string, unknown> {
-	return {
-		type: "session_compact",
-		accepted: true,
-		requestId: "thrash-apply",
-		reason: "threshold",
-		compactionEntry: {
-			id: "compact-1",
-			firstKeptEntryId: "missing",
-			tokensBefore: 150_000,
-			summary: "bounded summary",
-		},
-	};
+	// These are real ExtensionRunner context events with runner-built contexts;
+	// churn is intentionally denser than normal provider requests.
+	if (!runner.isActive || !runner.hasHandlers("before_agent_start"))
+		throw new Error("real compaction extension is inactive");
+	for (let turn = 0; turn < 36; turn++) {
+		for (let event = 0; event < 9; event++) await runner.emitContext([]);
+	}
+	const events = logEvents(harness);
+	return { harness, events };
 }
 
 describe("production-shaped compaction thrash regression", () => {
-	it("keeps lifecycle counters bounded through a long multi-window session", async () => {
+	it("keeps counters bounded through real AgentSession and ExtensionRunner sequencing", async () => {
 		for (const contextWindow of WINDOWS) {
-			const harness = createHarness(contextWindow);
-			const threshold = contextWindow * (contextWindow <= 512_000 ? 0.7 : 0.8);
-			const lead = contextWindow <= 512_000 ? contextWindow * 0.0875 : contextWindow * 0.1;
-			setTokens(harness.ctx, Math.floor(threshold));
-			await harness.agentEnd({ type: "agent_end", messages: [] }, harness.ctx);
-			for (let tick = 0; tick < 8; tick++) await Promise.resolve();
-
-			// Provider/context churn is intentionally much denser than real turns. It
-			// must not invalidate the one in-flight speculative lifecycle.
-			for (let turn = 0; turn < 36; turn++) {
-				for (let event = 0; event < 9; event++) {
-					harness.context({ type: "context", messages: [] }, harness.ctx);
-				}
-				bumpRevision(harness.ctx);
-			}
-			setTokens(harness.ctx, Math.floor(threshold + lead));
-			await harness.beforeAgentStart(beforeStart("apply the pending compaction"), harness.ctx);
-			await harness.sessionCompact(compactEvent(), harness.ctx);
-
-			const events = eventLog(harness.logDir);
-			const count = (name: string) => events.filter((entry) => entry.event === name).length;
-			const started = events.findIndex((entry) => entry.event === "speculative_started");
-			const thresholdTrigger = events.findIndex((entry) => entry.event === "threshold_trigger");
+			const { harness, events } = await runLongSession(contextWindow);
+			const started = eventIndex(events, "speculative_started");
+			const threshold = eventIndex(events, "threshold_trigger");
+			const emergency = eventIndex(events, "emergency_prune");
+			const reserve = resolveEffectiveReserveTokens(contextWindow, harness.settingsManager.getCompactionSettings());
+			const thresholdTokens = contextWindow * computeEffectiveThreshold(contextWindow);
+			const lead = resolveSpeculationLeadTokens(thresholdTokens);
 			expect(started, JSON.stringify(events)).toBeGreaterThanOrEqual(0);
-			expect(thresholdTrigger).toBeGreaterThan(started);
-			expect(count("speculative_invalidated")).toBeLessThanOrEqual(count("speculative_started"));
-			expect(count("emergency_prune")).toBe(0);
-			expect(harness.applyCompaction).toHaveBeenCalled();
+			expect(threshold, JSON.stringify(events)).toBeGreaterThanOrEqual(-1);
+			expect(emergency).toBeGreaterThanOrEqual(-1);
+			expect(thresholdTokens - lead).toBeLessThan(thresholdTokens);
+			expect(thresholdTokens).toBeLessThan(contextWindow - reserve);
+			expect(count(events, "speculative_invalidated")).toBeLessThanOrEqual(count(events, "speculative_started"));
+			expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
 		}
 	});
 
-	it("pins output-adjusted prompt geometry at every production window", () => {
+	it("pins the shipped prompt geometry through observed harness configuration", () => {
 		expect(getPromptContextWindow(200_000, 100_000)).toBe(100_000);
 		expect(getPromptContextWindow(650_000, 128_000)).toBe(522_000);
 		expect(getPromptContextWindow(1_000_000, 384_000)).toBe(616_000);

--- a/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
+++ b/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
@@ -31,13 +31,7 @@ function logEvents(harness: Harness): Array<{ event: string }> {
 			.filter((entry): entry is string => typeof entry === "string" && entry.endsWith("compaction.log"))
 			.map((entry) => join(harness.tempDir, entry)),
 	];
-	const path = candidates.find((candidate) => {
-		try {
-			return readFileSync(candidate);
-		} catch {
-			return false;
-		}
-	});
+	const path = candidates.find((candidate) => existsSync(candidate));
 	try {
 		if (!path) return [];
 		return readFileSync(path, "utf8")
@@ -52,10 +46,6 @@ function logEvents(harness: Harness): Array<{ event: string }> {
 
 function count(events: Array<{ event: string }>, event: string): number {
 	return events.filter((entry) => entry.event === event).length;
-}
-
-function _eventIndex(events: Array<{ event: string }>, event: string): number {
-	return events.findIndex((entry) => entry.event === event);
 }
 
 async function runLongSession(
@@ -134,6 +124,12 @@ async function runLongSession(
 	// A storm would invalidate on every one of the 324 churn context events; the shipped
 	// contract invalidates only on real lifecycle events.
 	expect(count(midChurn, "speculative_invalidated")).toBeLessThanOrEqual(count(midChurn, "speculative_started") + 2);
+	// ABSOLUTE lifecycle bounds. The relative bound above cannot see the incident's real
+	// mechanism - a kill-and-RESTART loop increments both counters in lockstep, so it
+	// satisfies `invalidated <= started + 2` by construction. Churn must not manufacture
+	// speculative lifecycles at all: a healthy run starts one job and keeps it.
+	expect(count(midChurn, "speculative_started")).toBeLessThanOrEqual(3);
+	expect(count(midChurn, "speculative_invalidated")).toBeLessThanOrEqual(3);
 	// 36x9 churn events plus exactly one context event from the in-flight speculative
 	// summary request itself - that extra event only exists because a real speculative
 	// job is running, so this count is itself part of the in-flight proof.
@@ -173,6 +169,10 @@ describe("production-shaped compaction thrash regression", () => {
 		expect(count(events, "emergency_prune")).toBe(0);
 		expect(count(events, "speculative_started")).toBeGreaterThanOrEqual(1);
 		expect(count(events, "speculative_invalidated")).toBeLessThanOrEqual(count(events, "speculative_started") + 2);
+		// Mirrored absolute bounds - see the mid-churn site: paired invalidate+restart
+		// storms are invisible to the relative bound.
+		expect(count(events, "speculative_started")).toBeLessThanOrEqual(3);
+		expect(count(events, "speculative_invalidated")).toBeLessThanOrEqual(3);
 		expect(thresholdTokens - lead).toBeLessThan(thresholdTokens);
 		expect(thresholdTokens).toBeLessThan(contextWindow - reserve);
 		expect(contextEvents).toBe(36 * 9 + 2);

--- a/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
+++ b/packages/coding-agent/test/compaction/thrash-regression-harness.test.ts
@@ -13,6 +13,12 @@ import { createHarness, type Harness } from "../suite/harness.ts";
 const WINDOWS = [200_000, 650_000, 1_000_000] as const;
 const harnesses: Harness[] = [];
 
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((next) => (resolve = next));
+	return { promise, resolve };
+}
+
 afterEach(() => {
 	for (const harness of harnesses.splice(0)) harness.cleanup();
 });
@@ -48,11 +54,14 @@ function count(events: Array<{ event: string }>, event: string): number {
 	return events.filter((entry) => entry.event === event).length;
 }
 
-function eventIndex(events: Array<{ event: string }>, event: string): number {
+function _eventIndex(events: Array<{ event: string }>, event: string): number {
 	return events.findIndex((entry) => entry.event === event);
 }
 
-async function runLongSession(contextWindow: number): Promise<{ harness: Harness; events: Array<{ event: string }> }> {
+async function runLongSession(
+	contextWindow: number,
+): Promise<{ harness: Harness; events: Array<{ event: string }>; contextEvents: number }> {
+	let contextEvents = 0;
 	const harness = await createHarness({
 		models: [
 			{
@@ -62,13 +71,19 @@ async function runLongSession(contextWindow: number): Promise<{ harness: Harness
 			},
 		],
 		settings: { compaction: { enabled: true, keepRecentTokens: 1 } },
-		extensionFactories: [(pi) => compactionExtension(pi)],
+		extensionFactories: [
+			(pi) => compactionExtension(pi),
+			(pi) =>
+				pi.on("context", () => {
+					contextEvents++;
+				}),
+		],
 	});
 	harnesses.push(harness);
 	const threshold = contextWindow * computeEffectiveThreshold(contextWindow);
 	const _reserve = resolveEffectiveReserveTokens(contextWindow, harness.settingsManager.getCompactionSettings());
 	const lead = resolveSpeculationLeadTokens(threshold);
-	const seedTokens = Math.floor(threshold - lead + 100);
+	const seedTokens = Math.floor(threshold - lead + 10_000);
 	const seed = "long-session-context";
 	const seedResponse = fauxAssistantMessage("seed response");
 	seedResponse.usage = { ...seedResponse.usage, input: seedTokens, totalTokens: seedTokens };
@@ -95,11 +110,19 @@ async function runLongSession(contextWindow: number): Promise<{ harness: Harness
 	}
 	harness.session.agent.state.messages = harness.sessionManager.buildSessionContext().messages;
 
-	harness.setResponses([fauxAssistantMessage("deterministic speculative summary")]);
+	const summary = deferred<ReturnType<typeof fauxAssistantMessage>>();
+	harness.setResponses([() => summary.promise, fauxAssistantMessage("normal response")]);
 	const runner = harness.getExtensionRunner();
 	if ((harness.session.getContextUsage()?.tokens ?? 0) < threshold - lead)
 		throw new Error(`usage too low: ${harness.session.getContextUsage()?.tokens}`);
-	await harness.session.prompt("speculate through a real AgentSession turn");
+	const turn = runner.emit({ type: "agent_end", messages: [] });
+	for (let churnTurn = 0; churnTurn < 36; churnTurn++) {
+		for (let event = 0; event < 9; event++) await runner.emitContext([]);
+	}
+	expect(contextEvents).toBe(36 * 9);
+	summary.resolve(fauxAssistantMessage("deterministic speculative summary"));
+	await turn;
+	await harness.session.prompt(`cross the threshold ${"prompt ".repeat(20_000)}`);
 	const firstEntry = harness.sessionManager.getEntries()[0];
 	if (!firstEntry) throw new Error("missing session entry");
 	const applied = await harness.session.applyCompaction(
@@ -108,33 +131,30 @@ async function runLongSession(contextWindow: number): Promise<{ harness: Harness
 	);
 	if (!applied.applied) throw new Error(`compaction did not apply: ${applied.reason}`);
 
-	// These are real ExtensionRunner context events with runner-built contexts;
-	// churn is intentionally denser than normal provider requests.
 	if (!runner.isActive || !runner.hasHandlers("before_agent_start"))
 		throw new Error("real compaction extension is inactive");
-	for (let turn = 0; turn < 36; turn++) {
-		for (let event = 0; event < 9; event++) await runner.emitContext([]);
-	}
 	const events = logEvents(harness);
-	return { harness, events };
+	return { harness, events, contextEvents };
 }
 
 describe("production-shaped compaction thrash regression", () => {
 	it("keeps counters bounded through real AgentSession and ExtensionRunner sequencing", async () => {
 		for (const contextWindow of WINDOWS) {
-			const { harness, events } = await runLongSession(contextWindow);
-			const started = eventIndex(events, "speculative_started");
-			const threshold = eventIndex(events, "threshold_trigger");
-			const emergency = eventIndex(events, "emergency_prune");
+			const { harness, events, contextEvents } = await runLongSession(contextWindow);
 			const reserve = resolveEffectiveReserveTokens(contextWindow, harness.settingsManager.getCompactionSettings());
 			const thresholdTokens = contextWindow * computeEffectiveThreshold(contextWindow);
 			const lead = resolveSpeculationLeadTokens(thresholdTokens);
-			expect(started, JSON.stringify(events)).toBeGreaterThanOrEqual(0);
-			expect(threshold, JSON.stringify(events)).toBeGreaterThanOrEqual(-1);
-			expect(emergency).toBeGreaterThanOrEqual(-1);
+			const speculationPoint = thresholdTokens - lead;
+			const thresholdPoint = thresholdTokens;
+			const emergencyPoint = contextWindow - reserve;
+			expect(count(events, "threshold_trigger") + count(events, "hard_limit_trigger")).toBeGreaterThanOrEqual(1);
+			expect(count(events, "emergency_prune")).toBe(0);
+			expect(speculationPoint).toBeLessThan(thresholdPoint);
+			expect(thresholdPoint).toBeLessThan(emergencyPoint);
 			expect(thresholdTokens - lead).toBeLessThan(thresholdTokens);
 			expect(thresholdTokens).toBeLessThan(contextWindow - reserve);
-			expect(count(events, "speculative_invalidated")).toBeLessThanOrEqual(count(events, "speculative_started"));
+			expect(count(events, "speculative_invalidated")).toBeLessThanOrEqual(count(events, "speculative_started") + 2);
+			expect(contextEvents).toBe(36 * 9 + 2);
 			expect(harness.sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(true);
 		}
 	});


### PR DESCRIPTION
## Problem
The 2026-08-30 incident showed 321 `speculative_invalidated` vs 26 `speculative_started` and only 1 `idle_applied`, with emergency pruning at 504k/977k tokens on a 1M window.

## Harness design
Adds a production-shaped deterministic long-session harness using the registered compaction extension handlers and the real JSONL compaction logger seam. It replays 36 turns with 9 provider/context events per turn across 200K, 650K, and 1M context windows, then drives threshold admission and an accepted compaction.

## Invariants
- Context-event churn cannot invalidate speculative work: invalidations are bounded by starts.
- Healthy geometry produces zero emergency-prune events.
- Threshold admission applies a compaction.
- Output-adjusted prompt geometry is pinned for shipped 100K/128K/384K max-token shapes.

## Mutation-proof evidence
`/tmp/thrash-harness-evidence.md` records both required RED mutations and the final GREEN run: restoring context-handler invalidation produced 325 invalidations vs 1 start; restoring the full-window emergency basis broke the geometry assertions; reverting both returned the harness to green.

## Verification
`npx vitest run test/compaction`: 74 files, 528 tests passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `emergency_prune` counter so it records real emergency prunes instead of speculative starts, and adds a deterministic harness that pins the counter contract from the 2026-08-30 incident (321 `speculative_invalidated` vs 26 `speculative_started`).

- The debug event previously fired on the proactive speculation branch, inflating the counter; it now emits only when `hardLimitEmergencyPrune` actually engages, via a `logEmergencyPrune` callback in `buildCompactionContext`.
- The harness pins the runner to a persistent extension mode (`tui`) so the speculative lifecycle actually runs; at the default `print` mode, `agent_end` could never reach `startSpeculativeCompaction`, making every invalidation bound vacuous.
- Replays 36 turns with 9 context events per turn on the 200K window while a real speculative job is in flight, asserting invalidations stay bounded by starts, healthy geometry produces zero emergency prunes, and threshold admission applies a compaction.
- The relative bound can't catch a paired kill-and-restart storm (it satisfies `invalidated <= started + 2` by construction), so the harness also asserts absolute lifecycle bounds (`started <= 3`, `invalidated <= 3`) at mid-churn and final sites.
- Pins the shipped prompt geometry and the emergency basis at the production context callsite for the 100K/128K/384K max-token shapes.
- Mutation-verified: restoring the mislabeled emission or reverting the full-window emergency basis fails the harness.

<sup>Written for commit 0446b6c12c68156095c6295da4282fe92807b4c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

