### PR TITLE
fix(auth): keep Claude OAuth named pools and stop provider hops

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Changed
 
 ### Fixed
+- Login no longer double-appends a provider-owned OAuth account pool as a fake `login-N` slot copied from the flat compatibility sentinel.
+- Claude Agent SDK `Lock file is already being held` is classified as a transient retryable error instead of an unknown/terminal failure.
 
 ### Removed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### Changed
 
 ### Fixed
-- Login no longer double-appends a provider-owned OAuth account pool as a fake `login-N` slot copied from the flat compatibility sentinel.
+- A provider-owned OAuth account pool is merged onto the stored pool at commit time instead of overwriting it with the pre-login snapshot, so a sibling account that rotated its refresh token or earned a rate-limit block during an interactive login is never rewound; pool slots carrying the provider's managed sentinel marker are recognized and dropped so they can never dead-end a request.
+- The auth-miss wording `Provider is not configured: <id>` is now a shared exported helper used by every throw site, so consumers keying recovery decisions off it cannot drift from the generators.
 - Claude Agent SDK `Lock file is already being held` is classified as a transient retryable error instead of an unknown/terminal failure.
 
 ### Removed

--- a/packages/ai/src/auth/pool/slots.ts
+++ b/packages/ai/src/auth/pool/slots.ts
@@ -166,6 +166,29 @@ function nextLoginSlotName(credential: PooledCredential): string {
 	throw new Error("Credential pool is full");
 }
 
