### PR TITLE
fix(coding-agent): keep fast mode and thinking level when a -fast variant starts a session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Starting a session with a compatible `-fast` catalog variant now keeps fast mode enabled and preserves the requested thinking level when the variant is normalized to its base model; remembered service-tier behavior for ordinary base-model starts is unchanged.
 - Interactive shared-host regression tests now wait for RPC child processes to exit before removing their temporary roots, preventing teardown `ENOTEMPTY` races.
 - Make the reftable polling fallback detect content changes without relying on filesystem timestamp precision, and test the fallback with deterministic timer/event control.
 ### Removed

--- a/packages/coding-agent/src/core/extensions/builtin/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/changes.md
@@ -1,5 +1,23 @@
 # Builtin extensions changes
 
+## Preserve explicit fast variants at session start (2026-09-05)
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/service-tier.ts`: when session startup receives a compatible `-fast` catalog variant, it still swaps to the base model but preserves the selected thinking level with a session-scoped setter and keeps fast mode enabled. Remembered tier derivation remains unchanged for non-`-fast` starts.
+
+### Why
+
+- Selecting a `-fast` model at startup previously lost both the requested thinking level and the priority service tier when the extension normalized the variant to its base model.
+
+### Why an extension could not handle it
+
+- The startup model normalization and session fast-mode state are owned by this built-in extension's `session_start` handler.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/extensions/builtin/service-tier.ts` and its focused regression tests.
+
 ## Recommend GPT-6 Astra ahead of GPT-5.6 Sol (2026-09-05)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -237,17 +237,23 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 		// fast-active when nothing is remembered; an explicit remembered `"auto"` (`/fast off`)
 		// wins over that inheritance. Malformed values read back as undefined.
 		//
-		// The flag is derived from the POST-swap model: a `-fast` catalog variant swaps down to
-		// its base before this reads `ctx.serviceTier`, so inheritance is judged on the model the
-		// user actually ends up on.
+		// The flag is derived from the POST-swap model for ordinary starts, but an explicit `-fast`
+		// selection is an explicit fast-mode request even though its catalog tier disappears with the
+		// swap to the base model. Preserve the requested level across that swap as well; the session
+		// setter clamps it against the base model's thinkingLevelMap without changing global defaults.
 		const remembered = getRememberedServiceTier(settingsManager, ctx.modelRegistry, model);
+		const requestedThinkingLevel = ctx.thinkingLevel;
 
 		const baseModel = findBaseModel(ctx.modelRegistry, model);
 		if (baseModel) {
 			await pi.setSessionModel(baseModel);
+			if (requestedThinkingLevel !== undefined) {
+				pi.setSessionThinkingLevel(requestedThinkingLevel);
+			}
 		}
 
-		sessionFastMode = remembered === PRIORITY_TIER || (remembered === undefined && ctx.serviceTier === PRIORITY_TIER);
+		sessionFastMode =
+			baseModel !== undefined || remembered === PRIORITY_TIER || (remembered === undefined && ctx.serviceTier === PRIORITY_TIER);
 		pi.setSessionFastMode(sessionFastMode);
 		const memoryModel = resolveServiceTierMemoryModel(ctx.modelRegistry, model);
 		liveMemoryKey = `${memoryModel.provider}/${memoryModel.id}`;

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -242,7 +242,7 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 		// swap to the base model. Preserve the requested level across that swap as well; the session
 		// setter clamps it against the base model's thinkingLevelMap without changing global defaults.
 		const remembered = getRememberedServiceTier(settingsManager, ctx.modelRegistry, model);
