### PR TITLE
feat(codemode): name the active bun-1-4 skill as MUST READ in the eval prompt

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+- The eval prompt's JS runtime line is now runtime-aware: on a bun kernel it names `Bun <version>` and
+  `Bun.*` builtins, and only while the bundled `bun-1-4` skill is active it adds a MUST READ pointer to
+  that skill's absolute path before the first js cell; node kernels keep the Node.js worker wording.
+  `activeBunSkillPath()` exposes the same gate the `resources_discover` contribution uses.
 ### Fixed
 
 ### Removed

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -12,6 +12,9 @@
   `Bun.*` builtins, and only while the bundled `bun-1-4` skill is active it adds a MUST READ pointer to
   that skill's absolute path before the first js cell; node kernels keep the Node.js worker wording.
   `activeBunSkillPath()` exposes the same gate the `resources_discover` contribution uses.
+- The bundled `bun-1-4` skill description is rewritten as a fact-framed MUST READ notice with
+  English-only copy (Korean trigger words removed; the `Bun.stringWidth` example no longer uses Hangul).
+
 ### Fixed
 
 ### Removed

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -36,7 +36,9 @@ task-tool names are known.
   resolves absolute executable paths, and the eval prompt host line names the
   JS runtime (`node`/`bun`).
 - JavaScript import rewriting for supported local modules and package imports
-  in the persistent Node.js worker.
+  in the persistent JS worker (Bun when senpi runs on bun, Node.js otherwise).
+- On a Bun >= 1.4 kernel the eval prompt names the bundled `bun-1-4` skill as
+  MUST READ before the first js cell; node kernels keep the Node.js wording.
 - GPT models receive a terse `eval` prompt dialect that prioritizes composing
   active tools through `tool.<name>(args)` and documents detach-on-timeout.
 
@@ -44,7 +46,7 @@ task-tool names are known.
 
 | Language | Default | Runtime | Notes |
 | --- | --- | --- | --- |
-| `js` | enabled | Node.js worker | Requires Node.js 24 or newer; supports top-level `await` and `return`. |
+| `js` | enabled | In-process worker on senpi's own runtime (Bun or Node.js 24+) | Supports top-level `await` and `return`; the eval prompt's runtime line follows the kernel. |
 | `py` | enabled | `python3` or `python` | Optional interpreter detected at session start. |
 | `rb` | disabled | `ruby` | Optional interpreter detected at session start. |
 | `jl` | disabled | `julia` | Optional interpreter detected at session start. |

--- a/packages/senpi-codemode/src/extension/skill-contribution.ts
+++ b/packages/senpi-codemode/src/extension/skill-contribution.ts
@@ -39,17 +39,25 @@ export function bundledBunSkillPath(baseDir: string = BUN_SKILL_BASE_DIR): strin
 }
 
 /**
- * Builds the `resources_discover` handler that contributes the bundled bun-1-4 skill
- * only when the in-process js eval kernel itself runs bun >= 1.4 (`process.versions.bun`).
- * A node kernel never receives the skill, regardless of any bun binary on PATH.
+ * Absolute path of the bundled bun-1-4 SKILL.md when it is active for this process:
+ * the in-process js eval kernel itself runs bun >= 1.4 (`process.versions.bun`) and the
+ * asset is shipped. A node kernel never activates it, regardless of any bun binary on PATH.
  */
