### PR TITLE
fix(codemode): keep Bun child-process output inside the JS eval cell

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- JavaScript eval cells no longer leak child-process output onto the host terminal under Bun: `Bun.$` commands awaited without `.quiet()`/`.text()` and `Bun.spawn` children with the default stderr now route their output into the cell's stdout/stderr streams instead of the inherited fd 1/2 that the interactive TUI owns.
+
 ### Removed
 
 ## [2026.9.3] - 2026-09-03

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,27 @@
 # senpi-codemode fork changes
 
+## Bun child-process output stays inside the JS cell (2026-09-03)
+
+### What changed
+
+- New `src/kernels/js/worker-shell-capture.js` (+ `.d.ts`): `installShellCapture({ isActive, emitText })` replaces `Bun.$` and `Bun.spawn` on the worker's `Bun` global. While a cell is active, every `Bun.$` promise is switched to native quiet mode before its command starts and its captured stdout/stderr are echoed once into the cell's `text` stream when it settles — unless the cell reads it through `.quiet()`/`.text()`/`.json()`/`.lines()`/`.arrayBuffer()`/`.bytes()`/`.blob()`, which Bun itself keeps silent. Shell-level `env`/`cwd`/`nothrow`/`throws` chain on the captured shell; the `Shell`/`ShellPromise`/`ShellError`/`braces`/`escape` statics are carried over. `Bun.spawn` calls that leave `stderr` at its default get `stderr: "pipe"` and the pipe is drained into the cell's stderr stream; explicit `stderr`/`stdio` choices pass through. Outside an active cell both surfaces behave exactly as before (inline-worker mode shares the host globals). On Node the installer is a no-op.
+- `src/kernels/js/worker-runtime.js` installs the capture beside the existing `console`/`process.stdout.write` routing and restores it from `__senpi_restore_console__`.
+- `test/js-kernel-shell-capture.test.ts` pins the contract against a fake that mirrors the verified Bun 1.4 `ShellPromise` behavior (lazy start on `then`, internal quiet for the read methods, same-object chaining); `test/js-kernel-shell-capture-bun.test.ts` runs the real kernel under `bun` (skipped when `bun` is absent) and asserts the markers never reach the driver's fd 1/2.
+
+### Why
+
+- Bun's shell streams a command's output to the process' fd 1/2 unless `.quiet()` is applied or the output is read through a `.text()`-style helper (verified on bun 1.4.0: `await Bun.$\`echo x\`.nothrow()` prints `x` to stdout AND captures it), and `Bun.spawn` defaults `stderr` to `inherit`. Inside the JS kernel those fds are the interactive TUI's terminal, so a cell doing `await $\`vibe-notion page get … --pretty\`.nothrow().then(r => r.stdout)` dumped the whole pretty-printed JSON onto the screen (observed 2026-09-03: a Notion page's block JSON landed in the user's editor and was pasted into the next prompt). The existing `routeWrite` only intercepts JS-level `process.stdout.write`; native child-output writes bypass it.
+- Echoing the captured output into the cell instead of only silencing it keeps Bun's documented "the output is visible" semantics at the correct sink, consistent with how `console.log` is routed today.
+
+### Why an extension could not handle it
+
+- The worker's `Bun` global and the cell-activity gate (`#hooks`) live inside this package's worker runtime; nothing outside the worker can wrap `Bun.$` before a cell's first `then` or attribute an emission to the running cell.
+
+### Expected merge conflict zones
+
+- LOW in `src/kernels/js/worker-runtime.js` around `#installGlobals` (import plus install/restore lines).
+- NONE for the new module and tests.
+
 ## Binary skill resolution and stdout-safe miss reporting (2026-09-02)
 
 ### What changed

--- a/packages/senpi-codemode/src/kernels/js/worker-runtime.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-runtime.js
@@ -3,6 +3,7 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, normalize, resolve, sep } from "node:path";
 import { inspect } from "node:util";
 import { awaitMaybePromise, indirectEval, wrapUserCode } from "./worker-indirect-eval.js";
+import { installShellCapture } from "./worker-shell-capture.js";
 
 const PREPARED_CELL_PREFIX = "/*senpi:prepared-cell*/";
 const INTERNAL_URL = /^([a-z][a-z0-9+.-]*):\/\/(.*)$/iu;
