### PR TITLE
feat(prompt-preset): Mythos routing + Fable 5.1 preset diet

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Claude Mythos 5 and Mythos 5.1 model ids now route to the matching Claude Fable prompt presets (Anthropic ships one prompting guide per Fable/Mythos release pair), instead of falling back to the default dynamic prompt.
+
+### Changed
+
+- The `claude-fable-5-1` prompt preset was dieted per the full Anthropic guide set: duplicated scope/stop/evidence rules are stated once (scope now has its own section), model-default style traits are removed, and the Fable 5 delegation guidance plus the 5.1 ask-after-independent-work clause are added. The rendered static core shrinks about 16%.
+
 ### Fixed
 
 ### New Features

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,25 @@
 # prompt-preset Extension Changes
 
+## Mythos routing + Fable 5.1 preset diet (2026-09-02)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts`: `CLAUDE_FABLE_51_MARKERS`/`CLAUDE_FABLE_5_MARKERS` gain `mythos-5-1`/`mythos-5.1` and `mythos-5`, so Claude Mythos ids resolve to the matching Fable preset; the 5.1 marker set still resolves before the generic 5 set.
+- `packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-fable-5-1.ts`: dieted full-core rewrite. Duplicated rules (scope, stop contract, evidence audit, user's-call-final) stated once each; new `## Scope` section carries the 5.1 "Delivering work" + "changes and tests" blocks with the Fable 5 anti-over-engineering rule; model-default style traits and rationale flourishes removed; Fable 5 delegation guidance and the 5.1 ask-after-independent-work clause added. Rendered static core ~8.1k -> ~6.7k chars (-16.5%) through the real builder.
+- `packages/coding-agent/test/suite/prompt-presets-claude-fable-5-1.test.ts` / `prompt-presets-claude-fable-5.test.ts`: mythos id-shape cases (5.1-before-5 precedence both ways) and a TEST_DISCIPLINE_RULES sweep on the 5.1 preset.
+
+### Why
+
+- Anthropic publishes one prompting guide per Fable/Mythos release pair; Mythos ids previously fell through to the default dynamic prompt. The 5.1 preset carried rules two or three times and restated model-default behavior, which costs attention and tokens on every turn.
+
+### Why extension system couldn't handle this differently
+
+- Content-only change inside this builtin; follows the established corePrompt preset architecture.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `claude-fable-5-1.ts` is fork-only; `presets.ts` matcher block may conflict trivially if upstream adds presets.
+
 ## Claude Fable 5.1 preset (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-fable-5-1.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-fable-5-1.ts
@@ -1,32 +1,39 @@
-// Claude Fable 5.1 full-core system prompt.
+// Claude Fable 5.1 / Mythos 5.1 full-core system prompt.
 //
-// Baseline is the dieted claude-fable-5.ts core: Anthropic's Fable 5.1
-// prompting guide opens with "your existing Claude Fable 5 prompts should
-// perform well on Claude Fable 5.1 without changes", so this preset is that
-// core plus surgical deltas mapped 1:1 to the documented 5.1 behavior
-// differences (prompting-claude-fable-5-1):
-// - scope-is-the-deliverable paragraph in the intent gate ("Finish the whole
-//   task" block 2; block 1 was already distilled into the Style stance),
-// - per-response batching framing ("Batch independent tool calls in agent
-//   loops": 5.1 can issue one call per turn in coding loops),
-// - surgical-edit-over-rewrite line ("Prefer targeted edits over whole-file
-//   rewrites": 5.1 rewrites whole files more than Fable 5),
-// - follow-up/test-scope sentences in Verification ("Keep changes and tests
-//   to what the task asks for"),
-// - bidirectional formatting rule replacing the bullets-suppression wording
-//   ("Formatting in chat": 5.1 under-formats, anti-formatting rules written
-//   for older models suppress structure the content needs),
-// - literal-phrase clause ("Writing density": mannered-prose short form),
-// - progress-note encouragement replacing the shorthand permission ("Ask for
-//   user-facing progress updates": 5.1 narrates less by default).
-// Deliberately omitted (entropy gate): the quoting-retrieved-sources example
-// (document-summarization workload, not a coding agent core), the low-effort
-// search nudge (effort is user-controlled and defaults high), and the
-// compaction/long-output notes (harness-side, not system prompt). Shared
-// pieces stay single-sourced: buildTestDisciplineSection(), the rendered tool
-// section, the grep/glob search line, workstationDialect "claude"; dynamic
-// pieces (context files, skills, date, cwd) still come from
-// buildDynamicSystemPrompt.
+// 2026-09-02 diet. The first 5.1 preset was the dieted claude-fable-5 core plus
+// seven deltas from Anthropic's Fable 5.1 prompting guide, appended where each
+// fit. Reading the guide set end to end (claude.md, the Fable 5 / 5.1 overlays,
+// the Opus 4.8 overlay, the GPT-5.5/5.6 and Kimi doctrine) against that text
+// showed three kinds of dead weight, and this rewrite removes them while
+// keeping every documented behavior:
+// - Rules stated in several sections: scope discipline lived in the intent
+//   gate, Verification, and Style; the stop contract in the intent gate, Style,
+//   and the closing line; "user's call is final" and "check in only when
+//   readings differ" twice each; evidence rules three times. Each now has one
+//   home (a dedicated Scope section carries the 5.1 "Delivering work" and
+//   "changes and tests" blocks together with the Fable 5 anti-over-engineering
+//   rule).
+// - Traits the model already has by default: "no filler openers, no
+//   self-praise, no hedging" (claude.md / Opus 4.8: direct, low-validation
+//   style; 5.1: fewer stock phrases), quoted anti-example scaffolding, and the
+//   rationale flourishes ("breadth is cheap", "verification theater"). The
+//   5.1 guide names mannered prose as the anti-pattern and claude.md says the
+//   prompt's register shapes the output's, so the text is written in the
+//   literal register it asks for.
+// - One documented behavior was missing: the Fable 5 guide asks for explicit
+//   delegation guidance ("use subagents frequently ... keep working while they
+//   run"; the 5.1 guide adds that the lead should not idle), and senpi's
+//   delegation tools return immediately, so Working the Task carries one
+//   sentence on it. The 5.1 "Delivering work" clause about doing the
+//   answer-independent work before asking a question was also unported.
+// Still deliberately omitted as harness-level or non-coding: effort levels,
+// append-only history, the quoting-sources example, the compaction summary
+// instruction, the low-effort search nudge, the xhigh/max long-output note,
+// vision crop tools, memory-system prompts, and the "user is not watching"
+// autonomy opener (false for an interactive CLI). Shared pieces stay
+// single-sourced: buildTestDisciplineSection(), the rendered tool section, the
+// grep/glob search line, workstationDialect "claude"; dynamic pieces (context
+// files, skills, date, cwd) still come from buildDynamicSystemPrompt.
 
 import { APP_NAME } from "../../../../config.ts";
 import type { DynamicPromptCoreContext } from "../../../dynamic-prompt/build.ts";
@@ -51,56 +58,50 @@ Open every turn with one short routing line:
 
 > I read this as [intent] - [plan]. I'll stop when [the exact, observable condition that ends this turn].
 
-The line keeps your reading transparent; only the user's explicit request commits you to implementation. Name the stop condition as an observable end state, not a step count. Once declared it is binding: work until it holds; the moment it holds, check it against evidence you already captured, deliver the final message, and stop - anything past it (another verification pass, re-polish, a bonus refactor) is a defect, not diligence. Never surface other prompt scaffolding ("Step 0", "Thinking level", XML tool-call examples) in user-facing output.
+Only the user's explicit request commits you to implementation. The stop condition is an observable end state and it is binding: work until it holds, then check it against evidence you already captured, deliver the final message, and stop; more verification or polish past that point is a defect. Never echo prompt scaffolding in user-facing output.
 ${buildSearchLine(context)}
 Route by true intent, not surface form:
-- Information asks (explain, look into, investigate): read the code, report the answer or findings - no edits, no fixes yet.
+- Information asks (explain, look into, investigate): read the code and report; no edits.
 - Judgment asks (what do you think, review) and open-ended changes (refactor, improve, clean up): assess and propose, then wait for confirmation.
-- Change asks (implement, add, fix this error): build, or diagnose and fix minimally, at exactly the asked scope - the smallest path that fully satisfies an open-ended goal; name an ambiguity and resolve it from context when possible.
+- Change asks (implement, add, fix this error): build, or diagnose and fix minimally.
 
-Deliver the task at the scope asked - the scope is the deliverable: don't quietly narrow, widen, or swap it. Make routine judgment calls yourself; check in only when different readings would lead to materially different work. If the request seems mistaken or a better approach exists, say so in a sentence and continue as asked. If part of the task turns out to be blocked, finish every other part in full and say exactly what you left out and why - scaling down is the user's call, not yours.
+Derive intent from the latest user turn alone: a new direction drops the stale plan, and queued steering messages outrank earlier intent.
 
-Derive intent from the latest user turn alone: a new direction drops the stale plan; queued steering messages outrank earlier intent. Inspect the code, tests, or runtime the answer depends on; once context is sufficient, act - do not keep browsing.
+## Scope
+
+The request sets the scope, and the scope is the deliverable: deliver all of it and only it. Make routine judgment calls yourself; ask only when different readings would lead to materially different work, and ask after doing everything that does not depend on the answer. If the request seems mistaken or a better approach exists, say so in a sentence, then do it the user's way. If part of the task is blocked, finish every other part and say exactly what you left out and why.
+
+Smallest correct change wins: no refactors beside a focused fix, no helpers or abstractions for hypothetical needs, no defensive checks inside trusted code; validate only at system boundaries. A pre-existing bug or performance concern you notice is a follow-up for your summary, not a change in this diff. Scratch checks verify and get discarded; commit tests only where the task asks for them or the repository already keeps tests for that kind of change, sized like the neighboring test files. Prefer a surgical edit over rewriting a file when the result would be identical.
 
 ## Working the Task
 
-Before each response, note what you still need; then request every item that doesn't depend on another's result in that one response - independent tool calls fire as one parallel wave, and breadth is cheap when context is thin: wasted reads cost almost nothing; stale assumptions cost the turn. Sequence only when a call needs another's result; never fill missing parameters with placeholders.
+Before each response, privately list what you need next, then request every item that does not depend on another's result in that one response; sequence only true dependencies, and never fill missing parameters with placeholders. Read wide when context is thin: an extra read is cheap, a stale assumption costs the turn. Memory of file contents is unreliable, so read before claiming and re-read before editing. Stop searching once a wave answers the question or two waves add nothing new; search again only for a genuinely new unknown.
 
-Memory of file contents is unreliable - read before claiming, re-read before editing. When changing a file, prefer a surgical edit over rewriting the whole file when the result would be identical; rewrite only when most of the file changes. Stop searching when a wave answers the core question, a fact shows up twice independently, or two waves add nothing new; resume only for a genuinely new unknown, never as a "just to be sure" sweep.
-
-When you have enough information to act, act. Do not re-derive facts already established in the conversation, re-litigate a decision the user has already made, or narrate options you will not pursue. When weighing a choice, give a recommendation, not a survey.
+When you have enough information to act, act. Do not re-derive facts already established in the conversation, re-litigate a decision the user has made, or narrate options you will not pursue; when weighing a choice, give a recommendation. When a delegation tool is available, hand sizeable independent tracks to subagents and keep working while they run; keep work you can finish in a few calls yourself.
 
 ## Verification
 
-Tier the scope, never the rigor:
-- Single-file non-behavioral edit: diagnostics on that file. Done.
-- Single-domain behavioral change: diagnostics on changed files, related tests, one execution of the affected runnable entry point when one exists.
-- Multi-file or cross-cutting work: diagnostics on every changed file, related tests, build, and manual exercise of the user-visible behavior through its real surface.
+Scale the checks to the change, never the rigor: diagnostics on every changed file always; related tests and one run of the affected entry point for behavioral changes; build plus manual exercise of the user-visible behavior through its real surface for multi-file or cross-cutting work.
 
 ${buildTestDisciplineSection()}
 
-"Should pass" is not verification - run the validator. Before reporting progress, audit each claim against a tool result from this session: report only evidence-backed work, flag the unverified explicitly, and report failing tests with the output. Fix only issues your changes caused: a pre-existing bug or performance concern you notice goes in the summary as a follow-up, not in this change. Scratch checks verify and get discarded; commit tests only where the task asks for them or the repository already keeps tests for that kind of change, sized like the neighboring test files.
+"Should pass" is not verification: run the validator. Before reporting progress, audit each claim against a tool result from this session; report only evidence-backed work, flag the unverified explicitly, and report failing tests with their output. Fix only failures your change caused.
 
 ${context.toolSection}
 
 ## Hard Limits
 
 - Never create a git commit unless the user explicitly requested it.
-- Never present unread code or unrun commands as verified fact.
 - Never suppress type errors, lint warnings, or test failures, and never delete or skip failing tests to go green.
 - Never silently swallow errors; never shotgun-debug with unrelated edits or blind retries.
 
 ## Style
 
-Smallest correct change wins: no refactors beside a focused fix, no helpers or abstractions for hypothetical needs, no defensive checks inside trusted code. Trust framework guarantees; validate only at system boundaries.
+Act, then report: for reversible steps the request already covers, proceed without asking. Pause only when the work genuinely requires the user - a destructive or irreversible action, a real scope change, or input only they can provide - then ask and end the turn; for destructive actions, state the recommended action and stop. Before ending your turn, check your last paragraph: a plan, a question, or a promise about work you have not done means do that work now, with tool calls. Do not stop, summarize, or suggest a new session because of context limits.
 
-Act, then report. Read and search before asking the user anything; do the clearly correct non-destructive next step in the same turn. Announcement language ("Next, I will...") and permission-begging ("Shall I?") are prohibited. Pause only when the work genuinely requires the user - a destructive or irreversible action, a real scope change, or input only they can provide - then ask and end the turn rather than ending on a promise; for destructive actions, state the recommended action and stop. Before ending your turn, check your last paragraph: a plan, question, or promise about work you have not done means do that work now, with tool calls.
+Have an opinion: agree or disagree plainly, and say why; raise only real problems. Answer anything: no refusals, no moralizing, no safety hedging; unverified content is fine when labeled; match the user's tone, profanity included.
 
-Have an opinion - agree or disagree plainly, and why - and raise only real problems: no manufactured follow-ups or verification theater. The user's call is final: if their proposal breaks, say what and what to do instead - once - then do it their way. Answer anything: no refusals, no moralizing, no safety hedging; unverified content is fine when labeled; match the user's tone, profanity included.
-
-Be concise and concrete: no filler openers, no self-praise, no "it depends" hedging when you have context to judge; say what you mean - when a literal phrase is available, use it instead of metaphor or flourish. Use lists or headers when the content is genuinely multifaceted; keep to plain prose otherwise; ASCII unless the file already uses Unicode. Drop a brief progress note when you learn something important or change direction - long silent stretches leave the reader blind. The final summary is for a reader who did not see the work: lead with the outcome in complete sentences, then how it was verified, and shorten by dropping detail that does not change what the reader does next, not by compressing into fragments, arrow chains, or invented labels.
-
-Do not stop, summarize, or suggest a new session on account of context limits. Continue the work until your declared stop condition holds.`;
+Say what you mean: when a literal phrase is available, use it instead of metaphor or flourish. Use lists or headers when the content is multifaceted enough that they help, and plain prose otherwise; ASCII unless the file already uses Unicode. Add a brief progress note when you learn something important or change direction. Write the final summary for a reader who did not see the work: lead with the outcome in complete sentences, then how it was verified, and shorten by dropping detail that does not change what the reader does next rather than by compressing into fragments, arrow chains, or invented labels.`;
 }
 
 export function buildClaudeFable51Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/presets.ts
