### PR TITLE
fix(claude-sdk-oauth): classify Fable usage-credit errors as entitlement

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Claude SDK OAuth classifies Fable-style "requires usage credits" failures as a non-retryable entitlement instead of a rate limit, so the account is not blocked for 60s and AgentSession can fall through to the next model ([#709](https://github.com/code-yeongyu/senpi/issues/709)).
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/changes.md
@@ -1,5 +1,25 @@
 # claude-sdk-oauth
 
+## 2026-09-03 - Classify Fable usage-credit failures as entitlement
+
+### What changed
+
+- `errors.ts`: added `SdkErrorKind` `entitlement` and classified prose matching `requires usage credits`, `/usage-credits`, and `credits_required` as `{ kind: "entitlement", retryable: false }`.
+- `guidance.ts`: `sdkErrorGuidance("entitlement")` tells the user to switch models, enable usage credits, or pin another account.
+
+### Why
+
+- #709: Claude Code returns "Fable 5 requires usage credits" for subscription accounts. Classifying that as `rate_limit` would block the single account for 60s and prevent Opus fallback on the same account. Non-retryable entitlement is thrown immediately (no account block); AgentSession's hard-error fallback already advances to the next model.
+
+### Why an extension could not handle it
+
+- SDK error classification and auth guidance live inside this builtin provider before any extension-facing result exists.
+
+### Expected merge conflict zones
+
+- MEDIUM in `errors.ts` around `classifySdkError` prose matchers and the `SdkErrorKind` union.
+- LOW in `guidance.ts` around `sdkErrorGuidance`.
+
 ## 2026-09-03 - Never resume an SDK session id the SDK never acknowledged
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/errors.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/errors.ts
@@ -1,7 +1,14 @@
 import type { SDKAssistantMessageError } from "@anthropic-ai/claude-agent-sdk";
 import type { SDKMessage } from "./sdk-boundary.ts";
 
-export type SdkErrorKind = "rate_limit" | "overloaded" | "auth_error" | "billing" | "org_not_allowed" | "other";
+export type SdkErrorKind =
+	| "rate_limit"
+	| "overloaded"
+	| "auth_error"
+	| "billing"
+	| "org_not_allowed"
+	| "entitlement"
+	| "other";
 
 export type SdkErrorClassification = {
 	kind: SdkErrorKind;
@@ -125,6 +132,12 @@ export function classifySdkError(error: unknown): SdkErrorClassification {
 	if (/\b(?:http\s*)?529\b|overloaded/.test(text)) return { kind: "overloaded", retryable: true };
 	if (/\binvalid_grant\b|\binvalid_token\b|\b(?:http\s*)?401\b|\bunauthorized\b/.test(text)) {
 		return { kind: "auth_error", retryable: true };
+	}
+	// Fable 5 and similar models are not in the subscription; Claude Code asks
+	// for usage credits. That is an account entitlement, not a 60s rate limit:
+	// blocking the only account would also block Opus fallback on it.
+	if (/\brequires usage credits\b|\/usage-credits\b|\bcredits_required\b/.test(text)) {
+		return { kind: "entitlement", retryable: false };
 	}
 	return OTHER_ERROR;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/guidance.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/guidance.ts
@@ -53,6 +53,8 @@ export function sdkErrorGuidance(kind: SdkErrorKind): string | undefined {
 			return "The selected Claude account has a billing problem. Check the plan at claude.com or switch accounts with /claude-account pin <name>.";
 		case "auth_error":
 			return `The account's OAuth token was rejected. Re-run /login ${PROVIDER} to refresh it, or remove the account with /claude-account remove <name>.`;
+		case "entitlement":
+			return "This model needs usage credits on the selected Claude account (it is not included in the subscription). Switch models with /model, enable usage credits at claude.com, or pick another account with /claude-account pin <name>.";
 		default:
 			return undefined;
 	}

--- a/packages/coding-agent/test/claude-sdk-oauth-errors.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-errors.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
 import * as errors from "../src/core/extensions/builtin/claude-sdk-oauth/errors.ts";
+import { withAuthGuidance } from "../src/core/extensions/builtin/claude-sdk-oauth/stream-guidance.ts";
+
+const fableUsageCredits =
+	"Claude Code returned an error result: Fable 5 requires usage credits. Run /usage-credits to continue or switch models with /model.";
+const entitlementGuidance =
+	"This model needs usage credits on the selected Claude account (it is not included in the subscription). Switch models with /model, enable usage credits at claude.com, or pick another account with /claude-account pin <name>.";
 
 const versionFloor = {
 	type: "result",
@@ -57,5 +63,13 @@ describe("Claude SDK OAuth error extraction", () => {
 			retryable: true,
 		});
 		expect(errors.classifySdkError("invalid_grant")).toEqual({ kind: "auth_error", retryable: true });
+	});
+
+	it("classifies Fable usage-credit prose as a non-retryable entitlement", () => {
+		expect(errors.classifySdkError(fableUsageCredits)).toEqual({ kind: "entitlement", retryable: false });
+		expect(errors.classifySdkError("credits_required")).toEqual({ kind: "entitlement", retryable: false });
+		const guided = withAuthGuidance(fableUsageCredits, fableUsageCredits);
+		expect(guided.startsWith(fableUsageCredits)).toBe(true);
+		expect(guided).toContain(entitlementGuidance);
 	});
 });

--- a/packages/coding-agent/test/suite/regressions/709-claude-sdk-oauth-entitlement-fallback.test.ts
+++ b/packages/coding-agent/test/suite/regressions/709-claude-sdk-oauth-entitlement-fallback.test.ts
@@ -1,0 +1,108 @@
+import { type CredentialStore, fauxAssistantMessage, InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type AccountSlot,
+	addAccount,
+	type ClaudeSdkOauthCredential,
+	emptyCredential,
+} from "../../../src/core/extensions/builtin/claude-sdk-oauth/accounts.ts";
+import { selectAccount } from "../../../src/core/extensions/builtin/claude-sdk-oauth/affinity.ts";
+import { classifySdkError } from "../../../src/core/extensions/builtin/claude-sdk-oauth/errors.ts";
+import { runFailover } from "../../../src/core/extensions/builtin/claude-sdk-oauth/failover.ts";
+import { createHarness, type Harness } from "../harness.ts";
+
+const primary = "faux/faux-1";
+const fallback = "faux/faux-2";
+const fableUsageCredits =
+	"Claude Code returned an error result: Fable 5 requires usage credits. Run /usage-credits to continue or switch models with /model.";
+const accountPool: AccountSlot[] = [
+	{ name: "alpha", refresh: "r-alpha", access: "a-alpha", expires: 1, source: "login" },
+	{ name: "bravo", refresh: "r-bravo", access: "a-bravo", expires: 1, source: "login" },
+];
+const now = 10_000;
+
+async function storeWithAccounts(): Promise<CredentialStore> {
+	const store = new InMemoryCredentialStore();
+	await store.modify("claude-sdk-oauth", async () =>
+		accountPool.reduce<ClaudeSdkOauthCredential>(
+			(credential, account) => addAccount(credential, account),
+			emptyCredential(),
+		),
+	);
+	return store;
+}
+
+async function collect(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
+	const events: unknown[] = [];
+	for await (const event of iterable) events.push(event);
+	return events;
+}
+
+describe("regression #709: Claude SDK OAuth entitlement fallback", () => {
+	const harnesses: Harness[] = [];
+	afterEach(() => {
+		while (harnesses.length > 0) harnesses.pop()?.cleanup();
+	});
+
+	it("advances the retry-fallback chain to the next model after a Fable usage-credit error", async () => {
+		const harness = await createHarness({
+			models: [{ id: "faux-1" }, { id: "faux-2" }],
+			settings: {
+				retry: { enabled: true, maxRetries: 0, baseDelayMs: 60_000, fallbackChains: { [primary]: [fallback] } },
+			},
+		});
+		harnesses.push(harness);
+		harness.setResponses([
+			fauxAssistantMessage("", { stopReason: "error", errorMessage: fableUsageCredits }),
+			fauxAssistantMessage("fallback answer"),
+		]);
+
+		await harness.session.prompt("hello");
+
+		expect(harness.faux.getCallLog().map((call) => call.modelId)).toEqual(["faux-1", "faux-2"]);
+		expect(
+			harness.events
+				.filter(
+					(event) =>
+						event.type === "retry_fallback_applied" ||
+						event.type === "auto_retry_start" ||
+						event.type === "retry_fallback_succeeded",
+				)
+				.map((event) => {
+					if (event.type === "retry_fallback_applied") return `${event.type}:${event.reason}`;
+					if (event.type === "auto_retry_start") return `${event.type}:${event.delayMs}`;
+					return event.type;
+				}),
+		).toEqual(["retry_fallback_applied:hard-error", "auto_retry_start:0", "retry_fallback_succeeded"]);
+	});
+
+	it("throws the usage-credit failure without blocking the OAuth account slot", async () => {
+		expect(classifySdkError(fableUsageCredits).retryable).toBe(false);
+		expect(classifySdkError(fableUsageCredits).kind).not.toBe("rate_limit");
+		const store = await storeWithAccounts();
+		const attempts: string[] = [];
+		const stream = runFailover({
+			accounts: accountPool,
+			selectFn: (pool) => selectAccount(pool, { sessionId: "entitlement", now }),
+			runAttempt: async function* (slot) {
+				attempts.push(slot.name);
+				if (attempts.length === 1) throw new Error(fableUsageCredits);
+				yield { type: "done", value: slot.name };
+			},
+			classify: classifySdkError,
+			store,
+			providerId: "claude-sdk-oauth",
+			now: () => now,
+		});
+		await expect(collect(stream)).rejects.toMatchObject({
+			name: "ClassifiedSdkError",
+			classification: { retryable: false },
+		});
+		expect(attempts).toHaveLength(1);
+		const credential = (await store.read("claude-sdk-oauth")) as ClaudeSdkOauthCredential;
+		for (const account of credential.accounts ?? []) {
+			expect(account.blockedUntil).toBeUndefined();
+			expect(account.blockReason).toBeUndefined();
+		}
+	});
+});


### PR DESCRIPTION
Fixes #709

## Summary

Claude Code returns `Fable 5 requires usage credits. Run /usage-credits...` for subscription accounts that do not have extra usage credits. That prose used to classify as non-retryable `other`, so the user got a dead-end error with no model guidance.

This PR adds `SdkErrorKind` `entitlement` (`retryable: false`) for:

- `requires usage credits`
- `/usage-credits`
- `credits_required`

`sdkErrorGuidance("entitlement")` tells the user to switch models, enable usage credits, or pin another account. Failover is unchanged: a non-retryable classification is thrown immediately and the OAuth account slot is **not** blocked.

## Why this is not `rate_limit`

Classifying the failure as `rate_limit` (`retryable: true`) would persist a 60s `blockedUntil` on the selected account. On a single-account setup that also blocks Opus (and every other Claude model) on the same account for a minute, which is the opposite of #709.

A source-level probe of AgentSession on main showed the hard-error fallback path already advances to the next configured model when `canTryFallback()` is true. The missing piece was a named, guided entitlement classification that stays non-retryable so the account stays usable for that fallback.

## Tests

- Classifier + `withAuthGuidance` pin in `test/claude-sdk-oauth-errors.test.ts` (RED on main: kind was `other`).
- Regression `test/suite/regressions/709-claude-sdk-oauth-entitlement-fallback.test.ts`: next-model fallback plus no `blockedUntil`/`blockReason` on the OAuth slot. The model-chain half was already green on main; it is the pin #709 asked for.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #709 by classifying Claude Code "Fable requires usage credits" failures as a non-retryable `entitlement` error instead of `other`, giving users actionable guidance while keeping the OAuth account slot unblocked for model fallback.

- Adds `SdkErrorKind` `entitlement` and matches `requires usage credits`, `/usage-credits`, and `credits_required` prose.
- `sdkErrorGuidance("entitlement")` tells the user to switch models, enable usage credits, or pin another account.
- Treating it as `rate_limit` would block the only account for 60s and stall Opus fallback on the same account, so the classification stays non-retryable and is thrown immediately.
- Regression test verifies next-model fallback and no `blockedUntil`/`blockReason` on the OAuth slot.

<sup>Written for commit 0af703aa2333b3f713a928ff55eb5bf4c7dca7d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

