### PR TITLE
fix: make provider retry and stream-start timeouts tolerant of slow thinking models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- The `senpi-default` retry profile is more patient with slow long-thinking providers (Opus/Fable-class with xhigh thinking): the turn-stage retry budget rises from 3 to 5 attempts, matching opencode's session retry budget and codex's `stream_max_retries` default, and the provider-stage server-hint ceiling rises from 60s to 300s, so a server-requested `Retry-After` longer than 60s is waited out instead of failing the turn instantly (opencode honors such hints uncapped, codex honors server-advised delays, oh-my-pi caps them at 300s).
+- The `senpi-default` retry profile is more patient with slow long-thinking providers (Opus/Fable-class with xhigh thinking): the turn-stage retry budget rises from 3 to 5 attempts, matching opencode's session retry budget and codex's `stream_max_retries` default. Backoff shapes, failure classification, `providerRequest.maxRetries` (still 0) and `KIMI_CODE_RETRY_PROFILE` are unchanged.
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- The `senpi-default` retry profile is more patient with slow long-thinking providers (Opus/Fable-class with xhigh thinking): the turn-stage retry budget rises from 3 to 5 attempts, matching opencode's session retry budget and codex's `stream_max_retries` default, and the provider-stage server-hint ceiling rises from 60s to 300s, so a server-requested `Retry-After` longer than 60s is waited out instead of failing the turn instantly (opencode honors such hints uncapped, codex honors server-advised delays, oh-my-pi caps them at 300s).
+
 ### Fixed
 
 ### Removed

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,21 @@
+## senpi-default retry profile is more patient with slow providers (2026-09-02)
+
+### What changed
+
+- `utils/retry-profile/profiles.ts`: `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries` goes from 3 to 5, and the `providerRequest` server-hint ceiling from 60s to 300s. Backoff shapes, the `error-with-marker` overflow behavior, `providerRequest.maxRetries` (still 0, so no hidden second budget), and `KIMI_CODE_RETRY_PROFILE` are untouched.
+
+### Why
+
+- Opus/Fable-class models with xhigh thinking make transient provider failures and long server-requested waits more likely per turn, and the previous budgets were the least tolerant of the harnesses we compared: opencode retries a session 5 times and honors `Retry-After` uncapped, codex defaults to `stream_max_retries` 5 and honors server-advised delays, and oh-my-pi allows up to 10 agent retries with a 300s hint cap. A 60s ceiling turned any provider asking for 61s into an instantly failed turn even though the turn stage's own hinted wait cap is already 300s.
+
+### Why an extension could not handle it
+
+- Shipped profile constants are read by the provider-request and turn retry planners before any extension seam exists; an extension can only override them per provider through settings, not change what every session inherits.
+
+### Expected merge conflict zones
+
+- LOW: the two constant lines inside `SENPI_DEFAULT_RETRY_PROFILE` in `utils/retry-profile/profiles.ts`.
+
 ## Actionable provider stream-start timeout guidance (2026-09-02)
 
 ### What changed

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -2,11 +2,11 @@
 
 ### What changed
 
-- `utils/retry-profile/profiles.ts`: `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries` goes from 3 to 5, and the `providerRequest` server-hint ceiling from 60s to 300s. Backoff shapes, the `error-with-marker` overflow behavior, `providerRequest.maxRetries` (still 0, so no hidden second budget), and `KIMI_CODE_RETRY_PROFILE` are untouched.
+- `utils/retry-profile/profiles.ts`: `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries` goes from 3 to 5. Backoff shapes, the server-hint policies, `providerRequest.maxRetries` (still 0, so no hidden second budget), and `KIMI_CODE_RETRY_PROFILE` are untouched.
 
 ### Why
 
