### PR TITLE
fix(hooks): read trust state fail-open when the lock dir is not writable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Image generation no longer fails with an OpenAI 401 when a placeholder API key is stored for the `openai` provider. A seeded `SK-SENTINEL-DO-NOT-LOG` value is treated as absent instead of as a credential, so resolution falls through to a configured OpenAI-compatible gateway, and image generation is reported as not configured when no gateway exists.
+- Hook trust-state reads no longer fail tool execution when the lock directory cannot be created (`EPERM`/`EACCES`/`EROFS` in sandboxed or read-only children); writers still fail closed on those errors.
 
 ### Removed
 

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,30 @@
 # Builtin extensions changes
 
+## Hooks trust-state reads fail open when the lock directory is not writable (2026-09-04)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts`: `FileHookStateStorage.read()` still
+  parses the on-disk snapshot lock-free. When that parse is empty or malformed and lock acquisition then fails with
+  `EPERM`, `EACCES`, or `EROFS`, the reader now returns the same fail-open empty state already used for `ELOCKED`.
+  `update()` is unchanged and still throws on permission errors.
+
+### Why
+
+- Sandboxed or read-only children (macOS seatbelt `deny file-write*`, bwrap `--ro-bind`, a read-only HOME) cannot
+  mkdir the `hooks-state.json.lock` directory. That error used to propagate out of the tool_call hook and fail every
+  tool call. A reader that cannot take a lock must not break tool execution; writers must still fail closed.
+
+### Why an extension could not handle it
+
+- The hooks builtin owns this persistence path and calls `storage.read()` on session_start, input, tool_call, and
+  tool_result before any user extension can intercept the failure.
+
+### Expected merge conflict zones
+
+- LOW in `packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts` around `FileHookStateStorage.read`'s
+  lock-acquisition catch. Keep `EPERM`/`EACCES`/`EROFS` fail-open on read only; writers must still throw.
+
 ## Loop-owned exposure for `schedule_wakeup` (2026-09-04)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts
