### PR TITLE
fix(coding-agent): drop errored and aborted assistant turns from every LLM request

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Fixed `prepareNextTurn` and `prepareNextTurnWithContext` being skipped on completed turns without tool calls: the next-turn preparation now runs after every completed assistant turn that can reach the preparation boundary, including a normal stop response, while the terminating queue boundary and ownership refresh are preserved before a continuation provider request.
 - Fixed next-turn compaction firing on completed turns that will not reach the provider: compaction is now gated on real provider admission (a tool continuation or queued message actually being admitted), while the next-turn callback keeps running on every completed turn and the late queue re-sample and one bounded callback replay after compaction are retained.
 
+- The harness `convertToLlm` (`packages/agent/src/harness/messages.ts`) now drops assistant turns with `stopReason` `error` or `aborted`, and the tool results orphaned by that drop, from its output via the shared `dropFailedAssistantTurns` from `@earendil-works/pi-ai`, so compaction, branch summarization, and any consumer building an LLM request from the converted list never replay a failed provider turn's partial text or unexecuted tool calls. A call id re-declared by a kept assistant keeps its result.
+
 ### Removed
 
 ## [2026.9.4] - 2026-09-04

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -91,6 +91,24 @@
 
 - MEDIUM: `agent-loop.ts` turn admission, queue restoration, and parallel tool scheduling.
 
+## 2026-09-04 - Failed provider turns leave the LLM context on every lane
+
+### What changed
+
+- `packages/agent/src/harness/messages.ts`: the harness `convertToLlm` runs the shared `dropFailedAssistantTurns` from `@earendil-works/pi-ai` as its final step, removing assistant turns with `stopReason` `error`/`aborted` and the tool results orphaned by that drop from the returned `Message[]`; an id re-declared by a kept assistant keeps its result, and `stop`/`length`/`toolUse` turns pass through untouched.
+
+### Why
+
+- Compaction, branch summarization, and any consumer building an LLM request from the converted list had no `stopReason` filter, so after a provider error or abort every subsequent request replayed the failed turn's partial text and unexecuted tool calls; the provider transform layer dropped them for pi-ai API requests only.
+
+### Why an extension could not handle it
+
+- The drop must happen inside `convertToLlm`, which consumers call before any extension seam runs; extensions observe the already-built context and cannot remove a failed assistant turn from every downstream request shape deterministically.
+
+### Expected merge conflict zones
+
+- LOW: the tail of `convertToLlm` in `packages/agent/src/harness/messages.ts` (the new `dropFailedAssistantTurns` return).
+
 ## 2026-09-02 - Name the stream-start timeout setting
 
 ### What changed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -110,6 +110,7 @@
 ### Expected merge conflict zones
 
 - LOW: the tail of `convertToLlm` in `packages/agent/src/harness/messages.ts` (the new `dropFailedAssistantTurns` return).
+- LOW: the head of `estimateContextTokens` and the `counted` parameter of `getLastAssistantUsageInfo` in `packages/agent/src/harness/compaction/compaction.ts`.
 
 ## 2026-09-02 - Name the stream-start timeout setting
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -96,6 +96,8 @@
 ### What changed
 
 - `packages/agent/src/harness/messages.ts`: the harness `convertToLlm` runs the shared `dropFailedAssistantTurns` from `@earendil-works/pi-ai` as its final step, removing assistant turns with `stopReason` `error`/`aborted` and the tool results orphaned by that drop from the returned `Message[]`; an id re-declared by a kept assistant keeps its result, and `stop`/`length`/`toolUse` turns pass through untouched.
+- `packages/agent/src/harness/compaction/compaction.ts`: `estimateContextTokens` applies the same `dropFailedAssistantTurns` before anchoring on usage and summing trailing tokens, so the estimate counts exactly the set the next request carries; failed turns and their orphaned results no longer inflate the compaction trigger.
+- `packages/agent/test/harness/convert-to-llm.test.ts` (new) and `packages/agent/test/harness/compaction.test.ts`: pin the harness `convertToLlm` drop (error, aborted, re-declared-id keep) and the estimator exclusion for both failure kinds.
 
 ### Why
 

--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -205,9 +205,14 @@ export interface ContextUsageEstimate {
 	lastUsageIndex: number | null;
 }
 
