### PR TITLE
feat(rpc): add auto-title sessions capability

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### New Features
 
+- RPC clients can opt into native session auto-titles with the `auto_title_sessions` capability; supported RPC sessions generate and emit their title through `session_info_changed`.
+
 ### Breaking Changes
 
 ### Added

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-09-01 - Negotiate RPC session auto-titling
+
+### What changed
+
+- `packages/coding-agent/src/main.ts` enables RPC session auto-titling when the client advertises `auto_title_sessions`, while preserving the context-message guard and default behavior for clients without the capability.
+- `packages/coding-agent/src/modes/rpc/connection-handler.ts`, `packages/coding-agent/src/modes/rpc/custom-capability.ts`, and `packages/coding-agent/src/modes/rpc/session-command-router.ts` define and advertise the capability in both RPC protocol surfaces.
+
+### Why
+
+- RPC clients that support native session titles need the engine to generate titles and forward the existing `session_info_changed` event without changing the default wire contract.
+
+### Why an extension could not handle it
+
+- The auto-title decision is made while the entrypoint constructs each `AgentSession`, before extension code loads.
+
+### Expected merge conflict zones
+
+- LOW: the `resolveAutoTitleSessions` helper and `autoTitleSessions` option in `main.ts`, plus RPC capability declarations and protocol responses.
+
 ## 2026-08-30 - Export the RPC transport-gone classifier
 
 ### What changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -82,6 +82,7 @@ import { runMigrations, showDeprecationWarnings } from "./migrations.ts";
 import { createInteractiveHostRuntime } from "./modes/interactive/interactive-host-runtime.ts";
 import { initTheme, stopThemeWatcher } from "./modes/interactive/theme/theme.ts";
 import { runPrintMode } from "./modes/print-mode.ts";
+import { AUTO_TITLE_SESSIONS_CAPABILITY, parseClientCapabilities } from "./modes/rpc/custom-capability.ts";
 import { findInternalSupervisorArgs, parseSupervisorArgs, runHostSupervisor } from "./modes/rpc/host-lifecycle.ts";
 import { runMultiSessionHost } from "./modes/rpc/multi-session-host.ts";
 import { runRpcMode } from "./modes/rpc/rpc-mode.ts";
@@ -178,13 +179,23 @@ function toProjectTrustMode(appMode: AppMode): AppMode {
 }
 
 /**
- * Interactive launches auto-title by default; every other app mode (RPC with or
- * without `--multi-session`, print, json, app-server) opts in with
+ * Interactive launches auto-title by default. RPC clients can opt in through
+ * `auto_title_sessions`; every other non-interactive app mode opts in with
  * `--auto-title-sessions`. Sessions resumed with existing context messages are
- * never retitled, whatever the mode or flag.
+ * never retitled, whatever the mode, capability, or flag.
  */
