### PR TITLE
fix(terminal): make monitor wake-budget pause single-source and scoped

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - The shared RPC supervisor's observer receives content-free session and agent lifecycle records even without a session attachment, so it no longer exits the host during an active turn.
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.
+- Monitor wake-budget pauses now use single-source, scoped state: only the noisy monitor is muted, quiet monitors are not left permanently paused, and `rearm` without a `bash_id` resumes all paused monitors.
 
 ### New Features
 
@@ -22,7 +23,6 @@
 ### Fixed
 
 ### Removed
-
 ## [2026.9.2-4] - 2026-09-02
 
 ### Added

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,24 @@
 # terminal builtin extension — fork surface
 
+## Scoped monitor wake-budget pauses (2026-09-02)
+
+### What changed
+
+- Monitor pause state is authoritative in the registry; wake-budget exhaustion pauses only the noisy monitor(s) that contributed to that injection. Rearming one monitor or all paused monitors clears delivery bookkeeping so intermediate events resume correctly.
+
+### Why
+
+- A global notifier pause could mute quiet monitors permanently after a noisy monitor exhausted the shared wake budget.
+
+### Why an extension could not handle it
+
+- The registry owns monitor lifecycle and pause state, while the notifier owns wake-budget batching and deduplication; only the builtin terminal extension coordinates both.
+
+### Expected merge conflict zones
+
+- LOW: `monitor-registry.ts`, `monitor-notify.ts`, `tools/monitor.ts`, `extension.ts`, and terminal monitor tests.
+
+
 ## Add native one-shot file monitors (2026-08-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -132,6 +132,7 @@ function buildToolContext(pi: ExtensionAPI, state: TerminalExtensionState): Term
 			state.bundle?.notifyBackgroundExit(id, runtime);
 		},
 		onMonitorRearmed: (id: string) => state.monitorNotifier?.rearm(id),
+		onMonitorsResumed: (ids: readonly string[]) => state.monitorNotifier?.resume(ids),
 	};
 }
 
@@ -211,7 +212,7 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 			getContext: () => state.ctx,
 			getMode: () => state.settings.notify,
 			getSettings: () => state.settings.monitor,
