### PR TITLE
fix(agent): name the stream-start knob in timeout errors

### DIFF
--- a/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-stream-start-knob-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/claude-sdk-oauth-stream-start-knob-probe.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Real-surface probe: a provider stream-start timeout on the claude-sdk-oauth
+ * lane must surface an error that names the knob users can raise
+ * (retry.provider.streamStartTimeoutMs).
+ *
+ * Drives createAgentSession() -> AgentSession.prompt() -> resident
+ * claude-sdk-oauth query -> the real Claude Code subprocess against a loopback
+ * Anthropic server that HOLDS its response past the configured 2s guard. No
+ * credentials, no network egress.
+ *
+ * Usage: bun .agents/skills/senpi-qa/scripts/claude-sdk-oauth-stream-start-knob-probe.mjs [--evidence <dir>]
+ */
+
+import { createServer } from "node:http";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { guardRealAuth, installCleanupHooks, makeSandbox, repoRoot, track } from "./lib/common.mjs";
+import { loopbackSseBody, seedProbeAgentDir } from "./lib/claude-sdk-oauth-fullstack-support.mjs";
+import { applyHermeticEnvironment, assertHermeticEnvironment } from "./lib/claude-sdk-oauth-hermetic-env.mjs";
+import { withTimeout } from "./lib/with-timeout.mjs";
+
+const ROOT = repoRoot();
+const MODEL_ID = "claude-haiku-4-5";
+const STREAM_START_TIMEOUT_MS = 2_000;
+const HOLD_MS = 12_000;
+const KNOB = "retry.provider.streamStartTimeoutMs";
+
+const argv = process.argv.slice(2);
+const evidenceArg = argv.indexOf("--evidence");
+const evidenceDir = evidenceArg === -1 ? undefined : argv[evidenceArg + 1];
+
+installCleanupHooks();
+
+const requests = [];
+function startLoopbackServer() {
+	return new Promise((resolve, reject) => {
+		const server = track(
+			createServer((request, response) => {
+				if (request.method !== "POST") {
+					response.writeHead(200);
+					response.end();
+					return;
+				}
+				request.resume();
+				request.on("end", () => {
+					const sequence = requests.length + 1;
+					requests.push({ sequence, heldMs: HOLD_MS });
+					// Hold the response past the stream-start guard, then answer so the
+					// CLI can wind down instead of leaking a socket.
+					const timer = setTimeout(() => {
+						if (response.destroyed) return;
+						response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+						response.end(loopbackSseBody("late reply", sequence));
+					}, HOLD_MS);
+					response.on("close", () => clearTimeout(timer));
+				});
+			}),
+		);
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolve({ server, baseUrl: `http://127.0.0.1:${server.address().port}` }));
+	});
+}
+
+const authGuard = guardRealAuth();
+const box = makeSandbox("claude-sdk-stream-start-knob-probe");
+let server;
+let session;
+let closeSession;
+let fatal;
+let outcome = { errorMessage: null, stopReason: null };
+try {
+	({ server, baseUrl: box.baseUrl } = await startLoopbackServer());
+	seedProbeAgentDir(box.agentDir);
+	writeFileSync(
+		join(box.agentDir, "settings.json"),
+		JSON.stringify({ retry: { enabled: false, provider: { streamStartTimeoutMs: STREAM_START_TIMEOUT_MS, timeoutMs: 60_000 } } }),
+	);
+	const claudeConfigDir = join(box.dir, "claude-config");
+	mkdirSync(claudeConfigDir, { recursive: true, mode: 0o700 });
+	writeFileSync(
+		join(claudeConfigDir, ".credentials.json"),
+		JSON.stringify({ claudeAiOauth: { accessToken: "knob-probe-dummy-access", refreshToken: "knob-probe-dummy-refresh", expiresAt: 4102444800000, scopes: ["user:inference", "user:profile", "user:sessions:claude_code"] } }),
+		{ mode: 0o600 },
+	);
+	applyHermeticEnvironment(process.env, {
+		HOME: box.dir,
+		USERPROFILE: box.dir,
+		TMPDIR: box.dir,
+		SENPI_CODING_AGENT_DIR: box.agentDir,
+		SENPI_CODING_AGENT_SESSION_DIR: box.sessionDir,
+		PI_OFFLINE: "1",
+		PI_TELEMETRY: "0",
+		ANTHROPIC_BASE_URL: box.baseUrl,
+		ANTHROPIC_API_KEY: "knob-probe-dummy-key",
+		CLAUDE_CONFIG_DIR: claudeConfigDir,
+		CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+		CLAUDE_CODE_DISABLE_TELEMETRY: "1",
+		SENPI_CLAUDE_SDK_OAUTH_TOKEN_INJECTION: "ambient",
+		SENPI_CLAUDE_SDK_OAUTH_ENABLED: "1",
+		NO_PROXY: "127.0.0.1,localhost",
+		no_proxy: "127.0.0.1,localhost",
+	});
+	assertHermeticEnvironment(process.env, box.baseUrl);
+
+	const sourceRoot = join(ROOT, "packages", "coding-agent", "src");
+	({ closeSession } = await import(pathToFileURL(join(sourceRoot, "core", "extensions", "builtin", "claude-sdk-oauth", "session-registry.ts")).href));
+	const { createAgentSession } = await import(pathToFileURL(join(sourceRoot, "index.ts")).href);
+	const created = await createAgentSession({ cwd: box.cwd, agentDir: box.agentDir, noTools: "all", autoTitleSessions: false });
+	session = created.session;
+	const model = session.modelRuntime.getModel("claude-sdk-oauth", MODEL_ID);
+	if (!model) throw new Error("claude-sdk-oauth provider did not register its models");
+	await session.setModel(model);
+	await withTimeout(session.prompt("Reply with TOKEN_KNOB.", { sessionTitlePrompt: false }), "stalled turn", 90_000);
+	const assistant = [...session.sessionManager.getBranch()].reverse().find((entry) => entry.type === "message" && entry.message?.role === "assistant");
+	outcome = {
+		requests: requests.length,
+		stopReason: assistant?.message?.stopReason ?? null,
+		errorMessage: assistant?.message?.errorMessage ?? null,
+	};
+} catch (error) {
+	fatal = error instanceof Error ? error : new Error(String(error));
+} finally {
+	try { if (session?.id && closeSession) closeSession(session.id, "probe_shutdown"); } catch {}
+	try { session?.dispose?.(); } catch {}
+	if (server) await new Promise((resolve) => server.close(resolve));
+	try { authGuard.assertUnchanged(); } catch (error) { fatal = fatal ?? (error instanceof Error ? error : new Error(String(error))); }
+	box.cleanup();
+}
+
+let verdict;
+if (fatal && /loopback|ECONNREFUSED|EADDRINUSE|claude_binary_not_found|Native CLI binary.*not found/i.test(fatal.message)) {
+	verdict = `REJECTED signal=loopback_unreachable detail=${fatal.message}`;
+	process.exitCode = 2;
+} else if (fatal) {
+	verdict = `FAIL signal=probe_error detail=${fatal.message}`;
+	process.exitCode = 1;
+} else {
+	const timedOut = typeof outcome.errorMessage === "string" && /stream start timed out/i.test(outcome.errorMessage);
+	const named = typeof outcome.errorMessage === "string" && outcome.errorMessage.includes(KNOB);
+	const ok = outcome.stopReason === "error" && timedOut && named;
+	verdict = ok
+		? `PASS stopReason=error knobNamed=true message=${JSON.stringify(outcome.errorMessage)}`
+		: `FAIL stopReason=${outcome.stopReason} timedOut=${timedOut} knobNamed=${named} message=${JSON.stringify(outcome.errorMessage)} requests=${outcome.requests}`;
+	process.exitCode = ok ? 0 : 1;
+}
+process.stdout.write(`${verdict}\n`);
+if (evidenceDir) {
+	mkdirSync(evidenceDir, { recursive: true });
+	const file = join(evidenceDir, "stream-start-knob.json");
+	writeFileSync(file, JSON.stringify({ verdict, outcome, fatal: fatal?.message ?? null }, null, 2));
+	process.stdout.write(`evidence=${file}\n`);
+}

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Provider stream-start timeout errors now name `retry.provider.streamStartTimeoutMs` and explain that `0` disables the guard.
+
 ### Removed
 
 ## [2026.9.2-2] - 2026-09-02

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -175,7 +175,7 @@ class StreamIdleTimeoutError extends Error {
 export class StreamStartTimeoutError extends Error {
 	constructor(timeoutMs: number) {
 		super(
-			`Provider stream start timed out after ${timeoutMs}ms (raise retry.provider.streamStartTimeoutMs, 0 disables)`,
+			`Provider stream start timed out after ${timeoutMs}ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)`,
 		);
 		this.name = "StreamStartTimeoutError";
 	}

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -172,9 +172,11 @@ class StreamIdleTimeoutError extends Error {
 // The wording must keep matching the retryable-error classifier
 // ("timed out" in packages/ai/src/utils/retry.ts) so a dead stream start is
 // retried instead of dead-ending the session.
-class StreamStartTimeoutError extends Error {
+export class StreamStartTimeoutError extends Error {
 	constructor(timeoutMs: number) {
-		super(`Provider stream start timed out after ${timeoutMs}ms`);
+		super(
+			`Provider stream start timed out after ${timeoutMs}ms (raise retry.provider.streamStartTimeoutMs, 0 disables)`,
+		);
 		this.name = "StreamStartTimeoutError";
 	}
 }

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,5 +1,23 @@
 # Changes
 
+## 2026-09-02 - Name the stream-start timeout setting
+
+### What changed
+
+- `StreamStartTimeoutError` now names `retry.provider.streamStartTimeoutMs` and explains that `0` disables the guard.
+
+### Why
+
+- A provider stream-start timeout must tell users which setting to raise when the configured bound is too aggressive.
+
+### Why an extension could not handle it
+
+- The error is constructed inside the core provider stream loop before extension code can alter its user-visible message.
+
+### Expected merge conflict zones
+
+- LOW: `agent-loop.ts` stream-start timeout error wording.
+
 ## 2026-08-29 - Propagate asynchronous shell capture callbacks
 
 ### What changed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -782,7 +782,7 @@ Conflict zone: `agent-loop.ts` `streamAssistantResponse` catch.
   session for 300s with zero events, zero usage, and nothing persisted. Observed in a donated
   5h session log where the same session hung deterministically on reopen while new sessions
   worked. After the first event arrives the idle bound governs as before.
-- The failure message `Provider stream start timed out after <ms>ms` deliberately contains
+- The failure message `Provider stream start timed out after <ms>ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)` deliberately contains
   "timed out" so the existing retryable-error classifier (`isRetryableErrorMessage`) retries
   it instead of dead-ending the session; the request-local abort controller tears the dead
   request down exactly like an idle timeout.

--- a/packages/agent/test/agent-loop-stream-start-timeout.test.ts
+++ b/packages/agent/test/agent-loop-stream-start-timeout.test.ts
@@ -6,7 +6,7 @@ import {
 	type Model,
 } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
-import { agentLoop } from "../src/agent-loop.ts";
+import { agentLoop, StreamStartTimeoutError } from "../src/agent-loop.ts";
 import type { AgentContext, AgentEvent, AgentLoopConfig, AgentMessage } from "../src/types.ts";
 
 /**
@@ -149,6 +149,9 @@ function findAssistant(messages: AgentMessage[]): AssistantMessage | undefined {
 }
 
 describe("agent loop stream-start timeout", () => {
+	it("names the setting that controls the stream-start timeout", () => {
+		expect(new StreamStartTimeoutError(123).message).toContain("retry.provider.streamStartTimeoutMs");
+	});
 	it("fails fast when the provider stream never emits a first event", async () => {
 		const config: AgentLoopConfig = {
 			model: createModel(),
@@ -166,7 +169,8 @@ describe("agent loop stream-start timeout", () => {
 		const { messages } = await collectAgentEvents(stream);
 		const assistantMessage = findAssistant(messages);
 		expect(assistantMessage?.stopReason).toBe("error");
-		expect(assistantMessage?.errorMessage).toBe("Provider stream start timed out after 20ms");
+		expect(assistantMessage?.errorMessage).toContain("Provider stream start timed out after 20ms");
+		expect(assistantMessage?.errorMessage).toContain("retry.provider.streamStartTimeoutMs");
 		expect(requestSignal?.aborted).toBe(true);
 		expect(String(requestSignal?.reason)).toContain("Provider stream start timed out after 20ms");
 	});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -660,7 +660,8 @@ describe("agentLoop with AgentMessage", () => {
 			const { events, messages } = await collectAgentEvents(stream, 500);
 			const assistantMessage = messages.find((message): message is AssistantMessage => message.role === "assistant");
 			expect(assistantMessage?.stopReason).toBe("error");
-			expect(assistantMessage?.errorMessage).toBe("Provider stream start timed out after 20ms");
+			expect(assistantMessage?.errorMessage).toContain("Provider stream start timed out after 20ms");
+			expect(assistantMessage?.errorMessage).toContain("retry.provider.streamStartTimeoutMs");
 			expect(events.map((event) => event.type)).toEqual([
 				"agent_start",
 				"turn_start",

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,21 @@
+## Actionable provider stream-start timeout guidance (2026-09-02)
+
+### What changed
+
+- `isProviderTimeoutError` accepts the actionable guidance suffix now appended to stream-start timeout messages while preserving strict matching of unrelated timeout text.
+
+### Why
+
+- Adding the setting name to a provider timeout must not disable retry classification.
+
+### Why an extension could not handle it
+
+- Timeout classification is centralized in the AI package and runs before coding-agent retry policy.
+
+### Expected merge conflict zones
+
+- LOW: `utils/retry.ts` provider timeout pattern.
+
 ## Cursor conversation cache eviction cannot break a live request (2026-08-31)
 
 ### What changed

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -360,7 +360,7 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
  * unrelated extension, command, or MCP timeout diagnostics.
  */
 const PROVIDER_STREAM_STALL_ERROR_PATTERN =
-	/^(?:Idle timeout waiting for provider stream after \d+ms|Provider stream start timed out after \d+ms)(?: \(|$)/i;
+	/^(?:Idle timeout waiting for provider stream after \d+ms|Provider stream start timed out after \d+ms(?: \([^)]*\))?)$/i;
 const PROVIDER_TRANSPORT_TIMEOUT_ERROR_PATTERN = /^Request timed out\.?$/i;
 
 export function isProviderStreamStallError(message: AssistantMessage): boolean {

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -360,7 +360,7 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
  * unrelated extension, command, or MCP timeout diagnostics.
  */
 const PROVIDER_STREAM_STALL_ERROR_PATTERN =
-	/^(?:Idle timeout waiting for provider stream after \d+ms|Provider stream start timed out after \d+ms)$/i;
+	/^(?:Idle timeout waiting for provider stream after \d+ms|Provider stream start timed out after \d+ms)(?: \(|$)/i;
 const PROVIDER_TRANSPORT_TIMEOUT_ERROR_PATTERN = /^Request timed out\.?$/i;
 
 export function isProviderStreamStallError(message: AssistantMessage): boolean {

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -118,6 +118,12 @@ describe("provider retry classification", () => {
 	it.each([
 		["Idle timeout waiting for provider stream after 300000ms", true, true],
 		["Provider stream start timed out after 90000ms", true, true],
+		[
+			"Provider stream start timed out after 90000ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)",
+			true,
+			true,
+		],
+		["Idle timeout waiting for provider stream after 5ms (x)", false, false],
 		["Request timed out.", false, true],
 		["Request timed out", false, true],
 		["Command timed out after 30000ms", false, false],
@@ -209,7 +215,8 @@ describe("provider retry classification", () => {
 			isProviderStreamStallError(
 				fauxAssistantMessage("", {
 					stopReason: "error",
-					errorMessage: "Provider stream start timed out after 90000ms",
+					errorMessage:
+						"Provider stream start timed out after 90000ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)",
 				}),
 			),
 		).toBe(true);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -869,7 +869,7 @@
   ending the turn after a single attempt. The retry-continuation watchdog was bounded by
   `retry.provider.streamRetryTimeoutMs` (30s) while the same retry was granted the configured
   `streamStartTimeoutMs` (90s), so a slow-but-alive provider was aborted 60s before its own deadline and the
-  turn surfaced `Provider stream start timed out after 90000ms` followed by `Aborted after 1 retry attempt`.
+  turn surfaced `Provider stream start timed out after 90000ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)` followed by `Aborted after 1 retry attempt`.
   The watchdog is now reconciled to the guard it grants, while still cancelling a retry that outlives it.
 - Published Senpi tarballs now retain the lockfile-recorded Babel 8 dependency closure inside the bundled codemode sidecar, preventing `@babel/parser` resolution failures during extension startup ([#923](https://github.com/code-yeongyu/senpi/issues/923)).
 - Headless Claude SDK OAuth continuation now restores a bounded SDK lineage from a private sidecar only after its
@@ -1136,7 +1136,7 @@
   second full compaction the moment you send your next message
   ([#853](https://github.com/code-yeongyu/senpi/pull/853)).
 
-- Provider stream stalls (`Provider stream start timed out after <n>ms` and `Idle timeout waiting for
+- Provider stream stalls (`Provider stream start timed out after <n>ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)` and `Idle timeout waiting for
   provider stream after <n>ms`) now use the same bounded retry budget as every other transient provider
   error instead of giving up after a single same-model attempt, so a turn no longer ends with
   `Retry failed after 1 attempts` while `retry.maxRetries` is 3. Retries also keep the configured provider

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Fixed
 
+- Provider retry continuation watchdog messages now name `retry.provider.streamStartTimeoutMs`; claude-sdk-oauth regression coverage pins SDK `api_retry` as stream liveness on query and resident paths.
+
 ### Removed
 
 ## [2026.9.2] - 2026-09-02

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -978,6 +978,18 @@ export function truncateToolResultBodies(
 // AgentSession Class
 // ============================================================================
 
+export function providerRetryWatchdogAbortMessage(
+	retryTimeoutMs: number | undefined,
+	streamStartTimeoutMs: number | undefined,
+): string {
+	return (
+		`Provider retry continuation watchdog timed out after ${retryTimeoutMs}ms` +
+		(streamStartTimeoutMs === undefined
+			? " (stream-start guard disabled; raise retry.provider.streamStartTimeoutMs, 0 disables)"
+			: ` (stream-start guard: ${streamStartTimeoutMs}ms; raise retry.provider.streamStartTimeoutMs, 0 disables)`)
+	);
+}
+
 export class AgentSession {
 	readonly agent: Agent;
 	readonly sessionManager: SessionManager;
@@ -6328,10 +6340,7 @@ export class AgentSession {
 				abortActive: () =>
 					this.agent.abort(
 						new ProviderRetryWatchdogAbortError(
-							`Provider retry continuation watchdog timed out after ${retryTimeoutMs}ms` +
-								(this.agent.streamStartTimeoutMs === undefined
-									? " (stream-start guard disabled)"
-									: ` (stream-start guard: ${this.agent.streamStartTimeoutMs}ms)`),
+							providerRetryWatchdogAbortMessage(retryTimeoutMs, this.agent.streamStartTimeoutMs),
 						),
 					),
 				timeoutMs: retryTimeoutMs,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1354,7 +1354,7 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
   reproduced the identical defect one layer up: `runBoundedRetryContinuation` aborted the attempt at 30s while
   the request still had 60s of its configured 90s stream-start budget left.
 - No attempt could therefore finish, so the bounded `retry.maxRetries` budget (default 3) collapsed into the
-  single user-visible `Provider stream start timed out after 90000ms` / `Aborted after 1 retry attempt`
+  single user-visible `Provider stream start timed out after 90000ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)` / `Aborted after 1 retry attempt`
   outcome. A slow-but-alive provider was again judged dead on a deadline it was never given.
 - Raising the watchdog to the granted guard preserves the wedge protection it was added for: the provider
   guards still fail a dead upstream, and the watchdog still cancels a retry that outlives every guard it was

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -18,6 +18,24 @@
 
 - LOW: models.json and extension composition in `packages/coding-agent/src/core/provider-composer.ts`.
 
+## 2026-09-02 - Name the retry stream-start setting
+
+### What changed
+
+- Provider retry continuation watchdog abort messages now name `retry.provider.streamStartTimeoutMs` and explain that `0` disables the guard.
+
+### Why
+
+- Users need an actionable setting name when a retry continuation watchdog reports a provider stream-start stall.
+
+### Why an extension could not handle it
+
+- The watchdog is owned by `AgentSession` and aborts the core agent directly, before extension hooks can rewrite the error.
+
+### Expected merge conflict zones
+
+- LOW: `agent-session.ts` retry watchdog abort message builder.
+
 ## 2026-08-31 - Session activity contract for host occupancy decisions
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -20,6 +20,24 @@
 - LOW in `stream.ts` around non-resident custom MCP server construction.
 
 
+## 2026-09-02 - Count SDK api_retry as stream liveness
+
+### What changed
+
+- Regression coverage pins that `system/api_retry` is the first stream event on both query and resident-pump paths.
+
+### Why
+
+- SDK retry notices prove the provider stream is alive and must prevent a false stream-start timeout before assistant content arrives.
+
+### Why an extension could not handle it
+
+- The SDK message-to-stream event boundary is internal to the builtin claude-sdk-oauth lane.
+
+### Expected merge conflict zones
+
+- LOW: claude-sdk-oauth stream regression tests.
+
 ## 2026-08-21 - Cache provider settings loads by mtime+size to cut lock convoy
 
 ### What changed

--- a/packages/coding-agent/test/aborted-error-label.test.ts
+++ b/packages/coding-agent/test/aborted-error-label.test.ts
@@ -58,12 +58,15 @@ describe("abortedErrorLabel", () => {
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "aborted",
-			errorMessage: "Provider stream start timed out after 90000ms",
+			errorMessage:
+				"Provider stream start timed out after 90000ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)",
 			timestamp: 0,
 		} satisfies AssistantMessage;
 		const rendered = abortedMessageForRendering(message, 1, "provider");
 		expect(rendered.errorMessage).toContain("Provider stream start timed out");
-		expect(message.errorMessage).toBe("Provider stream start timed out after 90000ms");
+		expect(message.errorMessage).toBe(
+			"Provider stream start timed out after 90000ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)",
+		);
 	});
 
 	it("includes a specific provider error without repeating generic abort wording", () => {

--- a/packages/coding-agent/test/claude-sdk-oauth-stream.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-stream.test.ts
@@ -67,6 +67,34 @@ async function collect<T>(stream: AsyncIterable<T>): Promise<T[]> {
 	return events;
 }
 
+const apiRetryMessage = sdkMessage({
+	type: "system",
+	subtype: "api_retry",
+	attempt: 1,
+	max_retries: 2,
+	retry_delay_ms: 1,
+	error_status: 429,
+	error: "rate limited",
+	uuid: "api-retry-1",
+	session_id: "session-1",
+});
+
+const assistantStreamMessages = [
+	sdkMessage({
+		type: "stream_event",
+		event: { type: "message_start", message: { usage: { input_tokens: 1, output_tokens: 0 } } },
+	}),
+	sdkMessage({
+		type: "stream_event",
+		event: { type: "content_block_start", index: 0, content_block: { type: "text" } },
+	}),
+	sdkMessage({
+		type: "stream_event",
+		event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hello" } },
+	}),
+	sdkMessage({ type: "stream_event", event: { type: "content_block_stop", index: 0 } }),
+];
+
 const scriptedMessages = [
 	sdkMessage({
 		type: "stream_event",
@@ -202,17 +230,32 @@ class StalledResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> 
 	}
 }
 
+const residentApiRetryGate = (() => {
+	let release!: () => void;
+	const promise = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	return { promise, release };
+})();
+
 class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
 	readonly submitted: SDKUserMessage[] = [];
 	readonly options: Options;
 	closes = 0;
 	private readonly initializationError: Error | undefined;
+	private readonly includeApiRetry: boolean;
 	private readonly queued: SDKMessage[] = [];
 	private readonly readers: Array<(value: IteratorResult<SDKMessage>) => void> = [];
 
-	constructor(prompt: AsyncIterable<SDKUserMessage>, options: Options, initializationError?: Error) {
+	constructor(
+		prompt: AsyncIterable<SDKUserMessage>,
+		options: Options,
+		initializationError?: Error,
+		includeApiRetry = false,
+	) {
 		this.options = options;
 		this.initializationError = initializationError;
+		this.includeApiRetry = includeApiRetry;
 		void this.consume(prompt);
 	}
 
@@ -250,6 +293,11 @@ class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
 			const uuid = message.uuid ?? `submitted-${this.submitted.length}`;
 			const sessionId = message.session_id;
 			this.emit(sdkMessage({ ...message, uuid, session_id: sessionId, isReplay: true }));
+			if (this.includeApiRetry) {
+				this.emit(apiRetryMessage);
+				if (textFrom(message) === "next") await residentApiRetryGate.promise;
+				for (const streamMessage of assistantStreamMessages) this.emit(streamMessage);
+			}
 			this.emit(
 				sdkMessage({
 					type: "assistant",
@@ -270,6 +318,16 @@ class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
 				}),
 			);
 		}
+	}
+}
+
+class ResidentQueryWithApiRetry extends ResidentQuery {
+	constructor(prompt: AsyncIterable<SDKUserMessage>, options: Options) {
+		super(prompt, options, undefined, true);
+	}
+
+	releaseAssistant(): void {
+		residentApiRetryGate.release();
 	}
 }
 
@@ -403,6 +461,55 @@ afterEach(() => {
 });
 
 describe("Claude SDK OAuth stream events", () => {
+	it("counts api_retry as the first event on the non-resident query path", async () => {
+		overrideSdkBoundary({
+			query: scriptedQuery([
+				apiRetryMessage,
+				...assistantStreamMessages,
+				sdkMessage({ type: "result", subtype: "success", result: "hello", stop_reason: "end_turn" }),
+			]),
+		});
+		const events = await collect(streamClaudeSdkOauth(model, { messages: [] }));
+		expect(events[0]).toMatchObject({ type: "start" });
+		expect(events.findIndex((event) => event.type === "start")).toBeLessThan(
+			events.findIndex((event) => event.type === "text_delta"),
+		);
+	});
+
+	it("counts api_retry as the first event on the resident pump path after replay claim", async () => {
+		let retryQuery: ResidentQueryWithApiRetry | undefined;
+		residentBoundary(new Set(), (prompt, options) => {
+			retryQuery = new ResidentQueryWithApiRetry(prompt, options);
+			return retryQuery;
+		});
+		const sessionId = "resident-api-retry-start";
+		const first = await streamClaudeSdkOauth(
+			model,
+			{ messages: [{ role: "user", content: "seed", timestamp: 1 }] },
+			mainOptions(sessionId),
+		);
+		await first.result();
+		const stream = streamClaudeSdkOauth(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "seed", timestamp: 1 },
+					assistant("old", 2),
+					{ role: "user", content: "next", timestamp: 3 },
+				],
+			},
+			mainOptions(sessionId),
+		);
+		const iterator = stream[Symbol.asyncIterator]();
+		const start = await iterator.next();
+		expect(start).toMatchObject({ value: { type: "start" }, done: false });
+		retryQuery?.releaseAssistant();
+		const events = [start.value!, ...(await collect({ [Symbol.asyncIterator]: () => iterator }))];
+		expect(events.findIndex((event) => event.type === "start")).toBeLessThan(
+			events.findIndex((event) => event.type === "text_delta"),
+		);
+	});
+
 	it("maps stream events, drains through the terminal result, and uses its usage and stop reason", async () => {
 		let consumedTerminalResult = false;
 		overrideSdkBoundary({

--- a/packages/coding-agent/test/claude-sdk-oauth-stream.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-stream.test.ts
@@ -230,20 +230,13 @@ class StalledResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> 
 	}
 }
 
-const residentApiRetryGate = (() => {
-	let release!: () => void;
-	const promise = new Promise<void>((resolve) => {
-		release = resolve;
-	});
-	return { promise, release };
-})();
-
 class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
 	readonly submitted: SDKUserMessage[] = [];
 	readonly options: Options;
 	closes = 0;
 	private readonly initializationError: Error | undefined;
 	private readonly includeApiRetry: boolean;
+	private readonly apiRetryGate: { promise: Promise<void>; release: () => void } | undefined;
 	private readonly queued: SDKMessage[] = [];
 	private readonly readers: Array<(value: IteratorResult<SDKMessage>) => void> = [];
 
@@ -252,10 +245,12 @@ class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
 		options: Options,
 		initializationError?: Error,
 		includeApiRetry = false,
+		apiRetryGate?: { promise: Promise<void>; release: () => void },
 	) {
 		this.options = options;
 		this.initializationError = initializationError;
 		this.includeApiRetry = includeApiRetry;
+		this.apiRetryGate = apiRetryGate;
 		void this.consume(prompt);
 	}
 
@@ -295,7 +290,7 @@ class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
 			this.emit(sdkMessage({ ...message, uuid, session_id: sessionId, isReplay: true }));
 			if (this.includeApiRetry) {
 				this.emit(apiRetryMessage);
-				if (textFrom(message) === "next") await residentApiRetryGate.promise;
+				if (textFrom(message) === "next") await this.apiRetryGate?.promise;
 				for (const streamMessage of assistantStreamMessages) this.emit(streamMessage);
 			}
 			this.emit(
@@ -322,12 +317,12 @@ class ResidentQuery implements SdkQueryHandle, AsyncIterator<SDKMessage> {
 }
 
 class ResidentQueryWithApiRetry extends ResidentQuery {
-	constructor(prompt: AsyncIterable<SDKUserMessage>, options: Options) {
-		super(prompt, options, undefined, true);
-	}
-
-	releaseAssistant(): void {
-		residentApiRetryGate.release();
+	constructor(
+		prompt: AsyncIterable<SDKUserMessage>,
+		options: Options,
+		apiRetryGate: { promise: Promise<void>; release: () => void },
+	) {
+		super(prompt, options, undefined, true, apiRetryGate);
 	}
 }
 
@@ -477,11 +472,14 @@ describe("Claude SDK OAuth stream events", () => {
 	});
 
 	it("counts api_retry as the first event on the resident pump path after replay claim", async () => {
-		let retryQuery: ResidentQueryWithApiRetry | undefined;
-		residentBoundary(new Set(), (prompt, options) => {
-			retryQuery = new ResidentQueryWithApiRetry(prompt, options);
-			return retryQuery;
-		});
+		let releaseApiRetry!: () => void;
+		const apiRetryGate = {
+			promise: new Promise<void>((resolve) => {
+				releaseApiRetry = resolve;
+			}),
+			release: () => releaseApiRetry(),
+		};
+		residentBoundary(new Set(), (prompt, options) => new ResidentQueryWithApiRetry(prompt, options, apiRetryGate));
 		const sessionId = "resident-api-retry-start";
 		const first = await streamClaudeSdkOauth(
 			model,
@@ -501,13 +499,18 @@ describe("Claude SDK OAuth stream events", () => {
 			mainOptions(sessionId),
 		);
 		const iterator = stream[Symbol.asyncIterator]();
-		const start = await iterator.next();
-		expect(start).toMatchObject({ value: { type: "start" }, done: false });
-		retryQuery?.releaseAssistant();
-		const events = [start.value!, ...(await collect({ [Symbol.asyncIterator]: () => iterator }))];
-		expect(events.findIndex((event) => event.type === "start")).toBeLessThan(
-			events.findIndex((event) => event.type === "text_delta"),
-		);
+		try {
+			const start = await iterator.next();
+			expect(start).toMatchObject({ value: { type: "start" }, done: false });
+			const eventsPromise = collect({ [Symbol.asyncIterator]: () => iterator });
+			releaseApiRetry();
+			const events = [start.value!, ...(await eventsPromise)];
+			expect(events.findIndex((event) => event.type === "start")).toBeLessThan(
+				events.findIndex((event) => event.type === "text_delta"),
+			);
+		} finally {
+			releaseApiRetry();
+		}
 	});
 
 	it("maps stream events, drains through the terminal result, and uses its usage and stop reason", async () => {

--- a/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
+++ b/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
@@ -10,7 +10,7 @@ const STREAM_RETRY_TIMEOUT_MS = 30_000;
 function stallMessage() {
 	return fauxAssistantMessage("", {
 		stopReason: "error",
-		errorMessage: `Provider stream start timed out after ${STREAM_START_TIMEOUT_MS}ms`,
+		errorMessage: `Provider stream start timed out after ${STREAM_START_TIMEOUT_MS}ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)`,
 	});
 }
 

--- a/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
+++ b/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
@@ -1,5 +1,6 @@
 import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { providerRetryWatchdogAbortMessage } from "../src/core/agent-session.ts";
 import { createProviderTimeoutRetryPlan, runBoundedRetryContinuation } from "../src/core/provider-timeout-retry.ts";
 
 const STREAM_START_TIMEOUT_MS = 90_000;
@@ -41,6 +42,9 @@ async function runRetryAttempt(watchdogTimeoutMs: number | undefined, respondsAf
 }
 
 describe("bounded retry continuation", () => {
+	it("names the setting that controls the retry stream-start guard", () => {
+		expect(providerRetryWatchdogAbortMessage(12_345, 6_789)).toContain("retry.provider.streamStartTimeoutMs");
+	});
 	beforeEach(() => {
 		vi.useFakeTimers();
 	});

--- a/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
+++ b/packages/coding-agent/test/provider-timeout-retry-continuation.test.ts
@@ -42,8 +42,16 @@ async function runRetryAttempt(watchdogTimeoutMs: number | undefined, respondsAf
 }
 
 describe("bounded retry continuation", () => {
-	it("names the setting that controls the retry stream-start guard", () => {
-		expect(providerRetryWatchdogAbortMessage(12_345, 6_789)).toContain("retry.provider.streamStartTimeoutMs");
+	it("pins the enabled watchdog guidance", () => {
+		expect(providerRetryWatchdogAbortMessage(12_345, 6_789)).toBe(
+			"Provider retry continuation watchdog timed out after 12345ms (stream-start guard: 6789ms; raise retry.provider.streamStartTimeoutMs, 0 disables)",
+		);
+	});
+
+	it("pins the disabled stream-start watchdog guidance", () => {
+		expect(providerRetryWatchdogAbortMessage(12_345, undefined)).toBe(
+			"Provider retry continuation watchdog timed out after 12345ms (stream-start guard disabled; raise retry.provider.streamStartTimeoutMs, 0 disables)",
+		);
 	});
 	beforeEach(() => {
 		vi.useFakeTimers();

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -277,7 +277,7 @@ describe("provider idle recovery", () => {
 				{
 					success: false,
 					attempt: 1,
-					finalError: `Provider stream start timed out after ${DEFAULT_STREAM_START_TIMEOUT_MS}ms`,
+					finalError: `Provider stream start timed out after ${DEFAULT_STREAM_START_TIMEOUT_MS}ms (raise retry.provider.streamStartTimeoutMs, 0 disables)`,
 				},
 			]);
 			expect(harness.eventsOfType("auto_retry_end").map((event) => event.finalError)).not.toContain(

--- a/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
+++ b/packages/coding-agent/test/suite/regressions/provider-idle-recovery.test.ts
@@ -277,7 +277,7 @@ describe("provider idle recovery", () => {
 				{
 					success: false,
 					attempt: 1,
-					finalError: `Provider stream start timed out after ${DEFAULT_STREAM_START_TIMEOUT_MS}ms (raise retry.provider.streamStartTimeoutMs, 0 disables)`,
+					finalError: `Provider stream start timed out after ${DEFAULT_STREAM_START_TIMEOUT_MS}ms (raise streamStartTimeoutMs — retry.provider.streamStartTimeoutMs in senpi settings; 0 disables)`,
 				},
 			]);
 			expect(harness.eventsOfType("auto_retry_end").map((event) => event.finalError)).not.toContain(


### PR DESCRIPTION
## Summary

Name `retry.provider.streamStartTimeoutMs` in provider stream-start timeout errors, and pin Claude SDK OAuth `system/api_retry` as stream liveness on both query paths.

## Why

Users need an actionable knob when a provider stream-start guard fires. SDK API retry notices prove the stream is alive and must start the provider stream before assistant content arrives.

## Changes

- Exported `StreamStartTimeoutError` and added the setting name plus `0 disables` guidance.
- Added an `AgentSession` watchdog message builder with the same setting guidance.
- Updated `isProviderTimeoutError` to preserve classification for the guided suffix while remaining strict for unrelated timeout text.
- Added non-resident and resident claude-sdk-oauth regressions. The resident fixture holds assistant frames until after the `api_retry`-driven start is observed.
- Added canonical tracker entries and `[Unreleased]` changelog entries.

Consumer analysis: `packages/ai/src/utils/retry.ts` previously matched the complete stream-start message with an end anchor, so the new actionable suffix required a suffix-tolerant pattern. `provider-timeout-retry.ts` consumes `isProviderTimeoutError`; agent-session classification call sites remain unchanged. `ProviderRetryWatchdogAbortError` is only constructed at the retry continuation watchdog seam, now through the tested builder. The leading `Provider stream start timed out after <n>ms` phrase remains stable.

## Tests

- Local RED (before source message edits): agent assertion failed because received `Provider stream start timed out after 20ms` lacked `retry.provider.streamStartTimeoutMs`.
- Local mutation-RED (temporarily skipped `system/api_retry` delivery in `session-registry-pump.ts`): resident regression failed/timed out while waiting for the gated stream, proving the test depends on API retry delivery. Production file restored before commit.
- Local GREEN: agent stream-start test 6 passed; coding-agent OAuth/retry tests 21 passed; AI retry tests 77 passed.
- Remote forced-build GREEN: 6 files, 39 tests passed.
- Remote post-build GREEN: 6 files, 39 tests passed.
- Pre-commit full biome, dependency/lock checks, TypeScript, and browser smoke checks passed.
- `scripts/check-pr-changelog.mjs --base 69d9437cd` passed.

Evidence files:
- `/tmp/ulw-g3-evidence/red-agent-after-install.txt`
- `/tmp/ulw-g3-evidence/mutation-red-final.txt`
- `/tmp/ulw-g3-evidence/green-agent-final.txt`
- `/tmp/ulw-g3-evidence/green-coding-final.txt`
- `/tmp/ulw-g3-evidence/remote-green-final.txt`
- `/tmp/ulw-g3-evidence/remote-green-postbuild.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provider stream-start timeout errors now name `retry.provider.streamStartTimeoutMs` and say that `0` disables the guard; previously they only reported the elapsed time. Users now have an actionable setting when the timeout fires.

**Bug Fixes**
- `AgentSession` retry watchdog abort messages include the same guidance and state whether the stream-start guard is enabled.
- The retryable-error classifier accepts the new suffix but still rejects unrelated timeout text.
- Regression tests pin `claude-sdk-oauth` `system/api_retry` as the first liveness event on both query and resident paths.
- The idle-recovery regression follows the new wording.
- Adds a loopback probe that holds a `claude-sdk-oauth` response past the guard and verifies the surfaced error names the knob.

<sup>Written for commit d3773d5ae0cc9d55d066d5166d6e23e3d6abe4e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

