### PR TITLE
fix(rpc): feed lifecycle records to the supervisor observer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- The shared RPC supervisor's observer receives content-free session and agent lifecycle records even without a session attachment, so it no longer exits the host during an active turn.
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.
 
 ### New Features

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -62,9 +62,11 @@ On Windows, listeners and clients deterministically map the logical socket path 
 `\\.\pipe\senpi-rpc-<sha256[:32]>`. Callers keep using the same `unix://` CLI value; the logical path remains the
 ownership and settings identity, and callers never construct the pipe name themselves.
 
-Socket event visibility is attachment-scoped: each connection receives agent events only from sessions attached to that
-connection, with every record tagged by its routing `sessionId`. Content-free `session_closed` lifecycle records remain
-broadcast to all connections so observers can track the session roster. Correlated responses and dialog extension UI
+Socket event visibility is attachment-scoped for session content: each connection receives agent output only from sessions
+attached to that connection, with every record tagged by its routing `sessionId`. Content-free lifecycle records
+(`agent_start`, `agent_settled`, `agent_idle`, `session_opened`, and `session_closed`) are broadcast to all registered
+connections, including the supervisor's unattached observer, so host lifecycle accounting remains accurate without exposing
+session content. Correlated responses and dialog extension UI
 requests (select, confirm, input, and editor) are requester-only; other extension UI state records go to the session's
 attached connections. To observe a foreign session, open it by its existing
 `sessionPath`; the host attaches that connection during `open_session`.

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,20 @@
 # changes
 
