### PR TITLE
fix(coding-agent): unbreak senpi main after the Ctrl+P context-skip change

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Persistent monitors now survive repeated restarts: file watches are re-registered and compare their persisted checkpoint once, reporting exactly one detached created, replaced, or modified change (and nothing when unchanged), while command watches are re-run once under the same `mon_` id without replaying pre-restart output. Sessions may keep up to five durable watches; each expires seven days after creation without extending that deadline on restart or rearm, and a watch muted by the wake budget remains muted when restored.
 - A standing watch that exceeds its 200-line matching-event budget within a rolling 24-hour window now mutes itself and says so once, telling you to rearm it; rearming resumes the watch, ordinary one-shot monitors are never counted, and the window survives restarts so a noisy watch cannot receive a fresh allowance.
 
+### Fixed
+
+- Favorite-model cycling (Ctrl+P) no longer breaks callers that predate the skipped-model list, and it raises the documented model-usability budget error again when the single alternative cannot host the current context instead of silently staying on the current model.
+
 ### Changed
 
 - The GPT-6 Astra prompt preset now treats the asynchronous form as the default for every call that offers one (child tasks and bash sessions start in the background, long eval cells detach) and names the only two cases for blocking, so a single dependent delegation is spawned in the background and the turn ends to wait instead of blocking on it.

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4839,13 +4839,17 @@ export class AgentSession {
 			break;
 		}
 		if (selectedIndex === undefined) {
-			// Every candidate was inadmissible. Skipping past an unusable model is a convenience;
-			// having NO usable target is the documented budget failure, so the caller still gets the
-			// ModelUsabilityBudgetError it had before candidate skipping existed. The immediate
-			// neighbour is the model the user actually asked to switch to, so it owns the message.
-			const attempted = favoriteModels[nextIndex];
-			if (attempted && !modelsAreEqual(attempted.model, currentModel)) {
-				this.assertModelUsable(attempted.model, this._getDownswitchLiveContextTokens(attempted.model));
+			// Every candidate was inadmissible. Skipping only makes sense when there was somewhere else
+			// to skip TO: with more than one alternative the cycle reports the skipped list and stays put
+			// (#1378's convenience). With a single alternative the user asked for THAT model, so the
+			// documented ModelUsabilityBudgetError still surfaces instead of a silent no-op.
+			const alternatives = favoriteModels.filter((entry) => !modelsAreEqual(entry.model, currentModel));
+			const onlyAlternative = alternatives.length === 1 ? alternatives[0] : undefined;
+			if (onlyAlternative) {
+				this.assertModelUsable(
+					onlyAlternative.model,
+					this._getDownswitchLiveContextTokens(onlyAlternative.model),
+				);
 			}
 			return {
 				model: currentModel,

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4839,6 +4839,14 @@ export class AgentSession {
 			break;
 		}
 		if (selectedIndex === undefined) {
+			// Every candidate was inadmissible. Skipping past an unusable model is a convenience;
+			// having NO usable target is the documented budget failure, so the caller still gets the
+			// ModelUsabilityBudgetError it had before candidate skipping existed. The immediate
+			// neighbour is the model the user actually asked to switch to, so it owns the message.
+			const attempted = favoriteModels[nextIndex];
+			if (attempted && !modelsAreEqual(attempted.model, currentModel)) {
+				this.assertModelUsable(attempted.model, this._getDownswitchLiveContextTokens(attempted.model));
+			}
 			return {
 				model: currentModel,
 				thinkingLevel: this.thinkingLevel,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -8,6 +8,11 @@
   before favorite-model cycling, emits `model_change_skipped` for rejected
   candidates, and continues in the requested direction. The cycle result
   carries skipped models when every alternative is rejected.
+- Skipping requires somewhere to skip TO: when the rotation holds several
+  alternatives and all are rejected, the cycle reports the skipped list and
+  stays on the current model, but a lone rejected alternative is an explicit
+  switch request and still raises `ModelUsabilityBudgetError` as it did before
+  candidate skipping existed.
 
 ### Why
 

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -6080,7 +6080,7 @@ export class InteractiveMode {
 						: buildFavoriteCycleStatusMessage("empty");
 				this.showStatus(msg);
 			} else {
-				if (result.skippedModels.length > 0 && modelsAreEqual(result.model, this.session.model)) {
+				if ((result.skippedModels?.length ?? 0) > 0 && modelsAreEqual(result.model, this.session.model)) {
 					this.showStatus(
 						"No favorite model can fit the current context. Compact the session or start a new one.",
 					);


### PR DESCRIPTION
## What changed
- `packages/coding-agent/src/modes/interactive/interactive-mode.ts`: the favorite-cycle handler reads `result.skippedModels` defensively (`?.length ?? 0`).
- `packages/coding-agent/src/core/agent-session.ts`: when every favorite candidate is inadmissible, the cycle keeps #1378's soft skip only when there was somewhere else to skip to; a **single** unusable alternative is an explicit switch request and raises `ModelUsabilityBudgetError` again.
- Trackers: `src/core/changes.md`, `CHANGELOG.md` (Fixed).

## Why
PR #1378 (`a4ebaf87c`, "skip context-incompatible Ctrl+P models") left **senpi main red**, which blocks every release: `npm test` in the release job fails with 3 failed / 9925 passed. Bisect on the fleet (gorky), same three suites at each commit:

| commit | result |
|---|---|
| 716138da7 (before #1378) | 3 passed |
| a4ebaf87c | **3 failed** |
| 671c7060e (#1378 merge) | **3 failed** |
| 82ef1fd31 (main) | **3 failed** |

Failures: `interactive-mode-external-owner-notice.test.ts` and `risky-main-model-warning-tui.test.ts` (both drive `InteractiveMode.cycleModel` with a session double whose result has no `skippedModels`), and `suite/model-shrink-speculative-warmstart.test.ts` (the documented `ModelUsabilityBudgetError` stopped being thrown, so an oversized shrink silently resolved).

## Verification (fleet, never local)
gorky, branch `fix/ctrl-p-skip-regression`:
```
bunx vitest --run test/interactive-mode-external-owner-notice.test.ts test/risky-main-model-warning-tui.test.ts \
  test/suite/model-shrink-speculative-warmstart.test.ts test/suite/agent-session-model-extension.test.ts
 Test Files  4 passed (4)
```
The fourth file is #1378's own `reports when every other favorite is rejected by the context budget`, which still passes — both contracts hold.

## Residual risk
The discriminator is "how many alternatives exist", not a new setting; a two-favorite rotation now surfaces the budget error instead of a status line, which is the pre-#1378 behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Ctrl+P favorite-model cycling regression from #1378 that left main's test suite red (3 failures) and blocked releases.

- Restores the documented `ModelUsabilityBudgetError` when a single alternative cannot host the current context, instead of silently staying on the current model.
- Makes `skippedModels` access defensive so callers predating the field don't crash.
- The soft-skip behavior still applies when more than one alternative exists.

<sup>Written for commit e344e3bd5ae836c11577c8c44fb2bf4999bf081c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

