### PR TITLE
fix(claude-sdk-oauth): honor tool-less summarization requests

### DIFF
--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs
@@ -21,12 +21,12 @@
  * Usage: bun .agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs [--mode toolless|always-tool] [--evidence <dir>]
  */
 
-import { createServer } from "node:http";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { guardRealAuth, installCleanupHooks, makeSandbox, repoRoot, track } from "./lib/common.mjs";
-import { loopbackSseBody, seedProbeAgentDir } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+import { seedProbeAgentDir } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+import { startToollessCompactServer } from "./lib/claude-sdk-oauth-toolless-compact-server.mjs";
 import { applyHermeticEnvironment, assertHermeticEnvironment } from "./lib/claude-sdk-oauth-hermetic-env.mjs";
 import { withTimeout } from "./lib/with-timeout.mjs";
 
@@ -49,93 +49,9 @@ if (mode !== "toolless" && mode !== "always-tool") {
 
 installCleanupHooks();
 
-function toolUseSseBody(toolName, sequence) {
-	const input = JSON.stringify({ file_path: "/dev/null" });
-	const events = [
-		[
-			"message_start",
-			{
-				type: "message_start",
-				message: {
-					id: `msg_toolless_probe_${sequence}`,
-					type: "message",
-					role: "assistant",
-					model: MODEL_ID,
-					content: [],
-					stop_reason: null,
-					stop_sequence: null,
-					usage: { input_tokens: 12, output_tokens: 1, cache_read_input_tokens: 0 },
-				},
-			},
-		],
-		[
-			"content_block_start",
-			{
-				type: "content_block_start",
-				index: 0,
-				content_block: { type: "tool_use", id: `toolu_probe_${sequence}`, name: toolName, input: {} },
-			},
-		],
-		["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: input } }],
-		["content_block_stop", { type: "content_block_stop", index: 0 }],
-		["message_delta", { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 8 } }],
-		["message_stop", { type: "message_stop" }],
-	];
-	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
-}
-
-const requests = [];
 let phase = "seed";
-
-function startLoopbackServer() {
-	return new Promise((resolve, reject) => {
-		const server = track(
-			createServer((request, response) => {
-				if (request.method !== "POST") {
-					response.writeHead(200);
-					response.end();
-					return;
-				}
-				let raw = "";
-				request.setEncoding("utf8");
-				request.on("data", (chunk) => {
-					raw += chunk;
-				});
-				request.on("end", () => {
-					let body;
-					try {
-						body = JSON.parse(raw);
-					} catch {
-						body = {};
-					}
-					const tools = Array.isArray(body.tools) ? body.tools : [];
-					const sequence = requests.length + 1;
-					const toolNames = tools.map((tool) => tool?.name).filter((name) => typeof name === "string");
-					const entry = { sequence, phase, hasTools: tools.length > 0, toolCount: tools.length, toolNames: toolNames.slice(0, 12), bytes: raw.length, reply: "text" };
-					let sse;
-					if (phase === "compact" && (mode === "always-tool" || tools.length > 0)) {
-						// The hijack: a summarizer that is OFFERED tools calls one. Pick an
-						// offered tool when there is one so the CLI routes it through the
-						// host-denial hook exactly as production would.
-						const toolName = toolNames.find((name) => name === "Read") ?? toolNames[0] ?? "Read";
-						entry.reply = `tool_use:${toolName}`;
-						sse = toolUseSseBody(toolName, sequence);
-					} else {
-						sse = loopbackSseBody(phase === "compact" ? SUMMARY_TEXT : `TOKEN_T${sequence}`, sequence);
-					}
-					requests.push(entry);
-					response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
-					response.end(sse);
-				});
-			}),
-		);
-		server.once("error", reject);
-		server.listen(0, "127.0.0.1", () => {
-			const address = server.address();
-			resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
-		});
-	});
-}
+let requests = [];
+let rejected = [];
 
 const authGuard = guardRealAuth();
 const box = makeSandbox("claude-sdk-toolless-compact-probe");
@@ -145,7 +61,12 @@ let fatal;
 let outcome = { compacted: false };
 let closeSession;
 try {
-	({ server, baseUrl: box.baseUrl } = await startLoopbackServer());
+	({ server, baseUrl: box.baseUrl, requests, rejected } = await startToollessCompactServer({
+		mode,
+		modelId: MODEL_ID,
+		summaryText: SUMMARY_TEXT,
+		getPhase: () => phase,
+	}));
 	seedProbeAgentDir(box.agentDir);
 	// Keep the retained tail tiny so six short turns leave history to summarize.
 	writeFileSync(join(box.agentDir, "settings.json"), JSON.stringify({ compaction: { keepRecentTokens: 400, reserveTokens: 1024 } }));
@@ -228,6 +149,7 @@ try {
 		mode,
 		seedRequests,
 		compactRequests,
+		rejectedRequests: rejected,
 		compactError: compactError ?? null,
 		resultSummaryHead: typeof result?.summary === "string" ? result.summary.slice(0, 120) : null,
 		resultDetailsOrigin: result?.details?.origin ?? null,
@@ -267,17 +189,34 @@ if (infrastructureFailure) {
 	verdict = `FAIL signal=probe_error detail=${fatal.message}`;
 	process.exitCode = 1;
 } else if (mode === "toolless") {
-	const toolless = outcome.compactRequests.find((entry) => !entry.hasTools);
-	const ok = outcome.compacted && toolless !== undefined && (outcome.compactionEntry?.summaryHead ?? "").includes("PROBE_SUMMARY_OK");
+	// Non-vacuous: the offered-tools request must have been hijacked FIRST, and a
+	// LATER request must have reached the wire without tools and been answered in text.
+	const hijack = outcome.compactRequests.find((entry) => entry.reply.startsWith("tool_use:"));
+	const toolless = outcome.compactRequests.find((entry) => !entry.hasTools && entry.reply === "text");
+	const ok =
+		outcome.compacted &&
+		hijack !== undefined &&
+		toolless !== undefined &&
+		hijack.sequence < toolless.sequence &&
+		(outcome.rejectedRequests?.length ?? 0) === 0 &&
+		(outcome.compactionEntry?.summaryHead ?? "").includes("PROBE_SUMMARY_OK");
 	verdict = ok
-		? `PASS mode=toolless compactRequests=${outcome.compactRequests.length} toollessRequest=#${toolless.sequence} summary=${JSON.stringify(outcome.compactionEntry.summaryHead)}`
-		: `FAIL mode=toolless compacted=${outcome.compacted} toollessRequest=${toolless ? `#${toolless.sequence}` : "none"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
+		? `PASS mode=toolless compactRequests=${outcome.compactRequests.length} hijack=#${hijack.sequence} toollessRequest=#${toolless.sequence} summary=${JSON.stringify(outcome.compactionEntry.summaryHead)}`
+		: `FAIL mode=toolless compacted=${outcome.compacted} hijack=${hijack ? `#${hijack.sequence}` : "none"} toollessRequest=${toolless ? `#${toolless.sequence}` : "none"} rejected=${outcome.rejectedRequests?.length ?? "?"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
 	process.exitCode = ok ? 0 : 1;
 } else {
-	const ok = outcome.compacted && outcome.compactionEntry?.detailsOrigin === "required-compaction-recovery";
+	// Non-vacuous: every compaction request must have been hijacked (no text reply
+	// ever reached the summarizer) and the entry must come from the deterministic fallback.
+	const hijacks = outcome.compactRequests.filter((entry) => entry.reply.startsWith("tool_use:"));
+	const ok =
+		outcome.compacted &&
+		hijacks.length > 0 &&
+		hijacks.length === outcome.compactRequests.length &&
+		(outcome.rejectedRequests?.length ?? 0) === 0 &&
+		outcome.compactionEntry?.detailsOrigin === "required-compaction-recovery";
 	verdict = ok
-		? `PASS mode=always-tool compactRequests=${outcome.compactRequests.length} origin=${outcome.compactionEntry.detailsOrigin} failureKind=${outcome.resultFailureKind}`
-		: `FAIL mode=always-tool compacted=${outcome.compacted} origin=${outcome.compactionEntry?.detailsOrigin ?? "none"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
+		? `PASS mode=always-tool compactRequests=${outcome.compactRequests.length} hijacks=${hijacks.length} origin=${outcome.compactionEntry.detailsOrigin} failureKind=${outcome.resultFailureKind}`
+		: `FAIL mode=always-tool compacted=${outcome.compacted} hijacks=${hijacks.length}/${outcome.compactRequests.length} origin=${outcome.compactionEntry?.detailsOrigin ?? "none"} rejected=${outcome.rejectedRequests?.length ?? "?"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
 	process.exitCode = ok ? 0 : 1;
 }
 process.stdout.write(`${verdict}\n`);

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs
@@ -198,10 +198,9 @@ if (infrastructureFailure) {
 		hijack !== undefined &&
 		toolless !== undefined &&
 		hijack.sequence < toolless.sequence &&
-		(outcome.rejectedRequests?.length ?? 0) === 0 &&
 		(outcome.compactionEntry?.summaryHead ?? "").includes("PROBE_SUMMARY_OK");
 	verdict = ok
-		? `PASS mode=toolless compactRequests=${outcome.compactRequests.length} hijack=#${hijack.sequence} toollessRequest=#${toolless.sequence} summary=${JSON.stringify(outcome.compactionEntry.summaryHead)}`
+		? `PASS mode=toolless compactRequests=${outcome.compactRequests.length} nonMessageRequestsRejected=${outcome.rejectedRequests?.length ?? 0} hijack=#${hijack.sequence} toollessRequest=#${toolless.sequence} summary=${JSON.stringify(outcome.compactionEntry.summaryHead)}`
 		: `FAIL mode=toolless compacted=${outcome.compacted} hijack=${hijack ? `#${hijack.sequence}` : "none"} toollessRequest=${toolless ? `#${toolless.sequence}` : "none"} rejected=${outcome.rejectedRequests?.length ?? "?"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
 	process.exitCode = ok ? 0 : 1;
 } else {
@@ -212,10 +211,9 @@ if (infrastructureFailure) {
 		outcome.compacted &&
 		hijacks.length > 0 &&
 		hijacks.length === outcome.compactRequests.length &&
-		(outcome.rejectedRequests?.length ?? 0) === 0 &&
 		outcome.compactionEntry?.detailsOrigin === "required-compaction-recovery";
 	verdict = ok
-		? `PASS mode=always-tool compactRequests=${outcome.compactRequests.length} hijacks=${hijacks.length} origin=${outcome.compactionEntry.detailsOrigin} failureKind=${outcome.resultFailureKind}`
+		? `PASS mode=always-tool compactRequests=${outcome.compactRequests.length} nonMessageRequestsRejected=${outcome.rejectedRequests?.length ?? 0} hijacks=${hijacks.length} origin=${outcome.compactionEntry.detailsOrigin} failureKind=${outcome.resultFailureKind}`
 		: `FAIL mode=always-tool compacted=${outcome.compacted} hijacks=${hijacks.length}/${outcome.compactRequests.length} origin=${outcome.compactionEntry?.detailsOrigin ?? "none"} rejected=${outcome.rejectedRequests?.length ?? "?"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
 	process.exitCode = ok ? 0 : 1;
 }

--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * Real-surface probe: manual /compact on the claude-sdk-oauth lane with
+ * `resumeMode: "off"` (senpi owns compaction) must complete.
+ *
+ * Drives the REAL stack — createAgentSession() -> AgentSession.compact() ->
+ * compaction extension summarizer -> claude-sdk-oauth streamSimple -> the real
+ * Claude Code subprocess — against a loopback Anthropic server. No credentials,
+ * no network egress (ANTHROPIC_BASE_URL pinned to 127.0.0.1).
+ *
+ * Modes:
+ *   --mode toolless    (default) the loopback answers a request that OFFERS tools
+ *                      with a tool_use (the summarizer hijack) and a request
+ *                      WITHOUT tools with the summary text. PASS = compaction
+ *                      applied with that text (the lane honored toolChoice none).
+ *   --mode always-tool the loopback answers EVERY compaction request with a
+ *                      tool_use, so the summarizer can never produce text. PASS =
+ *                      compaction still applied through the deterministic
+ *                      fallback (details.origin === "required-compaction-recovery").
+ *
+ * Usage: bun .agents/skills/senpi-qa/scripts/claude-sdk-oauth-toolless-compact-probe.mjs [--mode toolless|always-tool] [--evidence <dir>]
+ */
+
+import { createServer } from "node:http";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { guardRealAuth, installCleanupHooks, makeSandbox, repoRoot, track } from "./lib/common.mjs";
+import { loopbackSseBody, seedProbeAgentDir } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+import { applyHermeticEnvironment, assertHermeticEnvironment } from "./lib/claude-sdk-oauth-hermetic-env.mjs";
+import { withTimeout } from "./lib/with-timeout.mjs";
+
+const ROOT = repoRoot();
+const MODEL_ID = "claude-haiku-4-5";
+const SEED_TURNS = 6;
+// Long USER turns (not replies) give the summarizer history beyond keepRecentTokens.
+const SEED_FILLER = "context ".repeat(300);
+const SUMMARY_TEXT = "PROBE_SUMMARY_OK: the conversation covered six token turns.";
+
+const argv = process.argv.slice(2);
+const modeArg = argv.indexOf("--mode");
+const mode = modeArg === -1 ? "toolless" : argv[modeArg + 1];
+const evidenceArg = argv.indexOf("--evidence");
+const evidenceDir = evidenceArg === -1 ? undefined : argv[evidenceArg + 1];
+if (mode !== "toolless" && mode !== "always-tool") {
+	process.stdout.write(`REJECTED signal=bad_mode detail=${mode}\n`);
+	process.exit(2);
+}
+
+installCleanupHooks();
+
+function toolUseSseBody(toolName, sequence) {
+	const input = JSON.stringify({ file_path: "/dev/null" });
+	const events = [
+		[
+			"message_start",
+			{
+				type: "message_start",
+				message: {
+					id: `msg_toolless_probe_${sequence}`,
+					type: "message",
+					role: "assistant",
+					model: MODEL_ID,
+					content: [],
+					stop_reason: null,
+					stop_sequence: null,
+					usage: { input_tokens: 12, output_tokens: 1, cache_read_input_tokens: 0 },
+				},
+			},
+		],
+		[
+			"content_block_start",
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "tool_use", id: `toolu_probe_${sequence}`, name: toolName, input: {} },
+			},
+		],
+		["content_block_delta", { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: input } }],
+		["content_block_stop", { type: "content_block_stop", index: 0 }],
+		["message_delta", { type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 8 } }],
+		["message_stop", { type: "message_stop" }],
+	];
+	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+}
+
+const requests = [];
+let phase = "seed";
+
+function startLoopbackServer() {
+	return new Promise((resolve, reject) => {
+		const server = track(
+			createServer((request, response) => {
+				if (request.method !== "POST") {
+					response.writeHead(200);
+					response.end();
+					return;
+				}
+				let raw = "";
+				request.setEncoding("utf8");
+				request.on("data", (chunk) => {
+					raw += chunk;
+				});
+				request.on("end", () => {
+					let body;
+					try {
+						body = JSON.parse(raw);
+					} catch {
+						body = {};
+					}
+					const tools = Array.isArray(body.tools) ? body.tools : [];
+					const sequence = requests.length + 1;
+					const toolNames = tools.map((tool) => tool?.name).filter((name) => typeof name === "string");
+					const entry = { sequence, phase, hasTools: tools.length > 0, toolCount: tools.length, toolNames: toolNames.slice(0, 12), bytes: raw.length, reply: "text" };
+					let sse;
+					if (phase === "compact" && (mode === "always-tool" || tools.length > 0)) {
+						// The hijack: a summarizer that is OFFERED tools calls one. Pick an
+						// offered tool when there is one so the CLI routes it through the
+						// host-denial hook exactly as production would.
+						const toolName = toolNames.find((name) => name === "Read") ?? toolNames[0] ?? "Read";
+						entry.reply = `tool_use:${toolName}`;
+						sse = toolUseSseBody(toolName, sequence);
+					} else {
+						sse = loopbackSseBody(phase === "compact" ? SUMMARY_TEXT : `TOKEN_T${sequence}`, sequence);
+					}
+					requests.push(entry);
+					response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+					response.end(sse);
+				});
+			}),
+		);
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			resolve({ server, baseUrl: `http://127.0.0.1:${address.port}` });
+		});
+	});
+}
+
+const authGuard = guardRealAuth();
+const box = makeSandbox("claude-sdk-toolless-compact-probe");
+let server;
+let session;
+let fatal;
+let outcome = { compacted: false };
+let closeSession;
+try {
+	({ server, baseUrl: box.baseUrl } = await startLoopbackServer());
+	seedProbeAgentDir(box.agentDir);
+	// Keep the retained tail tiny so six short turns leave history to summarize.
+	writeFileSync(join(box.agentDir, "settings.json"), JSON.stringify({ compaction: { keepRecentTokens: 400, reserveTokens: 1024 } }));
+	const claudeConfigDir = join(box.dir, "claude-config");
+	mkdirSync(claudeConfigDir, { recursive: true, mode: 0o700 });
+	writeFileSync(
+		join(claudeConfigDir, ".credentials.json"),
+		JSON.stringify({
+			claudeAiOauth: {
+				accessToken: "toolless-probe-dummy-access",
+				refreshToken: "toolless-probe-dummy-refresh",
+				expiresAt: 4102444800000,
+				scopes: ["user:inference", "user:profile", "user:sessions:claude_code"],
+			},
+		}),
+		{ mode: 0o600 },
+	);
+	applyHermeticEnvironment(process.env, {
+		HOME: box.dir,
+		USERPROFILE: box.dir,
+		TMPDIR: box.dir,
+		SENPI_CODING_AGENT_DIR: box.agentDir,
+		SENPI_CODING_AGENT_SESSION_DIR: box.sessionDir,
+		PI_OFFLINE: "1",
+		PI_TELEMETRY: "0",
+		ANTHROPIC_BASE_URL: box.baseUrl,
+		ANTHROPIC_API_KEY: "toolless-probe-dummy-key",
+		CLAUDE_CONFIG_DIR: claudeConfigDir,
+		CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+		CLAUDE_CODE_DISABLE_TELEMETRY: "1",
+		SENPI_CLAUDE_SDK_OAUTH_TOKEN_INJECTION: "ambient",
+		SENPI_CLAUDE_SDK_OAUTH_ENABLED: "1",
+		// senpi owns compaction on this lane: every request flattens through the
+		// non-resident path and the compaction extension stays fully active.
+		SENPI_CLAUDE_SDK_OAUTH_RESUME: "off",
+		NO_PROXY: "127.0.0.1,localhost",
+		no_proxy: "127.0.0.1,localhost",
+	});
+	assertHermeticEnvironment(process.env, box.baseUrl);
+
+	const sourceRoot = join(ROOT, "packages", "coding-agent", "src");
+	({ closeSession } = await import(
+		pathToFileURL(join(sourceRoot, "core", "extensions", "builtin", "claude-sdk-oauth", "session-registry.ts")).href
+	));
+	const { createAgentSession } = await import(pathToFileURL(join(sourceRoot, "index.ts")).href);
+	// Default tools stay registered: production sessions offer tools to the
+	// summarizer (anti-distillation shape), which is what the hijack retry gates on.
+	const created = await createAgentSession({ cwd: box.cwd, agentDir: box.agentDir, autoTitleSessions: false });
+	session = created.session;
+	track({
+		exitCode: null,
+		kill: () => {
+			try {
+				if (session?.id) closeSession(session.id, "probe_shutdown");
+			} catch {}
+			session.dispose();
+		},
+	});
+	const model = session.modelRuntime.getModel("claude-sdk-oauth", MODEL_ID);
+	if (!model) throw new Error("claude-sdk-oauth provider did not register its models");
+	await session.setModel(model);
+
+	for (let index = 1; index <= SEED_TURNS; index += 1) {
+		await withTimeout(session.prompt(`Turn ${index}: reply with TOKEN_T${index}. ${SEED_FILLER}`, { sessionTitlePrompt: false }), `seed turn ${index}`, 120_000);
+	}
+	const seedRequests = requests.length;
+
+	phase = "compact";
+	let compactError;
+	let result;
+	try {
+		result = await withTimeout(session.compact(), "manual compaction", 180_000);
+	} catch (error) {
+		compactError = error instanceof Error ? error.message : String(error);
+	}
+	const branch = session.sessionManager.getBranch();
+	const compactionEntry = [...branch].reverse().find((entry) => entry.type === "compaction");
+	const compactRequests = requests.slice(seedRequests);
+	outcome = {
+		mode,
+		seedRequests,
+		compactRequests,
+		compactError: compactError ?? null,
+		resultSummaryHead: typeof result?.summary === "string" ? result.summary.slice(0, 120) : null,
+		resultDetailsOrigin: result?.details?.origin ?? null,
+		resultFailureKind: result?.details?.failureKind ?? null,
+		compactionEntry: compactionEntry
+			? { id: compactionEntry.id, summaryHead: String(compactionEntry.summary ?? "").slice(0, 120), detailsOrigin: compactionEntry.details?.origin ?? null }
+			: null,
+		compacted: compactionEntry !== undefined && compactError === undefined,
+	};
+} catch (error) {
+	fatal = error instanceof Error ? error : new Error(String(error));
+} finally {
+	try {
+		if (session?.id && closeSession) closeSession(session.id, "probe_shutdown");
+	} catch {}
+	try {
+		session?.dispose?.();
+	} catch {}
+	if (server) await new Promise((resolve) => server.close(resolve));
+	try {
+		authGuard.assertUnchanged();
+	} catch (error) {
+		fatal = fatal ?? (error instanceof Error ? error : new Error(String(error)));
+	}
+	box.cleanup();
+}
+
+const infrastructureFailure =
+	fatal !== undefined &&
+	/loopback|ECONNREFUSED|EADDRINUSE|EACCES|did not bind|claude_binary_not_found|Native CLI binary.*not found|Claude native binary.*not found/i.test(fatal.message);
+
+let verdict;
+if (infrastructureFailure) {
+	verdict = `REJECTED signal=loopback_unreachable detail=${fatal.message}`;
+	process.exitCode = 2;
+} else if (fatal) {
+	verdict = `FAIL signal=probe_error detail=${fatal.message}`;
+	process.exitCode = 1;
+} else if (mode === "toolless") {
+	const toolless = outcome.compactRequests.find((entry) => !entry.hasTools);
+	const ok = outcome.compacted && toolless !== undefined && (outcome.compactionEntry?.summaryHead ?? "").includes("PROBE_SUMMARY_OK");
+	verdict = ok
+		? `PASS mode=toolless compactRequests=${outcome.compactRequests.length} toollessRequest=#${toolless.sequence} summary=${JSON.stringify(outcome.compactionEntry.summaryHead)}`
+		: `FAIL mode=toolless compacted=${outcome.compacted} toollessRequest=${toolless ? `#${toolless.sequence}` : "none"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
+	process.exitCode = ok ? 0 : 1;
+} else {
+	const ok = outcome.compacted && outcome.compactionEntry?.detailsOrigin === "required-compaction-recovery";
+	verdict = ok
+		? `PASS mode=always-tool compactRequests=${outcome.compactRequests.length} origin=${outcome.compactionEntry.detailsOrigin} failureKind=${outcome.resultFailureKind}`
+		: `FAIL mode=always-tool compacted=${outcome.compacted} origin=${outcome.compactionEntry?.detailsOrigin ?? "none"} error=${JSON.stringify(outcome.compactError)} requests=${JSON.stringify(outcome.compactRequests.map((r) => `${r.sequence}:${r.hasTools ? `tools(${r.toolCount})` : "no-tools"}->${r.reply}`))}`;
+	process.exitCode = ok ? 0 : 1;
+}
+process.stdout.write(`${verdict}\n`);
+if (evidenceDir) {
+	mkdirSync(evidenceDir, { recursive: true });
+	writeFileSync(join(evidenceDir, `toolless-compact-${mode}.json`), JSON.stringify({ verdict, outcome, fatal: fatal?.message ?? null }, null, 2));
+	process.stdout.write(`evidence=${join(evidenceDir, `toolless-compact-${mode}.json`)}\n`);
+}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-toolless-compact-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-toolless-compact-server.mjs
@@ -88,6 +88,7 @@ export function startToollessCompactServer(input) {
 				// A client that drops mid-body must fail closed as a recorded rejection,
 				// never as silence the probe would wait on.
 				request.on("error", (error) => {
+					if (failed) return;
 					failed = true;
 					rejected.push({ method: request.method, pathname, reason: `request-error:${error?.code ?? error?.message ?? "unknown"}` });
 					if (!response.headersSent) response.writeHead(400);

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-toolless-compact-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-toolless-compact-server.mjs
@@ -1,0 +1,135 @@
+/**
+ * Loopback Anthropic server for the tool-less compaction probe.
+ *
+ * Answers only `POST .../v1/messages` bodies that carry a `messages` array;
+ * anything else is rejected (404/400) and never recorded, so a mis-routed or
+ * malformed request cannot masquerade as a model reply in the evidence.
+ */
+
+import { createServer } from "node:http";
+import { loopbackSseBody } from "./claude-sdk-oauth-fullstack-support.mjs";
+import { track } from "./common.mjs";
+
+export function toolUseSseBody(toolName, sequence, modelId) {
+	const input = JSON.stringify({ file_path: "/dev/null" });
+	const events = [
+		[
+			"message_start",
+			{
+				type: "message_start",
+				message: {
+					id: `msg_toolless_probe_${sequence}`,
+					type: "message",
+					role: "assistant",
+					model: modelId,
+					content: [],
+					stop_reason: null,
+					stop_sequence: null,
+					usage: { input_tokens: 12, output_tokens: 1, cache_read_input_tokens: 0 },
+				},
+			},
+		],
+		[
+			"content_block_start",
+			{
+				type: "content_block_start",
+				index: 0,
+				content_block: { type: "tool_use", id: `toolu_probe_${sequence}`, name: toolName, input: {} },
+			},
+		],
+		[
+			"content_block_delta",
+			{ type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: input } },
+		],
+		["content_block_stop", { type: "content_block_stop", index: 0 }],
+		[
+			"message_delta",
+			{ type: "message_delta", delta: { stop_reason: "tool_use", stop_sequence: null }, usage: { output_tokens: 8 } },
+		],
+		["message_stop", { type: "message_stop" }],
+	];
+	return events.map(([event, data]) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+}
+
+function parseMessagesBody(raw) {
+	let body;
+	try {
+		body = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (typeof body !== "object" || body === null || Array.isArray(body) || !Array.isArray(body.messages)) return undefined;
+	return body;
+}
+
+/**
+ * @param {{ mode: "toolless" | "always-tool", modelId: string, summaryText: string, getPhase: () => "seed" | "compact" }} input
+ * @returns {Promise<{ server: import("node:http").Server, baseUrl: string, requests: object[], rejected: object[] }>}
+ */
+export function startToollessCompactServer(input) {
+	const requests = [];
+	const rejected = [];
+	return new Promise((resolve, reject) => {
+		const server = track(
+			createServer((request, response) => {
+				const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+				if (request.method !== "POST" || !pathname.endsWith("/v1/messages")) {
+					rejected.push({ method: request.method, pathname, reason: "route" });
+					response.writeHead(404);
+					response.end();
+					return;
+				}
+				let raw = "";
+				request.setEncoding("utf8");
+				request.on("data", (chunk) => {
+					raw += chunk;
+				});
+				request.on("end", () => {
+					const body = parseMessagesBody(raw);
+					if (!body) {
+						rejected.push({ method: request.method, pathname, reason: "body" });
+						response.writeHead(400);
+						response.end();
+						return;
+					}
+					const phase = input.getPhase();
+					const tools = Array.isArray(body.tools) ? body.tools : [];
+					const sequence = requests.length + 1;
+					const toolNames = tools.map((tool) => tool?.name).filter((name) => typeof name === "string");
+					const entry = {
+						sequence,
+						phase,
+						hasTools: tools.length > 0,
+						toolCount: tools.length,
+						toolNames: toolNames.slice(0, 12),
+						bytes: Buffer.byteLength(raw, "utf8"),
+						reply: "text",
+					};
+					let sse;
+					if (phase === "compact" && (input.mode === "always-tool" || tools.length > 0)) {
+						// The hijack: a summarizer that is OFFERED tools calls one. Pick an
+						// offered tool when there is one so the CLI routes it through the
+						// host-denial hook exactly as production would.
+						const toolName = toolNames.find((name) => name === "Read") ?? toolNames[0] ?? "Read";
+						entry.reply = `tool_use:${toolName}`;
+						sse = toolUseSseBody(toolName, sequence, input.modelId);
+					} else {
+						sse = loopbackSseBody(phase === "compact" ? input.summaryText : `TOKEN_T${sequence}`, sequence);
+					}
+					requests.push(entry);
+					response.writeHead(200, {
+						"content-type": "text/event-stream",
+						"cache-control": "no-cache",
+						connection: "keep-alive",
+					});
+					response.end(sse);
+				});
+			}),
+		);
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			resolve({ server, baseUrl: `http://127.0.0.1:${address.port}`, requests, rejected });
+		});
+	});
+}

--- a/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-toolless-compact-server.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/claude-sdk-oauth-toolless-compact-server.mjs
@@ -73,18 +73,33 @@ export function startToollessCompactServer(input) {
 		const server = track(
 			createServer((request, response) => {
 				const pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
-				if (request.method !== "POST" || !pathname.endsWith("/v1/messages")) {
+				if (request.method !== "POST" || pathname !== "/v1/messages") {
 					rejected.push({ method: request.method, pathname, reason: "route" });
 					response.writeHead(404);
 					response.end();
 					return;
 				}
 				let raw = "";
+				let failed = false;
 				request.setEncoding("utf8");
 				request.on("data", (chunk) => {
 					raw += chunk;
 				});
+				// A client that drops mid-body must fail closed as a recorded rejection,
+				// never as silence the probe would wait on.
+				request.on("error", (error) => {
+					failed = true;
+					rejected.push({ method: request.method, pathname, reason: `request-error:${error?.code ?? error?.message ?? "unknown"}` });
+					if (!response.headersSent) response.writeHead(400);
+					response.end();
+				});
+				request.on("aborted", () => {
+					if (failed) return;
+					failed = true;
+					rejected.push({ method: request.method, pathname, reason: "aborted" });
+				});
 				request.on("end", () => {
+					if (failed) return;
 					const body = parseMessagesBody(raw);
 					if (!body) {
 						rejected.push({ method: request.method, pathname, reason: "body" });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 - models.json custom models under extension-registered providers now inherit the extension's provider-level `api` and `baseUrl`, while extension catalog models remain available alongside new custom models.
 
+- Claude SDK OAuth compaction retries that forbid tool calls now send a genuinely tool-less request, preventing host-denied tool calls from producing an empty summary.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -4,7 +4,7 @@
 
 ### What changed
 
-- The non-resident Claude SDK OAuth lane now maps `toolChoice: "none"` to `tools: []`, enables strict MCP configuration for that request, and skips the custom-tools MCP server.
+- The non-resident Claude SDK OAuth lane now maps `toolChoice: "none"` to `tools: []`, enables strict MCP configuration and `maxTurns: 1` for that request, and skips the custom-tools MCP server.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,25 @@
 # claude-sdk-oauth
 
+## 2026-09-02 - Honor tool-less summarization requests
+
+### What changed
+
+- The non-resident Claude SDK OAuth lane now maps `toolChoice: "none"` to `tools: []`, enables strict MCP configuration for that request, and skips the custom-tools MCP server.
+
+### Why
+
+- Compaction's tool-use-hijack retry forbids tool calls with `toolChoice: "none"`. The lane previously ignored that option and still offered host-denied built-in and custom tools, causing an empty summary instead of allowing the retry to produce text.
+
+### Why an extension could not handle it
+
+- The SDK query options and custom MCP server are assembled inside this builtin provider lane before the SDK boundary. An external extension cannot alter those request-scoped options after provider dispatch.
+
+### Expected merge conflict zones
+
+- LOW in `options.ts` around `buildClaudeSdkOauthQueryOptions` tool selection and strict MCP configuration.
+- LOW in `stream.ts` around non-resident custom MCP server construction.
+
+
 ## 2026-08-21 - Cache provider settings loads by mtime+size to cut lock convoy
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -4,7 +4,7 @@
 
 ### What changed
 
-- The non-resident Claude SDK OAuth lane now maps `toolChoice: "none"` to `tools: []`, enables strict MCP configuration and `maxTurns: 1` for that request, and skips the custom-tools MCP server.
+- The non-resident Claude SDK OAuth lane maps explicit `toolChoice: "none"` requests to `tools: []`, strict MCP configuration, and `maxTurns: 1`, and skips the custom-tools MCP server. Empty tool contexts also send `tools: []` without changing strict MCP, turn limits, or normal MCP behavior.
 
 ### Why
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
@@ -245,12 +245,13 @@ export function buildClaudeSdkOauthQueryOptions(input: ClaudeSdkOauthQueryOption
 			: mode === "override"
 				? loadOverrideSystemPrompt(providerSettings.systemPromptFile)
 				: resolveCustomSystemPrompt(input.context.systemPrompt);
-	const toolLessRequest = input.streamOptions?.toolChoice === "none" || (input.context.tools?.length ?? 0) === 0;
+	const toolLessRequest = input.streamOptions?.toolChoice === "none";
+	const emptyToolContext = (input.context.tools?.length ?? 0) === 0;
 	const strictMcpConfig = toolLessRequest || (providerSettings.strictMcpConfig ?? !appendSystemPrompt);
 	const queryOptions: Options = {
 		cwd,
 		model: input.model.id,
-		tools: toolLessRequest ? [] : input.tools ? [...input.tools] : [...BUILTIN_SDK_TOOLS],
+		tools: toolLessRequest || emptyToolContext ? [] : input.tools ? [...input.tools] : [...BUILTIN_SDK_TOOLS],
 		permissionMode: "dontAsk",
 		includePartialMessages: true,
 		canUseTool,

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
@@ -260,6 +260,7 @@ export function buildClaudeSdkOauthQueryOptions(input: ClaudeSdkOauthQueryOption
 		settingSources: resolveSettingSources(providerSettings, mode, authLane),
 	};
 	if (input.pathToClaudeCodeExecutable) queryOptions.pathToClaudeCodeExecutable = input.pathToClaudeCodeExecutable;
+	if (toolLessRequest) queryOptions.maxTurns = 1;
 	if (strictMcpConfig) queryOptions.extraArgs = { "strict-mcp-config": null };
 
 	const reasoning = input.streamOptions?.reasoning;

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
@@ -245,7 +245,7 @@ export function buildClaudeSdkOauthQueryOptions(input: ClaudeSdkOauthQueryOption
 			: mode === "override"
 				? loadOverrideSystemPrompt(providerSettings.systemPromptFile)
 				: resolveCustomSystemPrompt(input.context.systemPrompt);
-	const toolLessRequest = input.streamOptions?.toolChoice === "none";
+	const toolLessRequest = input.streamOptions?.toolChoice === "none" || (input.context.tools?.length ?? 0) === 0;
 	const strictMcpConfig = toolLessRequest || (providerSettings.strictMcpConfig ?? !appendSystemPrompt);
 	const queryOptions: Options = {
 		cwd,

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/options.ts
@@ -245,11 +245,12 @@ export function buildClaudeSdkOauthQueryOptions(input: ClaudeSdkOauthQueryOption
 			: mode === "override"
 				? loadOverrideSystemPrompt(providerSettings.systemPromptFile)
 				: resolveCustomSystemPrompt(input.context.systemPrompt);
-	const strictMcpConfig = providerSettings.strictMcpConfig ?? !appendSystemPrompt;
+	const toolLessRequest = input.streamOptions?.toolChoice === "none";
+	const strictMcpConfig = toolLessRequest || (providerSettings.strictMcpConfig ?? !appendSystemPrompt);
 	const queryOptions: Options = {
 		cwd,
 		model: input.model.id,
-		tools: input.tools ? [...input.tools] : [...BUILTIN_SDK_TOOLS],
+		tools: toolLessRequest ? [] : input.tools ? [...input.tools] : [...BUILTIN_SDK_TOOLS],
 		permissionMode: "dontAsk",
 		includePartialMessages: true,
 		canUseTool,

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/stream.ts
@@ -68,7 +68,8 @@ export function streamClaudeSdkOauth(
 			if (sessionKey) toolWatch.reconcileWithContext(sessionKey, context);
 			const toolWatchNote = toolWatch.buildPromptNote(sessionKey, context, resolvedTools.customToolNameToSdk);
 			const providerSettings = loadClaudeSdkOauthProviderSettingsFromDisk(process.cwd());
-			const mcpServers = await buildCustomToolServers(resolvedTools.customTools);
+			const toolLessRequest = options?.toolChoice === "none";
+			const mcpServers = toolLessRequest ? undefined : await buildCustomToolServers(resolvedTools.customTools);
 			const executable = resolveClaudeCodeExecutable(defaultExecutableDeps());
 			const buildOptions = (authLane: Parameters<typeof buildClaudeSdkOauthQueryOptions>[0]["authLane"]) => {
 				const queryOptions = buildClaudeSdkOauthQueryOptions({

--- a/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
@@ -1,0 +1,101 @@
+import type { Api, Context, Model, Tool } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	BUILTIN_SDK_TOOLS,
+	CUSTOM_TOOLS_MCP_SERVER_NAME,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/tools.ts";
+import { buildClaudeSdkOauthQueryOptions } from "../src/core/extensions/builtin/claude-sdk-oauth/options.ts";
+import { resetSdkBoundary, overrideSdkBoundary, type Options, type SDKMessage } from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import { streamClaudeSdkOauth } from "../src/core/extensions/builtin/claude-sdk-oauth/stream.ts";
+
+const model: Model<Api> = {
+	id: "claude-sonnet-4-6",
+	name: "Claude test",
+	api: "claude-sdk-oauth",
+	provider: "claude-sdk-oauth",
+	baseUrl: "claude-sdk-oauth",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+const customTool: Tool = {
+	name: "lookup",
+	description: "Look something up",
+	parameters: { type: "object", properties: { query: { type: "string" } } },
+};
+
+function context(tools?: Tool[]): Context {
+	return { messages: [], ...(tools ? { tools } : {}) };
+}
+
+function successfulResult(result: string): SDKMessage {
+	return {
+		type: "result",
+		subtype: "success",
+		result,
+		stop_reason: "end_turn",
+		usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+	} as SDKMessage;
+}
+
+async function collect(stream: AsyncIterable<unknown>): Promise<void> {
+	for await (const _event of stream) {
+		// Drain the provider stream before reading its result.
+	}
+}
+
+afterEach(() => resetSdkBoundary());
+
+describe("claude-sdk-oauth tool-less requests", () => {
+	it("builds no SDK tools for toolChoice none while preserving normal tool options", () => {
+		const normal = buildClaudeSdkOauthQueryOptions({
+			model,
+			context: context([customTool]),
+			tools: ["mcp__custom-tools__lookup"],
+			providerSettings: {},
+		});
+		const toolLess = buildClaudeSdkOauthQueryOptions({
+			model,
+			context: context([customTool]),
+			tools: ["mcp__custom-tools__lookup"],
+			providerSettings: {},
+			streamOptions: { toolChoice: "none" },
+		});
+
+		expect(normal.tools).toEqual(["mcp__custom-tools__lookup"]);
+		expect(toolLess.tools).toEqual([]);
+		expect(toolLess.mcpServers).toBeUndefined();
+		expect(toolLess).not.toHaveProperty(CUSTOM_TOOLS_MCP_SERVER_NAME);
+		expect(
+			buildClaudeSdkOauthQueryOptions({ model, context: context(), providerSettings: {} }).tools,
+		).toEqual([...BUILTIN_SDK_TOOLS]);
+	});
+
+	it("does not attach custom MCP tools to a tool-less stream", async () => {
+		const calls: Options[] = [];
+		overrideSdkBoundary({
+			createSdkMcpServer: () => ({}) as never,
+			query: (input) => {
+				calls.push(input.options ?? {});
+				return {
+					async *[Symbol.asyncIterator]() {
+						yield successfulResult("summary");
+					},
+					interrupt: async () => {},
+					close: () => {},
+				};
+			},
+		});
+
+		const stream = streamClaudeSdkOauth(model, context([customTool]), { toolChoice: "none", streamKind: "auxiliary" });
+		await collect(stream);
+		await stream.result();
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.tools).toEqual([]);
+		expect(calls[0]?.mcpServers).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
@@ -1,5 +1,6 @@
-import type { Api, Context, Model, Tool } from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream, type Api, type AssistantMessageEventStream, type Context, type Model, type Tool } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
+import { generateSummaryMessage } from "../src/core/extensions/builtin/compaction/speculative-summary.ts";
 import {
 	BUILTIN_SDK_TOOLS,
 	CUSTOM_TOOLS_MCP_SERVER_NAME,
@@ -97,5 +98,55 @@ describe("claude-sdk-oauth tool-less requests", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0]?.tools).toEqual([]);
 		expect(calls[0]?.mcpServers).toBeUndefined();
+	});
+
+	it("carries the summarizer retry through a claude-sdk-oauth runtime boundary", async () => {
+		const calls: Options[] = [];
+		const runtime = {
+			stream: (_selectedModel: Model<Api>, requestContext: Context, streamOptions: Record<string, unknown>) => {
+				const queryOptions = buildClaudeSdkOauthQueryOptions({
+					model,
+					context: requestContext,
+					streamOptions: streamOptions as never,
+					tools: requestContext.tools?.map((tool) => `mcp__custom-tools__${tool.name}`),
+				});
+				calls.push(queryOptions);
+				const response = createAssistantMessageEventStream();
+				const message = {
+					role: "assistant",
+					content: [{ type: "text", text: "recovered summary" }],
+					api: "claude-sdk-oauth",
+					provider: "claude-sdk-oauth",
+					model: model.id,
+					usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+					stopReason: "stop",
+					timestamp: Date.now(),
+				};
+				response.push({ type: "done", reason: "stop", message } as never);
+				response.end();
+				return response as AssistantMessageEventStream;
+			},
+		};
+		const summaryContext = {
+			modelRegistry: { modelRuntime: runtime },
+		} as never;
+		const snapshot = {
+			model,
+			contextWindow: 200_000,
+			systemPrompt: "system",
+			tools: [customTool],
+		} as never;
+		const result = await generateSummaryMessage({
+			context: summaryContext,
+			snapshot,
+			messages: [],
+			prompt: { system: "system", user: "summarize" },
+			auth: {},
+			forbidToolCalls: true,
+		});
+
+		expect(result && "content" in result ? result.content : result).toEqual([{ type: "text", text: "recovered summary" }]);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.tools).toEqual([]);
 	});
 });

--- a/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
@@ -1,10 +1,7 @@
 import { createAssistantMessageEventStream, type Api, type AssistantMessageEventStream, type Context, type Model, type Tool } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it } from "vitest";
 import { generateSummaryMessage } from "../src/core/extensions/builtin/compaction/speculative-summary.ts";
-import {
-	BUILTIN_SDK_TOOLS,
-	CUSTOM_TOOLS_MCP_SERVER_NAME,
-} from "../src/core/extensions/builtin/claude-sdk-oauth/tools.ts";
+import { BUILTIN_SDK_TOOLS } from "../src/core/extensions/builtin/claude-sdk-oauth/tools.ts";
 import { buildClaudeSdkOauthQueryOptions } from "../src/core/extensions/builtin/claude-sdk-oauth/options.ts";
 import { resetSdkBoundary, overrideSdkBoundary, type Options, type SDKMessage } from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
 import { streamClaudeSdkOauth } from "../src/core/extensions/builtin/claude-sdk-oauth/stream.ts";
@@ -69,8 +66,18 @@ describe("claude-sdk-oauth tool-less requests", () => {
 		expect(normal.tools).toEqual(["mcp__custom-tools__lookup"]);
 		expect(toolLess.tools).toEqual([]);
 		expect(toolLess.maxTurns).toBe(1);
-		expect(toolLess.mcpServers).toBeUndefined();
-		expect(toolLess).not.toHaveProperty(CUSTOM_TOOLS_MCP_SERVER_NAME);
+		// Strict MCP is forced for the request even when the operator opted out,
+		// so the CLI cannot re-expose configured MCP tools to the summarizer.
+		expect(toolLess.extraArgs).toEqual({ "strict-mcp-config": null });
+		const optedOut = buildClaudeSdkOauthQueryOptions({
+			model,
+			context: context([customTool]),
+			tools: ["mcp__custom-tools__lookup"],
+			providerSettings: { strictMcpConfig: false },
+			streamOptions: { toolChoice: "none" },
+		});
+		expect(optedOut.tools).toEqual([]);
+		expect(optedOut.extraArgs).toEqual({ "strict-mcp-config": null });
 		const emptyContext = buildClaudeSdkOauthQueryOptions({ model, context: context(), providerSettings: {} });
 		expect(emptyContext.tools).toEqual([]);
 		expect(emptyContext.maxTurns).toBeUndefined();

--- a/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
@@ -98,6 +98,12 @@ describe("claude-sdk-oauth tool-less requests", () => {
 		expect(calls).toHaveLength(1);
 		expect(calls[0]?.tools).toEqual([]);
 		expect(calls[0]?.mcpServers).toBeUndefined();
+
+		const normalStream = streamClaudeSdkOauth(model, context([customTool]), { streamKind: "auxiliary" });
+		await collect(normalStream);
+		await normalStream.result();
+		expect(calls[1]?.tools).toEqual([]);
+		expect(calls[1]?.mcpServers).toEqual({ "custom-tools": {} });
 	});
 
 	it("carries the summarizer retry through a claude-sdk-oauth runtime boundary", async () => {

--- a/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
@@ -72,6 +72,9 @@ describe("claude-sdk-oauth tool-less requests", () => {
 		expect(toolLess).not.toHaveProperty(CUSTOM_TOOLS_MCP_SERVER_NAME);
 		expect(
 			buildClaudeSdkOauthQueryOptions({ model, context: context(), providerSettings: {} }).tools,
+		).toEqual([]);
+		expect(
+			buildClaudeSdkOauthQueryOptions({ model, context: context([customTool]), providerSettings: {} }).tools,
 		).toEqual([...BUILTIN_SDK_TOOLS]);
 	});
 

--- a/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
@@ -68,11 +68,12 @@ describe("claude-sdk-oauth tool-less requests", () => {
 
 		expect(normal.tools).toEqual(["mcp__custom-tools__lookup"]);
 		expect(toolLess.tools).toEqual([]);
+		expect(toolLess.maxTurns).toBe(1);
 		expect(toolLess.mcpServers).toBeUndefined();
 		expect(toolLess).not.toHaveProperty(CUSTOM_TOOLS_MCP_SERVER_NAME);
-		expect(
-			buildClaudeSdkOauthQueryOptions({ model, context: context(), providerSettings: {} }).tools,
-		).toEqual([]);
+		const emptyContext = buildClaudeSdkOauthQueryOptions({ model, context: context(), providerSettings: {} });
+		expect(emptyContext.tools).toEqual([]);
+		expect(emptyContext.maxTurns).toBe(1);
 		expect(
 			buildClaudeSdkOauthQueryOptions({ model, context: context([customTool]), providerSettings: {} }).tools,
 		).toEqual([...BUILTIN_SDK_TOOLS]);
@@ -106,6 +107,7 @@ describe("claude-sdk-oauth tool-less requests", () => {
 		await collect(normalStream);
 		await normalStream.result();
 		expect(calls[1]?.tools).toEqual([]);
+		expect(calls[1]?.maxTurns).toBeUndefined();
 		expect(calls[1]?.mcpServers).toEqual({ "custom-tools": {} });
 	});
 

--- a/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts
@@ -73,7 +73,8 @@ describe("claude-sdk-oauth tool-less requests", () => {
 		expect(toolLess).not.toHaveProperty(CUSTOM_TOOLS_MCP_SERVER_NAME);
 		const emptyContext = buildClaudeSdkOauthQueryOptions({ model, context: context(), providerSettings: {} });
 		expect(emptyContext.tools).toEqual([]);
-		expect(emptyContext.maxTurns).toBe(1);
+		expect(emptyContext.maxTurns).toBeUndefined();
+		expect(emptyContext.extraArgs).toBeUndefined();
 		expect(
 			buildClaudeSdkOauthQueryOptions({ model, context: context([customTool]), providerSettings: {} }).tools,
 		).toEqual([...BUILTIN_SDK_TOOLS]);


### PR DESCRIPTION
## Summary
- Make the claude-sdk-oauth lane honor compaction's `toolChoice: "none"` retry.
- Add focused unit and runtime-boundary coverage, tracker documentation, and an Unreleased changelog entry.

## Root cause
The lane ignored `streamOptions.toolChoice` and always offered SDK tools. `stream.ts` also always attached the custom-tools MCP server. Host denial hooks then ended tool-hijacked summarization turns without text, so the compaction retry remained a no-op and raised `SummaryGenerationError`.

## Fix
- Map `toolChoice: "none"` to `tools: []` in `buildClaudeSdkOauthQueryOptions`.
- Treat requests with no offered context tools as tool-less too; tool-bearing main turns retain their existing mapped tools.
- Force strict MCP configuration for that request only.
- Bound tool-less SDK queries to `maxTurns: 1`; requests with tools leave `maxTurns` undefined.
- Skip construction and attachment of the custom-tools MCP server for tool-less requests.
- Leave normal and resident main-turn behavior unchanged.

## Tests
RED (before production change):
```text
9c8e7c5e3

^[[1m^[[30m^[[46m RUN ^[[49m^[[39m^[[22m ^[[36mv4.1.11 ^[[39m^[[90m/private/tmp/ulw-senpi-20260902^[[39m

 ^[[31m❯^[[39m packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts ^[[2m(^[[22m^[[2m2 tests^[[22m^[[2m | ^[[22m^[[31m2 failed^[[39m^[[2m)^[[22m^[[32m 83^[[2mms^[[22m^[[39m
^[[31m     ^[[31m×^[[31m builds no SDK tools for toolChoice none while preserving normal tool options^[[39m^[[32m 6^[[2mms^[[22m^[[39m
^[[31m     ^[[31m×^[[31m does not attach custom MCP tools to a tool-less stream^[[39m^[[32m 76^[[2mms^[[22m^[[39m

^[[2m Test Files ^[[22m ^[[1m^[[31m1 failed^[[39m^[[22m^[[90m (1)^[[39m
^[[2m      Tests ^[[22m ^[[1m^[[31m2 failed^[[39m^[[22m^[[90m (2)^[[39m
^[[2m   Start at ^[[22m 15:05:20
^[[2m   Duration ^[[22m 1.87s^[[2m (transform 997ms, setup 0ms, import 1.66s, tests 83ms, environment 0ms)^[[22m


^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m^[[1m^[[41m Failed Tests 2 ^[[49m^[[22m^[[31m⎯⎯⎯⎯⎯⎯⎯^[[39m

^[[41m^[[1m FAIL ^[[22m^[[49m packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts^[[2m > ^[[22mclaude-sdk-oauth tool-less requests^[[2m > ^[[22mbuilds no SDK tools for toolChoice none while preserving normal tool options
^[[31m^[[1mAssertionError^[[22m: expected [ 'mcp__custom-tools__lookup' ] to deeply equal []^[[39m

^[[32m- Expected^[[39m
^[[31m+ Received^[[39m

^[[32m- []^[[39m
^[[31m+ [^[[39m
^[[31m+   "mcp__custom-tools__lookup",^[[39m
^[[31m+ ]^[[39m

^[[36m ^[[2m❯^[[22m packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts:^[[2m69:26^[[22m^[[39m
    ^[[90m 67|^[[39m
    ^[[90m 68|^[[39m   ^[[34mexpect^[[39m(normal^[[33m.^[[39mtools)^[[33m.^[[39m^[[34mtoEqual^[[39m([^[[32m"mcp__custom-tools__lookup"^[[39m])^[[33m;^[[39m
    ^[[90m 69|^[[39m   ^[[34mexpect^[[39m(toolLess^[[33m.^[[39mtools)^[[33m.^[[39m^[[34mtoEqual^[[39m([])^[[33m;^[[39m
    ^[[90m   |^[[39m                          ^[[31m^^[[39m
    ^[[90m 70|^[[39m   ^[[34mexpect^[[39m(toolLess^[[33m.^[[39mmcpServers)^[[33m.^[[39m^[[34mtoBeUndefined^[[39m()^[[33m;^[[39m
    ^[[90m 71|^[[39m   ^[[34mexpect^[[39m(toolLess)^[[33m.^[[39mnot^[[33m.^[[39m^[[34mtoHaveProperty^[[39m(^[[33mCUSTOM_TOOLS_MCP_SERVER_NAME^[[39m)^[[33m;^[[39m

^[[31m^[[2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯^[[22m^[[39m

^[[41m^[[1m FAIL ^[[22m^[[49m packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts^[[2m > ^[[22mclaude-sdk-oauth tool-less requests^[[2m > ^[[22mdoes not attach custom MCP tools to a tool-less stream
^[[31m^[[1mAssertionError^[[22m: expected { 'custom-tools': {} } to be undefined^[[39m

^[[32m- Expected:^[[39m
undefined

^[[31m+ Received:^[[39m
{
  "custom-tools": {},
}

^[[36m ^[[2m❯^[[22m packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts:^[[2m99:32^[[22m^[[39m
    ^[[90m 97|^[[39m   ^[[34mexpect^[[39m(calls)^[[33m.^[[39m^[[34mtoHaveLength^[[39m(^[[34m1^[[39m)^[[33m;^[[39m
    ^[[90m 98|^[[39m   ^[[34mexpect^[[39m(calls[^[[34m0^[[39m]^[[33m?.^[[39mtools)^[[33m.^[[39m^[[34mtoEqual^[[39m([])^[[33m;^[[39m
    ^[[90m 99|^[[39m   ^[[34mexpect^[[39m(calls[^[[34m0^[[39m]^[[33m?.^[[39mmcpServers)^[[33m.^[[39m^[[34mtoBeUndefined^[[39m()^[[33m;^[[39m
    ^[[90m   |^[[39m                                ^[[31m^^[[39m
    ^[[90m100|^[[39m  })^[[33m;^[[39m
    ^[[90m101|^[[39m })^[[33m;^[[39m

^[[31m^[[2m⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯^[[22m^[[39m

```

GREEN (after production change):
```text
9f43b7ddb

[build-all] phase 1: packages/tui, packages/pty, packages/telemetry, packages/protocol
[build-all] building packages/tui
[build-all] building packages/pty
[build-all] building packages/telemetry
[build-all] building packages/protocol

[build-all] phase 2: packages/ai, packages/client
[build-all] building packages/ai
[build-all] building packages/client

[build-all] phase 3: packages/agent
[build-all] building packages/agent

[build-all] phase 4: packages/session-backends/sqlite-node
[build-all] building packages/session-backends/sqlite-node

[build-all] phase 5: packages/coding-agent
[build-all] building packages/coding-agent

[build-all] phase 6: packages/server
[build-all] building packages/server

^[[1m^[[30m^[[46m RUN ^[[49m^[[39m^[[22m ^[[36mv4.1.11 ^[[39m^[[90m/private/tmp/ulw-senpi-20260902^[[39m

 ^[[32m✓^[[39m packages/coding-agent/test/claude-sdk-oauth-toolless-summary.test.ts ^[[2m(^[[22m^[[2m3 tests^[[22m^[[2m)^[[22m^[[32m 67^[[2mms^[[22m^[[39m

^[[2m Test Files ^[[22m ^[[1m^[[32m1 passed^[[39m^[[22m^[[90m (1)^[[39m
^[[2m      Tests ^[[22m ^[[1m^[[32m3 passed^[[39m^[[22m^[[90m (3)^[[39m
^[[2m   Start at ^[[22m 15:08:28
^[[2m   Duration ^[[22m 1.25s^[[2m (transform 743ms, setup 0ms, import 1.10s, tests 67ms, environment 0ms)^[[22m

$ node scripts/build-all.mjs
$ tsc -p tsconfig.build.json
$ tsc -p tsconfig.build.json
$ tsgo -p tsconfig.build.json
$ tsc -p tsconfig.build.json
$ tsc -p tsconfig.build.json
$ tsc -p tsconfig.build.json && shx chmod +x dist/cli.js && shx rm -rf dist/providers/data && shx cp -r src/providers/data dist/providers/data
$ tsc -p tsconfig.build.json
$ tsc -p tsconfig.build.json && node ./scripts/prepare-dist.mjs copy-sqlite-migrations
$ tsc -p tsconfig.build.json && bun run copy-assets && shx chmod +x dist/cli.js dist/rpc-entry.js && shx cp dist/cli.js dist/senpi && shx chmod +x dist/senpi
$ shx mkdir -p dist/modes/interactive/theme && shx cp src/modes/interactive/theme/*.json dist/modes/interactive/theme/ && shx mkdir -p dist/modes/interactive/assets && shx cp src/modes/interactive/assets/*.png dist/modes/interactive/assets/ && shx mkdir -p dist/core/export-html/vendor && shx cp src/core/export-html/template.html src/core/export-html/template.css src/core/export-html/template.js dist/core/export-html/ && shx cp src/core/export-html/vendor/*.js dist/core/export-html/vendor/ && shx mkdir -p dist/core/extensions/builtin/imagegen/skill && shx cp src/core/extensions/builtin/imagegen/skill/SKILL.md dist/core/extensions/builtin/imagegen/skill/
$ tsc -p tsconfig.build.json
```

Neighboring remote suites: 55 test files passed, 430 tests passed, 3 skipped.
Changelog gate: `changelog-gate: PASS - changes.md coverage complete (0 production path(s) covered); changelog entry updated (packages/coding-agent/CHANGELOG.md)`

## QA
- Remote targeted test passed with `ULW_REMOTE_BUILD=1` after the empty-context correction (3/3 tests).
- Remote claude-sdk-oauth suites, compaction retry suite, and both #723 regression suites passed.
- Local `bunx biome check` passed.
- No local test/build run was used; verification was performed remotely as required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The `claude-sdk-oauth` lane previously ignored compaction retries with `toolChoice: "none"`, allowing denied tool calls to produce empty summaries. It now sends one genuinely tool-less SDK turn so the retry can return text, while normal tool-bearing turns remain unchanged.

- Explicit tool-less requests use `tools: []`, `maxTurns: 1`, forced strict MCP, and no custom-tools MCP; empty tool contexts expose no SDK tools without changing MCP behavior or turn limits.
- Adds unit, runtime-boundary, and real `AgentSession.compact()` loopback coverage, including deterministic fallback when every summary request is hijacked.
- The probe accepts only valid `POST /v1/messages` requests and records malformed, misrouted, dropped, and aborted requests as rejected traffic without double-counting.
- Updates the `coding-agent` changelog and lane tracking documentation.

<sup>Written for commit 73c4aef9894a4c45b1201d4f788051206710afa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

