### PR TITLE
feat(codemode): diet the eval tool description a second time

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- The `eval` tool description is dieted a second time: the `Fields:` list now defers to the parameter schema (its single home), the detach guidance is one paragraph, and helper lines keep every signature with fewer words. gpt/codex dialect 1,489 -> 1,087 o200k tokens (description + guidelines); claude 1,173, kimi 1,190, default 1,189. Also fixes the fused `jl` handle form in the all-languages render.
+
 - The `eval` tool description is dieted from ~2002 to ~1588 tokens (codex dialect): the three reuse-chain JSON examples, the `<workflow>` graph prose, the repeated state-persistence rules, and the per-dialect wait-doctrine clause are removed or folded; every helper signature and dialect routing is kept. The workflow block's fused `handle=True{ handle: true }` is fixed into per-language correct forms.
 
 ### Fixed

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,37 @@
 # senpi-codemode fork changes
 
+## 2026-09-04 - eval tool description diet, second pass
+
+### What changed
+
+- `src/prompt/eval-prompt.ts`: the `Fields:` block is gone; the description names the enabled
+  `language` values and defers every per-field rule (`summary`, `timeout`, `on_timeout`, `reset`,
+  `action`) to the parameter schema, which already carries each of them. The detach paragraph is one
+  sentence pair (what detaches, how to peek/stop). Helper doc lines drop restated words but keep every
+  signature; the `<workflow>` block keeps the graph rules in one sentence each. The `jl` handle form
+  now gets a separator when it follows `py`/`js` (`/ \`handle=true\``), fixing a fused
+  `}\`\`handle=true\`` render that the all-languages snapshot had pinned.
+- `test/prompt.test.ts` + snapshot: the field-semantics test now asserts the schema is the single home
+  (no `- \`timeout\``/`\`on_timeout\`` in the description) and that the guideline still states reset
+  scope; the handle-form test gains the four-language case and rejects the fused `jl` form.
+
+### Why
+
+- After the first diet the gpt/codex dialect still rendered 1,489 o200k tokens (description +
+  guidelines, py+js, spawns). The `Fields:` list restated the parameter schema word for word (198
+  tokens of schema text billed twice), and the detach/busy-kernel text said the same thing in three
+  places. Every deleted sentence has a surviving home; no helper signature or dialect block changed.
+
+### Why an extension could not handle it
+
+- The description is built inside this package's `buildEvalPrompt`; there is no hook that lets an
+  outer extension shorten a tool description it does not own.
+
+### Expected merge conflict zones
+
+- LOW: `EVAL_PROMPT_TEMPLATE` prose and the three snapshot files. Upstream pi has no codemode
+  package, so the zone is fork-only.
+
 ## 2026-09-04 - eval tool description diet
 
 ### What changed

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -67,7 +67,7 @@ type Context = Readonly<Record<string, ContextValue>>;
 const EVAL_PROMPT_TEMPLATE = `Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls{{#if spawns}} and \`task\` subagents{{/if}}: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls{{#if spawns}}, tool calls and \`task\` subagents{{else}} and tool calls{{/if}}: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 {{#if styleClaude}}<eval_first_batching>
 \`eval\` is your default execution surface: if a step needs more than one tool call, write ONE cell that performs the whole step — never issue the calls one at a time.
@@ -77,7 +77,7 @@ const EVAL_PROMPT_TEMPLATE = `Run one step of code in a persistent kernel.
 {{#if monitor}}- Start long-running work (build, test run, deploy, or watch) through \`tool.monitor({ command, filter })\`, putting the decisive-line filter inside the same cell, then keep working until its event wakes the turn.{{/if}}
 </eval_first_batching>{{/if}}{{#if styleGpt}}<gpt_eval_dialect>
 GPT eval: compose multi-tool work inside one cell with \`tool.<name>(args)\` and \`parallel(thunks)\`; do not split a planned step into serial tool calls.
-- Long pure-compute cells detach on timeout and notify on completion. Do not poll or re-run them; use \`eval({ action: "peek"|"stop", cell_id })\` only to inspect or stop a detached cell.
+- Long cells detach on timeout and notify on completion; do not poll or re-run them.
 - Filter, join, and aggregate tool results in the cell; return only decision-relevant facts.
 {{#if monitor}}- For long-running build, test run, deploy, or watch work, start \`tool.monitor({ command, filter })\` with the decisive-line filter in the same cell; keep working until its event wakes the turn.{{/if}}
 </gpt_eval_dialect>{{/if}}{{#if styleCodex}}Route multi-call steps through eval: one cell per step, independent lookups dispatched together via \`parallel(thunks)\`; keep work sequential only when one result determines the next action.
@@ -97,19 +97,11 @@ GPT eval: compose multi-tool work inside one cell with \`tool.<name>(args)\` and
 Host: {{hostLine}} — cells execute here. Size \`parallel(thunks)\` pools to its cores; \`tool.<name>()\` shell commands must fit this platform, even when the code you are writing targets another machine.
 {{/if}}
 
-Fields:
+\`language\`: {{#if py}}\`"py"\` IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}\`"js"\` persistent JavaScript VM{{/if}}{{#if rb}}{{#ifAny py js}}, {{/ifAny}}\`"rb"\` persistent Ruby kernel{{/if}}{{#if jl}}{{#ifAny py js rb}}, {{/ifAny}}\`"jl"\` persistent Julia kernel{{/if}}.
 
-- \`language\` — {{#if py}}\`"py"\` IPython kernel{{/if}}{{#ifAll py js}}, {{/ifAll}}{{#if js}}\`"js"\` persistent JavaScript VM{{/if}}{{#if rb}}{{#ifAny py js}}, {{/ifAny}}\`"rb"\` persistent Ruby kernel{{/if}}{{#if jl}}{{#ifAny py js rb}}, {{/ifAny}}\`"jl"\` persistent Julia kernel{{/if}}.
-- \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
-- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
-- \`reset\` (optional) — wipe this language's kernel first.{{#ifAll py js}} Per-language: a \`py\` reset never touches the JS VM.{{/ifAll}}
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
+A cell that outlives the foreground window detaches: it keeps its language kernel busy (another language can continue) and completes as one notification with its value or error and buffered output. Do not re-run a detached cell; read or cancel it with \`eval({ action: "peek", cell_id })\` / \`eval({ action: "stop", cell_id })\`.
 
-A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
-
-{{#if py}}Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".{{/if}}
+{{#if py}}Python runs on a live event loop: use top-level \`await\`; \`asyncio.run(…)\` raises.{{/if}}
 {{#if js}}{{#if jsBun}}JS runs in-process on Bun {{jsVersion}}: top-level \`await\`/\`return\` work; \`Bun.*\` builtins available.{{#if bunSkillPath}} MUST READ the bun-1-4 skill at {{bunSkillPath}} before your first js cell — its builtins replace the npm packages you would otherwise install.{{/if}}{{else}}JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.{{/if}}{{/if}}
 {{#if rb}}Ruby: synchronous; helper options are keyword args{{#if spawns}} (e.g. \`output("id", limit: 2)\`){{/if}}; the last expression auto-displays unless it is \`nil\`, an assignment, or a definition (like IRB).{{/if}}
 {{#if jl}}Julia: synchronous; helper options are standard keyword args{{#if spawns}} (e.g. \`output("id", limit=2)\`){{/if}}; the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).{{/if}}
@@ -128,22 +120,21 @@ read(path, offset?=1, limit?=None) → str
 write(path, content) → str
     Write file (creates parents) → resolved path. \`local://…\` persists across turns/subagents.
 env(key?=None, value?=None) → str | None | dict
-    No args → full env dict; one → value of \`key\`; two → set \`key=value\`, return value.
+    No args → full env dict; one → value; two → set \`key=value\`.
 {{#if spawns}}output(*ids, format?="raw", offset?=None, limit?=None) → str | dict | list[dict]
-    Task/agent output by id. Reads immediately: running tasks return their status; \`format\` selects full (\`"raw"\`) or trailing (\`"tail"\`) output.
+    Task/agent output by id. Reads immediately: running tasks return their status; \`format\` \`"raw"\` = full, \`"tail"\` = trailing.
 {{/if}}tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
+    Parameter schema of a tool (omit \`name\` to list tool names); a failed \`tool.<name>()\` call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
-    Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
+    Oneshot, stateless. \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → parsed structured output.
 {{#if spawns}}agent(prompt, agent?="{{spawnDefaultAgent}}", model?=None, label?=None, schema?=None, handle?=False) → str | dict
-    Run a subagent → final output. \`agent\` picks a discovered agent; omit it to use \`{{spawnDefaultAgent}}\`. \`schema\` as in completion(). \`handle\` → workflow node { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` with \`schema\`).
-{{#if js}}    JS: options are ONE trailing object — agent(prompt, { agent, schema, handle }).
-{{/if}}{{/if}}parallel(thunks) → list
-    Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
+    Run a subagent → final output. \`agent\` picks a discovered agent. \`schema\` as in completion(). \`handle\` → workflow node { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` with \`schema\`).
+{{/if}}parallel(thunks) → list
+    Thunks through a bounded pool (as wide as a \`task\` batch), input order kept; a throwing thunk propagates.
 pipeline(items, ...stages) → list
-    Map items through one-arg stages left-to-right, barrier between stages; stage 1 gets the item, later stages the previous result.
+    Map items through one-arg stages with a barrier between stages; each stage receives the previous stage's result.
 log(message) → None
     Progress line above the status tree.
 phase(title) → None
@@ -152,7 +143,7 @@ phase(title) → None
 </prelude>
 {{#if spawns}}
 <workflow>
-Build multi-agent work as an acyclic graph in code: one \`agent(…)\` node per step with its handle option ({{#if py}}\`handle=True\`{{/if}}{{#ifAll py js}} / {{/ifAll}}{{#if js}}\`{ handle: true }\`{{/if}}{{#if jl}}\`handle=true\`{{/if}}), \`parallel(thunks)\` for one wave of independent nodes, \`pipeline(items, *stages)\` for staged waves with a barrier between stages. Wire dependents by passing the upstream node's \`handle\` or \`output\` (or a \`write("local://…")\` URI for bulk text) in their prompt instead of re-inlining transcripts; wrap risky nodes in try/except so a failure aborts only its dependent subtree; a node never waits on its own descendant.
+Multi-agent work is an acyclic graph in code: one \`agent(…)\` node per step with its handle option ({{#if py}}\`handle=True\`{{/if}}{{#ifAll py js}} / {{/ifAll}}{{#if js}}\`{ handle: true }\`{{/if}}{{#if jl}}{{#ifAny py js}} / {{/ifAny}}\`handle=true\`{{/if}}), \`parallel(thunks)\` for independent nodes, \`pipeline(items, *stages)\` for staged waves. Pass an upstream node's \`handle\` or \`output\` (or a \`write("local://…")\` URI for bulk text) into dependents instead of re-inlining transcripts, and wrap risky nodes in try/except so a failure aborts only its subtree.
 </workflow>
 {{/if}}
 `;

--- a/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
+++ b/packages/senpi-codemode/test/__snapshots__/prompt.test.ts.snap
@@ -5,26 +5,18 @@ exports[`buildEvalPrompt > renders the all with spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls and \`task\` subagents: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls, tool calls and \`task\` subagents: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 **EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
 - **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
 - **DISTILL IN-KERNEL.** Filter, join, diff, and aggregate in code before returning; return facts, NOT dumps.
 
-Fields:
+\`language\`: \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM, \`"rb"\` persistent Ruby kernel, \`"jl"\` persistent Julia kernel.
 
-- \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM, \`"rb"\` persistent Ruby kernel, \`"jl"\` persistent Julia kernel.
-- \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
-- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
-- \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
+A cell that outlives the foreground window detaches: it keeps its language kernel busy (another language can continue) and completes as one notification with its value or error and buffered output. Do not re-run a detached cell; read or cancel it with \`eval({ action: "peek", cell_id })\` / \`eval({ action: "stop", cell_id })\`.
 
-A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
-
-Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
+Python runs on a live event loop: use top-level \`await\`; \`asyncio.run(…)\` raises.
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 Ruby: synchronous; helper options are keyword args (e.g. \`output("id", limit: 2)\`); the last expression auto-displays unless it is \`nil\`, an assignment, or a definition (like IRB).
 Julia: synchronous; helper options are standard keyword args (e.g. \`output("id", limit=2)\`); the last expression auto-displays unless it is an assignment or a definition (like the Julia REPL).
@@ -43,22 +35,21 @@ read(path, offset?=1, limit?=None) → str
 write(path, content) → str
     Write file (creates parents) → resolved path. \`local://…\` persists across turns/subagents.
 env(key?=None, value?=None) → str | None | dict
-    No args → full env dict; one → value of \`key\`; two → set \`key=value\`, return value.
+    No args → full env dict; one → value; two → set \`key=value\`.
 output(*ids, format?="raw", offset?=None, limit?=None) → str | dict | list[dict]
-    Task/agent output by id. Reads immediately: running tasks return their status; \`format\` selects full (\`"raw"\`) or trailing (\`"tail"\`) output.
+    Task/agent output by id. Reads immediately: running tasks return their status; \`format\` \`"raw"\` = full, \`"tail"\` = trailing.
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
+    Parameter schema of a tool (omit \`name\` to list tool names); a failed \`tool.<name>()\` call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
-    Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
+    Oneshot, stateless. \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → parsed structured output.
 agent(prompt, agent?="task", model?=None, label?=None, schema?=None, handle?=False) → str | dict
-    Run a subagent → final output. \`agent\` picks a discovered agent; omit it to use \`task\`. \`schema\` as in completion(). \`handle\` → workflow node { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` with \`schema\`).
-    JS: options are ONE trailing object — agent(prompt, { agent, schema, handle }).
+    Run a subagent → final output. \`agent\` picks a discovered agent. \`schema\` as in completion(). \`handle\` → workflow node { text, output, handle: \`agent://<id>\`, id, agent } (parsed under \`data\` with \`schema\`).
 parallel(thunks) → list
-    Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
+    Thunks through a bounded pool (as wide as a \`task\` batch), input order kept; a throwing thunk propagates.
 pipeline(items, ...stages) → list
-    Map items through one-arg stages left-to-right, barrier between stages; stage 1 gets the item, later stages the previous result.
+    Map items through one-arg stages with a barrier between stages; each stage receives the previous stage's result.
 log(message) → None
     Progress line above the status tree.
 phase(title) → None
@@ -67,7 +58,7 @@ phase(title) → None
 </prelude>
 
 <workflow>
-Build multi-agent work as an acyclic graph in code: one \`agent(…)\` node per step with its handle option (\`handle=True\` / \`{ handle: true }\`\`handle=true\`), \`parallel(thunks)\` for one wave of independent nodes, \`pipeline(items, *stages)\` for staged waves with a barrier between stages. Wire dependents by passing the upstream node's \`handle\` or \`output\` (or a \`write("local://…")\` URI for bulk text) in their prompt instead of re-inlining transcripts; wrap risky nodes in try/except so a failure aborts only its dependent subtree; a node never waits on its own descendant.
+Multi-agent work is an acyclic graph in code: one \`agent(…)\` node per step with its handle option (\`handle=True\` / \`{ handle: true }\` / \`handle=true\`), \`parallel(thunks)\` for independent nodes, \`pipeline(items, *stages)\` for staged waves. Pass an upstream node's \`handle\` or \`output\` (or a \`write("local://…")\` URI for bulk text) into dependents instead of re-inlining transcripts, and wrap risky nodes in try/except so a failure aborts only its subtree.
 </workflow>",
   "promptGuidelines": [
     "**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",
@@ -82,24 +73,16 @@ exports[`buildEvalPrompt > renders the js without spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 **EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
 - **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
 - **DISTILL IN-KERNEL.** Filter, join, diff, and aggregate in code before returning; return facts, NOT dumps.
 
-Fields:
+\`language\`: \`"js"\` persistent JavaScript VM.
 
-- \`language\` — \`"js"\` persistent JavaScript VM.
-- \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
-- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
-- \`reset\` (optional) — wipe this language's kernel first.
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
-
-A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
+A cell that outlives the foreground window detaches: it keeps its language kernel busy (another language can continue) and completes as one notification with its value or error and buffered output. Do not re-run a detached cell; read or cancel it with \`eval({ action: "peek", cell_id })\` / \`eval({ action: "stop", cell_id })\`.
 
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
@@ -118,17 +101,17 @@ read(path, offset?=1, limit?=None) → str
 write(path, content) → str
     Write file (creates parents) → resolved path. \`local://…\` persists across turns/subagents.
 env(key?=None, value?=None) → str | None | dict
-    No args → full env dict; one → value of \`key\`; two → set \`key=value\`, return value.
+    No args → full env dict; one → value; two → set \`key=value\`.
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
+    Parameter schema of a tool (omit \`name\` to list tool names); a failed \`tool.<name>()\` call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
-    Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
+    Oneshot, stateless. \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → parsed structured output.
 parallel(thunks) → list
-    Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
+    Thunks through a bounded pool (as wide as a \`task\` batch), input order kept; a throwing thunk propagates.
 pipeline(items, ...stages) → list
-    Map items through one-arg stages left-to-right, barrier between stages; stage 1 gets the item, later stages the previous result.
+    Map items through one-arg stages with a barrier between stages; each stage receives the previous stage's result.
 log(message) → None
     Progress line above the status tree.
 phase(title) → None
@@ -148,26 +131,18 @@ exports[`buildEvalPrompt > renders the js-py without spawns prompt 1`] = `
   "description": "Run one step of code in a persistent kernel.
 
 <instruction>
-**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers, datasets, and clients once and reuse them; never re-import, re-declare, or re-read what an earlier cell already holds. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\` proving it is gone, and check a sentinel variable first so a blind re-run cannot duplicate side effects.
+**One eval call = one cell = one logical step.** Top-level names persist per language across eval calls and tool calls: define helpers and clients once and reuse them instead of re-importing or re-reading. Rebuild state only after \`reset\`, a kernel restart, or a \`NameError\`/\`ReferenceError\`, and check a sentinel variable first so a re-run cannot duplicate side effects.
 
 **EVAL IS YOUR PRIMARY EXECUTION SURFACE.** Any step that needs MORE THAN ONE tool call MUST be written as ONE cell — NEVER as a chain of single tool calls.
 - **PLAN THE WHOLE STEP, THEN BATCH IT.** Enumerate every read/search/lookup the step needs and dispatch ALL independent ones through \`parallel(thunks)\` in one cell.
 - **WRITE REAL CODE, NOT CALL LISTS.** Loop or comprehend over file sets with \`read()\`/stdlib, branch \`if\`/\`else\` per case, post-process \`tool.<name>()\` results programmatically, and wrap EVERY risky call in try/except so ONE failure NEVER kills the batch.
 - **DISTILL IN-KERNEL.** Filter, join, diff, and aggregate in code before returning; return facts, NOT dumps.
 
-Fields:
+\`language\`: \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM.
 
-- \`language\` — \`"py"\` IPython kernel, \`"js"\` persistent JavaScript VM.
-- \`code\` — cell body, verbatim. Newlines/quotes JSON-encoded; no fences, no headers.
-- \`summary\` (REQUIRED for run) — ONE line in the USER'S conversational language stating WHAT this cell does and FOR WHAT PURPOSE (e.g. Korean conversation -> "src 전체에서 legacyClient 사용처 집계"); shown in the TUI while the cell runs; >80 chars is force-truncated.
-- \`timeout\` (optional) — seconds; raises the wall-clock kill deadline (default 1800s, never paused by tool calls, a killed cell notifies you). It does not hold the turn: interactive sessions detach the cell at a ~60s foreground window and it keeps running to the deadline.
-- \`on_timeout\` (optional) — \`"detach"\` (interactive default) frees the turn at the foreground window; \`"error"\` (print/json default) interrupts at the full \`timeout\` for deadline-sensitive work.
-- \`reset\` (optional) — wipe this language's kernel first. Per-language: a \`py\` reset never touches the JS VM.
-- \`action\` (optional) — defaults to \`"run"\`. A detached cell returns its id: \`eval({ action: "peek", cell_id })\` reads buffered output, \`eval({ action: "stop", cell_id })\` cancels it (the result says whether kernel state survived).
+A cell that outlives the foreground window detaches: it keeps its language kernel busy (another language can continue) and completes as one notification with its value or error and buffered output. Do not re-run a detached cell; read or cancel it with \`eval({ action: "peek", cell_id })\` / \`eval({ action: "stop", cell_id })\`.
 
-A detached cell keeps its language kernel busy until it finishes; another language can continue. Do not re-run a detached cell (the busy error names its cell id and output tail): completion arrives as one notification with the final value or error and the buffered output.
-
-Live event loop: use top-level \`await\` directly; \`asyncio.run(…)\` raises "cannot be called from a running event loop".
+Python runs on a live event loop: use top-level \`await\`; \`asyncio.run(…)\` raises.
 JS runs under Node.js worker: top-level \`await\`/\`return\` work; \`fetch\`/\`Buffer\` available.
 
 On error, fix and re-run only the failing step; a normal error keeps state, while a timeout or stop message says whether the kernel restarted.
@@ -185,17 +160,17 @@ read(path, offset?=1, limit?=None) → str
 write(path, content) → str
     Write file (creates parents) → resolved path. \`local://…\` persists across turns/subagents.
 env(key?=None, value?=None) → str | None | dict
-    No args → full env dict; one → value of \`key\`; two → set \`key=value\`, return value.
+    No args → full env dict; one → value; two → set \`key=value\`.
 tool.<name>(args) → unknown
     Invoke any session tool; \`args\` = its parameter object.
 tool_schema(name?) → dict
-    Parameter schema of a tool (omit \`name\` to list tool names); check it before a first call, and a failed call also returns the expected parameters.
+    Parameter schema of a tool (omit \`name\` to list tool names); a failed \`tool.<name>()\` call also returns the expected parameters.
 completion(prompt, model?="default", system?=None, schema?=None) → str | dict
-    Oneshot, stateless (no history/tools). \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → structured output, parsed object.
+    Oneshot, stateless. \`model\`: \`"smol"\` fast | \`"default"\` session | \`"slow"\` most capable. \`schema\` (JSON-Schema) → parsed structured output.
 parallel(thunks) → list
-    Thunks through a bounded pool (wide as a \`task\` batch — don't pre-shrink), input order kept; returns when all finish, a throwing thunk propagates.
+    Thunks through a bounded pool (as wide as a \`task\` batch), input order kept; a throwing thunk propagates.
 pipeline(items, ...stages) → list
-    Map items through one-arg stages left-to-right, barrier between stages; stage 1 gets the item, later stages the previous result.
+    Map items through one-arg stages with a barrier between stages; each stage receives the previous stage's result.
 log(message) → None
     Progress line above the status tree.
 phase(title) → None

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -46,14 +46,17 @@ describe("buildEvalPrompt", () => {
 		expect(buildEvalPrompt(enabled, options)).toMatchSnapshot();
 	});
 
-	it("documents only enabled language fields and reset scope", () => {
+	it("documents only enabled languages and leaves field semantics to the parameter schema", () => {
 		const prompt = fullPrompt({ py: true, js: true, rb: false, jl: false });
 
 		expect(prompt).toContain('`"py"` IPython kernel');
 		expect(prompt).toContain('`"js"` persistent JavaScript VM');
 		expect(prompt).not.toContain('`"rb"` persistent Ruby kernel');
 		expect(prompt).not.toContain('`"jl"` persistent Julia kernel');
-		expect(prompt).toContain("a `py` reset never touches the JS VM");
+		// The parameter schema is the single home of the per-field semantics; the guideline keeps reset scope.
+		expect(prompt).not.toContain("- `timeout`");
+		expect(prompt).not.toContain("`on_timeout`");
+		expect(prompt).toContain("reset is scoped to the selected language");
 	});
 
 	it("omits disabled and missing languages from the prompt", () => {
@@ -79,7 +82,6 @@ describe("buildEvalPrompt", () => {
 		expect(withSpawns).toContain('agent(prompt, agent?="researcher"');
 		expect(withSpawns).toContain('output(*ids, format?="raw"');
 		expect(withSpawns).toContain("<workflow>");
-		expect(withSpawns).toContain("omit it to use `researcher`");
 	});
 
 	it("documents core helpers with Node wording and no excluded surface when no js runtime is given", () => {
@@ -94,10 +96,10 @@ describe("buildEvalPrompt", () => {
 		}
 	});
 
-	it("documents timeout detachment, busy-kernel discipline, and detached-cell controls", () => {
+	it("documents detachment, busy-kernel discipline, and the detached-cell controls", () => {
 		const prompt = fullPrompt({ py: true, js: true, rb: false, jl: false });
 
-		expect(prompt).toContain("`on_timeout`");
+		expect(prompt).toContain("outlives the foreground window detaches");
 		expect(prompt).toContain('eval({ action: "peek", cell_id })');
 		expect(prompt).toContain('eval({ action: "stop", cell_id })');
 		expect(prompt).toContain("Do not re-run a detached cell");
@@ -184,6 +186,7 @@ describe("buildEvalPrompt", () => {
 			[{ py: false, js: true, rb: false, jl: false }, ["{ handle: true }"]],
 			[{ py: true, js: false, rb: false, jl: false }, ["handle=True"]],
 			[{ py: true, js: true, rb: false, jl: false }, ["handle=True", "{ handle: true }"]],
+			[{ py: true, js: true, rb: true, jl: true }, ["`handle=True` / `{ handle: true }` / `handle=true`"]],
 		];
 
 		for (const [enabled, expectedForms] of cases) {
@@ -192,6 +195,7 @@ describe("buildEvalPrompt", () => {
 			// Then: each enabled language's form is present and the two are never fused without a separator.
 			expect(prompt).not.toContain("handle=True{ handle: true }");
 			expect(prompt).not.toContain("True{");
+			expect(prompt).not.toContain("}``handle=true");
 			for (const form of expectedForms) expect(prompt).toContain(form);
 			if (enabled.js) expect(prompt).not.toContain("`handle=True``{ handle: true }`");
 		}


### PR DESCRIPTION
## Summary

Second diet of the `eval` tool description. After #1348 the gpt/codex dialect still rendered **1,489 o200k tokens** (description + guidelines, py+js, spawns). Two duplications remained:

- the `Fields:` list restated the parameter schema word for word — 198 tokens of schema text billed twice per turn;
- the detach / busy-kernel guidance said the same thing in three places (`timeout` field, `action` field, and a standalone paragraph).

The description now names the enabled `language` values and defers every per-field rule (`summary`, `timeout`, `on_timeout`, `reset`, `action`) to the schema, its single home; the detach guidance is one paragraph; helper doc lines drop restated words but keep **every signature** and every dialect block untouched.

Also fixes a latent render bug the all-languages snapshot had pinned: the `jl` handle form rendered fused as `` }``handle=true`` `` after `{ handle: true }`; it now carries the same ` / ` separator as the py/js pair.

Part of the prompt-token diet (#1345 dedup, #1348 first eval diet, #1349 skills alias, #1351 schedule_wakeup deferral; omo #7737/#7738/#7744).

## Measured (o200k, description + guidelines, py+js, spawns; `measure-tokens.ts` config)

| dialect | before (#1348) | after |
|---|---:|---:|
| gpt / codex (`gpt-6-astra`) | 1,489 | **1,087** (-402) |
| claude | 1,588 | 1,173 |
| kimi | 1,606 | 1,190 |
| codex (`o3-mini`) | 1,557 | 1,141 |
| default | 1,604 | 1,189 |

Realistic session render (monitor + host line + Bun runtime + skill pointer) for gpt: 1,232.

## Verification

- RED on unmodified main: 3 new assertions fail for the right reason (`- \`timeout\`` still present, detach paragraph absent, fused `}``handle=true`` present).
- GREEN on mengmotaMac: `test/prompt.test.ts` 18/18 with 3 snapshots updated; coding-agent consumers (`prompt-presets-gpt-eval-routing`, `prompt-surface-stale-wait-idioms`, `prompt-single-home`) 15/15.
- All 14 helper signatures present in every dialect (checked programmatically).
- Changelog gate PASS locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Diets the `eval` tool description a second time, cutting the gpt/codex render from 1,489 to 1,087 o200k tokens (description + guidelines, py+js, spawns).

- Removes the `Fields:` list, which restated the parameter schema word for word (~198 tokens billed twice per turn); per-field rules now live only in the schema.
- Consolidates the detach/busy-kernel guidance that appeared in three places into one paragraph.
- Trims helper doc lines without changing any signature or dialect block.
- Fixes the fused `}``handle=true`` render of the `jl` handle form in the all-languages workflow block.
- Other dialects: claude 1,173, kimi 1,190, `o3-mini` 1,141, default 1,189.

<sup>Written for commit 839de69b8a41a9c89f8b770dfa43cc459adf0b63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

