### PR TITLE
fix(interactive): never swallow a quit request

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Fixed
 
+- `/quit` and `/exit` submitted while startup is still finishing (managed-tool downloads) now quit instead of being parked back in the editor behind a "Startup is still in progress" notice. Parking the text also disabled the Ctrl+D quit escape, which only fires on an empty editor, so the usual way out was a dead end until the line was cleared by hand.
+
+- An extension calling `ctx.shutdown()` while the session is idle now shuts down immediately instead of waiting for an `agent_settled` event that an idle session never emits, which previously stranded the request until the user happened to run another turn.
+
 - Interactive quit now keeps stderr capture installed while session shutdown handlers drain during runtime disposal, so shutdown-time diagnostics (for example memory drain warnings) are recorded in the debug log instead of printing raw beside the resume hint. The TUI still stops first to avoid final-frame repaints, and stderr is restored after disposal even when disposal fails.
 
 - Multi-session RPC hosts launched with `SENPI_RPC_CLIENT_CAPABILITIES` (for example `extension_events`) now apply those capabilities to connection-owned session bindings when the client never sends `set_client_info`. Previously the launch capabilities were advertised through `get_protocol_info` but dropped at binding creation, so undeclared clients received no `extension_event` frames (breaking downstream task/DAG/monitor liveness in omo-desktop-app). An explicit `set_client_info` declaration, including an empty capability list, still overrides the launch default.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,42 @@
 # changes
 
