### PR TITLE
fix(rpc): ack abort before quiesce completes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- RPC `abort` acknowledgements are now sent immediately after the abort signal is dispatched instead of waiting for full session quiescence, preventing desktop stop requests from hitting their 10-second bounded-ack timeout under host load.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,12 @@
 # Local fork changes
 
+## 2026-09-01 - Acknowledge RPC abort before quiesce
+
+- The RPC `abort` command now acknowledges immediately after dispatching the abort signal, while observing quiesce failures through the existing `rpc_error` event path.
+
+- `abort_bash` and `abort_retry` remain unchanged because they synchronously dispatch their abort actions and do not await session quiescence.
+
+
 ## 2026-08-30 - Make interactive-host entry-parity tests rules-hermetic
 
 - The spawned RPC host in `test/interactive-host-runtime.test.ts` now sets `PI_RULES_DISABLED=1`, so the rules extension's asynchronous `pi-rules.scan` custom entry can no longer race the host-vs-local entry parity assertions (flaky `transports setup mutations to the authoritative host before rebind` on CI shard 1/3).

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-01 - Acknowledge RPC abort before quiesce
+
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/connection-handler.ts` now dispatches the RPC `abort` signal without awaiting full session quiescence, acknowledges the command immediately, and observes later failures through the `rpc_error` event path. `abort_bash` and `abort_retry` remain unchanged because their dispatch methods are synchronous.
+
+### Why
+
+- Under host load, desktop stop clicks could appear delayed until the previous quiesce completed; the desktop adapter bounds abort acknowledgement at 10 seconds, so waiting for quiescence could surface `abort timed out` even after the abort signal had been delivered.
+
+### Why an extension could not handle it
+
+- RPC command acknowledgement ordering is owned by the transport connection handler, below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: the `abort` command case in `connection-handler.ts`.
+
 ## 2026-08-31 - Ownership-safe RPC and app-server state locks
 
 - Replaced proper-lockfile for the shared RPC-host and app-server daemon locks with a persistent regular SQLite lock file using `BEGIN EXCLUSIVE`; release commits and closes without unlinking.

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -1080,7 +1080,10 @@ export function createRpcConnectionHandler(
 			}
 
 			case "abort": {
-				await session.abort();
+				void session.abort().catch((cause: unknown) => {
+					// Abort is acknowledged once dispatched; report quiesce failures out of band.
+					outputEvent({ type: "rpc_error", error: String(cause) });
+				});
 				return success(id, "abort");
 			}
 

--- a/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
+++ b/packages/coding-agent/test/rpc-prompt-response-semantics.test.ts
@@ -100,6 +100,8 @@ async function createRuntimeHost(options: {
 }): Promise<{
 	runtimeHost: AgentSessionRuntime;
 	cleanup: () => Promise<void>;
+	releaseResponse: () => void;
+	streamStarted: Promise<void>;
 }> {
 	const tempDir = join(tmpdir(), `pi-rpc-prompt-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(tempDir, { recursive: true });