-function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; index: number } | undefined {
+function getLastAssistantUsageInfo(
+	messages: AgentMessage[],
+	counted: ReadonlySet<AgentMessage>,
+): { usage: Usage; index: number } | undefined {
 	for (let i = messages.length - 1; i >= 0; i--) {
-		const usage = getAssistantUsage(messages[i]);
+		const message = messages[i];
+		if (!counted.has(message)) continue;
+		const usage = getAssistantUsage(message);
 		if (usage) return { usage, index: i };
 	}
 	return undefined;
@@ -217,13 +222,15 @@ function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; in
 export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEstimate {
 	// Count the same set the next provider request will carry: convertToLlm drops
 	// failed (error/aborted) assistant turns and their orphaned tool results.
-	const countedMessages = dropFailedAssistantTurns(messages);
-	const usageInfo = getLastAssistantUsageInfo(countedMessages);
+	// Indices stay relative to the INPUT array because callers read
+	// `messages[lastUsageIndex]` on the array they passed in.
+	const counted = new Set<AgentMessage>(dropFailedAssistantTurns(messages));
+	const usageInfo = getLastAssistantUsageInfo(messages, counted);
 
 	if (!usageInfo) {
 		let estimated = 0;
-		for (const message of countedMessages) {
-			estimated += estimateTokens(message);
+		for (const message of messages) {
+			if (counted.has(message)) estimated += estimateTokens(message);
 		}
 		return {
 			tokens: estimated,
@@ -235,8 +242,8 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
 
 	const usageTokens = calculateContextTokens(usageInfo.usage);
 	let trailingTokens = 0;
-	for (let i = usageInfo.index + 1; i < countedMessages.length; i++) {
-		trailingTokens += estimateTokens(countedMessages[i]);
+	for (let i = usageInfo.index + 1; i < messages.length; i++) {
+		if (counted.has(messages[i])) trailingTokens += estimateTokens(messages[i]);
 	}
 
 	return {

--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -2,6 +2,7 @@ import {
 	type Api,
 	type AssistantMessage,
 	type Context,
+	dropFailedAssistantTurns,
 	type Model,
 	type Models,
 	type RetryCallbacks,
@@ -214,11 +215,14 @@ function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; in
 
 /** Estimate context tokens for messages using provider usage when available. */
 export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEstimate {
-	const usageInfo = getLastAssistantUsageInfo(messages);
+	// Count the same set the next provider request will carry: convertToLlm drops
+	// failed (error/aborted) assistant turns and their orphaned tool results.
+	const countedMessages = dropFailedAssistantTurns(messages);
+	const usageInfo = getLastAssistantUsageInfo(countedMessages);
 
 	if (!usageInfo) {
 		let estimated = 0;
-		for (const message of messages) {
+		for (const message of countedMessages) {
 			estimated += estimateTokens(message);
 		}
 		return {
@@ -231,8 +235,8 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
 
 	const usageTokens = calculateContextTokens(usageInfo.usage);
 	let trailingTokens = 0;
-	for (let i = usageInfo.index + 1; i < messages.length; i++) {
-		trailingTokens += estimateTokens(messages[i]);
+	for (let i = usageInfo.index + 1; i < countedMessages.length; i++) {
+		trailingTokens += estimateTokens(countedMessages[i]);
 	}
 
 	return {

--- a/packages/agent/src/harness/messages.ts
+++ b/packages/agent/src/harness/messages.ts
@@ -1,4 +1,4 @@
-import type { ImageContent, Message, TextContent } from "@earendil-works/pi-ai";
+import { dropFailedAssistantTurns, type ImageContent, type Message, type TextContent } from "@earendil-works/pi-ai";
 import type { AgentMessage } from "../types.ts";
 
 export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
@@ -123,7 +123,7 @@ export function createCustomMessage(
 }
 
 export function convertToLlm(messages: AgentMessage[]): Message[] {
-	return messages
+	const converted = messages
 		.map((m): Message | undefined => {
 			switch (m.role) {
 				case "bashExecution":
@@ -166,4 +166,8 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 			}
 		})
 		.filter((m): m is Message => m !== undefined);
+	// Failed provider turns (stopReason error/aborted) must not be replayed by
+	// any lane that builds an LLM request from this output; dropping is
+	// deterministic, so earlier requests stay a prefix of later ones.
+	return dropFailedAssistantTurns(converted);
 }

--- a/packages/agent/test/harness/compaction.test.ts
+++ b/packages/agent/test/harness/compaction.test.ts
@@ -315,6 +315,24 @@ describe("harness compaction", () => {
 		expect(withFailedEstimate.trailingTokens).toBe(baselineEstimate.trailingTokens);
 	});
 
+	it("reports lastUsageIndex against the input array when a failed turn precedes the anchor", () => {
+		const failed: AssistantMessage = { ...createAssistantMessage("failed"), stopReason: "error" };
+		const anchor = createAssistantMessage("anchor", createMockUsage(200, 100));
+		const messages: AgentMessage[] = [
+			createUserMessage("Hello"),
+			createAssistantMessage("Hi", createMockUsage(100, 50)),
+			failed,
+			anchor,
+			createUserMessage("next"),
+		];
+
+		const estimate = estimateContextTokens(messages);
+
+		expect(estimate.lastUsageIndex).not.toBeNull();
+		expect(messages[estimate.lastUsageIndex as number]).toBe(anchor);
+		expect(estimate.usageTokens).toBe(300);
+	});
+
 	it("estimates tokens and context usage across supported message roles", () => {
 		const usage = createMockUsage(10, 5, 3, 2);
 		const assistant = createAssistantMessage("assistant", usage);

--- a/packages/agent/test/harness/compaction.test.ts
+++ b/packages/agent/test/harness/compaction.test.ts
@@ -277,6 +277,44 @@ describe("harness compaction", () => {
 		expect(result.firstKeptEntryIndex).toBe(lastValidCutPointIndex);
 	});
 
+	it.each(["error", "aborted"] as const)("excludes trailing %s turns from the context estimate", (stopReason) => {
+		const big = "x".repeat(40_000);
+		const failed: AssistantMessage = {
+			...createAssistantMessage(big),
+			stopReason,
+			content: [
+				{ type: "text", text: big },
+				{ type: "toolCall", id: "c-failed", name: "bash", arguments: { command: "ls" } },
+			],
+		};
+		const orphanResult: AgentMessage = {
+			role: "toolResult",
+			toolCallId: "c-failed",
+			toolName: "bash",
+			content: [{ type: "text", text: big }],
+			isError: true,
+			timestamp: Date.now(),
+		};
+		const withFailed: AgentMessage[] = [
+			createUserMessage("Hello"),
+			createAssistantMessage("Hi", createMockUsage(100, 50)),
+			failed,
+			orphanResult,
+			createUserMessage("next"),
+		];
+		const baseline: AgentMessage[] = [
+			createUserMessage("Hello"),
+			createAssistantMessage("Hi", createMockUsage(100, 50)),
+			createUserMessage("next"),
+		];
+
+		const withFailedEstimate = estimateContextTokens(withFailed);
+		const baselineEstimate = estimateContextTokens(baseline);
+
+		expect(withFailedEstimate.tokens).toBe(baselineEstimate.tokens);
+		expect(withFailedEstimate.trailingTokens).toBe(baselineEstimate.trailingTokens);
+	});
+
 	it("estimates tokens and context usage across supported message roles", () => {
 		const usage = createMockUsage(10, 5, 3, 2);
 		const assistant = createAssistantMessage("assistant", usage);

--- a/packages/agent/test/harness/convert-to-llm.test.ts
+++ b/packages/agent/test/harness/convert-to-llm.test.ts
@@ -1,0 +1,80 @@
+// Harness convertToLlm drops failed provider turns (stopReason error/aborted) and their orphaned tool results.
+
+import type { AssistantMessage, Message, Usage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { convertToLlm } from "../../src/harness/messages.ts";
+import type { AgentMessage } from "../../src/types.ts";
+
+function usage(): Usage {
+	return {
+		input: 100,
+		output: 50,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 150,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function user(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() };
+}
+
+function failedAssistant(stopReason: "error" | "aborted", toolCallId: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "text", text: "PARTIAL_BEFORE_FAILURE" },
+			{ type: "toolCall", id: toolCallId, name: "bash", arguments: { command: "ls" } },
+		],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: usage(),
+		stopReason,
+		timestamp: Date.now(),
+	};
+}
+
+function orphanResult(toolCallId: string): AgentMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "bash",
+		content: [{ type: "text", text: "Tool aborted" }],
+		isError: true,
+		timestamp: Date.now(),
+	};
+}
+
+describe("harness convertToLlm failed-turn drop", () => {
+	it("drops an errored assistant turn and its orphaned tool result", () => {
+		const out = convertToLlm([user("do X"), failedAssistant("error", "c1"), orphanResult("c1"), user("next")]);
+		const serialized = JSON.stringify(out);
+		expect(out).toHaveLength(2);
+		expect(out.every((m: Message) => m.role === "user")).toBe(true);
+		expect(serialized).not.toContain("PARTIAL_BEFORE_FAILURE");
+		expect(serialized).not.toContain("c1");
+	});
+
+	it("drops an aborted assistant turn and its orphaned tool result", () => {
+		const out = convertToLlm([user("do X"), failedAssistant("aborted", "c2"), orphanResult("c2")]);
+		const serialized = JSON.stringify(out);
+		expect(out).toHaveLength(1);
+		expect(serialized).not.toContain("PARTIAL_BEFORE_FAILURE");
+		expect(serialized).not.toContain("c2");
+	});
+
+	it("keeps a tool result whose id a later kept assistant re-declares", () => {
+		const kept: AssistantMessage = {
+			...failedAssistant("error", "c3"),
+			stopReason: "toolUse",
+			content: [{ type: "toolCall", id: "c3", name: "bash", arguments: { command: "ls" } }],
+		};
+		const out = convertToLlm([user("do X"), failedAssistant("error", "c3"), orphanResult("c3"), kept]);
+		const serialized = JSON.stringify(out);
+		expect(serialized).toContain("c3");
+		expect(serialized).toContain("Tool aborted");
+		expect(serialized).not.toContain("PARTIAL_BEFORE_FAILURE");
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Fixed the Cloudflare AI Gateway catalog to include supported `workers-ai/*` passthrough models omitted by models.dev.
 - Fixed OpenRouter reasoning controls by deriving `off` support and available effort levels from OpenRouter's model metadata, preventing reasoning-mandatory models from receiving `effort: "none"` ([#8614](https://github.com/earendil-works/pi/pull/8614) by [@davidbrai](https://github.com/davidbrai)).
 
+- New shared helper `dropFailedAssistantTurns` (exported from the package barrel) removes assistant turns with `stopReason` `error` or `aborted` from a converted LLM message list, together with every tool result whose `toolCallId` was declared only by those dropped assistants; a call id re-declared by a kept assistant keeps its result, mirroring the provider-layer `droppedCallIds` pairing in `transform-messages.ts`. Order and every other message are preserved. Consumed by both `convertToLlm` implementations (coding-agent core and agent harness) so every LLM request built from converted context excludes failed provider turns.
+
 ### Removed
 
 ## [2026.9.4] - 2026-09-04

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -17,6 +17,26 @@
 
 - LOW: `packages/ai/src/api/mistral-conversations.ts` tool-call block keying in `consumeChatStream` and `packages/ai/src/api/openai-responses.ts` in `getCompat` and `buildParams`.
 
+## 2026-09-04 - Failed assistant turns are dropped from converted LLM context
+
+### What changed
+
+- `packages/ai/src/utils/drop-failed-assistant-turns.ts` (new): `dropFailedAssistantTurns(messages)` removes every assistant message whose `stopReason` is `error` or `aborted`, plus every `toolResult` whose `toolCallId` was declared only by those dropped assistants; a call id re-declared by any kept assistant keeps its result, mirroring the `droppedCallIds` pairing in `api/transform-messages.ts`. Order and all other messages are preserved.
+- `packages/ai/src/index.ts`: the helper is exported from the package barrel.
+- `packages/ai/test/drop-failed-assistant-turns.test.ts` (new): pins the drop of error/aborted turns and their orphaned results, the re-declared-id keep, and the stop/length/toolUse pass-through.
+
+### Why
+
+- Two lanes build LLM requests straight from `convertToLlm` output with no `stopReason` filter (the claude-sdk-oauth prompt bridge and cursor turn building), so after a provider error or abort every subsequent request replayed the failed turn's partial text and unexecuted tool calls; token estimation counted them too. The provider transform layer already dropped them, but only for pi-ai API requests.
+
+### Why an extension could not handle it
+
+- The drop must happen inside `convertToLlm`, which both lanes consume before any extension seam runs; extensions observe the already-built context and cannot remove a failed assistant turn from every downstream request shape deterministically.
+
+### Expected merge conflict zones
+
+- LOW: `packages/ai/src/index.ts` (one barrel line beside the other utils exports).
+
 ## GPT-6 Astra joins the xhigh and max effort families (2026-09-04)
 
 ### What changed

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -110,6 +110,7 @@ export {
 	kCursorExecResolved,
 } from "./utils/block-symbols.ts";
 export * from "./utils/diagnostics.ts";
+export { dropFailedAssistantTurns } from "./utils/drop-failed-assistant-turns.ts";
 export { estimateContextTokens } from "./utils/estimate.ts";
 export * from "./utils/event-stream.ts";
 export * from "./utils/json-parse.ts";

--- a/packages/ai/src/utils/drop-failed-assistant-turns.ts
+++ b/packages/ai/src/utils/drop-failed-assistant-turns.ts
@@ -1,5 +1,3 @@
-import type { AssistantMessage, Message } from "../types.ts";
-
 /**
  * Drop assistant turns that terminated in failure (`stopReason` "error" or
  * "aborted") from a converted LLM message list, together with every tool
@@ -14,26 +12,45 @@ import type { AssistantMessage, Message } from "../types.ts";
  * and unexecuted tool calls on lanes that build requests straight from
  * `convertToLlm` output (claude-sdk-oauth prompt bridge, cursor turns, token
  * estimation).
+ *
+ * The input is typed structurally so both the AI package `Message[]` and the
+ * harness/coding-agent `AgentMessage[]` (a superset with extra custom roles)
+ * pass through the same drop.
  */
-export function dropFailedAssistantTurns(messages: readonly Message[]): Message[] {
+export function dropFailedAssistantTurns<T extends { role: string }>(messages: readonly T[]): T[] {
 	const callIdsByKeptAssistants = new Set<string>();
 	const callIdsByFailedAssistants = new Set<string>();
 	for (const message of messages) {
-		if (message.role !== "assistant") continue;
-		const declared = isFailedAssistant(message) ? callIdsByFailedAssistants : callIdsByKeptAssistants;
-		for (const block of message.content) {
-			if (block.type === "toolCall") declared.add(block.id);
+		const assistant = asAssistantTurn(message);
+		if (!assistant) continue;
+		const declared = isFailedStop(assistant.stopReason) ? callIdsByFailedAssistants : callIdsByKeptAssistants;
+		for (const block of assistant.content) {
+			if (block.type === "toolCall" && typeof block.id === "string") declared.add(block.id);
 		}
 	}
 	for (const id of callIdsByKeptAssistants) callIdsByFailedAssistants.delete(id);
 
 	return messages.filter((message) => {
-		if (message.role === "assistant") return !isFailedAssistant(message);
-		if (message.role === "toolResult") return !callIdsByFailedAssistants.has(message.toolCallId);
+		const assistant = asAssistantTurn(message);
+		if (assistant) return !isFailedStop(assistant.stopReason);
+		if (message.role === "toolResult" && "toolCallId" in message && typeof message.toolCallId === "string") {
+			return !callIdsByFailedAssistants.has(message.toolCallId);
+		}
 		return true;
 	});
 }
 
-function isFailedAssistant(message: AssistantMessage): boolean {
-	return message.stopReason === "error" || message.stopReason === "aborted";
+function asAssistantTurn(message: {
+	role: string;
+}): { stopReason: unknown; content: readonly { type: string; id?: unknown }[] } | undefined {
+	if (message.role !== "assistant") return undefined;
+	if (!("content" in message) || !Array.isArray(message.content)) return undefined;
+	return {
+		stopReason: "stopReason" in message ? message.stopReason : undefined,
+		content: message.content,
+	};
+}
+
+function isFailedStop(stopReason: unknown): boolean {
+	return stopReason === "error" || stopReason === "aborted";
 }

--- a/packages/ai/src/utils/drop-failed-assistant-turns.ts
+++ b/packages/ai/src/utils/drop-failed-assistant-turns.ts
@@ -1,0 +1,39 @@
+import type { AssistantMessage, Message } from "../types.ts";
+
+/**
+ * Drop assistant turns that terminated in failure (`stopReason` "error" or
+ * "aborted") from a converted LLM message list, together with every tool
+ * result whose `toolCallId` was declared ONLY by those dropped assistants.
+ * An id re-declared by any kept assistant keeps its results, mirroring the
+ * `droppedCallIds` pairing in `api/transform-messages.ts`. Order and every
+ * other message are preserved.
+ *
+ * A failed turn is the provider's response to the previous request, never part
+ * of one, so removing it keeps every earlier request a prefix of the next
+ * (provider prompt caches survive) while preventing the replay of partial text
+ * and unexecuted tool calls on lanes that build requests straight from
+ * `convertToLlm` output (claude-sdk-oauth prompt bridge, cursor turns, token
+ * estimation).
+ */
+export function dropFailedAssistantTurns(messages: readonly Message[]): Message[] {
+	const callIdsByKeptAssistants = new Set<string>();
+	const callIdsByFailedAssistants = new Set<string>();
+	for (const message of messages) {
+		if (message.role !== "assistant") continue;
+		const declared = isFailedAssistant(message) ? callIdsByFailedAssistants : callIdsByKeptAssistants;
+		for (const block of message.content) {
+			if (block.type === "toolCall") declared.add(block.id);
+		}
+	}
+	for (const id of callIdsByKeptAssistants) callIdsByFailedAssistants.delete(id);
+
+	return messages.filter((message) => {
+		if (message.role === "assistant") return !isFailedAssistant(message);
+		if (message.role === "toolResult") return !callIdsByFailedAssistants.has(message.toolCallId);
+		return true;
+	});
+}
+
+function isFailedAssistant(message: AssistantMessage): boolean {
+	return message.stopReason === "error" || message.stopReason === "aborted";
+}

--- a/packages/ai/test/drop-failed-assistant-turns.test.ts
+++ b/packages/ai/test/drop-failed-assistant-turns.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { AssistantMessage, Message, StopReason, ToolResultMessage } from "../src/types.ts";
+import { dropFailedAssistantTurns } from "../src/utils/drop-failed-assistant-turns.ts";
+
+function assistantMessage(
+	content: AssistantMessage["content"],
+	stopReason: StopReason,
+	timestamp: number,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "test-api",
+		provider: "test-provider",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp,
+	};
+}
+
+function toolResult(toolCallId: string, text: string, timestamp: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "search",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	};
+}
+
+function userMessage(text: string, timestamp: number): Message {
+	return { role: "user", content: text, timestamp };
+}
+
+describe("dropFailedAssistantTurns", () => {
+	it("drops error and aborted assistants and their orphaned tool results", () => {
+		// Given a history whose error and abort turns each declared one tool call
+		const messages: Message[] = [
+			userMessage("find the bug", 1),
+			assistantMessage(
+				[
+					{ type: "text", text: "PARTIAL" },
+					{ type: "toolCall", id: "call-error", name: "search", arguments: { q: 1 } },
+				],
+				"error",
+				2,
+			),
+			toolResult("call-error", "partial output", 3),
+			assistantMessage(
+				[
+					{ type: "text", text: "HALF-DONE" },
+					{ type: "toolCall", id: "call-aborted", name: "search", arguments: { q: 2 } },
+				],
+				"aborted",
+				4,
+			),
+			toolResult("call-aborted", "aborted output", 5),
+			userMessage("next", 6),
+		];
+
+		// When the failed turns are dropped
+		const result = dropFailedAssistantTurns(messages);
+
+		// Then only the two user messages survive, in order
+		expect(result).toEqual([userMessage("find the bug", 1), userMessage("next", 6)]);
+	});
+
+	it("keeps a tool result whose id is re-declared by a later kept assistant", () => {
+		// Given an errored turn and a kept turn re-using the same tool call id
+		const messages: Message[] = [
+			userMessage("retry", 1),
+			assistantMessage([{ type: "toolCall", id: "call-reused", name: "search", arguments: { q: 1 } }], "error", 2),
+			assistantMessage([{ type: "toolCall", id: "call-reused", name: "search", arguments: { q: 2 } }], "toolUse", 3),
+			toolResult("call-reused", "good output", 4),
+			userMessage("thanks", 5),
+		];
+
+		const result = dropFailedAssistantTurns(messages);
+
+		expect(result).toEqual([
+			userMessage("retry", 1),
+			assistantMessage([{ type: "toolCall", id: "call-reused", name: "search", arguments: { q: 2 } }], "toolUse", 3),
+			toolResult("call-reused", "good output", 4),
+			userMessage("thanks", 5),
+		]);
+	});
+
+	it("leaves stop, length, and toolUse turns and their results intact", () => {
+		const messages: Message[] = [
+			userMessage("go", 1),
+			assistantMessage([{ type: "text", text: "done" }], "stop", 2),
+			assistantMessage([{ type: "text", text: "cut off" }], "length", 3),
+			assistantMessage([{ type: "toolCall", id: "call-kept", name: "search", arguments: {} }], "toolUse", 4),
+			toolResult("call-kept", "kept output", 5),
+		];
+
+		const result = dropFailedAssistantTurns(messages);
+
+		expect(result).toEqual(messages);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -60,6 +60,8 @@
 - Fixed `prepareNextTurn` and `prepareNextTurnWithContext` being skipped on completed turns without tool calls: the next-turn preparation now runs after every completed assistant turn that can reach the preparation boundary, including a normal stop response, while the terminating queue boundary and ownership refresh are preserved before a continuation provider request.
 - Fixed next-turn compaction firing on completed turns that will not reach the provider: compaction is now gated on real provider admission (a tool continuation or queued message actually being admitted), while the next-turn callback keeps running on every completed turn and the late queue re-sample and one bounded callback replay after compaction are retained.
 
+- Errored and aborted provider turns are now excluded from every LLM request at the session level: `convertToLlm` runs the shared `dropFailedAssistantTurns` from `@earendil-works/pi-ai` as its final step, so lanes that build requests straight from its output (the claude-sdk-oauth prompt bridge's `<conversation_history>` rendering and cursor turn building) no longer replay a failed turn's partial text and unexecuted tool calls, and token estimation (`estimateContextTokens(buildSessionContext(...))`) no longer counts them. A tool call id re-declared by a later kept assistant keeps its result; `stop`/`length`/`toolUse` turns are untouched; the provider transform layer's existing drop in `transform-messages.ts` stays as-is.
+
 ### Removed
 
 ## [2026.9.4] - 2026-09-04

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -64,6 +64,28 @@
 - LOW: `packages/coding-agent/src/core/manual-continue.ts` (new file, no conflicts).
 - LOW: `packages/coding-agent/test/suite/regressions/pre-prompt-compaction-no-continue.test.ts` — the single assertion swap in the "dot retry" case.
 
+
+## 2026-09-04 - Failed provider turns leave the LLM context on every lane
+
+### What changed
+
+- `packages/coding-agent/src/core/messages.ts`: `convertToLlm` runs the shared `dropFailedAssistantTurns` from `@earendil-works/pi-ai` as its final step, removing assistant turns with `stopReason` `error`/`aborted` and the tool results orphaned by that drop from the returned `Message[]`. `convertToLlmForTransport` inherits the drop through `convertToLlm`.
+- `packages/coding-agent/test/convert-to-llm-drops-failed-turns.test.ts` (new): `convertToLlm` on `[user, assistant(error, "PARTIAL" + toolCall), toolResult, user]` yields no `PARTIAL` text and no orphaned tool call; same for an aborted turn.
+- `packages/coding-agent/test/claude-sdk-oauth-prompt-bridge.test.ts`: regression pinning that `buildPromptBlocks` over `convertToLlm`-processed history renders no failed-turn text and no orphaned tool call id.
+
+### Why
+
+- The claude-sdk-oauth prompt bridge (`buildPromptBlocks`) rendered every history assistant into `<conversation_history>` with no `stopReason` filter, so a failed provider turn's partial text and unexecuted tool calls were replayed to the SDK on every subsequent request; `estimateContextTokens(buildSessionContext(...))` counted the failed turns as live tokens. The provider transform layer already dropped them for pi-ai APIs only, leaving these two lanes and token estimation exposed.
+
+### Why an extension could not handle it
+
+- Both lanes consume `convertToLlm` output directly inside core request building (`prompt-bridge.ts`, cursor turn building, token estimation); no extension seam sits between the session message list and those builders.
+
+### Expected merge conflict zones
+
+- LOW: the tail of `convertToLlm` in `packages/coding-agent/src/core/messages.ts` (the new `dropFailedAssistantTurns` return).
+- LOW: `packages/coding-agent/test/claude-sdk-oauth-prompt-bridge.test.ts` (one new `it` before the stream test).
+
 ## 2026-09-04 - Restore the selected model, not its upstream wire id, on resume
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,5 +1,24 @@
 # changes.md — compaction
 
+## 2026-09-04 - Token estimation excludes failed provider turns
+
+### What changed
+
+- `packages/coding-agent/src/core/compaction/compaction.ts`: `estimateContextTokens` runs the shared `dropFailedAssistantTurns` from `@earendil-works/pi-ai` on its input before anchoring on the last assistant usage and summing trailing tokens. Assistant turns with `stopReason` `error`/`aborted`, and the tool results orphaned by that drop, no longer count toward the context estimate.
+- `packages/coding-agent/test/compaction.test.ts`: pins the exclusion for both failure kinds (the estimate with a failed trailing turn equals the estimate without it).
+
+### Why
+
+- `convertToLlm` now drops failed turns from every request, so an estimator that still counted them overstated context usage after any provider error or abort and could trigger compaction the next request did not need. The estimate must measure what is actually sent.
+
+### Why an extension could not handle it
+
+- The estimator is called by the core compaction admission path with raw session messages before any extension seam; an extension cannot rewrite the count the core uses to decide whether to compact.
+
+### Expected merge conflict zones
+
+- LOW: the head of `estimateContextTokens` in `packages/coding-agent/src/core/compaction/compaction.ts` (the `countedMessages` prelude) and the `@earendil-works/pi-ai` import line.
+
 ## Ideal-pipeline settings split out of the compaction module (2026-08-29)
 
 ### What changed

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -6,7 +6,13 @@
  */
 
 import type { AgentMessage, StreamFn, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { type RetryCallbacks, type RetryPolicy, retryAssistantCall, uuidv7 } from "@earendil-works/pi-ai";
+import {
+	dropFailedAssistantTurns,
+	type RetryCallbacks,
+	type RetryPolicy,
+	retryAssistantCall,
+	uuidv7,
+} from "@earendil-works/pi-ai";
 import type {
 	AssistantMessage,
 	Context,
@@ -281,11 +287,14 @@ function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; in
  * If there are messages after the last usage, estimate their tokens with estimateTokens.
  */
 export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEstimate {
-	const usageInfo = getLastAssistantUsageInfo(messages);
+	// Count the same set the next provider request will carry: convertToLlm drops
+	// failed (error/aborted) assistant turns and their orphaned tool results.
+	const countedMessages = dropFailedAssistantTurns(messages);
+	const usageInfo = getLastAssistantUsageInfo(countedMessages);
 
 	if (!usageInfo) {
 		let estimated = 0;
-		for (const message of messages) {
+		for (const message of countedMessages) {
 			estimated += estimateTokens(message);
 		}
 		return {
@@ -298,8 +307,8 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
 
 	const usageTokens = calculateContextTokens(usageInfo.usage);
 	let trailingTokens = 0;
-	for (let i = usageInfo.index + 1; i < messages.length; i++) {
-		trailingTokens += estimateTokens(messages[i]);
+	for (let i = usageInfo.index + 1; i < countedMessages.length; i++) {
+		trailingTokens += estimateTokens(countedMessages[i]);
 	}
 
 	return {

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -274,9 +274,14 @@ export interface ContextUsageEstimate {
 	lastUsageIndex: number | null;
 }
 
-function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; index: number } | undefined {
+function getLastAssistantUsageInfo(
+	messages: AgentMessage[],
+	counted: ReadonlySet<AgentMessage>,
+): { usage: Usage; index: number } | undefined {
 	for (let i = messages.length - 1; i >= 0; i--) {
-		const usage = getAssistantUsage(messages[i]);
+		const message = messages[i];
+		if (!counted.has(message)) continue;
+		const usage = getAssistantUsage(message);
 		if (usage) return { usage, index: i };
 	}
 	return undefined;
@@ -289,13 +294,15 @@ function getLastAssistantUsageInfo(messages: AgentMessage[]): { usage: Usage; in
 export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEstimate {
 	// Count the same set the next provider request will carry: convertToLlm drops
 	// failed (error/aborted) assistant turns and their orphaned tool results.
-	const countedMessages = dropFailedAssistantTurns(messages);
-	const usageInfo = getLastAssistantUsageInfo(countedMessages);
+	// Indices stay relative to the INPUT array because callers read
+	// `messages[lastUsageIndex]` on the array they passed in.
+	const counted = new Set<AgentMessage>(dropFailedAssistantTurns(messages));
+	const usageInfo = getLastAssistantUsageInfo(messages, counted);
 
 	if (!usageInfo) {
 		let estimated = 0;
-		for (const message of countedMessages) {
-			estimated += estimateTokens(message);
+		for (const message of messages) {
+			if (counted.has(message)) estimated += estimateTokens(message);
 		}
 		return {
 			tokens: estimated,
@@ -307,8 +314,8 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
 
 	const usageTokens = calculateContextTokens(usageInfo.usage);
 	let trailingTokens = 0;
-	for (let i = usageInfo.index + 1; i < countedMessages.length; i++) {
-		trailingTokens += estimateTokens(countedMessages[i]);
+	for (let i = usageInfo.index + 1; i < messages.length; i++) {
+		if (counted.has(messages[i])) trailingTokens += estimateTokens(messages[i]);
 	}
 
 	return {

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -6,7 +6,13 @@
  */
 
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import { copyContextProvenance, type ImageContent, type Message, type TextContent } from "@earendil-works/pi-ai";
+import {
+	copyContextProvenance,
+	dropFailedAssistantTurns,
+	type ImageContent,
+	type Message,
+	type TextContent,
+} from "@earendil-works/pi-ai";
 
 export const COMPACTION_SUMMARY_PREFIX = `The conversation history before this point was compacted into the following summary:
 
@@ -175,7 +181,7 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 		copyContextProvenance(source, target);
 	// Continuations are append-only here too: the transport array must extend the
 	// previous request verbatim to keep the provider's cache prefix valid.
-	return messages
+	const converted = messages
 		.map((m): Message | undefined => {
 			switch (m.role) {
 				case "bashExecution":
@@ -225,6 +231,12 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 			}
 		})
 		.filter((m) => m !== undefined);
+	// Failed provider turns (stopReason error/aborted) must never reach an LLM
+	// request: lanes that build requests straight from this output (claude-sdk
+	// prompt bridge, cursor turns) would otherwise replay their partial text and
+	// unexecuted tool calls, and token estimation would count them. Dropping is
+	// deterministic per session state, so the cache-prefix guarantee above holds.
+	return dropFailedAssistantTurns(converted);
 }
 
 // ============================================================================

--- a/packages/coding-agent/test/claude-sdk-oauth-prompt-bridge.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-prompt-bridge.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { buildPromptBlocks, buildPromptStream } from "../src/core/extensions/builtin/claude-sdk-oauth/prompt-bridge.ts";
+import { convertToLlm } from "../src/core/messages.ts";
 
 const anchor =
 	'The above is the conversation history so far, provided as context. Respond as the assistant to the user message below only. Never emit "USER:" or "ASSISTANT:" labels or continue the transcript.';
@@ -118,6 +119,45 @@ describe("Claude SDK OAuth prompt bridge", () => {
 			{ type: "text", text: "\n</conversation_history>" },
 			{ type: "text", text: anchor },
 		]);
+	});
+
+	it("renders no failed-turn content when the history comes from convertToLlm", () => {
+		// Given a provider turn that failed mid-stream (stopReason "error"),
+		// its orphaned tool result, and a healthy final user message
+		const failedTurn: AssistantMessage = {
+			...assistantMessage(
+				[
+					{ type: "text", text: "PARTIAL" },
+					{ type: "toolCall", id: "call-failed", name: "repoSearch", arguments: { query: "needle" } },
+				],
+				2,
+			),
+			stopReason: "error",
+		};
+		const context: Context = {
+			messages: convertToLlm([
+				{ role: "user", content: "Find it", timestamp: 1 },
+				failedTurn,
+				{
+					role: "toolResult",
+					toolCallId: "call-failed",
+					toolName: "repoSearch",
+					content: [{ type: "text", text: "partial match" }],
+					isError: false,
+					timestamp: 3,
+				},
+				{ role: "user", content: "Go on", timestamp: 4 },
+			]),
+		};
+
+		const rendered = buildPromptBlocks(context)
+			.map((block) => (block.type === "text" ? block.text : ""))
+			.join("\n");
+
+		expect(rendered).not.toContain("PARTIAL");
+		expect(rendered).not.toContain("call-failed");
+		expect(rendered).toContain("Find it");
+		expect(rendered).toContain("Go on");
 	});
 
 	it("streams the supplied blocks as one SDK user message", async () => {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -532,6 +532,44 @@ describe("estimateContextTokens", () => {
 		expect(estimate.trailingTokens).toBeGreaterThan(0);
 		expect(estimate.tokens).toBe(150 + estimate.trailingTokens);
 	});
+
+	it.each(["error", "aborted"] as const)("excludes trailing %s turns from the estimate", (stopReason) => {
+		const big = "x".repeat(40_000);
+		const failed: AssistantMessage = {
+			...createAssistantMessage(big),
+			stopReason,
+			content: [
+				{ type: "text", text: big },
+				{ type: "toolCall", id: "c-failed", name: "bash", arguments: { command: "ls" } },
+			],
+		};
+		const orphanResult: AgentMessage = {
+			role: "toolResult",
+			toolCallId: "c-failed",
+			toolName: "bash",
+			content: [{ type: "text", text: big }],
+			isError: true,
+			timestamp: Date.now(),
+		};
+		const withFailed: AgentMessage[] = [
+			createUserMessage("Hello"),
+			createAssistantMessage("Hi", createMockUsage(100, 50)),
+			failed,
+			orphanResult,
+			createUserMessage("next"),
+		];
+		const baseline: AgentMessage[] = [
+			createUserMessage("Hello"),
+			createAssistantMessage("Hi", createMockUsage(100, 50)),
+			createUserMessage("next"),
+		];
+
+		const withFailedEstimate = estimateContextTokens(withFailed);
+		const baselineEstimate = estimateContextTokens(baseline);
+
+		expect(withFailedEstimate.tokens).toBe(baselineEstimate.tokens);
+		expect(withFailedEstimate.trailingTokens).toBe(baselineEstimate.trailingTokens);
+	});
 });
 
 describe("estimateTokens base64 weighting", () => {

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -570,6 +570,24 @@ describe("estimateContextTokens", () => {
 		expect(withFailedEstimate.tokens).toBe(baselineEstimate.tokens);
 		expect(withFailedEstimate.trailingTokens).toBe(baselineEstimate.trailingTokens);
 	});
+
+	it("reports lastUsageIndex against the input array when a failed turn precedes the anchor", () => {
+		const failed: AssistantMessage = { ...createAssistantMessage("failed"), stopReason: "error" };
+		const anchor = createAssistantMessage("anchor", createMockUsage(200, 100));
+		const messages: AgentMessage[] = [
+			createUserMessage("Hello"),
+			createAssistantMessage("Hi", createMockUsage(100, 50)),
+			failed,
+			anchor,
+			createUserMessage("next"),
+		];
+
+		const estimate = estimateContextTokens(messages);
+
+		expect(estimate.lastUsageIndex).not.toBeNull();
+		expect(messages[estimate.lastUsageIndex as number]).toBe(anchor);
+		expect(estimate.usageTokens).toBe(300);
+	});
 });
 
 describe("estimateTokens base64 weighting", () => {

--- a/packages/coding-agent/test/convert-to-llm-drops-failed-turns.test.ts
+++ b/packages/coding-agent/test/convert-to-llm-drops-failed-turns.test.ts
@@ -1,0 +1,81 @@
+import type { AssistantMessage, ToolResultMessage } from "@earendil-works/pi-ai";
+import { describe, expect, it } from "vitest";
+import { convertToLlm } from "../src/core/messages.ts";
+
+function failedAssistant(
+	stopReason: "error" | "aborted",
+	text: string,
+	toolCallId: string,
+	timestamp: number,
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [
+			{ type: "text", text },
+			{ type: "toolCall", id: toolCallId, name: "search", arguments: { q: "needle" } },
+		],
+		api: "test-api",
+		provider: "test-provider",
+		model: "test-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp,
+	};
+}
+
+function toolResult(toolCallId: string, text: string, timestamp: number): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "search",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp,
+	};
+}
+
+function userMessage(text: string, timestamp: number): { role: "user"; content: string; timestamp: number } {
+	return { role: "user", content: text, timestamp };
+}
+
+describe("convertToLlm drops failed assistant turns", () => {
+	it("omits an errored assistant's partial text and orphaned tool call", () => {
+		// Given a session where one provider turn failed mid-stream
+		const messages = [
+			userMessage("first", 1),
+			failedAssistant("error", "PARTIAL", "call-1", 2),
+			toolResult("call-1", "partial result", 3),
+			userMessage("next", 4),
+		];
+
+		// When the history is converted for the LLM
+		const result = convertToLlm(messages);
+
+		// Then the failed turn and its orphaned tool result are gone
+		expect(result).toEqual([userMessage("first", 1), userMessage("next", 4)]);
+		expect(JSON.stringify(result)).not.toContain("PARTIAL");
+		expect(JSON.stringify(result)).not.toContain("call-1");
+	});
+
+	it("omits an aborted assistant's partial text and orphaned tool call", () => {
+		const messages = [
+			userMessage("first", 1),
+			failedAssistant("aborted", "STOPPED-MID", "call-2", 2),
+			toolResult("call-2", "aborted result", 3),
+			userMessage("next", 4),
+		];
+
+		const result = convertToLlm(messages);
+
+		expect(result).toEqual([userMessage("first", 1), userMessage("next", 4)]);
+		expect(JSON.stringify(result)).not.toContain("STOPPED-MID");
+		expect(JSON.stringify(result)).not.toContain("call-2");
+	});
+});


### PR DESCRIPTION
## Summary

Assistant turns that terminated in failure (`stopReason` `"error"` or `"aborted"`) were dropped only at the provider transform layer (`transform-messages.ts`) for pi-ai API requests. Two lanes bypassed that and replayed the failed turn's partial text and unexecuted tool calls on every subsequent request:

- **claude-sdk-oauth**: `buildPromptBlocks` rendered every history assistant into `<conversation_history>` with no `stopReason` filter.
- **cursor**: `buildConversationTurns` had no `stopReason` filter.
- Token estimation (`estimateContextTokens(buildSessionContext(...))`) also counted the failed turns.

This adds one shared pure helper applied at the session level, inside both `convertToLlm` implementations, so every LLM request built from converted context excludes failed provider turns. A tool call id re-declared by a later kept assistant keeps its result (mirroring the `droppedCallIds` pairing in `transform-messages.ts`); `stop`/`length`/`toolUse` turns are untouched; the provider-layer drop stays as-is (harmless double-drop). Because a failed turn is a *response* to a previous request and never part of one, dropping it is deterministic per session state and keeps earlier requests a prefix of later ones, so provider prompt caches survive.

## Changes by area

**packages/ai**
- `src/utils/drop-failed-assistant-turns.ts` (new): `dropFailedAssistantTurns(messages)` — removes error/aborted assistants and tool results orphaned by that drop; preserves order and everything else.
- `src/index.ts`: barrel export.
- `test/drop-failed-assistant-turns.test.ts` (new), `CHANGELOG.md`, `src/changes.md`.

**packages/coding-agent**
- `src/core/messages.ts`: `convertToLlm` runs `dropFailedAssistantTurns` as its final step (`convertToLlmForTransport` inherits it).
- `test/convert-to-llm-drops-failed-turns.test.ts` (new); `test/claude-sdk-oauth-prompt-bridge.test.ts` extended with the `<conversation_history>` regression pin; `CHANGELOG.md`, `src/core/changes.md`.

**packages/agent**
- `src/harness/messages.ts`: harness `convertToLlm` applies the same drop (compaction, branch summarization, and any consumer of the converted list).
- `CHANGELOG.md`.

Untouched by design: `transform-messages.ts` (provider drop stays), `agent-session.ts`, `interactive-mode.ts`.

## QA Evidence

TDD red → green, all via the remote vitest bridge (lane b = this branch, lane base = pristine `origin/main` 877c5929b):

**RED (before implementation)**
- `packages/ai` `test/drop-failed-assistant-turns.test.ts`:
  `Error: Cannot find module '../src/utils/drop-failed-assistant-turns.ts'` → `Test Files 1 failed (1)` (helper did not exist yet)
- `packages/coding-agent` `test/convert-to-llm-drops-failed-turns.test.ts`:
  `Test Files 1 failed (1) / Tests 2 failed (2)` — diff showed the errored/aborted assistant + orphaned toolResult present in output
- `packages/coding-agent` `test/claude-sdk-oauth-prompt-bridge.test.ts`:
  `1 failed | 6 passed` — rendered history contained `PARTIAL` and `TOOL RESULT (... id=call-failed)`

**GREEN (after implementation, post-rebase on 877c5929b)**
- `packages/ai` `test/drop-failed-assistant-turns.test.ts`:
  `Test Files 1 passed (1) / Tests 3 passed (3)`
- `packages/coding-agent` `test/convert-to-llm-drops-failed-turns.test.ts` + `test/claude-sdk-oauth-prompt-bridge.test.ts`:
  `Test Files 2 passed (2) / Tests 9 passed (9)`
- Existing suites re-run: `packages/agent` `test/harness`: `21 files, 385 passed | 1 skipped`; `packages/coding-agent` `test/compaction` + `image-elision` + `block-images`: `76 files, 561 passed`.

**Mutation check (new test vs pristine origin/main)**
- `--lane base --tests-only` replay of `test/convert-to-llm-drops-failed-turns.test.ts`:
  `Test Files 1 failed (1) / Tests 2 failed (2)` — the test fails where the fix is absent.

**Lint / types**
- `biome check --write` on all 7 changed files: clean.
- LSP diagnostics on changed files: clean (only pre-existing workspace-alias resolution noise also present on untouched files).
- The rebase's verify hook ran full-repo `biome check --error-on-warnings` + `tsc --noEmit` on each rewritten commit: passed.

## Risk

Low. The drop is a pure, deterministic filter over session state; a failed turn never appeared in any earlier request, so provider cache prefixes are unaffected. Kept-turn semantics (`stop`/`length`/`toolUse`) are pinned by tests, including the re-declared tool-call-id keep. Out-of-scope lanes (agent-session `prompt()`, interactive mode, `transform-messages.ts`) are unchanged. Compaction summaries consume the same filtered list, so future summaries no longer see failed turns either — intended, and covered by the re-run harness/compaction suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops assistant turns that ended in `error` or `aborted` from every LLM request built via `convertToLlm` and from token estimation. Previously only the pi-ai provider transform layer dropped them, so the claude-sdk-oauth prompt bridge, cursor turn building, and token estimation replayed the failed turn's partial text and unexecuted tool calls on every subsequent request.

**Bug Fixes**
- Adds a shared `dropFailedAssistantTurns` helper in `@earendil-works/pi-ai` and runs it as the final step in both `convertToLlm` implementations (coding-agent core and agent harness).
- Runs the same drop in `estimateContextTokens` in both compaction modules, so the estimate counts exactly the set the next request carries; `lastUsageIndex` still indexes the caller's original array.
- Removes tool results whose call id was declared only by dropped turns; a call id re-declared by a kept assistant keeps its result, and `stop`/`length`/`toolUse` turns are untouched.
- The provider-layer drop in `transform-messages.ts` stays as-is; the double-drop is harmless, and dropping is deterministic so provider prompt caches still work.

<sup>Written for commit 00092413a3d5a4fb347e2e4969493c3c8d5d02ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

