### PR TITLE
fix(coding-agent): request low reasoning for session title generation

### DIFF
--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-02 - Session title requests ask for low reasoning
+
+### What changed
+
+- `session-title-generator.ts`: `buildTitleOptions()` now sets `reasoning: "low"` and raises the title request's `maxTokens` from 64 to 1024.
+
+### Why
+
+- Leaving `reasoning` unset on the title request makes token-based providers fall back to their "disabled" mapping (e.g. `reasoning: { effort: "none" }` on OpenRouter-format models). Reasoning-mandatory endpoints such as Z.ai GLM 5.x reject that with HTTP 400 `Reasoning is mandatory for this endpoint and cannot be disabled.`, which surfaced as a repeated `session_title_generation` runtime error in every session on those models (agent turns were unaffected because they always carry the session's thinking level). Low reasoning keeps the cosmetic title cheap while producing a request every endpoint accepts; non-reasoning models ignore the hint via level clamping. The larger `maxTokens` keeps room for the `<title>` output once reasoning tokens count against the completion budget.
+
+### Why an extension could not handle it
+
+- Title generation is core background work invoked from `agent-session.ts`; extensions cannot alter the request options of the internal title call.
+
+### Expected merge conflict zones
+
+- LOW: the `buildTitleOptions()` literal in `session-title-generator.ts` and the new `generateSessionTitle` describe block in `test/session-title-generator.test.ts`.
+
 ## 2026-08-31 - Session activity contract for host occupancy decisions
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,22 +1,23 @@
 # changes
 
-## 2026-09-02 - Session title requests ask for low reasoning
+## 2026-09-02 - Session titles fall back to low reasoning on reasoning-mandatory endpoints
 
 ### What changed
 
-- `session-title-generator.ts`: `buildTitleOptions()` now sets `reasoning: "low"` and raises the title request's `maxTokens` from 64 to 1024.
+- `session-title-generator.ts`: `generateSessionTitle()` keeps the default title request reasoning-free; when the provider returns an error matching "Reasoning is mandatory" it retries once with `reasoning: "low"` and `maxTokens: 1024`. `buildTitleOptions()` takes an optional reasoning level that enables both.
 
 ### Why
 
-- Leaving `reasoning` unset on the title request makes token-based providers fall back to their "disabled" mapping (e.g. `reasoning: { effort: "none" }` on OpenRouter-format models). Reasoning-mandatory endpoints such as Z.ai GLM 5.x reject that with HTTP 400 `Reasoning is mandatory for this endpoint and cannot be disabled.`, which surfaced as a repeated `session_title_generation` runtime error in every session on those models (agent turns were unaffected because they always carry the session's thinking level). Low reasoning keeps the cosmetic title cheap while producing a request every endpoint accepts; non-reasoning models ignore the hint via level clamping. The larger `maxTokens` keeps room for the `<title>` output once reasoning tokens count against the completion budget.
+- Leaving `reasoning` unset makes token-based providers fall back to their "disabled" mapping (e.g. `reasoning: { effort: "none" }` on OpenRouter-format models), which reasoning-mandatory endpoints such as Z.ai GLM 5.x reject with HTTP 400 `Reasoning is mandatory for this endpoint and cannot be disabled.` — surfacing as a repeated `session_title_generation` runtime error in every session on those models (agent turns were unaffected because they always carry the session's thinking level).
+- Forcing `reasoning: "low"` on every title call instead would tax all reasoning-capable models on a cosmetic background call, and some catalogs map `low` to full effort (e.g. DeepSeek `low` -> `"high"` in `openai-completions.ts`). Matching on the specific 400 keeps the zero-reasoning path for every healthy endpoint and pays reasoning only where the endpoint demands it; the `maxTokens` bump leaves room for the `<title>` output once reasoning tokens count against the completion budget.
 
 ### Why an extension could not handle it
 
-- Title generation is core background work invoked from `agent-session.ts`; extensions cannot alter the request options of the internal title call.
+- Title generation is core background work invoked from `agent-session.ts`; extensions cannot alter the request options or the retry behavior of the internal title call.
 
 ### Expected merge conflict zones
 
-- LOW: the `buildTitleOptions()` literal in `session-title-generator.ts` and the new `generateSessionTitle` describe block in `test/session-title-generator.test.ts`.
+- LOW: the `generateSessionTitle()` retry block and `buildTitleOptions()` signature in `session-title-generator.ts`, and the `generateSessionTitle` describe block in `test/session-title-generator.test.ts`.
 
 ## 2026-08-31 - Session activity contract for host occupancy decisions
 

--- a/packages/coding-agent/src/core/session-title-generator.ts
+++ b/packages/coding-agent/src/core/session-title-generator.ts
@@ -88,7 +88,12 @@ export async function generateSessionTitle(options: GenerateSessionTitleOptions)
 	// Titles are cosmetic background work: honor the caller's retry policy so a
 	// single transient provider error (e.g. a 529 overloaded stream) does not
 	// surface as a scary runtime error. Mirrors completeSummarization().
-	const response = await retryAssistantCall(
+	// Reasoning-mandatory endpoints (e.g. Z.ai GLM 5.x via OpenRouter) reject the
+	// reasoning-disabled mapping pi-ai sends when `reasoning` is unset with HTTP
+	// 400 "Reasoning is mandatory for this endpoint and cannot be disabled.";
+	// retry those once with low reasoning instead of paying reasoning cost on
+	// every title call for every provider.
+	let response = await retryAssistantCall(
 		() =>
 			completeTitle(
 				options.model,
@@ -99,10 +104,29 @@ export async function generateSessionTitle(options: GenerateSessionTitleOptions)
 		options.retry,
 		options.signal,
 	);
+	if (response.stopReason === "error" && isReasoningMandatoryError(response.errorMessage)) {
+		response = await retryAssistantCall(
+			() =>
+				completeTitle(
+					options.model,
+					buildTitleContext(options.firstPrompt),
+					buildTitleOptions(options, "low"),
+					options.streamFn,
+				),
+			options.retry,
+			options.signal,
+		);
+	}
 	if (response.stopReason === "error") {
 		throw new Error(humanizeProviderError(response.errorMessage ?? "Session title generation failed"));
 	}
 	return parseSessionTitle(response);
+}
+
+const REASONING_MANDATORY_PATTERN = /reasoning is mandatory/i;
+
+function isReasoningMandatoryError(errorMessage: string | undefined): boolean {
+	return errorMessage !== undefined && REASONING_MANDATORY_PATTERN.test(errorMessage);
 }
 
 function buildTitleContext(firstPrompt: string): Context {
@@ -118,22 +142,24 @@ function buildTitleContext(firstPrompt: string): Context {
 	};
 }
 
-function buildTitleOptions(options: GenerateSessionTitleOptions): SimpleStreamOptions {
+function buildTitleOptions(
+	options: GenerateSessionTitleOptions,
+	reasoning?: SimpleStreamOptions["reasoning"],
+): SimpleStreamOptions {
 	const titleOptions: SimpleStreamOptions = {
 		...options.baseOptions,
 		sessionId: options.sessionId,
 		cacheRetention: options.model.cacheRetention === "none" ? "none" : "short",
-		// Titles are cosmetic background work, but leaving `reasoning` unset makes
-		// reasoning-capable models fall back to the provider's "disabled" mapping
-		// (e.g. `reasoning: { effort: "none" }` on OpenRouter), which
-		// reasoning-mandatory endpoints (e.g. Z.ai GLM 5.x) reject with HTTP 400
-		// "Reasoning is mandatory for this endpoint and cannot be disabled.".
-		// Ask for low reasoning explicitly instead; non-reasoning models ignore it.
-		reasoning: "low",
-		// Low reasoning consumes part of the completion budget on token-based
-		// providers, so keep room for the actual `<title>` output.
-		maxTokens: 1024,
+		maxTokens: 64,
 	};
+	if (reasoning !== undefined) {
+		// Fallback for reasoning-mandatory endpoints: low reasoning keeps the
+		// cosmetic title cheap, and the larger maxTokens leaves room for the
+		// `<title>` output once reasoning tokens count against the completion
+		// budget. Callers that never see the 400 keep the cheap default above.
+		titleOptions.reasoning = reasoning;
+		titleOptions.maxTokens = 1024;
+	}
 	if (options.auth.apiKey !== undefined) {
 		titleOptions.apiKey = options.auth.apiKey;
 	}

--- a/packages/coding-agent/src/core/session-title-generator.ts
+++ b/packages/coding-agent/src/core/session-title-generator.ts
@@ -123,7 +123,16 @@ function buildTitleOptions(options: GenerateSessionTitleOptions): SimpleStreamOp
 		...options.baseOptions,
 		sessionId: options.sessionId,
 		cacheRetention: options.model.cacheRetention === "none" ? "none" : "short",
-		maxTokens: 64,
+		// Titles are cosmetic background work, but leaving `reasoning` unset makes
+		// reasoning-capable models fall back to the provider's "disabled" mapping
+		// (e.g. `reasoning: { effort: "none" }` on OpenRouter), which
+		// reasoning-mandatory endpoints (e.g. Z.ai GLM 5.x) reject with HTTP 400
+		// "Reasoning is mandatory for this endpoint and cannot be disabled.".
+		// Ask for low reasoning explicitly instead; non-reasoning models ignore it.
+		reasoning: "low",
+		// Low reasoning consumes part of the completion budget on token-based
+		// providers, so keep room for the actual `<title>` output.
+		maxTokens: 1024,
 	};
 	if (options.auth.apiKey !== undefined) {
 		titleOptions.apiKey = options.auth.apiKey;

--- a/packages/coding-agent/test/session-title-generator.test.ts
+++ b/packages/coding-agent/test/session-title-generator.test.ts
@@ -20,30 +20,39 @@ const TITLE_MODEL = {
 	baseUrl: "https://openrouter.ai/api/v1",
 } as unknown as Model<Api>;
 
-function fakeTitleStream(text: string): {
+function fakeTitleStream(responses: AssistantMessage[]): {
 	streamFn: NonNullable<Parameters<typeof generateSessionTitle>[0]["streamFn"]>;
-	capturedOptions: () => SimpleStreamOptions | undefined;
+	capturedOptions: () => (SimpleStreamOptions | undefined)[];
 } {
-	let captured: SimpleStreamOptions | undefined;
-	const message = {
-		role: "assistant",
-		content: [{ type: "text", text }],
-		api: "openai-completions",
-		provider: "openrouter",
-		model: "z-ai/glm-5.3-flash",
-		usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
-		stopReason: "stop",
-	} as unknown as AssistantMessage;
+	const captured: (SimpleStreamOptions | undefined)[] = [];
 	const streamFn = ((_model: unknown, _context: unknown, options: SimpleStreamOptions | undefined) => {
-		captured = options;
+		captured.push(options);
+		const message = responses[Math.min(captured.length - 1, responses.length - 1)];
 		return { result: async () => message } as unknown as AssistantMessageEventStream;
 	}) as NonNullable<Parameters<typeof generateSessionTitle>[0]["streamFn"]>;
 	return { streamFn, capturedOptions: () => captured };
 }
 
+const OK_TITLE = {
+	role: "assistant",
+	content: [{ type: "text", text: "<title>Fix Login Bug</title>" }],
+	api: "openai-completions",
+	provider: "openrouter",
+	model: "z-ai/glm-5.3-flash",
+	usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+	stopReason: "stop",
+} as unknown as AssistantMessage;
+
+const REASONING_MANDATORY_ERROR = {
+	...OK_TITLE,
+	content: [],
+	stopReason: "error",
+	errorMessage: '400: {"error":{"message":"Reasoning is mandatory for this endpoint and cannot be disabled."}}',
+} as unknown as AssistantMessage;
+
 describe("generateSessionTitle", () => {
-	it("requests low reasoning so reasoning-mandatory endpoints do not reject the title call", async () => {
-		const { streamFn, capturedOptions } = fakeTitleStream("<title>Fix Login Bug</title>");
+	it("keeps the default title request reasoning-free so healthy endpoints pay nothing", async () => {
+		const { streamFn, capturedOptions } = fakeTitleStream([OK_TITLE]);
 		const title = await generateSessionTitle({
 			firstPrompt: "Fix the login bug in the auth service",
 			model: TITLE_MODEL,
@@ -53,11 +62,51 @@ describe("generateSessionTitle", () => {
 			retry: { enabled: false, maxRetries: 0, baseDelayMs: 0 },
 		});
 		expect(title).toBe("Fix Login Bug");
-		const options = capturedOptions();
-		// Unset reasoning makes pi-ai send `reasoning: { effort: "none" }` on
-		// OpenRouter, which reasoning-mandatory endpoints reject with HTTP 400.
-		expect(options?.reasoning).toBe("low");
-		expect(options?.maxTokens).toBe(1024);
+		const attempts = capturedOptions();
+		expect(attempts).toHaveLength(1);
+		// Forcing a reasoning level would enable thinking on every title call;
+		// some catalogs even map `low` to full effort (e.g. DeepSeek low -> "high").
+		expect(attempts[0]?.reasoning).toBeUndefined();
+		expect(attempts[0]?.maxTokens).toBe(64);
+	});
+
+	it("retries once with low reasoning when the endpoint mandates reasoning", async () => {
+		const { streamFn, capturedOptions } = fakeTitleStream([REASONING_MANDATORY_ERROR, OK_TITLE]);
+		const title = await generateSessionTitle({
+			firstPrompt: "Fix the login bug in the auth service",
+			model: TITLE_MODEL,
+			auth: {},
+			sessionId: "test-session",
+			streamFn,
+			retry: { enabled: false, maxRetries: 0, baseDelayMs: 0 },
+		});
+		expect(title).toBe("Fix Login Bug");
+		const attempts = capturedOptions();
+		expect(attempts).toHaveLength(2);
+		expect(attempts[0]?.reasoning).toBeUndefined();
+		expect(attempts[1]?.reasoning).toBe("low");
+		// Reasoning tokens count against the completion budget, so the fallback
+		// attempt needs headroom for the `<title>` output.
+		expect(attempts[1]?.maxTokens).toBe(1024);
+	});
+
+	it("does not retry other provider errors with reasoning", async () => {
+		const overloaded = {
+			...REASONING_MANDATORY_ERROR,
+			errorMessage: '529: {"error":{"message":"Overloaded"}}',
+		} as unknown as AssistantMessage;
+		const { streamFn, capturedOptions } = fakeTitleStream([overloaded, OK_TITLE]);
+		await expect(
+			generateSessionTitle({
+				firstPrompt: "Fix the login bug in the auth service",
+				model: TITLE_MODEL,
+				auth: {},
+				sessionId: "test-session",
+				streamFn,
+				retry: { enabled: false, maxRetries: 0, baseDelayMs: 0 },
+			}),
+		).rejects.toThrow("Overloaded (HTTP 529)");
+		expect(capturedOptions()).toHaveLength(1);
 	});
 });
 

--- a/packages/coding-agent/test/session-title-generator.test.ts
+++ b/packages/coding-agent/test/session-title-generator.test.ts
@@ -1,5 +1,65 @@
+import type {
+	Api,
+	AssistantMessage,
+	AssistantMessageEventStream,
+	Model,
+	SimpleStreamOptions,
+} from "@earendil-works/pi-ai/compat";
 import { describe, expect, it } from "vitest";
-import { humanizeProviderError, sessionTitleRetryPolicy } from "../src/core/session-title-generator.ts";
+import {
+	generateSessionTitle,
+	humanizeProviderError,
+	sessionTitleRetryPolicy,
+} from "../src/core/session-title-generator.ts";
+
+const TITLE_MODEL = {
+	api: "openai-completions",
+	provider: "openrouter",
+	id: "z-ai/glm-5.3-flash",
+	reasoning: true,
+	baseUrl: "https://openrouter.ai/api/v1",
+} as unknown as Model<Api>;
+
+function fakeTitleStream(text: string): {
+	streamFn: NonNullable<Parameters<typeof generateSessionTitle>[0]["streamFn"]>;
+	capturedOptions: () => SimpleStreamOptions | undefined;
+} {
+	let captured: SimpleStreamOptions | undefined;
+	const message = {
+		role: "assistant",
+		content: [{ type: "text", text }],
+		api: "openai-completions",
+		provider: "openrouter",
+		model: "z-ai/glm-5.3-flash",
+		usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+		stopReason: "stop",
+	} as unknown as AssistantMessage;
+	const streamFn = ((_model: unknown, _context: unknown, options: SimpleStreamOptions | undefined) => {
+		captured = options;
+		return { result: async () => message } as unknown as AssistantMessageEventStream;
+	}) as NonNullable<Parameters<typeof generateSessionTitle>[0]["streamFn"]>;
+	return { streamFn, capturedOptions: () => captured };
+}
+
+describe("generateSessionTitle", () => {
+	it("requests low reasoning so reasoning-mandatory endpoints do not reject the title call", async () => {
+		const { streamFn, capturedOptions } = fakeTitleStream("<title>Fix Login Bug</title>");
+		const title = await generateSessionTitle({
+			firstPrompt: "Fix the login bug in the auth service",
+			model: TITLE_MODEL,
+			auth: {},
+			sessionId: "test-session",
+			streamFn,
+			retry: { enabled: false, maxRetries: 0, baseDelayMs: 0 },
+		});
+		expect(title).toBe("Fix Login Bug");
+		const options = capturedOptions();
+		// Unset reasoning makes pi-ai send `reasoning: { effort: "none" }` on
+		// OpenRouter, which reasoning-mandatory endpoints reject with HTTP 400.
+		expect(options?.reasoning).toBe("low");
+		expect(options?.maxTokens).toBe(1024);
+	});
+});
 
 describe("sessionTitleRetryPolicy", () => {
 	it("caps the cosmetic title retry below the full agent-turn budget", () => {


### PR DESCRIPTION
## Summary

The background session-title request left `reasoning` unset in `buildTitleOptions()`. For reasoning-capable models, pi-ai's OpenAI-completions layer then fills the gap with the provider's "disabled" mapping — on OpenRouter-format models that is `reasoning: { effort: "none" }`. Endpoints that mandate reasoning (observed with Z.ai GLM 5.x models, e.g. `z-ai/glm-5.3-flash`) reject that with:

```
Runtime error (session_title_generation): Reasoning is mandatory for this endpoint and cannot be disabled. (HTTP 400)
```

Regular agent turns are unaffected because they always carry the session's thinking level — only the background title call (and therefore every fresh session on such a model) failed. The same behavior is publicly documented against OpenRouter in openclaw#24851.

## What changed

- `packages/coding-agent/src/core/session-title-generator.ts` — `buildTitleOptions()` now sends `reasoning: "low"` explicitly, and raises `maxTokens` from 64 to 1024 so low-effort reasoning tokens don't consume the budget needed for the `<title>` output on token-based providers.
- `packages/coding-agent/test/session-title-generator.test.ts` — deterministic regression test asserting the title request carries `reasoning: "low"` and `maxTokens: 1024` via a fake `streamFn` (no network, no tokens).
- `packages/coding-agent/src/core/changes.md` — fork-ledger entry per the changes.md contract.

Non-reasoning models are unaffected: pi-ai clamps the level per model and the OpenRouter reasoning branch only fires for `model.reasoning === true`.

## Validation

- `bunx vitest run test/session-title-generator.test.ts` — 12/12 pass (including the new regression test).
- Root `bun run check` — pass (Biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk-platform-lock, `tsc --noEmit`, browser-smoke).
- Manually verified against a local install of `omo` 5.0.0-0.beta.31 / senpi 2026.8.31: patching `buildTitleOptions` the same way eliminated the recurring `session_title_generation` 400 on OpenRouter `z-ai/glm-5.3-flash` sessions.

## Residual risk

- Titles on reasoning-capable models now include a small amount of reasoning output, marginally increasing cost per one-shot title call (bounded by `maxTokens: 1024`). An alternative would be retrying with a low effort only when the endpoint rejects disabled reasoning, but the simple explicit level avoids a second round trip for a known-broken class of endpoints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session title generation on reasoning-mandatory endpoints by retrying once with low reasoning when the provider rejects the default reasoning-free title request, so new sessions on models like Z.ai GLM 5.x no longer fail with a 400 error.

- Default title requests stay reasoning-free with `maxTokens: 64`, so healthy endpoints pay no reasoning cost.
- Only a "Reasoning is mandatory" 400 triggers the retry with `reasoning: "low"` and `maxTokens: 1024`, leaving room for the `<title>` output once reasoning tokens count against the budget.
- Adds regression tests covering the default path, the fallback retry, and non-matching errors (no retry).

<sup>Written for commit 94960bae6137a8d7537847b518e6ee8e76468bfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

