### PR TITLE
test(coding-agent): make interactive host teardown deterministic

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Interactive shared-host regression tests now wait for RPC child processes to exit before removing their temporary roots, preventing teardown `ENOTEMPTY` races.
+
 ### Removed
 
 ## [2026.9.4-3] - 2026-09-04

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Fixed
 
 - Interactive shared-host regression tests now wait for RPC child processes to exit before removing their temporary roots, preventing teardown `ENOTEMPTY` races.
-
+- Make the reftable polling fallback detect content changes without relying on filesystem timestamp precision, and test the fallback with deterministic timer/event control.
 ### Removed
 
 ## [2026.9.4-3] - 2026-09-04

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1447,6 +1447,24 @@ Conflict zone: `cursor-exec-bridge.ts` `executeTool`, `cursor-exec-bridge-sessio
 - `provider-composer.ts` end of `ProviderConfigInput`; `model-runtime.ts` near `hasConfiguredAuth`;
   `model-registry.ts` near `isUsingOAuth`.
 
+## 2026-09-04 - Make reftable polling content-aware
+
+### What changed
+
+- `footer-data-provider.ts` now retains the last `tables.list` contents and compares content on each polling callback in addition to filesystem metadata.
+
+### Why
+
+- Filesystem timestamp precision can make a changed reftable table list look unchanged when its size and timestamps are identical, leaving the footer branch stale.
+
+### Why an extension could not handle it
+
+- Reftable detection is core footer session plumbing and is not observable or replaceable by an extension.
+
+### Expected merge conflict zones
+
+- LOW: `footer-data-provider.ts` reftable polling callback.
+
 ## 2026-08-19 upstream sync integration repair (footer-data-provider watcher fallback)
 
 ### What changed

--- a/packages/coding-agent/src/core/footer-data-provider.ts
+++ b/packages/coding-agent/src/core/footer-data-provider.ts
@@ -361,8 +361,23 @@ export class FooterDataProvider {
 				// when watcher creation just failed. The path is recorded after the
 				// attempt because a failure synchronously clears watcher state.
 				this.reftableTablesListPath = tablesListPath;
+				let previousTablesListContent: string | undefined;
+				try {
+					previousTablesListContent = readFileSync(tablesListPath, "utf8");
+				} catch {
+					// The file may disappear between existsSync and the first poll.
+				}
 				watchFile(tablesListPath, { interval: 250 }, (current, previous) => {
+					let contentChanged = false;
+					try {
+						const currentContent = readFileSync(tablesListPath, "utf8");
+						contentChanged = previousTablesListContent !== currentContent;
+						previousTablesListContent = currentContent;
+					} catch {
+						contentChanged = true;
+					}
 					if (
+						contentChanged ||
 						current.mtimeMs !== previous.mtimeMs ||
 						current.ctimeMs !== previous.ctimeMs ||
 						current.size !== previous.size

--- a/packages/coding-agent/test/footer-data-provider-watch-fallback.test.ts
+++ b/packages/coding-agent/test/footer-data-provider-watch-fallback.test.ts
@@ -6,6 +6,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let resolvedBranch = "main";
 let branchResolutionDelivered: (() => void) | null = null;
+let tablesListPoll: ((current: unknown, previous: unknown) => void) | null = null;
+
+vi.mock("fs", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("fs")>();
+	return {
+		...actual,
+		watchFile: vi.fn((_path: string, _options: unknown, listener: (current: unknown, previous: unknown) => void) => {
+			tablesListPoll = listener;
+		}),
+		unwatchFile: vi.fn(),
+	};
+});
 
 vi.mock("child_process", () => ({
 	execFile: vi.fn(
@@ -69,20 +81,6 @@ function createReftableWorktree(tempDir: string): { worktreeDir: string; reftabl
 	return { worktreeDir, reftableDir };
 }
 
-async function awaitWithTimeout(event: Promise<void>, description: string, timeoutMs = 10000): Promise<void> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		await Promise.race([
-			event,
-			new Promise<never>((_resolve, reject) => {
-				timer = setTimeout(() => reject(new Error(`Timed out waiting for ${description}`)), timeoutMs);
-			}),
-		]);
-	} finally {
-		if (timer) clearTimeout(timer);
-	}
-}
-
 describe("FooterDataProvider reftable detection without usable fs.watch", () => {
 	let originalCwd: string;
 	let tempDir: string;
@@ -92,6 +90,8 @@ describe("FooterDataProvider reftable detection without usable fs.watch", () => 
 		tempDir = mkdtempSync(join(tmpdir(), "footer-watch-fallback-"));
 		resolvedBranch = "main";
 		branchResolutionDelivered = null;
+		tablesListPoll = null;
+		vi.useFakeTimers();
 		vi.mocked(spawnSync).mockClear();
 		vi.mocked(execFile).mockClear();
 	});
@@ -101,6 +101,7 @@ describe("FooterDataProvider reftable detection without usable fs.watch", () => 
 		if (tempDir && existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
+		vi.useRealTimers();
 	});
 
 	it("still refreshes the branch through the polling fallback", async () => {
@@ -118,7 +119,10 @@ describe("FooterDataProvider reftable detection without usable fs.watch", () => 
 				branchResolutionDelivered = resolve;
 			});
 			writeFileSync(join(reftableDir, "tables.list"), "1\n");
-			await awaitWithTimeout(resolutionDelivered, "the polled reftable refresh to resolve the branch");
+			expect(tablesListPoll).not.toBeNull();
+			tablesListPoll?.({ mtimeMs: 1, ctimeMs: 1, size: 2 }, { mtimeMs: 1, ctimeMs: 1, size: 2 });
+			await vi.advanceTimersByTimeAsync(500);
+			await resolutionDelivered;
 
 			expect(provider.getGitBranch()).toBe("foo");
 			expect(onBranchChange).toHaveBeenCalledTimes(1);

--- a/packages/coding-agent/test/helpers/process-teardown.ts
+++ b/packages/coding-agent/test/helpers/process-teardown.ts
@@ -1,0 +1,43 @@
+import type { ChildProcess } from "node:child_process";
+import { rmSync } from "node:fs";
+
+const DEFAULT_EXIT_TIMEOUT_MS = 5000;
+
+function hasExited(child: ChildProcess): boolean {
+	return child.exitCode !== null || child.signalCode !== null;
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+	if (hasExited(child)) return Promise.resolve(true);
+	return new Promise((resolve) => {
+		let settled = false;
+		const finish = (exited: boolean) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			child.removeListener("exit", onExit);
+			resolve(exited);
+		};
+		const onExit = () => finish(true);
+		const timer = setTimeout(() => finish(false), timeoutMs);
+		child.once("exit", onExit);
+		if (hasExited(child)) finish(true);
+	});
+}
+
+export async function teardownChildProcessesAndRoots(
+	children: ChildProcess[],
+	roots: string[],
+	timeoutMs = DEFAULT_EXIT_TIMEOUT_MS,
+): Promise<void> {
+	for (const child of children.splice(0)) {
+		if (hasExited(child)) continue;
+		child.kill("SIGTERM");
+		if (await waitForExit(child, timeoutMs)) continue;
+		child.kill("SIGKILL");
+		if (!(await waitForExit(child, timeoutMs))) {
+			throw new Error("Child process did not exit after SIGKILL");
+		}
+	}
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+}

--- a/packages/coding-agent/test/interactive-w3.test.ts
+++ b/packages/coding-agent/test/interactive-w3.test.ts
@@ -1,11 +1,12 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { MissingSessionCwdError } from "../src/core/session-cwd.ts";
 import { SessionManager } from "../src/core/session-manager.ts";
 import { RpcClient } from "../src/modes/rpc/rpc-client.ts";
+import { teardownChildProcessesAndRoots } from "./helpers/process-teardown.ts";
 import { startFakeModelServer } from "./helpers/rpc-fake-model.ts";
 import { hermeticProviderEnv, MOCK_MODEL, MOCK_PROVIDER, writeRpcModelsJson } from "./helpers/rpc-hermetic.ts";
 
@@ -13,8 +14,7 @@ const roots: string[] = [];
 const children: ChildProcessWithoutNullStreams[] = [];
 
 afterEach(async () => {
-	for (const child of children.splice(0)) child.kill("SIGTERM");
-	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+	await teardownChildProcessesAndRoots(children, roots);
 });
 
 async function fixture(label: string) {

--- a/packages/coding-agent/test/process-teardown.test.ts
+++ b/packages/coding-agent/test/process-teardown.test.ts
@@ -5,22 +5,28 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { teardownChildProcessesAndRoots } from "./helpers/process-teardown.ts";
 
-function spawnChurner(root: string, termMarker: string): ChildProcessWithoutNullStreams {
+function spawnChurner(root: string, termMarker: string, exitsOnTerm = false): ChildProcessWithoutNullStreams {
 	const script = `
 		const fs = require("node:fs");
 		const path = require("node:path");
 		const root = process.argv[1];
 		const termMarker = process.argv[2];
