### PR TITLE
fix(ai): fall back to manual code entry when the Anthropic OAuth callback port cannot bind

### DIFF
--- a/.agents/skills/senpi-qa/scripts/anthropic-oauth-callback-bind-fallback-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/anthropic-oauth-callback-bind-fallback-probe.mjs
@@ -1,7 +1,12 @@
 import { createServer } from "node:net";
-import { anthropicOAuth } from "../../../../packages/ai/src/auth/oauth/anthropic.ts";
 
+// The lane reads PI_OAUTH_CALLBACK_HOST at module load; pin the default so the
+// blocker below occupies the exact address the login will try to bind.
+const host = "127.0.0.1";
 const port = 53692;
+process.env.PI_OAUTH_CALLBACK_HOST = host;
+const { anthropicOAuth } = await import("../../../../packages/ai/src/auth/oauth/anthropic.ts");
+
 let listener;
 let authUrl;
 let manualPromptSeen = false;
@@ -10,7 +15,7 @@ try {
 	listener = createServer();
 	await new Promise((resolve, reject) => {
 		listener.once("error", reject);
-		listener.listen(port, "127.0.0.1", resolve);
+		listener.listen(port, host, resolve);
 	});
 	const fetchCalls = [];
 	globalThis.fetch = async (_input, init) => {
@@ -33,8 +38,15 @@ try {
 			return `${url.searchParams.get("redirect_uri")}?code=probe-code&state=${url.searchParams.get("state")}`;
 		},
 	});
-	const passed = authUrl && manualPromptSeen && credential.access === "probe-access" && fetchCalls.length === 1;
-	if (!passed) throw new Error("auth_url, manual prompt, and credential were not all observed");
+	const instructions = authUrl?.instructions ?? "";
+	const guidanceOk = instructions.includes(String(port)) && /redirect URL/i.test(instructions) && /EADDRINUSE|EACCES|EPERM/.test(instructions);
+	const redirectOk = fetchCalls[0]?.redirect_uri === `http://localhost:${port}/callback`;
+	const passed = authUrl && manualPromptSeen && credential.access === "probe-access" && fetchCalls.length === 1 && guidanceOk && redirectOk;
+	if (!passed) {
+		throw new Error(
+			`auth_url=${Boolean(authUrl)} manualPrompt=${manualPromptSeen} credential=${credential?.access === "probe-access"} fetchCalls=${fetchCalls.length} guidanceOk=${guidanceOk} redirectOk=${redirectOk} instructions=${JSON.stringify(instructions)}`,
+		);
+	}
 	console.log(`PASS auth_url + manual_code + credential; callback port ${port}; redirect_uri ${fetchCalls[0].redirect_uri}`);
 } catch (error) {
 	console.log(`FAIL ${error instanceof Error ? error.message : String(error)}`);
@@ -42,6 +54,6 @@ try {
 } finally {
 	if (listener) {
 		await new Promise((resolve) => listener.close(resolve));
-		console.log(`CLEANUP closed pre-bound listener on 127.0.0.1:${port}`);
+		console.log(`CLEANUP closed pre-bound listener on ${host}:${port}`);
 	}
 }

--- a/.agents/skills/senpi-qa/scripts/anthropic-oauth-callback-bind-fallback-probe.mjs
+++ b/.agents/skills/senpi-qa/scripts/anthropic-oauth-callback-bind-fallback-probe.mjs
@@ -1,0 +1,47 @@
+import { createServer } from "node:net";
+import { anthropicOAuth } from "../../../../packages/ai/src/auth/oauth/anthropic.ts";
+
+const port = 53692;
+let listener;
+let authUrl;
+let manualPromptSeen = false;
+
+try {
+	listener = createServer();
+	await new Promise((resolve, reject) => {
+		listener.once("error", reject);
+		listener.listen(port, "127.0.0.1", resolve);
+	});
+	const fetchCalls = [];
+	globalThis.fetch = async (_input, init) => {
+		fetchCalls.push(JSON.parse(init.body));
+		return new Response(JSON.stringify({ access_token: "probe-access", refresh_token: "probe-refresh", expires_in: 3600 }), {
+			status: 200,
+			headers: { "Content-Type": "application/json" },
+		});
+	};
+	const credential = await anthropicOAuth.login({
+		signal: new AbortController().signal,
+		notify: (event) => {
+			if (event.type === "auth_url") authUrl = event;
+		},
+		prompt: async (prompt) => {
+			if (prompt.type !== "manual_code") throw new Error(`unexpected prompt ${prompt.type}`);
+			manualPromptSeen = true;
+			if (!authUrl) throw new Error("manual prompt arrived before auth_url");
+			const url = new URL(authUrl.url);
+			return `${url.searchParams.get("redirect_uri")}?code=probe-code&state=${url.searchParams.get("state")}`;
+		},
+	});
+	const passed = authUrl && manualPromptSeen && credential.access === "probe-access" && fetchCalls.length === 1;
+	if (!passed) throw new Error("auth_url, manual prompt, and credential were not all observed");
+	console.log(`PASS auth_url + manual_code + credential; callback port ${port}; redirect_uri ${fetchCalls[0].redirect_uri}`);
+} catch (error) {
+	console.log(`FAIL ${error instanceof Error ? error.message : String(error)}`);
+	process.exitCode = 1;
+} finally {
+	if (listener) {
+		await new Promise((resolve) => listener.close(resolve));
+		console.log(`CLEANUP closed pre-bound listener on 127.0.0.1:${port}`);
+	}
+}

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### Fixed
 
+- Anthropic OAuth now falls back to manual redirect URL entry when callback port 53692 cannot be opened.
+
 ### Removed
 
 ## [2026.9.2-2] - 2026-09-02

--- a/packages/ai/src/auth/oauth/anthropic.ts
+++ b/packages/ai/src/auth/oauth/anthropic.ts
@@ -167,7 +167,11 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
 				});
 				return;
 			}
