### PR TITLE
feat(terminal): stable monitor ids, a shared session sidecar store, and a restore lease

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Terminal monitors now expose a stable `mon_` id in their result while retaining the runtime `bash_N` handle as `details.bash_id`, and `bash_output`, `bash_input`, `bash_resize`, `kill_bash`, and monitor rearming accept either id.
+
 ### Fixed
 
 - A clean checkout no longer fails `bun install --frozen-lockfile`, because the committed lockfile now matches the `@anthropic-ai/sdk` override in `package.json`.

--- a/packages/coding-agent/src/core/extensions/builtin/monitor-state-event.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/monitor-state-event.ts
@@ -51,6 +51,8 @@ export function isContinuationHoldStateEvent(data: unknown): data is Continuatio
 /** One live watch as broadcast on the monitor state event; mirrors MonitorSnapshotEntry. */
 export interface TerminalMonitorStateMonitorEntry {
 	readonly id: string;
+	/** Stable "mon_" identity surviving runtime id churn; absent in pre-enrichment payloads. */
+	readonly monitorId?: string;
 	readonly description: string;
 	readonly paused: boolean;
 	/** Epoch milliseconds when the watch registered; lets consumers render their own elapsed labels. */

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/manager.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/manager.ts
@@ -28,6 +28,8 @@ export interface CreatedTerminalSession {
 export class TerminalManager {
 	private readonly registry: SessionRegistry<TerminalSession>;
 	private readonly runtimes = new Map<string, TerminalRuntimeSession>();
+	/** Stable "mon_" identities bound to runtime session ids; survives PTY exit, then drops on session prune or teardown. */
+	private readonly monitorIds = new Map<string, string>();
 	private readonly scrollback?: number;
 	private readonly maxSessions: number;
 	private readonly exited = new Set<string>();
@@ -91,6 +93,21 @@ export class TerminalManager {
 		return this.runtimes.get(id) ?? null;
 	}
 
+	/** Bind a stable "mon_" id to its runtime session id; a later restore re-binds the same id. */
+	bindMonitorId(monitorId: string, sessionId: string): void {
+		this.monitorIds.set(monitorId, sessionId);
+	}
+
+	/**
+	 * Resolve a "mon_" monitor id to its current runtime "bash_N" (or "watch_N"), passing a
+	 * runtime id through unchanged; undefined when neither resolves. Bindings intentionally
+	 * outlive PTY exit for a final output read, then drop when the session is pruned or torn down.
+	 */
+	resolveId(idOrMonitorId: string): string | undefined {
+		if (idOrMonitorId.startsWith("mon_")) return this.monitorIds.get(idOrMonitorId);
+		return this.registry.get(idOrMonitorId) ? idOrMonitorId : undefined;
+	}
+
 	list(): { id: string; runtime: TerminalRuntimeSession }[] {
 		const result: { id: string; runtime: TerminalRuntimeSession }[] = [];
 		for (const entry of this.registry.list()) {
@@ -113,6 +130,7 @@ export class TerminalManager {
 		for (const runtime of this.runtimes.values()) runtime.dispose();
 		this.runtimes.clear();
 		this.exited.clear();
+		this.monitorIds.clear();
 	}
 
 	/** Dispose runtime wrappers whose registry entry was pruned (capacity/LRU eviction). */
@@ -123,6 +141,9 @@ export class TerminalManager {
 			runtime.dispose();
 			this.runtimes.delete(id);
 			this.exited.delete(id);
+			for (const [monitorId, sessionId] of this.monitorIds) {
+				if (sessionId === id) this.monitorIds.delete(monitorId);
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/manifest-lease.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/manifest-lease.ts
@@ -1,0 +1,118 @@
+import { mkdir, open, readFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
+
+export type AcquireTerminalLeaseOptions = {
+	dir: string;
+	encodedSessionId: string;
+	pid?: number;
+	now?: () => number;
+	isProcessAlive?: (pid: number) => boolean;
+};
+
+export type AcquireTerminalLeaseResult =
+	| { acquired: true; path: string; pid: number }
+	| { acquired: false; holder: { pid: number; startedAtMs: number } };
+
+type LeaseRecord = { pid: number; startedAtMs: number };
+
+function errorCode(error: unknown): string | undefined {
+	if (typeof error === "object" && error !== null && "code" in error && typeof error.code === "string") {
+		return error.code;
+	}
+	return undefined;
+}
+
+function probeAlive(pid: number, probe?: (pid: number) => boolean): boolean {
+	try {
+		if (probe) return probe(pid);
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const code = errorCode(error);
+		if (code === "EPERM") return true;
+		if (code === "ESRCH") return false;
+		throw error;
+	}
+}
+
+async function readLease(path: string): Promise<LeaseRecord | "missing" | "unparseable"> {
+	let raw: string;
+	try {
+		raw = await readFile(path, "utf8");
+	} catch (error) {
+		if (errorCode(error) === "ENOENT") return "missing";
+		throw error;
+	}
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (typeof parsed !== "object" || parsed === null) return "unparseable";
+		const pid = (parsed as { pid?: unknown }).pid;
+		const startedAtMs = (parsed as { startedAtMs?: unknown }).startedAtMs;
+		if (
+			typeof pid !== "number" ||
+			!Number.isFinite(pid) ||
+			typeof startedAtMs !== "number" ||
+			!Number.isFinite(startedAtMs)
+		) {
+			return "unparseable";
+		}
+		return { pid, startedAtMs };
+	} catch {
+		return "unparseable";
+	}
+}
+
+async function exclusiveCreate(path: string, record: LeaseRecord): Promise<void> {
+	const file = await open(path, "wx");
+	try {
+		await file.writeFile(JSON.stringify(record), "utf8");
+	} finally {
+		await file.close();
+	}
+}
+
+async function unlinkIfPresent(path: string): Promise<void> {
+	try {
+		await unlink(path);
+	} catch (error) {
+		if (errorCode(error) !== "ENOENT") throw error;
+	}
+}
+
+async function tryAcquire(
+	path: string,
+	record: LeaseRecord,
+	isProcessAlive: ((pid: number) => boolean) | undefined,
+	retry: boolean,
+): Promise<AcquireTerminalLeaseResult> {
+	try {
+		await exclusiveCreate(path, record);
+		return { acquired: true, path, pid: record.pid };
+	} catch (error) {
+		if (errorCode(error) !== "EEXIST") throw error;
+		const existing = await readLease(path);
+		const reclaimable =
+			existing === "missing" || existing === "unparseable" || !probeAlive(existing.pid, isProcessAlive);
+		if (reclaimable && retry) {
+			await unlinkIfPresent(path);
+			return tryAcquire(path, record, isProcessAlive, false);
+		}
+		if (existing === "missing" || existing === "unparseable") throw error;
+		return { acquired: false, holder: existing };
+	}
+}
+
+export async function acquireTerminalLease(options: AcquireTerminalLeaseOptions): Promise<AcquireTerminalLeaseResult> {
+	const pid = options.pid ?? process.pid;
+	const startedAtMs = (options.now ?? Date.now)();
+	const path = join(options.dir, `${options.encodedSessionId}.lease`);
+	await mkdir(options.dir, { recursive: true });
+	return tryAcquire(path, { pid, startedAtMs }, options.isProcessAlive, true);
+}
+
+export async function releaseTerminalLease(handle: { path: string; pid: number }): Promise<void> {
+	const existing = await readLease(handle.path);
+	if (existing === "missing" || existing === "unparseable") return;
+	if (existing.pid !== handle.pid) return;
+	await unlinkIfPresent(handle.path);
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { type FSWatcher, watch } from "node:fs";
 import { access, type FileHandle, lstat, open, realpath, stat } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
@@ -28,8 +28,28 @@ export interface MonitorResumeResult {
 	readonly mutedDropped: number;
 }
 
+const MONITOR_ID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/** Allocate a stable monitor identity: "mon_" + 16 Crockford base-32 chars (80 random bits). */
+export function allocateMonitorId(): string {
+	let id = "mon_";
+	let buffer = 0;
+	let bits = 0;
+	for (const byte of randomBytes(10)) {
+		buffer = (buffer << 8) | byte;
+		bits += 8;
+		while (bits >= 5) {
+			bits -= 5;
+			id += MONITOR_ID_ALPHABET[(buffer >> bits) & 31];
+		}
+	}
+	return id;
+}
+
 export interface MonitorSnapshotEntry {
 	readonly id: string;
+	/** Stable "mon_" identity carried alongside the runtime id; always set on live snapshots. */
+	readonly monitorId?: string;
 	readonly description: string;
 	readonly paused: boolean;
 	/** Epoch milliseconds when the watch registered; feeds the footer's live elapsed label. */
@@ -46,6 +66,8 @@ export interface MonitorRegistryOptions {
 export interface RegisterFileMonitorOptions {
 	readonly description: string;
 	readonly path: string;
+	/** Caller-supplied stable identity so a restore can re-bind the same "mon_" id. */
+	readonly monitorId?: string;
 	readonly event: "create" | "modify";
 	readonly timeoutMs: number;
 	readonly cwd: string;
@@ -54,6 +76,8 @@ export interface RegisterFileMonitorOptions {
 
 export interface RegisterMonitorOptions {
 	readonly id: string;
+	/** Caller-supplied stable identity so a restore can re-bind the same "mon_" id. */
+	readonly monitorId?: string;
 	readonly description: string;
 	readonly runtime: TerminalRuntimeSession;
 	readonly filter?: RegExp;
@@ -68,6 +92,8 @@ interface PendingFileRegistration {
 
 interface FileMonitorRecord {
 	readonly id: string;
+	readonly monitorId: string;
+	readonly sessionId: string;
 	readonly description: string;
 	readonly startedAtMs: number;
 	readonly path: string;
@@ -95,6 +121,8 @@ interface FileMonitorRecord {
 
 interface MonitorRecord {
 	readonly id: string;
+	readonly monitorId: string;
+	readonly sessionId: string;
 	readonly description: string;
 	readonly startedAtMs: number;
 	readonly runtime: TerminalRuntimeSession;
@@ -133,13 +161,14 @@ export class MonitorRegistry {
 	snapshot(): readonly MonitorSnapshotEntry[] {
 		return [...this.#records.values(), ...this.#files.values()].map((record) => ({
 			id: record.id,
+			monitorId: record.monitorId,
 			description: record.description,
 			paused: record.paused,
 			startedAtMs: record.startedAtMs,
 		}));
 	}
 
-	async registerFile(options: RegisterFileMonitorOptions): Promise<string> {
+	async registerFile(options: RegisterFileMonitorOptions): Promise<{ id: string; monitorId: string }> {
 		if (this.#disposed) throw new Error("Cannot create file monitor: monitor registry is disposed.");
 		this.#pendingRegistrations += 1;
 		const lifecycle = this.#lifecycle;
@@ -276,6 +305,8 @@ export class MonitorRegistry {
 		}
 		const record: FileMonitorRecord = {
 			id,
+			monitorId: options.monitorId ?? allocateMonitorId(),
+			sessionId: id,
 			description: options.description,
 			startedAtMs: Date.now(),
 			path,
@@ -311,7 +342,7 @@ export class MonitorRegistry {
 			throw new Error(registrationError ?? "Cannot create file monitor: monitor registry is disposed.");
 		}
 		this.#notifyChange();
-		return id;
+		return { id, monitorId: record.monitorId };
 	}
 
 	async stopFile(id: string): Promise<boolean> {
@@ -444,9 +475,11 @@ export class MonitorRegistry {
 		this.#settleFile(record, "watcher completed");
 	}
 
-	register(options: RegisterMonitorOptions): void {
+	register(options: RegisterMonitorOptions): string {
 		const record: MonitorRecord = {
 			id: options.id,
+			monitorId: options.monitorId ?? allocateMonitorId(),
+			sessionId: options.id,
 			description: options.description,
 			startedAtMs: Date.now(),
 			runtime: options.runtime,
@@ -467,6 +500,7 @@ export class MonitorRegistry {
 		record.unsubscribeOutput = record.runtime.onOutput((chunk) => this.#consume(record, chunk));
 		record.unsubscribeExit = record.runtime.session.onExit(() => this.#settle(record));
 		if (record.runtime.exited) this.#settle(record);
+		return record.monitorId;
 	}
 
 	pause(ids: readonly string[]): string[] {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-input.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-input.ts
@@ -28,7 +28,8 @@ export function createBashInputTool(ctx: TerminalToolContext) {
 		promptSnippet: "Send stdin/keys to a live background bash session (REPL steering, ctrl+c, etc.)",
 		parameters: bashInputSchema,
 		async execute(_toolCallId: string, input: BashInputInput, _signal?: AbortSignal): Promise<TerminalToolResult> {
-			const runtime = ctx.manager.get(input.bash_id);
+			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 			if (runtime.exited) return errorResult(`Session ${input.bash_id} is not running; cannot send input.`);
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-input.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-input.ts
@@ -1,6 +1,12 @@
 import { type Static, Type } from "typebox";
 import { encodeKeys, TERMINAL_INPUT_TOOL } from "../shared.ts";
-import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
+import {
+	errorResult,
+	resolveTerminalId,
+	type TerminalToolContext,
+	type TerminalToolResult,
+	textResult,
+} from "./context.ts";
 
 export const bashInputSchema = Type.Object({
 	bash_id: Type.String({ description: "Session id returned by a run_in_background bash call." }),
@@ -28,7 +34,7 @@ export function createBashInputTool(ctx: TerminalToolContext) {
 		promptSnippet: "Send stdin/keys to a live background bash session (REPL steering, ctrl+c, etc.)",
 		parameters: bashInputSchema,
 		async execute(_toolCallId: string, input: BashInputInput, _signal?: AbortSignal): Promise<TerminalToolResult> {
-			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			const sessionId = resolveTerminalId(ctx.manager, input.bash_id);
 			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 			if (runtime.exited) return errorResult(`Session ${input.bash_id} is not running; cannot send input.`);

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
@@ -2,7 +2,13 @@ import { type Static, Type } from "typebox";
 import { formatTerminalToolOutput } from "../output-format.ts";
 import type { TerminalRuntimeSession } from "../runtime-session.ts";
 import { safeRegExp, TERMINAL_OUTPUT_TOOL } from "../shared.ts";
-import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
+import {
+	errorResult,
+	resolveTerminalId,
+	type TerminalToolContext,
+	type TerminalToolResult,
+	textResult,
+} from "./context.ts";
 import { renderBashOutputCall, renderBashOutputResult } from "./render.ts";
 import { describeExit } from "./spawn.ts";
 
@@ -50,7 +56,7 @@ export function createBashOutputTool(ctx: TerminalToolContext) {
 			"Peek at background bash session output (filter, screen view, status); watch patterns with monitor, completion arrives as a notification",
 		parameters: bashOutputSchema,
 		async execute(_toolCallId: string, input: BashOutputInput): Promise<TerminalToolResult> {
-			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			const sessionId = resolveTerminalId(ctx.manager, input.bash_id);
 			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-output.ts
@@ -50,12 +50,13 @@ export function createBashOutputTool(ctx: TerminalToolContext) {
 			"Peek at background bash session output (filter, screen view, status); watch patterns with monitor, completion arrives as a notification",
 		parameters: bashOutputSchema,
 		async execute(_toolCallId: string, input: BashOutputInput): Promise<TerminalToolResult> {
-			const runtime = ctx.manager.get(input.bash_id);
+			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 
-			const monitorEntry = ctx.monitorRegistry?.snapshot().find((entry) => entry.id === input.bash_id);
+			const monitorEntry = ctx.monitorRegistry?.snapshot().find((entry) => entry.id === sessionId);
 			const muted = monitorEntry?.paused === true;
-			const mutedDropped = muted ? (ctx.monitorRegistry?.mutedDropped(input.bash_id) ?? 0) : 0;
+			const mutedDropped = muted ? (ctx.monitorRegistry?.mutedDropped(sessionId) ?? 0) : 0;
 			let mutedNote = "";
 			if (muted) {
 				mutedNote =

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-resize.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-resize.ts
@@ -1,6 +1,12 @@
 import { type Static, Type } from "typebox";
 import { TERMINAL_RESIZE_TOOL } from "../shared.ts";
-import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
+import {
+	errorResult,
+	resolveTerminalId,
+	type TerminalToolContext,
+	type TerminalToolResult,
+	textResult,
+} from "./context.ts";
 
 export const bashResizeSchema = Type.Object({
 	bash_id: Type.String({ description: "Session id returned by a run_in_background bash call." }),
@@ -23,7 +29,7 @@ export function createBashResizeTool(ctx: TerminalToolContext) {
 		promptSnippet: "Resize a background bash session's PTY so TUIs reflow",
 		parameters: bashResizeSchema,
 		async execute(_toolCallId: string, input: BashResizeInput, _signal?: AbortSignal): Promise<TerminalToolResult> {
-			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			const sessionId = resolveTerminalId(ctx.manager, input.bash_id);
 			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 			if (runtime.exited) return errorResult(`Session ${input.bash_id} is not running; cannot resize.`);

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-resize.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/bash-resize.ts
@@ -23,7 +23,8 @@ export function createBashResizeTool(ctx: TerminalToolContext) {
 		promptSnippet: "Resize a background bash session's PTY so TUIs reflow",
 		parameters: bashResizeSchema,
 		async execute(_toolCallId: string, input: BashResizeInput, _signal?: AbortSignal): Promise<TerminalToolResult> {
-			const runtime = ctx.manager.get(input.bash_id);
+			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
 			if (runtime.exited) return errorResult(`Session ${input.bash_id} is not running; cannot resize.`);
 			if (!valid(input.cols) || !valid(input.rows)) {

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/context.ts
@@ -41,6 +41,20 @@ export interface TerminalToolResult {
 	isError?: boolean;
 }
 
+/**
+ * Resolve a stable "mon_" monitor id to its current runtime id (bash_N/watch_N), passing a
+ * runtime id through unchanged. Companion tools may run against a manager that does not
+ * implement `resolveId` (narrower embedder/test managers expose `get` only); such managers
+ * have never seen a `mon_` id, so falling back to the id verbatim preserves the lookup they
+ * already supported. This is the single choke point for that rule — do not inline it.
+ */
+export function resolveTerminalId(
+	manager: Pick<TerminalManager, "get"> & Partial<Pick<TerminalManager, "resolveId">>,
+	id: string,
+): string {
+	return manager.resolveId?.(id) ?? id;
+}
+
 export function textResult(
 	text: string,
 	extra?: { details?: Record<string, unknown>; isError?: boolean },

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/kill-bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/kill-bash.ts
@@ -24,10 +24,11 @@ export function createKillBashTool(ctx: TerminalToolContext) {
 				return textResult(`Killed ${terminalCount + fileCount} session(s).`);
 			}
 			if (!input.bash_id) return errorResult("Provide `bash_id` or set `all:true`.");
-			if (await ctx.monitorRegistry?.stopFile(input.bash_id)) return textResult(`Killed ${input.bash_id}.`);
-			const runtime = ctx.manager.get(input.bash_id);
+			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			if (await ctx.monitorRegistry?.stopFile(sessionId)) return textResult(`Killed ${input.bash_id}.`);
+			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);
-			await ctx.manager.stop(input.bash_id);
+			await ctx.manager.stop(sessionId);
 			return textResult(`Killed ${input.bash_id}.`);
 		},
 	};

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/kill-bash.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/kill-bash.ts
@@ -1,6 +1,12 @@
 import { type Static, Type } from "typebox";
 import { TERMINAL_KILL_TOOL } from "../shared.ts";
-import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
+import {
+	errorResult,
+	resolveTerminalId,
+	type TerminalToolContext,
+	type TerminalToolResult,
+	textResult,
+} from "./context.ts";
 
 export const killBashSchema = Type.Object({
 	bash_id: Type.Optional(Type.String({ description: "Session id to tree-kill." })),
@@ -24,7 +30,7 @@ export function createKillBashTool(ctx: TerminalToolContext) {
 				return textResult(`Killed ${terminalCount + fileCount} session(s).`);
 			}
 			if (!input.bash_id) return errorResult("Provide `bash_id` or set `all:true`.");
-			const sessionId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+			const sessionId = resolveTerminalId(ctx.manager, input.bash_id);
 			if (await ctx.monitorRegistry?.stopFile(sessionId)) return textResult(`Killed ${input.bash_id}.`);
 			const runtime = ctx.manager.get(sessionId);
 			if (!runtime) return errorResult(`No terminal session found with id: ${input.bash_id}`);

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -3,7 +3,13 @@ import { type Static, Type } from "typebox";
 import { APPROVED_MONITOR_PARENT } from "../monitor-permission.ts";
 import { MonitorRegistry } from "../monitor-registry.ts";
 import { DEFAULT_COLS, DEFAULT_ROWS, TERMINAL_MONITOR_TOOL } from "../shared.ts";
-import { errorResult, type TerminalToolContext, type TerminalToolResult, textResult } from "./context.ts";
+import {
+	errorResult,
+	resolveTerminalId,
+	type TerminalToolContext,
+	type TerminalToolResult,
+	textResult,
+} from "./context.ts";
 import { renderMonitorCall } from "./render.ts";
 import { spawnCommandSession } from "./spawn.ts";
 
@@ -174,7 +180,7 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 							: `Re-armed ${resumed.length} paused monitor(s).`,
 					);
 				}
-				const bashId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
+				const bashId = resolveTerminalId(ctx.manager, input.bash_id);
 				const dropped = registry.mutedDropped(bashId);
 				const outcome = registry.rearm(bashId);
 				if (outcome === "not_found") return errorResult(`No active monitor found with id: ${bashId}`);

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -61,7 +61,7 @@ export const monitorSchema = Type.Object({
 		Type.Boolean({ description: "Keep watching until the command exits or kill_bash stops its bash_id." }),
 	),
 	bash_id: Type.Optional(
-		Type.String({ description: "Rearm: paused monitor bash_id to resume; omit to resume all paused monitors." }),
+		Type.String({ description: "Rearm: paused monitor id (mon_ or bash_id) to resume; omit for all paused." }),
 	),
 });
 export type MonitorInput = Static<typeof monitorSchema>;
@@ -123,8 +123,11 @@ async function createMonitor(
 		...(input.persistent ? {} : { timeoutMs: resolveTimeoutMs(input.timeout_ms) }),
 	});
 	ctx.onMonitorRearmed?.(id);
-	registry.register({ id, description: input.description, runtime, filter });
-	return textResult(`Monitor started with ID: ${id}`, { details: { bash_id: id, monitor: true } });
+	const monitorId = registry.register({ id, description: input.description, runtime, filter });
+	ctx.manager.bindMonitorId(monitorId, id);
+	return textResult(`Monitor started with ID: ${monitorId}`, {
+		details: { monitor_id: monitorId, bash_id: id, monitor: true },
+	});
 }
 
 /** Build the PTY-backed monitor tool. Monitor handles share TerminalManager's bash_N namespace. */
@@ -160,8 +163,7 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 		): Promise<TerminalToolResult> {
 			const registry = getRegistry();
 			if (input.action === "rearm") {
-				const bashId = input.bash_id;
-				if (bashId === undefined || bashId.length === 0) {
+				if (input.bash_id === undefined || input.bash_id.length === 0) {
 					const resumed = registry.resume();
 					if (resumed.length === 0) return textResult("No paused monitors to re-arm.");
 					ctx.onMonitorsResumed?.(resumed.map((monitor) => monitor.id));
@@ -172,6 +174,7 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 							: `Re-armed ${resumed.length} paused monitor(s).`,
 					);
 				}
+				const bashId = ctx.manager.resolveId(input.bash_id) ?? input.bash_id;
 				const dropped = registry.mutedDropped(bashId);
 				const outcome = registry.rearm(bashId);
 				if (outcome === "not_found") return errorResult(`No active monitor found with id: ${bashId}`);
@@ -192,7 +195,7 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 				if (!ctx.monitorRegistry)
 					return errorResult("Native file monitors require a lifecycle-owned monitor registry.");
 				try {
-					const id = await ctx.monitorRegistry.registerFile({
+					const { id, monitorId } = await ctx.monitorRegistry.registerFile({
 						description: input.description,
 						path: input.path,
 						event: input.event ?? "create",
@@ -206,8 +209,9 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 								}
 							: {}),
 					});
-					return textResult(`Monitor started with ID: ${id}`, {
-						details: { bash_id: id, watch_id: id, monitor: true },
+					ctx.manager.bindMonitorId(monitorId, id);
+					return textResult(`Monitor started with ID: ${monitorId}`, {
+						details: { monitor_id: monitorId, bash_id: id, monitor: true },
 					});
 				} catch (error) {
 					return errorResult(error instanceof Error ? error.message : String(error));

--- a/packages/coding-agent/src/core/session-sidecar-store.ts
+++ b/packages/coding-agent/src/core/session-sidecar-store.ts
@@ -1,0 +1,188 @@
+/**
+ * Generic atomic, versioned, per-session sidecar store.
+ *
+ * Extracted from the loop store's persistence discipline: a module-level per-file
+ * promise tail serializes read-modify-write cycles, writes go through a temp file
+ * with 0600 permissions and a rename, and parsing fails closed on version or
+ * session mismatches so a corrupt or foreign file never silently resets state.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export class InvalidSidecarStoreError extends Error {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "InvalidSidecarStoreError";
+	}
+}
+
+export class UnsupportedSidecarStoreVersionError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "UnsupportedSidecarStoreVersionError";
+	}
+}
+
+/** Location identity of one sidecar file: a directory plus the session it belongs to. */
+export interface SidecarStoreRef {
+	baseDir: string;
+	sessionId: string;
+}
+
+/** Validates the domain fields of an already version- and session-checked payload. */
+export type SidecarPayloadParser<T> = (raw: unknown, ref: SidecarStoreRef) => T;
+
+export interface CreateSidecarStoreOptions<T> {
+	baseDir: string;
+	sessionId: string;
+	version: number;
+	tempPrefix: string;
+	parse: SidecarPayloadParser<T>;
+}
+
+export interface SidecarStore<T> {
+	filePath: string;
+	read(): Promise<T | null>;
+	write(state: T): Promise<void>;
+	mutate(fn: (current: T | null) => T | Promise<T>): Promise<T>;
+	snapshot(): T | undefined;
+	clear(): void;
+}
+
+const mutationTails = new Map<string, Promise<void>>();
+const snapshots = new Map<string, unknown>();
+
+export function encodedSessionId(sessionId: string): string {
+	return encodeURIComponent(sessionId);
+}
+
+export function sidecarFilePath(ref: SidecarStoreRef): string {
+	return join(ref.baseDir, `${encodedSessionId(ref.sessionId)}.json`);
+}
+
+/**
+ * Creates a per-session store bound to `baseDir/<encoded session id>.json`.
+ * Two stores for the same file share the mutation tail and snapshot cache.
+ */
+export function createSidecarStore<T>(options: CreateSidecarStoreOptions<T>): SidecarStore<T> {
+	const ref: SidecarStoreRef = { baseDir: options.baseDir, sessionId: options.sessionId };
+	const filePath = sidecarFilePath(ref);
+
+	async function read(): Promise<T | null> {
+		let raw: string;
+		try {
+			raw = await readFile(filePath, "utf8");
+		} catch (error) {
+			if (isFileSystemError(error, "ENOENT")) return null;
+			throw error;
+		}
+		const state = parsePayload(raw, options, ref);
+		snapshots.set(filePath, state);
+		return state;
+	}
+
+	async function write(state: T): Promise<void> {
+		await mkdir(dirname(filePath), { recursive: true });
+		await writeAtomic(filePath, `${JSON.stringify(state, null, 2)}\n`, options.tempPrefix);
+		snapshots.set(filePath, state);
+	}
+
+	function mutate(fn: (current: T | null) => T | Promise<T>): Promise<T> {
+		return enqueue(filePath, async () => {
+			const next = await fn(await read());
+			await write(next);
+			return next;
+		});
+	}
+
+	return {
+		filePath,
+		read,
+		write,
+		mutate,
+		snapshot: () => snapshots.get(filePath) as T | undefined,
+		clear: () => {
+			snapshots.delete(filePath);
+		},
+	};
+}
+
+/**
+ * Writes `contents` to `filePath` atomically: a hidden temp file (0600) next to the
+ * target, then a rename over it. On failure the temp file is removed; if that
+ * cleanup also fails, both errors surface as one AggregateError.
+ */
+export async function writeAtomic(filePath: string, contents: string, tempPrefix: string): Promise<void> {
+	const tempPath = join(dirname(filePath), `.${tempPrefix}-${randomUUID()}.tmp`);
+	try {
+		await writeFile(tempPath, contents, { encoding: "utf8", mode: 0o600 });
+		await rename(tempPath, filePath);
+	} catch (error) {
+		try {
+			await rm(tempPath, { force: true });
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[error, cleanupError],
+				"sidecar store write failed and its temporary file could not be removed",
+			);
+		}
+		throw error;
+	}
+}
+
+/**
+ * Parses raw file contents, rejecting malformed JSON, a non-object payload, a
+ * version other than `options.version`, and a sessionId other than the ref's
+ * before handing the payload to the domain parser. Fail closed: never resets.
+ */
+function parsePayload<T>(raw: string, options: CreateSidecarStoreOptions<T>, ref: SidecarStoreRef): T {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw new InvalidSidecarStoreError("sidecar store contains unparseable JSON", { cause: error });
+	}
+	if (!isRecord(parsed)) throw new InvalidSidecarStoreError("sidecar store must be a JSON object");
+	if (parsed.version !== options.version) {
+		throw new UnsupportedSidecarStoreVersionError(
+			`unsupported sidecar store version: ${JSON.stringify(parsed.version)} (expected ${options.version})`,
+		);
+	}
+	if (typeof parsed.sessionId !== "string" || parsed.sessionId.length === 0) {
+		throw new InvalidSidecarStoreError("sidecar store is missing a sessionId");
+	}
+	if (parsed.sessionId !== ref.sessionId) {
+		throw new InvalidSidecarStoreError(
+			`sidecar store sessionId ${parsed.sessionId} does not match the session it was loaded for`,
+		);
+	}
+	return options.parse(parsed, ref);
+}
+
+/**
+ * Serializes operations per file through a promise tail so concurrent callers
+ * cannot interleave their read-modify-write cycles and lose an update.
+ */
+function enqueue<T>(key: string, operation: () => Promise<T>): Promise<T> {
+	const previous = mutationTails.get(key) ?? Promise.resolve();
+	const run = previous.then(operation);
+	const tail = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	mutationTails.set(key, tail);
+	void tail.then(() => {
+		if (mutationTails.get(key) === tail) mutationTails.delete(key);
+	});
+	return run;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFileSystemError(error: unknown, code: string): boolean {
+	return error instanceof Error && "code" in error && error.code === code;
+}

--- a/packages/coding-agent/test/suite/session-sidecar-store.test.ts
+++ b/packages/coding-agent/test/suite/session-sidecar-store.test.ts
@@ -1,0 +1,189 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const renameFault = vi.hoisted(() => ({
+	failOnPathContaining: undefined as string | undefined,
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		rename: async (...args: Parameters<typeof actual.rename>) => {
+			const target = String(args[0]);
+			if (renameFault.failOnPathContaining !== undefined && target.includes(renameFault.failOnPathContaining)) {
+				renameFault.failOnPathContaining = undefined;
+				throw new Error("simulated rename failure");
+			}
+			return actual.rename(...args);
+		},
+	};
+});
+
+import {
+	createSidecarStore,
+	InvalidSidecarStoreError,
+	type SidecarStore,
+	UnsupportedSidecarStoreVersionError,
+} from "../../src/core/session-sidecar-store.ts";
+
+const TEST_VERSION = 1;
+const TEMP_PREFIX = "sidecar";
+
+interface TestState {
+	version: number;
+	sessionId: string;
+	counter: number;
+}
+
+function parseTestState(raw: unknown, ref: { baseDir: string; sessionId: string }): TestState {
+	if (typeof raw !== "object" || raw === null) throw new Error("test state must be an object");
+	const value = raw as { counter?: unknown };
+	if (typeof value.counter !== "number") throw new Error("test state has an invalid counter");
+	return { version: TEST_VERSION, sessionId: ref.sessionId, counter: value.counter };
+}
+
+const tempDirs: string[] = [];
+
+async function tempStore(sessionId: string): Promise<SidecarStore<TestState>> {
+	const dir = await mkdtemp(join(tmpdir(), "senpi-sidecar-store-"));
+	tempDirs.push(dir);
+	return createSidecarStore({
+		baseDir: join(dir, "extensions", "sidecar"),
+		sessionId,
+		version: TEST_VERSION,
+		tempPrefix: TEMP_PREFIX,
+		parse: parseTestState,
+	});
+}
+
+function stateFor(sessionId: string, counter: number): TestState {
+	return { version: TEST_VERSION, sessionId, counter };
+}
+
+async function writeRawFile(store: SidecarStore<TestState>, contents: string): Promise<void> {
+	await mkdir(dirname(store.filePath), { recursive: true });
+	await rm(store.filePath, { force: true });
+	await writeFile(store.filePath, contents, "utf8");
+}
+
+afterEach(async () => {
+	renameFault.failOnPathContaining = undefined;
+	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("sidecar store round trip", () => {
+	it("writes then reads back the same state, with the file mode 0600", async () => {
+		// Given
+		const store = await tempStore("session-round-trip");
+		const state = stateFor("session-round-trip", 7);
+
+		// When
+		await store.write(state);
+
+		// Then
+		expect(await store.read()).toEqual(state);
+		const { stat } = await import("node:fs/promises");
+		const stats = await stat(store.filePath);
+		expect(stats.mode & 0o777).toBe(0o600);
+	});
+});
+
+describe("sidecar store mutation serialization", () => {
+	it("lands all 20 concurrent counter mutations with no lost update", async () => {
+		// Given
+		const store = await tempStore("session-concurrent");
+		const sessionId = "session-concurrent";
+
+		// When: every mutation is started before any of them resolves.
+		const increments = Array.from({ length: 20 }, () =>
+			store.mutate(async (current) => {
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				return stateFor(sessionId, (current?.counter ?? 0) + 1);
+			}),
+		);
+		await Promise.all(increments);
+
+		// Then: the persisted counter reflects all 20 increments.
+		const persisted = await store.read();
+		expect(persisted?.counter).toBe(20);
+	});
+});
+
+describe("sidecar store atomic writes", () => {
+	it("keeps the previous file intact when rename fails", async () => {
+		// Given: a committed state that must survive the failed write.
+		const store = await tempStore("session-atomic");
+		const committed = stateFor("session-atomic", 3);
+		await store.write(committed);
+		const committedRaw = await readFile(store.filePath, "utf8");
+
+		// When: the next write's rename onto the target dies.
+		renameFault.failOnPathContaining = `.${TEMP_PREFIX}-`;
+		const failed = store.write(stateFor("session-atomic", 99));
+
+		// Then: the failure surfaces, the committed file is untouched, and no temp debris remains.
+		await expect(failed).rejects.toThrow("simulated rename failure");
+		expect(await readFile(store.filePath, "utf8")).toBe(committedRaw);
+		const leftovers = await readdir(dirname(store.filePath));
+		expect(leftovers).toEqual([basename(store.filePath)]);
+	});
+});
+
+describe("sidecar store fail-closed parsing", () => {
+	it("rejects a payload with a wrong version instead of resetting it", async () => {
+		// Given
+		const store = await tempStore("session-wrong-version");
+		const raw = `${JSON.stringify({ version: 2, sessionId: "session-wrong-version", counter: 5 })}\n`;
+		await writeRawFile(store, raw);
+
+		// When / Then
+		await expect(store.read()).rejects.toBeInstanceOf(UnsupportedSidecarStoreVersionError);
+		expect(await readFile(store.filePath, "utf8")).toBe(raw);
+	});
+
+	it("rejects a payload whose sessionId mismatches the ref", async () => {
+		// Given
+		const store = await tempStore("session-mismatch");
+		const raw = `${JSON.stringify({ version: TEST_VERSION, sessionId: "someone-else", counter: 5 })}\n`;
+		await writeRawFile(store, raw);
+
+		// When / Then
+		await expect(store.read()).rejects.toBeInstanceOf(InvalidSidecarStoreError);
+		expect(await readFile(store.filePath, "utf8")).toBe(raw);
+	});
+
+	it("rejects malformed JSON instead of resetting the file", async () => {
+		// Given
+		const store = await tempStore("session-corrupt-json");
+		const raw = '{"version":1,"sessionId":"session-corrupt-json",';
+		await writeRawFile(store, raw);
+
+		// When / Then
+		await expect(store.read()).rejects.toBeInstanceOf(InvalidSidecarStoreError);
+		expect(await readFile(store.filePath, "utf8")).toBe(raw);
+	});
+});
+
+describe("sidecar store snapshot cache", () => {
+	it("returns the last written state from snapshot and drops it on clear", async () => {
+		// Given
+		const store = await tempStore("session-snapshot");
+		expect(store.snapshot()).toBeUndefined();
+		const state = stateFor("session-snapshot", 5);
+
+		// When
+		await store.write(state);
+
+		// Then
+		expect(store.snapshot()).toEqual(state);
+
+		// When
+		store.clear();
+
+		// Then
+		expect(store.snapshot()).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-manifest-lease.test.ts
+++ b/packages/coding-agent/test/suite/terminal-manifest-lease.test.ts
@@ -1,0 +1,210 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	acquireTerminalLease,
+	releaseTerminalLease,
+} from "../../src/core/extensions/builtin/terminal/manifest-lease.ts";
+
+const createdDirs: string[] = [];
+
+afterEach(async () => {
+	for (const dir of createdDirs.splice(0)) {
+		await rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function tempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), "senpi-terminal-lease-"));
+	createdDirs.push(dir);
+	return dir;
+}
+
+function epermProbe(): (pid: number) => boolean {
+	return () => {
+		const error = new Error("kill EPERM") as NodeJS.ErrnoException;
+		error.code = "EPERM";
+		throw error;
+	};
+}
+
+function spawnShortLived(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("true", [], { stdio: "ignore" });
+		if (child.pid === undefined) {
+			reject(new Error("spawn produced no pid"));
+			return;
+		}
+		const pid = child.pid;
+		child.once("error", reject);
+		child.once("exit", () => resolve(pid));
+	});
+}
+
+describe("acquireTerminalLease / releaseTerminalLease", () => {
+	it("succeeds on first acquire and writes the caller's pid", async () => {
+		const dir = join(await tempDir(), "nested", "leases");
+		const leasePath = join(dir, "sess-a.lease");
+		const startedAtMs = 1_700_000_000_000;
+		const result = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-a",
+			pid: process.pid,
+			now: () => startedAtMs,
+		});
+
+		expect(result).toEqual({
+			acquired: true,
+			path: leasePath,
+			pid: process.pid,
+		});
+		expect(JSON.parse(await readFile(leasePath, "utf8"))).toEqual({
+			pid: process.pid,
+			startedAtMs,
+		});
+	});
+
+	it("returns the live holder when a second acquire races an exclusive lease", async () => {
+		const dir = await tempDir();
+		const startedAtMs = 1_700_000_000_111;
+		const first = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-b",
+			pid: process.pid,
+			now: () => startedAtMs,
+		});
+		expect(first.acquired).toBe(true);
+
+		const second = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-b",
+			pid: process.pid + 1,
+			now: () => startedAtMs + 1,
+		});
+
+		expect(second).toEqual({
+			acquired: false,
+			holder: { pid: process.pid, startedAtMs },
+		});
+		expect(JSON.parse(await readFile(join(dir, "sess-b.lease"), "utf8"))).toEqual({
+			pid: process.pid,
+			startedAtMs,
+		});
+	});
+
+	it("reclaims a lease file that names a dead pid", async () => {
+		const dir = await tempDir();
+		const deadPid = await spawnShortLived();
+		expect(deadPid).toBeTypeOf("number");
+		const leasePath = join(dir, "sess-c.lease");
+		await writeFile(leasePath, JSON.stringify({ pid: deadPid, startedAtMs: 10 }), "utf8");
+
+		const result = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-c",
+			pid: process.pid,
+			now: () => 99,
+		});
+
+		expect(result).toEqual({ acquired: true, path: leasePath, pid: process.pid });
+		expect(JSON.parse(await readFile(leasePath, "utf8"))).toEqual({
+			pid: process.pid,
+			startedAtMs: 99,
+		});
+	});
+
+	it("does not reclaim a live holder whose startedAtMs is 11 minutes old", async () => {
+		const dir = await tempDir();
+		const startedAtMs = Date.now() - 11 * 60 * 1000;
+		const leasePath = join(dir, "sess-d.lease");
+		await writeFile(leasePath, JSON.stringify({ pid: process.pid, startedAtMs }), "utf8");
+
+		const result = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-d",
+			pid: process.pid + 1,
+			now: () => Date.now(),
+		});
+
+		expect(result).toEqual({
+			acquired: false,
+			holder: { pid: process.pid, startedAtMs },
+		});
+		expect(JSON.parse(await readFile(leasePath, "utf8"))).toEqual({
+			pid: process.pid,
+			startedAtMs,
+		});
+	});
+
+	it("treats an injected EPERM liveness probe as alive and does not reclaim", async () => {
+		const dir = await tempDir();
+		const holderPid = 424_242;
+		const startedAtMs = 1_111;
+		const leasePath = join(dir, "sess-e.lease");
+		await writeFile(leasePath, JSON.stringify({ pid: holderPid, startedAtMs }), "utf8");
+
+		const result = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-e",
+			pid: process.pid,
+			isProcessAlive: epermProbe(),
+		});
+
+		expect(result).toEqual({
+			acquired: false,
+			holder: { pid: holderPid, startedAtMs },
+		});
+		expect(JSON.parse(await readFile(leasePath, "utf8"))).toEqual({
+			pid: holderPid,
+			startedAtMs,
+		});
+	});
+
+	it("releaseTerminalLease unlinks matching pid and leaves an overwritten holder intact", async () => {
+		const dir = await tempDir();
+		const leasePath = join(dir, "sess-f.lease");
+		const acquired = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-f",
+			pid: process.pid,
+			now: () => 50,
+		});
+		expect(acquired).toEqual({ acquired: true, path: leasePath, pid: process.pid });
+		await releaseTerminalLease({ path: leasePath, pid: process.pid });
+		expect(existsSync(leasePath)).toBe(false);
+
+		const overwritten = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-f",
+			pid: process.pid,
+			now: () => 51,
+		});
+		expect(overwritten).toEqual({ acquired: true, path: leasePath, pid: process.pid });
+		const foreign = { pid: process.pid + 7, startedAtMs: 77 };
+		await writeFile(leasePath, JSON.stringify(foreign), "utf8");
+		await releaseTerminalLease({ path: leasePath, pid: process.pid });
+		expect(JSON.parse(await readFile(leasePath, "utf8"))).toEqual(foreign);
+	});
+
+	it("reclaims an unparseable lease file", async () => {
+		const dir = await tempDir();
+		const leasePath = join(dir, "sess-g.lease");
+		await writeFile(leasePath, "not-json{{{", "utf8");
+
+		const result = await acquireTerminalLease({
+			dir,
+			encodedSessionId: "sess-g",
+			pid: process.pid,
+			now: () => 123,
+		});
+
+		expect(result).toEqual({ acquired: true, path: leasePath, pid: process.pid });
+		expect(JSON.parse(await readFile(leasePath, "utf8"))).toEqual({
+			pid: process.pid,
+			startedAtMs: 123,
+		});
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-monitor-external-resume.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-external-resume.test.ts
@@ -3,10 +3,6 @@ import registerTerminalExtension from "../../src/core/extensions/builtin/termina
 import { MonitorRegistry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
 import { createHarness, type Harness } from "./harness.ts";
 
-function resultText(result: { content: Array<{ type: string; text?: string }> }): string {
-	return result.content.find((part) => part.type === "text")?.text ?? "";
-}
-
 describe("terminal monitor external resume", () => {
 	const harnesses: Harness[] = [];
 
@@ -24,7 +20,7 @@ describe("terminal monitor external resume", () => {
 			command: "sleep 30",
 			persistent: true,
 		});
-		const bashId = /bash_\d+/.exec(resultText(started))?.[0];
+		const bashId = String(((started.details ?? {}) as Record<string, unknown>).bash_id ?? "");
 		if (!bashId) throw new Error("Monitor did not return a bash id");
 		const registry = register.mock.instances[0] as MonitorRegistry | undefined;
 		if (!registry) throw new Error("Monitor registry was not captured");
@@ -33,6 +29,7 @@ describe("terminal monitor external resume", () => {
 			registry.pause([bashId]);
 			expect(registry.snapshot()).toContainEqual({
 				id: bashId,
+				monitorId: expect.stringMatching(/^mon_[0-9A-HJKMNP-TV-Z]{16}$/),
 				paused: true,
 				description: "external resume test",
 				startedAtMs: expect.any(Number),
@@ -43,6 +40,7 @@ describe("terminal monitor external resume", () => {
 				.emitInput("generated", undefined, "extension", undefined, "extension-input");
 			expect(registry.snapshot()).toContainEqual({
 				id: bashId,
+				monitorId: expect.stringMatching(/^mon_[0-9A-HJKMNP-TV-Z]{16}$/),
 				paused: true,
 				description: "external resume test",
 				startedAtMs: expect.any(Number),
@@ -51,6 +49,7 @@ describe("terminal monitor external resume", () => {
 			await harness.getExtensionRunner().emitInput("hi", undefined, "interactive", undefined, "user-input");
 			expect(registry.snapshot()).toContainEqual({
 				id: bashId,
+				monitorId: expect.stringMatching(/^mon_[0-9A-HJKMNP-TV-Z]{16}$/),
 				paused: false,
 				description: "external resume test",
 				startedAtMs: expect.any(Number),

--- a/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-footer.test.ts
@@ -149,6 +149,7 @@ describe("MonitorRegistry change notification", () => {
 		expect(snapshots[0]).toEqual([
 			{
 				id: expect.stringContaining("bash"),
+				monitorId: expect.stringMatching(/^mon_[0-9A-HJKMNP-TV-Z]{16}$/),
 				description: "quick echo watch",
 				paused: false,
 				startedAtMs: expect.any(Number),

--- a/packages/coding-agent/test/suite/terminal-monitor-identity.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-identity.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import {
+	allocateMonitorId,
+	type MonitorEvent,
+	MonitorRegistry,
+	type MonitorSummaryEvent,
+} from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import { createBashOutputTool } from "../../src/core/extensions/builtin/terminal/tools/bash-output.ts";
+import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import { createKillBashTool } from "../../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
+import { createMonitorTool, type MonitorInput } from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
+
+const MONITOR_ID_GRAMMAR = /^mon_[0-9A-HJKMNP-TV-Z]{16}$/;
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find((block) => block.type === "text")?.text ?? "";
+}
+
+function summaryEvent(event: MonitorEvent): MonitorSummaryEvent {
+	if (event.type !== "summary") throw new Error("Expected a monitor summary event");
+	return event;
+}
+
+class EventSink {
+	readonly events: MonitorEvent[] = [];
+	readonly #listeners = new Set<(event: MonitorEvent) => void>();
+
+	push(event: MonitorEvent): void {
+		this.events.push(event);
+		for (const listener of this.#listeners) listener(event);
+	}
+
+	waitFor(predicate: (event: MonitorEvent) => boolean, label: string): Promise<MonitorEvent> {
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.#listeners.delete(listener);
+				reject(new Error(`Timed out waiting for ${label}`));
+			}, 5000);
+			const listener = (event: MonitorEvent) => {
+				if (!predicate(event)) return;
+				clearTimeout(timeout);
+				this.#listeners.delete(listener);
+				resolve(event);
+			};
+			this.#listeners.add(listener);
+		});
+	}
+}
+
+describe("terminal monitor identity", () => {
+	let manager: TerminalManager;
+	let registry: MonitorRegistry;
+	let ctx: TerminalToolContext;
+	let sink: EventSink;
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+
+	beforeEach(() => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		manager = new TerminalManager();
+		sink = new EventSink();
+		registry = new MonitorRegistry((event) => sink.push(event));
+		ctx = {
+			manager,
+			cwd: process.cwd(),
+			defaultCols: 120,
+			defaultRows: 40,
+			getEnv: () => ({ ...process.env }),
+			monitorRegistry: registry,
+			onMonitorEvent: (event) => sink.push(event),
+		};
+	});
+
+	afterEach(async () => {
+		registry.dispose();
+		await manager.teardown();
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	it("(a) reports the stable monitor id in the result text and the runtime bash id in details", async () => {
+		const result = await createMonitorTool(ctx).execute("identity-create", {
+			description: "identity shape",
+			command: "sleep 30",
+			persistent: true,
+		} satisfies MonitorInput);
+
+		expect(result.isError).not.toBe(true);
+		expect(firstText(result)).toMatch(/^Monitor started with ID: mon_[0-9A-HJKMNP-TV-Z]{16}$/);
+		const monitorId = /^Monitor started with ID: (mon_\S+)$/.exec(firstText(result))?.[1];
+		const details = (result.details ?? {}) as Record<string, unknown>;
+		expect(String(details.bash_id)).toMatch(/^bash_\d+$/);
+		expect(details.monitor).toBe(true);
+		expect(details.monitor_id).toBe(monitorId);
+	});
+
+	it("(b) kill_bash accepts the monitor id, stops the PTY, and settles the monitor as killed", async () => {
+		const tool = createMonitorTool(ctx);
+		const started = await tool.execute("identity-kill-create", {
+			description: "kill via monitor id",
+			command: "sleep 30",
+			persistent: true,
+		} satisfies MonitorInput);
+		const monitorId = /ID: (mon_\S+)$/.exec(firstText(started))?.[1];
+		const bashId = String(((started.details ?? {}) as Record<string, unknown>).bash_id);
+		if (!monitorId || !/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return ids");
+
+		const settled = sink.waitFor(
+			(event) => event.type === "summary" && event.id === bashId,
+			"killed monitor summary",
+		);
+		const killed = await createKillBashTool(ctx).execute("identity-kill", { bash_id: monitorId });
+
+		expect(firstText(killed)).toContain(`Killed ${monitorId}`);
+		expect(summaryEvent(await settled).summary).toContain("killed");
+		expect(registry.snapshot().some((entry) => entry.id === bashId)).toBe(false);
+		expect(registry.snapshot().some((entry) => entry.monitorId === monitorId)).toBe(false);
+	});
+
+	it("(c) bash_output via the monitor id returns the same output as via the runtime bash id", async () => {
+		const tool = createMonitorTool(ctx);
+		const outputTool = createBashOutputTool(ctx);
+		const firstLine = sink.waitFor(
+			(event) => event.type === "line" && event.line === "IDENTITY_MARK",
+			"first monitor mark",
+		);
+		const secondLine = sink.waitFor(
+			(event) =>
+				event.type === "line" &&
+				event.line === "IDENTITY_MARK" &&
+				sink.events.filter((e) => e.type === "line").length >= 2,
+			"second monitor mark",
+		);
+		const first = await tool.execute("identity-output-a", {
+			description: "shared output a",
+			command: "printf 'IDENTITY_MARK\\n'; sleep 30",
+			persistent: true,
+		} satisfies MonitorInput);
+		const second = await tool.execute("identity-output-b", {
+			description: "shared output b",
+			command: "printf 'IDENTITY_MARK\\n'; sleep 30",
+			persistent: true,
+		} satisfies MonitorInput);
+		const monitorId = /ID: (mon_\S+)$/.exec(firstText(first))?.[1];
+		const bashId = String(((first.details ?? {}) as Record<string, unknown>).bash_id);
+		if (!monitorId || !/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return ids");
+		const otherBashId = String(((second.details ?? {}) as Record<string, unknown>).bash_id);
+		await Promise.all([firstLine, secondLine]);
+
+		const viaMonitorId = await outputTool.execute("identity-output-mon", { bash_id: monitorId });
+		const viaBashId = await outputTool.execute("identity-output-bash", { bash_id: otherBashId });
+
+		expect(firstText(viaMonitorId)).toBe(firstText(viaBashId));
+		expect(firstText(viaMonitorId)).toContain("IDENTITY_MARK");
+		expect(viaMonitorId.details).toEqual(viaBashId.details);
+	});
+
+	it("(d) monitor rearm accepts the monitor id of a paused monitor", async () => {
+		const tool = createMonitorTool(ctx);
+		const started = await tool.execute("identity-rearm-create", {
+			description: "rearm via monitor id",
+			command: "sleep 30",
+			persistent: true,
+		} satisfies MonitorInput);
+		const monitorId = /ID: (mon_\S+)$/.exec(firstText(started))?.[1];
+		const bashId = String(((started.details ?? {}) as Record<string, unknown>).bash_id);
+		if (!monitorId || !/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return ids");
+
+		expect(registry.pause([bashId])).toEqual([bashId]);
+		expect(registry.snapshot().find((entry) => entry.id === bashId)?.paused).toBe(true);
+
+		const rearmed = await tool.execute("identity-rearm", {
+			action: "rearm",
+			bash_id: monitorId,
+		} satisfies MonitorInput);
+
+		expect(rearmed.isError).not.toBe(true);
+		expect(firstText(rearmed)).toContain("re-armed");
+		expect(registry.snapshot().find((entry) => entry.id === bashId)?.paused).toBe(false);
+	});
+
+	it("(e) an unknown monitor id yields exactly the missing-session error", async () => {
+		const outputTool = createBashOutputTool(ctx);
+		const result = await outputTool.execute("identity-unknown", { bash_id: "mon_0000000000000000" });
+
+		expect(result.isError).toBe(true);
+		expect(firstText(result)).toBe("No terminal session found with id: mon_0000000000000000");
+	});
+
+	it("(f) allocates 1000 distinct monitor ids that all match the grammar", () => {
+		const ids = Array.from({ length: 1000 }, () => allocateMonitorId());
+
+		expect(new Set(ids).size).toBe(1000);
+		for (const id of ids) expect(id).toMatch(MONITOR_ID_GRAMMAR);
+	});
+
+	it("re-binds a caller-supplied monitorId so a later restore keeps the same identity", async () => {
+		const started = await createMonitorTool(ctx).execute("identity-restore-create", {
+			description: "restore target",
+			command: "sleep 30",
+			persistent: true,
+		} satisfies MonitorInput);
+		const bashId = String(((started.details ?? {}) as Record<string, unknown>).bash_id);
+		const runtime = manager.get(bashId);
+		if (!runtime) throw new Error("Monitor runtime missing");
+
+		const restored = new MonitorRegistry(() => {});
+		const monitorId = "mon_0123456789ABCDEFG";
+		const rebound = restored.register({ id: bashId, monitorId, description: "restored", runtime });
+		ctx.manager.bindMonitorId(rebound, bashId);
+
+		expect(rebound).toBe(monitorId);
+		expect(restored.snapshot()[0]?.monitorId).toBe(monitorId);
+		expect(restored.snapshot()[0]?.id).toBe(bashId);
+		expect(manager.resolveId(monitorId)).toBe(bashId);
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-monitor-state-event.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor-state-event.test.ts
@@ -12,10 +12,6 @@ interface MonitorStateEvent {
 	}>;
 }
 
-function resultText(result: { content?: Array<{ type: string; text?: string }> }): string {
-	return result.content?.find((part) => part.type === "text")?.text ?? "";
-}
-
 describe("terminal monitor liveness event", () => {
 	const harnesses: Harness[] = [];
 
@@ -55,8 +51,8 @@ describe("terminal monitor liveness event", () => {
 			command: "sleep 30",
 			persistent: true,
 		});
-		const bashId = /bash_\d+/.exec(resultText(started))?.[0];
-		if (!bashId) throw new Error("Monitor did not return a bash id");
+		const bashId = String((started.details as { bash_id?: string } | undefined)?.bash_id ?? "");
+		if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash id");
 
 		try {
 			expect(states).toContainEqual({
@@ -93,8 +89,8 @@ describe("terminal monitor liveness event", () => {
 				command: "sleep 30",
 				persistent: true,
 			});
-			const bashId = /bash_\d+/.exec(resultText(started))?.[0];
-			if (!bashId) throw new Error("Monitor did not return a bash id");
+			const bashId = String((started.details as { bash_id?: string } | undefined)?.bash_id ?? "");
+			if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash id");
 
 			try {
 				expect(rpcEvents).toContainEqual({

--- a/packages/coding-agent/test/suite/terminal-monitor.test.ts
+++ b/packages/coding-agent/test/suite/terminal-monitor.test.ts
@@ -139,9 +139,11 @@ describe("terminal monitor tool", () => {
 		});
 		const first = await tool.execute("monitor-rearm-all-a", { description: "paused a", command: "sleep 30" });
 		const second = await tool.execute("monitor-rearm-all-b", { description: "paused b", command: "sleep 30" });
-		const firstId = /ID: (bash_\d+)/.exec(firstText(first))?.[1];
-		const secondId = /ID: (bash_\d+)/.exec(firstText(second))?.[1];
-		if (!firstId || !secondId) throw new Error("Monitors did not return bash_ids");
+		const firstId = String(first.details?.bash_id ?? "");
+		const secondId = String(second.details?.bash_id ?? "");
+		if (!/^bash_\d+$/.test(firstId) || !/^bash_\d+$/.test(secondId)) {
+			throw new Error("Monitors did not return bash_ids");
+		}
 
 		expect(registry.pause([firstId, secondId])).toEqual([firstId, secondId]);
 		expect(registry.resume()).toEqual([
@@ -165,9 +167,9 @@ describe("terminal monitor tool", () => {
 			command: "printf 'ONE\\nTWO\\n'",
 		});
 
-		const bashId = /ID: (bash_\d+)/.exec(firstText(result))?.[1];
-		expect(bashId).toBeDefined();
-		expect(manager.get(bashId!)).not.toBeNull();
+		const bashId = String(result.details?.bash_id ?? "");
+		expect(bashId).toMatch(/^bash_\d+$/);
+		expect(manager.get(bashId)).not.toBeNull();
 		await summary;
 		expect(sink.events.map((event) => (event.type === "line" ? event.line : event.summary))).toEqual([
 			"ONE",
@@ -184,8 +186,8 @@ describe("terminal monitor tool", () => {
 			command: "printf 'KEEP_ONE\\nDROP\\nKEEP_TWO\\n'",
 			filter: "^KEEP",
 		});
-		const bashId = /ID: (bash_\d+)/.exec(firstText(result))?.[1];
-		if (!bashId) throw new Error("Monitor did not return a bash_id");
+		const bashId = String(result.details?.bash_id ?? "");
+		if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash_id");
 
 		await summary;
 		expect(sink.events.filter((event) => event.type === "line").map((event) => event.line)).toEqual([
@@ -206,7 +208,7 @@ describe("terminal monitor tool", () => {
 			command: "sleep 30",
 			timeout_ms: 50,
 		});
-		expect(firstText(timedResult)).toMatch(/ID: bash_\d+/);
+		expect(firstText(timedResult)).toMatch(/^Monitor started with ID: mon_[0-9A-HJKMNP-TV-Z]{16}$/);
 		expect(summaryEvent(await timedOut).summary).toContain("timed_out");
 
 		const persistent = sink.waitFor(
@@ -226,8 +228,8 @@ describe("terminal monitor tool", () => {
 		const tool = createMonitorTool(ctx);
 		const ended = sink.waitFor((event) => event.type === "summary", "killed monitor summary");
 		const started = await tool.execute("monitor-live", { description: "live", command: "sleep 30" });
-		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
-		if (!bashId) throw new Error("Monitor did not return a bash_id");
+		const bashId = String(started.details?.bash_id ?? "");
+		if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash_id");
 
 		const rearm = await tool.execute("monitor-rearm", { action: "rearm", bash_id: bashId });
 		expect(firstText(rearm)).toContain("not paused");
@@ -241,9 +243,11 @@ describe("terminal monitor tool", () => {
 		const tool = createMonitorTool({ ...ctx, monitorRegistry: registry });
 		const first = await tool.execute("monitor-paused-exit-a", { description: "paused a", command: "sleep 30" });
 		const second = await tool.execute("monitor-paused-exit-b", { description: "paused b", command: "sleep 30" });
-		const firstId = /ID: (bash_\d+)/.exec(firstText(first))?.[1];
-		const secondId = /ID: (bash_\d+)/.exec(firstText(second))?.[1];
-		if (!firstId || !secondId) throw new Error("Monitors did not return bash_ids");
+		const firstId = String(first.details?.bash_id ?? "");
+		const secondId = String(second.details?.bash_id ?? "");
+		if (!/^bash_\d+$/.test(firstId) || !/^bash_\d+$/.test(secondId)) {
+			throw new Error("Monitors did not return bash_ids");
+		}
 		const ended = sink.waitFor(
 			(event) => event.type === "summary" && event.id === firstId,
 			"muted monitor completion",
@@ -264,8 +268,8 @@ describe("terminal monitor tool", () => {
 			filter: "^KEEP",
 			persistent: true,
 		});
-		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
-		if (!bashId) throw new Error("Monitor did not return a bash_id");
+		const bashId = String(started.details?.bash_id ?? "");
+		if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash_id");
 		const output = manager.get(bashId);
 		if (!output) throw new Error("Monitor runtime was not retained");
 		expect(registry.pause([bashId])).toEqual([bashId]);
@@ -301,8 +305,8 @@ describe("terminal monitor tool", () => {
 				filter: "^KEEP",
 				persistent: true,
 			});
-			const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
-			if (!bashId) throw new Error("Monitor did not return a bash_id");
+			const bashId = String(started.details?.bash_id ?? "");
+			if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash_id");
 			const output = manager.get(bashId);
 			if (!output) throw new Error("Monitor runtime was not retained");
 			expect(registry.pause([bashId])).toEqual([bashId]);
@@ -341,8 +345,8 @@ describe("terminal monitor tool", () => {
 				description: "resume peek",
 				command: "sleep 30",
 			});
-			const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
-			if (!bashId) throw new Error("Monitor did not return a bash_id");
+			const bashId = String(started.details?.bash_id ?? "");
+			if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash_id");
 			expect(registry.pause([bashId])).toEqual([bashId]);
 			expect(registry.resume([bashId])).toEqual([{ id: bashId, mutedDropped: 0 }]);
 
@@ -379,8 +383,8 @@ describe("terminal monitor tool", () => {
 		const tool = createMonitorTool({ ...ctx, monitorRegistry: registry, onMonitorRearmed: (id) => (rearmedId = id) });
 		const ended = sink.waitFor((event) => event.type === "summary", "rearmed monitor completion");
 		const started = await tool.execute("monitor-paused", { description: "paused", command: "sleep 30" });
-		const bashId = /ID: (bash_\d+)/.exec(firstText(started))?.[1];
-		if (!bashId) throw new Error("Monitor did not return a bash_id");
+		const bashId = String(started.details?.bash_id ?? "");
+		if (!/^bash_\d+$/.test(bashId)) throw new Error("Monitor did not return a bash_id");
 
 		expect(registry.pauseAll()).toEqual([bashId]);
 		const rearmed = await tool.execute("monitor-resume", { action: "rearm", bash_id: bashId });
@@ -420,8 +424,8 @@ describe("terminal monitor tool", () => {
 				description: "artifact",
 				path: join(root, "artifact"),
 			} as MonitorInput);
-			const id = /ID: (watch_\d+)/.exec(firstText(started))?.[1];
-			expect(id).toMatch(/^watch_/);
+			const id = String(started.details?.bash_id ?? "");
+			expect(id).toMatch(/^watch_\d+$/);
 			await writeFile(join(root, "artifact"), "created");
 			expect((await line).type).toBe("line");
 		} finally {
@@ -854,8 +858,8 @@ describe("terminal monitor tool", () => {
 				description: "artifact",
 				path: join(root, "artifact"),
 			} as MonitorInput);
-			const id = /ID: (watch_\d+)/.exec(firstText(started))?.[1];
-			expect(id).toBeDefined();
+			const id = String(started.details?.bash_id ?? "");
+			expect(id).toMatch(/^watch_\d+$/);
 			const killed = await createKillBashTool({ ...ctx, monitorRegistry: registry }).execute("kill", {
 				bash_id: id,
 			});
@@ -1006,15 +1010,14 @@ describe("terminal monitor tool", () => {
 				if (created.runtime.exited) resolve();
 				else created.runtime.session.onExit(() => resolve());
 			});
-			await expect(
-				registry.registerFile({
-					description: "after exit",
-					path: join(root, "new"),
-					event: "create",
-					timeoutMs: 1000,
-					cwd: root,
-				}),
-			).resolves.toMatch(/^watch_/);
+			const { id } = await registry.registerFile({
+				description: "after exit",
+				path: join(root, "new"),
+				event: "create",
+				timeoutMs: 1000,
+				cwd: root,
+			});
+			expect(id).toMatch(/^watch_/);
 		} finally {
 			await registry.stopAllFiles();
 			await limited.teardown();

--- a/packages/coding-agent/test/suite/terminal-reload-survival.test.ts
+++ b/packages/coding-agent/test/suite/terminal-reload-survival.test.ts
@@ -11,6 +11,7 @@ type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unk
 interface ToolResultLike {
 	content: Array<{ type: string; text?: string }>;
 	isError?: boolean;
+	details?: { bash_id?: string };
 }
 
 interface ToolLike {
@@ -102,10 +103,10 @@ function firstText(result: ToolResultLike): string {
 	return result.content.find((block) => block.type === "text")?.text ?? "";
 }
 
-function extractBashId(text: string): string {
-	const match = /ID: (bash_\d+)/.exec(text);
-	if (!match?.[1]) throw new Error(`No bash id in tool result: ${text}`);
-	return match[1];
+function extractBashId(result: ToolResultLike | undefined): string {
+	const bashId = result?.details?.bash_id;
+	if (!bashId) throw new Error(`No bash id in tool result details: ${JSON.stringify(result?.details)}`);
+	return bashId;
 }
 
 describe("terminal extension — background state survives reload", () => {
@@ -171,7 +172,8 @@ describe("terminal extension — background state survives reload", () => {
 			persistent: true,
 		});
 		expect(created?.isError).toBeFalsy();
-		extractBashId(firstText(created ?? { content: [] }));
+		expect(firstText(created ?? { content: [] })).toMatch(/^Monitor started with ID: mon_[0-9A-HJKMNP-TV-Z]{16}$/);
+		extractBashId(created);
 
 		const gen2 = await reloadInto(gen1);
 
@@ -192,7 +194,7 @@ describe("terminal extension — background state survives reload", () => {
 			run_in_background: true,
 		});
 		expect(created?.isError).toBeFalsy();
-		const bashId = extractBashId(firstText(created ?? { content: [] }));
+		const bashId = extractBashId(created);
 
 		const gen2 = await reloadInto(gen1);
 
@@ -212,7 +214,7 @@ describe("terminal extension — background state survives reload", () => {
 			command: `sh -c 'while [ ! -e "${trigger}" ]; do sleep 0.05; done; echo finishing-now'`,
 			run_in_background: true,
 		});
-		const bashId = extractBashId(firstText(created ?? { content: [] }));
+		const bashId = extractBashId(created);
 
 		const gen2 = await reloadInto(gen1);
 

--- a/packages/coding-agent/test/suite/terminal-resumption-channel-state.test.ts
+++ b/packages/coding-agent/test/suite/terminal-resumption-channel-state.test.ts
@@ -16,6 +16,7 @@ type EventListener = (data: unknown) => void;
 interface ToolResultLike {
 	content: Array<{ type: string; text?: string }>;
 	isError?: boolean;
+	details?: { bash_id?: string };
 }
 
 interface ToolLike {
@@ -121,14 +122,10 @@ function createRunner(): FakeRunner {
 	};
 }
 
-function firstText(result: ToolResultLike | undefined): string {
-	return result?.content.find((block) => block.type === "text")?.text ?? "";
-}
-
 function extractBashId(result: ToolResultLike | undefined): string {
-	const match = /ID: (bash_\d+)/.exec(firstText(result));
-	if (!match?.[1]) throw new Error(`No bash id in tool result: ${firstText(result)}`);
-	return match[1];
+	const bashId = result?.details?.bash_id;
+	if (!bashId) throw new Error(`No bash id in tool result details: ${JSON.stringify(result?.details)}`);
+	return bashId;
 }
 
 function makeContext(cwd: string, sessionId: string): ExtensionContext {


### PR DESCRIPTION
## What

Phase 1 of the durable-monitor work: the groundwork that lets a later phase persist terminal state, plus the one user-visible piece it needs — a **stable monitor id**.

- `core/session-sidecar-store.ts` (new): one versioned, atomic, per-session sidecar store — 0600 temp file + rename, a per-file promise tail serializing read-modify-write cycles, a snapshot cache, and fail-closed parsing (wrong version / mismatched `sessionId` / malformed JSON all raise instead of silently resetting). Extracted from the loop store's semantics so `loop/store.ts` and `goal/store.ts` can migrate onto it next and stop carrying two copies of the same mutation tail.
- `terminal/manifest-lease.ts` (new): an exclusive per-session restore lease via `open(path, "wx")`. `process.kill(pid, 0)` decides liveness — no throw **and `EPERM`** mean ALIVE, only `ESRCH` means dead — so a dead holder is reclaimed once while a live holder never is. There is deliberately **no age-based stale rule**, because an age heuristic can evict a healthy owner.
- Stable monitor identity: a monitor now carries `mon_<16 Crockford base-32>` alongside its runtime `bash_N`. The monitor tool reports the stable id and still returns the runtime handle as `details.bash_id`; `TerminalManager.resolveId()` maps between them, and `bash_output`, `bash_input`, `bash_resize`, `kill_bash`, and monitor rearming accept **either** id, echoing back exactly what the caller passed on error.

## Why

`bash_N` is a PTY slot number: it is reallocated and cannot survive a process restart, so it is unusable as the handle for the durable terminal manifest that follows. Persisting an ephemeral handle is the classic mistake here (etcd separates a watch id from its revision for the same reason).

Bindings live and die with their session: they intentionally **outlive PTY exit** so a final `bash_output` read still resolves, and are dropped when the session is pruned or the manager is torn down.

## Zero prompt growth

No tool parameter and no action value were added. The monitor schema's `description` literals in fact **shrink from 1476 to 1474 bytes**.

## Verification

Every new test is **mutation-proven** by an independent verifier that did not write the code: break the exact production hunk the test names, watch that assertion fail, restore, watch it pass. 13 probes, 13 detected their regression, 0 false coverage — including "treat `EPERM` as dead", "never reclaim a dead pid", "neuter `resolveId`", "revert the reported id", and "return a constant monitor id".

```
bunx vitest --run <the 12 affected suites>   ->  12 files, 164 tests passed
bunx tsc --noEmit                            ->  clean
```

Two pre-existing tests pinned the old contract and were **migrated, not weakened**: the external-resume suite now reads `details.bash_id` instead of regexing the result text, and the footer suite keeps its strict `toEqual` while *adding* a `mon_` grammar matcher. No `.skip`, `.only`, `xfail`, or loosened assertion anywhere (grep-verified).

## Follow-on

Phase 2 migrates `loop/store.ts` and `goal/store.ts` onto the new primitive and adds the per-session terminal manifest plus a single resume report.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives terminal monitors a stable `mon_` id that survives restarts, and lays the groundwork for persisting terminal state with a shared sidecar store and an exclusive restore lease.

- Adds `core/session-sidecar-store.ts`: a versioned, atomic, per-session store with fail-closed parsing, extracted from the loop store's semantics so `loop/store.ts` and `goal/store.ts` can migrate onto it later.
- Adds `terminal/manifest-lease.ts`: an exclusive per-session lease via `open(path, "wx")`; `EPERM` counts as alive, only `ESRCH` allows reclaiming a dead holder, and there is no age-based stale rule.
- Monitors now report `mon_<16 Crockford base-32>` in results while still exposing the runtime handle as `details.bash_id`; `bash_output`, `bash_input`, `bash_resize`, `kill_bash`, and monitor rearming accept either id through a single resolver that passes ids through for managers without `resolveId`, echoing back what the caller passed on error.
- Bindings outlive PTY exit so a final `bash_output` read resolves, then drop when the session is pruned or the manager is torn down.
- No tool parameters or action values were added; the monitor schema's description literals shrink from 1476 to 1474 bytes.
- Tests pinning the old text-based id contract now read `details.bash_id`, with assertions kept or strengthened; all new tests are mutation-proven.

<sup>Written for commit ad9a74f920b5eefedf146dcbe36f633f8fdb888c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

