### PR TITLE
fix(release): canonicalize the [Unreleased] subsections re-added after a release

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
-### Fixed
-
-- TTSR now interrupts a single streamed assistant message that repeats the same paragraph three times (a within-message narration loop such as re-announcing the same "now writing the DAG cell" step for minutes without ever issuing the tool call): the collapse guard gains a paragraph-repeat mechanism, truncates the message from the first repeat, and injects the usual recovery nudge. Scalar runs, short periods, and line cycles were the only mechanisms before, and blank lines reset line-cycle tracking, so paragraph-level loops streamed unchecked until the user aborted. Tool-argument streams are not affected.
-
-### New Features
-
 ### Breaking Changes
 
 ### Added
@@ -19,6 +9,8 @@
 ### Changed
 
 ### Fixed
+
+- TTSR now interrupts a single streamed assistant message that repeats the same paragraph three times (a within-message narration loop such as re-announcing the same "now writing the DAG cell" step for minutes without ever issuing the tool call): the collapse guard gains a paragraph-repeat mechanism, truncates the message from the first repeat, and injects the usual recovery nudge. Scalar runs, short periods, and line cycles were the only mechanisms before, and blank lines reset line-cycle tracking, so paragraph-level loops streamed unchecked until the user aborted. Tool-argument streams are not affected.
 
 ### Removed
 

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -36,8 +36,33 @@ export function extractUnreleasedSubsections(content) {
 	return subsections;
 }
 