-			reject(new Error(`Could not open OAuth callback listener at ${CALLBACK_HOST}:${CALLBACK_PORT}: ${formatErrorDetails(err)}`));
+			reject(
+				new Error(
+					`Could not open OAuth callback listener at ${CALLBACK_HOST}:${CALLBACK_PORT}: ${formatErrorDetails(err)}`,
+				),
+			);
 		});
 
 		server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
@@ -251,7 +255,13 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 	const { verifier, challenge } = await generatePKCE();
 	const server = await startCallbackServer(verifier);
 	const manualAbort = new AbortController();
-	const onAbort = () => server.cancelWait();
+	// Cancelling the login must release BOTH waits: the callback listener and the
+	// manual prompt. In manual-only mode (callback port unavailable) the prompt is
+	// the only thing keeping the login alive, so leaving it open would hang cleanup.
+	const onAbort = () => {
+		server.cancelWait();
+		manualAbort.abort();
+	};
 	interaction.signal.addEventListener("abort", onAbort, { once: true });
 	if (interaction.signal.aborted) onAbort();
 	let code: string | undefined;

--- a/packages/ai/src/auth/oauth/anthropic.ts
+++ b/packages/ai/src/auth/oauth/anthropic.ts
@@ -12,11 +12,17 @@ import { oauthErrorHtml, oauthSuccessHtml } from "./oauth-page.ts";
 import { generatePKCE } from "./pkce.ts";
 
 type CallbackServerInfo = {
-	server: Server;
+	server?: Server;
 	redirectUri: string;
+	callbackUnavailable?: { code: string };
 	cancelWait: () => void;
 	waitForCode: () => Promise<{ code: string; state: string } | null>;
 };
+
+export function __setAnthropicOAuthNodeApisForTests(apis: NodeApis | null): void {
+	nodeApis = apis;
+	nodeApisPromise = null;
+}
 
 type NodeApis = {
 	createServer: typeof import("node:http").createServer;
@@ -151,7 +157,17 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
 		});
 
 		server.on("error", (err) => {
-			reject(err);
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code === "EACCES" || code === "EADDRINUSE" || code === "EPERM") {
+				resolve({
+					redirectUri: REDIRECT_URI,
+					callbackUnavailable: { code },
+					cancelWait: () => {},
+					waitForCode: async () => null,
+				});
+				return;
+			}
+			reject(new Error(`Could not open OAuth callback listener at ${CALLBACK_HOST}:${CALLBACK_PORT}: ${formatErrorDetails(err)}`));
 		});
 
 		server.listen(CALLBACK_PORT, CALLBACK_HOST, () => {
@@ -257,8 +273,9 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 		interaction.notify({
 			type: "auth_url",
 			url: `${AUTHORIZE_URL}?${authParams.toString()}`,
-			instructions:
-				"Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
+			instructions: server.callbackUnavailable
+				? `The local OAuth callback port ${CALLBACK_PORT} could not be opened (${server.callbackUnavailable.code}). Complete login in your browser, then copy the final redirect URL from the address bar and paste it here.`
+				: "Complete login in your browser. If the browser is on another machine, paste the final redirect URL here.",
 		});
 
 		const manualPromise = interaction
@@ -307,7 +324,7 @@ async function loginAnthropic(interaction: ProviderAuthInteraction): Promise<OAu
 	} finally {
 		interaction.signal.removeEventListener("abort", onAbort);
 		manualAbort.abort();
-		server.server.close();
+		server.server?.close();
 	}
 }
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -38,7 +38,7 @@
 
 ### What changed
 