@@ -44,7 +44,9 @@ export class FileHookStateStorage implements HookStateStorage {
 		try {
 			release = acquireHookStateLockSync(path);
 		} catch (error) {
-			if (errorCode(error) === "ELOCKED") {
+			const code = errorCode(error);
+			// Sandboxed/read-only children cannot mkdir the lock dir; fail open on read.
+			if (code === "ELOCKED" || code === "EPERM" || code === "EACCES" || code === "EROFS") {
 				return emptyHookTrustState();
 			}
 			throw error;

--- a/packages/coding-agent/test/suite/hooks-trust.test.ts
+++ b/packages/coding-agent/test/suite/hooks-trust.test.ts
@@ -29,8 +29,16 @@ const PROJECT_SOURCE: HookSourceMetadata = {
 
 const UPDATED_AT = "2026-06-29T00:00:00.000Z";
 const createdDirs: string[] = [];
+const restrictedDirs: string[] = [];
 
 afterEach(async () => {
+	for (const dir of restrictedDirs.splice(0)) {
+		try {
+			chmodSync(dir, 0o700);
+		} catch {
+			// Restore write access so recursive cleanup can remove the directory.
+		}
+	}
 	for (const dir of createdDirs.splice(0)) {
 		await rm(dir, { recursive: true, force: true });
 	}
@@ -357,6 +365,33 @@ describe("builtin hooks trust", () => {
 		// Then
 		expect(await readFile(statePath, "utf-8")).toContain('"version": 1');
 	});
+
+	it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+		"returns empty trust state when the lock directory is not writable",
+		async () => {
+			// Given
+			const root = await mkdtemp(join(tmpdir(), "senpi-hooks-trust-"));
+			createdDirs.push(root);
+			const agentDir = join(root, "agent");
+			const cwd = join(root, "repo");
+			mkdirSync(agentDir, { recursive: true });
+			mkdirSync(cwd, { recursive: true });
+			chmodSync(agentDir, 0o500);
+			restrictedDirs.push(agentDir);
+			const storage = new FileHookStateStorage({ agentDir, cwd });
+
+			// When / Then
+			expect(storage.read("global")).toEqual({ version: 1, hooks: {} });
+
+			let updateError: unknown;
+			try {
+				storage.update("global", (current) => current);
+			} catch (error) {
+				updateError = error;
+			}
+			expect(updateError).toMatchObject({ code: "EACCES" });
+		},
+	);
 });
 
 function commandHook(


### PR DESCRIPTION
## Problem

Builtin hooks call `FileHookStateStorage.read()` on `session_start`, `input`, `tool_call`, and `tool_result`. When the on-disk snapshot is missing or unparseable, `read()` acquires the writer lock. That path `mkdirSync`s the state dir and then `proper-lockfile.lockSync`s `${path}.lock`.

Only `ELOCKED` was caught (empty trust state). In a read-only or sandboxed child (macOS seatbelt `(deny file-write*)`, `bwrap --ro-bind`, a read-only HOME) the lock mkdir throws `EPERM`/`EACCES`/`EROFS`, the error propagates out of the tool_call hook, and every tool call of the child fails, e.g. `EPERM: operation not permitted, mkdir '.../hooks-state.json.lock'`. Observed 11/11 times in omo's sandboxed memorian child on 2026-09-04.

A reader that cannot take a lock must never break tool execution. Writers (`update()`) must keep failing loudly.

## Changes

- `FileHookStateStorage.read()` treats lock-acquisition failures with code `EPERM`, `EACCES`, or `EROFS` like `ELOCKED`: return the already-attempted parsed snapshot if one exists, otherwise empty `{version:1, hooks:{}}`.
- `update()` is unchanged and still throws on permission errors.
- POSIX regression: chmod the state dir to `0o500` with no `hooks-state.json`, assert `read("global")` returns empty state, assert `update("global", ...)` still throws `EACCES`.
- Record the fork-specific protocol in the nearest `changes.md` tracker and package changelog.

## Verification

Command:

```
cd packages/coding-agent && bunx vitest run test/suite/hooks-trust.test.ts
bunx biome check packages/coding-agent/src/core/extensions/builtin/hooks/trust-storage.ts packages/coding-agent/test/suite/hooks-trust.test.ts
bun scripts/check-pr-changelog.mjs --base origin/main
```

RED (before fix):

```
 FAIL  test/suite/hooks-trust.test.ts > builtin hooks trust > returns empty trust state when the lock directory is not writable
Error: EACCES: permission denied, mkdir '/var/folders/h6/w548ypzn1k78_xqndn63y7xc0000gn/T/senpi-hooks-trust-TEXPIA/agent/hooks-state.json.lock'
 Test Files  1 failed (1)
      Tests  1 failed | 11 passed | 1 skipped (13)
```

GREEN (after fix):

```
 Test Files  1 passed (1)
      Tests  12 passed | 1 skipped (13)
```

- Biome: Checked 2 files. No fixes applied.
- Changelog gate: `PASS - changes.md coverage complete (0 production path(s) covered); changelog entry updated (packages/coding-agent/CHANGELOG.md)`

## Risk

Readers in a sandboxed or read-only environment now see empty trust state instead of crashing every tool call, which is intentional fail-open. Complete on-disk snapshots remain lock-free and are still returned when parseable. Writers still fail closed on permission errors, so a read-only child cannot silently persist trust changes. Other lock errors besides `ELOCKED`/`EPERM`/`EACCES`/`EROFS` are still rethrown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes hook trust-state reads fail open when the lock directory can't be created, so sandboxed or read-only children no longer fail every tool call. `FileHookStateStorage.read()` now treats `EPERM`, `EACCES`, and `EROFS` the same as `ELOCKED` and returns empty trust state; `update()` still throws on permission errors. Other lock errors are still rethrown, and complete on-disk snapshots are still returned without taking a lock. Adds a regression test covering the read-only state directory and updates the changelog.

<sup>Written for commit 2e02371b8b24631ac0810b9be09e6b0e38ba614c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

