### PR TITLE
test(ai): wait for the manual OAuth prompt before aborting the login

### DIFF
--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -100,6 +100,12 @@ describe.sequential("Anthropic OAuth", () => {
 		installFailingListen("EADDRINUSE");
 		const controller = new AbortController();
 		let promptSignal: AbortSignal | undefined;
+		// Resolve the moment the login opens its manual prompt, so the abort below is
+		// ordered after the prompt exists instead of racing a macrotask tick.
+		let promptOpened!: () => void;
+		const opened = new Promise<void>((resolve) => {
+			promptOpened = resolve;
+		});
 		const login = anthropicOAuth.login({
 			signal: controller.signal,
 			notify: vi.fn(),
@@ -107,21 +113,17 @@ describe.sequential("Anthropic OAuth", () => {
 				new Promise<string>((_resolve, reject) => {
 					promptSignal = prompt.signal;
 					prompt.signal?.addEventListener("abort", () => reject(new Error("prompt aborted")), { once: true });
+					promptOpened();
 				}),
 		});
 		const settled = login.then(
 			() => "resolved",
 			(error: unknown) => (error instanceof Error ? error.message : String(error)),
 		);
-		// Give the login a turn to open the manual prompt, then cancel from the outside.
-		await new Promise((resolve) => setTimeout(resolve, 0));
+		await opened;
 		controller.abort();
-		const outcome = await Promise.race([
-			settled,
-			new Promise<string>((resolve) => setTimeout(() => resolve("still pending"), 500)),
-		]);
+		expect(await settled).toBe("prompt aborted");
 		expect(promptSignal?.aborted).toBe(true);
-		expect(outcome).toBe("prompt aborted");
 	});
 
 	it("rejects non-bind callback errors with the callback host and port", async () => {


### PR DESCRIPTION
## Summary

`packages/ai/test/anthropic-oauth.test.ts` "aborts a manual-only login while the manual prompt is still open" raced a `setTimeout(0)` against the login opening its manual prompt, then decided the outcome with a 500 ms timer. On loaded runners the prompt opened after the abort and the test reported `still pending`. It failed four separate PR runs today (#1318, #1320, #1308, #1267), each unrelated to the diff under test.

## Changes

- The prompt callback now resolves an explicit `opened` promise; the test awaits that signal, aborts, and asserts the settled outcome directly. No timers, no race.

## QA & Evidence

- Ran the file five times in a row under `CI=1` on a bunshin machine (mengmotaMac): 8/8 passed each time (`/tmp/ulw-sdk-20260903/flake-green.log`).
- Test-only change: no runtime source touched, so no CHANGELOG/changes.md entry (gate exempts tests).

## Related

- Repeated `Test (workspaces + scripts)` reruns on #1318 / #1320 / #1308 / #1267 today.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky Anthropic OAuth abort test by replacing timer-based racing with an explicit prompt-opened signal. The old test used a `setTimeout(0)` and a 500 ms `Promise.race`, which failed on loaded CI runners when the prompt opened after the abort. Now the prompt callback resolves an `opened` promise, the test awaits it, aborts, and asserts the settled outcome directly.

- Test-only change, no runtime source touched, so no changelog entry is needed.

<sup>Written for commit 32fc0d43adb242f72adcee9d5ed66fe0dc628017. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

