### PR TITLE
fix(ai): refuse provider requests once the context window is exhausted

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Provider requests are no longer sent with `max_tokens` shrunk to a handful of tokens (down to 1) once the estimated context fills the model window. `buildBaseOptions` now throws `ContextWindowExhaustedError` when fewer than 1024 tokens of answer room remain after the safety margin (windows under 5120 tokens cannot hold that geometry and keep the previous behavior); the lazy API boundary surfaces it as an assistant error ("Context window exhausted: the conversation is estimated at X of Y tokens, leaving fewer than 1024 tokens for a response. Compact the conversation, enable auto-compaction, or start a new session before retrying.") that `isContextOverflow` classifies as a context overflow, so auto-compaction can recover when it is enabled and the user sees the real cause when it is not. Previously such requests returned truncated tool calls ("Tool call stream ended before completion") or a one-token "length" stop while billing the whole prompt.
+
 ### Removed
 
 ## [2026.9.3-3] - 2026-09-03

--- a/packages/ai/src/api/context-room.ts
+++ b/packages/ai/src/api/context-room.ts
@@ -1,0 +1,48 @@
+import type { Api, Context, Model } from "../types.ts";
+import { estimateContextTokens } from "../utils/estimate.ts";
+
+export const CONTEXT_SAFETY_TOKENS = 4096;
+/** Tokens always left for the answer when a thinking budget shares the response ceiling. */
+export const MIN_ANSWER_TOKENS = 1024;
+const MIN_MAX_TOKENS = 1;
+/** Windows too small to hold the safety margin plus one answer keep the legacy one-token floor. */
+export const CONTEXT_GUARD_MIN_WINDOW = CONTEXT_SAFETY_TOKENS + MIN_ANSWER_TOKENS;
+
+export class ContextWindowExhaustedError extends Error {
+	readonly estimatedTokens: number;
+	readonly contextWindow: number;
+
+	constructor(estimatedTokens: number, contextWindow: number) {
+		super(
+			`Context window exhausted: the conversation is estimated at ${estimatedTokens} of ${contextWindow} tokens, ` +
+				`leaving fewer than ${MIN_ANSWER_TOKENS} tokens for a response. ` +
+				"Compact the conversation, enable auto-compaction, or start a new session before retrying.",
+		);
+		this.name = "ContextWindowExhaustedError";
+		this.estimatedTokens = estimatedTokens;
+		this.contextWindow = contextWindow;
+	}
+}
+
+/**
+ * Fit the requested output budget into the room the context leaves in the model window.
+ * For windows of at least {@link CONTEXT_GUARD_MIN_WINDOW} tokens this throws
+ * {@link ContextWindowExhaustedError} instead of shrinking the budget below
+ * {@link MIN_ANSWER_TOKENS}: such a request can only return a truncated tool call or an
+ * empty "length" stop while still billing the whole prompt.
+ */
+export function clampMaxTokensToContext(model: Model<Api>, context: Context, maxTokens: number): number {
+	if (model.contextWindow <= 0) {
+		return Number.isFinite(maxTokens) && maxTokens > 0
+			? Math.max(MIN_MAX_TOKENS, Math.floor(maxTokens))
+			: MIN_MAX_TOKENS;
+	}
+	const estimatedTokens = estimateContextTokens(context).tokens;
+	const available = model.contextWindow - estimatedTokens - CONTEXT_SAFETY_TOKENS;
+	if (model.contextWindow >= CONTEXT_GUARD_MIN_WINDOW && available < MIN_ANSWER_TOKENS) {
+		throw new ContextWindowExhaustedError(estimatedTokens, model.contextWindow);
+	}
+	const safeAvailable = Math.max(MIN_MAX_TOKENS, available);
+	const requested = Number.isFinite(maxTokens) && maxTokens > 0 ? Math.floor(maxTokens) : safeAvailable;
+	return Math.min(requested, safeAvailable);
+}

--- a/packages/ai/src/api/simple-options.ts
+++ b/packages/ai/src/api/simple-options.ts
@@ -7,7 +7,15 @@ import type {
 	ThinkingBudgets,
 	ThinkingLevel,
 } from "../types.ts";
