### PR TITLE
fix(ai): advertise Claude Code 2.1.251 in Anthropic OAuth requests

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+- Anthropic OAuth requests advertise `claude-cli/2.1.251` instead of the stale `2.1.75`, so Claude Fable 5.1 and Opus 5 no longer fail with `claude_code_version_too_old` (syncs upstream pi `96317e50`) ([oh-my-openagent#7650](https://github.com/code-yeongyu/oh-my-openagent/issues/7650)).
 - Anthropic OAuth now falls back to manual redirect URL entry when callback port 53692 cannot be opened.
 
 ### Removed

--- a/packages/ai/src/api/anthropic-messages.ts
+++ b/packages/ai/src/api/anthropic-messages.ts
@@ -114,7 +114,7 @@ function getCacheControl(
 }
 
 // Stealth mode: Mimic Claude Code's tool naming exactly
-const claudeCodeVersion = "2.1.75";
+const claudeCodeVersion = "2.1.251";
 
 // Claude Code 2.x tool names (canonical casing)
 // Source: https://cchistory.mariozechner.at/data/prompts-2.1.11.md

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,21 @@
+## Anthropic OAuth advertises Claude Code 2.1.251 (2026-09-02)
+
+### What changed
+
+- `packages/ai/src/api/anthropic-messages.ts`: `claudeCodeVersion` goes from `2.1.75` to `2.1.251`, so the OAuth client's `user-agent` header is `claude-cli/2.1.251`. Same value as upstream pi commit `96317e50`; the OAuth beta list, `x-app`, and tool naming are untouched.
+
+### Why
+
+- Anthropic now rejects OAuth requests for Claude Fable 5.1 and Opus 5 whose advertised Claude Code version is below 2.1.251 (`error_code: claude_code_version_too_old`), regardless of the Claude Code actually installed on the machine. Tracked as oh-my-openagent#7650. `test/anthropic-oauth-claude-code-version.test.ts` pins the advertised version at or above that minimum.
+
+### Why an extension could not handle it
+
+- The header is assembled inside `createClient()` before `onPayload` hooks run and is not part of the model or request options an extension can override; the SDK client is constructed with it as a default header.
+
+### Expected merge conflict zones
+
+- LOW: the single `claudeCodeVersion` constant near the top of `api/anthropic-messages.ts`; upstream already carries the identical value, so the next pin sync should resolve cleanly.
+
 ## senpi-default retry profile is more patient with slow providers (2026-09-02)
 
 ### What changed

--- a/packages/ai/test/anthropic-oauth-claude-code-version.test.ts
+++ b/packages/ai/test/anthropic-oauth-claude-code-version.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getBuiltinModel as getModel } from "../src/providers/all.ts";
+import { streamAnthropic } from "../src/providers/anthropic.ts";
+import type { Context } from "../src/types.ts";
+
+// Anthropic rejects OAuth requests whose advertised Claude Code version is older
+// than this with `claude_code_version_too_old`; the advertised version must never
+// fall below it. Mirrors upstream pi 96317e50 (2.1.75 -> 2.1.251).
+const MINIMUM_CLAUDE_CODE_VERSION = [2, 1, 251] as const;
+
+const mockState = vi.hoisted(() => ({
+	constructorOptions: undefined as { defaultHeaders?: Record<string, string | null> } | undefined,
+}));
+
+vi.mock("@anthropic-ai/sdk", () => {
+	function createSseResponse(): Response {
+		const body = [
+			`event: message_start\ndata: ${JSON.stringify({
+				type: "message_start",
+				message: {
+					id: "msg_test",
+					usage: { input_tokens: 10, output_tokens: 0 },
+				},
+			})}\n`,
+			`event: message_delta\ndata: ${JSON.stringify({
+				type: "message_delta",
+				delta: { stop_reason: "end_turn" },
+				usage: { output_tokens: 5 },
+			})}\n`,
+			`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n`,
+		].join("\n");
+
+		return new Response(body, {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	}
+
+	class FakeAnthropic {
+		constructor(options: { defaultHeaders?: Record<string, string | null> }) {
+			mockState.constructorOptions = options;
+		}
+
+		messages = {
+			create: () => ({
+				asResponse: async () => createSseResponse(),
+			}),
+		};
+	}
+
+	return { default: FakeAnthropic };
+});
+
+function parseClaudeCliVersion(userAgent: string | null | undefined): readonly [number, number, number] {
+	const match = /^claude-cli\/(\d+)\.(\d+)\.(\d+)$/.exec(userAgent ?? "");
+	if (!match) throw new Error(`user-agent is not a claude-cli version: ${String(userAgent)}`);
+	return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersions(a: readonly [number, number, number], b: readonly [number, number, number]): number {
+	for (let i = 0; i < 3; i++) {
+		if (a[i] !== b[i]) return a[i] - b[i];
+	}
+	return 0;
+}
+
+describe("Anthropic OAuth Claude Code identity headers", () => {
+	const context: Context = {
+		messages: [{ role: "user", content: "Hello", timestamp: Date.now() }],
+	};
+
+	beforeEach(() => {
+		mockState.constructorOptions = undefined;
+	});
+
+	it("advertises a claude-cli user-agent at or above Anthropic's minimum supported version", async () => {
+		const model = getModel("anthropic", "claude-sonnet-4-5");
+
+		const stream = streamAnthropic(model, context, { apiKey: "sk-ant-oat01-test-token" });
+		await stream.result();
+
+		const userAgent = mockState.constructorOptions?.defaultHeaders?.["user-agent"];
+		expect(mockState.constructorOptions?.defaultHeaders?.["x-app"]).toBe("cli");
+		expect(compareVersions(parseClaudeCliVersion(userAgent), MINIMUM_CLAUDE_CODE_VERSION)).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Anthropic OAuth requests advertise `claude-cli/2.1.251` instead of the stale `2.1.75`, so Claude Fable 5.1 and Opus 5 no longer fail with `claude_code_version_too_old` (syncs upstream pi `96317e50`) ([oh-my-openagent#7650](https://github.com/code-yeongyu/oh-my-openagent/issues/7650)).
+
 ### New Features
 
 ### Breaking Changes


### PR DESCRIPTION
## What changed

- `packages/ai/src/api/anthropic-messages.ts`: `claudeCodeVersion` `"2.1.75"` → `"2.1.251"`, so Anthropic OAuth clients send `user-agent: claude-cli/2.1.251`. Same value as upstream pi [`96317e50`](https://github.com/earendil-works/pi/commit/96317e50b8d6e7f6d0e47fd29122baf1461c00f5); the OAuth beta list, `x-app`, and Claude Code tool naming are untouched.
- `packages/ai/test/anthropic-oauth-claude-code-version.test.ts` (new): drives the OAuth branch of `createClient()` with an `sk-ant-oat…` token through the mocked SDK and asserts the wire `user-agent` parses as `claude-cli/X.Y.Z` with `X.Y.Z >= 2.1.251`.
- `packages/ai/src/changes.md` tracker entry + `CHANGELOG.md` `[Unreleased] › Fixed` entries in `ai` and `coding-agent` (cross-package duplication rule).

## Why

Anthropic now rejects OAuth requests for Claude Fable 5.1 / Opus 5 whose advertised Claude Code version is older than 2.1.251:

```
Claude Code 2.1.75 does not support this model; version 2.1.251 or newer is required.
error_code: claude_code_version_too_old
```

The published senpi tarball still shipped `2.1.75`, so every OMO Native OAuth user hit this regardless of the Claude Code actually installed. Reported in code-yeongyu/oh-my-openagent#7650 (reporter verified that patching the packaged value fixes the request).

## Observed behavior / QA

- RED first: the new test against the unchanged source fails with `expected -176 to be greater than or equal to 0` (2.1.75 vs the 2.1.251 floor).
- GREEN after the one-line bump: `1 passed`.
- `bun run --cwd packages/ai test test/anthropic-`: 31 files / 181 tests passed (one unrelated flake on the first run, clean on rerun).
- Full `bun run --cwd packages/ai test`: 257 files / 2493 tests passed; the single failing file (`codex-apply-patch-wire-schema.test.ts`) was a fresh-worktree resolution error for unbuilt `@earendil-works/pi-tui`, and passes after `npm run build --workspace packages/tui`.
- `node scripts/check-pr-changelog.mjs --base origin/main`: `PASS - changes.md coverage complete (1 production path(s) covered); changelog entry updated`.
- `biome check` clean on the touched files; pre-commit `check` passed.

No Anthropic OAuth credential is available on the build machine, so a live OAuth request was not exercised here; the reporter's manual verification in #7650 covers that path and the downstream OMO PR will re-verify against the published tarball.

## Residual risk

- If Anthropic raises the minimum again the constant goes stale again; the regression test pins the floor so a future bump is a one-line change caught by the same test. Deriving the value from the bundled SDK is a separate follow-up.

Refs code-yeongyu/oh-my-openagent#7650


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the advertised Claude Code version in Anthropic OAuth requests from `2.1.75` to `2.1.251`, because Anthropic now rejects older versions with `claude_code_version_too_old` for Claude Fable 5.1 and Opus 5. Fixes oh-my-openagent#7650.

- The `user-agent` header now advertises `claude-cli/2.1.251`, matching upstream pi `96317e50`.
- Adds a regression test that pins the advertised version at or above `2.1.251`.

<sup>Written for commit 7ea2693926b6c17410dc443bd735262b09f1e69a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

