### PR TITLE
fix(interactive): keep stderr guarded through quit cleanup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Interactive quit now keeps stderr capture installed while session shutdown handlers drain during runtime disposal, so shutdown-time diagnostics (for example memory drain warnings) are recorded in the debug log instead of printing raw beside the resume hint. The TUI still stops first to avoid final-frame repaints, and stderr is restored after disposal even when disposal fails.
+
 - Multi-session RPC hosts launched with `SENPI_RPC_CLIENT_CAPABILITIES` (for example `extension_events`) now apply those capabilities to connection-owned session bindings when the client never sends `set_client_info`. Previously the launch capabilities were advertised through `get_protocol_info` but dropped at binding creation, so undeclared clients received no `extension_event` frames (breaking downstream task/DAG/monitor liveness in omo-desktop-app). An explicit `set_client_info` declaration, including an empty capability list, still overrides the launch default.
 
 - RPC `abort` acknowledgements are now sent immediately after the abort signal is dispatched instead of waiting for full session quiescence, preventing desktop stop requests from hitting their 10-second bounded-ack timeout under host load.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## 2026-09-01 - Keep stderr hidden through interactive quit cleanup
+
+### What changed
+
+- Interactive quit now stops the TUI without restoring stderr, keeps the guard installed while session shutdown handlers drain, and restores stderr after cleanup completes, including when disposal fails.
+- Added regression coverage for stderr capture during disposal and restoration after both successful and failed cleanup.
+
+### Why
+
+- Session shutdown handlers can emit diagnostics while the interactive runtime is being disposed. Restoring stderr before disposal exposed those warnings beside the final resume hint and corrupted the user's terminal output.
+
+### Expected merge conflict zones
+
+- LOW: interactive shutdown and `stop()` lifecycle in `interactive-mode.ts`.
+
 ## 2026-08-30 - Harden shared-host reconnect fallback
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -4,12 +4,31 @@
 
 ### What changed
 
-- Interactive quit now stops the TUI without restoring stderr, keeps the guard installed while session shutdown handlers drain, and restores stderr after cleanup completes, including when disposal fails.
-- Added regression coverage for stderr capture during disposal and restoration after both successful and failed cleanup.
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: the interactive quit path in
+  `shutdown()` now calls `stop({ restoreStderr: false })` so the TUI still stops first (no
+  final-frame repaint) while the stderr guard stays installed across `runtimeHost.dispose()`, and
+  `restoreInteractiveStderr()` runs in a `finally` after disposal so a disposal failure can neither
+  leave the guard swallowed nor skip the restore.
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `stop()` now accepts
+  `FullscreenExitOutput | { restoreStderr?: boolean }`; the string form and every existing caller
+  keep the previous restore-always behavior.
+- `packages/coding-agent/test/suite/regressions/quit-stderr-guard-drain.test.ts`: regression
+  coverage proving stderr stays captured while session shutdown handlers drain and is restored
+  after both successful and failed disposal.
 
 ### Why
 
