### PR TITLE
ci(release): budget the release job for an in-job test gate

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -30,7 +30,12 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # `--ref main` resolves at run start, so the release can always check out a commit
+    # whose CI has not finished yet; the test gate then runs the full suite in-job.
+    # Measured full-gate releases land at 22-26 min, so a 30 min cap has under 5 min
+    # of headroom and kills the job mid-suite (run 33605173502). Budget for the slow
+    # path plus growth; gate-reused releases still finish in ~4 min.
+    timeout-minutes: 50
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Problem

The release job dies at its time cap whenever the test gate has to run the suite in-job.

`gh workflow run --ref main` resolves the ref **at run start**, so a release can always check out a commit whose `Check and test` has not finished yet. `release.mjs`'s gate then correctly reports `no green "Check and test" check for HEAD <sha>` and runs `CI=1 npm test` inside the release job.

Run [33605173502](https://github.com/code-yeongyu/senpi/actions/runs/33605173502) hit exactly that: `Run release` ran 07:49:15 → 08:12:02 (**22m47s**) against `timeout-minutes: 30` and was killed mid-`pi-ai` vitest. The log ends with no error annotation and every completed suite green (`fail 0`, 538 passed) — the signature of a cap kill, not a test failure. No tag was pushed, so `build-binaries.yml` never ran and nothing published.

## Why 30 is too thin

Measured `publish-npm.yml` durations:

| run | conclusion | duration |
|---|---|---|
| 33605173502 | failure (cap kill) | 26m |
| 33598014571 | success | 22m |
| 33579124060 | success | 25m |
| 33383284966 | success | 23m |

Full-gate releases land at 22–26 min against a 30 min cap — under 5 minutes of headroom on a job whose duration grows with the monorepo. Releases that *do* reuse a green CI result finish in ~4 min (runs 33580818451, 33385815238, 33323300236), so this budget only binds on the slow path.

## Change

Raise the release job to `timeout-minutes: 50` and record why in a comment. Nothing else changes: the gate logic, the publish path, and the fast path are untouched.

## Verification

- Patch applies cleanly and the YAML structure holds (`timeout-minutes: 50`, preceding lines all comments) — checked on the bunshin mesh.
- Config-only change with no test seam; no runtime source under `packages/*/src` is touched, and `.github/workflows/publish-npm.yml` is fork-only (absent from the `.github/upstream.json` pin), so no tracker or CHANGELOG entry is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the release job timeout from 30 to 50 minutes so the in-job full test gate can finish instead of being killed on slower releases. The green-CI fast path, gate logic, and publishing steps remain unchanged, with a comment documenting the measured 22–26 minute runtime.

<sup>Written for commit 40aa838ffb5c8b02d81b66b84444d79884d1b576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

