### PR TITLE
fix(terminal): label paused monitors "muted" in the footer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- The terminal monitor footer now labels paused monitors as `muted` or `N muted` while preserving the `paused` wire field.
+
 ### Fixed
 
 - The shared RPC supervisor's observer receives content-free session and agent lifecycle records even without a session attachment, so it no longer exits the host during an active turn.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,24 @@
 # terminal builtin extension — fork surface
 
+## Monitor footer muted label (2026-09-02)
+
+### What changed
+
+- The monitor footer now renders paused monitors as `muted` or `N muted`.
+- The `paused` wire field remains unchanged.
+
+### Why
+
+- `muted` communicates temporary silencing without implying that the monitor is frozen or stuck.
+
+### Why an extension could not handle it
+
+- The footer formatter owns the human-readable monitor status label.
+
+### Expected merge conflict zones
+
+- LOW: `monitor-status.ts` and terminal monitor footer tests.
+
 ## External user input resumes paused monitors (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-status.ts
@@ -60,7 +60,7 @@ export function monitorElapsedSeconds(snapshot: readonly MonitorSnapshotEntry[],
 export function formatMonitorStatus(snapshot: readonly MonitorSnapshotEntry[], nowMs: number): string | undefined {
 	if (snapshot.length === 0) return undefined;
 	const pausedCount = snapshot.filter((entry) => entry.paused).length;
-	const pausedPart = pausedCount === 0 ? "" : pausedCount === snapshot.length ? ", paused" : `, ${pausedCount} paused`;
+	const pausedPart = pausedCount === 0 ? "" : pausedCount === snapshot.length ? ", muted" : `, ${pausedCount} muted`;
 	const suffix = ` (${formatElapsedSeconds(monitorElapsedSeconds(snapshot, nowMs))}${pausedPart})`;
 	if (snapshot.length === 1) {
 		const head = `${WATCH_GLYPH} watching `;

--- a/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
@@ -96,7 +96,7 @@ describe("formatMonitorStatus", () => {
 
 	it("marks paused watches and keeps the marker through truncation", () => {
 		const all = formatMonitorStatus([entry("bash_1", "a", true), entry("bash_2", "b", true)], T0 + 60_000);
-		expect(all).toBe("◉ watching 2: a, b (1m, paused)");
+		expect(all).toBe("◉ watching 2: a, b (1m, muted)");
 		const some = formatMonitorStatus(
 			[
 				entry("bash_1", "errors in deploy.log", true),
@@ -105,7 +105,7 @@ describe("formatMonitorStatus", () => {
 			],
 			T0,
 		);
-		expect(some).toContain("1 paused");
+		expect(some).toContain("1 muted");
 		expect((some ?? "").length).toBeLessThanOrEqual(48);
 	});
 });


### PR DESCRIPTION
## What

Phase 3 of the monitor-pause lifecycle series. The TUI footer showed a paused monitor as `... (3h 27m, paused)`, which reads as "frozen". A user hit exactly this and read it as a stuck/broken monitor. Render the state as "muted" / "N muted" instead — it is silenced but alive.

## Change

- `monitor-status.ts` `formatMonitorStatus`: the paused suffix is now `", muted"` (all) / `", N muted"` (partial) instead of `paused`. One line; the `paused` boolean read, the `paused` wire field, and the 48-char `MAX_STATUS_LENGTH` cap are all unchanged ("muted" is shorter than "paused").
- Footer test updated to assert the new strings; the `<= 48` length assertion is kept.

Wire compatibility: `terminal_monitor_state`'s per-monitor `paused` field is untouched, so cross-repo consumers are unaffected (the desktop keeps its own "paused" chip — an intentional TUI-only wording change).

## Test (RED-first)

The footer test's exact-string assertions were flipped to `muted` first (RED against the unchanged `paused` renderer), then the one-line production change turns them GREEN. Mutation-proven: reverting `monitor-status.ts` fails the footer assertions. Full scoped monitor suite stays green.

Base: origin/main. Part of the monitor-pause lifecycle series (Phase 3 of 6).

Plan: .omo/plans/monitor-pause-lifecycle.md


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the terminal footer's paused-monitor label from "paused" to "muted" so a paused monitor reads as temporarily silenced rather than frozen or stuck.

- The footer now renders `muted` or `N muted` in place of `paused`.
- The `paused` wire field on `terminal_monitor_state` is unchanged, so cross-repo consumers are unaffected.
- `muted` is shorter than `paused`, so the 48-character footer cap still holds.

<sup>Written for commit ecc9d49a07561bd4311accef6bbd18bb0c3590bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

