### PR TITLE
fix(coding-agent): skip context-incompatible Ctrl+P models

### DIFF
--- a/local-ignore/qa-evidence/20260905-ctrl-p-context-skip/README.md
+++ b/local-ignore/qa-evidence/20260905-ctrl-p-context-skip/README.md
@@ -1,0 +1,32 @@
+# Ctrl+P context-window skip QA
+
+## What was tested
+
+- On `mengmotaMac` through bunshin, transferred this worktree to an isolated
+  `/tmp/ctrl-p-context-skip-*` directory.
+- Ran `bun install --frozen-lockfile`.
+- Ran `bun scripts/build-all.mjs`.
+- Ran
+  `bunx vitest run packages/coding-agent/test/suite/agent-session-model-extension.test.ts`.
+
+## What was observed
+
+- Build exited 0.
+- The focused suite passed: 1 test file, 20 tests.
+- The regression covers both an exhausted favorite being skipped before the next
+  usable favorite and all alternative favorites being rejected with a structured
+  result.
+- The isolated remote tree was removed after the run with exit 0.
+
+## Why this is enough
+
+- The test exercises `AgentSession.cycleModel()` with the real faux-provider
+  harness and observes the emitted `model_change_skipped` events and selected
+  model.
+- The build proves the new event is accepted by the coding-agent and transport
+  TypeScript surfaces.
+
+## Omitted
+
+- No credentials, environment dumps, provider requests, or raw remote logs are
+  included.

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,29 @@
 # changes
 
+## 2026-09-05 - Ctrl+P skips favorites without context room
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts` uses the existing model
+  usability projection before favorite cycling, emits `model_change_skipped`
+  events for rejected candidates, and reports all-skipped cycles explicitly.
+
+### Why
+
+- Ctrl+P is an explicit switch request. A model that cannot admit the current
+  context must be skipped instead of reaching the later usability assertion and
+  surfacing a failed switch.
+
+### Why an extension could not handle it
+
+- Favorite cycling and the session event stream are core runtime seams below the
+  extension API.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/agent-session.ts` model event types and
+  favorite cycling.
+
 ## 2026-09-04 - Export the UI prompt events and apply terminal overrides in main
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -451,6 +451,16 @@ export type AgentSessionEvent =
 			thinkingLevel: ThinkingLevel;
 			source: ModelSelectSource;
 	  }
