### PR TITLE
fix(coding-agent): resolve external-dir paths without opening them (fixes #1416)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- The permission system's external-directory classifier now resolves symlinks with `lstat` + `readlink` instead of `realpathSync`, so classifying a command that merely mentions an autofs trigger such as `/home`, a stalled network mount, or a FIFO can no longer block the host main thread and freeze the TUI ([#1416](https://github.com/code-yeongyu/senpi/issues/1416))
+
 ### Removed
 
 ## [2026.9.6] - 2026-09-06

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/external-dir.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/external-dir.ts
@@ -18,21 +18,61 @@ export function expandHome(inputPath: string): string {
 	return inputPath;
 }
 
+const MAX_SYMLINK_HOPS = 40;
+
+function splitSegments(value: string): string[] {
+	return value.split(/[\\/]+/).filter((segment) => segment.length > 0);
+}
+
+/**
+ * realpath(3) equivalent that resolves symlinks with lstat + readlink only.
+ *
+ * This runs on the host main thread for every classified path, so it must never
+ * open(2) a component: Bun implements realpathSync (and its native variant) with
+ * open(), which forces an automount for autofs triggers such as /home or /net and
+ * blocks forever on a wedged map, freezing the whole TUI. lstat and readlink never
+ * open the entry they inspect. Trailing components that do not exist are kept
+ * verbatim after the last resolvable one, and any other failure falls back to the
+ * unresolved path, matching the previous realpathSync-based behaviour.
+ */
 function normalizePath(inputPath: string): string {
-	let candidate = path.normalize(inputPath);
-	const suffix: string[] = [];
-	for (;;) {
-		try {
-			const resolved = fs.realpathSync(candidate);
-			return suffix.length === 0 ? resolved : path.join(resolved, ...suffix.reverse());
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") return candidate;
-			const parent = path.dirname(candidate);
-			if (parent === candidate) return candidate;
-			suffix.push(path.basename(candidate));
-			candidate = parent;
+	const normalized = path.normalize(inputPath);
+	const root = path.parse(normalized).root;
+	const pending = splitSegments(normalized.slice(root.length));
+	let resolved = root;
+	let hops = 0;
+
+	while (pending.length > 0) {
+		const segment = pending.shift();
+		if (segment === undefined || segment === ".") continue;
+		if (segment === "..") {
+			resolved = path.dirname(resolved);
+			continue;
 		}
+
+		const candidate = path.join(resolved, segment);
+		let linkTarget: string | undefined;
+		try {
+			const entry = fs.lstatSync(candidate, { throwIfNoEntry: false });
+			if (!entry) return path.join(candidate, ...pending);
+			if (entry.isSymbolicLink()) linkTarget = fs.readlinkSync(candidate);
+		} catch {
+			return normalized;
+		}
+
+		if (linkTarget === undefined) {
+			resolved = candidate;
+			continue;
+		}
+		if (++hops > MAX_SYMLINK_HOPS) return normalized;
+
+		const target = path.normalize(linkTarget);
+		const targetRoot = path.parse(target).root;
+		if (targetRoot.length > 0) resolved = targetRoot;
+		pending.unshift(...splitSegments(target.slice(targetRoot.length)));
 	}
+
+	return resolved.length > 0 ? resolved : normalized;
 }
 
 export function isExternalPath(inputPath: string, cwd: string): boolean {

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/external-dir.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/external-dir.ts
@@ -20,8 +20,8 @@ export function expandHome(inputPath: string): string {
 
 const MAX_SYMLINK_HOPS = 40;
 
-function splitSegments(value: string): string[] {
-	return value.split(/[\\/]+/).filter((segment) => segment.length > 0);
+function splitNormalizedSegments(value: string): string[] {
+	return value.split(path.sep).filter((segment) => segment.length > 0);
 }
 
 /**
@@ -38,7 +38,7 @@ function splitSegments(value: string): string[] {
 function normalizePath(inputPath: string): string {
 	const normalized = path.normalize(inputPath);
 	const root = path.parse(normalized).root;
-	const pending = splitSegments(normalized.slice(root.length));
+	const pending = splitNormalizedSegments(normalized.slice(root.length));
 	let resolved = root;
 	let hops = 0;
 
@@ -69,7 +69,7 @@ function normalizePath(inputPath: string): string {
 		const target = path.normalize(linkTarget);
 		const targetRoot = path.parse(target).root;
 		if (targetRoot.length > 0) resolved = targetRoot;
-		pending.unshift(...splitSegments(target.slice(targetRoot.length)));
+		pending.unshift(...splitNormalizedSegments(target.slice(targetRoot.length)));
 	}
 
 	return resolved.length > 0 ? resolved : normalized;

--- a/packages/coding-agent/test/permission/external-dir.test.ts
+++ b/packages/coding-agent/test/permission/external-dir.test.ts
@@ -1,12 +1,39 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	expandHome,
 	extractExternalPaths,
 	isExternalPath,
 } from "../../src/core/extensions/builtin/permission-system/external-dir.ts";
+
+const openingSyscalls = vi.hoisted(() => [] as string[]);
+
+function recordOpeningCall(name: string, actualFn: unknown): unknown {
+	return (...args: unknown[]): unknown => {
+		openingSyscalls.push(name);
+		return (actualFn as (...forwarded: unknown[]) => unknown)(...args);
+	};
+}
+
+vi.mock("node:fs", async (importOriginal) => {
+	const actual = (await importOriginal()) as typeof fs;
+	return {
+		...actual,
+		realpathSync: Object.assign(
+			recordOpeningCall("realpathSync", actual.realpathSync) as typeof actual.realpathSync,
+			{
+				native: recordOpeningCall(
+					"realpathSync.native",
+					actual.realpathSync.native,
+				) as typeof actual.realpathSync.native,
+			},
+		),
+		statSync: recordOpeningCall("statSync", actual.statSync) as typeof actual.statSync,
+		existsSync: recordOpeningCall("existsSync", actual.existsSync) as typeof actual.existsSync,
+	};
+});
 
 describe("external-dir", () => {
 	describe("expandHome", () => {
@@ -262,6 +289,77 @@ describe("external-dir", () => {
 			const command = "touch /Users/other/file.txt";
 			const result = extractExternalPaths(command, cwd);
 			expect(result).toEqual(["/Users/other/file.txt"]);
+		});
+	});
+
+	// Regression coverage for https://github.com/code-yeongyu/senpi/issues/1416
+	describe("path resolution never opens the classified path", () => {
+		beforeEach(() => {
+			openingSyscalls.length = 0;
+		});
+
+		it("classifies paths without realpathSync, statSync, or existsSync", () => {
+			expect(isExternalPath("/Users/other/deeply/nested/missing.txt", "/Users/me/project")).toBe(true);
+			expect(extractExternalPaths("bash /home/user/work/poll-fdl.sh", "/Users/me/project")).toEqual([
+				"/home/user/work/poll-fdl.sh",
+			]);
+
+			expect(openingSyscalls).toEqual([]);
+		});
+
+		it.skipIf(process.platform === "win32")("still resolves symlinked components", () => {
+			const realRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-walk-real-")));
+			const linkRoot = path.join(os.tmpdir(), `external-dir-walk-link-${process.pid}-${Date.now()}`);
+			fs.mkdirSync(path.join(realRoot, "nested"));
+			fs.symlinkSync(realRoot, linkRoot, "dir");
+			openingSyscalls.length = 0;
+			try {
+				expect(isExternalPath(path.join(linkRoot, "nested", "missing.ts"), path.join(realRoot, "nested"))).toBe(
+					false,
+				);
+				expect(openingSyscalls).toEqual([]);
+			} finally {
+				fs.rmSync(linkRoot, { force: true });
+				fs.rmSync(realRoot, { recursive: true, force: true });
+			}
+		});
+
+		it.skipIf(process.platform === "win32")("follows a chain of symlinks to the same real directory", () => {
+			const realRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-chain-real-")));
+			const firstLink = path.join(os.tmpdir(), `external-dir-chain-a-${process.pid}-${Date.now()}`);
+			const secondLink = path.join(os.tmpdir(), `external-dir-chain-b-${process.pid}-${Date.now()}`);
+			fs.symlinkSync(realRoot, firstLink, "dir");
+			fs.symlinkSync(firstLink, secondLink, "dir");
+			try {
+				expect(isExternalPath(path.join(secondLink, "src", "missing.ts"), realRoot)).toBe(false);
+			} finally {
+				fs.rmSync(secondLink, { force: true });
+				fs.rmSync(firstLink, { force: true });
+				fs.rmSync(realRoot, { recursive: true, force: true });
+			}
+		});
+
+		it.skipIf(process.platform === "win32")("returns a verdict for a symlink cycle instead of hanging", () => {
+			const realRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-loop-")));
+			fs.symlinkSync(path.join(realRoot, "b"), path.join(realRoot, "a"), "dir");
+			fs.symlinkSync(path.join(realRoot, "a"), path.join(realRoot, "b"), "dir");
+			openingSyscalls.length = 0;
+			try {
+				expect(isExternalPath(path.join(realRoot, "a", "file.txt"), realRoot)).toBe(false);
+				expect(openingSyscalls).toEqual([]);
+			} finally {
+				fs.rmSync(realRoot, { recursive: true, force: true });
+			}
+		});
+
+		it.skipIf(process.platform === "win32")("keeps non-existent trailing components verbatim", () => {
+			const realRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-tail-")));
+			try {
+				expect(isExternalPath(path.join(realRoot, "a", "b", "c.txt"), realRoot)).toBe(false);
+				expect(isExternalPath(path.join(realRoot, "..", "elsewhere", "c.txt"), realRoot)).toBe(true);
+			} finally {
+				fs.rmSync(realRoot, { recursive: true, force: true });
+			}
 		});
 	});
 });

--- a/packages/coding-agent/test/permission/external-dir.test.ts
+++ b/packages/coding-agent/test/permission/external-dir.test.ts
@@ -352,6 +352,13 @@ describe("external-dir", () => {
 			}
 		});
 
+		it.skipIf(process.platform === "win32")("treats a backslash as a filename character on posix", () => {
+			expect(isExternalPath("/tmp/project\\outside/file", "/tmp/project")).toBe(true);
+			expect(extractExternalPaths("cat /tmp/project\\outside/file", "/tmp/project")).toEqual([
+				"/tmp/project\\outside/file",
+			]);
+		});
+
 		it.skipIf(process.platform === "win32")("keeps non-existent trailing components verbatim", () => {
 			const realRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-tail-")));
 			try {


### PR DESCRIPTION
## Summary

`normalizePath()` in the permission system's external-directory classifier resolved symlinks with `fs.realpathSync`. Under Bun that is implemented with `open(2)`/`F_GETPATH`, so classifying a command that merely *mentions* an autofs trigger (`/home`, `/net`), a stalled network mount, or a FIFO forces an automount and can block forever. The hook runs on the host main thread, so the whole TUI freezes.

This replaces that walk with a `realpath(3)`-style component walker built on `lstat` + `readlink`, which never opens the entry it inspects.

Fixes #1416.

## Root cause

The `tool_call` hook classifies every `bash` / `monitor` path token through `extractExternalPaths()` -> `isExternalPath()` -> `normalizePath()`. For a path that does not exist, `normalizePath()` walked up to the nearest existing ancestor, calling `fs.realpathSync` at each level:

`/home/user/work/poll-fdl.sh` -> ENOENT -> `/home/user/work` -> ENOENT -> `/home/user` -> ENOENT -> `realpathSync("/home")`

`lstat` and `readlink` are enough to implement `realpath(3)` and never open a component, so the classifier no longer touches what it classifies.

## Changes

| File | Change |
|------|--------|
| `packages/coding-agent/src/core/extensions/builtin/permission-system/external-dir.ts` | `normalizePath()` resolves symlinks with an `lstat` + `readlink` component walker (40-hop cycle guard) instead of `fs.realpathSync` |
| `packages/coding-agent/test/permission/external-dir.test.ts` | Regression coverage: no `realpathSync`/`statSync`/`existsSync` during classification, plus symlink, symlink-chain, symlink-cycle and non-existent-tail behaviour |
| `packages/coding-agent/CHANGELOG.md` | `[Unreleased] > Fixed` entry |

Observable classification is unchanged by design: non-existent trailing components are kept verbatim after the last resolvable component, and any non-ENOENT failure falls back to the unresolved path, exactly as the previous `realpathSync` version did. The existing symlinked-cwd case still passes.

## Reproduction (before fix)

`node:fs` is swapped for a stub whose `realpathSync` blocks forever for `/home*` — a stand-in for the wedged `auto_home` map in the issue, since Bun's `realpathSync` never returns there.

```
$ bun probe.ts before   # external-dir.ts taken from origin/main
[probe] variant=before classifying: bash /home/user/work/poll-fdl.sh
[stub] realpathSync("/home/user/work/poll-fdl.sh") -> wedged automount, blocking forever
exit_code=137   # SIGKILL after the 5s deadline -> the classifier froze
```

The unit seam shows the same thing — one classification issued 15 `realpathSync` calls:

```
AssertionError: expected [ 'realpathSync', …(14) ] to deeply equal []
 ❯ test/permission/external-dir.test.ts > path resolution never opens the classified path
   > classifies paths without realpathSync, statSync, or existsSync
```

## Verification (after fix)

```
$ bun probe.ts after    # external-dir.ts from this branch
[probe] variant=after classifying: bash /home/user/work/poll-fdl.sh
CLASSIFIED ["/home/user/work/poll-fdl.sh"] in 23ms
exit_code=0
```

```
$ bun run --cwd packages/coding-agent test test/permission
 Test Files  15 passed (15)
      Tests  485 passed (485)

$ bun run check
CHECK_EXIT=0
```

Real-CLI QA (`.agents/skills/senpi-qa`), each asserting `~/.senpi/agent/auth.json` is unchanged:

```
common.mjs   --self-check          : 10/10 passed
cli-smoke.mjs --self-test          :  8/8  passed
rpc-drive.mjs --self-test          :  4/4  passed
mock-loop.mjs --with-tool          :  4/4  passed   # model -> bash tool -> final text
```

`mock-loop --with-tool` is the relevant end-to-end channel: it drives a real agent turn through the `bash` tool, which is exactly the hook that calls this classifier.

Evidence captured under `local-ignore/qa-evidence/20260907-1416-external-dir-lstat-walker/` (gitignored).

## Test

- Regression test: `packages/coding-agent/test/permission/external-dir.test.ts` (5 new cases)
- Related suite: `bun run --cwd packages/coding-agent test test/permission` — 485 pass
- Static gate: `bun run check` — clean

## Not in scope

`permission-system/parsers.ts` has a sibling `realpathSync(dirname(resolve(cwd, path)))` on the `monitor` parser. It is the same class of landmine, but it backs the authoritative canonical-parent check, so changing it is a security-semantics decision rather than a mechanical swap. Left untouched here; happy to follow up if you want it moved to the same walker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the external-directory classifier freezing the TUI when a command merely mentions an autofs trigger like `/home`, a stalled network mount, or a FIFO.

`normalizePath()` now resolves symlinks with an `lstat` + `readlink` component walker instead of `fs.realpathSync`, so classification never opens the path it inspects. Observable classification behavior is unchanged: non-existent trailing components stay verbatim and non-ENOENT failures fall back to the unresolved path.

**Bug Fixes**
- The component walker now splits on `path.sep` only, so a backslash in a posix path is treated as a filename character and no longer lets paths like `/tmp/project\outside/file` be classified as inside `/tmp/project`.
- Adds regression tests covering symlink chains, cycles, non-existent tails, and backslash handling, and verifies no `realpathSync`, `statSync`, or `existsSync` calls during classification.
- Updates the `coding-agent` changelog with a `Fixed` entry.

<sup>Written for commit 80c338022ca281f2eae8c1fdf8c970fcc8841111. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

