### PR TITLE
fix(rpc): remove shared-host session admission cap

### DIFF
--- a/packages/coding-agent/docs/rpc.md
+++ b/packages/coding-agent/docs/rpc.md
@@ -188,16 +188,16 @@ occupancy bounds itself, independent of the supervisor and of client cooperation
   background terminal jobs and any other published wake source (terminal monitors, loop-guard holds), compaction,
   and barrier-held session work all defer eviction, and the idle clock restarts when that work settles. An evicted
   session resumes like any other: the next `open_session` with the same `sessionPath` reopens it.
-- **Session cap**: `open_session` beyond `SENPI_RPC_MAX_SESSIONS` concurrently opening/open sessions (default 8)
-  fails with `too_many_sessions`. Attaching to an already-hosted session (`attached: true`) adds no runtime and never
-  counts against the cap, so resume and second-surface flows keep working while at it.
+- **Logical sessions**: `open_session` has no session-count admission limit. Every logical session remains isolated
+  by its routing handle and provider scope inside this one shared daemon; idle eviction and empty-host shutdown
+  reclaim resident resources without rejecting a new session.
 - **Empty-host exit**: when the registry holds zero sessions AND no client is connected, continuously for
   `SENPI_RPC_HOST_EMPTY_EXIT_MS` (default 15 minutes), the host exits through its clean shutdown path (flush, socket
   removal), for stdio and `--listen` hosts alike. A connected client counts as occupancy even with no session open,
   so the host never drops a live socket under itself. Supervised hosts stay clean either way: a supervisor reads a
   child exit of 0 without a signal as an intentional idle stop and exits 0 with the same cleanup, not as a crash.
 
-Values are positive integers; invalid values fall through to the defaults. These bounds run inside the host process,
+Values are positive integers; invalid values fall through to the defaults. These lifecycle windows run inside the host process,
 so they hold even for embedders and hand-started hosts that have no supervisor.
 
 ### D1 normative table (multi-session mode)
@@ -205,7 +205,7 @@ so they hold even for embedders and hand-started hosts that have no supervisor.
 | Command | Params | Success data | Notes |
 | --- | --- | --- | --- |
 | `get_protocol_info` | - | `{ protocolVersion: 1, serverVersion: string, capabilities: string[], mode: "classic"\|"multi" }` | Answered in BOTH modes; side-effect-free; the capability probe. Multi-session hosts include `multi_session` plus the negotiated launch capabilities. |