-import { estimateContextTokens } from "../utils/estimate.ts";
+import { clampMaxTokensToContext, MIN_ANSWER_TOKENS } from "./context-room.ts";
+
+export {
+	CONTEXT_GUARD_MIN_WINDOW,
+	CONTEXT_SAFETY_TOKENS,
+	ContextWindowExhaustedError,
+	clampMaxTokensToContext,
+	MIN_ANSWER_TOKENS,
+} from "./context-room.ts";
 
 /**
  * Merge user-supplied extraBody fields into a provider request payload, skipping
@@ -120,21 +128,6 @@ export const BEDROCK_RESERVED_BODY_KEYS: ReadonlySet<string> = new Set([
 	"requestMetadata",
 ]);
 
-const CONTEXT_SAFETY_TOKENS = 4096;
-const MIN_MAX_TOKENS = 1;
-
-export function clampMaxTokensToContext(model: Model<Api>, context: Context, maxTokens: number): number {
-	if (model.contextWindow <= 0) {
-		return Number.isFinite(maxTokens) && maxTokens > 0
-			? Math.max(MIN_MAX_TOKENS, Math.floor(maxTokens))
-			: MIN_MAX_TOKENS;
-	}
-	const available = model.contextWindow - estimateContextTokens(context).tokens - CONTEXT_SAFETY_TOKENS;
-	const safeAvailable = Math.max(MIN_MAX_TOKENS, available);
-	const requested = Number.isFinite(maxTokens) && maxTokens > 0 ? Math.floor(maxTokens) : safeAvailable;
-	return Math.min(requested, safeAvailable);
-}
-
 export function buildBaseOptions(
 	model: Model<Api>,
 	context: Context,
@@ -169,9 +162,6 @@ export function buildBaseOptions(
 		env: options?.env,
 	};
 }
-
-/** Tokens always left for the answer when a thinking budget shares the response ceiling. */
-export const MIN_ANSWER_TOKENS = 1024;
 
 export const DEFAULT_THINKING_BUDGETS: ThinkingBudgets = {
 	minimal: 1024,

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,50 @@
+## Provider requests are refused, not shrunk to one token, once the context window is exhausted (2026-09-03)
+
+### What changed
+
+- `packages/ai/src/api/context-room.ts` (new): owns `clampMaxTokensToContext`, `CONTEXT_SAFETY_TOKENS`,
+  `MIN_ANSWER_TOKENS`, and the new `ContextWindowExhaustedError`. The clamp still fits the requested output budget into
+  `contextWindow - estimateContextTokens(context).tokens - CONTEXT_SAFETY_TOKENS`, but when that room drops below
+  `MIN_ANSWER_TOKENS` (1024) it throws `ContextWindowExhaustedError` instead of flooring `max_tokens` at 1. Windows
+  smaller than `CONTEXT_GUARD_MIN_WINDOW` (5120 = safety margin + one answer) cannot satisfy that geometry at all and
+  keep the previous one-token floor, so tiny-window fixtures and models behave exactly as before. The error
+  message names the estimate and the window ("Context window exhausted: the conversation is estimated at X of Y tokens,
+  leaving fewer than 1024 tokens for a response. Compact the conversation, enable auto-compaction, or start a new session
+  before retrying.") and carries `estimatedTokens` / `contextWindow` as typed fields.
+- `packages/ai/src/api/simple-options.ts`: `clampMaxTokensToContext` and `MIN_ANSWER_TOKENS` moved to
+  `context-room.ts`; `simple-options.ts` re-exports them (plus `CONTEXT_SAFETY_TOKENS` and
+  `ContextWindowExhaustedError`) so `buildBaseOptions`, `anthropic-messages.ts`, `bedrock-converse-stream.ts`, and tests
+  keep their import sites. `buildBaseOptions` therefore throws before any provider request is built once the window is
+  exhausted; the lazy API boundary (`lazyStream`) turns that throw into an assistant `stopReason: "error"` message with
+  the text above, and the harness `ModelRuntime` / provider-composer `lazyStream` wrappers do the same for extension
+  providers.
+- `packages/ai/src/utils/overflow.ts`: `OVERFLOW_PATTERNS` gains `/^Context window exhausted: /` so
+  `isContextOverflow` classifies the guard's error as a context overflow; the retry classifier leaves it `unknown`
+  (never retried).
+
+### Why
+
+- Observed on 2026-09-03 (session `01a06520`, anthropic `claude-fable-5-1`, 1M window, auto-compaction disabled): at
+  an estimated 995,154 tokens the clamp produced `max_tokens: 750`; the model's tool call was cut mid-arguments and the
+  agent loop reported "Tool call stream ended before completion. Re-issue the tool call with complete arguments."; the
+  re-issued request got `max_tokens: 1`, stopped after one token, and the TUI rendered "Model stopped because it reached
+  the maximum output token limit". Both messages hid the real cause and each doomed request billed ~1M cached tokens.
+- A request that cannot produce a minimal answer is never worth sending. Refusing it with a typed, overflow-classified
+  error lets the existing overflow route compact and retry when auto-compaction is enabled, and gives the user an
+  actionable message (compact / enable auto-compaction / new session) when it is not.
+
+### Why an extension could not handle it
+
+- The clamp runs inside `buildBaseOptions`, in every provider adapter, after the harness has emitted its last
+  `before_provider_request` hook; no extension seam sits between the token estimate and the request body. Extensions also
+  cannot see the `max_tokens` the adapter is about to send, so they cannot tell a doomed request from a normal one.
+
+### Expected merge conflict zones
+
+- LOW: the `clampMaxTokensToContext` / `MIN_ANSWER_TOKENS` region of `packages/ai/src/api/simple-options.ts` (upstream
+  keeps both definitions inline; the fork re-exports them from `context-room.ts`).
+- LOW: the head of `OVERFLOW_PATTERNS` in `packages/ai/src/utils/overflow.ts` and its provider list comment.
+
 ## A legacy flat credential is promoted, not overwritten, by a second login (2026-09-03)
 
 ### What changed

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -36,8 +36,10 @@ import type { AssistantMessage } from "../types.ts";
  *   input filling the context window.
  * - DashScope/Qwen: "Range of input length should be [1, X]" (HTTP 400 invalid_parameter_error)
  * - Ollama: Some deployments truncate silently, others return errors like "prompt too long; exceeded max context length by X tokens"
+ * - pi-ai pre-flight guard (api/context-room.ts): "Context window exhausted: the conversation is estimated at X of Y tokens, ..." - raised before any provider call
  */
 const OVERFLOW_PATTERNS = [
+	/^Context window exhausted: /, // pi-ai pre-flight guard: no answer room left, provider never called
 	/prompt is too long/i, // Anthropic token overflow
 	/request_too_large/i, // Anthropic request byte-size overflow (HTTP 413)
 	/input is too long for requested model/i, // Amazon Bedrock

--- a/packages/ai/test/context-exhaustion-fixtures.ts
+++ b/packages/ai/test/context-exhaustion-fixtures.ts
@@ -1,0 +1,41 @@
+import { MIN_ANSWER_TOKENS } from "../src/api/simple-options.ts";
+import type { AssistantMessage, Context, Usage } from "../src/types.ts";
+import { estimateContextTokens } from "../src/utils/estimate.ts";
+
+export const CONTEXT_WINDOW = 10_000;
+const CONTEXT_SAFETY_TOKENS = 4_096;
+export const LAST_ADMITTED_ESTIMATE = CONTEXT_WINDOW - CONTEXT_SAFETY_TOKENS - MIN_ANSWER_TOKENS;
+export const FIRST_EXHAUSTED_ESTIMATE = LAST_ADMITTED_ESTIMATE + 1;
+
+function createUsage(totalTokens: number): Usage {
+	return {
+		input: totalTokens,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function createAssistant(totalTokens: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "kept" }],
+		api: "openai-completions",
+		provider: "test",
+		model: "test-model",
+		usage: createUsage(totalTokens),
+		stopReason: "stop",
+		timestamp: 100,
+	};
+}
+
+export function contextWithEstimate(estimate: number): Context {
+	const context: Context = {
+		messages: [createAssistant(estimate - 1), { role: "user", content: "tail", timestamp: 200 }],
+	};
+	const actual = estimateContextTokens(context).tokens;
+	if (actual !== estimate) throw new Error(`fixture estimate drifted: expected ${estimate}, got ${actual}`);
+	return context;
+}

--- a/packages/ai/test/context-exhaustion-guard-stream.test.ts
+++ b/packages/ai/test/context-exhaustion-guard-stream.test.ts
@@ -1,0 +1,103 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { MIN_ANSWER_TOKENS } from "../src/api/simple-options.ts";
+import { getModel, streamSimple } from "../src/compat.ts";
+import type { Model } from "../src/types.ts";
+import { isContextOverflow } from "../src/utils/overflow.ts";
+import {
+	CONTEXT_WINDOW,
+	contextWithEstimate,
+	FIRST_EXHAUSTED_ESTIMATE,
+	LAST_ADMITTED_ESTIMATE,
+} from "./context-exhaustion-fixtures.ts";
+
+const activeServers: Server[] = [];
+
+afterEach(async () => {
+	await Promise.all(
+		activeServers.splice(0).map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+	);
+});
+
+describe("context exhaustion guard through streamSimple", () => {
+	it("returns an overflow error without calling the provider once the window is exhausted", async () => {
+		const server = await startRecordingServer();
+		const model = testModel(server.baseUrl);
+
+		const response = await streamSimple(model, contextWithEstimate(FIRST_EXHAUSTED_ESTIMATE), {
+			apiKey: "test",
+			maxRetries: 0,
+		}).result();
+
+		expect(server.requests).toHaveLength(0);
+		expect(response.stopReason).toBe("error");
+		expect(response.errorMessage).toMatch(/^Context window exhausted/);
+		expect(response.usage.totalTokens).toBe(0);
+		expect(isContextOverflow(response, model.contextWindow)).toBe(true);
+	});
+
+	it("still sends the request with the clamped max tokens while answer room remains", async () => {
+		const server = await startRecordingServer();
+		const model = testModel(server.baseUrl);
+
+		const response = await streamSimple(model, contextWithEstimate(LAST_ADMITTED_ESTIMATE), {
+			apiKey: "test",
+			maxRetries: 0,
+		}).result();
+
+		expect(server.requests).toHaveLength(1);
+		expect(server.requests[0]?.max_completion_tokens ?? server.requests[0]?.max_tokens).toBe(MIN_ANSWER_TOKENS);
+		expect(response.stopReason).toBe("stop");
+		expect(response.errorMessage).toBeUndefined();
+	});
+});
+
+function testModel(baseUrl: string): Model<"openai-completions"> {
+	const model = getModel("openai", "gpt-4o-mini");
+	if (model === undefined) throw new Error("Missing gpt-4o-mini test model");
+	return { ...model, api: "openai-completions", provider: "test", baseUrl, contextWindow: CONTEXT_WINDOW };
+}
+
+interface RecordingServer {
+	readonly baseUrl: string;
+	readonly requests: Array<Record<string, unknown>>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function startRecordingServer(): Promise<RecordingServer> {
+	const requests: Array<Record<string, unknown>> = [];
+	const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+		const chunks: Buffer[] = [];
+		request.on("data", (chunk: Buffer) => chunks.push(chunk));
+		request.on("end", () => {
+			const body: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+			if (!isRecord(body)) throw new Error("expected a JSON object request body");
+			requests.push(body);
+			writeCompletion(response);
+		});
+	});
+	activeServers.push(server);
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", resolve);
+	});
+	const address = server.address();
+	if (address === null || typeof address === "string") throw new Error("Expected TCP server address");
+	return { baseUrl: `http://127.0.0.1:${address.port}/v1`, requests };
+}
+
+function writeCompletion(response: ServerResponse): void {
+	response.writeHead(200, { "content-type": "text/event-stream" });
+	response.write(
+		`data: ${JSON.stringify({
+			id: "chatcmpl-guard",
+			choices: [{ index: 0, delta: { content: "ok" }, finish_reason: "stop" }],
+			usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+		})}\n\n`,
+	);
+	response.write("data: [DONE]\n\n");
+	response.end();
+}

