### PR TITLE
fix(claude-sdk-oauth): map malformed content entries to text instead of broken image blocks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Bundled Claude Code is now 2.1.259 via `@anthropic-ai/claude-agent-sdk` 0.3.259, so `claude-sdk-oauth` sessions on `claude-fable-5-1` no longer fail with the API 400 that required version 2.1.251 or newer ([#1298](https://github.com/code-yeongyu/senpi/issues/1298)).
-
+- Claude SDK OAuth maps malformed or raw-string content entries to text (or an omission placeholder) instead of image blocks with undefined `media_type`/`data`, which made Claude Code abort the next query ([oh-my-openagent#7660](https://github.com/code-yeongyu/oh-my-openagent/issues/7660)).
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,28 @@
 # claude-sdk-oauth
 
+## 2026-09-03 - Map malformed content entries to text instead of broken image blocks
+
+### What changed
+
+- `content-blocks.ts`: new shared `appendSdkContentBlocks` mapper. Raw string entries become text blocks, well-formed images keep `media_type`/`data`, and anything else becomes an omission placeholder.
+- `prompt-bridge.ts`: flatten `appendContentBlocks` delegates to the shared mapper and keeps hasText / "(see attached image)" semantics.
+- `session-sync.ts`: resident delta `appendContent` delegates to the same mapper and ignores the boolean.
+
+### Why
+
+- Persisted tool results can include raw strings (OmO formatter notes mixed into `toolResult` content). Both bridges treated every non-`text` entry as a base64 image, so a string became `{type:"image", source:{media_type: undefined, data: undefined}}` and Claude Code aborted the next query with a Buffer/string type error ([oh-my-openagent#7660](https://github.com/code-yeongyu/oh-my-openagent/issues/7660)).
+
+### Why an extension could not handle it
+
+- Flatten and resident-delta content-block mapping are private to this builtin provider. An external extension cannot rewrite those SDK blocks after they are assembled.
+
+### Expected merge conflict zones
+
+- LOW in `prompt-bridge.ts` around `appendContentBlocks`.
+- LOW in `session-sync.ts` around `appendContent`.
+- NEW file `content-blocks.ts`.
+
+
 ## 2026-09-02 - Honor tool-less summarization requests
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/content-blocks.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/content-blocks.ts
@@ -28,7 +28,12 @@ function parseImageMediaType(value: string): Base64ImageSource["media_type"] | u
 
 function omittedPlaceholder(entry: unknown): string {
 	if (isRecord(entry) && typeof entry.type === "string") {
-		if (entry.type === "image") return "[image block omitted: missing data]";
+		if (entry.type === "image") {
+			const complete = typeof entry.mimeType === "string" && typeof entry.data === "string";
+			return complete
+				? `[image block omitted: unsupported media type ${entry.mimeType}]`
+				: "[image block omitted: missing data]";
+		}
 		return `[unsupported content block omitted: ${entry.type}]`;
 	}
 	return "[unsupported content block omitted]";

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/content-blocks.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/content-blocks.ts
@@ -1,0 +1,83 @@
+import type { Base64ImageSource, ContentBlockParam } from "./sdk-boundary.ts";
+
+const IMAGE_MEDIA_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"] as const;
+
+export function appendSdkContentBlocks(blocks: ContentBlockParam[], content: string | readonly unknown[]): boolean {
+	if (typeof content === "string") {
+		if (content.length > 0) blocks.push({ type: "text", text: content });
+		return content.trim().length > 0;
+	}
+
+	let hasText = false;
+	for (const entry of content) {
+		hasText = appendEntry(blocks, entry) || hasText;
+	}
+	return hasText;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseImageMediaType(value: string): Base64ImageSource["media_type"] | undefined {
+	for (const mediaType of IMAGE_MEDIA_TYPES) {
+		if (mediaType === value) return mediaType;
+	}
+	return undefined;
+}
+
+function omittedPlaceholder(entry: unknown): string {
+	if (isRecord(entry) && typeof entry.type === "string") {
+		if (entry.type === "image") return "[image block omitted: missing data]";
+		return `[unsupported content block omitted: ${entry.type}]`;
+	}
+	return "[unsupported content block omitted]";
+}
+
+function imageFromEntry(entry: Record<string, unknown>): ContentBlockParam | undefined {
+	if (typeof entry.mimeType !== "string" || typeof entry.data !== "string") return undefined;
+	const mediaType = parseImageMediaType(entry.mimeType);
+	if (mediaType === undefined) return undefined;
+	return {
+		type: "image",
+		source: {
+			type: "base64",
+			media_type: mediaType,
+			data: entry.data,
+		},
+	};
+}
+
+function appendEntry(blocks: ContentBlockParam[], entry: unknown): boolean {
+	if (typeof entry === "string") {
+		blocks.push({ type: "text", text: entry });
+		return entry.trim().length > 0;
+	}
+
+	if (!isRecord(entry)) {
+		blocks.push({ type: "text", text: omittedPlaceholder(entry) });
+		return true;
+	}
+
+	if (entry.type === "text") {
+		if (typeof entry.text === "string") {
+			blocks.push({ type: "text", text: entry.text });
+			return entry.text.trim().length > 0;
+		}
+		blocks.push({ type: "text", text: omittedPlaceholder(entry) });
+		return true;
+	}
+
+	if (entry.type === "image") {
+		const image = imageFromEntry(entry);
+		if (image) {
+			blocks.push(image);
+			return false;
+		}
+		blocks.push({ type: "text", text: omittedPlaceholder(entry) });
+		return true;
+	}
+
+	blocks.push({ type: "text", text: omittedPlaceholder(entry) });
+	return true;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/prompt-bridge.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/prompt-bridge.ts
@@ -1,10 +1,9 @@
-import type { AssistantMessage, Context, ImageContent, TextContent } from "@earendil-works/pi-ai";
-import type { Base64ImageSource, ContentBlockParam, SDKUserMessage } from "./sdk-boundary.ts";
+import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
+import { appendSdkContentBlocks } from "./content-blocks.ts";
+import type { ContentBlockParam, SDKUserMessage } from "./sdk-boundary.ts";
 import { mapPiToolNameToSdk } from "./tools.ts";
 
 export { mapPiToolNameToSdk } from "./tools.ts";
-
-type PromptContent = string | readonly (TextContent | ImageContent)[];
 
 export function contentToText(
 	content: AssistantMessage["content"],
@@ -22,29 +21,8 @@ export function contentToText(
 		.join("\n");
 }
 
-function appendContentBlocks(blocks: ContentBlockParam[], content: PromptContent): boolean {
-	if (typeof content === "string") {
-		if (content.length > 0) blocks.push({ type: "text", text: content });
-		return content.trim().length > 0;
-	}
-
-	let hasText = false;
-	for (const block of content) {
-		if (block.type === "text") {
-			blocks.push({ type: "text", text: block.text });
-			hasText ||= block.text.trim().length > 0;
-		} else {
-			blocks.push({
-				type: "image",
-				source: {
-					type: "base64",
-					media_type: block.mimeType as Base64ImageSource["media_type"],
-					data: block.data,
-				},
-			});
-		}
-	}
-	return hasText;
+function appendContentBlocks(blocks: ContentBlockParam[], content: string | readonly unknown[]): boolean {
+	return appendSdkContentBlocks(blocks, content);
 }
 
 export function buildPromptBlocks(

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
-import type { Context, ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
+import type { Context, Message } from "@earendil-works/pi-ai";
+import { appendSdkContentBlocks } from "./content-blocks.ts";
 import type { ClaudeSdkOauthAuthLane } from "./options.ts";
-import type { Base64ImageSource, ContentBlockParam, Options } from "./sdk-boundary.ts";
+import type { ContentBlockParam, Options } from "./sdk-boundary.ts";
 import type { ClaudeSdkOauthSessionEntry } from "./session-registry.ts";
 import { HOST_TOOL_POLICY_FINGERPRINT, mapPiToolNameToSdk } from "./tools.ts";
 
@@ -156,25 +157,8 @@ export function configFingerprint(
 	};
 }
 
-function appendContent(blocks: ContentBlockParam[], content: string | readonly (TextContent | ImageContent)[]): void {
-	if (typeof content === "string") {
-		blocks.push({ type: "text", text: content });
-		return;
-	}
-	for (const block of content) {
-		blocks.push(
-			block.type === "text"
-				? { type: "text", text: block.text }
-				: {
-						type: "image",
-						source: {
-							type: "base64",
-							media_type: block.mimeType as Base64ImageSource["media_type"],
-							data: block.data,
-						},
-					},
-		);
-	}
+function appendContent(blocks: ContentBlockParam[], content: string | readonly unknown[]): void {
+	appendSdkContentBlocks(blocks, content);
 }
 
 export function buildDeltaPromptBlocks(

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
@@ -158,6 +158,13 @@ export function configFingerprint(
 }
 
 function appendContent(blocks: ContentBlockParam[], content: string | readonly unknown[]): void {
+	// The delta path has always transmitted a whole-content empty string as an
+	// empty text block; keep that wire shape so resident sessions see the same
+	// payload as before the shared mapper (prompt-bridge intentionally skips it).
+	if (content === "") {
+		blocks.push({ type: "text", text: "" });
+		return;
+	}
 	appendSdkContentBlocks(blocks, content);
 }
 

--- a/packages/coding-agent/test/claude-sdk-oauth-content-blocks.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-content-blocks.test.ts
@@ -1,0 +1,115 @@
+import type { Context } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { buildPromptBlocks } from "../src/core/extensions/builtin/claude-sdk-oauth/prompt-bridge.ts";
+import {
+	buildDeltaPromptBlocks,
+	type SentMessage,
+} from "../src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts";
+
+const RAW_STRING_ENTRY = "\n(OmO) auto-formatted file";
+
+const ISSUE_7660_CONTENT = [
+	{ type: "text", text: "ok" },
+	RAW_STRING_ENTRY,
+	{ type: "text", text: "LSP errors detected" },
+];
+
+function toolResult(content: unknown, timestamp = 1): SentMessage {
+	return {
+		role: "toolResult",
+		toolCallId: "call-1",
+		toolName: "edit",
+		content,
+		isError: false,
+		timestamp,
+	} as SentMessage;
+}
+
+function user(content: unknown, timestamp = 2): SentMessage {
+	return { role: "user", content, timestamp } as SentMessage;
+}
+
+function promptContext(...messages: SentMessage[]): Context {
+	return { messages } as Context;
+}
+
+function imageBlocks(blocks: readonly { type: string }[]): unknown[] {
+	return blocks.filter((block) => block.type === "image");
+}
+
+function textOf(blocks: readonly { type: string; text?: string }[]): string[] {
+	return blocks.filter((block) => block.type === "text").map((block) => block.text ?? "");
+}
+
+describe("claude-sdk-oauth content blocks (#7660)", () => {
+	it("maps a raw string toolResult entry to text on flatten and delta bridges", () => {
+		const messages = [toolResult(ISSUE_7660_CONTENT), user("continue")];
+
+		const prompt = buildPromptBlocks(promptContext(...messages));
+		expect(imageBlocks(prompt)).toEqual([]);
+		expect(textOf(prompt)).toContain(RAW_STRING_ENTRY);
+
+		const delta = buildDeltaPromptBlocks(messages);
+		expect(imageBlocks(delta)).toEqual([]);
+		expect(textOf(delta)).toContain(RAW_STRING_ENTRY);
+	});
+
+	it("keeps a well-formed image as an image with media_type and data", () => {
+		const content = [{ type: "image", mimeType: "image/png", data: "aW1hZ2U=" }];
+		const expected = { type: "image", source: { type: "base64", media_type: "image/png", data: "aW1hZ2U=" } };
+
+		expect(buildPromptBlocks(promptContext(user(content)))).toContainEqual(expected);
+		expect(buildDeltaPromptBlocks([user(content)])).toContainEqual(expected);
+	});
+
+	it("maps an image missing data to a text placeholder instead of a broken image", () => {
+		const content = [{ type: "image", mimeType: "image/png" }];
+		const prompt = buildPromptBlocks(promptContext(user(content)));
+		const delta = buildDeltaPromptBlocks([user(content)]);
+
+		expect(imageBlocks(prompt)).toEqual([]);
+		expect(imageBlocks(delta)).toEqual([]);
+		expect(textOf(prompt)).toContain("[image block omitted: missing data]");
+		expect(textOf(delta)).toContain("[image block omitted: missing data]");
+	});
+
+	it("maps an unknown object type to a placeholder that includes the type", () => {
+		const content = [{ type: "tool_use", id: "x" }];
+		const prompt = buildPromptBlocks(promptContext(user(content)));
+		const delta = buildDeltaPromptBlocks([user(content)]);
+
+		expect(imageBlocks(prompt)).toEqual([]);
+		expect(imageBlocks(delta)).toEqual([]);
+		expect(textOf(prompt)).toContain("[unsupported content block omitted: tool_use]");
+		expect(textOf(delta)).toContain("[unsupported content block omitted: tool_use]");
+	});
+
+	it("maps a text block with non-string text to a placeholder", () => {
+		const content = [{ type: "text", text: 42 }];
+		const prompt = buildPromptBlocks(promptContext(user(content)));
+		const delta = buildDeltaPromptBlocks([user(content)]);
+
+		expect(imageBlocks(prompt)).toEqual([]);
+		expect(imageBlocks(delta)).toEqual([]);
+		expect(textOf(prompt)).toContain("[unsupported content block omitted: text]");
+		expect(textOf(delta)).toContain("[unsupported content block omitted: text]");
+	});
+
+	it("keeps hasText false for whitespace-only text so buildPromptBlocks still appends the image note", () => {
+		const blocks = buildPromptBlocks(
+			promptContext(
+				user([
+					{ type: "text", text: "   " },
+					{ type: "image", mimeType: "image/png", data: "aW1hZ2U=" },
+				]),
+			),
+		);
+
+		expect(blocks).toContainEqual({
+			type: "image",
+			source: { type: "base64", media_type: "image/png", data: "aW1hZ2U=" },
+		});
+		expect(textOf(blocks)).toContain("   ");
+		expect(textOf(blocks)).toContain("(see attached image)");
+	});
+});

--- a/packages/coding-agent/test/claude-sdk-oauth-content-blocks.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-content-blocks.test.ts
@@ -95,6 +95,19 @@ describe("claude-sdk-oauth content blocks (#7660)", () => {
 		expect(textOf(delta)).toContain("[unsupported content block omitted: text]");
 	});
 
+	it("keeps each bridge's historical whole-content empty-string shape", () => {
+		expect(buildDeltaPromptBlocks([user("")])).toEqual([{ type: "text", text: "" }]);
+		// prompt-bridge has always skipped the empty text block (and, with no text, appends its image note)
+		expect(buildPromptBlocks(promptContext(user("")))).not.toContainEqual({ type: "text", text: "" });
+	});
+
+	it("names an unsupported image media type instead of claiming missing data", () => {
+		const content = [{ type: "image", mimeType: "image/svg+xml", data: "PHN2Zz4=" }];
+		const prompt = buildPromptBlocks(promptContext(user(content)));
+		expect(imageBlocks(prompt)).toEqual([]);
+		expect(textOf(prompt)).toContain("[image block omitted: unsupported media type image/svg+xml]");
+	});
+
 	it("keeps hasText false for whitespace-only text so buildPromptBlocks still appends the image note", () => {
 		const blocks = buildPromptBlocks(
 			promptContext(


### PR DESCRIPTION
## Summary

Claude SDK OAuth flatten and resident-delta prompt bridges treated every non-`text` content entry as a base64 image. Persisted tool results can include raw strings (OmO formatter notes mixed into `toolResult` content), which became image blocks with undefined `media_type`/`data` and made Claude Code abort the next query. Both bridges now share one mapper that keeps well-formed images, maps strings to text, and replaces malformed entries with an omission placeholder.

## Changes

- Shared `appendSdkContentBlocks` mapper (`content-blocks.ts`) validates image `mimeType`/`data` against the SDK media-type union and never emits image blocks with undefined fields.
- Flatten (`prompt-bridge.ts`) and resident delta (`session-sync.ts`) both delegate to that mapper. Flatten still uses the returned `hasText` flag for `(see attached image)`.
- New tests pin the mixed toolResult fixture on both `buildPromptBlocks` and `buildDeltaPromptBlocks`, plus valid-image, missing-data, unknown-type, non-string text, and whitespace `hasText` edges.
- `changes.md` tracker and `CHANGELOG.md` [Unreleased] Fixed entry.

## QA & Evidence

- RED: new tests against current bridges. Observed: 4 failed / 2 passed; the #7660 case failed with `expected [ { type: 'image', source: { data: undefined, media_type: undefined } } ] to deeply equal []` (not an import error). Artifact: `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g3-red.log`. Sufficient because it reproduces the broken image block on the exact mixed string fixture.
- GREEN: same tests after the shared mapper. Observed: 6 passed on mengmotaMac. Artifact: `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g3-green.log`.
- MUTATION: string-entry guard forced into the image branch. Observed: 1 failed / 5 passed (`maps a raw string toolResult entry to text`). Guard restored. Artifact: `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g3-mutation.log`. Sufficient because the #7660 assertion is what dies when strings become images again.
- EDGE: content-block edges plus existing prompt-bridge tests. Observed: 12 passed. Artifact: `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g3-edge.log`. Existing well-formed output stayed green without modifying those tests.
- REGRESSION: `bunx tsc --noEmit -p tsconfig.build.json` then vitest on prompt-bridge, content-blocks, payload-bytes-utf8, prompt-directive-dedupe, session-registry, continuity-decision, and stream. Observed: cmd-exit=0, 7 files / 91 tests passed, commit `a3524da3c`. Artifact: `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g3-regression.log`. `rg` confirms no inline image branch remains in `prompt-bridge.ts` or `session-sync.ts`.
- Lane report: `/Users/yeongyu/sisyphuslabs/.omo/evidence/ulw/claude-sdk-fable51-20260903/g3-lane-report.md`.

## Risks & Residuals

- Whole-content empty string on the delta path now matches flatten (push nothing) instead of emitting an empty text block. No existing test covered that difference.
- Image mime types outside `image/jpeg|png|gif|webp` become omission placeholders instead of being cast through. Well-formed pi-ai images are unchanged.
- Out of scope: errors/auth-lane/stream/pump and oauth-login/accounts.

## Related Issues

Fixes https://github.com/code-yeongyu/oh-my-openagent/issues/7660

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Claude SDK OAuth content-block mapping so raw strings and malformed entries in tool results no longer become image blocks with undefined `media_type`/`data`, which made Claude Code abort the next query.

- Both the flatten and resident-delta bridges now delegate to a shared mapper in `content-blocks.ts` that validates images against the SDK media-type union, maps strings to text, and emits omission placeholders for unsupported entries.
- The delta bridge keeps its historical whole-content empty-string block; flatten continues to skip it.
- Image mime types outside `image/jpeg|png|gif|webp` get placeholders that name the unsupported media type instead of being cast through.

Fixes https://github.com/code-yeongyu/oh-my-openagent/issues/7660.

<sup>Written for commit e8fc5ec72cc8f44b0499c64ca7ad718d7a5b86b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

