### PR TITLE
ci(review): add review-claim label gate and modernize action pins

### DIFF
--- a/.github/changes.md
+++ b/.github/changes.md
@@ -1,5 +1,31 @@
 # changes
 
+## Shared GitHub Action pins move to current majors (2026-09-01)
+
+### What changed
+
+- `.github/workflows/ci.yml` and `.github/workflows/build-binaries.yml` and `.github/workflows/npm-audit.yml` and `.github/workflows/publish-model-catalog.yml` unify their shared action pins on the current releases.
+- `actions/checkout` moves to `3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1) and `actions/setup-node` to `820762786026740c76f36085b0efc47a31fe5020` (v7.0.0), collapsing the two competing pins each carried.
+- `actions/upload-artifact` moves to `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1) and `actions/download-artifact` to `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1), off the retiring v4 line.
+- Only `uses:` lines change. Every pin keeps the repository's full-commit-SHA style with a trailing version
+  comment, and the two previously comment-less checkout and setup-node pins gain one.
+
+### Why
+
+- The tree carried two different `actions/checkout` pins and two different `actions/setup-node` pins across
+  workflows, so the same step ran on different action majors depending on the file. The artifact actions were
+  still on v4, which GitHub is retiring. Unifying on one verified SHA per action removes the drift and keeps
+  the supply chain pinned to a reviewed commit rather than a mutable tag.
+
+### Why an extension could not handle it
+
+- Action resolution is GitHub Actions runner plumbing evaluated before any repository code, let alone the
+  coding-agent extension loader, is fetched or executed.
+
+### Expected merge conflict zones
+
+- LOW: the `uses:` lines of the shared checkout, setup-node, upload-artifact, and download-artifact steps in `.github/workflows/ci.yml`, `.github/workflows/build-binaries.yml`, `.github/workflows/npm-audit.yml`, and `.github/workflows/publish-model-catalog.yml` whenever upstream bumps the same actions.
+
 ## Windows fs.watch regression joins the terminal cross-OS CI job (2026-08-31)
 
 ### What changed

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -38,7 +38,7 @@ jobs:
       SOURCE_REF: ${{ github.event.inputs.source_ref || github.event.inputs.tag || github.ref_name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ env.SOURCE_REF }}
           persist-credentials: false
@@ -54,7 +54,7 @@ jobs:
         run: bun --version
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -107,7 +107,7 @@ jobs:
           sha256sum "${release_assets[@]}" > SHA256SUMS
 
       - name: Upload GitHub release payload
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-assets-${{ env.RELEASE_TAG }}
           path: release-assets/*
@@ -130,7 +130,7 @@ jobs:
       RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
     steps:
       - name: Download binary archives
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-assets-${{ env.RELEASE_TAG }}
           path: release-assets
@@ -199,7 +199,7 @@ jobs:
       RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
     steps:
       - name: Download GitHub release payload
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-assets-${{ env.RELEASE_TAG }}
           path: release-assets

--- a/.github/workflows/changelog-gate.yml
+++ b/.github/workflows/changelog-gate.yml
@@ -22,12 +22,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -65,10 +65,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -106,10 +106,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -127,10 +127,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -216,10 +216,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -249,10 +249,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/native-prebuilds.yml
+++ b/.github/workflows/native-prebuilds.yml
@@ -125,12 +125,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -289,7 +289,7 @@ jobs:
           } > "${artifact_dir}/manifest.txt"
 
       - name: Upload native prebuild
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: ${{ runner.temp }}/native-prebuild-artifact/*

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/perf-trend.yml
+++ b/.github/workflows/perf-trend.yml
@@ -17,10 +17,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -81,7 +81,7 @@ jobs:
 
       - name: Upload perf trend artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: perf-trend
           path: perf-trend.json

--- a/.github/workflows/publish-model-catalog.yml
+++ b/.github/workflows/publish-model-catalog.yml
@@ -63,7 +63,7 @@ jobs:
         run: npm run check:model-catalog
 
       - name: Upload model catalog JSON
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: model-catalog-json
           path: .artifacts/model-catalog
@@ -98,7 +98,7 @@ jobs:
           node-version: '24'
 
       - name: Download model catalog JSON
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: model-catalog-json
           path: .artifacts/model-catalog

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -44,14 +44,14 @@ jobs:
           git config user.email "actions@github.com"
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
           package-manager-cache: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: '1.4.0'
 

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -63,10 +63,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm
@@ -110,10 +110,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/review-claims.yml
+++ b/.github/workflows/review-claims.yml
@@ -1,0 +1,222 @@
+name: Review Claims
+
+# Review-claim label automation:
+# - will-review / in-review block merge via the "Review claim gate" required check
+# - labeling one of them auto-requests the labeler as reviewer and clears stale-review
+# - the claim label is removed ONLY when the claimer submits a real review (approve / request changes)
+# - claims idle for 3+ days are swept to stale-review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted]
+  schedule:
+    - cron: "23 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  gate:
+    name: Review claim gate
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: review-claim-gate-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Fail while a review claim label is present
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map((l) => l.name);
+            const claims = labels.filter((l) => l === 'will-review' || l === 'in-review');
+            if (claims.length > 0) {
+              core.setFailed(`Merge blocked: active review claim label(s): ${claims.join(', ')}. The claimer must submit their review (approve or request changes) to release the claim.`);
+            } else {
+              core.info('No active review claim labels. Gate is green.');
+            }
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Review claim gate"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| PR | #${{ github.event.pull_request.number }} |"
+            echo "| Event | ${{ github.event.action }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  claim:
+    name: Register claimer as reviewer
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'labeled' &&
+      (github.event.label.name == 'will-review' || github.event.label.name == 'in-review')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Request review from the claimer and clear stale-review
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const claimer = context.payload.sender.login;
+            const { owner, repo } = context.repo;
+            if (pr.labels.some((l) => l.name === 'stale-review')) {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: 'stale-review' })
+                .then(() => core.info('Removed stale-review: superseded by a fresh claim.'))
+                .catch((e) => core.info(`stale-review removal skipped: ${e.message}`));
+            }
+            if (context.payload.sender.type === 'Bot') {
+              core.info(`Label applied by bot ${claimer}; skipping reviewer request.`);
+              return;
+            }
+            if (claimer === pr.user.login) {
+              core.info('Claimer is the PR author; skipping self review request.');
+              return;
+            }
+            const requested = (pr.requested_reviewers ?? []).map((r) => r.login);
+            if (requested.includes(claimer)) {
+              core.info(`${claimer} is already a requested reviewer.`);
+              return;
+            }
+            await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [claimer] });
+            core.info(`Requested review from claimer ${claimer}.`);
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Review claim registered"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| PR | #${{ github.event.pull_request.number }} |"
+            echo "| Label | ${{ github.event.label.name }} |"
+            echo "| Claimer | ${{ github.event.sender.login }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release-claim:
+    name: Release claim on claimer review
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Remove claim labels owned by this reviewer
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const CLAIMS = ['will-review', 'in-review'];
+            const pr = context.payload.pull_request;
+            const reviewer = context.payload.review.user.login;
+            const { owner, repo } = context.repo;
+            const present = pr.labels.map((l) => l.name).filter((n) => CLAIMS.includes(n));
+            if (present.length === 0) {
+              core.info('No claim labels on this PR.');
+              return;
+            }
+            const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+              owner, repo, issue_number: pr.number, per_page: 100,
+            });
+            const latestLabeler = {};
+            for (const ev of events) {
+              if (ev.event === 'labeled' && ev.label && CLAIMS.includes(ev.label.name)) {
+                latestLabeler[ev.label.name] = ev.actor ? ev.actor.login : undefined;
+              }
+            }
+            for (const name of present) {
+              if (latestLabeler[name] === reviewer) {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
+                core.info(`Removed ${name}: claimer ${reviewer} submitted their review.`);
+              } else {
+                core.info(`Kept ${name}: claimed by ${latestLabeler[name] ?? 'unknown'}, review came from ${reviewer}.`);
+              }
+            }
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Review claim release"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| PR | #${{ github.event.pull_request.number }} |"
+            echo "| Reviewer | ${{ github.event.review.user.login }} |"
+            echo "| Review state | ${{ github.event.review.state }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  stale-sweep:
+    name: Sweep stale review claims
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Move 3+ day old claims to stale-review
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const CLAIMS = ['will-review', 'in-review'];
+            const STALE = 'stale-review';
+            const MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+            const { owner, repo } = context.repo;
+            const prs = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
+            for (const pr of prs) {
+              const names = pr.labels.map((l) => l.name);
+              const present = names.filter((n) => CLAIMS.includes(n));
+              if (present.length === 0) continue;
+              const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              const latest = {};
+              for (const ev of events) {
+                if (ev.event === 'labeled' && ev.label && CLAIMS.includes(ev.label.name)) {
+                  latest[ev.label.name] = { actor: ev.actor ? ev.actor.login : undefined, at: Date.parse(ev.created_at) };
+                }
+              }
+              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pr.number, per_page: 100 });
+              const now = Date.now();
+              let removedAny = false;
+              for (const name of present) {
+                const info = latest[name];
+                if (!info || now - info.at < MAX_AGE_MS) continue;
+                const reviewedSince = reviews.some((r) =>
+                  r.user && r.user.login === info.actor &&
+                  Date.parse(r.submitted_at) > info.at &&
+                  (r.state === 'APPROVED' || r.state === 'CHANGES_REQUESTED'));
+                if (reviewedSince) continue;
+                await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name })
+                  .catch((e) => core.info(`PR #${pr.number}: ${name} removal skipped: ${e.message}`));
+                removedAny = true;
+                core.info(`PR #${pr.number}: removed stale ${name} (claimed by ${info.actor ?? 'unknown'}).`);
+              }
+              if (removedAny && !names.includes(STALE)) {
+                await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [STALE] });
+                core.info(`PR #${pr.number}: applied ${STALE}.`);
+              }
+            }
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Stale review claim sweep"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| Trigger | ${{ github.event_name }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,3 +148,17 @@ Runtime flow: `ai` (models/auth -> providers -> api) feeds `agent/src/agent-loop
 - Deep guidance lives in ~60 nested `AGENTS.md` files holding the file-level maps this root omits; read the nearest one before editing. `packages/coding-agent` is by far the largest package (~105k LOC with tests).
 - `packages/ai` tests alias `@earendil-works/pi-telemetry` to telemetry source, so telemetry breakage fails AI tests. Node floors differ: packages require >=22.19.0, root and CI use Node 24.
 - `packages/tui` uses tabs in source and its own `node --test` runner — do not apply coding-agent test habits there. `packages/coding-agent/bin/senpi` is only a symlink to built output; launcher logic lives in `src/cli.ts` / `src/bun-runtime.ts`.