+		const exitsOnTerm = process.argv[3] === "true";
 		for (let i = 0; i < 20000; i++) {
 			fs.mkdirSync(path.join(root, "initial-" + i));
 		}
 		process.stdout.write("ready\\n");
 		let i = 0;
+		let interval;
 		process.on("SIGTERM", () => {
 			fs.writeFileSync(termMarker, "term-observed");
 			process.stdout.write("term-observed\\n");
+			if (exitsOnTerm) {
+				clearInterval(interval);
+				process.exit(0);
+			}
 		});
-		setInterval(() => {
+		interval = setInterval(() => {
 			try {
 				const dir = path.join(root, "live-" + i++);
 				fs.mkdirSync(dir);
@@ -28,7 +34,9 @@ function spawnChurner(root: string, termMarker: string): ChildProcessWithoutNull
 			} catch {}
 		}, 0);
 	`;
-	return spawn(process.execPath, ["-e", script, root, termMarker], { stdio: ["pipe", "pipe", "pipe"] });
+	return spawn(process.execPath, ["-e", script, root, termMarker, String(exitsOnTerm)], {
+		stdio: ["pipe", "pipe", "pipe"],
+	});
 }
 
 async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
@@ -82,4 +90,17 @@ describe("process teardown", () => {
 		rmSync(newMarker, { force: true });
 		expect(() => rmSync(newRoot, { recursive: true })).toThrow(/ENOENT/);
 	}, 15000);
+
+	it("waits for a child that exits gracefully on SIGTERM", async () => {
+		const root = mkdtempSync(join(tmpdir(), "senpi-teardown-graceful-"));
+		const marker = join(tmpdir(), `senpi-teardown-graceful-marker-${process.pid}`);
+		const child = spawnChurner(root, marker, true);
+		await waitForOutput(child, "ready");
+		await teardownChildProcessesAndRoots([child], [root]);
+		expect(readFileSync(marker, "utf8")).toBe("term-observed");
+		expect(child.exitCode).toBe(0);
+		expect(child.signalCode).not.toBe("SIGKILL");
+		rmSync(marker, { force: true });
+		expect(() => rmSync(root, { recursive: true })).toThrow(/ENOENT/);
+	});
 });

--- a/packages/coding-agent/test/process-teardown.test.ts
+++ b/packages/coding-agent/test/process-teardown.test.ts
@@ -1,0 +1,85 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { teardownChildProcessesAndRoots } from "./helpers/process-teardown.ts";
+
+function spawnChurner(root: string, termMarker: string): ChildProcessWithoutNullStreams {
+	const script = `
+		const fs = require("node:fs");
+		const path = require("node:path");
+		const root = process.argv[1];
+		const termMarker = process.argv[2];
+		for (let i = 0; i < 20000; i++) {
+			fs.mkdirSync(path.join(root, "initial-" + i));
+		}
+		process.stdout.write("ready\\n");
+		let i = 0;
+		process.on("SIGTERM", () => {
+			fs.writeFileSync(termMarker, "term-observed");
+			process.stdout.write("term-observed\\n");
+		});
+		setInterval(() => {
+			try {
+				const dir = path.join(root, "live-" + i++);
+				fs.mkdirSync(dir);
+				fs.writeFileSync(path.join(dir, "entry"), "x");
+			} catch {}
+		}, 0);
+	`;
+	return spawn(process.execPath, ["-e", script, root, termMarker], { stdio: ["pipe", "pipe", "pipe"] });
+}
+
+async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	await new Promise<void>((resolve) => child.once("exit", () => resolve()));
+}
+
+async function waitForOutput(child: ChildProcessWithoutNullStreams, expected: string): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		let output = "";
+		const onData = (chunk: Buffer) => {
+			output += chunk.toString();
+			if (output.includes(expected)) {
+				child.stdout.off("data", onData);
+				resolve();
+			}
+		};
+		child.stdout.on("data", onData);
+		child.once("error", reject);
+		child.once("exit", (code, signal) => reject(new Error(`churner exited: ${code ?? signal}`)));
+	});
+}
+
+describe("process teardown", () => {
+	it("proves immediate removal races a live writer, while event-driven teardown is clean", async () => {
+		const oldRoot = mkdtempSync(join(tmpdir(), "senpi-teardown-old-"));
+		const oldMarker = join(tmpdir(), `senpi-teardown-old-marker-${process.pid}`);
+		const oldChild = spawnChurner(oldRoot, oldMarker);
+		await waitForOutput(oldChild, "ready");
+		oldChild.kill("SIGTERM");
+		await waitForOutput(oldChild, "term-observed");
+		let oldError: unknown;
+		try {
+			rmSync(oldRoot, { recursive: true, force: true });
+		} catch (error) {
+			oldError = error;
+		}
+		oldChild.kill("SIGKILL");
+		await waitForExit(oldChild);
+		if (!oldError) rmSync(oldRoot, { recursive: true, force: true });
+		expect(oldError).toMatchObject({ code: "ENOTEMPTY" });
+
+		rmSync(oldMarker, { force: true });
+
+		const newRoot = mkdtempSync(join(tmpdir(), "senpi-teardown-new-"));
+		const newMarker = join(tmpdir(), `senpi-teardown-new-marker-${process.pid}`);
+		const newChild = spawnChurner(newRoot, newMarker);
+		await waitForOutput(newChild, "ready");
+		await teardownChildProcessesAndRoots([newChild], [newRoot], 100);
+		expect(readFileSync(newMarker, "utf8")).toBe("term-observed");
+		rmSync(newMarker, { force: true });
+		expect(() => rmSync(newRoot, { recursive: true })).toThrow(/ENOENT/);
+	}, 15000);
+});


### PR DESCRIPTION
## Summary
- wait for RPC child processes to exit before removing interactive-w3 temporary roots
- escalate wedged children from SIGTERM to SIGKILL with event-driven bounded waits
- add deterministic RED/GREEN teardown race, graceful-exit, and mutation coverage
- make reftable polling fallback detect content changes without timestamp precision dependence

## Why these land together
PR #1361 and this PR are mutually blocking: #1372 fixes the interactive-w3 ENOTEMPTY race that fails #1361, while #1361 fixes the reftable polling timeout that fails #1372. The failing jobs are [#1361 Test (coding-agent 3/3)](https://github.com/code-yeongyu/senpi/actions/runs/33878018773/job/101039562608) and [#1372 Test (coding-agent 2/3)](https://github.com/code-yeongyu/senpi/actions/runs/33880699930/job/101048365143). #1361 will be closed as included once this PR merges.

Root cause of the teardown failure: SIGTERM delivery is asynchronous; the old teardown removed roots while the RPC host could still write into them, and force does not suppress ENOTEMPTY.

Evidence is included in the focused regression tests and local mutation runs.