### PR TITLE
feat(coding-agent): recommend GPT-6 Astra ahead of GPT-5.6 Sol

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+- GPT-6 Astra (`gpt-6-astra`) is now a built-in recommended default model at thinking level `high`, placed ahead of GPT-5.6 Sol which remains the OpenAI fallback recommendation.
 - Persistent monitors now survive repeated restarts: file watches are re-registered and compare their persisted checkpoint once, reporting exactly one detached created, replaced, or modified change (and nothing when unchanged), while command watches are re-run once under the same `mon_` id without replaying pre-restart output. Sessions may keep up to five durable watches; each expires seven days after creation without extending that deadline on restart or rearm, and a watch muted by the wake budget remains muted when restored.
 - A standing watch that exceeds its 200-line matching-event budget within a rolling 24-hour window now mutes itself and says so once, telling you to rearm it; rearming resumes the watch, ordinary one-shot monitors are never counted, and the window survives restarts so a noisy watch cannot receive a fresh allowance.
 

--- a/packages/coding-agent/docs/settings.md
+++ b/packages/coding-agent/docs/settings.md
@@ -83,6 +83,7 @@ Permission rules are a confirmation policy, not a sandbox. Senpi, extensions, pa
 |---------|------|---------|-------------|
 | `defaultProvider` | string | - | Startup provider (e.g., `"anthropic"`, `"openai"`; saved with Ctrl+S in `/model`, or edited manually) |
 | `defaultModel` | string | - | Startup model ID (saved with Ctrl+S in `/model`, or edited manually) |
+| `recommendedModels` | string[] | `kimi-k3`, `gpt-6-astra`, `gpt-5.6-sol`, `claude-fable-5-1`, `claude-opus-5`, `glm-5.2` | Preferred default model ids in priority order. Built-in thinking levels are kimi-k3/`max`, GPT-6 Astra/`high`, GPT-5.6 Sol/`medium`, claude-fable-5-1/`high`, claude-opus-5/`xhigh`, glm-5.2/`max`. Override the list or disable auto-switch with `--no-recommended-models` / `warnings.offRecommendedModel`. |
 | `defaultThinkingLevel` | string | - | Startup thinking level (saved with Ctrl+S in `/thinking`, or edited manually): `"off"`, `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, `"max"` |
 | `modelThinkingLevels` | object | - | Per-model reasoning effort memory (`"provider/id": "level"`) |
 | `modelLastOnThinkingLevels` | object | - | Per-model last non-off reasoning level, used by `/reasoning on` to restore the previous effort |

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,23 @@
 # Builtin extensions changes
 
+## Recommend GPT-6 Astra ahead of GPT-5.6 Sol (2026-09-05)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts`: insert `["gpt-6-astra", "high"]` immediately before `["gpt-5.6-sol", "medium"]` in `RECOMMENDED_DEFAULT_MODELS`. Astra is the new OpenAI flagship recommendation; Sol stays as the fallback. `canonicalModelId` is unchanged, so `gpt-6-astra-fast` still strips to `gpt-6-astra`.
+
+### Why
+
+- Sessions that land on an implicit OpenAI default should prefer GPT-6 Astra at thinking level `high` when `openai-codex/gpt-6-astra` (or a `-fast` variant) is authenticated, instead of stopping at GPT-5.6 Sol/`medium`. `packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts` is the shipped priority list for that auto-switch.
+
+### Why an extension could not handle it
+
+- The shipped default lives in `packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts`. A user extension or `settings.recommendedModels` override can change one machine, not the binary default every session gets without an override.
+
+### Expected merge conflict zones
+
+- LOW in `packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts` around `RECOMMENDED_DEFAULT_MODELS`. Keep `["gpt-6-astra", "high"]` immediately before `["gpt-5.6-sol", "medium"]`; do not reorder the other entries.
+
 ## Hooks trust-state reads fail open when the lock directory is not writable (2026-09-04)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/recommended-models/index.ts
@@ -14,6 +14,7 @@ const MODEL_ID_SUFFIXES = ["-ultrafast", "-unlocked", "-256k", "-fast"] as const
 
 export const RECOMMENDED_DEFAULT_MODELS = [
 	["kimi-k3", "max"],
+	["gpt-6-astra", "high"],
 	["gpt-5.6-sol", "medium"],
 	["claude-fable-5-1", "high"],
 	["claude-opus-5", "xhigh"],

--- a/packages/coding-agent/test/suite/recommended-models-extension.test.ts
+++ b/packages/coding-agent/test/suite/recommended-models-extension.test.ts
@@ -2,6 +2,10 @@ import { fauxAssistantMessage, registerFauxProvider } from "@earendil-works/pi-a
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuthStorage } from "../../src/core/auth-storage.ts";
 import { builtinExtensions } from "../../src/core/extensions/builtin/index.ts";
+import {
+	canonicalModelId,
+	RECOMMENDED_DEFAULT_MODELS,
+} from "../../src/core/extensions/builtin/recommended-models/index.ts";
 import type { SessionStartEvent } from "../../src/core/extensions/types.ts";
 import { ModelRuntime } from "../../src/core/model-runtime.ts";
 import { createAgentSession } from "../../src/core/sdk.ts";
