### PR TITLE
fix(coding-agent): preserve inline skill references

### DIFF
--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,6 +1,6 @@
 # changes
 
-## [Unreleased] - Preserve inline skill anchors in composed prompts
+## Preserve inline skill anchors in composed prompts (2026-09-06)
 
 ### What changed
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,6 +1,6 @@
 # changes
 
-## 2026-09-06 - Preserve inline skill anchors in composed prompts
+## [Unreleased] - Preserve inline skill anchors in composed prompts
 
 ### What changed
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,6 +1,6 @@
 # changes
 
-## Preserve inline skill anchors in composed prompts (2026-09-06)
+## 2026-09-06 - Preserve inline skill anchors in composed prompts
 
 ### What changed
 

--- a/packages/coding-agent/src/changes.md
+++ b/packages/coding-agent/src/changes.md
@@ -1,5 +1,23 @@
 # changes
 
+## 2026-09-06 - Preserve inline skill anchors in composed prompts
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts` preserves known inline `$skill:name` references as readable `[skill: name]` anchors when composing the expanded user request.
+
+### Why
+
+- Inline skill expansion previously removed the token entirely, leaving a sentence hole and losing the user's explicit reference in the composed prompt.
+
+### Why an extension could not handle it
+
+- Skill invocation token removal and prompt composition are core `AgentSession` behavior below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: `removeSkillInvocationTokens` in `packages/coding-agent/src/core/agent-session.ts`.
+
 ## 2026-09-05 - Ctrl+P skips favorites without context room
 
 ### What changed

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -383,6 +383,7 @@ function removeSkillInvocationTokens(text: string, tokens: readonly SkillInvocat
 	let result = "";
 	for (const token of tokens) {
 		result += text.slice(cursor, token.start);
+		if (token.position === "inline") result += `[skill: ${token.name}]`;
 		cursor = token.end;
 		if (
 			token.position === "inline" &&

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -41,6 +41,24 @@
 
 # changes
 
+## 2026-09-06 - Preserve inline skill anchors in composed prompts
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts` preserves known inline `$skill:name` references as readable `[skill: name]` anchors when composing the expanded user request.
+
+### Why
+
+- Inline skill expansion previously removed the token entirely, leaving a sentence hole and losing the user's explicit reference in the composed prompt.
+
+### Why an extension could not handle it
+
+- Skill invocation token removal and prompt composition are core `AgentSession` behavior below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: `removeSkillInvocationTokens` in `packages/coding-agent/src/core/agent-session.ts`.
+
 ## 2026-09-05 - Require explicit fallback chains
 
 ### What changed

--- a/packages/coding-agent/test/suite/regressions/308-skill-composition.test.ts
+++ b/packages/coding-agent/test/suite/regressions/308-skill-composition.test.ts
@@ -202,13 +202,35 @@ describe("#308 skill composition", () => {
 		const actual = await promptAndCapture(harness, "Use $skill:debugging to inspect $HOME safely");
 		invocationEvents.unsubscribe();
 
-		expect(actual).toBe(`${skillBlock(skills[0]!, tempDir)}\n\n${userRequest("Use to inspect $HOME safely")}`);
+		expect(actual).toBe(
+			`${skillBlock(skills[0]!, tempDir)}\n\n${userRequest("Use [skill: debugging] to inspect $HOME safely")}`,
+		);
 		expect(invocationEvents.events).toEqual([
 			{
 				type: "skill_invocation",
 				skills: [{ name: "debugging", path: skills[0]!.filePath, syntax: "dollar" }],
 			},
 		]);
+	});
+
+	it("preserves Korean inline references and duplicate mixed invocations", async () => {
+		const { resourceLoader, skills, tempDir } = createFixtures([
+			{ name: "debugging", body: "# Debugging Skill\n\nTrace the defect." },
+			{ name: "review", body: "# Review Skill\n\nReview the result." },
+		]);
+		const harness = await createHarness({ resourceLoader });
+		harnesses.push(harness);
+
+		expect(
+			await promptAndCapture(
+				harness,
+				"한국어로 $skill:debugging 와 $skill:debugging 를 $skill:review 함께 확인해 주세요",
+			),
+		).toBe(
+			`${skillBlock(skills[0]!, tempDir)}\n\n${skillBlock(skills[1]!, tempDir)}\n\n${userRequest(
+				"한국어로 [skill: debugging] 와 [skill: debugging] 를 [skill: review] 함께 확인해 주세요",
+			)}`,
+		);
 	});
 
 	it("preserves indentation and blank-line structure outside removed tokens", async () => {


### PR DESCRIPTION
## Summary
- Preserve known inline `$skill:name` references as `[skill: name]` in expanded user requests.
- Keep leading invocation removal, ordinary `$HOME` prose, duplicate body deduplication, and mixed/Korean inline references covered.

## Verification
- `bun run --cwd packages/coding-agent test test/suite/regressions/308-skill-composition.test.ts` (13 passed)
- `bun run check` passed
- `bun run build` passed
- Built CLI `node packages/coding-agent/dist/cli.js --help` passed

Broad regressions had unrelated pre-existing failures; focused regression is green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the coding agent so inline `$skill:name` references in user requests are preserved as `[skill: name]` in expanded prompts instead of being stripped out. Previously, expanding a request like "Use $skill:debugging to inspect $HOME" dropped the reference and left broken prose; now the reference is kept while the leading invocation token is still removed, including duplicate and Korean inline references.

<sup>Written for commit 2a7d9d5e7ab489ca704d81c058ab28827d6558cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