+## [Unreleased] - Feed the supervisor's observer lifecycle records
+
+### What changed
+
+- `session-event-fanout.ts` delivers content-free lifecycle records (`agent_start`, `agent_settled`, `agent_idle`, `session_opened`, and `session_closed`) to every registered socket connection, including unattached observer connections. Session content, rendered component records, responses, and dialog requests retain their attachment/requester scoping.
+- The lifecycle supervisor's always-on internal observer therefore receives the turn boundaries required to prevent idle shutdown during an active turn without reopening cross-session content delivery.
+
+### Why
+
+- The supervisor must observe active turns independently of client session attachments; otherwise attached-only delivery leaves it believing an active host is idle.
+
+### Why an extension could not handle it
+
+- Socket fan-out and supervisor lifecycle accounting are transport behavior below the extension API.
+
 ## 2026-09-02 - Size the ensure-host lock wait to the startup critical section
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
@@ -10,6 +10,14 @@ export interface SessionEventWriterConnection {
 
 export const RENDERED_COMPONENT_RECORD = "__senpiRenderedComponent";
 
+const BROADCAST_LIFECYCLE_RECORDS = new Set([
+	"agent_start",
+	"agent_settled",
+	"agent_idle",
+	"session_opened",
+	"session_closed",
+]);
+
 type RegisteredConnection = {
 	readonly connection: SessionEventWriterConnection;
 	readonly actor: SocketEventSinkActor;
@@ -98,8 +106,11 @@ export class SessionEventFanout {
 		targetId: string | undefined,
 		isTargeted: boolean,
 		rendered: boolean,
+		recordType: unknown,
 	): readonly (string | undefined)[] {
 		if (isTargeted) return [targetId];
+		if (typeof recordType === "string" && BROADCAST_LIFECYCLE_RECORDS.has(recordType))
+			return this.connections.size > 0 ? [...this.connections.keys()] : [undefined];
 		if (rendered)
 			return this.connections.size > 0
 				? [...this.connections.keys()].filter(

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -179,7 +179,13 @@ export class SessionEventWriter {
 		const { [RENDERED_COMPONENT_RECORD]: _rendered, ...wireTagged } = tagged;
 		const line = serializeJsonLine(wireTagged);
 		if (!isTargeted) this.fanout.rememberSnapshot(sessionId, tagged, line);
-		const targets = this.fanout.targets(sessionId, targetId, isTargeted, record[RENDERED_COMPONENT_RECORD] === true);
+		const targets = this.fanout.targets(
+			sessionId,
+			targetId,
+			isTargeted,
+			record[RENDERED_COMPONENT_RECORD] === true,
+			record.type,
+		);
 		for (const target of targets) {
 			if (target !== undefined && !this.fanout.get(target)) continue;
 			const registered = target === undefined ? undefined : this.fanout.get(target);

--- a/packages/coding-agent/test/rpc-multi-session-events.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-events.test.ts
@@ -250,6 +250,43 @@ describe("multi-session RPC event writer", () => {
 		expect(records(unattached)).toEqual([]);
 	});
 
+	it("broadcasts content-free lifecycle records to unattached connections only", async () => {
+		const attached: string[] = [];
+		const unattached: string[] = [];
+		const writer = new SessionEventWriter(() => {});
+		writer.registerConnection("attached", {
+			writeRaw: (chunk) => attached.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.registerConnection("unattached", {
+			writeRaw: (chunk) => unattached.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.attachConnectionToSession("attached", "session");
+
+		for (const type of ["agent_start", "agent_settled", "agent_idle", "session_opened", "session_closed"])
+			writer.enqueue("session", { type });
+		writer.enqueue("session", { type: "message_update", message: "private" });
+		await writer.flush();
+
+		expect(records(unattached).map((record) => record.type)).toEqual([
+			"agent_start",
+			"agent_settled",
+			"agent_idle",
+			"session_opened",
+			"session_closed",
+		]);
+		expect(records(unattached).every((record) => record.sessionId === "session")).toBe(true);
+		expect(records(attached).map((record) => record.type)).toEqual([
+			"agent_start",
+			"agent_settled",
+			"agent_idle",
+			"session_opened",
+			"session_closed",
+			"message_update",
+		]);
+	});
+
 	it("does not let a gated socket stall a fast socket", async () => {
 		const slowGate = deferred<void>();
 		const slow: string[] = [];

--- a/packages/coding-agent/test/rpc-socket-host.test.ts
+++ b/packages/coding-agent/test/rpc-socket-host.test.ts
@@ -824,7 +824,15 @@ describe("RPC Unix-socket multi-connection host", () => {
 			const third = await connectPeer(qa.socketPath);
 			try {
 				await turn;
-				const foreign = (value: RecordValue) => value.sessionId === sessionB && value.type !== "session_closed";
+				const lifecycle = new Set([
+					"agent_start",
+					"agent_settled",
+					"agent_idle",
+					"session_opened",
+					"session_closed",
+				]);
+				const foreign = (value: RecordValue) =>
+					value.sessionId === sessionB && typeof value.type === "string" && !lifecycle.has(value.type);
 				expect(a.peer.messages.some(foreign)).toBe(false);
 				expect(third.peer.messages.some(foreign)).toBe(false);
 			} finally {


### PR DESCRIPTION
## Summary

The shared RPC supervisor keeps an always-on observer connection to the internal host. After attached-only event delivery, that unattached observer stopped seeing turn lifecycle records and could classify an active turn as idle.

This restores only the content-free lifecycle allowlist (`agent_start`, `agent_settled`, `agent_idle`, `session_opened`, `session_closed`) to all registered connections. Session content, rendered records, responses, and dialog requests remain attachment/requester scoped.

## Evidence

- RED at origin/main: focused unattached-observer test failed with `expected [] to deeply equal [agent_start, agent_settled, agent_idle, session_opened, session_closed]`.
- GREEN: gorky bridge Biome, `tsc --noEmit`, and five RPC suites passed (87/87).
- Dated CI evidence: pre-#1277 run `33602751743` was `7f0b535b...`; post-#1277 run `33622887744` was `2c6e385d...`; both had Windows named-pipe failures, while the post-#1277 attached-only delivery is the directly reproduced contract regression.

Refs #1290

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores broadcast of content-free lifecycle records (`agent_start`, `agent_settled`, `agent_idle`, `session_opened`, `session_closed`) to all registered RPC connections, including the supervisor's unattached observer. The observer previously stopped seeing these after attached-only delivery, causing it to treat an active turn as idle. Session content, rendered records, responses, and dialog requests remain attachment/requester scoped.

<sup>Written for commit a223381c8bc5ba3624cda038a79de6cad726c779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

