### PR TITLE
fix(coding-agent): restore the selected -fast variant on resume instead of its upstream base model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Anthropic Messages requests that carry deferred (`defer_loading`) tools no longer fail with `invalid_request_error: tools.N.tool_search_tool_bm25_20251119.name: Input should be 'tool_search_tool_bm25'`. The injected native tool-search server tool is now named `tool_search_tool_bm25` as the API contract requires; the local `tool_search` custom tool is unchanged.
 - The shared GPT eval-routing bridge no longer routes multi-call work to the `exec`/`wait` Code Mode tools that were removed in favor of detached `eval` cells; every GPT preset now points at `eval` only.
+- Resuming a session left on a `-fast` catalog variant (or any model with an `upstreamModelId`) now restores that exact selection instead of its upstream base model, so the priority tier and the fast indicator survive the resume; assistant messages no longer override an explicit same-provider model selection during session restore.
 - TTSR now interrupts a single streamed assistant message that repeats the same paragraph three times (a within-message narration loop such as re-announcing the same "now writing the DAG cell" step for minutes without ever issuing the tool call): the collapse guard gains a paragraph-repeat mechanism, truncates the message from the first repeat, and injects the usual recovery nudge. Scalar runs, short periods, and line cycles were the only mechanisms before, and blank lines reset line-cycle tracking, so paragraph-level loops streamed unchecked until the user aborted. Tool-argument streams are not affected.
 
 ### Removed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,35 @@
 # changes
 
+## 2026-09-04 - Restore the selected model, not its upstream wire id, on resume
+
+### What changed
+
+- `packages/coding-agent/src/core/session-manager.ts`: `getSessionContextSettings()` now treats an
+  explicit selection (a manual `model_change`, or the primary model restored from a fallback window)
+  as authoritative over later assistant messages from the same provider. An assistant message only
+  redefines the restored model when no explicit selection is in force or when it comes from a
+  different provider, which preserves legacy assistant-only sessions and the existing fallback
+  window handling.
+
+### Why
+
+- A catalog entry that maps to an `upstreamModelId` (the `-fast` priority variants, e.g.
+  `quotio-openai/gpt-5.6-sol-fast` -> `gpt-5.6-sol`) persists the upstream id on every assistant
+  message, because the request went out with that id. The old restore let that echo overwrite the
+  recorded selection, so resuming the session came back on the base model with no priority tier:
+  the fast indicator was gone and `service_tier` left the wire. Regression:
+  `test/session-manager/upstream-model-id-restore.test.ts`.
+
+### Why an extension could not handle it
+
+- Model restoration happens inside `SessionManager.buildSessionContext()` before the session or any
+  extension exists; `session_start` observes the already-resolved (wrong) model.
+
+### Expected merge conflict zones
+
+- LOW: the `model` bookkeeping inside `getSessionContextSettings()` in `session-manager.ts`.
+
+
 ## 2026-09-03 - Make eval-only tool routing unconditional and registry-aware
 
 ### What changed

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -422,6 +422,13 @@ function getSessionContextSettings(
 	let thinkingLevel = "off";
 	let thinkingSelection: ThinkingSelection | undefined;
 	let model: { provider: string; modelId: string } | null = null;
+	// An explicit selection (a manual `model_change`, or the primary restored from a fallback
+	// window) outranks the model id echoed by later assistant messages from the SAME provider:
+	// the persisted message id is the wire id, which differs from the catalog id whenever the
+	// catalog entry maps to an `upstreamModelId` (a `-fast` priority variant is the common case),
+	// so trusting the echo would resume the base model and silently drop the tier. A message
+	// from another provider still wins, since no `model_change` recorded that hop.
+	let isModelSelectionExplicit = false;
 	let isInFallbackWindow = false;
 	// A fallback switch applies an ephemeral thinking level to the fallback model, so
 	// the level recorded inside the window must not outlive it: restoring the primary
@@ -441,6 +448,7 @@ function getSessionContextSettings(
 					preFallbackThinkingSelection = thinkingSelection;
 					if (entry.originalProvider && entry.originalModelId) {
 						model = { provider: entry.originalProvider, modelId: entry.originalModelId };
+						isModelSelectionExplicit = true;
 					}
 				}
 				isInFallbackWindow = true;
@@ -454,10 +462,18 @@ function getSessionContextSettings(
 				// A manual model switch abandons the window: the level the user set inside
 				// it is a deliberate choice and carries over to the newly selected model.
 				isInFallbackWindow = false;
-				model = { provider: entry.provider, modelId: entry.modelId };
+				// Session files are parsed without validation, so an entry missing its provider or
+				// model id must not become an authoritative selection; the fallback-original restore
+				// above guards the same way, and a later assistant message still restores the model.
+				if (entry.provider && entry.modelId) {
+					model = { provider: entry.provider, modelId: entry.modelId };
+					isModelSelectionExplicit = true;
+				}
 			}
 		} else if (entry.type === "message" && entry.message.role === "assistant" && !isInFallbackWindow) {
+			if (isModelSelectionExplicit && model?.provider === entry.message.provider) continue;
 			model = { provider: entry.message.provider, modelId: entry.message.model };
+			isModelSelectionExplicit = false;
 		}
 	}
 

