### PR TITLE
fix(coding-agent): resolve external-dir paths without opening components (TUI freeze on autofs /home)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- The permission system's external-directory check no longer freezes the whole session when a `bash` or `monitor` command mentions a path such as `/home/user/...`: path normalization now resolves symlinks with `lstat`/`readlink` per component instead of `fs.realpathSync`, which under Bun `open(2)`s every directory it resolves and blocks forever on an autofs trigger (macOS `/home`) or misclassifies files under execute-only directories as external.
+
 ### Removed
 
 ## [2026.9.6] - 2026-09-06

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/changes.md
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/changes.md
@@ -22,6 +22,22 @@ Full port of opencode's permission system to senpi-mono as a builtin extension.
 ## Why Builtin Extension?
 Following pi-mono's extension-first philosophy. All permission logic is in the extension, zero core tool modifications.
 
+## 2026-09-06 - external-dir path normalization never opens path components
+
+### What changed
+
+- `external-dir.ts` `normalizePath()` resolves symlinks with a component walker built on `fs.lstatSync` + `fs.readlinkSync` (bounded by `MAX_SYMLINK_HOPS`), keeping components from the first missing one onward verbatim. It replaces the `fs.realpathSync` walk-up that climbed a non-existent path to its nearest existing ancestor.
+
+### Why
+
+- `extractExternalPaths()` runs inside the `tool_call` hook on the host main thread for every `bash`/`monitor` command. Bun implements `fs.realpathSync`, `realpathSync.native`, and `fs.promises.realpath` by `open(2)`-ing the path, so a command that merely mentioned `/home/user/work/x` (a path on a remote Linux box) climbed to `realpathSync("/home")`, an autofs trigger on macOS; the wedged automount never returned and the whole TUI froze (senpi #1416). The same open-based resolution fails with EACCES on execute-only directories, so files under them inside the project were reported as external.
+- `lstat` needs only search permission and never triggers a mount; this is what realpath(3) itself does.
+
+### Expected merge conflict zones
+
+- `external-dir.ts` `normalizePath` body.
+- `test/permission/external-dir-resolution.test.ts` (new file: filesystem-backed `isExternalPath` cases — symlinked cwd, execute-only directory, symlink escape, symlink loop; the symlinked-cwd case moved here from `external-dir.test.ts`).
+
 ## 2026-08-21 - Fix unhandled rejection on session shutdown with pending permissions
 
 ### What changed

--- a/packages/coding-agent/src/core/extensions/builtin/permission-system/external-dir.ts
+++ b/packages/coding-agent/src/core/extensions/builtin/permission-system/external-dir.ts
@@ -18,21 +18,52 @@ export function expandHome(inputPath: string): string {
 	return inputPath;
 }
 
+/** Symlink hops allowed while resolving one path; realpath(3) reports ELOOP past this. */
+const MAX_SYMLINK_HOPS = 40;
+
+function splitComponents(normalizedPath: string): { readonly root: string; readonly parts: readonly string[] } {
+	const { root } = path.parse(normalizedPath);
+	const parts = normalizedPath
+		.slice(root.length)
+		.split(path.sep)
+		.filter((part) => part.length > 0);
+	return { root, parts };
+}
+
+/**
+ * Resolve symlinks the way realpath(3) does — one lstat/readlink per component — without ever
+ * open(2)-ing a component. Bun's `fs.realpath*` opens every directory it resolves, so an autofs
+ * trigger such as macOS `/home` blocks the whole process (the classifier runs on the host main
+ * thread, freezing the TUI) and an execute-only directory fails with EACCES; lstat needs only
+ * search permission and never mounts anything. Components from the first missing one onward are
+ * kept verbatim, so a file that does not exist yet still lands where its symlinked parent points.
+ */
 function normalizePath(inputPath: string): string {
-	let candidate = path.normalize(inputPath);
-	const suffix: string[] = [];
-	for (;;) {
+	const { root, parts } = splitComponents(path.normalize(inputPath));
+	const pending = [...parts];
+	let resolved = root;
+	let hops = 0;
+	while (pending.length > 0) {
+		const part = pending.shift();
+		if (part === undefined) break;
+		const candidate = path.join(resolved, part);
+		let link: string;
 		try {
-			const resolved = fs.realpathSync(candidate);
-			return suffix.length === 0 ? resolved : path.join(resolved, ...suffix.reverse());
-		} catch (error) {
-			if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") return candidate;
-			const parent = path.dirname(candidate);
-			if (parent === candidate) return candidate;
-			suffix.push(path.basename(candidate));
-			candidate = parent;
+			if (!fs.lstatSync(candidate).isSymbolicLink()) {
+				resolved = candidate;
+				continue;
+			}
+			hops += 1;
+			if (hops > MAX_SYMLINK_HOPS) return path.join(candidate, ...pending);
+			link = fs.readlinkSync(candidate);
+		} catch {
+			return path.join(candidate, ...pending);
 		}
+		const target = splitComponents(path.resolve(resolved, link));
+		resolved = target.root;
+		pending.unshift(...target.parts);
 	}
+	return resolved;
 }
 
 export function isExternalPath(inputPath: string, cwd: string): boolean {

--- a/packages/coding-agent/test/permission/external-dir-resolution.test.ts
+++ b/packages/coding-agent/test/permission/external-dir-resolution.test.ts
@@ -1,0 +1,75 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { isExternalPath } from "../../src/core/extensions/builtin/permission-system/external-dir.ts";
+
+// Filesystem-backed resolution: these cases need real directories, symlinks, and modes.
+describe("external-dir path resolution", () => {
+	describe("isExternalPath", () => {
+		it.skipIf(process.platform === "win32")("keeps relative non-existent paths inside a symlinked cwd", () => {
+			const realRoot = fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-real-"));
+			const linkRoot = path.join(os.tmpdir(), `external-dir-link-${process.pid}-${Date.now()}`);
+			fs.symlinkSync(realRoot, linkRoot, "dir");
+			try {
+				expect(isExternalPath("src/new.ts", linkRoot)).toBe(false);
+			} finally {
+				fs.rmSync(linkRoot, { force: true });
+				fs.rmSync(realRoot, { recursive: true, force: true });
+			}
+		});
+
+		// Resolution must never open(2) a path component: Bun's fs.realpath* opens every
+		// directory it resolves, so an execute-only directory fails with EACCES (and an autofs
+		// trigger such as /home blocks the whole process). lstat + readlink need only search
+		// permission, which is what realpath(3) itself relies on.
+		it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+			"keeps a not-yet-created file under an execute-only directory inside cwd internal",
+			() => {
+				const root = fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-noread-"));
+				const realCwd = path.join(root, "real");
+				const executeOnly = path.join(realCwd, "noread");
+				const linkCwd = path.join(root, "link");
+				fs.mkdirSync(executeOnly, { recursive: true });
+				fs.chmodSync(executeOnly, 0o111);
+				fs.symlinkSync(realCwd, linkCwd, "dir");
+				try {
+					expect(isExternalPath(path.join(realCwd, "noread", "new.txt"), realCwd)).toBe(false);
+					expect(isExternalPath(path.join(linkCwd, "noread", "new.txt"), linkCwd)).toBe(false);
+				} finally {
+					fs.chmodSync(executeOnly, 0o755);
+					fs.rmSync(root, { recursive: true, force: true });
+				}
+			},
+		);
+
+		it.skipIf(process.platform === "win32")("reports a symlink inside cwd that points outside as external", () => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-escape-"));
+			const cwd = path.join(root, "project");
+			const outside = path.join(root, "outside");
+			fs.mkdirSync(cwd);
+			fs.mkdirSync(outside);
+			// Relative link target: it must resolve against the link's own directory.
+			fs.symlinkSync(path.join("..", "outside"), path.join(cwd, "escape"), "dir");
+			try {
+				expect(isExternalPath(path.join(cwd, "escape", "file.txt"), cwd)).toBe(true);
+				expect(isExternalPath(path.join(cwd, "kept", "file.txt"), cwd)).toBe(false);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		});
+
+		it.skipIf(process.platform === "win32")("stops on a symlink loop without throwing", () => {
+			const root = fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-loop-"));
+			const cwd = path.join(root, "project");
+			fs.mkdirSync(cwd);
+			fs.symlinkSync("b", path.join(cwd, "a"), "dir");
+			fs.symlinkSync("a", path.join(cwd, "b"), "dir");
+			try {
+				expect(isExternalPath(path.join(cwd, "a", "file.txt"), cwd)).toBe(false);
+			} finally {
+				fs.rmSync(root, { recursive: true, force: true });
+			}
+		});
+	});
+});

--- a/packages/coding-agent/test/permission/external-dir.test.ts
+++ b/packages/coding-agent/test/permission/external-dir.test.ts
@@ -1,4 +1,3 @@
-import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -149,18 +148,6 @@ describe("external-dir", () => {
 			const target = "/Users/me/project/src/../config";
 			const result = isExternalPath(target, cwd);
 			expect(result).toBe(false);
-		});
-
-		it.skipIf(process.platform === "win32")("keeps relative non-existent paths inside a symlinked cwd", () => {
-			const realRoot = fs.mkdtempSync(path.join(os.tmpdir(), "external-dir-real-"));
-			const linkRoot = path.join(os.tmpdir(), `external-dir-link-${process.pid}-${Date.now()}`);
-			fs.symlinkSync(realRoot, linkRoot, "dir");
-			try {
-				expect(isExternalPath("src/new.ts", linkRoot)).toBe(false);
-			} finally {
-				fs.rmSync(linkRoot, { force: true });
-				fs.rmSync(realRoot, { recursive: true, force: true });
-			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes #1416 — a whole senpi/omo TUI froze (herdr pane w37:p2, session 01a07736, pid 14091) when an eval cell called `tool.monitor` with a command that mentioned `/home/user/work/poll-fdl.sh`, a path on a remote Linux box.

**Root cause.** The permission system's `tool_call` hook runs `extractExternalPaths()` on every `bash`/`monitor` command, on the host main thread. `normalizePath()` climbed a non-existent path to its nearest existing ancestor with synchronous `fs.realpathSync`, so the token above ended in `realpathSync("/home")`. Bun implements `fs.realpathSync`, `.native` and `fs.promises.realpath` by `open(2)`-ing the path (Node uses lstat/readlink); `/home` is an autofs trigger on macOS, the wedged automount never returned, and the main thread parked in `openat$NOCANCEL` forever: TUI frozen, no foreground-window detach, no monitor deadline, no notification. The same open fails with EACCES on execute-only directories, so files under them inside the project were misclassified as external.

**Fix.** Resolve symlinks the way realpath(3) does — one `lstat`/`readlink` per component (bounded by `MAX_SYMLINK_HOPS`), never `open(2)`; components from the first missing one onward stay verbatim, so symlinked-cwd semantics are unchanged. `lstat` needs only search permission and never mounts.

## Evidence

- Diagnosis: `sample 14091` main thread 100 % in `openat$NOCANCEL`, Worker threads idle in `kevent64`; unified log at the freeze instant shows `automountd` Open Directory burst + `tccd` `kTCCServiceSystemPolicyAllFiles` preflight for the senpi `bun` pid.
- Bun vs Node on the affected host: `bun -e 'require("fs").realpathSync("/home")'` killed at 5 s (also `.native` and `promises.realpath`); `node -e` returns `/System/Volumes/Data/home` instantly; `lstatSync("/home")` instant.
- Real-surface RED → GREEN (macOS, bun 1.4.0): `extractExternalPaths(<exact stuck monitor command>, "/Users/yeongyu/sisyphuslabs")` — old code killed at 5.02 s with no output; new walker returns `["/home/user/work/poll-fdl.sh"]` in 20 ms.
- Unit-scenario RED → GREEN (macOS, bun): execute-only dir under cwd — old `isExternalPath` → `true` (misclassified), new → `false`; relative-symlink escape → `true`; symlink loop → no throw.
- ascii box (Linux x86_64, bun 1.4.0, node 24): `bun test test/permission test/suite/terminal-monitor.test.ts` — baseline 478 pass / 3 fail → after 481 pass / 3 fail with the **identical** pre-existing fail set (two "cascade reject" cases that fail under `bun test` on main independently of this change). New `external-dir.test.ts` 39/39 pass. Note: Bun's Linux realpath does not open directories, so the new execute-only case only turns RED on macOS Bun — the production runtime where the freeze happened.
- `biome check` clean on changed files; root `tsc --noEmit` exit 0; pre-commit `bun run check` passed on each commit.

## Not in this PR

- Six files on `main` are currently not biome-formatted (`agent-session.ts`, `retry-fallback/controller.ts`, four tests); the pre-commit hook rewrites them on every commit. Left out of this diff on purpose; separate style PR follows.
- `terminal/monitor-registry.ts` (file-watch branch) still uses async `fs.promises.realpath` on the watch target's parent — off the main thread and only after `access(parent)` succeeds, so it cannot freeze the TUI, but it would hang that one registration on a wedged mount. Tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the external-directory permission check freezing the whole session when a `bash` or `monitor` command mentions a path such as `/home/user/work/...` (#1416). `normalizePath()` now resolves symlinks per component with `lstat`/`readlink` instead of `fs.realpathSync`, which under Bun `open(2)`s every directory it resolves and blocks forever on autofs triggers like macOS `/home`; files under execute-only directories are no longer misclassified as external.

**Notes**
- Symlink resolution is capped at 40 hops, matching realpath(3)'s ELOOP limit; symlink loops return without throwing.
- Components past the first missing one are kept verbatim, so a not-yet-created file still resolves through its symlinked parent.
- Adds tests for execute-only directories, relative symlink escapes, and symlink loops.

<sup>Written for commit e710bec8868a3b50715288f1fcaf7457ca5385b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/code-yeongyu/senpi/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

