### PR TITLE
feat(coding-agent): alias skill roots in the skills prompt (-1,137 tokens/turn)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Added
 
+- The skills prompt section aliases each shared skill root to an `r0`/`r1` prefix once and renders per-skill locations relative to it, so the long absolute root is no longer billed per skill (145 skills, -1,137 tokens/turn).
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,24 @@
 # changes
 
+## 2026-09-04 - Skills prompt aliases each root to a short rN prefix
+
+### What changed
+
+- `skills.ts` `formatSkillsForPrompt`: emits a `<skill_roots></skill_roots>` table (one line per distinct root, `r0`, `r1`, ...) and renders each `<location>` as `alias/<name>/SKILL.md` plus a one-line expansion rule. `test/suite/skills-root-alias.test.ts` covers the table, alias re-join resolvability, and the character saving; `test/skills.test.ts` re-pins the location shape.
+
+### Why
+
+- The long absolute root was billed once per skill (145 skills): 23,381 -> 22,244 o200k tokens (-1,137) on the real set with no content removed.
+
+### Why an extension could not handle this differently
+
+- `skills.ts` owns the single renderer for the skills section; there is no extension seam for its formatting.
+
+### Expected merge conflict zones
+
+- LOW: `skills.ts` renderer body and `skills.test.ts` location assertion.
+
+
 ## 2026-09-04 - Restore the selected model, not its upstream wire id, on resume
 
 ### What changed