+## 2026-09-01 - Never swallow an interactive quit request
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: `handleStartupSubmit` now
+  treats `/quit` and `/exit` as control actions and calls `shutdown()` instead of parking the text
+  in the editor behind the "Startup is still in progress" notice. Every other submission keeps the
+  previous restore-and-notify behavior unchanged.
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: the extension-facing
+  `ctx.shutdown()` routes through a new `requestExtensionShutdown()` that records the request and
+  shuts down immediately when `session.isIdle`, matching the existing `shutdownHandler` rule.
+- `packages/coding-agent/test/interactive-mode-startup-input.test.ts`: coverage for quit and exit
+  during managed-tool setup, immediate versus deferred extension shutdown, and consumption of a
+  pending request at idle.
+
+### Why
+
+- Startup awaits `ensureTool("fd"/"rg")`, which downloads binaries on first run, so the startup
+  window is long enough to hit in practice. Submitting `/quit` there did nothing visible except
+  re-insert the text, and because `CustomEditor` only forwards Ctrl+D while the editor is EMPTY,
+  that re-inserted text also disabled the Ctrl+D quit escape — the user's natural quit sequence
+  became a dead end until they manually cleared the line.
+- `ctx.shutdown()` only set `shutdownRequested`, whose sole consumer is the `agent_settled` event.
+  An idle session emits no further settle event, so an extension asking to quit while idle was
+  stranded until the user happened to run another turn.
+
+### Why an extension could not handle it
+
+- Both paths are the interactive host's own input gate and shutdown bookkeeping: the startup submit
+  handler and the `shutdownRequested` flag live in `interactive-mode.ts`, and the swallowed request
+  is precisely the extension-facing API failing to reach them. No extension hook can repair the
+  handler that is meant to serve extensions.
+
+### Expected merge conflict zones
+
+- LOW: `handleStartupSubmit` and the extension command-context wiring in `interactive-mode.ts`.
+
 ## 2026-09-01 - Keep stderr hidden through interactive quit cleanup
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -2743,7 +2743,7 @@ export class InteractiveMode {
 			requestReload: () => this.handleReloadCommand(),
 			isCompacting: () => this.session.isCompacting,
 			shutdown: () => {
-				this.shutdownRequested = true;
+				this.requestExtensionShutdown();
 			},
 			getContextUsage: () => this.session.getContextUsage(),
 			getCompactionSettings: () => this.settingsManager.getCompactionSettings(),
@@ -4137,6 +4137,14 @@ export class InteractiveMode {
 	}
 
 	private handleStartupSubmit(text: string): void {
+		// Quit is a control action, not a prompt: honor it even while managed-tool setup
+		// is still running. Parking it in the editor would also disable the Ctrl+D quit
+		// escape, which CustomEditor only forwards while the editor is empty.
+		if (text.trim() === "/quit" || text.trim() === "/exit") {
+			this.editor.setText("");
+			void this.shutdown();
+			return;
+		}
 		this.editor.setText(text);
 		this.showStatus("Startup is still in progress");
 	}
@@ -5776,6 +5784,20 @@ export class InteractiveMode {
 		console.error(`${APP_NAME} exiting due to uncaughtException:`);
 		console.error(error);
 		process.exit(1);
+	}
+
+	/**
+	 * Record an extension shutdown request and honor it as soon as it is safe to do so.
+	 *
+	 * An idle session emits no further `agent_settled`, and that event is the only
+	 * consumer of the deferred flag, so an idle request must shut down here or it
+	 * strands until the user happens to run another turn.
+	 */
+	private requestExtensionShutdown(): void {
+		this.shutdownRequested = true;
+		if (this.session.isIdle) {
+			void this.shutdown();
+		}
 	}
 
 	/**

--- a/packages/coding-agent/test/interactive-mode-startup-input.test.ts
+++ b/packages/coding-agent/test/interactive-mode-startup-input.test.ts
@@ -47,6 +47,13 @@ type InputContext = {
 type StartupSubmitContext = {
 	editor: { setText: (text: string) => void };
 	showStatus: (message: string) => void;
+	shutdown?: () => Promise<void>;
+};
+
+type ExtensionShutdownContext = {
+	shutdownRequested: boolean;
+	session: { isIdle: boolean };
+	shutdown: () => Promise<void>;
 };
 
 type RunContext = {
@@ -80,6 +87,8 @@ type RunContext = {
 
 type InteractiveModePrivate = {
 	handleStartupSubmit(this: StartupSubmitContext, text: string): void;
+	requestExtensionShutdown(this: ExtensionShutdownContext): void;
+	checkShutdownRequested(this: ExtensionShutdownContext): Promise<void>;
 	setupEditorSubmitHandler(this: SubmitContext): void;
 	getUserInput(this: InputContext): Promise<{ text: string; images?: unknown[] }>;
 	takeSubmissionImages(this: SubmitContext, submittedText: string): unknown[];
@@ -131,6 +140,62 @@ describe("InteractiveMode startup input", () => {
 
 		expect(context.editor.setText).toHaveBeenCalledWith("early prompt");
 		expect(context.showStatus).toHaveBeenCalledWith("Startup is still in progress");
+	});
+
+	it.each(["/quit", "/exit"])("shuts down when %s is submitted while managed-tool setup is running", (command: string) => {
+		const context: StartupSubmitContext = {
+			editor: { setText: vi.fn() },
+			showStatus: vi.fn(),
+			shutdown: vi.fn(async () => {}),
+		};
+
+		interactiveModePrototype.handleStartupSubmit.call(context, command);
+
+		// The quit command is a control action, not a prompt: it must not be parked in
+		// the editor, because a non-empty editor also disables the Ctrl+D quit escape.
+		expect(context.shutdown).toHaveBeenCalledTimes(1);
+		expect(context.editor.setText).not.toHaveBeenCalledWith(command);
+		expect(context.showStatus).not.toHaveBeenCalledWith("Startup is still in progress");
+	});
+
+	it("honors an extension shutdown request immediately while the session is idle", () => {
+		const context: ExtensionShutdownContext = {
+			shutdownRequested: false,
+			session: { isIdle: true },
+			shutdown: vi.fn(async () => {}),
+		};
+
+		interactiveModePrototype.requestExtensionShutdown.call(context);
+
+		// An idle session emits no further agent_settled event, so a deferred request
+		// would strand until the user happened to run another turn.
+		expect(context.shutdownRequested).toBe(true);
+		expect(context.shutdown).toHaveBeenCalledTimes(1);
+	});
+
+	it("defers an extension shutdown request raised mid-turn", () => {
+		const context: ExtensionShutdownContext = {
+			shutdownRequested: false,
+			session: { isIdle: false },
+			shutdown: vi.fn(async () => {}),
+		};
+
+		interactiveModePrototype.requestExtensionShutdown.call(context);
+
+		expect(context.shutdownRequested).toBe(true);
+		expect(context.shutdown).not.toHaveBeenCalled();
+	});
+
+	it("consumes a pending shutdown request when the agent reaches idle", async () => {
+		const context: ExtensionShutdownContext = {
+			shutdownRequested: true,
+			session: { isIdle: true },
+			shutdown: vi.fn(async () => {}),
+		};
+
+		await interactiveModePrototype.checkShutdownRequested.call(context);
+
+		expect(context.shutdown).toHaveBeenCalledTimes(1);
 	});
 
 	it("queues a normal prompt submitted before the input callback is installed", async () => {


### PR DESCRIPTION
## Problem

Two ways an interactive quit request could be silently lost.

**1. `/quit` and `/exit` during startup were refused.** `handleStartupSubmit` treated them like a prompt: it re-inserted the text into the editor and showed "Startup is still in progress". Because `CustomEditor` only forwards Ctrl+D while the editor is EMPTY, that re-inserted text also disabled the Ctrl+D quit escape, so the natural sequence (type `/quit`, then Ctrl+D) became a dead end until the line was cleared by hand. The window is real: startup awaits `ensureTool("fd"/"rg")`, which downloads binaries on first run.

**2. `ctx.shutdown()` could strand forever.** It only set `shutdownRequested`, and the sole consumer of that flag is the `agent_settled` event. An idle session emits no further settle event, so an extension asking to quit while idle waited until the user happened to run another turn. The sibling `shutdownHandler` already had the idle-immediate branch; `ctx.shutdown()` did not.

## Design

- `handleStartupSubmit`: `/quit` and `/exit` clear the editor and call `shutdown()`. All other submissions keep the existing restore-and-notify behavior exactly.
- New `requestExtensionShutdown()`: records the request and shuts down immediately when `session.isIdle`, mirroring `shutdownHandler`. Mid-turn requests still defer to `agent_settled`.

Out of scope by design: Ctrl+D's empty-editor rule (upstream `CustomEditor` behavior) and startup duration itself. The invariant fixed here is that a quit request is never lost regardless of why startup is slow.

## Evidence

All runs on mengmotaMac via bunshin.

- **RED** (before implementation): `4 failed | 5 passed` — the four new cases failed for the intended reasons; the five pre-existing tests, including the unchanged-notice behavior, stayed green.
- **GREEN**: focused `9 passed (9)`; combined with the quit-stderr-guard regression `11 passed (11)`.
- **Typecheck**: pre-existing baseline only — identical counts on the untouched base and the changed tree (1179 total errors, 44 in `interactive-mode.ts`), and zero errors referencing `requestExtensionShutdown` or `handleStartupSubmit`. The baseline is this checkout's unresolved `@earendil-works/pi-*` dependencies.

Follow-up to #1251, which fixed where quit-time drain output goes; this one fixes whether the quit happens at all.
