### PR TITLE
fix(coding-agent): handle unusable model budget at startup

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,38 @@
 # changes
 
+## 2026-09-01 - Fail closed on an unusable model budget at startup
+
+### What changed
+
+- `packages/coding-agent/src/main.ts` wraps the `createAgentSessionRuntime` call with a try/catch that
+  specifically catches `ModelUsabilityBudgetError`, printing the error's own actionable message
+  (`chalk.red`) and exiting with `process.exit(1)` instead of letting the error escape uncaught.
+
+### Why
+
+- `AgentSession.assertModelUsable` (via `createAgentSession` in `sdk.ts`) throws
+  `ModelUsabilityBudgetError` when the selected model's context window cannot hold the assembled
+  session budget (live context + system prompt + tool schemas + output/compaction/speculation
+  reserves + safety margin) — most commonly hit when resuming a large existing session with a model
+  whose context window is too small. Nothing between that throw site and the top-level `await main()`
+  call in `cli-main.ts` ever catches it, so the error reaches Node as an uncaught exception: a raw
+  stack trace plus the `Node.js vX.Y.Z` crash banner, and the process exits without ever reaching the
+  point where the TUI, RPC transport, or any other surface could render a normal error state. The
+  thrown error's own message is already fully actionable (it names the exact shortfall and suggests
+  compacting the session and retrying), so the fix only needed to stop it from being silently dropped
+  before that message could reach the user.
+
+### Why an extension could not handle it
+
+- The throw happens inside `createAgentSessionRuntime`, which runs before any extension host exists;
+  by the time an extension could observe the failure, the process has already crashed.
+
+### Expected merge conflict zones
+
+- LOW: the `createAgentSessionRuntime` call site and its surrounding `time("createAgentSessionRuntime")`
+  call in `main.ts`; this block has changed at least once before (see the 2026-08-30 entry above) so a
+  future upstream sync may touch the same lines again.
+
 ## 2026-09-01 - Negotiate RPC session auto-titling
 
 ### What changed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -53,6 +53,7 @@ import { AuthStorage, ReadOnlyAuthStorage } from "./core/auth-storage.ts";
 import { envValue } from "./core/brand.ts";
 import { type CredentialAccountSummary, summarizeCredentialAccounts } from "./core/credential-accounts.ts";
 import { exportFromFile } from "./core/export-html/index.ts";
+import { ModelUsabilityBudgetError } from "./core/extensions/builtin/compaction/model-usability-budget.ts";
 import type { InlineExtension } from "./core/extensions/types.ts";
 import { applyHttpProxySettings, configureHttpDispatcher } from "./core/http-dispatcher.ts";
 import {
@@ -1113,13 +1114,20 @@ export async function main(args: string[], options?: MainOptions) {
 			listen: parsed.listen,
 		});
 	}