--- a/packages/coding-agent/test/session-manager/upstream-model-id-restore.test.ts
+++ b/packages/coding-agent/test/session-manager/upstream-model-id-restore.test.ts
@@ -1,0 +1,145 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SessionManager } from "../../src/core/session-manager.ts";
+
+/**
+ * A catalog entry that maps to an `upstreamModelId` (a `-fast` priority variant is the common
+ * case) persists the UPSTREAM id on every assistant message it produces, because that is the id
+ * the request went out with. The user's selection, however, is the catalog id recorded by the
+ * `model_change` entry. Resuming must restore the selection, not the wire echo: the base model
+ * has no priority tier, so restoring it silently turns fast mode off.
+ */
+const PROVIDER = "quotio-openai";
+const FAST_MODEL_ID = "gpt-5.6-sol-fast";
+const UPSTREAM_MODEL_ID = "gpt-5.6-sol";
+
+type Entry = Record<string, unknown>;
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	while (temporaryDirectories.length > 0) {
+		const directory = temporaryDirectories.pop();
+		if (directory) rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+function modelChange(id: string, parentId: string | null, provider: string, modelId: string): Entry {
+	return { type: "model_change", id, parentId, timestamp: "2026-09-04T00:00:00.000Z", provider, modelId };
+}
+
+function assistantMessage(id: string, parentId: string | null, provider: string, model: string): Entry {
+	return {
+		type: "message",
+		id,
+		parentId,
+		timestamp: "2026-09-04T00:00:00.000Z",
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: `answer from ${model}` }],
+			provider,
+			model,
+			api: "openai-responses",
+			usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+			stopReason: "stop",
+			timestamp: 1,
+		},
+	};
+}
+
+function openSession(entries: Entry[]): SessionManager {
+	const directory = join(tmpdir(), `upstream-model-id-restore-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	temporaryDirectories.push(directory);
+	mkdirSync(directory, { recursive: true });
+	const file = join(directory, "session.jsonl");
+	const header = {
+		type: "session",
+		version: 3,
+		id: "upstream-model-id-restore",
+		timestamp: "2026-09-04T00:00:00.000Z",
+		cwd: directory,
+	};
+	writeFileSync(file, `${[header, ...entries].map((entry) => JSON.stringify(entry)).join("\n")}\n`);
+	return SessionManager.open(file, directory);
+}
+
+describe("session model restoration with upstream model ids", () => {
+	it("keeps the selected -fast catalog variant when assistant messages carry its upstream model id", () => {
+		// given: the user selected the -fast variant and every reply echoed the upstream (base) id
+		const session = openSession([
+			modelChange("select", null, PROVIDER, FAST_MODEL_ID),
+			assistantMessage("reply-1", "select", PROVIDER, UPSTREAM_MODEL_ID),
+			assistantMessage("reply-2", "reply-1", PROVIDER, UPSTREAM_MODEL_ID),
+		]);
+
+		// when / then
+		expect(session.buildSessionContext().model).toEqual({ provider: PROVIDER, modelId: FAST_MODEL_ID });
+	});
+
+	it("restores the primary -fast selection after a fallback window closes", () => {
+		// given: a fallback hop and revert, then more upstream-id replies from the primary
+		const session = openSession([
+			modelChange("select", null, PROVIDER, FAST_MODEL_ID),
+			{
+				...modelChange("fallback", "select", "anthropic", "claude-opus-5"),
+				reason: "fallback",
+				originalProvider: PROVIDER,
+				originalModelId: FAST_MODEL_ID,
+			},
+			assistantMessage("fallback-reply", "fallback", "anthropic", "claude-opus-5"),
+			{ ...modelChange("revert", "fallback-reply", PROVIDER, FAST_MODEL_ID), reason: "fallback-revert" },
+			assistantMessage("reply", "revert", PROVIDER, UPSTREAM_MODEL_ID),
+		]);
+
+		// when / then
+		expect(session.buildSessionContext().model).toEqual({ provider: PROVIDER, modelId: FAST_MODEL_ID });
+	});
+
+	it("follows a later explicit selection over earlier upstream-id replies", () => {
+		// given
+		const session = openSession([
+			modelChange("select-fast", null, PROVIDER, FAST_MODEL_ID),
+			assistantMessage("reply-1", "select-fast", PROVIDER, UPSTREAM_MODEL_ID),
+			modelChange("select-base", "reply-1", PROVIDER, UPSTREAM_MODEL_ID),
+			assistantMessage("reply-2", "select-base", PROVIDER, UPSTREAM_MODEL_ID),
+		]);
+
+		// when / then
+		expect(session.buildSessionContext().model).toEqual({ provider: PROVIDER, modelId: UPSTREAM_MODEL_ID });
+	});
+
+	it("ignores an incomplete model_change entry instead of treating it as a selection", () => {
+		// given: a hand-edited / truncated entry with no model id, then a normal reply
+		const session = openSession([
+			{ ...modelChange("select", null, PROVIDER, FAST_MODEL_ID), modelId: "" },
+			assistantMessage("reply", "select", PROVIDER, UPSTREAM_MODEL_ID),
+		]);
+
+		// when / then
+		expect(session.buildSessionContext().model).toEqual({ provider: PROVIDER, modelId: UPSTREAM_MODEL_ID });
+	});
+
+	it("still restores the last assistant model when the session never recorded a selection", () => {
+		// given: a legacy session with no model_change entries at all
+		const session = openSession([
+			assistantMessage("reply-1", null, "anthropic", "claude-opus-4-8"),
+			assistantMessage("reply-2", "reply-1", "anthropic", "claude-opus-5"),
+		]);
+
+		// when / then
+		expect(session.buildSessionContext().model).toEqual({ provider: "anthropic", modelId: "claude-opus-5" });
+	});
+
+	it("still lets an assistant message from another provider override the selection", () => {
+		// given: a foreign-provider reply without a recorded switch (legacy / hand-edited sessions)
+		const session = openSession([
+			modelChange("select", null, PROVIDER, FAST_MODEL_ID),
+			assistantMessage("reply", "select", "anthropic", "claude-opus-5"),
+		]);
+
+		// when / then
+		expect(session.buildSessionContext().model).toEqual({ provider: "anthropic", modelId: "claude-opus-5" });
+	});
+});


### PR DESCRIPTION
## Summary

Resuming a session that was left on a `-fast` catalog variant backed by an `upstreamModelId` (for example a custom `quotio-openai/gpt-5.6-sol-fast` entry with `serviceTier: "priority"` and `upstreamModelId: "gpt-5.6-sol"`) came back on the **base** model: no priority tier on the wire, no fast indicator in the footer. The same thing happens to every `openai/*-fast` catalog variant.

Root cause: `getSessionContextSettings()` in `packages/coding-agent/src/core/session-manager.ts` let every assistant message's persisted `model` overwrite the model restored for the session. That field is the **wire** id (the request goes out with the upstream id, so `gpt-5.6-sol` is what pi-ai records), while the user's selection is the **catalog** id recorded by the `model_change` entry. On resume the last assistant echo won and `sdk.ts` restored `gpt-5.6-sol`.

## Change

- `session-manager.ts`: an explicit selection (a manual `model_change`, or the primary model restored from a fallback window) is now authoritative over later assistant messages **from the same provider**. An assistant message still redefines the restored model when no explicit selection is in force (legacy assistant-only sessions) or when it comes from a different provider, so the existing fallback-window handling and legacy restore behaviour are untouched.
- New regression suite `test/session-manager/upstream-model-id-restore.test.ts` (5 cases: fast variant kept, fallback window then upstream-id replies, later explicit selection wins, legacy assistant-only session, cross-provider override).
- `CHANGELOG.md` [Unreleased] + `src/core/changes.md` tracker entry.

## Evidence (all runs on mengmotaMac over bunshin; artifacts in `sisyphuslabs/local-ignore/qa-evidence/20260904-resume-fast-variant/`)

- **Unit RED -> GREEN**: on `origin/main` (f91130e0f) the new file fails 2/5 with `received gpt-5.6-sol, expected gpt-5.6-sol-fast`; at the fix commit 5/5 pass. `bunx vitest run test/session-manager`: 15 files / 150 tests green.
- **Real surface (RPC resume)**: `bun src/cli.ts --mode rpc --session <fixture>` with a temp agent dir whose `models.json` defines `quotio-openai/gpt-5.6-sol` and `gpt-5.6-sol-fast` (`serviceTier: priority`, `upstreamModelId: gpt-5.6-sol`), and a session file with `model_change -> gpt-5.6-sol-fast` followed by an assistant message persisted as `gpt-5.6-sol` (the exact shape found in real session files):
  - main: `get_state` -> `model.id: "gpt-5.6-sol"`, `serviceTier: null`, `fastMode: false`
  - this branch: `get_state` -> `model.id: "gpt-5.6-sol-fast"`, `serviceTier: "priority"`, `fastMode: true`
  - Why sufficient: this is the same `createAgentSession` restore path the interactive TUI uses on resume, and `serviceTier`/`fastMode` are what the footer indicator and `service_tier` injection derive from. QA temp dirs and processes were removed afterwards (receipt captured).
- Static: `biome check` clean on changed files, `tsc --noEmit` exit 0, `scripts/check-pr-changelog.mjs --base <merge-base>` PASS.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resuming a session left on a `-fast` catalog variant (or any model with an `upstreamModelId`) now restores that exact selection instead of its upstream base model, so the priority tier and fast indicator survive the resume. Assistant messages from the same provider no longer override an explicit selection during restore, because they persist the upstream wire id rather than the catalog id the user picked.

**Bug Fixes**
- `getSessionContextSettings()` now treats a manual `model_change` or fallback-window revert as authoritative over later same-provider assistant messages, and ignores incomplete `model_change` entries instead of turning them into selections.
- Assistant messages from a different provider still override the selection, and sessions with no explicit selection keep the legacy last-assistant-message behavior.
- Adds a regression suite covering fast variant resume, fallback windows, later explicit selections, incomplete entries, legacy assistant-only sessions, and cross-provider overrides.

<sup>Written for commit 9dd6968b8ef6a9b4caf6910b789de442e653142a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

### Review follow-up (post review-work gate)

The review gate returned PASS with no blocking issues. Its one substantive non-blocking note is fixed here rather than deferred: the manual `model_change` branch now guards `provider`/`modelId` before it becomes an authoritative selection, mirroring the fallback-original restore directly above it. Session files are parsed without validation, so without the guard a truncated or hand-edited entry would have been restored as the selection (previously the next assistant message would have corrected it). Captured RED (restored `modelId: ""`) before the guard and GREEN after; the regression case lives in the same test file (now 6 cases). Re-verified at the pushed tree: `test/session-manager` 15 files / 151 tests, biome clean, `tsc --noEmit` exit 0, changelog gate PASS.