@@ -17,6 +21,45 @@ afterEach(() => {
 });
 
 describe("recommended-models builtin", () => {
+	it("#given the shipped recommendation list #when order is read #then gpt-6-astra high sits directly before gpt-5.6-sol", () => {
+		const astraIndex = RECOMMENDED_DEFAULT_MODELS.findIndex(([modelId]) => modelId === "gpt-6-astra");
+		const solIndex = RECOMMENDED_DEFAULT_MODELS.findIndex(([modelId]) => modelId === "gpt-5.6-sol");
+
+		expect(astraIndex).toBeGreaterThanOrEqual(0);
+		expect(solIndex).toBe(astraIndex + 1);
+		expect(RECOMMENDED_DEFAULT_MODELS[astraIndex]?.[1]).toBe("high");
+	});
+
+	it("#given openai-codex/gpt-6-astra and sol #when an implicit-fallback provenance starts #then it switches to astra at high", async () => {
+		const astra = model("gpt-6-astra", "openai-codex");
+		const sol = model("gpt-5.6-sol", "openai-codex");
+		const harness = createHarness({
+			active: model("off-list"),
+			available: [sol, astra],
+		});
+
+		await harness.start("first-available");
+
+		expect(harness.getActiveModel()).toBe(astra);
+		expect(harness.getThinkingLevel()).toBe("high");
+		expect(harness.settings.getDefaultThinkingLevel()).toBe("high");
+		expect(harness.notices).toEqual([{ message: "Switched to recommended model 'gpt-6-astra'.", type: "info" }]);
+	});
+
+	it("#given gpt-6-astra-fast #when an implicit-fallback provenance starts #then it counts as recommended and is kept", async () => {
+		expect(canonicalModelId("gpt-6-astra-fast")).toBe("gpt-6-astra");
+
+		const harness = createHarness({
+			active: model("gpt-6-astra-fast"),
+			available: [model("gpt-5.6-sol", "openai-codex"), model("gpt-6-astra", "openai-codex")],
+		});
+
+		await harness.start("first-available");
+
+		expect(harness.getActiveModel().id).toBe("gpt-6-astra-fast");
+		expect(harness.notices).toEqual([]);
+	});
+
 	it("#given an off-list saved default #when settings provenance starts #then it keeps the saved default without switching, persisting, or notifying", async () => {
 		const offList = model("off-list");
 		const harness = createHarness({ active: offList, available: [model("kimi-k3", "kimi-coding")] });


### PR DESCRIPTION
## What

Insert `["gpt-6-astra", "high"]` immediately before `["gpt-5.6-sol", "medium"]` in the shipped `RECOMMENDED_DEFAULT_MODELS` list. Astra is the new OpenAI flagship recommendation; Sol stays as the fallback. `canonicalModelId` is unchanged, so `gpt-6-astra-fast` still counts as recommended.

Document the default list (Astra/high ahead of Sol/medium) on `recommendedModels` in `packages/coding-agent/docs/settings.md`.

## Why

Implicit-fallback sessions that have `openai-codex/gpt-6-astra` authenticated were still auto-switching to GPT-5.6 Sol at `medium`. The new flagship should win that choice at thinking level `high` without dropping Sol from the list.

## Observed behavior

- Recommendation order is now `kimi-k3/max`, `gpt-6-astra/high`, `gpt-5.6-sol/medium`, `claude-fable-5-1/high`, `claude-opus-5/xhigh`, `glm-5.2/max`.
- With both `openai-codex/gpt-6-astra` and Sol available, an implicit-fallback start switches to Astra and sets thinking `high`.
- An already-selected `gpt-6-astra-fast` is treated as recommended and is kept.
- Explicit `settings` / CLI / scoped provenance is unchanged.

## QA evidence

TDD on **mengmotaMac** (`34a6007a`), clone `/tmp/astra-a2-20260905/senpi`, `bun install --frozen-lockfile`, `cd packages/coding-agent && bunx vitest run test/suite/recommended-models-extension.test.ts`.

**RED** (test-only SHA `9c985f232`, before the list change) — 3 failed / 10 passed:

```
FAIL  #given the shipped recommendation list #when order is read #then gpt-6-astra high sits directly before gpt-5.6-sol
AssertionError: expected -1 to be greater than or equal to 0

FAIL  #given openai-codex/gpt-6-astra and sol #when an implicit-fallback provenance starts #then it switches to astra at high
AssertionError: expected { id: 'gpt-5.6-sol', … } to be { id: 'gpt-6-astra', … }

FAIL  #given gpt-6-astra-fast #when an implicit-fallback provenance starts #then it counts as recommended and is kept
AssertionError: expected 'gpt-5.6-sol' to be 'gpt-6-astra-fast'
```

**GREEN** (SHA `15696ec9b`) — 13 passed:

```
Test Files  1 passed (1)
     Tests  13 passed (13)
  Duration  6.06s
```

- `bunx biome check` on the changed files (no `--write`): clean
- `bun scripts/check-pr-changelog.mjs --base origin/main`: PASS

**Bunshin receipt:** machine `mengmotaMac`; temp dir `/tmp/astra-a2-20260905` removed (`REMOVED /tmp/astra-a2-20260905`).

## Residual risk

- Users who relied on implicit OpenAI fallback landing on Sol/`medium` will now land on Astra/`high` when Astra is authenticated. Explicit saved defaults and CLI/scoped selections are not overridden.
- Kimi K3 remains the first recommendation; this PR does not reorder any other entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes GPT-6 Astra to the top OpenAI recommendation ahead of GPT-5.6 Sol, so implicit-fallback sessions now start with Astra at thinking level `high` instead of Sol at `medium`. Sol remains the fallback recommendation.

**Behavior changes**

- Sessions with `openai-codex/gpt-6-astra` (or a `-fast` variant) authenticated now switch to Astra and set thinking to `high`.
- An already-selected `gpt-6-astra-fast` is treated as recommended and kept.
- Explicit saved defaults and CLI/scoped selections are not overridden.
- Kimi K3 remains the first recommendation; no other entries were reordered.

<sup>Written for commit 15696ec9b6abec9896f6b833e496ab2e9e3be3be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

