### PR TITLE
fix(auth): keep provider-owned Claude OAuth pools intact on login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Adding a second account to a provider that manages its own credential pool no longer stored the provider's placeholder tokens as an extra `login-2` slot; the pooled login result is now written through untouched ([#1279](https://github.com/code-yeongyu/senpi/issues/1279)).
+
 ### Removed
 
 ## [2026.9.3] - 2026-09-03

--- a/packages/ai/src/auth/pool/slots.ts
+++ b/packages/ai/src/auth/pool/slots.ts
@@ -144,8 +144,16 @@ function nextLoginSlotName(credential: PooledCredential): string {
  * Appends an unnamed flat credential to a pool as a generated `login-N` slot. A
  * flat or absent current entry keeps today's whole-write shape so no existing
  * user's stored bytes change until a second credential actually exists.
+ *
+ * A login result that already carries its own populated `accounts` array is a
+ * provider-owned pool: it IS the complete post-login credential, so it is
+ * written through untouched. Reading its top-level fields as a flat credential
+ * would append the provider's placeholder material as a second slot.
  */
 export function appendLoginSlot(current: PooledCredential | undefined, flat: Credential): Credential {
+	if ("accounts" in flat && Array.isArray(flat.accounts) && flat.accounts.length > 0) {
+		return flat;
+	}
 	if (!current || !Array.isArray(current.accounts) || current.accounts.length === 0) {
 		return flat;
 	}

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,21 @@
+## Login keeps a provider-owned credential pool intact (2026-09-03)
+
+### What changed
+
+- `packages/ai/src/auth/pool/slots.ts`: `appendLoginSlot` returns the login result untouched when that result already carries a populated `accounts` array. Every other branch is unchanged: an absent or flat `current` still stores the flat credential as-is, and an unnamed flat credential against a pooled `current` still becomes the next generated `login-N` slot with its own material.
+
+### Why
+
+- A provider whose own `login` returns the complete pooled credential (claude-sdk-oauth builds it with `addAccount`) was double-pooled: the shared login path read that result's top-level fields as if they were a flat credential and appended them as a second slot. For claude-sdk-oauth those top-level fields are the managed sentinel, so a second account produced a `login-2` slot holding `claude-sdk-oauth-managed` instead of the newly issued tokens, and selecting that slot failed authentication (senpi#1279).
+
+### Why an extension could not handle it
+
+- `appendLoginSlot` is the shared write step inside `ModelsImpl.login` and the coding-agent auth storage `set`; it runs after the provider's `login` returns and before the credential is persisted, so no provider or extension seam exists between producing the pool and mangling it.
+
+### Expected merge conflict zones
+
+- LOW: the guard at the top of `appendLoginSlot` and its JSDoc in `auth/pool/slots.ts`. The same hunk appears in the open PRs #1304 and #1196.
+
 ## Anthropic OAuth advertises Claude Code 2.1.251 (2026-09-02)
 
 ### What changed

--- a/packages/ai/test/credential-pool-mutations.test.ts
+++ b/packages/ai/test/credential-pool-mutations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+	appendLoginSlot,
 	type Credential,
 	type CredentialSlot,
 	listSlots,
@@ -79,5 +80,54 @@ describe("credential pool slot algebra", () => {
 	test("upsertSlot rejects a slot name that could collide with path syntax", () => {
 		const slot = { name: "../escape", key: "k", source: "login" } as CredentialSlot;
 		expect(() => upsertSlot(pooledApiKey(), slot)).toThrow(/Invalid account name/);
+	});
+
+	function sentinelPool(): PooledCredential {
+		return {
+			type: "oauth",
+			access: "claude-sdk-oauth-managed",
+			refresh: "claude-sdk-oauth-managed",
+			expires: 4_102_444_800_000,
+			accounts: [{ name: "default", source: "login", access: "real-a", refresh: "refresh-a", expires: 999 }],
+		};
+	}
+
+	test("appendLoginSlot returns a provider-owned pooled login result unchanged", () => {
+		const current = sentinelPool();
+		const providerLoginResult: PooledCredential = {
+			...current,
+			accounts: [
+				...listSlots(current),
+				{ name: "account-2", source: "login", access: "real-b", refresh: "refresh-b", expires: 999 },
+			],
+		};
+
+		const next = appendLoginSlot(current, providerLoginResult);
+
+		expect(next).toEqual(providerLoginResult);
+		expect(names(next)).toEqual(["default", "account-2"]);
+		expect(listSlots(next).at(-1)?.access).toBe("real-b");
+	});
+
+	test("appendLoginSlot still appends an unnamed flat oauth credential as login-2", () => {
+		const flat: Credential = { type: "oauth", access: "fresh-access", refresh: "fresh-refresh", expires: 999 };
+
+		const next = appendLoginSlot(sentinelPool(), flat);
+
+		expect(names(next)).toEqual(["default", "login-2"]);
+		expect(listSlots(next).at(-1)).toMatchObject({ access: "fresh-access", refresh: "fresh-refresh" });
+	});
+
+	test("appendLoginSlot still appends an unnamed flat api_key credential", () => {
+		const next = appendLoginSlot(pooledApiKey(), { type: "api_key", key: "third-key" });
+
+		expect(names(next)).toEqual(["default", "work", "login-2"]);
+		expect(listSlots(next).at(-1)?.key).toBe("third-key");
+	});
+
+	test("appendLoginSlot without a current credential writes the flat credential as-is", () => {
+		const flat: Credential = { type: "api_key", key: "only-key" };
+
+		expect(appendLoginSlot(undefined, flat)).toBe(flat);
 	});
 });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Bundled Claude Code is now 2.1.259 via `@anthropic-ai/claude-agent-sdk` 0.3.259, so `claude-sdk-oauth` sessions on `claude-fable-5-1` no longer fail with the API 400 that required version 2.1.251 or newer ([#1298](https://github.com/code-yeongyu/senpi/issues/1298)).
 - Claude SDK OAuth maps malformed or raw-string content entries to text (or an omission placeholder) instead of image blocks with undefined `media_type`/`data`, which made Claude Code abort the next query ([oh-my-openagent#7660](https://github.com/code-yeongyu/oh-my-openagent/issues/7660)).
+- A second `claude-sdk-oauth` login now stores the newly issued OAuth tokens instead of a broken slot holding the managed placeholder, and no longer fails with `Provider is not configured: claude-sdk-oauth` when account rotation has selected a single account ([#1279](https://github.com/code-yeongyu/senpi/issues/1279)).
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -21,8 +21,23 @@
 - LOW in `prompt-bridge.ts` around `appendContentBlocks`.
 - LOW in `session-sync.ts` around `appendContent`.
 - NEW file `content-blocks.ts`.
+## 2026-09-03 - Accept a rotation-projected OAuth slot as configured
 
+### What changed
 
+- `oauth-login.ts`: the `configuredFor` predicate behind `check` and `resolveAmbient` counts a stored credential whose top-level OAuth fields are concrete (neither `access` nor `refresh` is the managed sentinel) as one account, in addition to the `accounts` array and environment tokens. A projected sentinel still counts as zero, so the ambient opt-in path is unchanged.
+
+### Why
+
+- Shared credential rotation projects one named slot onto the flat credential shape and strips `accounts` before handing the credential to the provider. The predicate only counted `accounts`, so a projected concrete slot counted as zero accounts and the provider reported "Provider is not configured: claude-sdk-oauth" — which a user hit as a failing second login.
+
+### Why an extension could not handle it
+
+- This IS the extension side: the availability predicate lives in this builtin provider's auth config and runs before any request-scoped hook.
+
+### Expected merge conflict zones
+
+- LOW: `oauth-login.ts` around the `accountCount` computation in `configuredFor`. The same hunk appears in the open PRs #1304 and #1196.
 ## 2026-09-02 - Honor tool-less summarization requests
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts
@@ -109,9 +109,15 @@ export function createOAuthConfig(deps: {
 		environment?: Record<string, string>,
 	): Promise<boolean> => {
 		const storedAccounts = stored?.type === "oauth" && Array.isArray(stored.accounts) ? stored.accounts : [];
+		// Slot-scoped resolution projects one account onto the flat credential shape,
+		// stripping `accounts`; its concrete (non-sentinel) tokens are that account.
+		const selectedStoredAccount =
+			stored?.type === "oauth" &&
+			stored.access !== SENTINEL_OAUTH_FIELDS.access &&
+			stored.refresh !== SENTINEL_OAUTH_FIELDS.refresh;
 		const effectiveEnvironment = environment ?? (await claudeEnvironment(ctx));
 		const environmentTokenCount = Object.values(effectiveEnvironment).filter(Boolean).length;
-		const accountCount = storedAccounts.length + environmentTokenCount;
+		const accountCount = storedAccounts.length + (selectedStoredAccount ? 1 : 0) + environmentTokenCount;
 		const settings = deps.readSettings?.();
 		const lane = settings?.tokenInjection ?? (accountCount > 0 ? "oauth-slots" : "ambient");
 		if (lane === "ambient") {

--- a/packages/coding-agent/test/claude-sdk-oauth-login.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-login.test.ts
@@ -2,6 +2,7 @@ import type { OAuthAuth } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { listAccounts, SENTINEL_OAUTH_FIELDS } from "../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
 import { createOAuthConfig } from "../src/core/extensions/builtin/claude-sdk-oauth/oauth-login.ts";
+import { authContext } from "./support/claude-sdk-oauth-provider.ts";
 
 function fakeFlow(credential: { access: string; refresh: string; expires: number }): OAuthAuth {
 	return {
@@ -100,5 +101,24 @@ describe("claude-sdk-oauth oauth login config", () => {
 		const config = createOAuthConfig({ readCurrent: async () => undefined, loginFlow: fakeFlow(fresh) });
 		const credential = await config.login({});
 		expect(await config.refreshToken(credential)).toBe(credential);
+	});
+
+	it("check accepts a concrete oauth slot projected by credential rotation", async () => {
+		const config = createOAuthConfig({ readCurrent: async () => undefined, loginFlow: fakeFlow(fresh) });
+
+		const check = await config.check({
+			ctx: authContext(),
+			credential: { type: "oauth", access: "slot-access", refresh: "slot-refresh", expires: Date.now() + 60_000 },
+		});
+
+		expect(check).toEqual({ source: "Claude SDK OAuth", type: "oauth" });
+	});
+
+	it("check still rejects a projected sentinel that names no account", async () => {
+		const config = createOAuthConfig({ readCurrent: async () => undefined, loginFlow: fakeFlow(fresh) });
+
+		const check = await config.check({ ctx: authContext(), credential: { type: "oauth", ...SENTINEL_OAUTH_FIELDS } });
+
+		expect(check).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

Adding a second `claude-sdk-oauth` account produced a broken `login-2` slot holding the managed placeholder `claude-sdk-oauth-managed` instead of the newly issued OAuth tokens. The provider's own `login` already returns the complete pooled credential, but the shared `appendLoginSlot` write step read that result's top-level fields as if they were a flat credential and appended them a second time. This PR makes `appendLoginSlot` write a provider-owned pool through untouched, and teaches the claude-sdk-oauth availability predicate to accept a concrete OAuth account projected by shared credential rotation.

Observably: a second login now stores exactly one new slot carrying its real tokens, that slot participates in affinity and failover, and the second login no longer fails with `Provider is not configured: claude-sdk-oauth`. First logins, `api_key` logins, and the ambient (host Claude CLI) lane behave exactly as before.

## Changes

**Shared credential pool (`packages/ai`)**
- `appendLoginSlot` returns the login result unchanged when that result already carries a populated `accounts` array — a provider that manages its own pool produces the complete post-login credential, so re-appending its top-level fields is double pooling. Every other branch is byte-identical: an absent or flat `current` still stores the flat credential as-is, and an unnamed flat credential against a pooled `current` still becomes the next `login-N` slot with its own material.

**claude-sdk-oauth availability (`packages/coding-agent`)**
- `configuredFor`, the single predicate behind both `check` and `resolveAmbient`, now counts a stored credential whose top-level OAuth fields are concrete (neither `access` nor `refresh` is the sentinel) as one account. Slot-scoped resolution projects one named slot onto the flat credential shape and strips `accounts`, so such a credential previously counted as zero accounts. A projected sentinel still counts as zero, leaving the ambient opt-in requirement untouched.

**Tests and docs**
- The exact #1279 in-memory repro plus boundary cases in `packages/ai/test/credential-pool-mutations.test.ts`; projected-slot and projected-sentinel `check` cases in `packages/coding-agent/test/claude-sdk-oauth-login.test.ts`.
- Tracker entries in `packages/ai/src/changes.md` and `.../claude-sdk-oauth/changes.md`, plus `[Unreleased] > Fixed` bullets in both package changelogs.

## QA & Evidence

All test, typecheck, and build runs executed on a remote bunshin machine (`mengmotaMac`, bun 1.4.0, node v26.7.0). Evidence lives under `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903`.

| Check | What was tested | Observed result | Artifact |
| --- | --- | --- | --- |
| RED | New tests against untouched `9892d3eb2` sources | 2 genuine assertion failures (`login-2` holds `claude-sdk-oauth-managed`; `check` returns `undefined`) — no import errors | `g4-red.log` |
| GREEN | Same commands with the fix applied | `packages/ai` 18/18, `packages/coding-agent` 8/8 | `g4-green.log` |
| Mutation | Each guard reverted independently, then restored | Removing the `appendLoginSlot` early return kills only the #1279 test; removing `selectedStoredAccount` kills only the projected-slot test; restoring both is green again | `g4-mutation.log` |
| Edge | Verbose run naming every boundary case | Unnamed flat OAuth still becomes `login-2` with its own tokens; flat `api_key` still appends; `appendLoginSlot(undefined, flat)` returns identity; projected sentinel still rejected — 14/14 + 8/8 | `g4-edge.log` |
| Regression | On this branch with `--build`: `tsc --noEmit -p tsconfig.build.json` in both packages plus the credential-pool, auth, and claude-sdk-oauth suites (login, accounts, auth-lane, availability, all ambient, extension, account-command) | Build ok, both typechecks clean, 73 + 73 tests passed, `cmd-exit=0` | `g4-regression.log` |
| Changelog gate | `node scripts/check-pr-changelog.mjs --base 9892d3eb2` | `changelog-gate: PASS` | `g4-lane-report.md` |

The mutation pass is what makes this sufficient: each of the two production hunks has exactly one test that dies without it, so neither guard is passing by accident, and the edge run proves the untouched branches of `appendLoginSlot` still behave as before.

Note: neither package ships a plain `tsconfig.json`; both typechecks use `tsconfig.build.json`.

## Risks & Residuals

- Any provider whose `login` returns a populated `accounts` array now owns its entire pool write. `appendLoginSlot`'s only callers are `ModelsImpl.login` and `AuthStorage.set`, and claude-sdk-oauth is the only in-tree provider that returns a pooled login result, so no other provider's behavior changes.
- A genuinely flat-but-concrete stored OAuth credential (a legacy single-account entry) now counts as one configured account in the claude-sdk-oauth predicate. That is the intended reading, and it matches the referenced PRs.
- Not addressed here: #1308 (LAB-109 legacy-flat promotion for `openai-codex`) is a separate concern and stays open.

## Related Issues

- Fixes #1279.
- Credit to @eddieparc: this PR adopts the `packages/ai/src/auth/pool/slots.ts` and `claude-sdk-oauth/oauth-login.ts` hunks from his PRs #1304 and #1196 (#1304's `in`-narrowing form was preferred over #1196's `as PooledCredential` cast to satisfy the no-`as` discipline). The other hunks in #1304 — `agent-session.ts`, `retry.ts`, `session-continuity.ts`, `login-dialog.ts` — are deliberately **not** part of this PR.
- #1308 is a separate concern and is left open.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adding a second `claude-sdk-oauth` account no longer produces a broken `login-2` slot holding the managed placeholder, and that slot no longer fails with `Provider is not configured` once rotation selects it. The shared pool writer now passes a provider-owned pooled login result through untouched, and the claude-sdk-oauth availability predicate counts a rotation-projected concrete slot as one configured account.

- `appendLoginSlot` returns unchanged any login result that already carries a populated `accounts` array; first logins, flat `api_key` logins, and unnamed-slot writes keep their existing behavior.
- The availability predicate counts a flat OAuth credential with concrete (non-sentinel) tokens as one account; a sentinel still counts as zero, so the ambient opt-in path is unchanged.
- Fixes #1279.

<sup>Written for commit 90341383038c996f4b0d8ed0ed0caf5e3b0528f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

