### PR TITLE
fix(terminal): resume muted monitors on real user input

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `/reload` and hot-reload no longer stall for seconds on macOS/Linux: config-reload's per-directory `fs.watch` subscriptions are created and torn down on the watch worker thread instead of the interactive main thread (measured lifecycle phase 2.0-3.2s → ~150ms idle, 12s+ → ~150ms under load).
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.
 - Monitor wake-budget pauses now use single-source, scoped state: only the noisy monitor is muted, quiet monitors are not left permanently paused, and `rearm` without a `bash_id` resumes all paused monitors.
+- Real interactive and RPC user input now resumes paused terminal monitors while extension-generated input and tool calls remain unable to unpause them.
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,23 @@
 # terminal builtin extension — fork surface
 
+## External user input resumes paused monitors (2026-09-02)
+
+### What changed
+
+- Interactive and RPC user input now resumes all paused monitors and clears their notifier delivery bookkeeping; extension-generated input and tool calls remain streak-reset-only and do not resume monitors.
+
+### Why
+
+- Real user input is an intentional re-engagement signal, while agent-owned activity must preserve wake-storm protection.
+
+### Why an extension could not handle it
+
+- The authoritative monitor registry and notifier delivery bookkeeping are private to the builtin terminal extension's session state.
+
+### Expected merge conflict zones
+
+- LOW: `extension.ts` input handling, `prompt.ts`, and the terminal monitor external-resume regression test.
+
 ## Scoped monitor wake-budget pauses (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -237,7 +237,10 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 	});
 
 	pi.on("input", (event) => {
-		if (event.source !== "extension") state.monitorNotifier?.noteActivity();
+		if (event.source === "extension") return;
+		state.monitorNotifier?.noteActivity();
+		const resumed = state.bundle?.monitors.resume() ?? [];
+		if (resumed.length > 0) state.monitorNotifier?.resume(resumed);
 	});
 
 	pi.on("tool_call", () => {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/prompt.ts
@@ -20,7 +20,7 @@ manual \`&\` backgrounding — use the built-in session tools:
   printf 'READY\\n'\`). Stream: \`tail -n 0 -F | grep --line-buffered\`. Filter noise at the
   source and stop with \`kill_bash\`. Identical updates are deduped; repeated monitor-only wakes
   pause the noisy monitor(s) that caused them, not all monitors. Completion still wakes the session, and
-  \`monitor({ action: "rearm", bash_id })\` resumes one while \`monitor({ action: "rearm" })\` resumes all paused monitors.
+  \`monitor({ action: "rearm", bash_id })\` resumes one while \`monitor({ action: "rearm" })\` resumes all paused monitors; real user input also resumes paused monitors.
 - \`bash_input({ bash_id, input, keys, submit })\` sends stdin or named keys (e.g.
   \`["ctrl+c"]\`, \`["enter"]\`) to steer a REPL or interrupt a process.
 - \`bash_resize({ bash_id, cols, rows })\` resizes the PTY so full-screen programs reflow.

--- a/packages/coding-agent/test/suite/terminal-monitor-external-resume.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-external-resume.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import registerTerminalExtension from "../../src/core/extensions/builtin/terminal/index.ts";
+import { MonitorRegistry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import { createHarness, type Harness } from "./harness.ts";
+
+function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find((part) => part.type === "text")?.text ?? "";
+}
+
+describe("terminal monitor external resume", () => {
+	const harnesses: Harness[] = [];
+
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("resumes muted monitors for user input but not extension input", async () => {
+		const register = vi.spyOn(MonitorRegistry.prototype, "register");
+		const harness = await createHarness({ extensionFactories: [registerTerminalExtension] });
+		harnesses.push(harness);
+		await harness.session.bindExtensions({});
+		const started = await harness.session.executeTool("monitor", {
+			description: "external resume test",
+			command: "sleep 30",
+			persistent: true,
+		});
+		const bashId = /bash_\d+/.exec(resultText(started))?.[0];
+		if (!bashId) throw new Error("Monitor did not return a bash id");
+		const registry = register.mock.instances[0] as MonitorRegistry | undefined;
+		if (!registry) throw new Error("Monitor registry was not captured");
+
+		try {
+			registry.pause([bashId]);
+			expect(registry.snapshot()).toContainEqual({
+				id: bashId,
+				paused: true,
+				description: "external resume test",
+				startedAtMs: expect.any(Number),
+			});
+
+			await harness
+				.getExtensionRunner()
+				.emitInput("generated", undefined, "extension", undefined, "extension-input");
+			expect(registry.snapshot()).toContainEqual({
+				id: bashId,
+				paused: true,
+				description: "external resume test",
+				startedAtMs: expect.any(Number),
+			});
+
+			await harness.getExtensionRunner().emitInput("hi", undefined, "interactive", undefined, "user-input");
+			expect(registry.snapshot()).toContainEqual({
+				id: bashId,
+				paused: false,
+				description: "external resume test",
+				startedAtMs: expect.any(Number),
+			});
+		} finally {
+			await harness.session.executeTool("kill_bash", { bash_id: bashId });
+			register.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## What

Phase 2 of the monitor-pause lifecycle series. After Phase 1 (single-source registry pause + scoped muting), a muted monitor still only recovered via an explicit `monitor({ action: "rearm" })`. This adds natural recovery: a real user input resumes every muted monitor.

## Change

- `extension.ts` `pi.on("input")`: for a non-extension input (`source !== "extension"`, i.e. interactive/rpc), resume all muted monitors via `state.bundle.monitors.resume()` and clear the notifier's delivery bookkeeping for the resumed ids. `tool_call` and extension-sourced input are unchanged (streak-reset only), so the agent's own activity never unpauses a noisy watcher — wake-storm protection intact.
- prompt.ts note; `paused` wire field unchanged; no settings key.

## Test (RED-first)

New `terminal-monitor-external-resume.test.ts` (extension-level): spies `MonitorRegistry.register` to capture the extension-owned registry, creates a monitor, pauses it, then drives the real input handler via `ExtensionRunner.emitInput`:
- `source: "extension"` input -> monitor stays `paused: true` (wake-storm guard),
- `source: "interactive"` input -> monitor flips to `paused: false`.

Mutation-proven: reverting the `extension.ts` change fails the interactive-resume assertion. Full scoped monitor suite stays green.

Base: origin/main. Part of the monitor-pause lifecycle series (Phase 2 of 6).

Plan: .omo/plans/monitor-pause-lifecycle.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumes paused terminal monitors when the user sends real input, so a muted monitor can recover without an explicit `monitor({ action: "rearm" })` call. Extension-generated input and tool calls still leave monitors paused, so the agent's own activity can't unpause a noisy watcher into a wake loop.

- Interactive and RPC input resumes all paused monitors and clears the notifier's delivery bookkeeping for those IDs.
- Adds a regression test covering both extension input (stays paused) and interactive input (resumes).

<sup>Written for commit 18b282200986e23cb5d205f0f0c13878be64dc71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