-	const runtime = await createAgentSessionRuntime(createRuntime, {
-		cwd: sessionManager.getCwd(),
-		agentDir,
-		sessionManager,
-	}).finally(() => {
-		startupLoadingIndicator.stop();
-	});
+	let runtime: Awaited<ReturnType<typeof createAgentSessionRuntime>>;
+	try {
+		runtime = await createAgentSessionRuntime(createRuntime, {
+			cwd: sessionManager.getCwd(),
+			agentDir,
+			sessionManager,
+		}).finally(() => {
+			startupLoadingIndicator.stop();
+		});
+	} catch (error) {
+		if (!(error instanceof ModelUsabilityBudgetError)) throw error;
+		console.error(chalk.red(`Error: ${error.message}`));
+		process.exit(1);
+	}
 	time("createAgentSessionRuntime");
 	let selectedRuntime = runtime;
 	if (isTruthyEnvFlag(envValue("DISABLE_SHARED_HOST"))) {

--- a/packages/coding-agent/test/suite/regressions/model-usability-budget-startup-crash.test.ts
+++ b/packages/coding-agent/test/suite/regressions/model-usability-budget-startup-crash.test.ts
@@ -1,0 +1,223 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENV_AGENT_DIR } from "../../../src/config.ts";
+import { assertWorkspaceBuildPrerequisite } from "../../support/workspace-build-prerequisite.ts";
+
+assertWorkspaceBuildPrerequisite(import.meta.url);
+
+/**
+ * Regression: an unusable model budget at session-creation time must never
+ * escape as an uncaught exception.
+ *
+ * `AgentSession.assertModelUsable` throws `ModelUsabilityBudgetError` when
+ * the selected model's context window cannot hold the assembled session
+ * budget (live context + system prompt + tool schemas + reserves + safety
+ * margin) - the common trigger is resuming a large existing session with a
+ * model whose context window is too small for it. Before this fix, nothing
+ * between that throw site (`sdk.ts`, via `createAgentSessionRuntime` in
+ * `main.ts`) and the top-level `await main()` call caught it, so the error
+ * reached Node as an uncaught exception: a raw stack trace plus the
+ * `Node.js vX.Y.Z` crash banner, and the process died before any surface
+ * (TUI, RPC, print mode) could render a normal error state.
+ */
+
+const cliPath = resolve(__dirname, "../../../src/cli.ts");
+const SESSION_ID = "0197f6e4-4cf9-7f44-a2d8-f8f7f49ee9d4";
+const TINY_MODEL_CONTEXT_WINDOW = 16_000;
+const CHILD_TIMEOUT_MS = 20_000;
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*[A-Za-z]`, "g");
+
+interface CliFixture {
+	agentDir: string;
+	projectDir: string;
+	sessionDir: string;
+}
+
+interface CliResult {
+	code: number | null;
+	output: string;
+	timedOut: boolean;
+}
+
+const tempDirs: string[] = [];
+const liveChildren = new Set<ChildProcess>();
+
+function killChild(child: ChildProcess): void {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	const pid = child.pid;
+	if (pid === undefined) return;
+	try {
+		child.kill("SIGKILL");
+	} catch {
+		// Already gone.
+	}
+}
+
+afterEach(() => {
+	for (const child of liveChildren) killChild(child);
+	liveChildren.clear();
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function createFixture(): CliFixture {
+	// realpath: on macOS tmpdir() is a symlink (/var -> /private/var) while the
+	// spawned CLI sees the physical path via process.cwd(). Session cwd filtering
+	// compares paths textually, so the fixture must use physical paths.
+	const tempRoot = realpathSync(mkdtempSync(join(tmpdir(), "pi-model-usability-budget-crash-")));
+	tempDirs.push(tempRoot);
+	const fixture: CliFixture = {
+		agentDir: join(tempRoot, "agent"),
+		projectDir: join(tempRoot, "project"),
+		sessionDir: join(tempRoot, "sessions"),
+	};
+	for (const dir of [fixture.agentDir, fixture.projectDir, fixture.sessionDir]) {
+		mkdirSync(dir, { recursive: true });
+	}
+
+	// A custom provider whose only model has a context window far smaller than
+	// what the fixture session below will require, so session creation rejects
+	// the budget instead of silently accepting it.
+	writeFileSync(
+		join(fixture.agentDir, "models.json"),
+		`${JSON.stringify({
+			providers: {
+				"faux-tiny": {
+					baseUrl: "https://example.test/v1",
+					api: "openai-completions",
+					apiKey: "test-key",
+					models: [{ id: "tiny-ctx", contextWindow: TINY_MODEL_CONTEXT_WINDOW, maxTokens: 4_000 }],
+				},
+			},
+		})}\n`.replace("TINY_MODEL_CONTEXT_WINDOW", String(TINY_MODEL_CONTEXT_WINDOW)),
+	);
+
+	// A persisted session whose live context alone (~40k tokens of prior usage)
+	// already exceeds the tiny model's 16k context window once the fixed system
+	// prompt / tool schema / reserve overhead is added on top.
+	const sessionLines = [
+		JSON.stringify({
+			type: "session",
+			version: 3,
+			id: SESSION_ID,
+			timestamp: "2026-08-07T00:00:00.000Z",
+			cwd: fixture.projectDir,
+		}),
+		JSON.stringify({
+			type: "message",
+			id: "m1",
+			parentId: null,
+			timestamp: "2026-08-07T00:00:01.000Z",
+			message: { role: "user", content: [{ type: "text", text: "hello" }], timestamp: 1 },
+		}),
+		JSON.stringify({
+			type: "message",
+			id: "m2",
+			parentId: "m1",
+			timestamp: "2026-08-07T00:00:02.000Z",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "hi there" }],
+				api: "openai-completions",
+				provider: "faux-tiny",
+				model: "tiny-ctx",
+				stopReason: "stop",
+				usage: {
+					input: 40_000,
+					output: 1_000,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 41_000,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: 2,
+			},
+		}),
+	];
+	writeFileSync(join(fixture.sessionDir, `${SESSION_ID}.jsonl`), `${sessionLines.join("\n")}\n`);
+
+	return fixture;
+}
+
+function stripAnsi(value: string): string {
+	return value.replace(ANSI_PATTERN, "");
+}
+
+async function runCli(args: string[], fixture: CliFixture): Promise<CliResult> {
+	const child = spawn(process.execPath, args, {
+		cwd: fixture.projectDir,
+		env: {
+			...process.env,
+			[ENV_AGENT_DIR]: fixture.agentDir,
+			PI_OFFLINE: "1",
+		},
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	liveChildren.add(child);
+
+	let captured = "";
+	child.stdout?.on("data", (chunk: Buffer) => {
+		captured += chunk.toString();
+	});
+	child.stderr?.on("data", (chunk: Buffer) => {
+		captured += chunk.toString();
+	});
+
+	let timedOut = false;
+	const timeout = setTimeout(() => {
+		timedOut = true;
+		killChild(child);
+	}, CHILD_TIMEOUT_MS);
+
+	try {
+		const code = await new Promise<number | null>((resolveExit, rejectSpawn) => {
+			child.on("error", rejectSpawn);
+			child.on("close", (exitCode) => resolveExit(exitCode));
+		});
+		return { code, output: stripAnsi(captured), timedOut };
+	} finally {
+		clearTimeout(timeout);
+		killChild(child);
+		liveChildren.delete(child);
+	}
+}
+
+describe("model usability budget rejection at startup", () => {
+	it("fails closed with the budget error message instead of an uncaught crash", async () => {
+		const fixture = createFixture();
+
+		const result = await runCli(
+			[
+				cliPath,
+				"--session-dir",
+				fixture.sessionDir,
+				"--session",
+				SESSION_ID,
+				"--provider",
+				"faux-tiny",
+				"--model",
+				"tiny-ctx",
+				"-p",
+				"continue",
+			],
+			fixture,
+		);
+
+		expect(result.timedOut).toBe(false);
+		// The error is a clean, handled exit(1) - not the default 1 Node also uses
+		// for an uncaught exception - so this alone would not distinguish the two;
+		// the crash-signature assertions below are what pin the actual regression.
+		expect(result.code).toBe(1);
+		expect(result.output).toContain("cannot switch: target context window 16000 tokens");
+		expect(result.output).toContain("Compact the session, then revalidate and retry the model switch.");
+		// Before the fix, the error escaped as an uncaught exception: this asserts
+		// none of that crash signature is present in the handled output.
+		expect(result.output).not.toContain("Node.js v");
+		expect(result.output).not.toContain("at AgentSession.assertModelUsable");
+		expect(result.output).not.toContain("at createAgentSession");
+	});
+});


### PR DESCRIPTION
## Problem Situation
Resuming a session whose context cannot fit the selected model's usable budget throws ModelUsabilityBudgetError during createAgentSessionRuntime. Because the startup path has no handler around that call, the error reaches the top-level await main() as an uncaught exception. A real 3881-message OmO session reproduced this as a raw stack trace, Node.js v24.18.0 banner, and immediate process exit before the TUI could render a useful error.

## Reproduction Logs
Fresh source reproduction: node --import tsx packages/coding-agent/src/cli.ts --session-dir /tmp/senpi-repro/sessions --session 0197f6e4-4cf9-7f44-a2d8-f8f7f49ee9d4 --provider faux-tiny --model tiny-ctx -p continue, using a 16000-token model fixture and an oversized persisted session. Before the fix it emitted ModelUsabilityBudgetError with the full stack through main.ts:1116, sdk.ts:522, and agent-session.ts:4552, followed by Node.js v24.18.0. The same failure was reproduced against the user's real 3881-message session with omo-ai beta.31.

## Approach
Import the existing ModelUsabilityBudgetError type and wrap only the createAgentSessionRuntime startup call in main.ts. The handler prints the error's existing actionable message with the established chalk.red Error: prefix and exits with status 1. Other errors are rethrown unchanged. Add the required src/changes.md entry and a real CLI subprocess regression test that asserts the crash signature is absent.

## Why I Am Confident
The failing path was reproduced in a fresh clone at the exact source call chain, then the identical command passed after the change with one clean error line, exit 1, no stack trace, and no Node.js crash banner. A mutation proof reverted main.ts to the pre-fix version and made the new test fail on the exact uncaught stack trace; restoring the fix made it pass. Built dist/cli.js was also driven directly and showed the same clean behavior.

## Risks
Low. The change only catches the specific typed startup budget error at the existing CLI boundary; unrelated exceptions retain the prior behavior. Models with sufficient context continue through normal startup. The test uses a bounded child-process timeout and cleans its isolated fixture directory.

## User-Visible Behavior Changes
When a session is too large for the selected model, senpi now exits orderly with the precise shortfall and the existing compact/revalidate/retry guidance instead of terminating with an uncaught exception and raw Node.js stack trace. Successful sessions and other startup errors are unchanged.

## Verification
- RED mutation proof: with the startup catch removed, the regression test failed because output contained the exact uncaught ModelUsabilityBudgetError stack and Node.js v24.18.0 banner.
- GREEN focused suite: 4 test files passed, 19/19 tests passed, including the new startup-crash regression and all existing model-usability tests.
- bun run check components passed: Biome checked 3459 files with no fixes, pinned-deps, TS-import, shrinkwrap, install-lock, Claude SDK platform lock, and tsc --noEmit were clean; browser smoke exited 0.
- Built CLI manual QA: bun run build succeeded; dist/cli.js with the oversized session exited 1 with one clean Error line and zero Node.js/stack-signature matches; --help exited 0; a roomy model passed session creation and --list-tips exited 0.

---
This PR was debugged, implemented, and created with [LazyCodex](https://github.com/code-yeongyu/lazycodex).
Tag: lazycodex-generated


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash when resuming a session too large for the selected model's context window. Previously `ModelUsabilityBudgetError` escaped as an uncaught exception, printing a raw stack trace and Node.js crash banner before exiting; now the CLI prints the error's actionable message and exits with status 1.

- Catches only `ModelUsabilityBudgetError` around the `createAgentSessionRuntime` startup call in `main.ts`; all other errors are rethrown unchanged.
- Adds a regression test that spawns the real CLI with an oversized persisted session and a tiny-context model provider, asserting the crash signature does not appear.
- Adds a `changes.md` entry describing the fix.

<sup>Written for commit a191a5654364e5c3949025a5e92901f437871deb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