--- a/packages/ai/test/context-exhaustion-guard.test.ts
+++ b/packages/ai/test/context-exhaustion-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildBaseOptions,
+	CONTEXT_GUARD_MIN_WINDOW,
+	ContextWindowExhaustedError,
+	clampMaxTokensToContext,
+	MIN_ANSWER_TOKENS,
+} from "../src/api/simple-options.ts";
+import type { Context, Model } from "../src/types.ts";
+import {
+	CONTEXT_WINDOW,
+	contextWithEstimate,
+	FIRST_EXHAUSTED_ESTIMATE,
+	LAST_ADMITTED_ESTIMATE,
+} from "./context-exhaustion-fixtures.ts";
+
+const model: Model<"openai-responses"> = {
+	id: "test-model",
+	name: "Test Model",
+	api: "openai-responses",
+	provider: "openai",
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: CONTEXT_WINDOW,
+	maxTokens: 8_000,
+};
+
+function captureExhaustion(context: Context): ContextWindowExhaustedError {
+	try {
+		buildBaseOptions(model, context);
+	} catch (error) {
+		if (error instanceof ContextWindowExhaustedError) return error;
+		throw error;
+	}
+	throw new Error("expected buildBaseOptions to reject the exhausted context");
+}
+
+describe("context exhaustion guard", () => {
+	it("refuses to clamp max tokens below the minimum answer room", () => {
+		const context = contextWithEstimate(FIRST_EXHAUSTED_ESTIMATE);
+
+		expect(() => clampMaxTokensToContext(model, context, model.maxTokens)).toThrow(ContextWindowExhaustedError);
+		expect(() => buildBaseOptions(model, context)).toThrow(ContextWindowExhaustedError);
+	});
+
+	it("names the estimate, the window, and the remedy in the error", () => {
+		const error = captureExhaustion(contextWithEstimate(FIRST_EXHAUSTED_ESTIMATE));
+
+		expect(error.estimatedTokens).toBe(FIRST_EXHAUSTED_ESTIMATE);
+		expect(error.contextWindow).toBe(CONTEXT_WINDOW);
+		expect(error.message).toMatch(/^Context window exhausted/);
+		expect(error.message).toContain(`${FIRST_EXHAUSTED_ESTIMATE} of ${CONTEXT_WINDOW} tokens`);
+		expect(error.message).toContain(`fewer than ${MIN_ANSWER_TOKENS} tokens`);
+		expect(error.message).toMatch(/compact/i);
+	});
+
+	it("admits a request that still has exactly the minimum answer room", () => {
+		const context = contextWithEstimate(LAST_ADMITTED_ESTIMATE);
+
+		expect(buildBaseOptions(model, context).maxTokens).toBe(MIN_ANSWER_TOKENS);
+	});
+
+	it("keeps an explicitly small max tokens request on a small context", () => {
+		const context: Context = { messages: [{ role: "user", content: "OK", timestamp: 1 }] };
+
+		expect(buildBaseOptions(model, context, { maxTokens: 1 }).maxTokens).toBe(1);
+	});
+
+	it("skips the guard for models without a known context window", () => {
+		const context = contextWithEstimate(FIRST_EXHAUSTED_ESTIMATE);
+
+		expect(buildBaseOptions({ ...model, contextWindow: 0 }, context).maxTokens).toBe(model.maxTokens);
+	});
+
+	it("keeps the legacy one-token floor for windows smaller than the guard geometry", () => {
+		const context: Context = { messages: [{ role: "user", content: "OK", timestamp: 1 }] };
+
+		expect(buildBaseOptions({ ...model, contextWindow: 1000 }, context).maxTokens).toBe(1);
+		expect(() => buildBaseOptions({ ...model, contextWindow: CONTEXT_GUARD_MIN_WINDOW }, context)).toThrow(
+			ContextWindowExhaustedError,
+		);
+	});
+});