+	| {
+			type: "model_change_skipped";
+			model: Model<any>;
+			contextWindow: number;
+			liveContextTokens: number;
+			requiredTokens: number;
+			shortfallTokens: number;
+			safetyMarginProfile: string;
+			direction: "forward" | "backward";
+	  }
 	/** Effective service tier or fast-mode state changed. */
 	| { type: "service_tier_changed"; tier?: ServiceTier; fastMode: boolean }
 	| {
@@ -801,6 +811,8 @@ export interface ModelCycleResult {
 	thinkingLevel: ThinkingLevel;
 	/** Whether cycling used the configured favorite model list */
 	isScoped: boolean;
+	/** Models skipped because their usability budget cannot admit the current context. */
+	skippedModels: readonly Model<any>[];
 	/** Present when the model switch also changed the active system prompt. */
 	systemPromptChange?: SystemPromptChangeEvent;
 }
@@ -1794,6 +1806,18 @@ export class AgentSession {
 		this.abortBranchSummary();
 		this._delegatedCompactionKey = undefined;
 		this._incrementMessageRevision();
+	}
+
+	private _modelChangeWouldExhaustContext(model: Model<Api>): ReturnType<typeof projectModelUsabilityBudget> | undefined {
+		if (model.contextWindow <= 0) return undefined;
+		const projection = projectModelUsabilityBudget({
+			model,
+			systemPrompt: this.agent.state.systemPrompt,
+			tools: this.agent.state.tools,
+			liveContextTokens: this._getDownswitchLiveContextTokens(model),
+			compaction: this.settingsManager.getCompactionSettings(),
+		});
+		return projection.usable ? undefined : projection;
 	}
 
 	private _getIdleWaitPromise(): Promise<void> {
@@ -4777,6 +4801,7 @@ export class AgentSession {
 		if (favoriteModels.length <= 1) return undefined;
 
 		const currentModel = this.model;
+		if (!currentModel) return undefined;
 		const currentIndex = favoriteModels.findIndex((sm) => modelsAreEqual(sm.model, currentModel));
 
 		let nextIndex: number;
@@ -4786,7 +4811,40 @@ export class AgentSession {
 			const len = favoriteModels.length;
 			nextIndex = direction === "forward" ? (currentIndex + 1) % len : (currentIndex - 1 + len) % len;
 		}
-		const next = favoriteModels[nextIndex];
+		const favoriteCount = favoriteModels.length;
+		const step = direction === "forward" ? 1 : -1;
+		let selectedIndex: number | undefined;
+		const skippedModels: Model<any>[] = [];
+		for (let offset = 0; offset < favoriteCount; offset++) {
+			const candidate = favoriteModels[(nextIndex + step * offset + favoriteCount) % favoriteCount];
+			if (modelsAreEqual(candidate.model, currentModel)) continue;
+			const admission = this._modelChangeWouldExhaustContext(candidate.model);
+			if (admission) {
+				skippedModels.push(candidate.model);
+				this._emit({
+					type: "model_change_skipped",
+					model: candidate.model,
+					contextWindow: candidate.model.contextWindow,
+					liveContextTokens: admission.liveContextTokens,
+					requiredTokens: admission.requiredTokens,
+					shortfallTokens: admission.shortfallTokens,
+					safetyMarginProfile: admission.safetyMarginProfile,
+					direction,
+				});
+				continue;
+			}
+			selectedIndex = (nextIndex + step * offset + favoriteCount) % favoriteCount;
+			break;
+		}
+		if (selectedIndex === undefined) {
+			return {
+				model: currentModel,
+				thinkingLevel: this.thinkingLevel,
+				isScoped: true,
+				skippedModels,
+			};
+		}
+		const next = favoriteModels[selectedIndex];
 		const liveContextTokens = this._getDownswitchLiveContextTokens(next.model);
 		this.assertModelUsable(next.model, liveContextTokens);
 		const invalidatesCompaction =
@@ -4828,6 +4886,7 @@ export class AgentSession {
 				model: next.model,
 				thinkingLevel: this.thinkingLevel,
 				isScoped: true,
+				skippedModels,
 			};
 			if (systemPromptChange) {
 				cycleResult.systemPromptChange = systemPromptChange;

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,30 @@
 # changes
 
+## 2026-09-05 - Ctrl+P skips favorites without context room
+
+### What changed
+
+- `agent-session.ts` uses the existing `projectModelUsabilityBudget` projection
+  before favorite-model cycling, emits `model_change_skipped` for rejected
+  candidates, and continues in the requested direction. The cycle result
+  carries skipped models when every alternative is rejected.
+
+### Why
+
+- An explicit Ctrl+P switch request must skip a model that cannot admit the
+  current context instead of reaching the later usability assertion and
+  surfacing a failed switch.
+
+### Why an extension could not handle it
+
+- Favorite cycling and the session event stream are core runtime seams below the
+  extension API.
+
+### Expected merge conflict zones
+
+- LOW: the `AgentSessionEvent` union and `_cycleFavoriteModel` in
+  `agent-session.ts`.
+
 ## 2026-09-04 - File-storage locks wait through contention
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,32 @@
 # changes
 
+## 2026-09-05 - Ctrl+P skips favorites without context room
+
+### What changed
+
+- Favorite-model cycling emits a typed `model_change_skipped` event with the
+  target budget projection and continues in the requested direction.
+- Interactive mode renders a warning for each skipped model and a clear
+  compact-or-new-session status when every other favorite is rejected. The
+  event is also forwarded through existing session event transports, so desktop
+  consumers do not need a desktop-specific change.
+
+### Why
+
+- Ctrl+P is an explicit request to switch models. A target that cannot admit
+  the current context must be skipped rather than surfacing the later
+  `ModelUsabilityBudgetError` as a failed switch.
+
+### Why an extension could not handle it
+
+- Favorite cycling, model usability admission, and the session event stream are
+  core host seams below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: `AgentSessionEvent`, `ModelCycleResult`, and `_cycleFavoriteModel`.
+- LOW: the interactive `handleEvent` and cycle status path.
+
 ## 2026-09-04 - Branded build labels render verbatim in startup UI
 
 ### What changed
@@ -127,3 +154,47 @@
 ### Expected merge conflict zones
 
 - LOW: assistant diagnostics and thinking-toggle regression tests when upstream adds renderer-specific expectations.
+# 2026-09-05 - Ctrl+P skips models without context room
+
+### What changed
+
+- Favorite-model cycling emits a typed `model_change_skipped` event and continues
+  in the requested direction when a candidate model cannot leave the provider's
+  minimum answer room for the current conversation.
+- Interactive mode renders the event as a warning naming the skipped model and
+  the current context/window measurements. The desktop app can consume the event
+  without requiring a desktop-specific code change.
+
+### Why
+
+- Ctrl+P is an explicit request to switch, so a model that cannot admit the
+  current context must not block the request or silently look like a failed
+  switch. The next usable favorite is selected instead, while the skipped
+  candidate remains visible to the user.
+
+### Expected merge conflict zones
+
+- LOW: `AgentSessionEvent` model event union and `_cycleFavoriteModel`.
+- LOW: the interactive `handleEvent` switch.
+# 2026-09-05 - Ctrl+P skips models without context room
+
+### What changed
+
+- Favorite-model cycling emits a typed `model_change_skipped` event and continues
+  in the requested direction when a candidate model cannot leave the provider's
+  minimum answer room for the current conversation.
+- Interactive mode renders the event as a warning naming the skipped model and
+  the current context/window measurements. The desktop app can consume the event
+  without requiring a desktop-specific code change.
+
+### Why
+
+- Ctrl+P is an explicit request to switch, so a model that cannot admit the
+  current context must not block the request or silently look like a failed
+  switch. The next usable favorite is selected instead, while the skipped
+  candidate remains visible to the user.
+
+### Expected merge conflict zones
+
+- LOW: `AgentSessionEvent` model event union and `_cycleFavoriteModel`.
+- LOW: the interactive `handleEvent` switch.

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -6,10 +6,11 @@
 
 - Favorite-model cycling emits a typed `model_change_skipped` event with the
   target budget projection and continues in the requested direction.
-- Interactive mode renders a warning for each skipped model and a clear
-  compact-or-new-session status when every other favorite is rejected. The
-  event is also forwarded through existing session event transports, so desktop
-  consumers do not need a desktop-specific change.
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` renders a
+  warning for each skipped model and a clear compact-or-new-session status when
+  every other favorite is rejected. The event is also forwarded through existing
+  session event transports, so desktop consumers do not need a desktop-specific
+  change.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { AuthEvent, AuthPrompt } from "@earendil-works/pi-ai";
+import { modelsAreEqual, type AuthEvent, type AuthPrompt } from "@earendil-works/pi-ai";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent, Usage } from "@earendil-works/pi-ai/compat";
 import type {
 	AutocompleteItem,
@@ -4514,6 +4514,14 @@ export class InteractiveMode {
 				this.showStatus(`Thinking level: ${event.level}`);
 				break;
 
+			case "model_change_skipped":
+				this.showWarning(
+					`Skipped ${event.model.name || event.model.id}: current context needs ${event.shortfallTokens.toLocaleString()} ` +
+						`more tokens for its ${event.contextWindow.toLocaleString()}-token window ` +
+						`(${event.safetyMarginProfile} usability budget).`,
+				);
+				break;
+
 			case "high_reasoning_warning":
 				this.showHighReasoningWarning(event);
 				break;
@@ -6072,6 +6080,10 @@ export class InteractiveMode {
 						: buildFavoriteCycleStatusMessage("empty");
 				this.showStatus(msg);
 			} else {
+				if (result.skippedModels.length > 0 && modelsAreEqual(result.model, this.session.model)) {
+					this.showStatus("No favorite model can fit the current context. Compact the session or start a new one.");
+					return;
+				}
 				this.footer.invalidate();
 				// A model switch ends any external-owner delegation episode.
 				this.externalOwnerCompactionNoticeShown = false;

--- a/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
+++ b/packages/coding-agent/test/suite/agent-session-model-extension.test.ts
@@ -185,6 +185,61 @@ describe("AgentSession model and extension characterization", () => {
 		expect(harness.session.thinkingLevel).toBe("high");
 	});
 
+	it("reports when every other favorite is rejected by the context budget", async () => {
+		const skipped: string[] = [];
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", contextWindow: 20_000 },
+				{ id: "faux-2", name: "Two", contextWindow: 5_120 },
+				{ id: "faux-3", name: "Three", contextWindow: 6_000 },
+			],
+		});
+		harnesses.push(harness);
+		const [modelOne, modelTwo, modelThree] = harness.models;
+		harness.session.setFavoriteModels([{ model: modelOne }, { model: modelTwo }, { model: modelThree }]);
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "context ".repeat(3_000) }],
+			timestamp: Date.now(),
+		});
+		harness.session.subscribe((event) => {
+			if (event.type === "model_change_skipped") skipped.push(event.model.id);
+		});
+
+		const result = await harness.session.cycleModel();
+
+		expect(result?.model.id).toBe("faux-1");
+		expect(result?.skippedModels.map((model) => model.id)).toEqual(["faux-2", "faux-3"]);
+		expect(skipped).toEqual(["faux-2", "faux-3"]);
+	});
+
+	it("skips an exhausted-context favorite and cycles to the next usable model", async () => {
+		const skipped: string[] = [];
+		const harness = await createHarness({
+			models: [
+				{ id: "faux-1", name: "One", contextWindow: 20_000 },
+				{ id: "faux-2", name: "Too Small", contextWindow: 5_120 },
+				{ id: "faux-3", name: "Three", contextWindow: 100_000 },
+			],
+		});
+		harnesses.push(harness);
+		const [modelOne, modelTwo, modelThree] = harness.models;
+		harness.session.setFavoriteModels([{ model: modelOne }, { model: modelTwo }, { model: modelThree }]);
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: [{ type: "text", text: "context ".repeat(3_000) }],
+			timestamp: Date.now(),
+		});
+		harness.session.subscribe((event) => {
+			if (event.type === "model_change_skipped") skipped.push(event.model.id);
+		});
+
+		await harness.session.cycleModel();
+
+		expect(harness.session.model?.id).toBe("faux-3");
+		expect(skipped).toEqual(["faux-2"]);
+	});
+
 	it("clamps thinking levels to model capabilities and cycles available levels", async () => {
 		const harness = await createHarness({ models: [{ id: "faux-1", reasoning: false }] });
 		harnesses.push(harness);


### PR DESCRIPTION
## Summary
Ctrl+P favorite-model cycling now skips targets that cannot admit the current context under the existing model usability budget. Each skipped target emits a structured session event, and the interactive TUI explains the skip; the desktop transport receives the event through the existing session-event forwarding path.

## Changes
- Reuse `projectModelUsabilityBudget` as the single admission predicate before cycling into a favorite.
- Emit `model_change_skipped` with the target budget projection and continue in the requested direction.
- Return an explicit all-skipped result so the TUI recommends compacting or starting a new session instead of reporting a misleading single-favorite status.
- Add faux-provider regressions for one skipped candidate and all candidates skipped.

## QA & Evidence
- **What was tested:** `bun scripts/build-all.mjs` and `bunx vitest run packages/coding-agent/test/suite/agent-session-model-extension.test.ts` on `mengmotaMac` through bunshin.
- **Observed result:** build exit 0; 1 test file and 20 tests passed; remote temporary tree cleanup exit 0.
- **Artifact:** `local-ignore/qa-evidence/20260905-ctrl-p-context-skip/README.md`
- **Why sufficient:** covers the real AgentSession cycle path, event emission, candidate skipping, all-skipped result, and compile-time transport acceptance.

## Risks & Residuals
The desktop application itself is unchanged; the event is additive on the existing session event stream. No provider calls or credentials are used by the regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Ctrl+P favorite-model cycling so models that can't fit the current context are skipped instead of causing a failed switch.

- Reuses the existing usability budget projection before cycling into a favorite.
- Emits a `model_change_skipped` event per rejected candidate and continues cycling in the requested direction.
- Returns an all-skipped result; the TUI warns per skip and suggests compacting or starting a new session when none fit.
- The desktop app receives the event via existing forwarding; no desktop changes. Adds regression tests for one skipped and all skipped.

<sup>Written for commit 3091e7d6f4cb1df3081ab56daa1385c1e4e346d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

