### PR TITLE
feat(prompt-preset): make the asynchronous form the default in the gpt-6-astra preset

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- The GPT-6 Astra prompt preset now treats the asynchronous form as the default for every call that offers one (child tasks and bash sessions start in the background, long eval cells detach) and names the only two cases for blocking, so a single dependent delegation is spawned in the background and the turn ends to wait instead of blocking on it.
 - The `monitor` tool's `persistent` option now reads as what it is — a standing watch: no deadline, survives a session restart (the command is re-run once, the file is rescanned and any change missed while detached is reported), expires seven days after creation, and at most five per session. The native file branch no longer claims to reject `persistent`, since a persistent file watch is exactly the one that is checkpointed and restored, and the guidance the tool description duplicated from the terminal prompt section was removed rather than restated, so the reworded switch and its bounds cost fewer prompt bytes than the wording they replace.
 
 ### Fixed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1808,7 +1808,9 @@ export class AgentSession {
 		this._incrementMessageRevision();
 	}
 
-	private _modelChangeWouldExhaustContext(model: Model<Api>): ReturnType<typeof projectModelUsabilityBudget> | undefined {
+	private _modelChangeWouldExhaustContext(
+		model: Model<Api>,
+	): ReturnType<typeof projectModelUsabilityBudget> | undefined {
 		if (model.contextWindow <= 0) return undefined;
 		const projection = projectModelUsabilityBudget({
 			model,

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,25 @@
 # prompt-preset Extension Changes
 
+## GPT-6 Astra: asynchronous is the default form of every call (2026-09-05)
+
+### What changed
+
+- `gpt-6-astra.ts`: `async-handles` becomes `async-default` ("asynchronous is the default form of every call that offers one: child tasks and bash sessions start in the background, and a long eval cell detaches"), and a new plain rule `foreground-exception` names the only two cases for blocking (a call that finishes within a reply and decides the very next call, or an approval-gated/destructive action watched directly) and states that a child task never meets the first test even when its result is the next input. `turn-end-is-wait` gains "and the task continues"; the Intent Gate stop line and the Stop Goal say the *task* is over, not the *turn*. `delegation` now names the form (spawn together, in the background) and adopts the Astra guide's decision rule (whenever running tracks beside your own work saves time or improves the result). The `Gpt6AstraRuleId` union and `GPT6_ASTRA_RULES` follow; the file header records the async section's design.
+- `test/suite/prompt-presets-gpt-6-astra.test.ts`: concern/placement tables carry the two async ids; the async-work concern is pinned to exactly `async-default`, `foreground-exception`, `turn-end-is-wait`, `monitor-conditions` in that order; the emphasis set swaps `async-handles` for `async-default` (the exception rule stays plain).
+
+### Why
+
+- Live backtest against the real `gpt-6-astra` (senpi openai-codex path, rendered through `resolvePreset`, omo's `task` tool attached): with the shipped preset the model spawned a single dependent child with `run_in_background: false` (3/3 samples) or omitted (3/3) and blocked on it, reasoning "I'll have the deep agent investigate ... then I'll run the tests". Diagnosis per the prompt-engineering skill: `RUN LONG WORK ASYNCHRONOUSLY` made async conditional on the model's own reading of "long", so a child whose result is the next input read as "needed now" (misframing); `delegation` said "send them together" without saying where children run (unsatisfiable under a blocking default); and the Stop Goal's "the turn is over the moment all of these hold" contradicted `END YOUR TURN; THE COMPLETION WAKES YOU", which an instruction-follower resolves by never ending the turn. Each defect is fixed at its source; nothing was appended on top.
+- Token cost (o200k, same tool set and omo task guidelines in both renders): 3779 -> 3854 (+75), all of it the exception rule (+~55) and the turn/task fix (+5); "never assume or invent what it will contain" left the async rule because Hard Limits already forbid presenting a pending result as fact.
+
+### Why extension system couldn't handle this differently
+
+- Content-only change inside this builtin's rule data.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `gpt-6-astra.ts` and its test are fork-only.
+
 ## GPT-6 Astra preset, written from scratch (2026-09-04)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-6-astra.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-6-astra.ts
@@ -27,8 +27,9 @@
 //
 // Emphasis is deliberate and rationed: only the owner's two hard operating
 // rules render in capitals and bold - one js cell per multi-call step on the
-// Bun eval kernel, and asynchronous execution with `monitor` subscriptions in
-// place of waiting. Everything else stays plain so those two keep their weight.
+// Bun eval kernel, and asynchronous execution as the default form of every
+// call, with `monitor` subscriptions in place of waiting. Everything else
+// stays plain so those two keep their weight.
 //
 // Two harness facts Astra cannot derive get their own sections. Astra is
 // trained on async tool calling (an `async: true` call returns later on its
@@ -36,8 +37,14 @@
 // runs long work as background sessions, detached eval cells, monitors, and
 // child tasks whose completions arrive as injected messages, with no wait
 // tool at all. `## Asynchronous Work` maps the trained model onto these
-// surfaces: keep working, never invent the pending result, end the turn when
-// the next step needs it. Codex's own Astra template runs "code mode only"
+// surfaces: the asynchronous form is the default for every call that offers
+// one, blocking is a named exception (a call that finishes within a reply and
+// decides the very next call, or an approval-gated or destructive action
+// watched directly), and the turn ends when the next step needs a pending
+// result. A child task never meets the exception, even when its result is
+// the next input: an orchestrator that blocks on one child at a time forfeits
+// every other track, which is the failure this section exists to prevent.
+// Codex's own Astra template runs "code mode only"
 // (`functions.exec` batching independent calls with Promise.allSettled), so
 // senpi's eval-first orchestration rules fit Astra's prior directly.
 //
@@ -77,7 +84,8 @@ export type Gpt6AstraRuleId =
 	| "delegation"
 	| "legible-messages"
 	| "todo-granularity"
-	| "async-handles"
+	| "async-default"
+	| "foreground-exception"
 	| "turn-end-is-wait"
 	| "monitor-conditions"
 	| "verification-once"
@@ -152,7 +160,7 @@ const LSP_SYMBOL_ROUTING =
 	"Where LSP tools exist, let the language server answer symbol questions - a definition, its callers, the blast radius of a rename, the diagnostics on a file you just touched. Plain text search earns its place on literal strings, filenames, and commit history.";
 
 const DELEGATION =
-	"Independent tracks are worth handing to subagents or a team when the tools are there and the parallelism pays for the coordination. Send them together, each brief stating what to produce, where its edits may land, the observable condition that ends it, and the evidence it hands back for you to check. What you can close in a handful of calls, keep.";
+	"Hand independent tracks to subagents or a team whenever running them beside your own work saves time or improves the result: spawn them together in the background, each brief stating what to produce, where its edits may land, the observable condition that ends it, and the evidence it hands back for you to check. What you can close in a handful of calls, keep.";
 
 const LEGIBLE_MESSAGES =
 	"Messages to other agents and your final answer are read by people: full sentences, proper spaces between words and numbers, no private shorthand.";
@@ -160,11 +168,14 @@ const LEGIBLE_MESSAGES =
 const TODO_GRANULARITY =
 	"Given a todo tool, cut multi-step work into the smallest items that still stand alone - an edit paired with the check that proves it - and move each one the instant its state changes: opened, finished, newly discovered and appended, abandoned and dropped. A one-step ask carries no list.";
 
-const ASYNC_HANDLES =
-	"**RUN LONG WORK ASYNCHRONOUSLY.** A background bash session, a detached eval cell, or a child task returns at once with a handle and delivers its result later as a message in this conversation. Treat a handle exactly like a pending async call: keep working on everything that does not need it, and never assume or invent what it will contain.";
+const ASYNC_DEFAULT =
+	"**ASYNCHRONOUS IS THE DEFAULT FORM OF EVERY CALL THAT OFFERS ONE: CHILD TASKS AND BASH SESSIONS START IN THE BACKGROUND, AND A LONG EVAL CELL DETACHES.** Each returns a handle at once and delivers its result later as a message; treat the handle like a pending async call and keep working on everything that does not need it.";
+
+const FOREGROUND_EXCEPTION =
+	"Block only on a call that finishes within the time a reply takes and decides your very next call, or on an approval-gated or destructive action you must watch directly. A child task never meets the first test, even when its result is your next input; spawn it in the background and let the completion deliver it.";
 
 const TURN_END_IS_WAIT =
-	"**THERE IS NO WAIT TOOL. WHEN THE NEXT STEP NEEDS A PENDING RESULT, END YOUR TURN; THE COMPLETION WAKES YOU.** Repeated status reads, sleeps, and timed retries replay the whole context for nothing; a single peek serves a midpoint decision only.";
+	"**THERE IS NO WAIT TOOL. WHEN THE NEXT STEP NEEDS A PENDING RESULT, END YOUR TURN; THE COMPLETION WAKES YOU AND THE TASK CONTINUES.** Repeated status reads, sleeps, and timed retries replay the whole context for nothing; a single peek serves a midpoint decision only.";
 
 const MONITOR_CONDITIONS =
 	"**WHEN `monitor` IS AVAILABLE, USE IT FOR EVERY OBSERVABLE WAIT** - a log line, a build or test run finishing, a file appearing, a check turning green: register it, from inside the same cell when the run starts there, and keep working. Steer, read, or stop a running session or child through its session tools instead of launching a duplicate.";
@@ -213,7 +224,8 @@ export const GPT6_ASTRA_RULES = [
 	{ id: "delegation", concern: "delegation", directive: DELEGATION },
 	{ id: "legible-messages", concern: "delegation", directive: LEGIBLE_MESSAGES },
 	{ id: "todo-granularity", concern: "todo-discipline", directive: TODO_GRANULARITY },
-	{ id: "async-handles", concern: "async-work", directive: ASYNC_HANDLES },
+	{ id: "async-default", concern: "async-work", directive: ASYNC_DEFAULT },
+	{ id: "foreground-exception", concern: "async-work", directive: FOREGROUND_EXCEPTION },
 	{ id: "turn-end-is-wait", concern: "async-work", directive: TURN_END_IS_WAIT },
 	{ id: "monitor-conditions", concern: "async-work", directive: MONITOR_CONDITIONS },
 	{ id: "verification-once", concern: "verification", directive: VERIFICATION_ONCE },
@@ -234,7 +246,7 @@ function buildGpt6AstraCore(context: DynamicPromptCoreContext): string {
 
 Open every turn with one short routing line before anything else:
 
-> I read this as [intent] - [plan]. I'll stop right away when [the exact, observable condition that ends this turn].
+> I read this as [intent] - [plan]. I'll stop right away when [the exact, observable condition that ends this task].
 
 The declared stop condition is binding: work until it holds, then stop (see Stop Goal). Take intent from the latest user message; a new direction replaces the stale plan. Information asks (explain, look into, investigate) get reading and a report with no edits. Judgment asks (what do you think, review) and open-ended asks (refactor, improve, clean up) get an assessment and a proposal, then the user's confirmation. Everything else is an instruction to do the work - "implement", "fix", and equally "can you", "help me", "I want to" - so build it, or diagnose and fix it, at exactly the asked scope. Keep prompt scaffolding out of user-visible output.
 
@@ -260,7 +272,7 @@ ${TODO_GRANULARITY}
 
 ## Asynchronous Work
 
-${ASYNC_HANDLES} ${TURN_END_IS_WAIT} ${MONITOR_CONDITIONS}
+${ASYNC_DEFAULT} ${FOREGROUND_EXCEPTION} ${TURN_END_IS_WAIT} ${MONITOR_CONDITIONS}
 
 ## Verification
 
@@ -304,7 +316,7 @@ Code reviews: findings first, ordered by severity with file references, then ope
 
 ## Stop Goal
 
-The turn is over the moment all of these hold: every requested behavior works in observable use with nothing deferred, the checks for the change's tier are clean or explained, and the final message is delivered. Until then keep going; when they hold, confirm each item and your declared stop condition against evidence already captured, deliver the final message, and stop - another validation pass, a re-polish, or a bonus refactor after that point is a defect. Context compacts automatically when it runs low: continue from the summary without redoing finished work, and never stop, summarize, or suggest a new session on its account.
+The task is over the moment all of these hold: every requested behavior works in observable use with nothing deferred, the checks for the change's tier are clean or explained, and the final message is delivered. Until then keep going; when they hold, confirm each item and your declared stop condition against evidence already captured, deliver the final message, and stop - another validation pass, a re-polish, or a bonus refactor after that point is a defect. Context compacts automatically when it runs low: continue from the summary without redoing finished work, and never stop, summarize, or suggest a new session on its account.
 
 ${buildFileOperationsTuning()}`;
 }

--- a/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/service-tier.ts
@@ -253,7 +253,9 @@ export default function serviceTierExtension(pi: ExtensionAPI): void {
 		}
 
 		sessionFastMode =
-			baseModel !== undefined || remembered === PRIORITY_TIER || (remembered === undefined && ctx.serviceTier === PRIORITY_TIER);
+			baseModel !== undefined ||
+			remembered === PRIORITY_TIER ||
+			(remembered === undefined && ctx.serviceTier === PRIORITY_TIER);
 		pi.setSessionFastMode(sessionFastMode);
 		const memoryModel = resolveServiceTierMemoryModel(ctx.modelRegistry, model);
 		liveMemoryKey = `${memoryModel.provider}/${memoryModel.id}`;

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -7,7 +7,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { AgentMessage, ThinkingLevel } from "@earendil-works/pi-agent-core";
-import { modelsAreEqual, type AuthEvent, type AuthPrompt } from "@earendil-works/pi-ai";
+import { type AuthEvent, type AuthPrompt, modelsAreEqual } from "@earendil-works/pi-ai";
 import type { AssistantMessage, ImageContent, Message, Model, TextContent, Usage } from "@earendil-works/pi-ai/compat";
 import type {
 	AutocompleteItem,
@@ -6081,7 +6081,9 @@ export class InteractiveMode {
 				this.showStatus(msg);
 			} else {
 				if (result.skippedModels.length > 0 && modelsAreEqual(result.model, this.session.model)) {
-					this.showStatus("No favorite model can fit the current context. Compact the session or start a new one.");
+					this.showStatus(
+						"No favorite model can fit the current context. Compact the session or start a new one.",
+					);
 					return;
 				}
 				this.footer.invalidate();

--- a/packages/coding-agent/test/suite/prompt-presets-gpt-6-astra.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-gpt-6-astra.test.ts
@@ -93,7 +93,8 @@ const EXPECTED_CONCERN: Record<Gpt6AstraRuleId, Gpt6AstraConcern> = {
 	delegation: "delegation",
 	"legible-messages": "delegation",
 	"todo-granularity": "todo-discipline",
-	"async-handles": "async-work",
+	"async-default": "async-work",
+	"foreground-exception": "async-work",
 	"turn-end-is-wait": "async-work",
 	"monitor-conditions": "async-work",
 	"verification-once": "verification",
@@ -124,7 +125,8 @@ const EXPECTED_SECTION: Record<Gpt6AstraRuleId, string> = {
 	delegation: "Working the Task",
 	"legible-messages": "Working the Task",
 	"todo-granularity": "Working the Task",
-	"async-handles": "Asynchronous Work",
+	"async-default": "Asynchronous Work",
+	"foreground-exception": "Asynchronous Work",
 	"turn-end-is-wait": "Asynchronous Work",
 	"monitor-conditions": "Asynchronous Work",
 	"verification-once": "Verification",
@@ -256,7 +258,12 @@ describe("GPT-6 Astra behavior contract", () => {
 			expect(rule.directive).not.toMatch(/\p{Extended_Pictographic}/u);
 		}
 		const asyncRules = GPT6_ASTRA_RULES.filter((rule) => rule.concern === "async-work");
-		expect(asyncRules.length).toBeGreaterThanOrEqual(3);
+		expect(asyncRules.map((rule) => rule.id)).toEqual([
+			"async-default",
+			"foreground-exception",
+			"turn-end-is-wait",
+			"monitor-conditions",
+		]);
 	});
 
 	it("renders the eval-cell and asynchronous-execution rules with bold emphasis and no other rule in bold", () => {
@@ -264,7 +271,7 @@ describe("GPT-6 Astra behavior contract", () => {
 		const emphasized = new Set<Gpt6AstraRuleId>([
 			"eval-first-routing",
 			"parallel-batching",
-			"async-handles",
+			"async-default",
 			"turn-end-is-wait",
 			"monitor-conditions",
 		]);


### PR DESCRIPTION
## Summary

A live backtest against the real `gpt-6-astra` (senpi openai-codex path, prompt rendered through `resolvePreset`, omo's `task` tool attached) showed the shipped preset spawning a single dependent child with `run_in_background: false` (3/3 samples) or omitted (3/3) and blocking on it. The preset told the model to run *long* work asynchronously, never said where delegated children run, and its Stop Goal said the *turn* is over only when the task is done, which contradicts "end your turn; the completion wakes you".

This PR fixes each defect at its source (prompt-engineering diagnosis: misframing x2, one internal contradiction), with no directive appended on top:

- `async-handles` -> `async-default`: asynchronous is the default form of every call that offers one (child tasks and bash sessions start in the background, a long eval cell detaches).
- new `foreground-exception` (plain): block only on a call that finishes within a reply and decides the very next call, or an approval-gated/destructive action watched directly; a child task never qualifies, even when its result is the next input.
- `turn-end-is-wait`: "...and the task continues"; Intent Gate and Stop Goal say the task, not the turn, is over.
- `delegation`: spawn together, in the background, whenever it saves time or improves the result (the Astra guide's decision rule).
- Test: async-work concern pinned to its four ids in order; emphasis set follows the rename.
- Separate commit: biome formatting for three files that landed on main with drift (#1376, #1378).

## Evidence

- RED (updated test vs unmodified preset, mengmotaMac): 3 failed / 29 passed - rule-id set, emphasis, placement.
- GREEN: `prompt-presets-gpt-6-astra`, `prompt-presets-gpt-5-6`, `prompt-presets-gpt-eval-routing`, `prompt-presets-execution-tooling`, `brand-identity`: 5 files / 100 tests passed (mengmotaMac, origin/main + this change).
- `bunx biome check` (no --write) clean on the changed files; `bun run check` (pre-commit) passed; changelog gate PASS.
- Token cost (o200k, identical tool set + omo task guidelines): 3779 -> 3854 (+75); the Asynchronous Work section is +74, the rest of the preset is net +1. Entropy gate recorded in `prompt-preset/changes.md`.
- Live backtest old vs new is completed in the companion omo PR (task tool description rewrite) and reported there.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes asynchronous execution the default for all calls in the `gpt-6-astra` preset, fixing a backtest failure where the model blocked on a single dependent child.

- Replaces `async-handles` with `async-default` and adds `foreground-exception` to name the only two blocking cases; a child task never qualifies.
- Updates `turn-end-is-wait` and the Stop Goal so the turn ends and the task continues, removing the internal contradiction.
- Updates `delegation` to spawn children together in the background whenever it saves time or improves the result.
- Pins the async-work rule ids in the test and updates the emphasis set accordingly.
- A separate formatting-only commit fixes biome drift in three unrelated files that arrived without formatting.
- Token cost increases by ~75 tokens under o200k, all of it in the async section.

<sup>Written for commit 2961d2c30e6e638fcd15c8c0800c18f70a07b0e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

