### PR TITLE
test(coding-agent): align fallback tests with the explicit-chain contract

### DIFF
--- a/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
+++ b/packages/coding-agent/test/settings-manager-retry-fallback.test.ts
@@ -29,13 +29,9 @@ afterEach(() => {
 });
 
 describe("SettingsManager retry fallback settings", () => {
-	const defaultChains = {
-		"claude-fable-5-1": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
-		"claude-fable-5": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
-		// Last-resort lane so a model without its own chain still has an escape
-		// route instead of wedging the session terminal.
-		"*": ["k3:max", "kimi-k3:max", "claude-opus-5:xhigh", "claude-opus-4-8:xhigh"],
-	};
+	// Fallback chains ship EMPTY by default (2026-09-05 "require explicit fallback
+	// chains"): no implicit lanes, no wildcard escape route — a model falls back only
+	// when the user configured a chain for it.
 
 	it("defaults abortServerSideFallback to true and round-trips an explicit false", () => {
 		const { agentDir, projectDir } = createPaths();
@@ -48,11 +44,11 @@ describe("SettingsManager retry fallback settings", () => {
 		expect(SettingsManager.create(projectDir, agentDir).getAbortServerSideFallback()).toBe(true);
 	});
 
-	it("returns defaults when fallback settings are unset or malformed", () => {
+	it("returns empty chains when fallback settings are unset or malformed", () => {
 		const { agentDir, projectDir } = createPaths();
 		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
 			modelFallback: true,
-			chains: defaultChains,
+			chains: {},
 			revertPolicy: "cooldown-expiry",
 		});
 
@@ -69,7 +65,7 @@ describe("SettingsManager retry fallback settings", () => {
 
 		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings()).toEqual({
 			modelFallback: true,
-			chains: defaultChains,
+			chains: {},
 			revertPolicy: "cooldown-expiry",
 		});
 	});
@@ -83,14 +79,11 @@ describe("SettingsManager retry fallback settings", () => {
 		await manager.flush();
 
 		const reloaded = SettingsManager.create(projectDir, agentDir);
-		// Overriding one key layers over the shipped defaults; the wildcard lane
-		// survives so other models keep their escape route.
+		// Only the configured key exists; unconfigured models have no chain at all.
 		expect(reloaded.getRetryFallbackSettings()).toEqual({
 			modelFallback: false,
 			chains: {
 				"claude-fable-5": ["ccapi/kimi-k3:max"],
-				"claude-fable-5-1": defaultChains["claude-fable-5-1"],
-				"*": defaultChains["*"],
 			},
 			revertPolicy: "never",
 		});
@@ -99,11 +92,11 @@ describe("SettingsManager retry fallback settings", () => {
 		await reloaded.flush();
 		expect(existsSync(join(projectDir, CONFIG_DIR_NAME, "settings.json"))).toBe(false);
 
-		// Removing the user's override restores the shipped default for that key
-		// rather than leaving the model with no chain at all.
+		// Removing the user's override leaves no chain for that model — there is no
+		// shipped default to restore.
 		reloaded.removeFallbackChain("claude-fable-5");
 		await reloaded.flush();
-		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).toEqual(defaultChains);
+		expect(SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains).toEqual({});
 	});
 
 	it("reports which settings scope supplied the fallback chains", () => {
@@ -129,11 +122,11 @@ describe("SettingsManager retry fallback settings", () => {
 		writeFileSync(join(agentDir, "settings.json"), JSON.stringify({ retry: { fallbackChains: null } }));
 		const manager = SettingsManager.create(projectDir, agentDir);
 		expect(manager.getFallbackChainsScope()).toBe("global");
-		// Malformed input still degrades to the shipped defaults rather than to nothing.
-		expect(manager.getRetryFallbackSettings().chains).toEqual(defaultChains);
+		// Malformed input degrades to the empty default, not to shipped chains.
+		expect(manager.getRetryFallbackSettings().chains).toEqual({});
 	});
 
-	it("keeps default chains for models the user did not configure", () => {
+	it("resolves only the chains the user configured", () => {
 		const { agentDir, projectDir } = createPaths();
 		writeFileSync(
 			join(agentDir, "settings.json"),
@@ -149,7 +142,9 @@ describe("SettingsManager retry fallback settings", () => {
 		const chains = SettingsManager.create(projectDir, agentDir).getRetryFallbackSettings().chains;
 
 		expect(chains["example-gateway/unrelated-model"]).toEqual(["example-gateway/unrelated-fallback:max"]);
-		expect(chains["claude-fable-5"]).toEqual(defaultChains["claude-fable-5"]);
+		// No shipped defaults exist to fill in: unconfigured models have no chain.
+		expect(chains["claude-fable-5"]).toBeUndefined();
+		expect(Object.keys(chains)).toEqual(["example-gateway/unrelated-model"]);
 	});
 
 	it("lets a user chain replace a default outright and an empty array delete it", () => {

--- a/packages/coding-agent/test/suite/model-fallback-command.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-command.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, rm } from "node:fs/promises";
+import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
@@ -46,6 +47,10 @@ function model(provider: string, id: string, reasoning: boolean): Model<Api> {
 		maxTokens: 1,
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 	};
+}
+
+function writeSettings(dir: string, settings: unknown): void {
+	writeFileSync(join(dir, "settings.json"), JSON.stringify(settings));
 }
 
 async function harness(): Promise<Map<string, Command>> {
@@ -189,13 +194,12 @@ describe("model fallback builtin command", () => {
 		expect(command?.description).toContain("fallback");
 	});
 
-	it("lists a default chain only for models the user can actually select", async () => {
+	it("reports empty state when no fallback chains are configured", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
 		dirs.push(dir);
 		const notices: string[] = [];
 		const catalogOnly = model("github-copilot", "claude-fable-5", true);
-		// The builtin catalog publishes Fable 5 under many providers; only the SDK
-		// OAuth one is actually usable here, so only its chain belongs on screen.
+		// No shipped defaults exist anymore: with nothing configured the command says so.
 		const ctx = await context(
 			dir,
 			notices,
@@ -206,9 +210,32 @@ describe("model fallback builtin command", () => {
 
 		await (await harness()).get("fallback")?.handler("", ctx);
 
+		expect(notices.join("\n")).toContain("No fallback chains configured");
+	});
+
+	it("lists a configured chain for the provider the user actually pinned", async () => {
+		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
+		dirs.push(dir);
+		const notices: string[] = [];
+		// Chains resolve from the agent settings dir (repointed per-test in beforeEach).
+		const agentDir = process.env.SENPI_CODING_AGENT_DIR;
+		if (!agentDir) throw new Error("SENPI_CODING_AGENT_DIR not set");
+		writeSettings(agentDir, {
+			retry: { fallbackChains: { "claude-sdk-oauth/claude-fable-5": ["kimi-coding/k3:max"] } },
+		});
+		const ctx = await context(
+			dir,
+			notices,
+			["Show chains & live state"],
+			[sdkFable, sdkOpus5, kimiK3],
+			[sdkFable, sdkOpus5, kimiK3],
+		);
+
+		await (await harness()).get("fallback")?.handler("", ctx);
+
 		const rendered = notices.join("\n");
-		expect(rendered).toContain("claude-sdk-oauth/claude-fable-5 -> kimi-coding/k3:max");
-		expect(rendered).not.toContain("github-copilot/claude-fable-5 ->");
+		expect(rendered).toContain("claude-sdk-oauth/claude-fable-5 ->");
+		expect(rendered).toContain("kimi-coding/k3:max");
 	});
 
 	it("quick-set validates and persists a chain visible after a session-side reload", async () => {
@@ -244,37 +271,41 @@ describe("model fallback builtin command", () => {
 
 	it.each([
 		{
-			name: "all default models are available",
+			name: "all fallback models are available",
 			models: [primary, kimiK3, opus5, opus48],
-			expected:
-				"anthropic/claude-fable-5 -> kimi-coding/k3:max, anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
-		},
-		{
-			name: "Fable 5 is attached through the Claude SDK OAuth provider instead of anthropic",
-			models: [sdkFable, kimiK3, sdkOpus5],
-			expected: "claude-sdk-oauth/claude-fable-5 -> kimi-coding/k3:max, claude-sdk-oauth/claude-opus-5:xhigh",
+			mustList: ["kimi-coding/k3:max", "anthropic/claude-opus-5:xhigh"],
+			mustOmit: [] as string[],
 		},
 		{
 			name: "Kimi K3 is unavailable",
 			models: [primary, opus5, opus48],
-			expected: "anthropic/claude-fable-5 -> anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
+			mustList: ["anthropic/claude-opus-5:xhigh", "anthropic/claude-opus-4-8:xhigh"],
+			mustOmit: ["kimi-coding/k3:max"],
 		},
-		{
-			// Fable's own chain drops out with the model, but the shipped wildcard
-			// lane remains so a chainless model still has an escape route.
-			name: "Fable 5 is unavailable",
-			models: [opus5, opus48],
-			expected: "* -> anthropic/claude-opus-5:xhigh, anthropic/claude-opus-4-8:xhigh",
-		},
-	])("shows the availability-filtered default chain when $name", async ({ models, expected }) => {
+	])("filters a configured chain by live availability when $name", async ({ models, mustList, mustOmit }) => {
 		const dir = await mkdtemp(join(tmpdir(), "senpi-fallback-command-"));
 		dirs.push(dir);
 		const notices: string[] = [];
 		const choices = ["Show chains & live state"];
+		const agentDir = process.env.SENPI_CODING_AGENT_DIR;
+		if (!agentDir) throw new Error("SENPI_CODING_AGENT_DIR not set");
+		writeSettings(agentDir, {
+			retry: {
+				fallbackChains: {
+					"anthropic/claude-fable-5": [
+						"kimi-coding/k3:max",
+						"anthropic/claude-opus-5:xhigh",
+						"anthropic/claude-opus-4-8:xhigh",
+					],
+				},
+			},
+		});
 
 		await (await harness()).get("fallback")?.handler("", await context(dir, notices, choices, models));
 
-		expect(notices.join("\n")).toContain(expected);
+		const rendered = notices.join("\n");
+		for (const entry of mustList) expect(rendered).toContain(entry);
+		for (const entry of mustOmit) expect(rendered).not.toContain(entry);
 	});
 
 	it("handles a headless menu invocation cleanly", async () => {


### PR DESCRIPTION
## What changed
- `packages/coding-agent/test/settings-manager-retry-fallback.test.ts` and `packages/coding-agent/test/suite/model-fallback-command.test.ts` still pinned the removed shipped default chains and wildcard lane, leaving `npm test` red on main after the require-explicit-chains rework (089599d89 + daa81b0ed) had already updated the other fallback suites.
- Both files now assert the new contract: chains are empty by default, only configured keys resolve, malformed input degrades to empty, availability filtering applies to configured chains, and the command reports the empty-state message when nothing is configured. New listing tests write chains into the per-test `SENPI_CODING_AGENT_DIR` (the path `SettingsManager.create` actually reads), not the project dir.

## Why
The rework changed the product contract deliberately (its changes.md entry documents "fallback runs only for configured model keys") but left these two files red, so every release prepare fails at `npm test`. This completes the rework's own test alignment.

## Verification (fleet, never local)
gorky, branch `fix/stale-fallback-default-chain-tests`:
```
bunx vitest --run test/settings-manager-retry-fallback.test.ts test/suite/model-fallback-command.test.ts \
  test/suite/retry-fallback-chains.test.ts test/suite/retry-fallback-expansion.test.ts test/suite/retry-fallback-engine.test.ts
 Test Files  5 passed (5)
```
Release-run failures these tests caused: run 33952495736, `No fallback chains configured` assertion mismatches in both files.

## Residual risk
None beyond test expectations; no production code changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the two fallback test suites that still pinned the removed shipped default chains and wildcard lane, so `npm test` passes on main again after the require-explicit-chains rework.

- Both files now assert the new contract: chains are empty by default, only configured keys resolve, malformed input degrades to empty, and availability filtering applies to configured chains.
- The listing tests write chains into the per-test `SENPI_CODING_AGENT_DIR`, the path `SettingsManager.create` actually reads.
- No production code changed; only test expectations.

<sup>Written for commit fb95d7024c40951ba082e94588c1aece0a70f9c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

