### PR TITLE
fix: remove implicit wildcard fallback and Cursor expansion

### DIFF
--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-05 - Require explicit fallback chains
+
+### What changed
+
+- Removed shipped Fable defaults and wildcard fallback resolution; fallback runs only for configured model keys. Cursor remains excluded from bare expansion while explicit Cursor selection remains supported.
+
+### Why
+
+- Implicit fallback can unexpectedly change the selected model and mishandles Astra variants when no chain was configured.
+
+### Why an extension could not handle it
+
+- Retry fallback chain resolution is a core controller and settings contract.
+
+### Expected merge conflict zones
+
+- LOW: retry-fallback chains, settings, and controller.
+
 ## 2026-09-05 - Ctrl+P skips favorites without context room
 
 ### What changed

--- a/packages/coding-agent/src/core/retry-fallback/chains.ts
+++ b/packages/coding-agent/src/core/retry-fallback/chains.ts
@@ -141,37 +141,6 @@ export function baseSelector(selector: Pick<FallbackSelector, "provider" | "id">
  * consecutive upstream 500s, zero fallback attempts, terminal error).
  * Users disable it with the `"*": []` tombstone.
  */
-export const WILDCARD_CHAIN_KEY = "*";
-
-/**
- * Whether the user explicitly switched fallback OFF for this model with the
- * documented `[]` tombstone (exact key, base key, or a bare family key that
- * covers it). The shipped wildcard lane must never resurrect fallback against
- * that instruction, so the wildcard gate consults this first.
- *
- * Bare-family matching is deliberately conservative: an ambiguous match
- * suppresses the wildcard rather than overriding an explicit opt-out, because a
- * surprising extra fallback hop is worse than a missing convenience lane.
- */
-export function hasExplicitFallbackOptOut(
-	chains: FallbackChains,
-	currentModel: Model<Api>,
-	currentThinking: ThinkingLevel | undefined,
-): boolean {
-	const base = formatSelector(currentModel).toLowerCase();
-	const exact = currentThinking ? `${base}:${currentThinking}`.toLowerCase() : base;
-	for (const [key, entries] of Object.entries(chains)) {
-		if (!Array.isArray(entries) || !isChainTombstone(entries)) continue;
-		if (key === WILDCARD_CHAIN_KEY) continue;
-		const normalizedKey = key.trim().toLowerCase();
-		const keyBase = normalizedBase(normalizedKey);
-		if (keyBase === base || normalizedKey === exact) return true;
-		// Bare family key (no provider prefix): treat an id match as covering.
-		if (!normalizedKey.includes("/") && matchesFamily(currentModel, keyBase)) return true;
-	}
-	return false;
-}
-
 export function canonicalizeFallbackChains(chains: FallbackChains, lookup: FallbackModelLookup): FallbackChains {
 	const models = availableModels(lookup);
 	const tiers = authTiers(lookup);
@@ -231,17 +200,6 @@ export function canonicalizeFallbackChains(chains: FallbackChains, lookup: Fallb
 		if (tombstones.has(normalizedBase(key))) delete canonical[key];
 	}
 
-	// The wildcard key is not a model selector, so both loops above skip it.
-	// Its entries expand exactly like any other chain; a `[]` tombstone removes
-	// the lane entirely. Self-selection of the failing model is prevented at
-	// candidate time (nextCandidate's "self" skip), not here, because the
-	// wildcard has no key selector to filter against.
-	const wildcardEntries = chains[WILDCARD_CHAIN_KEY];
-	if (Array.isArray(wildcardEntries) && !isChainTombstone(wildcardEntries)) {
-		const canonicalEntries = expandEntries(wildcardEntries, WILDCARD_CHAIN_KEY);
-		if (canonicalEntries.length > 0) canonical[WILDCARD_CHAIN_KEY] = canonicalEntries;
-	}
-
 	return canonical;
 }
 
