### PR TITLE
fix(compaction): support Claude SDK OAuth model override

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Preserve Claude SDK OAuth terminal results and failure attribution across replay races.
+- Re-enable senpi compaction on Claude SDK OAuth lanes when `compaction.model` is configured, using that provider/model only for summarization and falling back safely to the session model when it cannot be resolved.
 
 ### Removed
 

--- a/packages/coding-agent/src/core/agent-session.ts
+++ b/packages/coding-agent/src/core/agent-session.ts
@@ -1365,6 +1365,24 @@ export class AgentSession {
 		}
 	}
 
+	/**
+	 * Resolve the model used for compaction summarization. When the user sets a
+	 * `compaction.model` override ("provider/model"), that model is used for the
+	 * summarization call instead of the session model — this is what lets an
+	 * SDK-owned lane (claude-sdk-oauth) compact on a cheaper/different model.
+	 * Any resolution failure (unset, malformed, unknown model) falls back to the
+	 * session model so compaction never silently breaks.
+	 */
+	private _resolveCompactionModel(sessionModel: Model<any>): Model<any> {
+		const override = this.settingsManager.getCompactionSettings().model;
+		if (!override) return sessionModel;
+		const slash = override.indexOf("/");
+		if (slash <= 0 || slash === override.length - 1) return sessionModel;
+		const provider = override.slice(0, slash);
+		const modelId = override.slice(slash + 1);
+		return this._modelRuntime.getModel(provider, modelId) ?? sessionModel;
+	}
+
 	private async _getCompactionRequestAuth(model: Model<any>): Promise<{
 		model: Model<any>;
 		apiKey?: string;
@@ -5685,13 +5703,19 @@ export class AgentSession {
 				}
 
 				if (!compactionResult) {
+					// A configured compaction.model override redirects only the
+					// summarization call to that model; every other part of the session
+					// (lifecycle record, preparation, branch) still tracks the session
+					// model. Falls back to the session model when the override is unset
+					// or cannot be resolved.
+					const compactionModel = this._resolveCompactionModel(model);
 					const {
 						model: requestModel,
 						apiKey,
 						headers,
 						extraBody,
 						env,
-					} = await this._getCompactionRequestAuth(model);
+					} = await this._getCompactionRequestAuth(compactionModel);
 					compactionResult = await this._runDefaultCompaction(
 						preparation,
 						requestModel,

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -4835,3 +4835,39 @@ unrelated fallback bus, silently disconnecting `pi.rpc.emit` on trust-requiring 
 ### Expected merge conflict zones
 
 - `src/core/agent-session.ts` next-turn refresh and compaction lifecycle; `src/core/agent-session-runtime.ts` replacement ordering.
+
+## 2026-09-06 - Optional compaction model override for Claude SDK OAuth
+
+### What changed
+
+- `packages/coding-agent/src/core/agent-session.ts`: resolves an optional `compaction.model` provider/model override for default compaction summarization, while preserving session-model lifecycle bookkeeping and falling back to the session model for malformed or unknown overrides.
+
+### Why
+
+- Claude SDK OAuth lanes can retain a resident SDK session whose native compaction does not fire; users need a reliable senpi-owned summarization escape hatch on a separate model.
+
+### Why an extension could not handle it
+
+- Model resolution, summarization authentication, and the core compaction execution request are session lifecycle boundaries below extension interception.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/agent-session.ts` around `_resolveCompactionModel()` and `_executeCompaction()` default summarization request construction.
+
+## 2026-09-06 - Thread compaction model overrides through settings
+
+### What changed
+
+- `packages/coding-agent/src/core/settings-manager.ts`: preserves the optional `compaction.model` provider/model value in the resolved compaction settings returned to core and extensions.
+
+### Why
+
+- The compaction executor and lane policy need one resolved settings path so the override is applied consistently without changing unrelated session settings.
+
+### Why an extension could not handle it
+
+- Settings resolution is owned by the core settings manager and occurs before extension contexts consume the resolved compaction settings.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/settings-manager.ts` `Settings.compaction` typing and `getCompactionSettings()` return value.

--- a/packages/coding-agent/src/core/compaction/changes.md
+++ b/packages/coding-agent/src/core/compaction/changes.md
@@ -565,3 +565,21 @@ If upstream changes branch summary preparation or adds new branch summary data s
 ### Expected merge conflict zones
 
 - `compaction.ts` around `completeSummarization` request option construction.
+
+## 2026-09-06 - Support an optional compaction summarization model
+
+### What changed
+
+- `packages/coding-agent/src/core/compaction/compaction.ts`: extends the exported compaction settings contract with an optional `model` provider/model override.
+
+### Why
+
+- Claude SDK OAuth sessions need an explicit senpi summarization model escape hatch when SDK-native compaction does not fire.
+
+### Why an extension could not handle it
+
+- The settings type is consumed by core compaction execution and must be part of the shared compaction contract before extension hooks run.
+
+### Expected merge conflict zones
+
+- `packages/coding-agent/src/core/compaction/compaction.ts` settings type re-export near the module imports.

--- a/packages/coding-agent/src/core/compaction/compaction.ts
+++ b/packages/coding-agent/src/core/compaction/compaction.ts
@@ -31,9 +31,13 @@ import {
 	type SessionEntry,
 	sessionEntryToContextMessages,
 } from "../session-manager.ts";
-import type { CompactionSettings } from "./compaction-settings.ts";
+import type { CompactionSettings as BaseCompactionSettings } from "./compaction-settings.ts";
 
-export { type CompactionSettings, DEFAULT_COMPACTION_SETTINGS } from "./compaction-settings.ts";
+export type CompactionSettings = BaseCompactionSettings & {
+	/** Optional "provider/model" override for the compaction summarization model. */
+	model?: string;
+};
+export { DEFAULT_COMPACTION_SETTINGS } from "./compaction-settings.ts";
 
 import {
 	consumeStreamWithIdleTimeout,

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/changes.md
@@ -1595,3 +1595,21 @@ untouched. Expected upstream conflict zones: `builtin/compaction/speculative.ts`
 - LOW: `index.ts` around the `session_compact` rejected branch.
 - LOW: `context-pipeline.ts` around the `sourceMessages` reduction predicate.
 - Coverage: `test/compaction/external-owner-breaker-isolation.test.ts`.
+
+## 2026-09-06 - Re-enable senpi compaction for configured SDK-lane overrides
+
+### What changed
+
+- `packages/coding-agent/src/core/extensions/builtin/compaction/lane-policy.ts`: accepts resolved compaction settings and lifts the Claude SDK OAuth stand-down when `compaction.model` is configured, while preserving the stand-down when it is unset.
+
+### Why
+
+- A configured alternate summarization model makes senpi the owner of summarization for the lane, preventing resident SDK sessions from growing without a compaction path.
+
+### Why an extension could not handle it
+
+- Lane ownership is decided by the builtin compaction policy before compaction triggers and context-reduction decisions; no external extension seam can override that policy safely.
+
+### Expected merge conflict zones
+
+- LOW: `lane-policy.ts` `LaneContext` and `disablesSenpiCompaction()` provider-scoping logic.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/lane-policy.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/lane-policy.ts
@@ -45,6 +45,13 @@ export interface SdkNativeLaneInput {
 export interface LaneContext {
 	cwd: string;
 	model: LaneModel | undefined;
+	/**
+	 * Optional resolved-settings getter (present on the real ExtensionContext).
+	 * Used to read a configured `compaction.model` override. When an override is
+	 * set the lane hands summarization to a senpi-owned model, so the SDK-native
+	 * stand-down no longer applies even with a resident SDK session.
+	 */
+	getCompactionSettings?: () => { model?: string };
 }
 
 export interface CompactionLanePolicy {
@@ -86,6 +93,10 @@ export function createCompactionLanePolicy(
 	return {
 		disablesSenpiCompaction(context: LaneContext): boolean {
 			if (context.model?.provider !== CLAUDE_SDK_OAUTH_PROVIDER_ID) return false;
+			// A configured compaction model override makes senpi own summarization
+			// for the lane, so the SDK-native stand-down no longer applies. This is
+			// the escape hatch for lanes whose SDK never fires native compaction.
+			if (context.getCompactionSettings?.().model) return false;
 			// Per-cwd cache is the intended contract (pinned by lane-policy.test.ts):
 			// resumeMode is read once per cwd. A mid-session switch takes effect on
 			// the next cwd or session.

--- a/packages/coding-agent/src/core/settings-manager.ts
+++ b/packages/coding-agent/src/core/settings-manager.ts
@@ -132,7 +132,7 @@ export interface Settings {
 	steeringMode?: "all" | "one-at-a-time";
 	followUpMode?: "all" | "one-at-a-time";
 	theme?: string;
-	compaction?: CompactionSettings;
+	compaction?: CompactionSettings & { model?: string };
 	branchSummary?: BranchSummarySettings;
 	retry?: RetrySettingsConfig;
 	hideThinkingBlock?: boolean;
@@ -1244,8 +1244,11 @@ export class SettingsManager {
 		return compactionKeepRecentTokens(this.settings.compaction);
 	}
 
-	getCompactionSettings(): ResolvedCompactionSettings {
-		return resolveCompactionSettings(this.settings.compaction);
+	getCompactionSettings(): ResolvedCompactionSettings & { model?: string } {
+		return {
+			...resolveCompactionSettings(this.settings.compaction),
+			model: this.settings.compaction?.model,
+		};
 	}
 
 	getBranchSummarySettings(): { reserveTokens: number; skipPrompt: boolean } {

--- a/packages/coding-agent/test/compaction/idle-settings.test.ts
+++ b/packages/coding-agent/test/compaction/idle-settings.test.ts
@@ -12,3 +12,15 @@ describe("idleCompactionEnabled setting", () => {
 		expect(sm.getCompactionSettings().idleCompactionEnabled).toBe(false);
 	});
 });
+
+describe("compaction model override setting", () => {
+	it("defaults to undefined", () => {
+		const sm = SettingsManager.inMemory();
+		expect(sm.getCompactionSettings().model).toBeUndefined();
+	});
+
+	it("passes through a configured provider/model override", () => {
+		const sm = SettingsManager.inMemory({ compaction: { model: "deepseek/deepseek-chat" } });
+		expect(sm.getCompactionSettings().model).toBe("deepseek/deepseek-chat");
+	});
+});

--- a/packages/coding-agent/test/compaction/lane-policy.test.ts
+++ b/packages/coding-agent/test/compaction/lane-policy.test.ts
@@ -105,6 +105,41 @@ describe("compaction lane policy — instance policy", () => {
 
 		expect(policy.disablesSenpiCompaction({ cwd: "/repo", model: { provider: "claude-sdk-oauth" } })).toBe(false);
 	});
+
+	it("re-enables senpi compaction on the SDK-native lane when a compaction model override is set", () => {
+		const policy = createCompactionLanePolicy({
+			loadProviderSettings: () => ({ resumeMode: "auto" }),
+		});
+		const ctx = {
+			cwd: "/repo",
+			model: { provider: "claude-sdk-oauth" },
+			getCompactionSettings: () => ({ model: "deepseek/deepseek-chat" }),
+		};
+
+		// The override makes senpi own summarization, so the stand-down lifts.
+		expect(policy.disablesSenpiCompaction(ctx)).toBe(false);
+	});
+
+	it("still stands down on the SDK-native lane when the override resolves to no model", () => {
+		const policy = createCompactionLanePolicy({
+			loadProviderSettings: () => ({ resumeMode: "auto" }),
+		});
+
+		expect(
+			policy.disablesSenpiCompaction({
+				cwd: "/repo",
+				model: { provider: "claude-sdk-oauth" },
+				getCompactionSettings: () => ({ model: undefined }),
+			}),
+		).toBe(true);
+		expect(
+			policy.disablesSenpiCompaction({
+				cwd: "/repo",
+				model: { provider: "claude-sdk-oauth" },
+				getCompactionSettings: () => ({}),
+			}),
+		).toBe(true);
+	});
 });
 
 describe("compaction lane policy — compact_boundary mirroring", () => {


### PR DESCRIPTION
## Summary

- apply PR #737's Claude SDK OAuth compaction model override to current `main` without a tip-to-tip diff
- re-enable senpi compaction on the SDK-native lane when `compaction.model` is configured
- use the override only for summarization auth/request model, with safe fallback to the session model
- add exact nearest `changes.md` coverage and coding-agent changelog entry

## Scope

The source delta is restricted to the six PR #737 paths. Current-main refactors required manual three-way conflict adaptation in `agent-session.ts`, `compaction.ts`, and `settings-manager.ts`; the exact record is in the attempt-13 fallback artifacts.

## Verification

- baseline focused tests: 16 pass, 0 fail
- green focused tests: 20 pass, 0 fail
- script tests: 185 pass, 0 fail
- changelog tests: 2 pass, 0 fail
- `bun run check`: passed
- root `tsc --noEmit`: passed
- remote Bunshin `mengmotaMac`: dependencies installed, focused tests 20 pass, 0 fail
- remote unique tree cleanup: verified CLEAN
- no `bun.lock` in the commit; no large deletion scope


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables senpi compaction on Claude SDK OAuth lanes when `compaction.model` is configured. Previously these lanes always stood down senpi compaction while a resident SDK session existed; now the override lifts that stand-down and routes the compaction summarization call to the override model, falling back to the session model when the override is unset, malformed, or unresolvable.

**Notes**

- The override applies only to the summarization request; session lifecycle, preparation, and branch bookkeeping still track the session model.
- The builtin lane policy reads resolved compaction settings so the stand-down lifts only when an override is actually set.
- `SettingsManager.getCompactionSettings()` now surfaces the optional `model` value.

<sup>Written for commit ef6b6dc11d09aceeae4ee9d961ddb3e7edbd0e8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

