### PR TITLE
fix(prompt-preset): name tool.monitor and the trigger in the gpt-6-astra subscription rule

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changed
 
+- The GPT-6 Astra prompt preset names the subscription form an eval session can call (`tool.monitor(...)` from the cell that starts the run) instead of gating the rule on a `monitor` tool the session withholds, lists the conditions worth a watch, and arms one the moment the user names such state, so a CI run, PR, deploy, or long command is subscribed to without being asked instead of polled.
 - The GPT-6 Astra prompt preset now treats the asynchronous form as the default for every call that offers one (child tasks and bash sessions start in the background, long eval cells detach) and names the only two cases for blocking, so a single dependent delegation is spawned in the background and the turn ends to wait instead of blocking on it.
 - The `monitor` tool's `persistent` option now reads as what it is — a standing watch: no deadline, survives a session restart (the command is re-run once, the file is rescanned and any change missed while detached is reported), expires seven days after creation, and at most five per session. The native file branch no longer claims to reject `persistent`, since a persistent file watch is exactly the one that is checkpointed and restored, and the guidance the tool description duplicated from the terminal prompt section was removed rather than restated, so the reworded switch and its bounds cost fewer prompt bytes than the wording they replace.
 

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/changes.md
@@ -1,5 +1,29 @@
 # prompt-preset Extension Changes
 
