### PR TITLE
test(coding-agent): install the churner's SIGTERM handler before it reports ready

### DIFF
--- a/packages/coding-agent/test/process-teardown.test.ts
+++ b/packages/coding-agent/test/process-teardown.test.ts
@@ -15,12 +15,13 @@ function spawnChurner(root: string, termMarker: string, exitsOnTerm = false): Ch
 		for (let i = 0; i < 20000; i++) {
 			fs.mkdirSync(path.join(root, "initial-" + i));
 		}
-		// fs.writeSync, not process.stdout.write: pipe writes are async on
-		// macOS, and process.exit() right after an async write discards it, so
-		// the acknowledgement the parent waits on would be lost under load.
-		fs.writeSync(1, "ready\\n");
 		let i = 0;
 		let interval;
+		// Install the SIGTERM handler BEFORE announcing readiness: the parent
+		// sends SIGTERM as soon as it reads "ready", and a signal that lands in
+		// the gap between the write and process.on() takes the default action,
+		// so the child dies without ever writing "term-observed" (seen on a
+		// loaded CI runner as 'child closed before writing "term-observed"').
 		process.on("SIGTERM", () => {
 			fs.writeFileSync(termMarker, "term-observed");
 			fs.writeSync(1, "term-observed\\n");
@@ -29,6 +30,10 @@ function spawnChurner(root: string, termMarker: string, exitsOnTerm = false): Ch
 				process.exit(0);
 			}
 		});
+		// fs.writeSync, not process.stdout.write: pipe writes are async on
+		// macOS, and process.exit() right after an async write discards it, so
+		// the acknowledgement the parent waits on would be lost under load.
+		fs.writeSync(1, "ready\\n");
 		interval = setInterval(() => {
 			try {
 				const dir = path.join(root, "live-" + i++);


### PR DESCRIPTION
## What breaks

`main` CI at 6d2d2d40e (run 34048102375, `Test (coding-agent 2/3)`): `test/process-teardown.test.ts > proves immediate removal races a live writer…` failed with `child closed before writing "term-observed"; saw: ""`. First occurrence in the last 40 runs, under runner load.

## Root cause

The churner child script wrote `ready` **before** calling `process.on("SIGTERM", …)`. The parent sends SIGTERM as soon as it reads `ready`, so a signal delivered in the gap between the write syscall and handler registration takes the default disposition: the child terminates without writing `term-observed`. Same class as the earlier "passing by timing luck" hardening (33e9510e7), one step further upstream.

## Fix

Register the handler first, then announce readiness — `ready` now means "ready to be signalled". Test-harness-only change; no production code touched.

## Verification

The race is a sub-millisecond scheduling gap and cannot be forced deterministically; the fix removes the window by construction. GREEN: the file passes on a disposable Linux box (log in a follow-up comment) and in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the teardown test harness where the churner child wrote `ready` before registering its SIGTERM handler. The parent sends SIGTERM the moment it reads `ready`, so a signal landing in that gap took the default action and the child died without writing `term-observed`. The handler is now installed before the readiness write, making `ready` mean "ready to be signalled". Test-only change; no production code touched.

<sup>Written for commit f5a39188caf440d69310d557081d7e2df8f9a043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

