### PR TITLE
fix(codemode): cooperative JS interrupt, bounded stop, stdin isolation (#1403)

### DIFF
--- a/packages/senpi-codemode/CHANGELOG.md
+++ b/packages/senpi-codemode/CHANGELOG.md
@@ -8,7 +8,13 @@
 
 ### Changed
 
+- JavaScript eval cells now interrupt cooperatively: `stop` and kernel timeouts first ask the worker to settle the cell (pending bridge `tool.*` calls are rejected, `Bun.spawn` children are killed) and keep the worker VM and its globals when the cell settles within a 2 s grace; only an unsettled cell restarts the worker.
+
 ### Fixed
+
+- `eval({ action: "stop" })` no longer hangs when the JavaScript worker is blocked in a synchronous call such as `Bun.spawnSync`: worker termination is bounded by a 3 s deadline, a fresh worker replaces the blocked one, and the cell output names the blocked synchronous call.
+- `Bun.$` commands run from a JavaScript cell no longer inherit the TUI's terminal as stdin (a stdin reader such as `cat`, an ssh or git credential prompt, or a keychain prompt blocked the cell forever); the shell wrapper isolates stdin while a cell is active without changing output, exit codes, `cwd`, `env`, or explicit stdin redirects.
+- Stop results and detached-cell completion notifications report the real interrupt outcome (variables preserved, worker restarted, or outcome unknown) instead of a hardcoded per-language note.
 
 ### Removed
 

--- a/packages/senpi-codemode/README.md
+++ b/packages/senpi-codemode/README.md
@@ -166,10 +166,26 @@ when the call had no summary), clearing as soon as the last detached cell settle
 
 Use `eval({ action: "peek", cell_id })` for its state and buffered output, or
 `eval({ action: "stop", cell_id })` to cancel it. Python stop interrupts the
-existing kernel and preserves variables. JavaScript stop kills and restarts its
-worker, so JavaScript VM state is lost. Detached completion messages state when
-kernel variables are available to the next eval cell; oversized buffered output
-is written under the session local root and referenced as `local://…`.
+existing kernel and preserves variables. JavaScript stop is cooperative first:
+the worker rejects the cell's pending bridge `tool.*` calls and kills the
+`Bun.spawn` children it started, and a cell that settles within the 2 s grace
+keeps the worker and every global. Only a cell that stays unsettled (a
+never-resolving promise, an un-abortable `fetch`, a `Bun.$` command) costs the
+worker VM. A worker blocked in a synchronous call (`Bun.spawnSync`,
+`child_process.spawnSync`) cannot be stopped at all; after a 3 s termination
+deadline a fresh worker replaces it, the cell output gains a stderr line naming
+the blocked synchronous call, and the blocked call keeps running until it
+returns. Kernel-level timeouts follow the same path. Stop results and detached
+completion messages report the real outcome - variables preserved, worker
+restarted, or outcome unknown - never a per-language assumption; oversized
+buffered output is written under the session local root and referenced as
+`local://…`.
+
+Commands a cell runs through `Bun.$` never read the host's terminal: the worker
+thread shares the TUI's stdin, so the shell wrapper hands every template an
+empty pipe (`true | ( … )`) while a cell is active. Output, exit codes, `cwd`,
+`env`, and explicit `< ${input}` redirects are unchanged; `Bun.spawn` and
+`Bun.spawnSync` already default stdin to `/dev/null`.
 
 ## Output and artifacts
 

--- a/packages/senpi-codemode/changes.md
+++ b/packages/senpi-codemode/changes.md
@@ -1,5 +1,66 @@
 # senpi-codemode fork changes
 
