### PR TITLE
test(ai): use gpt-5.3-codex for the copilot tool-call-id handoff tests

### DIFF
--- a/packages/ai/test/tool-call-id-normalization.test.ts
+++ b/packages/ai/test/tool-call-id-normalization.test.ts
@@ -36,7 +36,7 @@ const echoTool: Tool<typeof echoToolSchema> = {
 /**
  * Test 1: Live cross-provider handoff
  *
- * 1. Use github-copilot gpt-5.2-codex to generate a tool call
+ * 1. Use github-copilot gpt-5.3-codex to generate a tool call
  * 2. Switch to openrouter openai/gpt-5.2-codex and complete
  * 3. Switch to openai-codex gpt-5.5 and complete
  *
@@ -46,7 +46,7 @@ describe("Tool Call ID Normalization - Live Handoff", () => {
 	it.skipIf(!copilotToken || !openrouterKey)(
 		"github-copilot -> openrouter should normalize pipe-separated IDs",
 		async () => {
-			const copilotModel = getModel("github-copilot", "gpt-5.2-codex");
+			const copilotModel = getModel("github-copilot", "gpt-5.3-codex");
 			const openrouterModel = getModel("openrouter", "openai/gpt-5.2-codex");
 
 			// Step 1: Generate tool call with github-copilot
@@ -116,7 +116,7 @@ describe("Tool Call ID Normalization - Live Handoff", () => {
 	it.skipIf(!copilotToken || !codexToken)(
 		"github-copilot -> openai-codex should normalize pipe-separated IDs",
 		async () => {
-			const copilotModel = getModel("github-copilot", "gpt-5.2-codex");
+			const copilotModel = getModel("github-copilot", "gpt-5.3-codex");
 			const codexModel = getModel("openai-codex", "gpt-5.5");
 
 			// Step 1: Generate tool call with github-copilot


### PR DESCRIPTION
## Why

Release run [33842146239](https://github.com/code-yeongyu/senpi/actions/runs/33842146239) failed at `npm run check` (tsc). `publish-npm.yml` -> `scripts/release.mjs` regenerates the model catalog **live** from models.dev, then typechecks. models.dev's github-copilot catalog dropped `gpt-5.2-codex` (live list of 27 models has only `gpt-5.3-codex` as a codex variant), so the regenerated `ModelId` union no longer contains it:

```
packages/ai/test/tool-call-id-normalization.test.ts(49,52): error TS2345: Argument of type '"gpt-5.2-codex"' is not assignable to parameter of type 'ModelId<...>'
packages/ai/test/tool-call-id-normalization.test.ts(119,52): error TS2345: Argument of type '"gpt-5.2-codex"' is not assignable to parameter of type 'ModelId<...>'
```

Committed catalogs still contain `gpt-5.2-codex`, so PR CI on the frozen tree passes. The break only appears after live regeneration. Every release will fail until this is fixed. Unblocks 2026.9.4-2.

## What changed

- `packages/ai/test/tool-call-id-normalization.test.ts`: the two `getModel("github-copilot", ...)` pins and the matching doc-comment now use `gpt-5.3-codex`, which is present in both the committed github-copilot catalog and the live models.dev list.
- Left the openrouter `openai/gpt-5.2-codex` pins alone — openrouter still lists that id live.
- Did not regenerate or commit catalog data files; release.mjs regenerates those itself.

Live `generate-models` + `bunx tsc --noEmit` after this change: exit 0, no additional `TS2345` ModelId errors.

## Follow-up (not this PR)

This class of failure recurred on 2026-08-28 (`fireworks-models.test.ts:45`). The durable fix is dynamic selection (e.g. `getModels(provider).find(m => /codex/.test(m.id))`) or a synthetic `Model` object when the test does not need the catalog. Do not implement that here — this PR only unblocks the release typecheck.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release-time typecheck failure by updating the github-copilot model pins in the tool-call-id handoff tests from `gpt-5.2-codex` to `gpt-5.3-codex`. The live models.dev catalog no longer lists `gpt-5.2-codex`, so the regenerated `ModelId` union broke the build during `npm run check` in releases. The new id is present in both the committed and live catalogs. Openrouter pins remain unchanged.

<sup>Written for commit b17c3a347d414d83a8b109112dc926d5b41626df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

