### PR TITLE
fix(codemode): resolve the bundled bun-1-4 skill in compiled binaries and keep RPC stdout clean

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- Compiled binaries now contribute the bundled `bun-1-4` skill by resolving the codemode sidecar shipped next to the executable, and a missing skill is reported on stderr so it can no longer corrupt the RPC protocol stream on stdout.
+
 ### Removed
 
 ## [2026.9.2-2] - 2026-09-02

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,29 @@
 # senpi-codemode fork changes
 
+## Binary skill resolution and stdout-safe miss reporting (2026-09-02)
+
+### What changed
+
+- `packages/senpi-codemode/src/extension/skill-contribution.ts` resolves the bundled
+  `bun-1-4` SKILL.md through `resolveCodemodeRuntimeAsset`, so a compiled binary falls
+  back to the sidecar at
+  `node_modules/@code-yeongyu/senpi-codemode/src/skill/bun-1-4/SKILL.md` next to the
+  executable instead of only probing the embedded module-relative path.
+- The "skill not found" notice moves from `console.debug` to `console.error`.
+- `test/bun-skill-contribution.test.ts` pins both contracts: sidecar resolution in a
+  compiled-binary layout, and stderr-only reporting with stdout untouched.
+
+### Why
+
+- The compiled binary has no readable module-relative asset, so the skill was silently
+  skipped for every binary user, and the notice was written to stdout - the same stream
+  that carries the RPC JSONL protocol. `scripts/smoke-standalone-binary.mjs` parses that
+  stream and failed with `received malformed RPC output`, which failed the `Build binaries`
+  job of `build-binaries.yml` and skipped its final `Dispatch publish-npm.yml` job. Both
+  the v2026.9.2 and v2026.9.2-2 tag runs failed this way, so neither release reached npm.
+- The Ruby and Julia kernel runners already resolve their assets through the same sidecar
+  helper; this brings the skill asset onto that established path.
+
 ## Eval QA owns its temporary agent directory (2026-08-30)
 
 ### What changed

--- a/packages/senpi-codemode/src/extension/skill-contribution.ts
+++ b/packages/senpi-codemode/src/extension/skill-contribution.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../kernels/shared/runtime-asset.ts";
 
 const BUN_SKILL_BASE_DIR = dirname(fileURLToPath(import.meta.url));
 
@@ -27,13 +28,38 @@ export function bunVersionSupportsSkill(version: string | undefined): boolean {
 	return major > 1 || (major === 1 && minor >= 4);
 }
 
