### PR TITLE
fix(retry-fallback): log exhaustion and no-chain decisions without reserving a candidate

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Retry fallback logs `no_chain` and `candidates_exhausted` again when an attempt finds no admissible candidate; the atomic-admission change had tied those decision logs to candidate reservation, which the attempt path no longer performs before the switch is admitted.
 - Fallback activation now validates context admission before persisting or
   emitting model changes, and unusable refusal or transient fallback candidates
   fail closed without leaking internal admission errors.

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -107,7 +107,7 @@ export class RetryFallbackController {
 	}
 
 	canTryFallback(): boolean {
-		return this.nextCandidate(false) !== undefined;
+		return this.nextCandidate({ reserve: false, log: false }) !== undefined;
 	}
 
 	/**
@@ -199,11 +199,14 @@ export class RetryFallbackController {
 		failure: { errorMessage?: string; retryAfterMs?: number },
 	): Promise<boolean> {
 		const current = this.deps.getCurrentSelector();
-		const candidate = this.nextCandidate(false);
+		// Reservation happens only after the switch is admitted (atomic activation),
+		// but the decision log is part of the attempt itself: an exhausted or missing
+		// chain must still be recorded even though nothing was reserved.
+		const candidate = this.nextCandidate({ reserve: false, log: true });
 		if (!current || !candidate) return false;
 		const currentBase = formatSelector(current.model);
 		if (reason === "transient" || reason === "hard-error" || reason === "billing") {
-				this.deps.cooldowns.note(currentBase, failure);
+			this.deps.cooldowns.note(currentBase, failure);
 			this.deps.logger.info("cooldown_noted", { selector: currentBase, errorMessage: failure.errorMessage });
 		}
 
@@ -229,9 +232,10 @@ export class RetryFallbackController {
 		return true;
 	}
 
-	private nextCandidate(
+	private nextCandidate({
 		reserve = true,
-	): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
+		log = reserve,
+	}: { reserve?: boolean; log?: boolean } = {}): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
 		const settings = this.deps.getSettings();
 		const current = this.deps.getCurrentSelector();
 		if (!settings.modelFallback || !current) return undefined;
@@ -241,7 +245,7 @@ export class RetryFallbackController {
 		const chainKey = resolveChainKey(current.model, current.thinkingLevel, chains) ?? this.state?.chainKey;
 		const entries = chainKey ? chains[chainKey] : undefined;
 		if (!chainKey || !entries) {
-			if (reserve) this.deps.logger.debug("no_chain", { selector: formatSelector(current.model) });
+			if (log) this.deps.logger.debug("no_chain", { selector: formatSelector(current.model) });
 			return undefined;
 		}
 		for (const raw of candidatesAfter(entries, formatSelector(current.model, current.thinkingLevel))) {
@@ -276,7 +280,7 @@ export class RetryFallbackController {
 			return { chainKey, selector, model };
 		}
 		this.lastExhaustedChainKey = chainKey;
-		if (reserve) this.deps.logger.info("candidates_exhausted", { chainKey });
+		if (log) this.deps.logger.info("candidates_exhausted", { chainKey });
 		return undefined;
 	}
 


### PR DESCRIPTION
## What breaks

`main` (dd7f6ffde) is red: `test/suite/retry-fallback-hardening.test.ts` fails twice (`refuses a self-referential-only chain and logs the exhaustion decision`, `logs the no-chain decision for an unconfigured model`) — CI run 34044807021. `fallback.log` never gets `candidates_exhausted` / `no_chain` any more; in the second case the log file is not even created.

## Root cause

#1413 made fallback activation atomic: `tryFallback` now calls `nextCandidate(false)` and reserves the selector only after `switchModel` is admitted. But `nextCandidate` used that same `reserve` flag to gate the two decision logs, so a real attempt that finds no admissible candidate no longer records why.

## Fix

`nextCandidate({ reserve, log })` with `log` defaulting to `reserve`; `tryFallback` passes `{ reserve: false, log: true }`; the `canTryFallback()` probe passes `{ reserve: false, log: false }` and stays silent as before. Also un-indents the stray `cooldowns.note` line from #1413.

## Verification

RED: the two hardening failures on main (CI + disposable Linux box). GREEN: hardening + retry-fallback-admission + retry-fallback-engine suites on the same box with this change — logs in the follow-up comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes retry fallback logging so `no_chain` and `candidates_exhausted` are written again when an attempt finds no admissible candidate, without affecting atomic admission.

- Separates the `reserve` and `log` flags in `nextCandidate` so the attempt path can log decisions without reserving a candidate.
- The `canTryFallback()` probe stays silent as before.
- Fixes an indentation issue on the `cooldowns.note` line.

<sup>Written for commit fcf73003fc5a55edf20df7a73d62950ef259a95e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

