### PR TITLE
docs(ai): record the GPT-6 Astra async-tool and steering deferral

### DIFF
--- a/packages/ai/changes.md
+++ b/packages/ai/changes.md
@@ -1,3 +1,23 @@
+# 2026-09-05 - GPT-6 Astra async tool calling and WebSocket steering: deferred with design
+
+### What changed
+
+- No runtime change. This records the binding decision to DEFER two GPT-6 Astra wire features until the agent loop supports them, with the concrete designs below.
+
+### Why deferred
+
+- Async tool calling (`async: true`, late outputs on the original `call_id`): the agent loop executes tools synchronously and cannot proceed with a pending call. Proof: `packages/agent/src/agent-loop.ts:297` awaits `executeToolCalls` before `turn_end`, and the parallel batch barrier `await Promise.all(finalizedCalls)` at `packages/agent/src/agent-loop.ts:966` blocks until every `call_id` has a result. The Responses adapter sends one `response.create` (`packages/ai/src/api/openai-responses.ts:807`) and releases the socket after `response.completed`, with no call-id correlation surface. A payload-only `async: true` would advertise behavior the loop cannot honor.
+- Mid-turn steering over WebSocket: steering is polled only at turn boundaries (`packages/agent/src/agent-loop.ts:212`, `:325`, `:382` via `config.getSteeringMessages()`), never during `streamAssistant` or tool execution. The subscribe target for a future loop-owned dispatcher is `Agent.steeringQueue` (`packages/agent/src/agent.ts:209`, drained at `:445`/`:483`). Both the generic and Codex adapters have their own WebSocket paths (`packages/ai/src/api/openai-codex-responses.ts:299`/`:311`/`:1520`), so a bidirectional API must be built twice.
+
+### Designs (for future adoption)
+
+- Async: a loop-owned `PendingToolCall` registry keyed by provider `call_id` with durable session ownership, cancellation, duplicate/unknown handling, and a completion event that resumes the same response conversation; the adapter must expose a bidirectional Responses connection and serialize `function_call_output` on the original `call_id`.
+- Steering: a loop-owned active-turn command channel that subscribes to steering-queue mutation, assigns ordering/turn identity, encodes the steering event on the live socket, and defines interrupt-vs-queue-vs-merge semantics plus reconnect/abort behavior.
+
+### Exit criteria
+
+- Revisit only after a failing-first integration test proves (1) a detached tool returns after the model response preserving the original `call_id`, and (2) steering sent during an active WebSocket response is observed in that same turn, both with remote green evidence.
+
 # changes.md — ai
 
 ## 2026-09-05 - Normalize GPT-6 Astra reasoning maps across OpenAI-family catalogs


### PR DESCRIPTION
## What

GPT-6 Astra adds **async tool calling** (`async:true`, late outputs on the original `call_id`) and **mid-turn steering over WebSocket**. This records the binding decision to **defer both**, with the designs that would make them viable.

## Why defer

Neither is safe to advertise today:

- **Async tools** — the agent loop awaits every tool call before the turn proceeds (`packages/agent/src/agent-loop.ts:297`, batch barrier at `:966`). The adapter sends one `response.create` and releases the socket after `response.completed`, with no call-id correlation surface. A payload-only `async:true` would emit a call the loop then blocks on anyway, or a late output on an already-released socket.
- **Mid-turn steering** — steering is polled only at turn boundaries (`agent-loop.ts:212`, `:325`, `:382`), never during streaming or tool execution, so an unsolicited frame has no consumer. Both the generic and Codex adapters carry their own WebSocket paths, so a bidirectional API would have to be built twice.

## What's here

Docs only — no runtime change. `packages/ai/changes.md` records the verdict, the loop-owned designs (a `PendingToolCall` registry keyed by `call_id`; an active-turn command channel), and the exit criteria: a failing-first integration test proving a detached tool returns on its original `call_id`, and steering observed within the same active turn.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the decision to defer GPT-6 Astra's async tool calling and mid-turn WebSocket steering until the agent loop can support them. Docs only; no runtime change.

- The loop awaits every tool call before the turn proceeds, so `async: true` would promise behavior it can't honor.
- Steering is polled only at turn boundaries, so an unsolicited frame has no consumer, and both adapters would need separate bidirectional sockets.
- Records loop-owned designs: a `PendingToolCall` registry keyed by `call_id` and an active-turn command channel.
- Exit criteria: a failing-first integration test proving a detached tool returns on its original `call_id`, and steering observed within the same active turn.

<sup>Written for commit f60a7b0e3e48827bdbb73816c01d3e797195266f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