-/** Absolute path of the bundled bun-1-4 SKILL.md, or undefined (logged once) when it is not shipped. */
-export function bundledBunSkillPath(baseDir: string = BUN_SKILL_BASE_DIR): string | undefined {
-	const candidate = join(baseDir, "..", "skill", "bun-1-4", "SKILL.md");
+const BUN_SKILL_PACKAGE_RELATIVE_PATH = join("skill", "bun-1-4", "SKILL.md");
+
+/**
+ * Absolute path of the bundled bun-1-4 SKILL.md, or undefined (logged once) when it is not shipped.
+ *
+ * A compiled Bun binary has no readable module-relative asset, so resolution falls back to the
+ * codemode sidecar shipped next to the executable, exactly as the Ruby and Julia kernel runners do.
+ * The miss is reported on stderr because stdout carries the RPC protocol stream.
+ */
+export function bundledBunSkillPath(
+	baseDir: string = BUN_SKILL_BASE_DIR,
+	environment: CodemodeRuntimeAssetEnvironment = {},
+): string | undefined {
+	const localPath = join(baseDir, "..", "skill", "bun-1-4", "SKILL.md");
+	const candidate = resolveCodemodeRuntimeAsset(localPath, BUN_SKILL_PACKAGE_RELATIVE_PATH, environment);
 	if (existsSync(candidate)) return candidate;
 	if (!loggedMissingBunSkill) {
 		loggedMissingBunSkill = true;
-		console.debug(`[senpi-codemode] bundled bun-1-4 skill not found at ${candidate}; skipping contribution`);
+		// A compiled binary never has the module-relative asset, so naming only that path
+		// would hide the sidecar location an operator actually has to populate.
+		const executableDir = dirname(environment.executablePath ?? process.execPath);
+		const sidecarPath = join(
+			executableDir,
+			"node_modules",
+			"@code-yeongyu",
+			"senpi-codemode",
+			"src",
+			BUN_SKILL_PACKAGE_RELATIVE_PATH,
+		);
+		console.error(
+			`[senpi-codemode] bundled bun-1-4 skill not found at ${localPath} or ${sidecarPath}; skipping contribution`,
+		);
 	}
 	return undefined;
 }

--- a/packages/senpi-codemode/test/bun-skill-contribution.test.ts
+++ b/packages/senpi-codemode/test/bun-skill-contribution.test.ts
@@ -1,6 +1,7 @@
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	activeBunSkillPath,
 	bundledBunSkillPath,
@@ -45,6 +46,84 @@ describe("activeBunSkillPath", () => {
 			expect(activeBunSkillPath(() => version)).toBeUndefined();
 		},
 	);
+});
+
+describe("bundledBunSkillPath in a compiled-binary layout", () => {
+	let tempDir: string | undefined;
+
+	afterEach(() => {
+		if (tempDir !== undefined) {
+			rmSync(tempDir, { recursive: true, force: true });
+			tempDir = undefined;
+		}
+	});
+
+	it("resolves the sidecar skill next to the executable when the embedded path is absent", () => {
+		tempDir = mkdtempSync(join(tmpdir(), "codemode-skill-sidecar-"));
+		const binaryDir = join(tempDir, "bin");
+		const sidecarSkill = join(
+			binaryDir,
+			"node_modules",
+			"@code-yeongyu",
+			"senpi-codemode",
+			"src",
+			"skill",
+			"bun-1-4",
+			"SKILL.md",
+		);
+		mkdirSync(dirname(sidecarSkill), { recursive: true });
+		writeFileSync(sidecarSkill, "---\nname: bun-1-4\n---\n# Bun 1.4\n");
+
+		const result = bundledBunSkillPath(join(tempDir, "embedded", "extension"), {
+			bunVersion: "1.4.0",
+			executablePath: join(binaryDir, "pi"),
+		});
+
+		expect(result).toBe(sidecarSkill);
+	});
+
+	it("reports a missing skill on stderr so RPC stdout stays protocol-clean", async () => {
+		vi.resetModules();
+		const fresh = await import("../src/extension/skill-contribution.ts");
+		tempDir = mkdtempSync(join(tmpdir(), "codemode-skill-missing-"));
+		const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+		const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		try {
+			const result = fresh.bundledBunSkillPath(join(tempDir, "embedded", "extension"), {
+				bunVersion: "1.4.0",
+				executablePath: join(tempDir, "bin", "pi"),
+			});
+
+			expect(result).toBeUndefined();
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			expect(debugSpy).not.toHaveBeenCalled();
+			expect(logSpy).not.toHaveBeenCalled();
+
+			// The notice names BOTH probed locations: a compiled binary never has the
+			// module-relative asset, so the sidecar path is the actionable one.
+			const notice = String(errorSpy.mock.calls[0]?.[0] ?? "");
+			expect(notice).toContain(join(tempDir, "embedded", "skill", "bun-1-4", "SKILL.md"));
+			expect(notice).toContain(
+				join(
+					tempDir,
+					"bin",
+					"node_modules",
+					"@code-yeongyu",
+					"senpi-codemode",
+					"src",
+					"skill",
+					"bun-1-4",
+					"SKILL.md",
+				),
+			);
+		} finally {
+			debugSpy.mockRestore();
+			logSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
 });
 
 describe("createBunSkillDiscoverHandler", () => {


### PR DESCRIPTION
## Problem

**No senpi release has reached npm today.** Both `v2026.9.2` and `v2026.9.2-2` tag runs of `build-binaries.yml` failed identically at the `Build binaries` step, which skips its final `Dispatch publish-npm.yml` job:

```
Error: pi codemode RPC smoke received malformed RPC output:
[senpi-codemode] bundled bun-1-4 skill not found at /$bunfs/skill/bun-1-4/SKILL.md; skipping contribution
```

Evidence: npm packument `modified=2026-09-02T01:52:30Z` predates both release runs, and `@code-yeongyu/senpi@2026.9.2-2` does not exist on the registry while the git tag does.

## Root cause

`packages/senpi-codemode/src/extension/skill-contribution.ts` has two defects that compound:

1. It resolves the bundled `bun-1-4` SKILL.md only relative to `import.meta.url`. A compiled Bun binary has no readable module-relative asset there, so the skill was **silently skipped for every binary user**.
2. It reported that miss with `console.debug`, which writes to **stdout** — the same stream that carries the RPC JSONL protocol. `scripts/smoke-standalone-binary.mjs` parses stdout line-by-line as JSON and throws `received malformed RPC output` on the notice.

## Fix

- Resolve the skill through the existing `resolveCodemodeRuntimeAsset` helper, so a compiled binary falls back to the sidecar at `node_modules/@code-yeongyu/senpi-codemode/src/skill/bun-1-4/SKILL.md` next to the executable. `scripts/copy-codemode-sidecar.mjs` already ships that tree (`package.json` `files` includes `src`), and the Ruby/Julia kernel runners already resolve their assets exactly this way — this puts the skill asset on the same established path.
- Route the miss notice to `console.error` (stderr), matching the imagegen builtin. **No codemode diagnostic reaches stdout**, so the RPC stream stays protocol-clean regardless of whether the asset is present.

## Evidence (mengmotaMac via bunshin)

- **RED before the fix**: both new contracts fail for the right reasons — sidecar resolution returns `undefined`, and the stderr spy is called 0 times.
- **GREEN after**: `test/bun-skill-contribution.test.ts` 17/17.
- **Mutation proof**: reverting only the sidecar resolution fails exactly the resolution contract; reverting only the stderr routing fails exactly the stdout-purity contract (1 failed / 16 passed each).
- **No regressions introduced**: the package suite reports an identical `50 failed | 45 passed | 1 skipped` on this branch **and on `origin/main`** (pre-existing environment failures, unchanged by this PR); passing tests rise 331 → 333, exactly the two new contracts.
- `biome check --error-on-warnings` exit 0; root `tsc --noEmit` reports 0 errors in the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes compiled `senpi-codemode` binaries silently skipping the bundled `bun-1-4` skill and corrupting RPC stdout, which blocked the last two npm releases.

**Bug Fixes**
- Skill resolution now falls back to the codemode sidecar shipped next to the executable, matching the Ruby and Julia kernel runners.
- The missing-skill notice moves to stderr, so no codemode diagnostic touches the RPC JSONL stream.
- New tests pin both contracts; the package test suite shows no new failures.

<sup>Written for commit 692d05393dffa2b9d63eff41a82c41e449613af9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

