### PR TITLE
fix(rpc): size the ensure-host lock wait to the startup critical section

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Two concurrent shared-host starts for one socket no longer fail with a raw `database is locked`: the ensure-lock wait now covers the whole host startup critical section (probe, incompatible-host stop, spawned-host readiness) instead of ten seconds.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-02 - Size the ensure-host lock wait to the startup critical section
+
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/host-ensure.ts` derives the ensure-lock wait budget (`ENSURE_LOCK_WAIT_MS`, 42s) from the longest critical section a holder can run - existing-host probe, incompatible-host stop (SIGTERM wait plus SIGKILL grace), then spawned-host readiness - instead of the previous 10s (100 x 100ms) constant that only covered a fraction of it. The stop/readiness/SIGKILL literals now share named constants with that derivation.
+
+### Why
+
+- Two concurrent `ensureHost` callers for one socket serialize on the SQLite ensure lock; when the first holder's section outlived 10s the second surfaced a raw `database is locked` instead of reusing the host. This flaked the Windows RPC named-pipes CI job (`serializes concurrent starts for one socket across agent directories`) and is the same failure a second interactive session would hit on a slow machine.
+
+### Why an extension could not handle it
+
+- The lock wait is part of the host handshake below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: the constants block near the top of `host-ensure.ts` and the two `stopManagedHost` call sites.
+
 ## 2026-09-01 - Windows shared hosts use deterministic named pipes
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -71,10 +71,27 @@ type ProtocolInfo = {
 	readonly capabilities: readonly string[];
 };
 
-const lockOptions = { retries: { retries: 100, minTimeout: 20, maxTimeout: 100 } } as const;
 const REQUIRED_CAPABILITIES = ["multi_session", EXTENSION_EVENTS_CAPABILITY] as const;
 const SPAWNED_HOST_PROBE_TIMEOUT_MS = 10_000;
 const EXISTING_HOST_PROBE_TIMEOUT_MS = 10_000;
+const DEFAULT_READINESS_TIMEOUT_MS = 10_000;
+const DEFAULT_STOP_TIMEOUT_MS = 10_000;
+const SIGKILL_GRACE_MS = 2_000;
+/**
+ * A lock waiter must outlast the longest critical section a holder can run:
+ * probing an existing host, stopping an incompatible one (SIGTERM wait plus the
+ * SIGKILL grace), then spawning the replacement and waiting for it to answer.
+ * Each SQLite busy wait stays short because it blocks the event loop; this
+ * cumulative budget is what covers the whole section, with headroom for a slow
+ * runner. A waiter that gives up early surfaces as a raw "database is locked"
+ * failure on the second of two concurrent starts.
+ */
+const ENSURE_LOCK_WAIT_MS =
+	EXISTING_HOST_PROBE_TIMEOUT_MS + DEFAULT_STOP_TIMEOUT_MS + SIGKILL_GRACE_MS + DEFAULT_READINESS_TIMEOUT_MS + 10_000;
+const LOCK_BUSY_WAIT_MS = 100;
+const lockOptions = {
+	retries: { retries: ENSURE_LOCK_WAIT_MS / LOCK_BUSY_WAIT_MS, minTimeout: 20, maxTimeout: LOCK_BUSY_WAIT_MS },
+} as const;
 /**
  * Every ensured host starts with this installation-wide profile, independent of
  * the first caller. In particular, extension_events must remain available when
@@ -131,7 +148,7 @@ async function ensureHostLocked(
 		throw new Error(`RPC socket ${socket} is owned by an unmanaged host`);
 	}
 	if (pidFile && pidMatches) {
-		await stopManagedHost(pidFile, testOptions?.stopTimeoutMs ?? 10_000);
+		await stopManagedHost(pidFile, testOptions?.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS);
 	}
 	await cleanupState(paths);
 	return startHost(paths, socket, agentDir, policy, testOptions);
@@ -219,10 +236,10 @@ async function startHost(
 	} finally {
 		await stderr.close();
 	}
-	const readinessTimeoutMs = testOptions?.readinessTimeoutMs ?? 10_000;
+	const readinessTimeoutMs = testOptions?.readinessTimeoutMs ?? DEFAULT_READINESS_TIMEOUT_MS;
 	const result = await pollProtocolInfo(socket, readinessTimeoutMs, childExit);
 	if (isCompatible(result.protocol)) return { pid: pidFile.pid, socket, reused: false };
-	await stopManagedHost(pidFile, testOptions?.stopTimeoutMs ?? 10_000);
+	await stopManagedHost(pidFile, testOptions?.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS);
 	const message = result.protocol
 		? `RPC socket host answered get_protocol_info with serverVersion ${result.protocol.serverVersion} and capabilities ${JSON.stringify(result.protocol.capabilities)}, but is incompatible with serverVersion ${VERSION} and required capabilities ${JSON.stringify(REQUIRED_CAPABILITIES)}`
 		: result.exited
@@ -240,7 +257,7 @@ async function stopManagedHost(pidFile: DaemonPidFile, termTimeoutMs: number): P
 	await signalValidated(pidFile, "SIGTERM");
 	if (await waitForGone(pidFile, termTimeoutMs)) return;
 	await signalValidated(pidFile, "SIGKILL");
-	if (!(await waitForGone(pidFile, 2_000))) {
+	if (!(await waitForGone(pidFile, SIGKILL_GRACE_MS))) {
 		throw new Error(`RPC socket host pid ${pidFile.pid} remained alive after SIGKILL`);
 	}
 }

--- a/packages/coding-agent/test/rpc-host-ensure.test.ts
+++ b/packages/coding-agent/test/rpc-host-ensure.test.ts
@@ -70,6 +70,43 @@ describe("ensureHost", () => {
 		expect(secondResult).toMatchObject({ socket: qa.socket, reused: true });
 	}, 45_000);
 
+	it("waits for a holder whose critical section outlasts the previous ten-second lock budget", async () => {
+		const qa = await scratch("long-critical-section");
+		const secondAgentDir = join(qa.root, "other-agent");
+		let signalFirstLocked!: () => void;
+		const firstAcquired = new Promise<void>((resolve) => (signalFirstLocked = resolve));
+		const first = ensureHost({
+			agentDir: qa.agentDir,
+			socket: qa.socket,
+			_test: {
+				afterLockAcquired: async () => {
+					signalFirstLocked();
+					// Longer than the old cumulative wait (100 x 100ms): a waiter that still
+					// used it gave up with a raw "database is locked" instead of reusing.
+					await new Promise<void>((resolve) => setTimeout(resolve, 12_000));
+				},
+				spawn: {
+					command: process.execPath,
+					args: [fixture, qa.socket, VERSION, "multi_session,extension_events", "answer"],
+				},
+			},
+		});
+		await firstAcquired;
+		const second = ensureHost({
+			agentDir: secondAgentDir,
+			socket: qa.socket,
+			_test: {
+				spawn: {
+					command: process.execPath,
+					args: [fixture, qa.socket, VERSION, "multi_session,extension_events", "answer"],
+				},
+			},
+		});
+		const [firstResult, secondResult] = await Promise.all([first, second]);
+		expect(firstResult.reused).toBe(false);
+		expect(secondResult).toMatchObject({ socket: qa.socket, reused: true });
+	}, 60_000);
+
 	it("starts a missing host and reuses it on the second call", async () => {
 		const qa = await scratch("start-reuse");
 		const first = await ensureFixtureHost(qa);


### PR DESCRIPTION
## Summary

Two concurrent `ensureHost()` callers for the same socket serialize on the SQLite ensure lock. The waiter's cumulative budget was 100 x 100 ms = 10 s, but the holder's critical section can run an existing-host probe (10 s), an incompatible-host stop (10 s SIGTERM wait + 2 s SIGKILL grace) and a spawned-host readiness wait (10 s) back to back. A waiter that outlived the budget failed with a raw `Error: database is locked` instead of reusing the host.

This is the failure behind the `RPC named pipes (Windows)` flake `rpc-host-ensure.test.ts > serializes concurrent starts for one socket across agent directories` (seen on #1277 attempt 1 and #1284), and the same failure two interactive sessions would hit on a slow machine.

## Change

`host-ensure.ts`: derive `ENSURE_LOCK_WAIT_MS` (42 s) from the named bounds of the critical section and build `lockOptions` from it; the stop/readiness/SIGKILL literals become the named constants that derivation uses, so the call sites cannot drift from the budget. Per-attempt SQLite busy waits stay at 100 ms (they block the event loop).

## Tests (RED -> GREEN, remote runner gorky, node v24.4.1)

- New: `ensureHost > waits for a holder whose critical section outlasts the previous ten-second lock budget` (first holder keeps the lock 12 s; the second caller must reuse).
  - RED on base 0267481cc: `Error: database is locked` (1 failed | 12 passed).
  - GREEN with the fix: `test/rpc-host-ensure.test.ts` + `test/rpc-host-lifecycle.test.ts` -> 2 files, 42 tests passed; `tsc --noEmit` clean.

Companion test-only fix for the other Windows teardown flake in the same job: #1284.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concurrent shared-host starts failing with a raw `database is locked` when the first holder's startup critical section outlasts the previous 10-second lock wait. The ensure-lock wait now covers the whole section (42s) by deriving it from the named probe/stop/readiness timeouts, so the second caller waits and then reuses the host.

- Derives `ENSURE_LOCK_WAIT_MS` from `EXISTING_HOST_PROBE_TIMEOUT_MS`, `DEFAULT_STOP_TIMEOUT_MS`, `SIGKILL_GRACE_MS`, and `DEFAULT_READINESS_TIMEOUT_MS` plus headroom.
- Names the stop/readiness/SIGKILL literals so call sites cannot drift from the budget.
- Adds a regression test where the first holder keeps the lock for 12s and the second caller must reuse the host.

<sup>Written for commit c48f8831a50e286cf2f2d0fccfbed66b171245c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