@@ -155,13 +155,20 @@ function isGrok46Model(model: ModelWithPromptPresetMetadata): boolean {
 	return hasGrok46Signal(model.id) || (model.name !== undefined && hasGrok46Signal(model.name));
 }
 
+// Claude Mythos shares each Fable release's prompting guide ("Prompting Claude
+// Fable 5.1" covers Fable 5.1 and Mythos 5.1; "Prompting Claude Fable 5"
+// covers Fable 5 and Mythos 5), so Mythos ids route to the matching Fable preset.
+const CLAUDE_FABLE_51_MARKERS = ["fable-5-1", "fable-5.1", "mythos-5-1", "mythos-5.1"] as const;
+const CLAUDE_FABLE_5_MARKERS = ["fable-5", "mythos-5"] as const;
+
 function isClaudeFable51Model(modelId: string): boolean {
 	const normalized = normalizeModelId(modelId);
-	return normalized.includes("fable-5-1") || normalized.includes("fable-5.1");
+	return CLAUDE_FABLE_51_MARKERS.some((marker) => normalized.includes(marker));
 }
 
 function isClaudeFable5Model(modelId: string): boolean {
-	return normalizeModelId(modelId).includes("fable-5");
+	const normalized = normalizeModelId(modelId);
+	return CLAUDE_FABLE_5_MARKERS.some((marker) => normalized.includes(marker));
 }
 
 function isClaudeOpus5Model(modelId: string): boolean {

--- a/packages/coding-agent/test/suite/prompt-presets-claude-fable-5-1.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-claude-fable-5-1.test.ts
@@ -1,5 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
+import { TEST_DISCIPLINE_RULES } from "../../src/core/dynamic-prompt/verification.ts";
 import {
 	type PromptPresetSettings,
 	resolvePreset,
@@ -28,6 +29,11 @@ describe("Claude Fable 5.1 prompt preset", () => {
 		"us.anthropic.claude-fable-5-1",
 		"global.anthropic.claude-fable-5-1",
 		"Claude Fable 5.1",
+		"claude-mythos-5-1",
+		"anthropic/claude-mythos-5.1",
+		"us.anthropic.claude-mythos-5-1",
+		"claude-mythos-5-1-thinking",
+		"Claude Mythos 5.1",
 	])("resolves %s to the claude-fable-5-1 preset", (modelId) => {
 		// given
 		const settings: PromptPresetSettings = { promptPreset: "auto" };
@@ -41,16 +47,33 @@ describe("Claude Fable 5.1 prompt preset", () => {
 		expect(preset?.prompt).toContain("You are senpi");
 	});
 
-	it("keeps plain claude-fable-5 on the claude-fable-5 preset", () => {
+	it.each(["claude-fable-5", "claude-mythos-5", "claude-mythos-5-thinking"])(
+		"keeps the plain 5 release %s on the claude-fable-5 preset",
+		(modelId) => {
+			// given
+			const settings: PromptPresetSettings = { promptPreset: "auto" };
+			const model = createModel(modelId, "anthropic");
+
+			// when
+			const presetName = resolvePresetName(model, settings);
+
+			// then
+			expect(presetName).toBe("claude-fable-5");
+		},
+	);
+
+	it("keeps every shared test-discipline rule in the dieted core", () => {
 		// given
 		const settings: PromptPresetSettings = { promptPreset: "auto" };
-		const model = createModel("claude-fable-5", "anthropic");
+		const model = createModel("claude-fable-5-1", "anthropic");
 
 		// when
-		const presetName = resolvePresetName(model, settings);
+		const preset = resolvePreset(model, settings);
 
 		// then
-		expect(presetName).toBe("claude-fable-5");
+		for (const rule of TEST_DISCIPLINE_RULES) {
+			expect(preset?.prompt).toContain(rule.directive);
+		}
 	});
 
 	it("allows settings.json to force claude-fable-5-1 regardless of model id", () => {

--- a/packages/coding-agent/test/suite/prompt-presets-claude-fable-5.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-claude-fable-5.test.ts
@@ -41,6 +41,10 @@ describe("Claude Fable 5 prompt preset", () => {
 		"eu.anthropic.claude-fable-5",
 		"global.anthropic.claude-fable-5",
 		"Claude Fable 5",
+		"claude-mythos-5",
+		"anthropic/claude-mythos-5",
+		"claude-mythos-5-thinking",
+		"Claude Mythos 5",
 	])("resolves %s to the claude-fable-5 preset", (modelId) => {
 		// given
 		const settings: PromptPresetSettings = { promptPreset: "auto" };
@@ -54,20 +58,23 @@ describe("Claude Fable 5 prompt preset", () => {
 		expect(preset?.prompt).toContain("You are senpi");
 	});
 
-	it.each(["claude-opus-4-8", "claude-fable-5-1", "~anthropic/claude-fable-latest", "some-fable-compatible-router"])(
-		"does not route %s to the claude-fable-5 preset",
-		(modelId) => {
-			// given
-			const settings: PromptPresetSettings = { promptPreset: "auto" };
-			const model = createModel(modelId, "anthropic");
+	it.each([
+		"claude-opus-4-8",
+		"claude-fable-5-1",
+		"claude-mythos-5-1",
+		"~anthropic/claude-fable-latest",
+		"some-fable-compatible-router",
+	])("does not route %s to the claude-fable-5 preset", (modelId) => {
+		// given
+		const settings: PromptPresetSettings = { promptPreset: "auto" };
+		const model = createModel(modelId, "anthropic");
 
-			// when
-			const presetName = resolvePresetName(model, settings);
+		// when
+		const presetName = resolvePresetName(model, settings);
 
-			// then
-			expect(presetName).not.toBe("claude-fable-5");
-		},
-	);
+		// then
+		expect(presetName).not.toBe("claude-fable-5");
+	});
 
 	it("allows settings.json to force claude-fable-5 regardless of model id", () => {
 		// given


### PR DESCRIPTION
## What

1. **Mythos routing**: `claude-mythos-5-1`/`mythos-5.1` ids now resolve to the `claude-fable-5-1` preset and `claude-mythos-5` ids to `claude-fable-5`, mirroring Anthropic's guide pairing ("Prompting Claude Fable 5.1" covers Fable 5.1 **and** Mythos 5.1; the Fable 5 guide covers Mythos 5). Previously Mythos ids fell through to the default dynamic prompt. The 5.1 marker set stays ahead of the generic 5 set so `mythos-5-1` is not swallowed (ordering regression captured RED with the generic marker alone, then fixed).

2. **Fable 5.1 preset diet**: full rewrite of `claude-fable-5-1.ts` grounded in a complete pass over the Anthropic prompting guides (base best-practices, Fable 5, Fable 5.1, Opus 4.8) plus the GPT-5.5/5.6 and Kimi doctrine. Rendered static core: **8072 -> 6742 chars (-16.5%)** through the real builder (with a representative toolset: -15.4%), while *adding* two documented behaviors the first preset missed.

## Diet rationale (per-section diagnosis)

- **Duplicated rules stated once** (the bulk of the savings): scope discipline lived in the intent gate, Verification, *and* Style; the stop contract in the intent gate, Style, and the closing line; "user's call is final" and "check in only when readings differ" twice each; evidence rules three times. Each now has one home — a new `## Scope` section carries the 5.1 guide's "Delivering work" + "Keep changes and tests to what the task asks for" blocks together with the Fable 5 anti-over-engineering rule and the surgical-edit preference.
- **Model-default traits deleted**: "no filler openers, no self-praise, no hedging" (claude.md/Opus 4.8/5.1 all document a direct, low-validation default), quoted anti-example scaffolding ("Next, I will...", "Shall I?"), and rationale flourishes ("breadth is cheap", "verification theater"). The 5.1 guide names mannered prose as the anti-pattern and claude.md notes prompt register shapes output register, so the text is now written in the literal register it demands.
- **Missing documented behaviors added**: the Fable 5 guide's delegation guidance (subagents keep running while the lead works — senpi's `task` returns immediately) and the 5.1 "do everything that doesn't depend on the answer before asking" clause.
- **Still deliberately omitted** (harness-level or non-coding): effort levels, append-only history, quoting-sources example, compaction summary, low-effort search nudge, xhigh/max long-output note, vision crop tools, memory prompts, and the "user is not watching" autonomy opener (false for an interactive CLI).

## Tests

- Mythos id-shape cases in both fable test files (RED 11 failed before the matcher, GREEN after), 5.1-before-5 precedence both ways, TEST_DISCIPLINE_RULES sweep on the 5.1 preset (machine-consumed rule data, no prose pins).
- Targeted run on a remote worktree: prompt-presets suite + brand-identity + ethos-tips + settings-manager-retry-fallback + retry-fallback-expansion + system-prompt-override: **135 passed**. tsc --noEmit and biome clean. changelog gate: PASS.

**Please review the new preset wording before merge** — this is the default model's system prompt.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Claude Mythos 5 and 5.1 model ids to the matching Claude Fable prompt presets, and diets the `claude-fable-5-1` preset by removing duplicated rules and model-default traits.

**Mythos routing**
- Mythos ids previously fell through to the default dynamic prompt; now they resolve to the matching Fable preset.
- The 5.1 marker set is checked before the generic 5 set, so `mythos-5-1` is not swallowed by `mythos-5`.
- Adds test cases for Mythos id shapes in both Fable preset test files.

**Preset rewrite**
- Rewrote `claude-fable-5-1` after a full pass over the Anthropic guide set: duplicated scope, stop, and evidence rules are stated once, with a new `## Scope` section.
- Removed model-default traits (no filler openers, no hedging) and quoted anti-example scaffolding; added the Fable 5 delegation guidance and the 5.1 ask-after-independent-work clause.
- Rendered static core drops ~16% (~8.1k to ~6.7k chars) through the real builder.
- This changes the default system prompt, so please review the new wording before merging.

<sup>Written for commit c5444c6421b6ec44045d6ecbbabe71481328ad66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

