### PR TITLE
fix(models): omit speculation lead from resumed-session admission

### DIFF
--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -109,6 +109,7 @@ import { areExperimentalFeaturesEnabled } from "./experimental.ts";
 import { exportSessionToHtml, type ToolHtmlRenderer } from "./export-html/index.ts";
 import { createToolHtmlRenderer } from "./export-html/tool-renderer.ts";
 import {
+	type ModelUsabilityAdmission,
 	ModelUsabilityBudgetError,
 	projectModelUsabilityBudget,
 } from "./extensions/builtin/compaction/model-usability-budget.ts";
@@ -4555,7 +4556,11 @@ export class AgentSession {
 		return this._setModel(model, true);
 	}
 
-	assertModelUsable(model: Model<Api> | undefined = this.model, liveContextTokens = 0): void {
+	assertModelUsable(
+		model: Model<Api> | undefined = this.model,
+		liveContextTokens = 0,
+		options?: { includeSpeculationLead?: boolean; admission?: ModelUsabilityAdmission },
+	): void {
 		if (!model || model.contextWindow <= 0) return;
 		const projection = projectModelUsabilityBudget({
 			model,
@@ -4563,6 +4568,8 @@ export class AgentSession {
 			tools: this.agent.state.tools,
 			liveContextTokens,
 			compaction: this.settingsManager.getCompactionSettings(),
+			includeSpeculationLead: options?.includeSpeculationLead,
+			admission: options?.admission,
 		});
 		if (!projection.usable) throw new ModelUsabilityBudgetError(projection);
 	}

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/AGENTS.md
@@ -35,6 +35,7 @@ compaction/
 ├── deterministic-fallback.ts # Classification + construction when summarization fails outright
 ├── summarization-retry.ts, transient-failure.ts, retained-message-safety.ts  # Retry/safety predicates
 ├── openai-remote-{convert,model,schema,timeout,responses-v2}.ts  # Remote-route support modules
+├── model-usability-budget.ts # Startup/switch/resume context admission projection
 └── changes.md                # Fork tracker (restoration tracker, extension hook wiring)
 ```
 

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1,5 +1,36 @@
 # changes.md — builtin compaction policy
 
+## Omit speculation lead from resumed-session admission (2026-09-03)
+
+### What changed
+
+- `projectModelUsabilityBudget` accepts `includeSpeculationLead` (default true) and `admission`
+  (`start` | `resume` | `switch`). Resume projections report `speculationLeadTokens: 0` when the
+  lead is omitted, so the error breakdown matches the charged budget.
+- `createAgentSession` resume admission passes `includeSpeculationLead: false` and
+  `admission: "resume"`. Fresh startup and live model switches keep charging the lead.
+- `ModelUsabilityBudgetError` uses "cannot resume" for restored transcripts instead of the
+  switch copy that told the user to compact a session that never started.
+
+### Why
+
+- Speculative compaction is enabled by default and starts on `before_agent_start` / idle warmup.
+  Startup admission ran *before* that hook and charged the speculation lead against the full
+  uncompacted transcript, so a session already in the speculative band could not open and
+  auto-compaction never ran. Live miss: 828k restored / 1.05M window / 32,768 lead / 28,351
+  shortfall (`#1339`, `#1340`).
+- Model switch on a live session can still charge the lead: the user can compact first.
+
+### Why an extension could not handle it
+
+- `createAgentSession` throws `ModelUsabilityBudgetError` before the compaction extension is
+  wired; no extension hook can intercept that constructor-time reject.
+
+### Expected merge conflict zones
+
+- `model-usability-budget.ts` projection + error copy; `sdk.ts` startup `assertModelUsable` call;
+  `agent-session.ts` `assertModelUsable` options; `test/suite/model-usability-budget.test.ts`.
+
 ## Recover classified manual compaction failures deterministically (2026-09-02)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/model-usability-budget.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/model-usability-budget.ts
@@ -19,6 +19,8 @@ const MODEL_SAFETY_MARGIN_PROFILES: readonly ModelSafetyMarginProfile[] = [
 	{ id: "default", tokens: 8_192 },
 ];
 
+export type ModelUsabilityAdmission = "start" | "resume" | "switch";
+
 export interface ModelUsabilityBudgetProjection {
 	readonly model: string;
 	readonly contextWindow: number;
@@ -33,6 +35,7 @@ export interface ModelUsabilityBudgetProjection {
 	readonly requiredTokens: number;
 	readonly shortfallTokens: number;
 	readonly usable: boolean;
+	readonly admission: ModelUsabilityAdmission;
 }
 
 export interface ModelUsabilityBudgetInput<TApi extends Api> {
@@ -41,6 +44,9 @@ export interface ModelUsabilityBudgetInput<TApi extends Api> {
 	readonly tools: readonly Tool[];
 	readonly liveContextTokens?: number;
 	readonly compaction: CompactionPreparation["settings"];
+	/** Defaults to true. Resume/startup must pass false so speculation can run after admit. */
+	readonly includeSpeculationLead?: boolean;
+	readonly admission?: ModelUsabilityAdmission;
 }
 
 function matchesFamilyMarker(modelId: string, marker: string): boolean {
@@ -78,8 +84,11 @@ export function projectModelUsabilityBudget<TApi extends Api>(
 		input.model.contextWindow - getPromptContextWindow(input.model.contextWindow, input.model.maxTokens);
 	const geometry = resolveCompactionGeometry({ contextWindow: input.model.contextWindow, settings: input.compaction });
 	const compactionReserveTokens = input.compaction.enabled ? geometry.reserveTokens : 0;
+	const includeSpeculationLead = input.includeSpeculationLead !== false;
 	const speculationLeadTokens =
-		input.compaction.enabled && input.compaction.speculativeEnabled !== false ? geometry.leadTokens : 0;
+		includeSpeculationLead && input.compaction.enabled && input.compaction.speculativeEnabled !== false
+			? geometry.leadTokens
+			: 0;
 	const safetyMargin = resolveSafetyMarginProfile(input.model);
 	const requiredTokens =
 		liveContextTokens +
@@ -90,6 +99,7 @@ export function projectModelUsabilityBudget<TApi extends Api>(
 		speculationLeadTokens +
 		safetyMargin.tokens;
 	const shortfallTokens = Math.max(0, requiredTokens - input.model.contextWindow);
+	const admission = input.admission ?? (liveContextTokens > 0 ? "switch" : "start");
 
 	return {
 		model: `${input.model.provider}/${input.model.id}`,
@@ -105,6 +115,7 @@ export function projectModelUsabilityBudget<TApi extends Api>(
 		requiredTokens,
 		shortfallTokens,
 		usable: shortfallTokens === 0,
+		admission,
 	};
 }
 
@@ -114,9 +125,11 @@ export class ModelUsabilityBudgetError extends Error {
 	constructor(projection: ModelUsabilityBudgetProjection) {
 		const breakdown = `system prompt ${projection.systemPromptTokens}, active tool schemas ${projection.activeToolSchemaTokens}, output reserve ${projection.outputReserveTokens}, compaction reserve ${projection.compactionReserveTokens}, speculation lead ${projection.speculationLeadTokens}, safety margin ${projection.safetyMarginTokens} [${projection.safetyMarginProfile}]`;
 		const message =
-			projection.liveContextTokens > 0
-				? `Model "${projection.model}" cannot switch: target context window ${projection.contextWindow} tokens is ${projection.shortfallTokens} tokens short of the ${projection.requiredTokens}-token requirement (live context ${projection.liveContextTokens}, ${breakdown}). Compact the session, then revalidate and retry the model switch.`
-				: `Model "${projection.model}" cannot start: context window ${projection.contextWindow} tokens is ${projection.shortfallTokens} tokens short of the ${projection.requiredTokens}-token minimum (${breakdown}).`;
+			projection.admission === "resume"
+				? `Model "${projection.model}" cannot resume: target context window ${projection.contextWindow} tokens is ${projection.shortfallTokens} tokens short of the ${projection.requiredTokens}-token requirement (live context ${projection.liveContextTokens}, ${breakdown}).`
+				: projection.admission === "switch"
+					? `Model "${projection.model}" cannot switch: target context window ${projection.contextWindow} tokens is ${projection.shortfallTokens} tokens short of the ${projection.requiredTokens}-token requirement (live context ${projection.liveContextTokens}, ${breakdown}). Compact the session, then revalidate and retry the model switch.`
+					: `Model "${projection.model}" cannot start: context window ${projection.contextWindow} tokens is ${projection.shortfallTokens} tokens short of the ${projection.requiredTokens}-token minimum (${breakdown}).`;
 		super(message);
 		this.name = "ModelUsabilityBudgetError";
 		this.projection = projection;

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -519,7 +519,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const liveContextTokens = hasExistingSession
 		? existingSession.messages.reduce((total, message) => total + estimateTokens(message), 0)
 		: 0;
-	session.assertModelUsable(undefined, liveContextTokens);
+	session.assertModelUsable(
+		undefined,
+		liveContextTokens,
+		hasExistingSession ? { includeSpeculationLead: false, admission: "resume" } : { admission: "start" },
+	);
 	cursorBridgeSessionRef.current = session;
 	const extensionsResult = resourceLoader.getExtensions();
 

--- a/packages/coding-agent/test/suite/model-usability-budget.test.ts
+++ b/packages/coding-agent/test/suite/model-usability-budget.test.ts
@@ -243,8 +243,94 @@ describe("model usability budget", () => {
 				model: `${model.provider}/${model.id}`,
 				liveContextTokens: expect.any(Number),
 				usable: false,
+				admission: "resume",
+				speculationLeadTokens: 0,
 			},
 		});
+		expect(error).toBeInstanceOf(ModelUsabilityBudgetError);
+		if (!(error instanceof ModelUsabilityBudgetError)) throw new Error("expected resume budget rejection");
+		expect(error.message).toContain("cannot resume");
+		expect(error.message).not.toContain("cannot switch");
+		expect(error.message).not.toContain("retry the model switch");
+	});
+
+	it("resumes a restored transcript that only the speculation lead would have rejected", async () => {
+		// given
+		const harness = await createHarness({
+			models: [{ id: "startup", contextWindow: 1_050_000, maxTokens: 128_000 }],
+		});
+		harnesses.push(harness);
+		const model = harness.getModel();
+		const probe = await createAgentSession({
+			cwd: harness.tempDir,
+			agentDir: join(harness.tempDir, "resume-lead-probe"),
+			model,
+			sessionManager: SessionManager.inMemory(harness.tempDir),
+		});
+		const compaction = probe.session.settingsManager.getCompactionSettings();
+		const empty = projectModelUsabilityBudget({
+			model,
+			systemPrompt: probe.session.agent.state.systemPrompt,
+			tools: probe.session.agent.state.tools,
+			compaction,
+			includeSpeculationLead: false,
+			admission: "resume",
+		});
+		const withLead = projectModelUsabilityBudget({
+			model,
+			systemPrompt: probe.session.agent.state.systemPrompt,
+			tools: probe.session.agent.state.tools,
+			compaction,
+			includeSpeculationLead: true,
+			admission: "resume",
+		});
+		const systemPrompt = probe.session.agent.state.systemPrompt;
+		const tools = probe.session.agent.state.tools;
+		probe.session.dispose();
+		expect(withLead.speculationLeadTokens).toBeGreaterThan(1_000);
+		const liveContextTokens = model.contextWindow - empty.requiredTokens - withLead.speculationLeadTokens + 1_000;
+		expect(liveContextTokens).toBeGreaterThan(0);
+		expect(
+			projectModelUsabilityBudget({
+				model,
+				systemPrompt,
+				tools,
+				liveContextTokens,
+				compaction,
+				includeSpeculationLead: true,
+				admission: "resume",
+			}).usable,
+		).toBe(false);
+		expect(
+			projectModelUsabilityBudget({
+				model,
+				systemPrompt,
+				tools,
+				liveContextTokens,
+				compaction,
+				includeSpeculationLead: false,
+				admission: "resume",
+			}).usable,
+		).toBe(true);
+		const sessionManager = SessionManager.inMemory(harness.tempDir);
+		sessionManager.appendMessage({
+			role: "user",
+			// Spaces break the base64-run weighting so chars/4 stays 1:1 with liveContextTokens.
+			content: [{ type: "text", text: "! ".repeat(liveContextTokens * 2) }],
+			timestamp: Date.now(),
+		});
+
+		// when
+		const resumed = await createAgentSession({
+			cwd: harness.tempDir,
+			agentDir: join(harness.tempDir, "resume-lead-gap"),
+			model,
+			sessionManager,
+		});
+
+		// then
+		expect(resumed.session.agent.state.messages).toHaveLength(1);
+		resumed.session.dispose();
 	});
 
 	it("keeps fresh and fitting resumed sessions accepted", async () => {
@@ -303,6 +389,45 @@ describe("model usability budget", () => {
 		// then
 		expect(atBoundary).toMatchObject({ usable: true, requiredTokens: 36_769, shortfallTokens: 0 });
 		expect(belowBoundary).toMatchObject({ usable: false, requiredTokens: 36_769, shortfallTokens: 1 });
+	});
+
+	it("omits speculation lead from a restored-transcript projection when asked", async () => {
+		// given
+		const harness = await createHarness();
+		harnesses.push(harness);
+		const model = { ...harness.getModel(), contextWindow: 1_050_000, maxTokens: 128_000 };
+		const compaction = harness.settingsManager.getCompactionSettings();
+		const liveContextTokens = 850_000;
+
+		// when
+		const charged = projectModelUsabilityBudget({
+			model,
+			systemPrompt: "x",
+			tools: [],
+			liveContextTokens,
+			compaction,
+			admission: "resume",
+		});
+		const omitted = projectModelUsabilityBudget({
+			model,
+			systemPrompt: "x",
+			tools: [],
+			liveContextTokens,
+			compaction,
+			includeSpeculationLead: false,
+			admission: "resume",
+		});
+
+		// then
+		expect(charged.speculationLeadTokens).toBeGreaterThan(0);
+		expect(omitted).toMatchObject({
+			speculationLeadTokens: 0,
+			admission: "resume",
+			liveContextTokens,
+		});
+		expect(charged.requiredTokens - omitted.requiredTokens).toBe(charged.speculationLeadTokens);
+		expect(charged.usable).toBe(false);
+		expect(omitted.usable).toBe(true);
 	});
 
 	it("preserves disabled compaction and speculation opt-outs", async () => {


### PR DESCRIPTION
## Summary

Resume admission (`createAgentSession` with restored messages) charged speculation lead (up to 32,768 tokens) against the **full uncompacted transcript** before the compaction extension could run. Speculative auto-compaction is on by default and only starts on `before_agent_start` / idle warmup, so a session already in the speculative band could not open and auto-compaction never ran.

Fresh startup and live model switches still charge the lead. Those paths can compact first.

Resume `ModelUsabilityBudgetError` now says **cannot resume** instead of **cannot switch** / "compact then retry the model switch".

## Issues

- Fixes #1339
- Fixes #1340

## Live miss

omo-ai `5.0.0-0.beta.39` / senpi `2026.9.3-3`, `omo --session` on `llm-pool/codex/daybreak-blue`:

- window 1,050,000, live 828,594, speculation lead 32,768, shortfall **28,351**
- 828k is in the speculative band (~807k start, ~840k blocking, ~1.008M hard valve)
- dropping the lead would have admitted the session

## Test plan

- [x] `packages/coding-agent` vitest: `test/suite/model-usability-budget.test.ts`, `test/compaction/model-usability.test.ts`, `test/suite/model-usability-review.test.ts` (20 passed)
- [ ] Resume a session in the speculative band (`omo --session <id>`) after this lands in a senpi build

[bob]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumed sessions no longer charge the speculation lead (up to 32,768 tokens) against the full uncompacted transcript, so sessions already in the speculative band can open and auto-compaction can run. Fixes #1339 and #1340.

- Fresh startup and live model switches still charge the lead, since those paths can compact first.
- Resume budget errors now say "cannot resume" instead of "cannot switch."

<sup>Written for commit b09471ff7ad7267547f692c21bcfb4edde94a6ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

