### PR TITLE
test(coding-agent): fix flaky ownership-lock ordering assertion

### DIFF
--- a/packages/coding-agent/test/ownership-safe-lock.test.ts
+++ b/packages/coding-agent/test/ownership-safe-lock.test.ts
@@ -9,6 +9,17 @@ const roots: string[] = [];
 const children: ChildProcess[] = [];
 const childSource = `
   import { acquireOwnershipSafeLock } from ${JSON.stringify(new URL("../src/modes/rpc/ownership-safe-lock.ts", import.meta.url).href)};
+  let signalGo = () => {};
+  const go = new Promise((resolve) => { signalGo = resolve; });
+  // "mark" is echoed on THIS child's stdout, so the parent can order the echo against this
+  // child's own later lines instead of racing a sibling process's pipe.
+  process.stdin.on("data", (chunk) => {
+    for (const raw of String(chunk).split("\\n")) {
+      const line = raw.trim();
+      if (line === "mark") console.log("MARK");
+      else if (line === "go") signalGo();
+    }
+  });
   console.log("TRYING");
   const lock = await acquireOwnershipSafeLock(process.argv[1]);
   console.log("ACQUIRED");
@@ -18,7 +29,7 @@ const childSource = `
     while (Date.now() < end) {}
     console.log("UNBLOCKED");
   }
-  if (process.argv[2] === "hold") await new Promise((resolve) => process.stdin.once("data", resolve));
+  if (process.argv[2] === "hold") await go;
   await lock();
   console.log("RELEASED");
 `;
@@ -66,16 +77,21 @@ describe("ownership-safe-lock", () => {
 		const events: string[] = [];
 		const holder = tracked(lockPath, events, "holder", "hold");
 		await holder.seen("ACQUIRED");
-		const waiter = tracked(lockPath, events, "waiter");
-		// The waiter is provably attempting acquisition before the holder is
-		// told to release; ordering (not a fixed absence window) is the proof:
-		// a non-exclusive mutant acquires before holder:RELEASED and fails the
-		// index assertion below deterministically.
+		const waiter = tracked(lockPath, events, "waiter", "hold");
+		// Ordering (not a fixed absence window) is the proof, and both ordered events come
+		// from the WAITER's own stdout: while the holder still holds, the parent makes the
+		// waiter echo MARK, so MARK strictly precedes any later line from that same pipe.
+		// Anchoring on the holder's RELEASED line instead raced two pipes - the holder drops
+		// the lock before it prints, so a legitimate waiter could be observed acquiring first
+		// and invert the events (observed as CI flake). A non-exclusive mutant still fails
+		// deterministically: it prints ACQUIRED before it ever processes the mark.
 		await waiter.seen("TRYING");
+		waiter.child.stdin?.write("mark\n");
+		await waiter.seen("MARK");
 		holder.child.stdin?.write("go\n");
 		await holder.seen("RELEASED");
 		await waiter.seen("ACQUIRED");
-		expect(events.indexOf("waiter:ACQUIRED")).toBeGreaterThan(events.indexOf("holder:RELEASED"));
+		expect(events.indexOf("waiter:ACQUIRED")).toBeGreaterThan(events.indexOf("waiter:MARK"));
 	});
 
 	it("releases a killed holder and keeps a blocked event loop exclusive", async () => {


### PR DESCRIPTION
## Summary

`test/ownership-safe-lock.test.ts` "serializes real children" flakes in CI (observed on an unrelated PR: `AssertionError: expected 3 to be greater than 4`). The assertion ordered two events that arrive through **two different child stdout pipes**, and the holder drops the lock *before* it prints `RELEASED` — so a legitimate waiter can be observed acquiring first, inverting the two events without anything being wrong with the lock.

## Change (test-only)

The ordering anchor now travels through the **waiter's own stdout**: while the holder still holds, the parent asks the waiter to echo `MARK`, and the test asserts the waiter's `ACQUIRED` comes after its own `MARK`. Two lines from one pipe have a guaranteed order, so the race disappears while the exclusivity contract stays the thing under test. The child protocol gains a small stdin reader (`mark` → echo, `go` → release), replacing the previous "first stdin chunk releases" behaviour.

## Evidence (mengmotaMac via bunshin)

- **Failure mode reproduced deterministically**: with the holder's `RELEASED` print delayed 400ms after the real release, the old assertion fails (`expected 4 to be greater than 5`) — the same shape as the CI failure.
- **Mutation proof of the new assertion**: making `acquireOwnershipSafeLock` return a no-op release (non-exclusive lock) fails the test deterministically (`expected 3 to be greater than 4`). An intermediate parent-side anchor was rejected precisely because it did *not* catch this mutant.
- **Honest runs**: 5/5 `bunx vitest run test/ownership-safe-lock.test.ts` exit 0, 4 passed each; mutation reverted and working tree clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky `serializes real children` test in `packages/coding-agent` by anchoring the lock-ordering assertion on the waiter's own stdout instead of racing two child pipes.

The old assertion compared a waiter's `ACQUIRED` event against the holder's `RELEASED` event, but the holder drops the lock before printing `RELEASED`, so a legitimate waiter could acquire first and invert the order. Now the parent asks the waiter to echo `MARK` while the holder still holds, and the test asserts `ACQUIRED` comes after the waiter's own `MARK`. The child protocol gains a small stdin reader (`mark` → echo, `go` → release) replacing the previous "first stdin chunk releases" behavior.

<sup>Written for commit 5f015e9a24f5b40224e59aead3e77096093cfc84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