+export function activeBunSkillPath(
+	getKernelBunVersion: BunKernelVersionSource = kernelBunVersion,
+	baseDir?: string,
+): string | undefined {
+	if (!bunVersionSupportsSkill(getKernelBunVersion())) return undefined;
+	return bundledBunSkillPath(baseDir);
+}
+
+/** Builds the `resources_discover` handler that contributes the active bun-1-4 skill, if any. */
 export function createBunSkillDiscoverHandler(
 	getKernelBunVersion: BunKernelVersionSource = kernelBunVersion,
 	baseDir?: string,
 ): () => { skillPaths: string[] } | undefined {
 	return () => {
-		if (!bunVersionSupportsSkill(getKernelBunVersion())) return undefined;
-		const skillPath = bundledBunSkillPath(baseDir);
+		const skillPath = activeBunSkillPath(getKernelBunVersion, baseDir);
 		return skillPath === undefined ? undefined : { skillPaths: [skillPath] };
 	};
 }

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { jsRuntimeInfo, jsRuntimeLabel } from "./extension/runtime-info.ts";
 import type { CodemodeSessionManager, CreateCodemodeSessionManagerOptions } from "./extension/session-manager.ts";
 import { SessionManagerProxy } from "./extension/session-manager-proxy.ts";
-import { registerBunSkillContribution } from "./extension/skill-contribution.ts";
+import { activeBunSkillPath, registerBunSkillContribution } from "./extension/skill-contribution.ts";
 import { WAKE_SOURCE_STATE_EVENT, type WakeSourceState } from "./extension/wake-source-state.ts";
 import { EvalDetachedCellManager, type EvalDetachedCellStatusEntry } from "./tool/detached-cell-manager.ts";
 import {
@@ -68,6 +68,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 	const manager = new SessionManagerProxy();
 	const complete = options.complete ?? ((request, ctx) => createCompletionHandler()(ctx)(request));
 	const renderers = { renderCall: renderEvalCall, renderResult: renderEvalResult };
+	const bunSkillPath = activeBunSkillPath();
 	let activeRuntime: SessionRuntime | undefined;
 	let activeModelId: string | undefined;
 	let activeContext: ExtensionContext | undefined;
@@ -125,6 +126,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 				spawnDefaultAgent: runtime.settings.taskTools.task,
 				hostLine: hostLine(),
 				runtimes: runtime.runtimes,
+				...(bunSkillPath === undefined ? {} : { bunSkillPath }),
 				...(modelId === undefined ? {} : { modelId }),
 			}),
 		);
@@ -159,6 +161,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			renderers,
 			hostLine: hostLine(),
 			runtimes: { js: jsRuntimeInfo() },
