### PR TITLE
fix(deps): regenerate bun.lock for the @anthropic-ai/sdk override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,10 +19,10 @@
     },
     "packages/agent": {
       "name": "@earendil-works/pi-agent-core",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "dependencies": {
-        "@earendil-works/pi-ai": "^2026.9.3",
-        "@earendil-works/pi-telemetry": "^2026.9.3",
+        "@earendil-works/pi-ai": "^2026.9.4-2",
+        "@earendil-works/pi-telemetry": "^2026.9.4-2",
         "diff": "9.0.0",
         "ignore": "7.0.6",
         "typebox": "1.3.18",
@@ -37,15 +37,15 @@
     },
     "packages/ai": {
       "name": "@earendil-works/pi-ai",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "bin": {
         "pi-ai": "dist/cli.js",
       },
       "dependencies": {
-        "@anthropic-ai/sdk": "0.120.0",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1116.0",
         "@bufbuild/protobuf": "2.14.0",
-        "@earendil-works/pi-telemetry": "^2026.9.3",
+        "@earendil-works/pi-telemetry": "^2026.9.4-2",
         "@google/genai": "2.18.0",
         "@smithy/node-http-handler": "4.11.3",
         "@smithy/types": "4.17.2",
@@ -64,9 +64,9 @@
     },
     "packages/client": {
       "name": "@earendil-works/pi-client",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "dependencies": {
-        "@earendil-works/pi-protocol": "2026.9.3",
+        "@earendil-works/pi-protocol": "2026.9.4-2",
       },
       "devDependencies": {
         "shx": "0.4.0",
@@ -75,23 +75,23 @@
     },
     "packages/coding-agent": {
       "name": "@code-yeongyu/senpi",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "bin": {
         "pi": "dist/bundle/cli.js",
         "senpi": "dist/cli.js",
       },
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.3.259",
-        "@anthropic-ai/sdk": "0.120.0",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1116.0",
         "@bufbuild/protobuf": "2.14.0",
-        "@code-yeongyu/senpi-codemode": "^2026.9.3",
-        "@earendil-works/pi-agent-core": "^2026.9.3",
-        "@earendil-works/pi-ai": "^2026.9.3",
-        "@earendil-works/pi-client": "^2026.9.3",
-        "@earendil-works/pi-protocol": "^2026.9.3",
-        "@earendil-works/pi-pty": "^2026.9.3",
-        "@earendil-works/pi-tui": "^2026.9.3",
+        "@code-yeongyu/senpi-codemode": "^2026.9.4-2",
+        "@earendil-works/pi-agent-core": "^2026.9.4-2",
+        "@earendil-works/pi-ai": "^2026.9.4-2",
+        "@earendil-works/pi-client": "^2026.9.4-2",
+        "@earendil-works/pi-protocol": "^2026.9.4-2",
+        "@earendil-works/pi-pty": "^2026.9.4-2",
+        "@earendil-works/pi-tui": "^2026.9.4-2",
         "@modelcontextprotocol/sdk": "1.30.0",
         "@mozilla/readability": "0.6.0",
         "@opentelemetry/api": "1.9.1",
@@ -184,8 +184,8 @@
       "name": "@code-yeongyu/senpi-evals",
       "version": "2026.7.25",
       "devDependencies": {
-        "@code-yeongyu/senpi": "^2026.9.2-4",
-        "@earendil-works/pi-ai": "^2026.9.2-4",
+        "@code-yeongyu/senpi": "^2026.9.4-2",
+        "@earendil-works/pi-ai": "^2026.9.4-2",
         "@types/node": "26.2.0",
         "shx": "0.4.0",
         "typescript": "7.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/protocol": {
       "name": "@earendil-works/pi-protocol",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "dependencies": {
         "typebox": "1.3.18",
       },
@@ -206,7 +206,7 @@
     },
     "packages/pty": {
       "name": "@earendil-works/pi-pty",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "dependencies": {
         "@xterm/headless": "6.0.0",
       },
@@ -216,14 +216,14 @@
     },
     "packages/senpi-codemode": {
       "name": "@code-yeongyu/senpi-codemode",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "dependencies": {
         "@babel/parser": "8.0.4",
-        "@earendil-works/pi-ai": "^2026.9.3",
+        "@earendil-works/pi-ai": "^2026.9.4-2",
         "typebox": "1.3.18",
       },
       "devDependencies": {
-        "@code-yeongyu/senpi": "2026.9.3",
+        "@code-yeongyu/senpi": "2026.9.4-2",
       },
       "peerDependencies": {
         "@code-yeongyu/senpi": "*",
@@ -231,10 +231,10 @@
     },
     "packages/server": {
       "name": "@code-yeongyu/senpi-server",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "dependencies": {
-        "@earendil-works/pi-ai": "^2026.9.2-4",
-        "@earendil-works/pi-protocol": "^2026.9.2-4",
+        "@earendil-works/pi-ai": "^2026.9.4-2",
+        "@earendil-works/pi-protocol": "^2026.9.4-2",
       },
       "devDependencies": {
         "shx": "0.4.0",
@@ -245,8 +245,8 @@
       "name": "@earendil-works/pi-storage-sqlite-node",
       "version": "0.83.0",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^2026.9.2-4",
-        "@earendil-works/pi-ai": "^2026.9.2-4",
+        "@earendil-works/pi-agent-core": "^2026.9.4-2",
+        "@earendil-works/pi-ai": "^2026.9.4-2",
       },
       "devDependencies": {
         "@vitest/coverage-v8": "4.1.11",
@@ -255,7 +255,7 @@
     },
     "packages/telemetry": {
       "name": "@earendil-works/pi-telemetry",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "devDependencies": {
         "@types/node": "26.2.0",
         "vitest": "4.1.11",
@@ -263,7 +263,7 @@
     },
     "packages/tui": {
       "name": "@earendil-works/pi-tui",
-      "version": "2026.9.3",
+      "version": "2026.9.4-2",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
         "marked": "18.0.10",
@@ -280,7 +280,7 @@
     "protobufjs",
   ],
   "overrides": {
-    "@anthropic-ai/sdk": "0.120.0",
+    "@anthropic-ai/sdk": "0.123.0",
     "@hono/node-server": "2.1.1",
     "brace-expansion": "5.0.9",
     "esbuild": "0.28.2",
@@ -316,7 +316,7 @@
 
     "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.73", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-F608iUirrCqwvInZYGRRgJWDQj0tt6fNVE9aPagpotLJ5LhC4JbrMFIIZww5MFjb+HRCkpE0+xdI79c30tdVYg=="],
 
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.120.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.123.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@6.0.7", "", { "dependencies": { "@csstools/css-calc": "^3.3.0", "@csstools/css-color-parser": "^4.1.10", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.5.2" } }, "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw=="],
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- A clean checkout no longer fails `bun install --frozen-lockfile`, because the committed lockfile now matches the `@anthropic-ai/sdk` override in `package.json`.
 - Image generation no longer fails with an OpenAI 401 when a placeholder API key is stored for the `openai` provider. A seeded `SK-SENTINEL-DO-NOT-LOG` value is treated as absent instead of as a credential, so resolution falls through to a configured OpenAI-compatible gateway, and image generation is reported as not configured when no gateway exists.
 - Hook trust-state reads no longer fail tool execution when the lock directory cannot be created (`EPERM`/`EACCES`/`EROFS` in sandboxed or read-only children); writers still fail closed on those errors.
 


### PR DESCRIPTION
## Root cause
Commit `d052dbb6b` added the root `package.json` override for `@anthropic-ai/sdk` at `0.123.0` without regenerating `bun.lock`, which still recorded `0.120.0`. As a result, a clean checkout failed `bun install --frozen-lockfile` with `error: lockfile had changes, but lockfile is frozen`.

## RED
Command:
`bun install --frozen-lockfile --dry-run`

```text
bun install v1.4.0 (34cbb9a40)
Resolving dependencies
Resolved, downloaded and extracted [2]
error: lockfile had changes, but lockfile is frozen
note: overrides in package.json changed since bun.lock was saved
note: try re-running without --frozen-lockfile and commit the updated lockfile
```

Exit: 1.

## GREEN
Command:
`bun install --frozen-lockfile --dry-run`

```text
bun install v1.4.0 (34cbb9a40)

$ node scripts/create-bin-stubs.mjs
$ husky
[88.00ms] done
```

Exit: 0, with no frozen-lockfile error.

## Verification
- `cd /Volumes/mengmotaStorage/local-workspaces/senpi-wt/fix-bunlock-anthropic-override && bun install --frozen-lockfile --dry-run`
- `cd /Volumes/mengmotaStorage/local-workspaces/senpi-wt/fix-bunlock-anthropic-override && bun install`
- `cd /Volumes/mengmotaStorage/local-workspaces/senpi-wt/fix-bunlock-anthropic-override && grep -c '0.123.0' bun.lock` (4)
- `cd /Volumes/mengmotaStorage/local-workspaces/senpi-wt/fix-bunlock-anthropic-override && git diff origin/main -- package.json` (empty)
- `cd /Volumes/mengmotaStorage/local-workspaces/senpi-wt/fix-bunlock-anthropic-override && git status --porcelain | grep -v node_modules`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates `bun.lock` so the committed lockfile matches the `@anthropic-ai/sdk` override in `package.json`. Previously, `bun install --frozen-lockfile` failed on clean checkouts with a lockfile-frozen error; now it succeeds.

<sup>Written for commit b7ee9a311d54748c0e909c8fb0143de7664a0642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

