### PR TITLE
fix(coding-agent): send the Anthropic tool-search server tool under its contract name

### DIFF
--- a/.agents/skills/senpi-qa/scripts/mock-loop-anthropic-toolsearch.mjs
+++ b/.agents/skills/senpi-qa/scripts/mock-loop-anthropic-toolsearch.mjs
@@ -1,0 +1,50 @@
+// senpi-qa Channel 3 variant: real CLI --print against the local fake Anthropic server,
+// with an extension that registers a search-exposed tool so the tool-search builtin
+// injects Anthropic's native tool-search server tool. Asserts the REAL wire bytes.
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createChecks, evidenceDir, guardRealAuth, installCleanupHooks, makeSandbox, runCli, repoRoot } from "./lib/common.mjs";
+import { startFakeModelServer } from "./lib/fake-model-server.mjs";
+import { API_PRESETS, hermeticEnv, writeMockModelsJson } from "./lib/mock-loop-support.mjs";
+
+installCleanupHooks();
+const checks = createChecks("anthropic native tool-search wire contract");
+const guard = guardRealAuth();
+const apiName = "anthropic-messages";
+const p = API_PRESETS[apiName];
+const box = makeSandbox("mock-loop-anthropic-toolsearch");
+const marker = "SENPI-QA-TOOLSEARCH-OK";
+const server = await startFakeModelServer({ turns: [{ text: marker }] });
+writeMockModelsJson(box.agentDir, server, apiName);
+const typeboxUrl = pathToFileURL(join(repoRoot(), "node_modules", "typebox", "build", "index.mjs")).href;
+const extPath = join(box.dir, "searchable-ext.mjs");
+writeFileSync(extPath, `import { Type } from ${JSON.stringify(typeboxUrl)};
+export default function(pi) {
+  pi.registerTool({ name: "weather_forecast", label: "Weather", description: "Forecast weather", exposure: "search",
+    parameters: Type.Object({ city: Type.String() }),
+    async execute() { return { content: [{ type: "text", text: "sunny" }], details: {} }; } });
+}`);
+const args = ["--provider", p.provider, "--model", p.modelId, "--no-context-files", "--extension", extPath, "--print", "say the marker"];
+const result = await runCli(args, { env: hermeticEnv(box.env), cwd: box.cwd, timeoutMs: 120000 });
+const tools = server.requests.flatMap((r) => Array.isArray(r.tools) ? r.tools : []);
+const serverTools = tools.filter((t) => typeof t.type === "string" && t.type.startsWith("tool_search_tool_"));
+const canonical = serverTools.filter((t) => t.type === "tool_search_tool_bm25_20251119" && t.name === "tool_search_tool_bm25");
+const badName = tools.filter((t) => typeof t.type === "string" && t.type.startsWith("tool_search_tool_") && t.name === "tool_search");
+checks.ok("CLI completed", !result.timedOut && result.code === 0, "code=" + result.code);
+checks.ok("fake Anthropic server received a request", server.requests.length >= 1, "requests=" + server.requests.length);
+checks.ok("weather_forecast injected with defer_loading", tools.some((t) => t.name === "weather_forecast" && t.defer_loading === true));
+checks.ok("exactly one native tool-search server tool with the contract type+name", canonical.length === 1 && serverTools.length === 1, JSON.stringify(serverTools));
+checks.ok("no server tool named tool_search", badName.length === 0);
+checks.ok("local tool_search custom tool resident and undeferred", tools.some((t) => t.name === "tool_search" && t.type === undefined && t.defer_loading === undefined));
+checks.ok("final assistant text returned", (result.stdout + result.stderr).includes(marker));
+const dir = evidenceDir("anthropic-toolsearch-name");
+writeFileSync(join(dir, "requests.json"), JSON.stringify(server.requests, null, 2));
+writeFileSync(join(dir, "stdout.txt"), result.stdout);
+writeFileSync(join(dir, "stderr.txt"), result.stderr);
+writeFileSync(join(dir, "wire-tools.json"), JSON.stringify(tools, null, 2));
+process.stderr.write("evidence: " + dir + "\n");
+guard.assertUnchanged();
+await server.stop();
+box.cleanup();
+process.exit(checks.finish() ? 0 : 1);

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Anthropic Messages requests that carry deferred (`defer_loading`) tools no longer fail with `invalid_request_error: tools.N.tool_search_tool_bm25_20251119.name: Input should be 'tool_search_tool_bm25'`. The injected native tool-search server tool is now named `tool_search_tool_bm25` as the API contract requires; the local `tool_search` custom tool is unchanged.
 - TTSR now interrupts a single streamed assistant message that repeats the same paragraph three times (a within-message narration loop such as re-announcing the same "now writing the DAG cell" step for minutes without ever issuing the tool call): the collapse guard gains a paragraph-repeat mechanism, truncates the message from the first repeat, and injects the usual recovery nudge. Scalar runs, short periods, and line cycles were the only mechanisms before, and blank lines reset line-cycle tracking, so paragraph-level loops streamed unchecked until the user aborted. Tool-argument streams are not affected.
 
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/tool-search/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/tool-search/changes.md
@@ -1,5 +1,24 @@
 # Tool Search Builtin Changes
 
