### PR TITLE
fix(ai): honor explicit long-cache retention for Anthropic proxies

### DIFF
--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -113,6 +113,86 @@
 
 - LOW: `packages/ai/package.json` dependency pins during upstream syncs.
 
+## 2026-08-26 - Make the long-cache retention flag authoritative
+
+### What changed
+
+- `src/utils/prompt-cache-ttl.ts`: added an exported helper `allowsAnthropicLongCacheRetention(model)` that
+  resolves the long-cache decision as a tri-state. An explicit `compat.supportsLongCacheRetention` of `true` or
+  `false` now wins on any host. Only an unset (`undefined`) flag falls back to the previous inference, which is
+  `isAnthropicApiBaseUrl(model.baseUrl)` plus the existing fireworks carve-out.
+- The long-TTL condition used to be duplicated at two decision sites; both now call the one helper. The
+  `anthropic-messages` branch of `resolvePromptCacheTtlSeconds` uses it to pick 3600 vs 300 seconds, and the
+  private `getCacheControl` in `src/api/anthropic-messages.ts` uses it to pick the wire value
+  `cache_control.ttl: "1h"` vs omitting the field.
+- `src/api/anthropic-messages.ts` no longer imports `isAnthropicApiBaseUrl`.
+- `getAnthropicCompat` is unchanged. Its return type and the value it reports for
+  `supportsLongCacheRetention` are untouched; the helper is purely additive.
+
+### Why
+
+- `compat.supportsLongCacheRetention` is a documented public field in models.json, but for `anthropic-messages`
+  the 1-hour TTL was additionally gated on a hostname allowlist. A user pointing `baseUrl` at their own
+  Anthropic-wire-compatible proxy and explicitly setting the flag to `true` was silently ignored: the documented
+  knob did nothing.
+- The two sites had to converge for a second reason. While the condition stayed duplicated, a later edit to one
+  site could leave the computed TTL seconds disagreeing with the wire `ttl` string, and that divergence fails
+  silently. The request still succeeds while cache-expiry bookkeeping and safe-wait calculations can both be wrong.
+
+### Why an extension could not handle it
+
+Extensions sit above the provider request-construction and cache-accounting boundary. They cannot atomically
+change both Anthropic wire `cache_control.ttl` emission and the core `resolvePromptCacheTtlSeconds` bookkeeping.
+
+Changing only one side would silently desynchronize the actual request TTL from cache-expiry bookkeeping and safe-wait
+calculations. This belongs in the ai provider core and shared resolver.
+
+### Back-compat
+
+| baseUrl host | flag | before | after |
+| --- | --- | --- | --- |
+| api.anthropic.com | unset | 1h / 3600 | 1h / 3600 |
+| api.anthropic.com | false | 5m / 300 | 5m / 300 |
+| foreign proxy | unset | 5m / 300 | 5m / 300 |
+| foreign proxy | true | 5m / 300 | 1h / 3600 |
+
+- Only the last row changes behavior, and it changes only for a user who explicitly opted in.
+
+### Downstream effect
+
+- For an `anthropic-messages` model on a foreign proxy with long retention and an explicit
+  `supportsLongCacheRetention: true`, `resolvePromptCacheTtlSeconds` now reports the asserted cache TTL correctly:
+  300 seconds before, 3600 seconds after.
+- `packages/coding-agent` already propagates that TTL into
+  `ExtensionContext.getPromptCacheSafeWaitSeconds()`. With the default 30-second safety buffer, the corresponding
+  safe wait changes from 270 to 3570 seconds, not from 300 to 3600. Custom prompt-cache settings can disable this
+  budget or change the buffer.
+- Third-party extensions can observe the corrected safe wait through the public
+  `ExtensionContext.getPromptCacheSafeWaitSeconds()` getter. `packages/coding-agent` also mirrors it into the advisory
+  `PI_PROMPT_CACHE_SAFE_WAIT_SECONDS` environment variable for out-of-process consumers; no in-repository runtime
+  consumer currently reads that variable.
+- Existing safe-wait consumers are the opt-in cache-keepalive scheduler and monitor-delayed Goal continuation.
+  For the affected foreign-proxy case, the observable built-in behavior is the Goal continuation backstop and its
+  cache-warm metadata: under default settings, an active monitor/wake-source continuation can move from 270s to
+  3570s, subject to the configured Goal ceiling. The built-in cache-keepalive extension remains restricted to
+  `api.anthropic.com`, so this proxy opt-in does not activate or retime keepalive for a foreign proxy.
+- `bash-timeout` and `terminal` do not consume the cache-safe wait. Bash keeps its independent process kill
+  deadlines, while terminal foreground auto-detach uses the independent 60-second default foreground window
+  (5 seconds for classified sleep waits), configurable through `PI_BASH_FOREGROUND_SECONDS`.
+- Nothing under `packages/coding-agent/src/` changed; these effects are pre-existing propagation of the corrected
+  provider TTL.
+
+### Modified upstream files
+
+- `src/utils/prompt-cache-ttl.ts`
+- `src/api/anthropic-messages.ts`
+
+### Expected merge conflict zones
+
+- MEDIUM: the `anthropic-messages` branch of `resolvePromptCacheTtlSeconds`, rewritten from an inline conjunction
+  to a helper call.
+- MEDIUM: the `ttl` expression in `getCacheControl`, rewritten the same way.
+
 ## 2026-08-25 - Keep Cloudflare AI Gateway provider divergence covered
 
 ### What changed

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -41,7 +41,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord, providerHeadersToRecord } from "../utils/headers.ts";
 import { parseJsonWithRepair, parseStreamingJson } from "../utils/json-parse.ts";
 import { getPiUserAgent } from "../utils/pi-user-agent.ts";
