### PR TITLE
feat(rpc): media_placeholders capability - image_ref placeholders for tool-result images and get_media

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `/gpt-account` manages OpenAI Codex OAuth accounts the way `/claude-account` manages claude-sdk-oauth ones: `add` runs an interactive Codex login and stores the new account beside the existing ones, `remove <name>`, `pin <name>` and `unpin` select which account is used, and the bare command lists every stored account with its source, availability and pin state without printing token material.
+- RPC clients that send `media_placeholders` in `set_client_info` now receive inline tool-result images as `image_ref` placeholders shaped with `mimeType`, `byteLength` and a `{ toolCallId, contentIndex }` reference, and can retrieve an omitted image through the `get_media` command; default clients remain byte-identical, while classic stdio mode is not covered. This prevented inline image tool results from overflowing a desktop client's socket queue.
 
 ### Changed
 

--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -39,6 +39,33 @@ Rebranded distributions read the equivalent variable under their configured envi
 `extension_events` opts the client into generic extension-owned event records; clients that omit it
 retain the previous wire stream unchanged.
 
+#### media_placeholders
+
+A client that advertises `media_placeholders` in `set_client_info` tells the host it does not want
+inline media bytes on the wire. For that connection the host replaces every image block inside a
+tool result (`ToolResultMessage.content` and `tool_execution_end.result.content`, including the
+entries carried by `get_entries`, `get_messages`, `get_tree`, `open_session` state and attach-time
+snapshot replay) with an `image_ref` placeholder:
+
+```json
+{
+  "type": "image_ref",
+  "mimeType": "image/png",
+  "byteLength": 553000,
+  "ref": {"toolCallId": "call_abc123", "contentIndex": 1}
+}
+```
+
+`byteLength` is the decoded size of the omitted payload. The original block is fetched on demand with
+[`get_media`](#get_media) using the `ref`. User-authored images (`prompt`/`steer`/`follow_up`
+`images`) are never replaced.
+
+A connection that does not advertise the capability receives byte-identical output to before. The
+capability is advertised by the host in `get_protocol_info.capabilities` in both classic and
+multi-session mode, but the transform itself is applied only by the multi-session host: classic
+single-connection stdio mode never rewrites its output, so a stdio client always receives inline
+media even if it names the capability. `get_media` is answered in both modes.
+
 ## Multi-session mode (D1 wire protocol)
 
 Multi-session mode lets one `senpi --mode rpc` process serve several independent conversations concurrently over the same stdio JSONL stream. Classic single-session mode is byte-identical to today; the only additive classic-mode behavior is that `get_protocol_info` is answered.
@@ -199,6 +226,7 @@ In the response `error` field, machine-matchable:
 - `invalid_path` (relative `sessionPath`/`cwd`)
 - `too_many_sessions` (`open_session` while `SENPI_RPC_MAX_SESSIONS` sessions are already opening/open; attaching to a live session never fails this way)
 - `open_failed: <detail>`
+- `media_not_found` (`get_media` for an unknown `toolCallId`, or a `contentIndex` that does not point at an image block)
 
 ### Tagging
 