-| `open_session` | `sessionPath?`, `cwd?`, `provider?`, `modelId?`, `thinkingLevel?`, `permissionPreset?` (all optional; paths MUST be absolute) | `{ sessionId, state: RpcSessionState, attached?: true }` | `sessionPath` = today's `--session` semantics (open-if-exists else create persisting there, `session-manager.ts:926-940`); `provider`/`modelId` applied only on create (resume restores the session's model — mirrors `SenpiSessionRuntime.ts:198-200`); params form the immutable launch profile (D8). When the path is already held by a fully-open session, the open ATTACHES to it: same routing handle, `attached: true`, one more attachment counted; the runtime is torn down only when the last attachment closes. Fails with `too_many_sessions` at the occupancy cap (see [Shared host occupancy](#shared-host-occupancy-idle-eviction-session-cap-empty-host-exit)); idle sessions past the eviction window are closed by the host itself. |
+| `open_session` | `sessionPath?`, `cwd?`, `provider?`, `modelId?`, `thinkingLevel?`, `permissionPreset?` (all optional; paths MUST be absolute) | `{ sessionId, state: RpcSessionState, attached?: true }` | `sessionPath` = today's `--session` semantics (open-if-exists else create persisting there, `session-manager.ts:926-940`); `provider`/`modelId` applied only on create (resume restores the session's model — mirrors `SenpiSessionRuntime.ts:198-200`); params form the immutable launch profile (D8). When the path is already held by a fully-open session, the open ATTACHES to it: same routing handle, `attached: true`, one more attachment counted; the runtime is torn down only when the last attachment closes. Idle sessions past the eviction window are closed by the host itself. |
 | `close_session` | `sessionId` | `{}` | Aborts active work, awaits agent idle + settled persistence for up to the host grace window (default 10s), then force-releases the session; its response is the LAST record tagged with that handle for the first closer — no events after (test-pinned). A concurrent close joins the same teardown and receives its own successful response. |
 | `list_sessions` | - | `{ sessions: [{ sessionId, durableSessionId, sessionPath, cwd, name, status }] }` | Includes `opening`/`closing` entries with their status. |
 | every existing command | + `sessionId` (REQUIRED in multi mode) | unchanged | Routed to that session. |
@@ -224,7 +224,6 @@ In the response `error` field, machine-matchable:
 - `missing_session_id` (session-scoped command without `sessionId` in multi mode)
 - `multi_session_disabled` (`open_session` in classic mode)
 - `invalid_path` (relative `sessionPath`/`cwd`)
-- `too_many_sessions` (`open_session` while `SENPI_RPC_MAX_SESSIONS` sessions are already opening/open; attaching to a live session never fails this way)
 - `open_failed: <detail>`
 - `media_not_found` (`get_media` for an unknown `toolCallId`, or a `contentIndex` that does not point at an image block)
 

--- a/packages/coding-agent/src/modes/rpc/changes.md
+++ b/packages/coding-agent/src/modes/rpc/changes.md
@@ -1,5 +1,26 @@
 # changes
 
+## Shared-host logical sessions are unlimited by default (2026-09-06)
+
+### What changed
+
+- `multi-session-host.ts` and `session-registry.ts`: the session-count admission gate is removed. Logical session admission is unlimited; attach/path/lifecycle safety and idle/empty-host resource reclamation remain.
+- `docs/rpc.md`: the occupancy and D1 sections now define unlimited logical sessions as the only production behavior.
+- `test/rpc-session-occupancy.test.ts`: regression coverage opens 12 distinct sessions through the registry and 9 through the host core, then verifies close/reopen/attach lifecycle behavior.
+
+### Why
+
+- The cap refused `open_session` with `too_many_sessions` once 8 sessions were concurrently opening/open, which is a client-visible failure for an ordinary desktop workload that keeps more than eight logical sessions around. Admission control was the wrong lever: idle eviction and empty-host exit reclaim resident resources without failing a user's open.
+- A user session is never rejected because another session exists. Resident-resource reclamation remains lifecycle-driven and does not evict or borrow another user session as an admission workaround.
+
+### Why an extension could not handle it
+
+- Admission happens inside `RpcSessionRegistry.openSession`, beneath every extension surface; no extension observes or overrides the registry's open path.
+
+### Expected merge conflict zones
+
+- LOW: the `resolveHostIdlePolicy` tail in `multi-session-host.ts`, the occupancy section in `docs/rpc.md`, and the `(4.2)` regression block in `test/rpc-session-occupancy.test.ts`.
+
 ## `ensureHost` teardown never outranks the readiness diagnostic (2026-09-04)
 
 ### What changed

--- a/packages/coding-agent/src/modes/rpc/multi-session-host.ts
+++ b/packages/coding-agent/src/modes/rpc/multi-session-host.ts
@@ -42,16 +42,12 @@ export interface MultiSessionHostOptions {
 
 /** Environment override for the idle-session eviction window, in milliseconds. */
 export const RPC_SESSION_IDLE_EVICTION_MS_ENV = "SENPI_RPC_SESSION_IDLE_EVICTION_MS";
-/** Environment override for the concurrent open-session cap. */
-export const RPC_MAX_SESSIONS_ENV = "SENPI_RPC_MAX_SESSIONS";
 /** Environment override for the empty-host exit window, in milliseconds. */
 export const RPC_HOST_EMPTY_EXIT_MS_ENV = "SENPI_RPC_HOST_EMPTY_EXIT_MS";
 /** Environment override for the graceful close_session teardown window, in milliseconds. */
 export const RPC_CLOSE_GRACE_MS_ENV = "SENPI_RPC_CLOSE_GRACE_MS";
 /** Default idle-eviction window: 30 minutes after a session's last routed command or settled turn. */
 export const DEFAULT_SESSION_IDLE_EVICTION_MS = 30 * 60_000;
-/** Default session cap: an idle session holds a full runtime (~340-510 MB RSS measured). */
-export const DEFAULT_MAX_SESSIONS = 8;
 /** Default empty-host exit: 15 minutes with zero open sessions, matching the supervisor's idle window. */
 export const DEFAULT_HOST_EMPTY_EXIT_MS = 15 * 60_000;
 /** Win32 named-pipe close can leave libuv's server callback pending after handles are destroyed. */
@@ -62,7 +58,6 @@ export interface HostIdleOverrides {
 	now?: () => number;
 	idleEvictionMs?: number;
 	emptyExitMs?: number;
-	maxSessions?: number;
 	closeGraceMs?: number;
 	/** Shutdown hook the empty-exit window invokes; hosts pass their exit path. */
 	onEmptyExit?: () => void;
@@ -70,17 +65,13 @@ export interface HostIdleOverrides {
 	canExitWhenEmpty?: () => boolean;
 }
 
-function parseSessionCap(value: string | undefined): number | undefined {
-	if (value === undefined || !/^\d+$/.test(value.trim())) return undefined;
-	const parsed = Number(value.trim());
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-/** Precedence: explicit overrides beat environment variables beat documented defaults. */
+/**
+ * Resolve the host's idle lifecycle policy.
+ */
 export function resolveHostIdlePolicy(
 	env: Readonly<Record<string, string | undefined>>,
 	overrides: HostIdleOverrides = {},
-): { now: () => number; idleEvictionMs: number; emptyExitMs: number; maxSessions: number } {
+): { now: () => number; idleEvictionMs: number; emptyExitMs: number } {
 	return {
 		now: overrides.now ?? Date.now,
 		idleEvictionMs:
@@ -89,7 +80,6 @@ export function resolveHostIdlePolicy(
 			DEFAULT_SESSION_IDLE_EVICTION_MS,
 		emptyExitMs:
 			overrides.emptyExitMs ?? parseIdleExitMs(env[RPC_HOST_EMPTY_EXIT_MS_ENV]) ?? DEFAULT_HOST_EMPTY_EXIT_MS,
-		maxSessions: overrides.maxSessions ?? parseSessionCap(env[RPC_MAX_SESSIONS_ENV]) ?? DEFAULT_MAX_SESSIONS,
 	};
 }
 
@@ -123,7 +113,6 @@ export function createHostCore(
 			agentDir: options.agentDir,
 			createRuntime: options.createRuntime,
 			now: policy.now,
-			maxSessions: policy.maxSessions,
 			closeGraceMs: idle.closeGraceMs ?? parseIdleExitMs(process.env[RPC_CLOSE_GRACE_MS_ENV]) ?? 10_000,
 		}),
 		writer,

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -169,7 +169,6 @@ export const RPC_ERROR_MISSING_SESSION_ID = "missing_session_id";
 export const RPC_ERROR_MULTI_SESSION_DISABLED = "multi_session_disabled";
 export const RPC_ERROR_INVALID_PATH = "invalid_path";
 export const RPC_ERROR_OPEN_FAILED = "open_failed";
-export const RPC_ERROR_TOO_MANY_SESSIONS = "too_many_sessions";
 export const RPC_ERROR_MEDIA_NOT_FOUND = "media_not_found";
 
 export type RpcErrorCode =
@@ -180,7 +179,6 @@ export type RpcErrorCode =
 	| typeof RPC_ERROR_MULTI_SESSION_DISABLED
 	| typeof RPC_ERROR_INVALID_PATH
 	| typeof RPC_ERROR_OPEN_FAILED
-	| typeof RPC_ERROR_TOO_MANY_SESSIONS
 	| typeof RPC_ERROR_MEDIA_NOT_FOUND;
 
 /** Every established command accepts an additive routing envelope. */

--- a/packages/coding-agent/src/modes/rpc/session-registry.ts
+++ b/packages/coding-agent/src/modes/rpc/session-registry.ts
@@ -44,13 +44,7 @@ export interface RpcSessionEntry {
 }
 
 export class RpcSessionRegistryError extends Error {
-	readonly code:
-		| "unknown_session"
-		| "session_closing"
-		| "session_path_in_use"
-		| "invalid_path"
-		| "open_failed"
-		| "too_many_sessions";
+	readonly code: "unknown_session" | "session_closing" | "session_path_in_use" | "invalid_path" | "open_failed";
 
 	constructor(code: RpcSessionRegistryError["code"], reason?: string) {
 		super(code === "open_failed" && reason ? `${code}: ${reason}` : code);
@@ -64,8 +58,6 @@ export interface RpcSessionRegistryOptions {
 	createRuntime: CreateAgentSessionRuntimeFactory;
 	/** Injectable clock (defaults to Date.now) so idle bookkeeping is testable. */
 	now?: () => number;
-	/** Cap on concurrently opening/open sessions; attach-on-open is exempt. */
-	maxSessions?: number;
 	/** Maximum time to wait for graceful runtime teardown before forced release. */
 	closeGraceMs?: number;
 }
@@ -142,13 +134,6 @@ export class RpcSessionRegistry {
 				sessionPath: entry.sessionPath,
 				attached: true,
 			};
-		}
-		const maxSessions = this.options.maxSessions;
-		if (maxSessions !== undefined && this.countActiveSessions() >= maxSessions) {
-			// Reconnect-churn backstop: every open_session owns a complete runtime
-			// (hundreds of MB measured), so admission is bounded. Attachments to a
-			// live session add none and stay allowed via the branch above.
-			throw new RpcSessionRegistryError("too_many_sessions");
 		}
 		if (sessionPath) this.reservations.add(sessionPath);
 
@@ -329,13 +314,5 @@ export class RpcSessionRegistry {
 		if (!isAbsolute(profile.cwd) || (profile.sessionPath !== undefined && !isAbsolute(profile.sessionPath))) {
 			throw new RpcSessionRegistryError("invalid_path");
 		}
-	}
-
-	private countActiveSessions(): number {
-		let count = 0;
-		for (const entry of this.entries.values()) {
-			if (entry.state === "opening" || entry.state === "open") count += 1;
-		}
-		return count;
 	}
 }

--- a/packages/coding-agent/test/rpc-session-occupancy.test.ts
+++ b/packages/coding-agent/test/rpc-session-occupancy.test.ts
@@ -24,7 +24,8 @@ import { type RpcSessionLaunchProfile, RpcSessionRegistry } from "../src/modes/r
  * - (4.1) sessions idle beyond a configurable window are evicted through the
  *   normal close path (never one with an active turn), and a host whose
  *   registry stays empty exits instead of residenting forever;
- * - (4.2) concurrent open_session is capped.
+ * - (4.2) concurrent open_session is capped ONLY when a cap is configured
+ *   explicitly; the default admits logical sessions without bound.
  *
  * Time is driven exclusively by vitest fake timers plus the injected `now`
  * clocks, so nothing here depends on wall-clock sleeps.
@@ -127,12 +128,11 @@ function createRouterRig(
 	dir: string,
 	createRuntime: CreateAgentSessionRuntimeFactory,
 	idle?: RpcSessionIdlePolicy,
-	maxSessions?: number,
 ): RouterRig {
 	const records: Array<Record<string, unknown>> = [];
 	let bindingDisposals = 0;
 	let uiRequestsCancelled = 0;
-	const registry = new RpcSessionRegistry({ agentDir: dir, createRuntime, maxSessions });
+	const registry = new RpcSessionRegistry({ agentDir: dir, createRuntime });
 	const writer = new SessionEventWriter(
 		(chunk) => records.push(JSON.parse(chunk) as Record<string, unknown>),
 		(flush) => flush(),
@@ -176,7 +176,6 @@ const createHostCore = (
 				now?: () => number;
 				idleEvictionMs?: number;
 				emptyExitMs?: number;
-				maxSessions?: number;
 				onEmptyExit?: () => void;
 			},
 		) => { router: unknown; handle: (line: string) => Promise<void> };
@@ -465,79 +464,73 @@ describe("shared RPC host occupancy", () => {
 		expect(onEmptyExit).toHaveBeenCalledTimes(1);
 	});
 
-	test("(4.2) rejects new open_session beyond the concurrent session cap while attach still works", async () => {
+	test("(4.2) admits logical sessions without bound under the default policy", async () => {
 		const dir = await tempDir();
 		const { createRuntime } = createRuntimeFactory();
-		const registry = new RpcSessionRegistry({ agentDir: dir, createRuntime, maxSessions: 2 });
-		await registry.openSession(profile(dir, join(dir, "one.jsonl")));
-		await registry.openSession(profile(dir, join(dir, "two.jsonl")));
+		// No maxSessions and no SENPI_RPC_MAX_SESSIONS: the production default.
+		const registry = new RpcSessionRegistry({ agentDir: dir, createRuntime });
+		const opens = 12;
 
-		await expect(registry.openSession(profile(dir, join(dir, "three.jsonl")))).rejects.toMatchObject({
-			code: "too_many_sessions",
-		});
-		// Attaching to a live session adds no runtime and must stay allowed at cap.
-		await expect(registry.openSession(profile(dir, join(dir, "one.jsonl")))).resolves.toMatchObject({
+		const sessions = [];
+		for (let index = 0; index < opens; index += 1) {
+			sessions.push(await registry.openSession(profile(dir, join(dir, `unbounded-${index}.jsonl`))));
+		}
+
+		// Every open is a distinct logical session, well past the former cap of 8.
+		expect(new Set(sessions.map((session) => session.sessionId)).size).toBe(opens);
+		expect(sessions.every((session) => session.attached === undefined)).toBe(true);
+		expect(registry.list()).toHaveLength(opens);
+		expect(registry.list().every((entry) => entry.status === "open")).toBe(true);
+
+		// Lifecycle still works at that occupancy: a close releases exactly its own
+		// session and leaves every sibling open.
+		const closed = sessions[0]!;
+		await registry.close(closed.sessionId);
+		expect(registry.list()).toHaveLength(opens - 1);
+		expect(registry.list().some((entry) => entry.sessionId === closed.sessionId)).toBe(false);
+		// The released path reopens, and attach-on-open still joins a live session.
+		// A fresh open OMITS `attached` entirely (it is only set to true on an attach),
+		// so assert on the resolved value rather than matching a present-but-undefined key.
+		const reopened = await registry.openSession(profile(dir, join(dir, "unbounded-0.jsonl")));
+		expect(reopened.attached).toBeUndefined();
+		await expect(registry.openSession(profile(dir, join(dir, "unbounded-1.jsonl")))).resolves.toMatchObject({
 			attached: true,
 		});
-		expect(registry.list()).toHaveLength(2);
 	});
 
-	test("(4.2) frees capacity when a capped session closes", async () => {
+	test("(4.2) the host core default policy leaves open_session uncapped", async () => {
 		const dir = await tempDir();
 		const { createRuntime } = createRuntimeFactory();
-		const registry = new RpcSessionRegistry({ agentDir: dir, createRuntime, maxSessions: 1 });
-		const first = await registry.openSession(profile(dir, join(dir, "solo.jsonl")));
-		await registry.close(first.sessionId);
-		await expect(registry.openSession(profile(dir, join(dir, "next.jsonl")))).resolves.toMatchObject({
-			sessionId: expect.any(String),
-		});
-	});
-
-	test("(4.2) surfaces the cap as a typed open_session error through the router", async () => {
-		const dir = await tempDir();
-		const { createRuntime } = createRuntimeFactory();
-		const rig = createRouterRig(
-			dir,
-			createRuntime,
-			{ idleEvictionMs: Number.POSITIVE_INFINITY, emptyExitMs: Number.POSITIVE_INFINITY },
-			1,
-		);
-		await rig.router.handle({ id: "open", type: "open_session", cwd: dir, sessionPath: join(dir, "cap.jsonl") });
-		const response = await rig.router.handle({
-			id: "over",
-			type: "open_session",
-			cwd: dir,
-			sessionPath: join(dir, "over.jsonl"),
-		});
-		expect(response).toMatchObject({ success: false, error: "too_many_sessions" });
-	});
-
-	test("(4.2) host core resolves the session cap from SENPI_RPC_MAX_SESSIONS", async () => {
-		const dir = await tempDir();
-		const { createRuntime } = createRuntimeFactory();
-		vi.stubEnv("SENPI_RPC_MAX_SESSIONS", "1");
 		const records: Array<Record<string, unknown>> = [];
 		const writer = new SessionEventWriter(
 			(chunk) => records.push(JSON.parse(chunk) as Record<string, unknown>),
 			(flush) => flush(),
 		);
+		// Only the windows are overridden, so the session cap resolves the way a real
+		// host resolves it with SENPI_RPC_MAX_SESSIONS unset.
 		const { handle } = requireHostCore()(
 			{ agentDir: dir, createRuntime, cwd: dir, createBinding: fakeBindingFactory() },
 			writer,
 			[],
-			{
-				idleEvictionMs: Number.POSITIVE_INFINITY,
-				emptyExitMs: Number.POSITIVE_INFINITY,
-			},
+			{ idleEvictionMs: Number.POSITIVE_INFINITY, emptyExitMs: Number.POSITIVE_INFINITY },
 		);
-		const line = (command: Record<string, unknown>): string => JSON.stringify(command);
 
-		await handle(line({ id: "first", type: "open_session", cwd: dir, sessionPath: join(dir, "env-one.jsonl") }));
-		expect(records.some((record) => record.command === "open_session" && record.success === false)).toBe(false);
-		await handle(line({ id: "second", type: "open_session", cwd: dir, sessionPath: join(dir, "env-two.jsonl") }));
+		for (let index = 0; index < 9; index += 1) {
+			await handle(
+				JSON.stringify({
+					id: `open-${index}`,
+					type: "open_session",
+					cwd: dir,
+					sessionPath: join(dir, `host-unbounded-${index}.jsonl`),
+				}),
+			);
+		}
 
-		expect(records.find((record) => record.command === "open_session" && record.success === false)).toMatchObject({
-			error: "too_many_sessions",
-		});
+		const opened = records.filter((record) => record.command === "open_session" && record.success !== false);
+		expect(opened).toHaveLength(9);
+		// Nine DISTINCT routing handles: a cap would have failed the 9th, and a routing
+		// bug that reused one handle must not read as nine successful opens.
+		expect(new Set(opened.map((record) => record.sessionId)).size).toBe(9);
+		expect(records.filter((record) => record.command === "open_session" && record.success === false)).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

- remove the shared RPC host session-count admission gate
- preserve session isolation, attach/path reservations, idle eviction, and empty-host shutdown
- add regression coverage for 9+ logical sessions through registry and host core

## Verification

- mengmotaMac: bun run test -- test/rpc-session-occupancy.test.ts test/rpc-multi-session.test.ts
- 2 files, 26 tests passed

Ultraworked with [omo](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the shared RPC host's session-count admission cap so `open_session` no longer fails with `too_many_sessions` once 8 sessions are open. The host now admits logical sessions without bound; isolation, attach/path reservations, idle eviction, and empty-host shutdown are unchanged.

**Changes**
- Removed `SENPI_RPC_MAX_SESSIONS` env var and the `too_many_sessions` error code.
- Updated `docs/rpc.md` and the RPC changelog to define unlimited logical sessions as the only behavior.
- Added regression coverage for 12 registry and 9 host-core concurrent opens.

<sup>Written for commit 706d1a78c999bb8af0de1144d7b76d3d49c81920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