-		const requestedThinkingLevel = ctx.thinkingLevel;
+		const requestedThinkingLevel = pi.getThinkingLevel();
 
 		const baseModel = findBaseModel(ctx.modelRegistry, model);
 		if (baseModel) {

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -86,6 +86,9 @@ describe("service-tier builtin extension", () => {
 		});
 		harnesses.push(harness);
 		const runner = harness.getExtensionRunner();
+		const thinkingLevelMap = { off: null, low: "low", medium: "medium", high: "high" } as const;
+		harness.modelRegistry.find(CODEX_PROVIDER, FAST_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
+		harness.modelRegistry.find(CODEX_PROVIDER, BASE_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
 		expect(harness.session.isFastModeActive()).toBe(true);
 		harness.session.setSessionThinkingLevel("high");

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -82,7 +82,10 @@ describe("service-tier builtin extension", () => {
 				defaultProvider: CODEX_PROVIDER,
 				defaultModel: BASE_MODEL_ID,
 			},
-			extensionFactories: [serviceTierExtension],
+			extensionFactories: [
+				(pi) => pi.on("session_start", () => pi.setSessionThinkingLevel("high")),
+				serviceTierExtension,
+			],
 		});
 		harnesses.push(harness);
 		const runner = harness.getExtensionRunner();
@@ -95,8 +98,6 @@ describe("service-tier builtin extension", () => {
 		harness.modelRegistry.find(CODEX_PROVIDER, BASE_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
 		expect(harness.session.isFastModeActive()).toBe(true);
-		harness.session.agent.state.thinkingLevel = "high";
-		expect(harness.session.thinkingLevel).toBe("high");
 
 		// when
 		await harness.session.bindExtensions({});

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -73,8 +73,16 @@ describe("service-tier builtin extension", () => {
 			api: CODEX_API,
 			provider: CODEX_PROVIDER,
 			models: [
-				{ id: FAST_MODEL_ID, thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" } },
-				{ id: BASE_MODEL_ID, thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" } },
+				{
+					id: FAST_MODEL_ID,
+					reasoning: true,
+					thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" },
+				},
+				{
+					id: BASE_MODEL_ID,
+					reasoning: true,
+					thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" },
+				},
 			],
 			upstreamModelId: BASE_MODEL_ID,
 			serviceTier: "priority",

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -138,7 +138,9 @@ describe("service-tier builtin extension", () => {
 			api: CODEX_API,
 			provider: CODEX_PROVIDER,
 			models: [{ id: FAST_MODEL_ID }, { id: BASE_MODEL_ID }],
+			upstreamModelId: BASE_MODEL_ID,
 			serviceTier: "priority",
+			fileSettings: true,
 			settings: { modelServiceTiers: { [`${CODEX_PROVIDER}/${BASE_MODEL_ID}`]: "auto" } },
 			extensionFactories: [serviceTierExtension],
 		});
@@ -158,26 +160,31 @@ describe("service-tier builtin extension", () => {
 	it.each([
 		["auto", false],
 		["priority", true],
-	] as const)("keeps a base-model startup's remembered %s tier unchanged", async (remembered, fast) => {
-		const harness = await createHarness({
-			api: CODEX_API,
-			provider: CODEX_PROVIDER,
-			models: [{ id: BASE_MODEL_ID }],
-			settings: { modelServiceTiers: { [`${CODEX_PROVIDER}/${BASE_MODEL_ID}`]: remembered } },
-			extensionFactories: [serviceTierExtension],
-		});
-		harnesses.push(harness);
-		const runner = harness.getExtensionRunner();
+	] as const)(
+		"keeps a base-model startup's remembered %s tier unchanged",
+		async (remembered: "auto" | "priority", fast: boolean) => {
+			const harness = await createHarness({
+				api: CODEX_API,
+				provider: CODEX_PROVIDER,
+				models: [{ id: BASE_MODEL_ID }],
+				fileSettings: true,
+				settings: { modelServiceTiers: { [`${CODEX_PROVIDER}/${BASE_MODEL_ID}`]: remembered } },
+				extensionFactories: [serviceTierExtension],
+			});
+			harnesses.push(harness);
+			const runner = harness.getExtensionRunner();
 
-		await harness.session.bindExtensions({});
+			await harness.session.bindExtensions({});
 
-		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
-		expect(harness.session.isFastModeActive()).toBe(fast);
-		const payload = { model: BASE_MODEL_ID };
-		expect(await runner.emitBeforeProviderRequest(payload)).toEqual(
-			fast ? { model: BASE_MODEL_ID, service_tier: "priority" } : payload,
-		);
-	});
+			expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
+			expect(harness.session.isFastModeActive()).toBe(fast);
+			const payload = { model: BASE_MODEL_ID };
+			expect(await runner.emitBeforeProviderRequest(payload)).toEqual(
+				fast ? { model: BASE_MODEL_ID, service_tier: "priority" } : payload,
+			);
+		},
+	);
+
 
 	it("is a clear no-op for non-Codex providers", async () => {
 		// given

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -87,6 +87,7 @@ describe("service-tier builtin extension", () => {
 		harnesses.push(harness);
 		const runner = harness.getExtensionRunner();
 		const thinkingLevelMap = { off: null, low: "low", medium: "medium", high: "high" } as const;
+		harness.session.model!.thinkingLevelMap = thinkingLevelMap;
 		harness.modelRegistry.find(CODEX_PROVIDER, FAST_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
 		harness.modelRegistry.find(CODEX_PROVIDER, BASE_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -87,12 +87,16 @@ describe("service-tier builtin extension", () => {
 		harnesses.push(harness);
 		const runner = harness.getExtensionRunner();
 		const thinkingLevelMap = { off: null, low: "low", medium: "medium", high: "high" } as const;
+		harness.session.model!.reasoning = true;
 		harness.session.model!.thinkingLevelMap = thinkingLevelMap;
+		harness.modelRegistry.find(CODEX_PROVIDER, FAST_MODEL_ID)!.reasoning = true;
 		harness.modelRegistry.find(CODEX_PROVIDER, FAST_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
+		harness.modelRegistry.find(CODEX_PROVIDER, BASE_MODEL_ID)!.reasoning = true;
 		harness.modelRegistry.find(CODEX_PROVIDER, BASE_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
 		expect(harness.session.isFastModeActive()).toBe(true);
 		harness.session.setSessionThinkingLevel("high");
+		expect(harness.session.thinkingLevel).toBe("high");
 
 		// when
 		await harness.session.bindExtensions({});

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -126,6 +126,16 @@ describe("service-tier builtin extension", () => {
 		// when
 		await harness.session.prompt("/fast");
 
+		// then: startup's explicit fast intent toggles off before it can swap to the sibling.
+		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
+		expect(harness.session.serviceTier).toBeUndefined();
+		expect(harness.session.isFastModeActive()).toBe(false);
+		const defaultPayload = { model: BASE_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
+
+		// when
+		await harness.session.prompt("/fast");
+
 		// then
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
 		expect(harness.session.serviceTier).toBe("priority");
@@ -137,17 +147,8 @@ describe("service-tier builtin extension", () => {
 			model: BASE_MODEL_ID,
 			service_tier: "priority",
 		});
-
-		// when
-		await harness.session.prompt("/fast");
-
-		// then
-		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
-		expect(harness.session.serviceTier).toBeUndefined();
 		expect(harness.settingsManager.getDefaultProvider()).toBe(CODEX_PROVIDER);
 		expect(harness.settingsManager.getDefaultModel()).toBe(BASE_MODEL_ID);
-		const defaultPayload = { model: BASE_MODEL_ID };
-		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
 	});
 
 	it("keeps fast mode on when an explicit -fast selection outranks remembered auto", async () => {

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -95,7 +95,7 @@ describe("service-tier builtin extension", () => {
 		harness.modelRegistry.find(CODEX_PROVIDER, BASE_MODEL_ID)!.thinkingLevelMap = thinkingLevelMap;
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
 		expect(harness.session.isFastModeActive()).toBe(true);
-		harness.session.setSessionThinkingLevel("high");
+		harness.session.agent.state.thinkingLevel = "high";
 		expect(harness.session.thinkingLevel).toBe("high");
 
 		// when

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -73,16 +73,8 @@ describe("service-tier builtin extension", () => {
 			api: CODEX_API,
 			provider: CODEX_PROVIDER,
 			models: [
-				{
-					id: FAST_MODEL_ID,
-					reasoning: true,
-					thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" },
-				},
-				{
-					id: BASE_MODEL_ID,
-					reasoning: true,
-					thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" },
-				},
+				{ id: FAST_MODEL_ID, reasoning: true },
+				{ id: BASE_MODEL_ID, reasoning: true },
 			],
 			upstreamModelId: BASE_MODEL_ID,
 			serviceTier: "priority",
@@ -202,7 +194,6 @@ describe("service-tier builtin extension", () => {
 			);
 		},
 	);
-
 
 	it("is a clear no-op for non-Codex providers", async () => {
 		// given

--- a/packages/coding-agent/test/suite/service-tier-extension.test.ts
+++ b/packages/coding-agent/test/suite/service-tier-extension.test.ts
@@ -72,7 +72,10 @@ describe("service-tier builtin extension", () => {
 		const harness = await createHarness({
 			api: CODEX_API,
 			provider: CODEX_PROVIDER,
-			models: [{ id: FAST_MODEL_ID }, { id: BASE_MODEL_ID }],
+			models: [
+				{ id: FAST_MODEL_ID, thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" } },
+				{ id: BASE_MODEL_ID, thinkingLevelMap: { off: null, low: "low", medium: "medium", high: "high" } },
+			],
 			upstreamModelId: BASE_MODEL_ID,
 			serviceTier: "priority",
 			settings: {
@@ -85,6 +88,7 @@ describe("service-tier builtin extension", () => {
 		const runner = harness.getExtensionRunner();
 		expect(harness.session.model?.id).toBe(FAST_MODEL_ID);
 		expect(harness.session.isFastModeActive()).toBe(true);
+		harness.session.setSessionThinkingLevel("high");
 
 		// when
 		await harness.session.bindExtensions({});
@@ -92,7 +96,13 @@ describe("service-tier builtin extension", () => {
 		// then
 		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
 		expect(harness.session.serviceTier).toBeUndefined();
-		expect(harness.session.isFastModeActive()).toBe(false);
+		expect(harness.session.isFastModeActive()).toBe(true);
+		expect(harness.session.thinkingLevel).toBe("high");
+		const startupPayload = { model: BASE_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(startupPayload)).toEqual({
+			model: BASE_MODEL_ID,
+			service_tier: "priority",
+		});
 		expect(harness.settingsManager.getDefaultProvider()).toBe(CODEX_PROVIDER);
 		expect(harness.settingsManager.getDefaultModel()).toBe(BASE_MODEL_ID);
 
@@ -121,6 +131,52 @@ describe("service-tier builtin extension", () => {
 		expect(harness.settingsManager.getDefaultModel()).toBe(BASE_MODEL_ID);
 		const defaultPayload = { model: BASE_MODEL_ID };
 		expect(await runner.emitBeforeProviderRequest(defaultPayload)).toBe(defaultPayload);
+	});
+
+	it("keeps fast mode on when an explicit -fast selection outranks remembered auto", async () => {
+		const harness = await createHarness({
+			api: CODEX_API,
+			provider: CODEX_PROVIDER,
+			models: [{ id: FAST_MODEL_ID }, { id: BASE_MODEL_ID }],
+			serviceTier: "priority",
+			settings: { modelServiceTiers: { [`${CODEX_PROVIDER}/${BASE_MODEL_ID}`]: "auto" } },
+			extensionFactories: [serviceTierExtension],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+
+		await harness.session.bindExtensions({});
+
+		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
+		expect(harness.session.isFastModeActive()).toBe(true);
+		expect(await runner.emitBeforeProviderRequest({ model: BASE_MODEL_ID })).toEqual({
+			model: BASE_MODEL_ID,
+			service_tier: "priority",
+		});
+	});
+
+	it.each([
+		["auto", false],
+		["priority", true],
+	] as const)("keeps a base-model startup's remembered %s tier unchanged", async (remembered, fast) => {
+		const harness = await createHarness({
+			api: CODEX_API,
+			provider: CODEX_PROVIDER,
+			models: [{ id: BASE_MODEL_ID }],
+			settings: { modelServiceTiers: { [`${CODEX_PROVIDER}/${BASE_MODEL_ID}`]: remembered } },
+			extensionFactories: [serviceTierExtension],
+		});
+		harnesses.push(harness);
+		const runner = harness.getExtensionRunner();
+
+		await harness.session.bindExtensions({});
+
+		expect(harness.session.model?.id).toBe(BASE_MODEL_ID);
+		expect(harness.session.isFastModeActive()).toBe(fast);
+		const payload = { model: BASE_MODEL_ID };
+		expect(await runner.emitBeforeProviderRequest(payload)).toEqual(
+			fast ? { model: BASE_MODEL_ID, service_tier: "priority" } : payload,
+		);
 	});
 
 	it("is a clear no-op for non-Codex providers", async () => {


### PR DESCRIPTION
## Symptom
Starting a session with an explicit `-fast` catalog variant silently lost both the requested thinking level and fast mode. Live wire evidence from senpi 2026.9.4-3 (`/tmp/ulw-astra-20260905/evidence/RED-fast-variant-session-start.json`) showed:

- `--model openai-codex/gpt-6-astra-fast:high` sent `model: gpt-6-astra`, `reasoning.effort: low`, and no `service_tier`.
- `--model openai-codex/gpt-6-astra-fast --thinking high` sent low effort and no `service_tier`.
- `--model openai-codex/gpt-5.6-sol-fast:high` sent the model default medium effort and no `service_tier`.
- The session events showed `model_change gpt-6-astra-fast` -> `thinking_level_change high` -> `model_change gpt-6-astra` -> `thinking_level_change low`.

The control `gpt-6-astra:xhigh` retained `xhigh`.

## Root cause
The `session_start` handler intentionally normalizes a compatible `-fast` catalog variant to its base model. That model swap re-ran thinking-level selection and discarded the explicit level. It also derived fast mode from the post-swap base context, where the catalog priority was no longer present, so `before_provider_request` emitted no `service_tier` unless a prior `/fast on` preference existed.

## Fix
- Capture the effective thinking level from the live extension API before the swap.
- Keep the intended variant-to-base swap, then re-apply the level through `setSessionThinkingLevel`, preserving normal base-model clamping and avoiding global-default persistence.
- Treat finding the compatible base model as an explicit `-fast` selection, so fast mode is enabled regardless of remembered `auto`.
- Preserve normalized base-model memory keys and the existing non-`-fast` remembered-tier derivation.

## Tests
RED before the fix on commit `5ae26400a`:

- Scoped suite: 3 failed, 17 passed across 20 tests.
- Failures covered startup fast-mode loss, explicit `-fast` versus remembered `auto`, and remembered `priority` regression behavior.
- The two existing model-config/runtime test files passed.

GREEN on `56ab11054`:

- `Test Files 3 passed (3)`
- `Tests 20 passed (20)`

The existing startup test was reconciled with the intended semantics: after an explicit `-fast` startup, the session is already fast on the base model; the first `/fast` turns it off, and the next `/fast` selects the fast sibling. The swap-to-base remains intentional.

## Bunshin receipt
Executed on `mengmotaMac` (not locally):

```text
/tmp/astra-a3-20260905/senpi
bun install --frozen-lockfile
cd packages/coding-agent
bunx vitest run test/suite/service-tier-extension.test.ts test/suite/service-tier-model-config.test.ts test/model-runtime-catalog-service-tier.test.ts
Test Files 3 passed (3)
Tests 20 passed (20)
```

The temporary checkout was removed after the run.

## Residual risk
The behavior remains dependent on the catalog's existing compatible base/fast pairing and its `thinkingLevelMap`; unsupported requested levels continue to clamp according to the base model. No provider behavior, credentials, or `packages/ai` code was changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session startup with an explicit `-fast` catalog variant so fast mode and the requested thinking level are preserved when the variant is normalized to its base model.

- Captures the requested thinking level before the model swap and re-applies it using the session-scoped setter, so global defaults are untouched.
- Treats finding a compatible base model as an explicit fast-mode request, so fast mode stays active even if `auto` is remembered.
- Leaves remembered-tier behavior for ordinary base-model starts unchanged.

<sup>Written for commit b3bf0d592a26ee697268cf797272e282da14a010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

