### PR TITLE
fix(deps): bump @anthropic-ai/claude-agent-sdk to 0.3.259 for the claude-fable-5-1 version floor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,10 +19,10 @@
     },
     "packages/agent": {
       "name": "@earendil-works/pi-agent-core",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "dependencies": {
-        "@earendil-works/pi-ai": "^2026.9.2-4",
-        "@earendil-works/pi-telemetry": "^2026.9.2-4",
+        "@earendil-works/pi-ai": "^2026.9.3",
+        "@earendil-works/pi-telemetry": "^2026.9.3",
         "diff": "9.0.0",
         "ignore": "7.0.6",
         "typebox": "1.3.18",
@@ -37,7 +37,7 @@
     },
     "packages/ai": {
       "name": "@earendil-works/pi-ai",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "bin": {
         "pi-ai": "dist/cli.js",
       },
@@ -45,7 +45,7 @@
         "@anthropic-ai/sdk": "0.120.0",
         "@aws-sdk/client-bedrock-runtime": "3.1116.0",
         "@bufbuild/protobuf": "2.14.0",
-        "@earendil-works/pi-telemetry": "^2026.9.2-4",
+        "@earendil-works/pi-telemetry": "^2026.9.3",
         "@google/genai": "2.18.0",
         "@smithy/node-http-handler": "4.11.3",
         "@smithy/types": "4.17.2",
@@ -64,9 +64,9 @@
     },
     "packages/client": {
       "name": "@earendil-works/pi-client",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "dependencies": {
-        "@earendil-works/pi-protocol": "2026.9.2-4",
+        "@earendil-works/pi-protocol": "2026.9.3",
       },
       "devDependencies": {
         "shx": "0.4.0",
@@ -75,23 +75,23 @@
     },
     "packages/coding-agent": {
       "name": "@code-yeongyu/senpi",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "bin": {
         "pi": "dist/bundle/cli.js",
         "senpi": "dist/cli.js",
       },
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk": "0.3.259",
         "@anthropic-ai/sdk": "0.120.0",
         "@aws-sdk/client-bedrock-runtime": "3.1116.0",
         "@bufbuild/protobuf": "2.14.0",
-        "@code-yeongyu/senpi-codemode": "^2026.9.2-4",
-        "@earendil-works/pi-agent-core": "^2026.9.2-4",
-        "@earendil-works/pi-ai": "^2026.9.2-4",
-        "@earendil-works/pi-client": "^2026.9.2-4",
-        "@earendil-works/pi-protocol": "^2026.9.2-4",
-        "@earendil-works/pi-pty": "^2026.9.2-4",
-        "@earendil-works/pi-tui": "^2026.9.2-4",
+        "@code-yeongyu/senpi-codemode": "^2026.9.3",
+        "@earendil-works/pi-agent-core": "^2026.9.3",
+        "@earendil-works/pi-ai": "^2026.9.3",
+        "@earendil-works/pi-client": "^2026.9.3",
+        "@earendil-works/pi-protocol": "^2026.9.3",
+        "@earendil-works/pi-pty": "^2026.9.3",
+        "@earendil-works/pi-tui": "^2026.9.3",
         "@modelcontextprotocol/sdk": "1.30.0",
         "@mozilla/readability": "0.6.0",
         "@opentelemetry/api": "1.9.1",
@@ -195,7 +195,7 @@
     },
     "packages/protocol": {
       "name": "@earendil-works/pi-protocol",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "dependencies": {
         "typebox": "1.3.18",
       },
@@ -206,7 +206,7 @@
     },
     "packages/pty": {
       "name": "@earendil-works/pi-pty",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "dependencies": {
         "@xterm/headless": "6.0.0",
       },
@@ -216,14 +216,14 @@
     },
     "packages/senpi-codemode": {
       "name": "@code-yeongyu/senpi-codemode",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "dependencies": {
         "@babel/parser": "8.0.4",
-        "@earendil-works/pi-ai": "^2026.9.2-4",
+        "@earendil-works/pi-ai": "^2026.9.3",
         "typebox": "1.3.18",
       },
       "devDependencies": {
-        "@code-yeongyu/senpi": "2026.9.2-4",
+        "@code-yeongyu/senpi": "2026.9.3",
       },
       "peerDependencies": {
         "@code-yeongyu/senpi": "*",
@@ -231,7 +231,7 @@
     },
     "packages/server": {
       "name": "@code-yeongyu/senpi-server",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "dependencies": {
         "@earendil-works/pi-ai": "^2026.9.2-4",
         "@earendil-works/pi-protocol": "^2026.9.2-4",
@@ -255,7 +255,7 @@
     },
     "packages/telemetry": {
       "name": "@earendil-works/pi-telemetry",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "devDependencies": {
         "@types/node": "26.2.0",
         "vitest": "4.1.11",
@@ -263,7 +263,7 @@
     },
     "packages/tui": {
       "name": "@earendil-works/pi-tui",
-      "version": "2026.9.2-4",
+      "version": "2026.9.3",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
         "marked": "18.0.10",
@@ -296,23 +296,23 @@
     "ws": "8.21.3",
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.241", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.241", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.241", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.241", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.241", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.241", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.241", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.241", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.241" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-pIHdCSTywFe30H0oWDCKZzC4ipBLtF5YMDRKjf6PHyARg57O4l/72v3b6QKnnefwtKKMe6uWJ1Y9lUJg/sKWyA=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.259", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.259", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.259", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.259", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.259", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.259", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.259", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.259", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.259" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-5VJSzHQTAPFl2BytZSgyL0Xtdi3I7CeajEhO4KTvm6bx4nt1OIp+IHx78MuurA4Pp/t9UEPa3cWz8Q55Pi9MYw=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.241", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v26ta54lKFMFEZzbOE+6p3YhKERWnDiEA6OmkSAg+3fAQHOa1+aLTKw222cfgzxgiVixwFtHMk8c63zsDd8aXQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.259", "", { "os": "darwin", "cpu": "arm64" }, "sha512-irMesPeaTll57VE+ZWw1+J9eSMtllbb1Mr9cKVW9igS0mu4nPtDFaNuycSSb0e/XJZlmUwEM+Q74XbilcfUBdA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.241", "", { "os": "darwin", "cpu": "x64" }, "sha512-5jweT0vft1ZCaGSoxZHF9vJlHbx8Yxx4+x5aHAIXTd4lx7ZbT4o5buEF8kpmTeHUB+Fw9jtFIm4QDsRiBXgf+Q=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.259", "", { "os": "darwin", "cpu": "x64" }, "sha512-L8IESfv0vwoVFp+4icW3oSj1f0AT0jonnS5vVIF4RBr+52JogiPCTstG1AI9xSD5R82084Ov6G7ekjS/eZRREA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.241", "", { "os": "linux", "cpu": "arm64" }, "sha512-SxszQGffXiLzMEnAv+pJXEmQbA8haijKyRjjH/jOt1CLeMIfpjKcO9WQDv8dEA8nREWS3zJ103zjgecAF7oOQQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.259", "", { "os": "linux", "cpu": "arm64" }, "sha512-3AblD+jFXRkYssGQ/bfjIZ3kUmoqzgiVUO6G9UkVq8wClo6YNJTnYMUrkPvwX0ahR65Y3QsM2iPcLmao13vVCw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.241", "", { "os": "linux", "cpu": "arm64" }, "sha512-GslvPvSzehfCZyzOaJAt4lgodznm5zpl/LMXN8ygD12z5qnpM+I9/eFnmAaISJ0L8/vyohtlAP1jjaeR2jz1AQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.259", "", { "os": "linux", "cpu": "arm64" }, "sha512-6Mbet5P5LWwX1YexyzDkNP4vn1pmw8dlnNF/NU1+rXxEYmXiDVt2uf+p1hA/FbHCVottx8dc1CcVNgFy+QbQTA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.241", "", { "os": "linux", "cpu": "x64" }, "sha512-gJRa922Qcm7loumHcXMDFEFg//tz1aOi7Nx0sQa9I9lC1JSN8yL6i7/idzOU5Hp193tEDFOgqIMFL/yRiXg+rw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.259", "", { "os": "linux", "cpu": "x64" }, "sha512-kpPgmCwNN+OA+q1suGvzKbUk9sfrYKz/gJmLne4ag91oqRHBP0wAEWex0c/0bmTb+wDa98WmpwpZYCmqKppCdg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.241", "", { "os": "linux", "cpu": "x64" }, "sha512-kZigJ5Ug2I2G/n7Cunmwy4TGr0lOGnWrz6TkzyWiDcUmJOodoTH6GZECNarWAtETfN03AAeLfrpiz8z3hOEDqA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.259", "", { "os": "linux", "cpu": "x64" }, "sha512-5lBXB6eXN90VKc+HT+PEKQp+/omhK88OK9caWohUp4ozCiyy2LoUz4s+l0S2HaNa2yiY7z+lhwcgpAkuOp8Olw=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.241", "", { "os": "win32", "cpu": "arm64" }, "sha512-/3yA9jQuCvHDVlILzhtslH6kFYOvydXyMZiKwnzqM8ZfvFTNO41w8TpiFpBLseyM+4A4E8QMeTKu3L01Xyb5IQ=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.259", "", { "os": "win32", "cpu": "arm64" }, "sha512-ryidK7vUU9CV4RStETCBwfQctMgFZ0nb/uP08GL85mpbnzPFnw+tD06rA7aIkQTXHuOv4BFvFxHRgYouBoZ0bg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.241", "", { "os": "win32", "cpu": "x64" }, "sha512-cHYdAgORl9kynujMeYXyV1uj/hbmsBjRw9dRVkIW4/4sF7S6L4u/qDSzn1/wiNP7g2yWSJ4KbsvHDH2WWDnCBQ=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.259", "", { "os": "win32", "cpu": "x64" }, "sha512-0zJUo/avBoyxzI/81/T7Yv3xBor4rjUJAQvUa8bJ2zmc0RL/fczGlJAKEfOql69kG8ap+Igo9nbNZ6TLyURjrw=="],
 
     "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.73", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-F608iUirrCqwvInZYGRRgJWDQj0tt6fNVE9aPagpotLJ5LhC4JbrMFIIZww5MFjb+HRCkpE0+xdI79c30tdVYg=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,122 +32,6 @@
 				"node": ">=24.0.0"
 			}
 		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.241.tgz",
-			"integrity": "sha512-v26ta54lKFMFEZzbOE+6p3YhKERWnDiEA6OmkSAg+3fAQHOa1+aLTKw222cfgzxgiVixwFtHMk8c63zsDd8aXQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.241.tgz",
-			"integrity": "sha512-5jweT0vft1ZCaGSoxZHF9vJlHbx8Yxx4+x5aHAIXTd4lx7ZbT4o5buEF8kpmTeHUB+Fw9jtFIm4QDsRiBXgf+Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.241.tgz",
-			"integrity": "sha512-SxszQGffXiLzMEnAv+pJXEmQbA8haijKyRjjH/jOt1CLeMIfpjKcO9WQDv8dEA8nREWS3zJ103zjgecAF7oOQQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.241.tgz",
-			"integrity": "sha512-GslvPvSzehfCZyzOaJAt4lgodznm5zpl/LMXN8ygD12z5qnpM+I9/eFnmAaISJ0L8/vyohtlAP1jjaeR2jz1AQ==",
-			"cpu": [
-				"arm64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.241.tgz",
-			"integrity": "sha512-gJRa922Qcm7loumHcXMDFEFg//tz1aOi7Nx0sQa9I9lC1JSN8yL6i7/idzOU5Hp193tEDFOgqIMFL/yRiXg+rw==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"glibc"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.241.tgz",
-			"integrity": "sha512-kZigJ5Ug2I2G/n7Cunmwy4TGr0lOGnWrz6TkzyWiDcUmJOodoTH6GZECNarWAtETfN03AAeLfrpiz8z3hOEDqA==",
-			"cpu": [
-				"x64"
-			],
-			"libc": [
-				"musl"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.241.tgz",
-			"integrity": "sha512-/3yA9jQuCvHDVlILzhtslH6kFYOvydXyMZiKwnzqM8ZfvFTNO41w8TpiFpBLseyM+4A4E8QMeTKu3L01Xyb5IQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.241.tgz",
-			"integrity": "sha512-cHYdAgORl9kynujMeYXyV1uj/hbmsBjRw9dRVkIW4/4sF7S6L4u/qDSzn1/wiNP7g2yWSJ4KbsvHDH2WWDnCBQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "SEE LICENSE IN LICENSE.md",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
 		"node_modules/@anthropic-ai/sandbox-runtime": {
 			"version": "0.0.73",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.73.tgz",
@@ -7453,7 +7337,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/claude-agent-sdk": "0.3.241",
+				"@anthropic-ai/claude-agent-sdk": "0.3.259",
 				"@anthropic-ai/sdk": "0.120.0",
 				"@aws-sdk/client-bedrock-runtime": "3.1116.0",
 				"@bufbuild/protobuf": "2.14.0",
@@ -7560,22 +7444,22 @@
 			}
 		},
 		"packages/coding-agent/node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.241.tgz",
-			"integrity": "sha512-pIHdCSTywFe30H0oWDCKZzC4ipBLtF5YMDRKjf6PHyARg57O4l/72v3b6QKnnefwtKKMe6uWJ1Y9lUJg/sKWyA==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.259.tgz",
+			"integrity": "sha512-5VJSzHQTAPFl2BytZSgyL0Xtdi3I7CeajEhO4KTvm6bx4nt1OIp+IHx78MuurA4Pp/t9UEPa3cWz8Q55Pi9MYw==",
 			"license": "SEE LICENSE IN README.md",
 			"engines": {
 				"node": ">=18.0.0"
 			},
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.241"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.259"
 			},
 			"peerDependencies": {
 				"@anthropic-ai/sdk": ">=0.93.0",
@@ -7838,6 +7722,122 @@
 			"engines": {
 				"node": ">=24.0.0"
 			}
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.259.tgz",
+			"integrity": "sha512-irMesPeaTll57VE+ZWw1+J9eSMtllbb1Mr9cKVW9igS0mu4nPtDFaNuycSSb0e/XJZlmUwEM+Q74XbilcfUBdA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.259.tgz",
+			"integrity": "sha512-L8IESfv0vwoVFp+4icW3oSj1f0AT0jonnS5vVIF4RBr+52JogiPCTstG1AI9xSD5R82084Ov6G7ekjS/eZRREA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.259.tgz",
+			"integrity": "sha512-3AblD+jFXRkYssGQ/bfjIZ3kUmoqzgiVUO6G9UkVq8wClo6YNJTnYMUrkPvwX0ahR65Y3QsM2iPcLmao13vVCw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"libc": [
+				"glibc"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.259.tgz",
+			"integrity": "sha512-6Mbet5P5LWwX1YexyzDkNP4vn1pmw8dlnNF/NU1+rXxEYmXiDVt2uf+p1hA/FbHCVottx8dc1CcVNgFy+QbQTA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"libc": [
+				"musl"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.259.tgz",
+			"integrity": "sha512-kpPgmCwNN+OA+q1suGvzKbUk9sfrYKz/gJmLne4ag91oqRHBP0wAEWex0c/0bmTb+wDa98WmpwpZYCmqKppCdg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"libc": [
+				"glibc"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.259.tgz",
+			"integrity": "sha512-5lBXB6eXN90VKc+HT+PEKQp+/omhK88OK9caWohUp4ozCiyy2LoUz4s+l0S2HaNa2yiY7z+lhwcgpAkuOp8Olw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"libc": [
+				"musl"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.259.tgz",
+			"integrity": "sha512-ryidK7vUU9CV4RStETCBwfQctMgFZ0nb/uP08GL85mpbnzPFnw+tD06rA7aIkQTXHuOv4BFvFxHRgYouBoZ0bg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.259.tgz",
+			"integrity": "sha512-0zJUo/avBoyxzI/81/T7Yv3xBor4rjUJAQvUa8bJ2zmc0RL/fczGlJAKEfOql69kG8ap+Igo9nbNZ6TLyURjrw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		}
 	}
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Bundled Claude Code is now 2.1.259 via `@anthropic-ai/claude-agent-sdk` 0.3.259, so `claude-sdk-oauth` sessions on `claude-fable-5-1` no longer fail with the API 400 that required version 2.1.251 or newer ([#1298](https://github.com/code-yeongyu/senpi/issues/1298)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -5,6 +5,7 @@
 ### What changed
 
 - `packages/coding-agent/package.json`: `@anthropic-ai/claude-agent-sdk` 0.3.241 -> 0.3.259. Regenerated the coding-agent publish dependency closure, install lock, Claude Agent SDK platform lock, and root lockfiles from the refreshed pin.
+- `bun.lock`: besides the SDK entries, `bun install` also catches the workspace package versions up from `2026.9.2-4` to `2026.9.3`. The release commit `240fff144` bumped every workspace `package.json` and the npm locks but never regenerated `bun.lock`, so the tracked Bun lockfile was already stale on main; this PR records the state `bun install` produces from the current manifests and adds no dependency beyond the SDK's own optional platform packages.
 
 ### Why
 

--- a/packages/coding-agent/changes.md
+++ b/packages/coding-agent/changes.md
@@ -1,5 +1,23 @@
 # Local fork changes
 
+## 2026-09-03 - Bump @anthropic-ai/claude-agent-sdk to 0.3.259
+
+### What changed
+
+- `packages/coding-agent/package.json`: `@anthropic-ai/claude-agent-sdk` 0.3.241 -> 0.3.259. Regenerated the coding-agent publish dependency closure, install lock, Claude Agent SDK platform lock, and root lockfiles from the refreshed pin.
+
+### Why
+
+- SDK 0.3.241 bundles Claude Code 2.1.241, which the API rejects for `claude-fable-5-1` (`version 2.1.251 or newer is required`). 0.3.259 bundles Claude Code 2.1.259 and satisfies that floor.
+
+### Why an extension could not handle it
+
+- The bundled Claude Code binary is selected by the package pin and install graph before any extension loads. `CLAUDE_CODE_EXECUTABLE` is only a session-local workaround.
+
+### Expected merge conflict zones
+
+- HIGH: `packages/coding-agent/package.json` and the generated publish/install/platform locks.
+
 ## 2026-09-02 - RPC host lifecycle teardown treats a timed-out probe as unknown, not alive
 
 - `test/rpc-host-lifecycle.test.ts` decides Windows process liveness with the production `processIsLive(pid)` (`kill(pid, 0)`) instead of trusting the PowerShell CIM probe's `timedOut` flag. A loaded `windows-latest` runner could time the 10s CIM probe out for a supervisor that had genuinely idle-exited; `terminateSupervisor()` then rethrew the `Stop-Process` failure (`starts a fresh host transparently on the next ensure after an idle exit`), and `waitForHostExit()` spun to its deadline and threw `did not exit within Nms`. A timed-out probe means the state is unknown, so it is re-decided by `kill(pid, 0)` (`ESRCH` -> gone, `EPERM` -> alive); a process that is really still alive still rethrows / still keeps waiting.

--- a/packages/coding-agent/install-lock/package-lock.json
+++ b/packages/coding-agent/install-lock/package-lock.json
@@ -15,9 +15,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.241.tgz",
-			"integrity": "sha512-v26ta54lKFMFEZzbOE+6p3YhKERWnDiEA6OmkSAg+3fAQHOa1+aLTKw222cfgzxgiVixwFtHMk8c63zsDd8aXQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.259.tgz",
+			"integrity": "sha512-irMesPeaTll57VE+ZWw1+J9eSMtllbb1Mr9cKVW9igS0mu4nPtDFaNuycSSb0e/XJZlmUwEM+Q74XbilcfUBdA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"darwin"
@@ -28,9 +28,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.241.tgz",
-			"integrity": "sha512-5jweT0vft1ZCaGSoxZHF9vJlHbx8Yxx4+x5aHAIXTd4lx7ZbT4o5buEF8kpmTeHUB+Fw9jtFIm4QDsRiBXgf+Q==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.259.tgz",
+			"integrity": "sha512-L8IESfv0vwoVFp+4icW3oSj1f0AT0jonnS5vVIF4RBr+52JogiPCTstG1AI9xSD5R82084Ov6G7ekjS/eZRREA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"darwin"
@@ -41,9 +41,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.241.tgz",
-			"integrity": "sha512-SxszQGffXiLzMEnAv+pJXEmQbA8haijKyRjjH/jOt1CLeMIfpjKcO9WQDv8dEA8nREWS3zJ103zjgecAF7oOQQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.259.tgz",
+			"integrity": "sha512-3AblD+jFXRkYssGQ/bfjIZ3kUmoqzgiVUO6G9UkVq8wClo6YNJTnYMUrkPvwX0ahR65Y3QsM2iPcLmao13vVCw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -57,9 +57,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.241.tgz",
-			"integrity": "sha512-GslvPvSzehfCZyzOaJAt4lgodznm5zpl/LMXN8ygD12z5qnpM+I9/eFnmAaISJ0L8/vyohtlAP1jjaeR2jz1AQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.259.tgz",
+			"integrity": "sha512-6Mbet5P5LWwX1YexyzDkNP4vn1pmw8dlnNF/NU1+rXxEYmXiDVt2uf+p1hA/FbHCVottx8dc1CcVNgFy+QbQTA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -73,9 +73,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.241.tgz",
-			"integrity": "sha512-gJRa922Qcm7loumHcXMDFEFg//tz1aOi7Nx0sQa9I9lC1JSN8yL6i7/idzOU5Hp193tEDFOgqIMFL/yRiXg+rw==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.259.tgz",
+			"integrity": "sha512-kpPgmCwNN+OA+q1suGvzKbUk9sfrYKz/gJmLne4ag91oqRHBP0wAEWex0c/0bmTb+wDa98WmpwpZYCmqKppCdg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -89,9 +89,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.241.tgz",
-			"integrity": "sha512-kZigJ5Ug2I2G/n7Cunmwy4TGr0lOGnWrz6TkzyWiDcUmJOodoTH6GZECNarWAtETfN03AAeLfrpiz8z3hOEDqA==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.259.tgz",
+			"integrity": "sha512-5lBXB6eXN90VKc+HT+PEKQp+/omhK88OK9caWohUp4ozCiyy2LoUz4s+l0S2HaNa2yiY7z+lhwcgpAkuOp8Olw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -105,9 +105,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.241.tgz",
-			"integrity": "sha512-/3yA9jQuCvHDVlILzhtslH6kFYOvydXyMZiKwnzqM8ZfvFTNO41w8TpiFpBLseyM+4A4E8QMeTKu3L01Xyb5IQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.259.tgz",
+			"integrity": "sha512-ryidK7vUU9CV4RStETCBwfQctMgFZ0nb/uP08GL85mpbnzPFnw+tD06rA7aIkQTXHuOv4BFvFxHRgYouBoZ0bg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"win32"
@@ -118,9 +118,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.241.tgz",
-			"integrity": "sha512-cHYdAgORl9kynujMeYXyV1uj/hbmsBjRw9dRVkIW4/4sF7S6L4u/qDSzn1/wiNP7g2yWSJ4KbsvHDH2WWDnCBQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.259.tgz",
+			"integrity": "sha512-0zJUo/avBoyxzI/81/T7Yv3xBor4rjUJAQvUa8bJ2zmc0RL/fczGlJAKEfOql69kG8ap+Igo9nbNZ6TLyURjrw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"win32"
@@ -558,7 +558,7 @@
 				"typebox": "1.3.18",
 				"undici": "8.10.0",
 				"yaml": "2.9.0",
-				"@anthropic-ai/claude-agent-sdk": "0.3.241",
+				"@anthropic-ai/claude-agent-sdk": "0.3.259",
 				"@anthropic-ai/sdk": "0.120.0",
 				"@aws-sdk/client-bedrock-runtime": "3.1116.0",
 				"@bufbuild/protobuf": "2.14.0",
@@ -658,19 +658,19 @@
 			}
 		},
 		"node_modules/@code-yeongyu/senpi/node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.241.tgz",
-			"integrity": "sha512-pIHdCSTywFe30H0oWDCKZzC4ipBLtF5YMDRKjf6PHyARg57O4l/72v3b6QKnnefwtKKMe6uWJ1Y9lUJg/sKWyA==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.259.tgz",
+			"integrity": "sha512-5VJSzHQTAPFl2BytZSgyL0Xtdi3I7CeajEhO4KTvm6bx4nt1OIp+IHx78MuurA4Pp/t9UEPa3cWz8Q55Pi9MYw==",
 			"license": "SEE LICENSE IN README.md",
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.241"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.259"
 			},
 			"peerDependencies": {
 				"@anthropic-ai/sdk": ">=0.93.0",

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -67,7 +67,7 @@
 		"typebox": "1.3.18",
 		"undici": "8.10.0",
 		"yaml": "2.9.0",
-		"@anthropic-ai/claude-agent-sdk": "0.3.241",
+		"@anthropic-ai/claude-agent-sdk": "0.3.259",
 		"@anthropic-ai/sdk": "0.120.0",
 		"@aws-sdk/client-bedrock-runtime": "3.1116.0",
 		"@bufbuild/protobuf": "2.14.0",

--- a/packages/coding-agent/publish-deps.lock.json
+++ b/packages/coding-agent/publish-deps.lock.json
@@ -29,7 +29,7 @@
 				"typebox": "1.3.18",
 				"undici": "8.10.0",
 				"yaml": "2.9.0",
-				"@anthropic-ai/claude-agent-sdk": "0.3.241",
+				"@anthropic-ai/claude-agent-sdk": "0.3.259",
 				"@anthropic-ai/sdk": "0.120.0",
 				"@aws-sdk/client-bedrock-runtime": "3.1116.0",
 				"@bufbuild/protobuf": "2.14.0",
@@ -67,9 +67,9 @@
 			}
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.241.tgz",
-			"integrity": "sha512-v26ta54lKFMFEZzbOE+6p3YhKERWnDiEA6OmkSAg+3fAQHOa1+aLTKw222cfgzxgiVixwFtHMk8c63zsDd8aXQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.259.tgz",
+			"integrity": "sha512-irMesPeaTll57VE+ZWw1+J9eSMtllbb1Mr9cKVW9igS0mu4nPtDFaNuycSSb0e/XJZlmUwEM+Q74XbilcfUBdA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"darwin"
@@ -80,9 +80,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.241.tgz",
-			"integrity": "sha512-5jweT0vft1ZCaGSoxZHF9vJlHbx8Yxx4+x5aHAIXTd4lx7ZbT4o5buEF8kpmTeHUB+Fw9jtFIm4QDsRiBXgf+Q==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.259.tgz",
+			"integrity": "sha512-L8IESfv0vwoVFp+4icW3oSj1f0AT0jonnS5vVIF4RBr+52JogiPCTstG1AI9xSD5R82084Ov6G7ekjS/eZRREA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"darwin"
@@ -93,9 +93,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.241.tgz",
-			"integrity": "sha512-SxszQGffXiLzMEnAv+pJXEmQbA8haijKyRjjH/jOt1CLeMIfpjKcO9WQDv8dEA8nREWS3zJ103zjgecAF7oOQQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.259.tgz",
+			"integrity": "sha512-3AblD+jFXRkYssGQ/bfjIZ3kUmoqzgiVUO6G9UkVq8wClo6YNJTnYMUrkPvwX0ahR65Y3QsM2iPcLmao13vVCw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -109,9 +109,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.241.tgz",
-			"integrity": "sha512-GslvPvSzehfCZyzOaJAt4lgodznm5zpl/LMXN8ygD12z5qnpM+I9/eFnmAaISJ0L8/vyohtlAP1jjaeR2jz1AQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.259.tgz",
+			"integrity": "sha512-6Mbet5P5LWwX1YexyzDkNP4vn1pmw8dlnNF/NU1+rXxEYmXiDVt2uf+p1hA/FbHCVottx8dc1CcVNgFy+QbQTA==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -125,9 +125,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.241.tgz",
-			"integrity": "sha512-gJRa922Qcm7loumHcXMDFEFg//tz1aOi7Nx0sQa9I9lC1JSN8yL6i7/idzOU5Hp193tEDFOgqIMFL/yRiXg+rw==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.259.tgz",
+			"integrity": "sha512-kpPgmCwNN+OA+q1suGvzKbUk9sfrYKz/gJmLne4ag91oqRHBP0wAEWex0c/0bmTb+wDa98WmpwpZYCmqKppCdg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -141,9 +141,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.241.tgz",
-			"integrity": "sha512-kZigJ5Ug2I2G/n7Cunmwy4TGr0lOGnWrz6TkzyWiDcUmJOodoTH6GZECNarWAtETfN03AAeLfrpiz8z3hOEDqA==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.259.tgz",
+			"integrity": "sha512-5lBXB6eXN90VKc+HT+PEKQp+/omhK88OK9caWohUp4ozCiyy2LoUz4s+l0S2HaNa2yiY7z+lhwcgpAkuOp8Olw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"linux"
@@ -157,9 +157,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.241.tgz",
-			"integrity": "sha512-/3yA9jQuCvHDVlILzhtslH6kFYOvydXyMZiKwnzqM8ZfvFTNO41w8TpiFpBLseyM+4A4E8QMeTKu3L01Xyb5IQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.259.tgz",
+			"integrity": "sha512-ryidK7vUU9CV4RStETCBwfQctMgFZ0nb/uP08GL85mpbnzPFnw+tD06rA7aIkQTXHuOv4BFvFxHRgYouBoZ0bg==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"win32"
@@ -170,9 +170,9 @@
 			"optional": true
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.241.tgz",
-			"integrity": "sha512-cHYdAgORl9kynujMeYXyV1uj/hbmsBjRw9dRVkIW4/4sF7S6L4u/qDSzn1/wiNP7g2yWSJ4KbsvHDH2WWDnCBQ==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.259.tgz",
+			"integrity": "sha512-0zJUo/avBoyxzI/81/T7Yv3xBor4rjUJAQvUa8bJ2zmc0RL/fczGlJAKEfOql69kG8ap+Igo9nbNZ6TLyURjrw==",
 			"license": "SEE LICENSE IN LICENSE.md",
 			"os": [
 				"win32"
@@ -3487,19 +3487,19 @@
 			}
 		},
 		"packages/coding-agent/node_modules/@anthropic-ai/claude-agent-sdk": {
-			"version": "0.3.241",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.241.tgz",
-			"integrity": "sha512-pIHdCSTywFe30H0oWDCKZzC4ipBLtF5YMDRKjf6PHyARg57O4l/72v3b6QKnnefwtKKMe6uWJ1Y9lUJg/sKWyA==",
+			"version": "0.3.259",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.259.tgz",
+			"integrity": "sha512-5VJSzHQTAPFl2BytZSgyL0Xtdi3I7CeajEhO4KTvm6bx4nt1OIp+IHx78MuurA4Pp/t9UEPa3cWz8Q55Pi9MYw==",
 			"license": "SEE LICENSE IN README.md",
 			"optionalDependencies": {
-				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.241",
-				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.241"
+				"@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.259",
+				"@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.259"
 			},
 			"peerDependencies": {
 				"@anthropic-ai/sdk": ">=0.93.0",

--- a/packages/coding-agent/test/claude-sdk-oauth-project-instructions.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-project-instructions.test.ts
@@ -78,6 +78,7 @@ function optionsFor(
 function appendOf(queryOptions: ReturnType<typeof buildClaudeSdkOauthQueryOptions>): string {
 	const prompt = queryOptions.systemPrompt;
 	if (typeof prompt !== "object" || prompt === null || Array.isArray(prompt)) return "";
+	if (prompt.type !== "preset") return "";
 	return prompt.append ?? "";
 }
 


### PR DESCRIPTION
## Summary

Pins `@anthropic-ai/claude-agent-sdk` from `0.3.241` to `0.3.259` so the bundled Claude Code binary is `2.1.259`. The previous pin bundled `2.1.241`, which the API rejects for `claude-fable-5-1` with `400 Claude Code 2.1.241 does not support this model; version 2.1.251 or newer is required`. After this bump, a `claude-sdk-oauth` turn on that model completes instead of failing at the version floor.

This supersedes #1306 (`0.3.258`, now conflicting). Credit to @ndaemy for the lock-regeneration recipe (`bun run refresh-lock` + `scripts/generate-claude-agent-sdk-platform-lock.mjs`) and for the `appendOf` narrowing on the SDK `systemPrompt` union.

## Changes

- **Dependency pin.** `packages/coding-agent/package.json` now exact-pins `@anthropic-ai/claude-agent-sdk` `0.3.259`. The eight platform optionalDependencies (`darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-arm64-musl`, `linux-x64`, `linux-x64-musl`, `win32-arm64`, `win32-x64`) follow at the same version.
- **Lockfiles.** Regenerated root `package-lock.json`, `bun.lock`, `packages/coding-agent/publish-deps.lock.json`, and `packages/coding-agent/install-lock/package-lock.json`. `.npmrc` is unchanged: the main SDK was already on the `min-release-age` exclude list, and npm resolved `0.3.259` without lowering `min-release-age`.
- **Types in tests.** `appendOf` now returns early unless `prompt.type === "preset"` before reading `append`, matching the 0.3.259 `systemPrompt` union (`string | string[] | {type:'custom',...} | {type:'preset',...}`).
- **Docs.** `[Unreleased]` changelog bullet and a four-section `packages/coding-agent/changes.md` tracker for the production pin.

## QA & Evidence

- **Lock + typecheck + focused tests (bunshin `mengmotaMac`, commit `b9fa863fe`).** `check:pinned-deps`, `check:shrinkwrap`, `check:install-lock:coding-agent`, `check:claude-sdk-platform-lock` all exit 0; `tsc --noEmit` clean; vitest 3 files / 36 tests passed. Artifact: `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g1-lock-checks.log`. Sufficient because these are the same lock gates CI runs plus the SDK-oauth tests that consume `systemPrompt`.
- **Changelog gate (local).** `bun scripts/check-pr-changelog.mjs --base 9892d3eb2` -> `PASS - changes.md coverage complete (1 production path(s) covered); no runtime source changes detected`.
- **Real-surface binary probe (orchestrator, not re-run).** RED bundled `2.1.241` -> `api_error_status` 400, `"does not support this model; version 2.1.251 or newer is required"` (`g1-binary-probe-red.json`). GREEN `2.1.259` -> `"PONG"`, `modelUsage` includes `claude-fable-5-1` (`g1-binary-probe-green.json`). Both under `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/`.
- **Lane report.** `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g1-lane-report.md`.

## Risks & Residuals

- SDK `0.3.259` was published 2026-09-02 and is still inside the 2-day `min-release-age` window for packages that are not excluded. The main SDK is already excluded; platform packages were injected via the existing generator (`fetch` to the registry), not npm resolution, so `.npmrc` was left alone. A later `npm install` without the generator can drop the eight platform entries from `package-lock.json` — that is the pre-existing platform-lock workflow, not new.
- `bun.lock` also refreshed workspace package versions `2026.9.2-4` -> `2026.9.3` so the text lock matches the already-released manifests. No runtime source under `packages/coding-agent/src` was touched (owned by another lane).
- Does not close #1306; this PR is meant to replace it. No auto-merge.

## Related Issues

Fixes #1298.

Related: [oh-my-openagent#7626](https://github.com/code-yeongyu/oh-my-openagent/issues/7626) (same root cause: bundled Claude Code below the `claude-fable-5-1` version floor).

Supersedes #1306.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `@anthropic-ai/claude-agent-sdk` to `0.3.259`, bumping the bundled Claude Code binary from `2.1.241` to `2.1.259` so `claude-sdk-oauth` sessions on `claude-fable-5-1` no longer fail with the API 400 that required version 2.1.251 or newer.

**Dependencies**
- Updates the SDK and all eight platform optional dependencies to `0.3.259` in `package-lock.json`, `bun.lock`, `publish-deps.lock.json`, and the install lock.
- Regenerates `bun.lock` so workspace package versions advance to `2026.9.3` to match released manifests.
- Narrows `appendOf` in the oauth test to the preset prompt variant for the new `systemPrompt` union.

Supersedes #1306 (`0.3.258`).

<sup>Written for commit b2e0e5d5868e5e7daffcec940bf6a9dacf5854bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Lockfile note (review follow-up)

`bun.lock` also moves the workspace package versions `2026.9.2-4` -> `2026.9.3`. That is not new dependency drift introduced here: release commit `240fff144` bumped every workspace `package.json` and the npm locks but left `bun.lock` unregenerated, so main's Bun lockfile was already stale against its own manifests. `bun install` from the current manifests produces exactly this catch-up plus the SDK entries; the programmatic `package-lock.json` comparison against `9892d3eb2` shows only the nine Claude Agent SDK entries changing.