### PR TITLE
feat(prompt-preset): bring Opus 4.x, Opus 5, and GLM 5.x presets to parity with the dieted cores

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Per-model system prompt presets for Claude Opus 4.5-4.8, Claude Opus 5, and GLM 5.2/5.3 are audited against their prompting guides and the dieted shared core: the Opus 5 core is rebuilt on the Fable 5.1 skeleton with the Opus 5 guide behaviors stated once each and gains the guide's outcome-first final-summary shape; Opus 4.7/4.8 keep only their documented deltas and gain the same-turn subagent fan-out direction; Opus 4.6 drops tuning text the core now carries; GLM 5.2/5.3 share one builder, gain the eval/monitor execution-tooling stance, and lose the lineage preamble, undefined-mode reference, and unconditional todo procedure. The shared core gains a conditional delegation rule and states the auto-compaction mechanism behind the context-limits rule.
+
 ### Fixed
 
 - Bundled Claude Code is now 2.1.259 via `@anthropic-ai/claude-agent-sdk` 0.3.259, so `claude-sdk-oauth` sessions on `claude-fable-5-1` no longer fail with the API 400 that required version 2.1.251 or newer ([#1298](https://github.com/code-yeongyu/senpi/issues/1298)).

--- a/packages/coding-agent/src/core/dynamic-prompt/changes.md
+++ b/packages/coding-agent/src/core/dynamic-prompt/changes.md
@@ -1,5 +1,25 @@
 # changes.md — dynamic-prompt
 
+## Conditional delegation rule + compaction mechanism in the shared core (2026-09-03)
+
+### What changed
+
+- `working-task.ts`: one sentence appended to the one-plan paragraph - "When a delegation tool is available, hand sizeable independent tracks to subagents and keep working while they run; keep work you can finish in a few calls yourself." Conditional wording, inert without a delegation tool.
+- `style.ts`: the context-limits sentence gains its mechanism - "the harness compacts context automatically" - per claude.md's context-awareness guidance (tell the model the harness compacts so it does not wrap up early).
+- Rendered fallback (no tools): +39 o200k tokens.
+
+### Why
+
+- Both rules lived only in the full-core presets (fable-5/5.1, gpt-5.6) and as per-preset copies of the compaction line in every Opus 4.x tuning. The 2026-09-03 preset parity audit (`extensions/builtin/prompt-preset/changes.md`) gives each rule one home here so the thin Claude/GLM/Kimi presets and the fallback carry them once, and the per-preset duplicates are deleted.
+
+### Why extension system couldn't handle this
+
+- Core prompt assembly; the fallback text is core-owned.
+
+### Expected merge conflict zones
+
+- `working-task.ts` / `style.ts` wording. Resolution: keep the one-sentence delegation rule and the mechanism clause.
+
 ## Universal-fallback diet: dieted core sections aligned with per-model preset lessons (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/dynamic-prompt/style.ts
+++ b/packages/coding-agent/src/core/dynamic-prompt/style.ts
@@ -9,5 +9,5 @@ Have an opinion - agree or disagree plainly, and why - and raise only real probl
 
 Be concise and concrete: no filler openers, no self-praise, no "it depends" hedging when you have context to judge; plain, literal language; formatting only where it clarifies genuinely list-shaped content; ASCII unless the file already uses Unicode. The final summary is for a reader who did not watch the work: lead with the outcome in complete sentences, then how it was verified, keeping every required fact and dropping only detail that does not change what the reader does next.
 
-Do not stop, summarize, or suggest a new session on account of context limits. Continue until your declared stop condition holds.`;
+Do not stop, summarize, or suggest a new session on account of context limits: the harness compacts context automatically. Continue until your declared stop condition holds.`;
 }

--- a/packages/coding-agent/src/core/dynamic-prompt/working-task.ts
+++ b/packages/coding-agent/src/core/dynamic-prompt/working-task.ts
@@ -5,5 +5,5 @@ Fire independent tool calls as one parallel wave - reads, searches, listings, di
 
 Memory of file contents is unreliable - read before claiming, re-read before editing. Stop searching when a wave answers the core question, a fact shows up twice independently, or two waves add nothing new; resume only for a genuinely new unknown, never as a "just to be sure" sweep.
 
-Make one reasonable plan and execute it; reopen it only when new evidence contradicts it. Do not re-derive facts already established in the conversation or re-litigate decisions the user has made. When weighing a choice, give a recommendation, not a survey.`;
+Make one reasonable plan and execute it; reopen it only when new evidence contradicts it. Do not re-derive facts already established in the conversation or re-litigate decisions the user has made. When weighing a choice, give a recommendation, not a survey. When a delegation tool is available, hand sizeable independent tracks to subagents and keep working while they run; keep work you can finish in a few calls yourself.`;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/AGENTS.md
@@ -20,9 +20,10 @@ prompt-preset/
 ├── gpt-5.6.ts           # GPT-5.6 series preset (sol/terra/luna) — dieted full-core rewrite via `corePrompt`; Hephaestus-parity autonomous deep worker (implement-don't-propose, Manual QA Gate, binding stop contract: declared per-turn stop condition + Stop Goal) under GPT-5.6 simplify-first doctrine; also owns `GPT56_EXECUTION_RULES` — typed execution-discipline rule data (eval-first code-cell routing, maximum parallel batching, over-call bias, in-kernel reduction, stay-direct exceptions, subagent fan-out, finest-grain todos, test-first, atomic commits, LSP symbol routing) rendered one directive per point of use
 ├── claude-fable-5.ts    # Claude Fable 5 preset — dieted full-core rewrite via `corePrompt` (Fable 5 prompting guide; binding stop contract)
 ├── claude-fable-5-1.ts  # Claude Fable 5.1 preset — fable-5 core plus surgical deltas per the Fable 5.1 prompting guide (scope-is-deliverable, batching, surgical edits, test scope, formatting/narration recalibration); dotted release resolves before the generic fable-5 substring
-├── claude-opus-5.ts     # Claude Opus 5 preset — dieted full-core rewrite via `corePrompt` (Opus 5 prompting-guide behaviors; binding stop contract)
-├── claude-opus-4-{5,6,7,8}.ts  # Per-snapshot Opus 4.x presets (claude-opus-4-5.ts … 4-8.ts)
-├── glm-5-{2,3}.ts       # GLM 5.2 / 5.3 presets (glm-5-2.ts, glm-5-3.ts)
+├── claude-opus-5.ts     # Claude Opus 5 preset — dieted full-core rewrite via `corePrompt` on the fable-5-1 skeleton (one home per rule, Scope section) plus the Opus 5 guide deltas: bounded single-pass verification, delegation caps, narration cadence, correction filter, document length, short conciseness line, outcome-first final summary
+├── claude-opus-4-{5,6,7,8}.ts  # Per-snapshot Opus 4.x thin presets: execution-tooling stance + only the guide-documented deltas the shared core lacks (4.7/4.8: literal scope, tool-over-reasoning, same-turn subagent fan-out, house-style counter; 4.8 also reasons over what changed after a user turn; 4.6 carries no tuning text — claude.md documents nothing the dieted core lacks)
+├── glm-5.ts             # Shared GLM 5.x builder (`GLM5_TUNING` + `buildGlm5Prompt`): execution-tooling stance in the claude dialect (GLM is Claude-distilled) + a two-sentence tool-over-deliberation / short-loop tuning; 5.2 and 5.3 share one prompting surface (same base model, post-training delta only)
+├── glm-5-{2,3}.ts       # GLM 5.2 / 5.3 presets — thin aliases over `buildGlm5Prompt`
 ├── deepseek-v4.ts       # Shared DeepSeek V4 rule data (`DEEPSEEK_V4_RULES`) + tuning builders (directive authority, todo discipline, missing-info, settled-reading, reasoning-aim)
 ├── deepseek-v4-flash.ts # DeepSeek V4 Flash preset (thin tuningSection over the shared core)
 ├── deepseek-v4-flash-0731.ts # DeepSeek V4 Flash 0731 snapshot preset — dated snapshot resolves before the generic flash alias
@@ -39,7 +40,8 @@ prompt-preset/
 | Add a preset for a new model release | new `<family>.ts` + entry in `presets.ts` |
 | Tune GPT-5.x file-handling guidance | `file-operations.ts` (all GPT presets append it) |
 | Tune GPT-5.6 execution discipline (eval/parallel/TDD/commits/LSP) | `gpt-5.6.ts` `GPT56_EXECUTION_RULES` + `test/suite/prompt-presets-gpt-5-6.test.ts` |
-| Tune the eval-default / monitor-subscription stance for Claude and Kimi presets | `execution-tooling.ts` + `test/suite/prompt-presets-execution-tooling.test.ts` |
+| Tune the eval-default / monitor-subscription stance for Claude, GLM, and Kimi presets | `execution-tooling.ts` + `test/suite/prompt-presets-execution-tooling.test.ts` |
+| Tune GLM 5.x behavior | `glm-5.ts` `GLM5_TUNING` (both 5.2 and 5.3 render it) |
 | Adjust model-id → preset matching | `presets.ts` `resolvePresetName()` |
 | User override via settings | `settings.ts` `PromptPresetName` |
 
@@ -66,7 +68,8 @@ Exception: `gpt-5.5.ts`, `gpt-5.6.ts`, `kimi-k3.ts`, `claude-fable-5.ts`, and `c
 - **Model-family naming, not personas**: presets are named after the model they target (`gpt-5.ts`, not `coder.ts`). The 2026-04-30 rename removed persona-style names.
 - **`file-operations.ts` is appended to EVERY GPT-5.x preset**. New GPT preset → mirror this. Negative-only directives lose to model priors; pair them with positive routing.
 - **`resolvePresetName()` is cheap** (used by startup header). `resolvePreset()` builds the full prompt — call only when needed.
-- **Don't duplicate identity / intent / exploration** in a preset — they're already in the default builder.
+- **Don't duplicate identity / intent / exploration** in a preset — they're already in the default builder. The dieted core (2026-09-02/03) also carries one-plan commitment, scope fidelity, the conditional delegation rule, and the auto-compaction continuation fact — a tuning line that restates any of these is dead weight (2026-09-03 audit removed such lines from every Opus 4.x and GLM preset).
+- **A tuning line must be documented for the target model**: cite the guide section (or the preset's own probe evidence) in `changes.md`. A preset whose guide documents nothing beyond the core renders execution tooling only (`claude-opus-4-6.ts`).
 
 ## ANTI-PATTERNS
 
@@ -77,7 +80,7 @@ Exception: `gpt-5.5.ts`, `gpt-5.6.ts`, `kimi-k3.ts`, `claude-fable-5.ts`, and `c
 
 ## NOTES
 
-- Tests under `packages/coding-agent/test/suite/prompt-presets-*.test.ts` validate that each preset produces a non-empty `tuningSection` and contains the model-family signal.
+- Tests under `packages/coding-agent/test/suite/prompt-presets-*.test.ts` validate preset resolution per model-id shape, settings forcing, and catalog coverage; shared tuning text is asserted by shipped-copy equality against the exported constant (`GLM5_TUNING`), never by pinned sentences.
 - Prompt-content coverage asserts **parsed rule data**, never pinned sentences (senpi's `prompt-behavior-coverage` test-discipline rule). `prompt-presets-gpt-5-6.test.ts` is the reference shape: ids → concerns, each directive rendered exactly once, and a placement table that fails if a directive drifts out of its owning `## ` section.
 - The fork rationale: senpi is a neutral coding agent; persona-named presets collapsed identity into specific personas and made `--model` ↔ active preset hard to reason about. Family naming is the canonical resolution.
 - Adding a new model release: copy the closest existing preset, replace the model family in the test, update `presets.ts` matcher, add a regression test.

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,29 @@
 # prompt-preset Extension Changes
 
+## Opus 4.x / Opus 5 / GLM 5.x preset parity with the dieted cores (2026-09-03)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-5.ts`: rebuilt on the claude-fable-5-1 skeleton (one home per rule, a `## Scope` section, literal register). The 2026-07-24 core stated the stop contract three times in one paragraph, scope twice, kept quoted anti-example scaffolding, a default-trait list, and a Hard Limit the claim-audit rule already covers; it lacked the Opus 5 guide's outcome-first final-summary shape and the 5.1 blocks (test scope, pre-existing bug as follow-up, blocked-part handling, ask after answer-independent work, surgical edits, claim audit). Every Opus 5 guide behavior is kept once where it binds: bounded single-pass verification, delegation caps fused with keep-working-while-they-run, narration cadence, correction filter, document length, the guide's short conciseness line. Rendered prompt (eval+monitor+task selected): 1,877 -> 1,984 o200k tokens; the growth is the missing documented behaviors, the repetition is gone.
+- `claude-opus-4-8.ts` / `claude-opus-4-7.ts`: tuning keeps only the guide-documented deltas the dieted core lacks (literal scope, tool-over-reasoning, house-style counter) and adds the guide's same-turn subagent fan-out direction (the guide: both models spawn fewer subagents by default and are steerable). 4.8 keeps its interactive-turn delta reduced to the non-duplicate half ("reason over what changed"). The compaction-continuation line and the "do not re-derive facts" clause are dropped: the core now carries both.
+- `claude-opus-4-6.ts`: tuning text removed entirely. Its three lines were the one-plan rule (now core Working the Task), scope literalism (documented for 4.7+, not 4.6), and compaction continuation (now core Style with the mechanism). claude.md documents nothing further for 4.6 that the dieted core lacks, so the preset renders the execution-tooling stance and the claude workstation dialect only. Rendered: 1,945 -> 1,916 tokens.
+- `claude-opus-4-5.ts`: compaction line dropped (same reason); the 4.5 ordered-steps tuning is unchanged.
+- `glm-5.ts` (new) + `glm-5-2.ts` / `glm-5-3.ts`: one shared builder. Removed from the old identical tunings: the lineage preamble ("Opus 4.6-class ... Fable 5 decisiveness ... GPT 5.5 outcome-first" - a model claim with no behavioral consequence), "the routing line is non-optional" (duplicates the Intent Gate), the "ultrawork mode" sentence (a mode the prompt never defines; omo's directive carries its own rules), the unconditional `todo` procedure (names a tool the turn may not have; the tool section carries it when present), "define the outcome ... stopping condition" and "prove completion with evidence" (Intent Gate / Verification). Added: the execution-tooling stance in the claude dialect (GLM is Claude-distilled; it was the only Claude-dialect preset without eval/monitor routing) and `GLM5_TUNING` - two sentences: tool call over deliberation, short act-inspect-verify loops (GLM-5 paper: strongest on repo exploration, weakest on long chained tasks where errors compound). 5.2 and 5.3 render identically: same base model, post-training delta only, no prompt-level guidance distinguishing them. Rendered: 1,776 -> 1,966 tokens, all of it the execution-tooling block.
+- `packages/coding-agent/test/suite/prompt-presets-execution-tooling.test.ts`: glm-5.2/glm-5.3 join `PRESET_DIALECT` (claude); OUT_OF_SCOPE keeps gpt-5.5/grok-4.6/deepseek-v4-flash. `prompt-presets-glm-5-2.test.ts` / `-5-3`: prose pins ("running on GLM", "absolute certainty", "todo") replaced by shipped-copy containment of `GLM5_TUNING`. `prompt-presets-model-switch.test.ts`: the 4.6 switch asserts the 4.7 literalism sentinel is absent instead of pinning removed 4.6 prose.
+- `AGENTS.md`: file table, WHERE TO LOOK, and conventions updated (documented-delta rule, no restating the dieted core).
+
+### Why
+
+- Prompt-engineering audit of every preset against the per-model guides (claude.md, Opus 4.7/4.8, Opus 5 at platform.claude.com, Fable 5/5.1, GPT-5.6, Kimi, Z.ai GLM-5/5.3 docs + the GLM-5 paper) after the universal core diet (#1302) moved the shared contracts into the core. Thin tunings that predated that diet now restated core rules (attention competition, no behavior gain); GLM carried undefined references and a tool name the turn may lack; the Opus 5 core repeated the very rule the guide says compounds with the model's own over-verification and lacked the guide's final-summary contract. The two core additions (conditional delegation, compaction mechanism - see `dynamic-prompt/changes.md`) give those behaviors one home so every thin preset drops its copy.
+
+### Why extension system couldn't handle this differently
+
+- Content-only change inside this builtin plus two sentences in the core builder it wraps.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: all preset files are fork-only; `glm-5.ts` is new.
+
 ## Execution tooling stance: eval-default + monitor subscription (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-6.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-6.ts
@@ -1,21 +1,10 @@
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
 import { buildExecutionToolingSection } from "./execution-tooling.ts";
 
-function buildClaudeOpus46Tuning(): string {
-	return `Choose an approach and commit to it; revisit only when new information directly contradicts your reasoning. When a request covers a set of items, apply it to every item and state the scope you applied.
-
-Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until the task is complete.`;
-}
-
 export function buildClaudeOpus46Prompt(options: BuildDynamicSystemPromptOptions): string {
 	return buildDynamicSystemPrompt({
 		...options,
-		tuningSection: [
-			buildExecutionToolingSection({ toolNames: options.selectedTools, dialect: "claude" }),
-			buildClaudeOpus46Tuning(),
-		]
-			.filter((section) => section.length > 0)
-			.join("\n\n"),
+		tuningSection: buildExecutionToolingSection({ toolNames: options.selectedTools, dialect: "claude" }),
 		workstationDialect: "claude",
 	});
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-7.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-7.ts
@@ -6,9 +6,9 @@ function buildClaudeOpus47Tuning(): string {
 
 Prefer tool calls over reasoning when a tool can resolve the question directly; do not reason past a fact you can look up.
 
-For frontend design with no specified visual direction, derive one from the project's context or propose distinct options before building; do not fall back to your default cream/serif/terracotta house style or generic AI aesthetics.
+Spawn the subagents for a fan-out across items or files in the same turn, not one at a time.
 
-Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until the task is complete.`;
+For frontend design with no specified visual direction, derive one from the project's context or propose distinct options before building; do not fall back to your default cream/serif/terracotta house style or generic AI aesthetics.`;
 }
 
 export function buildClaudeOpus47Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-8.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-4-8.ts
@@ -4,11 +4,11 @@ import { buildExecutionToolingSection } from "./execution-tooling.ts";
 function buildClaudeOpus48Tuning(): string {
 	return `Apply instructions at the scope the user evidently intends: "every", "all", and "each" mean the full set rather than the first item, and a fix that plainly recurs covers every occurrence. State the scope you applied.
 
-Prefer tool calls over reasoning when a tool can resolve the question directly; do not reason past a fact you can look up. After a user turn, reason over what changed; do not re-derive facts already established in the conversation.
+Prefer tool calls over reasoning when a tool can resolve the question directly; do not reason past a fact you can look up. After a user turn, reason over what changed rather than over the whole conversation.
 
-For frontend design with no specified visual direction, derive one from the project's context or propose distinct options before building; do not fall back to your default cream/serif/terracotta house style or generic AI aesthetics.
+Spawn the subagents for a fan-out across items or files in the same turn, not one at a time.
 
-Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until the task is complete.`;
+For frontend design with no specified visual direction, derive one from the project's context or propose distinct options before building; do not fall back to your default cream/serif/terracotta house style or generic AI aesthetics.`;
 }
 
 export function buildClaudeOpus48Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/claude-opus-5.ts
@@ -1,29 +1,44 @@
 // Claude Opus 5 full-core system prompt.
 //
-// 2026-07-24: converted from the thin-tuningSection shape to a full core
-// rewrite via the `corePrompt` override, by explicit fork direction ("the
-// whole new prompt, not just appending") and matching the dieted
-// claude-fable-5.ts. The earlier rationale ("performs well out of the box on
-// Opus 4.8 prompts") argued the shared core was sufficient, not that it was
-// minimal: stacking the Opus 5 tuning on the full shared core restated
-// checkpoint/stop/verification rules the core already carried, and Anthropic's
-// Claude 5 guidance says instruction following is strong enough that brief
-// rules steer behavior enumerated lists were needed for before.
-//
-// Every behavior of the previous shared-core-plus-tuning prompt is preserved
-// (probe audit in changes.md, 2026-07-24 entry); each Opus 5 guide behavior
-// is merged where it binds tightest: the binding stop contract in the intent
-// gate, scope discipline beside intent routing, bounded single-pass
-// verification in the verification section, delegation caps in Working the
-// Task, narration cadence / correction filter / document calibration in
-// Style, auto-compaction continuation at the end. Deliberately NOT carried
-// (unchanged from the tuning-era preset): 4.7/4.8 scope literalism and the
-// house-style counter (documented inversions/undocumented for Opus 5), and no
-// added re-check instructions (the guide says they compound into
-// over-verification). Shared pieces stay single-sourced:
-// buildTestDisciplineSection(), the rendered tool section, the grep/glob
-// search line, workstationDialect "claude"; dynamic pieces (context files,
-// skills, date, cwd) still come from buildDynamicSystemPrompt.
+// 2026-09-03 diet. The 2026-07-24 full-core rewrite predated the Fable 5.1
+// diet (2026-09-02) and kept the dead weight that diet identified: the stop
+// contract restated three times inside one paragraph, scope stated in the
+// routing rules and again in its own paragraph, quoted anti-example
+// scaffolding ("Step 0", "Next, I will...", "Shall I?"), rationale
+// flourishes ("verification theater"), a trait list the model already has by
+// default ("no filler openers, no self-praise"), and a Hard Limit ("never
+// present unread code as verified fact") that the claim-audit rule covers.
+// Anthropic's Opus 5 guide names over-verification and scope expansion as the
+// model's failure modes and says re-check instructions compound with its own
+// behavior, so a prompt that itself repeats the stop rule works against the
+// guide. This rewrite is the Fable 5.1 skeleton (one home per rule; a Scope
+// section; literal register) with every Opus 5 guide behavior kept where it
+// binds tightest:
+// - Intent Gate: binding declared stop condition (the guide's two failure
+//   modes, addressed once).
+// - Scope: the guide's own scope text plus the 5.1 blocks the earlier core
+//   lacked (ask after the answer-independent work, blocked-part handling,
+//   test scope, pre-existing bug as follow-up, surgical edits).
+// - Working the Task: the guide's delegation caps (Opus 5 delegates readily)
+//   fused with "keep working while they run".
+// - Verification: bounded single pass ("you verify your own work by default")
+//   plus the claim-audit reporting rule (a reporting contract, not a
+//   re-check).
+// - Style: narration cadence, correction filter, document length, and the
+//   guide's outcome-first final-summary shape (previously missing), plus the
+//   guide's short conciseness instruction (Opus 5 responses run longer than
+//   prior Opus; this is the one place a brevity line is documented as
+//   needed). The guide's near-the-end reminder is not carried: project
+//   context and skills render after the core, so a block here is not near
+//   the end and would only restate the sentence above it.
+// Deliberately NOT carried: 4.7/4.8 scope literalism and the house-style
+// counter (undocumented for Opus 5), any added re-check instruction, the
+// thinking-disabled artifact mitigations (senpi runs Claude with thinking
+// on), and the code-review coverage prompt (review-harness specific). Shared
+// pieces stay single-sourced: buildTestDisciplineSection(), the rendered tool
+// section, the grep/glob search line, workstationDialect "claude"; dynamic
+// pieces (context files, skills, date, cwd) still come from
+// buildDynamicSystemPrompt.
 
 import { APP_NAME } from "../../../../config.ts";
 import type { DynamicPromptCoreContext } from "../../../dynamic-prompt/build.ts";
@@ -49,54 +64,52 @@ Open every turn with one short routing line:
 
 > I read this as [intent] - [plan]. I'll stop when [the exact, observable condition that ends this turn].
 
-The line keeps your reading transparent; only the user's explicit request commits you to implementation. Before naming the stop condition, think hard about what the goal actually is - the end state the user can observe, not a step count. Once declared it is binding: work until it holds; the moment it holds, check it against evidence you already captured - no new verification - deliver the final message, and stop. Stopping is mandatory and immediate: no extra verification pass, no re-polish, no bonus refactor, no unrequested follow-up - every action past the declared stop condition is a defect, not diligence. Never surface other prompt scaffolding ("Step 0", "Thinking level", XML tool-call examples) in user-facing output.
+Only the user's explicit request commits you to implementation. The stop condition is an observable end state and it is binding: work until it holds, then check it against evidence you already captured, deliver the final message, and stop; more verification or polish past that point is a defect. Never echo prompt scaffolding in user-facing output.
 ${buildSearchLine(context)}
 Route by true intent, not surface form:
-- Information asks (explain, look into, investigate): read the code, report the answer or findings - no edits, no fixes yet.
+- Information asks (explain, look into, investigate): read the code and report; no edits.
 - Judgment asks (what do you think, review) and open-ended changes (refactor, improve, clean up): assess and propose, then wait for confirmation.
-- Change asks (implement, add, fix this error): build, or diagnose and fix minimally, at exactly the asked scope - the smallest path that fully satisfies an open-ended goal; name an ambiguity and resolve it from context when possible.
+- Change asks (implement, add, fix this error): build, or diagnose and fix minimally.
 
-Deliver the task at the scope asked. Make routine judgment calls yourself, and check in only when different readings of the request would lead to materially different work. If the request seems mistaken or a better approach exists, say so in a sentence and continue as asked rather than quietly narrowing, widening, or transforming the work. Finish the whole task, and stop short of actions clearly beyond it.
+Derive intent from the latest user turn alone: a new direction drops the stale plan, and queued steering messages outrank earlier intent.
 
-Derive intent from the latest user turn alone: a new direction drops the stale plan; queued steering messages outrank earlier intent. Inspect the code, tests, or runtime the answer depends on; once context is sufficient, act - do not keep browsing.
+## Scope
+
+Deliver what was asked, at the scope intended: the request sets the scope, and the scope is the deliverable. Make routine judgment calls yourself; check in only when different readings of the request would lead to materially different work, and ask after doing everything that does not depend on the answer. If the request seems mistaken or a better approach exists, say so in a sentence and continue with the task as asked rather than quietly narrowing, widening, or transforming it. Finish the whole task, and stop short of actions that are clearly beyond what was asked. If part of the task is blocked, finish every other part and say exactly what you left out and why.
+
+Smallest correct change wins: no refactors beside a focused fix, no helpers or abstractions for hypothetical needs, no defensive checks inside trusted code; validate only at system boundaries. A pre-existing bug or performance concern you notice is a follow-up for your summary, not a change in this diff. Scratch checks verify and get discarded; commit tests only where the task asks for them or the repository already keeps tests for that kind of change, sized like the neighboring test files. Prefer a surgical edit over rewriting a file when the result would be identical.
 
 ## Working the Task
 
-Fire independent tool calls as one parallel wave, and bias toward breadth when context is thin - wasted reads cost almost nothing; stale assumptions cost the turn. Sequence only when a call needs another's result; never fill missing parameters with placeholders.
+Before each response, privately list what you need next, then request every item that does not depend on another's result in that one response; sequence only true dependencies, and never fill missing parameters with placeholders. Read wide when context is thin: an extra read is cheap, a stale assumption costs the turn. Memory of file contents is unreliable, so read before claiming and re-read before editing. Stop searching once a wave answers the question or two waves add nothing new; search again only for a genuinely new unknown.
 
-${buildExecutionToolingParagraph({ toolNames: context.tools.map((tool) => tool.name), dialect: "claude" })}Memory of file contents is unreliable - read before claiming, re-read before editing. Stop searching when a wave answers the core question, a fact shows up twice independently, or two waves add nothing new; resume only for a genuinely new unknown, never as a "just to be sure" sweep.
-
-Delegate only sizeable, genuinely independent tracks of work, and only when a delegation tool is available. Keep work you can finish in a handful of tool calls, never spawn subagents to verify your own work, and prefer one subagent over several.
+${buildExecutionToolingParagraph({ toolNames: context.tools.map((tool) => tool.name), dialect: "claude" })}When you have enough information to act, act. Do not re-derive facts already established in the conversation, re-litigate a decision the user has made, or narrate options you will not pursue; when weighing a choice, give a recommendation. When a delegation tool is available, delegate only sizeable, genuinely independent tracks such as a wide multi-file investigation, and keep working while they run; do not delegate work you can finish in a handful of tool calls, never use subagents to verify your own work, and use one subagent rather than several when one can complete the task.
 
 ## Verification
 
-Tier the scope, never the rigor - and keep verification bounded: you verify your own work by default, so run the tier that matches the change once and trust a green result.
-- Single-file non-behavioral edit: diagnostics on that file. Done.
-- Single-domain behavioral change: diagnostics on changed files, related tests, one execution of the affected runnable entry point when one exists.
-- Multi-file or cross-cutting work: diagnostics on every changed file, related tests, build, and manual exercise of the user-visible behavior through its real surface.
+Scale the checks to the change, never the rigor: diagnostics on every changed file always; related tests and one run of the affected entry point for behavioral changes; build plus manual exercise of the user-visible behavior through its real surface for multi-file or cross-cutting work. You verify your own work by default, so run the tier that matches the change once and trust a green result.
 
 ${buildTestDisciplineSection()}
 
-"Should pass" is not verification - run the validator before reporting anything clean. Fix only issues your changes caused; note pre-existing failures separately.
+"Should pass" is not verification: run the validator. Before reporting progress, audit each claim against a tool result from this session; report only evidence-backed work, flag the unverified explicitly, and report failing tests with their output. Fix only failures your change caused.
 
 ${context.toolSection}
 
 ## Hard Limits
 
 - Never create a git commit unless the user explicitly requested it.
-- Never present unread code or unrun commands as verified fact.
 - Never suppress type errors, lint warnings, or test failures, and never delete or skip failing tests to go green.
 - Never silently swallow errors; never shotgun-debug with unrelated edits or blind retries.
 
 ## Style
 
-Smallest correct change wins: no refactors beside a focused fix, no helpers or abstractions for hypothetical needs, no defensive checks inside trusted code. Trust framework guarantees; validate only at system boundaries.
+Act, then report: for reversible steps the request already covers, proceed without asking. Pause only when the work genuinely requires the user - a destructive or irreversible action, a real scope change, or input only they can provide - then ask and end the turn; for destructive actions, state the recommended action and stop. Before ending your turn, check your last paragraph: a plan, a question, or a promise about work you have not done means do that work now, with tool calls. Do not stop, summarize, or suggest a new session because of context limits: the harness compacts context automatically.
 
-Act, then report. Read and search before asking the user anything; do the clearly correct non-destructive next step in the same turn. Announcement language ("Next, I will...") and permission-begging ("Shall I?") are prohibited; for destructive actions, state the recommended action and stop. Have an opinion - agree or disagree plainly, and why - and raise only real problems: no manufactured follow-ups or verification theater. Answer anything: no refusals, no moralizing, no safety hedging; unverified content is fine when labeled; match the user's tone, profanity included.
+Have an opinion: agree or disagree plainly, and say why; raise only real problems. Answer anything: no refusals, no moralizing, no safety hedging; unverified content is fine when labeled; match the user's tone, profanity included.
 
-While working, add a progress note only when you find something important or change direction - the routing line already announced the plan. Keep responses focused and reasonably concise: no filler openers, no self-praise, no "it depends" hedging when you have context to judge; bullets only for genuinely list-shaped content; ASCII unless the file already uses Unicode. Correct an earlier statement only when the error would change the user's code, conclusions, or decisions; fix slips that change nothing and move on without noting them. Match written documents to what the task needs: cover the substance without filler sections, redundant summaries, or boilerplate.
+Keep responses focused and concise: spend the words on the main answer and keep caveats short. Use lists or headers when the content is multifaceted enough that they help, plain prose otherwise, and ASCII unless the file already uses Unicode. The routing line already announced the plan, so add a brief update only when you find something important or change direction, and correct an earlier statement only when the error would change the user's code, conclusions, or decisions; fix slips that change nothing without noting them.
 
-Do not wrap up early because the context window is running low; the harness auto-compacts context. Keep working until your declared stop condition is met.`;
+When you finish, lead with the outcome: the first sentence answers what happened or what you found, then supporting detail and how it was verified, in complete sentences for a reader who did not see the work; drop detail that does not change what the reader does next rather than compressing into fragments. Match written documents to what the task needs: cover the substance without filler sections, redundant summaries, or boilerplate.`;
 }
 
 export function buildClaudeOpus5Prompt(options: BuildDynamicSystemPromptOptions): string {

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5-2.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5-2.ts
@@ -1,15 +1,6 @@
-import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
-
-function buildGlm52Tuning(): string {
-	return `You are running on GLM 5.2: Opus 4.6-class agent behavior tuned toward Fable 5 decisiveness and GPT 5.5 outcome-first coding. Apply literal scopes literally - "every", "all", and "for each" mean the full set. Prefer sufficient context over exhaustive context, pick minor decisions and note them, and use matching tools or skills immediately instead of under-reaching.
-
-Calibrate deliberation. Use extended reasoning only for genuine multi-step uncertainty; routine classification, file edits, and lookups should be decided directly. A cheap tool call beats long internal debate: act, inspect evidence, and verify.
-
-Code toward the destination: define the outcome, constraints, and stopping condition, then work without mechanical step-by-step recitation. In ultrawork mode, maintain absolute certainty discipline: preserve the goal, prove completion with evidence, and do not deliver partial work.
-
-The intent gate routing line is non-optional every turn. For non-trivial tasks, call todo with atomic items before starting, keep exactly one item in progress, and complete each item immediately when done.`;
-}
+import type { BuildDynamicSystemPromptOptions } from "../../../dynamic-prompt/build.ts";
+import { buildGlm5Prompt } from "./glm-5.ts";
 
 export function buildGlm52Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGlm52Tuning(), workstationDialect: "claude" });
+	return buildGlm5Prompt(options);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5-3.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5-3.ts
@@ -1,15 +1,6 @@
-import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
-
-function buildGlm53Tuning(): string {
-	return `You are running on GLM 5.3: Opus 4.6-class agent behavior tuned toward Fable 5 decisiveness and GPT 5.5 outcome-first coding. Apply literal scopes literally - "every", "all", and "for each" mean the full set. Prefer sufficient context over exhaustive context, pick minor decisions and note them, and use matching tools or skills immediately instead of under-reaching.
-
-Calibrate deliberation. Use extended reasoning only for genuine multi-step uncertainty; routine classification, file edits, and lookups should be decided directly. A cheap tool call beats long internal debate: act, inspect evidence, and verify.
-
-Code toward the destination: define the outcome, constraints, and stopping condition, then work without mechanical step-by-step recitation. In ultrawork mode, maintain absolute certainty discipline: preserve the goal, prove completion with evidence, and do not deliver partial work.
-
-The intent gate routing line is non-optional every turn. For non-trivial tasks, call todo with atomic items before starting, keep exactly one item in progress, and complete each item immediately when done.`;
-}
+import type { BuildDynamicSystemPromptOptions } from "../../../dynamic-prompt/build.ts";
+import { buildGlm5Prompt } from "./glm-5.ts";
 
 export function buildGlm53Prompt(options: BuildDynamicSystemPromptOptions): string {
-	return buildDynamicSystemPrompt({ ...options, tuningSection: buildGlm53Tuning(), workstationDialect: "claude" });
+	return buildGlm5Prompt(options);
 }

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/glm-5.ts
@@ -1,16 +1,15 @@
 import { type BuildDynamicSystemPromptOptions, buildDynamicSystemPrompt } from "../../../dynamic-prompt/build.ts";
 import { buildExecutionToolingSection } from "./execution-tooling.ts";
 
-function buildClaudeOpus45Tuning(): string {
-	return `Break complex tasks into ordered steps with clear dependencies before executing. When a request covers a set of items, apply it to every item rather than only the first, and state the scope you applied.`;
-}
+export const GLM5_TUNING =
+	"A cheap tool call beats long internal debate: when reading, running, or searching can settle a question, do that and reason over the result. Work in short act-inspect-verify loops so an early mistake surfaces before later steps build on it.";
 
-export function buildClaudeOpus45Prompt(options: BuildDynamicSystemPromptOptions): string {
+export function buildGlm5Prompt(options: BuildDynamicSystemPromptOptions): string {
 	return buildDynamicSystemPrompt({
 		...options,
 		tuningSection: [
 			buildExecutionToolingSection({ toolNames: options.selectedTools, dialect: "claude" }),
-			buildClaudeOpus45Tuning(),
+			GLM5_TUNING,
 		]
 			.filter((section) => section.length > 0)
 			.join("\n\n"),

--- a/packages/coding-agent/test/suite/model-usability-budget.test.ts
+++ b/packages/coding-agent/test/suite/model-usability-budget.test.ts
@@ -122,8 +122,8 @@ describe("model usability budget", () => {
 			safetyMarginTokens: 8_192,
 			usable: false,
 		});
-		expect(error.projection.liveContextTokens).toBeGreaterThanOrEqual(318_290);
-		expect(error.projection.liveContextTokens).toBeLessThanOrEqual(318_360);
+		expect(error.projection.liveContextTokens).toBeGreaterThanOrEqual(318_240);
+		expect(error.projection.liveContextTokens).toBeLessThanOrEqual(318_330);
 		expect(error.projection.speculationLeadTokens).toBeGreaterThan(0);
 		expect(error.projection.requiredTokens).toBe(
 			error.projection.liveContextTokens +

--- a/packages/coding-agent/test/suite/prompt-presets-execution-tooling.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-execution-tooling.test.ts
@@ -68,9 +68,11 @@ const PRESET_DIALECT: ReadonlyArray<readonly [PromptPresetName, ExecutionTooling
 	["kimi-k3", "kimi"],
 	["kimi-k2-7", "kimi"],
 	["kimi-k2-6", "kimi"],
+	["glm-5.3", "claude"],
+	["glm-5.2", "claude"],
 ];
 
-const OUT_OF_SCOPE: readonly PromptPresetName[] = ["gpt-5.5", "grok-4.6", "deepseek-v4-flash", "glm-5.3"];
+const OUT_OF_SCOPE: readonly PromptPresetName[] = ["gpt-5.5", "grok-4.6", "deepseek-v4-flash"];
 
 const evalRules = () => EXECUTION_TOOLING_RULES.filter((rule) => rule.concern === "code-cell-routing");
 const monitorRules = () => EXECUTION_TOOLING_RULES.filter((rule) => rule.concern === "async-waiting");

--- a/packages/coding-agent/test/suite/prompt-presets-glm-5-2.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-glm-5-2.test.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getModels, getProviders } from "@earendil-works/pi-ai/compat";
 import { describe, expect, it } from "vitest";
+import { GLM5_TUNING } from "../../src/core/extensions/builtin/prompt-preset/glm-5.ts";
 import {
 	type PromptPresetSettings,
 	resolvePreset,
@@ -44,9 +45,7 @@ describe("GLM 5.2 prompt preset", () => {
 
 			// then
 			expect(preset?.name).toBe("glm-5.2");
-			expect(preset?.prompt).toContain("running on GLM 5.2");
-			expect(preset?.prompt).toContain("absolute certainty");
-			expect(preset?.prompt).toContain("todo");
+			expect(preset?.prompt).toContain(GLM5_TUNING);
 			expect(preset?.prompt).not.toContain("apply_patch");
 		},
 	);
@@ -76,7 +75,7 @@ describe("GLM 5.2 prompt preset", () => {
 
 		// then
 		expect(preset?.name).toBe("glm-5.2");
-		expect(preset?.prompt).toContain("running on GLM 5.2");
+		expect(preset?.prompt).toContain(GLM5_TUNING);
 	});
 
 	it("returns glm-5.2 preset for every GLM 5.2 built-in catalog model", () => {

--- a/packages/coding-agent/test/suite/prompt-presets-glm-5-3.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-glm-5-3.test.ts
@@ -1,6 +1,7 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getModels, getProviders } from "@earendil-works/pi-ai/compat";
 import { describe, expect, it } from "vitest";
+import { GLM5_TUNING } from "../../src/core/extensions/builtin/prompt-preset/glm-5.ts";
 import {
 	type PromptPresetSettings,
 	resolvePreset,
@@ -53,9 +54,7 @@ describe("GLM 5.3 prompt preset", () => {
 
 		// then
 		expect(preset?.name).toBe("glm-5.3");
-		expect(preset?.prompt).toContain("running on GLM 5.3");
-		expect(preset?.prompt).toContain("absolute certainty");
-		expect(preset?.prompt).toContain("todo");
+		expect(preset?.prompt).toContain(GLM5_TUNING);
 		expect(preset?.prompt).not.toContain("apply_patch");
 	});
 
@@ -84,7 +83,7 @@ describe("GLM 5.3 prompt preset", () => {
 
 		// then
 		expect(preset?.name).toBe("glm-5.3");
-		expect(preset?.prompt).toContain("running on GLM 5.3");
+		expect(preset?.prompt).toContain(GLM5_TUNING);
 	});
 
 	it("returns glm-5.3 preset for every GLM 5.3 built-in catalog model", () => {

--- a/packages/coding-agent/test/suite/prompt-presets-model-switch.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-model-switch.test.ts
@@ -96,7 +96,7 @@ describe("prompt preset model switching", () => {
 
 		// then
 		expect(promptChange?.systemPromptName).toBe("claude-opus-4-6");
-		expect(harness.session.systemPrompt).toContain("Choose an approach and commit to it");
+		expect(harness.session.systemPrompt).not.toContain("full set rather than the first item");
 		expect(harness.eventsOfType("system_prompt_change").map((event) => event.systemPromptName)).toEqual([
 			"claude-opus-4-6",
 		]);


### PR DESCRIPTION
## Summary

Prompt-engineering audit of the per-model presets that were not yet held to the standard of the dieted full cores (`claude-fable-5-1`, `claude-fable-5`, `gpt-5.6`), diagnosed A/B/C against each model's own guide before any edit, then fixed at the source (no patch-on-top).

Guides read: `claude.md` (Opus 4.6 general), Opus 4.7/4.8 overlays, **Prompting Claude Opus 5** (platform.claude.com), Fable 5 / 5.1 overlays, GPT-5.6, Kimi, Z.ai GLM-5 / GLM-5.3 docs + the GLM-5 paper findings.

## Diagnosis -> fix

| Preset | Defect | Category | Predicted impact | Fix |
|---|---|---|---|---|
| `claude-opus-4-6` | all 3 tuning lines now restate the dieted core (one-plan rule, scope fidelity, compaction) or are undocumented for 4.6 (scope literalism is a 4.7+ behavior) | A | duplicated rules compete for attention; zero behavior gain | tuning text removed; preset renders execution tooling + claude dialect only |
| `claude-opus-4-8` (+4.7) | compaction line and "do not re-derive" half duplicate the core | A | same | dropped |
| | guide: "spawns fewer subagents by default", steerable | **C** | under-delegation on fan-out work | same-turn fan-out sentence (guide's own example) |
| `claude-opus-5` | stop contract said 3x in one paragraph, scope 2x, quoted anti-example scaffolding, default-trait list, a Hard Limit covered by claim audit | A | the guide says re-check instructions *compound* Opus 5's own over-verification - a prompt that itself repeats the stop rule works against the guide | rebuilt on the Fable 5.1 skeleton: one home per rule, `## Scope` section |
| | missing the guide's outcome-first final-summary shape, claim audit, test scope / pre-existing-bug / blocked-part / ask-after-independent-work blocks | **C** | no final-summary contract; scope drift | added once each where they bind |
| | conciseness as a trait list | B | - | the guide's short conciseness instruction |
| `glm-5.2` / `glm-5.3` | lineage preamble with no behavioral consequence; "routing line non-optional" (dup); "ultrawork mode" (never defined); unconditional `todo` procedure (names a tool the turn may lack); "prove completion with evidence" (dup) | A | attention spent on model claims and undefined references | deleted |
| | **no execution-tooling stance at all** - the only Claude-dialect preset without eval/monitor routing (the test pinned it OUT_OF_SCOPE) | **C** | serial single-call loops + sleep/poll waits, worst on the model whose paper documents long-chain error compounding | shared `glm-5.ts` builder with the claude-dialect block + 2-sentence `GLM5_TUNING` (tool call over deliberation, short act-inspect-verify loops) |
| | two byte-identical files | A | drift | 5.2/5.3 are thin aliases over one builder (same base model, post-training delta only) |

### Shared core (dynamic-prompt), two sentences
- `working-task.ts`: conditional delegation rule ("When a delegation tool is available, hand sizeable independent tracks to subagents and keep working while they run; keep work you can finish in a few calls yourself"). Lived only in the full cores; now one home, so every thin preset and the fallback get it once.
- `style.ts`: the context-limits rule states its mechanism ("the harness compacts context automatically"), per claude.md's context-awareness guidance. Every Opus 4.x tuning copy of this line is deleted.

## Token evidence (o200k, eval+monitor+task+todo selected, rendered through the real builder)

| preset | before | after |
|---|---|---|
| fallback (no tools) | 1,557 | 1,596 (+39: the two core sentences) |
| claude-opus-4-6 | 1,945 | 1,916 |
| claude-opus-4-8 | 2,042 | 2,070 (+fan-out) |
| claude-opus-5 | 1,877 | 1,984 (missing documented behaviors added, repetition removed) |
| glm-5.2 / 5.3 | 1,776 | 1,966 (all of it the execution-tooling block) |

Redundancy audit over the rendered prompts: execution tooling, delegation rule, compaction fact, stop condition, one-plan rule each render exactly once in every touched preset; no `ultrawork` / `running on GLM` / house-style-on-Opus-5 leftovers.

## Tests
- `prompt-presets-execution-tooling`: glm-5.2/5.3 join the claude-dialect table (exactly-once + gating).
- `prompt-presets-glm-5-2/5-3`: prose pins replaced by shipped-copy containment of `GLM5_TUNING`.
- `prompt-presets-model-switch`: 4.6 switch asserts the 4.7 literalism sentinel is absent instead of pinning removed prose.
- `model-usability-budget`: live-context band recentered for the +39-token core (same recenter as #1302).

## Verification (bunshin, mengmotaMac, fresh worktree + `bun install`)
- `bunx biome check` on dynamic-prompt + prompt-preset + preset tests: clean
- `bunx tsc --noEmit` (root): exit 0
- `node scripts/check-pr-changelog.mjs --base origin/main`: PASS
- `bunx vitest --run` on 22 prompt/preset/budget/identity test files: 363/363 after the band recenter

Docs: `prompt-preset/AGENTS.md`, `prompt-preset/changes.md`, `dynamic-prompt/changes.md`, `packages/coding-agent/CHANGELOG.md` [Unreleased].

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Audits the Opus 4.x/5 and GLM 5.x prompt presets against their per-model guides and the dieted shared core, removing duplicated tuning text and adding the documented behaviors that were missing.

**Refactors**
- Opus 5 rebuilt on the Fable 5.1 skeleton; Opus 4.x tunings drop lines the core now carries.
- GLM 5.2/5.3 share one builder and lose the lineage preamble, undefined "ultrawork" reference, and unconditional `todo` procedure.
- Shared core gains the conditional delegation rule and states the auto-compaction mechanism.

**Bug Fixes**
- Opus 5 gains the guide's outcome-first final-summary shape and the 5.1 scope blocks it lacked.
- Opus 4.7/4.8 gain the same-turn subagent fan-out direction.
- GLM 5.2/5.3 gain the eval/monitor execution-tooling stance.

<sup>Written for commit ef988f17ae92ed54555d0199de2f50d63564916f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