-- Anthropic OAuth now falls back to manual redirect URL entry when local callback port 53692 cannot bind with EACCES, EADDRINUSE, or EPERM, while preserving the registered localhost redirect URI.
+- `auth/oauth/anthropic.ts`: Anthropic OAuth now falls back to manual redirect URL entry when local callback port 53692 cannot bind with EACCES, EADDRINUSE, or EPERM, while preserving the registered localhost redirect URI.
 
 ### Why
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -2,6 +2,7 @@
 
 ### What changed
 
+- The login abort handler now aborts the manual `manual_code` prompt as well as the callback wait, so cancelling a manual-only login (callback port unavailable) settles instead of leaving `loginAnthropic` pending.
 - `utils/retry-profile/profiles.ts`: `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries` goes from 3 to 5. Backoff shapes, the server-hint policies, `providerRequest.maxRetries` (still 0, so no hidden second budget), and `KIMI_CODE_RETRY_PROFILE` are untouched.
 
 ### Why

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -2,7 +2,6 @@
 
 ### What changed
 
-- The login abort handler now aborts the manual `manual_code` prompt as well as the callback wait, so cancelling a manual-only login (callback port unavailable) settles instead of leaving `loginAnthropic` pending.
 - `utils/retry-profile/profiles.ts`: `SENPI_DEFAULT_RETRY_PROFILE.turn.maxRetries` goes from 3 to 5. Backoff shapes, the server-hint policies, `providerRequest.maxRetries` (still 0, so no hidden second budget), and `KIMI_CODE_RETRY_PROFILE` are untouched.
 
 ### Why
@@ -39,6 +38,7 @@
 
 ### What changed
 
+- The login abort handler now aborts the manual `manual_code` prompt as well as the callback wait, so cancelling a manual-only login (callback port unavailable) settles instead of leaving `loginAnthropic` pending.
 - `auth/oauth/anthropic.ts`: Anthropic OAuth now falls back to manual redirect URL entry when local callback port 53692 cannot bind with EACCES, EADDRINUSE, or EPERM, while preserving the registered localhost redirect URI.
 
 ### Why

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -34,6 +34,25 @@
 
 - LOW: `utils/retry.ts` provider timeout pattern.
 
+## 2026-09-02 - Anthropic OAuth callback bind fallback
+
+### What changed
+
+- Anthropic OAuth now falls back to manual redirect URL entry when local callback port 53692 cannot bind with EACCES, EADDRINUSE, or EPERM, while preserving the registered localhost redirect URI.
+
+### Why
+
+- Fixed or restricted callback ports can be unavailable on Windows, sandboxed hosts, or when another senpi/Claude process is already listening, so login must not fail before presenting its existing manual-code path.
+
+### Why an extension could not handle it
+
+- The callback listener is created and owned inside the Anthropic provider OAuth implementation before auth interaction events are emitted; an extension cannot intercept its bind failure or preserve the provider's registered redirect URI.
+
+### Expected merge conflict zones
+
+- MEDIUM: `src/auth/oauth/anthropic.ts` callback listener startup, auth URL instructions, and cleanup.
+- LOW: `test/anthropic-oauth.test.ts` OAuth interaction coverage.
+
 ## Cursor conversation cache eviction cannot break a live request (2026-08-31)
 
 ### What changed

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-	__setAnthropicOAuthNodeApisForTests,
-	anthropicOAuth,
-} from "../src/auth/oauth/anthropic.ts";
+import { __setAnthropicOAuthNodeApisForTests, anthropicOAuth } from "../src/auth/oauth/anthropic.ts";
 import type { AuthEvent, AuthPrompt } from "../src/auth/types.ts";
 
 const neverAbortedSignal = new AbortController().signal;