@@ -108,6 +110,8 @@ async function createRuntimeHost(options: {
 	if (!model) {
 		throw new Error("Test model not found");
 	}
+	const streamStarted = Promise.withResolvers<void>();
+	let releaseResponse = () => {};
 
 	const agent = new Agent({
 		getApiKey: () => "test-key",
@@ -118,11 +122,12 @@ async function createRuntimeHost(options: {
 		},
 		streamFn: (_model, _context, _options) => {
 			const stream = new MockAssistantStream();
+			const finish = () => stream.push({ type: "done", reason: "stop", message: createAssistantMessage("done") });
+			if (options.holdResponse) releaseResponse = finish;
 			queueMicrotask(() => {
 				stream.push({ type: "start", partial: createAssistantMessage("") });
+				streamStarted.resolve();
 				if (!options.holdResponse) {
-					const finish = () =>
-						stream.push({ type: "done", reason: "stop", message: createAssistantMessage("done") });
 					if (options.responseDelayMs !== undefined) setTimeout(finish, options.responseDelayMs);
 					else finish();
 				}
@@ -158,6 +163,8 @@ async function createRuntimeHost(options: {
 
 	return {
 		runtimeHost,
+		releaseResponse: () => releaseResponse(),
+		streamStarted: streamStarted.promise,
 		cleanup: async () => {
 			try {
 				if (session.isStreaming) {
@@ -182,15 +189,22 @@ async function startRpcMode(options: {
 }): Promise<{
 	lineHandler: (line: string) => void;
 	cleanup: () => Promise<void>;
+	releaseResponse: () => void;
+	streamStarted: Promise<void>;
 }> {
 	rpcIo.outputLines = [];
 	rpcIo.lineHandler = undefined;
 
-	const { runtimeHost, cleanup } = await createRuntimeHost(options);
+	const { runtimeHost, cleanup, releaseResponse, streamStarted } = await createRuntimeHost(options);
 	void runRpcMode(runtimeHost);
 	await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
 
-	return { lineHandler: rpcIo.lineHandler!, cleanup };
+	return {
+		lineHandler: rpcIo.lineHandler!,
+		cleanup,
+		releaseResponse: () => releaseResponse(),
+		streamStarted,
+	};
 }
 
 describe("RPC prompt response semantics", () => {
@@ -288,6 +302,40 @@ describe("RPC prompt response semantics", () => {
 				});
 			});
 		} finally {
+			await cleanup();
+		}
+	});
+
+	it("acks abort while the session is still streaming", async () => {
+		const { lineHandler, cleanup, releaseResponse, streamStarted } = await startRpcMode({
+			withAuth: true,
+			holdResponse: true,
+		});
+
+		try {
+			lineHandler(JSON.stringify({ id: "abort-start", type: "prompt", message: "Hold this" }));
+			await vi.waitFor(() => {
+				expect(getPromptResponses(rpcIo.outputLines, "abort-start")).toHaveLength(1);
+			});
+			await streamStarted;
+
+			lineHandler(JSON.stringify({ id: "abort-1", type: "abort" }));
+			await vi.waitFor(() => {
+				expect(parseOutputLines(rpcIo.outputLines)).toContainEqual({
+					id: "abort-1",
+					type: "response",
+					command: "abort",
+					success: true,
+				});
+			});
+			const records = parseOutputLines(rpcIo.outputLines);
+			const abortResponseIndex = records.findIndex((record) => record.id === "abort-1");
+			const agentEndIndex = records.findIndex((record) => record.type === "agent_end");
+			expect(abortResponseIndex).toBeGreaterThanOrEqual(0);
+			expect(agentEndIndex).toBeGreaterThanOrEqual(0);
+			expect(abortResponseIndex).toBeLessThan(agentEndIndex);
+		} finally {
+			releaseResponse();
 			await cleanup();
 		}
 	});


### PR DESCRIPTION
## Symptom

During the 2026-09-01 mengmotaHost incident, desktop stop clicks appeared to take effect much later under host load. The desktop adapter bounds the RPC abort acknowledgement at 10 seconds and logs `abort timed out`; the RPC handler was awaiting full agent quiescence before sending that acknowledgement.

## Fix

- Dispatch `session.abort()` without awaiting full quiescence, then return the abort success response immediately.
- Observe the returned promise and report any later quiesce failure through the existing `rpc_error` event path, avoiding unhandled rejections.
- Add a deterministic RPC regression test with a held-open mock stream. It waits for the real stream-start event, sends abort, and proves the abort response precedes the abort-triggered `agent_end`.

## Ordering contract

`agent_end` remains the authoritative turn-end record, including abort provenance. This change only moves the command acknowledgement earlier; it does not weaken `close_session`, whose response remains the final record for its handle. Registry close still independently awaits `session.abort()` and `session.waitForIdle()`.

`abort_bash` and `abort_retry` are unchanged: both handler paths call synchronous dispatch methods and already return immediately, so they do not share the quiesce-wait problem. No existing test or changes note pinned abort acknowledgement after idle/`agent_end`.

## Test evidence

RED before production change:

```text
FAIL test/rpc-prompt-response-semantics.test.ts > RPC prompt response semantics > acks abort while the session is still streaming
Error: Test timed out in 30000ms.
Tests 1 failed | 4 passed (5)
```

GREEN:

```text
bunx vitest run test/rpc-prompt-response-semantics.test.ts
Test Files 1 passed (1)
Tests 5 passed (5)
```

The commit hook also completed repository formatting, lint, pinned dependency checks, TypeScript checking, and browser smoke checks successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the RPC `abort` command so it acknowledges immediately after dispatching the abort signal instead of waiting for agent quiescence, which previously could delay desktop stop clicks by up to 10 seconds under load.

**Bug Fixes**
- Quiesce failures are now reported via the existing `rpc_error` event path instead of delaying the acknowledgement.
- `agent_end` remains the authoritative turn-end record; `abort_bash`, `abort_retry`, and `close_session` are unchanged.
- Adds a regression test with a held-open mock stream proving the abort response precedes `agent_end`.
- Adds changelog entries documenting the new abort acknowledgement behavior.

<sup>Written for commit 2da59da1045b68d038d41e818dea51059371ed95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