+## 2026-09-04 - Name the Anthropic native tool-search server tool per the API contract
+
+### What changed
+
+- `native-search.ts`: `ANTHROPIC_TOOL_SEARCH_NAME` is now `tool_search_tool_bm25`. The injected server tool is `{ type: "tool_search_tool_bm25_20251119", name: "tool_search_tool_bm25" }`; the type is unchanged and the local `tool_search` custom tool keeps its own name.
+- `test/suite/regressions/0000-anthropic-native-tool-search-canonical-name.test.ts` pins the literal contract pair, keeps the local tool resident, and keeps non-Anthropic payloads byte-identical.
+
+### Why
+
+- Anthropic validates the server tool's `name` against the tool-search variant: every request carrying deferred tools was rejected with `invalid_request_error: tools.N.tool_search_tool_bm25_20251119.name: Input should be 'tool_search_tool_bm25'`, which then disabled native search for the session.
+
+### Why an extension could not handle it
+
+- The name is emitted by the builtin's own payload transform on `before_provider_request`; no extension hook rewrites an already-injected server tool.
+
+### Expected merge conflict zones
+
+- LOW: `native-search.ts` constant block.
+
 ## 2026-08-11 - Defer local tool registration until the catalog is searchable
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/tool-search/native-search.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/tool-search/native-search.ts
@@ -6,7 +6,7 @@ import type { ToolSearchDocument } from "./engine/document.ts";
 // scope because it requires a provider-layer seam.
 
 export const ANTHROPIC_TOOL_SEARCH_TYPE = "tool_search_tool_bm25_20251119";
-export const ANTHROPIC_TOOL_SEARCH_NAME = "tool_search";
+export const ANTHROPIC_TOOL_SEARCH_NAME = "tool_search_tool_bm25";
 /** Anthropic caps a request at 10k tools; beyond that native search is invalid. */
 export const ANTHROPIC_MAX_TOOLS = 10000;
 

--- a/packages/coding-agent/test/mcp/fixtures/native-search-mocks.ts
+++ b/packages/coding-agent/test/mcp/fixtures/native-search-mocks.ts
@@ -157,6 +157,8 @@ export function anthropicToolSearchResultBlock(toolUseId = "srvtoolu_spike_1"): 
 // ---------------------------------------------------------------------------
 
 export const ANTHROPIC_TOOL_SEARCH_TYPE = "tool_search_tool_bm25_20251119";
+/** The API validates the server tool's `name` against its variant: `tools.N.<type>.name: Input should be '<name>'`. */
+export const ANTHROPIC_TOOL_SEARCH_CONTRACT_NAME = "tool_search_tool_bm25";
 
 export interface AnthropicValidationResult {
 	readonly status: 200 | 400;
@@ -187,6 +189,18 @@ export function validateAnthropicToolSearchPayload(payload: unknown): AnthropicV
 	}
 	if (objs.length > 0 && deferred.length === objs.length) {
 		return { status: 400, error: "invalid_request: at least one tool must be non-deferred" };
+	}
+	// The API validates the server tool's `name` against its variant; a `name`-less
+	// stub is tolerated here so shape-only fixtures stay valid.
+	const misnamed = objs.findIndex(
+		(tool) =>
+			tool.type === ANTHROPIC_TOOL_SEARCH_TYPE && "name" in tool && tool.name !== ANTHROPIC_TOOL_SEARCH_CONTRACT_NAME,
+	);
+	if (misnamed >= 0) {
+		return {
+			status: 400,
+			error: `invalid_request_error: tools.${misnamed}.${ANTHROPIC_TOOL_SEARCH_TYPE}.name: Input should be '${ANTHROPIC_TOOL_SEARCH_CONTRACT_NAME}'`,
+		};
 	}
 	return { status: 200 };
 }

