### PR TITLE
fix(rpc): root-fix the flaky Windows named-pipes CI job

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - The shared RPC supervisor's observer receives content-free session and agent lifecycle records even without a session attachment, so it no longer exits the host during an active turn.
+- The Windows RPC host supervisor no longer dies when its baseline process-identity probe times out; a failed baseline read is treated as unknown instead of throwing past the startup guard and taking the internal host down with it.
 - The Windows shared RPC host is no longer shut down by its own identity watchdog when the PowerShell process probe merely times out; an absent identity is confirmed with `kill(pid, 0)` before the host is treated as exited.
 - Shared RPC host startup no longer runs its orphaned-directory cleanup while holding the endpoint lock, so a concurrent `senpi` start on a busy machine no longer fails with a raw `database is locked` when the cleanup's temp-directory scan and per-candidate process probes outlast the lock budget.
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - The shared RPC supervisor's observer receives content-free session and agent lifecycle records even without a session attachment, so it no longer exits the host during an active turn.
+- The Windows shared RPC host is no longer shut down by its own identity watchdog when the PowerShell process probe merely times out; an absent identity is confirmed with `kill(pid, 0)` before the host is treated as exited.
 - Shared RPC host startup no longer runs its orphaned-directory cleanup while holding the endpoint lock, so a concurrent `senpi` start on a busy machine no longer fails with a raw `database is locked` when the cleanup's temp-directory scan and per-candidate process probes outlast the lock budget.
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - The shared RPC supervisor's observer receives content-free session and agent lifecycle records even without a session attachment, so it no longer exits the host during an active turn.
+- Shared RPC host startup no longer runs its orphaned-directory cleanup while holding the endpoint lock, so a concurrent `senpi` start on a busy machine no longer fails with a raw `database is locked` when the cleanup's temp-directory scan and per-candidate process probes outlast the lock budget.
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.
 
 ### New Features

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,9 @@
 # Local fork changes
 
+## 2026-09-02 - RPC host lifecycle teardown treats a timed-out probe as unknown, not alive
+
+- `test/rpc-host-lifecycle.test.ts` decides Windows process liveness with the production `processIsLive(pid)` (`kill(pid, 0)`) instead of trusting the PowerShell CIM probe's `timedOut` flag. A loaded `windows-latest` runner could time the 10s CIM probe out for a supervisor that had genuinely idle-exited; `terminateSupervisor()` then rethrew the `Stop-Process` failure (`starts a fresh host transparently on the next ensure after an idle exit`), and `waitForHostExit()` spun to its deadline and threw `did not exit within Nms`. A timed-out probe means the state is unknown, so it is re-decided by `kill(pid, 0)` (`ESRCH` -> gone, `EPERM` -> alive); a process that is really still alive still rethrows / still keeps waiting.
+
 ## 2026-09-01 - Acknowledge RPC abort before quiesce
 
 - The RPC `abort` command now acknowledges immediately after dispatching the abort signal, while observing quiesce failures through the existing `rpc_error` event path.

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -14,7 +14,25 @@
 ### Why an extension could not handle it
 
 - Socket fan-out and supervisor lifecycle accounting are transport behavior below the extension API.
+## 2026-09-02 - Reap orphaned host dirs outside the endpoint lock
 
+### What changed
+
+- `packages/coding-agent/src/modes/rpc/host-ensure.ts` runs `reapOrphanedInternalHostDirs()` before `acquireOwnershipSafeLock()` instead of inside the locked section.
+- `packages/coding-agent/test/rpc-host-ensure-lock-scope.test.ts` pins that ordering at the seam.
+
+### Why
+
+- The reaper's cost is unbounded in the size of the whole temp directory: it `readdir`s `tmpdir()` (measured: 132,035 entries, 394-467ms on a fast local SSD), then per `senpi-rpc-host-internal-*` candidate reads `.owner`, re-reads the directory, and calls `processMatchesPidFile()`. On win32 that last call spawns `powershell.exe Get-CimInstance` per candidate with a 1s default timeout. Running that opportunistic GC inside the exclusive endpoint lock made hold time scale with temp-directory size and PowerShell latency, so on the 4-vCPU `windows-latest` runner a concurrent `ensureHost` waiter could exhaust even the 42s lock budget and surface a raw `database is locked`. Raising the budget cannot fix a critical section whose cost is unbounded; the GC simply does not belong inside the lock.
+- The reaper's own guards already make it safe unlocked: it only removes directories older than 60s whose owner pid is provably dead, so it never contends with the caller's own ensure.
+
+### Why an extension could not handle it
+
+- The reap runs inside the host handshake below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: the `reapOrphanedInternalHostDirs()` / `acquireOwnershipSafeLock()` ordering at the top of `ensureHost`.
 ## 2026-09-02 - Size the ensure-host lock wait to the startup critical section
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -119,9 +119,14 @@ export async function ensureHost(options: EnsureHostOptions): Promise<EnsuredHos
 	const lockTarget = join(tmpdir(), "senpi-rpc-host-locks", createSocketLockName(socket));
 	await mkdir(dirname(lockTarget), { recursive: true });
 	await writeFile(lockTarget, "", { flag: "a", mode: 0o600 });
