### PR TITLE
fix(rpc): keep the real startup error when a host spawn is cleaned up

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- A failing RPC socket host startup now reports its own cause instead of the signal `ensureHost` sent while cleaning up. `startHost()` kills the just-spawned child when registration fails before the pidfile is written, and that kill recorded the same early-exit result a genuine self-exit produces, so the catch block dropped the real error and always reported `exited with code null (SIGTERM) before answering get_protocol_info`. On the `windows-latest` runner this made every transient startup failure unobservable and surfaced as the flaky `RPC named pipes (Windows)` job ([#1290](https://github.com/code-yeongyu/senpi/issues/1290)).
+
 - The shared RPC supervisor's observer receives content-free session and agent lifecycle records even without a session attachment, so it no longer exits the host during an active turn.
 - The Windows RPC host supervisor no longer dies when its baseline process-identity probe times out; a failed baseline read is treated as unknown instead of throwing past the startup guard and taking the internal host down with it.
 - The Windows shared RPC host is no longer shut down by its own identity watchdog when the PowerShell process probe merely times out; an absent identity is confirmed with `kill(pid, 0)` before the host is treated as exited.

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## Startup failures keep their own diagnostic (2026-09-02)
+
+### What changed
+
+- `host-ensure.ts` `startHost()` latches whether the child had already exited (`exitedBeforeCleanup`) BEFORE the cleanup kill runs, and both the rethrow guard and the `exited ... before answering get_protocol_info` diagnostic now read that latch instead of the live `exitedEarly`.
+
+### Why
+
+- The cleanup kill is indistinguishable from a real self-exit at the observation point: `child.kill("SIGTERM")` makes the `exit` listener assign `exitedEarly = { code: null, signal: "SIGTERM" }`, so by the time the catch re-checked it the `!exitedEarly` rethrow was skipped and the original startup error was discarded forever. Every genuine startup failure was therefore reported as the host dying unprompted, with the host's stderr empty because it never got far enough to write any.
+- That is the root of the `RPC named pipes (Windows)` flake tracked in #1290 variant 1: the 4-vCPU runner produces the transient startup failure, and this code path replaced the evidence with a misleading self-inflicted message. Four separate sessions read those CI logs without being able to find a cause, because the cause had been thrown away.
+- Reproduced deterministically on macOS via the new `_test.beforePidFileWrite` hook, which fails registration while the child stays healthy — the same shape a loaded runner produces. The flake was never Windows-specific; Windows only made the triggering failure frequent.
+
+### Why this cannot be expressed externally
+
+- It is the mode's own spawn/registration error path.
+
+### Expected merge conflict zones
+
+- LOW: the `startHost()` catch block in `host-ensure.ts` and the `_test` option shape.
+
+
 ## [Unreleased] - Feed the supervisor's observer lifecycle records
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/host-ensure.ts
+++ b/packages/coding-agent/src/modes/rpc/host-ensure.ts
@@ -57,6 +57,12 @@ export interface EnsureHostOptions {
 		readonly hostArgs?: readonly string[];
 		/** Runs after endpoint ownership is locked; deterministic concurrency-test gate. */
 		readonly afterLockAcquired?: () => Promise<void>;
+		/**
+		 * Runs after the child is spawned but before its pidfile is registered, so a
+		 * test can force the startup failure a loaded runner produces without having
+		 * to stall the real process-identity probe.
+		 */
+		readonly beforePidFileWrite?: () => Promise<void>;
 	};
 }
 
@@ -211,13 +217,19 @@ async function startHost(
 			}),
 		]);
 		pidFile = { pid: child.pid, processStartTime };
