### PR TITLE
fix(config-reload): offload non-recursive fs.watch creation off the main thread (14-66x faster /reload)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 - The Windows RPC host supervisor no longer dies when its baseline process-identity probe times out; a failed baseline read is treated as unknown instead of throwing past the startup guard and taking the internal host down with it.
 - The Windows shared RPC host is no longer shut down by its own identity watchdog when the PowerShell process probe merely times out; an absent identity is confirmed with `kill(pid, 0)` before the host is treated as exited.
 - Shared RPC host startup no longer runs its orphaned-directory cleanup while holding the endpoint lock, so a concurrent `senpi` start on a busy machine no longer fails with a raw `database is locked` when the cleanup's temp-directory scan and per-candidate process probes outlast the lock budget.
+
+- `/reload` and hot-reload no longer stall for seconds on macOS/Linux: config-reload's per-directory `fs.watch` subscriptions are created and torn down on the watch worker thread instead of the interactive main thread (measured lifecycle phase 2.0-3.2s → ~150ms idle, 12s+ → ~150ms under load).
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.
 - Monitor wake-budget pauses now use single-source, scoped state: only the noisy monitor is muted, quiet monitors are not left permanently paused, and `rearm` without a `bash_id` resumes all paused monitors.
 

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/changes.md
@@ -1,5 +1,37 @@
 # config-reload Extension Changes
 
+## Offload non-recursive watch creation to the worker (2026-09-02)
+
+### What changed
+
+- `watch-event-source.ts` routes EVERY `fs.watch` subscription — recursive and
+  non-recursive — through the existing watch worker on darwin and linux. The
+  worker message gained a `recursive` flag; the worker passes it to `fs.watch`.
+- Windows (and other platforms) keep the direct main-thread `fs.watch` path.
+
+### Why
+
+- The per-directory watch redesign (2026-08-20) made every engine subscription
+  `{ recursive: false }`, which silently bypassed the worker offload added for
+  recursive watches: the offload gate required `watchOptions.recursive`. Every
+  FSEvents stream was again created synchronously on the interactive main
+  thread. Measured with PI_TIMING + dist probes on an M4 Pro under load:
+  `#attach` cost 8.0s for `~/.omo/agent/extensions` and 2.7s for the cwd
+  target; `rebuildWatchers` inside config-reload's `session_start` handler hit
+  89s worst-case, dominating the reload `lifecycle` phase (2.0-3.2s idle,
+  12s+ loaded). After offloading: lifecycle ~150ms, reload total ~180-230ms.
+
+### Why an extension could not handle it
+
+- The event source is internal to this builtin; nothing outside it controls how
+  subscriptions reach `fs.watch`.
+
+### Expected merge conflict zones
+
+- LOW: `watch-event-source.ts` offload gate and worker source string;
+  `config-reload-extension.test.ts` macOS offload describe block.
+
+
 ## Watch only in-scope directories instead of whole subtrees (2026-08-20)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
