### PR TITLE
fix(compaction): retain valid tool result images

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- The deterministic compaction fallback now retains a prepared suffix whose tool results carry a well-formed image block instead of rejecting it as unsafe content and leaving the session stuck above the threshold; malformed blocks stay rejected and the fallback records each candidate's rejection reason in its diagnostics.
 - Fallback activation now validates context admission before persisting or
   emitting model changes, and unusable refusal or transient fallback candidates
   fail closed without leaking internal admission errors.

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
@@ -258,7 +258,8 @@ export function createRequiredCompactionFallback(
 		const reject = (rejectionReason: DeterministicFallbackRejectionReason): undefined => {
 			if (diagnostics) {
 				diagnostics.rejectionReason = rejectionReason;
-				(diagnostics.candidateRejections ??= []).push({ firstKeptEntryId, rejectionReason });
+				diagnostics.candidateRejections ??= [];
+				diagnostics.candidateRejections.push({ firstKeptEntryId, rejectionReason });
 			}
 			return undefined;
 		};

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/deterministic-fallback.ts
@@ -42,6 +42,10 @@ interface DeterministicFallbackDetails {
 
 export interface DeterministicFallbackDiagnostic {
 	rejectionReason?: DeterministicFallbackRejectionReason;
+	candidateRejections?: Array<{
+		firstKeptEntryId: string;
+		rejectionReason: DeterministicFallbackRejectionReason;
+	}>;
 	candidatesChecked?: number;
 	budgetExceeded?: boolean;
 }
@@ -251,6 +255,13 @@ export function createRequiredCompactionFallback(
 	): CompactionResult<DeterministicFallbackDetails> | undefined => {
 		candidateCount++;
 		const details = { ...baseDetails, retainedSuffix };
+		const reject = (rejectionReason: DeterministicFallbackRejectionReason): undefined => {
+			if (diagnostics) {
+				diagnostics.rejectionReason = rejectionReason;
+				(diagnostics.candidateRejections ??= []).push({ firstKeptEntryId, rejectionReason });
+			}
+			return undefined;
+		};
 		const result: CompactionResult<DeterministicFallbackDetails> = {
 			summary,
 			firstKeptEntryId,
@@ -258,19 +269,10 @@ export function createRequiredCompactionFallback(
 			details,
 		};
 		const startIndex = messageIndexesByEntryId.get(firstKeptEntryId);
-		if (startIndex === undefined) {
-			if (diagnostics) diagnostics.rejectionReason = "context-reconstruction-failed";
-			return undefined;
-		}
+		if (startIndex === undefined) return reject("context-reconstruction-failed");
 		const retainedStart = Math.min(startIndex, projectedMessages.length);
-		if (unsafeSuffix[retainedStart]) {
-			if (diagnostics) diagnostics.rejectionReason = "unsafe-retained-content";
-			return undefined;
-		}
-		if (!toolChainValidAt[retainedStart]) {
-			if (diagnostics) diagnostics.rejectionReason = "atomic-tool-chain-cut";
-			return undefined;
-		}
+		if (unsafeSuffix[retainedStart]) return reject("unsafe-retained-content");
+		if (!toolChainValidAt[retainedStart]) return reject("atomic-tool-chain-cut");
 		// The hard-limit valve reserves the scaled budget, so accepting against the raw
 		// configured reserve would admit a context that valve immediately compacts again.
 		const budget = contextWindow - resolveEffectiveReserveTokens(contextWindow, preparation.settings);
@@ -283,11 +285,8 @@ export function createRequiredCompactionFallback(
 					);
 		const retainedTokens = (tokenSuffix[retainedStart] ?? Number.POSITIVE_INFINITY) + summaryTokens;
 		if (retainedTokens > budget) {
-			if (diagnostics) {
-				diagnostics.rejectionReason = "retained-token-budget-exceeded";
-				diagnostics.budgetExceeded = true;
-			}
-			return undefined;
+			if (diagnostics) diagnostics.budgetExceeded = true;
+			return reject("retained-token-budget-exceeded");
 		}
 		return { ...result, estimatedTokensAfter: retainedTokens };
 	};

--- a/packages/coding-agent/src/core/extensions/builtin/compaction/retained-message-safety.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/compaction/retained-message-safety.ts
@@ -14,6 +14,25 @@ function hasTextOnlyContent(content: unknown, allowString: boolean): boolean {
 	return content.every((block) => isRecord(block) && block.type === "text" && typeof block.text === "string");
 }
 
+function isWellFormedImageBlock(block: Record<string, unknown>): boolean {
+	return (
+		block.type === "image" &&
+		typeof block.mimeType === "string" &&
+		block.mimeType.startsWith("image/") &&
+		typeof block.data === "string" &&
+		block.data.length > 0
+	);
+}
+
+function hasSafeToolResultContent(content: unknown): boolean {
+	if (!Array.isArray(content)) return false;
+	return content.every(
+		(block) =>
+			isRecord(block) &&
+			((block.type === "text" && typeof block.text === "string") || isWellFormedImageBlock(block)),
+	);
+}
+
 function isUsage(value: unknown): boolean {
 	if (!isRecord(value) || !isRecord(value.cost)) return false;
 	for (const field of ["input", "output", "cacheRead", "cacheWrite", "totalTokens"] as const) {
@@ -133,7 +152,7 @@ function hasSafeToolResultEnvelope(message: Record<string, unknown>): boolean {
 		message.toolCallId.length > 0 &&
 		typeof message.toolName === "string" &&
 		message.toolName.length > 0 &&
-		hasTextOnlyContent(message.content, false) &&
+		hasSafeToolResultContent(message.content) &&
 		typeof message.isError === "boolean" &&
 		isFiniteNumber(message.timestamp) &&
 		(message.usage === undefined || isUsage(message.usage)) &&

--- a/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
+++ b/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
@@ -372,7 +372,10 @@ describe("required compaction deterministic fallback", () => {
 			const branchEntries = harness.sessionManager.getBranch();
 			const preparation = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS, true);
 			expect(preparation).toBeDefined();
-			const diagnostics: { rejectionReason?: string } = {};
+			const diagnostics: {
+				rejectionReason?: string;
+				candidateRejections?: Array<{ firstKeptEntryId: string; rejectionReason: string }>;
+			} = {};
 
 			const result = createRequiredCompactionFallback(
 				{ ...preparation!, firstKeptEntryId: preparedBoundaryId, tokensBefore: 10_000, settings: DEFAULT_COMPACTION_SETTINGS },
@@ -385,9 +388,10 @@ describe("required compaction deterministic fallback", () => {
 
 			expect(result).toBeUndefined();
 			expect(diagnostics.rejectionReason).toBe("unsafe-retained-content");
-			expect(diagnostics.candidateRejections).toEqual([
-			{ firstKeptEntryId: preparedBoundaryId, rejectionReason: "unsafe-retained-content" },
-		]);
+			expect(diagnostics.candidateRejections).toContainEqual({
+				firstKeptEntryId: preparedBoundaryId,
+				rejectionReason: "unsafe-retained-content",
+			});
 		}
 	});
 

--- a/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
+++ b/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
@@ -385,6 +385,9 @@ describe("required compaction deterministic fallback", () => {
 
 			expect(result).toBeUndefined();
 			expect(diagnostics.rejectionReason).toBe("unsafe-retained-content");
+			expect(diagnostics.candidateRejections).toEqual([
+			{ firstKeptEntryId: preparedBoundaryId, rejectionReason: "unsafe-retained-content" },
+		]);
 		}
 	});
 

--- a/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
+++ b/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
@@ -7,6 +7,7 @@ import { DEFAULT_COMPACTION_SETTINGS, prepareCompaction } from "../../src/core/c
 import { StreamDurationBudgetError } from "../../src/core/compaction/stream-watchdog.ts";
 import {
 	classifyRequiredCompactionFallbackFailure,
+	type DeterministicFallbackDiagnostic,
 	createRequiredCompactionFallback,
 } from "../../src/core/extensions/builtin/compaction/deterministic-fallback.ts";
 import { resolveCompactionGeometry } from "../../src/core/extensions/builtin/compaction/orchestration.ts";
@@ -327,7 +328,7 @@ describe("required compaction deterministic fallback", () => {
 		const branchEntries = harness.sessionManager.getBranch();
 		const preparation = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS, true);
 		expect(preparation).toBeDefined();
-		const diagnostics: { rejectionReason?: string; candidatesChecked?: number } = {};
+		const diagnostics: DeterministicFallbackDiagnostic = {};
 		const result = createRequiredCompactionFallback(
 			{ ...preparation!, firstKeptEntryId: preparedBoundaryId, tokensBefore: 10_000, settings: DEFAULT_COMPACTION_SETTINGS },
 			1_000_000,
@@ -372,10 +373,7 @@ describe("required compaction deterministic fallback", () => {
 			const branchEntries = harness.sessionManager.getBranch();
 			const preparation = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS, true);
 			expect(preparation).toBeDefined();
-			const diagnostics: {
-				rejectionReason?: string;
-				candidateRejections?: Array<{ firstKeptEntryId: string; rejectionReason: string }>;
-			} = {};
+			const diagnostics: DeterministicFallbackDiagnostic = {};
 
 			const result = createRequiredCompactionFallback(
 				{ ...preparation!, firstKeptEntryId: preparedBoundaryId, tokensBefore: 10_000, settings: DEFAULT_COMPACTION_SETTINGS },

--- a/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
+++ b/packages/coding-agent/test/compaction/required-compaction-deterministic-fallback.test.ts
@@ -3,7 +3,7 @@ import { fauxAssistantMessage } from "@earendil-works/pi-ai";
 import { describe, expect, it } from "vitest";
 import { convertMessages as convertGoogleMessages } from "../../../ai/src/api/google-shared.ts";
 import { transformMessages } from "../../../ai/src/api/transform-messages.ts";
-import { prepareCompaction } from "../../src/core/compaction/index.ts";
+import { DEFAULT_COMPACTION_SETTINGS, prepareCompaction } from "../../src/core/compaction/index.ts";
 import { StreamDurationBudgetError } from "../../src/core/compaction/stream-watchdog.ts";
 import {
 	classifyRequiredCompactionFallbackFailure,
@@ -294,6 +294,98 @@ describe("required compaction deterministic fallback", () => {
 			true,
 		);
 		expect(JSON.stringify(harness.sessionManager.buildSessionContext().messages)).toContain("Keep latest request");
+	});
+
+	it("retains a prepared tool result with a well-formed image block", () => {
+		const harness = createBlockingContext({ usageTokens: 9_900 });
+		harness.sessionManager.appendMessage({
+			role: "user",
+			content: "Inspect the image.",
+			timestamp: 4,
+		});
+		const preparedBoundaryId = harness.sessionManager.appendMessage({
+			...fauxAssistantMessage("", { timestamp: 5, stopReason: "toolUse" }),
+			api: "openai-responses",
+			provider: "openai",
+			content: [{ type: "toolCall", id: "t", name: "read", arguments: { path: "image.png" } }],
+		});
+		harness.sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "t",
+			toolName: "read",
+			content: [
+				{ type: "text", text: "Image result" },
+				{
+					type: "image",
+					mimeType: "image/png",
+					data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aZ1EAAAAASUVORK5CYII=",
+				},
+			],
+			isError: false,
+			timestamp: 6,
+		});
+		const branchEntries = harness.sessionManager.getBranch();
+		const preparation = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS, true);
+		expect(preparation).toBeDefined();
+		const diagnostics: { rejectionReason?: string; candidatesChecked?: number } = {};
+		const result = createRequiredCompactionFallback(
+			{ ...preparation!, firstKeptEntryId: preparedBoundaryId, tokensBefore: 10_000, settings: DEFAULT_COMPACTION_SETTINGS },
+			1_000_000,
+			"summarization-timeout",
+			{},
+			branchEntries,
+			diagnostics,
+		);
+
+		expect(result).toMatchObject({
+			firstKeptEntryId: preparedBoundaryId,
+			details: { retainedSuffix: "prepared" },
+		});
+		expect(diagnostics).toEqual({ candidatesChecked: 1 });
+	});
+
+	it("rejects malformed image blocks in retained tool results", () => {
+		for (const image of [
+			{ type: "image", mimeType: "image/png" },
+			{ type: "image", mimeType: "text/plain", data: "not-an-image" },
+		]) {
+			const harness = createBlockingContext({ usageTokens: 9_900 });
+			harness.sessionManager.appendMessage({
+				role: "user",
+				content: "Inspect the image.",
+				timestamp: 4,
+			});
+			const preparedBoundaryId = harness.sessionManager.appendMessage({
+				...fauxAssistantMessage("", { timestamp: 5, stopReason: "toolUse" }),
+				api: "openai-responses",
+				provider: "openai",
+				content: [{ type: "toolCall", id: "t", name: "read", arguments: { path: "image.png" } }],
+			});
+			harness.sessionManager.appendMessage({
+				role: "toolResult",
+				toolCallId: "t",
+				toolName: "read",
+				content: [{ type: "text", text: "Image result" }, image] as never,
+				isError: false,
+				timestamp: 6,
+			});
+			const branchEntries = harness.sessionManager.getBranch();
+			const preparation = prepareCompaction(branchEntries, DEFAULT_COMPACTION_SETTINGS, true);
+			expect(preparation).toBeDefined();
+			const diagnostics: { rejectionReason?: string } = {};
+
+			const result = createRequiredCompactionFallback(
+				{ ...preparation!, firstKeptEntryId: preparedBoundaryId, tokensBefore: 10_000, settings: DEFAULT_COMPACTION_SETTINGS },
+				1_000_000,
+				"summarization-timeout",
+				{},
+				branchEntries,
+				diagnostics,
+			);
+
+			expect(result).toBeUndefined();
+			expect(diagnostics.rejectionReason).toBe("unsafe-retained-content");
+		}
 	});
 
 	it("fails closed instead of throwing on malformed retained content blocks", () => {


### PR DESCRIPTION
## RED
- Added regression coverage for the reported retained tool-result suffix containing text plus a valid PNG image block.
- Added coverage proving missing image data and non-image MIME types remain rejected as unsafe retained content.

## GREEN
- Retained-message safety now accepts only image blocks with `type: "image"`, a non-empty `data` string, and an `image/` MIME type.
- Unknown and malformed content blocks remain rejected.
- Deterministic fallback diagnostics now retain the rejection reason for each rejected candidate.

Fixes code-yeongyu/oh-my-openagent#6871

Validation: `bunx biome check` passed for all touched files. Bun tests were not run per task instructions. The coding-agent typecheck command was attempted but the checkout has no installed workspace dependencies; using the main checkout type roots exposed unrelated existing package/type errors.