### PR TITLE
fix(imagegen): never accept a seeded placeholder as an image-generation credential

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Image generation no longer fails with an OpenAI 401 when a placeholder API key is stored for the `openai` provider. A seeded `SK-SENTINEL-DO-NOT-LOG` value is treated as absent instead of as a credential, so resolution falls through to a configured OpenAI-compatible gateway, and image generation is reported as not configured when no gateway exists.
+
 ### Removed
 
 ## [2026.9.4-2] - 2026-09-04

--- a/packages/coding-agent/src/core/extensions/builtin/imagegen/auth.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/imagegen/auth.ts
@@ -64,11 +64,20 @@ function resolvedHeaders(headers: Record<string, string | null> | undefined): Re
 	return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
 
+/**
+ * Seeded placeholder keys (`SK-SENTINEL-DO-NOT-LOG-*`) are not credentials. Left unfiltered, such a
+ * value satisfies the stored-openai branch, pins `api.openai.com`, and every request 401s with
+ * `Incorrect API key provided: SK-SENTI***OG-2` while a working gateway sits unused.
+ */
+function isPlaceholderKey(apiKey: string): boolean {
+	return /^SK-SENTINEL-DO-NOT-LOG/i.test(apiKey);
+}
+
 function credentialParts(
 	auth: { apiKey?: string; headers?: Record<string, string | null> } | undefined,
 ): CredentialParts | undefined {
 	const apiKey = nonEmpty(auth?.apiKey);
-	if (!apiKey) return undefined;
+	if (!apiKey || isPlaceholderKey(apiKey)) return undefined;
 	const headers = resolvedHeaders(auth?.headers);
 	return { apiKey, ...(headers ? { headers } : {}) };
 }
@@ -180,7 +189,7 @@ export async function resolveImageGenAuth<TModel extends ImageGenAuthModel>(
 	}
 
 	const envApiKey = nonEmpty(env.OPENAI_API_KEY);
