### PR TITLE
fix(coding-agent): preserve beta.36 working indicator animation

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Restored the literal `Working` text shimmer and formatter by removing duplicate working status indicator construction.
 - Favorite-model cycling (Ctrl+P) no longer breaks callers that predate the skipped-model list, and it raises the documented model-usability budget error again when the single alternative cannot host the current context instead of silently staying on the current model.
 
 ### Changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-05 - Restore Working text shimmer formatter
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` no longer constructs a duplicate working status indicator, preserving the literal `Working` text shimmer and formatter wiring.
+
+### Why
+
+- The duplicate construction overwrote the beta.36 conditional chrome-vs-default indicator and its shimmer formatter.
+
+### Why an extension could not handle it
+
+- `InteractiveMode.setWorkingVisible` is engine-owned interactive TUI behavior below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: `InteractiveMode.setWorkingVisible` working-indicator construction.
+
 ## 2026-09-05 - Ctrl+P skips favorites without context room
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3182,13 +3182,6 @@ export class InteractiveMode {
 							this.getWorkingIndicatorOptions(),
 						),
 			);
-			this.showStatusIndicator(
-				new WorkingStatusIndicator(
-					this.ui,
-					this.workingMessage ?? this.defaultWorkingMessage,
-					this.workingIndicatorOptions,
-				),
-			);
 		}
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/test/working-indicator-construction.test.ts
+++ b/packages/coding-agent/test/working-indicator-construction.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("working indicator construction", () => {
+	it("uses the configured chrome indicator without a duplicate fallback", () => {
+		const source = readFileSync(
+			resolve(import.meta.dirname, "../src/modes/interactive/interactive-mode.ts"),
+			"utf8",
+		);
+		const method = source.match(/\tprivate setWorkingVisible\(visible: boolean\): void \{([\s\S]*?)\n\t\}\n\n\tprivate setWorkingIndicator/);
+		expect(method).not.toBeNull();
+		const body = method?.[1] ?? "";
+		expect(body).toMatch(/this\.chrome\s*[\s\S]*?createWorkingIndicator/);
+		expect(body.match(/this\.showStatusIndicator\(/g)).toHaveLength(1);
+		expect(body).not.toMatch(/this\.showStatusIndicator\(\s*new WorkingStatusIndicator/);
+	});
+});


### PR DESCRIPTION
## Summary
Restore beta.36 working-text animation and formatter behavior by removing the duplicate unconditional status-indicator construction in `InteractiveMode.setWorkingVisible`.

## Behavior and regression
- **Beta.36 behavior:** `setWorkingVisible` constructs exactly one indicator through the conditional chrome-vs-default path: `chrome.createWorkingIndicator(...)` when chrome is available, otherwise `new WorkingStatusIndicator(...)`. That preserves the literal `Working` shimmer formatter, interval, and elapsed-time wiring.
- **Current regression:** `origin/main` performs that conditional construction and then unconditionally calls `showStatusIndicator(new WorkingStatusIndicator(...))` a second time. The second instance overwrites the selected formatter/options and breaks the beta.36 working-text animation parity.

## Reproduction evidence
- Exact regression comparison and source-level reproduction: `/Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/working-text-animation/beta-current-interactive-mode.diff`
- Focused red/green source proof: `/Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/working-text-animation/upstream-fix/red-green-source-proof.md`
- Captured real-surface regression: `/Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/L8-real-surface/ARM-A-RED/terminal.txt`
- Captured fixed real-surface result: `/Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/L8-real-surface/ARM-B-GREEN/terminal.txt`

## Fix
Commit `cc1e0a76d4afdf0e3de7dff2fdc234ee1ad08404` deletes only the seven-line unconditional `showStatusIndicator(new WorkingStatusIndicator(...))` block. No other source files are changed.

## Tests / QA
- Focused source-level red/green proof passed; the proof confirms one `showStatusIndicator` call remains inside the chrome-vs-default conditional.
- Real-surface RED/GREEN captures are recorded at the evidence paths above.
- No Bun test suite was run locally.
- LSP diagnostics were not clean in the isolated worktree because workspace dependencies/types are unavailable; this is an environment limitation, not a diagnostic caused by the deletion.

## Downstream note
`omo` must consume a later published Senpi version containing this fix before pin integration. This PR does not merge or publish a package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the beta.36 working-text shimmer animation by removing the duplicate unconditional `showStatusIndicator` call in `InteractiveMode.setWorkingVisible`, so only the conditional chrome-vs-default path constructs the indicator.

- The extra instance overwrote the selected formatter and broke the animation.
- Adds a regression test asserting exactly one indicator construction path remains.
- CHANGELOG entry documents the fix.
- `omo` must consume a later Senpi release containing this fix before pin integration.

<sup>Written for commit 8f78992034d11f0d15b39fb0bca4d5a23743ff6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

