### PR TITLE
feat(coding-agent): support bare npm package installs

### DIFF
--- a/packages/coding-agent/docs/packages.md
+++ b/packages/coding-agent/docs/packages.md
@@ -56,10 +56,16 @@ Pi accepts three source types in settings and `pi install`.
 ### npm
 
 ```
+npm-package
+npm-package@1.2.3
 npm:@scope/pkg@1.2.3
 npm:pkg
 ```
 
+- Bare unscoped package names are npm sources. Prefix a single-segment local
+  file or directory with `./` (for example, `./my-package`) to select the local
+  path explicitly.
+- Scoped npm packages continue to use the explicit `npm:` prefix.
 - Versioned specs are pinned and skipped by package updates (`pi update --extensions`, `pi update --all`).
 - User installs go under `~/.pi/agent/npm/`.
 - Project installs go under `.pi/npm/`.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,38 @@
 # changes
 
+## 2026-09-03 - Install bare unscoped npm package specs
+
+### What changed
+
+- `packages/coding-agent/src/core/package-manager.ts`: recognizes bare unscoped
+  npm package specs such as `foo`, `foo@latest`, and `foo@1.2.3` before the
+  package-manager-local fallback to local paths. Explicit relative, absolute,
+  `file:`, scoped, slash-containing, and Git sources keep their existing
+  classifications.
+- `packages/coding-agent/docs/packages.md`: documents bare unscoped npm installs
+  and the required `./` prefix for an otherwise ambiguous single-segment local
+  path.
+
+### Why
+
+- Users expect `senpi install foo` (and branded equivalents such as
+  `omo install foo`) to install the public npm package named `foo`. The old
+  parser treated every bare name as a local path and failed with
+  `Path does not exist` before npm could run.
+
+### Why an extension could not handle it
+
+- Package source parsing and installation happen before the target extension is
+  installed or loaded, so an extension cannot reinterpret its own install
+  source.
+
+### Expected merge conflict zones
+
+- LOW: `DefaultPackageManager.parseSource()` near npm/local/Git source
+  classification in `packages/coding-agent/src/core/package-manager.ts`.
+- LOW: npm and local source examples in
+  `packages/coding-agent/docs/packages.md`.
+
 ## 2026-09-03 - Make eval-only tool routing unconditional and registry-aware
 
 ### What changed

--- a/packages/coding-agent/src/core/package-manager.ts
+++ b/packages/coding-agent/src/core/package-manager.ts
@@ -50,6 +50,7 @@ import type { PackageSource, SettingsManager } from "./settings-manager.ts";
 const NETWORK_TIMEOUT_MS = 10000;
 const UPDATE_CHECK_CONCURRENCY = 4;
 const GIT_UPDATE_CONCURRENCY = 4;