+		await testOptions?.beforePidFileWrite?.();
 		await writeFile(paths.pidFile, `${JSON.stringify(pidFile)}\n`, { mode: 0o600 });
 		child.unref();
 	} catch (error: unknown) {
+		// Whether the child died on its own decides which diagnostic is true, and the
+		// cleanup kill below records an `exitedEarly` indistinguishable from a real
+		// self-exit. Latch it before killing, or the catch reports the SIGTERM it is
+		// about to send and discards the actual startup failure.
+		const exitedBeforeCleanup = exitedEarly;
 		// Keep the ChildProcess handle owned until registration succeeds. If startup
 		// fails before the pidfile is written, terminate this exact child through
 		// its still-attached handle rather than leaving an unmanaged daemon behind.
-		if (!exitedEarly && child && child.exitCode === null && child.signalCode === null) {
+		if (!exitedBeforeCleanup && child && child.exitCode === null && child.signalCode === null) {
 			try {
 				child.kill("SIGTERM");
 			} catch {}
@@ -228,13 +240,13 @@ async function startHost(
 				} catch {}
 			}
 		}
-		if (!exitedEarly) {
+		if (!exitedBeforeCleanup) {
 			await cleanupState(paths);
 			throw error;
 		}
 		const diagnostic = await appendStderr(
 			paths,
-			`RPC socket host exited with code ${exitedEarly.code ?? "null"}${exitedEarly.signal ? ` (${exitedEarly.signal})` : ""} before answering get_protocol_info`,
+			`RPC socket host exited with code ${exitedBeforeCleanup.code ?? "null"}${exitedBeforeCleanup.signal ? ` (${exitedBeforeCleanup.signal})` : ""} before answering get_protocol_info`,
 		);
 		await cleanupState(paths);
 		throw new Error(diagnostic);

--- a/packages/coding-agent/test/suite/regressions/1290-rpc-host-ensure-startup-error.test.ts
+++ b/packages/coding-agent/test/suite/regressions/1290-rpc-host-ensure-startup-error.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { VERSION } from "../../../src/config.ts";
+import { ensureHost } from "../../../src/modes/rpc/host-ensure.ts";
+
+/**
+ * Regression: a startup failure must surface its own cause.
+ *
+ * `startHost()` terminates the spawned child when registration fails before the
+ * pidfile is written. That cleanup kill sets the same `exitedEarly` record the
+ * child's own exit would, so the catch block mistook its own SIGTERM for the
+ * host dying unprompted, dropped the real error, and reported "exited with code
+ * null (SIGTERM) before answering get_protocol_info". On the windows-latest
+ * runner that made every genuine startup failure unobservable and was reported
+ * as the flake in code-yeongyu/senpi#1290.
+ */
+
+const roots: string[] = [];
+
+afterEach(async () => {
+	for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+async function scratch(label: string): Promise<{ root: string; agentDir: string; socket: string }> {
+	const root = await mkdtemp(join(tmpdir(), `senpi-host-ensure-${label}-`));
+	roots.push(root);
+	return { root, agentDir: join(root, "agent"), socket: join(root, "rpc.sock") };
+}
+
+const STARTUP_FAILURE = "disk full while registering the host";
+
+describe("startHost startup-failure diagnostics", () => {
+	it("surfaces the original startup error instead of its own cleanup signal", async () => {
+		const qa = await scratch("startup-error");
+		const fixture = join(import.meta.dirname, "..", "..", "fixtures", "rpc-host-fixture.mjs");
+
+		const failure = await ensureHost({
+			agentDir: qa.agentDir,
+			socket: qa.socket,
+			_test: {
+				spawn: {
+					command: process.execPath,
+					args: [fixture, qa.socket, VERSION, "multi_session,extension_events", "answer"],
+				},
+				// The child is healthy; only registration fails. This is the shape a
+				// loaded runner produces when the identity probe or pidfile write dies.
+				beforePidFileWrite: async () => {
+					throw new Error(STARTUP_FAILURE);
+				},
+			},
+		}).catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(Error);
+		const message = (failure as Error).message;
+
+		// The real cause must reach the caller.
+		expect(message).toContain(STARTUP_FAILURE);
+		// And must NOT be replaced by the signal this code path sent itself.
+		expect(message).not.toContain("before answering get_protocol_info");
+	}, 30_000);
+});


### PR DESCRIPTION
## Root cause

`startHost()` kills the child it just spawned when registration fails before the pidfile is written, so a failed start cannot leave an unmanaged daemon behind. That cleanup kill is **indistinguishable from the child dying on its own** at the point the error is classified:

```
L222  child.kill("SIGTERM")            // our own cleanup
L224  await childExit                  // L201 listener fires...
      // ...and assigns exitedEarly = { code: null, signal: "SIGTERM" }
L231  if (!exitedEarly) throw error    // now FALSE -> the real error is dropped
L235  "exited with code null (SIGTERM) before answering get_protocol_info"
```

So every genuine startup failure was reported as the host self-exiting, and the actual cause was discarded. `appendStderr` added nothing because the host never got far enough to write stderr.

This is the root of the `RPC named pipes (Windows)` flake tracked in #1290 (variant 1). The 4-vCPU `windows-latest` runner reliably produces a transient startup failure; this path then replaced the evidence with a self-inflicted, misleading message. That is why repeated CI-log investigations across several PRs could not find a cause — the cause had been thrown away before it was ever printed.

**The flake was never Windows-specific.** Windows only made the triggering failure frequent enough to notice.

## Fix

Latch the exit state *before* the cleanup kill and gate both the rethrow and the diagnostic on that latch. A real self-exit still yields the exited-before-answering message; a cleanup kill now surfaces the failure that actually happened.

## Failing-first proof

New `test/rpc-host-ensure-startup-error.test.ts` reproduces it deterministically **on macOS** via a test-only `_test.beforePidFileWrite` hook that fails registration while the child stays healthy — the exact shape a loaded runner produces.

RED (before the fix), which reproduces the CI string verbatim:

```
AssertionError: expected 'RPC socket host exited with code null…' to contain 'disk full while registering the host'
Expected: "disk full while registering the host"
Received: "RPC socket host exited with code null (SIGTERM) before answering get_protocol_info"
```

GREEN after: `Test Files 1 passed | Tests 1 passed`.

## Verification

Run on mengmotaHost via bunshin (never the session machine), `bunx vitest`:

| Check | Result |
|---|---|
| New regression test | 1/1 passed (RED->GREEN proven) |
| `rpc-host-ensure.test.ts` | **13/13 passed**, including the flaky concurrent-starts test |
| `bunx tsc --noEmit` | exit 0 |
| `bunx biome check` | clean |

`rpc-host-lifecycle.test.ts` has 6 failures on this branch **and byte-identically on pristine `origin/main`** in the same environment (`diff` of the failing-test sets => IDENTICAL). Those are pre-existing macOS-only failures in the supervisor path, not caused by this change.

Closes #1290 for variant 1 (host-ensure concurrent-start SIGTERM).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RPC socket host startup so a real startup failure now surfaces its own error instead of being reported as the host exiting before answering `get_protocol_info`. `startHost()` kills the child it just spawned when registration fails before the pidfile is written, and that cleanup kill looked identical to a genuine self-exit, so the real error was dropped and every startup failure was reported as `exited with code null (SIGTERM) before answering get_protocol_info`.

- Latches the child's exit state before the cleanup kill and uses it to decide whether to rethrow the real error or report the early exit.
- Adds a test-only `beforePidFileWrite` hook and a regression test that reproduces the failure deterministically on macOS, fixing the root cause behind the `RPC named pipes (Windows)` flake in #1290.

<sup>Written for commit 7f9ed1e1331eed13ff27da44956b115860d7b119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

