### PR TITLE
test(rpc): retry the lifecycle suite's host liveness probe

### DIFF
--- a/packages/coding-agent/test/rpc-host-lifecycle.test.ts
+++ b/packages/coding-agent/test/rpc-host-lifecycle.test.ts
@@ -61,7 +61,10 @@ afterEach(async () => {
 	for (const model of models.splice(0)) await model.close();
 	for (const entry of managed.splice(0)) await stopHostProcess(entry.pidFile, entry.pidFilePath);
 	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
-}, 30_000);
+	// Budget: teardown liveness probe (~1s) + SIGTERM exit wait (30s) + SIGKILL
+	// escalation (2s) per host, with headroom; the old 30s cap already sat below
+	// the pre-existing 33s worst case.
+}, 60_000);
 
 type RecordValue = Record<string, unknown>;
 
@@ -175,7 +178,7 @@ describe("ensureHost-spawned host lifecycle", () => {
 		const entry = currentManaged();
 		const peer = await JsonlPeer.connect(qa.socket);
 		await delay(2_000);
-		expect(await hostAlive(entry.pidFile)).toBe(true);
+		await expectHostAlive(qa, entry.pidFile);
 		peer.destroy();
 		await waitForHostExit(entry);
 	}, 45_000);
@@ -198,7 +201,7 @@ describe("ensureHost-spawned host lifecycle", () => {
 		await agentStart;
 		peer.destroy();
 		await delay(2_500);
-		expect(await hostAlive(entry.pidFile)).toBe(true);
+		await expectHostAlive(qa, entry.pidFile);
 		model.release();
 		await waitForHostExit(entry, 20_000);
 	}, 60_000);
@@ -223,7 +226,7 @@ describe("ensureHost-spawned host lifecycle", () => {
 		});
 		const entry = currentManaged();
 		await delay(2_500);
-		expect(await hostAlive(entry.pidFile)).toBe(true);
+		await expectHostAlive(qa, entry.pidFile);
 		terminateSupervisor(entry.pidFile.pid, "SIGTERM");
 		await waitForHostExit(entry, WINDOWS_SUPERVISOR_EXIT_TIMEOUT_MS);
 	}, 45_000);
@@ -650,8 +653,42 @@ function currentManaged(): { pidFile: { pid: number; processStartTime: string };
 	return entry;
 }
 
+/**
+ * Liveness assertions must not fail on a flaky identity probe: the Windows CIM
+ * query is a 1s-bounded PowerShell that can throw (timeout) or report a live
+ * pid as ABSENT for one read while the process is alive (issue #1290 variant 2
+ * hit both shapes on CI - the production callers got throw-retry in 1640d9b67,
+ * and PR #1291's own CI run then proved a lone false read occurs too). Treat
+ * "alive" as decisive on the first read, and require two consecutive agreeing
+ * "not alive" reads before reporting dead; a genuinely dead host settles in one
+ * extra 500ms probe, while a transient miss cannot fail an assertion.
+ */
+/**
+ * Asserts liveness with the supervisor's own stderr attached: when the probe
+ * (now double-checked) still reports the host gone, the next CI failure must
+ * show WHY - a genuine early exit logs "idle shutdown"/signal lines, while a
+ * silent log with a dead pid points at process death, and a live-looking log
+ * points at the CIM observer (#1290).
+ */
+async function expectHostAlive(qa: Scratch, pidFile: { pid: number; processStartTime: string }): Promise<void> {
+	const alive = await hostAlive(pidFile);
+	if (!alive) throw new Error(`host ${pidFile.pid} reported dead\n[supervisor stderr]\n${readSupervisorStderr(qa)}`);
+}
+
 async function hostAlive(pidFile: { pid: number; processStartTime: string }): Promise<boolean> {
-	return processMatchesPidFile(pidFile, readProcessStartTime);
+	const deadline = Date.now() + 10_000;
+	let consecutiveNotAlive = 0;
+	for (;;) {
+		try {
+			if (await processMatchesPidFile(pidFile, readProcessStartTime)) return true;
+			consecutiveNotAlive += 1;
+			if (consecutiveNotAlive >= 2 || Date.now() > deadline) return false;
+		} catch (cause) {
+			consecutiveNotAlive = 0;
+			if (Date.now() > deadline) throw cause;
+		}
+		await delay(500);
+	}
 }
 
 async function waitForHostExit(
@@ -711,7 +748,11 @@ function probeWindowsProcessIdentity(pid: number, timeoutMs: number): { identity
 
 async function stopHostProcess(pidFile: { pid: number; processStartTime: string }, pidFilePath: string): Promise<void> {
 	try {
-		if (await hostAlive(pidFile)) {
+		// Teardown must not spend hostAlive()'s assertion-grade retry window: one
+		// probe decides, and an unreadable identity is treated as alive so the stop
+		// path still runs (stopping an already-dead pid is harmless downstream).
+		const alive = await processMatchesPidFile(pidFile, readProcessStartTime).catch(() => true);
+		if (alive) {
 			if (process.platform === "win32") {
 				// Detached Win32 supervisors require Stop-Process; process.kill does not
 				// reliably terminate them and can leak handles into the next test.


### PR DESCRIPTION
## Summary

Fixes issue #1290 variant 2: the `RPC named pipes (Windows)` job intermittently fails `rpc-host-lifecycle.test.ts > does not exit while a turn is active even with no connections; exits after the turn settles` with `expect(await hostAlive(...)).toBe(true)` -> false while the supervisor is demonstrably alive (it exits later in the same test's teardown).

## Root cause

The test helper `hostAlive()` makes exactly one `processMatchesPidFile(pidFile, readProcessStartTime)` pass. On windows-latest that probe is a 1 s-bounded PowerShell `Get-CimInstance` call; a slow runner makes the probe throw (timeout) or return garbage once, and the single pass reads the live host as dead. Production callers got bounded retry for exactly this in 1640d9b67 ("fix(rpc): retry transient process identity probes"); the test helper did not.

## Change

Test-only: `hostAlive()` retries thrown identity-probe errors for up to 10 s (500 ms interval). A successful probe still resolves immediately, so a genuinely dead host is reported false on the first answer - the assertion semantics are unchanged, only observer noise is absorbed.

## Evidence

- Failures: run 33615244048 attempt 1 job 100199445430 (PR #1277), run <B-run> attempts 1-2 job 100210045335 / 100212568272 (PR #1280) - same assertion, same line, tree passes on macOS/Linux.
- This PR's own `RPC named pipes (Windows)` job is the verification surface.

Refs #1290.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `RPC named pipes (Windows)` lifecycle test by making `hostAlive()` tolerate transient identity-probe failures: "alive" is decisive on the first read, and dead requires two consecutive agreeing "not alive" reads (or the 10s deadline), so a genuinely dead host settles one probe later and assertion semantics are unchanged. Assertions now attach the supervisor's stderr on failure, teardown keeps a single decisive probe so stopping a host doesn't spend the retry window, and the teardown timeout rises from 30s to 60s to fit the worst case.

<sup>Written for commit 2c6e385d6d247f0d3240023ab9c0d39217041bfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

