### PR TITLE
fix(claude-sdk-oauth): state host-tool denial as a fact, not an instruction

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Claude SDK OAuth classifies Fable-style "requires usage credits" failures as a non-retryable entitlement instead of a rate limit, so the account is not blocked for 60s and AgentSession can fall through to the next model ([#709](https://github.com/code-yeongyu/senpi/issues/709)).
 - Print mode (`-p` / `--mode json`) now writes a stderr notice when retry fallback substitutes a model, so silent wrong-model answers are visible without corrupting JSON stdout ([oh-my-openagent#7626](https://github.com/code-yeongyu/oh-my-openagent/issues/7626)).
+- Claude SDK OAuth host-tool denial now states that Senpi executes the tool on the host and returns the result as the next user message, so models no longer treat "Do not retry with other tools; end the turn." as a failure ([#784](https://github.com/code-yeongyu/senpi/issues/784), [oh-my-openagent#7115](https://github.com/code-yeongyu/oh-my-openagent/issues/7115)).
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/AGENTS.md
@@ -36,7 +36,7 @@ Generated: 2026-08-07 | Commit: `4f26b8282`
 - Fork point is the last assistant boundary strictly before the divergence.
 - Non-fork reattach passes `resume` and must omit `sessionId` (the SDK rejects the pair). Fork adds `resumeSessionAt` + `forkSession`.
 - Abort never taints and never flattens; `interrupt()` receipts gate keep-vs-close.
-- Fingerprint normalizes the `Current date:` line (no midnight retirement); cwd and other regions stay fail-closed. `config-dir` lane failover is the one declared residual that still flattens.
+- Fingerprint normalizes the `Current date:` line (no midnight retirement); cwd and other regions stay fail-closed. Host-tool denial copy is versioned by `HOST_TOOL_POLICY_FINGERPRINT` in `toolsetHash`; bump it when the copy changes so resident sessions re-fingerprint instead of keeping the old reason. `config-dir` lane failover is the one declared residual that still flattens.
 - Every main turn emits exactly one continuity observation; TUI notices only for degradations.
 - `resumeMode: "off"` / `SENPI_CLAUDE_SDK_OAUTH_RESUME=off` restores legacy per-turn behavior.
 - `full`/`override` prompt modes default `settingSources` to `[]` (no CLAUDE.md double-injection). The CLI still prepends its own agent preamble; `full` means senpi's prompt arrives intact, not alone.

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -23,7 +23,7 @@
 
 ### What changed
 
-- `tools.ts`: `TOOL_EXECUTION_DENIED_MESSAGE` and `HOST_TOOL_EXECUTION_DENIED_MESSAGE` now state that Senpi executes the tool on the host and returns the result as the next user message; the copy no longer tells the model to end the turn. `HOST_TOOL_POLICY_FINGERPRINT` is `host-tool-denial-v2` so resident sessions re-fingerprint instead of silently keeping the old denial text. PreToolUse still denies with `continue: false` and `permissionDecisionReason`; there is no Stop hook.
+- `tools.ts`: `TOOL_EXECUTION_DENIED_MESSAGE` and `HOST_TOOL_EXECUTION_DENIED_MESSAGE` now state that Senpi executes the tool on the host and returns the result as the next user message; the copy no longer tells the model to end the turn. `HOST_TOOL_POLICY_FINGERPRINT` is `host-tool-denial-v2` so resident sessions re-fingerprint instead of silently keeping the old denial text; because `toolsetHash` is also persisted in the restart sidecar, the first admission after upgrading cold-seeds once (`flatten` / `options_changed`) instead of resuming the pre-bump SDK session - intended, pinned by `claude-sdk-oauth-fingerprint.test.ts`. PreToolUse still denies with `continue: false` and `permissionDecisionReason`; there is no Stop hook.
 - `session-sync.ts`: `configFingerprint` still hashes `hostToolPolicy: HOST_TOOL_POLICY_FINGERPRINT` into `toolsetHash`; the bump is what makes a wording-only denial change retire live queries via `options_changed`.
 
 ### Why

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -19,7 +19,25 @@
 
 - MEDIUM in `errors.ts` around `classifySdkError` prose matchers and the `SdkErrorKind` union.
 - LOW in `guidance.ts` around `sdkErrorGuidance`.
+## 2026-09-03 - State host-tool denial as a fact, not an instruction to end the turn
 
+### What changed
+
+- `tools.ts`: `TOOL_EXECUTION_DENIED_MESSAGE` and `HOST_TOOL_EXECUTION_DENIED_MESSAGE` now state that Senpi executes the tool on the host and returns the result as the next user message; the copy no longer tells the model to end the turn. `HOST_TOOL_POLICY_FINGERPRINT` is `host-tool-denial-v2` so resident sessions re-fingerprint instead of silently keeping the old denial text. PreToolUse still denies with `continue: false` and `permissionDecisionReason`; there is no Stop hook.
+- `session-sync.ts`: `configFingerprint` still hashes `hostToolPolicy: HOST_TOOL_POLICY_FINGERPRINT` into `toolsetHash`; the bump is what makes a wording-only denial change retire live queries via `options_changed`.
+
+### Why
+
+- senpi#784 / oh-my-openagent#7115: agents diagnosed "Do not retry with other tools; end the turn." as a failure and retried with other tools. The denial is not a failure - Senpi executes the captured call and returns the result as the next user message. A wording-only change without bumping the fingerprint would leave resident queries serving the old reason.
+
+### Why an extension could not handle it
+
+- Host-tool denial hooks and the session fingerprint are private to this builtin provider; no extension hook sees `permissionDecisionReason` or `toolsetHash`.
+
+### Expected merge conflict zones
+
+- LOW: `tools.ts` denial constants and `HOST_TOOL_POLICY_FINGERPRINT`.
+- LOW: `session-sync.ts` `configFingerprint` `hostToolPolicy` field.
 ## 2026-09-03 - Never resume an SDK session id the SDK never acknowledged
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts
@@ -148,6 +148,7 @@ export function configFingerprint(
 			authLane,
 			accountName,
 			permissionMode: options.permissionMode,
+			// Bump HOST_TOOL_POLICY_FINGERPRINT in tools.ts when denial copy or hooks change.
 			hostToolPolicy: HOST_TOOL_POLICY_FINGERPRINT,
 			settingSources: options.settingSources,
 			extraArgs: options.extraArgs,

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/tools.ts
@@ -20,12 +20,19 @@ export const PI_TO_SDK_TOOL_NAME: Readonly<Record<string, string>> = {
 	glob: "Glob",
 };
 
-export const HOST_TOOL_POLICY_FINGERPRINT = "host-tool-denial-v1";
+/**
+ * Versioned host-tool denial policy. `configFingerprint` in session-sync.ts hashes this as
+ * `hostToolPolicy` into `toolsetHash`; a mismatch is `options_changed` and retires the live
+ * resident query. Bump when denial copy or hooks change so wording-only edits cannot keep
+ * serving the old reason.
+ */
+export const HOST_TOOL_POLICY_FINGERPRINT = "host-tool-denial-v2";
 
 export const BUILTIN_SDK_TOOLS = ["Read", "Write", "Edit", "Bash", "Grep", "Glob"] as const;
-export const TOOL_EXECUTION_DENIED_MESSAGE = "Tool execution is unavailable in this environment.";
-export const HOST_TOOL_EXECUTION_DENIED_MESSAGE =
-	"This tool call is captured and executed by the host. Do not retry with other tools; end the turn.";
+export const TOOL_EXECUTION_DENIED_MESSAGE =
+	"Senpi executes this tool on the host and returns its result as the next user message. " +
+	"Wait for that result; this denial is not a failure.";
+export const HOST_TOOL_EXECUTION_DENIED_MESSAGE = TOOL_EXECUTION_DENIED_MESSAGE;
 export const CUSTOM_TOOLS_MCP_SERVER_NAME = "custom-tools";
 export const CUSTOM_TOOLS_MCP_PREFIX = `mcp__${CUSTOM_TOOLS_MCP_SERVER_NAME}__`;
 export const HOST_CAPTURED_SDK_TOOL_MATCHER = "Bash|Write|Edit|Read|Grep|Glob|mcp__custom-tools__.*";

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/tools.ts
@@ -23,8 +23,10 @@ export const PI_TO_SDK_TOOL_NAME: Readonly<Record<string, string>> = {
 /**
  * Versioned host-tool denial policy. `configFingerprint` in session-sync.ts hashes this as
  * `hostToolPolicy` into `toolsetHash`; a mismatch is `options_changed` and retires the live
- * resident query. Bump when denial copy or hooks change so wording-only edits cannot keep
- * serving the old reason.
+ * resident query. The same hash is persisted in the restart sidecar, so a bump also makes
+ * the first admission after an upgrade cold-seed (`flatten` / `options_changed`) instead of
+ * resuming the pre-bump SDK session - once per session, intended. Bump when denial copy or
+ * hooks change so wording-only edits cannot keep serving the old reason.
  */
 export const HOST_TOOL_POLICY_FINGERPRINT = "host-tool-denial-v2";
 

--- a/packages/coding-agent/test/claude-sdk-oauth-custom-tools-schema.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-custom-tools-schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { denyCustomToolExecution } from "../src/core/extensions/builtin/claude-sdk-oauth/custom-tools.ts";
 import { jsonSchemaToZodShape } from "../src/core/extensions/builtin/claude-sdk-oauth/custom-tools-schema.ts";
+import { TOOL_EXECUTION_DENIED_MESSAGE } from "../src/core/extensions/builtin/claude-sdk-oauth/tools.ts";
 
 describe("jsonSchemaToZodShape", () => {
 	it("converts TypeBox-style object schemas with required/optional fields", () => {
@@ -47,6 +48,7 @@ describe("custom tool advertisement", () => {
 	it("deny handler always refuses execution with the denial message", async () => {
 		const result = await denyCustomToolExecution();
 		expect(result.isError).toBe(true);
-		expect(result.content[0]?.text).toContain("unavailable");
+		expect(result.content[0]?.text).toBe(TOOL_EXECUTION_DENIED_MESSAGE);
+		expect(result.content[0]?.text).toContain("not a failure");
 	});
 });

--- a/packages/coding-agent/test/claude-sdk-oauth-fingerprint.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-fingerprint.test.ts
@@ -1,6 +1,7 @@
 import type { Context } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import type { Options } from "../src/core/extensions/builtin/claude-sdk-oauth/sdk-boundary.ts";
+import { decideNativeContinuity } from "../src/core/extensions/builtin/claude-sdk-oauth/session-continuity.ts";
 import { configFingerprint } from "../src/core/extensions/builtin/claude-sdk-oauth/session-sync.ts";
 import { HOST_TOOL_POLICY_FINGERPRINT } from "../src/core/extensions/builtin/claude-sdk-oauth/tools.ts";
 
@@ -113,6 +114,32 @@ describe("claude-sdk-oauth config fingerprint stability", () => {
 
 		expect(HOST_TOOL_POLICY_FINGERPRINT).toBe("host-tool-denial-v2");
 		expect(withDifferentCallbackIdentity.toolsetHash).toBe(policyProbe.toolsetHash);
+	});
+
+	it("cold-seeds a restart binding persisted under an older host-tool policy version", () => {
+		// The sidecar stores toolsetHash; after a policy bump the first admission
+		// must not resume the pre-bump SDK session (its hooks carried the old reason).
+		const current = configFingerprint(options(), context(), "oauth-slots", "primary");
+		const decision = decideNativeContinuity({
+			entry: undefined,
+			binding: {
+				sdkSessionId: "sdk-v1",
+				sentCount: 1,
+				sentHashes: ["h1"],
+				sentPrefixHash: undefined,
+				lastAssistantUuid: "a1",
+				accountName: "primary",
+				modelId: "claude-opus-4-5",
+				systemPromptHash: current.systemPromptHash,
+				toolsetHash: "toolset-hash-from-host-tool-denial-v1",
+			},
+			currentHashes: ["h1"],
+			accountName: "primary",
+			modelId: "claude-opus-4-5",
+			fingerprint: current,
+			transcriptAvailable: true,
+		});
+		expect(decision).toEqual({ kind: "flatten", reason: "options_changed" });
 	});
 
 	it("stays fail-closed when the resolved Claude executable changes", () => {

--- a/packages/coding-agent/test/claude-sdk-oauth-fingerprint.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-fingerprint.test.ts
@@ -111,7 +111,7 @@ describe("claude-sdk-oauth config fingerprint stability", () => {
 			"primary",
 		);
 
-		expect(HOST_TOOL_POLICY_FINGERPRINT).toBe("host-tool-denial-v1");
+		expect(HOST_TOOL_POLICY_FINGERPRINT).toBe("host-tool-denial-v2");
 		expect(withDifferentCallbackIdentity.toolsetHash).toBe(policyProbe.toolsetHash);
 	});
 

--- a/packages/coding-agent/test/claude-sdk-oauth-tools.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-tools.test.ts
@@ -12,6 +12,7 @@ import { createToolWatch, registerToolWatch } from "../src/core/extensions/built
 import {
 	BUILTIN_SDK_TOOLS,
 	canUseTool,
+	HOST_TOOL_EXECUTION_DENIED_MESSAGE,
 	mapPiToolNameToSdk,
 	mapSdkToolNameToPi,
 	mapToolArgs,
@@ -45,6 +46,14 @@ describe("Claude SDK OAuth tool integration", () => {
 	it("builds one in-process custom-tools MCP server for active custom tools", async () => {
 		const servers = await buildCustomToolServers([tool("repoSearch")]);
 		expect(Object.keys(servers ?? {})).toEqual(["custom-tools"]);
+	});
+
+	it("states host-tool denial as a fact without telling the model to end the turn", () => {
+		expect(HOST_TOOL_EXECUTION_DENIED_MESSAGE).toBe(
+			"Senpi executes this tool on the host and returns its result as the next user message. Wait for that result; this denial is not a failure.",
+		);
+		expect(TOOL_EXECUTION_DENIED_MESSAGE).toBe(HOST_TOOL_EXECUTION_DENIED_MESSAGE);
+		expect(HOST_TOOL_EXECUTION_DENIED_MESSAGE).not.toMatch(/end the turn/i);
 	});
 
 	it("always denies Claude Code-side tool execution", async () => {

--- a/packages/coding-agent/test/suite/regressions/494-claude-sdk-oauth-denied-tool-replay.test.ts
+++ b/packages/coding-agent/test/suite/regressions/494-claude-sdk-oauth-denied-tool-replay.test.ts
@@ -61,7 +61,9 @@ describe("issue #494: Claude SDK OAuth denied tool replay", () => {
 			hookSpecificOutput: {
 				hookEventName: "PreToolUse",
 				permissionDecision: "deny",
-				permissionDecisionReason: expect.stringMatching(/host.*do not retry/i),
+				permissionDecisionReason: expect.stringMatching(
+					/senpi executes this tool on the host.*this denial is not a failure/i,
+				),
 			},
 		});
 	});


### PR DESCRIPTION
## Summary

Claude SDK OAuth host-tool denial told the model "Do not retry with other tools; end the turn." Agents diagnosed that as a failure and retried with other tools (senpi#784, oh-my-openagent#7115). The PreToolUse hook still denies with `continue: false`; only the reason copy changed. It now states that Senpi executes the tool on the host and returns the result as the next user message, and that the denial is not a failure.

`HOST_TOOL_POLICY_FINGERPRINT` is `host-tool-denial-v2` so resident sessions re-fingerprint. `configFingerprint` hashes that version as `hostToolPolicy` into `toolsetHash`; a mismatch is `options_changed` and retires the live query. A wording-only change without the bump would keep serving the old reason.

## Changes

- `tools.ts`: both denial constants use the factual copy; fingerprint `host-tool-denial-v2`. PreToolUse + `permissionDecisionReason` and `continue: false` are unchanged; no Stop hook.
- `session-sync.ts`: documents that `hostToolPolicy` is the versioned denial policy.
- Tests: 494 regex, fingerprint pin, and an assertion that the copy contains no imperative "end the turn".
- `changes.md`, CHANGELOG Fixed bullet, AGENTS.md fingerprint invariant.

## QA & Evidence

Evidence dir: `sisyphuslabs/.omo/evidence/ulw/claude-sdk-ideal-state-20260903/` (bunshin `mengmotaMac`, never local).

- **RED** (`lane-denial-red.log`): new pins against the old copy — 3 failed / 17 passed (`v1` fingerprint, old "Do not retry" reason).
- **GREEN** (`lane-denial-green.log`): 3 files / 20 passed.
- **REGRESSION** (`lane-denial-regression.log`): `tsc --noEmit -p tsconfig.build.json` + biome (52 files) + 6 vitest files / 42 passed at 45db09daf.

## Related Issues

- Fixes #784
- Related https://github.com/code-yeongyu/oh-my-openagent/issues/7115

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrites the Claude SDK OAuth host-tool denial message so models stop treating a denial as a failure. The old copy told the model to end the turn without retrying; the new copy states that Senpi executes the tool on the host and returns the result as the next user message. Custom-tool denials now use the same shared copy. The PreToolUse hook still denies with `continue: false`; only the denial reason text changed. Fixes senpi#784 and addresses oh-my-openagent#7115.

**Rollout**
- `HOST_TOOL_POLICY_FINGERPRINT` is bumped to `host-tool-denial-v2` so resident sessions re-fingerprint and retire live queries via `options_changed` instead of keeping the old denial text.
- Because the fingerprint persists in the restart sidecar, the first admission after upgrading cold-seeds once (flatten via `options_changed`) instead of resuming the pre-bump SDK session; intended and pinned by a test.

<sup>Written for commit 5833cdc27ab867e282f9372ca01e67091b2c4a09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