-- Session shutdown handlers can emit diagnostics while the interactive runtime is being disposed. Restoring stderr before disposal exposed those warnings beside the final resume hint and corrupted the user's terminal output.
+- Session shutdown handlers emit diagnostics while the interactive runtime is being disposed
+  (observed in production: omo's memory shutdown drain printed `memory shutdown drain hit its
+  budget` raw beside the resume hint at quit). Restoring stderr before disposal exposed those
+  warnings on the user's terminal; the signal-triggered path already disposed first and never had
+  the leak.
+
+### Why an extension could not handle it
+
+- The ordering lives in the interactive mode's own `shutdown()`/`stop()` lifecycle, which no
+  extension hook reaches: extensions are the payload being disposed inside `runtimeHost.dispose()`,
+  so only the host can hold the stderr guard across that window.
 
 ### Expected merge conflict zones
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5694,8 +5694,12 @@ export class InteractiveMode {
 		this.themeController.disableAutoSync();
 		await this.ui.terminal.drainInput(1000);
 
-		this.stop();
-		await this.runtimeHost.dispose();
+		this.stop({ restoreStderr: false });
+		try {
+			await this.runtimeHost.dispose();
+		} finally {
+			restoreInteractiveStderr();
+		}
 
 		const resumeCommand = formatResumeCommand(this.sessionManager);
 		if (resumeCommand) {
@@ -8757,7 +8761,9 @@ export class InteractiveMode {
 		}
 	}
 
-	stop(fullscreenExitOutput?: FullscreenExitOutput): void {
+	stop(options?: FullscreenExitOutput | { restoreStderr?: boolean }): void {
+		const fullscreenExitOutput = typeof options === "string" ? options : undefined;
+		const restoreStderr = typeof options === "string" || options?.restoreStderr !== false;
 		InteractiveMode.restoreCompactionEscapeOverride(this);
 		this.streamingReveal.stop();
 		this.toolResultReveal.stop();
@@ -8782,9 +8788,9 @@ export class InteractiveMode {
 				this.stopInteractiveTui(fullscreenExitOutput ?? this.settingsManager.getFullscreenExitOutput());
 			} finally {
 				this.isInitialized = false;
-				restoreInteractiveStderr();
+				if (restoreStderr) restoreInteractiveStderr();
 			}
-		} else {
+		} else if (restoreStderr) {
 			restoreInteractiveStderr();
 		}
 		this.unregisterSignalHandlers();

--- a/packages/coding-agent/test/suite/regressions/quit-stderr-guard-drain.test.ts
+++ b/packages/coding-agent/test/suite/regressions/quit-stderr-guard-drain.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const stderrGuard = vi.hoisted(() => ({ installed: false }));
+
+vi.mock("../../../src/modes/interactive/interactive-stderr-guard.ts", () => ({
+	takeOverInteractiveStderr: vi.fn(() => {
+		stderrGuard.installed = true;
+	}),
+	restoreInteractiveStderr: vi.fn(() => {
+		stderrGuard.installed = false;
+	}),
+}));
+
+const { InteractiveMode } = await import("../../../src/modes/interactive/interactive-mode.ts");
+
+class ProcessExitError extends Error {}
+
+type ShutdownContext = {
+	isShuttingDown: boolean;
+	runtimeHost: { dispose: () => Promise<void> };
+	ui: { terminal: { drainInput: (ms: number) => Promise<void> } };
+	themeController: { disableAutoSync: () => void };
+	stop: (options?: { restoreStderr?: boolean }) => void;
+	sessionManager: { isPersisted: () => boolean };
+};
+
+type InteractiveModePrototype = {
+	shutdown(this: ShutdownContext, options?: { fromSignal?: boolean }): Promise<void>;
+};
+
+const shutdown = (InteractiveMode.prototype as unknown as InteractiveModePrototype).shutdown;
+
+function createContext(dispose: () => Promise<void>): ShutdownContext {
+	return {
+		isShuttingDown: false,
+		runtimeHost: { dispose },
+		ui: { terminal: { drainInput: vi.fn(async () => {}) } },
+		themeController: { disableAutoSync: vi.fn() },
+		stop: vi.fn((options) => {
+			if (options?.restoreStderr !== false) stderrGuard.installed = false;
+		}),
+		sessionManager: { isPersisted: () => false },
+	};
+}
+
+async function callShutdown(context: ShutdownContext): Promise<void> {
+	try {
+		await shutdown.call(context);
+	} catch (error) {
+		if (!(error instanceof ProcessExitError)) throw error;
+	}
+}
+
+describe("interactive quit stderr guard", () => {
+	afterEach(() => {
+		stderrGuard.installed = false;
+		vi.restoreAllMocks();
+	});
+
+	test("keeps stderr captured while session shutdown drains and restores it afterward", async () => {
+		vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new ProcessExitError();
+		}) as typeof process.exit);
+		stderrGuard.installed = true;
+		let capturedDuringDispose = false;
+		const context = createContext(async () => {
+			capturedDuringDispose = stderrGuard.installed;
+		});
+
+		await callShutdown(context);
+
+		expect(capturedDuringDispose).toBe(true);
+		expect(stderrGuard.installed).toBe(false);
+	});
+
+	test("restores stderr if session shutdown fails", async () => {
+		vi.spyOn(process, "exit").mockImplementation((() => {
+			throw new ProcessExitError();
+		}) as typeof process.exit);
+		stderrGuard.installed = true;
+		const context = createContext(async () => {
+			throw new Error("dispose failed");
+		});
+
+		await expect(callShutdown(context)).rejects.toThrow("dispose failed");
+		expect(stderrGuard.installed).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem
Interactive quit restored the stderr guard when stopping the TUI, before `runtimeHost.dispose()` ran. Session shutdown handlers could therefore emit raw diagnostics into the user's terminal beside the resume hint.

## Root cause
`packages/coding-agent/src/modes/interactive/interactive-mode.ts` stopped the TUI via `stop()`, which unconditionally called `restoreInteractiveStderr()`, and only then awaited `runtimeHost.dispose()` in the interactive shutdown path.

## Design
- Preserve the existing TUI-first shutdown ordering.
- Add an optional `restoreStderr` stop option, defaulting to the existing restore behavior for all callers.
- Interactive quit calls `stop({ restoreStderr: false })`, awaits disposal, and restores stderr in `finally`.
- Signal shutdown, uncaught crash, and emergency terminal exit paths are unchanged.

## Verification
- RED: `bunx vitest run test/suite/regressions/quit-stderr-guard-drain.test.ts` - 1 failed, 1 passed; the guard was observed restored during disposal.
- Focused GREEN: same command - 1 file passed, 2 tests passed.
- Broader interactive scope: 6 files passed, 24 tests passed.
- Remote typecheck attempted with `bunx tsc --noEmit -p packages/coding-agent/tsconfig.build.json`; blocked by pre-existing checkout dependency resolution errors (`@earendil-works/pi-*` modules unavailable) and unrelated baseline implicit-any errors. The requested `-p packages/coding-agent` form also fails because the package has no `tsconfig.json`.
- The lead will run the manual TUI quit smoke.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps stderr captured through interactive quit cleanup so session shutdown handlers can no longer leak raw diagnostics into the terminal beside the resume hint. Previously, `stop()` restored stderr before `runtimeHost.dispose()` ran; now interactive quit defers restoration until after disposal completes, including when disposal fails. Existing callers of `stop()` keep the old restore behavior by default.

**Bug Fixes**

- Interactive quit calls `stop({ restoreStderr: false })`, then restores stderr in a `finally` block after `runtimeHost.dispose()`.
- Added regression tests covering stderr capture during disposal and restoration after both successful and failed cleanup.

<sup>Written for commit d8c6ec436fee8722e5617111d6673f4f2f32290f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