@@ -84,11 +85,16 @@ export class JsWorkerRuntime {
 		process.stderr.write = routeWrite(process.stderr, originalStderrWrite, "stderr");
 		console.log = (...values) => this.#emitText("stdout", `${values.map(formatValue).join(" ")}\n`);
 		console.error = (...values) => this.#emitText("stderr", `${values.map(formatValue).join(" ")}\n`);
+		const restoreShellCapture = installShellCapture({
+			isActive: () => this.#hooks !== null,
+			emitText: (stream, data) => this.#emitText(stream, data),
+		});
 		globalThis.__senpi_restore_console__ = () => {
 			console.log = originalLog;
 			console.error = originalError;
 			process.stdout.write = originalStdoutWrite;
 			process.stderr.write = originalStderrWrite;
+			restoreShellCapture();
 		};
 	}
 

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
@@ -1,0 +1,10 @@
+export type ShellCaptureStream = "stdout" | "stderr";
+
+export type ShellCaptureRestore = () => void;
+
+export interface ShellCaptureOptions {
+	readonly isActive: () => boolean;
+	readonly emitText: (stream: ShellCaptureStream, data: string) => void;
+}
+
+export function installShellCapture(options: ShellCaptureOptions): ShellCaptureRestore;

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
@@ -1,0 +1,126 @@
+const SHELL_CONFIG_METHODS = ["env", "cwd", "nothrow", "throws"];
+const SHELL_READ_METHODS = ["text", "json", "lines", "arrayBuffer", "bytes", "blob"];
+
+export function installShellCapture(options) {
+	const bun = globalThis.Bun;
+	if (!isBunRuntime(bun)) return () => {};
+	const originalShell = bun.$;
+	const originalSpawn = bun.spawn;
+	bun.$ = capturedShell(originalShell, options);
+	bun.spawn = capturedSpawn(originalSpawn, options);
+	return () => {
+		bun.$ = originalShell;
+		bun.spawn = originalSpawn;
+	};
+}
+
+function isBunRuntime(bun) {
+	return bun !== null && typeof bun === "object" && typeof bun.$ === "function" && typeof bun.spawn === "function";
+}
+
+function capturedShell(originalShell, options) {
+	const shell = (strings, ...expressions) => {
+		const promise = originalShell(strings, ...expressions);
+		return options.isActive() ? captureShellPromise(promise, options.emitText) : promise;
+	};
+	for (const key of Object.keys(originalShell)) shell[key] = originalShell[key];
+	for (const method of SHELL_CONFIG_METHODS) {
+		shell[method] = (...args) => {
+			originalShell[method](...args);
+			return shell;
+		};
+	}
+	return shell;
+}
+
+function captureShellPromise(promise, emitText) {
+	const prototype = Object.getPrototypeOf(promise);
+	let echo = true;
+	const echoOnce = (output) => {
+		if (!echo) return;
+		echo = false;
+		emitShellOutput(output, emitText);
+	};
+	prototype.quiet.call(promise);
+	promise.quiet = function quiet() {
+		echo = false;
+		return prototype.quiet.call(this);
+	};
+	for (const method of SHELL_READ_METHODS) {
+		if (typeof prototype[method] !== "function") continue;
+		promise[method] = function read(...args) {
+			echo = false;
+			return prototype[method].apply(this, args);
+		};
+	}
+	promise.then = function then(onFulfilled, onRejected) {
+		return prototype.then.call(
+			this,
+			(output) => {
+				echoOnce(output);
+				return onFulfilled ? onFulfilled(output) : output;
+			},
+			(error) => {
+				echoOnce(error);
+				if (onRejected) return onRejected(error);
+				throw error;
+			},
+		);
+	};
+	return promise;
+}
+
+function emitShellOutput(output, emitText) {
+	if (output === null || typeof output !== "object") return;
+	const stdout = outputText(output.stdout);
+	if (stdout) emitText("stdout", stdout);
+	const stderr = outputText(output.stderr);
+	if (stderr) emitText("stderr", stderr);
+}
+
+function outputText(value) {
+	if (value instanceof Uint8Array) return new TextDecoder().decode(value);
+	return typeof value === "string" ? value : "";
+}
+
+function capturedSpawn(originalSpawn, options) {
+	return (...args) => {
+		if (!options.isActive()) return originalSpawn(...args);
+		const [first, second] = args;
+		if (Array.isArray(first)) {
+			const spawnOptions = second === undefined ? {} : second;
+			if (!needsStderrCapture(spawnOptions)) return originalSpawn(...args);
+			return drainStderr(originalSpawn(first, { ...spawnOptions, stderr: "pipe" }), options.emitText);
+		}
+		if (!needsStderrCapture(first)) return originalSpawn(...args);
+		return drainStderr(originalSpawn({ ...first, stderr: "pipe" }), options.emitText);
+	};
+}
+
+function needsStderrCapture(spawnOptions) {
+	return (
+		spawnOptions !== null &&
+		typeof spawnOptions === "object" &&
+		spawnOptions.stdio === undefined &&
+		spawnOptions.stderr === undefined
+	);
+}
+
+function drainStderr(child, emitText) {
+	const stream = child?.stderr;
+	if (!(stream instanceof ReadableStream)) return child;
+	void readStream(stream, emitText).catch((error) => {
+		emitText("stderr", `[spawn stderr capture failed: ${String(error)}]\n`);
+	});
+	return child;
+}
+
+async function readStream(stream, emitText) {
+	const decoder = new TextDecoder();
+	for await (const chunk of stream) {
+		const text = decoder.decode(chunk, { stream: true });
+		if (text) emitText("stderr", text);
+	}
+	const tail = decoder.decode();
+	if (tail) emitText("stderr", tail);
+}