+const BARE_NPM_PACKAGE_SPEC_PATTERN = /^[a-z0-9][a-z0-9._~-]*(?:@[^/\\\s]+)?$/i;
 
 function isOfflineModeEnabled(): boolean {
 	const value = envValue("OFFLINE");
@@ -1449,8 +1450,14 @@ export class DefaultPackageManager implements PackageManager {
 	}
 
 	private parseSource(source: string): ParsedSource {
-		if (source.startsWith("npm:")) {
-			const spec = source.slice("npm:".length).trim();
+		const trimmed = source.trim();
+		const npmSpec = source.startsWith("npm:")
+			? source.slice("npm:".length).trim()
+			: BARE_NPM_PACKAGE_SPEC_PATTERN.test(trimmed)
+				? trimmed
+				: undefined;
+		if (npmSpec !== undefined) {
+			const spec = npmSpec;
 			const { name, version } = this.parseNpmSpec(spec);
 			return {
 				type: "npm",

--- a/packages/coding-agent/test/package-command-paths.test.ts
+++ b/packages/coding-agent/test/package-command-paths.test.ts
@@ -931,7 +931,8 @@ if(args.includes("install")) process.exit(23);
 		}
 	});
 
-	it("suggests the configured source when update input omits the npm prefix", async () => {
+	it("updates a configured npm package when the input is a bare name", async () => {
+		vi.stubEnv("PI_OFFLINE", "1");
 		const settingsPath = join(agentDir, "settings.json");
 		writeFileSync(settingsPath, JSON.stringify({ packages: ["npm:pi-formatter"] }, null, 2));
 
@@ -943,9 +944,9 @@ if(args.includes("install")) process.exit(23);
 
 			const stderr = errorSpy.mock.calls.map(([message]) => String(message)).join("\n");
 			const stdout = logSpy.mock.calls.map(([message]) => String(message)).join("\n");
-			expect(stderr).toContain("Did you mean npm:pi-formatter?");
-			expect(stdout).not.toContain("Updated pi-formatter");
-			expect(process.exitCode).toBe(1);
+			expect(stderr).toBe("");
+			expect(stdout).toContain("Updated pi-formatter");
+			expect(process.exitCode).toBeUndefined();
 
 			const settings = JSON.parse(readFileSync(settingsPath, "utf-8")) as { packages?: string[] };
 			expect(settings.packages).toContain("npm:pi-formatter");

--- a/packages/coding-agent/test/package-manager.test.ts
+++ b/packages/coding-agent/test/package-manager.test.ts
@@ -699,6 +699,20 @@ Content`,
 	});
 
 	describe("npmCommand", () => {
+		it("should install a bare unscoped package name from npm", async () => {
+			const runCommandSpy = vi
+				.spyOn(packageManager as unknown as PackageManagerInternals, "runCommand")
+				.mockResolvedValue(undefined);
+
+			await packageManager.install("omo-codex-computer");
+
+			expect(runCommandSpy).toHaveBeenCalledWith(
+				"npm",
+				["install", "omo-codex-computer", "--prefix", join(agentDir, "npm"), "--legacy-peer-deps"],
+				undefined,
+			);
+		});
+
 		it("should use npmCommand argv for npm installs", async () => {
 			settingsManager = SettingsManager.inMemory({
 				npmCommand: ["mise", "exec", "node@20", "--", "npm"],
@@ -1240,6 +1254,9 @@ Content`,
 			expect(parseNpm("npm:@scope/pkg@1.2.3").pinned).toBe(true);
 			expect(parseNpm("npm:@scope/pkg@^1.2.3").pinned).toBe(false);
 			expect(parseNpm("npm:pkg").pinned).toBe(false);
+			expect(parseNpm("omo-codex-computer").spec).toBe("omo-codex-computer");
+			expect(parseNpm("omo-codex-computer@latest").pinned).toBe(false);
+			expect(parseNpm("omo-codex-computer@1.2.3").pinned).toBe(true);
 
 			expect((packageManager as any).parseSource("git:github.com/user/repo@v1").type).toBe("git");
 			expect((packageManager as any).parseSource("https://github.com/user/repo@v1").type).toBe("git");
@@ -1249,6 +1266,8 @@ Content`,
 			expect((packageManager as any).parseSource("/absolute/path/to/package").type).toBe("local");
 			expect((packageManager as any).parseSource("./relative/path/to/package").type).toBe("local");
 			expect((packageManager as any).parseSource("../relative/path/to/package").type).toBe("local");
+			expect((packageManager as any).parseSource("@scope/pkg").type).toBe("local");
+			expect((packageManager as any).parseSource("github.com/user/repo").type).toBe("local");
 		});
 
 		it("should never parse dot-relative paths as git", () => {
@@ -2498,12 +2517,11 @@ export default function(api) { api.registerTool({ name: "test", description: "te
 			expect(maxConcurrentGitUpdates).toBeGreaterThan(1);
 		});
 
-		it("should suggest npm source prefixes for update lookups", async () => {
+		it("should match bare npm names in update lookups", async () => {
+			process.env.PI_OFFLINE = "1";
 			settingsManager.setProjectPackages(["npm:example"]);
 
-			await expect(packageManager.update("example")).rejects.toThrow(
-				"No matching package found for example. Did you mean npm:example?",
-			);
+			await expect(packageManager.update("example")).resolves.toBeUndefined();
 		});
 
 		it("should suggest git source prefixes for update lookups", async () => {


### PR DESCRIPTION
## Summary

- Treat bare unscoped package specs such as `foo` and `foo@1.2.3` as npm sources in the package manager.
- Preserve explicit local paths, scoped bare names, slash-containing paths, and existing Git source forms.
- Document the ambiguity rule and record the upstream-owned change in the nearest tracker.

## Why

`omo install omo-codex-computer` currently resolves the package name as
`<cwd>/omo-codex-computer` and fails before npm runs. Extensions cannot fix
their own install-source parsing because it happens before they are installed
or loaded.

## Test plan

- RED: bare install failed with `Path does not exist: .../omo-codex-computer`.
- Focused package-manager/path suites: 145 passed, 1 pre-existing skip.
- Focused CLI command-path test: 1 passed.
- `bun run check`: passed, 3510 files, no fixes.
- Full coding-agent suite with `CI=1`: 1189 files passed, 5 skipped; 9712 tests passed, 39 skipped.
- Senpi QA CLI smoke: 8/8 passed.
- Real isolated source CLI: installed `omo-codex-computer@0.1.0` from the bare name and persisted `["omo-codex-computer"]`.
- Installed extension RPC status: Computer Use `ready`, Chrome `ready`.

## Local environment note

The repository-wide script suite's existing `stagePublishManifest`
platform-optional fixture fails on this macOS host independently of the
touched files. The affected package's complete 9,751-test suite is green after
the required workspace build and CI serialization.
