### PR TITLE
fix(coding-agent): preserve fallback decision logging

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- Fallback decision logging remains visible when atomic admission probes reject or exhaust candidates.
 - Fallback activation now validates context admission before persisting or
   emitting model changes, and unusable refusal or transient fallback candidates
   fail closed without leaking internal admission errors.

--- a/packages/coding-agent/src/core/changes.md
+++ b/packages/coding-agent/src/core/changes.md
@@ -41,6 +41,24 @@
 
 # changes
 
+## 2026-09-06 - Preserve fallback decision logs across atomic admission
+
+### What changed
+
+- `packages/coding-agent/src/core/retry-fallback/controller.ts`: separates fallback decision logging from candidate reservation, so actual fallback attempts still record `no_chain` and `candidates_exhausted` without reserving a candidate before context admission succeeds.
+
+### Why
+
+- The atomic admission fix correctly moved reservation until after model admission, but also suppressed the diagnostic logger on the same probe path. That removed the only durable fallback decision observable and caused `fallback.log` to disappear for no-chain and exhausted-chain decisions.
+
+### Why an extension could not handle it
+
+- Candidate reservation and fallback decision logging are private retry-controller state and lifecycle behavior below the extension API.
+
+### Expected merge conflict zones
+
+- LOW: `RetryFallbackController.tryFallback` and `nextCandidate` decision handling.
+
 ## 2026-09-06 - Preserve inline skill anchors in composed prompts
 
 ### What changed

--- a/packages/coding-agent/src/core/retry-fallback/controller.ts
+++ b/packages/coding-agent/src/core/retry-fallback/controller.ts
@@ -199,7 +199,7 @@ export class RetryFallbackController {
 		failure: { errorMessage?: string; retryAfterMs?: number },
 	): Promise<boolean> {
 		const current = this.deps.getCurrentSelector();
-		const candidate = this.nextCandidate(false);
+		const candidate = this.nextCandidate(false, true);
 		if (!current || !candidate) return false;
 		const currentBase = formatSelector(current.model);
 		if (reason === "transient" || reason === "hard-error" || reason === "billing") {
@@ -231,6 +231,7 @@ export class RetryFallbackController {
 
 	private nextCandidate(
 		reserve = true,
+		logDecision = reserve,
 	): { chainKey: string; selector: FallbackSelector; model: Model<Api> } | undefined {
 		const settings = this.deps.getSettings();
 		const current = this.deps.getCurrentSelector();
@@ -241,7 +242,7 @@ export class RetryFallbackController {
 		const chainKey = resolveChainKey(current.model, current.thinkingLevel, chains) ?? this.state?.chainKey;
 		const entries = chainKey ? chains[chainKey] : undefined;
 		if (!chainKey || !entries) {
-			if (reserve) this.deps.logger.debug("no_chain", { selector: formatSelector(current.model) });
+			if (logDecision) this.deps.logger.debug("no_chain", { selector: formatSelector(current.model) });
 			return undefined;
 		}
 		for (const raw of candidatesAfter(entries, formatSelector(current.model, current.thinkingLevel))) {
@@ -276,7 +277,7 @@ export class RetryFallbackController {
 			return { chainKey, selector, model };
 		}
 		this.lastExhaustedChainKey = chainKey;
-		if (reserve) this.deps.logger.info("candidates_exhausted", { chainKey });
+		if (logDecision) this.deps.logger.info("candidates_exhausted", { chainKey });
 		return undefined;
 	}
 


### PR DESCRIPTION
Fixes the observability regression introduced by atomic fallback admission in #1413.

`tryFallback` still avoids reserving candidates before context admission, while its probe records `no_chain` and `candidates_exhausted` decisions in `fallback.log`.

Verification:
- ASCII Box RED on dd7f6ffde: retry-fallback-hardening 3 passed, 2 failed (missing candidates_exhausted and fallback.log ENOENT).
- ASCII Box GREEN: retry-fallback-hardening 5 passed.
- ASCII Box related retry-fallback suites: 233 passed.
- Mutation: disabling decision logging reproduces 2 hardening failures.
- Full npm run check attempted; 2 vCPU/4 GB ASCII Box hit Node OOM during tsc, after earlier checks passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the observability regression from atomic fallback admission so fallback decision logs are preserved. `tryFallback` still avoids reserving candidates before context admission, but now records `no_chain` and `candidates_exhausted` decisions in `fallback.log` again, which was previously suppressed on the same probe path.

<sup>Written for commit 470058d1a1ae25b7aed9ca62ee265f10aba5af29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

