### PR TITLE
fix(config-reload): retire watcher after provider scope closes

### DIFF
--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,5 +1,32 @@
 # config-reload Extension Changes
 
+## Retire watchers after their provider scope closes (2026-09-01)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts` now
+  treats only the `Provider scope is closed` error from a scope-bound filesystem
+  callback as a terminal lifecycle signal and closes the config-reload watcher.
+  Other callback errors still propagate through their existing paths.
+
+### Why
+
+- A debounced filesystem event can outlive the RPC session provider scope that
+  created `packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts`.
+  The late callback previously threw an uncaught error, terminated the host, and
+  left callers waiting until their prompt timed out.
+
+### Why an extension could not handle it
+
+- `packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts` owns
+  both the internal watcher lifecycle and the provider-scope callback binding;
+  an external extension cannot retire this orphaned watcher safely.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts`
+  callback binding and watcher-construction wiring.
+
 ## Watch only in-scope directories instead of whole subtrees (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/index.ts
@@ -125,11 +125,20 @@ export class ConfigReloadHandoffRegistry<T> {
 
 const reloadHandoffs = new ConfigReloadHandoffRegistry<ReloadHandoff>();
 
-function bindExternalCallback<TArgs extends unknown[], TResult>(
-	callback: (...args: TArgs) => TResult,
-): (...args: TArgs) => TResult {
+function bindExternalCallback<TArgs extends unknown[]>(
+	callback: (...args: TArgs) => void,
+	onProviderScopeClosed: () => void,
+): (...args: TArgs) => void {
 	try {
-		return bindToProviderScope(callback);
+		const boundCallback = bindToProviderScope(callback);
+		return (...args: TArgs): void => {
+			try {
+				boundCallback(...args);
+			} catch (error: unknown) {
+				if (!(error instanceof Error) || error.message !== "Provider scope is closed") throw error;
+				onProviderScopeClosed();
+			}
+		};
 	} catch {
 		return callback;
 	}
@@ -342,10 +351,10 @@ export function configReloadExtension(pi: ExtensionAPI, options: ConfigReloadExt
 			debounceMs: settings.debounceMs,
 			clock: options.clock,
 			hashFile: options.hashFile,
-			onRealChange: bindExternalCallback(enqueueChange),
+			onRealChange: bindExternalCallback(enqueueChange, closeWatchers),
 			onError: bindExternalCallback((error, path) => {
 				logger.error("watcher_error", { path, message: errorMessage(error) });
-			}),
+			}, closeWatchers),
 		});
 		refreshSettingsContentSnapshots(settingsContents, agentDir, ctx.cwd);
 		logger.info("watcher_started", { targetCount: activeTargets.length });

--- a/packages/coding-agent/test/suite/config-reload-lazy-teardown.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-lazy-teardown.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ProviderScope, runWithProviderScope } from "@earendil-works/pi-ai/node/provider-scope";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEventBus } from "../../src/core/event-bus.ts";
 import configReloadExtension from "../../src/core/extensions/builtin/config-reload/index.ts";
@@ -190,6 +191,45 @@ describe("config reload watcher teardown is non-blocking", () => {
 		expect(onRealChange).not.toHaveBeenCalled();
 		await teardown;
 		expect(probe.activeListenerCount(watchedDir)).toBe(0);
+	});
+
+	it("drops debounced events after the bound provider scope closes", async () => {
+		// Given: an extension whose filesystem callbacks were bound to a live
+		// provider scope, with a content change waiting on the debounce clock.
+		vi.useFakeTimers();
+		const agentDir = createTempDir("senpi-config-reload-closed-scope-");
+		const settingsPath = join(agentDir, "settings.json");
+		writeFileSync(settingsPath, '{"theme":"dark"}\n', "utf-8");
+		const probe = createSlowTeardownProbe();
+		const extension = createManualExtension();
+		const scope = new ProviderScope();
+		runWithProviderScope(scope, () => {
+			configReloadExtension(extension.api, {
+				agentDir,
+				subscribe: probe.subscribe,
+				logger: silentLogger(),
+			});
+		});
+		const context = fakeContext(agentDir);
+		await runWithProviderScope(scope, () =>
+			invoke(
+				extension.handlers,
+				"session_start",
+				{ type: "session_start", reason: "startup" } satisfies SessionStartEvent,
+				context,
+			),
+		);
+		writeFileSync(settingsPath, '{"theme":"light"}\n', "utf-8");
+		probe.emit(agentDir, "settings.json");
+
+		// When: the owning session scope closes before the debounce expires.
+		scope.close();
+
+		// Then: the late callback cannot escape as an uncaught error and the
+		// orphaned watcher tears itself down.
+		await vi.advanceTimersByTimeAsync(200);
+		await vi.advanceTimersByTimeAsync(1);
+		expect(probe.activeListenerCount(agentDir)).toBe(0);
 	});
 
 	it("returns from session_shutdown without waiting for the unsubscribe loop", async () => {


### PR DESCRIPTION
## Summary

- treat only `Provider scope is closed` from scope-bound config-reload callbacks as a terminal lifecycle signal
- retire the orphaned watcher while preserving existing error propagation and non-blocking teardown behavior
- add a regression test for a debounced settings event delivered after the owning provider scope closes

## Reproduction

On `main`, the new regression test fails from `ConfigReloadWatchEngine.#evaluatePending` with an uncaught `Error: Provider scope is closed`. With this patch, the callback closes the watcher and its subscriptions drain on the existing deferred teardown tick.

## Verification

- `bun run --cwd packages/coding-agent test test/suite/config-reload-lazy-teardown.test.ts` (4 passed)
- config-reload test suite (7 files, 107 tests passed)
- `bun run check`
- isolated senpi QA: `common.mjs --self-check` (10/10), `rpc-drive.mjs --self-test` (4/4), `mock-loop.mjs --with-tool --api openai-responses` (4/4)

## Changelog

This fixes a user-visible RPC host crash and prompt timeout. Per `CONTRIBUTING.md`, external contributors must not edit `CHANGELOG.md`; a maintainer changelog entry is still needed for the changelog gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the config-reload extension when a debounced filesystem event fires after the owning provider scope closes.

- Treats only `Provider scope is closed` as a terminal signal and retires the orphaned watcher.
- Preserves error propagation for all other callback errors and retains non-blocking teardown.
- Adds a regression test covering a debounced event delivered after scope closure.

<sup>Written for commit 4061523881d72c2d8cbc8b2c7d52b9998ddaa582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