--- a/packages/ai/test/overflow.test.ts
+++ b/packages/ai/test/overflow.test.ts
@@ -30,6 +30,13 @@ function createErrorMessage(errorMessage: string): AssistantMessage {
 }
 
 describe("isContextOverflow", () => {
+	it("detects the local context exhaustion guard before any provider call", () => {
+		const message = createErrorMessage(
+			"Context window exhausted: the conversation is estimated at 995154 of 1000000 tokens, leaving fewer than 1024 tokens for a response. Compact the conversation, enable auto-compaction, or start a new session before retrying.",
+		);
+		expect(isContextOverflow(message, 1000000)).toBe(true);
+	});
+
 	it("detects explicit Ollama prompt-too-long errors", () => {
 		const message = createErrorMessage("400 `prompt too long; exceeded max context length by 100918 tokens`");
 		expect(isContextOverflow(message, 32768)).toBe(true);


### PR DESCRIPTION
## Problem

Once the estimated context fills the model window, `clampMaxTokensToContext` (`packages/ai/src/api/simple-options.ts`) floored `max_tokens` at 1 and the request still went out. The provider could only answer with a truncated tool call or an empty `max_tokens` stop, so users saw two misleading errors while paying for the whole prompt:

- `Tool call stream ended before completion. Re-issue the tool call with complete arguments.`
- `Error: Model stopped because it reached the maximum output token limit. The response may be incomplete.`

### Incident (2026-09-03, senpi session `01a06520`, omo-senpi x-search run)

`anthropic/claude-fable-5-1`, 1M window, `compaction.enabled: false` in settings, context at 996K/1M. Replaying the recorded session messages through the shipped clamp reproduces the exact request budgets and provider responses:

| request | estimate | shipped `max_tokens` | provider response |
|---|---|---|---|
| L787 | 972,766 | 23,138 | ok (tool_use) |
| L793 | 992,525 | 3,379 | ok (tool_use) |
| L795 | 995,154 | **750** | `max_tokens` stop, tool call cut mid-arguments -> "Re-issue the tool call" |
| L797 | 996,031 | **1** | `max_tokens` stop after 1 token -> "maximum output token limit" |

Each doomed request billed ~1M cached input tokens ($0.26-0.38).

## Fix

- New `packages/ai/src/api/context-room.ts` owns `clampMaxTokensToContext`, `CONTEXT_SAFETY_TOKENS`, `MIN_ANSWER_TOKENS` and the new `ContextWindowExhaustedError`. When `contextWindow - estimate - CONTEXT_SAFETY_TOKENS` drops below `MIN_ANSWER_TOKENS` (1024) the clamp throws instead of shrinking the budget. `simple-options.ts` re-exports the moved symbols, so every `buildBaseOptions` caller (anthropic, openai, google, bedrock, mistral, codex) gets the guard and existing import sites are unchanged.
- The lazy API boundary (`lazyStream`) already converts a setup throw into an assistant `stopReason: "error"`; the message is `Context window exhausted: the conversation is estimated at X of Y tokens, leaving fewer than 1024 tokens for a response. Compact the conversation, enable auto-compaction, or start a new session before retrying.`
- `packages/ai/src/utils/overflow.ts`: `isContextOverflow` matches `/^Context window exhausted: /`, so with auto-compaction enabled the harness takes its existing overflow route (compact + retry); with it disabled the user sees the real cause. The retry classifier leaves the message `unknown` (never retried).
- `test/telemetry-options.test.ts` fixture declared a 1,000-token window, which the 4,096-token safety margin alone exhausts; it now declares 128,000 (the test asserts telemetry propagation, not clamping).

Replaying the incident through the new clamp: L787/L793 admitted with the same budgets, L795/L797 refused with the message above (`overflow=true`).

## Tests

RED captured before the change, GREEN after (vitest on mengmotaMac via bunshin):

- `test/context-exhaustion-guard.test.ts` (5): throw below the floor, typed fields + message, boundary at exactly 1024 tokens of room admits with `maxTokens === 1024`, explicit `maxTokens: 1` on a small context still works, `contextWindow <= 0` skips the guard.
- `test/context-exhaustion-guard-stream.test.ts` (2): through `streamSimple` against a recording HTTP server - exhausted context -> 0 provider requests, `stopReason: "error"`, overflow-classified; admitted boundary -> 1 request with `max_completion_tokens === 1024`.
- `test/overflow.test.ts` (+1): classifier case.
- Full `packages/ai` suite: 2510 passed / 874 skipped (the `codex-apply-patch-wire-schema` file needs `packages/tui` built first - environment, unrelated). Root `tsc --noEmit`, repo-wide `biome check --error-on-warnings`, `check-pr-changelog` (changes.md coverage + CHANGELOG) all green.

## Follow-ups (not in this PR)

- Extension-triggered turns (`sendMessage({triggerTurn:true})`: goal continuations, task/monitor wakes) bypass `before_agent_start`, so the compaction extension's proactive threshold/speculative/hard-limit valve never runs for them; only the core `pre_prompt` gate does. Worth its own issue.
- With `compaction.enabled: false` nothing warns the user as the window fills; the footer percentage is the only signal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending provider requests when the estimated context leaves fewer than 1024 tokens for a response. Previously `clampMaxTokensToContext` floored `max_tokens` at 1, so the request went out and came back as a truncated tool call or a one-token "length" stop while billing the whole prompt.

- Throws a new `ContextWindowExhaustedError` before any request is built; the lazy API boundary surfaces it as an assistant error naming the estimate, the window, and the remedy.
- `isContextOverflow` matches the new error, so auto-compaction can compact and retry when enabled.
- Moved the clamp to `context-room.ts`; `simple-options.ts` re-exports the symbols so every `buildBaseOptions` caller gets the guard.
- The telemetry test fixture now uses a 128,000-token window because the 4,096-token safety margin alone exhausted its old 1,000-token window.

<sup>Written for commit 090a84f2d2798aa2318c1bc75e564b189df94ed4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

