### PR TITLE
feat(terminal): make persistent monitors survive restarts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Persistent monitors now survive repeated restarts: file watches are re-registered and compare their persisted checkpoint once, reporting exactly one detached created, replaced, or modified change (and nothing when unchanged), while command watches are re-run once under the same `mon_` id without replaying pre-restart output. Sessions may keep up to five durable watches; each expires seven days after creation without extending that deadline on restart or rearm, and a watch muted by the wake budget remains muted when restored.
+
 ### Changed
 
 ### Fixed

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/durable-command.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/durable-command.ts
@@ -1,0 +1,109 @@
+/**
+ * The `restartable-command` durability class: the restore handler that brings a persistent
+ * command monitor back after a restart. It re-spawns the saved command EXACTLY ONCE, in the
+ * saved working directory, with NO timeout (a persistent watch has no deadline), and
+ * re-registers it under the SAVED `mon_` id so the stable handle the agent already knows
+ * keeps resolving. Nothing the pre-restart PTY produced is replayed — no output is persisted
+ * anywhere, so a restored watch starts from an empty buffer by construction.
+ */
+
+import { stat } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+import type { MonitorRegistry } from "./monitor-registry.ts";
+import { type RestoreHandler, type RestoreHandlerResult, reapplyPersistedMute } from "./restore.ts";
+import { DEFAULT_COLS, DEFAULT_ROWS } from "./shared.ts";
+import type { ManifestMonitor } from "./terminal-manifest.ts";
+import type { TerminalToolContext } from "./tools/context.ts";
+import { spawnCommandSession } from "./tools/spawn.ts";
+
+export interface RestartableCommandDeps {
+	/** Spawn target: supplies the terminal manager, shell config, env and default geometry. */
+	readonly ctx: TerminalToolContext;
+	/** The live registry this generation owns; the restored watch is registered here. */
+	readonly registry: MonitorRegistry;
+	/** Seam for tests and future callers; defaults to the real PTY spawn. */
+	readonly spawn?: typeof spawnCommandSession;
+	/** Directory existence probe; defaults to a real stat of the saved cwd. */
+	readonly directoryExists?: (path: string) => Promise<boolean>;
+	/** Called after a successful restore with the stable id and its fresh runtime id. */
+	readonly onRestored?: (monitorId: string, runtimeId: string) => void;
+}
+
+const LOST: RestoreHandlerResult = { outcome: "lost" };
+
+async function defaultDirectoryExists(path: string): Promise<boolean> {
+	try {
+		return (await stat(path)).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function compileFilter(source: string | undefined): RegExp | undefined {
+	if (source === undefined) return undefined;
+	try {
+		return new RegExp(source);
+	} catch {
+		// A filter that no longer compiles must not sink the watch: restore it unfiltered.
+		return undefined;
+	}
+}
+
+function dimension(value: number | undefined, fallback: number): number {
+	return value !== undefined && Number.isFinite(value) && value >= 1 ? Math.trunc(value) : fallback;
+}
+
+/**
+ * Decide whether a manifest entry is a restorable persistent command watch. Only the
+ * command runtime kind qualifies, only when it was created `persistent: true` (a
+ * non-persistent watch had a deadline and is deliberately not resurrected), and only
+ * when it actually carries a command and an absolute cwd to spawn it in.
+ */
+function restorable(monitor: ManifestMonitor): { command: string; cwd: string } | undefined {
+	if (monitor.runtimeKind !== "command" || !monitor.persistent) return undefined;
+	const { command, cwd } = monitor;
+	if (command === undefined || command.length === 0) return undefined;
+	if (cwd === undefined || !isAbsolute(cwd)) return undefined;
+	return { command, cwd };
+}
+
+/**
+ * Build the `restartable-command` restore handler. Every guard rejects BEFORE spawning, so a
+ * rejected entry costs zero PTY sessions; a spawn failure is reported lost rather than thrown,
+ * because restore must never fail the startup path for one unrecoverable watch.
+ */
+export function createRestartableCommandHandler(deps: RestartableCommandDeps): RestoreHandler {
+	const spawn = deps.spawn ?? spawnCommandSession;
+	const directoryExists = deps.directoryExists ?? defaultDirectoryExists;
+	return async (monitor: ManifestMonitor): Promise<RestoreHandlerResult> => {
+		const target = restorable(monitor);
+		if (target === undefined) return LOST;
+		if (!(await directoryExists(target.cwd))) return LOST;
+
+		let spawned: Awaited<ReturnType<typeof spawnCommandSession>>;
+		try {
+			spawned = await spawn(deps.ctx, {
+				command: target.command,
+				cols: dimension(deps.ctx.defaultCols, DEFAULT_COLS),
+				rows: dimension(deps.ctx.defaultRows, DEFAULT_ROWS),
+				cwd: target.cwd,
+				// Persistent watches carry no deadline: omit timeoutMs entirely.
+			});
+		} catch {
+			return LOST;
+		}
+
+		deps.registry.register({
+			id: spawned.id,
+			monitorId: monitor.monitorId,
+			description: monitor.description,
+			runtime: spawned.runtime,
+			filter: compileFilter(monitor.filter),
+		});
+		deps.ctx.manager.bindMonitorId(monitor.monitorId, spawned.id);
+		deps.onRestored?.(monitor.monitorId, spawned.id);
+		// A persisted mute is re-applied by the FRESH runtime id; the registry resolves
+		// records by runtime id only, so the mon_ id would silently no-op here.
+		return { outcome: reapplyPersistedMute(deps.registry, monitor, spawned.id) };
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/durable-file.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/durable-file.ts
@@ -1,0 +1,120 @@
+/**
+ * The `checkpointed-file` durability class: the restore handler that makes a persistent file
+ * watch survive a restart. On create the monitor tool persists the registry's own identity
+ * tuple (dev/ino/size/mtimeMs/digest/present) as the manifest checkpoint; here that checkpoint
+ * is compared ONCE against the file as it is now, and any change that happened while the process
+ * was gone is reported as EXACTLY ONE line through the registry's normal event sink — so the
+ * notifier's coalescing and wake budget apply to it exactly as they do to a live watch event.
+ *
+ * `digest` is load-bearing: without it a same-size, same-mtime rewrite is invisible across a restart.
+ */
+
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { MonitorRegistry } from "./monitor-registry.ts";
+import type { RestoreHandler, RestoreHandlerResult } from "./restore.ts";
+import type { ManifestMonitor, TerminalManifestCheckpoint, TerminalManifestWriter } from "./terminal-manifest.ts";
+
+/**
+ * What a detached change is reported as. `null` means the file is byte-identical to the checkpoint;
+ * `"gone"` means it existed at checkpoint time and does not now, which is not restorable.
+ */
+export type DetachedChange = "created" | "replaced" | "modified" | "gone" | null;
+
+/** Only what the handler needs, so a caller can hand it a narrower registry/writer. */
+export interface CheckpointedFileRestoreDeps {
+	readonly registry: Pick<MonitorRegistry, "registerFile" | "fileCheckpoint" | "emitFileLine" | "stopFile">;
+	/** Optional: the durable checkpoint is re-persisted through the writer when one is bound. */
+	readonly writer?: Pick<TerminalManifestWriter, "scheduleCheckpoint">;
+	/** Optional: re-bind the stable `mon_` id to its fresh runtime id so kill_bash keeps resolving it. */
+	readonly bindMonitorId?: (monitorId: string, runtimeId: string) => void;
+	readonly now?: () => number;
+}
+
+/** The live tuple `registry.fileCheckpoint` returns; identical in shape to the persisted checkpoint. */
+type LiveCheckpoint = NonNullable<ReturnType<MonitorRegistry["fileCheckpoint"]>>;
+
+/**
+ * The single comparison, run once per restore. `created` and `replaced` outrank `modified`:
+ * an absent→present transition or a new dev/ino is a stronger statement about the same file.
+ */
+export function classifyDetachedChange(saved: TerminalManifestCheckpoint, live: LiveCheckpoint): DetachedChange {
+	if (!saved.present) return live.present ? "created" : null;
+	if (!live.present) return "gone";
+	if (live.dev !== saved.dev || live.ino !== saved.ino) return "replaced";
+	if (live.mtimeMs !== saved.mtimeMs || live.size !== saved.size || live.digest !== saved.digest) return "modified";
+	return null;
+}
+
+function lost(reason: string): RestoreHandlerResult {
+	return { outcome: "lost", reason };
+}
+
+/** Remaining lifetime of a durable watch; a watch with no recorded expiry keeps its default window. */
+function remainingMs(monitor: ManifestMonitor, now: number): number {
+	if (monitor.expiresAt === null) return DEFAULT_RESTORED_WATCH_MS;
+	return Math.max(1, monitor.expiresAt - now);
+}
+
+const DEFAULT_RESTORED_WATCH_MS = 300_000;
+
+/**
+ * Build the `checkpointed-file` restore handler. It re-registers the watch under its original
+ * `mon_` id and approved parent (so the permission decision still holds), then reports at most
+ * one detached-change line. Returns `lost` when the path is gone or unreadable, `restored` otherwise.
+ */
+export function createCheckpointedFileRestoreHandler(deps: CheckpointedFileRestoreDeps): RestoreHandler {
+	const now = deps.now ?? Date.now;
+	return async (monitor: ManifestMonitor): Promise<RestoreHandlerResult> => {
+		if (monitor.runtimeKind !== "file" || monitor.path === undefined || monitor.cwd === undefined) {
+			return lost(`monitor ${monitor.monitorId} is not a restorable file watch`);
+		}
+		const saved = monitor.lastCheckpoint;
+		if (saved === null) return lost(`monitor ${monitor.monitorId} has no checkpoint to compare against`);
+		// A watch whose file existed at checkpoint time but is gone or unreadable now cannot be
+		// resumed; probe BEFORE re-registering so a lost restore never leaves a live watch behind.
+		if (saved.present) {
+			try {
+				const target = await stat(resolve(monitor.cwd, monitor.path));
+				if (!target.isFile()) return lost(`watched path is no longer a regular file: ${monitor.path}`);
+			} catch (error) {
+				return lost(`watched path is gone: ${monitor.path} (${error instanceof Error ? error.message : error})`);
+			}
+		}
+
+		let runtimeId: string;
+		try {
+			const registered = await deps.registry.registerFile({
+				description: monitor.description,
+				path: monitor.path,
+				monitorId: monitor.monitorId,
+				event: monitor.event ?? "create",
+				timeoutMs: remainingMs(monitor, now()),
+				cwd: monitor.cwd,
+				// Preserve the parent approved at permission time: registerFile re-checks it.
+				...(monitor.approvedParent !== undefined ? { approvedParent: monitor.approvedParent } : {}),
+			});
+			runtimeId = registered.id;
+		} catch (error) {
+			return lost(`cannot re-watch ${monitor.path}: ${error instanceof Error ? error.message : String(error)}`);
+		}
+
+		const live = deps.registry.fileCheckpoint(runtimeId);
+		if (live === undefined) return lost(`monitor ${monitor.monitorId} settled before its checkpoint was compared`);
+
+		const change = classifyDetachedChange(saved, live);
+		if (change === "gone") {
+			// Lost the race with a deletion between the probe and re-registration: report lost, not a
+			// change, and settle the watch just registered so a lost restore leaves nothing behind.
+			await deps.registry.stopFile(runtimeId);
+			return lost(`watched path is gone: ${monitor.path}`);
+		}
+
+		deps.bindMonitorId?.(monitor.monitorId, runtimeId);
+		if (change !== null) deps.registry.emitFileLine(runtimeId, `changed while detached: ${change} ${monitor.path}`);
+		// Re-checkpoint on every restore: after `replaced` this is the new identity, and otherwise
+		// it re-states the tuple the next restart compares against.
+		deps.writer?.scheduleCheckpoint(monitor.monitorId, live);
+		return { outcome: "restored" };
+	};
+}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/extension.ts
@@ -6,13 +6,22 @@ import type { ExtensionAPI, ExtensionContext } from "../../types.ts";
 import { isAnthropicBashEnabled } from "../anthropic-bash/index.ts";
 import { isEvalOnlyRouting } from "../eval-only-routing.ts";
 import { TERMINAL_MONITOR_STATE_EVENT, WAKE_SOURCE_STATE_EVENT } from "../monitor-state-event.ts";
+import { createRestartableCommandHandler } from "./durable-command.ts";
+import { createCheckpointedFileRestoreHandler } from "./durable-file.ts";
 import { acquireTerminalLease, releaseTerminalLease } from "./manifest-lease.ts";
 import { MonitorNotifier } from "./monitor-notify.ts";
 import { MONITOR_STATUS_KEY } from "./monitor-status.ts";
 import { MonitorStatusTicker } from "./monitor-status-ticker.ts";
 import { getTerminalNotificationDelivery, TerminalNotifier } from "./notify.ts";
 import { buildTerminalPromptSection } from "./prompt.ts";
-import { type RestoreDigest, type RestoreHandlers, type RestoreOutcome, restoreTerminalState } from "./restore.ts";
+import {
+	type RestoreDigest,
+	type RestoreHandler,
+	type RestoreHandlers,
+	type RestoreOutcome,
+	reapplyPersistedMute,
+	restoreTerminalState,
+} from "./restore.ts";
 import type { TerminalRuntimeSession } from "./runtime-session.ts";
 import {
 	claimParkedBundle,
@@ -239,6 +248,8 @@ function restoreDigestSentence(
 async function adoptPersistedTerminalState(
 	pi: ExtensionAPI,
 	state: TerminalExtensionState,
+	toolCtx: TerminalToolContext,
+	bundle: TerminalSessionBundle,
 	sessionKey: string,
 ): Promise<void> {
 	const ctx = state.ctx;
@@ -259,15 +270,46 @@ async function adoptPersistedTerminalState(
 	state.recordedBackgroundIds.clear();
 	bindTerminalManifestWriter(sessionKey, writer);
 
-	// Restoration handlers: this generation does not re-spawn persisted commands on its own,
-	// so every durable entry reports lost; the outcomes still flow through the orchestrator.
-	const outcomesById = new Map<string, RestoreOutcome>();
-	const reportLost = (monitor: ManifestMonitor): { outcome: RestoreOutcome } => {
-		outcomesById.set(monitor.monitorId, "lost");
-		return { outcome: "lost" };
-	};
-	const handlers: RestoreHandlers = { "restartable-command": reportLost, "checkpointed-file": reportLost };
+	// The real durability handlers, built from what this restore site already owns: the live
+	// registry/manager of the bundle created for this generation, plus the manifest writer.
+	// Each monitor's REAL outcome is recorded so the digest attributes descriptions correctly.
 	const nowMs = Date.now();
+	const outcomesById = new Map<string, RestoreOutcome>();
+	const registry = bundle.monitors;
+	const record = (handler: RestoreHandler): RestoreHandler => {
+		return async (monitor: ManifestMonitor) => {
+			const result = await handler(monitor);
+			outcomesById.set(monitor.monitorId, result.outcome);
+			// Re-adopt every entry that is LIVE in this generation, so the next persist rewrites
+			// the manifest with it instead of erasing it: `restored` and `muted` both describe a
+			// live monitor (a mute only silences delivery). `lost`/`expired`/`attachedElsewhere`
+			// are deliberately not adopted — nothing is running for them here.
+			if (result.outcome === "restored" || result.outcome === "muted") writer.adoptRestored(monitor);
+			return result;
+		};
+	};
+	const restartableCommand = createRestartableCommandHandler({ ctx: toolCtx, registry });
+	// The file handler re-binds the mon_ id to the fresh runtime id; capture that id here so a
+	// persisted mute is re-applied by the runtime id the registry can actually resolve.
+	let freshFileRuntimeId: string | undefined;
+	const checkpointedFile = createCheckpointedFileRestoreHandler({
+		registry,
+		writer,
+		bindMonitorId: (monitorId, runtimeId) => {
+			freshFileRuntimeId = runtimeId;
+			bundle.manager.bindMonitorId(monitorId, runtimeId);
+		},
+		now: () => nowMs,
+	});
+	const handlers: RestoreHandlers = {
+		"restartable-command": record(restartableCommand),
+		"checkpointed-file": record(async (monitor) => {
+			freshFileRuntimeId = undefined;
+			const result = await checkpointedFile(monitor);
+			if (result.outcome !== "restored" || freshFileRuntimeId === undefined) return result;
+			return { ...result, outcome: reapplyPersistedMute(registry, monitor, freshFileRuntimeId) };
+		}),
+	};
 	const digest = await restoreTerminalState({ manifest: writer.store, handlers, now: () => nowMs });
 
 	let manifest = null;
@@ -292,9 +334,13 @@ async function adoptPersistedTerminalState(
 	const restoredDescriptions: string[] = [];
 	const lostDescriptions: string[] = [];
 	for (const monitor of manifest.monitors) {
-		if (monitor.expiresAt !== null && monitor.expiresAt < nowMs) continue;
-		if (outcomesById.get(monitor.monitorId) === "restored") restoredDescriptions.push(monitor.description);
-		else lostDescriptions.push(monitor.description);
+		// Same boundary as the restore orchestrator: at the deadline the entry is expired.
+		if (monitor.expiresAt !== null && monitor.expiresAt <= nowMs) continue;
+		const outcome = outcomesById.get(monitor.monitorId);
+		// Only `restored` and `lost` carry descriptions; a muted restore is reported by its own
+		// count clause, so naming it under either list would desync the clause counts.
+		if (outcome === "restored") restoredDescriptions.push(monitor.description);
+		else if (outcome === undefined || outcome === "lost") lostDescriptions.push(monitor.description);
 	}
 	for (const background of manifest.backgroundSessions) lostDescriptions.push(background.command);
 	const sentence = restoreDigestSentence(digest, restoredDescriptions, lostDescriptions);
@@ -395,7 +441,7 @@ export function registerTerminalExtension(pi: ExtensionAPI): void {
 				bindTerminalManifestWriter(sessionKey, writer);
 			}
 		} else if (sessionKey !== undefined) {
-			await adoptPersistedTerminalState(pi, state, sessionKey);
+			await adoptPersistedTerminalState(pi, state, toolCtx, state.bundle, sessionKey);
 		}
 		syncToolset(pi, state);
 	});

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/monitor-registry.ts
@@ -345,6 +345,22 @@ export class MonitorRegistry {
 		return { id, monitorId: record.monitorId };
 	}
 
+	/** Live identity tuple of one file watch; undefined when the id is not a live file watch. */
+	fileCheckpoint(id: string) {
+		const r = this.#files.get(id);
+		return (
+			r && { dev: r.device, ino: r.inode, size: r.size, mtimeMs: r.mtimeMs, digest: r.digest, present: r.present }
+		);
+	}
+
+	/** Emit one restored-watch line through the SAME sink a live watch uses (coalescing, wake budget). */
+	emitFileLine(id: string, line: string): boolean {
+		const record = this.#files.get(id);
+		if (!record || record.settled) return false;
+		this.#emit({ type: "line", id: record.id, description: record.description, line });
+		return true;
+	}
+
 	async stopFile(id: string): Promise<boolean> {
 		const record = this.#files.get(id);
 		if (!record) return false;

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/restore.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/restore.ts
@@ -13,6 +13,7 @@ import {
 	type ManifestMonitor,
 	TERMINAL_MANIFEST_VERSION,
 	type TerminalManifest,
+	type TerminalManifestCheckpoint,
 } from "./terminal-manifest.ts";
 
 export class InvalidTerminalManifestError extends InvalidSidecarStoreError {
@@ -46,6 +47,11 @@ function num(raw: Raw, field: string): number {
 	return raw[field];
 }
 
+function digest(raw: Raw, field: string): string {
+	if (typeof raw[field] !== "string") invalid(`field ${field} must be a string`);
+	return raw[field];
+}
+
 function bool(raw: Raw, field: string): boolean {
 	if (!isBool(raw[field])) invalid(`field ${field} must be a boolean`);
 	return raw[field];
@@ -62,9 +68,18 @@ function oneOf<T extends string>(values: readonly T[], raw: Raw, field: string):
 	return value as T;
 }
 
-function checkpoint(raw: unknown): { dev: number; ino: number; size: number; mtimeMs: number } {
+function checkpoint(raw: unknown): TerminalManifestCheckpoint {
 	if (!isObj(raw)) invalid("field lastCheckpoint must be an object");
-	return { dev: num(raw, "dev"), ino: num(raw, "ino"), size: num(raw, "size"), mtimeMs: num(raw, "mtimeMs") };
+	return {
+		dev: num(raw, "dev"),
+		ino: num(raw, "ino"),
+		size: num(raw, "size"),
+		mtimeMs: num(raw, "mtimeMs"),
+		// A checkpoint without a digest cannot detect a same-size, same-mtime rewrite, so the field is
+		// required — but an absent file legitimately checkpoints an empty digest, so "" is valid.
+		digest: digest(raw, "digest"),
+		present: bool(raw, "present"),
+	};
 }
 
 function fireWindow(raw: unknown): { startMs: number; count: number } {
@@ -120,6 +135,8 @@ export type RestoreOutcome = "restored" | "lost" | "muted" | "attachedElsewhere"
 
 export interface RestoreHandlerResult {
 	readonly outcome: RestoreOutcome;
+	/** Why a durable monitor could not be restored; diagnostic only, never part of the digest counts. */
+	readonly reason?: string;
 }
 
 export type RestoreHandler = (monitor: ManifestMonitor) => RestoreHandlerResult | Promise<RestoreHandlerResult>;
@@ -127,6 +144,27 @@ export type RestoreHandler = (monitor: ManifestMonitor) => RestoreHandlerResult 
 export interface RestoreHandlers {
 	readonly "restartable-command": RestoreHandler;
 	readonly "checkpointed-file": RestoreHandler;
+}
+
+/** The registry surface a restore handler needs to re-apply a persisted mute. */
+export interface PersistedMuteRegistry {
+	pause(ids: readonly string[]): string[];
+}
+
+/**
+ * Re-apply a persisted `deliveryPaused` mute to a freshly restored monitor and report the
+ * outcome it contributes to the digest. The mute MUST be applied by the FRESH runtime id
+ * (bash_N/watch_N) the restore just allocated: `MonitorRegistry.pause` resolves records by
+ * runtime id only, so passing the persisted `mon_` id silently no-ops and the mute is lost.
+ */
+export function reapplyPersistedMute(
+	registry: PersistedMuteRegistry,
+	monitor: Pick<ManifestMonitor, "deliveryPaused">,
+	runtimeId: string,
+): RestoreOutcome {
+	if (!monitor.deliveryPaused) return "restored";
+	registry.pause([runtimeId]);
+	return "muted";
 }
 
 /** Stub durability handlers: every durable monitor is reported lost until later phases land. */
@@ -170,7 +208,8 @@ export async function restoreTerminalState(options: RestoreTerminalStateOptions)
 	const now = (options.now ?? Date.now)();
 	const handlers: RestoreHandlers = { ...stubRestoreHandlers, ...options.handlers };
 	for (const monitor of state.monitors) {
-		if (monitor.expiresAt !== null && monitor.expiresAt < now) {
+		// At the deadline the entry is already expired: the handler must not see it at all.
+		if (monitor.expiresAt !== null && monitor.expiresAt <= now) {
 			digest.expired += 1;
 			continue;
 		}

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/shared.ts
@@ -35,6 +35,17 @@ export const BACKGROUND_START_GRACE_MS = 250;
 export const KILLED_SESSION_EXIT_GRACE_MS = 5000;
 
 /**
+ * Admission cap on durable (restart-surviving) monitors per session. Ephemeral monitors
+ * never count against it: only entries the manifest keeps across a restart do.
+ */
+export const MAX_DURABLE_MONITORS = 5;
+/**
+ * Absolute lifetime of a durable monitor, measured from its registration. It is a deadline,
+ * never a sliding window: neither a restore nor a rearm extends it.
+ */
+export const DURABLE_MONITOR_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
  * Non-interactive environment for foreground one-shot commands (codex-style):
  * cooperative tools (`gh`, `git`, pagers, color libs) skip spinners/colors at
  * the source instead of flooding the captured stream with redraw frames.

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/terminal-manifest.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/terminal-manifest.ts
@@ -9,19 +9,30 @@ import type { SessionManager } from "../../../session-manager.ts";
 import { createSidecarStore, type SidecarStore } from "../../../session-sidecar-store.ts";
 import type { MonitorSnapshotEntry } from "./monitor-registry.ts";
 import { parseTerminalManifest } from "./restore.ts";
+import { DURABLE_MONITOR_EXPIRY_MS } from "./shared.ts";
 
 export const TERMINAL_MANIFEST_VERSION = 1;
 /** Minimum debounce for checkpoint writes; a burst inside this window collapses to one write. */
 export const TERMINAL_MANIFEST_CHECKPOINT_DEBOUNCE_MS = 30_000;
+/**
+ * Re-exported so manifest consumers read one durability deadline. The value lives in
+ * `shared.ts` with the rest of the terminal caps; there is exactly one definition of it.
+ */
+export { DURABLE_MONITOR_EXPIRY_MS };
 export type TerminalManifestSession = Pick<SessionManager, "getSessionDir" | "getSessionId">;
 export type MonitorRuntimeKind = "command" | "file";
 export type MonitorDurabilityClass = "ephemeral" | "restartable-command" | "checkpointed-file";
-/** File-monitor checkpoint persisted by the writer: the registry's live identity tuple. */
+/**
+ * File-monitor checkpoint persisted by the writer: the registry's live identity tuple. `digest`
+ * is required — without it a same-size, same-mtime rewrite is undetectable across a restart.
+ */
 export interface TerminalManifestCheckpoint {
 	readonly dev: number;
 	readonly ino: number;
 	readonly size: number;
 	readonly mtimeMs: number;
+	readonly digest: string;
+	readonly present: boolean;
 }
 
 export interface ManifestMonitor {
@@ -79,6 +90,8 @@ export interface FileMonitorSpec {
 	readonly timeoutMs: number;
 	readonly cwd: string;
 	readonly approvedParent?: string;
+	/** Persistent file watches are the durable `checkpointed-file` class; one-shot ones stay ephemeral. */
+	readonly persistent: boolean;
 }
 export type MonitorSpec = CommandMonitorSpec | FileMonitorSpec;
 
@@ -120,6 +133,37 @@ export class TerminalManifestWriter {
 	recordRegister(registration: MonitorRegistration): Promise<void> {
 		this.#entries.set(registration.monitorId, this.#entryFor(registration));
 		return this.#persist();
+	}
+
+	/**
+	 * Re-adopt an entry a restore handler just brought back to life, so THIS generation's
+	 * in-memory map owns it again. Without this, the writer starts every generation empty and
+	 * the next persist (a register, a background start, a checkpoint flush, recordShutdown)
+	 * rewrites the manifest WITHOUT the restored monitors — the monitor survives one restart
+	 * and is erased on the second.
+	 *
+	 * Every persisted field is preserved verbatim, notably `createdAt` and `expiresAt`: the
+	 * durability deadline is set once at registration and a restore NEVER extends it. Only
+	 * `suspended` is cleared, because the monitor is live again in this process.
+	 *
+	 * Deliberately does NOT write: re-adoption is not a state transition, it is recovery of
+	 * state already on disk. The entry reaches the file again on the restore's own next
+	 * persist (the file class's checkpoint, any later transition, or recordShutdown), so a
+	 * restart costs zero extra writes and the write-on-transition invariant holds.
+	 */
+	adoptRestored(entry: ManifestMonitor): void {
+		this.#entries.set(entry.monitorId, { ...entry, suspended: false });
+	}
+
+	/**
+	 * Live durable-monitor count for admission control: entries that survive a restart.
+	 * Ephemeral entries are never counted, so any number of one-shot watches can coexist
+	 * with the durable ones.
+	 */
+	durableCount(): number {
+		let count = 0;
+		for (const entry of this.#entries.values()) if (entry.durabilityClass !== "ephemeral") count += 1;
+		return count;
 	}
 
 	/**
@@ -205,13 +249,19 @@ export class TerminalManifestWriter {
 
 	#entryFor({ monitorId, spec }: MonitorRegistration): ManifestMonitor {
 		const createdAt = this.#now();
+		// A spec that omits `persistent` is ephemeral: the persisted field is a boolean the
+		// strict parse rejects as undefined, so coerce here rather than trusting the caller.
+		const persistent = spec.persistent === true;
 		return {
 			monitorId,
 			sessionId: this.#sessionId,
 			description: spec.description,
 			runtimeKind: spec.kind,
-			durabilityClass:
-				spec.kind === "file" ? "checkpointed-file" : spec.persistent ? "restartable-command" : "ephemeral",
+			durabilityClass: !persistent
+				? "ephemeral"
+				: spec.kind === "file"
+					? "checkpointed-file"
+					: "restartable-command",
 			command: spec.kind === "command" ? spec.command : undefined,
 			path: spec.kind === "file" ? spec.path : undefined,
 			event: spec.kind === "file" ? spec.event : undefined,
@@ -219,8 +269,11 @@ export class TerminalManifestWriter {
 			cwd: spec.cwd,
 			approvedParent: spec.kind === "file" ? spec.approvedParent : undefined,
 			createdAt,
-			expiresAt: spec.kind === "file" ? createdAt + spec.timeoutMs : null,
-			persistent: spec.kind === "command" ? spec.persistent : false,
+			// Absolute durability deadline for every restart-surviving entry, set once here and
+			// never extended by a restore or a rearm. An ephemeral entry dies with the process,
+			// so its runtime deadline stays the registry's business, not the manifest's.
+			expiresAt: persistent ? createdAt + DURABLE_MONITOR_EXPIRY_MS : null,
+			persistent,
 			suspended: false,
 			lastCheckpoint: null,
 			deliveryPaused: false,

--- a/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/terminal/tools/monitor.ts
@@ -1,8 +1,9 @@
+import { resolve } from "node:path";
 import { StringEnum } from "@earendil-works/pi-ai";
 import { type Static, Type } from "typebox";
 import { APPROVED_MONITOR_PARENT } from "../monitor-permission.ts";
 import { MonitorRegistry } from "../monitor-registry.ts";
-import { DEFAULT_COLS, DEFAULT_ROWS, TERMINAL_MONITOR_TOOL } from "../shared.ts";
+import { DEFAULT_COLS, DEFAULT_ROWS, MAX_DURABLE_MONITORS, TERMINAL_MONITOR_TOOL } from "../shared.ts";
 import type { MonitorRegistration, TerminalManifestWriter } from "../terminal-manifest.ts";
 import {
 	errorResult,
@@ -46,7 +47,7 @@ export const monitorSchema = Type.Object({
 		Type.String({
 			minLength: 1,
 			description:
-				"Create, file branch (XOR command): one regular file to watch natively, whose parent directory must already exist; takes no filter and no persistent.",
+				"Create, file branch (XOR command): one regular file to watch natively, whose parent directory must already exist; takes no filter.",
 		}),
 	),
 	event: Type.Optional(
@@ -65,7 +66,10 @@ export const monitorSchema = Type.Object({
 		}),
 	),
 	persistent: Type.Optional(
-		Type.Boolean({ description: "Keep watching until the command exits or kill_bash stops its bash_id." }),
+		Type.Boolean({
+			description:
+				"Keep watching until the command exits or kill_bash stops its bash_id; on the path branch it also survives a restart and reports a change that happened while detached.",
+		}),
 	),
 	bash_id: Type.Optional(
 		Type.String({ description: "Rearm: paused monitor id (mon_ or bash_id) to resume; omit for all paused." }),
@@ -122,11 +126,14 @@ async function createMonitor(
 		return errorResult(`Invalid monitor filter regex: ${input.filter}`);
 	}
 
+	// Durability needs an absolute directory: a restore runs in a different process whose
+	// process cwd is unrelated, so the spec must carry the resolved path the spawn used.
+	const cwd = resolve(execCtx?.cwd ?? ctx.cwd);
 	const { id, runtime } = await spawnCommandSession(ctx, {
 		command: input.command,
 		cols: resolveDimension(undefined, ctx.defaultCols || DEFAULT_COLS),
 		rows: resolveDimension(undefined, ctx.defaultRows || DEFAULT_ROWS),
-		cwd: execCtx?.cwd,
+		cwd,
 		...(input.persistent ? {} : { timeoutMs: resolveTimeoutMs(input.timeout_ms) }),
 	});
 	ctx.onMonitorRearmed?.(id);
@@ -141,7 +148,7 @@ async function createMonitor(
 			description: input.description,
 			command: input.command,
 			filter: input.filter,
-			cwd: execCtx?.cwd,
+			cwd,
 			persistent: input.persistent === true,
 		},
 	});
@@ -173,6 +180,33 @@ function handMonitorSpec(sessionKey: string | undefined, registration: MonitorRe
 	void writer?.recordRegister(registration);
 }
 
+/** Persist a durable file watch's baseline checkpoint through the writer's debounced path. */
+function handFileCheckpoint(
+	sessionKey: string | undefined,
+	monitorId: string,
+	registry: MonitorRegistry,
+	runtimeId: string,
+): void {
+	const writer = sessionKey === undefined ? undefined : manifestWriters.get(sessionKey);
+	const checkpoint = registry.fileCheckpoint(runtimeId);
+	if (writer && checkpoint) writer.scheduleCheckpoint(monitorId, checkpoint);
+}
+
+/**
+ * Admission control for a durable create: refuse once the session already holds
+ * MAX_DURABLE_MONITORS restart-surviving monitors. Checked BEFORE any spawn or registry
+ * registration so a refused call leaves no PTY and no manifest entry behind. A context
+ * with no bound writer persists nothing, so it has no durable population to cap.
+ */
+function durableAdmissionError(ctx: TerminalToolContext): TerminalToolResult | undefined {
+	const sessionKey = manifestSessionKey(ctx);
+	const writer = sessionKey === undefined ? undefined : manifestWriters.get(sessionKey);
+	if (writer === undefined || writer.durableCount() < MAX_DURABLE_MONITORS) return undefined;
+	return errorResult(
+		`Cannot start another persistent monitor: this session already holds ${MAX_DURABLE_MONITORS} durable monitors (the maximum). Stop one with kill_bash first.`,
+	);
+}
+
 export function createMonitorTool(ctx: TerminalToolContext) {
 	let fallbackRegistry: MonitorRegistry | undefined;
 	const getRegistry = (): MonitorRegistry => {
@@ -185,7 +219,7 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 		name: TERMINAL_MONITOR_TOOL,
 		label: "monitor",
 		description:
-			"Subscribe to a change instead of polling. Pass command XOR path, never both: command watches a PTY session, where newline-terminated output lines (stderr merged) that match filter arrive as injected events while you keep working and command exit always delivers a summary event; path natively watches one file and fires once: create (the default) fires only when the file appears after registration, so watch a file that already exists with event modify. The path branch takes no filter and no persistent. Identical consecutive line-only update batches are deduped, so a watcher reprinting unchanged status does not re-wake the session. Returns a bash_id immediately; peek with bash_output, stop with kill_bash.",
+			"Subscribe to a change instead of polling. Pass command XOR path, never both: command watches a PTY session, where newline-terminated output lines (stderr merged) that match filter arrive as injected events while you keep working and command exit always delivers a summary event; path natively watches one file and fires once: create (the default) fires only when the file appears after registration, so watch a file that already exists with event modify. The path branch takes no filter; with persistent: true it survives a restart and reports a change that happened while detached. Identical consecutive line-only update batches are deduped, so a watcher reprinting unchanged status does not re-wake the session. Returns a bash_id immediately; peek with bash_output, stop with kill_bash.",
 		promptSnippet:
 			"Subscribe to a command's output or a file's create/modify event as injected events instead of polling",
 		promptGuidelines: [
@@ -231,9 +265,13 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 			const fileInput = isFileCreateInput(input);
 			const commandInput = isCreateInput(input);
 			if (fileInput && commandInput) return errorResult("monitor accepts either command or path, not both.");
+			// Admission runs before either create branch touches a PTY or the registry.
+			if (input.persistent === true && (fileInput || commandInput)) {
+				const refused = durableAdmissionError(ctx);
+				if (refused) return refused;
+			}
 			if (fileInput) {
-				if (input.filter !== undefined || input.persistent)
-					return errorResult("Native file monitors do not support filter or persistent.");
+				if (input.filter !== undefined) return errorResult("Native file monitors do not support filter.");
 				if (!ctx.monitorRegistry)
 					return errorResult("Native file monitors require a lifecycle-owned monitor registry.");
 				try {
@@ -250,7 +288,8 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 					});
 					ctx.manager.bindMonitorId(monitorId, id);
 					// Same spec capture as the command branch: durability inputs live only here.
-					handMonitorSpec(manifestSessionKey(ctx), {
+					const sessionKey = manifestSessionKey(ctx);
+					handMonitorSpec(sessionKey, {
 						monitorId,
 						spec: {
 							kind: "file",
@@ -259,9 +298,13 @@ export function createMonitorTool(ctx: TerminalToolContext) {
 							event: input.event ?? "create",
 							timeoutMs: resolveTimeoutMs(input.timeout_ms),
 							cwd: execCtx?.cwd ?? ctx.cwd,
+							persistent: input.persistent === true,
 							...(approvedParent !== undefined ? { approvedParent } : {}),
 						},
 					});
+					// A durable watch checkpoints the registry's own identity tuple straight away, so a
+					// restart before the first change still has a baseline (digest included) to compare to.
+					if (input.persistent === true) handFileCheckpoint(sessionKey, monitorId, ctx.monitorRegistry, id);
 					return textResult(`Monitor started with ID: ${monitorId}`, {
 						details: { monitor_id: monitorId, bash_id: id, monitor: true },
 					});

--- a/packages/coding-agent/test/suite/terminal-durable-admission.test.ts
+++ b/packages/coding-agent/test/suite/terminal-durable-admission.test.ts
@@ -1,0 +1,336 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import { MonitorNotifier } from "../../src/core/extensions/builtin/terminal/monitor-notify.ts";
+import { type MonitorEvent, MonitorRegistry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import {
+	type RestoreHandlers,
+	reapplyPersistedMute,
+	restoreTerminalState,
+} from "../../src/core/extensions/builtin/terminal/restore.ts";
+import { DURABLE_MONITOR_EXPIRY_MS, MAX_DURABLE_MONITORS } from "../../src/core/extensions/builtin/terminal/shared.ts";
+import {
+	type ManifestMonitor,
+	TerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/terminal-manifest.ts";
+import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import {
+	bindTerminalManifestWriter,
+	createMonitorTool,
+	unbindTerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
+import { spawnCommandSession } from "../../src/core/extensions/builtin/terminal/tools/spawn.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+import { FakeScheduler, line } from "./terminal-monitor-notify-harness.ts";
+
+interface Harness {
+	readonly writer: TerminalManifestWriter;
+	readonly sessionId: string;
+	readonly sessionDir: string;
+	readonly manager: TerminalManager;
+	readonly registry: MonitorRegistry;
+	readonly ctx: TerminalToolContext;
+	readonly tool: ReturnType<typeof createMonitorTool>;
+	readonly events: MonitorEvent[];
+	readonly createSpy: ReturnType<typeof vi.spyOn>;
+	readonly registerSpy: ReturnType<typeof vi.spyOn>;
+}
+
+let harnessSeq = 0;
+const openHarnesses: Harness[] = [];
+
+async function makeHarness(now?: () => number): Promise<Harness> {
+	harnessSeq += 1;
+	const sessionId = `durable-admission-${process.pid}-${harnessSeq}`;
+	// Never write inside the checkout: the manifest resolves under this absolute temp dir only.
+	const sessionDir = await mkdtemp(join(tmpdir(), "senpi-durable-admission-"));
+	const writer = new TerminalManifestWriter({
+		session: { getSessionDir: () => sessionDir, getSessionId: () => sessionId },
+		...(now ? { now } : {}),
+	});
+	expect(isAbsolute(writer.store.filePath)).toBe(true);
+	expect(writer.store.filePath.startsWith(join(sessionDir, "extensions", "terminal"))).toBe(true);
+	const manager = new TerminalManager();
+	const events: MonitorEvent[] = [];
+	const registry = new MonitorRegistry((event) => events.push(event), {
+		onChange: (snapshot) => void writer.observeMonitorState(snapshot),
+	});
+	const ctx: TerminalToolContext = {
+		manager,
+		cwd: sessionDir,
+		defaultCols: 120,
+		defaultRows: 40,
+		getEnv: () => ({ ...process.env }),
+		onMonitorEvent: (event) => events.push(event),
+		monitorRegistry: registry,
+		getSessionContext: () => ({ sessionManager: { getSessionId: () => sessionId } }) as unknown as ExtensionContext,
+	};
+	bindTerminalManifestWriter(sessionId, writer);
+	const harness: Harness = {
+		writer,
+		sessionId,
+		sessionDir,
+		manager,
+		registry,
+		ctx,
+		tool: createMonitorTool(ctx),
+		events,
+		createSpy: vi.spyOn(manager, "create"),
+		registerSpy: vi.spyOn(registry, "register"),
+	};
+	openHarnesses.push(harness);
+	return harness;
+}
+
+async function closeHarness(harness: Harness): Promise<void> {
+	harness.registry.dispose();
+	await harness.manager.teardown();
+	await harness.writer.flush();
+	unbindTerminalManifestWriter(harness.sessionId);
+}
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find((block) => block.type === "text")?.text ?? "";
+}
+
+async function createPersistent(harness: Harness, description: string) {
+	return harness.tool.execute(`create-${description}`, {
+		description,
+		command: "cat",
+		persistent: true,
+	});
+}
+
+async function createEphemeral(harness: Harness, description: string) {
+	return harness.tool.execute(`create-${description}`, {
+		description,
+		command: "cat",
+		timeout_ms: 300_000,
+	});
+}
+
+describe("durable monitor admission control", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+
+	beforeEach(() => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+	});
+
+	afterEach(async () => {
+		while (openHarnesses.length > 0) {
+			const harness = openHarnesses.pop();
+			if (harness) await closeHarness(harness);
+		}
+		vi.restoreAllMocks();
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	it("admits exactly MAX_DURABLE_MONITORS persistent monitors and rejects the next with no spawn and no registration", async () => {
+		const harness = await makeHarness();
+		expect(MAX_DURABLE_MONITORS).toBe(5);
+		for (let index = 1; index <= MAX_DURABLE_MONITORS; index += 1) {
+			const created = await createPersistent(harness, `durable ${index}`);
+			expect(created.isError, firstText(created)).toBeFalsy();
+		}
+		await harness.writer.flush();
+		const spawnsBefore = harness.createSpy.mock.calls.length;
+		const registrationsBefore = harness.registerSpy.mock.calls.length;
+
+		const rejected = await createPersistent(harness, "durable overflow");
+
+		expect(rejected.isError).toBe(true);
+		expect(firstText(rejected)).toBe(
+			`Cannot start another persistent monitor: this session already holds ${MAX_DURABLE_MONITORS} durable monitors (the maximum). Stop one with kill_bash first.`,
+		);
+		expect(harness.createSpy.mock.calls.length).toBe(spawnsBefore);
+		expect(harness.registerSpy.mock.calls.length).toBe(registrationsBefore);
+		expect(harness.registry.snapshot()).toHaveLength(MAX_DURABLE_MONITORS);
+		await harness.writer.flush();
+		const manifest = await harness.writer.store.read();
+		expect(manifest?.monitors.map((entry) => entry.description)).toEqual([
+			"durable 1",
+			"durable 2",
+			"durable 3",
+			"durable 4",
+			"durable 5",
+		]);
+	});
+
+	it("never counts ephemeral monitors against the cap: 10 ephemeral first, then 5 persistent, all succeed", async () => {
+		const harness = await makeHarness();
+		// Ephemeral first: a cap that counted them would already be over budget by the 6th one,
+		// so every persistent create below would be refused.
+		for (let index = 1; index <= 10; index += 1) {
+			const created = await createEphemeral(harness, `ephemeral ${index}`);
+			expect(created.isError, firstText(created)).toBeFalsy();
+		}
+		for (let index = 1; index <= MAX_DURABLE_MONITORS; index += 1) {
+			const created = await createPersistent(harness, `durable ${index}`);
+			expect(created.isError, firstText(created)).toBeFalsy();
+		}
+		await harness.writer.flush();
+
+		const manifest = await harness.writer.store.read();
+		const durable = manifest?.monitors.filter((entry) => entry.durabilityClass !== "ephemeral") ?? [];
+		const ephemeral = manifest?.monitors.filter((entry) => entry.durabilityClass === "ephemeral") ?? [];
+		expect(durable).toHaveLength(MAX_DURABLE_MONITORS);
+		expect(ephemeral).toHaveLength(10);
+		expect(harness.registry.snapshot()).toHaveLength(MAX_DURABLE_MONITORS + 10);
+	});
+
+	it("registers a durable monitor with an absolute 7-day expiry that a restore and a rearm both leave byte-identical", async () => {
+		const registeredAt = 1_700_000_000_000;
+		// A moving clock: an expiry refreshed by any later transition is observable as a slide.
+		let clock = registeredAt;
+		const harness = await makeHarness(() => clock);
+		const created = await createPersistent(harness, "expiry stable");
+		expect(created.isError, firstText(created)).toBeFalsy();
+		const monitorId = created.details?.monitor_id as string;
+		const runtimeId = created.details?.bash_id as string;
+		await harness.writer.flush();
+
+		const atRegister = (await harness.writer.store.read())?.monitors[0];
+		expect(atRegister?.expiresAt).toBe(registeredAt + DURABLE_MONITOR_EXPIRY_MS);
+
+		// A restore reads the entry and re-reports it; it must never push the deadline out.
+		const digest = await restoreTerminalState({
+			manifest: harness.writer.store,
+			handlers: {
+				"restartable-command": () => ({ outcome: "restored" }),
+			},
+			now: () => registeredAt + 1_000,
+		});
+		expect(digest.restored).toBe(1);
+		expect((await harness.writer.store.read())?.monitors[0]?.expiresAt).toBe(atRegister?.expiresAt);
+
+		// A rearm is a delivery transition, not a lifetime transition.
+		clock = registeredAt + 60_000;
+		expect(harness.registry.pause([runtimeId])).toEqual([runtimeId]);
+		await harness.writer.flush();
+		expect((await harness.writer.store.read())?.monitors[0]?.expiresAt).toBe(atRegister?.expiresAt);
+		clock = registeredAt + 120_000;
+		const rearmed = await harness.tool.execute("rearm-expiry", { action: "rearm", bash_id: monitorId });
+		expect(rearmed.isError, firstText(rearmed)).toBeFalsy();
+		await harness.writer.flush();
+
+		const afterRearm = (await harness.writer.store.read())?.monitors[0];
+		expect(afterRearm?.expiresAt).toBe(atRegister?.expiresAt);
+		expect(afterRearm?.createdAt).toBe(registeredAt);
+		expect(afterRearm?.deliveryPaused).toBe(false);
+	});
+
+	it("does not restore an entry at or past expiresAt and never calls its handler", async () => {
+		const harness = await makeHarness();
+		const now = 4_000_000_000_000;
+		const base: Omit<ManifestMonitor, "monitorId" | "expiresAt"> = {
+			sessionId: harness.sessionId,
+			description: "stale durable",
+			runtimeKind: "command",
+			durabilityClass: "restartable-command",
+			command: "cat",
+			createdAt: now - DURABLE_MONITOR_EXPIRY_MS,
+			persistent: true,
+			suspended: true,
+			lastCheckpoint: null,
+			deliveryPaused: false,
+			wakeCount: 0,
+			fireWindow: { startMs: 1, count: 0 },
+		};
+		await harness.writer.store.write({
+			version: 1,
+			sessionId: harness.sessionId,
+			monitors: [
+				{ ...base, monitorId: "mon_atexpiry", expiresAt: now },
+				{ ...base, monitorId: "mon_pastexpiry", expiresAt: now - 1 },
+			],
+			backgroundSessions: [],
+			updatedAt: now,
+		});
+		const seen: string[] = [];
+		const handler = (monitor: ManifestMonitor) => {
+			seen.push(monitor.monitorId);
+			return { outcome: "restored" as const };
+		};
+		const handlers: RestoreHandlers = { "restartable-command": handler, "checkpointed-file": handler };
+
+		const digest = await restoreTerminalState({ manifest: harness.writer.store, handlers, now: () => now });
+
+		expect(digest).toEqual({
+			restored: 0,
+			lost: 0,
+			expired: 2,
+			muted: 0,
+			attachedElsewhere: 0,
+			storeError: false,
+		});
+		expect(seen).toEqual([]);
+	});
+
+	it("keeps a wake-budget mute across a restart: the restored monitor is paused in the snapshot and counted as muted", async () => {
+		const first = await makeHarness();
+		const created = await createPersistent(first, "noisy durable");
+		expect(created.isError, firstText(created)).toBeFalsy();
+		const monitorId = created.details?.monitor_id as string;
+		const runtimeId = created.details?.bash_id as string;
+
+		const scheduler = new FakeScheduler();
+		const notifier = new MonitorNotifier({
+			sendMessage: () => {},
+			getContext: () => ({ mode: "tui", model: { id: "mock", api: "openai-completions" } }) as never,
+			getMode: () => "wake",
+			getSettings: () => ({
+				coalesceWindowMs: 10,
+				rateLimitMs: 1,
+				maxLinesPerInjection: 50,
+				maxCharsPerInjection: 4096,
+				wakeBudget: 1,
+			}),
+			pauseMonitors: (ids) => first.registry.pause(ids),
+			scheduler,
+		});
+		notifier.notifyEvent(line(runtimeId, "noisy durable", "chatter"));
+		scheduler.advanceBy(10);
+		notifier.dispose();
+
+		expect(first.registry.snapshot().find((entry) => entry.id === runtimeId)?.paused).toBe(true);
+		await first.writer.flush();
+		const persisted = (await first.writer.store.read())?.monitors[0];
+		expect(persisted?.monitorId).toBe(monitorId);
+		expect(persisted?.deliveryPaused).toBe(true);
+
+		// Restart: a fresh generation with its own registry restores the persisted entry.
+		const second = await makeHarness();
+		const restoredIds: string[] = [];
+		const digest = await restoreTerminalState({
+			manifest: first.writer.store,
+			handlers: {
+				"restartable-command": async (monitor) => {
+					const { id, runtime } = await spawnCommandSession(second.ctx, {
+						command: monitor.command ?? "cat",
+						cols: 120,
+						rows: 40,
+					});
+					second.registry.register({
+						id,
+						monitorId: monitor.monitorId,
+						description: monitor.description,
+						runtime,
+					});
+					restoredIds.push(id);
+					return { outcome: reapplyPersistedMute(second.registry, monitor, id) };
+				},
+			},
+		});
+
+		expect(restoredIds).toHaveLength(1);
+		expect(restoredIds[0]).not.toBe(monitorId);
+		const restoredEntry = second.registry.snapshot().find((entry) => entry.monitorId === monitorId);
+		expect(restoredEntry?.id).toBe(restoredIds[0]);
+		expect(restoredEntry?.paused).toBe(true);
+		expect(digest.muted).toBe(1);
+		expect(digest.restored).toBe(0);
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-durable-command.test.ts
+++ b/packages/coding-agent/test/suite/terminal-durable-command.test.ts
@@ -1,0 +1,429 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRestartableCommandHandler } from "../../src/core/extensions/builtin/terminal/durable-command.ts";
+import { registerTerminalExtension } from "../../src/core/extensions/builtin/terminal/extension.ts";
+import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import { type MonitorEvent, MonitorRegistry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import { restoreTerminalState } from "../../src/core/extensions/builtin/terminal/restore.ts";
+import { DURABLE_MONITOR_EXPIRY_MS } from "../../src/core/extensions/builtin/terminal/shared.ts";
+import {
+	type ManifestMonitor,
+	TerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/terminal-manifest.ts";
+import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import {
+	bindTerminalManifestWriter,
+	createMonitorTool,
+	unbindTerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
+import type { SpawnRequest } from "../../src/core/extensions/builtin/terminal/tools/spawn.ts";
+import { spawnCommandSession } from "../../src/core/extensions/builtin/terminal/tools/spawn.ts";
+import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
+import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
+
+const spawnTracker = vi.hoisted(() => ({ calls: 0 }));
+
+vi.mock("../../src/core/extensions/builtin/terminal/tools/spawn.ts", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../../src/core/extensions/builtin/terminal/tools/spawn.ts")>();
+	return {
+		...original,
+		spawnCommandSession: (...args: Parameters<typeof original.spawnCommandSession>) => {
+			spawnTracker.calls += 1;
+			return original.spawnCommandSession(...args);
+		},
+	};
+});
+
+class EventSink {
+	readonly events: MonitorEvent[] = [];
+	readonly #listeners = new Set<(event: MonitorEvent) => void>();
+
+	push(event: MonitorEvent): void {
+		this.events.push(event);
+		for (const listener of this.#listeners) listener(event);
+	}
+
+	lines(): string[] {
+		return this.events.flatMap((event) => (event.type === "line" ? [event.line] : []));
+	}
+
+	waitFor(predicate: (event: MonitorEvent) => boolean, label: string): Promise<MonitorEvent> {
+		return new Promise((resolve, reject) => {
+			const timeout = setTimeout(() => {
+				this.#listeners.delete(listener);
+				reject(new Error(`Timed out waiting for ${label}`));
+			}, 5000);
+			const listener = (event: MonitorEvent) => {
+				if (!predicate(event)) return;
+				clearTimeout(timeout);
+				this.#listeners.delete(listener);
+				resolve(event);
+			};
+			this.#listeners.add(listener);
+			for (const event of this.events) listener(event);
+		});
+	}
+}
+
+function manifestMonitor(overrides: Partial<ManifestMonitor> & Pick<ManifestMonitor, "monitorId">): ManifestMonitor {
+	return {
+		sessionId: "durable-session",
+		description: "restartable watch",
+		runtimeKind: "command",
+		durabilityClass: "restartable-command",
+		command: "cat",
+		createdAt: 1,
+		expiresAt: null,
+		persistent: true,
+		suspended: true,
+		lastCheckpoint: null,
+		deliveryPaused: false,
+		wakeCount: 0,
+		fireWindow: { startMs: 1, count: 0 },
+		...overrides,
+	};
+}
+
+describe("restartable-command durability class", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+	let tmp: string;
+	let sessionDir: string;
+	let workDir: string;
+	let sessionId: string;
+	let manager: TerminalManager;
+	let registry: MonitorRegistry;
+	let sink: EventSink;
+	let ctx: TerminalToolContext;
+	let writer: TerminalManifestWriter;
+	let sessionSeq = 0;
+
+	beforeEach(async () => {
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		spawnTracker.calls = 0;
+		tmp = await mkdtemp(join(tmpdir(), "senpi-durable-command-"));
+		sessionDir = join(tmp, "session");
+		workDir = join(tmp, "work");
+		sessionId = `durable-command-${process.pid}-${++sessionSeq}`;
+		manager = new TerminalManager();
+		sink = new EventSink();
+		registry = new MonitorRegistry((event) => sink.push(event));
+		ctx = {
+			manager,
+			cwd: workDir,
+			defaultCols: 120,
+			defaultRows: 40,
+			getEnv: () => ({ ...process.env }),
+			monitorRegistry: registry,
+			onMonitorEvent: (event) => sink.push(event),
+			getSessionContext: () =>
+				({
+					sessionManager: { getSessionId: () => sessionId, getSessionDir: () => sessionDir },
+				}) as unknown as ExtensionContext,
+		};
+		writer = new TerminalManifestWriter({
+			session: { getSessionDir: () => sessionDir, getSessionId: () => sessionId },
+		});
+		expect(isAbsolute(writer.store.filePath)).toBe(true);
+	});
+
+	afterEach(async () => {
+		registry.dispose();
+		await manager.teardown();
+		unbindTerminalManifestWriter(sessionId);
+		await rm(tmp, { recursive: true, force: true });
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+	});
+
+	async function restore(monitor: ManifestMonitor) {
+		await writer.store.write({
+			version: 1,
+			sessionId,
+			monitors: [monitor],
+			backgroundSessions: [],
+			updatedAt: 2,
+		});
+		const handler = createRestartableCommandHandler({ ctx, registry });
+		return await restoreTerminalState({ manifest: writer.store, handlers: { "restartable-command": handler } });
+	}
+
+	it("(a) persists command, absolute cwd, filter and expiresAt for a persistent command monitor", async () => {
+		await mkdir(workDir, { recursive: true });
+		bindTerminalManifestWriter(sessionId, writer);
+		const before = Date.now();
+		// No execCtx cwd: the branch must fall back to the tool context cwd and persist it absolute.
+		const result = await createMonitorTool(ctx).execute("durable-create", {
+			description: "tail the log",
+			command: "cat",
+			filter: "^READY$",
+			persistent: true,
+		});
+		await writer.flush();
+		const entry = (await writer.store.read())?.monitors[0];
+		expect(entry?.monitorId).toBe(result.details?.monitor_id);
+		expect(entry?.durabilityClass).toBe("restartable-command");
+		expect(entry?.command).toBe("cat");
+		expect(entry?.filter).toBe("^READY$");
+		expect(entry?.expiresAt).not.toBe(null);
+		expect(entry?.expiresAt ?? 0).toBeGreaterThanOrEqual(before + DURABLE_MONITOR_EXPIRY_MS);
+		expect(entry?.cwd !== undefined && isAbsolute(entry.cwd)).toBe(true);
+		expect(entry?.cwd).toBe(workDir);
+	});
+
+	it("(b) records a non-persistent command monitor as ephemeral, never as restartable-command", async () => {
+		await mkdir(workDir, { recursive: true });
+		bindTerminalManifestWriter(sessionId, writer);
+		await createMonitorTool(ctx).execute("durable-ephemeral", {
+			description: "short watch",
+			command: "cat",
+			timeout_ms: 60_000,
+		});
+		await writer.flush();
+		const entry = (await writer.store.read())?.monitors[0];
+		expect(entry?.durabilityClass).toBe("ephemeral");
+		expect(entry?.persistent).toBe(false);
+	});
+
+	it("(c) restores by spawning exactly once with the saved command and cwd, keeping the mon_ id", async () => {
+		await mkdir(workDir, { recursive: true });
+		const marker = join(workDir, "restored-marker");
+		const monitorId = "mon_DURABLE0000000A";
+		const digest = await restore(
+			manifestMonitor({
+				monitorId,
+				command: `sh -c 'printf "restored-here\\n"; while [ ! -e "${marker}" ]; do sleep 0.05; done'`,
+				cwd: workDir,
+			}),
+		);
+
+		expect(digest).toEqual({ restored: 1, lost: 0, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+		expect(spawnTracker.calls).toBe(1);
+		await sink.waitFor((event) => event.type === "line" && event.line === "restored-here", "restored PTY line");
+		const snapshot = registry.snapshot();
+		expect(snapshot).toHaveLength(1);
+		expect(snapshot[0]?.monitorId).toBe(monitorId);
+		expect(snapshot[0]?.id).toMatch(/^bash_\d+$/);
+		expect(manager.resolveId(monitorId)).toBe(snapshot[0]?.id);
+		expect(sink.lines()).not.toContain("");
+	});
+
+	it("(d) never replays output the pre-restart runtime produced before shutdown", async () => {
+		await mkdir(workDir, { recursive: true });
+		const monitorId = "mon_DURABLE0000000B";
+		const oldSpawn = await spawnCommandSession(ctx, {
+			command: "sh -c 'printf \"pre-restart-marker\\n\"; sleep 30'",
+			cols: 120,
+			rows: 40,
+			cwd: workDir,
+		});
+		registry.register({ id: oldSpawn.id, monitorId, description: "restartable watch", runtime: oldSpawn.runtime });
+		manager.bindMonitorId(monitorId, oldSpawn.id);
+		await sink.waitFor(
+			(event) => event.type === "line" && event.line === "pre-restart-marker",
+			"pre-restart marker line",
+		);
+		const oldRuntimeId = oldSpawn.id;
+		// The pre-restart runtime deliberately stays resident and still bound to the mon_ id:
+		// a handler that re-adopted it instead of spawning would replay its buffered marker.
+		registry.dispose();
+		sink.events.length = 0;
+		spawnTracker.calls = 0;
+		registry = new MonitorRegistry((event) => sink.push(event));
+
+		const digest = await restore(
+			manifestMonitor({ monitorId, command: "sh -c 'printf \"post-restart\\n\"; sleep 30'", cwd: workDir }),
+		);
+
+		// The registry replays a freshly registered runtime's buffered output synchronously
+		// inside register(), so a re-adopted old runtime would have delivered its marker by now.
+		expect(sink.lines()).not.toContain("pre-restart-marker");
+		expect(digest.restored).toBe(1);
+		expect(spawnTracker.calls).toBe(1);
+		await sink.waitFor((event) => event.type === "line" && event.line === "post-restart", "post-restart line");
+		expect(sink.lines()).not.toContain("pre-restart-marker");
+		expect(registry.snapshot()[0]?.monitorId).toBe(monitorId);
+		expect(registry.snapshot()[0]?.id).not.toBe(oldRuntimeId);
+	});
+
+	it("(e) reports lost without spawning when the saved cwd no longer exists", async () => {
+		const digest = await restore(
+			manifestMonitor({ monitorId: "mon_DURABLE0000000C", cwd: join(tmp, "vanished-dir") }),
+		);
+
+		expect(digest).toEqual({ restored: 0, lost: 1, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+		expect(spawnTracker.calls).toBe(0);
+		expect(registry.snapshot()).toEqual([]);
+	});
+
+	it("(f) reports lost without spawning for a non-persistent command entry", async () => {
+		await mkdir(workDir, { recursive: true });
+		const digest = await restore(
+			manifestMonitor({ monitorId: "mon_DURABLE0000000D", cwd: workDir, persistent: false }),
+		);
+
+		expect(digest).toEqual({ restored: 0, lost: 1, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+		expect(spawnTracker.calls).toBe(0);
+		expect(registry.snapshot()).toEqual([]);
+	});
+
+	it("(g) re-applies a persisted mute by the FRESH runtime id and reports muted", async () => {
+		await mkdir(workDir, { recursive: true });
+		const monitorId = "mon_DURABLE0000000F";
+
+		const digest = await restore(manifestMonitor({ monitorId, command: "cat", cwd: workDir, deliveryPaused: true }));
+
+		expect(digest).toEqual({ restored: 0, lost: 0, expired: 0, muted: 1, attachedElsewhere: 0, storeError: false });
+		expect(spawnTracker.calls).toBe(1);
+		const snapshot = registry.snapshot();
+		expect(snapshot).toHaveLength(1);
+		expect(snapshot[0]?.monitorId).toBe(monitorId);
+		expect(snapshot[0]?.paused).toBe(true);
+	});
+
+	it("(h) spawns the restored session with no timeout so a persistent watch is never killed", async () => {
+		await mkdir(workDir, { recursive: true });
+		const requests: SpawnRequest[] = [];
+		const handler = createRestartableCommandHandler({
+			ctx,
+			registry,
+			spawn: async (spawnCtx, request) => {
+				requests.push(request);
+				return await spawnCommandSession(spawnCtx, request);
+			},
+		});
+
+		const outcome = await handler(
+			manifestMonitor({ monitorId: "mon_DURABLE0000000E", command: "cat", cwd: workDir, filter: "^READY$" }),
+		);
+
+		expect(outcome).toEqual({ outcome: "restored" });
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.command).toBe("cat");
+		expect(requests[0]?.cwd).toBe(workDir);
+		expect(requests[0]?.timeoutMs).toBeUndefined();
+	});
+});
+
+interface ToolLike {
+	execute: (
+		id: string,
+		input: Record<string, unknown>,
+	) => Promise<{
+		content?: Array<{ type: string; text?: string }>;
+		isError?: boolean;
+		details?: { bash_id?: string; monitor_id?: string };
+	}>;
+}
+
+function firstText(result: { content?: Array<{ type: string; text?: string }> } | undefined): string {
+	return result?.content?.find((block) => block.type === "text")?.text ?? "";
+}
+
+describe("restartable-command durability class — reload", () => {
+	const savedForcePipe = process.env.SENPI_PTY_FORCE_PIPE;
+	const savedAgentDir = process.env.SENPI_CODING_AGENT_DIR;
+	let tmp: string;
+	let cwd: string;
+	let sessionDir: string;
+	let sessionId: string;
+	let live: Array<{ emit: (type: string, payload: Record<string, unknown>) => Promise<void> }> = [];
+	let counter = 0;
+
+	beforeEach(async () => {
+		initTheme("dark");
+		process.env.SENPI_PTY_FORCE_PIPE = "1";
+		tmp = await mkdtemp(join(tmpdir(), "senpi-durable-reload-"));
+		process.env.SENPI_CODING_AGENT_DIR = join(tmp, "agent-home");
+		cwd = join(tmp, "project");
+		sessionDir = join(tmp, "sessions");
+		await mkdir(cwd, { recursive: true });
+		sessionId = `durable-reload-${Date.now().toString(36)}-${++counter}`;
+		live = [];
+		spawnTracker.calls = 0;
+	});
+
+	afterEach(async () => {
+		for (const generation of live) await generation.emit("session_shutdown", { reason: "quit" });
+		await rm(tmp, { recursive: true, force: true });
+		if (savedForcePipe === undefined) delete process.env.SENPI_PTY_FORCE_PIPE;
+		else process.env.SENPI_PTY_FORCE_PIPE = savedForcePipe;
+		if (savedAgentDir === undefined) delete process.env.SENPI_CODING_AGENT_DIR;
+		else process.env.SENPI_CODING_AGENT_DIR = savedAgentDir;
+	});
+
+	function createGeneration() {
+		const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => Promise<void> | void>>();
+		const tools = new Map<string, ToolLike>();
+		let activeTools: string[] = [];
+		const pi = {
+			registerTool: (tool: { name: string }) => tools.set(tool.name, tool as never),
+			on: (eventType: string, handler: (event: unknown, ctx: ExtensionContext) => Promise<void> | void) => {
+				handlers.set(eventType, [...(handlers.get(eventType) ?? []), handler]);
+			},
+			sendMessage: () => {},
+			sendUserMessage: () => {},
+			getActiveTools: () => activeTools,
+			setActiveTools: (next: string[]) => {
+				activeTools = next;
+			},
+		} as unknown as ExtensionAPI;
+		const ctx = {
+			cwd,
+			mode: "tui",
+			model: { id: "test-model", api: "openai-completions" },
+			ui: { setStatus: () => {}, notify: () => {}, theme },
+			sessionManager: {
+				getSessionId: () => sessionId,
+				getSessionFile: () => join(sessionDir, `${sessionId}.jsonl`),
+				getSessionDir: () => sessionDir,
+			},
+		} as unknown as ExtensionContext;
+		const generation = {
+			tools,
+			async emit(eventType: string, payload: Record<string, unknown>) {
+				for (const handler of handlers.get(eventType) ?? []) await handler({ type: eventType, ...payload }, ctx);
+			},
+		};
+		registerTerminalExtension(pi);
+		live.push(generation);
+		return generation;
+	}
+
+	it("(i) a reload re-start spawns nothing: the parked bundle keeps the same runtime session", async () => {
+		const gen1 = createGeneration();
+		await gen1.emit("session_start", { reason: "startup" });
+		const created = await gen1.tools.get("monitor")?.execute("reload-monitor", {
+			description: "reload watch",
+			command: "sh -c 'printf \"before-reload-marker\\n\"; cat'",
+			persistent: true,
+		});
+		expect(created?.isError).toBeFalsy();
+		const runtimeId = created?.details?.bash_id;
+		const monitorId = created?.details?.monitor_id;
+		expect(runtimeId).toMatch(/^bash_\d+$/);
+		const spawnsAfterCreate = spawnTracker.calls;
+		expect(spawnsAfterCreate).toBe(1);
+
+		await gen1.emit("session_shutdown", { reason: "reload" });
+		live = [];
+		const gen2 = createGeneration();
+		await gen2.emit("session_start", { reason: "reload" });
+
+		expect(spawnTracker.calls).toBe(spawnsAfterCreate);
+		// The parked bundle kept the SAME PTY: its pre-reload output is still readable through
+		// the stable mon_ id. A reload that re-spawned would hand back an empty fresh session.
+		const peeked = await gen2.tools.get("bash_output")?.execute("peek", { bash_id: monitorId, view: "screen" });
+		expect(peeked?.isError).toBeFalsy();
+		await expect
+			.poll(
+				async () =>
+					firstText(
+						await gen2.tools.get("bash_output")?.execute("peek-again", { bash_id: monitorId, view: "screen" }),
+					),
+				{ timeout: 5000 },
+			)
+			.toContain("before-reload-marker");
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-durable-file.test.ts
+++ b/packages/coding-agent/test/suite/terminal-durable-file.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { mkdtemp, rename, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -214,9 +214,19 @@ describe("checkpointed-file durability class", () => {
 		const saved = (await lane.writer.store.read())?.monitors[0]?.lastCheckpoint;
 
 		lane.restart();
-		await rm(path);
-		await writeFile(path, "replacement");
+		// Atomic replace, as a real writer (editors, writeAtomic, log rotation) performs it: the
+		// replacement is written at a sibling staging path in the same directory (same filesystem,
+		// so the rename is atomic) and renamed over the watched path. The original still holds its
+		// inode while the staging file is created, and two live files on one filesystem can never
+		// share an inode, so the identity swap is GUARANTEED — unlike rm + recreate, where the
+		// allocator may hand the freed inode straight back (which is how CI failed).
+		const staging = join(root, "swapped.txt.next");
+		await writeFile(staging, "replacement");
+		const staged = await stat(staging);
+		expect(staged.ino).not.toBe(saved?.ino);
+		await rename(staging, path);
 		const replacement = await stat(path);
+		expect(replacement.ino).toBe(staged.ino);
 		expect(replacement.ino).not.toBe(saved?.ino);
 
 		const digest = await lane.restore();

--- a/packages/coding-agent/test/suite/terminal-durable-file.test.ts
+++ b/packages/coding-agent/test/suite/terminal-durable-file.test.ts
@@ -1,0 +1,339 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createCheckpointedFileRestoreHandler } from "../../src/core/extensions/builtin/terminal/durable-file.ts";
+import { TerminalManager } from "../../src/core/extensions/builtin/terminal/manager.ts";
+import { type MonitorEvent, MonitorRegistry } from "../../src/core/extensions/builtin/terminal/monitor-registry.ts";
+import { restoreTerminalState } from "../../src/core/extensions/builtin/terminal/restore.ts";
+import {
+	DURABLE_MONITOR_EXPIRY_MS,
+	type ManifestMonitor,
+	TerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/terminal-manifest.ts";
+import type { TerminalToolContext } from "../../src/core/extensions/builtin/terminal/tools/context.ts";
+import { createKillBashTool } from "../../src/core/extensions/builtin/terminal/tools/kill-bash.ts";
+import {
+	bindTerminalManifestWriter,
+	createMonitorTool,
+	type MonitorInput,
+	unbindTerminalManifestWriter,
+} from "../../src/core/extensions/builtin/terminal/tools/monitor.ts";
+import type { ExtensionContext } from "../../src/core/extensions/types.ts";
+
+function firstText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find((block) => block.type === "text")?.text ?? "";
+}
+
+/**
+ * The registry's own digest shape for a file below its 64 KiB sample window: `size:sha256(bytes)`.
+ * Recomputed here so the persisted checkpoint is asserted exactly, with no wildcard matcher.
+ */
+function sampleDigest(content: string): string {
+	const bytes = Buffer.from(content);
+	return `${bytes.length}:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+/**
+ * One restart lane: an absolute tmp session dir (never the checkout), a manifest writer with the
+ * debounce disabled so a checkpoint is observable without fake timers, and one registry
+ * generation at a time — teardown of generation 1 is the "process died" boundary.
+ */
+class Lane {
+	readonly events: MonitorEvent[] = [];
+	readonly manager = new TerminalManager();
+	registry = new MonitorRegistry((event) => this.events.push(event));
+	readonly writer: TerminalManifestWriter;
+	readonly sessionId: string;
+	readonly root: string;
+	readonly sessionDir: string;
+
+	constructor(root: string, sessionDir: string, seq: number) {
+		this.root = root;
+		this.sessionDir = sessionDir;
+		this.sessionId = `durable-file-${process.pid}-${seq}`;
+		this.writer = new TerminalManifestWriter({
+			session: { getSessionDir: () => sessionDir, getSessionId: () => this.sessionId },
+			debounceMs: 1,
+		});
+		bindTerminalManifestWriter(this.sessionId, this.writer);
+	}
+
+	tool() {
+		const ctx: TerminalToolContext = {
+			manager: this.manager,
+			cwd: this.root,
+			defaultCols: 120,
+			defaultRows: 40,
+			getEnv: () => ({ ...process.env }),
+			onMonitorEvent: (event) => this.events.push(event),
+			monitorRegistry: this.registry,
+			getSessionContext: () =>
+				({ sessionManager: { getSessionId: () => this.sessionId } }) as unknown as ExtensionContext,
+		};
+		return { monitor: createMonitorTool(ctx), kill: createKillBashTool(ctx) };
+	}
+
+	/** The restart boundary: drop the live registry, then hand back a fresh one. */
+	restart(): MonitorRegistry {
+		this.registry.dispose();
+		this.events.length = 0;
+		this.registry = new MonitorRegistry((event) => this.events.push(event));
+		return this.registry;
+	}
+
+	handler() {
+		return createCheckpointedFileRestoreHandler({
+			registry: this.registry,
+			writer: this.writer,
+			bindMonitorId: (monitorId, runtimeId) => this.manager.bindMonitorId(monitorId, runtimeId),
+		});
+	}
+
+	restore() {
+		return restoreTerminalState({
+			manifest: this.writer.store,
+			handlers: { "checkpointed-file": this.handler() },
+		});
+	}
+
+	lines(): string[] {
+		return this.events.filter((event) => event.type === "line").map((event) => event.line);
+	}
+
+	async dispose(): Promise<void> {
+		this.registry.dispose();
+		await this.manager.teardown();
+		await this.writer.flush();
+		unbindTerminalManifestWriter(this.sessionId);
+	}
+}
+
+let seq = 0;
+
+describe("checkpointed-file durability class", () => {
+	let root: string;
+	let sessionDir: string;
+	let lane: Lane;
+
+	beforeEach(async () => {
+		// Absolute tmp dirs only: a monitor lane must never write inside the checkout.
+		root = await mkdtemp(join(tmpdir(), "senpi-durable-file-work-"));
+		sessionDir = await mkdtemp(join(tmpdir(), "senpi-durable-file-session-"));
+		expect(isAbsolute(root)).toBe(true);
+		expect(isAbsolute(sessionDir)).toBe(true);
+		seq += 1;
+		lane = new Lane(root, sessionDir, seq);
+		expect(lane.writer.store.filePath.startsWith(join(sessionDir, "extensions", "terminal"))).toBe(true);
+	});
+
+	afterEach(async () => {
+		await lane.dispose();
+		await rm(root, { recursive: true, force: true });
+		await rm(sessionDir, { recursive: true, force: true });
+	});
+
+	/** Create one persistent file watch through the tool and settle its debounced checkpoint. */
+	async function createPersistentWatch(path: string, event: "create" | "modify" = "modify") {
+		const created = await lane.tool().monitor.execute("durable-create", {
+			description: "durable artifact",
+			path,
+			event,
+			persistent: true,
+		} as MonitorInput);
+		expect(created.isError, firstText(created)).toBeFalsy();
+		await lane.writer.flush();
+		return created;
+	}
+
+	it("persists class, durable expiry and the record's checkpoint (digest included) on create", async () => {
+		const path = join(root, "artifact.bin");
+		await writeFile(path, "one");
+		const before = Date.now();
+		const created = await createPersistentWatch(path);
+		const entry = (await lane.writer.store.read())?.monitors[0];
+		const live = await stat(path);
+
+		expect(entry?.monitorId).toBe(created.details?.monitor_id);
+		expect(entry?.durabilityClass).toBe("checkpointed-file");
+		expect(entry?.persistent).toBe(true);
+		expect(entry?.path).toBe(path);
+		expect(entry?.expiresAt).toBe((entry?.createdAt ?? 0) + DURABLE_MONITOR_EXPIRY_MS);
+		expect(entry?.createdAt).toBeGreaterThanOrEqual(before);
+		expect(entry?.lastCheckpoint).toEqual({
+			dev: live.dev,
+			ino: live.ino,
+			size: live.size,
+			mtimeMs: live.mtimeMs,
+			digest: sampleDigest("one"),
+			present: true,
+		});
+	});
+
+	it("reports one created line when a watch on an absent path finds the file after a restart", async () => {
+		const path = join(root, "late.txt");
+		await createPersistentWatch(path, "create");
+		expect((await lane.writer.store.read())?.monitors[0]?.lastCheckpoint?.present).toBe(false);
+
+		lane.restart();
+		await writeFile(path, "landed");
+		const digest = await lane.restore();
+
+		expect(digest).toEqual({ restored: 1, lost: 0, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+		expect(lane.lines()).toEqual([`changed while detached: created ${path}`]);
+	});
+
+	it("reports one modified line for a same-size, same-mtime content change (digest only)", async () => {
+		const path = join(root, "same-shape.txt");
+		// Pin mtime to a whole second first: utimes has coarser resolution than a native write's
+		// mtime, so only a pre-pinned timestamp can be restored byte-exactly after the rewrite.
+		const pinned = new Date(1_700_000_000_000);
+		await writeFile(path, "aaaa");
+		await utimes(path, pinned, pinned);
+		await createPersistentWatch(path);
+		const saved = await stat(path);
+		expect(saved.mtimeMs).toBe(pinned.getTime());
+
+		lane.restart();
+		await writeFile(path, "bbbb");
+		await utimes(path, pinned, pinned);
+		const rewritten = await stat(path);
+		expect(rewritten.size).toBe(saved.size);
+		expect(rewritten.mtimeMs).toBe(saved.mtimeMs);
+
+		const digest = await lane.restore();
+		expect(digest.restored).toBe(1);
+		expect(lane.lines()).toEqual([`changed while detached: modified ${path}`]);
+	});
+
+	it("reports one replaced line and re-checkpoints the new identity when dev/ino differ", async () => {
+		const path = join(root, "swapped.txt");
+		await writeFile(path, "original");
+		await createPersistentWatch(path);
+		const saved = (await lane.writer.store.read())?.monitors[0]?.lastCheckpoint;
+
+		lane.restart();
+		await rm(path);
+		await writeFile(path, "replacement");
+		const replacement = await stat(path);
+		expect(replacement.ino).not.toBe(saved?.ino);
+
+		const digest = await lane.restore();
+		await lane.writer.flush();
+
+		expect(digest.restored).toBe(1);
+		expect(lane.lines()).toEqual([`changed while detached: replaced ${path}`]);
+		expect((await lane.writer.store.read())?.monitors[0]?.lastCheckpoint).toEqual({
+			dev: replacement.dev,
+			ino: replacement.ino,
+			size: replacement.size,
+			mtimeMs: replacement.mtimeMs,
+			digest: sampleDigest("replacement"),
+			present: true,
+		});
+	});
+
+	it("emits zero events when the file is untouched across the restart", async () => {
+		const path = join(root, "quiet.txt");
+		await writeFile(path, "unchanged");
+		await createPersistentWatch(path);
+
+		lane.restart();
+		const digest = await lane.restore();
+
+		expect(digest).toEqual({ restored: 1, lost: 0, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+		expect(lane.events).toEqual([]);
+	});
+
+	it("reports lost without re-registering when the watched path is gone", async () => {
+		const path = join(root, "vanished.txt");
+		await writeFile(path, "here");
+		await createPersistentWatch(path);
+
+		lane.restart();
+		await rm(path);
+		const digest = await lane.restore();
+
+		expect(digest).toEqual({ restored: 0, lost: 1, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+		// Nothing was re-registered, so no watch was left behind and no event was manufactured.
+		expect(lane.registry.snapshot()).toEqual([]);
+		expect(lane.events).toEqual([]);
+	});
+
+	it("reports lost and leaves no watch behind when the file is deleted mid-restore", async () => {
+		const path = join(root, "racing.txt");
+		await writeFile(path, "here");
+		await createPersistentWatch(path);
+		const saved = (await lane.writer.store.read())?.monitors[0];
+
+		const registry = lane.restart();
+		// Force the race the probe cannot close: the file survives the pre-check and is unlinked
+		// while the real registerFile runs, so the fresh record comes back present: false.
+		const handler = createCheckpointedFileRestoreHandler({
+			registry: {
+				registerFile: async (options) => {
+					await rm(path);
+					return registry.registerFile(options);
+				},
+				fileCheckpoint: (id) => registry.fileCheckpoint(id),
+				emitFileLine: (id, line) => registry.emitFileLine(id, line),
+				stopFile: (id) => registry.stopFile(id),
+			},
+			writer: lane.writer,
+		});
+
+		const result = await handler(saved as ManifestMonitor);
+
+		expect(result.outcome).toBe("lost");
+		expect(result.reason).toContain("gone");
+		expect(lane.lines()).toEqual([]);
+		expect(registry.snapshot()).toEqual([]);
+	});
+
+	it("never restores a non-persistent file monitor and never re-registers it", async () => {
+		const path = join(root, "ephemeral.txt");
+		await writeFile(path, "one");
+		const created = await lane.tool().monitor.execute("ephemeral-create", {
+			description: "one-shot artifact",
+			path,
+			event: "modify",
+		} as MonitorInput);
+		expect(created.isError, firstText(created)).toBeFalsy();
+		await lane.writer.flush();
+		expect((await lane.writer.store.read())?.monitors[0]?.durabilityClass).toBe("ephemeral");
+
+		lane.restart();
+		await writeFile(path, "two");
+		const digest = await lane.restore();
+
+		expect(digest).toEqual({ restored: 0, lost: 1, expired: 0, muted: 0, attachedElsewhere: 0, storeError: false });
+		expect(lane.registry.snapshot()).toEqual([]);
+		expect(lane.events).toEqual([]);
+	});
+
+	it("keeps the mon_ id across the restore and stops the restored watch with kill_bash", async () => {
+		const path = join(root, "keeps-id.txt");
+		await writeFile(path, "one");
+		const created = await createPersistentWatch(path);
+		const monitorId = String(created.details?.monitor_id ?? "");
+		expect(monitorId).toMatch(/^mon_[0-9A-Z]{16}$/);
+
+		lane.restart();
+		const digest = await lane.restore();
+		expect(digest.restored).toBe(1);
+
+		const restored = lane.registry.snapshot();
+		expect(restored).toHaveLength(1);
+		expect(restored[0]?.monitorId).toBe(monitorId);
+		// The stable mon_ id now resolves to the FRESH runtime id, not the pre-restart one.
+		const runtimeId = restored[0]?.id ?? "";
+		expect(runtimeId).toMatch(/^watch_\d+$/);
+		expect(lane.manager.resolveId(monitorId)).toBe(runtimeId);
+
+		const killed = await lane.tool().kill.execute("durable-kill", { bash_id: monitorId });
+		expect(killed.isError, firstText(killed)).toBeFalsy();
+		expect(firstText(killed)).toBe(`Killed ${monitorId}.`);
+		expect(lane.registry.snapshot()).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/suite/terminal-manifest.test.ts
+++ b/packages/coding-agent/test/suite/terminal-manifest.test.ts
@@ -119,11 +119,19 @@ describe("terminal manifest writer", () => {
 					event: "modify",
 					timeoutMs: 300_000,
 					cwd: "/tmp",
+					persistent: true,
 				},
 			});
 			expect(writeSpy).toHaveBeenCalledTimes(1);
 			for (let i = 1; i <= 5; i += 1) {
-				writer.scheduleCheckpoint("mon_file1", { dev: 1, ino: i, size: 100 + i, mtimeMs: 1_000 + i });
+				writer.scheduleCheckpoint("mon_file1", {
+					dev: 1,
+					ino: i,
+					size: 100 + i,
+					mtimeMs: 1_000 + i,
+					digest: `${100 + i}:digest-${i}`,
+					present: true,
+				});
 				await vi.advanceTimersByTimeAsync(5_000);
 			}
 			expect(writeSpy).toHaveBeenCalledTimes(1);
@@ -131,7 +139,14 @@ describe("terminal manifest writer", () => {
 			await writer.flush();
 			expect(writeSpy).toHaveBeenCalledTimes(2);
 			const manifest = await writer.store.read();
-			expect(manifest?.monitors[0]?.lastCheckpoint).toEqual({ dev: 1, ino: 5, size: 105, mtimeMs: 1_005 });
+			expect(manifest?.monitors[0]?.lastCheckpoint).toEqual({
+				dev: 1,
+				ino: 5,
+				size: 105,
+				mtimeMs: 1_005,
+				digest: "105:digest-5",
+				present: true,
+			});
 		} finally {
 			vi.useRealTimers();
 		}
@@ -243,6 +258,47 @@ describe("terminal manifest writer", () => {
 		await writer.recordBackgroundExit("bg-1");
 		expect(writeSpy).toHaveBeenCalledTimes(2);
 		expect((await writer.store.read())?.backgroundSessions).toEqual([]);
+	});
+
+	it("re-adopts a restored entry without a write, keeps every persisted field, clears suspended, and counts it as durable", async () => {
+		const { writer, sessionId } = await makeFixture();
+		const writeSpy = vi.spyOn(writer.store, "write");
+		const restored = manifestMonitor({
+			monitorId: "mon_readopt",
+			sessionId,
+			durabilityClass: "checkpointed-file",
+			runtimeKind: "file",
+			description: "standing artifact watch",
+			path: "out.bin",
+			event: "modify",
+			cwd: "/tmp",
+			approvedParent: "/tmp",
+			persistent: true,
+			suspended: true,
+			createdAt: 1_000,
+			expiresAt: 9_000,
+			lastCheckpoint: { dev: 7, ino: 11, size: 42, mtimeMs: 2_500, digest: "42:abc", present: true },
+			deliveryPaused: true,
+			wakeCount: 3,
+			fireWindow: { startMs: 1_500, count: 2 },
+		});
+		expect(writer.durableCount()).toBe(0);
+
+		writer.adoptRestored(restored);
+
+		// Re-adoption is recovery, not a transition: it must not write on its own.
+		expect(writeSpy).not.toHaveBeenCalled();
+		// The cap still holds after a restart because re-adopted durable entries are counted.
+		expect(writer.durableCount()).toBe(1);
+
+		// The next persist — any transition — now carries the restored entry instead of erasing it.
+		await writer.recordBackgroundStart("bg-after-restore", "echo hi", 123);
+		expect(writeSpy).toHaveBeenCalledTimes(1);
+		const persisted = (await writer.store.read())?.monitors ?? [];
+		expect(persisted).toEqual([{ ...restored, suspended: false }]);
+		// Explicitly: the durability deadline set at registration is not extended by a restore.
+		expect(persisted[0]?.expiresAt).toBe(9_000);
+		expect(persisted[0]?.createdAt).toBe(1_000);
 	});
 
 	it("surfaces an error for a snapshot entry missing its stable monitorId instead of skipping it", async () => {

--- a/packages/coding-agent/test/suite/terminal-restore-digest.test.ts
+++ b/packages/coding-agent/test/suite/terminal-restore-digest.test.ts
@@ -1,9 +1,11 @@
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { registerTerminalExtension } from "../../src/core/extensions/builtin/terminal/extension.ts";
+import { DURABLE_MONITOR_EXPIRY_MS } from "../../src/core/extensions/builtin/terminal/shared.ts";
 import type { ExtensionAPI, ExtensionContext } from "../../src/core/extensions/types.ts";
 import { initTheme, theme } from "../../src/modes/interactive/theme/theme.ts";
 
@@ -142,12 +144,33 @@ function createGeneration(cwd: string, sessionId: string, sessionDir: string): G
 	};
 }
 
+/** The registry's own digest shape for a file below its 64 KiB sample window: `size:sha256(bytes)`. */
+function fileCheckpoint(path: string, content: string) {
+	const live = statSync(path);
+	const bytes = Buffer.from(content);
+	return {
+		dev: live.dev,
+		ino: live.ino,
+		size: live.size,
+		mtimeMs: live.mtimeMs,
+		digest: `${bytes.length}:${createHash("sha256").update(bytes).digest("hex")}`,
+		present: true,
+	};
+}
+
 function terminalMessages(generation: Generation): SentMessage[] {
 	return generation.sent.filter((entry) => entry.message.customType === "senpi-terminal:notification");
 }
 
 function reminderContents(generation: Generation): string[] {
 	return terminalMessages(generation).map((entry) => entry.message.content);
+}
+
+/** Monitor line/summary injections travel on their own custom type, not the terminal one. */
+function monitorEventContents(generation: Generation): string[] {
+	return generation.sent
+		.filter((entry) => entry.message.customType === "senpi-monitor:notification")
+		.map((entry) => entry.message.content);
 }
 
 describe("terminal restore digest — lease, manifest restore, one resume digest", () => {
@@ -209,6 +232,26 @@ describe("terminal restore digest — lease, manifest restore, one resume digest
 		return join(stateDir, `${encodeURIComponent(sessionId)}.json`);
 	}
 
+	interface ManifestFile {
+		monitors: Array<{
+			monitorId: string;
+			description: string;
+			suspended: boolean;
+			createdAt: number;
+			expiresAt: number | null;
+		}>;
+	}
+
+	function readManifest(): ManifestFile {
+		return JSON.parse(readFileSync(manifestPath(), "utf8")) as ManifestFile;
+	}
+
+	/** Descriptions as the manifest FILE currently holds them, in persisted order. */
+	function manifestDescriptions(): string[] {
+		if (!existsSync(manifestPath())) return [];
+		return readManifest().monitors.map((entry) => entry.description);
+	}
+
 	async function startMonitor(generation: Generation, description: string): Promise<void> {
 		const created = await generation.tools.get("monitor")?.execute(`mon-${description}`, {
 			description,
@@ -218,7 +261,7 @@ describe("terminal restore digest — lease, manifest restore, one resume digest
 		expect(created?.isError, firstText(created)).toBeFalsy();
 	}
 
-	it("(a) restart after quit delivers exactly one digest naming every monitor and background session as lost", async () => {
+	it("(a) restart after quit delivers exactly one digest naming every restored monitor and every lost background session", async () => {
 		const gen1 = await start("startup");
 		expect(gen1.sent).toHaveLength(0);
 		trackers.restoreCalls = 0;
@@ -238,11 +281,54 @@ describe("terminal restore digest — lease, manifest restore, one resume digest
 
 		const gen2 = await start("resume");
 		expect(trackers.restoreCalls).toBe(1);
+		// The three persistent command monitors are durable, so the real restartable-command
+		// handler brings them back; a background session carries no durable identity and is lost.
 		expect(reminderContents(gen2)).toEqual([
-			"<system-reminder>Terminal state after restart: lost 4 (watch alpha, watch beta, watch gamma, background build log).</system-reminder>",
+			"<system-reminder>Terminal state after restart: restored 3 (watch alpha, watch beta, watch gamma); lost 1 (background build log).</system-reminder>",
 		]);
 		expect(terminalMessages(gen2)).toHaveLength(1);
 		expect(gen2.userMessages).toEqual([]);
+	});
+
+	it("(a2) a durable monitor survives TWO consecutive restarts even though the middle generation persists again", async () => {
+		// Generation 1: create the durable watch and shut down so it is persisted suspended.
+		const gen1 = await start("startup");
+		await startMonitor(gen1, "standing watch");
+		await gen1.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		live = [];
+		expect(manifestDescriptions()).toEqual(["standing watch"]);
+		const persisted = readManifest().monitors[0];
+		expect(persisted?.expiresAt).toBe((persisted?.createdAt ?? 0) + DURABLE_MONITOR_EXPIRY_MS);
+
+		// Generation 2: the watch comes back, then something else persists the manifest. Before
+		// re-adoption existed, that write rewrote the file from an in-memory map that never
+		// contained the restored entry, erasing it.
+		const gen2 = await start("resume");
+		expect(reminderContents(gen2)).toEqual([
+			"<system-reminder>Terminal state after restart: restored 1 (standing watch).</system-reminder>",
+		]);
+		await startMonitor(gen2, "second watch");
+		// The intervening persist really landed on disk, and it kept the restored entry.
+		await expect.poll(() => manifestDescriptions(), { timeout: 3000 }).toEqual(["standing watch", "second watch"]);
+		await gen2.emit("session_shutdown", { type: "session_shutdown", reason: "quit" });
+		live = [];
+		expect(manifestDescriptions()).toEqual(["standing watch", "second watch"]);
+
+		// Generation 3: the original durable monitor is STILL restored, not lost.
+		const gen3 = await start("resume");
+		expect(reminderContents(gen3)).toEqual([
+			"<system-reminder>Terminal state after restart: restored 2 (standing watch, second watch).</system-reminder>",
+		]);
+		// The stable mon_ handle from generation 1 still resolves two restarts later.
+		const standing = readManifest().monitors.find((entry) => entry.description === "standing watch");
+		expect(standing?.monitorId).toBe(persisted?.monitorId);
+		const peeked = await gen3.tools
+			.get("bash_output")
+			?.execute("peek-standing", { bash_id: standing?.monitorId, view: "screen" });
+		expect(peeked?.isError, firstText(peeked)).toBeFalsy();
+		// Two restarts later the deadline is still the one set at first registration: never extended.
+		expect(standing?.createdAt).toBe(persisted?.createdAt);
+		expect(standing?.expiresAt).toBe(persisted?.expiresAt);
 	});
 
 	it("(b) a reload start claims the parked bundle, sends no digest, and keeps the lease with the same pid", async () => {
@@ -337,6 +423,134 @@ describe("terminal restore digest — lease, manifest restore, one resume digest
 		expect(generation.sent).toHaveLength(0);
 		expect(trackers.restoreCalls).toBeGreaterThanOrEqual(1);
 		expect(existsSync(leasePath())).toBe(true);
+	});
+
+	it("(g) the production restore path runs the REAL durable handlers: both entries come back restored", async () => {
+		const watched = join(cwd, "durable-artifact.txt");
+		writeFileSync(watched, "before-detach", "utf8");
+		const checkpoint = fileCheckpoint(watched, "before-detach");
+		// The file changes while no process is attached: the checkpointed-file handler must notice
+		// it once on restore, which is only possible if the production path builds the real handler.
+		writeFileSync(watched, "after-detach-change", "utf8");
+		mkdirSync(stateDir, { recursive: true });
+		writeFileSync(
+			manifestPath(),
+			JSON.stringify({
+				version: 1,
+				sessionId,
+				monitors: [
+					{
+						monitorId: "mon_WIREDFILE00000001",
+						sessionId,
+						description: "durable artifact watch",
+						runtimeKind: "file",
+						durabilityClass: "checkpointed-file",
+						path: watched,
+						event: "modify",
+						cwd,
+						createdAt: Date.now() - 1000,
+						expiresAt: null,
+						persistent: true,
+						suspended: true,
+						lastCheckpoint: checkpoint,
+						deliveryPaused: false,
+						wakeCount: 0,
+						fireWindow: { startMs: 1, count: 0 },
+					},
+					{
+						monitorId: "mon_WIREDCOMMAND00001",
+						sessionId,
+						description: "durable command watch",
+						runtimeKind: "command",
+						durabilityClass: "restartable-command",
+						command: "cat",
+						cwd,
+						createdAt: Date.now() - 1000,
+						expiresAt: null,
+						persistent: true,
+						suspended: true,
+						lastCheckpoint: null,
+						deliveryPaused: false,
+						wakeCount: 0,
+						fireWindow: { startMs: 1, count: 0 },
+					},
+				],
+				backgroundSessions: [],
+				updatedAt: Date.now(),
+			}),
+			"utf8",
+		);
+
+		const generation = await start("resume");
+
+		expect(reminderContents(generation)).toContain(
+			"<system-reminder>Terminal state after restart: restored 2 (durable artifact watch, durable command watch).</system-reminder>",
+		);
+		// Exactly one PTY for the restartable-command entry; the file watch spawns nothing.
+		expect(trackers.spawnCalls).toBe(1);
+		expect(trackers.handlerCalls).toBe(2);
+		// The detached change is reported once through the registry's normal event sink.
+		await expect
+			.poll(
+				() =>
+					monitorEventContents(generation).some((content) =>
+						content.includes(`changed while detached: modified ${watched}`),
+					),
+				{ timeout: 5000 },
+			)
+			.toBe(true);
+		// The restored command watch is steerable through its persisted mon_ id, so the fresh
+		// runtime id really is bound in this generation's manager.
+		const peeked = await generation.tools
+			.get("bash_output")
+			?.execute("peek-restored", { bash_id: "mon_WIREDCOMMAND00001", view: "screen" });
+		expect(peeked?.isError, firstText(peeked)).toBeFalsy();
+	});
+
+	it("(h) a restored durable monitor whose manifest entry is muted is re-muted and counted as muted", async () => {
+		mkdirSync(stateDir, { recursive: true });
+		writeFileSync(
+			manifestPath(),
+			JSON.stringify({
+				version: 1,
+				sessionId,
+				monitors: [
+					{
+						monitorId: "mon_WIREDMUTED0000001",
+						sessionId,
+						description: "muted durable command",
+						runtimeKind: "command",
+						durabilityClass: "restartable-command",
+						command: "cat",
+						cwd,
+						createdAt: Date.now() - 1000,
+						expiresAt: null,
+						persistent: true,
+						suspended: true,
+						lastCheckpoint: null,
+						deliveryPaused: true,
+						wakeCount: 0,
+						fireWindow: { startMs: 1, count: 0 },
+					},
+				],
+				backgroundSessions: [],
+				updatedAt: Date.now(),
+			}),
+			"utf8",
+		);
+
+		const generation = await start("resume");
+
+		expect(reminderContents(generation)).toContain(
+			"<system-reminder>Terminal state after restart: 1 still muted.</system-reminder>",
+		);
+		expect(trackers.spawnCalls).toBe(1);
+		// The mute was applied by the FRESH runtime id: bash_output reports the live monitor muted.
+		const peeked = await generation.tools
+			.get("bash_output")
+			?.execute("peek-muted", { bash_id: "mon_WIREDMUTED0000001", view: "screen" });
+		expect(peeked?.isError, firstText(peeked)).toBeFalsy();
+		expect(firstText(peeked)).toContain("muted");
 	});
 
 	it("(f) a non-reload shutdown flushes the manifest as suspended and releases the lease", async () => {


### PR DESCRIPTION
## What

Phase 3 makes `persistent: true` mean what it says: a standing watch that comes back after a restart.

- **`durable-file.ts` — the `checkpointed-file` class.** On restore the watch is re-registered under its original `mon_` id and compared ONCE against its persisted `{ dev, ino, size, mtimeMs, digest, present }`, so a change made while nobody was listening surfaces as exactly one coalesced line (`created`, `replaced` on a new inode, or `modified`) and an unchanged file produces nothing. The comparison reuses the detector the registry already owns and emits through its single sink, so notifier coalescing, dedupe and the wake budget keep applying. `digest` is in the checkpoint deliberately: without it a same-size, same-mtime edit is invisible across a restart.
- **`durable-command.ts` — the `restartable-command` class.** A restore spawns the saved command **exactly once** with its recorded cwd and filter, re-registers it under the SAME `mon_` id, and rebinds that id to the fresh runtime handle. Nothing from before the restart is replayed, a vanished cwd reports lost without spawning, and a reload never takes this path.
- **Bounded, expiring, and still muted.** At most 5 durable watches per session (one-shot monitors never counted, further ones refused); a 7-day deadline from creation, checked on the same `<=` boundary the restore orchestrator uses and never extended by a restore or rearm; and a watch the wake budget had muted comes back muted — re-applied by the **fresh runtime id**, because `MonitorRegistry.pause` resolves runtime ids only and the persisted `mon_` id would silently no-op.
- **Survives repeated restarts.** Restored entries are re-adopted into the session manifest, so the next ordinary write cannot erase them.

## Two defects found in review and fixed here, both mutation-proven

1. **The handlers were never wired.** All three new suites were green while `extension.ts` still hardwired every durable entry to `lost` — the modules were imported only by their own tests. Wiring them in, plus a new case that drives the production `session_start` and asserts `restored 2` with the command spawned once. Forcing the old `lost` wiring back fails three cases.
2. **A restored watch survived only the FIRST restart.** The manifest writer starts each generation with an empty entry map and rewrites the file from it, so the next write after a restore erased the restored monitors. Added `adoptRestored`, called for `restored` and `muted` outcomes only. A new three-generation case proves it; deleting the re-adoption call fails it with `['second watch']` instead of `['standing watch', 'second watch']`.

Neither was visible from a green suite — the root cause of the second was that no test had ever driven two restarts.

## Verification

```
new P3 suites + restore digest + manifest + extension + reload  ->   57 tests passed
wider terminal / store regression gate (14 suites)              ->  185 tests passed
bunx tsc --noEmit                                               ->  clean
```

New files: `durable-file.ts` 120 LOC, `durable-command.ts` 109 LOC. No test writes inside the checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `persistent: true` terminal monitors survive restarts: file watches re-register and compare once against their saved checkpoint, and command watches re-spawn once under the same `mon_` id. Previously every durable monitor was reported lost after a restart.

**Restore behavior**
- A file watch emits exactly one `created`, `replaced`, or `modified` line for a change made while detached, and nothing when the file is unchanged.
- The persisted checkpoint includes a content digest so same-size, same-mtime rewrites are still detected.
- A command watch re-spawns with its saved command, absolute cwd, and filter; nothing from before the restart is replayed, and a vanished cwd reports lost without spawning.
- Restored entries are re-adopted into the manifest so a standing watch survives repeated restarts, not just the first.

**Limits and fixes**
- A session may hold at most five durable watches; further ones are refused before any spawn, one-shot monitors never count, and file monitors now accept `persistent: true`.
- Durable watches expire seven days after creation, checked with the same `<=` boundary as the restore orchestrator and never extended by a restore or rearm.
- A monitor muted by the wake budget comes back muted, re-applied by the fresh runtime id because the persisted `mon_` id silently no-ops.
- Two review defects are fixed: the durable handlers were never wired into `extension.ts`, and restored watches were erased by the next manifest write.
- Manifests written before this change lack the now-required `digest` and `present` checkpoint fields and will fail the strict manifest parse.

<sup>Written for commit c1fea9c8f61dd71e1e2e14a21b03618dd9b49dc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

