### PR TITLE
fix(codemode): cap the interactive eval detach budget at a foreground window

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- `foregroundWindowSeconds` codemode setting (default `60`, env `SENPI_CODEMODE_FOREGROUND_SECONDS`): the longest an interactive `eval` call blocks the turn before the cell detaches. A larger `timeout` now frees the turn at this window while the cell keeps running to the hard limit, instead of blocking the agent loop for the whole `timeout`.
+
 ### Changed
 
 ### Fixed
@@ -235,6 +237,7 @@
 
 ### Fixed
 
+- An explicit `timeout` no longer silently disables detach for interactive `eval` cells. Previously `timeout` was both the detach budget and the hard-limit extension with no cap, so a call like `timeout: 7000` (intended to keep a long detached cell alive) blocked the agent loop for ~2h before the hard limit killed it. The detach point is now capped at the foreground window; `on_timeout: "error"` (and print/json) keep `timeout` as the unclamped deadline, and the hard-limit extension (`max(hardLimitSeconds, timeout)`) is unchanged.
 - Detached-eval same-language busy errors now name each idle enabled kernel and tell the agent to continue the step there (`continue this step in an idle kernel: js`), instead of only pointing at peek and the output tail. A busy Python kernel no longer reads as "eval is unavailable", which previously sent agents to `bash`+`python3` while JavaScript (or another idle kernel) was free. Single-language sessions and fully-busy sessions omit the idle-kernel claim.
 - JavaScript eval cells now persist only top-level declarations, including destructuring bindings and uninitialized variables, without rewriting declaration-shaped text inside literals or comments.
 - Eval completion and detached-cell handling retain explicit lifecycle observability: nested tool counts, wall/kernel timing, detach state, `peek`, `stop`, hard limits, and crash recovery remain bounded and machine-readable for hosts and telemetry consumers.

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -71,6 +71,7 @@ Configuration is loaded in this order:
     "jl": false
   },
   "cellTimeoutSeconds": 30,
+  "foregroundWindowSeconds": 60,
   "parallelPoolWidth": 4,
   "taskTools": {
     "task": "task",
@@ -88,6 +89,7 @@ Configuration is loaded in this order:
 | --- | --- | --- |
 | `languages` | `py`/`js` enabled; `rb`/`jl` disabled | Selects desired languages before interpreter detection. |
 | `cellTimeoutSeconds` | `30` | Idle timeout for one cell unless the call supplies `timeout`; interactive calls detach by default and print/json calls error. |
+| `foregroundWindowSeconds` | `60` | Longest an interactive (detach-behavior) call blocks the turn before the cell detaches, capping the `timeout` detach budget. A larger `timeout` still raises the hard limit and keeps the cell running, but the turn is freed at this window. `on_timeout: "error"` calls keep the full `timeout` as an uncapped deadline. Env override: `SENPI_CODEMODE_FOREGROUND_SECONDS`. |
 | `parallelPoolWidth` | `4` | Maximum concurrent `parallel()` thunks. |
 | `taskTools.task` | `"task"` | Registered tool name used by `agent()`. |
 | `taskTools.output` | `"task_output"` | Registered tool name used by `output()`. |

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,30 @@
 # senpi-codemode fork changes
 
+## eval foreground window caps the interactive detach budget (2026-09-04)
+
+### What changed
+
+- `packages/senpi-codemode/src/config/settings.ts` adds `foregroundWindowSeconds` to the settings schema, `CodemodeSettings`, `defaultCodemodeSettings` (`60`), and `mergeSettings`, plus `DEFAULT_FOREGROUND_WINDOW_SECONDS`, `FOREGROUND_WINDOW_ENVIRONMENT_FLAG` (`SENPI_CODEMODE_FOREGROUND_SECONDS`), and `resolveForegroundWindowSeconds()` mirroring the hard-limit resolver.
+- `packages/senpi-codemode/src/tool/eval-tool.ts` computes the timeout behavior first, then clamps the detach watchdog budget to `min(timeout ?? cellTimeoutSeconds, foregroundWindowSeconds)` only when the behavior is `"detach"`; `"error"` keeps the unclamped deadline. The wall-clock hard limit (`max(hardLimitSeconds, timeout)`) is untouched.
+- `packages/senpi-codemode/src/tool/eval-tool-options.ts` adds the optional `foregroundWindowSeconds` factory option; `packages/senpi-codemode/src/index.ts` passes `resolveForegroundWindowSeconds(...)` at both eval registration sites.
+- `packages/senpi-codemode/src/prompt/eval-prompt.ts` and `packages/senpi-codemode/src/tool/types.ts` document that `timeout` is the detach budget capped at the foreground window and that a larger value extends the hard limit, not the foreground block.
+
+### Why
+
+- A real session passed `timeout: 7000` to keep a long detached orchestration cell alive; because `timeout` had no cap it blocked the agent loop for ~2h and then hit the 7000s hard limit, killing the cell and restarting the kernel. The bash tool already separates a 60s foreground window from the kill deadline; eval had no equivalent, so `timeout` did the worst of both worlds.
+
+### Why an extension could not handle it
+
+- The detach-vs-error decision and the idle watchdog budget are computed inside this package's `runEvalCell`; no downstream hook can re-cap the detach timer before the cell is scheduled, and the setting must live in this package's settings schema and registration path.
+
+### Expected merge conflict zones
+
+- LOW in `src/config/settings.ts` around the settings schema, defaults, and resolver functions.
+- LOW in `src/tool/eval-tool.ts` around the `timeoutMs` computation in `runEvalCell`.
+- LOW in `src/index.ts` at the two `createEvalTool` registration sites.
+- LOW in `src/tool/types.ts` and `src/prompt/eval-prompt.ts` around the `timeout`/`on_timeout` descriptions.
+
+
 ## Eval description subscribes to monitor events when available (2026-09-03)
 
 ### What changed

--- a/packages/senpi-codemode/src/config/settings.ts
+++ b/packages/senpi-codemode/src/config/settings.ts
@@ -19,6 +19,7 @@ export const codemodeSettingsSchema = Type.Object(
 			),
 		),
 		cellTimeoutSeconds: Type.Optional(Type.Number({ minimum: 1 })),