-	if (envApiKey) {
+	if (envApiKey && !isPlaceholderKey(envApiKey)) {
 		return {
 			kind: "native-openai",
 			apiKey: envApiKey,

--- a/packages/coding-agent/src/core/extensions/builtin/imagegen/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/imagegen/changes.md
@@ -1,3 +1,20 @@
+# changes
+
+## Placeholder credentials no longer hijack image-generation auth (2026-09-04)
+
+### What changed
+
+- `auth.ts` treats a `SK-SENTINEL-DO-NOT-LOG*` value as absent rather than as a credential, in both the stored-`openai` branch (`credentialParts`) and the `OPENAI_API_KEY` env branch. Resolution falls through to the gateway chain, and with no gateway the tool reports "not configured" instead of pinning `api.openai.com`.
+
+### Why
+
+- `~/.omo/agent/auth.json` on Jobdori carries seeded placeholders `SK-SENTINEL-DO-NOT-LOG-1/-2`. The `-2` entry sits under provider `openai`, so step 1 of the chain accepted it, pinned `https://api.openai.com/v1`, and every `gpt-image-2` request answered 401 `Incorrect API key provided: SK-SENTI***OG-2` while a healthy Quotio gateway (`openai-quotio`, verified 200 + real PNG) sat unused. Reported twice on 2026-09-04; the same symptom was "fixed" on 2026-08-21 by deleting the entry, and it came back.
+- Deleting the entry is not a fix: a placeholder is not a credential, and the resolver is the only place that can tell the difference before a request is sent.
+
+### Why this cannot be expressed externally
+
+- The chain runs inside the builtin extension before any request; a caller cannot distinguish "stored openai key" from "stored placeholder" without duplicating the resolver.
+
 # imagegen builtin — changes
 
 ## Bun-compiled skill asset (2026-08-27)

--- a/packages/coding-agent/test/imagegen-auth-chain.test.ts
+++ b/packages/coding-agent/test/imagegen-auth-chain.test.ts
@@ -53,6 +53,32 @@ function resolveWithRealRegistrySurface(modelRegistry: ModelRegistry) {
 void resolveWithRealRegistrySurface;
 
 describe("imagegen credential resolution", () => {
+	// Regression: a placeholder key seeded into the openai store entry (SK-SENTINEL-DO-NOT-LOG-*)
+	// won step 1 and sent gpt-image-2 requests to api.openai.com, which answered 401
+	// "Incorrect API key provided: SK-SENTI***OG-2" while a working gateway sat unused. Fixed by
+	// deleting the entry on 2026-08-21; it reappeared on 2026-09-04. A placeholder is not a
+	// credential, so resolution must fall through to the gateway chain.
+	it("#given a placeholder openai store key and a configured gateway #when resolving #then the gateway wins", async () => {
+		const result = await resolve({
+			models: [model("openai-quotio", { baseUrl: "https://quotio.example/v1" })],
+			storedOpenAi: { type: "api_key", key: "SK-SENTINEL-DO-NOT-LOG-2" },
+			providerAuth: { openai: { auth: { apiKey: "SK-SENTINEL-DO-NOT-LOG-2" } } },
+			modelAuth: { "openai-quotio": { ok: true, apiKey: "quotio-local-real" } },
+		});
+
+		expect(result.kind).toBe("gateway");
+		expect(result.kind === "gateway" && result.baseUrl).toBe("https://quotio.example/v1");
+	});
+
+	it("#given only a placeholder openai store key #when resolving #then image generation is reported as not configured", async () => {
+		const result = await resolve({
+			storedOpenAi: { type: "api_key", key: "SK-SENTINEL-DO-NOT-LOG-2" },
+			providerAuth: { openai: { auth: { apiKey: "SK-SENTINEL-DO-NOT-LOG-2" } } },
+		});
+
+		expect(result.kind).toBe("none");
+	});
+
 	it("prefers stored native OpenAI auth over a pinned gateway", async () => {
 		const result = await resolve(
 			{


### PR DESCRIPTION
## Problem

Built-in `generate_image` on Jobdori returned OpenAI 401 `Incorrect API key provided: SK-SENTI************OG-2` (reported twice on 2026-09-04 by session w2N:p15) while the `~/.agents/skills/imagegen` Quotio path worked.

## Root cause

`~/.omo/agent/auth.json` carries seeded placeholders `SK-SENTINEL-DO-NOT-LOG-1` / `-2`. The `-2` value sits under provider `openai`, and step 1 of the imagegen chain (`resolveStoredOpenAi` -> `credentialParts`) accepts **any** non-empty `apiKey`. So the placeholder won resolution, pinned `https://api.openai.com/v1`, and every `gpt-image-2` request 401'd — while a healthy gateway (`openai-quotio`, `https://quotio.mengmota.com/v1`) sat unused.

This exact symptom was "fixed" on 2026-08-21 by deleting the entry. It came back. Deleting a file entry is not a fix: the resolver is the only place that can tell a placeholder from a credential before a request goes out.

## Fix

`auth.ts` treats `SK-SENTINEL-DO-NOT-LOG*` as absent in both credential branches (stored `openai` and `OPENAI_API_KEY`). Resolution falls through to the gateway chain; with no gateway the tool reports "not configured" instead of pinning `api.openai.com`.

## Verification

- **RED**: with a placeholder `openai` entry plus a configured gateway, resolution returned `native-openai` (the 401 path). Captured before the fix.
- **GREEN**: now returns `gateway` with the gateway `baseUrl`; placeholder-only config returns `none`.
- **Mutation proof**: neutralizing the guard (`return false`) makes both new tests fail; restoring makes them pass. The tests genuinely cover the regression.
- 3 imagegen suites pass (`imagegen-auth-chain`, `imagegen-tool`, `imagegen-skill-gating`).
- `biome check --error-on-warnings` exit 0; changelog gate PASS; no `imagegen` typecheck errors.
- **Real surface**: after removing the sentinel entry on the affected machine, `POST /v1/images/generations` model `gpt-image-2` against the Quotio gateway returned **200 with a real PNG** (b64 length 1,114,752). Live machine remediated with a timestamped backup; the `google` sentinel entry was left untouched.

Reported by w2N:p15; triaged in the senpi-issues lane (w33:p26).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats seeded `SK-SENTINEL-DO-NOT-LOG*` values as absent during image-generation credential resolution, so a placeholder no longer wins resolution, pins `api.openai.com`, and makes every request 401. Resolution now falls through to the gateway chain, and reports "not configured" when no gateway exists.

**Bug Fixes**
- Treats placeholder keys as absent in both the stored `openai` and `OPENAI_API_KEY` credential branches.
- Adds regression tests covering gateway fall-through and the not-configured case.

<sup>Written for commit 7506d24b5a06ad258d519000c73eb8ebb93ba989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

