### PR TITLE
fix(rpc): fall back to launch capabilities for session bindings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Multi-session RPC hosts launched with `SENPI_RPC_CLIENT_CAPABILITIES` (for example `extension_events`) now apply those capabilities to connection-owned session bindings when the client never sends `set_client_info`. Previously the launch capabilities were advertised through `get_protocol_info` but dropped at binding creation, so undeclared clients received no `extension_event` frames (breaking downstream task/DAG/monitor liveness in omo-desktop-app). An explicit `set_client_info` declaration, including an empty capability list, still overrides the launch default.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,17 @@
 # changes
 
+## [Unreleased] - Preserve launch capabilities for undeclared multi-session clients
+
+- `session-command-router.ts`: connection-owned session bindings now fall back to the host launch capabilities when the client has not sent `set_client_info`; an explicit empty capability declaration still wins.
+
+### Why
+
+- Multi-session hosts launched with `extension_events` advertised the capability but did not forward extension events to clients that never declared capabilities, breaking omo-desktop-app subagent/monitor liveness since 2026-08-28.
+
+### Why an extension could not handle it
+
+- Capability negotiation and session binding creation are transport routing behavior beneath the extension API.
+
 ## 2026-08-31 - Ownership-safe RPC and app-server state locks
 
 - Replaced proper-lockfile for the shared RPC-host and app-server daemon locks with a persistent regular SQLite lock file using `BEGIN EXCLUSIVE`; release commits and closes without unlinking.

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -323,7 +323,7 @@ export class SessionCommandRouter {
 							...this.connectionOptions,
 							capabilities:
 								owner !== undefined
-									? (this.pendingCapabilities.get(owner) ?? [])
+									? (this.pendingCapabilities.get(owner) ?? this.connectionOptions?.capabilities ?? [])
 									: this.connectionOptions?.capabilities,
 							sharedWidth: {
 								getWidth: () => {

--- a/packages/coding-agent/test/rpc-multi-session.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session.test.ts
@@ -97,6 +97,95 @@ describe("multi-session RPC routing", () => {
 		);
 	});
 
+	test("forwards launch capabilities to connection-owned bindings and honors explicit empty capabilities", async () => {
+		const entry = {
+			runtime: {
+				session: {
+					model: undefined,
+					thinkingLevel: "off",
+					isStreaming: false,
+					isCompacting: false,
+					steeringMode: "one-at-a-time",
+					followUpMode: "one-at-a-time",
+					sessionFile: undefined,
+					sessionId: "durable-session",
+					sessionName: undefined,
+				},
+			},
+		};
+		const sessionIds = ["rpc-session-env", "rpc-session-explicit-empty"];
+		const registry = {
+			openSession: async () => ({ sessionId: sessionIds.shift() ?? "unexpected" }),
+			getForCommand: () => entry,
+			list: () => [],
+			beginClose: () => entry,
+			closeMarked: async () => {},
+		} as never;
+		const chunks: string[] = [];
+		const writer = new SessionEventWriter(
+			(chunk) => chunks.push(chunk),
+			(flush) => flush(),
+		);
+		writer.registerConnection("client", {
+			writeRaw: (chunk) => chunks.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		const emitters = new Map<string, () => void>();
+		const createBinding = vi.fn(
+			async (
+				sessionId: string,
+				_entry: unknown,
+				eventWriter: SessionEventWriter,
+				_close: unknown,
+				options: { capabilities?: readonly string[] },
+			) => {
+				const forwardsExtensionEvents = options.capabilities?.includes("extension_events") ?? false;
+				emitters.set(sessionId, () => {
+					if (!forwardsExtensionEvents) return;
+					eventWriter.enqueue(sessionId, {
+						type: "extension_event",
+						name: "fixture.progress",
+						data: { step: 1 },
+					});
+				});
+				return { handle: async () => {}, dispose: async () => {} };
+			},
+		);
+		const router = Reflect.construct(SessionCommandRouter, [
+			registry,
+			writer,
+			{ cwd: "/tmp" },
+			createBinding,
+			{ capabilities: ["extension_events"] },
+		]) as SessionCommandRouter;
+
+		await writer.withConnection("client", () => router.handle({ id: "open-env", type: "open_session", cwd: "/tmp" }));
+		emitters.get("rpc-session-env")?.();
+		await writer.flush();
+		expect(JSON.parse(chunks.join("").split("\n").filter(Boolean).at(-1) ?? "{}")).toMatchObject({
+			type: "extension_event",
+			name: "fixture.progress",
+			sessionId: "rpc-session-env",
+		});
+
+		await writer.withConnection("client", () =>
+			router.handle({ id: "info", type: "set_client_info", width: 80, capabilities: [] }),
+		);
+		await writer.withConnection("client", () =>
+			router.handle({ id: "open-empty", type: "open_session", cwd: "/tmp" }),
+		);
+		emitters.get("rpc-session-explicit-empty")?.();
+		await writer.flush();
+		expect(
+			chunks
+				.join("")
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line) as { type?: string; sessionId?: string })
+				.filter((record) => record.type === "extension_event" && record.sessionId === "rpc-session-explicit-empty"),
+		).toEqual([]);
+	});
+
 	test("routes extension requests only to the addressed session binding", async () => {
 		const sessionIds = ["rpc-session-alpha", "rpc-session-beta"];
 		const entryFor = (sessionId: string) => ({


### PR DESCRIPTION
## Summary

- Fix multi-session RPC session bindings to fall back to host launch capabilities when a client never sends `set_client_info`.
- Preserve explicit capability declarations, including `capabilities: []`, as the winning value.
- Add regression coverage for extension-event forwarding and explicit-empty capability behavior.

## Root cause

The connection-owned binding path used `pendingCapabilities.get(owner) ?? []`, while the attach path already used `pendingCapabilities.get(owner) ?? connectionOptions.capabilities ?? []`. This asymmetry was introduced by `91cbd868a` (`feat(rpc): forward extension events from plugins`). As a result, a host could advertise `extension_events` from `SENPI_RPC_CLIENT_CAPABILITIES` but fail to apply it to a client that never sent `set_client_info`.

## Downstream impact

This caused the omo-desktop-app subagent/monitor extension-event outage fleet-wide since 2026-08-28, leaving clients without extension-event frames and breaking their liveness monitoring.

## Verification

RED (before the router fix):

```text
Test Files 1 failed (1)
Tests no tests
```

Focused RED assertion: expected an `extension_event` frame for `rpc-session-env`, received `{}`; 6 tests passed and 1 failed.

GREEN (after the router fix):

```text
Test Files 1 passed (1)
Tests 7 passed (7)
```

Focused command: `cd packages/coding-agent && npm run test -- test/rpc-multi-session.test.ts`

Changelog gate passed with the repository's `no-changelog` label for this tracker-only, non-release-facing fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-session RPC session bindings to fall back to host launch capabilities when a client never sends `set_client_info`, so `extension_events` are forwarded to those clients. Explicit empty capability declarations still win, and regression coverage now verifies both behaviors.

<sup>Written for commit 8fe851731aad24b23e62c66a2ba867e400f3b03b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