+## GPT-6 Astra: the subscription rule names `tool.monitor` and the trigger (2026-09-05)
+
+### What changed
+
+- `gpt-6-astra.ts`: `monitor-conditions` no longer opens with "WHEN `monitor` IS AVAILABLE". It reads "EVERY CONDITION YOU WOULD OTHERWISE CHECK ON GETS A SUBSCRIPTION: `tool.monitor({ description, command, filter })` FROM THE EVAL CELL THAT STARTS THE RUN" (a direct `monitor` call only in a session without `eval`), lists the conditions (a build, install, or test run finishing; a CI check or PR turning green; a deploy landing; a log line; a file appearing; another session or machine changing state), says to arm the watch the moment the model's own work starts it *or the user names it, without being asked*, and states the cost once: the subscription is the whole cost of the wait and its matching line wakes you; a cell that awaits the wait holds the js kernel until the cell limit kills it. The steer/read/stop-through-session-tools sentence is unchanged. `async-default` now names the form a wait takes - "A WAIT IS A `tool.monitor` SUBSCRIPTION - NEVER A CELL THAT SITS ON A `--watch` OR A SPAWNED PROCESS, NEVER A CHILD SPAWNED TO WATCH" - next to the three forms it already listed, and "a long eval cell detaches" becomes "a long computation detaches its eval cell". The file header records why the rule names the form and the trigger.
+- `test/suite/prompt-presets-gpt-6-astra.test.ts`: one sentinel - the rendered `## Asynchronous Work` section contains `tool.monitor(` - captured RED on `7c1de741e` and GREEN after the edit. Rule ids, concerns, placement, and the emphasis set are unchanged.
+
+### Why
+
+- Category A per the prompt-engineering skill: since 2026-09-03 `bash` and `monitor` leave the model's direct tool list whenever the session has `eval` (terminal `prompt.ts` renders `tool.monitor(...)` shapes for that branch). A rule conditioned on `monitor` being available therefore evaluated false in every eval session - the only sessions omo runs - and the model behaved as if it had no subscription primitive.
+- Evidence, 17 `gpt-6-astra-fast` sessions of 2026-09-05 (`~/.omo/agent/sessions`): `tool.monitor` appeared in three sessions, each one whose request itself named the CI run or the async work; one orchestrator session polled `task_output` 35 times (status every ~40 s on the same child) and another blocked inside eval cells on `Bun.spawn` + `setTimeout(kill, 580-880 s)` for installs, builds, and test runs. A sandboxed backtest against the real model in the eval-only tool shape (no direct `bash`/`monitor`, real eval description and terminal section, omo task tool, effort high; `/tmp/ulw-astra-monitor/monitor-run.ts`) reproduced it before the edit: 0 of 12 valid first responses across three wait-shaped requests (a 12-minute test run with parallel reading, a CI-then-merge request, and a "CI is running on my push, meanwhile inspect this file" request) registered a subscription - the model read files, opened a todo list, or started the long command with `tool.bash({ run_in_background: true })` and no filter.
+- Category B for `async-default`: it listed background bash, a detached cell, and a background child as equally good asynchronous forms and said nothing about which form a *wait* takes, so once plain polling was ruled out the model awaited `gh pr checks --watch` through `Bun.spawn` inside a cell (2 of 3 multi-round samples on a CI-then-merge request; the cell detaches, which the rule sanctioned) or spawned a `quick` child whose whole brief was "monitor PR #7801 until green, then merge" - the child is a model session polling on its behalf. The wait form is now named in the same sentence as the other forms.
+- Category C for the trigger: the old list named only waits the model had started itself, so state the user mentioned (a CI run on their push) never became a watch. The GPT-5.6 guide's tool-routing rule applies - name the route when it is not obvious; generic "use it efficiently" wording does not produce it - and its decision-rule preference over absolute wording: "every condition you would otherwise check on" is the decision rule, and the bold/caps emphasis on this rule stays by the owner's standing direction.
+- Token cost (o200k, eval-only shape with the terminal section, same tool set): rendered prompt 4392 -> 4565; the async section 289 -> 451 carries the call form, the no-`eval` fallback, the trigger list, the wait-form clause in `async-default`, the in-scope clause for user-named state, and the one-sentence cost; the availability gate and the old four-item list were removed to pay for part of it. Nothing outside the two rules changed.
+- Real-model result (multi-round harness, effort high, 3 samples per cell, old = 7c1de741e preset, new = this change plus the senpi-codemode GPT dialect fix): a 12-minute test run with parallel reading 0/3 -> 3/3 `tool.monitor`; CI-then-merge 1/3 -> 3/3; "CI is running on my push, meanwhile inspect this file" 0/3 -> 2/3, the new samples arming `gh run watch <id> --exit-status` next to the read. With the ultrawork directive attached (2 samples per cell): CI-then-merge 0/2 -> 2/2. Evidence: `/tmp/ulw-astra-monitor/evidence/mr{3,4,5}-*/<request>/summary.json` on mengmotaHost.
+
+### Why extension system couldn't handle this differently
+
+- Content-only change inside this builtin's rule data.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: `gpt-6-astra.ts` and its test are fork-only.
+
 ## GPT-6 Astra: asynchronous is the default form of every call (2026-09-05)
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-6-astra.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/prompt-preset/gpt-6-astra.ts
@@ -44,6 +44,12 @@
 // result. A child task never meets the exception, even when its result is
 // the next input: an orchestrator that blocks on one child at a time forfeits
 // every other track, which is the failure this section exists to prevent.
+// The subscription rule names the form the session can call - `bash` and
+// `monitor` leave the direct tool list whenever `eval` exists, so
+// `tool.monitor` inside a cell is the only form there is and a rule
+// conditioned on `monitor` being available never fires - and names the
+// trigger as state the user mentions, not only a wait the model itself
+// started.
 // Codex's own Astra template runs "code mode only"
 // (`functions.exec` batching independent calls with Promise.allSettled), so
 // senpi's eval-first orchestration rules fit Astra's prior directly.
@@ -169,7 +175,7 @@ const TODO_GRANULARITY =
 	"Given a todo tool, cut multi-step work into the smallest items that still stand alone - an edit paired with the check that proves it - and move each one the instant its state changes: opened, finished, newly discovered and appended, abandoned and dropped. A one-step ask carries no list.";
 
 const ASYNC_DEFAULT =