--- a/packages/coding-agent/test/mcp/native-search-validator-name.test.ts
+++ b/packages/coding-agent/test/mcp/native-search-validator-name.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { addAnthropicNativeToolSearch } from "../../src/core/extensions/builtin/tool-search/native-search.ts";
+import {
+	ANTHROPIC_TOOL_SEARCH_CONTRACT_NAME,
+	ANTHROPIC_TOOL_SEARCH_TYPE,
+	validateAnthropicToolSearchPayload,
+} from "./fixtures/native-search-mocks.ts";
+
+// The mock validator must reject what the real API rejects: a tool-search server
+// tool whose `name` does not match its variant. Before this check existed, eleven
+// focused files stayed green while production returned
+// `tools.N.tool_search_tool_bm25_20251119.name: Input should be 'tool_search_tool_bm25'`.
+describe("mock Anthropic validator: server tool name", () => {
+	const CONFIG = { searchToolName: "tool_search", isDeferrable: (name: string) => name.startsWith("mcp_") };
+
+	it("rejects the pre-fix wire shape with the production error path", () => {
+		const result = validateAnthropicToolSearchPayload({
+			tools: [
+				{ name: "tool_search", description: "search", input_schema: {} },
+				{ name: "mcp_docs_a", description: "docs", input_schema: {}, defer_loading: true },
+				{ type: ANTHROPIC_TOOL_SEARCH_TYPE, name: "tool_search" },
+			],
+		});
+		expect(result.status).toBe(400);
+		expect(result.error).toBe(
+			`invalid_request_error: tools.2.${ANTHROPIC_TOOL_SEARCH_TYPE}.name: Input should be '${ANTHROPIC_TOOL_SEARCH_CONTRACT_NAME}'`,
+		);
+	});
+
+	it("accepts the payload the production adapter emits", () => {
+		const payload = addAnthropicNativeToolSearch(
+			"anthropic-messages",
+			{
+				tools: [
+					{ name: "tool_search", description: "search", input_schema: {} },
+					{ name: "mcp_docs_a", description: "docs", input_schema: {} },
+				],
+			},
+			CONFIG,
+		);
+		expect(validateAnthropicToolSearchPayload(payload)).toEqual({ status: 200 });
+	});
+});