-export function resolveAutoTitleSessions(appMode: AppMode, parsed: Args, hasContextMessages: boolean): boolean {
-	return (appMode === "interactive" || parsed.autoTitleSessions === true) && !hasContextMessages;
+export function resolveAutoTitleSessions(
+	appMode: AppMode,
+	parsed: Args,
+	hasContextMessages: boolean,
+	clientCapabilities: readonly string[] = parseClientCapabilities(envValue("RPC_CLIENT_CAPABILITIES")),
+): boolean {
+	return (
+		(appMode === "interactive" ||
+			parsed.autoTitleSessions === true ||
+			(appMode === "rpc" && clientCapabilities.includes(AUTO_TITLE_SESSIONS_CAPABILITY))) &&
+		!hasContextMessages
+	);
 }
 
 function isPlainRuntimeMetadataCommand(parsed: Args): boolean {
@@ -1065,7 +1076,12 @@ export async function main(args: string[], options?: MainOptions) {
 			excludeTools: sessionOptions.excludeTools,
 			noTools: sessionOptions.noTools,
 			customTools: sessionOptions.customTools,
-			autoTitleSessions: resolveAutoTitleSessions(appMode, parsed, sessionManager.hasContextMessages()),
+			autoTitleSessions: resolveAutoTitleSessions(
+				appMode,
+				parsed,
+				sessionManager.hasContextMessages(),
+				parseClientCapabilities(envValue("RPC_CLIENT_CAPABILITIES")),
+			),
 		});
 		const cliThinkingOverride = runtimeParsed.thinking !== undefined || cliThinkingFromModel;
 		if (created.session.model && cliThinkingOverride) {

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,10 @@
 # changes
 
+## 2026-09-01 - Negotiate RPC session auto-titling
+
+- Added the `auto_title_sessions` client capability. RPC sessions auto-generate a title only when the client advertises support, while interactive defaults and resumed-session context guards remain unchanged.
+- Advertised the capability from both classic and multi-session `get_protocol_info` responses.
+
 ## 2026-09-01 - Acknowledge RPC abort before quiesce
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -57,6 +57,7 @@ import { getSupportedThinkingLevels } from "../../core/thinking-levels.ts";
 import { ProjectTrustStore } from "../../core/trust-manager.ts";
 import { type Theme, theme } from "../interactive/theme/theme.ts";
 import {
+	AUTO_TITLE_SESSIONS_CAPABILITY,
 	buildCustomUnsupportedRequest,
 	DEFAULT_CUSTOM_EXTENSION_LABEL,
 	EXTENSION_EVENTS_CAPABILITY,
@@ -989,7 +990,9 @@ export function createRpcConnectionHandler(
 					data: {
 						protocolVersion: 1,
 						serverVersion: VERSION,
-						capabilities: [...new Set(["multi_session", ...(options.capabilities ?? [])])],
+						capabilities: [
+							...new Set(["multi_session", AUTO_TITLE_SESSIONS_CAPABILITY, ...(options.capabilities ?? [])]),
+						],
 						mode: "classic",
 					},
 				};

--- a/packages/coding-agent/src/modes/rpc/custom-capability.ts
+++ b/packages/coding-agent/src/modes/rpc/custom-capability.ts
@@ -21,6 +21,7 @@ import type { RpcExtensionUIRequest } from "./rpc-types.ts";
 export const CUSTOM_UNSUPPORTED_CAPABILITY = "custom_unsupported";
 export const EXTENSION_EVENTS_CAPABILITY = "extension_events";
 export const RENDERED_COMPONENTS_CAPABILITY = "rendered_components";
+export const AUTO_TITLE_SESSIONS_CAPABILITY = "auto_title_sessions";
 
 /**
  * Env var carrying client capabilities to a single-connection stdio RPC host

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -1,5 +1,6 @@
 import { VERSION } from "../../config.ts";
 import { buildRpcSessionState } from "./connection-handler.ts";
+import { AUTO_TITLE_SESSIONS_CAPABILITY } from "./custom-capability.ts";
 import type { RpcCommand, RpcResponse } from "./rpc-types.ts";
 import {
 	RPC_ERROR_MISSING_SESSION_ID,
@@ -103,7 +104,11 @@ export class SessionCommandRouter {
 
 	async handle(command: RpcCommand): Promise<RpcResponse | undefined> {
 		if (command.type === "get_protocol_info") {
-			const capabilities = new Set(["multi_session", ...(this.connectionOptions?.capabilities ?? [])]);
+			const capabilities = new Set([
+				"multi_session",
+				AUTO_TITLE_SESSIONS_CAPABILITY,
+				...(this.connectionOptions?.capabilities ?? []),
+			]);
 			return {
 				id: command.id,
 				type: "response",

--- a/packages/coding-agent/test/auto-title-sessions-flag.test.ts
+++ b/packages/coding-agent/test/auto-title-sessions-flag.test.ts
@@ -2,6 +2,9 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, test } from "vitest";
 import { parseArgs } from "../src/cli/args.ts";
 import { resolveAutoTitleSessions } from "../src/main.ts";
+import { AUTO_TITLE_SESSIONS_CAPABILITY } from "../src/modes/rpc/custom-capability.ts";
+import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
 import { waitForSessionName } from "./agent-session-auto-title-helpers.ts";
 import { createHarness, type Harness } from "./suite/harness.ts";
 
@@ -22,6 +25,11 @@ describe("resolveAutoTitleSessions", () => {
 		expect(resolveAutoTitleSessions("rpc", parsed, false)).toBe(false);
 	});
 
+	test("opts RPC sessions into auto-titling when the client advertises the capability", () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session"]);
+		expect(resolveAutoTitleSessions("rpc", parsed, false, [AUTO_TITLE_SESSIONS_CAPABILITY])).toBe(true);
+	});
+
 	test.each(["rpc", "print", "json", "app-server"] as const)("honors the flag in %s mode", (appMode) => {
 		const parsed = parseArgs(["--mode", "rpc", "--multi-session", "--auto-title-sessions"]);
 		expect(resolveAutoTitleSessions(appMode, parsed, false)).toBe(true);
@@ -32,9 +40,66 @@ describe("resolveAutoTitleSessions", () => {
 		expect(resolveAutoTitleSessions("rpc", parsed, true)).toBe(false);
 	});
 
+	test("keeps the capability opt-in behind the context guard", () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session"]);
+		expect(resolveAutoTitleSessions("rpc", parsed, true, [AUTO_TITLE_SESSIONS_CAPABILITY])).toBe(false);
+	});
+
 	test("suppresses auto-titling for interactive resumes with context messages", () => {
 		const parsed = parseArgs([]);
 		expect(resolveAutoTitleSessions("interactive", parsed, true)).toBe(false);
+	});
+});
+
+describe("RPC client capability auto-titling", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	test("titles a fresh RPC session and emits session_info_changed", async () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session"]);
+		const harness = await createHarness({
+			persistSession: true,
+			autoTitleSessions: resolveAutoTitleSessions("rpc", parsed, false, [AUTO_TITLE_SESSIONS_CAPABILITY]),
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("turn complete"),
+			fauxAssistantMessage("<title>Capability Titled Session</title>"),
+		]);
+
+		const sessionName = waitForSessionName(harness);
+		await harness.session.prompt("fix the RPC session title pipeline");
+
+		expect(await sessionName).toBe("Capability Titled Session");
+		expect(harness.eventsOfType("session_info_changed")).toHaveLength(1);
+	});
+
+	test("does not emit an auto-title event without the capability", async () => {
+		const parsed = parseArgs(["--mode", "rpc", "--multi-session"]);
+		const harness = await createHarness({
+			persistSession: true,
+			autoTitleSessions: resolveAutoTitleSessions("rpc", parsed, false),
+		});
+		harnesses.push(harness);
+		harness.setResponses([fauxAssistantMessage("turn complete")]);
+
+		await harness.session.prompt("leave the default RPC title behavior unchanged");
+		await harness.session.waitForSettledSessionWork();
+
+		expect(harness.eventsOfType("session_info_changed")).toHaveLength(0);
+		expect(harness.faux.getCallLog()).toHaveLength(1);
+	});
+});
+
+describe("RPC protocol capabilities", () => {
+	test("advertises auto_title_sessions", async () => {
+		const registry = { list: () => [] } as never;
+		const router = new SessionCommandRouter(registry, new SessionEventWriter(() => {}), { cwd: "/tmp" });
+		const response = await router.handle({ id: "probe", type: "get_protocol_info" });
+		expect(response).toMatchObject({ data: { capabilities: ["multi_session", AUTO_TITLE_SESSIONS_CAPABILITY] } });
 	});
 });
 

--- a/packages/coding-agent/test/rpc-multi-session.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session.test.ts
@@ -46,7 +46,12 @@ describe("multi-session RPC routing", () => {
 			type: "response",
 			command: "get_protocol_info",
 			success: true,
-			data: { protocolVersion: 1, serverVersion: VERSION, capabilities: ["multi_session"], mode: "multi" },
+			data: {
+				protocolVersion: 1,
+				serverVersion: VERSION,
+				capabilities: ["multi_session", "auto_title_sessions"],
+				mode: "multi",
+			},
 		});
 	});
 


### PR DESCRIPTION
## Problem
RPC-mode sessions only enabled automatic session title generation for interactive launches, so capable desktop RPC clients could not receive native session titles.

## Fix
- Add the `auto_title_sessions` client capability.
- Enable auto-title generation for RPC sessions that advertise it, while preserving the no-context guard and default unflagged behavior.
- Advertise support in classic and multi-session `get_protocol_info`.
- Add deterministic capability, title-event, no-event, and protocol tests.

## Test evidence
- RED first: `bun test --run test/auto-title-sessions-flag.test.ts` failed with the expected missing capability behavior: `Expected: true / Received: false`, timed-out title event, and missing protocol capability.
- GREEN: `bun test --run test/auto-title-sessions-flag.test.ts` -> 15 pass, 0 fail.
- GREEN: `bun test --run test/rpc-multi-session.test.ts` -> 6 pass, 0 fail.
- Commit pre-checks passed: formatting/lint, dependency/import/lock checks, and TypeScript.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `auto_title_sessions` RPC client capability that opts RPC sessions into automatic title generation, so capable desktop clients get native session titles without the `--auto-title-sessions` flag.

- RPC clients advertise the capability through `RPC_CLIENT_CAPABILITIES`; sessions without it keep the existing default behavior.
- `get_protocol_info` advertises the capability in both classic and multi-session responses.
- Resumed sessions with existing context messages are still never retitled, and the interactive default and flag behavior are unchanged.
- Adds tests covering capability opt-in, missing-capability behavior, and protocol advertisement.

<sup>Written for commit 7215fd56423504043f331964e6480a9d34141825. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