+function providedSlots(credential: Credential): CredentialSlot[] | undefined {
+	const accounts = (credential as PooledCredential).accounts;
+	return Array.isArray(accounts) && accounts.length > 0 ? accounts : undefined;
+}
+
+/**
+ * Unions a provider-owned pool onto the value read under the credential lock.
+ * `current` wins for every name it already holds: the provider built its
+ * object from a snapshot taken BEFORE the interactive browser round trip, so a
+ * sibling account that rotated its refresh token or earned a rate-limit block
+ * during that window must not be rewound to the snapshot. Only names that do
+ * not exist yet are appended.
+ */
+function mergeProvidedPool(
+	current: PooledCredential,
+	existing: readonly CredentialSlot[],
+	provided: readonly CredentialSlot[],
+): PooledCredential {
+	const known = new Set(existing.map((slot) => slot.name));
+	const added = provided.filter((slot) => !known.has(slot.name));
+	return added.length === 0 ? current : { ...current, accounts: [...existing, ...added] };
+}
+
 /**
  * Appends an unnamed flat credential to a pool as a generated `login-N` slot.
  * An absent current entry keeps today's whole-write shape; a flat current entry
@@ -173,18 +196,62 @@ function nextLoginSlotName(credential: PooledCredential): string {
  * instead of being overwritten by the second login.
  *
  * A login result that already carries its own populated `accounts` array is a
- * provider-owned pool: it IS the complete post-login credential, so it is
- * written through untouched. Reading its top-level fields as a flat credential
- * would append the provider's placeholder material as a second slot.
+ * provider-owned pool, and a provider that already holds a POOL names the
+ * account this login created itself. That pool is MERGED onto `current` rather
+ * than written through: a pre-browser-flow snapshot must never overwrite what
+ * concurrent writers stored meanwhile. A flat `current` keeps the whole-write
+ * shape - the provider echoes the flat fields it read, so there is nothing to
+ * preserve and the login must not be dropped on a name collision.
  */
 export function appendLoginSlot(current: PooledCredential | undefined, flat: Credential): Credential {
-	if ("accounts" in flat && Array.isArray(flat.accounts) && flat.accounts.length > 0) {
-		return flat;
-	}
 	if (!current) {
 		return flat;
 	}
+	const storedAccounts = Array.isArray(current.accounts) ? current.accounts : undefined;
+	const provided = providedSlots(flat);
+	if (provided) {
+		// A pool merges onto the stored pool; a flat current keeps the whole-write
+		// shape because the provider's accounts already carry this login.
+		return storedAccounts ? mergeProvidedPool(current, storedAccounts, provided) : flat;
+	}
 	return upsertSlot(current, slotFromFlatCredentialNamed(flat, nextLoginSlotName(current)));
+}
+
+/**
+ * Material a provider writes into the flat credential when the real token lives
+ * outside auth.json (an SDK subprocess or a vendor CLI owns it): the literal
+ * `<providerId>-managed` in both OAuth fields. It is a marker, never a token.
+ */
+export function managedSentinelMaterial(providerId: string): string {
+	return `${providerId}-managed`;
+}
+
+/**
+ * A POOL SLOT carrying that marker can never authenticate: `projectSlot` hands
+ * it to the provider's `check`, which rejects it, and the request dies with
+ * "Provider is not configured". Slots like that exist only because a shipped
+ * build appended a provider-owned pool's flat sentinel as a generated `login-N`
+ * slot.
+ */
+export function isManagedSentinelSlot(providerId: string, slot: CredentialSlot): boolean {
+	const sentinel = managedSentinelMaterial(providerId);
+	return slot.access === sentinel && slot.refresh === sentinel;
+}
+
+/**
+ * Drops those poisoned slots from a stored credential, clearing a pin that
+ * named one. Returns `undefined` when the credential holds none, so a caller
+ * can tell a repair from a no-op and only rewrite storage when the bytes
+ * actually change.
+ */
+export function repairManagedSentinelSlots(providerId: string, credential: Credential): PooledCredential | undefined {
+	const pooled = credential as PooledCredential;
+	if (!Array.isArray(pooled.accounts)) return undefined;
+	const kept = pooled.accounts.filter((slot) => !isManagedSentinelSlot(providerId, slot));
+	if (kept.length === pooled.accounts.length) return undefined;
+	const repaired: PooledCredential = { ...pooled, accounts: kept };
+	if (repaired.pinned !== undefined && !kept.some((slot) => slot.name === repaired.pinned)) delete repaired.pinned;
+	return repaired;
 }
 
 /**

--- a/packages/ai/src/auth/resolve.ts
+++ b/packages/ai/src/auth/resolve.ts
@@ -36,6 +36,18 @@ export interface AuthResolutionOverrides {
 	signal?: AbortSignal;
 }
 
+/**
+ * Prefix of the auth-miss every resolution site raises when a provider has no
+ * usable credential. Consumers key recovery decisions off this exact wording,
+ * so it is a shared constant instead of a literal repeated at each throw site:
+ * rewording one copy would silently disable the other's behavior.
+ */
+export const PROVIDER_NOT_CONFIGURED_PREFIX = "Provider is not configured: ";
+
+export function providerNotConfiguredMessage(providerId: string): string {
+	return `${PROVIDER_NOT_CONFIGURED_PREFIX}${providerId}`;
+}
+
 export class ModelsError extends Error {
 	readonly code: ModelsErrorCode;
 

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,23 @@
+## Classify Claude SDK session lock contention as retryable (2026-09-02)
+
+### What changed
+
+- `packages/ai/src/utils/retry.ts`: `RETRYABLE_PROVIDER_ERROR_PATTERN` matches `Lock file is already being held`.
+- `packages/ai/test/retry.test.ts`: pins that wording as a retryable assistant error.
+
+### Why
+
+- Claude Agent SDK session resume/stream hits proper-lockfile while a previous subprocess still holds `session.json`. The failure is local and transient; treating it as unknown/terminal made the coding-agent hard-error fallback hop providers.
+
+### Why an extension could not handle it
+
+- Retry classification lives in the shared `pi-ai` regexes used by every caller of `isRetryableAssistantError`.
+
+### Expected merge conflict zones
+
+- LOW: `RETRYABLE_PROVIDER_ERROR_PATTERN` in `retry.ts`.
+
+## Preserve provider-owned credential pools during login (2026-09-02)
 ## 2026-09-10 - Kimi Code client identity headers on the subscription path (#1504)
 
 ### What changed

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,23 @@
+## PR #1304 review fixes: shared auth-miss prefix, login merge, sentinel repair (2026-09-10)
+
+### What changed
+
+- `packages/ai/src/auth/resolve.ts`: `PROVIDER_NOT_CONFIGURED_PREFIX` / `providerNotConfiguredMessage()` export the exact auth-miss wording every resolution site throws; `packages/ai/src/models.ts` re-exports both and throws through the helper. Consumers keying recovery decisions off that message (the coding-agent session layer and the credential-pool classifier) can never drift from the throw sites.
+- `packages/ai/src/auth/pool/slots.ts`: `appendLoginSlot` MERGES a provider-owned pool onto the value read under the credential lock - stored slots and their block state win for names that already exist, only genuinely new names are appended - instead of whole-writing a snapshot the provider built before the interactive browser round trip. `managedSentinelMaterial` / `isManagedSentinelSlot` / `repairManagedSentinelSlots` recognize and drop pool slots whose `access` and `refresh` both equal the provider's `<providerId>-managed` marker (clearing a pin that pointed at one), reporting whether a repair happened so callers rewrite storage only when bytes change.
+- `packages/ai/test/credential-pool-mutations.test.ts`: a pre-login snapshot never rewinds a sibling that rotated or earned a block; a provider-owned pool onto a flat current keeps the whole-write shape; sentinel slots are recognized, dropped, un-pinned, and a clean pool is a no-op.
+
+### Why
+
+- The provider builds its returned pool from a snapshot read BEFORE the browser flow, tens of seconds before the commit under the lock: writing it verbatim rolled a sibling's rotated refresh token back to the consumed value (a forced re-login, since Anthropic rotates refresh tokens on use) and erased its rate-limit block. Separately, a shipped build stored the provider pool's flat sentinel as a generated `login-N` slot; such a slot can never authenticate and dead-ends every request whose affinity picks it, so the coding-agent store now heals those entries on load.
+
+### Why an extension could not handle it
+
+- Both the merge and the repair algebra run inside the shared credential-pool read/write path the runtime owns; providers cannot intercept what the runtime stores after login returns or what every reader parses from auth.json.
+
+### Expected merge conflict zones
+
+- LOW: `appendLoginSlot` and the sentinel helpers in `auth/pool/slots.ts`; the prefix helpers in `auth/resolve.ts` and their re-export in `models.ts`.
+
 ## Classify Claude SDK session lock contention as retryable (2026-09-02)
 
 ### What changed

--- a/packages/ai/src/models.ts
+++ b/packages/ai/src/models.ts
@@ -3,7 +3,12 @@ import { defaultProviderAuthContext as defaultAuthContext } from "./auth/context
 import { InMemoryCredentialStore } from "./auth/credential-store.ts";
 import { appendLoginSlot, removeSlot } from "./auth/pool/slots.ts";
 import { resolveRefreshCredential } from "./auth/refresh-credential.ts";
-import { type AuthResolutionOverrides, ModelsError, resolveProviderAuth } from "./auth/resolve.ts";
+import {
+	type AuthResolutionOverrides,
+	ModelsError,
+	providerNotConfiguredMessage,
+	resolveProviderAuth,
+} from "./auth/resolve.ts";
 import type {
 	AuthCheck,
 	AuthContext,
@@ -38,7 +43,12 @@ import type {
 import { operationSignal, raceWithAbortSignal } from "./utils/abort.ts";
 import type { RetryPolicyProfile } from "./utils/retry-profile/types.ts";
 
-export { ModelsError, type ModelsErrorCode } from "./auth/resolve.ts";
+export {
+	ModelsError,
+	type ModelsErrorCode,
+	PROVIDER_NOT_CONFIGURED_PREFIX,
+	providerNotConfiguredMessage,
+} from "./auth/resolve.ts";
 
 export interface ModelsPublication {
 	/** Provider-selected persisted catalog. Omit to leave storage unchanged; null deletes it. */
@@ -655,7 +665,7 @@ class ModelsImpl implements MutableModels {
 			signal: options?.signal,
 		});
 		if (!resolution) {
-			throw new ModelsError("auth", `Provider is not configured: ${model.provider}`);
+			throw new ModelsError("auth", providerNotConfiguredMessage(model.provider));
 		}
 		const auth = resolution.auth;
 

--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -133,6 +133,11 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
 
 	// gRPC based providers (e.g. NVIDIA NIM)
 	"ResourceExhausted",
+
+	// Claude Agent SDK session.json lock contention. A second stream/resume
+	// hits proper-lockfile while the previous subprocess still holds the file.
+	// Same-process retry recovers; hopping providers cannot release that lock.
+	"Lock file is already being held",
 ]);
 
 /**

--- a/packages/ai/test/credential-pool-mutations.test.ts
+++ b/packages/ai/test/credential-pool-mutations.test.ts
@@ -5,9 +5,12 @@ import {
 	appendLoginSlot,
 	type Credential,
 	type CredentialSlot,
+	isManagedSentinelSlot,
 	listSlots,
+	managedSentinelMaterial,
 	type PooledCredential,
 	removeSlot,
+	repairManagedSentinelSlots,
 	upsertSlot,
 } from "../src/auth/pool/slots.ts";
 import { resolveProviderAuth } from "../src/auth/resolve.ts";
@@ -174,6 +177,56 @@ describe("credential pool slot algebra", () => {
 		expect(listSlots(next).at(-1)?.access).toBe("real-b");
 	});
 
+	test("a provider-owned pool never rewinds a sibling the browser round trip left behind", () => {
+		// The provider builds its pool from a snapshot read BEFORE the interactive
+		// login; the value under the credential lock at commit time may have moved
+		// on since (a sibling rotated its token, or earned a rate-limit block).
+		type BlockableSlot = CredentialSlot & { blockedUntil?: number; blockReason?: string };
+		const snapshot = sentinelPool();
+		const rotated: BlockableSlot = {
+			name: "default",
+			source: "login",
+			access: "rotated-access",
+			refresh: "rotated-refresh",
+			expires: 4_102_444_800_000,
+			blockedUntil: 4_102_444_800_000,
+			blockReason: "rate_limit",
+		};
+		const authoritative: PooledCredential = {
+			...snapshot,
+			pinned: "default",
+			accounts: [rotated],
+		};
+		const providerLoginResult: PooledCredential = {
+			...snapshot,
+			accounts: [
+				...(snapshot.accounts ?? []),
+				{ name: "account-2", source: "login", access: "real-b", refresh: "refresh-b", expires: 999 },
+			],
+		};
+
+		const next = appendLoginSlot(authoritative, providerLoginResult) as PooledCredential;
+
+		expect(names(next)).toEqual(["default", "account-2"]);
+		const stored = next.accounts?.find((slot) => slot.name === "default");
+		expect(stored).toEqual(authoritative.accounts?.[0]);
+	});
+
+	test("a provider-owned pool onto a flat current keeps the whole-write shape", () => {
+		const flat: PooledCredential = { type: "oauth", access: "legacy-a", refresh: "legacy-r", expires: 999 };
+		const providerLoginResult: PooledCredential = {
+			type: "oauth",
+			access: "legacy-a",
+			refresh: "legacy-r",
+			expires: 999,
+			accounts: [{ name: "default", source: "login", access: "fresh-a", refresh: "fresh-r", expires: 999 }],
+		};
+
+		const next = appendLoginSlot(flat, providerLoginResult);
+
+		expect(next).toEqual(providerLoginResult);
+	});
+
 	test("appendLoginSlot still appends an unnamed flat oauth credential as login-2", () => {
 		const flat: Credential = { type: "oauth", access: "fresh-access", refresh: "fresh-refresh", expires: 999 };
 
@@ -245,5 +298,52 @@ describe("ordinary auth resolution after removing a promoted account", () => {
 		const resolved = await resolveProviderAuth(provider, store, authContext);
 
 		expect(resolved?.auth.apiKey).toBe("legacy-access");
+	});
+});
+
+describe("provider-managed sentinel slot repair", () => {
+	const sentinel = managedSentinelMaterial("claude-sdk-oauth");
+
+	function poisoned(): PooledCredential {
+		return {
+			type: "oauth",
+			access: sentinel,
+			refresh: sentinel,
+			expires: 4_102_444_800_000,
+			pinned: "default",
+			accounts: [
+				{ name: "default", access: "real-access", refresh: "real-refresh", expires: 999, source: "login" },
+				{ name: "login-2", access: sentinel, refresh: sentinel, expires: 4_102_444_800_000, source: "login" },
+			],
+		};
+	}
+
+	test("recognizes a slot carrying the provider's managed sentinel in both fields", () => {
+		expect(isManagedSentinelSlot("claude-sdk-oauth", { name: "login-2", access: sentinel, refresh: sentinel })).toBe(
+			true,
+		);
+		expect(
+			isManagedSentinelSlot("claude-sdk-oauth", { name: "default", access: "real-access", refresh: sentinel }),
+		).toBe(false);
+		expect(isManagedSentinelSlot("other-provider", { name: "default", access: sentinel, refresh: sentinel })).toBe(
+			false,
+		);
+	});
+
+	test("repair drops a poisoned slot and clears a pin that pointed at one", () => {
+		const poisonedPinnedAtJunk: PooledCredential = { ...poisoned(), pinned: "login-2" };
+		const repaired = repairManagedSentinelSlots("claude-sdk-oauth", poisonedPinnedAtJunk);
+		expect(repaired).toBeDefined();
+		expect(listSlots(repaired).map((slot) => slot.name)).toEqual(["default"]);
+		expect(repaired?.pinned).toBeUndefined();
+		expect(repairManagedSentinelSlots("claude-sdk-oauth", poisoned())?.pinned).toBe("default");
+	});
+
+	test("a clean pool or flat credential is a no-op so no storage is rewritten", () => {
+		const clean = removeSlot(poisoned(), "login-2") as PooledCredential;
+		expect(repairManagedSentinelSlots("claude-sdk-oauth", clean)).toBeUndefined();
+		expect(
+			repairManagedSentinelSlots("claude-sdk-oauth", { type: "oauth", access: "a", refresh: "r", expires: 1 }),
+		).toBe(undefined);
 	});
 });

--- a/packages/ai/test/retry.test.ts
+++ b/packages/ai/test/retry.test.ts
@@ -261,6 +261,17 @@ describe("provider retry classification", () => {
 		).toBe(true);
 	});
 
+	it("matches Claude Agent SDK session lock contention", () => {
+		expect(
+			isRetryableAssistantError(
+				fauxAssistantMessage("", {
+					stopReason: "error",
+					errorMessage: "Lock file is already being held",
+				}),
+			),
+		).toBe(true);
+	});
+
 	it("matches upstream request buffer exhaustion wording", () => {
 		expect(
 			isRetryableAssistantError(

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -542,6 +542,7 @@
 ### Fixed
 
 - Anthropic OAuth requests advertise `claude-cli/2.1.251` instead of the stale `2.1.75`, so Claude Fable 5.1 and Opus 5 no longer fail with `claude_code_version_too_old` (syncs upstream pi `96317e50`) ([oh-my-openagent#7650](https://github.com/code-yeongyu/oh-my-openagent/issues/7650)).
+- OAuth login no longer paints two live `>` prompts when the browser callback finishes before the paste-code field is submitted.
 
 ### New Features
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -521,6 +521,7 @@
 - Rearming a muted monitor now reports how many filter-matching output lines were dropped while it was muted; the count resets on resume.
 - `bash_output` now reports when the peeked session is a muted monitor (`details.monitorMuted`, plus `mutedDropped` and a short note) so the muted state remains in the model's textual context; non-monitor sessions are unchanged.
 
+- `Provider is not configured:` is no longer a hard-error model fallback, so an auth miss on Claude SDK OAuth does not eject the turn onto another provider.
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Fixed
 
+- A pool slot holding a provider's managed sentinel (`claude-sdk-oauth-managed`) is healed the moment auth.json is read and the repair is written back once, so a second login on an affected build no longer leaves a dead `login-N` entry that hard-errors every request whose affinity picks it; the rotation classifier also treats an unconfigured-slot auth miss as a per-credential failure, so a single bad slot can never dead-end a healthy multi-account pool.
+- A provider-owned login pool is merged onto the stored pool at commit time instead of overwriting it with the pre-browser-flow snapshot, so a sibling account's rotated refresh token and rate-limit block survive another account's interactive login.
+- The Claude SDK lane's session-lock and bare `invalid_request` remint, and its `Provider is not configured:` fallback exclusion, are scoped to that provider: provider-agnostic stream stalls keep consuming the shared same-model retry budget and still escalate to the configured fallback chain, and another provider's auth miss or `invalid_request` still hops the chain.
+- OAuth login no longer paints two live `>` prompts when the browser callback finishes before the paste-code field is submitted, and an interleaved waiting or info step replaces (never duplicates) the live `(to cancel)`/`(to close)` hint row.
+
 ### Removed
 
 ## [2026.9.10-2] - 2026-09-10
@@ -521,7 +526,6 @@
 - Rearming a muted monitor now reports how many filter-matching output lines were dropped while it was muted; the count resets on resume.
 - `bash_output` now reports when the peeked session is a muted monitor (`details.monitorMuted`, plus `mutedDropped` and a short note) so the muted state remains in the model's textual context; non-monitor sessions are unchanged.
 
-- `Provider is not configured:` is no longer a hard-error model fallback, so an auth miss on Claude SDK OAuth does not eject the turn onto another provider.
 ### New Features
 
 ### Breaking Changes
@@ -542,10 +546,6 @@
 ### Fixed
 
 - Anthropic OAuth requests advertise `claude-cli/2.1.251` instead of the stale `2.1.75`, so Claude Fable 5.1 and Opus 5 no longer fail with `claude_code_version_too_old` (syncs upstream pi `96317e50`) ([oh-my-openagent#7650](https://github.com/code-yeongyu/oh-my-openagent/issues/7650)).
-- OAuth login no longer paints two live `>` prompts when the browser callback finishes before the paste-code field is submitted.
-- Claude Agent SDK `Lock file is already being held` retries on the same model and no longer hard-error-falls back onto another provider.
-- Claude SDK stream-start timeouts and a bare `invalid_request` remint the same model instead of hopping to an unauthenticated OpenGateway Anthropic route.
-- A persisted Claude SDK binding whose prompt/toolset drifted after a timeout now forks at the last assistant UUID instead of flattening megabytes of transcript.
 
 ### New Features
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -543,6 +543,7 @@
 
 - Anthropic OAuth requests advertise `claude-cli/2.1.251` instead of the stale `2.1.75`, so Claude Fable 5.1 and Opus 5 no longer fail with `claude_code_version_too_old` (syncs upstream pi `96317e50`) ([oh-my-openagent#7650](https://github.com/code-yeongyu/oh-my-openagent/issues/7650)).
 - OAuth login no longer paints two live `>` prompts when the browser callback finishes before the paste-code field is submitted.
+- Claude Agent SDK `Lock file is already being held` retries on the same model and no longer hard-error-falls back onto another provider.
 
 ### New Features
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -544,6 +544,8 @@
 - Anthropic OAuth requests advertise `claude-cli/2.1.251` instead of the stale `2.1.75`, so Claude Fable 5.1 and Opus 5 no longer fail with `claude_code_version_too_old` (syncs upstream pi `96317e50`) ([oh-my-openagent#7650](https://github.com/code-yeongyu/oh-my-openagent/issues/7650)).
 - OAuth login no longer paints two live `>` prompts when the browser callback finishes before the paste-code field is submitted.
 - Claude Agent SDK `Lock file is already being held` retries on the same model and no longer hard-error-falls back onto another provider.
+- Claude SDK stream-start timeouts and a bare `invalid_request` remint the same model instead of hopping to an unauthenticated OpenGateway Anthropic route.
+- A persisted Claude SDK binding whose prompt/toolset drifted after a timeout now forks at the last assistant UUID instead of flattening megabytes of transcript.
 
 ### New Features
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2555,10 +2555,11 @@ export class AgentSession {
 			const hardErrorFallbackEligible = this._isHardErrorFallbackEligible(msg);
 			const cursorZeroTokenRe = isCursorZeroTokenResourceExhausted(msg);
 			const cursorQuotaRe = isCursorQuotaResourceExhausted(msg, this.model?.contextWindow ?? 0);
+			const claudeSdkSameModelRemint = this._isClaudeSdkSameModelRemintError(msg);
 			const retryCanAdmitProvider =
 				!userAbortSuppressedQueuedContinuation &&
 				this.settingsManager.getRetrySettings().enabled &&
-				(retryableError || hardErrorFallbackEligible || cursorZeroTokenRe || cursorQuotaRe);
+				(retryableError || hardErrorFallbackEligible || cursorZeroTokenRe || cursorQuotaRe || claudeSdkSameModelRemint);
 			let compactedBeforeRetry = false;
 			if (
 				retryCanAdmitProvider &&
@@ -2582,7 +2583,7 @@ export class AgentSession {
 					// failed assistant before provider fallback so replay stays valid.
 					this._retireFailedRetryAssistant(msg);
 					retryOutcome = await this._handleRetryableError(msg, { hardErrorFallback: true });
-				} else if (this._isClaudeSdkSessionLockError(msg)) {
+				} else if (claudeSdkSameModelRemint) {
 					retryOutcome = await this._handleRetryableError(msg, { sameModelRemint: true });
 				} else if (retryableError) {
 					retryOutcome = await this._handleRetryableError(msg);
@@ -7890,11 +7891,23 @@ export class AgentSession {
 		return (message.errorMessage ?? "").includes("Lock file is already being held");
 	}
 
+	private _isClaudeSdkInvalidRequestError(message: AssistantMessage): boolean {
+		return message.errorMessage === "invalid_request";
+	}
+
+	private _isClaudeSdkSameModelRemintError(message: AssistantMessage): boolean {
+		return (
+			this._isClaudeSdkSessionLockError(message) ||
+			this._isClaudeSdkInvalidRequestError(message) ||
+			isProviderStreamStallError(message)
+		);
+	}
+
 	private _isHardErrorFallbackEligible(message: AssistantMessage): boolean {
 		return (
 			!message.errorMessage?.startsWith(TURN_RETRY_SUPPRESSION_PREFIX) &&
 			!message.errorMessage?.startsWith("Provider is not configured:") &&
-			!this._isClaudeSdkSessionLockError(message) &&
+			!this._isClaudeSdkSameModelRemintError(message) &&
 			message.stopReason === "error" &&
 			!isContextOverflow(message, this.model?.contextWindow ?? 0) &&
 			!this._isCursorPayloadOverflow(message) &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -2582,6 +2582,8 @@ export class AgentSession {
 					// failed assistant before provider fallback so replay stays valid.
 					this._retireFailedRetryAssistant(msg);
 					retryOutcome = await this._handleRetryableError(msg, { hardErrorFallback: true });
+				} else if (this._isClaudeSdkSessionLockError(msg)) {
+					retryOutcome = await this._handleRetryableError(msg, { sameModelRemint: true });
 				} else if (retryableError) {
 					retryOutcome = await this._handleRetryableError(msg);
 				} else if (hardErrorFallbackEligible) {
@@ -7884,10 +7886,15 @@ export class AgentSession {
 		return true;
 	}
 
+	private _isClaudeSdkSessionLockError(message: AssistantMessage): boolean {
+		return (message.errorMessage ?? "").includes("Lock file is already being held");
+	}
+
 	private _isHardErrorFallbackEligible(message: AssistantMessage): boolean {
 		return (
 			!message.errorMessage?.startsWith(TURN_RETRY_SUPPRESSION_PREFIX) &&
 			!message.errorMessage?.startsWith("Provider is not configured:") &&
+			!this._isClaudeSdkSessionLockError(message) &&
 			message.stopReason === "error" &&
 			!isContextOverflow(message, this.model?.contextWindow ?? 0) &&
 			!this._isCursorPayloadOverflow(message) &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -36,6 +36,7 @@ import { ProviderRetryWatchdogAbortError, prepareAgentToolCall } from "@earendil
 import {
 	contentText,
 	measureCursorHistorySerializedBytes,
+	providerNotConfiguredMessage,
 	SERVER_FALLBACK_ABORTED_DIAGNOSTIC,
 	type ThinkingSelection,
 } from "@earendil-works/pi-ai";
@@ -116,6 +117,7 @@ import {
 import { areExperimentalFeaturesEnabled } from "./experimental.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
+import { CLAUDE_SDK_OAUTH_PROVIDER_ID } from "./extensions/builtin/claude-sdk-oauth/account-management.ts";
 import {
 	type ModelUsabilityAdmission,
 	ModelUsabilityBudgetError,
@@ -2559,7 +2561,11 @@ export class AgentSession {
 			const retryCanAdmitProvider =
 				!userAbortSuppressedQueuedContinuation &&
 				this.settingsManager.getRetrySettings().enabled &&
-				(retryableError || hardErrorFallbackEligible || cursorZeroTokenRe || cursorQuotaRe || claudeSdkSameModelRemint);
+				(retryableError ||
+					hardErrorFallbackEligible ||
+					cursorZeroTokenRe ||
+					cursorQuotaRe ||
+					claudeSdkSameModelRemint);
 			let compactedBeforeRetry = false;
 			if (
 				retryCanAdmitProvider &&
@@ -7895,18 +7901,39 @@ export class AgentSession {
 		return message.errorMessage === "invalid_request";
 	}
 
+	/**
+	 * Claude-SDK-only quirks that a provider hop cannot fix: the session.json
+	 * lock is held by this session's own subprocess, and a bare `invalid_request`
+	 * from the SDK boundary carries no provider-neutral meaning. Both are scoped
+	 * to the Claude SDK lane, because the SAME wording from another provider is
+	 * an ordinary failure whose classification (transient retry, or hard-error
+	 * fallback) must not change. Provider-agnostic classes - the stream-stall
+	 * watchdog above all - stay out of this predicate: they already consume the
+	 * shared same-model budget through `isRetryableAssistantError` and must still
+	 * escalate to the fallback chain when that budget runs out.
+	 */
 	private _isClaudeSdkSameModelRemintError(message: AssistantMessage): boolean {
+		if (this.model?.provider !== CLAUDE_SDK_OAUTH_PROVIDER_ID) return false;
+		return this._isClaudeSdkSessionLockError(message) || this._isClaudeSdkInvalidRequestError(message);
+	}
+
+	/**
+	 * The Claude SDK lane owns its own account pool: an auth miss there is
+	 * repaired or failed over inside the pool, so hopping to another provider
+	 * would abandon the user's Claude subscription on a recoverable miss. Every
+	 * other provider keeps the configured fallback-chain hop.
+	 */
+	private _isClaudeSdkAuthMissError(message: AssistantMessage): boolean {
 		return (
-			this._isClaudeSdkSessionLockError(message) ||
-			this._isClaudeSdkInvalidRequestError(message) ||
-			isProviderStreamStallError(message)
+			this.model?.provider === CLAUDE_SDK_OAUTH_PROVIDER_ID &&
+			message.errorMessage === providerNotConfiguredMessage(CLAUDE_SDK_OAUTH_PROVIDER_ID)
 		);
 	}
 
 	private _isHardErrorFallbackEligible(message: AssistantMessage): boolean {
 		return (
 			!message.errorMessage?.startsWith(TURN_RETRY_SUPPRESSION_PREFIX) &&
-			!message.errorMessage?.startsWith("Provider is not configured:") &&
+			!this._isClaudeSdkAuthMissError(message) &&
 			!this._isClaudeSdkSameModelRemintError(message) &&
 			message.stopReason === "error" &&
 			!isContextOverflow(message, this.model?.contextWindow ?? 0) &&

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -7887,6 +7887,7 @@ export class AgentSession {
 	private _isHardErrorFallbackEligible(message: AssistantMessage): boolean {
 		return (
 			!message.errorMessage?.startsWith(TURN_RETRY_SUPPRESSION_PREFIX) &&
+			!message.errorMessage?.startsWith("Provider is not configured:") &&
 			message.stopReason === "error" &&
 			!isContextOverflow(message, this.model?.contextWindow ?? 0) &&
 			!this._isCursorPayloadOverflow(message) &&

--- a/packages/coding-agent/src/core/auth-storage.ts
+++ b/packages/coding-agent/src/core/auth-storage.ts
@@ -23,6 +23,7 @@ import {
 	listSlots,
 	type PooledCredential,
 	removeSlot,
+	repairManagedSentinelSlots,
 	upsertSlot,
 } from "@earendil-works/pi-ai/auth/pool/slots";
 import { builtinProviders } from "@earendil-works/pi-ai/providers/all";
@@ -45,6 +46,26 @@ import {
 import { isCommandConfigValue, resolveConfigValue } from "./resolve-config-value.ts";
 
 type AuthStorageData = Record<string, Credential>;
+
+/**
+ * Heals pools poisoned by a shipped build that stored a provider-owned pool's
+ * flat sentinel as a generated `login-N` slot. Such a slot resolves to sentinel
+ * material, fails the provider's auth `check`, and hard-errors every request
+ * whose affinity picks it - deterministically, for the lifetime of the entry -
+ * so it is dropped the moment auth.json is read and the repair is written back
+ * once by the mutable store.
+ */
+function repairPoisonedPoolSlots(data: AuthStorageData): { data: AuthStorageData; repaired: boolean } {
+	let repaired: AuthStorageData | undefined;
+	for (const [providerId, credential] of Object.entries(data)) {
+		if (typeof credential !== "object" || credential === null) continue;
+		const healed = repairManagedSentinelSlots(providerId, credential);
+		if (!healed) continue;
+		repaired ??= { ...data };
+		repaired[providerId] = healed;
+	}
+	return repaired ? { data: repaired, repaired: true } : { data, repaired: false };
+}
 
 export type AuthCredential = Credential;
 export type { ApiKeyCredential, OAuthCredential };
@@ -289,7 +310,7 @@ export class ReadOnlyAuthStorage implements CredentialStore {
 			throw new Error(`Invalid auth.json credential for provider "${providerId}"`);
 		}
 
-		this.data = parsed as AuthStorageData;
+		this.data = repairPoisonedPoolSlots(parsed as AuthStorageData).data;
 		return this.data;
 	}
 
@@ -406,10 +427,15 @@ export class AuthStorage implements CredentialStore {
 	}
 
 	private parseStorageData(content: string | undefined): AuthStorageData {
+		return this.parseStorageContent(content).data;
+	}
+
+	/** Reports whether the parse had to heal poisoned pool slots, so a load can write the repair back once. */
+	private parseStorageContent(content: string | undefined): { data: AuthStorageData; repaired: boolean } {
 		if (!content) {
-			return {};
+			return { data: {}, repaired: false };
 		}
-		return JSON.parse(stripBom(content)) as AuthStorageData;
+		return repairPoisonedPoolSlots(JSON.parse(stripBom(content)) as AuthStorageData);
 	}
 
 	private recordError(error: unknown): void {
@@ -426,15 +452,20 @@ export class AuthStorage implements CredentialStore {
 	 * Reload credentials from storage.
 	 */
 	reload(): void {
-		let content: string | undefined;
+		let data: AuthStorageData = {};
 		let revision: string | undefined;
 		try {
 			this.storage.withLock((current) => {
-				content = current;
-				revision = this.authPath ? getFileRevision(this.authPath) : undefined;
-				return { result: undefined };
+				const parsed = this.parseStorageContent(current);
+				data = parsed.data;
+				// A written repair invalidates the revision read before it; leaving it
+				// unset makes the next reader re-read instead of trusting a stale stamp.
+				revision = parsed.repaired || !this.authPath ? undefined : getFileRevision(this.authPath);
+				return parsed.repaired
+					? { result: undefined, next: JSON.stringify(parsed.data, null, 2) }
+					: { result: undefined };
 			});
-			this.updateReadState(this.parseStorageData(content), revision);
+			this.updateReadState(data, revision);
 		} catch (error) {
 			// Preserve the last valid in-memory snapshot.
 			this.recordError(error instanceof Error ? error : new Error(String(error)));
@@ -532,10 +563,12 @@ export class AuthStorage implements CredentialStore {
 
 	private async reloadFromStorageAsync(options?: AuthOperationOptions): Promise<AuthStorageData> {
 		return this.storage.withLockAsync(async (content) => {
-			const currentData = this.parseStorageData(content);
-			const revision = this.authPath ? getFileRevision(this.authPath) : undefined;
-			this.updateReadState(currentData, revision);
-			return { result: currentData };
+			const parsed = this.parseStorageContent(content);
+			const revision = parsed.repaired || !this.authPath ? undefined : getFileRevision(this.authPath);
+			this.updateReadState(parsed.data, revision);
+			return parsed.repaired
+				? { result: parsed.data, next: JSON.stringify(parsed.data, null, 2) }
+				: { result: parsed.data };
 		}, options);
 	}
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-09-02 - Keep Claude SDK stalls and invalid_request on the same model
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `Provider stream start timed out after Nms` and a bare `invalid_request` remint the same model. They are not hard-error provider hops.
+- `packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts`: both recover on faux-1 and never apply a fallback chain.
+
+### Why
+
+- After a 1.7MB flatten the SDK timed out, then returned `invalid_request`. Hard-error fallback switched onto `opengateway/anthropic/claude-opus-4-8` which has no key and 401-looped until the goal continuation cap fired.
+
+### Why an extension could not handle it
+
+- Hard-error vs same-model retry is decided in `AgentSession` before extension failover runs.
+
+### Expected merge conflict zones
+
+- LOW: `_isHardErrorFallbackEligible` and the `agent_end` remint branch in `agent-session.ts`.
+
 ## 2026-09-02 - Retry Claude SDK session locks on the same model
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,28 @@
 # changes
 
+## 2026-09-10 - Review fixes for PR #1304: scoped remint/auth-miss, pool merge, sentinel repair
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `_isClaudeSdkSameModelRemintError` matches ONLY the Claude SDK lane's session-lock and bare `invalid_request` quirks (`this.model?.provider === CLAUDE_SDK_OAUTH_PROVIDER_ID`); the provider-agnostic stream-stall watchdog class is no longer swallowed, so a stall for ANY provider consumes the ordinary shared same-model budget and escalates to the fallback chain exactly as before. The auth-miss exclusion is `_isClaudeSdkAuthMissError`, an exact-message, Claude-lane-scoped check built on the shared `providerNotConfiguredMessage()` helper, so another provider's auth miss still hops the configured fallback chain. Supersedes the 2026-09-02 "Keep Claude SDK stalls and invalid_request on the same model" entry above.
+- `packages/ai/src/auth/resolve.ts` + `packages/ai/src/models.ts`: `PROVIDER_NOT_CONFIGURED_PREFIX` / `providerNotConfiguredMessage()` export the exact auth-miss wording; `packages/coding-agent/src/core/model-runtime.ts` throws through the helper instead of its own literal, so the session-layer guard can never drift from the throw sites (the `TURN_RETRY_SUPPRESSION_PREFIX` pattern).
+- `packages/coding-agent/src/core/auth-storage.ts`: every auth.json parse drops pool slots whose `access`/`refresh` equal the provider's `<providerId>-managed` sentinel and clears a pin naming one; the mutable store writes the repair back once inside its existing lock. `packages/coding-agent/src/core/credential-pool/classify.ts` classifies that auth miss as `failover`/`auth_error` so one bad slot can never dead-end a pool. `packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/accounts.ts` never lists a sentinel-material slot as an account.
+- `packages/ai/src/auth/pool/slots.ts`: `appendLoginSlot` MERGES a provider-owned pool onto the value read under the credential lock (stored slots and their block state win; only genuinely new names are appended) instead of whole-writing a snapshot read before the browser round trip; `managedSentinelMaterial` / `isManagedSentinelSlot` / `repairManagedSentinelSlots` implement the repair algebra. A flat `current` keeps the whole-write shape because the provider's accounts already carry this login.
+- `packages/coding-agent/src/modes/interactive/components/login-dialog.ts`: every `(to cancel)` / `(to close)` hint row routes through one tracked live hint, so `showWaiting` / `showInfo` replace a previous hint instead of painting beside it, and content-clearing paths reset the tracked hint.
+- Tests: `test/suite/retry-fallback-hard-error.test.ts` (Claude-lane tests run under a `claude-sdk-oauth` faux provider, plus new guards proving a non-Claude `invalid_request` and a non-Claude auth miss still hop the chain), `test/auth-storage.test.ts`, `test/credential-error-taxonomy.test.ts`, `test/model-runtime-credential-rotation.test.ts`, `test/claude-sdk-oauth-accounts.test.ts`, `packages/ai/test/credential-pool-mutations.test.ts`, `test/suite/regressions/5433-extension-oauth-prompt-input.test.ts` (the bare-`>` line was a tautology; it now asserts exactly one live `>` row and one live hint row).
+
+### Why
+
+- PR #1304 review (pullrequestreview-5167950734): the remint predicate ORed the provider-agnostic stall class in, so stalls never reached the fallback chain and the exhaustion event's attempt counter drifted by one - three suites that pass at the merge base failed at the branch head. The `Provider is not configured:` exclusion and the `invalid_request` remint were global, reclassifying every provider's failures. `appendLoginSlot`'s early return turned login into a blind overwrite with the pre-browser-flow snapshot, rolling a sibling account's rotated refresh token back to the consumed value and erasing its rate-limit block. Nothing repaired the sentinel `login-N` entries the already-shipped bug wrote, so those pools dead-ended deterministically. `forkBindingOrFlatten` was dropped during the rebase onto main in favor of main's `crossAccountResumeSupported` wiring, which already flattens account drift on the config-dir lane (`cross_root_unsupported`) exactly as `verifyRestoredTranscript` declares.
+
+### Why an extension could not handle it
+
+- Hard-error vs same-model retry eligibility, the auth.json parse/repair, the rotation classification, and the shared credential-pool write path all live below every extension hook.
+
+### Expected merge conflict zones
+
+- LOW: `_isClaudeSdkSameModelRemintError` / `_isClaudeSdkAuthMissError` / `_isHardErrorFallbackEligible` in `agent-session.ts`; `repairPoisonedPoolSlots` and `parseStorageContent` in `auth-storage.ts`; `appendLoginSlot` and the sentinel helpers in `packages/ai/src/auth/pool/slots.ts`; the prefix helpers in `auth/resolve.ts`; the prefix branch in `credential-pool/classify.ts`; `storedSlots` filtering in `accounts.ts`; `setLiveHint` in `login-dialog.ts`.
+
 ## 2026-09-02 - Keep Claude SDK stalls and invalid_request on the same model
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -40,6 +40,25 @@
 - `packages/coding-agent/src/core/agent-session.ts`: the `AgentSessionEvent` union, the `_setModel` guard block, and the `_cycleFavoriteModel` commit block.
 - `packages/coding-agent/src/core/session-manager.ts`: the `SessionEntry` union and the append helpers near `appendModelChange`.
 
+## 2026-09-02 - Do not hard-fallback a provider-not-configured auth miss
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `_isHardErrorFallbackEligible` no longer treats `Provider is not configured:` as a model hard-error that ejects onto another provider.
+- `packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts`: a configured fallback chain stays unused when the current model fails with that auth miss.
+
+### Why
+
+- Auth wiring failures were classified as hard-error and immediately switched `claude-sdk-oauth/claude-opus-5` onto a different provider (for example `opengateway/anthropic/claude-opus-5`) instead of staying on Claude SDK OAuth or its sibling accounts.
+
+### Why an extension could not handle it
+
+- Hard-error fallback eligibility is decided in `AgentSession` before extension failover runs.
+
+### Expected merge conflict zones
+
+- LOW: `_isHardErrorFallbackEligible` in `agent-session.ts`.
+
 ## Leaf token and typed errors for assistant edits (2026-09-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,24 @@
+# changes
+
+## 2026-09-02 - Retry Claude SDK session locks on the same model
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: `Lock file is already being held` is same-model remint, not hard-error provider fallback.
+- `packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts`: lock recovers on the original model and never hops after budget exhaustion.
+
+### Why
+
+- A held Claude Agent SDK session lock cannot be released by switching to OpenGateway or another provider. Immediate hard-error fallback produced 401 storms and `resume_initialization_aborted` resends.
+
+### Why an extension could not handle it
+
+- Hard-error vs same-model retry is decided in `AgentSession` before extension failover runs.
+
+### Expected merge conflict zones
+
+- LOW: `_isHardErrorFallbackEligible` and the `agent_end` retry branch in `agent-session.ts`.
+
 ## Shared manual-continue submission predicate (2026-09-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/credential-pool/classify.ts
+++ b/packages/coding-agent/src/core/credential-pool/classify.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_NOT_CONFIGURED_PREFIX } from "@earendil-works/pi-ai";
 import { DEFAULT_SLOT_BLOCK_MS, MAX_SLOT_BLOCK_MS } from "@earendil-works/pi-ai/auth/pool/failover";
 import { normalizeProviderError } from "@earendil-works/pi-ai/utils/error-body";
 import { getOverflowPatterns } from "@earendil-works/pi-ai/utils/overflow";
@@ -76,6 +77,13 @@ export function classifyCredentialFailure(
 	const failureCount = context.failureCount ?? 0;
 
 	if (isAbort(error, text)) return { kind: "fail_request" };
+	// A slot whose material no longer resolves to usable auth is a per-credential
+	// fault, not a provider-wide one: failing the request here would let ONE bad
+	// slot dead-end a pool whose siblings are healthy. The block is permanent
+	// because only a re-login or a repaired entry can change that answer.
+	if (text.includes(PROVIDER_NOT_CONFIGURED_PREFIX)) {
+		return { kind: "failover", block: { reason: "auth_error" } };
+	}
 	if (status === 401 || INVALID_KEY_TEXT.test(text)) {
 		return { kind: "failover", block: { reason: "auth_error" } };
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/accounts.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/accounts.ts
@@ -32,11 +32,21 @@ function storedSlots(credential: ClaudeSdkOauthCredential): AccountSlot[] {
 	return credential.accounts ?? [];
 }
 
+/**
+ * A stored account whose material is the managed sentinel holds no token at
+ * all: it was written by a build that stored this credential's own flat
+ * projection as a generated `login-N` slot. Selecting it fails the provider's
+ * auth check and dead-ends the request, so it is never listed as an account.
+ */
+export function isSentinelSlot(slot: Pick<AccountSlot, "access" | "refresh">): boolean {
+	return slot.access === SENTINEL_OAUTH_FIELDS.access && slot.refresh === SENTINEL_OAUTH_FIELDS.refresh;
+}
+
 export function listAccounts(
 	credential: ClaudeSdkOauthCredential,
 	env?: (name: string) => string | undefined,
 ): AccountSlot[] {
-	const slots = [...storedSlots(credential)];
+	const slots = storedSlots(credential).filter((slot) => !isSentinelSlot(slot));
 	if (env) {
 		const state = credential.slotState ?? {};
 		for (const slot of envSlots(env)) {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,24 @@
 # claude-sdk-oauth
 
+## 2026-09-10 - Never list a sentinel-material stored slot as an account
+
+### What changed
+
+- `accounts.ts`: `isSentinelSlot` recognizes a stored account whose `access` and `refresh` are both the managed sentinel, and `listAccounts` filters those out.
+- `test/claude-sdk-oauth-accounts.test.ts`: a pool holding a real account plus a generated `login-2` sentinel slot lists only the real one.
+
+### Why
+
+- A shipped build stored this credential's own flat sentinel projection as a generated `login-N` slot. Selecting it fails the provider's auth check and dead-ends the request. The coding-agent auth store heals the stored entry on load (see the core tracker); this filter covers the extension's own direct reads (`readStoredCredential`) so a poisoned entry can never be selected even before that repair runs.
+
+### Why an extension could not handle it
+
+- The account listing is this provider's own pool surface.
+
+### Expected merge conflict zones
+
+- LOW: `storedSlots` filtering in `accounts.ts`.
+
 ## Recording a refused model switch keeps the stored binding (2026-09-10)
 
 ### What changed

--- a/packages/coding-agent/src/core/model-runtime.ts
+++ b/packages/coding-agent/src/core/model-runtime.ts
@@ -33,6 +33,7 @@ import {
 	type Provider,
 	type ProviderHeaders,
 	type ProviderRequestOptions,
+	providerNotConfiguredMessage,
 	type SimpleStreamOptions,
 	type StreamOptions,
 	setWireIdentity,
@@ -708,7 +709,7 @@ export class ModelRuntime implements Models {
 			signal: options?.signal,
 			...(slotAuth?.slotName === undefined ? {} : { slotName: slotAuth.slotName }),
 		});
-		if (!resolution) throw new ModelsError("auth", `Provider is not configured: ${model.provider}`);
+		if (!resolution) throw new ModelsError("auth", providerNotConfiguredMessage(model.provider));
 
 		const { transformHeaders, ...rawProviderOptions } = options ?? {};
 		const providerOptions = rawProviderOptions as Omit<TOptions, "transformHeaders"> &

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -41,8 +41,8 @@
 
 ### What changed
 
-- `packages/coding-agent/src/modes/interactive/components/login-dialog.ts`: `showManualInput` and `showPrompt` remount the single Input widget instead of adding it twice, so a browser-callback login no longer shows two stacked `>` prompts.
-- `packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts`: covers an unsubmitted paste-code prompt followed by the account-name prompt.
+- `packages/coding-agent/src/modes/interactive/components/login-dialog.ts`: `showManualInput` and `showPrompt` remount the single Input widget instead of adding it twice, so a browser-callback login no longer shows two stacked `>` prompts. Every `(to cancel)` / `(to close)` hint row is routed through one tracked live hint (`setLiveHint`), so `showWaiting` and `showInfo(showCloseHint)` REPLACE a previous hint instead of painting beside it, and every content-clearing path resets the tracked hint.
+- `packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts`: covers an unsubmitted paste-code prompt followed by the account-name prompt - asserting exactly one live `>` row - plus an interleaved waiting step that must leave exactly one live hint row.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -35,6 +35,28 @@
 - LOW: the `isSettingsEntry` predicate, `entrySearchText`, and the entry render switch.
 
 ## 2026-09-10 - /tree edits carry the leaf token and reach shared hosts
+# changes
+
+## 2026-09-02 - Do not paint two live login inputs
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/components/login-dialog.ts`: `showManualInput` and `showPrompt` remount the single Input widget instead of adding it twice, so a browser-callback login no longer shows two stacked `>` prompts.
+- `packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts`: covers an unsubmitted paste-code prompt followed by the account-name prompt.
+
+### Why
+
+- Anthropic OAuth completes via localhost callback while the paste-code input is still mounted. The name prompt then added the same Input child again, and the TUI painted two live `>` rows.
+
+### Why an extension could not handle it
+
+- Login chrome is the interactive LoginDialogComponent, not an extension surface.
+
+### Expected merge conflict zones
+
+- LOW: `showManualInput` / `showPrompt` in `login-dialog.ts`.
+
+## 2026-09-01 - Never swallow an interactive quit request
 
 ### What changed
 

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -15,6 +15,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	private abortController = new AbortController();
 	private inputResolver?: (value: string) => void;
 	private inputRejecter?: (error: Error) => void;
+	private liveHint?: Text;
 	private onComplete: (success: boolean, message?: string) => void;
 
 	// Focusable implementation - propagate to input for IME cursor positioning
@@ -80,6 +81,16 @@ export class LoginDialogComponent extends Container implements Focusable {
 		);
 	}
 
+	/** The Input widget is a single instance; mounting it twice paints two live `>` rows. */
+	private remountInput(hint: Text): void {
+		this.contentContainer.children = this.contentContainer.children.filter(
+			(child) => child !== this.input && child !== this.liveHint,
+		);
+		this.contentContainer.addChild(this.input);
+		this.liveHint = hint;
+		this.contentContainer.addChild(hint);
+	}
+
 	private cancel(): void {
 		this.abortController.abort();
 		if (this.inputRejecter) {
@@ -137,8 +148,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.input.setValue("");
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("dim", prompt), 1, 0));
-		this.contentContainer.addChild(this.input);
-		this.contentContainer.addChild(new Text(`(${keyHint("tui.select.cancel", "to cancel")})`, 1, 0));
+		this.remountInput(new Text(`(${keyHint("tui.select.cancel", "to cancel")})`, 1, 0));
 		this.tui.requestRender();
 
 		return new Promise((resolve, reject) => {
@@ -157,8 +167,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		if (placeholder) {
 			this.contentContainer.addChild(new Text(theme.fg("dim", `e.g., ${placeholder}`), 1, 0));
 		}
-		this.contentContainer.addChild(this.input);
-		this.contentContainer.addChild(
+		this.remountInput(
 			new Text(
 				`(${keyHint("tui.select.cancel", "to cancel,")} ${keyHint("tui.select.confirm", "to submit")})`,
 				1,

--- a/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
+++ b/packages/coding-agent/src/modes/interactive/components/login-dialog.ts
@@ -91,6 +91,23 @@ export class LoginDialogComponent extends Container implements Focusable {
 		this.contentContainer.addChild(hint);
 	}
 
+	/**
+	 * Exactly one `(to ...) ` hint row is ever live: a new one replaces the
+	 * tracked previous hint wherever the input is NOT being remounted, so an
+	 * interleaved wait/info step never leaves a stale hint beside the live one.
+	 */
+	private setLiveHint(hint: Text): void {
+		this.contentContainer.children = this.contentContainer.children.filter((child) => child !== this.liveHint);
+		this.liveHint = hint;
+		this.contentContainer.addChild(hint);
+	}
+
+	/** Content that clears the dialog also drops any tracked live hint with it. */
+	private resetContent(): void {
+		this.contentContainer.clear();
+		this.liveHint = undefined;
+	}
+
 	private cancel(): void {
 		this.abortController.abort();
 		if (this.inputRejecter) {
@@ -105,7 +122,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Called by onAuth callback - show URL and optional instructions
 	 */
 	showAuth(url: string, instructions?: string): void {
-		this.contentContainer.clear();
+		this.resetContent();
 		this.contentContainer.addChild(new Spacer(1));
 		const linkedUrl = `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`;
 		this.contentContainer.addChild(new Text(theme.fg("accent", linkedUrl), 1, 0));
@@ -127,7 +144,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	 * Called by onDeviceCode callback - show URL and user code.
 	 */
 	showDeviceCode(info: OAuthDeviceCodeInfo): void {
-		this.contentContainer.clear();
+		this.resetContent();
 		this.contentContainer.addChild(new Spacer(1));
 		const linkedUrl = `\x1b]8;;${info.verificationUri}\x07${info.verificationUri}\x1b]8;;\x07`;
 		this.contentContainer.addChild(new Text(theme.fg("accent", linkedUrl), 1, 0));
@@ -186,7 +203,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 
 	/** Show informational text before another login step. */
 	showDetails(lines: string[]): void {
-		this.contentContainer.clear();
+		this.resetContent();
 		this.contentContainer.addChild(new Spacer(1));
 		for (const line of lines) {
 			this.contentContainer.addChild(new Text(line, 1, 0));
@@ -205,7 +222,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 		}
 		if (showCloseHint) {
 			this.contentContainer.addChild(new Spacer(1));
-			this.contentContainer.addChild(new Text(`(${keyHint("tui.select.cancel", "to close")})`, 1, 0));
+			this.setLiveHint(new Text(`(${keyHint("tui.select.cancel", "to close")})`, 1, 0));
 		}
 		this.tui.requestRender();
 	}
@@ -216,7 +233,7 @@ export class LoginDialogComponent extends Container implements Focusable {
 	showWaiting(message: string): void {
 		this.contentContainer.addChild(new Spacer(1));
 		this.contentContainer.addChild(new Text(theme.fg("dim", message), 1, 0));
-		this.contentContainer.addChild(new Text(`(${keyHint("tui.select.cancel", "to cancel")})`, 1, 0));
+		this.setLiveHint(new Text(`(${keyHint("tui.select.cancel", "to cancel")})`, 1, 0));
 		this.tui.requestRender();
 	}
 

--- a/packages/coding-agent/test/auth-storage.test.ts
+++ b/packages/coding-agent/test/auth-storage.test.ts
@@ -549,3 +549,72 @@ describe("AuthStorage", () => {
 		expect(readFileSync(authJsonPath, "utf8")).toBe("{invalid-json");
 	});
 });
+
+describe("poisoned managed-sentinel pool slot migration", () => {
+	const sentinel = "claude-sdk-oauth-managed";
+
+	function poisonedPool(): Record<string, unknown> {
+		return {
+			type: "oauth",
+			access: sentinel,
+			refresh: sentinel,
+			expires: 4_102_444_800_000,
+			pinned: "login-2",
+			accounts: [
+				{ name: "default", access: "real-access", refresh: "real-refresh", expires: 1, source: "login" },
+				{ name: "login-2", access: sentinel, refresh: sentinel, expires: 4_102_444_800_000, source: "login" },
+			],
+		};
+	}
+
+	const tempDir = join(tmpdir(), `pi-test-auth-storage-sentinel-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const poisonedPath = join(tempDir, "auth.json");
+
+	beforeEach(() => {
+		if (existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+		mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		if (existsSync(tempDir)) rmSync(tempDir, { recursive: true });
+	});
+
+	test("a poisoned pool is healed on read and the repair is written back once", async () => {
+		writeFileSync(poisonedPath, JSON.stringify({ "claude-sdk-oauth": poisonedPool() }, null, 2));
+		const storage = AuthStorage.create(poisonedPath);
+
+		const credential = (await storage.read("claude-sdk-oauth")) as unknown as {
+			accounts: Array<{ name: string; access: string; refresh: string }>;
+			pinned?: string;
+		};
+		expect(credential.accounts.map((slot) => slot.name)).toEqual(["default"]);
+		expect(credential.pinned).toBeUndefined();
+
+		// The on-disk bytes no longer carry the poisoned entry, so every later
+		// process - including a rotation reader - starts from a clean pool.
+		const onDisk = JSON.parse(readFileSync(poisonedPath, "utf8")) as Record<
+			string,
+			{ accounts: Array<{ name: string }>; pinned?: string }
+		>;
+		expect(onDisk["claude-sdk-oauth"].accounts.map((slot) => slot.name)).toEqual(["default"]);
+		expect(onDisk["claude-sdk-oauth"].pinned).toBeUndefined();
+	});
+
+	test("a clean pool is never rewritten", async () => {
+		const clean = {
+			type: "oauth",
+			access: sentinel,
+			refresh: sentinel,
+			expires: 4_102_444_800_000,
+			accounts: [
+				{ name: "default", access: "real-access", refresh: "real-refresh", expires: 1, source: "login" },
+				{ name: "work", access: "work-access", refresh: "work-refresh", expires: 1, source: "login" },
+			],
+		};
+		const before = JSON.stringify({ "claude-sdk-oauth": clean }, null, 2);
+		writeFileSync(poisonedPath, before);
+		const storage = AuthStorage.create(poisonedPath);
+		await storage.read("claude-sdk-oauth");
+		expect(readFileSync(poisonedPath, "utf8")).toBe(before);
+	});
+});

--- a/packages/coding-agent/test/claude-sdk-oauth-accounts.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-accounts.test.ts
@@ -6,6 +6,7 @@ import {
 	type ClaudeSdkOauthCredential,
 	emptyCredential,
 	envSlots,
+	isSentinelSlot,
 	listAccounts,
 	pinAccount,
 	refreshSlot,
@@ -138,5 +139,29 @@ describe("account slots", () => {
 		gate?.();
 		await Promise.all([first, second]);
 		expect(calls).toBe(1);
+	});
+
+	it("never lists a stored slot whose material is the managed sentinel", () => {
+		// The exact shape a shipped bug wrote: a real account plus a generated
+		// `login-N` slot holding the flat sentinel projection.
+		const poisoned: ClaudeSdkOauthCredential = {
+			...emptyCredential(),
+			accounts: [
+				{ ...slotA, name: "default" },
+				{
+					name: "login-2",
+					access: SENTINEL_OAUTH_FIELDS.access,
+					refresh: SENTINEL_OAUTH_FIELDS.refresh,
+					expires: SENTINEL_OAUTH_FIELDS.expires,
+					source: "login",
+				},
+			],
+			pinned: "login-2",
+		};
+		expect(isSentinelSlot({ access: SENTINEL_OAUTH_FIELDS.access, refresh: SENTINEL_OAUTH_FIELDS.refresh })).toBe(
+			true,
+		);
+		expect(isSentinelSlot({ access: "aA", refresh: "rA" })).toBe(false);
+		expect(listAccounts(poisoned).map((account) => account.name)).toEqual(["default"]);
 	});
 });

--- a/packages/coding-agent/test/credential-error-taxonomy.test.ts
+++ b/packages/coding-agent/test/credential-error-taxonomy.test.ts
@@ -60,6 +60,15 @@ describe("credential error taxonomy", () => {
 		expect(classifyCredentialFailure(error).kind).toBe("fail_request");
 	});
 
+	test("an unconfigured-slot auth miss fails over instead of dead-ending the pool", () => {
+		// `Provider is not configured: <provider>` is what prepareRequest throws
+		// when the slot the rotation picked carries no usable auth (the sentinel
+		// slots a shipped bug wrote). One such slot must block ITSELF and let the
+		// pool try the healthy siblings, not fail the request.
+		const action = classifyCredentialFailure(new Error("Provider is not configured: claude-sdk-oauth"));
+		expect(action).toEqual({ kind: "failover", block: { reason: "auth_error" } });
+	});
+
 	test("the server retry hint is a floor, not an override", () => {
 		// A hint shorter than the earned backoff must not shorten the cooldown.
 		expect(rateLimitCooldown(3, 1_000).cooldownMs).toBe(COOLDOWN_BASE_MS * 8);

--- a/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
+++ b/packages/coding-agent/test/model-runtime-credential-rotation.test.ts
@@ -164,6 +164,60 @@ describe("credential rotation over a pooled provider", () => {
 		rmSync(dir, { recursive: true, force: true });
 	});
 
+	test("a pool holding a poisoned sentinel slot never attempts it and serves the healthy account", async () => {
+		const sentinelDir = mkdtempSync(join(tmpdir(), "sentinel-pool-rotation-"));
+		const sentinelRepository = new CredentialSlotRepository(join(sentinelDir, "credential-pool-state.json"));
+		// The pool exactly as the shipped double-store bug left it: real accounts
+		// plus a generated `login-2` slot carrying the provider-managed sentinel
+		// in place of tokens.
+		const poisoned: PooledCredential = {
+			type: "oauth",
+			access: "key-default",
+			refresh: "r-default",
+			pinned: "login-2",
+			expires: NOW + 3_600_000,
+			accounts: [
+				{ name: "default", access: "key-default", refresh: "r-default", expires: NOW + 3_600_000, source: "login" },
+				{
+					name: "login-2",
+					access: "claude-sdk-oauth-managed",
+					refresh: "claude-sdk-oauth-managed",
+					expires: NOW + 3_600_000,
+					source: "login",
+				},
+				{ name: "work", access: "key-work", refresh: "r-work", expires: NOW + 3_600_000, source: "login" },
+			],
+		};
+		// The store parse heals the pool before rotation ever lists it.
+		const store = AuthStorage.inMemory({ "claude-sdk-oauth": poisoned });
+		const healed = (await store.read("claude-sdk-oauth")) as PooledCredential;
+		const sources = {
+			providerId: "claude-sdk-oauth",
+			credential: healed,
+			env: () => undefined,
+			repository: sentinelRepository,
+			now: () => NOW,
+		};
+		const slots = await listRotationSlots(sources);
+		expect(slots.map((slot) => slot.name)).toEqual(["default", "work"]);
+
+		const attempted: string[] = [];
+		const events = await collect(
+			streamWithCredentialRotation({
+				sources,
+				affinityKey: "sentinel-pool",
+				runAttempt: (slot) => {
+					attempted.push(slot.name);
+					return stream(startEvent(), textEvent("healthy-account-ok"));
+				},
+			}),
+		);
+		expect(attempted).toHaveLength(1);
+		expect(attempted[0]).not.toBe("login-2");
+		expect(events.some((event) => event.type === "text_delta")).toBe(true);
+		rmSync(sentinelDir, { recursive: true, force: true });
+	});
+
 	test("runtime admits one canonical env slot plus one policy slot", async () => {
 		const configDir = mkdtempSync(join(tmpdir(), "combined-runtime-"));
 		const faux = fauxProvider({ provider: "anthropic" });

--- a/packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts
@@ -96,6 +96,24 @@ describe("LoginDialogComponent OAuth prompts", () => {
 		expect(output).toContain("Enter API key:");
 	});
 
+	test("does not paint two live inputs when a later prompt starts before the first is submitted", () => {
+		const dialog = createDialog();
+
+		dialog.showAuth("https://example.invalid/login");
+		void dialog.showManualInput("Complete login in your browser, or paste the authorization code / redirect URL here:");
+		dialog.showProgress("Exchanging authorization code for tokens...");
+		void dialog.showPrompt("Name for this account (existing: default)", "account-2");
+		dialog.handleInput("jgplabs");
+
+		const lines = renderDialog(dialog);
+		const output = lines.join("\n");
+		expect(output).toContain("https://example.invalid/login");
+		expect(output).toContain("Exchanging authorization code for tokens...");
+		expect(output).toContain("Name for this account (existing: default)");
+		expect(countRenderedValue(lines, "jgplabs")).toBe(1);
+		expect(lines.filter((line) => /^>\s*$/.test(line.trim()) || line.trim() === ">").length).toBe(0);
+	});
+
 	test("keeps previous manual input stable when a later prompt is active", async () => {
 		const dialog = createDialog();
 

--- a/packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts
+++ b/packages/coding-agent/test/suite/regressions/5433-extension-oauth-prompt-input.test.ts
@@ -100,7 +100,9 @@ describe("LoginDialogComponent OAuth prompts", () => {
 		const dialog = createDialog();
 
 		dialog.showAuth("https://example.invalid/login");
-		void dialog.showManualInput("Complete login in your browser, or paste the authorization code / redirect URL here:");
+		void dialog.showManualInput(
+			"Complete login in your browser, or paste the authorization code / redirect URL here:",
+		);
 		dialog.showProgress("Exchanging authorization code for tokens...");
 		void dialog.showPrompt("Name for this account (existing: default)", "account-2");
 		dialog.handleInput("jgplabs");
@@ -110,8 +112,26 @@ describe("LoginDialogComponent OAuth prompts", () => {
 		expect(output).toContain("https://example.invalid/login");
 		expect(output).toContain("Exchanging authorization code for tokens...");
 		expect(output).toContain("Name for this account (existing: default)");
+		// Exactly ONE live input row renders the typed value. The pre-fix bug
+		// mounted the single Input widget twice, painting `> jgplabs` twice; the
+		// assertion has to catch that shape, not merely count bare `>` rows.
 		expect(countRenderedValue(lines, "jgplabs")).toBe(1);
-		expect(lines.filter((line) => /^>\s*$/.test(line.trim()) || line.trim() === ">").length).toBe(0);
+		expect(lines.filter((line) => line.trim().startsWith(">")).length).toBe(1);
+	});
+
+	test("an interleaved waiting step leaves exactly one live hint row", () => {
+		const dialog = createDialog();
+
+		void dialog.showManualInput("Paste callback URL:");
+		dialog.showWaiting("Waiting for device confirmation...");
+		void dialog.showPrompt("Choose a name:");
+
+		const lines = renderDialog(dialog);
+		const hintLines = lines.filter((line) => /^\([^)]*to (?:cancel|close|submit)/.test(line.trim()));
+		// The waiting step's `(esc to cancel)` hint must be REPLACED by the prompt's
+		// `(esc to cancel, enter to submit)` hint, never painted beside it.
+		expect(hintLines.length).toBe(1);
+		expect(hintLines[0]).toContain("to submit");
 	});
 
 	test("keeps previous manual input stable when a later prompt is active", async () => {

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -213,6 +213,45 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 	});
 
+	it("retries a Claude SDK stream-start timeout on the same model instead of hopping providers", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 2, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		const timeout = "Provider stream start timed out after 90000ms";
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: timeout }),
+			fauxAssistantMessage("recovered after stall"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-1"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+	});
+
+	it("does not hop providers on a bare Claude SDK invalid_request", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 1, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_request" }),
+			fauxAssistantMessage("recovered after invalid_request"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-1"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+	});
+
 	it("retries a Claude SDK session lock on the same model instead of hopping providers", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -213,6 +213,47 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 	});
 
+	it("retries a Claude SDK session lock on the same model instead of hopping providers", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 2, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		const lock = "Lock file is already being held";
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: lock }),
+			fauxAssistantMessage("recovered after lock"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-1"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.eventsOfType("auto_retry_end").map((event) => event.success)).toEqual([true]);
+	});
+
+	it("does not hop providers when a Claude SDK session lock exhausts same-model retries", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 1, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		const lock = "Lock file is already being held";
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: lock }),
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: lock }),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-1"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+	});
+
 	it("does not switch providers on a provider-not-configured auth miss", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -6,6 +6,8 @@ import { createHarness, type Harness } from "./harness.ts";
 
 const primary = "faux/faux-1";
 const fallback = "faux/faux-2";
+const claudePrimary = "claude-sdk-oauth/faux-1";
+const claudeFallback = "claude-sdk-oauth/faux-2";
 const insufficientQuota = "billing error: insufficient_quota";
 const toolSchemaRejection =
 	'500 server_error: Invalid request: tools.function.parameters.type is required and must be "object"';
@@ -213,7 +215,10 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 	});
 
-	it("retries a Claude SDK stream-start timeout on the same model instead of hopping providers", async () => {
+	it("retries a provider stream stall on the same model via the shared transient budget", async () => {
+		// A stall is a provider-AGNOSTIC class: it consumes the ordinary shared
+		// retry budget for every provider - the Claude SDK lane included - and
+		// must never be swallowed by a Claude-specific remint branch.
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			settings: {
@@ -233,11 +238,17 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 	});
 
-	it("does not hop providers on a bare Claude SDK invalid_request", async () => {
+	it("does not hop providers on a bare invalid_request from the Claude SDK lane", async () => {
 		const harness = await createHarness({
+			provider: "claude-sdk-oauth",
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			settings: {
-				retry: { enabled: true, maxRetries: 1, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+				retry: {
+					enabled: true,
+					maxRetries: 1,
+					baseDelayMs: 1,
+					fallbackChains: { [claudePrimary]: [claudeFallback] },
+				},
 			},
 		});
 		harnesses.push(harness);
@@ -252,11 +263,45 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 	});
 
-	it("retries a Claude SDK session lock on the same model instead of hopping providers", async () => {
+	it("a bare invalid_request from any other provider still hops the configured fallback chain", async () => {
+		// The same wording outside the Claude SDK lane is an ordinary hard error:
+		// only the Claude-SDK-specific quirks are remint-only.
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			settings: {
-				retry: { enabled: true, maxRetries: 2, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+				retry: {
+					enabled: true,
+					maxRetries: 1,
+					baseDelayMs: 1,
+					fallbackChains: { [primary]: [fallback] },
+				},
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: "invalid_request" }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, chainKey: primary, reason: "hard-error" },
+		]);
+	});
+
+	it("retries a Claude SDK session lock on the same model instead of hopping providers", async () => {
+		const harness = await createHarness({
+			provider: "claude-sdk-oauth",
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: {
+					enabled: true,
+					maxRetries: 2,
+					baseDelayMs: 1,
+					fallbackChains: { [claudePrimary]: [claudeFallback] },
+				},
 			},
 		});
 		harnesses.push(harness);
@@ -275,9 +320,15 @@ describe("retry fallback hard errors", () => {
 
 	it("does not hop providers when a Claude SDK session lock exhausts same-model retries", async () => {
 		const harness = await createHarness({
+			provider: "claude-sdk-oauth",
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
 			settings: {
-				retry: { enabled: true, maxRetries: 1, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } },
+				retry: {
+					enabled: true,
+					maxRetries: 1,
+					baseDelayMs: 1,
+					fallbackChains: { [claudePrimary]: [claudeFallback] },
+				},
 			},
 		});
 		harnesses.push(harness);
@@ -293,10 +344,17 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 	});
 
-	it("does not switch providers on a provider-not-configured auth miss", async () => {
+	it("does not switch providers on a Claude SDK lane auth miss", async () => {
 		const harness = await createHarness({
+			provider: "claude-sdk-oauth",
 			models: [{ id: "faux-1" }, { id: "faux-2" }],
-			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					fallbackChains: { [claudePrimary]: [claudeFallback] },
+				},
+			},
 		});
 		harnesses.push(harness);
 		const authMiss = "Provider is not configured: claude-sdk-oauth";
@@ -307,6 +365,26 @@ describe("retry fallback hard errors", () => {
 		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1"]);
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 		expect(harness.session.state.messages.at(-1)).toMatchObject({ errorMessage: authMiss });
+	});
+
+	it("still hops the fallback chain on another provider's auth miss", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		const authMiss = "Provider is not configured: faux";
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: authMiss }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
+			{ from: primary, to: fallback, chainKey: primary, reason: "hard-error" },
+		]);
 	});
 
 	it("does not treat an aborted response as a hard-error fallback", async () => {

--- a/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-hard-error.test.ts
@@ -213,6 +213,22 @@ describe("retry fallback hard errors", () => {
 		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
 	});
 
+	it("does not switch providers on a provider-not-configured auth miss", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: { retry: { enabled: true, baseDelayMs: 1, fallbackChains: { [primary]: [fallback] } } },
+		});
+		harnesses.push(harness);
+		const authMiss = "Provider is not configured: claude-sdk-oauth";
+		harness.setResponses([fauxAssistantMessage("", { stopReason: "error", errorMessage: authMiss })]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1"]);
+		expect(harness.eventsOfType("retry_fallback_applied")).toEqual([]);
+		expect(harness.session.state.messages.at(-1)).toMatchObject({ errorMessage: authMiss });
+	});
+
 	it("does not treat an aborted response as a hard-error fallback", async () => {
 		const harness = await createHarness({
 			models: [{ id: "faux-1" }, { id: "faux-2" }],


### PR DESCRIPTION
## Summary
- Keep a provider-owned Claude SDK OAuth account pool on login instead of appending a fake `login-N` slot copied from the managed sentinel.
- Treat a rotation-selected concrete OAuth slot as configured so a second login does not fail with `Provider is not configured: claude-sdk-oauth`.
- Do not classify that auth miss as a hard-error model fallback, so the turn stays off other providers such as `opengateway`.

## Root causes
1. `appendLoginSlot` always treated the login result as a flat credential. Claude SDK OAuth already returns the full named pool, so the second account became `login-2` with sentinel tokens.
2. With two or more slots, credential rotation projects one slot (no `accounts` array). `oauth.check` only counted `accounts.length`, so every request looked unconfigured.
3. `AgentSession` treated that `ModelsError("auth")` as a hard-error and walked the fallback chain onto another provider that happened to have a key.

## Test plan
- [x] `packages/ai` `credential-pool-resolve-slot.test.ts` — named pool preserved; unnamed flat still becomes `login-N`
- [x] `packages/coding-agent` `claude-sdk-oauth-login.test.ts` — projected non-sentinel slot passes `check`; sentinel does not
- [x] `packages/coding-agent` `retry-fallback-hard-error.test.ts` — `Provider is not configured:` does not switch models

This is a focused replay of the pool/readiness fixes from #1196 (that branch is far behind `main`) plus the hard-error hop guard. No internal tracker ids.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Claude SDK OAuth login, retry, and interactive login behavior so account selection stays stable and transient failures do not trigger unrelated provider fallbacks.

**Bug Fixes**
- Preserves provider-owned named OAuth pools on login by merging them onto the stored pool, so a sibling's rotated token or rate-limit block is never rewound.
- Drops synthetic sentinel slots: poisoned `login-N` slots are healed on auth.json read, their pins cleared, and an unconfigured-slot auth miss fails over per-slot so one bad slot can't dead-end a healthy pool.
- Scopes same-model remint and auth-miss exclusion to the Claude SDK lane: session locks and bare `invalid_request` stay on the same model, other providers' failures still hop the fallback chain, and provider-agnostic stalls use the shared retry budget.
- Remounts the single login `Input` widget and tracks one live hint row so a browser callback no longer shows two `>` prompts or duplicate hint rows.

<sup>Written for commit 8d14a5f4df9dfa04a1d1eda066e80e25e821a35f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