@@ -448,6 +476,51 @@ Response:
 ```
 
 Messages are `AgentMessage` objects (see [Message Types](#message-types)).
+
+#### get_media
+
+Fetch one media block that was omitted for a [`media_placeholders`](#media_placeholders) client. The
+parameters are exactly the placeholder's `ref`.
+
+```json
+{"type": "get_media", "toolCallId": "call_abc123", "contentIndex": 1}
+```
+
+Response:
+```json
+{
+  "type": "response",
+  "command": "get_media",
+  "success": true,
+  "data": {
+    "toolCallId": "call_abc123",
+    "contentIndex": 1,
+    "content": {"type": "image", "data": "<base64>", "mimeType": "image/png"}
+  }
+}
+```
+
+`content` is the original `ImageContent` block, byte-for-byte. `contentIndex` indexes the tool
+result's `content` array. The host looks the tool call up in the durable session entries first (so a
+block stays fetchable after the live message window moved on), then in the current messages for a
+result that has not been persisted yet.
+
+When the tool call is unknown, the index is out of range, or the index points at a non-image block,
+the response fails with `error` and `errorCode` both set to `media_not_found`:
+
+```json
+{
+  "type": "response",
+  "command": "get_media",
+  "success": false,
+  "error": "media_not_found",
+  "errorCode": "media_not_found"
+}
+```
+
+The command is answered in classic and multi-session mode alike; in multi-session mode it takes the
+usual `sessionId` envelope. It is answerable regardless of whether the connection advertised
+`media_placeholders`.
 
 ### Model
 

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## `media_placeholders`: inline tool-result images are replaced at one choke point (2026-09-03)
+
+### What changed
+
+- New pure module `media-placeholders.ts` exports `omitInlineMedia(record)`. It replaces `{type:"image", data:<base64>}` blocks with `{type:"image_ref", mimeType, byteLength, ref:{toolCallId, contentIndex}}` inside every object carrying `role:"toolResult"` and inside `tool_execution_end.result.content`. `byteLength` is derived from the base64 string length (`floor(len*3/4) - padding`); the payload is never decoded. User-authored images (`prompt.images`) are left intact.
+- The transform is type-gated first: only `tool_execution_end`, `message_start`, `message_end`, `turn_end`, `agent_end`, `entry_appended`, and `response` records whose command is one of `get_messages`, `get_entries`, `get_tree`, `get_state`, `open_session` are walked. `message_update` — one record per token — is never walked.
+- The walk is copy-on-write and returns the SAME record reference when nothing changed, so unchanged sub-trees keep their identity and live agent state handed to `success()` by reference is never mutated.
+- `SessionEventWriter.enqueue` applies it once, after `targets()`: when no target advertises `media_placeholders` the record is not walked and `serializeJsonLine` is still called exactly once, byte-identical to before. Otherwise the placeholder line is built once and each target is handed the variant it advertised.
+- `SessionEventFanout` gained the generic `connectionHas(id, capability)` accessor; the four hard-coded `"rendered_components"` string checks now go through it with `RENDERED_COMPONENTS_CAPABILITY`. Behavior is unchanged.
+- `SnapshotRecord` gained `placeholderLine` and the source record. `replaySnapshot` picks the variant by the attaching connection's capability; the variant is derived on the first capable replay and memoized, so a session with no capable client pays nothing and replay stays O(1) per record.
+
+### Why
+
+- Four base64 `read` results overflowed a socket queue in one burst (2026-09-03, omo-desktop) and the host then dropped every record and command response for that connection. Gating the bytes on a client capability is the structural fix the previous entry recorded as a follow-up.
+- The image-carrying wire paths are not enumerable reliably: beyond the obvious events, `entry_appended`, `get_entries`, `get_tree` and `open_session`'s `state.entries` all carry `ToolResultMessage.content`. Every one of them converges on `SessionEventWriter.enqueue` in multi-session mode, so the transform runs there once instead of at each call site.
+
+### Scope
+
+- Classic single-connection stdio mode is out of scope: applying the transform there needs a second application point in `connection-handler.ts`, and no stdio client asks for placeholders.
+- A default client (one that never advertised `media_placeholders`) receives byte-identical output.
+
+### Expected merge conflict zones
+
+- LOW: `session-event-writer.ts` `enqueue` fan-out loop and `session-event-fanout.ts` snapshot record shape.
+
 ## Socket fan-out: lossless supersession, and overflow closes the socket (2026-09-03)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -11,14 +11,16 @@
 - `SessionEventFanout` gained the generic `connectionHas(id, capability)` accessor; the four hard-coded `"rendered_components"` string checks now go through it with `RENDERED_COMPONENTS_CAPABILITY`. Behavior is unchanged.
 - `SnapshotRecord` gained `placeholderLine` and the source record. `replaySnapshot` picks the variant by the attaching connection's capability; the variant is derived on the first capable replay and memoized, so a session with no capable client pays nothing and replay stays O(1) per record.
 
+- `rpc-types.ts` adds the `get_media {toolCallId, contentIndex}` command, its `get_media` response and `RPC_ERROR_MEDIA_NOT_FOUND`; `connection-handler.ts` answers it (`findToolResultMedia`: durable session entries first, live messages second) and lists `media_placeholders` in classic-mode `get_protocol_info`; `session-command-router.ts` lists it in multi-mode `get_protocol_info`; `rpc-client.ts` gains `getMedia()`; `custom-capability.ts` declares `MEDIA_PLACEHOLDERS_CAPABILITY`.
+
 ### Why
 
 - Four base64 `read` results overflowed a socket queue in one burst (2026-09-03, omo-desktop) and the host then dropped every record and command response for that connection. Gating the bytes on a client capability is the structural fix the previous entry recorded as a follow-up.
 - The image-carrying wire paths are not enumerable reliably: beyond the obvious events, `entry_appended`, `get_entries`, `get_tree` and `open_session`'s `state.entries` all carry `ToolResultMessage.content`. Every one of them converges on `SessionEventWriter.enqueue` in multi-session mode, so the transform runs there once instead of at each call site.
 
-### Scope
+### Why this cannot be expressed externally
 
-- Classic single-connection stdio mode is out of scope: applying the transform there needs a second application point in `connection-handler.ts`, and no stdio client asks for placeholders.
+- The rewrite has to live inside the host: only the host knows which connection advertised the capability and which records converge on `SessionEventWriter.enqueue`; a client-side filter would still receive the bytes it wants to avoid. Classic single-connection stdio mode is out of scope: applying the transform there needs a second application point in `connection-handler.ts`, and no stdio client asks for placeholders.
 - A default client (one that never advertised `media_placeholders`) receives byte-identical output.
 
 ### Expected merge conflict zones

--- a/packages/coding-agent/src/modes/rpc/connection-handler.ts
+++ b/packages/coding-agent/src/modes/rpc/connection-handler.ts
@@ -18,6 +18,7 @@
 import * as crypto from "node:crypto";
 import { existsSync } from "node:fs";
 import { basename, dirname, extname } from "node:path";
+import type { ImageContent } from "@earendil-works/pi-ai";
 import type { OAuthProviderId } from "@earendil-works/pi-ai/compat";
 import { VERSION } from "../../config.ts";
 import type { AgentAbortSource } from "../../core/agent-abort-provenance.ts";
@@ -61,6 +62,7 @@ import {
 	buildCustomUnsupportedRequest,
 	DEFAULT_CUSTOM_EXTENSION_LABEL,
 	EXTENSION_EVENTS_CAPABILITY,
+	MEDIA_PLACEHOLDERS_CAPABILITY,
 	RENDERED_COMPONENTS_CAPABILITY,
 } from "./custom-capability.ts";
 import { createRpcEventOutputBuffer } from "./event-output-buffer.ts";
@@ -82,6 +84,7 @@ import type {
 	RpcSessionState,
 	RpcSkillInvocationEvent,
 } from "./rpc-types.ts";
+import { RPC_ERROR_MEDIA_NOT_FOUND } from "./rpc-types.ts";
 import { RENDERED_COMPONENT_RECORD } from "./session-event-writer.ts";
 import { SessionExtensionUiRequests } from "./session-extension-ui-requests.ts";
 import { createLiveComponentRenderer, type LiveComponentRenderer } from "./widget-line-renderer.ts";
@@ -257,6 +260,44 @@ function loadedSurfacesFingerprint(
 		extensions,
 		mcpServers,
 	});
+}
+
+/**
+ * Locate one media block inside a tool result by `(toolCallId, contentIndex)`.
+ *
+ * Durable session entries are searched first: they survive the live message window
+ * being compacted or trimmed away. The live `session.messages` cover the window
+ * between `tool_execution_end` and persistence. Returns `undefined` unless the index
+ * lands on an actual image block, so a text block or an out-of-range index is
+ * reported as `media_not_found` rather than as a differently-shaped success.
+ */
+function findToolResultMedia(
+	session: AgentSession,
+	toolCallId: string,
+	contentIndex: number,
+): ImageContent | undefined {
+	const fromContent = (content: unknown): ImageContent | undefined => {
+		if (!Array.isArray(content)) return undefined;
+		const block = content[contentIndex] as ImageContent | undefined;
+		return block?.type === "image" ? block : undefined;
+	};
+	const matches = (message: unknown): message is { role: "toolResult"; toolCallId: string; content: unknown } => {
+		const candidate = message as { role?: unknown; toolCallId?: unknown } | null;
+		return candidate?.role === "toolResult" && candidate.toolCallId === toolCallId;
+	};
+
+	for (const entry of session.sessionManager.getEntries()) {
+		if (entry.type !== "message") continue;
+		if (!matches(entry.message)) continue;
+		const found = fromContent(entry.message.content);
+		if (found) return found;
+	}
+	for (const message of session.messages) {
+		if (!matches(message)) continue;
+		const found = fromContent(message.content);
+		if (found) return found;
+	}
+	return undefined;
 }
 
 /**
@@ -995,7 +1036,12 @@ export function createRpcConnectionHandler(
 						protocolVersion: 1,
 						serverVersion: VERSION,
 						capabilities: [
-							...new Set(["multi_session", AUTO_TITLE_SESSIONS_CAPABILITY, ...(options.capabilities ?? [])]),
+							...new Set([
+								"multi_session",
+								AUTO_TITLE_SESSIONS_CAPABILITY,
+								MEDIA_PLACEHOLDERS_CAPABILITY,
+								...(options.capabilities ?? []),
+							]),
 						],
 						mode: "classic",
 					},
@@ -1463,6 +1509,19 @@ export function createRpcConnectionHandler(
 
 			case "get_messages": {
 				return success(id, "get_messages", { messages: session.messages });
+			}
+
+			// On-demand fetch of a media block a `media_placeholders` client received as
+			// an `image_ref` stub. Durable session entries first (they survive the live
+			// message window being compacted away), then the live messages for a result
+			// that has not been persisted yet.
+			case "get_media": {
+				const { toolCallId, contentIndex } = command;
+				const content = findToolResultMedia(session, toolCallId, contentIndex);
+				if (!content) {
+					return error(id, "get_media", RPC_ERROR_MEDIA_NOT_FOUND, RPC_ERROR_MEDIA_NOT_FOUND);
+				}
+				return success(id, "get_media", { toolCallId, contentIndex, content });
 			}
 
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/custom-capability.ts
+++ b/packages/coding-agent/src/modes/rpc/custom-capability.ts
@@ -22,6 +22,11 @@ export const CUSTOM_UNSUPPORTED_CAPABILITY = "custom_unsupported";
 export const EXTENSION_EVENTS_CAPABILITY = "extension_events";
 export const RENDERED_COMPONENTS_CAPABILITY = "rendered_components";
 export const AUTO_TITLE_SESSIONS_CAPABILITY = "auto_title_sessions";
+/**
+ * Opt-in: the host replaces inline image bytes inside tool results with `image_ref`
+ * placeholders for this connection; the client fetches a block on demand with `get_media`.
+ */
+export const MEDIA_PLACEHOLDERS_CAPABILITY = "media_placeholders";
 
 /**
  * Env var carrying client capabilities to a single-connection stdio RPC host

--- a/packages/coding-agent/src/modes/rpc/media-placeholders.ts
+++ b/packages/coding-agent/src/modes/rpc/media-placeholders.ts
@@ -1,0 +1,161 @@
+/**
+ * The `media_placeholders` transform (one choke point, not five).
+ *
+ * A client that advertised `MEDIA_PLACEHOLDERS_CAPABILITY` must never receive
+ * `{type:"image", data:<base64>}` inside a tool result — four inline images once
+ * overflowed a 4 MiB socket queue and froze the desktop. Rather than patching each
+ * wire path that can carry a tool result (`message_start`/`message_end`,
+ * `turn_end.toolResults`, `agent_end`, `entry_appended`, and the `get_messages`,
+ * `get_entries`, `get_tree`, `get_state`, `open_session` responses — a list that has
+ * already been wrong once), every record is funnelled through this pure transform at
+ * `SessionEventWriter.enqueue`.
+ *
+ * Two hard rules:
+ * - Type-gate FIRST. `message_update` is the hot path (one record per token) and must
+ *   never be walked.
+ * - Copy-on-write. Responses hand out live agent state by reference
+ *   (`success(id, "get_messages", { messages: session.messages })`), so the input graph
+ *   is never mutated and unchanged sub-trees keep their identity. When nothing changed
+ *   the SAME record reference comes back, which lets the caller reuse the line it
+ *   already serialized.
+ *
+ * User-authored images (`prompt.images`) stay intact: they are bounded by the client
+ * that sent them; the fan-out hazard is tool output.
+ */
+
+type RpcRecord = Record<string, unknown>;
+
+/** Record types that can carry a tool result somewhere in their payload. */
+const MEDIA_BEARING_RECORD_TYPES = new Set([
+	"tool_execution_end",
+	"message_start",
+	"message_end",
+	"turn_end",
+	"agent_end",
+	"entry_appended",
+]);
+
+/** Response commands whose payload can carry a tool result. */
+const MEDIA_BEARING_RESPONSE_COMMANDS = new Set([
+	"get_messages",
+	"get_entries",
+	"get_tree",
+	"get_state",
+	"open_session",
+]);
+
+/** The block a capable client receives in place of inline image bytes. */
+export interface ImageRefBlock {
+	readonly type: "image_ref";
+	readonly mimeType: string;
+	readonly byteLength: number;
+	readonly ref: { readonly toolCallId: string; readonly contentIndex: number };
+}
+
+/**
+ * Decoded byte length of a base64 string, derived from its length alone.
+ *
+ * Decoding a multi-MiB payload just to report its size would defeat the purpose of
+ * omitting it.
+ */
+export function base64ByteLength(data: string): number {
+	const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+	return Math.max(0, Math.floor((data.length * 3) / 4) - padding);
+}
+
+function isPlainObject(value: unknown): value is RpcRecord {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isInlineImage(value: unknown): value is { type: "image"; data: string; mimeType?: string } {
+	return isPlainObject(value) && value.type === "image" && typeof value.data === "string";
+}
+
+/** Replace inline images in one tool-result content array; same reference when none. */
+function omitContentImages(content: readonly unknown[], toolCallId: string): readonly unknown[] {
+	let replaced: unknown[] | undefined;
+	for (let index = 0; index < content.length; index++) {
+		const block = content[index];
+		if (!isInlineImage(block)) continue;
+		replaced ??= [...content];
+		replaced[index] = {
+			type: "image_ref",
+			mimeType: typeof block.mimeType === "string" ? block.mimeType : "application/octet-stream",
+			byteLength: base64ByteLength(block.data),
+			ref: { toolCallId, contentIndex: index },
+		} satisfies ImageRefBlock;
+	}
+	return replaced ?? content;
+}
+
+/** A toolResult message whose content array carries images, rebuilt without them. */
+function omitToolResultImages(message: RpcRecord): RpcRecord {
+	const content = message.content;
+	const toolCallId = typeof message.toolCallId === "string" ? message.toolCallId : "";
+	if (!Array.isArray(content)) return message;
+	const omitted = omitContentImages(content, toolCallId);
+	return omitted === content ? message : { ...message, content: omitted };
+}
+
+/**
+ * Copy-on-write walk. Every object with `role:"toolResult"` has its content array
+ * scrubbed, wherever it sits (message arrays, `turn_end.toolResults`, session entries,
+ * tree nodes, `state.entries`). Unchanged sub-trees are returned by reference.
+ */
+function walk(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		let replaced: unknown[] | undefined;
+		for (let index = 0; index < value.length; index++) {
+			const next = walk(value[index]);
+			if (next === value[index]) continue;
+			replaced ??= [...value];
+			replaced[index] = next;
+		}
+		return replaced ?? value;
+	}
+	if (!isPlainObject(value)) return value;
+
+	const scrubbed = value.role === "toolResult" ? omitToolResultImages(value) : value;
+	let replaced: RpcRecord | undefined = scrubbed === value ? undefined : { ...scrubbed };
+	for (const [key, child] of Object.entries(scrubbed)) {
+		if (key === "content" && scrubbed !== value) continue;
+		if (!isPlainObject(child) && !Array.isArray(child)) continue;
+		const next = walk(child);
+		if (next === child) continue;
+		replaced ??= { ...scrubbed };
+		replaced[key] = next;
+	}
+	return replaced ?? value;
+}
+
+/** `tool_execution_end.result.content` is not a toolResult message; scrub it explicitly. */
+function omitToolExecutionEndImages(record: RpcRecord): RpcRecord {
+	const result = record.result;
+	if (!isPlainObject(result) || !Array.isArray(result.content)) return record;
+	const toolCallId = typeof record.toolCallId === "string" ? record.toolCallId : "";
+	const omitted = omitContentImages(result.content, toolCallId);
+	return omitted === result.content ? record : { ...record, result: { ...result, content: omitted } };
+}
+
+/** True when this record type can carry a tool result at all (cheap gate). */
+function carriesMedia(record: RpcRecord): boolean {
+	if (typeof record.type !== "string") return false;
+	if (MEDIA_BEARING_RECORD_TYPES.has(record.type)) return true;
+	return record.type === "response" && typeof record.command === "string"
+		? MEDIA_BEARING_RESPONSE_COMMANDS.has(record.command)
+		: false;
+}
+
+/**
+ * Replace inline tool-result images with `image_ref` placeholders.
+ *
+ * Returns the SAME reference when nothing changed, so the caller can skip the second
+ * serialization entirely.
+ */
+export function omitInlineMedia<T extends object>(record: T): T {
+	const typed = record as unknown as RpcRecord;
+	if (!carriesMedia(typed)) return record;
+	const scrubbed = typed.type === "tool_execution_end" ? omitToolExecutionEndImages(typed) : typed;
+	const walked = walk(scrubbed);
+	return (walked === typed ? record : walked) as T;
+}

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -844,6 +844,18 @@ export class RpcClient {
 	}
 
 	/**
+	 * Fetch one media block that arrived as an `image_ref` placeholder.
+	 *
+	 * `contentIndex` is the index inside the tool result's `content` array carried by
+	 * the placeholder's `ref`. Rejects with `media_not_found` when the tool call is
+	 * unknown or the index does not point at an image block.
+	 */
+	async getMedia(toolCallId: string, contentIndex: number): Promise<ImageContent> {
+		const response = await this.send({ type: "get_media", toolCallId, contentIndex });
+		return this.getData<{ toolCallId: string; contentIndex: number; content: ImageContent }>(response).content;
+	}
+
+	/**
 	 * Get available commands (extension commands, prompt templates, skills).
 	 */
 	async getCommands(): Promise<RpcSlashCommand[]> {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -132,6 +132,12 @@ type RpcSessionCommand =
 
 	// Messages
 	| { id?: string; type: "get_messages" }
+	/**
+	 * Fetch one media block a `media_placeholders` client received as an `image_ref`
+	 * stub. `contentIndex` indexes the toolResult's `content` array and must point at
+	 * an image block; anything else answers `media_not_found`.
+	 */
+	| { id?: string; type: "get_media"; toolCallId: string; contentIndex: number }
 
 	// Commands and loaded runtime surfaces
 	| { id?: string; type: "get_commands" }
@@ -164,6 +170,7 @@ export const RPC_ERROR_MULTI_SESSION_DISABLED = "multi_session_disabled";
 export const RPC_ERROR_INVALID_PATH = "invalid_path";
 export const RPC_ERROR_OPEN_FAILED = "open_failed";
 export const RPC_ERROR_TOO_MANY_SESSIONS = "too_many_sessions";
+export const RPC_ERROR_MEDIA_NOT_FOUND = "media_not_found";
 
 export type RpcErrorCode =
 	| typeof RPC_ERROR_UNKNOWN_SESSION
@@ -173,7 +180,8 @@ export type RpcErrorCode =
 	| typeof RPC_ERROR_MULTI_SESSION_DISABLED
 	| typeof RPC_ERROR_INVALID_PATH
 	| typeof RPC_ERROR_OPEN_FAILED
-	| typeof RPC_ERROR_TOO_MANY_SESSIONS;
+	| typeof RPC_ERROR_TOO_MANY_SESSIONS
+	| typeof RPC_ERROR_MEDIA_NOT_FOUND;
 
 /** Every established command accepts an additive routing envelope. */
 export type RpcCommand =
@@ -519,6 +527,13 @@ export type RpcResponse =
 
 	// Messages
 	| { id?: string; type: "response"; command: "get_messages"; success: true; data: { messages: AgentMessage[] } }
+	| {
+			id?: string;
+			type: "response";
+			command: "get_media";
+			success: true;
+			data: { toolCallId: string; contentIndex: number; content: ImageContent };
+	  }
 
 	// Commands and loaded runtime surfaces
 	| {

--- a/packages/coding-agent/src/modes/rpc/session-command-router.ts
+++ b/packages/coding-agent/src/modes/rpc/session-command-router.ts
@@ -1,6 +1,6 @@
 import { VERSION } from "../../config.ts";
 import { buildRpcSessionState } from "./connection-handler.ts";
-import { AUTO_TITLE_SESSIONS_CAPABILITY } from "./custom-capability.ts";
+import { AUTO_TITLE_SESSIONS_CAPABILITY, MEDIA_PLACEHOLDERS_CAPABILITY } from "./custom-capability.ts";
 import type { RpcCommand, RpcResponse } from "./rpc-types.ts";
 import {
 	RPC_ERROR_MISSING_SESSION_ID,
@@ -103,6 +103,7 @@ export class SessionCommandRouter {
 			const capabilities = new Set([
 				"multi_session",
 				AUTO_TITLE_SESSIONS_CAPABILITY,
+				MEDIA_PLACEHOLDERS_CAPABILITY,
 				...(this.connectionOptions?.capabilities ?? []),
 			]);
 			return {

--- a/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-fanout.ts
@@ -1,3 +1,6 @@
+import { MEDIA_PLACEHOLDERS_CAPABILITY, RENDERED_COMPONENTS_CAPABILITY } from "./custom-capability.ts";
+import { serializeJsonLine } from "./jsonl.ts";
+import { omitInlineMedia } from "./media-placeholders.ts";
 import { SocketEventSinkActor } from "./socket-event-fanout.ts";
 
 export type RawWriter = (chunk: string) => void;
@@ -30,7 +33,30 @@ type RegisteredConnection = {
 	readonly actor: SocketEventSinkActor;
 };
 
-type SnapshotRecord = { readonly line: string; readonly rendered: boolean };
+/**
+ * A replayable snapshot line.
+ *
+ * `placeholderLine` is the `media_placeholders` variant. The writer supplies it only when
+ * a capable connection was already attached when the record was emitted; a connection that
+ * attaches later still needs it, so `source` carries the wire record and the variant is
+ * derived once, on the first capable replay, then memoized. Records with no media resolve
+ * `placeholderLine` to `line`, so replay stays O(1) and never re-serializes twice.
+ */
+type SnapshotRecord = {
+	readonly line: string;
+	placeholderLine?: string;
+	readonly source?: Record<string, unknown>;
+	readonly rendered: boolean;
+};
+
+/** The placeholder variant of a remembered record, derived and memoized on first use. */
+function snapshotPlaceholderLine(record: SnapshotRecord): string {
+	if (record.placeholderLine !== undefined) return record.placeholderLine;
+	const redacted = record.source === undefined ? undefined : omitInlineMedia(record.source);
+	record.placeholderLine =
+		redacted === undefined || redacted === record.source ? record.line : serializeJsonLine(redacted);
+	return record.placeholderLine;
+}
 
 export class SessionEventFanout {
 	private readonly connections = new Map<string, RegisteredConnection>();
@@ -47,12 +73,12 @@ export class SessionEventFanout {
 		const actor = new SocketEventSinkActor(
 			connection,
 			(cause) => {
-			if (this.connections.get(id)?.actor === actor) {
-				this.connections.delete(id);
-				this.connectionCapabilities.delete(id);
-				this.connectionSessions.delete(id);
-				this.registeredCapabilityConnections.delete(id);
-			}
+				if (this.connections.get(id)?.actor === actor) {
+					this.connections.delete(id);
+					this.connectionCapabilities.delete(id);
+					this.connectionSessions.delete(id);
+					this.registeredCapabilityConnections.delete(id);
+				}
 				process.stderr.write(
 					`senpi rpc connection ${id} event queue failed; closing: ${cause instanceof Error ? cause.message : String(cause)}\n`,
 				);
@@ -91,10 +117,10 @@ export class SessionEventFanout {
 	setConnectionCapabilities(id: string, capabilities: readonly string[]): void {
 		const registered = this.connections.get(id);
 		if (!registered) return;
-		const wasCapable = this.connectionCapabilities.get(id)?.has("rendered_components") ?? false;
+		const wasCapable = this.connectionCapabilities.get(id)?.has(RENDERED_COMPONENTS_CAPABILITY) ?? false;
 		this.connectionCapabilities.set(id, new Set(capabilities));
 		this.registeredCapabilityConnections.add(id);
-		if (!wasCapable && capabilities.includes("rendered_components"))
+		if (!wasCapable && capabilities.includes(RENDERED_COMPONENTS_CAPABILITY))
 			for (const sessionId of this.connectionSessions.get(id) ?? []) this.replayRendered(id, sessionId);
 	}
 
@@ -115,9 +141,15 @@ export class SessionEventFanout {
 	}
 
 	hasCapableConnection(sessionId: string): boolean {
-		for (const [id, capabilities] of this.connectionCapabilities)
-			if (capabilities.has("rendered_components") && this.connectionSessions.get(id)?.has(sessionId)) return true;
+		for (const id of this.connectionCapabilities.keys())
+			if (this.connectionHas(id, RENDERED_COMPONENTS_CAPABILITY) && this.connectionSessions.get(id)?.has(sessionId))
+				return true;
 		return false;
+	}
+
+	/** Whether a connection advertised a capability. The only capability lookup in this file. */
+	connectionHas(id: string | undefined, capability: string): boolean {
+		return id === undefined ? false : (this.connectionCapabilities.get(id)?.has(capability) ?? false);
 	}
 
 	targets(
@@ -134,7 +166,7 @@ export class SessionEventFanout {
 			return this.connections.size > 0
 				? [...this.connections.keys()].filter(
 						(id) =>
-							this.connectionCapabilities.get(id)?.has("rendered_components") &&
+							this.connectionHas(id, RENDERED_COMPONENTS_CAPABILITY) &&
 							this.connectionSessions.get(id)?.has(sessionId),
 					)
 				: [undefined];
@@ -160,9 +192,20 @@ export class SessionEventFanout {
 		for (const { actor } of this.connections.values()) actor.enqueue(line);
 	}
 
-	rememberSnapshot(sessionId: string, value: Record<string, unknown>, line: string): void {
+	rememberSnapshot(
+		sessionId: string,
+		value: Record<string, unknown>,
+		line: string,
+		placeholderLine?: string,
+		source?: Record<string, unknown>,
+	): void {
 		const event = value.assistantMessageEvent as Record<string, unknown> | undefined;
-		const record = { line, rendered: value[RENDERED_COMPONENT_RECORD] === true };
+		const record: SnapshotRecord = {
+			line,
+			placeholderLine,
+			source,
+			rendered: value[RENDERED_COMPONENT_RECORD] === true,
+		};
 		if (value.type === "message_start" || (value.type === "message_update" && event?.type === "text_start")) {
 			this.sessionSnapshots.set(sessionId, [record]);
 		} else if (this.sessionSnapshots.has(sessionId)) {
@@ -178,9 +221,10 @@ export class SessionEventFanout {
 	private replaySnapshot(id: string, sessionId: string): void {
 		const actor = this.connections.get(id)?.actor;
 		if (!actor) return;
-		const capable = this.connectionCapabilities.get(id)?.has("rendered_components") ?? false;
+		const capable = this.connectionHas(id, RENDERED_COMPONENTS_CAPABILITY);
+		const placeholders = this.connectionHas(id, MEDIA_PLACEHOLDERS_CAPABILITY);
 		for (const record of this.sessionSnapshots.get(sessionId) ?? [])
-			if (!record.rendered || capable) actor.enqueue(record.line);
+			if (!record.rendered || capable) actor.enqueue(placeholders ? snapshotPlaceholderLine(record) : record.line);
 	}
 
 	private replayRendered(id: string, sessionId: string): void {

--- a/packages/coding-agent/src/modes/rpc/session-event-writer.ts
+++ b/packages/coding-agent/src/modes/rpc/session-event-writer.ts
@@ -1,5 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { MEDIA_PLACEHOLDERS_CAPABILITY } from "./custom-capability.ts";
 import { serializeJsonLine } from "./jsonl.ts";
+import { omitInlineMedia } from "./media-placeholders.ts";
 import {
 	RENDERED_COMPONENT_RECORD,
 	SessionEventFanout,
@@ -188,7 +190,6 @@ export class SessionEventWriter {
 		const tagged = { ...value, sessionId } as RpcRecord;
 		const { [RENDERED_COMPONENT_RECORD]: _rendered, ...wireTagged } = tagged;
 		const line = serializeJsonLine(wireTagged);
-		if (!isTargeted) this.fanout.rememberSnapshot(sessionId, tagged, line);
 		const targets = this.fanout.targets(
 			sessionId,
 			targetId,
@@ -196,18 +197,28 @@ export class SessionEventWriter {
 			record[RENDERED_COMPONENT_RECORD] === true,
 			record.type,
 		);
+		// A record is only walked and re-serialized when a target asked for placeholders;
+		// otherwise this is byte-for-byte today's path, with serializeJsonLine called once.
+		const hasPlaceholderTarget = targets.some((target) =>
+			this.fanout.connectionHas(target, MEDIA_PLACEHOLDERS_CAPABILITY),
+		);
+		const redacted = hasPlaceholderTarget ? omitInlineMedia(wireTagged) : wireTagged;
+		const placeholderLine = redacted === wireTagged ? undefined : serializeJsonLine(redacted);
+		if (!isTargeted) this.fanout.rememberSnapshot(sessionId, tagged, line, placeholderLine, wireTagged);
 		for (const target of targets) {
 			if (target !== undefined && !this.fanout.get(target)) continue;
 			const registered = target === undefined ? undefined : this.fanout.get(target);
+			const wants =
+				placeholderLine !== undefined && this.fanout.connectionHas(target, MEDIA_PLACEHOLDERS_CAPABILITY);
 			if (registered) {
 				const keyed = compactDelta(tagged) !== undefined && tagged.message !== null;
 				registered.actor.enqueue(
-					line,
+					wants ? placeholderLine : line,
 					keyed ? MESSAGE_KEY : undefined,
 					undefined,
 					keyed ? serializeJsonLine(demoteToDeltaOnly(wireTagged)) : undefined,
 				);
-			} else this.appendSessionRecord(sessionId, wireTagged, target);
+			} else this.appendSessionRecord(sessionId, wants ? (redacted as RpcRecord) : wireTagged, target);
 		}
 		this.requestFlush();
 		return true;

--- a/packages/coding-agent/test/auto-title-sessions-flag.test.ts
+++ b/packages/coding-agent/test/auto-title-sessions-flag.test.ts
@@ -2,7 +2,7 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai/compat";
 import { afterEach, describe, expect, test } from "vitest";
 import { parseArgs } from "../src/cli/args.ts";
 import { resolveAutoTitleSessions } from "../src/main.ts";
-import { AUTO_TITLE_SESSIONS_CAPABILITY } from "../src/modes/rpc/custom-capability.ts";
+import { AUTO_TITLE_SESSIONS_CAPABILITY, MEDIA_PLACEHOLDERS_CAPABILITY } from "../src/modes/rpc/custom-capability.ts";
 import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
 import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
 import { waitForSessionName } from "./agent-session-auto-title-helpers.ts";
@@ -99,7 +99,9 @@ describe("RPC protocol capabilities", () => {
 		const registry = { list: () => [] } as never;
 		const router = new SessionCommandRouter(registry, new SessionEventWriter(() => {}), { cwd: "/tmp" });
 		const response = await router.handle({ id: "probe", type: "get_protocol_info" });
-		expect(response).toMatchObject({ data: { capabilities: ["multi_session", AUTO_TITLE_SESSIONS_CAPABILITY] } });
+		expect(response).toMatchObject({
+			data: { capabilities: ["multi_session", AUTO_TITLE_SESSIONS_CAPABILITY, MEDIA_PLACEHOLDERS_CAPABILITY] },
+		});
 	});
 });
 

--- a/packages/coding-agent/test/rpc-get-media.test.ts
+++ b/packages/coding-agent/test/rpc-get-media.test.ts
@@ -1,0 +1,248 @@
+/**
+ * `get_media` on-demand media fetch + `media_placeholders` capability advertisement.
+ *
+ * A connection that opted into `media_placeholders` receives `image_ref` stubs instead
+ * of inline base64 inside tool results; this command is how it fetches the original
+ * block back. The lookup is the durable session record first
+ * (`sessionManager.getEntries()` message entries with `role: "toolResult"`), then the
+ * live agent message window (`session.messages`) for results that have not been
+ * persisted yet.
+ *
+ * Harness: the in-process classic RPC harness (`test/fixtures/rpc-classic-harness.ts`,
+ * same mocks as `test/rpc-classic-compat.test.ts`) — commands are driven through the
+ * injected stdin line handler and every emitted line is captured at the
+ * `writeRawStdout` boundary. The capability advertisement is asserted in BOTH modes:
+ * classic (`connection-handler.ts`) through the harness, multi
+ * (`session-command-router.ts`) through a direct router call as in
+ * `test/rpc-multi-session.test.ts`.
+ */
+
+import { setMaxListeners } from "node:events";
+import type { ImageContent, ToolResultMessage } from "@earendil-works/pi-ai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSession } from "../src/core/agent-session.ts";
+import { MEDIA_PLACEHOLDERS_CAPABILITY } from "../src/modes/rpc/custom-capability.ts";
+import { RpcClient } from "../src/modes/rpc/rpc-client.ts";
+import { runRpcMode } from "../src/modes/rpc/rpc-mode.ts";
+import { RPC_ERROR_MEDIA_NOT_FOUND } from "../src/modes/rpc/rpc-types.ts";
+import { SessionCommandRouter } from "../src/modes/rpc/session-command-router.ts";
+import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
+import { createFakeRuntimeHost, type ParsedOutputLine, parseOutputLines } from "./fixtures/rpc-classic-harness.ts";
+
+const rpcIo = {
+	outputLines: [] as string[],
+	lineHandler: undefined as ((line: string) => void) | undefined,
+};
+
+vi.mock("../src/core/output-guard.js", () => ({
+	flushRawStdout: vi.fn(async () => {}),
+	takeOverStdout: vi.fn(),
+	waitForRawStdoutBackpressure: vi.fn(async () => {}),
+	writeRawStdout: (chunk: string) => {
+		rpcIo.outputLines.push(chunk);
+	},
+}));
+
+vi.mock("../src/modes/interactive/theme/theme.js", () => ({ theme: {} }));
+
+vi.mock("../src/modes/rpc/jsonl.js", () => ({
+	MAX_RPC_LINE_CHARACTERS: 16 * 1024 * 1024,
+	attachJsonlLineReader: vi.fn((_stream: NodeJS.ReadableStream, onLine: (line: string) => void) => {
+		rpcIo.lineHandler = onLine;
+		return () => {};
+	}),
+	serializeJsonLine: (value: unknown) => `${JSON.stringify(value)}\n`,
+}));
+
+const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUg==";
+
+interface StartedRpc {
+	lineHandler: (line: string) => void;
+	session: AgentSession;
+	cleanup: () => Promise<void>;
+}
+
+async function startClassicRpc(): Promise<StartedRpc> {
+	rpcIo.outputLines = [];
+	rpcIo.lineHandler = undefined;
+
+	const host = await createFakeRuntimeHost({ withSwapSession: false, withAuth: true, responseDelayMs: 0 });
+	void runRpcMode(host.runtimeHost);
+	await vi.waitFor(() => expect(rpcIo.lineHandler).toBeDefined());
+
+	return {
+		lineHandler: rpcIo.lineHandler!,
+		session: host.runtimeHost.session,
+		cleanup: host.cleanup,
+	};
+}
+
+function sendCommand(lineHandler: (line: string) => void, command: Record<string, unknown>): string {
+	const id = `c-${Math.random().toString(36).slice(2, 10)}`;
+	lineHandler(JSON.stringify({ id, ...command }));
+	return id;
+}
+
+function responseFor(id: string): ParsedOutputLine | undefined {
+	return parseOutputLines(rpcIo.outputLines).find((record) => record.id === id && record.type === "response");
+}
+
+async function awaitResponse(id: string): Promise<ParsedOutputLine> {
+	await vi.waitFor(() => expect(responseFor(id)).toBeDefined());
+	return responseFor(id)!;
+}
+
+function toolResult(toolCallId: string, content: ToolResultMessage["content"]): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read_image",
+		content,
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+describe("get_media", () => {
+	beforeEach(() => {
+		setMaxListeners(0, process);
+		setMaxListeners(0, process.stdin);
+	});
+	afterEach(() => {
+		rpcIo.outputLines = [];
+		rpcIo.lineHandler = undefined;
+	});
+
+	it("returns the original image block from a persisted toolResult entry", async () => {
+		const { lineHandler, session, cleanup } = await startClassicRpc();
+		try {
+			const image: ImageContent = { type: "image", data: PNG_BASE64, mimeType: "image/png" };
+			session.sessionManager.appendMessage(
+				toolResult("call_persisted", [{ type: "text", text: "screenshot" }, image]),
+			);
+
+			const id = sendCommand(lineHandler, { type: "get_media", toolCallId: "call_persisted", contentIndex: 1 });
+			const response = await awaitResponse(id);
+
+			expect(response).toMatchObject({
+				type: "response",
+				command: "get_media",
+				success: true,
+				data: {
+					toolCallId: "call_persisted",
+					contentIndex: 1,
+					content: { type: "image", data: PNG_BASE64, mimeType: "image/png" },
+				},
+			});
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("falls back to the live message window for a not-yet-persisted toolResult", async () => {
+		const { lineHandler, session, cleanup } = await startClassicRpc();
+		try {
+			const image: ImageContent = { type: "image", data: PNG_BASE64, mimeType: "image/jpeg" };
+			// Live agent state only: nothing appended to the session manager.
+			session.messages.push(toolResult("call_live", [image]));
+
+			const id = sendCommand(lineHandler, { type: "get_media", toolCallId: "call_live", contentIndex: 0 });
+			const response = await awaitResponse(id);
+
+			expect(response).toMatchObject({
+				success: true,
+				data: { content: { type: "image", data: PNG_BASE64, mimeType: "image/jpeg" } },
+			});
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("answers media_not_found for an unknown toolCallId", async () => {
+		const { lineHandler, cleanup } = await startClassicRpc();
+		try {
+			const id = sendCommand(lineHandler, { type: "get_media", toolCallId: "call_missing", contentIndex: 0 });
+			const response = await awaitResponse(id);
+
+			expect(response).toMatchObject({
+				command: "get_media",
+				success: false,
+				error: RPC_ERROR_MEDIA_NOT_FOUND,
+				errorCode: RPC_ERROR_MEDIA_NOT_FOUND,
+			});
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("answers media_not_found when contentIndex is not an image block", async () => {
+		const { lineHandler, session, cleanup } = await startClassicRpc();
+		try {
+			session.sessionManager.appendMessage(
+				toolResult("call_text", [
+					{ type: "text", text: "no image here" },
+					{ type: "image", data: PNG_BASE64, mimeType: "image/png" },
+				]),
+			);
+
+			const textIndex = sendCommand(lineHandler, { type: "get_media", toolCallId: "call_text", contentIndex: 0 });
+			const outOfRange = sendCommand(lineHandler, { type: "get_media", toolCallId: "call_text", contentIndex: 9 });
+
+			expect(await awaitResponse(textIndex)).toMatchObject({
+				success: false,
+				error: RPC_ERROR_MEDIA_NOT_FOUND,
+				errorCode: RPC_ERROR_MEDIA_NOT_FOUND,
+			});
+			expect(await awaitResponse(outOfRange)).toMatchObject({
+				success: false,
+				error: RPC_ERROR_MEDIA_NOT_FOUND,
+				errorCode: RPC_ERROR_MEDIA_NOT_FOUND,
+			});
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("advertises media_placeholders in get_protocol_info in classic mode", async () => {
+		const { lineHandler, cleanup } = await startClassicRpc();
+		try {
+			const id = sendCommand(lineHandler, { type: "get_protocol_info" });
+			const response = await awaitResponse(id);
+			const data = response.data as { capabilities: string[]; mode: string };
+
+			expect(data.mode).toBe("classic");
+			expect(data.capabilities).toContain(MEDIA_PLACEHOLDERS_CAPABILITY);
+		} finally {
+			await cleanup();
+		}
+	});
+
+	it("advertises media_placeholders in get_protocol_info in multi mode", async () => {
+		const registry = { list: () => [] } as never;
+		const router = new SessionCommandRouter(registry, new SessionEventWriter(() => {}), { cwd: "/tmp" });
+
+		const response = await router.handle({ id: "probe", type: "get_protocol_info" });
+		const data = (response as { data: { capabilities: string[]; mode: string } }).data;
+
+		expect(data.mode).toBe("multi");
+		expect(data.capabilities).toContain(MEDIA_PLACEHOLDERS_CAPABILITY);
+	});
+
+	it("RpcClient.getMedia sends the command and unwraps the content block", async () => {
+		const client = new RpcClient();
+		const sent: unknown[] = [];
+		const content: ImageContent = { type: "image", data: PNG_BASE64, mimeType: "image/png" };
+		(client as unknown as { send: (command: unknown) => Promise<unknown> }).send = async (command) => {
+			sent.push(command);
+			return {
+				type: "response",
+				command: "get_media",
+				success: true,
+				data: { toolCallId: "call_abc", contentIndex: 1, content },
+			};
+		};
+
+		await expect(client.getMedia("call_abc", 1)).resolves.toEqual(content);
+		expect(sent).toEqual([{ type: "get_media", toolCallId: "call_abc", contentIndex: 1 }]);
+	});
+});

--- a/packages/coding-agent/test/rpc-media-placeholders.test.ts
+++ b/packages/coding-agent/test/rpc-media-placeholders.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import { omitInlineMedia } from "../src/modes/rpc/media-placeholders.ts";
+
+const PNG_BASE64 = "aGVsbG8gd29ybGQh"; // 16 chars, no padding -> 12 bytes
+
+function toolResultMessage(data: string): Record<string, unknown> {
+	return {
+		role: "toolResult",
+		toolCallId: "call_abc",
+		toolName: "read",
+		content: [
+			{ type: "text", text: "read image" },
+			{ type: "image", data, mimeType: "image/png" },
+		],
+	};
+}
+
+describe("omitInlineMedia", () => {
+	it("returns the same reference when the record carries no tool-result image", () => {
+		const record = {
+			type: "message_end",
+			message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+		};
+
+		expect(omitInlineMedia(record)).toBe(record);
+	});
+
+	it("never walks a message_update record even when it nests a toolResult image", () => {
+		// The hot path must pay nothing: message_update is type-gated out, so a
+		// (non-production) nested toolResult image is returned untouched, by reference.
+		const record = {
+			type: "message_update",
+			message: toolResultMessage(PNG_BASE64),
+		};
+
+		expect(omitInlineMedia(record)).toBe(record);
+	});
+
+	it("replaces images inside a toolResult message and copies on write", () => {
+		const message = toolResultMessage(PNG_BASE64);
+		const content = message.content;
+		const record = { type: "message_end", sessionId: "rpc-1", message };
+
+		const result = omitInlineMedia(record) as {
+			type: string;
+			sessionId: string;
+			message: { content: Array<Record<string, unknown>> };
+		};
+
+		expect(result).not.toBe(record);
+		expect(result.type).toBe("message_end");
+		expect(result.sessionId).toBe("rpc-1");
+		expect(result.message).not.toBe(message);
+		expect(result.message.content).not.toBe(content);
+		expect(result.message.content[0]).toEqual({ type: "text", text: "read image" });
+		expect(result.message.content[1]).toEqual({
+			type: "image_ref",
+			mimeType: "image/png",
+			byteLength: 12,
+			ref: { toolCallId: "call_abc", contentIndex: 1 },
+		});
+		// Input untouched: responses hand out live session state.
+		expect(message.content).toBe(content);
+		expect((content as Array<Record<string, unknown>>)[1]).toEqual({
+			type: "image",
+			data: PNG_BASE64,
+			mimeType: "image/png",
+		});
+	});
+
+	it("replaces images inside tool_execution_end.result.content", () => {
+		const record = {
+			type: "tool_execution_end",
+			toolCallId: "call_xyz",
+			toolName: "read",
+			result: {
+				output: "ok",
+				content: [{ type: "image", data: PNG_BASE64, mimeType: "image/jpeg" }],
+			},
+		};
+
+		const result = omitInlineMedia(record) as { result: { output: string; content: Array<unknown> } };
+
+		expect(result).not.toBe(record);
+		expect(result.result.output).toBe("ok");
+		expect(result.result.content[0]).toEqual({
+			type: "image_ref",
+			mimeType: "image/jpeg",
+			byteLength: 12,
+			ref: { toolCallId: "call_xyz", contentIndex: 0 },
+		});
+	});
+
+	it("leaves user-message images intact", () => {
+		const record = {
+			type: "message_start",
+			message: {
+				role: "user",
+				content: [{ type: "image", data: PNG_BASE64, mimeType: "image/png" }],
+			},
+		};
+
+		expect(omitInlineMedia(record)).toBe(record);
+	});
+
+	it("transforms nested get_tree entries in a response payload", () => {
+		const record = {
+			type: "response",
+			command: "get_tree",
+			success: true,
+			data: {
+				tree: {
+					entry: { type: "message", id: "e1", message: { role: "assistant", content: [] } },
+					children: [
+						{
+							entry: { type: "message", id: "e2", message: toolResultMessage(PNG_BASE64) },
+							children: [],
+						},
+					],
+				},
+			},
+		};
+
+		const result = omitInlineMedia(record) as unknown as {
+			data: { tree: { children: Array<{ entry: { message: { content: Array<Record<string, unknown>> } } }> } };
+		};
+
+		expect(result).not.toBe(record);
+		expect(result.data.tree.children[0]!.entry.message.content[1]).toEqual({
+			type: "image_ref",
+			mimeType: "image/png",
+			byteLength: 12,
+			ref: { toolCallId: "call_abc", contentIndex: 1 },
+		});
+	});
+
+	it("transforms get_entries response entries", () => {
+		const record = {
+			type: "response",
+			command: "get_entries",
+			success: true,
+			data: {
+				entries: [
+					{ type: "message", id: "e1", message: toolResultMessage(PNG_BASE64) },
+					{ type: "thinking_level_change", id: "e2", thinkingLevel: "off" },
+				],
+			},
+		};
+
+		const result = omitInlineMedia(record) as {
+			data: { entries: Array<{ message?: { content: Array<Record<string, unknown>> } }> };
+		};
+
+		expect(result.data.entries[0]!.message!.content[1]).toMatchObject({ type: "image_ref" });
+		expect(result.data.entries[1]).toEqual({ type: "thinking_level_change", id: "e2", thinkingLevel: "off" });
+	});
+
+	it("transforms open_session state.entries", () => {
+		const record = {
+			type: "response",
+			command: "open_session",
+			success: true,
+			data: {
+				sessionId: "rpc-1",
+				state: {
+					entries: [{ type: "message", id: "e1", message: toolResultMessage(PNG_BASE64) }],
+				},
+			},
+		};
+
+		const result = omitInlineMedia(record) as unknown as {
+			data: { state: { entries: Array<{ message: { content: Array<Record<string, unknown>> } }> } };
+		};
+
+		expect(result.data.state.entries[0]!.message.content[1]).toMatchObject({ type: "image_ref" });
+	});
+
+	it("leaves an unrelated response command untouched", () => {
+		const record = {
+			type: "response",
+			command: "get_commands",
+			success: true,
+			data: { messages: [toolResultMessage(PNG_BASE64)] },
+		};
+
+		expect(omitInlineMedia(record)).toBe(record);
+	});
+
+	it("computes byteLength from the base64 length without decoding", () => {
+		const cases: Array<{ data: string; bytes: number }> = [
+			{ data: "", bytes: 0 },
+			{ data: "QQ==", bytes: 1 },
+			{ data: "QUI=", bytes: 2 },
+			{ data: "QUJD", bytes: 3 },
+			{ data: "A".repeat(1024), bytes: 768 },
+		];
+
+		for (const { data, bytes } of cases) {
+			const record = {
+				type: "tool_execution_end",
+				toolCallId: "call_1",
+				result: { content: [{ type: "image", data, mimeType: "image/png" }] },
+			};
+			const result = omitInlineMedia(record) as unknown as { result: { content: Array<{ byteLength: number }> } };
+			expect(result.result.content[0]!.byteLength).toBe(bytes);
+		}
+	});
+
+	it("keeps sibling blocks and only rebuilds the changed message", () => {
+		const untouched = { role: "assistant", content: [{ type: "text", text: "hi" }] };
+		const record = {
+			type: "turn_end",
+			toolResults: [untouched, toolResultMessage(PNG_BASE64)],
+		};
+
+		const result = omitInlineMedia(record) as { toolResults: Array<Record<string, unknown>> };
+
+		expect(result.toolResults[0]).toBe(untouched);
+		expect((result.toolResults[1] as { content: Array<Record<string, unknown>> }).content[1]).toMatchObject({
+			type: "image_ref",
+		});
+	});
+});

--- a/packages/coding-agent/test/rpc-multi-session-events.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session-events.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MEDIA_PLACEHOLDERS_CAPABILITY } from "../src/modes/rpc/custom-capability.ts";
 import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
 import { SessionExtensionUiRequests } from "../src/modes/rpc/session-extension-ui-requests.ts";
 
@@ -33,6 +34,28 @@ function flushedDeltas(output: readonly Record<string, unknown>[]): string {
 		.filter((record) => record.type === "message_update")
 		.map((record) => (record.assistantMessageEvent as { delta?: string }).delta ?? "")
 		.join("");
+}
+
+const SNAPSHOT_IMAGE_BASE64 = "aGVsbG8gd29ybGQh"; // 16 chars -> 12 bytes decoded
+
+function toolResultEnd(): Record<string, unknown> {
+	return {
+		type: "tool_execution_end",
+		toolCallId: "call_abc",
+		toolName: "read",
+		result: {
+			content: [
+				{ type: "text", text: "read image" },
+				{ type: "image", data: SNAPSHOT_IMAGE_BASE64, mimeType: "image/png" },
+			],
+		},
+	};
+}
+
+function imageBlock(chunks: readonly string[]): Record<string, unknown> | undefined {
+	const record = records(chunks).find((parsed) => parsed.type === "tool_execution_end");
+	const content = (record?.result as { content?: Array<Record<string, unknown>> } | undefined)?.content;
+	return content?.[1];
 }
 
 function deferred<T = void>(): {
@@ -673,6 +696,60 @@ describe("multi-session RPC event writer", () => {
 			success: true,
 			sessionId: "a",
 		});
+	});
+
+	it("replays the placeholder snapshot variant to a capable connection attaching mid-message", async () => {
+		const first: string[] = [];
+		const capable: string[] = [];
+		const writer = new SessionEventWriter(() => {});
+		writer.registerConnection("first", {
+			writeRaw: (chunk) => first.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.attachConnectionToSession("first", "session");
+		writer.enqueue("session", { type: "message_start", message: { role: "assistant", content: [] } });
+		writer.enqueue("session", toolResultEnd());
+		await writer.flush();
+
+		// When: a media_placeholders client attaches mid-message.
+		writer.registerConnection("capable", {
+			writeRaw: (chunk) => capable.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.setConnectionCapabilities("capable", [MEDIA_PLACEHOLDERS_CAPABILITY]);
+		writer.attachConnectionToSession("capable", "session");
+		await writer.flush();
+
+		// Then: the replayed snapshot carries placeholders, the live client kept the bytes.
+		expect(imageBlock(capable)).toEqual({
+			type: "image_ref",
+			mimeType: "image/png",
+			byteLength: 12,
+			ref: { toolCallId: "call_abc", contentIndex: 1 },
+		});
+		expect(imageBlock(first)).toEqual({ type: "image", data: SNAPSHOT_IMAGE_BASE64, mimeType: "image/png" });
+		expect(records(capable).map((record) => record.type)).toEqual(["message_start", "tool_execution_end"]);
+	});
+
+	it("does not retroactively replay when media_placeholders is advertised after attach", async () => {
+		const late: string[] = [];
+		const writer = new SessionEventWriter(() => {});
+		writer.registerConnection("late", {
+			writeRaw: (chunk) => late.push(chunk),
+			waitForBackpressure: async () => {},
+		});
+		writer.attachConnectionToSession("late", "session");
+		writer.enqueue("session", { type: "message_start", message: { role: "assistant", content: [] } });
+		writer.enqueue("session", toolResultEnd());
+		await writer.flush();
+
+		// When: the connection flips the capability on after it already received the bytes.
+		writer.setConnectionCapabilities("late", [MEDIA_PLACEHOLDERS_CAPABILITY]);
+		await writer.flush();
+
+		// Then: nothing is replayed; the earlier records stay as delivered.
+		expect(records(late).map((record) => record.type)).toEqual(["message_start", "tool_execution_end"]);
+		expect(imageBlock(late)).toEqual({ type: "image", data: SNAPSHOT_IMAGE_BASE64, mimeType: "image/png" });
 	});
 
 	it("rejects flush and control completion on permanent stdout errors", async () => {

--- a/packages/coding-agent/test/rpc-multi-session.test.ts
+++ b/packages/coding-agent/test/rpc-multi-session.test.ts
@@ -49,7 +49,7 @@ describe("multi-session RPC routing", () => {
 			data: {
 				protocolVersion: 1,
 				serverVersion: VERSION,
-				capabilities: ["multi_session", "auto_title_sessions"],
+				capabilities: ["multi_session", "auto_title_sessions", "media_placeholders"],
 				mode: "multi",
 			},
 		});

--- a/packages/coding-agent/test/session-event-writer-socket-fanout.test.ts
+++ b/packages/coding-agent/test/session-event-writer-socket-fanout.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { MEDIA_PLACEHOLDERS_CAPABILITY } from "../src/modes/rpc/custom-capability.ts";
+import * as jsonl from "../src/modes/rpc/jsonl.ts";
 import { SessionEventWriter } from "../src/modes/rpc/session-event-writer.ts";
+
+vi.mock("../src/modes/rpc/jsonl.ts", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/modes/rpc/jsonl.ts")>();
+	return { ...actual, serializeJsonLine: vi.fn(actual.serializeJsonLine) };
+});
+
+const serializeJsonLineSpy = vi.mocked(jsonl.serializeJsonLine);
 
 type StalledConnection = {
 	writes: string[];
@@ -35,6 +44,111 @@ function stalledConnection(): StalledConnection {
 }
 
 const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+const IMAGE_BASE64 = "aGVsbG8gd29ybGQh"; // 16 chars -> 12 bytes decoded
+
+function openConnection(): {
+	writes: string[];
+	connection: { writeRaw(chunk: string): void; waitForBackpressure(): Promise<void> };
+} {
+	const writes: string[] = [];
+	return {
+		writes,
+		connection: {
+			writeRaw: (chunk) => {
+				writes.push(chunk);
+			},
+			waitForBackpressure: async () => {},
+		},
+	};
+}
+
+function toolResultEnd(): Record<string, unknown> {
+	return {
+		type: "tool_execution_end",
+		toolCallId: "call_abc",
+		toolName: "read",
+		result: {
+			content: [
+				{ type: "text", text: "read image" },
+				{ type: "image", data: IMAGE_BASE64, mimeType: "image/png" },
+			],
+		},
+	};
+}
+
+function blocks(chunks: readonly string[]): Array<Record<string, unknown>> {
+	const record = chunks
+		.join("")
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line) as Record<string, unknown>)
+		.find((parsed) => parsed.type === "tool_execution_end");
+	return ((record?.result as { content?: Array<Record<string, unknown>> } | undefined)?.content ?? []) as Array<
+		Record<string, unknown>
+	>;
+}
+
+describe("SessionEventWriter media placeholders fan-out", () => {
+	it("gives the capable connection image_ref and the default connection the bytes", async () => {
+		// Given: two connections on one session, only one advertising media_placeholders.
+		const writer = new SessionEventWriter(() => {});
+		const capable = openConnection();
+		const plain = openConnection();
+		writer.registerConnection("capable", capable.connection);
+		writer.registerConnection("plain", plain.connection);
+		writer.setConnectionCapabilities("capable", [MEDIA_PLACEHOLDERS_CAPABILITY]);
+		writer.setConnectionCapabilities("plain", []);
+		writer.attachConnectionToSession("capable", "rpc-1");
+		writer.attachConnectionToSession("plain", "rpc-1");
+
+		// When: a tool result carrying an inline image is fanned out.
+		writer.enqueue("rpc-1", toolResultEnd());
+		await writer.flush();
+
+		// Then: the capable client sees a placeholder, the default client sees bytes.
+		expect(blocks(capable.writes)[1]).toEqual({
+			type: "image_ref",
+			mimeType: "image/png",
+			byteLength: 12,
+			ref: { toolCallId: "call_abc", contentIndex: 1 },
+		});
+		expect(blocks(plain.writes)[1]).toEqual({ type: "image", data: IMAGE_BASE64, mimeType: "image/png" });
+		expect(blocks(capable.writes)[0]).toEqual({ type: "text", text: "read image" });
+	});
+
+	it("serializes the record once when no target advertises media_placeholders", async () => {
+		// Given: a single default connection.
+		const writer = new SessionEventWriter(() => {});
+		const plain = openConnection();
+		writer.registerConnection("plain", plain.connection);
+		writer.setConnectionCapabilities("plain", []);
+		writer.attachConnectionToSession("plain", "rpc-1");
+		serializeJsonLineSpy.mockClear();
+
+		// When: an image-bearing record is enqueued.
+		writer.enqueue("rpc-1", toolResultEnd());
+
+		// Then: today's exact path - one serialization, no transform walk.
+		expect(serializeJsonLineSpy).toHaveBeenCalledTimes(1);
+		await writer.flush();
+		expect(blocks(plain.writes)[1]).toEqual({ type: "image", data: IMAGE_BASE64, mimeType: "image/png" });
+	});
+
+	it("reuses the single line for a capable target when the record has no media", async () => {
+		const writer = new SessionEventWriter(() => {});
+		const capable = openConnection();
+		writer.registerConnection("capable", capable.connection);
+		writer.setConnectionCapabilities("capable", [MEDIA_PLACEHOLDERS_CAPABILITY]);
+		writer.attachConnectionToSession("capable", "rpc-1");
+		serializeJsonLineSpy.mockClear();
+
+		writer.enqueue("rpc-1", { type: "message_start", message: { role: "assistant", content: [] } });
+
+		expect(serializeJsonLineSpy).toHaveBeenCalledTimes(1);
+		await writer.flush();
+	});
+});
 
 const textDelta = (delta: string, text: string) => ({
 	type: "message_update",
@@ -72,7 +186,10 @@ describe("SessionEventWriter socket fan-out under a stalled reader", () => {
 		// reached the wire and the desktop rendered "ENABLED" as the whole message.)
 		const updates = connection.writes
 			.slice(1)
-			.map((line) => JSON.parse(line) as { message: unknown; assistantMessageEvent: { delta: string; partial: unknown } });
+			.map(
+				(line) =>
+					JSON.parse(line) as { message: unknown; assistantMessageEvent: { delta: string; partial: unknown } },
+			);
 		expect(updates.map((update) => update.assistantMessageEvent.delta)).toEqual(["ULTRAWORK ", "MODE ", "ENABLED"]);
 		expect(updates.map((update) => update.message === null)).toEqual([true, true, false]);
 		expect(updates.map((update) => update.assistantMessageEvent.partial === null)).toEqual([true, true, false]);

--- a/packages/coding-agent/test/socket-event-fanout.test.ts
+++ b/packages/coding-agent/test/socket-event-fanout.test.ts
@@ -71,7 +71,12 @@ describe("SocketEventSinkActor", () => {
 		expect(sink.writes).toEqual(["barrier\n"]);
 		actor.enqueue('{"delta":"hel","message":{"full":1}}\n', "message", undefined, '{"delta":"hel","message":null}\n');
 		actor.enqueue('{"delta":"lo ","message":{"full":2}}\n', "message", undefined, '{"delta":"lo ","message":null}\n');
-		actor.enqueue('{"delta":"world","message":{"full":3}}\n', "message", undefined, '{"delta":"world","message":null}\n');
+		actor.enqueue(
+			'{"delta":"world","message":{"full":3}}\n',
+			"message",
+			undefined,
+			'{"delta":"world","message":null}\n',
+		);
 
 		// When: the reader drains.
 		for (let i = 0; i < 4; i++) {


### PR DESCRIPTION
## Summary

Structural fix for the 2026-09-03 desktop freeze (follow-up to #1324, which raised the queue cap and closed the socket on overflow): binary tool-result payloads no longer fan out to clients that never render them.

- New opt-in client capability `media_placeholders` (sent in `set_client_info`). For that connection the multi-session host replaces every `{type:"image", data}` block inside tool results with `{type:"image_ref", mimeType, byteLength, ref:{toolCallId, contentIndex}}`.
- The rewrite happens at the single choke point every record crosses, `SessionEventWriter.enqueue`, so all wire paths that carry a `ToolResultMessage` (`message_start`/`message_end`, `turn_end.toolResults`, `agent_end`, `entry_appended`, and the `get_messages` / `get_entries` / `get_tree` / `get_state` / `open_session` responses) plus `tool_execution_end.result.content` are covered without enumerating them. The desktop's re-attach hydration actually goes through `get_entries`, which the earlier path list missed.
- Attach-time snapshot replay hands a capable connection the placeholder variant (derived once, memoized).
- Type-gated (`message_update` is never walked), copy-on-write (live session state handed to responses by reference is never mutated), and skipped entirely when no capable connection is targeted: default clients stay byte-identical with one `serializeJsonLine` per record.
- New `get_media {toolCallId, contentIndex}` command returns the original `ImageContent` (durable entries first, live messages second); unknown tool call / out-of-range index / non-image block answer `media_not_found`. `get_protocol_info` advertises the capability in both modes; `RpcClient.getMedia()`; `docs/rpc.md` documents everything. Classic stdio mode keeps inline media (documented).
- `SessionEventFanout.connectionHas(id, capability)` replaces the hard-coded `"rendered_components"` checks.

## Tests

- `test/rpc-media-placeholders.test.ts` (pure transform: identity on no-op, copy-on-write, `message_update` untouched, nested responses, byteLength math), `test/rpc-get-media.test.ts` (happy path, `media_not_found` cases, protocol info in both modes), extended `session-event-writer-socket-fanout.test.ts` (one capable + one default connection; single serialization without a capable target), `rpc-multi-session-events.test.ts` (placeholder snapshot replay; late capability does not retroactively replay), protocol-info assertions in `rpc-multi-session.test.ts` / `auto-title-sessions-flag.test.ts`.
- RED captured before the implementation for both lanes (transform 2 failed / get_media 7 failed), GREEN after (47 + 28 passed).
- Full `packages/coding-agent` vitest run, `biome check`, `tsc --noEmit` and `bun run build` on mengmotaMac: appended below once the run settles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 2026-09-03 desktop freeze, where four base64 image tool results overflowed a client's socket queue, by replacing inline tool-result images with `image_ref` placeholders for clients that opt in.

**Bug Fixes**
- Clients that send `media_placeholders` in `set_client_info` receive stubs carrying `mimeType`, `byteLength`, and a `{toolCallId, contentIndex}` reference.
- The rewrite runs at a single choke point every record crosses, covering all tool-result wire paths plus attach-time snapshot replay.
- Default clients stay byte-identical and `message_update` is never walked.

**New Features**
- New `get_media` command fetches the original image, checking durable entries before live messages.
- Unknown tool calls, out-of-range indexes, and non-image blocks answer `media_not_found`.
- The capability is advertised in both modes; classic stdio keeps inline media.

<sup>Written for commit 162d295be0962e3035f7f034e390853b34cdd577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

