### PR TITLE
feat(terminal): surface muted-monitor state in bash_output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Monitor wake-budget pauses now use single-source, scoped state: only the noisy monitor is muted, quiet monitors are not left permanently paused, and `rearm` without a `bash_id` resumes all paused monitors.
 - Real interactive and RPC user input now resumes paused terminal monitors while extension-generated input and tool calls remain unable to unpause them.
 - Rearming a muted monitor now reports how many filter-matching output lines were dropped while it was muted; the count resets on resume.
+- `bash_output` now reports when the peeked session is a muted monitor (`details.monitorMuted`, plus `mutedDropped` and a short note) so the muted state remains in the model's textual context; non-monitor sessions are unchanged.
 
 ### New Features
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/changes.md
@@ -1,5 +1,23 @@
 # terminal builtin extension — fork surface
 
+## bash_output muted-monitor metadata (2026-09-02)
+
+### What changed
+
+- `bash_output` looks up the peeked `bash_id` in `monitorRegistry.snapshot()`. When that monitor is paused, it prepends a concise muted note (including `mutedDropped` when lines were dropped) to both log and screen results and attaches `{ monitorMuted, mutedDropped }` details. Non-monitor sessions are unchanged: no note, no monitor details.
+
+### Why
+
+- The one-shot pause notice can scroll away or disappear after compaction, and the footer is not in the model's textual context. `bash_output` is a surface the model reads directly, so muted state and the dropped-line count need to stay legible there without altering runtime history.
+
+### Why an extension could not handle it
+
+- `bash_output` is the builtin peek surface over the terminal manager and monitor registry; only it can prepend the note onto the result the model reads.
+
+### Expected merge conflict zones
+
+- LOW: `tools/bash-output.ts` and `test/suite/terminal-monitor.test.ts`.
+
 ## Muted monitor dropped-line counts (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
@@ -53,14 +53,27 @@ export function createBashOutputTool(ctx: TerminalToolContext) {
 			const runtime = ctx.manager.get(input.bash_id);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 
+			const monitorEntry = ctx.monitorRegistry?.snapshot().find((entry) => entry.id === input.bash_id);
+			const muted = monitorEntry?.paused === true;
+			const mutedDropped = muted ? (ctx.monitorRegistry?.mutedDropped(input.bash_id) ?? 0) : 0;
+			let mutedNote = "";
+			if (muted) {
+				mutedNote =
+					mutedDropped > 0
+						? `monitor muted — ${mutedDropped} line(s) dropped while muted; run monitor({ action: "rearm", bash_id: "${input.bash_id}" }) to resume.`
+						: `monitor muted; run monitor({ action: "rearm", bash_id: "${input.bash_id}" }) to resume.`;
+			}
+			const extra = monitorEntry ? { details: { monitorMuted: muted, mutedDropped } } : undefined;
+			const prefix = mutedNote.length > 0 ? `${mutedNote}\n` : "";
+
 			if (input.view === "screen") {
-				return textResult(`${statusLine(runtime)}\n${screenView(runtime)}`);
+				return textResult(`${prefix}${statusLine(runtime)}\n${screenView(runtime)}`, extra);
 			}
 
 			const delta = runtime.readDelta();
 			const formatted = formatTerminalToolOutput(applyFilter(delta.text, input.filter));
 			const dropped = delta.droppedChars > 0 ? `[${delta.droppedChars} earlier chars dropped]\n` : "";
-			return textResult(`${statusLine(runtime)}\n${dropped}${formatted.text || "(no new output)"}`);
+			return textResult(`${prefix}${statusLine(runtime)}\n${dropped}${formatted.text || "(no new output)"}`, extra);
 		},
 		renderCall: renderBashOutputCall,
 		renderResult: renderBashOutputResult,

--- a/packages/coding-agent/test/suite/terminal-monitor.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor.test.ts
@@ -31,6 +31,8 @@ import {
 	MonitorRegistry,
 	type MonitorSummaryEvent,
 } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import { createPtyBashTool } from "../../src/core/extensions/builtin/terminal/tools/bash.ts";
