### PR TITLE
fix(coding-agent): dedupe session tree edges

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Session tree construction no longer freezes on sessions with duplicate entry IDs; `getTree()` builds one edge per unique node instead of re-linking the same node for every persisted row ([#1247](https://github.com/code-yeongyu/senpi/issues/1247)).
+
 - Multi-session RPC hosts launched with `SENPI_RPC_CLIENT_CAPABILITIES` (for example `extension_events`) now apply those capabilities to connection-owned session bindings when the client never sends `set_client_info`. Previously the launch capabilities were advertised through `get_protocol_info` but dropped at binding creation, so undeclared clients received no `extension_event` frames (breaking downstream task/DAG/monitor liveness in omo-desktop-app). An explicit `set_client_info` declaration, including an empty capability list, still overrides the launch default.
 
 - RPC `abort` acknowledgements are now sent immediately after the abort signal is dispatched instead of waiting for full session quiescence, preventing desktop stop requests from hitting their 10-second bounded-ack timeout under host load.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-01 - Bound session tree construction with duplicate entry IDs
+
+### What changed
+
+- `packages/coding-agent/src/core/session-manager.ts`: `SessionManager.getTree()` now links each unique entry ID once, while preserving the existing final-entry-wins index semantics for repeated persisted rows.
+
+### Why
+
+- Duplicate entry IDs caused the same `SessionTreeNode` object to be appended repeatedly to a parent's children. Repeated duplicate edges along a branch multiplied the later traversal work and could freeze the interactive session tree before it rendered.
+
+### Why an extension could not handle it
+
+- Persisted session indexing and tree construction are core `SessionManager` responsibilities below the extension API. An extension cannot replace the synchronous tree returned to interactive, RPC, and other consumers.
+
+### Expected merge conflict zones
+
+- LOW: the edge-construction loop in `packages/coding-agent/src/core/session-manager.ts`.
+
 ## 2026-08-31 - Session activity contract for host occupancy decisions
 
 ### What changed

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -1568,9 +1568,10 @@ export class SessionManager {
 			nodeMap.set(entry.id, { entry, children: [], label, labelTimestamp });
 		}
 
-		// Build tree
-		for (const entry of entries) {
-			const node = nodeMap.get(entry.id)!;
+		// Build one edge per unique ID. Persisted sessions can contain repeated rows,
+		// and nodeMap intentionally keeps the final entry for each ID.
+		for (const node of nodeMap.values()) {
+			const { entry } = node;
 			if (entry.parentId === null || entry.parentId === entry.id) {
 				roots.push(node);
 			} else {

--- a/packages/coding-agent/test/suite/regressions/issue-1247-session-tree-duplicate-entry-ids.test.ts
+++ b/packages/coding-agent/test/suite/regressions/issue-1247-session-tree-duplicate-entry-ids.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { type CustomEntry, SessionManager } from "../../../src/core/session-manager.ts";
+
+function customEntry(id: string, parentId: string | null, revision: number): CustomEntry {
+	return {
+		type: "custom",
+		customType: "duplicate-id-regression",
+		data: { revision },
+		id,
+		parentId,
+		timestamp: `2026-09-01T00:00:0${revision}.000Z`,
+	};
+}
+
+describe("issue #1247 duplicate session entry IDs", () => {
+	it("builds one tree node per entry ID when persisted rows repeat", () => {
+		// Given: a persisted-style chain where the same child ID appears twice.
+		const session = SessionManager.inMemory();
+		session.appendEntry(customEntry("root", null, 0));
+		session.appendEntry(customEntry("child", "root", 1));
+		session.appendEntry(customEntry("child", "root", 2));
+		session.appendEntry(customEntry("grandchild", "child", 3));
+
+		// When: the session tree is constructed.
+		const tree = session.getTree();
+
+		// Then: the last row for the duplicate ID wins without adding duplicate edges.
+		expect(tree).toHaveLength(1);
+		expect(tree[0]?.entry.id).toBe("root");
+		expect(tree[0]?.children.map((node) => node.entry.id)).toEqual(["child"]);
+		expect(tree[0]?.children[0]?.entry).toMatchObject({
+			id: "child",
+			data: { revision: 2 },
+		});
+		expect(tree[0]?.children[0]?.children.map((node) => node.entry.id)).toEqual(["grandchild"]);
+	});
+});


### PR DESCRIPTION
## Summary

- build session-tree edges once per unique persisted entry ID
- preserve the existing final-entry-wins index semantics for repeated IDs
- add an issue regression covering duplicate child rows and descendant preservation
- document the core divergence in `packages/coding-agent/src/core/changes.md`

Closes #1247.

## Root cause

`SessionManager.getTree()` created one `SessionTreeNode` per unique ID, but then linked nodes by iterating every persisted row. Repeated rows therefore pushed the same node object into a parent's `children` array multiple times. Duplicate edges along a branch multiplied the subsequent iterative traversal and could block the TUI before the tree selector rendered.

## Verification

- RED: regression initially failed with `expected [ 'child', 'child' ] to deeply equal [ 'child' ]`
- `bun run --cwd packages/coding-agent test test/suite/regressions/issue-1247-session-tree-duplicate-entry-ids.test.ts`
- `bun run --cwd packages/coding-agent test test/session-manager`
- `bun run check`
- `bun run build`
- Senpi QA common harness: 10/10
- Senpi RPC QA: 4/4
- Senpi mock-loop QA: 48/48, zero real provider calls
- Senpi TUI smoke: 5/5

## Real-session QA

The affected private session was exercised without exposing message contents:

- 7,202 entries
- 7,094 unique IDs
- 108 duplicate IDs
- pre-fix `getTree()`: exceeded 60 seconds
- fixed `getTree()`: 3.4 ms
- returned 7,094 unique tree nodes and 7,093 edges
- source JSONL SHA-256 unchanged

QA receipts are stored locally under `local-ignore/qa-evidence/` and are not committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session tree construction freezing on sessions with duplicate entry IDs. `getTree()` now builds one edge per unique node instead of re-linking the same node for every persisted row, while preserving the existing final-entry-wins index semantics.

**Bug Fixes**
- Duplicate persisted rows previously appended the same node object to a parent’s children repeatedly, multiplying traversal work and blocking the TUI before the tree rendered.
- Adds a regression test covering duplicate child rows and descendant preservation.

<sup>Written for commit a95f34972938c30e76291ff6afdd5f543279eae1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

