### PR TITLE
feat(terminal): report lines dropped while a monitor was muted

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Multi-session RPC `close_session` teardown is bounded by a 10-second grace period (configurable via `SENPI_RPC_CLOSE_GRACE_MS`), force-releasing the session and path reservation on expiry; a second close joins the in-flight teardown instead of returning `unknown_session`.
 - Monitor wake-budget pauses now use single-source, scoped state: only the noisy monitor is muted, quiet monitors are not left permanently paused, and `rearm` without a `bash_id` resumes all paused monitors.
 - Real interactive and RPC user input now resumes paused terminal monitors while extension-generated input and tool calls remain unable to unpause them.
+- Rearming a muted monitor now reports how many filter-matching output lines were dropped while it was muted; the count resets on resume.
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,23 @@
 # terminal builtin extension — fork surface
 
+## Muted monitor dropped-line counts (2026-09-02)
+
+### What changed
+
+- Filter-matching complete lines received while a command monitor is muted are counted and reported when the monitor is re-armed; the count resets on resume.
+
+### Why
+
+- A re-arm report tells the agent how much matching output it missed without retaining or replaying dropped text.
+
+### Why an extension could not handle it
+
+- The monitor registry owns line consumption, pause state, and the re-arm lifecycle.
+
+### Expected merge conflict zones
+
+- LOW: `monitor-registry.ts`, `tools/monitor.ts`, and terminal monitor tests.
+
 ## Monitor footer muted label (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -240,7 +240,7 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 		if (event.source === "extension") return;
 		state.monitorNotifier?.noteActivity();
 		const resumed = state.bundle?.monitors.resume() ?? [];
