### PR TITLE
test(coding-agent): move the last shipped-default fallback fixtures onto explicit chains

### DIFF
--- a/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
+++ b/packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts
@@ -22,11 +22,19 @@ describe("model fallback host wiring", () => {
 		while (harnesses.length > 0) harnesses.pop()?.cleanup();
 	});
 
-	it("uses the first available candidate from the shipped Fable 5 chain", async () => {
+	it("uses the first available candidate from a configured Fable 5 chain", async () => {
 		const harness = await createHarness({
 			provider: "anthropic",
 			models: [{ id: "claude-fable-5" }, { id: "claude-opus-5" }, { id: "claude-opus-4-8" }],
-			settings: { retry: { enabled: true, baseDelayMs: 1, maxRetries: 0 } },
+			// No shipped default exists any more; the chain must be configured explicitly.
+			settings: {
+				retry: {
+					enabled: true,
+					baseDelayMs: 1,
+					maxRetries: 0,
+					fallbackChains: { "claude-fable-5": ["claude-opus-5:xhigh", "claude-opus-4-8:xhigh"] },
+				},
+			},
 		});
 		harnesses.push(harness);
 		harness.setResponses([
@@ -34,7 +42,7 @@ describe("model fallback host wiring", () => {
 			fauxAssistantMessage("recovered"),
 		]);
 
-		await harness.session.prompt("use the default Fable fallback chain");
+		await harness.session.prompt("use the configured Fable fallback chain");
 
 		expect(harness.eventsOfType("retry_fallback_applied")).toMatchObject([
 			{ from: "anthropic/claude-fable-5", to: "anthropic/claude-opus-5" },
@@ -52,8 +60,7 @@ describe("model fallback host wiring", () => {
 
 		expect(harness.settingsManager.getRawFallbackChains()).toBeUndefined();
 		await getFallbackCommand(harness).handler(`${primary} ${fallback}`, context);
-		// The quick-set chain is what must reach the engine; shipped defaults for
-		// other models stay resolved alongside it.
+		// The quick-set chain is what must reach the engine.
 		expect(harness.settingsManager.getRetryFallbackSettings().chains[primary]).toEqual([fallback]);
 
 		harness.setResponses([

--- a/packages/coding-agent/test/suite/retry-fallback-expansion-eligibility.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion-eligibility.test.ts
@@ -1,7 +1,6 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { canonicalizeFallbackChains } from "../../src/core/retry-fallback/chains.ts";
-import { DEFAULT_FALLBACK_CHAINS } from "../../src/core/retry-fallback/settings.ts";
 
 function model(provider: string, id: string): Model<Api> {
 	return {
@@ -21,6 +20,10 @@ function model(provider: string, id: string): Model<Api> {
 
 const FABLE = "claude-fable-5";
 const OPUS5 = "claude-opus-5";
+
+// No shipped defaults exist (2026-09-05 "require explicit fallback chains"): the
+// bare-key expansion under test is driven by a user-configured bare chain.
+const BARE_CHAINS = { [FABLE]: ["k3:max", `${OPUS5}:xhigh`] };
 
 /** Registry stand-in with a deterministic per-provider eligibility gate. */
 function lookup(models: Model<Api>[], oauthProviders: string[] = [], ineligible: string[] = []) {
@@ -42,35 +45,39 @@ const catalog = [
 
 describe("bare expansion eligibility gate", () => {
 	it("excludes a provider whose registration declares the lane unusable, even with an OAuth credential", () => {
-		// The regression shape: cursor-cli-oauth holds an OAuth credential (tier 0,
-		// ranked first) but its unacknowledged --force gate guarantees a refusal.
-		// Ranking alone would hand it a top expansion slot it can never serve.
+		// The regression shape: claude-sdk-oauth holds an OAuth credential (tier 0,
+		// ranked first) but its registration declares the lane unusable. Ranking
+		// alone would hand it a top expansion slot it can never serve.
 		const chains = canonicalizeFallbackChains(
-			DEFAULT_FALLBACK_CHAINS,
-			lookup(catalog, ["cursor-cli-oauth"], ["cursor-cli-oauth"]),
+			BARE_CHAINS,
+			lookup(catalog, ["claude-sdk-oauth"], ["claude-sdk-oauth"]),
 		);
 
 		const entries = chains[`anthropic/${FABLE}`] ?? [];
 		expect(entries.length).toBeGreaterThan(0);
-		expect(entries.some((entry) => entry.startsWith("cursor-cli-oauth/"))).toBe(false);
+		expect(entries.some((entry) => entry.startsWith("claude-sdk-oauth/"))).toBe(false);
 		// The freed slot goes to a provider that can actually serve.
 		expect(entries.some((entry) => entry.includes(OPUS5))).toBe(true);
 	});
 
-	it("keeps every provider when the gate reports eligible", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, lookup(catalog, ["cursor-cli-oauth"]));
+	it("keeps an eligible OAuth provider while Cursor stays out of bare expansion by policy", () => {
+		const chains = canonicalizeFallbackChains(BARE_CHAINS, lookup(catalog, ["claude-sdk-oauth", "cursor-cli-oauth"]));
 
 		const entries = chains[`anthropic/${FABLE}`] ?? [];
-		expect(entries.some((entry) => entry.startsWith("cursor-cli-oauth/"))).toBe(true);
+		expect(entries.some((entry) => entry.startsWith("claude-sdk-oauth/"))).toBe(true);
+		// Cursor is on the bare-expansion denylist regardless of the eligibility gate;
+		// only an explicit cursor selector can route there.
+		expect(entries.some((entry) => entry.startsWith("cursor-cli-oauth/"))).toBe(false);
 	});
 
-	it("keeps providers when the registry exposes no eligibility gate", () => {
-		const chains = canonicalizeFallbackChains(DEFAULT_FALLBACK_CHAINS, {
+	it("keeps eligible providers when the registry exposes no eligibility gate", () => {
+		const chains = canonicalizeFallbackChains(BARE_CHAINS, {
 			getAll: () => catalog,
-			isUsingOAuth: (candidate: Model<Api>) => candidate.provider === "cursor-cli-oauth",
+			isUsingOAuth: (candidate: Model<Api>) => candidate.provider === "claude-sdk-oauth",
 		});
 
 		const entries = chains[`anthropic/${FABLE}`] ?? [];
-		expect(entries.some((entry) => entry.startsWith("cursor-cli-oauth/"))).toBe(true);
+		expect(entries.some((entry) => entry.startsWith("claude-sdk-oauth/"))).toBe(true);
+		expect(entries.some((entry) => entry.startsWith("cursor-cli-oauth/"))).toBe(false);
 	});
 });


### PR DESCRIPTION
## What changed
- `packages/coding-agent/test/suite/model-fallback-host-wiring.test.ts`: the "shipped Fable 5 chain" case now configures the chain explicitly (`retry.fallbackChains`) — no shipped default exists any more.
- `packages/coding-agent/test/suite/retry-fallback-expansion-eligibility.test.ts`: drops the `DEFAULT_FALLBACK_CHAINS` import (now `{}`), drives bare-key expansion from an explicit bare chain, and asserts the current policy: an ineligible OAuth lane is excluded, an eligible OAuth lane (claude-sdk-oauth) is kept, and Cursor stays out of bare expansion because it is on `BARE_EXPANSION_DENYLIST` regardless of the eligibility gate.

## Why
Follow-up to #1384: the require-explicit-chains rework (089599d89 + daa81b0ed) removed shipped defaults and denylisted Cursor from bare expansion, but these two suites still exercised the shipped chain and asserted Cursor inside it. Release run 33954412559 failed `npm test` on exactly these four cases (`expected [] to match object`, `expected 0 to be greater than 0`, two `expected false to be true`). A full sweep of `packages/coding-agent/test` for `DEFAULT_FALLBACK_CHAINS` / shipped-default fixtures shows no other file with the stale semantics.

## Verification (fleet, never local)
gorky, branch `fix/stale-fallback-tests-2`, full `packages/coding-agent` suite (`CI=1 bunx vitest --run`): neither changed file fails; every remaining failure is in gorky-sandbox-bound suites (rpc/stdio, fswatch, socket host runtime, cross-project resume) that pass in the GitHub release runs — the release job's own `npm test` remains the gate. Log: evidence `senpi-coding-agent-full-gorky.txt`.

## Residual risk
Test-only change; no production code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates two coding-agent test suites to reflect the removal of shipped default fallback chains, fixing four failing test cases.

- Tests now configure explicit fallback chains instead of relying on `DEFAULT_FALLBACK_CHAINS`, which is now empty.
- Assertions now match the current policy: eligible OAuth providers are kept in bare expansion, while Cursor is excluded via the denylist.

<sup>Written for commit 575b2c4b5fd10847a7f79c89931d5cb889cd5a54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

