### PR TITLE
ci: add workflow summary steps to remaining touched workflows

### DIFF
--- a/.github/changes.md
+++ b/.github/changes.md
@@ -10,6 +10,14 @@
 
 - Every workflow must render an at-a-glance result on the run page; this workflow was modernized earlier today but still lacked the summary step the repository standard requires.
 
+### Why an extension could not handle it
+
+- GitHub workflow files execute on GitHub's runners; no senpi extension surface can inject a job summary step into a workflow definition.
+
+### Expected merge conflict zones
+
+- `.github/workflows/publish-model-catalog.yml` tail of the final job (upstream has no such workflow; conflict risk is fork-local only).
+
 ## Shared GitHub Action pins move to current majors (2026-09-01)
 
 ### What changed

--- a/.github/changes.md
+++ b/.github/changes.md
@@ -1,5 +1,15 @@
 # changes
 
+## Workflow summary step for the model catalog publisher (2026-09-01)
+
+### What changed
+
+- `.github/workflows/publish-model-catalog.yml` gains the mandatory `$GITHUB_STEP_SUMMARY` step reporting job status, ref, and commit at the end of its final job.
+
+### Why
+
+- Every workflow must render an at-a-glance result on the run page; this workflow was modernized earlier today but still lacked the summary step the repository standard requires.
+
 ## Shared GitHub Action pins move to current majors (2026-09-01)
 
 ### What changed

--- a/.github/workflows/publish-model-catalog.yml
+++ b/.github/workflows/publish-model-catalog.yml
@@ -144,3 +144,17 @@ jobs:
             --bucket pi-artifacts \
             --endpoint "$R2_ENDPOINT" \
             --source-commit "$(git rev-parse HEAD)"
+
+      - name: Workflow summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Model catalog publish"
+            echo
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Job status | ${{ job.status }} |"
+            echo "| Ref | ${{ github.ref_name }} |"
+            echo "| Commit | ${{ github.sha }} |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds the mandatory $GITHUB_STEP_SUMMARY step to workflows touched by the actions-modernization PR that lacked one. actionlint verified locally (exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the required `$GITHUB_STEP_SUMMARY` step to the model catalog publish workflow so every run renders its job status, ref, and commit in the Actions UI, even on failure. Updates `changes.md` to document the change.

<sup>Written for commit 3da19e19ab2236fd8e2b0ef5c372f26cabc3560b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