+import { createBashOutputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
 import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
 import { createKillBashTool } from "../../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
 import {
@@ -286,6 +288,89 @@ describe("terminal monitor tool", () => {
 		});
 		expect(firstText(secondRearm)).toBe(`Monitor ${bashId} re-armed.`);
 		await createKillBashTool(ctx).execute("kill-dropped-count", { bash_id: bashId });
+	});
+
+	describe("bash_output muted monitor metadata", () => {
+		it("returns monitorMuted details and a muted note while preserving runtime history", async () => {
+			const registry = new MonitorRegistry((event) => sink.push(event));
+			const tool = createMonitorTool({ ...ctx, monitorRegistry: registry });
+			const outputTool = createBashOutputTool({ ...ctx, monitorRegistry: registry });
+			const started = await tool.execute("monitor-bash-output-muted", {
+				description: "muted peek",
+				command: "read _; printf 'KEEP_ONE\\nDROP\\nKEEP_TWO\\n'; sleep 30",
+				filter: "^KEEP",
+				persistent: true,
+			});
+			const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
+			if (!bashId) throw new Error("Monitor did not return a bash_id");
+			const output = manager.get(bashId);
+			if (!output) throw new Error("Monitor runtime was not retained");
+			expect(registry.pause([bashId])).toEqual([bashId]);
+			const outputSeen = new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(() => reject(new Error("KEEP_TWO never arrived")), 5000);
+				const unsubscribe = output.onOutput((chunk) => {
+					if (!chunk.includes("KEEP_TWO")) return;
+					clearTimeout(timer);
+					unsubscribe();
+					resolve();
+				});
+			});
+			output.session.write("\n");
+			await outputSeen;
+
+			const screen = await outputTool.execute("peek-muted-screen", { bash_id: bashId, view: "screen" });
+			expect(screen.details).toEqual({ monitorMuted: true, mutedDropped: 2 });
+			expect(firstText(screen)).toMatch(/muted/i);
+			expect(firstText(screen)).toContain("status:");
+
+			const peeked = await outputTool.execute("peek-muted-log", { bash_id: bashId });
+			expect(peeked.details).toEqual({ monitorMuted: true, mutedDropped: 2 });
+			const text = firstText(peeked);
+			expect(text).toMatch(/muted/i);
+			expect(text).toContain("status:");
+			expect(text).toContain("KEEP_ONE");
+			expect(text).toContain("KEEP_TWO");
+			await createKillBashTool(ctx).execute("kill-bash-output-muted", { bash_id: bashId });
+		});
+
+		it("clears muted metadata on bash_output after resume", async () => {
+			const registry = new MonitorRegistry((event) => sink.push(event));
+			const tool = createMonitorTool({ ...ctx, monitorRegistry: registry });
+			const outputTool = createBashOutputTool({ ...ctx, monitorRegistry: registry });
+			const started = await tool.execute("monitor-bash-output-resume", {
+				description: "resume peek",
+				command: "sleep 30",
+			});
+			const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
+			if (!bashId) throw new Error("Monitor did not return a bash_id");
+			expect(registry.pause([bashId])).toEqual([bashId]);
+			expect(registry.resume([bashId])).toEqual([{ id: bashId, mutedDropped: 0 }]);
+
+			const peeked = await outputTool.execute("peek-resumed", { bash_id: bashId });
+			expect(peeked.details).toEqual({ monitorMuted: false, mutedDropped: 0 });
+			expect(firstText(peeked)).not.toMatch(/muted/i);
+			expect(firstText(peeked)).toContain("status:");
+			await createKillBashTool(ctx).execute("kill-bash-output-resume", { bash_id: bashId });
+		});
+
+		it("leaves non-monitor bash_output results unchanged", async () => {
+			const registry = new MonitorRegistry((event) => sink.push(event));
+			const bash = createPtyBashTool({ ...ctx, monitorRegistry: registry });
+			const outputTool = createBashOutputTool({ ...ctx, monitorRegistry: registry });
+			const started = await bash.execute("plain-bg", {
+				command: "sleep 30",
+				run_in_background: true,
+			});
+			const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
+			if (!bashId) throw new Error("Background bash did not return a bash_id");
+
+			const peeked = await outputTool.execute("peek-plain", { bash_id: bashId });
+			expect(peeked.isError).not.toBe(true);
+			expect(peeked.details).toBeUndefined();
+			expect(firstText(peeked)).toContain("status:");
+			expect(firstText(peeked)).not.toMatch(/muted/i);
+			await createKillBashTool(ctx).execute("kill-plain", { bash_id: bashId });
+		});
 	});
 
 	it("rearms a wake-budget-paused monitor and notifies the session delivery controller", async () => {


### PR DESCRIPTION
## What

Phase 5 (final behavior phase) of the monitor-pause lifecycle series. A muted monitor's one-shot pause notice can scroll away or disappear after compaction, and the footer isn't in the model's textual context. `bash_output` is a surface the model reads directly, so peeking a muted monitor should say so.

## Change

- `bash-output.ts` looks up `ctx.monitorRegistry.snapshot()` for the peeked `bash_id`; when that monitor is `paused`, it prepends a concise note — `monitor muted — N line(s) dropped while muted; run monitor({ action: "rearm", bash_id }) to resume.` (using Phase 4's `mutedDropped(id)`) — to both the `log` and `screen` paths, and attaches structured `details: { monitorMuted, mutedDropped }`.
- Non-monitor bash sessions are unchanged (no note, `details` undefined). The status line, delta/history output, filter, and screen grid content are untouched. No settings key; registry/notifier/footer and the `terminal_monitor_state` wire payload are not touched.

## Test (RED-first)

New `terminal-monitor.test.ts` cases: a muted monitor peeked via `bash_output` reports `details === { monitorMuted: true, mutedDropped: 2 }` (screen and log views) plus a "muted" note, while still returning the runtime status and history (KEEP_ONE/KEEP_TWO); after resume, the metadata clears (`monitorMuted: false`). Deterministic stdin gate (no fixed sleep, bounded 5s barrier). Mutation-proven: reverting `bash-output.ts` fails the metadata assertions. Full scoped monitor suite green.

Base: origin/main. Part of the monitor-pause lifecycle series (Phase 5 of 6).

Plan: .omo/plans/monitor-pause-lifecycle.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `bash_output` report when the peeked session is a muted monitor, so the muted state stays legible in the text the model reads. Previously the one-shot pause notice could scroll away or vanish after compaction, and the footer isn't in the model's textual context.

- When the peeked `bash_id` is paused, both log and screen results get a short muted note (with the dropped-line count) and `details: { monitorMuted, mutedDropped }`.
- Non-monitor sessions are unchanged: no note and no monitor details; status line, delta/history, filter, and screen grid are untouched, with no settings key or wire payload changes.
- Tests cover muted peek, resume clearing the metadata, and unchanged non-monitor output.

<sup>Written for commit 8096275b3f7f6fd7380324aa588f514f0bbc2e6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