-- Opus/Fable-class models with xhigh thinking make transient provider failures and long server-requested waits more likely per turn, and the previous budgets were the least tolerant of the harnesses we compared: opencode retries a session 5 times and honors `Retry-After` uncapped, codex defaults to `stream_max_retries` 5 and honors server-advised delays, and oh-my-pi allows up to 10 agent retries with a 300s hint cap. A 60s ceiling turned any provider asking for 61s into an instantly failed turn even though the turn stage's own hinted wait cap is already 300s.
+- Opus/Fable-class models with xhigh thinking make transient provider failures more likely per turn, and the previous turn budget was the least tolerant of the harnesses we compared: opencode retries a session 5 times, codex defaults to `stream_max_retries` 5, and oh-my-pi allows up to 10 agent retries. The `providerRequest` server-hint ceiling was deliberately left alone: `planRetryDelay` has no production caller today, so changing that constant would have been an inert edit dressed up as a fix.
 
 ### Why an extension could not handle it
 

--- a/packages/ai/src/utils/retry-profile/profiles.ts
+++ b/packages/ai/src/utils/retry-profile/profiles.ts
@@ -22,13 +22,17 @@ export const SENPI_DEFAULT_RETRY_PROFILE: RetryPolicyProfile = {
 		serverHint: {
 			mode: "override",
 			acceptZero: true,
-			ceiling: { maxDelayMs: 60_000, onExceeded: "error-with-marker" },
+			// 300s matches the turn stage's hinted-wait cap and the 300s ceilings
+			// opencode/codex/oh-my-pi grant slow providers (opus/fable-class).
+			ceiling: { maxDelayMs: 300_000, onExceeded: "error-with-marker" },
 		},
 		classify: classifySenpiAssistantFailure,
 	},
 	turn: {
 		enabled: true,
-		maxRetries: 3,
+		// 5 attempts matches opencode's session retry budget and codex's
+		// stream_max_retries default for slow long-thinking providers.
+		maxRetries: 5,
 		backoff: {
 			baseDelayMs: 2_000,
 			growthFactor: 2,

--- a/packages/ai/src/utils/retry-profile/profiles.ts
+++ b/packages/ai/src/utils/retry-profile/profiles.ts
@@ -22,9 +22,7 @@ export const SENPI_DEFAULT_RETRY_PROFILE: RetryPolicyProfile = {
 		serverHint: {
 			mode: "override",
 			acceptZero: true,
-			// 300s matches the turn stage's hinted-wait cap and the 300s ceilings
-			// opencode/codex/oh-my-pi grant slow providers (opus/fable-class).
-			ceiling: { maxDelayMs: 300_000, onExceeded: "error-with-marker" },
+			ceiling: { maxDelayMs: 60_000, onExceeded: "error-with-marker" },
 		},
 		classify: classifySenpiAssistantFailure,
 	},

--- a/packages/ai/test/retry-profile-profiles.test.ts
+++ b/packages/ai/test/retry-profile-profiles.test.ts
@@ -8,9 +8,6 @@ describe("shipped retry profiles", () => {
 		expect(KIMI_CODE_RETRY_PROFILE.id).toBe("kimi-code");
 		expect(SENPI_DEFAULT_RETRY_PROFILE.providerRequest.maxRetries).toBe(0);
 		expect(SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries).toBe(5);
-		expect(SENPI_DEFAULT_RETRY_PROFILE.providerRequest.serverHint).toMatchObject({
-			ceiling: { maxDelayMs: 300_000 },
-		});
 		expect(KIMI_CODE_RETRY_PROFILE.providerRequest.enabled).toBe(false);
 		expect(KIMI_CODE_RETRY_PROFILE.turn.maxRetries).toBe(9);
 	});

--- a/packages/ai/test/retry-profile-profiles.test.ts
+++ b/packages/ai/test/retry-profile-profiles.test.ts
@@ -7,7 +7,10 @@ describe("shipped retry profiles", () => {
 		expect(SENPI_DEFAULT_RETRY_PROFILE.id).toBe("senpi-default");
 		expect(KIMI_CODE_RETRY_PROFILE.id).toBe("kimi-code");
 		expect(SENPI_DEFAULT_RETRY_PROFILE.providerRequest.maxRetries).toBe(0);
-		expect(SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries).toBe(3);
+		expect(SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries).toBe(5);
+		expect(SENPI_DEFAULT_RETRY_PROFILE.providerRequest.serverHint).toMatchObject({
+			ceiling: { maxDelayMs: 300_000 },
+		});
 		expect(KIMI_CODE_RETRY_PROFILE.providerRequest.enabled).toBe(false);
 		expect(KIMI_CODE_RETRY_PROFILE.turn.maxRetries).toBe(9);
 	});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ### Changed
 
+- The default provider stream-start timeout rises from 90s to 300s (`retry.provider.streamStartTimeoutMs` overrides are unchanged, and the default still never exceeds the idle timeout), so Opus/Fable-class models with long thinking no longer fail healthy requests with `Provider stream start timed out after 90000ms` before the first stream event; every comparable harness (opencode, codex, oh-my-pi) already grants 300s here. The `senpi-default` retry profile also gets more patient: the turn-stage retry budget rises from 3 to 5 attempts and the provider-stage server-hint ceiling from 60s to 300s, so long server-requested `Retry-After` waits are honored instead of failing the turn instantly.
+
 ### Fixed
 
 - Provider retry continuation watchdog messages now name `retry.provider.streamStartTimeoutMs`; claude-sdk-oauth regression coverage pins SDK `api_retry` as stream liveness on query and resident paths.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 ### Changed
 
-- The default provider stream-start timeout rises from 90s to 300s (`retry.provider.streamStartTimeoutMs` overrides are unchanged, and the default still never exceeds the idle timeout), so Opus/Fable-class models with long thinking no longer fail healthy requests with `Provider stream start timed out after 90000ms` before the first stream event; every comparable harness (opencode, codex, oh-my-pi) already grants 300s here. The `senpi-default` retry profile also gets more patient: the turn-stage retry budget rises from 3 to 5 attempts and the provider-stage server-hint ceiling from 60s to 300s, so long server-requested `Retry-After` waits are honored instead of failing the turn instantly.
+- The default provider stream-start timeout rises from 90s to 300s (`retry.provider.streamStartTimeoutMs` overrides are unchanged, and the default still never exceeds the idle timeout), so Opus/Fable-class models with long thinking no longer fail healthy requests with `Provider stream start timed out after 90000ms` before the first stream event; every comparable harness (opencode, codex, oh-my-pi) already grants 300s here. The agent-level retry budget also rises from 3 to 5 attempts: `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries` and the `retry.maxRetries` settings default now agree, so the documented default is the budget every consumer actually sees (session-title retry stays clamped by its own cap).
 
 ### Fixed
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -212,14 +212,14 @@ Set `PI_SKIP_VERSION_CHECK=1` to disable the senpi version update check. Use `--
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `retry.enabled` | boolean | `true` | Enable automatic agent-level retry on transient errors |
-| `retry.maxRetries` | number | `3` | Maximum agent-level retry attempts |
+| `retry.maxRetries` | number | `5` | Maximum agent-level retry attempts |
 | `retry.baseDelayMs` | number | `2000` | Base delay for agent-level exponential backoff (2s, 4s, 8s) |
 | `retry.modelFallback` | boolean | `true` | Let eligible retry failures advance through configured per-model fallback chains |
 | `retry.fallbackChains` | `Record<string, string[]>` | `{}` | Ordered exact model-selector to fallback-selector chains |
 | `retry.fallbackRevertPolicy` | `"cooldown-expiry"` \| `"never"` | `"cooldown-expiry"` | Automatic primary-model restoration policy |
 | `retry.abortServerSideFallback` | boolean | `true` | Abort a turn when the provider substitutes a different model after a classifier decline |
 | `retry.provider.timeoutMs` | number | `300000` | Provider/SDK request timeout and stream idle timeout in milliseconds |
-| `retry.provider.streamStartTimeoutMs` | number | `90000` | Maximum wait for the first provider stream event; `0` disables |
+| `retry.provider.streamStartTimeoutMs` | number | `300000` | Maximum wait for the first provider stream event; `0` disables |
 | `retry.provider.streamRetryTimeoutMs` | number | `30000` | First-request liveness cap after a known provider stream/transport timeout; `0` disables the cap |
 | `retry.provider.maxRetries` | number | `0` | Provider/SDK retry attempts |
 | `retry.provider.maxRetryDelayMs` | number | `60000` | Max server-requested delay honored on the same model before the fallback chain engages (60s) |
@@ -236,11 +236,11 @@ Keep `retry.provider.maxRetries` at `0` unless provider-level retries are explic
 {
   "retry": {
     "enabled": true,
-    "maxRetries": 3,
+    "maxRetries": 5,
     "baseDelayMs": 2000,
     "provider": {
       "timeoutMs": 3600000,
-      "streamStartTimeoutMs": 90000,
+      "streamStartTimeoutMs": 300000,
       "streamRetryTimeoutMs": 30000,
       "maxRetries": 0,
       "maxRetryDelayMs": 60000

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-09-02 - Provider stream-start default raised to 300s for slow thinking models
+
+### What changed
+
+- `packages/coding-agent/src/core/settings-manager.ts`: `DEFAULT_STREAM_START_TIMEOUT_MS` goes from 90_000 to 300_000, so the default provider stream-start watchdog grants 300s for the first SSE event. The effective value is still `min(default, idle timeout)`, explicit `retry.provider.streamStartTimeoutMs` overrides win unchanged, and `0` still disables the watchdog.
+- `packages/coding-agent/docs/settings.md`: the defaults table and the JSON example track the new default.
+
+### Why
+
+- Opus/Fable-class models with xhigh thinking routinely take longer than 90s to emit the first stream event, so the old default aborted healthy requests (`Provider stream start timed out after 90000ms`) and support had to tell users to raise the timeout by hand. Every comparable harness already grants 300s here (opencode's header timeout, codex's stream idle timeout, oh-my-pi's first-event timeout), and senpi's own stream idle default is already 300s.
+
+### Why an extension could not handle it
+
+- The value is a shipped core constant that applies only when no explicit setting exists; extensions can set `retry.provider.streamStartTimeoutMs` per session but cannot change the unset default every session inherits.
+
+### Expected merge conflict zones
+
+- LOW: the single constant line in `settings-manager.ts` plus the two matching rows in `docs/settings.md`.
+
 ## 2026-09-02 - Inherit extension provider settings for models.json custom models
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -5,6 +5,7 @@
 ### What changed
 
 - `packages/coding-agent/src/core/settings-manager.ts`: `DEFAULT_STREAM_START_TIMEOUT_MS` goes from 90_000 to 300_000, so the default provider stream-start watchdog grants 300s for the first SSE event. The effective value is still `min(default, idle timeout)`, explicit `retry.provider.streamStartTimeoutMs` overrides win unchanged, and `0` still disables the watchdog.
+- `packages/coding-agent/src/core/settings-manager.ts`: `getRetrySettings()` now defaults `maxRetries` to 5 instead of 3, matching `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries`. Without this the one `retry.maxRetries` key meant 5 on the turn stage but 3 on every `getRetrySettings()` consumer (session-title retry, compaction summarization retry, the agent-session retry gate), and the documented default could only be true for one of them.
 - `packages/coding-agent/docs/settings.md`: the defaults table and the JSON example track the new default.
 
 ### Why
@@ -17,7 +18,7 @@
 
 ### Expected merge conflict zones
 
-- LOW: the single constant line in `settings-manager.ts` plus the two matching rows in `docs/settings.md`.
+- LOW: the two default lines in `settings-manager.ts` (`DEFAULT_STREAM_START_TIMEOUT_MS`, the `getRetrySettings()` fallback) plus the matching rows in `docs/settings.md`.
 
 ## 2026-09-02 - Inherit extension provider settings for models.json custom models
 

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -50,7 +50,7 @@ import type { BranchSummarySettings, TerminalSettings } from "./terminal-setting
 
 export type * from "./settings-public-types.ts";
 
-export const DEFAULT_STREAM_START_TIMEOUT_MS = 90_000;
+export const DEFAULT_STREAM_START_TIMEOUT_MS = 300_000;
 export const DEFAULT_PROVIDER_STREAM_RETRY_TIMEOUT_MS = 30_000;
 
 export type TuiMode = RendererTuiMode;
@@ -1503,7 +1503,7 @@ export class SettingsManager {
 	 * accepts the request but never answers is otherwise bounded only by the
 	 * idle timeout (default 5 minutes) — long enough to make a session feel
 	 * permanently stuck. `retry.provider.streamStartTimeoutMs` overrides the
-	 * 90s default (0 disables). The default never exceeds the idle timeout and
+	 * 300s default (0 disables). The default never exceeds the idle timeout and
 	 * is disabled together with a disabled idle guard.
 	 */
 	getAgentStreamStartTimeoutMs(): number | undefined {

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1277,7 +1277,9 @@ export class SettingsManager {
 	} {
 		return {
 			enabled: this.getRetryEnabled(),
-			maxRetries: this.settings.retry?.maxRetries ?? 3,
+			// Matches SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries so the one
+			// `retry.maxRetries` key means the same budget on every consumer.
+			maxRetries: this.settings.retry?.maxRetries ?? 5,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
 		};
 	}

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -1277,9 +1277,9 @@ export class SettingsManager {
 	} {
 		return {
 			enabled: this.getRetryEnabled(),
-			// Matches SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries so the one
-			// `retry.maxRetries` key means the same budget on every consumer.
-			maxRetries: this.settings.retry?.maxRetries ?? 5,
+			// Derived, not duplicated: the one `retry.maxRetries` key must mean the
+			// same budget on every consumer, so the default tracks the shipped profile.
+			maxRetries: this.settings.retry?.maxRetries ?? SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries,
 			baseDelayMs: this.settings.retry?.baseDelayMs ?? 2000,
 		};
 	}

--- a/packages/coding-agent/test/settings-manager-retry-profiles.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-profiles.test.ts
@@ -111,7 +111,7 @@ describeProfile("resolveRetryProfile precedence", () => {
 			expectProfile(kimi.turn.backoff.perAttemptCapMs).toBe(32_000);
 
 			const anthropic = manager.resolveRetryProfile({ id: "anthropic" });
-			expectProfile(anthropic.turn.maxRetries).toBe(3);
+			expectProfile(anthropic.turn.maxRetries).toBe(5);
 			expectProfile(anthropic.turn.backoff.baseDelayMs).toBe(2000);
 			// Phase-2 default policy: locally computed turn backoff gained +0..25%
 			// additive jitter and an 8s per-attempt cap (see profiles.ts senpi-default).
@@ -144,7 +144,7 @@ describeProfile("resolveRetryProfile precedence", () => {
 		expectProfile(kimi.turn.maxRetries).toBe(4);
 
 		const anthropic = manager.resolveRetryProfile({ id: "anthropic" });
-		expectProfile(anthropic.turn.maxRetries).toBe(3);
+		expectProfile(anthropic.turn.maxRetries).toBe(5);
 	});
 
 	itProfile("retry.enabled false forces turn.enabled false on both", () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -428,13 +428,13 @@ describe("SettingsManager", () => {
 			expect(whenManager.getAgentStreamIdleTimeoutMs()).toBe(5_000);
 		});
 
-		it("should default the agent stream start timeout to 90s", () => {
+		it("should default the agent stream start timeout to 300s", () => {
 			const givenSettingsPath = join(agentDir, "settings.json");
 			writeFileSync(givenSettingsPath, JSON.stringify({ theme: "dark" }));
 
 			const whenManager = SettingsManager.create(projectDir, agentDir);
 
-			expect(whenManager.getAgentStreamStartTimeoutMs()).toBe(90_000);
+			expect(whenManager.getAgentStreamStartTimeoutMs()).toBe(300_000);
 		});
 
 		it("should prefer retry.provider.streamStartTimeoutMs for the agent stream start timeout", () => {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -428,6 +428,24 @@ describe("SettingsManager", () => {
 			expect(whenManager.getAgentStreamIdleTimeoutMs()).toBe(5_000);
 		});
 
+		it("should default retry.maxRetries to the shipped turn budget", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ theme: "dark" }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getRetrySettings().maxRetries).toBe(5);
+		});
+
+		it("should prefer an explicit retry.maxRetries over the default", () => {
+			const givenSettingsPath = join(agentDir, "settings.json");
+			writeFileSync(givenSettingsPath, JSON.stringify({ retry: { maxRetries: 2 } }));
+
+			const whenManager = SettingsManager.create(projectDir, agentDir);
+
+			expect(whenManager.getRetrySettings().maxRetries).toBe(2);
+		});
+
 		it("should default the agent stream start timeout to 300s", () => {
 			const givenSettingsPath = join(agentDir, "settings.json");
 			writeFileSync(givenSettingsPath, JSON.stringify({ theme: "dark" }));

--- a/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-engine.test.ts
@@ -695,7 +695,7 @@ describe("retry fallback engine", () => {
 			{
 				type: "auto_retry_start",
 				attempt: 1,
-				maxAttempts: 3,
+				maxAttempts: 5,
 				delayMs: 1,
 				errorMessage: codexUpstreamUnavailableMessage,
 			},


### PR DESCRIPTION
## Summary

Slow long-thinking models (Opus/Fable-class with xhigh thinking) fail healthy turns with `Provider stream start timed out after 90000ms` before they emit their first stream event, and the workaround so far has been telling users to raise the timeout by hand. This PR makes senpi's provider retry/timeout defaults as patient as every harness we compared against, without loosening any failure classification.

Two shipped defaults change: the provider stream-start watchdog (90s -> 300s) and the agent-level retry budget (3 -> 5, in both places that define it). Explicit settings overrides, backoff shapes, permanent-failure classification, `providerRequest.maxRetries` (still 0) and `KIMI_CODE_RETRY_PROFILE` are untouched.

## Why these numbers (cross-harness comparison)

| Knob | senpi (before) | senpi (after) | opencode | openai/codex | oh-my-pi |
|---|---|---|---|---|---|
| First-event / stream-start timeout | **90s** | **300s** | 300s header timeout (`provider.ts` `OPENAI_HEADER_TIMEOUT_DEFAULT`) | 300s stream idle (`DEFAULT_STREAM_IDLE_TIMEOUT_MS`) | 300s (`DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS`) |
| Turn / session retries | **3** | **5** | 5 (`RETRY_MAX_RETRIES`) | 5 (`DEFAULT_STREAM_MAX_RETRIES`) | 10 agent retries |
| Transport/provider retries | 0 | 0 (unchanged) | 0 at SDK layer | 4 (`DEFAULT_REQUEST_MAX_RETRIES`) | 5-10 per layer |

senpi was the least tolerant harness on both rows that matter for a slow provider, and its own stream *idle* default was already 300s, so the 90s start bound was the odd one out.

## Changes

- **packages/coding-agent** — `DEFAULT_STREAM_START_TIMEOUT_MS` 90_000 -> 300_000. Resolution order is unchanged: an explicit `retry.provider.streamStartTimeoutMs` still wins, `0` still disables the watchdog, and the effective value is still `min(default, idle timeout)`.
- **packages/coding-agent** — `getRetrySettings()` defaults `maxRetries` to 5 instead of 3 so the one `retry.maxRetries` key means the same budget on every consumer (turn stage *and* session-title / compaction-summarization / agent-session gate). Session-title retry stays clamped by its own `MAX_TITLE_RETRIES`.
- **packages/ai** — `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries` 3 -> 5.
- Docs, tracker (`changes.md`) and `[Unreleased]` changelog entries updated to match.

## Review response (cubic)

Both findings were real and are fixed — thanks:

1. **Inert ceiling.** The first revision also raised `providerRequest.serverHint.ceiling` 60s -> 300s and claimed it removed a "61s+ instantly fails" cliff. Verified in code: `planRetryDelay` has **no production caller** (definition + barrel re-export + tests only), and `sdk.ts` deliberately sends 0 retries into the `providerRequest` stage, so that ceiling is never consulted at runtime. The claim was false, so the constant is **reverted** and the prose now says what the code does.
2. **Default divergence.** Raising only the profile made `retry.maxRetries` mean 5 on the turn stage but 3 via `getRetrySettings()` (settings-manager.ts:1280), so the documented default could only be true for one consumer. Both are 5 now, pinned by tests.

## QA & Evidence

Manual QA drove the **real CLI from source** against a local Anthropic-messages SSE endpoint that withholds everything (headers included) for 120s before streaming a valid event sequence — a healthy provider with a 2-minute thinking preamble. Driver: `local-ignore/qa-evidence/20260902-provider-retry-leniency/slow-first-event-qa.mjs` (senpi-qa sandbox, hermetic provider env, real-auth sha256 guard).

- **Observed (before):** turn failed — `Provider stream start timed out after 90000ms`, **3 provider attempts** all killed at the 90s bound, no answer, exit 1 (`base-run/summary.json`: `sawStreamStartTimeoutMs: 90000`, `requestCount: 3`).
- **Observed (after):** turn completed — **1 provider attempt**, marker text returned, exit 0 (`wt-run/summary.json`: `sawStreamStartTimeoutMs: null`, `sawMarker: true`).
- **Artifacts:** `local-ignore/qa-evidence/20260902-provider-retry-leniency/{base-run,wt-run}/{summary.json,stdout.txt,stderr.txt,requests.json}` (sandboxed, credential-free; `realAuthUnchanged: true` in both).

Automated (all runs on a remote build host, bun only):

- **Failing-first proofs, captured against unmodified source before each change:** `expected 3 to be 5` (profile turn budget), `expected 90000 to be 300000` (stream-start default), `expected 3 to be 5` (`getRetrySettings()` default). Each green afterwards; the `retry.maxRetries` pin is paired with an explicit-override case (value 2) so it cannot pass tautologically.
- `bun run check` (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk platform lock, `tsc --noEmit`, browser-smoke): exit 0.
- Focused scope green: retry-profile ×5, provider-retry, retry, settings-manager, settings-manager-retry-profiles, retry-fallback-engine, provider-timeout-classification.

## Risks & Residuals

- *A genuinely dead stream now hangs longer before the watchdog fires (90s -> 300s).* Accepted and intentional: it is the bound senpi already applies to stream idleness and what all three comparison harnesses use; `retry.provider.streamStartTimeoutMs: 90000` restores the old aggressiveness.
- *Two extra retry attempts before model fallback.* Bounded by the existing 2s-base backoff capped at 8s per attempt; fallback classification is unchanged and hard failures (quota, auth, refusals) still switch immediately.
- *`getRetrySettings()` consumers now retry 5 times instead of 3.* Same direction as the PR, and session-title retry keeps its own lower cap.
- No changes to retryable/permanent classification, backoff math, the Kimi profile, or any provider-stage behavior.