-	"**ASYNCHRONOUS IS THE DEFAULT FORM OF EVERY CALL THAT OFFERS ONE: CHILD TASKS AND BASH SESSIONS START IN THE BACKGROUND, AND A LONG EVAL CELL DETACHES.** Each returns a handle at once and delivers its result later as a message; treat the handle like a pending async call and keep working on everything that does not need it.";
+	"**ASYNCHRONOUS IS THE DEFAULT FORM OF EVERY CALL THAT OFFERS ONE: CHILD TASKS AND BASH SESSIONS START IN THE BACKGROUND, A LONG COMPUTATION DETACHES ITS EVAL CELL, AND A WAIT IS A `tool.monitor` SUBSCRIPTION - NEVER A CELL THAT SITS ON A `--watch` OR A SPAWNED PROCESS, NEVER A CHILD SPAWNED TO WATCH.** Each returns a handle at once and delivers its result later as a message; treat the handle like a pending async call and keep working on everything that does not need it.";
 
 const FOREGROUND_EXCEPTION =
 	"Block only on a call that finishes within the time a reply takes and decides your very next call, or on an approval-gated or destructive action you must watch directly. A child task never meets the first test, even when its result is your next input; spawn it in the background and let the completion deliver it.";
@@ -178,7 +184,7 @@ const TURN_END_IS_WAIT =
 	"**THERE IS NO WAIT TOOL. WHEN THE NEXT STEP NEEDS A PENDING RESULT, END YOUR TURN; THE COMPLETION WAKES YOU AND THE TASK CONTINUES.** Repeated status reads, sleeps, and timed retries replay the whole context for nothing; a single peek serves a midpoint decision only.";
 
 const MONITOR_CONDITIONS =
-	"**WHEN `monitor` IS AVAILABLE, USE IT FOR EVERY OBSERVABLE WAIT** - a log line, a build or test run finishing, a file appearing, a check turning green: register it, from inside the same cell when the run starts there, and keep working. Steer, read, or stop a running session or child through its session tools instead of launching a duplicate.";
+	"**EVERY CONDITION YOU WOULD OTHERWISE CHECK ON GETS A SUBSCRIPTION: `tool.monitor({ description, command, filter })` FROM THE EVAL CELL THAT STARTS THE RUN** (a direct `monitor` call only in a session without `eval`). A build, install, or test run finishing, a CI check or PR turning green, a deploy landing, a log line, a file appearing, another session or machine changing state: arm the watch the moment your work starts it or the user names it. A run, check, PR, or deploy the user mentions is in scope even when the ask is about something else - it gets its watch in the same turn, without being asked. The subscription is the whole cost of the wait and its matching line wakes you; a cell that awaits the wait holds the js kernel until the cell limit kills it. Steer, read, or stop a running session or child through its session tools instead of launching a duplicate.";
 
 const VERIFICATION_ONCE =
 	"Broaden or repeat checks only when a new change, a failure, or an open concern justifies it; otherwise keep moving toward completion.";

--- a/packages/coding-agent/test/suite/prompt-presets-gpt-6-astra.test.ts
+++ b/packages/coding-agent/test/suite/prompt-presets-gpt-6-astra.test.ts
@@ -296,6 +296,15 @@ describe("GPT-6 Astra behavior contract", () => {
 		}
 	});
 