+		foregroundWindowSeconds: Type.Optional(Type.Number({ minimum: 1 })),
 		hardLimitSeconds: Type.Optional(Type.Number({ minimum: 1 })),
 		parallelPoolWidth: Type.Optional(Type.Number({ minimum: 1 })),
 		taskTools: Type.Optional(
@@ -64,6 +65,13 @@ export interface CodemodeSettings {
 		readonly jl: boolean;
 	};
 	readonly cellTimeoutSeconds: number;
+	/**
+	 * Longest an interactive eval call blocks the agent loop before the cell detaches, independent
+	 * of `timeout` (which becomes the detach budget only up to this window). A still-running cell
+	 * keeps living up to the hard limit; this only frees the turn. Ignored for `on_timeout: "error"`
+	 * (and print/json) calls, where `timeout` stays the unclamped deadline.
+	 */
+	readonly foregroundWindowSeconds: number;
 	/** Wall-clock kill deadline for a single cell; bounds detached cells too. */
 	readonly hardLimitSeconds: number;
 	readonly parallelPoolWidth: number;
@@ -98,6 +106,16 @@ export const DEFAULT_HARD_LIMIT_SECONDS = 1800;
 
 export const HARD_LIMIT_ENVIRONMENT_FLAG = "SENPI_CODEMODE_HARD_LIMIT_SECONDS";
 
+/**
+ * Bash parity: `terminal/tools/foreground-window.ts` auto-detaches a still-running bash command to a
+ * background session at 60s regardless of its `timeout` kill deadline. An eval cell gets the same
+ * default foreground window so a large `timeout` extends the cell's lifetime without holding the turn
+ * hostage for hours.
+ */
+export const DEFAULT_FOREGROUND_WINDOW_SECONDS = 60;
+
+export const FOREGROUND_WINDOW_ENVIRONMENT_FLAG = "SENPI_CODEMODE_FOREGROUND_SECONDS";
+
 // OMP settings-schema.ts:3211-3299 has language/path settings only; eval.ts:427
 // defaults timeout to 30s, and codemode pins concurrency-bridge.ts:30 width to 4.
 export const defaultCodemodeSettings: ResolvedCodemodeSettings = {
@@ -108,6 +126,7 @@ export const defaultCodemodeSettings: ResolvedCodemodeSettings = {
 		jl: false,
 	},
 	cellTimeoutSeconds: 30,
+	foregroundWindowSeconds: DEFAULT_FOREGROUND_WINDOW_SECONDS,
 	hardLimitSeconds: DEFAULT_HARD_LIMIT_SECONDS,
 	parallelPoolWidth: 4,
 	taskTools: {
@@ -166,6 +185,15 @@ export function resolveHardLimitSeconds(settings: CodemodeSettings, env: Environ
 	return parsed;
 }
 
+/** Environment override wins over the settings file; a non-positive or malformed value is ignored. */
+export function resolveForegroundWindowSeconds(settings: CodemodeSettings, env: Environment = process.env): number {
+	const override = env[FOREGROUND_WINDOW_ENVIRONMENT_FLAG];
+	if (override === undefined) return settings.foregroundWindowSeconds;
+	const parsed = Number.parseInt(override, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) return settings.foregroundWindowSeconds;
+	return parsed;
+}
+
 async function loadSettingsFile(path: string): Promise<LoadedCodemodeSettings> {
 	const raw = await readFile(path, "utf8");
 	let parsed: unknown;
@@ -200,6 +228,7 @@ function mergeSettings(input: CodemodeSettingsInput): ResolvedCodemodeSettings {
 			jl: input.languages?.jl ?? defaultCodemodeSettings.languages.jl,
 		},
 		cellTimeoutSeconds: input.cellTimeoutSeconds ?? defaultCodemodeSettings.cellTimeoutSeconds,
+		foregroundWindowSeconds: input.foregroundWindowSeconds ?? defaultCodemodeSettings.foregroundWindowSeconds,
 		hardLimitSeconds: input.hardLimitSeconds ?? defaultCodemodeSettings.hardLimitSeconds,
 		parallelPoolWidth: input.parallelPoolWidth ?? defaultCodemodeSettings.parallelPoolWidth,
 		taskTools: {

--- a/packages/senpi-codemode/src/index.ts
+++ b/packages/senpi-codemode/src/index.ts
@@ -3,7 +3,7 @@ import type { ExtensionContext } from "@code-yeongyu/senpi";
 import type { AgentExecuteTool } from "./bridges/agent-bridge.ts";
 import type { EvalSchemaToolInfo } from "./bridges/schema-bridge.ts";
 import { type CompletionRequest, type CompletionResult, createCompletionHandler } from "./completion/handler.ts";
-import { defaultCodemodeSettings, resolveHardLimitSeconds } from "./config/settings.ts";
+import { defaultCodemodeSettings, resolveForegroundWindowSeconds, resolveHardLimitSeconds } from "./config/settings.ts";
 import { EvalNotifier } from "./extension/eval-notifier.ts";
 import { EVAL_CELLS_STATUS_KEY } from "./extension/eval-status.ts";
 import { EvalStatusTicker } from "./extension/eval-status-ticker.ts";
@@ -127,6 +127,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 				enabledLanguages: runtime.enabledLanguages,
 				kernelManager: manager,
 				cellTimeoutSeconds: runtime.settings.cellTimeoutSeconds,
+				foregroundWindowSeconds: resolveForegroundWindowSeconds(runtime.settings),
 				executeTool: runtime.executeTool,
 				listTools: () => pi.getAllTools(),
 				complete,
@@ -161,6 +162,7 @@ export default function senpiCodemode(pi: CodemodeExtensionAPI, options: SenpiCo
 			enabledLanguages: { py: true, js: true, rb: true, jl: true },
 			kernelManager: manager,
 			cellTimeoutSeconds: defaultCodemodeSettings.cellTimeoutSeconds,
+			foregroundWindowSeconds: resolveForegroundWindowSeconds(defaultCodemodeSettings),
 			executeTool: createExecuteTool(pi),
 			listTools: () => pi.getAllTools(),
 			complete,

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -136,9 +136,9 @@ Fields:
 - \`language\` — {{#if py}}\`"py"\` IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}\`"js"\` persistent JavaScript VM{{/if}}{{#if rb}}{{#ifAny py js}}, {{/ifAny}}\`"rb"\` persistent Ruby kernel{{/if}}{{#if jl}}{{#ifAny py js rb}}, {{/ifAny}}\`"jl"\` persistent Julia kernel{{/if}}.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds. Raise only for heavy compute or long{{#if spawns}} non-agent{{/if}} tool calls.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 

--- a/packages/senpi-codemode/src/tool/cell-execution.ts
+++ b/packages/senpi-codemode/src/tool/cell-execution.ts
@@ -17,6 +17,12 @@ export interface CellExecutionOptions {
 	readonly callerSignal: AbortSignal;
 	readonly cellId: string;
 	readonly timeoutMs: number;
+	/**
+	 * Caps how long a host-bridge pause may suspend the idle watchdog. When the cell will detach on
+	 * timeout this is set to the foreground window so a bridge-parked cell still frees the turn at the
+	 * window; left undefined (error mode) it keeps the idle-timeout default grace.
+	 */
+	readonly maxPauseGraceMs?: number;
 	readonly timeoutFactory: EvalTimeoutFactory;
 	readonly onTimeout: (error: Error) => void;
 	readonly onAbort: (error: Error) => void;
@@ -46,6 +52,7 @@ export class CellExecution {
 		this.#watchdog = options.timeoutFactory.create({
 			cellId: options.cellId,
 			timeoutMs: options.timeoutMs,
+			...(options.maxPauseGraceMs === undefined ? {} : { maxPauseGraceMs: options.maxPauseGraceMs }),
 			onTimeout: ({ error }) => options.onTimeout(error),
 		});
 		this.#callerSignal.addEventListener("abort", this.#handleCallerAbort, {

--- a/packages/senpi-codemode/src/tool/eval-tool-options.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool-options.ts
@@ -21,6 +21,12 @@ export interface CreateEvalToolOptions {
 	readonly enabledLanguages: EnabledEvalLanguages;
 	readonly kernelManager: EvalKernelManager;
 	readonly cellTimeoutSeconds: number;
+	/**
+	 * Longest an interactive (detach-behavior) call blocks the agent loop before the cell detaches,
+	 * capping the `timeout` detach budget. Defaults to {@link DEFAULT_FOREGROUND_WINDOW_SECONDS}.
+	 * Does not affect `on_timeout: "error"` calls or the wall-clock hard limit.
+	 */
+	readonly foregroundWindowSeconds?: number;
 	/** Wall-clock kill deadline applied to every cell; only used when this factory creates its own manager. */
 	readonly hardLimitSeconds?: number;
 	readonly executeTool: ExecuteTool;

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import type { AgentToolResult, ExtensionContext, ToolDefinition } from "@code-yeongyu/senpi";
-import { defaultCodemodeSettings } from "../config/settings.ts";
+import { DEFAULT_FOREGROUND_WINDOW_SECONDS, defaultCodemodeSettings } from "../config/settings.ts";
 import { buildEvalPrompt } from "../prompt/eval-prompt.ts";
 import { TIMEOUT_PAUSE_OP, TIMEOUT_RESUME_OP } from "../timeouts/bridge-timeout.ts";
 import { abortError, CellExecution, defaultTimeoutFactory } from "./cell-execution.ts";
@@ -101,8 +101,16 @@ async function runEvalCell(
 	invocation: EvalCellInvocation,
 ): Promise<AgentToolResult<EvalToolDetails>> {
 	if (invocation.signal.aborted) throw abortError(invocation.signal.reason);
-	const timeoutMs = Math.floor((invocation.input.timeout ?? options.cellTimeoutSeconds) * 1_000);
 	const timeoutBehavior = evalTimeoutBehavior(invocation.input, invocation.ctx);
+	const requestedTimeoutMs = Math.floor((invocation.input.timeout ?? options.cellTimeoutSeconds) * 1_000);
+	// The `timeout` (and its `cellTimeoutSeconds` default) is the detach budget for interactive calls.
+	// Cap it at the foreground window so a large `timeout` — whose real purpose is to raise the
+	// wall-clock hard limit (see EvalDetachedCellManager) — frees the turn at the window instead of
+	// blocking the agent loop for its full duration. `on_timeout: "error"` (and print/json) keep the
+	// unclamped deadline, since there the cell is killed rather than detached.
+	const foregroundWindowMs = (options.foregroundWindowSeconds ?? DEFAULT_FOREGROUND_WINDOW_SECONDS) * 1_000;
+	const timeoutMs =
+		timeoutBehavior === "detach" ? Math.min(requestedTimeoutMs, foregroundWindowMs) : requestedTimeoutMs;
 	const bridgeAbortController = new AbortController();
 	const cellSignal = AbortSignal.any([invocation.signal, bridgeAbortController.signal]);
 	const bridgeContext: ExtensionContext = { ...invocation.ctx, signal: cellSignal };

--- a/packages/senpi-codemode/src/tool/eval-tool.ts
+++ b/packages/senpi-codemode/src/tool/eval-tool.ts
@@ -111,6 +111,9 @@ async function runEvalCell(
 	const foregroundWindowMs = (options.foregroundWindowSeconds ?? DEFAULT_FOREGROUND_WINDOW_SECONDS) * 1_000;
 	const timeoutMs =
 		timeoutBehavior === "detach" ? Math.min(requestedTimeoutMs, foregroundWindowMs) : requestedTimeoutMs;
+	// A cell that pauses its watchdog for a host bridge call would otherwise wait the full pause grace
+	// (~10 min) before detaching; cap the grace at the foreground window too so the detach guarantee
+	// holds for bridge-parked cells. Error mode keeps the default grace (its timeout is the deadline).
 	const bridgeAbortController = new AbortController();
 	const cellSignal = AbortSignal.any([invocation.signal, bridgeAbortController.signal]);
 	const bridgeContext: ExtensionContext = { ...invocation.ctx, signal: cellSignal };
@@ -139,6 +142,7 @@ async function runEvalCell(
 		callerSignal: invocation.signal,
 		cellId: invocation.cellId,
 		timeoutMs,
+		...(timeoutBehavior === "detach" ? { maxPauseGraceMs: foregroundWindowMs } : {}),
 		timeoutFactory: options.timeoutFactory ?? defaultTimeoutFactory,
 		onTimeout: (error) => {
 			if (timeoutBehavior === "detach" && cellManager.detach(cell)) {

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -13,6 +13,12 @@ export function enabledLanguageList(enabled: EnabledEvalLanguages): EvalLanguage
 
 export const EVAL_SUMMARY_MAX_LENGTH = 80;
 
+const TIMEOUT_FIELD_DESCRIPTION =
+	"Seconds the cell may block the turn before it detaches, and the amount by which it raises the wall-clock hard limit. In interactive sessions the detach point is capped at the foreground window (default 60s), so a large value frees the turn at the window while the cell keeps running; on_timeout:'error' (and print/json) keep the full value as the uncapped deadline.";
+
+const ON_TIMEOUT_FIELD_DESCRIPTION =
+	"Timeout behavior. Interactive sessions detach by default (at the foreground window); print/json sessions error by default. 'error' uses the full timeout as an uncapped deadline.";
+
 export interface EvalToolInput {
 	readonly language: EvalLanguage;
 	readonly code: string;
@@ -47,10 +53,10 @@ const fullEvalInputSchema = Type.Object({
 				"REQUIRED for run. ONE line in the USER'S conversational language (Korean conversation -> Korean summary) stating WHAT this cell does and FOR WHAT PURPOSE; shown in the TUI while the cell runs. Longer values are force-truncated to 80 chars.",
 		}),
 	),
-	timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
+	timeout: Type.Optional(Type.Number({ minimum: 1, description: TIMEOUT_FIELD_DESCRIPTION })),
 	on_timeout: Type.Optional(
 		Type.Union([Type.Literal("detach"), Type.Literal("error")], {
-			description: "Timeout behavior. Interactive sessions detach by default; print/json sessions error by default.",
+			description: ON_TIMEOUT_FIELD_DESCRIPTION,
 		}),
 	),
 	reset: Type.Optional(Type.Boolean({ description: "Reset this language kernel before running." })),
@@ -83,11 +89,10 @@ export function createEvalInputSchema(enabled: EnabledEvalLanguages): EvalInputS
 						"REQUIRED for run. ONE line in the USER'S conversational language (Korean conversation -> Korean summary) stating WHAT this cell does and FOR WHAT PURPOSE; shown in the TUI while the cell runs. Longer values are force-truncated to 80 chars.",
 				}),
 			),
-			timeout: Type.Optional(Type.Number({ minimum: 1, description: "Timeout in seconds." })),
+			timeout: Type.Optional(Type.Number({ minimum: 1, description: TIMEOUT_FIELD_DESCRIPTION })),
 			on_timeout: Type.Optional(
 				Type.Union([Type.Literal("detach"), Type.Literal("error")], {
-					description:
-						"Timeout behavior. Interactive sessions detach by default; print/json sessions error by default.",
+					description: ON_TIMEOUT_FIELD_DESCRIPTION,
 				}),
 			),
 			reset: Type.Optional(Type.Boolean({ description: "Reset this language kernel before running." })),

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -19,9 +19,9 @@ Fields:
 - \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM, \`"rb"\` persistent Ruby kernel, \`"jl"\` persistent Julia kernel.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds. Raise only for heavy compute or long non-agent tool calls.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
@@ -140,9 +140,9 @@ Fields:
 - \`language\` — \`"js"\` persistent JavaScript VM.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 
@@ -236,9 +236,9 @@ Fields:
 - \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds. Raise only for heavy compute or long tool calls.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default); \`"error"\` interrupts for deadline-sensitive work and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises it, and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
+- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
+- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
 - \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
 

--- a/packages/senpi-codemode/test/config.test.ts
+++ b/packages/senpi-codemode/test/config.test.ts
@@ -6,6 +6,7 @@ import {
 	defaultCodemodeSettings,
 	loadCodemodeSettings,
 	resolveEnabledLanguages,
+	resolveForegroundWindowSeconds,
 	resolveHardLimitSeconds,
 } from "../src/config/settings.ts";
 
@@ -34,6 +35,7 @@ describe("codemode settings", () => {
 			expect(loaded.settings).toEqual({
 				languages: { py: false, js: true, rb: true, jl: false },
 				cellTimeoutSeconds: 30,
+				foregroundWindowSeconds: 60,
 				hardLimitSeconds: 1800,
 				parallelPoolWidth: 9,
 				taskTools: { task: "task", output: "task_output" },
@@ -63,6 +65,7 @@ describe("codemode settings", () => {
 			expect(loaded.settings).toEqual({
 				languages: { py: true, js: false, rb: false, jl: true },
 				cellTimeoutSeconds: 12,
+				foregroundWindowSeconds: 60,
 				hardLimitSeconds: 1800,
 				parallelPoolWidth: 4,
 				taskTools: { task: "task", output: "task_output" },
@@ -230,6 +233,49 @@ describe("codemode settings", () => {
 
 		for (const value of ["0", "-5", "abc", ""]) {
 			expect(resolveHardLimitSeconds(settings, { SENPI_CODEMODE_HARD_LIMIT_SECONDS: value })).toBe(90);
+		}
+	});
+
+	it("defaults foregroundWindowSeconds to the bash-parity 60s window", async () => {
+		const root = await mkdtemp(join(tmpdir(), "senpi-codemode-config-"));
+		try {
+			const loaded = await loadCodemodeSettings({ cwd: join(root, "project"), homeDir: join(root, "home") });
+
+			expect(loaded.settings.foregroundWindowSeconds).toBe(60);
+			expect(defaultCodemodeSettings.foregroundWindowSeconds).toBe(60);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("reads foregroundWindowSeconds from the settings file", async () => {
+		const root = await mkdtemp(join(tmpdir(), "senpi-codemode-config-"));
+		try {
+			const projectDir = join(root, "project");
+			await mkdir(join(projectDir, ".senpi"), { recursive: true });
+			await writeFile(join(projectDir, ".senpi", "codemode.json"), JSON.stringify({ foregroundWindowSeconds: 15 }));
+
+			const loaded = await loadCodemodeSettings({ cwd: projectDir, homeDir: join(root, "home") });
+
+			expect(loaded.warnings).toEqual([]);
+			expect(loaded.settings.foregroundWindowSeconds).toBe(15);
+			expect(resolveForegroundWindowSeconds(loaded.settings, {})).toBe(15);
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("lets the environment override beat the settings file foreground window", () => {
+		const settings = { ...defaultCodemodeSettings, foregroundWindowSeconds: 15 };
+
+		expect(resolveForegroundWindowSeconds(settings, { SENPI_CODEMODE_FOREGROUND_SECONDS: "7" })).toBe(7);
+	});
+
+	it("ignores a non-positive or malformed foreground window environment value", () => {
+		const settings = { ...defaultCodemodeSettings, foregroundWindowSeconds: 15 };
+
+		for (const value of ["0", "-5", "abc", ""]) {
+			expect(resolveForegroundWindowSeconds(settings, { SENPI_CODEMODE_FOREGROUND_SECONDS: value })).toBe(15);
 		}
 	});
 });

--- a/packages/senpi-codemode/test/eval-foreground-window.test.ts
+++ b/packages/senpi-codemode/test/eval-foreground-window.test.ts
@@ -1,0 +1,190 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultCodemodeSettings, loadCodemodeSettings } from "../src/config/settings.ts";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+type TextContent = Extract<AgentToolResult<unknown>["content"][number], { type: "text" }>;
+
+function textOf(resultValue: AgentToolResult<unknown>): string {
+	const texts: string[] = [];
+	for (const part of resultValue.content as readonly TextContent[]) {
+		if (part.type === "text") texts.push(part.text);
+	}
+	return texts.join("\n");
+}
+
+function interactiveContext() {
+	return { ...fakeExtensionContext(), mode: "tui" as const };
+}
+
+function createTool(manager: EvalDetachedCellManager, kernel: FakeKernel, foregroundWindowSeconds: number) {
+	return createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager: new FakeManager([["js", kernel]]),
+		cellTimeoutSeconds: 1,
+		foregroundWindowSeconds,
+		executeTool: vi.fn(),
+		cellManager: manager,
+	});
+}
+
+function trackSettlement(execution: Promise<AgentToolResult<EvalToolDetailsLike>>) {
+	const state = { settled: false };
+	void execution.then(
+		() => {
+			state.settled = true;
+		},
+		() => {
+			state.settled = true;
+		},
+	);
+	return state;
+}
+
+type EvalToolDetailsLike = unknown;
+
+describe("eval foreground window", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("detaches an explicit long timeout at the foreground window instead of blocking for it", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		const tool = createTool(manager, kernel, 5);
+
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"fw-long-cell",
+			{ language: "js", code: "await forever", summary: "long orchestration", timeout: 3600 },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		const settlement = trackSettlement(execution);
+
+		await vi.advanceTimersByTimeAsync(4_999);
+		expect(settlement.settled).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(settlement.settled).toBe(true);
+		const detached = await execution;
+		expect(textOf(detached)).toContain("detached and is still running");
+		expect(kernel.interrupts).toEqual([]);
+		expect(manager.busyFor("js")).toMatchObject({ cellId: "fw-long-cell", state: "detached" });
+		await manager.stop("fw-long-cell");
+		await manager.flushNotifications();
+	});
+
+	it("still detaches at the explicit timeout when it is shorter than the window", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		const tool = createTool(manager, kernel, 5);
+
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"fw-short-cell",
+			{ language: "js", code: "await forever", summary: "medium work", timeout: 3 },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		const settlement = trackSettlement(execution);
+
+		await vi.advanceTimersByTimeAsync(2_999);
+		expect(settlement.settled).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(settlement.settled).toBe(true);
+		const detached = await execution;
+		expect(textOf(detached)).toContain("detached and is still running");
+		expect(manager.busyFor("js")).toMatchObject({ cellId: "fw-short-cell", state: "detached" });
+		await manager.stop("fw-short-cell");
+		await manager.flushNotifications();
+	});
+
+	it("keeps an explicit on_timeout:error deadline unclamped by the foreground window", async () => {
+		vi.useFakeTimers();
+		const kernel = new FakeKernel([]);
+		const tool = createTool(new EvalDetachedCellManager(), kernel, 2);
+
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"fw-error-cell",
+			{ language: "js", code: "await forever", summary: "deadline-sensitive work", timeout: 3, on_timeout: "error" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		const settlement = trackSettlement(execution);
+
+		await vi.advanceTimersByTimeAsync(2_999);
+		expect(settlement.settled).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1);
+		const outcome = await execution.then(
+			() => ({ status: "fulfilled" as const }),
+			(error: unknown) => ({ status: "rejected" as const, error }),
+		);
+		expect(outcome).toMatchObject({ status: "rejected", error: { name: "TimeoutError" } });
+		expect(kernel.interrupts).toEqual(["Cell timed out after 3000ms"]);
+	});
+
+	it("keeps the default detach at cellTimeoutSeconds when no explicit timeout is given", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		const kernel = new FakeKernel([]);
+		const tool = createTool(manager, kernel, 5);
+
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"fw-default-cell",
+			{ language: "js", code: "await forever", summary: "default budget" },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		const settlement = trackSettlement(execution);
+
+		await vi.advanceTimersByTimeAsync(999);
+		expect(settlement.settled).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(settlement.settled).toBe(true);
+		const detached = await execution;
+		expect(textOf(detached)).toContain("detached and is still running");
+		await manager.stop("fw-default-cell");
+		await manager.flushNotifications();
+	});
+
+	it("defaults the foreground window to 60 seconds", () => {
+		expect(defaultCodemodeSettings).toMatchObject({ foregroundWindowSeconds: 60 });
+	});
+
+	it("loads foregroundWindowSeconds from codemode.json", async () => {
+		const root = await mkdtemp(join(tmpdir(), "senpi-codemode-fw-"));
+		try {
+			const projectDir = join(root, "project");
+			await mkdir(join(projectDir, ".senpi"), { recursive: true });
+			await writeFile(join(projectDir, ".senpi", "codemode.json"), JSON.stringify({ foregroundWindowSeconds: 42 }));
+
+			const loaded = await loadCodemodeSettings({ cwd: projectDir, homeDir: join(root, "home") });
+
+			expect(loaded.warnings).toEqual([]);
+			expect(loaded.settings).toMatchObject({ foregroundWindowSeconds: 42, cellTimeoutSeconds: 30 });
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/senpi-codemode/test/eval-foreground-window.test.ts
+++ b/packages/senpi-codemode/test/eval-foreground-window.test.ts
@@ -112,6 +112,35 @@ describe("eval foreground window", () => {
 		await manager.flushNotifications();
 	});
 
+	it("detaches a bridge-paused cell at the foreground window, not the default pause grace", async () => {
+		vi.useFakeTimers();
+		const manager = new EvalDetachedCellManager();
+		// The cell pauses its idle watchdog for a host bridge call (e.g. dag-wait) that never resumes.
+		const kernel = new FakeKernel([{ type: "status", event: { op: "timeout-pause" } }]);
+		const tool = createTool(manager, kernel, 2);
+
+		const started = kernel.deferNextRun();
+		const execution = tool.execute(
+			"fw-bridge-cell",
+			{ language: "js", code: "await tool.dag_wait({})", summary: "stuck bridge", timeout: 3600 },
+			undefined,
+			undefined,
+			interactiveContext(),
+		);
+		await started;
+		const settlement = trackSettlement(execution);
+
+		await vi.advanceTimersByTimeAsync(1_999);
+		expect(settlement.settled).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(settlement.settled).toBe(true);
+		const detached = await execution;
+		expect(textOf(detached)).toContain("detached and is still running");
+		await manager.stop("fw-bridge-cell");
+		await manager.flushNotifications();
+	});
+
 	it("keeps an explicit on_timeout:error deadline unclamped by the foreground window", async () => {
 		vi.useFakeTimers();
 		const kernel = new FakeKernel([]);

--- a/packages/senpi-codemode/test/interpreter.test.ts
+++ b/packages/senpi-codemode/test/interpreter.test.ts
@@ -99,6 +99,7 @@ describe("interpreter detection", () => {
 			{
 				languages: { py: true, js: true, rb: false, jl: false },
 				cellTimeoutSeconds: 30,
+				foregroundWindowSeconds: 60,
 				hardLimitSeconds: 1800,
 				parallelPoolWidth: 4,
 			},


### PR DESCRIPTION
## Summary

An explicit `timeout` on the `eval` tool used to disable detach for its entire duration. `timeout` was both the detach budget AND the hard-limit extension with no cap, so `eval({ timeout: 7000 })` — passed to keep a long *detached* cell alive — actually blocked the agent loop for ~2h and then hit the 7000s hard limit, killing the cell and restarting the kernel (real incident; see #1342). The `bash` tool already separates a 60s foreground window from its kill deadline; `eval` had no equivalent. This PR adds that foreground window.

## Changes

- **Setting** (`src/config/settings.ts`): new `foregroundWindowSeconds` (default `60`, env `SENPI_CODEMODE_FOREGROUND_SECONDS`) with `resolveForegroundWindowSeconds()` mirroring `resolveHardLimitSeconds`.
- **Clamp** (`src/tool/eval-tool.ts`): `runEvalCell` resolves the timeout behavior first, then caps the detach watchdog budget to `min(timeout ?? cellTimeoutSeconds, foregroundWindowSeconds)` **only when the behavior is `detach`**. `on_timeout: "error"` (and print/json) keep the full, unclamped deadline. The wall-clock hard limit (`max(hardLimitSeconds, timeout)`) is untouched, so a large `timeout` still extends a detached cell's lifetime — it just no longer holds the turn.
- **Wiring** (`src/tool/eval-tool-options.ts`, `src/index.ts`): the resolved window flows to both eval registration sites.
- **Docs** (`src/prompt/eval-prompt.ts`, `src/tool/types.ts`, `README.md`): the `timeout`/`on_timeout` descriptions now teach that `timeout` is the detach budget capped at the foreground window, and that raising it extends the hard limit, not the foreground block. Prompt snapshots regenerated.

## QA & Evidence

Tests and `bun run check` run on a mengmotaMac rig (bun + full build). Evidence under `local-ignore/qa-evidence/20260904-eval-foreground-window/`.

- **Failing-first (RED)** — `red-focused-full.txt`: new `test/eval-foreground-window.test.ts` on unchanged code → `3 failed | 3 passed`; the key failure is `detaches an explicit long timeout at the foreground window instead of blocking for it` (`expected false to be true` — cell with `timeout: 3600` still pending after 5s).
- **GREEN + regression** — `green-full.txt`, `green-check.txt`: full codemode suite `709 passed | 6 skipped`; root `bun run check` exit 0 (biome, pinned-deps, ts-imports, shrinkwrap, install-lock, claude-sdk lock, `tsc --noEmit`, browser-smoke).
- **Mutation proof** — `mutation-clamp.txt`: removing the `Math.min(...)` clamp makes exactly the foreground test fail (`1 failed | 5 passed`), then restored.
- **Real-surface QA** — `qa-drivers.txt`: `qa-e2e-eval`, `qa-detached-peek`, `qa-timeout-state` all pass on real kernels (the last confirms `on_timeout:"error"` still errors at its deadline and preserves state). `qa-clamp-real.txt`: a real JS kernel with `timeout: 30` + `foregroundWindowSeconds: 2` detaches at **2002ms**, not 30s.

## Risks & Residuals

- Behavior change is scoped to the interactive detach path; `error`/print/json deadlines and the hard limit are unchanged, each pinned by a dedicated test.
- Default 60s matches the bash foreground window, so out-of-the-box interactive behavior for cells under 60s is unchanged (the 30s `cellTimeoutSeconds` default still wins).

## Related Issues

Closes #1342

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the interactive eval detach budget at a new `foregroundWindowSeconds` setting (default 60s), so a large `timeout` no longer blocks the agent loop for its full duration—the cell detaches at the window and keeps running to the hard limit. Fixes #1342 where `timeout: 7000` held the turn for ~2h.

**Changes**
- Adds `foregroundWindowSeconds` setting with `SENPI_CODEMODE_FOREGROUND_SECONDS` env override.
- Clamps the detach watchdog budget to `min(timeout, foregroundWindowSeconds)` only for `detach` behavior; `on_timeout: "error"` keeps the full, unclamped deadline.
- Caps the watchdog pause grace at the window for detach cells, so a bridge-parked cell frees the turn instead of waiting the ~10 min default pause.
- Default 60s matches bash's foreground window, so cells under 60s behave exactly as before.

<sup>Written for commit 3f585daeb35a81fbdf8e61f34bc58bc85c47144f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