--- a/packages/coding-agent/src/core/skills.ts
+++ b/packages/coding-agent/src/core/skills.ts
@@ -352,6 +352,10 @@ function loadSkillFromFile(
  * Skills with disableModelInvocation=true are excluded from the prompt
  * (they can only be invoked explicitly via /skill:name commands).
  */
+// Skill roots share long absolute prefixes across every skill under them; rendering
+// that prefix per skill bills it once per skill. The roots table pays it once per
+// distinct root and each location becomes a short alias/relative path. A one-line
+// rule tells the model to expand aliases by joining them back to the root.
 export function formatSkillsForPrompt(skills: Skill[]): string {
 	const visibleSkills = skills.filter((s) => !s.disableModelInvocation);
 
@@ -359,19 +363,37 @@ export function formatSkillsForPrompt(skills: Skill[]): string {
 		return "";
 	}
 
+	const rootByPath = new Map<string, string>();
+	for (const skill of visibleSkills) {
+		const dir = skill.filePath.split("/").slice(0, -2).join("/"); // parent of <name>/SKILL.md
+		if (!rootByPath.has(dir)) rootByPath.set(dir, `r${rootByPath.size}`);
+	}
+
 	const lines = [
 		"\n\nThe following skills provide specialized instructions for specific tasks.",
 		"Use the read tool to load a skill's file whenever its description even loosely matches the task - loading an irrelevant skill costs little; missing a relevant one degrades the work.",
 		"When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
 		"",
-		"<available_skills>",
+		"<skill_roots>",
 	];
+	for (const [dir, alias] of rootByPath) {
+		lines.push(`  <${alias}>${escapeXml(dir)}</${alias}>`);
+	}
+	lines.push(
+		"</skill_roots>",
+		"A location's `rN/` prefix expands to the matching root above.",
+		"",
+		"<available_skills>",
+	);
 
 	for (const skill of visibleSkills) {
+		const dir = skill.filePath.split("/").slice(0, -2).join("/");
+		const alias = rootByPath.get(dir);
+		const relative = skill.filePath.startsWith(`${dir}/`) ? skill.filePath.slice(dir.length + 1) : skill.filePath;
 		lines.push("  <skill>");
 		lines.push(`    <name>${escapeXml(skill.name)}</name>`);
 		lines.push(`    <description>${escapeXml(skill.description)}</description>`);
-		lines.push(`    <location>${escapeXml(skill.filePath)}</location>`);
+		lines.push(`    <location>${escapeXml(`${alias}/${relative}`)}</location>`);
 		lines.push("  </skill>");
 	}
 

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -244,7 +244,8 @@ describe("skills", () => {
 			expect(result).toContain("<skill>");
 			expect(result).toContain("<name>test-skill</name>");
 			expect(result).toContain("<description>A test skill.</description>");
-			expect(result).toContain("<location>/path/to/skill/SKILL.md</location>");
+			expect(result).toContain("<location>r0/skill/SKILL.md</location>");
+			expect(result).toContain("<r0>/path/to</r0>");
 		});
 
 		it("should escape XML special characters", () => {

--- a/packages/coding-agent/test/suite/skills-root-alias.test.ts
+++ b/packages/coding-agent/test/suite/skills-root-alias.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatSkillsForPrompt, type Skill } from "../../src/core/skills.ts";
+
+function skill(name: string, root: string): Skill {
+	return {
+		name,
+		description: `${name} description.`,
+		filePath: `${root}/${name}/SKILL.md`,
+		baseDir: `${root}/${name}`,
+	} as Skill;
+}
+
+describe("formatSkillsForPrompt root aliases", () => {
+	it("declares each skill root once and renders locations relative to it", () => {
+		const skills = [
+			skill("alpha", "/Users/u/.agents/skills"),
+			skill("beta", "/Users/u/.agents/skills"),
+			skill("gamma", "/opt/plugin/skills"),
+		];
+
+		const result = formatSkillsForPrompt(skills);
+
+		// each root appears once in a roots table
+		expect(result).toContain("<skill_roots>");
+		expect(result).toContain("<location>r0/alpha/SKILL.md</location>");
+		expect(result).toContain("<location>r0/beta/SKILL.md</location>");
+		expect(result).toContain("<location>r1/gamma/SKILL.md</location>");
+		// the absolute roots are stated exactly once each, in the table
+		expect(result.split("/Users/u/.agents/skills").length - 1).toBe(1);
+		expect(result.split("/opt/plugin/skills").length - 1).toBe(1);
+		// an expansion rule teaches the model to join alias + relative path
+		expect(result).toMatch(/expand|resolve|join/i);
+	});
+
+	it("keeps the absolute path resolvable for every skill", () => {
+		const skills = [skill("alpha", "/Users/u/.agents/skills"), skill("gamma", "/opt/plugin/skills")];
+
+		const result = formatSkillsForPrompt(skills);
+		const aliasForRoot: Record<string, string> = {};
+		for (const m of result.matchAll(/<(r\d+)>([^<]+)<\/\1>/g)) aliasForRoot[m[1]] = m[2];
+		const locations = [...result.matchAll(/<location>(r\d+)\/([^<]+)<\/location>/g)];
+		expect(locations).toHaveLength(2);
+		const resolved = locations.map(([, alias, rel]) => `${aliasForRoot[alias]}/${rel}`);
+		expect(resolved).toContain("/Users/u/.agents/skills/alpha/SKILL.md");
+		expect(resolved).toContain("/opt/plugin/skills/gamma/SKILL.md");
+	});
+
+	it("renders fewer location characters than absolute paths when roots are long", () => {
+		const longRoot = "/Users/yeongyu/.bun/install/global/node_modules/omo-ai/plugin/skills";
+		const skills = Array.from({ length: 24 }, (_, i) => skill(`s${i}`, longRoot));
+		const result = formatSkillsForPrompt(skills);
+		const locationChars = [...result.matchAll(/<location>([^<]+)<\/location>/g)].reduce((n, m) => n + m[1].length, 0);
+		const absoluteLocationChars = skills.reduce((n, s) => n + s.filePath.length, 0);
+		expect(locationChars).toBeLessThan(absoluteLocationChars / 4);
+	});
+});


### PR DESCRIPTION
## Summary

`formatSkillsForPrompt` billed every skill's full absolute path, so the shared root prefix (`/Users/.../.agents/skills`, `/Users/.../node_modules/omo-ai/plugin/skills`) repeated 145 times per turn. It now emits a `<skill_roots>` table (`r0`, `r1`) once and renders each location as `rN/<name>/SKILL.md`, with a one-line rule telling the model to expand the prefix. A test re-joins every alias to its root and asserts the absolute path is unchanged.

## Measured (o200k)

Real set (121 `~/.agents/skills` + 24 omo plugin): skills section **23,381 → 22,244 (−1,137, −4.9%)**.

## Tests

- New `test/suite/skills-root-alias.test.ts` (RED on main: 3 failures; GREEN after) — roots table, alias re-join resolvability, location-character saving.
- `test/skills.test.ts` re-pins the location shape. 30/30 green on mengmotaMac.

Tracker: src/core/changes.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders skill locations as short alias references instead of full absolute paths, cutting the skills prompt by ~1,137 tokens per turn with no content removed. The shared root prefix is now emitted once per distinct root in a `<skill_roots>` table and each location becomes `rN/<name>/SKILL.md`, with a one-line rule telling the model to join aliases back to their roots. Tests re-join each alias to its root to confirm the absolute path is unchanged.

<sup>Written for commit 84344685cc7825d5f1332503efe0b399138bcee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

