### PR TITLE
fix(claude-sdk-oauth): restore replay failure attribution

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Preserve Claude SDK OAuth terminal results and failure attribution across replay races.
+
 ### Removed
 
 ## [2026.9.5-3] - 2026-09-05

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
@@ -133,8 +133,7 @@ function handleMessage(
 		else if (message.type === "result" && resultMatchesTurn(message, turn)) {
 			const failure = sdkResultFailure(message);
 			if (failure) throw failure;
-			claimTurn(entry, turn);
-			for (const buffered of turn.preReplay) deliver(entry, turn, buffered);
+			for (const buffered of claimTurn(entry, turn)) deliver(entry, turn, buffered);
 			finishTurn(registry, entry, turn, message);
 			return false;
 		} else if (message.type === "result") {

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
@@ -1,3 +1,4 @@
+import { sdkResultFailure } from "./errors.ts";
 import { refusalError } from "./refusal.ts";
 import type { SDKMessage, SDKUserMessage } from "./sdk-boundary.ts";
 import { evaluateAbortOutcome } from "./session-reattach.ts";
@@ -117,21 +118,27 @@ function handleMessage(
 	// the fork's content is lost.
 	if (message.type === "system" && message.subtype === "init" && typeof message.session_id === "string") {
 		if (message.session_id !== entry.sdkSessionId) entry.sdkSessionId = message.session_id;
+		entry.sdkSessionIdConfirmed = true;
 	}
 	const turn = currentTurn(entry);
 	if (!turn || !registry.isCurrentGeneration(entry.senpiSessionId, turn.generation)) return false;
 	if (!turn.claimed) {
 		if (isReplayFor(message, turn.uuid)) {
+			entry.sdkSessionIdConfirmed = true;
 			for (const buffered of claimTurn(entry, turn)) {
 				if (buffered.type === "result") finishTurn(registry, entry, turn, buffered);
 				else deliver(entry, turn, buffered);
 			}
-		}
-		else if (message.type === "stream_event") bufferBeforeReplay(registry, entry, turn, message);
-		else if (message.type === "result" && resultMatchesTurn(message, turn)) {
-			claimTurn(entry, turn);
-			finishTurn(registry, entry, turn, message);
-			return false;
+		} else if (message.type === "stream_event") bufferBeforeReplay(registry, entry, turn, message);
+		else if (message.type === "result") {
+			// A result that fails before the SDK ever echoed our user message (a
+			// 400 version floor, a session limit) must surface as that failure so
+			// failover can classify and rotate; only a genuine success-before-claim
+			// is an attribution error.
+			throw (
+				sdkResultFailure(message) ??
+				new SessionTurnAttributionError("Claude SDK OAuth result arrived before replay claim")
+			);
 		}
 		return false;
 	}
@@ -141,8 +148,14 @@ function handleMessage(
 		failTurn(registry, entry, refusal);
 		return true;
 	}
-	if (message.type === "result") finishTurn(registry, entry, turn, message);
-	else deliver(entry, turn, message);
+	if (message.type === "result") {
+		const failure = sdkResultFailure(message);
+		if (failure) {
+			failTurn(registry, entry, failure);
+			return true;
+		}
+		finishTurn(registry, entry, turn, message);
+	} else deliver(entry, turn, message);
 	return false;
 }
 

--- a/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/claude-sdk-oauth/session-registry-pump.ts
@@ -130,7 +130,14 @@ function handleMessage(
 				else deliver(entry, turn, buffered);
 			}
 		} else if (message.type === "stream_event") bufferBeforeReplay(registry, entry, turn, message);
-		else if (message.type === "result") {
+		else if (message.type === "result" && resultMatchesTurn(message, turn)) {
+			const failure = sdkResultFailure(message);
+			if (failure) throw failure;
+			claimTurn(entry, turn);
+			for (const buffered of turn.preReplay) deliver(entry, turn, buffered);
+			finishTurn(registry, entry, turn, message);
+			return false;
+		} else if (message.type === "result") {
 			// A result that fails before the SDK ever echoed our user message (a
 			// 400 version floor, a session limit) must surface as that failure so
 			// failover can classify and rotate; only a genuine success-before-claim

--- a/packages/coding-agent/test/claude-sdk-oauth-session-registry.test.ts
+++ b/packages/coding-agent/test/claude-sdk-oauth-session-registry.test.ts
@@ -536,7 +536,7 @@ describe("Claude SDK OAuth session registry", () => {
 		expect(isBoundAccountTokenExpiring(entry, accounts)).toBe(false);
 	});
 
-	it("preserves a terminal result that arrives before replay claim", async () => {
+	it("preserves a matching early terminal result", async () => {
 		const { query, registry, entry } = pumpFixture();
 		const turn = submitSessionTurn(registry, entry, { message: userContent });
 		const submitted = await submittedMessage(entry);
@@ -544,6 +544,15 @@ describe("Claude SDK OAuth session registry", () => {
 		query.emit(terminal);
 		expect((await turn).messages).toEqual([terminal]);
 		expect(entry.activeTurn).toBeNull();
+	});
+
+	it("restores sdkResultFailure classification before replay claim", async () => {
+		const { query, registry, entry } = pumpFixture();
+		const turn = submitSessionTurn(registry, entry, { message: userContent });
+		await submittedMessage(entry);
+		query.emit({ type: "result", subtype: "error_during_execution", is_error: true, result: "rate_limit", session_id: entry.sdkSessionId } as unknown as SDKMessage);
+		await expect(turn).rejects.toThrow(/rate_limit/i);
+		expect(query.closes).toBe(1);
 	});
 
 	it("claims a turn from the replayed submitted uuid", async () => {


### PR DESCRIPTION
Restores sdkResultFailure classification and sdkSessionIdConfirmed semantics while preserving early-terminal replay handling. Adds focused regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `sdkResultFailure` classification for early terminal results in the Claude SDK OAuth session registry so rate-limit and version-floor errors surface as SDK failures instead of being misattributed as replay attribution errors.

**Bug Fixes**
- Sets `sdkSessionIdConfirmed` on init and when a replay claim happens.
- Claiming a turn now delivers its buffered messages; matching early terminal results are preserved, failures before the claim throw, and failures after the claim fail the turn instead of finishing it.
- Adds regression tests for failure classification and matching early terminal results.

<sup>Written for commit a0dfd49a8e0c6584d5f099d1fcfcc56f7c4e8c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

