### PR TITLE
feat(terminal): record terminal state per session and report it once on startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Terminal monitors and background Bash sessions are now recorded per session, and a fresh startup reports what was carried over, lost, expired, or unreadable in exactly one notification instead of silently dropping the state; durable watches are reported as lost rather than resumed for now, while reloads continue preserving live terminal state without this report.
+
 ### Changed
 
 - Terminal monitors now expose a stable `mon_` id in their result while retaining the runtime `bash_N` handle as `details.bash_id`, and `bash_output`, `bash_input`, `bash_resize`, `kill_bash`, and monitor rearming accept either id.

--- a/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/goal/store.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { serializeByKey } from "../../../session-sidecar-store.ts";
 import { GoalAlreadyExistsError, GoalNotFoundError } from "./errors.ts";
 import { encodedThreadId, goalFilePath, readGoalFile, writeGoalFile } from "./persistence.ts";
 import { transitionGoalStatus } from "./transitions.ts";
@@ -15,23 +16,6 @@ import type {
 import { resolveTokenBudget, validateObjective, validateTokenBudget } from "./validation.ts";
 
 export { goalFilePath };
-
-const goalMutationTails = new Map<string, Promise<void>>();
-
-function enqueueGoalMutation<T>(ref: GoalStoreRef, mutation: () => Promise<T>): Promise<T> {
-	const key = goalFilePath(ref);
-	const previous = goalMutationTails.get(key) ?? Promise.resolve();
-	const run = previous.then(mutation);
-	const tail = run.then(
-		() => undefined,
-		() => undefined,
-	);
-	goalMutationTails.set(key, tail);
-	void tail.then(() => {
-		if (goalMutationTails.get(key) === tail) goalMutationTails.delete(key);
-	});
-	return run;
-}
 
 export function goalHistoryFilePath(ref: GoalStoreRef): string {
 	return join(ref.baseDir, `${encodedThreadId(ref)}.history.jsonl`);
@@ -50,11 +34,11 @@ export async function readGoal(ref: GoalStoreRef): Promise<Goal | null> {
 }
 
 export async function writeGoal(ref: GoalStoreRef, goal: Goal | null): Promise<void> {
-	await enqueueGoalMutation(ref, () => writeGoalFile(ref, goal));
+	await serializeByKey(goalFilePath(ref), () => writeGoalFile(ref, goal));
 }
 
 export async function createGoal(ref: GoalStoreRef, objective: string, tokenBudget?: number): Promise<Goal> {
-	return enqueueGoalMutation(ref, async () => {
+	return serializeByKey(goalFilePath(ref), async () => {
 		const validatedObjective = validateObjective(objective, objectiveFullTextFileName(ref));
 		const current = await readGoalFile(ref);
 		if (current !== null && current.status !== "complete") {
@@ -87,7 +71,7 @@ export async function updateGoal(
 	update: GoalUpdate,
 	source: GoalUpdateSource = "model",
 ): Promise<Goal> {
-	return enqueueGoalMutation(ref, async () => {
+	return serializeByKey(goalFilePath(ref), async () => {
 		const current = await readGoalFile(ref);
 		if (!current) throw new GoalNotFoundError("cannot update goal: no goal exists");
 
@@ -158,7 +142,7 @@ async function writeFullObjectiveText(ref: GoalStoreRef, objective: string): Pro
 }
 
 export async function clearGoal(ref: GoalStoreRef): Promise<boolean> {
-	return enqueueGoalMutation(ref, async () => {
+	return serializeByKey(goalFilePath(ref), async () => {
 		const hadGoal = (await readGoalFile(ref)) !== null;
 		await writeGoalFile(ref, null);
 		return hadGoal;
@@ -172,7 +156,7 @@ export async function accountGoalUsage(
 	mode: GoalAccountingMode = "active",
 	expectedGoalId?: string,
 ): Promise<Goal | null> {
-	return enqueueGoalMutation(ref, async () => {
+	return serializeByKey(goalFilePath(ref), async () => {
 		const goal = await readGoalFile(ref);
 		if (!goal || (expectedGoalId !== undefined && goal.id !== expectedGoalId) || !canAccountGoalUsage(goal, mode)) {
 			return goal;
@@ -194,7 +178,7 @@ export async function recordContinuationDelivered(
 	expectedGoalId?: string,
 	options: { countUnattended?: boolean } = {},
 ): Promise<Goal | null> {
-	return enqueueGoalMutation(ref, async () => {
+	return serializeByKey(goalFilePath(ref), async () => {
 		const goal = await readGoalFile(ref);
 		if (!goal || (expectedGoalId !== undefined && goal.id !== expectedGoalId)) return null;
 		const next: Goal = {
@@ -212,7 +196,7 @@ export async function resetContinuationStreak(
 	ref: GoalStoreRef,
 	options: { unattended?: boolean } = {},
 ): Promise<Goal | null> {
-	return enqueueGoalMutation(ref, async () => {
+	return serializeByKey(goalFilePath(ref), async () => {
 		const goal = await readGoalFile(ref);
 		if (!goal) return goal;
 		const next: Goal = { ...goal, consecutiveContinuations: 0 };

--- a/packages/coding-agent/src/core/extensions/builtin/loop/store.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/loop/store.ts
@@ -1,19 +1,26 @@
 /**
  * Atomic, versioned, per-session sidecar store for `/loop` state.
  *
- * Mirrors the goal store's persistence discipline (temp file + rename, per-file mutation
- * serialization, strict versioned parsing) because scheduler state must never be half
- * written or silently reset: a corrupt file arms nothing and surfaces a typed error so
- * the extension can end affected loops with `error` instead of guessing.
+ * Persistence (temp file + rename, per-file mutation serialization, envelope
+ * version/session checks) lives in the shared session sidecar primitive. This
+ * module supplies the loop domain parser and keeps the historical exported
+ * surface so callers continue to catch {@link InvalidLoopStoreError} /
+ * {@link UnsupportedLoopStoreVersionError} by name.
  *
  * Session custom entries are deliberately NOT the authoritative store: they are branch
  * nodes, so a globally scanned "latest" entry can come from an abandoned branch, while
  * loop schedules are session-scoped.
  */
 
-import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import {
+	createSidecarStore,
+	encodedSessionId as encodeSidecarSessionId,
+	InvalidSidecarStoreError,
+	type SidecarStore,
+	type SidecarStoreRef,
+	sidecarFilePath,
+	UnsupportedSidecarStoreVersionError,
+} from "../../../session-sidecar-store.ts";
 import {
 	type CronEntry,
 	type DynamicCronEntry,
@@ -46,14 +53,14 @@ import {
 	type SentinelDeliveryState,
 } from "./types.ts";
 
-export class InvalidLoopStoreError extends Error {
+export class InvalidLoopStoreError extends InvalidSidecarStoreError {
 	constructor(message: string, options?: { cause?: unknown }) {
 		super(message, options);
 		this.name = "InvalidLoopStoreError";
 	}
 }
 
-export class UnsupportedLoopStoreVersionError extends Error {
+export class UnsupportedLoopStoreVersionError extends UnsupportedSidecarStoreVersionError {
 	constructor(message: string) {
 		super(message);
 		this.name = "UnsupportedLoopStoreVersionError";
@@ -63,19 +70,46 @@ export class UnsupportedLoopStoreVersionError extends Error {
 /** Mutation callback. May be async; its result becomes the next persisted state. */
 export type LoopStateMutation = (current: LoopState) => LoopState | Promise<LoopState>;
 
-const mutationTails = new Map<string, Promise<void>>();
-const snapshots = new Map<string, LoopState>();
+const stores = new Map<string, SidecarStore<LoopState>>();
 
 export function encodedSessionId(ref: LoopStoreRef): string {
-	return encodeURIComponent(ref.sessionId);
+	return encodeSidecarSessionId(ref.sessionId);
 }
 
 export function loopStateFilePath(ref: LoopStoreRef): string {
-	return join(ref.baseDir, `${encodedSessionId(ref)}.json`);
+	return sidecarFilePath(ref);
 }
 
 export function emptyLoopState(sessionId: string): LoopState {
 	return { version: LOOP_STATE_VERSION, sessionId, entries: {}, activeDynamicId: null, updatedAt: 0 };
+}
+
+function storeFor(ref: LoopStoreRef): SidecarStore<LoopState> {
+	const filePath = loopStateFilePath(ref);
+	const existing = stores.get(filePath);
+	if (existing !== undefined) return existing;
+	const store = createSidecarStore<LoopState>({
+		baseDir: ref.baseDir,
+		sessionId: ref.sessionId,
+		version: LOOP_STATE_VERSION,
+		tempPrefix: "loop",
+		parse: parseLoopPayload,
+	});
+	stores.set(filePath, store);
+	return store;
+}
+
+function remapLoopStoreError(error: unknown): never {
+	if (error instanceof InvalidLoopStoreError || error instanceof UnsupportedLoopStoreVersionError) {
+		throw error;
+	}
+	if (error instanceof UnsupportedSidecarStoreVersionError) {
+		throw new UnsupportedLoopStoreVersionError(error.message.replaceAll("sidecar store", "loop store"));
+	}
+	if (error instanceof InvalidSidecarStoreError) {
+		throw new InvalidLoopStoreError(error.message.replaceAll("sidecar store", "loop store"), { cause: error });
+	}
+	throw error;
 }
 
 /**
@@ -84,16 +118,11 @@ export function emptyLoopState(sessionId: string): LoopState {
  * unusable state so callers fail closed rather than resetting a user's schedule.
  */
 export async function readLoopState(ref: LoopStoreRef): Promise<LoopState | null> {
-	let raw: string;
 	try {
-		raw = await readFile(loopStateFilePath(ref), "utf8");
+		return await storeFor(ref).read();
 	} catch (error) {
-		if (isFileSystemError(error, "ENOENT")) return null;
-		throw error;
+		remapLoopStoreError(error);
 	}
-	const state = parseLoopState(raw, ref);
-	snapshots.set(loopStateFilePath(ref), state);
-	return state;
 }
 
 /** Like {@link readLoopState}, but returns an empty state when nothing is persisted. */
@@ -106,7 +135,7 @@ export async function loadLoopState(ref: LoopStoreRef): Promise<LoopState> {
  * (status line, tick attribution). Undefined until the store has been touched.
  */
 export function snapshotLoopState(ref: LoopStoreRef): LoopState | undefined {
-	return snapshots.get(loopStateFilePath(ref));
+	return storeFor(ref).snapshot();
 }
 
 /**
@@ -114,91 +143,33 @@ export function snapshotLoopState(ref: LoopStoreRef): LoopState | undefined {
  * timer, tool, and lifecycle writes cannot interleave and lose an update.
  */
 export function mutateLoopState(ref: LoopStoreRef, mutation: LoopStateMutation): Promise<LoopState> {
-	return enqueue(ref, async () => {
-		const current = await loadLoopState(ref);
-		const next = await mutation(current);
-		await writeLoopState(ref, next);
-		return next;
-	});
+	return storeFor(ref)
+		.mutate((current) => mutation(current ?? emptyLoopState(ref.sessionId)))
+		.catch((error: unknown) => remapLoopStoreError(error));
 }
 
 /** Persists a complete state atomically. Prefer {@link mutateLoopState} for updates. */
 export async function writeLoopState(ref: LoopStoreRef, state: LoopState): Promise<void> {
-	const filePath = loopStateFilePath(ref);
-	await mkdir(dirname(filePath), { recursive: true });
-	await writeAtomic(filePath, `${JSON.stringify(state, null, 2)}\n`);
-	snapshots.set(filePath, state);
+	await storeFor(ref).write(state);
 }
 
 /** Drops cached snapshots; used when a session ends or tests reset global state. */
 export function clearLoopStateSnapshot(ref: LoopStoreRef): void {
-	snapshots.delete(loopStateFilePath(ref));
+	storeFor(ref).clear();
 }
 
-function enqueue<T>(ref: LoopStoreRef, operation: () => Promise<T>): Promise<T> {
-	const key = loopStateFilePath(ref);
-	const previous = mutationTails.get(key) ?? Promise.resolve();
-	const run = previous.then(operation);
-	const tail = run.then(
-		() => undefined,
-		() => undefined,
-	);
-	mutationTails.set(key, tail);
-	void tail.then(() => {
-		if (mutationTails.get(key) === tail) mutationTails.delete(key);
-	});
-	return run;
-}
-
-async function writeAtomic(filePath: string, contents: string): Promise<void> {
-	const tempPath = join(dirname(filePath), `.loop-${randomUUID()}.tmp`);
-	try {
-		await writeFile(tempPath, contents, { encoding: "utf8", mode: 0o600 });
-		await rename(tempPath, filePath);
-	} catch (error) {
-		try {
-			await rm(tempPath, { force: true });
-		} catch (cleanupError) {
-			throw new AggregateError(
-				[error, cleanupError],
-				"loop store write failed and its temporary file could not be removed",
-			);
-		}
-		throw error;
-	}
-}
-
-function parseLoopState(raw: string, ref: LoopStoreRef): LoopState {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(raw);
-	} catch (error) {
-		throw new InvalidLoopStoreError("loop store contains unparseable JSON", { cause: error });
-	}
-	if (!isRecord(parsed)) throw new InvalidLoopStoreError("loop store must be a JSON object");
-	if (parsed.version !== LOOP_STATE_VERSION) {
-		throw new UnsupportedLoopStoreVersionError(
-			`unsupported loop store version: ${JSON.stringify(parsed.version)} (expected ${LOOP_STATE_VERSION})`,
-		);
-	}
-	if (typeof parsed.sessionId !== "string" || parsed.sessionId.length === 0) {
-		throw new InvalidLoopStoreError("loop store is missing a sessionId");
-	}
-	if (parsed.sessionId !== ref.sessionId) {
-		throw new InvalidLoopStoreError(
-			`loop store sessionId ${parsed.sessionId} does not match the session it was loaded for`,
-		);
-	}
-	if (!isEpochMs(parsed.updatedAt)) throw new InvalidLoopStoreError("loop store has an invalid updatedAt");
-	if (!isRecord(parsed.entries)) throw new InvalidLoopStoreError("loop store entries must be an object");
+function parseLoopPayload(raw: unknown, ref: SidecarStoreRef): LoopState {
+	if (!isRecord(raw)) throw new InvalidLoopStoreError("loop store must be a JSON object");
+	if (!isEpochMs(raw.updatedAt)) throw new InvalidLoopStoreError("loop store has an invalid updatedAt");
+	if (!isRecord(raw.entries)) throw new InvalidLoopStoreError("loop store entries must be an object");
 
 	const entries: Record<string, CronEntry> = {};
-	for (const [id, value] of Object.entries(parsed.entries)) {
+	for (const [id, value] of Object.entries(raw.entries)) {
 		const entry = parseEntry(id, value);
 		entries[id] = entry;
 	}
 
-	const activeDynamicId = parsed.activeDynamicId;
+	const activeDynamicId = raw.activeDynamicId;
 	if (activeDynamicId !== null) {
 		if (typeof activeDynamicId !== "string") {
 			throw new InvalidLoopStoreError("loop store activeDynamicId must be a string or null");
@@ -211,10 +182,10 @@ function parseLoopState(raw: string, ref: LoopStoreRef): LoopState {
 
 	return {
 		version: LOOP_STATE_VERSION,
-		sessionId: parsed.sessionId,
+		sessionId: ref.sessionId,
 		entries,
 		activeDynamicId,
-		updatedAt: parsed.updatedAt,
+		updatedAt: raw.updatedAt,
 	};
 }
 
@@ -491,8 +462,4 @@ function isRequestedIntervalUnit(value: string): value is RequestedIntervalUnit 
 
 function isEffectiveIntervalUnit(value: string): value is EffectiveIntervalUnit {
 	return (EFFECTIVE_INTERVAL_UNITS as readonly string[]).includes(value);
-}
-
-function isFileSystemError(error: unknown, code: string): boolean {
-	return error instanceof Error && "code" in error && error.code === code;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -1,14 +1,18 @@
+import { isAbsolute, join } from "node:path";
 import { getShellEnv } from "../../../../utils/shell.ts";
+import { encodedSessionId } from "../../../session-sidecar-store.ts";
 import { SettingsManager } from "../../../settings-manager.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
 import { isEvalOnlyRouting } from "../eval-only-routing.ts";
 import { TERMINAL_MONITOR_STATE_EVENT, WAKE_SOURCE_STATE_EVENT } from "../monitor-state-event.ts";
+import { acquireTerminalLease, releaseTerminalLease } from "./manifest-lease.ts";
 import { MonitorNotifier } from "./monitor-notify.ts";
 import { MONITOR_STATUS_KEY } from "./monitor-status.ts";
 import { MonitorStatusTicker } from "./monitor-status-ticker.ts";
-import { TerminalNotifier } from "./notify.ts";
+import { getTerminalNotificationDelivery, TerminalNotifier } from "./notify.ts";
 import { buildTerminalPromptSection } from "./prompt.ts";
+import { type RestoreDigest, type RestoreHandlers, type RestoreOutcome, restoreTerminalState } from "./restore.ts";
 import type { TerminalRuntimeSession } from "./runtime-session.ts";
 import {
 	claimParkedBundle,
@@ -19,13 +23,14 @@ import {
 } from "./session-bundle.ts";
 import { loadTerminalSettings, type ResolvedTerminalSettings, TERMINAL_SETTINGS_DEFAULTS } from "./settings.ts";
 import { TERMINAL_BASH_TOOL, TERMINAL_COMPANION_TOOLS } from "./shared.ts";
+import { type ManifestMonitor, TerminalManifestWriter } from "./terminal-manifest.ts";
 import { createPtyBashTool } from "./tools/bash.ts";
 import { createBashInputTool } from "./tools/bash-input.ts";
 import { createBashOutputTool } from "./tools/bash-output.ts";
 import { createBashResizeTool } from "./tools/bash-resize.ts";
 import type { TerminalToolContext } from "./tools/context.ts";
 import { createKillBashTool } from "./tools/kill-bash.ts";
-import { createMonitorTool } from "./tools/monitor.ts";
+import { bindTerminalManifestWriter, createMonitorTool, unbindTerminalManifestWriter } from "./tools/monitor.ts";
 
 interface TerminalExtensionState {
 	bundle: TerminalSessionBundle | null;
@@ -37,11 +42,26 @@ interface TerminalExtensionState {
 	shellPath: string | undefined;
 	steppedAside: boolean;
 	noticeShown: boolean;
+	/** Set only when this generation acquired the persistence lease (non-reload starts). */
+	lease: { path: string; pid: number } | null;
+	/** Manifest recorder; present only while this process owns the session's lease. */
+	manifestWriter: TerminalManifestWriter | null;
+	recordedBackgroundIds: Set<string>;
 }
 
 /** Tests and SDK callers may hand partial contexts without a session manager. */
 function sessionKeyOf(ctx: ExtensionContext | undefined): string | undefined {
 	return ctx?.sessionManager?.getSessionId?.();
+}
+
+/**
+ * Per-session persistence dir for the terminal lease + manifest; undefined when the context
+ * carries no durable session dir (SDK/in-memory sessions must not persist terminal state).
+ */
+function terminalStateDir(ctx: ExtensionContext | undefined): string | undefined {
+	const sessionDir = ctx?.sessionManager?.getSessionDir?.();
+	if (sessionDir === undefined || sessionDir.length === 0 || !isAbsolute(sessionDir)) return undefined;
+	return join(sessionDir, "extensions", "terminal");
 }
 
 function createBundle(state: TerminalExtensionState): TerminalSessionBundle {
@@ -77,6 +97,7 @@ function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalE
 					startedAtMs: entry.startedAtMs,
 				})),
 			});
+			if (state.manifestWriter) void state.manifestWriter.observeMonitorState(snapshot);
 		},
 		onBackgroundState: (snapshot) => {
 			pi.events?.emit(WAKE_SOURCE_STATE_EVENT, {
@@ -84,8 +105,19 @@ function bundleSinks(pi: ExtensionAPI, state: TerminalExtensionState): TerminalE
 				activeCount: snapshot.length,
 				items: snapshot,
 			});
+			const writer = state.manifestWriter;
+			if (!writer) return;
+			for (const entry of snapshot) {
+				if (state.recordedBackgroundIds.has(entry.id)) continue;
+				state.recordedBackgroundIds.add(entry.id);
+				void writer.recordBackgroundStart(entry.id, entry.description ?? entry.id, entry.startedAtMs);
+			}
 		},
-		onBackgroundExit: (id, runtime) => state.notifier?.notifyCompletion(id, runtime),
+		onBackgroundExit: (id, runtime) => {
+			state.recordedBackgroundIds.delete(id);
+			if (state.manifestWriter) void state.manifestWriter.recordBackgroundExit(id);
+			state.notifier?.notifyCompletion(id, runtime);
+		},
 	};
 }
 
@@ -166,6 +198,127 @@ function syncToolset(pi: ExtensionAPI, state: TerminalExtensionState): void {
 	pi.setActiveTools([...active]);
 }
 
+/** Send one model-visible terminal reminder; suppressed by notify `off` and non-interactive modes. */
+function sendTerminalReminder(pi: ExtensionAPI, state: TerminalExtensionState, sentence: string): void {
+	getTerminalNotificationDelivery({
+		sendMessage: (message, options) => pi.sendMessage(message, options),
+		getContext: () => state.ctx,
+		getMode: () => state.settings.notify,
+	})?.send(`<system-reminder>${sentence}</system-reminder>`);
+}
+
+function clauseWithDescriptions(label: string, count: number, descriptions: readonly string[]): string {
+	return descriptions.length > 0 ? `${label} ${count} (${descriptions.join(", ")})` : `${label} ${count}`;
+}
+
+/**
+ * The ONE coalesced restore digest. Counts come from the restore orchestrator; descriptions
+ * are attributed per manifest entry so the sentence stays a single message however many
+ * monitors there are. Empty clauses are omitted; undefined when there is nothing to report.
+ */
+function restoreDigestSentence(
+	digest: RestoreDigest,
+	restoredDescriptions: readonly string[],
+	lostDescriptions: readonly string[],
+): string | undefined {
+	const clauses: string[] = [];
+	if (digest.restored > 0) clauses.push(clauseWithDescriptions("restored", digest.restored, restoredDescriptions));
+	if (digest.lost > 0) clauses.push(clauseWithDescriptions("lost", digest.lost, lostDescriptions));
+	if (digest.expired > 0) clauses.push(`expired ${digest.expired}`);
+	if (digest.muted > 0) clauses.push(`${digest.muted} still muted`);
+	if (clauses.length === 0) return undefined;
+	return `Terminal state after restart: ${clauses.join("; ")}.`;
+}
+
+/**
+ * Non-reload startup: acquire the persistence lease, then restore from the manifest and
+ * deliver EXACTLY ONE coalesced digest. A live foreign holder keeps its lease and gets one
+ * attached-elsewhere reminder; an unreadable manifest fails closed with one notice and no
+ * restore attempt. Only the lease owner records manifest state afterwards.
+ */
+async function adoptPersistedTerminalState(
+	pi: ExtensionAPI,
+	state: TerminalExtensionState,
+	sessionKey: string,
+): Promise<void> {
+	const ctx = state.ctx;
+	const dir = terminalStateDir(ctx);
+	if (dir === undefined || !ctx?.sessionManager) return;
+	const lease = await acquireTerminalLease({ dir, encodedSessionId: sessionKey });
+	if (!lease.acquired) {
+		sendTerminalReminder(
+			pi,
+			state,
+			`Terminal monitors for this session are attached in another live process (pid ${lease.holder.pid}); nothing was restored here.`,
+		);
+		return;
+	}
+	state.lease = { path: lease.path, pid: lease.pid };
+	const writer = new TerminalManifestWriter({ session: ctx.sessionManager });
+	state.manifestWriter = writer;
+	state.recordedBackgroundIds.clear();
+	bindTerminalManifestWriter(sessionKey, writer);
+
+	// Restoration handlers: this generation does not re-spawn persisted commands on its own,
+	// so every durable entry reports lost; the outcomes still flow through the orchestrator.
+	const outcomesById = new Map<string, RestoreOutcome>();
+	const reportLost = (monitor: ManifestMonitor): { outcome: RestoreOutcome } => {
+		outcomesById.set(monitor.monitorId, "lost");
+		return { outcome: "lost" };
+	};
+	const handlers: RestoreHandlers = { "restartable-command": reportLost, "checkpointed-file": reportLost };
+	const nowMs = Date.now();
+	const digest = await restoreTerminalState({ manifest: writer.store, handlers, now: () => nowMs });
+
+	let manifest = null;
+	let unreadable = digest.storeError;
+	if (!unreadable) {
+		try {
+			manifest = await writer.store.read();
+		} catch {
+			unreadable = true;
+		}
+	}
+	if (unreadable) {
+		sendTerminalReminder(
+			pi,
+			state,
+			"Terminal state after restart: the persisted terminal manifest is corrupt; nothing was restored here (fail closed).",
+		);
+		return;
+	}
+	if (manifest === null) return; // nothing was ever persisted for this session
+
+	const restoredDescriptions: string[] = [];
+	const lostDescriptions: string[] = [];
+	for (const monitor of manifest.monitors) {
+		if (monitor.expiresAt !== null && monitor.expiresAt < nowMs) continue;
+		if (outcomesById.get(monitor.monitorId) === "restored") restoredDescriptions.push(monitor.description);
+		else lostDescriptions.push(monitor.description);
+	}
+	for (const background of manifest.backgroundSessions) lostDescriptions.push(background.command);
+	const sentence = restoreDigestSentence(digest, restoredDescriptions, lostDescriptions);
+	if (sentence !== undefined) sendTerminalReminder(pi, state, sentence);
+}
+
+/** Detach the manifest recorder without writing (a reload keeps live state instead). */
+function detachManifestWriter(state: TerminalExtensionState, sessionKey: string | undefined): void {
+	state.manifestWriter = null;
+	state.recordedBackgroundIds.clear();
+	if (sessionKey !== undefined) unbindTerminalManifestWriter(sessionKey);
+}
+
+/**
+ * Shutdown view of the manifest: recordShutdown absorbs pending checkpoints, marks every
+ * live monitor `suspended`, and persists in one write. Detach FIRST so bundle teardown's
+ * empty-registry sync cannot touch the recorder afterwards.
+ */
+async function suspendAndFlushManifest(state: TerminalExtensionState, sessionKey: string): Promise<void> {
+	const writer = state.manifestWriter;
+	detachManifestWriter(state, sessionKey);
+	if (writer) await writer.recordShutdown();
+}
+
 export function registerTerminalExtension(pi: ExtensionAPI): void {
 	const state: TerminalExtensionState = {
 		bundle: null,
@@ -187,6 +340,9 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 		shellPath: undefined,
 		steppedAside: false,
 		noticeShown: false,
+		lease: null,
+		manifestWriter: null,
+		recordedBackgroundIds: new Set(),
 	};
 	const toolCtx = buildToolContext(pi, state);
 
@@ -229,6 +385,18 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 		}
 		state.bundle ??= createBundle(state);
 		state.bundle.bind(bundleSinks(pi, state));
+		if (event.reason === "reload") {
+			// Park/claim and the lease stay untouched: the same pid keeps holding it. The
+			// reload generation only rebinds the recorder so manifest coverage continues.
+			if (sessionKey !== undefined && terminalStateDir(ctx) !== undefined) {
+				const writer = new TerminalManifestWriter({ session: ctx.sessionManager });
+				state.manifestWriter = writer;
+				state.recordedBackgroundIds.clear();
+				bindTerminalManifestWriter(sessionKey, writer);
+			}
+		} else if (sessionKey !== undefined) {
+			await adoptPersistedTerminalState(pi, state, sessionKey);
+		}
 		syncToolset(pi, state);
 	});
 
@@ -264,9 +432,27 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 		if (event.reason === "reload" && state.bundle && sessionKey !== undefined) {
 			// Keep state.bundle referenced: exit listeners captured by this instance's tool
 			// context still route through the shared bundle after the new owner claims it.
+			// The lease is deliberately NOT released: the same pid keeps it across the reload.
+			detachManifestWriter(state, sessionKey);
 			state.bundle.park();
 			await parkBundle(sessionKey, state.bundle);
 			return;
+		}
+		if (sessionKey !== undefined) await suspendAndFlushManifest(state, sessionKey);
+		const lease = state.lease;
+		state.lease = null;
+		if (lease !== null) {
+			await releaseTerminalLease(lease);
+		} else if (sessionKey !== undefined) {
+			const dir = terminalStateDir(ctx) ?? terminalStateDir(state.ctx);
+			// A reload generation inherits the pre-reload lease without re-acquiring it;
+			// releasing by (path, own pid) removes exactly that file and no foreign holder's.
+			if (dir !== undefined) {
+				await releaseTerminalLease({
+					path: join(dir, `${encodedSessionId(sessionKey)}.lease`),
+					pid: process.pid,
+				});
+			}
 		}
 		const bundle = state.bundle;
 		state.bundle = null;

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/restore.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/restore.ts
@@ -1,0 +1,187 @@
+/**
+ * The terminal manifest's read side and restore orchestrator: the strict fail-closed
+ * parse every persisted manifest must survive, plus `restoreTerminalState`, which
+ * replays the manifest after a restart. Each monitor is classified by its durability
+ * class and handed to that class's handler; ephemeral monitors and background sessions
+ * are always lost, and an expired watch never reaches its handler. Both durable
+ * handler slots ship as stubs reporting `lost` — later phases plug the real ones in.
+ */
+
+import { InvalidSidecarStoreError, type SidecarStore, type SidecarStoreRef } from "../../../session-sidecar-store.ts";
+import {
+	type ManifestBackgroundSession,
+	type ManifestMonitor,
+	TERMINAL_MANIFEST_VERSION,
+	type TerminalManifest,
+} from "./terminal-manifest.ts";
+
+export class InvalidTerminalManifestError extends InvalidSidecarStoreError {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, options);
+		this.name = "InvalidTerminalManifestError";
+	}
+}
+
+type Raw = Record<string, unknown>;
+
+const RUNTIME_KINDS = ["command", "file"] as const;
+const DURABILITY_CLASSES = ["ephemeral", "restartable-command", "checkpointed-file"] as const;
+const FILE_EVENTS = ["create", "modify"] as const;
+const isStr = (value: unknown): value is string => typeof value === "string" && value.length > 0;
+const isNum = (value: unknown): value is number => typeof value === "number" && Number.isFinite(value);
+const isBool = (value: unknown): value is boolean => typeof value === "boolean";
+const isObj = (value: unknown): value is Raw => typeof value === "object" && value !== null && !Array.isArray(value);
+
+function invalid(message: string): never {
+	throw new InvalidTerminalManifestError(`terminal manifest is invalid: ${message}`);
+}
+
+function str(raw: Raw, field: string): string {
+	if (!isStr(raw[field])) invalid(`field ${field} must be a non-empty string`);
+	return raw[field];
+}
+
+function num(raw: Raw, field: string): number {
+	if (!isNum(raw[field])) invalid(`field ${field} must be a finite number`);
+	return raw[field];
+}
+
+function bool(raw: Raw, field: string): boolean {
+	if (!isBool(raw[field])) invalid(`field ${field} must be a boolean`);
+	return raw[field];
+}
+
+function opt<T>(raw: Raw, field: string, required: (raw: Raw, field: string) => T): T | undefined {
+	return raw[field] === undefined ? undefined : required(raw, field);
+}
+
+function oneOf<T extends string>(values: readonly T[], raw: Raw, field: string): T {
+	const value = raw[field];
+	if (typeof value !== "string" || !values.includes(value as T))
+		invalid(`field ${field} must be one of: ${values.join(", ")}`);
+	return value as T;
+}
+
+function checkpoint(raw: unknown): { dev: number; ino: number; size: number; mtimeMs: number } {
+	if (!isObj(raw)) invalid("field lastCheckpoint must be an object");
+	return { dev: num(raw, "dev"), ino: num(raw, "ino"), size: num(raw, "size"), mtimeMs: num(raw, "mtimeMs") };
+}
+
+function fireWindow(raw: unknown): { startMs: number; count: number } {
+	if (!isObj(raw)) invalid("field fireWindow must be an object");
+	return { startMs: num(raw, "startMs"), count: num(raw, "count") };
+}
+
+function parseMonitor(entry: unknown): ManifestMonitor {
+	if (!isObj(entry)) invalid("a monitor entry must be an object");
+	return {
+		monitorId: str(entry, "monitorId"),
+		sessionId: str(entry, "sessionId"),
+		description: str(entry, "description"),
+		runtimeKind: oneOf(RUNTIME_KINDS, entry, "runtimeKind"),
+		durabilityClass: oneOf(DURABILITY_CLASSES, entry, "durabilityClass"),
+		command: opt(entry, "command", str),
+		path: opt(entry, "path", str),
+		event: opt(entry, "event", (raw, field) => oneOf(FILE_EVENTS, raw, field)),
+		filter: opt(entry, "filter", str),
+		cwd: opt(entry, "cwd", str),
+		approvedParent: opt(entry, "approvedParent", str),
+		createdAt: num(entry, "createdAt"),
+		expiresAt: entry.expiresAt === undefined || entry.expiresAt === null ? null : num(entry, "expiresAt"),
+		persistent: bool(entry, "persistent"),
+		suspended: bool(entry, "suspended"),
+		lastCheckpoint: entry.lastCheckpoint === null ? null : checkpoint(entry.lastCheckpoint),
+		deliveryPaused: bool(entry, "deliveryPaused"),
+		wakeCount: num(entry, "wakeCount"),
+		fireWindow: fireWindow(entry.fireWindow),
+	};
+}
+
+function parseBackgroundSession(entry: unknown): ManifestBackgroundSession {
+	if (!isObj(entry)) invalid("a background session entry must be an object");
+	return { id: str(entry, "id"), command: str(entry, "command"), startedAtMs: num(entry, "startedAtMs") };
+}
+
+/** Strict fail-closed domain parse; the sidecar store has already checked version and session. */
+export function parseTerminalManifest(raw: unknown, ref: SidecarStoreRef): TerminalManifest {
+	if (!isObj(raw)) invalid("the payload must be an object");
+	if (!Array.isArray(raw.monitors)) invalid("field monitors must be an array");
+	if (!Array.isArray(raw.backgroundSessions)) invalid("field backgroundSessions must be an array");
+	return {
+		version: TERMINAL_MANIFEST_VERSION,
+		sessionId: ref.sessionId,
+		monitors: raw.monitors.map(parseMonitor),
+		backgroundSessions: raw.backgroundSessions.map(parseBackgroundSession),
+		updatedAt: num(raw, "updatedAt"),
+	};
+}
+
+export type RestoreOutcome = "restored" | "lost" | "muted" | "attachedElsewhere";
+
+export interface RestoreHandlerResult {
+	readonly outcome: RestoreOutcome;
+}
+
+export type RestoreHandler = (monitor: ManifestMonitor) => RestoreHandlerResult | Promise<RestoreHandlerResult>;
+
+export interface RestoreHandlers {
+	readonly "restartable-command": RestoreHandler;
+	readonly "checkpointed-file": RestoreHandler;
+}
+
+/** Stub durability handlers: every durable monitor is reported lost until later phases land. */
+export const stubRestoreHandlers: RestoreHandlers = {
+	"restartable-command": () => ({ outcome: "lost" }),
+	"checkpointed-file": () => ({ outcome: "lost" }),
+};
+
+export interface RestoreDigest {
+	restored: number;
+	lost: number;
+	expired: number;
+	muted: number;
+	attachedElsewhere: number;
+	storeError: boolean;
+}
+
+export interface RestoreTerminalStateOptions {
+	readonly manifest: SidecarStore<TerminalManifest>;
+	readonly handlers?: Partial<RestoreHandlers>;
+	readonly now?: () => number;
+}
+
+export async function restoreTerminalState(options: RestoreTerminalStateOptions): Promise<RestoreDigest> {
+	const digest: RestoreDigest = {
+		restored: 0,
+		lost: 0,
+		expired: 0,
+		muted: 0,
+		attachedElsewhere: 0,
+		storeError: false,
+	};
+	let state: TerminalManifest | null;
+	try {
+		state = await options.manifest.read();
+	} catch {
+		// Fail closed: a corrupt or foreign manifest restores nothing and reports the store error.
+		return { ...digest, storeError: true };
+	}
+	if (state === null) return digest;
+	const now = (options.now ?? Date.now)();
+	const handlers: RestoreHandlers = { ...stubRestoreHandlers, ...options.handlers };
+	for (const monitor of state.monitors) {
+		if (monitor.expiresAt !== null && monitor.expiresAt < now) {
+			digest.expired += 1;
+			continue;
+		}
+		if (monitor.durabilityClass === "ephemeral") {
+			digest.lost += 1;
+			continue;
+		}
+		const outcome = (await handlers[monitor.durabilityClass](monitor)).outcome;
+		digest[outcome] += 1;
+	}
+	// Background sessions carry no durable identity: every one of them is lost.
+	digest.lost += state.backgroundSessions.length;
+	return digest;
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/terminal-manifest.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/terminal-manifest.ts
@@ -1,0 +1,250 @@
+/**
+ * Per-session terminal manifest: the durable sidecar record of live monitors and background
+ * sessions that `restore.ts` reads back after a restart. The writer persists ONLY lifecycle
+ * transitions plus debounced checkpoints — never per-line output and never a runtime handle.
+ */
+
+import { join } from "node:path";
+import type { SessionManager } from "../../../session-manager.ts";
+import { createSidecarStore, type SidecarStore } from "../../../session-sidecar-store.ts";
+import type { MonitorSnapshotEntry } from "./monitor-registry.ts";
+import { parseTerminalManifest } from "./restore.ts";
+
+export const TERMINAL_MANIFEST_VERSION = 1;
+/** Minimum debounce for checkpoint writes; a burst inside this window collapses to one write. */
+export const TERMINAL_MANIFEST_CHECKPOINT_DEBOUNCE_MS = 30_000;
+export type TerminalManifestSession = Pick<SessionManager, "getSessionDir" | "getSessionId">;
+export type MonitorRuntimeKind = "command" | "file";
+export type MonitorDurabilityClass = "ephemeral" | "restartable-command" | "checkpointed-file";
+/** File-monitor checkpoint persisted by the writer: the registry's live identity tuple. */
+export interface TerminalManifestCheckpoint {
+	readonly dev: number;
+	readonly ino: number;
+	readonly size: number;
+	readonly mtimeMs: number;
+}
+
+export interface ManifestMonitor {
+	readonly monitorId: string;
+	/** Owning agent session id — never the bash_N/watch_N runtime id. */
+	readonly sessionId: string;
+	readonly description: string;
+	readonly runtimeKind: MonitorRuntimeKind;
+	readonly durabilityClass: MonitorDurabilityClass;
+	readonly command?: string;
+	readonly path?: string;
+	readonly event?: "create" | "modify";
+	readonly filter?: string;
+	readonly cwd?: string;
+	readonly approvedParent?: string;
+	readonly createdAt: number;
+	readonly expiresAt: number | null;
+	readonly persistent: boolean;
+	readonly suspended: boolean;
+	readonly lastCheckpoint: TerminalManifestCheckpoint | null;
+	readonly deliveryPaused: boolean;
+	readonly wakeCount: number;
+	readonly fireWindow: { startMs: number; count: number };
+}
+
+export interface ManifestBackgroundSession {
+	readonly id: string;
+	readonly command: string;
+	readonly startedAtMs: number;
+}
+
+export interface TerminalManifest {
+	readonly version: typeof TERMINAL_MANIFEST_VERSION;
+	readonly sessionId: string;
+	readonly monitors: readonly ManifestMonitor[];
+	readonly backgroundSessions: readonly ManifestBackgroundSession[];
+	readonly updatedAt: number;
+}
+
+/** What the monitor tool captures at its call site — the only place the branch inputs live. */
+export interface CommandMonitorSpec {
+	readonly kind: "command";
+	readonly description: string;
+	readonly command: string;
+	readonly filter?: string;
+	readonly cwd?: string;
+	readonly persistent: boolean;
+}
+
+export interface FileMonitorSpec {
+	readonly kind: "file";
+	readonly description: string;
+	readonly path: string;
+	readonly event: "create" | "modify";
+	readonly timeoutMs: number;
+	readonly cwd: string;
+	readonly approvedParent?: string;
+}
+export type MonitorSpec = CommandMonitorSpec | FileMonitorSpec;
+
+export interface MonitorRegistration {
+	readonly monitorId: string;
+	readonly spec: MonitorSpec;
+}
+
+export function createTerminalManifestStore(session: TerminalManifestSession): SidecarStore<TerminalManifest> {
+	return createSidecarStore({
+		baseDir: join(session.getSessionDir(), "extensions", "terminal"),
+		sessionId: session.getSessionId(),
+		version: TERMINAL_MANIFEST_VERSION,
+		tempPrefix: "terminal",
+		parse: parseTerminalManifest,
+	});
+}
+
+export class TerminalManifestWriter {
+	readonly store: SidecarStore<TerminalManifest>;
+	readonly #sessionId: string;
+	readonly #debounceMs: number;
+	readonly #now: () => number;
+	readonly #entries = new Map<string, ManifestMonitor>();
+	readonly #backgrounds = new Map<string, ManifestBackgroundSession>();
+	readonly #pending = new Map<string, TerminalManifestCheckpoint>();
+	#timer: ReturnType<typeof setTimeout> | undefined;
+	#tail: Promise<void> = Promise.resolve();
+	/** Last persist failure: transitions never reject, so a durability write can never fail a live tool call. */
+	persistFailure: unknown;
+
+	constructor(options: { session: TerminalManifestSession; debounceMs?: number; now?: () => number }) {
+		this.store = createTerminalManifestStore(options.session);
+		this.#sessionId = options.session.getSessionId();
+		this.#debounceMs = options.debounceMs ?? TERMINAL_MANIFEST_CHECKPOINT_DEBOUNCE_MS;
+		this.#now = options.now ?? Date.now;
+	}
+
+	recordRegister(registration: MonitorRegistration): Promise<void> {
+		this.#entries.set(registration.monitorId, this.#entryFor(registration));
+		return this.#persist();
+	}
+
+	/**
+	 * Reconcile a registry transition snapshot (the bundle's single onChange consumer
+	 * forwards it here): settle removes entries, pause/resume/rearm flips deliveryPaused.
+	 * An entry missing its stable monitorId throws — never silently skipped; entries not
+	 * registered through the tool call site are left alone (durability spec unknown).
+	 */
+	observeMonitorState(snapshot: readonly MonitorSnapshotEntry[]): Promise<void> {
+		const live = new Map<string, boolean>();
+		for (const entry of snapshot) {
+			if (typeof entry.monitorId !== "string" || entry.monitorId.length === 0) {
+				throw new Error(
+					`terminal manifest writer saw a monitor snapshot entry without a stable monitorId (runtime id ${entry.id}); surfacing instead of silently skipping it`,
+				);
+			}
+			live.set(entry.monitorId, entry.paused);
+		}
+		let changed = false;
+		for (const [monitorId, known] of this.#entries) {
+			const paused = live.get(monitorId);
+			if (paused === undefined) {
+				if (known.suspended) continue; // shutdown-suspended entries are expected to be absent
+				this.#entries.delete(monitorId); // settle: the registry transitioned it out
+				changed = true;
+			} else if (known.deliveryPaused !== paused) {
+				this.#entries.set(monitorId, { ...known, deliveryPaused: paused });
+				changed = true;
+			}
+		}
+		return changed ? this.#persist() : Promise.resolve();
+	}
+
+	/** Debounced checkpoint persist: a burst inside the window collapses into one write. */
+	scheduleCheckpoint(monitorId: string, checkpoint: TerminalManifestCheckpoint): void {
+		this.#pending.set(monitorId, checkpoint);
+		if (this.#timer !== undefined) clearTimeout(this.#timer);
+		this.#timer = setTimeout(() => {
+			this.#timer = undefined;
+			this.#absorbPending();
+			void this.#persist();
+		}, this.#debounceMs);
+	}
+
+	/** Drain: apply any pending checkpoints and await every in-flight write. */
+	async flush(): Promise<void> {
+		if (this.#timer !== undefined) {
+			clearTimeout(this.#timer);
+			this.#timer = undefined;
+		}
+		if (this.#pending.size === 0) await this.#tail;
+		else {
+			this.#absorbPending();
+			await this.#persist();
+		}
+	}
+	/** Shutdown transition: flush checkpoints and mark every live monitor suspended in one write. */
+	async recordShutdown(): Promise<void> {
+		if (this.#timer !== undefined) {
+			clearTimeout(this.#timer);
+			this.#timer = undefined;
+		}
+		this.#absorbPending();
+		for (const [monitorId, entry] of this.#entries) this.#entries.set(monitorId, { ...entry, suspended: true });
+		await this.#persist();
+	}
+
+	recordBackgroundStart(id: string, command: string, startedAtMs?: number): Promise<void> {
+		this.#backgrounds.set(id, { id, command, startedAtMs: startedAtMs ?? this.#now() });
+		return this.#persist();
+	}
+
+	recordBackgroundExit(id: string): Promise<void> {
+		return this.#backgrounds.delete(id) ? this.#persist() : Promise.resolve();
+	}
+	#absorbPending(): void {
+		for (const [monitorId, checkpoint] of this.#pending) {
+			const entry = this.#entries.get(monitorId);
+			if (entry) this.#entries.set(monitorId, { ...entry, lastCheckpoint: checkpoint });
+		}
+		this.#pending.clear();
+	}
+
+	#entryFor({ monitorId, spec }: MonitorRegistration): ManifestMonitor {
+		const createdAt = this.#now();
+		return {
+			monitorId,
+			sessionId: this.#sessionId,
+			description: spec.description,
+			runtimeKind: spec.kind,
+			durabilityClass:
+				spec.kind === "file" ? "checkpointed-file" : spec.persistent ? "restartable-command" : "ephemeral",
+			command: spec.kind === "command" ? spec.command : undefined,
+			path: spec.kind === "file" ? spec.path : undefined,
+			event: spec.kind === "file" ? spec.event : undefined,
+			filter: spec.kind === "command" ? spec.filter : undefined,
+			cwd: spec.cwd,
+			approvedParent: spec.kind === "file" ? spec.approvedParent : undefined,
+			createdAt,
+			expiresAt: spec.kind === "file" ? createdAt + spec.timeoutMs : null,
+			persistent: spec.kind === "command" ? spec.persistent : false,
+			suspended: false,
+			lastCheckpoint: null,
+			deliveryPaused: false,
+			wakeCount: 0,
+			fireWindow: { startMs: createdAt, count: 0 },
+		};
+	}
+
+	#persist(): Promise<void> {
+		const run = this.#tail.then(() =>
+			this.store.write({
+				version: TERMINAL_MANIFEST_VERSION,
+				sessionId: this.#sessionId,
+				monitors: [...this.#entries.values()],
+				backgroundSessions: [...this.#backgrounds.values()],
+				updatedAt: this.#now(),
+			}),
+		);
+		this.#tail = run.then(
+			() => undefined,
+			(error) => {
+				this.persistFailure = error;
+			},
+		);
+		return this.#tail;
+	}
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -3,6 +3,7 @@ import { type Static, Type } from "typebox";
 import { APPROVED_MONITOR_PARENT } from "../monitor-permission.ts";
 import { MonitorRegistry } from "../monitor-registry.ts";
 import { DEFAULT_COLS, DEFAULT_ROWS, TERMINAL_MONITOR_TOOL } from "../shared.ts";
+import type { MonitorRegistration, TerminalManifestWriter } from "../terminal-manifest.ts";
 import {
 	errorResult,
 	resolveTerminalId,
@@ -131,12 +132,47 @@ async function createMonitor(
 	ctx.onMonitorRearmed?.(id);
 	const monitorId = registry.register({ id, description: input.description, runtime, filter });
 	ctx.manager.bindMonitorId(monitorId, id);
+	// The tool call site is the only place the branch inputs (command, persistent, filter)
+	// live; hand the captured spec to the session's manifest writer for durable recording.
+	handMonitorSpec(manifestSessionKey(ctx), {
+		monitorId,
+		spec: {
+			kind: "command",
+			description: input.description,
+			command: input.command,
+			filter: input.filter,
+			cwd: execCtx?.cwd,
+			persistent: input.persistent === true,
+		},
+	});
 	return textResult(`Monitor started with ID: ${monitorId}`, {
 		details: { monitor_id: monitorId, bash_id: id, monitor: true },
 	});
 }
 
 /** Build the PTY-backed monitor tool. Monitor handles share TerminalManager's bash_N namespace. */
+const manifestWriters = new Map<string, TerminalManifestWriter>();
+
+/** Bind the session's manifest writer so monitor tool calls can hand it specs captured at the call site. */
+export function bindTerminalManifestWriter(sessionId: string, writer: TerminalManifestWriter): void {
+	manifestWriters.set(sessionId, writer);
+}
+
+export function unbindTerminalManifestWriter(sessionId: string): void {
+	manifestWriters.delete(sessionId);
+}
+
+/** The durability session key for a tool context: the agent session id, when the context carries one. */
+function manifestSessionKey(ctx: TerminalToolContext): string | undefined {
+	return ctx.getSessionContext?.()?.sessionManager?.getSessionId?.();
+}
+
+/** Hand a spec captured at the monitor tool call site to the session's bound writer, if any. */
+function handMonitorSpec(sessionKey: string | undefined, registration: MonitorRegistration): void {
+	const writer = sessionKey === undefined ? undefined : manifestWriters.get(sessionKey);
+	void writer?.recordRegister(registration);
+}
+
 export function createMonitorTool(ctx: TerminalToolContext) {
 	let fallbackRegistry: MonitorRegistry | undefined;
 	const getRegistry = (): MonitorRegistry => {
@@ -201,21 +237,31 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 				if (!ctx.monitorRegistry)
 					return errorResult("Native file monitors require a lifecycle-owned monitor registry.");
 				try {
+					const approvedParent = (input as Record<string | symbol, unknown>)[APPROVED_MONITOR_PARENT] as
+						| string
+						| undefined;
 					const { id, monitorId } = await ctx.monitorRegistry.registerFile({
 						description: input.description,
 						path: input.path,
 						event: input.event ?? "create",
 						timeoutMs: resolveTimeoutMs(input.timeout_ms),
 						cwd: execCtx?.cwd ?? ctx.cwd,
-						...((input as Record<string | symbol, unknown>)[APPROVED_MONITOR_PARENT] !== undefined
-							? {
-									approvedParent: (input as Record<string | symbol, unknown>)[
-										APPROVED_MONITOR_PARENT
-									] as string,
-								}
-							: {}),
+						...(approvedParent !== undefined ? { approvedParent } : {}),
 					});
 					ctx.manager.bindMonitorId(monitorId, id);
+					// Same spec capture as the command branch: durability inputs live only here.
+					handMonitorSpec(manifestSessionKey(ctx), {
+						monitorId,
+						spec: {
+							kind: "file",
+							description: input.description,
+							path: input.path,
+							event: input.event ?? "create",
+							timeoutMs: resolveTimeoutMs(input.timeout_ms),
+							cwd: execCtx?.cwd ?? ctx.cwd,
+							...(approvedParent !== undefined ? { approvedParent } : {}),
+						},
+					});
 					return textResult(`Monitor started with ID: ${monitorId}`, {
 						details: { monitor_id: monitorId, bash_id: id, monitor: true },
 					});

--- a/packages/coding-agent/src/core/session-sidecar-store.ts
+++ b/packages/coding-agent/src/core/session-sidecar-store.ts
@@ -90,7 +90,7 @@ export function createSidecarStore<T>(options: CreateSidecarStoreOptions<T>): Si
 	}
 
 	function mutate(fn: (current: T | null) => T | Promise<T>): Promise<T> {
-		return enqueue(filePath, async () => {
+		return serializeByKey(filePath, async () => {
 			const next = await fn(await read());
 			await write(next);
 			return next;
@@ -162,10 +162,15 @@ function parsePayload<T>(raw: string, options: CreateSidecarStoreOptions<T>, ref
 }
 
 /**
- * Serializes operations per file through a promise tail so concurrent callers
- * cannot interleave their read-modify-write cycles and lose an update.
+ * Serializes read-modify-write cycles per key across every sidecar consumer.
+ *
+ * `key` must be the resolved absolute file path of the sidecar (the same string
+ * `createSidecarStore` uses for that file). Callers that own their own writer
+ * (goal) call this directly around that writer. Callers that want the whole
+ * store (loop) go through `createSidecarStore`, whose `mutate` already uses
+ * this tail.
  */
-function enqueue<T>(key: string, operation: () => Promise<T>): Promise<T> {
+export function serializeByKey<T>(key: string, operation: () => Promise<T>): Promise<T> {
 	const previous = mutationTails.get(key) ?? Promise.resolve();
 	const run = previous.then(operation);
 	const tail = run.then(

--- a/packages/coding-agent/test/suite/session-sidecar-store.test.ts
+++ b/packages/coding-agent/test/suite/session-sidecar-store.test.ts
@@ -26,6 +26,7 @@ import {
 	createSidecarStore,
 	InvalidSidecarStoreError,
 	type SidecarStore,
+	serializeByKey,
 	UnsupportedSidecarStoreVersionError,
 } from "../../src/core/session-sidecar-store.ts";
 
@@ -107,6 +108,35 @@ describe("sidecar store mutation serialization", () => {
 		await Promise.all(increments);
 
 		// Then: the persisted counter reflects all 20 increments.
+		const persisted = await store.read();
+		expect(persisted?.counter).toBe(20);
+	});
+
+	it("lands 10 serializeByKey increments and 10 mutate increments on the same file", async () => {
+		// Given: one file, two callers — the exported serializer (goal-style own writer)
+		// and store.mutate (loop-style), both keyed to the same resolved path.
+		const store = await tempStore("session-shared-tail");
+		const sessionId = "session-shared-tail";
+
+		// When: every operation is started before any of them resolves.
+		const viaSerializer = Array.from({ length: 10 }, () =>
+			serializeByKey(store.filePath, async () => {
+				const current = await store.read();
+				await Promise.resolve();
+				const next = stateFor(sessionId, (current?.counter ?? 0) + 1);
+				await store.write(next);
+				return next;
+			}),
+		);
+		const viaMutate = Array.from({ length: 10 }, () =>
+			store.mutate(async (current) => {
+				await Promise.resolve();
+				return stateFor(sessionId, (current?.counter ?? 0) + 1);
+			}),
+		);
+		await Promise.all([...viaSerializer, ...viaMutate]);
+
+		// Then: the shared tail landed every increment.
 		const persisted = await store.read();
 		expect(persisted?.counter).toBe(20);
 	});

--- a/packages/coding-agent/test/suite/terminal-manifest.test.ts
+++ b/packages/coding-agent/test/suite/terminal-manifest.test.ts
@@ -1,0 +1,340 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import {
+	type MonitorEvent,
+	MonitorRegistry,
+	type MonitorSnapshotEntry,
+} from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import {
+	InvalidTerminalManifestError,
+	type RestoreHandlerResult,
+	type RestoreHandlers,
+	restoreTerminalState,
+	stubRestoreHandlers,
+} from "../../src/core/extensions/builtin/terminal/restore.ts";
+import {
+	type ManifestMonitor,
+	TerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/terminal-manifest.ts";
+import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import {
+	bindTerminalManifestWriter,
+	createMonitorTool,
+	unbindTerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+import { InvalidSidecarStoreError } from "../../src/core/session-sidecar-store.ts";
+
+interface Fixture {
+	writer: TerminalManifestWriter;
+	sessionId: string;
+	sessionDir: string;
+}
+
+let fixtureSeq = 0;
+
+async function makeFixture(): Promise<Fixture> {
+	fixtureSeq += 1;
+	const sessionId = `manifest-session-${process.pid}-${fixtureSeq}`;
+	const sessionDir = await mkdtemp(join(tmpdir(), "senpi-terminal-manifest-"));
+	const writer = new TerminalManifestWriter({
+		session: { getSessionDir: () => sessionDir, getSessionId: () => sessionId },
+	});
+	// The manifest must never resolve inside the repo tree: pin the fake session dir as
+	// absolute and prove the store resolved its sidecar path under that exact directory.
+	expect(isAbsolute(sessionDir)).toBe(true);
+	expect(isAbsolute(writer.store.filePath)).toBe(true);
+	expect(writer.store.filePath.startsWith(join(sessionDir, "extensions", "terminal"))).toBe(true);
+	return { writer, sessionId, sessionDir };
+}
+
+function manifestMonitor(
+	overrides: Partial<ManifestMonitor> & Pick<ManifestMonitor, "monitorId" | "durabilityClass">,
+): ManifestMonitor {
+	return {
+		sessionId: "unused",
+		description: "watch",
+		runtimeKind: "command",
+		createdAt: 1,
+		expiresAt: null,
+		persistent: false,
+		suspended: false,
+		lastCheckpoint: null,
+		deliveryPaused: false,
+		wakeCount: 0,
+		fireWindow: { startMs: 1, count: 0 },
+		...overrides,
+	};
+}
+
+function countingHandler(seen: string[]): Pick<RestoreHandlers, "restartable-command" | "checkpointed-file"> {
+	const handler = (monitor: ManifestMonitor): RestoreHandlerResult => {
+		seen.push(monitor.monitorId);
+		return { outcome: "restored" };
+	};
+	return { "restartable-command": handler, "checkpointed-file": handler };
+}
+
+class EventSink {
+	readonly events: MonitorEvent[] = [];
+	readonly #listeners = new Set<(event: MonitorEvent) => void>();
+
+	push(event: MonitorEvent): void {
+		this.events.push(event);
+		for (const listener of this.#listeners) listener(event);
+	}
+
+	waitFor(predicate: (event: MonitorEvent) => boolean, label: string): Promise<MonitorEvent> {
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.#listeners.delete(listener);
+				reject(new Error(`Timed out waiting for ${label}`));
+			}, 5000);
+			const listener = (event: MonitorEvent) => {
+				if (!predicate(event)) return;
+				clearTimeout(timeout);
+				this.#listeners.delete(listener);
+				resolve(event);
+			};
+			this.#listeners.add(listener);
+		});
+	}
+}
+
+describe("terminal manifest writer", () => {
+	it("collapses five checkpoint updates inside the debounce window into one write", async () => {
+		vi.useFakeTimers();
+		try {
+			const { writer } = await makeFixture();
+			const writeSpy = vi.spyOn(writer.store, "write");
+			await writer.recordRegister({
+				monitorId: "mon_file1",
+				spec: {
+					kind: "file",
+					description: "wait for artifact",
+					path: "out.bin",
+					event: "modify",
+					timeoutMs: 300_000,
+					cwd: "/tmp",
+				},
+			});
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+			for (let i = 1; i <= 5; i += 1) {
+				writer.scheduleCheckpoint("mon_file1", { dev: 1, ino: i, size: 100 + i, mtimeMs: 1_000 + i });
+				await vi.advanceTimersByTimeAsync(5_000);
+			}
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+			await vi.advanceTimersByTimeAsync(30_000);
+			await writer.flush();
+			expect(writeSpy).toHaveBeenCalledTimes(2);
+			const manifest = await writer.store.read();
+			expect(manifest?.monitors[0]?.lastCheckpoint).toEqual({ dev: 1, ino: 5, size: 105, mtimeMs: 1_005 });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("settles a monitor with exactly one write and removes its manifest entry", async () => {
+		const { writer } = await makeFixture();
+		const writeSpy = vi.spyOn(writer.store, "write");
+		await writer.recordRegister({
+			monitorId: "mon_cmd1",
+			spec: { kind: "command", description: "tail logs", command: "tail -f app.log", persistent: true },
+		});
+		expect(writeSpy).toHaveBeenCalledTimes(1);
+		expect((await writer.store.read())?.monitors).toHaveLength(1);
+		await writer.observeMonitorState([]);
+		expect(writeSpy).toHaveBeenCalledTimes(2);
+		expect((await writer.store.read())?.monitors).toHaveLength(0);
+	});
+
+	it("fails closed on a corrupt manifest: typed read error and storeError digest without handler calls", async () => {
+		const { writer, sessionId } = await makeFixture();
+		await mkdir(dirname(writer.store.filePath), { recursive: true });
+		await writeFile(writer.store.filePath, "{ this is not json", "utf8");
+		await expect(writer.store.read()).rejects.toBeInstanceOf(InvalidSidecarStoreError);
+		await writeFile(
+			writer.store.filePath,
+			JSON.stringify({ version: 1, sessionId, monitors: "not-an-array", backgroundSessions: [], updatedAt: 1 }),
+			"utf8",
+		);
+		await expect(writer.store.read()).rejects.toBeInstanceOf(InvalidTerminalManifestError);
+		const seen: string[] = [];
+		const digest = await restoreTerminalState({
+			manifest: writer.store,
+			handlers: countingHandler(seen),
+		});
+		expect(digest).toEqual({ restored: 0, lost: 0, expired: 0, muted: 0, attachedElsewhere: 0, storeError: true });
+		expect(seen).toEqual([]);
+	});
+
+	it("classifies restartable-command and checkpointed-file entries through their stub handler slots as lost", async () => {
+		const { writer, sessionId } = await makeFixture();
+		await writer.store.write({
+			version: 1,
+			sessionId,
+			monitors: [
+				manifestMonitor({
+					monitorId: "mon_restart",
+					sessionId,
+					durabilityClass: "restartable-command",
+					persistent: true,
+					command: "tail -f app.log",
+				}),
+				manifestMonitor({
+					monitorId: "mon_file",
+					sessionId,
+					durabilityClass: "checkpointed-file",
+					runtimeKind: "file",
+					path: "out.bin",
+					event: "modify",
+					expiresAt: Date.now() + 60_000,
+				}),
+				manifestMonitor({ monitorId: "mon_ephemeral", sessionId, durabilityClass: "ephemeral" }),
+			],
+			backgroundSessions: [{ id: "bg-1", command: "echo done", startedAtMs: 5 }],
+			updatedAt: 2,
+		});
+		const digest = await restoreTerminalState({ manifest: writer.store, handlers: stubRestoreHandlers });
+		expect(digest).toEqual({ restored: 0, lost: 4, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+	});
+
+	it("expires monitors whose expiresAt has passed without calling their handler", async () => {
+		const { writer, sessionId } = await makeFixture();
+		const now = 5_000_000;
+		await writer.store.write({
+			version: 1,
+			sessionId,
+			monitors: [
+				manifestMonitor({
+					monitorId: "mon_stale",
+					sessionId,
+					durabilityClass: "checkpointed-file",
+					runtimeKind: "file",
+					path: "out.bin",
+					event: "modify",
+					expiresAt: now - 1_000,
+				}),
+			],
+			backgroundSessions: [],
+			updatedAt: 3,
+		});
+		const seen: string[] = [];
+		const digest = await restoreTerminalState({
+			manifest: writer.store,
+			handlers: countingHandler(seen),
+			now: () => now,
+		});
+		expect(digest).toEqual({ restored: 0, lost: 0, expired: 1, muted: 0, attachedElsewhere: 0, storeError: false });
+		expect(seen).toEqual([]);
+	});
+
+	it("records background start and exit as one write each", async () => {
+		const { writer } = await makeFixture();
+		const writeSpy = vi.spyOn(writer.store, "write");
+		await writer.recordBackgroundStart("bg-1", "echo done", 123);
+		expect(writeSpy).toHaveBeenCalledTimes(1);
+		expect((await writer.store.read())?.backgroundSessions).toEqual([
+			{ id: "bg-1", command: "echo done", startedAtMs: 123 },
+		]);
+		await writer.recordBackgroundExit("bg-1");
+		expect(writeSpy).toHaveBeenCalledTimes(2);
+		expect((await writer.store.read())?.backgroundSessions).toEqual([]);
+	});
+
+	it("surfaces an error for a snapshot entry missing its stable monitorId instead of skipping it", async () => {
+		const { writer } = await makeFixture();
+		const writeSpy = vi.spyOn(writer.store, "write");
+		const entry: MonitorSnapshotEntry = { id: "watch_1", description: "unidentified", paused: false, startedAtMs: 1 };
+		expect(() => writer.observeMonitorState([entry])).toThrow(/monitorId/);
+		await writer.flush();
+		expect(writeSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe("terminal manifest spec capture through the monitor tool", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+
+	beforeEach(() => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+	});
+
+	afterEach(() => {
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	function makeHarness(fixture: Fixture) {
+		const manager = new TerminalManager();
+		const sink = new EventSink();
+		const registry = new MonitorRegistry((event) => sink.push(event), {
+			onChange: (snapshot) => void fixture.writer.observeMonitorState(snapshot),
+		});
+		const ctx: TerminalToolContext = {
+			manager,
+			cwd: fixture.sessionDir,
+			defaultCols: 120,
+			defaultRows: 40,
+			getEnv: () => ({ ...process.env }),
+			onMonitorEvent: (event) => sink.push(event),
+			monitorRegistry: registry,
+			getSessionContext: () =>
+				({ sessionManager: { getSessionId: () => fixture.sessionId } }) as unknown as ExtensionContext,
+		};
+		return { manager, sink, registry, tool: createMonitorTool(ctx) };
+	}
+
+	it("registers an ephemeral monitor with exactly one write, durabilityClass ephemeral and expiresAt null", async () => {
+		const fixture = await makeFixture();
+		bindTerminalManifestWriter(fixture.sessionId, fixture.writer);
+		const harness = makeHarness(fixture);
+		try {
+			const writeSpy = vi.spyOn(fixture.writer.store, "write");
+			const result = await harness.tool.execute("manifest-create", {
+				description: "quiet watch",
+				command: "sleep 30",
+			});
+			await fixture.writer.flush();
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+			const manifest = await fixture.writer.store.read();
+			expect(manifest?.monitors).toHaveLength(1);
+			const entry = manifest?.monitors[0];
+			expect(entry?.durabilityClass).toBe("ephemeral");
+			expect(entry?.expiresAt).toBe(null);
+			expect(entry?.persistent).toBe(false);
+			expect(entry?.runtimeKind).toBe("command");
+			expect(entry?.command).toBe("sleep 30");
+			expect(entry?.monitorId).toBe(result.details?.monitor_id);
+			expect(entry?.sessionId).toBe(fixture.sessionId);
+		} finally {
+			await harness.manager.teardown();
+			harness.registry.dispose();
+			await fixture.writer.flush();
+			unbindTerminalManifestWriter(fixture.sessionId);
+		}
+	});
+
+	it("emits 500 matching PTY lines without any additional manifest writes", async () => {
+		const fixture = await makeFixture();
+		bindTerminalManifestWriter(fixture.sessionId, fixture.writer);
+		const harness = makeHarness(fixture);
+		try {
+			const writeSpy = vi.spyOn(fixture.writer.store, "write");
+			await harness.tool.execute("manifest-lines", {
+				description: "chatty watch",
+				command: "seq 1 500; sleep 30",
+			});
+			await harness.sink.waitFor((event) => event.type === "line" && event.line === "500", "500th monitor line");
+			await fixture.writer.flush();
+			expect(writeSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			await harness.manager.teardown();
+			harness.registry.dispose();
+			await fixture.writer.flush();
+			unbindTerminalManifestWriter(fixture.sessionId);
+		}
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-restore-digest.test.ts
+++ b/packages/coding-agent/test/suite/terminal-restore-digest.test.ts
@@ -1,0 +1,360 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerTerminalExtension } from "../../src/core/extensions/builtin/terminal/extension.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+
+/**
+ * Passthrough counters so the tests can prove ordering and call discipline
+ * (manifest read, restore invocation, handler calls, checkpoint flush, spawn)
+ * without stubbing any behavior away.
+ */
+const trackers = vi.hoisted(() => ({
+	restoreCalls: 0,
+	handlerCalls: 0,
+	writerFlushes: 0,
+	spawnCalls: 0,
+}));
+
+vi.mock("../../src/core/extensions/builtin/terminal/restore.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../../src/core/extensions/builtin/terminal/restore.ts")>();
+	return {
+		...original,
+		restoreTerminalState: async (options: Parameters<typeof original.restoreTerminalState>[0]) => {
+			trackers.restoreCalls += 1;
+			let forwarded = options;
+			const handlers = options.handlers;
+			if (handlers) {
+				const wrapped: Record<string, unknown> = {};
+				for (const [key, handler] of Object.entries(handlers)) {
+					wrapped[key] = (monitor: unknown) => {
+						trackers.handlerCalls += 1;
+						return (handler as (monitor: unknown) => unknown)(monitor);
+					};
+				}
+				forwarded = { ...options, handlers: wrapped } as typeof options;
+			}
+			return original.restoreTerminalState(forwarded);
+		},
+	};
+});
+
+vi.mock("../../src/core/extensions/builtin/terminal/terminal-manifest.ts", async (importOriginal) => {
+	const original =
+		await importOriginal<typeof import("../../src/core/extensions/builtin/terminal/terminal-manifest.ts")>();
+	return {
+		...original,
+		TerminalManifestWriter: class extends original.TerminalManifestWriter {
+			recordShutdown(): Promise<void> {
+				trackers.writerFlushes += 1;
+				return super.recordShutdown();
+			}
+		},
+	};
+});
+
+vi.mock("../../src/core/extensions/builtin/terminal/tools/spawn.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../../src/core/extensions/builtin/terminal/tools/spawn.ts")>();
+	return {
+		...original,
+		spawnCommandSession: (...args: Parameters<typeof original.spawnCommandSession>) => {
+			trackers.spawnCalls += 1;
+			return original.spawnCommandSession(...args);
+		},
+	};
+});
+
+type Handler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+
+interface ToolResultLike {
+	content: Array<{ type: string; text?: string }>;
+	isError?: boolean;
+	details?: { bash_id?: string };
+}
+
+interface ToolLike {
+	name: string;
+	execute: (id: string, input: Record<string, unknown>) => Promise<ToolResultLike>;
+}
+
+interface SentMessage {
+	message: { customType: string; content: string; display: boolean };
+	options: { triggerTurn?: boolean; deliverAs?: string };
+}
+
+/** One extension-runner generation, mirroring how AgentSession.reload() swaps runners. */
+interface Generation {
+	pi: ExtensionAPI;
+	tools: Map<string, ToolLike>;
+	sent: SentMessage[];
+	userMessages: string[];
+	emit(eventType: string, payload: Record<string, unknown>): Promise<void>;
+}
+
+function firstText(result: ToolResultLike | undefined): string {
+	return result?.content.find((block) => block.type === "text")?.text ?? "";
+}
+
+function createGeneration(cwd: string, sessionId: string, sessionDir: string): Generation {
+	const handlers = new Map<string, Handler[]>();
+	const tools = new Map<string, ToolLike>();
+	const sent: SentMessage[] = [];
+	const userMessages: string[] = [];
+	let activeTools: string[] = [];
+	const pi = {
+		registerTool: (tool: ToolLike) => tools.set(tool.name, tool),
+		on: (eventType: string, handler: Handler) => {
+			const registered = handlers.get(eventType) ?? [];
+			registered.push(handler);
+			handlers.set(eventType, registered);
+		},
+		sendMessage: (message: SentMessage["message"], options: SentMessage["options"]) => {
+			sent.push({ message, options });
+		},
+		sendUserMessage: (content: string) => userMessages.push(String(content)),
+		getActiveTools: () => activeTools,
+		setActiveTools: (next: string[]) => {
+			activeTools = next;
+		},
+	} as unknown as ExtensionAPI;
+	const ctx: ExtensionContext = {
+		cwd,
+		mode: "tui",
+		model: { id: "test-model", api: "openai-completions" },
+		ui: { setStatus: () => {}, notify: () => {}, theme },
+		sessionManager: {
+			getSessionId: () => sessionId,
+			getSessionFile: () => join(sessionDir, `${sessionId}.jsonl`),
+			getSessionDir: () => sessionDir,
+		},
+	} as unknown as ExtensionContext;
+	return {
+		pi,
+		tools,
+		sent,
+		userMessages,
+		async emit(eventType, payload) {
+			for (const handler of handlers.get(eventType) ?? []) await handler(payload, ctx);
+		},
+	};
+}
+
+function terminalMessages(generation: Generation): SentMessage[] {
+	return generation.sent.filter((entry) => entry.message.customType === "senpi-terminal:notification");
+}
+
+function reminderContents(generation: Generation): string[] {
+	return terminalMessages(generation).map((entry) => entry.message.content);
+}
+
+describe("terminal restore digest — lease, manifest restore, one resume digest", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+	const savedAgentDir = process.env.SENPI_CODING_AGENT_DIR;
+	let tmp: string;
+	let cwd: string;
+	let sessionDir: string;
+	let stateDir: string;
+	let sessionId: string;
+	let live: Generation[] = [];
+	let extraChildren: Array<{ kill(): void }> = [];
+	let counter = 0;
+
+	beforeEach(() => {
+		initTheme("dark");
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		tmp = mkdtempSync(join(tmpdir(), "senpi-restore-digest-"));
+		process.env.SENPI_CODING_AGENT_DIR = join(tmp, "agent-home");
+		cwd = join(tmp, "project");
+		sessionDir = join(tmp, "sessions");
+		mkdirSync(join(cwd, ".senpi"), { recursive: true });
+		writeFileSync(join(cwd, ".senpi", "settings.json"), JSON.stringify({ terminal: { notify: "wake" } }));
+		sessionId = `restore-digest-${Date.now().toString(36)}-${++counter}`;
+		stateDir = join(sessionDir, "extensions", "terminal");
+		live = [];
+		extraChildren = [];
+		trackers.restoreCalls = 0;
+		trackers.handlerCalls = 0;
+		trackers.writerFlushes = 0;
+		trackers.spawnCalls = 0;
+	});
+
+	afterEach(async () => {
+		for (const generation of live) {
+			await generation.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		}
+		for (const child of extraChildren) child.kill();
+		rmSync(tmp, { recursive: true, force: true });
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+		if (savedAgentDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+		else process.env.SENPI_CODING_AGENT_DIR = savedAgentDir;
+	});
+
+	async function start(reason: string): Promise<Generation> {
+		const generation = createGeneration(cwd, sessionId, sessionDir);
+		registerTerminalExtension(generation.pi);
+		live.push(generation);
+		await generation.emit("session_start", { type: "session_start", reason });
+		return generation;
+	}
+
+	function leasePath(): string {
+		return join(stateDir, `${encodeURIComponent(sessionId)}.lease`);
+	}
+
+	function manifestPath(): string {
+		return join(stateDir, `${encodeURIComponent(sessionId)}.json`);
+	}
+
+	async function startMonitor(generation: Generation, description: string): Promise<void> {
+		const created = await generation.tools.get("monitor")?.execute(`mon-${description}`, {
+			description,
+			command: "cat",
+			persistent: true,
+		});
+		expect(created?.isError, firstText(created)).toBeFalsy();
+	}
+
+	it("(a) restart after quit delivers exactly one digest naming every monitor and background session as lost", async () => {
+		const gen1 = await start("startup");
+		expect(gen1.sent).toHaveLength(0);
+		trackers.restoreCalls = 0;
+		await startMonitor(gen1, "watch alpha");
+		await startMonitor(gen1, "watch beta");
+		await startMonitor(gen1, "watch gamma");
+		const background = await gen1.tools.get("bash")?.execute("bg-build", {
+			command: "cat",
+			description: "background build log",
+			run_in_background: true,
+		});
+		expect(background?.isError).toBeFalsy();
+
+		await gen1.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		live = [];
+		expect(existsSync(manifestPath())).toBe(true);
+
+		const gen2 = await start("resume");
+		expect(trackers.restoreCalls).toBe(1);
+		expect(reminderContents(gen2)).toEqual([
+			"<system-reminder>Terminal state after restart: lost 4 (watch alpha, watch beta, watch gamma, background build log).</system-reminder>",
+		]);
+		expect(terminalMessages(gen2)).toHaveLength(1);
+		expect(gen2.userMessages).toEqual([]);
+	});
+
+	it("(b) a reload start claims the parked bundle, sends no digest, and keeps the lease with the same pid", async () => {
+		const gen1 = await start("startup");
+		const created = await gen1.tools.get("bash")?.execute("bg-reload", {
+			command: "sh -c 'echo before-reload-marker; cat'",
+			run_in_background: true,
+		});
+		const bashId = created?.details?.bash_id;
+		expect(bashId).toMatch(/^bash_\d+$/);
+		expect(existsSync(leasePath())).toBe(true);
+		trackers.restoreCalls = 0;
+
+		await gen1.emit("session_shutdown", { type: "session_shutdown", reason: "reload" });
+		live = [];
+		const gen2 = await start("reload");
+
+		expect(trackers.restoreCalls).toBe(0);
+		expect(terminalMessages(gen2)).toHaveLength(0);
+		expect(existsSync(leasePath())).toBe(true);
+
+		const peeked = await gen2.tools.get("bash_output")?.execute("peek-reload", {
+			bash_id: bashId,
+			view: "screen",
+		});
+		expect(peeked?.isError).toBeFalsy();
+		expect(firstText(peeked)).toContain("before-reload-marker");
+	});
+
+	it("(c) a lease held by a live pid yields one attached-elsewhere reminder and zero spawns", async () => {
+		const child = spawn("sleep", ["30"], { stdio: "ignore" });
+		extraChildren.push(child);
+		expect(child.pid).toBeDefined();
+		mkdirSync(stateDir, { recursive: true });
+		writeFileSync(leasePath(), JSON.stringify({ pid: child.pid, startedAtMs: Date.now() }), "utf8");
+
+		const generation = await start("resume");
+
+		expect(reminderContents(generation)).toEqual([
+			`<system-reminder>Terminal monitors for this session are attached in another live process (pid ${child.pid}); nothing was restored here.</system-reminder>`,
+		]);
+		expect(trackers.restoreCalls).toBe(0);
+		expect(trackers.spawnCalls).toBe(0);
+	});
+
+	it("(d) a corrupt manifest yields one fail-closed reminder and no handler call", async () => {
+		mkdirSync(stateDir, { recursive: true });
+		writeFileSync(manifestPath(), "not-a-manifest{{{", "utf8");
+
+		const generation = await start("resume");
+
+		const contents = reminderContents(generation);
+		expect(contents).toHaveLength(1);
+		expect(contents[0]).toContain("corrupt");
+		expect(contents[0]).toContain("<system-reminder>");
+		expect(trackers.handlerCalls).toBe(0);
+	});
+
+	it("(e) notify mode off suppresses every message while the manifest is still read and the lease acquired", async () => {
+		writeFileSync(join(cwd, ".senpi", "settings.json"), JSON.stringify({ terminal: { notify: "off" } }));
+		mkdirSync(stateDir, { recursive: true });
+		writeFileSync(
+			manifestPath(),
+			JSON.stringify({
+				version: 1,
+				sessionId,
+				monitors: [
+					{
+						monitorId: "mon_offseason000000001",
+						sessionId,
+						description: "muted watch",
+						runtimeKind: "command",
+						durabilityClass: "ephemeral",
+						createdAt: Date.now(),
+						expiresAt: null,
+						persistent: false,
+						suspended: true,
+						lastCheckpoint: null,
+						deliveryPaused: true,
+						wakeCount: 0,
+						fireWindow: { startMs: 1, count: 0 },
+					},
+				],
+				backgroundSessions: [],
+				updatedAt: Date.now(),
+			}),
+			"utf8",
+		);
+
+		const generation = await start("resume");
+
+		expect(generation.sent).toHaveLength(0);
+		expect(trackers.restoreCalls).toBeGreaterThanOrEqual(1);
+		expect(existsSync(leasePath())).toBe(true);
+	});
+
+	it("(f) a non-reload shutdown flushes the manifest as suspended and releases the lease", async () => {
+		const generation = await start("startup");
+		await startMonitor(generation, "watch delta");
+		await expect.poll(() => existsSync(manifestPath()), { timeout: 3000 }).toBe(true);
+		expect(existsSync(leasePath())).toBe(true);
+
+		await generation.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		live = [];
+
+		expect(trackers.writerFlushes).toBeGreaterThanOrEqual(1);
+		expect(existsSync(leasePath())).toBe(false);
+		const manifest = JSON.parse(readFileSync(manifestPath(), "utf8")) as {
+			monitors: Array<{ description: string; suspended: boolean }>;
+		};
+		expect(
+			manifest.monitors.map((entry) => ({ description: entry.description, suspended: entry.suspended })),
+		).toEqual([{ description: "watch delta", suspended: true }]);
+	});
+});


### PR DESCRIPTION
## What

Phase 2 of the durable-monitor work: terminal state is now **recorded**, and a restart **reports** it instead of losing it silently.

- **`core/session-sidecar-store.ts` is now shared.** `loop/store.ts` drops its private promise tail, atomic writer and snapshot cache; `goal/store.ts` drops its byte-identical `enqueueGoalMutation` for the primitive's `serializeByKey`. Goal deliberately keeps its own writer — `persistence.ts` was *already* atomic and owns an exclusive-create (`wx`) variant — so it takes the serialization only, and its ref stays `{ baseDir, threadId }` with the cwd-hashed no-session path so **no goal file moves**.
- **`terminal/terminal-manifest.ts` (new)** persists live monitors and background bash sessions to `<sessionDir>/extensions/terminal/<encodedSessionId>.json`: versioned, atomic, fail-closed on a corrupt or wrong-version payload. Writes happen only on real transitions plus a debounced checkpoint — **never per output line** — and the spec is captured at the tool call site so the registry stays free of durability policy.
- **`terminal/restore.ts` (new)** replays that manifest into durability-class handler slots. Ephemeral monitors and background sessions are always lost, an expired watch never reaches its handler, and **both durable slots ship as stubs reporting `lost`** — the classes that actually resume them land in the next phase.
- **One report, once.** A fresh (non-reload) start takes the exclusive restore lease, replays the manifest, and sends **exactly one** notification covering restored / lost / expired / unreadable, however many monitors are involved. Shutdown suspends entries, flushes the checkpoint, releases the lease. **Reload is untouched**: it still parks and reclaims its bundle, keeps the lease under the same pid, and emits no report.

## Verification

```
terminal regression gate (14 suites)     ->  132 tests passed
new P2 suites + loop/goal migration net  ->  208 tests passed
bunx tsc --noEmit                        ->  clean
```

Both store migrations pass their **pre-existing suites unedited** — that is the characterization net for the refactor, and no test file of theirs is touched by this PR.

A production defect found during review is fixed here and **mutation-proven**: `manifestSessionKey` guarded the context but not `sessionManager`, so a manager-less context (real embedders, and one pre-existing footer test) crashed `createMonitor` with `TypeError: ... reading 'getSessionId'`. Removing the guard reproduces exactly that failure; restoring it returns the suite to green. A context without a session manager now records nothing and the monitor stays ephemeral.

## Scope

`monitor-notify.ts` and `monitor-registry.ts` diffs are empty — notifier mechanics and the registry are deliberately frozen. New files: `terminal-manifest.ts` 250 LOC, `restore.ts` 187 LOC.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records terminal monitors and background bash sessions per session and reports what was restored, lost, expired, or unreadable in exactly one notification on fresh startup, instead of dropping it silently. Durable watches report as lost for now; reloads keep live state and emit no report.

**Refactors**
- `loop/store.ts` and `goal/store.ts` now share the sidecar store's mutation serializer, dropping duplicated promise tails, atomic writers, and snapshot caches; goal keeps its own writer, so no goal file moves.

**Behavior**
- The manifest persists to `<sessionDir>/extensions/terminal/<encodedSessionId>.json`, written only on lifecycle transitions plus a debounced checkpoint, never per output line.
- Fresh startup takes an exclusive restore lease and sends one coalesced digest; shutdown suspends entries, flushes pending checkpoints, and releases the lease.
- Ephemeral monitors and background sessions are always lost; both durable classes ship as stubs reporting `lost` until resumption lands in a later phase.
- `createMonitor` no longer crashes on contexts without a session manager; such contexts record nothing and keep the monitor ephemeral.

<sup>Written for commit 39ea040d6fa2875462c6c0d4d55e09938f7e7758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

