### PR TITLE
fix(coding-agent): make reftable polling deterministic

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Make the reftable polling fallback detect content changes without relying on filesystem timestamp precision, and test the fallback with deterministic timer/event control.
+
 ### Removed
 
 ## [2026.9.4-3] - 2026-09-04

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1447,6 +1447,24 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 - `provider-composer.ts` end of `ProviderConfigInput`; `model-runtime.ts` near `hasConfiguredAuth`;
   `model-registry.ts` near `isUsingOAuth`.
 
+## 2026-09-04 - Make reftable polling content-aware
+
+### What changed
+
+- `footer-data-provider.ts` now retains the last `tables.list` contents and compares content on each polling callback in addition to filesystem metadata.
+
+### Why
+
+- Filesystem timestamp precision can make a changed reftable table list look unchanged when its size and timestamps are identical, leaving the footer branch stale.
+
+### Why an extension could not handle it
+
+- Reftable detection is core footer session plumbing and is not observable or replaceable by an extension.
+
+### Expected merge conflict zones
+
+- LOW: `footer-data-provider.ts` reftable polling callback.
+
 ## 2026-08-19 upstream sync integration repair (footer-data-provider watcher fallback)
 
 ### What changed

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -361,8 +361,23 @@ export class FooterDataProvider {
 				// when watcher creation just failed. The path is recorded after the
 				// attempt because a failure synchronously clears watcher state.
 				this.reftableTablesListPath = tablesListPath;
+				let previousTablesListContent: string | undefined;
+				try {
+					previousTablesListContent = readFileSync(tablesListPath, "utf8");
+				} catch {
+					// The file may disappear between existsSync and the first poll.
+				}
 				watchFile(tablesListPath, { interval: 250 }, (current, previous) => {
+					let contentChanged = false;
+					try {
+						const currentContent = readFileSync(tablesListPath, "utf8");
+						contentChanged = previousTablesListContent !== currentContent;
+						previousTablesListContent = currentContent;
+					} catch {
+						contentChanged = true;
+					}
 					if (
+						contentChanged ||
 						current.mtimeMs !== previous.mtimeMs ||
 						current.ctimeMs !== previous.ctimeMs ||
 						current.size !== previous.size

--- a/packages/coding-agent/test/footer-data-provider-watch-fallback.test.ts
+++ b/packages/coding-agent/test/footer-data-provider-watch-fallback.test.ts
@@ -6,6 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let resolvedBranch = "main";
 let branchResolutionDelivered: (() => void) | null = null;
+let tablesListPoll: ((current: unknown, previous: unknown) => void) | null = null;
+
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>();
+	return {
+		...actual,
+		watchFile: vi.fn((_path: string, _options: unknown, listener: (current: unknown, previous: unknown) => void) => {
+			tablesListPoll = listener;
+		}),
+		unwatchFile: vi.fn(),
+	};
+});
 
 vi.mock("child_process", () => ({
 	execFile: vi.fn(
@@ -69,20 +81,6 @@ function createReftableWorktree(tempDir: string): { worktreeDir: string; reftabl
 	return { worktreeDir, reftableDir };
 }
 
-async function awaitWithTimeout(event: Promise<void>, description: string, timeoutMs = 10000): Promise<void> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		await Promise.race([
-			event,
-			new Promise<never>((_resolve, reject) => {
-				timer = setTimeout(() => reject(new Error(`Timed out waiting for ${description}`)), timeoutMs);
-			}),
-		]);
-	} finally {
-		if (timer) clearTimeout(timer);
-	}
-}
-
 describe("FooterDataProvider reftable detection without usable fs.watch", () => {
 	let originalCwd: string;
 	let tempDir: string;
@@ -92,6 +90,8 @@ describe("FooterDataProvider reftable detection without usable fs.watch", () => 
 		tempDir = mkdtempSync(join(tmpdir(), "footer-watch-fallback-"));
 		resolvedBranch = "main";
 		branchResolutionDelivered = null;
+		tablesListPoll = null;
+		vi.useFakeTimers();
 		vi.mocked(spawnSync).mockClear();
 		vi.mocked(execFile).mockClear();
 	});
@@ -101,6 +101,7 @@ describe("FooterDataProvider reftable detection without usable fs.watch", () => 
 		if (tempDir && existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
+		vi.useRealTimers();
 	});
 
 	it("still refreshes the branch through the polling fallback", async () => {
@@ -118,7 +119,13 @@ describe("FooterDataProvider reftable detection without usable fs.watch", () => 
 				branchResolutionDelivered = resolve;
 			});
 			writeFileSync(join(reftableDir, "tables.list"), "1\n");
-			await awaitWithTimeout(resolutionDelivered, "the polled reftable refresh to resolve the branch");
+			expect(tablesListPoll).not.toBeNull();
+			tablesListPoll?.(
+				{ mtimeMs: 1, ctimeMs: 1, size: 2 },
+				{ mtimeMs: 1, ctimeMs: 1, size: 2 },
+			);
+			await vi.advanceTimersByTimeAsync(500);
+			await resolutionDelivered;
 
 			expect(provider.getGitBranch()).toBe("foo");
 			expect(onBranchChange).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Root cause
The fs.watch-less reftable fallback used fs.watchFile metadata (mtime/ctime/size) as its only change detector, so timestamp precision could hide a tables.list update. The regression also mutated the file immediately after arming watchFile and waited on a 10s real-clock timeout, allowing the first poll to establish the new state as its baseline or to miss the runner deadline.

## Fix
- Compare tables.list content on every fallback poll in addition to metadata.
- Capture the poll callback in the regression, drive the 500ms debounce with Vitest fake timers, and await the exact mocked git-resolution event.
- No real-clock timeout, sleep, or polling was added.

## Evidence
- Historical CI: runs 33846120172 and 33825736383 failed in `test/footer-data-provider-watch-fallback.test.ts` with `Timed out waiting for the polled reftable refresh to resolve the branch` at line 78; timeout was 10,000ms; fs.watch was explicitly mocked unavailable.
- Linux gorky loop: 30/30 green under CI=1.
- Mutation receipt: disabling content-change detection caused the deterministic test to remain unresolved and the bounded remote run exited via SIGTERM; restoring detection returns green.
- `bun run check`: attempted remotely; blocked by pre-existing environment mismatch (Biome 2.5.10 vs configured 2.5.6 and missing `@typescript/typescript6`).

Do not merge model-registry or github-copilot-oauth changes; this PR only touches footer polling and its changelog/test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the reftable polling fallback detect `tables.list` content changes instead of relying only on filesystem metadata, so timestamp precision can no longer hide a table list update and leave the footer branch stale. Also makes the fallback test deterministic by replacing the 10s real-clock timeout with fake timers and explicit event control.

- The polling callback compares the current `tables.list` contents with the previous poll's contents in addition to mtime/ctime/size.
- The test captures the poll callback, drives the 500ms debounce with Vitest fake timers, and awaits the mocked git-resolution event.

<sup>Written for commit 87c9cedfa5c47125c28e4d3fd88c752b0481269e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

