### PR TITLE
fix(coding-agent): compose models.json custom models under extension providers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- models.json custom models under extension-registered providers now inherit the extension's provider-level `api` and `baseUrl`, while extension catalog models remain available alongside new custom models.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-02 - Inherit extension provider settings for models.json custom models
+
+### What changed
+
+- `packages/coding-agent/src/core/provider-composer.ts` now lets models.json custom models inherit an extension-registered provider's `api` and `baseUrl`, and preserves extension catalog models when adding new custom IDs.
+
+### Why
+
+- A custom models.json model under an extension provider previously failed before the extension could compose it because the models.json layer could not see the extension's provider-level settings; models.json custom definitions not declared by the extension catalog were also dropped.
+
+### Why an extension could not handle it
+
+- Provider composition order and models.json merging are core responsibilities in `packages/coding-agent/src/core/provider-composer.ts`, before extension model behavior can repair the intermediate layer.
+
+### Expected merge conflict zones
+
+- LOW: models.json and extension composition in `packages/coding-agent/src/core/provider-composer.ts`.
+
 ## 2026-08-31 - Session activity contract for host occupancy decisions
 
 ### What changed

--- a/packages/coding-agent/src/core/provider-composer.ts
+++ b/packages/coding-agent/src/core/provider-composer.ts
@@ -218,6 +218,7 @@ function applyModelsJson(
 	providerId: string,
 	baseModels: readonly Model<Api>[],
 	config: ModelsJsonProvider | undefined,
+	extension: ProviderConfigInput | undefined,
 ): Model<Api>[] {
 	if (!config) return [...baseModels];
 	const hasOverrides = config.modelOverrides && Object.keys(config.modelOverrides).length > 0;
@@ -248,7 +249,11 @@ function applyModelsJson(
 	for (const definition of config.models ?? []) {
 		const existingIndex = models.findIndex((model) => model.id === definition.id);
 		const defaults = existingIndex >= 0 ? models[existingIndex] : models[0];
-		const model = modelFromJson(providerId, definition, config, defaults);
+		const model = modelFromJson(providerId, definition, config, {
+			...defaults,
+			api: extension?.api ?? defaults?.api,
+			baseUrl: extension?.baseUrl ?? defaults?.baseUrl,
+		});
 		if (existingIndex >= 0) models[existingIndex] = model;
 		else models.push(model);
 	}
@@ -264,12 +269,14 @@ function applyExtension(
 	providerId: string,
 	models: readonly Model<Api>[],
 	config: ProviderConfigInput | undefined,
+	customModelIds: ReadonlySet<string>,
 ): Model<Api>[] {
 	if (!config) return [...models];
 	if (!config.models) {
 		return config.baseUrl ? models.map((model) => ({ ...model, baseUrl: config.baseUrl! })) : [...models];
 	}
-	return config.models.map((definition) => {
+	const declaredModels = config.models;
+	const extensionModels = declaredModels.map((definition) => {
 		const defaults = models.find((model) => model.id === definition.id) ?? models[0];
 		const api = definition.api ?? config.api ?? defaults?.api;
 		if (!api) {
@@ -287,6 +294,12 @@ function applyExtension(
 			headers: undefined,
 		};
 	});
+	return [
+		...extensionModels,
+		...models.filter(
+			(model) => customModelIds.has(model.id) && !declaredModels.some((definition) => definition.id === model.id),
+		),
+	];
 }
 
 function adaptOAuth(config: ExtensionOAuthConfig): OAuthAuth {
@@ -375,7 +388,12 @@ export function validateExtensionProvider(
 	if (extension.streamSimple && !extension.api) {
 		throw new Error(`Provider ${providerId}: "api" is required when registering streamSimple.`);
 	}
-	applyExtension(providerId, applyModelsJson(providerId, base?.getModels() ?? [], modelsConfig), extension);
+	applyExtension(
+		providerId,
+		applyModelsJson(providerId, base?.getModels() ?? [], modelsConfig, extension),
+		extension,
+		new Set((modelsConfig?.models ?? []).map((definition) => definition.id)),
+	);
 }
 
 /** Compose built-in, models.json, and extension layers without reading credentials. */
@@ -395,8 +413,9 @@ export function composeModelProvider(
 	const getModels = () => {
 		let models = applyExtension(
 			providerId,
-			applyModelsJson(providerId, base?.getModels() ?? [], config),
+			applyModelsJson(providerId, base?.getModels() ?? [], config, currentExtension()),
 			currentExtension(),
+			new Set((config?.models ?? []).map((definition) => definition.id)),
 		);
 		if (extensionOAuthCredential && extension?.oauth?.modifyModels) {
 			models = extension.oauth.modifyModels(models, extensionOAuthCredential);
@@ -470,10 +489,15 @@ export function composeModelProvider(
 							update: () => {
 								if (refreshed) {
 									// Validate before publishing the new synchronous list.
-									applyExtension(providerId, applyModelsJson(providerId, base?.getModels() ?? [], config), {
-										...extension,
-										models: refreshed,
-									});
+									applyExtension(
+										providerId,
+										applyModelsJson(providerId, base?.getModels() ?? [], config, extension),
+										{
+											...extension,
+											models: refreshed,
+										},
+										new Set((config?.models ?? []).map((definition) => definition.id)),
+									);
 									refreshedExtensionModels = refreshed;
 								}
 								extensionOAuthCredential = oauthCredential;

--- a/packages/coding-agent/test/provider-composer-extension-models-json.test.ts
+++ b/packages/coding-agent/test/provider-composer-extension-models-json.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Model, Provider } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ModelConfig } from "../src/core/model-config.ts";
+import {
+	composeModelProvider,
+	type ProviderConfigInput,
+	validateExtensionProvider,
+} from "../src/core/provider-composer.ts";
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+	if (tempDir !== undefined) {
+		rmSync(tempDir, { recursive: true, force: true });
+		tempDir = undefined;
+	}
+});
+
+const extension = {
+	api: "claude-sdk-oauth",
+	baseUrl: "claude-sdk-oauth",
+	streamSimple: vi.fn(),
+	models: [
+		{
+			id: "claude-opus-5",
+			name: "Claude Opus 5",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+			contextWindow: 200000,
+			maxTokens: 32000,
+		},
+		{
+			id: "claude-sonnet-5",
+			name: "Claude Sonnet 5",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+			contextWindow: 200000,
+			maxTokens: 16000,
+		},
+	],
+} satisfies ProviderConfigInput;
+
+function configFor(provider: string, models?: readonly { id: string; name?: string }[]) {
+	tempDir = mkdtempSync(join(tmpdir(), "senpi-composer-extension-models-json-"));
+	const modelsPath = join(tempDir, "models.json");
+	const providers = models === undefined ? {} : { [provider]: { models } };
+	writeFileSync(modelsPath, JSON.stringify({ providers }));
+	return ModelConfig.loadSync(modelsPath);
+}
+
+function baseProvider(models: readonly Model<"anthropic-messages">[]): Provider {
+	return {
+		id: "anthropic",
+		name: "Anthropic",
+		auth: { apiKey: { name: "Inherited auth", resolve: async () => ({ auth: {} }) } },
+		getModels: () => models,
+		stream: vi.fn(),
+		streamSimple: vi.fn(),
+	};
+}
+
+function catalogModel(id: string): Model<"anthropic-messages"> {
+	return {
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://example.invalid/v1",
+		reasoning: true,
+		input: ["text", "image"],
+		cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200000,
+		maxTokens: 32000,
+	};
+}
+
+function modelById(provider: ReturnType<typeof composeModelProvider>, id: string): Model<"claude-sdk-oauth"> {
+	const model = provider.getModels().find((entry) => entry.id === id);
+	if (model === undefined) throw new Error(`Expected model ${id}`);
+	return model as Model<"claude-sdk-oauth">;
+}
+
+describe("models.json custom models under extension providers", () => {
+	it("inherits extension api and baseUrl and validates the composed provider", () => {
+		const config = configFor("claude-sdk-oauth", [{ id: "claude-fable-5-1" }]);
+		const provider = composeModelProvider("claude-sdk-oauth", undefined, config, extension);
+
+		const model = modelById(provider, "claude-fable-5-1");
+		expect(model.api).toBe("claude-sdk-oauth");
+		expect(model.baseUrl).toBe("claude-sdk-oauth");
+		expect(() =>
+			validateExtensionProvider("claude-sdk-oauth", undefined, config.getProvider("claude-sdk-oauth"), extension),
+		).not.toThrow();
+	});
+
+	it("preserves extension catalog models and gives extension definitions precedence", () => {
+		const config = configFor("claude-sdk-oauth", [
+			{ id: "claude-fable-5-1" },
+			{ id: "claude-opus-5", name: "custom-name" },
+		]);
+		const provider = composeModelProvider("claude-sdk-oauth", undefined, config, extension);
+		const models = provider.getModels();
+
+		expect(models.map((model) => model.id)).toEqual(["claude-opus-5", "claude-sonnet-5", "claude-fable-5-1"]);
+		expect(modelById(provider, "claude-opus-5").name).toBe("Claude Opus 5");
+	});
+
+	it("replaces a builtin catalog instead of leaking undeclared builtin models", () => {
+		const first = catalogModel("builtin-first");
+		const second = catalogModel("builtin-second");
+		const config = configFor("anthropic");
+		const provider = composeModelProvider("anthropic", baseProvider([first, second]), config, {
+			...extension,
+			models: [
+				{
+					...extension.models[0],
+					id: first.id,
+				},
+			],
+		});
+
+		expect(provider.getModels().map((model) => model.id)).toEqual([first.id]);
+	});
+
+	it("keeps models.json custom models alongside a builtin replacement catalog", () => {
+		const first = catalogModel("builtin-first");
+		const second = catalogModel("builtin-second");
+		const config = configFor("anthropic", [{ id: "custom-x" }]);
+		const provider = composeModelProvider("anthropic", baseProvider([first, second]), config, {
+			...extension,
+			models: [
+				{
+					...extension.models[0],
+					id: first.id,
+				},
+			],
+		});
+
+		expect(provider.getModels().map((model) => model.id)).toEqual([first.id, "custom-x"]);
+		expect(modelById(provider, "custom-x").api).toBe("claude-sdk-oauth");
+		expect(modelById(provider, "custom-x").baseUrl).toBe("claude-sdk-oauth");
+	});
+
+	it("keeps the existing missing api error", () => {
+		const config = configFor("kiro-like", [{ id: "custom-model" }]);
+		expect(() => composeModelProvider("kiro-like", undefined, config, undefined)).toThrow(
+			'Provider kiro-like, model custom-model: no "api" specified. Set at provider or model level.',
+		);
+	});
+
+	it("keeps the existing missing baseUrl error", () => {
+		tempDir = mkdtempSync(join(tmpdir(), "senpi-composer-extension-models-json-"));
+		const modelsPath = join(tempDir, "models.json");
+		writeFileSync(
+			modelsPath,
+			JSON.stringify({ providers: { "kiro-like": { api: "kiro-api", models: [{ id: "custom-model" }] } } }),
+		);
+		const config = ModelConfig.loadSync(modelsPath);
+
+		expect(() => composeModelProvider("kiro-like", undefined, config, undefined)).toThrow(
+			'Provider kiro-like: "baseUrl" is required when defining custom models.',
+		);
+	});
+});


### PR DESCRIPTION
## Problem

A models.json custom model under an extension-registered provider fails to compose. Reported on Discord (omo-ai beta.31, senpi 2026.8.31): a user whose bundled anthropic catalog predated `claude-fable-5-1` added

```json
{"providers":{"claude-sdk-oauth":{"models":[{"id":"claude-fable-5-1"}]}}}
```

and every session open died with:

```
Extension "<builtin:claude-sdk-oauth>" error: Provider claude-sdk-oauth, model claude-fable-5-1: no "api" specified. Set at provider or model level.
```

preceded by `No models match pattern "claude-sdk-oauth/claude-opus-5"` warnings - the whole provider failed to compose, so every pattern on it missed.

## Root cause

Two gaps in `provider-composer.ts`:

1. `applyModelsJson` -> `modelFromJson` resolves `api`/`baseUrl` as `definition ?? models.json provider ?? builtin defaults`. Extension-registered providers (claude-sdk-oauth registers both at provider level via `pi.registerProvider`) have no builtin base, so the extension's provider-level values were never consulted -> throw.
2. `applyExtension` returns `config.models.map(...)` whenever the extension declares models, silently dropping models.json custom models whose id the extension does not declare.

## Fix

- Thread the extension registration into `applyModelsJson` so custom-model `api`/`baseUrl` resolve as **definition > models.json provider > extension provider-level > builtin defaults**.
- In `applyExtension`, preserve models.json custom definitions absent from the extension catalog (appended after it). Builtin base models are still replaced by the extension catalog exactly as before, and shared ids keep extension precedence.
- No behavior change when no extension is registered; the existing "no \"api\" specified" / missing-baseUrl errors are pinned unchanged.

## Evidence (vitest on the repo suite, mengmotaMac)

- RED before the fix at the test-only commit: the new file fails with the exact production error text; GREEN after (6/6).
- Mutation proofs at the final tree: reverting the inheritance hunk -> 3 tests fail with the exact "no \"api\" specified" text; reverting the survival hunk -> survival cases fail.
- Adjacent regression: composer + model-resolver + claude-sdk-oauth suites, 58 files / 510 tests pass; `biome check` clean on both touched files; root `tsc --noEmit` clean.
- Real CLI surface: `--list-models` with the user's exact models.json + the real builtin lane reproduces the error at origin/main and lists `claude-sdk-oauth  claude-fable-5-1` cleanly with this fix.

Tracker entry: `packages/coding-agent/src/core/changes.md` (upstream-owned path, four canonical sections); changelog under `packages/coding-agent/CHANGELOG.md` [Unreleased] Fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `models.json` custom models under extension-registered providers so sessions open normally instead of crashing when a custom model id isn't in the extension's catalog.

**Bug Fixes**
- Custom models now inherit the extension's provider-level `api` and `baseUrl`, with precedence: definition > models.json provider > extension provider-level > builtin defaults.
- Custom models absent from the extension catalog are preserved alongside it, with shared ids keeping extension precedence.
- Behavior is unchanged when no extension is registered, and the existing missing `api`/`baseUrl` errors are still thrown.

<sup>Written for commit 84e91f0ca06e4dcb33c680c1d0dcada83ff4d1a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

