### PR TITLE
test(coding-agent): assert the exact cursor provider in the bare-expansion denylist

### DIFF
--- a/packages/coding-agent/test/suite/retry-fallback-expansion-eligibility.test.ts
+++ b/packages/coding-agent/test/suite/retry-fallback-expansion-eligibility.test.ts
@@ -60,24 +60,26 @@ describe("bare expansion eligibility gate", () => {
 		expect(entries.some((entry) => entry.includes(OPUS5))).toBe(true);
 	});
 
-	it("keeps an eligible OAuth provider while Cursor stays out of bare expansion by policy", () => {
-		const chains = canonicalizeFallbackChains(BARE_CHAINS, lookup(catalog, ["claude-sdk-oauth", "cursor-cli-oauth"]));
+	it("keeps an eligible OAuth provider while the exact Cursor provider stays out of bare expansion by policy", () => {
+		// cursor (the exact denylisted provider id) never enters bare expansion even with an
+		// OAuth credential; cursor-cli-oauth is a different provider id and is NOT denylisted.
+		const withCursor = [...catalog, model("cursor", OPUS5)];
+		const chains = canonicalizeFallbackChains(BARE_CHAINS, lookup(withCursor, ["claude-sdk-oauth", "cursor"]));
 
 		const entries = chains[`anthropic/${FABLE}`] ?? [];
 		expect(entries.some((entry) => entry.startsWith("claude-sdk-oauth/"))).toBe(true);
-		// Cursor is on the bare-expansion denylist regardless of the eligibility gate;
-		// only an explicit cursor selector can route there.
-		expect(entries.some((entry) => entry.startsWith("cursor-cli-oauth/"))).toBe(false);
+		expect(entries.some((entry) => entry.startsWith("cursor/"))).toBe(false);
 	});
 
 	it("keeps eligible providers when the registry exposes no eligibility gate", () => {
+		const withCursor = [...catalog, model("cursor", OPUS5)];
 		const chains = canonicalizeFallbackChains(BARE_CHAINS, {
-			getAll: () => catalog,
-			isUsingOAuth: (candidate: Model<Api>) => candidate.provider === "claude-sdk-oauth",
+			getAll: () => withCursor,
+			isUsingOAuth: (candidate: Model<Api>) => candidate.provider === "claude-sdk-oauth" || candidate.provider === "cursor",
 		});
 
 		const entries = chains[`anthropic/${FABLE}`] ?? [];
 		expect(entries.some((entry) => entry.startsWith("claude-sdk-oauth/"))).toBe(true);
-		expect(entries.some((entry) => entry.startsWith("cursor-cli-oauth/"))).toBe(false);
+		expect(entries.some((entry) => entry.startsWith("cursor/"))).toBe(false);
 	});
 });


### PR DESCRIPTION
## What changed
`packages/coding-agent/test/suite/retry-fallback-expansion-eligibility.test.ts`: the two "Cursor stays out of bare expansion" cases now add an exact `cursor` catalog entry and assert THAT provider is excluded (with `claude-sdk-oauth` kept). The previous assertion targeted `cursor-cli-oauth`, which is a different provider id and is NOT on `BARE_EXPANSION_DENYLIST` — whether it appeared depended on OAuth-tier ranking against `MAX_PROVIDERS_PER_FAMILY = 2`, so release run 33956569977 failed on it (`expected true to be false`) while a gorky run passed.

## Why
Follow-up to #1386: makes the eligibility assertions match the real denylist semantics (exact provider id `cursor`) instead of a ranking-dependent outcome. Release run 33956569977 was otherwise fully green: 9930 passed, 1 failed (this case).

## Verification (fleet)
gorky: `bunx vitest --run test/suite/retry-fallback-expansion-eligibility.test.ts test/suite/retry-fallback-expansion.test.ts` → Test Files 2 passed (2).

## Residual risk
Test-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bare-expansion eligibility tests to assert the exact denylisted provider id `cursor` instead of `cursor-cli-oauth`, which is a different provider and not on the denylist.

- The previous assertion depended on OAuth-tier ranking and caused a release run failure; now it matches the actual `BARE_EXPANSION_DENYLIST` semantics.
- Keeps `claude-sdk-oauth` in the eligibility checks and adds a direct `cursor` catalog entry for the test.
- Test-only change, no production behavior affected.

<sup>Written for commit 54b1fd2daf0229052cce639e5aa5ee27e09b23e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