-import { getAnthropicCompat, isAnthropicApiBaseUrl } from "../utils/prompt-cache-ttl.ts";
+import { allowsAnthropicLongCacheRetention, getAnthropicCompat } from "../utils/prompt-cache-ttl.ts";
 import { getProviderEnvValue } from "../utils/provider-env.ts";
 import { retryProviderRequest } from "../utils/provider-retry.ts";
 import { appendRetryAfterMsMarker, extract429RetryAfterMs } from "../utils/retry-hint.ts";
@@ -101,12 +101,7 @@ function getCacheControl(
 	if (retention === "none") {
 		return { retention };
 	}
-	const ttl =
-		retention === "long" &&
-		isAnthropicApiBaseUrl(model.baseUrl) &&
-		getAnthropicCompat(model).supportsLongCacheRetention
-			? "1h"
-			: undefined;
+	const ttl = retention === "long" && allowsAnthropicLongCacheRetention(model) ? "1h" : undefined;
 	return {
 		retention,
 		cacheControl: { type: "ephemeral", ...(ttl && { ttl }) },

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,21 @@
+## Honor explicit Anthropic long-cache retention on compatible proxies (2026-08-31)
+
+### What changed
+
+- `packages/ai/src/api/anthropic-messages.ts`: the wire-level `cache_control.ttl` decision now delegates to the shared Anthropic long-cache retention helper, so an explicit `compat.supportsLongCacheRetention` value is authoritative while an unset value keeps hostname-based inference.
+
+### Why
+
+- A model routed through an Anthropic-compatible proxy could explicitly declare one-hour cache support, but the wire path still required the official Anthropic hostname and silently omitted `ttl: "1h"`. Sharing the resolver decision prevents the request and internal TTL accounting from drifting.
+
+### Why an extension could not handle it
+
+- The cache-control object is serialized inside the private Anthropic Messages request builder before dispatch; no extension hook can rewrite that provider-wire field or keep it synchronized with internal TTL accounting.
+
+### Expected merge conflict zones
+
+- LOW: the prompt-cache helper import and `getCacheControl` TTL expression in `packages/ai/src/api/anthropic-messages.ts`.
+
 ## Cursor conversation cache eviction cannot break a live request (2026-08-31)
 
 ### What changed

--- a/packages/ai/src/utils/prompt-cache-ttl.ts
+++ b/packages/ai/src/utils/prompt-cache-ttl.ts
@@ -35,6 +35,13 @@ function defaultSupportsToolReferences(model: Model<"anthropic-messages">): bool
 	return major > 4 || (major === 4 && minor >= 5);
 }
 
+export function allowsAnthropicLongCacheRetention(model: Model<"anthropic-messages">): boolean {
+	return (
+		model.compat?.supportsLongCacheRetention ??
+		(isAnthropicApiBaseUrl(model.baseUrl) && getAnthropicCompat(model).supportsLongCacheRetention)
+	);
+}
+
 export function getAnthropicCompat(
 	model: Model<"anthropic-messages">,
 ): Required<Omit<AnthropicMessagesCompat, "forceAdaptiveThinking">> {
@@ -346,9 +353,7 @@ export function resolvePromptCacheTtlSeconds(model: Model<Api>, env?: ProviderEn
 			const anthropicModel = model as Model<"anthropic-messages">;
 			const retention = resolveAnthropicCacheRetention(anthropicModel.cacheRetention, env, "short");
 			if (retention === "none") return undefined;
-			return retention === "long" &&
-				isAnthropicApiBaseUrl(anthropicModel.baseUrl) &&
-				getAnthropicCompat(anthropicModel).supportsLongCacheRetention
+			return retention === "long" && allowsAnthropicLongCacheRetention(anthropicModel)
 				? PROMPT_CACHE_TTL_LONG_SECONDS
 				: PROMPT_CACHE_TTL_SHORT_SECONDS;
 		}

--- a/packages/ai/test/prompt-cache-ttl.test.ts
+++ b/packages/ai/test/prompt-cache-ttl.test.ts
@@ -285,3 +285,75 @@ describe("automatic and unknown cache backends", () => {
 		},
 	);
 });
