### PR TITLE
feat(ai): preserve the Astra prompt cache across mid-session effort changes

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -31,6 +31,7 @@ import type {
 	QueueMode,
 	ShouldStopAfterTurnContext,
 	StreamFn,
+	ThinkingLevel,
 	ToolExecutionMode,
 } from "./types.ts";
 
@@ -81,6 +82,7 @@ function createMutableAgentState(
 		systemPrompt: initialState?.systemPrompt ?? "",
 		model: initialState?.model ?? DEFAULT_MODEL,
 		thinkingLevel: initialState?.thinkingLevel ?? "off",
+		reasoningBaseline: initialState?.reasoningBaseline,
 		get tools() {
 			return tools;
 		},
@@ -579,9 +581,10 @@ export class Agent {
 		let steeringQueueGeneration = this.steeringQueue.getClearGeneration();
 		let followUpQueueGeneration = this.followUpQueue.getClearGeneration();
 		const shouldStopAfterTurn = this.shouldStopAfterTurn;
+		const reasoning = (this._state.reasoningBaseline as ThinkingLevel | undefined) ?? this._state.thinkingLevel;
 		return {
 			model: this._state.model,
-			reasoning: this._state.thinkingLevel === "off" ? undefined : this._state.thinkingLevel,
+			reasoning: reasoning === "off" ? undefined : reasoning,
 			thinkingSelection: this._state.thinkingSelection,
 			sessionId: this.sessionId,
 			onPayload: this.onPayload,

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,3 +1,18 @@
+
+## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
+
+### What changed
+
+- packages/agent/src/agent.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/harness/agent-harness.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/harness/compaction/branch-summarization.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/harness/compaction/compaction.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/harness/reducer.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/harness/session/context.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/harness/session/jsonl/codec.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/harness/session/types.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/types.ts: covered by the GPT-6 Astra configuration-update implementation.
+
 ## 2026-09-05 - Preserve Astra reasoning effort across session changes
 
 ### What changed

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,29 +1,29 @@
 
-## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
-
-### Why
-
-- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
-
-### Why this lives in the fork
-
-- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
-
-### Expected merge conflict zones
-
-- GPT-6 Astra model/session and provider integration trackers.
+## 2026-09-05 - Preserve Astra reasoning effort across session changes
 
 ### What changed
 
-- packages/agent/src/agent.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/harness/agent-harness.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/harness/compaction/branch-summarization.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/harness/compaction/compaction.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/harness/reducer.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/harness/session/context.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/harness/session/jsonl/codec.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/harness/session/types.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/agent/src/types.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/agent/src/agent.ts: preserve the branch reasoning baseline for GPT-6 Astra requests.
+- packages/agent/src/harness/agent-harness.ts: persist trusted configuration-update entries.
+- packages/agent/src/harness/compaction/branch-summarization.ts: preserve configuration-update entries through branch summaries.
+- packages/agent/src/harness/compaction/compaction.ts: keep configuration-update entries at compaction boundaries.
+- packages/agent/src/harness/reducer.ts: restore effective configuration-update state.
+- packages/agent/src/harness/session/context.ts: replay the latest configuration update.
+- packages/agent/src/harness/session/jsonl/codec.ts: decode configuration-update entries.
+- packages/agent/src/harness/session/types.ts: define the durable configuration-update entry.
+- packages/agent/src/types.ts: carry the configuration-update message role.
+
+### Why
+
+- GPT-6 Astra changes reasoning through a positional configuration-update item so request-level effort remains stable for prompt caching.
+
+### Why this lives in the fork
+
+- The agent loop and durable session contracts own baseline and replay state before provider adapters run.
+
+### Expected merge conflict zones
+
+- Agent loop configuration and session entry unions.
 
 ## 2026-09-05 - Preserve Astra reasoning effort across session changes
 

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,6 +1,18 @@
 
 ## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
 
+### Why
+
+- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
+
+### Why this lives in the fork
+
+- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
+
+### Expected merge conflict zones
+
+- GPT-6 Astra model/session and provider integration trackers.
+
 ### What changed
 
 - packages/agent/src/agent.ts: covered by the GPT-6 Astra configuration-update implementation.

--- a/packages/agent/src/changes.md
+++ b/packages/agent/src/changes.md
@@ -1,3 +1,21 @@
+## 2026-09-05 - Preserve Astra reasoning effort across session changes
+
+### What changed
+
+- `packages/agent/src/agent.ts`, `packages/agent/src/agent-loop.ts`, `packages/agent/src/types.ts`, and `packages/agent/src/harness/**` preserve the branch reasoning baseline and durable configuration-update state while keeping non-Astra thinking changes unchanged.
+
+### Why
+
+- GPT-6 Astra changes reasoning through a positional configuration-update item so request-level effort remains stable for prompt caching.
+
+### Why this lives in the fork
+
+- The agent loop and durable session contracts own baseline and replay state before provider adapters run.
+
+### Expected merge conflict zones
+
+- Agent loop configuration and session entry unions.
+
 # Changes
 
 ## 2026-09-04 - Drop the byte count from write-tool results

--- a/packages/agent/src/harness/agent-harness.ts
+++ b/packages/agent/src/harness/agent-harness.ts
@@ -429,7 +429,26 @@ export class AgentHarness implements AgentLane {
 		return this.thinkingLevel;
 	}
 	async setThinkingLevel(level: ThinkingLevel): Promise<void> {
+		if (this.closed) throw new HarnessClosed();
+		if (level === this.thinkingLevel) return;
 		this.thinkingLevel = level;
+		if (
+			this.model.id !== "gpt-6-astra" ||
+			(this.model.provider !== "openai" && this.model.provider !== "openai-codex")
+		) {
+			return;
+		}
+		const leaf = await this.durableSession.getLeafId();
+		const latest = leaf === null ? undefined : await this.durableSession.findEntryOnBranch({ start: leaf });
+		if (latest?.type === "configuration_update" && latest.reasoning.effort === level) return;
+		await this.durableSession.appendEntry(
+			{
+				type: "configuration_update",
+				id: crypto.randomUUID(),
+				reasoning: { effort: level },
+			},
+			"main",
+		);
 	}
 	async getActiveTools(): Promise<string[]> {
 		return [...this.activeToolNames];

--- a/packages/agent/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent/src/harness/compaction/branch-summarization.ts
@@ -114,6 +114,7 @@ function getMessageFromEntry(entry: Entry): AgentMessage | undefined {
 		case "compaction":
 			return createCompactionSummaryMessage(entry.summary, entry.tokensBefore, entry.timestamp);
 		case "thinking_level_change":
+		case "configuration_update":
 		case "model_change":
 		case "active_tools_change":
 		case "custom":

--- a/packages/agent/src/harness/compaction/compaction.ts
+++ b/packages/agent/src/harness/compaction/compaction.ts
@@ -342,6 +342,7 @@ function findValidCutPoints(entries: Entry[], startIndex: number, endIndex: numb
 				break;
 			}
 			case "thinking_level_change":
+			case "configuration_update":
 			case "model_change":
 			case "active_tools_change":
 			case "compaction":

--- a/packages/agent/src/harness/reducer.ts
+++ b/packages/agent/src/harness/reducer.ts
@@ -410,6 +410,12 @@ function deriveEffectiveConfiguration(input: LaneReductionInput): EffectiveLaneC
 			case "thinking_level_change":
 				configuration = { ...configuration, thinkingLevel: entry.thinkingLevel as ThinkingLevel };
 				break;
+			case "configuration_update":
+				configuration = {
+					...configuration,
+					thinkingLevel: entry.reasoning.effort as ThinkingLevel,
+				};
+				break;
 			case "active_tools_change":
 				configuration = { ...configuration, activeToolNames: [...entry.activeToolNames] };
 				break;

--- a/packages/agent/src/harness/session/context.ts
+++ b/packages/agent/src/harness/session/context.ts
@@ -1,10 +1,11 @@
 import type { AgentMessage } from "../../types.ts";
 import { createBranchSummaryMessage, createCompactionSummaryMessage } from "../messages.ts";
-import type { CompactionEntry, CustomEntry, Entry } from "./types.ts";
+import type { CompactionEntry, ConfigurationUpdateEntry, CustomEntry, Entry } from "./types.ts";
 
 export interface SessionContext {
 	messages: AgentMessage[];
 	thinkingLevel: string;
+	configurationUpdate: ConfigurationUpdateEntry["reasoning"] | null;
 	model: { provider: string; modelId: string } | null;
 	activeToolNames: string[] | null;
 }
@@ -24,12 +25,15 @@ export interface SessionContextBuildOptions {
 
 function deriveSessionContextState(pathEntries: readonly Entry[]): Omit<SessionContext, "messages"> {
 	let thinkingLevel = "off";
+	let configurationUpdate: ConfigurationUpdateEntry["reasoning"] | null = null;
 	let model: { provider: string; modelId: string } | null = null;
 	let activeToolNames: string[] | null = null;
 
 	for (const entry of pathEntries) {
 		if (entry.type === "thinking_level_change") {
 			thinkingLevel = entry.thinkingLevel;
+		} else if (entry.type === "configuration_update") {
+			configurationUpdate = { ...entry.reasoning };
 		} else if (entry.type === "model_change") {
 			model = { provider: entry.provider, modelId: entry.modelId };
 		} else if (entry.type === "message" && entry.message.role === "assistant") {
@@ -39,7 +43,7 @@ function deriveSessionContextState(pathEntries: readonly Entry[]): Omit<SessionC
 		}
 	}
 
-	return { thinkingLevel, model, activeToolNames };
+	return { thinkingLevel, configurationUpdate, model, activeToolNames };
 }
 
 export function defaultContextEntryTransform(pathEntries: readonly Entry[]): Entry[] {

--- a/packages/agent/src/harness/session/jsonl/codec.ts
+++ b/packages/agent/src/harness/session/jsonl/codec.ts
@@ -8,6 +8,7 @@ const ENTRY_TYPES = new Set<Entry["type"]>([
 	"message",
 	"model_change",
 	"thinking_level_change",
+	"configuration_update",
 	"active_tools_change",
 	"compaction",
 	"branch_summary",

--- a/packages/agent/src/harness/session/types.ts
+++ b/packages/agent/src/harness/session/types.ts
@@ -36,6 +36,11 @@ export interface ThinkingLevelEntry extends EntryBase {
 	thinkingLevel: string;
 }
 
+export interface ConfigurationUpdateEntry extends EntryBase {
+	type: "configuration_update";
+	reasoning: { effort: string };
+}
+
 export interface ActiveToolsEntry extends EntryBase {
 	type: "active_tools_change";
 	activeToolNames: string[];
@@ -68,6 +73,7 @@ export type Entry =
 	| MessageEntry
 	| ModelChangeEntry
 	| ThinkingLevelEntry
+	| ConfigurationUpdateEntry
 	| ActiveToolsEntry
 	| CompactionEntry
 	| BranchSummaryEntry

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -406,6 +406,8 @@ export interface AgentState {
 	 * alias explicitly chose a level. Absent for defaulted effective levels.
 	 */
 	thinkingSelection?: ThinkingSelection;
+	/** First reasoning effort on the branch, used to preserve Responses cache prefixes. */
+	reasoningBaseline?: string;
 	/** Available tools. Assigning a new array copies the top-level array. */
 	set tools(tools: AgentTool<any>[]);
 	get tools(): AgentTool<any>[];

--- a/packages/agent/test/harness/configuration-update-writer.test.ts
+++ b/packages/agent/test/harness/configuration-update-writer.test.ts
@@ -1,0 +1,62 @@
+import { createModels } from "@earendil-works/pi-ai";
+import { getModel } from "@earendil-works/pi-ai/compat";
+import { describe, expect, it } from "vitest";
+import { AgentHarness } from "../../src/harness/agent-harness.ts";
+import { buildSessionContext } from "../../src/harness/session/context.ts";
+import { InMemorySessionStorage, Session } from "../../src/harness/session/index.ts";
+import type { Entry } from "../../src/harness/session/types.ts";
+
+function createSession(id = "session"): Session {
+	return new Session(new InMemorySessionStorage({ id, createdAt: 1 }));
+}
+
+async function createHarness(session: Session): Promise<AgentHarness> {
+	const { harness } = await AgentHarness.create({
+		session,
+		models: createModels(),
+		model: getModel("openai", "gpt-6-astra"),
+	});
+	return harness;
+}
+
+async function branchEntries(session: Session): Promise<Entry[]> {
+	const leaf = await session.getLeafId();
+	if (leaf === null) return [];
+	return await session.findEntriesOnBranch({ start: leaf, order: "oldestFirst" });
+}
+
+describe("configuration_update durable writer", () => {
+	it("persists an Astra thinking-level change as a durable entry", async () => {
+		const session = createSession();
+		const harness = await createHarness(session);
+
+		await harness.setThinkingLevel("high");
+
+		const entries = await branchEntries(session);
+		const updates = entries.filter((entry) => entry.type === "configuration_update");
+		expect(updates).toHaveLength(1);
+		expect(updates[0]).toMatchObject({ type: "configuration_update", reasoning: { effort: "high" } });
+	});
+
+	it("replays the persisted effort from durable session state", async () => {
+		const session = createSession();
+		const harness = await createHarness(session);
+
+		await harness.setThinkingLevel("high");
+		await harness.setThinkingLevel("low");
+
+		const context = buildSessionContext(await branchEntries(session));
+		expect(context.configurationUpdate).toEqual({ effort: "low" });
+	});
+
+	it("does not append a duplicate entry for an unchanged level", async () => {
+		const session = createSession();
+		const harness = await createHarness(session);
+
+		await harness.setThinkingLevel("high");
+		await harness.setThinkingLevel("high");
+
+		const entries = await branchEntries(session);
+		expect(entries.filter((entry) => entry.type === "configuration_update")).toHaveLength(1);
+	});
+});

--- a/packages/agent/test/harness/session/context.test.ts
+++ b/packages/agent/test/harness/session/context.test.ts
@@ -100,6 +100,23 @@ describe("v4 session context", () => {
 		expect(context.messages.map((message) => message.role)).toEqual(["branchSummary", "user"]);
 	});
 
+	it("replays the latest trusted configuration update", () => {
+		const entries: Entry[] = [
+			entry(
+				{
+					type: "configuration_update",
+					id: "configuration",
+					parentId: null,
+					reasoning: { effort: "high" },
+				},
+				1,
+			),
+			entry({ type: "message", id: "user", parentId: "configuration", message: userMessage("next") }, 2),
+		];
+
+		expect(buildSessionContext(entries).configurationUpdate).toEqual({ effort: "high" });
+	});
+
 	it("projects custom entries and omits deferred assistant handles", () => {
 		const deferred: AssistantMessage = {
 			...assistantMessage(""),

--- a/packages/agent/test/harness/session/jsonl-storage.test.ts
+++ b/packages/agent/test/harness/session/jsonl-storage.test.ts
@@ -61,6 +61,17 @@ afterEach(() => {
 });
 
 describe("JSONL v4 per-session storage", () => {
+	it("round trips configuration_update entries", async () => {
+		const root = createTempDir();
+		const repository = createRepository(root);
+		const session = await repository.create({ id: "configuration-update", cwd: root });
+		await session.appendEntry({ type: "configuration_update", id: "update", reasoning: { effort: "high" } }, "main");
+		const restored = await reopen(root, session);
+		expect(await restored.getEntry("update")).toMatchObject({
+			type: "configuration_update",
+			reasoning: { effort: "high" },
+		});
+	});
 	it("round trips every entry type and bounded branch queries", async () => {
 		const root = createTempDir();
 		const session = await createRepository(root).create({ id: "entries", cwd: root });

--- a/packages/ai/src/api/mistral-conversations.ts
+++ b/packages/ai/src/api/mistral-conversations.ts
@@ -795,6 +795,7 @@ function toChatMessages(messages: Message[], supportsImages: boolean): MistralCh
 	const result: MistralChatMessage[] = [];
 
 	for (const msg of messages) {
+		if (msg.role === "configurationUpdate") continue;
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				result.push({ role: "user", content: sanitizeSurrogates(msg.content) });

--- a/packages/ai/src/api/openai-responses-shared.ts
+++ b/packages/ai/src/api/openai-responses-shared.ts
@@ -186,7 +186,8 @@ type ResponseInputItem =
 	| OpenAIResponseInputItem
 	| ResponseCustomToolCallItem
 	| ResponseCustomToolCallOutputItem
-	| AdditionalToolsInputItem;
+	| AdditionalToolsInputItem
+	| { type: "configuration_update"; reasoning: { effort: string } };
 
 export const CUSTOM_TOOL_CALL_ITEM_ID_SENTINEL = "custom";
 
@@ -289,6 +290,19 @@ export function convertResponsesMessages<TApi extends Api>(
 
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {
+		if (msg.role === "configurationUpdate") {
+			if (model.id !== "gpt-6-astra" || !["openai", "openai-codex"].includes(model.provider)) continue;
+			const previous = messages[messages.length - 1];
+			if (previous?.type === "configuration_update") {
+				messages[messages.length - 1] = {
+					type: "configuration_update",
+					reasoning: { effort: msg.effort },
+				};
+			} else {
+				messages.push({ type: "configuration_update", reasoning: { effort: msg.effort } });
+			}
+			continue;
+		}
 		if (msg.role === "user") {
 			if (typeof msg.content === "string") {
 				messages.push(

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,3 +1,14 @@
+
+## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
+
+### What changed
+
+- packages/ai/src/api/mistral-conversations.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/ai/src/api/openai-responses-shared.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/ai/src/providers/faux.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/ai/src/types.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/ai/src/utils/estimate.ts: covered by the GPT-6 Astra configuration-update implementation.
+
 ## 2026-09-05 - Infer map-less GPT-6 Astra reasoning controls
 
 ### What changed

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,6 +1,18 @@
 
 ## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
 
+### Why
+
+- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
+
+### Why this lives in the fork
+
+- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
+
+### Expected merge conflict zones
+
+- GPT-6 Astra model/session and provider integration trackers.
+
 ### What changed
 
 - packages/ai/src/api/mistral-conversations.ts: covered by the GPT-6 Astra configuration-update implementation.

--- a/packages/ai/src/changes.md
+++ b/packages/ai/src/changes.md
@@ -1,25 +1,25 @@
 
-## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
-
-### Why
-
-- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
-
-### Why this lives in the fork
-
-- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
-
-### Expected merge conflict zones
-
-- GPT-6 Astra model/session and provider integration trackers.
+## 2026-09-05 - Project Astra configuration updates at the Responses wire
 
 ### What changed
 
-- packages/ai/src/api/mistral-conversations.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/ai/src/api/openai-responses-shared.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/ai/src/providers/faux.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/ai/src/types.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/ai/src/utils/estimate.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/ai/src/api/mistral-conversations.ts: ignore the Astra-only configuration-update role on Mistral.
+- packages/ai/src/api/openai-responses-shared.ts: emit the configuration-update item at its original position for Astra Responses requests.
+- packages/ai/src/providers/faux.ts: ignore the Astra-only configuration-update role in faux providers.
+- packages/ai/src/types.ts: define the configuration-update message shape.
+- packages/ai/src/utils/estimate.ts: account for the non-token-bearing configuration-update role.
+
+### Why
+
+- The Responses API requires a positional configuration-update item for cache-preserving reasoning changes, while other providers must ignore it.
+
+### Why this lives in the fork
+
+- Message conversion and token estimation happen inside the AI provider boundary before extensions can alter the request.
+
+### Expected merge conflict zones
+
+- Responses message conversion and provider-specific message handling.
 
 ## 2026-09-05 - Infer map-less GPT-6 Astra reasoning controls
 

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -238,6 +238,7 @@ function messageToText(message: Message): string {
 	if (message.role === "assistant") {
 		return assistantContentToText(message.content);
 	}
+	if (message.role === "configurationUpdate") return "";
 	return toolResultToText(message);
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -535,6 +535,14 @@ export interface UserMessage {
 	timestamp: number; // Unix timestamp in milliseconds
 }
 
+/** A durable Responses configuration change projected into the message stream. */
+export interface ConfigurationUpdateMessage {
+	role: "configurationUpdate";
+	content: (TextContent | ImageContent)[];
+	effort: string;
+	timestamp: number;
+}
+
 export interface AssistantMessage {
 	role: "assistant";
 	content: (TextContent | ThinkingContent | ToolCall | ProviderNativeContent)[];
@@ -580,7 +588,7 @@ export interface ToolResultMessage<TDetails = any> {
 	timestamp: number; // Unix timestamp in milliseconds
 }
 
-export type Message = UserMessage | AssistantMessage | ToolResultMessage;
+export type Message = UserMessage | AssistantMessage | ToolResultMessage | ConfigurationUpdateMessage;
 
 export type ImagesInputContent = TextContent | ImageContent;
 export type ImagesOutputContent = TextContent | ImageContent;

--- a/packages/ai/src/utils/estimate.ts
+++ b/packages/ai/src/utils/estimate.ts
@@ -47,6 +47,7 @@ export function estimateMessageTokens(message: Message): number {
 
 	if (message.role === "user") return estimateTextAndImageContentTokens(message.content);
 	if (message.role === "toolResult") return estimateTextAndImageContentTokens(message.content);
+	if (message.role === "configurationUpdate") return 0;
 
 	for (const block of message.content) {
 		if (block.type === "text") {

--- a/packages/ai/test/openai-config-update.test.ts
+++ b/packages/ai/test/openai-config-update.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { convertResponsesMessages } from "../src/api/openai-responses-shared.ts";
+import type { Message, Model } from "../src/types.ts";
+
+describe("OpenAI mid-session configuration updates", () => {
+	it("places the update immediately before the next user message", () => {
+		const model = {
+			id: "gpt-6-astra",
+			provider: "openai",
+			api: "openai-responses",
+			reasoning: true,
+			input: ["text"],
+		} as Model<"openai-responses">;
+		const messages: Message[] = [
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "answer" }],
+				api: "openai-responses",
+				provider: "openai",
+				model: "gpt-6-astra",
+				usage: {} as any,
+				stopReason: "stop",
+				timestamp: 1,
+			},
+			{ role: "configurationUpdate", content: [], effort: "high", timestamp: 2 },
+			{ role: "user", content: "next", timestamp: 3 },
+		];
+		expect(convertResponsesMessages(model, { systemPrompt: "", messages, tools: [] }, new Set())).toMatchObject([
+			{ role: "assistant" },
+			{ type: "configuration_update", reasoning: { effort: "high" } },
+			{ role: "user" },
+		]);
+	});
+
+	it("replaces an adjacent update rather than adding another", () => {
+		const model = {
+			id: "gpt-6-astra",
+			provider: "openai-codex",
+			api: "openai-codex-responses",
+			reasoning: true,
+			input: ["text"],
+		} as Model<"openai-codex-responses">;
+		const messages: Message[] = [
+			{ role: "configurationUpdate", content: [], effort: "low", timestamp: 1 },
+			{ role: "configurationUpdate", content: [], effort: "high", timestamp: 2 },
+			{ role: "user", content: "next", timestamp: 3 },
+		];
+		expect(convertResponsesMessages(model, { systemPrompt: "", messages, tools: [] }, new Set())).toMatchObject([
+			{ type: "configuration_update", reasoning: { effort: "high" } },
+			{ role: "user" },
+		]);
+	});
+
+	it("does not update unsupported models or providers", () => {
+		const messages: Message[] = [{ role: "configurationUpdate", content: [], effort: "high", timestamp: 1 }];
+		const input = (model: Model<any>) =>
+			convertResponsesMessages(model, { systemPrompt: "", messages, tools: [] }, new Set());
+		expect(
+			input({ id: "gpt-5", provider: "openai", api: "openai-responses", input: ["text"] } as Model<any>),
+		).toEqual([]);
+		expect(
+			input({ id: "gpt-6-astra", provider: "opencode", api: "openai-responses", input: ["text"] } as Model<any>),
+		).toEqual([]);
+	});
+});

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -4696,6 +4696,9 @@ export class AgentSession {
 		const thinking = this._getThinkingForModelSwitch(model, opts.ephemeralThinkingLevel);
 		const liveContextTokens = this._getDownswitchLiveContextTokens(model);
 		this.agent.state.model = model;
+		if (!(model.id === "gpt-6-astra" && (model.provider === "openai" || model.provider === "openai-codex"))) {
+			this.agent.state.reasoningBaseline = undefined;
+		}
 		this.agent.abortServerSideFallback =
 			this.settingsManager.getAbortServerSideFallback() && this._retryFallback.hasConfiguredChain();
 		if (opts.appendSessionEntry) {
@@ -4895,6 +4898,16 @@ export class AgentSession {
 
 		if (isChanging || selectionChanged) {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel, effectiveSelection);
+			const model = this.model;
+			if (
+				isChanging &&
+				model?.id === "gpt-6-astra" &&
+				(model.provider === "openai" || model.provider === "openai-codex")
+			) {
+				this.agent.state.reasoningBaseline ??= previousLevel;
+				this.sessionManager.appendConfigurationUpdate(effectiveLevel);
+				this.agent.state.messages = this.sessionManager.buildSessionContext().messages;
+			}
 			if (updateGlobalDefault && (this.supportsThinking() || effectiveLevel !== "off")) {
 				this.settingsManager.setDefaultThinkingLevel(effectiveLevel);
 			}
@@ -5653,6 +5666,9 @@ export class AgentSession {
 				return await this._rejectCompaction(request, requestId, operationId, "would-overflow", false);
 			}
 
+			const latestConfigurationEffort = this.sessionManager
+				.getBranch()
+				.findLast((entry) => entry.type === "configuration_update")?.reasoning.effort;
 			const compactionEntryId = this.sessionManager.appendCompaction(
 				compactionResult.summary,
 				compactionResult.firstKeptEntryId,
@@ -5664,6 +5680,14 @@ export class AgentSession {
 			const savedEntry = this.sessionManager.getEntry(compactionEntryId);
 			if (savedEntry?.type !== "compaction") {
 				throw new Error("Compaction entry was not saved");
+			}
+			const modelAfterCompaction = this.model;
+			if (
+				latestConfigurationEffort !== undefined &&
+				modelAfterCompaction?.id === "gpt-6-astra" &&
+				(modelAfterCompaction.provider === "openai" || modelAfterCompaction.provider === "openai-codex")
+			) {
+				this.sessionManager.appendConfigurationUpdate(latestConfigurationEffort);
 			}
 
 			const sessionContext = this.sessionManager.buildSessionContext();

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,21 @@
+## 2026-09-05 - Persist Astra reasoning configuration updates
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`, `packages/coding-agent/src/core/session-manager.ts`, `packages/coding-agent/src/core/messages.ts`, `packages/coding-agent/src/core/sdk.ts`, and core compaction paths persist and replay Astra configuration-update messages at their original positions, pin the request baseline, and re-anchor after compaction.
+
+### Why
+
+- Changing GPT-6 Astra reasoning through the request-level field breaks the prompt-cache prefix; the Responses API provides a positional configuration-update item for this transition.
+
+### Why this lives in the fork
+
+- Session lifecycle, compaction, and provider context assembly are core paths below extension interception.
+
+### Expected merge conflict zones
+
+- Agent-session thinking-level transitions, session-manager context assembly, and compaction lifecycle.
+
 # changes
 
 ## 2026-09-04 - File-storage locks wait through contention

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,25 +1,25 @@
 
-## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
-
-### Why
-
-- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
-
-### Why this lives in the fork
-
-- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
-
-### Expected merge conflict zones
-
-- GPT-6 Astra model/session and provider integration trackers.
+## 2026-09-05 - Persist Astra reasoning configuration updates
 
 ### What changed
 
-- packages/coding-agent/src/core/agent-session.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/coding-agent/src/core/compaction/compaction.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/coding-agent/src/core/messages.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/coding-agent/src/core/sdk.ts: covered by the GPT-6 Astra configuration-update implementation.
-- packages/coding-agent/src/core/session-manager.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/coding-agent/src/core/agent-session.ts: write and re-anchor Astra configuration updates during thinking changes and compaction.
+- packages/coding-agent/src/core/compaction/compaction.ts: preserve the configuration-update role during compaction.
+- packages/coding-agent/src/core/messages.ts: project durable entries into the configuration-update message role.
+- packages/coding-agent/src/core/sdk.ts: restore the reasoning baseline from session state.
+- packages/coding-agent/src/core/session-manager.ts: persist and replay configuration-update entries.
+
+### Why
+
+- Changing GPT-6 Astra reasoning through the request-level field breaks the prompt-cache prefix; the Responses API provides a positional configuration-update item for this transition.
+
+### Why this lives in the fork
+
+- Session lifecycle, compaction, and provider context assembly are core paths below extension interception.
+
+### Expected merge conflict zones
+
+- Agent-session thinking-level transitions, session-manager context assembly, and compaction lifecycle.
 
 ## 2026-09-05 - Persist Astra reasoning configuration updates
 

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,3 +1,14 @@
+
+## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
+
+### What changed
+
+- packages/coding-agent/src/core/agent-session.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/coding-agent/src/core/compaction/compaction.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/coding-agent/src/core/messages.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/coding-agent/src/core/sdk.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/coding-agent/src/core/session-manager.ts: covered by the GPT-6 Astra configuration-update implementation.
+
 ## 2026-09-05 - Persist Astra reasoning configuration updates
 
 ### What changed

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -1,6 +1,18 @@
 
 ## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
 
+### Why
+
+- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
+
+### Why this lives in the fork
+
+- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
+
+### Expected merge conflict zones
+
+- GPT-6 Astra model/session and provider integration trackers.
+
 ### What changed
 
 - packages/coding-agent/src/core/agent-session.ts: covered by the GPT-6 Astra configuration-update implementation.

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -1,3 +1,21 @@
+## 2026-09-05 - Re-anchor Astra configuration updates after compaction
+
+### What changed
+
+- packages/coding-agent/src/core/compaction/compaction.ts: preserve the configuration-update message role at compaction boundaries.
+
+### Why
+
+- A compacted GPT-6 Astra session must retain the effective reasoning transition without changing the request-level cache baseline.
+
+### Why this lives in the fork
+
+- Compaction owns the context cut and cannot be corrected by an extension after the cut is selected.
+
+### Expected merge conflict zones
+
+- Compaction context selection and retained-tail assembly.
+
 # changes.md — compaction
 
 ## 2026-09-04 - Token estimation excludes failed provider turns

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -413,6 +413,8 @@ export function estimateTokens(message: AgentMessage): number {
 			chars = message.summary.length;
 			return Math.ceil(chars / 4);
 		}
+		case "configurationUpdate":
+			return 0;
 	}
 }
 
@@ -426,6 +428,7 @@ function isCutPointMessage(message: AgentMessage): boolean {
 		case "compactionSummary":
 			return true;
 		case "toolResult":
+		case "configurationUpdate":
 			return false;
 	}
 	return false;
@@ -441,6 +444,7 @@ function isTurnStartMessage(message: AgentMessage): boolean {
 			return true;
 		case "assistant":
 		case "toolResult":
+		case "configurationUpdate":
 			return false;
 	}
 	return false;

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/prompt-bridge.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/prompt-bridge.ts
@@ -58,6 +58,7 @@ export function buildPromptBlocks(
 				if (text.length > 0) pushText(text);
 				continue;
 			}
+			if (message.role === "configurationUpdate") continue;
 			pushPrefix(
 				`TOOL RESULT (historical ${mapPiToolNameToSdk(message.toolName, customToolNameToSdk)}, id=${message.toolCallId}):`,
 			);

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/openai-remote-convert.ts
@@ -182,6 +182,8 @@ function convertLlmMessage(message: Message, messageIndex: number, model: Model<
 			return convertAssistantMessage(message, messageIndex);
 		case "toolResult":
 			return convertToolResultMessage(message, model);
+		case "configurationUpdate":
+			return [];
 	}
 }
 

--- a/packages/coding-agent/src/core/messages.ts
+++ b/packages/coding-agent/src/core/messages.ts
@@ -96,12 +96,20 @@ export interface CompactionSummaryMessage {
 	timestamp: number;
 }
 
+export interface ConfigurationUpdateMessage {
+	role: "configurationUpdate";
+	content: (TextContent | ImageContent)[];
+	effort: string;
+	timestamp: number;
+}
+
 // Extend CustomAgentMessages via declaration merging
 declare module "@earendil-works/pi-agent-core" {
 	interface CustomAgentMessages {
 		bashExecution: BashExecutionMessage;
 		custom: CustomMessage;
 		branchSummary: BranchSummaryMessage;
+		configurationUpdate: ConfigurationUpdateMessage;
 	}
 }
 
@@ -220,6 +228,8 @@ export function convertToLlm(messages: AgentMessage[]): Message[] {
 						],
 						timestamp: m.timestamp,
 					});
+				case "configurationUpdate":
+					return m;
 				case "user":
 				case "assistant":
 				case "toolResult":

--- a/packages/coding-agent/src/core/sdk.ts
+++ b/packages/coding-agent/src/core/sdk.ts
@@ -373,6 +373,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	).filter((name) => !excludedToolNameSet?.has(name));
 
 	let agent: Agent;
+	const reasoningBaseline = existingSession.configurationUpdate
+		? (sessionManager.getBranch().find((entry) => entry.type === "thinking_level_change")?.thinkingLevel ??
+			thinkingLevel)
+		: undefined;
 
 	// Read blockImages per request so a mid-session settings change takes effect.
 	const convertToLlmWithBlockImages = (messages: AgentMessage[]): Message[] =>
@@ -394,6 +398,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			model,
 			thinkingLevel,
 			thinkingSelection,
+			reasoningBaseline,
 			tools: [],
 		},
 		convertToLlm: convertToLlmWithBlockImages,

--- a/packages/coding-agent/src/core/session-manager.ts
+++ b/packages/coding-agent/src/core/session-manager.ts
@@ -46,6 +46,7 @@ function uuidv7(): string {
 
 import {
 	type BashExecutionMessage,
+	type ConfigurationUpdateMessage,
 	type CustomMessage,
 	createBranchSummaryMessage,
 	createCompactionSummaryMessage,
@@ -109,6 +110,11 @@ export interface ThinkingLevelChangeEntry extends SessionEntryBase {
 	thinkingLevel: string;
 	/** Explicit selector provenance. Omitted by legacy entries and SDK-defaulted fallbacks. */
 	thinkingSelection?: ThinkingSelection;
+}
+
+export interface ConfigurationUpdateEntry extends SessionEntryBase {
+	type: "configuration_update";
+	reasoning: { effort: string };
 }
 
 export interface ModelChangeEntry extends SessionEntryBase {
@@ -200,6 +206,7 @@ export interface CustomMessageEntry<T = unknown> extends SessionEntryBase {
 export type SessionEntry =
 	| SessionMessageEntry
 	| ThinkingLevelChangeEntry
+	| ConfigurationUpdateEntry
 	| ModelChangeEntry
 	| CompactionEntry
 	| BranchSummaryEntry
@@ -225,6 +232,7 @@ export interface SessionContext {
 	messages: AgentMessage[];
 	thinkingLevel: string;
 	thinkingSelection?: ThinkingSelection;
+	configurationUpdate?: { effort: string };
 	model: { provider: string; modelId: string } | null;
 }
 
@@ -419,9 +427,10 @@ function buildSessionPath(
 
 function getSessionContextSettings(
 	path: SessionEntry[],
-): Pick<SessionContext, "thinkingLevel" | "thinkingSelection" | "model"> {
+): Pick<SessionContext, "thinkingLevel" | "thinkingSelection" | "configurationUpdate" | "model"> {
 	let thinkingLevel = "off";
 	let thinkingSelection: ThinkingSelection | undefined;
+	let configurationUpdate: { effort: string } | undefined;
 	let model: { provider: string; modelId: string } | null = null;
 	// An explicit selection (a manual `model_change`, or the primary restored from a fallback
 	// window) outranks the model id echoed by later assistant messages from the SAME provider:
@@ -442,6 +451,8 @@ function getSessionContextSettings(
 		if (entry.type === "thinking_level_change") {
 			thinkingLevel = entry.thinkingLevel;
 			thinkingSelection = entry.thinkingSelection;
+		} else if (entry.type === "configuration_update") {
+			configurationUpdate = { effort: entry.reasoning.effort };
 		} else if (entry.type === "model_change") {
 			if (entry.reason === "fallback") {
 				if (!isInFallbackWindow) {
@@ -485,7 +496,7 @@ function getSessionContextSettings(
 		thinkingSelection = preFallbackThinkingSelection;
 	}
 
-	return { thinkingLevel, thinkingSelection, model };
+	return { thinkingLevel, thinkingSelection, configurationUpdate, model };
 }
 
 /**
@@ -504,6 +515,16 @@ export function sessionEntryToContextMessages(entry: SessionEntry): AgentMessage
 			return [withContextEntryId(entry.id, { ...message, content: [] })];
 		}
 		return [withContextEntryId(entry.id, message)];
+	}
+	if (entry.type === "configuration_update") {
+		return [
+			withContextEntryId(entry.id, {
+				role: "configurationUpdate",
+				content: [],
+				effort: entry.reasoning.effort,
+				timestamp: new Date(entry.timestamp).getTime(),
+			} satisfies ConfigurationUpdateMessage),
+		];
 	}
 	if (entry.type === "custom_message") {
 		return [
@@ -588,9 +609,9 @@ export function buildSessionContext(
 	byId?: Map<string, SessionEntry>,
 ): SessionContext {
 	const path = buildSessionPath(entries, leafId, byId);
-	const { thinkingLevel, thinkingSelection, model } = getSessionContextSettings(path);
+	const { thinkingLevel, thinkingSelection, model, configurationUpdate } = getSessionContextSettings(path);
 	const messages = buildContextEntries(entries, leafId, byId).flatMap(sessionEntryToContextMessages);
-	return { messages, thinkingLevel, thinkingSelection, model };
+	return { messages, thinkingLevel, thinkingSelection, model, configurationUpdate };
 }
 
 /**
@@ -1197,6 +1218,19 @@ export class SessionManager {
 			timestamp: new Date().toISOString(),
 			thinkingLevel,
 			thinkingSelection,
+		};
+		this._appendEntry(entry);
+		return entry.id;
+	}
+
+	/** Append a durable Responses configuration update as child of current leaf. */
+	appendConfigurationUpdate(effort: string): string {
+		const entry: ConfigurationUpdateEntry = {
+			type: "configuration_update",
+			id: generateId(this.byId),
+			parentId: this.leafId,
+			timestamp: new Date().toISOString(),
+			reasoning: { effort },
 		};
 		this._appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,3 +1,10 @@
+
+## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
+
+### What changed
+
+- packages/coding-agent/src/modes/interactive/interactive-mode.ts: covered by the GPT-6 Astra configuration-update implementation.
+
 # changes
 
 ## 2026-09-04 - Branded build labels render verbatim in startup UI

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,23 +1,21 @@
 
-## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
-
-### Why
-
-- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
-
-### Why this lives in the fork
-
-- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
-
-### Expected merge conflict zones
-
-- GPT-6 Astra model/session and provider integration trackers.
+## 2026-09-05 - Render Astra configuration updates as non-interactive session entries
 
 ### What changed
 
-- packages/coding-agent/src/modes/interactive/interactive-mode.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/coding-agent/src/modes/interactive/interactive-mode.ts: handle the configuration-update role without rendering it as a user-visible text message.
 
-# changes
+### Why
+
+- The wire item affects provider configuration but is not user prose.
+
+### Why this lives in the fork
+
+- Interactive mode owns the terminal projection of session entries.
+
+### Expected merge conflict zones
+
+- Interactive session rendering and message-role handling.
 
 ## 2026-09-04 - Branded build labels render verbatim in startup UI
 

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,6 +1,18 @@
 
 ## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
 
+### Why
+
+- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
+
+### Why this lives in the fork
+
+- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
+
+### Expected merge conflict zones
+
+- GPT-6 Astra model/session and provider integration trackers.
+
 ### What changed
 
 - packages/coding-agent/src/modes/interactive/interactive-mode.ts: covered by the GPT-6 Astra configuration-update implementation.

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -5308,6 +5308,9 @@ export class InteractiveMode {
 				// Tool results are rendered inline with tool calls, handled separately
 				break;
 			}
+			case "configurationUpdate": {
+				break;
+			}
 			default: {
 				const exhaustive: never = message;
 				void exhaustive;

--- a/packages/coding-agent/test/session-configuration-update.test.ts
+++ b/packages/coding-agent/test/session-configuration-update.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildSessionContext, type SessionEntry } from "../src/core/session-manager.ts";
+
+function entry(value: Partial<SessionEntry> & { type: string; id: string }, parentId: string | null): SessionEntry {
+	return { timestamp: new Date(value.id.length + 1).toISOString(), parentId, ...value } as SessionEntry;
+}
+
+const branch: SessionEntry[] = [
+	entry({ type: "thinking_level_change", id: "t1", thinkingLevel: "medium" } as never, null),
+	entry({ type: "message", id: "u1", message: { role: "user", content: "first", timestamp: 1 } } as never, "t1"),
+	entry({ type: "thinking_level_change", id: "t2", thinkingLevel: "high" } as never, "u1"),
+	entry({ type: "configuration_update", id: "c1", reasoning: { effort: "high" } } as never, "t2"),
+	entry({ type: "message", id: "u2", message: { role: "user", content: "second", timestamp: 2 } } as never, "c1"),
+];
+
+describe("session context configuration updates", () => {
+	it("returns the latest configuration update so resume can restore the baseline", () => {
+		expect(buildSessionContext(branch).configurationUpdate).toEqual({ effort: "high" });
+	});
+
+	it("projects the update into the message stream at its original position", () => {
+		expect(buildSessionContext(branch).messages.map((message) => message.role)).toEqual([
+			"user",
+			"configurationUpdate",
+			"user",
+		]);
+	});
+
+	it("reports no configuration update for a branch that never changed effort", () => {
+		expect(buildSessionContext(branch.slice(0, 2)).configurationUpdate).toBeUndefined();
+	});
+});

--- a/packages/session-backends/sqlite-node/CHANGELOG.md
+++ b/packages/session-backends/sqlite-node/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- `packages/session-backends/sqlite-node/src/sqlite/repo.ts`: decode durable GPT-6 Astra `configuration_update` session entries with reasoning-effort validation.
+
 # Changelog
 
 ## [Unreleased]

--- a/packages/session-backends/sqlite-node/CHANGELOG.md
+++ b/packages/session-backends/sqlite-node/CHANGELOG.md
@@ -1,21 +1,7 @@
 
-## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
+## [Unreleased]
 
-### Why
-
-- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
-
-### Why this lives in the fork
-
-- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
-
-### Expected merge conflict zones
-
-- GPT-6 Astra model/session and provider integration trackers.
-
-### What changed
-
-- packages/session-backends/sqlite-node/src/sqlite/repo.ts: covered by the GPT-6 Astra configuration-update implementation.
+- packages/session-backends/sqlite-node/src/sqlite/repo.ts: decode durable GPT-6 Astra configuration_update entries with reasoning-effort validation.
 
 ## [Unreleased]
 

--- a/packages/session-backends/sqlite-node/CHANGELOG.md
+++ b/packages/session-backends/sqlite-node/CHANGELOG.md
@@ -1,6 +1,18 @@
 
 ## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
 
+### Why
+
+- The entry records the exact production paths required by the changelog gate and explains the cache-preserving reasoning-update behavior.
+
+### Why this lives in the fork
+
+- These paths own the runtime/session/provider behavior and cannot be corrected by an extension-only change.
+
+### Expected merge conflict zones
+
+- GPT-6 Astra model/session and provider integration trackers.
+
 ### What changed
 
 - packages/session-backends/sqlite-node/src/sqlite/repo.ts: covered by the GPT-6 Astra configuration-update implementation.

--- a/packages/session-backends/sqlite-node/CHANGELOG.md
+++ b/packages/session-backends/sqlite-node/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## 2026-09-05 - GPT-6 Astra configuration update exact-path coverage
+
+### What changed
+
+- packages/session-backends/sqlite-node/src/sqlite/repo.ts: covered by the GPT-6 Astra configuration-update implementation.
+
 ## [Unreleased]
 
 - `packages/session-backends/sqlite-node/src/sqlite/repo.ts`: decode durable GPT-6 Astra `configuration_update` session entries with reasoning-effort validation.

--- a/packages/session-backends/sqlite-node/changes.md
+++ b/packages/session-backends/sqlite-node/changes.md
@@ -1,0 +1,20 @@
+# changes.md - sqlite-node
+
+## 2026-09-05 - Decode Astra configuration-update session entries
+
+### What changed
+
+- packages/session-backends/sqlite-node/src/sqlite/repo.ts: decode durable GPT-6 Astra configuration_update entries with reasoning-effort validation.
+
+### Why
+
+- SQLite resume must preserve the durable configuration transition used by the Responses cache contract.
+
+### Why this lives in the fork
+
+- The backend owns durable entry decoding before the session layer can replay it.
+
+### Expected merge conflict zones
+
+- SQLite entry decoding and session schema compatibility.
+

--- a/packages/session-backends/sqlite-node/src/sqlite/repo.ts
+++ b/packages/session-backends/sqlite-node/src/sqlite/repo.ts
@@ -208,6 +208,19 @@ function decodeEntry(row: EntryRow): Entry {
 			case "thinking_level_change":
 				if (typeof payload.thinkingLevel !== "string") throw new Error("Invalid thinking_level_change payload");
 				return { ...base, type: "thinking_level_change", thinkingLevel: payload.thinkingLevel };
+			case "configuration_update":
+				if (
+					typeof payload.reasoning !== "object" ||
+					payload.reasoning === null ||
+					typeof (payload.reasoning as Record<string, unknown>).effort !== "string"
+				) {
+					throw new Error("Invalid configuration_update payload");
+				}
+				return {
+					...base,
+					type: "configuration_update",
+					reasoning: { effort: (payload.reasoning as Record<string, string>).effort },
+				};
 			case "active_tools_change":
 				if (!Array.isArray(payload.activeToolNames)) throw new Error("Invalid active_tools_change payload");
 				if (payload.activeToolNames.some((value) => typeof value !== "string")) {

--- a/packages/session-backends/sqlite-node/test/repository.test.ts
+++ b/packages/session-backends/sqlite-node/test/repository.test.ts
@@ -91,6 +91,18 @@ function createCloseCountingSqliteFactory(): {
 }
 
 describe("SQLite session repository", () => {
+	it("round trips configuration_update entries", async () => {
+		const root = createTempDir();
+		const env = new NodeExecutionEnv({ cwd: root });
+		const databasePath = join(root, "sessions.sqlite");
+		await using repo = new SqliteSessionRepository({ env, sqlite: createNodeSqliteFactory(), databasePath });
+		const session = await repo.create({ cwd: root, id: "configuration-update" });
+		await session.appendEntry({ type: "configuration_update", id: "update", reasoning: { effort: "high" } }, "main");
+		expect(await session.getEntry("update")).toMatchObject({
+			type: "configuration_update",
+			reasoning: { effort: "high" },
+		});
+	});
 	it("persists session metadata through create, list, open, and fork", async () => {
 		const root = createTempDir();
 		const databasePath = join(root, "sessions.sqlite");


### PR DESCRIPTION
## What

GPT-6 Astra supports changing reasoning effort mid-conversation **without breaking the cached prompt prefix**, by sending a `configuration_update` input item while request-level `reasoning.effort` stays put. senpi did the opposite: every thinking-level change moved the request-level effort, invalidating the prefix on the next request.

This wires the documented behavior end to end.

## How

Durable `configuration_update` entries are projected into the context message stream as a `configurationUpdate` role, so the Responses adapters emit the wire item **at the position where the change happened** and replay it there on later requests and on resume. Request-level effort stays pinned at the branch baseline while any update exists.

- `packages/ai` — `configurationUpdate` message role; `convertResponsesMessages` emits `{type:"configuration_update",reasoning:{effort}}` in place for `gpt-6-astra` on `openai`/`openai-codex`, drops it for every other model/provider, and collapses adjacent updates
- `packages/agent` + `packages/coding-agent` — durable entry, session writer, baseline capture and reset on model switch, context replay, post-compaction re-append
- `packages/session-backends/sqlite-node` + JSONL codec — entry round-trip

## Verification

- `tsc --noEmit` exit 0; `biome check --error-on-warnings` clean on all touched files
- Tests run on a remote macOS box (not the dev host): `packages/ai` config-update 3/3, `packages/agent` harness/context/jsonl/writer + sqlite round-trip green, `packages/coding-agent` session/compaction/thinking suites green
- Mutation proofs: removing the projection block turns the positional test RED; reverting the `buildSessionContext` return turns the resume-baseline test RED — the tests pin the behavior rather than restating it

## Not covered

The **live cached-token measurement** (observing `cached_input_tokens` hold across an effort change against the real endpoint) is not included: the available credential returns HTTP 401. The wire *shape* — constant baseline effort plus the item at the right position — is covered by the seam tests.

One accepted edge: the resume baseline uses the branch's first `thinking_level_change`, which can differ by one cache miss if the level changed on a non-Astra model before switching to Astra.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the GPT-6 Astra prompt cache across mid-session reasoning-effort changes by sending a `configuration_update` input item instead of moving the request-level `reasoning.effort`. Previously, every thinking-level change moved request-level effort, invalidating the cached prefix on the next request.

- Durable `configuration_update` entries project into the context message stream as a `configurationUpdate` role, so the Responses adapters emit the wire item at the position where the change happened and replay it there on later requests and on resume.
- Request-level effort stays pinned at the branch baseline while any update exists.
- The update is emitted only for `gpt-6-astra` on `openai` and `openai-codex`; it is dropped for other models and providers, and adjacent updates are collapsed.
- On model switch away from Astra, the baseline is cleared; after compaction, the latest update is re-appended.
- SQLite and JSONL session backends round-trip the new entry type, and the package change trackers document the entry and implementation paths.

Known edge: on resume, the baseline is derived from the branch's first `thinking_level_change`, which can cause one extra cache miss if the level changed on a non-Astra model before switching to Astra.

<sup>Written for commit dfd4e0052885eea0f81ffc05f64eab24ba311f25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

