### PR TITLE
fix(coding-agent): announce print-mode model fallback on stderr

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Claude SDK OAuth classifies Fable-style "requires usage credits" failures as a non-retryable entitlement instead of a rate limit, so the account is not blocked for 60s and AgentSession can fall through to the next model ([#709](https://github.com/code-yeongyu/senpi/issues/709)).
-
+- Print mode (`-p` / `--mode json`) now writes a stderr notice when retry fallback substitutes a model, so silent wrong-model answers are visible without corrupting JSON stdout ([oh-my-openagent#7626](https://github.com/code-yeongyu/oh-my-openagent/issues/7626)).
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-03 - Announce print-mode model fallback on stderr
+
+### What changed
+
+- `packages/coding-agent/src/modes/print-mode.ts` writes one stderr line when `retry_fallback_applied`, `retry_fallback_exhausted`, or `retry_fallback_reverted` fires, in both text and json print modes, without changing JSON stdout.
+
+### Why
+
+- `senpi -p` answered on a fallback model with no human-visible notice, so users could treat the wrong model's output as the requested model's. JSON mode already streamed `retry_fallback_applied` on stdout; stderr is the channel that does not corrupt that stream.
+
+### Why an extension could not handle it
+
+- Print mode owns the `-p` / `--mode json` I/O path and is the only subscriber that can write stderr without going through the interactive TUI. Retry fallback already emits session events; the hole is print-mode rendering, not the controller.
+
+### Expected merge conflict zones
+
+- LOW: the `session.subscribe` callback in `packages/coding-agent/src/modes/print-mode.ts`.
+
 ## 2026-09-02 - Export the RPC open-in-flight client error
 
 ### What changed

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -107,6 +107,13 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 		unsubscribe?.();
 		unsubscribeBackpressure?.();
 		unsubscribe = session.subscribe((event) => {
+			if (event.type === "retry_fallback_applied") {
+				console.error(`Model fallback: ${event.from} -> ${event.to} (${event.reason})`);
+			} else if (event.type === "retry_fallback_exhausted") {
+				console.error(`Model fallback exhausted: ${event.chainKey} (${event.lastError})`);
+			} else if (event.type === "retry_fallback_reverted") {
+				console.error(`Model fallback reverted: ${event.from} -> ${event.to}`);
+			}
 			if (mode === "json") {
 				writeRawStdout(`${JSON.stringify(toJsonEvent(event))}\n`);
 			}

--- a/packages/coding-agent/test/print-mode-fallback-notice.test.ts
+++ b/packages/coding-agent/test/print-mode-fallback-notice.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionEvent } from "../src/core/agent-session.ts";
+import { runPrintMode } from "../src/modes/print-mode.ts";
+
+const outputGuard = vi.hoisted((): { stdout: string[] } => ({ stdout: [] }));
+
+vi.mock("../src/core/output-guard.ts", () => ({
+	flushRawStdout: vi.fn(async () => {}),
+	waitForRawStdoutBackpressure: vi.fn(async () => {}),
+	writeRawStdout: vi.fn((text: string) => {
+		outputGuard.stdout.push(text);
+	}),
+}));
+
+const applied: Extract<AgentSessionEvent, { type: "retry_fallback_applied" }> = {
+	type: "retry_fallback_applied",
+	from: "anthropic/claude-opus-4-6",
+	to: "openai/gpt-4o",
+	chainKey: "anthropic/claude-opus-4-6",
+	reason: "billing",
+};
+
+const exhausted: Extract<AgentSessionEvent, { type: "retry_fallback_exhausted" }> = {
+	type: "retry_fallback_exhausted",
+	chainKey: "anthropic/claude-opus-4-6",
+	lastError: "all models unavailable",
+};
+
+const reverted: Extract<AgentSessionEvent, { type: "retry_fallback_reverted" }> = {
+	type: "retry_fallback_reverted",
+	from: "openai/gpt-4o",
+	to: "anthropic/claude-opus-4-6",
+};
+
+function createRuntimeHost(events: AgentSessionEvent[]) {
+	let listener: ((event: AgentSessionEvent) => void) | undefined;
+	const session = {
+		sessionManager: { getHeader: () => undefined },
+		agent: { waitForIdle: async () => {}, subscribe: vi.fn(() => () => {}) },
+		state: { messages: [] },
+		extensionRunner: { hasHandlers: () => false, emit: vi.fn(async () => {}) },
+		bindExtensions: vi.fn(async () => {}),
+		subscribe: vi.fn((cb: (event: AgentSessionEvent) => void) => {
+			listener = cb;
+			return () => {
+				listener = undefined;
+			};
+		}),
+		prompt: vi.fn(async () => {
+			for (const event of events) {
+				listener?.(event);
+			}
+		}),
+		reload: vi.fn(async () => {}),
+		waitForSettledSessionWork: vi.fn(async () => {}),
+	};
+
+	return {
+		session,
+		newSession: vi.fn(async () => undefined),
+		fork: vi.fn(async () => ({ selectedText: "" })),
+		switchSession: vi.fn(async () => undefined),
+		dispose: vi.fn(async () => {}),
+		setRebindSession: vi.fn(),
+	};
+}
+
+async function runWithEvents(mode: "text" | "json", events: AgentSessionEvent[]) {
+	const runtimeHost = createRuntimeHost(events);
+	const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+	const exitCode = await runPrintMode(runtimeHost as unknown as Parameters<typeof runPrintMode>[0], {
+		mode,
+		initialMessage: "hello",
+	});
+	return { exitCode, errorSpy, stdout: outputGuard.stdout.join("") };
+}
+
+function jsonStdout(stdout: string): unknown[] {
+	const parsed: unknown[] = [];
+	for (const line of stdout.split("\n")) {
+		if (line.length > 0) {
+			parsed.push(JSON.parse(line));
+		}
+	}
+	return parsed;
+}
+
+afterEach(() => {
+	outputGuard.stdout = [];
+	vi.restoreAllMocks();
+});
+
+describe("print-mode fallback notice", () => {
+	it("writes retry_fallback_applied to stderr in text mode and leaves stdout empty", async () => {
+		const { exitCode, errorSpy, stdout } = await runWithEvents("text", [applied]);
+
+		expect(exitCode).toBe(0);
+		expect(errorSpy).toHaveBeenCalledWith("Model fallback: anthropic/claude-opus-4-6 -> openai/gpt-4o (billing)");
+		expect(stdout).toBe("");
+	});
+
+	it("writes retry_fallback_applied to stderr in json mode and keeps the stdout JSON event", async () => {
+		const { exitCode, errorSpy, stdout } = await runWithEvents("json", [applied]);
+
+		expect(exitCode).toBe(0);
+		expect(errorSpy).toHaveBeenCalledWith("Model fallback: anthropic/claude-opus-4-6 -> openai/gpt-4o (billing)");
+		expect(jsonStdout(stdout)).toEqual([applied]);
+		expect(stdout).not.toContain("Model fallback:");
+	});
+
+	it("writes exhausted and reverted fallback notices to stderr", async () => {
+		const { errorSpy } = await runWithEvents("text", [exhausted, reverted]);
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			"Model fallback exhausted: anthropic/claude-opus-4-6 (all models unavailable)",
+		);
+		expect(errorSpy).toHaveBeenCalledWith("Model fallback reverted: openai/gpt-4o -> anthropic/claude-opus-4-6");
+	});
+});


### PR DESCRIPTION
## Summary

Print mode (`-p` / `--mode json`) now writes one stderr line when retry fallback substitutes, exhausts, or reverts a model:

- `Model fallback: <from> -> <to> (<reason>)`
- `Model fallback exhausted: <chainKey> (<lastError>)`
- `Model fallback reverted: <from> -> <to>`

`--mode json` stdout is unchanged: `retry_fallback_applied` still streams as JSONL. stderr does not corrupt that stream. Interactive TUI notices are unchanged. `RetryFallbackController` and `AgentSession` emit are unchanged.

Related: https://github.com/code-yeongyu/oh-my-openagent/issues/7626

## Test plan

- [x] `cd packages/coding-agent && bunx tsc --noEmit -p tsconfig.build.json`
- [x] `bunx biome check src/modes/print-mode.ts test/print-mode*.test.ts`
- [x] `bunx vitest run test/print-mode*.test.ts test/suite/model-fallback-command.test.ts` (18 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Print mode (`-p` / `--mode json`) silently answered on fallback models with no visible notice, so users could mistake the fallback model's output for the requested model's. It now writes a stderr line when retry fallback substitutes, exhausts, or reverts a model, leaving JSON stdout and interactive TUI notices unchanged. Fixes [oh-my-openagent#7626](https://github.com/code-yeongyu/oh-my-openagent/issues/7626).

<sup>Written for commit 7c33aa0c24caac263a1eba368d9b561455984a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

