### PR TITLE
ci(review-claims): refresh the gate check after automated claim release

### DIFF
--- a/.github/workflows/review-claims.yml
+++ b/.github/workflows/review-claims.yml
@@ -19,6 +19,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
+  checks: write
 
 jobs:
   gate:
@@ -136,11 +137,13 @@ jobs:
                 latestLabeler[ev.label.name] = ev.actor ? ev.actor.login : undefined;
               }
             }
+            let removedAny = false;
             for (const name of present) {
               if (latestLabeler[name] === reviewer) {
                 try {
                   await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name });
                   core.info(`Removed ${name}: claimer ${reviewer} submitted their review.`);
+                  removedAny = true;
                 } catch (e) {
                   if (e.status === 403) {
                     core.warning(`Token is read-only in this PR context; the hourly sweep will release ${name} instead.`);
@@ -150,6 +153,21 @@ jobs:
                 }
               } else {
                 core.info(`Kept ${name}: claimed by ${latestLabeler[name] ?? 'unknown'}, review came from ${reviewer}.`);
+              }
+            }
+            if (removedAny) {
+              const { data: rest } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: pr.number });
+              if (!rest.some((l) => CLAIMS.includes(l.name))) {
+                try {
+                  await github.rest.checks.create({
+                    owner, repo, name: 'Review claim gate', head_sha: pr.head.sha,
+                    status: 'completed', conclusion: 'success',
+                    output: { title: 'No active review claims', summary: 'Claim released by the claimer review; merge unblocked.' },
+                  });
+                  core.info('Refreshed the Review claim gate check to success.');
+                } catch (e) {
+                  core.warning(`Gate check refresh skipped: ${e.message}`);
+                }
               }
             }
       - name: Workflow summary
@@ -220,6 +238,19 @@ jobs:
               if (removedAny && !names.includes(STALE)) {
                 await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [STALE] });
                 core.info(`PR #${pr.number}: applied ${STALE}.`);
+              }
+              const { data: rest } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: pr.number });
+              if (!rest.some((l) => CLAIMS.includes(l.name))) {
+                try {
+                  await github.rest.checks.create({
+                    owner, repo, name: 'Review claim gate', head_sha: pr.head.sha,
+                    status: 'completed', conclusion: 'success',
+                    output: { title: 'No active review claims', summary: 'Claims cleared by the sweep; merge unblocked.' },
+                  });
+                  core.info(`PR #${pr.number}: refreshed the Review claim gate check to success.`);
+                } catch (e) {
+                  core.warning(`PR #${pr.number}: gate check refresh skipped: ${e.message}`);
+                }
               }
             }
       - name: Workflow summary


### PR DESCRIPTION
## Summary
Closes the last gap in the review-claims automation: label removals performed with GITHUB_TOKEN do not retrigger workflows (GitHub recursion guard), so after the automation released a claim the `Review claim gate` check stayed red until an unrelated PR event.

## Changes
- `checks: write` permission added.
- After `release-claim` or the sweep removes claim labels and none remain, the job creates a fresh `Review claim gate` success check run on the PR head, unblocking merge immediately.
- Fork-context 403s are caught and logged; the trusted sweep covers those PRs.

actionlint verified locally (exit 0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the review-claims gate so PRs unblock immediately after automated claim release instead of staying red until the next unrelated PR event.

- Adds `checks: write` permission to the workflow.
- After the release-claim handler or the sweep removes the last claim label, it creates a successful `Review claim gate` check run on the PR head.
- Fork-context 403s are caught and logged; the hourly sweep still covers those PRs.

<sup>Written for commit c2ef4451feb31111060288ce1f2f20091d15f5e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