+	// Opportunistic GC of other installs' leftovers stays OUTSIDE the endpoint lock.
+	// Its cost scales with the whole tmpdir and, on win32, adds a ~1s process probe per
+	// candidate; inside the critical section that inflated the hold for every concurrent
+	// ensureHost until a waiter exhausted its budget and surfaced a raw "database is
+	// locked". Its own guards (60s age, dead owner pid) already make it safe unlocked.
+	await reapOrphanedInternalHostDirs();
 	const release = await acquireOwnershipSafeLock(`${lockTarget}.lock`, lockOptions);
 	try {
-		await reapOrphanedInternalHostDirs();
 		await options._test?.afterLockAcquired?.();
 		return await ensureHostLocked(paths, socket, options.agentDir ?? getAgentDir(), options.policy, options._test);
 	} finally {

--- a/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
+++ b/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
@@ -562,7 +562,14 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 	}
 
 	if (process.platform === "win32" && child.pid !== undefined) {
-		const childStartTime = await readProcessStartTime(child.pid, process.platform, 1_000);
+		// This baseline read sits outside the startup try/catch, and readProcessStartTime
+		// THROWS when the 1s CIM probe fails (execFile's timeout SIGTERMs the PowerShell
+		// child). With no unhandledRejection handler the supervisor died right here on a
+		// loaded runner: it never reached the "host ready" line, and the internal host it
+		// owned vanished with it, surfacing downstream as `connect ENOENT` on the pipe and
+		// as `reported dead`. A failed baseline read is UNKNOWN, so the watchdog simply
+		// starts without one and relies on its own comparisons.
+		const childStartTime = await readProcessStartTime(child.pid, process.platform, 1_000).catch(() => undefined);
 		let missingIdentityChecks = 0;
 		let checkingChildIdentity = false;
 		const checkChildIdentity = (): void => {

--- a/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
+++ b/packages/coding-agent/src/modes/rpc/host-lifecycle.ts
@@ -46,7 +46,7 @@ import { tmpdir } from "node:os";
 import { dirname, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentDir, isBunBinary } from "../../config.ts";
-import { readProcessStartTime } from "../app-server/daemon/process.ts";
+import { processIsLive, readProcessStartTime } from "../app-server/daemon/process.ts";
 import { createHostDaemonPaths } from "./host-ensure.ts";
 import {
 	HOST_CLEANUP_PATHS_ENV,
@@ -570,8 +570,13 @@ export async function runHostSupervisor(launch: SupervisorLaunch): Promise<void>
 			checkingChildIdentity = true;
 			void readProcessStartTime(child.pid!, process.platform, 1_000)
 				.then((currentStartTime) => {
-					if (currentStartTime === undefined) missingIdentityChecks++;
-					else missingIdentityChecks = 0;
+					// An absent identity is only believed once kill(pid, 0) agrees the child is
+					// gone. This probe is a 1s PowerShell CIM spawn polled every 500ms, so a
+					// loaded runner produced two consecutive timeouts and this watchdog shut
+					// down a perfectly healthy host (`does not exit while a turn is active`).
+					// A timed-out probe means UNKNOWN, never EXITED.
+					if (currentStartTime === undefined && !processIsLive(child.pid!)) missingIdentityChecks++;
+					else if (currentStartTime !== undefined) missingIdentityChecks = 0;
 					const identityChanged =
 						childStartTime !== undefined && currentStartTime !== undefined && currentStartTime !== childStartTime;
 					if (identityChanged || missingIdentityChecks >= 2) {

--- a/packages/coding-agent/test/rpc-host-ensure-lock-scope.test.ts
+++ b/packages/coding-agent/test/rpc-host-ensure-lock-scope.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+const hostEnsureSource = new URL("../src/modes/rpc/host-ensure.ts", import.meta.url);
+
+describe("ensureHost lock scope", () => {
+	it("#given the ensureHost body #when the endpoint lock is taken #then the tmpdir reap is ordered before acquisition", async () => {
+		const source = await readFile(hostEnsureSource, "utf8");
+		const body = source.slice(source.indexOf("export async function ensureHost("));
+		const reapAt = body.indexOf("reapOrphanedInternalHostDirs()");
+		const acquireAt = body.indexOf("acquireOwnershipSafeLock(");
+
+		expect(reapAt).toBeGreaterThan(-1);
+		expect(acquireAt).toBeGreaterThan(-1);
+		// Reaping inside the critical section made lock hold time scale with the whole
+		// tmpdir and, on win32, with a ~1s process probe per candidate, until a concurrent
+		// ensureHost exhausted its lock budget and surfaced a raw "database is locked".
+		expect(reapAt).toBeLessThan(acquireAt);
+	});
+});

--- a/packages/coding-agent/test/rpc-host-lifecycle.test.ts
+++ b/packages/coding-agent/test/rpc-host-lifecycle.test.ts
@@ -17,7 +17,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { VERSION } from "../src/config.ts";
-import { processMatchesPidFile, readProcessStartTime } from "../src/modes/app-server/daemon/process.ts";
+import { processIsLive, processMatchesPidFile, readProcessStartTime } from "../src/modes/app-server/daemon/process.ts";
 import { createHostDaemonPaths, ensureHost, type HostLifecyclePolicyInput } from "../src/modes/rpc/host-ensure.ts";
 import {
 	DEFAULT_HOST_IDLE_EXIT_MS,
@@ -704,7 +704,10 @@ async function waitForHostExit(
 			// avoids the 50ms polling storm that caused every probe to time out.
 			const probe = probeWindowsProcessIdentity(entry.pidFile.pid, 10_000);
 			currentIdentity = probe.identity;
-			probeTimedOut = probe.timedOut;
+			// A probe that timed out reports UNKNOWN, not ALIVE. kill(pid, 0) answers
+			// liveness deterministically, so a host that really exited is recognized here
+			// instead of spinning until the deadline and failing with "did not exit".
+			probeTimedOut = probe.timedOut && processIsLive(entry.pidFile.pid);
 		} else {
 			currentIdentity = await readProcessStartTime(entry.pidFile.pid);
 		}
@@ -792,8 +795,12 @@ function terminateSupervisor(pid: number, signal: NodeJS.Signals): void {
 			// The supervisor idle-exits on its own timer, so it can vanish between the
 			// caller's liveness check and this Stop-Process: an already-gone pid is the
 			// outcome the caller wanted, not a failure.
-			const probe = probeWindowsProcessIdentity(pid, 10_000);
-			if (probe.identity === undefined && !probe.timedOut) return;
+			//
+			// Liveness is decided by kill(pid, 0), not by the PowerShell CIM probe: that
+			// probe has its own timeout, and a loaded runner hitting it reported
+			// `timedOut` for a process that had genuinely exited, which rethrew and made
+			// teardown fail on runner slowness alone. A timeout means UNKNOWN, never ALIVE.
+			if (!processIsLive(pid)) return;
 			throw cause;
 		}
 		return;


### PR DESCRIPTION
## What this fixes

Four defects behind the flaky `RPC named pipes (Windows)` job, each found from real CI logs. I state below exactly which ones CI proved and which are defensive, because two of them were **not** the cause of any failure I observed.

## Root causes

### 1. `readProcessStartTime` threw past the startup guard — production, `host-lifecycle.ts`

The win32 baseline read sat **outside** the startup `try`/`catch`, and that function throws when its 1s CIM probe fails (`execFile`'s timeout SIGTERMs the PowerShell child). With no `unhandledRejection` handler the supervisor died right there.

Evidence chain from CI: `senpi rpc host ready` appeared **0 times** against two `listening on` lines, and `startup failed` **0 times** — it died past the startup guard but before the ready line. `CHILD_WATCH_FD` then did exactly what it is designed to do: the internal host saw EOF and shut itself down, surfacing as `connect ENOENT` on the public pipe and as `host <pid> reported dead`.

**CI-proven:** the next run showed `host ready` **2 times** (was 0), with `ENOENT` and CIM errors both dropping to **0**.

### 2. Opportunistic GC ran inside the endpoint lock — production, `host-ensure.ts`

`ensureHost()` ran `reapOrphanedInternalHostDirs()` **inside** the exclusive lock. That reaper's cost is unbounded in temp-directory size (measured locally: 132,035 entries, ~400ms) and on win32 spawns a `powershell.exe` probe per candidate, so a concurrent waiter could exhaust even the 42s budget and surface a raw `database is locked`.

The prior `changes.md` entry had already **raised the budget to 42s** chasing this. A larger budget cannot fix a critical section whose cost is unbounded; the reaper's own guards (60s age, dead owner pid) make it safe unlocked, so it now runs before the lock is taken.

**CI-proven:** mutation-killed by the new `rpc-host-ensure-lock-scope.test.ts` (`expected 1120 to be less than 1044` when the reap moves back inside), and the ensure suite has passed 13/13 on Windows CI in every run since.

### 3. A timed-out probe was read as ALIVE — test helper, two sites

`waitForHostExit()` and `terminateSupervisor()` trusted the CIM probe's `timedOut` flag, so a timeout meant "still alive": teardown rethrew and the exit wait spun to its deadline. Liveness is now decided by `processIsLive(pid)` (`kill(pid, 0)`), this repo's existing idiom.

**Defensive — not CI-proven.** `identity watchdog` appeared 0 times in the run I suspected, so this was never the direct cause of an observed failure.

### 4. The watchdog believed an absent identity too readily — production, `host-lifecycle.ts`

The win32 identity watchdog polls every 500ms with a 1s CIM timeout and shut the host down after two consecutive `undefined` readings — two timeouts ~1s apart could kill a healthy host. An absent identity is now confirmed with `kill(pid, 0)` first, and a timed-out probe neither increments nor resets the counter. `identityChanged` detection is unchanged.

**Defensive — not CI-proven**, same reason as #3.

## Relationship to the maintainer's parallel fixes

This job was failing repo-wide, and two maintainer fixes landed while this PR was open. This branch is rebased onto both.

- **#1291 (`hostAlive` retry).** I had written my own single `processIsLive` fallback for the same helper. Their version is stricter — "alive" is decisive on the first read, "dead" requires two consecutive agreeing reads or a 10s deadline, and a thrown probe resets the streak — and their commit message notes the probe can also *return* a lone `false` rather than throw, which my version did not cover. **I dropped mine and took theirs** during the rebase.
- **#1296 (lifecycle observer fan-out).** This closed the last failure: `session-event-fanout.ts` delivered lifecycle records only to attached connections, so the supervisor's observer never saw `agent_start` and judged an active host idle. That is the `idle shutdown` line in the final failing log.

Root cause #1 above is what unblocked the stage before theirs: with the supervisor dying at startup, `host ready` never printed at all.

## Repeated-run evidence

`RPC named pipes (Windows)`, same commit, job re-executed each round:

| round | run id | job id | result |
|---|---|---|---|
| 1 | 33628874723 | 100243105794 | SUCCESS |
| 2 | 33628874723 | 100245721750 | SUCCESS |
| 3 | 33628874723 | 100247129659 | SUCCESS |
| 4 | 33628874723 | 100248850116 | SUCCESS |
| 5 | 33628874723 | 100250298953 | SUCCESS |

Every round carries a distinct job id, so each is a genuine re-execution on a fresh Windows runner rather than a cached conclusion.

Round 1 was verified as a real pass rather than a skip: the four suites reported 13, 27 (+2 pre-existing skips), 10, and 6 passing, with `FAIL`, `database is locked`, `connect ENOENT`, `reported dead`, `identity watchdog`, and `idle shutdown` all at zero occurrences.

## Local verification

- `rpc-host-lifecycle` + `rpc-host-ensure` + the new lock-scope test: **43/43**
- 20 consecutive local runs of the ensure suites: **20/20 green**
- `npx tsc --noEmit`: clean · Changelog gate: PASS

## Honest limitations

- Fixes 1, 3, and 4 live inside `process.platform === "win32"` branches. No Windows machine is available to me, so local runs cannot exercise them — verified rather than assumed: removing fix 1's `.catch` is a **no-op** locally (30/30 unchanged). Real Windows CI is the only instrument for those.
- No assertion was weakened, no test skipped/`.only`/xfail'd, and no retry-until-green wrapper was added around a test.
