### PR TITLE
fix(rpc): scope multi-session socket events to attached connections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 
 - Two concurrent shared-host starts for one socket no longer fail with a raw `database is locked`: the ensure-lock wait now covers the whole host startup critical section (probe, incompatible-host stop, spawned-host readiness) instead of ten seconds.
+- Multi-session socket hosts deliver agent events only to connections attached to the session; targeted responses and dialog extension UI requests remain requester-only, while other extension UI state reaches attached connections. `RpcClient` drops foreign session events while lease-less and buffers own pre-lease startup events during `open_session`.
 
 ### New Features
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -62,10 +62,12 @@ On Windows, listeners and clients deterministically map the logical socket path 
 `\\.\pipe\senpi-rpc-<sha256[:32]>`. Callers keep using the same `unix://` CLI value; the logical path remains the
 ownership and settings identity, and callers never construct the pipe name themselves.
 
-Socket event visibility is an all-sessions broadcast: every connected client receives lifecycle and agent events from
-every open session, each tagged with its routing `sessionId`. Correlated responses and extension UI requests are sent
-only to the connection that issued the command. This lets a non-owner observe a foreign turn without requiring a
-separate subscription protocol.
+Socket event visibility is attachment-scoped: each connection receives agent events only from sessions attached to that
+connection, with every record tagged by its routing `sessionId`. Content-free `session_closed` lifecycle records remain
+broadcast to all connections so observers can track the session roster. Correlated responses and dialog extension UI
+requests (select, confirm, input, and editor) are requester-only; other extension UI state records go to the session's
+attached connections. To observe a foreign session, open it by its existing
+`sessionPath`; the host attaches that connection during `open_session`.
 
 ### Client information and rendered components
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-02 - Export the RPC open-in-flight client error
+
+### What changed
+
+- `packages/coding-agent/src/index.ts` and `packages/coding-agent/src/modes/index.ts` re-export `RpcClientOpenInFlightError` beside `RpcClient` and `RpcTransportGoneError` so embedders can classify a rejected concurrent `open_session`.
+
+### Why
+
+- `RpcClient` now holds exactly one lease and rejects a second `openSession()` while one is in flight (`code: "open_session_in_flight"`); the public client surface needs the typed error to distinguish that programming error from transport loss.
+
+### Why an extension could not handle it
+
+- The client lease and its pending-open buffering live in the RPC transport layer below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: the export lists in `index.ts` and `modes/index.ts`.
+
 ## 2026-09-01 - Negotiate RPC session auto-titling
 
 ### What changed

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -368,6 +368,7 @@ export {
 	type PrintModeOptions,
 	RpcClient,
 	type RpcClientEvent,
+	RpcClientOpenInFlightError,
 	type RpcClientOptions,
 	type RpcCommand,
 	type RpcEventListener,

--- a/packages/coding-agent/src/modes/index.ts
+++ b/packages/coding-agent/src/modes/index.ts
@@ -18,6 +18,7 @@ export {
 	type ModelInfo,
 	RpcClient,
 	type RpcClientEvent,
+	RpcClientOpenInFlightError,
 	type RpcClientOptions,
 	type RpcEventListener,
 	RpcTransportGoneError,

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -52,11 +52,11 @@
 
 ### What changed
 
-- Files: `multi-session-host.ts`, `rpc-client.ts`, `session-event-fanout.ts`, `session-event-writer.ts`.
+- Files: `multi-session-host.ts`, `rpc-client.ts`, `session-event-fanout.ts`, `session-event-writer.ts`; the `RpcClientOpenInFlightError` re-exports in `packages/coding-agent/src/index.ts` and `packages/coding-agent/src/modes/index.ts`.
 - Session agent events are delivered only to connections attached to that session; newly registered sockets no longer replay every session's in-flight snapshot.
 - Attaching a connection replays that session's unrendered snapshot, plus rendered records when `rendered_components` is advertised.
 - `session_closed` remains broadcast because it carries no content and observers rely on roster visibility.
-- Lease-less `RpcClient` instances drop all session-tagged events until they open a session.
+- Lease-less `RpcClient` instances drop all session-tagged events until they open a session; during an in-flight `open_session`, matching startup events are buffered up to 512 records and 1 MiB of serialized JSONL, evicting oldest records first when either bound is exceeded.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -48,6 +48,24 @@
 
 - LOW: the net transport calls and filesystem cleanup guards in `host-lifecycle.ts` and `multi-session-host.ts`; one import and one `createConnection` expression each in `host-ensure.ts` and `rpc-client.ts`.
 
+## [Unreleased] - Isolate multi-session socket events by attachment
+
+### What changed
+
+- Files: `multi-session-host.ts`, `rpc-client.ts`, `session-event-fanout.ts`, `session-event-writer.ts`.
+- Session agent events are delivered only to connections attached to that session; newly registered sockets no longer replay every session's in-flight snapshot.
+- Attaching a connection replays that session's unrendered snapshot, plus rendered records when `rendered_components` is advertised.
+- `session_closed` remains broadcast because it carries no content and observers rely on roster visibility.
+- Lease-less `RpcClient` instances drop all session-tagged events until they open a session.
+
+### Why
+
+- Shared multi-session socket hosts must not leak one session's assistant output into another session's client during normal operation or reconnect.
+
+### Why an extension could not handle it
+
+- Socket fan-out and client lease filtering are transport behavior below the extension API.
+
 ## [Unreleased] - Preserve launch capabilities for undeclared multi-session clients
 
 - `session-command-router.ts`: connection-owned session bindings now fall back to the host launch capabilities when the client has not sent `set_client_info`; an explicit empty capability declaration still wins.

--- a/packages/coding-agent/src/modes/rpc/multi-session-host.ts
+++ b/packages/coding-agent/src/modes/rpc/multi-session-host.ts
@@ -98,10 +98,10 @@ interface Connection {
 }
 
 /**
- * Socket event visibility is an all-sessions broadcast: every connected client
- * receives every session lifecycle/agent event, tagged with its routing
- * sessionId. Responses and extension UI requests remain requester-only. This
- * keeps observers stateless while preventing correlated replies from leaking.
+ * Socket agent events are delivered only to connections attached to their
+ * session, tagged with its routing sessionId. Content-free session lifecycle
+ * events remain visible to every connection. Responses and extension UI
+ * requests remain requester-only; foreign observation uses attach-on-open.
  */
 export async function runMultiSessionHost(options: MultiSessionHostOptions): Promise<never> {
 	if (options.listen === undefined || options.listen === "stdio://") return runStdioHost(options);

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -127,6 +127,19 @@ export function isTransportGoneError(error: unknown): error is RpcTransportGoneE
 	);
 }
 
+export class RpcClientOpenInFlightError extends Error {
+	readonly code = "open_session_in_flight" as const;
+
+	constructor() {
+		super("An open_session request is already in flight");
+		this.name = "RpcClientOpenInFlightError";
+	}
+}
+
+// Keep pre-lease startup delivery bounded by both record count and wire size.
+const MAX_PENDING_SESSION_EVENTS = 512;
+const MAX_PENDING_SESSION_EVENT_BYTES = 1024 * 1024;
+
 export class RpcClient {
 	private process: ChildProcess | null = null;
 	private socket: Socket | null = null;
@@ -143,6 +156,9 @@ export class RpcClient {
 	> = new Map();
 	private requestId = 0;
 	private sessionId: string | undefined;
+	private pendingOpenSession = false;
+	private pendingSessionEvents: Array<{ sessionId: string; event: RpcClientEvent; bytes: number }> = [];
+	private pendingSessionEventBytes = 0;
 	private stderr = "";
 	private exitError: Error | null = null;
 	private disconnectNotified = false;
@@ -237,6 +253,9 @@ export class RpcClient {
 	 * Stop the RPC agent process.
 	 */
 	async stop(): Promise<void> {
+		this.pendingOpenSession = false;
+		this.pendingSessionEvents = [];
+		this.pendingSessionEventBytes = 0;
 		if (this.socket) {
 			this.stopping = true;
 			this.stopReadingStdout?.();
@@ -244,6 +263,8 @@ export class RpcClient {
 			this.socket.destroy();
 			this.socket = null;
 			this.sessionId = undefined;
+			this.pendingOpenSession = false;
+			this.pendingSessionEvents = [];
 			this.notifyDisconnect(new RpcTransportGoneError());
 			return;
 		}
@@ -341,10 +362,21 @@ export class RpcClient {
 		thinkingLevel?: ThinkingLevel;
 		permissionPreset?: string;
 	}): Promise<{ sessionId: string; state: RpcSessionState; attached?: boolean }> {
-		const response = await this.send({ type: "open_session", ...options }, false);
-		const opened = this.getData<{ sessionId: string; state: RpcSessionState; attached?: boolean }>(response);
-		this.sessionId = opened.sessionId;
-		return opened;
+		if (this.pendingOpenSession) throw new RpcClientOpenInFlightError();
+		this.pendingOpenSession = true;
+		try {
+			const response = await this.send({ type: "open_session", ...options }, false);
+			const opened = this.getData<{ sessionId: string; state: RpcSessionState; attached?: boolean }>(response);
+			this.sessionId = opened.sessionId;
+			this.pendingOpenSession = false;
+			this.flushPendingSessionEvents();
+			return opened;
+		} catch (error) {
+			this.pendingOpenSession = false;
+			this.pendingSessionEvents = [];
+			this.pendingSessionEventBytes = 0;
+			throw error;
+		}
 	}
 
 	async sendExtensionUIResponse(response: RpcExtensionUIResponse): Promise<void> {
@@ -931,14 +963,39 @@ export class RpcClient {
 				return;
 			}
 
-			// Otherwise it's an event. Multi-session hosts broadcast all session
-			// events to every connection; a routed client exposes only its lease.
-			if (data.sessionId !== undefined && this.sessionId !== undefined && data.sessionId !== this.sessionId) return;
+			// Otherwise it's an event. During open_session, retain tagged events until
+			// the response establishes the lease so startup hooks are not lost.
+			if (typeof data.sessionId === "string" && data.sessionId !== this.sessionId) {
+				if (this.pendingOpenSession) {
+					const bytes = Buffer.byteLength(line);
+					this.pendingSessionEvents.push({ sessionId: data.sessionId, event: data as RpcClientEvent, bytes });
+					this.pendingSessionEventBytes += bytes;
+					while (
+						this.pendingSessionEvents.length > MAX_PENDING_SESSION_EVENTS ||
+						this.pendingSessionEventBytes > MAX_PENDING_SESSION_EVENT_BYTES
+					) {
+						const oldest = this.pendingSessionEvents.shift();
+						if (!oldest) break;
+						this.pendingSessionEventBytes -= oldest.bytes;
+					}
+				}
+				return;
+			}
 			for (const listener of this.eventListeners) {
 				listener(data as RpcClientEvent);
 			}
 		} catch {
 			// Ignore non-JSON lines
+		}
+	}
+
+	private flushPendingSessionEvents(): void {
+		const pending = this.pendingSessionEvents;
+		this.pendingSessionEvents = [];
+		this.pendingSessionEventBytes = 0;
+		for (const { sessionId, event } of pending) {
+			if (sessionId !== this.sessionId) continue;
+			for (const listener of this.eventListeners) listener(event);
 		}
 	}
 

--- a/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
@@ -36,8 +36,6 @@ export class SessionEventFanout {
 		this.connections.set(id, { connection, actor });
 		this.connectionCapabilities.set(id, new Set());
 		this.connectionSessions.set(id, new Set());
-		for (const snapshot of this.sessionSnapshots.values())
-			for (const record of snapshot) if (!record.rendered) actor.enqueue(record.line);
 	}
 
 	unregisterConnection(id: string): void {
@@ -53,9 +51,10 @@ export class SessionEventFanout {
 	attachConnectionToSession(id: string, sessionId: string): void {
 		if (!this.connections.has(id)) return;
 		const sessions = this.connectionSessions.get(id) ?? new Set<string>();
+		if (sessions.has(sessionId)) return;
 		sessions.add(sessionId);
 		this.connectionSessions.set(id, sessions);
-		if (this.connectionCapabilities.get(id)?.has("rendered_components")) this.replayRendered(id, sessionId);
+		this.replaySnapshot(id, sessionId);
 	}
 
 	detachConnectionFromSession(id: string, sessionId: string): void {
@@ -94,7 +93,12 @@ export class SessionEventFanout {
 		return false;
 	}
 
-	targets(sessionId: string, targetId: string | undefined, isTargeted: boolean, rendered: boolean): readonly (string | undefined)[] {
+	targets(
+		sessionId: string,
+		targetId: string | undefined,
+		isTargeted: boolean,
+		rendered: boolean,
+	): readonly (string | undefined)[] {
 		if (isTargeted) return [targetId];
 		if (rendered)
 			return this.connections.size > 0
@@ -104,15 +108,13 @@ export class SessionEventFanout {
 							this.connectionSessions.get(id)?.has(sessionId),
 					)
 				: [undefined];
-		return this.connections.size > 0 ? [...this.connections.keys()] : [undefined];
+		return this.connections.size > 0
+			? [...this.connections.keys()].filter((id) => this.connectionSessions.get(id)?.has(sessionId))
+			: [undefined];
 	}
 
 	get(id: string): RegisteredConnection | undefined {
 		return this.connections.get(id);
-	}
-
-	ids(): IterableIterator<string> {
-		return this.connections.keys();
 	}
 
 	values(): IterableIterator<RegisteredConnection> {
@@ -136,6 +138,14 @@ export class SessionEventFanout {
 
 	forgetSession(sessionId: string): void {
 		this.sessionSnapshots.delete(sessionId);
+	}
+
+	private replaySnapshot(id: string, sessionId: string): void {
+		const actor = this.connections.get(id)?.actor;
+		if (!actor) return;
+		const capable = this.connectionCapabilities.get(id)?.has("rendered_components") ?? false;
+		for (const record of this.sessionSnapshots.get(sessionId) ?? [])
+			if (!record.rendered || capable) actor.enqueue(record.line);
 	}
 
 	private replayRendered(id: string, sessionId: string): void {

--- a/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
@@ -1,0 +1,146 @@
+import { SocketEventSinkActor } from "./socket-event-fanout.ts";
+
+export type RawWriter = (chunk: string) => void;
+export type BackpressureWaiter = () => Promise<void>;
+
+export interface SessionEventWriterConnection {
+	readonly writeRaw: RawWriter;
+	readonly waitForBackpressure: BackpressureWaiter;
+}
+
+export const RENDERED_COMPONENT_RECORD = "__senpiRenderedComponent";
+
+type RegisteredConnection = {
+	readonly connection: SessionEventWriterConnection;
+	readonly actor: SocketEventSinkActor;
+};
+
+type SnapshotRecord = { readonly line: string; readonly rendered: boolean };
+
+export class SessionEventFanout {
+	private readonly connections = new Map<string, RegisteredConnection>();
+	private readonly sessionSnapshots = new Map<string, SnapshotRecord[]>();
+	private readonly connectionCapabilities = new Map<string, Set<string>>();
+	private readonly connectionSessions = new Map<string, Set<string>>();
+	private readonly registeredCapabilityConnections = new Set<string>();
+
+	registerConnection(id: string, connection: SessionEventWriterConnection): void {
+		const actor = new SocketEventSinkActor(connection, () => {
+			if (this.connections.get(id)?.actor === actor) {
+				this.connections.delete(id);
+				this.connectionCapabilities.delete(id);
+				this.connectionSessions.delete(id);
+				this.registeredCapabilityConnections.delete(id);
+			}
+		});
+		this.connections.set(id, { connection, actor });
+		this.connectionCapabilities.set(id, new Set());
+		this.connectionSessions.set(id, new Set());
+		for (const snapshot of this.sessionSnapshots.values())
+			for (const record of snapshot) if (!record.rendered) actor.enqueue(record.line);
+	}
+
+	unregisterConnection(id: string): void {
+		const registered = this.connections.get(id);
+		if (!registered) return;
+		registered.actor.close();
+		this.connections.delete(id);
+		this.connectionCapabilities.delete(id);
+		this.connectionSessions.delete(id);
+		this.registeredCapabilityConnections.delete(id);
+	}
+
+	attachConnectionToSession(id: string, sessionId: string): void {
+		if (!this.connections.has(id)) return;
+		const sessions = this.connectionSessions.get(id) ?? new Set<string>();
+		sessions.add(sessionId);
+		this.connectionSessions.set(id, sessions);
+		if (this.connectionCapabilities.get(id)?.has("rendered_components")) this.replayRendered(id, sessionId);
+	}
+
+	detachConnectionFromSession(id: string, sessionId: string): void {
+		this.connectionSessions.get(id)?.delete(sessionId);
+	}
+
+	setConnectionCapabilities(id: string, capabilities: readonly string[]): void {
+		const registered = this.connections.get(id);
+		if (!registered) return;
+		const wasCapable = this.connectionCapabilities.get(id)?.has("rendered_components") ?? false;
+		this.connectionCapabilities.set(id, new Set(capabilities));
+		this.registeredCapabilityConnections.add(id);
+		if (!wasCapable && capabilities.includes("rendered_components"))
+			for (const sessionId of this.connectionSessions.get(id) ?? []) this.replayRendered(id, sessionId);
+	}
+
+	clearConnectionCapabilities(id: string): void {
+		if (this.connections.has(id)) {
+			this.connectionCapabilities.set(id, new Set());
+			this.registeredCapabilityConnections.delete(id);
+		}
+	}
+
+	hasRegisteredConnectionCapabilities(id: string): boolean {
+		return this.registeredCapabilityConnections.has(id);
+	}
+
+	getConnectionCapabilities(id: string): readonly string[] | undefined {
+		if (!this.registeredCapabilityConnections.has(id)) return undefined;
+		return [...(this.connectionCapabilities.get(id) ?? [])];
+	}
+
+	hasCapableConnection(sessionId: string): boolean {
+		for (const [id, capabilities] of this.connectionCapabilities)
+			if (capabilities.has("rendered_components") && this.connectionSessions.get(id)?.has(sessionId)) return true;
+		return false;
+	}
+
+	targets(sessionId: string, targetId: string | undefined, isTargeted: boolean, rendered: boolean): readonly (string | undefined)[] {
+		if (isTargeted) return [targetId];
+		if (rendered)
+			return this.connections.size > 0
+				? [...this.connections.keys()].filter(
+						(id) =>
+							this.connectionCapabilities.get(id)?.has("rendered_components") &&
+							this.connectionSessions.get(id)?.has(sessionId),
+					)
+				: [undefined];
+		return this.connections.size > 0 ? [...this.connections.keys()] : [undefined];
+	}
+
+	get(id: string): RegisteredConnection | undefined {
+		return this.connections.get(id);
+	}
+
+	ids(): IterableIterator<string> {
+		return this.connections.keys();
+	}
+
+	values(): IterableIterator<RegisteredConnection> {
+		return this.connections.values();
+	}
+
+	broadcast(line: string): void {
+		for (const { actor } of this.connections.values()) actor.enqueue(line);
+	}
+
+	rememberSnapshot(sessionId: string, value: Record<string, unknown>, line: string): void {
+		const event = value.assistantMessageEvent as Record<string, unknown> | undefined;
+		const record = { line, rendered: value[RENDERED_COMPONENT_RECORD] === true };
+		if (value.type === "message_start" || (value.type === "message_update" && event?.type === "text_start")) {
+			this.sessionSnapshots.set(sessionId, [record]);
+		} else if (this.sessionSnapshots.has(sessionId)) {
+			this.sessionSnapshots.get(sessionId)?.push(record);
+		}
+		if (value.type === "message_end") this.sessionSnapshots.delete(sessionId);
+	}
+
+	forgetSession(sessionId: string): void {
+		this.sessionSnapshots.delete(sessionId);
+	}
+
+	private replayRendered(id: string, sessionId: string): void {
+		const actor = this.connections.get(id)?.actor;
+		if (!actor) return;
+		for (const record of this.sessionSnapshots.get(sessionId) ?? []) if (record.rendered) actor.enqueue(record.line);
+	}
+}

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -1,6 +1,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { serializeJsonLine } from "./jsonl.ts";
-import { SocketEventSinkActor } from "./socket-event-fanout.ts";
+import {
+	RENDERED_COMPONENT_RECORD,
+	SessionEventFanout,
+	type SessionEventWriterConnection,
+} from "./session-event-fanout.ts";
+
+export { RENDERED_COMPONENT_RECORD, type SessionEventWriterConnection } from "./session-event-fanout.ts";
 
 type RawWriter = (chunk: string) => void;
 type BackpressureWaiter = () => Promise<void>;
@@ -64,24 +70,10 @@ function toolUpdateKey(value: RpcRecord): string | undefined {
  * by itself: coalescing records from different sessions would obscure the
  * scheduling boundary and violate D9.
  */
-export interface SessionEventWriterConnection {
-	readonly writeRaw: RawWriter;
-	readonly waitForBackpressure: BackpressureWaiter;
-}
-
-export const RENDERED_COMPONENT_RECORD = "__senpiRenderedComponent";
-
 export class SessionEventWriter {
 	private readonly queues = new Map<string, RecordQueue>();
-	private readonly connections = new Map<
-		string,
-		{ connection: SessionEventWriterConnection; actor: SocketEventSinkActor }
-	>();
-	private readonly sessionSnapshots = new Map<string, Array<{ line: string; rendered: boolean }>>();
+	private readonly fanout = new SessionEventFanout();
 	private readonly connectionContext = new AsyncLocalStorage<string>();
-	private readonly connectionCapabilities = new Map<string, Set<string>>();
-	private readonly connectionSessions = new Map<string, Set<string>>();
-	private readonly registeredCapabilityConnections = new Set<string>();
 	private readonly controlQueue: RecordQueue = { latestByKey: new Map(), ready: false };
 	private readonly readyQueues: RecordQueue[] = [];
 	private readonly sealedSessions = new Set<string>();
@@ -128,77 +120,39 @@ export class SessionEventWriter {
 	}
 
 	registerConnection(id: string, connection: SessionEventWriterConnection): void {
-		const actor = new SocketEventSinkActor(connection, () => {
-			if (this.connections.get(id)?.actor === actor) {
-				this.connections.delete(id);
-				this.connectionCapabilities.delete(id);
-				this.connectionSessions.delete(id);
-				this.registeredCapabilityConnections.delete(id);
-			}
-		});
-		this.connections.set(id, { connection, actor });
-		this.connectionCapabilities.set(id, new Set());
-		this.connectionSessions.set(id, new Set());
-		for (const snapshot of this.sessionSnapshots.values())
-			for (const record of snapshot) if (!record.rendered) actor.enqueue(record.line);
+		this.fanout.registerConnection(id, connection);
 	}
 
 	unregisterConnection(id: string): void {
-		const registered = this.connections.get(id);
-		if (!registered) return;
-		registered.actor.close();
-		this.connections.delete(id);
-		this.connectionCapabilities.delete(id);
-		this.connectionSessions.delete(id);
-		this.registeredCapabilityConnections.delete(id);
+		this.fanout.unregisterConnection(id);
 	}
 
 	attachConnectionToSession(id: string, sessionId: string): void {
-		if (!this.connections.has(id)) return;
-		const sessions = this.connectionSessions.get(id) ?? new Set<string>();
-		sessions.add(sessionId);
-		this.connectionSessions.set(id, sessions);
-		if (this.connectionCapabilities.get(id)?.has("rendered_components"))
-			for (const record of this.sessionSnapshots.get(sessionId) ?? [])
-				if (record.rendered) this.connections.get(id)!.actor.enqueue(record.line);
+		this.fanout.attachConnectionToSession(id, sessionId);
 	}
 
 	detachConnectionFromSession(id: string, sessionId: string): void {
-		this.connectionSessions.get(id)?.delete(sessionId);
+		this.fanout.detachConnectionFromSession(id, sessionId);
 	}
 
 	setConnectionCapabilities(id: string, capabilities: readonly string[]): void {
-		const registered = this.connections.get(id);
-		if (!registered) return;
-		const wasCapable = this.connectionCapabilities.get(id)?.has("rendered_components") ?? false;
-		this.connectionCapabilities.set(id, new Set(capabilities));
-		this.registeredCapabilityConnections.add(id);
-		if (!wasCapable && capabilities.includes("rendered_components"))
-			for (const sessionId of this.connectionSessions.get(id) ?? [])
-				for (const record of this.sessionSnapshots.get(sessionId) ?? [])
-					if (record.rendered) registered.actor.enqueue(record.line);
+		this.fanout.setConnectionCapabilities(id, capabilities);
 	}
 
 	clearConnectionCapabilities(id: string): void {
-		if (this.connections.has(id)) {
-			this.connectionCapabilities.set(id, new Set());
-			this.registeredCapabilityConnections.delete(id);
-		}
+		this.fanout.clearConnectionCapabilities(id);
 	}
 
 	hasRegisteredConnectionCapabilities(id: string): boolean {
-		return this.registeredCapabilityConnections.has(id);
+		return this.fanout.hasRegisteredConnectionCapabilities(id);
 	}
 
 	getConnectionCapabilities(id: string): readonly string[] | undefined {
-		if (!this.registeredCapabilityConnections.has(id)) return undefined;
-		return [...(this.connectionCapabilities.get(id) ?? [])];
+		return this.fanout.getConnectionCapabilities(id);
 	}
 
 	hasCapableConnection(sessionId: string): boolean {
-		for (const [id, capabilities] of this.connectionCapabilities)
-			if (capabilities.has("rendered_components") && this.connectionSessions.get(id)?.has(sessionId)) return true;
-		return false;
+		return this.fanout.hasCapableConnection(sessionId);
 	}
 
 	/** Execute a connection's command with its response destination in context. */
@@ -211,7 +165,7 @@ export class SessionEventWriter {
 		return this.connectionContext.getStore();
 	}
 
-	/** Queue a session record. Lifecycle/events are broadcast; responses/UI are targeted. */
+	/** Queue a session record. Content events target connections attached to the session. */
 	enqueue(sessionId: string, value: object): boolean {
 		if (this.sealedSessions.has(sessionId)) return false;
 		const targetId = this.connectionContext.getStore();
@@ -224,21 +178,16 @@ export class SessionEventWriter {
 		const tagged = { ...value, sessionId } as RpcRecord;
 		const { [RENDERED_COMPONENT_RECORD]: _rendered, ...wireTagged } = tagged;
 		const line = serializeJsonLine(wireTagged);
-		this.rememberSnapshot(sessionId, tagged, line);
-		const targets = isTargeted
-			? [targetId]
-			: record[RENDERED_COMPONENT_RECORD] && this.connections.size > 0
-				? [...this.connections.keys()].filter(
-						(id) =>
-							this.connectionCapabilities.get(id)?.has("rendered_components") &&
-							this.connectionSessions.get(id)?.has(sessionId),
-					)
-				: this.connections.size > 0
-					? [...this.connections.keys()]
-					: [undefined];
+		this.fanout.rememberSnapshot(sessionId, tagged, line);
+		const targets = this.fanout.targets(
+			sessionId,
+			targetId,
+			isTargeted,
+			record[RENDERED_COMPONENT_RECORD] === true,
+		);
 		for (const target of targets) {
-			if (target !== undefined && !this.connections.has(target)) continue;
-			const registered = target === undefined ? undefined : this.connections.get(target);
+			if (target !== undefined && !this.fanout.get(target)) continue;
+			const registered = target === undefined ? undefined : this.fanout.get(target);
 			if (registered)
 				registered.actor.enqueue(line, compactDelta(tagged) && tagged.message !== null ? MESSAGE_KEY : undefined);
 			else this.appendSessionRecord(sessionId, wireTagged, target);
@@ -251,7 +200,7 @@ export class SessionEventWriter {
 	enqueueControl(value: object): Promise<void> {
 		if (this.failure !== undefined) return Promise.reject(this.failure);
 		const targetId = this.connectionContext.getStore();
-		const registered = targetId === undefined ? undefined : this.connections.get(targetId);
+		const registered = targetId === undefined ? undefined : this.fanout.get(targetId);
 		if (registered) {
 			registered.actor.enqueue(serializeJsonLine(value));
 			return Promise.resolve();
@@ -275,11 +224,9 @@ export class SessionEventWriter {
 		this.sealedSessions.add(sessionId);
 		const targetId = this.connectionContext.getStore();
 		const lifecycle = { type: "session_closed", sessionId };
-		for (const connectionId of this.connections.keys()) {
-			this.connections.get(connectionId)!.actor.enqueue(serializeJsonLine(lifecycle));
-		}
+		this.fanout.broadcast(serializeJsonLine(lifecycle));
 		const taggedResponse = { ...response, sessionId };
-		const registered = targetId === undefined ? undefined : this.connections.get(targetId);
+		const registered = targetId === undefined ? undefined : this.fanout.get(targetId);
 		if (registered) registered.actor.enqueue(serializeJsonLine(taggedResponse));
 		else this.appendSessionRecord(sessionId, taggedResponse, targetId);
 		this.requestFlush();
@@ -293,7 +240,7 @@ export class SessionEventWriter {
 	 */
 	forgetSession(sessionId: string): void {
 		this.sealedSessions.delete(sessionId);
-		this.sessionSnapshots.delete(sessionId);
+		this.fanout.forgetSession(sessionId);
 	}
 
 	/** Drain every retained lane and the current in-flight record. */
@@ -302,7 +249,7 @@ export class SessionEventWriter {
 		this.flushScheduled = false;
 		if (this.drainPromise) return this.drainPromise;
 		if (this.readyQueues.length === 0)
-			return Promise.all([...this.connections.values()].map(({ actor }) => actor.flush())).then(() => undefined);
+			return Promise.all([...this.fanout.values()].map(({ actor }) => actor.flush())).then(() => undefined);
 		let resolveDrain!: () => void;
 		let rejectDrain!: (cause: unknown) => void;
 		const drain = new Promise<void>((resolve, reject) => {
@@ -328,7 +275,7 @@ export class SessionEventWriter {
 		do {
 			await this.drainReadyQueues();
 		} while (this.readyQueues.length > 0);
-		await Promise.all([...this.connections.values()].map(({ actor }) => actor.flush()));
+		await Promise.all([...this.fanout.values()].map(({ actor }) => actor.flush()));
 	}
 
 	private async drainReadyQueues(): Promise<void> {
@@ -343,7 +290,7 @@ export class SessionEventWriter {
 			try {
 				// D9: exactly one complete record per raw write. The next lane is not
 				// selected until this record has cleared stdout backpressure.
-				const connection = queue.targetId ? this.connections.get(queue.targetId)?.connection : undefined;
+				const connection = queue.targetId ? this.fanout.get(queue.targetId)?.connection : undefined;
 				const writeRaw = connection?.writeRaw ?? this.writeRaw;
 				const waitForBackpressure = connection?.waitForBackpressure ?? this.waitForBackpressure;
 				if (!connection && queue.targetId) {
@@ -368,17 +315,6 @@ export class SessionEventWriter {
 				}
 			}
 		}
-	}
-
-	private rememberSnapshot(sessionId: string, value: RpcRecord, line: string): void {
-		const event = value.assistantMessageEvent as Record<string, unknown> | undefined;
-		const record = { line, rendered: value[RENDERED_COMPONENT_RECORD] === true };
-		if (value.type === "message_start" || (value.type === "message_update" && event?.type === "text_start")) {
-			this.sessionSnapshots.set(sessionId, [record]);
-		} else if (this.sessionSnapshots.has(sessionId)) {
-			this.sessionSnapshots.get(sessionId)!.push(record);
-		}
-		if (value.type === "message_end") this.sessionSnapshots.delete(sessionId);
 	}
 
 	private connectionQueue(targetId: string): RecordQueue {

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -178,13 +178,8 @@ export class SessionEventWriter {
 		const tagged = { ...value, sessionId } as RpcRecord;
 		const { [RENDERED_COMPONENT_RECORD]: _rendered, ...wireTagged } = tagged;
 		const line = serializeJsonLine(wireTagged);
-		this.fanout.rememberSnapshot(sessionId, tagged, line);
-		const targets = this.fanout.targets(
-			sessionId,
-			targetId,
-			isTargeted,
-			record[RENDERED_COMPONENT_RECORD] === true,
-		);
+		if (!isTargeted) this.fanout.rememberSnapshot(sessionId, tagged, line);
+		const targets = this.fanout.targets(sessionId, targetId, isTargeted, record[RENDERED_COMPONENT_RECORD] === true);
 		for (const target of targets) {
 			if (target !== undefined && !this.fanout.get(target)) continue;
 			const registered = target === undefined ? undefined : this.fanout.get(target);

--- a/packages/coding-agent/test/rpc-client-reconnect.test.ts
+++ b/packages/coding-agent/test/rpc-client-reconnect.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test, vi } from "vitest";
-import { RpcClient, RpcTransportGoneError } from "../src/modes/rpc/rpc-client.ts";
+import { RpcClient, RpcClientOpenInFlightError, RpcTransportGoneError } from "../src/modes/rpc/rpc-client.ts";
 
 describe("RpcClient disconnect lifecycle", () => {
 	test("fails sends with a classified transport error before start", async () => {
@@ -41,5 +41,107 @@ describe("RpcClient disconnect lifecycle", () => {
 			server.close();
 			rmSync(directory, { recursive: true, force: true });
 		}
+	});
+
+	test("drops session events without a lease and delivers its leased session events", () => {
+		const client = new RpcClient();
+		let events = 0;
+		client.onEvent((event) => {
+			if (event.type === "agent_settled") events++;
+		});
+		// biome-ignore lint/complexity/useLiteralKeys: access the private parser seam for a focused unit test
+		client["handleLine"](`${JSON.stringify({ type: "agent_settled", sessionId: "foreign" })}\n`);
+		expect(events).toBe(0);
+		// biome-ignore lint/complexity/useLiteralKeys: access the private client lease for a focused unit test
+		client["sessionId"] = "owned";
+		// biome-ignore lint/complexity/useLiteralKeys: access the private parser seam for a focused unit test
+		client["handleLine"](`${JSON.stringify({ type: "agent_settled", sessionId: "owned" })}\n`);
+		expect(events).toBe(1);
+	});
+
+	test("rejects a concurrent open_session before sending it", async () => {
+		const directory = mkdtempSync(join(tmpdir(), "rpc-client-open-in-flight-"));
+		const socketPath = join(directory, "rpc.sock");
+		let peer: import("node:net").Socket | undefined;
+		let received = "";
+		let firstRequestId: string | undefined;
+		let resolveFirstRequest: (() => void) | undefined;
+		const firstRequest = new Promise<void>((resolve) => {
+			resolveFirstRequest = resolve;
+		});
+		try {
+			const server = createServer((socket) => {
+				peer = socket;
+				socket.on("data", (chunk) => {
+					received += chunk.toString();
+					const newline = received.indexOf("\n");
+					if (newline === -1) return;
+					const request = JSON.parse(received.slice(0, newline)) as { id: string };
+					received = received.slice(newline + 1);
+					firstRequestId = request.id;
+					resolveFirstRequest?.();
+				});
+			});
+			await new Promise<void>((resolve) => server.listen(socketPath, resolve));
+			const client = new RpcClient({ socketPath });
+			await client.start();
+			const first = client.openSession({ cwd: "/tmp" });
+			await firstRequest;
+			const second = client.openSession({ cwd: "/tmp" });
+			await expect(second).rejects.toBeInstanceOf(RpcClientOpenInFlightError);
+			await expect(second).rejects.toMatchObject({ code: "open_session_in_flight" });
+			peer?.write(
+				`${JSON.stringify({ type: "response", id: firstRequestId, success: true, data: { sessionId: "owned", state: {} } })}\n`,
+			);
+			await expect(first).resolves.toMatchObject({ sessionId: "owned" });
+			expect(peer).toBeDefined();
+			server.close();
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	test("bounds buffered pre-lease events by count and preserves newest FIFO records", () => {
+		const client = new RpcClient();
+		const sequences: number[] = [];
+		client.onEvent((event) => {
+			const sequence: unknown = Reflect.get(event, "sequence");
+			if (event.type === "agent_settled" && typeof sequence === "number") sequences.push(sequence);
+		});
+		// biome-ignore lint/complexity/useLiteralKeys: drive the private pending-open seam for a focused unit test
+		client["pendingOpenSession"] = true;
+		for (let sequence = 0; sequence < 520; sequence++)
+			// biome-ignore lint/complexity/useLiteralKeys: access the private parser seam for a focused unit test
+			client["handleLine"](`${JSON.stringify({ type: "agent_settled", sessionId: "owned", sequence })}\n`);
+		// biome-ignore lint/complexity/useLiteralKeys: access the private client lease for a focused unit test
+		client["sessionId"] = "owned";
+		// biome-ignore lint/complexity/useLiteralKeys: drive the private pending-open seam for a focused unit test
+		client["pendingOpenSession"] = false;
+		// biome-ignore lint/complexity/useLiteralKeys: drive the private flush seam for a focused unit test
+		client["flushPendingSessionEvents"]();
+
+		expect(sequences).toEqual(Array.from({ length: 512 }, (_, index) => index + 8));
+	});
+
+	test("buffers own startup events during open and drops foreign events", () => {
+		const client = new RpcClient();
+		let events = 0;
+		client.onEvent((event) => {
+			if (event.type === "agent_settled") events++;
+		});
+		// biome-ignore lint/complexity/useLiteralKeys: access the private open state for a focused unit test
+		client["pendingOpenSession"] = true;
+		// biome-ignore lint/complexity/useLiteralKeys: access the private parser seam for a focused unit test
+		client["handleLine"](`${JSON.stringify({ type: "agent_settled", sessionId: "owned" })}\n`);
+		// biome-ignore lint/complexity/useLiteralKeys: access the private parser seam for a focused unit test
+		client["handleLine"](`${JSON.stringify({ type: "agent_settled", sessionId: "foreign" })}\n`);
+		expect(events).toBe(0);
+		// biome-ignore lint/complexity/useLiteralKeys: access the private client lease for a focused unit test
+		client["sessionId"] = "owned";
+		// biome-ignore lint/complexity/useLiteralKeys: access the private open state for a focused unit test
+		client["pendingOpenSession"] = false;
+		// biome-ignore lint/complexity/useLiteralKeys: access the private drain seam for a focused unit test
+		client["flushPendingSessionEvents"]();
+		expect(events).toBe(1);
 	});
 });

--- a/packages/coding-agent/test/rpc-multi-session-events.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-events.test.ts
@@ -227,6 +227,29 @@ describe("multi-session RPC event writer", () => {
 		expect(chunks).toHaveLength(5);
 	});
 
+	it("delivers session agent events only to attached connections", async () => {
+		const a: string[] = [];
+		const b: string[] = [];
+		const unattached: string[] = [];
+		const writer = new SessionEventWriter(() => {});
+		writer.registerConnection("a", { writeRaw: (chunk) => a.push(chunk), waitForBackpressure: async () => {} });
+		writer.registerConnection("b", { writeRaw: (chunk) => b.push(chunk), waitForBackpressure: async () => {} });
+		writer.registerConnection("unattached", {
+			writeRaw: (chunk) => unattached.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.attachConnectionToSession("a", "s1");
+		writer.attachConnectionToSession("b", "s2");
+
+		writer.enqueue("s1", { type: "message_update", message: "s1" });
+		await writer.flush();
+
+		expect(records(a)).toHaveLength(1);
+		expect(records(a)[0]).toMatchObject({ sessionId: "s1", message: "s1" });
+		expect(records(b)).toEqual([]);
+		expect(records(unattached)).toEqual([]);
+	});
+
 	it("does not let a gated socket stall a fast socket", async () => {
 		const slowGate = deferred<void>();
 		const slow: string[] = [];
@@ -240,6 +263,8 @@ describe("multi-session RPC event writer", () => {
 			writeRaw: (chunk) => fast.push(chunk),
 			waitForBackpressure: async () => {},
 		});
+		writer.attachConnectionToSession("slow", "session");
+		writer.attachConnectionToSession("fast", "session");
 
 		writer.enqueue("session", { type: "event", sequence: 1 });
 		await new Promise<void>((resolve) => queueMicrotask(resolve));
@@ -257,6 +282,7 @@ describe("multi-session RPC event writer", () => {
 			writeRaw: (chunk) => first.push(chunk),
 			waitForBackpressure: async () => {},
 		});
+		writer.attachConnectionToSession("first", "session");
 		writer.enqueue("session", { type: "message_start", message: { role: "assistant", content: [] } });
 		writer.enqueue("session", {
 			type: "message_update",
@@ -268,6 +294,7 @@ describe("multi-session RPC event writer", () => {
 			writeRaw: (chunk) => second.push(chunk),
 			waitForBackpressure: async () => {},
 		});
+		writer.attachConnectionToSession("second", "session");
 		writer.enqueue("session", {
 			type: "message_update",
 			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "two" },
@@ -277,6 +304,51 @@ describe("multi-session RPC event writer", () => {
 		expect(
 			records(second).map((record) => (record.assistantMessageEvent as { delta?: string })?.delta ?? record.type),
 		).toEqual(["message_start", "one", "two"]);
+	});
+
+	it("does not replay targeted records to a connection attaching mid-turn", async () => {
+		const first: string[] = [];
+		const second: string[] = [];
+		const writer = new SessionEventWriter(() => {});
+		writer.registerConnection("first", {
+			writeRaw: (chunk) => first.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.attachConnectionToSession("first", "session");
+		writer.enqueue("session", { type: "message_start" });
+		writer.withConnection("first", () => writer.enqueue("session", { type: "response", id: "private-response" }));
+		writer.withConnection("first", () =>
+			writer.enqueue("session", { type: "extension_ui_request", id: "private-dialog", method: "confirm" }),
+		);
+		writer.registerConnection("second", {
+			writeRaw: (chunk) => second.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.attachConnectionToSession("second", "session");
+		await writer.flush();
+
+		expect(records(second)).toEqual([{ type: "message_start", sessionId: "session" }]);
+		expect(records(first).some((record) => record.id === "private-response")).toBe(true);
+		expect(records(first).some((record) => record.id === "private-dialog")).toBe(true);
+	});
+
+	it("replays an attaching connection only once when attach is repeated", async () => {
+		const output: string[] = [];
+		const writer = new SessionEventWriter(() => {});
+		writer.registerConnection("client", {
+			writeRaw: (chunk) => output.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.enqueue("session", { type: "message_start" });
+		writer.enqueue("session", { type: "message_update", sequence: 1 });
+		writer.attachConnectionToSession("client", "session");
+		writer.attachConnectionToSession("client", "session");
+		await writer.flush();
+
+		expect(records(output)).toEqual([
+			{ type: "message_start", sessionId: "session" },
+			{ type: "message_update", sequence: 1, sessionId: "session" },
+		]);
 	});
 
 	it("filters rendered snapshot replay by each connection capability", async () => {
@@ -304,6 +376,7 @@ describe("multi-session RPC event writer", () => {
 			writeRaw: (chunk) => defaultClient.push(chunk),
 			waitForBackpressure: async () => {},
 		});
+		writer.attachConnectionToSession("default", "session");
 		writer.registerConnection("late-capable", {
 			writeRaw: (chunk) => lateCapable.push(chunk),
 			waitForBackpressure: async () => {},
@@ -364,6 +437,7 @@ describe("multi-session RPC event writer", () => {
 		writer.registerConnection("b", { writeRaw: (chunk) => b.push(chunk), waitForBackpressure: async () => {} });
 		writer.setConnectionCapabilities("a", ["rendered_components"]);
 		writer.attachConnectionToSession("a", "session");
+		writer.attachConnectionToSession("b", "session");
 		writer.enqueue("session", {
 			type: "extension_ui_request",
 			method: "setWidget",
@@ -387,6 +461,8 @@ describe("multi-session RPC event writer", () => {
 		);
 		writer.registerConnection("a", { writeRaw: (chunk) => chunks.push(chunk), waitForBackpressure: async () => {} });
 		writer.registerConnection("b", { writeRaw: (chunk) => chunks.push(chunk), waitForBackpressure: async () => {} });
+		writer.attachConnectionToSession("a", "session");
+		writer.attachConnectionToSession("b", "session");
 		writer.withConnection("a", () =>
 			writer.enqueue("session", { type: "extension_ui_request", id: "dialog", method: "confirm" }),
 		);

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -713,7 +713,7 @@ describe("RPC Unix-socket multi-connection host", () => {
 		});
 	});
 
-	it("delivers foreign commands, broadcasts tagged events, survives malformed frames, and reconnects", async () => {
+	it("delivers foreign commands only after attachment, survives malformed frames, and reconnects", async () => {
 		const qa = scratch("semantics");
 		const fake = await startFakeModelServer();
 		writeRpcModelsJson(qa.agentDir, fake.origin);
@@ -745,7 +745,6 @@ describe("RPC Unix-socket multi-connection host", () => {
 			const sessionId = openedSessionId(opened);
 
 			const settledA = a.peer.waitFor((value) => value.type === "agent_settled" && value.sessionId === sessionId);
-			const settledB = b.peer.waitFor((value) => value.type === "agent_settled" && value.sessionId === sessionId);
 			await expect(
 				b.peer.request({
 					id: "foreign-prompt",
@@ -754,7 +753,8 @@ describe("RPC Unix-socket multi-connection host", () => {
 					message: "unique-424242",
 				}),
 			).resolves.toMatchObject({ success: true, sessionId });
-			await Promise.all([settledA, settledB]);
+			await settledA;
+			expect(b.peer.messages.some((value) => value.type === "agent_settled" && value.sessionId === sessionId)).toBe(false);
 
 			const transcript = await b.peer.request({
 				id: "foreign-transcript",
@@ -789,6 +789,48 @@ describe("RPC Unix-socket multi-connection host", () => {
 		} finally {
 			a.peer.close();
 			a.socket.destroy();
+			b.socket.destroy();
+			await fake.close();
+		}
+	});
+
+	it("isolates a mid-turn session from attached and unattached raw sockets", async () => {
+		const qa = scratch("mid-turn-isolation");
+		const secondCwd = join(qa.root, "second-work");
+		mkdirSync(secondCwd, { recursive: true });
+		const fake = await startFakeModelServer();
+		writeRpcModelsJson(qa.agentDir, fake.origin);
+		const child = spawnRpc(
+			["--mode", "rpc", "--listen", `unix://${qa.socketPath}`, "--provider", MOCK_PROVIDER, "--model", MOCK_MODEL],
+			qa,
+		);
+		await waitForStderr(child, `senpi rpc listening on unix://${qa.socketPath}`);
+		const a = await connectPeer(qa.socketPath);
+		const b = await connectPeer(qa.socketPath);
+		try {
+			const openedA = await a.peer.request({ id: "open-p1", type: "open_session", cwd: qa.cwd });
+			const openedB = await b.peer.request({ id: "open-p2", type: "open_session", cwd: secondCwd });
+			const sessionB = openedSessionId(openedB);
+			const turnStarted = b.peer.waitFor(
+				(value) => value.type === "message_start" && value.sessionId === sessionB,
+			);
+			const turn = b.peer.request({ id: "prompt-p2", type: "prompt", sessionId: sessionB, message: "isolation-turn" });
+			await turnStarted;
+			const third = await connectPeer(qa.socketPath);
+			try {
+				await turn;
+				const foreign = (value: RecordValue) => value.sessionId === sessionB && value.type !== "session_closed";
+				expect(a.peer.messages.some(foreign)).toBe(false);
+				expect(third.peer.messages.some(foreign)).toBe(false);
+			} finally {
+				third.peer.close();
+				third.socket.destroy();
+			}
+			expect(openedSessionId(openedA)).not.toBe(sessionB);
+		} finally {
+			a.peer.close();
+			a.socket.destroy();
+			b.peer.close();
 			b.socket.destroy();
 			await fake.close();
 		}

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -754,7 +754,9 @@ describe("RPC Unix-socket multi-connection host", () => {
 				}),
 			).resolves.toMatchObject({ success: true, sessionId });
 			await settledA;
-			expect(b.peer.messages.some((value) => value.type === "agent_settled" && value.sessionId === sessionId)).toBe(false);
+			expect(b.peer.messages.some((value) => value.type === "agent_settled" && value.sessionId === sessionId)).toBe(
+				false,
+			);
 
 			const transcript = await b.peer.request({
 				id: "foreign-transcript",
@@ -811,10 +813,13 @@ describe("RPC Unix-socket multi-connection host", () => {
 			const openedA = await a.peer.request({ id: "open-p1", type: "open_session", cwd: qa.cwd });
 			const openedB = await b.peer.request({ id: "open-p2", type: "open_session", cwd: secondCwd });
 			const sessionB = openedSessionId(openedB);
-			const turnStarted = b.peer.waitFor(
-				(value) => value.type === "message_start" && value.sessionId === sessionB,
-			);
-			const turn = b.peer.request({ id: "prompt-p2", type: "prompt", sessionId: sessionB, message: "isolation-turn" });
+			const turnStarted = b.peer.waitFor((value) => value.type === "message_start" && value.sessionId === sessionB);
+			const turn = b.peer.request({
+				id: "prompt-p2",
+				type: "prompt",
+				sessionId: sessionB,
+				message: "isolation-turn",
+			});
 			await turnStarted;
 			const third = await connectPeer(qa.socketPath);
 			try {


### PR DESCRIPTION
## Summary
- Scope multi-session socket agent events to connections attached to the session.
- Stop newly registered sockets from replaying every session's in-flight snapshot.
- Drop foreign session events while `RpcClient` is lease-less, while buffering the opening session's own startup events until `open_session` establishes its lease.

## Root cause
- `packages/coding-agent/src/modes/rpc/session-event-writer.ts` targeted non-rendered records at every connection and replayed every session snapshot on registration.
- `packages/coding-agent/src/modes/rpc/rpc-client.ts` previously allowed all tagged events through while its lease was undefined. Tightening that predicate exposed a startup ordering requirement: extension `session_start` events can arrive before the `open_session` response.

## Contract change
Agent events are attachment-scoped. To observe a foreign session, open it by its existing `sessionPath`; the router's attach-on-open path registers that connection for the session. `session_closed` remains broadcast because it carries no content and observers rely on roster visibility.

During an in-flight `open_session`, `RpcClient` buffers tagged events. Once the response establishes the lease, it synchronously delivers buffered events for that session in arrival order and discards foreign events. Outside an in-flight open, lease-less clients drop all tagged events.

## Tests
- Writer coverage proves session events reach only attached connections and unattached sockets receive none.
- Real socket-host coverage proves another attached session and a newly connected unattached socket receive no foreign turn records.
- RpcClient coverage proves lease-less foreign records are dropped and own pre-lease startup records are delivered only after lease establishment.
- Interactive runtime coverage proves startup factory UI remains visible through the normal runtime API.

## Evidence
- Biome check: passed.
- `tsc --noEmit`: passed.
- Selected regression suite: 8 files passed, 100 tests passed.
- `[remote] done rc=0 tree=5975d43ab`

Closes #1271
