### PR TITLE
fix(codemode): expose JavaScript first in eval schema

### DIFF
--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -3,7 +3,7 @@ import { type TUnsafe, Type } from "typebox";
 import type { HostToKernelMessage, KernelToHostMessage } from "../bridge/protocol.ts";
 import type { TruncationMeta } from "../output/output-meta.ts";
 
-export const evalLanguageOrder = ["py", "js", "rb", "jl"] as const;
+export const evalLanguageOrder = ["js", "py", "rb", "jl"] as const;
 export type EvalLanguage = (typeof evalLanguageOrder)[number];
 export type EnabledEvalLanguages = Readonly<Record<EvalLanguage, boolean>>;
 
@@ -37,7 +37,7 @@ const fullEvalInputSchema = Type.Object({
 		}),
 	),
 	language: Type.Optional(
-		Type.Union([Type.Literal("py"), Type.Literal("js"), Type.Literal("rb"), Type.Literal("jl")]),
+		Type.Union([Type.Literal("js"), Type.Literal("py"), Type.Literal("rb"), Type.Literal("jl")]),
 	),
 	code: Type.Optional(Type.String({ description: "Cell body, verbatim." })),
 	summary: Type.Optional(

--- a/packages/senpi-codemode/test/eval-schema-order.test.ts
+++ b/packages/senpi-codemode/test/eval-schema-order.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { createEvalInputSchema, evalLanguageOrder } from "../src/tool/types.ts";
+
+describe("eval schema language order", () => {
+	it("exposes JavaScript before Python while preserving every supported language", () => {
+		const schema = createEvalInputSchema({ py: true, js: true, rb: true, jl: true });
+		const languageSchema = schema.properties.language;
+
+		expect(evalLanguageOrder).toEqual(["js", "py", "rb", "jl"]);
+		expect(languageSchema.anyOf?.map((item) => item.const)).toEqual(["js", "py", "rb", "jl"]);
+	});
+});


### PR DESCRIPTION
Change the eval language enum and enabled-language ordering to expose JavaScript before Python. Add a focused schema contract covering the ordered canonical language set.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes the eval language ordering so JavaScript comes before Python in the language enum and schema union.

- Adds a test asserting the ordered language set stays `js`, `py`, `rb`, `jl`.

<sup>Written for commit 15236bf97f3866d6e718cf0dedc91e21e2a63daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

