### PR TITLE
test(ai): select the copilot codex model dynamically in the tool-call-id handoff tests

### DIFF
--- a/packages/ai/test/tool-call-id-normalization.test.ts
+++ b/packages/ai/test/tool-call-id-normalization.test.ts
@@ -12,10 +12,38 @@
 
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import { completeSimple, getModel } from "../src/compat.ts";
+import { completeSimple, getModel, getModels } from "../src/compat.ts";
 import type { AssistantMessage, Message, Tool, ToolResultMessage } from "../src/types.ts";
 import { getLiveEnvApiKey, OPENROUTER_LIVE_TEST_FLAG } from "./live-api-gates.ts";
 import { resolveApiKey } from "./oauth.ts";
+
+const COPILOT_CODEX_MISSING = "github-copilot catalog has no codex-family model; update the test";
+const OPENROUTER_CODEX_MISSING = "openrouter catalog has no openai gpt-5 codex-family model; update the test";
+
+/**
+ * Pick a catalog model by id family so tests never pin a ModelId literal.
+ * Release-time generate-models rewrites the ModelId union from models.dev;
+ * a retired pin fails tsc even when the live test is skipIf-gated.
+ */
+function requireCatalogModel<T extends { id: string }>(
+	models: readonly T[],
+	idPattern: RegExp,
+	missingMessage: string,
+): T {
+	const model = models.find((candidate) => idPattern.test(candidate.id));
+	if (!model) {
+		throw new Error(missingMessage);
+	}
+	return model;
+}
+
+function requireCopilotCodexModel() {
+	return requireCatalogModel(getModels("github-copilot"), /codex/i, COPILOT_CODEX_MISSING);
+}
+
+function requireOpenrouterGpt5CodexModel() {
+	return requireCatalogModel(getModels("openrouter"), /openai\/gpt-5.*codex/, OPENROUTER_CODEX_MISSING);
+}
 
 // Resolve API keys
 const copilotToken = await resolveApiKey("github-copilot");
@@ -33,11 +61,23 @@ const echoTool: Tool<typeof echoToolSchema> = {
 	parameters: echoToolSchema,
 };
 
+describe("Tool Call ID Normalization - catalog model selection", () => {
+	it("selects a github-copilot codex-family model from the committed catalog", () => {
+		expect(requireCopilotCodexModel().id).toMatch(/codex/i);
+	});
+
+	it("throws when a provider has no codex-family model", () => {
+		expect(() => requireCatalogModel([] as Array<{ id: string }>, /codex/i, COPILOT_CODEX_MISSING)).toThrow(
+			COPILOT_CODEX_MISSING,
+		);
+	});
+});
+
 /**
  * Test 1: Live cross-provider handoff
  *
- * 1. Use github-copilot gpt-5.3-codex to generate a tool call
- * 2. Switch to openrouter openai/gpt-5.2-codex and complete
+ * 1. Use a github-copilot codex-family model (catalog-selected, not a pinned ModelId) to generate a tool call
+ * 2. Switch to an openrouter openai gpt-5*codex model and complete
  * 3. Switch to openai-codex gpt-5.5 and complete
  *
  * Both should succeed without "call_id too long" errors.
@@ -46,8 +86,8 @@ describe("Tool Call ID Normalization - Live Handoff", () => {
 	it.skipIf(!copilotToken || !openrouterKey)(
 		"github-copilot -> openrouter should normalize pipe-separated IDs",
 		async () => {
-			const copilotModel = getModel("github-copilot", "gpt-5.3-codex");
-			const openrouterModel = getModel("openrouter", "openai/gpt-5.2-codex");
+			const copilotModel = requireCopilotCodexModel();
+			const openrouterModel = requireOpenrouterGpt5CodexModel();
 
 			// Step 1: Generate tool call with github-copilot
 			const userMessage: Message = {
@@ -116,7 +156,7 @@ describe("Tool Call ID Normalization - Live Handoff", () => {
 	it.skipIf(!copilotToken || !codexToken)(
 		"github-copilot -> openai-codex should normalize pipe-separated IDs",
 		async () => {
-			const copilotModel = getModel("github-copilot", "gpt-5.3-codex");
+			const copilotModel = requireCopilotCodexModel();
 			const codexModel = getModel("openai-codex", "gpt-5.5");
 
 			// Step 1: Generate tool call with github-copilot
@@ -240,7 +280,7 @@ describe("Tool Call ID Normalization - Prefilled Context", () => {
 	it.skipIf(!openrouterKey)(
 		"openrouter should handle prefilled context with long pipe-separated IDs",
 		async () => {
-			const model = getModel("openrouter", "openai/gpt-5.2-codex");
+			const model = requireOpenrouterGpt5CodexModel();
 			const messages = buildPrefilledMessages();
 
 			const response = await completeSimple(


### PR DESCRIPTION
## Why

Release-time typecheck keeps breaking on a retired github-copilot ModelId pin. `publish-npm.yml` -> `scripts/release.mjs` regenerates the model catalog **live** from models.dev, then runs `tsc`. A test that passes a literal id into `getModel`'s ModelId parameter fails the moment upstream drops that id, even when the live test is skipIf-gated.

This class of failure hit senpi on 2026-08-28 (`fireworks-models.test.ts:45`) and again today: [release run 33842146239](https://github.com/code-yeongyu/senpi/actions/runs/33842146239) failed because `gpt-5.2-codex` left the live github-copilot catalog. [#1353](https://github.com/code-yeongyu/senpi/pull/1353) unblocked 2026.9.4-2 by swapping the pin to `gpt-5.3-codex`. That is still a literal pin, so the next retirement repeats the outage.

## What changed

- `packages/ai/test/tool-call-id-normalization.test.ts`: the two `getModel("github-copilot", ...)` pins (and the openrouter `openai/gpt-5.2-codex` pins) now select a family match from `getModels(...)`. No literal string flows into `getModel`'s ModelId parameter.
- If the catalog has no match, the helper throws `github-copilot catalog has no codex-family model; update the test` (and a sibling message for openrouter) instead of silently skipping.
- Token-gated live handoff coverage is unchanged. A small non-gated unit test asserts the helper returns a /codex/ id on the committed catalog and throws that explicit message for an empty stub catalog.

## Verification

- `bunx tsc --noEmit` exit 0 on the committed catalog
- `npm --prefix packages/ai run generate-models` (live) then `bunx tsc --noEmit` exit 0; regen discarded
- `bunx vitest run packages/ai/test/tool-call-id-normalization.test.ts` green (2 passed, 4 skipIf'd without tokens)
- `bunx biome check --error-on-warnings packages/ai/test` exit 0
- `node scripts/check-pr-changelog.mjs --base origin/main` exit 0 (test-only; no runtime source)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release-time typecheck failures by selecting the Copilot Codex model dynamically in the tool-call-id handoff tests. The tests previously used hardcoded model IDs that would break when models.dev retired them; now they pick a codex-family model from the live catalog and throw a clear error if none exists.

<sup>Written for commit a0a43c5082404ebe2f060f8cb2438483f009dd43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

