### PR TITLE
feat(codemode): diet the eval tool description (-400 tokens/turn, codex dialect)

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- The `eval` tool description is dieted from ~2002 to ~1588 tokens (codex dialect): the three reuse-chain JSON examples, the `<workflow>` graph prose, the repeated state-persistence rules, and the per-dialect wait-doctrine clause are removed or folded; every helper signature and dialect routing is kept. The workflow block's fused `handle=True{ handle: true }` is fixed into per-language correct forms.
+
 ### Fixed
 
 ### Removed

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,21 @@
 # senpi-codemode fork changes
 
+## 2026-09-04 - eval tool description diet
+
+### What changed
+
+- `src/prompt/eval-prompt.ts`: dropped `REUSE_CHAIN_EXAMPLES` (three embedded JSON call examples), collapsed the `<workflow>` block to one dense rule sentence, merged the three state-persistence restatements into one, tightened the timeout/on_timeout/hard-limit/detach prose, and removed the per-dialect "sleeping/timed retries are not waiting" clause from the monitor bullets (the terminal section owns that doctrine). Helper signatures and dialect selection are unchanged. Fixed the workflow block's fused `handle=True{ handle: true }` into per-language correct forms.
+- `test/prompt.test.ts`: removed the reuse-chain filter test (its subject is gone), added the handle-form regression test, regenerated snapshots.
+
+### Why
+
+- The description cost ~2.0k tokens on every eval-enabled turn; the cuts are content the model already does by default or that the terminal section states. codex dialect 2002 -> 1588, claude 2058 -> 1648, kimi 2073 -> 1668, default 2079 -> 1668 (o200k).
+
+### Expected merge conflict zones
+
+- LOW: `eval-prompt.ts` template and the prompt snapshots; regenerate snapshots rather than merging.
+
+
 ## eval foreground window caps the interactive detach budget (2026-09-04)
 
 ### What changed

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -64,69 +64,35 @@ export function evalEmphasisStyle(modelId: string | undefined): EvalEmphasisStyl
 
 type ContextValue = string | boolean;
 type Context = Readonly<Record<string, ContextValue>>;