+
+describe("Anthropic long-cache opt-in", () => {
+	it("(a) enables one-hour retention for opt-in proxied Anthropic models", () => {
+		const model = createModel("anthropic-messages", {
+			baseUrl: "https://proxy.example.com/v1",
+			cacheRetention: "long",
+			compat: { supportsLongCacheRetention: true },
+		});
+
+		expect(resolvePromptCacheTtlSeconds(model)).toBe(3600);
+	});
+
+	it("(b) keeps direct Anthropic long retention short when compat opts out", () => {
+		const model = createModel("anthropic-messages", {
+			baseUrl: "https://api.anthropic.com/v1",
+			cacheRetention: "long",
+			compat: { supportsLongCacheRetention: false },
+		});
+
+		expect(resolvePromptCacheTtlSeconds(model)).toBe(300);
+	});
+
+	it("(c) keeps proxied Anthropic long retention short when compat opts out", () => {
+		const model = createModel("anthropic-messages", {
+			baseUrl: "https://proxy.example.com/v1",
+			cacheRetention: "long",
+			compat: { supportsLongCacheRetention: false },
+		});
+
+		expect(resolvePromptCacheTtlSeconds(model)).toBe(300);
+	});
+
+	it("(d) keeps malformed Anthropic URLs on short retention without compat", () => {
+		const model = createModel("anthropic-messages", {
+			baseUrl: "not a url",
+			cacheRetention: "long",
+		});
+
+		expect(resolvePromptCacheTtlSeconds(model)).toBe(300);
+	});
+
+	it("(e) disables caching regardless of the long-cache opt-in", () => {
+		const model = createModel("anthropic-messages", {
+			baseUrl: "https://proxy.example.com/v1",
+			cacheRetention: "none",
+			compat: { supportsLongCacheRetention: true },
+		});
+
+		expect(resolvePromptCacheTtlSeconds(model)).toBeUndefined();
+	});
+
+	it("(f) honors an explicit long-cache opt-in for Fireworks-hosted models", () => {
+		const model = createModel("anthropic-messages", {
+			provider: "fireworks",
+			baseUrl: "https://api.anthropic.com/v1",
+			cacheRetention: "long",
+			compat: { supportsLongCacheRetention: true },
+		});
+
+		expect(resolvePromptCacheTtlSeconds(model)).toBe(3600);
+	});
+
+	it("(g) honors ProviderEnv long retention for opt-in proxied Anthropic models", () => {
+		const model = createModel("anthropic-messages", {
+			baseUrl: "https://proxy.example.com/v1",
+			compat: { supportsLongCacheRetention: true },
+		});
+		const env = { PI_CACHE_RETENTION: "long" };
+
+		expect(resolvePromptCacheTtlSeconds(model, env)).toBe(3600);
+	});
+});

--- a/packages/coding-agent/docs/models.md
+++ b/packages/coding-agent/docs/models.md
@@ -529,7 +529,7 @@ Built-in Anthropic models enable `supportsStrictTools` in their model metadata. 
 | Field | Description |
 |-------|-------------|
 | `supportsEagerToolInputStreaming` | Whether the provider accepts per-tool `eager_input_streaming`. Default: `true`. Set to `false` to omit that field and use the legacy fine-grained tool streaming beta header on tool-enabled requests. |