-		if (resumed.length > 0) state.monitorNotifier?.resume(resumed);
+		if (resumed.length > 0) state.monitorNotifier?.resume(resumed.map((monitor) => monitor.id));
 	});
 
 	pi.on("tool_call", () => {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
@@ -23,6 +23,11 @@ export type MonitorEvent = MonitorLineEvent | MonitorSummaryEvent;
 
 export type MonitorRearmResult = "rearmed" | "not_paused" | "not_found";
 
+export interface MonitorResumeResult {
+	readonly id: string;
+	readonly mutedDropped: number;
+}
+
 export interface MonitorSnapshotEntry {
 	readonly id: string;
 	readonly description: string;
@@ -95,6 +100,7 @@ interface MonitorRecord {
 	readonly runtime: TerminalRuntimeSession;
 	readonly filter: RegExp | undefined;
 	lineBuffer: string;
+	mutedDropped: number;
 	paused: boolean;
 	settled: boolean;
 	unsubscribeOutput: (() => void) | undefined;
@@ -446,6 +452,7 @@ export class MonitorRegistry {
 			runtime: options.runtime,
 			filter: options.filter,
 			lineBuffer: "",
+			mutedDropped: 0,
 			paused: false,
 			settled: false,
 			unsubscribeOutput: undefined,
@@ -478,18 +485,24 @@ export class MonitorRegistry {
 		return this.pause([...this.#records.keys(), ...this.#files.keys()]);
 	}
 
-	resume(ids?: readonly string[]): string[] {
+	resume(ids?: readonly string[]): MonitorResumeResult[] {
 		const candidates = ids ?? [...this.#records.keys(), ...this.#files.keys()];
-		const resumed: string[] = [];
+		const resumed: MonitorResumeResult[] = [];
 		for (const id of candidates) {
 			const record = this.#records.get(id) ?? this.#files.get(id);
 			if (!record?.paused) continue;
 			record.paused = false;
-			resumed.push(record.id);
+			const mutedDropped = "mutedDropped" in record ? record.mutedDropped : 0;
+			if ("mutedDropped" in record) record.mutedDropped = 0;
+			resumed.push({ id: record.id, mutedDropped });
 			if ("pendingChange" in record && record.pendingChange) void this.#checkFile(record.id);
 		}
 		if (resumed.length > 0) this.#notifyChange();
 		return resumed;
+	}
+
+	mutedDropped(id: string): number {
+		return this.#records.get(id)?.mutedDropped ?? 0;
 	}
 
 	rearm(id: string): MonitorRearmResult {
@@ -592,7 +605,12 @@ export class MonitorRegistry {
 			const rawLine = remaining.slice(0, newline);
 			remaining = remaining.slice(newline + 1);
 			const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
-			if (record.paused || (record.filter && !record.filter.test(line))) continue;
+			const matchesFilter = !record.filter || record.filter.test(line);
+			if (!matchesFilter) continue;
+			if (record.paused) {
+				record.mutedDropped += 1;
+				continue;
+			}
 			this.#emit({ type: "line", id: record.id, description: record.description, line });
 		}
 		record.lineBuffer = remaining;

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -164,14 +164,24 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 				if (bashId === undefined || bashId.length === 0) {
 					const resumed = registry.resume();
 					if (resumed.length === 0) return textResult("No paused monitors to re-arm.");
-					ctx.onMonitorsResumed?.(resumed);
-					return textResult(`Re-armed ${resumed.length} paused monitor(s).`);
+					ctx.onMonitorsResumed?.(resumed.map((monitor) => monitor.id));
+					const total = resumed.reduce((sum, monitor) => sum + monitor.mutedDropped, 0);
+					return textResult(
+						total > 0
+							? `Re-armed ${resumed.length} paused monitor(s) (${total} line(s) dropped while muted).`
+							: `Re-armed ${resumed.length} paused monitor(s).`,
+					);
 				}
+				const dropped = registry.mutedDropped(bashId);
 				const outcome = registry.rearm(bashId);
 				if (outcome === "not_found") return errorResult(`No active monitor found with id: ${bashId}`);
 				if (outcome === "not_paused") return textResult(`Monitor ${bashId} is not paused; no action taken.`);
 				ctx.onMonitorRearmed?.(bashId);
-				return textResult(`Monitor ${bashId} re-armed.`);
+				return textResult(
+					dropped > 0
+						? `Monitor ${bashId} re-armed (${dropped} line(s) dropped while muted).`
+						: `Monitor ${bashId} re-armed.`,
+				);
 			}
 			const fileInput = isFileCreateInput(input);
 			const commandInput = isCreateInput(input);

--- a/packages/coding-agent/test/suite/terminal-monitor.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor.test.ts
@@ -142,7 +142,10 @@ describe("terminal monitor tool", () => {
 		if (!firstId || !secondId) throw new Error("Monitors did not return bash_ids");
 
 		expect(registry.pause([firstId, secondId])).toEqual([firstId, secondId]);
-		expect(registry.resume()).toEqual([firstId, secondId]);
+		expect(registry.resume()).toEqual([
+			{ id: firstId, mutedDropped: 0 },
+			{ id: secondId, mutedDropped: 0 },
+		]);
 		expect(registry.pause([firstId, secondId])).toEqual([firstId, secondId]);
 		const result = await tool.execute("monitor-rearm-all", { action: "rearm" } as MonitorInput);
 		expect(result.isError).not.toBe(true);
@@ -248,6 +251,41 @@ describe("terminal monitor tool", () => {
 		await createKillBashTool(ctx).execute("kill-paused", { bash_id: firstId });
 		expect(summaryEvent(await ended).summary).toContain("killed");
 		expect(registry.snapshot()).toEqual([expect.objectContaining({ id: secondId, paused: true })]);
+	});
+
+	it("reports filter-matching lines dropped while muted and resets the count on a second rearm", async () => {
+		const registry = new MonitorRegistry((event) => sink.push(event));
+		const tool = createMonitorTool({ ...ctx, monitorRegistry: registry });
+		const started = await tool.execute("monitor-dropped-count", {
+			description: "dropped count",
+			command: "read _; printf 'KEEP_ONE\\nDROP\\nKEEP_TWO\\n'; sleep 30",
+			filter: "^KEEP",
+			persistent: true,
+		});
+		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
+		if (!bashId) throw new Error("Monitor did not return a bash_id");
+		const output = manager.get(bashId);
+		if (!output) throw new Error("Monitor runtime was not retained");
+		expect(registry.pause([bashId])).toEqual([bashId]);
+		const outputSeen = new Promise<void>((resolve) => {
+			const unsubscribe = output.onOutput((chunk) => {
+				if (!chunk.includes("KEEP_TWO")) return;
+				unsubscribe();
+				resolve();
+			});
+		});
+		output.session.write("\n");
+		await outputSeen;
+
+		const rearmed = await tool.execute("monitor-dropped-count-rearm", { action: "rearm", bash_id: bashId });
+		expect(firstText(rearmed)).toContain("2 line(s) dropped while muted");
+		expect(registry.pause([bashId])).toEqual([bashId]);
+		const secondRearm = await tool.execute("monitor-dropped-count-rearm-again", {
+			action: "rearm",
+			bash_id: bashId,
+		});
+		expect(firstText(secondRearm)).toBe(`Monitor ${bashId} re-armed.`);
+		await createKillBashTool(ctx).execute("kill-dropped-count", { bash_id: bashId });
 	});
 
 	it("rearms a wake-budget-paused monitor and notifies the session delivery controller", async () => {


### PR DESCRIPTION
## What

Phase 4 of the monitor-pause lifecycle series. A muted monitor silently drops its filter-matching output lines; on rearm the agent had no idea how much it missed. Now the rearm result reports the count.

## Change

- `MonitorRecord.mutedDropped` counts filter-MATCHING lines dropped while the record is muted. `#consume` now separates the filter check from the pause check, so only lines that would have been emitted are counted (non-matching lines are not).
- The count resets when the record is resumed and is reported in the `monitor({ action: "rearm" })` result — `Monitor <id> re-armed (N line(s) dropped while muted).` for a single id, and `Re-armed N paused monitor(s) (M line(s) dropped while muted).` for resume-all. No dropped text is retained or replayed; `bash_output` still has the full runtime history.
- `registry.resume()` now returns `{ id, mutedDropped }[]`; the one other caller (the external-input resume handler) maps to ids. `rearm(id)`'s three-way result and the `terminal_monitor_state` `paused` wire payload are unchanged. No settings key.

## Test (RED-first)

New `terminal-monitor.test.ts` case: a real monitor emits `KEEP_ONE / DROP / KEEP_TWO` with filter `^KEEP`, is muted before the output arrives, and rearm reports `2 line(s) dropped while muted` (DROP is filtered, not counted); a second rearm reports 0 (reset). Mutation-proven: reverting the production files fails the count assertions. Full scoped monitor suite green.

Base: origin/main. Part of the monitor-pause lifecycle series (Phase 4 of 6).

Plan: .omo/plans/monitor-pause-lifecycle.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Muted terminal monitors were silently dropping filter-matching output, so the agent had no idea how much it missed on rearm. The rearm result now reports the count of complete lines dropped while muted, and the count resets when the monitor resumes.

**Changes**
- Only lines that pass the monitor filter are counted; non-matching lines are skipped.
- Both single-id and resume-all rearm paths include the dropped count when it's greater than zero.
- No dropped text is retained or replayed; `bash_output` still has full runtime history.
- `registry.resume()` now returns `{ id, mutedDropped }[]`; the external-input handler maps to ids.

<sup>Written for commit f277cc45f253369b3d14655afc3b71038f8c7c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

