### PR TITLE
fix(ai): bound CI Vitest fork concurrency

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- CI now bounds pi-ai's Vitest fork pool and teardown time to prevent subprocess-heavy provider lifecycle tests from stranding workers on constrained runners.
+
 ### Fixed
 
 ### Removed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- CI now bounds pi-ai's Vitest fork pool and teardown time to prevent subprocess-heavy provider lifecycle tests from stranding workers on constrained runners.
+- CI now bounds pi-ai's Vitest fork pool and teardown time, and Cursor stream attempts clear their health timers, preventing subprocess-heavy lifecycle tests from stranding workers on constrained runners.
 
 ### Fixed
 

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,6 +1,6 @@
 # changes.md — ai
 
-## Bound pi-ai CI Vitest fork concurrency
+## 2026-09-04 - Bound pi-ai CI Vitest fork concurrency
 
 ### What changed
 

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -4,7 +4,7 @@
 
 ### What changed
 
-- `packages/ai/vitest.config.ts` uses the forks pool with two workers and a bounded teardown timeout when CI is running.
+- `packages/ai/vitest.config.ts` uses the forks pool with two workers and a bounded teardown timeout when CI is running; `packages/ai/src/api/cursor-agent.ts` clears the stream-health timer when each attempt ends.
 
 ### Why
 

--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,5 +1,23 @@
 # changes.md — ai
 
+## Bound pi-ai CI Vitest fork concurrency
+
+### What changed
+
+- `packages/ai/vitest.config.ts` uses the forks pool with two workers and a bounded teardown timeout when CI is running.
+
+### Why
+
+- Provider lifecycle tests create real network clients and subprocesses; unbounded fork concurrency can strand workers while a constrained CI runner tears down the pool.
+
+### Why this lives in the fork
+
+- Vitest execution policy is package-owned test infrastructure and cannot be configured by a runtime extension.
+
+### Expected merge conflict zones
+
+- LOW: `packages/ai/vitest.config.ts` test settings.
+
 ## 2026-09-04 - Restore the @anthropic-ai/sdk 0.123.0 pin the R4b merge dropped
 
 ### What changed

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -1247,6 +1247,10 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 					clearInterval(heartbeatTimer);
 					heartbeatTimer = null;
 				}
+				if (streamHealthTimer) {
+					clearTimeout(streamHealthTimer);
+					streamHealthTimer = null;
+				}
 				h2Request?.close();
 				h2Client?.close();
 				h2Request = null;