-type EvalPromptExample = {
-	readonly caption: string;
-	readonly language: keyof EnabledLanguages;
-	readonly summary: string;
-	readonly code: string;
-};
-
-// senpi ToolDefinition has no examples field, so description embeds the examples.
-// ADAPTATION: payloads diverge from omp's json-config chain to teach batch read,
-// comprehension filtering, and parallel tool.<name> fan-out while keeping the
-// three-cell reuse narrative.
-const REUSE_CHAIN_EXAMPLES = [
-	{
-		caption: "First call — set up once",
-		language: "js",
-		summary: "Count all TypeScript source files under src/ excluding tests",
-		code: "import { readdir } from 'node:fs/promises'\nimport { extname } from 'node:path'\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\nprint(files.length)",
-	},
-	{
-		caption: "Second call — reuse `files`, fan out session tools in parallel",
-		language: "js",
-		summary: "Grep legacyClient per directory in one cell",
-		code: "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\ndisplay(hits.map(h => h.matches?.length ?? 0))",
-	},
-	{
-		caption: "JS kernel is busy with a detached cell — continue in py",
-		language: "py",
-		summary: "Aggregate legacyClient hits while JS is busy",
-		code: "from pathlib import Path\nprint(sum('legacyClient' in read(p) for p in Path('src').rglob('*.ts')))",
-	},
-] as const satisfies readonly EvalPromptExample[];
-
 const EVAL_PROMPT_TEMPLATE = `Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls{{#if spawns}}, and \`task\` subagents{{/if}} — define helpers, datasets, and clients in one call, then later calls reuse them directly.
-
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls{{#if spawns}} and \`task\` subagents{{/if}}: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
 
 {{#if styleClaude}}<eval_first_batching>
 \`eval\` is your default execution surface: if a step needs more than one tool call, write ONE cell that performs the whole step — never issue the calls one at a time.
 - Enumerate every lookup the step needs, then run all independent ones simultaneously with \`parallel(thunks)\` inside the cell; keep calls sequential only when one result feeds the next.
 - Write real code around the calls: loop or comprehend over file sets with \`read()\`/stdlib, branch per case, and wrap risky calls in try/except so one failure degrades only its item — recover or retry inside the cell, keep the batch alive.
 - Post-process \`tool.<name>()\` results programmatically — filter, join, aggregate — and return distilled facts, not raw dumps.
-{{#if monitor}}- Start long-running work (build, test run, deploy, or watch) through \`tool.monitor({ command, filter })\`, putting the decisive-line filter inside the same cell, then keep working until its event wakes the turn; sleeping, timed retries, and repeated status reads are not waiting.{{/if}}
+{{#if monitor}}- Start long-running work (build, test run, deploy, or watch) through \`tool.monitor({ command, filter })\`, putting the decisive-line filter inside the same cell, then keep working until its event wakes the turn.{{/if}}
 </eval_first_batching>{{/if}}{{#if styleGpt}}<gpt_eval_dialect>
 GPT eval: compose multi-tool work inside one cell with \`tool.<name>(args)\` and \`parallel(thunks)\`; do not split a planned step into serial tool calls.
 - Long pure-compute cells detach on timeout and notify on completion. Do not poll or re-run them; use \`eval({ action: "peek"|"stop", cell_id })\` only to inspect or stop a detached cell.
 - Filter, join, and aggregate tool results in the cell; return only decision-relevant facts.
-{{#if monitor}}- For long-running build, test run, deploy, or watch work, start \`tool.monitor({ command, filter })\` with the decisive-line filter in the same cell; keep working while its event wakes the turn; sleeping, timed retries, and repeated status reads are not waiting.{{/if}}
+{{#if monitor}}- For long-running build, test run, deploy, or watch work, start \`tool.monitor({ command, filter })\` with the decisive-line filter in the same cell; keep working until its event wakes the turn.{{/if}}
 </gpt_eval_dialect>{{/if}}{{#if styleCodex}}Route multi-call steps through eval: one cell per step, independent lookups dispatched together via \`parallel(thunks)\`; keep work sequential only when one result determines the next action.
 - Loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time; post-process \`tool.<name>()\` results programmatically — filter, join, aggregate.
 - Wrap failable calls in try/except inside the cell; a failed item degrades only itself. After two distinct failed strategies for the same fact, fall back to direct tool calls.
 - Reduce large results in-kernel to the facts the task needs before returning.
-{{#if monitor}}- Long-running build/test/deploy/watch work: start \`tool.monitor({ command, filter })\` with the decisive-line filter inside the same cell, then continue working; its event wakes the turn — sleeping, timed retries, and repeated status reads are not waiting.{{/if}}{{/if}}{{#if styleKimi}}**EVAL IS YOUR SUPERPOWER — MAKE IT YOUR DEFAULT WAY TO ACT.** Before any step, think: "how do I execute this WHOLE step in ONE parallelized cell?" — then write that ONE cell.
+{{#if monitor}}- Long-running build/test/deploy/watch work: start \`tool.monitor({ command, filter })\` with the decisive-line filter inside the same cell, then continue working until its event wakes the turn.{{/if}}{{/if}}{{#if styleKimi}}**EVAL IS YOUR SUPERPOWER — MAKE IT YOUR DEFAULT WAY TO ACT.** Before any step, think: "how do I execute this WHOLE step in ONE parallelized cell?" — then write that ONE cell.
 - **BATCH EVERYTHING AT ONCE:** enumerate EVERY independent lookup the step needs and dispatch them ALL simultaneously with \`parallel(thunks)\` in that cell; keep calls sequential only when one result feeds the next.
 - **WRITE REAL CODE, NOT CALL CHAINS:** loop or comprehend over file sets with \`read()\`/stdlib, post-process \`tool.<name>()\` results programmatically, and put try/except around each risky call so the rest of the batch completes.
 - **DISTILL IN-KERNEL:** filter, join, and aggregate \`tool.<name>()\` results in code, then return ONLY the distilled facts.
-{{#if monitor}}- **DO start long-running build, test run, deploy, or watch work with \`tool.monitor({ command, filter })\`, put the decisive-line filter INSIDE THE SAME CELL, and KEEP WORKING until its event wakes the turn; sleeping, timed retries, and repeated status reads are not waiting.**{{/if}}{{/if}}{{#if styleDefault}}**EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
+{{#if monitor}}- **DO start long-running build, test run, deploy, or watch work with \`tool.monitor({ command, filter })\`, put the decisive-line filter INSIDE THE SAME CELL, and KEEP WORKING until its event wakes the turn.**{{/if}}{{/if}}{{#if styleDefault}}**EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
 - **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
 - **DISTILL IN-KERNEL.** Filter, join, diff, and aggregate in code before returning; return facts, NOT dumps.
-{{#if monitor}}- **LONG-RUNNING build, test run, deploy, or watch work MUST start with \`tool.monitor({ command, filter })\`, with the decisive-line filter INSIDE THE SAME CELL; KEEP WORKING until its event wakes the turn — SLEEPING, TIMED RETRIES, AND REPEATED STATUS READS ARE NOT WAITING.**{{/if}}{{/if}}
+{{#if monitor}}- **LONG-RUNNING build, test run, deploy, or watch work MUST start with \`tool.monitor({ command, filter })\`, with the decisive-line filter INSIDE THE SAME CELL; KEEP WORKING until its event wakes the turn.**{{/if}}{{/if}}
 {{#if hostLine}}
 Host: {{hostLine}} — cells execute here. Size \`parallel(thunks)\` pools to its cores; \`tool.<name>()\` shell commands must fit this platform, even when the code you are writing targets another machine.
 {{/if}}
@@ -136,19 +102,18 @@ Fields:
 - \`language\` — {{#if py}}\`"py"\` IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}\`"js"\` persistent JavaScript VM{{/if}}{{#if rb}}{{#ifAny py js}}, {{/ifAny}}\`"rb"\` persistent Ruby kernel{{/if}}{{#if jl}}{{#ifAny py js rb}}, {{/ifAny}}\`"jl"\` persistent Julia kernel{{/if}}.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
+- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
 - \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
 
-A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
 
 {{#if py}}Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".{{/if}}
 {{#if js}}{{#if jsBun}}JS runs in-process on Bun {{jsVersion}}: top-level \`await\`/\`return\` work; \`Bun.*\` builtins available.{{#if bunSkillPath}} MUST READ the bun-1-4 skill at {{bunSkillPath}} before your first js cell — its builtins replace the npm packages you would otherwise install.{{/if}}{{else}}JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.{{/if}}{{/if}}
 {{#if rb}}Ruby: synchronous; helper options are keyword args{{#if spawns}} (e.g. \`output("id", limit: 2)\`){{/if}}; the last expression auto-displays unless it is \`nil\`, an assignment, or a definition (like IRB).{{/if}}
 {{#if jl}}Julia: synchronous; helper options are standard keyword args{{#if spawns}} (e.g. \`output("id", limit=2)\`){{/if}}; the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).{{/if}}
-On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
+On error, fix and re-run only the failing step; a normal error keeps state, while a timeout or stop message says whether the kernel restarted.
 </instruction>
 
 <prelude>
@@ -169,14 +134,11 @@ env(key?=None, value?=None) → str | None | dict
 {{/if}}tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
-    Use it before calling a tool you have not called before — a failed call also
-    returns the expected parameters, so fix the args and retry in the next cell
-    instead of abandoning eval.
+    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 {{#if spawns}}agent(prompt, agent?="{{spawnDefaultAgent}}", model?=None, label?=None, schema?=None, handle?=False) → str | dict
-    Run a subagent → final output. \`agent\` picks another discovered agent; omit it to use \`{{spawnDefaultAgent}}\`. \`schema\` as in completion(). Background via \`local://\` files named in the prompt. \`handle\` → workflow node dict { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` when \`schema\` set).
+    Run a subagent → final output. \`agent\` picks a discovered agent; omit it to use \`{{spawnDefaultAgent}}\`. \`schema\` as in completion(). \`handle\` → workflow node { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` with \`schema\`).
 {{#if js}}    JS: options are ONE trailing object — agent(prompt, { agent, schema, handle }).
 {{/if}}{{/if}}parallel(thunks) → list
     Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
@@ -190,18 +152,10 @@ phase(title) → None
 </prelude>
 {{#if spawns}}
 <workflow>
-Define the workflow spec IN CODE: partition the work into logically distinct steps, one node per step, then wire them as acyclic waves — never hand-author the graph as a single opaque call.
-- **Name nodes.** Capture each \`agent(…, {{#if py}}handle=True{{/if}}{{#if js}}{ handle: true }{{/if}}{{#if jl}}handle=true{{/if}})\` result; carries \`handle\` (\`agent://<id>\`) + \`output\`.
-- **Wire edges by reference.** Put an upstream node's \`handle\`/\`output\` in the dependent stage's prompt — large transcript never re-inlined. Bulk: \`write("local://<name>.md", …)\`, pass the URI.
-- **\`pipeline(items, *stages)\` = staged waves**, barrier between stages (every item clears stage N before any enters N+1). **\`parallel(thunks)\` = one wave** of independent nodes.
-- **Isolate failure.** A raising node re-raises the lowest-index error, aborts its wave; wrap risky nodes in try/except so a failure degrades only its dependent subtree, independent branches finish.
-- **Acyclic only.** A node never waits on its own descendant.
+Build multi-agent work as an acyclic graph in code: one \`agent(…)\` node per step with its handle option ({{#if py}}\`handle=True\`{{/if}}{{#ifAll py js}} / {{/ifAll}}{{#if js}}\`{ handle: true }\`{{/if}}{{#if jl}}\`handle=true\`{{/if}}), \`parallel(thunks)\` for one wave of independent nodes, \`pipeline(items, *stages)\` for staged waves with a barrier between stages. Wire dependents by passing the upstream node's \`handle\` or \`output\` (or a \`write("local://…")\` URI for bulk text) in their prompt instead of re-inlining transcripts; wrap risky nodes in try/except so a failure aborts only its dependent subtree; a node never waits on its own descendant.
 </workflow>
 {{/if}}
-
-<critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
-</critical>`;
+`;
 
 export function buildEvalPrompt(
 	enabled: EnabledLanguages,
@@ -230,20 +184,9 @@ export function buildEvalPrompt(
 		jsVersion: options.jsRuntime?.version ?? "",
 		bunSkillPath: options.bunSkillPath ?? "",
 	};
-	const examples = REUSE_CHAIN_EXAMPLES.filter((example) => enabled[example.language])
-		.map((example) => {
-			const call = { language: example.language, summary: example.summary, code: example.code };
-			return `### ${example.caption}\n\`\`\`json\n${JSON.stringify(call, null, 2)}\n\`\`\``;
-		})
-		.join("\n\n");
-	const description = [
-		renderTemplate(EVAL_PROMPT_TEMPLATE, context)
-			.replace(/\n{3,}/g, "\n\n")
-			.trim(),
-		examples === "" ? "" : `<examples>\n${examples}\n</examples>`,
-	]
-		.filter((part) => part !== "")
-		.join("\n\n");
+	const description = renderTemplate(EVAL_PROMPT_TEMPLATE, context)
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
 	return {
 		description,
 		promptSnippet: "Run one incremental code cell in a persistent language kernel.",

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -5,9 +5,7 @@ exports[`buildEvalPrompt > renders the all with spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls, and \`task\` subagents — define helpers, datasets, and clients in one call, then later calls reuse them directly.
-
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls and \`task\` subagents: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
 
 **EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
@@ -19,19 +17,18 @@ Fields:
 - \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM, \`"rb"\` persistent Ruby kernel, \`"jl"\` persistent Julia kernel.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
+- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
 
-A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 Ruby: synchronous; helper options are keyword args (e.g. \`output("id", limit: 2)\`); the last expression auto-displays unless it is \`nil\`, an assignment, or a definition (like IRB).
 Julia: synchronous; helper options are standard keyword args (e.g. \`output("id", limit=2)\`); the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).
-On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
+On error, fix and re-run only the failing step; a normal error keeps state, while a timeout or stop message says whether the kernel restarted.
 </instruction>
 
 <prelude>
@@ -52,14 +49,11 @@ output(*ids, format?="raw", offset?=None, limit?=None) → str | dict | list[dic
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
-    Use it before calling a tool you have not called before — a failed call also
-    returns the expected parameters, so fix the args and retry in the next cell
-    instead of abandoning eval.
+    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 agent(prompt, agent?="task", model?=None, label?=None, schema?=None, handle?=False) → str | dict
-    Run a subagent → final output. \`agent\` picks another discovered agent; omit it to use \`task\`. \`schema\` as in completion(). Background via \`local://\` files named in the prompt. \`handle\` → workflow node dict { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` when \`schema\` set).
+    Run a subagent → final output. \`agent\` picks a discovered agent; omit it to use \`task\`. \`schema\` as in completion(). \`handle\` → workflow node { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` with \`schema\`).
     JS: options are ONE trailing object — agent(prompt, { agent, schema, handle }).
 parallel(thunks) → list
     Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
@@ -73,46 +67,8 @@ phase(title) → None
 </prelude>
 
 <workflow>
-Define the workflow spec IN CODE: partition the work into logically distinct steps, one node per step, then wire them as acyclic waves — never hand-author the graph as a single opaque call.
-- **Name nodes.** Capture each \`agent(…, handle=True{ handle: true }handle=true)\` result; carries \`handle\` (\`agent://<id>\`) + \`output\`.
-- **Wire edges by reference.** Put an upstream node's \`handle\`/\`output\` in the dependent stage's prompt — large transcript never re-inlined. Bulk: \`write("local://<name>.md", …)\`, pass the URI.
-- **\`pipeline(items, *stages)\` = staged waves**, barrier between stages (every item clears stage N before any enters N+1). **\`parallel(thunks)\` = one wave** of independent nodes.
-- **Isolate failure.** A raising node re-raises the lowest-index error, aborts its wave; wrap risky nodes in try/except so a failure degrades only its dependent subtree, independent branches finish.
-- **Acyclic only.** A node never waits on its own descendant.
-</workflow>
-
-<critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
-</critical>
-
-<examples>
-### First call — set up once
-\`\`\`json
-{
-  "language": "js",
-  "summary": "Count all TypeScript source files under src/ excluding tests",
-  "code": "import { readdir } from 'node:fs/promises'\\nimport { extname } from 'node:path'\\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\\nprint(files.length)"
-}
-\`\`\`
-
-### Second call — reuse \`files\`, fan out session tools in parallel
-\`\`\`json
-{
-  "language": "js",
-  "summary": "Grep legacyClient per directory in one cell",
-  "code": "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\\ndisplay(hits.map(h => h.matches?.length ?? 0))"
-}
-\`\`\`
-
-### JS kernel is busy with a detached cell — continue in py
-\`\`\`json
-{
-  "language": "py",
-  "summary": "Aggregate legacyClient hits while JS is busy",
-  "code": "from pathlib import Path\\nprint(sum('legacyClient' in read(p) for p in Path('src').rglob('*.ts')))"
-}
-\`\`\`
-</examples>",
+Build multi-agent work as an acyclic graph in code: one \`agent(…)\` node per step with its handle option (\`handle=True\` / \`{ handle: true }\`\`handle=true\`), \`parallel(thunks)\` for one wave of independent nodes, \`pipeline(items, *stages)\` for staged waves with a barrier between stages. Wire dependents by passing the upstream node's \`handle\` or \`output\` (or a \`write("local://…")\` URI for bulk text) in their prompt instead of re-inlining transcripts; wrap risky nodes in try/except so a failure aborts only its dependent subtree; a node never waits on its own descendant.
+</workflow>",
   "promptGuidelines": [
     "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
     "Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
@@ -126,9 +82,7 @@ exports[`buildEvalPrompt > renders the js without spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls — define helpers, datasets, and clients in one call, then later calls reuse them directly.
-
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
 
 **EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
@@ -140,17 +94,16 @@ Fields:
 - \`language\` — \`"js"\` persistent JavaScript VM.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
+- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
 - \`reset\` (optional) — wipe this language's kernel first.
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
 
-A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
 
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
-On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
+On error, fix and re-run only the failing step; a normal error keeps state, while a timeout or stop message says whether the kernel restarted.
 </instruction>
 
 <prelude>
@@ -169,10 +122,7 @@ env(key?=None, value?=None) → str | None | dict
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
-    Use it before calling a tool you have not called before — a failed call also
-    returns the expected parameters, so fix the args and retry in the next cell
-    instead of abandoning eval.
+    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 parallel(thunks) → list
@@ -184,31 +134,7 @@ log(message) → None
 phase(title) → None
     Phase grouping subsequent status lines.
 \`\`\`
-</prelude>
-
-<critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
-</critical>
-
-<examples>
-### First call — set up once
-\`\`\`json
-{
-  "language": "js",
-  "summary": "Count all TypeScript source files under src/ excluding tests",
-  "code": "import { readdir } from 'node:fs/promises'\\nimport { extname } from 'node:path'\\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\\nprint(files.length)"
-}
-\`\`\`
-
-### Second call — reuse \`files\`, fan out session tools in parallel
-\`\`\`json
-{
-  "language": "js",
-  "summary": "Grep legacyClient per directory in one cell",
-  "code": "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\\ndisplay(hits.map(h => h.matches?.length ?? 0))"
-}
-\`\`\`
-</examples>",
+</prelude>",
   "promptGuidelines": [
     "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
     "Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
@@ -222,9 +148,7 @@ exports[`buildEvalPrompt > renders the js-py without spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** State persists per language across separate eval calls and tool calls — define helpers, datasets, and clients in one call, then later calls reuse them directly.
-
-Work incrementally: imports in one call, define in the next, test, then use — each its own eval call. Re-run setup ONLY after \`reset\`, a kernel crash, or a \`NameError\`/\`ReferenceError\` proving the state is gone.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
 
 **EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
@@ -236,18 +160,17 @@ Fields:
 - \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM.
 - \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
 - \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds the cell may block the turn before it detaches; also raises the wall-clock hard limit below. In interactive sessions the detach point is capped at a ~60s foreground window, so a large \`timeout\` frees the turn at the window while the cell keeps running to the hard limit — it does NOT hold the turn for its full duration. Raise it to let a long detached cell live longer, not to wait longer in the foreground.
-- \`on_timeout\` (optional) — \`"detach"\` keeps pure computation running in interactive sessions (the default), detaching at the foreground window; \`"error"\` interrupts for deadline-sensitive work at the full \`timeout\` (uncapped) and is the print/json default.
-- Every cell is killed at a wall-clock hard limit (default 1800s) that survives detach and is never paused by tool calls; a larger explicit \`timeout\` raises this kill deadline (not the foreground block), and a killed cell notifies you that it hit the limit.
+- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
+- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
 - \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: use \`eval({ action: "peek", cell_id })\` for buffered output/state or \`eval({ action: "stop", cell_id })\` to cancel it.
+- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
 
-A detached cell keeps its language kernel busy while it finishes; another language can continue. Do not re-run a detached cell: the same-language busy error names its cell id and output tail. Completion arrives as one notification with the final value/error and buffered output. Stopping a cell interrupts its kernel; the stop result states whether kernel state survived or the kernel was restarted and its variables lost.
+A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
 
 Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
-On error, fix and re-run only the failing step. State usually survives a normal error, but a timeout or stop may have restarted the kernel — its message says which. Before rebuilding state, check a sentinel (a variable you defined earlier); only re-establish what is actually gone, since blind re-runs duplicate side effects.
+On error, fix and re-run only the failing step; a normal error keeps state, while a timeout or stop message says whether the kernel restarted.
 </instruction>
 
 <prelude>
@@ -266,10 +189,7 @@ env(key?=None, value?=None) → str | None | dict
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool without calling it; omit \`name\` to list tool names.
-    Use it before calling a tool you have not called before — a failed call also
-    returns the expected parameters, so fix the args and retry in the next cell
-    instead of abandoning eval.
+    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
     Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
 parallel(thunks) → list
@@ -281,40 +201,7 @@ log(message) → None
 phase(title) → None
     Phase grouping subsequent status lines.
 \`\`\`
-</prelude>
-
-<critical>
-Prior top-level names (\`data\`, \`sessions\`, helpers, imports) survive into the next eval call — reuse them; NEVER re-import, re-require, or re-declare a helper. Re-read a file only if it may have changed since the last read.
-</critical>
-
-<examples>
-### First call — set up once
-\`\`\`json
-{
-  "language": "js",
-  "summary": "Count all TypeScript source files under src/ excluding tests",
-  "code": "import { readdir } from 'node:fs/promises'\\nimport { extname } from 'node:path'\\nconst files = (await readdir('src', { recursive: true })).filter(f => extname(f) === '.ts' && !f.includes('test'))\\nprint(files.length)"
-}
-\`\`\`
-
-### Second call — reuse \`files\`, fan out session tools in parallel
-\`\`\`json
-{
-  "language": "js",
-  "summary": "Grep legacyClient per directory in one cell",
-  "code": "const dirs = [...new Set(files.map(f => f.split('/')[0]))]\\nconst hits = await Promise.all(dirs.map(d => tool.grep({ pattern: 'legacyClient', path: d })))\\ndisplay(hits.map(h => h.matches?.length ?? 0))"
-}
-\`\`\`
-
-### JS kernel is busy with a detached cell — continue in py
-\`\`\`json
-{
-  "language": "py",
-  "summary": "Aggregate legacyClient hits while JS is busy",
-  "code": "from pathlib import Path\\nprint(sum('legacyClient' in read(p) for p in Path('src').rglob('*.ts')))"
-}
-\`\`\`
-</examples>",
+</prelude>",
   "promptGuidelines": [
     "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
     "Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -82,21 +82,6 @@ describe("buildEvalPrompt", () => {
 		expect(withSpawns).toContain("omit it to use `researcher`");
 	});
 
-	it("filters reuse-chain examples by enabled language", () => {
-		// Given: prompts exposing the Python example set and kernels without one.
-		const python = buildEvalPrompt({ py: true, js: false, rb: false, jl: false }, { spawns: false }).description;
-		const ruby = buildEvalPrompt({ py: false, js: false, rb: true, jl: false }, { spawns: false }).description;
-		const node = buildEvalPrompt({ py: false, js: true, rb: false, jl: false }, { spawns: false }).description;
-
-		// When: their embedded reuse-chain examples are rendered.
-		// Then: JS kernels carry the batched fan-out examples, Python kernels carry the kernel-hop example, and other languages have none.
-		expect(node).toContain("Count all TypeScript source files under src/ excluding tests");
-		expect(node).toContain("tool.grep");
-		expect(node).toContain("Promise.all");
-		expect(python).toContain("JS kernel is busy with a detached cell — continue in py");
-		expect(ruby).not.toContain("<examples>");
-	});
-
 	it("documents core helpers with Node wording and no excluded surface when no js runtime is given", () => {
 		const prompt = fullPrompt({ py: true, js: true, rb: true, jl: true });
 
@@ -190,6 +175,25 @@ describe("buildEvalPrompt", () => {
 					"event wakes the turn",
 				);
 			}
+		}
+	});
+
+	it("shows each enabled language its correctly-formed handle option, never a fused dialect", () => {
+		// Given: spawn-enabled prompts across kernel combinations.
+		const cases: Array<[{ py: boolean; js: boolean; rb: boolean; jl: boolean }, string[]]> = [
+			[{ py: false, js: true, rb: false, jl: false }, ["{ handle: true }"]],
+			[{ py: true, js: false, rb: false, jl: false }, ["handle=True"]],
+			[{ py: true, js: true, rb: false, jl: false }, ["handle=True", "{ handle: true }"]],
+		];
+
+		for (const [enabled, expectedForms] of cases) {
+			const prompt = buildEvalPrompt(enabled, { spawns: true }).description;
+
+			// Then: each enabled language's form is present and the two are never fused without a separator.
+			expect(prompt).not.toContain("handle=True{ handle: true }");
+			expect(prompt).not.toContain("True{");
+			for (const form of expectedForms) expect(prompt).toContain(form);
+			if (enabled.js) expect(prompt).not.toContain("`handle=True``{ handle: true }`");
 		}
 	});
 


### PR DESCRIPTION
## Summary

Diets the eval tool description from ~2002 to ~1588 o200k tokens (codex dialect; claude 2058→1648, kimi 2073→1668, default 2079→1668) with no helper or dialect lost:

- drop the three reuse-chain JSON examples — content the model already does; per the GPT-5.6 guide, examples that don't change behavior are dead weight
- collapse `<workflow>` to the load-bearing rules (node per step, parallel/pipeline, wire-by-handle, subtree failure isolation, acyclic)
- fold the three state-persistence restatements (head, "On error" tail, `<critical>`) into one
- tighten timeout / on_timeout / hard-limit / detach prose
- remove each dialect's monitor bullet's repeat of the waiting doctrine (the terminal section owns it)

Also fixes a latent defect: the workflow block rendered a fused `handle=True{ handle: true }` when both py and js were enabled; it now shows each language its correct form.

Helper signatures, dialect selection, and every helper name are all preserved (a probe asserts all 14 helper signatures still render).

## Tests

- `test/prompt.test.ts`: dropped the reuse-chain filter test (its subject is gone by design), added the per-language handle-form regression test, regenerated snapshots. 18/18 green on mengmotaMac.
- `eval-tool-prompt-runtime.test.ts` fails identically on unmodified main in a fresh worktree install (pi-telemetry entry resolution, unrelated to this change).

Tracker: senpi-codemode/changes.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the eval tool description from ~2.0k to ~1.6k tokens per eval-enabled turn (codex 2002→1588, claude 2058→1648, kimi 2073→1668, default 2079→1668) by removing content the model already does by default or that the terminal section states; no helper signature or dialect is lost. Also fixes the workflow block rendering a fused `handle=True{ handle: true }` when both py and js were enabled — each language now sees its correct form.

**Changes**
- Removed the three reuse-chain JSON examples and the `<critical>` state-persistence restatement.
- Collapsed `<workflow>` to its load-bearing rules: one node per step, `parallel`/`pipeline` waves, wire-by-handle, subtree failure isolation, acyclic.
- Tightened the timeout, `on_timeout`, hard-limit, and detach prose.
- Dropped the repeated "sleeping, timed retries, and repeated status reads are not waiting" clause from each dialect's monitor bullet.
- Updated tests: removed the reuse-chain filter test, added a per-language handle-form regression test, regenerated snapshots.

<sup>Written for commit 784c93b88e103e7c3c6a9b86c1dc7198664b2a41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