@@ -42,71 +39,100 @@ describe.sequential("Anthropic OAuth", () => {
 		__setAnthropicOAuthNodeApisForTests(null);
 	});
 
-	it("falls back to manual redirect URL entry when the callback port is unavailable", async () => {
-		const error = Object.assign(new Error("listen EACCES: permission denied 127.0.0.1:53692"), { code: "EACCES" });
+	function installFailingListen(code: string): { close: ReturnType<typeof vi.fn> } {
+		const error = Object.assign(new Error(`listen ${code}: 127.0.0.1:53692`), { code });
 		const listeners = new Map<string, (...args: unknown[]) => void>();
 		const close = vi.fn();
 		__setAnthropicOAuthNodeApisForTests({
-			createServer: (() => ({
-				on: (event: string, listener: (...args: unknown[]) => void) => {
-					listeners.set(event, listener);
-					return this;
+			createServer: (() => {
+				const server = {
+					on: (event: string, listener: (...args: unknown[]) => void) => {
+						listeners.set(event, listener);
+						return server;
+					},
+					listen: () => {
+						queueMicrotask(() => listeners.get("error")?.(error));
+						return server;
+					},
+					close,
+				};
+				return server;
+			}) as never,
+		});
+		return { close };
+	}
+
+	for (const code of ["EACCES", "EADDRINUSE", "EPERM"]) {
+		it(`falls back to manual redirect URL entry when the callback port fails with ${code}`, async () => {
+			const { close } = installFailingListen(code);
+			const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit): Promise<Response> => {
+				const body = getJsonBody(init);
+				expect(body.redirect_uri).toBe("http://localhost:53692/callback");
+				expect(body.code).toBe("manual-code");
+				return jsonResponse({ access_token: "access", refresh_token: "refresh", expires_in: 3600 });
+			});
+			vi.stubGlobal("fetch", fetchMock);
+			const events: AuthEvent[] = [];
+			const credential = await anthropicOAuth.login({
+				signal: neverAbortedSignal,
+				notify: (event) => events.push(event),
+				prompt: async (prompt) => {
+					if (prompt.type !== "manual_code") throw new Error(`Unexpected prompt: ${prompt.type}`);
+					const authUrl = events.find((event) => event.type === "auth_url");
+					if (authUrl?.type !== "auth_url") throw new Error("Missing auth URL");
+					const url = new URL(authUrl.url);
+					return `http://localhost:53692/callback?code=manual-code&state=${url.searchParams.get("state")}`;
 				},
-				listen: (_port: number, _host: string, callback: () => void) => {
-					queueMicrotask(() => listeners.get("error")?.(error));
-					return this;
-				},
-				close,
-			})) as never,
+			});
+			const authUrl = events.find((event) => event.type === "auth_url");
+			expect(authUrl?.type).toBe("auth_url");
+			const instructions = authUrl?.type === "auth_url" ? authUrl.instructions : "";
+			expect(instructions).toContain("53692");
+			expect(instructions).toContain(code);
+			expect(instructions).toMatch(/redirect URL/i);
+			expect(credential.access).toBe("access");
+			expect(close).not.toHaveBeenCalled();
+			expect(fetchMock).toHaveBeenCalledOnce();
 		});
-		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit): Promise<Response> => {
-			const body = getJsonBody(init);
-			expect(body.redirect_uri).toBe("http://localhost:53692/callback");
-			expect(body.code).toBe("manual-code");
-			return jsonResponse({ access_token: "access", refresh_token: "refresh", expires_in: 3600 });
+	}
+
+	it("aborts a manual-only login while the manual prompt is still open", async () => {
+		installFailingListen("EADDRINUSE");
+		const controller = new AbortController();
+		let promptSignal: AbortSignal | undefined;
+		const login = anthropicOAuth.login({
+			signal: controller.signal,
+			notify: vi.fn(),
+			prompt: (prompt) =>
+				new Promise<string>((_resolve, reject) => {
+					promptSignal = prompt.signal;
+					prompt.signal?.addEventListener("abort", () => reject(new Error("prompt aborted")), { once: true });
+				}),
 		});
-		vi.stubGlobal("fetch", fetchMock);
-		const events: AuthEvent[] = [];
-		const credential = await anthropicOAuth.login({
-			signal: neverAbortedSignal,
-			notify: (event) => events.push(event),
-			prompt: async (prompt) => {
-				if (prompt.type !== "manual_code") throw new Error(`Unexpected prompt: ${prompt.type}`);
-				const authUrl = events.find((event) => event.type === "auth_url");
-				if (!authUrl || authUrl.type !== "auth_url") throw new Error("Missing auth URL");
-				const url = new URL(authUrl.url);
-				return `http://localhost:53692/callback?code=manual-code&state=${url.searchParams.get("state")}`;
-			},
-		});
-		const authUrl = events.find((event) => event.type === "auth_url");
-		expect(authUrl?.type).toBe("auth_url");
-		expect(authUrl && authUrl.type === "auth_url" ? authUrl.instructions : "").toMatch(/53692|redirect URL/i);
-		expect(credential.access).toBe("access");
-		expect(close).not.toHaveBeenCalled();
-		expect(fetchMock).toHaveBeenCalledOnce();
+		const settled = login.then(
+			() => "resolved",
+			(error: unknown) => (error instanceof Error ? error.message : String(error)),
+		);
+		// Give the login a turn to open the manual prompt, then cancel from the outside.
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		controller.abort();
+		const outcome = await Promise.race([
+			settled,
+			new Promise<string>((resolve) => setTimeout(() => resolve("still pending"), 500)),
+		]);
+		expect(promptSignal?.aborted).toBe(true);
+		expect(outcome).toBe("prompt aborted");
 	});
 
 	it("rejects non-bind callback errors with the callback host and port", async () => {
-		const error = Object.assign(new Error("unexpected failure"), { code: "EUNKNOWN" });
-		const listeners = new Map<string, (...args: unknown[]) => void>();
-		__setAnthropicOAuthNodeApisForTests({
-			createServer: (() => ({
-				on: (event: string, listener: (...args: unknown[]) => void) => {
-					listeners.set(event, listener);
-					return this;
-				},
-				listen: () => {
-					queueMicrotask(() => listeners.get("error")?.(error));
-					return this;
-				},
-				close: vi.fn(),
-			})) as never,
-		});
-		await expect(anthropicOAuth.login({
-			signal: neverAbortedSignal,
-			notify: vi.fn(),
-			prompt: vi.fn(),
-		})).rejects.toThrow(/127\.0\.0\.1:53692/);
+		installFailingListen("EUNKNOWN");
+		await expect(
+			anthropicOAuth.login({
+				signal: neverAbortedSignal,
+				notify: vi.fn(),
+				prompt: vi.fn(),
+			}),
+		).rejects.toThrow(/127\.0\.0\.1:53692/);
 	});
 
 	it("keeps the localhost redirect_uri for manual callback login", async () => {

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { anthropicOAuth } from "../src/auth/oauth/anthropic.ts";
+import {
+	__setAnthropicOAuthNodeApisForTests,
+	anthropicOAuth,
+} from "../src/auth/oauth/anthropic.ts";
 import type { AuthEvent, AuthPrompt } from "../src/auth/types.ts";
 
 const neverAbortedSignal = new AbortController().signal;
@@ -36,6 +39,74 @@ function getJsonBody(init?: RequestInit): Record<string, string> {
 describe.sequential("Anthropic OAuth", () => {
 	afterEach(() => {
 		vi.unstubAllGlobals();
+		__setAnthropicOAuthNodeApisForTests(null);
+	});
+
+	it("falls back to manual redirect URL entry when the callback port is unavailable", async () => {
+		const error = Object.assign(new Error("listen EACCES: permission denied 127.0.0.1:53692"), { code: "EACCES" });
+		const listeners = new Map<string, (...args: unknown[]) => void>();
+		const close = vi.fn();
+		__setAnthropicOAuthNodeApisForTests({
+			createServer: (() => ({
+				on: (event: string, listener: (...args: unknown[]) => void) => {
+					listeners.set(event, listener);
+					return this;
+				},
+				listen: (_port: number, _host: string, callback: () => void) => {
+					queueMicrotask(() => listeners.get("error")?.(error));
+					return this;
+				},
+				close,
+			})) as never,
+		});
+		const fetchMock = vi.fn(async (_input: unknown, init?: RequestInit): Promise<Response> => {
+			const body = getJsonBody(init);
+			expect(body.redirect_uri).toBe("http://localhost:53692/callback");
+			expect(body.code).toBe("manual-code");
+			return jsonResponse({ access_token: "access", refresh_token: "refresh", expires_in: 3600 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+		const events: AuthEvent[] = [];
+		const credential = await anthropicOAuth.login({
+			signal: neverAbortedSignal,
+			notify: (event) => events.push(event),
+			prompt: async (prompt) => {
+				if (prompt.type !== "manual_code") throw new Error(`Unexpected prompt: ${prompt.type}`);
+				const authUrl = events.find((event) => event.type === "auth_url");
+				if (!authUrl || authUrl.type !== "auth_url") throw new Error("Missing auth URL");
+				const url = new URL(authUrl.url);
+				return `http://localhost:53692/callback?code=manual-code&state=${url.searchParams.get("state")}`;
+			},
+		});
+		const authUrl = events.find((event) => event.type === "auth_url");
+		expect(authUrl?.type).toBe("auth_url");
+		expect(authUrl && authUrl.type === "auth_url" ? authUrl.instructions : "").toMatch(/53692|redirect URL/i);
+		expect(credential.access).toBe("access");
+		expect(close).not.toHaveBeenCalled();
+		expect(fetchMock).toHaveBeenCalledOnce();
+	});
+
+	it("rejects non-bind callback errors with the callback host and port", async () => {
+		const error = Object.assign(new Error("unexpected failure"), { code: "EUNKNOWN" });
+		const listeners = new Map<string, (...args: unknown[]) => void>();
+		__setAnthropicOAuthNodeApisForTests({
+			createServer: (() => ({
+				on: (event: string, listener: (...args: unknown[]) => void) => {
+					listeners.set(event, listener);
+					return this;
+				},
+				listen: () => {
+					queueMicrotask(() => listeners.get("error")?.(error));
+					return this;
+				},
+				close: vi.fn(),
+			})) as never,
+		});
+		await expect(anthropicOAuth.login({
+			signal: neverAbortedSignal,
+			notify: vi.fn(),
+			prompt: vi.fn(),
+		})).rejects.toThrow(/127\.0\.0\.1:53692/);
 	});
 
 	it("keeps the localhost redirect_uri for manual callback login", async () => {


### PR DESCRIPTION
## Summary
- Make Anthropic OAuth login survive an unavailable local callback listener on port 53692.
- Preserve the registered `http://localhost:53692/callback` redirect URI and use the existing manual redirect URL prompt.

## Root cause
`anthropicOAuth.login` started the fixed-port callback server before emitting `auth_url`. Any `EACCES` or `EADDRINUSE` listen error rejected login before the manual-code interaction could be shown.

## Fix
- Treat `EACCES`, `EADDRINUSE`, and `EPERM` as callback-unavailable and continue in manual-only mode.
- Tell users that port 53692 could not be opened and to paste the final browser redirect URL.
- Keep unexpected listen errors fatal with the callback host and port in the error.
- Make cleanup tolerate the absent callback server.

## Tests
- RED (before implementation): the new bind-fallback regression test rejected before emitting `auth_url` with the listen error.
- GREEN (local): `bunx vitest run packages/ai/test/anthropic-oauth.test.ts` -> `Test Files 1 passed; Tests 5 passed`.
- Remote Anthropic OAuth test/build runs on gorky are attached by the orchestrator.

## Real-surface probe
- The probe pre-binds `127.0.0.1:53692`, runs the real `anthropicOAuth.login`, scripts the manual redirect URL, stubs token exchange, and verifies the credential.
- Branch and baseline real-surface probe outputs are attached by the orchestrator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anthropic OAuth no longer aborts before the manual redirect URL prompt when localhost callback port 53692 cannot bind; it now continues with manual code entry while preserving `http://localhost:53692/callback` for token exchange. Cancelling this manual-only flow now aborts the prompt instead of leaving login pending.

**Bug Fixes**

- Shows the bind error code and port-specific guidance for `EACCES`, `EADDRINUSE`, and `EPERM`.
- Keeps unexpected listener errors fatal with the callback host and port, and makes cleanup safe without a listener.
- Adds unit coverage and a real-surface probe for bind failures, cancellation, and redirect URI preservation.

<sup>Written for commit 624010979174d623e5671eed5fa2a67ca876fcec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