--- a/packages/coding-agent/test/suite/regressions/0000-anthropic-native-tool-search-canonical-name.test.ts
+++ b/packages/coding-agent/test/suite/regressions/0000-anthropic-native-tool-search-canonical-name.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { addAnthropicNativeToolSearch } from "../../../src/core/extensions/builtin/tool-search/native-search.ts";
+
+// The Anthropic Messages tool-search server tool is identified by the exact
+// pair {type:"tool_search_tool_bm25_20251119", name:"tool_search_tool_bm25"} --
+// the dated type is the versioned server-tool identifier, and the name is the
+// tool name the model invokes. Both literals are spelled out here on purpose:
+// importing the production constants would make the assertion a tautology that
+// passes for any value they hold.
+const ANTHROPIC_CONTRACT_TYPE = "tool_search_tool_bm25_20251119";
+const ANTHROPIC_CONTRACT_NAME = "tool_search_tool_bm25";
+const LOCAL_SEARCH_TOOL_NAME = "tool_search";
+
+const CONFIG = {
+	searchToolName: LOCAL_SEARCH_TOOL_NAME,
+	isDeferrable: (name: string) => name.startsWith("mcp_"),
+};
+
+function toolsOf(payload: unknown): Record<string, unknown>[] {
+	return ((payload as { tools?: unknown[] }).tools ?? []).filter(
+		(tool): tool is Record<string, unknown> => typeof tool === "object" && tool !== null,
+	);
+}
+
+function catalogPayload(): { tools: Record<string, unknown>[] } {
+	return {
+		tools: [
+			{ name: LOCAL_SEARCH_TOOL_NAME, description: "search", input_schema: {} },
+			{ name: "mcp_docs_get-library-docs", description: "docs", input_schema: {} },
+		],
+	};
+}
+
+describe("Anthropic native tool-search canonical naming regression", () => {
+	it("injects the server tool under the exact Anthropic type and name", () => {
+		// given a payload carrying the local tool_search tool plus a deferrable MCP tool
+		const payload = catalogPayload();
+
+		// when the native adapter injects the Anthropic server tool
+		const tools = toolsOf(addAnthropicNativeToolSearch("anthropic-messages", payload, CONFIG));
+
+		// then exactly one injected object carries the canonical type/name pair
+		const injected = tools.filter((tool) => tool.type === ANTHROPIC_CONTRACT_TYPE);
+		expect(injected).toEqual([{ type: ANTHROPIC_CONTRACT_TYPE, name: ANTHROPIC_CONTRACT_NAME }]);
+	});
+
+	it("keeps the local tool_search custom tool resident and undeferred", () => {
+		// given the same payload
+		const payload = catalogPayload();
+
+		// when the native adapter runs
+		const tools = toolsOf(addAnthropicNativeToolSearch("anthropic-messages", payload, CONFIG));
+
+		// then the local custom tool survives untouched alongside the server tool
+		const local = tools.find((tool) => tool.name === LOCAL_SEARCH_TOOL_NAME && tool.type === undefined);
+		expect(local).toEqual({ name: LOCAL_SEARCH_TOOL_NAME, description: "search", input_schema: {} });
+	});
+
+	it("leaves a non-anthropic payload byte-identical", () => {
+		// given a payload destined for a non-Anthropic api
+		const payload = catalogPayload();
+		const before = JSON.stringify(payload);
+
+		// when the native adapter runs against openai-responses
+		const out = addAnthropicNativeToolSearch("openai-responses", payload, CONFIG);
+
+		// then the very same object is returned, unmutated
+		expect(out).toBe(payload);
+		expect(JSON.stringify(out)).toBe(before);
+	});
+});


### PR DESCRIPTION
## Summary
Anthropic rejects the native tool-search server tool senpi injects on every Anthropic Messages request that carries deferred tools:

`tools.N.tool_search_tool_bm25_20251119.name: Input should be 'tool_search_tool_bm25'`

The wire contract (https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool) is `{ "type": "tool_search_tool_bm25_20251119", "name": "tool_search_tool_bm25" }`. senpi sent `name: "tool_search"` (the local custom tool's name). One-line fix: `ANTHROPIC_TOOL_SEARCH_NAME = "tool_search_tool_bm25"`. The type is unchanged.

## Blast radius
`ANTHROPIC_TOOL_SEARCH_NAME` has one consumer (the injection site) plus a re-export; the local `tool_search` tool keeps `TOOL_SEARCH_TOOL_NAME = "tool_search"` and stays resident/undeferred. Response-side `server_tool_use` / `tool_search_tool_result` blocks are replayed verbatim without name comparison.

## Evidence
- RED: new regression test failed on `name` only (type already matched) before the change.
- GREEN: 15 files / 104 tests across test/tool-search, mcp/native-anthropic, native-spike, tool-search-promotion, exposure-* on mengmotaMac; `tsc --noEmit` exit 0.
- The regression test pins the literal contract pair (does not import the constants), so it cannot pass by echoing the source.

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic rejecting the injected tool-search server tool by sending the correct contract name (`tool_search_tool_bm25` instead of the local `tool_search` tool name).

- The mock Anthropic validator now rejects a mis-named server tool with the same 400 production returns, closing the coverage gap that let the bug ship.
- Adds a regression test pinning the literal contract pair and confirming the local tool stays resident and non-Anthropic payloads remain untouched.
- Adds a mock-loop QA driver that runs the real CLI against a fake Anthropic server and asserts the actual wire bytes.

<sup>Written for commit 0802fafe041b3b0d2675a94557e860042ebb0e02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