+## 2026-09-06 - JS kernel: cooperative interrupt, bounded stop, stdin isolation (#1403)
+
+### What changed
+
+- `src/kernels/js/worker-core.js`: handles the `interrupt` bridge message. It emits an
+  `interrupt-ack` status at once, rejects every pending bridge `tool.*` call and any later call from
+  the same cell with `CellInterruptedError` (`JS cell interrupted: <reason>`), and asks the runtime to
+  kill the cell's children, so a cell parked on a bridge call or a spawned child settles without
+  losing the worker.
+- `src/kernels/js/worker-runtime.js`: tracks `Bun.spawn` children created during the active cell
+  (forgotten when they exit or the cell ends) and kills the live ones on `interrupt()`.
+- `src/kernels/js/worker-shell-capture.js` (+ `.d.ts`): while a cell is active every `Bun.$`
+  template is framed as `true | (\n<template>\n)` so no command inherits the host's terminal as
+  stdin; `Bun.spawn` children are reported through the new optional `onChild` hook.
+- `src/kernels/js/context-manager.ts`: `interrupt()` and the kernel timeout go through
+  `#stopActive` - post `interrupt`, wait for the ack (`INTERRUPT_ACK_MS`) and then the settlement
+  grace (`JS_INTERRUPT_GRACE_MS`), and only replace the worker when the cell stays unsettled;
+  the host-composed result (`interruptResult`) wins over the worker's own error text; a worker
+  abandoned at the termination deadline gets a stderr note into the cell output. The worker
+  generation moved to `src/kernels/js/worker-slot.ts` (startup with inline fallback, message
+  fencing, bounded retirement) and the startup sequence to `src/kernels/js/worker-startup.ts`
+  (also the new home of `resolveJsWorkerEntryUrl`, re-exported from `context-manager.ts`).
+- `src/kernels/js/interrupt-bounds.ts`: `awaitCooperativeSettlement`, `retireWorker` (bounded by
+  `WORKER_TERMINATE_DEADLINE_MS`), `abandonedWorkerNote`.
+- `src/kernels/js/run-queue.ts`: pending runs carry `settlement`, `interruptResult`,
+  `interruptAck`, `settledByWorker`; `settleAll` prefers the in-flight interrupt result.
+- `src/bridge/reserved.ts`: `INTERRUPT_ACK_OP`.
+- `src/tool/detached-cell-manager.ts`: `stop` and the hard limit cancel through `#cancel`, which
+  parks the completion notification (`interruptOutcome`) until the kernel reported whether state
+  survived and keeps the handle's `note`; the public snapshot/notifier/options interfaces moved to
+  `src/tool/detached-cell-contract.ts` (re-exported) and the status/wake-source projections to
+  `src/tool/detached-cell-status.ts`; `src/tool/detached-notification-queue.ts` awaits async
+  snapshots; `src/tool/detached-cell-snapshot.ts` and `src/tool/detached-eval-result.ts` carry
+  `interruptNote` into the stop result.
+- `src/tool/cell-execution.ts` + `src/tool/interrupt-note.ts`: the foreground timeout path keeps the
+  whole interrupt handle (`interruptHandle`) so `describeTimeoutState` can wait for a bounded stop
+  and append the kernel's note; `src/tool/types.ts` adds the optional `note` to
+  `KernelInterruptHandle`.
+- `src/tool/detached-cell-notification.ts`: the state note comes from `interruptionStateNote` /
+  `unknownInterruptionStateNote` (`src/tool/interrupt-note.ts`) instead of a per-language constant.
+
+### Why
+
+- Audit of 30k eval calls (#1403): `stop` on a worker blocked in `Bun.spawnSync` hung the tool call
+  (51 min in production) because `worker.terminate()` had no deadline; `Bun.$` inherited the TUI's
+  stdin so `cat`, ssh/git prompts, and keychain dialogs blocked cells forever; every interrupt or
+  timeout wiped the VM and the note claimed the worker was "unresponsive" without ever asking it.
+  Python already preserves state on SIGINT; JavaScript now matches it where the cell can settle and
+  tells the truth where it cannot.
+
+### Why an extension could not handle it
+
+- Interrupt delivery, worker lifecycle, and the shell wrapper live inside the kernel package's
+  worker protocol; no extension can reach the worker thread or the run queue.
+
+### Expected merge conflict zones
+
+- MEDIUM: `src/kernels/js/context-manager.ts` was split; an upstream change to worker startup or
+  interrupt lands in `worker-slot.ts` / `worker-startup.ts` / `interrupt-bounds.ts` now.
+- LOW: `worker-core.js`, `worker-runtime.js`, `worker-shell-capture.js`, `detached-cell-*.ts`.
+
 ## 2026-09-05 - GPT eval dialect routes waits through tool.monitor
 
 ### What changed

--- a/packages/senpi-codemode/scripts/qa-js-interrupt-state.ts
+++ b/packages/senpi-codemode/scripts/qa-js-interrupt-state.ts
@@ -1,0 +1,129 @@
+import type { AgentToolResult, ExtensionContext } from "@code-yeongyu/senpi";
+import { JavaScriptKernel } from "../src/kernels/js/context-manager.ts";
+import { EvalDetachedCellManager } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import type { EvalToolDetails } from "../src/tool/types.ts";
+
+class QaScenarioError extends Error {
+	readonly name = "QaScenarioError";
+}
+
+const BLOCKED_STOP_BUDGET_MS = 5_000;
+const BLOCKED_HOLD_MS = 12_000;
+const runtime = Reflect.has(globalThis, "Bun") ? "bun" : "node";
+
+function textOf(result: AgentToolResult<EvalToolDetails>): string {
+	return result.content
+		.map((part) => (part.type === "text" ? part.text : ""))
+		.filter(Boolean)
+		.join("\n");
+}
+
+function requireMatch(label: string, text: string, pattern: RegExp): void {
+	if (!pattern.test(text)) throw new QaScenarioError(`${label}: expected ${pattern} in:\n${text}`);
+}
+
+const kernel = new JavaScriptKernel({
+	sessionId: `qa-js-interrupt-${crypto.randomUUID()}`,
+	cwd: process.cwd(),
+	parallelPoolWidth: 2,
+});
+const cellManager = new EvalDetachedCellManager({});
+const tool = createEvalTool({
+	enabledLanguages: { js: true, py: false, rb: false, jl: false },
+	kernelManager: { getKernel: async () => kernel },
+	cellTimeoutSeconds: 1,
+	// The only bridge tool never answers, so a cell awaiting it can settle solely through interrupt.
+	executeTool: (async () => await new Promise<never>(() => {})) as never,
+	cellManager,
+});
+const ctx = { mode: "tui", hasUI: true, cwd: process.cwd() } as unknown as ExtensionContext;
+const report: Record<string, unknown> = { runtime };
+
+try {
+	const timeout = await tool
+		.execute(
+			"qa-timeout",
+			{
+				language: "js",
+				code: "globalThis.qaTimeoutMarker = 42; return await tool.never({})",
+				on_timeout: "error",
+				timeout: 1,
+				summary: "Await a bridge call that never answers under a 1s timeout",
+			},
+			undefined,
+			undefined,
+			ctx,
+		)
+		.then(() => "UNEXPECTED-SUCCESS", (error: Error) => `${error.name}: ${error.message}`);
+	report.timeout = timeout;
+	requireMatch("timeout", timeout, /TimeoutError/u);
+	requireMatch("timeout state", timeout, /remains running|preserved/iu);
+	const timeoutReadback = await kernel.run({ cellId: "qa-timeout-readback", code: "qaTimeoutMarker", timeoutMs: 5_000 });
+	report.timeoutReadback = timeoutReadback;
+	if (!timeoutReadback.ok || timeoutReadback.valueRepr !== "42")
+		throw new QaScenarioError(`state did not survive the timeout: ${JSON.stringify(timeoutReadback)}`);
+
+	const detached = await tool.execute(
+		"qa-detached",
+		{
+			language: "js",
+			code: "globalThis.qaStopMarker = 7; return await tool.never({})",
+			on_timeout: "detach",
+			timeout: 1,
+			summary: "Detach on a bridge call that never answers",
+		},
+		undefined,
+		undefined,
+		ctx,
+	);
+	requireMatch("detach", textOf(detached), /detached/u);
+	const stopped = await tool.execute("qa-stop", { action: "stop", cell_id: "qa-detached" }, undefined, undefined, ctx);
+	report.stop = textOf(stopped);
+	requireMatch("stop state", textOf(stopped), /remains running|preserved/iu);
+	const stopReadback = await kernel.run({ cellId: "qa-stop-readback", code: "qaStopMarker", timeoutMs: 5_000 });
+	report.stopReadback = stopReadback;
+	if (!stopReadback.ok || stopReadback.valueRepr !== "7")
+		throw new QaScenarioError(`state did not survive the stop: ${JSON.stringify(stopReadback)}`);
+
+	const holdScript = `setTimeout(() => {}, ${BLOCKED_HOLD_MS})`;
+	const blocked = await tool.execute(
+		"qa-blocked",
+		{
+			language: "js",
+			code: [
+				'const { spawnSync } = await import("node:child_process");',
+				"globalThis.qaBlockedMarker = 1;",
+				`spawnSync(process.execPath, ["-e", ${JSON.stringify(holdScript)}]);`,
+				'return "unblocked";',
+			].join("\n"),
+			on_timeout: "detach",
+			timeout: 1,
+			summary: "Block the worker in spawnSync, then detach",
+		},
+		undefined,
+		undefined,
+		ctx,
+	);
+	requireMatch("blocked detach", textOf(blocked), /detached/u);
+	const stopStartedAt = performance.now();
+	const blockedStop = await tool.execute("qa-blocked-stop", { action: "stop", cell_id: "qa-blocked" }, undefined, undefined, ctx);
+	const stopMs = performance.now() - stopStartedAt;
+	report.blockedStop = textOf(blockedStop);
+	report.blockedStopMs = stopMs;
+	await cellManager.flushNotifications();
+	const snapshot = cellManager.peek("qa-blocked");
+	report.blockedSnapshot = { state: snapshot.state, stateRetained: snapshot.stateRetained, outputTail: snapshot.outputTail };
+	if (stopMs >= BLOCKED_STOP_BUDGET_MS) throw new QaScenarioError(`blocked stop took ${stopMs}ms`);
+	requireMatch("blocked stop state", textOf(blockedStop), /restarted|lost/iu);
+	requireMatch("blocked stop note", textOf(blockedStop), /synchronous/iu);
+	const fresh = await kernel.run({ cellId: "qa-blocked-readback", code: "typeof qaBlockedMarker", timeoutMs: 5_000 });
+	report.blockedReadback = fresh;
+	if (!fresh.ok || fresh.valueRepr !== '"undefined"')
+		throw new QaScenarioError(`fresh worker did not serve the next cell: ${JSON.stringify(fresh)}`);
+
+	console.log(JSON.stringify({ ok: true, ...report }, null, 2));
+} finally {
+	await cellManager.dispose();
+	await kernel.close();
+}

--- a/packages/senpi-codemode/src/bridge/reserved.ts
+++ b/packages/senpi-codemode/src/bridge/reserved.ts
@@ -9,3 +9,5 @@ export const RESERVED_SCHEMA_TOOL = "__schema__" as const;
 export const TIMEOUT_PAUSE_OP = "timeout-pause" as const;
 /** Canonical oh-my-pi eval-timeout resume operation. */
 export const TIMEOUT_RESUME_OP = "timeout-resume" as const;
+/** Status op the JS worker emits the moment it receives `interrupt`; proves its event loop is not blocked. */
+export const INTERRUPT_ACK_OP = "interrupt-ack" as const;

--- a/packages/senpi-codemode/src/kernels/js/context-manager.ts
+++ b/packages/senpi-codemode/src/kernels/js/context-manager.ts
@@ -1,9 +1,7 @@
-import { dirname, join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
 import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
+import { INTERRUPT_ACK_OP } from "../../bridge/reserved.ts";
 import type { KernelInterruptHandle } from "../../tool/types.ts";
-import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
-import { createInlineWorker, type WorkerLike } from "./inline-worker.ts";
+import { abandonedWorkerNote, awaitCooperativeSettlement, type WorkerRetirement } from "./interrupt-bounds.ts";
 import {
 	assertJavaScriptKernelOpen,
 	type JavaScriptKernelMode,
@@ -12,31 +10,20 @@ import {
 	type ResultMessage,
 	type ToolCallMessage,
 } from "./kernel-contract.ts";
-import { type JavaScriptKernelOptions, LocalModuleLoader, localBridgeConnection } from "./local-module-loader.ts";
+import { type JavaScriptKernelOptions, LocalModuleLoader } from "./local-module-loader.ts";
 import { JavaScriptRunQueue, type PendingJavaScriptRun, stoppedResult } from "./run-queue.ts";
-import { bridgeError, spawnNodeWorker, WorkerStartupCancelledError, waitForReady } from "./worker-host.ts";
+import { bridgeError, WorkerStartupCancelledError } from "./worker-host.ts";
+import { WorkerSlot } from "./worker-slot.ts";
 
 export { JavaScriptKernelClosedError, type JavaScriptKernelMode, type JavaScriptRunInput } from "./kernel-contract.ts";
 export type { JavaScriptKernelOptions } from "./local-module-loader.ts";
-
-export interface JavaScriptWorkerEntryUrlOptions extends CodemodeRuntimeAssetEnvironment {
-	readonly localPath?: string;
-}
-
-export function resolveJsWorkerEntryUrl(options: JavaScriptWorkerEntryUrlOptions = {}): URL {
-	const localPath = options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "worker-entry.js");
-	return pathToFileURL(resolveCodemodeRuntimeAsset(localPath, join("kernels", "js", "worker-entry.js"), options));
-}
+export { type JavaScriptWorkerEntryUrlOptions, resolveJsWorkerEntryUrl } from "./worker-startup.ts";
 
 export class JavaScriptKernel {
 	readonly #options: JavaScriptKernelOptions;
 	readonly #moduleLoader: LocalModuleLoader;
-	#worker: WorkerLike | null = null;
-	#mode: JavaScriptKernelMode = "worker";
+	readonly #slot: WorkerSlot;
 	#lifecycle: LifecycleState = "open";
-	#ready: Promise<void> | null = null;
-	#startupAbort: AbortController | null = null;
-	#generation = 0;
 	#activation: Promise<void> | null = null;
 	#recovery: Promise<void> | null = null;
 	#closePromise: Promise<void> | null = null;
@@ -48,10 +35,15 @@ export class JavaScriptKernel {
 	constructor(options: JavaScriptKernelOptions) {
 		this.#options = options;
 		this.#moduleLoader = new LocalModuleLoader(options);
+		this.#slot = new WorkerSlot(options, {
+			isOpen: () => this.#lifecycle === "open",
+			onMessage: (message) => this.#handleMessage(message),
+			onCrash: (error) => this.#handleCrash(error),
+		});
 	}
 
 	get mode(): JavaScriptKernelMode {
-		return this.#mode;
+		return this.#slot.mode;
 	}
 
 	async run(input: JavaScriptRunInput): Promise<ResultMessage> {
@@ -64,13 +56,16 @@ export class JavaScriptKernel {
 	async interrupt(reason = "interrupted"): Promise<KernelInterruptHandle> {
 		assertJavaScriptKernelOpen(this.#lifecycle, "interrupt");
 		const active = this.#runs.active;
-		const target = this.#runs.takeInterruptTarget();
-		if (!target) return { stateRetained: Promise.resolve(true) };
-		if (target === active) this.#clearTimeout();
-		this.#runs.settle(target, stoppedResult(target.input.cellId, `JS cell interrupted: ${reason}`));
-		await this.#restartAfterStop();
-		// A restart always replaces the worker VM, so no user global survives.
-		return { stateRetained: Promise.resolve(false) };
+		if (!active) {
+			const queued = this.#runs.takeInterruptTarget();
+			if (!queued) return { stateRetained: Promise.resolve(true) };
+			this.#runs.settle(queued, stoppedResult(queued.input.cellId, `JS cell interrupted: ${reason}`));
+			await this.#restartAfterStop();
+			return { stateRetained: Promise.resolve(false) };
+		}
+		this.#clearTimeout();
+		const stop = await this.#stopActive(active, reason, `JS cell interrupted: ${reason}`);
+		return { stateRetained: Promise.resolve(stop.retained), ...(stop.note === undefined ? {} : { note: stop.note }) };
 	}
 
 	async reset(): Promise<void> {
@@ -82,7 +77,7 @@ export class JavaScriptKernel {
 	}
 
 	deliverToolReply(message: Extract<HostToKernelMessage, { type: "tool-reply" }>): void {
-		if (this.#lifecycle === "open") this.#worker?.postMessage(message);
+		if (this.#lifecycle === "open") this.#slot.postMessage(message);
 	}
 
 	async nextToolCall(): Promise<ToolCallMessage> {
@@ -93,7 +88,7 @@ export class JavaScriptKernel {
 
 	async close(): Promise<void> {
 		if (this.#closePromise) return await this.#closePromise;
-		this.#worker?.postMessage({ type: "close" });
+		this.#slot.postMessage({ type: "close" });
 		this.#lifecycle = "closing";
 		this.#runs.settleAll("JS kernel closed");
 		const recovery = this.#recovery;
@@ -129,92 +124,17 @@ export class JavaScriptKernel {
 
 	async #ensureReady(): Promise<void> {
 		assertJavaScriptKernelOpen(this.#lifecycle, "run");
-		if (!this.#ready) {
-			const generation = ++this.#generation;
-			const controller = new AbortController();
-			this.#startupAbort = controller;
-			const ready = this.#startWorker(generation, controller.signal);
-			this.#ready = ready;
-			void ready.then(
-				() => {
-					if (this.#ready === ready) this.#startupAbort = null;
-				},
-				() => {
-					if (this.#ready === ready) {
-						this.#ready = null;
-						this.#startupAbort = null;
-					}
-				},
-			);
-		}
-		return await this.#ready;
-	}
-
-	async #startWorker(generation: number, signal: AbortSignal): Promise<void> {
-		let worker = this.#spawnWorker();
-		this.#publishWorker(worker, generation);
-		try {
-			await this.#initializeWorker(worker, signal);
-			return;
-		} catch (error) {
-			if (!this.#isCurrent(worker, generation) || error instanceof WorkerStartupCancelledError) {
-				await worker.terminate();
-				throw new WorkerStartupCancelledError();
-			}
-			if (worker.mode === "inline") throw error;
-			this.#worker = null;
-			await worker.terminate();
-		}
-		if (this.#lifecycle !== "open" || generation !== this.#generation) throw new WorkerStartupCancelledError();
-		worker = createInlineWorker(this.#options.cwd, this.#options.parallelPoolWidth);
-		this.#publishWorker(worker, generation);
-		await this.#initializeWorker(worker, signal);
-	}
-
-	#spawnWorker(): WorkerLike {
-		try {
-			const url = this.#options.workerEntryUrl ?? resolveJsWorkerEntryUrl();
-			return spawnNodeWorker(url, this.#options.cwd, this.#options.parallelPoolWidth);
-		} catch (error) {
-			if (!(error instanceof Error)) throw error;
-			return createInlineWorker(this.#options.cwd, this.#options.parallelPoolWidth);
-		}
-	}
-
-	#publishWorker(worker: WorkerLike, generation: number): void {
-		if (this.#lifecycle !== "open" || generation !== this.#generation) throw new WorkerStartupCancelledError();
-		this.#worker = worker;
-		this.#mode = worker.mode;
-		worker.onMessage((message) => {
-			if (this.#isCurrent(worker, generation)) this.#handleMessage(message);
-		});
-		worker.onError((error) => {
-			if (this.#isCurrent(worker, generation)) this.#handleCrash(error);
-		});
-	}
-
-	async #initializeWorker(worker: WorkerLike, signal: AbortSignal): Promise<void> {
-		const ready = waitForReady(worker, signal);
-		worker.postMessage({
-			type: "init",
-			sessionId: this.#options.sessionId,
-			connection: localBridgeConnection(this.#options),
-		});
-		await ready;
-	}
-
-	#isCurrent(worker: WorkerLike, generation: number): boolean {
-		return this.#lifecycle === "open" && this.#worker === worker && this.#generation === generation;
+		await this.#slot.ensureReady();
 	}
 
 	#startNext(): void {
-		if (this.#lifecycle !== "open" || this.#runs.active || !this.#worker) return;
+		if (this.#lifecycle !== "open" || this.#runs.active || !this.#slot.present) return;
 		const next = this.#runs.startNext(performance.now());
 		if (!next) return;
 		if (next.input.timeoutMs) {
 			this.#timeout = setTimeout(() => void this.#timeoutActive(next), next.input.timeoutMs);
 		}
-		this.#worker.postMessage({
+		this.#slot.postMessage({
 			type: "run",
 			cellId: next.input.cellId,
 			code: this.#moduleLoader.prepareCell(next.input.code),
@@ -223,21 +143,46 @@ export class JavaScriptKernel {
 	}
 
 	async #timeoutActive(run: PendingJavaScriptRun): Promise<void> {
-		if (!this.#runs.releaseActive(run)) return;
+		if (this.#runs.active !== run || run.settled) return;
 		const durationMs = run.input.timeoutMs ?? 0;
-		this.#runs.settle(run, {
-			type: "result",
-			cellId: run.input.cellId,
-			ok: false,
-			error: { message: `JS cell timed out after ${durationMs}ms` },
+		await this.#stopActive(
+			run,
+			`timed out after ${durationMs}ms`,
+			`JS cell timed out after ${durationMs}ms`,
 			durationMs,
-		});
-		await this.#restartAfterStop();
+		);
+	}
+
+	/**
+	 * Asks the worker to settle the active cell cooperatively (rejecting its bridge calls and killing its
+	 * children); only a cell that stays unsettled past the grace costs the worker VM. Reports whether the
+	 * worker state survived and, when a blocked worker had to be abandoned, the note that explains it.
+	 */
+	async #stopActive(
+		run: PendingJavaScriptRun,
+		reason: string,
+		message: string,
+		durationMs = 0,
+	): Promise<{ readonly retained: boolean; readonly note?: string }> {
+		run.interruptResult = { type: "result", cellId: run.input.cellId, ok: false, error: { message }, durationMs };
+		run.interruptAck ??= Promise.withResolvers<void>();
+		this.#slot.postMessage({ type: "interrupt", reason });
+		if ((await awaitCooperativeSettlement(run)) === "settled") return { retained: run.settledByWorker };
+		if (!this.#runs.releaseActive(run)) return { retained: run.settledByWorker };
+		const retirement = await this.#terminate();
+		this.#runs.settle(run, run.interruptResult ?? stoppedResult(run.input.cellId, message));
+		void this.#recover(() => Promise.resolve());
+		return retirement === "abandoned" ? { retained: false, note: abandonedWorkerNote() } : { retained: false };
 	}
 
 	async #restartAfterStop(): Promise<void> {
+		await this.#recover(() => this.#terminate());
+	}
+
+	/** One recovery at a time: retire through `retire` (a no-op when the worker is already gone), then bring a fresh worker up. */
+	async #recover(retire: () => Promise<unknown>): Promise<void> {
 		if (this.#recovery) return await this.#recovery;
-		const recovery = this.#performRestartAfterStop();
+		const recovery = this.#performRecovery(retire);
 		this.#recovery = recovery;
 		try {
 			await recovery;
@@ -246,9 +191,9 @@ export class JavaScriptKernel {
 		}
 	}
 
-	async #performRestartAfterStop(): Promise<void> {
+	async #performRecovery(retire: () => Promise<unknown>): Promise<void> {
 		try {
-			await this.#terminate();
+			await retire();
 			if (this.#lifecycle !== "open") return;
 			await this.#ensureReady();
 			if (this.#lifecycle === "open") this.#startNext();
@@ -259,6 +204,10 @@ export class JavaScriptKernel {
 	}
 
 	#handleMessage(message: KernelToHostMessage): void {
+		if (message.type === "status" && message.event.op === INTERRUPT_ACK_OP) {
+			this.#runs.active?.interruptAck?.resolve();
+			return;
+		}
 		this.#options.onMessage?.(message);
 		this.#runs.active?.input.onMessage?.(message);
 		if (message.type === "tool-call") {
@@ -272,13 +221,14 @@ export class JavaScriptKernel {
 		if (!active || active.input.cellId !== message.cellId) return;
 		this.#clearTimeout();
 		this.#runs.releaseActive(active);
-		this.#runs.settle(active, message);
+		active.settledByWorker = true;
+		this.#runs.settle(active, active.interruptResult ?? message);
 		this.#startNext();
 	}
 
 	#handleCrash(error: Error): void {
 		const active = this.#runs.active;
-		if (!active && this.#startupAbort) return;
+		if (!active && this.#slot.startingUp) return;
 		this.#clearTimeout();
 		if (active) {
 			this.#runs.releaseActive(active);
@@ -298,14 +248,8 @@ export class JavaScriptKernel {
 		this.#timeout = null;
 	}
 
-	async #terminate(): Promise<void> {
+	async #terminate(): Promise<WorkerRetirement> {
 		this.#clearTimeout();
-		this.#generation += 1;
-		this.#startupAbort?.abort();
-		this.#startupAbort = null;
-		this.#ready = null;
-		const worker = this.#worker;
-		this.#worker = null;
-		if (worker) await worker.terminate();
+		return await this.#slot.retire();
 	}
 }

--- a/packages/senpi-codemode/src/kernels/js/interrupt-bounds.ts
+++ b/packages/senpi-codemode/src/kernels/js/interrupt-bounds.ts
@@ -1,0 +1,66 @@
+import type { WorkerLike } from "./inline-worker.ts";
+import type { PendingJavaScriptRun } from "./run-queue.ts";
+
+/** How long the worker gets to acknowledge `interrupt`; silence means its event loop is blocked in synchronous code. */
+export const INTERRUPT_ACK_MS = 500;
+/** How long an acknowledged cell gets to settle before the VM is replaced. */
+export const JS_INTERRUPT_GRACE_MS = 2_000;
+/** How long `worker.terminate()` may take before the worker is abandoned as blocked in a synchronous call. */
+export const WORKER_TERMINATE_DEADLINE_MS = 3_000;
+
+export type CooperativeSettlement = "settled" | "unresponsive";
+export type WorkerRetirement = "terminated" | "abandoned";
+
+export interface CooperativeSettlementBounds {
+	readonly ackMs: number;
+	readonly graceMs: number;
+}
+
+const DEFAULT_SETTLEMENT_BOUNDS: CooperativeSettlementBounds = {
+	ackMs: INTERRUPT_ACK_MS,
+	graceMs: JS_INTERRUPT_GRACE_MS,
+};
+
+export async function awaitCooperativeSettlement(
+	run: PendingJavaScriptRun,
+	bounds = DEFAULT_SETTLEMENT_BOUNDS,
+): Promise<CooperativeSettlement> {
+	if (run.settled) return "settled";
+	const settled = run.settlement.then((): "settled" => "settled");
+	const acked = run.interruptAck?.promise.then((): "acked" => "acked") ?? Promise.resolve<"acked">("acked");
+	const first = await raceDeadline(Promise.race([settled, acked]), bounds.ackMs, "unresponsive");
+	if (first !== "acked") return first;
+	return await raceDeadline(settled, bounds.graceMs, "unresponsive");
+}
+
+export async function retireWorker(
+	worker: WorkerLike,
+	deadlineMs = WORKER_TERMINATE_DEADLINE_MS,
+): Promise<WorkerRetirement> {
+	const termination = worker.terminate().then((): WorkerRetirement => "terminated");
+	const outcome = await raceDeadline(termination, deadlineMs, "abandoned");
+	if (outcome === "abandoned") void termination.then(undefined, ignoreLateTerminationFailure);
+	return outcome;
+}
+
+export function abandonedWorkerNote(deadlineMs = WORKER_TERMINATE_DEADLINE_MS): string {
+	return `JavaScript worker did not stop within ${deadlineMs}ms: a synchronous call (for example Bun.spawnSync or child_process.spawnSync) is blocking it. A fresh worker replaced it; the blocked call keeps running until it returns.\n`;
+}
+
+async function raceDeadline<T extends string, Fallback extends string>(
+	operation: Promise<T>,
+	deadlineMs: number,
+	fallback: Fallback,
+): Promise<T | Fallback> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const deadline = new Promise<Fallback>((resolve) => {
+		timer = setTimeout(() => resolve(fallback), deadlineMs);
+	});
+	try {
+		return await Promise.race([operation, deadline]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+function ignoreLateTerminationFailure(): void {}

--- a/packages/senpi-codemode/src/kernels/js/run-queue.ts
+++ b/packages/senpi-codemode/src/kernels/js/run-queue.ts
@@ -7,8 +7,13 @@ export interface PendingJavaScriptRun {
 	readonly input: JavaScriptRunInput;
 	readonly resolve: (message: ResultMessage) => void;
 	readonly reject: (error: Error) => void;
+	readonly settlement: Promise<ResultMessage>;
 	startedAtMs: number | null;
 	settled: boolean;
+	/** Host-composed result that wins over whatever the worker reports once an interrupt is in flight. */
+	interruptResult: ResultMessage | null;
+	interruptAck: PromiseWithResolvers<void> | null;
+	settledByWorker: boolean;
 }
 
 export class JavaScriptRunQueue {
@@ -24,9 +29,19 @@ export class JavaScriptRunQueue {
 	}
 
 	enqueue(input: JavaScriptRunInput): Promise<ResultMessage> {
-		return new Promise((resolve, reject) => {
-			this.#queue.push({ input, resolve, reject, startedAtMs: null, settled: false });
+		const { promise, resolve, reject } = Promise.withResolvers<ResultMessage>();
+		this.#queue.push({
+			input,
+			resolve,
+			reject,
+			settlement: promise,
+			startedAtMs: null,
+			settled: false,
+			interruptResult: null,
+			interruptAck: null,
+			settledByWorker: false,
 		});
+		return promise;
 	}
 
 	startNext(startedAtMs: number): PendingJavaScriptRun | null {
@@ -64,7 +79,7 @@ export class JavaScriptRunQueue {
 	settleAll(message: string): void {
 		const active = this.#active;
 		this.#active = null;
-		if (active) this.settle(active, stoppedResult(active.input.cellId, message));
+		if (active) this.settle(active, active.interruptResult ?? stoppedResult(active.input.cellId, message));
 		for (const queued of this.#queue.splice(0)) this.settle(queued, stoppedResult(queued.input.cellId, message));
 	}
 

--- a/packages/senpi-codemode/src/kernels/js/worker-core.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-core.js
@@ -1,7 +1,11 @@
 import { JsWorkerRuntime } from "./worker-runtime.js";
 
+// Mirrors INTERRUPT_ACK_OP in src/bridge/reserved.ts (this worker file cannot import TypeScript).
+const INTERRUPT_ACK_OP = "interrupt-ack";
+
 export function createWorkerCore(transport, options) {
 	let runtime = null;
+	let activeCell = null;
 	const pendingTools = new Map();
 
 	function emit(message) {
@@ -14,6 +18,7 @@ export function createWorkerCore(transport, options) {
 			return;
 		}
 		const startedAtMs = performance.now();
+		activeCell = { cellId: message.cellId, interruption: null };
 		try {
 			const value = await runtime.run(message.code, message.cellId, {
 				emit,
@@ -22,14 +27,29 @@ export function createWorkerCore(transport, options) {
 			emit({ type: "result", cellId: message.cellId, ok: true, valueRepr: valueRepr(value), durationMs: durationMs(startedAtMs) });
 		} catch (error) {
 			emit({ type: "result", cellId: message.cellId, ok: false, error: bridgeError(error), durationMs: durationMs(startedAtMs) });
+		} finally {
+			activeCell = null;
 		}
 	}
 
 	async function callTool(toolName, args) {
+		if (activeCell?.interruption) throw activeCell.interruption;
 		const callId = `js-${crypto.randomUUID()}`;
 		const promise = new Promise((resolve, reject) => pendingTools.set(callId, { resolve, reject }));
 		emit({ type: "tool-call", callId, toolName, args });
 		return await promise;
+	}
+
+	function interruptCell(reason) {
+		if (!activeCell || !runtime) return;
+		emit({ type: "status", event: { op: INTERRUPT_ACK_OP, cellId: activeCell.cellId } });
+		const interruption = cellInterruptedError(reason);
+		activeCell.interruption = interruption;
+		for (const [callId, pending] of pendingTools) {
+			pendingTools.delete(callId);
+			pending.reject(interruption);
+		}
+		runtime.interrupt();
 	}
 
 	function onMessage(message) {
@@ -55,6 +75,10 @@ export function createWorkerCore(transport, options) {
 			else pending.reject(errorFromBridge(message.error));
 			return;
 		}
+		if (message.type === "interrupt") {
+			interruptCell(message.reason ?? "interrupted");
+			return;
+		}
 		if (message.type === "close") {
 			emit({ type: "closed" });
 			transport.close();
@@ -77,6 +101,12 @@ function durationMs(startedAtMs) {
 function valueRepr(value) {
 	if (value === undefined) return undefined;
 	return JSON.stringify(value);
+}
+
+function cellInterruptedError(reason) {
+	const error = new Error(`JS cell interrupted: ${reason}`);
+	error.name = "CellInterruptedError";
+	return error;
 }
 
 function bridgeError(error) {

--- a/packages/senpi-codemode/src/kernels/js/worker-runtime.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-runtime.js
@@ -16,6 +16,7 @@ export class JsWorkerRuntime {
 	#env = new Map();
 	#hooks = null;
 	#pendingDisplays = [];
+	#children = new Set();
 
 	constructor(options) {
 		this.#cwd = options.cwd;
@@ -41,8 +42,22 @@ export class JsWorkerRuntime {
 			return value;
 		} finally {
 			this.#pendingDisplays = [];
+			this.#children.clear();
 			this.#hooks = null;
 		}
+	}
+
+	interrupt() {
+		for (const child of this.#children) {
+			if (child.exitCode === null && child.signalCode === null) child.kill();
+		}
+	}
+
+	#trackChild(child) {
+		if (child === null || typeof child !== "object" || typeof child.kill !== "function") return;
+		this.#children.add(child);
+		const forget = () => this.#children.delete(child);
+		if (child.exited instanceof Promise) child.exited.then(forget, forget);
 	}
 
 	async #drainPendingDisplays() {
@@ -99,6 +114,7 @@ export class JsWorkerRuntime {
 		const restoreShellCapture = installShellCapture({
 			isActive: () => this.#hooks !== null,
 			emitText: (stream, data) => this.#emitText(stream, data),
+			onChild: (child) => this.#trackChild(child),
 		});
 		globalThis.__senpi_restore_console__ = () => {
 			console.log = originalLog;

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.d.ts
@@ -2,9 +2,18 @@ export type ShellCaptureStream = "stdout" | "stderr";
 
 export type ShellCaptureRestore = () => void;
 
+export interface ShellCaptureChild {
+	readonly exitCode: number | null;
+	readonly signalCode: string | null;
+	readonly exited: Promise<number>;
+	kill(): void;
+}
+
 export interface ShellCaptureOptions {
 	readonly isActive: () => boolean;
 	readonly emitText: (stream: ShellCaptureStream, data: string) => void;
+	/** Receives every `Bun.spawn` child created while a cell is active so the runtime can kill it on interrupt. */
+	readonly onChild?: (child: ShellCaptureChild) => void;
 }
 
 export function installShellCapture(options: ShellCaptureOptions): ShellCaptureRestore;

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
@@ -1,6 +1,5 @@
 const SHELL_CONFIG_METHODS = ["env", "cwd", "nothrow", "throws"];
 const SHELL_READ_METHODS = ["text", "json", "lines", "arrayBuffer", "bytes", "blob"];
-
 export function installShellCapture(options) {
 	const bun = globalThis.Bun;
 	if (!isBunRuntime(bun)) return () => {};
@@ -20,8 +19,9 @@ function isBunRuntime(bun) {
 
 function capturedShell(originalShell, options) {
 	const shell = (strings, ...expressions) => {
+		if (!options.isActive()) return originalShell(strings, ...expressions);
 		const promise = originalShell(strings, ...expressions);
-		return options.isActive() ? captureShellPromise(promise, options.emitText) : promise;
+		return captureShellPromise(promise, options.emitText);
 	};
 	for (const key of Object.keys(originalShell)) shell[key] = originalShell[key];
 	for (const method of SHELL_CONFIG_METHODS) {
@@ -87,13 +87,19 @@ function capturedSpawn(originalSpawn, options) {
 	return (...args) => {
 		if (!options.isActive()) return originalSpawn(...args);
 		const [first, second] = args;
+		let child;
 		if (Array.isArray(first)) {
 			const spawnOptions = second === undefined ? {} : second;
-			if (!needsStderrCapture(spawnOptions)) return originalSpawn(...args);
-			return drainStderr(originalSpawn(first, { ...spawnOptions, stderr: "pipe" }), options.emitText);
+			child = needsStderrCapture(spawnOptions)
+				? drainStderr(originalSpawn(first, { ...spawnOptions, stderr: "pipe" }), options.emitText)
+				: originalSpawn(...args);
+		} else {
+			child = needsStderrCapture(first)
+				? drainStderr(originalSpawn({ ...first, stderr: "pipe" }), options.emitText)
+				: originalSpawn(...args);
 		}
-		if (!needsStderrCapture(first)) return originalSpawn(...args);
-		return drainStderr(originalSpawn({ ...first, stderr: "pipe" }), options.emitText);
+		options.onChild?.(child);
+		return child;
 	};
 }
 

--- a/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
+++ b/packages/senpi-codemode/src/kernels/js/worker-shell-capture.js
@@ -1,5 +1,13 @@
 const SHELL_CONFIG_METHODS = ["env", "cwd", "nothrow", "throws"];
 const SHELL_READ_METHODS = ["text", "json", "lines", "arrayBuffer", "bytes", "blob"];
+// `true | ( … )` hands every command in the template an empty pipe as stdin. The worker thread shares
+// the host process's fd 0 (the TUI's terminal), which Bun.$ would otherwise inherit, so a stdin
+// reader would wait on the user's keyboard forever. The newline before `)` keeps a trailing comment
+// from swallowing the closing paren; the Bun shell has no other stdin control (no `$.stdin`, no
+// redirect on a subshell).
+const STDIN_ISOLATION_HEAD = "true | (\n";
+const STDIN_ISOLATION_TAIL = "\n)";
+
 export function installShellCapture(options) {
 	const bun = globalThis.Bun;
 	if (!isBunRuntime(bun)) return () => {};
@@ -20,7 +28,7 @@ function isBunRuntime(bun) {
 function capturedShell(originalShell, options) {
 	const shell = (strings, ...expressions) => {
 		if (!options.isActive()) return originalShell(strings, ...expressions);
-		const promise = originalShell(strings, ...expressions);
+		const promise = originalShell(isolateStdin(strings), ...expressions);
 		return captureShellPromise(promise, options.emitText);
 	};
 	for (const key of Object.keys(originalShell)) shell[key] = originalShell[key];
@@ -31,6 +39,18 @@ function capturedShell(originalShell, options) {
 		};
 	}
 	return shell;
+}
+
+function isolateStdin(strings) {
+	if (!Array.isArray(strings) || !Array.isArray(strings.raw)) return strings;
+	const cooked = [...strings];
+	const raw = [...strings.raw];
+	const last = cooked.length - 1;
+	cooked[0] = `${STDIN_ISOLATION_HEAD}${cooked[0]}`;
+	raw[0] = `${STDIN_ISOLATION_HEAD}${raw[0]}`;
+	cooked[last] = `${cooked[last]}${STDIN_ISOLATION_TAIL}`;
+	raw[last] = `${raw[last]}${STDIN_ISOLATION_TAIL}`;
+	return Object.freeze(Object.assign(cooked, { raw: Object.freeze(raw) }));
 }
 
 function captureShellPromise(promise, emitText) {

--- a/packages/senpi-codemode/src/kernels/js/worker-slot.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-slot.ts
@@ -1,0 +1,106 @@
+import type { HostToKernelMessage, KernelToHostMessage } from "../../bridge/protocol.ts";
+import type { WorkerLike } from "./inline-worker.ts";
+import { retireWorker, type WorkerRetirement } from "./interrupt-bounds.ts";
+import type { JavaScriptKernelMode } from "./kernel-contract.ts";
+import type { JavaScriptKernelOptions } from "./local-module-loader.ts";
+import { WorkerStartupCancelledError } from "./worker-host.ts";
+import { startWorkerWithInlineFallback } from "./worker-startup.ts";
+
+export interface WorkerSlotListeners {
+	isOpen(): boolean;
+	onMessage(message: KernelToHostMessage): void;
+	onCrash(error: Error): void;
+}
+
+/** The kernel's current worker generation: startup with inline fallback, message fencing, bounded retirement. */
+export class WorkerSlot {
+	readonly #options: JavaScriptKernelOptions;
+	readonly #listeners: WorkerSlotListeners;
+	#worker: WorkerLike | null = null;
+	#mode: JavaScriptKernelMode = "worker";
+	#generation = 0;
+	#ready: Promise<void> | null = null;
+	#startupAbort: AbortController | null = null;
+
+	constructor(options: JavaScriptKernelOptions, listeners: WorkerSlotListeners) {
+		this.#options = options;
+		this.#listeners = listeners;
+	}
+
+	get mode(): JavaScriptKernelMode {
+		return this.#mode;
+	}
+
+	get present(): boolean {
+		return this.#worker !== null;
+	}
+
+	get startingUp(): boolean {
+		return this.#startupAbort !== null;
+	}
+
+	postMessage(message: HostToKernelMessage): void {
+		this.#worker?.postMessage(message);
+	}
+
+	async ensureReady(): Promise<void> {
+		if (!this.#ready) {
+			const generation = ++this.#generation;
+			const controller = new AbortController();
+			this.#startupAbort = controller;
+			const ready = startWorkerWithInlineFallback(
+				{
+					options: this.#options,
+					publish: (worker) => this.#publish(worker, generation),
+					isCurrent: (worker) => this.#isCurrent(worker, generation),
+					retire: (worker) => {
+						if (this.#worker === worker) this.#worker = null;
+					},
+					canFallBackInline: () => this.#listeners.isOpen() && generation === this.#generation,
+				},
+				controller.signal,
+			);
+			this.#ready = ready;
+			void ready.then(
+				() => {
+					if (this.#ready !== ready) return;
+					this.#startupAbort = null;
+					this.#mode = this.#worker?.mode ?? this.#mode;
+				},
+				() => {
+					if (this.#ready === ready) {
+						this.#ready = null;
+						this.#startupAbort = null;
+					}
+				},
+			);
+		}
+		return await this.#ready;
+	}
+
+	async retire(): Promise<WorkerRetirement> {
+		this.#generation += 1;
+		this.#startupAbort?.abort();
+		this.#startupAbort = null;
+		this.#ready = null;
+		const worker = this.#worker;
+		this.#worker = null;
+		if (!worker) return "terminated";
+		return await retireWorker(worker);
+	}
+
+	#publish(worker: WorkerLike, generation: number): void {
+		if (!this.#listeners.isOpen() || generation !== this.#generation) throw new WorkerStartupCancelledError();
+		this.#worker = worker;
+		worker.onMessage((message) => {
+			if (this.#isCurrent(worker, generation)) this.#listeners.onMessage(message);
+		});
+		worker.onError((error) => {
+			if (this.#isCurrent(worker, generation)) this.#listeners.onCrash(error);
+		});
+	}
+
+	#isCurrent(worker: WorkerLike, generation: number): boolean {
+		return this.#listeners.isOpen() && this.#worker === worker && this.#generation === generation;
+	}
+}

--- a/packages/senpi-codemode/src/kernels/js/worker-startup.ts
+++ b/packages/senpi-codemode/src/kernels/js/worker-startup.ts
@@ -1,0 +1,69 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { type CodemodeRuntimeAssetEnvironment, resolveCodemodeRuntimeAsset } from "../shared/runtime-asset.ts";
+import { createInlineWorker, type WorkerLike } from "./inline-worker.ts";
+import { type JavaScriptKernelOptions, localBridgeConnection } from "./local-module-loader.ts";
+import { spawnNodeWorker, WorkerStartupCancelledError, waitForReady } from "./worker-host.ts";
+
+export interface JavaScriptWorkerEntryUrlOptions extends CodemodeRuntimeAssetEnvironment {
+	readonly localPath?: string;
+}
+
+export function resolveJsWorkerEntryUrl(options: JavaScriptWorkerEntryUrlOptions = {}): URL {
+	const localPath = options.localPath ?? join(dirname(fileURLToPath(import.meta.url)), "worker-entry.js");
+	return pathToFileURL(resolveCodemodeRuntimeAsset(localPath, join("kernels", "js", "worker-entry.js"), options));
+}
+
+export interface WorkerStartupHooks {
+	readonly options: JavaScriptKernelOptions;
+	/** Wires the worker into the kernel; throws `WorkerStartupCancelledError` once the generation is stale. */
+	publish(worker: WorkerLike): void;
+	isCurrent(worker: WorkerLike): boolean;
+	retire(worker: WorkerLike): void;
+	canFallBackInline(): boolean;
+}
+
+export async function startWorkerWithInlineFallback(hooks: WorkerStartupHooks, signal: AbortSignal): Promise<void> {
+	let worker = spawnWorker(hooks.options);
+	hooks.publish(worker);
+	try {
+		await initializeWorker(worker, hooks.options, signal);
+		return;
+	} catch (error) {
+		if (!hooks.isCurrent(worker) || error instanceof WorkerStartupCancelledError) {
+			await worker.terminate();
+			throw new WorkerStartupCancelledError();
+		}
+		if (worker.mode === "inline") throw error;
+		hooks.retire(worker);
+		await worker.terminate();
+	}
+	if (!hooks.canFallBackInline()) throw new WorkerStartupCancelledError();
+	worker = createInlineWorker(hooks.options.cwd, hooks.options.parallelPoolWidth);
+	hooks.publish(worker);
+	await initializeWorker(worker, hooks.options, signal);
+}
+
+function spawnWorker(options: JavaScriptKernelOptions): WorkerLike {
+	try {
+		const url = options.workerEntryUrl ?? resolveJsWorkerEntryUrl();
+		return spawnNodeWorker(url, options.cwd, options.parallelPoolWidth);
+	} catch (error) {
+		if (!(error instanceof Error)) throw error;
+		return createInlineWorker(options.cwd, options.parallelPoolWidth);
+	}
+}
+
+async function initializeWorker(
+	worker: WorkerLike,
+	options: JavaScriptKernelOptions,
+	signal: AbortSignal,
+): Promise<void> {
+	const ready = waitForReady(worker, signal);
+	worker.postMessage({
+		type: "init",
+		sessionId: options.sessionId,
+		connection: localBridgeConnection(options),
+	});
+	await ready;
+}

--- a/packages/senpi-codemode/src/tool/cell-execution.ts
+++ b/packages/senpi-codemode/src/tool/cell-execution.ts
@@ -1,5 +1,5 @@
 import { IdleTimeout, type IdleTimeoutOptions, type TimeoutPauseHandle } from "../timeouts/idle-timeout.ts";
-import type { EvalKernel } from "./types.ts";
+import type { EvalKernel, KernelInterruptHandle } from "./types.ts";
 
 const INTERRUPT_DELIVERY_GRACE_MS = 100;
 
@@ -104,7 +104,8 @@ export class CellExecution {
 		this.#abort(this.#callerSignal.reason);
 	};
 
-	interruptStateRetained: Promise<boolean> | undefined;
+	/** Resolves with the kernel's interrupt handle once the abort reached it; undefined when no kernel was bound. */
+	interruptHandle: Promise<KernelInterruptHandle> | undefined;
 
 	#abort(reason: unknown): void {
 		if (!this.#active) return;
@@ -118,15 +119,12 @@ export class CellExecution {
 			return;
 		}
 		this.#interruptDeadline = setTimeout(() => this.#settleAbort(error), INTERRUPT_DELIVERY_GRACE_MS);
-		void Promise.resolve()
-			.then(async () => {
-				const handle = await kernel.interrupt(error.message);
-				this.interruptStateRetained = handle?.stateRetained;
-			})
-			.then(
-				() => this.#settleAbort(error),
-				(interruptError: unknown) => this.#settleAbort(interruptError),
-			);
+		const handle = Promise.resolve().then(async () => await kernel.interrupt(error.message));
+		this.interruptHandle = handle;
+		void handle.then(
+			() => this.#settleAbort(error),
+			(interruptError: unknown) => this.#settleAbort(interruptError),
+		);
 	}
 
 	#settleAbort(reason: unknown): void {

--- a/packages/senpi-codemode/src/tool/detached-cell-contract.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-contract.ts
@@ -1,0 +1,45 @@
+import type { AgentToolResult } from "@code-yeongyu/senpi";
+import type { WakeSourceState } from "../extension/wake-source-state.ts";
+import type { EvalLanguage, EvalToolDetails } from "./types.ts";
+
+export type EvalDetachedCellState = "running" | "detached" | "completed" | "failed" | "cancelled";
+
+export interface EvalDetachedCellSnapshot {
+	readonly cellId: string;
+	readonly language: EvalLanguage;
+	readonly state: EvalDetachedCellState;
+	readonly outputTail: string;
+	readonly result: AgentToolResult<EvalToolDetails>;
+	readonly stateRetained: boolean | undefined;
+	/** Kernel-supplied detail about the interrupt outcome, e.g. an abandoned blocked worker. */
+	readonly interruptNote?: string;
+	/** Set only when the wall-clock kill deadline ended this cell. */
+	readonly hardLimitSeconds?: number;
+}
+
+export interface EvalDetachedCellNotification {
+	readonly cellId: string;
+	readonly content: string;
+}
+
+export interface EvalDetachedCellNotifier {
+	notify(cells: readonly EvalDetachedCellNotification[]): void;
+}
+
+export interface EvalDetachedCellStatusEntry {
+	readonly cellId: string;
+	readonly language: EvalLanguage;
+	readonly summary?: string;
+	readonly startedAtMs: number;
+}
+
+export interface EvalDetachedCellManagerOptions {
+	readonly artifactsDir?: string;
+	readonly notifier?: EvalDetachedCellNotifier;
+	/** Wall-clock kill deadline in seconds; defaults to the bash-parity 1800s. */
+	readonly hardLimitSeconds?: number;
+	readonly onStatusChange?: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
+	/** Receives a full per-source liveness snapshot on every detached-cell transition; used by the goal builtin. */
+	readonly onWakeSourceState?: (state: WakeSourceState) => void;
+	readonly now?: () => number;
+}

--- a/packages/senpi-codemode/src/tool/detached-cell-manager.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-manager.ts
@@ -1,6 +1,12 @@
 import type { AgentToolResult } from "@code-yeongyu/senpi";
 import { DEFAULT_HARD_LIMIT_SECONDS } from "../config/settings.ts";
-import { SENPI_CODEMODE_WAKE_SOURCE, type WakeSourceState } from "../extension/wake-source-state.ts";
+import type { WakeSourceState } from "../extension/wake-source-state.ts";
+import type {
+	EvalDetachedCellManagerOptions,
+	EvalDetachedCellSnapshot,
+	EvalDetachedCellState,
+	EvalDetachedCellStatusEntry,
+} from "./detached-cell-contract.ts";
 import { detachedNotificationSpillPath } from "./detached-cell-notification.ts";
 import { currentDetachedResult, detachedErrorResult, snapshotDetachedCell } from "./detached-cell-snapshot.ts";
 import {
@@ -8,10 +14,18 @@ import {
 	allowsDetachedCellTransition,
 	detachedCellIsActive,
 } from "./detached-cell-state.ts";
+import { detachedStatusEntries, detachedWakeSourceState } from "./detached-cell-status.ts";
 import { DetachedNotificationQueue } from "./detached-notification-queue.ts";
 import type { EvalKernel, EvalLanguage, EvalToolDetails, EvalToolInput } from "./types.ts";
 
-export type EvalDetachedCellState = "running" | "detached" | "completed" | "failed" | "cancelled";
+export type {
+	EvalDetachedCellManagerOptions,
+	EvalDetachedCellNotification,
+	EvalDetachedCellNotifier,
+	EvalDetachedCellSnapshot,
+	EvalDetachedCellState,
+	EvalDetachedCellStatusEntry,
+} from "./detached-cell-contract.ts";
 
 type LiveResultProvider = () => AgentToolResult<EvalToolDetails>;
 
@@ -26,6 +40,9 @@ type ManagedCell = {
 	wasDetached: boolean;
 	kernel: EvalKernel | undefined;
 	stateRetained: boolean | undefined;
+	interruptNote: string | undefined;
+	/** Holds the completion notification until the interrupt has reported whether kernel state survived. */
+	interruptOutcome: PromiseWithResolvers<void> | undefined;
 	liveResult: LiveResultProvider | undefined;
 	terminalResult: AgentToolResult<EvalToolDetails> | undefined;
 	notificationQueued: boolean;
@@ -34,44 +51,6 @@ type ManagedCell = {
 	hardLimited: boolean;
 	onHardLimit: ((error: Error) => void) | undefined;
 };
-
-export interface EvalDetachedCellSnapshot {
-	readonly cellId: string;
-	readonly language: EvalLanguage;
-	readonly state: EvalDetachedCellState;
-	readonly outputTail: string;
-	readonly result: AgentToolResult<EvalToolDetails>;
-	readonly stateRetained: boolean | undefined;
-	/** Set only when the wall-clock kill deadline ended this cell. */
-	readonly hardLimitSeconds?: number;
-}
-
-export interface EvalDetachedCellNotification {
-	readonly cellId: string;
-	readonly content: string;
-}
-
-export interface EvalDetachedCellNotifier {
-	notify(cells: readonly EvalDetachedCellNotification[]): void;
-}
-
-export interface EvalDetachedCellStatusEntry {
-	readonly cellId: string;
-	readonly language: EvalLanguage;
-	readonly summary?: string;
-	readonly startedAtMs: number;
-}
-
-export interface EvalDetachedCellManagerOptions {
-	readonly artifactsDir?: string;
-	readonly notifier?: EvalDetachedCellNotifier;
-	/** Wall-clock kill deadline in seconds; defaults to the bash-parity 1800s. */
-	readonly hardLimitSeconds?: number;
-	readonly onStatusChange?: (entries: readonly EvalDetachedCellStatusEntry[]) => void;
-	/** Receives a full per-source liveness snapshot on every detached-cell transition; used by the goal builtin. */
-	readonly onWakeSourceState?: (state: WakeSourceState) => void;
-	readonly now?: () => number;
-}
 
 export function hardLimitError(cellId: string, hardLimitSeconds: number): Error {
 	const error = new Error(`Eval cell ${cellId} was killed at the ${hardLimitSeconds}s hard limit.`);
@@ -114,6 +93,8 @@ export class EvalDetachedCellManager {
 			wasDetached: false,
 			kernel: undefined,
 			stateRetained: undefined,
+			interruptNote: undefined,
+			interruptOutcome: undefined,
 			liveResult: undefined,
 			terminalResult: undefined,
 			notificationQueued: false,
@@ -162,13 +143,7 @@ export class EvalDetachedCellManager {
 
 	async stop(cellId: string, reason = "Stopped detached eval cell"): Promise<EvalDetachedCellSnapshot> {
 		const cell = this.#get(cellId);
-		if (cell.state === "detached") {
-			const claimed = this.#settle(cell, "cancelled", currentDetachedResult(cell));
-			if (claimed && cell.kernel !== undefined) {
-				const handle = await cell.kernel.interrupt(reason);
-				cell.stateRetained = await handle.stateRetained;
-			}
-		}
+		if (cell.state === "detached") await this.#cancel(cell, reason);
 		return this.#snapshot(cell);
 	}
 
@@ -221,7 +196,10 @@ export class EvalDetachedCellManager {
 			if (!cell.notificationQueued) {
 				cell.notificationQueued = true;
 				this.#notificationQueue.enqueue({
-					snapshot: () => this.#snapshot(cell),
+					snapshot: async () => {
+						await cell.interruptOutcome?.promise;
+						return this.#snapshot(cell);
+					},
 					spillPath: cell.spillPath,
 				});
 			}
@@ -250,40 +228,34 @@ export class EvalDetachedCellManager {
 		const foreground = cell.state === "running" && cell.onHardLimit !== undefined;
 		cell.hardLimited = true;
 		const error = hardLimitError(cell.cellId, cell.hardLimitSeconds);
-		if (!this.#settle(cell, "cancelled", currentDetachedResult(cell))) return;
 		if (foreground) {
-			cell.onHardLimit?.(error);
+			if (this.#settle(cell, "cancelled", currentDetachedResult(cell))) cell.onHardLimit?.(error);
 			return;
 		}
-		if (cell.kernel === undefined) return;
-		const handle = await cell.kernel.interrupt(error.message);
-		cell.stateRetained = await handle.stateRetained;
+		await this.#cancel(cell, error.message);
+	}
+
+	async #cancel(cell: ManagedCell, reason: string): Promise<void> {
+		const outcome = Promise.withResolvers<void>();
+		cell.interruptOutcome = outcome;
+		try {
+			if (!this.#settle(cell, "cancelled", currentDetachedResult(cell)) || cell.kernel === undefined) return;
+			const handle = await cell.kernel.interrupt(reason);
+			cell.interruptNote = handle.note;
+			cell.stateRetained = await handle.stateRetained;
+		} finally {
+			outcome.resolve();
+		}
 	}
 
 	#emitStatus(): void {
 		const liveCells = [...this.#detachedByLanguage.values()];
-		this.#onStatusChange?.(
-			liveCells.map((cell) => ({
-				cellId: cell.cellId,
-				language: cell.input.language,
-				startedAtMs: cell.startedAtMs,
-				...(cell.input.summary === undefined ? {} : { summary: cell.input.summary }),
-			})),
-		);
+		this.#onStatusChange?.(detachedStatusEntries(liveCells));
 		this.#emitWakeSourceState(liveCells);
 	}
 
 	#emitWakeSourceState(liveCells: readonly ManagedCell[]): void {
-		this.#onWakeSourceState?.({
-			source: SENPI_CODEMODE_WAKE_SOURCE,
-			activeCount: liveCells.length,
-			items: liveCells.map((cell) => ({
-				id: cell.cellId,
-				description:
-					cell.input.summary === undefined || cell.input.summary.length === 0 ? cell.cellId : cell.input.summary,
-				startedAtMs: cell.startedAtMs,
-			})),
-		});
+		this.#onWakeSourceState?.(detachedWakeSourceState(liveCells));
 	}
 
 	#snapshot(cell: ManagedCell): EvalDetachedCellSnapshot {

--- a/packages/senpi-codemode/src/tool/detached-cell-notification.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-notification.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { EvalDetachedCellNotification, EvalDetachedCellSnapshot } from "./detached-cell-manager.ts";
+import { interruptionStateNote, unknownInterruptionStateNote } from "./interrupt-note.ts";
 
 const NOTIFICATION_TAIL_BYTES = 512;
 
@@ -74,11 +75,9 @@ function outcomeOf(cell: EvalDetachedCellSnapshot): string {
 }
 
 function stateNoteOf(cell: EvalDetachedCellSnapshot): string {
-	if (cell.state === "cancelled" && cell.language === "js")
-		return "JavaScript worker was restarted; VM state was lost.";
-	if (cell.state === "cancelled" && cell.language === "py")
-		return "Python kernel was interrupted; its existing variables are preserved.";
-	return "Kernel state updated - variables are available to the next eval cell.";
+	if (cell.state !== "cancelled") return "Kernel state updated - variables are available to the next eval cell.";
+	const note = interruptionStateNote(cell.language, cell.stateRetained) ?? unknownInterruptionStateNote(cell.language);
+	return cell.interruptNote === undefined ? note : `${note} ${cell.interruptNote.trim()}`;
 }
 
 function safeCellId(cellId: string): string {

--- a/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-snapshot.ts
@@ -10,6 +10,7 @@ export interface DetachedCellResultSource {
 	state: EvalDetachedCellState;
 	kernel: EvalKernel | undefined;
 	stateRetained: boolean | undefined;
+	interruptNote?: string | undefined;
 	liveResult: (() => AgentToolResult<EvalToolDetails>) | undefined;
 	terminalResult: AgentToolResult<EvalToolDetails> | undefined;
 	hardLimited?: boolean;
@@ -26,6 +27,7 @@ export function snapshotDetachedCell(cell: DetachedCellResultSource, nowMs: numb
 		outputTail: detachedOutputTail(result),
 		result,
 		stateRetained: cell.stateRetained,
+		...(cell.interruptNote === undefined ? {} : { interruptNote: cell.interruptNote }),
 		...(cell.hardLimited === true && cell.hardLimitSeconds !== undefined
 			? { hardLimitSeconds: cell.hardLimitSeconds }
 			: {}),

--- a/packages/senpi-codemode/src/tool/detached-cell-status.ts
+++ b/packages/senpi-codemode/src/tool/detached-cell-status.ts
@@ -1,0 +1,30 @@
+import { SENPI_CODEMODE_WAKE_SOURCE, type WakeSourceState } from "../extension/wake-source-state.ts";
+import type { EvalDetachedCellStatusEntry } from "./detached-cell-manager.ts";
+
+export interface LiveDetachedCell {
+	readonly cellId: string;
+	readonly startedAtMs: number;
+	readonly input: { readonly language: EvalDetachedCellStatusEntry["language"]; readonly summary?: string };
+}
+
+export function detachedStatusEntries(liveCells: readonly LiveDetachedCell[]): EvalDetachedCellStatusEntry[] {
+	return liveCells.map((cell) => ({
+		cellId: cell.cellId,
+		language: cell.input.language,
+		startedAtMs: cell.startedAtMs,
+		...(cell.input.summary === undefined ? {} : { summary: cell.input.summary }),
+	}));
+}
+
+export function detachedWakeSourceState(liveCells: readonly LiveDetachedCell[]): WakeSourceState {
+	return {
+		source: SENPI_CODEMODE_WAKE_SOURCE,
+		activeCount: liveCells.length,
+		items: liveCells.map((cell) => ({
+			id: cell.cellId,
+			description:
+				cell.input.summary === undefined || cell.input.summary.length === 0 ? cell.cellId : cell.input.summary,
+			startedAtMs: cell.startedAtMs,
+		})),
+	};
+}

--- a/packages/senpi-codemode/src/tool/detached-eval-result.ts
+++ b/packages/senpi-codemode/src/tool/detached-eval-result.ts
@@ -40,6 +40,7 @@ export function createDetachedControlResult(snapshot: EvalDetachedCellSnapshot):
 		`Eval cell ${snapshot.cellId} (${snapshot.language}) is ${snapshot.state}.`,
 		output.length === 0 ? "(no buffered output)" : output,
 		...(terminationNote === undefined ? [] : [terminationNote]),
+		...(snapshot.interruptNote === undefined ? [] : [snapshot.interruptNote.trim()]),
 	].join("\n");
 	return {
 		content: [{ type: "text", text }, ...snapshot.result.content.filter((part) => part.type === "image")],

--- a/packages/senpi-codemode/src/tool/detached-notification-queue.ts
+++ b/packages/senpi-codemode/src/tool/detached-notification-queue.ts
@@ -2,7 +2,7 @@ import type { EvalDetachedCellNotifier, EvalDetachedCellSnapshot } from "./detac
 import { buildDetachedCellNotification } from "./detached-cell-notification.ts";
 
 export interface PendingDetachedNotification {
-	readonly snapshot: () => EvalDetachedCellSnapshot;
+	readonly snapshot: () => EvalDetachedCellSnapshot | Promise<EvalDetachedCellSnapshot>;
 	readonly spillPath: string | undefined;
 }
 
@@ -30,7 +30,7 @@ export class DetachedNotificationQueue {
 		const flush = Promise.resolve().then(async () => {
 			const pending = this.#pending.splice(0);
 			const notifications = await Promise.all(
-				pending.map(async (item) => await buildDetachedCellNotification(item.snapshot(), item.spillPath)),
+				pending.map(async (item) => await buildDetachedCellNotification(await item.snapshot(), item.spillPath)),
 			);
 			this.#notifier?.notify(notifications);
 		});

--- a/packages/senpi-codemode/src/tool/interrupt-note.ts
+++ b/packages/senpi-codemode/src/tool/interrupt-note.ts
@@ -1,4 +1,4 @@
-import type { EvalLanguage } from "./types.ts";
+import type { EvalLanguage, KernelInterruptHandle } from "./types.ts";
 
 const TIMEOUT_STATE_GRACE_MS = 5_500;
 
@@ -13,28 +13,38 @@ function fallbackTimeoutMessage(base: string): string {
  */
 export async function describeTimeoutState(
 	error: Error,
-	execution: { readonly interruptStateRetained: Promise<boolean> | undefined },
+	execution: { readonly interruptHandle: Promise<KernelInterruptHandle> | undefined },
 ): Promise<Error> {
-	const outcome = execution.interruptStateRetained;
-	if (outcome === undefined) {
+	const pending = execution.interruptHandle;
+	if (pending === undefined) {
 		error.message = fallbackTimeoutMessage(error.message);
 		return error;
 	}
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	const retained = await Promise.race([
-		outcome,
-		new Promise<boolean | undefined>((resolve) => {
-			timer = setTimeout(() => resolve(undefined), TIMEOUT_STATE_GRACE_MS);
-		}),
-	]).finally(() => {
-		if (timer !== undefined) clearTimeout(timer);
-	});
-	if (retained === undefined) error.message = fallbackTimeoutMessage(error.message);
-	else if (retained)
+	const outcome = await withinGrace(
+		pending.then(async (handle) => ({ retained: await handle.stateRetained, note: handle.note })),
+		TIMEOUT_STATE_GRACE_MS,
+	);
+	if (outcome === undefined) error.message = fallbackTimeoutMessage(error.message);
+	else if (outcome.retained)
 		error.message = `${error.message} The kernel remains running; its existing variables are preserved.`;
 	else
 		error.message = `${error.message} The kernel was unresponsive and restarted; variables from earlier cells are lost.`;
+	if (outcome?.note !== undefined) error.message = `${error.message} ${outcome.note.trim()}`;
 	return error;
+}
+
+async function withinGrace<T>(operation: Promise<T>, graceMs: number): Promise<T | undefined> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<undefined>((resolve) => {
+				timer = setTimeout(() => resolve(undefined), graceMs);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
 }
 
 const LANGUAGE_LABEL: Record<EvalLanguage, string> = {
@@ -55,4 +65,8 @@ export function interruptionStateNote(language: EvalLanguage, stateRetained: boo
 	const label = LANGUAGE_LABEL[language];
 	if (stateRetained) return `${label} was interrupted and remains running; its existing variables are preserved.`;
 	return `${label} was unresponsive to interrupt and was restarted; variables from earlier cells are lost.`;
+}
+
+export function unknownInterruptionStateNote(language: EvalLanguage): string {
+	return `${LANGUAGE_LABEL[language]} interrupt outcome is unknown; re-establish any variables the next cell needs.`;
 }

--- a/packages/senpi-codemode/src/tool/types.ts
+++ b/packages/senpi-codemode/src/tool/types.ts
@@ -112,6 +112,8 @@ export interface EvalKernelRunInput {
 export interface KernelInterruptHandle {
 	/** Resolves once the kernel knows whether user state survived the interrupt. */
 	readonly stateRetained: Promise<boolean>;
+	/** Extra outcome detail worth showing the model, e.g. that a blocked worker was abandoned. */
+	readonly note?: string;
 }
 
 export interface EvalKernel {

--- a/packages/senpi-codemode/test/detached-cell-notification.test.ts
+++ b/packages/senpi-codemode/test/detached-cell-notification.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { EvalDetachedCellSnapshot } from "../src/tool/detached-cell-manager.ts";
+import { buildDetachedCellNotification } from "../src/tool/detached-cell-notification.ts";
+import { interruptionStateNote, unknownInterruptionStateNote } from "../src/tool/interrupt-note.ts";
+import type { EvalLanguage } from "../src/tool/types.ts";
+
+function cancelledSnapshot(
+	language: EvalLanguage,
+	stateRetained: boolean | undefined,
+	interruptNote?: string,
+): EvalDetachedCellSnapshot {
+	return {
+		cellId: `cancelled-${language}`,
+		language,
+		state: "cancelled",
+		outputTail: "",
+		stateRetained,
+		...(interruptNote === undefined ? {} : { interruptNote }),
+		result: {
+			content: [{ type: "text", text: "buffered tail" }],
+			details: { language, durationMs: 0, toolCalls: [], truncated: false },
+		},
+	};
+}
+
+describe("detached cell notification state note", () => {
+	it("Given a cancelled js cell whose worker survived the interrupt when the notification is built then it reports the retained state", async () => {
+		const notification = await buildDetachedCellNotification(cancelledSnapshot("js", true), undefined);
+
+		expect(notification.content).toContain(interruptionStateNote("js", true));
+	});
+
+	it("Given a cancelled js cell whose worker was restarted when the notification is built then it reports the lost state", async () => {
+		const notification = await buildDetachedCellNotification(cancelledSnapshot("js", false), undefined);
+
+		expect(notification.content).toContain(interruptionStateNote("js", false));
+	});
+
+	it("Given a cancelled py cell whose kernel was restarted when the notification is built then it does not claim the variables survived", async () => {
+		const notification = await buildDetachedCellNotification(cancelledSnapshot("py", false), undefined);
+
+		expect(notification.content).toContain(interruptionStateNote("py", false));
+	});
+
+	it("Given a cancelled js cell whose kernel supplied an interrupt note when the notification is built then the note follows the state", async () => {
+		const notification = await buildDetachedCellNotification(
+			cancelledSnapshot("js", false, "A synchronous call is blocking the old worker.\n"),
+			undefined,
+		);
+
+		expect(notification.content).toContain(
+			`${interruptionStateNote("js", false)} A synchronous call is blocking the old worker.`,
+		);
+	});
+
+	it("Given a cancelled cell with no interrupt outcome when the notification is built then it says the outcome is unknown", async () => {
+		const notification = await buildDetachedCellNotification(cancelledSnapshot("js", undefined), undefined);
+
+		expect(notification.content).toContain(unknownInterruptionStateNote("js"));
+	});
+});

--- a/packages/senpi-codemode/test/eval-detach-stop-notification.test.ts
+++ b/packages/senpi-codemode/test/eval-detach-stop-notification.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvalDetachedCellManager, type EvalDetachedCellNotification } from "../src/tool/detached-cell-manager.ts";
+import { createEvalTool } from "../src/tool/eval-tool.ts";
+import { interruptionStateNote } from "../src/tool/interrupt-note.ts";
+import { FakeKernel, FakeManager, fakeExtensionContext } from "./eval/fakes.ts";
+
+class NotificationRecorder {
+	readonly notices: EvalDetachedCellNotification[] = [];
+
+	notify(cells: readonly EvalDetachedCellNotification[]): void {
+		this.notices.push(...cells);
+	}
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+async function stopDetachedCell(stateRetainedOnInterrupt: boolean): Promise<NotificationRecorder> {
+	vi.useFakeTimers();
+	const recorder = new NotificationRecorder();
+	const manager = new EvalDetachedCellManager({ notifier: recorder });
+	const kernel = new FakeKernel([]);
+	kernel.stateRetainedOnInterrupt = stateRetainedOnInterrupt;
+	const tool = createEvalTool({
+		enabledLanguages: { js: true, py: false, rb: false, jl: false },
+		kernelManager: new FakeManager([["js", kernel]]),
+		cellTimeoutSeconds: 1,
+		executeTool: vi.fn(),
+		cellManager: manager,
+	});
+	const started = kernel.deferNextRun();
+	const execution = tool.execute(
+		"stop-notify",
+		{ language: "js", code: "await forever", summary: "detach then stop", on_timeout: "detach" },
+		undefined,
+		undefined,
+		{ ...fakeExtensionContext(), mode: "tui" as const },
+	);
+	await started;
+	await vi.advanceTimersByTimeAsync(1_000);
+	await execution;
+
+	await manager.stop("stop-notify");
+	await manager.flushNotifications();
+	return recorder;
+}
+
+describe("detached cell stop notification", () => {
+	it("Given a stop whose interrupt keeps the worker when the notification is delivered then it carries the retained outcome", async () => {
+		const recorder = await stopDetachedCell(true);
+
+		expect(recorder.notices).toHaveLength(1);
+		expect(recorder.notices[0]?.content).toContain(interruptionStateNote("js", true));
+	});
+
+	it("Given a stop whose interrupt restarts the worker when the notification is delivered then it carries the lost outcome", async () => {
+		const recorder = await stopDetachedCell(false);
+
+		expect(recorder.notices).toHaveLength(1);
+		expect(recorder.notices[0]?.content).toContain(interruptionStateNote("js", false));
+	});
+});

--- a/packages/senpi-codemode/test/eval/fake-bun-shell.ts
+++ b/packages/senpi-codemode/test/eval/fake-bun-shell.ts
@@ -1,0 +1,201 @@
+import type { ShellCaptureOptions } from "../../src/kernels/js/worker-shell-capture.d.ts";
+
+export type InstallShellCapture = (options: ShellCaptureOptions) => () => void;
+
+export type EmittedText = { readonly stream: "stdout" | "stderr"; readonly data: string };
+
+export type FakeShellOutput = {
+	readonly stdout: Buffer;
+	readonly stderr: Buffer;
+	readonly exitCode: number;
+};
+
+export class FakeShellError extends Error implements FakeShellOutput {
+	readonly name = "ShellError";
+	readonly stdout: Buffer;
+	readonly stderr: Buffer;
+	readonly exitCode: number;
+
+	constructor(output: FakeShellOutput) {
+		super(`Failed with exit code ${output.exitCode}`);
+		this.stdout = output.stdout;
+		this.stderr = output.stderr;
+		this.exitCode = output.exitCode;
+	}
+}
+
+/**
+ * Mirrors the Bun 1.4 ShellPromise contract that matters here (verified against bun 1.4.0):
+ * - the command starts lazily on the first `then` call;
+ * - without `quiet()`, the child's output is streamed to the process' fd 1/2 as it runs;
+ * - `text()`/`json()`/`lines()` switch to quiet mode INTERNALLY (not via the instance `quiet` property);
+ * - `quiet()`/`nothrow()`/`throws()` return the same promise.
+ */
+export class FakeShellPromise extends Promise<FakeShellOutput> {
+	static get [Symbol.species](): PromiseConstructor {
+		return Promise;
+	}
+
+	readonly printed: string[];
+	#quiet = false;
+	#nothrow = false;
+	#started = false;
+	readonly #output: FakeShellOutput;
+
+	constructor(output: FakeShellOutput, printed: string[]) {
+		let settle: (value: FakeShellOutput) => void = () => {};
+		let fail: (error: unknown) => void = () => {};
+		super((resolve, reject) => {
+			settle = resolve;
+			fail = reject;
+		});
+		this.#output = output;
+		this.printed = printed;
+		this.#start = () => {
+			if (this.#started) return;
+			this.#started = true;
+			if (!this.#quiet) this.printed.push(this.#output.stdout.toString(), this.#output.stderr.toString());
+			if (this.#output.exitCode !== 0 && !this.#nothrow) fail(new FakeShellError(this.#output));
+			else settle(this.#output);
+		};
+	}
+
+	#start: () => void;
+
+	quiet(): this {
+		this.#quiet = true;
+		return this;
+	}
+
+	nothrow(): this {
+		this.#nothrow = true;
+		return this;
+	}
+
+	throws(shouldThrow: boolean): this {
+		this.#nothrow = !shouldThrow;
+		return this;
+	}
+
+	async text(): Promise<string> {
+		this.#quiet = true;
+		const result = await this.then((value) => value);
+		return result.stdout.toString();
+	}
+
+	// biome-ignore lint/suspicious/noThenProperty: intentional thenable — Bun's ShellPromise starts the command on its own then()
+	override then<TResult1 = FakeShellOutput, TResult2 = never>(
+		onFulfilled?: ((value: FakeShellOutput) => TResult1 | PromiseLike<TResult1>) | null,
+		onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
+	): Promise<TResult1 | TResult2> {
+		this.#start();
+		return super.then(onFulfilled, onRejected);
+	}
+}
+
+export type FakeSpawnCall = { readonly cmd: readonly string[]; readonly options: Record<string, unknown> };
+
+export type FakeBun = {
+	$: FakeShell;
+	spawn: (...args: unknown[]) => FakeSubprocess;
+	spawnSync: (...args: unknown[]) => unknown;
+};
+
+export type FakeShell = {
+	(strings: TemplateStringsArray, ...expressions: unknown[]): FakeShellPromise;
+	nothrow(): FakeShell;
+	throws(shouldThrow: boolean): FakeShell;
+	env(values?: Record<string, string>): FakeShell;
+	cwd(path?: string): FakeShell;
+	braces(pattern: string): string[];
+	escape(value: string): string;
+	Shell: () => void;
+	ShellPromise: typeof FakeShellPromise;
+	ShellError: typeof FakeShellError;
+	calls: string[];
+	/** Per template: whether it arrived wrapped in the stdin-isolation frame `true | (\n…\n)`. */
+	framed: boolean[];
+};
+
+const STDIN_ISOLATION_FRAME = /^true \| \(\n([\s\S]*)\n\)$/u;
+
+export type FakeSubprocess = {
+	readonly stderr: ReadableStream<Uint8Array> | undefined;
+	readonly exited: Promise<number>;
+};
+
+export function output(stdout: string, stderr = "", exitCode = 0): FakeShellOutput {
+	return { stdout: Buffer.from(stdout), stderr: Buffer.from(stderr), exitCode };
+}
+
+export function createFakeBun(): {
+	bun: FakeBun;
+	printed: string[];
+	spawnCalls: FakeSpawnCall[];
+	outputs: Map<string, FakeShellOutput>;
+} {
+	const printed: string[] = [];
+	const spawnCalls: FakeSpawnCall[] = [];
+	const outputs = new Map<string, FakeShellOutput>();
+	const shell = ((strings: TemplateStringsArray) => {
+		const joined = strings.join("");
+		const framed = STDIN_ISOLATION_FRAME.exec(joined);
+		shell.framed.push(framed !== null);
+		const command = framed?.[1] ?? joined;
+		return new FakeShellPromise(outputs.get(command) ?? output(""), printed);
+	}) as FakeShell;
+	shell.calls = [];
+	shell.framed = [];
+	shell.nothrow = () => {
+		shell.calls.push("nothrow");
+		return shell;
+	};
+	shell.throws = (shouldThrow) => {
+		shell.calls.push(`throws:${shouldThrow}`);
+		return shell;
+	};
+	shell.env = () => {
+		shell.calls.push("env");
+		return shell;
+	};
+	shell.cwd = () => {
+		shell.calls.push("cwd");
+		return shell;
+	};
+	shell.braces = (pattern) => [pattern];
+	shell.escape = (value) => value;
+	shell.Shell = () => {};
+	shell.ShellPromise = FakeShellPromise;
+	shell.ShellError = FakeShellError;
+	const spawn = (...args: unknown[]): FakeSubprocess => {
+		const [first, second] = args;
+		const options: Record<string, unknown> = Array.isArray(first)
+			? { ...(second as Record<string, unknown> | undefined) }
+			: { ...(first as Record<string, unknown>) };
+		const cmd = Array.isArray(first) ? (first as string[]) : (options.cmd as string[]);
+		spawnCalls.push({ cmd, options });
+		const stderr =
+			options.stderr === "pipe"
+				? new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(new TextEncoder().encode(`child stderr for ${cmd.join(" ")}\n`));
+							controller.close();
+						},
+					})
+				: undefined;
+		return { stderr, exited: Promise.resolve(0) };
+	};
+	const bun: FakeBun = { $: shell, spawn, spawnSync: () => ({}) };
+	return { bun, printed, spawnCalls, outputs };
+}
+
+export function installFakeBun(): ReturnType<typeof createFakeBun> {
+	const fake = createFakeBun();
+	Object.defineProperty(globalThis, "Bun", { value: fake.bun, configurable: true, writable: true });
+	return fake;
+}
+
+export function emitter(): { emitted: EmittedText[]; emitText: (stream: "stdout" | "stderr", data: string) => void } {
+	const emitted: EmittedText[] = [];
+	return { emitted, emitText: (stream, data) => emitted.push({ stream, data }) };
+}

--- a/packages/senpi-codemode/test/eval/js-worker-spawn-log.ts
+++ b/packages/senpi-codemode/test/eval/js-worker-spawn-log.ts
@@ -1,0 +1,68 @@
+import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export interface SpawnLoggingWorkerEntry {
+	readonly root: string;
+	readonly url: URL;
+	readonly spawnLog: string;
+}
+
+/**
+ * A worker entry that runs the real worker core and appends one line to `spawnLog` per spawn, so a
+ * test can prove whether the kernel replaced its worker VM. With `blockFirstReady` the first spawn
+ * swallows `init` (it never becomes ready) and reports a `readiness-blocked` phase instead.
+ */
+export async function createSpawnLoggingWorkerEntry(blockFirstReady = false): Promise<SpawnLoggingWorkerEntry> {
+	const root = await mkdtemp(join(tmpdir(), "senpi-js-lifecycle-"));
+	const entry = join(root, "worker-entry.mjs");
+	const spawnLog = join(root, "spawns.txt");
+	const gate = join(root, "first-started");
+	const coreUrl = pathToFileURL(join(process.cwd(), "src", "kernels", "js", "worker-core.js")).href;
+	const source = `
+import { closeSync, constants, openSync } from "node:fs";
+import { appendFileSync } from "node:fs";
+import { parentPort, workerData } from "node:worker_threads";
+import { createWorkerCore } from ${JSON.stringify(coreUrl)};
+
+if (!parentPort) throw new Error("test worker missing parentPort");
+appendFileSync(${JSON.stringify(spawnLog)}, "spawn\\n");
+
+const transport = {
+  send(message) { parentPort.postMessage(message); },
+  onMessage(handler) {
+    const listener = (message) => {
+      if (${JSON.stringify(blockFirstReady)} && message.type === "init") {
+        try {
+          const descriptor = openSync(${JSON.stringify(gate)}, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+          closeSync(descriptor);
+          parentPort.postMessage({ type: "phase", title: "readiness-blocked" });
+          return;
+        } catch (error) {
+          if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
+        }
+      }
+      handler(message);
+    };
+    parentPort.on("message", listener);
+    return () => parentPort.off("message", listener);
+  },
+  close() { parentPort.close(); },
+};
+
+createWorkerCore(transport, { cwd: workerData.cwd, parallelPoolWidth: workerData.parallelPoolWidth });
+`;
+	await writeFile(entry, source);
+	await appendFile(spawnLog, "");
+	return { root, url: pathToFileURL(entry), spawnLog };
+}
+
+export async function spawnCount(entry: SpawnLoggingWorkerEntry): Promise<number> {
+	const contents = await readFile(entry.spawnLog, "utf8");
+	return contents.split("\n").filter(Boolean).length;
+}
+
+export async function removeWorkerEntry(entry: SpawnLoggingWorkerEntry): Promise<void> {
+	await rm(entry.root, { recursive: true, force: true });
+}

--- a/packages/senpi-codemode/test/js-kernel-cooperative-interrupt.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-cooperative-interrupt.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { JavaScriptKernel } from "../src/kernels/js/context-manager.ts";
+import {
+	createSpawnLoggingWorkerEntry,
+	removeWorkerEntry,
+	type SpawnLoggingWorkerEntry,
+	spawnCount,
+} from "./eval/js-worker-spawn-log.ts";
+
+const UNRESPONSIVE_INTERRUPT_BUDGET_MS = 5_000;
+const BLOCKED_WORKER_STOP_BUDGET_MS = 4_500;
+const BLOCKED_WORKER_HOLD_MS = 8_000;
+const FRESH_WORKER_RUN_BUDGET_MS = 1_500;
+
+const kernels = new Set<JavaScriptKernel>();
+const entries = new Set<SpawnLoggingWorkerEntry>();
+
+afterEach(async () => {
+	await Promise.all([...kernels].map(async (kernel) => await kernel.close()));
+	await Promise.all([...entries].map(async (entry) => await removeWorkerEntry(entry)));
+	kernels.clear();
+	entries.clear();
+});
+
+async function createKernel(): Promise<{
+	readonly kernel: JavaScriptKernel;
+	readonly entry: SpawnLoggingWorkerEntry;
+}> {
+	const entry = await createSpawnLoggingWorkerEntry();
+	entries.add(entry);
+	const kernel = new JavaScriptKernel({
+		sessionId: `cooperative-${crypto.randomUUID()}`,
+		cwd: process.cwd(),
+		parallelPoolWidth: 2,
+		workerEntryUrl: entry.url,
+	});
+	kernels.add(kernel);
+	return { kernel, entry };
+}
+
+async function releaseBridgeCall(kernel: JavaScriptKernel): Promise<void> {
+	const call = await kernel.nextToolCall();
+	kernel.deliverToolReply({ type: "tool-reply", callId: call.callId, ok: true, value: null });
+}
+
+async function elapsed<T>(operation: Promise<T>): Promise<{ readonly value: T; readonly ms: number }> {
+	const startedAt = performance.now();
+	const value = await operation;
+	return { value, ms: performance.now() - startedAt };
+}
+
+describe("JavaScriptKernel cooperative interrupt", () => {
+	it("Given a cell parked on a promise nothing settles when interrupted then the worker restarts and the note is truthful", async () => {
+		const { kernel, entry } = await createKernel();
+		const run = kernel.run({
+			cellId: "unresponsive",
+			code: "globalThis.stuckMarker = 1; await tool.started({}); await new Promise(() => {})",
+			timeoutMs: 60_000,
+		});
+		await releaseBridgeCall(kernel);
+
+		const { value: handle, ms } = await elapsed(kernel.interrupt("unresponsive-stop"));
+
+		expect(ms).toBeLessThan(UNRESPONSIVE_INTERRUPT_BUDGET_MS);
+		await expect(run).resolves.toMatchObject({
+			ok: false,
+			error: { message: expect.stringContaining("unresponsive-stop") },
+		});
+		await expect(handle.stateRetained).resolves.toBe(false);
+		await expect(
+			kernel.run({ cellId: "after-restart", code: "return typeof stuckMarker", timeoutMs: 2_000 }),
+		).resolves.toMatchObject({ ok: true, valueRepr: '"undefined"' });
+		expect(await spawnCount(entry)).toBe(2);
+	});
+
+	it("Given a worker blocked in a synchronous child call when interrupted then a fresh worker replaces it within the stop deadline", async () => {
+		const { kernel, entry } = await createKernel();
+		const holdScript = `setTimeout(() => {}, ${BLOCKED_WORKER_HOLD_MS})`;
+		const run = kernel.run({
+			cellId: "sync-block",
+			code: [
+				'const { spawnSync } = await import("node:child_process");',
+				"await tool.started({});",
+				`spawnSync(process.execPath, ["-e", ${JSON.stringify(holdScript)}]);`,
+				'return "unblocked";',
+			].join("\n"),
+			timeoutMs: 60_000,
+		});
+		await releaseBridgeCall(kernel);
+
+		const { value: handle, ms } = await elapsed(kernel.interrupt("sync-stop"));
+
+		expect(ms).toBeLessThan(BLOCKED_WORKER_STOP_BUDGET_MS);
+		await expect(run).resolves.toMatchObject({
+			ok: false,
+			error: { message: expect.stringContaining("sync-stop") },
+		});
+		await expect(handle.stateRetained).resolves.toBe(false);
+		expect(handle.note).toMatch(/synchronous/iu);
+		const next = await elapsed(kernel.run({ cellId: "after-block", code: "return 42", timeoutMs: 2_000 }));
+		expect(next.value).toMatchObject({ ok: true, valueRepr: "42" });
+		expect(next.ms).toBeLessThan(FRESH_WORKER_RUN_BUDGET_MS);
+		expect(await spawnCount(entry)).toBe(2);
+	});
+
+	it("Given a cell awaiting a bridge call when its kernel timeout fires then the cell times out and the worker state survives", async () => {
+		const { kernel, entry } = await createKernel();
+		const run = kernel.run({
+			cellId: "timeout-retain",
+			code: "globalThis.timeoutMarker = 1; return await tool.started({})",
+			timeoutMs: 400,
+		});
+		await kernel.nextToolCall();
+
+		await expect(run).resolves.toMatchObject({
+			ok: false,
+			error: { message: expect.stringMatching(/timed out/iu) },
+		});
+		await expect(
+			kernel.run({ cellId: "after-timeout", code: "return timeoutMarker", timeoutMs: 2_000 }),
+		).resolves.toMatchObject({ ok: true, valueRepr: "1" });
+		expect(await spawnCount(entry)).toBe(1);
+	});
+});

--- a/packages/senpi-codemode/test/js-kernel-interrupt-bun.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-interrupt-bun.test.ts
@@ -1,0 +1,105 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import type { KernelToHostMessage } from "../src/bridge/protocol.ts";
+
+const kernelModulePath = fileURLToPath(new URL("../src/kernels/js/context-manager.ts", import.meta.url));
+const bunAvailable = spawnSync("bun", ["--version"], { encoding: "utf8" }).status === 0;
+
+type Result = Extract<KernelToHostMessage, { type: "result" }>;
+
+type DriverReport = {
+	readonly result: Result;
+	readonly stateRetained: boolean;
+	readonly childAlive: boolean;
+	readonly interruptMs: number;
+	readonly next: Result;
+	readonly nextMs: number;
+	readonly note: string | undefined;
+};
+
+const CHILD_EXIT_POLL_MS = 25;
+const CHILD_EXIT_POLL_ROUNDS = 80;
+const BLOCKED_WORKER_HOLD_SECONDS = 8;
+const BLOCKED_WORKER_STOP_BUDGET_MS = 4_500;
+const FRESH_WORKER_RUN_BUDGET_MS = 1_500;
+
+const SPAWN_CHILD_CELL =
+	'globalThis.childMarker = 1; const child = Bun.spawn(["sleep", "30"]); print("MARK=" + child.pid); await child.exited; return "exited"';
+const SYNC_BLOCK_CELL = `globalThis.childMarker = 1; print("MARK=0"); await Bun.sleep(50); Bun.spawnSync(["sleep", "${BLOCKED_WORKER_HOLD_SECONDS}"]); return "unblocked"`;
+
+function driverSource(cell: string): string {
+	return [
+		'import { writeFile } from "node:fs/promises";',
+		`import { JavaScriptKernel } from ${JSON.stringify(kernelModulePath)};`,
+		"const [reportPath] = process.argv.slice(2);",
+		'const kernel = new JavaScriptKernel({ sessionId: "interrupt-bun", cwd: process.cwd(), parallelPoolWidth: 1 });',
+		"const marker = Promise.withResolvers();",
+		"const run = kernel.run({",
+		'  cellId: "interrupt-target",',
+		`  code: ${JSON.stringify(cell)},`,
+		"  timeoutMs: 20_000,",
+		"  onMessage: (message) => {",
+		'    if (message.type !== "text") return;',
+		"    const match = /MARK=(\\d+)/.exec(message.data);",
+		"    if (match) marker.resolve(Number(match[1]));",
+		"  },",
+		"});",
+		"const pid = await marker.promise;",
+		"await Bun.sleep(150);",
+		"const interruptStartedAt = performance.now();",
+		'const handle = await kernel.interrupt("kill-child");',
+		"const interruptMs = performance.now() - interruptStartedAt;",
+		"const result = await run;",
+		"const stateRetained = await handle.stateRetained;",
+		"const isAlive = () => { if (pid === 0) return false; try { process.kill(pid, 0); return true; } catch { return false; } };",
+		`for (let round = 0; round < ${CHILD_EXIT_POLL_ROUNDS} && isAlive(); round += 1) await Bun.sleep(${CHILD_EXIT_POLL_MS});`,
+		"const childAlive = isAlive();",
+		"if (childAlive) process.kill(pid);",
+		"const nextStartedAt = performance.now();",
+		'const next = await kernel.run({ cellId: "after-interrupt", code: "return globalThis.childMarker", timeoutMs: 5_000 });',
+		"const nextMs = performance.now() - nextStartedAt;",
+		"await kernel.close();",
+		'await writeFile(reportPath, JSON.stringify({ result, stateRetained, childAlive, interruptMs, next, nextMs, note: handle.note }), "utf8");',
+	].join("\n");
+}
+
+async function runInterruptDriver(cell: string): Promise<DriverReport> {
+	const root = await mkdtemp(join(tmpdir(), "senpi-interrupt-bun-"));
+	try {
+		const driverPath = join(root, "driver.ts");
+		const reportPath = join(root, "report.json");
+		await writeFile(driverPath, driverSource(cell), "utf8");
+		const run = spawnSync("bun", [driverPath, reportPath], { encoding: "utf8", cwd: root, timeout: 60_000 });
+		if (run.status !== 0) throw new Error(`bun driver exited with ${run.status}: ${run.stderr}`);
+		return JSON.parse(await readFile(reportPath, "utf8"));
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+describe.skipIf(!bunAvailable)("JavaScript kernel under Bun interrupts a running cell", () => {
+	it("Given a cell awaiting `Bun.spawn(...).exited` when interrupted then the child is killed and the worker state survives", async () => {
+		const report = await runInterruptDriver(SPAWN_CHILD_CELL);
+
+		expect(report.result).toMatchObject({ ok: false, error: { message: expect.stringContaining("kill-child") } });
+		expect(report.childAlive).toBe(false);
+		expect(report.stateRetained).toBe(true);
+		expect(report.next).toMatchObject({ ok: true, valueRepr: "1" });
+	});
+
+	it("Given a worker blocked in `Bun.spawnSync` when interrupted then the stop returns within its deadline and a fresh worker serves the next cell", async () => {
+		const report = await runInterruptDriver(SYNC_BLOCK_CELL);
+
+		expect(report.interruptMs).toBeLessThan(BLOCKED_WORKER_STOP_BUDGET_MS);
+		expect(report.result).toMatchObject({ ok: false, error: { message: expect.stringContaining("kill-child") } });
+		expect(report.stateRetained).toBe(false);
+		expect(report.note).toMatch(/synchronous/iu);
+		expect(report.next).toMatchObject({ ok: true });
+		expect(report.next).not.toHaveProperty("valueRepr");
+		expect(report.nextMs).toBeLessThan(FRESH_WORKER_RUN_BUDGET_MS);
+	});
+});

--- a/packages/senpi-codemode/test/js-kernel-interrupt.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-interrupt.test.ts
@@ -1,16 +1,7 @@
-import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { KernelToHostMessage } from "../src/bridge/protocol.ts";
 import { JavaScriptKernel } from "../src/kernels/js/context-manager.ts";
-
-interface TestWorkerEntry {
-	readonly root: string;
-	readonly url: URL;
-	readonly spawnLog: string;
-}
+import { createSpawnLoggingWorkerEntry, removeWorkerEntry, spawnCount } from "./eval/js-worker-spawn-log.ts";
 
 const kernels = new Set<JavaScriptKernel>();
 
@@ -33,62 +24,9 @@ function createKernel(
 	return kernel;
 }
 
-async function createWorkerEntry(blockFirstReady: boolean): Promise<TestWorkerEntry> {
-	const root = await mkdtemp(join(tmpdir(), "senpi-js-lifecycle-"));
-	const entry = join(root, "worker-entry.mjs");
-	const spawnLog = join(root, "spawns.txt");
-	const gate = join(root, "first-started");
-	const coreUrl = pathToFileURL(join(process.cwd(), "src", "kernels", "js", "worker-core.js")).href;
-	const source = `
-import { closeSync, constants, openSync } from "node:fs";
-import { appendFileSync } from "node:fs";
-import { parentPort, workerData } from "node:worker_threads";
-import { createWorkerCore } from ${JSON.stringify(coreUrl)};
-
-if (!parentPort) throw new Error("test worker missing parentPort");
-appendFileSync(${JSON.stringify(spawnLog)}, "spawn\\n");
-
-const transport = {
-  send(message) { parentPort.postMessage(message); },
-  onMessage(handler) {
-    const listener = (message) => {
-      if (${JSON.stringify(blockFirstReady)} && message.type === "init") {
-        try {
-          const descriptor = openSync(${JSON.stringify(gate)}, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
-          closeSync(descriptor);
-          parentPort.postMessage({ type: "phase", title: "readiness-blocked" });
-          return;
-        } catch (error) {
-          if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") throw error;
-        }
-      }
-      handler(message);
-    };
-    parentPort.on("message", listener);
-    return () => parentPort.off("message", listener);
-  },
-  close() { parentPort.close(); },
-};
-
-createWorkerCore(transport, { cwd: workerData.cwd, parallelPoolWidth: workerData.parallelPoolWidth });
-`;
-	await writeFile(entry, source);
-	await appendFile(spawnLog, "");
-	return { root, url: pathToFileURL(entry), spawnLog };
-}
-
-async function spawnCount(entry: TestWorkerEntry): Promise<number> {
-	const contents = await readFile(entry.spawnLog, "utf8");
-	return contents.split("\n").filter(Boolean).length;
-}
-
-async function removeWorkerEntry(entry: TestWorkerEntry): Promise<void> {
-	await rm(entry.root, { recursive: true, force: true });
-}
-
 describe("JavaScriptKernel lifecycle", () => {
 	it("does not lose an interrupt while run awaits worker readiness", async () => {
-		const entry = await createWorkerEntry(true);
+		const entry = await createSpawnLoggingWorkerEntry(true);
 		let readinessBlocked: (() => void) | undefined;
 		const blocked = new Promise<void>((resolve) => {
 			readinessBlocked = resolve;
@@ -121,7 +59,7 @@ describe("JavaScriptKernel lifecycle", () => {
 		}
 	});
 
-	it("interrupts an active run after its observable execution-start tool call", async () => {
+	it("interrupts an active run at its pending bridge call and keeps the worker state", async () => {
 		const kernel = createKernel();
 		const run = kernel.run({
 			cellId: "active-interrupt",
@@ -131,17 +69,18 @@ describe("JavaScriptKernel lifecycle", () => {
 		const started = await kernel.nextToolCall();
 		expect(started).toMatchObject({ toolName: "started", args: { marker: 1 } });
 
-		await kernel.interrupt("active-stop");
+		const handle = await kernel.interrupt("active-stop");
 
 		await expect(run).resolves.toMatchObject({
 			ok: false,
 			error: { message: expect.stringContaining("active-stop") },
 		});
+		await expect(handle.stateRetained).resolves.toBe(true);
 		await expect(
-			kernel.run({ cellId: "fresh", code: "return typeof interruptMarker", timeoutMs: 2_000 }),
+			kernel.run({ cellId: "fresh", code: "return interruptMarker", timeoutMs: 2_000 }),
 		).resolves.toMatchObject({
 			ok: true,
-			valueRepr: '"undefined"',
+			valueRepr: "1",
 		});
 	});
 
@@ -201,7 +140,7 @@ describe("JavaScriptKernel lifecycle", () => {
 	});
 
 	it("does not restart or publish a worker after concurrent interrupt and close", async () => {
-		const entry = await createWorkerEntry(false);
+		const entry = await createSpawnLoggingWorkerEntry();
 		let readyMessages = 0;
 		const kernel = createKernel({
 			workerEntryUrl: entry.url,
@@ -231,7 +170,7 @@ describe("JavaScriptKernel lifecycle", () => {
 
 	it("does not restart or publish a worker when close overtakes timeout recovery", async () => {
 		vi.useFakeTimers();
-		const entry = await createWorkerEntry(false);
+		const entry = await createSpawnLoggingWorkerEntry();
 		let readyMessages = 0;
 		const kernel = createKernel({
 			workerEntryUrl: entry.url,

--- a/packages/senpi-codemode/test/js-kernel-shell-capture-bun.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture-bun.test.ts
@@ -1,4 +1,5 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -49,6 +50,38 @@ async function runCellUnderBun(code: string): Promise<DriverRun> {
 	}
 }
 
+const OPEN_STDIN_CELL_TIMEOUT_MS = 5_000;
+
+async function runCellUnderBunWithOpenStdin(code: string): Promise<DriverRun> {
+	const root = await mkdtemp(join(tmpdir(), "senpi-shell-stdin-"));
+	try {
+		const driverPath = join(root, "driver.ts");
+		const reportPath = join(root, "report.json");
+		await writeFile(driverPath, driverSource(OPEN_STDIN_CELL_TIMEOUT_MS), "utf8");
+		const child = spawn("bun", [driverPath, code, reportPath], { cwd: root, stdio: ["pipe", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8").on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+		child.stderr.setEncoding("utf8").on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+		const [status] = (await once(child, "exit")) as [number | null];
+		if (status !== 0) throw new Error(`bun driver exited with ${status}: ${stderr}`);
+		const report: DriverReport = JSON.parse(await readFile(reportPath, "utf8"));
+		return { stdout, stderr, report };
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+function textOf(messages: readonly KernelToHostMessage[], stream: "stdout" | "stderr"): string {
+	return messages
+		.flatMap((message) => (message.type === "text" && message.stream === stream ? [message.data] : []))
+		.join("");
+}
+
 describe.skipIf(!bunAvailable)("JavaScript kernel under Bun keeps child output off the host terminal", () => {
 	it("Given a cell awaiting `Bun.$` without quiet when it runs then the output lands in the cell, not on fd 1", async () => {
 		const run = await runCellUnderBun(
@@ -78,5 +111,38 @@ describe.skipIf(!bunAvailable)("JavaScript kernel under Bun keeps child output o
 
 		expect(run.report.result).toMatchObject({ ok: true, valueRepr: "0" });
 		expect(run.stderr).not.toContain("SPAWN_LEAK_MARKER");
+	});
+});
+
+describe.skipIf(!bunAvailable)("JavaScript kernel under Bun keeps the host stdin away from `Bun.$` children", () => {
+	it("Given the host keeps its stdin open when a cell awaits `Bun.$` on a command that reads stdin then the command sees EOF instead of waiting on the host", async () => {
+		const run = await runCellUnderBunWithOpenStdin(
+			"const r = await Bun.$`cat`.nothrow(); return [r.exitCode, r.stdout.toString().length]",
+		);
+
+		expect(run.report.result).toMatchObject({ ok: true, valueRepr: "[0,0]" });
+	});
+
+	it("Given the host keeps its stdin open when the stdin reader heads a pipeline then the pipeline still completes", async () => {
+		const run = await runCellUnderBunWithOpenStdin("return (await Bun.$`cat | wc -c`.text()).trim()");
+
+		expect(run.report.result).toMatchObject({ ok: true, valueRepr: '"0"' });
+	});
+
+	it("Given stdin isolation when a command exits non-zero with output on both streams then exit code, stdout, and stderr are unchanged", async () => {
+		const run = await runCellUnderBunWithOpenStdin(
+			"const r = await Bun.$`sh -c 'printf PAR_ERR >&2; printf PAR_OUT; exit 7'`.nothrow().quiet(); return [r.exitCode, r.stdout.toString(), r.stderr.toString()]",
+		);
+
+		expect(run.report.result).toMatchObject({ ok: true, valueRepr: '[7,"PAR_OUT","PAR_ERR"]' });
+	});
+
+	it("Given stdin isolation when the cell redirects its own stdin from a Response then that input still reaches the command", async () => {
+		const run = await runCellUnderBunWithOpenStdin(
+			// biome-ignore lint/suspicious/noTemplateCurlyInString: the placeholder belongs to the cell's own Bun.$ template
+			'return await Bun.$`cat < ${new Response("own-input")}`.text()',
+		);
+
+		expect(run.report.result).toMatchObject({ ok: true, valueRepr: '"own-input"' });
 	});
 });

--- a/packages/senpi-codemode/test/js-kernel-shell-capture-bun.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture-bun.test.ts
@@ -21,14 +21,14 @@ type DriverRun = {
 	readonly report: DriverReport;
 };
 
-function driverSource(): string {
+function driverSource(cellTimeoutMs: number): string {
 	return [
 		'import { writeFile } from "node:fs/promises";',
 		`import { JavaScriptKernel } from ${JSON.stringify(kernelModulePath)};`,
 		"const [code, reportPath] = process.argv.slice(2);",
 		'const kernel = new JavaScriptKernel({ sessionId: "shell-capture", cwd: process.cwd(), parallelPoolWidth: 1 });',
 		"const messages = [];",
-		'const result = await kernel.run({ cellId: "shell-capture-cell", code, timeoutMs: 20_000, onMessage: (message) => messages.push(message) });',
+		`const result = await kernel.run({ cellId: "shell-capture-cell", code, timeoutMs: ${cellTimeoutMs}, onMessage: (message) => messages.push(message) });`,
 		"await kernel.close();",
 		'await writeFile(reportPath, JSON.stringify({ mode: kernel.mode, result, messages }), "utf8");',
 	].join("\n");
@@ -39,7 +39,7 @@ async function runCellUnderBun(code: string): Promise<DriverRun> {
 	try {
 		const driverPath = join(root, "driver.ts");
 		const reportPath = join(root, "report.json");
-		await writeFile(driverPath, driverSource(), "utf8");
+		await writeFile(driverPath, driverSource(20_000), "utf8");
 		const run = spawnSync("bun", [driverPath, code, reportPath], { encoding: "utf8", cwd: root, timeout: 60_000 });
 		if (run.status !== 0) throw new Error(`bun driver exited with ${run.status}: ${run.stderr}`);
 		const report: DriverReport = JSON.parse(await readFile(reportPath, "utf8"));
@@ -47,12 +47,6 @@ async function runCellUnderBun(code: string): Promise<DriverRun> {
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
-}
-
-function textOf(messages: readonly KernelToHostMessage[], stream: "stdout" | "stderr"): string {
-	return messages
-		.flatMap((message) => (message.type === "text" && message.stream === stream ? [message.data] : []))
-		.join("");
 }
 
 describe.skipIf(!bunAvailable)("JavaScript kernel under Bun keeps child output off the host terminal", () => {

--- a/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
@@ -1,9 +1,15 @@
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import type { ShellCaptureOptions, ShellCaptureRestore } from "../src/kernels/js/worker-shell-capture.d.ts";
-
-type InstallShellCapture = (options: ShellCaptureOptions) => ShellCaptureRestore;
+import type { ShellCaptureRestore } from "../src/kernels/js/worker-shell-capture.d.ts";
+import {
+	emitter,
+	FakeShellError,
+	FakeShellPromise,
+	type InstallShellCapture,
+	installFakeBun,
+	output,
+} from "./eval/fake-bun-shell.ts";
 
 const captureModuleUrl = pathToFileURL(join(process.cwd(), "src", "kernels", "js", "worker-shell-capture.js")).href;
 
@@ -17,196 +23,6 @@ async function loadInstallShellCapture(): Promise<InstallShellCapture> {
 	const loaded: unknown = await import(captureModuleUrl);
 	if (!isShellCaptureModule(loaded)) throw new Error("worker-shell-capture.js does not export installShellCapture");
 	return loaded.installShellCapture;
-}
-
-type EmittedText = { readonly stream: "stdout" | "stderr"; readonly data: string };
-
-type FakeShellOutput = {
-	readonly stdout: Buffer;
-	readonly stderr: Buffer;
-	readonly exitCode: number;
-};
-
-class FakeShellError extends Error implements FakeShellOutput {
-	readonly name = "ShellError";
-	readonly stdout: Buffer;
-	readonly stderr: Buffer;
-	readonly exitCode: number;
-
-	constructor(output: FakeShellOutput) {
-		super(`Failed with exit code ${output.exitCode}`);
-		this.stdout = output.stdout;
-		this.stderr = output.stderr;
-		this.exitCode = output.exitCode;
-	}
-}
-
-/**
- * Mirrors the Bun 1.4 ShellPromise contract that matters here (verified against bun 1.4.0):
- * - the command starts lazily on the first `then` call;
- * - without `quiet()`, the child's output is streamed to the process' fd 1/2 as it runs;
- * - `text()`/`json()`/`lines()` switch to quiet mode INTERNALLY (not via the instance `quiet` property);
- * - `quiet()`/`nothrow()`/`throws()` return the same promise.
- */
-class FakeShellPromise extends Promise<FakeShellOutput> {
-	static get [Symbol.species](): PromiseConstructor {
-		return Promise;
-	}
-
-	readonly printed: string[];
-	#quiet = false;
-	#nothrow = false;
-	#started = false;
-	readonly #output: FakeShellOutput;
-
-	constructor(output: FakeShellOutput, printed: string[]) {
-		let settle: (value: FakeShellOutput) => void = () => {};
-		let fail: (error: unknown) => void = () => {};
-		super((resolve, reject) => {
-			settle = resolve;
-			fail = reject;
-		});
-		this.#output = output;
-		this.printed = printed;
-		this.#start = () => {
-			if (this.#started) return;
-			this.#started = true;
-			if (!this.#quiet) this.printed.push(this.#output.stdout.toString(), this.#output.stderr.toString());
-			if (this.#output.exitCode !== 0 && !this.#nothrow) fail(new FakeShellError(this.#output));
-			else settle(this.#output);
-		};
-	}
-
-	#start: () => void;
-
-	quiet(): this {
-		this.#quiet = true;
-		return this;
-	}
-
-	nothrow(): this {
-		this.#nothrow = true;
-		return this;
-	}
-
-	throws(shouldThrow: boolean): this {
-		this.#nothrow = !shouldThrow;
-		return this;
-	}
-
-	async text(): Promise<string> {
-		this.#quiet = true;
-		const result = await this.then((value) => value);
-		return result.stdout.toString();
-	}
-
-	// biome-ignore lint/suspicious/noThenProperty: intentional thenable — Bun's ShellPromise starts the command on its own then()
-	override then<TResult1 = FakeShellOutput, TResult2 = never>(
-		onFulfilled?: ((value: FakeShellOutput) => TResult1 | PromiseLike<TResult1>) | null,
-		onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null,
-	): Promise<TResult1 | TResult2> {
-		this.#start();
-		return super.then(onFulfilled, onRejected);
-	}
-}
-
-type FakeSpawnCall = { readonly cmd: readonly string[]; readonly options: Record<string, unknown> };
-
-type FakeBun = {
-	$: FakeShell;
-	spawn: (...args: unknown[]) => FakeSubprocess;
-	spawnSync: (...args: unknown[]) => unknown;
-};
-
-type FakeShell = {
-	(strings: TemplateStringsArray, ...expressions: unknown[]): FakeShellPromise;
-	nothrow(): FakeShell;
-	throws(shouldThrow: boolean): FakeShell;
-	env(values?: Record<string, string>): FakeShell;
-	cwd(path?: string): FakeShell;
-	braces(pattern: string): string[];
-	escape(value: string): string;
-	Shell: () => void;
-	ShellPromise: typeof FakeShellPromise;
-	ShellError: typeof FakeShellError;
-	calls: string[];
-};
-
-type FakeSubprocess = {
-	readonly stderr: ReadableStream<Uint8Array> | undefined;
-	readonly exited: Promise<number>;
-};
-
-function output(stdout: string, stderr = "", exitCode = 0): FakeShellOutput {
-	return { stdout: Buffer.from(stdout), stderr: Buffer.from(stderr), exitCode };
-}
-
-function createFakeBun(): {
-	bun: FakeBun;
-	printed: string[];
-	spawnCalls: FakeSpawnCall[];
-	outputs: Map<string, FakeShellOutput>;
-} {
-	const printed: string[] = [];
-	const spawnCalls: FakeSpawnCall[] = [];
-	const outputs = new Map<string, FakeShellOutput>();
-	const shell = ((strings: TemplateStringsArray) => {
-		const command = strings.join("");
-		return new FakeShellPromise(outputs.get(command) ?? output(""), printed);
-	}) as FakeShell;
-	shell.calls = [];
-	shell.nothrow = () => {
-		shell.calls.push("nothrow");
-		return shell;
-	};
-	shell.throws = (shouldThrow) => {
-		shell.calls.push(`throws:${shouldThrow}`);
-		return shell;
-	};
-	shell.env = () => {
-		shell.calls.push("env");
-		return shell;
-	};
-	shell.cwd = () => {
-		shell.calls.push("cwd");
-		return shell;
-	};
-	shell.braces = (pattern) => [pattern];
-	shell.escape = (value) => value;
-	shell.Shell = () => {};
-	shell.ShellPromise = FakeShellPromise;
-	shell.ShellError = FakeShellError;
-	const spawn = (...args: unknown[]): FakeSubprocess => {
-		const [first, second] = args;
-		const options: Record<string, unknown> = Array.isArray(first)
-			? { ...(second as Record<string, unknown> | undefined) }
-			: { ...(first as Record<string, unknown>) };
-		const cmd = Array.isArray(first) ? (first as string[]) : (options.cmd as string[]);
-		spawnCalls.push({ cmd, options });
-		const stderr =
-			options.stderr === "pipe"
-				? new ReadableStream<Uint8Array>({
-						start(controller) {
-							controller.enqueue(new TextEncoder().encode(`child stderr for ${cmd.join(" ")}\n`));
-							controller.close();
-						},
-					})
-				: undefined;
-		return { stderr, exited: Promise.resolve(0) };
-	};
-	const bun: FakeBun = { $: shell, spawn, spawnSync: () => ({}) };
-	return { bun, printed, spawnCalls, outputs };
-}
-
-function installFakeBun(): ReturnType<typeof createFakeBun> {
-	const fake = createFakeBun();
-	Object.defineProperty(globalThis, "Bun", { value: fake.bun, configurable: true, writable: true });
-	return fake;
-}
-
-function emitter(): { emitted: EmittedText[]; emitText: (stream: "stdout" | "stderr", data: string) => void } {
-	const emitted: EmittedText[] = [];
-	return { emitted, emitText: (stream, data) => emitted.push({ stream, data }) };
 }
 
 describe("JS kernel shell output capture", () => {

--- a/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
+++ b/packages/senpi-codemode/test/js-kernel-shell-capture.test.ts
@@ -124,6 +124,22 @@ describe("JS kernel shell output capture", () => {
 		expect(promise).toBeInstanceOf(FakeShellPromise);
 		expect(fake.printed).toEqual(["idle\n", ""]);
 		expect(emitted).toEqual([]);
+		expect(fake.bun.$.framed).toEqual([false]);
+	});
+
+	it("Given an active cell when `$` runs then the template is framed so its commands read an empty stdin", async () => {
+		const fake = installFakeBun();
+		fake.outputs.set("cat file.txt | wc -c", output("0\n"));
+		const { emitText } = emitter();
+		let active = true;
+		restore = installShellCapture({ isActive: () => active, emitText });
+
+		const framed = await fake.bun.$`cat file.txt | wc -c`.text();
+		active = false;
+		await fake.bun.$`echo after`;
+
+		expect(framed).toBe("0\n");
+		expect(fake.bun.$.framed).toEqual([true, false]);
 	});
 
 	it("Given the captured shell when shell-level configuration methods are used then they chain on the captured shell", () => {


### PR DESCRIPTION
Fixes #1403.

## What

Three defects in the JavaScript eval kernel made the model and the user perceive "eval hangs" (audit of 30k eval calls across 309 sessions, 2026-08-27 → 09-06):

1. **`stop` hung when the worker was blocked in a synchronous call** (`Bun.spawnSync`): `worker.terminate()` had no deadline (51 min in production).
2. **`Bun.$` children inherited the TUI's terminal as stdin**: `cat`, ssh/git credential prompts, keychain dialogs blocked cells forever.
3. **Every interrupt/timeout wiped the worker VM** and the note claimed the worker was "unresponsive" without asking it; the detached-cell notification hardcoded the note per language.

## How

- `533c49098` **cooperative interrupt + bounded stop**: `stop` and kernel timeouts post `interrupt`; the worker acks at once (`interrupt-ack` status), rejects pending bridge `tool.*` calls, kills tracked `Bun.spawn` children, and the cell settles. Settled within the grace (ack 500 ms + 2 s) → worker and globals **retained** (Python parity). Otherwise the worker is retired under a 3 s termination deadline; a worker blocked in a synchronous call is abandoned, replaced in the background, and the interrupt handle carries a note naming the blocked synchronous call. The worker generation moved to `worker-slot.ts`, startup to `worker-startup.ts`, bounds to `interrupt-bounds.ts` (context-manager.ts is 223 pure LOC now).
- `d36616e5b` **stdin isolation**: while a cell is active every `Bun.$` template is framed as `true | (\n…\n)`; the Bun shell has no other stdin control (no `$.stdin`, no redirect on a subshell). Parity verified for exit codes, stderr, `cd`, comments, array interpolation, env prefixes, `2>&1`, file redirects, nested pipes, 1 MiB stdout, `ShellError` shape, explicit `< ${Response}`.
- `ae98f2100` **truthful outcome notes**: the completion notification is parked until the kernel's interrupt handle resolves; notes come from `interruptionStateNote` / `unknownInterruptionStateNote`; the kernel's note (abandoned blocked worker) is appended to stop results, foreground timeout errors, and notifications.
- `7a30506ce` README / CHANGELOG `[Unreleased]` / `changes.md`.

## Evidence

RED before the fix (mengmotaMac, base `fdccd6261`): 12 failed / 12 passed across the new contracts — see the issue comment.

GREEN + mutation proofs (mengmotaMac): focused suites 97/97; mutations each RED on their own (stdin frame removed → 3 fail, worker ignores `interrupt` → 4 fail, unbounded terminate → 2 fail, hardcoded note → 6 fail).

Regression gate: `packages/senpi-codemode` full vitest suite **743 passed / 6 skipped (107 files)** on mengmotaMac (bun 1.4.0, node 26) and on an ascii box (Linux x86_64, bun 1.4.0, node 24); root `bun run check` exit 0 (mengmotaMac + local).

Real surface: `scripts/qa-js-interrupt-state.ts` (new; foreground timeout keeps state, detached stop keeps state, blocked-worker stop returns < 5 s with the synchronous-call note), `qa-detached-peek`, `qa-timeout-state`, and a PTY-hosted driver (`script`) proving `Bun.$\`cat\`` returns `[0,0,"0","own"]` in 18 ms while `process.stdin.isTTY === true`.

Final-tree reruns on both boxes are posted on #1403 before merge.

## Windows note

No Windows-specific paths (file handles, separators, process spawn semantics) change; the Bun driver tests use `sh`/`sleep`, which the existing `js-kernel-shell-capture-bun.test.ts` already relies on.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three JavaScript eval kernel defects in `packages/senpi-codemode` (#1403): `stop` could hang indefinitely on a worker blocked in synchronous code and always wiped the worker VM, `Bun.$` commands inherited the TUI's terminal as stdin and blocked cells forever, and detached-cell notifications reported a hardcoded per-language outcome instead of the real one. JS `stop` now interrupts cooperatively and keeps the worker VM when the cell settles within a grace period; worker termination is bounded so a blocked worker is replaced instead of hanging.

**Interrupt behavior**
- `stop` and kernel timeouts ask the worker to settle the cell; it acks immediately, rejects the cell's pending bridge `tool.*` calls, and kills its `Bun.spawn` children.
- A cell that settles within the ack (500 ms) and grace (2 s) window keeps the worker and all globals; only an unsettled cell restarts the worker.
- A worker blocked in a synchronous call (`Bun.spawnSync`) is retired under a 3 s termination deadline and replaced in the background, with the output naming the blocked call.

**Shell and notifications**
- While a cell is active, every `Bun.$` template is framed as `true | (\n…\n)` so no command inherits the TUI terminal as stdin; stdout, stderr, exit codes, `cwd`, `env`, and explicit `< ${input}` redirects are unchanged.
- Detached-cell completion notifications now wait for the kernel's interrupt handle and report the true outcome, including the note when a blocked worker was abandoned.

<sup>Written for commit 53a88c70c0610760549e676f1f5cce9d49fd7dd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