+			...(bunSkillPath === undefined ? {} : { bunSkillPath }),
 		}),
 	);
 	pi.registerRemovedToolHint(

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -1,3 +1,5 @@
+import type { EvalRuntimeInfo } from "../tool/types.ts";
+
 export interface EnabledLanguages {
 	readonly py: boolean;
 	readonly js: boolean;
@@ -18,6 +20,10 @@ export interface EvalPromptOptions {
 	readonly modelId?: string;
 	/** Preformatted host line (e.g. "darwin arm64 · Apple M5 Max · 18 cores"); enables the host-sizing note. */
 	readonly hostLine?: string;
+	/** Identity of the in-process js kernel; a bun runtime swaps the Node.js worker line for the Bun one. */
+	readonly jsRuntime?: EvalRuntimeInfo;
+	/** Absolute path of the active bun-1-4 skill; rendered as a MUST READ pointer only on a bun kernel. */
+	readonly bunSkillPath?: string;
 }
 
 /** Prompt dialect for the eval-first batching emphasis. */
@@ -132,7 +138,7 @@ Fields:
 A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
 
 {{#if py}}Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".{{/if}}
-{{#if js}}JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.{{/if}}
+{{#if js}}{{#if jsBun}}JS runs in-process on Bun {{jsVersion}}: top-level \`await\`/\`return\` work; \`Bun.*\` builtins available.{{#if bunSkillPath}} MUST READ the bun-1-4 skill at {{bunSkillPath}} before your first js cell — its builtins replace the npm packages you would otherwise install.{{/if}}{{else}}JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.{{/if}}{{/if}}
 {{#if rb}}Ruby: synchronous; helper options are keyword args{{#if spawns}} (e.g. \`output("id", limit: 2)\`){{/if}}; the last expression auto-displays unless it is \`nil\`, an assignment, or a definition (like IRB).{{/if}}
 {{#if jl}}Julia: synchronous; helper options are standard keyword args{{#if spawns}} (e.g. \`output("id", limit=2)\`){{/if}}; the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).{{/if}}
 On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
@@ -212,6 +218,9 @@ export function buildEvalPrompt(
 		styleKimi: style === "kimi",
 		styleDefault: style === "default",
 		hostLine: options.hostLine ?? "",
+		jsBun: options.jsRuntime?.name === "bun",
+		jsVersion: options.jsRuntime?.version ?? "",
+		bunSkillPath: options.bunSkillPath ?? "",
 	};
 	const examples = REUSE_CHAIN_EXAMPLES.filter((example) => enabled[example.language])
 		.map((example) => {

--- a/packages/senpi-codemode/src/skill/bun-1-4/SKILL.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-1-4
-description: "MUST USE whenever writing or running JavaScript/TypeScript with Bun — including JS through the eval tool, bun -e one-liners, scratch scripts, servers, CLIs, tests, bundling, or package management. Bun 1.4 replaced 15+ npm deps with builtins: consult BEFORE npm-installing sharp, puppeteer/playwright (scraping), marked, node-cron, node-pty, concurrently, serve-static, tar, json5, fast-xml-parser, string-width — Bun ships it. Triggers: bun, Bun.serve, bun test, bun build, bun install, bun run, JS 스크립트, 번들링, 이미지 리사이즈, 헤드리스 브라우저, 크론, PTY, eval js."
+description: "MUST READ before your first js eval cell: this session's eval js kernel runs Bun 1.4+ (this skill is present only when it does). Also read before any bun -e, script, server, CLI, test, bundle, or package-management work. Bun 1.4 ships builtins that replace 15+ npm deps — check here BEFORE installing sharp, puppeteer/playwright (scraping), marked, node-cron, node-pty, concurrently, serve-static, tar, json5, fast-xml-parser, string-width. Triggers: eval js, bun, Bun.serve, bun test, bun build, bun install, bun run, image resize, headless browser, markdown render, cron, PTY."
 ---
 
 # Bun 1.4 — Use the Builtins First

--- a/packages/senpi-codemode/src/skill/bun-1-4/references/runtime-apis.md
+++ b/packages/senpi-codemode/src/skill/bun-1-4/references/runtime-apis.md
@@ -139,7 +139,7 @@ Blog: [#also-built-in](https://bun.com/blog/bun-v1.4#also-built-in)
 Docs: <https://bun.com/docs/runtime/utils>
 
 ```ts
-Bun.stringWidth("한글 text");     // terminal columns, ANSI + grapheme aware
+Bun.stringWidth("\x1b[32mgreen\x1b[0m e\u0301"); // terminal columns, ANSI + grapheme aware
 Bun.sliceAnsi(str, 0, 20);        // slice by columns, preserving ANSI codes
 Bun.wrapAnsi(str, 80);            // wrap by columns
 ```

--- a/packages/senpi-codemode/src/tool/eval-tool-options.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool-options.ts
@@ -39,8 +39,10 @@ export interface CreateEvalToolOptions {
 	readonly spawnDefaultAgent?: string;
 	readonly modelId?: string;
 	readonly hostLine?: string;
-	/** Display identity of each language's runtime, shown in headers and details. */
+	/** Display identity of each language's runtime, shown in headers and details; `js` also selects the prompt's runtime line. */
 	readonly runtimes?: EvalRuntimes;
+	/** Absolute path of the active bun-1-4 skill; the prompt names it as MUST READ on a bun kernel. */
+	readonly bunSkillPath?: string;
 }
 
 export interface EvalCellInvocation {

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -31,6 +31,8 @@ export function createEvalTool(options: CreateEvalToolOptions): ToolDefinition<E
 		...(options.spawnDefaultAgent === undefined ? {} : { spawnDefaultAgent: options.spawnDefaultAgent }),
 		...(options.modelId === undefined ? {} : { modelId: options.modelId }),
 		...(options.hostLine === undefined ? {} : { hostLine: options.hostLine }),
+		...(options.runtimes?.js === undefined ? {} : { jsRuntime: options.runtimes.js }),
+		...(options.bunSkillPath === undefined ? {} : { bunSkillPath: options.bunSkillPath }),
 	});
 	const languages = enabledLanguageList(options.enabledLanguages);
 	const cellManager =

--- a/packages/senpi-codemode/test/bun-skill-contribution.test.ts
+++ b/packages/senpi-codemode/test/bun-skill-contribution.test.ts
@@ -2,6 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	activeBunSkillPath,
 	bundledBunSkillPath,
 	bunVersionSupportsSkill,
 	createBunSkillDiscoverHandler,
@@ -31,6 +32,19 @@ describe("bundledBunSkillPath", () => {
 		expect(result).toBe(bunSkillMd);
 		expect(result !== undefined && existsSync(result)).toBe(true);
 	});
+});
+
+describe("activeBunSkillPath", () => {
+	it("returns the bundled SKILL.md path on a bun >= 1.4 kernel", () => {
+		expect(activeBunSkillPath(() => "1.4.2")).toBe(bunSkillMd);
+	});
+
+	it.each([{ version: "1.3.0" }, { version: undefined }, { version: "not-a-version" }])(
+		"returns undefined for kernel version $version",
+		({ version }) => {
+			expect(activeBunSkillPath(() => version)).toBeUndefined();
+		},
+	);
 });
 
 describe("createBunSkillDiscoverHandler", () => {

--- a/packages/senpi-codemode/test/bun-skill-contribution.test.ts
+++ b/packages/senpi-codemode/test/bun-skill-contribution.test.ts
@@ -105,6 +105,14 @@ describe("bun-1-4 skill assets", () => {
 		expect(references).toHaveLength(10);
 	});
 
+	it("ships English-only copy: no Hangul in SKILL.md or any reference", () => {
+		const hangul = /[\u1100-\u11ff\u3130-\u318f\uac00-\ud7af]/u;
+		const files = [bunSkillMd, ...readdirSync(bunSkillRefs).map((name) => join(bunSkillRefs, name))];
+		for (const file of files) {
+			expect(hangul.test(readFileSync(file, "utf8")), file).toBe(false);
+		}
+	});
+
 	it("ships a single document: one frontmatter block and one H1", () => {
 		const text = readFileSync(bunSkillMd, "utf8");
 		expect(text.match(/^---$/gm)).toHaveLength(2);

--- a/packages/senpi-codemode/test/eval-tool-prompt-runtime.test.ts
+++ b/packages/senpi-codemode/test/eval-tool-prompt-runtime.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { EvalRuntimes } from "../src/tool/types.ts";
+import { FakeManager } from "./eval/fakes.ts";
+
+const bunSkillPath = "/opt/senpi/skill/bun-1-4/SKILL.md";
+
+function evalDescription(options: { readonly runtimes?: EvalRuntimes; readonly bunSkillPath?: string }): string {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager: new FakeManager([]),
+		cellTimeoutSeconds: 30,
+		executeTool: vi.fn(),
+		...options,
+	}).description;
+}
+
+describe("createEvalTool prompt runtime line", () => {
+	it("names the active bun-1-4 skill as MUST READ on a bun kernel", () => {
+		const description = evalDescription({
+			runtimes: { js: { name: "bun", version: "1.4.0", path: "/usr/local/bin/bun" } },
+			bunSkillPath,
+		});
+
+		expect(description).toContain("JS runs in-process on Bun 1.4.0");
+		expect(description).toContain(`MUST READ the bun-1-4 skill at ${bunSkillPath}`);
+	});
+
+	it("keeps the Bun line without a pointer when no skill is active", () => {
+		const description = evalDescription({ runtimes: { js: { name: "bun", version: "1.4.0" } } });
+
+		expect(description).toContain("JS runs in-process on Bun 1.4.0");
+		expect(description).not.toContain("MUST READ");
+	});
+
+	it("keeps the Node.js wording on a node kernel even when a skill path is supplied", () => {
+		const description = evalDescription({
+			runtimes: { js: { name: "node", version: "26.7.0", path: "/usr/local/bin/node" } },
+			bunSkillPath,
+		});
+
+		expect(description).toContain("Node.js worker");
+		expect(description).not.toContain(bunSkillPath);
+	});
+});

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -97,7 +97,7 @@ describe("buildEvalPrompt", () => {
 		expect(ruby).not.toContain("<examples>");
 	});
 
-	it("documents core helpers with Node wording and no excluded surface", () => {
+	it("documents core helpers with Node wording and no excluded surface when no js runtime is given", () => {
 		const prompt = fullPrompt({ py: true, js: true, rb: true, jl: true });
 
 		for (const helperName of coreHelperNames) {
@@ -218,6 +218,42 @@ describe("buildEvalPrompt", () => {
 		expect(withHost).toContain("Host: darwin arm64 \u00b7 Apple M5 Max \u00b7 18 cores — cells execute here.");
 		expect(withHost).toContain("Size `parallel(thunks)` pools to its cores");
 		expect(withoutHost).not.toContain("Host:");
+	});
+
+	it("describes the Bun kernel and names the bun-1-4 skill as MUST READ only while it is active", () => {
+		// Given: the same kernel set under a bun kernel with the skill, a bun kernel without it, and a node kernel.
+		const enabled = { py: true, js: true, rb: false, jl: false };
+		const bunSkillPath = "/opt/senpi/skill/bun-1-4/SKILL.md";
+		const bunWithSkill = buildEvalPrompt(enabled, {
+			spawns: false,
+			jsRuntime: { name: "bun", version: "1.4.0", path: "/usr/local/bin/bun" },
+			bunSkillPath,
+		}).description;
+		const bunWithoutSkill = buildEvalPrompt(enabled, {
+			spawns: false,
+			jsRuntime: { name: "bun", version: "1.3.9", path: "/usr/local/bin/bun" },
+		}).description;
+		const node = buildEvalPrompt(enabled, {
+			spawns: false,
+			jsRuntime: { name: "node", version: "26.7.0", path: "/usr/local/bin/node" },
+			bunSkillPath,
+		}).description;
+		const jsDisabled = buildEvalPrompt(
+			{ py: true, js: false, rb: false, jl: false },
+			{ spawns: false, jsRuntime: { name: "bun", version: "1.4.0" }, bunSkillPath },
+		).description;
+
+		// Then: only the bun kernel with an active skill carries the pointer; node keeps its wording.
+		expect(bunWithSkill).toContain("JS runs in-process on Bun 1.4.0");
+		expect(bunWithSkill).toContain(`MUST READ the bun-1-4 skill at ${bunSkillPath} before your first js cell`);
+		expect(bunWithSkill).not.toContain("Node.js worker");
+		expect(bunWithoutSkill).toContain("JS runs in-process on Bun 1.3.9");
+		expect(bunWithoutSkill).not.toContain("MUST READ");
+		expect(node).toContain("Node.js worker");
+		expect(node).not.toContain("MUST READ");
+		expect(node).not.toContain(bunSkillPath);
+		expect(jsDisabled).not.toContain("Bun");
+		expect(jsDisabled).not.toContain(bunSkillPath);
 	});
 
 	it("throws when no kernels are enabled", () => {


### PR DESCRIPTION
## Why

The bundled `bun-1-4` skill is contributed via `resources_discover` only when the js eval kernel runs Bun >= 1.4, but nothing at the point of use told the model so. The eval tool description still said `JS runs under Node.js worker` on a bun kernel (contradicting the `bun 1.4.0` host line right above it), `test/prompt.test.ts` pinned that wording and forbade the token `Bun`, and the skill description was framed conditionally ("MUST USE whenever ... with Bun"), so the model had to infer it was on Bun from a prompt that told it Node. Result: the skill sat unread among ~130 entries in `<available_skills>`.

## What

- `src/prompt/eval-prompt.ts`: the js runtime line is now runtime-aware. On a bun kernel it reads `JS runs in-process on Bun <version>: ... Bun.* builtins available.` and, **only while the bundled skill is active**, appends `MUST READ the bun-1-4 skill at <absolute SKILL.md path> before your first js cell — its builtins replace the npm packages you would otherwise install.` Node kernels keep the existing `Node.js worker` wording; a bun kernel below 1.4 gets the Bun line without the pointer. The pointer is nested inside the bun branch of the template, so a stray `bunSkillPath` can never surface on a node kernel.
- `src/extension/skill-contribution.ts`: `activeBunSkillPath()` extracted; it is the single gate shared by the `resources_discover` handler and the prompt, so the pointer and the skill listing can never disagree.
- `src/index.ts` / `src/tool/eval-tool.ts` / `eval-tool-options.ts`: `runtimes.js` (already carried for the header badge) and `bunSkillPath` are wired into `buildEvalPrompt` for both the load-time and the `session_start` / `model_select` registrations.
- `src/skill/bun-1-4/SKILL.md`: description rewritten as a fact-framed MUST READ notice (the skill is only visible when the kernel is Bun 1.4, so it states that instead of asking the model to infer it). Korean trigger words removed; `references/runtime-apis.md` no longer uses Hangul in the `Bun.stringWidth` example. English-only copy is pinned by a new asset test.
- README and CHANGELOG `[Unreleased]` updated. No net growth for node kernels; the bun branch adds one sentence that carries the skill path the model cannot derive.

## Verification (mengmotaMac via bunshin, `/tmp/senpi-bunskill-20260902`, HEAD bb8f1239e)

- `packages/senpi-codemode`: `bun run test` -> 681 passed, 6 skipped, 1 failed (`test/js-kernel-inline-fallback.test.ts`, 150 ms cell deadline hit under load ~100-148; unrelated to this change, passed 2/2 on rerun).
- Targeted: `prompt.test.ts`, `eval-tool-prompt-runtime.test.ts`, `bun-skill-contribution.test.ts`, `extension.test.ts`, `factory.test.ts` -> 5 files, 53 tests passed. Snapshots unchanged (no `jsRuntime` -> Node wording).
- Mutation checks (each restored afterwards): dropping the MUST READ sentence from the template fails 2 tests; forcing `jsBun: true` fails 6 (node case + snapshots); reintroducing a Hangul token in the skill description fails the English-only asset test.
- `bunx biome check --error-on-warnings packages/senpi-codemode` clean; root `bunx tsc --noEmit` exit 0.
- Real surface under Bun 1.4.0: instantiating the extension with a fake host and printing the registered `eval` description yields

  ```
  Host: darwin arm64 · Apple M5 Max · 18 cores · bun 1.4.0 — cells execute here. ...
  JS runs in-process on Bun 1.4.0: top-level `await`/`return` work; `Bun.*` builtins available. MUST READ the bun-1-4 skill at /private/tmp/senpi-bunskill-20260902/packages/senpi-codemode/src/skill/bun-1-4/SKILL.md before your first js cell — its builtins replace the npm packages you would otherwise install.
  ```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the eval prompt runtime-aware so the bundled `bun-1-4` skill no longer sits unread among the available skills on Bun ≥ 1.4 kernels.

- The prompt always said JS runs under a Node.js worker; it now says `JS runs in-process on Bun <version>` on bun kernels and appends a MUST READ pointer to the skill's absolute path before the first js cell. Node kernels keep the existing wording.
- `activeBunSkillPath()` is now the single gate shared by the `resources_discover` handler and the prompt, so the pointer and the skill listing cannot disagree.
- The skill description is reframed as a fact-framed MUST READ notice; Korean trigger words are removed and an asset test pins the skill directory as English-only.

<sup>Written for commit 23e6cad9c255355d5fd99001934c1862565a07a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