+	it("names the eval-cell form of the monitor subscription in Asynchronous Work", () => {
+		// given: bash and monitor leave the direct tool list whenever eval exists, so
+		// the only callable form of a subscription is tool.monitor(...) inside a cell.
+		const sections = sectionsOf(buildPrompt("gpt-6-astra", "gpt-6-astra"));
+
+		// then
+		expect(sections.get("Asynchronous Work")).toContain("tool.monitor(");
+	});
+
 	it("keeps the shared GPT code-execution routing bridge and file-operations tuning once each", () => {
 		// given
 		const prompt = buildPrompt("gpt-6-astra", "gpt-6-astra");

--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- The GPT eval dialect now routes a wait or a long run through `tool.monitor` inside the cell (the subscription line precedes the detach note, and the `## Tool Guidelines` line says so when `monitor` is reachable), so a GPT model no longer reads "long cells detach" as the way to wait on a `--watch`.
+
 ### Fixed
 
 ### Removed

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,40 @@
 # senpi-codemode fork changes
 
+## 2026-09-05 - GPT eval dialect routes waits through tool.monitor
+
+### What changed
+
+- `src/prompt/eval-prompt.ts`: in `<gpt_eval_dialect>` the `tool.monitor` line moves ahead of the
+  detach line and reads "A wait or a long run (build, test run, deploy, watch) starts through
+  `tool.monitor({ command, filter })` in that same cell with the decisive-line filter; its event wakes
+  the turn, so no cell sits on the wait and no child is spawned for it." The detach sentence is
+  unchanged and now describes computation cells. The GPT batching guideline (the line senpi renders
+  under `## Tool Guidelines`) becomes monitor-aware: with `monitor` reachable it reads "Use eval to
+  compose tool work in one cell; a wait or a long run starts through `tool.monitor` in that cell, so
+  no cell sits on it and nothing polls."; without it the previous detach wording stays.
+- `test/prompt.test.ts`: pins the monitor-aware guideline copy for `gpt-5.6` with `monitor: true`,
+  and that the gpt description names `tool.monitor(` before "detach on timeout" and carries "no cell
+  sits on the wait". Existing gating and dialect assertions are unchanged.
+
+### Why
+
+- The GPT guideline said "long cells detach on timeout and notify on completion, so do not poll" -
+  the only wait mechanism the system prompt named for GPT models, while the subscription route lived
+  three lines down in the tool description. A multi-round backtest against the real `gpt-6-astra`
+  (eval-only tool shape) showed the consequence on a CI-then-merge request: 2 of 3 samples awaited
+  `gh pr checks --watch` through `Bun.spawn` inside a cell, a form the guideline sanctioned. Two routes
+  for one situation is the contradiction the GPT-5.6 guide warns about; the guideline now names the
+  route, the description states the cost once (a cell that waits holds the kernel; a child spawned
+  to watch burns a session), and the detach fact stays as mechanics rather than advice.
+
+### Why extension system couldn't handle this differently
+
+- Prompt text owned by this package; no runtime behavior changed.
+
+### Expected merge conflict zones on next upstream sync
+
+- LOW: fork-only dialect text and its test.
+
 ## 2026-09-04 - eval tool description diet, second pass
 
 ### What changed

--- a/packages/senpi-codemode/src/prompt/eval-prompt.ts
+++ b/packages/senpi-codemode/src/prompt/eval-prompt.ts
@@ -77,9 +77,9 @@ const EVAL_PROMPT_TEMPLATE = `Run one step of code in a persistent kernel.
 {{#if monitor}}- Start long-running work (build, test run, deploy, or watch) through \`tool.monitor({ command, filter })\`, putting the decisive-line filter inside the same cell, then keep working until its event wakes the turn.{{/if}}
 </eval_first_batching>{{/if}}{{#if styleGpt}}<gpt_eval_dialect>
 GPT eval: compose multi-tool work inside one cell with \`tool.<name>(args)\` and \`parallel(thunks)\`; do not split a planned step into serial tool calls.
-- Long cells detach on timeout and notify on completion; do not poll or re-run them.
+{{#if monitor}}- A wait or a long run (build, test run, deploy, watch) starts through \`tool.monitor({ command, filter })\` in that same cell with the decisive-line filter; its event wakes the turn, so no cell sits on the wait and no child is spawned for it.
+{{/if}}- Long cells detach on timeout and notify on completion; do not poll or re-run them.
 - Filter, join, and aggregate tool results in the cell; return only decision-relevant facts.
-{{#if monitor}}- For long-running build, test run, deploy, or watch work, start \`tool.monitor({ command, filter })\` with the decisive-line filter in the same cell; keep working until its event wakes the turn.{{/if}}
 </gpt_eval_dialect>{{/if}}{{#if styleCodex}}Route multi-call steps through eval: one cell per step, independent lookups dispatched together via \`parallel(thunks)\`; keep work sequential only when one result determines the next action.
 - Loop or comprehend over file sets with \`read()\`/stdlib instead of reading files one call at a time; post-process \`tool.<name>()\` results programmatically — filter, join, aggregate.
 - Wrap failable calls in try/except inside the cell; a failed item degrades only itself. After two distinct failed strategies for the same fact, fall back to direct tool calls.
@@ -182,7 +182,7 @@ export function buildEvalPrompt(
 		description,
 		promptSnippet: "Run one incremental code cell in a persistent language kernel.",
 		promptGuidelines: [
-			BATCHING_GUIDELINES[style],
+			style === "gpt" && context.monitor === true ? GPT_MONITOR_BATCHING_GUIDELINE : BATCHING_GUIDELINES[style],
 			"Use eval reset only when a language kernel must be wiped; reset is scoped to the selected language.",
 		],
 	};
@@ -191,8 +191,13 @@ export function buildEvalPrompt(
 /**
  * System-prompt guideline per emphasis dialect. The default dialect carries
  * maximum emphasis so unmapped models still batch through eval; the others are
- * tuned to what steers that family reliably.
+ * tuned to what steers that family reliably. The GPT line routes waits to the
+ * subscription when `monitor` is reachable, because a GPT model that reads
+ * "long cells detach" as the way to wait awaits a `--watch` inside a cell.
  */
+const GPT_MONITOR_BATCHING_GUIDELINE =
+	"Use eval to compose tool work in one cell; a wait or a long run starts through `tool.monitor` in that cell, so no cell sits on it and nothing polls.";
+
 const BATCHING_GUIDELINES: Record<EvalEmphasisStyle, string> = {
 	default:
 		"**EVAL FIRST.** Any step needing MORE THAN ONE tool call MUST be ONE eval cell: run independent calls in parallel, wrap risky calls in try/except, and return distilled facts — NEVER a chain of single tool calls.",

--- a/packages/senpi-codemode/test/prompt.test.ts
+++ b/packages/senpi-codemode/test/prompt.test.ts
@@ -220,6 +220,9 @@ describe("buildEvalPrompt", () => {
 		expect(gpt).toContain("<gpt_eval_dialect>");
 		expect(gpt).toContain("detach on timeout");
 		expect(gpt).not.toContain("<eval_first_batching>");
+		const gptWithMonitor = buildEvalPrompt(enabled, { spawns: false, modelId: "gpt-5.6", monitor: true }).description;
+		expect(gptWithMonitor.indexOf("tool.monitor(")).toBeLessThan(gptWithMonitor.indexOf("detach on timeout"));
+		expect(gptWithMonitor).toContain("no cell sits on the wait");
 		expect(gpt).not.toContain("EVAL IS YOUR PRIMARY EXECUTION SURFACE");
 		const kimiInstruction = kimi.slice(0, kimi.indexOf("<prelude>"));
 		expect(kimiInstruction).toContain("EVAL IS YOUR SUPERPOWER");
@@ -241,6 +244,9 @@ describe("buildEvalPrompt", () => {
 		);
 		expect(guideline("gpt-5.6")).toBe(
 			"Use eval to compose tool work in one cell; long cells detach on timeout and notify on completion, so do not poll.",
+		);
+		expect(buildEvalPrompt(enabled, { spawns: false, modelId: "gpt-5.6", monitor: true }).promptGuidelines[0]).toBe(
+			"Use eval to compose tool work in one cell; a wait or a long run starts through `tool.monitor` in that cell, so no cell sits on it and nothing polls.",
 		);
 		expect(guideline("kimi-k2.6")).toBe(
 			"**EVAL IS YOUR SUPERPOWER — DEFAULT TO IT.** Execute EVERY multi-call step as ONE eval cell: run ALL independent calls simultaneously via parallel(thunks), handle failures per item in code, and return ONLY distilled facts.",


### PR DESCRIPTION
## Problem

The GPT-6 Astra preset's `monitor-conditions` rule opened with "WHEN `monitor` IS AVAILABLE, USE IT FOR EVERY OBSERVABLE WAIT". Since 2026-09-03 `bash` and `monitor` leave the model's direct tool list whenever the session has `eval`, so that gate evaluated false in every eval session - the only sessions omo runs - and the model behaved as if it had no subscription primitive. The 2026-09-05 `gpt-6-astra-fast` session traces: `tool.monitor` appeared in three sessions, each one whose request itself named the CI run or the async work; one orchestrator polled `task_output` 35 times; another blocked inside eval cells on `Bun.spawn` + `setTimeout(kill, 580-880 s)` for installs, builds, and test runs.

## Fix (prompt-engineering skill: category A + C, GPT-5.6 tool-routing rule)

`monitor-conditions` now reads: **EVERY CONDITION YOU WOULD OTHERWISE CHECK ON GETS A SUBSCRIPTION: `tool.monitor({ description, command, filter })` FROM THE EVAL CELL THAT STARTS THE RUN** (a direct `monitor` call only in a session without `eval`), lists the conditions (a build, install, or test run finishing; a CI check or PR turning green; a deploy landing; a log line; a file appearing; another session or machine changing state), and says to arm the watch the moment the model's own work starts it *or the user names it, without being asked*. Rule ids, concerns, placement, and emphasis set are unchanged; the file header records why the rule names the form and the trigger.

- Test: the rendered `## Asynchronous Work` section contains `tool.monitor(` - RED on 7c1de741e, GREEN after.
- o200k (eval-only render with the terminal section): 4392 -> 4445, all +53 in the async section; the availability gate and the old four-item list were removed. Entropy gate recorded in `prompt-preset/changes.md`.

## Verification (mengmotaMac via bunshin; nothing ran on the deploy host)

- `bun run --cwd packages/coding-agent test test/suite/prompt-presets-gpt-6-astra.test.ts test/suite/prompt-presets-execution-tooling.test.ts test/suite/prompt-presets-gpt-5-6.test.ts test/suite/prompt-presets-gpt-eval-routing.test.ts test/suite/prompt-presets-model-switch.test.ts test/suite/brand-identity.test.ts`: all passed.
- `bunx biome check` on the two touched files: clean. Root `bunx tsc --noEmit`: exit 0. Husky pre-commit (`npm run check`) passed on commit.
- Real-model backtest (sandboxed gpt-6-astra through the codex backend, real preset rendered in the eval-only tool shape, omo task tool attached, multi-round with locally executed reads and synthetic status-query outputs so the run reaches the subscribe-or-poll decision): summary appended below once the run completes.

Companion: omo PR "fix(omo-senpi): name tool.monitor in the ultrawork directive and drop the polling loop".

Model: claude-fable-5-1 via omo native (senpi), ultrawork mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GPT-6 Astra subscription rule so eval sessions actually subscribe instead of polling or blocking, and routes waits through `tool.monitor` in the GPT eval dialect so the model stops treating "long cells detach" as permission to await a `--watch` inside a cell.

**Bug Fixes**
- `monitor-conditions` previously gated on `monitor` being available; since 2026-09-03 `bash` and `monitor` leave the direct tool list whenever `eval` exists, so the gate never fired. It now names the only callable form — `tool.monitor({ description, command, filter })` from the cell that starts the run — and arms a watch for state the user mentions, including a run, check, PR, or deploy the user names even when the ask is about something else.
- Session traces and a sandboxed backtest show the old rule produced no subscriptions: one orchestrator polled `task_output` 35 times, another blocked on `Bun.spawn` kill timers, and 0 of 12 backtest responses registered a subscription; on CI-then-merge requests the model awaited `gh pr checks --watch` inside a cell in 2 of 3 samples.
- The GPT eval dialect now states the subscription route before the detach note, and the tool guideline routes a wait or long run through `tool.monitor` when reachable; without it, the previous detach wording stays.
- Adds tests pinning the rendered `## Asynchronous Work` section contains `tool.monitor(` and the monitor-aware guideline copy.
- Prompt cost rises 173 tokens in the eval-only render (4392 → 4565); rule ids, concerns, placement, and emphasis set are unchanged.

<sup>Written for commit 0b69f1aef04a691695768ff3c8b8ab9515776dbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

