### PR TITLE
fix(coding-agent): avoid project trust read contention

### DIFF
--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -41,6 +41,24 @@
 
 # changes
 
+## 2026-09-05 - Read project trust without writer-lock contention
+
+### What changed
+
+- `packages/coding-agent/src/core/trust-manager.ts`: project-trust reads load the last published `trust.json` snapshot without acquiring the writer lock; writes remain serialized by proper-lockfile and now publish through a same-directory temporary file plus atomic rename.
+
+### Why
+
+- A trust read during another process's write previously retried the writer lock synchronously and then threw `ELOCKED`, interrupting startup and session-state projection even though the prior complete trust snapshot was safe to read.
+
+### Why an extension could not handle it
+
+- Project trust is loaded by core startup, package-command, interactive, and RPC paths before or below extension interception; only the store can separate snapshot reads from serialized read-modify-write publication.
+
+### Expected merge conflict zones
+
+- LOW: `packages/coding-agent/src/core/trust-manager.ts` read and write helpers.
+
 ## 2026-09-05 - Require explicit fallback chains
 
 ### What changed

--- a/packages/coding-agent/src/core/trust-manager.ts
+++ b/packages/coding-agent/src/core/trust-manager.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import lockfile from "proper-lockfile";
@@ -131,7 +132,21 @@ function writeTrustFile(path: string, data: TrustFile): void {
 		}
 	}
 	mkdirSync(dirname(path), { recursive: true });
-	writeFileSync(path, `${JSON.stringify(sorted, null, 2)}\n`, "utf-8");
+	const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+	try {
+		writeFileSync(tempPath, `${JSON.stringify(sorted, null, 2)}\n`, "utf-8");
+		renameSync(tempPath, path);
+	} catch (publicationError) {
+		try {
+			rmSync(tempPath, { force: true });
+		} catch (cleanupError) {
+			throw new AggregateError(
+				[publicationError, cleanupError],
+				"Failed to publish and clean up project trust snapshot",
+			);
+		}
+		throw publicationError;
+	}
 }
 
 function acquireTrustLockSync(path: string): () => void {
@@ -218,10 +233,8 @@ export class ProjectTrustStore {
 	}
 
 	getEntry(cwd: string): ProjectTrustStoreEntry | null {
-		return withTrustFileLock(this.trustPath, () => {
-			const data = readTrustFile(this.trustPath);
-			return findNearestTrustEntry(data, cwd);
-		});
+		const data = readTrustFile(this.trustPath);
+		return findNearestTrustEntry(data, cwd);
 	}
 
 	set(cwd: string, decision: ProjectTrustDecision): void {

--- a/packages/coding-agent/test/suite/regressions/project-trust-lock-contention.test.ts
+++ b/packages/coding-agent/test/suite/regressions/project-trust-lock-contention.test.ts
@@ -1,0 +1,43 @@
+import { EventEmitter, once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import lockfile from "proper-lockfile";
+import { expect, test } from "vitest";
+import { ProjectTrustStore } from "../../../src/core/trust-manager.ts";
+
+// Regression: https://github.com/code-yeongyu/senpi/issues/1393
+test("project trust reads the published snapshot while a writer lock is held", async () => {
+	// Given a persisted trust decision and a real writer holding the store lock.
+	const tempDir = mkdtempSync(join(tmpdir(), "senpi-project-trust-lock-"));
+	const agentDir = join(tempDir, "agent");
+	const projectDir = join(tempDir, "project");
+	const store = new ProjectTrustStore(agentDir);
+	store.set(projectDir, true);
+
+	const writerEvents = new EventEmitter();
+	const lockHeld = once(writerEvents, "lock-held");
+	const releaseRequested = once(writerEvents, "release-requested");
+	const writer = (async () => {
+		const release = await lockfile.lock(agentDir, {
+			realpath: false,
+			lockfilePath: join(agentDir, "trust.json.lock"),
+		});
+		writerEvents.emit("lock-held");
+		await releaseRequested;
+		await release();
+	})();
+
+	await lockHeld;
+	try {
+		// When the reader loads trust during the writer's critical section.
+		const decision = store.get(projectDir);
+
+		// Then it sees the last atomically published snapshot without contending on the lock.
+		expect(decision).toBe(true);
+	} finally {
+		writerEvents.emit("release-requested");
+		await writer;
+		rmSync(tempDir, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## What changed

- Removed writer-lock acquisition from project trust reads.
- `trust.json` writes keep the existing proper-lockfile serialization but publish through a same-directory temp file and an atomic rename.
- Added a regression test that reads the stored trust decision while a real writer lock is held.

## Why

When several Senpi/OMO processes run concurrently, a read-only project trust lookup could contend with the writer lock and kill the process with `Lock file is already being held`. A completed previous snapshot is safe to read, so there is no reason for a reader to wait on the writer lock.

## How

The reader reads the last published snapshot directly and validates it with the existing strict parser. The writer performs read-modify-write inside the lock, writes complete JSON to a temp file, and renames it. The fail-closed semantics for malformed snapshots and for the trust default are unchanged.

## Verification

- `npm --prefix packages/coding-agent test -- test/suite/regressions/project-trust-lock-contention.test.ts test/trust-manager.test.ts` PASS (3/3)
- `bun run check` PASS
- The source CLI `--list-models` exits 0 while a real proper-lockfile writer holds `trust.json.lock`
- Senpi CLI smoke PASS (8/8), real auth files unchanged

## Out of scope

Credential/settings lock policy and the trust decision itself are unchanged. The 18 tool-protocol leak scenarios in the full mock-loop self-test are pre-existing failures unrelated to this path and were left as-is.

Closes #1393

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes project trust reads retrying the writer lock synchronously and throwing `ELOCKED`, which could kill concurrent processes. Reads now use the last atomically published `trust.json` snapshot without acquiring the lock, while writes keep proper-lockfile serialization and publish via temp file plus atomic rename.

- Adds a regression test that reads trust while a real writer holds the lock.
- Updates `changes.md` with the change details and expected merge conflict zones.

<sup>Written for commit f20ffa912165baf2d7db8e789a6c8df82cb39df4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