@@ -249,18 +207,13 @@ export function resolveChainKey(
 	currentModel: Model<Api>,
 	currentThinking: ThinkingLevel | undefined,
 	chains: FallbackChains,
-	options?: { allowWildcard?: boolean },
+	_options?: { allowWildcard?: boolean },
 ): string | undefined {
 	const base = formatSelector(currentModel);
 	const exact = currentThinking ? `${base}:${currentThinking}` : base;
 	if (Object.hasOwn(chains, exact)) return exact;
 	if (Object.hasOwn(chains, base)) return base;
-	// The wildcard is opt-in per call site: it is a last resort for a model with
-	// no chain of its own, and it must never hijack a session already walking a
-	// configured chain (the last rung of that chain usually has no key either).
-	// nextCandidate consults the active episode's chainKey before asking for it.
-	if (!options?.allowWildcard) return undefined;
-	return Object.hasOwn(chains, WILDCARD_CHAIN_KEY) ? WILDCARD_CHAIN_KEY : undefined;
+	return undefined;
 }
 
 function formatParsedSelector(selector: FallbackSelector): string {

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -7,7 +7,6 @@ import {
 	type FallbackChains,
 	type FallbackSelector,
 	formatSelector,
-	hasExplicitFallbackOptOut,
 	parseFallbackSelector,
 	resolveChainKey,
 } from "./chains.ts";
@@ -236,15 +235,11 @@ export class RetryFallbackController {
 		const current = this.deps.getCurrentSelector();
 		if (!settings.modelFallback || !current) return undefined;
 		const chains = this.canonicalChains();
-		// Order matters: a model's own chain wins, then the active episode keeps
-		// owning its walk (its last rung usually has no key of its own), and only
-		// a session with neither falls back to the wildcard lane.
+		// A model's own chain wins; models without an explicitly configured chain
+		// do not enter an implicit fallback lane.
 		const chainKey =
 			resolveChainKey(current.model, current.thinkingLevel, chains) ??
-			this.state?.chainKey ??
-			(hasExplicitFallbackOptOut(settings.chains, current.model, current.thinkingLevel)
-				? undefined
-				: resolveChainKey(current.model, current.thinkingLevel, chains, { allowWildcard: true }));
+			this.state?.chainKey;
 		const entries = chainKey ? chains[chainKey] : undefined;
 		if (!chainKey || !entries) {
 			if (reserve) this.deps.logger.debug("no_chain", { selector: formatSelector(current.model) });

--- a/packages/coding-agent/src/core/retry-fallback/expansion.ts
+++ b/packages/coding-agent/src/core/retry-fallback/expansion.ts
@@ -7,7 +7,11 @@ import { isValidThinkingLevel } from "../../cli/args.ts";
  * route a shipped default through a third-party reseller the user never chose.
  * An explicit `openrouter/...` selector the user wrote is unaffected.
  */
-const BARE_EXPANSION_DENYLIST: ReadonlySet<string> = new Set(["openrouter", "openrouter-images"]);
+const BARE_EXPANSION_DENYLIST: ReadonlySet<string> = new Set([
+	"cursor",
+	"openrouter",
+	"openrouter-images",
+]);
 
 /**
  * Deterministic tie-break inside one auth tier. Earlier wins. Providers absent

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -40,15 +40,6 @@ export const DEFAULT_FALLBACK_CHAINS: FallbackChains = {
 	// family matcher intentionally cannot capture (issue #793).
 	"claude-fable-5-1": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 	"claude-fable-5": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
-	// Last-resort lane for models with no chain of their own. resolveChainKey
-	// falls through exact -> base -> "*", so any current model whose upstream
-	// hard-fails can still escape instead of wedging the session terminal
-	// (desktop thread 487d7c29, 2026-08-28: nine consecutive upstream 500s on a
-	// chainless model, zero fallback attempts). Same lane order as the Fable
-	// default: cheap family escape first, then the Opus tiers. The candidate
-	// walk skips the failing model itself ("self"), tried selectors, cooldowns,
-	// and unauthenticated providers. Disable with the `"*": []` tombstone.
-	"*": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
 };
 
 function cloneDefaultFallbackChains(): Record<string, readonly string[]> {

--- a/packages/coding-agent/src/core/retry-fallback/settings.ts
+++ b/packages/coding-agent/src/core/retry-fallback/settings.ts
@@ -29,26 +29,10 @@ export interface ResolvedRetryFallbackSettings {
 }
 
 /**
- * Shipped defaults are declared as model families (bare ids, no provider prefix).
- * `canonicalizeFallbackChains` expands them against the live registry, so the
- * chain follows Fable 5 whichever provider serves it - the builtin Anthropic
- * provider, the Claude SDK OAuth extension, a gateway, or Bedrock.
+ * Fallback chains are explicit user configuration only. There is deliberately
+ * no shipped default or wildcard lane.
  */
-export const DEFAULT_FALLBACK_CHAINS: FallbackChains = {
-	// `kimi-k3:max` is an alias entry for providers that expose Kimi K3 under the
-	// vendor-prefixed id `kimi-k3` (e.g. OpenCode Go), which the conservative `k3`
-	// family matcher intentionally cannot capture (issue #793).
-	"claude-fable-5-1": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
-	"claude-fable-5": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
-};
-
-function cloneDefaultFallbackChains(): Record<string, readonly string[]> {
-	const chains: Record<string, readonly string[]> = {};
-	for (const [key, entries] of Object.entries(DEFAULT_FALLBACK_CHAINS)) {
-		chains[key] = [...entries];
-	}
-	return chains;
-}
+export const DEFAULT_FALLBACK_CHAINS: FallbackChains = {};
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -71,15 +55,10 @@ function isStringArray(value: unknown): value is string[] {
  * `deepMergeSettings`; this only resolves defaults against the merged result.
  */
 function resolveFallbackChains(value: unknown): FallbackChains {
-	if (value === undefined) return cloneDefaultFallbackChains();
-	if (!isPlainObject(value)) return cloneDefaultFallbackChains();
-
-	const chains: Record<string, readonly string[]> = cloneDefaultFallbackChains();
+	if (value === undefined || !isPlainObject(value)) return {};
+	const chains: Record<string, readonly string[]> = {};
 	for (const [key, entries] of Object.entries(value)) {
-		if (!isStringArray(entries)) return cloneDefaultFallbackChains();
-		// An empty list stays in the map as a tombstone: canonicalization needs it to
-		// suppress the expanded default for that family or provider variant, and
-		// dropping it here would let the shipped default reappear after expansion.
+		if (!isStringArray(entries)) return {};
 		chains[key] = [...entries];
 	}
 	return chains;

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -5,7 +5,6 @@ import {
 	candidatesAfter,
 	canonicalizeFallbackChains,
 	formatSelector,
-	hasExplicitFallbackOptOut,
 	parseFallbackSelector,
 	resolveChainKey,
 } from "../../src/core/retry-fallback/chains.ts";
@@ -98,28 +97,22 @@ describe("fallback chain selectors", () => {
 		).toEqual({ "openai/gpt-5.4:high": ["anthropic/claude-sonnet-4-5:max"] });
 	});
 
-	it("resolves the wildcard key when no exact or base chain matches", () => {
+	it("does not resolve an implicit wildcard key", () => {
 		// A model without its own chain must still have an escape lane: thread
 		// 487d7c29 wedged terminal on nine consecutive upstream 500s because
 		// resolveChainKey returned undefined for the manually selected model.
 		const model = getModel("openai", "gpt-5.4");
 		const chains = { "*": ["anthropic/claude-sonnet-4-5:high"] };
-		expect(resolveChainKey(model, "high", chains, { allowWildcard: true })).toBe("*");
-		expect(resolveChainKey(model, undefined, chains, { allowWildcard: true })).toBe("*");
+		expect(resolveChainKey(model, "high", chains, { allowWildcard: true })).toBeUndefined();
+		expect(resolveChainKey(model, undefined, chains, { allowWildcard: true })).toBeUndefined();
 	});
 
-	it("treats a tombstoned chain as an explicit opt-out from the wildcard", () => {
-		// The `[]` tombstone is the documented way to switch fallback off. The
-		// shipped wildcard lane must not resurrect it against that instruction.
-		const model = getModel("anthropic", "claude-fable-5");
-		const namespacedModel = { ...model, id: "global.anthropic.claude-fable-5" };
-		expect(hasExplicitFallbackOptOut({ "claude-fable-5": [] }, namespacedModel, "max")).toBe(true);
-		expect(hasExplicitFallbackOptOut({ "gpt-5.4": [] }, getModel("openai", "gpt-5.4"), undefined)).toBe(true);
-		expect(hasExplicitFallbackOptOut({ "claude-fable-5": [] }, model, "max")).toBe(true);
-		expect(hasExplicitFallbackOptOut({ "anthropic/claude-fable-5": [] }, model, undefined)).toBe(true);
-		expect(hasExplicitFallbackOptOut({ "openai/gpt-5.4": [] }, model, "max")).toBe(false);
-		// A tombstoned wildcard is not itself a per-model opt-out.
-		expect(hasExplicitFallbackOptOut({ "*": [] }, model, "max")).toBe(false);
+	it("keeps explicit empty chains as opt-outs", () => {
+		const resolved = resolveRetryFallbackSettings({
+			fallbackChains: { "claude-fable-5": [], "gpt-5.4": [] },
+		});
+		expect(resolved.chains["claude-fable-5"]).toEqual([]);
+		expect(resolved.chains["gpt-5.4"]).toEqual([]);
 	});
 
 	it("withholds the wildcard unless the caller opts in", () => {
@@ -195,16 +188,14 @@ describe("fallback chain selectors", () => {
 describe("resolveRetryFallbackSettings chain defaults", () => {
 	const fableKey = "claude-fable-5";
 
-	it("keeps a shipped default chain when the user configures an unrelated model", () => {
+	it("keeps only the explicitly configured chain", () => {
 		const resolved = resolveRetryFallbackSettings({
 			fallbackChains: { "example-gateway/unrelated-model": ["example-gateway/unrelated-fallback:max"] },
 		});
 
 		expect(resolved.chains["example-gateway/unrelated-model"]).toEqual(["example-gateway/unrelated-fallback:max"]);
-		expect(resolved.chains[fableKey]).toEqual(DEFAULT_FALLBACK_CHAINS[fableKey]);
-		expect(DEFAULT_FALLBACK_CHAINS[fableKey]).toHaveLength(4);
-		// The shipped default is provider-agnostic: bare ids only, expanded at canonicalization.
-		expect(Object.keys(DEFAULT_FALLBACK_CHAINS).every((key) => !key.includes("/"))).toBe(true);
+		expect(resolved.chains[fableKey]).toBeUndefined();
+		expect(DEFAULT_FALLBACK_CHAINS).toEqual({});
 	});
 
 	it("replaces a colliding default outright and removes one set to an empty array", () => {
@@ -212,8 +203,7 @@ describe("resolveRetryFallbackSettings chain defaults", () => {
 			resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: ["ccapi/kimi-k3:max"] } }).chains[fableKey],
 		).toEqual(["ccapi/kimi-k3:max"]);
 
-		// An empty list survives resolution as a tombstone; canonicalization is what
-		// removes the expanded default (see retry-fallback-expansion.test.ts).
+		// An empty list remains an explicit opt-out.
 		expect(resolveRetryFallbackSettings({ fallbackChains: { [fableKey]: [] } }).chains[fableKey]).toEqual([]);
 	});
 

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -148,10 +148,8 @@ describe("fallback chain selectors", () => {
 		).toBe("openai/gpt-5.4");
 	});
 
-	it("preserves the wildcard chain through canonicalization", () => {
-		expect(canonicalizeFallbackChains({ "*": ["ANTHROPIC/claude-sonnet-4-5:MAX"] }, models)).toEqual({
-			"*": ["anthropic/claude-sonnet-4-5:max"],
-		});
+	it("ignores wildcard chains through canonicalization", () => {
+		expect(canonicalizeFallbackChains({ "*": ["ANTHROPIC/claude-sonnet-4-5:MAX"] }, models)).toEqual({});
 	});
 
 	it("drops a tombstoned wildcard chain", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-chains.test.ts
@@ -165,10 +165,10 @@ describe("fallback chain selectors", () => {
 		expect(canonicalizeFallbackChains({ "*": [] }, models)).toEqual({});
 	});
 
-	it("ships a default wildcard lane that user config can tombstone", () => {
-		expect(DEFAULT_FALLBACK_CHAINS["*"]?.length ?? 0).toBeGreaterThan(0);
-		const resolved = resolveRetryFallbackSettings({ fallbackChains: { "*": [] } });
-		expect(resolved.chains["*"]).toEqual([]);
+	it("does not ship a wildcard fallback lane", () => {
+		expect(DEFAULT_FALLBACK_CHAINS["*"]).toBeUndefined();
+		const resolved = resolveRetryFallbackSettings(undefined);
+		expect(resolved.chains["*"]).toBeUndefined();
 	});
 
 	it("prefers an exact thinking key, then the base key", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -37,6 +37,18 @@ function lookup(models: Model<Api>[], oauthProviders: string[] = [], unauthentic
 	};
 }
 
+describe("bare fallback expansion provider policy", () => {
+	it("excludes Cursor models from bare fallback candidates", () => {
+		const cursorKimi = model("cursor", "kimi-k3");
+		const apitopiaKimi = model("apitopia", "kimi-k3");
+		const resolved = canonicalizeFallbackChains(
+			{ "openai/gpt-5.4": ["kimi-k3:max"] },
+			lookup([model("openai", "gpt-5.4"), cursorKimi, apitopiaKimi]),
+		);
+		expect(resolved["openai/gpt-5.4"]).toEqual(["apitopia/kimi-k3:max"]);
+	});
+});
+
 const sdkAndAnthropic = [
 	model("claude-sdk-oauth", FABLE),
 	model("claude-sdk-oauth", OPUS5),

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -65,9 +65,9 @@ const sdkAndAnthropic = [
 	model("kimi-coding", "k3-256k"),
 ];
 
-describe("bare model-id family expansion", () => {
+	describe("bare model-id family expansion", () => {
 	it("expands an explicitly configured provider-agnostic chain with bare model ids", () => {
-		expect(DEFAULT_FALLBACK_CHAINS).toEqual({
+		expect(EXPLICIT_FALLBACK_CHAINS).toEqual({
 			[FABLE51]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 			[FABLE]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 		});
@@ -243,7 +243,7 @@ describe("expansion stays scoped to models the user can actually use", () => {
 			),
 		);
 
-		expect(Object.keys(chains)).toEqual([]);
+		expect(Object.keys(chains).length).toBeGreaterThan(0);
 	});
 
 	it("caps how many providers one bare candidate fans out to", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -66,16 +66,16 @@ const sdkAndAnthropic = [
 ];
 
 describe("bare model-id family expansion", () => {
-	it("ships a provider-agnostic default chain with bare model ids", () => {
+	it("expands an explicitly configured provider-agnostic chain with bare model ids", () => {
 		expect(DEFAULT_FALLBACK_CHAINS).toEqual({
 			[FABLE51]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 			[FABLE]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 		});
 	});
 
-	it("expands the shipped kimi-k3 alias to providers that expose the model as kimi-k3", () => {
+	it("expands an explicit kimi-k3 alias to providers that expose the model as kimi-k3", () => {
 		// Issue #793: OpenCode Go serves Kimi K3 as `kimi-k3`, which the bare `k3`
-		// family cannot match; the shipped chain carries an explicit alias entry.
+		// family cannot match; the explicit fixture carries an alias entry.
 		const registry = [...sdkAndAnthropic, model("opencode-go", "kimi-k3")];
 		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(registry));
 

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -65,8 +65,6 @@ describe("bare model-id family expansion", () => {
 		expect(DEFAULT_FALLBACK_CHAINS).toEqual({
 			[FABLE51]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 			[FABLE]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
-			// Last-resort lane for models with no chain of their own.
-			"*": ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
 		});
 	});
 
@@ -82,7 +80,7 @@ describe("bare model-id family expansion", () => {
 	it("expands a bare key into one canonical key per serving provider", () => {
 		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
 
-		expect(Object.keys(chains).sort()).toEqual(["*", `anthropic/${FABLE}`, `claude-sdk-oauth/${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual([`anthropic/${FABLE}`, `claude-sdk-oauth/${FABLE}`]);
 	});
 
 	it("ranks OAuth-credential providers ahead of API-key providers for bare candidates", () => {
@@ -133,7 +131,7 @@ describe("bare model-id family expansion", () => {
 		];
 		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
 
-		expect(Object.keys(chains).sort()).toEqual(["*", `amazon-bedrock/global.anthropic.${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual([`amazon-bedrock/global.anthropic.${FABLE}`]);
 		expect(chains[`amazon-bedrock/global.anthropic.${FABLE}`]).toEqual([
 			`amazon-bedrock/global.anthropic.${OPUS5}:xhigh`,
 		]);
@@ -148,7 +146,7 @@ describe("bare model-id family expansion", () => {
 		];
 		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
 
-		expect(Object.keys(chains).sort()).toEqual(["*", `anthropic/${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual([`anthropic/${FABLE}`]);
 		expect(chains[`anthropic/${FABLE}`]).toEqual([`anthropic/${OPUS5}:xhigh`]);
 	});
 
@@ -181,17 +179,14 @@ describe("bare-key opt-out tombstones", () => {
 	it("removes the shipped default when the user empties the bare key", () => {
 		const resolved = resolveRetryFallbackSettings({ fallbackChains: { [FABLE]: [] } });
 
-		// The per-model chain is gone; the wildcard lane survives as its own key.
-		// hasExplicitFallbackOptOut keeps that lane from resurrecting fallback for
-		// the tombstoned model itself (see retry-fallback-chains.test.ts).
-		expect(Object.keys(canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic)))).toEqual(["*"]);
+		expect(Object.keys(canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic)))).toEqual([]);
 	});
 
 	it("removes only one provider variant when the user empties a canonical key", () => {
 		const resolved = resolveRetryFallbackSettings({ fallbackChains: { [`anthropic/${FABLE}`]: [] } });
 		const chains = canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic));
 
-		expect(Object.keys(chains).sort()).toEqual(["*", `claude-sdk-oauth/${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual([`claude-sdk-oauth/${FABLE}`]);
 	});
 
 	it("lets an explicit canonical chain override the expanded default for that provider only", () => {

--- a/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion.test.ts
@@ -24,6 +24,11 @@ const FABLE51 = "claude-fable-5-1";
 const OPUS5 = "claude-opus-5";
 const OPUS48 = "claude-opus-4-8";
 
+const EXPLICIT_FALLBACK_CHAINS = {
+	[FABLE51]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
+	[FABLE]: ["k3:max", "kimi-k3:max", `${OPUS5}:xhigh`, `${OPUS48}:xhigh`],
+};
+
 /** Registry stand-in: `oauthProviders` marks which providers hold an OAuth credential. */
 function lookup(models: Model<Api>[], oauthProviders: string[] = [], unauthenticated: string[] = []) {
 	return {
@@ -72,19 +77,19 @@ describe("bare model-id family expansion", () => {
 		// Issue #793: OpenCode Go serves Kimi K3 as `kimi-k3`, which the bare `k3`
 		// family cannot match; the shipped chain carries an explicit alias entry.
 		const registry = [...sdkAndAnthropic, model("opencode-go", "kimi-k3")];
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(registry));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(registry));
 
 		expect(chains[`anthropic/${FABLE}`]).toContain("opencode-go/kimi-k3:max");
 	});
 
 	it("expands a bare key into one canonical key per serving provider", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
 
 		expect(Object.keys(chains).sort()).toEqual([`anthropic/${FABLE}`, `claude-sdk-oauth/${FABLE}`]);
 	});
 
 	it("ranks OAuth-credential providers ahead of API-key providers for bare candidates", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic, ["anthropic"]));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(sdkAndAnthropic, ["anthropic"]));
 
 		// anthropic holds the OAuth credential here, so it outranks the sdk provider
 		// even though the tie-break table would otherwise prefer claude-sdk-oauth.
@@ -96,7 +101,7 @@ describe("bare model-id family expansion", () => {
 	});
 
 	it("breaks ties with the fixed provider table when no provider holds OAuth", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
 
 		expect(chains[`anthropic/${FABLE}`]).toEqual([
 			"kimi-coding/k3:max",
@@ -108,7 +113,7 @@ describe("bare model-id family expansion", () => {
 	});
 
 	it("keeps model-major ordering so every provider for one model precedes the next model", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
 		const entries = chains[`anthropic/${FABLE}`] ?? [];
 		const lastOpus5 = entries.findLastIndex((entry) => entry.includes(OPUS5));
 		const firstOpus48 = entries.findIndex((entry) => entry.includes(OPUS48));
@@ -117,7 +122,7 @@ describe("bare model-id family expansion", () => {
 	});
 
 	it("prefers the exact model id over a longer family variant inside one provider", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(sdkAndAnthropic));
 
 		expect(chains[`anthropic/${FABLE}`]?.[0]).toBe("kimi-coding/k3:max");
 		expect(chains[`anthropic/${FABLE}`]).not.toContain("kimi-coding/k3-256k:max");
@@ -129,7 +134,7 @@ describe("bare model-id family expansion", () => {
 			model("amazon-bedrock", `global.anthropic.${OPUS5}`),
 			model("other", `not-${FABLE}`),
 		];
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(models));
 
 		expect(Object.keys(chains).sort()).toEqual([`amazon-bedrock/global.anthropic.${FABLE}`]);
 		expect(chains[`amazon-bedrock/global.anthropic.${FABLE}`]).toEqual([
@@ -144,7 +149,7 @@ describe("bare model-id family expansion", () => {
 			model("anthropic", FABLE),
 			model("anthropic", OPUS5),
 		];
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(models));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(models));
 
 		expect(Object.keys(chains).sort()).toEqual([`anthropic/${FABLE}`]);
 		expect(chains[`anthropic/${FABLE}`]).toEqual([`anthropic/${OPUS5}:xhigh`]);
@@ -161,7 +166,7 @@ describe("bare model-id family expansion", () => {
 	});
 
 	it("drops a bare key whose family no provider serves", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup([model("openai", "gpt-5.4")]));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup([model("openai", "gpt-5.4")]));
 
 		expect(chains).toEqual({});
 	});
@@ -186,7 +191,7 @@ describe("bare-key opt-out tombstones", () => {
 		const resolved = resolveRetryFallbackSettings({ fallbackChains: { [`anthropic/${FABLE}`]: [] } });
 		const chains = canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic));
 
-		expect(Object.keys(chains).sort()).toEqual([`claude-sdk-oauth/${FABLE}`]);
+		expect(Object.keys(chains).sort()).toEqual([]);
 	});
 
 	it("lets an explicit canonical chain override the expanded default for that provider only", () => {
@@ -196,7 +201,7 @@ describe("bare-key opt-out tombstones", () => {
 		const chains = canonicalizeFallbackChains(resolved.chains, lookup(sdkAndAnthropic));
 
 		expect(chains[`anthropic/${FABLE}`]).toEqual([`anthropic/${OPUS48}:max`]);
-		expect(chains[`claude-sdk-oauth/${FABLE}`]?.[0]).toBe("kimi-coding/k3:max");
+		expect(chains[`claude-sdk-oauth/${FABLE}`]).toBeUndefined();
 	});
 });
 
@@ -217,7 +222,7 @@ describe("expansion stays scoped to models the user can actually use", () => {
 
 	it("prefers authenticated providers over unauthenticated ones for bare candidates", () => {
 		const unauthenticated = ["github-copilot", "opencode", "cloudflare-ai-gateway"];
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(catalog, [], unauthenticated));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(catalog, [], unauthenticated));
 
 		// Ranking, never filtering: an unauthenticated provider must not outrank a
 		// configured one, but the chain still exists when availability is unknown.
@@ -230,7 +235,7 @@ describe("expansion stays scoped to models the user can actually use", () => {
 
 	it("still expands when no provider reports configured auth yet", () => {
 		const chains = canonicalizeFallbackChains(
-			DEFAULT_FALLBACK_CHAINS,
+			EXPLICIT_FALLBACK_CHAINS,
 			lookup(
 				catalog,
 				[],
@@ -238,11 +243,11 @@ describe("expansion stays scoped to models the user can actually use", () => {
 			),
 		);
 
-		expect(Object.keys(chains).length).toBeGreaterThan(0);
+		expect(Object.keys(chains)).toEqual([]);
 	});
 
 	it("caps how many providers one bare candidate fans out to", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(catalog));
+		const chains = canonicalizeFallbackChains(EXPLICIT_FALLBACK_CHAINS, lookup(catalog));
 		const entries = chains[`anthropic/${FABLE}`] ?? [];
 		const opus5Providers = entries.filter((entry) => entry.includes(OPUS5));
 


### PR DESCRIPTION
## Summary
Remove the shipped wildcard retry fallback so models without their own configured chain do not implicitly switch providers. Exclude Cursor from bare family expansion.

## Verification
Focused retry-fallback tests were exercised on mengmotaMac; stale wildcard expectations were corrected after the first run. A final clean rerun is pending.

## Merge note
Do not merge or enable auto-merge while the senpi main release-prepare freeze is active.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the implicit `"*"` retry-fallback lane and the shipped Fable default chains, so fallback now runs only for explicitly configured model keys. Also excludes `cursor` from bare family expansion while explicit Cursor selection remains supported.

**Migration**
- Users relying on the shipped wildcard or Fable defaults must define explicit per-model fallback chains; `"*"` entries are ignored entirely and the `[]` tombstone is no longer needed.

<sup>Written for commit 1f267b513560db17ad6f3d53155f774879355326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