-| `supportsLongCacheRetention` | Whether the provider accepts Anthropic long cache retention (`cache_control.ttl: "1h"`) when cache retention is `long`. Default: `true`. |
+| `supportsLongCacheRetention` | Whether the provider accepts Anthropic long cache retention (`cache_control.ttl: "1h"`) when cache retention is `long`. Tri-state. Leave it unset (the default) and senpi infers support from the `baseUrl` host, enabling the 1-hour TTL only on the native Anthropic host. Set it to `true` and that's authoritative: the 1-hour TTL is sent on any host, including a custom proxy. Set it to `false` and that's authoritative too: the long TTL is refused on every host, native Anthropic included. Only set `true` for a proxy you've verified actually honors `cache_control.ttl`; the flag is your assertion, not a capability probe, and 1-hour cache writes cost more than 5-minute writes. |
 | `sendSessionAffinityHeaders` | Whether to send `x-session-affinity` from the session id when caching is enabled. Default: auto-detected for known providers. |
 | `supportsCacheControlOnTools` | Whether the provider accepts Anthropic-style `cache_control` markers on tool definitions. Default: `true`. |
 | `forceAdaptiveThinking` | Whether to send adaptive thinking (`thinking.type: "adaptive"` plus `output_config.effort`) for this model. Built-in adaptive models set this automatically. Default: `false`. |


### PR DESCRIPTION
## Problem

`compat.supportsLongCacheRetention: true` was ignored for Anthropic-compatible proxies. Both long-retention decision sites additionally required `baseUrl` to use the native Anthropic hostname, so an explicit proxy opt-in could never enable the one-hour cache TTL.

The wire serializer and the internal TTL resolver also duplicated this condition, leaving room for request TTL and cache accounting to drift.

## Solution

Add one shared `allowsAnthropicLongCacheRetention()` helper and use it for both:

- the wire-level `cache_control.ttl: "1h"` decision in `getCacheControl`
- the `300` / `3600` second decision in `resolvePromptCacheTtlSeconds`

The helper preserves tri-state semantics:

- explicit `true`: authoritative on any host, including a custom proxy
- explicit `false`: authoritative on every host, including native Anthropic
- `undefined`: preserve existing hostname inference and the Fireworks fallback

The helper uses nullish coalescing, so an explicit `false` never falls through to host inference.

## Compatibility

| Host | Setting | Before | After |
| --- | --- | --- | --- |
| Native Anthropic | unset | 1h / 3600s | 1h / 3600s |
| Native Anthropic | `false` | 5m / 300s | 5m / 300s |
| Third-party proxy | unset | 5m / 300s | 5m / 300s |
| Third-party proxy | `true` | 5m / 300s | 1h / 3600s |

Only the explicit proxy opt-in changes behavior.

## Impact

For an opted-in `anthropic-messages` proxy using long retention:

- the request now carries `cache_control.ttl: "1h"`
- the internal cache TTL changes from 300 to 3600 seconds
- with the default 30-second safety buffer, the exposed safe-wait value changes from 270 to 3570 seconds

The built-in cache keepalive remains restricted to the native Anthropic host, so this change does not enable keepalive for third-party proxies. Bash process deadlines and terminal foreground windows are independent of this value.

## Verification

- `npm test --workspace=@earendil-works/pi-ai`
  - 257 test files passed
  - 2,493 tests passed
- `npm run check`
  - Biome, policy checks, `tsc --noEmit`, and browser smoke passed
- real exported-resolver matrix: 4/4 passed
  - native / unset -> 3600
  - native / false -> 300
  - proxy / unset -> 300
  - proxy / true -> 3600
- `node scripts/check-pr-changelog.mjs --base origin/main --labels no-changelog`
  - exact-nearest `changes.md` coverage passed

## Out of scope

This PR does not change:

- OpenAI completions or responses cache behavior
- Bedrock cache behavior
- the hostname allowlist
- the public configuration schema
- any file under `packages/coding-agent/src/`
- dependencies, lockfiles, or generated model data

The `no-changelog` label is required because contributor policy prohibits directly editing the release `CHANGELOG.md`; exact-nearest `changes.md` tracker coverage is included separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors an explicit `supportsLongCacheRetention: true` for Anthropic-compatible proxies, so opted-in proxies now get the one-hour cache TTL instead of the default five minutes. An explicit `false` is also respected on the native Anthropic host; leaving the flag unset keeps the previous hostname-based inference. Only the explicit proxy opt-in changes behavior (TTL 300s → 3600s, safe-wait 270s → 3570s). Built-in cache keepalive stays restricted to the native Anthropic host.

**Refactors**
- The wire-level `cache_control.ttl` decision and the internal TTL seconds resolver now share one `allowsAnthropicLongCacheRetention()` helper, preventing the two from drifting.
- Adds tests for the tri-state matrix and updates the `supportsLongCacheRetention` docs.

<sup>Written for commit 6f4d3291af9c4be8e7840992246244be7cd8fa71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