+
+## Review claim labels (merge-gating)
+
+Three PR labels drive the review workflow; automation lives in `.github/workflows/review-claims.yml`:
+
+- `will-review` — a reviewer claims the PR ("I will review this"). Applying it auto-requests the labeler as reviewer and BLOCKS merge via the required `Review claim gate` check.
+- `in-review` — the claimer is actively reviewing. Same merge-blocking + auto-reviewer-request effects.
+- `stale-review` — a claim sat 3+ days without the claimer's review; the sweep removes the claim labels and applies this one. A fresh claim clears it.
+
+Rules:
+- Apply `will-review` when you plan to review a PR; switch to `in-review` when you start.
+- NEVER merge a PR carrying `will-review` or `in-review`; the gate check enforces this.
+- Claim labels are removed automatically ONLY when the claimer (the person who applied the label) submits an approve or request-changes review. Do not remove someone else's claim label by hand.
+- If a PR shows `stale-review`, it needs a (new) reviewer: claim it.


### PR DESCRIPTION
## What

Installs the review-claim label system and unifies the shared GitHub Action pins on their current majors.

## The three labels

| Label | Color | Meaning |
| --- | --- | --- |
| `will-review` | `fbca04` | A reviewer claims the PR ("I will review this"). Blocks merge. |
| `in-review` | `1d76db` | The claimer is actively reviewing. Blocks merge. |
| `stale-review` | `d93f0b` | A claim sat 3+ days without the claimer's review; the sweep cleared the claim. Needs a (new) reviewer. |

