### PR TITLE
feat(loop): expose schedule_wakeup only while a dynamic loop is live

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Changed
 
+- `schedule_wakeup` is no longer a resident tool: it registers search-exposed with lazy activation disabled, and the `/loop` extension activates it only while a dynamic loop is live and retires it when that loop ends or suspends (-234 prompt tokens per turn in every session without a dynamic loop). Its description keeps the delay guidance and drops the monitor/`bash_output`/`kill_bash` waiting rule that the dynamic tick prompt already carries.
 - Changed selectors in `/thinking`, `/model`, `/scoped-models`, `/trust`, per-model thinking settings, and theme settings to keep active options marked while browsing. `/scoped-models` now uses consistent per-item toggles and strikes through unavailable models ([#8900](https://github.com/earendil-works/pi/pull/8900)).
 
 ### Fixed

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,46 @@
 # Builtin extensions changes
 
+## Loop-owned exposure for `schedule_wakeup` (2026-09-04)
+
+### What changed
+
+- `loop/tools.ts`: `registerLoopTools` registers `schedule_wakeup` with `exposure: "search"` and
+  `allowLazyActivation: false`, so the tool is absent from the default active list and from the
+  `tool_search` catalog. `SCHEDULE_WAKEUP_DESCRIPTION` keeps the clamp, idle-range, prompt-cache and
+  fallback-heartbeat guidance and drops the monitor/`bash_output`/`kill_bash`/`task` waiting rule;
+  `tick-prompt.ts`'s dynamic rule is that rule's single home.
+- `loop/index.ts`: `syncScheduleWakeupActivation()` derives the wanted state from scheduler state
+  (some `dynamic` entry whose phase is neither `ended` nor `suspended`) and calls `pi.setActiveTools`
+  only when the active list disagrees. It runs at the top of `refreshStatus()` (every command,
+  timer, tool, restore, and settle transition already ends there) and again in `dispatchTick`
+  before `sendUserMessage`, so the tool is active before the tick turn reads its tool list.
+- Tests: `loop-wakeup-tool.test.ts` pins the exposure contract and the trimmed description;
+  `loop-extension.test.ts` pins activation on dynamic start, one entry across the tick lifecycle,
+  retirement on stop, no activation for fixed loops, and re-activation on session restore;
+  `regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts` no longer lists the tool as
+  resident.
+
+### Why
+
+- The tool is meaningful only inside a dynamic loop (every other call is a typed error), yet it
+  shipped 234 o200k tokens of description on every turn of every session. Search exposure with
+  loop-owned activation removes that cost without changing the loop contract: the dynamic tick
+  prompt still names a callable tool.
+- Lazy activation is disabled because a `tool_search` hit outside a loop would only activate a
+  tool that errors; explicit `setActiveTools` from the loop extension is the one legitimate path.
+
+### Why an extension could not handle it
+
+- `loop` is a builtin registered for every session; the activation decision needs the loop
+  scheduler's own state transitions (create, tick, settle, stop, suspend, restore), which only
+  `loop/index.ts` observes. No public event exposes those transitions to a sibling extension.
+
+### Expected merge conflict zones
+
+- LOW: `loop/index.ts` around `refreshStatus`/`dispatchTick` and the `./tools.ts` import;
+  `loop/tools.ts` description + registration object. Upstream has no `/loop` extension, so the
+  zone is fork-only.
+
 ## OpenAI Codex OAuth account command (2026-09-03)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/AGENTS.md
@@ -73,7 +73,10 @@ user — a schedule that cannot be persisted must not keep running.
 
 ## MODEL SURFACE
 
-`schedule_wakeup` (`tools.ts`) is the only model-callable surface. Its TypeBox schema is a
+`schedule_wakeup` (`tools.ts`) is the only model-callable surface. It registers `exposure: "search"`
+with lazy activation disabled; `index.ts` activates it (`setActiveTools`) exactly while a dynamic loop
+is live and retires it when that loop ends or suspends, so no-loop sessions never pay for it.
+Its TypeBox schema is a
 flat object with no root union (several provider conversions rebuild schemas from top-level
 `properties`; a root `anyOf` would arrive empty — same reasoning as `terminal/tools/monitor.ts`).
 `delaySeconds` carries no schema bounds; the executor clamps out-of-range integers (60-3600s)

--- a/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/index.ts
@@ -38,7 +38,7 @@ import {
 import { formatLoopStatus, formatNoopFold, LoopStatusTicker } from "./status.ts";
 import { readLoopState, writeLoopState } from "./store.ts";
 import { buildTickMessage, type LoopFileSnapshot, type LoopMode, type TickDelivery } from "./tick-prompt.ts";
-import { registerLoopTools, type ScheduleWakeupTarget } from "./tools.ts";
+import { registerLoopTools, SCHEDULE_WAKEUP_TOOL, type ScheduleWakeupTarget } from "./tools.ts";
 import type {
 	CronEntry,
 	DeliveryId,
@@ -425,7 +425,26 @@ export function createLoopExtension(deps: LoopExtensionDeps = {}): ExtensionFact
 			ctx?.ui.notify(`/loop state could not be used and the affected loops were ended: ${message}`, "error");
 		}
 
+		/**
+		 * `schedule_wakeup` is search-exposed, so it is callable only while this extension keeps it
+		 * active: exactly when a dynamic loop is live (not ended, not suspended). Idempotent, so
+		 * every state transition can call it without churning the active tool list.
+		 */
+		function syncScheduleWakeupActivation(): void {
+			if (scheduler === undefined) return;
+			const wanted = Object.values(scheduler.getState().entries).some(
+				(entry) => entry.kind === "dynamic" && entry.phase !== "ended" && entry.phase !== "suspended",
+			);
+			const active = pi.getActiveTools();
+			const present = active.includes(SCHEDULE_WAKEUP_TOOL);
+			if (wanted === present) return;
+			pi.setActiveTools(
+				wanted ? [...active, SCHEDULE_WAKEUP_TOOL] : active.filter((name) => name !== SCHEDULE_WAKEUP_TOOL),
+			);
+		}
+
 		function refreshStatus(): void {
+			syncScheduleWakeupActivation();
 			if (scheduler === undefined) return;
 			const state = scheduler.getState();
 			// The ticker owns a repeating render timer, so it only runs while a loop is armed;
@@ -510,6 +529,9 @@ export function createLoopExtension(deps: LoopExtensionDeps = {}): ExtensionFact
 			attributedLoopId = entry.id;
 			attributedDeliveryId = tick.deliveryId;
 			attributionResolved = false;
+			// The tick prompt tells the model to call schedule_wakeup, so the tool must be active
+			// before the tick is queued, not after the turn has already read its tool list.
+			syncScheduleWakeupActivation();
 			pi.sendUserMessage(built.text, {
 				expandPromptTemplates: true,
 				...(busy ? { deliverAs: "followUp" as const } : {}),

--- a/packages/coding-agent/src/core/extensions/builtin/loop/tools.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/tools.ts
@@ -2,6 +2,11 @@
  * The `schedule_wakeup` model tool: the ONLY model-callable surface of the `/loop`
  * extension. It lets a dynamic (self-paced) loop pick its own next delay, or end itself.
  *
+ * Exposure: the tool is registered `exposure: "search"` with lazy activation disabled, so it is
+ * absent from the resident tool list (and from `tool_search`) until the loop extension activates it
+ * for a live dynamic loop and retires it when that loop ends. Outside a dynamic loop every call is
+ * an error, so a resident registration only cost prompt tokens.
+ *
  * Two deliberate shape decisions:
  * - The TypeBox schema is a FLAT object with no root union. Several provider payload
  *   conversions rebuild tool schemas from top-level `properties` only, so a root
@@ -28,7 +33,7 @@ export const MAX_WAKEUP_DELAY_SECONDS = 3600;
 
 export const SCHEDULE_WAKEUP_DESCRIPTION = `Schedule when to resume work in /loop dynamic mode. Always pass the \`prompt\` argument unless stopping. Call this as the last action before ending a dynamic loop iteration so the loop remains alive; call with \`stop: true\` to end the active dynamic loop immediately.
 
-\`delaySeconds\` is clamped to ${MIN_WAKEUP_DELAY_SECONDS}-${MAX_WAKEUP_DELAY_SECONDS} seconds. For idle polling, normally use 1200-1800 seconds. Avoid choosing 300 seconds merely to poll: short polling repeatedly loses prompt-cache value on many API paths. When work is gated on observable terminal state, use \`monitor\` instead of sleeping or polling; inspect it with \`bash_output\` and stop the watcher with \`kill_bash\`. For delegated work, use the available \`task\` output and control tools and let task completion notifications wake the session. When a monitor or task notification is the primary wake source, the scheduled delay is only a fallback heartbeat.
+\`delaySeconds\` is clamped to ${MIN_WAKEUP_DELAY_SECONDS}-${MAX_WAKEUP_DELAY_SECONDS} seconds; 1200-1800 is the normal idle range, and a short delay chosen merely to poll loses prompt-cache value on many API paths. When a monitor or task notification is the primary wake source, the scheduled delay is only a fallback heartbeat.
 
 For normal dynamic re-entry, set \`prompt\` to the complete original command, for example \`/loop check the deploy\`, preserving the user's text verbatim. Set \`noop: true\` only when this iteration found no actionable change; consecutive noop iterations are folded in the terminal view. Omit \`noop\` when stopping. Notify the user only when state changes in a way worth acting on, not once per tick.`;
 
@@ -266,6 +271,8 @@ export function registerLoopTools(pi: ExtensionAPI, deps: LoopToolRegistrationDe
 		label: "Schedule Wakeup",
 		description: SCHEDULE_WAKEUP_DESCRIPTION,
 		parameters: scheduleWakeupSchema,
+		exposure: "search",
+		allowLazyActivation: false,
 		// Sequential so two concurrent model tool calls cannot race scheduler state.
 		executionMode: "sequential",
 		async execute(_toolCallId, params): Promise<AgentToolResult<ScheduleWakeupDetails>> {

--- a/packages/coding-agent/test/suite/loop-extension.test.ts
+++ b/packages/coding-agent/test/suite/loop-extension.test.ts
@@ -93,6 +93,8 @@ interface Fixture {
 	readonly ctx: ExtensionContext;
 	readonly timers: FakeTimers;
 	readonly controller: LoopController;
+	readonly registeredTools: Array<{ name: string; exposure?: string; allowLazyActivation?: boolean }>;
+	activeTools(): string[];
 	readonly userMessages: SentUserMessage[];
 	readonly customMessages: SentCustomMessage[];
 	readonly entries: Array<{ customType: string; data: unknown }>;
@@ -152,9 +154,19 @@ async function fixture(
 		await writeFile(path, options.corruptStore, "utf8");
 	}
 
+	const registeredTools: Array<{ name: string; exposure?: string; allowLazyActivation?: boolean }> = [];
+	// Mirrors the session's active-tool list: search-exposed tools start inactive and only
+	// `setActiveTools` promotes them, exactly like `AgentSession.setActiveToolsByName`.
+	let activeTools: string[] = ["read", "bash"];
 	const pi = {
 		on: (event: string, handler: Handler) => handlers.set(event, [...(handlers.get(event) ?? []), handler]),
-		registerTool: () => {},
+		registerTool: (tool: { name: string; exposure?: string; allowLazyActivation?: boolean }) => {
+			registeredTools.push(tool);
+		},
+		getActiveTools: () => [...activeTools],
+		setActiveTools: (names: string[]) => {
+			activeTools = [...names];
+		},
 		registerEntryRenderer: () => {},
 		registerCommand: () => {},
 		appendEntry: (customType: string, data: unknown) => entries.push({ customType, data }),
@@ -253,6 +265,8 @@ async function fixture(
 		ctx,
 		timers,
 		controller,
+		registeredTools,
+		activeTools: () => [...activeTools],
 		userMessages,
 		customMessages,
 		entries,
@@ -609,6 +623,63 @@ describe("loop extension sentinel delivery", () => {
 		await withoutAnchor.controller.fireDue(created.loopId);
 		const unanchoredTick = withoutAnchor.userMessages[withoutAnchor.userMessages.length - 1];
 		expect(unanchoredTick.text).toContain("do the tasks");
+	});
+});
+
+describe("loop extension schedule_wakeup exposure", () => {
+	it("registers schedule_wakeup search-exposed and keeps it inactive while no loop runs", async () => {
+		const f = await fixture();
+		await f.emit("session_start");
+
+		const tool = f.registeredTools.find((entry) => entry.name === "schedule_wakeup");
+		expect(tool?.exposure).toBe("search");
+		expect(tool?.allowLazyActivation).toBe(false);
+		expect(f.activeTools()).not.toContain("schedule_wakeup");
+	});
+
+	it("activates schedule_wakeup for a live dynamic loop and retires it when the loop ends", async () => {
+		const f = await fixture();
+		await f.emit("session_start");
+		const created = await f.controller.startDynamic({ originalArgs: "watch the queue", prompt: "watch the queue" });
+		if (!created.ok) throw new Error(created.message);
+
+		expect(f.activeTools()).toContain("schedule_wakeup");
+		// Idempotent across the tick lifecycle: one entry, never a duplicate.
+		await settleTurn(f, created.loopId);
+		expect(f.activeTools().filter((name) => name === "schedule_wakeup")).toHaveLength(1);
+
+		await f.controller.stop(created.loopId, "done");
+		expect(f.activeTools()).not.toContain("schedule_wakeup");
+		expect(f.activeTools()).toEqual(["read", "bash"]);
+	});
+
+	it("never activates schedule_wakeup for a fixed loop", async () => {
+		const f = await fixture();
+		await f.emit("session_start");
+		const created = await f.controller.startFixed({
+			originalArgs: "5m ping",
+			prompt: "ping",
+			requestedInterval: { value: 5, unit: "m", raw: "5m" },
+		});
+		if (!created.ok) throw new Error(created.message);
+
+		expect(f.activeTools()).not.toContain("schedule_wakeup");
+	});
+
+	it("re-activates schedule_wakeup when a dynamic loop is restored on session start", async () => {
+		const first = await fixture();
+		await first.emit("session_start");
+		const created = await first.controller.startDynamic({ originalArgs: "watch the queue", prompt: "watch the queue" });
+		if (!created.ok) throw new Error(created.message);
+		await settleTurn(first, created.loopId);
+		await first.emit("session_shutdown", { reason: "quit" });
+		const suspended = await first.persisted();
+		if (suspended === undefined) throw new Error("expected a suspended snapshot");
+
+		const resumed = await fixture({ now: first.now() + MINUTE, initialState: suspended });
+		expect(resumed.activeTools()).not.toContain("schedule_wakeup");
+		await resumed.emit("session_start", { reason: "resume" });
+		expect(resumed.activeTools()).toContain("schedule_wakeup");
 	});
 });
 

--- a/packages/coding-agent/test/suite/loop-wakeup-tool.test.ts
+++ b/packages/coding-agent/test/suite/loop-wakeup-tool.test.ts
@@ -128,12 +128,17 @@ describe("schedule_wakeup tool", () => {
 			expect(json.required).toEqual(["reason"]);
 		});
 
-		it("describes senpi tooling and cache-aware delays, never Claude Code tool names", () => {
-			expect(tool.description).toContain("monitor");
-			expect(tool.description).toContain("bash_output");
-			expect(tool.description).toContain("kill_bash");
-			expect(tool.description).toContain("task");
+		it("registers search-exposed with lazy activation disabled so only a live dynamic loop activates it", () => {
+			expect(tool.exposure).toBe("search");
+			expect(tool.allowLazyActivation).toBe(false);
+		});
+
+		it("describes cache-aware delays and leaves the waiting doctrine to the dynamic tick prompt", () => {
 			expect(tool.description).toContain("1200-1800");
+			expect(tool.description).toContain("fallback heartbeat");
+			// The dynamic tick prompt is the single home of the monitor/bash_output/kill_bash rule.
+			expect(tool.description).not.toContain("bash_output");
+			expect(tool.description).not.toContain("kill_bash");
 			expect(tool.description).not.toContain("Monitor(");
 			expect(tool.description).not.toContain("TaskList");
 			expect(tool.description).not.toContain("TaskStop");

--- a/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
+++ b/packages/coding-agent/test/suite/regressions/3592-no-builtin-tools-keeps-extension-tools.test.ts
@@ -135,7 +135,7 @@ describe("regression #3592: no-builtin-tools keeps extension tools enabled", () 
 			"create_goal",
 			"update_goal",
 			"get_goal",
-			"schedule_wakeup",
+			// schedule_wakeup is search-exposed: the loop extension activates it only for a live dynamic loop.
 		]);
 		expect(session.systemPrompt).toContain("- todo:");
 		expect(session.systemPrompt).not.toContain("- read:");


### PR DESCRIPTION
## Summary

`schedule_wakeup` only means something inside a dynamic `/loop` (every other call is a typed error), yet it shipped **234 o200k tokens** of description on every turn of every session. It now registers `exposure: "search"` with lazy activation disabled, and the loop extension activates it from scheduler state (a dynamic entry that is neither `ended` nor `suspended`) at every transition and right before each tick dispatch, retiring it when the loop ends or suspends.

The description keeps the clamp / idle-range / prompt-cache / fallback-heartbeat guidance and drops the monitor / `bash_output` / `kill_bash` / `task` waiting rule that the dynamic tick prompt already carries, so that rule has one home.

Part of the prompt-token diet (senpi #1345 dedup, #1348 eval diet, #1349 skills alias; omo #7737 tasklist tools -> tool_search, #7738 task/memory diets).

## Measured (o200k)

| Surface | Before | After |
|---|---:|---:|
| `schedule_wakeup` on the resident list, no dynamic loop | 234 tokens / turn | 0 |
| `schedule_wakeup` description while a dynamic loop is live | 234 | ~150 (waiting rule moved to the tick prompt's single home) |

## Verification

- RED (on unmodified main): 5 new assertions failed for the right reason (exposure undefined; active list `['read','bash']` never gained the tool; description still carried `bash_output`).
- GREEN on mengmotaMac: loop-extension, loop-wakeup-tool, loop-command, loop-tick-prompt, loop-scheduler, regressions/3592, prompt-surface-stale-wait-idioms, prompt-single-home — 8 files / 118 tests pass; root `tsc --noEmit` reports nothing for the touched files.
- New tests: search exposure + lazy activation off; activation on dynamic start; exactly one entry across the tick lifecycle; retirement on stop; never active for fixed loops; re-activation on session restore.
- `regressions/3592` updated: the tool is no longer part of the resident extension-tool list under `noTools: "builtin"`.
- Changelog gate: PASS locally (`bun scripts/check-pr-changelog.mjs --base origin/main`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers `schedule_wakeup` search-exposed with lazy activation disabled, so its 234-token description no longer ships on every turn of every session. The `/loop` extension activates the tool only while a dynamic loop is live and retires it when the loop ends or suspends.

**Tool description**
- Keeps the clamp, idle-range, prompt-cache, and fallback-heartbeat guidance.
- Drops the monitor/`bash_output`/`kill_bash`/`task` waiting rule; the dynamic tick prompt is now its single home.

<sup>Written for commit 781f4082657594665fe0e9ea761c589909d1207b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

