### PR TITLE
fix(coding-agent): restore Working text shimmer

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Restored the literal `Working` text shimmer on turn start by supplying the generated working indicator options.
+
 ### Removed
 
 ## [2026.9.5] - 2026-09-05

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -1,4 +1,18 @@
 
+## 2026-09-05 - Restore Working text shimmer on turn start
+
+### What changed
+
+- `packages/coding-agent/src/modes/interactive/interactive-mode.ts` now supplies the generated working indicator options when a turn starts.
+
+### Why
+
+- The turn-start path previously passed the unset raw options field, disabling the literal `Working` text shimmer formatter.
+
+### Why this lives in the fork
+
+- Interactive mode owns the working status indicator and its animation configuration.
+
 ## 2026-09-05 - Render Astra configuration updates as non-interactive session entries
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/changes.md
+++ b/packages/coding-agent/src/modes/interactive/changes.md
@@ -13,6 +13,14 @@
 
 - Interactive mode owns the working status indicator and its animation configuration.
 
+### Why an extension could not handle it
+
+- `InteractiveMode.showWorkingStatusIndicator` is engine-owned interactive TUI behavior below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: `InteractiveMode.showWorkingStatusIndicator` working-indicator construction.
+
 ## 2026-09-05 - Render Astra configuration updates as non-interactive session entries
 
 ### What changed

--- a/packages/coding-agent/src/modes/interactive/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive/interactive-mode.ts
@@ -3156,7 +3156,7 @@ export class InteractiveMode {
 			new WorkingStatusIndicator(
 				this.ui,
 				this.workingMessage ?? this.defaultWorkingMessage,
-				this.workingIndicatorOptions,
+				this.getWorkingIndicatorOptions(),
 			),
 		);
 	}


### PR DESCRIPTION
## Summary\n\nPass the generated working indicator options on the turn-start path so the literal Working text receives its shimmer formatter and animation interval.\n\n## Evidence\n\nCompiled PTY A/B proof from the regression report:\n- Report: /Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/L9-origin-dev-working-fix/REPORT.md\n- Control artifacts: /Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/L9-origin-dev-working-fix/working-shimmer/ and runtime-build/\n- Fixed artifacts: /Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/L9-origin-dev-working-fix/working-shimmer-fixed/ and runtime-build-fixed/\n- Comparison: /Users/yeongyu/sisyphuslabs/.omo/ulw-loop/beta36-regression-2026-09-05T05-39-37-633Z/L9-origin-dev-working-fix/frame-comparison.json\n\nCONTROL captured 0 styled frames; FIXED captured 214 styled frames and 191 style signatures over 10.9 seconds.\n\nNo local Bun tests were run per task constraint; tests are remote-only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the shimmer animation on the literal "Working" text in interactive mode by passing the generated working indicator options instead of the unset raw options field when a turn starts.

- Records the fix in `packages/coding-agent/CHANGELOG.md` and `packages/coding-agent/src/modes/interactive/changes.md`.

<sup>Written for commit 2b94905f0b8997505fb1427c239dd9bc234a61ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