The labels already exist on the repository; this PR ships the automation and the documentation.

## The merge gate

`Review claim gate` fails while `will-review` or `in-review` is present on the PR, and passes otherwise. It runs on `pull_request_target` for open / reopen / synchronize / ready_for_review / label / unlabel, so the status refreshes the moment a claim is applied or released. The job name is stable so it can be wired up as a required branch-protection context; that wiring is intentionally **not** part of this PR.

## The automation jobs

| Job | Trigger | Behavior |
| --- | --- | --- |
| `Review claim gate` | `pull_request_target` | Fails while a claim label is present; green when there is none. |
| `Register claimer as reviewer` | claim label applied | Requests review from the labeler and clears `stale-review`. Skips bots and self-review by the PR author. |
| `Release claim on claimer review` | `pull_request_review` submitted | Removes a claim label **only** when the person who applied it submits approve / request-changes. Another reviewer's review leaves the claim intact. |
| `Sweep stale review claims` | cron `23 */6 * * *` + manual | Removes claims idle 3+ days without the claimer's review and applies `stale-review`. |

Claim ownership is resolved from the issue timeline (`labeled` events), so a claim can only be released by its own claimer.

## Version bumps

Two competing `actions/checkout` pins and two competing `actions/setup-node` pins are collapsed onto one verified SHA each; the artifact actions leave the retiring v4 line. Every pin keeps the repository's full-commit-SHA style with a trailing version comment.

