### PR TITLE
fix(ttsr): interrupt within-message paragraph repetition

### DIFF
--- a/.agents/skills/senpi-qa/scripts/lib/mock-loop-ttsr.mjs
+++ b/.agents/skills/senpi-qa/scripts/lib/mock-loop-ttsr.mjs
@@ -5,7 +5,49 @@ import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks } from ".
 const CTRL_SEP = ["<", "|", "sep", "|", ">"].join("");
 const BANG_RUN_300 = /!{300}/;
 
-export const TTSR_SCENARIOS = ["ttsr-collapse", "ttsr-leak", "ttsr-repetitive-turns"];
+export const TTSR_SCENARIOS = ["ttsr-collapse", "ttsr-leak", "ttsr-repetitive-turns", "ttsr-paragraph-loop"];
+
+// Shape of session 01a06648: the model re-announced the same planning step for minutes as
+// plain text without ever issuing the tool call. Three byte-identical paragraphs per cycle,
+// three cycles, blank-line separated; only the paragraph-repeat mechanism can see it.
+const PARAGRAPH_LOOP_CYCLE = [
+	"Now I'm writing the actual DAG code: setting up the shared context block with rules and tool guidance, then each research lane with its own scoped prompt and report path.",
+	"I'm setting up the goal and todo registration, then writing out the full DAG with all seven lanes, synth, and verify nodes in a single dispatch cell.",
+	"I'm now running the actual DAG start and capturing the run ID to track progress across all the parallel lanes before summarizing.",
+];
+const PARAGRAPH_LOOP_TEXT = `${Array.from({ length: 3 }, () => PARAGRAPH_LOOP_CYCLE.join("\n\n")).join("\n\n")}\n\n`;
+
+function readFirstPersistedAssistant(box) {
+	const files = readdirSync(box.sessionDir, { recursive: true, encoding: "utf8" })
+		.filter((name) => name.endsWith(".jsonl"))
+		.map((name) => join(box.sessionDir, name));
+	for (const file of files) {
+		for (const line of readFileSync(file, "utf8").split(/\r?\n/)) {
+			if (!line.trim()) continue;
+			const entry = JSON.parse(line);
+			if (entry.type === "message" && entry.message?.role === "assistant") return entry.message;
+		}
+	}
+	return undefined;
+}
+
+function assistantText(message) {
+	if (message === undefined || !Array.isArray(message.content)) return "";
+	return message.content
+		.filter((block) => block?.type === "text" && typeof block.text === "string")
+		.map((block) => block.text)
+		.join("");
+}
+
+function countOccurrences(haystack, needle) {
+	let count = 0;
+	let index = haystack.indexOf(needle);
+	while (index !== -1) {
+		count += 1;
+		index = haystack.indexOf(needle, index + needle.length);
+	}
+	return count;
+}
 
 export function isTtsrScenario(name) {
 	return TTSR_SCENARIOS.includes(name);
@@ -166,9 +208,15 @@ export async function runTtsrScenario({ scenarioName, apiName, driveTurn, eviden
 		return runRepetitiveTurnsScenario({ apiName, driveTurn, evidenceSlug, checks, guard, finalMarker, scenarioName });
 	}
 	const collapse = scenarioName === "ttsr-collapse";
-	const firstTurn = collapse
-		? { reasoning: `analyzing the problem ${"!".repeat(600)}`, chunks: 40 }
-		: { reasoning: `Thinking... ${CTRL_SEP} ${CTRL_SEP} ${CTRL_SEP} trailing garbage ${"x".repeat(400)}`, chunks: 20 };
+	const paragraphLoop = scenarioName === "ttsr-paragraph-loop";
+	let firstTurn;
+	if (collapse) {
+		firstTurn = { reasoning: `analyzing the problem ${"!".repeat(600)}`, chunks: 40 };
+	} else if (paragraphLoop) {
+		firstTurn = { text: PARAGRAPH_LOOP_TEXT, chunks: 60 };
+	} else {
+		firstTurn = { reasoning: `Thinking... ${CTRL_SEP} ${CTRL_SEP} ${CTRL_SEP} trailing garbage ${"x".repeat(400)}`, chunks: 20 };
+	}
 	const { box, server, result } = await driveTurn({
 		apiName,
 		turns: [firstTurn, { text: finalMarker }],
@@ -191,6 +239,28 @@ export async function runTtsrScenario({ scenarioName, apiName, driveTurn, eviden
 				"ttsr-collapse: truncated garbage absent from recovery request",
 				!BANG_RUN_300.test(replayBody),
 				`bangRun300=${BANG_RUN_300.test(replayBody)}`,
+			);
+		} else if (paragraphLoop) {
+			const firstParagraph = PARAGRAPH_LOOP_CYCLE[0];
+			const replayOccurrences = countOccurrences(replayBody, JSON.stringify(firstParagraph).slice(1, -1));
+			checks.ok(
+				"ttsr-paragraph-loop: recovery request never replays the repeated paragraph",
+				replayOccurrences <= 1,
+				`firstParagraphOccurrences=${replayOccurrences} (streamed 3)`,
+			);
+			const aborted = readFirstPersistedAssistant(box);
+			const persistedText = assistantText(aborted);
+			checks.ok(
+				"ttsr-paragraph-loop: persisted aborted message keeps the first cycle and is truncated at the first repeat",
+				aborted?.stopReason === "aborted" &&
+					countOccurrences(persistedText, firstParagraph) === 1 &&
+					persistedText.includes("[output interrupted by stream rule]"),
+				`stopReason=${aborted?.stopReason ?? "missing"} persistedOccurrences=${countOccurrences(persistedText, firstParagraph)} chars=${persistedText.length}/${PARAGRAPH_LOOP_TEXT.length}`,
+			);
+			checks.ok(
+				"ttsr-paragraph-loop: collapse-repetition system-interrupt injected into the recovery request",
+				replayBody.includes('rule=\\"collapse-repetition\\"'),
+				`interruptPresent=${replayBody.includes("collapse-repetition")}`,
 			);
 		} else {
 			checks.ok(

--- a/.agents/skills/senpi-qa/scripts/mock-loop.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop.mjs
@@ -674,7 +674,7 @@ if (argv[0] === "--self-test") {
 			"  node mock-loop.mjs --with-truncated-text-tool-leak --api <anthropic-messages|openai-completions>",
 			"  node mock-loop.mjs --with-eval-hard-limit [--api <name>]  eval cell killed by the wall-clock hard limit",
 			"  node mock-loop.mjs --with-mcp-tool <tool> [--tool-args JSON]",
-			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|model-request-rejected-recover|ttsr-collapse|ttsr-leak|ttsr-repetitive-turns> [--api <name>]",
+			"  node mock-loop.mjs --scenario <transient-recover|budget-exhaust|server-error-fallback|long-retry-after|billing-swap|anthropic-policy-refusal-fallback|kimi-xtml-thinking-recover|model-request-rejected-recover|ttsr-collapse|ttsr-leak|ttsr-repetitive-turns|ttsr-paragraph-loop> [--api <name>]",
 			"  node mock-loop.mjs --scenario <hinted-429-in-turn|no-hint-429-fast-fallback|hinted-429-probe-back|no-hint-429-no-chain>",
 			"  node mock-loop.mjs --run <prompt> [--api <name>]",
 			`  APIs: ${ALL_APIS.join(", ")}`,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- TTSR now interrupts a single streamed assistant message that repeats the same paragraph three times (a within-message narration loop such as re-announcing the same "now writing the DAG cell" step for minutes without ever issuing the tool call): the collapse guard gains a paragraph-repeat mechanism, truncates the message from the first repeat, and injects the usual recovery nudge. Scalar runs, short periods, and line cycles were the only mechanisms before, and blank lines reset line-cycle tracking, so paragraph-level loops streamed unchecked until the user aborted. Tool-argument streams are not affected.
+
 ### New Features
 
 ### Breaking Changes

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/changes.md
@@ -1,5 +1,26 @@
 # TTSR Fork Tracker
 
+## 2026-09-03 - Within-message paragraph repetition
+
+### What changed and why
+
+- Added `detectors/collapse-paragraphs.ts` (`paragraph-repeat`) for byte-exact paragraph repetition within one streamed message. The existing four mechanisms could not see a 7-paragraph, ~2,100-character, 14-line cycle: scalar and short-period bounds are too small, line cycles are bounded and reset at blank lines, repetitive turns compare across turns, and loop-guard requires tool calls.
+- Tool-argument streams are excluded on purpose because fixtures can legitimately repeat blocks.
+- Thresholds are 64 characters, 24 word characters, 3 occurrences, and a 64-entry recent-paragraph ring.
+- Remediation reuses the existing collapse path: abort, truncate from the second occurrence, and send the collapse nudge.
+- Known limit: a paragraph ends only at a blank (whitespace-only) line, so narration that separates steps with single newlines is one paragraph to this mechanism; line cycles up to period 4 remain the line-cycle detector's job.
+
+### Why an extension-local change is required
+
+- The stream watcher already owns per-message detector state and collapse remediation, so paragraph tracking belongs in the extension-local collapse chain without changing provider or core stream contracts.
+
+### Coverage and expected conflict zones
+
+- `test/ttsr/detector-collapse-paragraphs.test.ts` covers chunking, eligibility, byte equality, multiline paragraphs, separators, and tool exclusion.
+- `test/ttsr/extension-wiring.test.ts` covers abort, truncation, activation, nudge, retry, and recovery.
+- Real-CLI QA ships as `senpi-qa` mock-loop scenario `ttsr-paragraph-loop` (text stream from the local fake model server; asserts the recovery request keeps one copy of the first paragraph and carries the `collapse-repetition` interrupt).
+- LOW: `detectors/collapse.ts` and the wiring test; no existing detector thresholds or unrelated routing are changed.
+
 ## 2026-08-25 - Cover streamed tool-call arguments
 
 ### What changed and why

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/detectors/collapse-paragraphs.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/detectors/collapse-paragraphs.ts
@@ -1,0 +1,141 @@
+import { CharCode, FixedRing, isAsciiWhitespace, type ScalarEntry } from "../stream-utils.ts";
+import type { DetectorMatch } from "../types.ts";
+import { isAsciiAlphanumeric, isBoxDrawing } from "./collapse-scalars.ts";
+
+export const PARAGRAPH_MIN_CHARS = 64;
+export const PARAGRAPH_MIN_WORD_CHARS = 24;
+export const PARAGRAPH_REPEAT_THRESHOLD = 3;
+export const PARAGRAPH_RING_CAPACITY = 64;
+export const PARAGRAPH_TEXT_RETENTION_MAX = 512;
+
+const SAMPLE_LENGTH = 80;
+const HASH_A_OFFSET = 0x811c9dc5;
+const HASH_A_PRIME = 0x01000193;
+const HASH_B_OFFSET = 5381;
+const HASH_B_MULTIPLIER = 31;
+
+interface ParagraphEntry {
+	readonly hashA: number;
+	readonly hashB: number;
+	readonly utf16Length: number;
+	readonly startOffset: number;
+	readonly text: string | undefined;
+}
+
+export interface ParagraphRepeatState {
+	readonly ring: FixedRing<ParagraphEntry>;
+	lineHashA: number;
+	lineHashB: number;
+	lineLength: number;
+	lineWordChars: number;
+	lineHasContent: boolean;
+	lineStartOffset: number;
+	lineText: string;
+	hashA: number;
+	hashB: number;
+	length: number;
+	wordChars: number;
+	startOffset: number;
+	retained: string;
+}
+
+export function createParagraphRepeatState(): ParagraphRepeatState {
+	return {
+		ring: new FixedRing<ParagraphEntry>(PARAGRAPH_RING_CAPACITY),
+		lineHashA: HASH_A_OFFSET,
+		lineHashB: HASH_B_OFFSET,
+		lineLength: 0,
+		lineWordChars: 0,
+		lineHasContent: false,
+		lineStartOffset: 0,
+		lineText: "",
+		hashA: HASH_A_OFFSET,
+		hashB: HASH_B_OFFSET,
+		length: 0,
+		wordChars: 0,
+		startOffset: 0,
+		retained: "",
+	};
+}
+
+function isSameParagraph(a: ParagraphEntry, b: ParagraphEntry): boolean {
+	return a.hashA === b.hashA && a.hashB === b.hashB && a.utf16Length === b.utf16Length;
+}
+
+function completeParagraph(state: ParagraphRepeatState): DetectorMatch | null {
+	const paragraph: ParagraphEntry = {
+		hashA: state.hashA,
+		hashB: state.hashB,
+		utf16Length: state.length,
+		startOffset: state.startOffset,
+		text: state.retained.length > 0 ? state.retained : undefined,
+	};
+	const eligible = state.length >= PARAGRAPH_MIN_CHARS && state.wordChars >= PARAGRAPH_MIN_WORD_CHARS;
+	state.hashA = HASH_A_OFFSET;
+	state.hashB = HASH_B_OFFSET;
+	state.length = 0;
+	state.wordChars = 0;
+	state.startOffset = 0;
+	state.retained = "";
+	if (!eligible) return null;
+	// Oldest -> newest, so `first` is the earliest occurrence and `second` the first repeat.
+	let occurrences = 1;
+	let first: ParagraphEntry | undefined;
+	let second: ParagraphEntry | undefined;
+	for (let back = state.ring.size - 1; back >= 0; back--) {
+		const previous = state.ring.getBack(back);
+		if (previous === undefined || !isSameParagraph(previous, paragraph)) continue;
+		occurrences += 1;
+		if (first === undefined) first = previous;
+		else if (second === undefined) second = previous;
+	}
+	state.ring.push(paragraph);
+	if (occurrences < PARAGRAPH_REPEAT_THRESHOLD || first === undefined || second === undefined) return null;
+	return {
+		rule: "collapse-repetition",
+		reason: `paragraph repeated ${occurrences} times within one message (${paragraph.utf16Length} chars)`,
+		anomalyStartOffset: first.startOffset,
+		garbageStartOffset: second.startOffset,
+		detail: {
+			mechanism: "paragraph-repeat",
+			occurrences,
+			paragraphChars: paragraph.utf16Length,
+			sample: (first.text ?? "").slice(0, SAMPLE_LENGTH),
+		},
+	};
+}
+
+export function updateParagraphRepeats(state: ParagraphRepeatState, entry: ScalarEntry): DetectorMatch | null {
+	if (entry.value.charCodeAt(0) === CharCode.LineFeed) {
+		let result: DetectorMatch | null = null;
+		if (state.lineHasContent) {
+			if (state.length === 0) state.startOffset = state.lineStartOffset;
+			state.hashA = Math.imul(state.hashA ^ state.lineHashA, HASH_A_PRIME);
+			state.hashB = (Math.imul(state.hashB, HASH_B_MULTIPLIER) + state.lineHashB) | 0;
+			state.length += state.lineLength + 1;
+			state.wordChars += state.lineWordChars;
+			if (state.retained.length < PARAGRAPH_TEXT_RETENTION_MAX) state.retained += `${state.lineText}\n`;
+		} else if (state.length > 0) {
+			result = completeParagraph(state);
+		}
+		state.lineHashA = HASH_A_OFFSET;
+		state.lineHashB = HASH_B_OFFSET;
+		state.lineLength = 0;
+		state.lineWordChars = 0;
+		state.lineHasContent = false;
+		state.lineStartOffset = entry.startOffset + 1;
+		state.lineText = "";
+		return result;
+	}
+	for (let i = 0; i < entry.value.length; i++) {
+		const code = entry.value.charCodeAt(i);
+		state.lineHashA = Math.imul(state.lineHashA ^ code, HASH_A_PRIME);
+		state.lineHashB = (Math.imul(state.lineHashB, HASH_B_MULTIPLIER) + code) | 0;
+	}
+	const codePoint = entry.value.codePointAt(0) ?? 0;
+	if (!isAsciiWhitespace(codePoint)) state.lineHasContent = true;
+	if (isAsciiAlphanumeric(codePoint) || (codePoint > 0x7f && !isBoxDrawing(codePoint))) state.lineWordChars += 1;
+	state.lineLength += entry.width;
+	if (state.lineText.length < PARAGRAPH_TEXT_RETENTION_MAX) state.lineText += entry.value;
+	return null;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/ttsr/detectors/collapse.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/ttsr/detectors/collapse.ts
@@ -1,6 +1,11 @@
 import { FixedRing, type ScalarEntry, ScalarScanner } from "../stream-utils.ts";
 import type { DetectorContext, DetectorMatch, StreamDetector } from "../types.ts";
 import { createLineCycleState, type LineCycleState, updateLineCycles } from "./collapse-lines.ts";
+import {
+	createParagraphRepeatState,
+	type ParagraphRepeatState,
+	updateParagraphRepeats,
+} from "./collapse-paragraphs.ts";
 import { createShortPeriodState, type ShortPeriodState, updateShortPeriods } from "./collapse-periods.ts";
 import {
 	createDominantRunState,
@@ -20,6 +25,7 @@ export interface CollapseState {
 	readonly whitespace: WhitespaceFloodState;
 	readonly periods: ShortPeriodState;
 	readonly lines: LineCycleState;
+	readonly paragraphs: ParagraphRepeatState;
 	latched: DetectorMatch | null;
 }
 
@@ -31,19 +37,22 @@ export function createCollapseState(): CollapseState {
 		whitespace: createWhitespaceFloodState(),
 		periods: createShortPeriodState(),
 		lines: createLineCycleState(),
+		paragraphs: createParagraphRepeatState(),
 		latched: null,
 	};
 }
 
-function checkDelta(state: CollapseState, delta: string, _context: DetectorContext): DetectorMatch | null {
+function checkDelta(state: CollapseState, delta: string, context: DetectorContext): DetectorMatch | null {
 	if (state.latched !== null) return state.latched;
+	const watchParagraphs = context.source !== "tool";
 	for (const entry of state.scanner.push(delta)) {
 		state.tailRing.push(entry);
 		const match =
 			updateDominantRun(state.run, entry) ??
 			updateWhitespaceFlood(state.whitespace, entry) ??
 			updateShortPeriods(state.periods, entry, state.tailRing) ??
-			updateLineCycles(state.lines, entry);
+			updateLineCycles(state.lines, entry) ??
+			(watchParagraphs ? updateParagraphRepeats(state.paragraphs, entry) : null);
 		if (match !== null) {
 			state.latched = match;
 			return match;

--- a/packages/coding-agent/test/ttsr/detector-collapse-paragraphs.test.ts
+++ b/packages/coding-agent/test/ttsr/detector-collapse-paragraphs.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { collapseDetector, createCollapseState } from "../../src/core/extensions/builtin/ttsr/detectors/collapse.ts";
+import {
+	createParagraphRepeatState,
+	updateParagraphRepeats,
+} from "../../src/core/extensions/builtin/ttsr/detectors/collapse-paragraphs.ts";
+import { ScalarScanner } from "../../src/core/extensions/builtin/ttsr/stream-utils.ts";
+import type { DetectorContext, DetectorMatch } from "../../src/core/extensions/builtin/ttsr/types.ts";
+import { lcg } from "./collapse-test-inputs.ts";
+
+type Source = DetectorContext["source"];
+
+const context: DetectorContext = { source: "text", streamKey: "text:0", generation: 1 };
+
+function narration(i: number): string {
+	return `Now I'm writing step ${i} of the plan: defining the shared context block with rules and tool guidance, then each research lane with its own scoped prompt and report path. The implementation keeps every result precise and useful.`;
+}
+
+function loop(cycle: number, cycles: number, separator = "\n\n"): string {
+	const block = Array.from({ length: cycle }, (_, i) => narration(i)).join(separator);
+	return `${Array.from({ length: cycles }, () => block).join(separator)}${separator}`;
+}
+
+function feedChunks(chunks: readonly string[], source: Source = "text"): DetectorMatch | null {
+	const state = createCollapseState();
+	let match: DetectorMatch | null = null;
+	for (const chunk of chunks) match ??= collapseDetector.checkDelta(state, chunk, { ...context, source });
+	return match;
+}
+
+function perChar(input: string, source: Source = "text"): DetectorMatch | null {
+	return feedChunks(input.split(""), source);
+}
+
+function random(input: string, seed: number, source: Source = "text"): DetectorMatch | null {
+	const next = lcg(seed);
+	const chunks: string[] = [];
+	for (let offset = 0; offset < input.length; ) {
+		const size = 1 + (next() % 97);
+		chunks.push(input.slice(offset, offset + size));
+		offset += size;
+	}
+	return feedChunks(chunks, source);
+}
+
+function direct(input: string): DetectorMatch | null {
+	const state = createParagraphRepeatState();
+	const scanner = new ScalarScanner();
+	let match: DetectorMatch | null = null;
+	for (const entry of scanner.push(input)) match ??= updateParagraphRepeats(state, entry);
+	return match;
+}
+
+describe("paragraph repetition detector", () => {
+	it("fires when the same 7-paragraph cycle streams three times", () => {
+		const input = loop(7, 3);
+		const match = perChar(input);
+		const randomMatch = random(input, 41);
+		expect(match?.rule).toBe("collapse-repetition");
+		expect(match?.detail).toMatchObject({ mechanism: "paragraph-repeat", occurrences: 3 });
+		expect(match?.anomalyStartOffset).toBe(0);
+		expect(match?.garbageStartOffset).toBe(loop(7, 1).length);
+		expect(randomMatch).toEqual(match);
+	});
+
+	it("stays silent after only two occurrences", () => expect(perChar(loop(7, 2))).toBeNull());
+
+	it("ignores short paragraphs and punctuation-only paragraphs", () => {
+		expect(direct("Done.\n\n".repeat(5))).toBeNull();
+		expect(direct(`${"-".repeat(80)}\n\n`.repeat(4))).toBeNull();
+	});
+
+	it("compares paragraphs byte-exactly", () => {
+		const variant = narration(0).replace("scoped prompt", "scoped brief");
+		expect(direct(`${narration(0)}\n\n${narration(0)}\n\n${variant}\n\n`)).toBeNull();
+		expect(direct(`${narration(0)}\n\n${narration(0)}\n\n${narration(0)}\n\n`)?.detail.occurrences).toBe(3);
+	});
+
+	it("treats whitespace-only lines as paragraph separators and hashes multi-line paragraphs", () => {
+		const lines = [
+			"Now the first detailed line explains the shared plan and its purpose.",
+			"The second line carries enough prose to remain an eligible paragraph.",
+			"Finally the third line records the scoped guidance for the lane.",
+		];
+		const input = `${Array.from({ length: 3 }, () => lines.join("\n")).join("\n   \n")}\n   \n`;
+		expect(direct(input)?.detail.mechanism).toBe("paragraph-repeat");
+		expect(direct(`${lines.join("\n")}\n\n${lines.join("\n")}\n\n${[...lines].reverse().join("\n")}\n\n`)).toBeNull();
+	});
+
+	it("does not watch tool argument streams", () => {
+		const input = loop(7, 3);
+		expect(perChar(input, "tool")).toBeNull();
+		expect(perChar(input, "thinking")?.detail.mechanism).toBe("paragraph-repeat");
+	});
+});

--- a/packages/coding-agent/test/ttsr/extension-wiring.test.ts
+++ b/packages/coding-agent/test/ttsr/extension-wiring.test.ts
@@ -39,6 +39,14 @@ function readSessionEntries(harness: Harness): PersistedEntry[] {
 		.map((line) => JSON.parse(line) as PersistedEntry);
 }
 
+function textOf(message: PersistedMessage | undefined): string {
+	if (message === undefined || !Array.isArray(message.content)) return "";
+	return (message.content as Array<{ type: string; text?: string }>)
+		.filter((block) => block.type === "text")
+		.map((block) => block.text ?? "")
+		.join("");
+}
+
 function thinkingTextOf(message: PersistedMessage | undefined): string {
 	if (message === undefined || !Array.isArray(message.content)) return "";
 	return (message.content as Array<{ type: string; thinking?: string }>)
@@ -144,6 +152,36 @@ describe("ttsr extension wiring", () => {
 		expect(harness.faux.getCallLog().length).toBe(2);
 		const finalText = assistantEntries.map((e) => getMessageText(e.message)).join("\n");
 		expect(finalText).toContain("recovered answer");
+	});
+
+	it("aborts a text stream that repeats the same paragraph, truncates from the first repeat, nudges, and continues", async () => {
+		const paragraph = (i: number) =>
+			`Now I'm writing step ${i} of the plan: defining the shared context block with rules and tool guidance, then each research lane with its own scoped prompt and report path. The implementation stays precise.`;
+		const loopText = `${Array.from({ length: 3 }, () => [0, 1, 2].map(paragraph).join("\n\n")).join("\n\n")}\n\n`;
+		harness.setResponses([
+			fauxAssistantMessage([fauxText(loopText)]),
+			fauxAssistantMessage([fauxText("recovered after paragraph loop")]),
+		]);
+		await harness.session.prompt("do work");
+		const entries = readSessionEntries(harness);
+		const assistants = entries.filter((e) => e.type === "message" && e.message?.role === "assistant");
+		const aborted = assistants[0]?.message;
+		const text = textOf(aborted);
+		expect(aborted?.stopReason).toBe("aborted");
+		expect(text.split(paragraph(0)).length - 1).toBe(1);
+		expect(text.length).toBeLessThan(loopText.length);
+		expect(notices).toEqual([]);
+		expect(entries.filter((e) => e.type === "custom" && e.customType === RULE_ACTIVATION_ENTRY_TYPE)).toHaveLength(1);
+		expect(entries).toContainEqual(
+			expect.objectContaining({
+				data: { kind: "ttsr", owner: "collapse-repetition", rules: ["collapse-repetition"], remediation: "nudge" },
+			}),
+		);
+		expect(entries.some((e) => e.type === "custom_message" && e.customType === TTSR_INJECTION_CUSTOM_TYPE)).toBe(
+			true,
+		);
+		expect(harness.faux.getCallLog()).toHaveLength(2);
+		expect(textOf(assistants[1]?.message)).toContain("recovered after paragraph loop");
 	});
 
 	it("aborts a collapsing tool argument stream before the flood and persists no flooded arguments", async () => {


### PR DESCRIPTION
## Summary

A model can stream a single assistant message that re-announces the same planning step as prose for minutes without ever issuing the tool call. Session `01a06648` (2026-09-03, `claude-fable-5-1`) did exactly that: one 38,193-character text part, a 7-paragraph cycle repeated 9 times, zero tool calls, 139 seconds until the user aborted. Nothing in senpi fired:

- `ttsr/detectors/collapse-periods.ts` only sees periods up to 64 scalars (the cycle was ~2,100 chars).
- `ttsr/detectors/collapse-lines.ts` only sees line cycles with period <= 4 and resets its counters on every blank line, so blank-line separated paragraphs can never accumulate a streak.
- `ttsr/detectors/repetitive-turns.ts` compares completed turns against each other, never a message against its own earlier paragraphs.
- `loop-guard` keys on tool calls, and there were none.

This PR adds a fifth mechanism to the TTSR collapse chain: **`paragraph-repeat`**.

## What changed

- `detectors/collapse-paragraphs.ts` (new): paragraphs are blank-line (whitespace-only line) delimited blocks, hashed line by line with the same dual FNV-1a/djb2 scheme as `collapse-lines.ts`; a `FixedRing(64)` remembers recent eligible paragraphs (>= 64 UTF-16 chars, >= 24 word chars). The third byte-identical occurrence fires `collapse-repetition` with `anomalyStartOffset` at the first occurrence and `garbageStartOffset` at the first repeat, mirroring line-cycle semantics.
- `detectors/collapse.ts`: wires the mechanism last in the `??` chain for `text` and `thinking` streams only. Tool-argument streams are excluded on purpose: fixtures and generated files legitimately repeat blocks.
- Remediation is untouched: the existing abort -> truncate -> `collapse-repetition` nudge path handles the match.
- `ttsr/changes.md`: 2026-09-03 tracker section (thresholds, exclusions, known limit: single-newline separated narration is one paragraph to this mechanism).
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased]` -> `Fixed` entry.
- `senpi-qa`: new mock-loop scenario `ttsr-paragraph-loop` (real CLI from source against the fake model server).

## Verification

Tests and type-check ran on a clean worktree of this branch (mengmotaMac via bunshin), Bun-invoked:

- `bunx vitest run test/ttsr/detector-collapse-paragraphs.test.ts test/ttsr/extension-wiring.test.ts` -> 10/10 passed.
- `bunx vitest run test/ttsr test/suite/ttsr-extension.test.ts test/suite/loop-guard-saturation.test.ts test/suite/rule-activation-renderer.test.ts` -> 20 files, 329 tests passed.
- Mutation check: with the `collapse.ts` wiring line removed, the three positive tests fail (`detector … fires`, `thinking source fires`, wiring `aborts a text stream …`) and the seven negatives still pass; restored -> 10/10.
- `bunx tsc --noEmit` -> exit 0; `biome format`/`biome check` clean on the changed files.
- Replay of the real incident text through the built detector: fires at 18,864 chars (49% of the stream, ~69 s into the 139 s generation) on a 510-char paragraph repeated three times. The incident text itself is not committed (customer names).

Manual QA (`.agents/skills/senpi-qa`, mock loop, both wire formats):

```
node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario ttsr-paragraph-loop --api anthropic-messages --evidence ttsr-paragraph-loop-anthropic-messages
node .agents/skills/senpi-qa/scripts/mock-loop.mjs --scenario ttsr-paragraph-loop --api openai-completions --evidence ttsr-paragraph-loop-openai-completions
```

Both 6/6 PASS: the CLI exits 0, exactly two model turns (abort + one bounded recovery), the persisted aborted message keeps the first cycle truncated at the first repeat (489/1362 chars, first paragraph exactly once, truncation marker present), the recovery request never replays the repeated paragraph and carries the `collapse-repetition` system-interrupt, and the recovery answer arrives. Evidence saved under `local-ignore/qa-evidence/20260903-ttsr-paragraph-loop-*/`.

One observation from the QA (pre-existing behavior, unchanged here): the aborted assistant message is dropped from the provider payload entirely, so the recovery request contains only the user prompt and the interrupt; the truncated copy lives in the persisted session.

## Notes for reviewers

- Thresholds (`PARAGRAPH_MIN_CHARS = 64`, `PARAGRAPH_MIN_WORD_CHARS = 24`, `PARAGRAPH_REPEAT_THRESHOLD = 3`, `PARAGRAPH_RING_CAPACITY = 64`) are exported constants next to the other collapse thresholds.
- No existing detector threshold or ordering changed; the new mechanism runs after the four existing ones and only when they did not match.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TTSR collapse guard so a single streamed assistant message that repeats the same paragraph is interrupted instead of re-announcing the same step for minutes without a tool call. Previously only scalar runs, short periods, line cycles, and cross-turn repetition were caught, and blank lines reset line-cycle tracking; now a `paragraph-repeat` mechanism aborts on the third byte-identical paragraph, truncates from the first repeat, and sends the usual recovery nudge. Tool-argument streams are intentionally not watched, and existing thresholds and remediation paths are unchanged.

**Notes**
- A paragraph is any blank-line-delimited block of at least 64 characters and 24 word characters; single-newline-separated narration counts as one paragraph.
- Adds the `senpi-qa` `ttsr-paragraph-loop` mock-loop scenario plus unit and wiring tests covering abort, truncation, interrupt injection, and recovery.

<sup>Written for commit ad5ee5ce4c11ad62c8d505ff05dde96c49ca0bfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