--- a/packages/ai/src/api/cursor-agent.ts
+++ b/packages/ai/src/api/cursor-agent.ts
@@ -774,10 +774,6 @@ export const stream: StreamFunction<"cursor-agent", CursorAgentOptions> = (
 		const settleH2 = (error?: unknown): void => {
 			if (h2Settled) return;
 			h2Settled = true;
-			if (streamHealthTimer) {
-				clearTimeout(streamHealthTimer);
-				streamHealthTimer = null;
-			}
 			if (error !== undefined) {
 				rejectH2(error);
 				return;

--- a/packages/ai/test/ci-diagnostics.ts
+++ b/packages/ai/test/ci-diagnostics.ts
@@ -1,0 +1,7 @@
+function dumpActiveResources(signal: string): void {
+	if (!process.env.CI && !process.env.GITHUB_ACTIONS) return;
+	console.error(`[pi-ai vitest diagnostics] ${signal} active resources:`, process.getActiveResourcesInfo());
+}
+
+process.on("beforeExit", () => dumpActiveResources("beforeExit"));
+process.on("SIGTERM", () => dumpActiveResources("SIGTERM"));

--- a/packages/ai/test/cursor-agent-exec-lifecycle.cases.ts
+++ b/packages/ai/test/cursor-agent-exec-lifecycle.cases.ts
@@ -73,6 +73,17 @@ export function registerCursorExecLifecycleTests(): void {
 	});
 
 	describe("cursor-agent turn termination", () => {
+		it("clears the stream health timer after teardown", async () => {
+			vi.useFakeTimers();
+			try {
+				const message = await runTurnTerminationScenario("turnEndedOpen");
+				expect(message.stopReason).toBe("stop");
+				expect(vi.getTimerCount()).toBe(0);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it("completes after turnEnded while the server keeps the stream open", async () => {
 			const message = await runTurnTerminationScenario("turnEndedOpen");
 			expect(message.stopReason).toBe("stop");

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 		testTimeout: 30000, // 30 seconds for API calls
 		reporters: process.env.GITHUB_ACTIONS ? ["dot", "github-actions"] : ["dot"],
 		silent: "passed-only",
+		...(process.env.CI || process.env.GITHUB_ACTIONS ? { setupFiles: ["./test/ci-diagnostics.ts"] } : {}),
 		// The provider and Cursor lifecycle suites create real HTTP/HTTP2 clients and
 		// child processes. Keep CI fork concurrency bounded so a small runner cannot
 		// oversubscribe the process table and strand a worker during pool teardown.

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
 		testTimeout: 30000, // 30 seconds for API calls
 		reporters: process.env.GITHUB_ACTIONS ? ["dot", "github-actions"] : ["dot"],
 		silent: "passed-only",
+		// The provider and Cursor lifecycle suites create real HTTP/HTTP2 clients and
+		// child processes. Keep CI fork concurrency bounded so a small runner cannot
+		// oversubscribe the process table and strand a worker during pool teardown.
+		...(process.env.CI || process.env.GITHUB_ACTIONS
+			? { pool: "forks" as const, maxWorkers: 2, teardownTimeout: 20000 }
+			: {}),
 	},
 	resolve: {
 		alias: [{ find: /^@earendil-works\/pi-telemetry$/, replacement: telemetrySrcIndex }],


### PR DESCRIPTION
## Root cause
The pi-ai Vitest config used the default worker pool on GitHub's constrained Ubuntu runner. Its provider and Cursor lifecycle tests create real HTTP/HTTP2 clients and subprocesses; unbounded fork concurrency can oversubscribe process/IO resources and strand a worker during pool teardown. The failure signature is process-level: runs 33837361835, 33846120172, and 33846538567 all stop after the pi-ai `RUN v4.1.11` banner without a Vitest summary or test timeout, while passing runs complete normally.

## Fix
Use the forks pool with `maxWorkers: 2` and `teardownTimeout: 20000` whenever `CI` or `GITHUB_ACTIONS` is set. Local runs retain Vitest's default concurrency.

## Evidence
- 33846538567 (primary sample): last pi-ai line `RUN v4.1.11 .../packages/ai` at 07:01:11, then job failure summary at 07:04:42.
- 33846120172: last pi-ai line at 06:53:09, then failure summary at 06:56:49.
- 33837361835: last pi-ai line at 04:39:10, then release failure summary at 05:00:11.
- Passing same-day run 33843615248 completed pi-ai with 41 files / 548 tests.

## Verification
- Changed-file diff check passes.
- LSP diagnostics could not resolve dependencies because this isolated worktree has no installed `node_modules`.
- Required gorky reproduction was attempted under `/tmp/flake-senpi-piai-20260904`; exact npm archive install was blocked by the base archive's lockfile mismatch, and gorky lacks `systemd-run`. A subsequent 20+20 comparison using the available command surface recorded infrastructure exit 127 (`systemd-run` unavailable), not test results. No 20/20 green receipt or mutation receipt is claimed.
- Root `bun run check` was not run due to the reproduction environment/toolchain blocker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `pi-ai` CI hangs by bounding Vitest fork concurrency on constrained GitHub runners and clearing cursor stream health timers when each attempt ends, so provider lifecycle tests no longer strand workers or keep processes alive during teardown.

- Uses the forks pool with `maxWorkers: 2` and `teardownTimeout: 20000` when `CI` or `GITHUB_ACTIONS` is set; local runs keep Vitest's default concurrency.
- Adds a test asserting the stream health timer is cleared after teardown, plus a CI-only diagnostics hook that logs active resources on exit.
- Verification was limited: the changed-file diff passes, but the reproduction environment had no installed `node_modules` or `systemd-run`, so the flake reproduction and root `bun run check` could not be completed.

<sup>Written for commit 633cd5fe54b84b4db490915b5def2566e43637de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Deterministic teardown proof

- Test: `packages/ai/test/cursor-agent-exec-lifecycle.cases.ts` - `cursor-agent turn termination > clears the stream health timer after teardown`.
- GREEN receipt: `CI=1 bun run --cwd packages/ai test -- --pool=forks --maxWorkers=1 test/cursor-agent.test.ts -t 'clears the stream health timer'` -> 1 passed, 33 skipped, exit 0.
- Mutation receipt: temporarily removed the `finally` clearTimeout block in `packages/ai/src/api/cursor-agent.ts`; the same test failed with `expected 1 to be +0`, exit 1. The fix was restored and pushed.
- Root `bun run check` also passes via the pre-commit hook, exit 0.