@@ -37,7 +37,7 @@ parentPort.on("message", (message) => {
 	try {
 		const watcher = watch(
 			message.path,
-			{ recursive: true, encoding: "utf8" },
+			{ recursive: message.recursive !== false, encoding: "utf8" },
 			(eventType, filename) => {
 				parentPort.postMessage({
 					kind: "event",
@@ -85,12 +85,15 @@ function isRecursiveWatchMessage(message: unknown): message is RecursiveWatchMes
 }
 
 /**
- * Platforms whose recursive fs.watch handles are expensive to create and tear down on the
- * interactive main thread: inotify tree walks on Linux, FSEvents stream teardown on macOS.
+ * Platforms whose fs.watch handles are expensive to create and tear down on the
+ * interactive main thread: inotify tree walks on Linux, FSEvents stream rendezvous on
+ * macOS. Non-recursive per-directory watches pay the same FSEvents setup latency —
+ * measured 2.7-8.0s per watch-engine target under system load — so every watch is
+ * offloaded, not only recursive ones.
  */
-const WORKER_OFFLOADED_RECURSIVE_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["linux", "darwin"]);
+const WORKER_OFFLOADED_WATCH_PLATFORMS: ReadonlySet<NodeJS.Platform> = new Set(["linux", "darwin"]);
 
-/** Production event source. Recursive setup and teardown run off the interactive main thread. */
+/** Production event source. Watch setup and teardown run off the interactive main thread. */
 export function createFsWatchEventSource(
 	onError: (error: unknown, path: string) => void = () => {},
 	options: FsWatchEventSourceOptions = {},
@@ -120,11 +123,11 @@ export function createFsWatchEventSource(
 	};
 
 	return (path, listener, watchOptions) => {
-		if (WORKER_OFFLOADED_RECURSIVE_PLATFORMS.has(options.platform ?? process.platform) && watchOptions?.recursive) {
+		if (WORKER_OFFLOADED_WATCH_PLATFORMS.has(options.platform ?? process.platform)) {
 			const id = nextSubscriptionId++;
 			const worker = ensureRecursiveWorker();
 			recursiveSubscriptions.set(id, { path, listener });
-			worker.postMessage({ kind: "watch", id, path });
+			worker.postMessage({ kind: "watch", id, path, recursive: watchOptions?.recursive ?? false });
 			return () => {
 				if (!recursiveSubscriptions.delete(id)) return;
 				if (recursiveSubscriptions.size > 0) {

--- a/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/config-reload/watch-event-source.ts
@@ -98,7 +98,10 @@ export function createFsWatchEventSource(
 	onError: (error: unknown, path: string) => void = () => {},
 	options: FsWatchEventSourceOptions = {},
 ): WatchEventSource {
-	const recursiveSubscriptions = new Map<number, { readonly path: string; readonly listener: WatchEventListener }>();
+	const recursiveSubscriptions = new Map<
+		number,
+		{ readonly path: string; readonly listener: WatchEventListener; readonly recursive: boolean }
+	>();
 	let recursiveWorker: RecursiveWatchWorker | undefined;
 	let nextSubscriptionId = 1;
 
@@ -117,6 +120,15 @@ export function createFsWatchEventSource(
 		});
 		worker.on("error", (error) => {
 			for (const subscription of recursiveSubscriptions.values()) onError(error, subscription.path);
+			// A worker that raised an uncaught error is dead; keeping it would leave every
+			// live subscription silent. Drop it and move the survivors to a fresh worker.
+			if (recursiveWorker !== worker) return;
+			recursiveWorker = undefined;
+			if (recursiveSubscriptions.size === 0) return;
+			const replacement = ensureRecursiveWorker();
+			for (const [id, subscription] of recursiveSubscriptions) {
+				replacement.postMessage({ kind: "watch", id, path: subscription.path, recursive: subscription.recursive });
+			}
 		});
 		recursiveWorker = worker;
 		return worker;
@@ -125,11 +137,14 @@ export function createFsWatchEventSource(
 	return (path, listener, watchOptions) => {
 		if (WORKER_OFFLOADED_WATCH_PLATFORMS.has(options.platform ?? process.platform)) {
 			const id = nextSubscriptionId++;
-			const worker = ensureRecursiveWorker();
-			recursiveSubscriptions.set(id, { path, listener });
-			worker.postMessage({ kind: "watch", id, path, recursive: watchOptions?.recursive ?? false });
+			const recursive = watchOptions?.recursive ?? false;
+			ensureRecursiveWorker().postMessage({ kind: "watch", id, path, recursive });
+			recursiveSubscriptions.set(id, { path, listener, recursive });
 			return () => {
 				if (!recursiveSubscriptions.delete(id)) return;
+				// Resolve at unsubscribe time: the worker may have been replaced after a crash.
+				const worker = recursiveWorker;
+				if (!worker) return;
 				if (recursiveSubscriptions.size > 0) {
 					worker.postMessage({ kind: "unwatch", id });
 					return;

--- a/packages/coding-agent/test/suite/config-reload-extension.test.ts
+++ b/packages/coding-agent/test/suite/config-reload-extension.test.ts
@@ -1635,11 +1635,13 @@ describe("macOS recursive watch offload", () => {
 			kind: "watch",
 			id: 1,
 			path: "/Users/dev/large-workspace",
+			recursive: true,
 		});
 		expect(worker.postMessage).toHaveBeenCalledWith({
 			kind: "watch",
 			id: 2,
 			path: "/Users/dev/another-config-root",
+			recursive: true,
 		});
 		expect(listener).toHaveBeenCalledWith("change", ".omo/omo.json");
 		expect(onError).not.toHaveBeenCalled();
@@ -1652,9 +1654,12 @@ describe("macOS recursive watch offload", () => {
 		expect(worker.terminate).toHaveBeenCalledTimes(1);
 	});
 
-	it("keeps darwin non-recursive watches on the main thread", () => {
-		// Given: a darwin event source whose worker factory must stay unused
-		const createRecursiveWorker = vi.fn(() => new DarwinWorkerProbe());
+	it("routes darwin non-recursive watches through the worker too", () => {
+		// Given: a darwin event source with an injected fake worker. Non-recursive
+		// FSEvents setup blocks the main thread for seconds under load (measured
+		// 2.7-8.0s per watch-engine target), so it must be offloaded like recursive.
+		const worker = new DarwinWorkerProbe();
+		const createRecursiveWorker = vi.fn(() => worker);
 		const agentDir = mkdtempSync(join(tmpdir(), "senpi-darwin-nonrecursive-"));
 		agentDirs.push(agentDir);
 		const source = createFsWatchEventSource(vi.fn(), { platform: "darwin", createRecursiveWorker });
@@ -1662,9 +1667,15 @@ describe("macOS recursive watch offload", () => {
 		// When: a non-recursive watch is registered
 		const unsubscribe = source(agentDir, vi.fn(), { recursive: false });
 
-		// Then: no worker is spawned
-		expect(createRecursiveWorker).not.toHaveBeenCalled();
+		// Then: setup went to the worker with the non-recursive flag
+		expect(worker.postMessage).toHaveBeenCalledWith({
+			kind: "watch",
+			id: 1,
+			path: agentDir,
+			recursive: false,
+		});
 
 		unsubscribe();
+		expect(worker.terminate).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/non-recursive-watch-main-thread-stall.test.ts
+++ b/packages/coding-agent/test/suite/regressions/non-recursive-watch-main-thread-stall.test.ts
@@ -21,47 +21,41 @@ class WorkerProbe extends EventEmitter {
 	readonly terminate = vi.fn(async () => 0);
 }
 
-describe("issue #477 recursive watch main-thread stall", () => {
+describe("non-recursive watch main-thread stall", () => {
 	beforeEach(() => {
 		mocks.fsWatch.mockReset();
 	});
 
-	it("offloads Linux recursive watch setup instead of calling fs.watch on the main thread", () => {
+	it("offloads non-recursive watch creation to the worker on darwin", () => {
 		const worker = new WorkerProbe();
 		const createRecursiveWorker = vi.fn(() => worker);
 		const listener = vi.fn<WatchEventListener>();
 		const source = createFsWatchEventSource(vi.fn(), {
-			platform: "linux",
+			platform: "darwin",
 			createRecursiveWorker,
 		});
 
-		const unsubscribe = source("/large-workspace-mount", listener, { recursive: true });
-		const unsubscribeSecond = source("/another-config-root", vi.fn(), { recursive: true });
-		worker.emit("message", { kind: "event", id: 1, eventType: "change", filename: ".omo/omo.json" });
+		// The watch engine subscribes per-directory with { recursive: false } since the
+		// per-directory redesign; FSEvents stream creation blocks the main thread for
+		// seconds under load, so it must run on the worker like recursive watches.
+		const unsubscribe = source("/agent/extensions", listener, { recursive: false });
+		worker.emit("message", { kind: "event", id: 1, eventType: "change", filename: "ext.ts" });
 
 		expect(createRecursiveWorker).toHaveBeenCalledTimes(1);
 		expect(worker.postMessage).toHaveBeenCalledWith({
 			kind: "watch",
 			id: 1,
-			path: "/large-workspace-mount",
-			recursive: true,
-		});
-		expect(worker.postMessage).toHaveBeenCalledWith({
-			kind: "watch",
-			id: 2,
-			path: "/another-config-root",
-			recursive: true,
+			path: "/agent/extensions",
+			recursive: false,
 		});
 		expect(mocks.fsWatch).not.toHaveBeenCalled();
-		expect(listener).toHaveBeenCalledWith("change", ".omo/omo.json");
+		expect(listener).toHaveBeenCalledWith("change", "ext.ts");
 
 		unsubscribe();
-		expect(worker.terminate).not.toHaveBeenCalled();
-		unsubscribeSecond();
 		expect(worker.terminate).toHaveBeenCalledTimes(1);
 	});
 
-	it("keeps non-recursive config file watches on direct fs.watch on non-offloaded platforms", () => {
+	it("keeps every watch on direct fs.watch on windows", () => {
 		const watcher = new WatcherProbe();
 		mocks.fsWatch.mockReturnValue(watcher);
 		const createRecursiveWorker = vi.fn(() => new WorkerProbe());

--- a/packages/coding-agent/test/suite/regressions/non-recursive-watch-main-thread-stall.test.ts
+++ b/packages/coding-agent/test/suite/regressions/non-recursive-watch-main-thread-stall.test.ts
@@ -55,6 +55,39 @@ describe("non-recursive watch main-thread stall", () => {
 		expect(worker.terminate).toHaveBeenCalledTimes(1);
 	});
 
+	it("recreates the worker and re-watches live subscriptions after the worker dies", () => {
+		const workers: WorkerProbe[] = [];
+		const createRecursiveWorker = vi.fn(() => {
+			const worker = new WorkerProbe();
+			workers.push(worker);
+			return worker;
+		});
+		const onError = vi.fn();
+		const listener = vi.fn<WatchEventListener>();
+		const source = createFsWatchEventSource(onError, { platform: "darwin", createRecursiveWorker });
+
+		source("/agent/extensions", listener, { recursive: false });
+		workers[0]?.emit("error", new Error("worker crashed"));
+
+		// The dead worker is dropped and live subscriptions land on a fresh one.
+		expect(onError).toHaveBeenCalledWith(expect.any(Error), "/agent/extensions");
+		expect(createRecursiveWorker).toHaveBeenCalledTimes(2);
+		expect(workers[1]?.postMessage).toHaveBeenCalledWith({
+			kind: "watch",
+			id: 1,
+			path: "/agent/extensions",
+			recursive: false,
+		});
+
+		// Events from the replacement worker still reach the original listener.
+		workers[1]?.emit("message", { kind: "event", id: 1, eventType: "change", filename: "ext.ts" });
+		expect(listener).toHaveBeenCalledWith("change", "ext.ts");
+
+		// A later subscription reuses the replacement, not a third worker.
+		source("/agent/skills", vi.fn(), { recursive: false });
+		expect(createRecursiveWorker).toHaveBeenCalledTimes(2);
+	});
+
 	it("keeps every watch on direct fs.watch on windows", () => {
 		const watcher = new WatcherProbe();
 		mocks.fsWatch.mockReturnValue(watcher);


### PR DESCRIPTION
## Summary

`/reload` ("Reloading keybindings, extensions, skills, prompts, themes, and context files...") stalled for seconds because config-reload created every per-directory `fs.watch` subscription synchronously on the interactive main thread.

The 2026-08-20 per-directory watch redesign made every engine subscription `{ recursive: false }`, which silently bypassed the darwin/linux worker offload added in #1032 — its gate required `watchOptions.recursive`. FSEvents stream creation blocks the calling thread under load, so `rebuildWatchers` inside config-reload's `session_start` handler dominated the reload `lifecycle` phase.

**Fix:** route every `fs.watch` subscription (recursive and non-recursive) through the existing watch worker on darwin/linux; the worker message carries a `recursive` flag. Windows keeps the direct main-thread path.

## Measurements

Method: `PI_TIMING=1 PI_OFFLINE=1 PI_SKIP_VERSION_CHECK=1 PI_CODING_AGENT_DIR=~/.omo/agent node dist/cli.js` in a 240-col pty, `/reload`, reading the `reload timings:` status line. Real agent dir (46 extensions, 120+ skills), Mac mini M4 Pro.

### Before (origin/main build)

| run | shutdown | settings | models | resources | runtime | chatRebuild | lifecycle | total |
|---|---|---|---|---|---|---|---|---|
| idle 1 | 2ms | 0ms | 10ms | 43ms | 2ms | 1ms | **3151ms** | **3209ms** |
| idle 2 | 2ms | 1ms | 11ms | 43ms | 1ms | 1ms | **2038ms** | **2105ms** |
| loaded | 2ms | 1ms | 7ms | 24ms | 1ms | 1ms | **12159ms** | **12195ms** |
| loaded (worst) | 4ms | 0ms | 26206ms* | 40ms | 3ms | 2ms | — | — |

Attribution probes (dist-patched `appendFileSync` timers): `session_start <builtin:config-reload>` = 89.4s worst-case, entirely in `rebuildWatchers`; per-target `#attach` (watch creation): 8033ms for `~/.omo/agent/extensions`, 2746ms for the cwd target — scan itself was 0-1ms. *The loaded-machine `models` spike shares the same root cause: main-thread starvation while watchers attach.

### After (this branch)

| run | shutdown | settings | models | resources | runtime | chatRebuild | lifecycle | total |
|---|---|---|---|---|---|---|---|---|
| 1 | 5ms | 1ms | 22ms | 51ms | 3ms | 1ms | **146ms** | **229ms** |
| 2 | 1ms | 0ms | 6ms | 23ms | 1ms | 0ms | **148ms** | **179ms** |
| 3 | 0ms | 1ms | 6ms | 22ms | 1ms | 1ms | **153ms** | **184ms** |

~14-66x faster reload; hot reload is actually hot now.

## Regression QA

- Touched `<cwd>/.omo/settings.json` in the live TUI → `Hot-reloading:` → `Hot-reloaded:` → full reload completed in 217ms. Watch events flow end-to-end through the worker.
- Tests: new regression `non-recursive-watch-main-thread-stall.test.ts` (RED before fix: worker not used, direct fs.watch called; GREEN after), updated `477-recursive-watch-main-thread-stall.test.ts` + `config-reload-extension.test.ts` macOS offload block to the new contract. 4 files / 81 tests green.

## Files

- `watch-event-source.ts`: offload gate no longer requires `recursive`; worker `watch` message carries `recursive`; worker passes it to `fs.watch`.
- CHANGELOG + `config-reload/changes.md` entries per fork convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `/reload` and hot-reload 14-66x faster on macOS/Linux by offloading all `fs.watch` setup to a worker thread, ending multi-second main-thread stalls.

- The per-directory watch redesign made every subscription non-recursive, which bypassed the existing offload that only handled recursive watches.
- darwin/linux now route all subscriptions through the worker, carrying a `recursive` flag; Windows keeps the main-thread path.
- A crashed worker is dropped and replaced, and live subscriptions are re-posted so watches go silent only briefly.
- Measured reload lifecycle drops from 2-12s to ~150ms.

<sup>Written for commit 0244aff081fa417c529e725cf81652500b73413f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