+// The captured shape used to be copied verbatim, so one malformed block propagated
+// to every following release cycle.
+const UNRELEASED_SUBSECTION_ALIASES = new Map([
+	["### New Features", "### Added"],
+	["### Features", "### Added"],
+	["### Fixes", "### Fixed"],
+	["### Bug Fixes", "### Fixed"],
+]);
+
+export function canonicalizeUnreleasedSubsections(subsections) {
+	const seen = new Set();
+	for (const raw of subsections) {
+		const heading = raw.trim();
+		if (heading.length === 0) continue;
+		seen.add(UNRELEASED_SUBSECTION_ALIASES.get(heading) ?? heading);
+	}
+	const canonical = DEFAULT_UNRELEASED_SUBSECTIONS.filter((heading) => seen.has(heading));
+	const extras = [...seen].filter((heading) => !DEFAULT_UNRELEASED_SUBSECTIONS.includes(heading));
+	return [...canonical, ...extras];
+}
+
 export function resolveNextUnreleasedSubsections(capturedSubsections) {
-	return capturedSubsections ?? DEFAULT_UNRELEASED_SUBSECTIONS;
+	if (capturedSubsections === undefined || capturedSubsections === null) {
+		return DEFAULT_UNRELEASED_SUBSECTIONS;
+	}
+	const canonical = canonicalizeUnreleasedSubsections(capturedSubsections);
+	return canonical.length > 0 ? canonical : DEFAULT_UNRELEASED_SUBSECTIONS;
 }
 
 export function buildUnreleasedBlock(subsections) {

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -8,6 +8,7 @@ import {
 	CHANGELOGS,
 	DEFAULT_UNRELEASED_SUBSECTIONS,
 	buildUnreleasedBlock,
+	canonicalizeUnreleasedSubsections,
 	insertUnreleasedBlock,
 	resolveNextUnreleasedSubsections,
 } from "./release-changelog.mjs";
@@ -126,6 +127,60 @@ describe("release changelog bookkeeping", () => {
 
 		// Then
 		assert.deepEqual(subsections, ["### Fixed"]);
+	});
+
+	it("collapses duplicated and aliased subsections into the canonical order", () => {
+		// Given
+		const capturedSubsections = [
+			"### Added",
+			"### Changed",
+			"### Fixed",
+			"### New Features",
+			"### Breaking Changes",
+			"### Added",
+			"### Changed",
+			"### Fixed",
+			"### Removed",
+		];
+
+		// When
+		const subsections = resolveNextUnreleasedSubsections(capturedSubsections);
+
+		// Then
+		assert.deepEqual(subsections, DEFAULT_UNRELEASED_SUBSECTIONS);
+	});
+
+	it("keeps an unknown subsection once, after the canonical ones", () => {
+		// Given
+		const capturedSubsections = ["### Fixed", "### Security", "### Security", "### Added"];
+
+		// When
+		const subsections = resolveNextUnreleasedSubsections(capturedSubsections);
+
+		// Then
+		assert.deepEqual(subsections, ["### Added", "### Fixed", "### Security"]);
+	});
+
+	it("falls back to the default block when the captured block had no subsections", () => {
+		// Given
+		const capturedSubsections = [];
+
+		// When
+		const subsections = resolveNextUnreleasedSubsections(capturedSubsections);
+
+		// Then
+		assert.deepEqual(subsections, DEFAULT_UNRELEASED_SUBSECTIONS);
+	});
+
+	it("canonicalizeUnreleasedSubsections trims heading whitespace before matching", () => {
+		// Given
+		const capturedSubsections = ["### Fixed ", " ### Added"];
+
+		// When
+		const subsections = canonicalizeUnreleasedSubsections(capturedSubsections);
+
+		// Then
+		assert.deepEqual(subsections, ["### Added", "### Fixed"]);
 	});
 
 	it("inserts the next-cycle section before the stamped release header", () => {


### PR DESCRIPTION
## Summary

Release tooling defect found while landing #1326: `reAddUnreleasedSections` re-creates the next-cycle `## [Unreleased]` block from the heading shape it captured before stamping, and `resolveNextUnreleasedSubsections` returned that shape verbatim. One malformed block therefore propagates forever. `packages/coding-agent/CHANGELOG.md` has carried this for three releases today (`v2026.9.3`, `-2`, `-3`):

```
### Added / ### Changed / ### Fixed / ### New Features / ### Breaking Changes / ### Added / ### Changed / ### Fixed / ### Removed
```

## What changed

- `scripts/release-changelog.mjs`: new exported `canonicalizeUnreleasedSubsections()` folds aliases (`### New Features` -> `### Added`, `### Fixes`/`### Bug Fixes` -> `### Fixed`, ...), drops duplicates, emits the canonical `DEFAULT_UNRELEASED_SUBSECTIONS` order first and any unknown heading once after it. `resolveNextUnreleasedSubsections()` now routes through it and falls back to the default block when nothing usable was captured.
- `scripts/release.test.mjs`: four new node:test cases (the exact corrupted shape collapses to the canonical five; unknown heading kept once after the canonical ones; empty capture falls back; whitespace trimmed). Existing cases unchanged.
- `packages/coding-agent/CHANGELOG.md`: the current `[Unreleased]` block normalized to the canonical five headings, keeping the one existing `### Fixed` entry. No released section touched.

## Verification (mengmotaMac via bunshin, clean worktree of this branch)

- `bun run test:scripts` -> 185 pass / 0 fail.
- Mutation check: reverting `resolveNextUnreleasedSubsections` to `captured ?? DEFAULT` fails exactly the three new resolve-based cases (7 pass / 3 fail); restored -> 10/10 in `release.test.mjs`.
- `bun run check` -> exit 0 (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, platform lock, tsc, browser smoke).

Not user-facing: release tooling plus a changelog structure repair, so the CHANGELOG change is the normalization itself rather than a new entry.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release changelog tooling so a malformed `[Unreleased]` block no longer propagates into every following release cycle. The `packages/coding-agent/CHANGELOG.md` had duplicated and aliased headings for three releases; it is now normalized to the canonical five subsections.

**Bug Fixes**

- `resolveNextUnreleasedSubsections` now canonicalizes the captured block instead of copying it verbatim.
- Aliases like `### New Features` map to `### Added`; duplicates are dropped; unknown headings are kept once after the canonical ones.
- Falls back to the default block when nothing usable was captured.
- Adds four tests covering the corrupted shape, unknowns, empty capture, and whitespace trimming.

<sup>Written for commit 66f0e24f3f47ef559dbf187cf505b2bdc398b7c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

