### PR TITLE
test(rpc): tolerate an already-exited host in Windows supervisor teardown

### DIFF
--- a/packages/coding-agent/test/rpc-host-lifecycle.test.ts
+++ b/packages/coding-agent/test/rpc-host-lifecycle.test.ts
@@ -613,15 +613,26 @@ async function ensureLifecycleHost(
 					: { command: process.execPath, args: [hostLifecycleEntry(), "--socket", qa.socket, ...hostArgs] },
 			},
 		});
-		managed.push({
-			pidFile: JSON.parse(await readFile(qa.pidFilePath, "utf8")) as { pid: number; processStartTime: string },
-			pidFilePath: qa.pidFilePath,
-		});
+		managed.push({ pidFile: await recordedPidFile(qa.pidFilePath, ensured.pid), pidFilePath: qa.pidFilePath });
 		return ensured;
 	} catch (error) {
 		throw new Error(
 			`${error instanceof Error ? error.message : String(error)}\n[supervisor stderr]\n${readSupervisorStderr(qa)}`,
 		);
+	}
+}
+
+/**
+ * The transient supervisor can idle-exit between answering the handshake and
+ * ensureHost returning, so the pidfile may already be gone; the returned pid is
+ * still the identity every later liveness/exit probe needs.
+ */
+async function recordedPidFile(pidFilePath: string, pid: number): Promise<{ pid: number; processStartTime: string }> {
+	try {
+		return JSON.parse(await readFile(pidFilePath, "utf8")) as { pid: number; processStartTime: string };
+	} catch (error: unknown) {
+		if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+		return { pid, processStartTime: (await readProcessStartTime(pid)) ?? "" };
 	}
 }
 
@@ -730,11 +741,20 @@ function terminateSupervisor(pid: number, signal: NodeJS.Signals): void {
 		// Bun cannot deliver catchable POSIX signals to detached Windows processes.
 		// taskkill is the real Windows termination primitive; the child watchdog must
 		// still perform the cleanup assertions below when this bypasses JS handlers.
-		execFileSync(
-			"powershell.exe",
-			["-NoProfile", "-NonInteractive", "-Command", `Stop-Process -Id ${String(pid)} -Force`],
-			{ stdio: "ignore", windowsHide: true },
-		);
+		try {
+			execFileSync(
+				"powershell.exe",
+				["-NoProfile", "-NonInteractive", "-Command", `Stop-Process -Id ${String(pid)} -Force`],
+				{ stdio: "ignore", windowsHide: true },
+			);
+		} catch (cause) {
+			// The supervisor idle-exits on its own timer, so it can vanish between the
+			// caller's liveness check and this Stop-Process: an already-gone pid is the
+			// outcome the caller wanted, not a failure.
+			const probe = probeWindowsProcessIdentity(pid, 10_000);
+			if (probe.identity === undefined && !probe.timedOut) return;
+			throw cause;
+		}
 		return;
 	}
 	process.kill(pid, signal);


### PR DESCRIPTION
## Summary

Fixes a Windows-only teardown race in `test/rpc-host-lifecycle.test.ts` that failed the `RPC named pipes (Windows)` CI job on two unrelated PRs today (#1277 attempt 2, #1280 at df1f3ff12).

## Root cause

`stopHostProcess()` checks `hostAlive()` and then calls `terminateSupervisor()` → `Stop-Process -Id <pid> -Force`. The supervisor idle-exits on its own timer (`idleExitMs` 600ms in "starts a fresh host transparently on the next ensure after an idle exit"), so it can exit between the two steps; `execFileSync` then throws `Command failed: powershell.exe ... Stop-Process -Id 7388 -Force` and the test fails in teardown although the host is already gone.

## Change

`terminateSupervisor()` (win32 branch) re-probes the pid with the existing `probeWindowsProcessIdentity()` after a `Stop-Process` failure and returns when the process no longer exists; any other failure (probe timeout, process still present) still throws. Test-only; no runtime code touched.

## Evidence

- CI failure logs: run 33602751743 attempt 2 job 100164143208 and run 33605120492 job 100167240214, both `Error: Command failed: powershell.exe -NoProfile -NonInteractive -Command Stop-Process -Id <pid> -Force` in that test.
- This PR's own `RPC named pipes (Windows)` job is the verification surface (the branch is macOS-inert).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Windows RPC lifecycle test races where the supervisor idle-exits between steps, so teardown and host recording no longer fail on an already-gone process.

- Recording a managed host now falls back to the returned pid and its start time when the pidfile is already gone.
- `Stop-Process` failures re-probe the PID and only ignore a confirmed missing process; other errors still fail.
- Test-only change; runtime code is unaffected.

<sup>Written for commit a0564d74255caf84f73d18eaa8be5f2e1f20fa12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