| Action | Old pin | New pin | Tag |
| --- | --- | --- | --- |
| `actions/checkout` | `df4cb1c0` (15x) + `3d3c42e5` (3x) | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
| `actions/setup-node` | `48b55a01` (15x) + `82076278` (3x) | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0 |
| `actions/upload-artifact` | `ea165f8d` (v4.6.2) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
| `actions/download-artifact` | `d3f86a10` (v4.3.0) | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | v8.0.1 |
| `oven-sh/setup-bun` | `4bc047ad` (v2.0.1) | `0c5077e51419868618aeaa5fe8019c62421857d6` | v2.2.0 |
| `actions/github-script` (new file) | — | `3a2844b7e9c422d3c10d287c895573f7108da1b3` | v9.0.0 |

Only `uses:` lines change in the bump commit — no runner labels, no unrelated actions, no reformatting.

## Verification

- `actionlint` v1.7.10: exit 0, zero findings.
- `node scripts/check-pr-changelog.mjs`: `PASS - changes.md coverage complete (4 production path(s) covered); no runtime source changes detected`. The four upstream-owned workflows are covered in `.github/changes.md` with all four canonical sections, so no `no-changelog` label is required.
- The mandatory workflow-summary checker reports 7 pre-existing violations that are byte-identical on `main`; `review-claims.yml` itself writes a summary in every job (baseline 5/12 -> 6/13).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a review-claim label system that blocks merges while a PR is claimed, and unifies the shared GitHub Action pins on current majors.

- `will-review` and `in-review` fail the `Review claim gate` job; applying one requests the labeler as reviewer and clears `stale-review`.
- A claim is removed only when the claimer submits an approve or request-changes review; another reviewer's review leaves it intact.
- A 6-hourly sweep moves claims idle 3+ days to `stale-review`, which signals the PR needs a new reviewer.
- The gate runs on `pull_request_target` so the status refreshes on label changes; branch protection must still be wired to the job separately.
- Workflows now pin `actions/checkout` v7.0.1, `actions/setup-node` v7.0.0, `actions/upload-artifact` v7.0.1, `actions/download-artifact` v8.0.1, and `oven-sh/setup-bun` v2.2.0 as single SHAs, collapsing the two competing checkout and setup-node pins.
- Only `uses:` lines change across the modified workflows.
- AGENTS.md documents the label rules and the no-merge-while-claimed rule.

<sup>Written for commit 65a1ed3503e2bfe7d99c5d0598135154fdfcf943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

