### PR TITLE
fix(compaction): recover manual compaction with deterministic fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 - Claude SDK OAuth compaction retries that forbid tool calls now send a genuinely tool-less request, preventing host-denied tool calls from producing an empty summary.
 
+- Manual `/compact` now recovers through the deterministic no-LLM fallback for classified summarizer failures, while unclassified failures remain fail-closed.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,25 @@
 # changes.md — builtin compaction policy
 
+## Recover classified manual compaction failures deterministically (2026-09-02)
+
+### What changed
+
+- Manual `/compact` requests now use the existing deterministic, no-LLM recovery when summarization fails with a classified failure (`summarization-timeout`, `upstream-stream-truncated`, `summarization-overflow-exhausted`, or `summarization-empty-summary`).
+- The recovery preserves the existing `required-compaction-recovery` diagnostic and failure kind; unclassified failures remain fail-closed.
+
+### Why
+
+A manual compaction is an explicit request to reduce context immediately. Failing closed on a classified summarizer failure could leave the session above its compaction threshold and eventually trip the compaction breaker, despite a safe local recovery already being available.
+
+### Why an extension could not handle it
+
+The fallback decision is made inside the builtin `session_before_compact` core route, where the summarizer failure classification, compaction preparation boundary, and breaker bookkeeping are coordinated. An external extension cannot safely admit this recovery after the builtin route throws.
+
+### Expected merge conflict zones
+
+- LOW: `extension-wiring.ts` required-compaction reason predicate.
+- LOW: compaction route tests and changelog entries.
+
 ## Emergency-prune counter emitted at its one true site (2026-09-01)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/extension-wiring.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/extension-wiring.ts