--- a/packages/senpi-codemode/test/js-kernel-shell-capture-bun.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture-bun.test.ts
@@ -1,0 +1,88 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { KernelToHostMessage } from "../src/bridge/protocol.ts";
+
+const kernelModulePath = fileURLToPath(new URL("../src/kernels/js/context-manager.ts", import.meta.url));
+const bunAvailable = spawnSync("bun", ["--version"], { encoding: "utf8" }).status === 0;
+
+type DriverReport = {
+	readonly mode: string;
+	readonly result: Extract<KernelToHostMessage, { type: "result" }>;
+	readonly messages: readonly KernelToHostMessage[];
+};
+
+type DriverRun = {
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly report: DriverReport;
+};
+
+function driverSource(): string {
+	return [
+		'import { writeFile } from "node:fs/promises";',
+		`import { JavaScriptKernel } from ${JSON.stringify(kernelModulePath)};`,
+		"const [code, reportPath] = process.argv.slice(2);",
+		'const kernel = new JavaScriptKernel({ sessionId: "shell-capture", cwd: process.cwd(), parallelPoolWidth: 1 });',
+		"const messages = [];",
+		'const result = await kernel.run({ cellId: "shell-capture-cell", code, timeoutMs: 20_000, onMessage: (message) => messages.push(message) });',
+		"await kernel.close();",
+		'await writeFile(reportPath, JSON.stringify({ mode: kernel.mode, result, messages }), "utf8");',
+	].join("\n");
+}
+
+async function runCellUnderBun(code: string): Promise<DriverRun> {
+	const root = await mkdtemp(join(tmpdir(), "senpi-shell-capture-"));
+	try {
+		const driverPath = join(root, "driver.ts");
+		const reportPath = join(root, "report.json");
+		await writeFile(driverPath, driverSource(), "utf8");
+		const run = spawnSync("bun", [driverPath, code, reportPath], { encoding: "utf8", cwd: root, timeout: 60_000 });
+		if (run.status !== 0) throw new Error(`bun driver exited with ${run.status}: ${run.stderr}`);
+		const report: DriverReport = JSON.parse(await readFile(reportPath, "utf8"));
+		return { stdout: run.stdout, stderr: run.stderr, report };
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+function textOf(messages: readonly KernelToHostMessage[], stream: "stdout" | "stderr"): string {
+	return messages
+		.flatMap((message) => (message.type === "text" && message.stream === stream ? [message.data] : []))
+		.join("");
+}
+
+describe.skipIf(!bunAvailable)("JavaScript kernel under Bun keeps child output off the host terminal", () => {
+	it("Given a cell awaiting `Bun.$` without quiet when it runs then the output lands in the cell, not on fd 1", async () => {
+		const run = await runCellUnderBun(
+			"const r = await Bun.$`printf SHELL_LEAK_MARKER; sh -c 'printf SHELL_ERR_MARKER >&2'`.nothrow(); return r.exitCode",
+		);
+
+		expect(run.report.mode).toBe("worker");
+		expect(run.report.result).toMatchObject({ ok: true, valueRepr: "0" });
+		expect(run.stdout).not.toContain("SHELL_LEAK_MARKER");
+		expect(run.stderr).not.toContain("SHELL_ERR_MARKER");
+		expect(textOf(run.report.messages, "stdout")).toBe("SHELL_LEAK_MARKER");
+		expect(textOf(run.report.messages, "stderr")).toBe("SHELL_ERR_MARKER");
+	});
+
+	it("Given a cell reading `Bun.$` through `.text()` when it runs then nothing is echoed anywhere", async () => {
+		const run = await runCellUnderBun("return await Bun.$`printf TEXT_MARKER`.text()");
+
+		expect(run.report.result).toMatchObject({ ok: true, valueRepr: '"TEXT_MARKER"' });
+		expect(run.stdout).not.toContain("TEXT_MARKER");
+		expect(textOf(run.report.messages, "stdout")).toBe("");
+	});
+
+	it("Given a cell spawning a child with the default stderr when it runs then the child's stderr stays off fd 2", async () => {
+		const run = await runCellUnderBun(
+			'const child = Bun.spawn(["sh", "-c", "printf SPAWN_LEAK_MARKER >&2"]); return await child.exited',
+		);
+
+		expect(run.report.result).toMatchObject({ ok: true, valueRepr: "0" });
+		expect(run.stderr).not.toContain("SPAWN_LEAK_MARKER");
+	});
+});

--- a/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
@@ -1,0 +1,393 @@
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { ShellCaptureOptions, ShellCaptureRestore } from "../src/kernels/js/worker-shell-capture.d.ts";
+
+type InstallShellCapture = (options: ShellCaptureOptions) => ShellCaptureRestore;
+
+const captureModuleUrl = pathToFileURL(join(process.cwd(), "src", "kernels", "js", "worker-shell-capture.js")).href;
+
+function isShellCaptureModule(value: unknown): value is { readonly installShellCapture: InstallShellCapture } {
+	return (
+		typeof value === "object" && value !== null && typeof Reflect.get(value, "installShellCapture") === "function"
+	);
+}
+
+async function loadInstallShellCapture(): Promise<InstallShellCapture> {
+	const loaded: unknown = await import(captureModuleUrl);
+	if (!isShellCaptureModule(loaded)) throw new Error("worker-shell-capture.js does not export installShellCapture");
+	return loaded.installShellCapture;
+}
+
+type EmittedText = { readonly stream: "stdout" | "stderr"; readonly data: string };
+
+type FakeShellOutput = {
+	readonly stdout: Buffer;
+	readonly stderr: Buffer;
+	readonly exitCode: number;
+};
+
+class FakeShellError extends Error implements FakeShellOutput {
+	readonly name = "ShellError";
+	readonly stdout: Buffer;
+	readonly stderr: Buffer;
+	readonly exitCode: number;
+
+	constructor(output: FakeShellOutput) {
+		super(`Failed with exit code ${output.exitCode}`);
+		this.stdout = output.stdout;
+		this.stderr = output.stderr;
+		this.exitCode = output.exitCode;
+	}
+}
+
+/**
+ * Mirrors the Bun 1.4 ShellPromise contract that matters here (verified against bun 1.4.0):
+ * - the command starts lazily on the first `then` call;
+ * - without `quiet()`, the child's output is streamed to the process' fd 1/2 as it runs;
+ * - `text()`/`json()`/`lines()` switch to quiet mode INTERNALLY (not via the instance `quiet` property);
+ * - `quiet()`/`nothrow()`/`throws()` return the same promise.
+ */
+class FakeShellPromise extends Promise<FakeShellOutput> {
+	static get [Symbol.species](): PromiseConstructor {
+		return Promise;
+	}
+
+	readonly printed: string[];
+	#quiet = false;
+	#nothrow = false;
+	#started = false;
+	readonly #output: FakeShellOutput;
+
+	constructor(output: FakeShellOutput, printed: string[]) {
+		let settle: (value: FakeShellOutput) => void = () => {};
+		let fail: (error: unknown) => void = () => {};
+		super((resolve, reject) => {
+			settle = resolve;
+			fail = reject;
+		});
+		this.#output = output;
+		this.printed = printed;
+		this.#start = () => {
+			if (this.#started) return;
+			this.#started = true;
+			if (!this.#quiet) this.printed.push(this.#output.stdout.toString(), this.#output.stderr.toString());
+			if (this.#output.exitCode !== 0 && !this.#nothrow) fail(new FakeShellError(this.#output));
+			else settle(this.#output);
+		};
+	}
+
+	#start: () => void;
+
+	quiet(): this {
+		this.#quiet = true;
+		return this;
+	}
+
+	nothrow(): this {
+		this.#nothrow = true;
+		return this;
+	}
+
+	throws(shouldThrow: boolean): this {
+		this.#nothrow = !shouldThrow;
+		return this;
+	}
+
+	async text(): Promise<string> {
+		this.#quiet = true;
+		const result = await this.then((value) => value);
+		return result.stdout.toString();
+	}
+
+	// biome-ignore lint/suspicious/noThenProperty: intentional thenable — Bun's ShellPromise starts the command on its own then()
+	override then<TResult1 = FakeShellOutput, TResult2 = never>(
+		onFulfilled?: ((value: FakeShellOutput) => TResult1 | PromiseLike<TResult1>) | null,
+		onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+	): Promise<TResult1 | TResult2> {
+		this.#start();
+		return super.then(onFulfilled, onRejected);
+	}
+}
+
+type FakeSpawnCall = { readonly cmd: readonly string[]; readonly options: Record<string, unknown> };
+
+type FakeBun = {
+	$: FakeShell;
+	spawn: (...args: unknown[]) => FakeSubprocess;
+	spawnSync: (...args: unknown[]) => unknown;
+};
+
+type FakeShell = {
+	(strings: TemplateStringsArray, ...expressions: unknown[]): FakeShellPromise;
+	nothrow(): FakeShell;
+	throws(shouldThrow: boolean): FakeShell;
+	env(values?: Record<string, string>): FakeShell;
+	cwd(path?: string): FakeShell;
+	braces(pattern: string): string[];
+	escape(value: string): string;
+	Shell: () => void;
+	ShellPromise: typeof FakeShellPromise;
+	ShellError: typeof FakeShellError;
+	calls: string[];
+};
+
+type FakeSubprocess = {
+	readonly stderr: ReadableStream<Uint8Array> | undefined;
+	readonly exited: Promise<number>;
+};
+
+function output(stdout: string, stderr = "", exitCode = 0): FakeShellOutput {
+	return { stdout: Buffer.from(stdout), stderr: Buffer.from(stderr), exitCode };
+}
+
+function createFakeBun(): {
+	bun: FakeBun;
+	printed: string[];
+	spawnCalls: FakeSpawnCall[];
+	outputs: Map<string, FakeShellOutput>;
+} {
+	const printed: string[] = [];
+	const spawnCalls: FakeSpawnCall[] = [];
+	const outputs = new Map<string, FakeShellOutput>();
+	const shell = ((strings: TemplateStringsArray) => {
+		const command = strings.join("");
+		return new FakeShellPromise(outputs.get(command) ?? output(""), printed);
+	}) as FakeShell;
+	shell.calls = [];
+	shell.nothrow = () => {
+		shell.calls.push("nothrow");
+		return shell;
+	};
+	shell.throws = (shouldThrow) => {
+		shell.calls.push(`throws:${shouldThrow}`);
+		return shell;
+	};
+	shell.env = () => {
+		shell.calls.push("env");
+		return shell;
+	};
+	shell.cwd = () => {
+		shell.calls.push("cwd");
+		return shell;
+	};
+	shell.braces = (pattern) => [pattern];
+	shell.escape = (value) => value;
+	shell.Shell = () => {};
+	shell.ShellPromise = FakeShellPromise;
+	shell.ShellError = FakeShellError;
+	const spawn = (...args: unknown[]): FakeSubprocess => {
+		const [first, second] = args;
+		const options: Record<string, unknown> = Array.isArray(first)
+			? { ...(second as Record<string, unknown> | undefined) }
+			: { ...(first as Record<string, unknown>) };
+		const cmd = Array.isArray(first) ? (first as string[]) : (options.cmd as string[]);
+		spawnCalls.push({ cmd, options });
+		const stderr =
+			options.stderr === "pipe"
+				? new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(new TextEncoder().encode(`child stderr for ${cmd.join(" ")}\n`));
+							controller.close();
+						},
+					})
+				: undefined;
+		return { stderr, exited: Promise.resolve(0) };
+	};
+	const bun: FakeBun = { $: shell, spawn, spawnSync: () => ({}) };
+	return { bun, printed, spawnCalls, outputs };
+}
+
+function installFakeBun(): ReturnType<typeof createFakeBun> {
+	const fake = createFakeBun();
+	Object.defineProperty(globalThis, "Bun", { value: fake.bun, configurable: true, writable: true });
+	return fake;
+}
+
+function emitter(): { emitted: EmittedText[]; emitText: (stream: "stdout" | "stderr", data: string) => void } {
+	const emitted: EmittedText[] = [];
+	return { emitted, emitText: (stream, data) => emitted.push({ stream, data }) };
+}
+
+describe("JS kernel shell output capture", () => {
+	const hadBun = Object.hasOwn(globalThis, "Bun");
+	const originalBun: unknown = Reflect.get(globalThis, "Bun");
+	let restore: ShellCaptureRestore = () => {};
+	let installShellCapture: InstallShellCapture = () => () => {};
+
+	beforeAll(async () => {
+		installShellCapture = await loadInstallShellCapture();
+	});
+
+	afterEach(() => {
+		restore();
+		restore = () => {};
+		if (hadBun) Object.defineProperty(globalThis, "Bun", { value: originalBun, configurable: true, writable: true });
+		else Reflect.deleteProperty(globalThis, "Bun");
+	});
+
+	it("Given no Bun global when capture installs then it is a no-op with a callable restore", () => {
+		Reflect.deleteProperty(globalThis, "Bun");
+		const { emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+		expect(typeof restore).toBe("function");
+		expect(Object.hasOwn(globalThis, "Bun")).toBe(false);
+	});
+
+	it("Given an active cell when `$` is awaited without quiet then nothing prints and the output is echoed into the cell", async () => {
+		const fake = installFakeBun();
+		fake.outputs.set("echo hi", output("hi\n", "warn\n"));
+		const { emitted, emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		const result = await fake.bun.$`echo hi`;
+
+		expect(result.stdout.toString()).toBe("hi\n");
+		expect(fake.printed).toEqual([]);
+		expect(emitted).toEqual([
+			{ stream: "stdout", data: "hi\n" },
+			{ stream: "stderr", data: "warn\n" },
+		]);
+	});
+
+	it("Given an active cell when `.nothrow()` is awaited then the failing command's output is echoed exactly once", async () => {
+		const fake = installFakeBun();
+		fake.outputs.set("exit 3", output("partial\n", "boom\n", 3));
+		const { emitted, emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		const promise = fake.bun.$`exit 3`.nothrow();
+		const [first, second] = await Promise.all([promise, promise]);
+
+		expect(first.exitCode).toBe(3);
+		expect(second).toBe(first);
+		expect(fake.printed).toEqual([]);
+		expect(emitted).toEqual([
+			{ stream: "stdout", data: "partial\n" },
+			{ stream: "stderr", data: "boom\n" },
+		]);
+	});
+
+	it("Given an active cell when a throwing command rejects then the rejection propagates and its output is echoed", async () => {
+		const fake = installFakeBun();
+		fake.outputs.set("exit 2", output("", "fatal\n", 2));
+		const { emitted, emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		await expect(fake.bun.$`exit 2`).rejects.toMatchObject({ name: "ShellError", exitCode: 2 });
+
+		expect(fake.printed).toEqual([]);
+		expect(emitted).toEqual([{ stream: "stderr", data: "fatal\n" }]);
+	});
+
+	it("Given an active cell when `.text()` or `.quiet()` reads the output then nothing is echoed", async () => {
+		const fake = installFakeBun();
+		fake.outputs.set("echo text", output("text\n"));
+		fake.outputs.set("echo quiet", output("quiet\n"));
+		const { emitted, emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		const text = await fake.bun.$`echo text`.text();
+		const quiet = await fake.bun.$`echo quiet`.quiet();
+
+		expect(text).toBe("text\n");
+		expect(quiet.stdout.toString()).toBe("quiet\n");
+		expect(fake.printed).toEqual([]);
+		expect(emitted).toEqual([]);
+	});
+
+	it("Given no active cell when `$` runs then the original shell promise is returned untouched", async () => {
+		const fake = installFakeBun();
+		fake.outputs.set("echo idle", output("idle\n"));
+		const { emitted, emitText } = emitter();
+		restore = installShellCapture({ isActive: () => false, emitText });
+
+		const promise = fake.bun.$`echo idle`;
+		await promise;
+
+		expect(promise).toBeInstanceOf(FakeShellPromise);
+		expect(fake.printed).toEqual(["idle\n", ""]);
+		expect(emitted).toEqual([]);
+	});
+
+	it("Given the captured shell when shell-level configuration methods are used then they chain on the captured shell", () => {
+		const fake = installFakeBun();
+		const original = fake.bun.$;
+		const { emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		const captured = fake.bun.$;
+		expect(captured).not.toBe(original);
+		expect(captured.nothrow()).toBe(captured);
+		expect(captured.throws(true)).toBe(captured);
+		expect(captured.env({ A: "1" })).toBe(captured);
+		expect(captured.cwd("/tmp")).toBe(captured);
+		expect(original.calls).toEqual(["nothrow", "throws:true", "env", "cwd"]);
+		expect(captured.braces("a{b,c}")).toEqual(["a{b,c}"]);
+		expect(captured.escape("x")).toBe("x");
+		expect(captured.Shell).toBe(original.Shell);
+		expect(captured.ShellPromise).toBe(FakeShellPromise);
+		expect(captured.ShellError).toBe(FakeShellError);
+	});
+
+	it("Given a captured runtime when restore runs then the original Bun surfaces come back", () => {
+		const fake = installFakeBun();
+		const originalShell = fake.bun.$;
+		const originalSpawn = fake.bun.spawn;
+		const { emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+		expect(fake.bun.$).not.toBe(originalShell);
+		expect(fake.bun.spawn).not.toBe(originalSpawn);
+
+		restore();
+		restore = () => {};
+
+		expect(fake.bun.$).toBe(originalShell);
+		expect(fake.bun.spawn).toBe(originalSpawn);
+	});
+
+	it("Given an active cell when Bun.spawn runs with the default stderr then stderr is piped and drained into the cell", async () => {
+		const fake = installFakeBun();
+		const { emitted, emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		const child = fake.bun.spawn(["sh", "-c", "echo x >&2"]);
+		await child.exited;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(fake.spawnCalls).toEqual([{ cmd: ["sh", "-c", "echo x >&2"], options: { stderr: "pipe" } }]);
+		expect(emitted).toEqual([{ stream: "stderr", data: "child stderr for sh -c echo x >&2\n" }]);
+	});
+
+	it("Given an active cell when Bun.spawn uses the object form with the default stderr then stderr is piped as well", async () => {
+		const fake = installFakeBun();
+		const { emitted, emitText } = emitter();
+		restore = installShellCapture({ isActive: () => true, emitText });
+
+		fake.bun.spawn({ cmd: ["ls"], stdout: "pipe" });
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(fake.spawnCalls).toEqual([{ cmd: ["ls"], options: { cmd: ["ls"], stdout: "pipe", stderr: "pipe" } }]);
+		expect(emitted).toEqual([{ stream: "stderr", data: "child stderr for ls\n" }]);
+	});
+
+	it("Given explicit stdio choices or no active cell when Bun.spawn runs then the options pass through unchanged", async () => {
+		const fake = installFakeBun();
+		const { emitted, emitText } = emitter();
+		let active = true;
+		restore = installShellCapture({ isActive: () => active, emitText });
+
+		fake.bun.spawn(["a"], { stderr: "inherit" });
+		fake.bun.spawn(["b"], { stdio: ["ignore", "pipe", "inherit"] });
+		active = false;
+		fake.bun.spawn(["c"]);
+		await new Promise<void>((resolve) => setImmediate(resolve));
+
+		expect(fake.spawnCalls).toEqual([
+			{ cmd: ["a"], options: { stderr: "inherit" } },
+			{ cmd: ["b"], options: { stdio: ["ignore", "pipe", "inherit"] } },
+			{ cmd: ["c"], options: {} },
+		]);
+		expect(emitted).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

Under Bun, `Bun.$` streams a command's output to the process' fd 1/2 unless `.quiet()` is applied or a `.text()`-style reader is used, and `Bun.spawn` inherits stderr by default. Inside the JS eval kernel worker those fds are the interactive TUI's terminal, so a cell such as

```js
const r = await $`vibe-notion page get <id> --pretty`.nothrow().then(r => r.stdout.toString())
```

dumped the whole pretty-printed JSON straight onto the screen (observed 2026-09-03: a Notion page's block JSON landed in the user's editor and was pasted into the next prompt). The existing `routeWrite` only intercepts JS-level `process.stdout.write`; native child-output writes bypass it.

## Fix

New `src/kernels/js/worker-shell-capture.js` (+ `.d.ts`), installed by `worker-runtime.js` beside the existing console/stdout routing and restored from `__senpi_restore_console__`:

- While a cell is active, every `Bun.$` promise is switched to native quiet mode before its command starts and its captured stdout/stderr are echoed once into the cell's text stream on settle. Reads through `.quiet()`/`.text()`/`.json()`/`.lines()`/`.arrayBuffer()`/`.bytes()`/`.blob()` stay silent, matching Bun.
- `env`/`cwd`/`nothrow`/`throws` chain on the captured shell; `Shell`/`ShellPromise`/`ShellError`/`braces`/`escape` are carried over.
- `Bun.spawn` calls that leave `stderr` at its default get `stderr: "pipe"` drained into the cell's stderr stream; explicit `stderr`/`stdio` choices pass through.
- Outside an active cell both surfaces are untouched (inline-worker mode shares the host globals). On Node the installer is a no-op.

## Tests

- `test/js-kernel-shell-capture.test.ts`: contract against a fake mirroring the verified Bun 1.4.0 `ShellPromise` behavior (lazy start on `then`, internal quiet for read methods, same-object chaining).
- `test/js-kernel-shell-capture-bun.test.ts`: real kernel under `bun` (skipped when `bun` is absent); asserts the markers never reach the driver's fd 1/2 and do land in the cell's text messages.
- RED before the fix on mengmotaMac (bun 1.4.0): `expected 'SHELL_LEAK_MARKER' not to contain 'SHELL_LEAK_MARKER'`, `expected 'SPAWN_LEAK_MARKER' not to contain 'SPAWN_LEAK_MARKER'`.
- Mutation checks (each fails the suite): removing the native `quiet()` call, removing the runtime wiring, disabling the spawn stderr capture.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JS eval cells leaking Bun child-process output onto the host terminal. `Bun.$` commands and `Bun.spawn` children with the default stderr now route their output into the cell's stdout/stderr streams instead of the inherited fd 1/2 that the TUI owns.

**Bug Fixes**

- Wraps `Bun.$` and `Bun.spawn` on the worker global while a cell is active; shell output is echoed once on settle unless read through `.quiet()`/`.text()`/`.json()`/`.lines()`/`.arrayBuffer()`/`.bytes()`/`.blob()`.
- Default-stderr spawns get a piped stderr drained into the cell; explicit `stderr`/`stdio` choices pass through unchanged.
- Outside an active cell both surfaces behave as before, and on Node the installer is a no-op.
- Adds tests pinning the contract against a fake shell and asserting markers stay off fd 1/2 under a real Bun kernel.

<sup>Written for commit 5fa3502f86cd02547285ccdb9726bbb34da82202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

