### PR TITLE
fix(scripts): stop root workspace fan-out scripts recursing under bun

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,24 @@
 # changes — senpi-monorepo root
 
+## Root workspace fan-out scripts no longer recurse under bun (2026-09-02)
+
+### What changed
+
+- `package.json`: the three root scripts that fan out to workspaces stop passing workspace flags after the script name. `test` and `clean` move the flags before the script name (`npm run --workspaces --if-present <script>`), and `eval` moves its flag before `run` (`npm --workspace=@code-yeongyu/senpi-evals run eval --`). npm behavior is unchanged in all three cases.
+- `scripts/root-workspace-scripts.test.mjs` (new): parses the root manifest and fails if any root script passes `--workspace`/`--workspaces` after the script name, so the shape cannot regress.
+
+### Why
+
+- Bun rewrites `npm run <name>` to `bun run <name>` inside script text, and bun appends flags placed after the script name to the script itself instead of parsing them. `npm run test --workspaces --if-present` therefore re-invoked the ROOT script with an ever-growing flag suffix (`bun run test --workspaces --if-present --workspaces --if-present ...`) and spun forever instead of running the workspace suites — it never failed, so it read as a slow suite. `clean` and `eval` had the same defect. Verified in a throwaway fixture: the flag-before form fans out under both npm and bun, while the singular `--workspace=<name>` form still recurses under bun (bun does not recognize it), which is why `eval` needs the flag before `run` so no `npm run` substring remains to rewrite.
+
+### Why an extension could not handle it
+
+- These are root package manifest scripts consumed by the release gate (`scripts/release.mjs`, `scripts/local-release.mjs` run `CI=1 npm test`) and by contributors directly; no extension surface exists above the package manager.
+
+### Expected merge conflict zones
+
+- LOW: the `test`, `clean`, and `eval` lines in the root `package.json` scripts block.
+
 ## Shared-host rendering isolation (2026-08-30)
 
 Shared socket clients now register `rendered_components` through additive `set_client_info` capabilities. Factory-rendered component records are filtered per connection, including capability-aware snapshot replay. Capabilities remain connection-wide across sessions and are cleared only on socket release; explicit close removes only the closing width. Shared bindings retain factories while disposing live renderers and footer providers when no capable connection remains, recreating them for later capable joiners.

--- a/changes.md
+++ b/changes.md
@@ -5,7 +5,7 @@
 ### What changed
 
 - `package.json`: the three root scripts that fan out to workspaces stop passing workspace flags after the script name. `test` and `clean` move the flags before the script name (`npm run --workspaces --if-present <script>`), and `eval` moves its flag before `run` (`npm --workspace=@code-yeongyu/senpi-evals run eval --`). npm behavior is unchanged in all three cases.