@@ -44,7 +44,7 @@ export function isAbortedAssistantMessage(event: { message: AgentMessage }): boo
 }
 
 export function isRequiredCompactionFallbackReason(reason: SessionBeforeCompactEvent["reason"]): boolean {
-	return reason === "threshold" || reason === "overflow";
+	return reason === "manual" || reason === "threshold" || reason === "overflow";
 }
 
 export function recentCheckpoint(ctx: ExtensionContext): checkpointState.AgentCheckpoint | null {

--- a/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
+++ b/packages/coding-agent/test/compaction/before-compact-error-surfacing.test.ts
@@ -190,11 +190,10 @@ describe("session_before_compact error surfacing", () => {
 		// When
 		const result = await harness.beforeCompact(createEvent(), harness.ctx);
 
-		// Then: the cancel reason names the real failure (no text + stop reason)
-		// instead of the undiagnosable "returned no summary".
+		// Then: this classified failure enters deterministic recovery, but the
+		// deliberately boundary-less fixture cannot retain a safe suffix.
 		expect(result?.cancel).toBe(true);
-		expect(result?.reason ?? "").toContain("no text");
-		expect(result?.reason ?? "").toContain("stopReason: length");
+		expect(result?.reason).toBe("deterministic compaction fallback cannot retain the prepared suffix");
 	});
 
 	it("cancels with the credential error when summarization auth is unavailable", async () => {

--- a/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
+++ b/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
@@ -131,7 +131,7 @@ describe("required compaction deterministic fallback", () => {
 		});
 	});
 
-	it("does not recover manual, aborted, or unrelated failures", async () => {
+	it("does not recover aborted or unrelated failures", async () => {
 		for (const testCase of [
 			{ reason: "threshold" as const, message: "upstream_stream_truncated", aborted: true, refusal: false },
 			{ reason: "threshold" as const, message: "unrelated provider refusal", aborted: false, refusal: false },

--- a/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
+++ b/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
@@ -133,7 +133,6 @@ describe("required compaction deterministic fallback", () => {
 
 	it("does not recover manual, aborted, or unrelated failures", async () => {
 		for (const testCase of [
-			{ reason: "manual" as const, message: "upstream_stream_truncated", aborted: false, refusal: false },
 			{ reason: "threshold" as const, message: "upstream_stream_truncated", aborted: true, refusal: false },
 			{ reason: "threshold" as const, message: "unrelated provider refusal", aborted: false, refusal: false },
 			{ reason: "threshold" as const, message: "upstream_stream_truncated", aborted: false, refusal: true },
@@ -176,7 +175,7 @@ describe("required compaction deterministic fallback", () => {
 	});
 
 	it("fails closed for every non-required reason even when typed truncation recovery would fit", async () => {
-		const nonRequiredReasons = ["manual", "pre_prompt", "branch", "extension"] satisfies CompactionReason[];
+		const nonRequiredReasons = ["pre_prompt", "branch", "extension"] satisfies CompactionReason[];
 		for (const reason of nonRequiredReasons) {
 			const handlers = createCompactionHandlers();
 			const harness = createBlockingContext({ usageTokens: 9_900 });

--- a/packages/coding-agent/test/compaction/summarization-tooluse-retry.test.ts
+++ b/packages/coding-agent/test/compaction/summarization-tooluse-retry.test.ts
@@ -173,7 +173,7 @@ describe("empty-summary deterministic fallback classification", () => {
 });
 
 describe("required compaction recovery from summarizer tool-call hijack", () => {
-	it("Given a threshold compaction whose summarizer only tool-calls When the handler runs Then the deterministic fallback engages instead of cancelling", async () => {
+	it("Given a manual compaction whose summarizer only tool-calls When the handler runs Then the deterministic fallback engages instead of cancelling", async () => {
 		const handlers = createCompactionHandlers();
 		const harness = createBlockingContext({ usageTokens: 9_900 });
 		harness.registration.setResponses([bareToolCallResponse()]);
@@ -184,9 +184,9 @@ describe("required compaction recovery from summarizer tool-call hijack", () => 
 		const result = await handlers.sessionBeforeCompact(
 			{
 				type: "session_before_compact",
-				reason: "threshold",
+				reason: "manual",
 				willRetry: false,
-				requestId: "tooluse-hijack-recovery",
+				requestId: "manual-tooluse-hijack-recovery",
 				preparation: preparation!,
 				branchEntries,
 				signal: new AbortController().signal,
@@ -204,5 +204,104 @@ describe("required compaction recovery from summarizer tool-call hijack", () => 
 				},
 			},
 		});
+
+		// Two subsequent unclassified threshold failures must not trip the breaker:
+		// the manual recovery itself must not have recorded a failure.
+		harness.registration.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "unclassified failure" }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "unclassified failure" }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "unclassified failure" }),
+		]);
+		for (let attempt = 0; attempt < 3; attempt++) {
+			await handlers.sessionBeforeCompact(
+				{
+					type: "session_before_compact",
+					reason: "threshold",
+					willRetry: false,
+					requestId: `breaker-probe-${attempt}`,
+					preparation: preparation!,
+					branchEntries,
+					signal: new AbortController().signal,
+				},
+				harness.ctx,
+			);
+		}
+		expect(harness.registration.getCallLog()).toHaveLength(4);
+	});
+
+	it("Given a manual compaction whose summarizer times out When the handler runs Then the deterministic fallback engages", async () => {
+		vi.useFakeTimers();
+		try {
+			const handlers = createCompactionHandlers();
+			const harness = createBlockingContext({ usageTokens: 9_900 });
+			harness.registration.setResponses([async () => await new Promise<never>(() => undefined)]);
+			const branchEntries = harness.ctx.sessionManager.getBranch();
+			const preparation = prepareCompaction(branchEntries, harness.ctx.getCompactionSettings(), true);
+			const resultPromise = handlers.sessionBeforeCompact(
+				{
+					type: "session_before_compact",
+					reason: "manual",
+					willRetry: false,
+					requestId: "manual-timeout-recovery",
+					preparation: preparation!,
+					branchEntries,
+					signal: new AbortController().signal,
+				},
+				harness.ctx,
+			);
+			await vi.advanceTimersByTimeAsync(120_001);
+			await expect(resultPromise).resolves.toMatchObject({
+				compaction: {
+					details: { origin: "required-compaction-recovery", failureKind: "summarization-timeout" },
+				},
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps idle and speculative-origin failures fail-closed", async () => {
+		for (const reason of ["pre_prompt", "extension"] as const) {
+			const handlers = createCompactionHandlers();
+			const harness = createBlockingContext({ usageTokens: 9_900 });
+			harness.registration.setResponses([bareToolCallResponse()]);
+			const branchEntries = harness.ctx.sessionManager.getBranch();
+			const preparation = prepareCompaction(branchEntries, harness.ctx.getCompactionSettings(), true);
+			const result = await handlers.sessionBeforeCompact(
+				{
+					type: "session_before_compact",
+					reason,
+					willRetry: false,
+					requestId: `fail-closed-${reason}`,
+					preparation: preparation!,
+					branchEntries,
+					signal: new AbortController().signal,
+				},
+				harness.ctx,
+			);
+			expect(result).toMatchObject({ cancel: true });
+			expect(result).not.toHaveProperty("compaction");
+		}
+	});
+
+	it("keeps manual auth failures fail-closed", async () => {
+		const handlers = createCompactionHandlers();
+		const harness = createBlockingContext({ usageTokens: 9_900, withAuth: false });
+		const branchEntries = harness.ctx.sessionManager.getBranch();
+		const preparation = prepareCompaction(branchEntries, harness.ctx.getCompactionSettings(), true);
+		const result = await handlers.sessionBeforeCompact(
+			{
+				type: "session_before_compact",
+				reason: "manual",
+				willRetry: false,
+				requestId: "manual-auth-failure",
+				preparation: preparation!,
+				branchEntries,
+				signal: new AbortController().signal,
+			},
+			harness.ctx,
+		);
+		expect(result).toMatchObject({ cancel: true });
+		expect(result).not.toHaveProperty("compaction");
 	});
 });


### PR DESCRIPTION
## Summary
- Recover user-initiated manual compaction through the existing deterministic no-LLM fallback for classified summarizer failures.
- Preserve fail-closed behavior for non-required routes and unclassified failures.

## Root cause
The core `session_before_compact` recovery gate only treated `threshold` and `overflow` as required routes. Manual `/compact` uses `reason: "manual"`, so classified summarizer failures propagated as cancellation instead of using the already-implemented deterministic recovery.

## Fix
- Include `manual` in `isRequiredCompactionFallbackReason`.
- Add handler-level tests for empty-summary and watchdog timeout recovery, non-required fail-closed behavior, and manual auth failure.
- Update the compaction tracker and coding-agent changelog.

## Tests
RED before production change:
```
2 failed | 7 passed (9)
manual empty-summary and manual timeout returned { cancel: true } instead of a deterministic compaction
```

GREEN after production change:
```
Test Files  1 passed (1)
Tests  9 passed (9)
```

Additional verification:
- Local compaction suite: 74 files, 533 tests passed.
- Biome: passed.
- Changelog gate: passed.
- Remote compaction suite: 72 passed, 2 pre-existing timeout failures in `blocking-compaction-review-hardening.test.ts` and `blocking-compaction-shared-retry.test.ts` (reproduced on rerun; changed tests all pass).

## Behavior change note
Manual `/compact` now recovers context deterministically for classified summarization failures (`summarization-timeout`, `upstream-stream-truncated`, `summarization-overflow-exhausted`, and `summarization-empty-summary`). Auth and other unclassified errors still fail closed; speculative/idle and other non-required routes are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Manual `/compact` previously cancelled on classified summarizer failures; it now uses the existing deterministic no-LLM fallback. Unclassified failures, including auth errors, and non-required routes still fail closed, while successful recovery does not record a breaker failure.

- Covers timeout, truncated-stream, overflow-exhausted, and empty-summary failures.
- Adds tests for manual recovery, fail-closed cases, and breaker bookkeeping.
- Documents the policy in the compaction changes log and `packages/coding-agent` changelog.

<sup>Written for commit bf42495296b325434c823e5c5d922683f781220e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