-			pauseMonitors: () => state.bundle?.monitors.pauseAll() ?? [],
+			pauseMonitors: (ids) => state.bundle?.monitors.pause(ids) ?? [],
 		});
 		const sessionKey = sessionKeyOf(ctx);
 		if (event.reason === "reload") {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-notify.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-notify.ts
@@ -23,8 +23,8 @@ const systemScheduler: MonitorNotificationScheduler = {
 
 export interface MonitorNotifierDeps extends TerminalNotifierDeps {
 	readonly getSettings: () => MonitorDeliverySettings;
-	/** Pause live monitors when their shared wake budget is exhausted. */
-	readonly pauseMonitors: () => readonly string[];
+	/** Pause the monitors contributing to a shared wake-budget exhaustion. */
+	readonly pauseMonitors: (ids: readonly string[]) => readonly string[];
 	readonly scheduler?: MonitorNotificationScheduler;
 }
 
@@ -89,7 +89,6 @@ export class MonitorNotifier {
 	#scheduledAt: number | undefined;
 	#consecutiveWakes = 0;
 	#lastWakeAt: number | undefined;
-	#wakeBudgetPaused = false;
 
 	constructor(deps: MonitorNotifierDeps) {
 		this.#deps = deps;
@@ -97,17 +96,18 @@ export class MonitorNotifier {
 	}
 
 	notifyEvent(event: MonitorEvent): void {
-		if (this.#wakeBudgetPaused) {
-			if (event.type === "line") return;
-			this.#wakeBudgetPaused = false;
-			this.#consecutiveWakes = 0;
+		if (event.type === "summary") {
 			this.#lastInjectionAt.delete(event.id);
+			this.#lastInjectedBatch.delete(event.id);
 		}
 		if (!getTerminalNotificationDelivery(this.#deps, MONITOR_NOTIFICATION_CUSTOM_TYPE)) return;
 		const settings = resolveSettings(this.#deps.getSettings());
 		const rendered = `Monitor event(${event.description}): ${eventBody(event)}`;
 		const queueLimit = Math.max(1, settings.maxCharsPerInjection - QUEUE_OVERHEAD_CHARS);
-		if (this.#events.length >= settings.maxLinesPerInjection || this.#eventChars + rendered.length > queueLimit) {
+		if (
+			event.type !== "summary" &&
+			(this.#events.length >= settings.maxLinesPerInjection || this.#eventChars + rendered.length > queueLimit)
+		) {
 			this.#recordOverflow(event.id);
 		} else {
 			this.#events.push(event);
@@ -121,12 +121,17 @@ export class MonitorNotifier {
 		this.#consecutiveWakes = 0;
 	}
 
-	/** Explicit rearm resumes intermediate line delivery after the session-global wake pause. */
-	rearm(id: string): void {
-		this.#wakeBudgetPaused = false;
+	/** Clear delivery bookkeeping for monitors explicitly resumed by the registry. */
+	resume(ids: readonly string[]): void {
+		for (const id of ids) {
+			this.#lastInjectionAt.delete(id);
+			this.#lastInjectedBatch.delete(id);
+		}
 		this.#consecutiveWakes = 0;
-		this.#lastInjectionAt.delete(id);
-		this.#lastInjectedBatch.delete(id);
+	}
+
+	rearm(id: string): void {
+		this.resume([id]);
 	}
 
 	dispose(): void {
@@ -156,10 +161,6 @@ export class MonitorNotifier {
 	#flush(): void {
 		this.#timer = undefined;
 		this.#scheduledAt = undefined;
-		if (this.#wakeBudgetPaused) {
-			this.dispose();
-			return;
-		}
 		const delivery = getTerminalNotificationDelivery(this.#deps, MONITOR_NOTIFICATION_CUSTOM_TYPE);
 		if (!delivery) {
 			this.dispose();
@@ -170,8 +171,10 @@ export class MonitorNotifier {
 		const now = this.#scheduler.now();
 		const pendingIds = new Set([...this.#events.map((event) => event.id), ...this.#overflow.keys()]);
 		if (pendingIds.size === 0) return;
+		const summaryIds = new Set(this.#events.filter((event) => event.type === "summary").map((event) => event.id));
 		const ready = new Set(
 			[...pendingIds].filter((id) => {
+				if (summaryIds.has(id)) return true;
 				const last = this.#lastInjectionAt.get(id);
 				return last === undefined || now - last >= settings.rateLimitMs;
 			}),
@@ -227,11 +230,11 @@ export class MonitorNotifier {
 		this.#consecutiveWakes = deliversSummary ? 0 : this.#consecutiveWakes + 1;
 
 		if (reachesBudget) {
-			this.#wakeBudgetPaused = true;
-			this.#deps.pauseMonitors();
+			this.#deps.pauseMonitors([...injectedIds]);
 			this.#events = [];
 			this.#eventChars = 0;
 			this.#overflow.clear();
+			this.#consecutiveWakes = 0;
 			return;
 		}
 		const remainingIds = new Set([...this.#events.map((event) => event.id), ...this.#overflow.keys()]);

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
@@ -462,10 +462,11 @@ export class MonitorRegistry {
 		if (record.runtime.exited) this.#settle(record);
 	}
 
-	pauseAll(): string[] {
+	pause(ids: readonly string[]): string[] {
 		const paused: string[] = [];
-		for (const record of [...this.#records.values(), ...this.#files.values()]) {
-			if (record.paused) continue;
+		for (const id of ids) {
+			const record = this.#records.get(id) ?? this.#files.get(id);
+			if (!record || record.paused) continue;
 			record.paused = true;
 			paused.push(record.id);
 		}
@@ -473,13 +474,29 @@ export class MonitorRegistry {
 		return paused;
 	}
 
+	pauseAll(): string[] {
+		return this.pause([...this.#records.keys(), ...this.#files.keys()]);
+	}
+
+	resume(ids?: readonly string[]): string[] {
+		const candidates = ids ?? [...this.#records.keys(), ...this.#files.keys()];
+		const resumed: string[] = [];
+		for (const id of candidates) {
+			const record = this.#records.get(id) ?? this.#files.get(id);
+			if (!record?.paused) continue;
+			record.paused = false;
+			resumed.push(record.id);
+			if ("pendingChange" in record && record.pendingChange) void this.#checkFile(record.id);
+		}
+		if (resumed.length > 0) this.#notifyChange();
+		return resumed;
+	}
+
 	rearm(id: string): MonitorRearmResult {
 		const record = this.#records.get(id) ?? this.#files.get(id);
 		if (!record) return "not_found";
 		if (!record.paused) return "not_paused";
-		record.paused = false;
-		this.#notifyChange();
-		if ("pendingChange" in record && record.pendingChange) void this.#checkFile(record.id);
+		this.resume([id]);
 		return "rearmed";
 	}
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
@@ -18,9 +18,9 @@ manual \`&\` backgrounding — use the built-in session tools:
   injected events while you keep working; command exit always delivers a summary. One-shot
   gate: wait inside the command and print one sentinel (\`until <cond>; do sleep 1; done;
   printf 'READY\\n'\`). Stream: \`tail -n 0 -F | grep --line-buffered\`. Filter noise at the
-  source and stop with \`kill_bash\`. Identical updates are deduped; enough monitor-only wakes
-  pause ALL monitors - completion still wakes the session, and
-  \`monitor({ action: "rearm", bash_id })\` resumes intermediate events.
+  source and stop with \`kill_bash\`. Identical updates are deduped; repeated monitor-only wakes
+  pause the noisy monitor(s) that caused them, not all monitors. Completion still wakes the session, and
+  \`monitor({ action: "rearm", bash_id })\` resumes one while \`monitor({ action: "rearm" })\` resumes all paused monitors.
 - \`bash_input({ bash_id, input, keys, submit })\` sends stdin or named keys (e.g.
   \`["ctrl+c"]\`, \`["enter"]\`) to steer a REPL or interrupt a process.
 - \`bash_resize({ bash_id, cols, rows })\` resizes the PTY so full-screen programs reflow.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
@@ -30,6 +30,8 @@ export interface TerminalToolContext {
 	readonly onMonitorEvent?: (event: MonitorEvent) => void;
 	/** Resets session-global wake-budget delivery for a fresh or explicitly rearmed monitor. */
 	readonly onMonitorRearmed?: (id: string) => void;
+	/** Clears notifier bookkeeping when multiple paused monitors are resumed. */
+	readonly onMonitorsResumed?: (ids: readonly string[]) => void;
 }
 
 /** Minimal tool-result shape returned by the terminal tools. */

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -51,7 +51,9 @@ export const monitorSchema = Type.Object({
 	persistent: Type.Optional(
 		Type.Boolean({ description: "Keep watching until the command exits or kill_bash stops its bash_id." }),
 	),
-	bash_id: Type.Optional(Type.String({ description: "Rearm (required): paused monitor bash_id to resume." })),
+	bash_id: Type.Optional(
+		Type.String({ description: "Rearm: paused monitor bash_id to resume; omit to resume all paused monitors." }),
+	),
 });
 export type MonitorInput = Static<typeof monitorSchema>;
 
@@ -148,7 +150,12 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 			const registry = getRegistry();
 			if (input.action === "rearm") {
 				const bashId = input.bash_id;
-				if (bashId === undefined || bashId.length === 0) return errorResult("monitor rearm requires bash_id.");
+				if (bashId === undefined || bashId.length === 0) {
+					const resumed = registry.resume();
+					if (resumed.length === 0) return textResult("No paused monitors to re-arm.");
+					ctx.onMonitorsResumed?.(resumed);
+					return textResult(`Re-armed ${resumed.length} paused monitor(s).`);
+				}
 				const outcome = registry.rearm(bashId);
 				if (outcome === "not_found") return errorResult(`No active monitor found with id: ${bashId}`);
 				if (outcome === "not_paused") return textResult(`Monitor ${bashId} is not paused; no action taken.`);

--- a/packages/coding-agent/test/suite/terminal-monitor-notify-harness.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-notify-harness.ts
@@ -78,7 +78,7 @@ export function createNotifier(
 ) {
 	const scheduler = new FakeScheduler();
 	const sent: SentMessage[] = [];
-	const pauseMonitors = vi.fn(() => ["bash_budget"]);
+	const pauseMonitors = vi.fn((_ids: readonly string[]) => ["bash_budget"]);
 	const notifier = new MonitorNotifier({
 		sendMessage: (message, options) => sent.push({ message, options }),
 		getContext: () =>

--- a/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-notify.test.ts
@@ -47,6 +47,21 @@ describe("terminal monitor event delivery", () => {
 		expect(pauseMonitors).toHaveBeenCalledTimes(1);
 	});
 
+	it("mutes only the noisy monitor and still delivers a quiet monitor line", () => {
+		const { notifier, pauseMonitors, scheduler, sent } = createNotifier({
+			settings: { coalesceWindowMs: 10, rateLimitMs: 1, wakeBudget: 1 },
+		});
+		notifier.notifyEvent(line("A", "noisy", "wake-1"));
+		scheduler.advanceBy(10);
+
+		expect(pauseMonitors).toHaveBeenCalledWith(["A"]);
+		notifier.notifyEvent(line("B", "quiet", "still-running"));
+		scheduler.advanceBy(10);
+
+		expect(sent).toHaveLength(2);
+		expect(sent[1]?.message.content).toContain("Monitor event(quiet): still-running");
+	});
+
 	it("enforces the per-monitor rate limit while retaining an overflow event for the next wake", () => {
 		const { notifier, scheduler, sent } = createNotifier();
 		notifier.notifyEvent(line("bash_rate", "rate", "first"));
@@ -120,6 +135,46 @@ describe("terminal monitor event delivery", () => {
 		scheduler.advanceBy(2000);
 		expect(sent).toHaveLength(6);
 		expect(sent[5]?.message.content).toContain("resumed");
+	});
+
+	it("delivers an exit summary even when the injection queue is full", () => {
+		const { notifier, scheduler, sent } = createNotifier({
+			settings: { coalesceWindowMs: 10, rateLimitMs: 5000, maxLinesPerInjection: 1, wakeBudget: 5 },
+		});
+		notifier.notifyEvent(line("A", "noisy", "busy"));
+		notifier.notifyEvent(summary("B", "done-b", "watcher completed (exit code 0)"));
+		scheduler.advanceBy(10);
+
+		expect(sent.some(({ message }) => message.content.includes("watcher completed (exit code 0)"))).toBe(true);
+	});
+
+	it("delivers a summary that arrives while its own monitor is rate-limited and the queue is full", () => {
+		const { notifier, scheduler, sent } = createNotifier({
+			settings: { coalesceWindowMs: 10, rateLimitMs: 5000, maxLinesPerInjection: 1, wakeBudget: 5 },
+		});
+		notifier.notifyEvent(line("A", "running", "started"));
+		scheduler.advanceBy(10);
+		notifier.notifyEvent(line("B", "noisy", "busy"));
+		notifier.notifyEvent(summary("A", "running", "watcher completed (exit code 0)"));
+		scheduler.advanceBy(10);
+
+		expect(sent.some(({ message }) => message.content.includes("watcher completed (exit code 0)"))).toBe(true);
+	});
+
+	it("delivers a muted monitor summary without resuming another muted monitor", () => {
+		const { notifier, pauseMonitors, scheduler, sent } = createNotifier({
+			settings: { coalesceWindowMs: 10, rateLimitMs: 1, wakeBudget: 1 },
+		});
+		notifier.notifyEvent(line("A", "muted-a", "wake"));
+		scheduler.advanceBy(10);
+		notifier.notifyEvent(line("B", "muted-b", "wake"));
+		scheduler.advanceBy(10);
+		notifier.notifyEvent(summary("A", "muted-a", "completed"));
+		scheduler.advanceBy(10);
+
+		expect(pauseMonitors).toHaveBeenCalledTimes(2);
+		expect(sent).toHaveLength(3);
+		expect(sent[2]?.message.content).toContain("Monitor event(muted-a): completed");
 	});
 
 	it("delivers a paused monitor completion without rearm", () => {

--- a/packages/coding-agent/test/suite/terminal-monitor.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor.test.ts
@@ -127,11 +127,28 @@ describe("terminal monitor tool", () => {
 		expect(firstText(result)).toContain("command");
 	});
 
-	it("rejects rearm without bash_id", async () => {
-		const tool = createMonitorTool(ctx);
-		const result = await tool.execute("monitor-rearm-missing", { action: "rearm" } as MonitorInput);
-		expect(result.isError).toBe(true);
-		expect(firstText(result)).toContain("bash_id");
+	it("rearms all paused monitors without bash_id", async () => {
+		let resumedIds: readonly string[] | undefined;
+		const registry = new MonitorRegistry((event) => sink.push(event));
+		const tool = createMonitorTool({
+			...ctx,
+			monitorRegistry: registry,
+			onMonitorsResumed: (ids) => (resumedIds = ids),
+		});
+		const first = await tool.execute("monitor-rearm-all-a", { description: "paused a", command: "sleep 30" });
+		const second = await tool.execute("monitor-rearm-all-b", { description: "paused b", command: "sleep 30" });
+		const firstId = /ID: (bash_\d+)/.exec(firstText(first))?.[1];
+		const secondId = /ID: (bash_\d+)/.exec(firstText(second))?.[1];
+		if (!firstId || !secondId) throw new Error("Monitors did not return bash_ids");
+
+		expect(registry.pause([firstId, secondId])).toEqual([firstId, secondId]);
+		expect(registry.resume()).toEqual([firstId, secondId]);
+		expect(registry.pause([firstId, secondId])).toEqual([firstId, secondId]);
+		const result = await tool.execute("monitor-rearm-all", { action: "rearm" } as MonitorInput);
+		expect(result.isError).not.toBe(true);
+		expect(firstText(result)).toContain("Re-armed 2 paused monitor(s).");
+		expect(resumedIds).toEqual([firstId, secondId]);
+		expect(registry.snapshot().every((entry) => !entry.paused)).toBe(true);
 	});
 
 	it("returns a bash_id immediately and emits complete stdout lines in order before its summary", async () => {
@@ -214,17 +231,23 @@ describe("terminal monitor tool", () => {
 		expect(summaryEvent(await ended).summary).toContain("killed");
 	});
 
-	it("emits a final summary when a wake-budget-paused monitor exits", async () => {
+	it("emits a final summary for one muted monitor without resuming another", async () => {
 		const registry = new MonitorRegistry((event) => sink.push(event));
 		const tool = createMonitorTool({ ...ctx, monitorRegistry: registry });
-		const ended = sink.waitFor((event) => event.type === "summary", "paused monitor completion");
-		const started = await tool.execute("monitor-paused-exit", { description: "paused exit", command: "sleep 30" });
-		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
-		if (!bashId) throw new Error("Monitor did not return a bash_id");
+		const first = await tool.execute("monitor-paused-exit-a", { description: "paused a", command: "sleep 30" });
+		const second = await tool.execute("monitor-paused-exit-b", { description: "paused b", command: "sleep 30" });
+		const firstId = /ID: (bash_\d+)/.exec(firstText(first))?.[1];
+		const secondId = /ID: (bash_\d+)/.exec(firstText(second))?.[1];
+		if (!firstId || !secondId) throw new Error("Monitors did not return bash_ids");
+		const ended = sink.waitFor(
+			(event) => event.type === "summary" && event.id === firstId,
+			"muted monitor completion",
+		);
 
-		registry.pauseAll();
-		await createKillBashTool(ctx).execute("kill-paused", { bash_id: bashId });
+		expect(registry.pause([firstId, secondId])).toEqual([firstId, secondId]);
+		await createKillBashTool(ctx).execute("kill-paused", { bash_id: firstId });
 		expect(summaryEvent(await ended).summary).toContain("killed");
+		expect(registry.snapshot()).toEqual([expect.objectContaining({ id: secondId, paused: true })]);
 	});
 
 	it("rearms a wake-budget-paused monitor and notifies the session delivery controller", async () => {


### PR DESCRIPTION
## What

Monitor wake-budget "paused" state could get stuck: a quiet watcher was left permanently muted after a noisy neighbor exhausted the session-global wake budget, and the footer showed a stale `paused` for the rest of the watcher's life.

Root cause: pause state was duplicated across two holders that recovered independently — the notifier's session-global `#wakeBudgetPaused` and each registry record's `paused`. `pauseAll()` muted everything; only an explicit rearm cleared the registry, while a summary cleared only the notifier flag.

## Change

- **Registry is the single source of truth** for pause state (`pause(ids)` / `resume(ids?)`; `pauseAll` and `rearm` delegate).
- **Scoped mute**: budget exhaustion pauses only the monitor ids in the exhausting injection, not every live monitor — so a quiet monitor is never muted by a noisy one.
- **Notifier** loses its redundant `#wakeBudgetPaused`; it owns delivery accounting only. Streak resets on pause (epoch close). Summary delivery is now rate-limit-independent, keeping completion sacred.
- **`monitor({ action: "rearm" })` with no `bash_id` resumes all paused monitors** (asymmetry fixed).
- Prompt/docs updated; `paused` wire field unchanged (cross-repo consumers safe); no new settings key.

## Tests (RED-first)

- notify harness: exhausting the budget mutes only the noisy id (`pauseMonitors(["A"])`) and a quiet monitor's next line is still delivered; a muted monitor's summary is delivered without resuming another muted monitor.
- registry integration: `resume()` / `rearm` with no bash_id resumes all; killing one muted monitor still emits its summary while the other stays muted.
- All existing terminal-monitor tests green; call-shape expectations updated to the scoped API preserving intent.

Base: origin/main. Part of the monitor-pause lifecycle series (Phase 1 of 6).


Plan: .omo/plans/monitor-pause-lifecycle.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes monitor wake-budget pauses so a quiet watcher is no longer left permanently muted when a noisy neighbor exhausts the shared wake budget. Pause state now lives only in the registry, and budget exhaustion mutes only the monitors that caused it.

**Behavior changes**

- `monitor({ action: "rearm" })` with no `bash_id` now resumes all paused monitors instead of erroring.
- Summary delivery no longer waits on the per-monitor rate limit, and exit summaries always retain full content even when the queue or char budget overflows.
- The `paused` wire field and wake-storm protection are unchanged, so cross-repo consumers are unaffected.

<sup>Written for commit 8d5fef1e1713a16c86b88db3f7db33b3a1641b7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