-- `scripts/root-workspace-scripts.test.mjs` (new): parses the root manifest and fails if any root script passes `--workspace`/`--workspaces` after the script name, so the shape cannot regress.
+- `scripts/root-workspace-scripts.test.mjs` (new): parses the root manifest and fails a root script for either recursion-prone shape — a workspace flag after the script name, or a singular `--workspace` on an `npm run` call (which bun ignores, re-entering the root script). Both shipped shapes are covered; a mutation check confirms reverting `eval` to `npm run --workspace=<name> eval` fails the guard.
 
 ### Why
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"packages/coding-agent/examples/extensions/gondolin"
 	],
 	"scripts": {
-		"clean": "shx rm -rf dist && npm run clean --workspaces",
+		"clean": "shx rm -rf dist && npm run --workspaces --if-present clean",
 		"build": "node scripts/build-all.mjs",
 		"build:npm": "node scripts/build-all.mjs --pm npm",
 		"build:bun": "node scripts/build-all.mjs --pm bun",
@@ -31,11 +31,11 @@
 		"generate:models": "npm --prefix packages/ai run generate-models && npm --prefix packages/ai run generate-image-models",
 		"generate:model-catalog": "npm --prefix packages/ai run generate-model-catalog",
 		"diff:model-catalog": "node scripts/diff-model-catalog.mjs",
-		"eval": "npm run eval --workspace=@code-yeongyu/senpi-evals --",
+		"eval": "npm --workspace=@code-yeongyu/senpi-evals run eval --",
 		"check:model-catalog": "node scripts/publish-model-catalog.mjs --input .artifacts/model-catalog --dry-run",
 		"profile:tui": "node scripts/profile-coding-agent-node.mjs --mode tui",
 		"profile:rpc": "node scripts/profile-coding-agent-node.mjs --mode rpc",
-		"test": "npm run test:scripts && npm run test --workspaces --if-present",
+		"test": "npm run test:scripts && npm run --workspaces --if-present test",
 		"test:scripts": "node --test scripts/*.test.mjs",
 		"version:patch": "npm version patch --workspaces --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",
 		"version:minor": "npm version minor --workspaces --no-git-tag-version --no-workspaces-update && node scripts/sync-versions.js && npm install --package-lock-only --ignore-scripts",

--- a/scripts/root-workspace-scripts.test.mjs
+++ b/scripts/root-workspace-scripts.test.mjs
@@ -31,9 +31,25 @@ const rootManifest = JSON.parse(readFileSync(join(repoRoot, "package.json"), "ut
 const FLAG_AFTER_SCRIPT_NAME = /npm run\s+(?!-)[\w:.@/-]+\s+[^&|]*--workspaces?\b/;
 const NPM_RUN_WITH_SINGULAR_WORKSPACE = /npm run\s+[^&|]*--workspace(?![s\w])/;
 
+/**
+ * Tokens after a standalone `--` are forwarded to the script as arguments, not
+ * parsed as package-manager flags: `npm run build -- --workspace=foo` becomes
+ * `bun run build -- --workspace=foo` and passes the token through without
+ * re-entering the root script. Only the pre-`--` portion of each command can
+ * carry a recursion hazard, so that is all we inspect.
+ */
+function beforeForwardedArgs(command) {
+	return command.split(/\s--(?:\s|$)/, 1)[0];
+}
+
 function recursionRisk(body) {
-	if (FLAG_AFTER_SCRIPT_NAME.test(body)) return "workspace flag after the script name";
-	if (NPM_RUN_WITH_SINGULAR_WORKSPACE.test(body)) return "singular --workspace on an `npm run` call (bun ignores it and re-enters the root script)";
+	const inspected = body
+		.split(/&&|\|\|/)
+		.map(beforeForwardedArgs)
+		.join(" && ");
+	if (FLAG_AFTER_SCRIPT_NAME.test(inspected)) return "workspace flag after the script name";
+	if (NPM_RUN_WITH_SINGULAR_WORKSPACE.test(inspected))
+		return "singular --workspace on an `npm run` call (bun ignores it and re-enters the root script)";
 	return undefined;
 }
 

--- a/scripts/root-workspace-scripts.test.mjs
+++ b/scripts/root-workspace-scripts.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const rootManifest = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+
+/**
+ * Bun rewrites `npm run <name>` to `bun run <name>` inside package.json script
+ * text, and bun appends flags placed AFTER the script name to the script itself
+ * instead of parsing them as its own flags. A root script shaped like
+ * `npm run test --workspaces` therefore re-invokes the ROOT script with the
+ * flags appended, growing the command forever instead of fanning out:
+ *
+ *   bun run test --workspaces --if-present --workspaces --if-present ...
+ *
+ * The flag-before form (`npm run --workspaces --if-present test`) fans out
+ * correctly under both npm and bun, so that is the shape we require here.
+ */
+const RECURSION_PRONE_FANOUT = /npm run\s+(?!-)[\w:.@/-]+\s+[^&|]*--workspaces?\b/;
+
+test("root workspace fan-out scripts keep --workspaces before the script name", () => {
+	const offenders = Object.entries(rootManifest.scripts ?? {})
+		.filter(([, body]) => RECURSION_PRONE_FANOUT.test(body))
+		.map(([name, body]) => `${name}: ${body}`);
+
+	assert.deepEqual(
+		offenders,
+		[],
+		`These root scripts pass workspace flags after the script name, which recurses under bun.\nMove the flags before the script name (npm run --workspaces --if-present <script>):\n${offenders.join("\n")}`,
+	);
+});

--- a/scripts/root-workspace-scripts.test.mjs
+++ b/scripts/root-workspace-scripts.test.mjs
@@ -16,19 +16,36 @@ const rootManifest = JSON.parse(readFileSync(join(repoRoot, "package.json"), "ut
  *
  *   bun run test --workspaces --if-present --workspaces --if-present ...
  *
- * The flag-before form (`npm run --workspaces --if-present test`) fans out
- * correctly under both npm and bun, so that is the shape we require here.
+ * Two shapes are safe, and they are NOT interchangeable:
+ *
+ *   - plural:   `npm run --workspaces --if-present <script>` — bun parses
+ *     `--workspaces` as its own flag and fans out natively.
+ *   - singular: `npm --workspace=<name> run <script>` — bun does NOT recognize
+ *     `--workspace=<name>`, so `npm run --workspace=<name> <script>` STILL
+ *     recurses. The flag must sit before `run` so no `npm run` substring is
+ *     left for bun to rewrite, keeping the call on real npm.
+ *
+ * Anything that leaves `npm run` followed by a singular `--workspace` is
+ * therefore just as broken as the flag-after-script-name shape.
  */
-const RECURSION_PRONE_FANOUT = /npm run\s+(?!-)[\w:.@/-]+\s+[^&|]*--workspaces?\b/;
+const FLAG_AFTER_SCRIPT_NAME = /npm run\s+(?!-)[\w:.@/-]+\s+[^&|]*--workspaces?\b/;
+const NPM_RUN_WITH_SINGULAR_WORKSPACE = /npm run\s+[^&|]*--workspace(?![s\w])/;
 
-test("root workspace fan-out scripts keep --workspaces before the script name", () => {
+function recursionRisk(body) {
+	if (FLAG_AFTER_SCRIPT_NAME.test(body)) return "workspace flag after the script name";
+	if (NPM_RUN_WITH_SINGULAR_WORKSPACE.test(body)) return "singular --workspace on an `npm run` call (bun ignores it and re-enters the root script)";
+	return undefined;
+}
+
+test("root workspace fan-out scripts cannot recurse under bun", () => {
 	const offenders = Object.entries(rootManifest.scripts ?? {})
-		.filter(([, body]) => RECURSION_PRONE_FANOUT.test(body))
-		.map(([name, body]) => `${name}: ${body}`);
+		.map(([name, body]) => ({ name, body, risk: recursionRisk(body) }))
+		.filter((entry) => entry.risk !== undefined)
+		.map((entry) => `${entry.name}: ${entry.body}  <-- ${entry.risk}`);
 
 	assert.deepEqual(
 		offenders,
 		[],
-		`These root scripts pass workspace flags after the script name, which recurses under bun.\nMove the flags before the script name (npm run --workspaces --if-present <script>):\n${offenders.join("\n")}`,
+		`These root scripts recurse under bun.\nUse \`npm run --workspaces --if-present <script>\` for all-workspace fan-out, or \`npm --workspace=<name> run <script>\` for a single workspace:\n${offenders.join("\n")}`,
 	);
 });


### PR DESCRIPTION
## Summary

Three root scripts that fan out to workspaces spin forever under bun instead of running the workspace suites. They never fail, so it reads as "the suite is still running" — I lost real time to this while validating #1276.

```
$ bun run test:scripts && bun run test --workspaces --if-present --workspaces --if-present --workspaces --if-present ...
```

## Mechanism

Bun rewrites `npm run <name>` to `bun run <name>` **inside package.json script text**, and bun appends flags placed **after** the script name to the script itself instead of parsing them as its own. So `npm run test --workspaces --if-present` becomes `bun run test --workspaces --if-present`, which re-invokes the ROOT `test` script with the flags appended, growing the suffix on every level. `clean` and `eval` share the defect.

Under real npm all three work today and keep working after this change.

## Fix, and why the two shapes differ

Verified in a throwaway fixture (root + three workspace packages, one deliberately without a `test` script) against **both** package managers:

| Shape | npm | bun |
|---|---|---|
| `npm run test --workspaces --if-present` (current) | fans out | **recurses** |
| `npm run --workspaces --if-present test` | fans out | fans out |
| `npm run eval --workspace=NAME --` (current) | fans out | **recurses** |
| `npm run --workspace=NAME eval --` | fans out | **still recurses** |
| `npm --workspace=NAME run eval --` | fans out | fans out |

Bun recognizes the plural `--workspaces` as its own `bun run` flag but **not** the singular `--workspace=<name>`, so moving the flag before the script name is enough for `test`/`clean`, while `eval` needs the flag before `run` so no `npm run` substring is left to rewrite. That asymmetry is the whole reason the two lines look different — assuming symmetry here would have shipped a still-broken `eval`.

- `test`: `npm run test:scripts && npm run --workspaces --if-present test`
- `clean`: `shx rm -rf dist && npm run --workspaces --if-present clean`
- `eval`: `npm --workspace=@code-yeongyu/senpi-evals run eval --`

## Regression guard

`scripts/root-workspace-scripts.test.mjs` parses the root manifest and fails if any root script passes `--workspace`/`--workspaces` after the script name. It is machine-consumed (parsed JSON, not prose), and it found the `eval` offender I had missed by hand.

## Evidence

**Failing-first**, captured against unmodified `origin/main` before the fix:

```
AssertionError [ERR_ASSERTION]: These root scripts pass workspace flags after the script name, which recurses under bun.
  clean: shx rm -rf dist && npm run clean --workspaces
  test: npm run test:scripts && npm run test --workspaces --if-present
  actual: [ 'clean: ...', 'eval: npm run eval --workspace=@code-yeongyu/senpi-evals --', 'test: ...' ]
```

After the fix: `✔ root workspace fan-out scripts keep --workspaces before the script name` — pass 1, fail 0.

**Both-PM proof on this repo** (bounded slices, remote build host):

- `bun run test`: doubled-flag signature count **0**; the printed command is `bun run test:scripts && bun run --workspaces --if-present test` and it proceeds into real work (`node --test scripts/*.test.mjs` → `✔ archiveUpstreamAgentReport ...`).
- `bun run clean`: fans out across workspaces, each `Exited with code 0`.
- `npm run --workspaces --if-present test`: dispatches into `@earendil-works/pi-agent-core test > vitest --run`.
- `bun run check`: exit 0 (after `npm ci` + `bun run build`; a first run on a hand-copied `node_modules` failed identically on a pristine `origin/main` tree with `TS2307: Cannot find module 'ignore'`, i.e. environmental).

## Risk

- CI is unaffected: it never invokes the root `test` script (it runs `npx vitest run --shard=N/3` plus explicit per-workspace `npm run test`).
- The release gate keeps working: `scripts/release.mjs` and `scripts/local-release.mjs` spawn `npm` with `["test"]` directly, so they take the npm path, which this change leaves semantically identical.
- `version:*` scripts are deliberately untouched: they use `npm version --workspaces`, not `npm run`, so bun does not rewrite them and they never recursed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the root workspace fan-out scripts (`test`, `clean`, and `eval`) so they no longer recurse indefinitely under bun instead of running workspace commands. `test` and `clean` move workspace flags before the script name, while `eval` moves its singular workspace flag before `run`; npm behavior is unchanged.

- Adds `scripts/root-workspace-scripts.test.mjs`, which parses the root manifest and rejects both recursion-prone command shapes while ignoring forwarded args after a standalone `--`.
- CI and the release gate are unaffected because they do not invoke the root `test` script directly.

<sup>Written for commit a50696739b4acefc6169d4bdd83d4166e5f0e5c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

